### PR TITLE
fix(reviewer): preserve correction artifact provenance

### DIFF
--- a/src/main/reviewer/correction.test.ts
+++ b/src/main/reviewer/correction.test.ts
@@ -575,6 +575,61 @@ describe('single-round auditor correction', () => {
     expect(msg).toContain('[fail]')
   })
 
+  it('marks checks unaddressed when correction provenance is incomplete', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, {
+      reviewerSessionId: 'reviewer-session-1',
+      mainSessionId: 'main-session-1',
+      simulateFindingsViaHttp: true,
+      checksToSubmit: [
+        {
+          status: 'fail',
+          claim: 'Test claim',
+          evidence: 'Test evidence',
+          locator: { blockRef: { blockIndex: 0 }, contentHash: 'hash1' }
+        }
+      ]
+    })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await ensureProjectSchema(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+    const session = makeSession()
+    session.conversationGraph = createLinearConversationGraph({
+      sessionId: session.id,
+      messages: session.messages,
+      frameworkId: 'claude-code',
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt
+    })
+    session.conversationGraph.runtimeSegments = []
+    const correctionPrompts: string[] = []
+
+    const review = await runReview({
+      sessionId: session.id,
+      turnMessageId: 'msg-2',
+      projectId: session.projectId,
+      getSession: () => session,
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!,
+      mainSessionId: 'main-session-1',
+      onCorrectionPrompt: (text) => correctionPrompts.push(text)
+    })
+
+    expect(review.checks[0]?.resolution).toBe('unaddressed')
+    expect(correctionPrompts).toHaveLength(0)
+
+    await client.$disconnect()
+  })
+
   it('error in correction sendPrompt does not spin into a re-review loop', async () => {
     const process = new FakeAgentProcess()
     const checksToSubmit = [

--- a/src/main/reviewer/correction.test.ts
+++ b/src/main/reviewer/correction.test.ts
@@ -16,7 +16,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from '../acp/runtime'
 import { ReviewRepository } from './repository'
@@ -24,6 +24,7 @@ import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-c
 import { runReview } from './orchestrator'
 import { callSubmitFindingsAfterReadingEvidence as callSubmitFindings } from './reviewer-mcp-test-client'
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import { createLinearConversationGraph } from '../../shared/conversation-graph'
 
 // ---------------------------------------------------------------------------
 // FakeAgentProcess — re-used from orchestrator.test.ts
@@ -267,6 +268,14 @@ describe('single-round auditor correction', () => {
     await ensureProjectSchema(client)
     const repository = new ReviewRepository(() => Promise.resolve(client))
     const session = makeSession()
+    session.conversationGraph = createLinearConversationGraph({
+      sessionId: 'pending-session-1',
+      messages: session.messages,
+      frameworkId: 'claude-code',
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt
+    })
+    const correctionSendPrompt = vi.spyOn(runtime, 'sendPrompt')
 
     // Capture prompts sent to the main session via sendCorrectionPrompt.
     const correctionPrompts: string[] = []
@@ -307,6 +316,18 @@ describe('single-round auditor correction', () => {
     // Must end with the instruction line.
     expect(auditorMsg).toContain('Acknowledge in one line')
     expect(auditorMsg).toContain("Don't restate or narrate")
+    expect(correctionSendPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'main-session-1',
+        provenanceContext: expect.objectContaining({
+          rootFrameId: 'root-frame-pending-session-1',
+          agentFrameId: 'root-frame-pending-session-1',
+          messageBranchId: 'message-branch-pending-session-1',
+          runtimeSegmentId: 'runtime-segment-pending-session-1',
+          promptMessageId: expect.stringMatching(/^prompt-/u)
+        })
+      })
+    )
 
     await client.$disconnect()
   })

--- a/src/main/reviewer/correction.ts
+++ b/src/main/reviewer/correction.ts
@@ -6,6 +6,7 @@
 
 import type { ReviewerAcpRuntime } from './acp-runtime'
 import { createLogger } from '../logger'
+import type { AcpPromptRequest } from '../../shared/acp'
 import type { ReviewCheck } from '../../shared/reviewer'
 
 const log = createLogger('reviewer:correction')
@@ -42,13 +43,21 @@ export const injectAuditorMessage = async (options: {
   mainSessionId: string
   findings: ReviewCheck[] // the full checks list; only warn/fail are injected
   acpRuntime: ReviewerAcpRuntime
+  provenanceContext: NonNullable<AcpPromptRequest['provenanceContext']>
   // Optional hook for tests to capture the injected message text.
   onCorrectionPrompt?: (text: string) => void
   // Called if the correction sendPrompt fails, so the caller can undo pre-emptive suppression.
   onCorrectionFailed?: () => void
 }): Promise<void> => {
-  const { sessionId, mainSessionId, findings, acpRuntime, onCorrectionPrompt, onCorrectionFailed } =
-    options
+  const {
+    sessionId,
+    mainSessionId,
+    findings,
+    acpRuntime,
+    provenanceContext,
+    onCorrectionPrompt,
+    onCorrectionFailed
+  } = options
 
   // Only inject for warn/fail checks.
   const warnFailChecks = findings.filter((c) => c.status === 'warn' || c.status === 'fail')
@@ -71,7 +80,7 @@ export const injectAuditorMessage = async (options: {
   try {
     // Inject through the main-session sendPrompt path (design.md cross-cutting requirement).
     // This is a normal prompt turn that the user sees in the conversation.
-    await acpRuntime.sendPrompt({ sessionId: mainSessionId, text: message })
+    await acpRuntime.sendPrompt({ sessionId: mainSessionId, text: message, provenanceContext })
     log.info('[Auditor] correction turn complete', { mainSessionId })
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error)

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -580,25 +580,34 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
     }
     const messagesBefore = sessionBefore.messages
     const messageIdsBefore = new Set(messagesBefore.map((message) => message.id))
-    const provenanceContext = getActiveConversationContext(
-      materializeSessionConversationGraph(sessionBefore).conversationGraph!,
-      `prompt-${randomUUID()}`
-    )
 
     // Step B: inject [Auditor] with the currently-open warn/fail checks.
     let correctionFailed = false
-    await injectAuditorMessage({
-      sessionId,
-      mainSessionId,
-      findings: openChecks,
-      acpRuntime,
-      provenanceContext,
-      onCorrectionPrompt,
-      onCorrectionFailed: () => {
-        correctionFailed = true
-        onCorrectionFailed?.()
-      }
-    })
+    try {
+      const provenanceContext = getActiveConversationContext(
+        materializeSessionConversationGraph(sessionBefore).conversationGraph!,
+        `prompt-${randomUUID()}`
+      )
+      await injectAuditorMessage({
+        sessionId,
+        mainSessionId,
+        findings: openChecks,
+        acpRuntime,
+        provenanceContext,
+        onCorrectionPrompt,
+        onCorrectionFailed: () => {
+          correctionFailed = true
+          onCorrectionFailed?.()
+        }
+      })
+    } catch (error) {
+      correctionFailed = true
+      log.warn('fix loop: failed to derive correction provenance', {
+        sessionId,
+        round,
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
 
     // Error handling: a failed correction counts as a round (prevents infinite loop) but we
     // cannot re-review (there's no correction turn). Mark remaining as unaddressed and stop.

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -7,6 +7,7 @@
 //
 // Errors are isolated: reviewer failures set lifecycle='error' and do NOT crash the main session.
 
+import { randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 
 import type { ActiveSession } from '@agentclientprotocol/sdk'
@@ -24,13 +25,17 @@ import type {
 } from '../../shared/reviewer'
 import type { ReviewRepository } from './repository'
 import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
-import type { PersistedChatSession } from '../../shared/session-persistence'
+import {
+  materializeSessionConversationGraph,
+  type PersistedChatSession
+} from '../../shared/session-persistence'
 import { ReviewerMcpServer } from './mcp-server'
 import { ReviewerHostServer, type ArtifactVersionContentResolver } from './host-sdk'
 import { buildReviewScopeSnapshot } from './scope-snapshot'
 import { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } from './rubric'
 import { injectAuditorMessage } from './correction'
 import { buildHistoryPreamble } from '../../shared/history-preamble'
+import { getActiveConversationContext } from '../../shared/conversation-graph'
 
 const log = createLogger('reviewer:orchestrator')
 
@@ -575,6 +580,10 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
     }
     const messagesBefore = sessionBefore.messages
     const messageIdsBefore = new Set(messagesBefore.map((message) => message.id))
+    const provenanceContext = getActiveConversationContext(
+      materializeSessionConversationGraph(sessionBefore).conversationGraph!,
+      `prompt-${randomUUID()}`
+    )
 
     // Step B: inject [Auditor] with the currently-open warn/fail checks.
     let correctionFailed = false
@@ -583,6 +592,7 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
       mainSessionId,
       findings: openChecks,
       acpRuntime,
+      provenanceContext,
       onCorrectionPrompt,
       onCorrectionFailed: () => {
         correctionFailed = true


### PR DESCRIPTION
## Problem

Reviewer-owned correction prompts omitted the durable conversation-graph provenance. After a pending Session was bound to its durable runtime id, ArtifactTurnOwner could synthesize a root Frame from the runtime id that did not match the durable graph, causing Artifact finalization to fail closed.

## Proposed change

- Materialize the already-loaded durable Session graph before the correction turn.
- Reuse the existing active-conversation helper to pass the full Frame, Branch, Runtime Segment, ancestry, and prompt binding through sendPrompt.
- Cover a durable graph whose root still uses a pending Session id while the correction targets a different runtime Session id.

## Scope and non-goals

- No schema, migration, durable graph rewrite, dependency, or user-interface change.
- The separate Runtime Segment mismatch reported in #722 was fixed by 92c2072 and has been closed.

## Acceptance criteria and validation

Final evidence after the last material edit:

- Reviewer correction durable ownership -> npm test -- --run src/main/reviewer/correction.test.ts -> 7 passed.
- Main-process type safety -> npm run typecheck:node -> passed.
- Source lint -> npm run lint -> passed with 0 errors and 17 existing warnings outside this diff.
- Portable suite -> npm test -> 11,024 passed and 2 unrelated 15-second timeouts in unmodified Notebook and ProjectFilesView tests. The affected files passed in isolation: ProjectFilesView 69/69, Notebook runtime 180/180, completion-gate 22/22, and the Notebook state-budget case 1/1.
- Independent review -> Standards 0 findings; Spec 0 findings.

The branch was rebased over non-overlapping upstream commits after validation; the focused Reviewer test was rerun post-rebase and passed 7/7.

## Review focus

Confirm that correction prompts use the durable active graph identity rather than any Session-id-derived fallback.

Related to #722.
