### PR TITLE
fix(mcp-runtime): diagnose Windows startup failures

### DIFF
--- a/patches/@agentclientprotocol+claude-agent-acp+0.60.0.patch
+++ b/patches/@agentclientprotocol+claude-agent-acp+0.60.0.patch
@@ -1,20 +1,20 @@
 diff --git a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.d.ts b/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.d.ts
-index f247a7e..1288e59 100644
+index f247a7e..266f90d 100644
 --- a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.d.ts
 +++ b/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.d.ts
 @@ -13,6 +13,7 @@ export interface Logger {
      log: (...args: any[]) => void;
      error: (...args: any[]) => void;
  }
-+export declare function waitForMcpServers(query: Pick<Query, "mcpServerStatus" | "close">, serverNames: string[], timeoutMs?: number): Promise<void>;
++export declare function waitForMcpServers(query: Pick<Query, "mcpServerStatus" | "close">, serverNames: string[], timeoutMs?: number, logger?: Pick<Logger, "error">): Promise<void>;
  type AccumulatedUsage = {
      inputTokens: number;
      outputTokens: number;
 diff --git a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js b/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
-index 361d032..1e98b3f 100644
+index 361d032..69371ea 100644
 --- a/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
 +++ b/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js
-@@ -438,6 +438,59 @@ class ClientConnection {
+@@ -438,6 +438,62 @@ class ClientConnection {
          return this.ctx.notify(method, params);
      }
  }
@@ -33,7 +33,7 @@ index 361d032..1e98b3f 100644
 +        reject(error);
 +    });
 +});
-+export async function waitForMcpServers(query, serverNames, timeoutMs = MCP_STARTUP_TIMEOUT_MS) {
++export async function waitForMcpServers(query, serverNames, timeoutMs = MCP_STARTUP_TIMEOUT_MS, logger = console) {
 +    if (serverNames.length === 0) {
 +        return;
 +    }
@@ -42,6 +42,7 @@ index 361d032..1e98b3f 100644
 +    while (pending.size > 0) {
 +        const remainingMs = deadline - Date.now();
 +        if (remainingMs <= 0) {
++            logger.error(`[mcp-readiness] Timed out waiting for MCP servers: ${[...pending].join(", ")}`);
 +            query.close();
 +            throw new Error(`Timed out waiting for MCP servers: ${[...pending].join(", ")}`);
 +        }
@@ -50,6 +51,7 @@ index 361d032..1e98b3f 100644
 +            statuses = await withTimeout(query.mcpServerStatus(), remainingMs, () => new Error(`Timed out waiting for MCP servers: ${[...pending].join(", ")}`));
 +        }
 +        catch (error) {
++            logger.error(`[mcp-readiness] ${error instanceof Error ? error.message : String(error)}`);
 +            query.close();
 +            throw error;
 +        }
@@ -62,6 +64,7 @@ index 361d032..1e98b3f 100644
 +                continue;
 +            }
 +            if (status.status === "failed" || status.status === "needs-auth" || status.status === "disabled") {
++                logger.error(`[mcp-readiness] MCP server ${status.name} is ${status.status}${status.error ? `: ${status.error}` : ""}`);
 +                query.close();
 +                throw new Error(`MCP server ${status.name} is ${status.status}${status.error ? `: ${status.error}` : ""}`);
 +            }
@@ -74,7 +77,7 @@ index 361d032..1e98b3f 100644
  export class ClaudeAcpAgent {
      sessions;
      client;
-@@ -2353,7 +2406,7 @@ export class ClaudeAcpAgent {
+@@ -2353,7 +2409,7 @@ export class ClaudeAcpAgent {
                                      cache_creation_input_tokens: usage.cache_creation_input_tokens ?? prev.cache_creation_input_tokens,
                                  };
                              }
@@ -83,7 +86,7 @@ index 361d032..1e98b3f 100644
                              if (nextUsage !== lastAssistantTotalUsage) {
                                  lastAssistantTotalUsage = nextUsage;
                                  await sendUpdate({
-@@ -2465,7 +2518,7 @@ export class ClaudeAcpAgent {
+@@ -2465,7 +2521,7 @@ export class ClaudeAcpAgent {
                          // aligned with what the user's current selection is producing.
                          if (message.type === "assistant" && message.parent_tool_use_id === null) {
                              lastAssistantUsage = snapshotFromUsage(message.message.usage);
@@ -92,15 +95,15 @@ index 361d032..1e98b3f 100644
                              if (message.message.model && message.message.model !== "<synthetic>") {
                                  lastAssistantModel = message.message.model;
                              }
-@@ -4067,6 +4120,7 @@ export class ClaudeAcpAgent {
+@@ -4067,6 +4123,7 @@ export class ClaudeAcpAgent {
          let initializationResult;
          try {
              initializationResult = await q.initializationResult();
-+            await waitForMcpServers(q, Object.keys(mcpServers));
++            await waitForMcpServers(q, Object.keys(mcpServers), undefined, this.logger);
          }
          catch (error) {
              if (creationOpts.resume &&
-@@ -4282,15 +4336,10 @@ function sessionUsage(session) {
+@@ -4282,15 +4339,10 @@ function sessionUsage(session) {
              session.accumulatedUsage.cachedWriteTokens,
      };
  }
@@ -120,7 +123,7 @@ index 361d032..1e98b3f 100644
  }
  /**
   * Build the `data` payload attached to a `RequestError.internalError` when we
-@@ -4307,7 +4356,7 @@ function errorKindData(errorKind) {
+@@ -4307,7 +4359,7 @@ function errorKindData(errorKind) {
  }
  /** Project a nullable API usage object into our non-null snapshot shape.
   *  Both SDK message_start and assistant message `usage` have `number | null`

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -3,20 +3,29 @@
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
 import { homedir, tmpdir } from 'node:os'
 import { basename, join, resolve, win32 } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+
 const APP_EXECUTABLE = 'open-science.exe'
+const ARTIFACT_MCP_SERVER_ARG = '--open-science-artifact-mcp'
+const NOTEBOOK_MCP_SERVER_ARG = '--open-science-notebook-mcp'
 const CONFIG_DIRECTORY = '.open-science'
 const PROCESS_TIMEOUT_MS = 120_000
 const STARTUP_TIMEOUT_MS = 60_000
 const SHUTDOWN_TIMEOUT_MS = 60_000
 const HTTP_REQUEST_TIMEOUT_MS = 15_000
 const TERMINATION_TIMEOUT_MS = 10_000
+const MCP_REQUEST_TIMEOUT_MS = 30_000
 const SMOKE_ROOT_PREFIX = 'open-science-installer-smoke-'
+const RPC_SMOKE_ROOT_PREFIX = 'open-science-rpc-smoke-'
 const UPGRADE_SENTINEL_PREFIX = 'installer-smoke-upgrade-sentinel-'
 const UPGRADE_SENTINEL_CONTENT = 'previous-version-profile-preserved\n'
+const RPC_SMOKE_CONTENT = 'windows-rpc-smoke\n'
 
 const delay = (milliseconds) =>
   new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds))
@@ -319,6 +328,267 @@ const packagedResourcePaths = (installDirectory) => [
   )
 ]
 
+const packagedMainEntryPath = (installDirectory) =>
+  join(installDirectory, 'resources', 'app.asar', 'out', 'main', 'index.js')
+
+const stringEnvironment = (environment) =>
+  Object.fromEntries(Object.entries(environment).filter((entry) => typeof entry[1] === 'string'))
+
+const listenOnPipe = (server, socketPath) =>
+  new Promise((resolveListen, rejectListen) => {
+    const onError = (error) => rejectListen(error)
+    server.once('error', onError)
+    server.listen(socketPath, () => {
+      server.off('error', onError)
+      resolveListen()
+    })
+  })
+
+const closeServer = (server) =>
+  new Promise((resolveClose, rejectClose) => {
+    server.close((error) => (error ? rejectClose(error) : resolveClose()))
+  })
+
+const readJsonBody = async (request) => {
+  let body = ''
+  request.setEncoding('utf8')
+  for await (const chunk of request) body += chunk
+  return JSON.parse(body)
+}
+
+const sendJson = (response, statusCode, payload) => {
+  response.writeHead(statusCode, { 'content-type': 'application/json' })
+  response.end(JSON.stringify(payload))
+}
+
+const toolResultText = (result) =>
+  result.content
+    .filter((item) => item.type === 'text')
+    .map((item) => item.text)
+    .join('\n')
+
+const assertToolResult = (toolName, result, expectedText) => {
+  const text = toolResultText(result)
+  if (result.isError || !text.includes(expectedText)) {
+    throw new Error(
+      `${toolName} did not return the expected packaged MCP result.${text ? `\n${text}` : ''}`
+    )
+  }
+}
+
+const appendMcpStderr = (error, stderr) => {
+  const detail = stderr().trim()
+  if (error instanceof Error && detail && !error.message.includes(detail))
+    error.message += `\n${detail}`
+  return error
+}
+
+const connectPackagedMcp = async ({ executable, entryPath, serverArg, env, cwd }) => {
+  const transport = new StdioClientTransport({
+    command: executable,
+    args: [entryPath, serverArg],
+    env: stringEnvironment(env),
+    cwd,
+    stderr: 'pipe'
+  })
+  let stderr = ''
+  transport.stderr?.setEncoding?.('utf8')
+  transport.stderr?.on('data', (chunk) => {
+    stderr += chunk
+  })
+  const client = new Client({ name: 'windows-installer-smoke', version: '1.0.0' })
+  try {
+    await client.connect(transport, { timeout: MCP_REQUEST_TIMEOUT_MS })
+  } catch (error) {
+    await transport.close().catch(() => undefined)
+    throw appendMcpStderr(error, () => stderr)
+  }
+  return { client, stderr: () => stderr }
+}
+
+const runPackagedLocalRpcSmoke = async ({ installDirectory, env }) => {
+  const root = await mkdtemp(join(env.TEMP, RPC_SMOKE_ROOT_PREFIX))
+  const workspace = join(root, 'workspace')
+  const artifactStorage = join(root, 'artifacts')
+  const currentRunFile = join(root, 'current-run.json')
+  const socketPath = `\\\\.\\pipe\\open-science-installer-smoke-${process.pid}-${randomUUID()}`
+  const token = randomUUID()
+  const methods = []
+  const server = createServer(async (request, response) => {
+    try {
+      if (request.headers.authorization !== `Bearer ${token}`) {
+        sendJson(response, 401, { error: 'Unauthorized installer smoke RPC request.' })
+        return
+      }
+      const body = await readJsonBody(request)
+      methods.push(body.method)
+      if (body.method === 'state') {
+        sendJson(response, 200, {
+          result: {
+            sessionId: 'installer-smoke-session',
+            cwd: workspace,
+            dataRoot: workspace,
+            kernelStatus: 'idle',
+            cells: [],
+            runs: [],
+            environments: []
+          }
+        })
+        return
+      }
+      if (body.method === 'executeShell') {
+        sendJson(response, 200, {
+          result: {
+            runId: 'installer-smoke-shell-run',
+            kernelKind: 'bash',
+            status: 'completed',
+            exitCode: 0,
+            stdout: RPC_SMOKE_CONTENT,
+            stderr: '',
+            traceback: '',
+            outputs: [],
+            workingFiles: []
+          }
+        })
+        return
+      }
+      if (body.method === 'artifactCreateVersion') {
+        sendJson(response, 200, {
+          result: {
+            id: 'installer-smoke-version',
+            artifactId: 'installer-smoke-artifact',
+            versionId: 'installer-smoke-version',
+            versionNumber: 1,
+            checksum: 'a'.repeat(64),
+            createdAt: new Date(0).toISOString(),
+            projectName: 'installer-smoke-project',
+            sessionId: 'installer-smoke-session',
+            runId: 'installer-smoke-artifact-run',
+            name: 'windows-rpc-smoke.txt',
+            path: join(workspace, 'windows-rpc-smoke.txt'),
+            fileUrl: 'file:///windows-rpc-smoke.txt',
+            mimeType: 'text/plain',
+            size: Buffer.byteLength(RPC_SMOKE_CONTENT),
+            mtimeMs: 0,
+            producerRunId: 'installer-smoke-shell-run'
+          }
+        })
+        return
+      }
+      sendJson(response, 400, { error: `Unexpected installer smoke RPC method: ${body.method}` })
+    } catch (error) {
+      sendJson(response, 500, {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  })
+  let notebookMcp
+  let artifactMcp
+  let primaryError
+  try {
+    await Promise.all([
+      mkdir(workspace, { recursive: true }),
+      mkdir(artifactStorage, { recursive: true })
+    ])
+    await writeFile(
+      currentRunFile,
+      JSON.stringify({
+        artifactRunId: 'installer-smoke-artifact-run',
+        appSessionId: 'installer-smoke-session',
+        rootFrameId: 'installer-smoke-root-frame',
+        agentFrameId: 'installer-smoke-agent-frame',
+        messageBranchId: 'installer-smoke-branch',
+        runtimeSegmentId: 'installer-smoke-runtime',
+        promptMessageId: 'installer-smoke-prompt',
+        notebookSessionId: 'installer-smoke-session',
+        rpcCapabilityToken: token
+      })
+    )
+    await listenOnPipe(server, socketPath)
+
+    const executable = join(installDirectory, APP_EXECUTABLE)
+    const entryPath = packagedMainEntryPath(installDirectory)
+    const sharedEnv = { ...env, ELECTRON_RUN_AS_NODE: '1' }
+    notebookMcp = await connectPackagedMcp({
+      executable,
+      entryPath,
+      serverArg: NOTEBOOK_MCP_SERVER_ARG,
+      cwd: workspace,
+      env: {
+        ...sharedEnv,
+        OPEN_SCIENCE_NOTEBOOK_RPC_ENDPOINT: 'http://localhost',
+        OPEN_SCIENCE_NOTEBOOK_RPC_SOCKET_PATH: socketPath,
+        OPEN_SCIENCE_NOTEBOOK_RPC_TOKEN: token,
+        OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME: 'installer-smoke-project',
+        OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'installer-smoke-session',
+        OPEN_SCIENCE_NOTEBOOK_WORKSPACE_CWD: workspace
+      }
+    })
+    const state = await notebookMcp.client.callTool(
+      { name: 'notebook_state', arguments: {} },
+      undefined,
+      { timeout: MCP_REQUEST_TIMEOUT_MS }
+    )
+    assertToolResult('notebook_state', state, 'installer-smoke-session')
+    const shell = await notebookMcp.client.callTool(
+      { name: 'bash_execute', arguments: { command: 'Write-Output windows-rpc-smoke' } },
+      undefined,
+      { timeout: MCP_REQUEST_TIMEOUT_MS }
+    )
+    assertToolResult('bash_execute', shell, RPC_SMOKE_CONTENT.trim())
+
+    artifactMcp = await connectPackagedMcp({
+      executable,
+      entryPath,
+      serverArg: ARTIFACT_MCP_SERVER_ARG,
+      cwd: workspace,
+      env: {
+        ...sharedEnv,
+        OPEN_SCIENCE_ARTIFACT_STORAGE_ROOT: artifactStorage,
+        OPEN_SCIENCE_ARTIFACT_PROJECT_NAME: 'installer-smoke-project',
+        OPEN_SCIENCE_ARTIFACT_SESSION_ID: 'installer-smoke-session',
+        OPEN_SCIENCE_ARTIFACT_CURRENT_RUN_FILE: currentRunFile,
+        OPEN_SCIENCE_ARTIFACT_ALLOWED_IMPORT_ROOTS: JSON.stringify([workspace]),
+        OPEN_SCIENCE_ARTIFACT_RPC_ENDPOINT: 'http://localhost',
+        OPEN_SCIENCE_ARTIFACT_RPC_SOCKET_PATH: socketPath
+      }
+    })
+    const artifact = await artifactMcp.client.callTool(
+      {
+        name: 'write_artifact_file',
+        arguments: {
+          filename: 'windows-rpc-smoke.txt',
+          mimeType: 'text/plain',
+          content: RPC_SMOKE_CONTENT,
+          encoding: 'utf8',
+          producerRunId: 'installer-smoke-shell-run'
+        }
+      },
+      undefined,
+      { timeout: MCP_REQUEST_TIMEOUT_MS }
+    )
+    assertToolResult('write_artifact_file', artifact, 'installer-smoke-version')
+
+    const expectedMethods = ['state', 'executeShell', 'artifactCreateVersion']
+    if (JSON.stringify(methods) !== JSON.stringify(expectedMethods)) {
+      throw new Error(`Unexpected packaged local RPC sequence: ${methods.join(' -> ')}`)
+    }
+  } catch (error) {
+    const stderr = [notebookMcp?.stderr(), artifactMcp?.stderr()].filter(Boolean).join('\n').trim()
+    primaryError = appendMcpStderr(error, () => stderr)
+  }
+  const cleanupResults = await Promise.allSettled([
+    notebookMcp?.client.close(),
+    artifactMcp?.client.close(),
+    server.listening ? closeServer(server) : undefined,
+    rm(root, { force: true, maxRetries: 10, recursive: true, retryDelay: 500 })
+  ])
+  const cleanupFailure = cleanupResults.find((result) => result.status === 'rejected')
+  if (primaryError) throw primaryError
+  if (cleanupFailure?.status === 'rejected') throw cleanupFailure.reason
+  console.log('Packaged Windows MCP local RPC smoke completed successfully.')
+}
+
 const windowsProfileEnvironment = (profileDirectory, baseEnvironment = process.env) => {
   const temporaryDirectory = join(profileDirectory, 'Temp')
   return {
@@ -458,6 +728,7 @@ const installAndProbe = async ({ installer, installDirectory, phase, env, legacy
   await runProcess(installer, ['/S', `/D=${installDirectory}`], { env })
   await assertPackagedResources(installDirectory)
   await runProcess(join(installDirectory, 'resources', 'micromamba.exe'), ['--version'], { env })
+  if (phase === 'current') await runPackagedLocalRpcSmoke({ installDirectory, env })
   return launchAndProbe({
     installDirectory,
     expectedVersion: installerVersion(installer),
@@ -597,6 +868,7 @@ export {
   fetchWithTimeout,
   findSetupInstaller,
   installerVersion,
+  packagedMainEntryPath,
   packagedResourcePaths,
   parsePackagedAppEndpoint,
   readPackagedAppConfigRoot,

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -14,6 +14,7 @@ import {
   fetchWithTimeout,
   findSetupInstaller,
   installerVersion,
+  packagedMainEntryPath,
   packagedResourcePaths,
   parsePackagedAppEndpoint,
   readPackagedAppConfigRoot,
@@ -281,6 +282,12 @@ Open Science Web: http://127.0.0.1:52378/?token=iUFHGSACwBz2k1kSJfPixHbclDywVg0C
         'query_engine-windows.dll.node'
       )
     ])
+  })
+
+  it('targets the bundled main entry for packaged MCP subprocesses', () => {
+    expect(packagedMainEntryPath(join('smoke', 'app'))).toBe(
+      join('smoke', 'app', 'resources', 'app.asar', 'out', 'main', 'index.js')
+    )
   })
 
   it('builds an isolated profile environment for smoke child processes', () => {

--- a/src/main/acp/claude-agent-acp-patch.test.ts
+++ b/src/main/acp/claude-agent-acp-patch.test.ts
@@ -51,15 +51,22 @@ describe('claude-agent-acp MCP readiness patch', () => {
     expect(query.close).not.toHaveBeenCalled()
   })
 
-  it('reports a configured MCP server startup failure', async () => {
+  it.each([
+    ['failed', 'process exited'],
+    ['needs-auth', 'login required']
+  ] as const)('logs a configured MCP server %s state', async (state, detail) => {
     const mcpServerStatus = vi
       .fn<McpStatusQuery['mcpServerStatus']>()
-      .mockResolvedValue([status('open-science-notebook', 'failed', 'process exited')])
+      .mockResolvedValue([status('open-science-notebook', state, detail)])
 
     const query = queryWithStatus(mcpServerStatus)
+    const logger = { error: vi.fn() }
 
-    await expect(waitForMcpServers(query, ['open-science-notebook'], 100)).rejects.toThrow(
-      'MCP server open-science-notebook is failed: process exited'
+    await expect(waitForMcpServers(query, ['open-science-notebook'], 100, logger)).rejects.toThrow(
+      `MCP server open-science-notebook is ${state}: ${detail}`
+    )
+    expect(logger.error).toHaveBeenCalledWith(
+      `[mcp-readiness] MCP server open-science-notebook is ${state}: ${detail}`
     )
     expect(query.close).toHaveBeenCalledOnce()
   })
@@ -70,9 +77,13 @@ describe('claude-agent-acp MCP readiness patch', () => {
       .mockReturnValue(new Promise<McpServerStatus[]>(() => undefined))
 
     const query = queryWithStatus(mcpServerStatus)
+    const logger = { error: vi.fn() }
 
-    await expect(waitForMcpServers(query, ['open-science-notebook'], 5)).rejects.toThrow(
+    await expect(waitForMcpServers(query, ['open-science-notebook'], 5, logger)).rejects.toThrow(
       'Timed out waiting for MCP servers: open-science-notebook'
+    )
+    expect(logger.error).toHaveBeenCalledWith(
+      '[mcp-readiness] Timed out waiting for MCP servers: open-science-notebook'
     )
     expect(query.close).toHaveBeenCalledOnce()
   })

--- a/src/main/local-rpc-transport.test.ts
+++ b/src/main/local-rpc-transport.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { fetchLocalRpc, listenForLocalRpc } from './local-rpc-transport'
+import { fetchLocalRpc, listenForLocalRpc, localRpcServerLogFields } from './local-rpc-transport'
 
 const servers: Array<ReturnType<typeof createServer>> = []
 
@@ -29,6 +29,11 @@ describe('local RPC transport', () => {
     })
 
     expect(connection.socketPath).toBeTruthy()
+    expect(localRpcServerLogFields(server)).toEqual({
+      transport: 'pipe',
+      listening: true,
+      socketPath: connection.socketPath
+    })
     const response = await fetchLocalRpc(
       { ...connection, endpoint: `${connection.endpoint}/rpc` },
       {
@@ -42,6 +47,19 @@ describe('local RPC transport', () => {
     await expect(response.json()).resolves.toEqual({
       path: '/rpc',
       authorized: 'Bearer test-token'
+    })
+  })
+
+  it('reports the bound TCP host, port, and listening state', async () => {
+    const server = createServer()
+    servers.push(server)
+    await listenForLocalRpc(server, { name: 'transport-test', transport: 'tcp' })
+
+    expect(localRpcServerLogFields(server)).toMatchObject({
+      transport: 'tcp',
+      listening: true,
+      host: '127.0.0.1',
+      port: expect.any(Number)
     })
   })
 

--- a/src/main/local-rpc-transport.ts
+++ b/src/main/local-rpc-transport.ts
@@ -14,6 +14,14 @@ type LocalRpcListenOptions = {
   transport?: 'tcp' | 'pipe'
 }
 
+type LocalRpcServerLogFields = {
+  transport: 'tcp' | 'pipe' | 'pending'
+  listening: boolean
+  host?: string
+  port?: number
+  socketPath?: string
+}
+
 const namedPipePath = (name: string): string =>
   process.platform === 'win32'
     ? `\\\\.\\pipe\\open-science-${name}-${process.pid}-${randomUUID()}`
@@ -53,6 +61,22 @@ const listenForLocalRpc = async (
     throw new Error('Local RPC server did not return a TCP address.')
   }
   return { endpoint: `http://${address.address}:${address.port}` }
+}
+
+const localRpcServerLogFields = (server: Server): LocalRpcServerLogFields => {
+  const address = server.address()
+  if (typeof address === 'string') {
+    return { transport: 'pipe', listening: server.listening, socketPath: address }
+  }
+  if (address) {
+    return {
+      transport: 'tcp',
+      listening: server.listening,
+      host: address.address,
+      port: address.port
+    }
+  }
+  return { transport: 'pending', listening: server.listening }
 }
 
 const requestBody = (
@@ -147,5 +171,5 @@ const fetchLocalRpc = async (
   }
 }
 
-export { fetchLocalRpc, fetchOverSocket, listenForLocalRpc }
-export type { LocalRpcListenOptions, LocalRpcTransport }
+export { fetchLocalRpc, fetchOverSocket, listenForLocalRpc, localRpcServerLogFields }
+export type { LocalRpcListenOptions, LocalRpcServerLogFields, LocalRpcTransport }

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -30,7 +30,14 @@ import {
   type TrustedCallingSession,
   type TrustedControlInvocationIdentity
 } from '../../shared/agents-contract'
-import { listenForLocalRpc, type LocalRpcListenOptions } from '../local-rpc-transport'
+import {
+  listenForLocalRpc,
+  localRpcServerLogFields,
+  type LocalRpcListenOptions
+} from '../local-rpc-transport'
+import { createLogger, errorLogFields } from '../logger'
+
+const log = createLogger('notebook:local-rpc')
 
 type NotebookLocalRpcServerOptions = {
   token?: string
@@ -284,11 +291,26 @@ class NotebookLocalRpcServer {
       void this.handleRequest(request, response)
     })
     this.server = server
+    log.info('notebook RPC server starting', {
+      transport: this.transport ?? (process.platform === 'win32' ? 'pipe' : 'tcp'),
+      listening: server.listening
+    })
     this.startPromise = listenForLocalRpc(server, {
       name: 'notebook-rpc',
       host: this.host,
       transport: this.transport
-    }).then((connection) => ({ ...connection, token: this.token }))
+    })
+      .then((connection) => {
+        log.info('notebook RPC server listening', localRpcServerLogFields(server))
+        return { ...connection, token: this.token }
+      })
+      .catch((error) => {
+        log.error('notebook RPC server failed to listen', {
+          ...localRpcServerLogFields(server),
+          ...errorLogFields(error)
+        })
+        throw error
+      })
 
     return this.startPromise
   }
@@ -306,12 +328,16 @@ class NotebookLocalRpcServer {
 
     if (!server) return
 
+    const connection = localRpcServerLogFields(server)
+    log.info('notebook RPC server stopping', connection)
+
     await new Promise<void>((resolve, reject) => {
       server.close((error) => {
         if (error) reject(error)
         else resolve()
       })
     })
+    log.info('notebook RPC server stopped', { ...connection, listening: server.listening })
   }
 
   // Remembers the final ACP session id for notebook aliases created before session start.

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -24,7 +24,7 @@ import {
 } from '../../shared/reviewer'
 import { assertBlockInScope, type ReviewerHostServer } from './host-sdk'
 import { createLogger } from '../logger'
-import { listenForLocalRpc } from '../local-rpc-transport'
+import { listenForLocalRpc, localRpcServerLogFields } from '../local-rpc-transport'
 import { createReviewerMcpStdioProxyConfig } from './mcp-stdio-proxy'
 
 const log = createLogger('reviewer:mcp')
@@ -261,16 +261,15 @@ export class ReviewerMcpServer {
     this._endpoint = `${connection.endpoint}/mcp`
     this._socketPath = connection.socketPath
 
-    log.info('reviewer MCP server started', {
-      transport: this._socketPath ? 'pipe' : 'tcp',
-      ...(!this._socketPath ? { endpoint: this._endpoint } : {})
-    })
+    log.info('reviewer MCP server started', localRpcServerLogFields(this.httpServer))
 
     return { endpoint: this._endpoint, token: this.token }
   }
 
   // Stops the HTTP server; called after the reviewer session is disposed.
   async stop(): Promise<void> {
+    const connection = localRpcServerLogFields(this.httpServer)
+    log.info('reviewer MCP server stopping', connection)
     for (const transport of this.transports.values()) {
       await transport.close().catch(() => undefined)
     }
@@ -278,7 +277,10 @@ export class ReviewerMcpServer {
 
     await new Promise<void>((resolve) => this.httpServer.close(() => resolve()))
 
-    log.info('reviewer MCP server stopped')
+    log.info('reviewer MCP server stopped', {
+      ...connection,
+      listening: this.httpServer.listening
+    })
   }
 
   // Returns the native HTTP config, or the Windows stdio proxy config for a named pipe.

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -1069,17 +1069,41 @@ describe('Responses-compatible bridge conversion', () => {
     }
   })
 
-  it('advertises reviewer MCP functions only for a trusted registered session key', async () => {
+  it('carries DeepSeek reviewer tool calls only for a trusted registered session key', async () => {
     const upstreamRequests: Array<Record<string, unknown>> = []
+    const upstreamUrls: string[] = []
     const upstreamFetch = vi.fn(
-      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
-        upstreamRequests.push(JSON.parse(String(init?.body)) as Record<string, unknown>)
+      async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        const request = JSON.parse(String(init?.body)) as Record<string, unknown>
+        const reviewer = upstreamRequests.length === 1
+        upstreamUrls.push(String(url))
+        upstreamRequests.push(request)
         return new Response(
           [
             `data: ${JSON.stringify({
               id: 'chat-reviewer-scope',
-              model: 'model-a',
-              choices: [{ index: 0, delta: {}, finish_reason: 'stop' }]
+              model: 'deepseek-v4-pro',
+              choices: [
+                {
+                  index: 0,
+                  delta: reviewer
+                    ? {
+                        tool_calls: [
+                          {
+                            index: 0,
+                            id: 'call-deepseek-reviewer',
+                            type: 'function',
+                            function: {
+                              name: 'mcp__open_science_reviewer__submit_findings',
+                              arguments: '{"checks":[]}'
+                            }
+                          }
+                        ]
+                      }
+                    : {},
+                  finish_reason: reviewer ? 'tool_calls' : 'stop'
+                }
+              ]
             })}`,
             '',
             'data: [DONE]',
@@ -1091,7 +1115,7 @@ describe('Responses-compatible bridge conversion', () => {
     )
     const bridge = new ResponsesBridge(
       {
-        baseUrl: 'https://vendor.example/v1',
+        baseUrl: 'https://api.deepseek.com/v1',
         namespacedTools: [
           {
             namespace: 'mcp__open_science_notebook',
@@ -1117,7 +1141,7 @@ describe('Responses-compatible bridge conversion', () => {
       upstreamFetch
     )
     const connection = await bridge.start()
-    const post = async (input: string, promptCacheKey: string): Promise<void> => {
+    const post = async (input: string, promptCacheKey: string): Promise<string> => {
       const response = await fetch(`${connection.baseUrl}/responses`, {
         method: 'POST',
         headers: {
@@ -1125,7 +1149,7 @@ describe('Responses-compatible bridge conversion', () => {
           'content-type': 'application/json'
         },
         body: JSON.stringify({
-          model: 'model-a',
+          model: 'deepseek-v4-pro',
           input,
           prompt_cache_key: promptCacheKey,
           stream: true,
@@ -1137,7 +1161,7 @@ describe('Responses-compatible bridge conversion', () => {
           tool_choice: { type: 'function', name: 'exec_command' }
         })
       })
-      await response.text()
+      return response.text()
     }
 
     try {
@@ -1146,7 +1170,10 @@ describe('Responses-compatible bridge conversion', () => {
 
       await post(`${legacyReviewerMarker} normal user content`, 'normal-session')
       bridge.registerReviewerSession('reviewer-session')
-      await post('review this turn without a model-visible routing marker', 'reviewer-session')
+      const reviewerOutput = await post(
+        'review this turn without a model-visible routing marker',
+        'reviewer-session'
+      )
       expect(bridge.unregisterReviewerSession('reviewer-session')).toBe(true)
 
       const toolNames = upstreamRequests.map((request) =>
@@ -1164,6 +1191,14 @@ describe('Responses-compatible bridge conversion', () => {
         function: { name: 'exec_command' }
       })
       expect(upstreamRequests[1]?.tool_choice).toBe('auto')
+      expect(upstreamUrls).toEqual([
+        'https://api.deepseek.com/v1/chat/completions',
+        'https://api.deepseek.com/v1/chat/completions'
+      ])
+      expect(reviewerOutput).toContain('"type":"function_call"')
+      expect(reviewerOutput).toContain('"namespace":"mcp__open_science_reviewer"')
+      expect(reviewerOutput).toContain('"name":"submit_findings"')
+      expect(reviewerOutput).toContain('"call_id":"call-deepseek-reviewer"')
     } finally {
       await bridge.close()
     }


### PR DESCRIPTION
## Problem

The Windows named-pipe transport from #738 removes loopback TCP from packaged app tools, but failure reports still lack the bound RPC lifecycle state and exact ACP MCP readiness status. The Windows installer gate also did not exercise the installed Notebook and Artifact stdio entry points, and the Reviewer bridge lacked a DeepSeek tool-call compatibility case.

## Proposed change

- Log Notebook/Artifact local RPC start, listening, stopping, and stopped state with transport, host or pipe path, port, and listening status. Preserve nested system error details such as `cause.code` in fetch failures.
- Log explicit ACP MCP readiness failures for `failed`, `needs-auth`, disabled, query errors, and timeout before the generic session startup error is returned.
- Extend the existing Windows installer smoke to launch the installed `open-science.exe` against the bundled `app.asar` MCP entry and exercise `notebook_state -> bash_execute -> write_artifact_file` over an authenticated named pipe.
- Cover DeepSeek Reviewer tool advertisement, tool choice, namespaced tool-call conversion, and trusted Reviewer session scoping.

## Scope and non-goals

- No architecture, persistence schema, data relationship, or user interaction changes.
- No new production test endpoint or alternate transport path; the smoke reuses the existing installer gate and packaged MCP entry points.
- Renderer native-crash and white-screen investigation is not part of this PR.

## Acceptance criteria and validation

All checks below ran after the last material edit and after rebasing onto the latest `main`:

- RPC lifecycle and named-pipe/TCP metadata -> `npm test -- --run src/main/local-rpc-transport.test.ts src/main/notebook/local-rpc-server.test.ts src/main/reviewer/mcp-server.test.ts` -> passed.
- ACP readiness state diagnostics -> `npm test -- --run src/main/acp/claude-agent-acp-patch.test.ts` -> passed for failed, needs-auth, and timeout.
- DeepSeek Reviewer protocol compatibility -> `npm test -- --run src/main/settings/responses-bridge.test.ts` -> 59 passed.
- Installer smoke planning and packaged MCP entry resolution -> `npm test -- --run scripts/windows-installer-smoke.test.ts` -> passed.
- Combined final Test Impact Set -> 6 files, 138 tests passed.
- Affected Node runtime types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors; 17 pre-existing warnings remain outside this diff.

The actual installed Windows executable and named-pipe chain cannot run on the local macOS host or in the current PR Gate. It is wired into the existing blocking Windows installer step in the reusable Build workflow and will execute on the next nightly/release packaged build. Until that platform run occurs, the packaged chain remains the explicit uncovered risk; PR Gate Windows core/E2E checks are supplementary, not evidence for the installed chain.

## Review focus

- Named-pipe lifecycle cleanup and child stderr preservation in the installer smoke.
- Exact readiness details emitted by the patched Claude ACP adapter before its generic startup error.
- Reviewer-session trust boundary and DeepSeek namespaced tool-call conversion.