### PR TITLE
refactor(web): use direct application commands

### DIFF
--- a/src/main/application-command-client.test.ts
+++ b/src/main/application-command-client.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ApplicationCommandByNameDispatcher } from './application-command-composition'
+import type { ApplicationInvocation } from './application-command-router'
+import { createCallerContext, createWebCallerContext } from './caller-context'
+import { createApplicationCommandClient } from './application-command-client'
+
+describe('Application command client', () => {
+  it('reuses a caller lease until release, then replaces and aborts it', async () => {
+    const invocations: ApplicationInvocation<readonly unknown[]>[] = []
+    const dispatcher: ApplicationCommandByNameDispatcher = {
+      commandNames: () => ['projects:list'],
+      invoke: vi.fn(async (_commandName, invocation) => {
+        invocations.push(invocation)
+        return invocation.args
+      })
+    }
+    const client = createApplicationCommandClient()
+    const callerContext = createWebCallerContext('browser-1')
+
+    await client.invoke(dispatcher, 'projects:list', callerContext, ['first'])
+    await client.invoke(dispatcher, 'projects:list', callerContext, ['second'])
+
+    expect(invocations[1]?.callerLease).toBe(invocations[0]?.callerLease)
+    expect(invocations[0]?.callerLease.isCurrent()).toBe(true)
+
+    client.releaseClient('web', 'browser-1')
+    expect(invocations[0]?.callerLease.signal.aborted).toBe(true)
+    expect(invocations[0]?.callerLease.isCurrent()).toBe(false)
+
+    await client.invoke(dispatcher, 'projects:list', callerContext, ['third'])
+    expect(invocations[2]?.callerLease).not.toBe(invocations[0]?.callerLease)
+    expect(invocations[2]?.callerLease.generation).toBeGreaterThan(
+      invocations[0]?.callerLease.generation ?? 0
+    )
+  })
+
+  it('aborts every caller on disposal and rejects later invocations as a promise', async () => {
+    let invocation: ApplicationInvocation<readonly unknown[]> | undefined
+    const dispatcher: ApplicationCommandByNameDispatcher = {
+      commandNames: () => ['projects:list'],
+      invoke: vi.fn(async (_commandName, current) => {
+        invocation = current
+        return undefined
+      })
+    }
+    const client = createApplicationCommandClient()
+    const callerContext = createWebCallerContext('browser-disposed')
+
+    await client.invoke(dispatcher, 'projects:list', callerContext, [])
+    client.dispose()
+
+    expect(invocation?.callerLease.signal.aborted).toBe(true)
+    await expect(client.invoke(dispatcher, 'projects:list', callerContext, [])).rejects.toThrow(
+      'Application command client is disposed.'
+    )
+    expect(dispatcher.invoke).toHaveBeenCalledOnce()
+  })
+
+  it('keeps caller leases isolated by surface when client ids match', async () => {
+    const invocations: ApplicationInvocation<readonly unknown[]>[] = []
+    const dispatcher: ApplicationCommandByNameDispatcher = {
+      commandNames: () => ['projects:list'],
+      invoke: vi.fn(async (_commandName, invocation) => {
+        invocations.push(invocation)
+        return undefined
+      })
+    }
+    const client = createApplicationCommandClient()
+    const web = createWebCallerContext('shared-client')
+    const task = createCallerContext({
+      clientId: 'shared-client',
+      lifecycleClientId: 'web:shared-client',
+      leaseId: 'shared-client',
+      surface: 'task',
+      location: 'local',
+      principalKind: 'automation',
+      actionOrigin: 'automation'
+    })
+
+    await client.invoke(dispatcher, 'projects:list', web, [])
+    await client.invoke(dispatcher, 'projects:list', task, [])
+    client.releaseClient('web', 'shared-client')
+
+    expect(invocations[0]?.callerLease.signal.aborted).toBe(true)
+    expect(invocations[1]?.callerLease.signal.aborted).toBe(false)
+    expect(invocations[1]?.callerLease.isCurrent()).toBe(true)
+  })
+})

--- a/src/main/application-command-client.ts
+++ b/src/main/application-command-client.ts
@@ -1,0 +1,71 @@
+import type { ApplicationCommandByNameDispatcher } from './application-command-composition'
+import {
+  ApplicationCallerLeaseRegistry,
+  callerLeaseOwnershipKeyForContext
+} from './caller-lifecycle'
+import type { CallerContext, CallerSurface } from './caller-context'
+
+type ActiveCaller = Readonly<{
+  clientId: string
+  surface: CallerSurface
+  lease: ReturnType<ApplicationCallerLeaseRegistry['acquire']>
+}>
+
+type ApplicationCommandClient = Readonly<{
+  invoke: (
+    dispatcher: ApplicationCommandByNameDispatcher,
+    commandName: string,
+    callerContext: CallerContext,
+    args: readonly unknown[]
+  ) => Promise<unknown>
+  releaseClient: (surface: CallerSurface, clientId: string) => void
+  dispose: () => void
+}>
+
+const createApplicationCommandClient = (): ApplicationCommandClient => {
+  const registry = new ApplicationCallerLeaseRegistry()
+  const callers = new Map<string, ActiveCaller>()
+  let disposed = false
+
+  const callerFor = (callerContext: CallerContext): ActiveCaller => {
+    if (disposed) throw new Error('Application command client is disposed.')
+    const key = callerLeaseOwnershipKeyForContext(callerContext)
+    const existing = callers.get(key)
+    if (existing?.lease.lease.isCurrent()) return existing
+
+    const caller = Object.freeze({
+      clientId: callerContext.clientId,
+      surface: callerContext.surface,
+      lease: registry.acquire(callerContext)
+    })
+    callers.set(key, caller)
+    return caller
+  }
+
+  return Object.freeze({
+    invoke: async (dispatcher, commandName, callerContext, args) => {
+      const caller = callerFor(callerContext)
+      return dispatcher.invoke(commandName, {
+        callerContext,
+        callerLease: caller.lease.lease,
+        args
+      })
+    },
+    releaseClient: (surface, clientId): void => {
+      for (const [key, caller] of callers) {
+        if (caller.surface !== surface || caller.clientId !== clientId) continue
+        callers.delete(key)
+        caller.lease.release()
+      }
+    },
+    dispose: (): void => {
+      if (disposed) return
+      disposed = true
+      callers.clear()
+      registry.dispose()
+    }
+  })
+}
+
+export { createApplicationCommandClient }
+export type { ApplicationCommandClient }

--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -143,7 +143,7 @@ describe('production application command wiring', () => {
     expect(runtimeSource).toContain("await modules.dispose('rollback')")
   })
 
-  it('late-binds the unique Remote Access owner and leaves command views unconsumed', () => {
+  it('late-binds the unique Remote Access owner and passes only narrow views to Web and Task', () => {
     const startup = compact(
       between(
         indexSource,
@@ -159,8 +159,15 @@ describe('production application command wiring', () => {
     expect(startup).toContain('registerRemoteAccessIpcHandlers(remoteAccess)')
 
     expect(occurrences(ipcSource, 'applicationCommands')).toBe(2)
-    expect(indexSource).not.toContain('applicationCommands')
-    expect(readSource('src/main/web-service/index.ts')).not.toContain('applicationCommands')
+    expect(indexSource).toContain('applicationCommands,')
+    expect(startup).toContain('applicationCommands,')
+    const webServiceSource = readSource('src/main/web-service/index.ts')
+    expect(webServiceSource).toContain(
+      "Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>"
+    )
+    expect(webServiceSource).toContain('{ commands: applicationCommands.task, agent: taskAgent }')
+    expect(webServiceSource).toContain('localWeb: applicationCommands.localWeb')
+    expect(webServiceSource).toContain('remoteWeb: applicationCommands.remoteWeb')
     expect(readSource('src/main/tasks/task-runner.ts')).not.toContain('applicationCommands')
   })
 })

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -290,7 +290,7 @@ describe('application surface shutdown', () => {
           }
         },
         webController: {
-          close: () => {
+          dispose: () => {
             order.push('web-controller')
           }
         },
@@ -304,13 +304,13 @@ describe('application surface shutdown', () => {
     await expect(lifecycle.shutdownBackends()).resolves.toBe('completed')
 
     expect(lifecycle.marker).toBe('electron-lifecycle')
-    expect(order).toEqual(['application-runtime', 'remote-access', 'web-controller', 'web-rpc'])
+    expect(order).toEqual(['web-controller', 'application-runtime', 'remote-access', 'web-rpc'])
   })
 
   it('diagnoses runtime failure and continues closing surfaces without rejecting lifecycle', async () => {
     const failure = new Error('backend shutdown failed')
     const shutdownRemoteAccess = vi.fn()
-    const closeWebController = vi.fn()
+    const disposeWebController = vi.fn()
     const disposeWebRpc = vi.fn()
     const log = { error: vi.fn() }
 
@@ -318,7 +318,7 @@ describe('application surface shutdown', () => {
       shutdownApplicationSurfaces({
         disposeApplicationRuntime: () => Promise.reject(failure),
         shutdownRemoteAccess,
-        closeWebController,
+        disposeWebController,
         disposeWebRpc,
         log
       })
@@ -331,20 +331,20 @@ describe('application surface shutdown', () => {
     })
     expect(JSON.stringify(log.error.mock.calls)).not.toContain('backend shutdown failed')
     expect(shutdownRemoteAccess).toHaveBeenCalledOnce()
-    expect(closeWebController).toHaveBeenCalledOnce()
+    expect(disposeWebController).toHaveBeenCalledOnce()
     expect(disposeWebRpc).toHaveBeenCalledOnce()
   })
 
   it('continues closing surfaces when the shutdown diagnostic sink throws', async () => {
     const shutdownRemoteAccess = vi.fn()
-    const closeWebController = vi.fn()
+    const disposeWebController = vi.fn()
     const disposeWebRpc = vi.fn()
 
     await expect(
       shutdownApplicationSurfaces({
         disposeApplicationRuntime: () => Promise.reject(new Error('runtime failure')),
         shutdownRemoteAccess,
-        closeWebController,
+        disposeWebController,
         disposeWebRpc,
         log: {
           error: () => {
@@ -355,7 +355,7 @@ describe('application surface shutdown', () => {
     ).resolves.toBe('failed')
 
     expect(shutdownRemoteAccess).toHaveBeenCalledOnce()
-    expect(closeWebController).toHaveBeenCalledOnce()
+    expect(disposeWebController).toHaveBeenCalledOnce()
     expect(disposeWebRpc).toHaveBeenCalledOnce()
   })
 
@@ -372,7 +372,7 @@ describe('application surface shutdown', () => {
           disposeApplicationRuntime: () =>
             Promise.reject(new BackendShutdownOutcomeError(expected)),
           shutdownRemoteAccess: vi.fn(),
-          closeWebController: vi.fn(),
+          disposeWebController: vi.fn(),
           disposeWebRpc: vi.fn(),
           log
         })

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -45,7 +45,7 @@ export type ApplicationRuntime<Interfaces> = {
 export type ApplicationSurfaceShutdown = {
   disposeApplicationRuntime(): Awaitable<void>
   shutdownRemoteAccess(): Awaitable<void>
-  closeWebController(): Awaitable<void>
+  disposeWebController(): Awaitable<void>
   disposeWebRpc(): Awaitable<void>
   log?: Pick<Logger, 'error'>
 }
@@ -53,17 +53,18 @@ export type ApplicationSurfaceShutdown = {
 export type ApplicationLifecycleShutdownDependencies = {
   disposeApplicationRuntime: ApplicationSurfaceShutdown['disposeApplicationRuntime']
   remoteAccess: { shutdown(): Awaitable<void> }
-  webController: { close(): Awaitable<void> }
+  webController: { dispose(): Awaitable<void> }
   webRpc: { dispose(): Awaitable<void> }
   log?: ApplicationSurfaceShutdown['log']
 }
 
-// Preserves the desktop quit order while guaranteeing that a failed surface cannot strand a later
-// one. Backend shutdown is owned by the application runtime and remains bounded by its coordinator.
+// Direct Web/Task adapters close before the application command router, which in turn closes before
+// its underlying RemoteAccess owner. Closing Web first can publish RemoteAccess's stopped state, but
+// this path runs only while the app is quitting. A failed surface still cannot strand a later one.
 export const shutdownApplicationSurfaces = async ({
   disposeApplicationRuntime,
   shutdownRemoteAccess,
-  closeWebController,
+  disposeWebController,
   disposeWebRpc,
   log
 }: ApplicationSurfaceShutdown): Promise<ShutdownStepOutcome> => {
@@ -107,9 +108,9 @@ export const shutdownApplicationSurfaces = async ({
     }
   }
 
+  await dispose('web-controller', disposeWebController)
   await dispose('application-runtime', disposeApplicationRuntime)
   await dispose('remote-access', shutdownRemoteAccess)
-  await dispose('web-controller', closeWebController)
   await dispose('web-rpc', disposeWebRpc)
   return overallOutcome
 }
@@ -127,7 +128,7 @@ export const createApplicationLifecycleShutdown = ({
     shutdownApplicationSurfaces({
       disposeApplicationRuntime,
       shutdownRemoteAccess: () => remoteAccess.shutdown(),
-      closeWebController: () => webController.close(),
+      disposeWebController: () => webController.dispose(),
       disposeWebRpc: () => webRpc.dispose(),
       log
     })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -270,6 +270,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       const webMode = parseWebModeOptions(process.argv)
       // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
       const {
+        applicationCommands,
         applicationEvents,
         bindRemoteAccess,
         taskNotifications,
@@ -355,6 +356,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       bindRemoteAccess(remoteAccess)
       const webController = createWebServiceController({
         rpc: webRpc,
+        applicationCommands,
         requestQuit: () => app.quit(),
         externalAccess: remoteAccess.webAccess,
         applicationEvents,

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -980,7 +980,7 @@ describe('logger: application shutdown diagnostics', () => {
           ])
         ),
       shutdownRemoteAccess: () => undefined,
-      closeWebController: () => undefined,
+      disposeWebController: () => undefined,
       disposeWebRpc: () => undefined,
       log
     })

--- a/src/main/remote-access/service.test.ts
+++ b/src/main/remote-access/service.test.ts
@@ -49,6 +49,7 @@ const webController = (port = 4180): WebServiceController => ({
     url: `http://127.0.0.1:${port}/?token=local-only`
   }),
   close: vi.fn().mockResolvedValue(undefined),
+  dispose: vi.fn().mockResolvedValue(undefined),
   closeExternalConnections: vi.fn(),
   onStopped: vi.fn(() => vi.fn()),
   isRunning: vi.fn(() => true),

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { ApplicationEventHub } from '../application-events'
+import type { ApplicationEventSource } from '../application-events'
+import type { ApplicationCommandComposition } from '../application-command-composition'
 import type { WebRpcRouter } from '../ipc-handler-registry'
+import type { TaskAgentPort } from '../tasks/task-runner'
 import { createWebServiceController, type WebServiceControllerDeps } from './index'
 
 type StartOptions = Parameters<WebServiceControllerDeps['startServer']>[0]
@@ -11,7 +14,13 @@ type StartOptions = Parameters<WebServiceControllerDeps['startServer']>[0]
 // options it was given (so the test can drive the captured onShutdownRequest).
 const makeController = (
   overrides: Partial<WebServiceControllerDeps> = {},
-  requestQuit = vi.fn()
+  requestQuit = vi.fn(),
+  applicationCommands: Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'> = {
+    localWeb: { commandNames: () => [], invoke: vi.fn() },
+    remoteWeb: { commandNames: () => [], rejectedCommandNames: () => [], invoke: vi.fn() },
+    task: { commandNames: () => [], invoke: vi.fn() }
+  },
+  runtime: { applicationEvents?: ApplicationEventSource; taskAgent?: TaskAgentPort } = {}
 ): {
   controller: ReturnType<typeof createWebServiceController>
   startServer: ReturnType<typeof vi.fn>
@@ -35,9 +44,10 @@ const makeController = (
   const controller = createWebServiceController(
     {
       rpc: {} as WebRpcRouter,
+      applicationCommands,
       requestQuit,
-      applicationEvents: new ApplicationEventHub(),
-      taskAgent: {} as never
+      applicationEvents: runtime.applicationEvents ?? new ApplicationEventHub(),
+      taskAgent: runtime.taskAgent ?? ({} as never)
     },
     {
       startServer,
@@ -69,6 +79,35 @@ const makeController = (
 }
 
 describe('createWebServiceController', () => {
+  it('passes only Web command views to the server and the narrow Task view to its façade', async () => {
+    const taskInvoke = vi.fn(async () => [])
+    const applicationCommands = {
+      localWeb: { commandNames: () => ['projects:list'], invoke: vi.fn() },
+      remoteWeb: {
+        commandNames: () => ['projects:list'],
+        rejectedCommandNames: () => [],
+        invoke: vi.fn()
+      },
+      task: { commandNames: () => ['projects:list'], invoke: taskInvoke }
+    } satisfies Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>
+    const h = makeController({}, vi.fn(), applicationCommands)
+
+    await h.controller.ensureStarted(44100, { attached: true })
+
+    expect(h.lastOptions().applicationCommands).toEqual({
+      localWeb: applicationCommands.localWeb,
+      remoteWeb: applicationCommands.remoteWeb
+    })
+    await expect(h.lastOptions().tasks?.listProjects()).resolves.toEqual([])
+    expect(taskInvoke).toHaveBeenCalledWith(
+      'projects:list',
+      expect.objectContaining({
+        callerContext: expect.objectContaining({ surface: 'task' }),
+        args: []
+      })
+    )
+  })
+
   it('starts once and records the port/url plus the attached flag in the state file', async () => {
     const h = makeController()
     const result = await h.controller.ensureStarted(44100, { attached: true })
@@ -129,6 +168,145 @@ describe('createWebServiceController', () => {
 
     await h.controller.ensureStarted(44100, { attached: true })
     expect(h.startServer).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves Task run state and its caller lease across a restartable close', async () => {
+    const project = {
+      id: 'project-1',
+      name: 'Project',
+      description: '',
+      isExample: false,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const callerSignals: AbortSignal[] = []
+    const sessions: unknown[] = []
+    const taskInvoke = vi.fn(async (name, invocation) => {
+      callerSignals.push(invocation.callerLease.signal)
+      if (name === 'projects:list') return [project]
+      if (name === 'sessions:load-all') return { sessions, manifest: { version: 1 } }
+      if (name === 'sessions:save-session') {
+        sessions.splice(0, sessions.length, invocation.args[0])
+        return undefined
+      }
+      throw new Error(`Unexpected Task command: ${name}`)
+    })
+    const applicationCommands = {
+      localWeb: { commandNames: () => [], invoke: vi.fn() },
+      remoteWeb: { commandNames: () => [], rejectedCommandNames: () => [], invoke: vi.fn() },
+      task: { commandNames: () => ['projects:list'], invoke: taskInvoke }
+    } satisfies Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>
+    const h = makeController({}, vi.fn(), applicationCommands, {
+      taskAgent: {
+        listAttachedSessionIds: vi.fn(async () => []),
+        createSession: vi.fn(async () => ({ sessionId: 'session-created' })),
+        resumeSession: vi.fn(async (request) => ({ sessionId: request.sessionId })),
+        setPermissionProfile: vi.fn(async () => undefined),
+        prompt: vi.fn(async () => undefined)
+      }
+    })
+
+    await h.controller.ensureStarted(44100, { attached: true })
+    const firstTasks = h.lastOptions().tasks!
+    const run = await firstTasks.startRun({ project: project.id, prompt: 'Research.' })
+
+    await h.controller.close()
+    expect(callerSignals.every((signal) => !signal.aborted)).toBe(true)
+
+    await h.controller.ensureStarted(44100, { attached: true })
+    const restartedTasks = h.lastOptions().tasks!
+    expect(restartedTasks).toBe(firstTasks)
+    expect(restartedTasks.getRun(run.id)).toMatchObject({ id: run.id, sessionId: run.sessionId })
+  })
+
+  it('terminal dispose is idempotent, releases Task once, and rejects later starts', async () => {
+    const unsubscribe = vi.fn()
+    const applicationEvents = { subscribe: vi.fn(() => unsubscribe) }
+    const callerSignals: AbortSignal[] = []
+    const applicationCommands = {
+      localWeb: { commandNames: () => [], invoke: vi.fn() },
+      remoteWeb: { commandNames: () => [], rejectedCommandNames: () => [], invoke: vi.fn() },
+      task: {
+        commandNames: () => ['projects:list'],
+        invoke: vi.fn(async (_name, invocation) => {
+          callerSignals.push(invocation.callerLease.signal)
+          return []
+        })
+      }
+    } satisfies Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>
+    const h = makeController({}, vi.fn(), applicationCommands, { applicationEvents })
+
+    await h.controller.ensureStarted(44100, { attached: true })
+    await h.lastOptions().tasks?.listProjects()
+    await h.controller.dispose()
+    await h.controller.dispose()
+
+    expect(h.serverClose).toHaveBeenCalledOnce()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(callerSignals[0]?.aborted).toBe(true)
+    await expect(h.controller.ensureStarted(44100, { attached: true })).rejects.toThrow(
+      'Web service controller is disposed.'
+    )
+  })
+
+  it('waits for a pending start before terminal disposal closes the server', async () => {
+    let releaseStart: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      releaseStart = resolve
+    })
+    const serverClose = vi.fn().mockResolvedValue(undefined)
+    const startServer = vi.fn(async (options: StartOptions) => {
+      await gate
+      return { port: options.port, closeExternalConnections: vi.fn(), close: serverClose }
+    })
+    const h = makeController({ startServer })
+
+    const start = h.controller.ensureStarted(44100, { attached: true })
+    const dispose = h.controller.dispose()
+    expect(serverClose).not.toHaveBeenCalled()
+    releaseStart?.()
+    await Promise.all([start, dispose])
+
+    expect(serverClose).toHaveBeenCalledOnce()
+    expect(h.removeState).toHaveBeenCalledWith('/fake/root')
+    expect(h.controller.isRunning()).toBe(false)
+  })
+
+  it('does not deadlock after start failure and still releases Task on terminal dispose', async () => {
+    const failure = new Error('listen failed')
+    const unsubscribe = vi.fn()
+    const h = makeController(
+      { startServer: vi.fn().mockRejectedValue(failure) },
+      vi.fn(),
+      undefined,
+      { applicationEvents: { subscribe: vi.fn(() => unsubscribe) } }
+    )
+
+    await expect(h.controller.ensureStarted(44100, { attached: true })).rejects.toBe(failure)
+    await expect(h.controller.dispose()).resolves.toBeUndefined()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('releases Task even when terminal server cleanup fails', async () => {
+    const failure = new Error('server close failed')
+    const unsubscribe = vi.fn()
+    const h = makeController(
+      {
+        startServer: async (options) => ({
+          port: options.port,
+          closeExternalConnections: vi.fn(),
+          close: vi.fn().mockRejectedValue(failure)
+        })
+      },
+      vi.fn(),
+      undefined,
+      { applicationEvents: { subscribe: vi.fn(() => unsubscribe) } }
+    )
+
+    await h.controller.ensureStarted(44100, { attached: true })
+    await expect(h.controller.dispose()).rejects.toBe(failure)
+    expect(h.removeState).toHaveBeenCalledWith('/fake/root')
+    expect(unsubscribe).toHaveBeenCalledOnce()
   })
 
   it('forwards remote socket closure to the running server', async () => {

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -13,9 +13,10 @@ vi.mock('electron', () => ({
 }))
 
 import { WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
-import { WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
+import { isWebRpcChannel, WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
 import { ApplicationEventHub } from '../application-events'
 import type { CallerContext } from '../caller-context'
+import type { WebRpcRouter } from '../ipc-handler-registry'
 import {
   REMOTE_LOCAL_ONLY_RPC_CHANNELS,
   startWebHttpServer,
@@ -27,9 +28,39 @@ import { TaskApiError } from './task-api'
 const roots: string[] = []
 const servers: RunningWebServer[] = []
 const applicationEvents = new ApplicationEventHub()
+type TestWebServerOptions = Omit<
+  Parameters<typeof startWebHttpServer>[0],
+  'applicationCommands' | 'applicationEvents' | 'rpc'
+> &
+  Partial<Pick<Parameters<typeof startWebHttpServer>[0], 'applicationCommands'>> & {
+    rpc: WebRpcRouter
+  }
 const startTestWebHttpServer = (
-  options: Omit<Parameters<typeof startWebHttpServer>[0], 'applicationEvents'>
-): ReturnType<typeof startWebHttpServer> => startWebHttpServer({ ...options, applicationEvents })
+  options: TestWebServerOptions
+): ReturnType<typeof startWebHttpServer> => {
+  const localNames = options.rpc.channels().filter(isWebRpcChannel)
+  const remoteRejectedNames = localNames.filter((channel) =>
+    REMOTE_LOCAL_ONLY_RPC_CHANNELS.has(channel)
+  )
+  const invokeCaptured = (
+    channel: string,
+    invocation: { callerContext: CallerContext; args: readonly unknown[] }
+  ): Promise<unknown> => options.rpc.invoke(channel, invocation.callerContext, [...invocation.args])
+
+  return startWebHttpServer({
+    ...options,
+    applicationCommands: options.applicationCommands ?? {
+      localWeb: { commandNames: () => localNames, invoke: invokeCaptured },
+      remoteWeb: {
+        commandNames: () =>
+          localNames.filter((channel) => !REMOTE_LOCAL_ONLY_RPC_CHANNELS.has(channel)),
+        rejectedCommandNames: () => remoteRejectedNames,
+        invoke: invokeCaptured
+      }
+    },
+    applicationEvents
+  })
+}
 const authorizedExternalAccess = (): ExternalWebAccessAuthorization => ({
   kind: 'authorized-pairing-manager' as const,
   isCurrent: () => true
@@ -47,6 +78,93 @@ afterEach(async () => {
 })
 
 describe('startWebHttpServer', () => {
+  it('dispatches local Web RPC through the narrow application command view', async () => {
+    const capturedInvoke = vi.fn()
+    const directInvoke = vi.fn(
+      async (
+        _channel: string,
+        invocation: { args: readonly unknown[]; callerLease: { signal: AbortSignal } }
+      ) => Promise.resolve(invocation.args[0])
+    )
+    const rpc = {
+      channels: () => ['projects:list'],
+      invoke: capturedInvoke,
+      releaseClient: vi.fn(),
+      dispose: vi.fn()
+    }
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc,
+      applicationCommands: {
+        localWeb: { commandNames: rpc.channels, invoke: directInvoke },
+        remoteWeb: {
+          commandNames: () => [],
+          rejectedCommandNames: () => ['projects:list'],
+          invoke: vi.fn()
+        }
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    const firstSocket = new WebSocket(
+      `ws://127.0.0.1:${server.port}/events?token=test-token&client=direct-client`
+    )
+    const secondSocket = new WebSocket(
+      `ws://127.0.0.1:${server.port}/events?token=test-token&client=direct-client`
+    )
+    await Promise.all([
+      new Promise<void>((resolve) => firstSocket.once('open', resolve)),
+      new Promise<void>((resolve) => secondSocket.once('open', resolve))
+    ])
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+        'x-open-science-client': 'direct-client'
+      },
+      body: JSON.stringify({
+        protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+        args: [{ source: 'direct' }]
+      })
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true, result: { source: 'direct' } })
+    expect(directInvoke).toHaveBeenCalledWith(
+      'projects:list',
+      expect.objectContaining({
+        callerContext: expect.objectContaining({
+          clientId: 'direct-client',
+          surface: 'web',
+          location: 'local'
+        }),
+        callerLease: expect.objectContaining({ leaseId: 'direct-client' }),
+        args: [{ source: 'direct' }]
+      })
+    )
+    expect(capturedInvoke).not.toHaveBeenCalled()
+
+    const directSignal = directInvoke.mock.calls[0]?.[1].callerLease.signal
+    firstSocket.close()
+    await new Promise<void>((resolve) => firstSocket.once('close', () => resolve()))
+    expect(directSignal.aborted).toBe(false)
+    secondSocket.close()
+    await new Promise<void>((resolve) => secondSocket.once('close', () => resolve()))
+    await vi.waitFor(() => expect(directSignal.aborted).toBe(true))
+  })
+
   it('releases its application-event subscription when listening fails', async () => {
     const unsubscribe = vi.fn()
     const subscribe = vi.fn(() => unsubscribe)
@@ -60,6 +178,10 @@ describe('startWebHttpServer', () => {
         invoke: vi.fn(async () => undefined),
         releaseClient: vi.fn(),
         dispose: vi.fn()
+      },
+      applicationCommands: {
+        localWeb: { commandNames: () => [], invoke: vi.fn() },
+        remoteWeb: { commandNames: () => [], rejectedCommandNames: () => [], invoke: vi.fn() }
       },
       bootstrap: {
         appName: 'Open Science',
@@ -372,16 +494,25 @@ describe('startWebHttpServer', () => {
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
     const releaseClient = vi.fn()
+    const directSignals: AbortSignal[] = []
+    const directInvoke = vi.fn(async (_channel, invocation) => {
+      directSignals.push(invocation.callerLease.signal)
+      return []
+    })
     const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
       token: 'test-token',
       staticRoot,
       rpc: {
-        channels: () => [],
+        channels: () => ['projects:list'],
         invoke: vi.fn(),
         releaseClient,
         dispose: vi.fn()
+      },
+      applicationCommands: {
+        localWeb: { commandNames: () => ['projects:list'], invoke: directInvoke },
+        remoteWeb: { commandNames: () => [], rejectedCommandNames: () => [], invoke: vi.fn() }
       },
       bootstrap: {
         appName: 'Open Science',
@@ -402,12 +533,23 @@ describe('startWebHttpServer', () => {
       new Promise<void>((resolve) => firstSocket.once('open', resolve)),
       new Promise<void>((resolve) => secondSocket.once('open', resolve))
     ])
+    await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+        'x-open-science-client': 'test-client'
+      },
+      body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+    })
+    expect(directSignals[0]?.aborted).toBe(false)
 
     await server.close()
     servers.splice(servers.indexOf(server), 1)
 
     expect(releaseClient).toHaveBeenCalledTimes(1)
     expect(releaseClient).toHaveBeenCalledWith('test-client')
+    expect(directSignals[0]?.aborted).toBe(true)
   })
 
   it('passes pairing authority only for trusted-browser Web RPC calls', async () => {
@@ -621,9 +763,11 @@ describe('startWebHttpServer', () => {
     const localOnlyChannels = [...REMOTE_LOCAL_ONLY_RPC_CHANNELS]
     const remotelyAvailableChannel = 'projects:list'
     const rpcChannels = [...localOnlyChannels, remotelyAvailableChannel]
+    const localInvoke = vi.fn(async () => ({ installed: true }))
+    const remoteInvoke = vi.fn(async () => ({ projects: [] }))
     const rpc = {
       channels: () => rpcChannels,
-      invoke: vi.fn(async () => ({ installed: true })),
+      invoke: vi.fn(),
       releaseClient: vi.fn(),
       dispose: vi.fn()
     }
@@ -633,6 +777,14 @@ describe('startWebHttpServer', () => {
       token: 'local-token',
       staticRoot,
       rpc,
+      applicationCommands: {
+        localWeb: { commandNames: () => rpcChannels, invoke: localInvoke },
+        remoteWeb: {
+          commandNames: () => [remotelyAvailableChannel],
+          rejectedCommandNames: () => localOnlyChannels,
+          invoke: remoteInvoke
+        }
+      },
       externalAccess: {
         authorizeHttp: vi.fn().mockResolvedValue(authorizedExternalAccess()),
         authorizeWebSocket: vi.fn().mockResolvedValue({})
@@ -690,7 +842,16 @@ describe('startWebHttpServer', () => {
         body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
       })
       expect(remoteResponse.status, channel).toBe(403)
+      expect(await remoteResponse.json(), channel).toEqual({
+        protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+        ok: false,
+        error: {
+          code: 'method_not_found',
+          message: `Channel only available from the local app: ${channel}`
+        }
+      })
     }
+    expect(remoteInvoke).not.toHaveBeenCalled()
     expect(rpc.invoke).not.toHaveBeenCalled()
 
     const localResponse = await fetch(rpcUrl('cli:install'), {
@@ -702,7 +863,8 @@ describe('startWebHttpServer', () => {
       body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
     })
     expect(localResponse.status).toBe(200)
-    expect(rpc.invoke).toHaveBeenCalledOnce()
+    expect(localInvoke).toHaveBeenCalledOnce()
+    expect(rpc.invoke).not.toHaveBeenCalled()
   })
 
   it('pins the remote Web Notebook capability matrix', () => {

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -16,6 +16,8 @@ import {
   createWebCallerContext,
   type CallerContext
 } from '../caller-context'
+import { createApplicationCommandClient } from '../application-command-client'
+import type { ApplicationCommandComposition } from '../application-command-composition'
 import type { WebRpcRouter } from '../ipc-handler-registry'
 import type { ApplicationEventSource } from '../application-events'
 import {
@@ -64,7 +66,8 @@ type WebServerOptions = {
   port: number
   token: string
   staticRoot: string
-  rpc: WebRpcRouter
+  rpc: Pick<WebRpcRouter, 'releaseClient'>
+  applicationCommands: Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb'>
   applicationEvents: ApplicationEventSource
   externalAccess?: ExternalWebAccess
   tasks?: Pick<
@@ -420,7 +423,11 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   const sockets = new Set<WebSocket>()
   const externalSockets = new Map<WebSocket, string | undefined>()
   const publicEventSockets = new Set<WebSocket>()
-  const clientLeases = new ClientLeaseRegistry(options.rpc.releaseClient)
+  const commandClient = createApplicationCommandClient()
+  const clientLeases = new ClientLeaseRegistry((clientId) => {
+    commandClient.releaseClient('web', clientId)
+    options.rpc.releaseClient(clientId)
+  })
   const wsServer = new WebSocketServer({ noServer: true })
 
   const server = createServer(async (request, response) => {
@@ -452,13 +459,12 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       }
 
       if (url.pathname === '/api/bootstrap' && request.method === 'GET') {
-        const allRpcChannels = options.rpc.channels().filter(isWebRpcChannel)
+        const rpcChannels = auth.ok
+          ? options.applicationCommands.localWeb.commandNames()
+          : options.applicationCommands.remoteWeb.commandNames()
         const restrictedRpcChannels = auth.ok
           ? []
-          : allRpcChannels.filter((channel) => REMOTE_LOCAL_ONLY_RPC_CHANNELS.has(channel))
-        const rpcChannels = allRpcChannels.filter(
-          (channel) => auth.ok || !REMOTE_LOCAL_ONLY_RPC_CHANNELS.has(channel)
-        )
+          : options.applicationCommands.remoteWeb.rejectedCommandNames()
         json(response, 200, {
           ...options.bootstrap,
           rpcProtocolVersion: WEB_RPC_PROTOCOL_VERSION,
@@ -576,7 +582,15 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         })
         try {
           assertExternalAuthorizationCurrent(externalAuthorization)
-          const result = await options.rpc.invoke(channel, callerContext, parsed.data.args)
+          const dispatcher = auth.ok
+            ? options.applicationCommands.localWeb
+            : options.applicationCommands.remoteWeb
+          const result = await commandClient.invoke(
+            dispatcher,
+            channel,
+            callerContext,
+            parsed.data.args
+          )
           json(response, 200, {
             protocolVersion: WEB_RPC_PROTOCOL_VERSION,
             ok: true,
@@ -687,7 +701,11 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     })
   } catch (error) {
     removeBroadcastSink()
-    clientLeases.dispose()
+    try {
+      clientLeases.dispose()
+    } finally {
+      commandClient.dispose()
+    }
     throw error
   }
 
@@ -708,7 +726,11 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       for (const socket of sockets) socket.close()
       wsServer.close()
       await new Promise<void>((resolveClose) => server.close(() => resolveClose()))
-      clientLeases.dispose()
+      try {
+        clientLeases.dispose()
+      } finally {
+        commandClient.dispose()
+      }
     }
   }
 }

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 
 import { app } from 'electron'
 
+import type { ApplicationCommandComposition } from '../application-command-composition'
 import type { WebRpcRouter } from '../ipc-handler-registry'
 import { createLogger } from '../logger'
 import type { ApplicationEventSource } from '../application-events'
@@ -25,6 +26,8 @@ export type WebServiceController = {
   ) => Promise<{ port: number; url: string }>
   // Stops the web service and removes its state file. Idempotent; safe to call when not running.
   close: () => Promise<void>
+  // Permanently closes the service and its Task adapter. Used only by application shutdown.
+  dispose: () => Promise<void>
   // Closes remotely authenticated sockets without disturbing local Web clients.
   closeExternalConnections: (sessionId?: string) => void
   // Subscribes to actual server stops, including attached shutdown requests from the CLI.
@@ -57,18 +60,20 @@ const authUrl = (token: string, port: number): string =>
 const buildAuthenticatedWebUrl = async (port: number): Promise<string> =>
   authUrl(await loadOrCreateWebToken(resolveConfigRoot()), port)
 
-// Builds the controller. `rpc` is the always-installed capture layer (so handlers registered before any
-// serving are reachable over HTTP); `requestQuit` quits the whole app when a dedicated headless daemon
-// is asked to shut down. An attached service instead only tears itself down and leaves the app running.
+// Builds the controller. `rpc` retains the always-installed captured fallback while Web and Task use
+// their application-owned narrow command views. `requestQuit` quits the whole app when a dedicated
+// headless daemon is asked to shut down. An attached service instead only tears itself down.
 const createWebServiceController = (
   {
     rpc,
+    applicationCommands,
     requestQuit,
     externalAccess,
     applicationEvents,
     taskAgent
   }: {
-    rpc: WebRpcRouter
+    rpc: Pick<WebRpcRouter, 'releaseClient'>
+    applicationCommands: Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>
     requestQuit: () => void
     externalAccess?: ExternalWebAccess
     applicationEvents: ApplicationEventSource
@@ -95,7 +100,7 @@ const createWebServiceController = (
       pid: process.pid
     }))
   const tasks = new HeadlessTaskApi(
-    { rpc, agent: taskAgent },
+    { commands: applicationCommands.task, agent: taskAgent },
     {
       subscribeEvents: (listener) =>
         applicationEvents.subscribe((event) => {
@@ -104,7 +109,6 @@ const createWebServiceController = (
         })
     }
   )
-
   let running:
     | {
         close: () => Promise<void>
@@ -114,9 +118,11 @@ const createWebServiceController = (
       }
     | undefined
   let starting: Promise<{ port: number; url: string }> | undefined
+  let disposal: Promise<void> | undefined
+  let disposed = false
   const stoppedListeners = new Set<() => void>()
 
-  const close = async (): Promise<void> => {
+  const closeRunning = async (): Promise<void> => {
     const current = running
     running = undefined
     if (!current) return
@@ -125,6 +131,25 @@ const createWebServiceController = (
     } finally {
       for (const listener of stoppedListeners) listener()
     }
+  }
+
+  const close = async (): Promise<void> => {
+    const pending = starting
+    if (pending) await pending.catch(() => undefined)
+    await closeRunning()
+  }
+
+  const dispose = (): Promise<void> => {
+    if (disposal) return disposal
+    disposed = true
+    disposal = (async () => {
+      try {
+        await close()
+      } finally {
+        tasks.dispose()
+      }
+    })()
+    return disposal
   }
 
   const start = async (port: number, attached: boolean): Promise<{ port: number; url: string }> => {
@@ -137,6 +162,10 @@ const createWebServiceController = (
       token,
       staticRoot: join(info.appPath, 'out', 'web'),
       rpc,
+      applicationCommands: {
+        localWeb: applicationCommands.localWeb,
+        remoteWeb: applicationCommands.remoteWeb
+      },
       applicationEvents,
       externalAccess,
       tasks,
@@ -174,7 +203,7 @@ const createWebServiceController = (
         attached
       })
     } catch (error) {
-      await close()
+      await closeRunning()
       throw error
     }
 
@@ -192,6 +221,7 @@ const createWebServiceController = (
     port: number,
     { attached }: { attached: boolean }
   ): Promise<{ port: number; url: string }> => {
+    if (disposed) throw new Error('Web service controller is disposed.')
     if (running) {
       const token = await loadWebToken(running.configRoot)
       return { port: running.port, url: authUrl(token, running.port) }
@@ -206,6 +236,7 @@ const createWebServiceController = (
   return {
     ensureStarted,
     close,
+    dispose,
     closeExternalConnections: (sessionId) => running?.closeExternalConnections(sessionId),
     onStopped: (listener) => {
       stoppedListeners.add(listener)

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, type MockedFunction } from 'vitest'
 
 import type { AcpRuntimeEvent } from '../../shared/acp'
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { ApplicationCommandByNameDispatcher } from '../application-command-composition'
 import { createTaskCallerContext, type CallerContext } from '../caller-context'
 import type { TaskAgentPort } from '../tasks/task-runner'
 import { HeadlessTaskApi } from './task-api'
@@ -41,7 +42,35 @@ const createAgent = (overrides: Partial<TaskAgentMock> = {}): TaskAgentMock => (
   ...overrides
 })
 
+const commandsFrom = (
+  invoke: (channel: string, callerContext: CallerContext, args: unknown[]) => Promise<unknown>
+): ApplicationCommandByNameDispatcher => ({
+  commandNames: () => [],
+  invoke: (channel, invocation) => invoke(channel, invocation.callerContext, [...invocation.args])
+})
+
 describe('HeadlessTaskApi adapter', () => {
+  it('dispatches façade operations through the narrow Task command view', async () => {
+    const commandInvoke = vi.fn(async () => [project])
+    const api = new HeadlessTaskApi({
+      commands: {
+        commandNames: () => ['projects:list'],
+        invoke: commandInvoke
+      },
+      agent: createAgent()
+    })
+
+    await expect(api.listProjects()).resolves.toEqual([project])
+    expect(commandInvoke).toHaveBeenCalledWith(
+      'projects:list',
+      expect.objectContaining({
+        callerContext: taskCallerContext(),
+        callerLease: expect.objectContaining({ leaseId: 'headless-task-api' }),
+        args: []
+      })
+    )
+  })
+
   it('maps public query and artifact commands to the compatibility façade', async () => {
     const session: PersistedChatSession = {
       id: 'session-query',
@@ -82,7 +111,7 @@ describe('HeadlessTaskApi adapter', () => {
       if (channel === 'preview-resources:release') return undefined
       throw new Error(`Unexpected RPC channel: ${channel}`)
     })
-    const api = new HeadlessTaskApi({ rpc: { invoke }, agent: createAgent() })
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent: createAgent() })
 
     await expect(api.createProject({ name: 'Created' })).resolves.toMatchObject({
       id: 'project-created',
@@ -148,7 +177,7 @@ describe('HeadlessTaskApi adapter', () => {
     })
     const ids = ['attached-user', 'attached-run', 'attached-agent']
     const api = new HeadlessTaskApi(
-      { rpc: { invoke }, agent },
+      { commands: commandsFrom(invoke), agent },
       {
         createId: () => ids.shift() ?? 'generated-id',
         subscribeEvents: (listener) => {
@@ -204,7 +233,7 @@ describe('HeadlessTaskApi adapter', () => {
     })
     const ids = ['detached-user', 'detached-run', 'detached-agent']
     const api = new HeadlessTaskApi(
-      { rpc: { invoke }, agent },
+      { commands: commandsFrom(invoke), agent },
       { createId: () => ids.shift() ?? 'generated-id' }
     )
 
@@ -247,7 +276,7 @@ describe('HeadlessTaskApi adapter', () => {
       })),
       prompt: vi.fn(async () => promptGate)
     })
-    const api = new HeadlessTaskApi({ rpc: { invoke }, agent })
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent })
     let authorizationCurrent = true
     const context = createTaskCallerContext({
       location: 'remote',
@@ -293,7 +322,7 @@ describe('HeadlessTaskApi adapter', () => {
       throw new Error(`Unexpected RPC channel: ${channel}`)
     })
     const agent = createAgent()
-    const api = new HeadlessTaskApi({ rpc: { invoke }, agent })
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent })
     const context = createTaskCallerContext({
       location: 'remote',
       isAuthorizationCurrent: () => authorizationCurrent

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -14,6 +14,8 @@ import type {
   TaskRun,
   TaskSessionSummary
 } from '../../shared/task-api'
+import { createApplicationCommandClient } from '../application-command-client'
+import type { ApplicationCommandByNameDispatcher } from '../application-command-composition'
 import { createTaskCallerContext, type CallerContext } from '../caller-context'
 import {
   TaskRunner,
@@ -26,12 +28,8 @@ import {
 
 const TASK_CALLER_CONTEXT = createTaskCallerContext()
 
-type TaskRpc = {
-  invoke(channel: string, callerContext: CallerContext, args: unknown[]): Promise<unknown>
-}
-
 type TaskApiPorts = {
-  rpc: TaskRpc
+  commands: ApplicationCommandByNameDispatcher
   agent: TaskAgentPort
 }
 
@@ -43,6 +41,7 @@ type TaskApiDependencies = {
 
 class HeadlessTaskApi {
   private readonly callerContexts = new AsyncLocalStorage<CallerContext>()
+  private readonly commandClient = createApplicationCommandClient()
   private readonly runner: TaskRunner
 
   constructor(
@@ -94,9 +93,12 @@ class HeadlessTaskApi {
         // Capability cleanup must remain available if request authorization is revoked while a
         // response stream drains. The fixed local automation context grants no new access.
         release: async (resourceId) => {
-          await this.ports.rpc.invoke('preview-resources:release', TASK_CALLER_CONTEXT, [
-            { resourceId }
-          ])
+          await this.commandClient.invoke(
+            this.ports.commands,
+            'preview-resources:release',
+            TASK_CALLER_CONTEXT,
+            [{ resourceId }]
+          )
         }
       },
       runtimeEvents: { subscribe: subscribeEvents },
@@ -106,7 +108,11 @@ class HeadlessTaskApi {
   }
 
   dispose(): void {
-    this.runner.dispose()
+    try {
+      this.runner.dispose()
+    } finally {
+      this.commandClient.dispose()
+    }
   }
 
   runWithCallerContext<Result>(context: CallerContext, operation: () => Result): Result {
@@ -154,7 +160,12 @@ class HeadlessTaskApi {
   }
 
   private invoke(channel: string, ...args: unknown[]): Promise<unknown> {
-    return this.ports.rpc.invoke(channel, this.currentCallerContext(), args)
+    return this.commandClient.invoke(
+      this.ports.commands,
+      channel,
+      this.currentCallerContext(),
+      args
+    )
   }
 
   private currentCallerContext(): CallerContext {
@@ -170,4 +181,4 @@ class HeadlessTaskApi {
 }
 
 export { HeadlessTaskApi, TaskRunnerError as TaskApiError, summarizeSession }
-export type { TaskApiDependencies, TaskApiPorts, TaskRpc }
+export type { TaskApiDependencies, TaskApiPorts }


### PR DESCRIPTION
# PR: `refactor(web): use direct application commands`

## Problem

Web and Headless Task still executed application behavior through the captured Electron IPC router.
That kept transport wiring in the ownership path after the 216-command application composition was
already available, and it would force future application capabilities such as issue #458 to pass
through Electron-specific capture.

## Proposed change

- Dispatch local Web through the exact 214-command `localWeb` view.
- Dispatch remote Web through its 158-command view while preserving the 56 local-only rejecting
  stubs and every pre-dispatch authorization gate.
- Dispatch only the existing seven-command Headless Task façade through the narrow `task` view.
- Add an application-command client that owns per-caller leases independently of transport capture.
- Keep captured IPC installed for compatibility and T2i negative certification.
- Make Web controller shutdown explicit: restartable `close()` preserves Task runs, while terminal
  `dispose()` releases Task and caller state before the application router and owners.

```mermaid
flowchart LR
  LW["Local Web (214)"] --> LC["localWeb command view"]
  RW["Remote Web (158 + 56 rejected)"] --> RC["remoteWeb command view"]
  TK["Headless Task (7)"] --> TC["task command view"]
  LC --> CC["Application command client / caller leases"]
  RC --> CC
  TC --> CC
  CC --> AR["Application command router"]
  AR --> OW["Application owners"]
  CAP["Captured IPC fallback"] -. "retained for T2i" .-> WEB["Web lifecycle release"]
```

Terminal shutdown order is now:

```text
Web/Task adapters -> application router -> RemoteAccess owner -> captured Web RPC fallback
```

## Scope and non-goals

- No public wire contract, RPC v1 envelope, event, persisted schema, data relationship, or UI change.
- Electron behavior remains on its current adapter path in this PR.
- CLI/local RPC remains unchanged and does not gain Web-only capabilities.
- Specialist, Permission, and Compute keep their current cross-surface asymmetry.
- Remote Web still receives HTTP 403 + `method_not_found` for local-only commands, with the exact
  existing message and zero dispatcher calls.
- The nine characterized Runtime positional/object deviations remain unchanged.
- This creates a provider-neutral seam for issue #458 but adds no orchestration semantics or API.
- Captured fallback removal and final negative certification belong to T2i.

## Acceptance criteria and validation

All listed checks ran after the last material edit and cover the final diff.

| Behavior | Command | Final result |
| --- | --- | --- |
| Caller lease reuse/release/disposal | `npm test -- --run src/main/application-command-client.test.ts` | Passed |
| Local/remote Web dispatch, gates, envelopes, binary/event ordering | targeted HTTP server and Web projection suites | Passed |
| Restartable close, terminal disposal, pending-start barrier | targeted controller and lifecycle suites | Passed |
| Narrow Task façade and prompt/caller ordering | targeted Task API and Task runner suites | Passed |
| Composition, wiring, surface inventory and renderer argument shapes | targeted command composition/wiring and shared/renderer contract suites | Passed |
| RemoteAccess/local filesystem compatibility | targeted service/IPC suites | Passed |
| Final targeted impact set | 22 Vitest suites / 225 tests | Passed |
| Main-process types | `npm run typecheck:node` | Passed |
| Web types | `npm run typecheck:web` | Passed after prerequisite #717 added `DOM.AsyncIterable` |
| Repository lint | `npm run lint -- --no-cache` | Passed: 0 errors, same 17 baseline warnings |
| Formatting / whitespace | Prettier check + `git diff --check` | Passed |
| Independent review | Standards + Spec | 0 findings |

Cross-platform, build, and E2E lanes were not duplicated locally; the online PR Gate classifies and
runs those checks from the final base-to-head diff. The separate main-baseline correction in #717 was
squash-merged before this PR rebased, so both Node and Web typechecks now pass locally.

## Review focus

- Confirm remote local-only rejection occurs before either direct or captured invocation.
- Confirm Task state survives restartable Web close but is released exactly once at terminal shutdown.
- Confirm adapters are disposed before the application command router and underlying owners.
- Confirm the captured path has no remaining Web/Task invocation consumer before T2i removes it.
