### PR TITLE
refactor(acp): add Codex turn adapter

### DIFF
--- a/src/main/acp/codex-turn-adapter.test.ts
+++ b/src/main/acp/codex-turn-adapter.test.ts
@@ -1,0 +1,187 @@
+import type { PromptResponse } from '@agentclientprotocol/sdk'
+import { describe, expect, it } from 'vitest'
+
+import { ACP_MODEL_TURN_COUNT_META_KEY, ACP_TURN_TOKEN_USAGE_META_KEY } from '../../shared/acp'
+import { createCodexTurnAdapter } from './codex-turn-adapter'
+
+describe('Codex turn adapter', () => {
+  it('normalizes the whole-turn usage metadata through the provider turn interface', async () => {
+    const probe = await createCodexTurnAdapter().begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const response = {
+      stopReason: 'end_turn',
+      _meta: {
+        [ACP_TURN_TOKEN_USAGE_META_KEY]: {
+          totalTokens: 110,
+          inputTokens: 40,
+          cachedReadTokens: 40,
+          cachedWriteTokens: 20,
+          outputTokens: 10
+        }
+      }
+    } satisfies PromptResponse
+
+    expect(await probe.finalize({ response })).toEqual({
+      turnUsage: {
+        inputTokens: 40,
+        cacheTokens: 60,
+        cachedReadTokens: 40,
+        cachedWriteTokens: 20,
+        outputTokens: 10
+      }
+    })
+  })
+
+  it('falls back to terminal response usage when whole-turn metadata is missing', async () => {
+    const probe = await createCodexTurnAdapter().begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const response = {
+      stopReason: 'max_tokens',
+      usage: {
+        totalTokens: 32_212,
+        inputTokens: 174,
+        cachedReadTokens: 32_000,
+        outputTokens: 38
+      }
+    } satisfies PromptResponse
+
+    expect(await probe.finalize({ response })).toMatchObject({
+      turnUsage: {
+        inputTokens: 174,
+        cacheTokens: 32_000,
+        outputTokens: 38
+      }
+    })
+  })
+
+  it('reports the managed adapter model-turn count separately from token usage', async () => {
+    const probe = await createCodexTurnAdapter().begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const response = {
+      stopReason: 'end_turn',
+      _meta: { [ACP_MODEL_TURN_COUNT_META_KEY]: 3 }
+    } satisfies PromptResponse
+
+    expect(await probe.finalize({ response })).toEqual({ modelTurnCount: 3 })
+  })
+
+  it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '3'])(
+    'omits the invalid model-turn count %s',
+    async (modelTurnCount) => {
+      const probe = await createCodexTurnAdapter().begin({
+        providerSessionId: 'provider-session-1',
+        cwd: '/workspace'
+      })
+      const response = {
+        stopReason: 'end_turn',
+        _meta: { [ACP_MODEL_TURN_COUNT_META_KEY]: modelTurnCount }
+      } satisfies PromptResponse
+
+      expect(await probe.finalize({ response })).toEqual({})
+    }
+  )
+
+  it('recombines uncached and cached-read input for the exact context numerator', async () => {
+    const probe = await createCodexTurnAdapter().begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const response = {
+      stopReason: 'end_turn',
+      usage: {
+        totalTokens: 32_712,
+        inputTokens: 174,
+        cachedReadTokens: 32_000,
+        cachedWriteTokens: 500,
+        outputTokens: 38
+      },
+      _meta: {
+        [ACP_TURN_TOKEN_USAGE_META_KEY]: {
+          totalTokens: 110,
+          inputTokens: 60,
+          cachedReadTokens: 40,
+          outputTokens: 10
+        }
+      }
+    } satisfies PromptResponse
+
+    expect(await probe.finalize({ response })).toEqual({
+      turnUsage: {
+        inputTokens: 60,
+        cacheTokens: 40,
+        outputTokens: 10
+      },
+      contextUsedTokens: 32_174
+    })
+  })
+
+  it('omits an unsafe context numerator without discarding otherwise valid usage', async () => {
+    const probe = await createCodexTurnAdapter().begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const response = {
+      stopReason: 'end_turn',
+      usage: {
+        totalTokens: Number.MAX_SAFE_INTEGER,
+        inputTokens: Number.MAX_SAFE_INTEGER,
+        cachedReadTokens: 1,
+        outputTokens: 0
+      }
+    } satisfies PromptResponse
+
+    expect(await probe.finalize({ response })).toEqual({
+      turnUsage: {
+        inputTokens: Number.MAX_SAFE_INTEGER,
+        cacheTokens: 1,
+        outputTokens: 0
+      }
+    })
+  })
+
+  it('publishes terminal facts at most once and closes cancelled probes', async () => {
+    const input = { providerSessionId: 'provider-session-1', cwd: '/workspace' }
+    const response = {
+      stopReason: 'end_turn',
+      _meta: { [ACP_MODEL_TURN_COUNT_META_KEY]: 2 }
+    } satisfies PromptResponse
+    const cancelledProbe = await createCodexTurnAdapter().begin(input)
+    const finalizedProbe = await createCodexTurnAdapter().begin(input)
+
+    await cancelledProbe.cancel()
+    expect(await cancelledProbe.finalize({ response })).toEqual({})
+    expect(await finalizedProbe.finalize({ response })).toEqual({ modelTurnCount: 2 })
+    expect(await finalizedProbe.finalize({ response })).toEqual({})
+  })
+
+  it('keeps the raw terminal response caller-owned and returns no provider payload', async () => {
+    const probe = await createCodexTurnAdapter().begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const response = {
+      stopReason: 'refusal',
+      usage: {
+        totalTokens: 12,
+        inputTokens: 7,
+        cachedReadTokens: 2,
+        outputTokens: 3
+      },
+      _meta: { quota: { remaining: 42 } }
+    } satisfies PromptResponse
+    const originalResponse = structuredClone(response)
+
+    const result = await probe.finalize({ response })
+
+    expect(response).toEqual(originalResponse)
+    expect(result).not.toHaveProperty('response')
+    expect(probe.observe).toBeUndefined()
+    expect(await probe.cancel()).toBeUndefined()
+  })
+})

--- a/src/main/acp/codex-turn-adapter.ts
+++ b/src/main/acp/codex-turn-adapter.ts
@@ -1,0 +1,53 @@
+import { ACP_MODEL_TURN_COUNT_META_KEY, ACP_TURN_TOKEN_USAGE_META_KEY } from '../../shared/acp'
+import { toCodexTurnTokenUsage } from './codex-turn-usage'
+import type { AcpProviderTurnAdapter } from './provider-turn-adapter'
+
+const nonNegativeSafeInteger = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined
+
+const positiveSafeInteger = (value: unknown): number | undefined => {
+  const count = nonNegativeSafeInteger(value)
+  return count !== undefined && count > 0 ? count : undefined
+}
+
+// Runtime selection is intentionally deferred to the ARD-24 serialized executor cutover.
+const createCodexTurnAdapter = (): AcpProviderTurnAdapter => ({
+  begin: () => {
+    let closed = false
+    return {
+      finalize: ({ response }) => {
+        if (closed) return {}
+        closed = true
+        const terminalUsage = toCodexTurnTokenUsage(response.usage)
+        // Managed Codex metadata carries whole-turn footer usage, while PromptResponse.usage remains
+        // the latest request snapshot and therefore the exact context numerator. The pinned adapter
+        // publishes uncached and cached-read input as exclusive categories, so recombine them here;
+        // cache writes populate future requests and are not part of the current model input.
+        const turnUsage =
+          toCodexTurnTokenUsage(response._meta?.[ACP_TURN_TOKEN_USAGE_META_KEY]) ?? terminalUsage
+        const contextInputTokens = nonNegativeSafeInteger(response.usage?.inputTokens)
+        const contextCachedReadTokens = nonNegativeSafeInteger(
+          response.usage?.cachedReadTokens ?? 0
+        )
+        const reportedContextUsedTokens =
+          contextInputTokens !== undefined && contextCachedReadTokens !== undefined
+            ? contextInputTokens + contextCachedReadTokens
+            : undefined
+        const contextUsedTokens = Number.isSafeInteger(reportedContextUsedTokens)
+          ? reportedContextUsedTokens
+          : undefined
+        const modelTurnCount = positiveSafeInteger(response._meta?.[ACP_MODEL_TURN_COUNT_META_KEY])
+        return {
+          ...(turnUsage ? { turnUsage } : {}),
+          ...(modelTurnCount === undefined ? {} : { modelTurnCount }),
+          ...(contextUsedTokens === undefined ? {} : { contextUsedTokens })
+        }
+      },
+      cancel: () => {
+        closed = true
+      }
+    }
+  }
+})
+
+export { createCodexTurnAdapter }


### PR DESCRIPTION
## Problem

Codex terminal turn facts needed a provider-specific implementation of the shared `AcpProviderTurnAdapter` seam before the serialized prompt-executor cutover.

Related: #458 (forward-compatibility constraint only; this PR added no orchestration data, public API, or user interaction).

## Proposed change

- Add a stateless Codex turn adapter over the existing Codex usage normalizer.
- Prefer managed whole-turn usage metadata, with terminal response usage as fallback.
- Keep model-turn count separate and validated.
- Recombine uncached and cached terminal input for the exact context numerator.
- Close each turn probe on cancellation or first finalization so terminal facts publish at most once.
- Keep the raw provider response caller-owned and return no Codex payload.

## Scope and non-goals

- Pure-addition ARD-11 provider adapter only; no Runtime or executor integration.
- No composition, coordinator, AgentFramework, transport, schema, wire/IPC, UI, authority, or cross-surface changes.
- No Session resume/adoption behavior; ARD-04 retained that policy.
- ARD-24 retained responsibility for construction, selection, and Runtime cutover.

Exact production raw: **53 additions, 0 deletions**.

## Ownership and sequence

No Mermaid diagram is needed for this pure adapter leaf: it introduced no shared state owner, resource transfer, transaction, or production call sequence. Probe closure owned only adapter-local attempt state; the caller retained the raw response and integration lifecycle.

## Acceptance criteria and validation

The historical PR record states that the following local checks ran after the last material edit and final rebase:

- Codex metadata, fallback, cache, model-turn, context, and lifecycle facts -> `npm test -- src/main/acp/codex-turn-adapter.test.ts src/main/acp/codex-turn-usage.test.ts src/main/acp/provider-turn-adapter.test.ts` -> **18 tests passed**.
- Node contracts -> `npm run typecheck:node` -> **passed**.
- Source lint -> `npm run lint` -> **passed with 0 errors; 17 pre-existing warnings outside the diff**.
- Formatting -> targeted Prettier check -> **passed**. The historical record did not preserve the exact Prettier argv.
- Diff integrity -> `git diff --check origin/main...HEAD` -> **passed**.
- Final online gates -> GitHub check history records **PR Gate, Unit tests, Static checks, Coverage macOS, macOS build and E2E, Windows E2E, CodeQL, and AI review workflow success**.

Independent Standards and Spec reviews recorded no findings. No local consumer or platform lane was selected because this adapter had no production caller and did not change the shared interface.

## Review focus

- Whole-turn footer usage versus latest-request context numerator.
- Exact-once probe finalization/cancellation.
- Absence of Runtime integration and compatibility-surface changes.

## Uncovered risks

- Real Runtime integration was intentionally deferred to ARD-24.
- Future managed Codex response-metadata drift remained outside this leaf; malformed or absent metadata falls back to terminal response usage.

