### PR TITLE
refactor(host): register review and platform commands

### DIFF
--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -1,0 +1,450 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { RemoteAccessSnapshot } from '../shared/remote-access'
+import { RENDERER_CONTRACT_GROUPS } from '../shared/renderer-contract-catalog'
+import type { UpdateStatus } from '../shared/update'
+import {
+  createApplicationCommandRouter,
+  type ApplicationCallerLease,
+  type ApplicationCommand,
+  type ApplicationInvocation
+} from './application-command-router'
+import {
+  createElectronCallerContext,
+  createWebCallerContext,
+  type CallerContext
+} from './caller-context'
+import {
+  hostApplicationCommandGroups,
+  hostApplicationCommands,
+  registerHostApplicationCommands,
+  type HostApplicationCommandDependencies
+} from './host-application-commands'
+
+const HOST_CAPABILITIES = [
+  'cli',
+  'github',
+  'local-fs',
+  'logs',
+  'notifications',
+  'remote-access',
+  'reviewer',
+  'storage',
+  'update'
+] as const
+
+const remoteSnapshot: RemoteAccessSnapshot = {
+  canManage: true,
+  canManagePairing: true,
+  mode: 'off',
+  enabled: false,
+  lifecycle: 'disabled',
+  remoteIt: { installed: false, loggedIn: false, registered: false },
+  pendingRequests: [],
+  trustedBrowsers: []
+}
+
+const updateStatus: UpdateStatus = { state: 'idle', current: '1.0.0' }
+
+const createDependencies = (): HostApplicationCommandDependencies => ({
+  cli: {
+    getStatus: vi.fn(async () => ({
+      installed: false,
+      target: '/bin/open-science',
+      onPath: false
+    })),
+    install: vi.fn(async () => ({ installed: true, target: '/bin/open-science', onPath: true })),
+    uninstall: vi.fn(async () => ({ installed: false, target: '/bin/open-science', onPath: true }))
+  },
+  github: { getStars: vi.fn(async () => 42) },
+  localFs: {
+    getRoots: vi.fn(() => ({ home: '/home/scientist', machineName: 'Lab' })),
+    listDir: vi.fn(async (path: string) => ({ entries: [], truncated: false, resolvedPath: path })),
+    openPath: vi.fn(async () => ''),
+    readPreview: vi.fn(async () => ({
+      content: 'result',
+      encoding: 'utf8' as const,
+      size: 6,
+      truncated: false
+    })),
+    revealInFolder: vi.fn(() => undefined)
+  },
+  logs: {
+    getPath: vi.fn(() => '/logs/main.log'),
+    openFile: vi.fn(async () => ({ opened: true })),
+    revealInFolder: vi.fn(() => ({ revealed: true }))
+  },
+  notifications: {
+    peekPendingOpenSession: vi.fn(() => ({ sessionId: 'session-1', token: 7 })),
+    takePendingOpenSession: vi.fn(() => ({ sessionId: 'session-1', token: 7 }))
+  },
+  remoteAccess: {
+    snapshot: vi.fn(() => remoteSnapshot),
+    detect: vi.fn(async () => remoteSnapshot),
+    setMode: vi.fn(async () => remoteSnapshot),
+    disable: vi.fn(async () => remoteSnapshot),
+    approve: vi.fn(async () => remoteSnapshot),
+    reject: vi.fn(() => remoteSnapshot),
+    revoke: vi.fn(async () => remoteSnapshot)
+  } as unknown as HostApplicationCommandDependencies['remoteAccess'],
+  reviewer: {
+    run: vi.fn(async () => ({ started: true })),
+    getForSession: vi.fn(async () => []),
+    abortFixLoop: vi.fn(() => undefined)
+  },
+  storage: {
+    getInfo: vi.fn(async () => ({
+      dataRoot: '/data',
+      isDefault: true,
+      defaultDataRoot: '/data',
+      defaultParent: '/',
+      dataRootMissing: false,
+      legacyDataMovePrompt: false,
+      usage: { categories: [], totalBytes: 0 },
+      availableBytes: 100
+    })),
+    revealAppStorage: vi.fn(async () => ({ revealed: true })),
+    detectActive: vi.fn(() => []),
+    pickDirectory: vi.fn(async () => '/data-parent'),
+    validateDataRoot: vi.fn(async () => ({ ok: true as const })),
+    inspectDataRoot: vi.fn(async () => ({
+      kind: 'move' as const,
+      dataRoot: '/target/OpenScience'
+    })),
+    migrate: vi.fn(async () => ({ ok: true as const })),
+    setDataRootAndRelaunch: vi.fn(async () => ({ ok: true as const })),
+    cancelMigrate: vi.fn(() => undefined),
+    commitAndRelaunch: vi.fn(async () => ({ ok: true as const })),
+    discardMigratedCopy: vi.fn(async () => undefined),
+    dismissLegacyMovePrompt: vi.fn(async () => undefined)
+  },
+  update: {
+    getAppInfo: vi.fn(() => ({ name: 'Open Science', version: '1.0.0', copyright: 'Aipoch' })),
+    getStatus: vi.fn(() => updateStatus),
+    check: vi.fn(async () => updateStatus),
+    download: vi.fn(async () => updateStatus),
+    cancel: vi.fn(async () => updateStatus),
+    apply: vi.fn(async () => updateStatus)
+  }
+})
+
+const invocation = <Args extends readonly unknown[]>(
+  args: Args,
+  callerContext: CallerContext = createElectronCallerContext(7)
+): ApplicationInvocation<Args> => {
+  const callerLease: ApplicationCallerLease = Object.freeze({
+    leaseId: callerContext.leaseId,
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  })
+  return Object.freeze({ args, callerContext, callerLease })
+}
+
+const commandByName = (name: string): ApplicationCommand<string, readonly unknown[], unknown> => {
+  for (const { commands } of hostApplicationCommandGroups) {
+    const command = (
+      commands as readonly ApplicationCommand<string, readonly unknown[], unknown>[]
+    ).find((candidate) => candidate.name === name)
+    if (command) return command
+  }
+  throw new Error(`Missing host command: ${name}`)
+}
+
+describe('Host application commands', () => {
+  it('defines the exact 42 request channels in their existing capability groups', () => {
+    const expected = RENDERER_CONTRACT_GROUPS.filter(({ capability }) =>
+      HOST_CAPABILITIES.includes(capability as (typeof HOST_CAPABILITIES)[number])
+    ).map(({ capability, contracts }) => ({
+      capability,
+      channels: contracts
+        .filter(
+          ({ kind, surfaceInstallation }) =>
+            kind === 'method' && surfaceInstallation.localWeb === 'web-rpc'
+        )
+        .map(({ channel }) => channel)
+        .filter((channel): channel is string => channel !== null)
+    }))
+
+    expect(expected.flatMap(({ channels }) => channels)).toHaveLength(42)
+    expect(
+      hostApplicationCommandGroups.map(({ name, commands }) => ({
+        capability: name,
+        channels: commands.map(({ name: commandName }) => commandName)
+      }))
+    ).toEqual(expected)
+  })
+
+  it('installs and uninstalls every host group atomically', () => {
+    const router = createApplicationCommandRouter()
+    const installation = registerHostApplicationCommands(
+      router.registrar,
+      {} as HostApplicationCommandDependencies
+    )
+
+    expect(router.dispatcher.commandNames()).toHaveLength(42)
+    installation.uninstall()
+    expect(router.dispatcher.commandNames()).toEqual([])
+  })
+
+  it('delegates every canonical argument tuple to the existing capability owner', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerHostApplicationCommands(router.registrar, dependencies)
+    const previewRequest = { path: '/data/result.txt', encoding: 'utf8' as const }
+    const reviewRun = {
+      sessionId: 'session-1',
+      turnMessageId: 'message-1',
+      projectId: 'project-1',
+      origin: 'manual' as const
+    }
+    const reviewSession = { projectId: 'project-1', appSessionId: 'session-1' }
+    const parent = { parent: '/target' }
+    const root = { parent: '/target', markOnboarding: true }
+
+    await router.dispatcher.invoke(hostApplicationCommands.cli.getStatus, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.cli.install, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.cli.uninstall, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.github.getStars, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.localFs.getRoots, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.localFs.listDir, invocation(['/data']))
+    await router.dispatcher.invoke(
+      hostApplicationCommands.localFs.openPath,
+      invocation(['/data/a'])
+    )
+    await router.dispatcher.invoke(
+      hostApplicationCommands.localFs.readPreview,
+      invocation([previewRequest])
+    )
+    await router.dispatcher.invoke(hostApplicationCommands.localFs.reveal, invocation(['/data/a']))
+    await router.dispatcher.invoke(hostApplicationCommands.logs.getPath, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.logs.openFile, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.logs.revealInFolder, invocation([]))
+    await router.dispatcher.invoke(
+      hostApplicationCommands.notifications.peekPendingOpenSession,
+      invocation([])
+    )
+    await router.dispatcher.invoke(
+      hostApplicationCommands.notifications.takePendingOpenSession,
+      invocation([7])
+    )
+    await router.dispatcher.invoke(
+      hostApplicationCommands.remoteAccess.approve,
+      invocation([{ requestId: 'pair-1', decision: 'once' }])
+    )
+    await router.dispatcher.invoke(hostApplicationCommands.remoteAccess.detect, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.remoteAccess.disable, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.remoteAccess.getSnapshot, invocation([]))
+    await router.dispatcher.invoke(
+      hostApplicationCommands.remoteAccess.reject,
+      invocation([{ requestId: 'pair-2' }])
+    )
+    await router.dispatcher.invoke(
+      hostApplicationCommands.remoteAccess.revokeBrowser,
+      invocation([{ browserId: 'browser-1' }])
+    )
+    await router.dispatcher.invoke(
+      hostApplicationCommands.remoteAccess.setMode,
+      invocation([{ mode: 'remoteit' }])
+    )
+    await router.dispatcher.invoke(
+      hostApplicationCommands.reviewer.abortFixLoop,
+      invocation([reviewSession])
+    )
+    await router.dispatcher.invoke(
+      hostApplicationCommands.reviewer.getForSession,
+      invocation([reviewSession])
+    )
+    await router.dispatcher.invoke(hostApplicationCommands.reviewer.run, invocation([reviewRun]))
+    await router.dispatcher.invoke(hostApplicationCommands.storage.cancelMigrate, invocation([]))
+    await router.dispatcher.invoke(
+      hostApplicationCommands.storage.commitAndRelaunch,
+      invocation([parent])
+    )
+    await router.dispatcher.invoke(hostApplicationCommands.storage.detectActive, invocation([]))
+    await router.dispatcher.invoke(
+      hostApplicationCommands.storage.discardMigratedCopy,
+      invocation([parent])
+    )
+    await router.dispatcher.invoke(
+      hostApplicationCommands.storage.dismissLegacyMovePrompt,
+      invocation([])
+    )
+    await router.dispatcher.invoke(hostApplicationCommands.storage.getInfo, invocation([]))
+    await router.dispatcher.invoke(
+      hostApplicationCommands.storage.inspectDataRoot,
+      invocation([parent])
+    )
+    await router.dispatcher.invoke(hostApplicationCommands.storage.migrate, invocation([parent]))
+    await router.dispatcher.invoke(hostApplicationCommands.storage.pickDirectory, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.storage.revealAppStorage, invocation([]))
+    await router.dispatcher.invoke(
+      hostApplicationCommands.storage.setDataRootAndRelaunch,
+      invocation([root])
+    )
+    await router.dispatcher.invoke(
+      hostApplicationCommands.storage.validateDataRoot,
+      invocation([parent])
+    )
+    await router.dispatcher.invoke(hostApplicationCommands.update.apply, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.update.cancel, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.update.check, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.update.download, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.update.getAppInfo, invocation([]))
+    await router.dispatcher.invoke(hostApplicationCommands.update.getStatus, invocation([]))
+
+    expect(dependencies.localFs.listDir).toHaveBeenCalledWith('/data')
+    expect(dependencies.localFs.readPreview).toHaveBeenCalledWith(previewRequest)
+    expect(dependencies.notifications.takePendingOpenSession).toHaveBeenCalledWith(7)
+    expect(dependencies.remoteAccess.approve).toHaveBeenCalledWith(
+      { requestId: 'pair-1', decision: 'once' },
+      true,
+      true
+    )
+    expect(dependencies.remoteAccess.reject).toHaveBeenCalledWith('pair-2', true, true)
+    expect(dependencies.remoteAccess.revoke).toHaveBeenCalledWith('browser-1', true, true)
+    expect(dependencies.remoteAccess.setMode).toHaveBeenCalledWith('remoteit')
+    expect(dependencies.reviewer.run).toHaveBeenCalledWith(reviewRun)
+    expect(dependencies.reviewer.getForSession).toHaveBeenCalledWith(reviewSession)
+    expect(dependencies.storage.commitAndRelaunch).toHaveBeenCalledWith(parent)
+    expect(dependencies.storage.setDataRootAndRelaunch).toHaveBeenCalledWith(root)
+
+    const ownerMethods = Object.values(dependencies).flatMap((owner) => Object.values(owner))
+    expect(
+      ownerMethods.filter(vi.isMockFunction).every((method) => method.mock.calls.length === 1)
+    ).toBe(true)
+  })
+
+  it('rejects the exact local-only host inventory before entering an owner', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerHostApplicationCommands(router.registrar, dependencies)
+    const remoteCaller = createWebCallerContext('remote-browser', { location: 'remote' })
+    const previewRequest = { path: '/data/result.txt', encoding: 'utf8' as const }
+    const parent = { parent: '/target' }
+    const argsByChannel: Readonly<Record<string, readonly unknown[]>> = {
+      'local-fs:list-dir': ['/data'],
+      'local-fs:open-path': ['/data/result.txt'],
+      'local-fs:read-preview': [previewRequest],
+      'local-fs:reveal': ['/data/result.txt'],
+      'storage:commit-and-relaunch': [parent],
+      'storage:discard-migrated-copy': [parent],
+      'storage:inspect-data-root': [parent],
+      'storage:migrate': [parent],
+      'storage:set-data-root-and-relaunch': [{ ...parent, markOnboarding: true }],
+      'storage:validate-data-root': [parent]
+    }
+    const localOnlyChannels = RENDERER_CONTRACT_GROUPS.filter(({ capability }) =>
+      HOST_CAPABILITIES.includes(capability as (typeof HOST_CAPABILITIES)[number])
+    ).flatMap(({ contracts }) =>
+      contracts
+        .filter(
+          ({ surfaceInstallation }) =>
+            surfaceInstallation.localWeb === 'web-rpc' &&
+            surfaceInstallation.remoteWeb === 'rejecting-stub'
+        )
+        .map(({ channel }) => channel)
+        .filter((channel): channel is string => channel !== null)
+    )
+
+    expect(localOnlyChannels).toHaveLength(21)
+    for (const channel of localOnlyChannels) {
+      await expect(
+        router.dispatcher.invoke(
+          commandByName(channel),
+          invocation(argsByChannel[channel] ?? [], remoteCaller)
+        )
+      ).rejects.toThrow(`Channel only available from the local app: ${channel}`)
+    }
+
+    const ownerMethods = Object.values(dependencies).flatMap((owner) => Object.values(owner))
+    expect(
+      ownerMethods.filter(vi.isMockFunction).every((method) => method.mock.calls.length === 0)
+    ).toBe(true)
+  })
+
+  it('preserves the five-state Remote Access authority and freshness matrix', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerHostApplicationCommands(router.registrar, dependencies)
+    const desktop = createElectronCallerContext(7)
+    const localWeb = createWebCallerContext('local-web')
+    const ordinaryRemote = createWebCallerContext('ordinary-remote', { location: 'remote' })
+    const currentManager = createWebCallerContext('pairing-manager', {
+      location: 'remote',
+      authorities: ['manage-remote-pairing']
+    })
+    const staleManager = createWebCallerContext('stale-manager', {
+      location: 'remote',
+      authorities: ['manage-remote-pairing'],
+      isAuthorizationCurrent: () => false
+    })
+
+    for (const caller of [desktop, localWeb, ordinaryRemote, currentManager]) {
+      await router.dispatcher.invoke(
+        hostApplicationCommands.remoteAccess.getSnapshot,
+        invocation([], caller)
+      )
+    }
+    await expect(
+      router.dispatcher.invoke(
+        hostApplicationCommands.remoteAccess.getSnapshot,
+        invocation([], staleManager)
+      )
+    ).rejects.toThrow('Caller authorization is no longer current.')
+
+    expect(dependencies.remoteAccess.snapshot).toHaveBeenNthCalledWith(1, true, true)
+    expect(dependencies.remoteAccess.snapshot).toHaveBeenNthCalledWith(2, false, false)
+    expect(dependencies.remoteAccess.snapshot).toHaveBeenNthCalledWith(3, false, false)
+    expect(dependencies.remoteAccess.snapshot).toHaveBeenNthCalledWith(4, false, true)
+
+    const approval = { requestId: 'pair-1', decision: 'once' as const }
+    await expect(
+      router.dispatcher.invoke(
+        hostApplicationCommands.remoteAccess.approve,
+        invocation([approval], ordinaryRemote)
+      )
+    ).rejects.toThrow(
+      'Pairing can only be managed from the Open Science desktop app or an approved browser.'
+    )
+    await expect(
+      router.dispatcher.invoke(
+        hostApplicationCommands.remoteAccess.approve,
+        invocation([approval], currentManager)
+      )
+    ).resolves.toBe(remoteSnapshot)
+    expect(dependencies.remoteAccess.approve).toHaveBeenCalledWith(approval, false, true)
+
+    await expect(
+      router.dispatcher.invoke(
+        hostApplicationCommands.remoteAccess.detect,
+        invocation([], currentManager)
+      )
+    ).rejects.toThrow('This action must be approved from the Open Science desktop app.')
+    expect(dependencies.remoteAccess.detect).not.toHaveBeenCalled()
+  })
+
+  it('keeps pending-notification token validation ahead of owner mutation', async () => {
+    const dependencies = createDependencies()
+    const router = createApplicationCommandRouter()
+    registerHostApplicationCommands(router.registrar, dependencies)
+
+    for (const invalidToken of ['7', 0, -1, 1.5, Number.POSITIVE_INFINITY]) {
+      await expect(
+        router.dispatcher.invoke(
+          hostApplicationCommands.notifications.takePendingOpenSession,
+          invocation([invalidToken])
+        )
+      ).resolves.toBeNull()
+    }
+    expect(dependencies.notifications.takePendingOpenSession).not.toHaveBeenCalled()
+
+    await expect(
+      router.dispatcher.invoke(
+        hostApplicationCommands.notifications.takePendingOpenSession,
+        invocation([7])
+      )
+    ).resolves.toEqual({ sessionId: 'session-1', token: 7 })
+    expect(dependencies.notifications.takePendingOpenSession).toHaveBeenCalledWith(7)
+  })
+})

--- a/src/main/host-application-commands.ts
+++ b/src/main/host-application-commands.ts
@@ -1,0 +1,477 @@
+import type { ArtifactPreviewResult, ReadArtifactPreviewRequest } from '../shared/artifacts'
+import type { CliLauncherStatus } from '../shared/cli'
+import type { LocalDirListing, LocalRoots } from '../shared/local-fs'
+import type { OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
+import type { OpenSessionFromNotificationRequest } from '../shared/notifications'
+import type {
+  ApproveRemotePairingRequest,
+  RemoteAccessSnapshot,
+  RemotePairingRequestId,
+  RevokeRemoteBrowserRequest,
+  SetRemoteAccessModeRequest
+} from '../shared/remote-access'
+import type {
+  ReviewRunRequest,
+  ReviewRunResult,
+  ReviewSessionRequest,
+  ReviewWithChecks
+} from '../shared/reviewer'
+import type {
+  ActiveSessionInfo,
+  DataRootInspection,
+  DataRootValidationResult,
+  MigrationOutcome,
+  RevealAppStorageResult,
+  StorageInfo
+} from '../shared/storage'
+import type { AppInfo, UpdateStatus } from '../shared/update'
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRegistrar
+} from './application-command-router'
+import type { CallerContext } from './caller-context'
+import type { LocalFsService } from './local-fs/service'
+import {
+  canManagePairing,
+  isDesktopCaller,
+  requireDesktopCaller,
+  requirePairingManager
+} from './remote-access/ipc'
+import type { RemoteAccessService } from './remote-access/service'
+
+type StorageParentRequest = Readonly<{ parent: string }>
+type StorageRootRequest = Readonly<{ parent: string; markOnboarding?: boolean }>
+
+const cliCommands = Object.freeze({
+  getStatus: defineApplicationCommand<'cli:get-status', readonly [], CliLauncherStatus>(
+    'cli:get-status'
+  ),
+  install: defineApplicationCommand<'cli:install', readonly [], CliLauncherStatus>('cli:install'),
+  uninstall: defineApplicationCommand<'cli:uninstall', readonly [], CliLauncherStatus>(
+    'cli:uninstall'
+  )
+})
+
+const githubCommands = Object.freeze({
+  getStars: defineApplicationCommand<'github:get-stars', readonly [], number | null>(
+    'github:get-stars'
+  )
+})
+
+const localFsCommands = Object.freeze({
+  getRoots: defineApplicationCommand<'local-fs:get-roots', readonly [], LocalRoots>(
+    'local-fs:get-roots'
+  ),
+  listDir: defineApplicationCommand<'local-fs:list-dir', readonly [path: string], LocalDirListing>(
+    'local-fs:list-dir'
+  ),
+  openPath: defineApplicationCommand<'local-fs:open-path', readonly [path: string], string>(
+    'local-fs:open-path'
+  ),
+  readPreview: defineApplicationCommand<
+    'local-fs:read-preview',
+    readonly [request: ReadArtifactPreviewRequest],
+    ArtifactPreviewResult
+  >('local-fs:read-preview'),
+  reveal: defineApplicationCommand<'local-fs:reveal', readonly [path: string], void>(
+    'local-fs:reveal'
+  )
+})
+
+const logsCommands = Object.freeze({
+  getPath: defineApplicationCommand<'logs:get-path', readonly [], string | null>('logs:get-path'),
+  openFile: defineApplicationCommand<'logs:open-file', readonly [], OpenLogFileResult>(
+    'logs:open-file'
+  ),
+  revealInFolder: defineApplicationCommand<
+    'logs:reveal-in-folder',
+    readonly [],
+    RevealLogFileResult
+  >('logs:reveal-in-folder')
+})
+
+const notificationCommands = Object.freeze({
+  peekPendingOpenSession: defineApplicationCommand<
+    'notifications:peek-pending-open-session',
+    readonly [],
+    OpenSessionFromNotificationRequest | null
+  >('notifications:peek-pending-open-session'),
+  takePendingOpenSession: defineApplicationCommand<
+    'notifications:take-pending-open-session',
+    readonly [expectedToken: unknown],
+    OpenSessionFromNotificationRequest | null
+  >('notifications:take-pending-open-session')
+})
+
+const remoteAccessCommands = Object.freeze({
+  approve: defineApplicationCommand<
+    'remote-access:approve',
+    readonly [request: ApproveRemotePairingRequest],
+    RemoteAccessSnapshot
+  >('remote-access:approve'),
+  detect: defineApplicationCommand<'remote-access:detect', readonly [], RemoteAccessSnapshot>(
+    'remote-access:detect'
+  ),
+  disable: defineApplicationCommand<'remote-access:disable', readonly [], RemoteAccessSnapshot>(
+    'remote-access:disable'
+  ),
+  getSnapshot: defineApplicationCommand<
+    'remote-access:get-snapshot',
+    readonly [],
+    RemoteAccessSnapshot
+  >('remote-access:get-snapshot'),
+  reject: defineApplicationCommand<
+    'remote-access:reject',
+    readonly [request: RemotePairingRequestId],
+    RemoteAccessSnapshot
+  >('remote-access:reject'),
+  revokeBrowser: defineApplicationCommand<
+    'remote-access:revoke-browser',
+    readonly [request: RevokeRemoteBrowserRequest],
+    RemoteAccessSnapshot
+  >('remote-access:revoke-browser'),
+  setMode: defineApplicationCommand<
+    'remote-access:set-mode',
+    readonly [request: SetRemoteAccessModeRequest],
+    RemoteAccessSnapshot
+  >('remote-access:set-mode')
+})
+
+const reviewerCommands = Object.freeze({
+  abortFixLoop: defineApplicationCommand<
+    'reviewer:abort-fix-loop',
+    readonly [request: ReviewSessionRequest],
+    void
+  >('reviewer:abort-fix-loop'),
+  getForSession: defineApplicationCommand<
+    'reviewer:get-for-session',
+    readonly [request: ReviewSessionRequest],
+    ReviewWithChecks[]
+  >('reviewer:get-for-session'),
+  run: defineApplicationCommand<
+    'reviewer:run',
+    readonly [request: ReviewRunRequest],
+    ReviewRunResult
+  >('reviewer:run')
+})
+
+const storageCommands = Object.freeze({
+  cancelMigrate: defineApplicationCommand<'storage:cancel-migrate', readonly [], void>(
+    'storage:cancel-migrate'
+  ),
+  commitAndRelaunch: defineApplicationCommand<
+    'storage:commit-and-relaunch',
+    readonly [request: StorageParentRequest],
+    MigrationOutcome
+  >('storage:commit-and-relaunch'),
+  detectActive: defineApplicationCommand<'storage:detect-active', readonly [], ActiveSessionInfo[]>(
+    'storage:detect-active'
+  ),
+  discardMigratedCopy: defineApplicationCommand<
+    'storage:discard-migrated-copy',
+    readonly [request: StorageParentRequest],
+    void
+  >('storage:discard-migrated-copy'),
+  dismissLegacyMovePrompt: defineApplicationCommand<
+    'storage:dismiss-legacy-move-prompt',
+    readonly [],
+    void
+  >('storage:dismiss-legacy-move-prompt'),
+  getInfo: defineApplicationCommand<'storage:get-info', readonly [], StorageInfo>(
+    'storage:get-info'
+  ),
+  inspectDataRoot: defineApplicationCommand<
+    'storage:inspect-data-root',
+    readonly [request: StorageParentRequest],
+    DataRootInspection
+  >('storage:inspect-data-root'),
+  migrate: defineApplicationCommand<
+    'storage:migrate',
+    readonly [request: StorageParentRequest],
+    MigrationOutcome
+  >('storage:migrate'),
+  pickDirectory: defineApplicationCommand<'storage:pick-directory', readonly [], string | null>(
+    'storage:pick-directory'
+  ),
+  revealAppStorage: defineApplicationCommand<
+    'storage:reveal-app-storage',
+    readonly [],
+    RevealAppStorageResult
+  >('storage:reveal-app-storage'),
+  setDataRootAndRelaunch: defineApplicationCommand<
+    'storage:set-data-root-and-relaunch',
+    readonly [request: StorageRootRequest],
+    DataRootValidationResult
+  >('storage:set-data-root-and-relaunch'),
+  validateDataRoot: defineApplicationCommand<
+    'storage:validate-data-root',
+    readonly [request: StorageParentRequest],
+    DataRootValidationResult
+  >('storage:validate-data-root')
+})
+
+const updateCommands = Object.freeze({
+  apply: defineApplicationCommand<'update:apply', readonly [], UpdateStatus>('update:apply'),
+  cancel: defineApplicationCommand<'update:cancel', readonly [], UpdateStatus>('update:cancel'),
+  check: defineApplicationCommand<'update:check', readonly [], UpdateStatus>('update:check'),
+  download: defineApplicationCommand<'update:download', readonly [], UpdateStatus>(
+    'update:download'
+  ),
+  getAppInfo: defineApplicationCommand<'update:get-app-info', readonly [], AppInfo>(
+    'update:get-app-info'
+  ),
+  getStatus: defineApplicationCommand<'update:get-status', readonly [], UpdateStatus>(
+    'update:get-status'
+  )
+})
+
+const hostApplicationCommands = Object.freeze({
+  cli: cliCommands,
+  github: githubCommands,
+  localFs: localFsCommands,
+  logs: logsCommands,
+  notifications: notificationCommands,
+  remoteAccess: remoteAccessCommands,
+  reviewer: reviewerCommands,
+  storage: storageCommands,
+  update: updateCommands
+})
+
+const hostApplicationCommandGroups = Object.freeze([
+  defineApplicationCommandGroup('cli', Object.values(cliCommands)),
+  defineApplicationCommandGroup('github', Object.values(githubCommands)),
+  defineApplicationCommandGroup('local-fs', Object.values(localFsCommands)),
+  defineApplicationCommandGroup('logs', Object.values(logsCommands)),
+  defineApplicationCommandGroup('notifications', Object.values(notificationCommands)),
+  defineApplicationCommandGroup('remote-access', Object.values(remoteAccessCommands)),
+  defineApplicationCommandGroup('reviewer', Object.values(reviewerCommands)),
+  defineApplicationCommandGroup('storage', Object.values(storageCommands)),
+  defineApplicationCommandGroup('update', Object.values(updateCommands))
+] as const)
+
+type HostApplicationCommandDependencies = Readonly<{
+  cli: Readonly<{
+    getStatus: () => Promise<CliLauncherStatus>
+    install: () => Promise<CliLauncherStatus>
+    uninstall: () => Promise<CliLauncherStatus>
+  }>
+  github: Readonly<{ getStars: () => Promise<number | null> }>
+  localFs: Pick<
+    LocalFsService,
+    'getRoots' | 'listDir' | 'openPath' | 'readPreview' | 'revealInFolder'
+  >
+  logs: Readonly<{
+    getPath: () => string | null
+    openFile: () => Promise<OpenLogFileResult>
+    revealInFolder: () => RevealLogFileResult
+  }>
+  notifications: Readonly<{
+    peekPendingOpenSession: () => OpenSessionFromNotificationRequest | null
+    takePendingOpenSession: (expectedToken: number) => OpenSessionFromNotificationRequest | null
+  }>
+  remoteAccess: Pick<
+    RemoteAccessService,
+    'snapshot' | 'detect' | 'setMode' | 'disable' | 'approve' | 'reject' | 'revoke'
+  >
+  reviewer: Readonly<{
+    run: (request: ReviewRunRequest) => Promise<ReviewRunResult>
+    getForSession: (request: ReviewSessionRequest) => Promise<ReviewWithChecks[]>
+    abortFixLoop: (request: ReviewSessionRequest) => void
+  }>
+  storage: Readonly<{
+    getInfo: () => Promise<StorageInfo>
+    revealAppStorage: () => Promise<RevealAppStorageResult>
+    detectActive: () => ActiveSessionInfo[]
+    pickDirectory: () => Promise<string | null>
+    validateDataRoot: (request: StorageParentRequest) => Promise<DataRootValidationResult>
+    inspectDataRoot: (request: StorageParentRequest) => Promise<DataRootInspection>
+    migrate: (request: StorageParentRequest) => Promise<MigrationOutcome>
+    setDataRootAndRelaunch: (request: StorageRootRequest) => Promise<DataRootValidationResult>
+    cancelMigrate: () => void
+    commitAndRelaunch: (request: StorageParentRequest) => Promise<MigrationOutcome>
+    discardMigratedCopy: (request: StorageParentRequest) => Promise<void>
+    dismissLegacyMovePrompt: () => Promise<void>
+  }>
+  update: Readonly<{
+    getAppInfo: () => AppInfo
+    getStatus: () => UpdateStatus
+    check: () => Promise<UpdateStatus>
+    download: () => Promise<UpdateStatus>
+    cancel: () => Promise<UpdateStatus>
+    apply: () => Promise<UpdateStatus>
+  }>
+}>
+
+const localCommand = <Result>(
+  context: CallerContext,
+  channel: string,
+  invoke: () => Result
+): Result => {
+  if (context.location !== 'local') {
+    throw new Error(`Channel only available from the local app: ${channel}`)
+  }
+  return invoke()
+}
+
+// Production composition registers all bounded command groups atomically; this group must not be
+// exposed through a live transport in isolation.
+const registerHostApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  dependencies: HostApplicationCommandDependencies
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+  try {
+    scope.registerGroup(hostApplicationCommandGroups[0], {
+      'cli:get-status': () => dependencies.cli.getStatus(),
+      'cli:install': ({ callerContext }) =>
+        localCommand(callerContext, 'cli:install', () => dependencies.cli.install()),
+      'cli:uninstall': ({ callerContext }) =>
+        localCommand(callerContext, 'cli:uninstall', () => dependencies.cli.uninstall())
+    })
+    scope.registerGroup(hostApplicationCommandGroups[1], {
+      'github:get-stars': () => dependencies.github.getStars()
+    })
+    scope.registerGroup(hostApplicationCommandGroups[2], {
+      'local-fs:get-roots': ({ callerContext }) =>
+        localCommand(callerContext, 'local-fs:get-roots', () => dependencies.localFs.getRoots()),
+      'local-fs:list-dir': ({ args, callerContext }) =>
+        localCommand(callerContext, 'local-fs:list-dir', () =>
+          dependencies.localFs.listDir(args[0])
+        ),
+      'local-fs:open-path': ({ args, callerContext }) =>
+        localCommand(callerContext, 'local-fs:open-path', () =>
+          dependencies.localFs.openPath(args[0])
+        ),
+      'local-fs:read-preview': ({ args, callerContext }) =>
+        localCommand(callerContext, 'local-fs:read-preview', () =>
+          dependencies.localFs.readPreview(args[0])
+        ),
+      'local-fs:reveal': ({ args, callerContext }) =>
+        localCommand(callerContext, 'local-fs:reveal', () =>
+          dependencies.localFs.revealInFolder(args[0])
+        )
+    })
+    scope.registerGroup(hostApplicationCommandGroups[3], {
+      'logs:get-path': () => dependencies.logs.getPath(),
+      'logs:open-file': ({ callerContext }) =>
+        localCommand(callerContext, 'logs:open-file', () => dependencies.logs.openFile()),
+      'logs:reveal-in-folder': ({ callerContext }) =>
+        localCommand(callerContext, 'logs:reveal-in-folder', () =>
+          dependencies.logs.revealInFolder()
+        )
+    })
+    scope.registerGroup(hostApplicationCommandGroups[4], {
+      'notifications:peek-pending-open-session': () =>
+        dependencies.notifications.peekPendingOpenSession(),
+      'notifications:take-pending-open-session': ({ args }) =>
+        typeof args[0] === 'number' && Number.isSafeInteger(args[0]) && args[0] > 0
+          ? dependencies.notifications.takePendingOpenSession(args[0])
+          : null
+    })
+    scope.registerGroup(hostApplicationCommandGroups[5], {
+      'remote-access:approve': ({ args, callerContext }) => {
+        requirePairingManager(callerContext)
+        const desktop = isDesktopCaller(callerContext)
+        return dependencies.remoteAccess.approve(args[0], desktop, canManagePairing(callerContext))
+      },
+      'remote-access:detect': ({ callerContext }) => {
+        requireDesktopCaller(callerContext)
+        return dependencies.remoteAccess.detect()
+      },
+      'remote-access:disable': ({ callerContext }) => {
+        requireDesktopCaller(callerContext)
+        return dependencies.remoteAccess.disable()
+      },
+      'remote-access:get-snapshot': ({ callerContext }) => {
+        const desktop = isDesktopCaller(callerContext)
+        return dependencies.remoteAccess.snapshot(desktop, canManagePairing(callerContext))
+      },
+      'remote-access:reject': ({ args, callerContext }) => {
+        requirePairingManager(callerContext)
+        const desktop = isDesktopCaller(callerContext)
+        return dependencies.remoteAccess.reject(
+          args[0].requestId,
+          desktop,
+          canManagePairing(callerContext)
+        )
+      },
+      'remote-access:revoke-browser': ({ args, callerContext }) => {
+        requirePairingManager(callerContext)
+        const desktop = isDesktopCaller(callerContext)
+        return dependencies.remoteAccess.revoke(
+          args[0].browserId,
+          desktop,
+          canManagePairing(callerContext)
+        )
+      },
+      'remote-access:set-mode': ({ args, callerContext }) => {
+        requireDesktopCaller(callerContext)
+        return dependencies.remoteAccess.setMode(args[0].mode)
+      }
+    })
+    scope.registerGroup(hostApplicationCommandGroups[6], {
+      'reviewer:abort-fix-loop': ({ args }) => dependencies.reviewer.abortFixLoop(args[0]),
+      'reviewer:get-for-session': ({ args }) => dependencies.reviewer.getForSession(args[0]),
+      'reviewer:run': ({ args }) => dependencies.reviewer.run(args[0])
+    })
+    scope.registerGroup(hostApplicationCommandGroups[7], {
+      'storage:cancel-migrate': ({ callerContext }) =>
+        localCommand(callerContext, 'storage:cancel-migrate', () =>
+          dependencies.storage.cancelMigrate()
+        ),
+      'storage:commit-and-relaunch': ({ args, callerContext }) =>
+        localCommand(callerContext, 'storage:commit-and-relaunch', () =>
+          dependencies.storage.commitAndRelaunch(args[0])
+        ),
+      'storage:detect-active': () => dependencies.storage.detectActive(),
+      'storage:discard-migrated-copy': ({ args, callerContext }) =>
+        localCommand(callerContext, 'storage:discard-migrated-copy', () =>
+          dependencies.storage.discardMigratedCopy(args[0])
+        ),
+      'storage:dismiss-legacy-move-prompt': () => dependencies.storage.dismissLegacyMovePrompt(),
+      'storage:get-info': () => dependencies.storage.getInfo(),
+      'storage:inspect-data-root': ({ args, callerContext }) =>
+        localCommand(callerContext, 'storage:inspect-data-root', () =>
+          dependencies.storage.inspectDataRoot(args[0])
+        ),
+      'storage:migrate': ({ args, callerContext }) =>
+        localCommand(callerContext, 'storage:migrate', () => dependencies.storage.migrate(args[0])),
+      'storage:pick-directory': ({ callerContext }) =>
+        localCommand(callerContext, 'storage:pick-directory', () =>
+          dependencies.storage.pickDirectory()
+        ),
+      'storage:reveal-app-storage': ({ callerContext }) =>
+        localCommand(callerContext, 'storage:reveal-app-storage', () =>
+          dependencies.storage.revealAppStorage()
+        ),
+      'storage:set-data-root-and-relaunch': ({ args, callerContext }) =>
+        localCommand(callerContext, 'storage:set-data-root-and-relaunch', () =>
+          dependencies.storage.setDataRootAndRelaunch(args[0])
+        ),
+      'storage:validate-data-root': ({ args, callerContext }) =>
+        localCommand(callerContext, 'storage:validate-data-root', () =>
+          dependencies.storage.validateDataRoot(args[0])
+        )
+    })
+    scope.registerGroup(hostApplicationCommandGroups[8], {
+      'update:apply': ({ callerContext }) =>
+        localCommand(callerContext, 'update:apply', () => dependencies.update.apply()),
+      'update:cancel': ({ callerContext }) =>
+        localCommand(callerContext, 'update:cancel', () => dependencies.update.cancel()),
+      'update:check': () => dependencies.update.check(),
+      'update:download': ({ callerContext }) =>
+        localCommand(callerContext, 'update:download', () => dependencies.update.download()),
+      'update:get-app-info': () => dependencies.update.getAppInfo(),
+      'update:get-status': () => dependencies.update.getStatus()
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export { hostApplicationCommandGroups, hostApplicationCommands, registerHostApplicationCommands }
+export type { HostApplicationCommandDependencies }


### PR DESCRIPTION
# T2g pull request

Title: `refactor(host): register review and platform commands`

## Problem

Host, Reviewer, and platform services still expose transport-shaped handler sets. The staged router
needs a bounded registration layer that preserves authorization, filesystem locality, notification
tokens, Reviewer isolation, and existing surface capability asymmetry.

## Proposed change

- Register the exact nine groups / 42 commands for CLI, GitHub, Local FS, Logs, Notifications, Remote
  Access, Reviewer, Storage, and Update.
- Reject the exact 21 remote-Web local-only commands before owner mutation.
- Preserve the Remote Access five-state policy and authorization freshness checks.
- Validate notification tokens before mutation and forward Reviewer requests, including `origin`, to
  the existing owner unchanged.

## Scope and non-goals

- This is staged registration only; no live import/composition or transport cutover. The absence of
  a production call site is intentional: T2h0f exclusively owns live composition and is the first PR
  allowed to invoke this registration function.
- Specialist stays Electron-only; Permission and Compute are not added here.
- No wire/data/UI, filesystem/storage authority, Reviewer lifecycle, Electron/Web/Task/CLI capability,
  or Issue #458 orchestration change.

## Acceptance criteria and validation

- Exact nine groups / 42 commands -> contract tests -> passed.
- Exact 21 remote-Web local-only rejections occur before owner invocation -> command tests -> passed.
- Remote five-state and authorization freshness remain fail-closed -> focused tests -> passed.
- Notification token and Reviewer request/origin delegation preserve existing behavior -> command and
  owner regressions -> passed.
- Focused host/reviewer/storage/remote regression -> 10 files / 187 tests passed; new contract set ->
  6 tests passed.
- `npm run typecheck:node`, targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards and Spec reviews -> 0 actionable findings.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- No command may widen Remote, filesystem, storage, Reviewer, or notification authority.
- Production churn is 477 lines, below but close to the 500-line hard stop; Storage remains included.

## Uncovered risk

Shared Storage/Reviewer/Host owner extraction remains T2h0c/T2h0d; live owner injection, global
collisions, and adapter lifecycle ordering remain T2h0f/T2h1 certification responsibilities.
