### PR TITLE
refactor(acp): deepen context usage turn ownership

### DIFF
--- a/src/main/acp/context-usage-tracker.test.ts
+++ b/src/main/acp/context-usage-tracker.test.ts
@@ -722,6 +722,195 @@ describe('ContextUsageTracker', () => {
     })
   })
 
+  it('closes a completed turn once and restores its transient preflight reading', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    tracker.beginSession('s1', { frameworkId: 'opencode', model: 'deepseek-v4' })
+    tracker.appendText('s1', 'messages', 'committed history')
+    tracker.reconcileProviderUsage('s1', { used: 20, size: 128_000 })
+
+    const turn = tracker.beginTurn('s1')
+    tracker.appendPromptContent('s1', 'new prompt')
+    tracker.observeSessionUpdate('s1', {
+      sessionId: 's1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        messageId: 'answer-1',
+        content: { type: 'text', text: 'completed answer' }
+      }
+    })
+    expect(tracker.refreshUsage('s1', 'preflight', 128_000)).toBe(true)
+
+    expect(turn.complete()).toBe(true)
+    expect(turn.complete()).toBe(false)
+    expect(tracker.usage('s1')).toMatchObject({
+      used: 20,
+      size: 128_000,
+      breakdown: { status: 'reconciled' }
+    })
+
+    tracker.commitPendingAssistantOutput('s1')
+    expect(tracker.estimate('s1')?.categories).toContainEqual({
+      key: 'messages',
+      tokens: 6,
+      estimated: true
+    })
+  })
+
+  it('rolls back a turn rejected before provider data to its captured checkpoint', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    tracker.beginSession('s1', { frameworkId: 'opencode', model: 'deepseek-v4' })
+    tracker.appendText('s1', 'messages', 'committed history')
+    tracker.reconcileProviderUsage('s1', { used: 20, size: 128_000 })
+    const beforeTurn = tracker.usage('s1')
+
+    const turn = tracker.beginTurn('s1')
+    tracker.appendPromptContent('s1', 'rejected prompt content')
+    tracker.replaceText('s1', 'prompt-skill', 'skills', 'rejected skill content')
+    expect(tracker.refreshUsage('s1', 'preflight', 128_000)).toBe(true)
+
+    turn.fail()
+    turn.fail()
+    expect(tracker.usage('s1')).toEqual(beforeTurn)
+    expect(tracker.estimate('s1')?.categories).toEqual([
+      { key: 'messages', tokens: 2, estimated: true }
+    ])
+  })
+
+  it('retains a partially observed failed turn while restoring prior authoritative usage', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    tracker.beginSession('s1', { frameworkId: 'opencode', model: 'deepseek-v4' })
+    tracker.appendText('s1', 'messages', 'committed history')
+    tracker.reconcileProviderUsage('s1', { used: 20, size: 128_000 })
+    const beforeTurn = tracker.usage('s1')
+
+    const turn = tracker.beginTurn('s1')
+    tracker.appendPromptContent('s1', 'new prompt')
+    expect(tracker.refreshUsage('s1', 'preflight', 128_000)).toBe(true)
+    tracker.observeSessionUpdate('s1', {
+      sessionId: 's1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        messageId: 'partial-answer',
+        content: { type: 'text', text: 'partial answer' }
+      }
+    })
+    tracker.observeSessionUpdate('s1', {
+      sessionId: 's1',
+      update: {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'partial-tool',
+        status: 'completed',
+        rawOutput: 'partial tool result'
+      }
+    })
+
+    turn.fail()
+    turn.fail()
+    expect(tracker.usage('s1')).toEqual(beforeTurn)
+    tracker.commitPendingAssistantOutput('s1')
+    expect(tracker.estimate('s1')?.categories).toEqual([
+      { key: 'tools', tokens: 3, estimated: true },
+      { key: 'messages', tokens: 6, estimated: true }
+    ])
+  })
+
+  it('does not let a superseded turn restore over its successor revision', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    tracker.beginSession('s1', { frameworkId: 'opencode', model: 'deepseek-v4' })
+    tracker.reconcileProviderUsage('s1', { used: 20, size: 128_000 })
+
+    const stale = tracker.beginTurn('s1')
+    tracker.appendPromptContent('s1', 'first prompt')
+    expect(tracker.refreshUsage('s1', 'preflight', 128_000)).toBe(true)
+
+    const successor = tracker.beginTurn('s1')
+    tracker.appendPromptContent('s1', 'successor prompt')
+    tracker.reconcileProviderUsage('s1', { used: 42, size: 128_000 })
+
+    stale.fail()
+    expect(stale.complete()).toBe(false)
+    stale.supersede()
+    expect(tracker.usage('s1')).toMatchObject({
+      used: 42,
+      size: 128_000,
+      breakdown: { status: 'reconciled' }
+    })
+
+    successor.supersede()
+    successor.supersede()
+  })
+
+  it('invalidates a matching turn when its estimate session resets', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    const input = { frameworkId: 'opencode' as const, model: 'deepseek-v4' }
+    tracker.beginSession('s1', input)
+    tracker.reconcileProviderUsage('s1', { used: 20, size: 128_000 })
+    const stale = tracker.beginTurn('s1')
+    tracker.appendPromptContent('s1', 'old prompt')
+    expect(tracker.refreshUsage('s1', 'preflight', 128_000)).toBe(true)
+
+    tracker.resetSession('s1', input)
+    tracker.reconcileProviderUsage('s1', { used: 7, size: 128_000 })
+
+    stale.fail()
+    expect(tracker.usage('s1')).toMatchObject({ used: 7, size: 128_000 })
+  })
+
+  it('invalidates a matching turn when its session is deleted and reused', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    const input = { frameworkId: 'opencode' as const, model: 'deepseek-v4' }
+    tracker.beginSession('s1', input)
+    tracker.reconcileProviderUsage('s1', { used: 20, size: 128_000 })
+    const stale = tracker.beginTurn('s1')
+    tracker.appendPromptContent('s1', 'deleted prompt')
+    expect(tracker.refreshUsage('s1', 'preflight', 128_000)).toBe(true)
+
+    tracker.deleteSession('s1')
+    tracker.beginSession('s1', input)
+    tracker.reconcileProviderUsage('s1', { used: 7, size: 128_000 })
+
+    stale.fail()
+    expect(tracker.usage('s1')).toMatchObject({ used: 7, size: 128_000 })
+  })
+
+  it('invalidates every matching turn when its provider generation clears', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    const input = { frameworkId: 'opencode' as const, model: 'deepseek-v4' }
+    tracker.beginSession('s1', input)
+    tracker.beginSession('s2', input)
+    const staleTurns = [tracker.beginTurn('s1'), tracker.beginTurn('s2')]
+    tracker.appendPromptContent('s1', 'old prompt one')
+    tracker.appendPromptContent('s2', 'old prompt two')
+
+    tracker.clear()
+    tracker.beginSession('s1', input)
+    tracker.reconcileProviderUsage('s1', { used: 7, size: 128_000 })
+
+    for (const turn of staleTurns) turn.fail()
+    expect(tracker.usage('s1')).toMatchObject({ used: 7, size: 128_000 })
+  })
+
+  it('invalidates a prompt turn when compaction captures its own checkpoint', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    const input = { frameworkId: 'claude-code' as const, model: 'claude-sonnet-4-5' }
+    tracker.beginSession('s1', input)
+    tracker.reconcileProviderUsage('s1', { used: 100, size: 200_000 })
+    const stale = tracker.beginTurn('s1')
+    tracker.appendPromptContent('s1', 'overflowing prompt')
+    expect(tracker.refreshUsage('s1', 'preflight', 200_000)).toBe(true)
+
+    const compactionCheckpoint = tracker.checkpointSession('s1')
+    tracker.reconcileProviderUsage('s1', { used: 12, size: 200_000 })
+
+    stale.fail()
+    tracker.resetAfterCompaction('s1', input, compactionCheckpoint, 200_000)
+    expect(tracker.usage('s1')).toMatchObject({
+      used: 12,
+      size: 200_000,
+      breakdown: { status: 'reconciled' }
+    })
+  })
+
   it('keeps only a fresh provider reading after context compaction', () => {
     const tracker = new ContextUsageTracker(wordCounter)
     const input = { frameworkId: 'claude-code' as const, model: 'claude-sonnet-4-5' }

--- a/src/main/acp/context-usage-tracker.ts
+++ b/src/main/acp/context-usage-tracker.ts
@@ -57,6 +57,28 @@ type SessionUpdateObservation = {
   skillFilePath?: string
 }
 
+const contextUsageTurnHandleKey = Symbol('context-usage-turn-handle')
+
+type ContextUsageTurnHandle = Readonly<{
+  readonly [contextUsageTurnHandleKey]: symbol
+  // Completion reports whether the transient preflight usage projection was restored, so the caller
+  // can publish that one observable change. Other terminal operations are state-owner cleanup only.
+  complete: () => boolean
+  fail: () => void
+  supersede: () => void
+}>
+
+type ContextUsageTurnOutcome =
+  'completed' | 'rejected-before-provider-data' | 'partially-observed-failure' | 'superseded'
+
+type ContextUsageTurn = {
+  readonly sessionId: string
+  readonly revision: number
+  readonly checkpoint: SessionEstimateCheckpoint
+  providerDataObserved: boolean
+  outcome?: ContextUsageTurnOutcome
+}
+
 const ESTIMATED_CATEGORY_KEYS: EstimatedCategoryKey[] = [
   'system',
   'tools',
@@ -317,8 +339,71 @@ class ContextUsageTracker {
   private readonly sessions = new Map<string, SessionEstimate>()
   private readonly usageBySession = new Map<string, AcpContextUsage>()
   private readonly usageRevisions = new Map<string, number>()
+  private readonly activeTurnsBySession = new Map<string, ContextUsageTurn>()
+  private nextTurnRevision = 0
 
   constructor(private readonly counter: TokenCounter = defaultTokenCounter) {}
+
+  beginTurn(sessionId: string): ContextUsageTurnHandle {
+    this.supersedeActiveTurn(sessionId)
+    const turn: ContextUsageTurn = {
+      sessionId,
+      revision: ++this.nextTurnRevision,
+      checkpoint: this.checkpointSession(sessionId),
+      providerDataObserved: false
+    }
+    this.activeTurnsBySession.set(sessionId, turn)
+    return Object.freeze({
+      [contextUsageTurnHandleKey]: Symbol(),
+      complete: () => this.completeTurn(turn),
+      fail: () => this.failTurn(turn),
+      supersede: () => this.supersedeTurn(turn)
+    })
+  }
+
+  private completeTurn(turn: ContextUsageTurn): boolean {
+    if (turn.outcome || this.activeTurnsBySession.get(turn.sessionId)?.revision !== turn.revision) {
+      return false
+    }
+    turn.outcome = 'completed'
+    this.activeTurnsBySession.delete(turn.sessionId)
+    this.finalizeAssistantOutput(turn.sessionId)
+    return this.restorePreflightUsage(turn.sessionId, turn.checkpoint)
+  }
+
+  private failTurn(turn: ContextUsageTurn): void {
+    if (turn.outcome || this.activeTurnsBySession.get(turn.sessionId)?.revision !== turn.revision) {
+      return
+    }
+    turn.outcome = turn.providerDataObserved
+      ? 'partially-observed-failure'
+      : 'rejected-before-provider-data'
+    this.activeTurnsBySession.delete(turn.sessionId)
+    if (turn.providerDataObserved) {
+      this.finalizeAssistantOutput(turn.sessionId)
+      this.restorePreflightUsage(turn.sessionId, turn.checkpoint)
+    } else {
+      this.restoreSession(turn.sessionId, turn.checkpoint)
+    }
+  }
+
+  private observeActiveTurn(sessionId: string): void {
+    const turn = this.activeTurnsBySession.get(sessionId)
+    if (turn && !turn.outcome) turn.providerDataObserved = true
+  }
+
+  private supersedeTurn(turn: ContextUsageTurn): void {
+    if (turn.outcome || this.activeTurnsBySession.get(turn.sessionId)?.revision !== turn.revision) {
+      return
+    }
+    turn.outcome = 'superseded'
+    this.activeTurnsBySession.delete(turn.sessionId)
+  }
+
+  private supersedeActiveTurn(sessionId: string): void {
+    const turn = this.activeTurnsBySession.get(sessionId)
+    if (turn) this.supersedeTurn(turn)
+  }
 
   beginSession(sessionId: string, input: SessionEstimateInput): void {
     const profile = tokenizerProfileFor(input.frameworkId, input.model)
@@ -353,11 +438,15 @@ class ContextUsageTracker {
   }
 
   resetSession(sessionId: string, input: SessionEstimateInput): void {
+    this.supersedeActiveTurn(sessionId)
     this.sessions.delete(sessionId)
     this.beginSession(sessionId, input)
   }
 
   checkpointSession(sessionId: string): SessionEstimateCheckpoint {
+    // A public checkpoint belongs to a control turn such as compaction. It supersedes any prompt
+    // handle first so delayed prompt cleanup cannot restore over the control turn or its successor.
+    this.supersedeActiveTurn(sessionId)
     const state = this.sessions.get(sessionId)
     const usage = this.usageBySession.get(sessionId)
     return {
@@ -394,6 +483,7 @@ class ContextUsageTracker {
     usage: AcpContextUsage,
     selectedContextWindow?: number
   ): void {
+    this.observeActiveTurn(sessionId)
     const breakdown = this.compare(sessionId, usage.used, 'reconciled')
     this.replaceUsage(sessionId, {
       ...usage,
@@ -405,6 +495,7 @@ class ContextUsageTracker {
   reconcileUsed(sessionId: string, used: number): boolean {
     const current = this.usageBySession.get(sessionId)
     if (!current || !Number.isSafeInteger(used)) return false
+    this.observeActiveTurn(sessionId)
     if (current.used === used && current.breakdown?.status === 'reconciled') return false
 
     this.replaceUsage(sessionId, {
@@ -580,6 +671,13 @@ class ContextUsageTracker {
     observation: SessionUpdateObservation = {}
   ): void {
     const update = notification.update
+    if (
+      update.sessionUpdate === 'agent_message_chunk' ||
+      update.sessionUpdate === 'tool_call' ||
+      update.sessionUpdate === 'tool_call_update'
+    ) {
+      this.observeActiveTurn(sessionId)
+    }
     if (update.sessionUpdate === 'agent_message_chunk') {
       const state = this.sessions.get(sessionId)
       if (state) state.pendingAssistantText += contentBlockText(update.content)
@@ -766,12 +864,15 @@ class ContextUsageTracker {
   }
 
   deleteSession(sessionId: string): void {
+    this.supersedeActiveTurn(sessionId)
     this.sessions.delete(sessionId)
     this.deleteUsage(sessionId)
     this.usageRevisions.delete(sessionId)
   }
 
   clear(): void {
+    for (const turn of this.activeTurnsBySession.values()) turn.outcome = 'superseded'
+    this.activeTurnsBySession.clear()
     this.sessions.clear()
     this.usageBySession.clear()
     this.usageRevisions.clear()
@@ -779,4 +880,10 @@ class ContextUsageTracker {
 }
 
 export { ContextUsageTracker, MAX_TOOL_ESTIMATE_CHARS, tokenizerProfileFor }
-export type { EstimatedCategoryKey, SessionEstimateInput, SessionUpdateObservation, TokenCounter }
+export type {
+  ContextUsageTurnHandle,
+  EstimatedCategoryKey,
+  SessionEstimateInput,
+  SessionUpdateObservation,
+  TokenCounter
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -10071,6 +10071,23 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().contextUsageBySession).toEqual({})
   })
 
+  it('invalidates context usage when its session is deleted', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['remote-session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    contextUsageMap(runtime).set(session.sessionId, { used: 12_000, size: 128_000 })
+
+    await runtime.deleteSession({ sessionId: session.sessionId })
+
+    expect(runtime.getSnapshot().contextUsageBySession).toEqual({})
+  })
+
   it('clears a session MCP server names when the session is deleted', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['remote-session-1'])

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -87,6 +87,7 @@ import { opencodeStorageDir } from '../agent-framework/opencode'
 import { CodexSkillActivityProjector } from './codex-skill-activity'
 import {
   ContextUsageTracker,
+  type ContextUsageTurnHandle,
   type SessionEstimateInput,
   type SessionUpdateObservation
 } from './context-usage-tracker'
@@ -503,9 +504,6 @@ const isUnresumableSessionError = (error: unknown): boolean => {
 class AcpRuntime {
   private readonly snapshotOwner: AcpRuntimeSnapshotOwner
   private readonly contextUsageTracker: ContextUsageTracker
-  // Prompt lifecycle stays with the runtime: this marks turns that received provider-side
-  // context-bearing updates so a rejected prompt rolls back only when the provider saw no turn data.
-  private readonly contextUsageUpdatedPromptTurnsBySession = new Map<string, number>()
   private readonly connectionResources: AcpConnectionResourceOwner
   private readonly connectionTransitions: AcpConnectionTransitionOwner
   private readonly generationActivity: AcpGenerationActivityOwner
@@ -1560,7 +1558,6 @@ class AcpRuntime {
     // A context reset creates a new agent-side conversation under the same app id. Do not carry the
     // previous context size into the fresh conversation before its first usage_update arrives.
     this.contextUsageTracker.deleteSession(request.sessionId)
-    this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
     this.sessionRegistry.lookup(request.sessionId)?.aggregate.clearAppliedModel()
 
     // Release the failed interaction now. Its own `finally` may run only after async artifact cleanup;
@@ -2289,7 +2286,6 @@ class AcpRuntime {
     })
     this.connectionTransitions.resetReconnect()
     this.contextUsageTracker.clear()
-    this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.clearAppliedSessionModels()
   }
 
@@ -2342,9 +2338,9 @@ class AcpRuntime {
     // The selected backend changed even if teardown must wait for an active prompt. Its old context
     // measurement no longer describes the selected generation, so hide it immediately and let the
     // replacement generation repopulate usage after reconnect/resume.
-    if (this.contextUsageTracker.hasUsage()) {
-      this.contextUsageTracker.clear()
-      this.contextUsageUpdatedPromptTurnsBySession.clear()
+    const contextUsageWasVisible = this.contextUsageTracker.hasUsage()
+    this.contextUsageTracker.clear()
+    if (contextUsageWasVisible) {
       this.clearAppliedSessionModels()
       this.emitState()
     }
@@ -2414,7 +2410,6 @@ class AcpRuntime {
     // including when a later session.dispose throws. A reconnect may resume the native context or
     // replay history into a fresh one; only that generation's own usage_update can repopulate it.
     this.contextUsageTracker.clear()
-    this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.clearAppliedSessionModels()
 
     const activeSessionIds = this.activeSessionIds()
@@ -2717,8 +2712,7 @@ class AcpRuntime {
     let skillActivitiesStarted = false
     let skillActivitiesFinalized = false
     let revokeReferencedUploadGrant: (() => void) | undefined
-    let contextUsageCheckpoint: ReturnType<ContextUsageTracker['checkpointSession']> | undefined
-    let contextUsageEstimateCommitted = false
+    let contextUsageTurn: ContextUsageTurnHandle | undefined
     let observedPromptStop:
       | {
           response: PromptResponse
@@ -2784,6 +2778,7 @@ class AcpRuntime {
           sessionId: request.sessionId,
           stopReason: response.stopReason
         })
+        contextUsageTurn?.fail()
         publishObservedPromptStop()
         return response
       }
@@ -2884,7 +2879,7 @@ class AcpRuntime {
       }
       const promptContent = preparedPrompt.content
 
-      contextUsageCheckpoint = this.contextUsageTracker.checkpointSession(request.sessionId)
+      contextUsageTurn = this.contextUsageTracker.beginTurn(request.sessionId)
       await this.recordPromptContextEstimate(
         request.sessionId,
         promptContent,
@@ -2982,21 +2977,12 @@ class AcpRuntime {
           if (!this.sessionInteractions.captureTerminal(promptInteraction, 'stop')) {
             return message.response
           }
-          contextUsageEstimateCommitted = true
           this.recordCodexPromptResponseContextUsage(
             request.sessionId,
             message.response,
             promptTurn
           )
-          this.contextUsageTracker.finalizeAssistantOutput(request.sessionId)
-          if (
-            this.restoreContextUsageBeforePromptIfPreflight(
-              request.sessionId,
-              contextUsageCheckpoint
-            )
-          ) {
-            this.emitState()
-          }
+          if (contextUsageTurn.complete()) this.emitState()
           // Emit artifact metadata before stop so the renderer can attach files to the finished message.
           await this.emitArtifactRunEvent(request.sessionId, artifactRun)
           artifactEmitted = true
@@ -3050,6 +3036,7 @@ class AcpRuntime {
       if (observedPromptStop) {
         // Provider stop/cancellation already won the outcome race. App-side finalization failure,
         // reset, or connection teardown cannot rewrite it as a prompt failure.
+        contextUsageTurn?.complete()
         if (publishObservedPromptStop()) {
           log.warn('prompt terminal finalization failed', {
             sessionId: request.sessionId,
@@ -3061,27 +3048,12 @@ class AcpRuntime {
       if (this.sessionInteractions.current(request.sessionId) !== promptInteraction) {
         // Reset/replacement is silent. Unexpected connection teardown settles and publishes every
         // visible prompt in handleConnectionClosed before releasing its interaction scope.
+        contextUsageTurn?.supersede()
         throw error
       }
       // A fresh provider failure captures its terminal outcome before rollback work can add latency.
       if (!this.sessionInteractions.captureTerminal(promptInteraction, 'error')) throw error
-      if (
-        contextUsageCheckpoint &&
-        !contextUsageEstimateCommitted &&
-        !this.pendingProviderReconnect
-      ) {
-        const partialTurnWasObserved =
-          this.contextUsageUpdatedPromptTurnsBySession.get(request.sessionId) === promptTurn
-        if (partialTurnWasObserved) {
-          // The provider may keep a turn that already streamed context-bearing updates even when its
-          // prompt request ultimately rejects. Preserve those prompt/tool/output estimates, but do not
-          // leave their transient preflight reading in place without a fresh authoritative total.
-          this.contextUsageTracker.finalizeAssistantOutput(request.sessionId)
-          this.restoreContextUsageBeforePromptIfPreflight(request.sessionId, contextUsageCheckpoint)
-        } else {
-          this.contextUsageTracker.restoreSession(request.sessionId, contextUsageCheckpoint)
-        }
-      }
+      contextUsageTurn?.fail()
       if (skillActivitiesStarted && !skillActivitiesFinalized) {
         this.emitCodexSkillInputActivities(
           request.sessionId,
@@ -3155,10 +3127,8 @@ class AcpRuntime {
         this.sessionInteractions.current(request.sessionId) === promptInteraction
       if (ownsInteraction) {
         this.permissionContext.clearCorrelationsForSession(request.sessionId)
-        if (this.contextUsageUpdatedPromptTurnsBySession.get(request.sessionId) === promptTurn) {
-          this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
-        }
       }
+      contextUsageTurn?.supersede()
       this.sessionInteractions.release(promptInteraction)
       if (ownsInteraction) {
         try {
@@ -3276,7 +3246,6 @@ class AcpRuntime {
     this.promptContentOwner.resetSession(request.sessionId)
     this.handoffContinuity.clearSession(request.sessionId)
     this.contextUsageTracker.deleteSession(request.sessionId)
-    this.contextUsageUpdatedPromptTurnsBySession.delete(request.sessionId)
 
     // Only announce a deletion and shift the current session when something was actually attached; a
     // detached cleanup (post-switch) must not emit a spurious event or move the current selection.
@@ -3923,16 +3892,6 @@ class AcpRuntime {
     if (this.contextUsageTracker.reconcileUsed(sessionId, used)) this.emitState()
   }
 
-  private restoreContextUsageBeforePromptIfPreflight(
-    sessionId: string,
-    checkpoint: ReturnType<ContextUsageTracker['checkpointSession']>
-  ): boolean {
-    // Preflight is a generation-only projection. If this turn produced no authoritative update,
-    // return to the last Agent reading so compaction remains available; a prior preflight reading is
-    // not authoritative either, so clear it instead of carrying the transient state across turns.
-    return this.contextUsageTracker.restorePreflightUsage(sessionId, checkpoint)
-  }
-
   private contextUsageSelectionFor(sessionId?: string): {
     model?: string
     contextWindow?: number
@@ -4076,21 +4035,6 @@ class AcpRuntime {
         this.contextUsageTracker.observeSessionUpdate(routed.sessionId, routed, observation)
       } else {
         this.contextUsageTracker.observeSessionUpdate(routed.sessionId, routed)
-      }
-
-      if (
-        event.contextUsage ||
-        routed.update.sessionUpdate === 'agent_message_chunk' ||
-        routed.update.sessionUpdate === 'tool_call' ||
-        routed.update.sessionUpdate === 'tool_call_update'
-      ) {
-        const promptInteraction = this.currentPromptInteraction(routed.sessionId)
-        if (promptInteraction) {
-          this.contextUsageUpdatedPromptTurnsBySession.set(
-            routed.sessionId,
-            promptInteraction.sequence
-          )
-        }
       }
     }
 
@@ -4274,7 +4218,6 @@ class AcpRuntime {
     this.handoffContinuity.clearGeneration()
     this.codexSkillActivity.clear()
     this.contextUsageTracker.clear()
-    this.contextUsageUpdatedPromptTurnsBySession.clear()
     this.sessionCapabilities.clearHttpRoutes()
     this.sessionRegistry.select(undefined)
     this.sessionInteractions.supersedeAll()


### PR DESCRIPTION
## Problem

`ContextUsageTracker` owned estimates and provider reconciliation, while Runtime still owned a per-Session updated-turn Map plus prompt checkpoint/rollback policy. That split allowed stale prompt cleanup to threaten successor context state.

Related: #458. This PR only establishes a forward context-usage ownership constraint; it does not implement Issue #458 orchestration state, schema, public interfaces, wire contracts, or user-visible behavior.

## Proposed change

- Add opaque, revision-bound `ContextUsageTurnHandle` instances from `beginTurn(...)`.
- Close turns idempotently as completed, rejected before provider data, partially observed failure, or superseded.
- Invalidate matching turns on reset, delete, generation clear/reconnect, and compaction checkpoints.
- Remove the Runtime updated-turn Map and prompt rollback branching; the tracker now owns turn observation and rollback.
- Preserve authoritative provider reconciliation, Codex correction, OpenCode sizing, preflight estimates, compaction behavior, and snapshot shapes.

## Scope and non-goals

ARD-08 only. No provider-adapter, schema, persistence, IPC/preload, Web/Task/CLI/SDK, UI, Specialist, Permission, Compute, terminal-usage, Reviewer, Artifact, or Issue #458 behavior changes.

Exact production raw: **190** lines, below the 500-line split gate.

## Ownership and sequence

`ContextUsageTracker` becomes the sole owner of per-turn context observation, revision fencing, and prompt checkpoint/rollback. Runtime receives an opaque turn handle and selects one terminal outcome; it no longer writes a parallel updated-turn Map or rollback policy.

```mermaid
stateDiagram-v2
  [*] --> Open: beginTurn(revision)
  Open --> Completed: provider facts finalized
  Open --> RolledBack: rejected before provider data
  Open --> PartiallyObserved: failure after provider observation
  Open --> Superseded: reset / delete / generation clear / reconnect / compaction
  Completed --> [*]
  RolledBack --> [*]
  PartiallyObserved --> [*]
  Superseded --> [*]
  Completed --> Completed: repeated close is inert
  Superseded --> Superseded: stale handle cannot affect successor revision
```

Revision binding prevents stale handles from rolling back or clearing a successor's context state. Provider reconciliation remains authoritative where data exists; pre-provider rejection rolls back the provisional prompt estimate.

## Acceptance criteria and validation

All recorded checks ran after the last material source edit:

- Turn lifecycle and affected Runtime/Coordinator/provider contracts → `npm test -- src/main/acp/context-usage-tracker.test.ts src/main/acp/runtime.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/provider-turn-adapter.test.ts` → **487 passed**.
- Node contracts → `npm run typecheck:node` → passed.
- Source lint → `npm run lint` → 0 errors; 17 pre-existing warnings outside this diff.
- Changed-file lint → `eslint --no-cache` on the four changed files → passed with no findings; the historical description did not preserve the full executable prefix.
- Source format → `prettier --check` on the four changed files → passed; the historical description did not preserve the full executable prefix.
- Diff integrity → `git diff --check` → passed.
- Independent Standards review → 0 findings.
- Independent Spec review → 0 findings.
- Final-head online gates → PR Gate, AI review, CodeQL, Static checks, Unit tests, Coverage macOS, macOS build/E2E, and Windows E2E all passed. `Windows core` was skipped by classification.

The full local portable suite was not run under the ARD delivery policy. The focused set covered the tracker, Runtime, Coordinator, and provider-turn interface consumers. The final-head online PR Gate is authoritative for full selection, live provider/platform risk, and cross-platform validation.

## Review focus

- Revision-safe stale-handle closure.
- Partial-failure retention versus pre-provider rollback.
- Invalidation ordering across reconnect, reset, delete, generation clear, and compaction.
- Removal of parallel Runtime turn/rollback ownership.

## Uncovered risks

A full local portable suite and real live-provider probes were not run. The historical description did not preserve the complete executable form of the targeted ESLint and Prettier commands. Cross-platform and provider confidence comes from the final-head online gates. Issue #458 integration remains deferred.
