### PR TITLE
refactor(acp): own turn-scoped Skill lifecycle

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -15567,6 +15567,56 @@ describe('ACP runtime skill force-load + nudge', () => {
     expect(runtime.getSnapshot().status).toBe('idle')
   })
 
+  it('restores normal backend preparation after a forced Skill reload fails', async () => {
+    const backendContexts: string[][] = []
+    let spawnCount = 0
+    const spawn = (): ChildProcessWithoutNullStreams => {
+      spawnCount += 1
+      const process = new FakeAgentProcess()
+      startFakeAgent(
+        process,
+        ['remote-session-1'],
+        spawnCount === 2
+          ? {
+              onResumeRequest: () => {
+                throw new Error('provider unavailable')
+              }
+            }
+          : {}
+      )
+      return asAgentProcess(process)
+    }
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: (context) => {
+        backendContexts.push([...context.forcedSkillIds])
+        return {
+          framework: { ...claudeCodeFramework, spawn },
+          executablePath: '/bin/agent',
+          env: {}
+        }
+      },
+      skills: {
+        needForceLoad: async (ids) => ids,
+        namesForIds: async (ids) => ids
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await expect(
+      runtime.sendPrompt({
+        sessionId: 'remote-session-1',
+        text: 'use the disabled skill',
+        forcedSkillIds: ['research']
+      })
+    ).rejects.toThrow()
+    await vi.waitFor(() => expect(runtime.getSnapshot().status).toBe('idle'))
+
+    await runtime.resumeSession({ sessionId: 'remote-session-1', cwd: '/workspace' })
+    expect(backendContexts.slice(0, 3)).toEqual([[], ['research'], []])
+  })
+
   it('nudges without any reconnect when every picked skill is already enabled', async () => {
     const spawner = createFreshAgentSpawner()
     const hooks = createSkillsHooks({ needForceLoad: [] })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -76,7 +76,6 @@ import {
 } from '../skills/mcp-server'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
-import type { ResponsesBridgeSkillCandidate } from '../settings/responses-bridge'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { withDataRootWrite } from '../storage/migration-state'
 import { opencodeStorageDir } from '../agent-framework/opencode'
@@ -133,6 +132,12 @@ import {
 } from './backend-generation-owner'
 import { AcpSessionConfigurator, type AcpSessionConfigurationFacts } from './session-configurator'
 import { AcpSessionUpdateProjector, type AcpSessionUpdateEffect } from './session-update-projector'
+import {
+  AcpTurnSkillOwner,
+  type AcpTurnSkillHooks,
+  type TurnSkillHandle,
+  type TurnSkillOutcome
+} from './turn-skill-owner'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -169,7 +174,7 @@ type AcpRuntimeOptions = {
   uploads?: AcpRuntimeUploadOptions
   notebook?: AcpRuntimeNotebookOptions
   skillImport?: AcpRuntimeSkillImportOptions
-  skills?: AcpRuntimeSkillsOptions
+  skills?: AcpTurnSkillHooks
   // The agent backend to drive. Defaults to Claude Code; selecting another (opencode) swaps only the
   // framework-coupled behavior (spawn, session meta, permission-mode mapping) via AgentFramework.
   framework?: AgentFramework
@@ -200,24 +205,6 @@ type AcpRuntimeOptions = {
   // intentionally separate from Main Agent enablement: a Main-disabled installed Skill remains
   // eligible for a Specialist.
   resolveSpecialistSkills?: (specialistId: string) => Promise<EffectiveSpecialistSkills>
-}
-
-// Turn-scoped skill force-load hooks, wired from the settings service. Optional so tests that construct
-// the runtime without them are unaffected; every usage guards on presence.
-type AcpRuntimeSkillsOptions = {
-  // Returns the subset of forced ids that are currently disabled (i.e. need a respawn to materialize).
-  needForceLoad: (ids: string[]) => Promise<string[]>
-  // Resolves picker ids to the names accepted by the agent's Skill tool.
-  namesForIds: (ids: string[]) => Promise<string[]>
-  // Resolves picker ids to exact app-owned Codex Skill files. Codex carries these as private ACP
-  // metadata; Claude Code and OpenCode keep the existing text nudge.
-  descriptorsForIds?: (
-    ids: string[],
-    codexHome: string | undefined
-  ) => Promise<Array<{ name: string; path: string }>>
-  // Lists only enabled, materialized app-owned Skills from the active isolated Codex home. The
-  // Chat Completions compatibility selector receives name + description; paths remain local.
-  catalogForCodexHome?: (codexHome: string | undefined) => Promise<ResponsesBridgeSkillCandidate[]>
 }
 
 type AcpRuntimeArtifactOptions = {
@@ -511,14 +498,11 @@ class AcpRuntime {
   private readonly sessionInteractions: AcpSessionInteractionOwner
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
-  // Forced skill state belongs to this runtime generation. It is passed explicitly into backend
-  // provisioning so concurrent old/new generations cannot overwrite a SettingsService singleton.
-  private readonly turnForcedSkillIds = new Set<string>()
+  private readonly turnSkills: AcpTurnSkillOwner
   private readonly handoffContinuity = new AcpHandoffContinuityOwner()
   private readonly permissionContext: AcpPermissionContext
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
-  private readonly skillsHooks: AcpRuntimeSkillsOptions | undefined
   private readonly backendGeneration: AcpBackendGenerationOwner
   private readonly sessionConfigurator: AcpSessionConfigurator
   private readonly sessionUpdateProjector = new AcpSessionUpdateProjector()
@@ -557,8 +541,12 @@ class AcpRuntime {
       recoverFailedDeferredDisconnect: () => this.recoverFailedDeferredDisconnect(),
       reportFailure: (message, error) => safeLogError(message, errorLogFields(error))
     })
+    this.turnSkills = new AcpTurnSkillOwner({
+      resolveSpecialistSkills: options.resolveSpecialistSkills,
+      skills: options.skills,
+      requestSkillsReload: () => this.connectionTransitions.requestSkillsReload()
+    })
     this.spawnAgent = options.spawnAgent
-    this.skillsHooks = options.skills
     this.backendGeneration = new AcpBackendGenerationOwner(options.framework ?? claudeCodeFramework)
     this.sessionConfigurator = new AcpSessionConfigurator({
       assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
@@ -2471,7 +2459,7 @@ class AcpRuntime {
 
     const backend = this.options.resolveBackend
       ? await this.options.resolveBackend({
-          forcedSkillIds: [...this.turnForcedSkillIds],
+          forcedSkillIds: [...this.turnSkills.backendPreparation().forcedSkillIds],
           systemPromptAppends: await this.getBackendSystemPromptAppends()
         })
       : undefined
@@ -2566,100 +2554,62 @@ class AcpRuntime {
       turnToken: request.continuation?.originatingTurnToken
     })
 
-    // A chip can survive a catalog/profile edit in the renderer. Re-resolve immediately before
-    // dispatch so it cannot be used to escape the active Specialist scope.
-    // Ordinary sessions continue without yielding. Specialist sessions await their authoritative scope,
-    // but the reservation is invalidated by reset/replacement before a stale attempt can be activated.
-    let currentSpecialistSkills: EffectiveSpecialistSkills | undefined
+    let turnSkillHandle: TurnSkillHandle
     try {
-      currentSpecialistSkills =
-        this.sessionRegistry.lookup(request.sessionId)?.aggregate.snapshot().specialistId &&
-        this.options.resolveSpecialistSkills
-          ? await this.resolveCurrentSpecialistSkills(request.sessionId)
-          : undefined
+      const authorization = this.turnSkills.authorize({
+        specialistId: this.sessionRegistry.lookup(request.sessionId)?.aggregate.snapshot()
+          .specialistId,
+        selectedSkillIds: request.forcedSkillIds,
+        signal: promptReservation.signal
+      })
+      turnSkillHandle = authorization instanceof Promise ? await authorization : authorization
     } catch (error) {
       this.sessionInteractions.release(promptReservation)
       throw error
     }
-    if (currentSpecialistSkills && currentSpecialistSkills.kind !== 'main') {
-      if (currentSpecialistSkills.kind === 'unavailable') {
-        this.sessionInteractions.release(promptReservation)
-        throw new Error(currentSpecialistSkills.reason)
-      }
-      const rejected = (request.forcedSkillIds ?? []).find(
-        (id) =>
-          !currentSpecialistSkills.skillIds.includes(id) &&
-          // Connector docs are materialized as `mcp-<id>` Skills. They deliberately have no
-          // durable Skill catalog id, so their allow-list lives in frameworkNames alongside the
-          // specialist's ordinary skills. A continuation may inherit one from its source turn.
-          !(id.startsWith('mcp-') && currentSpecialistSkills.frameworkNames.includes(id))
-      )
-      if (rejected) {
-        this.sessionInteractions.release(promptReservation)
-        throw new Error(`Skill "${rejected}" is not available to the active specialist.`)
-      }
-    }
-
-    // Turn-scoped skill force-load: a skill the user picked but has toggled off must run this turn only.
-    // If any pick is currently disabled, mark the picks forced and respawn the agent (drop the connection,
-    // then resume the same session) so the fresh spawn's provisioning materializes them with full context
-    // restored. Picks that are already enabled need no respawn. Restored to the normal set after the turn.
-    const forced = request.forcedSkillIds ?? []
-    let didForceReload = false
+    const rejectedSkillOutcome =
+      turnSkillHandle.reloadDecision.kind === 'reload' ? 'reload-restored' : 'failed'
 
     try {
-      if (this.skillsHooks && forced.length > 0) {
-        const toForce = await this.skillsHooks.needForceLoad(forced)
-
-        // The Skill check yields before a force-load reconnect mutates runtime-wide state. A newer turn
-        // may have claimed this session meanwhile, so refuse the stale reconnect before it can tear down
-        // that turn.
+      if (turnSkillHandle.reloadDecision.kind === 'reload') {
         if (this.hasSessionInteractionInFlight(request.sessionId)) {
           throw new Error('An ACP prompt is already running for this session')
         }
 
-        if (toForce.length > 0) {
-          // Capture routing before disconnect clears it, so resume lands on the same conversation.
-          const aggregateSnapshot = this.sessionRegistry
-            .lookup(request.sessionId)
-            ?.aggregate.snapshot()
-          const sessionCwd = aggregateSnapshot?.cwd ?? this.snapshotOwner.cwd
-          const projectName = this.resolveSessionProjectName(request.sessionId)
-          const permissionProfile =
-            aggregateSnapshot?.permissionProfile?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE
-          this.turnForcedSkillIds.clear()
-          for (const id of forced) this.turnForcedSkillIds.add(id)
-          didForceReload = true
-          await this.disconnect(false)
-          const reloadResume = await this.resumeSession({
-            sessionId: request.sessionId,
-            cwd: sessionCwd,
-            projectName,
-            permissionProfile
-          })
-          if (reloadResume.contextReset) {
-            request.historyPreamble = request.resumeFallback?.historyPreamble
-            request.historyAttachments = request.resumeFallback?.historyAttachments
-            request.historyImages = request.resumeFallback?.historyImages
-          }
-
-          const reloaded = this.activeSessionFor(request.sessionId)
-          if (!reloaded) {
-            throw new Error(`ACP session not found after force-load: ${request.sessionId}`)
-          }
-          activeSession = reloaded
-          // disconnect() invalidates every scope belonging to the old provider generation. Reserve the
-          // resumed stable App Session again before this same authorized attempt can continue.
-          promptReservation = this.sessionInteractions.reservePrompt({
-            sessionId: request.sessionId,
-            kind: 'prompt',
-            promptMessageId: request.provenanceContext?.promptMessageId,
-            turnToken: request.continuation?.originatingTurnToken
-          })
+        const aggregateSnapshot = this.sessionRegistry
+          .lookup(request.sessionId)
+          ?.aggregate.snapshot()
+        const sessionCwd = aggregateSnapshot?.cwd ?? this.snapshotOwner.cwd
+        const projectName = this.resolveSessionProjectName(request.sessionId)
+        const permissionProfile =
+          aggregateSnapshot?.permissionProfile?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE
+        await this.disconnect(false)
+        const reloadResume = await this.resumeSession({
+          sessionId: request.sessionId,
+          cwd: sessionCwd,
+          projectName,
+          permissionProfile
+        })
+        if (reloadResume.contextReset) {
+          request.historyPreamble = request.resumeFallback?.historyPreamble
+          request.historyAttachments = request.resumeFallback?.historyAttachments
+          request.historyImages = request.resumeFallback?.historyImages
         }
+
+        const reloaded = this.activeSessionFor(request.sessionId)
+        if (!reloaded) {
+          throw new Error(`ACP session not found after force-load: ${request.sessionId}`)
+        }
+        activeSession = reloaded
+        promptReservation = this.sessionInteractions.reservePrompt({
+          sessionId: request.sessionId,
+          kind: 'prompt',
+          promptMessageId: request.provenanceContext?.promptMessageId,
+          turnToken: request.continuation?.originatingTurnToken
+        })
       }
     } catch (error) {
-      if (didForceReload) this.turnForcedSkillIds.clear()
+      turnSkillHandle.close('reload-restored')
       this.sessionInteractions.release(promptReservation)
       throw error
     }
@@ -2667,12 +2617,14 @@ class AcpRuntime {
     // Another prompt can claim this session while authorization preflight is awaiting. Activate only
     // the newest reservation so a delayed attempt cannot overwrite a newer turn's lifecycle state.
     if (this.hasSessionInteractionInFlight(request.sessionId)) {
+      turnSkillHandle.close(rejectedSkillOutcome)
       this.sessionInteractions.release(promptReservation)
       throw new Error('An ACP prompt is already running for this session')
     }
 
     const refreshedActiveSession = this.activeSessionFor(request.sessionId)
     if (!refreshedActiveSession) {
+      turnSkillHandle.close(rejectedSkillOutcome)
       this.sessionInteractions.release(promptReservation)
       throw new Error(`ACP session not found: ${request.sessionId}`)
     }
@@ -2684,6 +2636,7 @@ class AcpRuntime {
       this.sessionRegistry.select(request.sessionId)
       this.handoffContinuity.recordAdmittedPrompt(request)
     } catch (error) {
+      turnSkillHandle.close(rejectedSkillOutcome)
       this.sessionInteractions.release(promptReservation)
       throw error
     }
@@ -2709,6 +2662,7 @@ class AcpRuntime {
     let skillActivitiesFinalized = false
     let revokeReferencedUploadGrant: (() => void) | undefined
     let contextUsageTurn: ContextUsageTurnHandle | undefined
+    let turnSkillOutcome: TurnSkillOutcome = 'failed'
     let observedPromptStop:
       | {
           response: PromptResponse
@@ -2762,6 +2716,7 @@ class AcpRuntime {
         })
       }
       const finishCancelledBeforePrompt = async (): Promise<PromptResponse> => {
+        turnSkillOutcome = 'cancelled'
         const response: PromptResponse = { stopReason: 'cancelled' }
         observedPromptStop = { response }
         if (!this.sessionInteractions.captureTerminal(promptInteraction, 'cancelled')) {
@@ -2784,51 +2739,44 @@ class AcpRuntime {
         return finishCancelledBeforePrompt()
       }
 
-      // Prepend a short steering nudge naming the picked skills. It goes only into the content sent to
-      // the agent; the user-facing message event keeps the original text (which already shows /Name).
-      // Framework-neutral delivery of system-prompt guidance: Claude carries appends in session _meta;
-      // frameworks without a session preset carry the guidance as a prompt prefix.
-      const specialistSkillGuidance = this.specialistSkillGuidance(currentSpecialistSkills)
-      const { promptPrefix: frameworkPromptPrefix } = this.framework.buildSessionSetup({
-        systemPromptAppends: this.backend.prompt.persistentSystemPrompt
-          ? []
-          : this.getSystemPromptAppends(),
-        turnPromptReminders: specialistSkillGuidance ? [specialistSkillGuidance] : [],
-        sessionOptions: this.backend.session.options
-      })
-      // For Codex/OpenCode, prepend the per-session specialist identity prefix (set at createSession).
-      // Claude carries its identity in session-level _meta; no per-turn prefix needed there.
       const sessionSpecialistPrefix = this.sessionRegistry
         .lookup(request.sessionId)
         ?.aggregate.snapshot().specialistPrefix
-      const promptPrefix =
-        [sessionSpecialistPrefix, frameworkPromptPrefix]
-          .filter((segment): segment is string => Boolean(segment))
-          .join('\n\n') || undefined
-      const selectorSignal =
-        this.framework.id === 'codex' &&
-        forced.length === 0 &&
-        this.connectionResources.bridgeSkillsAvailable
-          ? promptInteraction.signal
-          : undefined
-      const codexSkillInputs = await this.resolveCodexSkillInputs(
-        forced,
-        request.text,
-        selectorSignal,
-        currentSpecialistSkills
-      )
+      const promptRequestText = request.continuation
+        ? this.buildSpecialistHandoffContinuationText(request)
+        : request.text
+      const skillPreparation = await turnSkillHandle.prepareProvider({
+        frameworkId: this.framework.id,
+        selectionText: request.text,
+        promptText: promptRequestText,
+        codex: {
+          home: this.backend.adapter.codexHome,
+          bridgeSkillsAvailable: this.connectionResources.bridgeSkillsAvailable,
+          selectSkills: async (text, catalog, signal) =>
+            (await this.connectionResources.selectBridgeSkills(text, catalog, signal)) ?? [],
+          signal: promptInteraction.signal
+        }
+      })
       if (
         (await this.sessionInteractions.cancellationCheckpoint(promptInteraction)) === 'cancelled'
       ) {
         return finishCancelledBeforePrompt()
       }
-      const promptRequestText = request.continuation
-        ? this.buildSpecialistHandoffContinuationText(request)
-        : request.text
-      const nudgedText = await this.applySkillNudge(promptRequestText, forced)
-      // A history preamble (transcript replayed after a context reset) leads, then the framework guidance
-      // prefix, then the nudged user text. Absent segments drop out so the normal turn is unchanged.
-      const promptText = [request.historyPreamble, promptPrefix, nudgedText]
+      const { promptPrefix: frameworkPromptPrefix } = this.framework.buildSessionSetup({
+        systemPromptAppends: this.backend.prompt.persistentSystemPrompt
+          ? []
+          : this.getSystemPromptAppends(),
+        turnPromptReminders: skillPreparation.specialistSkillGuidance
+          ? [skillPreparation.specialistSkillGuidance]
+          : [],
+        sessionOptions: this.backend.session.options
+      })
+      const promptPrefix =
+        [sessionSpecialistPrefix, frameworkPromptPrefix]
+          .filter((segment): segment is string => Boolean(segment))
+          .join('\n\n') || undefined
+      const codexSkillInputs = [...skillPreparation.codexSkillInputs]
+      const promptText = [request.historyPreamble, promptPrefix, skillPreparation.text]
         .filter((segment): segment is string => Boolean(segment))
         .join('\n\n')
       revokeReferencedUploadGrant = await this.authorizeReferencedSkillUploads(
@@ -2952,6 +2900,7 @@ class AcpRuntime {
         }
 
         if (message.kind === 'stop') {
+          turnSkillOutcome = message.response.stopReason === 'cancelled' ? 'cancelled' : 'completed'
           const codexTurnCount = message.response._meta?.[ACP_MODEL_TURN_COUNT_META_KEY]
           const reportedTurnCount =
             promptFramework === 'codex' &&
@@ -3140,14 +3089,8 @@ class AcpRuntime {
       } catch (error) {
         safeLogError('emitState after prompt turn failed', errorLogFields(error))
       }
-      // A disabled skill forced for this turn is restored now: clear the force set, then schedule a
-      // reconnect so the NEXT prompt respawns with the normal enabled set. Ordering matters — the clear
-      // must happen before the reconnect is applied so the fresh spawn no longer sees the forced ids.
-      if (didForceReload) {
-        this.turnForcedSkillIds.clear()
-        this.connectionTransitions.requestSkillsReload()
-      } else {
-        // A provider switch requested mid-turn is applied now that the session is idle.
+      turnSkillHandle.close(turnSkillOutcome)
+      if (turnSkillHandle.reloadDecision.kind === 'continue') {
         this.connectionTransitions.activityChanged()
       }
     }
@@ -3295,72 +3238,6 @@ class AcpRuntime {
     rawInput: unknown
   }): Promise<boolean> {
     return this.permissionContext.requestAppApproval(input)
-  }
-
-  // Prepends a one-line steering nudge naming the picked skills to the prompt text. No-op when no skills
-  // were picked or no hooks are wired. It is prompt text, not a system directive, per the design.
-  //
-  // Featured skill ids equal their frontmatter names, while personal/imported ids include an app-owned
-  // source prefix. Resolve the picker ids through settings so every nudge uses the name the agent's
-  // Skill tool accepts.
-  private async applySkillNudge(text: string, forcedSkillIds: string[]): Promise<string> {
-    if (!this.skillsHooks || forcedSkillIds.length === 0 || this.framework.id === 'codex')
-      return text
-
-    const names = await this.skillsHooks.namesForIds(forcedSkillIds)
-    if (names.length === 0) return text
-
-    return `Use the following skill(s) for this task: ${names.join(', ')}.\n\n${text}`
-  }
-
-  private async resolveCodexSkillInputs(
-    forcedSkillIds: string[],
-    text: string,
-    signal?: AbortSignal,
-    specialistSkills?: EffectiveSpecialistSkills
-  ): Promise<Array<{ name: string; path: string }>> {
-    if (this.framework.id !== 'codex') return []
-
-    // An explicit picker choice is authoritative even when it no longer resolves. Never supplement
-    // it with model-selected Skills, which would make the user's visible choice nondeterministic.
-    if (forcedSkillIds.length > 0) {
-      if (!this.skillsHooks?.descriptorsForIds) return []
-      return this.skillsHooks.descriptorsForIds(forcedSkillIds, this.backend.adapter.codexHome)
-    }
-
-    if (!this.connectionResources.bridgeSkillsAvailable || !this.skillsHooks?.catalogForCodexHome) {
-      return []
-    }
-
-    let catalog: ResponsesBridgeSkillCandidate[]
-    try {
-      catalog = await this.skillsHooks.catalogForCodexHome(this.backend.adapter.codexHome)
-    } catch {
-      log.warn('Codex Skill selection failed', { reason: 'catalog-error' })
-      return []
-    }
-    // Codex receives selected Skills as native prompt metadata. Unlike Claude, it has no
-    // session-native whitelist, so its automatic selector must be scoped before it sees the
-    // catalog. This includes connector docs: they are materialized as `mcp-<id>` Skills and are
-    // part of frameworkNames, not the app's durable skillIds.
-    const allowedFrameworkNames =
-      specialistSkills?.kind === 'specialist' ? new Set(specialistSkills.frameworkNames) : undefined
-    if (allowedFrameworkNames) {
-      catalog = catalog.filter((skill) => allowedFrameworkNames.has(skill.name))
-    }
-    if (catalog.length === 0) return []
-
-    try {
-      const selected = await this.connectionResources.selectBridgeSkills(text, catalog, signal)
-      if (!selected) return []
-      // Treat the selector as advisory: retain only Skills it was offered. This keeps an out-of-date
-      // selector result from reintroducing a Skill or mcp-* connector from the previous specialist.
-      const offeredSkills = new Set(catalog.map((skill) => `${skill.name}\u0000${skill.path}`))
-      return selected.filter((skill) => offeredSkills.has(`${skill.name}\u0000${skill.path}`))
-    } catch {
-      log.warn('Codex Skill selection failed', { reason: 'selector-error' })
-      return []
-    }
   }
 
   // Native UserInput::Skill entries are consumed inside Codex and may not emit a filesystem read
@@ -3621,15 +3498,6 @@ class AcpRuntime {
     } catch {
       return String(value)
     }
-  }
-
-  // Codex and OpenCode have no session-native whitelist. Their guidance is intentionally factual
-  // rather than presented as an isolation boundary; enforcement remains the picker/send gate.
-  private specialistSkillGuidance(
-    skills: EffectiveSpecialistSkills | undefined
-  ): string | undefined {
-    if (this.framework.id === 'claude-code' || skills?.kind !== 'specialist') return undefined
-    return `Allowed Specialist Skills for this session:\n${skills.frameworkNames.map((name) => `- ${name}`).join('\n')}`
   }
 
   // Builds the ACP `_meta` argument for session/new and session/resume, delegating the framework-specific

--- a/src/main/acp/turn-skill-owner.test.ts
+++ b/src/main/acp/turn-skill-owner.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { codexFramework, opencodeFramework } from '../agent-framework'
+import { AcpTurnSkillOwner } from './turn-skill-owner'
+
+describe('AcpTurnSkillOwner', () => {
+  it('keeps ordinary Main turns synchronous when no Skill work can yield', () => {
+    const owner = new AcpTurnSkillOwner({ requestSkillsReload: vi.fn() })
+
+    const handle = owner.authorize({})
+
+    expect(handle).not.toBeInstanceOf(Promise)
+    expect(handle).toMatchObject({ reloadDecision: { kind: 'continue' } })
+  })
+
+  it('re-resolves Specialist scope and rejects a stale selected Skill fail-closed', async () => {
+    const resolveSpecialistSkills = vi.fn(async () => ({
+      kind: 'specialist' as const,
+      skillIds: ['current-skill'],
+      frameworkNames: ['Current Skill', 'mcp-current-connector'],
+      missingSkillIds: []
+    }))
+    const owner = new AcpTurnSkillOwner({
+      resolveSpecialistSkills,
+      requestSkillsReload: vi.fn()
+    })
+
+    await expect(
+      owner.authorize({ specialistId: 'specialist-1', selectedSkillIds: ['stale-skill'] })
+    ).rejects.toThrow('Skill "stale-skill" is not available to the active specialist.')
+    expect(resolveSpecialistSkills).toHaveBeenCalledWith('specialist-1')
+
+    await expect(
+      owner.authorize({
+        specialistId: 'specialist-1',
+        selectedSkillIds: ['mcp-current-connector']
+      })
+    ).resolves.toMatchObject({ reloadDecision: { kind: 'continue' } })
+    expect(resolveSpecialistSkills).toHaveBeenCalledTimes(2)
+  })
+
+  it('transfers overlapping forced IDs and lets only the current handle restore reload state', async () => {
+    const ownerRef: { current?: AcpTurnSkillOwner } = {}
+    const requestSkillsReload = vi.fn(() => {
+      expect(ownerRef.current?.backendPreparation()).toEqual({ forcedSkillIds: [] })
+    })
+    const owner = new AcpTurnSkillOwner({
+      skills: {
+        needForceLoad: async (ids) => [...ids],
+        namesForIds: async (ids) => [...ids]
+      },
+      requestSkillsReload
+    })
+    ownerRef.current = owner
+
+    const first = await owner.authorize({ selectedSkillIds: ['first'] })
+    expect(first.reloadDecision).toEqual({ kind: 'reload' })
+    expect(owner.backendPreparation()).toEqual({ forcedSkillIds: ['first'] })
+
+    const successor = await owner.authorize({ selectedSkillIds: ['successor'] })
+    expect(successor.reloadDecision).toEqual({ kind: 'reload' })
+    expect(owner.backendPreparation()).toEqual({ forcedSkillIds: ['successor'] })
+
+    first.close('completed')
+    expect(owner.backendPreparation()).toEqual({ forcedSkillIds: ['successor'] })
+    expect(requestSkillsReload).not.toHaveBeenCalled()
+
+    successor.close('failed')
+    successor.close('cancelled')
+    expect(owner.backendPreparation()).toEqual({ forcedSkillIds: [] })
+    expect(requestSkillsReload).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a newer forced authorization when an older preflight finishes last', async () => {
+    const completions = new Map<string, (disabled: string[]) => void>()
+    const requestSkillsReload = vi.fn()
+    const olderReservation = new AbortController()
+    const owner = new AcpTurnSkillOwner({
+      skills: {
+        needForceLoad: (ids) =>
+          new Promise((resolve) => {
+            completions.set(ids[0], resolve)
+          }),
+        namesForIds: async (ids) => [...ids]
+      },
+      requestSkillsReload
+    })
+
+    const olderAuthorization = owner.authorize({
+      selectedSkillIds: ['older'],
+      signal: olderReservation.signal
+    })
+    olderReservation.abort()
+    const newerAuthorization = owner.authorize({ selectedSkillIds: ['newer'] })
+    completions.get('newer')?.(['newer'])
+    const newer = await newerAuthorization
+    expect(owner.backendPreparation()).toEqual({ forcedSkillIds: ['newer'] })
+
+    completions.get('older')?.(['older'])
+    const older = await olderAuthorization
+    expect(older.reloadDecision).toEqual({ kind: 'continue' })
+    expect(owner.backendPreparation()).toEqual({ forcedSkillIds: ['newer'] })
+
+    older.close('failed')
+    expect(owner.backendPreparation()).toEqual({ forcedSkillIds: ['newer'] })
+    newer.close('completed')
+    expect(requestSkillsReload).toHaveBeenCalledOnce()
+  })
+
+  it('keeps an independent forced authorization valid when it finishes last', async () => {
+    const completions = new Map<string, (disabled: string[]) => void>()
+    const owner = new AcpTurnSkillOwner({
+      skills: {
+        needForceLoad: (ids) =>
+          new Promise((resolve) => {
+            completions.set(ids[0], resolve)
+          }),
+        namesForIds: async (ids) => [...ids]
+      },
+      requestSkillsReload: vi.fn()
+    })
+
+    const firstSession = owner.authorize({ selectedSkillIds: ['first-session'] })
+    const secondSession = owner.authorize({ selectedSkillIds: ['second-session'] })
+    completions.get('second-session')?.(['second-session'])
+    const second = await secondSession
+    expect(second.reloadDecision).toEqual({ kind: 'reload' })
+
+    completions.get('first-session')?.(['first-session'])
+    const first = await firstSession
+    expect(first.reloadDecision).toEqual({ kind: 'reload' })
+    expect(owner.backendPreparation()).toEqual({ forcedSkillIds: ['first-session'] })
+  })
+
+  it.each(['cancelled', 'reload-restored'] as const)(
+    'clears forced IDs before requesting reload when the handle closes as %s',
+    async (outcome) => {
+      const ownerRef: { current?: AcpTurnSkillOwner } = {}
+      const requestSkillsReload = vi.fn(() => {
+        expect(ownerRef.current?.backendPreparation()).toEqual({ forcedSkillIds: [] })
+      })
+      const owner = new AcpTurnSkillOwner({
+        skills: {
+          needForceLoad: async (ids) => [...ids],
+          namesForIds: async (ids) => [...ids]
+        },
+        requestSkillsReload
+      })
+      ownerRef.current = owner
+
+      const handle = await owner.authorize({ selectedSkillIds: ['disabled'] })
+      expect(owner.backendPreparation()).toEqual({ forcedSkillIds: ['disabled'] })
+      expect(owner.backendPreparation()).toEqual({ forcedSkillIds: ['disabled'] })
+
+      handle.close(outcome)
+      handle.close(outcome)
+      expect(requestSkillsReload).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('retains forced IDs across backend reconnect preparations until the turn closes', async () => {
+    const owner = new AcpTurnSkillOwner({
+      skills: {
+        needForceLoad: async (ids) => [...ids],
+        namesForIds: async (ids) => [...ids]
+      },
+      requestSkillsReload: vi.fn()
+    })
+    const handle = await owner.authorize({ selectedSkillIds: ['disabled'] })
+
+    const firstConnect = owner.backendPreparation()
+    const reconnect = owner.backendPreparation()
+    expect(firstConnect).toEqual({ forcedSkillIds: ['disabled'] })
+    expect(reconnect).toEqual({ forcedSkillIds: ['disabled'] })
+
+    handle.close('completed')
+    expect(owner.backendPreparation()).toEqual({ forcedSkillIds: [] })
+  })
+
+  it('prepares non-Codex Skill nudges and current Specialist guidance together', async () => {
+    const owner = new AcpTurnSkillOwner({
+      resolveSpecialistSkills: async () => ({
+        kind: 'specialist',
+        skillIds: ['personal-research'],
+        frameworkNames: ['Research', 'mcp-pubmed'],
+        missingSkillIds: []
+      }),
+      skills: {
+        needForceLoad: async () => [],
+        namesForIds: async () => ['Research']
+      },
+      requestSkillsReload: vi.fn()
+    })
+    const handle = await owner.authorize({
+      specialistId: 'specialist-1',
+      selectedSkillIds: ['personal-research']
+    })
+
+    const prepared = await handle.prepareProvider({
+      frameworkId: opencodeFramework.id,
+      selectionText: 'find papers',
+      promptText: 'find papers'
+    })
+
+    expect(prepared.text).toBe('Use the following skill(s) for this task: Research.\n\nfind papers')
+    expect(prepared.specialistSkillGuidance).toContain('Allowed Specialist Skills for this session')
+    expect(prepared.specialistSkillGuidance).toContain('mcp-pubmed')
+    expect(prepared.codexSkillInputs).toEqual([])
+  })
+
+  it('prepares an explicit Codex Skill as native input without changing prompt text', async () => {
+    const namesForIds = vi.fn(async (ids: readonly string[]) => [...ids])
+    const descriptorsForIds = vi.fn(async () => [
+      { name: 'Research', path: '/codex/skills/research/SKILL.md' }
+    ])
+    const selectSkills = vi.fn(async () => [
+      { name: 'automatic', path: '/codex/skills/automatic/SKILL.md' }
+    ])
+    const owner = new AcpTurnSkillOwner({
+      skills: {
+        needForceLoad: async () => [],
+        namesForIds,
+        descriptorsForIds
+      },
+      requestSkillsReload: vi.fn()
+    })
+    const handle = await owner.authorize({ selectedSkillIds: ['personal-research'] })
+
+    const prepared = await handle.prepareProvider({
+      frameworkId: codexFramework.id,
+      selectionText: 'find papers',
+      promptText: 'find papers',
+      codex: {
+        home: '/codex',
+        bridgeSkillsAvailable: true,
+        selectSkills
+      }
+    })
+
+    expect(descriptorsForIds).toHaveBeenCalledWith(['personal-research'], '/codex')
+    expect(namesForIds).not.toHaveBeenCalled()
+    expect(selectSkills).not.toHaveBeenCalled()
+    expect(prepared).toMatchObject({
+      text: 'find papers',
+      codexSkillInputs: [{ name: 'Research', path: '/codex/skills/research/SKILL.md' }]
+    })
+  })
+
+  it('scopes Codex automatic selection and rejects stale selector results', async () => {
+    const oldSkill = {
+      name: 'mcp-old',
+      description: 'Old connector',
+      path: '/codex/skills/mcp-old/SKILL.md'
+    }
+    const currentSkill = {
+      name: 'mcp-current',
+      description: 'Current connector',
+      path: '/codex/skills/mcp-current/SKILL.md'
+    }
+    const signal = new AbortController().signal
+    const selectSkills = vi.fn(async () => [oldSkill, currentSkill])
+    const owner = new AcpTurnSkillOwner({
+      resolveSpecialistSkills: async () => ({
+        kind: 'specialist',
+        skillIds: [],
+        frameworkNames: ['mcp-current'],
+        missingSkillIds: []
+      }),
+      skills: {
+        needForceLoad: async () => [],
+        namesForIds: async () => [],
+        catalogForCodexHome: async () => [oldSkill, currentSkill]
+      },
+      requestSkillsReload: vi.fn()
+    })
+    const handle = await owner.authorize({ specialistId: 'specialist-1' })
+
+    const prepared = await handle.prepareProvider({
+      frameworkId: codexFramework.id,
+      selectionText: 'use the current connector',
+      promptText: 'use the current connector',
+      codex: {
+        home: '/codex',
+        bridgeSkillsAvailable: true,
+        selectSkills,
+        signal
+      }
+    })
+
+    expect(selectSkills).toHaveBeenCalledWith('use the current connector', [currentSkill], signal)
+    expect(prepared.codexSkillInputs).toEqual([currentSkill])
+  })
+
+  it('passes cancellation to the Codex selector and fails open when it aborts', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const selectSkills = vi.fn(async (_text, _catalog, signal?: AbortSignal) => {
+      expect(signal?.aborted).toBe(true)
+      throw new Error('aborted')
+    })
+    const owner = new AcpTurnSkillOwner({
+      skills: {
+        needForceLoad: async () => [],
+        namesForIds: async () => [],
+        catalogForCodexHome: async () => [
+          { name: 'research', description: 'Research', path: '/skills/research/SKILL.md' }
+        ]
+      },
+      requestSkillsReload: vi.fn()
+    })
+    const handle = await owner.authorize({})
+
+    const prepared = await handle.prepareProvider({
+      frameworkId: codexFramework.id,
+      selectionText: 'find papers',
+      promptText: 'find papers',
+      codex: {
+        bridgeSkillsAvailable: true,
+        selectSkills,
+        signal: controller.signal
+      }
+    })
+
+    expect(selectSkills).toHaveBeenCalledOnce()
+    expect(prepared.codexSkillInputs).toEqual([])
+  })
+})

--- a/src/main/acp/turn-skill-owner.ts
+++ b/src/main/acp/turn-skill-owner.ts
@@ -1,0 +1,179 @@
+import type { AgentFrameworkId } from '../../shared/settings'
+import type { EffectiveSpecialistSkills } from '../../shared/specialist'
+import type { ResolvedAgentBackend } from '../agent-framework'
+import { createLogger } from '../logger'
+import type {
+  ResponsesBridgeSkillCandidate,
+  ResponsesBridgeSkillInput
+} from '../settings/responses-bridge'
+import { AcpSessionPresentationPolicy } from './session-presentation-policy'
+const log = createLogger('acp-turn-skill-owner')
+const presentation = new AcpSessionPresentationPolicy()
+type AcpTurnSkillHooks = Readonly<{
+  needForceLoad: (ids: string[]) => Promise<string[]>
+  namesForIds: (ids: string[]) => Promise<string[]>
+  descriptorsForIds?: (
+    ids: string[],
+    codexHome: string | undefined
+  ) => Promise<ResponsesBridgeSkillInput[]>
+  catalogForCodexHome?: (codexHome: string | undefined) => Promise<ResponsesBridgeSkillCandidate[]>
+}>
+type TurnSkillOutcome = 'completed' | 'failed' | 'cancelled' | 'reload-restored'
+type ProviderPreparationInput = Readonly<{
+  frameworkId: AgentFrameworkId
+  selectionText: string
+  promptText: string
+  codex?: Readonly<{
+    home?: string
+    bridgeSkillsAvailable: boolean
+    selectSkills: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>['selectSkills']
+    signal?: AbortSignal
+  }>
+}>
+type ProviderPreparation = Readonly<{
+  text: string
+  specialistSkillGuidance?: string
+  codexSkillInputs: readonly ResponsesBridgeSkillInput[]
+}>
+type TurnSkillHandle = Readonly<{
+  reloadDecision: Readonly<{ kind: 'continue' | 'reload' }>
+  prepareProvider: (input: ProviderPreparationInput) => Promise<ProviderPreparation>
+  close: (outcome: TurnSkillOutcome) => void
+}>
+type Authorization = {
+  outcome?: TurnSkillOutcome
+  selectedSkillIds: readonly string[]
+  scope?: EffectiveSpecialistSkills
+}
+class AcpTurnSkillOwner {
+  private forced: Authorization | undefined
+  constructor(
+    private readonly options: Readonly<{
+      resolveSpecialistSkills?: (id: string) => Promise<EffectiveSpecialistSkills>
+      skills?: AcpTurnSkillHooks
+      requestSkillsReload: () => void
+    }>
+  ) {}
+  authorize(input: {
+    specialistId?: string
+    selectedSkillIds?: readonly string[]
+    signal?: AbortSignal
+  }): TurnSkillHandle | Promise<TurnSkillHandle> {
+    const selected = Object.freeze([...(input.selectedSkillIds ?? [])])
+    const finish = (
+      scope?: EffectiveSpecialistSkills
+    ): TurnSkillHandle | Promise<TurnSkillHandle> => {
+      if (scope?.kind === 'unavailable') throw new Error(scope.reason)
+      if (scope?.kind === 'specialist') {
+        const rejected = selected.find(
+          (id) =>
+            !scope.skillIds.includes(id) &&
+            !(id.startsWith('mcp-') && scope.frameworkNames.includes(id))
+        )
+        if (rejected) {
+          throw new Error(`Skill "${rejected}" is not available to the active specialist.`)
+        }
+      }
+      const create = (disabled: string[]): TurnSkillHandle => {
+        const needsReload = disabled.length > 0 && !input.signal?.aborted
+        const state: Authorization = {
+          selectedSkillIds: selected,
+          ...(scope ? { scope } : {})
+        }
+        if (needsReload) this.forced = state
+        return Object.freeze({
+          reloadDecision: Object.freeze({ kind: needsReload ? 'reload' : 'continue' }),
+          prepareProvider: (providerInput) => this.prepareProvider(state, providerInput),
+          close: (outcome) => this.close(state, outcome)
+        })
+      }
+      return this.options.skills && selected.length > 0
+        ? this.options.skills.needForceLoad([...selected]).then(create)
+        : create([])
+    }
+    if (!input.specialistId || !this.options.resolveSpecialistSkills) return finish()
+    return this.options
+      .resolveSpecialistSkills(input.specialistId)
+      .catch(
+        () => ({ kind: 'unavailable', reason: 'The bound specialist is unavailable.' }) as const
+      )
+      .then(finish)
+  }
+  backendPreparation(): Readonly<{ forcedSkillIds: readonly string[] }> {
+    return Object.freeze({
+      forcedSkillIds: Object.freeze([...(this.forced?.selectedSkillIds ?? [])])
+    })
+  }
+  private close(state: Authorization, outcome: TurnSkillOutcome): void {
+    if (state.outcome) return
+    state.outcome = outcome
+    if (this.forced !== state) return
+    this.forced = undefined
+    this.options.requestSkillsReload()
+  }
+  private async prepareProvider(
+    state: Authorization,
+    input: ProviderPreparationInput
+  ): Promise<ProviderPreparation> {
+    const skillNames =
+      input.frameworkId !== 'codex' && state.selectedSkillIds.length > 0 && this.options.skills
+        ? await this.options.skills.namesForIds([...state.selectedSkillIds])
+        : []
+    const codexSkillInputs = await this.resolveCodexInputs(state, input)
+    const presented = presentation.presentTurnSkills({
+      frameworkId: input.frameworkId,
+      text: input.promptText,
+      skillNames,
+      codexSkillInputs
+    })
+    const guidance =
+      input.frameworkId !== 'claude-code' && state.scope?.kind === 'specialist'
+        ? `Allowed Specialist Skills for this session:\n${state.scope.frameworkNames.map((name) => `- ${name}`).join('\n')}`
+        : undefined
+    return Object.freeze({
+      ...presented,
+      ...(guidance ? { specialistSkillGuidance: guidance } : {}),
+      codexSkillInputs: Object.freeze(codexSkillInputs)
+    })
+  }
+  private async resolveCodexInputs(
+    state: Authorization,
+    input: ProviderPreparationInput
+  ): Promise<ResponsesBridgeSkillInput[]> {
+    if (input.frameworkId !== 'codex') return []
+    if (state.selectedSkillIds.length > 0) {
+      return (
+        this.options.skills?.descriptorsForIds?.([...state.selectedSkillIds], input.codex?.home) ??
+        []
+      )
+    }
+    const codex = input.codex
+    if (!codex?.bridgeSkillsAvailable || !this.options.skills?.catalogForCodexHome) return []
+    let catalog: ResponsesBridgeSkillCandidate[]
+    try {
+      catalog = await this.options.skills.catalogForCodexHome(codex.home)
+    } catch {
+      return this.selectionFailed('catalog-error')
+    }
+    if (state.scope?.kind === 'specialist') {
+      const allowed = new Set(state.scope.frameworkNames)
+      catalog = catalog.filter((skill) => allowed.has(skill.name))
+    }
+    if (catalog.length === 0) return []
+    try {
+      const selected = await codex.selectSkills(input.selectionText, catalog, codex.signal)
+      if (!selected) return []
+      const offered = new Set(catalog.map((skill) => `${skill.name}\u0000${skill.path}`))
+      return selected.filter((skill) => offered.has(`${skill.name}\u0000${skill.path}`))
+    } catch {
+      return this.selectionFailed('selector-error')
+    }
+  }
+  private selectionFailed(reason: 'catalog-error' | 'selector-error'): [] {
+    log.warn('Codex Skill selection failed', { reason })
+    return []
+  }
+}
+
+export { AcpTurnSkillOwner }
+export type { AcpTurnSkillHooks, TurnSkillHandle, TurnSkillOutcome }


### PR DESCRIPTION
## Problem

Runtime spread turn-scoped Skill authorization, forced-ID state, reload restoration, and provider preparation across mutable call-site state. Overlapping prompt preflights made ownership and exact-once cleanup difficult to reason about.

Related: #458 (forward-compatibility constraint only; this PR added no orchestration data model or public interface).

## Proposed change

- Add `AcpTurnSkillOwner.authorize(...)` and a typed `TurnSkillHandle` lifecycle.
- Re-resolve Specialist scope and fail closed on stale or unavailable selected Skills.
- Make the owner the sole writer of forced Skill IDs and clear them before requesting the existing reload transition.
- Supply forced IDs only during backend preparation and preserve them across reconnect preparation until handle close.
- Prepare Claude/OpenCode nudges, Specialist guidance, and Codex native Skill inputs/selection without changing provider adapters.
- Bind same-Session supersession to Runtime's prompt-reservation signal while preserving independent concurrent authorizations.

## Scope and non-goals

- No public API, data model, IPC, UI, orchestration data, Specialist management, or provider-adapter change.
- No ownership change to the ARD-13 update-derived Codex Skill projector.
- The new owner did not own reconnect transitions.
- Exact production raw: **493** (tests/docs/generated excluded).

## Ownership and sequence

```mermaid
sequenceDiagram
  participant R as AcpRuntime
  participant O as AcpTurnSkillOwner
  participant B as Backend preparation
  participant T as Existing reload transition
  R->>O: authorize(Session, selected Skills)
  O->>O: re-resolve scope and own forced IDs
  O-->>R: TurnSkillHandle
  R->>B: prepare with handle-owned forced IDs
  R->>O: close handle
  O->>O: clear forced IDs
  O->>T: request reload when required
```

`AcpTurnSkillOwner` is the sole forced-ID writer. Runtime retains prompt reservation/supersession and the existing transition path retains reload/reconnect authority.

## Acceptance criteria and validation

The historical PR record states that these checks ran on the final material state:

- Turn-Skill and Runtime Skill/Specialist behavior, including reverse-completion overlap, cancellation, reload failure, and reconnect preparation -> focused tests -> **passed**. Exact test argv/count was not retained.
- Portable suite -> `npm test` -> **756 files passed, 14 skipped; 11,199 tests passed, 184 skipped**.
- Node contracts -> `npm run typecheck:node` -> **passed**.
- Source lint -> `npm run lint` -> **passed with 0 errors and 17 pre-existing warnings**.
- Formatting -> targeted Prettier check -> **passed**; exact argv unavailable.
- Diff integrity -> `git diff --check` -> **passed**.
- Final online gates -> GitHub records **PR Gate, Unit tests, Static checks, Coverage macOS, macOS build and E2E, Windows E2E, CodeQL, and AI review workflow success**.

Independent Standards review recorded no findings; Spec review recorded no findings after overlap fixes.

## Review focus

- Forced-ID writer ownership and clear-before-reload order.
- Same-Session superseded preflight versus independent concurrent authorization.
- Preservation of Specialist whitelist, disabled-Skill reload/resume, Codex native inputs, activity, and next-turn restoration behavior.

## Uncovered risks

- Historical focused-test argv was not retained.
- Live provider behavior and OS packaging were not separately reproduced locally; successful online platform lanes remain the retained evidence.

