### PR TITLE
refactor(acp): extract live effort configuration

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16691,6 +16691,40 @@ describe('ACP runtime — session effort', () => {
     expect(fakeAgent.configChanges).toEqual([])
   })
 
+  it('attempts every remaining open session after a live effort update is rejected', async () => {
+    const process = new FakeAgentProcess()
+    let rejectLiveUpdate = false
+    const fakeAgent = startFakeAgent(process, ['rejected-session', 'updated-session'], {
+      configOptions: [thoughtLevelOption(['low', 'high'])],
+      onSetConfigOption: ({ sessionId }) => {
+        if (rejectLiveUpdate && sessionId === 'rejected-session') {
+          throw new Error('live effort rejected')
+        }
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/claude',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+    rejectLiveUpdate = true
+
+    const applied = await runtime.applyReasoningEffortChange('high')
+
+    expect(applied).toBe(false)
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 'rejected-session', configId: 'effort', value: 'high' },
+      { sessionId: 'updated-session', configId: 'effort', value: 'high' }
+    ])
+  })
+
   it('declines the live change when the framework bakes effort into its spawn config', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['s-effort'], {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -895,8 +895,7 @@ class AcpRuntime {
         session,
         configOptions:
           (this.sessionRegistry.lookup(appSessionId)?.aggregate.snapshot().configOptions as
-            | readonly SessionConfigOption[]
-            | undefined) ??
+            readonly SessionConfigOption[] | undefined) ??
           (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
             .newSessionResponse?.configOptions,
         assertCurrent: () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -64,7 +64,6 @@ import {
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { toCodexTurnTokenUsage } from './codex-turn-usage'
 import { fetchOpenCodeUsageSnapshot, sumOpenCodeTurnUsage } from './opencode-turn-usage'
-import { resolveSessionEffortOption, type SessionModelSelection } from './session-config'
 import { describePromptError, isProviderPromptError } from './prompt-error'
 import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { ConversationPermissionGrantStore } from './permission-broker'
@@ -878,7 +877,6 @@ class AcpRuntime {
   // either). On success the generation view tracks the new level, so sessions created later in
   // this process inherit it; the persisted setting covers the next respawn.
   async applyReasoningEffortChange(effort: ResolvedReasoningEffort): Promise<boolean> {
-    if (!this.framework.supportsLiveEffortChange) return false
     // A provider/model switch may be waiting for an in-flight turn to finish. The incoming effort was
     // resolved against that newly selected model, while this connection still owns the old one. Let
     // the persisted setting reach the fresh backend after reconnect instead of leaking it here.
@@ -887,64 +885,28 @@ class AcpRuntime {
     const backend = this.backendGeneration.updateReasoningEffort(effort)
     this.connectionResources.setBridgeReasoningEffort(backend.session.effort)
     const connection = this.connection
-    if (!connection) return true
+    if (!connection) return backend.framework.supportsLiveEffortChange
 
-    let allApplied = true
-    let appliedToAny = false
-
-    const activeEntries = this.activeSessionEntries()
-    for (const [appSessionId, session] of activeEntries) {
-      const configOptions =
-        (this.sessionRegistry.lookup(appSessionId)?.aggregate.snapshot().configOptions as
-          readonly SessionConfigOption[] | undefined) ??
-        (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
-          .newSessionResponse?.configOptions
-      const selection = resolveSessionEffortOption(configOptions, effort)
-
-      if (!selection) {
-        log.info('no session effort option to apply', this.diagnosticContext())
-        continue
-      }
-
-      if (!(await this.sendSessionEffort(session, selection, connection))) {
-        allApplied = false
-      } else {
-        appliedToAny = true
-      }
-    }
-
-    // No open session could take the level over ACP. For Claude there is no other channel — the
-    // model simply doesn't support effort, and a respawn can't change that. Codex also bakes the
-    // level into its spawn config (model_reasoning_effort), so a reconnect DOES deliver it: report
-    // failure rather than leaving the UI showing a level the running session never received.
-    if (!appliedToAny && activeEntries.length > 0 && this.framework.id === 'codex') return false
-
-    return allApplied
-  }
-
-  // Sends one resolved effort selection to a session. Best-effort: a failure is logged (never
-  // thrown) and reported as false, so live callers can escalate while build-time callers stay
-  // non-fatal.
-  private async sendSessionEffort(
-    session: ActiveSession,
-    selection: SessionModelSelection,
-    connection: ClientConnection | undefined = this.connection
-  ): Promise<boolean> {
-    try {
-      await connection?.agent.request(acp.methods.agent.session.setConfigOption, {
-        sessionId: session.sessionId,
-        configId: selection.configId,
-        value: selection.value
-      })
-      log.info('session effort applied', this.diagnosticContext())
-      return true
-    } catch (error) {
-      log.warn('set session effort failed', {
-        ...diagnosticErrorFields(error),
-        ...this.diagnosticContext()
-      })
-      return false
-    }
+    const facts = await this.sessionConfigurator.applyLiveEffort({
+      backend,
+      connection,
+      effort,
+      sessions: this.activeSessionEntries().map(([appSessionId, session]) => ({
+        session,
+        configOptions:
+          (this.sessionRegistry.lookup(appSessionId)?.aggregate.snapshot().configOptions as
+            | readonly SessionConfigOption[]
+            | undefined) ??
+          (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
+            .newSessionResponse?.configOptions,
+        assertCurrent: () => {
+          if (this.activeSessionFor(appSessionId) !== session) {
+            throw new Error('ACP session startup was superseded.')
+          }
+        }
+      }))
+    })
+    return !facts.reconnectRequired
   }
 
   // Starts a fresh agent process connection and initializes protocol capabilities.

--- a/src/main/acp/session-configurator.test.ts
+++ b/src/main/acp/session-configurator.test.ts
@@ -2,7 +2,7 @@ import * as acp from '@agentclientprotocol/sdk'
 import type { ActiveSession, ClientConnection, SessionConfigOption } from '@agentclientprotocol/sdk'
 import { describe, expect, it, vi } from 'vitest'
 
-import { claudeCodeFramework, codexFramework } from '../agent-framework'
+import { claudeCodeFramework, codexFramework, opencodeFramework } from '../agent-framework'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
 import { AcpSessionConfigurator } from './session-configurator'
 
@@ -277,5 +277,196 @@ describe('AcpSessionConfigurator', () => {
       appliedModel: undefined
     })
     expect(request).toHaveBeenCalledOnce()
+  })
+
+  it('applies live effort to every eligible open session and returns immutable fallback facts', async () => {
+    const request = vi.fn(async () => ({}))
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const assertCurrentConnection = vi.fn()
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection,
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connected' })
+    })
+    const sessions = ['session-1', 'session-2'].map((sessionId) => ({
+      session: { sessionId } as unknown as ActiveSession,
+      configOptions: [selectOption('effort', 'thought_level', 'low', ['low', 'high'])],
+      assertCurrent: vi.fn()
+    }))
+
+    const facts = await configurator.applyLiveEffort({
+      backend: backendView({ modelRequired: false, effort: 'high' }),
+      connection,
+      effort: 'high',
+      sessions
+    })
+
+    expect(request).toHaveBeenNthCalledWith(1, acp.methods.agent.session.setConfigOption, {
+      sessionId: 'session-1',
+      configId: 'effort',
+      value: 'high'
+    })
+    expect(request).toHaveBeenNthCalledWith(2, acp.methods.agent.session.setConfigOption, {
+      sessionId: 'session-2',
+      configId: 'effort',
+      value: 'high'
+    })
+    expect(sessions[0].assertCurrent).toHaveBeenCalledOnce()
+    expect(sessions[1].assertCurrent).toHaveBeenCalledOnce()
+    expect(assertCurrentConnection).toHaveBeenCalledTimes(2)
+    expect(assertCurrentConnection).toHaveBeenCalledWith(connection)
+    expect(facts).toEqual({ reconnectRequired: false })
+    expect(Object.isFrozen(facts)).toBe(true)
+  })
+
+  it('isolates a superseded session and requests reconnect after attempting the remaining sessions', async () => {
+    const request = vi.fn(async () => ({}))
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connected' })
+    })
+    const configOptions = [selectOption('effort', 'thought_level', 'low', ['low', 'high'])]
+    const staleSession = {
+      session: { sessionId: 'stale-session' } as unknown as ActiveSession,
+      configOptions,
+      assertCurrent: vi.fn(() => {
+        throw new Error('ACP session startup was superseded.')
+      })
+    }
+    const currentSession = {
+      session: { sessionId: 'current-session' } as unknown as ActiveSession,
+      configOptions,
+      assertCurrent: vi.fn()
+    }
+
+    const facts = await configurator.applyLiveEffort({
+      backend: backendView({ modelRequired: false, effort: 'high' }),
+      connection,
+      effort: 'high',
+      sessions: [staleSession, currentSession]
+    })
+
+    expect(request).toHaveBeenCalledOnce()
+    expect(request).toHaveBeenCalledWith(acp.methods.agent.session.setConfigOption, {
+      sessionId: 'current-session',
+      configId: 'effort',
+      value: 'high'
+    })
+    expect(staleSession.assertCurrent).toHaveBeenCalledOnce()
+    expect(currentSession.assertCurrent).toHaveBeenCalledOnce()
+    expect(facts).toEqual({ reconnectRequired: true })
+  })
+
+  it('requests reconnect without a protocol call when effort is baked into spawn configuration', async () => {
+    const request = vi.fn(async () => ({}))
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const assertCurrent = vi.fn()
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'opencode', generation: 1, status: 'connected' })
+    })
+
+    const facts = await configurator.applyLiveEffort({
+      backend: backendView({ modelRequired: false, effort: 'high' }, opencodeFramework),
+      connection,
+      effort: 'high',
+      sessions: [
+        {
+          session: { sessionId: 'session-1' } as unknown as ActiveSession,
+          configOptions: [selectOption('effort', 'thought_level', 'low', ['low', 'high'])],
+          assertCurrent
+        }
+      ]
+    })
+
+    expect(request).not.toHaveBeenCalled()
+    expect(assertCurrent).not.toHaveBeenCalled()
+    expect(facts).toEqual({ reconnectRequired: true })
+  })
+
+  it('requests reconnect when no open Codex session advertises a live effort option', async () => {
+    const request = vi.fn(async () => ({}))
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const assertCurrent = vi.fn()
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'codex', generation: 1, status: 'connected' })
+    })
+
+    const facts = await configurator.applyLiveEffort({
+      backend: backendView({ modelRequired: false, effort: 'high' }, codexFramework),
+      connection,
+      effort: 'high',
+      sessions: [
+        {
+          session: { sessionId: 'session-1' } as unknown as ActiveSession,
+          configOptions: [],
+          assertCurrent
+        }
+      ]
+    })
+
+    expect(request).not.toHaveBeenCalled()
+    expect(assertCurrent).not.toHaveBeenCalled()
+    expect(facts).toEqual({ reconnectRequired: true })
+  })
+
+  it('does not request reconnect when a Claude session has no live effort option', async () => {
+    const request = vi.fn(async () => ({}))
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connected' })
+    })
+
+    const facts = await configurator.applyLiveEffort({
+      backend: backendView({ modelRequired: false, effort: 'high' }),
+      connection,
+      effort: 'high',
+      sessions: [
+        {
+          session: { sessionId: 'session-1' } as unknown as ActiveSession,
+          configOptions: [],
+          assertCurrent: vi.fn()
+        }
+      ]
+    })
+
+    expect(request).not.toHaveBeenCalled()
+    expect(facts).toEqual({ reconnectRequired: false })
+  })
+
+  it('isolates a rejected live update and still attempts every remaining eligible session', async () => {
+    const request = vi.fn(async (_method: unknown, params: unknown) => {
+      if ((params as { sessionId: string }).sessionId === 'rejected-session') {
+        throw new Error('live effort rejected')
+      }
+      return {}
+    })
+    const connection = { agent: { request } } as unknown as ClientConnection
+    const configurator = new AcpSessionConfigurator({
+      assertCurrentConnection: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connected' })
+    })
+    const configOptions = [selectOption('effort', 'thought_level', 'low', ['low', 'high'])]
+
+    const facts = await configurator.applyLiveEffort({
+      backend: backendView({ modelRequired: false, effort: 'high' }),
+      connection,
+      effort: 'high',
+      sessions: ['rejected-session', 'updated-session'].map((sessionId) => ({
+        session: { sessionId } as unknown as ActiveSession,
+        configOptions,
+        assertCurrent: vi.fn()
+      }))
+    })
+
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(request).toHaveBeenLastCalledWith(acp.methods.agent.session.setConfigOption, {
+      sessionId: 'updated-session',
+      configId: 'effort',
+      value: 'high'
+    })
+    expect(facts).toEqual({ reconnectRequired: true })
   })
 })

--- a/src/main/acp/session-configurator.ts
+++ b/src/main/acp/session-configurator.ts
@@ -5,6 +5,7 @@ import type {
   PermissionProfileId,
   SessionPermissionProfileState
 } from '../../shared/permission-profiles'
+import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import { createLogger, diagnosticErrorFields } from '../logger'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
 import {
@@ -21,6 +22,16 @@ type ConfigurationContext = Readonly<{
 }>
 type StartupConfiguration = ConfigurationContext &
   Readonly<{ session: ActiveSession; permissionProfile: PermissionProfileId }>
+type LiveEffortSession = Readonly<{
+  session: ActiveSession
+  configOptions: readonly SessionConfigOption[] | null | undefined
+  assertCurrent: () => void
+}>
+type LiveEffortConfiguration = ConfigurationContext &
+  Readonly<{
+    effort: ResolvedReasoningEffort
+    sessions: readonly LiveEffortSession[]
+  }>
 type ModelApplication = Readonly<{
   appliedModel: string | undefined
   configOptions: SessionConfigOption[] | null | undefined
@@ -29,6 +40,9 @@ export type AcpSessionConfigurationFacts = Readonly<{
   permissionProfile: SessionPermissionProfileState
   appliedModel: string | undefined
   configOptions: SessionConfigOption[] | undefined
+}>
+export type AcpLiveEffortConfigurationFacts = Readonly<{
+  reconnectRequired: boolean
 }>
 const configOptionsOf = (session: ActiveSession): SessionConfigOption[] | null | undefined =>
   (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
@@ -76,6 +90,38 @@ export class AcpSessionConfigurator {
     input: StartupConfiguration
   ): Promise<Readonly<SessionPermissionProfileState>> {
     return deepFreeze(structuredClone(await this.applyPermissionMode(input)))
+  }
+
+  async applyLiveEffort(
+    input: LiveEffortConfiguration
+  ): Promise<AcpLiveEffortConfigurationFacts> {
+    if (!input.backend.framework.supportsLiveEffortChange) {
+      return deepFreeze({ reconnectRequired: true })
+    }
+    let reconnectRequired = false
+    let appliedToAny = false
+    for (const candidate of input.sessions) {
+      const selection = resolveSessionEffortOption(candidate.configOptions, input.effort)
+      if (!selection) {
+        log.info('no session effort option to apply', this.deps.diagnosticContext(input.backend))
+        continue
+      }
+      try {
+        candidate.assertCurrent()
+        if (await this.sendEffort(input, candidate.session, selection)) appliedToAny = true
+        else reconnectRequired = true
+      } catch (error) {
+        log.warn('set session effort failed', {
+          ...diagnosticErrorFields(error),
+          ...this.deps.diagnosticContext(input.backend)
+        })
+        reconnectRequired = true
+      }
+    }
+    if (!appliedToAny && input.sessions.length > 0 && input.backend.framework.id === 'codex') {
+      reconnectRequired = true
+    }
+    return deepFreeze({ reconnectRequired })
   }
 
   private async applyPermissionMode(

--- a/src/main/acp/session-configurator.ts
+++ b/src/main/acp/session-configurator.ts
@@ -92,9 +92,7 @@ export class AcpSessionConfigurator {
     return deepFreeze(structuredClone(await this.applyPermissionMode(input)))
   }
 
-  async applyLiveEffort(
-    input: LiveEffortConfiguration
-  ): Promise<AcpLiveEffortConfigurationFacts> {
+  async applyLiveEffort(input: LiveEffortConfiguration): Promise<AcpLiveEffortConfigurationFacts> {
     if (!input.backend.framework.supportsLiveEffortChange) {
       return deepFreeze({ reconnectRequired: true })
     }


### PR DESCRIPTION
## Problem

Live reasoning-effort application still lived in `AcpRuntime`, leaving the stateless session configurator responsible only for startup configuration after ARD-06A.

Related: #458. This PR only deepens a forward orchestration seam; it does not add Issue #458 orchestration state, schema, wire/public contracts, or user-visible behavior.

## Proposed change

- Extend `AcpSessionConfigurator` with live-effort fan-out across captured open sessions.
- Return one frozen reconnect-fallback fact without writing Registry, Settings, Permission, aggregate, backend-generation, or bridge state.
- Keep pending-reconnect validation, backend-generation and bridge updates, Registry-derived option snapshots, session-current assertions, and the existing boolean surface in Runtime.
- Isolate rejected or superseded sessions so every remaining eligible session is still attempted.

## Scope and non-goals

- Preserve the Codex, Claude, and baked-spawn fallback matrix.
- Do not change startup mode, model, or startup-effort behavior.
- Do not change schema/data, IPC/preload, Web/Task/CLI/SDK surfaces, UI, Specialist, Permission, Compute, Reviewer, Artifact, replay/reset/adoption, or Issue #458 behavior.
- Do not begin ARD-08.

Production raw churn: **123** lines, within the ARD-06B expected 100–150 range and below the 500-line hard stop.

## Ownership and sequence

`AcpSessionConfigurator` remains stateless. It fans the requested live effort out to a captured set of open sessions and returns one immutable reconnect-fallback fact. Runtime remains responsible for pending-reconnect validation, current-session/generation checks, backend-generation and bridge mutation, Registry-derived option snapshots, and its existing boolean result. Because no state or resource ownership transfers to the configurator, an ownership diagram would imply a writer that does not exist.

## Acceptance criteria and validation

All recorded checks ran after the last material edit:

- Live-effort matrix, failure isolation, Runtime/Coordinator/session contracts, and the settings boolean consumer → `npm test -- --run src/main/acp/session-configurator.test.ts src/main/acp/runtime.test.ts src/main/acp/runtime-coordinator.test.ts src/main/settings/workflows.test.ts` → **480 passed**.
- ACP main-process contracts → `npm run typecheck:node` → passed.
- Source standards → `npm run lint` → passed with 0 errors; unrelated pre-existing warnings remained outside this diff.
- Changed-file formatting → `npx prettier --check src/main/acp/session-configurator.ts src/main/acp/session-configurator.test.ts src/main/acp/runtime.ts src/main/acp/runtime.test.ts` → passed.
- Patch whitespace → `git diff --check 06005a662247b850d119cec9719f204e485d39ff...HEAD` → passed.
- Independent Standards review → no findings.
- Independent Spec review → no findings.
- Final-head online gates → PR Gate, AI review, CodeQL, Static checks, Unit tests, Coverage macOS, macOS build/E2E, and Windows E2E all passed. `Windows core` was skipped by classification.

The full local suite was intentionally not run. The focused set included every directly affected consumer: configurator, Runtime, Coordinator, and Settings workflow boolean consumer. The final-head online PR Gate is the authoritative full and cross-platform evidence.

## Review focus

- Reconnect-fallback matrix and per-session failure isolation.
- Backend-generation affinity plus current Session/connection revalidation.
- Configurator statelessness and absence of alternate writers.
- Preservation of the existing Runtime boolean surface.

## Uncovered risks

Real provider/platform behavior exercised only by online lanes was not reproduced locally, and no full local portable suite was run. Cross-platform confidence therefore comes from the final-head online gates. Issue #458 integration remains deliberately deferred.
