### PR TITLE
refactor(acp): define provider turn adapter interface

### DIFF
--- a/src/main/acp/provider-turn-adapter.test.ts
+++ b/src/main/acp/provider-turn-adapter.test.ts
@@ -1,0 +1,120 @@
+import type { PromptResponse } from '@agentclientprotocol/sdk'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+import type {
+  AcpProviderTurnAdapter,
+  AcpProviderTurnBeginInput,
+  AcpProviderTurnFinalizationInput,
+  AcpProviderTurnProbe,
+  AcpProviderTurnResult
+} from './provider-turn-adapter'
+
+type IfEquals<Left, Right, Yes = Left, No = never> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? Yes
+    : No
+
+type WritableKeys<Value> = {
+  [Key in keyof Value]-?: IfEquals<
+    { [Property in Key]: Value[Key] },
+    { -readonly [Property in Key]: Value[Key] },
+    Key
+  >
+}[keyof Value]
+
+describe('ACP provider turn adapter interface', () => {
+  it('exposes only the turn-scoped probe lifecycle', () => {
+    expectTypeOf<keyof AcpProviderTurnAdapter>().toEqualTypeOf<'begin'>()
+    expectTypeOf<keyof AcpProviderTurnProbe>().toEqualTypeOf<'observe' | 'finalize' | 'cancel'>()
+  })
+
+  it('keeps inputs and normalized results immutable', () => {
+    expectTypeOf<WritableKeys<AcpProviderTurnBeginInput>>().toEqualTypeOf<never>()
+    expectTypeOf<WritableKeys<AcpProviderTurnFinalizationInput>>().toEqualTypeOf<never>()
+    expectTypeOf<WritableKeys<AcpProviderTurnResult>>().toEqualTypeOf<never>()
+    expectTypeOf<
+      WritableKeys<NonNullable<AcpProviderTurnResult['turnUsage']>>
+    >().toEqualTypeOf<never>()
+    expectTypeOf<
+      'turnCount' extends keyof NonNullable<AcpProviderTurnResult['turnUsage']> ? true : false
+    >().toEqualTypeOf<false>()
+  })
+
+  it('supports optional observation, cancellation, and best-effort missing facts', async () => {
+    const cancel = vi.fn()
+    const adapter: AcpProviderTurnAdapter = {
+      begin: ({ providerSessionId, cwd }) => {
+        expect(providerSessionId).toBe('provider-session-1')
+        expect(cwd).toBe('/workspace')
+        return {
+          finalize: ({ response }) => {
+            expect(response.stopReason).toBe('end_turn')
+            return {}
+          },
+          cancel
+        }
+      }
+    }
+
+    const finalizedProbe = await adapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const result = await finalizedProbe.finalize({
+      response: { stopReason: 'end_turn' } as PromptResponse
+    })
+
+    expect(result).toEqual({})
+    expect(finalizedProbe.observe).toBeUndefined()
+
+    const cancelledProbe = await adapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    await cancelledProbe.cancel()
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it('normalizes complete usage, model-turn, and context facts without provider payloads', async () => {
+    const observe = vi.fn()
+    const adapter: AcpProviderTurnAdapter = {
+      begin: async () => ({
+        observe,
+        finalize: async () => ({
+          turnUsage: {
+            inputTokens: 10,
+            cacheTokens: 4,
+            cachedReadTokens: 3,
+            cachedWriteTokens: 1,
+            outputTokens: 2
+          },
+          modelTurnCount: 3,
+          contextUsedTokens: 14
+        }),
+        cancel: async () => undefined
+      })
+    }
+
+    const probe = await adapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const observation = { sessionId: 'provider-session-1', message: { type: 'result' } }
+    probe.observe?.(observation)
+
+    await expect(
+      probe.finalize({ response: { stopReason: 'end_turn' } as PromptResponse })
+    ).resolves.toEqual({
+      turnUsage: {
+        inputTokens: 10,
+        cacheTokens: 4,
+        cachedReadTokens: 3,
+        cachedWriteTokens: 1,
+        outputTokens: 2
+      },
+      modelTurnCount: 3,
+      contextUsedTokens: 14
+    })
+    expect(observe).toHaveBeenCalledWith(observation)
+  })
+})

--- a/src/main/acp/provider-turn-adapter.ts
+++ b/src/main/acp/provider-turn-adapter.ts
@@ -1,0 +1,69 @@
+import type { PromptResponse } from '@agentclientprotocol/sdk'
+
+import type { AcpTurnTokenUsage } from '../../shared/acp'
+
+/**
+ * Provider-facing identity and workspace facts for one prompt attempt.
+ *
+ * This deliberately carries the replaceable provider Session id rather than the stable application
+ * Session id. Provider credentials and provider-specific probe configuration belong to the concrete
+ * adapter's construction dependencies, not to the shared turn seam.
+ */
+export type AcpProviderTurnBeginInput = Readonly<{
+  providerSessionId: string
+  cwd: string
+}>
+
+/**
+ * The provider stop response is the only terminal provider payload exposed at this seam. Adapters
+ * may inspect it to recover usage metadata, but the executor keeps ownership of the raw response.
+ */
+export type AcpProviderTurnFinalizationInput = Readonly<{
+  response: Readonly<PromptResponse>
+}>
+
+/**
+ * Best-effort provider facts for a completed turn.
+ *
+ * Every fact is optional because provider adapters can omit, reject, or partially report usage.
+ * Present counters must already be normalized and validated by the concrete adapter:
+ *
+ * - token counters and `contextUsedTokens` are non-negative safe integers;
+ * - `modelTurnCount` is a positive safe integer;
+ * - cached read/write counters appear together when the provider exposes both;
+ * - model-turn count appears only in `modelTurnCount`, never nested in token usage.
+ *
+ * Durable interaction, context, and Session owners decide whether and how to publish these facts.
+ */
+export type AcpProviderTurnResult = Readonly<{
+  turnUsage?: Readonly<Omit<AcpTurnTokenUsage, 'turnCount'>>
+  modelTurnCount?: number
+  contextUsedTokens?: number
+}>
+
+/**
+ * Opaque turn-scoped observation lifetime returned by an adapter.
+ *
+ * The probe exposes no provider state. `observe`, when present, accepts an out-of-band provider
+ * message such as Claude Code's `_claude/sdkMessage`; malformed or unrelated values are ignored by
+ * the concrete adapter. A caller terminates the probe exactly once with `finalize` after provider
+ * stop or `cancel` when the attempt is rejected, cancelled, or superseded.
+ */
+export type AcpProviderTurnProbe = Readonly<{
+  observe?: (message: unknown) => void
+  finalize: (
+    input: AcpProviderTurnFinalizationInput
+  ) => AcpProviderTurnResult | Promise<AcpProviderTurnResult>
+  cancel: () => void | Promise<void>
+}>
+
+/**
+ * Provider-specific observation adapter selected for one backend generation.
+ *
+ * `begin` may perform a best-effort before-probe (OpenCode) or simply allocate local observation
+ * state (Claude Code/Codex). Missing provider data is represented by an empty final result rather
+ * than by widening this interface with provider payloads or application-owner concerns.
+ */
+export type AcpProviderTurnAdapter = Readonly<{
+  begin: (input: AcpProviderTurnBeginInput) => AcpProviderTurnProbe | Promise<AcpProviderTurnProbe>
+}>


### PR DESCRIPTION
## Problem

Provider-turn observation had no provider-neutral seam. The later Claude Code, Codex, and OpenCode adapter leaves needed a narrow contract that did not absorb Session resume, credentials, events, Permission, Artifact, Registry, or Runtime workflow ownership.

Related: #458. This PR introduces only a forward-compatible type seam; it does not implement Issue #458 orchestration state, schema, public wire/API behavior, or user interaction.

## Proposed change

- Add `AcpProviderTurnAdapter.begin(...)` for provider Session/cwd-bound turn probes.
- Keep probe state opaque behind optional out-of-band observation and exactly one terminal path: `finalize(...)` or `cancel()`.
- Return immutable, best-effort normalized token-usage, model-turn, and context-used facts.
- Keep model-turn count separate from token usage so the interaction owner remains the sole model-turn fact writer.
- Add direct compile-time/interface tests for the public surface, immutability, cancellation, absent facts, and complete normalized facts.

## Scope and non-goals

- Pure addition only: no Runtime/composition/coordinator edits and no provider implementation or cutover.
- No schema/data relationship, IPC/preload, Web RPC v1, Task HTTP/WebSocket, CLI/SDK, UI, Specialist, Permission, Compute, Session identity/adoption/contextReset/replay, terminal fact, Reviewer, Artifact, or Issue #458 behavior change.
- Claude Code, Codex, and OpenCode adapters remain ARD-10/11/12; executor integration remains ARD-24.

Exact production raw: **69 additions + 0 deletions**.

## Ownership and sequence

No durable writer was introduced. Concrete adapters may own only ephemeral probe state. `AcpSessionInteractionOwner`, `ContextUsageTracker`, and Session owners retain their existing facts. Successful provider stop will finalize the probe; rejection, cancellation, or supersession will cancel it. Concrete cleanup behavior remains deferred to ARD-10/11/12. Because this leaf defines a pure interface without a concrete resource owner or Runtime transaction, an ownership diagram would imply implementation that is intentionally absent.

## Acceptance criteria and validation

The recorded checks ran after the last material edit:

- Probe surface, immutability, cancellation, missing-data best effort, normalized facts → `npm test -- --run src/main/acp/provider-turn-adapter.test.ts` → **4/4 passed**.
- Node-process interface compatibility → `npm run typecheck:node` → passed.
- New source/test lint → `npm exec -- eslint src/main/acp/provider-turn-adapter.ts src/main/acp/provider-turn-adapter.test.ts` → passed.
- Focused formatting → `npm exec -- prettier --check src/main/acp/provider-turn-adapter.ts src/main/acp/provider-turn-adapter.test.ts` → passed.
- Diff whitespace → `git diff --cached --check` on the final staged state → passed.
- Independent final review → Standards: 0 findings; Spec: 0 findings after resolving the initial model-turn separation finding.
- Final-head online gates → PR Gate, AI review, CodeQL, Static checks, Unit tests, Coverage macOS, macOS build/E2E, and Windows E2E all passed. `Windows core` was skipped by classification.

Consumer and platform lanes were excluded locally because the diff added an unconsumed type seam and did not cut over Runtime or provider/platform behavior. The final-head online PR Gate is the authoritative cross-platform evidence.

## Review focus

- Whether the probe lifecycle is narrow enough for all three provider leaves without exposing credentials or durable owner concerns.
- Whether `AcpProviderTurnResult` keeps token usage, model-turn, and context facts unambiguous for later interaction/context-owner application.
- Exact-one-terminal-path semantics and opacity of provider-specific probe state.

## Uncovered risks

Concrete provider parsing/probing, cleanup, and executor integration were intentionally deferred to ARD-10/11/12 and ARD-24. This pure interface leaf did not run consumer or live-provider tests because it had no implementation/cutover. Issue #458 integration remains deferred.
