### PR TITLE
refactor(acp): add Claude turn adapter

### DIFF
--- a/src/main/acp/claude-turn-adapter.test.ts
+++ b/src/main/acp/claude-turn-adapter.test.ts
@@ -1,0 +1,140 @@
+import type { PromptResponse } from '@agentclientprotocol/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { claudeCodeTurnAdapter } from './claude-turn-adapter'
+
+describe('Claude Code turn adapter', () => {
+  it('returns generic ACP usage and the matching terminal SDK model-turn count', async () => {
+    const probe = await claudeCodeTurnAdapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+
+    probe.observe?.({
+      sessionId: 'provider-session-1',
+      message: {
+        type: 'result',
+        num_turns: 3,
+        origin: { kind: 'human' }
+      }
+    })
+
+    const result = await probe.finalize({
+      response: {
+        stopReason: 'end_turn',
+        usage: {
+          totalTokens: 60,
+          inputTokens: 31,
+          cachedReadTokens: 8,
+          cachedWriteTokens: 7,
+          outputTokens: 14
+        }
+      } as PromptResponse
+    })
+
+    expect(result).toEqual({
+      turnUsage: {
+        inputTokens: 31,
+        cacheTokens: 15,
+        cachedReadTokens: 8,
+        cachedWriteTokens: 7,
+        outputTokens: 14
+      },
+      modelTurnCount: 3
+    })
+  })
+
+  it('sums user-driven results while excluding every autonomous Claude origin', async () => {
+    const probe = await claudeCodeTurnAdapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const observeResult = (numTurns: number, origin?: string): void =>
+      probe.observe?.({
+        sessionId: 'provider-session-1',
+        message: {
+          type: 'result',
+          num_turns: numTurns,
+          ...(origin === undefined ? {} : { origin: { kind: origin } })
+        }
+      })
+
+    for (const origin of [
+      'task-notification',
+      'peer',
+      'coordinator',
+      'observer',
+      'observer-activity'
+    ]) {
+      observeResult(100, origin)
+    }
+    observeResult(2, 'human')
+    observeResult(3, 'future-user-lane')
+
+    await expect(
+      Promise.resolve(probe.finalize({ response: { stopReason: 'end_turn' } as PromptResponse }))
+    ).resolves.toEqual({ modelTurnCount: 5 })
+  })
+
+  it('ignores stale Sessions and missing or malformed SDK result facts', async () => {
+    const probe = await claudeCodeTurnAdapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const observations: unknown[] = [
+      undefined,
+      null,
+      [],
+      {},
+      { sessionId: 'provider-session-1' },
+      { sessionId: 'provider-session-1', message: null },
+      { sessionId: 'provider-session-1', message: [] },
+      { sessionId: 'provider-session-1', message: { type: 'assistant', num_turns: 100 } },
+      { sessionId: 'provider-session-1', message: { type: 'result' } },
+      { sessionId: 'provider-session-1', message: { type: 'result', num_turns: 0 } },
+      { sessionId: 'provider-session-1', message: { type: 'result', num_turns: -1 } },
+      { sessionId: 'provider-session-1', message: { type: 'result', num_turns: 1.5 } },
+      { sessionId: 'provider-session-1', message: { type: 'result', num_turns: '2' } },
+      {
+        sessionId: 'stale-provider-session',
+        message: { type: 'result', num_turns: 100, origin: { kind: 'human' } }
+      }
+    ]
+
+    for (const observation of observations) probe.observe?.(observation)
+    probe.observe?.({
+      sessionId: 'provider-session-1',
+      message: { type: 'result', num_turns: 2 }
+    })
+
+    expect(
+      await probe.finalize({ response: { stopReason: 'end_turn' } as PromptResponse })
+    ).toEqual({ modelTurnCount: 2 })
+  })
+
+  it('drops turn-scoped observation when the probe is cancelled', async () => {
+    const probe = await claudeCodeTurnAdapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    probe.observe?.({
+      sessionId: 'provider-session-1',
+      message: { type: 'result', num_turns: 2 }
+    })
+
+    await probe.cancel()
+    probe.observe?.({
+      sessionId: 'provider-session-1',
+      message: { type: 'result', num_turns: 100 }
+    })
+
+    expect(
+      await probe.finalize({
+        response: {
+          stopReason: 'end_turn',
+          usage: { inputTokens: 3, outputTokens: 1 }
+        } as PromptResponse
+      })
+    ).toEqual({})
+  })
+})

--- a/src/main/acp/claude-turn-adapter.ts
+++ b/src/main/acp/claude-turn-adapter.ts
@@ -1,0 +1,65 @@
+import { toAcpTurnTokenUsage } from '../../shared/acp'
+import type { AcpProviderTurnAdapter, AcpProviderTurnResult } from './provider-turn-adapter'
+
+// Unknown future origins stay eligible so a new user-driven lane does not silently under-report
+// model turns before Open Science knows its name.
+const CLAUDE_AUTONOMOUS_RESULT_ORIGINS = new Set([
+  'task-notification',
+  'peer',
+  'coordinator',
+  'observer',
+  'observer-activity'
+])
+
+// ARD-24 owns Runtime probe selection and lifecycle wiring; this leaf only provides the
+// side-effect-free Claude interpretation module for that serialized executor cutover.
+export const claudeCodeTurnAdapter: AcpProviderTurnAdapter = {
+  begin: ({ providerSessionId }) => {
+    let modelTurnCount = 0
+    let closed = false
+    const close = (): void => {
+      closed = true
+      modelTurnCount = 0
+    }
+
+    return {
+      observe: (value) => {
+        if (closed) return
+        if (typeof value !== 'object' || value === null || Array.isArray(value)) return
+        const params = value as Record<string, unknown>
+        if (params.sessionId !== providerSessionId) return
+        if (
+          typeof params.message !== 'object' ||
+          params.message === null ||
+          Array.isArray(params.message)
+        ) {
+          return
+        }
+
+        const message = params.message as Record<string, unknown>
+        if (message.type !== 'result') return
+        const origin =
+          typeof message.origin === 'object' && message.origin !== null
+            ? (message.origin as Record<string, unknown>).kind
+            : undefined
+        if (typeof origin === 'string' && CLAUDE_AUTONOMOUS_RESULT_ORIGINS.has(origin)) return
+        if (!Number.isSafeInteger(message.num_turns) || (message.num_turns as number) <= 0) return
+
+        const nextCount = modelTurnCount + (message.num_turns as number)
+        if (Number.isSafeInteger(nextCount)) modelTurnCount = nextCount
+      },
+      finalize: ({ response }) => {
+        if (closed) return {}
+        const finalModelTurnCount = modelTurnCount
+        close()
+        const turnUsage = toAcpTurnTokenUsage(response.usage)
+        const result: AcpProviderTurnResult = {
+          ...(turnUsage ? { turnUsage } : {}),
+          ...(finalModelTurnCount > 0 ? { modelTurnCount: finalModelTurnCount } : {})
+        }
+        return result
+      },
+      cancel: close
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Claude Code turn facts were interpreted inline by `AcpRuntime`, so the later prompt-executor cutover needed a narrow provider-specific implementation of the `AcpProviderTurnAdapter` seam introduced by ARD-09.

Related: #458 (forward-compatibility constraint only; this PR added no orchestration data, public API, or user interaction).

## Proposed change

- Add a Claude Code provider-turn adapter that observes matching `_claude/sdkMessage` result frames.
- Preserve generic ACP token-usage normalization and accumulate positive, safe `num_turns` deltas.
- Exclude known autonomous result origins while leaving unknown future user-driven origins eligible.
- Suppress stale provider Sessions and malformed observations.
- Clear all turn-scoped observation on finalization or cancellation.

## Scope and non-goals

- Pure-addition ARD-10 leaf; no Runtime cutover or production caller was added here.
- No changes to composition, coordinator, ACP client, wire/IPC, transport, schema, persistence, UI, other providers, Specialist, Permission, Compute, Session, context, Reviewer, Artifact, or usage contracts.
- No Session settlement, event publication, resume-ID parsing, or provider credential ownership.
- ARD-24 retained responsibility for adapter selection, probe lifecycle wiring, and removal of the inline collector.

Exact production raw: **65 additions, 0 deletions**.

## Ownership and sequence

No Mermaid diagram is needed for this pure adapter leaf: it introduced no shared state owner, resource transfer, transaction, or production call sequence. The caller remained responsible for probe lifetime; `finalize`/`cancel` only discarded adapter-local observation.

## Acceptance criteria and validation

The historical PR record states that the following local checks ran after the last material edit and final rebase:

- Claude observation, normalization, and cleanup -> `npm test -- --run src/main/acp/claude-turn-adapter.test.ts src/main/acp/provider-turn-adapter.test.ts src/shared/acp.test.ts src/main/agent-framework/claude-code.test.ts` -> **4 files, 17 tests passed**.
- Existing Claude model-turn compatibility -> `npm test -- --run src/main/acp/runtime.test.ts -t 'attaches Claude SDK model-turn counts|excludes autonomous Claude result lanes'` -> **2 tests passed**.
- Node contracts -> `npm run typecheck:node` -> **passed**.
- Source lint -> `npm run lint` -> **passed with 0 errors; 17 pre-existing warnings outside the diff**.
- Changed-file formatting -> `npx prettier --check src/main/acp/claude-turn-adapter.ts src/main/acp/claude-turn-adapter.test.ts` -> **passed**.
- Diff integrity -> `git diff --check origin/main...HEAD` -> **passed**.
- Portable suite -> `npm test` -> **744 files and 11,034 tests passed**; the recorded unrelated notebook timeout passed on an exact isolated rerun.
- Final online gates -> GitHub check history records **PR Gate, Unit tests, Static checks, Coverage macOS, macOS build and E2E, Windows E2E, CodeQL, and AI review workflow success**.

Independent Standards and Spec reviews recorded no findings. Consumer/platform lanes were excluded locally because this adapter had no production caller and changed no shared interface or platform resource.

## Review focus

- Parity with Claude autonomous-origin and safe-positive-turn rules.
- Provider Session matching and exact probe cleanup.
- Absence of Runtime integration or compatibility-surface changes.

## Uncovered risks

- Real production integration was intentionally deferred to ARD-24.
- Future Claude result-origin or metadata drift remained outside this leaf; malformed observations fail closed.

