### PR TITLE
fix(conversation): ignore replayed Branch message events

### DIFF
--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -2043,6 +2043,58 @@ describe('truncateSessionFromMessage', () => {
     expect(useSessionStore.getState().sessions[0].branchContextResetRequired).toBe(true)
   })
 
+  it('does not replay an original Branch event onto an edited Branch', () => {
+    seedSession({
+      messages: [
+        createMessage('user-1', 'user', baseTime),
+        createMessage('agent-1', 'agent', baseTime + 100),
+        createMessage('user-2', 'user', baseTime + 200),
+        createMessage('agent-2', 'agent', baseTime + 300, {
+          streamId: 'assistant-2',
+          responseToMessageId: 'user-2',
+          eventIds: ['event-2']
+        })
+      ]
+    })
+    useSessionStore.getState().truncateSessionFromMessage('session-1', 'user-2')
+    const edited = useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'edited user-2'
+    })
+    const beforeReplay = useSessionStore.getState().sessions[0]
+
+    const replayed = useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'assistant-2',
+      eventId: 'event-2',
+      promptMessageId: 'user-2',
+      content: 'agent-2 content'
+    })
+
+    const afterReplay = useSessionStore.getState().sessions[0]
+    expect(replayed?.messageId).toBe('agent-2')
+    expect(afterReplay).toBe(beforeReplay)
+    expect(afterReplay.messages.map((message) => message.id)).toEqual([
+      'user-1',
+      'agent-1',
+      edited?.messageId
+    ])
+
+    const collidingEvent = useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'assistant-edited',
+      eventId: 'event-2',
+      promptMessageId: edited?.messageId,
+      content: 'edited agent response'
+    })
+    expect(collidingEvent?.messageId).not.toBe('agent-2')
+    expect(useSessionStore.getState().sessions[0].messages.at(-1)).toMatchObject({
+      id: collidingEvent?.messageId,
+      responseToMessageId: edited?.messageId,
+      content: 'edited agent response'
+    })
+  })
+
   it('retains an edited Branch response when an unchanged finalized Artifact is switched away and back', () => {
     seedSession()
     useSessionStore.getState().truncateSessionFromMessage('session-1', 'user-2')

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -1231,6 +1231,17 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     const session = state.sessions.find((item) => item.id === sessionId)
 
     if (!session) return undefined
+    const responseToMessageId = promptMessageId ?? session.activeRun?.promptMessageId
+    const replayedGraphMessage = session.conversationGraph?.messages.find(
+      (message) =>
+        message.role === 'agent' &&
+        message.responseToMessageId === responseToMessageId &&
+        message.eventIds.includes(eventId)
+    )
+
+    // Branch switches remove downstream messages only from the flat projection. Ignore a bounded
+    // runtime event already owned by another Branch instead of appending it to the active Branch.
+    if (replayedGraphMessage) return { sessionId, messageId: replayedGraphMessage.id }
     const sessionImageBytes = session.messages.reduce(
       (total, message) =>
         total + (message.images ?? []).reduce((sum, candidate) => sum + candidate.byteLength, 0),
@@ -1248,7 +1259,6 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       (message) => message.role === 'agent' && message.streamId === streamId
     )
     const messageId = existingMessage?.id ?? createMessageId()
-    const responseToMessageId = promptMessageId ?? session.activeRun?.promptMessageId
     const now = Date.now()
 
     set({


### PR DESCRIPTION
## Problem

Switching from an interrupted conversation to an edited Message Branch removes downstream messages from the flat active projection but retains them in the durable Conversation Graph. A runtime snapshot can replay already-applied assistant events. `appendAgentMessageChunk` checked only the flat projection, so events owned by the original Branch were appended to the edited Branch, mixing messages and rendering extra `Completed` / `Usage` footers.

The dev session data confirms that the incorrect copied messages carry the exact original `eventIds`, `streamId`, and `responseToMessageId`; they are replayed events rather than newly generated model output.

## Proposed change

Deduplicate assistant chunks against `conversationGraph.messages` using the bounded event ID and prompt message ID before mutating the active flat projection. Return the existing owning message when the event was already applied.

Add a store regression test that reproduces the original-Branch replay after truncating to an edited Branch. The test also verifies that a legacy event-ID collision remains valid for a different prompt.

## Scope and non-goals

- No architecture, schema, data-model, data-relationship, or interaction change.
- No migration or rewrite of already-corrupted dev session JSON.
- No redesign of runtime event processing.

## Acceptance criteria and validation

- An assistant event already owned by an inactive Branch is not appended to the active edited Branch.
- The same legacy event ID remains accepted when it belongs to a different prompt.
- `npm test -- src/renderer/src/stores/session-store.test.ts` — 76 passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed with 17 existing unrelated warnings and 0 errors.
- `npm test` — 727 test files passed, 10,791 tests passed, with 15 files / 184 tests explicitly skipped.
- `git diff --check` — passed.

All listed checks ran after the last material edit. The store is broadly consumed, so the complete portable test suite was used in addition to the focused regression test.

Uncovered risk: session JSON already polluted by this bug is intentionally left unchanged; this patch prevents future replay pollution.

## Review focus

- Prompt-scoped Conversation Graph deduplication correctness.
- Compatibility with legacy event-ID collisions across different prompts.
