### PR TITLE
refactor(acp): project session updates through ordered effects

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16021,6 +16021,53 @@ describe('ACP runtime Codex Skill activity projection', () => {
     expect(categories).toContainEqual(expect.objectContaining({ key: 'skills', estimated: true }))
     expect(categories).not.toContainEqual(expect.objectContaining({ key: 'tools' }))
   })
+
+  it('clears sparse Codex Skill correlation when the backend generation disconnects', async () => {
+    const events: AcpRuntimeEvent[] = []
+    const codexHome = join('/data', 'codex-subscription')
+    const skillPath = join(codexHome, 'skills', 'mcp-pubmed', 'SKILL.md')
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['session-1'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        backendId: 'codex:isolated',
+        executablePath: '/data/codex-acp',
+        env: { CODEX_HOME: codexHome }
+      }),
+      callbacks: { onEvent: (event) => events.push(event) }
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+
+    handleSessionUpdate(runtime, {
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'read-skill-1',
+        kind: 'read',
+        title: `Read file '${skillPath}'`,
+        status: 'in_progress',
+        locations: [{ path: skillPath }]
+      }
+    })
+    await runtime.disconnect(false)
+    handleSessionUpdate(runtime, {
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'read-skill-1',
+        status: 'completed'
+      }
+    })
+
+    expect(
+      events.filter((event) => event.toolCallId === 'read-skill-1').map((event) => event.title)
+    ).toEqual(['Loading skill: mcp-pubmed', undefined])
+  })
 })
 
 describe('ACP runtime — agent process lifecycle logging', () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -56,11 +56,7 @@ import {
 } from '../agent-framework'
 import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
-import {
-  extractProviderToolName,
-  extractToolFailureText,
-  toAcpRuntimeEvent
-} from './runtime-events'
+import { extractProviderToolName } from './runtime-events'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { toCodexTurnTokenUsage } from './codex-turn-usage'
 import { fetchOpenCodeUsageSnapshot, sumOpenCodeTurnUsage } from './opencode-turn-usage'
@@ -84,12 +80,10 @@ import type { ResponsesBridgeSkillCandidate } from '../settings/responses-bridge
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { withDataRootWrite } from '../storage/migration-state'
 import { opencodeStorageDir } from '../agent-framework/opencode'
-import { CodexSkillActivityProjector } from './codex-skill-activity'
 import {
   ContextUsageTracker,
   type ContextUsageTurnHandle,
-  type SessionEstimateInput,
-  type SessionUpdateObservation
+  type SessionEstimateInput
 } from './context-usage-tracker'
 import { contextUsageMcpSections } from './context-usage-static-context'
 import { createManagedFileReferenceResolver } from './file-reference-resolver'
@@ -138,6 +132,7 @@ import {
   type AcpBackendGenerationView
 } from './backend-generation-owner'
 import { AcpSessionConfigurator, type AcpSessionConfigurationFacts } from './session-configurator'
+import { AcpSessionUpdateProjector, type AcpSessionUpdateEffect } from './session-update-projector'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -526,7 +521,7 @@ class AcpRuntime {
   private readonly skillsHooks: AcpRuntimeSkillsOptions | undefined
   private readonly backendGeneration: AcpBackendGenerationOwner
   private readonly sessionConfigurator: AcpSessionConfigurator
-  private readonly codexSkillActivity = new CodexSkillActivityProjector()
+  private readonly sessionUpdateProjector = new AcpSessionUpdateProjector()
   // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
   private readonly resumeTimeoutMs: number
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
@@ -985,7 +980,7 @@ class AcpRuntime {
       }
 
       const backend = backendAttempt.publish()
-      this.codexSkillActivity.setSkillsRoot(
+      this.sessionUpdateProjector.beginGeneration(
         backend.adapter.codexHome ? join(backend.adapter.codexHome, 'skills') : undefined
       )
       this.attachAgentProcessEvents(agentProcess, generation)
@@ -2285,6 +2280,7 @@ class AcpRuntime {
       this.backendGeneration.supersede(this.connectionGeneration - 1)
     })
     this.connectionTransitions.resetReconnect()
+    this.sessionUpdateProjector.clearGeneration()
     this.contextUsageTracker.clear()
     this.clearAppliedSessionModels()
   }
@@ -2426,7 +2422,7 @@ class AcpRuntime {
       entry.aggregate.setPermissionProfile(undefined)
     }
     this.promptContentOwner.clear()
-    this.codexSkillActivity.clear()
+    this.sessionUpdateProjector.clearGeneration()
     runCleanup('MCP HTTP routes', () => this.sessionCapabilities.clearHttpRoutes())
     this.sessionRegistry.select(undefined)
 
@@ -3857,12 +3853,15 @@ class AcpRuntime {
     const framework =
       reviewerContext?.frameworkId ??
       this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().frameworkId
-    this.permissionContext.observeToolCall(notification, {
-      sessionId,
-      framework,
-      mcpServerNames:
-        reviewerContext?.mcpServerNames ?? this.sessionCapabilities.mcpServerNamesFor(sessionId)
-    })
+    this.applySessionUpdateEffects(
+      this.sessionUpdateProjector.project(notification, {
+        kind: 'permission',
+        appSessionId: sessionId,
+        framework,
+        mcpServerNames:
+          reviewerContext?.mcpServerNames ?? this.sessionCapabilities.mcpServerNamesFor(sessionId)
+      })
+    )
   }
 
   private cancelPermissionFlowForSession(sessionId: string): void {
@@ -3997,107 +3996,75 @@ class AcpRuntime {
     appSessionId?: string,
     visible = true
   ): void {
-    // When a session was adopted onto a replaced agent, the agent labels updates with its own id;
-    // relabel to the app-facing id so events land in the conversation the renderer tracks.
-    const routed =
-      appSessionId && appSessionId !== notification.sessionId
-        ? { ...notification, sessionId: appSessionId }
-        : notification
-    const projection = this.codexSkillActivity.projectWithContext(
-      toAcpRuntimeEvent(routed, this.nextEventId())
-    )
-    const event = projection.event
-
-    // A provider reconnect clears context immediately while its superseded prompt drains. Continue
-    // surfacing that prompt's visible output, but never rebuild usage from its late notifications.
-    if (!this.pendingProviderReconnect) {
-      this.ensureContextUsageTracking(routed.sessionId)
-      if (
-        routed.update.sessionUpdate === 'tool_call' ||
-        routed.update.sessionUpdate === 'tool_call_update'
-      ) {
-        const mcpServerNames = this.sessionCapabilities.mcpServerNamesFor(routed.sessionId)
-        const providerToolName = extractProviderToolName(routed.update)
-        const isMcp =
-          isMcpToolName(routed.update.title, mcpServerNames) ||
-          isMcpToolName(providerToolName, mcpServerNames)
-        const hasReportedToolIdentity =
-          routed.update.sessionUpdate === 'tool_call' ||
-          Boolean(routed.update.title) ||
-          Boolean(providerToolName)
-        const observation: SessionUpdateObservation = projection.skillFile
-          ? { toolCategory: 'skills', skillFilePath: projection.skillFile.path }
-          : isMcp
-            ? { toolCategory: 'mcp' }
-            : hasReportedToolIdentity
-              ? { toolCategory: 'tools' }
-              : {}
-        this.contextUsageTracker.observeSessionUpdate(routed.sessionId, routed, observation)
-      } else {
-        this.contextUsageTracker.observeSessionUpdate(routed.sessionId, routed)
-      }
-    }
-
-    if (routed.update.sessionUpdate === 'current_mode_update') {
-      const aggregate = this.sessionRegistry.lookup(routed.sessionId)?.aggregate
-      const profileState = aggregate?.snapshot().permissionProfile
-
-      if (profileState) {
-        aggregate.setPermissionProfile(
-          applyCurrentModeUpdate(
-            profileState as SessionPermissionProfileState,
-            routed.update.currentModeId
-          )
-        )
-        this.emitState()
-      }
-    }
-
-    // usage_update carries the session's context-window usage, not conversation content: record it per
-    // session and emit state so the indicator updates, but never push it as a visible event.
-    if (event.contextUsage) {
-      // A provider switch can wait for this prompt to finish. Any updates from that superseded backend
-      // must stay hidden until disconnect replaces the agent-context generation.
-      if (this.pendingProviderReconnect) return
-
-      this.contextUsageTracker.reconcileProviderUsage(
-        routed.sessionId,
-        event.contextUsage,
-        this.selectedContextWindowFor(routed.sessionId)
-      )
-      this.emitState()
-      return
-    }
-
-    if (!visible) return
-
-    if (
-      !this.pendingProviderReconnect &&
-      this.contextUsageTracker.usage(routed.sessionId)?.breakdown?.status !== 'reconciled'
-    ) {
-      this.refreshEstimatedContextUsage(routed.sessionId, 'preflight')
-    }
-
-    // Tool results (e.g. WebFetch's claude.ai domain-safety preflight, a failed Bash command) stream as
-    // tool_call_update content, which the session-update log omits — so a tool that runs and fails leaves
-    // no trace. Surface failures with the tool name and a bounded, text-only reason; never the arguments,
-    // raw output, or the URL/command-bearing title, to keep user data out of the log.
-    if (event.kind === 'tool' && event.status === 'failed') {
-      log.warn('tool call failed', {
-        tool:
-          this.toolIdentityForDiagnostics(event.providerToolName, routed.sessionId) ??
-          event.toolKind,
-        toolCallId: event.toolCallId,
-        sessionId: event.sessionId,
-        reason: extractToolFailureText(event.toolContent)
+    const sessionId = appSessionId ?? notification.sessionId
+    this.applySessionUpdateEffects(
+      this.sessionUpdateProjector.project(notification, {
+        kind: 'runtime',
+        appSessionId,
+        eventId: this.nextEventId(),
+        visible,
+        reconnectPending: this.pendingProviderReconnect,
+        mcpServerNames: this.sessionCapabilities.mcpServerNamesFor(sessionId)
       })
-    }
+    )
+  }
 
-    if ((event.kind === 'message' || event.kind === 'thought') && !event.text) {
-      return
+  private applySessionUpdateEffects(effects: readonly AcpSessionUpdateEffect[]): void {
+    for (const effect of effects) {
+      switch (effect.kind) {
+        case 'permission-tool-correlation':
+          this.permissionContext.observeToolCall(effect.notification, effect.context)
+          break
+        case 'context-observation':
+          this.ensureContextUsageTracking(effect.sessionId)
+          this.contextUsageTracker.observeSessionUpdate(
+            effect.sessionId,
+            effect.notification,
+            effect.observation
+          )
+          break
+        case 'current-mode': {
+          const aggregate = this.sessionRegistry.lookup(effect.sessionId)?.aggregate
+          const profileState = aggregate?.snapshot().permissionProfile
+          if (profileState) {
+            aggregate.setPermissionProfile(
+              applyCurrentModeUpdate(
+                profileState as SessionPermissionProfileState,
+                effect.currentModeId
+              )
+            )
+            this.emitState()
+          }
+          break
+        }
+        case 'provider-usage':
+          this.contextUsageTracker.reconcileProviderUsage(
+            effect.sessionId,
+            effect.usage,
+            this.selectedContextWindowFor(effect.sessionId)
+          )
+          this.emitState()
+          break
+        case 'context-refresh':
+          if (
+            this.contextUsageTracker.usage(effect.sessionId)?.breakdown?.status !== 'reconciled'
+          ) {
+            this.refreshEstimatedContextUsage(effect.sessionId, 'preflight')
+          }
+          break
+        case 'tool-failure-diagnostic':
+          log.warn('tool call failed', {
+            tool: effect.tool,
+            toolCallId: effect.toolCallId,
+            sessionId: effect.sessionId,
+            reason: effect.reason
+          })
+          break
+        case 'visible-event':
+          this.pushEvent(effect.event)
+          break
+      }
     }
-
-    this.pushEvent(event)
   }
 
   private toolIdentityForDiagnostics(
@@ -4216,7 +4183,7 @@ class AcpRuntime {
     }
     this.promptContentOwner.clear()
     this.handoffContinuity.clearGeneration()
-    this.codexSkillActivity.clear()
+    this.sessionUpdateProjector.dispose()
     this.contextUsageTracker.clear()
     this.sessionCapabilities.clearHttpRoutes()
     this.sessionRegistry.select(undefined)

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -1,0 +1,289 @@
+import type { SessionNotification } from '@agentclientprotocol/sdk'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { AcpSessionUpdateProjector } from './session-update-projector'
+
+describe('AcpSessionUpdateProjector', () => {
+  it('relabels provider updates and orders context projection before the visible event', () => {
+    const projector = new AcpSessionUpdateProjector()
+    const notification: SessionNotification = {
+      sessionId: 'provider-session',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        messageId: 'message-1',
+        content: { type: 'text', text: 'Hello' }
+      }
+    }
+
+    const effects = projector.project(notification, {
+      kind: 'runtime',
+      appSessionId: 'stable-session',
+      eventId: 'event-1',
+      timestamp: 1710000000000,
+      visible: true,
+      reconnectPending: false,
+      mcpServerNames: []
+    })
+
+    expect(effects.map((effect) => effect.kind)).toEqual([
+      'context-observation',
+      'context-refresh',
+      'visible-event'
+    ])
+    expect(effects[0]).toMatchObject({
+      kind: 'context-observation',
+      sessionId: 'stable-session',
+      notification: { sessionId: 'stable-session' }
+    })
+    expect(effects[2]).toMatchObject({
+      kind: 'visible-event',
+      event: {
+        id: 'event-1',
+        timestamp: 1710000000000,
+        sessionId: 'stable-session',
+        kind: 'message',
+        text: 'Hello'
+      }
+    })
+    expect(Object.isFrozen(effects)).toBe(true)
+    expect(effects.every(Object.isFrozen)).toBe(true)
+  })
+
+  it('projects usage to context state without a visible event and suppresses stale reconnect usage', () => {
+    const projector = new AcpSessionUpdateProjector()
+    const notification: SessionNotification = {
+      sessionId: 'session-1',
+      update: { sessionUpdate: 'usage_update', used: 42, size: 128_000 }
+    }
+    const routing = {
+      kind: 'runtime' as const,
+      eventId: 'event-usage',
+      visible: true,
+      reconnectPending: false,
+      mcpServerNames: []
+    }
+
+    expect(projector.project(notification, routing)).toMatchObject([
+      { kind: 'context-observation', sessionId: 'session-1' },
+      {
+        kind: 'provider-usage',
+        sessionId: 'session-1',
+        usage: { used: 42, size: 128_000 }
+      }
+    ])
+    expect(projector.project(notification, { ...routing, reconnectPending: true })).toEqual([])
+  })
+
+  it('projects hidden current-mode updates while a reconnect suppresses stale context effects', () => {
+    const projector = new AcpSessionUpdateProjector()
+    const notification: SessionNotification = {
+      sessionId: 'session-1',
+      update: { sessionUpdate: 'current_mode_update', currentModeId: 'bypassPermissions' }
+    }
+    const routing = {
+      kind: 'runtime' as const,
+      eventId: 'event-mode',
+      visible: false,
+      reconnectPending: true,
+      mcpServerNames: []
+    }
+
+    expect(projector.project(notification, routing)).toMatchObject([
+      {
+        kind: 'current-mode',
+        sessionId: 'session-1',
+        currentModeId: 'bypassPermissions'
+      }
+    ])
+  })
+
+  it('classifies MCP context and emits a bounded canonical failure diagnostic before the event', () => {
+    const projector = new AcpSessionUpdateProjector()
+    const notification: SessionNotification = {
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'tool-1',
+        title: 'https://example.com/secret',
+        kind: 'other',
+        status: 'failed',
+        content: [
+          {
+            type: 'content',
+            content: { type: 'text', text: 'Unable to save the artifact.' }
+          }
+        ],
+        rawOutput: { secret: 'do-not-log' },
+        _meta: { toolName: 'open_science_artifacts_write_artifact_file' }
+      }
+    }
+
+    const effects = projector.project(notification, {
+      kind: 'runtime',
+      eventId: 'event-tool',
+      visible: true,
+      reconnectPending: false,
+      mcpServerNames: ['open-science-artifacts']
+    })
+
+    expect(effects.map((effect) => effect.kind)).toEqual([
+      'context-observation',
+      'context-refresh',
+      'tool-failure-diagnostic',
+      'visible-event'
+    ])
+    expect(effects[0]).toMatchObject({ observation: { toolCategory: 'mcp' } })
+    expect(effects[2]).toEqual({
+      kind: 'tool-failure-diagnostic',
+      tool: 'open-science-artifacts/write_artifact_file',
+      toolCallId: 'tool-1',
+      sessionId: 'session-1',
+      reason: 'Unable to save the artifact.'
+    })
+    expect(JSON.stringify(effects[2])).not.toContain('example.com')
+    expect(JSON.stringify(effects[2])).not.toContain('do-not-log')
+  })
+
+  it('suppresses empty message events after retaining their context refresh ordering', () => {
+    const projector = new AcpSessionUpdateProjector()
+    const effects = projector.project(
+      {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: '' }
+        }
+      },
+      {
+        kind: 'runtime',
+        eventId: 'event-empty',
+        visible: true,
+        reconnectPending: false,
+        mcpServerNames: []
+      }
+    )
+
+    expect(effects.map((effect) => effect.kind)).toEqual(['context-observation', 'context-refresh'])
+  })
+
+  it('owns Codex Skill activity state for one generation and clears sparse lifecycle correlation', () => {
+    const projector = new AcpSessionUpdateProjector()
+    const skillsRoot = join('/data', 'codex-home', 'skills')
+    const skillPath = join(skillsRoot, 'mcp-pubmed', 'SKILL.md')
+    projector.beginGeneration(skillsRoot)
+    const routing = {
+      kind: 'runtime' as const,
+      eventId: 'event-skill',
+      visible: true,
+      reconnectPending: false,
+      mcpServerNames: []
+    }
+
+    const loading = projector.project(
+      {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'skill-1',
+          title: `Read file '${skillPath}'`,
+          kind: 'read',
+          status: 'in_progress',
+          locations: [{ path: skillPath }]
+        }
+      },
+      routing
+    )
+    const completed = projector.project(
+      {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'skill-1',
+          status: 'completed',
+          rawOutput: { formatted_output: 'PRIVATE SKILL BODY' }
+        }
+      },
+      { ...routing, eventId: 'event-skill-complete' }
+    )
+
+    expect(loading[0]).toMatchObject({
+      kind: 'context-observation',
+      observation: { toolCategory: 'skills', skillFilePath: skillPath }
+    })
+    expect(loading.at(-1)).toMatchObject({
+      kind: 'visible-event',
+      event: { title: 'Loading skill: mcp-pubmed' }
+    })
+    expect(completed[0]).toMatchObject({
+      observation: { toolCategory: 'skills', skillFilePath: skillPath }
+    })
+    expect(completed.at(-1)).toMatchObject({
+      event: { title: 'Loaded skill: mcp-pubmed' }
+    })
+    expect(JSON.stringify(completed.at(-1))).not.toContain('PRIVATE SKILL BODY')
+
+    projector.clearGeneration()
+    const afterClear = projector.project(
+      {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'skill-1',
+          status: 'completed'
+        }
+      },
+      { ...routing, eventId: 'event-after-clear' }
+    )
+    expect(afterClear[0]).toMatchObject({ observation: {} })
+    expect(afterClear.at(-1)).not.toMatchObject({
+      event: { title: expect.stringContaining('skill') }
+    })
+
+    projector.dispose()
+  })
+
+  it('projects Permission tool correlation first with the stable Session identity', () => {
+    const projector = new AcpSessionUpdateProjector()
+    const effects = projector.project(
+      {
+        sessionId: 'provider-session',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'mcp-1',
+          title: 'Run notebook cell',
+          kind: 'execute',
+          status: 'pending'
+        }
+      },
+      {
+        kind: 'permission',
+        appSessionId: 'stable-session',
+        framework: 'codex',
+        mcpServerNames: ['open-science-notebook']
+      }
+    )
+
+    expect(effects).toEqual([
+      {
+        kind: 'permission-tool-correlation',
+        notification: {
+          sessionId: 'stable-session',
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'mcp-1',
+            title: 'Run notebook cell',
+            kind: 'execute',
+            status: 'pending'
+          }
+        },
+        context: {
+          sessionId: 'stable-session',
+          framework: 'codex',
+          mcpServerNames: ['open-science-notebook']
+        }
+      }
+    ])
+    expect(Object.isFrozen(effects[0])).toBe(true)
+  })
+})

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -1,0 +1,206 @@
+import type { SessionNotification } from '@agentclientprotocol/sdk'
+
+import type { AcpContextUsage, AcpRuntimeEvent } from '../../shared/acp'
+import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
+import { CodexSkillActivityProjector } from './codex-skill-activity'
+import type { SessionUpdateObservation } from './context-usage-tracker'
+import type { PermissionToolContext } from './permission-context'
+import { isMcpToolName } from './permission-policy'
+import {
+  extractProviderToolName,
+  extractToolFailureText,
+  toAcpRuntimeEvent
+} from './runtime-events'
+
+type RuntimeProjectionRouting = Readonly<{
+  kind: 'runtime'
+  appSessionId?: string
+  eventId: string
+  timestamp?: number
+  visible: boolean
+  reconnectPending: boolean
+  mcpServerNames: readonly string[]
+}>
+
+type PermissionProjectionRouting = Readonly<{
+  kind: 'permission'
+  appSessionId: string
+  framework: PermissionToolContext['framework']
+  mcpServerNames: readonly string[]
+}>
+
+type AcpSessionUpdateRouting = RuntimeProjectionRouting | PermissionProjectionRouting
+
+type AcpSessionUpdateEffect =
+  | Readonly<{
+      kind: 'permission-tool-correlation'
+      notification: Readonly<SessionNotification>
+      context: Readonly<PermissionToolContext>
+    }>
+  | Readonly<{
+      kind: 'context-observation'
+      sessionId: string
+      notification: Readonly<SessionNotification>
+      observation: Readonly<SessionUpdateObservation>
+    }>
+  | Readonly<{
+      kind: 'context-refresh'
+      sessionId: string
+    }>
+  | Readonly<{
+      kind: 'provider-usage'
+      sessionId: string
+      usage: Readonly<AcpContextUsage>
+    }>
+  | Readonly<{
+      kind: 'current-mode'
+      sessionId: string
+      currentModeId: string
+    }>
+  | Readonly<{
+      kind: 'tool-failure-diagnostic'
+      tool?: string
+      toolCallId?: string
+      sessionId: string
+      reason?: string
+    }>
+  | Readonly<{
+      kind: 'visible-event'
+      event: Readonly<AcpRuntimeEvent>
+    }>
+
+const deepFreeze = <Value>(value: Value): Value => {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value
+  for (const nested of Object.values(value)) deepFreeze(nested)
+  return Object.freeze(value)
+}
+
+const toolObservation = (
+  notification: Readonly<SessionNotification>,
+  mcpServerNames: readonly string[]
+): SessionUpdateObservation => {
+  const update = notification.update
+  if (update.sessionUpdate !== 'tool_call' && update.sessionUpdate !== 'tool_call_update') return {}
+
+  const providerToolName = extractProviderToolName(update)
+  if (
+    isMcpToolName(update.title, mcpServerNames) ||
+    isMcpToolName(providerToolName, mcpServerNames)
+  ) {
+    return { toolCategory: 'mcp' }
+  }
+  return update.sessionUpdate === 'tool_call' || update.title || providerToolName
+    ? { toolCategory: 'tools' }
+    : {}
+}
+
+// Translates provider Session notifications into immutable application-owner effects. The runtime
+// applies them once in order; event retention and context state remain with their existing owners.
+class AcpSessionUpdateProjector {
+  private readonly codexSkillActivity = new CodexSkillActivityProjector()
+
+  beginGeneration(codexSkillsRoot?: string): void {
+    this.codexSkillActivity.setSkillsRoot(codexSkillsRoot)
+  }
+
+  clearGeneration(): void {
+    this.codexSkillActivity.setSkillsRoot(undefined)
+  }
+
+  dispose(): void {
+    this.clearGeneration()
+  }
+
+  project(
+    notification: SessionNotification,
+    routing: AcpSessionUpdateRouting
+  ): readonly AcpSessionUpdateEffect[] {
+    const routed = structuredClone(notification)
+    if (routing.appSessionId) routed.sessionId = routing.appSessionId
+    deepFreeze(routed)
+
+    if (routing.kind === 'permission') {
+      return Object.freeze([
+        deepFreeze({
+          kind: 'permission-tool-correlation' as const,
+          notification: routed,
+          context: {
+            sessionId: routed.sessionId,
+            framework: routing.framework,
+            mcpServerNames: [...routing.mcpServerNames]
+          }
+        })
+      ])
+    }
+
+    const projection = this.codexSkillActivity.projectWithContext(
+      toAcpRuntimeEvent(routed, routing.eventId, routing.timestamp)
+    )
+    const event = deepFreeze(projection.event)
+    if (event.contextUsage && routing.reconnectPending) return Object.freeze([])
+
+    const effects: AcpSessionUpdateEffect[] = []
+    if (!routing.reconnectPending) {
+      effects.push(
+        deepFreeze({
+          kind: 'context-observation' as const,
+          sessionId: routed.sessionId,
+          notification: routed,
+          observation: projection.skillFile
+            ? { toolCategory: 'skills', skillFilePath: projection.skillFile.path }
+            : toolObservation(routed, routing.mcpServerNames)
+        })
+      )
+    }
+
+    if (routed.update.sessionUpdate === 'current_mode_update') {
+      effects.push(
+        deepFreeze({
+          kind: 'current-mode' as const,
+          sessionId: routed.sessionId,
+          currentModeId: routed.update.currentModeId
+        })
+      )
+    }
+
+    if (event.contextUsage) {
+      effects.push(
+        deepFreeze({
+          kind: 'provider-usage' as const,
+          sessionId: routed.sessionId,
+          usage: event.contextUsage
+        })
+      )
+      return Object.freeze(effects)
+    }
+
+    if (routing.visible) {
+      if (!routing.reconnectPending) {
+        effects.push(deepFreeze({ kind: 'context-refresh' as const, sessionId: routed.sessionId }))
+      }
+      if (event.kind === 'tool' && event.status === 'failed') {
+        const canonicalTool = event.providerToolName
+          ? resolveCanonicalMcpToolIdentity(event.providerToolName, routing.mcpServerNames)
+          : undefined
+        effects.push(
+          deepFreeze({
+            kind: 'tool-failure-diagnostic' as const,
+            tool: canonicalTool ?? event.providerToolName ?? event.toolKind,
+            toolCallId: event.toolCallId,
+            sessionId: routed.sessionId,
+            reason: extractToolFailureText(event.toolContent)
+          })
+        )
+      }
+      if ((event.kind === 'message' || event.kind === 'thought') && !event.text) {
+        return Object.freeze(effects)
+      }
+      effects.push(deepFreeze({ kind: 'visible-event' as const, event }))
+    }
+
+    return Object.freeze(effects)
+  }
+}
+
+export { AcpSessionUpdateProjector }
+export type { AcpSessionUpdateEffect, AcpSessionUpdateRouting }


### PR DESCRIPTION
## Problem

`AcpRuntime` directly interpreted ACP Session updates across event, context, Permission, mode, usage, diagnostics, and Codex Skill concerns, leaving projection order and Skill activity state distributed in the facade.

Related: #458 (forward-compatibility constraint only; this PR added no orchestration data model or public interface).

## Proposed change

- Add `AcpSessionUpdateProjector.project(notification, routing)` with ordered, deeply immutable application effects.
- Move Codex Skill activity construction and generation cleanup into the projector.
- Apply each effect exactly once through the existing Snapshot, Registry/Aggregate, Permission, and Context owners.
- Preserve the pre-ActiveSession Permission-correlation callback while cutting Runtime update handling over to effects.

## Scope and non-goals

- Internal behavior-preserving ARD-13 refactor only.
- No public event type, persisted data, IPC/wire, UI, Permission/context owner implementation, Specialist, Compute, or orchestration-boundary change.
- Exact production raw: **401** (287 additions + 114 deletions; tests/docs/generated/lockfile excluded).

## Ownership and sequence

```mermaid
flowchart LR
  N[ACP Session update] --> R[AcpRuntime routing facts]
  R --> P[AcpSessionUpdateProjector]
  P --> E[Ordered immutable effects]
  E --> S[Snapshot owner]
  E --> A[Session registry / aggregate]
  E --> M[Permission owner]
  E --> C[Context owner]
```

The projector owns interpretation and effect order, not mutable application state. Existing owners remain the only writers of their respective state; Runtime applies every returned effect once.

## Acceptance criteria and validation

The historical PR record states that all listed local checks ran after the last material edit:

- Projector plus Runtime event, Skill, Permission, and context behavior -> targeted ACP tests -> **72 passed**. The original record did not preserve the exact test argv, so no reconstructed command is presented as historical fact.
- Session-update integration and generation cleanup -> `npm test` together with the Runtime target -> **complete portable suite passed: 755 files passed, 14 skipped; 11,186 tests passed, 184 skipped**. The exact separate Runtime argv was not retained.
- Node contracts -> `npm run typecheck:node` -> **passed**.
- Source lint -> `npm run lint` -> **passed with 0 errors; 17 pre-existing warnings in untouched files**.
- Formatting -> targeted Prettier check -> **passed**; exact argv unavailable in the retained record.
- Diff integrity -> `git diff --check` -> **passed**.
- Final online gates -> GitHub records **PR Gate, Unit tests, Static checks, Coverage macOS, macOS build and E2E, Windows E2E, CodeQL, and AI review workflow success**.

Independent post-commit Standards and Spec reviews recorded no findings.

## Review focus

- Effect order and exact-once application.
- Permission correlation timing and provider-ID relabeling.
- Hidden usage/reconnect suppression, safe MCP diagnostics, and Codex Skill generation cleanup.

## Uncovered risks

- Local evidence did not cover platform-specific packaging/E2E; the successful online macOS/Windows lanes are the retained platform evidence.
- Historical local test argv is incomplete, so this normalized description intentionally does not claim a more precise command than the record proves.

