### PR TITLE
refactor(acp): own backend generation state

### DIFF
--- a/src/main/acp/backend-generation-owner.test.ts
+++ b/src/main/acp/backend-generation-owner.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { claudeCodeFramework, codexFramework } from '../agent-framework'
+import { AcpBackendGenerationOwner } from './backend-generation-owner'
+
+describe('AcpBackendGenerationOwner', () => {
+  it('publishes one immutable secret-free behavior view atomically', () => {
+    const owner = new AcpBackendGenerationOwner(claudeCodeFramework)
+    const sessionOptions = { settingSources: ['user'] }
+    const systemPromptAppends = ['Use the app tools.']
+    const attempt = owner.prepare(
+      { epoch: 7, assertCurrent: vi.fn() },
+      {
+        framework: codexFramework,
+        backendId: 'codex:isolated',
+        executablePath: '/private/provider/bin/codex-acp',
+        env: { CODEX_HOME: '/data/codex', PROVIDER_TOKEN: 'spawn-secret' },
+        args: ['--token=argument-secret'],
+        sessionModel: 'gpt-selected',
+        sessionModelRequired: true,
+        sessionEffort: 'high',
+        sessionOptions,
+        systemPromptAppends,
+        persistentSystemPrompt: 'Stable instructions.',
+        contextWindow: 1_000_000,
+        contextUsageModel: 'provider-model',
+        authentication: { methodId: 'codex-login' },
+        providerConfiguration: {
+          providerId: 'custom-gateway',
+          apiType: 'openai',
+          baseUrl: 'https://provider.example',
+          headers: { authorization: 'Bearer provider-secret' }
+        },
+        opencodeUsageApi: {
+          baseUrl: 'http://127.0.0.1:4242',
+          authorization: 'Basic usage-secret'
+        }
+      }
+    )
+
+    expect(owner.current.framework.id).toBe('claude-code')
+
+    const view = attempt.publish()
+    sessionOptions.settingSources.push('project')
+    systemPromptAppends.push('late mutation')
+
+    expect(owner.current).toBe(view)
+    expect(view).toMatchObject({
+      framework: codexFramework,
+      backendId: 'codex:isolated',
+      session: {
+        model: 'gpt-selected',
+        modelRequired: true,
+        effort: 'high',
+        options: { settingSources: ['user'] }
+      },
+      prompt: {
+        systemPromptAppends: ['Use the app tools.'],
+        persistentSystemPrompt: 'Stable instructions.'
+      },
+      context: { window: 1_000_000, model: 'provider-model' },
+      adapter: {
+        codexHome: '/data/codex',
+        nativeMcpEnabled: false,
+        bridgeMcpAliasesEnabled: true
+      }
+    })
+    expect(Object.isFrozen(view)).toBe(true)
+    expect(Object.isFrozen(view.session)).toBe(true)
+    expect(Object.isFrozen(view.session.options)).toBe(true)
+    expect(Object.isFrozen(view.prompt.systemPromptAppends)).toBe(true)
+    expect(JSON.stringify(view)).not.toMatch(
+      /spawn-secret|argument-secret|provider-secret|usage-secret|provider\.example|\/private\/provider/
+    )
+  })
+
+  it('consumes attempt-bound initialize material exactly once', () => {
+    const owner = new AcpBackendGenerationOwner(claudeCodeFramework)
+    const authentication = { methodId: 'codex-login', _meta: { token: 'auth-secret' } }
+    const providerConfiguration = {
+      providerId: 'custom-gateway' as const,
+      apiType: 'openai' as const,
+      baseUrl: 'https://provider.example',
+      headers: { authorization: 'Bearer provider-secret' }
+    }
+    const attempt = owner.prepare(
+      { epoch: 1, assertCurrent: vi.fn() },
+      {
+        framework: codexFramework,
+        executablePath: '/bin/codex-acp',
+        env: {},
+        authentication,
+        providerConfiguration
+      }
+    )
+    attempt.publish()
+
+    expect(attempt.consumeInitializeMaterial()).toEqual({
+      authentication,
+      providerConfiguration
+    })
+    expect(attempt.consumeInitializeMaterial()).toBeUndefined()
+  })
+
+  it('rejects a stale reconnect attempt without replacing the published generation', () => {
+    const owner = new AcpBackendGenerationOwner(claudeCodeFramework)
+    const stale = owner.prepare(
+      { epoch: 1, assertCurrent: vi.fn() },
+      {
+        framework: codexFramework,
+        backendId: 'codex:stale',
+        executablePath: '/bin/codex-acp',
+        env: {},
+        sessionModel: 'model-old'
+      }
+    )
+    const successor = owner.prepare(
+      { epoch: 2, assertCurrent: vi.fn() },
+      {
+        framework: claudeCodeFramework,
+        backendId: 'claude-code:current',
+        executablePath: '/bin/claude',
+        env: {},
+        sessionModel: 'model-new'
+      }
+    )
+
+    expect(() => stale.publish()).toThrow('ACP backend generation was superseded.')
+    expect(owner.current.backendId).toBeUndefined()
+
+    successor.publish()
+    expect(owner.current.backendId).toBe('claude-code:current')
+    expect(owner.current.session.model).toBe('model-new')
+  })
+
+  it('clears unconsumed secrets when a published attempt fails', () => {
+    const owner = new AcpBackendGenerationOwner(claudeCodeFramework)
+    const attempt = owner.prepare(
+      { epoch: 1, assertCurrent: vi.fn() },
+      {
+        framework: codexFramework,
+        backendId: 'codex:failed',
+        executablePath: '/bin/codex-acp',
+        env: {},
+        authentication: { methodId: 'codex-login', _meta: { token: 'auth-secret' } },
+        opencodeUsageApi: {
+          baseUrl: 'http://127.0.0.1:4242',
+          authorization: 'Basic usage-secret'
+        }
+      }
+    )
+    attempt.publish()
+    expect(owner.openCodeUsageApi()).toEqual({
+      baseUrl: 'http://127.0.0.1:4242',
+      authorization: 'Basic usage-secret'
+    })
+
+    attempt.fail()
+
+    expect(attempt.consumeInitializeMaterial()).toBeUndefined()
+    expect(owner.openCodeUsageApi()).toBeUndefined()
+    expect(owner.current.backendId).toBe('codex:failed')
+  })
+
+  it('clears sensitive material when the connection generation is superseded', () => {
+    const owner = new AcpBackendGenerationOwner(claudeCodeFramework)
+    const attempt = owner.prepare(
+      { epoch: 1, assertCurrent: vi.fn() },
+      {
+        framework: codexFramework,
+        backendId: 'codex:retiring',
+        executablePath: '/bin/codex-acp',
+        env: {},
+        authentication: { methodId: 'codex-login' },
+        opencodeUsageApi: {
+          baseUrl: 'http://127.0.0.1:4242',
+          authorization: 'Basic usage-secret'
+        }
+      }
+    )
+    attempt.publish()
+
+    owner.supersede(1)
+
+    expect(attempt.consumeInitializeMaterial()).toBeUndefined()
+    expect(owner.openCodeUsageApi()).toBeUndefined()
+    expect(owner.current.backendId).toBe('codex:retiring')
+  })
+
+  it('does not let an older teardown supersede a newer generation', () => {
+    const owner = new AcpBackendGenerationOwner(claudeCodeFramework)
+    owner
+      .prepare(
+        { epoch: 1, assertCurrent: vi.fn() },
+        {
+          framework: codexFramework,
+          executablePath: '/bin/codex-acp',
+          env: {},
+          opencodeUsageApi: {
+            baseUrl: 'http://127.0.0.1:4242',
+            authorization: 'Basic old'
+          }
+        }
+      )
+      .publish()
+    owner
+      .prepare(
+        { epoch: 3, assertCurrent: vi.fn() },
+        {
+          framework: codexFramework,
+          executablePath: '/bin/codex-acp',
+          env: {},
+          opencodeUsageApi: {
+            baseUrl: 'http://127.0.0.1:4242',
+            authorization: 'Basic successor'
+          }
+        }
+      )
+      .publish()
+
+    owner.supersede(1)
+
+    expect(owner.openCodeUsageApi()?.authorization).toBe('Basic successor')
+    owner.supersede(3)
+    expect(owner.openCodeUsageApi()).toBeUndefined()
+  })
+
+  it('live-updates effort by replacing only the immutable Session view', () => {
+    const owner = new AcpBackendGenerationOwner(claudeCodeFramework)
+    owner
+      .prepare(
+        { epoch: 1, assertCurrent: vi.fn() },
+        {
+          framework: claudeCodeFramework,
+          backendId: 'claude-code:shared',
+          executablePath: '/bin/claude',
+          env: {},
+          sessionModel: 'claude-model',
+          sessionEffort: 'medium',
+          contextWindow: 200_000
+        }
+      )
+      .publish()
+    const prior = owner.current
+
+    const updated = owner.updateReasoningEffort('high')
+
+    expect(updated).toBe(owner.current)
+    expect(updated).not.toBe(prior)
+    expect(updated.session).toEqual({
+      model: 'claude-model',
+      modelRequired: false,
+      effort: 'high'
+    })
+    expect(updated.context).toBe(prior.context)
+    expect(prior.session.effort).toBe('medium')
+
+    expect(owner.updateReasoningEffort('default').session.effort).toBeUndefined()
+  })
+})

--- a/src/main/acp/backend-generation-owner.ts
+++ b/src/main/acp/backend-generation-owner.ts
@@ -1,0 +1,207 @@
+import type { ModelReasoningEffort, ResolvedReasoningEffort } from '../../shared/reasoning-effort'
+import type { AgentFramework, ResolvedAgentBackend } from '../agent-framework'
+
+type AcpBackendGenerationAttemptIdentity = Readonly<{
+  epoch: number
+  assertCurrent: () => void
+}>
+
+export type AcpBackendGenerationView = Readonly<{
+  framework: AgentFramework
+  backendId?: string
+  session: Readonly<{
+    model?: string
+    modelRequired: boolean
+    effort?: ModelReasoningEffort
+    options?: Readonly<Record<string, unknown>>
+  }>
+  prompt: Readonly<{
+    systemPromptAppends: readonly string[]
+    persistentSystemPrompt?: string
+  }>
+  context: Readonly<{
+    window?: number
+    model?: string
+  }>
+  adapter: Readonly<{
+    codexHome?: string
+    nativeMcpEnabled: boolean
+    bridgeMcpAliasesEnabled: boolean
+  }>
+}>
+
+type PreparedAttempt = {
+  identity: AcpBackendGenerationAttemptIdentity
+  view: AcpBackendGenerationView
+  initializeMaterial: AcpBackendInitializeMaterial | undefined
+  openCodeUsageApi: AcpOpenCodeUsageApi | undefined
+  published: boolean
+  failed: boolean
+}
+
+export type AcpBackendInitializeMaterial = Readonly<{
+  authentication?: ResolvedAgentBackend['authentication']
+  providerConfiguration?: ResolvedAgentBackend['providerConfiguration']
+}>
+
+export type AcpOpenCodeUsageApi = Readonly<NonNullable<ResolvedAgentBackend['opencodeUsageApi']>>
+
+export type AcpBackendGenerationAttempt = Readonly<{
+  publish: () => AcpBackendGenerationView
+  consumeInitializeMaterial: () => AcpBackendInitializeMaterial | undefined
+  fail: () => void
+}>
+
+const deepFreeze = <T>(value: T): T => {
+  if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return value
+  for (const nested of Object.values(value)) deepFreeze(nested)
+  return Object.freeze(value)
+}
+
+const generationView = (backend: ResolvedAgentBackend): AcpBackendGenerationView => {
+  const codexHome =
+    backend.framework.id === 'codex' && typeof backend.env.CODEX_HOME === 'string'
+      ? backend.env.CODEX_HOME
+      : undefined
+  const bridgeMcpAliasesEnabled =
+    backend.framework.id === 'codex' && backend.providerConfiguration !== undefined
+
+  return Object.freeze({
+    framework: backend.framework,
+    ...(backend.backendId ? { backendId: backend.backendId } : {}),
+    session: Object.freeze({
+      ...(backend.sessionModel ? { model: backend.sessionModel } : {}),
+      modelRequired: backend.sessionModelRequired ?? false,
+      ...(backend.sessionEffort ? { effort: backend.sessionEffort } : {}),
+      ...(backend.sessionOptions
+        ? { options: deepFreeze(structuredClone(backend.sessionOptions)) }
+        : {})
+    }),
+    prompt: Object.freeze({
+      systemPromptAppends: Object.freeze([...(backend.systemPromptAppends ?? [])]),
+      ...(backend.persistentSystemPrompt
+        ? { persistentSystemPrompt: backend.persistentSystemPrompt }
+        : {})
+    }),
+    context: Object.freeze({
+      ...(backend.contextWindow ? { window: backend.contextWindow } : {}),
+      ...(backend.contextUsageModel ? { model: backend.contextUsageModel } : {})
+    }),
+    adapter: Object.freeze({
+      ...(codexHome ? { codexHome } : {}),
+      nativeMcpEnabled: backend.framework.id !== 'codex' || !bridgeMcpAliasesEnabled,
+      bridgeMcpAliasesEnabled
+    })
+  })
+}
+
+// Owns one runtime generation's derived backend behavior. Attempt material remains provisional until
+// the corresponding connection attempt proves current and publishes the complete secret-free view.
+export class AcpBackendGenerationOwner {
+  private currentView: AcpBackendGenerationView
+  private prepared: PreparedAttempt | undefined
+  private currentOpenCodeUsageApi: AcpOpenCodeUsageApi | undefined
+
+  constructor(initialFramework: AgentFramework) {
+    this.currentView = generationView({
+      framework: initialFramework,
+      executablePath: '',
+      env: {}
+    })
+  }
+
+  get current(): AcpBackendGenerationView {
+    return this.currentView
+  }
+
+  openCodeUsageApi(): AcpOpenCodeUsageApi | undefined {
+    return this.currentOpenCodeUsageApi
+  }
+
+  supersede(throughEpoch: number): void {
+    if (this.prepared && this.prepared.identity.epoch <= throughEpoch) {
+      this.clearAttempt(this.prepared)
+    }
+  }
+
+  updateReasoningEffort(effort: ResolvedReasoningEffort): AcpBackendGenerationView {
+    const session = { ...this.currentView.session }
+    if (effort === 'default') delete session.effort
+    else session.effort = effort
+    this.currentView = Object.freeze({
+      ...this.currentView,
+      session: Object.freeze(session)
+    })
+    return this.currentView
+  }
+
+  prepare(
+    identity: AcpBackendGenerationAttemptIdentity,
+    backend: ResolvedAgentBackend
+  ): AcpBackendGenerationAttempt {
+    identity.assertCurrent()
+    if (this.prepared) this.clearAttempt(this.prepared)
+    const initializeMaterial =
+      backend.authentication || backend.providerConfiguration
+        ? Object.freeze({
+            ...(backend.authentication ? { authentication: backend.authentication } : {}),
+            ...(backend.providerConfiguration
+              ? { providerConfiguration: backend.providerConfiguration }
+              : {})
+          })
+        : undefined
+    const prepared: PreparedAttempt = {
+      identity,
+      view: generationView(backend),
+      initializeMaterial,
+      openCodeUsageApi: backend.opencodeUsageApi
+        ? Object.freeze({ ...backend.opencodeUsageApi })
+        : undefined,
+      published: false,
+      failed: false
+    }
+    this.prepared = prepared
+
+    return Object.freeze({
+      publish: () => {
+        this.assertCurrent(prepared)
+        this.currentView = prepared.view
+        this.currentOpenCodeUsageApi = prepared.openCodeUsageApi
+        prepared.openCodeUsageApi = undefined
+        prepared.published = true
+        return this.currentView
+      },
+      consumeInitializeMaterial: () => {
+        if (prepared.failed) return undefined
+        this.assertCurrent(prepared)
+        if (!prepared.published) throw new Error('ACP backend generation is not published.')
+        const material = prepared.initializeMaterial
+        prepared.initializeMaterial = undefined
+        return material
+      },
+      fail: () => this.clearAttempt(prepared)
+    })
+  }
+
+  private assertCurrent(prepared: PreparedAttempt): void {
+    try {
+      prepared.identity.assertCurrent()
+      if (this.prepared === prepared) return
+    } catch (error) {
+      this.clearAttempt(prepared)
+      throw error
+    }
+    this.clearAttempt(prepared)
+    throw new Error('ACP backend generation was superseded.')
+  }
+
+  private clearAttempt(prepared: PreparedAttempt): void {
+    prepared.initializeMaterial = undefined
+    prepared.openCodeUsageApi = undefined
+    prepared.failed = true
+    if (prepared.published && this.prepared === prepared) {
+      this.currentOpenCodeUsageApi = undefined
+    }
+    if (this.prepared === prepared) this.prepared = undefined
+  }
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -838,21 +838,15 @@ const pendingReviewerSessionIds = (runtime: AcpRuntime): Map<string, symbol> =>
       .map(({ sessionId }) => [sessionId, Symbol.for(sessionId)])
   )
 
-const contextUsageSelectionForTest = (
-  runtime: AcpRuntime,
-  sessionId: string
-): { model?: string; contextWindow?: number } =>
-  (
-    runtime as unknown as {
-      contextUsageSelectionFor: (sessionId: string) => {
-        model?: string
-        contextWindow?: number
-      }
-    }
-  ).contextUsageSelectionFor(sessionId)
-
 const permissionContext = (runtime: AcpRuntime): AcpPermissionContext =>
   (runtime as unknown as { permissionContext: AcpPermissionContext }).permissionContext
+
+const openCodeUsageApiForTest = (runtime: AcpRuntime): unknown =>
+  (
+    runtime as unknown as {
+      backendGeneration: { openCodeUsageApi: () => unknown }
+    }
+  ).backendGeneration.openCodeUsageApi()
 
 const codexMcpToolIdentitiesMap = (runtime: AcpRuntime): Map<string, Map<string, unknown>> =>
   (
@@ -1664,6 +1658,125 @@ describe('ACP runtime session management', () => {
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'continue' })
 
     expect(fakeAgent.actions).toEqual(['mode:bypassPermissions', 'prompt:continue'])
+  })
+
+  const terminalGenerationActions = [
+    ['disconnect', async (runtime: AcpRuntime) => void (await runtime.disconnect())],
+    ['synchronous shutdown', (runtime: AcpRuntime) => runtime.shutdown()],
+    [
+      'unexpected close cleanup',
+      (runtime: AcpRuntime) =>
+        (
+          runtime as unknown as {
+            handleConnectionClosed: () => void
+          }
+        ).handleConnectionClosed()
+    ],
+    [
+      'failed deferred disconnect recovery',
+      (runtime: AcpRuntime) =>
+        (
+          runtime as unknown as {
+            recoverFailedDeferredDisconnect: () => void
+          }
+        ).recoverFailedDeferredDisconnect()
+    ]
+  ] satisfies ReadonlyArray<readonly [string, (runtime: AcpRuntime) => void | Promise<void>]>
+
+  it.each(terminalGenerationActions)(
+    'clears backend usage credentials on %s',
+    async (_name, terminate) => {
+      const process = new FakeAgentProcess()
+      startFakeAgent(process, [])
+      const framework = { ...opencodeFramework, spawn: () => asAgentProcess(process) }
+      const runtime = new AcpRuntime({
+        appVersion: '0.2.0',
+        defaultCwd: '/workspace',
+        framework,
+        resolveBackend: () => ({
+          framework,
+          executablePath: '/bin/opencode',
+          env: {},
+          opencodeUsageApi: {
+            baseUrl: 'http://127.0.0.1:4242',
+            authorization: 'Basic generation-secret'
+          }
+        })
+      })
+
+      await runtime.connect({ cwd: '/workspace' })
+      expect(openCodeUsageApiForTest(runtime)).toBeDefined()
+
+      await terminate(runtime)
+
+      expect(openCodeUsageApiForTest(runtime)).toBeUndefined()
+    }
+  )
+
+  it('retains backend usage credentials when disconnect rolls back a live connection', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, [])
+    const framework = { ...opencodeFramework, spawn: () => asAgentProcess(process) }
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      framework,
+      resolveBackend: () => ({
+        framework,
+        executablePath: '/bin/opencode',
+        env: {},
+        opencodeUsageApi: {
+          baseUrl: 'http://127.0.0.1:4242',
+          authorization: 'Basic generation-secret'
+        }
+      })
+    })
+    await runtime.connect({ cwd: '/workspace' })
+    vi.spyOn(
+      runtime as unknown as {
+        disconnectCurrent: () => Promise<AcpStateSnapshot>
+      },
+      'disconnectCurrent'
+    ).mockRejectedValueOnce(new Error('disconnect teardown failed'))
+
+    await expect(runtime.disconnect()).rejects.toThrow('disconnect teardown failed')
+
+    expect(openCodeUsageApiForTest(runtime)).toBeDefined()
+    runtime.shutdown()
+  })
+
+  it('clears backend usage credentials when disconnect fails after detaching', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['usage-session'])
+    const framework = { ...opencodeFramework, spawn: () => asAgentProcess(process) }
+    const runtime = new AcpRuntime({
+      appVersion: '0.2.0',
+      defaultCwd: '/workspace',
+      framework,
+      resolveBackend: () => ({
+        framework,
+        executablePath: '/bin/opencode',
+        env: {},
+        opencodeUsageApi: {
+          baseUrl: 'http://127.0.0.1:4242',
+          authorization: 'Basic generation-secret'
+        }
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    const disposeSpy = vi
+      .spyOn(acp.ActiveSession.prototype, 'dispose')
+      .mockImplementationOnce(() => {
+        throw new Error('session dispose failed')
+      })
+
+    try {
+      await expect(runtime.disconnect()).rejects.toThrow('session dispose failed')
+    } finally {
+      disposeSpy.mockRestore()
+    }
+
+    expect(openCodeUsageApiForTest(runtime)).toBeUndefined()
   })
 
   it('kills the agent process synchronously on shutdown so it cannot outlive the app', async () => {
@@ -5059,7 +5172,7 @@ describe('ACP runtime session management', () => {
     }
   })
 
-  it('cleans partial provisional routes after a framework switch without replacing the startup error', async () => {
+  it('cleans partial provisional routes without replacing the startup error', async () => {
     const root = await createTemporaryRoot()
     const startupFailure = new Error('notebook capability setup failed')
     let unregisterAttempt = 0
@@ -5104,7 +5217,6 @@ describe('ACP runtime session management', () => {
         projectName: 'default-project',
         mcpEntryPath: '/app/out/main/index.js',
         getRpcConnection: async () => {
-          setRuntimeFramework(runtime, claudeCodeFramework)
           throw startupFailure
         }
       },
@@ -6983,7 +7095,7 @@ describe('ACP runtime session management', () => {
     ])
   })
 
-  it('strips Codex policy amendments using the session framework after this.framework moves', async () => {
+  it('strips Codex policy amendments using the Session framework', async () => {
     const process = new FakeAgentProcess()
     const permissionRequests: Array<{
       requestId: string
@@ -7047,11 +7159,6 @@ describe('ACP runtime session management', () => {
       }
     })
     const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
-
-    // Simulate an overlapping reconnect moving the process-global framework off codex while the
-    // Codex session persists. The projection must key off the per-session framework, not this one.
-    ;(runtime as unknown as { framework: typeof claudeCodeFramework }).framework =
-      claudeCodeFramework
 
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'deploy' })
 
@@ -8414,74 +8521,6 @@ describe('ACP runtime session management', () => {
     }
   })
 
-  it('does not let a stale primary model application replace its successor projection', async () => {
-    const process = new FakeAgentProcess()
-    const staleModelStarted = createDeferred()
-    const releaseStaleModel = createDeferred()
-    const configOptions = [
-      {
-        type: 'select',
-        id: 'model',
-        name: 'Model',
-        category: 'model',
-        currentValue: 'model-default',
-        options: [
-          { value: 'model-old', name: 'Old model' },
-          { value: 'model-new', name: 'New model' }
-        ]
-      } as SessionConfigOption
-    ]
-    startFakeAgent(process, ['shared-primary', 'shared-primary'], {
-      configOptions,
-      onSetConfigOption: async ({ value }) => {
-        if (value === 'model-old') {
-          staleModelStarted.resolve()
-          await releaseStaleModel.promise
-        }
-      }
-    })
-    const runtime = new AcpRuntime({
-      appVersion: '0.1.0',
-      defaultCwd: '/workspace',
-      resolveBackend: () => ({
-        framework: { ...opencodeFramework, spawn: () => asAgentProcess(process) },
-        executablePath: '/bin/opencode-acp',
-        env: {},
-        sessionModel: 'model-old'
-      }),
-      framework: opencodeFramework
-    })
-    await runtime.connect({ cwd: '/workspace' })
-    const disconnectCurrentSpy = vi
-      .spyOn(
-        runtime as unknown as {
-          disconnectCurrent: (emitClosedStatus?: boolean) => Promise<AcpStateSnapshot>
-        },
-        'disconnectCurrent'
-      )
-      .mockRejectedValueOnce(new Error('disconnect teardown failed'))
-    const stale = runtime.createSession({ cwd: '/workspace' })
-    await staleModelStarted.promise
-    let successor: Awaited<ReturnType<AcpRuntime['createSession']>> | undefined
-
-    try {
-      await expect(runtime.disconnect()).rejects.toThrow('disconnect teardown failed')
-      ;(runtime as unknown as { pendingSessionModel?: string }).pendingSessionModel = 'model-new'
-      successor = await runtime.createSession({ cwd: '/workspace' })
-      expect(contextUsageSelectionForTest(runtime, 'shared-primary').model).toBe('model-new')
-
-      releaseStaleModel.resolve()
-      await expect(stale).rejects.toThrow('ACP session startup was superseded.')
-      expect(contextUsageSelectionForTest(runtime, 'shared-primary').model).toBe('model-new')
-    } finally {
-      releaseStaleModel.resolve()
-      await stale.catch(() => undefined)
-      disconnectCurrentSpy.mockRestore()
-      if (successor) await runtime.deleteSession({ sessionId: successor.sessionId })
-      await runtime.disconnect().catch(() => undefined)
-    }
-  })
-
   it('disposes a created primary session when teardown invalidates its startup', async () => {
     const process = new FakeAgentProcess()
     const pendingModeStarted = createDeferred()
@@ -8792,7 +8831,11 @@ describe('ACP runtime session management', () => {
             spawn: () => asAgentProcess(process)
           },
           executablePath: '/bin/agent',
-          env: {}
+          env: {},
+          opencodeUsageApi: {
+            baseUrl: 'http://127.0.0.1:4242',
+            authorization: process === oldProcess ? 'Basic old' : 'Basic successor'
+          }
         }
       },
       mcpHttpHost: httpHost,
@@ -8827,12 +8870,18 @@ describe('ACP runtime session management', () => {
       expect(successorRoutingId).toBeDefined()
       expect(successorRoutingId).not.toBe(firstRoutingId)
       expect(routes.size).toBe(1)
+      expect(openCodeUsageApiForTest(runtime)).toMatchObject({
+        authorization: 'Basic successor'
+      })
 
       releaseOldKill.resolve()
       await oldDisconnect
 
       expect(close).not.toHaveBeenCalled()
       expect(routes).toContain(successorRoutingId)
+      expect(openCodeUsageApiForTest(runtime)).toMatchObject({
+        authorization: 'Basic successor'
+      })
       expect(runtime.getSnapshot()).toMatchObject({
         status: 'connected',
         sessionIds: ['new-http-session']
@@ -15711,34 +15760,28 @@ describe('ACP runtime skill force-load + nudge', () => {
 })
 
 describe('ACP runtime Codex Skill activity projection', () => {
-  it('emits only the Skill name for a native Codex SKILL.md read lifecycle', () => {
+  it('emits only the Skill name for a native Codex SKILL.md read lifecycle', async () => {
     const events: AcpRuntimeEvent[] = []
     const codexHome = join('/data', 'codex-subscription')
     const skillPath = join(codexHome, 'skills', 'mcp-pubmed', 'SKILL.md')
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['session-1'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+    })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        backendId: 'codex:isolated',
+        executablePath: '/data/codex-acp',
+        env: { CODEX_HOME: codexHome }
+      }),
       callbacks: { onEvent: (event) => events.push(event) }
     })
-    const internal = runtime as unknown as {
-      applyResolvedBackend: (backend: {
-        framework: typeof codexFramework
-        backendId: string
-        executablePath: string
-        env: NodeJS.ProcessEnv
-      }) => void
-      handleSessionUpdate: (notification: SessionNotification) => void
-      activeSessionFor: (sessionId: string) => { sessionId: string } | undefined
-    }
-    internal.applyResolvedBackend({
-      framework: codexFramework,
-      backendId: 'codex:isolated',
-      executablePath: '/data/codex-acp',
-      env: { CODEX_HOME: codexHome }
-    })
-    vi.spyOn(internal, 'activeSessionFor').mockReturnValue({ sessionId: 'session-1' })
+    await runtime.createSession({ cwd: '/workspace' })
 
-    internal.handleSessionUpdate({
+    handleSessionUpdate(runtime, {
       sessionId: 'session-1',
       update: {
         sessionUpdate: 'tool_call',
@@ -15749,7 +15792,7 @@ describe('ACP runtime Codex Skill activity projection', () => {
         locations: [{ path: skillPath }]
       }
     })
-    internal.handleSessionUpdate({
+    handleSessionUpdate(runtime, {
       sessionId: 'session-1',
       update: {
         sessionUpdate: 'tool_call_update',
@@ -15758,29 +15801,25 @@ describe('ACP runtime Codex Skill activity projection', () => {
         rawOutput: { formatted_output: 'FULL SKILL BODY', exit_code: 0 }
       }
     })
-    internal.handleSessionUpdate({
+    handleSessionUpdate(runtime, {
       sessionId: 'session-1',
       update: { sessionUpdate: 'usage_update', used: 100, size: 128000 }
     })
 
-    expect(events).toHaveLength(2)
-    expect(events.map((event) => event.title)).toEqual([
+    const skillEvents = events.filter((event) => event.toolCallId === 'read-skill-1')
+    expect(skillEvents).toHaveLength(2)
+    expect(skillEvents.map((event) => event.title)).toEqual([
       'Loading skill: mcp-pubmed',
       'Loaded skill: mcp-pubmed'
     ])
-    expect(JSON.stringify(events)).not.toContain(skillPath)
-    expect(JSON.stringify(events)).not.toContain('FULL SKILL BODY')
+    expect(JSON.stringify(skillEvents)).not.toContain(skillPath)
+    expect(JSON.stringify(skillEvents)).not.toContain('FULL SKILL BODY')
     const categories =
       runtime.getSnapshot().contextUsageBySession['session-1']?.breakdown?.categories
     expect(categories).toContainEqual(expect.objectContaining({ key: 'skills', estimated: true }))
     expect(categories).not.toContainEqual(expect.objectContaining({ key: 'tools' }))
   })
 })
-
-// Reads the private framework pointer so a test can simulate a mid-reconnect backend switch.
-const setRuntimeFramework = (runtime: AcpRuntime, framework: unknown): void => {
-  ;(runtime as unknown as { framework: unknown }).framework = framework
-}
 
 describe('ACP runtime — agent process lifecycle logging', () => {
   it('logs a non-zero agent exit with code, framework, pid, and expected=false', async () => {
@@ -15893,19 +15932,32 @@ describe('ACP runtime — agent process lifecycle logging', () => {
 
   it('labels a late stderr with the framework captured at bind time, not the current one', async () => {
     warnLogSpy.mockClear()
-    const process = new FakeAgentProcess()
-    startFakeAgent(process, ['bind-session'])
+    const oldProcess = new FakeAgentProcess()
+    const replacementProcess = new FakeAgentProcess()
+    startFakeAgent(oldProcess, ['old-session'])
+    startFakeAgent(replacementProcess, ['replacement-session'])
+    const backends = [
+      {
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(oldProcess) },
+        executablePath: '/bin/claude',
+        env: {}
+      },
+      {
+        framework: { ...opencodeFramework, spawn: () => asAgentProcess(replacementProcess) },
+        executablePath: '/bin/opencode',
+        env: {}
+      }
+    ]
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
+      resolveBackend: () => backends.shift()!
     })
 
     await runtime.createSession({ cwd: '/workspace' })
-    // Simulate a reconnect having swapped the active backend after this process was bound. A late
-    // stderr from the *old* process must still be attributed to the framework it was spawned under.
-    setRuntimeFramework(runtime, opencodeFramework)
-    process.stderr.emit('data', Buffer.from('slow tail output'))
+    await runtime.disconnect()
+    await runtime.createSession({ cwd: '/workspace' })
+    oldProcess.stderr.emit('data', Buffer.from('slow tail output'))
 
     const call = warnLogSpy.mock.calls.find(([message]) => message === 'agent stderr')
     expect((call?.[1] as { framework: string }).framework).toBe('claude-code')
@@ -16023,6 +16075,7 @@ describe('ACP runtime — connect failure logging', () => {
     warnLogSpy.mockClear()
     errorLogSpy.mockClear()
     const process = new FakeAgentProcess()
+    const { lease, release } = createBackendLeaseHarness()
     process.pid = 3434
     let signalEntered: () => void = () => undefined
     const enteredResolver = new Promise<void>((resolvePromise) => {
@@ -16037,8 +16090,8 @@ describe('ACP runtime — connect failure logging', () => {
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       // A genuinely async backend resolution that signals once entered, then parks. The test only
-      // supersedes AFTER the connect is inside the resolver (past the pre-spawn teardown + generation
-      // assertion), so the supersede is detected post-spawn and the child is captured in the log.
+      // supersedes AFTER the connect is inside the resolver (past the pre-spawn teardown), so the
+      // supersede is detected when the resolved backend is prepared, before the child can spawn.
       resolveBackend: async () => {
         signalEntered()
         await backendGate
@@ -16046,7 +16099,8 @@ describe('ACP runtime — connect failure logging', () => {
         return {
           framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
           executablePath: '/bin/agent',
-          env: {}
+          env: {},
+          responsesBridgeLease: lease
         }
       }
     })
@@ -16060,9 +16114,11 @@ describe('ACP runtime — connect failure logging', () => {
 
     await expect(createPromise).rejects.toThrow(/superseded|shutting down/i)
 
-    // The connect resumes, spawns the child, then detects the supersede and abandons it. Key guarantees:
-    // logged as *abandoned* (a warning) with safe lifecycle context, and NOT also raised as the
-    // error-level "failed" record.
+    // The connect detects the supersede before spawning. Key guarantees: the resolved bridge lease is
+    // released, the attempt is logged as *abandoned* with safe lifecycle context, and it is NOT also
+    // raised as the error-level "failed" record.
+    expect(release).toHaveBeenCalledOnce()
+    expect(process.killed).toBe(false)
     const abandoned = warnLogSpy.mock.calls.find(
       ([message]) => message === 'agent connection abandoned (superseded or shutting down)'
     )

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -48,7 +48,7 @@ import {
 } from '../../shared/permission-profiles'
 import { type AgentFrameworkId } from '../../shared/settings'
 import type { EffectiveSpecialistSkills } from '../../shared/specialist'
-import type { ModelReasoningEffort, ResolvedReasoningEffort } from '../../shared/reasoning-effort'
+import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import type {
   ApprovedSwitchReadBack,
   ClaudeCodeReplayInput,
@@ -140,6 +140,11 @@ import {
   type AcpConnectionResourceReadyHandle
 } from './connection-resource-owner'
 import { AcpConnectionTransitionOwner } from './connection-transition-owner'
+import {
+  AcpBackendGenerationOwner,
+  type AcpBackendGenerationAttempt,
+  type AcpBackendGenerationView
+} from './backend-generation-owner'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -550,34 +555,8 @@ class AcpRuntime {
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
   private readonly skillsHooks: AcpRuntimeSkillsOptions | undefined
-  // Mutable: refreshed from resolveBackend on each connect so a framework switch applies on reconnect.
-  private framework: AgentFramework
-  private backendId: string | undefined
-  private codexHome: string | undefined
+  private readonly backendGeneration: AcpBackendGenerationOwner
   private readonly codexSkillActivity = new CodexSkillActivityProjector()
-  // A Chat Completions provider uses the local Responses bridge. App-owned notebook, artifact, and
-  // reviewer MCPs have explicit namespaced bridge mappings; other MCP tools still require Responses.
-  private nativeMcpEnabled = true
-  private bridgeMcpAliasesEnabled = false
-  // Model to apply per session via the ACP model configOption (opencode); undefined for env-driven
-  // frameworks (Claude). Refreshed from the resolved backend on each connect.
-  private pendingSessionModel: string | undefined
-  private pendingSessionModelRequired = false
-  // The selected upstream model owns the denominator. Adapter values are fallback-only because a
-  // bridge can report its internal transport model (for example Codex gpt-5.5) instead.
-  private selectedModelContextWindow: number | undefined
-  private selectedContextUsageModel: string | undefined
-  // Reasoning-effort level to apply per session via the ACP thought_level configOption; undefined
-  // means "don't override" (the agent keeps its own default). Refreshed on each connect.
-  private pendingSessionEffort: ModelReasoningEffort | undefined
-  private pendingSessionOptions: Record<string, unknown> | undefined
-  private pendingSystemPromptAppends: string[] = []
-  private pendingPersistentSystemPrompt: string | undefined
-  // One-shot ACP authentication material resolved alongside the spawn config. It is cleared after
-  // initialize so the decrypted key is not retained by the runtime longer than necessary.
-  private pendingAuthentication: ResolvedAgentBackend['authentication']
-  private pendingProviderConfiguration: ResolvedAgentBackend['providerConfiguration']
-  private opencodeUsageApi: ResolvedAgentBackend['opencodeUsageApi']
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
@@ -613,7 +592,7 @@ class AcpRuntime {
     })
     this.spawnAgent = options.spawnAgent
     this.skillsHooks = options.skills
-    this.framework = options.framework ?? claudeCodeFramework
+    this.backendGeneration = new AcpBackendGenerationOwner(options.framework ?? claudeCodeFramework)
     this.resumeTimeoutMs = options.resumeTimeoutMs ?? 30_000
     this.contextUsageTracker = options.contextUsageTracker ?? new ContextUsageTracker()
     this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
@@ -726,6 +705,18 @@ class AcpRuntime {
       unregisterBridgeSession: (sessionId) =>
         this.connectionResources.unregisterBridgeReviewerSession(sessionId)
     })
+  }
+
+  private get backend(): AcpBackendGenerationView {
+    return this.backendGeneration.current
+  }
+
+  private get framework(): AgentFramework {
+    return this.backend.framework
+  }
+
+  private get backendId(): string | undefined {
+    return this.backend.backendId
   }
 
   private get connection(): ClientConnection | undefined {
@@ -1024,7 +1015,7 @@ class AcpRuntime {
 
   // Applies the active model to a freshly built/resumed session via the ACP model configOption, for
   // frameworks that select the model over the protocol (opencode). No-op for env-driven frameworks
-  // (pendingSessionModel undefined). Optional selections keep the agent default when no matching option
+  // (generation Session model undefined). Optional selections keep the default when no matching option
   // exists or application fails; required selections fail visibly rather than silently running another
   // model. Returns the agent's post-application configOptions when it reports them — effort levels are
   // model-dependent, so callers resolving further options must use the set from AFTER the model switch.
@@ -1032,21 +1023,20 @@ class AcpRuntime {
     session: ActiveSession,
     connection: ClientConnection | undefined = this.connection
   ): Promise<SessionModelApplication> {
-    if (!this.pendingSessionModel || !connection) {
+    const model = this.backend.session.model
+    if (!model || !connection) {
       return { appliedModel: undefined, configOptions: undefined }
     }
 
     const configOptions = (
       session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } }
     ).newSessionResponse?.configOptions
-    const selection = matchSessionModelOption(configOptions, this.pendingSessionModel)
+    const selection = matchSessionModelOption(configOptions, model)
 
     if (!selection) {
       log.info('no matching session model option', this.diagnosticContext())
-      if (this.pendingSessionModelRequired) {
-        throw new Error(
-          `The selected model "${this.pendingSessionModel}" is not available for this Codex account.`
-        )
+      if (this.backend.session.modelRequired) {
+        throw new Error(`The selected model "${model}" is not available for this Codex account.`)
       }
       return { appliedModel: undefined, configOptions: undefined }
     }
@@ -1081,17 +1071,15 @@ class AcpRuntime {
         ...diagnosticErrorFields(error),
         ...this.diagnosticContext()
       })
-      if (this.pendingSessionModelRequired) {
-        throw new Error(
-          `The selected model "${this.pendingSessionModel}" could not be applied: ${message}`
-        )
+      if (this.backend.session.modelRequired) {
+        throw new Error(`The selected model "${model}" could not be applied: ${message}`)
       }
       return { appliedModel: undefined, configOptions: undefined }
     }
   }
 
   // Applies the user's reasoning-effort preference to a freshly built/resumed session via the ACP
-  // thought_level configOption. No-op when no explicit level is set (pendingSessionEffort undefined —
+  // thought_level configOption. No-op when the generation view has no explicit effort level —
   // the agent then keeps its own default) or when the agent advertises no effort option. The desired
   // level is already resolved by the model profile and therefore only an exact advertised match is
   // sent. `configOptions` should be the agent's latest option set (e.g. returned by a model switch
@@ -1102,13 +1090,14 @@ class AcpRuntime {
     configOptions?: SessionConfigOption[] | null,
     connection: ClientConnection | undefined = this.connection
   ): Promise<void> {
-    if (!this.pendingSessionEffort || !connection) return
+    const effort = this.backend.session.effort
+    if (!effort || !connection) return
 
     const effectiveOptions =
       configOptions ??
       (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
         .newSessionResponse?.configOptions
-    const selection = resolveSessionEffortOption(effectiveOptions, this.pendingSessionEffort)
+    const selection = resolveSessionEffortOption(effectiveOptions, effort)
 
     if (!selection) {
       log.info('no session effort option to apply', this.diagnosticContext())
@@ -1126,7 +1115,7 @@ class AcpRuntime {
   // leaving the UI showing a level the agent never received. All sessions are attempted even after
   // a failure, so the set never straddles two levels longer than the reconnect takes. Sessions that
   // simply advertise no effort option are skipped (a reconnect could not give their model one
-  // either). On success pendingSessionEffort tracks the new level, so sessions created later in
+  // either). On success the generation view tracks the new level, so sessions created later in
   // this process inherit it; the persisted setting covers the next respawn.
   async applyReasoningEffortChange(effort: ResolvedReasoningEffort): Promise<boolean> {
     if (!this.framework.supportsLiveEffortChange) return false
@@ -1135,8 +1124,8 @@ class AcpRuntime {
     // the persisted setting reach the fresh backend after reconnect instead of leaking it here.
     if (this.pendingProviderReconnect) return false
 
-    this.pendingSessionEffort = effort === 'default' ? undefined : effort
-    this.connectionResources.setBridgeReasoningEffort(this.pendingSessionEffort)
+    const backend = this.backendGeneration.updateReasoningEffort(effort)
+    this.connectionResources.setBridgeReasoningEffort(backend.session.effort)
     const connection = this.connection
     if (!connection) return true
 
@@ -1222,9 +1211,8 @@ class AcpRuntime {
     let agentProcess: ChildProcessWithoutNullStreams | undefined
     let unattachedConnection: ClientConnection | undefined
     let unattachedBridgeLease: ResolvedAgentBackend['responsesBridgeLease']
+    let backendAttempt: AcpBackendGenerationAttempt | undefined
     let resourceAttached = false
-    let connectionAuthentication: ResolvedAgentBackend['authentication']
-    let connectionProviderConfiguration: ResolvedAgentBackend['providerConfiguration']
     // The framework THIS connect spawned under, bound atomically to the spawn (spawnAgentProcess returns
     // it alongside the process, and tags a spawn-throw with it) rather than re-read from the mutable
     // this.framework, which an overlapping reconnect can move before the failure log is written. Seeded
@@ -1243,12 +1231,11 @@ class AcpRuntime {
       this.setStatus('connecting')
       log.info('connecting agent', this.diagnosticContext(this.framework.id, generation))
 
-      const spawned = await this.spawnAgentProcess()
+      const spawned = await this.spawnAgentProcess(attempt)
       agentProcess = spawned.process
       spawnedFramework = spawned.framework
-      connectionAuthentication = spawned.backend.authentication
-      connectionProviderConfiguration = spawned.backend.providerConfiguration
-      unattachedBridgeLease = spawned.backend.responsesBridgeLease
+      backendAttempt = spawned.backendAttempt
+      unattachedBridgeLease = spawned.bridgeLease
 
       // spawnAgentProcess resolves the provider config asynchronously, so the connection may have been
       // torn down or superseded during the spawn: a quit latched shuttingDown, or any teardown/reconnect
@@ -1278,7 +1265,10 @@ class AcpRuntime {
         )
       }
 
-      this.applyResolvedBackend(spawned.backend)
+      const backend = backendAttempt.publish()
+      this.codexSkillActivity.setSkillsRoot(
+        backend.adapter.codexHome ? join(backend.adapter.codexHome, 'skills') : undefined
+      )
       this.attachAgentProcessEvents(agentProcess, generation)
 
       const stream = acp.ndJsonStream(
@@ -1292,7 +1282,7 @@ class AcpRuntime {
         process: agentProcess,
         connection,
         framework: spawned.framework,
-        bridgeLease: spawned.backend.responsesBridgeLease
+        bridgeLease: spawned.bridgeLease
       })
       resourceAttached = true
       unattachedConnection = undefined
@@ -1327,21 +1317,20 @@ class AcpRuntime {
         }
       })
       attempt.assertCurrent()
-      if (this.pendingAuthentication) {
-        const authentication = this.pendingAuthentication
-        await connection.agent.request(acp.methods.agent.authenticate, authentication)
+      const initializeMaterial = backendAttempt.consumeInitializeMaterial()
+      if (initializeMaterial?.authentication) {
+        await connection.agent.request(
+          acp.methods.agent.authenticate,
+          initializeMaterial.authentication
+        )
         attempt.assertCurrent()
-        if (this.pendingAuthentication === authentication) {
-          this.pendingAuthentication = undefined
-        }
       }
-      if (this.pendingProviderConfiguration) {
-        const providerConfiguration = this.pendingProviderConfiguration
-        await connection.agent.request(acp.methods.agent.providers.set, providerConfiguration)
+      if (initializeMaterial?.providerConfiguration) {
+        await connection.agent.request(
+          acp.methods.agent.providers.set,
+          initializeMaterial.providerConfiguration
+        )
         attempt.assertCurrent()
-        if (this.pendingProviderConfiguration === providerConfiguration) {
-          this.pendingProviderConfiguration = undefined
-        }
       }
       const handle = attempt.publish({
         close: Boolean(initResult.agentCapabilities?.sessionCapabilities?.close),
@@ -1368,6 +1357,7 @@ class AcpRuntime {
       this.setStatus('connected')
       return handle
     } catch (thrown) {
+      backendAttempt?.fail()
       // A spawn failure arrives wrapped so it can name the framework it targeted without mutating the
       // original throwable; unwrap to the real cause (logged and re-thrown) and prefer its framework
       // (the process never returned to update spawnedFramework). `instanceof` is guarded because a
@@ -1400,18 +1390,6 @@ class AcpRuntime {
         unattachedConnection = undefined
         agentProcess = undefined
         unattachedBridgeLease = undefined
-      }
-
-      // This connect owns the one-shot credential/config intent only while its generation is current.
-      // Clear every unconsumed value on a same-generation failure (including initialize/auth failure),
-      // but leave a successor generation's possibly identity-equal configuration untouched.
-      if (generation === this.connectionGeneration) {
-        if (this.pendingAuthentication === connectionAuthentication) {
-          this.pendingAuthentication = undefined
-        }
-        if (this.pendingProviderConfiguration === connectionProviderConfiguration) {
-          this.pendingProviderConfiguration = undefined
-        }
       }
 
       // The entire failure-handling body is best-effort: logging, notification sinks (pushEvent/
@@ -1559,8 +1537,8 @@ class AcpRuntime {
       provisionalHttpMcpRoutes = !this.framework.acceptsStdioMcp
       const builtCapabilities = await this.sessionCapabilities.build({
         framework: this.framework,
-        nativeMcpEnabled: this.nativeMcpEnabled,
-        bridgeMcpAliasesEnabled: this.bridgeMcpAliasesEnabled,
+        nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
+        bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
         policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
         routingIds,
         sessionCwd,
@@ -2286,8 +2264,8 @@ class AcpRuntime {
       provisionalHttpMcpRoutes = !this.framework.acceptsStdioMcp
       const builtCapabilities = await this.sessionCapabilities.build({
         framework: this.framework,
-        nativeMcpEnabled: this.nativeMcpEnabled,
-        bridgeMcpAliasesEnabled: this.bridgeMcpAliasesEnabled,
+        nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
+        bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
         policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
         routingIds,
         sessionCwd,
@@ -2525,8 +2503,8 @@ class AcpRuntime {
       provisionalHttpMcpRoutes = !this.framework.acceptsStdioMcp
       const builtCapabilities = await this.sessionCapabilities.build({
         framework: this.framework,
-        nativeMcpEnabled: this.nativeMcpEnabled,
-        bridgeMcpAliasesEnabled: this.bridgeMcpAliasesEnabled,
+        nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
+        bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
         policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
         routingIds,
         sessionCwd,
@@ -2732,7 +2710,10 @@ class AcpRuntime {
   // the app is gone would be an orphaned process still holding its network connection open. The OS
   // reclaims the remaining connection/session state as the process exits.
   shutdown(): void {
-    this.connectionResources.shutdownSynchronously(() => this.invalidatePendingSessionStartups())
+    this.connectionResources.shutdownSynchronously(() => {
+      this.invalidatePendingSessionStartups()
+      this.backendGeneration.supersede(this.connectionGeneration - 1)
+    })
     this.connectionTransitions.resetReconnect()
     this.contextUsageTracker.clear()
     this.contextUsageUpdatedPromptTurnsBySession.clear()
@@ -2802,6 +2783,7 @@ class AcpRuntime {
     // A failed Runtime teardown may still expose the stale connection. Supersede it before releasing
     // the transition barrier so the next startup must resolve and connect a fresh backend.
     const teardownGeneration = this.connectionResources.supersede()
+    this.backendGeneration.supersede(teardownGeneration - 1)
     void this.connectionResources.teardown(teardownGeneration, (stage, cleanupError) => {
       safeLogError(`${stage} cleanup after failed deferred disconnect failed`, {
         ...diagnosticErrorFields(cleanupError)
@@ -2911,6 +2893,7 @@ class AcpRuntime {
       runCleanup('closed-status', () => this.setStatus('closed'))
     }
 
+    this.backendGeneration.supersede(teardownGeneration - 1)
     if (teardownFailed) throw teardownFailure
     return this.getSnapshot()
   }
@@ -2918,21 +2901,32 @@ class AcpRuntime {
   // Creates the agent process, preferring an injected spawner (tests) and otherwise resolving the
   // active agent backend so each reconnect uses the current framework + up-to-date credentials. Returns
   // the child paired with the framework it was spawned under so the caller labels lifecycle/failure logs
-  // atomically — never by re-reading the mutable this.framework, which an overlapping reconnect can move.
-  private async spawnAgentProcess(): Promise<{
+  // atomically — never by re-reading the current generation view after an overlapping reconnect.
+  private async spawnAgentProcess(identity: AcpConnectionResourceAttempt): Promise<{
     process: ChildProcessWithoutNullStreams
     framework: AgentFramework['id']
-    backend: ResolvedAgentBackend
+    bridgeLease: ResolvedAgentBackend['responsesBridgeLease']
+    backendAttempt: AcpBackendGenerationAttempt
   }> {
     if (this.spawnAgent) {
+      const backend: ResolvedAgentBackend = {
+        framework: this.framework,
+        executablePath: '',
+        env: {}
+      }
+      const backendAttempt = this.backendGeneration.prepare(identity, backend)
+      let process: ChildProcessWithoutNullStreams
+      try {
+        process = this.spawnAgent()
+      } catch (error) {
+        backendAttempt.fail()
+        throw error
+      }
       return {
-        process: this.spawnAgent(),
+        process,
         framework: this.framework.id,
-        backend: {
-          framework: this.framework,
-          executablePath: '',
-          env: {}
-        }
+        bridgeLease: undefined,
+        backendAttempt
       }
     }
 
@@ -2945,6 +2939,15 @@ class AcpRuntime {
 
     if (!backend) {
       throw new Error('ACP agent spawn configuration is not available.')
+    }
+    let backendAttempt: AcpBackendGenerationAttempt
+    try {
+      backendAttempt = this.backendGeneration.prepare(identity, backend)
+    } catch (error) {
+      await this.connectionResources.cleanupUnattached({
+        bridgeLease: backend.responsesBridgeLease
+      })
+      throw error
     }
 
     // Record the resolved framework without retaining executable paths, arguments, environment names,
@@ -2966,39 +2969,18 @@ class AcpRuntime {
       await this.connectionResources.cleanupUnattached({
         bridgeLease: backend.responsesBridgeLease
       })
+      backendAttempt.fail()
       throw new SpawnFailure(backend.framework.id, error)
     }
 
     log.info('agent process spawned', this.diagnosticContext(backend.framework.id))
 
-    return { process, framework: backend.framework.id, backend }
-  }
-
-  private applyResolvedBackend(backend: ResolvedAgentBackend): void {
-    this.framework = backend.framework
-    this.backendId = backend.backendId
-    this.codexHome =
-      backend.framework.id === 'codex' && typeof backend.env.CODEX_HOME === 'string'
-        ? backend.env.CODEX_HOME
-        : undefined
-    this.codexSkillActivity.setSkillsRoot(
-      this.codexHome ? join(this.codexHome, 'skills') : undefined
-    )
-    this.nativeMcpEnabled =
-      backend.framework.id !== 'codex' || backend.providerConfiguration === undefined
-    this.bridgeMcpAliasesEnabled =
-      backend.framework.id === 'codex' && backend.providerConfiguration !== undefined
-    this.pendingSessionModel = backend.sessionModel
-    this.pendingSessionModelRequired = backend.sessionModelRequired ?? false
-    this.pendingSessionEffort = backend.sessionEffort
-    this.selectedModelContextWindow = backend.contextWindow
-    this.selectedContextUsageModel = backend.contextUsageModel
-    this.pendingSessionOptions = backend.sessionOptions
-    this.pendingSystemPromptAppends = [...(backend.systemPromptAppends ?? [])]
-    this.pendingPersistentSystemPrompt = backend.persistentSystemPrompt
-    this.pendingAuthentication = backend.authentication
-    this.pendingProviderConfiguration = backend.providerConfiguration
-    this.opencodeUsageApi = backend.opencodeUsageApi
+    return {
+      process,
+      framework: backend.framework.id,
+      bridgeLease: backend.responsesBridgeLease,
+      backendAttempt
+    }
   }
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
@@ -3270,11 +3252,11 @@ class AcpRuntime {
       // frameworks without a session preset carry the guidance as a prompt prefix.
       const specialistSkillGuidance = this.specialistSkillGuidance(currentSpecialistSkills)
       const { promptPrefix: frameworkPromptPrefix } = this.framework.buildSessionSetup({
-        systemPromptAppends: this.pendingPersistentSystemPrompt
+        systemPromptAppends: this.backend.prompt.persistentSystemPrompt
           ? []
           : this.getSystemPromptAppends(),
         turnPromptReminders: specialistSkillGuidance ? [specialistSkillGuidance] : [],
-        sessionOptions: this.pendingSessionOptions
+        sessionOptions: this.backend.session.options
       })
       // For Codex/OpenCode, prepend the per-session specialist identity prefix (set at createSession).
       // Claude carries its identity in session-level _meta; no per-turn prefix needed there.
@@ -3379,10 +3361,11 @@ class AcpRuntime {
         .lookup(request.sessionId)
         ?.aggregate.snapshot()
       const promptFramework = promptSessionSnapshot?.frameworkId ?? this.framework.id
+      const openCodeUsageApi = this.backendGeneration.openCodeUsageApi()
       const opencodeUsageBefore =
-        promptFramework === 'opencode' && this.opencodeUsageApi
+        promptFramework === 'opencode' && openCodeUsageApi
           ? await fetchOpenCodeUsageSnapshot(
-              this.opencodeUsageApi,
+              openCodeUsageApi,
               activeSession.sessionId,
               promptSessionSnapshot?.cwd ?? this.snapshotOwner.cwd,
               this.options.opencodeUsageFetch
@@ -3475,11 +3458,11 @@ class AcpRuntime {
             stopReason: message.stopReason
           })
           const opencodeTurnUsage =
-            promptFramework === 'opencode' && this.opencodeUsageApi
+            promptFramework === 'opencode' && openCodeUsageApi
               ? sumOpenCodeTurnUsage(
                   opencodeUsageBefore,
                   await fetchOpenCodeUsageSnapshot(
-                    this.opencodeUsageApi,
+                    openCodeUsageApi,
                     activeSession.sessionId,
                     this.sessionRegistry.lookup(request.sessionId)?.aggregate.snapshot().cwd ??
                       this.snapshotOwner.cwd,
@@ -3565,7 +3548,7 @@ class AcpRuntime {
       // nested in the payload serializes without its (non-enumerable) message, which once hid the
       // provider's real rejection reason from the log.
       log.error('prompt failed', { sessionId: request.sessionId, ...errorLogFields(error) })
-      const text = describePromptError(error, { model: this.pendingSessionModel })
+      const text = describePromptError(error, { model: this.backend.session.model })
       // Tag a request-size overflow as recoverable so the renderer tries native compaction, falls back
       // to context replacement + text replay, and retries instead of dead-ending.
       // The structured errorKind slug is checked alongside the message text: providers relay the same
@@ -3832,7 +3815,7 @@ class AcpRuntime {
     // it with model-selected Skills, which would make the user's visible choice nondeterministic.
     if (forcedSkillIds.length > 0) {
       if (!this.skillsHooks?.descriptorsForIds) return []
-      return this.skillsHooks.descriptorsForIds(forcedSkillIds, this.codexHome)
+      return this.skillsHooks.descriptorsForIds(forcedSkillIds, this.backend.adapter.codexHome)
     }
 
     if (!this.connectionResources.bridgeSkillsAvailable || !this.skillsHooks?.catalogForCodexHome) {
@@ -3841,7 +3824,7 @@ class AcpRuntime {
 
     let catalog: ResponsesBridgeSkillCandidate[]
     try {
-      catalog = await this.skillsHooks.catalogForCodexHome(this.codexHome)
+      catalog = await this.skillsHooks.catalogForCodexHome(this.backend.adapter.codexHome)
     } catch {
       log.warn('Codex Skill selection failed', { reason: 'catalog-error' })
       return []
@@ -4046,8 +4029,8 @@ class AcpRuntime {
   > {
     return this.sessionCapabilities.toolingAvailability({
       framework: this.framework,
-      nativeMcpEnabled: this.nativeMcpEnabled,
-      bridgeMcpAliasesEnabled: this.bridgeMcpAliasesEnabled,
+      nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
+      bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
       policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY
     })
   }
@@ -4072,7 +4055,7 @@ class AcpRuntime {
     // omit it otherwise so the agent isn't told to use tools it wasn't given.
     return [
       ...this.getAppSystemPromptAppends(),
-      ...this.pendingSystemPromptAppends,
+      ...this.backend.prompt.systemPromptAppends,
       ...(skillGuidance ? [skillGuidance] : [])
     ]
   }
@@ -4143,7 +4126,7 @@ class AcpRuntime {
   // shape to the active framework. Claude applies its settingSources restriction, resolved backend
   // options, and system-prompt appends; opencode returns no meta and uses a prompt prefix instead.
   // `extraAppends` lets createSession inject a one-off specialist identity without touching the
-  // shared pendingSystemPromptAppends that apply to every session on this runtime generation.
+  // shared generation appends that apply to every session on this runtime generation.
   private buildSessionMetaArg(
     extraAppends: string[] = [],
     specialistSkills?: EffectiveSpecialistSkills
@@ -4156,7 +4139,7 @@ class AcpRuntime {
           : undefined
     const setup = this.framework.buildSessionSetup({
       systemPromptAppends: [...this.getSystemPromptAppends(), ...extraAppends],
-      sessionOptions: this.pendingSessionOptions,
+      sessionOptions: this.backend.session.options,
       ...(skillWhitelist !== undefined ? { skillWhitelist } : {})
     })
 
@@ -4326,8 +4309,8 @@ class AcpRuntime {
           : { ...normalizedParams, sessionId: appSessionId },
         {
           profile: profileState?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE,
-          // Source the framework from the per-session map, not mutable this.framework — an overlapping
-          // reconnect can move this.framework off codex mid-request and leak the amendment options.
+          // Source the framework from the per-session map, not the current generation view — an
+          // overlapping reconnect can move it off Codex mid-request and leak the amendment options.
           frameworkId: permissionFrameworkId,
           shellDialect: permissionFramework.commandShellDialect,
           autoReviewStrategy: profileState?.autoReviewStrategy,
@@ -4418,31 +4401,33 @@ class AcpRuntime {
     // through env or an app-owned bridge, independently of the ACP transport model.
     const selectedModelConfirmed = !(
       this.framework.id === 'opencode' &&
-      this.pendingSessionModel &&
+      this.backend.session.model &&
       !appliedModel
     )
     if (!selectedModelConfirmed) return {}
 
-    const model = this.selectedContextUsageModel ?? appliedModel
+    const model = this.backend.context.model ?? appliedModel
     return {
       ...(model ? { model } : {}),
-      ...(this.selectedModelContextWindow ? { contextWindow: this.selectedModelContextWindow } : {})
+      ...(this.backend.context.window ? { contextWindow: this.backend.context.window } : {})
     }
   }
 
   private contextUsageEstimateInput(sessionId?: string): SessionEstimateInput {
     const { model } = this.contextUsageSelectionFor(sessionId)
     const sessionSetup = this.framework.buildSessionSetup({
-      systemPromptAppends: this.pendingPersistentSystemPrompt ? [] : this.getSystemPromptAppends(),
-      sessionOptions: this.pendingSessionOptions
+      systemPromptAppends: this.backend.prompt.persistentSystemPrompt
+        ? []
+        : this.getSystemPromptAppends(),
+      sessionOptions: this.backend.session.options
     })
     const persistentSystemPrompt =
-      this.pendingPersistentSystemPrompt ?? sessionSetup.persistentSystemPrompt
+      this.backend.prompt.persistentSystemPrompt ?? sessionSetup.persistentSystemPrompt
     const persistentSections = contextUsageMcpSections(this.framework.id, {
       artifacts: this.artifactToolingAvailable(),
       notebook: this.notebookToolingAvailable(),
       skillImport: this.skillImportToolingAvailable(),
-      codexBridgeAliases: this.bridgeMcpAliasesEnabled
+      codexBridgeAliases: this.backend.adapter.bridgeMcpAliasesEnabled
     }).map(({ sectionId, text }) => ({ sectionId, category: 'mcp' as const, text }))
 
     return {
@@ -4646,7 +4631,7 @@ class AcpRuntime {
     generation: number
   ): void {
     // Bind the framework this process was spawned under now. During a reconnect the runtime's
-    // this.framework may already point at a new backend, so reading it inside the async handlers would
+    // The current generation view may already name a new backend, so reading it in async handlers would
     // mislabel a late stderr/exit from the old process.
     const framework = this.framework.id
 
@@ -4734,6 +4719,7 @@ class AcpRuntime {
     this.permissionContext.dispose()
     this.reviewerSessions.clear()
     this.connectionResources.cleanupUnexpectedClose(teardownGeneration)
+    this.backendGeneration.supersede(teardownGeneration)
     this.sessionCapabilities.dispose(this.activeSessionIds())
     for (const entry of this.sessionRegistry.entries()) {
       if (entry.attachment) this.sessionRegistry.detach(entry.attachment, 'connection')
@@ -4824,7 +4810,7 @@ class AcpRuntime {
         return {
           connection,
           framework: this.framework,
-          sessionOptions: this.pendingSessionOptions,
+          sessionOptions: this.backend.session.options,
           startupGeneration: this.sessionRegistry.startupGeneration
         }
       })


### PR DESCRIPTION
## Problem

`AcpRuntime` directly owned a wide set of mutable, backend-derived generation fields. That made reconnect publication non-atomic, left stale attempts able to influence generation behavior, and spread sensitive initialization and usage material across the runtime coordinator.

Related: #458. This PR only establishes a forward ownership constraint for future orchestration work; it does not add Issue #458 orchestration data, public interfaces, wire contracts, or user-visible behavior.

## Proposed change

- Add `AcpBackendGenerationOwner` as the sole writer for one immutable, secret-free backend generation view.
- Prepare backend attempts provisionally, publish only after the connection attempt proves current, and reject stale publication.
- Release a resolved bridge lease if async backend resolution returns after its connection identity has gone stale, before any child is spawned.
- Consume authentication/provider initialization material once and clear it on consume, failure, or supersession.
- Keep the OpenCode usage API behind a narrow owner accessor and clear it whenever a generation genuinely ends, including post-detach teardown failure, synchronous shutdown, unexpected close, and failed deferred-disconnect recovery. Supersession is epoch-scoped so an older teardown cannot clear a concurrently published successor.
- Preserve a live generation's material when disconnect fails before detach and the published connection is restored.
- Replace Runtime's writable generation fields with read-only owner-backed access and use the published view for session model/options/effort, prompt inputs, context selection, MCP behavior, framework/backend identity, and OpenCode usage.

## Scope and non-goals

The diff is confined to the four ARD-01-owned files:

- `src/main/acp/backend-generation-owner.ts`
- `src/main/acp/backend-generation-owner.test.ts`
- `src/main/acp/runtime.ts`
- `src/main/acp/runtime.test.ts`

No ARD-02 work, schema/data relationship, IPC/preload/Web RPC/Task transport/CLI SDK, UI, Specialist, Permission, Compute, Session identity/adoption/contextReset/replay, Reviewer, or Artifact contract changes are included.

Exact production raw: **487** lines (`backend-generation-owner.ts`: 207 additions; `runtime.ts`: 133 additions + 147 deletions), below the 500-line hard stop.

## Ownership and sequence

Before this change, `AcpRuntime` wrote framework/backend identity, model/effort/options, prompt/context/MCP adapter inputs, initialize material, and OpenCode usage configuration. After this change, `AcpBackendGenerationOwner` is the only writer; Runtime retains process/client/bridge and orchestration ownership and reads the current view.

```mermaid
flowchart LR
  R["AcpRuntime orchestration"] -->|"prepare provisional generation"| O["AcpBackendGenerationOwner"]
  R -->|"publish only if attempt is current"| O
  O -->|"immutable secret-free view"| R
  T["disconnect / failure / supersession"] -->|"retire matching epoch"| O
  O -. "older teardown cannot clear successor" .-> N["newer published generation"]
```

Successful disconnect/pre-connect teardown, post-detach failed teardown, synchronous shutdown, unexpected close, and failed deferred recovery supersede only the retired backend generation. Pre-detach rollback retains the view for the still-live restored connection, and delayed older teardown leaves a newer generation intact.

## Acceptance criteria and validation

The recorded final Test Impact Set was:

- Backend generation publication, immutability, secret exclusion, consume-once material, stale reconnects, epoch-scoped supersession, failure cleanup, and live effort replacement → `backend-generation-owner.test.ts` → **7 passed**.
- Runtime generation cutover, reconnect/model/context/prompt/MCP/auth-provider ordering, framework-sensitive behavior, and every terminal credential cleanup/rollback path → `runtime.test.ts` → **389 passed**.
- Runtime coordinator, provider-turn adapter, backend resolver, and Specialist identity contracts → five files / **102 tests passed** (including the owner tests above).
- Completion-gate loopback integration → **22 passed**.
- `npm run typecheck:node` → passed.
- `npm run lint` → 0 errors; 17 pre-existing warnings outside this cut.
- Prettier check and `git diff --check` → passed.
- Independent Spec and Standards reviews → no findings on the final diff; both confirmed the scope/invariants and 487 production raw.
- Final-head online gates → PR Gate, AI review, CodeQL, Static checks, Unit tests, Coverage macOS, macOS build/E2E, and Windows E2E all passed. `Windows core` was skipped by classification.

Historical evidence limitation: the portable suite ran before the final cleanup refinement and reported 10,824 passed, 184 skipped, and 12 failures under concurrent resource pressure. The one changed-file failure was corrected and the complete Runtime file passed; all 11 unrelated failures cleared in isolated/serial reruns, with loopback permission required for the completion gate. After the final cleanup refinement, the focused lifecycle cases, complete Runtime file, affected contracts, typecheck, lint, and formatting passed. Therefore the focused results above are the after-last-material-edit local evidence; the final-head online gates are the authoritative cross-platform evidence.

Consumer/platform rationale: the impact set covers Runtime, its owner and adjacent ACP/Specialist contracts. Renderer, wire, schema, persistence, and public transport lanes were not locally selected because those surfaces did not change.

## Review focus

- Atomic publication and stale-attempt rejection.
- Sensitive material lifetime on successful, failed, rolled-back, and unexpected teardown paths.
- Preservation of reconnect-sensitive session, prompt, context, MCP, framework, and OpenCode behavior without a second writer or compatibility store.

## Uncovered risks

Real external ACP provider behavior beyond the project-owned protocol fakes was not reproduced locally. Cross-platform and integration confidence comes from the final-head online gates. Issue #458 integration remains deliberately deferred.
