### PR TITLE
fix(local-rpc): stabilize Windows transport tests

### DIFF
--- a/src/main/acp/codex-completion-handoff.integration.test.ts
+++ b/src/main/acp/codex-completion-handoff.integration.test.ts
@@ -137,6 +137,7 @@ describe('Codex approved handoff', () => {
       localToolHandlers: { 'molecule/preview_molecule': localConnector }
     })
     const notebookRpcServer = new NotebookLocalRpcServer({} as NotebookRuntimeService, {
+      transport: 'tcp',
       connectorService
     })
     onTestFinished(async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3048,6 +3048,7 @@ describe('ACP runtime session management', () => {
       repository: new NotebookRunRepository(root)
     })
     const notebookRpcServer = new NotebookLocalRpcServer(notebookService, {
+      transport: 'tcp',
       token: 'control-token',
       connectorService: { call: connectorCall }
     })
@@ -14505,6 +14506,7 @@ describe('ACP runtime session management', () => {
       repository: new NotebookRunRepository(storageRoot)
     })
     const rpcServer = new NotebookLocalRpcServer(notebookService, {
+      transport: 'tcp',
       artifactProvenance: {
         createVersion: async (request) => {
           rpcWriteStarted.resolve()

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -1,5 +1,5 @@
 import type { SessionNotification } from '@agentclientprotocol/sdk'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { AcpSessionUpdateProjector } from './session-update-projector'
@@ -169,7 +169,7 @@ describe('AcpSessionUpdateProjector', () => {
 
   it('owns Codex Skill activity state for one generation and clears sparse lifecycle correlation', () => {
     const projector = new AcpSessionUpdateProjector()
-    const skillsRoot = join('/data', 'codex-home', 'skills')
+    const skillsRoot = resolve('/data', 'codex-home', 'skills')
     const skillPath = join(skillsRoot, 'mcp-pubmed', 'SKILL.md')
     projector.beginGeneration(skillsRoot)
     const routing = {

--- a/src/main/agents/completion-gate.integration.test.ts
+++ b/src/main/agents/completion-gate.integration.test.ts
@@ -902,6 +902,7 @@ describe('completion gate tracer bullet', () => {
   it('uses the real repl host.agents.switch SDK route before the completion gate intercepts its outer result', async () => {
     const harness = createHarness({ status: 'approved' })
     const server = new NotebookLocalRpcServer({} as NotebookRuntimeService, {
+      transport: 'tcp',
       token: 'completion-gate-token',
       agentsService: harness.agents
     })
@@ -1009,6 +1010,7 @@ describe('completion gate tracer bullet', () => {
       switchNotifier: createCompletionGateSwitchNotifier(coordinator)
     })
     const server = new NotebookLocalRpcServer({} as NotebookRuntimeService, {
+      transport: 'tcp',
       token: 'opencode-handoff-token',
       agentsService: agents
     })

--- a/src/main/notebook/local-rpc-server.agents.test.ts
+++ b/src/main/notebook/local-rpc-server.agents.test.ts
@@ -42,6 +42,7 @@ describe('notebook RPC agentsCall route', () => {
   it('rejects agentsCall through the server master token even with forged trusted identity fields', async () => {
     const read = vi.fn(async () => [])
     const server = new NotebookLocalRpcServer(await makeService(), {
+      transport: 'tcp',
       token: 'tok',
       agentsService: { read }
     })
@@ -74,6 +75,7 @@ describe('notebook RPC agentsCall route', () => {
   it('forwards the op to the AgentsService and returns its result', async () => {
     const read = vi.fn(async () => [{ id: 'sp-1', name: 'Bio', revision: 1 }])
     const server = new NotebookLocalRpcServer(await makeService(), {
+      transport: 'tcp',
       token: 'tok',
       agentsService: { read }
     })
@@ -102,6 +104,7 @@ describe('notebook RPC agentsCall route', () => {
 
   it('rejects calls without the bearer token', async () => {
     const server = new NotebookLocalRpcServer(await makeService(), {
+      transport: 'tcp',
       token: 'tok',
       agentsService: { read: vi.fn() }
     })
@@ -121,6 +124,7 @@ describe('notebook RPC agentsCall route', () => {
   it('rejects a privileged switch when the session capability has no active control invocation', async () => {
     const read = vi.fn(async () => ({ status: 'approved' }))
     const server = new NotebookLocalRpcServer(await makeService(), {
+      transport: 'tcp',
       agentsService: { read }
     })
     const connection = await server.issueControlConnection('trusted-session', 'default-project')
@@ -156,6 +160,7 @@ describe('notebook RPC agentsCall route', () => {
   it('forwards snake_case params and the trusted session_id as context', async () => {
     const read = vi.fn(async () => null)
     const server = new NotebookLocalRpcServer(await makeService(), {
+      transport: 'tcp',
       token: 'tok',
       agentsService: { read }
     })
@@ -189,6 +194,7 @@ describe('notebook RPC agentsCall route', () => {
       throw new Error('host.agents.get: not found')
     })
     const server = new NotebookLocalRpcServer(await makeService(), {
+      transport: 'tcp',
       token: 'tok',
       agentsService: { read }
     })
@@ -214,6 +220,7 @@ describe('notebook RPC agentsCall route', () => {
   it('strips sandbox-supplied switch/reconfigure/identity fields so they cannot be forged', async () => {
     const read = vi.fn(async () => null)
     const server = new NotebookLocalRpcServer(await makeService(), {
+      transport: 'tcp',
       token: 'tok',
       agentsService: { read }
     })
@@ -259,6 +266,7 @@ describe('notebook RPC agentsCall route', () => {
     const dispatch = vi.fn(async () => ['via-dispatch'])
     const read = vi.fn(async () => ['via-read'])
     const server = new NotebookLocalRpcServer(await makeService(), {
+      transport: 'tcp',
       token: 'tok',
       agentsService: { read, dispatch }
     })

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -20,6 +20,7 @@ afterEach(async () => {
 describe('mcpCall RPC', () => {
   it('rejects privileged calls made with the server-wide bootstrap token', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       connectorService: fakeConnector as never
     })
     const { endpoint, token } = await server.ensureStarted()
@@ -40,6 +41,7 @@ describe('mcpCall RPC', () => {
 
   it('issues a scoped control connection without invalidating the Agent session connection', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       connectorService: fakeConnector as never
     })
     const agentConnection = await sessionConnection(server)
@@ -78,6 +80,7 @@ describe('mcpCall RPC', () => {
 
   it('routes mcpCall to the connector service', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       connectorService: fakeConnector as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -108,6 +111,7 @@ describe('mcpCall RPC', () => {
       }
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       connectorService: capturing as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -158,6 +162,7 @@ describe('mcpCall RPC', () => {
       }
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       connectorService: capturing
     })
     server.registerSessionSpecialist('real-session', 'specialist-1')
@@ -203,6 +208,7 @@ describe('computeCall RPC', () => {
       })
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -240,6 +246,7 @@ describe('computeCall RPC', () => {
 
   it('returns 401 without Bearer token', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: {} as never
     })
     const { endpoint } = await sessionConnection(server)
@@ -252,7 +259,9 @@ describe('computeCall RPC', () => {
   })
 
   it('returns 500 when compute service is not configured', async () => {
-    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never)
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp'
+    })
     const { endpoint, token } = await sessionConnection(server)
     const res = await fetch(endpoint, {
       method: 'POST',
@@ -277,6 +286,7 @@ describe('computeCall RPC', () => {
       }
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -297,6 +307,7 @@ describe('computeCall RPC', () => {
   it('returns 500 for unknown op', async () => {
     const fakeCompute = { callCommand: async () => ({}) }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -330,6 +341,7 @@ describe('computeCall RPC', () => {
       })
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -371,6 +383,7 @@ describe('computeCall RPC', () => {
       }
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -399,6 +412,7 @@ describe('computeCall RPC', () => {
       replaceDetails: async () => {}
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -424,6 +438,7 @@ describe('computeCall RPC', () => {
       replaceDetails: async () => {}
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -453,6 +468,7 @@ describe('computeCall RPC', () => {
       replaceDetails: async () => {}
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -484,6 +500,7 @@ describe('computeCall RPC', () => {
       }
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -519,6 +536,7 @@ describe('computeCall RPC', () => {
       replaceDetails: async () => {}
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -560,6 +578,7 @@ describe('computeCall RPC', () => {
       getEnabledComputeHosts: () => []
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)
@@ -593,6 +612,7 @@ describe('computeCall RPC', () => {
       getEnabledComputeHosts: () => []
     }
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       computeService: fakeCompute as never
     })
     const { endpoint, token } = await sessionConnection(server)

--- a/src/main/notebook/local-rpc-server.skill-import.test.ts
+++ b/src/main/notebook/local-rpc-server.skill-import.test.ts
@@ -16,6 +16,7 @@ describe('NotebookLocalRpcServer Skill import bridge', () => {
       skills: [{ id: 'imported-demo', name: 'Demo', status: 'imported' }]
     })
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       token: 'secret-token',
       skillImporter: { request }
     })
@@ -55,6 +56,7 @@ describe('NotebookLocalRpcServer Skill import bridge', () => {
   it('routes a GitHub Skill import through the active conversation', async () => {
     const request = vi.fn().mockResolvedValue({ status: 'cancelled', skills: [] })
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       token: 'secret-token',
       skillImporter: { request }
     })
@@ -100,6 +102,7 @@ describe('NotebookLocalRpcServer Skill import bridge', () => {
   it('rejects shared and out-of-scope RPC capabilities', async () => {
     const request = vi.fn().mockResolvedValue({ status: 'cancelled', skills: [] })
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
       token: 'secret-token',
       skillImporter: { request }
     })

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -133,7 +133,10 @@ describe('notebook local RPC server', () => {
         shutdown: async () => ({ reaped: true })
       })
     })
-    const server = new NotebookLocalRpcServer(service, { token: 'secret-token' })
+    const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
+      token: 'secret-token'
+    })
     const connection = await server.ensureStarted()
 
     try {
@@ -211,7 +214,10 @@ describe('notebook local RPC server', () => {
         refreshAfterPackageMutation: vi.fn()
       }
     })
-    const server = new NotebookLocalRpcServer(service, { token: 'secret-token' })
+    const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
+      token: 'secret-token'
+    })
     const connection = await server.ensureStarted()
 
     try {
@@ -265,7 +271,10 @@ describe('notebook local RPC server', () => {
         shutdown: async () => ({ reaped: true })
       })
     })
-    const server = new NotebookLocalRpcServer(service, { token: 'secret-token' })
+    const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
+      token: 'secret-token'
+    })
     const connection = await server.ensureStarted()
 
     server.registerSessionAlias('notebook-session-1', 'real-session-1')
@@ -308,6 +317,7 @@ describe('notebook local RPC server', () => {
       repository: new NotebookRunRepository(root)
     })
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       onSessionReleased,
       connectorService: { call: connectorCall }
@@ -357,6 +367,7 @@ describe('notebook local RPC server', () => {
       repository: new NotebookRunRepository(root)
     })
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       connectorService: { call: connectorCall }
     })
@@ -399,6 +410,7 @@ describe('notebook local RPC server', () => {
       repository: new NotebookRunRepository(root)
     })
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       agentsService: { read: agentsRead },
       inputRegistry: {
@@ -502,7 +514,7 @@ describe('notebook local RPC server', () => {
           throw new NotebookControlCompletionCapturedError()
         }
       } as unknown as NotebookRuntimeService,
-      { token: 'secret-token' }
+      { transport: 'tcp', token: 'secret-token' }
     )
     const connection = await server.ensureStarted()
 
@@ -535,6 +547,7 @@ describe('notebook local RPC server', () => {
       repository: new NotebookRunRepository(root)
     })
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       connectorService: { call: connectorCall }
     })
@@ -574,6 +587,7 @@ describe('notebook local RPC server', () => {
     })
     const requests: unknown[] = []
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       artifactProvenance: {
         createVersion: async (request) => {
@@ -661,6 +675,7 @@ describe('notebook local RPC server', () => {
     const releaseCreate = createDeferred()
     let now = 1_000
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       now: () => now,
       artifactProvenance: {
@@ -751,6 +766,7 @@ describe('notebook local RPC server', () => {
     })
     const createVersion = vi.fn()
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       artifactProvenance: { createVersion }
     })
@@ -797,6 +813,7 @@ describe('notebook local RPC server', () => {
     })
     const createVersion = vi.fn()
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       now: () => now,
       artifactProvenance: { createVersion }
@@ -860,6 +877,7 @@ describe('notebook local RPC server', () => {
     })
     const createVersion = vi.fn().mockResolvedValue({ versionId: 'version-1' })
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       now: () => now,
       artifactProvenance: { createVersion }
@@ -916,6 +934,7 @@ describe('notebook local RPC server', () => {
       promptMessageId: 'message-user-1'
     }
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       artifactProvenance: {
         createVersion: vi.fn(),
@@ -945,6 +964,7 @@ describe('notebook local RPC server', () => {
     }
 
     const unconfigured = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       artifactProvenance: { createVersion: vi.fn() }
     })
@@ -1014,6 +1034,7 @@ describe('notebook local RPC server', () => {
       })
     })
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       inputRegistry: {
         registerTurn: async () => undefined,
@@ -1106,6 +1127,7 @@ describe('notebook local RPC server', () => {
       throw failure
     })
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       inputRegistry: {
         registerTurn: vi.fn().mockResolvedValue(undefined),
@@ -1181,7 +1203,7 @@ describe('notebook local RPC server', () => {
         projectName: 'default-project',
         repository: new NotebookRunRepository(root)
       }),
-      { token: 'secret-token' }
+      { transport: 'tcp', token: 'secret-token' }
     )
     const firstResolve = vi.fn().mockResolvedValue('/managed/groups.csv')
     const secondResolve = vi.fn().mockResolvedValue('/managed/groups.csv')
@@ -1236,7 +1258,10 @@ describe('notebook local RPC server', () => {
         return { ok: true, needsRestart: false, log: 'installed' }
       }
     })
-    const server = new NotebookLocalRpcServer(service, { token: 'secret-token' })
+    const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
+      token: 'secret-token'
+    })
     const connection = await server.ensureStarted()
 
     try {
@@ -1286,7 +1311,10 @@ describe('notebook local RPC server', () => {
         removeEnvironment: () => []
       }
     })
-    const server = new NotebookLocalRpcServer(service, { token: 'secret-token' })
+    const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
+      token: 'secret-token'
+    })
     const connection = await server.ensureStarted()
 
     try {
@@ -1349,6 +1377,7 @@ describe('notebook local RPC server', () => {
       })
     }
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       computeService: fakeComputeService
     })
@@ -1428,6 +1457,7 @@ describe('notebook local RPC server', () => {
       })
     }
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       computeService: fakeComputeService
     })
@@ -1481,6 +1511,7 @@ describe('notebook local RPC server', () => {
       })
     }
     const server = new NotebookLocalRpcServer(service, {
+      transport: 'tcp',
       token: 'secret-token',
       computeService: fakeComputeService
     })

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -256,7 +256,9 @@ export class ReviewerMcpServer {
   async start(): Promise<{ endpoint: string; token: string }> {
     const connection = await listenForLocalRpc(this.httpServer, {
       name: 'reviewer-mcp',
-      transport: this.options.transport
+      transport:
+        this.options.transport ??
+        (this.options.command && this.options.entryPath ? undefined : 'tcp')
     })
     this._endpoint = `${connection.endpoint}/mcp`
     this._socketPath = connection.socketPath


### PR DESCRIPTION
## Problem

The Windows full-test shards in [job 1](https://github.com/aipoch/open-science/actions/runs/30938304352/job/92089928313) and [job 2](https://github.com/aipoch/open-science/actions/runs/30938304352/job/92089928719) failed after app-local RPC switched to Windows named pipes. Transport-agnostic tests used plain `fetch` against `http://localhost`, reaching runner IIS instead of the named pipe; Reviewer tests lacked the stdio proxy entry required for pipe transport. A Skill-path assertion also assumed POSIX root semantics.

## Proposed change

- Pin transport-agnostic local RPC tests to TCP while retaining dedicated named-pipe coverage.
- Let Reviewer MCP use the platform default only when its stdio proxy command and entry path are available; production Windows composition still selects named pipes.
- Resolve the Skill root with platform-aware absolute-path semantics.

## Scope and non-goals

No architecture, data-model, data-relation, or user-interface changes. No new dependencies.

## Acceptance criteria and validation

All checks ran after the last material edit.

- Windows RPC and Reviewer behavior -> targeted 14-file Vitest run -> 14 files and 554 tests passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors; 17 pre-existing warnings remain.
- Portable suite -> `npm test` -> 756 files and 11,199 tests passed; 14 files and 184 tests skipped.
- Independent Standards and Spec review -> 0 findings on both axes.

ACP handoff/runtime and Agent completion consumers were included because they consume the local RPC transport. Windows branch selection was exercised with a temporary platform-fixed regression harness and passed; actual Windows hosted-runner execution remains the CI-owned platform check. The local Darwin host cannot reproduce the Windows named-pipe kernel itself; dedicated pipe tests and Windows CI retain that coverage.

## Review focus

Please focus on the Reviewer transport fallback and the explicit TCP isolation of transport-agnostic tests.