### PR TITLE
refactor(uploads): add command owner

### DIFF
--- a/src/main/uploads/command-owner.test.ts
+++ b/src/main/uploads/command-owner.test.ts
@@ -1,0 +1,458 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ApplicationInvocation } from '../application-command-router'
+import { createElectronCallerContext } from '../caller-context'
+import { ApplicationCallerLeaseRegistry } from '../caller-lifecycle'
+import type { DataContentApplicationCommandDependencies } from '../data-content-application-commands'
+import {
+  beginMigration,
+  clearMigrationPending,
+  waitForDataRootWriters
+} from '../storage/migration-state'
+import { createUploadCommandOwner } from './command-owner'
+import type { UploadRepository } from './repository'
+
+type TestCaller = Readonly<{
+  context: ReturnType<typeof createElectronCallerContext>
+  ownedLease: ReturnType<ApplicationCallerLeaseRegistry['acquire']>
+}>
+
+const createCaller = (leases: ApplicationCallerLeaseRegistry, id: number): TestCaller => {
+  const context = createElectronCallerContext(id)
+  return { context, ownedLease: leases.acquire(context) }
+}
+
+const invocationFor = <Args extends readonly unknown[]>(
+  caller: TestCaller,
+  args: Args
+): ApplicationInvocation<Args> => ({
+  callerContext: caller.context,
+  callerLease: caller.ownedLease.lease,
+  args
+})
+
+describe('upload command owner', () => {
+  const temporaryRoots: string[] = []
+
+  afterEach(async () => {
+    clearMigrationPending()
+    await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true })))
+  })
+
+  it('keeps one transfer owner across application command calls', async () => {
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'shared-transfer',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      finishTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const firstCaller = createCaller(leases, 1)
+    const secondCaller = createCaller(leases, 2)
+
+    await owner.beginTransfer(
+      invocationFor(firstCaller, [
+        { transferId: 'shared-transfer', name: 'data.csv', size: 10 }
+      ] as const)
+    )
+
+    await expect(
+      owner.finishTransfer(
+        invocationFor(secondCaller, [{ transferId: 'shared-transfer' }] as const)
+      )
+    ).rejects.toThrow(/another renderer/i)
+    await expect(
+      owner.finishTransfer(invocationFor(firstCaller, [{ transferId: 'shared-transfer' }] as const))
+    ).resolves.toBeUndefined()
+    expect(repository.finishTransfer).toHaveBeenCalledOnce()
+  })
+
+  it('reports native staging progress only through the invoking adapter', async () => {
+    const progress = {
+      transferId: 'native-transfer',
+      name: 'data.csv',
+      receivedBytes: 4,
+      totalBytes: 10
+    }
+    const attachment = {
+      id: 'attachment-1',
+      sessionId: '.pending',
+      name: 'data.csv',
+      originalName: 'data.csv',
+      path: '/managed/.pending/data.csv',
+      size: 10
+    }
+    const repository = {
+      stageLocalFile: vi.fn(
+        async (_request: unknown, onProgress: (value: typeof progress) => void) => {
+          onProgress(progress)
+          return attachment
+        }
+      )
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 7)
+    const report = vi.fn()
+
+    await expect(
+      owner.stageLocalFile(
+        invocationFor(caller, [
+          {
+            transferId: 'native-transfer',
+            sourcePath: '/fixtures/data.csv',
+            name: 'data.csv',
+            size: 10
+          }
+        ] as const),
+        { report }
+      )
+    ).resolves.toEqual(attachment)
+    expect(report).toHaveBeenCalledWith(progress)
+
+    owner.claimLocalFile(invocationFor(caller, [{ transferId: 'native-transfer' }] as const))
+  })
+
+  it('rejects an invalid standalone native path before staging', async () => {
+    const repository = { stageLocalFile: vi.fn() } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 8)
+
+    await expect(
+      owner.stageLocalPath(
+        invocationFor(caller, [
+          { transferId: 'invalid-path', sourcePath: 'relative/data.csv', name: 'data.csv' }
+        ] as const)
+      )
+    ).rejects.toThrow('Invalid local path upload request.')
+    expect(repository.stageLocalFile).not.toHaveBeenCalled()
+  })
+
+  it('releases every transfer owned by a caller on adapter navigation cleanup', async () => {
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'navigating-transfer',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 9)
+
+    await owner.beginTransfer(
+      invocationFor(caller, [
+        { transferId: 'navigating-transfer', name: 'data.csv', size: 10 }
+      ] as const)
+    )
+    owner.releaseCaller(caller.ownedLease.lease)
+
+    await vi.waitFor(() => {
+      expect(repository.abortTransfer).toHaveBeenCalledWith({
+        transferId: 'navigating-transfer'
+      })
+    })
+  })
+
+  it('isolates a replacement caller generation from stale lease cleanup', async () => {
+    const repository = {
+      beginTransfer: vi.fn(async (request: { transferId: string; name: string; size: number }) => ({
+        transferId: request.transferId,
+        name: request.name,
+        receivedBytes: 0,
+        totalBytes: request.size
+      })),
+      finishTransfer: vi.fn(async () => undefined),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const staleCaller = createCaller(leases, 16)
+
+    await owner.beginTransfer(
+      invocationFor(staleCaller, [
+        { transferId: 'stale-generation', name: 'old.csv', size: 5 }
+      ] as const)
+    )
+
+    const replacement = createCaller(leases, 16)
+    expect(staleCaller.ownedLease.lease.signal.aborted).toBe(true)
+    await vi.waitFor(() => {
+      expect(repository.abortTransfer).toHaveBeenCalledTimes(1)
+    })
+    expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'stale-generation' })
+
+    await owner.beginTransfer(
+      invocationFor(replacement, [
+        { transferId: 'replacement-generation', name: 'new.csv', size: 7 }
+      ] as const)
+    )
+    staleCaller.ownedLease.release()
+    owner.releaseCaller(staleCaller.ownedLease.lease)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(repository.abortTransfer).not.toHaveBeenCalledWith({
+      transferId: 'replacement-generation'
+    })
+    await expect(
+      owner.finishTransfer(
+        invocationFor(replacement, [{ transferId: 'replacement-generation' }] as const)
+      )
+    ).resolves.toBeUndefined()
+  })
+
+  it('holds the data-root writer across a complete chunk transfer', async () => {
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'leased-transfer',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      finishTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 10)
+
+    await owner.beginTransfer(
+      invocationFor(caller, [
+        { transferId: 'leased-transfer', name: 'data.csv', size: 10 }
+      ] as const)
+    )
+    beginMigration()
+    let drained = false
+    const drain = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    await owner.finishTransfer(invocationFor(caller, [{ transferId: 'leased-transfer' }] as const))
+    await drain
+    expect(drained).toBe(true)
+  })
+
+  it('waits for an in-flight append before caller cleanup aborts the transfer', async () => {
+    let finishAppend: ((status: unknown) => void) | undefined
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'in-flight-transfer',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      appendTransfer: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            finishAppend = resolve
+          })
+      ),
+      abortTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 11)
+
+    await owner.beginTransfer(
+      invocationFor(caller, [
+        { transferId: 'in-flight-transfer', name: 'data.csv', size: 10 }
+      ] as const)
+    )
+    const append = owner.appendTransfer(
+      invocationFor(caller, [
+        {
+          transferId: 'in-flight-transfer',
+          offset: 0,
+          chunk: new Uint8Array(10)
+        }
+      ] as const)
+    )
+    await Promise.resolve()
+    beginMigration()
+    owner.releaseCaller(caller.ownedLease.lease)
+    let drained = false
+    const drain = waitForDataRootWriters().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+    expect(repository.abortTransfer).not.toHaveBeenCalled()
+
+    finishAppend?.({
+      transferId: 'in-flight-transfer',
+      name: 'data.csv',
+      receivedBytes: 10,
+      totalBytes: 10
+    })
+    await append
+    await drain
+    expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'in-flight-transfer' })
+  })
+
+  it('deletes a staged native upload when its caller releases before claim', async () => {
+    const attachment = {
+      id: 'unclaimed-attachment',
+      sessionId: '.pending',
+      name: 'data.csv',
+      originalName: 'data.csv',
+      path: '/managed/.pending/data.csv',
+      size: 10
+    }
+    const repository = {
+      stageLocalFile: vi.fn(async () => attachment),
+      abortTransfer: vi.fn(async () => undefined),
+      deleteUpload: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 12)
+
+    await owner.stageLocalFile(
+      invocationFor(caller, [
+        {
+          transferId: 'unclaimed-transfer',
+          sourcePath: '/fixtures/data.csv',
+          name: 'data.csv',
+          size: 10
+        }
+      ] as const),
+      { report: () => undefined }
+    )
+    owner.releaseCaller(caller.ownedLease.lease)
+
+    await vi.waitFor(() => {
+      expect(repository.deleteUpload).toHaveBeenCalledWith({ path: attachment.path })
+    })
+  })
+
+  it('uses the native file size and releases standalone staging before publication', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upload-owner-'))
+    temporaryRoots.push(root)
+    const sourcePath = join(root, 'notes.txt')
+    await writeFile(sourcePath, 'standalone upload')
+    const attachment = {
+      id: 'standalone-attachment',
+      sessionId: '.pending',
+      name: 'notes.txt',
+      originalName: 'notes.txt',
+      path: '/managed/.pending/notes.txt',
+      size: 17
+    }
+    const repository = {
+      stageLocalFile: vi.fn(async () => attachment),
+      finalizePendingSessionUploads: vi.fn(async () => [attachment])
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 13)
+
+    await expect(
+      owner.stageLocalPath(
+        invocationFor(caller, [
+          {
+            transferId: 'standalone-transfer',
+            sourcePath,
+            name: 'notes.txt',
+            projectId: 'project-1'
+          }
+        ] as const)
+      )
+    ).resolves.toEqual(attachment)
+    expect(repository.stageLocalFile).toHaveBeenCalledWith(
+      expect.objectContaining({ sourcePath, size: 17 }),
+      expect.any(Function)
+    )
+    expect(repository.finalizePendingSessionUploads).toHaveBeenCalledWith(
+      'standalone-uploads',
+      [attachment],
+      'project-1'
+    )
+
+    beginMigration()
+    await waitForDataRootWriters()
+  })
+
+  it('deletes the standalone copy when its durable publication fails', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upload-owner-'))
+    temporaryRoots.push(root)
+    const sourcePath = join(root, 'orphan.txt')
+    await writeFile(sourcePath, 'orphan')
+    const attachment = {
+      id: 'orphan-attachment',
+      sessionId: '.pending',
+      name: 'orphan.txt',
+      originalName: 'orphan.txt',
+      path: '/managed/.pending/orphan.txt',
+      size: 6
+    }
+    const repository = {
+      stageLocalFile: vi.fn(async () => attachment),
+      finalizePendingSessionUploads: vi.fn(async () => {
+        throw new Error('publish failed')
+      }),
+      deleteUpload: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 14)
+
+    await expect(
+      owner.stageLocalPath(
+        invocationFor(caller, [
+          { transferId: 'orphan-transfer', sourcePath, name: 'orphan.txt' }
+        ] as const)
+      )
+    ).rejects.toThrow('publish failed')
+    expect(repository.deleteUpload).toHaveBeenCalledWith({ path: attachment.path })
+  })
+
+  it('finalizes session uploads inside the injected session mutation', async () => {
+    const repository = {
+      finalizePendingSessionUploads: vi.fn(async () => [])
+    } as unknown as UploadRepository
+    const order: string[] = []
+    const mutationScopes: Array<{ projectId: string; sessionId: string }> = []
+    const withSessionMutation = async <Result>(
+      projectId: string,
+      sessionId: string,
+      mutation: () => Promise<Result>
+    ): Promise<Result> => {
+      mutationScopes.push({ projectId, sessionId })
+      order.push('lock')
+      const result = await mutation()
+      order.push('unlock')
+      return result
+    }
+    const owner = createUploadCommandOwner(repository, { withSessionMutation })
+    const leases = new ApplicationCallerLeaseRegistry()
+    const caller = createCaller(leases, 15)
+
+    await owner.finalizeSession(
+      invocationFor(caller, [
+        { projectId: 'project-1', sessionId: 'session-1', attachments: [] }
+      ] as const)
+    )
+
+    expect(mutationScopes).toEqual([{ projectId: 'project-1', sessionId: 'session-1' }])
+    expect(order).toEqual(['lock', 'unlock'])
+  })
+
+  it('exposes the exact staged data-command owner interface', () => {
+    const owner = createUploadCommandOwner({} as UploadRepository)
+    const stagedOwner: DataContentApplicationCommandDependencies['uploads'] = owner
+
+    expect(stagedOwner).toBe(owner)
+  })
+})

--- a/src/main/uploads/command-owner.ts
+++ b/src/main/uploads/command-owner.ts
@@ -1,0 +1,399 @@
+import { stat } from 'node:fs/promises'
+
+import type { ApplicationCallerLease, ApplicationInvocation } from '../application-command-router'
+import { acquireDataRootWriter, withDataRootWrite } from '../storage/migration-state'
+
+import type { ArtifactPreviewResult, ReadArtifactPreviewRequest } from '../../shared/artifacts'
+import type {
+  AppendUploadTransferRequest,
+  BeginUploadTransferRequest,
+  DeleteUploadRequest,
+  FinalizeUploadSessionRequest,
+  StageLocalPathUploadRequest,
+  StageLocalUploadRequest,
+  UploadTransferRequest,
+  UploadTransferProgress,
+  UploadTransferStatus
+} from '../../shared/uploads'
+import {
+  DEFAULT_UPLOAD_PROJECT_NAME,
+  STANDALONE_UPLOAD_SESSION_ID,
+  type UploadedAttachment
+} from '../../shared/uploads'
+import { validateLocalPath } from '../../shared/local-fs'
+import type { UploadRepository } from './repository'
+
+type UploadCaller = {
+  transferIds: Set<string>
+  release: () => void
+}
+
+type ChunkWriter = {
+  owner: UploadCaller
+  release: () => void
+  ready: Promise<UploadTransferStatus>
+  cancelled: boolean
+  settling: boolean
+  inFlight: Set<Promise<unknown>>
+  cleanup?: Promise<void>
+}
+
+type LocalWriter = {
+  owner: UploadCaller
+  release: () => void
+  cancelled: boolean
+  ready?: Promise<UploadedAttachment>
+  attachment?: UploadedAttachment
+  cleanup?: Promise<void>
+}
+
+type UploadProgressTarget = Readonly<{
+  report: (progress: UploadTransferProgress) => void
+}>
+
+type UploadCommandOwnerOptions = Readonly<{
+  withSessionMutation?: <Result>(
+    projectId: string,
+    sessionId: string,
+    mutation: () => Promise<Result>
+  ) => Promise<Result>
+}>
+
+type UploadCommandOwner = Readonly<{
+  releaseCaller(lease: ApplicationCallerLease): void
+  stageLocalFile(
+    invocation: ApplicationInvocation<readonly [StageLocalUploadRequest]>,
+    progressTarget: UploadProgressTarget
+  ): Promise<UploadedAttachment>
+  claimLocalFile(invocation: ApplicationInvocation<readonly [UploadTransferRequest]>): void
+  stageLocalPath(
+    invocation: ApplicationInvocation<readonly [StageLocalPathUploadRequest]>
+  ): Promise<UploadedAttachment>
+  beginTransfer(
+    invocation: ApplicationInvocation<readonly [BeginUploadTransferRequest]>
+  ): Promise<UploadTransferStatus>
+  appendTransfer(
+    invocation: ApplicationInvocation<readonly [AppendUploadTransferRequest]>
+  ): Promise<UploadTransferStatus>
+  transferStatus(
+    invocation: ApplicationInvocation<readonly [UploadTransferRequest]>
+  ): Promise<UploadTransferStatus | null>
+  finishTransfer(
+    invocation: ApplicationInvocation<readonly [UploadTransferRequest]>
+  ): Promise<Awaited<ReturnType<UploadRepository['finishTransfer']>>>
+  abortTransfer(invocation: ApplicationInvocation<readonly [UploadTransferRequest]>): Promise<void>
+  deleteUpload(invocation: ApplicationInvocation<readonly [DeleteUploadRequest]>): Promise<void>
+  finalizeSession(
+    invocation: ApplicationInvocation<readonly [FinalizeUploadSessionRequest]>
+  ): Promise<UploadedAttachment[]>
+  readPreview(
+    invocation: ApplicationInvocation<readonly [ReadArtifactPreviewRequest]>
+  ): Promise<ArtifactPreviewResult>
+}>
+
+// T2h0a1 deliberately has no live transport consumer. T2h0a2 replaces the legacy IPC closure
+// atomically and injects this same owner into both IPC and staged application commands.
+const createUploadCommandOwner = (
+  repository: UploadRepository,
+  options: UploadCommandOwnerOptions = {}
+): UploadCommandOwner => {
+  const callers = new WeakMap<ApplicationCallerLease, UploadCaller>()
+  const chunkWriters = new Map<string, ChunkWriter>()
+  const localWriters = new Map<string, LocalWriter>()
+
+  const releaseChunkWriter = (transferId: string, writer: ChunkWriter): void => {
+    if (chunkWriters.get(transferId) !== writer) return
+    chunkWriters.delete(transferId)
+    writer.owner.transferIds.delete(transferId)
+    writer.release()
+  }
+  const abortChunkWriter = (transferId: string, writer: ChunkWriter): Promise<void> => {
+    if (writer.cleanup) return writer.cleanup
+
+    writer.cancelled = true
+    writer.cleanup = (async () => {
+      try {
+        await writer.ready.catch(() => undefined)
+        await Promise.allSettled([...writer.inFlight])
+        await repository.abortTransfer({ transferId }).catch(() => undefined)
+      } finally {
+        releaseChunkWriter(transferId, writer)
+      }
+    })()
+    return writer.cleanup
+  }
+  const releaseLocalWriter = (transferId: string, writer: LocalWriter): void => {
+    if (localWriters.get(transferId) !== writer) return
+    localWriters.delete(transferId)
+    writer.owner.transferIds.delete(transferId)
+    writer.release()
+  }
+  const abortLocalWriter = (transferId: string, writer: LocalWriter): Promise<void> => {
+    if (writer.cleanup) return writer.cleanup
+
+    writer.cancelled = true
+    writer.cleanup = (async () => {
+      try {
+        await repository.abortTransfer({ transferId }).catch(() => undefined)
+        const attachment = writer.attachment ?? (await writer.ready?.catch(() => undefined))
+        if (attachment) {
+          await repository.deleteUpload({ path: attachment.path }).catch(() => undefined)
+        }
+      } finally {
+        releaseLocalWriter(transferId, writer)
+      }
+    })()
+    return writer.cleanup
+  }
+  const registerCaller = (lease: ApplicationCallerLease): UploadCaller => {
+    const existing = callers.get(lease)
+    if (existing) return existing
+    if (lease.signal.aborted || !lease.isCurrent()) {
+      throw new Error('Upload renderer is no longer available.')
+    }
+
+    function release(): void {
+      if (callers.get(lease) !== caller) return
+      callers.delete(lease)
+      lease.signal.removeEventListener('abort', release)
+      for (const transferId of [...caller.transferIds]) {
+        const writer = chunkWriters.get(transferId)
+        if (writer?.owner === caller && !writer.settling) {
+          void abortChunkWriter(transferId, writer)
+        }
+        const localWriter = localWriters.get(transferId)
+        if (localWriter?.owner === caller) void abortLocalWriter(transferId, localWriter)
+      }
+    }
+    const caller: UploadCaller = { transferIds: new Set(), release }
+    callers.set(lease, caller)
+    lease.signal.addEventListener('abort', release, { once: true })
+    if (lease.signal.aborted || !lease.isCurrent()) {
+      release()
+      throw new Error('Upload renderer is no longer available.')
+    }
+    return caller
+  }
+  const getOwnedChunkWriter = (
+    lease: ApplicationCallerLease,
+    transferId: string
+  ): ChunkWriter | undefined => {
+    const owner = registerCaller(lease)
+    const writer = chunkWriters.get(transferId)
+    if (writer && writer.owner !== owner) {
+      throw new Error(`Upload transfer belongs to another renderer: ${transferId}`)
+    }
+    return writer
+  }
+  const getOwnedLocalWriter = (
+    lease: ApplicationCallerLease,
+    transferId: string
+  ): LocalWriter | undefined => {
+    const owner = registerCaller(lease)
+    const writer = localWriters.get(transferId)
+    if (writer && writer.owner !== owner) {
+      throw new Error(`Upload transfer belongs to another renderer: ${transferId}`)
+    }
+    return writer
+  }
+  const runLocalStaging = async (
+    invocation: ApplicationInvocation<readonly [StageLocalUploadRequest]>,
+    progressTarget: UploadProgressTarget,
+    releaseOnCommit: boolean
+  ): Promise<UploadedAttachment> => {
+    const {
+      callerLease,
+      args: [request]
+    } = invocation
+    const owner = registerCaller(callerLease)
+    const existing = localWriters.get(request.transferId) ?? chunkWriters.get(request.transferId)
+    if (existing) {
+      if (existing.owner !== owner) {
+        throw new Error(`Upload transfer belongs to another renderer: ${request.transferId}`)
+      }
+      throw new Error(`Upload transfer already exists: ${request.transferId}`)
+    }
+
+    const writer: LocalWriter = {
+      owner,
+      release: acquireDataRootWriter(),
+      cancelled: false
+    }
+    localWriters.set(request.transferId, writer)
+    owner.transferIds.add(request.transferId)
+    try {
+      writer.ready = repository.stageLocalFile(request, (progress) => {
+        if (!writer.cancelled) progressTarget.report(progress)
+      })
+      const attachment = await writer.ready
+      writer.attachment = attachment
+      if (writer.cancelled) {
+        await writer.cleanup
+        throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+      }
+      if (releaseOnCommit) releaseLocalWriter(request.transferId, writer)
+      return attachment
+    } catch (error) {
+      if (writer.cancelled) await writer.cleanup
+      else releaseLocalWriter(request.transferId, writer)
+      throw error
+    }
+  }
+
+  return Object.freeze({
+    releaseCaller: (lease) => callers.get(lease)?.release(),
+    stageLocalFile: (invocation, progressTarget) =>
+      runLocalStaging(invocation, progressTarget, false),
+    claimLocalFile: ({ callerLease, args: [request] }) => {
+      const writer = getOwnedLocalWriter(callerLease, request.transferId)
+      if (!writer) return
+      if (!writer.attachment) {
+        throw new Error(`Upload transfer is not ready to claim: ${request.transferId}`)
+      }
+      if (writer.cancelled) {
+        throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+      }
+      releaseLocalWriter(request.transferId, writer)
+    },
+    stageLocalPath: async (invocation) => {
+      const request = invocation.args[0]
+      if (
+        typeof request !== 'object' ||
+        request === null ||
+        typeof request.transferId !== 'string' ||
+        typeof request.name !== 'string' ||
+        typeof request.sourcePath !== 'string' ||
+        validateLocalPath(request.sourcePath, process.platform) !== undefined
+      ) {
+        throw new Error('Invalid local path upload request.')
+      }
+      const sourceInfo = await stat(request.sourcePath)
+      const attachment = await runLocalStaging(
+        { ...invocation, args: [{ ...request, size: sourceInfo.size }] },
+        { report: () => undefined },
+        true
+      )
+      const projectId = request.projectId ?? DEFAULT_UPLOAD_PROJECT_NAME
+      try {
+        await withDataRootWrite(() =>
+          repository.finalizePendingSessionUploads(
+            STANDALONE_UPLOAD_SESSION_ID,
+            [attachment],
+            projectId
+          )
+        )
+      } catch (error) {
+        await repository.deleteUpload({ path: attachment.path }).catch(() => undefined)
+        throw error
+      }
+      return attachment
+    },
+    beginTransfer: async ({ callerLease, args: [request] }) => {
+      const owner = registerCaller(callerLease)
+      const localWriter = localWriters.get(request.transferId)
+      if (localWriter) {
+        if (localWriter.owner !== owner) {
+          throw new Error(`Upload transfer belongs to another renderer: ${request.transferId}`)
+        }
+        throw new Error(`Upload transfer already exists: ${request.transferId}`)
+      }
+      const existing = chunkWriters.get(request.transferId)
+      if (existing) {
+        if (existing.owner !== owner) {
+          throw new Error(`Upload transfer belongs to another renderer: ${request.transferId}`)
+        }
+        await existing.ready
+        return repository.beginTransfer(request)
+      }
+
+      const writer: ChunkWriter = {
+        owner,
+        release: acquireDataRootWriter(),
+        ready: repository.beginTransfer(request),
+        cancelled: false,
+        settling: false,
+        inFlight: new Set()
+      }
+      chunkWriters.set(request.transferId, writer)
+      owner.transferIds.add(request.transferId)
+      try {
+        const status = await writer.ready
+        if (writer.cancelled) {
+          await writer.cleanup
+          throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+        }
+        return status
+      } catch (error) {
+        releaseChunkWriter(request.transferId, writer)
+        throw error
+      }
+    },
+    appendTransfer: async ({ callerLease, args: [request] }) => {
+      const writer = getOwnedChunkWriter(callerLease, request.transferId)
+      if (!writer) return withDataRootWrite(() => repository.appendTransfer(request))
+
+      await writer.ready
+      if (writer.cancelled) {
+        throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+      }
+      const operation = repository.appendTransfer(request)
+      writer.inFlight.add(operation)
+      try {
+        return await operation
+      } finally {
+        writer.inFlight.delete(operation)
+      }
+    },
+    transferStatus: ({ callerLease, args: [request] }) => {
+      getOwnedChunkWriter(callerLease, request.transferId)
+      return repository.getTransferStatus(request)
+    },
+    finishTransfer: async ({ callerLease, args: [request] }) => {
+      const writer = getOwnedChunkWriter(callerLease, request.transferId)
+      if (!writer) return withDataRootWrite(() => repository.finishTransfer(request))
+
+      try {
+        await writer.ready
+        if (writer.cancelled) {
+          await writer.cleanup
+          throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
+        }
+        writer.settling = true
+        await Promise.allSettled([...writer.inFlight])
+        return await repository.finishTransfer(request)
+      } catch (error) {
+        await repository.abortTransfer(request).catch(() => undefined)
+        throw error
+      } finally {
+        releaseChunkWriter(request.transferId, writer)
+      }
+    },
+    abortTransfer: async ({ callerLease, args: [request] }) => {
+      const localWriter = getOwnedLocalWriter(callerLease, request.transferId)
+      if (localWriter) return abortLocalWriter(request.transferId, localWriter)
+
+      const writer = getOwnedChunkWriter(callerLease, request.transferId)
+      if (!writer) return withDataRootWrite(() => repository.abortTransfer(request))
+
+      await abortChunkWriter(request.transferId, writer)
+    },
+    deleteUpload: ({ args: [request] }) =>
+      withDataRootWrite(() => repository.deleteUpload(request)),
+    finalizeSession: ({ args: [request] }) =>
+      withDataRootWrite(() => {
+        const finalize = (): Promise<UploadedAttachment[]> =>
+          repository.finalizePendingSessionUploads(
+            request.sessionId,
+            request.attachments,
+            request.projectId
+          )
+        return options.withSessionMutation && request.projectId
+          ? options.withSessionMutation(request.projectId, request.sessionId, finalize)
+          : finalize()
+      }),
+    readPreview: ({ args: [request] }) => repository.readManagedUploadPreview(request)
+  })
+}
+
+export { createUploadCommandOwner }
+export type { UploadCommandOwner }


### PR DESCRIPTION
# T2h0a1 pull request

Title: `refactor(uploads): add command owner`

## Problem

Upload transfer/writer/caller state is trapped inside one legacy IPC registration closure. Moving the
closure and transport adapter together measures at least 838 raw production changed lines, beyond the
500-line hard stop. The stateful owner must be established first as a reviewable seam.

## Proposed change

- Add one transport-neutral Upload command owner for per-caller ownership, chunk/local writer maps,
  data-root writer leases, transfer transitions, session mutation, and cleanup.
- Preserve generation replacement, real AbortSignal cancellation, stale-release/ABA fencing, caller
  isolation, append draining, unclaimed local cleanup, and standalone failure cleanup.
- Expose only the ten staged data-command methods plus `stageLocalFile` and `releaseCaller` required by
  the follow-up legacy Electron adapter.

## Scope and non-goals

- This is a compile-time preparatory owner and deliberately has no production call site. T2h0a2 is
  the only PR allowed to replace the live IPC closure; partial wiring here would create two owners.
- No Electron/IpcMain/WebContents types enter the owner.
- No legacy IPC, global composition, transport, public wire, data model, UI, or capability change.

## Acceptance criteria and validation

- Exact transfer/write ownership and transition behavior -> direct owner tests -> passed.
- Real lease AbortSignal replacement and stale cleanup do not affect the new generation -> ABA tracer
  test -> passed.
- Writer drain/release, caller isolation, local cleanup, mutation and failure paths -> focused tests ->
  2 files / 35 tests passed.
- `npm run typecheck:node`, targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards/Spec review -> 0 actionable findings.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- The module must own one state graph and expose no speculative API.
- Production raw churn is 399, below the 500-line hard stop.

## Uncovered risk

T2h0a2 still owns deletion of the legacy closure, Electron progress/navigation adaptation, and live
single-owner certification. T2h0f later composes the application router.
