### PR TITLE
refactor(acp): add session presentation policy

### DIFF
--- a/src/main/acp/session-presentation-policy.test.ts
+++ b/src/main/acp/session-presentation-policy.test.ts
@@ -246,6 +246,20 @@ describe('ACP Session presentation policy', () => {
     )
   })
 
+  it('falls back when a returned handoff value has no JSON representation', () => {
+    expect(
+      policy.continuationText({
+        text: 'Continue the analysis.',
+        continuation: {
+          kind: 'specialist-handoff',
+          originatingTurnToken: 'turn-3',
+          targetName: null,
+          completion: { kind: 'returned', value: Symbol('result') }
+        }
+      })
+    ).toContain('Captured outer tool result:\nSymbol(result)')
+  })
+
   it('keeps Codex Skill paths in immutable private inputs without changing prompt text', () => {
     const presentation = policy.presentTurnSkills({
       frameworkId: 'codex',

--- a/src/main/acp/session-presentation-policy.test.ts
+++ b/src/main/acp/session-presentation-policy.test.ts
@@ -246,7 +246,7 @@ describe('ACP Session presentation policy', () => {
     )
   })
 
-  it('falls back when a returned handoff value has no JSON representation', () => {
+  it('preserves current handoff text when a returned value has no JSON representation', () => {
     expect(
       policy.continuationText({
         text: 'Continue the analysis.',
@@ -257,7 +257,7 @@ describe('ACP Session presentation policy', () => {
           completion: { kind: 'returned', value: Symbol('result') }
         }
       })
-    ).toContain('Captured outer tool result:\nSymbol(result)')
+    ).toContain('Captured outer tool result:\nundefined')
   })
 
   it('keeps Codex Skill paths in immutable private inputs without changing prompt text', () => {

--- a/src/main/acp/session-presentation-policy.test.ts
+++ b/src/main/acp/session-presentation-policy.test.ts
@@ -104,16 +104,18 @@ describe('ACP Session presentation policy', () => {
     expect(Object.isFrozen(presentation.metaArg._meta)).toBe(true)
   })
 
-  it('excludes stable appends from prompt text when the backend already installed them persistently', () => {
+  it('excludes stable appends installed persistently but preserves one-off Session appends', () => {
     expect(
       policy.buildSessionSetup({
         framework: codexFramework,
         tooling: { artifacts: true, notebook: true, skillImport: true },
         backendSystemPromptAppends: ['Already installed by the backend.'],
+        extraSystemPromptAppends: ['One-off Session guidance.'],
         persistentSystemPrompt: 'Baked Codex developer instructions.'
       })
     ).toEqual({
       metaArg: {},
+      promptPrefix: 'One-off Session guidance.',
       persistentSystemPrompt: 'Baked Codex developer instructions.'
     })
   })

--- a/src/main/acp/session-presentation-policy.test.ts
+++ b/src/main/acp/session-presentation-policy.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest'
+
+import { claudeCodeFramework } from '../agent-framework/claude-code'
+import { codexFramework } from '../agent-framework/codex'
+import { opencodeFramework } from '../agent-framework/opencode'
+import { NOTEBOOK_SYSTEM_PROMPT_APPEND } from '../notebook/mcp-server'
+import { SKILL_IMPORT_SYSTEM_PROMPT_APPEND } from '../skills/mcp-server'
+import { AcpSessionPresentationPolicy } from './session-presentation-policy'
+
+const TURN_CONTINUITY_APPEND = [
+  '<open_science_turn_continuity_instructions>',
+  'Do not describe a tool-backed action as future work and then end the turn. If you say you will download, install, run, edit, analyze, or otherwise perform an action that needs a tool, issue the corresponding tool call in this same turn.',
+  'If a required tool cannot be used or its operation fails, do not promise another attempt. Clearly state that the turn has stopped, what prevented progress, and what the user can do next.',
+  '</open_science_turn_continuity_instructions>'
+].join('\n')
+
+const LARGE_DATA_FILE_APPEND = [
+  '<open_science_large_file_instructions>',
+  'Large attached data files (CSV, TSV, TXT, JSON, FASTA/FASTQ, VCF, and similar tabular or text data) are provided as a file reference plus a short preview, not as full inline content.',
+  'Never read, cat, or print such a file in its entirety — a single large read can exceed the request-size limit and break the conversation.',
+  'Inspect structure first (columns, row count, a few sample rows), then read only the specific line ranges, rows, or columns you need.',
+  'To analyze, filter, or aggregate over a large file, load it in the notebook (e.g. pandas) and compute there instead of reading its contents into the conversation.',
+  '</open_science_large_file_instructions>'
+].join('\n')
+
+const ARTIFACT_FILE_APPEND = [
+  '<open_science_artifact_instructions>',
+  'When this turn creates or saves local user-facing files such as images, documents, reports, data exports, XML, SVG, HTML, CSV, PDF, or archives, you MUST save them through the MCP tool `write_artifact_file` from the `open-science-artifacts` server.',
+  'Do not save generated user-facing files directly into the workspace or current directory unless the user explicitly asks to modify project files.',
+  'Pass the filename, MIME type, and either inline content or a local source path to `write_artifact_file`; the app assigns the project, session, Artifact run, and final message location.',
+  'If a Notebook, REPL, or shell execution produced the file, also pass `producerRunId` with the exact `runId` returned by the execution that created or last modified it. Omit `producerRunId` only when no Notebook execution produced the file; never use the Artifact run ID as the producer.',
+  'Only claim a generated file is available after `write_artifact_file` succeeds. If it fails or is denied, state that the local file may exist but was not saved as an Artifact, and do not present it as downloadable.',
+  'After using the tool, mention the generated filename rather than an absolute filesystem path. The app will display the generated file list below your message.',
+  'Never write files inside a skill directory — loaded skills are read-only; route any file a skill generates through `write_artifact_file`.',
+  '</open_science_artifact_instructions>'
+].join('\n')
+
+describe('ACP Session presentation policy', () => {
+  const policy = new AcpSessionPresentationPolicy()
+
+  it('returns the exact application appends in stable order when every tool is available', () => {
+    const appends = policy.applicationSystemPromptAppends({
+      artifacts: true,
+      notebook: true,
+      skillImport: true
+    })
+
+    expect(appends).toEqual([
+      TURN_CONTINUITY_APPEND,
+      LARGE_DATA_FILE_APPEND,
+      ARTIFACT_FILE_APPEND,
+      NOTEBOOK_SYSTEM_PROMPT_APPEND,
+      SKILL_IMPORT_SYSTEM_PROMPT_APPEND
+    ])
+    expect(Object.isFrozen(appends)).toBe(true)
+  })
+
+  it('keeps unconditional guidance while omitting unavailable tooling and Skill privacy text', () => {
+    const appends = policy.applicationSystemPromptAppends({
+      artifacts: false,
+      notebook: false,
+      skillImport: false
+    })
+
+    expect(appends).toEqual([TURN_CONTINUITY_APPEND, LARGE_DATA_FILE_APPEND])
+    expect(appends.join('\n\n')).not.toContain('<open_science_skill_privacy_instructions>')
+  })
+
+  it('builds immutable Claude Session metadata in exact append order and fails closed on Skills', () => {
+    const presentation = policy.buildSessionSetup({
+      framework: claudeCodeFramework,
+      tooling: { artifacts: false, notebook: false, skillImport: false },
+      backendSystemPromptAppends: ['Backend connector guidance.'],
+      extraSystemPromptAppends: ['Specialist identity.'],
+      sessionOptions: { plugins: [{ type: 'local', path: '/app/claude' }] },
+      specialistSkills: { kind: 'unavailable', reason: 'disabled' }
+    })
+    const exactAppend = [
+      TURN_CONTINUITY_APPEND,
+      LARGE_DATA_FILE_APPEND,
+      'Backend connector guidance.',
+      'Specialist identity.'
+    ].join('\n\n')
+
+    expect(presentation).toEqual({
+      metaArg: {
+        _meta: {
+          claudeCode: {
+            emitRawSDKMessages: [{ type: 'result' }],
+            options: {
+              tools: { type: 'preset', preset: 'claude_code' },
+              plugins: [{ type: 'local', path: '/app/claude' }],
+              settingSources: ['user'],
+              skills: []
+            }
+          },
+          systemPrompt: { type: 'preset', preset: 'claude_code', append: exactAppend }
+        }
+      },
+      persistentSystemPrompt: exactAppend
+    })
+    expect(Object.isFrozen(presentation)).toBe(true)
+    expect(Object.isFrozen(presentation.metaArg)).toBe(true)
+    expect(Object.isFrozen(presentation.metaArg._meta)).toBe(true)
+  })
+
+  it('excludes stable appends from prompt text when the backend already installed them persistently', () => {
+    expect(
+      policy.buildSessionSetup({
+        framework: codexFramework,
+        tooling: { artifacts: true, notebook: true, skillImport: true },
+        backendSystemPromptAppends: ['Already installed by the backend.'],
+        persistentSystemPrompt: 'Baked Codex developer instructions.'
+      })
+    ).toEqual({
+      metaArg: {},
+      persistentSystemPrompt: 'Baked Codex developer instructions.'
+    })
+  })
+
+  it('returns exact immutable Session append and turn prefix text for a Specialist identity', () => {
+    const profile = {
+      name: 'RNA-seq Reviewer',
+      systemPrompt: '  Focus on batch effects and QC.  '
+    }
+    const append = [
+      '[open-science:specialist-identity]',
+      '# Specialist identity — RNA-seq Reviewer',
+      '',
+      '> The following overrides the Main Agent general identity description for this session.',
+      '> App safety rules, tool rules, and workflow instructions still apply and are not replaced.',
+      '',
+      'Focus on batch effects and QC.'
+    ].join('\n')
+    const prefix = [
+      '[open-science:specialist-identity]',
+      '[Specialist: RNA-seq Reviewer]',
+      '(This overrides the Main Agent identity for this session.',
+      ' App safety rules, tool rules, and workflow instructions still apply.)',
+      '',
+      'Focus on batch effects and QC.',
+      '',
+      '---',
+      ''
+    ].join('\n')
+
+    const claudeIdentity = policy.specialistIdentity('claude-code', profile)
+    const codexIdentity = policy.specialistIdentity('codex', profile)
+    const opencodeIdentity = policy.specialistIdentity('opencode', profile)
+
+    expect(claudeIdentity).toEqual({ append, prefix: '' })
+    expect(codexIdentity).toEqual({ append: '', prefix })
+    expect(opencodeIdentity).toEqual(codexIdentity)
+    expect(Object.isFrozen(claudeIdentity)).toBe(true)
+    expect(Object.isFrozen(codexIdentity)).toBe(true)
+  })
+
+  it('orders the OpenCode Specialist identity before exact per-turn Skill guidance', () => {
+    expect(
+      policy.buildTurnPromptPrefix({
+        framework: opencodeFramework,
+        tooling: { artifacts: false, notebook: false, skillImport: false },
+        persistentSystemPrompt: 'Baked OpenCode instructions.',
+        specialistPrefix: 'Specialist identity prefix.',
+        specialistSkills: {
+          kind: 'specialist',
+          skillIds: ['research', 'pubmed'],
+          frameworkNames: ['Research', 'mcp-pubmed'],
+          missingSkillIds: []
+        }
+      })
+    ).toBe(
+      [
+        'Specialist identity prefix.',
+        'Allowed Specialist Skills for this session:\n- Research\n- mcp-pubmed'
+      ].join('\n\n')
+    )
+  })
+
+  it('uses the same per-turn prefix contract for Codex and no Specialist reminder for Claude', () => {
+    const specialistSkills = {
+      kind: 'specialist' as const,
+      skillIds: ['research'],
+      frameworkNames: ['Research'],
+      missingSkillIds: []
+    }
+    const tooling = { artifacts: false, notebook: false, skillImport: false }
+
+    expect(
+      policy.buildTurnPromptPrefix({
+        framework: codexFramework,
+        tooling,
+        persistentSystemPrompt: 'Baked Codex instructions.',
+        specialistPrefix: 'Codex Specialist identity.',
+        specialistSkills
+      })
+    ).toBe('Codex Specialist identity.\n\nAllowed Specialist Skills for this session:\n- Research')
+    expect(
+      policy.buildTurnPromptPrefix({
+        framework: claudeCodeFramework,
+        tooling,
+        specialistSkills
+      })
+    ).toBeUndefined()
+  })
+
+  it('renders exact Specialist handoff continuation text from the original request and result', () => {
+    expect(
+      policy.continuationText({
+        text: 'Analyze the dataset.',
+        continuation: {
+          kind: 'specialist-handoff',
+          originatingTurnToken: 'turn-1',
+          targetName: 'Data Analyst',
+          completion: { kind: 'returned', value: { rows: 42 } }
+        }
+      })
+    ).toBe(
+      [
+        'Continue the original user task as Data Analyst. Do not repeat work already shown before the handoff.',
+        'Original user request:\nAnalyze the dataset.',
+        'Captured outer tool result:\n{"rows":42}'
+      ].join('\n\n')
+    )
+  })
+
+  it('renders Main Agent and thrown handoff outcomes without reinterpreting the error', () => {
+    expect(
+      policy.continuationText({
+        text: 'Continue the analysis.',
+        continuation: {
+          kind: 'specialist-handoff',
+          originatingTurnToken: 'turn-2',
+          targetName: null,
+          completion: { kind: 'threw', errorMessage: 'switch failed' }
+        }
+      })
+    ).toBe(
+      [
+        'Continue the original user task as Main Agent. Do not repeat work already shown before the handoff.',
+        'Original user request:\nContinue the analysis.',
+        'Captured outer tool error:\nswitch failed'
+      ].join('\n\n')
+    )
+  })
+
+  it('keeps Codex Skill paths in immutable private inputs without changing prompt text', () => {
+    const presentation = policy.presentTurnSkills({
+      frameworkId: 'codex',
+      text: 'Summarize the paper.',
+      skillNames: ['Research'],
+      codexSkillInputs: [{ name: 'research', path: '/data/codex/skills/os-research/SKILL.md' }]
+    })
+
+    expect(presentation).toEqual({
+      text: 'Summarize the paper.',
+      codexSkillInputs: [{ name: 'research', path: '/data/codex/skills/os-research/SKILL.md' }]
+    })
+    expect(presentation.text).not.toContain('/data/codex')
+    expect(Object.isFrozen(presentation)).toBe(true)
+    expect(Object.isFrozen(presentation.codexSkillInputs)).toBe(true)
+    expect(Object.isFrozen(presentation.codexSkillInputs[0])).toBe(true)
+  })
+
+  it.each(['claude-code', 'opencode'] as const)(
+    'nudges %s with resolved Skill names and discards Codex-only inputs',
+    (frameworkId) => {
+      expect(
+        policy.presentTurnSkills({
+          frameworkId,
+          text: 'Summarize the paper.',
+          skillNames: ['Research', 'My Skill'],
+          codexSkillInputs: [{ name: 'private', path: '/data/codex/skills/private/SKILL.md' }]
+        })
+      ).toEqual({
+        text: 'Use the following skill(s) for this task: Research, My Skill.\n\nSummarize the paper.',
+        codexSkillInputs: []
+      })
+    }
+  )
+})

--- a/src/main/acp/session-presentation-policy.ts
+++ b/src/main/acp/session-presentation-policy.ts
@@ -215,7 +215,7 @@ class AcpSessionPresentationPolicy {
   }
 
   private systemPromptAppends(input: AcpSessionSetupPresentationInput): string[] {
-    if (input.persistentSystemPrompt) return []
+    if (input.persistentSystemPrompt) return [...(input.extraSystemPromptAppends ?? [])]
     return [
       ...this.applicationSystemPromptAppends(input.tooling),
       ...(input.backendSystemPromptAppends ?? []),

--- a/src/main/acp/session-presentation-policy.ts
+++ b/src/main/acp/session-presentation-policy.ts
@@ -235,7 +235,8 @@ class AcpSessionPresentationPolicy {
     if (typeof value === 'string') return value
     try {
       const serialized = JSON.stringify(value)
-      return serialized === undefined ? String(value) : serialized
+      // Preserve Runtime's template interpolation until the later behavior-neutral cutover.
+      return serialized === undefined ? 'undefined' : serialized
     } catch {
       return String(value)
     }

--- a/src/main/acp/session-presentation-policy.ts
+++ b/src/main/acp/session-presentation-policy.ts
@@ -1,0 +1,254 @@
+import { NOTEBOOK_SYSTEM_PROMPT_APPEND } from '../notebook/mcp-server'
+import { SKILL_IMPORT_SYSTEM_PROMPT_APPEND } from '../skills/mcp-server'
+import type { AgentFramework, SessionSetup } from '../agent-framework/types'
+import type { EffectiveSpecialistSkills, SpecialistProfileView } from '../../shared/specialist'
+import type { AcpPromptRequest } from '../../shared/acp'
+
+type AcpSessionToolingAvailability = Readonly<{
+  artifacts: boolean
+  notebook: boolean
+  skillImport: boolean
+}>
+
+type AcpSessionSetupPresentationInput = Readonly<{
+  framework: Pick<AgentFramework, 'id' | 'buildSessionSetup'>
+  tooling: AcpSessionToolingAvailability
+  backendSystemPromptAppends?: readonly string[]
+  extraSystemPromptAppends?: readonly string[]
+  persistentSystemPrompt?: string
+  sessionOptions?: Record<string, unknown>
+  specialistSkills?: EffectiveSpecialistSkills
+}>
+
+type AcpSessionSetupPresentation = Readonly<{
+  metaArg: Readonly<{ _meta?: Readonly<Record<string, unknown>> }>
+  promptPrefix?: string
+  persistentSystemPrompt?: string
+}>
+
+type AcpSpecialistIdentityPresentation = Readonly<{
+  append: string
+  prefix: string
+}>
+
+type AcpTurnPromptPrefixInput = AcpSessionSetupPresentationInput &
+  Readonly<{ specialistPrefix?: string }>
+
+type AcpCodexSkillInput = Readonly<{ name: string; path: string }>
+
+type AcpTurnSkillPresentationInput = Readonly<{
+  frameworkId: AgentFramework['id']
+  text: string
+  skillNames: readonly string[]
+  codexSkillInputs: readonly AcpCodexSkillInput[]
+}>
+
+type AcpTurnSkillPresentation = Readonly<{
+  text: string
+  codexSkillInputs: readonly AcpCodexSkillInput[]
+}>
+
+const immutableCopy = <Value>(value: Value): Value => {
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map((entry) => immutableCopy(entry))) as Value
+  }
+  if (value && typeof value === 'object') {
+    return Object.freeze(
+      Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, immutableCopy(entry)]))
+    ) as Value
+  }
+  return value
+}
+
+const TURN_CONTINUITY_SYSTEM_PROMPT_APPEND = [
+  '<open_science_turn_continuity_instructions>',
+  'Do not describe a tool-backed action as future work and then end the turn. If you say you will download, install, run, edit, analyze, or otherwise perform an action that needs a tool, issue the corresponding tool call in this same turn.',
+  'If a required tool cannot be used or its operation fails, do not promise another attempt. Clearly state that the turn has stopped, what prevented progress, and what the user can do next.',
+  '</open_science_turn_continuity_instructions>'
+].join('\n')
+
+const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
+  '<open_science_artifact_instructions>',
+  'When this turn creates or saves local user-facing files such as images, documents, reports, data exports, XML, SVG, HTML, CSV, PDF, or archives, you MUST save them through the MCP tool `write_artifact_file` from the `open-science-artifacts` server.',
+  'Do not save generated user-facing files directly into the workspace or current directory unless the user explicitly asks to modify project files.',
+  'Pass the filename, MIME type, and either inline content or a local source path to `write_artifact_file`; the app assigns the project, session, Artifact run, and final message location.',
+  'If a Notebook, REPL, or shell execution produced the file, also pass `producerRunId` with the exact `runId` returned by the execution that created or last modified it. Omit `producerRunId` only when no Notebook execution produced the file; never use the Artifact run ID as the producer.',
+  'Only claim a generated file is available after `write_artifact_file` succeeds. If it fails or is denied, state that the local file may exist but was not saved as an Artifact, and do not present it as downloadable.',
+  'After using the tool, mention the generated filename rather than an absolute filesystem path. The app will display the generated file list below your message.',
+  'Never write files inside a skill directory — loaded skills are read-only; route any file a skill generates through `write_artifact_file`.',
+  '</open_science_artifact_instructions>'
+].join('\n')
+
+const LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND = [
+  '<open_science_large_file_instructions>',
+  'Large attached data files (CSV, TSV, TXT, JSON, FASTA/FASTQ, VCF, and similar tabular or text data) are provided as a file reference plus a short preview, not as full inline content.',
+  'Never read, cat, or print such a file in its entirety — a single large read can exceed the request-size limit and break the conversation.',
+  'Inspect structure first (columns, row count, a few sample rows), then read only the specific line ranges, rows, or columns you need.',
+  'To analyze, filter, or aggregate over a large file, load it in the notebook (e.g. pandas) and compute there instead of reading its contents into the conversation.',
+  '</open_science_large_file_instructions>'
+].join('\n')
+
+const SPECIALIST_IDENTITY_TAG = '[open-science:specialist-identity]'
+
+// Pure presentation policy for exact Session and turn text. It owns neither Session state nor the
+// capabilities whose availability is supplied by their existing owner.
+class AcpSessionPresentationPolicy {
+  applicationSystemPromptAppends(tooling: AcpSessionToolingAvailability): readonly string[] {
+    return Object.freeze([
+      TURN_CONTINUITY_SYSTEM_PROMPT_APPEND,
+      LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND,
+      ...(tooling.artifacts ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
+      ...(tooling.notebook ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : []),
+      ...(tooling.skillImport ? [SKILL_IMPORT_SYSTEM_PROMPT_APPEND] : [])
+    ])
+  }
+
+  buildSessionSetup(input: AcpSessionSetupPresentationInput): AcpSessionSetupPresentation {
+    const skillWhitelist =
+      input.specialistSkills?.kind === 'specialist'
+        ? [...input.specialistSkills.frameworkNames]
+        : input.specialistSkills?.kind === 'unavailable'
+          ? []
+          : undefined
+    const setup = input.framework.buildSessionSetup({
+      systemPromptAppends: this.systemPromptAppends(input),
+      sessionOptions: input.sessionOptions,
+      ...(skillWhitelist !== undefined ? { skillWhitelist } : {})
+    })
+
+    return this.immutableSessionSetup(setup, input.persistentSystemPrompt)
+  }
+
+  specialistIdentity(
+    frameworkId: AgentFramework['id'],
+    profile: Pick<SpecialistProfileView, 'name' | 'systemPrompt'>
+  ): AcpSpecialistIdentityPresentation {
+    const prompt = profile.systemPrompt.trim()
+    if (!prompt) return Object.freeze({ append: '', prefix: '' })
+
+    const append = [
+      SPECIALIST_IDENTITY_TAG,
+      `# Specialist identity — ${profile.name}`,
+      '',
+      '> The following overrides the Main Agent general identity description for this session.',
+      '> App safety rules, tool rules, and workflow instructions still apply and are not replaced.',
+      '',
+      prompt
+    ].join('\n')
+    const prefix = [
+      SPECIALIST_IDENTITY_TAG,
+      `[Specialist: ${profile.name}]`,
+      '(This overrides the Main Agent identity for this session.',
+      ' App safety rules, tool rules, and workflow instructions still apply.)',
+      '',
+      prompt,
+      '',
+      '---',
+      ''
+    ].join('\n')
+
+    return Object.freeze(
+      frameworkId === 'claude-code' ? { append, prefix: '' } : { append: '', prefix }
+    )
+  }
+
+  buildTurnPromptPrefix(input: AcpTurnPromptPrefixInput): string | undefined {
+    const specialistSkillGuidance = this.specialistSkillGuidance(
+      input.framework.id,
+      input.specialistSkills
+    )
+    const setup = input.framework.buildSessionSetup({
+      systemPromptAppends: this.systemPromptAppends(input),
+      turnPromptReminders: specialistSkillGuidance ? [specialistSkillGuidance] : [],
+      sessionOptions: input.sessionOptions
+    })
+
+    return (
+      [input.specialistPrefix, setup.promptPrefix]
+        .filter((segment): segment is string => Boolean(segment))
+        .join('\n\n') || undefined
+    )
+  }
+
+  continuationText(request: Pick<AcpPromptRequest, 'text' | 'continuation'>): string {
+    const continuation = request.continuation
+    if (!continuation) return request.text
+
+    const outcome =
+      continuation.completion.kind === 'returned'
+        ? this.serializeHandoffValue(continuation.completion.value)
+        : continuation.completion.errorMessage
+    const outcomeLabel = continuation.completion.kind === 'returned' ? 'result' : 'error'
+    const target = continuation.targetName ?? 'Main Agent'
+    return [
+      `Continue the original user task as ${target}. Do not repeat work already shown before the handoff.`,
+      `Original user request:\n${request.text}`,
+      `Captured outer tool ${outcomeLabel}:\n${outcome}`
+    ].join('\n\n')
+  }
+
+  presentTurnSkills(input: AcpTurnSkillPresentationInput): AcpTurnSkillPresentation {
+    if (input.frameworkId === 'codex') {
+      return immutableCopy({
+        text: input.text,
+        codexSkillInputs: input.codexSkillInputs.map(({ name, path }) => ({ name, path }))
+      })
+    }
+
+    const text =
+      input.skillNames.length > 0
+        ? `Use the following skill(s) for this task: ${input.skillNames.join(', ')}.\n\n${input.text}`
+        : input.text
+    return Object.freeze({ text, codexSkillInputs: Object.freeze([]) })
+  }
+
+  private immutableSessionSetup(
+    setup: SessionSetup,
+    installedPersistentSystemPrompt: string | undefined
+  ): AcpSessionSetupPresentation {
+    const persistentSystemPrompt = installedPersistentSystemPrompt ?? setup.persistentSystemPrompt
+    return immutableCopy({
+      metaArg: setup.meta ? { _meta: setup.meta } : {},
+      ...(setup.promptPrefix ? { promptPrefix: setup.promptPrefix } : {}),
+      ...(persistentSystemPrompt ? { persistentSystemPrompt } : {})
+    })
+  }
+
+  private systemPromptAppends(input: AcpSessionSetupPresentationInput): string[] {
+    if (input.persistentSystemPrompt) return []
+    return [
+      ...this.applicationSystemPromptAppends(input.tooling),
+      ...(input.backendSystemPromptAppends ?? []),
+      ...(input.extraSystemPromptAppends ?? [])
+    ]
+  }
+
+  private specialistSkillGuidance(
+    frameworkId: AgentFramework['id'],
+    skills: EffectiveSpecialistSkills | undefined
+  ): string | undefined {
+    if (frameworkId === 'claude-code' || skills?.kind !== 'specialist') return undefined
+    return `Allowed Specialist Skills for this session:\n${skills.frameworkNames.map((name) => `- ${name}`).join('\n')}`
+  }
+
+  private serializeHandoffValue(value: unknown): string {
+    if (typeof value === 'string') return value
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+}
+
+export { AcpSessionPresentationPolicy }
+export type {
+  AcpCodexSkillInput,
+  AcpSessionSetupPresentation,
+  AcpSessionSetupPresentationInput,
+  AcpSessionToolingAvailability,
+  AcpSpecialistIdentityPresentation,
+  AcpTurnPromptPrefixInput,
+  AcpTurnSkillPresentation,
+  AcpTurnSkillPresentationInput
+}

--- a/src/main/acp/session-presentation-policy.ts
+++ b/src/main/acp/session-presentation-policy.ts
@@ -234,7 +234,8 @@ class AcpSessionPresentationPolicy {
   private serializeHandoffValue(value: unknown): string {
     if (typeof value === 'string') return value
     try {
-      return JSON.stringify(value)
+      const serialized = JSON.stringify(value)
+      return serialized === undefined ? String(value) : serialized
     } catch {
       return String(value)
     }

--- a/src/main/acp/session-presentation-policy.ts
+++ b/src/main/acp/session-presentation-policy.ts
@@ -90,8 +90,8 @@ const LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND = [
 
 const SPECIALIST_IDENTITY_TAG = '[open-science:specialist-identity]'
 
-// Pure presentation policy for exact Session and turn text. It owns neither Session state nor the
-// capabilities whose availability is supplied by their existing owner.
+// ARD-07 is a P0 pure-addition seam: later serialized Session and prompt leaves own Runtime
+// integration. This policy owns neither Session state nor capabilities supplied by existing owners.
 class AcpSessionPresentationPolicy {
   applicationSystemPromptAppends(tooling: AcpSessionToolingAvailability): readonly string[] {
     return Object.freeze([


### PR DESCRIPTION
## Problem

ARD-07 required the exact ACP Session and turn presentation rules to have a pure owner before any Runtime cutover. The behavior spans application prompt appends, framework Session setup, Specialist identity and Skills, handoff continuation text, and provider-specific Skill presentation.

Related: #458. This PR establishes only a type/policy-level forward boundary; it does not implement Issue #458 orchestration state, schema, wire/API contracts, or user-visible integration.

## Proposed change

- Add `AcpSessionPresentationPolicy` as an immutable, stateless presentation owner for application prompt appends and tooling gates, framework setup/meta, Specialist identity and guidance, turn prefixes, continuation text, and Codex/other Skill presentation.
- Add golden contract tests for exact text, ordering, provider differences, privacy, fail-closed Skill behavior, deep immutability, persistent-prompt handling, and non-JSON handoff values.
- Preserve one-off extra Session appends when persistent guidance is installed, while excluding stable application/backend appends already installed persistently.
- Keep non-JSON handoff presentation exactly behavior-neutral with the existing Runtime while making the policy return contract explicit.

## Scope and non-goals

- P0 pure addition: only the policy and its test file are added.
- The authoritative ARD-07 boundary forbids edits to `runtime.ts`, `runtime.test.ts`, `runtime-composition.ts`, and `runtime-coordinator.ts`; Runtime integration belongs to later serialized Session and prompt leaves.
- No Runtime, runtime composition/coordinator, provider adapter, transport, schema, data, UI, Artifact, Reviewer, or writer changes.
- No consumer cutover or integration in this leaf.
- Production raw: **256 additions**, below the 500-line hard stop.

## Ownership and sequence

`AcpSessionPresentationPolicy` is immutable and stateless. It owns presentation decisions and exact returned text only; it does not own Session state, Runtime resources, a transaction, or any writer. Therefore an ownership diagram would imply lifecycle state that is intentionally absent. Runtime integration is deferred to the later serialized Session and prompt leaves; the absence of Runtime wiring is an acceptance constraint, not missing behavior.

## Acceptance criteria and validation

The recorded final-head checks ran after the last material edit and after rebasing onto then-current `origin/main` (`53fda40`):

- Exact prompt text/order, provider presentation, Skill privacy, immutability, persistent-prompt behavior, behavior-neutral handoff serialization, and the adjacent provider-turn interface → targeted test run → **4 files and 36 tests passed**. The historical description did not preserve the exact command text.
- Full portable regression suite during the final review cycle → **745 files and 11,044 tests passed; 15 files and 184 tests skipped**.
- Node process contracts → `npm run typecheck:node` → passed.
- Source quality → `npm run lint` → 0 errors; 17 pre-existing warnings outside the added files.
- Formatting and patch hygiene → Prettier check and `git diff --check` → passed; the historical description did not preserve the exact Prettier invocation.
- Independent Standards and ARD-07 Spec reviews on final head `5675ba2` → no actionable findings.
- Final-head online gates → PR Gate, AI review, CodeQL, Static checks, Unit tests, Coverage macOS, macOS build/E2E, and Windows E2E all passed. `Windows core` was skipped by classification.

The then-latest base added a file-disjoint backend-generation owner. Both independent reviewers confirmed that its immutable backend presentation inputs remained compatible with ARD-07 and did not overlap policy authority.

Consumer and platform lanes were excluded from the minimum local impact map because this leaf added no consumer or platform integration. The final-head online PR Gate supplied authoritative cross-platform validation.

## Review focus

- Application/backend/extra append ordering, tooling gates, and persistent-system-prompt exclusion.
- Claude versus Codex/OpenCode Specialist identity and Skill presentation, especially filesystem-path privacy.
- Exact behavior-neutral handoff value serialization and immutable return values.
- Absence of state/resources and adherence to the P0 pure-addition boundary.

## Uncovered risks

The deliberately deferred Runtime cutover was the remaining risk of this pure leaf. The exact targeted and Prettier command strings were not preserved in the historical PR description, although their results were. Issue #458 integration remains deferred.
