### PR TITLE
refactor(acp): own generation activity state

### DIFF
--- a/src/main/acp/generation-activity-owner.test.ts
+++ b/src/main/acp/generation-activity-owner.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AcpGenerationActivityOwner } from './generation-activity-owner'
+
+const createDeferred = (): { promise: Promise<void>; resolve: () => void } => {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('AcpGenerationActivityOwner', () => {
+  it('holds immutable reconnect and retirement blockers for a balanced activity scope', async () => {
+    const activityChanged = vi.fn()
+    const owner = new AcpGenerationActivityOwner({
+      activityChanged,
+      hasActivePrompts: () => false,
+      hasActiveReviewerSessions: () => false
+    })
+    const release = createDeferred()
+
+    const activity = owner.withActivity(() => release.promise)
+
+    expect(owner.blockers()).toEqual({ reconnect: true, retirement: true })
+    expect(Object.isFrozen(owner.blockers())).toBe(true)
+
+    release.resolve()
+    await activity
+
+    expect(owner.blockers()).toEqual({ reconnect: false, retirement: false })
+    expect(activityChanged).toHaveBeenCalledOnce()
+  })
+
+  it('blocks only retirement during an operation and releases the lease when work throws', async () => {
+    const activityChanged = vi.fn()
+    const owner = new AcpGenerationActivityOwner({
+      activityChanged,
+      hasActivePrompts: () => false,
+      hasActiveReviewerSessions: () => false
+    })
+    const boom = new Error('operation failed')
+    let reject!: (error: Error) => void
+    const failed = new Promise<void>((_resolve, fail) => {
+      reject = fail
+    })
+
+    const operation = owner.withOperation(() => failed)
+
+    expect(owner.blockers()).toEqual({ reconnect: false, retirement: true })
+    reject(boom)
+    await expect(operation).rejects.toBe(boom)
+
+    expect(owner.blockers()).toEqual({ reconnect: false, retirement: false })
+    expect(activityChanged).toHaveBeenCalledOnce()
+  })
+
+  it('keeps nested activity scopes blocked until the final release', async () => {
+    const activityChanged = vi.fn()
+    const owner = new AcpGenerationActivityOwner({
+      activityChanged,
+      hasActivePrompts: () => false,
+      hasActiveReviewerSessions: () => false
+    })
+    const releaseInner = createDeferred()
+    const releaseOuter = createDeferred()
+
+    const inner = owner.withActivity(() => releaseInner.promise)
+    const outer = owner.withActivity(() => releaseOuter.promise)
+
+    releaseInner.resolve()
+    await inner
+    expect(owner.blockers()).toEqual({ reconnect: true, retirement: true })
+
+    releaseOuter.resolve()
+    await outer
+    expect(owner.blockers()).toEqual({ reconnect: false, retirement: false })
+    expect(activityChanged).toHaveBeenCalledTimes(2)
+  })
+
+  it('acquires and releases an opaque startup blocker exactly once', () => {
+    const activityChanged = vi.fn()
+    const owner = new AcpGenerationActivityOwner({
+      activityChanged,
+      hasActivePrompts: () => false,
+      hasActiveReviewerSessions: () => false
+    })
+    const token = Symbol('session-startup')
+
+    owner.acquireStartup(token)
+    expect(owner.blockers()).toEqual({ reconnect: true, retirement: true })
+
+    owner.releaseStartup(token)
+    owner.releaseStartup(token)
+
+    expect(owner.blockers()).toEqual({ reconnect: false, retirement: false })
+    expect(activityChanged).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidates every startup blocker and ignores their late releases', () => {
+    const activityChanged = vi.fn()
+    const owner = new AcpGenerationActivityOwner({
+      activityChanged,
+      hasActivePrompts: () => false,
+      hasActiveReviewerSessions: () => false
+    })
+    const primary = Symbol('primary-startup')
+    const reviewer = Symbol('reviewer-startup')
+    owner.acquireStartup(primary)
+    owner.acquireStartup(reviewer)
+
+    owner.invalidateStartups()
+    owner.releaseStartup(primary)
+    owner.releaseStartup(reviewer)
+
+    expect(owner.blockers()).toEqual({ reconnect: false, retirement: false })
+    expect(activityChanged).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not publish the transient gap in a Reviewer startup handoff', async () => {
+    let reviewerActive = false
+    const activityChanged = vi.fn()
+    const owner = new AcpGenerationActivityOwner({
+      activityChanged,
+      hasActivePrompts: () => false,
+      hasActiveReviewerSessions: () => reviewerActive
+    })
+    const token = Symbol('reviewer-startup')
+
+    await owner.withOperation(async () => {
+      owner.acquireStartup(token)
+      activityChanged.mockClear()
+      owner.releaseStartup(token)
+      reviewerActive = true
+    })
+
+    expect(owner.blockers()).toEqual({ reconnect: true, retirement: true })
+    expect(activityChanged).toHaveBeenCalledOnce()
+
+    reviewerActive = false
+    expect(owner.blockers()).toEqual({ reconnect: false, retirement: false })
+  })
+
+  it('notifies when one operation releases startup activity while another operation remains', async () => {
+    const activityChanged = vi.fn()
+    const owner = new AcpGenerationActivityOwner({
+      activityChanged,
+      hasActivePrompts: () => false,
+      hasActiveReviewerSessions: () => false
+    })
+    const releaseOtherOperation = createDeferred()
+    const otherOperation = owner.withOperation(() => releaseOtherOperation.promise)
+    activityChanged.mockClear()
+
+    await owner.withOperation(async () => {
+      const token = Symbol('failed-startup')
+      owner.acquireStartup(token)
+      owner.releaseStartup(token)
+    })
+
+    expect(owner.blockers()).toEqual({ reconnect: false, retirement: true })
+    expect(activityChanged).toHaveBeenCalledOnce()
+
+    releaseOtherOperation.resolve()
+    await otherOperation
+    expect(owner.blockers()).toEqual({ reconnect: false, retirement: false })
+    expect(activityChanged).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/acp/generation-activity-owner.ts
+++ b/src/main/acp/generation-activity-owner.ts
@@ -1,0 +1,84 @@
+export type AcpGenerationActivityBlockers = Readonly<{
+  reconnect: boolean
+  retirement: boolean
+}>
+export type AcpGenerationStartupToken = symbol
+
+type AcpGenerationActivityOwnerOptions = Readonly<{
+  activityChanged: () => void
+  hasActivePrompts: () => boolean
+  hasActiveReviewerSessions: () => boolean
+}>
+
+// Owns the balanced leases and startup membership for one backend generation. Transition intent stays
+// in AcpConnectionTransitionOwner, which observes only this immutable blocker projection.
+export class AcpGenerationActivityOwner {
+  private activityLeaseCount = 0
+  private operationLeaseCount = 0
+  private readonly startupTokens = new Set<AcpGenerationStartupToken>()
+
+  constructor(private readonly options: AcpGenerationActivityOwnerOptions) {}
+
+  blockers(): AcpGenerationActivityBlockers {
+    const reconnect =
+      this.options.hasActivePrompts() ||
+      this.options.hasActiveReviewerSessions() ||
+      this.activityLeaseCount > 0 ||
+      this.startupTokens.size > 0
+    return Object.freeze({
+      reconnect,
+      retirement: reconnect || this.operationLeaseCount > 0
+    })
+  }
+
+  async withOperation<T>(work: () => Promise<T>): Promise<T> {
+    this.operationLeaseCount += 1
+    try {
+      return await work()
+    } finally {
+      this.operationLeaseCount -= 1
+      this.options.activityChanged()
+    }
+  }
+
+  async withActivity<T>(work: () => Promise<T>): Promise<T> {
+    this.activityLeaseCount += 1
+    try {
+      return await work()
+    } finally {
+      this.activityLeaseCount -= 1
+      this.options.activityChanged()
+    }
+  }
+
+  acquireStartup(token: AcpGenerationStartupToken): void {
+    this.changeStartupFacts(() => this.startupTokens.add(token))
+  }
+
+  releaseStartup(token: AcpGenerationStartupToken): void {
+    this.changeStartupFacts(() => this.startupTokens.delete(token))
+  }
+
+  invalidateStartups(): void {
+    this.changeStartupFacts(() => this.startupTokens.clear())
+  }
+
+  private changeStartupFacts(change: () => void): void {
+    // Session and Reviewer startups run inside an operation. Coalesce their synchronous
+    // startup-token-to-active-owner handoff so transition arbitration never observes a false idle gap.
+    if (this.operationLeaseCount > 0) {
+      change()
+      return
+    }
+    this.changeFacts(change)
+  }
+
+  private changeFacts(change: () => void): void {
+    const before = this.blockers()
+    change()
+    const after = this.blockers()
+    if (before.reconnect !== after.reconnect || before.retirement !== after.retirement) {
+      this.options.activityChanged()
+    }
+  }
+}

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -140,6 +140,7 @@ import {
   type AcpConnectionResourceReadyHandle
 } from './connection-resource-owner'
 import { AcpConnectionTransitionOwner } from './connection-transition-owner'
+import { AcpGenerationActivityOwner } from './generation-activity-owner'
 import {
   AcpBackendGenerationOwner,
   type AcpBackendGenerationAttempt,
@@ -521,6 +522,7 @@ class AcpRuntime {
   private readonly contextUsageUpdatedPromptTurnsBySession = new Map<string, number>()
   private readonly connectionResources: AcpConnectionResourceOwner
   private readonly connectionTransitions: AcpConnectionTransitionOwner
+  private readonly generationActivity: AcpGenerationActivityOwner
   // Stable app identities, provider aliases, publication order, selection, and startup/delete
   // arbitration share one owner. The runtime retains only protocol/resource orchestration.
   private readonly sessionRegistry: AcpSessionRegistry
@@ -530,18 +532,6 @@ class AcpRuntime {
   private readonly sessionInteractions: AcpSessionInteractionOwner
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
-  // A startup that begins while a reconnect barrier is already armed must not block the reconnect it
-  // is waiting for. Once it reaches the replacement connection, renewal adds its token here so any
-  // later reconnect waits for publication or rollback.
-  private readonly pendingSessionStartupBlockers = new Set<symbol>()
-  // Public operations acquire this lease synchronously, before backend resolution, skill checks, or
-  // session handshakes can await. Retirement cannot remove a generation while one of those preflight
-  // phases is still capable of spawning or attaching a process/session.
-  private operationLeaseCount = 0
-  // Workflow-scoped leases keep this generation alive across gaps between ephemeral sessions and main
-  // prompts (for example reviewer -> correction -> re-review). A framework switch can retire the runtime
-  // only after every lease and reviewer session has been released.
-  private activityLeaseCount = 0
   // Forced skill state belongs to this runtime generation. It is passed explicitly into backend
   // provisioning so concurrent old/new generations cannot overwrite a SettingsService singleton.
   private readonly turnForcedSkillIds = new Set<string>()
@@ -578,11 +568,13 @@ class AcpRuntime {
         await options.mcpHttpHost?.close()
       }
     })
+    this.generationActivity = new AcpGenerationActivityOwner({
+      activityChanged: () => this.connectionTransitions.activityChanged(),
+      hasActivePrompts: () => this.sessionInteractions.snapshot().length > 0,
+      hasActiveReviewerSessions: () => this.reviewerSessions.hasActiveSessions()
+    })
     this.connectionTransitions = new AcpConnectionTransitionOwner({
-      blockers: () => ({
-        reconnect: this.hasBlockingActivity(),
-        retirement: this.hasRetirementBlockingActivity()
-      }),
+      blockers: () => this.generationActivity.blockers(),
       connectionGeneration: () => this.connectionGeneration,
       disconnect: (emitClosedStatus) => this.disconnect(emitClosedStatus),
       onRetired: () => this.callbacks.onRetired?.(),
@@ -647,7 +639,7 @@ class AcpRuntime {
       inlineImageBudgetBytes: options.inlineImageBudgetBytes
     })
     this.sessionRegistry = new AcpSessionRegistry({
-      addStartupBlocker: (token) => this.pendingSessionStartupBlockers.add(token),
+      addStartupBlocker: (token) => this.generationActivity.acquireStartup(token),
       foreignIdentityCollision: (sessionIds) => {
         const pendingReviewerCollision = sessionIds.find((sessionId) =>
           this.reviewerSessions.hasPendingSessionId(sessionId)
@@ -664,7 +656,7 @@ class AcpRuntime {
           ? new Error(`Primary session id collision with reviewer: ${activeReviewerCollision}`)
           : undefined
       },
-      removeStartupBlocker: (token) => this.pendingSessionStartupBlockers.delete(token)
+      removeStartupBlocker: (token) => this.generationActivity.releaseStartup(token)
     })
     this.permissionContext = new AcpPermissionContext({
       emitPermissionRequest: (request) => {
@@ -693,7 +685,7 @@ class AcpRuntime {
       }
     })
     this.reviewerSessions = new ReviewerSessionOwner({
-      addStartupBlocker: (token) => this.pendingSessionStartupBlockers.add(token),
+      addStartupBlocker: (token) => this.generationActivity.acquireStartup(token),
       clearPermissionCorrelations: (sessionId) =>
         this.permissionContext.clearCorrelationsForSession(sessionId),
       currentStartupGeneration: () => this.sessionRegistry.startupGeneration,
@@ -701,7 +693,7 @@ class AcpRuntime {
       onActiveSessionReleased: () => this.connectionTransitions.activityChanged(),
       registerBridgeSession: (sessionId) =>
         this.connectionResources.registerBridgeReviewerSession(sessionId),
-      removeStartupBlocker: (token) => this.pendingSessionStartupBlockers.delete(token),
+      removeStartupBlocker: (token) => this.generationActivity.releaseStartup(token),
       unregisterBridgeSession: (sessionId) =>
         this.connectionResources.unregisterBridgeReviewerSession(sessionId)
     })
@@ -2802,36 +2794,11 @@ class AcpRuntime {
     _options: AcpRuntimeActivityOptions,
     work: (runtime: AcpRuntimeActivity) => Promise<T>
   ): Promise<T> {
-    this.activityLeaseCount += 1
-    try {
-      return await work(this)
-    } finally {
-      this.activityLeaseCount = Math.max(0, this.activityLeaseCount - 1)
-      this.connectionTransitions.activityChanged()
-    }
+    return this.generationActivity.withActivity(() => work(this))
   }
 
   private async withOperationLease<T>(work: () => Promise<T>): Promise<T> {
-    this.operationLeaseCount += 1
-    try {
-      return await work()
-    } finally {
-      this.operationLeaseCount = Math.max(0, this.operationLeaseCount - 1)
-      this.connectionTransitions.activityChanged()
-    }
-  }
-
-  private hasBlockingActivity(): boolean {
-    return (
-      this.sessionInteractions.snapshot().length > 0 ||
-      this.reviewerSessions.hasActiveSessions() ||
-      this.pendingSessionStartupBlockers.size > 0 ||
-      this.activityLeaseCount > 0
-    )
-  }
-
-  private hasRetirementBlockingActivity(): boolean {
-    return this.operationLeaseCount > 0 || this.hasBlockingActivity()
+    return this.generationActivity.withOperation(work)
   }
 
   private async disconnectCurrent(
@@ -4818,6 +4785,7 @@ class AcpRuntime {
   }
 
   private invalidatePendingSessionStartups(): void {
+    this.generationActivity.invalidateStartups()
     this.sessionRegistry.invalidatePending()
     this.reviewerSessions.invalidatePending()
   }


### PR DESCRIPTION
## Problem

`AcpRuntime` directly owned operation and activity lease counters plus pending Session startup blocker membership. That left generation-lifetime arbitration spread across the facade instead of one state owner.

Related: #458. This PR only establishes a forward ownership constraint for possible future orchestration; it does not add Issue #458 orchestration state, schema, wire contracts, or public behavior.

## Proposed change

- Add `AcpGenerationActivityOwner` as the sole writer for operation/activity leases and startup tokens.
- Expose immutable reconnect and retirement blocker facts to `AcpConnectionTransitionOwner`.
- Preserve operation-release notification timing, including concurrent failed-startup cases.
- Coalesce startup-token-to-active-Reviewer handoffs so reconnect arbitration cannot observe a false idle gap.
- Cut `AcpRuntime` over without changing public methods or transition intent.

## Scope and non-goals

ARD-02 only. No schema, persistence, IPC/preload, Web RPC v1, Task HTTP/WebSocket, CLI/SDK, UI, Specialist, Permission, Compute, Session identity/adoption/reset/replay, terminal fact, Reviewer ownership, Artifact, or Issue #458 orchestration changes.

Production raw: **146** lines (84 owner additions plus 15 additions and 47 deletions in `runtime.ts`), below the 500-line hard stop.

## Ownership and sequence

`AcpGenerationActivityOwner` becomes the only writer for generation-scoped operation/activity leases and startup tokens. `AcpRuntime` coordinates lifecycle calls, while `AcpConnectionTransitionOwner` consumes only the immutable blocker projection.

```mermaid
flowchart LR
  R["AcpRuntime"] -->|"acquire / release scoped activity"| A["AcpGenerationActivityOwner"]
  A -->|"immutable blocker facts"| T["AcpConnectionTransitionOwner"]
  S["startup token"] -->|"atomic handoff"| V["active Reviewer lease"]
  V --> A
  A -->|"release notification after true idle"| T
```

The startup-token-to-Reviewer handoff is coalesced, so reconnect arbitration never sees a transient idle state. An unrelated active operation continues to block reconnect even when another operation releases or startup fails.

## Acceptance criteria and validation

All recorded local checks ran after the final material edit and final rebase:

- Owner lease/token semantics → `npm test -- src/main/acp/generation-activity-owner.test.ts` → **7 passed**.
- Affected Runtime/Coordinator/Reviewer contracts → focused seven-file Vitest set → **473 passed**.
- Portable regression suite → `npm test` → **749 files passed, 11,088 tests passed; 15 files and 184 tests skipped**.
- Node contracts → `npm run typecheck:node` → passed.
- Repository source lint → `npm run lint` → 0 errors; 17 unrelated existing warnings.
- Source formatting → Prettier check on the three changed files → passed.
- Whitespace integrity → `git diff --check origin/main...HEAD` → passed.
- Independent Standards review → no findings.
- Independent Spec review → no findings after fixing the concurrent-operation notification finding.
- Final-head online gates → PR Gate, AI review, CodeQL, Static checks, Unit tests, Coverage macOS, macOS build/E2E, and Windows E2E all passed. `Windows core` was skipped by classification.

Consumer/platform rationale: Runtime, Coordinator, transition, Registry, activity-interface, and Reviewer contracts were included because they consume the blocker projection or scoped activity behavior. No renderer, wire, schema, persistence, or platform-specific behavior changed, so no local UI/E2E or migration lane was indicated; the portable suite and online gates supplied broader regression coverage.

## Review focus

- Balanced scope cleanup and late release.
- Startup invalidation and the startup-to-Reviewer handoff.
- Reconnect notification while an unrelated operation remains active.
- Absence of a second lease/token writer in Runtime.

## Uncovered risks

Real provider timing and OS-specific scheduling were not reproduced by the focused owner tests. The portable suite and final-head cross-platform online gates provide the available coverage. Issue #458 integration remains deferred.
