### PR TITLE
refactor(permission): share projection owner

### DIFF
--- a/src/main/permission-grants/application-commands.test.ts
+++ b/src/main/permission-grants/application-commands.test.ts
@@ -11,9 +11,9 @@ import { createWebCallerContext } from '../caller-context'
 import {
   permissionGrantApplicationCommandGroup,
   permissionGrantApplicationCommands,
-  registerPermissionGrantApplicationCommands,
-  type PermissionGrantCommandOwner
+  registerPermissionGrantApplicationCommands
 } from './application-commands'
+import type { PermissionGrantProjection } from './projection-controller'
 
 const snapshot: PermissionGrantSnapshot = {
   version: 4,
@@ -22,7 +22,7 @@ const snapshot: PermissionGrantSnapshot = {
   counts: { all: 0, global: 0, project: 0, session: 0 }
 }
 
-const createOwner = (): PermissionGrantCommandOwner => ({
+const createOwner = (): PermissionGrantProjection => ({
   list: vi.fn(async () => snapshot),
   revoke: vi.fn(async () => ({ ...snapshot, receipt: undefined, conflicts: [] })),
   extendUndo: vi.fn(async () => ({ undoToken: 'undo-1', expiresAt: 10, revokedCount: 1 })),

--- a/src/main/permission-grants/application-commands.ts
+++ b/src/main/permission-grants/application-commands.ts
@@ -12,19 +12,11 @@ import {
   type ApplicationCommandInstallation,
   type ApplicationCommandRegistrar
 } from '../application-command-router'
+import type { PermissionGrantProjection } from './projection-controller'
 
 // Composition injects one projection owner. Command registration deliberately does not subscribe,
 // publish permissions:changed, or dispose the owner, so Electron and application adapters cannot
 // create competing revision controllers.
-type PermissionGrantCommandOwner = Readonly<{
-  list(): Promise<PermissionGrantSnapshot>
-  revoke(request: PermissionGrantRevokeRequest): Promise<PermissionGrantMutationView>
-  extendUndo(
-    request: PermissionGrantUndoExtendRequest
-  ): Promise<PermissionGrantUndoReceipt | undefined>
-  restore(request: PermissionGrantRestoreRequest): Promise<PermissionGrantMutationView>
-}>
-
 const permissionGrantApplicationCommands = Object.freeze({
   list: defineApplicationCommand<'permissions:list', readonly [], PermissionGrantSnapshot>(
     'permissions:list'
@@ -55,7 +47,7 @@ const permissionGrantApplicationCommandGroup = defineApplicationCommandGroup('pe
 
 const registerPermissionGrantApplicationCommands = (
   registrar: ApplicationCommandRegistrar,
-  owner: PermissionGrantCommandOwner
+  owner: PermissionGrantProjection
 ): ApplicationCommandInstallation => {
   const scope = registrar.createScope()
   try {
@@ -77,4 +69,3 @@ export {
   permissionGrantApplicationCommands,
   registerPermissionGrantApplicationCommands
 }
-export type { PermissionGrantCommandOwner }

--- a/src/main/permission-grants/ipc.test.ts
+++ b/src/main/permission-grants/ipc.test.ts
@@ -1,23 +1,130 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { handlers } = vi.hoisted(() => ({
-  handlers: new Map<string, (...args: unknown[]) => unknown>()
+const { handlers, registrationFailure } = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  registrationFailure: {
+    channel: undefined as string | undefined,
+    error: undefined as Error | undefined
+  }
 }))
 
 vi.mock('electron', () => ({
   ipcMain: {
-    handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+      if (registrationFailure.channel === channel) {
+        throw registrationFailure.error ?? new Error('registration failed')
+      }
       handlers.set(channel, handler)
+    }
   }
 }))
 
 import type { PermissionGrantRegistry } from './registry'
+import {
+  createApplicationCommandRouter,
+  type ApplicationCallerLease,
+  type ApplicationInvocation
+} from '../application-command-router'
+import { createWebCallerContext } from '../caller-context'
 import { webRpc } from '../ipc-handler-registry'
-import { registerPermissionGrantIpcHandlers } from './ipc'
+import {
+  permissionGrantApplicationCommands,
+  registerPermissionGrantApplicationCommands
+} from './application-commands'
+import { registerPermissionGrantIpcAdapter, registerPermissionGrantIpcHandlers } from './ipc'
+import { createPermissionGrantProjectionController } from './projection-controller'
 
-beforeEach(() => handlers.clear())
+const invocation = <Args extends readonly unknown[]>(args: Args): ApplicationInvocation<Args> => {
+  const callerContext = createWebCallerContext('remote-web', { location: 'remote' })
+  const callerLease: ApplicationCallerLease = Object.freeze({
+    leaseId: callerContext.leaseId,
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  })
+  return Object.freeze({ args, callerContext, callerLease })
+}
+
+beforeEach(() => {
+  handlers.clear()
+  registrationFailure.channel = undefined
+  registrationFailure.error = undefined
+})
 
 describe('permission grant IPC', () => {
+  it('shares one application-owned projection between IPC and application commands', async () => {
+    const registry = {
+      list: vi.fn().mockResolvedValue([]),
+      subscribe: vi.fn(() => vi.fn())
+    } as unknown as PermissionGrantRegistry
+    const owner = createPermissionGrantProjectionController({
+      registry,
+      projects: { list: vi.fn().mockResolvedValue([]) },
+      sessions: { metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }) },
+      publishChanged: vi.fn()
+    })
+    registerPermissionGrantIpcAdapter(owner)
+    const router = createApplicationCommandRouter()
+    registerPermissionGrantApplicationCommands(router.registrar, owner)
+
+    await expect(handlers.get('permissions:list')?.(undefined)).resolves.toMatchObject({
+      version: 0
+    })
+    await expect(
+      router.dispatcher.invoke(permissionGrantApplicationCommands.list, invocation([]))
+    ).resolves.toMatchObject({ version: 0 })
+    expect(registry.subscribe).toHaveBeenCalledOnce()
+  })
+
+  it('releases the compatibility owner when IPC registration fails', () => {
+    const unsubscribe = vi.fn()
+    const registry = {
+      subscribe: vi.fn(() => unsubscribe)
+    } as unknown as PermissionGrantRegistry
+    registrationFailure.channel = 'permissions:restore'
+
+    expect(() =>
+      registerPermissionGrantIpcHandlers({
+        registry,
+        projects: { list: vi.fn().mockResolvedValue([]) },
+        sessions: {
+          metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true })
+        },
+        broadcast: vi.fn()
+      })
+    ).toThrow('registration failed')
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('retains registration and disposal failures when rollback also fails', () => {
+    const registrationError = new Error('registration failed')
+    const disposalError = new Error('unsubscribe failed')
+    const registry = {
+      subscribe: vi.fn(() => () => {
+        throw disposalError
+      })
+    } as unknown as PermissionGrantRegistry
+    registrationFailure.channel = 'permissions:restore'
+    registrationFailure.error = registrationError
+    let thrown: unknown
+
+    try {
+      registerPermissionGrantIpcHandlers({
+        registry,
+        projects: { list: vi.fn().mockResolvedValue([]) },
+        sessions: {
+          metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true })
+        },
+        broadcast: vi.fn()
+      })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError)
+    expect((thrown as AggregateError).errors).toEqual([registrationError, disposalError])
+  })
+
   it('projects Session-scoped grants from cached metadata without loading Session storage', async () => {
     const loadAll = vi.fn().mockRejectedValue(new Error('full Session load must not run'))
     const metadataSnapshot = vi.fn().mockResolvedValue({

--- a/src/main/permission-grants/ipc.ts
+++ b/src/main/permission-grants/ipc.ts
@@ -1,157 +1,72 @@
 import type {
-  PermissionGrantMutationView,
-  PermissionGrantMutationResult,
   PermissionGrantRestoreRequest,
   PermissionGrantRevokeRequest,
-  PermissionGrantSnapshot,
   PermissionGrantUndoExtendRequest,
-  PermissionGrantUndoReceipt,
   PermissionGrantsChangedEvent
 } from '../../shared/permission-grants'
-import type { Project } from '../../shared/projects'
 import { ipcMainHandle } from '../ipc-handler-registry'
 import { broadcastToRenderers } from '../renderer-broadcast'
-import type { SessionMetadataSnapshot } from '../session-persistence/coordinator'
 import {
-  projectPermissionGrantMutation,
-  projectPermissionGrantSnapshot,
-  type ConnectorPolicySnapshot
-} from './catalog'
-import type { PermissionGrantRegistry } from './registry'
+  createPermissionGrantProjectionController,
+  type PermissionGrantProjection,
+  type PermissionGrantProjectionController,
+  type PermissionGrantProjectionControllerOptions
+} from './projection-controller'
 
-type PermissionGrantIpcOptions = {
-  registry: PermissionGrantRegistry
-  projects: { list(): Promise<Project[]> }
-  sessions: { metadataSnapshot(): Promise<SessionMetadataSnapshot> }
-  connectors?: { get(): Promise<ConnectorPolicySnapshot | undefined> }
+type PermissionGrantIpcOptions = Omit<
+  PermissionGrantProjectionControllerOptions,
+  'publishChanged'
+> & {
   broadcast?: (channel: string, payload: PermissionGrantsChangedEvent) => void
 }
 
-type PermissionGrantIpcController = {
-  dispose(): void
-  invalidateProjection(): void
+type PermissionGrantIpcController = Pick<
+  PermissionGrantProjectionController,
+  'dispose' | 'invalidateProjection'
+>
+
+// This adapter owns only Electron/Web handler registration. Supplying the projection keeps its
+// Registry subscription and revision lifetime application-owned and shareable with command routing.
+const registerPermissionGrantIpcAdapter = (owner: PermissionGrantProjection): void => {
+  ipcMainHandle('permissions:list', () => owner.list())
+  ipcMainHandle('permissions:revoke', (_event, request: PermissionGrantRevokeRequest) =>
+    owner.revoke(request)
+  )
+  ipcMainHandle('permissions:extend-undo', (_event, request: PermissionGrantUndoExtendRequest) =>
+    owner.extendUndo(request)
+  )
+  ipcMainHandle('permissions:restore', (_event, request: PermissionGrantRestoreRequest) =>
+    owner.restore(request)
+  )
 }
 
-const validateRevokeRequest = (request: PermissionGrantRevokeRequest): void => {
-  if (!request || !Array.isArray(request.grants) || request.grants.length === 0) {
-    throw new Error('Select at least one permission grant to revoke.')
-  }
-  if (request.grants.length > 1_000) throw new Error('Too many permission grants selected.')
-  for (const grant of request.grants) {
-    if (!grant.id?.trim() || !Number.isSafeInteger(grant.revision) || grant.revision < 1) {
-      throw new Error('Invalid permission grant revision.')
-    }
-  }
-}
-
-const validateRestoreRequest = (request: PermissionGrantRestoreRequest): void => {
-  if (!request?.undoToken?.trim()) throw new Error('Permission Undo token is required.')
-}
-
+// Compatibility composition for the current Electron runtime. The application composition can
+// construct the same owner directly and call registerPermissionGrantIpcAdapter during transport
+// cutover without changing any channel or projection semantics.
 const registerPermissionGrantIpcHandlers = (
   options: PermissionGrantIpcOptions
 ): PermissionGrantIpcController => {
-  const names = async (): Promise<{
-    projects: Map<string, string>
-    sessions: Map<string, string>
-    connectorPolicy?: ConnectorPolicySnapshot
-    incompleteStores: PermissionGrantSnapshot['incompleteStores']
-  }> => {
-    const [projectsResult, sessionsResult, connectorPolicyResult] = await Promise.allSettled([
-      options.projects.list(),
-      Promise.resolve().then(() => options.sessions.metadataSnapshot()),
-      options.connectors?.get()
-    ])
-    const projects = projectsResult.status === 'fulfilled' ? projectsResult.value : []
-    const sessions: SessionMetadataSnapshot =
-      sessionsResult.status === 'fulfilled'
-        ? sessionsResult.value
-        : { sessions: [], isComplete: false }
-    const connectorPolicy =
-      connectorPolicyResult.status === 'fulfilled' ? connectorPolicyResult.value : undefined
-    const incompleteStores: PermissionGrantSnapshot['incompleteStores'] = []
-    if (projectsResult.status === 'rejected') incompleteStores.push('projects')
-    if (sessionsResult.status === 'rejected' || !sessions.isComplete) {
-      incompleteStores.push('sessions')
+  const { broadcast: broadcastOverride, ...projectionOptions } = options
+  const broadcast = broadcastOverride ?? broadcastToRenderers
+  const owner = createPermissionGrantProjectionController({
+    ...projectionOptions,
+    publishChanged: (payload) => broadcast('permissions:changed', payload)
+  })
+  try {
+    registerPermissionGrantIpcAdapter(owner)
+    return owner
+  } catch (error) {
+    try {
+      owner.dispose()
+    } catch (disposeError) {
+      throw new AggregateError(
+        [error, disposeError],
+        'Permission Grant IPC registration and owner disposal failed.'
+      )
     }
-    if (connectorPolicyResult.status === 'rejected') incompleteStores.push('connector_policy')
-    return {
-      projects: new Map(projects.map((project): [string, string] => [project.id, project.name])),
-      sessions: new Map(
-        sessions.sessions.map((session): [string, string] => [session.id, session.title])
-      ),
-      incompleteStores,
-      ...(connectorPolicy ? { connectorPolicy } : {})
-    }
+    throw error
   }
-
-  let version = 0
-  const snapshot = async (): Promise<PermissionGrantSnapshot> => {
-    for (;;) {
-      const snapshotVersion = version
-      const metadata = await names()
-      const records = await options.registry.list()
-      if (snapshotVersion !== version) continue
-      return projectPermissionGrantSnapshot(records, metadata, {
-        version: snapshotVersion,
-        incompleteStores: metadata.incompleteStores
-      })
-    }
-  }
-  const mutationSnapshot = async (
-    result: PermissionGrantMutationResult
-  ): Promise<PermissionGrantMutationView> => {
-    for (;;) {
-      const snapshotVersion = version
-      const metadata = await names()
-      result.grants = await options.registry.list()
-      if (snapshotVersion !== version) continue
-      return projectPermissionGrantMutation(result, metadata, {
-        version: snapshotVersion,
-        incompleteStores: metadata.incompleteStores
-      })
-    }
-  }
-
-  ipcMainHandle('permissions:list', snapshot)
-  ipcMainHandle(
-    'permissions:revoke',
-    async (_event, request: PermissionGrantRevokeRequest): Promise<PermissionGrantMutationView> => {
-      validateRevokeRequest(request)
-      const result = await options.registry.revoke(request)
-      return mutationSnapshot(result)
-    }
-  )
-  ipcMainHandle(
-    'permissions:extend-undo',
-    async (
-      _event,
-      request: PermissionGrantUndoExtendRequest
-    ): Promise<PermissionGrantUndoReceipt | undefined> => {
-      validateRestoreRequest(request)
-      return options.registry.extendUndo(request)
-    }
-  )
-  ipcMainHandle(
-    'permissions:restore',
-    async (
-      _event,
-      request: PermissionGrantRestoreRequest
-    ): Promise<PermissionGrantMutationView> => {
-      validateRestoreRequest(request)
-      const result = await options.registry.restore(request)
-      return mutationSnapshot(result)
-    }
-  )
-
-  const broadcast = options.broadcast ?? broadcastToRenderers
-  const invalidateProjection = (): void => {
-    version += 1
-    broadcast('permissions:changed', { revision: version })
-  }
-  const dispose = options.registry.subscribe(invalidateProjection)
-  return { dispose, invalidateProjection }
 }
 
-export { registerPermissionGrantIpcHandlers }
+export { registerPermissionGrantIpcAdapter, registerPermissionGrantIpcHandlers }
 export type { PermissionGrantIpcController, PermissionGrantIpcOptions }

--- a/src/main/permission-grants/projection-controller.test.ts
+++ b/src/main/permission-grants/projection-controller.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PermissionGrantRegistry } from './registry'
+import { createPermissionGrantProjectionController } from './projection-controller'
+
+describe('Permission Grant projection controller', () => {
+  it('owns one Registry subscription and versions projections before publishing changes', async () => {
+    let registryChanged: (() => void) | undefined
+    const registry = {
+      list: vi.fn().mockResolvedValue([
+        {
+          id: 'grant-1',
+          revision: 1,
+          capability: { kind: 'file_operation', key: 'file:read' },
+          scope: { kind: 'global' }
+        }
+      ]),
+      subscribe: vi.fn((listener: () => void) => {
+        registryChanged = listener
+        return vi.fn()
+      })
+    } as unknown as PermissionGrantRegistry
+    const publishChanged = vi.fn()
+    const controller = createPermissionGrantProjectionController({
+      registry,
+      projects: { list: vi.fn().mockResolvedValue([]) },
+      sessions: { metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }) },
+      publishChanged
+    })
+
+    expect(registry.subscribe).toHaveBeenCalledOnce()
+    await expect(controller.list()).resolves.toMatchObject({ version: 0, counts: { all: 1 } })
+
+    registryChanged?.()
+
+    expect(publishChanged).toHaveBeenCalledWith({ revision: 1 })
+    await expect(controller.list()).resolves.toMatchObject({ version: 1, counts: { all: 1 } })
+  })
+
+  it('restarts projection when metadata is invalidated during an in-flight read', async () => {
+    let registryChanged: (() => void) | undefined
+    let resolveFirstProjects: ((projects: Array<{ id: string; name: string }>) => void) | undefined
+    const firstProjects = new Promise<Array<{ id: string; name: string }>>((resolve) => {
+      resolveFirstProjects = resolve
+    })
+    const projects = {
+      list: vi
+        .fn()
+        .mockImplementationOnce(() => firstProjects)
+        .mockResolvedValue([{ id: 'project-1', name: 'Current project' }])
+    }
+    const registry = {
+      list: vi.fn().mockResolvedValue([
+        {
+          id: 'grant-1',
+          revision: 1,
+          capability: { kind: 'file_operation', key: 'file:read' },
+          scope: { kind: 'project', projectId: 'project-1' }
+        }
+      ]),
+      subscribe: vi.fn((listener: () => void) => {
+        registryChanged = listener
+        return vi.fn()
+      })
+    } as unknown as PermissionGrantRegistry
+    const controller = createPermissionGrantProjectionController({
+      registry,
+      projects,
+      sessions: { metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }) },
+      publishChanged: vi.fn()
+    })
+
+    const projection = controller.list()
+    registryChanged?.()
+    resolveFirstProjects?.([{ id: 'project-1', name: 'Stale project' }])
+
+    await expect(projection).resolves.toMatchObject({
+      version: 1,
+      grants: [{ scopeLabel: 'Project: Current project' }]
+    })
+    expect(projects.list).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns a refreshed mutation projection at the Registry change revision', async () => {
+    let registryChanged: (() => void) | undefined
+    const revoke = vi.fn(async () => {
+      registryChanged?.()
+      return {
+        grants: [],
+        conflicts: [],
+        receipt: { undoToken: 'undo-1', expiresAt: 10, revokedCount: 1 }
+      }
+    })
+    const registry = {
+      list: vi.fn().mockResolvedValue([]),
+      revoke,
+      subscribe: vi.fn((listener: () => void) => {
+        registryChanged = listener
+        return vi.fn()
+      })
+    } as unknown as PermissionGrantRegistry
+    const publishChanged = vi.fn()
+    const controller = createPermissionGrantProjectionController({
+      registry,
+      projects: { list: vi.fn().mockResolvedValue([]) },
+      sessions: { metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }) },
+      publishChanged
+    })
+    const request = { grants: [{ id: 'grant-1', revision: 2 }] }
+
+    await expect(controller.revoke(request)).resolves.toMatchObject({
+      version: 1,
+      receipt: { undoToken: 'undo-1' },
+      conflicts: []
+    })
+    expect(revoke).toHaveBeenCalledWith(request)
+    expect(publishChanged).toHaveBeenCalledWith({ revision: 1 })
+  })
+
+  it('rejects an empty revoke before calling the Registry', async () => {
+    const revoke = vi.fn()
+    const controller = createPermissionGrantProjectionController({
+      registry: {
+        revoke,
+        subscribe: vi.fn(() => vi.fn())
+      } as unknown as PermissionGrantRegistry,
+      projects: { list: vi.fn().mockResolvedValue([]) },
+      sessions: { metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }) },
+      publishChanged: vi.fn()
+    })
+
+    await expect(controller.revoke({ grants: [] })).rejects.toThrow(
+      'Select at least one permission grant to revoke.'
+    )
+    expect(revoke).not.toHaveBeenCalled()
+  })
+
+  it('extends a valid Undo receipt through the shared owner', async () => {
+    const receipt = { undoToken: 'undo-1', expiresAt: 10, revokedCount: 1 }
+    const extendUndo = vi.fn().mockResolvedValue(receipt)
+    const controller = createPermissionGrantProjectionController({
+      registry: {
+        extendUndo,
+        subscribe: vi.fn(() => vi.fn())
+      } as unknown as PermissionGrantRegistry,
+      projects: { list: vi.fn().mockResolvedValue([]) },
+      sessions: { metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }) },
+      publishChanged: vi.fn()
+    })
+
+    await expect(controller.extendUndo({ undoToken: 'undo-1' })).resolves.toBe(receipt)
+    expect(extendUndo).toHaveBeenCalledWith({ undoToken: 'undo-1' })
+  })
+
+  it.each(['extendUndo', 'restore'] as const)(
+    'keeps Undo token validation inside %s',
+    async (method) => {
+      const operation = vi.fn()
+      const controller = createPermissionGrantProjectionController({
+        registry: {
+          [method]: operation,
+          subscribe: vi.fn(() => vi.fn())
+        } as unknown as PermissionGrantRegistry,
+        projects: { list: vi.fn().mockResolvedValue([]) },
+        sessions: {
+          metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true })
+        },
+        publishChanged: vi.fn()
+      })
+
+      await expect(controller[method]({ undoToken: ' ' })).rejects.toThrow(
+        'Permission Undo token is required.'
+      )
+      expect(operation).not.toHaveBeenCalled()
+    }
+  )
+
+  it('restores through the shared owner and returns the current projection', async () => {
+    let registryChanged: (() => void) | undefined
+    const restore = vi.fn(async () => {
+      registryChanged?.()
+      return { grants: [], conflicts: [] }
+    })
+    const controller = createPermissionGrantProjectionController({
+      registry: {
+        list: vi.fn().mockResolvedValue([]),
+        restore,
+        subscribe: vi.fn((listener: () => void) => {
+          registryChanged = listener
+          return vi.fn()
+        })
+      } as unknown as PermissionGrantRegistry,
+      projects: { list: vi.fn().mockResolvedValue([]) },
+      sessions: { metadataSnapshot: vi.fn().mockResolvedValue({ sessions: [], isComplete: true }) },
+      publishChanged: vi.fn()
+    })
+
+    await expect(controller.restore({ undoToken: 'undo-1' })).resolves.toMatchObject({
+      version: 1,
+      conflicts: []
+    })
+    expect(restore).toHaveBeenCalledWith({ undoToken: 'undo-1' })
+  })
+})

--- a/src/main/permission-grants/projection-controller.ts
+++ b/src/main/permission-grants/projection-controller.ts
@@ -1,0 +1,154 @@
+import type {
+  PermissionGrantMutationResult,
+  PermissionGrantMutationView,
+  PermissionGrantRestoreRequest,
+  PermissionGrantRevokeRequest,
+  PermissionGrantSnapshot,
+  PermissionGrantUndoExtendRequest,
+  PermissionGrantUndoReceipt,
+  PermissionGrantsChangedEvent
+} from '../../shared/permission-grants'
+import type { Project } from '../../shared/projects'
+import type { SessionMetadataSnapshot } from '../session-persistence/coordinator'
+import {
+  projectPermissionGrantMutation,
+  projectPermissionGrantSnapshot,
+  type ConnectorPolicySnapshot
+} from './catalog'
+import type { PermissionGrantRegistry } from './registry'
+
+type PermissionGrantProjectionControllerOptions = {
+  registry: PermissionGrantRegistry
+  projects: { list(): Promise<Project[]> }
+  sessions: { metadataSnapshot(): Promise<SessionMetadataSnapshot> }
+  connectors?: { get(): Promise<ConnectorPolicySnapshot | undefined> }
+  publishChanged: (event: PermissionGrantsChangedEvent) => void
+}
+
+type PermissionGrantProjection = Readonly<{
+  list(): Promise<PermissionGrantSnapshot>
+  revoke(request: PermissionGrantRevokeRequest): Promise<PermissionGrantMutationView>
+  extendUndo(
+    request: PermissionGrantUndoExtendRequest
+  ): Promise<PermissionGrantUndoReceipt | undefined>
+  restore(request: PermissionGrantRestoreRequest): Promise<PermissionGrantMutationView>
+}>
+
+type PermissionGrantProjectionController = PermissionGrantProjection & {
+  invalidateProjection(): void
+  dispose(): void
+}
+
+const validateRevokeRequest = (request: PermissionGrantRevokeRequest): void => {
+  if (!request || !Array.isArray(request.grants) || request.grants.length === 0) {
+    throw new Error('Select at least one permission grant to revoke.')
+  }
+  if (request.grants.length > 1_000) throw new Error('Too many permission grants selected.')
+  for (const grant of request.grants) {
+    if (!grant.id?.trim() || !Number.isSafeInteger(grant.revision) || grant.revision < 1) {
+      throw new Error('Invalid permission grant revision.')
+    }
+  }
+}
+
+const validateRestoreRequest = (request: PermissionGrantRestoreRequest): void => {
+  if (!request?.undoToken?.trim()) throw new Error('Permission Undo token is required.')
+}
+
+const createPermissionGrantProjectionController = (
+  options: PermissionGrantProjectionControllerOptions
+): PermissionGrantProjectionController => {
+  const names = async (): Promise<{
+    projects: Map<string, string>
+    sessions: Map<string, string>
+    connectorPolicy?: ConnectorPolicySnapshot
+    incompleteStores: PermissionGrantSnapshot['incompleteStores']
+  }> => {
+    const [projectsResult, sessionsResult, connectorPolicyResult] = await Promise.allSettled([
+      options.projects.list(),
+      Promise.resolve().then(() => options.sessions.metadataSnapshot()),
+      options.connectors?.get()
+    ])
+    const projects = projectsResult.status === 'fulfilled' ? projectsResult.value : []
+    const sessions: SessionMetadataSnapshot =
+      sessionsResult.status === 'fulfilled'
+        ? sessionsResult.value
+        : { sessions: [], isComplete: false }
+    const connectorPolicy =
+      connectorPolicyResult.status === 'fulfilled' ? connectorPolicyResult.value : undefined
+    const incompleteStores: PermissionGrantSnapshot['incompleteStores'] = []
+    if (projectsResult.status === 'rejected') incompleteStores.push('projects')
+    if (sessionsResult.status === 'rejected' || !sessions.isComplete) {
+      incompleteStores.push('sessions')
+    }
+    if (connectorPolicyResult.status === 'rejected') incompleteStores.push('connector_policy')
+    return {
+      projects: new Map(projects.map((project): [string, string] => [project.id, project.name])),
+      sessions: new Map(
+        sessions.sessions.map((session): [string, string] => [session.id, session.title])
+      ),
+      incompleteStores,
+      ...(connectorPolicy ? { connectorPolicy } : {})
+    }
+  }
+
+  let version = 0
+  const list = async (): Promise<PermissionGrantSnapshot> => {
+    for (;;) {
+      const snapshotVersion = version
+      const metadata = await names()
+      const records = await options.registry.list()
+      if (snapshotVersion !== version) continue
+      return projectPermissionGrantSnapshot(records, metadata, {
+        version: snapshotVersion,
+        incompleteStores: metadata.incompleteStores
+      })
+    }
+  }
+  const mutationSnapshot = async (
+    result: PermissionGrantMutationResult
+  ): Promise<PermissionGrantMutationView> => {
+    for (;;) {
+      const snapshotVersion = version
+      const metadata = await names()
+      result.grants = await options.registry.list()
+      if (snapshotVersion !== version) continue
+      return projectPermissionGrantMutation(result, metadata, {
+        version: snapshotVersion,
+        incompleteStores: metadata.incompleteStores
+      })
+    }
+  }
+  const revoke = async (
+    request: PermissionGrantRevokeRequest
+  ): Promise<PermissionGrantMutationView> => {
+    validateRevokeRequest(request)
+    return mutationSnapshot(await options.registry.revoke(request))
+  }
+  const extendUndo = async (
+    request: PermissionGrantUndoExtendRequest
+  ): Promise<PermissionGrantUndoReceipt | undefined> => {
+    validateRestoreRequest(request)
+    return options.registry.extendUndo(request)
+  }
+  const restore = async (
+    request: PermissionGrantRestoreRequest
+  ): Promise<PermissionGrantMutationView> => {
+    validateRestoreRequest(request)
+    return mutationSnapshot(await options.registry.restore(request))
+  }
+  const invalidateProjection = (): void => {
+    version += 1
+    options.publishChanged({ revision: version })
+  }
+  const dispose = options.registry.subscribe(invalidateProjection)
+
+  return { list, revoke, extendUndo, restore, invalidateProjection, dispose }
+}
+
+export { createPermissionGrantProjectionController }
+export type {
+  PermissionGrantProjection,
+  PermissionGrantProjectionController,
+  PermissionGrantProjectionControllerOptions
+}


### PR DESCRIPTION
# T2h0e pull request

Title: `refactor(permission): share projection owner`

## Problem

Permission projection methods, revision state, and the registry subscription are owned inside legacy
IPC registration. Final application command composition cannot reuse that authority without either
duplicating revisions/subscriptions or first extracting one lifecycle owner.

## Proposed change

- Add one application-owned Permission projection controller for snapshot/profile/metadata/restore,
  validation, revision retries, invalidation, and registry subscription.
- Make legacy IPC a compatibility adapter over that controller; expose a pure adapter for the four
  staged Permission commands to share the same instance.
- Dispose the controller on IPC registration rollback. If registration and unsubscribe both fail,
  preserve both errors in ordered `AggregateError([registrationError, disposeError])` form.

## Scope and non-goals

- No global `ipc.ts` composition edit or transport cutover; T2h0f injects the shared controller.
- No public method/event, profile semantics, persisted data, UI, or authorization change.
- Electron/Web versus Task/CLI Permission capability asymmetry remains unchanged.
- PR #675 command-group capability/profile behavior is preserved on the rebased baseline.

## Acceptance criteria and validation

- One controller owns the only subscription/revision authority -> direct controller/adapter tests ->
  passed.
- Legacy IPC request/event shapes and ordering remain unchanged -> IPC regressions -> passed.
- Registration rollback unsubscribes; dual registration/dispose failures retain both ordered errors ->
  failure-path tests -> passed.
- Command authority, scope liveness, reconciliation, profile and surface behavior -> focused suite ->
  12 files / 114 tests passed before rebase.
- Post-PR-#675 rebase: projection/IPC/commands/capability -> 4 files / 186 tests passed.
- `npm run typecheck:node`, targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards/Spec review -> 0 actionable findings on the fixed/rebased head.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- Legacy and application adapters must never own separate revision/subscription state.
- Adapter failure must not leak a subscription or hide the original registration error.
- Production raw churn is 348, below the 500-line hard stop.

## Uncovered risk

Global construction/disposal order and live router injection remain T2h0f responsibilities.
