### PR TITLE
refactor(main): wire application command owners

### DIFF
--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -1,0 +1,166 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = resolve(__dirname, '../..')
+const readSource = (path: string): string => readFileSync(resolve(projectRoot, path), 'utf8')
+const compact = (source: string): string => source.replace(/\s+/g, ' ').trim()
+const occurrences = (source: string, token: string): number => source.split(token).length - 1
+
+const between = (source: string, start: string, end: string): string => {
+  const startIndex = source.indexOf(start)
+  const endIndex = source.indexOf(end, startIndex + start.length)
+  if (startIndex < 0 || endIndex < 0) {
+    throw new Error(`Production command wiring marker is missing: ${start} -> ${end}`)
+  }
+  return source.slice(startIndex, endIndex)
+}
+
+const ipcSource = readSource('src/main/ipc.ts')
+const indexSource = readSource('src/main/index.ts')
+const runtimeSource = readSource('src/main/application-runtime.ts')
+const compositionSource = readSource('src/main/application-command-composition.ts')
+const legacyAdapterBlock = compact(
+  between(ipcSource, "declareElectronAdapter('desktop-utilities'", 'const electronSenderFor')
+)
+const dependencyBlock = compact(
+  between(
+    ipcSource,
+    'const applicationCommandDependencies:',
+    '// The shared coordinator remains the sole ACP + Notebook teardown owner.'
+  )
+)
+
+describe('production application command wiring', () => {
+  it('injects each stateful owner into both legacy Electron and command composition', () => {
+    const sharedOwners = [
+      [
+        'managedPreviewOwners',
+        'installManagedPreviewElectronAdapter(previewResources, undefined, managedPreviewOwners)',
+        'managedPreview: managedPreviewOwners'
+      ],
+      [
+        'projectHandlers',
+        'projectDeletionCoordinator, projectHandlers )',
+        'projects: projectHandlers'
+      ],
+      [
+        'projectFilesHandlers',
+        'projectDeletionCoordinator, projectFilesHandlers )',
+        'projectFiles: projectFilesHandlers'
+      ],
+      [
+        'sessionPersistenceHandlers',
+        'reviewRepository, sessionPersistenceHandlers )',
+        'sessions: sessionPersistenceHandlers'
+      ],
+      ['artifactHandlers', 'artifactHandlers )', 'artifacts: artifactHandlers'],
+      [
+        'permissionGrantProjection',
+        'registerPermissionGrantIpcAdapter(permissionGrantProjection)',
+        'permissionGrants: permissionGrantProjection'
+      ],
+      ['storageCommandOwner', 'storageCommandOwner )', 'storage: storageCommandOwner'],
+      [
+        'reviewerCommandOwner',
+        'registerReviewerIpcHandlers(reviewerOptions, reviewerCommandOwner)',
+        'reviewer: reviewerCommandOwner'
+      ],
+      [
+        'updateCommandOwner',
+        'registerUpdateIpcHandlers(updateStrategy, updateCommandOwner)',
+        'update: updateCommandOwner'
+      ],
+      ['cliCommandOwner', 'registerCliInstallIpcHandlers(cliCommandOwner)', 'cli: cliCommandOwner'],
+      [
+        'githubCommandOwner',
+        'registerGithubIpcHandlers({}, githubCommandOwner)',
+        'github: githubCommandOwner'
+      ],
+      ['logsCommandOwner', 'registerLogsIpcHandlers(logsCommandOwner)', 'logs: logsCommandOwner'],
+      [
+        'uploadCommandOwner',
+        'registerUploadIpcHandlers(uploadCommandOwner, {',
+        'uploads: uploadCommandOwner'
+      ],
+      [
+        'conversationExportService',
+        'registerConversationExportIpcHandler(conversationExportService)',
+        'conversationExportService.exportConversation('
+      ]
+    ] as const
+
+    for (const [owner, electronUse, compositionUse] of sharedOwners) {
+      expect(legacyAdapterBlock, `${owner} must be used by the legacy Electron adapter`).toContain(
+        electronUse
+      )
+      expect(dependencyBlock, `${owner} must be used by command composition`).toContain(
+        compositionUse
+      )
+    }
+
+    expect(compact(ipcSource)).toContain(
+      'electronAdapters: { beforeCompute: beforeComputeAdapters, compute: computeIpcModule,'
+    )
+    expect(dependencyBlock).toContain('compute: computeIpcModule.handlers')
+    expect(dependencyBlock).toContain('enabledHosts: hostsRegistry')
+  })
+
+  it('keeps native-only commands inside the Electron owner adapter and exposes only narrow views', () => {
+    const electronOwner = compact(
+      between(dependencyBlock, 'electron: {', 'events: applicationEvents')
+    )
+    expect(occurrences(electronOwner, 'exportConversationFromInvokingWindow')).toBe(1)
+    expect(occurrences(electronOwner, 'stageLocalFileWithProgress')).toBe(1)
+    expect(compositionSource).toContain("'sessions:export-conversation'")
+    expect(compositionSource).toContain("'uploads:stage-local-file'")
+
+    const returnedViews = compact(
+      between(ipcSource, 'return {\n    applicationCommands:', '    applicationEvents,')
+    )
+    expect(returnedViews).toContain('localWeb: applicationCommandComposition.localWeb')
+    expect(returnedViews).toContain('remoteWeb: applicationCommandComposition.remoteWeb')
+    expect(returnedViews).toContain('task: applicationCommandComposition.task')
+    expect(occurrences(returnedViews, 'applicationCommandComposition.')).toBe(3)
+  })
+
+  it('adds transport adapters after composition and disposes the router before its owners', () => {
+    const backendModule = ipcSource.indexOf("name: 'backend-shutdown-coordinator'")
+    const commandModule = ipcSource.indexOf("name: 'application-command-composition'")
+    expect(backendModule).toBeGreaterThan(-1)
+    expect(commandModule).toBeGreaterThan(backendModule)
+    expect(compact(ipcSource)).toContain('dispose: () => composition.dispose()')
+
+    const build = runtimeSource.indexOf('const built = await createModules(modules)')
+    const install = runtimeSource.indexOf(
+      'const installation = await installAdapters(built.electronAdapters)'
+    )
+    const ownAdapter = runtimeSource.indexOf('await modules.add(installation, (installed) => ({')
+    expect(build).toBeGreaterThan(-1)
+    expect(install).toBeGreaterThan(build)
+    expect(ownAdapter).toBeGreaterThan(install)
+    expect(runtimeSource).toContain("await modules.dispose('rollback')")
+  })
+
+  it('late-binds the unique Remote Access owner and leaves command views unconsumed', () => {
+    const startup = compact(
+      between(
+        indexSource,
+        'const remoteAccess = await RemoteAccessService.create()',
+        '// A launch that itself requested serving'
+      )
+    )
+    expect(occurrences(indexSource, 'RemoteAccessService.create()')).toBe(1)
+    expect(startup).toMatch(
+      /const remoteAccess = await RemoteAccessService\.create\(\) bindRemoteAccess\(remoteAccess\) const webController = createWebServiceController\(\{[^}]*externalAccess: remoteAccess\.webAccess/
+    )
+    expect(startup).toContain('remoteAccess.attachWebController(webController)')
+    expect(startup).toContain('registerRemoteAccessIpcHandlers(remoteAccess)')
+
+    expect(occurrences(ipcSource, 'applicationCommands')).toBe(2)
+    expect(indexSource).not.toContain('applicationCommands')
+    expect(readSource('src/main/web-service/index.ts')).not.toContain('applicationCommands')
+    expect(readSource('src/main/tasks/task-runner.ts')).not.toContain('applicationCommands')
+  })
+})

--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -21,7 +21,8 @@ import { ArtifactRepository } from './repository'
 import {
   createArtifactHandlers,
   createDefaultArtifactRepository,
-  registerArtifactIpcHandlers
+  registerArtifactIpcHandlers,
+  type ArtifactHandlers
 } from './ipc'
 import { ArtifactRunRegistry } from './run-registry'
 import {
@@ -34,10 +35,17 @@ import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-c
 // Capture every ipcMain.handle registration so registerArtifactIpcHandlers can be verified directly.
 // The mock is set up here (before importing the IPC module) so registering handlers in tests is
 // observable without depending on a real Electron process.
-const ipcHandlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
+const { ipcHandlers, registrationFailure } = vi.hoisted(() => ({
+  ipcHandlers: new Map<string, (event: unknown, payload: unknown) => unknown>(),
+  registrationFailure: {
+    channel: undefined as string | undefined,
+    error: undefined as Error | undefined
+  }
+}))
 vi.mock('electron', () => ({
   ipcMain: {
     handle: (channel: string, handler: (event: unknown, payload: unknown) => unknown) => {
+      if (registrationFailure.channel === channel) throw registrationFailure.error
       ipcHandlers.set(channel, handler)
     }
   },
@@ -82,6 +90,8 @@ afterEach(async () => {
 // registrations from a prior test case. Individual tests re-register as needed.
 beforeEach(() => {
   ipcHandlers.clear()
+  registrationFailure.channel = undefined
+  registrationFailure.error = undefined
 })
 
 describe('artifact IPC handlers', () => {
@@ -753,6 +763,67 @@ describe('artifact IPC handler registration', () => {
       'artifacts:read-preview',
       'artifacts:reconcile-pending'
     ])
+  })
+
+  it('shares the injected artifact finalization lock with application commands', async () => {
+    let releaseFinalize!: () => void
+    const finalizePending = new Promise<ArtifactFile[]>((resolve) => {
+      releaseFinalize = () => resolve([])
+    })
+    const repository = {
+      finalizeRunArtifacts: vi.fn().mockReturnValue(finalizePending),
+      listMessageFiles: vi.fn().mockResolvedValue([])
+    } as unknown as ArtifactRepository
+    const runRegistry = new ArtifactRunRegistry()
+    const claimId = runRegistry.register({
+      projectName: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-1'
+    })
+    const injected = createArtifactHandlers(repository, runRegistry)
+    registerArtifactIpcHandlers(repository, runRegistry, undefined, undefined, undefined, injected)
+    const request = { claimId, messageId: 'message-1' }
+
+    const applicationFinalize = injected.finalizeRunArtifacts(request)
+    await vi.waitFor(() => expect(repository.finalizeRunArtifacts).toHaveBeenCalledOnce())
+    const electronFinalize = ipcHandlers.get('artifacts:finalize-run')?.({}, request)
+    await Promise.resolve()
+
+    expect(repository.finalizeRunArtifacts).toHaveBeenCalledOnce()
+    releaseFinalize()
+    await expect(applicationFinalize).resolves.toEqual([])
+    await expect(electronFinalize).resolves.toEqual({ ok: true, artifacts: [] })
+    expect(repository.finalizeRunArtifacts).toHaveBeenCalledOnce()
+    expect(repository.listMessageFiles).toHaveBeenCalledOnce()
+  })
+
+  it('preserves an injected handler identity when registration fails', async () => {
+    const failure = new Error('registration failed')
+    const injected: ArtifactHandlers = {
+      finalizeRunArtifacts: vi.fn(),
+      listProjectFiles: vi.fn().mockResolvedValue([]),
+      reconcilePendingArtifacts: vi.fn(),
+      openFile: vi.fn(),
+      readPreview: vi.fn(),
+      getLineage: vi.fn(),
+      getVersionProvenance: vi.fn(),
+      getVersionExecution: vi.fn(),
+      getVersionMessages: vi.fn(),
+      getVersionReview: vi.fn()
+    }
+    registrationFailure.channel = 'artifacts:finalize-run'
+    registrationFailure.error = failure
+
+    expect(() =>
+      registerArtifactIpcHandlers(undefined, undefined, undefined, undefined, undefined, injected)
+    ).toThrow(failure)
+
+    registrationFailure.channel = undefined
+    registrationFailure.error = undefined
+    registerArtifactIpcHandlers(undefined, undefined, undefined, undefined, undefined, injected)
+    await ipcHandlers.get('artifacts:list-project-files')?.({}, { projectName: 'default-project' })
+    expect(injected.listProjectFiles).toHaveBeenCalledOnce()
   })
 
   it('delegates each registered channel to the matching handler implementation', async () => {

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -341,14 +341,13 @@ const registerArtifactIpcHandlers = (
     | 'getVersionReview'
     | 'resolveVersionContent'
   >,
-  withSessionMutation?: ArtifactHandlerDependencies['withSessionMutation']
-): void => {
-  const handlers = createArtifactHandlers(repository, runRegistry, {
+  withSessionMutation?: ArtifactHandlerDependencies['withSessionMutation'],
+  handlers: ArtifactHandlers = createArtifactHandlers(repository, runRegistry, {
     getActiveArtifactRunIds,
     provenance,
     withSessionMutation
   })
-
+): void => {
   ipcMainHandle(
     'artifacts:finalize-run',
     async (_event, request: FinalizeRunArtifactsRequest): Promise<FinalizeRunArtifactsResult> => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -271,6 +271,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
       const {
         applicationEvents,
+        bindRemoteAccess,
         taskNotifications,
         settingsService,
         taskAgent,
@@ -351,6 +352,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         initialVariant
       })
       const remoteAccess = await RemoteAccessService.create()
+      bindRemoteAccess(remoteAccess)
       const webController = createWebServiceController({
         rpc: webRpc,
         requestQuit: () => app.quit(),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,7 +1,16 @@
 import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 
-import { app, BrowserWindow, net, Notification, protocol, webContents } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  net,
+  Notification,
+  protocol,
+  webContents,
+  type WebContents
+} from 'electron'
 
 import { createIpcHandlerInstallationScope, ipcMainHandle } from './ipc-handler-registry'
 import {
@@ -9,13 +18,23 @@ import {
   composeApplicationRuntimeWithAdapters,
   type ApplicationModuleBuilder
 } from './application-runtime'
+import {
+  createApplicationCommandComposition,
+  type ApplicationCommandComposition,
+  type ApplicationCommandCompositionDependencies
+} from './application-command-composition'
+import type { ApplicationInvocation } from './application-command-router'
 import { createApplicationEventModule, type ApplicationEventSource } from './application-events'
 
 import { createAcpRuntime } from './acp/runtime-composition'
 import { createAcpCreateSessionWorkflow } from './acp/create-session-workflow'
 import { createAcpHandlerWorkflows } from './acp/handler-workflows'
 import { createAcpTaskAgentPort } from './acp/task-agent-port'
-import { createDefaultArtifactRepository, registerArtifactIpcHandlers } from './artifacts/ipc'
+import {
+  createArtifactHandlers,
+  createDefaultArtifactRepository,
+  registerArtifactIpcHandlers
+} from './artifacts/ipc'
 import { ArtifactProvenanceRepository } from './artifacts/provenance-repository'
 import { ProvenanceMessageSnapshotRepository } from './artifacts/provenance-message-snapshot'
 import { ArtifactRunRegistry } from './artifacts/run-registry'
@@ -31,8 +50,8 @@ import { ConnectorRuntimeSettingsProjection } from './connectors/runtime-setting
 import { ConnectorService } from './connectors/service'
 import { registerFileSaveHandlers } from './file-save'
 import { createSessionArtifactFileResolver } from './session-artifact-file-resolver'
-import { registerCliInstallIpcHandlers } from './cli-install/ipc'
-import { registerGithubIpcHandlers } from './github-ipc'
+import { createCliCommandOwner, registerCliInstallIpcHandlers } from './cli-install/ipc'
+import { createGithubCommandOwner, registerGithubIpcHandlers } from './github-ipc'
 import {
   BackendShutdownOutcomeError,
   BackendShutdownCoordinator,
@@ -41,7 +60,7 @@ import {
   type ShutdownStepOutcome
 } from './lifecycle-shutdown'
 import { registerLifecycleIpcHandlers } from './lifecycle-broadcast'
-import { registerLogsIpcHandlers } from './logs-ipc'
+import { createLogsCommandOwner, registerLogsIpcHandlers } from './logs-ipc'
 import { registerWindowIpcHandlers } from './window-ipc'
 import { registerWindowFindIpcHandlers } from './window-find-ipc'
 import { TaskNotificationService } from './notifications/task-notifications'
@@ -60,7 +79,10 @@ import {
 } from './notebook/application'
 import { serializeProvisioner } from './notebook/environment-operation-foundation'
 import { createNotebookEnvironmentLifecycle } from './notebook/environment-lifecycle-workflows'
-import { installManagedPreviewElectronAdapter } from './managed-preview-ipc'
+import {
+  createManagedPreviewOwnerRegistry,
+  installManagedPreviewElectronAdapter
+} from './managed-preview-ipc'
 import { ManagedPreviewResources } from './managed-preview-resources'
 import type { ManagedPreviewSource } from '../shared/preview-resources'
 import {
@@ -91,12 +113,14 @@ import { prepareExternalPythonRuntime } from './notebook/venv-overlay'
 import {
   createDefaultPreviewStateRepository,
   createDefaultProjectRepository,
+  createProjectHandlers,
   registerProjectIpcHandlers
 } from './projects/ipc'
-import { registerReviewerIpcHandlers } from './reviewer/ipc'
+import { createReviewerCommandOwner, registerReviewerIpcHandlers } from './reviewer/ipc'
 import {
   createDefaultReviewRepository,
   createDefaultSessionRepository,
+  createSessionPersistenceHandlers,
   loadSessionMetadataAfterProjectRecovery,
   loadSessionsAfterProjectRecovery,
   registerSessionPersistenceIpcHandlers
@@ -105,18 +129,19 @@ import {
   createConversationExportService,
   registerConversationExportIpcHandler
 } from './session-persistence/conversation-export'
-import { registerProjectFilesIpcHandlers } from './project-files/ipc'
+import { createProjectFilesHandlers, registerProjectFilesIpcHandlers } from './project-files/ipc'
 import { createManagedFileIndexRepository } from './project-files/repository'
 import { ProjectDeletionCoordinator } from './projects/deletion-coordinator'
 import { getProjectDbClient } from './projects/prisma-client'
 import { createPermissionGrantRegistry } from './permission-grants/registry'
 import { isPermissionGrantScopeLive } from './permission-grants/scope-liveness'
-import { registerPermissionGrantIpcHandlers } from './permission-grants/ipc'
+import { registerPermissionGrantIpcAdapter } from './permission-grants/ipc'
+import { createPermissionGrantProjectionController } from './permission-grants/projection-controller'
 import { reconcilePermissionGrantOwners } from './permission-grants/reconciliation'
 import { SessionPersistenceCoordinator } from './session-persistence/coordinator'
 import { type SessionPersistenceBackend } from './session-persistence/ipc'
 import { tryDecryptKey } from './settings/crypto'
-import { registerSettingsIpcHandlers } from './settings/ipc'
+import { SETTINGS_INSTALL_LOG_CHANNEL, registerSettingsIpcHandlers } from './settings/ipc'
 import { registerLocalFsIpcHandlers } from './local-fs/ipc'
 import { LocalFsService } from './local-fs/service'
 import { getAppClaudeConfigDir } from './settings/provider-env'
@@ -155,6 +180,8 @@ import { SessionBindingService } from './specialist/session-binding'
 import { SPECIALIST_IPC } from '../shared/specialist'
 import type { AppIconPreview, AppIconVariant, RespondApprovalRequest } from '../shared/settings'
 import { registerStorageIpcHandlers } from './storage/ipc'
+import { createStorageCommandOwner } from './storage/command-owner'
+import { withDataRootWrite } from './storage/migration-state'
 import { normalizeLegacyDataPaths } from './storage/normalize-legacy-paths'
 import { detectActiveSessions } from './storage/detect-active'
 import {
@@ -165,7 +192,7 @@ import {
   resolveStorageRoot,
   samePath
 } from './storage-root'
-import { registerUpdateIpcHandlers } from './update/ipc'
+import { createUpdateCommandOwner, registerUpdateIpcHandlers } from './update/ipc'
 import { createUpdateStrategy } from './update/create-strategy'
 import { startUpdateScheduler } from './update/scheduler'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './uploads/ipc'
@@ -197,7 +224,9 @@ type IpcRegistrationOptions = {
 }
 
 export type ApplicationRuntimeInterfaces = {
+  applicationCommands: Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>
   applicationEvents: ApplicationEventSource
+  bindRemoteAccess: ApplicationCommandComposition['bindRemoteAccess']
   taskNotifications: Pick<
     TaskNotificationService,
     'setActivationHandler' | 'setAttentionHandlers' | 'setPendingOpenSession' | 'setUnreadHandler'
@@ -384,6 +413,7 @@ const createApplicationModules = async (
   const previewResources = new ManagedPreviewResources({
     resolvePath: resolveManagedFilePath
   })
+  const managedPreviewOwners = createManagedPreviewOwnerRegistry(previewResources)
 
   // Permission scope validation starts before the ACP coordinator is constructed. Keep the late-bound
   // reference here so a first-turn Session grant can recognize its live owner before the renderer's
@@ -435,6 +465,12 @@ const createApplicationModules = async (
     reviewRepository,
     artifactProvenanceRepository,
     permissionGrantRegistry
+  )
+  const projectHandlers = createProjectHandlers(projectRepository, projectDeletionCoordinator)
+  const projectFilesHandlers = createProjectFilesHandlers(
+    projectFilesRepository,
+    sessionPersistenceCoordinator,
+    projectDeletionCoordinator
   )
   // Stashed host.agents.switch bindings for sessions that are not yet durable (fresh unsent drafts),
   // flushed to disk on the session's first save so an approved switch survives an app restart before
@@ -885,11 +921,14 @@ const createApplicationModules = async (
       )
     )
 
+  const cliCommandOwner = createCliCommandOwner()
+  const githubCommandOwner = createGithubCommandOwner()
+  const logsCommandOwner = createLogsCommandOwner()
   declareElectronAdapter('desktop-utilities', () => {
     registerFileSaveHandlers({ resolveManagedFilePath, resolveSessionArtifactFilePath })
-    registerLogsIpcHandlers()
-    registerGithubIpcHandlers()
-    registerCliInstallIpcHandlers()
+    registerLogsIpcHandlers(logsCommandOwner)
+    registerGithubIpcHandlers({}, githubCommandOwner)
+    registerCliInstallIpcHandlers(cliCommandOwner)
     registerWindowIpcHandlers()
     registerWindowFindIpcHandlers()
   })
@@ -1031,6 +1070,7 @@ const createApplicationModules = async (
   const updateStrategy = createUpdateStrategy(process.platform, {
     installGate: () => shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
   })
+  const updateCommandOwner = createUpdateCommandOwner(updateStrategy)
   let stopUpdateScheduler: (() => void) | undefined
   await modules.add(undefined, () => ({
     name: 'update-scheduler',
@@ -1038,14 +1078,46 @@ const createApplicationModules = async (
     dispose: () => stopUpdateScheduler?.()
   }))
   declareElectronAdapter('update', () => {
-    const updateService = registerUpdateIpcHandlers(updateStrategy)
-    stopUpdateScheduler = startUpdateScheduler(updateService)
+    registerUpdateIpcHandlers(updateStrategy, updateCommandOwner)
+    stopUpdateScheduler = startUpdateScheduler(updateStrategy)
   })
+  const permissionGrantProjection = await modules.add(
+    {
+      registry: permissionGrantRegistry,
+      projects: {
+        list: async () => {
+          await projectDeletionCoordinator.recoverPendingDeletions()
+          return projectRepository.list()
+        }
+      },
+      sessions: {
+        metadataSnapshot: () =>
+          loadSessionMetadataAfterProjectRecovery(
+            projectDeletionCoordinator,
+            sessionPersistenceCoordinator
+          )
+      },
+      connectors: {
+        get: async () => ({
+          ...(await settingsService.getConnectors()),
+          bundledConnectorIds: ALL_CONNECTOR_IDS
+        })
+      }
+    },
+    (dependencies) => {
+      const owner = createPermissionGrantProjectionController({
+        ...dependencies,
+        publishChanged: (payload) => broadcastToRenderers('permissions:changed', payload)
+      })
+      return {
+        name: 'permission-grant-projection',
+        capability: owner,
+        dispose: () => owner.dispose()
+      }
+    }
+  )
   // Spawn-config changes rotate the coordinator's runtime for future sessions. Existing sessions retain
   // their owning runtime, so a framework/provider switch cannot interrupt an in-flight turn.
-  let invalidatePermissionProjection = (): void => {
-    broadcastToRenderers('permissions:changed', { revision: Date.now() })
-  }
   const settingsWorkflows = createSettingsWorkflows(settingsService, {
     runtime: {
       requestProviderReconnect: () => void runtime.requestProviderReconnect(),
@@ -1054,7 +1126,7 @@ const createApplicationModules = async (
     },
     skills: { requestSkillsReload: () => void runtime.requestSkillsReload() },
     connectors: {
-      invalidatePermissionProjection: () => invalidatePermissionProjection(),
+      invalidatePermissionProjection: () => permissionGrantProjection.invalidateProjection(),
       refreshConnectorSkillDocs: () => connectorRuntimeSettings.refresh(),
       requestSkillsReload: () => void runtime.requestSkillsReload(),
       pruneCustomServerPermissions: (serverId) =>
@@ -1083,6 +1155,10 @@ const createApplicationModules = async (
     await originalDeleteSession(projectId, sessionId)
     sessionBindingService.clearSession(sessionId)
   }
+  const sessionPersistenceHandlers = createSessionPersistenceHandlers(
+    sessionPersistenceBackend,
+    reviewRepository
+  )
   const specialistPersistLog = createLogger('specialist:persist')
   declareElectronAdapter('specialist', () =>
     registerSpecialistIpcHandlers(
@@ -1144,7 +1220,7 @@ const createApplicationModules = async (
     registerRuntimeIpcHandlers(runtimeSelectionWorkflows)
   )
   declareElectronAdapter('managed-preview', () =>
-    installManagedPreviewElectronAdapter(previewResources)
+    installManagedPreviewElectronAdapter(previewResources, undefined, managedPreviewOwners)
   )
   declareElectronAdapter('office-preview-runtime', () =>
     registerOfficePreviewRuntimeProtocol(
@@ -1281,14 +1357,30 @@ const createApplicationModules = async (
   }
 
   // Registered after the acp/notebook handlers exist: migration needs to interrupt both runtimes.
+  const storageCommandOwner = createStorageCommandOwner({
+    runtime,
+    notebook: notebookService,
+    getActivePromptSessions: () => runtime.getActivePromptSessions(),
+    settingsService
+  })
   declareElectronAdapter('storage', () =>
-    registerStorageIpcHandlers({
-      runtime,
-      notebook: notebookService,
-      getActivePromptSessions: () => runtime.getActivePromptSessions(),
-      settingsService
-    })
+    registerStorageIpcHandlers(
+      {
+        runtime,
+        notebook: notebookService,
+        getActivePromptSessions: () => runtime.getActivePromptSessions(),
+        settingsService
+      },
+      storageCommandOwner
+    )
   )
+  const artifactHandlers = createArtifactHandlers(artifactRepository, artifactRunRegistry, {
+    getActiveArtifactRunIds: () =>
+      runtimeRef.current ? runtimeRef.current.getActiveArtifactRunIds() : [],
+    provenance: artifactProvenanceRepository,
+    withSessionMutation: (projectId, sessionId, mutation) =>
+      sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
+  })
   declareElectronAdapter('artifacts', () =>
     registerArtifactIpcHandlers(
       artifactRepository,
@@ -1296,7 +1388,8 @@ const createApplicationModules = async (
       () => (runtimeRef.current ? runtimeRef.current.getActiveArtifactRunIds() : []),
       artifactProvenanceRepository,
       (projectId, sessionId, mutation) =>
-        sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
+        sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation),
+      artifactHandlers
     )
   )
   declareElectronAdapter('uploads', () =>
@@ -1318,52 +1411,34 @@ const createApplicationModules = async (
     )
   })
   declareElectronAdapter('session-persistence', () =>
-    registerSessionPersistenceIpcHandlers(sessionPersistenceBackend, reviewRepository)
-  )
-  declareElectronAdapter('conversation-export', () =>
-    registerConversationExportIpcHandler(
-      createConversationExportService({
-        loadSession: (projectId, sessionId) => sessionRepository.loadSession(projectId, sessionId),
-        isSessionActive: (projectId, sessionId) =>
-          runtime
-            .getActivePromptSessions()
-            .some(
-              (activeSession) =>
-                activeSession.projectName === projectId && activeSession.sessionId === sessionId
-            )
-      })
+    registerSessionPersistenceIpcHandlers(
+      sessionPersistenceBackend,
+      reviewRepository,
+      sessionPersistenceHandlers
     )
   )
-  declareElectronAdapter('permission-grants', () => {
-    const permissionGrantIpc = registerPermissionGrantIpcHandlers({
-      registry: permissionGrantRegistry,
-      projects: {
-        list: async () => {
-          await projectDeletionCoordinator.recoverPendingDeletions()
-          return projectRepository.list()
-        }
-      },
-      sessions: {
-        metadataSnapshot: () =>
-          loadSessionMetadataAfterProjectRecovery(
-            projectDeletionCoordinator,
-            sessionPersistenceCoordinator
-          )
-      },
-      connectors: {
-        get: async () => ({
-          ...(await settingsService.getConnectors()),
-          bundledConnectorIds: ALL_CONNECTOR_IDS
-        })
-      }
-    })
-    invalidatePermissionProjection = permissionGrantIpc.invalidateProjection
+  const conversationExportService = createConversationExportService({
+    loadSession: (projectId, sessionId) => sessionRepository.loadSession(projectId, sessionId),
+    isSessionActive: (projectId, sessionId) =>
+      runtime
+        .getActivePromptSessions()
+        .some(
+          (activeSession) =>
+            activeSession.projectName === projectId && activeSession.sessionId === sessionId
+        )
   })
+  declareElectronAdapter('conversation-export', () =>
+    registerConversationExportIpcHandler(conversationExportService)
+  )
+  declareElectronAdapter('permission-grants', () =>
+    registerPermissionGrantIpcAdapter(permissionGrantProjection)
+  )
   declareElectronAdapter('project-files', () =>
     registerProjectFilesIpcHandlers(
       projectFilesRepository,
       sessionPersistenceCoordinator,
-      projectDeletionCoordinator
+      projectDeletionCoordinator,
+      projectFilesHandlers
     )
   )
   // Backs the "This computer" browser; shares localFsService with the managed-preview resolver.
@@ -1372,7 +1447,8 @@ const createApplicationModules = async (
     registerProjectIpcHandlers(
       projectRepository,
       previewStateRepository,
-      projectDeletionCoordinator
+      projectDeletionCoordinator,
+      projectHandlers
     )
   )
   declareElectronAdapter('lifecycle', () => registerLifecycleIpcHandlers())
@@ -1382,17 +1458,115 @@ const createApplicationModules = async (
   // and 'reviewer:get-for-session' so the renderer's fire-and-forget reviewer calls resolve to
   // real handlers instead of no-ops. Passing the already-constructed AcpRuntime so the reviewer
   // can spawn sessions under the same agent connection.
+  const reviewerOptions = {
+    acpRuntime: runtime,
+    artifactProvenanceRepository,
+    withSessionMutation: <Result>(
+      projectId: string,
+      sessionId: string,
+      mutation: () => Promise<Result>
+    ) => sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
+  }
+  const reviewerCommandOwner = createReviewerCommandOwner(reviewerOptions)
   declareElectronAdapter('reviewer', () => {
-    registerReviewerIpcHandlers({
-      acpRuntime: runtime,
-      artifactProvenanceRepository,
-      withSessionMutation: (projectId, sessionId, mutation) =>
-        sessionPersistenceCoordinator.runSessionMutation(projectId, sessionId, mutation)
-    })
+    registerReviewerIpcHandlers(reviewerOptions, reviewerCommandOwner)
   })
 
-  // The shared coordinator is the sole normal owner of ACP + Notebook teardown. Register it last so
-  // reverse disposal executes the existing bounded backend shutdown before supporting modules stop.
+  const electronSenderFor = (
+    invocation: ApplicationInvocation<readonly unknown[]>
+  ): WebContents => {
+    const senderId = Number(invocation.callerContext.clientId)
+    const sender =
+      Number.isSafeInteger(senderId) && senderId > 0 ? webContents.fromId(senderId) : null
+    if (!sender || sender.isDestroyed()) {
+      throw new Error('Electron command caller is no longer available.')
+    }
+    return sender
+  }
+  const applicationCommandDependencies: ApplicationCommandCompositionDependencies = {
+    acp: { runtime, workflows: acpHandlerWorkflows },
+    notebook: {
+      workflows: notebookCommands,
+      readInputPreview: (request) => notebookInputRegistry.readPreview(request)
+    },
+    notebookEnvironment: notebookEnvironmentLifecycle,
+    notebookRuntime: {
+      workflows: runtimeSelectionWorkflows,
+      pickInterpreter: async () => {
+        const result = await dialog.showOpenDialog({ properties: ['openFile'] })
+        return result.filePaths[0] ?? null
+      }
+    },
+    settingsCore: {
+      service: settingsService,
+      appearance: settingsWorkflows.appearance,
+      emitInstallEvent: (event) => broadcastToRenderers(SETTINGS_INSTALL_LOG_CHANNEL, event),
+      listAppIconPreviews
+    },
+    settingsIntegration: {
+      skills: settingsWorkflows.skills,
+      connectors: settingsWorkflows.connectors,
+      connectorApprovals: approvalBroker,
+      skillImportApprovals: skillImportApprovalBroker
+    },
+    settingsRuntime: { workflows: settingsWorkflows.runtime },
+    compute: {
+      compute: computeIpcModule.handlers,
+      bookmarks: {
+        get: (providerId) => settingsService.getComputeBookmarks(providerId),
+        set: (providerId, folders) => settingsService.setComputeBookmarks(providerId, folders)
+      },
+      enabledHosts: hostsRegistry
+    },
+    permissionGrants: permissionGrantProjection,
+    dataContent: {
+      artifacts: artifactHandlers,
+      electron: {
+        exportConversationFromInvokingWindow: (invocation) => {
+          const sender = electronSenderFor(invocation)
+          return conversationExportService.exportConversation(
+            invocation.args[0],
+            BrowserWindow.fromWebContents(sender) ?? undefined
+          )
+        },
+        stageLocalFileWithProgress: (invocation) => {
+          const sender = electronSenderFor(invocation)
+          return uploadCommandOwner.stageLocalFile(invocation, {
+            report: (progress) => sender.send('uploads:transfer-progress', progress)
+          })
+        }
+      },
+      events: applicationEvents,
+      managedPreview: managedPreviewOwners,
+      preview: {
+        load: (request) => previewStateRepository.get(request.projectId),
+        save: (request) => previewStateRepository.save(request.projectId, request.state),
+        delete: (request) => previewStateRepository.delete(request.projectId)
+      },
+      projectFiles: projectFilesHandlers,
+      projects: projectHandlers,
+      sessions: sessionPersistenceHandlers,
+      uploads: uploadCommandOwner,
+      withDataRootWrite
+    },
+    host: {
+      cli: cliCommandOwner,
+      github: githubCommandOwner,
+      localFs: localFsService,
+      logs: logsCommandOwner,
+      notifications: {
+        peekPendingOpenSession: () => taskNotifications.peekPendingOpenSession(),
+        takePendingOpenSession: (expectedToken) =>
+          taskNotifications.takePendingOpenSession(expectedToken)
+      },
+      reviewer: reviewerCommandOwner,
+      storage: storageCommandOwner,
+      update: updateCommandOwner
+    }
+  }
+
+  // The shared coordinator remains the sole ACP + Notebook teardown owner. Register command routing
+  // after it so reverse disposal removes adapters, then the router, before any underlying owner stops.
   await modules.add({ shutdownCoordinator }, ({ shutdownCoordinator: coordinator }) => ({
     name: 'backend-shutdown-coordinator',
     capability: undefined,
@@ -1400,9 +1574,26 @@ const createApplicationModules = async (
     dispose: async () => BackendShutdownOutcomeError.assertClean(await coordinator.runForQuit())
   }))
   backendTeardownOwnedByCoordinator = true
+  const applicationCommandComposition = await modules.add(
+    applicationCommandDependencies,
+    (dependencies) => {
+      const composition = createApplicationCommandComposition(dependencies)
+      return {
+        name: 'application-command-composition',
+        capability: composition,
+        dispose: () => composition.dispose()
+      }
+    }
+  )
 
   return {
+    applicationCommands: {
+      localWeb: applicationCommandComposition.localWeb,
+      remoteWeb: applicationCommandComposition.remoteWeb,
+      task: applicationCommandComposition.task
+    },
     applicationEvents,
+    bindRemoteAccess: applicationCommandComposition.bindRemoteAccess,
     taskNotifications,
     settingsService,
     taskAgent,

--- a/src/main/managed-preview-ipc.test.ts
+++ b/src/main/managed-preview-ipc.test.ts
@@ -500,6 +500,23 @@ describe('managed preview IPC handlers', () => {
     expect(() => registerManagedPreviewIpcHandlers(resources, retryOwners)).not.toThrow()
   })
 
+  it('installs the protocol adapter over an explicitly shared owner registry', () => {
+    handlers.clear()
+    const resources = createResources()
+    const targetProtocol = { handle: vi.fn(), unhandle: vi.fn() }
+    const owners = {
+      acquire: vi.fn<ManagedPreviewOwnerRegistry['acquire']>(),
+      readRange: vi.fn<ManagedPreviewOwnerRegistry['readRange']>(),
+      register: vi.fn<ManagedPreviewOwnerRegistry['register']>(),
+      release: vi.fn<ManagedPreviewOwnerRegistry['release']>()
+    } satisfies ManagedPreviewOwnerRegistry
+
+    const cleanup = installManagedPreviewElectronAdapter(resources, targetProtocol, owners)
+
+    expect(createManagedPreviewOwnerRegistry(resources)).toBe(owners)
+    cleanup()
+  })
+
   it('releases a newly bound owner when protocol teardown fails', () => {
     handlers.clear()
     const resources = createResources()

--- a/src/main/managed-preview-ipc.ts
+++ b/src/main/managed-preview-ipc.ts
@@ -178,9 +178,10 @@ const registerManagedPreviewIpcHandlers = (
 
 const installManagedPreviewElectronAdapter = (
   resources: ManagedPreviewResources,
-  targetProtocol?: PreviewProtocolRegistrar
+  targetProtocol?: PreviewProtocolRegistrar,
+  injectedOwners?: ManagedPreviewOwnerRegistry
 ): (() => void) => {
-  const cleanupOwners = registerManagedPreviewIpcHandlers(resources)
+  const cleanupOwners = registerManagedPreviewIpcHandlers(resources, injectedOwners)
   try {
     const unregisterProtocol = registerManagedPreviewProtocol(resources, targetProtocol)
     return () => {

--- a/src/main/project-files/ipc.test.ts
+++ b/src/main/project-files/ipc.test.ts
@@ -3,17 +3,25 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createProjectFilesHandlers,
   registerProjectFilesIpcHandlers,
+  type ProjectFilesHandlers,
   type ProjectFilesQueryRepository,
   type ProjectFilesRecoveryBackend,
   type ProjectFilesRepairBackend
 } from './ipc'
 
 // Capture ipcMain.handle registrations so the registered handler can be invoked directly from tests.
-const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
+const { handlers, registrationFailure } = vi.hoisted(() => ({
+  handlers: new Map<string, (event: unknown, payload: unknown) => unknown>(),
+  registrationFailure: {
+    channel: undefined as string | undefined,
+    error: undefined as Error | undefined
+  }
+}))
 
 vi.mock('electron', () => ({
   ipcMain: {
     handle: (channel: string, handler: (event: unknown, payload: unknown) => unknown) => {
+      if (registrationFailure.channel === channel) throw registrationFailure.error
       handlers.set(channel, handler)
     }
   }
@@ -173,6 +181,8 @@ describe('registerProjectFilesIpcHandlers', () => {
 
   beforeEach(() => {
     handlers.clear()
+    registrationFailure.channel = undefined
+    registrationFailure.error = undefined
     repository = {
       getOverview: vi.fn().mockResolvedValue({
         totalCount: 0,
@@ -201,6 +211,61 @@ describe('registerProjectFilesIpcHandlers', () => {
     expect(handlers.has('project-files:list-artifact-groups')).toBe(true)
     expect(handlers.has('project-files:search-artifacts')).toBe(true)
     expect(handlers.has('project-files:repair-index')).toBe(true)
+  })
+
+  it('dispatches through the injected application handler identity', async () => {
+    const overview = {
+      totalCount: 0,
+      uploadCount: 0,
+      artifactCount: 0,
+      artifactGroupCount: 0,
+      isIndexComplete: true
+    }
+    const injected: ProjectFilesHandlers = {
+      getOverview: vi.fn().mockResolvedValue(overview),
+      listFiles: vi.fn(),
+      listArtifactGroups: vi.fn(),
+      searchArtifacts: vi.fn(),
+      repairIndex: vi.fn()
+    }
+
+    registerProjectFilesIpcHandlers(repository, repairBackend, recoveryBackend, injected)
+
+    await expect(invoke('project-files:get-overview', { projectId: 'project-1' })).resolves.toBe(
+      overview
+    )
+    expect(injected.getOverview).toHaveBeenCalledWith({ projectId: 'project-1' })
+    expect(repository.getOverview).not.toHaveBeenCalled()
+    expect(recoveryBackend.recoverPendingDeletions).not.toHaveBeenCalled()
+  })
+
+  it('preserves an injected handler identity when registration fails', async () => {
+    const failure = new Error('registration failed')
+    const injected: ProjectFilesHandlers = {
+      getOverview: vi.fn().mockResolvedValue({
+        totalCount: 0,
+        uploadCount: 0,
+        artifactCount: 0,
+        artifactGroupCount: 0,
+        isIndexComplete: true
+      }),
+      listFiles: vi.fn(),
+      listArtifactGroups: vi.fn(),
+      searchArtifacts: vi.fn(),
+      repairIndex: vi.fn()
+    }
+    registrationFailure.channel = 'project-files:get-overview'
+    registrationFailure.error = failure
+
+    expect(() =>
+      registerProjectFilesIpcHandlers(repository, repairBackend, recoveryBackend, injected)
+    ).toThrow(failure)
+
+    registrationFailure.channel = undefined
+    registrationFailure.error = undefined
+    registerProjectFilesIpcHandlers(repository, repairBackend, recoveryBackend, injected)
+    await invoke('project-files:get-overview', { projectId: 'project-1' })
+    expect(injected.getOverview).toHaveBeenCalledOnce()
   })
 
   it('get-overview handler waits for deletion recovery before reading the overview', async () => {

--- a/src/main/project-files/ipc.ts
+++ b/src/main/project-files/ipc.ts
@@ -68,10 +68,13 @@ const createProjectFilesHandlers = (
 const registerProjectFilesIpcHandlers = (
   repository: ProjectFilesQueryRepository,
   repairBackend: ProjectFilesRepairBackend,
-  recoveryBackend: ProjectFilesRecoveryBackend
+  recoveryBackend: ProjectFilesRecoveryBackend,
+  handlers: ProjectFilesHandlers = createProjectFilesHandlers(
+    repository,
+    repairBackend,
+    recoveryBackend
+  )
 ): void => {
-  const handlers = createProjectFilesHandlers(repository, repairBackend, recoveryBackend)
-
   ipcMainHandle('project-files:get-overview', (_event, request: GetProjectFilesOverviewRequest) =>
     handlers.getOverview(request)
   )

--- a/src/main/projects/ipc.test.ts
+++ b/src/main/projects/ipc.test.ts
@@ -3,24 +3,32 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PreviewStateRepository } from './preview-repository'
 import type { ProjectRepository } from './repository'
 
-const { broadcastLifecycleEvent, ipcHandlers } = vi.hoisted(() => ({
+const { broadcastLifecycleEvent, ipcHandlers, registrationFailure } = vi.hoisted(() => ({
   broadcastLifecycleEvent: vi.fn(),
-  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>()
+  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>(),
+  registrationFailure: {
+    channel: undefined as string | undefined,
+    error: undefined as Error | undefined
+  }
 }))
 
 vi.mock('electron', () => ({
   ipcMain: {
-    handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+      if (registrationFailure.channel === channel) throw registrationFailure.error
       ipcHandlers.set(channel, handler)
+    }
   }
 }))
 vi.mock('../lifecycle-broadcast', () => ({ broadcastLifecycleEvent }))
 
-import { createProjectHandlers, registerProjectIpcHandlers } from './ipc'
+import { createProjectHandlers, registerProjectIpcHandlers, type ProjectHandlers } from './ipc'
 
 beforeEach(() => {
   ipcHandlers.clear()
   broadcastLifecycleEvent.mockClear()
+  registrationFailure.channel = undefined
+  registrationFailure.error = undefined
 })
 
 describe('createProjectHandlers', () => {
@@ -152,6 +160,67 @@ describe('createProjectHandlers', () => {
     expect(previewRepository.get).toHaveBeenCalledWith('project-1')
     expect(previewRepository.save).toHaveBeenCalledWith('project-1', previewState)
     expect(previewRepository.delete).toHaveBeenCalledWith('project-1')
+  })
+
+  it('dispatches project commands through the injected application handler identity', async () => {
+    const repository = {
+      list: vi.fn(),
+      get: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn()
+    } as unknown as ProjectRepository
+    const previewRepository = {
+      get: vi.fn(),
+      save: vi.fn(),
+      delete: vi.fn()
+    } as unknown as PreviewStateRepository
+    const deletionCoordinator = {
+      deleteProject: vi.fn(),
+      recoverPendingDeletions: vi.fn()
+    }
+    const injected: ProjectHandlers = {
+      list: vi.fn().mockResolvedValue([project]),
+      get: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn()
+    }
+
+    registerProjectIpcHandlers(repository, previewRepository, deletionCoordinator, injected)
+
+    await expect(ipcHandlers.get('projects:list')?.()).resolves.toEqual([project])
+    expect(injected.list).toHaveBeenCalledOnce()
+    expect(repository.list).not.toHaveBeenCalled()
+    expect(deletionCoordinator.recoverPendingDeletions).not.toHaveBeenCalled()
+  })
+
+  it('preserves an injected project handler identity when registration fails', async () => {
+    const failure = new Error('registration failed')
+    const repository = {} as ProjectRepository
+    const previewRepository = {} as PreviewStateRepository
+    const deletionCoordinator = {
+      deleteProject: vi.fn(),
+      recoverPendingDeletions: vi.fn()
+    }
+    const injected: ProjectHandlers = {
+      list: vi.fn().mockResolvedValue([]),
+      get: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn()
+    }
+    registrationFailure.channel = 'projects:list'
+    registrationFailure.error = failure
+
+    expect(() =>
+      registerProjectIpcHandlers(repository, previewRepository, deletionCoordinator, injected)
+    ).toThrow(failure)
+
+    registrationFailure.channel = undefined
+    registrationFailure.error = undefined
+    registerProjectIpcHandlers(repository, previewRepository, deletionCoordinator, injected)
+    await ipcHandlers.get('projects:list')?.()
+    expect(injected.list).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/main/projects/ipc.ts
+++ b/src/main/projects/ipc.ts
@@ -75,10 +75,9 @@ const createProjectHandlers = (
 const registerProjectIpcHandlers = (
   repository: ProjectRepository,
   previewRepository: PreviewStateRepository,
-  deletionCoordinator: ProjectDeleteHandler
+  deletionCoordinator: ProjectDeleteHandler,
+  handlers: ProjectHandlers = createProjectHandlers(repository, deletionCoordinator)
 ): void => {
-  const handlers = createProjectHandlers(repository, deletionCoordinator)
-
   ipcMainHandle('projects:list', () => handlers.list())
   ipcMainHandle('projects:get', (_event, id: string) => handlers.get(id))
   ipcMainHandle('projects:create', async (_event, request: CreateProjectRequest) => {

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -4,19 +4,26 @@ import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { Logger } from '../logger'
 import type { ReviewRepository } from '../reviewer/repository'
 
-const { broadcastLifecycleEvent, getLifecycleClientId, ipcHandlers } = vi.hoisted(() => ({
-  broadcastLifecycleEvent: vi.fn(),
-  getLifecycleClientId: vi.fn(
-    (event: { sender: { id: number; lifecycleClientId?: string } }) =>
-      event.sender.lifecycleClientId ?? `electron:${event.sender.id}`
-  ),
-  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>()
-}))
+const { broadcastLifecycleEvent, getLifecycleClientId, ipcHandlers, registrationFailure } =
+  vi.hoisted(() => ({
+    broadcastLifecycleEvent: vi.fn(),
+    getLifecycleClientId: vi.fn(
+      (event: { sender: { id: number; lifecycleClientId?: string } }) =>
+        event.sender.lifecycleClientId ?? `electron:${event.sender.id}`
+    ),
+    ipcHandlers: new Map<string, (...args: unknown[]) => unknown>(),
+    registrationFailure: {
+      channel: undefined as string | undefined,
+      error: undefined as Error | undefined
+    }
+  }))
 
 vi.mock('electron', () => ({
   ipcMain: {
-    handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+      if (registrationFailure.channel === channel) throw registrationFailure.error
       ipcHandlers.set(channel, handler)
+    }
   }
 }))
 vi.mock('../lifecycle-broadcast', () => ({
@@ -29,7 +36,8 @@ import {
   loadSessionMetadataAfterProjectRecovery,
   loadSessionsAfterProjectRecovery,
   registerSessionPersistenceIpcHandlers,
-  type SessionPersistenceBackend
+  type SessionPersistenceBackend,
+  type SessionPersistenceHandlers
 } from './ipc'
 import { beginMigration, clearMigrationPending } from '../storage/migration-state'
 
@@ -37,6 +45,8 @@ beforeEach(() => {
   ipcHandlers.clear()
   broadcastLifecycleEvent.mockClear()
   getLifecycleClientId.mockClear()
+  registrationFailure.channel = undefined
+  registrationFailure.error = undefined
 })
 afterEach(() => clearMigrationPending())
 
@@ -321,6 +331,56 @@ describe('session persistence IPC handlers', () => {
       originClientId: 'web:browser-1'
     })
     expect(broadcastLifecycleEvent).toHaveBeenCalledWith('session:deleted', deleteRequest)
+  })
+
+  it('dispatches through the injected application handler identity', async () => {
+    const loadResult = { sessions: [createSession()], manifest: { version: 1 as const } }
+    const repository: SessionPersistenceBackend = {
+      loadAll: vi.fn(),
+      saveSession: vi.fn(),
+      deleteSession: vi.fn(),
+      saveManifest: vi.fn()
+    }
+    const injected: SessionPersistenceHandlers = {
+      loadAll: vi.fn().mockResolvedValue(loadResult),
+      saveSession: vi.fn(),
+      deleteSession: vi.fn(),
+      saveManifest: vi.fn()
+    }
+
+    registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository(), injected)
+
+    await expect(ipcHandlers.get('sessions:load-all')?.()).resolves.toBe(loadResult)
+    expect(injected.loadAll).toHaveBeenCalledOnce()
+    expect(repository.loadAll).not.toHaveBeenCalled()
+  })
+
+  it('preserves an injected handler identity when registration fails', async () => {
+    const failure = new Error('registration failed')
+    const repository: SessionPersistenceBackend = {
+      loadAll: vi.fn(),
+      saveSession: vi.fn(),
+      deleteSession: vi.fn(),
+      saveManifest: vi.fn()
+    }
+    const injected: SessionPersistenceHandlers = {
+      loadAll: vi.fn().mockResolvedValue({ sessions: [], manifest: { version: 1 as const } }),
+      saveSession: vi.fn(),
+      deleteSession: vi.fn(),
+      saveManifest: vi.fn()
+    }
+    registrationFailure.channel = 'sessions:load-all'
+    registrationFailure.error = failure
+
+    expect(() =>
+      registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository(), injected)
+    ).toThrow(failure)
+
+    registrationFailure.channel = undefined
+    registrationFailure.error = undefined
+    registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository(), injected)
+    await ipcHandlers.get('sessions:load-all')?.()
+    expect(injected.loadAll).toHaveBeenCalledOnce()
   })
 
   it('rejects session persistence while a data-root migration is pending', async () => {

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -129,10 +129,12 @@ const createDefaultReviewRepository = (): ReviewRepository =>
 // Registers renderer-callable persistence commands without coupling them to ACP runtime IPC.
 const registerSessionPersistenceIpcHandlers = (
   repository: SessionPersistenceBackend,
-  reviewRepository = createDefaultReviewRepository()
+  reviewRepository = createDefaultReviewRepository(),
+  handlers: SessionPersistenceHandlers = createSessionPersistenceHandlers(
+    repository,
+    reviewRepository
+  )
 ): void => {
-  const handlers = createSessionPersistenceHandlers(repository, reviewRepository)
-
   // Keep persistence IPC separate from ACP runtime commands; it owns durable UI state only.
   // loadAll can replay pending deletions and every mutation can materialize provenance/upload bytes.
   // Hold the shared data-root lease at the IPC boundary so migration drains the complete operation.


### PR DESCRIPTION
# refactor(main): wire application command owners

## Problem

The transport-neutral composition core merged in #710, but the production runtime still constructs
several stateful command handlers inside legacy Electron adapters. Without one production assembly
point, Electron and the future Web/Task command views could accidentally use different owner
instances, duplicate locks/projections, or dispose them in the wrong order.

## Proposed change

- Construct one production instance for each stateful command owner and inject that same identity
  into both the existing Electron registrar and the application command composition.
- Cover Projects, Project Files, Sessions, Artifacts, Managed Preview, Permission, Storage,
  Reviewer, Update, CLI, GitHub, Logs, Upload, and Conversation Export; reuse the existing Compute,
  ACP, Notebook, Settings, Local FS, and event owners.
- Adapt the two Electron-native commands through the existing Conversation Export and Upload owners.
- Add the command composition after the backend coordinator so application-runtime reverse disposal
  remains Electron adapters -> command composition/router -> backend and underlying owners.
- Bind the one `RemoteAccessService` instance created by `index.ts` into the composition exactly
  once before attaching its Web controller and legacy IPC adapter.
- Return the three narrow command views for the later T2h1 cutover, without activating a Web/Task
  consumer in this PR.

```mermaid
flowchart TD
  O["Single production owner instances"] --> E["Existing Electron adapters"]
  O --> C["Application command composition"]
  C --> L["Local Web view (unconsumed)"]
  C --> R["Remote Web view (unconsumed)"]
  C --> T["Task view (unconsumed)"]
  RA["One RemoteAccessService from index.ts"] -->|"one-shot bind"| C

  subgraph Shutdown["Reverse disposal"]
    D1["Electron adapters"] --> D2["Composition / router"] --> D3["Backend and owners"]
  end
```

Related to #458 only as a future command-group seam. This PR adds no orchestrator group, tool,
event, session hierarchy, budget, plan, persistence, UI/CLI/SDK API, or provider-specific behavior.

## Scope and non-goals

- No public wire contract, data model, data relationship, persisted data, or user interaction change.
- No Web or Task transport cutover; T2h1 owns that step.
- Electron/local Web/remote Web/Task/CLI capabilities remain unchanged.
- Specialist remains publicly Electron-only. Permission remains Electron/Web with the existing
  Task/CLI profile/event subset. Compute remains complete on Electron/local Web, keeps remote Web
  download/reveal rejection, and adds no direct CLI management API.
- No second Remote Access service and no Issue #458 orchestration semantics.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Production owner identity, native Electron commands, module/adapter order, Remote Access binding,
  and zero Web/Task consumers ->
  `npm test -- --run src/main/application-command-wiring.test.ts` -> 4/4 passed.
- Changed legacy Electron injection seams and owner behavior -> targeted suites for Artifacts,
  Managed Preview, Project Files, Projects, Sessions, Permission, Storage, Update, Reviewer, and
  Upload -> passed.
- Composition/runtime and all affected registrar families -> targeted suites for application
  composition/runtime, ACP, Notebook, Settings, Compute, Data Content, Host, and Permission ->
  passed.
- Combined exact Test Impact Set -> the 23 project-owned suites above -> 268/268 passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Post-rebase confirmation on `origin/main@a064e24` -> production assembly contract 4/4 and
  `npm run typecheck:node` -> passed.
- Linted source -> `npm run lint -- --no-cache` -> passed with 0 errors and 17 baseline warnings.
- Changed-file formatting -> Prettier check across all 13 changed files -> passed.
- Patch whitespace -> `git diff --check` -> passed.
- Independent Standards and Spec reviews -> 0 findings.

The impact set includes the production assembly contract, every changed legacy adapter, the
composition/runtime lifecycle, and every affected registrar family. Renderer/preload interfaces,
wire contracts, persistence, migrations, and platform-specific implementation paths did not change,
so Web typecheck, local build, platform, and E2E lanes were excluded locally. The authoritative PR
Gate may select them. The remaining uncovered behavior is Web/Task transport cutover, deliberately
owned by T2h1.

## Review focus

- Each legacy Electron registrar and composition dependency receives the exact same owner identity.
- Remote Access is created once and bound once; no second service or replacement path exists.
- Reverse disposal removes adapters before the router and the router before underlying owners.
- No command view has an active Web/Task transport consumer yet.
- Production raw remains below the 500-line hard stop: 379 (288+/91-).
