### PR TITLE
fix(specialists): make contribution template path test portable

### DIFF
--- a/src/main/specialist/package/contribution-template.test.ts
+++ b/src/main/specialist/package/contribution-template.test.ts
@@ -109,7 +109,7 @@ describe('contribution template ZIP', () => {
       join(repositoryRoot, 'resources', 'specialists', 'template', 'v1', 'README.txt')
     )
     expect(packagedPath).toContain(
-      '/app.asar.unpacked/resources/specialists/template/v1/README.txt'
+      join('app.asar.unpacked', 'resources', 'specialists', 'template', 'v1', 'README.txt')
     )
   })
 


### PR DESCRIPTION
## Problem

The Windows full-test lane fails in `contribution-template.test.ts` because the assertion hardcodes POSIX `/` separators while `node:path.join` correctly returns Windows `\` separators. The production path already contains `app.asar.unpacked`; only the test expectation is non-portable.

Related run: https://github.com/aipoch/open-science/actions/runs/30911532302/job/91999231786

## Proposed change

Build the expected packaged-resource suffix with the existing `node:path.join` import so the assertion follows the host platform's path semantics.

## Scope and non-goals

- Test-only one-line change; no production code changes.
- No architecture, data model, data relationship, or user interaction changes.
- No new dependency or abstraction.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- Contribution-template path behavior -> `npm test -- src/main/specialist/package/contribution-template.test.ts` -> passed (1 file, 6 tests).
- Portable Vitest suite -> `npm test` -> passed outside the filesystem sandbox (751 files passed, 15 skipped; 11,134 tests passed, 184 skipped).
- Real Windows full suite -> [Windows Full Test run 30914186764](https://github.com/aipoch/open-science/actions/runs/30914186764) -> passed both shards on Node 22 / `windows-latest` (shard 1 in 19m32s; shard 2 in 13m48s).
- Linted source -> `npm run lint` -> passed with 0 errors (17 pre-existing warnings outside this change).
- Diff hygiene -> `git diff --check` -> passed.

The manually dispatched Windows Full Test advisory workflow is included because Windows is the affected platform and provides the independent platform check that PR Gate's skipped `Windows core` lane does not. Runtime consumer tests, typechecks, and E2E lanes are excluded from the local impact set because the final diff changes only a test expectation and no interface or runtime code. No fix-specific risk remains uncovered after both real-Windows shards passed.

## Review focus

Confirm that deriving the expected suffix with `join(...)` preserves the original assertion while making it separator-portable.
