### PR TITLE
refactor(acp): own handoff continuity state

### DIFF
--- a/src/main/acp/handoff-continuity-owner.test.ts
+++ b/src/main/acp/handoff-continuity-owner.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+
+import { AcpHandoffContinuityOwner } from './handoff-continuity-owner'
+
+const switchReadBack = {
+  status: 'approved' as const,
+  operation: 'switch' as const,
+  binding: {
+    sessionId: 'session-1',
+    specialistId: 'specialist-1',
+    targetName: 'Target Specialist',
+    revision: 4
+  }
+}
+
+describe('AcpHandoffContinuityOwner', () => {
+  it('constructs an app-owned continuation from the latest admitted prompt context', () => {
+    const owner = new AcpHandoffContinuityOwner()
+    const attachments = [
+      {
+        id: 'upload-1',
+        sessionId: 'session-1',
+        name: 'dataset.csv',
+        originalName: 'dataset.csv',
+        path: '/workspace/dataset.csv',
+        size: 42
+      }
+    ]
+    owner.recordAdmittedPrompt({
+      sessionId: 'session-1',
+      text: 'Analyse the dataset',
+      provenanceContext: {
+        promptMessageId: 'message-1',
+        messageAncestry: ['message-root']
+      },
+      attachments,
+      forcedSkillIds: ['source-only-skill']
+    })
+
+    const continuation = owner.createClaudeContinuation({
+      sessionId: 'session-1',
+      switchReadBack
+    })
+
+    expect(continuation).toEqual({
+      sessionId: 'session-1',
+      text: 'Continue the existing task from the approved handoff as Target Specialist.',
+      suppressUserMessage: true,
+      provenanceContext: {
+        promptMessageId: 'message-1',
+        messageAncestry: ['message-root']
+      },
+      attachments
+    })
+    expect(continuation).not.toHaveProperty('forcedSkillIds')
+    expect(continuation.attachments).not.toBe(attachments)
+    expect(continuation.provenanceContext?.messageAncestry).not.toBe(
+      owner.createClaudeContinuation({ sessionId: 'session-1', switchReadBack }).provenanceContext
+        ?.messageAncestry
+    )
+  })
+
+  it('retains a deduplicated Claude replay stage until successful adoption commits it', () => {
+    const owner = new AcpHandoffContinuityOwner()
+    owner.recordAdmittedPrompt({
+      sessionId: 'session-1',
+      text: '  Load the live experiment  ',
+      provenanceContext: { promptMessageId: 'live-message' }
+    })
+    owner.recordAdmittedPrompt({
+      sessionId: 'session-1',
+      text: 'Analyse the experiment',
+      provenanceContext: { promptMessageId: 'analysis-message' }
+    })
+
+    owner.stageClaudeReplay({
+      sessionId: 'session-1',
+      capturedCompletion: { kind: 'returned', value: { afterAwait: 'complete' } },
+      supportedTaskContext: [
+        { messageId: 'persisted-message', text: 'Open the saved project' },
+        { messageId: 'live-message', text: 'stale persisted copy' }
+      ],
+      switchReadBack
+    })
+
+    const staged = owner.peekClaudeReplay('session-1')
+    expect(staged).toContain(
+      '1. Open the saved project\n2. Load the live experiment\n3. Analyse the experiment'
+    )
+    expect(staged).not.toContain('stale persisted copy')
+    expect(staged).toContain('"afterAwait":"complete"')
+    expect(staged).toContain('"revision":4')
+
+    expect(owner.peekClaudeReplay('session-1')).toBe(staged)
+    owner.commitClaudeReplay('session-1')
+    expect(owner.peekClaudeReplay('session-1')).toBeUndefined()
+    owner.commitClaudeReplay('session-1')
+  })
+
+  it('bounds retained task and serialized completion context', () => {
+    const owner = new AcpHandoffContinuityOwner()
+    owner.recordAdmittedPrompt({
+      sessionId: 'session-1',
+      text: `discarded-prefix${'t'.repeat(12_000)}`,
+      provenanceContext: { promptMessageId: 'large-task' }
+    })
+    owner.stageClaudeReplay({
+      sessionId: 'session-1',
+      capturedCompletion: { kind: 'returned', value: 'c'.repeat(9_000) },
+      switchReadBack
+    })
+
+    const staged = owner.peekClaudeReplay('session-1') ?? ''
+    const taskContext = staged.match(
+      /Prior user task requests \(oldest first\):\n1\. ([\s\S]+)\n\nCaptured control completion:/
+    )?.[1]
+    const completion = staged.match(
+      /Captured control completion: ([\s\S]+)\n\nApproved switch read-back:/
+    )?.[1]
+
+    expect(taskContext).toBe('t'.repeat(12_000))
+    expect(completion).toHaveLength(8_000)
+  })
+
+  it('discards only replay staging and clears continuity by Session or generation', () => {
+    const owner = new AcpHandoffContinuityOwner()
+    for (const sessionId of ['session-1', 'session-2']) {
+      owner.recordAdmittedPrompt({ sessionId, text: `Task for ${sessionId}` })
+      owner.stageClaudeReplay({
+        sessionId,
+        capturedCompletion: { kind: 'returned', value: 'done' },
+        switchReadBack: {
+          ...switchReadBack,
+          binding: { ...switchReadBack.binding, sessionId }
+        }
+      })
+    }
+
+    owner.discardClaudeReplay('session-1')
+    expect(owner.peekClaudeReplay('session-1')).toBeUndefined()
+    expect(
+      owner.createClaudeContinuation({ sessionId: 'session-1', switchReadBack })
+    ).toMatchObject({ sessionId: 'session-1', suppressUserMessage: true })
+
+    owner.clearSession('session-1')
+    expect(() =>
+      owner.createClaudeContinuation({ sessionId: 'session-1', switchReadBack })
+    ).toThrow('No user task is available')
+
+    owner.clearGeneration()
+    expect(owner.peekClaudeReplay('session-2')).toBeUndefined()
+    expect(() =>
+      owner.createClaudeContinuation({
+        sessionId: 'session-2',
+        switchReadBack: {
+          ...switchReadBack,
+          binding: { ...switchReadBack.binding, sessionId: 'session-2' }
+        }
+      })
+    ).toThrow('No user task is available')
+  })
+})

--- a/src/main/acp/handoff-continuity-owner.ts
+++ b/src/main/acp/handoff-continuity-owner.ts
@@ -1,0 +1,163 @@
+import { randomUUID } from 'node:crypto'
+
+import type { AcpPromptRequest } from '../../shared/acp'
+import type {
+  ApprovedSwitchReadBack,
+  ClaudeCodeReplayInput,
+  HandoffUserTask
+} from '../agents/claude-code-handoff'
+
+type HandoffPromptContext = Pick<
+  AcpPromptRequest,
+  | 'provenanceContext'
+  | 'attachments'
+  | 'referencedArtifacts'
+  | 'historyAttachments'
+  | 'historyImages'
+>
+
+const copyPromptContext = (source: HandoffPromptContext): HandoffPromptContext => ({
+  ...(source.provenanceContext
+    ? {
+        provenanceContext: {
+          ...source.provenanceContext,
+          ...(source.provenanceContext.messageBranchAncestry
+            ? { messageBranchAncestry: [...source.provenanceContext.messageBranchAncestry] }
+            : {}),
+          ...(source.provenanceContext.messageAncestry
+            ? { messageAncestry: [...source.provenanceContext.messageAncestry] }
+            : {})
+        }
+      }
+    : {}),
+  ...(source.attachments
+    ? { attachments: source.attachments.map((attachment) => ({ ...attachment })) }
+    : {}),
+  ...(source.referencedArtifacts
+    ? { referencedArtifacts: source.referencedArtifacts.map((artifact) => ({ ...artifact })) }
+    : {}),
+  ...(source.historyAttachments
+    ? { historyAttachments: source.historyAttachments.map((attachment) => ({ ...attachment })) }
+    : {}),
+  ...(source.historyImages
+    ? { historyImages: source.historyImages.map((image) => ({ ...image })) }
+    : {})
+})
+
+// Owns application prompt context that must survive a provider Session replacement during an
+// approved completion handoff. Provider Session and transcript lifetimes remain with their owners.
+export class AcpHandoffContinuityOwner {
+  private readonly promptContextBySession = new Map<string, HandoffPromptContext>()
+  private readonly userTasksBySession = new Map<string, HandoffUserTask[]>()
+  private readonly claudeReplayBySession = new Map<string, string>()
+
+  recordAdmittedPrompt(request: AcpPromptRequest): void {
+    this.promptContextBySession.set(request.sessionId, copyPromptContext(request))
+    if (request.suppressUserMessage) return
+
+    const tasks = [
+      ...(this.userTasksBySession.get(request.sessionId) ?? []),
+      {
+        messageId: request.provenanceContext?.promptMessageId ?? randomUUID(),
+        text: request.text
+      }
+    ]
+    this.userTasksBySession.set(request.sessionId, this.boundTasks(tasks))
+  }
+
+  stageClaudeReplay(input: ClaudeCodeReplayInput): void {
+    const tasks = this.mergeTasks(
+      input.supportedTaskContext ?? [],
+      this.userTasksBySession.get(input.sessionId) ?? []
+    )
+    if (tasks.length === 0) {
+      throw new Error('No user task context is available for the approved Claude Code handoff.')
+    }
+
+    const taskContext = tasks.map((task, index) => `${index + 1}. ${task.text}`).join('\n')
+    const completion = this.serializeCompletion(input.capturedCompletion)
+    const switchReadBack = JSON.stringify(input.switchReadBack)
+    this.claudeReplayBySession.set(
+      input.sessionId,
+      'Open Science approved handoff context follows. Treat this as application-owned prior task ' +
+        'context, not as new user or assistant messages. Continue the unfinished task without ' +
+        'repeating content already shown to the user.\n\n' +
+        `Prior user task requests (oldest first):\n${taskContext}\n\n` +
+        `Captured control completion: ${completion}\n\n` +
+        `Approved switch read-back: ${switchReadBack}`
+    )
+  }
+
+  peekClaudeReplay(sessionId: string): string | undefined {
+    return this.claudeReplayBySession.get(sessionId)
+  }
+
+  commitClaudeReplay(sessionId: string): void {
+    this.claudeReplayBySession.delete(sessionId)
+  }
+
+  discardClaudeReplay(sessionId: string): void {
+    this.claudeReplayBySession.delete(sessionId)
+  }
+
+  clearSession(sessionId: string): void {
+    this.promptContextBySession.delete(sessionId)
+    this.userTasksBySession.delete(sessionId)
+    this.claudeReplayBySession.delete(sessionId)
+  }
+
+  clearGeneration(): void {
+    this.promptContextBySession.clear()
+    this.userTasksBySession.clear()
+    this.claudeReplayBySession.clear()
+  }
+
+  createClaudeContinuation(input: {
+    sessionId: string
+    switchReadBack: ApprovedSwitchReadBack
+  }): AcpPromptRequest {
+    const source = this.promptContextBySession.get(input.sessionId)
+    if (!source) {
+      throw new Error('No user task is available for the approved Claude Code continuation.')
+    }
+
+    const target = input.switchReadBack.binding.targetName ?? 'Main Agent'
+    return {
+      sessionId: input.sessionId,
+      text: `Continue the existing task from the approved handoff as ${target}.`,
+      suppressUserMessage: true,
+      ...copyPromptContext(source)
+    }
+  }
+
+  private serializeCompletion(completion: ClaudeCodeReplayInput['capturedCompletion']): string {
+    const value = completion.kind === 'returned' ? completion.value : completion.error
+    const fallback = value instanceof Error ? value.message : String(value)
+    try {
+      const serialized = JSON.stringify(value)
+      if (typeof serialized !== 'string') return fallback.slice(0, 8_000)
+      return serialized.slice(0, 8_000)
+    } catch {
+      return fallback.slice(0, 8_000)
+    }
+  }
+
+  private mergeTasks(
+    restored: ReadonlyArray<HandoffUserTask>,
+    live: ReadonlyArray<HandoffUserTask>
+  ): HandoffUserTask[] {
+    const merged = new Map<string, HandoffUserTask>()
+    for (const task of [...restored, ...live]) {
+      const text = task.text.trim()
+      if (text) merged.set(task.messageId, { messageId: task.messageId, text })
+    }
+    return this.boundTasks(Array.from(merged.values()))
+  }
+
+  private boundTasks(tasks: HandoffUserTask[]): HandoffUserTask[] {
+    let used = tasks.reduce((total, task) => total + task.text.length, 0)
+    while (tasks.length > 1 && used > 12_000) used -= tasks.shift()?.text.length ?? 0
+    if (used > 12_000) tasks[0] = { ...tasks[0], text: tasks[0].text.slice(-12_000) }
+    return tasks
+  }
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -10785,6 +10785,155 @@ describe('ACP runtime session management', () => {
     })
   })
 
+  it('retains handoff continuity across expected reconnect teardown', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'Continue this task after reconnect',
+      provenanceContext: { promptMessageId: 'message-1' }
+    })
+
+    await runtime.disconnect(false)
+
+    expect(
+      runtime.createClaudeCodeContinuationRequest({
+        sessionId: session.sessionId,
+        switchReadBack: {
+          status: 'approved',
+          operation: 'switch',
+          binding: {
+            sessionId: session.sessionId,
+            specialistId: 'specialist-1',
+            targetName: 'Target Specialist'
+          }
+        }
+      })
+    ).toMatchObject({
+      sessionId: session.sessionId,
+      suppressUserMessage: true,
+      provenanceContext: { promptMessageId: 'message-1' }
+    })
+  })
+
+  it('retains staged Claude replay after failed adoption and commits it after success', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(
+      process,
+      ['session-1', 'failed-replacement', 'successful-replacement', 'post-commit-replacement'],
+      {
+        resumeNotFound: true,
+        onNewSession: ({ index }) => {
+          if (index === 1) throw new Error('replacement startup failed')
+        }
+      }
+    )
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'Carry this task through replacement',
+      provenanceContext: { promptMessageId: 'message-1' }
+    })
+    runtime.prepareClaudeCodeHandoffReplay({
+      sessionId: session.sessionId,
+      capturedCompletion: { kind: 'returned', value: 'approved completion' },
+      switchReadBack: {
+        status: 'approved',
+        operation: 'switch',
+        binding: {
+          sessionId: session.sessionId,
+          specialistId: 'specialist-1',
+          targetName: 'Target Specialist'
+        }
+      }
+    })
+
+    await expect(runtime.switchSpecialist(session.sessionId, 'specialist-1')).rejects.toThrow()
+    expect(JSON.stringify(fakeAgent.newSessions[1]?._meta)).toContain(
+      'Carry this task through replacement'
+    )
+
+    await runtime.resumeSession({ sessionId: session.sessionId, cwd: '/workspace' })
+    expect(JSON.stringify(fakeAgent.newSessions[2]?._meta)).toContain(
+      'Carry this task through replacement'
+    )
+
+    await runtime.switchSpecialist(session.sessionId, 'specialist-1')
+    expect(JSON.stringify(fakeAgent.newSessions[3]?._meta)).not.toContain(
+      'Carry this task through replacement'
+    )
+  })
+
+  it('clears handoff continuity when its Session is deleted', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'Delete this task' })
+
+    await runtime.deleteSession({ sessionId: session.sessionId })
+
+    expect(() =>
+      runtime.createClaudeCodeContinuationRequest({
+        sessionId: session.sessionId,
+        switchReadBack: {
+          status: 'approved',
+          operation: 'switch',
+          binding: {
+            sessionId: session.sessionId,
+            specialistId: 'specialist-1',
+            targetName: 'Target Specialist'
+          }
+        }
+      })
+    ).toThrow('No user task is available')
+  })
+
+  it('clears handoff continuity after an unexpected protocol close', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'Interrupted task' })
+
+    process.stdout.end()
+    await vi.waitFor(() => expect(runtime.getSnapshot().status).toBe('closed'))
+
+    expect(() =>
+      runtime.createClaudeCodeContinuationRequest({
+        sessionId: session.sessionId,
+        switchReadBack: {
+          status: 'approved',
+          operation: 'switch',
+          binding: {
+            sessionId: session.sessionId,
+            specialistId: 'specialist-1',
+            targetName: 'Target Specialist'
+          }
+        }
+      })
+    ).toThrow('No user task is available')
+  })
+
   it('adopts a fresh session when the agent returns a generic Internal error on resume', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['adopted-session-1'], { resumeInternalError: true })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -11,7 +11,6 @@ import type {
   SessionNotification
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
-import { randomUUID } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { Readable, Writable } from 'node:stream'
@@ -49,11 +48,7 @@ import {
 import { type AgentFrameworkId } from '../../shared/settings'
 import type { EffectiveSpecialistSkills } from '../../shared/specialist'
 import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
-import type {
-  ApprovedSwitchReadBack,
-  ClaudeCodeReplayInput,
-  HandoffUserTask
-} from '../agents/claude-code-handoff'
+import type { ApprovedSwitchReadBack, ClaudeCodeReplayInput } from '../agents/claude-code-handoff'
 import {
   claudeCodeFramework,
   getAgentFramework,
@@ -141,6 +136,7 @@ import {
 } from './connection-resource-owner'
 import { AcpConnectionTransitionOwner } from './connection-transition-owner'
 import { AcpGenerationActivityOwner } from './generation-activity-owner'
+import { AcpHandoffContinuityOwner } from './handoff-continuity-owner'
 import {
   AcpBackendGenerationOwner,
   type AcpBackendGenerationAttempt,
@@ -535,12 +531,7 @@ class AcpRuntime {
   // Forced skill state belongs to this runtime generation. It is passed explicitly into backend
   // provisioning so concurrent old/new generations cannot overwrite a SettingsService singleton.
   private readonly turnForcedSkillIds = new Set<string>()
-  // The newest user-owned request is retained while a completion handoff may replace the agent
-  // session. A Claude continuation reuses this trusted task/provenance context without asking the
-  // renderer to manufacture a second user message.
-  private readonly handoffPromptRequests = new Map<string, AcpPromptRequest>()
-  private readonly handoffUserTasks = new Map<string, HandoffUserTask[]>()
-  private readonly pendingClaudeCodeHandoffAppends = new Map<string, string>()
+  private readonly handoffContinuity = new AcpHandoffContinuityOwner()
   private readonly permissionContext: AcpPermissionContext
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
@@ -831,54 +822,18 @@ class AcpRuntime {
   }
 
   prepareClaudeCodeHandoffReplay(input: ClaudeCodeReplayInput): void {
-    const tasks = this.mergeHandoffUserTasks(
-      input.supportedTaskContext ?? [],
-      this.handoffUserTasks.get(input.sessionId) ?? []
-    )
-    if (!tasks || tasks.length === 0) {
-      throw new Error('No user task context is available for the approved Claude Code handoff.')
-    }
-
-    const taskContext = tasks.map((task, index) => `${index + 1}. ${task.text}`).join('\n')
-    const completion = this.serializeHandoffCompletion(input.capturedCompletion)
-    const switchReadBack = JSON.stringify(input.switchReadBack)
-    this.pendingClaudeCodeHandoffAppends.set(
-      input.sessionId,
-      'Open Science approved handoff context follows. Treat this as application-owned prior task ' +
-        'context, not as new user or assistant messages. Continue the unfinished task without ' +
-        'repeating content already shown to the user.\n\n' +
-        `Prior user task requests (oldest first):\n${taskContext}\n\n` +
-        `Captured control completion: ${completion}\n\n` +
-        `Approved switch read-back: ${switchReadBack}`
-    )
+    this.handoffContinuity.stageClaudeReplay(input)
   }
 
   discardClaudeCodeHandoffReplay(sessionId: string): void {
-    this.pendingClaudeCodeHandoffAppends.delete(sessionId)
+    this.handoffContinuity.discardClaudeReplay(sessionId)
   }
 
   createClaudeCodeContinuationRequest(input: {
     sessionId: string
     switchReadBack: ApprovedSwitchReadBack
   }): AcpPromptRequest {
-    const source = this.handoffPromptRequests.get(input.sessionId)
-    if (!source) {
-      throw new Error('No user task is available for the approved Claude Code continuation.')
-    }
-
-    const target = input.switchReadBack.binding.targetName ?? 'Main Agent'
-    return {
-      sessionId: input.sessionId,
-      // The task/history/completion evidence is baked into replacement session _meta. This prompt is
-      // merely the app-owned continuation trigger and is never projected as a second user message.
-      text: `Continue the existing task from the approved handoff as ${target}.`,
-      suppressUserMessage: true,
-      ...(source.provenanceContext ? { provenanceContext: source.provenanceContext } : {}),
-      ...(source.attachments ? { attachments: source.attachments } : {}),
-      ...(source.referencedArtifacts ? { referencedArtifacts: source.referencedArtifacts } : {}),
-      ...(source.historyAttachments ? { historyAttachments: source.historyAttachments } : {}),
-      ...(source.historyImages ? { historyImages: source.historyImages } : {})
-    }
+    return this.handoffContinuity.createClaudeContinuation(input)
   }
 
   reportApprovedHandoffFailure(sessionId: string): void {
@@ -889,52 +844,6 @@ class AcpRuntime {
       title: 'Specialist handoff failed',
       text: 'The approved specialist could not continue the current task.'
     })
-  }
-
-  private serializeHandoffCompletion(
-    completion: { kind: 'returned'; value: unknown } | { kind: 'threw'; error: unknown }
-  ): string {
-    const value = completion.kind === 'returned' ? completion.value : completion.error
-    const fallback = value instanceof Error ? value.message : String(value)
-    try {
-      const serialized = JSON.stringify(value)
-      if (typeof serialized !== 'string') return fallback.slice(0, 8_000)
-      return serialized.slice(0, 8_000)
-    } catch {
-      return fallback.slice(0, 8_000)
-    }
-  }
-
-  private rememberHandoffUserTask(sessionId: string, request: AcpPromptRequest): void {
-    const tasks = [
-      ...(this.handoffUserTasks.get(sessionId) ?? []),
-      {
-        messageId: request.provenanceContext?.promptMessageId ?? randomUUID(),
-        text: request.text
-      }
-    ]
-    let used = tasks.reduce((total, task) => total + task.text.length, 0)
-    while (tasks.length > 1 && used > 12_000) {
-      used -= tasks.shift()?.text.length ?? 0
-    }
-    if (used > 12_000) tasks[0] = { ...tasks[0], text: tasks[0].text.slice(-12_000) }
-    this.handoffUserTasks.set(sessionId, tasks)
-  }
-
-  private mergeHandoffUserTasks(
-    restored: ReadonlyArray<HandoffUserTask>,
-    live: ReadonlyArray<HandoffUserTask>
-  ): HandoffUserTask[] {
-    const merged = new Map<string, HandoffUserTask>()
-    for (const task of [...restored, ...live]) {
-      const text = task.text.trim()
-      if (text) merged.set(task.messageId, { messageId: task.messageId, text })
-    }
-    const tasks = Array.from(merged.values())
-    let used = tasks.reduce((total, task) => total + task.text.length, 0)
-    while (tasks.length > 1 && used > 12_000) used -= tasks.shift()?.text.length ?? 0
-    if (used > 12_000) tasks[0] = { ...tasks[0], text: tasks[0].text.slice(-12_000) }
-    return tasks
   }
 
   private getInFlightSessionIds(): string[] {
@@ -2519,7 +2428,7 @@ class AcpRuntime {
         request.sessionId,
         stagedSpecialistId
       )
-      const handoffAppend = this.pendingClaudeCodeHandoffAppends.get(request.sessionId)
+      const handoffAppend = this.handoffContinuity.peekClaudeReplay(request.sessionId)
       adopted = await connection.agent
         .buildSession({
           cwd: sessionCwd,
@@ -2573,7 +2482,7 @@ class AcpRuntime {
       if (request.specialistId) {
         aggregate.setSpecialistId(request.specialistId)
       }
-      this.pendingClaudeCodeHandoffAppends.delete(request.sessionId)
+      this.handoffContinuity.commitClaudeReplay(request.sessionId)
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
       this.sessionCapabilities.commit({
         appSessionId: request.sessionId,
@@ -3110,8 +3019,7 @@ class AcpRuntime {
     try {
       promptInteraction = this.sessionInteractions.activatePrompt(promptReservation)
       this.sessionRegistry.select(request.sessionId)
-      this.handoffPromptRequests.set(request.sessionId, request)
-      if (!request.suppressUserMessage) this.rememberHandoffUserTask(request.sessionId, request)
+      this.handoffContinuity.recordAdmittedPrompt(request)
     } catch (error) {
       this.sessionInteractions.release(promptReservation)
       throw error
@@ -3694,9 +3602,7 @@ class AcpRuntime {
     this.sessionCapabilities.revokeSession(request.sessionId)
     const removal = deletion.finish(target)
     this.promptContentOwner.resetSession(request.sessionId)
-    this.handoffPromptRequests.delete(request.sessionId)
-    this.handoffUserTasks.delete(request.sessionId)
-    this.pendingClaudeCodeHandoffAppends.delete(request.sessionId)
+    this.handoffContinuity.clearSession(request.sessionId)
     this.contextUsageTracker.deleteSession(request.sessionId)
     this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
 
@@ -4693,9 +4599,7 @@ class AcpRuntime {
       else entry.aggregate.detachConnection()
     }
     this.promptContentOwner.clear()
-    this.handoffPromptRequests.clear()
-    this.handoffUserTasks.clear()
-    this.pendingClaudeCodeHandoffAppends.clear()
+    this.handoffContinuity.clearGeneration()
     this.codexSkillActivity.clear()
     this.contextUsageTracker.clear()
     this.contextUsageUpdatedPromptTurnsBySession.clear()


### PR DESCRIPTION
## Problem

`AcpRuntime` still directly wrote three Maps for prompt/task provenance and Claude replay staging. That left completion-handoff continuity without a single lifecycle owner.

Related: #458. This PR only establishes a forward ownership boundary for future orchestration compatibility; it does not implement Issue #458 orchestration state, schema, wire/API contracts, or user interaction.

## Proposed change

- Add `AcpHandoffContinuityOwner` as the sole writer for admitted prompt context, bounded user-task history, and staged Claude replay metadata.
- Expose explicit stage/peek/commit/discard plus Session/generation cleanup operations.
- Delegate Runtime prompt, adoption, delete, and unexpected-close paths to the owner.
- Preserve expected reconnect continuity while consuming successful Claude adoption replay exactly once.

## Scope and non-goals

- ARD-03 only; no ARD-05 work.
- No schema/data relationship, IPC/preload, Web RPC v1, Task HTTP/WebSocket, CLI/SDK, UI, Specialist, Permission, Compute, Session identity/adoption/reset/replay contract, terminal fact, Reviewer, or Artifact behavior change.
- No Issue #458 orchestration implementation.

Exact production raw: **281** (`handoff-continuity-owner.ts` 163 additions; `runtime.ts` 11 additions + 107 deletions). The >500 mandatory split was not activated.

## Ownership and sequence

Before the change, `AcpRuntime` wrote three private Maps. After the change, `AcpHandoffContinuityOwner` is the only writer for prompt/task provenance and staged replay continuity; Runtime orchestrates lifecycle transitions through its methods.

```mermaid
flowchart LR
  R["AcpRuntime lifecycle"] -->|"admit prompt / stage replay"| O["AcpHandoffContinuityOwner"]
  O -->|"peek immutable continuity"| R
  R -->|"successful adoption"| C["commit exactly once"]
  R -->|"handoff failure"| D["discard staging"]
  X["Session delete / unexpected close"] -->|"clear Session or generation"| O
  E["expected reconnect"] -->|"retain continuity"| O
  C --> O
  D --> O
```

Session deletion clears one Session; unexpected close clears the generation; explicit handoff failure discards replay staging; expected reconnect retains continuity. Successful Claude adoption consumes staged replay exactly once.

## Acceptance criteria and validation

All recorded checks ran after the last material edit:

- Owner bounds/dedup/copy/transaction/cleanup behavior plus affected Runtime/Coordinator/Claude handoff/Specialist contracts → `npm test -- src/main/acp/handoff-continuity-owner.test.ts src/main/acp/runtime.test.ts src/main/acp/runtime-coordinator.test.ts src/main/agents/claude-code-handoff.test.ts src/main/specialist/specialist-identity-injection.test.ts` → **468 passed**.
- Affected Node runtime types → `npm run typecheck:node` → passed.
- Source lint → `npm run lint` → 0 errors; 17 warnings outside this diff.
- Touched-file formatting → Prettier check on the four changed files → passed.
- Patch whitespace → `git diff --check` → passed.
- Independent Standards review → 0 findings.
- Independent Spec review → 0 findings.
- Final-head online gates → PR Gate, AI review, CodeQL, Static checks, Unit tests, Coverage macOS, macOS build/E2E, and Windows E2E all passed. `Windows core` was skipped by classification.

Consumer coverage includes the Runtime facade, RuntimeCoordinator, Claude completion-gate adapter, and Specialist replay integration. Renderer/web/platform lanes were excluded locally because no public surface or platform-specific code changed; the final-head online PR Gate is the authoritative cross-platform evidence.

## Review focus

- One-writer ownership and removal of all Runtime compatibility Maps.
- Replay retention on failed adoption versus exact-once commit on success.
- Expected reconnect retention and delete/unexpected-close cleanup.
- Preservation of app-owned continuation provenance without a second user message.

## Uncovered risks

No uncovered local behavior risk was recorded. Real provider and cross-platform behavior was left to the final-head online gates. Issue #458 orchestration integration remains deliberately deferred.
