### PR TITLE
refactor(host): share command owners

### DIFF
--- a/src/main/cli-install/ipc.test.ts
+++ b/src/main/cli-install/ipc.test.ts
@@ -30,7 +30,7 @@ vi.mock('../logger', () => ({
 
 vi.mock('./launcher', () => launcher)
 
-import { registerCliInstallIpcHandlers } from './ipc'
+import { registerCliInstallIpcHandlers, type CliCommandOwner } from './ipc'
 
 const INSTALLED = { installed: true, target: '/home/u/.local/bin/open-science', onPath: true }
 
@@ -41,6 +41,20 @@ beforeEach(() => {
 })
 
 describe('registerCliInstallIpcHandlers', () => {
+  it('delegates every channel to one injected command owner', async () => {
+    handlers.clear()
+    const owner: CliCommandOwner = {
+      getStatus: vi.fn().mockResolvedValue(INSTALLED),
+      install: vi.fn().mockResolvedValue(INSTALLED),
+      uninstall: vi.fn().mockResolvedValue({ ...INSTALLED, installed: false })
+    }
+
+    expect(registerCliInstallIpcHandlers(owner)).toBe(owner)
+    await expect(handlers.get('cli:get-status')?.()).resolves.toBe(INSTALLED)
+    await expect(handlers.get('cli:install')?.()).resolves.toBe(INSTALLED)
+    await expect(handlers.get('cli:uninstall')?.()).resolves.toMatchObject({ installed: false })
+  })
+
   it('registers the three cli channels', () => {
     expect([...handlers.keys()].sort()).toEqual(['cli:get-status', 'cli:install', 'cli:uninstall'])
   })

--- a/src/main/cli-install/ipc.ts
+++ b/src/main/cli-install/ipc.ts
@@ -16,6 +16,12 @@ import {
 
 const logger = createLogger('cli-install')
 
+type CliCommandOwner = Readonly<{
+  getStatus: () => Promise<CliLauncherStatus>
+  install: () => Promise<CliLauncherStatus>
+  uninstall: () => Promise<CliLauncherStatus>
+}>
+
 // Resolves the launcher environment from Electron at call time. Packaged builds ship the CLI under
 // resources/cli (see electron-builder.yml extraResources); in dev it lives in the repo's cli/ dir.
 const resolveEnv = (): CliLauncherEnv => ({
@@ -30,31 +36,37 @@ const resolveEnv = (): CliLauncherEnv => ({
   pathVar: process.env.PATH ?? ''
 })
 
-// Registers the renderer-callable command-line-tool commands (Settings -> General). Read is safe; the
-// install/uninstall handlers write only the user's own shim and (on Windows) their own PATH entry, so
-// they never need elevation. Every handler is guarded so a failure surfaces as a message, not a raw
-// rejection.
-const registerCliInstallIpcHandlers = (): void => {
-  ipcMainHandle('cli:get-status', async (): Promise<CliLauncherStatus> => {
+const createCliCommandOwner = (): CliCommandOwner => ({
+  getStatus: async (): Promise<CliLauncherStatus> => {
     try {
       return await getCliLauncherStatus(resolveEnv())
     } catch (error) {
       logger.error('cli get-status failed', error)
       return { installed: false, target: '', onPath: false }
     }
-  })
-
-  ipcMainHandle('cli:install', async (): Promise<CliLauncherStatus> => {
+  },
+  install: async (): Promise<CliLauncherStatus> => {
     const status = await installCliLauncher(resolveEnv())
     logger.info('installed cli launcher', { target: status.target, onPath: status.onPath })
     return status
-  })
-
-  ipcMainHandle('cli:uninstall', async (): Promise<CliLauncherStatus> => {
+  },
+  uninstall: async (): Promise<CliLauncherStatus> => {
     const status = await uninstallCliLauncher(resolveEnv())
     logger.info('uninstalled cli launcher', { target: status.target })
     return status
-  })
+  }
+})
+
+// Registers the renderer-callable command-line-tool commands (Settings -> General). The same owner
+// can be injected into Host commands without changing launcher error/result behavior.
+const registerCliInstallIpcHandlers = (
+  owner: CliCommandOwner = createCliCommandOwner()
+): CliCommandOwner => {
+  ipcMainHandle('cli:get-status', () => owner.getStatus())
+  ipcMainHandle('cli:install', () => owner.install())
+  ipcMainHandle('cli:uninstall', () => owner.uninstall())
+  return owner
 }
 
-export { registerCliInstallIpcHandlers }
+export type { CliCommandOwner }
+export { registerCliInstallIpcHandlers, createCliCommandOwner }

--- a/src/main/github-ipc.test.ts
+++ b/src/main/github-ipc.test.ts
@@ -12,6 +12,7 @@ vi.mock('electron', () => ({
 }))
 
 const { registerGithubIpcHandlers } = await import('./github-ipc')
+type GithubCommandOwner = import('./github-ipc').GithubCommandOwner
 
 const invoke = (channel: string): unknown => handlers.get(channel)!(undefined, undefined)
 
@@ -19,6 +20,14 @@ const jsonResponse = (body: unknown, ok = true): Response =>
   ({ ok, json: () => Promise.resolve(body) }) as unknown as Response
 
 describe('github IPC handler', () => {
+  it('delegates to an injected owner instance', async () => {
+    handlers.clear()
+    const owner: GithubCommandOwner = { getStars: vi.fn().mockResolvedValue(99) }
+
+    expect(registerGithubIpcHandlers({}, owner)).toBe(owner)
+    await expect(invoke('github:get-stars')).resolves.toBe(99)
+  })
+
   it('registers the get-stars channel', () => {
     handlers.clear()
     registerGithubIpcHandlers({ fetch: vi.fn() })

--- a/src/main/github-ipc.ts
+++ b/src/main/github-ipc.ts
@@ -3,6 +3,7 @@ import { ipcMainHandle } from './ipc-handler-registry'
 import { APP } from '../shared/app-config'
 
 type FetchFn = typeof fetch
+type GithubCommandOwner = Readonly<{ getStars: () => Promise<number | null> }>
 
 // Reads the repository star count. GitHub requires a User-Agent on API requests; anonymous requests
 // are rate-limited (60/hour/IP), so the result is cached for the app session and concurrent callers
@@ -26,26 +27,36 @@ const fetchStars = async (fetchFn: FetchFn): Promise<number | null> => {
   }
 }
 
-// The cache lives in this closure. In production register runs once, so the count is fetched at most
-// once per session; a failed attempt is not cached, so a later mount may retry.
-const registerGithubIpcHandlers = (deps: { fetch?: FetchFn } = {}): void => {
+// The cache lives in this owner. A failed attempt is not cached, so a later call may retry.
+const createGithubCommandOwner = (deps: { fetch?: FetchFn } = {}): GithubCommandOwner => {
   const fetchFn = deps.fetch ?? fetch
   let cachedStars: number | null = null
   let inFlight: Promise<number | null> | null = null
 
-  ipcMainHandle('github:get-stars', (): Promise<number | null> => {
-    if (cachedStars !== null) return Promise.resolve(cachedStars)
+  return {
+    getStars: (): Promise<number | null> => {
+      if (cachedStars !== null) return Promise.resolve(cachedStars)
 
-    if (!inFlight) {
-      inFlight = fetchStars(fetchFn).then((count) => {
-        if (count !== null) cachedStars = count
-        inFlight = null
-        return count
-      })
+      if (!inFlight) {
+        inFlight = fetchStars(fetchFn).then((count) => {
+          if (count !== null) cachedStars = count
+          inFlight = null
+          return count
+        })
+      }
+
+      return inFlight
     }
-
-    return inFlight
-  })
+  }
 }
 
-export { registerGithubIpcHandlers }
+const registerGithubIpcHandlers = (
+  deps: { fetch?: FetchFn } = {},
+  owner: GithubCommandOwner = createGithubCommandOwner(deps)
+): GithubCommandOwner => {
+  ipcMainHandle('github:get-stars', () => owner.getStars())
+  return owner
+}
+
+export type { GithubCommandOwner }
+export { registerGithubIpcHandlers, createGithubCommandOwner }

--- a/src/main/host-application-commands.ts
+++ b/src/main/host-application-commands.ts
@@ -32,7 +32,10 @@ import {
   type ApplicationCommandRegistrar
 } from './application-command-router'
 import type { CallerContext } from './caller-context'
+import type { CliCommandOwner } from './cli-install/ipc'
+import type { GithubCommandOwner } from './github-ipc'
 import type { LocalFsService } from './local-fs/service'
+import type { LogsCommandOwner } from './logs-ipc'
 import {
   canManagePairing,
   isDesktopCaller,
@@ -40,6 +43,8 @@ import {
   requirePairingManager
 } from './remote-access/ipc'
 import type { RemoteAccessService } from './remote-access/service'
+import type { ReviewerCommandOwner } from './reviewer/ipc'
+import type { UpdateCommandOwner } from './update/ipc'
 
 type StorageParentRequest = Readonly<{ parent: string }>
 type StorageRootRequest = Readonly<{ parent: string; markOnboarding?: boolean }>
@@ -252,21 +257,13 @@ const hostApplicationCommandGroups = Object.freeze([
 ] as const)
 
 type HostApplicationCommandDependencies = Readonly<{
-  cli: Readonly<{
-    getStatus: () => Promise<CliLauncherStatus>
-    install: () => Promise<CliLauncherStatus>
-    uninstall: () => Promise<CliLauncherStatus>
-  }>
-  github: Readonly<{ getStars: () => Promise<number | null> }>
+  cli: CliCommandOwner
+  github: GithubCommandOwner
   localFs: Pick<
     LocalFsService,
     'getRoots' | 'listDir' | 'openPath' | 'readPreview' | 'revealInFolder'
   >
-  logs: Readonly<{
-    getPath: () => string | null
-    openFile: () => Promise<OpenLogFileResult>
-    revealInFolder: () => RevealLogFileResult
-  }>
+  logs: LogsCommandOwner
   notifications: Readonly<{
     peekPendingOpenSession: () => OpenSessionFromNotificationRequest | null
     takePendingOpenSession: (expectedToken: number) => OpenSessionFromNotificationRequest | null
@@ -275,11 +272,7 @@ type HostApplicationCommandDependencies = Readonly<{
     RemoteAccessService,
     'snapshot' | 'detect' | 'setMode' | 'disable' | 'approve' | 'reject' | 'revoke'
   >
-  reviewer: Readonly<{
-    run: (request: ReviewRunRequest) => Promise<ReviewRunResult>
-    getForSession: (request: ReviewSessionRequest) => Promise<ReviewWithChecks[]>
-    abortFixLoop: (request: ReviewSessionRequest) => void
-  }>
+  reviewer: Pick<ReviewerCommandOwner, 'run' | 'getForSession' | 'abortFixLoop'>
   storage: Readonly<{
     getInfo: () => Promise<StorageInfo>
     revealAppStorage: () => Promise<RevealAppStorageResult>
@@ -294,14 +287,7 @@ type HostApplicationCommandDependencies = Readonly<{
     discardMigratedCopy: (request: StorageParentRequest) => Promise<void>
     dismissLegacyMovePrompt: () => Promise<void>
   }>
-  update: Readonly<{
-    getAppInfo: () => AppInfo
-    getStatus: () => UpdateStatus
-    check: () => Promise<UpdateStatus>
-    download: () => Promise<UpdateStatus>
-    cancel: () => Promise<UpdateStatus>
-    apply: () => Promise<UpdateStatus>
-  }>
+  update: UpdateCommandOwner
 }>
 
 const localCommand = <Result>(

--- a/src/main/logs-ipc.test.ts
+++ b/src/main/logs-ipc.test.ts
@@ -26,6 +26,7 @@ vi.mock('./logger', () => ({
 }))
 
 const { registerLogsIpcHandlers } = await import('./logs-ipc')
+type LogsCommandOwner = import('./logs-ipc').LogsCommandOwner
 
 const invoke = (channel: string): unknown => handlers.get(channel)!(undefined, undefined)
 
@@ -35,6 +36,19 @@ describe('logs IPC handlers', () => {
     openPath.mockClear()
     showItemInFolder.mockClear()
     logPath.value = '/logs/main.log'
+  })
+
+  it('delegates every channel to one injected command owner', async () => {
+    const owner: LogsCommandOwner = {
+      getPath: vi.fn(() => '/injected/main.log'),
+      openFile: vi.fn().mockResolvedValue({ opened: true }),
+      revealInFolder: vi.fn(() => ({ revealed: true }))
+    }
+
+    expect(registerLogsIpcHandlers(owner)).toBe(owner)
+    expect(invoke('logs:get-path')).toBe('/injected/main.log')
+    await expect(invoke('logs:open-file')).resolves.toEqual({ opened: true })
+    expect(invoke('logs:reveal-in-folder')).toEqual({ revealed: true })
   })
 
   it('registers the diagnostics channels', () => {

--- a/src/main/logs-ipc.ts
+++ b/src/main/logs-ipc.ts
@@ -5,13 +5,15 @@ import { ipcMainHandle } from './ipc-handler-registry'
 import { getLogFilePath } from './logger'
 import type { OpenLogFileResult, RevealLogFileResult } from '../shared/logs'
 
-// Renderer-callable diagnostics surface. Logs live only on this device and are never transmitted; the
-// renderer can read the file path (to show it), open the file, or reveal it in its folder (to grab and
-// attach when reporting a bug). "Open" targets the log file itself; "reveal" selects it in the folder.
-const registerLogsIpcHandlers = (): void => {
-  ipcMainHandle('logs:get-path', () => getLogFilePath() ?? null)
+type LogsCommandOwner = Readonly<{
+  getPath: () => string | null
+  openFile: () => Promise<OpenLogFileResult>
+  revealInFolder: () => RevealLogFileResult
+}>
 
-  ipcMainHandle('logs:open-file', async (): Promise<OpenLogFileResult> => {
+const createLogsCommandOwner = (): LogsCommandOwner => ({
+  getPath: () => getLogFilePath() ?? null,
+  openFile: async (): Promise<OpenLogFileResult> => {
     const path = getLogFilePath()
 
     if (!path) return { opened: false, error: 'No log file is available yet.' }
@@ -20,9 +22,8 @@ const registerLogsIpcHandlers = (): void => {
     const error = await shell.openPath(path)
 
     return error ? { opened: false, error } : { opened: true }
-  })
-
-  ipcMainHandle('logs:reveal-in-folder', (): RevealLogFileResult => {
+  },
+  revealInFolder: (): RevealLogFileResult => {
     const path = getLogFilePath()
 
     if (!path) return { revealed: false, error: 'No log file is available yet.' }
@@ -31,7 +32,19 @@ const registerLogsIpcHandlers = (): void => {
     shell.showItemInFolder(path)
 
     return { revealed: true }
-  })
+  }
+})
+
+// Renderer-callable diagnostics surface. Local-only Host gates remain in the Host router; this
+// adapter only shares the same injectable command owner with Electron IPC.
+const registerLogsIpcHandlers = (
+  owner: LogsCommandOwner = createLogsCommandOwner()
+): LogsCommandOwner => {
+  ipcMainHandle('logs:get-path', () => owner.getPath())
+  ipcMainHandle('logs:open-file', () => owner.openFile())
+  ipcMainHandle('logs:reveal-in-folder', () => owner.revealInFolder())
+  return owner
 }
 
-export { registerLogsIpcHandlers }
+export type { LogsCommandOwner }
+export { registerLogsIpcHandlers, createLogsCommandOwner }

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -89,7 +89,7 @@ vi.mock('./stale-reviews', () => ({
     (flagStaleReviews as unknown as (...a: unknown[]) => unknown)(...args)
 }))
 
-const { registerReviewerIpcHandlers } = await import('./ipc')
+const { createReviewerCommandOwner, registerReviewerIpcHandlers } = await import('./ipc')
 const { beginMigration, clearMigrationPending } = await import('../storage/migration-state')
 
 const acpRuntime = {} as AcpRuntime
@@ -124,6 +124,31 @@ beforeEach(() => {
 afterEach(() => clearMigrationPending())
 
 describe('reviewer IPC handlers', () => {
+  it('shares one in-flight arbitration owner between direct and IPC commands', async () => {
+    let finishRun: (() => void) | undefined
+    let backgroundRun: Promise<void> | undefined
+    runReview.mockImplementation((options?: { onStarted?: () => void }) => {
+      backgroundRun = new Promise<void>((resolve) => {
+        options?.onStarted?.()
+        finishRun = resolve
+      })
+      return backgroundRun
+    })
+    const options = { acpRuntime }
+    const owner = createReviewerCommandOwner(options)
+    registerReviewerIpcHandlers(options, owner)
+
+    await expect(owner.run(createRequest())).resolves.toEqual({ started: true })
+    await expect(handlers.get(REVIEWER_IPC.RUN)?.({}, createRequest())).resolves.toEqual({
+      started: false,
+      reason: 'already-in-flight'
+    })
+    expect(runReview).toHaveBeenCalledTimes(1)
+
+    finishRun?.()
+    await backgroundRun
+  })
+
   it('runs reviews with artifacts rooted at the data root, not the config root', async () => {
     registerReviewerIpcHandlers({ acpRuntime })
 

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -87,13 +87,16 @@ type ReviewerIpcOptions = {
   ) => Promise<Result>
 }
 
-// Registers the reviewer IPC handlers on the Electron main process. Returns a function that can
-// be called directly to trigger a review (e.g., from the finishRun hook path).
-const registerReviewerIpcHandlers = (
-  options: ReviewerIpcOptions
-): {
+type ReviewerCommandOwner = Readonly<{
+  run: (request: ReviewRunRequest) => Promise<ReviewRunResult>
   triggerReview: (request: ReviewRunRequest) => Promise<ReviewRunResult>
-} => {
+  getForSession: (request: ReviewSessionRequest) => Promise<ReviewWithChecks[]>
+  abortFixLoop: (request: ReviewSessionRequest) => void
+}>
+
+// Owns reviewer arbitration and fix-loop cancellation independently from any command transport.
+// The triggerReview alias preserves the existing direct-call result returned by IPC registration.
+const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerCommandOwner => {
   const storageRoot = options.storageRoot ?? resolveStorageRoot()
   const dataRoot = options.dataRoot ?? resolveDataRoot()
   const reviewRepository = createDefaultReviewRepository(storageRoot, dataRoot)
@@ -115,14 +118,10 @@ const registerReviewerIpcHandlers = (
   // The renderer also disables its button, but this is the authoritative guard.
   const inFlightReviewKeys = new Set<string>()
 
-  // reviewer:run — trigger a review for a completed turn. Fire-and-forget: the renderer does
-  // not await this; it receives reviewer:updated events as the lifecycle progresses.
-  ipcMainHandle(REVIEWER_IPC.RUN, (_event, request: ReviewRunRequest) => triggerReview(request))
-
-  // reviewer:get-for-session — load persisted reviews for a session at startup, flagging any whose
+  // Loads persisted reviews for a session at startup, flagging any whose
   // audited turn has since changed (e.g. an artifact was edited after the review completed) so the UI
   // does not present a stale verdict as current.
-  ipcMainHandle(REVIEWER_IPC.GET_FOR_SESSION, async (_event, request: ReviewSessionRequest) => {
+  const getForSession = async (request: ReviewSessionRequest): Promise<ReviewWithChecks[]> => {
     const reviews = await reviewRepository.getReviewsForProjectSession(
       request.projectId,
       request.appSessionId
@@ -136,11 +135,9 @@ const registerReviewerIpcHandlers = (
     return flagStaleReviews(reviews, session, dataRoot, (versionRequest) =>
       artifactProvenanceRepository.resolveVersionContent(versionRequest)
     )
-  })
+  }
 
-  // reviewer:abort-fix-loop — renderer requests that the active fix loop for a session be aborted.
-  // This is triggered when the user presses the cancel button during a fix loop.
-  ipcMainHandle(REVIEWER_IPC.ABORT_FIX_LOOP, (_event, request: ReviewSessionRequest) => {
+  const abortFixLoop = (request: ReviewSessionRequest): void => {
     const key = `${request.projectId}\0${request.appSessionId}`
     const controller = fixLoopAbortControllers.get(key)
     if (controller) {
@@ -149,7 +146,7 @@ const registerReviewerIpcHandlers = (
     } else {
       log.warn('abort-fix-loop: no active fix loop found for session', request)
     }
-  })
+  }
 
   // Returns whether a review actually STARTED. The session is loaded up front (not in the background)
   // so a load failure — or an already-in-flight run for this turn — is reported as started:false with
@@ -336,7 +333,24 @@ const registerReviewerIpcHandlers = (
     })
   }
 
-  return { triggerReview }
+  return { run: triggerReview, triggerReview, getForSession, abortFixLoop }
 }
 
-export { registerReviewerIpcHandlers, createDefaultReviewRepository }
+// Registers the legacy Electron adapter against an injectable owner. A future Host command
+// registrar can receive the same owner instance without duplicating arbitration state.
+const registerReviewerIpcHandlers = (
+  options: ReviewerIpcOptions,
+  owner: ReviewerCommandOwner = createReviewerCommandOwner(options)
+): ReviewerCommandOwner => {
+  ipcMainHandle(REVIEWER_IPC.RUN, (_event, request: ReviewRunRequest) => owner.run(request))
+  ipcMainHandle(REVIEWER_IPC.GET_FOR_SESSION, (_event, request: ReviewSessionRequest) =>
+    owner.getForSession(request)
+  )
+  ipcMainHandle(REVIEWER_IPC.ABORT_FIX_LOOP, (_event, request: ReviewSessionRequest) =>
+    owner.abortFixLoop(request)
+  )
+  return owner
+}
+
+export type { ReviewerCommandOwner, ReviewerIpcOptions }
+export { registerReviewerIpcHandlers, createReviewerCommandOwner, createDefaultReviewRepository }

--- a/src/main/update/ipc.test.ts
+++ b/src/main/update/ipc.test.ts
@@ -12,6 +12,7 @@ vi.mock('electron', () => ({
 }))
 
 const { registerUpdateIpcHandlers } = await import('./ipc')
+type UpdateCommandOwner = import('./ipc').UpdateCommandOwner
 
 const status = { state: 'available' as const, current: '0.5.1', latest: '0.5.2' }
 
@@ -26,6 +27,23 @@ const createStrategy = (): UpdateStrategy => ({
 describe('registerUpdateIpcHandlers', () => {
   beforeEach(() => {
     handlers.clear()
+  })
+
+  it('delegates IPC to an injected owner while returning the scheduler strategy', async () => {
+    const strategy = createStrategy()
+    const owner: UpdateCommandOwner = {
+      getAppInfo: vi.fn(() => ({ name: 'Injected', version: '1.0.0', copyright: 'test' })),
+      getStatus: vi.fn(() => status),
+      check: vi.fn().mockResolvedValue(status),
+      download: vi.fn().mockResolvedValue(status),
+      cancel: vi.fn().mockResolvedValue(status),
+      apply: vi.fn().mockResolvedValue(status)
+    }
+
+    expect(registerUpdateIpcHandlers(strategy, owner)).toBe(strategy)
+    expect(handlers.get('update:get-app-info')?.()).toMatchObject({ name: 'Injected' })
+    await expect(handlers.get('update:check')?.()).resolves.toBe(status)
+    expect(strategy.check).not.toHaveBeenCalled()
   })
 
   it('registers every renderer update command and returns the supplied strategy', async () => {

--- a/src/main/update/ipc.ts
+++ b/src/main/update/ipc.ts
@@ -5,19 +5,41 @@ import type { AppInfo, UpdateStatus } from '../../shared/update'
 import { createUpdateStrategy } from './create-strategy'
 import type { UpdateStrategy } from './strategy'
 
-// Registers the renderer-callable update commands. Returns the strategy so the scheduler can drive it.
-export const registerUpdateIpcHandlers = (
-  strategy: UpdateStrategy = createUpdateStrategy()
-): UpdateStrategy => {
-  ipcMainHandle('update:get-app-info', (): AppInfo => ({
+type UpdateCommandOwner = Readonly<{
+  getAppInfo: () => AppInfo
+  getStatus: () => UpdateStatus
+  check: () => Promise<UpdateStatus>
+  download: () => Promise<UpdateStatus>
+  cancel: () => Promise<UpdateStatus>
+  apply: () => Promise<UpdateStatus>
+}>
+
+const createUpdateCommandOwner = (strategy: UpdateStrategy): UpdateCommandOwner => ({
+  getAppInfo: (): AppInfo => ({
     name: APP.name,
     version: strategy.getStatus().current,
     copyright: APP.copyright
-  }))
-  ipcMainHandle('update:get-status', (): UpdateStatus => strategy.getStatus())
-  ipcMainHandle('update:check', (): Promise<UpdateStatus> => strategy.check())
-  ipcMainHandle('update:download', (): Promise<UpdateStatus> => strategy.download())
-  ipcMainHandle('update:cancel', (): Promise<UpdateStatus> => strategy.cancel())
-  ipcMainHandle('update:apply', (): Promise<UpdateStatus> => strategy.apply())
+  }),
+  getStatus: () => strategy.getStatus(),
+  check: () => strategy.check(),
+  download: () => strategy.download(),
+  cancel: () => strategy.cancel(),
+  apply: () => strategy.apply()
+})
+
+// Registers the renderer-callable update commands. Returns the strategy so the scheduler can drive it.
+export const registerUpdateIpcHandlers = (
+  strategy: UpdateStrategy = createUpdateStrategy(),
+  owner: UpdateCommandOwner = createUpdateCommandOwner(strategy)
+): UpdateStrategy => {
+  ipcMainHandle('update:get-app-info', () => owner.getAppInfo())
+  ipcMainHandle('update:get-status', () => owner.getStatus())
+  ipcMainHandle('update:check', () => owner.check())
+  ipcMainHandle('update:download', () => owner.download())
+  ipcMainHandle('update:cancel', () => owner.cancel())
+  ipcMainHandle('update:apply', () => owner.apply())
   return strategy
 }
+
+export type { UpdateCommandOwner }
+export { createUpdateCommandOwner }


### PR DESCRIPTION
# T2h0d pull request

Title: `refactor(host): share command owners`

## Problem

Reviewer run/fix-loop arbitration is owned inside legacy IPC registration, while CLI installation,
GitHub stars, Logs, and Update operations also expose only IPC-shaped construction. Final application
command composition cannot share those authorities without first making their owners injectable.

## Proposed change

- Add one Reviewer command owner for in-flight run arbitration and fix-loop cancellation.
- Expose injectable owners for CLI installation, GitHub stars, Logs, and Update operations.
- Keep legacy IPC as compatibility adapters and make the staged Host command group delegate to the
  same owner shapes.
- Preserve Update strategy as the scheduler/status lifecycle owner.

## Scope and non-goals

- No global `ipc.ts` composition or live transport cutover; T2h0f injects the shared instances.
- Remote Access late binding remains T2h0f because its service is constructed after IPC setup.
- No public method/event, persisted data, UI, ACP runtime identity, or capability change.
- Electron/Web/CLI availability and all local-only gates remain unchanged.

## Acceptance criteria and validation

- IPC and direct owner calls share Reviewer run/fix-loop state -> focused arbitration/cancellation
  tests -> passed.
- CLI/GitHub/Logs/Update legacy request/result and error behavior -> focused IPC regressions ->
  passed.
- Host command delegation and local-only gates remain unchanged -> Host command tests -> passed.
- Final focused suite -> 6 files / 56 tests passed after rebase.
- `npm run typecheck:node`, `npm run typecheck:web`, web API map, targeted ESLint, Prettier, and
  `git diff --check` -> passed after the last material edit.
- Independent Standards/Spec review -> 0 actionable findings on the rebased head.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- Reviewer IPC and Host commands must never own separate in-flight/fix-loop state.
- Update scheduler/status ownership and shutdown behavior must remain single-instance.
- Production raw churn is 246, below the 500-line hard stop.

## Uncovered risk

Global construction/disposal order, Remote Access late binding, and live router injection remain
T2h0f responsibilities.
