### PR TITLE
refactor(uploads): share command owner

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -170,6 +170,7 @@ import { registerUpdateIpcHandlers } from './update/ipc'
 import { createUpdateStrategy } from './update/create-strategy'
 import { startUpdateScheduler } from './update/scheduler'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './uploads/ipc'
+import { createUploadCommandOwner } from './uploads/command-owner'
 import { broadcastToRenderers, installRendererBroadcastEventHub } from './renderer-broadcast'
 import {
   installElectronRuntimeAdapters,
@@ -423,6 +424,10 @@ const createApplicationModules = async (
         reconcilePermissionGrantOwners(permissionGrantRegistry, { sessions })
     }
   )
+  const uploadCommandOwner = createUploadCommandOwner(uploadRepository, {
+    withSessionMutation: (projectId, sessionId, mutation) =>
+      sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
+  })
   const reviewRepository = createDefaultReviewRepository()
   const projectDeletionCoordinator = new ProjectDeletionCoordinator(
     projectRepository,
@@ -1297,9 +1302,7 @@ const createApplicationModules = async (
     )
   )
   declareElectronAdapter('uploads', () =>
-    registerUploadIpcHandlers(uploadRepository, {
-      withSessionMutation: (projectId, sessionId, mutation) =>
-        sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation),
+    registerUploadIpcHandlers(uploadCommandOwner, {
       // Standalone "Save as artifact" uploads have no session mutation to piggyback on, so the
       // Files panel only learns about them through this broadcast.
       onStandaloneUploadSaved: (projectId, sessionId) =>

--- a/src/main/uploads/command-owner.ts
+++ b/src/main/uploads/command-owner.ts
@@ -67,7 +67,8 @@ type UploadCommandOwner = Readonly<{
   ): Promise<UploadedAttachment>
   claimLocalFile(invocation: ApplicationInvocation<readonly [UploadTransferRequest]>): void
   stageLocalPath(
-    invocation: ApplicationInvocation<readonly [StageLocalPathUploadRequest]>
+    invocation: ApplicationInvocation<readonly [StageLocalPathUploadRequest]>,
+    progressTarget?: UploadProgressTarget
   ): Promise<UploadedAttachment>
   beginTransfer(
     invocation: ApplicationInvocation<readonly [BeginUploadTransferRequest]>
@@ -255,7 +256,7 @@ const createUploadCommandOwner = (
       }
       releaseLocalWriter(request.transferId, writer)
     },
-    stageLocalPath: async (invocation) => {
+    stageLocalPath: async (invocation, progressTarget = { report: () => undefined }) => {
       const request = invocation.args[0]
       if (
         typeof request !== 'object' ||
@@ -270,7 +271,7 @@ const createUploadCommandOwner = (
       const sourceInfo = await stat(request.sourcePath)
       const attachment = await runLocalStaging(
         { ...invocation, args: [{ ...request, size: sourceInfo.size }] },
-        { report: () => undefined },
+        progressTarget,
         true
       )
       const projectId = request.projectId ?? DEFAULT_UPLOAD_PROJECT_NAME

--- a/src/main/uploads/ipc.test.ts
+++ b/src/main/uploads/ipc.test.ts
@@ -27,8 +27,16 @@ import {
   clearMigrationPending,
   waitForDataRootWriters
 } from '../storage/migration-state'
-import { createWebCallerContext, type CallerContext } from '../caller-context'
-import { createDefaultUploadRepository, registerUploadIpcHandlers } from './ipc'
+import {
+  createElectronCallerContext,
+  createWebCallerContext,
+  type CallerContext
+} from '../caller-context'
+import { createUploadCommandOwner } from './command-owner'
+import {
+  createDefaultUploadRepository,
+  registerUploadIpcHandlers as registerUploadOwnerIpcHandlers
+} from './ipc'
 import type { UploadRepository } from './repository'
 import { stageUploadFixtures } from './repository.test-utils'
 
@@ -72,6 +80,25 @@ const createIpcEvent = (
       for (const listener of [...(listeners.get(channel) ?? [])]) listener(...args)
     }
   }
+}
+
+const registerUploadIpcHandlers = (
+  repository: UploadRepository,
+  options: {
+    withSessionMutation?: <Result>(
+      projectId: string,
+      sessionId: string,
+      mutation: () => Promise<Result>
+    ) => Promise<Result>
+    onStandaloneUploadSaved?: (projectId: string, sessionId: string) => void
+  } = {}
+): void => {
+  const owner = createUploadCommandOwner(repository, {
+    withSessionMutation: options.withSessionMutation
+  })
+  registerUploadOwnerIpcHandlers(owner, {
+    onStandaloneUploadSaved: options.onStandaloneUploadSaved
+  })
 }
 
 describe('default upload repository', () => {
@@ -158,6 +185,47 @@ describe('default upload repository', () => {
     expect(drained).toBe(true)
     expect(repository.appendTransfer).toHaveBeenCalledOnce()
     expect(repository.finishTransfer).toHaveBeenCalledOnce()
+  })
+
+  it('shares transfer ownership between legacy IPC and the injected command owner', async () => {
+    const repository = {
+      beginTransfer: vi.fn(async () => ({
+        transferId: 'shared-ipc-transfer',
+        name: 'data.csv',
+        receivedBytes: 0,
+        totalBytes: 10
+      })),
+      finishTransfer: vi.fn(async () => undefined)
+    } as unknown as UploadRepository
+    const owner = createUploadCommandOwner(repository)
+    registerUploadOwnerIpcHandlers(owner)
+    const begin = ipcHandlers.get('uploads:begin-transfer')!
+    const finish = ipcHandlers.get('uploads:finish-transfer')!
+    const caller = createIpcEvent(1)
+
+    await begin(caller.event, {
+      transferId: 'shared-ipc-transfer',
+      name: 'data.csv',
+      size: 10
+    })
+
+    const otherContext = createElectronCallerContext(2)
+    const otherController = new AbortController()
+    await expect(
+      owner.finishTransfer({
+        callerContext: otherContext,
+        callerLease: {
+          leaseId: otherContext.leaseId,
+          generation: 1,
+          signal: otherController.signal,
+          isCurrent: () => true
+        },
+        args: [{ transferId: 'shared-ipc-transfer' }]
+      })
+    ).rejects.toThrow(/another renderer/i)
+    expect(repository.finishTransfer).not.toHaveBeenCalled()
+
+    await finish(caller.event, { transferId: 'shared-ipc-transfer' })
   })
 
   it('finalizes Upload Versions inside the shared Session mutation boundary', async () => {
@@ -631,6 +699,45 @@ describe('default upload repository', () => {
 
     expect(caller.send).toHaveBeenCalledWith('uploads:transfer-progress', progress)
     await claim(caller.event, { transferId: 'local-transfer-progress' })
+  })
+
+  it('routes standalone local-path progress only through the invoking caller sender', async () => {
+    homeRoot = await mkdtemp(join(tmpdir(), 'open-science-upload-ipc-'))
+    const sourcePath = join(homeRoot, 'standalone-progress.csv')
+    await writeFile(sourcePath, 'event,count\nheadache,4\n')
+    const progress = {
+      transferId: 'local-path-progress',
+      receivedBytes: 8,
+      totalBytes: 23
+    }
+    const attachment = {
+      id: 'standalone-progress-attachment',
+      sessionId: '.pending',
+      name: 'standalone-progress.csv',
+      originalName: 'standalone-progress.csv',
+      path: '/managed/.pending/standalone-progress.csv',
+      size: 23
+    }
+    const repository = {
+      stageLocalFile: vi.fn(async (_request, report: (value: typeof progress) => void) => {
+        report(progress)
+        return attachment
+      }),
+      finalizePendingSessionUploads: vi.fn(async () => [attachment])
+    } as unknown as UploadRepository
+    registerUploadIpcHandlers(repository)
+    const stageLocalPath = ipcHandlers.get('uploads:stage-local-path')!
+    const caller = createIpcEvent(31)
+    const otherCaller = createIpcEvent(32)
+
+    await stageLocalPath(caller.event, {
+      transferId: 'local-path-progress',
+      sourcePath,
+      name: 'standalone-progress.csv'
+    })
+
+    expect(caller.send).toHaveBeenCalledWith('uploads:transfer-progress', progress)
+    expect(otherCaller.send).not.toHaveBeenCalled()
   })
 
   it('does not let another renderer cancel an active native-path upload', async () => {

--- a/src/main/uploads/ipc.ts
+++ b/src/main/uploads/ipc.ts
@@ -1,13 +1,11 @@
 import { type Event as ElectronEvent, type IpcMainInvokeEvent } from 'electron'
-import { stat } from 'node:fs/promises'
 
-import type { ApplicationCallerLease } from '../application-command-router'
+import type { ApplicationCallerLease, ApplicationInvocation } from '../application-command-router'
 import { callerContextForEvent } from '../caller-context'
 import { callerLeaseForEvent } from '../caller-lifecycle'
 import { ipcMainHandle } from '../ipc-handler-registry'
 
 import type { ReadArtifactPreviewRequest } from '../../shared/artifacts'
-import { validateLocalPath } from '../../shared/local-fs'
 import type {
   AppendUploadTransferRequest,
   BeginUploadTransferRequest,
@@ -15,14 +13,12 @@ import type {
   FinalizeUploadSessionRequest,
   StageLocalPathUploadRequest,
   StageLocalUploadRequest,
-  UploadTransferRequest,
-  UploadTransferStatus,
-  UploadedAttachment
+  UploadTransferRequest
 } from '../../shared/uploads'
 import { DEFAULT_UPLOAD_PROJECT_NAME, STANDALONE_UPLOAD_SESSION_ID } from '../../shared/uploads'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
-import { acquireDataRootWriter, withDataRootWrite } from '../storage/migration-state'
+import type { UploadCommandOwner } from './command-owner'
 import { UploadRepository } from './repository'
 
 // Uploads are data-class: they follow the configurable data root (defaults to the config root).
@@ -33,113 +29,23 @@ const createDefaultUploadRepository = (): UploadRepository =>
 
 // Registers the small upload IPC surface used by the renderer composer and preview panel.
 const registerUploadIpcHandlers = (
-  repository = createDefaultUploadRepository(),
+  owner: UploadCommandOwner,
   options: {
-    withSessionMutation?: <Result>(
-      projectId: string,
-      sessionId: string,
-      mutation: () => Promise<Result>
-    ) => Promise<Result>
     // Called after a standalone "Save as artifact" upload has been persisted to SQLite so
     // the caller can broadcast a project-files:changed event to the renderer.
     onStandaloneUploadSaved?: (projectId: string, sessionId: string) => void
   } = {}
 ): void => {
-  // A chunk transfer spans several IPC calls but is one logical write. Holding the writer lease from
-  // begin through finish/abort makes data-root migration wait across the gaps between chunks.
-  type UploadOwner = {
-    lease: ApplicationCallerLease
-    transferIds: Set<string>
-  }
-  type ChunkWriter = {
-    owner: UploadOwner
-    release: () => void
-    ready: Promise<UploadTransferStatus>
-    cancelled: boolean
-    settling: boolean
-    inFlight: Set<Promise<unknown>>
-    cleanup?: Promise<void>
-  }
-  type LocalWriter = {
-    owner: UploadOwner
-    release: () => void
-    cancelled: boolean
-    ready?: Promise<UploadedAttachment>
-    attachment?: UploadedAttachment
-    cleanup?: Promise<void>
-  }
-  const uploadOwners = new WeakMap<ApplicationCallerLease, UploadOwner>()
-  const chunkWriters = new Map<string, ChunkWriter>()
-  const localWriters = new Map<string, LocalWriter>()
-  const releaseChunkWriter = (transferId: string, writer: ChunkWriter): void => {
-    if (chunkWriters.get(transferId) !== writer) return
-    chunkWriters.delete(transferId)
-    writer.owner.transferIds.delete(transferId)
-    writer.release()
-  }
-  const abortChunkWriter = (transferId: string, writer: ChunkWriter): Promise<void> => {
-    if (writer.cleanup) return writer.cleanup
-
-    writer.cancelled = true
-    writer.cleanup = (async () => {
-      try {
-        await writer.ready.catch(() => undefined)
-        await Promise.allSettled([...writer.inFlight])
-        await repository.abortTransfer({ transferId }).catch(() => undefined)
-      } finally {
-        releaseChunkWriter(transferId, writer)
-      }
-    })()
-    return writer.cleanup
-  }
-  const releaseLocalWriter = (transferId: string, writer: LocalWriter): void => {
-    if (localWriters.get(transferId) !== writer) return
-    localWriters.delete(transferId)
-    writer.owner.transferIds.delete(transferId)
-    writer.release()
-  }
-  const abortLocalWriter = (transferId: string, writer: LocalWriter): Promise<void> => {
-    if (writer.cleanup) return writer.cleanup
-
-    writer.cancelled = true
-    writer.cleanup = (async () => {
-      try {
-        await repository.abortTransfer({ transferId }).catch(() => undefined)
-        const attachment = writer.attachment ?? (await writer.ready?.catch(() => undefined))
-        if (attachment) {
-          await repository.deleteUpload({ path: attachment.path }).catch(() => undefined)
-        }
-      } finally {
-        releaseLocalWriter(transferId, writer)
-      }
-    })()
-    return writer.cleanup
-  }
-  const registerUploadOwner = (event: IpcMainInvokeEvent): UploadOwner => {
+  const navigationBindings = new WeakMap<ApplicationCallerLease, () => void>()
+  const bindElectronNavigationCleanup = (event: IpcMainInvokeEvent): void => {
     const lease = callerLeaseForEvent(event)
-    const existing = uploadOwners.get(lease)
-    if (existing) return existing
-    if (lease.signal.aborted || !lease.isCurrent()) {
-      throw new Error('Upload renderer is no longer available.')
-    }
+    if (callerContextForEvent(event).surface !== 'electron' || navigationBindings.has(lease)) return
 
-    const releaseOnNavigation = callerContextForEvent(event).surface === 'electron'
-    const owner: UploadOwner = { lease, transferIds: new Set() }
-    const releaseOwner = (): void => {
-      if (uploadOwners.get(lease) !== owner) return
-      uploadOwners.delete(lease)
-      lease.signal.removeEventListener('abort', releaseOwner)
-      if (releaseOnNavigation) {
-        event.sender.removeListener('did-start-navigation', releaseOnMainFrameNavigation)
-      }
-      for (const transferId of [...owner.transferIds]) {
-        const chunkWriter = chunkWriters.get(transferId)
-        if (chunkWriter?.owner === owner && !chunkWriter.settling) {
-          void abortChunkWriter(transferId, chunkWriter)
-        }
-        const localWriter = localWriters.get(transferId)
-        if (localWriter?.owner === owner) void abortLocalWriter(transferId, localWriter)
-      }
+    const releaseBinding = (): void => {
+      if (navigationBindings.get(lease) !== releaseBinding) return
+      navigationBindings.delete(lease)
+      lease.signal.removeEventListener('abort', releaseBinding)
+      event.sender.removeListener('did-start-navigation', releaseOnMainFrameNavigation)
     }
     const releaseOnMainFrameNavigation = (
       _navigationEvent: ElectronEvent,
@@ -147,254 +53,73 @@ const registerUploadIpcHandlers = (
       _isInPlace: boolean,
       isMainFrame: boolean
     ): void => {
-      if (isMainFrame) releaseOwner()
+      if (!isMainFrame) return
+      releaseBinding()
+      owner.releaseCaller(lease)
     }
-    uploadOwners.set(lease, owner)
-    lease.signal.addEventListener('abort', releaseOwner, { once: true })
-    if (releaseOnNavigation) {
-      event.sender.on('did-start-navigation', releaseOnMainFrameNavigation)
-    }
+    navigationBindings.set(lease, releaseBinding)
+    lease.signal.addEventListener('abort', releaseBinding, { once: true })
+    event.sender.on('did-start-navigation', releaseOnMainFrameNavigation)
     if (lease.signal.aborted || !lease.isCurrent()) {
-      releaseOwner()
+      releaseBinding()
       throw new Error('Upload renderer is no longer available.')
     }
-    return owner
   }
-  const getOwnedChunkWriter = (
+  const invocationFor = <const Args extends readonly unknown[]>(
     event: IpcMainInvokeEvent,
-    transferId: string
-  ): ChunkWriter | undefined => {
-    const owner = registerUploadOwner(event)
-    const writer = chunkWriters.get(transferId)
-    if (writer && writer.owner !== owner) {
-      throw new Error(`Upload transfer belongs to another renderer: ${transferId}`)
-    }
-    return writer
-  }
-  const getOwnedLocalWriter = (
-    event: IpcMainInvokeEvent,
-    transferId: string
-  ): LocalWriter | undefined => {
-    const owner = registerUploadOwner(event)
-    const writer = localWriters.get(transferId)
-    if (writer && writer.owner !== owner) {
-      throw new Error(`Upload transfer belongs to another renderer: ${transferId}`)
-    }
-    return writer
-  }
-
-  // Shared skeleton for native-path staging: one owner/writer lifecycle, with the renderer-facing
-  // handlers keeping only their differences (request validation, size source, claim vs. release).
-  const runLocalStaging = async (
-    event: IpcMainInvokeEvent,
-    request: StageLocalUploadRequest,
-    options: { releaseOnCommit: boolean }
-  ): Promise<UploadedAttachment> => {
-    const owner = registerUploadOwner(event)
-    const existing = localWriters.get(request.transferId) ?? chunkWriters.get(request.transferId)
-    if (existing) {
-      if (existing.owner !== owner) {
-        throw new Error(`Upload transfer belongs to another renderer: ${request.transferId}`)
-      }
-      throw new Error(`Upload transfer already exists: ${request.transferId}`)
-    }
-
-    const writer: LocalWriter = {
-      owner,
-      release: acquireDataRootWriter(),
-      cancelled: false
-    }
-    localWriters.set(request.transferId, writer)
-    owner.transferIds.add(request.transferId)
-    try {
-      writer.ready = repository.stageLocalFile(request, (progress) => {
-        if (!writer.cancelled) event.sender.send('uploads:transfer-progress', progress)
-      })
-      const attachment = await writer.ready
-      writer.attachment = attachment
-      if (writer.cancelled) {
-        await writer.cleanup
-        throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
-      }
-      if (options.releaseOnCommit) releaseLocalWriter(request.transferId, writer)
-      return attachment
-    } catch (error) {
-      if (writer.cancelled) await writer.cleanup
-      else releaseLocalWriter(request.transferId, writer)
-      throw error
-    }
-  }
-
-  // Uploads write/mutate under the data root, so block them during the data-root copy→commit window.
-  ipcMainHandle('uploads:stage-local-file', async (event, request: StageLocalUploadRequest) =>
-    // The composer claims the committed transfer later, so the writer lease stays held.
-    runLocalStaging(event, request, { releaseOnCommit: false })
-  )
-  ipcMainHandle('uploads:claim-local-file', (event, request: UploadTransferRequest) => {
-    const writer = getOwnedLocalWriter(event, request.transferId)
-    // Chunk/Web transfers have no local ownership record, so claiming them is an idempotent no-op.
-    if (!writer) return
-    if (!writer.attachment) {
-      throw new Error(`Upload transfer is not ready to claim: ${request.transferId}`)
-    }
-    if (writer.cancelled) {
-      throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
-    }
-    releaseLocalWriter(request.transferId, writer)
+    args: Args
+  ): ApplicationInvocation<Args> => ({
+    callerContext: callerContextForEvent(event),
+    callerLease: callerLeaseForEvent(event),
+    args
   })
-  // Save-as-artifact from the local-file preview follows the composer upload pipeline, but the
-  // renderer supplies a path instead of a File and no composer will claim the transfer, so the
-  // writer lease is released as soon as the staged upload commits.
+  const ownedInvocationFor = <const Args extends readonly unknown[]>(
+    event: IpcMainInvokeEvent,
+    args: Args
+  ): ApplicationInvocation<Args> => {
+    bindElectronNavigationCleanup(event)
+    return invocationFor(event, args)
+  }
+
+  ipcMainHandle('uploads:stage-local-file', (event, request: StageLocalUploadRequest) =>
+    owner.stageLocalFile(ownedInvocationFor(event, [request]), {
+      report: (progress) => event.sender.send('uploads:transfer-progress', progress)
+    })
+  )
+  ipcMainHandle('uploads:claim-local-file', (event, request: UploadTransferRequest) =>
+    owner.claimLocalFile(ownedInvocationFor(event, [request]))
+  )
   ipcMainHandle('uploads:stage-local-path', async (event, request: StageLocalPathUploadRequest) => {
-    if (
-      typeof request !== 'object' ||
-      request === null ||
-      typeof request.transferId !== 'string' ||
-      typeof request.name !== 'string' ||
-      typeof request.sourcePath !== 'string' ||
-      // The renderer hands over a raw host path, so it gets the same shape checks the local-fs
-      // browser applies — absolute, no control characters — before stat() or any copy sees it.
-      validateLocalPath(request.sourcePath, process.platform) !== undefined
-    ) {
-      throw new Error('Invalid local path upload request.')
-    }
-    // Stat before registering the writer so a stale renderer-side size can never reach staging.
-    const sourceInfo = await stat(request.sourcePath)
-    const attachment = await runLocalStaging(
-      event,
-      { ...request, size: sourceInfo.size },
-      { releaseOnCommit: true }
-    )
-    // Publish to SQLite (uploadFile + uploadVersion + ManagedFile) so the file shows up in
-    // "Your uploads" without an active conversation session. completeStagingUpload (called from
-    // publishAttachment inside finalizePendingSessionUploads) writes ManagedFile with
-    // source='upload', which is what listFiles({ collection: 'uploads' }) queries.
+    const attachment = await owner.stageLocalPath(ownedInvocationFor(event, [request]), {
+      report: (progress) => event.sender.send('uploads:transfer-progress', progress)
+    })
     const projectId = request.projectId ?? DEFAULT_UPLOAD_PROJECT_NAME
-    try {
-      await withDataRootWrite(() =>
-        repository.finalizePendingSessionUploads(
-          STANDALONE_UPLOAD_SESSION_ID,
-          [attachment],
-          projectId
-        )
-      )
-    } catch (error) {
-      // Staging already committed its bytes into .pending/ and the writer lease is gone, so a failed
-      // publish would leave a file with no Version row and nothing to sweep it. Drop the copy and
-      // surface the original failure.
-      await repository.deleteUpload({ path: attachment.path }).catch(() => undefined)
-      throw error
-    }
     options.onStandaloneUploadSaved?.(projectId, STANDALONE_UPLOAD_SESSION_ID)
     return attachment
   })
-  ipcMainHandle('uploads:begin-transfer', async (event, request: BeginUploadTransferRequest) => {
-    const owner = registerUploadOwner(event)
-    const localWriter = localWriters.get(request.transferId)
-    if (localWriter) {
-      if (localWriter.owner !== owner) {
-        throw new Error(`Upload transfer belongs to another renderer: ${request.transferId}`)
-      }
-      throw new Error(`Upload transfer already exists: ${request.transferId}`)
-    }
-    const existing = chunkWriters.get(request.transferId)
-    if (existing) {
-      if (existing.owner !== owner) {
-        throw new Error(`Upload transfer belongs to another renderer: ${request.transferId}`)
-      }
-      await existing.ready
-      return repository.beginTransfer(request)
-    }
-
-    const writer: ChunkWriter = {
-      owner,
-      release: acquireDataRootWriter(),
-      ready: repository.beginTransfer(request),
-      cancelled: false,
-      settling: false,
-      inFlight: new Set()
-    }
-    chunkWriters.set(request.transferId, writer)
-    owner.transferIds.add(request.transferId)
-    try {
-      const status = await writer.ready
-      if (writer.cancelled) {
-        await writer.cleanup
-        throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
-      }
-      return status
-    } catch (error) {
-      releaseChunkWriter(request.transferId, writer)
-      throw error
-    }
-  })
-  ipcMainHandle('uploads:append-transfer', async (event, request: AppendUploadTransferRequest) => {
-    const writer = getOwnedChunkWriter(event, request.transferId)
-    if (!writer) return withDataRootWrite(() => repository.appendTransfer(request))
-
-    await writer.ready
-    if (writer.cancelled) {
-      throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
-    }
-    const operation = repository.appendTransfer(request)
-    writer.inFlight.add(operation)
-    try {
-      return await operation
-    } finally {
-      writer.inFlight.delete(operation)
-    }
-  })
-  ipcMainHandle('uploads:transfer-status', (event, request: UploadTransferRequest) => {
-    getOwnedChunkWriter(event, request.transferId)
-    return repository.getTransferStatus(request)
-  })
-  ipcMainHandle('uploads:finish-transfer', async (event, request: UploadTransferRequest) => {
-    const writer = getOwnedChunkWriter(event, request.transferId)
-    if (!writer) return withDataRootWrite(() => repository.finishTransfer(request))
-
-    try {
-      await writer.ready
-      if (writer.cancelled) {
-        await writer.cleanup
-        throw new Error(`Upload renderer is no longer available: ${request.transferId}`)
-      }
-      writer.settling = true
-      await Promise.allSettled([...writer.inFlight])
-      return await repository.finishTransfer(request)
-    } catch (error) {
-      await repository.abortTransfer(request).catch(() => undefined)
-      throw error
-    } finally {
-      releaseChunkWriter(request.transferId, writer)
-    }
-  })
-  ipcMainHandle('uploads:abort-transfer', async (event, request: UploadTransferRequest) => {
-    const localWriter = getOwnedLocalWriter(event, request.transferId)
-    if (localWriter) return abortLocalWriter(request.transferId, localWriter)
-
-    const writer = getOwnedChunkWriter(event, request.transferId)
-    if (!writer) return withDataRootWrite(() => repository.abortTransfer(request))
-
-    await abortChunkWriter(request.transferId, writer)
-  })
-  ipcMainHandle('uploads:delete', (_event, request: DeleteUploadRequest) =>
-    withDataRootWrite(() => repository.deleteUpload(request))
+  ipcMainHandle('uploads:begin-transfer', (event, request: BeginUploadTransferRequest) =>
+    owner.beginTransfer(ownedInvocationFor(event, [request]))
   )
-  ipcMainHandle('uploads:finalize-session', (_event, request: FinalizeUploadSessionRequest) =>
-    withDataRootWrite(() => {
-      const finalize = (): Promise<UploadedAttachment[]> =>
-        repository.finalizePendingSessionUploads(
-          request.sessionId,
-          request.attachments,
-          request.projectId
-        )
-      return options.withSessionMutation && request.projectId
-        ? options.withSessionMutation(request.projectId, request.sessionId, finalize)
-        : finalize()
-    })
+  ipcMainHandle('uploads:append-transfer', (event, request: AppendUploadTransferRequest) =>
+    owner.appendTransfer(ownedInvocationFor(event, [request]))
   )
-  ipcMainHandle('uploads:read-preview', (_event, request: ReadArtifactPreviewRequest) =>
-    repository.readManagedUploadPreview(request)
+  ipcMainHandle('uploads:transfer-status', (event, request: UploadTransferRequest) =>
+    owner.transferStatus(ownedInvocationFor(event, [request]))
+  )
+  ipcMainHandle('uploads:finish-transfer', (event, request: UploadTransferRequest) =>
+    owner.finishTransfer(ownedInvocationFor(event, [request]))
+  )
+  ipcMainHandle('uploads:abort-transfer', (event, request: UploadTransferRequest) =>
+    owner.abortTransfer(ownedInvocationFor(event, [request]))
+  )
+  ipcMainHandle('uploads:delete', (event, request: DeleteUploadRequest) =>
+    owner.deleteUpload(invocationFor(event, [request]))
+  )
+  ipcMainHandle('uploads:finalize-session', (event, request: FinalizeUploadSessionRequest) =>
+    owner.finalizeSession(invocationFor(event, [request]))
+  )
+  ipcMainHandle('uploads:read-preview', (event, request: ReadArtifactPreviewRequest) =>
+    owner.readPreview(invocationFor(event, [request]))
   )
 }
 


### PR DESCRIPTION
# T2h0a2 pull request

Title: `refactor(uploads): share command owner`

## Problem

Legacy Upload IPC still owns transfer maps, writer leases, cancellation, and caller-navigation cleanup
inside its registration closure. The staged Upload application commands cannot share that authority
until IPC becomes a narrow adapter over the owner added by T2h0a1.

## Proposed change

- Construct one `UploadCommandOwner` in application composition and inject it into legacy IPC.
- Replace the IPC-owned transfer maps and transition methods with an 11-channel Electron adapter.
- Keep event-to-invocation mapping, Electron main-frame navigation cleanup, targeted transfer progress,
  and standalone Project Files invalidation in the adapter.
- Route native/chunk staging, claim, migration exclusion, mutation, and cleanup through the shared
  transport-neutral owner.

## Scope and non-goals

- No Web/Task transport cutover or public command inventory change; T2h0f/T2h1 own those steps.
- No public IPC channel, request/result, persisted data, user interaction, or capability change.
- Native path/progress resources remain Electron-only; the owner has no Electron, `IpcMain`,
  `WebContents`, or sender dependency.

## Acceptance criteria and validation

- IPC and direct commands use one owner and preserve caller isolation -> cross-surface transfer
  ownership tracer -> passed.
- All 11 legacy channels and wire shapes remain exact -> registration/compatibility tests -> passed.
- Renderer destroy/main-frame navigation, release-once, claim, migration writer gates, and transfer
  cleanup -> focused lifecycle tests -> passed.
- `stage-local-path` retains invoking-sender-only `uploads:transfer-progress`; a second sender receives
  nothing -> regression test added after independent review -> passed.
- Standalone publish success broadcasts only after persistence; failure deletes the orphan and does
  not invalidate -> focused tests -> passed.
- Final owner/IPC/composition suite -> 3 files / 46 tests passed after the final rebase.
- `npm run typecheck:node`, targeted ESLint, Prettier, and `git diff --check` -> passed after the last
  material edit.
- Independent Standards/Spec review -> initial P2 progress finding fixed; final 0 actionable findings.
- Full and cross-platform suites are delegated to online CI.

## Review focus

- No mutable Upload transfer authority may remain in IPC.
- Electron navigation cleanup and progress targeting must not leak into the owner.
- Production raw churn is 415, below the 500-line hard stop; `uploads/ipc.ts` falls from 401 to 126
  lines after the progress fix.

## Uncovered risk

Real Electron `WebContents` teardown is covered by the existing sender/lifecycle harness rather than a
local E2E run. Live Host command composition and Web/Task direct dispatch remain T2h0f/T2h1 work.
