### PR TITLE
fix(web-types): include DOM async iterables

### DIFF
--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -10,6 +10,7 @@
   ],
   "compilerOptions": {
     "composite": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
# PR: `fix(web-types): include DOM async iterables`

## Problem

The Web TypeScript configuration includes `DOM` and `DOM.Iterable`, but current TypeScript declares
async iteration for `ReadableStream` in the separate `DOM.AsyncIterable` library. As a result,
`npm run typecheck:web` reports TS2504 for two existing main-process Responses stream loops and blocks
otherwise-green PR Gate runs.

## Proposed change

Add `DOM.AsyncIterable` to `tsconfig.web.json` while retaining the inherited `ESNext`, `DOM`, and
`DOM.Iterable` libraries.

## Scope and non-goals

- Configuration-only: no runtime code, API, wire contract, schema, data relationship, or UI change.
- Does not modify either Responses stream implementation.
- Does not change Electron, Web, CLI/Task, Specialist, Permission, or Compute behavior.
- Kept separate from runtime state-ownership PR #716.

## Acceptance criteria and validation

All checks ran after the final edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Web program recognizes `ReadableStream` async iteration | `npm run typecheck:web` | Passed, 0 errors |
| Node program remains valid | `npm run typecheck:node` | Passed, 0 errors |
| Configuration formatting | `npx prettier --check tsconfig.web.json` | Passed |
| Whitespace integrity | `git diff --check` | Passed |

Repository lint, portable tests, and platform lanes are intentionally delegated to the online PR Gate
for this one-line global validation-input change, per the approved accelerated workflow.

## Review focus

- Confirm the library addition matches the existing `for await` runtime behavior rather than changing
  either stream loop.
- Confirm no other compiler option or source file changed.
