### PR TITLE
refactor(main): compose application command core

### DIFF
--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -1,0 +1,472 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const routerFactoryControl = vi.hoisted(() => ({
+  actual: undefined as ((onDiagnostic?: unknown) => unknown) | undefined,
+  replacement: undefined as ((onDiagnostic?: unknown) => unknown) | undefined
+}))
+
+vi.mock('./application-command-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./application-command-router')>()
+  routerFactoryControl.actual = actual.createApplicationCommandRouter as unknown as (
+    onDiagnostic?: unknown
+  ) => unknown
+  return {
+    ...actual,
+    createApplicationCommandRouter: (
+      onDiagnostic?: Parameters<typeof actual.createApplicationCommandRouter>[0]
+    ) =>
+      routerFactoryControl.replacement?.(onDiagnostic) ??
+      actual.createApplicationCommandRouter(onDiagnostic)
+  }
+})
+
+import { RENDERER_CONTRACT_CATALOG } from '../shared/renderer-contract-catalog'
+import {
+  createApplicationCommandComposition,
+  type ApplicationCommandCompositionDependencies
+} from './application-command-composition'
+import {
+  type ApplicationCommandInstallation,
+  type ApplicationCommandRouter,
+  type ApplicationCommandRegistrationScope,
+  type ApplicationInvocation
+} from './application-command-router'
+import { createCallerContext } from './caller-context'
+
+const EMPTY_OWNER = Object.freeze({})
+
+const dependencies = (): ApplicationCommandCompositionDependencies =>
+  ({
+    acp: EMPTY_OWNER,
+    notebook: EMPTY_OWNER,
+    notebookEnvironment: EMPTY_OWNER,
+    notebookRuntime: EMPTY_OWNER,
+    settingsCore: EMPTY_OWNER,
+    settingsIntegration: EMPTY_OWNER,
+    settingsRuntime: EMPTY_OWNER,
+    compute: EMPTY_OWNER,
+    permissionGrants: EMPTY_OWNER,
+    dataContent: EMPTY_OWNER,
+    host: EMPTY_OWNER
+  }) as ApplicationCommandCompositionDependencies
+
+const expectedLocalWebCommands = (): string[] =>
+  RENDERER_CONTRACT_CATALOG.flatMap(({ channel, kind, surfaceInstallation }) =>
+    channel !== null && kind === 'method' && surfaceInstallation.localWeb === 'web-rpc'
+      ? [channel]
+      : []
+  ).sort()
+
+const expectedRemoteCommands = (): string[] =>
+  RENDERER_CONTRACT_CATALOG.flatMap(({ channel, kind, surfaceInstallation }) =>
+    channel !== null && kind === 'method' && surfaceInstallation.remoteWeb === 'web-rpc'
+      ? [channel]
+      : []
+  ).sort()
+
+const expectedRemoteRejections = (): string[] =>
+  RENDERER_CONTRACT_CATALOG.flatMap(({ channel, kind, surfaceInstallation }) =>
+    channel !== null &&
+    kind === 'method' &&
+    surfaceInstallation.localWeb === 'web-rpc' &&
+    surfaceInstallation.remoteWeb === 'rejecting-stub'
+      ? [channel]
+      : []
+  ).sort()
+
+const installInstrumentedRouterFactory = (
+  events: string[],
+  options: Readonly<{
+    failInstallAt?: number
+    failCompleteAt?: number
+    failUninstallAt?: ReadonlySet<number>
+    failRouterDispose?: boolean
+    onRegisterGroup?: (groupName: string, handlers: unknown) => void
+  }> = {}
+): void => {
+  const actualFactory = routerFactoryControl.actual as unknown as (
+    onDiagnostic?: unknown
+  ) => ApplicationCommandRouter
+  routerFactoryControl.replacement = (onDiagnostic): ApplicationCommandRouter => {
+    const router = actualFactory(onDiagnostic)
+    let nextScope = 0
+
+    return Object.freeze({
+      ...router,
+      registrar: Object.freeze({
+        createScope: (): ApplicationCommandRegistrationScope => {
+          const index = nextScope++
+          events.push(`install:${index}`)
+          if (options.failInstallAt === index) throw new Error(`install failed:${index}`)
+          const scope = router.registrar.createScope()
+          const registerGroup: ApplicationCommandRegistrationScope['registerGroup'] = (
+            group,
+            handlers
+          ) => {
+            options.onRegisterGroup?.(group.name, handlers)
+            scope.registerGroup(group, handlers)
+          }
+          return Object.freeze({
+            ...scope,
+            registerGroup,
+            complete: (cleanup): ApplicationCommandInstallation => {
+              if (options.failCompleteAt === index) {
+                throw new Error(`complete failed:${index}`)
+              }
+              const installation = scope.complete(cleanup)
+              return Object.freeze({
+                uninstall: (): void => {
+                  events.push(`uninstall:${index}`)
+                  installation.uninstall()
+                  if (options.failUninstallAt?.has(index)) {
+                    throw new Error(`uninstall failed:${index}`)
+                  }
+                }
+              })
+            }
+          })
+        }
+      }),
+      dispose: (): void => {
+        events.push('router:dispose')
+        router.dispose()
+        if (options.failRouterDispose) throw new Error('router dispose failed')
+      }
+    })
+  }
+}
+
+afterEach(() => {
+  routerFactoryControl.replacement = undefined
+})
+
+const invocation = (
+  location: 'local' | 'remote' = 'local'
+): ApplicationInvocation<readonly unknown[]> => {
+  const callerContext = createCallerContext({
+    clientId: 'web-client',
+    lifecycleClientId: 'web:web-client',
+    leaseId: 'lease-1',
+    surface: 'web',
+    location,
+    principalKind: 'human',
+    actionOrigin: 'human'
+  })
+  return Object.freeze({
+    callerContext,
+    callerLease: Object.freeze({
+      leaseId: callerContext.leaseId,
+      generation: 1,
+      signal: new AbortController().signal,
+      isCurrent: () => true
+    }),
+    args: Object.freeze([])
+  })
+}
+
+describe('application command composition', () => {
+  it('certifies the complete group inventory behind the local Web view', () => {
+    const composition = createApplicationCommandComposition(dependencies())
+
+    expect(composition.localWeb.commandNames()).toEqual(expectedLocalWebCommands())
+    expect(composition.localWeb.commandNames()).toHaveLength(214)
+  })
+
+  it('partitions remote Web dispatch from fail-closed pre-dispatch rejections', async () => {
+    const listProjects = vi.fn().mockResolvedValue([{ id: 'project-1' }])
+    const onDiagnostic = vi.fn()
+    const composition = createApplicationCommandComposition(
+      {
+        ...dependencies(),
+        dataContent: { projects: { list: listProjects } } as never
+      },
+      onDiagnostic
+    )
+
+    expect(composition.remoteWeb.commandNames()).toEqual(expectedRemoteCommands())
+    expect(composition.remoteWeb.commandNames()).toHaveLength(158)
+    expect(composition.remoteWeb.rejectedCommandNames()).toEqual(expectedRemoteRejections())
+    expect(composition.remoteWeb.rejectedCommandNames()).toHaveLength(56)
+    await expect(
+      composition.remoteWeb.invoke('compute:download', invocation('remote'))
+    ).rejects.toThrow('Application command is rejected before dispatch: compute:download')
+    expect(onDiagnostic).not.toHaveBeenCalled()
+    await expect(
+      composition.remoteWeb.invoke('projects:list', invocation('remote'))
+    ).resolves.toEqual([{ id: 'project-1' }])
+    expect(listProjects).toHaveBeenCalledOnce()
+  })
+
+  it('exposes only the seven Task commands and no transport-wide capability', async () => {
+    const composition = createApplicationCommandComposition(dependencies())
+
+    expect(composition.task.commandNames()).toEqual([
+      'projects:list',
+      'projects:create',
+      'sessions:load-all',
+      'sessions:save-session',
+      'artifacts:finalize-run',
+      'preview-resources:acquire',
+      'preview-resources:release'
+    ])
+    await expect(
+      composition.localWeb.invoke('sessions:export-conversation', invocation())
+    ).rejects.toThrow(
+      'Application command is unavailable in this view: sessions:export-conversation'
+    )
+    await expect(composition.task.invoke('cli:get-status', invocation())).rejects.toThrow(
+      'Application command is unavailable in this view: cli:get-status'
+    )
+    expect(composition).not.toHaveProperty('registrar')
+    expect(composition).not.toHaveProperty('dispatcher')
+    expect(composition).not.toHaveProperty('electron')
+    expect(composition).not.toHaveProperty('cli')
+    expect(composition).not.toHaveProperty('localRpc')
+    expect(composition).not.toHaveProperty('specialist')
+  })
+
+  it('late-binds the single Remote Access owner and fails closed around its lifetime', async () => {
+    const snapshot = Object.freeze({ lifecycle: 'disabled' })
+    const firstSnapshot = vi.fn(() => snapshot)
+    const firstOwner = {
+      snapshot: firstSnapshot,
+      detect: vi.fn(),
+      setMode: vi.fn(),
+      disable: vi.fn(),
+      approve: vi.fn(),
+      reject: vi.fn(),
+      revoke: vi.fn()
+    }
+    const replacementSnapshot = vi.fn(() => Object.freeze({ lifecycle: 'running' }))
+    const replacementOwner = { ...firstOwner, snapshot: replacementSnapshot }
+    const composition = createApplicationCommandComposition(dependencies())
+
+    await expect(
+      composition.remoteWeb.invoke('remote-access:get-snapshot', invocation('remote'))
+    ).rejects.toThrow('Remote Access command owner is not bound.')
+
+    composition.bindRemoteAccess(firstOwner as never)
+    await expect(
+      composition.remoteWeb.invoke('remote-access:get-snapshot', invocation('remote'))
+    ).resolves.toBe(snapshot)
+    expect(firstSnapshot).toHaveBeenCalledOnce()
+    expect(() => composition.bindRemoteAccess(replacementOwner as never)).toThrow(
+      'Remote Access command owner is already bound.'
+    )
+    expect(replacementSnapshot).not.toHaveBeenCalled()
+
+    composition.dispose()
+    composition.dispose()
+    expect(() => composition.bindRemoteAccess(firstOwner as never)).toThrow(
+      'Remote Access command owner slot is disposed.'
+    )
+    await expect(
+      composition.remoteWeb.invoke('remote-access:get-snapshot', invocation('remote'))
+    ).rejects.toThrow('Application command router is disposed.')
+  })
+
+  it('installs every registrar family in a fixed order and stops at a partial failure', () => {
+    const orderedNames = [
+      'acp',
+      'notebook',
+      'notebookEnvironment',
+      'notebookRuntime',
+      'settingsCore',
+      'settingsIntegration',
+      'settingsRuntime',
+      'compute',
+      'permissionGrants',
+      'dataContent',
+      'host'
+    ] as const satisfies readonly (keyof ApplicationCommandCompositionDependencies)[]
+    const source = dependencies()
+    const reads: string[] = []
+    const ordered = Object.create(null) as ApplicationCommandCompositionDependencies
+    for (const name of orderedNames) {
+      Object.defineProperty(ordered, name, {
+        enumerable: true,
+        get: () => {
+          reads.push(name)
+          return source[name]
+        }
+      })
+    }
+
+    const normalEvents: string[] = []
+    installInstrumentedRouterFactory(normalEvents)
+    const composition = createApplicationCommandComposition(ordered)
+    expect(reads).toEqual(orderedNames)
+    expect(normalEvents).toEqual(orderedNames.map((_, index) => `install:${index}`))
+    composition.dispose()
+    expect(normalEvents.slice(11)).toEqual([
+      'uninstall:10',
+      'uninstall:9',
+      'uninstall:8',
+      'uninstall:7',
+      'uninstall:6',
+      'uninstall:5',
+      'uninstall:4',
+      'uninstall:3',
+      'uninstall:2',
+      'uninstall:1',
+      'uninstall:0',
+      'router:dispose'
+    ])
+    const disposedEventCount = normalEvents.length
+    composition.dispose()
+    expect(normalEvents).toHaveLength(disposedEventCount)
+
+    const partialEvents: string[] = []
+    installInstrumentedRouterFactory(partialEvents, { failInstallAt: 4 })
+    expect(() => createApplicationCommandComposition(source)).toThrow('install failed:4')
+    expect(partialEvents).toEqual([
+      'install:0',
+      'install:1',
+      'install:2',
+      'install:3',
+      'install:4',
+      'uninstall:3',
+      'uninstall:2',
+      'uninstall:1',
+      'uninstall:0',
+      'router:dispose'
+    ])
+
+    const cleanupFailureEvents: string[] = []
+    installInstrumentedRouterFactory(cleanupFailureEvents, {
+      failInstallAt: 4,
+      failUninstallAt: new Set([3, 1]),
+      failRouterDispose: true
+    })
+    let constructionFailure: unknown
+    try {
+      createApplicationCommandComposition(source)
+    } catch (error) {
+      constructionFailure = error
+    }
+    expect(constructionFailure).toBeInstanceOf(AggregateError)
+    expect(
+      (constructionFailure as AggregateError).errors.map((error) => (error as Error).message)
+    ).toEqual([
+      'install failed:4',
+      'uninstall failed:3',
+      'uninstall failed:1',
+      'router dispose failed'
+    ])
+    expect(cleanupFailureEvents.slice(5)).toEqual([
+      'uninstall:3',
+      'uninstall:2',
+      'uninstall:1',
+      'uninstall:0',
+      'router:dispose'
+    ])
+
+    const disposeFailureEvents: string[] = []
+    let disposedRemoteAccessHandler:
+      ((invocation: ApplicationInvocation<readonly unknown[]>) => unknown) | undefined
+    installInstrumentedRouterFactory(disposeFailureEvents, {
+      failUninstallAt: new Set([10, 3]),
+      failRouterDispose: true,
+      onRegisterGroup: (groupName, handlers) => {
+        if (groupName !== 'remote-access') return
+        disposedRemoteAccessHandler = (
+          handlers as Record<
+            string,
+            (invocation: ApplicationInvocation<readonly unknown[]>) => unknown
+          >
+        )['remote-access:get-snapshot']
+      }
+    })
+    const disposeFailure = createApplicationCommandComposition(source)
+    let disposalFailure: unknown
+    try {
+      disposeFailure.dispose()
+    } catch (error) {
+      disposalFailure = error
+    }
+    expect(disposalFailure).toBeInstanceOf(AggregateError)
+    expect(
+      (disposalFailure as AggregateError).errors.map((error) => (error as Error).message)
+    ).toEqual(['uninstall failed:10', 'uninstall failed:3', 'router dispose failed'])
+    expect(disposeFailureEvents.slice(11)).toEqual([
+      'uninstall:10',
+      'uninstall:9',
+      'uninstall:8',
+      'uninstall:7',
+      'uninstall:6',
+      'uninstall:5',
+      'uninstall:4',
+      'uninstall:3',
+      'uninstall:2',
+      'uninstall:1',
+      'uninstall:0',
+      'router:dispose'
+    ])
+    expect(() => disposeFailure.dispose()).not.toThrow()
+    expect(() => disposedRemoteAccessHandler?.(invocation('remote'))).toThrow(
+      'Remote Access command owner slot is disposed.'
+    )
+
+    let remoteAccessHandler:
+      ((invocation: ApplicationInvocation<readonly unknown[]>) => unknown) | undefined
+    const slotFailureEvents: string[] = []
+    installInstrumentedRouterFactory(slotFailureEvents, {
+      failCompleteAt: 10,
+      failRouterDispose: true,
+      onRegisterGroup: (groupName, handlers) => {
+        if (groupName !== 'remote-access') return
+        remoteAccessHandler = (
+          handlers as Record<
+            string,
+            (invocation: ApplicationInvocation<readonly unknown[]>) => unknown
+          >
+        )['remote-access:get-snapshot']
+      }
+    })
+    let slotConstructionFailure: unknown
+    try {
+      createApplicationCommandComposition(source)
+    } catch (error) {
+      slotConstructionFailure = error
+    }
+    expect(slotConstructionFailure).toBeInstanceOf(AggregateError)
+    expect(
+      (slotConstructionFailure as AggregateError).errors.map((error) => (error as Error).message)
+    ).toEqual(['complete failed:10', 'router dispose failed'])
+    expect(slotFailureEvents.slice(11)).toEqual([
+      'uninstall:9',
+      'uninstall:8',
+      'uninstall:7',
+      'uninstall:6',
+      'uninstall:5',
+      'uninstall:4',
+      'uninstall:3',
+      'uninstall:2',
+      'uninstall:1',
+      'uninstall:0',
+      'router:dispose'
+    ])
+    expect(() => remoteAccessHandler?.(invocation('remote'))).toThrow(
+      'Remote Access command owner slot is disposed.'
+    )
+  })
+
+  it('routes different narrow views through one shared command owner', async () => {
+    const listProjects = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 'from-local-web' }])
+      .mockResolvedValueOnce([{ id: 'from-task' }])
+    const composition = createApplicationCommandComposition({
+      ...dependencies(),
+      dataContent: { projects: { list: listProjects } } as never
+    })
+
+    await expect(composition.localWeb.invoke('projects:list', invocation())).resolves.toEqual([
+      { id: 'from-local-web' }
+    ])
+    await expect(composition.task.invoke('projects:list', invocation())).resolves.toEqual([
+      { id: 'from-task' }
+    ])
+    expect(listProjects).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -1,0 +1,382 @@
+import { RENDERER_CONTRACT_CATALOG } from '../shared/renderer-contract-catalog'
+import {
+  acpApplicationCommands,
+  registerAcpCommands,
+  type AcpApplicationCommandDependencies
+} from './acp/application-commands'
+import {
+  createApplicationCommandRouter,
+  type ApplicationCommand,
+  type ApplicationCommandDiagnostic,
+  type ApplicationCommandInstallation,
+  type ApplicationInvocation
+} from './application-command-router'
+import {
+  computeApplicationCommandGroup,
+  registerComputeApplicationCommands,
+  type ComputeApplicationCommandDependencies
+} from './compute/application-commands'
+import {
+  dataContentApplicationCommandGroups,
+  registerDataContentApplicationCommands,
+  type DataContentApplicationCommandDependencies
+} from './data-content-application-commands'
+import {
+  hostApplicationCommandGroups,
+  registerHostApplicationCommands,
+  type HostApplicationCommandDependencies
+} from './host-application-commands'
+import {
+  installNotebookApplicationCommands,
+  notebookApplicationCommands,
+  type NotebookApplicationCommandDependencies
+} from './notebook/application-commands'
+import {
+  installNotebookEnvironmentApplicationCommands,
+  notebookEnvironmentApplicationCommands
+} from './notebook/environment-application-commands'
+import {
+  registerRuntimeApplicationCommands,
+  runtimeApplicationCommandGroup,
+  type RuntimeApplicationCommandDependencies
+} from './notebook/runtime-application-commands'
+import {
+  permissionGrantApplicationCommandGroup,
+  registerPermissionGrantApplicationCommands
+} from './permission-grants/application-commands'
+import {
+  registerCoreSettingsApplicationCommands,
+  settingsCoreApplicationCommandGroup,
+  type CoreSettingsApplicationCommandDependencies
+} from './settings/application-commands'
+import {
+  registerIntegrationSettingsApplicationCommands,
+  settingsApprovalApplicationCommandGroup,
+  settingsConnectorApplicationCommandGroup,
+  settingsSkillApplicationCommandGroup,
+  type IntegrationSettingsApplicationCommandDependencies
+} from './settings/integration-application-commands'
+import {
+  registerRuntimeSettingsApplicationCommands,
+  settingsRuntimeApplicationCommandGroup,
+  type RuntimeSettingsApplicationCommandDependencies
+} from './settings/runtime-application-commands'
+
+type AnyApplicationCommand = ApplicationCommand<string, readonly unknown[], unknown>
+type NotebookEnvironmentDependencies = Parameters<
+  typeof installNotebookEnvironmentApplicationCommands
+>[1]
+type PermissionGrantDependencies = Parameters<typeof registerPermissionGrantApplicationCommands>[1]
+type RemoteAccessOwner = HostApplicationCommandDependencies['remoteAccess']
+
+type ApplicationCommandByNameDispatcher = Readonly<{
+  invoke: (
+    commandName: string,
+    invocation: ApplicationInvocation<readonly unknown[]>
+  ) => Promise<unknown>
+  commandNames: () => readonly string[]
+}>
+
+type RemoteWebApplicationCommandDispatcher = ApplicationCommandByNameDispatcher &
+  Readonly<{ rejectedCommandNames: () => readonly string[] }>
+
+type ApplicationCommandCompositionDependencies = Readonly<{
+  acp: AcpApplicationCommandDependencies
+  notebook: NotebookApplicationCommandDependencies
+  notebookEnvironment: NotebookEnvironmentDependencies
+  notebookRuntime: RuntimeApplicationCommandDependencies
+  settingsCore: CoreSettingsApplicationCommandDependencies
+  settingsIntegration: IntegrationSettingsApplicationCommandDependencies
+  settingsRuntime: RuntimeSettingsApplicationCommandDependencies
+  compute: ComputeApplicationCommandDependencies
+  permissionGrants: PermissionGrantDependencies
+  dataContent: DataContentApplicationCommandDependencies
+  host: Omit<HostApplicationCommandDependencies, 'remoteAccess'>
+}>
+
+type ApplicationCommandComposition = Readonly<{
+  localWeb: ApplicationCommandByNameDispatcher
+  remoteWeb: RemoteWebApplicationCommandDispatcher
+  task: ApplicationCommandByNameDispatcher
+  bindRemoteAccess: (owner: RemoteAccessOwner) => void
+  dispose: () => void
+}>
+
+const GROUP_COUNT = 28
+const INTERNAL_COMMAND_COUNT = 216
+const LOCAL_WEB_COMMAND_COUNT = 214
+const REMOTE_WEB_COMMAND_COUNT = 158
+const REMOTE_REJECTED_COMMAND_COUNT = 56
+const TASK_COMMAND_COUNT = 7
+
+const ELECTRON_NATIVE_COMMAND_NAMES = Object.freeze([
+  'sessions:export-conversation',
+  'uploads:stage-local-file'
+])
+
+const TASK_COMMAND_NAMES = Object.freeze([
+  'projects:list',
+  'projects:create',
+  'sessions:load-all',
+  'sessions:save-session',
+  'artifacts:finalize-run',
+  'preview-resources:acquire',
+  'preview-resources:release'
+])
+
+const APPLICATION_COMMAND_GROUPS = Object.freeze([
+  acpApplicationCommands,
+  notebookApplicationCommands,
+  notebookEnvironmentApplicationCommands,
+  runtimeApplicationCommandGroup,
+  settingsCoreApplicationCommandGroup,
+  settingsSkillApplicationCommandGroup,
+  settingsConnectorApplicationCommandGroup,
+  settingsApprovalApplicationCommandGroup,
+  settingsRuntimeApplicationCommandGroup,
+  computeApplicationCommandGroup,
+  permissionGrantApplicationCommandGroup,
+  ...dataContentApplicationCommandGroups,
+  ...hostApplicationCommandGroups
+])
+
+const failInventory = (detail: string): never => {
+  throw new Error(`Application command inventory mismatch: ${detail}`)
+}
+
+const collectCatalogCommands = (
+  installed: (
+    installation: (typeof RENDERER_CONTRACT_CATALOG)[number]['surfaceInstallation']
+  ) => boolean
+): readonly string[] =>
+  Object.freeze(
+    RENDERER_CONTRACT_CATALOG.flatMap(({ channel, kind, surfaceInstallation }) =>
+      channel !== null && kind === 'method' && installed(surfaceInstallation) ? [channel] : []
+    ).sort()
+  )
+
+const createRemoteAccessSlot = (): Readonly<{
+  owner: RemoteAccessOwner
+  bind: (owner: RemoteAccessOwner) => void
+  dispose: () => void
+}> => {
+  let bound: RemoteAccessOwner | undefined
+  let disposed = false
+  const current = (): RemoteAccessOwner => {
+    if (disposed) throw new Error('Remote Access command owner slot is disposed.')
+    if (!bound) throw new Error('Remote Access command owner is not bound.')
+    return bound
+  }
+  const owner: RemoteAccessOwner = Object.freeze({
+    snapshot: (...args) => current().snapshot(...args),
+    detect: (...args) => current().detect(...args),
+    setMode: (...args) => current().setMode(...args),
+    disable: (...args) => current().disable(...args),
+    approve: (...args) => current().approve(...args),
+    reject: (...args) => current().reject(...args),
+    revoke: (...args) => current().revoke(...args)
+  })
+
+  return Object.freeze({
+    owner,
+    bind: (next): void => {
+      if (disposed) throw new Error('Remote Access command owner slot is disposed.')
+      if (bound) throw new Error('Remote Access command owner is already bound.')
+      bound = next
+    },
+    dispose: (): void => {
+      disposed = true
+      bound = undefined
+    }
+  })
+}
+
+const certifyInventory = (): Readonly<{
+  commands: ReadonlyMap<string, AnyApplicationCommand>
+  localWebNames: readonly string[]
+  remoteWebNames: readonly string[]
+  remoteRejectedNames: readonly string[]
+}> => {
+  if (APPLICATION_COMMAND_GROUPS.length !== GROUP_COUNT) {
+    failInventory(`expected ${GROUP_COUNT} groups, received ${APPLICATION_COMMAND_GROUPS.length}`)
+  }
+
+  const groupNames = new Set<string>()
+  const commands = new Map<string, AnyApplicationCommand>()
+  for (const group of APPLICATION_COMMAND_GROUPS) {
+    if (groupNames.has(group.name)) failInventory(`duplicate group ${group.name}`)
+    groupNames.add(group.name)
+    for (const command of group.commands) {
+      if (commands.has(command.name)) failInventory(`duplicate command ${command.name}`)
+      commands.set(command.name, command as AnyApplicationCommand)
+    }
+  }
+  if (commands.size !== INTERNAL_COMMAND_COUNT) {
+    failInventory(`expected ${INTERNAL_COMMAND_COUNT} commands, received ${commands.size}`)
+  }
+
+  const localWebNames = collectCatalogCommands(({ localWeb }) => localWeb === 'web-rpc')
+  const remoteWebNames = collectCatalogCommands(({ remoteWeb }) => remoteWeb === 'web-rpc')
+  const remoteRejectedNames = collectCatalogCommands(
+    ({ localWeb, remoteWeb }) => localWeb === 'web-rpc' && remoteWeb === 'rejecting-stub'
+  )
+  const expectedCounts = [
+    [localWebNames, LOCAL_WEB_COMMAND_COUNT, 'local Web commands'],
+    [remoteWebNames, REMOTE_WEB_COMMAND_COUNT, 'remote Web commands'],
+    [remoteRejectedNames, REMOTE_REJECTED_COMMAND_COUNT, 'remote Web rejections'],
+    [TASK_COMMAND_NAMES, TASK_COMMAND_COUNT, 'Task commands']
+  ] as const
+  for (const [names, count, label] of expectedCounts) {
+    if (names.length !== count)
+      failInventory(`expected ${count} ${label}, received ${names.length}`)
+    if (new Set(names).size !== names.length) failInventory(`${label} contains duplicate names`)
+    for (const name of names) {
+      if (!commands.has(name)) failInventory(`${label} contains unknown command ${name}`)
+    }
+  }
+
+  const nonWebNames = [...commands.keys()].filter((name) => !localWebNames.includes(name)).sort()
+  if (nonWebNames.join('\n') !== [...ELECTRON_NATIVE_COMMAND_NAMES].sort().join('\n')) {
+    failInventory(`unexpected Electron-native commands ${nonWebNames.join(', ')}`)
+  }
+  const remotePartition = new Set([...remoteWebNames, ...remoteRejectedNames])
+  if (
+    remotePartition.size !== localWebNames.length ||
+    localWebNames.some((name) => !remotePartition.has(name))
+  ) {
+    failInventory('remote dispatch and rejection inventories do not partition local Web')
+  }
+
+  return Object.freeze({ commands, localWebNames, remoteWebNames, remoteRejectedNames })
+}
+
+const createApplicationCommandComposition = (
+  dependencies: ApplicationCommandCompositionDependencies,
+  onDiagnostic?: (diagnostic: ApplicationCommandDiagnostic) => void
+): ApplicationCommandComposition => {
+  const certified = certifyInventory()
+  const router = createApplicationCommandRouter(onDiagnostic)
+  const remoteAccess = createRemoteAccessSlot()
+  const installations: ApplicationCommandInstallation[] = []
+  let disposed = false
+
+  const installers = [
+    () => registerAcpCommands(router.registrar, dependencies.acp),
+    () => installNotebookApplicationCommands(router.registrar, dependencies.notebook),
+    () =>
+      installNotebookEnvironmentApplicationCommands(
+        router.registrar,
+        dependencies.notebookEnvironment
+      ),
+    () => registerRuntimeApplicationCommands(router.registrar, dependencies.notebookRuntime),
+    () => registerCoreSettingsApplicationCommands(router.registrar, dependencies.settingsCore),
+    () =>
+      registerIntegrationSettingsApplicationCommands(
+        router.registrar,
+        dependencies.settingsIntegration
+      ),
+    () =>
+      registerRuntimeSettingsApplicationCommands(router.registrar, dependencies.settingsRuntime),
+    () => registerComputeApplicationCommands(router.registrar, dependencies.compute),
+    () =>
+      registerPermissionGrantApplicationCommands(router.registrar, dependencies.permissionGrants),
+    () => registerDataContentApplicationCommands(router.registrar, dependencies.dataContent),
+    () =>
+      registerHostApplicationCommands(router.registrar, {
+        ...dependencies.host,
+        remoteAccess: remoteAccess.owner
+      })
+  ] as const
+
+  try {
+    for (const install of installers) installations.push(install())
+  } catch (error) {
+    const failures: unknown[] = [error]
+    for (const installation of [...installations].reverse()) {
+      try {
+        installation.uninstall()
+      } catch (cleanupError) {
+        failures.push(cleanupError)
+      }
+    }
+    try {
+      router.dispose()
+    } catch (cleanupError) {
+      failures.push(cleanupError)
+    }
+    remoteAccess.dispose()
+    if (failures.length > 1) {
+      throw new AggregateError(failures, 'Application command composition failed.')
+    }
+    throw error
+  }
+
+  const view = (
+    names: readonly string[],
+    rejectedNames: readonly string[] = []
+  ): ApplicationCommandByNameDispatcher => {
+    const allowed = new Set(names)
+    const rejected = new Set(rejectedNames)
+    return Object.freeze({
+      commandNames: (): readonly string[] => names,
+      invoke: (commandName, invocation): Promise<unknown> => {
+        if (rejected.has(commandName)) {
+          return Promise.reject(
+            new Error(`Application command is rejected before dispatch: ${commandName}`)
+          )
+        }
+        if (!allowed.has(commandName)) {
+          return Promise.reject(
+            new Error(`Application command is unavailable in this view: ${commandName}`)
+          )
+        }
+        return router.dispatcher.invoke(certified.commands.get(commandName)!, invocation)
+      }
+    })
+  }
+
+  const localWeb = view(certified.localWebNames)
+  const remoteDispatcher = view(certified.remoteWebNames, certified.remoteRejectedNames)
+  const remoteWeb = Object.freeze({
+    ...remoteDispatcher,
+    rejectedCommandNames: (): readonly string[] => certified.remoteRejectedNames
+  })
+  const task = view(TASK_COMMAND_NAMES)
+
+  return Object.freeze({
+    localWeb,
+    remoteWeb,
+    task,
+    bindRemoteAccess: remoteAccess.bind,
+    dispose: (): void => {
+      if (disposed) return
+      disposed = true
+      const failures: unknown[] = []
+      for (const installation of [...installations].reverse()) {
+        try {
+          installation.uninstall()
+        } catch (error) {
+          failures.push(error)
+        }
+      }
+      try {
+        router.dispose()
+      } catch (error) {
+        failures.push(error)
+      }
+      remoteAccess.dispose()
+      if (failures.length > 0) {
+        throw new AggregateError(failures, 'Application command composition cleanup failed.')
+      }
+    }
+  })
+}
+
+export { createApplicationCommandComposition }
+export type {
+  ApplicationCommandByNameDispatcher,
+  ApplicationCommandComposition,
+  ApplicationCommandCompositionDependencies,
+  RemoteAccessOwner,
+  RemoteWebApplicationCommandDispatcher
+}


### PR DESCRIPTION
# refactor(main): compose application command core

## Problem

Application command groups are individually owned, but their inventory and lifecycle still lack one
transport-neutral composition boundary. Web, Task, and Electron wiring therefore cannot migrate to a
shared state owner without either duplicating registration or exposing the full command router.

## Proposed change

- Add one composition Module for the existing 11 registrar families / 28 groups / 216 commands.
- Expose only by-name views for local Web (214), remote Web (158 dispatchable + 56 fail-closed
  rejections), and Task (7).
- Own fixed-order install, reverse rollback/disposal, cleanup error aggregation, and one-shot
  fail-closed Remote Access late binding.
- Keep production transport consumers at zero; T2h0f2 will construct owners and wire Electron, then
  T2h1 will cut Web and Task over.

```mermaid
flowchart LR
  G["11 existing registrar families\n28 groups / 216 commands"] --> C["Application command composition"]
  C --> L["Local Web view\n214"]
  C --> R["Remote Web view\n158 dispatch + 56 reject"]
  C --> T["Task view\n7"]
  RA["Remote Access owner\ncreated later"] -->|"one-shot late bind"| C
  L -. "no transport consumer in this PR" .-> X["T2h0f2 / T2h1"]
  R -.-> X
  T -.-> X
```

Related to #458. This PR adds only a future command-group seam; it does not add orchestrator groups,
tools, events, session hierarchy, budgets, plans, persistence, UI/CLI/SDK APIs, or provider-specific
semantics.

## Scope and non-goals

- No wire contract, persisted data, data relationship, or user interaction change.
- No Electron, local Web, remote Web, Task, or CLI capability change.
- Specialist remains Electron-only at the public surface; Permission and Compute asymmetries remain
  unchanged.
- No production owner construction or IPC/index wiring.
- No registrar, full dispatcher, router factory, or diagnostic inventory is exposed.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- Composition lifecycle, narrow-view behavior, and router behavior ->
  `npm test -- --run src/main/application-command-composition.test.ts src/main/application-command-router.test.ts`
  -> passed.
- Renderer catalog, surface inventory/matrix, and Web RPC contract ->
  `npm test -- --run src/shared/renderer-contract-catalog.test.ts src/shared/renderer-surface-inventory.test.ts src/shared/renderer-surface-matrix.test.ts src/shared/web-rpc-contract.test.ts`
  -> passed.
- Combined final targeted impact set -> the six suites above -> 39/39 passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Linted source -> `npm run lint -- --no-cache` -> passed with 0 errors and 17 pre-existing warnings.
- Changed-file formatting -> Prettier check -> passed.
- Patch whitespace -> `git diff --check` -> passed.
- Independent Standards/Spec review -> 0 hard violations, 0 judgment items.

The impact set includes the owner Module, router Interface, renderer capability catalog, surface
inventory/matrix, and Web RPC contract. There are no production consumers in this PR, so no
consumer, browser, Electron E2E, persistence, migration, build, or platform lane is added locally.
The authoritative PR Gate may select additional lanes. The uncovered risk is production wiring,
deliberately deferred to T2h0f2.

## Review focus

- Inventory certification and exact 214 / 158 + 56 / 7 capability partitions.
- No escape hatch to the registrar or full dispatcher.
- Reverse cleanup order, error aggregation, idempotence, and Remote Access fail-closed behavior.
- Ordinary production raw remains below the 500-line hard stop (382 lines).
