### PR TITLE
refactor(acp): add Session resume policy

### DIFF
--- a/src/main/acp/session-resume-policy.test.ts
+++ b/src/main/acp/session-resume-policy.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest'
+
+import { AcpSessionResumePolicy } from './session-resume-policy'
+
+describe('ACP Session resume policy', () => {
+  it('resumes a compatible provider Session without replacing the stable App Session identity', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.decide({
+        appSessionId: 'stable-app-session',
+        providerSessionId: 'provider-session-42',
+        previousFrameworkId: 'opencode',
+        currentFrameworkId: 'opencode',
+        previousBackendId: 'opencode:provider-a',
+        currentBackendId: 'opencode:provider-a',
+        resumeCapabilityAdvertised: true
+      })
+    ).toEqual({
+      action: 'resume',
+      reason: 'compatible',
+      appSessionId: 'stable-app-session',
+      providerSessionId: 'provider-session-42',
+      contextReset: false
+    })
+  })
+
+  it.each([
+    {
+      name: 'framework',
+      previousFrameworkId: 'claude-code' as const,
+      currentFrameworkId: 'opencode' as const,
+      previousBackendId: 'shared-backend',
+      currentBackendId: 'shared-backend',
+      reason: 'framework-changed'
+    },
+    {
+      name: 'backend',
+      previousFrameworkId: 'codex' as const,
+      currentFrameworkId: 'codex' as const,
+      previousBackendId: 'codex:shared',
+      currentBackendId: 'codex:isolated',
+      reason: 'backend-changed'
+    }
+  ])('adopts under the stable App Session ID when the $name affinity changes', (affinity) => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.decide({
+        appSessionId: 'stable-app-session',
+        providerSessionId: 'old-provider-session',
+        ...affinity,
+        resumeCapabilityAdvertised: false
+      })
+    ).toEqual({
+      action: 'adopt',
+      reason: affinity.reason,
+      appSessionId: 'stable-app-session',
+      providerSessionId: 'old-provider-session',
+      contextReset: true
+    })
+  })
+
+  it('adopts a fresh Codex Session when the provider Session ID is not a UUID', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.decide({
+        appSessionId: '019fb8c8-6c66-7f22-9653-17b5b287dbbb',
+        providerSessionId: 'ses_0458258b7ffeH2DeqPYBPk6fh2',
+        previousFrameworkId: 'codex',
+        currentFrameworkId: 'codex',
+        resumeCapabilityAdvertised: true
+      })
+    ).toEqual({
+      action: 'adopt',
+      reason: 'codex-provider-session-id-incompatible',
+      appSessionId: '019fb8c8-6c66-7f22-9653-17b5b287dbbb',
+      providerSessionId: 'ses_0458258b7ffeH2DeqPYBPk6fh2',
+      contextReset: true
+    })
+  })
+
+  it.each([
+    '019fb8c8-6c66-7f22-9653-17b5b287dbbb',
+    'urn:uuid:019fb8c8-6c66-7f22-9653-17b5b287dbbb'
+  ])(
+    'resumes the valid Codex provider Session ID %s under a stable App alias',
+    (providerSessionId) => {
+      const policy = new AcpSessionResumePolicy()
+
+      expect(
+        policy.decide({
+          appSessionId: 'stable-app-session',
+          providerSessionId,
+          previousFrameworkId: 'codex',
+          currentFrameworkId: 'codex',
+          resumeCapabilityAdvertised: true
+        })
+      ).toEqual({
+        action: 'resume',
+        reason: 'compatible',
+        appSessionId: 'stable-app-session',
+        providerSessionId,
+        contextReset: false
+      })
+    }
+  )
+
+  it('adopts instead of sending a legacy OpenCode Session ID to Claude', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.decide({
+        appSessionId: 'stable-app-session',
+        providerSessionId: 'ses_03fed93d1ffe1uw7XFraUNPhun',
+        currentFrameworkId: 'claude-code',
+        resumeCapabilityAdvertised: true
+      })
+    ).toEqual({
+      action: 'adopt',
+      reason: 'opencode-provider-session-id-incompatible-with-claude',
+      appSessionId: 'stable-app-session',
+      providerSessionId: 'ses_03fed93d1ffe1uw7XFraUNPhun',
+      contextReset: true
+    })
+  })
+
+  it('fails a same-backend resume when the Agent did not advertise resume support', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.decide({
+        appSessionId: 'stable-app-session',
+        currentFrameworkId: 'opencode',
+        previousFrameworkId: 'opencode',
+        previousBackendId: 'opencode:provider-a',
+        currentBackendId: 'opencode:provider-a',
+        resumeCapabilityAdvertised: false
+      })
+    ).toEqual({
+      action: 'fail',
+      reason: 'resume-capability-not-advertised',
+      appSessionId: 'stable-app-session',
+      providerSessionId: 'stable-app-session',
+      contextReset: false,
+      message: 'ACP agent does not support session resume.'
+    })
+  })
+
+  it('classifies the ACP resource-not-found response as adoptable', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(policy.classifyFailure({ code: -32002, message: 'Resource not found' })).toEqual({
+      disposition: 'adoptable',
+      reason: 'resource-not-found-code'
+    })
+  })
+
+  it('classifies a legacy session-not-found message as adoptable', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(policy.classifyFailure({ code: -32603, message: 'Session not found' })).toEqual({
+      disposition: 'adoptable',
+      reason: 'session-not-found-message'
+    })
+  })
+
+  it('treats the provider session-service marker as an adoptable failure', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.classifyFailure({
+        code: -32603,
+        message: 'OpenCode service failure',
+        data: { service: 'session' }
+      })
+    ).toEqual({
+      disposition: 'adoptable',
+      reason: 'session-service-failure'
+    })
+  })
+
+  it.each([
+    'session-not-found',
+    'conversation_not_found',
+    'Session Missing',
+    'conversation-missing',
+    'session_resume_failed',
+    'conversation restore failed'
+  ])('recognizes the structured unresumable error kind %s', (errorKind) => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.classifyFailure({
+        code: -32603,
+        message: 'Internal error',
+        data: { errorKind, details: 'localized diagnostic' }
+      })
+    ).toEqual({
+      disposition: 'adoptable',
+      reason: 'unresumable-error-kind'
+    })
+  })
+
+  it('keeps an unknown structured reason authoritative even when its detail looks adoptable', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.classifyFailure({
+        code: -32603,
+        message: 'Internal error',
+        data: {
+          errorKind: 'provider-error',
+          details: 'Failed to restore the previous conversation'
+        }
+      })
+    ).toEqual({
+      disposition: 'authoritative',
+      reason: 'unknown-error-kind'
+    })
+  })
+
+  it.each([
+    'Failed to restore the previous conversation',
+    'The session identifier was not found',
+    'No saved session is available'
+  ])('recognizes a narrow legacy unresumable detail: %s', (details) => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.classifyFailure({
+        code: -32603,
+        message: 'Internal error',
+        data: { details }
+      })
+    ).toEqual({
+      disposition: 'adoptable',
+      reason: 'legacy-unresumable-details'
+    })
+  })
+
+  it('keeps an explicit non-session service failure authoritative', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.classifyFailure({
+        code: -32603,
+        message: 'Internal error',
+        data: { service: 'provider' }
+      })
+    ).toEqual({
+      disposition: 'authoritative',
+      reason: 'non-session-service-failure'
+    })
+  })
+
+  it('keeps the legacy detail-free Internal error adoptable', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(policy.classifyFailure({ code: -32603, message: 'Internal error' })).toEqual({
+      disposition: 'adoptable',
+      reason: 'legacy-internal-error-without-details'
+    })
+  })
+
+  it.each([
+    'Authentication failed while configuring the provider',
+    'Failed to load session provider credentials',
+    'Unable to load Model Context Protocol server for this session',
+    'Unknown model context for this conversation'
+  ])('keeps an unrelated Internal error authoritative: %s', (details) => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.classifyFailure({ code: -32603, message: 'Internal error', data: { details } })
+    ).toEqual({
+      disposition: 'authoritative',
+      reason: 'unrelated-internal-error'
+    })
+  })
+
+  it.each([
+    { code: -32602, message: 'Invalid params' },
+    { code: -32603, message: 'Internal error: provider blew up' }
+  ])('keeps the non-resumable provider error $code / $message authoritative', (failure) => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(policy.classifyFailure(failure)).toEqual({
+      disposition: 'authoritative',
+      reason: 'non-internal-error'
+    })
+  })
+
+  it('classifies hostile error objects without invoking their traps beyond recovery', () => {
+    const policy = new AcpSessionResumePolicy()
+    const hostileMessage = Object.defineProperty({ code: -32603 }, 'message', {
+      get: () => {
+        throw new Error('message getter trap')
+      }
+    })
+    const hostileError = new Proxy(
+      {},
+      {
+        get: () => {
+          throw new Error('error proxy trap')
+        }
+      }
+    )
+    const hostileData = {
+      code: -32603,
+      message: 'Internal error',
+      data: new Proxy(
+        {},
+        {
+          get: () => {
+            throw new Error('data proxy trap')
+          }
+        }
+      )
+    }
+
+    for (const failure of [hostileMessage, hostileError, hostileData]) {
+      expect(policy.classifyFailure(failure)).toEqual({
+        disposition: 'authoritative',
+        reason: 'uninspectable-error'
+      })
+    }
+  })
+})

--- a/src/main/acp/session-resume-policy.ts
+++ b/src/main/acp/session-resume-policy.ts
@@ -144,8 +144,9 @@ const authoritativeFailure = (
   reason: AcpSessionResumeAuthoritativeFailureReason
 ): AcpSessionResumeFailureClassification => Object.freeze({ disposition: 'authoritative', reason })
 
-// Pure preflight and provider-error policy. Session ownership, protocol calls, and replay remain with
-// the provider Session transactions that consume these decisions.
+// ARD-04 intentionally adds this pure policy without a production caller. ARD-20 exclusively owns
+// the Runtime cutover once its transaction seams exist; integrating here would violate the serialized
+// hot-file boundary. Session ownership, protocol calls, and replay stay with those transactions.
 class AcpSessionResumePolicy {
   decide(input: AcpSessionResumePolicyInput): AcpSessionResumeDecision {
     const providerSessionId = input.providerSessionId ?? input.appSessionId

--- a/src/main/acp/session-resume-policy.ts
+++ b/src/main/acp/session-resume-policy.ts
@@ -1,0 +1,278 @@
+import type { AgentFrameworkId } from '../../shared/settings'
+
+type AcpSessionResumePolicyInput = Readonly<{
+  appSessionId: string
+  providerSessionId?: string
+  previousFrameworkId?: AgentFrameworkId
+  currentFrameworkId: AgentFrameworkId
+  previousBackendId?: string
+  currentBackendId?: string
+  resumeCapabilityAdvertised: boolean
+}>
+
+type AcpSessionResumeAdoptionReason =
+  | 'framework-changed'
+  | 'backend-changed'
+  | 'codex-provider-session-id-incompatible'
+  | 'opencode-provider-session-id-incompatible-with-claude'
+
+const isCodexProviderSessionId = (sessionId: string): boolean =>
+  /^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)
+
+type AcpSessionResumeDecisionIdentity = Readonly<{
+  appSessionId: string
+  providerSessionId: string
+}>
+
+type AcpSessionResumeDecision =
+  | (AcpSessionResumeDecisionIdentity &
+      Readonly<{
+        action: 'resume'
+        reason: 'compatible'
+        contextReset: false
+      }>)
+  | (AcpSessionResumeDecisionIdentity &
+      Readonly<{
+        action: 'adopt'
+        reason: AcpSessionResumeAdoptionReason
+        contextReset: true
+      }>)
+  | (AcpSessionResumeDecisionIdentity &
+      Readonly<{
+        action: 'fail'
+        reason: 'resume-capability-not-advertised'
+        contextReset: false
+        message: 'ACP agent does not support session resume.'
+      }>)
+
+type AcpSessionResumeAdoptableFailureReason =
+  | 'resource-not-found-code'
+  | 'session-not-found-message'
+  | 'session-service-failure'
+  | 'unresumable-error-kind'
+  | 'legacy-unresumable-details'
+  | 'legacy-internal-error-without-details'
+
+type AcpSessionResumeAuthoritativeFailureReason =
+  | 'unrecognized-error'
+  | 'unknown-error-kind'
+  | 'non-session-service-failure'
+  | 'unrelated-internal-error'
+  | 'non-internal-error'
+  | 'uninspectable-error'
+
+type AcpSessionResumeFailureClassification =
+  | Readonly<{
+      disposition: 'adoptable'
+      reason: AcpSessionResumeAdoptableFailureReason
+    }>
+  | Readonly<{
+      disposition: 'authoritative'
+      reason: AcpSessionResumeAuthoritativeFailureReason
+    }>
+
+type SafePropertyRead = Readonly<{ readable: true; value: unknown }> | Readonly<{ readable: false }>
+
+const readProperty = (value: unknown, property: string): SafePropertyRead => {
+  if ((typeof value !== 'object' || value === null) && typeof value !== 'function') {
+    return { readable: true, value: undefined }
+  }
+
+  try {
+    return { readable: true, value: Reflect.get(value, property) }
+  } catch {
+    return { readable: false }
+  }
+}
+
+const UNRESUMABLE_ERROR_KINDS = new Set([
+  'session_not_found',
+  'conversation_not_found',
+  'session_missing',
+  'conversation_missing',
+  'session_resume_failed',
+  'conversation_restore_failed'
+])
+
+const isUnresumableErrorKind = (value: unknown): boolean =>
+  typeof value === 'string' &&
+  UNRESUMABLE_ERROR_KINDS.has(
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_|_$/g, '')
+  )
+
+// Legacy agents may expose only English diagnostics. This fallback stays narrow because a false
+// positive silently drops provider context, while a false negative preserves the original error.
+const describesUnresumableSession = (details: unknown): boolean => {
+  if (typeof details !== 'string') return false
+  if (
+    /\b(?:auth|authentication|authorization|credential|provider|mcp|model|tool|server)\b/i.test(
+      details
+    )
+  ) {
+    return false
+  }
+
+  const describesMissingSession =
+    /\b(?:session|conversation)(?:\s+(?:id|identifier))?\s+(?:(?:was|is)\s+)?(?:not found|missing|unknown)\b/i.test(
+      details
+    ) ||
+    /\b(?:session|conversation)(?:\s+(?:id|identifier))?\s+does not exist\b/i.test(details) ||
+    /\b(?:no|missing|unknown)\s+(?:saved\s+|previous\s+)?(?:session|conversation)\b/i.test(details)
+  const describesFailedResume =
+    /\b(?:failed|unable|cannot|can't|could not)\s+to\s+(?:resume|restore|reopen|reattach)\b.{0,80}\b(?:session|conversation)\b/i.test(
+      details
+    ) ||
+    /\b(?:session|conversation)\b.{0,40}\b(?:failed|was unable)\s+to\s+(?:resume|restore|reopen|reattach)\b/i.test(
+      details
+    ) ||
+    /\b(?:session|conversation)\b.{0,40}\b(?:could not|cannot|can't)\s+be\s+(?:resumed|restored|reopened|reattached)\b/i.test(
+      details
+    )
+
+  return describesMissingSession || describesFailedResume
+}
+
+const adoptableFailure = (
+  reason: AcpSessionResumeAdoptableFailureReason
+): AcpSessionResumeFailureClassification => Object.freeze({ disposition: 'adoptable', reason })
+
+const authoritativeFailure = (
+  reason: AcpSessionResumeAuthoritativeFailureReason
+): AcpSessionResumeFailureClassification => Object.freeze({ disposition: 'authoritative', reason })
+
+// Pure preflight and provider-error policy. Session ownership, protocol calls, and replay remain with
+// the provider Session transactions that consume these decisions.
+class AcpSessionResumePolicy {
+  decide(input: AcpSessionResumePolicyInput): AcpSessionResumeDecision {
+    const providerSessionId = input.providerSessionId ?? input.appSessionId
+
+    if (
+      input.previousFrameworkId !== undefined &&
+      input.previousFrameworkId !== input.currentFrameworkId
+    ) {
+      return Object.freeze({
+        action: 'adopt',
+        reason: 'framework-changed',
+        appSessionId: input.appSessionId,
+        providerSessionId,
+        contextReset: true
+      })
+    }
+
+    if (
+      input.previousBackendId !== undefined &&
+      input.currentBackendId !== undefined &&
+      input.previousBackendId !== input.currentBackendId
+    ) {
+      return Object.freeze({
+        action: 'adopt',
+        reason: 'backend-changed',
+        appSessionId: input.appSessionId,
+        providerSessionId,
+        contextReset: true
+      })
+    }
+
+    if (input.currentFrameworkId === 'codex' && !isCodexProviderSessionId(providerSessionId)) {
+      return Object.freeze({
+        action: 'adopt',
+        reason: 'codex-provider-session-id-incompatible',
+        appSessionId: input.appSessionId,
+        providerSessionId,
+        contextReset: true
+      })
+    }
+
+    if (input.currentFrameworkId === 'claude-code' && providerSessionId.startsWith('ses_')) {
+      return Object.freeze({
+        action: 'adopt',
+        reason: 'opencode-provider-session-id-incompatible-with-claude',
+        appSessionId: input.appSessionId,
+        providerSessionId,
+        contextReset: true
+      })
+    }
+
+    if (!input.resumeCapabilityAdvertised) {
+      return Object.freeze({
+        action: 'fail',
+        reason: 'resume-capability-not-advertised',
+        appSessionId: input.appSessionId,
+        providerSessionId,
+        contextReset: false,
+        message: 'ACP agent does not support session resume.'
+      })
+    }
+
+    return Object.freeze({
+      action: 'resume',
+      reason: 'compatible',
+      appSessionId: input.appSessionId,
+      providerSessionId,
+      contextReset: false
+    })
+  }
+
+  classifyFailure(error: unknown): AcpSessionResumeFailureClassification {
+    const code = readProperty(error, 'code')
+    if (!code.readable) return authoritativeFailure('uninspectable-error')
+    if (code.value === -32002) return adoptableFailure('resource-not-found-code')
+
+    const message = readProperty(error, 'message')
+    if (!message.readable) return authoritativeFailure('uninspectable-error')
+    if (
+      typeof message.value === 'string' &&
+      /resource not found|session not found/i.test(message.value)
+    ) {
+      return adoptableFailure('session-not-found-message')
+    }
+
+    if (code.value !== -32603) {
+      return code.value !== undefined || message.value !== undefined
+        ? authoritativeFailure('non-internal-error')
+        : authoritativeFailure('unrecognized-error')
+    }
+
+    const data = readProperty(error, 'data')
+    if (!data.readable) return authoritativeFailure('uninspectable-error')
+
+    const service = readProperty(data.value, 'service')
+    if (!service.readable) return authoritativeFailure('uninspectable-error')
+    if (service.value === 'session') return adoptableFailure('session-service-failure')
+    if (service.value !== undefined) return authoritativeFailure('non-session-service-failure')
+
+    if (typeof message.value !== 'string' || !/^internal error\.?$/i.test(message.value.trim())) {
+      return authoritativeFailure('non-internal-error')
+    }
+
+    const errorKind = readProperty(data.value, 'errorKind')
+    if (!errorKind.readable) return authoritativeFailure('uninspectable-error')
+    if (isUnresumableErrorKind(errorKind.value)) {
+      return adoptableFailure('unresumable-error-kind')
+    }
+    if (errorKind.value !== undefined) return authoritativeFailure('unknown-error-kind')
+
+    const details = readProperty(data.value, 'details')
+    if (!details.readable) return authoritativeFailure('uninspectable-error')
+    if (describesUnresumableSession(details.value)) {
+      return adoptableFailure('legacy-unresumable-details')
+    }
+    return details.value === undefined
+      ? adoptableFailure('legacy-internal-error-without-details')
+      : authoritativeFailure('unrelated-internal-error')
+  }
+}
+
+export { AcpSessionResumePolicy }
+export type {
+  AcpSessionResumeAdoptionReason,
+  AcpSessionResumeAdoptableFailureReason,
+  AcpSessionResumeAuthoritativeFailureReason,
+  AcpSessionResumeDecision,
+  AcpSessionResumeFailureClassification,
+  AcpSessionResumePolicyInput
+}


### PR DESCRIPTION
## Problem

ACP resume preflight and failed-resume interpretation were embedded in the Runtime transaction, making the compatibility decision hard to review and reuse for the later ARD-20 cutover.

Related: #458. This pure policy is only a forward compatibility constraint for future orchestration; it does not add Issue #458 orchestration state, schema, public interfaces, wire behavior, or user interaction.

## Proposed change

- Add the pure `AcpSessionResumePolicy` interface with typed resume, adopt, and fail decisions.
- Keep stable App Session identity distinct from the provider Session ID and encode `contextReset` on fresh adoption.
- Classify ACP structured, legacy, and hostile failed-resume values as adoptable or authoritative without I/O or mutable state.

## Scope and non-goals

- Pure addition: only the new policy source and direct tests are added.
- No edits to Runtime, Coordinator, composition, Registry, framework adapters, schema, wire contracts, UI, or Issue #458 orchestration boundaries.
- Production raw was recorded as **278 added lines**, below the 500-line hard stop.

## Ownership and sequence

This leaf is a stateless decision policy. It introduces no mutable state, resource owner, lifecycle transaction, or writer change, so an ownership diagram would imply behavior that is not present. The policy only maps immutable resume inputs and provider failure facts to one of three typed decisions: resume, adopt, or fail. Runtime cutover remains deferred to ARD-20.

## Acceptance criteria and validation

The recorded checks ran after the last material code edit (`957e93b`). The final PR head (`bac61d0`) contained only the follow-up documentation clarification:

- Resume/adoption/error decision table → `npm test -- src/main/acp/session-resume-policy.test.ts` → passed, **30 tests**.
- Node runtime types → `npm run typecheck:node` → passed.
- Source lint → `npm run lint` → passed.
- Full portable suite → `npm test` → passed; the historical description did not record file/test totals.
- Formatting and whitespace → `npx prettier --check` on both added files and `git diff --cached --check` → passed.
- Independent review → Standards: 0 findings; Spec: 0 findings.
- Final-head online gates → PR Gate, AI review, CodeQL, Static checks, Unit tests, Coverage macOS, macOS build/E2E, and Windows E2E all passed. `Windows core` was skipped by classification.

Consumer/platform rationale: no consumer or platform lane was locally affected because this leaf added an unintegrated pure interface; existing Runtime behavior and every external contract remained untouched. The final-head online PR Gate is the authoritative cross-platform evidence.

## Review focus

- Decision precedence for framework/backend affinity and provider Session ID compatibility.
- Conservative classification of structured, legacy, and hostile provider errors.
- Stable App Session identity and `contextReset` signaling.
- Absence of I/O, mutable state, and premature Runtime cutover.

## Uncovered risks

Provider-specific integration at the future ARD-20 cutover was intentionally outside this leaf. The historical full-suite record says only “passed,” so exact portable-suite totals cannot be reconstructed from the PR description; the final-head online gates remain verifiable evidence.
