### PR TITLE
refactor(storage): move command owner module

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -155,7 +155,7 @@ import { registerSpecialistIpcHandlers } from './specialist/ipc'
 import { SessionBindingService } from './specialist/session-binding'
 import { SPECIALIST_IPC } from '../shared/specialist'
 import type { AppIconPreview, AppIconVariant, RespondApprovalRequest } from '../shared/settings'
-import { registerStorageIpcHandlers } from './storage/ipc'
+import { registerStorageIpcHandlers } from './storage/electron-ipc'
 import { normalizeLegacyDataPaths } from './storage/normalize-legacy-paths'
 import { detectActiveSessions } from './storage/detect-active'
 import {

--- a/src/main/lifecycle-shutdown.ts
+++ b/src/main/lifecycle-shutdown.ts
@@ -31,7 +31,8 @@ export class BackendShutdownOutcomeError extends Error {
 type ShutdownLogger = Pick<Logger, 'error'>
 
 // Deps for the quit/relaunch helper: only the latching teardown is needed. Kept narrow so the migration
-// relaunch path (storage/ipc.ts) does not have to expose the non-latching gate method it never uses.
+// relaunch path (storage/command-owner.ts) does not have to expose the non-latching gate method it
+// never uses.
 export type QuitShutdownDeps = {
   runtime: {
     // Latching quit teardown: sets the runtime's shutting-down flag so a mid-spawn connect self-aborts
@@ -121,7 +122,8 @@ const runBounded = async (
 }
 
 // Quit/relaunch helper (latching teardown). Kept as a standalone function for the data-root migration
-// relaunch path (storage/ipc.ts); the app-quit path goes through BackendShutdownCoordinator instead.
+// relaunch path (storage/command-owner.ts); the app-quit path goes through
+// BackendShutdownCoordinator instead.
 // Returns void for backward compatibility — that caller only needs the bounded, never-throwing await.
 export const shutdownBackends = async (deps: QuitShutdownDeps): Promise<void> => {
   await runBounded(

--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -5,8 +5,6 @@ import { join } from 'node:path'
 
 import { app, dialog, shell } from 'electron'
 
-import { ipcMainHandle } from '../ipc-handler-registry'
-
 import type {
   ActiveSessionInfo,
   DataRootInspection,
@@ -47,7 +45,7 @@ import { markApplicationShutdownTrigger } from '../application-shutdown-trigger'
 
 type SessionSource = { projectName: string; sessionId: string }
 
-type StorageIpcDeps = {
+type StorageCommandOwnerDeps = {
   // disconnect/shutdownAll drive the reusable migration session-interrupt; shutdownForQuit/dispose are
   // the terminal teardown used by cleanRelaunch (via shutdownBackends).
   runtime: {
@@ -82,8 +80,6 @@ type StorageIpcDeps = {
   cleanupRuntimeCache?: (runtimeRoot: string) => void
   logger?: Logger
 }
-
-type StorageCommandOwnerDeps = StorageIpcDeps
 
 type StorageParentRequest = Readonly<{ parent: string }>
 type StorageRootRequest = Readonly<{ parent: string; markOnboarding?: boolean }>
@@ -507,29 +503,5 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
 
 type StorageCommandOwner = ReturnType<typeof createStorageCommandOwner>
 
-const registerStorageIpcHandlers = (
-  deps: StorageIpcDeps,
-  owner: StorageCommandOwner = createStorageCommandOwner(deps)
-): void => {
-  ipcMainHandle('storage:get-info', () => owner.getInfo())
-  ipcMainHandle('storage:reveal-app-storage', () => owner.revealAppStorage())
-  ipcMainHandle('storage:dismiss-legacy-move-prompt', () => owner.dismissLegacyMovePrompt())
-  ipcMainHandle('storage:detect-active', () => owner.detectActive())
-  ipcMainHandle('storage:pick-directory', () => owner.pickDirectory())
-  ipcMainHandle('storage:migrate', (_event, request) => owner.migrate(request))
-  ipcMainHandle('storage:cancel-migrate', () => owner.cancelMigrate())
-  ipcMainHandle('storage:discard-migrated-copy', (_event, request) =>
-    owner.discardMigratedCopy(request)
-  )
-  ipcMainHandle('storage:commit-and-relaunch', (_event, request) =>
-    owner.commitAndRelaunch(request)
-  )
-  ipcMainHandle('storage:validate-data-root', (_event, request) => owner.validateDataRoot(request))
-  ipcMainHandle('storage:inspect-data-root', (_event, request) => owner.inspectDataRoot(request))
-  ipcMainHandle('storage:set-data-root-and-relaunch', (_event, request) =>
-    owner.setDataRootAndRelaunch(request)
-  )
-}
-
-export { createStorageCommandOwner, registerStorageIpcHandlers }
-export type { StorageCommandOwner, StorageCommandOwnerDeps, StorageIpcDeps }
+export { createStorageCommandOwner }
+export type { StorageCommandOwner, StorageCommandOwnerDeps }

--- a/src/main/storage/electron-ipc.ts
+++ b/src/main/storage/electron-ipc.ts
@@ -1,0 +1,35 @@
+import { ipcMainHandle } from '../ipc-handler-registry'
+import {
+  createStorageCommandOwner,
+  type StorageCommandOwner,
+  type StorageCommandOwnerDeps
+} from './command-owner'
+
+type StorageIpcDeps = StorageCommandOwnerDeps
+
+const registerStorageIpcHandlers = (
+  deps: StorageIpcDeps,
+  owner: StorageCommandOwner = createStorageCommandOwner(deps)
+): void => {
+  ipcMainHandle('storage:get-info', () => owner.getInfo())
+  ipcMainHandle('storage:reveal-app-storage', () => owner.revealAppStorage())
+  ipcMainHandle('storage:dismiss-legacy-move-prompt', () => owner.dismissLegacyMovePrompt())
+  ipcMainHandle('storage:detect-active', () => owner.detectActive())
+  ipcMainHandle('storage:pick-directory', () => owner.pickDirectory())
+  ipcMainHandle('storage:migrate', (_event, request) => owner.migrate(request))
+  ipcMainHandle('storage:cancel-migrate', () => owner.cancelMigrate())
+  ipcMainHandle('storage:discard-migrated-copy', (_event, request) =>
+    owner.discardMigratedCopy(request)
+  )
+  ipcMainHandle('storage:commit-and-relaunch', (_event, request) =>
+    owner.commitAndRelaunch(request)
+  )
+  ipcMainHandle('storage:validate-data-root', (_event, request) => owner.validateDataRoot(request))
+  ipcMainHandle('storage:inspect-data-root', (_event, request) => owner.inspectDataRoot(request))
+  ipcMainHandle('storage:set-data-root-and-relaunch', (_event, request) =>
+    owner.setDataRootAndRelaunch(request)
+  )
+}
+
+export { registerStorageIpcHandlers }
+export type { StorageIpcDeps }

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -41,7 +41,8 @@ vi.mock('electron', () => ({
 }))
 
 const { initDataRoot } = await import('../storage-root')
-const { createStorageCommandOwner, registerStorageIpcHandlers } = await import('./ipc')
+const { createStorageCommandOwner } = await import('./command-owner')
+const { registerStorageIpcHandlers } = await import('./electron-ipc')
 const { clearMigrationPending, isMigrationPending } = await import('./migration-state')
 const { clearApplicationShutdownTrigger, currentApplicationShutdownTrigger } =
   await import('../application-shutdown-trigger')


### PR DESCRIPTION
# T2h0c2a pull request

Title: `refactor(storage): move command owner module`

## Problem

T2h0c established a single Storage command owner, but the owner still co-resides with IPC registration
in `storage/ipc.ts`. Moving it directly while retaining that path for the adapter measured 1,021
ordinary production raw lines because Git treated the owner as a copy rather than a rename.

## Proposed change

- Rename the established owner implementation from `storage/ipc.ts` to
  `storage/command-owner.ts` with `R094` detection.
- Put the unchanged 12-channel Electron compatibility adapter temporarily in
  `storage/electron-ipc.ts`.
- Update production and focused-test imports; update stale code comments to the new owner path.
- Leave final adapter path normalization to T2h0c2b after this rename merges.

## Scope and non-goals

- Pure physical module move; no owner method, dependency, state transition, or return behavior change.
- No public channel/request/result, local-only gate, persisted data, UI, capability, or transport
  inventory change.
- No global command composition or Web/Task cutover.

## Acceptance criteria and validation

- Git recognizes the owner move rather than duplicate code -> staged summary `R094` -> passed.
- All 12 IPC handlers and default/injected owner construction remain exact -> adapter comparison and
  focused tests -> passed.
- Production and tests import the owner/adapter from their distinct modules -> node/web typecheck ->
  passed.
- Storage owner/IPC behavior and Host dependency consumer ->
  `npm test -- --run src/main/storage/ipc.test.ts src/main/host-application-commands.test.ts` ->
  2 files / 62 tests passed after the last material edit.
- Node and renderer type consumers -> `npm run typecheck:node` and `npm run typecheck:web` -> passed.
- Linted source and formatting -> targeted ESLint, Prettier, and `git diff --check` -> passed.
- Independent Standards/Spec review -> 0 actionable findings.
- Host commands are included because they consume the moved owner dependency shape. No local
  platform/E2E lane is included because this PR changes paths only and has no platform branch, wire,
  persistence, build, or UI behavior; PR Gate remains authoritative for selected cross-platform lanes.

## Review focus

- `command-owner.ts` must be a mechanical relocation of the established owner.
- `electron-ipc.ts` must remain a thin, exact compatibility adapter.
- Production raw churn is 77, below the 500-line hard stop.

## Uncovered risk

The temporary adapter path is intentionally short-lived. T2h0c2b renames `electron-ipc.ts` back to
the stable `storage/ipc.ts` path before T2h0f composes the live command router.
