### PR TITLE
fix(acp): keep large files out of model context

### DIFF
--- a/src/main/acp/attachment-content.ts
+++ b/src/main/acp/attachment-content.ts
@@ -209,7 +209,7 @@ export const formatBytes = (bytes: number): string => {
   return `${value.toFixed(1)} ${units[unit]}`
 }
 
-// Builds the text block that accompanies an oversized file's resource_link: it states why the file is
+// Builds the notice that accompanies an oversized file's local descriptor: it states why the file is
 // not inlined, tells the agent to read only what it needs, and shows a bounded preview of the start.
 export const buildOversizedAttachmentNotice = (input: {
   name: string
@@ -225,7 +225,7 @@ export const buildOversizedAttachmentNotice = (input: {
   const trailer = truncated ? '\n\n… file continues beyond this preview.' : ''
 
   return [
-    `[Attached file "${name}" (${formatBytes(size)}) is too large to include in full and is available on disk via the linked resource below.`,
+    `[Attached file "${name}" (${formatBytes(size)}) is too large to include in full and is available on disk via the local file reference below.`,
     `Do not load the whole file — read ${readHint}. For analysis over the full file, compute in the notebook rather than reading it into the conversation.`,
     'Preview of the start of the file:',
     '',
@@ -235,10 +235,10 @@ export const buildOversizedAttachmentNotice = (input: {
 }
 
 // Binary spreadsheets and scientific containers cannot provide a useful UTF-8 preview. Give the
-// agent an explicit analysis contract alongside the resource link instead of a context-free URI.
+// agent an explicit analysis contract alongside a local file reference instead of a provider file.
 export const buildDatasetAttachmentNotice = (input: { name: string; size: number }): string =>
   [
-    `[Attached dataset "${input.name}" (${formatBytes(input.size)}) is available on disk via the linked resource below.`,
+    `[Attached dataset "${input.name}" (${formatBytes(input.size)}) is available on disk via the local file reference below.`,
     'Do not load the whole file into the conversation. Inspect its schema and a small sample first, then use the notebook or a streaming/query tool to compute over the full dataset.]'
   ].join('\n')
 

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -286,6 +286,15 @@ class AcpPromptContentOwner {
         `</${tag}>`
       ].join('\n')
     })
+    const localFileTextReference = (notice: string): ContentBlock => ({
+      type: 'text',
+      text: [
+        notice,
+        '<attached_local_file>',
+        JSON.stringify({ name, uri, mimeType, size }),
+        '</attached_local_file>'
+      ].join('\n')
+    })
 
     if (
       input.skillImportEnabled &&
@@ -372,25 +381,20 @@ class AcpPromptContentOwner {
       )
 
       return [
-        {
-          type: 'text',
-          text: buildOversizedAttachmentNotice({
+        localFileTextReference(
+          buildOversizedAttachmentNotice({
             name,
             size,
             preview: preview.content,
             truncated: preview.truncated,
             tabular: isTabularAttachment(name, mimeType)
           })
-        },
-        { type: 'resource_link', uri, name, title: name, mimeType, size }
+        )
       ]
     }
 
     if (isDatasetAttachment(name, mimeType)) {
-      return [
-        { type: 'text', text: buildDatasetAttachmentNotice({ name, size }) },
-        { type: 'resource_link', uri, name, title: name, mimeType, size }
-      ]
+      return [localFileTextReference(buildDatasetAttachmentNotice({ name, size }))]
     }
 
     return [{ type: 'resource_link', uri, name, title: name, mimeType, size }]

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2864,7 +2864,7 @@ describe('ACP runtime session management', () => {
     })
   })
 
-  it('sends an oversized text upload as a bounded preview + resource_link, never the full contents', async () => {
+  it('sends compute files as bounded local references without ACP file blocks', async () => {
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
     // A >512 KB CSV: a unique marker after the preview window must never reach the prompt.
@@ -2875,7 +2875,12 @@ describe('ACP runtime session management', () => {
     expect(Buffer.byteLength(csvBody, 'utf8')).toBeGreaterThan(512 * 1024)
     const stagedAttachments = await stageUploadFixtures(uploadRepository, {
       files: [
-        { name: 'big.csv', mimeType: 'text/csv', content: Buffer.from(csvBody).toString('base64') }
+        { name: 'big.csv', mimeType: 'text/csv', content: Buffer.from(csvBody).toString('base64') },
+        {
+          name: 'matrix.xlsx',
+          mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          content: Buffer.from('workbook-bytes').toString('base64')
+        }
       ]
     })
     const process = new FakeAgentProcess()
@@ -2901,20 +2906,21 @@ describe('ACP runtime session management', () => {
 
     expect(receivedPrompts).toHaveLength(1)
     const [prompt] = receivedPrompts
-    // Order is preserved: user text, then the file's preview notice, then its link.
+    // Order is preserved: user text, then the file's preview notice and local reference.
     expect(prompt[0]).toEqual({ type: 'text', text: 'analyze this table' })
     const notice = prompt[1] as Extract<ContentBlock, { type: 'text' }>
     expect(notice.type).toBe('text')
     expect(notice.text).toContain('big.csv')
     expect(notice.text).toContain('too large to include in full')
     expect(notice.text).toContain('id,name,value')
-    expect(prompt[2]).toMatchObject({
-      type: 'resource_link',
-      name: 'big.csv',
-      mimeType: 'text/csv',
-      uri: expect.stringContaining('/uploads/default-project/remote-session-1/big.csv')
-    })
-    // The full contents are never inlined: no `resource` block, and the past-preview marker never ships.
+    expect(notice.text).toContain('<attached_local_file>')
+    expect(notice.text).toContain('/uploads/default-project/remote-session-1/big.csv')
+    const datasetNotice = prompt[2] as Extract<ContentBlock, { type: 'text' }>
+    expect(datasetNotice.text).toContain('matrix.xlsx')
+    expect(datasetNotice.text).toContain('<attached_local_file>')
+    expect(prompt).toHaveLength(3)
+    // ACP file/resource blocks can be eagerly hydrated downstream, so only bounded text ships.
+    expect(prompt.some((block) => block.type === 'resource_link')).toBe(false)
     expect(prompt.some((block) => block.type === 'resource')).toBe(false)
     expect(JSON.stringify(prompt)).not.toContain('SENTINEL_PAST_PREVIEW_WINDOW')
   })


### PR DESCRIPTION
## Problem

OpenCode eagerly hydrates ACP `resource_link` blocks. For large text attachments such as an 18.2 MB CSV, the downstream AI SDK decodes the entire file into the provider prompt, overflowing the model context even though Open Science only intended to send a bounded preview.

## Proposed change

- Keep oversized text files and compute datasets on managed disk.
- Send the existing bounded preview/instructions plus an `<attached_local_file>` JSON descriptor containing the file URI and metadata.
- Do not emit ACP `resource` or `resource_link` blocks for those compute inputs, so downstream adapters cannot eagerly inline them.

```mermaid
flowchart LR
  Upload["Large CSV / dataset"] --> Disk["Managed disk storage"]
  Disk --> Descriptor["Bounded preview + local-file descriptor"]
  Descriptor --> Context["Model context"]
  Disk --> Compute["Notebook / shell reads full file"]
  Compute --> Results["Computed results"]
  Results --> Context
```

## Scope and non-goals

- No renderer, user-flow, persistence, or data-model changes.
- Small text files, images, PDFs, archives, and ordinary binary attachments keep their existing behavior.
- This PR does not modify OpenCode or AI SDK upstream behavior.

## Acceptance criteria and validation

All checks below ran after the last material source edit and after rebasing onto the latest `origin/main`; the focused regression reran once more after a review-only test-title clarification.

- Large compute-file serialization and ACP adapter contract -> `npm test -- src/main/acp/attachment-content.test.ts src/main/acp/prompt-content-owner.test.ts src/main/acp/runtime.test.ts` -> 411 passed.
- Final focused regression -> `npm test -- src/main/acp/runtime.test.ts -t 'sends compute files as bounded local references without ACP file blocks'` -> 1 passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors; 17 pre-existing warnings outside this diff.
- Independent Standards review -> no findings.
- Independent Spec review -> no findings after clarifying the ACP test boundary.

Uncovered integration risk: the repository does not contain the OpenCode -> AI SDK -> provider adapter chain, so no live provider request was made. The regression verifies the local prevention contract: no ACP `resource`/`resource_link` reaches that external chain, and content beyond the preview sentinel is absent.

## Review focus

- Confirm `<attached_local_file>` preserves enough metadata for notebook/shell access.
- Confirm the compute-file branches are the narrowest safe place to prevent eager downstream hydration.
