### PR TITLE
refactor(acp): extract client callback adapter

### DIFF
--- a/src/main/acp/agent-connection-adapter.test.ts
+++ b/src/main/acp/agent-connection-adapter.test.ts
@@ -1,0 +1,327 @@
+import * as acp from '@agentclientprotocol/sdk'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough, Readable, Writable } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AcpAgentConnectionAdapter, type AcpAgentConnectionHooks } from './agent-connection-adapter'
+
+class FakeAgentProcess extends EventEmitter {
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+}
+
+const asAgentProcess = (process: FakeAgentProcess): ChildProcessWithoutNullStreams =>
+  process as unknown as ChildProcessWithoutNullStreams
+
+const hooks = (): AcpAgentConnectionHooks => ({
+  requestPermission: vi.fn(async () => ({ outcome: { outcome: 'cancelled' as const } })),
+  observeSessionUpdate: vi.fn(),
+  observeClaudeSdkMessage: vi.fn(),
+  filesystem: {
+    resolveSessionCwd: vi.fn(() => '/workspace'),
+    protectedReadRoots: vi.fn(() => [])
+  }
+})
+
+describe('AcpAgentConnectionAdapter', () => {
+  it('opens an ACP client connection over the child process streams', async () => {
+    const process = new FakeAgentProcess()
+    acp
+      .agent({ name: 'test-agent' })
+      .onRequest(acp.methods.agent.initialize, () => ({
+        protocolVersion: acp.PROTOCOL_VERSION,
+        agentCapabilities: { loadSession: false },
+        authMethods: []
+      }))
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+
+    const connection = new AcpAgentConnectionAdapter().open(
+      { process: asAgentProcess(process) },
+      hooks()
+    )
+
+    await expect(
+      connection.agent.request(acp.methods.agent.initialize, {
+        protocolVersion: acp.PROTOCOL_VERSION,
+        clientInfo: { name: 'open-science', version: '0.1.0' },
+        clientCapabilities: {}
+      })
+    ).resolves.toMatchObject({ protocolVersion: acp.PROTOCOL_VERSION })
+
+    connection.close()
+  })
+
+  it('translates permission requests and returns the hook response', async () => {
+    const process = new FakeAgentProcess()
+    const agentConnection = acp
+      .agent({ name: 'test-agent' })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+    const connectionHooks = hooks()
+    const request = {
+      sessionId: 'provider-session',
+      toolCall: {
+        toolCallId: 'tool-1',
+        title: 'Run tests',
+        kind: 'execute' as const,
+        status: 'pending' as const
+      },
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' as const }]
+    }
+    vi.mocked(connectionHooks.requestPermission).mockResolvedValue({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    const connection = new AcpAgentConnectionAdapter().open(
+      { process: asAgentProcess(process) },
+      connectionHooks
+    )
+
+    await expect(
+      agentConnection.client.request(acp.methods.client.session.requestPermission, request)
+    ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow-once' } })
+    expect(connectionHooks.requestPermission).toHaveBeenCalledWith(request)
+
+    connection.close()
+    agentConnection.close()
+  })
+
+  it('returns permission hook failures over ACP without replacing their diagnostic detail', async () => {
+    const process = new FakeAgentProcess()
+    const agentConnection = acp
+      .agent({ name: 'test-agent' })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+    const connectionHooks = hooks()
+    vi.mocked(connectionHooks.requestPermission).mockRejectedValue(
+      new Error('permission hook failed')
+    )
+    const connection = new AcpAgentConnectionAdapter().open(
+      { process: asAgentProcess(process) },
+      connectionHooks
+    )
+
+    await expect(
+      agentConnection.client.request(acp.methods.client.session.requestPermission, {
+        sessionId: 'provider-session',
+        toolCall: {
+          toolCallId: 'tool-1',
+          title: 'Run tests',
+          kind: 'execute',
+          status: 'pending'
+        },
+        options: [{ optionId: 'reject', name: 'Reject', kind: 'reject_once' }]
+      })
+    ).rejects.toMatchObject({
+      code: -32603,
+      data: { details: 'permission hook failed' }
+    })
+
+    connection.close()
+    agentConnection.close()
+  })
+
+  it('delivers a session update before the following permission request', async () => {
+    const process = new FakeAgentProcess()
+    const agentConnection = acp
+      .agent({ name: 'test-agent' })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+    const actions: string[] = []
+    const connectionHooks = hooks()
+    vi.mocked(connectionHooks.observeSessionUpdate).mockImplementation(() => {
+      actions.push('update')
+    })
+    vi.mocked(connectionHooks.requestPermission).mockImplementation(async () => {
+      actions.push('permission')
+      return { outcome: { outcome: 'cancelled' } }
+    })
+    const connection = new AcpAgentConnectionAdapter().open(
+      { process: asAgentProcess(process) },
+      connectionHooks
+    )
+
+    const notification = {
+      sessionId: 'provider-session',
+      update: {
+        sessionUpdate: 'tool_call' as const,
+        toolCallId: 'tool-1',
+        title: 'Run tests',
+        status: 'pending' as const
+      }
+    }
+    await agentConnection.client.notify(acp.methods.client.session.update, notification)
+    await agentConnection.client.request(acp.methods.client.session.requestPermission, {
+      sessionId: 'provider-session',
+      toolCall: notification.update,
+      options: [{ optionId: 'reject', name: 'Reject', kind: 'reject_once' }]
+    })
+
+    expect(connectionHooks.observeSessionUpdate).toHaveBeenCalledWith(notification)
+    expect(actions).toEqual(['update', 'permission'])
+
+    connection.close()
+    agentConnection.close()
+  })
+
+  it('translates Claude SDK message notifications', async () => {
+    const process = new FakeAgentProcess()
+    const agentConnection = acp
+      .agent({ name: 'test-agent' })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+    const connectionHooks = hooks()
+    const connection = new AcpAgentConnectionAdapter().open(
+      { process: asAgentProcess(process) },
+      connectionHooks
+    )
+    const notification = {
+      sessionId: 'provider-session',
+      message: { type: 'result', num_turns: 2, origin: { kind: 'human' } }
+    }
+
+    await agentConnection.client.notify('_claude/sdkMessage', notification)
+
+    await vi.waitFor(() =>
+      expect(connectionHooks.observeClaudeSdkMessage).toHaveBeenCalledWith(notification)
+    )
+
+    connection.close()
+    agentConnection.close()
+  })
+
+  it('reads text files inside the session workspace', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'acp-connection-adapter-'))
+    const filePath = join(workspace, 'notes.txt')
+    await writeFile(filePath, 'one\ntwo\nthree', 'utf8')
+    const process = new FakeAgentProcess()
+    const agentConnection = acp
+      .agent({ name: 'test-agent' })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+    const connectionHooks = hooks()
+    vi.mocked(connectionHooks.filesystem.resolveSessionCwd).mockReturnValue(workspace)
+    const connection = new AcpAgentConnectionAdapter().open(
+      { process: asAgentProcess(process) },
+      connectionHooks
+    )
+
+    await expect(
+      agentConnection.client.request(acp.methods.client.fs.readTextFile, {
+        sessionId: 'provider-session',
+        path: filePath,
+        line: 2,
+        limit: 1
+      })
+    ).resolves.toEqual({ content: 'two' })
+    expect(connectionHooks.filesystem.resolveSessionCwd).toHaveBeenCalledWith('provider-session')
+    expect(connectionHooks.filesystem.protectedReadRoots).toHaveBeenCalledOnce()
+
+    connection.close()
+    agentConnection.close()
+    await rm(workspace, { recursive: true, force: true })
+  })
+
+  it('rejects reads from protected application roots', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'acp-connection-adapter-'))
+    const protectedRoot = join(workspace, '.provider-config')
+    const filePath = join(protectedRoot, 'credentials.json')
+    await mkdir(protectedRoot)
+    await writeFile(filePath, 'secret', 'utf8')
+    const process = new FakeAgentProcess()
+    const agentConnection = acp
+      .agent({ name: 'test-agent' })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+    const connectionHooks = hooks()
+    vi.mocked(connectionHooks.filesystem.resolveSessionCwd).mockReturnValue(workspace)
+    vi.mocked(connectionHooks.filesystem.protectedReadRoots).mockReturnValue([protectedRoot])
+    const connection = new AcpAgentConnectionAdapter().open(
+      { process: asAgentProcess(process) },
+      connectionHooks
+    )
+
+    await expect(
+      agentConnection.client.request(acp.methods.client.fs.readTextFile, {
+        sessionId: 'provider-session',
+        path: filePath
+      })
+    ).rejects.toMatchObject({
+      code: -32603,
+      data: {
+        details: 'This file belongs to a protected application directory and cannot be read.'
+      }
+    })
+
+    connection.close()
+    agentConnection.close()
+    await rm(workspace, { recursive: true, force: true })
+  })
+
+  it('writes text files inside the session workspace', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'acp-connection-adapter-'))
+    const filePath = join(workspace, 'nested', 'notes.txt')
+    const process = new FakeAgentProcess()
+    const agentConnection = acp
+      .agent({ name: 'test-agent' })
+      .connect(
+        acp.ndJsonStream(
+          Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+          Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+        )
+      )
+    const connectionHooks = hooks()
+    vi.mocked(connectionHooks.filesystem.resolveSessionCwd).mockReturnValue(workspace)
+    const connection = new AcpAgentConnectionAdapter().open(
+      { process: asAgentProcess(process) },
+      connectionHooks
+    )
+
+    await expect(
+      agentConnection.client.request(acp.methods.client.fs.writeTextFile, {
+        sessionId: 'provider-session',
+        path: filePath,
+        content: 'written through ACP'
+      })
+    ).resolves.toEqual({})
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('written through ACP')
+    expect(connectionHooks.filesystem.resolveSessionCwd).toHaveBeenCalledWith('provider-session')
+
+    connection.close()
+    agentConnection.close()
+    await rm(workspace, { recursive: true, force: true })
+  })
+})

--- a/src/main/acp/agent-connection-adapter.ts
+++ b/src/main/acp/agent-connection-adapter.ts
@@ -1,0 +1,69 @@
+import * as acp from '@agentclientprotocol/sdk'
+import type {
+  ClientConnection,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+  SessionNotification
+} from '@agentclientprotocol/sdk'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { Readable, Writable } from 'node:stream'
+
+import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
+
+type AcpAgentConnectionHooks = Readonly<{
+  requestPermission: (
+    request: RequestPermissionRequest
+  ) => RequestPermissionResponse | Promise<RequestPermissionResponse>
+  observeSessionUpdate: (notification: SessionNotification) => void
+  observeClaudeSdkMessage: (message: Record<string, unknown>) => void
+  filesystem: Readonly<{
+    resolveSessionCwd: (sessionId: string) => string
+    protectedReadRoots: () => readonly string[]
+  }>
+}>
+
+type AcpAgentConnectionInput = Readonly<{
+  process: ChildProcessWithoutNullStreams
+}>
+
+// Translates one spawned agent's stdio and client-side protocol callbacks into an ACP connection.
+// Process, connection, bridge-lease, and transition ownership remain with the Runtime/resource owner.
+class AcpAgentConnectionAdapter {
+  open(input: AcpAgentConnectionInput, hooks: AcpAgentConnectionHooks): ClientConnection {
+    const stream = acp.ndJsonStream(
+      Writable.toWeb(input.process.stdin) as WritableStream<Uint8Array>,
+      Readable.toWeb(input.process.stdout) as ReadableStream<Uint8Array>
+    )
+
+    return acp
+      .client({ name: 'open-science' })
+      .onRequest(acp.methods.client.session.requestPermission, (context) =>
+        hooks.requestPermission(context.params)
+      )
+      .onNotification(acp.methods.client.session.update, (context) =>
+        hooks.observeSessionUpdate(context.params)
+      )
+      .onNotification(
+        '_claude/sdkMessage',
+        (params) => params as Record<string, unknown>,
+        (context) => hooks.observeClaudeSdkMessage(context.params)
+      )
+      .onRequest(acp.methods.client.fs.readTextFile, (context) =>
+        readWorkspaceTextFile(
+          hooks.filesystem.resolveSessionCwd(context.params.sessionId),
+          context.params,
+          [...hooks.filesystem.protectedReadRoots()]
+        )
+      )
+      .onRequest(acp.methods.client.fs.writeTextFile, (context) =>
+        writeWorkspaceTextFile(
+          hooks.filesystem.resolveSessionCwd(context.params.sessionId),
+          context.params
+        )
+      )
+      .connect(stream)
+  }
+}
+
+export { AcpAgentConnectionAdapter }
+export type { AcpAgentConnectionHooks, AcpAgentConnectionInput }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -15,6 +15,7 @@ import { PassThrough, Readable, Writable } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from './runtime'
+import type { AcpAgentConnectionAdapter } from './agent-connection-adapter'
 import { AcpPermissionContext } from './permission-context'
 import { ContextUsageTracker, type TokenCounter } from './context-usage-tracker'
 import {
@@ -5551,15 +5552,11 @@ describe('ACP runtime session management', () => {
         responsesBridgeLease: lease
       })
     })
-    const internal = runtime as unknown as {
-      createClientConnection: (
-        stream: acp.Stream
-      ) => import('@agentclientprotocol/sdk').ClientConnection
-    }
-    const createConnection = internal.createClientConnection.bind(runtime)
+    const internal = runtime as unknown as { connectionAdapter: AcpAgentConnectionAdapter }
+    const openConnection = internal.connectionAdapter.open.bind(internal.connectionAdapter)
     let disconnect: Promise<unknown> | undefined
-    vi.spyOn(internal, 'createClientConnection').mockImplementation((stream) => {
-      const connection = createConnection(stream)
+    vi.spyOn(internal.connectionAdapter, 'open').mockImplementation((input, hooks) => {
+      const connection = openConnection(input, hooks)
       disconnect = runtime.disconnect()
       return connection
     })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -13,7 +13,6 @@ import type {
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
-import { Readable, Writable } from 'node:stream'
 
 import type {
   AcpCancelPromptRequest,
@@ -57,7 +56,6 @@ import {
 import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import { extractProviderToolName } from './runtime-events'
-import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 import { toCodexTurnTokenUsage } from './codex-turn-usage'
 import { fetchOpenCodeUsageSnapshot, sumOpenCodeTurnUsage } from './opencode-turn-usage'
 import { describePromptError, isProviderPromptError } from './prompt-error'
@@ -122,6 +120,7 @@ import {
   type AcpConnectionResourceAttempt,
   type AcpConnectionResourceReadyHandle
 } from './connection-resource-owner'
+import { AcpAgentConnectionAdapter } from './agent-connection-adapter'
 import { AcpConnectionTransitionOwner } from './connection-transition-owner'
 import { AcpGenerationActivityOwner } from './generation-activity-owner'
 import { AcpHandoffContinuityOwner } from './handoff-continuity-owner'
@@ -486,6 +485,7 @@ const isUnresumableSessionError = (error: unknown): boolean => {
 class AcpRuntime {
   private readonly snapshotOwner: AcpRuntimeSnapshotOwner
   private readonly contextUsageTracker: ContextUsageTracker
+  private readonly connectionAdapter = new AcpAgentConnectionAdapter()
   private readonly connectionResources: AcpConnectionResourceOwner
   private readonly connectionTransitions: AcpConnectionTransitionOwner
   private readonly generationActivity: AcpGenerationActivityOwner
@@ -973,12 +973,18 @@ class AcpRuntime {
       )
       this.attachAgentProcessEvents(agentProcess, generation)
 
-      const stream = acp.ndJsonStream(
-        Writable.toWeb(agentProcess.stdin) as WritableStream<Uint8Array>,
-        Readable.toWeb(agentProcess.stdout) as ReadableStream<Uint8Array>
+      const connection = this.connectionAdapter.open(
+        { process: agentProcess },
+        {
+          requestPermission: (params) => this.handlePermissionRequest(params),
+          observeSessionUpdate: (notification) => this.observePermissionToolContext(notification),
+          observeClaudeSdkMessage: (params) => this.observeClaudeSdkMessage(params),
+          filesystem: {
+            resolveSessionCwd: (sessionId) => this.resolveSessionCwd(sessionId),
+            protectedReadRoots: () => this.protectedReadRoots()
+          }
+        }
       )
-
-      const connection = this.createClientConnection(stream)
       unattachedConnection = connection
       attempt.attach({
         process: agentProcess,
@@ -3321,34 +3327,6 @@ class AcpRuntime {
 
     log.info('ensureConnected: connection established', this.diagnosticContext())
     return this.connection
-  }
-
-  // Registers client-side protocol handlers exposed to the agent process.
-  private createClientConnection(stream: acp.Stream): ClientConnection {
-    return acp
-      .client({ name: 'open-science' })
-      .onRequest(acp.methods.client.session.requestPermission, (ctx) =>
-        this.handlePermissionRequest(ctx.params)
-      )
-      .onNotification(acp.methods.client.session.update, (ctx) =>
-        this.observePermissionToolContext(ctx.params)
-      )
-      .onNotification(
-        '_claude/sdkMessage',
-        (params) => params as Record<string, unknown>,
-        (ctx) => this.observeClaudeSdkMessage(ctx.params)
-      )
-      .onRequest(acp.methods.client.fs.readTextFile, (ctx) =>
-        readWorkspaceTextFile(
-          this.resolveSessionCwd(ctx.params.sessionId),
-          ctx.params,
-          this.protectedReadRoots()
-        )
-      )
-      .onRequest(acp.methods.client.fs.writeTextFile, (ctx) =>
-        writeWorkspaceTextFile(this.resolveSessionCwd(ctx.params.sessionId), ctx.params)
-      )
-      .connect(stream)
   }
 
   private observeClaudeSdkMessage(params: Record<string, unknown>): void {


### PR DESCRIPTION
## Problem

`AcpRuntime` directly constructed ACP NDJSON streams and the SDK client while registering filesystem, Permission, Session-update, and Claude callback translations, hiding the external protocol seam inside lifecycle orchestration.

Related: #458 (forward-compatibility constraint only; this PR added no orchestration data model or public interface).

## Proposed change

- Add `AcpAgentConnectionAdapter.open(process, hooks)` for stdio/NDJSON, SDK client construction, and client-side callback translation.
- Cut Runtime over to narrow Permission, Session-update, Claude, and filesystem hooks.
- Add interface tests for construction, every callback class, callback failures, protected roots, and update-before-Permission ordering.

## Scope and non-goals

- Runtime retained process spawn, diagnostics, bridge leases, resource attachment/teardown, connection-close handling, and transition intent.
- The adapter had no disposer, candidate ownership, or cleanup path; those belonged to later ARD-15B work.
- No public event, IPC/wire, data model, UI, Specialist, Permission, Reviewer, Projector, turn-observation, filesystem, Compute, or surface-asymmetry change.
- Exact production raw: **117** against the recorded base `afb660e778da6e172ef8fb77720f38612b737606`.

## Ownership and sequence

```mermaid
flowchart LR
  R[AcpRuntime: spawn and lifecycle owner] --> P[Provider child process]
  R --> A[AcpAgentConnectionAdapter]
  P --> A
  A --> C[ACP SDK client and NDJSON translation]
  C --> H[Narrow Runtime hooks]
  H --> R
  R --> O[Existing resource / transition owners]
```

The adapter owns protocol construction and callback translation only. Runtime and existing owners remain responsible for physical resources, cleanup, diagnostics, and transition state.

## Acceptance criteria and validation

The historical PR record states that these checks ran after the last material edit:

- Client/stream callbacks plus Runtime and filesystem consumer contracts -> `npm test -- src/main/acp/agent-connection-adapter.test.ts src/main/acp/runtime.test.ts src/main/acp/filesystem.test.ts` -> **410 tests passed**.
- Node contracts -> `npm run typecheck:node` -> **passed**.
- Source lint -> `npm run lint` -> **passed with 0 errors; 17 pre-existing warnings outside the diff**.
- Formatting -> targeted Prettier check -> **passed**; exact argv unavailable.
- Diff integrity -> `git diff --check` -> **passed**.
- Independent final-commit review -> **Standards 0 findings; Spec 0 findings**.
- Final online gates -> GitHub records **PR Gate, Unit tests, Static checks, Coverage macOS, macOS build and E2E, Windows E2E, CodeQL, and AI review workflow success**.

No local Electron/Web/CLI/IPC or E2E lane was selected because those contracts and transports were unchanged.

## Review focus

- Translation-only adapter boundary.
- Runtime's retained single cleanup/ownership path.
- One clear ARD-15B extension seam without a second resource owner.

## Uncovered risks

- Windows process-tree and live-provider behavior were not reproduced by the local target set; online platform lanes are the retained evidence.
- Candidate ownership and cleanup were intentionally deferred to ARD-15B.

