### PR TITLE
fix(artifacts): preserve prompt runtime ownership

### DIFF
--- a/src/shared/conversation-graph.test.ts
+++ b/src/shared/conversation-graph.test.ts
@@ -91,6 +91,38 @@ describe('conversation graph', () => {
     })
   })
 
+  it('keeps a resumed Agent response on its Prompt Runtime Segment', () => {
+    const prompt = message('u1', 'user', 'create a file', 1)
+    const resumed = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [prompt],
+      frameworkId: 'codex',
+      backendId: 'codex-subscription',
+      model: 'gpt-5.5',
+      createdAt: 1,
+      updatedAt: 1
+    })
+    const runtimeChangedBeforeResponse = ensureConversationRuntimeSegment(resumed, {
+      id: 'runtime-later',
+      frameworkId: 'codex',
+      backendId: 'codex-subscription',
+      startedAt: 2
+    })
+    const response = {
+      ...message('a1', 'agent', 'done', 3),
+      responseToMessageId: prompt.id
+    }
+    const completed = synchronizeActiveConversationMessages(
+      runtimeChangedBeforeResponse,
+      [prompt, response],
+      3
+    )
+
+    expect(completed.messages.find(({ id }) => id === response.id)?.runtimeSegmentId).toBe(
+      completed.messages.find(({ id }) => id === prompt.id)?.runtimeSegmentId
+    )
+  })
+
   it('keeps graph-owned history when a stale flat projection is shorter or older', () => {
     const graph = createLinearConversationGraph({
       sessionId: 'session-1',

--- a/src/shared/conversation-graph.ts
+++ b/src/shared/conversation-graph.ts
@@ -312,7 +312,7 @@ export const synchronizeActiveConversationMessages = (
   if (!frame) throw new Error('Active Agent Frame not found.')
   const branch = next.branches.find((candidate) => candidate.id === frame.activeBranchId)
   if (!branch) throw new Error('Active Message Branch not found.')
-  const runtimeSegmentId = next.runtimeSegments
+  const activeRuntimeSegmentId = next.runtimeSegments
     .filter((segment) => segment.agentFrameId === frame.id)
     .at(-1)?.id
   const existing = indexById(next.messages)
@@ -333,6 +333,10 @@ export const synchronizeActiveConversationMessages = (
       if (message.updatedAt > known.updatedAt) Object.assign(known, message)
       continue
     }
+    const runtimeSegmentId =
+      message.role === 'agent' && message.responseToMessageId
+        ? (existing.get(message.responseToMessageId)?.runtimeSegmentId ?? activeRuntimeSegmentId)
+        : activeRuntimeSegmentId
     const node: PersistedMessageNode = {
       ...message,
       agentFrameId: frame.id,


### PR DESCRIPTION
## Problem

After a detached Codex session resumes, the active Runtime Segment can change between the user Prompt projection and the terminal Agent Message projection. The shared graph synchronizer assigned every new Message to the latest Segment, so the Agent response could differ from its Prompt and Artifact finalization rejected the durable ownership proof.

## Proposed change

Assign a new Agent Message to the Runtime Segment of its `responseToMessageId` Prompt, falling back to the active Segment only when that Prompt ownership is unavailable. Add a regression test covering a resumed Prompt followed by a later Segment change.

## Scope and non-goals

- No schema, migration, architecture, or UI changes.
- No relaxation of Artifact finalization validation.
- No new dependencies or abstractions.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- Resumed Prompt/Agent ownership stays on one Runtime Segment -> `npm test -- src/shared/conversation-graph.test.ts src/renderer/src/lib/acp/workspace-events.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts src/main/artifacts/provenance-repository.test.ts` -> 4 files, 200 tests passed.
- Type contracts remain valid -> `npm run typecheck` -> passed.
- Repository lint gate -> `npm run lint` -> passed with 17 pre-existing warnings and 0 errors; changed files add no warnings.
- Full regression suite -> `npm test` -> 725 files / 10,746 tests passed; 15 files / 184 tests skipped.

Uncovered risk: the supplied production session JSON was unavailable, so the regression reproduces the exact Runtime Segment ownership invariant and finalization precondition rather than replaying that private session file.

## Review focus

Confirm that Agent responses should inherit their Prompt Runtime Segment when runtime metadata changes before the response is projected.