### PR TITLE
refactor(acp): provision session capabilities through owner handle

### DIFF
--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -113,7 +113,7 @@ import {
 import {
   AcpSessionCapabilityOwner,
   CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-  type SessionCapabilityRoutingIds
+  type SessionCapabilityProvision
 } from './session-capability-owner'
 import { ArtifactTurnOwner, type ArtifactTurnHandle } from './artifact-turn-owner'
 import { AcpPromptContentOwner } from './prompt-content-owner'
@@ -1391,12 +1391,9 @@ class AcpRuntime {
   private async createSessionOperation(
     request: AcpCreateSessionRequest = {}
   ): Promise<AcpCreateSessionResponse> {
-    let provisionalRoutingIds: SessionCapabilityRoutingIds | undefined
-    let releaseProvisionalNotebookConnection: (() => void) | undefined
-    let releaseProvisionalSkillImportConnection: (() => void) | undefined
+    let capabilityProvision: SessionCapabilityProvision | undefined
     let primaryIdentityReservation: AcpPrimarySessionIdentityReservation | undefined
     let provisionalSession: ActiveSession | undefined
-    let provisionalHttpMcpRoutes = false
     try {
       log.info('createSession: starting', this.diagnosticContext())
       const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
@@ -1405,8 +1402,6 @@ class AcpRuntime {
       const connection = await this.ensureConnected(sessionCwd)
       this.assertCurrentConnectedConnection(connection)
       const sessionStartupGeneration = this.sessionRegistry.startupGeneration
-      const routingIds = this.sessionCapabilities.createRoutingIds()
-      provisionalRoutingIds = routingIds
 
       // Resolve specialist identity before starting the ACP session so the identity append is
       // included in session/new. Main process reads the latest Profile — renderer only sends the UUID.
@@ -1435,23 +1430,15 @@ class AcpRuntime {
       }
 
       log.info('createSession: createMcpServers', this.diagnosticContext())
-      provisionalHttpMcpRoutes = !this.framework.acceptsStdioMcp
-      const builtCapabilities = await this.sessionCapabilities.build({
+      capabilityProvision = await this.sessionCapabilities.provision({
         framework: this.framework,
         nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
         bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
         policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-        routingIds,
         sessionCwd,
-        projectName,
-        onNotebookConnection: (connection) => {
-          releaseProvisionalNotebookConnection = connection.release
-        },
-        onSkillImportConnection: (connection) => {
-          releaseProvisionalSkillImportConnection = connection.release
-        }
+        projectName
       })
-      const { mcpServers } = builtCapabilities
+      const { mcpServers } = capabilityProvision
       log.info('createSession: buildSession', this.diagnosticContext())
       const extraAppends = specialistAppend ? [specialistAppend] : []
       const session = await connection.agent
@@ -1528,22 +1515,14 @@ class AcpRuntime {
       } else {
         aggregate.setSpecialistId(undefined)
       }
+      capabilityProvision.commit(session.sessionId)
       provisionalSession = undefined
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
       primaryIdentityReservation = undefined
-      this.sessionCapabilities.commit({
-        appSessionId: session.sessionId,
-        routingIds,
-        descriptor: builtCapabilities.descriptor,
-        notebookRelease: releaseProvisionalNotebookConnection,
-        skillImportRelease: releaseProvisionalSkillImportConnection
-      })
       // Route and bearer ownership is now represented by the committed app-session maps. End the
       // provisional rollback window before invoking external observers so their failures cannot tear
       // down a Session that has already been published.
-      provisionalRoutingIds = undefined
-      releaseProvisionalNotebookConnection = undefined
-      releaseProvisionalSkillImportConnection = undefined
+      capabilityProvision = undefined
       try {
         this.notebookOptions?.registerSessionSpecialist?.(session.sessionId, request.specialistId)
       } catch (error) {
@@ -1598,20 +1577,7 @@ class AcpRuntime {
           'primary startup session disposal failed'
         )
       }
-      this.sessionCapabilities.revokeProvisional({
-        routingIds: provisionalRoutingIds
-          ? [
-              provisionalRoutingIds.artifact,
-              provisionalRoutingIds.notebook,
-              provisionalRoutingIds.skillImport
-            ]
-          : [],
-        usedHttpTransport: provisionalHttpMcpRoutes,
-        notebookSessionId: provisionalRoutingIds?.notebook || undefined,
-        notebookRelease: releaseProvisionalNotebookConnection,
-        skillImportRelease: releaseProvisionalSkillImportConnection,
-        ownsStableIdentity: true
-      })
+      capabilityProvision?.release({ ownsStableIdentity: true })
       safeLogError('createSession: failed', {
         ...diagnosticErrorFields(startupError),
         ...this.diagnosticContext()
@@ -2150,35 +2116,21 @@ class AcpRuntime {
       throw new Error('ACP agent does not support session resume.')
     }
 
-    // Session bearer tokens are provisional until the resumed session is fully registered. Any
-    // later setup failure must revoke them so an unattached Agent cannot retain app capabilities.
-    let notebookCapabilityProvisional = Boolean(this.notebookOptions)
-    let skillImportCapabilityProvisional = Boolean(this.skillImportOptions)
-    let releaseProvisionalNotebookConnection: (() => void) | undefined
-    let releaseProvisionalSkillImportConnection: (() => void) | undefined
+    let capabilityProvision: SessionCapabilityProvision | undefined
     let session: ActiveSession | undefined
-    let provisionalHttpMcpRoutes = false
-    const routingIds = this.sessionCapabilities.createRoutingIds(request.sessionId)
     try {
       // Resumed sessions already have stable ids, so the artifact session mirrors the runtime session
       // id.
-      provisionalHttpMcpRoutes = !this.framework.acceptsStdioMcp
-      const builtCapabilities = await this.sessionCapabilities.build({
+      capabilityProvision = await this.sessionCapabilities.provision({
+        stableAppSessionId: request.sessionId,
         framework: this.framework,
         nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
         bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
         policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-        routingIds,
         sessionCwd,
-        projectName,
-        onNotebookConnection: (connection) => {
-          releaseProvisionalNotebookConnection = connection.release
-        },
-        onSkillImportConnection: (connection) => {
-          releaseProvisionalSkillImportConnection = connection.release
-        }
+        projectName
       })
-      const { mcpServers } = builtCapabilities
+      const { mcpServers } = capabilityProvision
       let resumeResponse
       try {
         resumeResponse = await connection.agent.request(acp.methods.agent.session.resume, {
@@ -2202,20 +2154,8 @@ class AcpRuntime {
         try {
           this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
         } catch (supersededError) {
-          if (notebookCapabilityProvisional || skillImportCapabilityProvisional) {
-            this.sessionCapabilities.revokeProvisional({
-              routingIds: [routingIds.artifact, routingIds.notebook, routingIds.skillImport],
-              usedHttpTransport: false,
-              notebookSessionId: routingIds.notebook || undefined,
-              notebookRelease: releaseProvisionalNotebookConnection,
-              skillImportRelease: releaseProvisionalSkillImportConnection,
-              ownsStableIdentity: false
-            })
-            notebookCapabilityProvisional = false
-            skillImportCapabilityProvisional = false
-            releaseProvisionalNotebookConnection = undefined
-            releaseProvisionalSkillImportConnection = undefined
-          }
+          capabilityProvision.release({ ownsStableIdentity: false })
+          capabilityProvision = undefined
           throw supersededError
         }
 
@@ -2223,20 +2163,8 @@ class AcpRuntime {
         // longer holds it — surfacing as -32002 not-found or a generic -32603 Internal error). Revoke
         // the token handed to that failed attempt before adopting a brand-new agent session under the
         // SAME app id; adoptFreshSession owns the replacement token's lifecycle.
-        if (notebookCapabilityProvisional || skillImportCapabilityProvisional) {
-          this.sessionCapabilities.revokeProvisional({
-            routingIds: [routingIds.artifact, routingIds.notebook, routingIds.skillImport],
-            usedHttpTransport: false,
-            notebookSessionId: routingIds.notebook || undefined,
-            notebookRelease: releaseProvisionalNotebookConnection,
-            skillImportRelease: releaseProvisionalSkillImportConnection,
-            ownsStableIdentity: true
-          })
-          notebookCapabilityProvisional = false
-          skillImportCapabilityProvisional = false
-          releaseProvisionalNotebookConnection = undefined
-          releaseProvisionalSkillImportConnection = undefined
-        }
+        capabilityProvision.release({ ownsStableIdentity: true })
+        capabilityProvision = undefined
         log.info('resumed session adopted after unrecoverable resume error', {
           sessionId: request.sessionId,
           ...errorLogFields(error)
@@ -2295,18 +2223,9 @@ class AcpRuntime {
       if (request.specialistId) {
         aggregate.setSpecialistId(request.specialistId)
       }
+      capabilityProvision.commit(request.sessionId)
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      this.sessionCapabilities.commit({
-        appSessionId: request.sessionId,
-        routingIds,
-        descriptor: builtCapabilities.descriptor,
-        notebookRelease: releaseProvisionalNotebookConnection,
-        skillImportRelease: releaseProvisionalSkillImportConnection
-      })
-      notebookCapabilityProvisional = false
-      skillImportCapabilityProvisional = false
-      releaseProvisionalNotebookConnection = undefined
-      releaseProvisionalSkillImportConnection = undefined
+      capabilityProvision = undefined
       this.snapshotOwner.updateCwd(sessionCwd)
       try {
         this.pushEvent({
@@ -2339,41 +2258,17 @@ class AcpRuntime {
       }
     } catch (error) {
       let startupError = error
-      let ownsProvisionalHttpRoutes = true
+      let ownsStableIdentity = true
       try {
         this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       } catch (supersededError) {
         startupError = supersededError
-        ownsProvisionalHttpRoutes = false
+        ownsStableIdentity = false
       }
-      if (ownsProvisionalHttpRoutes) {
-        this.sessionCapabilities.revokeProvisional({
-          routingIds: [routingIds.artifact, routingIds.notebook, routingIds.skillImport],
-          usedHttpTransport: provisionalHttpMcpRoutes,
-          notebookSessionId: routingIds.notebook || undefined,
-          notebookRelease: notebookCapabilityProvisional
-            ? releaseProvisionalNotebookConnection
-            : undefined,
-          skillImportRelease: skillImportCapabilityProvisional
-            ? releaseProvisionalSkillImportConnection
-            : undefined,
-          ownsStableIdentity: notebookCapabilityProvisional
-        })
-        notebookCapabilityProvisional = false
-        skillImportCapabilityProvisional = false
-      }
+      capabilityProvision?.release({ ownsStableIdentity })
+      capabilityProvision = undefined
       if (session) {
         this.disposeSessionAfterFailure(session, 'resumed startup session disposal failed')
-      }
-      if (notebookCapabilityProvisional || skillImportCapabilityProvisional) {
-        this.sessionCapabilities.revokeProvisional({
-          routingIds: [],
-          usedHttpTransport: false,
-          notebookSessionId: routingIds.notebook || undefined,
-          notebookRelease: releaseProvisionalNotebookConnection,
-          skillImportRelease: releaseProvisionalSkillImportConnection,
-          ownsStableIdentity: ownsProvisionalHttpRoutes
-        })
       }
       throw startupError
     }
@@ -2393,31 +2288,19 @@ class AcpRuntime {
     // Fresh adoption also receives provisional app capability tokens. Transfer ownership only after
     // adoptSession has registered the replacement; every earlier failure revokes them and disposes any
     // partially-created Agent session.
-    let notebookCapabilityProvisional = Boolean(this.notebookOptions)
-    let skillImportCapabilityProvisional = Boolean(this.skillImportOptions)
-    let releaseProvisionalNotebookConnection: (() => void) | undefined
-    let releaseProvisionalSkillImportConnection: (() => void) | undefined
+    let capabilityProvision: SessionCapabilityProvision | undefined
     let adopted: ActiveSession | undefined
-    let provisionalHttpMcpRoutes = false
-    const routingIds = this.sessionCapabilities.createRoutingIds(request.sessionId)
     try {
-      provisionalHttpMcpRoutes = !this.framework.acceptsStdioMcp
-      const builtCapabilities = await this.sessionCapabilities.build({
+      capabilityProvision = await this.sessionCapabilities.provision({
+        stableAppSessionId: request.sessionId,
         framework: this.framework,
         nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
         bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
         policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-        routingIds,
         sessionCwd,
-        projectName,
-        onNotebookConnection: (connection) => {
-          releaseProvisionalNotebookConnection = connection.release
-        },
-        onSkillImportConnection: (connection) => {
-          releaseProvisionalSkillImportConnection = connection.release
-        }
+        projectName
       })
-      const { mcpServers } = builtCapabilities
+      const { mcpServers } = capabilityProvision
       // A freshly adopted session carries no prior _meta, so the specialist identity append (Claude)
       // must be re-resolved from the live binding. Without this, a context reset or specialist switch
       // would silently drop the session's specialist identity.
@@ -2482,19 +2365,10 @@ class AcpRuntime {
       if (request.specialistId) {
         aggregate.setSpecialistId(request.specialistId)
       }
+      capabilityProvision.commit(request.sessionId)
       this.handoffContinuity.commitClaudeReplay(request.sessionId)
       this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      this.sessionCapabilities.commit({
-        appSessionId: request.sessionId,
-        routingIds,
-        descriptor: builtCapabilities.descriptor,
-        notebookRelease: releaseProvisionalNotebookConnection,
-        skillImportRelease: releaseProvisionalSkillImportConnection
-      })
-      notebookCapabilityProvisional = false
-      skillImportCapabilityProvisional = false
-      releaseProvisionalNotebookConnection = undefined
-      releaseProvisionalSkillImportConnection = undefined
+      capabilityProvision = undefined
       try {
         this.emitState()
       } catch (error) {
@@ -2513,41 +2387,17 @@ class AcpRuntime {
       }
     } catch (error) {
       let startupError = error
-      let ownsProvisionalHttpRoutes = true
+      let ownsStableIdentity = true
       try {
         this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       } catch (supersededError) {
         startupError = supersededError
-        ownsProvisionalHttpRoutes = false
+        ownsStableIdentity = false
       }
-      if (ownsProvisionalHttpRoutes) {
-        this.sessionCapabilities.revokeProvisional({
-          routingIds: [routingIds.artifact, routingIds.notebook, routingIds.skillImport],
-          usedHttpTransport: provisionalHttpMcpRoutes,
-          notebookSessionId: routingIds.notebook || undefined,
-          notebookRelease: notebookCapabilityProvisional
-            ? releaseProvisionalNotebookConnection
-            : undefined,
-          skillImportRelease: skillImportCapabilityProvisional
-            ? releaseProvisionalSkillImportConnection
-            : undefined,
-          ownsStableIdentity: notebookCapabilityProvisional
-        })
-        notebookCapabilityProvisional = false
-        skillImportCapabilityProvisional = false
-      }
+      capabilityProvision?.release({ ownsStableIdentity })
+      capabilityProvision = undefined
       if (adopted) {
         this.disposeSessionAfterFailure(adopted, 'adopted startup session disposal failed')
-      }
-      if (notebookCapabilityProvisional || skillImportCapabilityProvisional) {
-        this.sessionCapabilities.revokeProvisional({
-          routingIds: [],
-          usedHttpTransport: false,
-          notebookSessionId: routingIds.notebook || undefined,
-          notebookRelease: releaseProvisionalNotebookConnection,
-          skillImportRelease: releaseProvisionalSkillImportConnection,
-          ownsStableIdentity: ownsProvisionalHttpRoutes
-        })
       }
       throw startupError
     }

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -55,24 +55,429 @@ describe('ACP session capability owner', () => {
     expect(owner.toolingAvailability(input).skillImport).toBe(true)
   })
 
-  it('derives the exact current primary set while reviewer and unknown capabilities fail closed', async () => {
-    const owner = createOwner()
-    const routingIds = owner.createRoutingIds('session-1')
-    const primary = await owner.build({
+  it('commits a provision under the stable app identity', async () => {
+    const release = vi.fn()
+    const registerSessionAlias = vi.fn()
+    const releaseSessionCapabilities = vi.fn()
+    const owner = createOwner({
+      artifacts: undefined,
+      skillImport: undefined,
+      notebook: {
+        projectName: 'project',
+        mcpEntryPath: '/app/main.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:1',
+          token: 'notebook',
+          release
+        }),
+        registerSessionAlias,
+        releaseSessionCapabilities
+      }
+    })
+
+    const provision = await owner.provision({
+      stableAppSessionId: 'provider-session',
       framework: opencodeFramework,
       nativeMcpEnabled: true,
       bridgeMcpAliasesEnabled: false,
       policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-      routingIds,
       sessionCwd: '/workspace',
       projectName: 'project'
     })
-    const reviewer = await owner.build({
+
+    provision.commit('app-session')
+
+    expect(registerSessionAlias).toHaveBeenCalledWith('provider-session', 'app-session')
+    expect(owner.mcpServerNamesFor('app-session')).toEqual(['open-science-notebook'])
+    expect(release).not.toHaveBeenCalled()
+
+    owner.revokeSession('app-session')
+    expect(release).toHaveBeenCalledOnce()
+    expect(releaseSessionCapabilities).toHaveBeenCalledWith('app-session')
+  })
+
+  it('releases acquired local RPC leases when a later provision step fails', async () => {
+    const notebookRelease = vi.fn()
+    const releaseSessionCapabilities = vi.fn()
+    const owner = createOwner({
+      notebook: {
+        projectName: 'project',
+        mcpEntryPath: '/app/main.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:1',
+          token: 'notebook',
+          release: notebookRelease
+        }),
+        releaseSessionCapabilities
+      },
+      skillImport: {
+        mcpEntryPath: '/app/main.js',
+        getRpcConnection: async () => {
+          throw new Error('Skill import RPC unavailable')
+        }
+      }
+    })
+
+    await expect(
+      owner.provision({
+        stableAppSessionId: 'session-1',
+        framework: opencodeFramework,
+        nativeMcpEnabled: true,
+        bridgeMcpAliasesEnabled: false,
+        policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+        sessionCwd: '/workspace',
+        projectName: 'project'
+      })
+    ).rejects.toThrow('Skill import RPC unavailable')
+    expect(notebookRelease).toHaveBeenCalledOnce()
+    expect(releaseSessionCapabilities).toHaveBeenCalledWith('session-1')
+  })
+
+  it('unregisters partial HTTP routes when provision building fails', async () => {
+    const unregister = vi.fn()
+    const host = {
+      ensureStarted: vi.fn(async () => ({ endpoint: 'http://127.0.0.1:3', token: 'host' })),
+      registerArtifact: vi.fn(),
+      registerNotebook: vi.fn(),
+      registerSkillImport: vi.fn(),
+      urlFor: vi.fn((kind: string, routingId: string) => `http://127.0.0.1:3/${kind}/${routingId}`),
+      unregister,
+      clear: vi.fn(),
+      close: vi.fn()
+    } as unknown as AgentMcpHttpHost
+    const owner = createOwner({
+      mcpHttpHost: host,
+      skillImport: {
+        mcpEntryPath: '/app/main.js',
+        getRpcConnection: async () => {
+          throw new Error('Skill import RPC unavailable')
+        }
+      }
+    })
+
+    await expect(
+      owner.provision({
+        stableAppSessionId: 'session-1',
+        framework: { ...opencodeFramework, acceptsStdioMcp: false },
+        nativeMcpEnabled: true,
+        bridgeMcpAliasesEnabled: false,
+        policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+        sessionCwd: '/workspace',
+        projectName: 'project'
+      })
+    ).rejects.toThrow('Skill import RPC unavailable')
+
+    expect(unregister).toHaveBeenCalledOnce()
+    expect(unregister).toHaveBeenCalledWith('session-1')
+  })
+
+  it('revokes a committed same-ID HTTP route when its replacement fails before registration', async () => {
+    const startupFailure = new Error('MCP host startup failed')
+    const ensureStarted = vi
+      .fn()
+      .mockResolvedValueOnce({ endpoint: 'http://127.0.0.1:3', token: 'host' })
+      .mockRejectedValueOnce(startupFailure)
+    const unregister = vi.fn()
+    const host = {
+      ensureStarted,
+      registerNotebook: vi.fn(),
+      urlFor: vi.fn((kind: string, routingId: string) => `http://127.0.0.1:3/${kind}/${routingId}`),
+      unregister,
+      clear: vi.fn(),
+      close: vi.fn()
+    } as unknown as AgentMcpHttpHost
+    const owner = createOwner({
+      artifacts: undefined,
+      skillImport: undefined,
+      mcpHttpHost: host
+    })
+    const input = {
+      stableAppSessionId: 'session-1',
+      framework: { ...opencodeFramework, acceptsStdioMcp: false },
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+      sessionCwd: '/workspace',
+      projectName: 'project'
+    }
+    const committed = await owner.provision(input)
+    committed.commit('session-1')
+
+    await expect(owner.provision(input)).rejects.toBe(startupFailure)
+
+    expect(unregister).toHaveBeenCalledOnce()
+    expect(unregister).toHaveBeenCalledWith('session-1')
+  })
+
+  it('retains provisional cleanup ownership through disposal', async () => {
+    let resolveConnection!: (connection: { endpoint: string; token: string }) => void
+    const connection = new Promise<{ endpoint: string; token: string }>((resolve) => {
+      resolveConnection = resolve
+    })
+    const getRpcConnection = vi.fn(() => connection)
+    const unregister = vi.fn()
+    const clear = vi.fn()
+    const registerNotebook = vi.fn()
+    const host = {
+      ensureStarted: vi.fn(async () => ({ endpoint: 'http://127.0.0.1:3', token: 'host' })),
+      registerNotebook,
+      urlFor: vi.fn((kind: string, routingId: string) => `http://127.0.0.1:3/${kind}/${routingId}`),
+      unregister,
+      clear,
+      close: vi.fn()
+    } as unknown as AgentMcpHttpHost
+    const owner = createOwner({
+      artifacts: undefined,
+      skillImport: undefined,
+      mcpHttpHost: host,
+      notebook: {
+        projectName: 'project',
+        mcpEntryPath: '/app/main.js',
+        getRpcConnection
+      }
+    })
+    const provisionPromise = owner.provision({
+      stableAppSessionId: 'session-1',
+      framework: { ...opencodeFramework, acceptsStdioMcp: false },
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+      sessionCwd: '/workspace',
+      projectName: 'project'
+    })
+    await vi.waitFor(() => expect(getRpcConnection).toHaveBeenCalledOnce())
+
+    owner.dispose()
+    owner.clearHttpRoutes()
+    resolveConnection({ endpoint: 'http://127.0.0.1:1', token: 'notebook' })
+    const provision = await provisionPromise
+    provision.release({ ownsStableIdentity: true })
+
+    expect(clear).toHaveBeenCalledOnce()
+    expect(registerNotebook).not.toHaveBeenCalled()
+    expect(unregister).toHaveBeenCalledOnce()
+    expect(unregister).toHaveBeenCalledWith('session-1')
+  })
+
+  it('prevents a stale HTTP provision from overwriting its same-ID successor', async () => {
+    let resolveFirstConnection!: (connection: { endpoint: string; token: string }) => void
+    const firstConnection = new Promise<{ endpoint: string; token: string }>((resolve) => {
+      resolveFirstConnection = resolve
+    })
+    let connectionIndex = 0
+    const getRpcConnection = vi.fn(() => {
+      connectionIndex += 1
+      return connectionIndex === 1
+        ? firstConnection
+        : Promise.resolve({ endpoint: 'http://127.0.0.1:2', token: 'successor' })
+    })
+    const registerNotebook = vi.fn()
+    const unregister = vi.fn()
+    const host = {
+      ensureStarted: vi.fn(async () => ({ endpoint: 'http://127.0.0.1:3', token: 'host' })),
+      registerNotebook,
+      urlFor: vi.fn((kind: string, routingId: string) => `http://127.0.0.1:3/${kind}/${routingId}`),
+      unregister,
+      clear: vi.fn(),
+      close: vi.fn()
+    } as unknown as AgentMcpHttpHost
+    const owner = createOwner({
+      artifacts: undefined,
+      skillImport: undefined,
+      mcpHttpHost: host,
+      notebook: {
+        projectName: 'project',
+        mcpEntryPath: '/app/main.js',
+        getRpcConnection
+      }
+    })
+    const input = {
+      stableAppSessionId: 'session-1',
+      framework: { ...opencodeFramework, acceptsStdioMcp: false },
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+      sessionCwd: '/workspace',
+      projectName: 'project'
+    }
+    const staleProvisionPromise = owner.provision(input)
+    await vi.waitFor(() => expect(getRpcConnection).toHaveBeenCalledOnce())
+    owner.dispose()
+    owner.clearHttpRoutes()
+
+    const successor = await owner.provision(input)
+    successor.commit('session-1')
+    resolveFirstConnection({ endpoint: 'http://127.0.0.1:1', token: 'stale' })
+    const stale = await staleProvisionPromise
+    stale.release({ ownsStableIdentity: true })
+
+    expect(registerNotebook).toHaveBeenCalledOnce()
+    expect(registerNotebook).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({ token: 'successor' })
+    )
+    expect(unregister).not.toHaveBeenCalled()
+  })
+
+  it('rejects a provision commit from before owner disposal', async () => {
+    const owner = createOwner({ artifacts: undefined, skillImport: undefined })
+    const provision = await owner.provision({
+      stableAppSessionId: 'session-1',
+      framework: opencodeFramework,
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+      sessionCwd: '/workspace',
+      projectName: 'project'
+    })
+
+    owner.dispose()
+
+    expect(() => provision.commit('session-1')).toThrow('provision was superseded')
+    expect(owner.mcpServerNamesFor('session-1')).toEqual([])
+  })
+
+  it('performs only the first terminal provision action', async () => {
+    const release = vi.fn()
+    const registerSessionAlias = vi.fn()
+    const releaseSessionCapabilities = vi.fn()
+    const owner = createOwner({
+      artifacts: undefined,
+      skillImport: undefined,
+      notebook: {
+        projectName: 'project',
+        mcpEntryPath: '/app/main.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:1',
+          token: 'notebook',
+          release
+        }),
+        registerSessionAlias,
+        releaseSessionCapabilities
+      }
+    })
+    const provision = await owner.provision({
+      stableAppSessionId: 'provider-session',
+      framework: opencodeFramework,
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+      sessionCwd: '/workspace',
+      projectName: 'project'
+    })
+
+    provision.release({ ownsStableIdentity: true })
+    provision.release({ ownsStableIdentity: true })
+    provision.commit('app-session')
+
+    expect(release).toHaveBeenCalledOnce()
+    expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
+    expect(releaseSessionCapabilities).toHaveBeenCalledWith('provider-session')
+    expect(registerSessionAlias).not.toHaveBeenCalled()
+    expect(owner.mcpServerNamesFor('app-session')).toEqual([])
+  })
+
+  it('does not broadly revoke stable capability state from a superseded provision', async () => {
+    const firstRelease = vi.fn()
+    const secondRelease = vi.fn()
+    const releaseSessionCapabilities = vi.fn()
+    let provisionIndex = 0
+    const owner = createOwner({
+      artifacts: undefined,
+      skillImport: undefined,
+      notebook: {
+        projectName: 'project',
+        mcpEntryPath: '/app/main.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:1',
+          token: 'notebook',
+          release: [firstRelease, secondRelease][provisionIndex++]
+        }),
+        releaseSessionCapabilities
+      }
+    })
+    const input = {
+      stableAppSessionId: 'session-1',
+      framework: opencodeFramework,
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+      sessionCwd: '/workspace',
+      projectName: 'project'
+    }
+    const first = await owner.provision(input)
+    const second = await owner.provision(input)
+
+    first.release({ ownsStableIdentity: true })
+
+    expect(firstRelease).toHaveBeenCalledOnce()
+    expect(releaseSessionCapabilities).not.toHaveBeenCalled()
+
+    second.commit('session-1')
+    owner.revokeSession('session-1')
+    expect(secondRelease).toHaveBeenCalledOnce()
+    expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
+  })
+
+  it('rejects commit from a superseded stable-identity provision', async () => {
+    const firstRelease = vi.fn()
+    const secondRelease = vi.fn()
+    const releaseSessionCapabilities = vi.fn()
+    let provisionIndex = 0
+    const owner = createOwner({
+      artifacts: undefined,
+      skillImport: undefined,
+      notebook: {
+        projectName: 'project',
+        mcpEntryPath: '/app/main.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:1',
+          token: 'notebook',
+          release: [firstRelease, secondRelease][provisionIndex++]
+        }),
+        releaseSessionCapabilities
+      }
+    })
+    const input = {
+      stableAppSessionId: 'session-1',
+      framework: opencodeFramework,
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+      sessionCwd: '/workspace',
+      projectName: 'project'
+    }
+    const first = await owner.provision(input)
+    const second = await owner.provision(input)
+
+    expect(() => first.commit('stale-session')).toThrow('provision was superseded')
+    expect(firstRelease).toHaveBeenCalledOnce()
+    expect(releaseSessionCapabilities).not.toHaveBeenCalled()
+    expect(owner.mcpServerNamesFor('stale-session')).toEqual([])
+
+    second.commit('session-1')
+    owner.revokeSession('session-1')
+    expect(secondRelease).toHaveBeenCalledOnce()
+    expect(releaseSessionCapabilities).toHaveBeenCalledOnce()
+  })
+
+  it('derives the exact current primary set while reviewer and unknown capabilities fail closed', async () => {
+    const owner = createOwner()
+    const primary = await owner.provision({
+      stableAppSessionId: 'session-1',
+      framework: opencodeFramework,
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+      sessionCwd: '/workspace',
+      projectName: 'project'
+    })
+    const reviewer = await owner.provision({
+      stableAppSessionId: 'reviewer-session',
       framework: opencodeFramework,
       nativeMcpEnabled: true,
       bridgeMcpAliasesEnabled: false,
       policy: REVIEWER_SESSION_CAPABILITY_POLICY,
-      routingIds,
       sessionCwd: '/workspace',
       projectName: 'project'
     })
@@ -106,12 +511,12 @@ describe('ACP session capability owner', () => {
 
   it('returns an immutable, credential-free descriptor', async () => {
     const owner = createOwner()
-    const built = await owner.build({
+    const built = await owner.provision({
+      stableAppSessionId: 'session-1',
       framework: opencodeFramework,
       nativeMcpEnabled: true,
       bridgeMcpAliasesEnabled: false,
       policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-      routingIds: owner.createRoutingIds('session-1'),
       sessionCwd: '/workspace',
       projectName: 'project'
     })
@@ -129,39 +534,49 @@ describe('ACP session capability owner', () => {
     const firstSkillImportRelease = vi.fn()
     const secondSkillImportRelease = vi.fn()
     const releaseSessionCapabilities = vi.fn()
+    let notebookProvision = 0
+    let skillImportProvision = 0
     const owner = createOwner({
       notebook: {
         projectName: 'project',
         mcpEntryPath: '/app/main.js',
-        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:1', token: 'notebook' }),
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:1',
+          token: 'notebook',
+          release: [firstRelease, secondRelease][notebookProvision++]
+        }),
         releaseSessionCapabilities
+      },
+      skillImport: {
+        mcpEntryPath: '/app/main.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:2',
+          token: 'skill',
+          release: [firstSkillImportRelease, secondSkillImportRelease][skillImportProvision++]
+        })
       }
     })
-    const routingIds = owner.createRoutingIds('session-1')
-    const built = await owner.build({
+    const first = await owner.provision({
+      stableAppSessionId: 'session-1',
       framework: opencodeFramework,
       nativeMcpEnabled: true,
       bridgeMcpAliasesEnabled: false,
       policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-      routingIds,
+      sessionCwd: '/workspace',
+      projectName: 'project'
+    })
+    first.commit('session-1')
+    const second = await owner.provision({
+      stableAppSessionId: 'session-1',
+      framework: opencodeFramework,
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
       sessionCwd: '/workspace',
       projectName: 'project'
     })
 
-    owner.commit({
-      appSessionId: 'session-1',
-      routingIds,
-      descriptor: built.descriptor,
-      notebookRelease: firstRelease,
-      skillImportRelease: firstSkillImportRelease
-    })
-    owner.commit({
-      appSessionId: 'session-1',
-      routingIds,
-      descriptor: built.descriptor,
-      notebookRelease: secondRelease,
-      skillImportRelease: secondSkillImportRelease
-    })
+    second.commit('session-1')
 
     expect(firstRelease).toHaveBeenCalledOnce()
     expect(firstSkillImportRelease).toHaveBeenCalledOnce()
@@ -190,17 +605,16 @@ describe('ACP session capability owner', () => {
       close
     } as unknown as AgentMcpHttpHost
     const owner = createOwner({ mcpHttpHost: host })
-    const routingIds = owner.createRoutingIds('session-1')
-    const built = await owner.build({
+    const provision = await owner.provision({
+      stableAppSessionId: 'session-1',
       framework: { ...opencodeFramework, acceptsStdioMcp: false },
       nativeMcpEnabled: true,
       bridgeMcpAliasesEnabled: false,
       policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-      routingIds,
       sessionCwd: '/workspace',
       projectName: 'project'
     })
-    owner.commit({ appSessionId: 'session-1', routingIds, descriptor: built.descriptor })
+    provision.commit('session-1')
 
     owner.revokeSession('session-1')
 
@@ -229,26 +643,24 @@ describe('ACP session capability owner', () => {
       notebook: {
         projectName: 'project',
         mcpEntryPath: '/app/main.js',
-        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:1', token: 'notebook' }),
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:1',
+          token: 'notebook',
+          release: notebookRelease
+        }),
         releaseSessionCapabilities
       }
     })
-    const routingIds = owner.createRoutingIds('session-1')
-    const built = await owner.build({
+    const provision = await owner.provision({
+      stableAppSessionId: 'session-1',
       framework: { ...opencodeFramework, acceptsStdioMcp: false },
       nativeMcpEnabled: true,
       bridgeMcpAliasesEnabled: false,
       policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-      routingIds,
       sessionCwd: '/workspace',
       projectName: 'project'
     })
-    owner.commit({
-      appSessionId: 'session-1',
-      routingIds,
-      descriptor: built.descriptor,
-      notebookRelease
-    })
+    provision.commit('session-1')
 
     expect(() => owner.revokeSession('session-1')).not.toThrow()
     expect(unregister).toHaveBeenCalledOnce()

--- a/src/main/acp/session-capability-owner.ts
+++ b/src/main/acp/session-capability-owner.ts
@@ -73,7 +73,7 @@ export type EffectiveSessionCapabilityDescriptor = Readonly<{
   controlRpcMethods: readonly string[]
 }>
 
-export type SessionCapabilityRoutingIds = Readonly<{
+type SessionCapabilityRoutingIds = Readonly<{
   artifact: string
   notebook: string
   skillImport: string
@@ -108,21 +108,45 @@ export type SessionCapabilitySkillImportOptions = {
   releaseSessionCapabilities?: (sessionId: string) => void
 }
 
-export type BuildSessionCapabilitiesRequest = {
+type BuildSessionCapabilitiesRequest = {
   framework: Pick<AgentFramework, 'id' | 'acceptsStdioMcp'>
   nativeMcpEnabled: boolean
   bridgeMcpAliasesEnabled: boolean
   policy: SessionCapabilityPolicy
   routingIds: SessionCapabilityRoutingIds
+  routingOwner: object
+  provisionGeneration: number
   sessionCwd: string
   projectName: string
   onNotebookConnection?: (connection: NotebookRpcConnection) => void
   onSkillImportConnection?: (connection: SkillImportRpcConnection) => void
 }
 
-export type BuiltSessionCapabilities = Readonly<{
+type BuiltSessionCapabilities = Readonly<{
   mcpServers: McpServer[]
   descriptor: EffectiveSessionCapabilityDescriptor
+}>
+
+export type ProvisionSessionCapabilitiesRequest = Omit<
+  BuildSessionCapabilitiesRequest,
+  | 'routingIds'
+  | 'routingOwner'
+  | 'provisionGeneration'
+  | 'onNotebookConnection'
+  | 'onSkillImportConnection'
+> & {
+  stableAppSessionId?: string
+}
+
+export type SessionCapabilityOwnershipFacts = Readonly<{
+  ownsStableIdentity: boolean
+}>
+
+export type SessionCapabilityProvision = Readonly<{
+  mcpServers: McpServer[]
+  descriptor: EffectiveSessionCapabilityDescriptor
+  commit: (appSessionId: string) => void
+  release: (ownershipFacts: SessionCapabilityOwnershipFacts) => void
 }>
 
 type CommitSessionCapabilitiesRequest = {
@@ -184,6 +208,8 @@ export class AcpSessionCapabilityOwner {
   private readonly skillImportCapabilityReleases = new Map<string, () => void>()
   private readonly descriptors = new Map<string, EffectiveSessionCapabilityDescriptor>()
   private readonly committedSessionIds = new Set<string>()
+  private readonly provisionalRoutingOwners = new Map<string, object>()
+  private provisionalGeneration = 0
   private artifactSessionSequence = 0
   private notebookSessionSequence = 0
   private skillImportSessionSequence = 0
@@ -191,7 +217,107 @@ export class AcpSessionCapabilityOwner {
 
   constructor(private readonly options: SessionCapabilityOwnerOptions) {}
 
-  createRoutingIds(stableAppSessionId?: string): SessionCapabilityRoutingIds {
+  async provision(
+    request: ProvisionSessionCapabilitiesRequest
+  ): Promise<SessionCapabilityProvision> {
+    const routingIds = this.createRoutingIds(request.stableAppSessionId)
+    const routingOwner = this.trackProvisionalRoutingOwner(routingIds)
+    const provisionGeneration = this.provisionalGeneration
+    let notebookRelease: (() => void) | undefined
+    let skillImportRelease: (() => void) | undefined
+    let built: BuiltSessionCapabilities
+    try {
+      built = await this.build({
+        framework: request.framework,
+        nativeMcpEnabled: request.nativeMcpEnabled,
+        bridgeMcpAliasesEnabled: request.bridgeMcpAliasesEnabled,
+        policy: request.policy,
+        routingIds,
+        routingOwner,
+        provisionGeneration,
+        sessionCwd: request.sessionCwd,
+        projectName: request.projectName,
+        onNotebookConnection: (connection) => {
+          notebookRelease = connection.release
+        },
+        onSkillImportConnection: (connection) => {
+          skillImportRelease = connection.release
+        }
+      })
+    } catch (error) {
+      const ownsStableIdentity = this.ownsProvisionalRoutingIds(routingIds, routingOwner)
+      this.revokeProvisional({
+        routingIds: [routingIds.artifact, routingIds.notebook, routingIds.skillImport],
+        usedHttpTransport: ownsStableIdentity && !request.framework.acceptsStdioMcp,
+        notebookSessionId: routingIds.notebook || undefined,
+        notebookRelease,
+        skillImportRelease,
+        ownsStableIdentity
+      })
+      this.finishProvisionalRoutingOwner(routingIds, routingOwner)
+      throw error
+    }
+    let terminal = false
+
+    return Object.freeze({
+      ...built,
+      commit: (appSessionId: string): void => {
+        if (terminal) return
+        terminal = true
+        const ownsRoutingIds = this.ownsProvisionalRoutingIds(routingIds, routingOwner)
+        if (provisionGeneration !== this.provisionalGeneration) {
+          this.revokeProvisional({
+            routingIds: [routingIds.artifact, routingIds.notebook, routingIds.skillImport],
+            usedHttpTransport: ownsRoutingIds && !request.framework.acceptsStdioMcp,
+            notebookSessionId: routingIds.notebook || undefined,
+            notebookRelease,
+            skillImportRelease,
+            ownsStableIdentity: ownsRoutingIds
+          })
+          this.finishProvisionalRoutingOwner(routingIds, routingOwner)
+          throw new Error('ACP session capability provision was superseded.')
+        }
+        if (!ownsRoutingIds) {
+          this.revokeProvisional({
+            routingIds: [],
+            usedHttpTransport: false,
+            notebookSessionId: routingIds.notebook || undefined,
+            notebookRelease,
+            skillImportRelease,
+            ownsStableIdentity: false
+          })
+          this.finishProvisionalRoutingOwner(routingIds, routingOwner)
+          throw new Error('ACP session capability provision was superseded.')
+        }
+        this.commit({
+          appSessionId,
+          routingIds,
+          descriptor: built.descriptor,
+          notebookRelease,
+          skillImportRelease
+        })
+        this.finishProvisionalRoutingOwner(routingIds, routingOwner)
+      },
+      release: (ownershipFacts: SessionCapabilityOwnershipFacts): void => {
+        if (terminal) return
+        terminal = true
+        const ownsStableIdentity =
+          ownershipFacts.ownsStableIdentity &&
+          this.ownsProvisionalRoutingIds(routingIds, routingOwner)
+        this.revokeProvisional({
+          routingIds: [routingIds.artifact, routingIds.notebook, routingIds.skillImport],
+          usedHttpTransport: ownsStableIdentity && !request.framework.acceptsStdioMcp,
+          notebookSessionId: routingIds.notebook || undefined,
+          notebookRelease,
+          skillImportRelease,
+          ownsStableIdentity
+        })
+        this.finishProvisionalRoutingOwner(routingIds, routingOwner)
+      }
+    })
+  }
+
+  private createRoutingIds(stableAppSessionId?: string): SessionCapabilityRoutingIds {
     if (stableAppSessionId) {
       return Object.freeze({
         artifact: this.options.artifacts ? stableAppSessionId : '',
@@ -218,7 +344,7 @@ export class AcpSessionCapabilityOwner {
     })
   }
 
-  async build(request: BuildSessionCapabilitiesRequest): Promise<BuiltSessionCapabilities> {
+  private async build(request: BuildSessionCapabilitiesRequest): Promise<BuiltSessionCapabilities> {
     const transport = request.framework.acceptsStdioMcp
       ? 'stdio'
       : this.options.mcpHttpHost
@@ -290,7 +416,7 @@ export class AcpSessionCapabilityOwner {
     return Object.freeze({ mcpServers: modelFacingServers, descriptor })
   }
 
-  commit(request: CommitSessionCapabilitiesRequest): void {
+  private commit(request: CommitSessionCapabilitiesRequest): void {
     const { appSessionId, routingIds, descriptor } = request
     if (routingIds.artifact) this.artifactRoutingIds.set(appSessionId, routingIds.artifact)
     if (routingIds.notebook) {
@@ -317,7 +443,7 @@ export class AcpSessionCapabilityOwner {
     this.commitSkillImportRelease(appSessionId, request.skillImportRelease)
   }
 
-  revokeProvisional(request: RevokeProvisionalSessionCapabilitiesRequest): void {
+  private revokeProvisional(request: RevokeProvisionalSessionCapabilitiesRequest): void {
     if (request.usedHttpTransport && this.options.mcpHttpHost) {
       for (const routingId of new Set(request.routingIds)) {
         if (!routingId) continue
@@ -390,6 +516,7 @@ export class AcpSessionCapabilityOwner {
   }
 
   dispose(sessionIds: Iterable<string> = []): void {
+    this.provisionalGeneration += 1
     const ownedSessionIds = new Set([
       ...sessionIds,
       ...this.artifactRoutingIds.keys(),
@@ -412,6 +539,8 @@ export class AcpSessionCapabilityOwner {
     this.skillImportCapabilityReleases.clear()
     this.descriptors.clear()
     this.committedSessionIds.clear()
+    // In-flight provisions retain terminal cleanup ownership across teardown. A same-id successor
+    // supersedes that ownership when it starts provisioning.
   }
 
   clearHttpRoutes(): void {
@@ -599,7 +728,7 @@ export class AcpSessionCapabilityOwner {
         request.sessionCwd,
         request.projectName
       )
-      if (environment) {
+      if (environment && this.canPublishHttpRoute(request)) {
         host.registerArtifact(request.routingIds.artifact, environment)
         servers.push({
           type: 'http',
@@ -616,7 +745,7 @@ export class AcpSessionCapabilityOwner {
         request.projectName,
         request.onNotebookConnection
       )
-      if (environment) {
+      if (environment && this.canPublishHttpRoute(request)) {
         host.registerNotebook(request.routingIds.notebook, environment)
         servers.push({
           type: 'http',
@@ -631,7 +760,7 @@ export class AcpSessionCapabilityOwner {
         request.routingIds.skillImport,
         request.onSkillImportConnection
       )
-      if (environment) {
+      if (environment && this.canPublishHttpRoute(request)) {
         host.registerSkillImport(request.routingIds.skillImport, environment)
         servers.push({
           type: 'http',
@@ -642,6 +771,42 @@ export class AcpSessionCapabilityOwner {
       }
     }
     return servers
+  }
+
+  private canPublishHttpRoute(request: BuildSessionCapabilitiesRequest): boolean {
+    return (
+      request.provisionGeneration === this.provisionalGeneration &&
+      this.ownsProvisionalRoutingIds(request.routingIds, request.routingOwner)
+    )
+  }
+
+  private trackProvisionalRoutingOwner(routingIds: SessionCapabilityRoutingIds): object {
+    const owner = {}
+    for (const routingId of new Set(Object.values(routingIds))) {
+      if (routingId) this.provisionalRoutingOwners.set(routingId, owner)
+    }
+    return owner
+  }
+
+  private ownsProvisionalRoutingIds(
+    routingIds: SessionCapabilityRoutingIds,
+    owner: object
+  ): boolean {
+    for (const routingId of new Set(Object.values(routingIds))) {
+      if (routingId && this.provisionalRoutingOwners.get(routingId) !== owner) return false
+    }
+    return true
+  }
+
+  private finishProvisionalRoutingOwner(
+    routingIds: SessionCapabilityRoutingIds,
+    owner: object
+  ): void {
+    for (const routingId of new Set(Object.values(routingIds))) {
+      if (routingId && this.provisionalRoutingOwners.get(routingId) === owner) {
+        this.provisionalRoutingOwners.delete(routingId)
+      }
+    }
   }
 
   private registerAlias(


### PR DESCRIPTION
## Problem

Runtime manually retained capability routing IDs, release callbacks, HTTP/provisional flags, and build/commit/revoke choreography across Session create, resume, and adoption. That split lifetime ownership between Runtime and `AcpSessionCapabilityOwner`.

Related: #458. This PR only establishes a forward resource-ownership constraint for possible future orchestration; it does not add Issue #458 orchestration data, schema, public API/wire contracts, or user-visible behavior.

## Proposed change

- Deepen `AcpSessionCapabilityOwner` with `provision(...) -> SessionCapabilityProvision`.
- Expose only MCP payload/descriptor plus one terminal `commit(appId)` or `release(ownershipFacts)` action.
- Clean partial stdio/HTTP provisioning failures inside the owner and fence stale same-ID release and commit operations.
- Cut Runtime create, resume, and fresh-adoption paths over to the opaque handle.
- Replace low-level owner tests and the superseded Runtime unregister-count probe with interface-level behavior coverage.

## Scope and non-goals

- ARD-05 only; production edits are limited to the capability owner and Runtime call-site cutover.
- No schema/data, IPC/preload, Web RPC v1, Task HTTP/WebSocket, CLI/SDK, UI, Specialist, Permission, Compute, MCP naming/alias, transport-selection, Notebook/Artifact/Skill-import, Reviewer/Artifact, or terminal-fact behavior changes.
- No Issue #458 orchestration implementation.
- Exact production raw was recorded as **373 additions plus deletions**, below the >500 hard stop.

## Ownership and sequence

`AcpSessionCapabilityOwner` owns provisional and committed capability resources. Runtime receives an opaque, single-use provision handle and never retains routing IDs, low-level release callbacks, or provisional transport flags.

```mermaid
stateDiagram-v2
  [*] --> Provisioning: owner.provision
  Provisioning --> Released: partial build failure / release
  Provisioning --> Committed: commit(appId)
  Committed --> Revoked: owner revoke
  Released --> [*]
  Revoked --> [*]
  Committed --> Committed: stale same-ID release fenced
  Released --> Released: repeated terminal action is inert
```

The handle exposes exactly one terminal path: `commit(appId)` or `release(ownershipFacts)`. Partial stdio/HTTP provisioning failures clean up inside the owner, and stable-identity fencing prevents a stale provision from revoking a successor.

## Acceptance criteria and validation

All recorded checks ran after the last material edit:

- Provision lifecycle, build failure, partial HTTP/local RPC cleanup, commit/release one-shot behavior, stable-identity fencing, committed revoke → `npm test -- src/main/acp/session-capability-owner.test.ts` → **12 passed**.
- Runtime create/resume/adopt, delete/disconnect, MCP names/transports, host agents binding, Specialist/Permission/Reviewer/Artifact/terminal compatibility → `npm test -- src/main/acp/runtime.test.ts` → **393 passed**.
- Coordinator ownership/adoption contracts → `npm test -- src/main/acp/runtime-coordinator.test.ts` → **51 passed**.
- Notebook capability rotation/alias cleanup plus host integration → combined focused command → **22 passed; 4 existing platform-gated host integration cases skipped**. The historical description did not record the exact combined command text.
- Node contracts → `npm run typecheck:node` → passed.
- Source lint → `npm run lint` → 0 errors; 17 pre-existing warnings outside changed files.
- Changed-file format → Prettier check → passed; the historical description did not record the exact command.
- Diff integrity → `git diff --check origin/main...HEAD` → passed.
- Independent Standards review → no findings.
- Independent Spec review → no findings after the stale-commit fencing fix.
- Final-head online gates → PR Gate, AI review, CodeQL, Static checks, Unit tests, Coverage macOS, macOS build/E2E, and Windows E2E all passed. `Windows core` was skipped by classification.

No full local suite was run under the approved leaf delivery policy. Consumer coverage included the owner, Runtime, Coordinator, Notebook capability rotation, and host integration contracts. The final-head online PR Gate is the authoritative full and cross-platform validation.

## Review focus

- One-writer resource ownership in the provision handle.
- Exact-once terminal behavior and partial-failure cleanup.
- Same-ID supersession safety during resume/adoption cleanup.
- Absence of retained low-level capability handles in Runtime.

## Uncovered risks

The historical record does not preserve the exact combined Notebook/host command or the exact Prettier invocation. A full local portable suite was not run. Real transport/platform behavior and the omitted full regression breadth are covered only by the final-head online gates. Issue #458 integration remains deferred.
