### PR TITLE
refactor(web): remove captured IPC dispatch

### DIFF
--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -21,6 +21,14 @@ const ipcSource = readSource('src/main/ipc.ts')
 const indexSource = readSource('src/main/index.ts')
 const runtimeSource = readSource('src/main/application-runtime.ts')
 const compositionSource = readSource('src/main/application-command-composition.ts')
+const ipcRegistrySource = readSource('src/main/ipc-handler-registry.ts')
+const webAdapterSources = [
+  'src/main/application-command-client.ts',
+  'src/main/tasks/task-runner.ts',
+  'src/main/web-service/http-server.ts',
+  'src/main/web-service/index.ts',
+  'src/main/web-service/task-api.ts'
+].map(readSource)
 const legacyAdapterBlock = compact(
   between(ipcSource, "declareElectronAdapter('desktop-utilities'", 'const electronSenderFor')
 )
@@ -169,5 +177,16 @@ describe('production application command wiring', () => {
     expect(webServiceSource).toContain('localWeb: applicationCommands.localWeb')
     expect(webServiceSource).toContain('remoteWeb: applicationCommands.remoteWeb')
     expect(readSource('src/main/tasks/task-runner.ts')).not.toContain('applicationCommands')
+  })
+
+  it('keeps Web and Task direct dispatch independent from Electron IPC capture machinery', () => {
+    expect(ipcRegistrySource).not.toContain('WebIpcSender')
+    expect(ipcRegistrySource).not.toContain('webHandlers')
+    expect(ipcRegistrySource).not.toContain('nextSenderId')
+    for (const source of webAdapterSources) {
+      expect(source).not.toContain('ipc-handler-registry')
+      expect(source).not.toContain('IpcMainInvokeEvent')
+      expect(source).not.toContain('sender.id')
+    }
   })
 })

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -294,24 +294,27 @@ describe('application surface shutdown', () => {
             order.push('web-controller')
           }
         },
-        webRpc: {
-          dispose: () => {
-            order.push('web-rpc')
-          }
+        disposeIpcHandlers: () => {
+          order.push('ipc-handlers')
         }
       }
     )
     await expect(lifecycle.shutdownBackends()).resolves.toBe('completed')
 
     expect(lifecycle.marker).toBe('electron-lifecycle')
-    expect(order).toEqual(['web-controller', 'application-runtime', 'remote-access', 'web-rpc'])
+    expect(order).toEqual([
+      'web-controller',
+      'application-runtime',
+      'remote-access',
+      'ipc-handlers'
+    ])
   })
 
   it('diagnoses runtime failure and continues closing surfaces without rejecting lifecycle', async () => {
     const failure = new Error('backend shutdown failed')
     const shutdownRemoteAccess = vi.fn()
     const disposeWebController = vi.fn()
-    const disposeWebRpc = vi.fn()
+    const disposeIpcHandlers = vi.fn()
     const log = { error: vi.fn() }
 
     await expect(
@@ -319,7 +322,7 @@ describe('application surface shutdown', () => {
         disposeApplicationRuntime: () => Promise.reject(failure),
         shutdownRemoteAccess,
         disposeWebController,
-        disposeWebRpc,
+        disposeIpcHandlers,
         log
       })
     ).resolves.toBe('failed')
@@ -332,20 +335,20 @@ describe('application surface shutdown', () => {
     expect(JSON.stringify(log.error.mock.calls)).not.toContain('backend shutdown failed')
     expect(shutdownRemoteAccess).toHaveBeenCalledOnce()
     expect(disposeWebController).toHaveBeenCalledOnce()
-    expect(disposeWebRpc).toHaveBeenCalledOnce()
+    expect(disposeIpcHandlers).toHaveBeenCalledOnce()
   })
 
   it('continues closing surfaces when the shutdown diagnostic sink throws', async () => {
     const shutdownRemoteAccess = vi.fn()
     const disposeWebController = vi.fn()
-    const disposeWebRpc = vi.fn()
+    const disposeIpcHandlers = vi.fn()
 
     await expect(
       shutdownApplicationSurfaces({
         disposeApplicationRuntime: () => Promise.reject(new Error('runtime failure')),
         shutdownRemoteAccess,
         disposeWebController,
-        disposeWebRpc,
+        disposeIpcHandlers,
         log: {
           error: () => {
             throw new Error('sink failure')
@@ -356,7 +359,7 @@ describe('application surface shutdown', () => {
 
     expect(shutdownRemoteAccess).toHaveBeenCalledOnce()
     expect(disposeWebController).toHaveBeenCalledOnce()
-    expect(disposeWebRpc).toHaveBeenCalledOnce()
+    expect(disposeIpcHandlers).toHaveBeenCalledOnce()
   })
 
   it.each([
@@ -373,7 +376,7 @@ describe('application surface shutdown', () => {
             Promise.reject(new BackendShutdownOutcomeError(expected)),
           shutdownRemoteAccess: vi.fn(),
           disposeWebController: vi.fn(),
-          disposeWebRpc: vi.fn(),
+          disposeIpcHandlers: vi.fn(),
           log
         })
       ).resolves.toBe(backendOutcome)

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -46,7 +46,7 @@ export type ApplicationSurfaceShutdown = {
   disposeApplicationRuntime(): Awaitable<void>
   shutdownRemoteAccess(): Awaitable<void>
   disposeWebController(): Awaitable<void>
-  disposeWebRpc(): Awaitable<void>
+  disposeIpcHandlers(): Awaitable<void>
   log?: Pick<Logger, 'error'>
 }
 
@@ -54,7 +54,7 @@ export type ApplicationLifecycleShutdownDependencies = {
   disposeApplicationRuntime: ApplicationSurfaceShutdown['disposeApplicationRuntime']
   remoteAccess: { shutdown(): Awaitable<void> }
   webController: { dispose(): Awaitable<void> }
-  webRpc: { dispose(): Awaitable<void> }
+  disposeIpcHandlers: ApplicationSurfaceShutdown['disposeIpcHandlers']
   log?: ApplicationSurfaceShutdown['log']
 }
 
@@ -65,7 +65,7 @@ export const shutdownApplicationSurfaces = async ({
   disposeApplicationRuntime,
   shutdownRemoteAccess,
   disposeWebController,
-  disposeWebRpc,
+  disposeIpcHandlers,
   log
 }: ApplicationSurfaceShutdown): Promise<ShutdownStepOutcome> => {
   const flattenErrors = (error: unknown): unknown[] =>
@@ -111,7 +111,7 @@ export const shutdownApplicationSurfaces = async ({
   await dispose('web-controller', disposeWebController)
   await dispose('application-runtime', disposeApplicationRuntime)
   await dispose('remote-access', shutdownRemoteAccess)
-  await dispose('web-rpc', disposeWebRpc)
+  await dispose('ipc-handlers', disposeIpcHandlers)
   return overallOutcome
 }
 
@@ -121,7 +121,7 @@ export const createApplicationLifecycleShutdown = ({
   disposeApplicationRuntime,
   remoteAccess,
   webController,
-  webRpc,
+  disposeIpcHandlers,
   log
 }: ApplicationLifecycleShutdownDependencies): (() => Promise<ShutdownStepOutcome>) => {
   return () =>
@@ -129,7 +129,7 @@ export const createApplicationLifecycleShutdown = ({
       disposeApplicationRuntime,
       shutdownRemoteAccess: () => remoteAccess.shutdown(),
       disposeWebController: () => webController.dispose(),
-      disposeWebRpc: () => webRpc.dispose(),
+      disposeIpcHandlers,
       log
     })
 }

--- a/src/main/caller-context.test.ts
+++ b/src/main/caller-context.test.ts
@@ -69,25 +69,17 @@ describe('caller context', () => {
     expect(canSatisfyHumanApproval(context)).toBe(false)
   })
 
-  it('derives one stable Electron context and accepts an adapter-owned Web context', () => {
+  it('derives one stable context only for a real Electron sender', () => {
     const sender = { id: 7 }
     const first = callerContextForEvent({ sender })
     expect(callerContextForEvent({ sender })).toBe(first)
     expect(first.lifecycleClientId).toBe('electron:7')
-
-    const web = createWebCallerContext('browser-1')
-    expect(callerContextForEvent({ sender: { id: -1, callerContext: web } })).toBe(web)
   })
 
-  it('fails closed when a synthetic negative sender omits its adapter context', () => {
-    const context = callerContextForEvent({
-      sender: { id: -1, lifecycleClientId: 'web:legacy-browser' }
-    })
-
-    expect(context.surface).toBe('web')
-    expect(context.principalKind).toBe('automation')
-    expect(context.lifecycleClientId).toBe('web:legacy-browser')
-    expect(canSatisfyHumanApproval(context)).toBe(false)
+  it('rejects non-Electron sender ids instead of manufacturing a Web caller', () => {
+    expect(() => callerContextForEvent({ sender: { id: -1 } })).toThrow(
+      'Electron caller sender id must be positive.'
+    )
   })
 })
 

--- a/src/main/caller-context.ts
+++ b/src/main/caller-context.ts
@@ -96,30 +96,17 @@ export type ClientLease = Readonly<{
 type CallerEvent = {
   sender: {
     id: number
-    callerContext?: CallerContext
-    lifecycleClientId?: string
   }
 }
 
 const nativeCallerContexts = new WeakMap<object, CallerContext>()
 
 const callerContextForEvent = (event: CallerEvent): CallerContext => {
-  if (event.sender.callerContext) return event.sender.callerContext
+  if (event.sender.id <= 0) throw new Error('Electron caller sender id must be positive.')
   const sender = event.sender as object
   const existing = nativeCallerContexts.get(sender)
   if (existing) return existing
-  const context =
-    event.sender.id > 0
-      ? createElectronCallerContext(event.sender.id)
-      : createCallerContext({
-          clientId: event.sender.lifecycleClientId?.replace(/^web:/, '') ?? String(event.sender.id),
-          lifecycleClientId: event.sender.lifecycleClientId ?? `electron:${event.sender.id}`,
-          leaseId: event.sender.lifecycleClientId?.replace(/^web:/, '') ?? String(event.sender.id),
-          surface: 'web',
-          location: 'remote',
-          principalKind: 'automation',
-          actionOrigin: 'automation'
-        })
+  const context = createElectronCallerContext(event.sender.id)
   nativeCallerContexts.set(sender, context)
   return context
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -189,7 +189,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { installMigrationQuitGuard, isMigrationInProgress },
         { createAppTray, setTrayIconVariant },
         { installAppLifecycle },
-        { webRpc },
+        { disposeIpcHandlerRegistry },
         { parseWebModeOptions, createWebServiceController, buildAuthenticatedWebUrl },
         { routeSecondInstance },
         { createElectronCloseConfirm },
@@ -355,7 +355,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       const remoteAccess = await RemoteAccessService.create()
       bindRemoteAccess(remoteAccess)
       const webController = createWebServiceController({
-        rpc: webRpc,
         applicationCommands,
         requestQuit: () => app.quit(),
         externalAccess: remoteAccess.webAccess,
@@ -407,7 +406,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         webMode,
         webController,
         remoteAccess,
-        webRpc
+        disposeIpcHandlerRegistry
       }
     },
     // Warn (rather than silently tear down) if the user tries to quit mid data-root migration. Installed
@@ -469,7 +468,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             disposeApplicationRuntime: ctx.disposeApplicationRuntime,
             remoteAccess: ctx.remoteAccess,
             webController: ctx.webController,
-            webRpc: ctx.webRpc,
+            disposeIpcHandlers: ctx.disposeIpcHandlerRegistry,
             log: ctx.log
           }
         )

--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ApplicationCallerLease } from './application-command-router'
 import { callerLeaseForEvent } from './caller-lifecycle'
-import { createTaskCallerContext, createWebCallerContext } from './caller-context'
 import { createIpcHandlerRegistry } from './ipc-handler-registry'
-import { createManagedPreviewOwnerRegistry } from './managed-preview-ipc'
 
 describe('createIpcHandlerRegistry', () => {
   it('keeps injected handler registrars callable without an Electron event', () => {
@@ -122,188 +120,6 @@ describe('createIpcHandlerRegistry', () => {
     expect(replacement.signal.aborted).toBe(false)
   })
 
-  it('keeps caller-controlled Web lease ids isolated from Electron ownership', async () => {
-    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
-    const registry = createIpcHandlerRegistry({
-      handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
-        nativeHandlers.set(channel, handler)
-    } as never)
-    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
-
-    const electronLease = nativeHandlers.get('projects:list')?.({ sender: { id: 7 } }) as {
-      leaseId: string
-      signal: AbortSignal
-      isCurrent: () => boolean
-    }
-    const webLease = (await registry.webRpc.invoke(
-      'projects:list',
-      createWebCallerContext('electron:7'),
-      []
-    )) as typeof electronLease
-
-    expect(electronLease.leaseId).toBe('electron:7')
-    expect(webLease.leaseId).toBe('electron:7')
-    expect(electronLease.signal.aborted).toBe(false)
-    expect(electronLease.isCurrent()).toBe(true)
-    expect(webLease.isCurrent()).toBe(true)
-  })
-
-  it('keeps colliding Web and Task callers isolated when the Web client is released', async () => {
-    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
-    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
-
-    const webLease = (await registry.webRpc.invoke(
-      'projects:list',
-      createWebCallerContext('headless-task-api'),
-      []
-    )) as ApplicationCallerLease
-    const taskLease = (await registry.webRpc.invoke(
-      'projects:list',
-      createTaskCallerContext(),
-      []
-    )) as ApplicationCallerLease
-    const resources = {
-      acquire: vi.fn(),
-      readRange: vi.fn(),
-      release: vi.fn(),
-      releaseOwner: vi.fn()
-    }
-    const owners = createManagedPreviewOwnerRegistry(resources as never)
-    const webOwner = owners.register(webLease)
-    const taskOwner = owners.register(taskLease)
-
-    expect(taskLease).not.toBe(webLease)
-    expect(taskLease.signal).not.toBe(webLease.signal)
-    expect(taskOwner.ownerId).not.toBe(webOwner.ownerId)
-
-    registry.webRpc.releaseClient('headless-task-api')
-
-    expect(webLease.signal.aborted).toBe(true)
-    expect(taskLease.signal.aborted).toBe(false)
-    expect(taskLease.isCurrent()).toBe(true)
-    expect(resources.releaseOwner).toHaveBeenCalledOnce()
-    expect(resources.releaseOwner).toHaveBeenCalledWith(webOwner.ownerId)
-    expect(owners.register(taskLease)).toBe(taskOwner)
-
-    registry.webRpc.dispose()
-    expect(taskLease.signal.aborted).toBe(true)
-  })
-
-  it('registers every native handler but routes only allowlisted Web RPC channels', async () => {
-    const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
-    const handle = vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
-      nativeHandlers.set(channel, handler)
-    })
-    const registry = createIpcHandlerRegistry({ handle } as never)
-
-    registry.ipcMainHandle('projects:list', (_event, request) => ({ request }))
-    registry.ipcMainHandle('test:unsafe', () => ({ exposed: true }))
-
-    expect([...nativeHandlers.keys()]).toEqual(['projects:list', 'test:unsafe'])
-    expect(registry.webRpc.channels()).toEqual(['projects:list'])
-    await expect(
-      registry.webRpc.invoke('projects:list', createWebCallerContext('client-a'), [{ page: 1 }])
-    ).resolves.toEqual({ request: { page: 1 } })
-    await expect(
-      registry.webRpc.invoke('test:unsafe', createWebCallerContext('client-a'), [])
-    ).rejects.toThrow('Unknown Web RPC channel')
-  })
-
-  it('uses stable lifecycle senders and releases them without patching ipcMain.handle', async () => {
-    const handle = vi.fn()
-    const registry = createIpcHandlerRegistry({ handle } as never)
-    const destroyed = vi.fn()
-    registry.ipcMainHandle('projects:list', (event: unknown) => {
-      const sender = (
-        event as {
-          sender: {
-            id: number
-            lifecycleClientId: string
-            once: (event: string, listener: () => void) => unknown
-          }
-        }
-      ).sender
-      sender.once('destroyed', destroyed)
-      return { senderId: sender.id, lifecycleClientId: sender.lifecycleClientId }
-    })
-
-    const first = (await registry.webRpc.invoke(
-      'projects:list',
-      createWebCallerContext('browser-1'),
-      []
-    )) as {
-      senderId: number
-      lifecycleClientId: string
-    }
-    const second = (await registry.webRpc.invoke(
-      'projects:list',
-      createWebCallerContext('browser-1'),
-      []
-    )) as typeof first
-    expect(second.senderId).toBe(first.senderId)
-    expect(first.lifecycleClientId).toBe('web:browser-1')
-
-    registry.webRpc.releaseClient('browser-1')
-    expect(destroyed).toHaveBeenCalledTimes(2)
-
-    const reconnected = (await registry.webRpc.invoke(
-      'projects:list',
-      createWebCallerContext('browser-1'),
-      []
-    )) as typeof first
-    expect(reconnected.senderId).not.toBe(first.senderId)
-    expect(reconnected.lifecycleClientId).toBe(first.lifecycleClientId)
-    expect(handle).toHaveBeenCalledTimes(1)
-    registry.webRpc.dispose()
-  })
-
-  it('starts fresh Web and Task lease epochs when handlers are registered after disposal', async () => {
-    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
-    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
-
-    const disposedWebLease = (await registry.webRpc.invoke(
-      'projects:list',
-      createWebCallerContext('browser-1'),
-      []
-    )) as ApplicationCallerLease
-    const disposedTaskLease = (await registry.webRpc.invoke(
-      'projects:list',
-      createTaskCallerContext(),
-      []
-    )) as ApplicationCallerLease
-    registry.webRpc.dispose()
-
-    expect(disposedWebLease.signal.aborted).toBe(true)
-    expect(disposedWebLease.isCurrent()).toBe(false)
-    expect(disposedTaskLease.signal.aborted).toBe(true)
-    expect(disposedTaskLease.isCurrent()).toBe(false)
-
-    registry.ipcMainHandle('projects:list', (event) => callerLeaseForEvent(event))
-    const replacementWebLease = (await registry.webRpc.invoke(
-      'projects:list',
-      createWebCallerContext('browser-1'),
-      []
-    )) as ApplicationCallerLease
-    const replacementTaskLease = (await registry.webRpc.invoke(
-      'projects:list',
-      createTaskCallerContext(),
-      []
-    )) as ApplicationCallerLease
-
-    expect(replacementWebLease).not.toBe(disposedWebLease)
-    expect(replacementWebLease.signal).not.toBe(disposedWebLease.signal)
-    expect(replacementWebLease.signal.aborted).toBe(false)
-    expect(replacementWebLease.isCurrent()).toBe(true)
-    expect(replacementTaskLease).not.toBe(disposedTaskLease)
-    expect(replacementTaskLease.signal).not.toBe(disposedTaskLease.signal)
-    expect(replacementTaskLease.signal.aborted).toBe(false)
-    expect(replacementTaskLease.isCurrent()).toBe(true)
-
-    registry.webRpc.releaseClient('browser-1')
-    expect(replacementWebLease.signal.aborted).toBe(true)
-    expect(replacementTaskLease.signal.aborted).toBe(false)
-  })
-
   it('keeps disposed native handler epochs terminal after later registrations', () => {
     const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
     const registry = createIpcHandlerRegistry({
@@ -316,7 +132,7 @@ describe('createIpcHandlerRegistry', () => {
     const sender = { id: 42 }
 
     const disposedLease = disposedWrapper?.({ sender }) as ApplicationCallerLease
-    registry.webRpc.dispose()
+    registry.dispose()
 
     expect(() => disposedWrapper?.({ sender })).toThrow('registry is disposed')
     expect(initialHandler).toHaveBeenCalledOnce()
@@ -334,105 +150,6 @@ describe('createIpcHandlerRegistry', () => {
     expect(disposedLease.isCurrent()).toBe(false)
     expect(replacementLease.signal.aborted).toBe(false)
     expect(replacementLease.isCurrent()).toBe(true)
-  })
-
-  it('lets in-flight Web work observe final client release without cancelling its result', async () => {
-    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
-    let resolve!: (value: string) => void
-    const pending = new Promise<string>((complete) => (resolve = complete))
-    const observedRelease = vi.fn()
-    registry.ipcMainHandle('projects:list', (event: unknown) => {
-      callerLeaseForEvent(event as { sender: object }).signal.addEventListener(
-        'abort',
-        observedRelease,
-        { once: true }
-      )
-      return pending
-    })
-
-    const invocation = registry.webRpc.invoke(
-      'projects:list',
-      createWebCallerContext('browser-1'),
-      []
-    )
-    registry.webRpc.releaseClient('browser-1')
-    resolve('complete')
-
-    await expect(invocation).resolves.toBe('complete')
-    expect(observedRelease).toHaveBeenCalledOnce()
-  })
-
-  it('scopes remote pairing authority to the current Web RPC invocation', async () => {
-    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
-    registry.ipcMainHandle('remote-access:get-snapshot', (event: unknown) =>
-      (
-        event as { sender: { callerContext: { authorities: readonly string[] } } }
-      ).sender.callerContext.authorities.includes('manage-remote-pairing')
-    )
-
-    await expect(
-      registry.webRpc.invoke(
-        'remote-access:get-snapshot',
-        createWebCallerContext('browser-1', {
-          location: 'remote',
-          authorities: ['manage-remote-pairing']
-        }),
-        []
-      )
-    ).resolves.toBe(true)
-    await expect(
-      registry.webRpc.invoke('remote-access:get-snapshot', createWebCallerContext('browser-1'), [])
-    ).resolves.toBe(false)
-  })
-
-  it('does not leak authority between concurrent calls from the same Web client', async () => {
-    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
-    let resumeFirst!: () => void
-    const firstPaused = new Promise<void>((resolve) => {
-      resumeFirst = resolve
-    })
-    registry.ipcMainHandle(
-      'remote-access:get-snapshot',
-      async (event: unknown, request: { pause?: boolean }) => {
-        if (request.pause) await firstPaused
-        return (
-          event as { sender: { callerContext: { authorities: readonly string[] } } }
-        ).sender.callerContext.authorities.includes('manage-remote-pairing')
-      }
-    )
-
-    const trusted = registry.webRpc.invoke(
-      'remote-access:get-snapshot',
-      createWebCallerContext('browser-1', {
-        location: 'remote',
-        authorities: ['manage-remote-pairing']
-      }),
-      [{ pause: true }]
-    )
-    await expect(
-      registry.webRpc.invoke(
-        'remote-access:get-snapshot',
-        createWebCallerContext('browser-1', { location: 'remote' }),
-        [{}]
-      )
-    ).resolves.toBe(false)
-    resumeFirst()
-    await expect(trusted).resolves.toBe(true)
-  })
-
-  it('rejects a caller whose authorization became stale before dispatch', async () => {
-    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never)
-    const handler = vi.fn()
-    registry.ipcMainHandle('projects:list', handler)
-    const context = createWebCallerContext('browser-1', {
-      location: 'remote',
-      isAuthorizationCurrent: () => false
-    })
-
-    await expect(registry.webRpc.invoke('projects:list', context, [])).rejects.toThrow(
-      'authorization is no longer current'
-    )
-    expect(handler).not.toHaveBeenCalled()
   })
 
   it('uninstalls only the handlers registered by a completed installation scope', () => {
@@ -497,40 +214,5 @@ describe('createIpcHandlerRegistry', () => {
     expect(JSON.stringify(warn.mock.calls)).not.toContain('/private/native.txt')
     expect(JSON.stringify(warn.mock.calls)).not.toContain('private native failure')
     expect(JSON.stringify(warn.mock.calls)).not.toContain('42')
-  })
-
-  it('records a rejected Web RPC handler once using the supplied caller vocabulary', async () => {
-    const warn = vi.fn()
-    const now = vi.fn().mockReturnValueOnce(10).mockReturnValueOnce(18)
-    const registry = createIpcHandlerRegistry({ handle: vi.fn() } as never, { log: { warn }, now })
-    const rejection = new TypeError('private Web failure')
-    registry.ipcMainHandle('projects:list', async () => {
-      throw rejection
-    })
-
-    await expect(
-      registry.webRpc.invoke(
-        'projects:list',
-        createWebCallerContext('secret-client-id', {
-          location: 'remote',
-          principalKind: 'automation',
-          actionOrigin: 'agent-session'
-        }),
-        [{ token: 'web-secret' }]
-      )
-    ).rejects.toBe(rejection)
-    expect(warn).toHaveBeenCalledOnce()
-    expect(warn).toHaveBeenCalledWith('ipc handler rejected', {
-      channel: 'projects:list',
-      surface: 'web',
-      location: 'remote',
-      principalKind: 'automation',
-      actionOrigin: 'agent-session',
-      durationMs: 8,
-      errorCategory: 'type'
-    })
-    expect(JSON.stringify(warn.mock.calls)).not.toContain('secret-client-id')
-    expect(JSON.stringify(warn.mock.calls)).not.toContain('web-secret')
-    expect(JSON.stringify(warn.mock.calls)).not.toContain('private Web failure')
   })
 })

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -1,13 +1,9 @@
-import { EventEmitter } from 'node:events'
-
 import { ipcMain, type IpcMain, type IpcMainInvokeEvent } from 'electron'
 
-import { isWebRpcChannel } from '../shared/web-rpc-contract'
 import { callerContextForEvent, type CallerContext } from './caller-context'
 import {
   ApplicationCallerLeaseRegistry,
   bindCallerLeaseToEvent,
-  callerLeaseOwnershipKeyForContext,
   type OwnedApplicationCallerLease
 } from './caller-lifecycle'
 import {
@@ -15,8 +11,6 @@ import {
   type IpcRejectionLogger
 } from './diagnostics/ipc-rejection'
 import { createLogger } from './logger'
-
-type IpcHandler = Parameters<IpcMain['handle']>[1]
 
 type IpcHandlerInstallation = {
   uninstall(): void
@@ -27,53 +21,10 @@ type IpcHandlerInstallationScope = {
   rollback(): void
 }
 
-class WebIpcSender {
-  readonly id: number
-  readonly lifecycleClientId: string
-  readonly callerContext: CallerContext
-
-  constructor(
-    id: number,
-    callerContext: CallerContext,
-    private readonly lifecycle: EventEmitter
-  ) {
-    this.id = id
-    this.lifecycleClientId = callerContext.lifecycleClientId
-    this.callerContext = callerContext
-  }
-
-  once(event: string, listener: (...args: unknown[]) => void): this {
-    this.lifecycle.once(event, listener)
-    return this
-  }
-
-  on(event: string, listener: (...args: unknown[]) => void): this {
-    this.lifecycle.on(event, listener)
-    return this
-  }
-
-  off(event: string, listener: (...args: unknown[]) => void): this {
-    this.lifecycle.off(event, listener)
-    return this
-  }
-
-  removeListener(event: string, listener: (...args: unknown[]) => void): this {
-    this.lifecycle.removeListener(event, listener)
-    return this
-  }
-}
-
-export type WebRpcRouter = {
-  invoke: (channel: string, callerContext: CallerContext, args: unknown[]) => Promise<unknown>
-  releaseClient: (clientId: string) => void
-  dispose: () => void
-  channels: () => string[]
-}
-
 type IpcHandlerRegistry = {
   ipcMainHandle: IpcMain['handle']
-  webRpc: WebRpcRouter
   createInstallationScope(): IpcHandlerInstallationScope
+  dispose(): void
 }
 
 type IpcHandlerRegistryDiagnostics = {
@@ -117,21 +68,9 @@ const createIpcHandlerRegistry = (
     ({
       warn: (message, data) => createLogger('ipc').warn(message, data)
     } satisfies IpcRejectionLogger)
-  const webHandlers = new Map<string, IpcHandler>()
   const registeredChannels = new Set<string>()
-  const clients = new Map<
-    string,
-    {
-      id: number
-      clientId: string
-      surface: CallerContext['surface']
-      lifecycle: EventEmitter
-      callerLease: OwnedApplicationCallerLease
-    }
-  >()
   let activeCallerLeaseEpoch = createCallerLeaseEpoch()
   const destroyedNativeCallers = new WeakSet<object>()
-  let nextSenderId = -1
 
   const callerLeaseEpochForRegistration = (): CallerLeaseEpoch => {
     if (activeCallerLeaseEpoch.disposed) activeCallerLeaseEpoch = createCallerLeaseEpoch()
@@ -168,42 +107,6 @@ const createIpcHandlerRegistry = (
     }
   }
 
-  const senderFor = (
-    callerContext: CallerContext
-  ): { sender: WebIpcSender; lease: OwnedApplicationCallerLease['lease'] } => {
-    const ownershipKey = callerLeaseOwnershipKeyForContext(callerContext)
-    let client = clients.get(ownershipKey)
-    if (!client) {
-      client = {
-        id: nextSenderId--,
-        clientId: callerContext.clientId,
-        surface: callerContext.surface,
-        lifecycle: new EventEmitter(),
-        callerLease: activeCallerLeaseEpoch.registry.acquire(callerContext)
-      }
-      clients.set(ownershipKey, client)
-    }
-    return {
-      sender: new WebIpcSender(client.id, callerContext, client.lifecycle),
-      lease: client.callerLease.lease
-    }
-  }
-
-  const destroyClient = (ownershipKey: string): void => {
-    const client = clients.get(ownershipKey)
-    if (!client) return
-    clients.delete(ownershipKey)
-    client.callerLease.release()
-    client.lifecycle.emit('destroyed')
-    client.lifecycle.removeAllListeners()
-  }
-
-  const releaseWebClient = (clientId: string): void => {
-    for (const [ownershipKey, client] of clients) {
-      if (client.surface === 'web' && client.clientId === clientId) destroyClient(ownershipKey)
-    }
-  }
-
   const ipcMainHandle: IpcMain['handle'] = (channel, listener) => {
     const callerLeaseEpoch = callerLeaseEpochForRegistration()
     target.handle(channel, (event, ...args) =>
@@ -227,14 +130,12 @@ const createIpcHandlerRegistry = (
       })
     )
     registeredChannels.add(channel)
-    if (isWebRpcChannel(channel)) webHandlers.set(channel, listener)
   }
 
   const removeChannels = (channels: Iterable<string>): void => {
     for (const channel of channels) {
       target.removeHandler?.(channel)
       registeredChannels.delete(channel)
-      webHandlers.delete(channel)
     }
   }
 
@@ -270,34 +171,9 @@ const createIpcHandlerRegistry = (
         }
       }
     },
-    webRpc: {
-      invoke: async (channel, callerContext, args) => {
-        if (!isWebRpcChannel(channel)) throw new Error(`Unknown Web RPC channel: ${channel}`)
-        const handler = webHandlers.get(channel)
-        if (!handler) throw new Error(`Unregistered Web RPC channel: ${channel}`)
-        if (!callerContext.isAuthorizationCurrent()) {
-          throw new Error('Caller authorization is no longer current.')
-        }
-        const { sender, lease } = senderFor(callerContext)
-        const event = { sender } as unknown as IpcMainInvokeEvent
-        bindCallerLeaseToEvent(event, lease)
-        assertCurrentLease(lease)
-        return invokeWithIpcRejectionDiagnostics({
-          channel,
-          callerContext,
-          invoke: () => handler(event, ...args),
-          log: diagnosticLog,
-          now: diagnostics.now
-        })
-      },
-      releaseClient: releaseWebClient,
-      dispose: () => {
-        for (const ownershipKey of [...clients.keys()]) destroyClient(ownershipKey)
-        activeCallerLeaseEpoch.registry.dispose()
-        activeCallerLeaseEpoch.disposed = true
-        webHandlers.clear()
-      },
-      channels: () => [...webHandlers.keys()].sort()
+    dispose: () => {
+      activeCallerLeaseEpoch.registry.dispose()
+      activeCallerLeaseEpoch.disposed = true
     }
   }
 }
@@ -305,9 +181,14 @@ const createIpcHandlerRegistry = (
 const defaultRegistry = createIpcHandlerRegistry(ipcMain)
 
 const ipcMainHandle = defaultRegistry.ipcMainHandle
-const webRpc = defaultRegistry.webRpc
+const disposeIpcHandlerRegistry = (): void => defaultRegistry.dispose()
 const createIpcHandlerInstallationScope = (): IpcHandlerInstallationScope =>
   defaultRegistry.createInstallationScope()
 
-export { createIpcHandlerInstallationScope, createIpcHandlerRegistry, ipcMainHandle, webRpc }
+export {
+  createIpcHandlerInstallationScope,
+  createIpcHandlerRegistry,
+  disposeIpcHandlerRegistry,
+  ipcMainHandle
+}
 export type { IpcHandlerInstallation, IpcHandlerInstallationScope, IpcHandlerRegistryDiagnostics }

--- a/src/main/lifecycle-broadcast.test.ts
+++ b/src/main/lifecycle-broadcast.test.ts
@@ -22,14 +22,11 @@ import { getLifecycleClientId, registerLifecycleIpcHandlers } from './lifecycle-
 describe('lifecycle broadcast IPC', () => {
   beforeEach(() => ipcHandlers.clear())
 
-  it('identifies Electron and Web renderers through stable lifecycle client IDs', async () => {
+  it('identifies Electron renderers through stable lifecycle client IDs', async () => {
     registerLifecycleIpcHandlers()
 
     const getClientId = ipcHandlers.get('lifecycle:client-id')
     expect(getClientId?.({ sender: { id: 42 } })).toBe('electron:42')
-    expect(getClientId?.({ sender: { id: -2, lifecycleClientId: 'web:browser-1' } })).toBe(
-      'web:browser-1'
-    )
   })
 
   it('requires the surface adapter to bind a caller lease', () => {

--- a/src/main/lifecycle-broadcast.ts
+++ b/src/main/lifecycle-broadcast.ts
@@ -2,7 +2,7 @@ import { ipcMainHandle } from './ipc-handler-registry'
 
 import { LIFECYCLE_CHANNELS } from '../shared/lifecycle-events'
 import { callerLeaseForEvent } from './caller-lifecycle'
-import { callerContextForEvent, type CallerContext } from './caller-context'
+import { callerContextForEvent } from './caller-context'
 import { createLogger } from './logger'
 import type { ApplicationEventChannel, ApplicationEventMap } from './application-events'
 import { broadcastToRenderers } from './renderer-broadcast'
@@ -25,9 +25,7 @@ const broadcastLifecycleEvent = <Channel extends ApplicationEventChannel>(
   }
 }
 
-const getLifecycleClientId = (event: {
-  sender: { id: number; callerContext?: CallerContext; lifecycleClientId?: string }
-}): string => {
+const getLifecycleClientId = (event: { sender: { id: number } }): string => {
   const context = callerContextForEvent(event)
   const lease = callerLeaseForEvent(event)
   if (lease.leaseId !== context.leaseId || !lease.isCurrent()) {

--- a/src/main/local-fs/ipc.test.ts
+++ b/src/main/local-fs/ipc.test.ts
@@ -4,8 +4,8 @@ const { ipcHandlers } = vi.hoisted(() => ({
   ipcHandlers: new Map<string, (...args: unknown[]) => unknown>()
 }))
 
-// The real registry is built over this fake ipcMain, so channel tracking and the Web RPC router
-// behave exactly as they do in the app.
+// The real registry is built over this fake ipcMain so channel tracking and adapter teardown behave
+// exactly as they do in the app.
 vi.mock('electron', () => ({
   ipcMain: {
     handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
@@ -14,7 +14,7 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { createIpcHandlerInstallationScope, webRpc } from '../ipc-handler-registry'
+import { createIpcHandlerInstallationScope } from '../ipc-handler-registry'
 import type { LocalFsService } from './service'
 import {
   LOCAL_FS_GET_ROOTS_CHANNEL,
@@ -44,12 +44,11 @@ const createServiceStub = (): LocalFsService =>
 
 beforeEach(() => {
   ipcHandlers.clear()
-  webRpc.dispose()
 })
 
 describe('registerLocalFsIpcHandlers', () => {
   // Raw ipcMain.handle registers a working handler but stays invisible to the registry, which
-  // silently breaks adapter teardown and the Web RPC router. Assert the registry actually sees them.
+  // silently breaks adapter teardown. Assert the registry actually sees them.
   it('registers every channel through the handler registry so teardown can remove them', () => {
     const scope = createIpcHandlerInstallationScope()
     registerLocalFsIpcHandlers(createServiceStub())
@@ -59,23 +58,5 @@ describe('registerLocalFsIpcHandlers', () => {
 
     installation.uninstall()
     expect([...ipcHandlers.keys()]).toEqual([])
-  })
-
-  it('exposes the channels to the Web RPC router', async () => {
-    const service = createServiceStub()
-    registerLocalFsIpcHandlers(service)
-
-    expect(webRpc.channels()).toEqual(expect.arrayContaining(CHANNELS))
-
-    const callerContext = {
-      lifecycleClientId: 'web:test',
-      isAuthorizationCurrent: () => true
-    }
-    await webRpc.invoke(
-      LOCAL_FS_LIST_DIR_CHANNEL,
-      callerContext as unknown as Parameters<typeof webRpc.invoke>[1],
-      ['/Users/test']
-    )
-    expect(service.listDir).toHaveBeenCalledWith('/Users/test')
   })
 })

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -981,7 +981,7 @@ describe('logger: application shutdown diagnostics', () => {
         ),
       shutdownRemoteAccess: () => undefined,
       disposeWebController: () => undefined,
-      disposeWebRpc: () => undefined,
+      disposeIpcHandlers: () => undefined,
       log
     })
     await flushLogs()

--- a/src/main/permission-grants/ipc.test.ts
+++ b/src/main/permission-grants/ipc.test.ts
@@ -26,7 +26,6 @@ import {
   type ApplicationInvocation
 } from '../application-command-router'
 import { createWebCallerContext } from '../caller-context'
-import { webRpc } from '../ipc-handler-registry'
 import {
   permissionGrantApplicationCommands,
   registerPermissionGrantApplicationCommands
@@ -187,14 +186,6 @@ describe('permission grant IPC', () => {
       'permissions:extend-undo',
       'permissions:restore'
     ])
-    expect(webRpc.channels()).toEqual(
-      expect.arrayContaining([
-        'permissions:list',
-        'permissions:revoke',
-        'permissions:extend-undo',
-        'permissions:restore'
-      ])
-    )
     await handlers.get('permissions:revoke')?.(undefined, {
       grants: [{ id: 'grant-1', revision: 2 }]
     })

--- a/src/main/remote-access/ipc.test.ts
+++ b/src/main/remote-access/ipc.test.ts
@@ -5,12 +5,10 @@ vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }))
 import {
   canManagePairing,
   isDesktopCaller,
-  registerRemoteAccessIpcHandlers,
   requireDesktopCaller,
   requirePairingManager
 } from './ipc'
 import { createElectronCallerContext, createWebCallerContext } from '../caller-context'
-import { webRpc } from '../ipc-handler-registry'
 
 describe('remote access IPC authorization', () => {
   it.each([
@@ -42,27 +40,6 @@ describe('remote access IPC authorization', () => {
     expect(canManagePairing(context)).toBe(expected)
   })
 
-  it('registers remote access handlers with the Web RPC router', async () => {
-    const snapshot = vi.fn(() => ({ mode: 'off' }))
-    registerRemoteAccessIpcHandlers({ snapshot } as never)
-
-    expect(webRpc.channels()).toEqual(
-      expect.arrayContaining([
-        'remote-access:approve',
-        'remote-access:detect',
-        'remote-access:disable',
-        'remote-access:get-snapshot',
-        'remote-access:reject',
-        'remote-access:revoke-browser',
-        'remote-access:set-mode'
-      ])
-    )
-    await expect(
-      webRpc.invoke('remote-access:get-snapshot', createWebCallerContext('browser-1'), [])
-    ).resolves.toEqual({ mode: 'off' })
-    expect(snapshot).toHaveBeenCalledWith(false, false)
-  })
-
   it('allows a real Electron WebContents sender', () => {
     const context = createElectronCallerContext(7)
     expect(isDesktopCaller(context)).toBe(true)
@@ -71,7 +48,7 @@ describe('remote access IPC authorization', () => {
     expect(() => requirePairingManager(context)).not.toThrow()
   })
 
-  it('rejects the synthetic negative sender used by every Web RPC client', () => {
+  it('rejects an ordinary remote Web caller', () => {
     const context = createWebCallerContext('browser-1', { location: 'remote' })
     expect(isDesktopCaller(context)).toBe(false)
     expect(canManagePairing(context)).toBe(false)

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -8,8 +8,7 @@ const { broadcastLifecycleEvent, getLifecycleClientId, ipcHandlers, registration
   vi.hoisted(() => ({
     broadcastLifecycleEvent: vi.fn(),
     getLifecycleClientId: vi.fn(
-      (event: { sender: { id: number; lifecycleClientId?: string } }) =>
-        event.sender.lifecycleClientId ?? `electron:${event.sender.id}`
+      (event: { sender: { id: number } }) => `electron:${event.sender.id}`
     ),
     ipcHandlers: new Map<string, (...args: unknown[]) => unknown>(),
     registrationFailure: {
@@ -308,7 +307,7 @@ describe('session persistence IPC handlers', () => {
 
     const deleteRequest = { projectId: 'project-a', sessionId: 'session-1' }
     const manifestRequest = { lastProjectId: 'project-a', lastSessionId: 'session-1' }
-    const event = { sender: { id: -2, lifecycleClientId: 'web:browser-1' } }
+    const event = { sender: { id: 2 } }
     await expect(ipcHandlers.get('sessions:load-all')?.()).resolves.toBe(loadResult)
     await expect(ipcHandlers.get('sessions:save-session')?.(event, session)).resolves.toBe(
       durableSession
@@ -324,11 +323,11 @@ describe('session persistence IPC handlers', () => {
     expect(repository.saveManifest).toHaveBeenCalledWith(manifestRequest)
     expect(broadcastLifecycleEvent).toHaveBeenCalledWith('session:created', {
       session: durableSession,
-      originClientId: 'web:browser-1'
+      originClientId: 'electron:2'
     })
     expect(broadcastLifecycleEvent).toHaveBeenCalledWith('session:updated', {
       session: durableSession,
-      originClientId: 'web:browser-1'
+      originClientId: 'electron:2'
     })
     expect(broadcastLifecycleEvent).toHaveBeenCalledWith('session:deleted', deleteRequest)
   })
@@ -413,10 +412,7 @@ describe('session persistence IPC handlers', () => {
     registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository())
 
     await expect(
-      ipcHandlers.get('sessions:save-session')?.(
-        { sender: { id: 1, lifecycleClientId: 'electron:origin' } },
-        createSession()
-      )
+      ipcHandlers.get('sessions:save-session')?.({ sender: { id: 1 } }, createSession())
     ).rejects.toBe(failure)
     expect(broadcastLifecycleEvent).not.toHaveBeenCalled()
   })
@@ -438,13 +434,10 @@ describe('session persistence IPC handlers', () => {
     }
     registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository())
 
-    const save = ipcHandlers.get('sessions:save-session')?.(
-      { sender: { id: 1, lifecycleClientId: 'electron:origin' } },
-      session
-    )
+    const save = ipcHandlers.get('sessions:save-session')?.({ sender: { id: 1 } }, session)
 
     expect(getLifecycleClientId).toHaveBeenCalledOnce()
-    expect(getLifecycleClientId).toHaveReturnedWith('electron:origin')
+    expect(getLifecycleClientId).toHaveReturnedWith('electron:1')
     completeSave()
     await expect(save).resolves.toBe(session)
   })
@@ -466,10 +459,7 @@ describe('session persistence IPC handlers', () => {
     })
     registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository())
 
-    await ipcHandlers.get('sessions:save-session')?.(
-      { sender: { id: 1, lifecycleClientId: 'electron:origin' } },
-      session
-    )
+    await ipcHandlers.get('sessions:save-session')?.({ sender: { id: 1 } }, session)
 
     expect(repository.saveSession).toHaveBeenCalledOnce()
     expect(broadcastLifecycleEvent).toHaveBeenCalledOnce()

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -23,8 +23,6 @@ vi.mock('electron', () => ({
 
 const { registerSettingsIpcHandlers } = await import('./ipc')
 const { createSettingsWorkflows } = await import('./workflows')
-const { webRpc } = await import('../ipc-handler-registry')
-const { createWebCallerContext } = await import('../caller-context')
 
 // A fake service whose methods are all spies; cast to SettingsService only when registering handlers.
 type FakeSettingsService = Record<
@@ -228,23 +226,6 @@ const invoke = (channel: string, payload?: unknown): unknown =>
   handlers.get(channel)!(undefined, payload)
 
 describe('settings IPC handlers', () => {
-  it('routes local Web RPC through the same workflow command as Electron', async () => {
-    handlers.clear()
-    const service = createFakeService()
-    const onActiveProviderChanged = vi.fn()
-    registerTestSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
-    const context = createWebCallerContext('settings-workflow-test')
-
-    try {
-      await webRpc.invoke('settings:set-active-provider', context, [{ id: 'p1' }])
-    } finally {
-      webRpc.releaseClient(context.clientId)
-    }
-
-    expect(service.setActiveProvider).toHaveBeenCalledWith('p1', undefined)
-    expect(onActiveProviderChanged).toHaveBeenCalledOnce()
-  })
-
   it('registers every settings channel', () => {
     handlers.clear()
     registerTestSettingsIpcHandlers({ service: asService(createFakeService()) })

--- a/src/main/uploads/ipc.test.ts
+++ b/src/main/uploads/ipc.test.ts
@@ -27,11 +27,7 @@ import {
   clearMigrationPending,
   waitForDataRootWriters
 } from '../storage/migration-state'
-import {
-  createElectronCallerContext,
-  createWebCallerContext,
-  type CallerContext
-} from '../caller-context'
+import { createElectronCallerContext, type CallerContext } from '../caller-context'
 import { createUploadCommandOwner } from './command-owner'
 import {
   createDefaultUploadRepository,
@@ -477,31 +473,6 @@ describe('default upload repository', () => {
     sender.emit('did-start-navigation', {}, 'http://localhost/', false, true)
     await drainPromise
     expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'transfer-4' })
-  })
-
-  it('does not compose Electron navigation cleanup into Web callers', async () => {
-    const repository = {
-      beginTransfer: vi.fn(async () => ({
-        transferId: 'web-transfer',
-        name: 'data.csv',
-        receivedBytes: 0,
-        totalBytes: 10
-      })),
-      abortTransfer: vi.fn(async () => undefined)
-    } as unknown as UploadRepository
-    registerUploadIpcHandlers(repository)
-    const begin = ipcHandlers.get('uploads:begin-transfer')!
-    const caller = createIpcEvent(-1, createWebCallerContext('browser-1'))
-
-    await begin(caller.event, { transferId: 'web-transfer', name: 'data.csv', size: 10 })
-    caller.emit('did-start-navigation', {}, 'http://localhost/', false, true)
-    await new Promise((resolve) => setImmediate(resolve))
-    expect(repository.abortTransfer).not.toHaveBeenCalled()
-
-    caller.emit('destroyed')
-    await vi.waitFor(() => {
-      expect(repository.abortTransfer).toHaveBeenCalledWith({ transferId: 'web-transfer' })
-    })
   })
 
   it('aborts a native-path upload and releases its migration lease when its renderer is destroyed', async () => {

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 import { ApplicationEventHub } from '../application-events'
 import type { ApplicationEventSource } from '../application-events'
 import type { ApplicationCommandComposition } from '../application-command-composition'
-import type { WebRpcRouter } from '../ipc-handler-registry'
 import type { TaskAgentPort } from '../tasks/task-runner'
 import { createWebServiceController, type WebServiceControllerDeps } from './index'
 
@@ -11,7 +10,7 @@ type StartOptions = Parameters<WebServiceControllerDeps['startServer']>[0]
 
 // Builds a controller over fully faked I/O so the idempotency + attached logic is exercised without
 // Electron, the network, or the filesystem. `startServer` echoes the requested port and records the
-// options it was given (so the test can drive the captured onShutdownRequest).
+// options it was given (so the test can drive onShutdownRequest).
 const makeController = (
   overrides: Partial<WebServiceControllerDeps> = {},
   requestQuit = vi.fn(),
@@ -43,7 +42,6 @@ const makeController = (
 
   const controller = createWebServiceController(
     {
-      rpc: {} as WebRpcRouter,
       applicationCommands,
       requestQuit,
       applicationEvents: runtime.applicationEvents ?? new ApplicationEventHub(),

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -16,7 +16,6 @@ import { WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
 import { isWebRpcChannel, WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
 import { ApplicationEventHub } from '../application-events'
 import type { CallerContext } from '../caller-context'
-import type { WebRpcRouter } from '../ipc-handler-registry'
 import {
   REMOTE_LOCAL_ONLY_RPC_CHANNELS,
   startWebHttpServer,
@@ -30,32 +29,38 @@ const servers: RunningWebServer[] = []
 const applicationEvents = new ApplicationEventHub()
 type TestWebServerOptions = Omit<
   Parameters<typeof startWebHttpServer>[0],
-  'applicationCommands' | 'applicationEvents' | 'rpc'
+  'applicationCommands' | 'applicationEvents'
 > &
   Partial<Pick<Parameters<typeof startWebHttpServer>[0], 'applicationCommands'>> & {
-    rpc: WebRpcRouter
+    rpc: {
+      channels: () => string[]
+      invoke: (channel: string, callerContext: CallerContext, args: unknown[]) => Promise<unknown>
+      releaseClient?: (clientId: string) => void
+      dispose?: () => void
+    }
   }
 const startTestWebHttpServer = (
   options: TestWebServerOptions
 ): ReturnType<typeof startWebHttpServer> => {
-  const localNames = options.rpc.channels().filter(isWebRpcChannel)
+  const { rpc, ...serverOptions } = options
+  const localNames = rpc.channels().filter(isWebRpcChannel)
   const remoteRejectedNames = localNames.filter((channel) =>
     REMOTE_LOCAL_ONLY_RPC_CHANNELS.has(channel)
   )
-  const invokeCaptured = (
+  const invokeDirect = (
     channel: string,
     invocation: { callerContext: CallerContext; args: readonly unknown[] }
-  ): Promise<unknown> => options.rpc.invoke(channel, invocation.callerContext, [...invocation.args])
+  ): Promise<unknown> => rpc.invoke(channel, invocation.callerContext, [...invocation.args])
 
   return startWebHttpServer({
-    ...options,
+    ...serverOptions,
     applicationCommands: options.applicationCommands ?? {
-      localWeb: { commandNames: () => localNames, invoke: invokeCaptured },
+      localWeb: { commandNames: () => localNames, invoke: invokeDirect },
       remoteWeb: {
         commandNames: () =>
           localNames.filter((channel) => !REMOTE_LOCAL_ONLY_RPC_CHANNELS.has(channel)),
         rejectedCommandNames: () => remoteRejectedNames,
-        invoke: invokeCaptured
+        invoke: invokeDirect
       }
     },
     applicationEvents
@@ -79,7 +84,7 @@ afterEach(async () => {
 
 describe('startWebHttpServer', () => {
   it('dispatches local Web RPC through the narrow application command view', async () => {
-    const capturedInvoke = vi.fn()
+    const unusedFallbackInvoke = vi.fn()
     const directInvoke = vi.fn(
       async (
         _channel: string,
@@ -88,7 +93,7 @@ describe('startWebHttpServer', () => {
     )
     const rpc = {
       channels: () => ['projects:list'],
-      invoke: capturedInvoke,
+      invoke: unusedFallbackInvoke,
       releaseClient: vi.fn(),
       dispose: vi.fn()
     }
@@ -154,7 +159,7 @@ describe('startWebHttpServer', () => {
         args: [{ source: 'direct' }]
       })
     )
-    expect(capturedInvoke).not.toHaveBeenCalled()
+    expect(unusedFallbackInvoke).not.toHaveBeenCalled()
 
     const directSignal = directInvoke.mock.calls[0]?.[1].callerLease.signal
     firstSocket.close()
@@ -204,7 +209,7 @@ describe('startWebHttpServer', () => {
     expect(unsubscribe).toHaveBeenCalledTimes(2)
   })
 
-  it('authenticates, serves the UI, invokes RPC, and mirrors events over WebSocket', async () => {
+  it('authenticates, invokes direct commands, and delivers projected events once in order', async () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html><title>Web test</title>')
@@ -363,14 +368,11 @@ describe('startWebHttpServer', () => {
     const socketClosed = new Promise<void>((resolve) => socket.once('close', () => resolve()))
     socket.close()
     await socketClosed
-    expect(rpc.releaseClient).not.toHaveBeenCalled()
     const secondSocketClosed = new Promise<void>((resolve) =>
       secondSocket.once('close', () => resolve())
     )
     secondSocket.close()
     await secondSocketClosed
-    await vi.waitFor(() => expect(rpc.releaseClient).toHaveBeenCalledWith('test-client'))
-    expect(rpc.releaseClient).toHaveBeenCalledTimes(1)
 
     await new Promise<void>((resolve, reject) => {
       const unauthenticatedSocket = new WebSocket(`ws://127.0.0.1:${server.port}/api/v1/events`)
@@ -493,7 +495,6 @@ describe('startWebHttpServer', () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)
     await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
-    const releaseClient = vi.fn()
     const directSignals: AbortSignal[] = []
     const directInvoke = vi.fn(async (_channel, invocation) => {
       directSignals.push(invocation.callerLease.signal)
@@ -507,7 +508,6 @@ describe('startWebHttpServer', () => {
       rpc: {
         channels: () => ['projects:list'],
         invoke: vi.fn(),
-        releaseClient,
         dispose: vi.fn()
       },
       applicationCommands: {
@@ -547,8 +547,6 @@ describe('startWebHttpServer', () => {
     await server.close()
     servers.splice(servers.indexOf(server), 1)
 
-    expect(releaseClient).toHaveBeenCalledTimes(1)
-    expect(releaseClient).toHaveBeenCalledWith('test-client')
     expect(directSignals[0]?.aborted).toBe(true)
   })
 

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -18,7 +18,6 @@ import {
 } from '../caller-context'
 import { createApplicationCommandClient } from '../application-command-client'
 import type { ApplicationCommandComposition } from '../application-command-composition'
-import type { WebRpcRouter } from '../ipc-handler-registry'
 import type { ApplicationEventSource } from '../application-events'
 import {
   isWebRpcChannel,
@@ -66,7 +65,6 @@ type WebServerOptions = {
   port: number
   token: string
   staticRoot: string
-  rpc: Pick<WebRpcRouter, 'releaseClient'>
   applicationCommands: Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb'>
   applicationEvents: ApplicationEventSource
   externalAccess?: ExternalWebAccess
@@ -426,7 +424,6 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   const commandClient = createApplicationCommandClient()
   const clientLeases = new ClientLeaseRegistry((clientId) => {
     commandClient.releaseClient('web', clientId)
-    options.rpc.releaseClient(clientId)
   })
   const wsServer = new WebSocketServer({ noServer: true })
 

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path'
 import { app } from 'electron'
 
 import type { ApplicationCommandComposition } from '../application-command-composition'
-import type { WebRpcRouter } from '../ipc-handler-registry'
 import { createLogger } from '../logger'
 import type { ApplicationEventSource } from '../application-events'
 import type { TaskAgentPort } from '../tasks/task-runner'
@@ -60,19 +59,17 @@ const authUrl = (token: string, port: number): string =>
 const buildAuthenticatedWebUrl = async (port: number): Promise<string> =>
   authUrl(await loadOrCreateWebToken(resolveConfigRoot()), port)
 
-// Builds the controller. `rpc` retains the always-installed captured fallback while Web and Task use
-// their application-owned narrow command views. `requestQuit` quits the whole app when a dedicated
-// headless daemon is asked to shut down. An attached service instead only tears itself down.
+// Builds the controller over application-owned narrow command views. `requestQuit` quits the whole
+// app when a dedicated headless daemon is asked to shut down. An attached service instead only tears
+// itself down.
 const createWebServiceController = (
   {
-    rpc,
     applicationCommands,
     requestQuit,
     externalAccess,
     applicationEvents,
     taskAgent
   }: {
-    rpc: Pick<WebRpcRouter, 'releaseClient'>
     applicationCommands: Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>
     requestQuit: () => void
     externalAccess?: ExternalWebAccess
@@ -161,7 +158,6 @@ const createWebServiceController = (
       port,
       token,
       staticRoot: join(info.appPath, 'out', 'web'),
-      rpc,
       applicationCommands: {
         localWeb: applicationCommands.localWeb,
         remoteWeb: applicationCommands.remoteWeb

--- a/src/renderer/web/api-installer.test.ts
+++ b/src/renderer/web/api-installer.test.ts
@@ -125,7 +125,7 @@ describe('installWebRendererContracts', () => {
           kind: 'method',
           parameterCodec: { electron: 'positional', web: 'positional' },
           surfaceInstallation: surface('preload', 'web-rpc'),
-          dispatchPolicy: surface('electron-ipc-request', 'captured-ipc-request'),
+          dispatchPolicy: surface('electron-ipc-request', 'direct-application-request'),
           eventDeliverability: surface('not-event', 'not-event'),
           authorityFlow: surface('electron-sender', 'caller-context'),
           mapProjection: 'invoke'

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -42,8 +42,8 @@ describe('renderer contract catalog', () => {
     ).toMatchObject({
       dispatchPolicy: {
         electron: 'electron-ipc-request',
-        localWeb: 'browser-native-with-captured-ipc',
-        remoteWeb: 'browser-native-with-captured-ipc'
+        localWeb: 'browser-native-with-direct-application-request',
+        remoteWeb: 'browser-native-with-direct-application-request'
       },
       authorityFlow: {
         electron: 'electron-sender',

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -75,11 +75,11 @@ const expandEntry = (
         ? 'browser-native'
         : 'unavailable'
   const localDispatch = isWebRequest
-    ? 'captured-ipc-request'
+    ? 'direct-application-request'
     : isWebEvent
       ? 'web-event-subscription'
       : profile === DELEGATED_NATIVE
-        ? 'browser-native-with-captured-ipc'
+        ? 'browser-native-with-direct-application-request'
         : isNative
           ? 'surface-native'
           : 'none'

--- a/src/shared/renderer-contract.test.ts
+++ b/src/shared/renderer-contract.test.ts
@@ -15,8 +15,8 @@ const seed = (publicPath: string, channel: string): RendererContractSeed => ({
   surfaceInstallation: { electron: 'preload', localWeb: 'web-rpc', remoteWeb: 'web-rpc' },
   dispatchPolicy: {
     electron: 'electron-ipc-request',
-    localWeb: 'captured-ipc-request',
-    remoteWeb: 'captured-ipc-request'
+    localWeb: 'direct-application-request',
+    remoteWeb: 'direct-application-request'
   },
   eventDeliverability: {
     electron: 'not-event',

--- a/src/shared/renderer-contract.ts
+++ b/src/shared/renderer-contract.ts
@@ -7,7 +7,7 @@ export type RendererSurfaceInstallation =
   'preload' | 'web-rpc' | 'web-event' | 'browser-native' | 'rejecting-stub' | 'unavailable'
 
 // prettier-ignore
-export type RendererDispatchPolicy = 'electron-ipc-request' | 'electron-ipc-send' | 'electron-ipc-subscription' | 'captured-ipc-request' | 'browser-native-with-captured-ipc' | 'web-event-subscription' | 'surface-native' | 'rejecting-stub' | 'none'
+export type RendererDispatchPolicy = 'electron-ipc-request' | 'electron-ipc-send' | 'electron-ipc-subscription' | 'direct-application-request' | 'browser-native-with-direct-application-request' | 'web-event-subscription' | 'surface-native' | 'rejecting-stub' | 'none'
 
 export type RendererEventDeliverability =
   'not-event' | 'electron-ipc' | 'application-event' | 'installed-undelivered' | 'unavailable'


### PR DESCRIPTION
# PR: `refactor(web): remove captured IPC dispatch`

## Problem

After Web and Headless Task moved to direct application commands, the main process still retained the
old captured IPC implementation: synthetic sender identities, a Web handler map, negative-sender
caller-context inference, and catalog vocabulary that described the obsolete route. Leaving both
paths present would obscure state ownership and invite future features to depend on the wrong seam.

## Proposed change

- Remove captured Web handler storage, `WebIpcSender`, synthetic negative sender allocation, and the
  negative-sender caller-context fallback.
- Keep the Electron registry responsible only for real WebContents leases and disposal.
- Remove the captured router from Web/Task composition and shutdown.
- Rename internal renderer catalog policies to direct application request vocabulary.
- Add source dependency certification for Web, Task façade, and TaskRunner, plus event ordering and
  single-delivery guards.

```mermaid
flowchart LR
  E["Electron renderer"] --> IPC["Real Electron IPC adapter"]
  W["Local / remote Web"] --> AC["Application command views"]
  T["Headless Task"] --> AC
  C["CLI / local RPC"] --> OWN["Existing narrow application owners"]
  IPC --> OWN
  AC --> OWN
```

## Scope and non-goals

- No public generated map, Web RPC v1 envelope, event contract, schema, data relationship, or UI
  change.
- Real Electron-event adapters required for Electron-only resource routing remain intact.
- CLI/local RPC stays on its current narrow capability path.
- Specialist, Permission, and Compute retain their existing Electron/Web/CLI asymmetry.
- Issue #458 gains only a clean future transport-neutral seam; no orchestration data or API is added.
- The separate Web type baseline correction from #717 remains unchanged here.

## Acceptance criteria and validation

All listed checks ran after the last material edit and cover the final diff.

| Behavior | Command | Final result |
| --- | --- | --- |
| No captured/synthetic production vocabulary | targeted `rg` scans + application wiring source contract | Passed |
| Electron keeps real sender lease/disposal only | IPC registry and application lifecycle suites | Passed |
| Web/Task import no IPC registry, Electron event, or sender ID | Web/Task/TaskRunner dependency scans | Passed |
| Direct Web RPC contracts and native delegation | HTTP, installer, contract catalog, surface matrix suites | Passed |
| Caller authority and local-only enforcement | caller-context, RemoteAccess, local-fs, Settings/Permission IPC suites | Passed |
| Event projection single-delivery and ordering | lifecycle broadcast/application-event suites | Passed |
| Final targeted impact set | 25 Vitest suites / 277 tests, including Upload IPC | Passed |
| Main-process types | `npm run typecheck:node` | Passed |
| Web types | `npm run typecheck:web` | Passed |
| Repository lint | `npm run lint -- --no-cache` | Passed: 0 errors, same 17 baseline warnings |
| Formatting / whitespace | Prettier + `git diff --check` | Passed |
| Independent review | Standards + final Spec | 0 findings |

Cross-platform and E2E lanes remain online PR Gate responsibilities. This branch is rebased onto
`origin/main@e5a809e`, which contains the T2h1 squash and #717 Web type correction. Exact-head CI/AI
review remains the publication gate.

The first exact-head Coverage lane found one Upload IPC test that still constructed the removed Web
caller by combining a negative sender ID with `createWebCallerContext`. The obsolete test was deleted;
Electron navigation/destruction coverage and direct Web dispatcher/lease/owner coverage remain. The
focused follow-up and independent Standards/Spec reviews passed with 0 findings.

## Review focus

- Confirm no Web/Task application invocation can reach the Electron IPC registry.
- Confirm real Electron sender lease replacement and disposal remain unchanged.
- Confirm direct-policy renames are internal only and do not alter generated wire maps.
- Confirm no transport gained Specialist, Permission, or Compute capabilities.
