### PR TITLE
refactor(preview): share managed owner

### DIFF
--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -88,7 +88,13 @@ const createDependencies = () => {
       mimeType: 'text/plain',
       version: 1
     })),
-    readRange: vi.fn(async () => ({ begin: 0, end: 1, total: 1, data: new Uint8Array([1]) })),
+    readRange: vi.fn(async () => ({
+      begin: 0,
+      end: 1,
+      total: 1,
+      data: new Uint8Array([1])
+    })),
+    register: vi.fn(),
     release: vi.fn()
   }
   const preview = { load: vi.fn(), save: vi.fn(), delete: vi.fn() }
@@ -347,19 +353,19 @@ describe('Data and content application commands', () => {
         key: 'previewResourceAcquire',
         args: [request('preview-resource-acquire')],
         owner: deps.managedPreview.acquire,
-        passInvocation: true
+        passCallerLease: true
       },
       {
         key: 'previewResourceReadRange',
         args: [request('preview-resource-read')],
         owner: deps.managedPreview.readRange,
-        passInvocation: true
+        passCallerLease: true
       },
       {
         key: 'previewResourceRelease',
         args: [request('preview-resource-release')],
         owner: deps.managedPreview.release,
-        passInvocation: true
+        passCallerLease: true
       },
       {
         key: 'projectFilesGetOverview',
@@ -447,7 +453,12 @@ describe('Data and content application commands', () => {
     for (const testCase of cases) {
       const dispatched = dispatchCommand(router, testCase.key, testCase.args)
       await dispatched.result
-      const expectedArgs = 'passInvocation' in testCase ? [dispatched.invocation] : testCase.args
+      const expectedArgs =
+        'passInvocation' in testCase
+          ? [dispatched.invocation]
+          : 'passCallerLease' in testCase
+            ? [dispatched.invocation.callerLease, ...testCase.args]
+            : testCase.args
       expect(testCase.owner, testCase.key).toHaveBeenCalledWith(...expectedArgs)
     }
 
@@ -490,7 +501,10 @@ describe('Data and content application commands', () => {
       invocation([{ projectId: 'project-1' }] as const)
     )
 
-    expect(deps.managedPreview.acquire).toHaveBeenCalledWith(managedInvocation)
+    expect(deps.managedPreview.acquire).toHaveBeenCalledWith(
+      managedInvocation.callerLease,
+      managedInvocation.args[0]
+    )
     expect(deps.uploads.appendTransfer).toHaveBeenCalledWith(uploadInvocation)
     expect(deps.projectFiles.repairIndex).toHaveBeenCalledWith({ projectId: 'project-1' })
     expect(deps.preview.load).toHaveBeenCalledWith({ projectId: 'project-1' })

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -11,6 +11,7 @@ import { ArtifactOwnershipPersistenceRaceError } from './artifacts/provenance-re
 import type { ProjectFilesHandlers } from './project-files/ipc'
 import type { ProjectHandlers } from './projects/ipc'
 import type { SessionPersistenceHandlers } from './session-persistence/ipc'
+import type { ManagedPreviewOwnerRegistry } from './managed-preview-ipc'
 
 import * as Artifacts from '../shared/artifacts'
 import type * as ConversationExport from '../shared/conversation-export'
@@ -86,15 +87,7 @@ type ElectronDataContentApplicationCommandAdapter = InvocationOwner<{
   ) => Promise<Uploads.UploadedAttachment>
 }>
 
-type ManagedPreviewApplicationCommandOwner = InvocationOwner<{
-  acquire: (
-    request: PreviewResources.AcquireManagedPreviewRequest
-  ) => Promise<PreviewResources.ManagedPreviewResource>
-  readRange: (
-    request: PreviewResources.ReadManagedPreviewRangeRequest
-  ) => Promise<PreviewResources.ManagedPreviewRangeResult>
-  release: (request: PreviewResources.ReleaseManagedPreviewRequest) => void
-}>
+type ManagedPreviewApplicationCommandOwner = ManagedPreviewOwnerRegistry
 
 type UploadApplicationCommandOwner = InvocationOwner<{
   claimLocalFile: (request: Uploads.UploadTransferRequest) => void
@@ -142,7 +135,6 @@ const projectFilesCommand = commandFor<ProjectFilesHandlers>()
 const projectCommand = commandFor<ProjectHandlers>()
 const sessionCommand = commandFor<SessionApplicationCommandOwner>()
 const electronCommand = invocationCommandFor<ElectronDataContentApplicationCommandAdapter>()
-const managedPreviewCommand = invocationCommandFor<ManagedPreviewApplicationCommandOwner>()
 const uploadCommand = invocationCommandFor<UploadApplicationCommandOwner>()
 
 const dataContentApplicationCommands = Object.freeze({
@@ -178,9 +170,21 @@ const dataContentApplicationCommands = Object.freeze({
   previewDelete: previewCommand('preview:delete', 'delete'),
   previewLoad: previewCommand('preview:load', 'load'),
   previewSave: previewCommand('preview:save', 'save'),
-  previewResourceAcquire: managedPreviewCommand('preview-resources:acquire', 'acquire'),
-  previewResourceReadRange: managedPreviewCommand('preview-resources:read-range', 'readRange'),
-  previewResourceRelease: managedPreviewCommand('preview-resources:release', 'release'),
+  previewResourceAcquire: defineApplicationCommand<
+    'preview-resources:acquire',
+    readonly [request: PreviewResources.AcquireManagedPreviewRequest],
+    PreviewResources.ManagedPreviewResource
+  >('preview-resources:acquire'),
+  previewResourceReadRange: defineApplicationCommand<
+    'preview-resources:read-range',
+    readonly [request: PreviewResources.ReadManagedPreviewRangeRequest],
+    PreviewResources.ManagedPreviewRangeResult
+  >('preview-resources:read-range'),
+  previewResourceRelease: defineApplicationCommand<
+    'preview-resources:release',
+    readonly [request: PreviewResources.ReleaseManagedPreviewRequest],
+    void
+  >('preview-resources:release'),
   projectFilesGetOverview: projectFilesCommand('project-files:get-overview', 'getOverview'),
   projectFilesListArtifactGroups: projectFilesCommand(
     'project-files:list-artifact-groups',
@@ -376,10 +380,12 @@ const registerDataContentApplicationCommands = (
       'preview:save': ({ args }) => dependencies.preview.save(args[0])
     })
     scope.registerGroup(dataContentApplicationCommandGroups[3], {
-      'preview-resources:acquire': (invocation) => dependencies.managedPreview.acquire(invocation),
-      'preview-resources:read-range': (invocation) =>
-        dependencies.managedPreview.readRange(invocation),
-      'preview-resources:release': (invocation) => dependencies.managedPreview.release(invocation)
+      'preview-resources:acquire': ({ args, callerLease }) =>
+        dependencies.managedPreview.acquire(callerLease, args[0]),
+      'preview-resources:read-range': ({ args, callerLease }) =>
+        dependencies.managedPreview.readRange(callerLease, args[0]),
+      'preview-resources:release': ({ args, callerLease }) =>
+        dependencies.managedPreview.release(callerLease, args[0])
     })
     scope.registerGroup(dataContentApplicationCommandGroups[4], {
       'project-files:get-overview': ({ args }) => dependencies.projectFiles.getOverview(args[0]),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -60,8 +60,7 @@ import {
 } from './notebook/application'
 import { serializeProvisioner } from './notebook/environment-operation-foundation'
 import { createNotebookEnvironmentLifecycle } from './notebook/environment-lifecycle-workflows'
-import { registerManagedPreviewIpcHandlers } from './managed-preview-ipc'
-import { registerManagedPreviewProtocol } from './managed-preview-protocol'
+import { installManagedPreviewElectronAdapter } from './managed-preview-ipc'
 import { ManagedPreviewResources } from './managed-preview-resources'
 import type { ManagedPreviewSource } from '../shared/preview-resources'
 import {
@@ -1144,10 +1143,9 @@ const createApplicationModules = async (
   declareElectronAdapter('notebook-runtime', () =>
     registerRuntimeIpcHandlers(runtimeSelectionWorkflows)
   )
-  declareElectronAdapter('managed-preview', () => {
-    registerManagedPreviewIpcHandlers(previewResources)
-    registerManagedPreviewProtocol(previewResources)
-  })
+  declareElectronAdapter('managed-preview', () =>
+    installManagedPreviewElectronAdapter(previewResources)
+  )
   declareElectronAdapter('office-preview-runtime', () =>
     registerOfficePreviewRuntimeProtocol(
       {

--- a/src/main/managed-preview-ipc.test.ts
+++ b/src/main/managed-preview-ipc.test.ts
@@ -8,16 +8,26 @@ import { ApplicationCallerLeaseRegistry } from './caller-lifecycle'
 import type { ManagedPreviewResources } from './managed-preview-resources'
 import {
   createManagedPreviewOwnerRegistry,
-  registerManagedPreviewIpcHandlers
+  installManagedPreviewElectronAdapter,
+  registerManagedPreviewIpcHandlers,
+  type ManagedPreviewOwnerRegistry
 } from './managed-preview-ipc'
 
 // Vitest hoists vi.mock(...) above the rest of the module body, so anything the factory closes over
 // has to exist before the factory runs. vi.hoisted guarantees that.
-const handlers = vi.hoisted(() => new Map<string, (event: unknown, payload: unknown) => unknown>())
+const testIpc = vi.hoisted(() => ({
+  failingChannel: undefined as string | undefined,
+  handlers: new Map<string, (event: unknown, payload: unknown) => unknown>()
+}))
+const { handlers } = testIpc
 
 vi.mock('electron', () => ({
   ipcMain: {
     handle: (channel: string, handler: (event: unknown, payload: unknown) => unknown) => {
+      if (testIpc.failingChannel === channel) {
+        testIpc.failingChannel = undefined
+        throw new Error('IPC handler registration failed.')
+      }
       handlers.set(channel, handler)
     }
   }
@@ -59,6 +69,18 @@ const createResources = (
   }) as unknown as ManagedPreviewResources
 
 describe('managed preview IPC handlers', () => {
+  it('reuses one owner registry per resource authority and isolates different authorities', () => {
+    const resources = createResources()
+    const otherResources = createResources()
+
+    expect(createManagedPreviewOwnerRegistry(resources)).toBe(
+      createManagedPreviewOwnerRegistry(resources)
+    )
+    expect(createManagedPreviewOwnerRegistry(otherResources)).not.toBe(
+      createManagedPreviewOwnerRegistry(resources)
+    )
+  })
+
   it('uses an opaque negative owner scoped to the caller lease', () => {
     const resources = createResources()
     const lifecycle = new ApplicationCallerLeaseRegistry()
@@ -112,6 +134,65 @@ describe('managed preview IPC handlers', () => {
       owners.acquire(caller.lease, { source: 'artifact', path: '/managed/report.pdf' })
     ).resolves.toEqual(resource)
     expect(resources.release).not.toHaveBeenCalled()
+  })
+
+  it('owns acquire, range read, and release behind one caller-lease interface', async () => {
+    const resource = previewResource('owned-resource')
+    const rangeResult = {
+      begin: 0,
+      end: 1,
+      total: 4,
+      data: new Uint8Array([104])
+    }
+    const resources = createResources({
+      acquire: vi.fn().mockResolvedValue(resource),
+      readRange: vi.fn().mockResolvedValue(rangeResult)
+    })
+    const lifecycle = new ApplicationCallerLeaseRegistry()
+    const caller = lifecycle.acquire(createWebCallerContext('preview-client'))
+    const owners = createManagedPreviewOwnerRegistry(resources)
+
+    await expect(
+      owners.acquire(caller.lease, { source: 'artifact', path: '/managed/report.pdf' })
+    ).resolves.toEqual(resource)
+    await expect(
+      owners.readRange(caller.lease, { resourceId: resource.id, begin: 0, end: 1 })
+    ).resolves.toEqual(rangeResult)
+    owners.release(caller.lease, { resourceId: resource.id })
+
+    const ownerId = (resources.acquire as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as number
+    expect(resources.readRange).toHaveBeenCalledWith(ownerId, {
+      resourceId: resource.id,
+      begin: 0,
+      end: 1
+    })
+    expect(resources.release).toHaveBeenCalledWith(ownerId, { resourceId: resource.id })
+  })
+
+  it('applies strict byte admission inside the shared owner for every adapter', async () => {
+    const resource = previewResource('strict-owner-resource')
+    const snapshot = { size: 128, version: 7, dev: 8n, ino: 9n, mtimeNs: 7_000_000n }
+    const resources = createResources({
+      inspect: vi.fn().mockResolvedValue(snapshot),
+      acquire: vi.fn().mockResolvedValue(resource)
+    })
+    const lifecycle = new ApplicationCallerLeaseRegistry()
+    const caller = lifecycle.acquire(createWebCallerContext('preview-client'))
+    const owners = createManagedPreviewOwnerRegistry(resources)
+
+    await owners.acquire(caller.lease, {
+      source: 'artifact',
+      path: '/managed/report.pdf',
+      maxBytes: 1024
+    })
+
+    const request = { source: 'artifact' as const, path: '/managed/report.pdf' }
+    const ownerId = (resources.acquire as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as number
+    expect(resources.inspect).toHaveBeenCalledWith(request)
+    expect(resources.acquire).toHaveBeenCalledWith(ownerId, request, {
+      snapshot,
+      maxBytes: 1024
+    })
   })
 
   it('reuses one preview owner for the same active caller generation', () => {
@@ -260,6 +341,217 @@ describe('managed preview IPC handlers', () => {
     expect(firstOwner).toBeLessThan(0)
     expect(secondOwner).toBeLessThan(0)
     expect(secondOwner).not.toBe(firstOwner)
+  })
+
+  it('uses an explicitly injected owner registry instead of creating adapter-local state', async () => {
+    handlers.clear()
+    const resources = createResources({
+      readRange: vi.fn().mockResolvedValue({ begin: 0, end: 0, total: 1, data: new Uint8Array() })
+    })
+    const register = vi.fn<ManagedPreviewOwnerRegistry['register']>(() => ({
+      ownerId: -37,
+      ownershipKey: 'injected',
+      generation: 1
+    }))
+    const injectedOwners = {
+      acquire: vi.fn<ManagedPreviewOwnerRegistry['acquire']>(),
+      readRange: vi.fn((lease, request) => resources.readRange(register(lease).ownerId, request)),
+      register,
+      release: vi.fn<ManagedPreviewOwnerRegistry['release']>()
+    } satisfies ManagedPreviewOwnerRegistry
+
+    registerManagedPreviewIpcHandlers(resources, injectedOwners)
+    const readHandler = handlers.get('preview-resources:read-range') as (
+      event: unknown,
+      payload: unknown
+    ) => Promise<unknown>
+    await readHandler(createFakeEvent(94).event, { resourceId: 'resource', begin: 0, end: 0 })
+
+    expect(injectedOwners.readRange).toHaveBeenCalledOnce()
+    expect(injectedOwners.register).toHaveBeenCalledOnce()
+    expect(resources.readRange).toHaveBeenCalledWith(-37, {
+      resourceId: 'resource',
+      begin: 0,
+      end: 0
+    })
+  })
+
+  it('binds an explicitly injected owner registry to its resource authority', () => {
+    handlers.clear()
+    const resources = createResources()
+    const injectedOwners = {
+      acquire: vi.fn<ManagedPreviewOwnerRegistry['acquire']>(),
+      readRange: vi.fn<ManagedPreviewOwnerRegistry['readRange']>(),
+      register: vi.fn<ManagedPreviewOwnerRegistry['register']>(),
+      release: vi.fn<ManagedPreviewOwnerRegistry['release']>()
+    } satisfies ManagedPreviewOwnerRegistry
+
+    registerManagedPreviewIpcHandlers(resources, injectedOwners)
+
+    expect(createManagedPreviewOwnerRegistry(resources)).toBe(injectedOwners)
+  })
+
+  it('rejects a conflicting owner registry before registering any handlers', () => {
+    handlers.clear()
+    const resources = createResources()
+    const existingOwners = createManagedPreviewOwnerRegistry(resources)
+    const conflictingOwners = {
+      acquire: vi.fn<ManagedPreviewOwnerRegistry['acquire']>(),
+      readRange: vi.fn<ManagedPreviewOwnerRegistry['readRange']>(),
+      register: vi.fn<ManagedPreviewOwnerRegistry['register']>(),
+      release: vi.fn<ManagedPreviewOwnerRegistry['release']>()
+    } satisfies ManagedPreviewOwnerRegistry
+
+    expect(() => registerManagedPreviewIpcHandlers(resources, conflictingOwners)).toThrow(
+      'Managed preview resources already have a different owner registry.'
+    )
+
+    expect(handlers.size).toBe(0)
+    expect(createManagedPreviewOwnerRegistry(resources)).toBe(existingOwners)
+  })
+
+  it('leaves an authority unbound when explicit IPC registration fails', () => {
+    handlers.clear()
+    const resources = createResources()
+    const injectedOwners = {
+      acquire: vi.fn<ManagedPreviewOwnerRegistry['acquire']>(),
+      readRange: vi.fn<ManagedPreviewOwnerRegistry['readRange']>(),
+      register: vi.fn<ManagedPreviewOwnerRegistry['register']>(),
+      release: vi.fn<ManagedPreviewOwnerRegistry['release']>()
+    } satisfies ManagedPreviewOwnerRegistry
+    testIpc.failingChannel = 'preview-resources:read-range'
+
+    expect(() => registerManagedPreviewIpcHandlers(resources, injectedOwners)).toThrow(
+      'IPC handler registration failed.'
+    )
+
+    expect(createManagedPreviewOwnerRegistry(resources)).not.toBe(injectedOwners)
+  })
+
+  it('allows a fresh owner registry after default IPC registration fails', () => {
+    handlers.clear()
+    const resources = createResources()
+    const retryOwners = {
+      acquire: vi.fn<ManagedPreviewOwnerRegistry['acquire']>(),
+      readRange: vi.fn<ManagedPreviewOwnerRegistry['readRange']>(),
+      register: vi.fn<ManagedPreviewOwnerRegistry['register']>(),
+      release: vi.fn<ManagedPreviewOwnerRegistry['release']>()
+    } satisfies ManagedPreviewOwnerRegistry
+    testIpc.failingChannel = 'preview-resources:read-range'
+
+    expect(() => registerManagedPreviewIpcHandlers(resources)).toThrow(
+      'IPC handler registration failed.'
+    )
+    expect(() => registerManagedPreviewIpcHandlers(resources, retryOwners)).not.toThrow()
+    expect(createManagedPreviewOwnerRegistry(resources)).toBe(retryOwners)
+  })
+
+  it('does not let stale registration cleanup remove a replacement owner registry', () => {
+    handlers.clear()
+    const resources = createResources()
+    const firstCleanup = registerManagedPreviewIpcHandlers(resources)
+    const firstOwners = createManagedPreviewOwnerRegistry(resources)
+    const replacementOwners = {
+      acquire: vi.fn<ManagedPreviewOwnerRegistry['acquire']>(),
+      readRange: vi.fn<ManagedPreviewOwnerRegistry['readRange']>(),
+      register: vi.fn<ManagedPreviewOwnerRegistry['register']>(),
+      release: vi.fn<ManagedPreviewOwnerRegistry['release']>()
+    } satisfies ManagedPreviewOwnerRegistry
+
+    firstCleanup()
+    const replacementCleanup = registerManagedPreviewIpcHandlers(resources, replacementOwners)
+    firstCleanup()
+
+    expect(createManagedPreviewOwnerRegistry(resources)).toBe(replacementOwners)
+    expect(createManagedPreviewOwnerRegistry(resources)).not.toBe(firstOwners)
+    replacementCleanup()
+  })
+
+  it('does not let IPC cleanup remove an owner registry that predated registration', () => {
+    handlers.clear()
+    const resources = createResources()
+    const existingOwners = createManagedPreviewOwnerRegistry(resources)
+
+    const cleanup = registerManagedPreviewIpcHandlers(resources)
+    cleanup()
+
+    expect(createManagedPreviewOwnerRegistry(resources)).toBe(existingOwners)
+  })
+
+  it('releases a newly bound owner when protocol registration fails', () => {
+    handlers.clear()
+    const resources = createResources()
+    const targetProtocol = {
+      handle: vi.fn(() => {
+        throw new Error('Protocol registration failed.')
+      }),
+      unhandle: vi.fn()
+    }
+    const retryOwners = {
+      acquire: vi.fn<ManagedPreviewOwnerRegistry['acquire']>(),
+      readRange: vi.fn<ManagedPreviewOwnerRegistry['readRange']>(),
+      register: vi.fn<ManagedPreviewOwnerRegistry['register']>(),
+      release: vi.fn<ManagedPreviewOwnerRegistry['release']>()
+    } satisfies ManagedPreviewOwnerRegistry
+
+    expect(() => installManagedPreviewElectronAdapter(resources, targetProtocol)).toThrow(
+      'Protocol registration failed.'
+    )
+    expect(() => registerManagedPreviewIpcHandlers(resources, retryOwners)).not.toThrow()
+  })
+
+  it('releases a newly bound owner when protocol teardown fails', () => {
+    handlers.clear()
+    const resources = createResources()
+    const targetProtocol = {
+      handle: vi.fn(),
+      unhandle: vi.fn(() => {
+        throw new Error('Protocol teardown failed.')
+      })
+    }
+    const retryOwners = {
+      acquire: vi.fn<ManagedPreviewOwnerRegistry['acquire']>(),
+      readRange: vi.fn<ManagedPreviewOwnerRegistry['readRange']>(),
+      register: vi.fn<ManagedPreviewOwnerRegistry['register']>(),
+      release: vi.fn<ManagedPreviewOwnerRegistry['release']>()
+    } satisfies ManagedPreviewOwnerRegistry
+    const cleanup = installManagedPreviewElectronAdapter(resources, targetProtocol)
+
+    expect(cleanup).toThrow('Protocol teardown failed.')
+    expect(() => registerManagedPreviewIpcHandlers(resources, retryOwners)).not.toThrow()
+  })
+
+  it('shares owner state between the default legacy path and explicit owner injection', async () => {
+    handlers.clear()
+    const resources = createResources({
+      readRange: vi.fn().mockResolvedValue({ begin: 0, end: 0, total: 1, data: new Uint8Array() })
+    })
+
+    registerManagedPreviewIpcHandlers(resources)
+    await handlers.get('preview-resources:read-range')?.call(undefined, createFakeEvent(95).event, {
+      resourceId: 'first-resource',
+      begin: 0,
+      end: 0
+    })
+
+    const owners = createManagedPreviewOwnerRegistry(resources)
+    registerManagedPreviewIpcHandlers(resources, owners)
+    await handlers.get('preview-resources:read-range')?.call(undefined, createFakeEvent(96).event, {
+      resourceId: 'second-resource',
+      begin: 0,
+      end: 0
+    })
+
+    expect(resources.readRange).toHaveBeenNthCalledWith(1, -1, {
+      resourceId: 'first-resource',
+      begin: 0,
+      end: 0
+    })
+    expect(resources.readRange).toHaveBeenNthCalledWith(2, -2, {
+      resourceId: 'second-resource',
+      begin: 0,
+      end: 0
+    })
   })
 
   it('uses a strict inspected snapshot when acquire specifies a byte limit', async () => {

--- a/src/main/managed-preview-ipc.ts
+++ b/src/main/managed-preview-ipc.ts
@@ -3,6 +3,10 @@ import { type IpcMainInvokeEvent } from 'electron'
 import type { ApplicationCallerLease } from './application-command-router'
 import { callerLeaseForEvent, callerLeaseOwnershipKey } from './caller-lifecycle'
 import { ipcMainHandle } from './ipc-handler-registry'
+import {
+  registerManagedPreviewProtocol,
+  type PreviewProtocolRegistrar
+} from './managed-preview-protocol'
 
 import type {
   AcquireManagedPreviewRequest,
@@ -15,6 +19,9 @@ import type { ManagedPreviewResources } from './managed-preview-resources'
 import type { AcquireManagedPreviewOptions } from './managed-preview-resources'
 
 type ManagedPreviewHandlers = {
+  inspect: (
+    request: AcquireManagedPreviewRequest
+  ) => Promise<AcquireManagedPreviewOptions['snapshot']>
   acquire: (
     ownerId: number,
     request: AcquireManagedPreviewRequest,
@@ -32,14 +39,21 @@ type OwnerTicket = { ownerId: number; ownershipKey: string; generation: number }
 type ManagedPreviewOwnerRegistry = {
   acquire: (
     lease: ApplicationCallerLease,
-    request: AcquireManagedPreviewRequest,
-    prepareOptions?: () => Promise<AcquireManagedPreviewOptions>
+    request: AcquireManagedPreviewRequest
   ) => Promise<ManagedPreviewResource>
+  readRange: (
+    lease: ApplicationCallerLease,
+    request: ReadManagedPreviewRangeRequest
+  ) => Promise<ManagedPreviewRangeResult>
+  release: (lease: ApplicationCallerLease, request: ReleaseManagedPreviewRequest) => void
   register: (lease: ApplicationCallerLease) => OwnerTicket
 }
 
+// All adapters for one resource authority must share owner ids and lease teardown state.
+const ownerRegistries = new WeakMap<ManagedPreviewHandlers, ManagedPreviewOwnerRegistry>()
+
 // Couples every capability to the current surface-owned caller lease.
-const createManagedPreviewOwnerRegistry = (
+const buildManagedPreviewOwnerRegistry = (
   handlers: ManagedPreviewHandlers
 ): ManagedPreviewOwnerRegistry => {
   const active = new Map<string, OwnerTicket>()
@@ -81,19 +95,23 @@ const createManagedPreviewOwnerRegistry = (
 
   const acquire = async (
     lease: ApplicationCallerLease,
-    request: AcquireManagedPreviewRequest,
-    prepareOptions?: () => Promise<AcquireManagedPreviewOptions>
+    request: AcquireManagedPreviewRequest
   ): Promise<ManagedPreviewResource> => {
+    const { maxBytes, ...resourceRequest } = request
+    if (maxBytes !== undefined && (!Number.isSafeInteger(maxBytes) || maxBytes <= 0)) {
+      throw new Error('Invalid managed preview byte limit.')
+    }
+
     const ticket = register(lease)
     let resource: ManagedPreviewResource
-    if (prepareOptions) {
-      const options = await prepareOptions()
+    if (maxBytes !== undefined) {
+      const snapshot = await handlers.inspect(resourceRequest)
       if (!isActive(ticket, lease)) {
         throw new Error('Managed preview owner is no longer available.')
       }
-      resource = await handlers.acquire(ticket.ownerId, request, options)
+      resource = await handlers.acquire(ticket.ownerId, resourceRequest, { snapshot, maxBytes })
     } else {
-      resource = await handlers.acquire(ticket.ownerId, request)
+      resource = await handlers.acquire(ticket.ownerId, resourceRequest)
     }
 
     // Acquisition may finish after renderer teardown; immediately revoke that late capability.
@@ -105,37 +123,82 @@ const createManagedPreviewOwnerRegistry = (
     return resource
   }
 
-  return { acquire, register }
+  const readRange = (
+    lease: ApplicationCallerLease,
+    request: ReadManagedPreviewRangeRequest
+  ): Promise<ManagedPreviewRangeResult> => handlers.readRange(register(lease).ownerId, request)
+
+  const release = (lease: ApplicationCallerLease, request: ReleaseManagedPreviewRequest): void =>
+    handlers.release(register(lease).ownerId, request)
+
+  return { acquire, readRange, register, release }
 }
 
-const registerManagedPreviewIpcHandlers = (resources: ManagedPreviewResources): void => {
-  const owners = createManagedPreviewOwnerRegistry(resources)
+const createManagedPreviewOwnerRegistry = (
+  handlers: ManagedPreviewHandlers
+): ManagedPreviewOwnerRegistry => {
+  const existing = ownerRegistries.get(handlers)
+  if (existing) return existing
+
+  const registry = buildManagedPreviewOwnerRegistry(handlers)
+  ownerRegistries.set(handlers, registry)
+  return registry
+}
+
+const registerManagedPreviewIpcHandlers = (
+  resources: ManagedPreviewResources,
+  injectedOwners?: ManagedPreviewOwnerRegistry
+): (() => void) => {
+  const existingOwners = ownerRegistries.get(resources)
+  if (injectedOwners && existingOwners && existingOwners !== injectedOwners) {
+    throw new Error('Managed preview resources already have a different owner registry.')
+  }
+  const owners = injectedOwners ?? existingOwners ?? buildManagedPreviewOwnerRegistry(resources)
+  const bindsOwners = existingOwners === undefined
+
   const callerLease = (event: IpcMainInvokeEvent): ApplicationCallerLease =>
     callerLeaseForEvent(event)
-  const ownerId = (event: IpcMainInvokeEvent): number => owners.register(callerLease(event)).ownerId
 
-  ipcMainHandle(
-    'preview-resources:acquire',
-    async (event, { maxBytes, ...request }: AcquireManagedPreviewRequest) => {
-      const lease = callerLease(event)
-      if (maxBytes === undefined) return owners.acquire(lease, request)
-      if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
-        throw new Error('Invalid managed preview byte limit.')
-      }
-
-      return owners.acquire(lease, request, async () => ({
-        snapshot: await resources.inspect(request),
-        maxBytes
-      }))
-    }
+  ipcMainHandle('preview-resources:acquire', (event, request: AcquireManagedPreviewRequest) =>
+    owners.acquire(callerLease(event), request)
   )
   ipcMainHandle('preview-resources:read-range', (event, request: ReadManagedPreviewRangeRequest) =>
-    resources.readRange(ownerId(event), request)
+    owners.readRange(callerLease(event), request)
   )
   ipcMainHandle('preview-resources:release', (event, request: ReleaseManagedPreviewRequest) =>
-    resources.release(ownerId(event), request)
+    owners.release(callerLease(event), request)
   )
+  ownerRegistries.set(resources, owners)
+  return () => {
+    if (bindsOwners && ownerRegistries.get(resources) === owners) {
+      ownerRegistries.delete(resources)
+    }
+  }
 }
 
-export { createManagedPreviewOwnerRegistry, registerManagedPreviewIpcHandlers }
-export type { ManagedPreviewHandlers }
+const installManagedPreviewElectronAdapter = (
+  resources: ManagedPreviewResources,
+  targetProtocol?: PreviewProtocolRegistrar
+): (() => void) => {
+  const cleanupOwners = registerManagedPreviewIpcHandlers(resources)
+  try {
+    const unregisterProtocol = registerManagedPreviewProtocol(resources, targetProtocol)
+    return () => {
+      try {
+        unregisterProtocol()
+      } finally {
+        cleanupOwners()
+      }
+    }
+  } catch (error) {
+    cleanupOwners()
+    throw error
+  }
+}
+
+export {
+  createManagedPreviewOwnerRegistry,
+  installManagedPreviewElectronAdapter,
+  registerManagedPreviewIpcHandlers
+}
+export type { ManagedPreviewHandlers, ManagedPreviewOwnerRegistry }


### PR DESCRIPTION
# T2h0b pull request

Title: `refactor(preview): share managed owner`

## Problem

Managed Preview IPC constructs its own owner registry while the staged data command group needs the
same acquire/read/release authority. Independent registries would duplicate caller ownership and
allow lifecycle behavior to diverge during final command composition.

## Proposed change

- Reuse one stable owner registry for the same `ManagedPreviewResources`; isolate different resource
  instances.
- Allow legacy IPC to receive that registry explicitly while keeping its default path on the same
  owner factory.
- Move acquire, strict range admission/read, and release into the shared owner.
- Make the data command group delegate with the exact caller lease rather than recreate ownership.

## Scope and non-goals

- The former no-`ipc.ts` boundary is narrowed only for atomic Managed Preview adapter lifecycle:
  protocol-registration failure and adapter teardown must release a registry binding created by that
  installation. T2h0f still owns final production owner injection and transport composition.
- No transport cutover, command inventory, public wire, data model, UI, or surface capability change.
- Upload ownership and native progress remain separate T2h0a work.

## Acceptance criteria and validation

- Same resources -> same owner; different resources -> isolated owners -> tests passed.
- Successful explicit injection binds the authority cache; conflicting injection fails before any
  handler is registered; registration rollback leaves the cache unbound -> tests passed.
- Failed default registration can retry with a fresh owner; stale cleanup cannot remove a replacement
  or pre-existing shared owner -> tests passed.
- Legacy default/explicit IPC and data commands use exact caller leases -> tests passed.
- Owner retains range admission, generation replacement, abort/navigation/disconnect cleanup,
  release-once, and graceful disposal -> focused regressions passed.
- Managed Preview owner/IPC/protocol/resources behavior, caller lifecycle, and data command consumer ->
  `npm test -- --run src/main/data-content-application-commands.test.ts src/main/managed-preview-ipc.test.ts src/main/managed-preview-protocol.test.ts src/main/managed-preview-resources.test.ts src/main/caller-lifecycle.test.ts`
  -> 5 files / 77 tests passed after the last material edit.
- Node module/interface consumers -> `npm run typecheck:node` -> passed after the last material edit.
- Linted source and formatting -> targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards/Spec review -> 0 actionable findings.
- Data command and caller-lifecycle tests are included because they consume the shared owner and lease
  interfaces. No local platform/E2E lane is included because the change has no platform branch,
  persistence, build, or UI interaction; PR Gate remains authoritative for selected cross-platform
  lanes.

## Review focus

- No second mutable registry may be created for the same resources authority.
- Production raw churn is 175 on `origin/main@be8cee3`, below the 500-line hard stop.

## Uncovered risk

Global construction/disposal order and the live router consumer remain T2h0f responsibilities.
