### PR TITLE
refactor(acp): add OpenCode turn adapter

### DIFF
--- a/src/main/acp/opencode-turn-adapter.test.ts
+++ b/src/main/acp/opencode-turn-adapter.test.ts
@@ -1,0 +1,147 @@
+import type { PromptResponse } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AcpOpenCodeTurnAdapter } from './opencode-turn-adapter'
+import type { OpenCodeUsageSnapshot } from './opencode-turn-usage'
+
+describe('ACP OpenCode turn adapter', () => {
+  it('captures one provider Session and cwd before and after the turn', async () => {
+    const snapshots: OpenCodeUsageSnapshot[] = [
+      {
+        assistantMessageIds: new Set(['old']),
+        usageByMessageId: new Map()
+      },
+      {
+        assistantMessageIds: new Set(['old', 'step-1', 'step-2']),
+        usageByMessageId: new Map([
+          [
+            'step-1',
+            {
+              inputTokens: 12,
+              cacheTokens: 3,
+              cachedReadTokens: 2,
+              cachedWriteTokens: 1,
+              outputTokens: 2
+            }
+          ],
+          [
+            'step-2',
+            {
+              inputTokens: 19,
+              cacheTokens: 5,
+              cachedReadTokens: 4,
+              cachedWriteTokens: 1,
+              outputTokens: 3
+            }
+          ]
+        ])
+      }
+    ]
+    const readUsageSnapshot = vi.fn(async () => snapshots.shift())
+    const adapter = new AcpOpenCodeTurnAdapter(readUsageSnapshot)
+
+    const probe = await adapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+    const result = await probe.finalize({
+      response: { stopReason: 'end_turn' } as PromptResponse
+    })
+
+    expect(readUsageSnapshot).toHaveBeenNthCalledWith(1, 'provider-session-1', '/workspace')
+    expect(readUsageSnapshot).toHaveBeenNthCalledWith(2, 'provider-session-1', '/workspace')
+    expect(result).toEqual({
+      turnUsage: {
+        inputTokens: 31,
+        cacheTokens: 8,
+        cachedReadTokens: 6,
+        cachedWriteTokens: 2,
+        outputTokens: 5
+      },
+      modelTurnCount: 2
+    })
+  })
+
+  it('returns empty facts when the final usage snapshot fails', async () => {
+    const readUsageSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce({
+        assistantMessageIds: new Set<string>(),
+        usageByMessageId: new Map()
+      })
+      .mockRejectedValueOnce(new Error('loopback connection closed'))
+    const adapter = new AcpOpenCodeTurnAdapter(readUsageSnapshot)
+
+    const probe = await adapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+
+    await expect(
+      probe.finalize({ response: { stopReason: 'end_turn' } as PromptResponse })
+    ).resolves.toEqual({})
+  })
+
+  it('returns empty facts when the baseline usage snapshot fails', async () => {
+    const readUsageSnapshot = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('loopback connection closed'))
+      .mockResolvedValueOnce({
+        assistantMessageIds: new Set(['step-1']),
+        usageByMessageId: new Map([
+          ['step-1', { inputTokens: 12, cacheTokens: 3, outputTokens: 2 }]
+        ])
+      })
+    const adapter = new AcpOpenCodeTurnAdapter(readUsageSnapshot)
+
+    const probe = await adapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+
+    await expect(
+      probe.finalize({ response: { stopReason: 'end_turn' } as PromptResponse })
+    ).resolves.toEqual({})
+  })
+
+  it('does not publish a partial delta when the baseline snapshot is missing', async () => {
+    const readUsageSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        assistantMessageIds: new Set(['step-1']),
+        usageByMessageId: new Map([
+          ['step-1', { inputTokens: 12, cacheTokens: 3, outputTokens: 2 }]
+        ])
+      })
+    const adapter = new AcpOpenCodeTurnAdapter(readUsageSnapshot)
+
+    const probe = await adapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+
+    await expect(
+      probe.finalize({ response: { stopReason: 'end_turn' } as PromptResponse })
+    ).resolves.toEqual({})
+  })
+
+  it('drops the attempt snapshot when the probe is cancelled', async () => {
+    const readUsageSnapshot = vi.fn(async () => ({
+      assistantMessageIds: new Set<string>(),
+      usageByMessageId: new Map()
+    }))
+    const adapter = new AcpOpenCodeTurnAdapter(readUsageSnapshot)
+    const probe = await adapter.begin({
+      providerSessionId: 'provider-session-1',
+      cwd: '/workspace'
+    })
+
+    await probe.cancel()
+
+    await expect(
+      probe.finalize({ response: { stopReason: 'cancelled' } as PromptResponse })
+    ).resolves.toEqual({})
+    expect(readUsageSnapshot).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/acp/opencode-turn-adapter.ts
+++ b/src/main/acp/opencode-turn-adapter.ts
@@ -1,0 +1,73 @@
+import type {
+  AcpProviderTurnAdapter,
+  AcpProviderTurnBeginInput,
+  AcpProviderTurnProbe,
+  AcpProviderTurnResult
+} from './provider-turn-adapter'
+import { sumOpenCodeTurnUsage, type OpenCodeUsageSnapshot } from './opencode-turn-usage'
+
+export type OpenCodeUsageSnapshotReader = (
+  providerSessionId: string,
+  cwd: string
+) => Promise<OpenCodeUsageSnapshot | undefined>
+
+const EMPTY_RESULT: AcpProviderTurnResult = Object.freeze({})
+
+const readSnapshotBestEffort = async (
+  reader: OpenCodeUsageSnapshotReader,
+  providerSessionId: string,
+  cwd: string
+): Promise<OpenCodeUsageSnapshot | undefined> => {
+  try {
+    return await reader(providerSessionId, cwd)
+  } catch {
+    return undefined
+  }
+}
+
+const normalizeTurnUsage = (
+  before: OpenCodeUsageSnapshot | undefined,
+  after: OpenCodeUsageSnapshot | undefined
+): AcpProviderTurnResult => {
+  const usage = sumOpenCodeTurnUsage(before, after)
+  if (!usage) return EMPTY_RESULT
+
+  const { turnCount: modelTurnCount, ...turnUsage } = usage
+  return Object.freeze({
+    turnUsage: Object.freeze(turnUsage),
+    modelTurnCount
+  })
+}
+
+/**
+ * Adapts an authenticated, credential-opaque snapshot reader into normalized provider-turn facts.
+ * Each probe retains only its before snapshot and releases that attempt state on either close path.
+ */
+export class AcpOpenCodeTurnAdapter implements AcpProviderTurnAdapter {
+  constructor(private readonly readUsageSnapshot: OpenCodeUsageSnapshotReader) {}
+
+  async begin(input: AcpProviderTurnBeginInput): Promise<AcpProviderTurnProbe> {
+    const { providerSessionId, cwd } = input
+    let reader: OpenCodeUsageSnapshotReader | undefined = this.readUsageSnapshot
+    let before = await readSnapshotBestEffort(reader, providerSessionId, cwd)
+    let closed = false
+
+    const close = (): void => {
+      closed = true
+      before = undefined
+      reader = undefined
+    }
+
+    return Object.freeze({
+      finalize: async () => {
+        if (closed || !reader) return EMPTY_RESULT
+        const baseline = before
+        const finalReader = reader
+        close()
+        const after = await readSnapshotBestEffort(finalReader, providerSessionId, cwd)
+        return normalizeTurnUsage(baseline, after)
+      },
+      cancel: close
+    })
+  }
+}

--- a/src/main/acp/opencode-turn-usage.test.ts
+++ b/src/main/acp/opencode-turn-usage.test.ts
@@ -121,6 +121,35 @@ describe('OpenCode turn usage', () => {
     })
   })
 
+  it('omits the cache split when any new assistant step lacks it', () => {
+    expect(
+      sumOpenCodeTurnUsage(
+        { assistantMessageIds: new Set(), usageByMessageId: new Map() },
+        {
+          assistantMessageIds: new Set(['step-1', 'step-2']),
+          usageByMessageId: new Map([
+            [
+              'step-1',
+              {
+                inputTokens: 12,
+                cacheTokens: 3,
+                cachedReadTokens: 2,
+                cachedWriteTokens: 1,
+                outputTokens: 2
+              }
+            ],
+            ['step-2', { inputTokens: 19, cacheTokens: 5, outputTokens: 3 }]
+          ])
+        }
+      )
+    ).toEqual({
+      inputTokens: 31,
+      cacheTokens: 8,
+      outputTokens: 5,
+      turnCount: 2
+    })
+  })
+
   it('fails closed instead of publishing a partial sum', () => {
     expect(
       sumOpenCodeTurnUsage(


### PR DESCRIPTION
## Problem

The provider-turn seam had no OpenCode adapter for the existing authenticated before/after usage snapshots, leaving provider-specific attempt facts outside the new interface.

Related: #458 (forward-compatibility constraint only; this PR added no orchestration data, public API, or user interaction).

## Proposed change

- Add `AcpOpenCodeTurnAdapter` over a credential-opaque snapshot reader.
- Capture the before snapshot at `begin`, then capture the same provider Session/cwd at `finalize`.
- Normalize all new assistant steps into token usage plus model-turn count.
- Release attempt-scoped reader/snapshot state on finalize or cancel and fail closed when either probe is unavailable.
- Pin cache-breakdown completeness in the existing OpenCode usage contract.

## Scope and non-goals

- Pure-addition ARD-12 adapter; no Runtime/executor integration.
- No Runtime, coordinator, transport, schema, data, wire/IPC, UI, Permission, Specialist, Compute, Session, Reviewer, Artifact, or other-provider changes.
- ARD-24 retained responsibility for production construction and cutover.

Exact production raw: **73 additions, 0 deletions**.

## Ownership and sequence

No Mermaid diagram is needed for this pure adapter leaf: it introduced no shared state owner, resource transfer, transaction, or production call sequence. The adapter owned only attempt-local snapshots and disposed them on finalize/cancel; credential and provider-process ownership stayed outside the adapter.

## Acceptance criteria and validation

The historical PR record states that the following checks ran on the final material diff:

- Snapshot affinity, multi-step normalization, failure fallback, missing baseline, and cancellation cleanup -> `npm test -- src/main/acp/opencode-turn-adapter.test.ts src/main/acp/opencode-turn-usage.test.ts src/main/acp/provider-turn-adapter.test.ts` -> **3 files, 19 tests passed**.
- Node contracts -> `npm run typecheck:node` -> **passed**.
- Source lint -> `npm run lint` -> **passed with 0 errors; 17 pre-existing warnings outside the diff**.
- Formatting -> targeted Prettier check -> **passed**. The historical record did not preserve the exact Prettier argv.
- Diff integrity -> `git diff --check origin/main...HEAD` -> **passed**.
- Portable suite -> `npm test` -> **745 files passed, 15 skipped; 11,037 tests passed, 184 skipped** after retrying with local-loopback permission.
- Final online gates -> GitHub check history records **PR Gate, Unit tests, Static checks, Coverage macOS, macOS build and E2E, Windows E2E, CodeQL, and AI review workflow success**.

Independent Standards and Spec reviews recorded no findings. No Runtime consumer or local platform lane was selected because the adapter had no production caller and the existing usage-helper implementation was unchanged.

## Review focus

- Credential-opaque dependency and attempt cleanup.
- Exact provider Session/cwd affinity across snapshots.
- Separation of token usage from normalized model-turn count.
- Absence of Runtime integration or compatibility-surface changes.

## Uncovered risks

- Real OpenCode process integration was intentionally deferred to ARD-24.
- Live provider behavior beyond the authenticated snapshot contract was not exercised by this pure leaf.

