### PR TITLE
refactor(acp): extract startup session configurator

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -8493,8 +8493,14 @@ describe('ACP runtime session management', () => {
   it('does not let stale permission setup target a same-id successor connection', async () => {
     const oldProcess = new FakeAgentProcess()
     const newProcess = new FakeAgentProcess()
+    const permissionSetupStarted = createDeferred()
+    const releasePermissionSetup = createDeferred()
     startFakeAgent(oldProcess, ['shared-primary'], {
-      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onSetMode: async () => {
+        permissionSetupStarted.resolve()
+        await releasePermissionSetup.promise
+      }
     })
     const newAgent = startFakeAgent(newProcess, ['shared-primary'], {
       modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
@@ -8514,17 +8520,6 @@ describe('ACP runtime session management', () => {
           env: {}
         }
       }
-    })
-    const permissionSetupStarted = createDeferred()
-    const releasePermissionSetup = createDeferred()
-    const internal = runtime as unknown as {
-      configurePermissionProfile: (...args: unknown[]) => Promise<unknown>
-    }
-    const configurePermissionProfile = internal.configurePermissionProfile.bind(runtime)
-    vi.spyOn(internal, 'configurePermissionProfile').mockImplementationOnce(async (...args) => {
-      permissionSetupStarted.resolve()
-      await releasePermissionSetup.promise
-      return configurePermissionProfile(...args)
     })
 
     const stale = runtime.createSession({
@@ -10377,10 +10372,17 @@ describe('ACP runtime session management', () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, [])
     const releaseSessionCapabilities = vi.fn()
+    const failure = new Error('resumed permission setup failed')
+    const mapPermissionProfile = vi
+      .fn(claudeCodeFramework.mapPermissionProfile)
+      .mockImplementationOnce(() => {
+        throw failure
+      })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
+      framework: { ...claudeCodeFramework, mapPermissionProfile },
       notebook: {
         projectName: 'default-project',
         mcpEntryPath: '/app/out/main/index.js',
@@ -10391,11 +10393,6 @@ describe('ACP runtime session management', () => {
         releaseSessionCapabilities
       }
     })
-    const failure = new Error('resumed permission setup failed')
-    vi.spyOn(
-      runtime as unknown as { configurePermissionProfile: () => Promise<void> },
-      'configurePermissionProfile'
-    ).mockRejectedValueOnce(failure)
     const disposeSpy = vi
       .spyOn(acp.ActiveSession.prototype, 'dispose')
       .mockImplementationOnce(() => {
@@ -10425,10 +10422,17 @@ describe('ACP runtime session management', () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['adopted-session', 'adopted-session'])
     const releaseSessionCapabilities = vi.fn()
+    const failure = new Error('adopted permission setup failed')
+    const mapPermissionProfile = vi
+      .fn(claudeCodeFramework.mapPermissionProfile)
+      .mockImplementationOnce(() => {
+        throw failure
+      })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
+      framework: { ...claudeCodeFramework, mapPermissionProfile },
       notebook: {
         projectName: 'default-project',
         mcpEntryPath: '/app/out/main/index.js',
@@ -10439,11 +10443,6 @@ describe('ACP runtime session management', () => {
         releaseSessionCapabilities
       }
     })
-    const failure = new Error('adopted permission setup failed')
-    vi.spyOn(
-      runtime as unknown as { configurePermissionProfile: () => Promise<void> },
-      'configurePermissionProfile'
-    ).mockRejectedValueOnce(failure)
     const disposeSpy = vi
       .spyOn(acp.ActiveSession.prototype, 'dispose')
       .mockImplementationOnce(() => {
@@ -16856,22 +16855,21 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
     errorLogSpy.mockClear()
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['perm-fail-session', 'perm-fail-session'])
+    const boom = Object.assign(new Error('permission setup failed'), { code: 'EPERM' })
+    const mapPermissionProfile = vi
+      .fn(claudeCodeFramework.mapPermissionProfile)
+      .mockImplementationOnce(() => {
+        throw boom
+      })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
+      spawnAgent: () => asAgentProcess(process),
+      framework: { ...claudeCodeFramework, mapPermissionProfile }
     })
-    // Force the permission-profile step to throw after the session is built.
-    const boom = Object.assign(new Error('permission setup failed'), { code: 'EPERM' })
-    vi.spyOn(
-      runtime as unknown as { configurePermissionProfile: () => Promise<void> },
-      'configurePermissionProfile'
-    ).mockRejectedValueOnce(boom)
 
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toBe(boom)
-    const call = errorLogSpy.mock.calls.find(
-      ([message]) => message === 'createSession: configurePermissionProfile failed'
-    )
+    const call = errorLogSpy.mock.calls.find(([message]) => message === 'createSession: failed')
     expect(call).toBeDefined()
     expect(call?.[1]).toEqual({
       errorCategory: 'permission',
@@ -16889,10 +16887,17 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['perm-fail-session'])
     const releaseSessionCapabilities = vi.fn()
+    const failure = new Error('permission setup failed')
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
+      framework: {
+        ...claudeCodeFramework,
+        mapPermissionProfile: () => {
+          throw failure
+        }
+      },
       notebook: {
         projectName: 'default-project',
         mcpEntryPath: '/app/out/main/index.js',
@@ -16903,11 +16908,6 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
         releaseSessionCapabilities
       }
     })
-    const failure = new Error('permission setup failed')
-    vi.spyOn(
-      runtime as unknown as { configurePermissionProfile: () => Promise<void> },
-      'configurePermissionProfile'
-    ).mockRejectedValueOnce(failure)
 
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toBe(failure)
 
@@ -16922,10 +16922,17 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
     startFakeAgent(process, ['perm-fail-session'])
     const release = vi.fn()
     const releaseSessionCapabilities = vi.fn()
+    const failure = new Error('permission setup failed')
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
+      framework: {
+        ...claudeCodeFramework,
+        mapPermissionProfile: () => {
+          throw failure
+        }
+      },
       notebook: {
         projectName: 'default-project',
         mcpEntryPath: '/app/out/main/index.js',
@@ -16937,11 +16944,6 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
         releaseSessionCapabilities
       }
     })
-    const failure = new Error('permission setup failed')
-    vi.spyOn(
-      runtime as unknown as { configurePermissionProfile: () => Promise<void> },
-      'configurePermissionProfile'
-    ).mockRejectedValueOnce(failure)
 
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toBe(failure)
 
@@ -17407,16 +17409,18 @@ describe('ACP runtime — failure-path robustness (errorMessage coercion + sync-
   it('re-throws the permission-profile failure even when the logger throws', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['perm-log-session'])
+    const boom = new Error('permission setup failed')
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
+      spawnAgent: () => asAgentProcess(process),
+      framework: {
+        ...claudeCodeFramework,
+        mapPermissionProfile: () => {
+          throw boom
+        }
+      }
     })
-    const boom = new Error('permission setup failed')
-    vi.spyOn(
-      runtime as unknown as { configurePermissionProfile: () => Promise<void> },
-      'configurePermissionProfile'
-    ).mockRejectedValueOnce(boom)
     errorLogSpy.mockImplementation(() => {
       throw new Error('logger boom')
     })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -42,7 +42,6 @@ import { ACP_PROMPT_FAILED_EVENT_TITLE } from '../../shared/acp'
 import {
   DEFAULT_PERMISSION_PROFILE,
   normalizePermissionProfile,
-  type PermissionProfileId,
   type SessionPermissionProfileState
 } from '../../shared/permission-profiles'
 import { type AgentFrameworkId } from '../../shared/settings'
@@ -65,11 +64,7 @@ import {
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { toCodexTurnTokenUsage } from './codex-turn-usage'
 import { fetchOpenCodeUsageSnapshot, sumOpenCodeTurnUsage } from './opencode-turn-usage'
-import {
-  matchSessionModelOption,
-  resolveSessionEffortOption,
-  type SessionModelSelection
-} from './session-config'
+import { resolveSessionEffortOption, type SessionModelSelection } from './session-config'
 import { describePromptError, isProviderPromptError } from './prompt-error'
 import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { ConversationPermissionGrantStore } from './permission-broker'
@@ -142,6 +137,7 @@ import {
   type AcpBackendGenerationAttempt,
   type AcpBackendGenerationView
 } from './backend-generation-owner'
+import { AcpSessionConfigurator, type AcpSessionConfigurationFacts } from './session-configurator'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -227,11 +223,6 @@ type AcpRuntimeSkillsOptions = {
   // Lists only enabled, materialized app-owned Skills from the active isolated Codex home. The
   // Chat Completions compatibility selector receives name + description; paths remain local.
   catalogForCodexHome?: (codexHome: string | undefined) => Promise<ResponsesBridgeSkillCandidate[]>
-}
-
-type SessionModelApplication = {
-  appliedModel: string | undefined
-  configOptions: SessionConfigOption[] | null | undefined
 }
 
 type AcpRuntimeArtifactOptions = {
@@ -537,6 +528,7 @@ class AcpRuntime {
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
   private readonly skillsHooks: AcpRuntimeSkillsOptions | undefined
   private readonly backendGeneration: AcpBackendGenerationOwner
+  private readonly sessionConfigurator: AcpSessionConfigurator
   private readonly codexSkillActivity = new CodexSkillActivityProjector()
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
@@ -576,6 +568,10 @@ class AcpRuntime {
     this.spawnAgent = options.spawnAgent
     this.skillsHooks = options.skills
     this.backendGeneration = new AcpBackendGenerationOwner(options.framework ?? claudeCodeFramework)
+    this.sessionConfigurator = new AcpSessionConfigurator({
+      assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
+      diagnosticContext: (backend) => this.diagnosticContext(backend.framework.id)
+    })
     this.resumeTimeoutMs = options.resumeTimeoutMs ?? 30_000
     this.contextUsageTracker = options.contextUsageTracker ?? new ContextUsageTracker()
     this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
@@ -870,143 +866,6 @@ class AcpRuntime {
   // turn is still writing, while a crashed run — absent here — correctly surfaces as orphaned.
   getActiveArtifactRunIds(): string[] {
     return this.artifactTurns?.activeRunIds() ?? []
-  }
-
-  // Resolves an application profile against per-session ACP capabilities and applies the real Agent
-  // mode before any prompt is sent. The selected/effective projection is then shared with the UI and
-  // the conservative fallback reviewer.
-  private async applyPermissionProfileMode(
-    session: ActiveSession,
-    profile: PermissionProfileId,
-    connection: ClientConnection | undefined = this.connection
-  ): Promise<SessionPermissionProfileState> {
-    const application = this.framework.mapPermissionProfile(profile, session.modes)
-
-    if (application.modeId && application.modeId !== session.modes?.currentModeId) {
-      if (!connection) throw new Error('ACP connection is not available.')
-      this.assertCurrentConnectedConnection(connection)
-
-      await connection.agent.request(acp.methods.agent.session.setMode, {
-        sessionId: session.sessionId,
-        modeId: application.modeId
-      })
-    }
-
-    log.info('permission profile applied', this.diagnosticContext())
-    return application.state
-  }
-
-  private async configurePermissionProfile(
-    appSessionId: string,
-    session: ActiveSession,
-    profile: PermissionProfileId,
-    commit = true,
-    connection: ClientConnection | undefined = this.connection
-  ): Promise<SessionPermissionProfileState> {
-    const state = await this.applyPermissionProfileMode(session, profile, connection)
-    if (commit) {
-      if (this.activeSessionFor(appSessionId) !== session) {
-        throw new Error('ACP session startup was superseded.')
-      }
-      if (connection) this.assertCurrentConnectedConnection(connection)
-      this.sessionRegistry.lookup(appSessionId)?.aggregate.setPermissionProfile(state)
-    }
-    return state
-  }
-
-  // Applies the active model to a freshly built/resumed session via the ACP model configOption, for
-  // frameworks that select the model over the protocol (opencode). No-op for env-driven frameworks
-  // (generation Session model undefined). Optional selections keep the default when no matching option
-  // exists or application fails; required selections fail visibly rather than silently running another
-  // model. Returns the agent's post-application configOptions when it reports them — effort levels are
-  // model-dependent, so callers resolving further options must use the set from AFTER the model switch.
-  private async applySessionModel(
-    session: ActiveSession,
-    connection: ClientConnection | undefined = this.connection
-  ): Promise<SessionModelApplication> {
-    const model = this.backend.session.model
-    if (!model || !connection) {
-      return { appliedModel: undefined, configOptions: undefined }
-    }
-
-    const configOptions = (
-      session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } }
-    ).newSessionResponse?.configOptions
-    const selection = matchSessionModelOption(configOptions, model)
-
-    if (!selection) {
-      log.info('no matching session model option', this.diagnosticContext())
-      if (this.backend.session.modelRequired) {
-        throw new Error(`The selected model "${model}" is not available for this Codex account.`)
-      }
-      return { appliedModel: undefined, configOptions: undefined }
-    }
-
-    // The agent already has the desired model — typically because the framework seeded it via
-    // CODEX_CONFIG (codex-isolated subscription) or because the previous call landed on it. Skip the
-    // redundant session/set_config_option round-trip: codex-acp reloads on every call, and even
-    // sending the same value back stalled the first prompt of a new session for ~2 min (issue #277).
-    if (selection.alreadyCurrent) {
-      log.info('session model already current', this.diagnosticContext())
-      return { appliedModel: selection.value, configOptions: configOptions ?? null }
-    }
-
-    this.assertCurrentConnectedConnection(connection)
-    try {
-      const response = (await connection.agent.request(acp.methods.agent.session.setConfigOption, {
-        sessionId: session.sessionId,
-        configId: selection.configId,
-        value: selection.value
-      })) as { configOptions?: SessionConfigOption[] | null }
-      log.info('session model applied', this.diagnosticContext())
-      // The model switch rebuilds the agent's options (effort rungs are model-dependent). The
-      // caller commits the fresh set to latestSessionConfigOptions once the session is registered,
-      // so the map never holds an entry for a session that failed to attach.
-      return {
-        appliedModel: selection.value,
-        configOptions: response?.configOptions ?? configOptions
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      log.warn('set session model failed', {
-        ...diagnosticErrorFields(error),
-        ...this.diagnosticContext()
-      })
-      if (this.backend.session.modelRequired) {
-        throw new Error(`The selected model "${model}" could not be applied: ${message}`)
-      }
-      return { appliedModel: undefined, configOptions: undefined }
-    }
-  }
-
-  // Applies the user's reasoning-effort preference to a freshly built/resumed session via the ACP
-  // thought_level configOption. No-op when the generation view has no explicit effort level —
-  // the agent then keeps its own default) or when the agent advertises no effort option. The desired
-  // level is already resolved by the model profile and therefore only an exact advertised match is
-  // sent. `configOptions` should be the agent's latest option set (e.g. returned by a model switch
-  // just before); falls back to the session's original response. Best-effort: a failure is logged,
-  // never fatal to the session.
-  private async applySessionEffort(
-    session: ActiveSession,
-    configOptions?: SessionConfigOption[] | null,
-    connection: ClientConnection | undefined = this.connection
-  ): Promise<void> {
-    const effort = this.backend.session.effort
-    if (!effort || !connection) return
-
-    const effectiveOptions =
-      configOptions ??
-      (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
-        .newSessionResponse?.configOptions
-    const selection = resolveSessionEffortOption(effectiveOptions, effort)
-
-    if (!selection) {
-      log.info('no session effort option to apply', this.diagnosticContext())
-      return
-    }
-
-    this.assertCurrentConnectedConnection(connection)
-    await this.sendSessionEffort(session, selection, connection)
   }
 
   // Live-applies a reasoning-effort change to every open session — the ACP equivalent of a model
@@ -1466,26 +1325,14 @@ class AcpRuntime {
       primaryIdentityReservation = reservationResult.reservation
 
       log.info('createSession: configurePermissionProfile', this.diagnosticContext())
-      let permissionState: SessionPermissionProfileState
-      try {
-        permissionState = await this.configurePermissionProfile(
-          session.sessionId,
-          session,
-          normalizePermissionProfile(request.permissionProfile),
-          false,
-          connection
-        )
-      } catch (error) {
-        safeLogError('createSession: configurePermissionProfile failed', {
-          ...diagnosticErrorFields(error),
-          ...this.diagnosticContext()
-        })
-        throw error
-      }
-
       log.info('createSession: applySessionModel', this.diagnosticContext())
-      const modelApplication = await this.applySessionModel(session, connection)
-      await this.applySessionEffort(session, modelApplication.configOptions, connection)
+      const backend = this.backend
+      const configuration = await this.sessionConfigurator.configure({
+        backend,
+        connection,
+        session,
+        permissionProfile: normalizePermissionProfile(request.permissionProfile)
+      })
 
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       // Commit app-owned projections only after the reservation is known to still own this id. No
@@ -1498,11 +1345,11 @@ class AcpRuntime {
           session,
           cwd: sessionCwd,
           projectName,
-          frameworkId: this.framework.id,
-          backendId: this.backendId,
-          permissionProfile: permissionState,
-          appliedModel: modelApplication.appliedModel,
-          configOptions: modelApplication.configOptions
+          frameworkId: backend.framework.id,
+          backendId: backend.backendId,
+          permissionProfile: structuredClone(configuration.permissionProfile),
+          appliedModel: configuration.appliedModel,
+          configOptions: structuredClone(configuration.configOptions)
         }
       )
       if (specialistPrefix) {
@@ -1599,19 +1446,18 @@ class AcpRuntime {
     session: ActiveSession,
     cwd: string,
     projectName: string,
-    permissionProfile: SessionPermissionProfileState,
-    appliedModel: string | undefined,
-    configOptions: SessionConfigOption[] | null | undefined
+    backend: AcpBackendGenerationView,
+    configuration: AcpSessionConfigurationFacts
   ): AcpSessionRegistryEntry {
     const entry = this.attachSessionAggregate(primaryIdentityReservation, appSessionId, {
       session,
       cwd,
       projectName,
-      frameworkId: this.framework.id,
-      backendId: this.backendId,
-      permissionProfile,
-      appliedModel,
-      configOptions
+      frameworkId: backend.framework.id,
+      backendId: backend.backendId,
+      permissionProfile: structuredClone(configuration.permissionProfile),
+      appliedModel: configuration.appliedModel,
+      configOptions: structuredClone(configuration.configOptions)
     })
 
     this.snapshotOwner.updateCwd(cwd)
@@ -1638,15 +1484,23 @@ class AcpRuntime {
       if (request.specialistId) {
         aggregate.setSpecialistId(request.specialistId)
       }
-      await this.configurePermissionProfile(
-        request.sessionId,
-        attachedSession,
-        normalizePermissionProfile(
+      const connection = this.connection
+      if (!connection) throw new Error('ACP connection is not available.')
+      const permissionProfile = await this.sessionConfigurator.configurePermissionProfile({
+        backend: this.backend,
+        connection,
+        session: attachedSession,
+        permissionProfile: normalizePermissionProfile(
           request.permissionProfile ??
             aggregate.snapshot().permissionProfile?.selectedProfile ??
             DEFAULT_PERMISSION_PROFILE
         )
-      )
+      })
+      if (this.activeSessionFor(request.sessionId) !== attachedSession) {
+        throw new Error('ACP session startup was superseded.')
+      }
+      this.assertCurrentConnectedConnection(connection)
+      aggregate.setPermissionProfile(structuredClone(permissionProfile))
       this.sessionRegistry.select(request.sessionId)
       this.snapshotOwner.updateCwd(sessionCwd)
       aggregate.updateLocation(sessionCwd, projectName)
@@ -2194,16 +2048,13 @@ class AcpRuntime {
         throw reservationResult.collision
       }
 
-      const permissionState = await this.configurePermissionProfile(
-        request.sessionId,
+      const backend = this.backend
+      const configuration = await this.sessionConfigurator.configure({
+        backend,
+        connection,
         session,
-        normalizePermissionProfile(request.permissionProfile),
-        false,
-        connection
-      )
-
-      const modelApplication = await this.applySessionModel(session, connection)
-      await this.applySessionEffort(session, modelApplication.configOptions, connection)
+        permissionProfile: normalizePermissionProfile(request.permissionProfile)
+      })
 
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       const { aggregate } = this.attachSessionAggregate(
@@ -2213,11 +2064,11 @@ class AcpRuntime {
           session,
           cwd: sessionCwd,
           projectName,
-          frameworkId: this.framework.id,
-          backendId: this.backendId,
-          permissionProfile: permissionState,
-          appliedModel: modelApplication.appliedModel,
-          configOptions: modelApplication.configOptions
+          frameworkId: backend.framework.id,
+          backendId: backend.backendId,
+          permissionProfile: structuredClone(configuration.permissionProfile),
+          appliedModel: configuration.appliedModel,
+          configOptions: structuredClone(configuration.configOptions)
         }
       )
       if (request.specialistId) {
@@ -2336,16 +2187,13 @@ class AcpRuntime {
       }
       primaryIdentityReservation = reservationResult.reservation
 
-      const permissionState = await this.configurePermissionProfile(
-        request.sessionId,
-        adopted,
-        normalizePermissionProfile(request.permissionProfile),
-        false,
-        connection
-      )
-
-      const modelApplication = await this.applySessionModel(adopted, connection)
-      await this.applySessionEffort(adopted, modelApplication.configOptions, connection)
+      const backend = this.backend
+      const configuration = await this.sessionConfigurator.configure({
+        backend,
+        connection,
+        session: adopted,
+        permissionProfile: normalizePermissionProfile(request.permissionProfile)
+      })
       this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
       const { aggregate } = this.adoptSession(
         primaryIdentityReservation,
@@ -2353,9 +2201,8 @@ class AcpRuntime {
         adopted,
         sessionCwd,
         projectName,
-        permissionState,
-        modelApplication.appliedModel,
-        modelApplication.configOptions
+        backend,
+        configuration
       )
       if (specialistIdentity) {
         aggregate.setSpecialistPrefix(specialistIdentity.prefix || undefined)
@@ -2422,7 +2269,21 @@ class AcpRuntime {
       throw new Error('Resolve the pending permission request before changing profiles.')
     }
 
-    await this.configurePermissionProfile(request.sessionId, session, request.profile)
+    const connection = this.connection
+    if (!connection) throw new Error('ACP connection is not available.')
+    const permissionProfile = await this.sessionConfigurator.configurePermissionProfile({
+      backend: this.backend,
+      connection,
+      session,
+      permissionProfile: request.profile
+    })
+    if (this.activeSessionFor(request.sessionId) !== session) {
+      throw new Error('ACP session startup was superseded.')
+    }
+    this.assertCurrentConnectedConnection(connection)
+    this.sessionRegistry
+      .lookup(request.sessionId)
+      ?.aggregate.setPermissionProfile(structuredClone(permissionProfile))
     this.emitState()
 
     return this.getSnapshot()

--- a/src/main/acp/session-configurator.test.ts
+++ b/src/main/acp/session-configurator.test.ts
@@ -1,0 +1,281 @@
+import * as acp from '@agentclientprotocol/sdk'
+import type { ActiveSession, ClientConnection, SessionConfigOption } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import { claudeCodeFramework, codexFramework } from '../agent-framework'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import { AcpSessionConfigurator } from './session-configurator'
+
+const backendView = (
+  session: AcpBackendGenerationView['session'],
+  framework: AcpBackendGenerationView['framework'] = claudeCodeFramework
+): AcpBackendGenerationView =>
+  Object.freeze({
+    framework,
+    session: Object.freeze(session),
+    prompt: Object.freeze({ systemPromptAppends: Object.freeze([]) }),
+    context: Object.freeze({}),
+    adapter: Object.freeze({ nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false })
+  })
+
+const selectOption = (
+  id: string,
+  category: string,
+  currentValue: string,
+  values: readonly string[]
+): SessionConfigOption =>
+  ({
+    type: 'select',
+    id,
+    name: id,
+    category,
+    currentValue,
+    options: values.map((value) => ({ value, name: value }))
+  }) as SessionConfigOption
+
+describe('AcpSessionConfigurator', () => {
+  it('applies mode, model, and post-model effort in protocol order and returns immutable facts', async () => {
+    const initialOptions = [
+      selectOption('model', 'model', 'model-a', ['model-a', 'model-b']),
+      selectOption('effort', 'thought_level', 'low', ['low', 'high'])
+    ]
+    const postModelOptions = [selectOption('effort', 'thought_level', 'medium', ['medium', 'high'])]
+    const requests: Array<{ method: unknown; params: unknown }> = []
+    const request = vi.fn(async (method: unknown, params: unknown) => {
+      requests.push({ method, params })
+      return method === acp.methods.agent.session.setConfigOption &&
+        (params as { configId?: string }).configId === 'model'
+        ? { configOptions: postModelOptions }
+        : {}
+    })
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const session = {
+      sessionId: 'session-1',
+      modes: {
+        currentModeId: 'default',
+        availableModes: [
+          { id: 'default', name: 'Default' },
+          { id: 'bypassPermissions', name: 'Full access' }
+        ]
+      },
+      newSessionResponse: { configOptions: initialOptions }
+    } as unknown as ActiveSession
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connected' })
+    })
+
+    const facts = await configurator.configure({
+      backend: backendView({ model: 'model-b', modelRequired: true, effort: 'high' }),
+      connection,
+      session,
+      permissionProfile: 'full'
+    })
+
+    expect(requests).toEqual([
+      {
+        method: acp.methods.agent.session.setMode,
+        params: { sessionId: 'session-1', modeId: 'bypassPermissions' }
+      },
+      {
+        method: acp.methods.agent.session.setConfigOption,
+        params: { sessionId: 'session-1', configId: 'model', value: 'model-b' }
+      },
+      {
+        method: acp.methods.agent.session.setConfigOption,
+        params: { sessionId: 'session-1', configId: 'effort', value: 'high' }
+      }
+    ])
+    expect(facts).toMatchObject({
+      permissionProfile: { selectedProfile: 'full', currentModeId: 'bypassPermissions' },
+      appliedModel: 'model-b',
+      configOptions: postModelOptions
+    })
+    expect(Object.isFrozen(facts)).toBe(true)
+    expect(Object.isFrozen(facts.permissionProfile)).toBe(true)
+    expect(Object.isFrozen(facts.permissionProfile.availableModeIds)).toBe(true)
+    expect(Object.isFrozen(facts.configOptions)).toBe(true)
+  })
+
+  it('applies a permission-only change and returns an immutable profile fact', async () => {
+    const request = vi.fn(async () => ({}))
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const session = {
+      sessionId: 'session-1',
+      modes: {
+        currentModeId: 'default',
+        availableModes: [
+          { id: 'default', name: 'Default' },
+          { id: 'bypassPermissions', name: 'Full access' }
+        ]
+      }
+    } as unknown as ActiveSession
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connected' })
+    })
+
+    const profile = await configurator.configurePermissionProfile({
+      backend: backendView({ model: 'unused-model', modelRequired: true, effort: 'high' }),
+      connection,
+      session,
+      permissionProfile: 'full'
+    })
+
+    expect(request).toHaveBeenCalledOnce()
+    expect(request).toHaveBeenCalledWith(acp.methods.agent.session.setMode, {
+      sessionId: 'session-1',
+      modeId: 'bypassPermissions'
+    })
+    expect(profile).toMatchObject({ selectedProfile: 'full', currentModeId: 'bypassPermissions' })
+    expect(Object.isFrozen(profile)).toBe(true)
+    expect(Object.isFrozen(profile.availableModeIds)).toBe(true)
+  })
+
+  it.each([
+    {
+      failure: 'the required model is unavailable',
+      configOptions: [selectOption('model', 'model', 'model-a', ['model-a'])],
+      request: vi.fn(async () => ({})),
+      message: 'The selected model "model-b" is not available for this Codex account.'
+    },
+    {
+      failure: 'the required model request is rejected',
+      configOptions: [selectOption('model', 'model', 'model-a', ['model-a', 'model-b'])],
+      request: vi.fn(async () => {
+        throw new Error('provider rejected model-b')
+      }),
+      message: 'The selected model "model-b" could not be applied: provider rejected model-b'
+    }
+  ])('fails startup when $failure', async ({ configOptions, request, message }) => {
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const session = {
+      sessionId: 'session-1',
+      modes: { currentModeId: 'default', availableModes: [{ id: 'default', name: 'Default' }] },
+      newSessionResponse: { configOptions }
+    } as unknown as ActiveSession
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connected' })
+    })
+
+    await expect(
+      configurator.configure({
+        backend: backendView({ model: 'model-b', modelRequired: true, effort: 'high' }),
+        connection,
+        session,
+        permissionProfile: 'ask'
+      })
+    ).rejects.toThrow(message)
+  })
+
+  it('falls back from an optional-model failure and still applies startup effort', async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('optional model rejected'))
+      .mockResolvedValueOnce({})
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const configOptions = [
+      selectOption('model', 'model', 'model-a', ['model-a', 'model-b']),
+      selectOption('effort', 'thought_level', 'low', ['low', 'high'])
+    ]
+    const session = {
+      sessionId: 'session-1',
+      modes: { currentModeId: 'default', availableModes: [{ id: 'default', name: 'Default' }] },
+      newSessionResponse: { configOptions }
+    } as unknown as ActiveSession
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connected' })
+    })
+
+    const facts = await configurator.configure({
+      backend: backendView({ model: 'model-b', modelRequired: false, effort: 'high' }),
+      connection,
+      session,
+      permissionProfile: 'ask'
+    })
+
+    expect(request).toHaveBeenNthCalledWith(1, acp.methods.agent.session.setConfigOption, {
+      sessionId: 'session-1',
+      configId: 'model',
+      value: 'model-b'
+    })
+    expect(request).toHaveBeenNthCalledWith(2, acp.methods.agent.session.setConfigOption, {
+      sessionId: 'session-1',
+      configId: 'effort',
+      value: 'high'
+    })
+    expect(facts).toMatchObject({ appliedModel: undefined, configOptions: undefined })
+  })
+
+  it('skips a redundant Codex model request while retaining its configuration facts', async () => {
+    const request = vi.fn(async () => ({}))
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const configOptions = [
+      selectOption('model', 'model', 'openai/gpt-5', ['openai/gpt-5']),
+      selectOption('effort', 'thought_level', 'low', ['low', 'high'])
+    ]
+    const session = {
+      sessionId: 'session-1',
+      modes: {
+        currentModeId: 'read-only',
+        availableModes: [{ id: 'read-only', name: 'Read only' }]
+      },
+      newSessionResponse: { configOptions }
+    } as unknown as ActiveSession
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'codex', generation: 1, status: 'connected' })
+    })
+
+    const facts = await configurator.configure({
+      backend: backendView({ model: 'gpt-5', modelRequired: true, effort: 'high' }, codexFramework),
+      connection,
+      session,
+      permissionProfile: 'ask'
+    })
+
+    expect(request).toHaveBeenCalledOnce()
+    expect(request).toHaveBeenCalledWith(acp.methods.agent.session.setConfigOption, {
+      sessionId: 'session-1',
+      configId: 'effort',
+      value: 'high'
+    })
+    expect(facts).toMatchObject({
+      appliedModel: 'openai/gpt-5',
+      configOptions
+    })
+  })
+
+  it('keeps startup effort best-effort when the protocol request is rejected', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('effort rejected')
+    })
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const session = {
+      sessionId: 'session-1',
+      modes: { currentModeId: 'default', availableModes: [{ id: 'default', name: 'Default' }] },
+      newSessionResponse: {
+        configOptions: [selectOption('effort', 'thought_level', 'low', ['low', 'high'])]
+      }
+    } as unknown as ActiveSession
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connected' })
+    })
+
+    await expect(
+      configurator.configure({
+        backend: backendView({ modelRequired: false, effort: 'high' }),
+        connection,
+        session,
+        permissionProfile: 'ask'
+      })
+    ).resolves.toMatchObject({
+      permissionProfile: { selectedProfile: 'ask' },
+      appliedModel: undefined
+    })
+    expect(request).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/acp/session-configurator.ts
+++ b/src/main/acp/session-configurator.ts
@@ -1,0 +1,163 @@
+import * as acp from '@agentclientprotocol/sdk'
+import type { ActiveSession, ClientConnection, SessionConfigOption } from '@agentclientprotocol/sdk'
+
+import type {
+  PermissionProfileId,
+  SessionPermissionProfileState
+} from '../../shared/permission-profiles'
+import { createLogger, diagnosticErrorFields } from '../logger'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import {
+  matchSessionModelOption,
+  resolveSessionEffortOption,
+  type SessionModelSelection
+} from './session-config'
+
+const log = createLogger('acp')
+
+type ConfigurationContext = Readonly<{
+  backend: AcpBackendGenerationView
+  connection: ClientConnection
+}>
+type StartupConfiguration = ConfigurationContext &
+  Readonly<{ session: ActiveSession; permissionProfile: PermissionProfileId }>
+type ModelApplication = Readonly<{
+  appliedModel: string | undefined
+  configOptions: SessionConfigOption[] | null | undefined
+}>
+export type AcpSessionConfigurationFacts = Readonly<{
+  permissionProfile: SessionPermissionProfileState
+  appliedModel: string | undefined
+  configOptions: SessionConfigOption[] | undefined
+}>
+const configOptionsOf = (session: ActiveSession): SessionConfigOption[] | null | undefined =>
+  (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
+    .newSessionResponse?.configOptions
+
+const deepFreeze = <Value>(value: Value): Value => {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value
+  for (const nested of Object.values(value)) deepFreeze(nested)
+  return Object.freeze(value)
+}
+
+// Statelessly sequences provider Session configuration; callers retain every ownership commit.
+export class AcpSessionConfigurator {
+  constructor(
+    private readonly deps: Readonly<{
+      assertCurrentConnection: (connection: ClientConnection) => void
+      diagnosticContext: (backend: AcpBackendGenerationView) => Readonly<Record<string, unknown>>
+    }>
+  ) {}
+
+  async configure(input: StartupConfiguration): Promise<AcpSessionConfigurationFacts> {
+    const permissionState = await this.applyPermissionMode(input)
+    const modelApplication = await this.applyModel(input)
+    const effort = input.backend.session.effort
+    if (effort) {
+      const selection = resolveSessionEffortOption(
+        modelApplication.configOptions ?? configOptionsOf(input.session),
+        effort
+      )
+      if (selection) await this.sendEffort(input, input.session, selection)
+      else log.info('no session effort option to apply', this.deps.diagnosticContext(input.backend))
+    }
+
+    return deepFreeze({
+      permissionProfile: structuredClone(permissionState),
+      appliedModel: modelApplication.appliedModel,
+      configOptions:
+        modelApplication.configOptions == null
+          ? undefined
+          : structuredClone(modelApplication.configOptions)
+    })
+  }
+
+  async configurePermissionProfile(
+    input: StartupConfiguration
+  ): Promise<Readonly<SessionPermissionProfileState>> {
+    return deepFreeze(structuredClone(await this.applyPermissionMode(input)))
+  }
+
+  private async applyPermissionMode(
+    input: StartupConfiguration
+  ): Promise<SessionPermissionProfileState> {
+    const application = input.backend.framework.mapPermissionProfile(
+      input.permissionProfile,
+      input.session.modes
+    )
+    if (application.modeId && application.modeId !== input.session.modes?.currentModeId) {
+      this.deps.assertCurrentConnection(input.connection)
+      await input.connection.agent.request(acp.methods.agent.session.setMode, {
+        sessionId: input.session.sessionId,
+        modeId: application.modeId
+      })
+    }
+    log.info('permission profile applied', this.deps.diagnosticContext(input.backend))
+    return application.state
+  }
+
+  private async applyModel(input: StartupConfiguration): Promise<ModelApplication> {
+    const model = input.backend.session.model
+    if (!model) return { appliedModel: undefined, configOptions: undefined }
+    const configOptions = configOptionsOf(input.session)
+    const selection = matchSessionModelOption(configOptions, model)
+
+    if (!selection) {
+      log.info('no matching session model option', this.deps.diagnosticContext(input.backend))
+      if (input.backend.session.modelRequired) {
+        throw new Error(`The selected model "${model}" is not available for this Codex account.`)
+      }
+      return { appliedModel: undefined, configOptions: undefined }
+    }
+    if (selection.alreadyCurrent) {
+      log.info('session model already current', this.deps.diagnosticContext(input.backend))
+      return { appliedModel: selection.value, configOptions: configOptions ?? null }
+    }
+
+    this.deps.assertCurrentConnection(input.connection)
+    try {
+      const response = (await input.connection.agent.request(
+        acp.methods.agent.session.setConfigOption,
+        { sessionId: input.session.sessionId, configId: selection.configId, value: selection.value }
+      )) as { configOptions?: SessionConfigOption[] | null }
+      log.info('session model applied', this.deps.diagnosticContext(input.backend))
+      return {
+        appliedModel: selection.value,
+        configOptions: response?.configOptions ?? configOptions
+      }
+    } catch (error) {
+      log.warn('set session model failed', {
+        ...diagnosticErrorFields(error),
+        ...this.deps.diagnosticContext(input.backend)
+      })
+      if (input.backend.session.modelRequired) {
+        const message = error instanceof Error ? error.message : String(error)
+        throw new Error(`The selected model "${model}" could not be applied: ${message}`)
+      }
+      return { appliedModel: undefined, configOptions: undefined }
+    }
+  }
+
+  private async sendEffort(
+    input: ConfigurationContext,
+    session: ActiveSession,
+    selection: SessionModelSelection
+  ): Promise<boolean> {
+    this.deps.assertCurrentConnection(input.connection)
+    try {
+      await input.connection.agent.request(acp.methods.agent.session.setConfigOption, {
+        sessionId: session.sessionId,
+        configId: selection.configId,
+        value: selection.value
+      })
+      log.info('session effort applied', this.deps.diagnosticContext(input.backend))
+      return true
+    } catch (error) {
+      log.warn('set session effort failed', {
+        ...diagnosticErrorFields(error),
+        ...this.deps.diagnosticContext(input.backend)
+      })
+      return false
+    }
+  }
+}


### PR DESCRIPTION
## Problem

ACP startup Session configuration was sequenced inside `AcpRuntime`, mixing protocol ordering with Runtime reservation and publication responsibilities.

Related: #458. This PR only creates a forward orchestration seam; it does not implement Issue #458 orchestration state, schema, wire/public contracts, or user-visible behavior.

## Proposed change

- Add stateless `AcpSessionConfigurator` for startup permission mode, required/optional model, and post-model startup effort.
- Return cloned, recursively frozen permission/model/config facts.
- Keep reservation validation and `AcpSessionAggregate` publication in Runtime.
- Replace private Runtime-layout probes with public framework/protocol failure contracts.

## Scope and non-goals

- ARD-06A only; live-effort configuration remains unchanged in Runtime and is deferred to ARD-06B.
- No Settings mutation or Registry commit in the configurator.
- No schema, persistence, IPC/preload, Web/Task/CLI/SDK, UI, Specialist, Compute, Reviewer, Artifact, reset/replay, terminal-fact, or Issue #458 orchestration surface changes.
- Exact production raw: **450** (`runtime.ts` 287 + `session-configurator.ts` 163), below the 500-line hard stop.

## Ownership and sequence

`AcpSessionConfigurator` is stateless and owns only the startup protocol sequence: permission mode → required/optional model → post-model startup effort. It does not own Session state or resources. `AcpRuntime` retains reservation validation, and `AcpSessionAggregate` publication remains outside the configurator. Because this is a pure sequencing interface with no mutable owner or resource transfer, an ownership diagram would imply state that the module does not hold.

## Acceptance criteria and validation

The recorded checks ran after the last material edit:

- Startup ordering, required/optional model failures, redundant Codex model skip, post-model effort, best-effort effort, immutable facts → `npm test -- src/main/acp/session-configurator.test.ts` → **7 passed**.
- Runtime create/resume/adopt/permission, generation-affinity, cleanup, and live-effort regression contracts → `npm test -- src/main/acp/runtime.test.ts` → **394 passed**.
- Coordinator, permission owner/mapping, aggregate, and registry contracts → `npm test -- src/main/acp/runtime-coordinator.test.ts src/main/acp/permission-context.test.ts src/main/acp/permission-profile-controller.test.ts src/main/acp/session-aggregate.test.ts src/main/acp/session-registry.test.ts` → **77 passed**.
- Final combined focused module/owner set → **84 passed**; the historical description did not record the exact command text.
- `npm run typecheck:node` → passed.
- `npm run lint` → 0 errors; 17 pre-existing warnings outside changed files.
- Targeted Prettier check and `git diff --check` → passed; the historical description did not record the exact Prettier invocation.
- Independent Standards review → 0 findings.
- Independent Spec review → 0 findings.
- Final-head online gates → PR Gate, AI review, CodeQL, Static checks, Unit tests, Coverage macOS, macOS build/E2E, and Windows E2E all passed. `Windows core` was skipped by classification.

The listed checks ran after the final material edit. The local full suite was intentionally omitted under the approved delivery policy. Consumer coverage included Runtime, Coordinator, Permission owner/mapping, Aggregate, and Registry because they participate in startup configuration and publication. The final-head online PR Gate is the authoritative cross-platform validation.

## Review focus

- Permission mode → model → post-model effort protocol order.
- Runtime-owned reservation validation and Aggregate publication.
- Immutable returned facts and absence of Permission/Registry/Settings writes.
- Complete exclusion of ARD-06B live-effort changes.

## Uncovered risks

Real external ACP implementations beyond the in-memory protocol contracts were not exercised locally. A full local portable suite was not run, and the historical record does not preserve the exact combined focused or Prettier command. Cross-platform/provider confidence comes from the final-head online gates. Issue #458 integration remains deferred.
