### PR TITLE
refactor(runtime): remove obsolete compatibility paths

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -72,6 +72,51 @@ Open Science today is an Electron + React + TypeScript desktop application built
 | **Execution / Data Plane** | Managed code execution, artifact generation                               | Persistent Python, R, and REPL control-plane kernels plus stateless shell execution (`src/main/notebook/`) with durable, inspectable run history, app-managed environments, and remote SSH execution targets                              |
 | **Persistence**            | Project/session storage, artifact storage                                 | Prisma + SQLite for project and provenance metadata; per-project, per-file session storage on disk (`src/main/session-persistence/`); immutable artifact versions and evidence sidecars under app-managed storage (`src/main/artifacts/`) |
 
+### Runtime State Ownership and Surface Boundaries
+
+The main process has one composition root (`src/main/ipc.ts`). It constructs state owners once,
+installs transport adapters after ownership is established, and disposes modules in reverse order.
+The transport-neutral application command router and application event hub expose capabilities; they
+do not become alternate state stores.
+
+| Owner boundary                  | State and lifecycle responsibility                                                                                                                                                                                                                               |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Settings modules                | Persist provider, runtime, skill, connector, appearance, and related configuration. Runtime consumers capture a non-secret backend selection and resolve fresh credentials/configuration when a generation starts; they do not retain Settings mutable state.    |
+| ACP runtime coordinator         | Own runtime generations and stable application Session identity across reconnect/reset. A provider protocol Session id belongs to its generation and may be replaced; Codex fresh-session adoption, transcript replay, context reset, and cleanup remain intact. |
+| ACP runtime and Session owners  | Own one generation's live processes, prompts, permissions, resources, and per-turn terminal results. Context-window aggregation stays with the context-usage tracker; terminal timestamp, token usage, and model-turn count stay with the completed prompt turn. |
+| Notebook runtime                | Own runtime discovery, Session binding decisions, execution, environment operations, and durable run history. It consumes enablement snapshots through the named Settings capability rather than owning or reading raw Settings state.                           |
+| Persistence and artifact owners | Own project/session files, uploads, artifact versions, provenance, and deletion/finalization coordination. Application commands receive narrow handler capabilities instead of repositories.                                                                     |
+
+```mermaid
+flowchart LR
+  Electron["Electron IPC adapters"] --> Commands["Application command interfaces"]
+  LocalWeb["Local Web direct dispatcher"] --> Commands
+  RemoteWeb["Remote Web allow/reject dispatcher"] --> Commands
+  Task["Task / CLI subset"] --> Commands
+  Commands --> Owners["Existing Settings / ACP / Notebook / data owners"]
+  Owners --> Events["Application event interfaces"]
+  Future["Future orchestration (Issue #458)"] -. "declared interfaces only" .-> Commands
+  Future -. "publish / subscribe only" .-> Events
+```
+
+This boundary preserves the current surface asymmetry; it is not a parity roadmap:
+
+- Specialist management remains fully exposed only by Electron. The existing authenticated
+  `host.agents` capability remains separate and is not expanded into new Web or CLI management UI.
+- Permission management remains available on Electron and Web. Task/CLI retain only their current
+  permission-profile and event subset.
+- Compute management remains available on Electron and local Web. Remote Web continues to reject
+  download/reveal operations, and CLI/Task have no direct Compute management API.
+- Web and Task invoke transport-neutral application commands directly. Electron continues to use
+  typed IPC adapters; no Web or Task path captures or synthesizes an Electron sender.
+
+Issue #458 may add an orchestration layer above the ACP coordinator later. That layer must consume
+only declared Settings, ACP, Notebook, Artifact, Permission, Workspace, and Event interfaces. Compute
+remains orthogonal. It must not import concrete runtimes, Settings storage, repositories, Electron,
+renderer, Web/HTTP, Task, CLI, or Specialist modules. This refactor adds an architecture test for that
+future dependency rule, but adds no orchestration state, schema, public wire contract, or user-facing
+behavior.
+
 Key implemented capabilities, mapped to the codebase:
 
 - **Project layer.** Prisma + SQLite `Project` model; full CRUD via IPC (`projects:create/list/get/update/delete`); a home page showing all projects and the five most recent sessions across them.

--- a/src/main/acp/reviewer-session-owner.ts
+++ b/src/main/acp/reviewer-session-owner.ts
@@ -398,10 +398,6 @@ export class ReviewerSessionOwner {
     return { rejectedToolCalls, reviewerBridgeScoped }
   }
 
-  rejectedToolCallCount(sessionId: string): number {
-    return this.rejectedToolCalls.get(sessionId) ?? 0
-  }
-
   invalidatePending(): void {
     for (const token of this.pendingIds.values()) this.dependencies.removeStartupBlocker(token)
     this.pendingIds.clear()

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -769,13 +769,6 @@ class AcpRuntimeCoordinator {
     return runtime.disposeReviewerSession(session)
   }
 
-  reviewerRejectedToolCallCount(sessionId: string): number {
-    return Array.from(this.runtimes).reduce(
-      (count, runtime) => count + runtime.reviewerRejectedToolCallCount(sessionId),
-      0
-    )
-  }
-
   private createScopedActivityRuntime(
     runtime: AcpRuntime,
     options: AcpRuntimeActivityOptions

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -7563,8 +7563,10 @@ describe('ACP runtime session management', () => {
     expect(permissionResponse).toEqual({
       outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
-    expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(0)
-    runtime.disposeReviewerSession(session)
+    expect(runtime.disposeReviewerSession(session)).toEqual({
+      rejectedToolCalls: 0,
+      reviewerBridgeScoped: undefined
+    })
   })
 
   // Claude Code preserves hyphens in MCP server names in real tool traces, so the permission title
@@ -7607,8 +7609,10 @@ describe('ACP runtime session management', () => {
     expect(permissionResponse).toEqual({
       outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
-    expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(0)
-    runtime.disposeReviewerSession(session)
+    expect(runtime.disposeReviewerSession(session)).toEqual({
+      rejectedToolCalls: 0,
+      reviewerBridgeScoped: undefined
+    })
   })
 
   // Security: the toolCallId is agent-controlled, so a reviewer-shaped id must NOT authorize a call
@@ -7647,8 +7651,10 @@ describe('ACP runtime session management', () => {
     expect(permissionResponse).toEqual({
       outcome: { outcome: 'selected', optionId: 'reject-once' }
     })
-    expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(1)
-    runtime.disposeReviewerSession(session)
+    expect(runtime.disposeReviewerSession(session)).toEqual({
+      rejectedToolCalls: 1,
+      reviewerBridgeScoped: undefined
+    })
   })
 
   it('counts reviewer tool calls rejected by the strict gate', async () => {
@@ -7678,13 +7684,11 @@ describe('ACP runtime session management', () => {
     })
     await session.prompt([{ type: 'text', text: 'run a shell command' }])
 
-    expect(runtime.reviewerRejectedToolCallCount(session.sessionId)).toBe(1)
     // dispose returns the final count and clears it atomically — the orchestrator relies on this.
     expect(runtime.disposeReviewerSession(session)).toEqual({
       rejectedToolCalls: 1,
       reviewerBridgeScoped: undefined
     })
-    expect(runtime.reviewerRejectedToolCallCount('reviewer-session-1')).toBe(0)
   })
 
   it('refuses a non-loopback reviewer MCP before starting an agent connection', async () => {
@@ -12805,7 +12809,6 @@ describe('ACP runtime session management', () => {
     expect(() => runtime.disposeReviewerSession(session)).toThrow('reviewer dispose failed')
 
     expect(unregisterReviewerSession).toHaveBeenCalledWith('reviewer-session-1')
-    expect(runtime.reviewerRejectedToolCallCount('reviewer-session-1')).toBe(0)
     await expect(stat(reviewerCwd)).rejects.toMatchObject({ code: 'ENOENT' })
     await vi.waitFor(() => expect(process.killed).toBe(true))
     expect(releaseBridge).toHaveBeenCalledOnce()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -4899,12 +4899,6 @@ class AcpRuntime {
   ): ReviewerSessionDisposition {
     return this.reviewerSessions.dispose(session)
   }
-
-  // Returns how many permission requests the strict reviewer gate rejected for a given reviewer
-  // session. Non-zero means the session was active but the gate blocked its tool calls.
-  reviewerRejectedToolCallCount(sessionId: string): number {
-    return this.reviewerSessions.rejectedToolCallCount(sessionId)
-  }
 }
 
 export { AcpRuntime }

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -17,7 +17,6 @@ import {
   createComputeIpcModule,
   createJobUpdatedBroadcaster,
   installComputeIpcHandlers,
-  registerComputeIpcHandlers,
   toJobSummary
 } from './ipc'
 import type { ComputeJobRepository } from './job-repository'
@@ -1145,7 +1144,7 @@ describe('compute handlers — jobsMarkConsumed', () => {
 })
 
 // ---------------------------------------------------------------------------
-// registerComputeIpcHandlers — channel registration + enabled-hosts + error serialization
+// Compute IPC installation — channel registration + enabled-hosts + error serialization
 // ---------------------------------------------------------------------------
 
 const invokeHandler = async (channel: string, ...args: unknown[]): Promise<unknown> => {
@@ -1165,7 +1164,7 @@ const invokeExpectingError = async (channel: string, ...args: unknown[]): Promis
   throw new Error(`Handler ${channel} resolved unexpectedly; expected it to reject`)
 }
 
-describe('registerComputeIpcHandlers', () => {
+describe('installComputeIpcHandlers', () => {
   let storageRoot: string
 
   beforeEach(async () => {
@@ -1180,7 +1179,8 @@ describe('registerComputeIpcHandlers', () => {
   })
 
   it('registers every compute:* channel that the renderer can invoke', () => {
-    registerComputeIpcHandlers(mockRepository({}), mockJobRepo({}))
+    const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
+    installComputeIpcHandlers(module)
 
     const expected = [
       'compute:list',
@@ -1222,7 +1222,8 @@ describe('registerComputeIpcHandlers', () => {
   })
 
   it('round-trips the enabled-hosts registry through get/set IPC channels', async () => {
-    registerComputeIpcHandlers(mockRepository({}), mockJobRepo({}))
+    const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
+    installComputeIpcHandlers(module)
 
     // Initially empty for an unseen session.
     const initial = await invokeHandler('compute:enabled-hosts:get', 'sess-fresh')
@@ -1247,16 +1248,17 @@ describe('registerComputeIpcHandlers', () => {
   })
 
   it('returns the production computeService and jobRepository so downstream wiring can use them', () => {
-    const result = registerComputeIpcHandlers(mockRepository({}), mockJobRepo({}))
+    const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
+    installComputeIpcHandlers(module)
 
-    expect(result.computeService).toBeDefined()
-    expect(result.jobRepository).toBeDefined()
-    expect(result.hostRepository).toBeDefined()
-    expect(result.enabledComputeHostsRegistry).toBeInstanceOf(EnabledComputeHostsRegistry)
+    expect(module.computeService).toBeDefined()
+    expect(module.jobRepository).toBeDefined()
+    expect(module.hostRepository).toBeDefined()
+    expect(module.enabledComputeHostsRegistry).toBeInstanceOf(EnabledComputeHostsRegistry)
   })
 })
 
-describe('registerComputeIpcHandlers — remoteFsError serialization', () => {
+describe('installComputeIpcHandlers — remoteFsError serialization', () => {
   let storageRoot: string
 
   beforeEach(async () => {
@@ -1270,9 +1272,8 @@ describe('registerComputeIpcHandlers — remoteFsError serialization', () => {
     await rm(storageRoot, { recursive: true, force: true })
   })
 
-  // Drive the handler installed by registerComputeIpcHandlers directly. registerComputeIpcHandlers
-  // accepts a `service` seam so the renderer-callable try/catch wrapper around listDir / download
-  // is exercised end-to-end against a fake service — no hand-rolled wrapper duplication.
+  // Drive the production create/install seams directly so the renderer-callable try/catch wrapper
+  // around listDir / download is exercised end-to-end against a fake service.
   it('encodes a remoteFsError on the compute:list-dir channel via the production handler wrapper', async () => {
     const fsErr = new Error('no such file or directory') as Error & {
       remoteFsError: { detail: string; remoteKind: 'not_found'; retry_after_user_action: boolean }
@@ -1285,7 +1286,8 @@ describe('registerComputeIpcHandlers — remoteFsError serialization', () => {
     const listDir = vi.fn(() => Promise.reject(fsErr))
     const service = mockService({ listDir })
 
-    registerComputeIpcHandlers(mockRepository({}), mockJobRepo({}), undefined, service)
+    const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}), undefined, service)
+    installComputeIpcHandlers(module)
 
     const err = await invokeExpectingError('compute:list-dir', 'ssh:biowulf', '/missing')
 
@@ -1307,7 +1309,8 @@ describe('registerComputeIpcHandlers — remoteFsError serialization', () => {
     const download = vi.fn(() => Promise.reject(fsErr))
     const service = mockService({ download })
 
-    registerComputeIpcHandlers(mockRepository({}), mockJobRepo({}), undefined, service)
+    const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}), undefined, service)
+    installComputeIpcHandlers(module)
 
     const dest: DownloadDest = { kind: 'os-downloads' }
     const err = await invokeExpectingError('compute:download', 'ssh:biowulf', '/some/dir', dest)
@@ -1323,7 +1326,8 @@ describe('registerComputeIpcHandlers — remoteFsError serialization', () => {
     const download = vi.fn(() => Promise.reject(new Error('boom: plain failure')))
     const service = mockService({ download })
 
-    registerComputeIpcHandlers(mockRepository({}), mockJobRepo({}), undefined, service)
+    const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}), undefined, service)
+    installComputeIpcHandlers(module)
 
     const dest: DownloadDest = { kind: 'os-downloads' }
     const err = await invokeExpectingError('compute:download', 'ssh:biowulf', '/x', dest)

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -624,39 +624,12 @@ const installComputeIpcHandlers = (module: ComputeIpcAdapter): IpcHandlerInstall
   }
 }
 
-// Compatibility wrapper for isolated callers; application composition uses the two-phase seam above.
-const registerComputeIpcHandlers = (
-  repository = createDefaultComputeHostRepository(),
-  jobRepository = createDefaultComputeJobRepository(),
-  artifactResolver?: ArtifactResolver,
-  injectedService?: ComputeService,
-  taskNotifications?: Pick<TaskNotificationService, 'handleComputeApproval'>,
-  permissionGrantRegistry?: PermissionGrantRegistry
-): Omit<ComputeIpcModule, 'handlers'> => {
-  const module = createComputeIpcModule(
-    repository,
-    jobRepository,
-    artifactResolver,
-    injectedService,
-    taskNotifications,
-    permissionGrantRegistry
-  )
-  installComputeIpcHandlers(module)
-  return {
-    computeService: module.computeService,
-    jobRepository: module.jobRepository,
-    hostRepository: module.hostRepository,
-    enabledComputeHostsRegistry: module.enabledComputeHostsRegistry
-  }
-}
-
 export {
   createComputeHandlers,
   createComputeIpcModule,
   createDefaultComputeHostRepository,
   createDefaultComputeJobRepository,
   installComputeIpcHandlers,
-  registerComputeIpcHandlers,
   enabledComputeHostsRegistry
 }
 export type { ComputeHandlers, ComputeIpcModule }

--- a/src/main/notebook/e2e.certification.test.ts
+++ b/src/main/notebook/e2e.certification.test.ts
@@ -111,10 +111,17 @@ const makeHarness = async (opts: { idleTimeoutMs?: number } = {}): Promise<Harne
     // v4 seam: discovery surfaces the system python as a user-own runtime and enablement turns it on,
     // so the session can bind it below (no micromamba provisioning exists on this machine).
     discoverRuntimes: async (language) => (language === 'python' ? [externalPython] : []),
-    getRuntimeEnablement: async () => ({
-      enabled: { [pyBin as string]: true },
-      installAuthorized: {}
-    }),
+    notebookRuntimeSettings: {
+      getSnapshot: async (language) => ({
+        language,
+        runtimeEnablement: {
+          enabled: { [pyBin as string]: true },
+          installAuthorized: {}
+        },
+        manualInterpreters: [],
+        packageMirror: {}
+      })
+    },
     // The real kernel executor with the shipped loop scripts. No micromamba provisioning exists on this
     // machine, so the two runtimes reach the system interpreters by different (both production) routes:
     // Python via the Runtime Registry's EXTERNAL (BYO) seam (setRuntimeSelectionResolver below), R via

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -508,10 +508,17 @@ describe('notebook runtime service', () => {
       dataRoot: root,
       projectName: 'default-project',
       repository: new NotebookRunRepository(root),
-      getRuntimeEnablement: async () => ({
-        enabled: { [defaultInterpreter]: false },
-        installAuthorized: {}
-      }),
+      notebookRuntimeSettings: {
+        getSnapshot: async (language) => ({
+          language,
+          runtimeEnablement: {
+            enabled: { [defaultInterpreter]: false },
+            installAuthorized: {}
+          },
+          manualInterpreters: [],
+          packageMirror: {}
+        })
+      },
       environmentStateTracker,
       executorFactory: () => ({ execute, shutdown: async () => ({ reaped: true }) })
     })
@@ -3486,10 +3493,17 @@ describe('notebook runtime service', () => {
                 }
               ]
             : [],
-        getRuntimeEnablement: async () => ({
-          enabled: { [runtimeId]: true },
-          installAuthorized: {}
-        }),
+        notebookRuntimeSettings: {
+          getSnapshot: async (language) => ({
+            language,
+            runtimeEnablement: {
+              enabled: { [runtimeId]: true },
+              installAuthorized: {}
+            },
+            manualInterpreters: [],
+            packageMirror: {}
+          })
+        },
         environmentStateTracker: {
           prepareRun: vi.fn(),
           captureCompletedRun: vi.fn(),
@@ -7338,10 +7352,17 @@ describe('v4 runtime bindings & agent tools', () => {
       projectName: 'default-project',
       repository: new NotebookRunRepository(root),
       discoverRuntimes: async (language) => (language === 'python' ? [userPyA, userPyB] : []),
-      getRuntimeEnablement: async () => ({
-        enabled: { [userPyA.envId]: true, [userPyB.envId]: true },
-        installAuthorized: {}
-      }),
+      notebookRuntimeSettings: {
+        getSnapshot: async (language) => ({
+          language,
+          runtimeEnablement: {
+            enabled: { [userPyA.envId]: true, [userPyB.envId]: true },
+            installAuthorized: {}
+          },
+          manualInterpreters: [],
+          packageMirror: {}
+        })
+      },
       executorFactory: () => ({
         execute: () => {
           executionCount += 1

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -117,6 +117,15 @@ import {
 // to public hosts, so this default never silently forces a CN mirror).
 const DEFAULT_LOCALE = 'en-US'
 
+const EMPTY_NOTEBOOK_RUNTIME_SETTINGS: Pick<NotebookRuntimeSettings, 'getSnapshot'> = {
+  getSnapshot: async (language) => ({
+    language,
+    runtimeEnablement: { enabled: {}, installAuthorized: {} },
+    manualInterpreters: [],
+    packageMirror: {}
+  })
+}
+
 const REPAIR_QUARANTINE_FAILED = 'REPAIR_QUARANTINE_FAILED'
 
 const isRepairQuarantineError = (error: unknown): boolean =>
@@ -240,17 +249,8 @@ type NotebookRuntimeServiceOptions = {
   // double works just as well as the real disk-backed settings service.
   getPackageMirror?: () => PackageMirror | undefined | Promise<PackageMirror | undefined>
   // Stable, detached Settings capability used by runtime discovery and binding policy. Production
-  // injects this named capability; the raw resolvers below remain compatibility seams for isolated
-  // callers and tests that predate the Settings capability split.
+  // injects this named capability; isolated tests may omit it and receive a fail-safe empty policy.
   notebookRuntimeSettings?: Pick<NotebookRuntimeSettings, 'getSnapshot'>
-  // Resolves the v4 per-language enablement (enabled/install-authorized maps) used to gate which
-  // discovered runtimes the agent may bind. Undefined / returning undefined -> the provenance defaults
-  // (app-managed enabled; user-own disabled), so an omitted resolver can never enable a BYO env — the
-  // enable gate holds by default (defense-in-depth).
-  getRuntimeEnablement?: (language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>
-  // Resolves Settings-added interpreters that are not discoverable from PATH/conda roots. Injected at
-  // construction so production cannot briefly expose a different catalog during startup.
-  getManualInterpreters?: (language: NotebookLanguage) => Promise<string[]>
   // Discovers the interpreters available for a language (app-managed + user-own). Injectable so tests
   // don't spawn real interpreters; production defaults to environment-discovery over the runtime root.
   discoverRuntimes?: (language: NotebookLanguage) => Promise<DiscoveredInterpreter[]>
@@ -449,12 +449,9 @@ class NotebookRuntimeService {
     this.recoveryCoordinator = new NotebookRecoveryCoordinator(getRuntimeRoot(options.dataRoot))
     this.mcpRpcConnectionResolver = options.getMcpRpcConnection
     this.packageMirrorResolver = options.getPackageMirror
-    this.runtimeEnablementResolver = options.notebookRuntimeSettings
-      ? async (language) =>
-          (await options.notebookRuntimeSettings?.getSnapshot(language))?.runtimeEnablement
-      : options.getRuntimeEnablement
-    const runtimeSettings =
-      options.notebookRuntimeSettings ?? this.legacyRuntimeSettingsCapability(options)
+    const runtimeSettings = options.notebookRuntimeSettings ?? EMPTY_NOTEBOOK_RUNTIME_SETTINGS
+    this.runtimeEnablementResolver = async (language) =>
+      (await runtimeSettings.getSnapshot(language)).runtimeEnablement
     this.runtimeBindingOwner = new NotebookRuntimeBindingOwner({
       dataRoot: options.dataRoot,
       repository: this.repository,
@@ -505,25 +502,6 @@ class NotebookRuntimeService {
       platform: options.platform,
       shellProcess: options.shellProcess
     })
-  }
-
-  private legacyRuntimeSettingsCapability(
-    options: NotebookRuntimeServiceOptions
-  ): Pick<NotebookRuntimeSettings, 'getSnapshot'> {
-    return {
-      getSnapshot: async (language) => {
-        const [runtimeEnablement, manualInterpreters] = await Promise.all([
-          options.getRuntimeEnablement?.(language).catch(() => undefined),
-          options.getManualInterpreters?.(language).catch(() => [])
-        ])
-        return {
-          language,
-          runtimeEnablement: runtimeEnablement ?? { enabled: {}, installAuthorized: {} },
-          manualInterpreters: manualInterpreters ?? [],
-          packageMirror: {}
-        }
-      }
-    }
   }
 
   private async resolveRuntimeEnablement(

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -1,0 +1,442 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { basename, dirname, relative, resolve, sep } from 'node:path'
+
+import {
+  createSourceFile,
+  forEachChild,
+  isCallExpression,
+  isExportDeclaration,
+  isExpressionWithTypeArguments,
+  isIdentifier,
+  isImportDeclaration,
+  isImportTypeNode,
+  isLiteralTypeNode,
+  isNamedImports,
+  isStringLiteralLike,
+  isTypeReferenceNode,
+  isUnionTypeNode,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  type Node
+} from 'typescript'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+
+import type { AcpApplicationCommandDependencies } from './acp/application-commands'
+import type { ApplicationEventPublisher, ApplicationEventSource } from './application-events'
+import type { DataContentApplicationCommandDependencies } from './data-content-application-commands'
+import type { installNotebookEnvironmentApplicationCommands } from './notebook/environment-application-commands'
+import type { NotebookApplicationCommandDependencies } from './notebook/application-commands'
+import type { RuntimeApplicationCommandDependencies } from './notebook/runtime-application-commands'
+import type { registerPermissionGrantApplicationCommands } from './permission-grants/application-commands'
+import type { CoreSettingsApplicationCommandDependencies } from './settings/application-commands'
+import type { IntegrationSettingsApplicationCommandDependencies } from './settings/integration-application-commands'
+import type { RuntimeSettingsApplicationCommandDependencies } from './settings/runtime-application-commands'
+
+type FutureOrchestrationInterfaces = Readonly<{
+  settings: Readonly<{
+    settingsCore: CoreSettingsApplicationCommandDependencies
+    settingsIntegration: IntegrationSettingsApplicationCommandDependencies
+    settingsRuntime: RuntimeSettingsApplicationCommandDependencies
+  }>
+  acp: AcpApplicationCommandDependencies
+  notebook: Readonly<{
+    notebook: NotebookApplicationCommandDependencies
+    notebookEnvironment: Parameters<typeof installNotebookEnvironmentApplicationCommands>[1]
+    notebookRuntime: RuntimeApplicationCommandDependencies
+  }>
+  artifacts: Pick<DataContentApplicationCommandDependencies, 'artifacts'>
+  permission: Parameters<typeof registerPermissionGrantApplicationCommands>[1]
+  workspace: Pick<
+    DataContentApplicationCommandDependencies,
+    'projects' | 'projectFiles' | 'sessions'
+  >
+  events: ApplicationEventPublisher & ApplicationEventSource
+}>
+
+const projectRoot = resolve(__dirname, '../..')
+const mainRoot = resolve(projectRoot, 'src/main')
+const orchestrationRoot = resolve(mainRoot, 'orchestration')
+const readSource = (path: string): string => readFileSync(resolve(projectRoot, path), 'utf8')
+const modulePath = (path: string): string => path.replace(/\.(?:[cm]?[jt]sx?)$/, '')
+
+type ImportReference = Readonly<{
+  specifier: string
+  kind: 'named-type' | 'other'
+  names: readonly string[]
+}>
+
+const importReferencesFrom = (source: string): readonly ImportReference[] => {
+  const imports: ImportReference[] = []
+  const sourceFile = createSourceFile(
+    'architecture-source.ts',
+    source,
+    ScriptTarget.Latest,
+    true,
+    ScriptKind.TS
+  )
+  const visit = (node: Node): void => {
+    if (
+      (isImportDeclaration(node) || isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      const clause = isImportDeclaration(node) ? node.importClause : undefined
+      const bindings = clause?.namedBindings
+      const elements = bindings && isNamedImports(bindings) ? bindings.elements : undefined
+      const typeOnlyNames =
+        elements &&
+        !clause?.name &&
+        elements.every(
+          (element) => !element.propertyName && (clause?.isTypeOnly || element.isTypeOnly)
+        )
+          ? elements.map((element) => element.name.text)
+          : undefined
+      imports.push({
+        specifier: node.moduleSpecifier.text,
+        kind: typeOnlyNames ? 'named-type' : 'other',
+        names: typeOnlyNames ?? []
+      })
+    } else if (isImportTypeNode(node)) {
+      const argument = node.argument
+      imports.push({
+        specifier:
+          isLiteralTypeNode(argument) && isStringLiteralLike(argument.literal)
+            ? argument.literal.text
+            : '<dynamic import type>',
+        kind: 'other',
+        names: []
+      })
+    } else if (isCallExpression(node)) {
+      const [argument] = node.arguments
+      const isRequire = isIdentifier(node.expression) && node.expression.text === 'require'
+      const isDynamicImport = node.expression.kind === SyntaxKind.ImportKeyword
+      if (isRequire || isDynamicImport) {
+        imports.push({
+          specifier:
+            node.arguments.length === 1 && argument && isStringLiteralLike(argument)
+              ? argument.text
+              : isRequire
+                ? '<dynamic require>'
+                : '<dynamic import>',
+          kind: 'other',
+          names: []
+        })
+      }
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return imports
+}
+
+const resolveImportTarget = (sourcePath: string, specifier: string): string | undefined =>
+  specifier.startsWith('.')
+    ? modulePath(resolve(dirname(resolve(projectRoot, sourcePath)), specifier))
+    : undefined
+
+const CONCRETE_OWNER_TARGETS = new Set([
+  modulePath(resolve(mainRoot, 'acp/runtime')),
+  modulePath(resolve(mainRoot, 'acp/runtime-coordinator')),
+  modulePath(resolve(mainRoot, 'notebook/runtime-service')),
+  modulePath(resolve(mainRoot, 'settings/service')),
+  modulePath(resolve(mainRoot, 'settings/types'))
+])
+
+const isCurrentSeamViolation = (sourcePath: string, specifier: string): boolean => {
+  const target = resolveImportTarget(sourcePath, specifier)
+  return (
+    specifier === 'electron' ||
+    specifier.startsWith('electron/') ||
+    (target !== undefined &&
+      (CONCRETE_OWNER_TARGETS.has(target) ||
+        /(?:^|-)repository$/.test(basename(target)) ||
+        target.startsWith(resolve(mainRoot, 'web-service') + sep) ||
+        (dirname(target) === mainRoot && basename(target).startsWith('renderer')) ||
+        basename(target).includes('http')))
+  )
+}
+
+const currentSeamViolations = (sourcePath: string, source: string): readonly string[] =>
+  importReferencesFrom(source)
+    .map(({ specifier }) => specifier)
+    .filter((specifier) => isCurrentSeamViolation(sourcePath, specifier))
+
+const FUTURE_INTERFACE_IMPORTS = new Map<string, ReadonlySet<string>>([
+  [
+    modulePath(resolve(mainRoot, 'acp/application-commands')),
+    new Set(['AcpApplicationCommandDependencies'])
+  ],
+  [
+    modulePath(resolve(mainRoot, 'notebook/application-commands')),
+    new Set(['NotebookApplicationCommandDependencies'])
+  ],
+  [
+    modulePath(resolve(mainRoot, 'notebook/environment-application-commands')),
+    new Set(['installNotebookEnvironmentApplicationCommands'])
+  ],
+  [
+    modulePath(resolve(mainRoot, 'notebook/runtime-application-commands')),
+    new Set(['RuntimeApplicationCommandDependencies'])
+  ],
+  [
+    modulePath(resolve(mainRoot, 'settings/application-commands')),
+    new Set(['CoreSettingsApplicationCommandDependencies'])
+  ],
+  [
+    modulePath(resolve(mainRoot, 'settings/integration-application-commands')),
+    new Set(['IntegrationSettingsApplicationCommandDependencies'])
+  ],
+  [
+    modulePath(resolve(mainRoot, 'settings/runtime-application-commands')),
+    new Set(['RuntimeSettingsApplicationCommandDependencies'])
+  ],
+  [
+    modulePath(resolve(mainRoot, 'data-content-application-commands')),
+    new Set(['DataContentApplicationCommandDependencies'])
+  ],
+  [
+    modulePath(resolve(mainRoot, 'permission-grants/application-commands')),
+    new Set(['registerPermissionGrantApplicationCommands'])
+  ],
+  [
+    modulePath(resolve(mainRoot, 'application-events')),
+    new Set(['ApplicationEventPublisher', 'ApplicationEventSource'])
+  ]
+])
+
+const isWithin = (path: string, root: string): boolean =>
+  path === root || path.startsWith(root + sep)
+
+const isFutureOrchestrationImportAllowed = (
+  sourcePath: string,
+  reference: ImportReference
+): boolean => {
+  const target = resolveImportTarget(sourcePath, reference.specifier)
+  if (target === undefined) return false
+  if (isWithin(target, orchestrationRoot)) return true
+  const allowedNames = FUTURE_INTERFACE_IMPORTS.get(target)
+  return (
+    reference.kind === 'named-type' &&
+    allowedNames !== undefined &&
+    reference.names.length > 0 &&
+    reference.names.every((name) => allowedNames.has(name))
+  )
+}
+
+const hasInvalidDataContentTypeUse = (source: string): boolean => {
+  const sourceFile = createSourceFile(
+    'future-orchestration.ts',
+    source,
+    ScriptTarget.Latest,
+    true,
+    ScriptKind.TS
+  )
+  const allowedKeys = new Set(['artifacts', 'projects', 'projectFiles', 'sessions'])
+  let invalid = false
+  const literalKeys = (node: Node): readonly string[] | undefined => {
+    if (isLiteralTypeNode(node) && isStringLiteralLike(node.literal)) return [node.literal.text]
+    if (isUnionTypeNode(node)) {
+      const keys = node.types.flatMap((type) => literalKeys(type) ?? [])
+      return keys.length === node.types.length ? keys : undefined
+    }
+    return undefined
+  }
+  const visit = (node: Node): void => {
+    if (
+      isTypeReferenceNode(node) &&
+      isIdentifier(node.typeName) &&
+      node.typeName.text === 'DataContentApplicationCommandDependencies'
+    ) {
+      const pick = node.parent
+      const keys =
+        isTypeReferenceNode(pick) &&
+        isIdentifier(pick.typeName) &&
+        pick.typeName.text === 'Pick' &&
+        pick.typeArguments?.[0] === node &&
+        pick.typeArguments[1]
+          ? literalKeys(pick.typeArguments[1])
+          : undefined
+      if (!keys || keys.some((key) => !allowedKeys.has(key))) invalid = true
+    } else if (
+      isExpressionWithTypeArguments(node) &&
+      isIdentifier(node.expression) &&
+      node.expression.text === 'DataContentApplicationCommandDependencies'
+    ) {
+      invalid = true
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return invalid
+}
+
+const futureOrchestrationViolations = (sourcePath: string, source: string): readonly string[] => {
+  const violations = importReferencesFrom(source)
+    .filter((reference) => !isFutureOrchestrationImportAllowed(sourcePath, reference))
+    .map(({ specifier }) => specifier)
+  if (hasInvalidDataContentTypeUse(source)) {
+    violations.push('DataContentApplicationCommandDependencies')
+  }
+  return violations
+}
+
+const productionOrchestrationSources = (): readonly string[] => {
+  if (!existsSync(orchestrationRoot)) return []
+  const files: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isDirectory()) {
+        visit(path)
+      } else if (
+        /\.[cm]?tsx?$/.test(entry.name) &&
+        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
+      ) {
+        files.push(relative(projectRoot, path))
+      }
+    }
+  }
+  visit(orchestrationRoot)
+  return files.sort()
+}
+
+describe('runtime state ownership architecture', () => {
+  it('defines the future orchestration seam only from declared application interfaces', () => {
+    expectTypeOf<keyof FutureOrchestrationInterfaces>().toEqualTypeOf<
+      'settings' | 'acp' | 'notebook' | 'artifacts' | 'permission' | 'workspace' | 'events'
+    >()
+    expectTypeOf<keyof FutureOrchestrationInterfaces['settings']>().toEqualTypeOf<
+      'settingsCore' | 'settingsIntegration' | 'settingsRuntime'
+    >()
+    expectTypeOf<keyof FutureOrchestrationInterfaces['notebook']>().toEqualTypeOf<
+      'notebook' | 'notebookEnvironment' | 'notebookRuntime'
+    >()
+    expectTypeOf<keyof FutureOrchestrationInterfaces['artifacts']>().toEqualTypeOf<'artifacts'>()
+    expectTypeOf<keyof FutureOrchestrationInterfaces['workspace']>().toEqualTypeOf<
+      'projects' | 'projectFiles' | 'sessions'
+    >()
+    expectTypeOf<FutureOrchestrationInterfaces['events']>().toEqualTypeOf<
+      ApplicationEventPublisher & ApplicationEventSource
+    >()
+  })
+
+  it('keeps the current seams free of known concrete owners, repositories, and transports', () => {
+    const seamSources = [
+      'src/main/application-command-composition.ts',
+      'src/main/application-events.ts'
+    ]
+
+    for (const path of seamSources) {
+      expect(currentSeamViolations(path, readSource(path)), path).toEqual([])
+    }
+  })
+
+  it('accepts declared interface imports for a future orchestration module', () => {
+    const source = `
+      import type { AcpApplicationCommandDependencies } from '../acp/application-commands'
+      import type { NotebookApplicationCommandDependencies } from '../notebook/application-commands'
+      import type { installNotebookEnvironmentApplicationCommands } from '../notebook/environment-application-commands'
+      import type { RuntimeApplicationCommandDependencies } from '../notebook/runtime-application-commands'
+      import type { CoreSettingsApplicationCommandDependencies } from '../settings/application-commands'
+      import type { IntegrationSettingsApplicationCommandDependencies } from '../settings/integration-application-commands'
+      import type { RuntimeSettingsApplicationCommandDependencies } from '../settings/runtime-application-commands'
+      import type { DataContentApplicationCommandDependencies } from '../data-content-application-commands'
+      import type { registerPermissionGrantApplicationCommands } from '../permission-grants/application-commands'
+      import type { ApplicationEventPublisher, ApplicationEventSource } from '../application-events'
+      import { coordinateStep } from './coordinate-step'
+      type Artifacts = Pick<DataContentApplicationCommandDependencies, 'artifacts'>
+      type Workspace = Pick<
+        DataContentApplicationCommandDependencies,
+        'projects' | 'projectFiles' | 'sessions'
+      >
+    `
+
+    expect(futureOrchestrationViolations('src/main/orchestration/orchestrator.ts', source)).toEqual(
+      []
+    )
+  })
+
+  it.each([
+    ['../application-command-composition', 'ApplicationCommandCompositionDependencies'],
+    ['../acp/runtime', 'AcpRuntime'],
+    ['../acp/runtime-coordinator.js', 'AcpRuntimeCoordinator'],
+    ['../acp/reviewer-session-owner', 'ReviewerSessionOwner'],
+    ['../settings/service', 'SettingsService'],
+    ['../settings/backend-resolver', 'AgentBackendResolver'],
+    ['../settings/ipc', 'registerSettingsIpcHandlers'],
+    ['../settings/types', 'StoredSettings'],
+    ['../notebook/runtime-service', 'NotebookRuntimeService'],
+    ['../notebook/execution-owner', 'NotebookExecutionOwner'],
+    ['../notebook/local-rpc-server', 'NotebookLocalRpcServer'],
+    ['../artifacts/repository', 'ArtifactRepository'],
+    ['../tasks/task-runner', 'TaskRunner'],
+    ['../specialist/service', 'ProfileService'],
+    ['../ipc', 'createApplicationModules'],
+    ['../renderer-broadcast', 'broadcastToRenderers'],
+    ['../web-service/http-server', 'WebHttpServer'],
+    ['electron', 'ipcMain'],
+    ['../compute/application-commands', 'ComputeApplicationCommandDependencies'],
+    ['../../../packages/open-science/index', 'OpenScienceClient']
+  ])('rejects direct future orchestration dependency on %s', (specifier, symbol) => {
+    const source = `import { ${symbol} } from '${specifier}'`
+
+    expect(futureOrchestrationViolations('src/main/orchestration/orchestrator.ts', source)).toEqual(
+      [specifier]
+    )
+  })
+
+  it('rejects value and namespace imports from an allowed interface module', () => {
+    const source = `
+      import { registerAcpCommands } from '../acp/application-commands'
+      import type * as AcpCommands from '../acp/application-commands'
+    `
+
+    expect(futureOrchestrationViolations('src/main/orchestration/orchestrator.ts', source)).toEqual(
+      ['../acp/application-commands', '../acp/application-commands']
+    )
+  })
+
+  it('rejects broad or non-owned data-content capability access', () => {
+    const source = `
+      import type { DataContentApplicationCommandDependencies } from '../data-content-application-commands'
+      type WholeDataPlane = DataContentApplicationCommandDependencies
+      type Uploads = Pick<DataContentApplicationCommandDependencies, 'uploads'>
+      interface ExtendedDataPlane extends DataContentApplicationCommandDependencies {}
+    `
+
+    expect(futureOrchestrationViolations('src/main/orchestration/orchestrator.ts', source)).toEqual(
+      ['DataContentApplicationCommandDependencies']
+    )
+  })
+
+  it('rejects dynamic imports and CommonJS requires outside the future interface seam', () => {
+    const source = `
+      const runtime = import('../acp/runtime')
+      const settings = require('../settings/service')
+    `
+
+    expect(futureOrchestrationViolations('src/main/orchestration/orchestrator.ts', source)).toEqual(
+      ['../acp/runtime', '../settings/service']
+    )
+  })
+
+  it('rejects import types and non-literal module loading', () => {
+    const source = `
+      type Runtime = import('../acp/runtime').AcpRuntime
+      type DynamicType = import(typePath).Owner
+      const settings = require(settingsPath)
+      const notebook = import(notebookPath)
+    `
+
+    expect(futureOrchestrationViolations('src/main/orchestration/orchestrator.ts', source)).toEqual(
+      ['../acp/runtime', '<dynamic import type>', '<dynamic require>', '<dynamic import>']
+    )
+  })
+
+  it('keeps production orchestration modules on the declared interface seam once introduced', () => {
+    for (const path of productionOrchestrationSources()) {
+      expect(futureOrchestrationViolations(path, readSource(path)), path).toEqual([])
+    }
+  })
+})

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -18,6 +18,7 @@ import type {
 import type { ClaudeSharedAuthControllerPort } from './claude-shared-auth'
 import type { UserSkillRepository } from '../skills/user-skill-repository'
 import type { SystemProxyEnvironment } from './system-proxy'
+import type { AgentBackendResolutionContext } from './backend-resolver'
 
 // Reversible fake safeStorage so provider keys can be encrypted/decrypted without an OS keychain.
 vi.mock('electron', () => ({
@@ -49,6 +50,14 @@ const { netFetch } = await import('../skills/net-fetch')
 const { net: mockedNet } = (await import('electron')) as unknown as {
   net: { fetch: ReturnType<typeof vi.fn> }
 }
+
+// Production captures the non-secret framework selection at generation construction, then resolves
+// current credentials and provider configuration at spawn. Integration tests use that same public seam.
+const resolveActiveBackend = async (
+  service: InstanceType<typeof SettingsService>,
+  context: AgentBackendResolutionContext = {}
+): ReturnType<InstanceType<typeof SettingsService>['resolveAgentBackend']> =>
+  service.resolveAgentBackend(await service.captureActiveAgentBackendSelection(), context)
 
 let storageRoot: string
 let repository: InstanceType<typeof SettingsRepository>
@@ -1085,7 +1094,7 @@ describe('SettingsService: providers', () => {
       lastValidatedAt: Date.now()
     })
     await service.setActiveProvider(view.id)
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
     expect(content.provider.anthropic.models.m.limit.context).toBe(64_000)
   })
@@ -1112,7 +1121,7 @@ describe('SettingsService: providers', () => {
       lastValidatedAt: Date.now()
     })
     await service.setActiveProvider(view.id)
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
     expect(content.provider.anthropic.models.m.limit.context).toBe(200_000)
   })
@@ -1133,7 +1142,7 @@ describe('SettingsService: providers', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
 
-    const backend = await service.resolveActiveAgentBackend({
+    const backend = await resolveActiveBackend(service, {
       systemPromptAppends: ['Stable Open Science app guidance.']
     })
 
@@ -1881,7 +1890,9 @@ describe('SettingsService: preflight & spawn config', () => {
     })
     await service.setActiveProvider(CLAUDE_SHARED_PROVIDER_ID)
 
-    await expect(service.getClaudeSharedStatus()).resolves.toMatchObject({ ok: true })
+    await expect(
+      service.validateProvider({ providerId: CLAUDE_SHARED_PROVIDER_ID })
+    ).resolves.toMatchObject({ ok: true })
     await expect(service.getPreflight()).resolves.toMatchObject({ activeProviderReady: true })
 
     expect(claudeSharedAuth.getStatus).toHaveBeenCalledOnce()
@@ -2100,7 +2111,7 @@ describe('SettingsService: preflight & spawn config', () => {
     await service.setActiveProvider(provider.id)
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
 
-    const backend = await service.resolveActiveAgentBackend({
+    const backend = await resolveActiveBackend(service, {
       systemPromptAppends: ['Stable Open Science developer guidance.']
     })
     const selection = await service.captureActiveAgentBackendSelection()
@@ -2178,7 +2189,7 @@ describe('SettingsService: preflight & spawn config', () => {
     await service.setActiveProvider(provider.id, 'gpt-5.4')
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     expect(JSON.parse(backend.env.CODEX_CONFIG ?? '{}')).not.toHaveProperty('model_catalog_json')
   })
@@ -2216,7 +2227,7 @@ describe('SettingsService: preflight & spawn config', () => {
     await service.setActiveProvider(provider.id, 'gpt-5.4')
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     expect(JSON.parse(backend.env.CODEX_CONFIG ?? '{}')).toHaveProperty('model_catalog_json')
   })
@@ -2255,7 +2266,7 @@ describe('SettingsService: preflight & spawn config', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     expect(backend.executablePath).toBe(adapterPath)
     expect(await readFile(adapterPath, 'utf8')).toContain(
@@ -2300,7 +2311,7 @@ describe('SettingsService: preflight & spawn config', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     expect(backend.executablePath).toBe(managedAdapterPath)
     expect(backend.env.CODEX_PATH).toBe(globalNativePath)
@@ -2339,7 +2350,7 @@ describe('SettingsService: preflight & spawn config', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
 
-    await expect(service.resolveActiveAgentBackend()).rejects.toThrow(
+    await expect(resolveActiveBackend(service)).rejects.toThrow(
       'Open Science Codex ACP adapter not found. Install Codex in settings.'
     )
   })
@@ -2368,7 +2379,7 @@ describe('SettingsService: preflight & spawn config', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
 
-    await expect(service.resolveActiveAgentBackend()).rejects.toThrow(
+    await expect(resolveActiveBackend(service)).rejects.toThrow(
       'Codex native executable not found. Re-detect or install Codex in settings.'
     )
   })
@@ -2450,7 +2461,7 @@ describe('SettingsService: preflight & spawn config', () => {
     )
 
     expect(await service.getPreflight()).toMatchObject({ activeProviderReady: true })
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     expect(backend.backendId).toBe('codex:builtin-codex-isolated')
     expect(backend.sessionModel).toBe('gpt-5.6-terra')
@@ -2485,7 +2496,7 @@ describe('SettingsService: preflight & spawn config', () => {
       codexDetected: { path: adapterPath, version: 'codex-acp 1.1.4' },
       resolveCodexProxyEnvironment: () => Promise.resolve(undefined)
     })
-    const fallbackBackend = await fallbackService.resolveActiveAgentBackend()
+    const fallbackBackend = await resolveActiveBackend(fallbackService)
 
     expect(fallbackBackend.proxyEnvironmentMode).toBe('inherit')
     expect(fallbackBackend.env).not.toHaveProperty('HTTP_PROXY')
@@ -2516,14 +2527,14 @@ describe('SettingsService: preflight & spawn config', () => {
     })
     await service.setActiveProvider(CODEX_SHARED_PROVIDER_ID)
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     expect(backend.sessionModel).toBeUndefined()
     expect(backend.sessionModelRequired).toBeUndefined()
   })
 
   it('declares the model image capability in the resolved OpenCode backend config', async () => {
-    // resolveActiveAgentBackend honors this forced-framework env above stored settings; set it
+    // AgentBackendResolver honors this forced-framework env above stored settings; set it
     // explicitly (a prior Codex test leaves it stubbed to 'codex') so this resolves OpenCode.
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
     await repository.setAgentFramework('opencode')
@@ -2535,7 +2546,7 @@ describe('SettingsService: preflight & spawn config', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     // End-to-end guard for the whole capability chain: resolveProvider must carry supportsImageInput
     // for the multimodal default (kimi-k3) and prepareModelConfig must surface it, so OpenCode receives
@@ -2565,13 +2576,13 @@ describe('SettingsService: preflight & spawn config', () => {
     ).providers[0]
 
     await service.setActiveProvider(provider.id, 'glm-5.1')
-    const smallBackend = await service.resolveActiveAgentBackend()
+    const smallBackend = await resolveActiveBackend(service)
     const smallConfig = JSON.parse(smallBackend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
     expect(smallBackend.contextWindow).toBe(200_000)
     expect(smallConfig.provider['openai-compatible'].models['glm-5.1'].limit.context).toBe(200_000)
 
     await service.setActiveProvider(provider.id, 'glm-5.2')
-    const largeBackend = await service.resolveActiveAgentBackend()
+    const largeBackend = await resolveActiveBackend(service)
     const largeConfig = JSON.parse(largeBackend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
     expect(largeBackend.contextWindow).toBe(1_000_000)
     expect(largeConfig.provider['openai-compatible'].models['glm-5.2'].limit.context).toBe(
@@ -2635,7 +2646,7 @@ describe('SettingsService: preflight & spawn config', () => {
     await repository.setReasoningEffort('low')
 
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     // Chat Completions provider ⇒ bridge ⇒ Codex runs the classic-tool-mode catalog model so it
     // advertises the shell_command function tool the bridge can forward (CODEX_BRIDGE_MODEL).
@@ -2715,7 +2726,7 @@ describe('SettingsService: preflight & spawn config', () => {
     await backend.responsesBridgeLease?.release()
     await repository.setConversationSkillImportEnabled(false)
     upstreamRequest = undefined
-    const disabledBackend = await service.resolveActiveAgentBackend()
+    const disabledBackend = await resolveActiveBackend(service)
     const disabledBridgeResponse = await localFetch(
       `${disabledBackend.providerConfiguration?.baseUrl}/responses`,
       {
@@ -2812,9 +2823,9 @@ describe('SettingsService: preflight & spawn config', () => {
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
 
     await service.setActiveProvider(first.id)
-    const firstBackend = await service.resolveActiveAgentBackend()
+    const firstBackend = await resolveActiveBackend(service)
     await service.setActiveProvider(second.id)
-    const secondBackend = await service.resolveActiveAgentBackend()
+    const secondBackend = await resolveActiveBackend(service)
 
     expect(firstBackend.providerConfiguration?.baseUrl).not.toBe(
       secondBackend.providerConfiguration?.baseUrl
@@ -2898,7 +2909,7 @@ describe('SettingsService: preflight & spawn config', () => {
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
 
     try {
-      await expect(service.resolveActiveAgentBackend()).rejects.toBe(startError)
+      await expect(resolveActiveBackend(service)).rejects.toBe(startError)
       expect(closeSpy).toHaveBeenCalledOnce()
     } finally {
       startSpy.mockRestore()
@@ -2937,7 +2948,7 @@ describe('SettingsService: preflight & spawn config', () => {
     await service.setActiveProvider(provider.id)
 
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     expect(backend.providerConfiguration).toEqual({
       providerId: 'custom-gateway',
@@ -2993,10 +3004,10 @@ describe('SettingsService: preflight & spawn config', () => {
     ).providers[0]
     await service.setActiveProvider(created.id)
 
-    const config = await service.resolveActiveSpawnConfig()
+    const config = await resolveActiveBackend(service)
 
     expect(config.executablePath).toBe(execPath)
-    expect(config.envOverrides).toMatchObject({
+    expect(config.env).toMatchObject({
       // A user-supplied trailing /v1 is normalized away; the client appends /v1/messages itself.
       ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
       ANTHROPIC_AUTH_TOKEN: 'test-key',
@@ -3010,7 +3021,7 @@ describe('SettingsService: preflight & spawn config', () => {
       }
     })
     // Custom providers always use the bearer token variable, never x-api-key.
-    expect(config.envOverrides.ANTHROPIC_API_KEY).toBeUndefined()
+    expect(config.env.ANTHROPIC_API_KEY).toBeUndefined()
   })
 
   it('does not inject WebFetch preflight settings into isolated Claude sessions', async () => {
@@ -3023,7 +3034,7 @@ describe('SettingsService: preflight & spawn config', () => {
     })
     await service.setActiveProvider(CLAUDE_ISOLATED_PROVIDER_ID)
 
-    const config = await service.resolveActiveSpawnConfig()
+    const config = await resolveActiveBackend(service)
 
     expect(config.sessionOptions).toBeUndefined()
   })
@@ -3032,7 +3043,7 @@ describe('SettingsService: preflight & spawn config', () => {
     const service = createService()
     await repository.setClaudeInfo({ resolvedPath: execPath, version: '2.1.0' })
 
-    await expect(service.resolveActiveSpawnConfig()).rejects.toThrow(/active model provider/i)
+    await expect(resolveActiveBackend(service)).rejects.toThrow(/active model provider/i)
   })
 })
 
@@ -3120,9 +3131,9 @@ describe('SettingsService: official vendors', () => {
     ).providers[0]
     await service.setActiveProvider(created.id, 'deepseek-v4-flash')
 
-    const config = await service.resolveActiveSpawnConfig()
+    const config = await resolveActiveBackend(service)
 
-    expect(config.envOverrides).toMatchObject({
+    expect(config.env).toMatchObject({
       ANTHROPIC_BASE_URL: 'https://api.deepseek.com/anthropic',
       ANTHROPIC_AUTH_TOKEN: 'sk-ds',
       ANTHROPIC_MODEL: 'deepseek-v4-flash'
@@ -3150,7 +3161,7 @@ describe('SettingsService: official vendors', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id, 'deepseek-v4-flash')
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     expect(backend.contextUsageModel).toBe('deepseek-v4-flash')
   })
@@ -3626,11 +3637,11 @@ describe('SettingsService: skills', () => {
       )
 
     // Disabled: the skill is not materialized on a normal spawn.
-    await service.resolveActiveSpawnConfig()
+    await resolveActiveBackend(service)
     expect(await exists(skillDir)).toBe(false)
 
     // Turn-forced: the disabled skill is materialized for this spawn only.
-    await service.resolveActiveSpawnConfig({ forcedSkillIds: ['demo'] })
+    await resolveActiveBackend(service, { forcedSkillIds: ['demo'] })
     expect(await exists(skillDir)).toBe(true)
 
     // The stored disabled set is untouched, so the skill still lists as disabled.
@@ -3638,7 +3649,7 @@ describe('SettingsService: skills', () => {
     expect(skills.find((skill) => skill.id === 'demo')?.enabled).toBe(false)
 
     // Clearing the force set removes it again on the next spawn.
-    await service.resolveActiveSpawnConfig()
+    await resolveActiveBackend(service)
     expect(await exists(skillDir)).toBe(false)
   })
 
@@ -3672,10 +3683,10 @@ describe('SettingsService: skills', () => {
     const managedSkillDir = join(appClaudeDir, 'skills', 'os-demo')
     const managedSkillFile = join(managedSkillDir, 'SKILL.md')
     try {
-      const config = await service.resolveActiveSpawnConfig()
-      const backend = await service.resolveActiveAgentBackend()
+      const config = await resolveActiveBackend(service)
+      const backend = await resolveActiveBackend(service)
 
-      expect(config.envOverrides.CLAUDE_CONFIG_DIR).toBe(userClaudeDir)
+      expect(config.env.CLAUDE_CONFIG_DIR).toBe(userClaudeDir)
       expect(config.sessionOptions).toEqual({
         settings: join(appClaudeDir, 'settings.json'),
         plugins: [{ type: 'local', path: appClaudeDir, skipMcpDiscovery: true }]
@@ -3714,7 +3725,7 @@ describe('SettingsService: skills', () => {
     await service.upsertProvider({ type: 'claude-shared', model: 'claude-opus-4-8' })
     await service.setActiveProvider(CLAUDE_SHARED_PROVIDER_ID, 'claude-opus-4-8')
 
-    await expect(service.resolveActiveSpawnConfig()).resolves.toMatchObject({
+    await expect(resolveActiveBackend(service)).resolves.toMatchObject({
       contextWindow: 1_000_000
     })
   })
@@ -3762,7 +3773,7 @@ describe('SettingsService: skills', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
 
-    await service.resolveActiveAgentBackend()
+    await resolveActiveBackend(service)
 
     const materializedDir = join(storageRoot, 'codex', 'skills', 'os-demo')
     const materializedFile = join(materializedDir, 'SKILL.md')
@@ -3874,7 +3885,7 @@ describe('SettingsService: skills', () => {
     })
     await service.setActiveProvider(CODEX_SHARED_PROVIDER_ID)
 
-    await service.resolveActiveAgentBackend()
+    await resolveActiveBackend(service)
 
     expect(
       await readFile(
@@ -4591,7 +4602,7 @@ describe('SettingsService: reasoning effort', () => {
     expect(await service.resolveActiveReasoningEffort('max')).toBe('default')
 
     await repository.setReasoningEffort('max')
-    expect((await service.resolveActiveAgentBackend()).sessionEffort).toBeUndefined()
+    expect((await resolveActiveBackend(service)).sessionEffort).toBeUndefined()
   })
 
   it('does not guess an effort profile for an unpinned Claude subscription model', async () => {
@@ -4605,13 +4616,13 @@ describe('SettingsService: reasoning effort', () => {
     await repository.setReasoningEffort('max')
 
     expect(await service.resolveActiveReasoningEffort('max')).toBe('default')
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
     expect(backend.sessionEffort).toBeUndefined()
     expect(backend.env).not.toHaveProperty('ANTHROPIC_MODEL')
   })
 
   it('passes the model-mapped effort to both OpenCode delivery channels', async () => {
-    // resolveActiveAgentBackend honors this forced-framework env above stored settings; set it
+    // AgentBackendResolver honors this forced-framework env above stored settings; set it
     // explicitly (a prior test may leave it stubbed) so this resolves OpenCode.
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
     await repository.setAgentFramework('opencode')
@@ -4629,7 +4640,7 @@ describe('SettingsService: reasoning effort', () => {
     await service.setActiveProvider(provider.id, 'deepseek-v4-pro')
     await repository.setReasoningEffort('low')
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     expect(backend.sessionEffort).toBe('none')
     // The official vendor identity survives provider resolution, so OpenCode receives DeepSeek's
@@ -4660,7 +4671,7 @@ describe('SettingsService: reasoning effort', () => {
     const stored = (await repository.getSettings()).providers[0]
     await repository.upsertProvider({ ...stored, fetchedModels: ['claude-opus-5'] })
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
 
     expect(backend.sessionModel).toBe('claude-opus-5')
@@ -4684,7 +4695,7 @@ describe('SettingsService: reasoning effort', () => {
     await service.setActiveProvider(provider.id)
     await repository.setReasoningEffort('low')
 
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
 
     expect(backend.framework.id).toBe('claude-code')
     expect(backend.sessionEffort).toBe('low')
@@ -4710,11 +4721,11 @@ describe('SettingsService: reasoning effort', () => {
     await service.setActiveProvider(provider.id)
 
     // Unset: nothing stored yet.
-    expect((await service.resolveActiveAgentBackend()).sessionEffort).toBeUndefined()
+    expect((await resolveActiveBackend(service)).sessionEffort).toBeUndefined()
 
     // 'default' means "don't override": the agent keeps its own default effort.
     await repository.setReasoningEffort('default')
-    expect((await service.resolveActiveAgentBackend()).sessionEffort).toBeUndefined()
+    expect((await resolveActiveBackend(service)).sessionEffort).toBeUndefined()
   })
 
   it('lets the owning runtime update its live bridge with a model-resolved effort', async () => {
@@ -4766,7 +4777,7 @@ describe('SettingsService: reasoning effort', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')
-    const backend = await service.resolveActiveAgentBackend()
+    const backend = await resolveActiveBackend(service)
     const post = (): Promise<string> =>
       localFetch(`${backend.providerConfiguration?.baseUrl}/responses`, {
         method: 'POST',
@@ -5597,7 +5608,7 @@ describe('SettingsService: claude-isolated login + status coordination', () => {
       lastValidationFailure: undefined
     })
 
-    const result = await service.getClaudeIsolatedStatus()
+    const result = await service.validateProvider({ providerId: CLAUDE_ISOLATED_PROVIDER_ID })
 
     expect(probe).toHaveBeenCalledOnce()
     expect(result).toMatchObject({ ok: false, category: 'auth' })
@@ -6490,18 +6501,18 @@ describe('SettingsService: claude-shared login orchestration', () => {
         (provider) => provider.id === CLAUDE_SHARED_PROVIDER_ID
       )?.disconnectedAt
     ).toBeGreaterThan(0)
-    await expect(service.getClaudeSharedStatus()).resolves.toMatchObject({
+    await expect(
+      service.validateProvider({ providerId: CLAUDE_SHARED_PROVIDER_ID })
+    ).resolves.toMatchObject({
       ok: false,
       category: 'auth',
       message: expect.stringContaining('disconnected from Open Science')
     })
-    await expect(service.resolveActiveSpawnConfig()).rejects.toThrow(
-      /disconnected from Open Science/
-    )
+    await expect(resolveActiveBackend(service)).rejects.toThrow(/disconnected from Open Science/)
 
     await expect(service.loginClaudeShared()).resolves.toMatchObject({ ok: true, applied: true })
-    await expect(service.resolveActiveSpawnConfig()).resolves.toMatchObject({
-      envOverrides: expect.objectContaining({
+    await expect(resolveActiveBackend(service)).resolves.toMatchObject({
+      env: expect.objectContaining({
         CLAUDE_CONFIG_DIR: join(storageRoot, 'no-user-claude')
       })
     })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -83,8 +83,7 @@ import { AgentRuntimeManager, type ExecuteClaudeProbe } from './agent-runtime-ma
 import {
   AgentBackendResolver,
   type AgentBackendResolutionContext,
-  type AgentBackendSelection,
-  type AgentSpawnConfig
+  type AgentBackendSelection
 } from './backend-resolver'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import { SkillRegistry } from '../skills/registry'
@@ -753,14 +752,6 @@ class SettingsService {
     return this.providers.logoutClaudeShared()
   }
 
-  async getClaudeSharedStatus(): Promise<ValidateProviderResult> {
-    return this.providers.getClaudeSharedStatus()
-  }
-
-  async getClaudeIsolatedStatus(): Promise<ValidateProviderResult> {
-    return this.providers.getClaudeIsolatedStatus()
-  }
-
   async setActiveProvider(id: string, model?: string): Promise<SettingsSnapshot> {
     await this.providers.setActiveProvider(id, model)
     return this.getSettingsView()
@@ -868,24 +859,6 @@ class SettingsService {
     await this.repository.setComputeBookmarks(providerId, folders)
   }
 
-  // Builds the spawn env for the active provider, read fresh so switching takes effect on reconnect.
-  async resolveActiveSpawnConfig(
-    context: AgentBackendResolutionContext = {}
-  ): Promise<AgentSpawnConfig> {
-    return this.backendResolver.resolveActiveSpawnConfig(context)
-  }
-
-  // Resolves the active agent backend for one connect: the selected framework plus its spawn inputs.
-  // Claude reuses the existing provider-env path unchanged; other frameworks (opencode) map the active
-  // provider to their own native config (a generated opencode.json) via the framework adapter and get
-  // it written to disk before spawn. The framework can be forced with OPEN_SCIENCE_AGENT_FRAMEWORK for
-  // the spike until the settings selector lands.
-  async resolveActiveAgentBackend(
-    context: AgentBackendResolutionContext = {}
-  ): Promise<ResolvedAgentBackend> {
-    return this.backendResolver.resolveActiveBackend(context)
-  }
-
   // Captures only non-secret backend identity. Runtime generations resolve credentials again at spawn,
   // so decrypted keys are not retained by the coordinator after AcpRuntime finishes authentication.
   async captureActiveAgentBackendSelection(): Promise<AgentBackendSelection> {
@@ -905,8 +878,4 @@ const createDefaultSettingsService = (): SettingsService => new SettingsService(
 
 export { SettingsService, createDefaultSettingsService }
 export type { CustomServerSecurityChangeGuard }
-export type {
-  AgentBackendResolutionContext,
-  AgentBackendSelection,
-  AgentSpawnConfig
-} from './backend-resolver'
+export type { AgentBackendResolutionContext, AgentBackendSelection } from './backend-resolver'


### PR DESCRIPTION
# PR: `refactor(runtime): remove obsolete compatibility paths`

## Problem

The runtime ownership migration left several compatibility entry points that had no production
callers: a Compute registration wrapper used only by tests, legacy Notebook Settings resolver
options, SettingsService forwarding methods, and an ACP reviewer rejection getter chain. Keeping
these paths would let new tests or features depend on superseded ownership seams.

Issue #458 also needs a clear future dependency boundary, but adding a placeholder orchestrator or
schema in this cleanup would prematurely create a second source of runtime state.

## Proposed change

- Remove the obsolete Compute, Notebook, Settings, and ACP compatibility paths.
- Migrate tests to the production create/install seam, named Notebook Settings capability, public
  Settings backend capture/resolve capability, provider validation capability, and atomic reviewer
  disposition.
- Add a test-only architecture rule for any future `src/main/orchestration/` production module:
  imports are restricted to exact, type-only application interfaces for Settings, ACP, Notebook,
  Artifact, Permission, Workspace, and Events; concrete owners, repositories, transports, Task/CLI,
  Specialist, and Compute imports are rejected.
- Document current runtime state ownership and cross-surface compatibility in `docs/PRD.md`.

```mermaid
flowchart LR
  E["Electron IPC"] --> I["Declared application interfaces"]
  W["Local / remote Web direct dispatch"] --> I
  T["Task / CLI subset"] --> I
  I --> O["Existing state owners"]
  F["Future Issue #458 orchestration"] -. "type-only interface dependencies" .-> I
  F -. "no direct dependency" .-> C["Compute / transports / repositories"]
```

## Scope and non-goals

- No public IPC/Web/Task/CLI contract, schema, data relationship, persistence, authority, or UI
  change.
- No production orchestrator, orchestration state, Session tree, MCP/API/CLI surface, or placeholder
  directory is added for Issue #458.
- `AcpRuntimeCoordinator`, `AcpRuntime`, `SettingsService`, `NotebookRuntimeService`,
  `NotebookApplication.runtime`, and `HeadlessTaskApi` remain because they have production callers.
- `settings/service-capabilities.ts` remains because ACP composition and window wiring still consume
  its narrow interfaces; moving it here would create unrelated shared-file churn.
- Specialist remains Electron-complete with the existing authenticated `host.agents` capability;
  Permission remains Electron/Web-complete with the existing Task/CLI subset; Compute remains
  Electron/local-Web complete, remote Web keeps download/reveal denial, and CLI/Task gain no direct
  Compute management API.

## Acceptance criteria and validation

All listed checks ran after the last material edit and cover the final diff.

| Behavior | Command | Final result |
| --- | --- | --- |
| Cleanup uses current owner seams | Core Compute/ACP/Notebook/Settings targeted suites | Passed: 4 suites / 512 tests |
| Reviewer rejection accounting remains atomic | affected ACP reviewer tests | Passed: 5 tests |
| Future orchestration dependency rule | `runtime-state-ownership.architecture.test.ts` | Passed: 28 tests |
| Electron and application composition remain aligned | application composition/wiring/Electron suites | Passed |
| Renderer/Web/Task surface inventories remain unchanged | renderer catalog/matrix + Web event/index/task/HTTP suites | Passed: 9 suites / 55 tests |
| CLI compatibility | `npm run test:cli` | Passed: 3 suites / 31 tests |
| Main-process types | `npm run typecheck:node` | Passed |
| Web types and generated contract | `npm run typecheck:web`; `npm run check:web-api-map` | Passed |
| Changed-source lint and formatting | exact-file ESLint, Prettier, `git diff --check` | Passed |
| Independent review | Standards + Spec across cleanup, architecture test, and PRD | 0 findings |

The Web HTTP and Settings bridge tests were rerun outside the sandbox because sandboxed loopback
listen fails with `EPERM`; both passed there. Notebook certification skipped 9 host-runtime Python/R
cases on this machine. Full coverage, platform E2E, CodeQL, security, and complete-suite checks remain
the exact-head online PR Gate.

## Review focus

- Confirm every removed API had no production caller and replacement tests use a current public owner
  seam.
- Confirm the architecture test rejects broad aggregate, value, namespace, alias, dynamic, CommonJS,
  repository, transport, and orthogonal Compute dependencies without adding production orchestration.
- Confirm the PRD records current state and surface asymmetry rather than promising parity or Issue
  #458 behavior.

Refs #458
