### PR TITLE
fix(workspace): filter images when replaying text-only sessions

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -2809,7 +2809,7 @@ describe('recovering from a request-size overflow', () => {
     vi.unstubAllGlobals()
   })
 
-  const seedOverflowedConversation = (): void => {
+  const seedOverflowedConversation = (includeHistoryImage = false): void => {
     // A completed prior turn (replayed as text) followed by the unanswered turn that overflowed.
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',
@@ -2824,6 +2824,14 @@ describe('recovering from a request-size overflow', () => {
       eventId: 'event-1',
       content: 'Here is what it shows'
     })
+    if (includeHistoryImage) {
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'session-1',
+        streamId: 'assistant-image-1',
+        eventId: 'image-event-1',
+        image: { mimeType: 'image/png', data: 'aGVsbG8=', byteLength: 5 }
+      })
+    }
     useSessionStore.getState().finishRun('session-1')
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',
@@ -2839,7 +2847,7 @@ describe('recovering from a request-size overflow', () => {
     vi.stubGlobal('window', {
       api: { acp: { getState: vi.fn().mockResolvedValue(createSnapshot(['session-1'])) } }
     })
-    seedOverflowedConversation()
+    seedOverflowedConversation(true)
 
     const runtime = {
       state: {
@@ -2857,7 +2865,7 @@ describe('recovering from a request-size overflow', () => {
       sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
-    const recovered = await recoverContextOverflowWorkspaceSession(runtime, 'session-1')
+    const recovered = await recoverContextOverflowWorkspaceSession(runtime, 'session-1', false)
     await flushRuntimeTasks()
 
     expect(recovered).toBe(true)
@@ -2873,6 +2881,8 @@ describe('recovering from a request-size overflow', () => {
     expect(preamble).toContain('Analyze the first screenshot')
     expect(preamble).toContain('Here is what it shows')
     expect(preamble).not.toContain('now compare with this new screenshot')
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toBeUndefined()
+    expect(runtime.sendPrompt.mock.calls[0]?.[7]).toBeUndefined()
   })
 
   it('uses native framework compaction and retries without replaying app-owned history', async () => {
@@ -2986,6 +2996,7 @@ describe('recovering from a request-size overflow', () => {
     const recovered = await recoverContextOverflowWorkspaceSession(
       runtime,
       'session-1',
+      undefined,
       cancelledSessionIds
     )
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1003,7 +1003,7 @@ describe('workspace agent message sending', () => {
     expect(useSessionStore.getState().sessions[0].branchContextResetRequired).toBe(true)
   })
 
-  it('keeps Branch replay required when selected history cannot be replayed', async () => {
+  it('clears Branch replay after filtering images for a text-only model', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',
       content: 'Inspect this upload',
@@ -1038,7 +1038,7 @@ describe('workspace agent message sending', () => {
       createSession: vi.fn(),
       resumeSession: vi.fn(),
       resetSessionContext: vi.fn().mockResolvedValue({ contextReset: true }),
-      sendPrompt: vi.fn()
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
     }
 
     await sendWorkspaceMessage(runtime, {
@@ -1048,9 +1048,12 @@ describe('workspace agent message sending', () => {
       projectId: 'project-1',
       supportsImageInput: false
     })
+    await flushRuntimeTasks()
 
-    expect(runtime.sendPrompt).not.toHaveBeenCalled()
-    expect(useSessionStore.getState().sessions[0].branchContextResetRequired).toBe(true)
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toBeUndefined()
+    expect(runtime.sendPrompt.mock.calls[0]?.[7]).toBeUndefined()
+    expect(useSessionStore.getState().sessions[0].branchContextResetRequired).toBeFalsy()
   })
 
   it('shows a new conversation prompt before ACP session creation resolves', async () => {
@@ -2707,7 +2710,7 @@ describe('resuming an interrupted session on demand', () => {
     expect(runtime.sendPrompt.mock.calls[0]?.[5]).toBeUndefined()
   })
 
-  it('blocks image replay after switching to a model without image input', async () => {
+  it('resumes, resets image history, and replays only text for a model without image input', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',
       content: 'Inspect this image',
@@ -2727,11 +2730,15 @@ describe('resuming an interrupted session on demand', () => {
       resumeSession: vi.fn().mockResolvedValue({
         sessionId: 'session-1',
         cwd: '/workspace/project',
+        frameworkId: 'codex'
+      }),
+      resetSessionContext: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        cwd: '/workspace/project',
         contextReset: true,
         frameworkId: 'codex'
       }),
-      resetSessionContext: vi.fn(),
-      sendPrompt: vi.fn()
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
     await sendWorkspaceMessage(runtime, {
@@ -2741,9 +2748,18 @@ describe('resuming an interrupted session on demand', () => {
       projectId: 'default-project',
       supportsImageInput: false
     })
+    await flushRuntimeTasks()
 
-    expect(runtime.sendPrompt).not.toHaveBeenCalled()
-    expect(useSessionStore.getState().sessions[0].error).toContain('does not support image input')
+    expect(runtime.resumeSession).toHaveBeenCalledOnce()
+    expect(runtime.resetSessionContext).toHaveBeenCalledOnce()
+    expect(runtime.resumeSession.mock.invocationCallOrder[0]).toBeLessThan(
+      runtime.resetSessionContext.mock.invocationCallOrder[0]
+    )
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt.mock.calls[0]?.[5]).toContain('Inspect this image')
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toBeUndefined()
+    expect(runtime.sendPrompt.mock.calls[0]?.[7]).toBeUndefined()
+    expect(useSessionStore.getState().sessions[0].error).toBeUndefined()
     expect(useSessionStore.getState().sessions[0].agentFrameworkId).toBe('codex')
   })
 
@@ -3859,7 +3875,7 @@ describe('edit resend reply streaming', () => {
   })
 })
 
-describe('sendWorkspaceMessage replay image gate', () => {
+describe('sendWorkspaceMessage replay image filtering', () => {
   const baseTime = 1710000000000
 
   const createMessage = (
@@ -3886,7 +3902,7 @@ describe('sendWorkspaceMessage replay image gate', () => {
     vi.unstubAllGlobals()
   })
 
-  it('blocks the replay before dispatch when the kept history has user-uploaded images', async () => {
+  it('omits user-uploaded images when replaying into a text-only model', async () => {
     useSessionStore.setState({
       ...createInitialSessionState(),
       sessions: [
@@ -3925,13 +3941,14 @@ describe('sendWorkspaceMessage replay image gate', () => {
       forceHistoryReplay: true,
       supportsImageInput: false
     })
+    await flushRuntimeTasks()
 
-    // The user turn is recorded, but the replayed upload would become an image block the model
-    // cannot take, so nothing is dispatched and the session carries the gate's error.
     expect(sent).toBeDefined()
-    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt.mock.calls[0]?.[5]).toContain('first prompt')
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toBeUndefined()
+    expect(runtime.sendPrompt.mock.calls[0]?.[7]).toBeUndefined()
     const session = useSessionStore.getState().sessions[0]
-    expect(session?.status).toBe('error')
-    expect(session?.error).toContain('image replay')
+    expect(session?.error).toBeUndefined()
   })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -63,7 +63,7 @@ type SendWorkspaceMessageInput = {
   // internal re-resume below runs against an already-attached session and can't report the reset
   // again, so this forces the prior turns to be replayed as a history preamble on the re-sent turn.
   forceHistoryReplay?: boolean
-  // Current Provider capability, injected by the hook so context replay cannot bypass image gating.
+  // Current Provider capability, injected by the hook so replay can omit unsupported image media.
   supportsImageInput?: boolean
   // Internal edit-resend seam: reset the selected runtime first, then replace the active Branch from
   // this message and replay only the retained prefix into the fresh context.
@@ -712,6 +712,13 @@ const sendWorkspaceMessage = async (
     const branchResetRequired = Boolean(
       truncateFromMessageId || currentSession?.branchContextResetRequired
     )
+    const resumeNeedsImageFiltering =
+      runtimeMustAdoptSession &&
+      supportsImageInput === false &&
+      (() => {
+        const media = buildHistoryReplayMedia(currentSession?.messages ?? [], sessionProjectName)
+        return media.images.length > 0 || media.attachments.length > 0
+      })()
     const sendPreparationRequired = branchResetRequired || runtimeMustAdoptSession
 
     if (sendPreparationRequired) {
@@ -786,8 +793,8 @@ const sendWorkspaceMessage = async (
           .markResumed(targetSessionId, resumeResult?.frameworkId, resumeResult?.backendId)
 
         // A provider may resume an existing selected-runtime session without resetting its hidden
-        // history. Branch isolation requires a fresh context even in that case, now on the adopted owner.
-        if (branchContextResetPerformed && !contextResetFromResume) {
+        // history. Branch isolation and text-only models both require a fresh context in that case.
+        if ((branchContextResetPerformed || resumeNeedsImageFiltering) && !contextResetFromResume) {
           const reset = await runtime.resetSessionContext(
             targetSessionId,
             resumeCwd,
@@ -875,15 +882,8 @@ const sendWorkspaceMessage = async (
     ) {
       historyPreamble = buildHistoryPreamble(historyMessages)
       const media = buildHistoryReplayMedia(historyMessages, sessionProjectName)
-      if (
-        supportsImageInput === false &&
-        (media.images.length > 0 || media.attachments.length > 0)
-      ) {
-        useSessionStore.getState().failRun(targetSessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
-        return appended
-      }
-      historyAttachments = media.attachments
-      historyImages = media.images
+      historyAttachments = supportsImageInput === false ? undefined : media.attachments
+      historyImages = supportsImageInput === false ? undefined : media.images
     }
 
     const resumeFallback =
@@ -892,7 +892,7 @@ const sendWorkspaceMessage = async (
             const media = buildHistoryReplayMedia(historyMessages, sessionProjectName)
             return {
               historyPreamble: buildHistoryPreamble(historyMessages),
-              historyAttachments: media.attachments,
+              historyAttachments: supportsImageInput === false ? undefined : media.attachments,
               historyImages: supportsImageInput === false ? undefined : media.images
             }
           })()

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -1187,6 +1187,7 @@ const compactWorkspaceSession = async (
 const recoverContextOverflowWorkspaceSession = async (
   runtime: WorkspaceMessageRuntime,
   sessionId: string,
+  supportsImageInput?: boolean,
   cancelledSessionIds?: Set<string>
 ): Promise<boolean> => {
   const session = useSessionStore.getState().sessions.find((item) => item.id === sessionId)
@@ -1292,6 +1293,7 @@ const recoverContextOverflowWorkspaceSession = async (
     // OpenScience to replay the prior transcript into its first prompt.
     forceHistoryReplay: !nativeCompacted,
     allowCompactionRecovery: true,
+    supportsImageInput,
     agentModel: session.agentModel
   })
 
@@ -1613,6 +1615,7 @@ const useWorkspaceAgentRuntime = (): {
         return recoverContextOverflowWorkspaceSession(
           recoveryRuntime,
           sessionId,
+          supportsImageInput,
           cancelledOverflowRecoverySessionIds.current
         )
       }


### PR DESCRIPTION
## Problem

Switching a conversation with image history to a text-only model successfully resumes the native ACP session, but the resumed Claude Agent SDK context still contains the old image blocks. The next text-only request is therefore rejected with `Model Incompatible with image`.

## Proposed change

- Keep the native `session/resume` attempt.
- When the destination model is text-only and the local history contains image media, reset the resumed Agent context through the existing context-reset path.
- Replay the text transcript while omitting historical image blocks and image uploads.
- Apply the same media filtering to the existing fallback replay path.

## Scope and non-goals

- No provider- or model-specific special case; `step-router-v1` remains configured as text-only.
- No architecture, persistence schema, or data-relationship changes.
- Local chat history and images remain visible; only the provider-bound replay omits unsupported media.
- No new prompt, banner, or notification is added.

## Acceptance criteria and validation

- Native resume remains first, then incompatible hidden image context is reset: `npm test -- src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts` -> 101 passed.
- Text-only replay preserves the text preamble and omits both historical image uploads and inline images: covered by the same 101-test module suite.
- Renderer types remain valid: `npm run typecheck:web` -> passed.
- Repository lint: `npm run lint` -> 0 errors; 17 pre-existing warnings outside the changed files.
- Portable regression suite after the final rebase: `npm test` -> 727 files passed, 15 skipped; 10,791 tests passed, 184 skipped.
- A local characterization probe using the installed Claude Agent SDK and a loopback Anthropic-compatible endpoint reproduced that native resume re-sends the old image and triggers the same 400; the probe was temporary and is not part of this PR.

Uncovered risk: no live request was sent to the Step Plan production gateway; the provider behavior is covered by the reported error and the local protocol-level reproduction.

## Review focus

- Confirm that capability downgrade resets only sessions whose replayable history contains image media.
- Confirm that text-only replay never forwards `historyAttachments` or `historyImages`.

Closes #621
