### PR TITLE
refactor(acp): transfer process candidates once

### DIFF
--- a/src/main/acp/agent-connection-adapter.test.ts
+++ b/src/main/acp/agent-connection-adapter.test.ts
@@ -60,7 +60,7 @@ const hooks = (): AcpAgentConnectionHooks => ({
   onProcessSpawned: vi.fn(),
   onBackendPublished: vi.fn(),
   onProcessTreeReaped: vi.fn(),
-  attachProcessDiagnostics: vi.fn(),
+  attachProcessDiagnostics: vi.fn(() => vi.fn()),
   onConnectionClosed: vi.fn(),
   reportCleanupFailure: vi.fn(),
   reportProcessTreeError: vi.fn()

--- a/src/main/acp/agent-connection-adapter.test.ts
+++ b/src/main/acp/agent-connection-adapter.test.ts
@@ -5,14 +5,44 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { AcpAgentConnectionAdapter, type AcpAgentConnectionHooks } from './agent-connection-adapter'
+import { claudeCodeFramework, type ResolvedAgentBackend } from '../agent-framework'
+import {
+  AcpAgentConnectionAdapter,
+  type AcpAgentConnectionCandidate,
+  type AcpAgentConnectionHooks
+} from './agent-connection-adapter'
+import { AcpBackendGenerationOwner } from './backend-generation-owner'
+import {
+  AcpConnectionResourceOwner,
+  type AcpConnectionResourceAttempt
+} from './connection-resource-owner'
+
+const terminateProcessTree = vi.hoisted(() =>
+  vi.fn(async (child?: { kill?: () => void }) => {
+    child?.kill?.()
+    return { reaped: true }
+  })
+)
+vi.mock('../process-tree', () => ({ terminateProcessTree }))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
 
 class FakeAgentProcess extends EventEmitter {
   stdin = new PassThrough()
   stdout = new PassThrough()
   stderr = new PassThrough()
+  killed = false
+  pid = 1234
+
+  kill(): boolean {
+    this.killed = true
+    this.emit('exit', 0, null)
+    return true
+  }
 }
 
 const asAgentProcess = (process: FakeAgentProcess): ChildProcessWithoutNullStreams =>
@@ -25,10 +55,180 @@ const hooks = (): AcpAgentConnectionHooks => ({
   filesystem: {
     resolveSessionCwd: vi.fn(() => '/workspace'),
     protectedReadRoots: vi.fn(() => [])
-  }
+  },
+  onBackendResolved: vi.fn(),
+  onProcessSpawned: vi.fn(),
+  onBackendPublished: vi.fn(),
+  attachProcessDiagnostics: vi.fn(),
+  onConnectionClosed: vi.fn(),
+  reportCleanupFailure: vi.fn(),
+  reportProcessTreeError: vi.fn()
 })
 
+const openConnection = async (
+  process: FakeAgentProcess,
+  connectionHooks: AcpAgentConnectionHooks
+): Promise<{ connection: acp.ClientConnection; close: () => Promise<void> }> => {
+  const owner = new AcpConnectionResourceOwner()
+  const backendOwner = new AcpBackendGenerationOwner(claudeCodeFramework)
+  const ready = await owner.connect(async (attempt) => {
+    const candidate = await new AcpAgentConnectionAdapter().open(
+      {
+        epoch: attempt.epoch,
+        resolveBackend: async () => ({
+          framework: claudeCodeFramework,
+          executablePath: '',
+          env: {}
+        }),
+        prepareBackend: (backend) => backendOwner.prepare(attempt, backend),
+        isCurrent: () => attempt.epoch === owner.epoch,
+        isShuttingDown: () => owner.isShuttingDown,
+        spawnAgent: () => asAgentProcess(process)
+      },
+      connectionHooks
+    )
+    candidate.transferTo(attempt)
+    return attempt.publish({ close: false, delete: false, resume: false })
+  })
+  return { connection: ready.connection, close: () => owner.teardown(owner.epoch) }
+}
+
+const openCandidate = async (
+  process: FakeAgentProcess,
+  backend: ResolvedAgentBackend = {
+    framework: claudeCodeFramework,
+    executablePath: '',
+    env: {}
+  }
+): Promise<AcpAgentConnectionCandidate> => {
+  const backendOwner = new AcpBackendGenerationOwner(claudeCodeFramework)
+  const identity = { epoch: 1, assertCurrent: vi.fn() }
+  return new AcpAgentConnectionAdapter().open(
+    {
+      epoch: identity.epoch,
+      resolveBackend: async () => backend,
+      prepareBackend: (resolved) => backendOwner.prepare(identity, resolved),
+      isCurrent: () => true,
+      isShuttingDown: () => false,
+      spawnAgent: () => asAgentProcess(process)
+    },
+    hooks()
+  )
+}
+
 describe('AcpAgentConnectionAdapter', () => {
+  it('reaps an untransferred process tree and releases its bridge lease exactly once', async () => {
+    const process = new FakeAgentProcess()
+    const release = vi.fn(async () => undefined)
+    const backend: ResolvedAgentBackend = {
+      framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+      executablePath: '/bin/agent',
+      env: {},
+      responsesBridgeLease: {
+        selectSkills: vi.fn(async () => []),
+        registerReviewerSession: vi.fn(),
+        unregisterReviewerSession: vi.fn(() => false),
+        release
+      }
+    }
+    const candidate = await openCandidate(process, backend)
+
+    await candidate.dispose()
+    await candidate.dispose()
+
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
+    expect(terminateProcessTree.mock.calls[0]?.[0]).toBe(process)
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a transfer to a different owner epoch without consuming the candidate', async () => {
+    const process = new FakeAgentProcess()
+    const candidate = await openCandidate(process)
+    const attach = vi.fn()
+    const mismatchedAttempt = {
+      epoch: 2,
+      attach,
+      publish: vi.fn(),
+      assertCurrent: vi.fn(),
+      owns: vi.fn(() => false)
+    } as unknown as AcpConnectionResourceAttempt
+
+    expect(() => candidate.transferTo(mismatchedAttempt)).toThrow(/superseded/i)
+    expect(attach).not.toHaveBeenCalled()
+
+    await candidate.dispose()
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
+  })
+
+  it('transfers once without exposing resources and leaves teardown solely to the owner', async () => {
+    const process = new FakeAgentProcess()
+    const release = vi.fn(async () => undefined)
+    const owner = new AcpConnectionResourceOwner()
+    let candidateDispose: (() => Promise<void>) | undefined
+    await owner.connect(async (attempt) => {
+      const candidate = await openCandidate(process, {
+        framework: claudeCodeFramework,
+        executablePath: '',
+        env: {},
+        responsesBridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => false),
+          release
+        }
+      })
+      candidateDispose = candidate.dispose
+      const transferred = candidate.transferTo(attempt)
+
+      expect(Object.keys(candidate).sort()).toEqual(['dispose', 'transferTo'])
+      expect(Object.keys(transferred).sort()).toEqual([
+        'authenticate',
+        'backendAttempt',
+        'initialize',
+        'setProvider'
+      ])
+      expect(candidate).not.toHaveProperty('process')
+      expect(candidate).not.toHaveProperty('connection')
+      expect(candidate).not.toHaveProperty('bridgeLease')
+      expect(transferred).not.toHaveProperty('process')
+      expect(transferred).not.toHaveProperty('connection')
+      expect(transferred).not.toHaveProperty('bridgeLease')
+      expect(() => candidate.transferTo(attempt)).toThrow(/already transferred/i)
+      await candidate.dispose()
+
+      expect(terminateProcessTree).not.toHaveBeenCalled()
+      expect(release).not.toHaveBeenCalled()
+      return attempt.publish({ close: false, delete: false, resume: false })
+    })
+
+    await candidateDispose?.()
+    expect(terminateProcessTree).not.toHaveBeenCalled()
+    expect(release).not.toHaveBeenCalled()
+
+    await owner.teardown(owner.epoch)
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('retains cleanup ownership when the resource owner rejects transfer', async () => {
+    const process = new FakeAgentProcess()
+    const candidate = await openCandidate(process)
+    const rejectedAttempt = {
+      epoch: 1,
+      attach: vi.fn(() => {
+        throw new Error('owner rejected transfer')
+      }),
+      publish: vi.fn(),
+      assertCurrent: vi.fn(),
+      owns: vi.fn(() => false)
+    } as unknown as AcpConnectionResourceAttempt
+
+    expect(() => candidate.transferTo(rejectedAttempt)).toThrow('owner rejected transfer')
+    await candidate.dispose()
+
+    expect(terminateProcessTree).toHaveBeenCalledOnce()
+  })
+
   it('opens an ACP client connection over the child process streams', async () => {
     const process = new FakeAgentProcess()
     acp
@@ -45,10 +245,7 @@ describe('AcpAgentConnectionAdapter', () => {
         )
       )
 
-    const connection = new AcpAgentConnectionAdapter().open(
-      { process: asAgentProcess(process) },
-      hooks()
-    )
+    const { connection, close } = await openConnection(process, hooks())
 
     await expect(
       connection.agent.request(acp.methods.agent.initialize, {
@@ -58,7 +255,7 @@ describe('AcpAgentConnectionAdapter', () => {
       })
     ).resolves.toMatchObject({ protocolVersion: acp.PROTOCOL_VERSION })
 
-    connection.close()
+    await close()
   })
 
   it('translates permission requests and returns the hook response', async () => {
@@ -85,17 +282,14 @@ describe('AcpAgentConnectionAdapter', () => {
     vi.mocked(connectionHooks.requestPermission).mockResolvedValue({
       outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
-    const connection = new AcpAgentConnectionAdapter().open(
-      { process: asAgentProcess(process) },
-      connectionHooks
-    )
+    const { close } = await openConnection(process, connectionHooks)
 
     await expect(
       agentConnection.client.request(acp.methods.client.session.requestPermission, request)
     ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow-once' } })
     expect(connectionHooks.requestPermission).toHaveBeenCalledWith(request)
 
-    connection.close()
+    await close()
     agentConnection.close()
   })
 
@@ -113,10 +307,7 @@ describe('AcpAgentConnectionAdapter', () => {
     vi.mocked(connectionHooks.requestPermission).mockRejectedValue(
       new Error('permission hook failed')
     )
-    const connection = new AcpAgentConnectionAdapter().open(
-      { process: asAgentProcess(process) },
-      connectionHooks
-    )
+    const { close } = await openConnection(process, connectionHooks)
 
     await expect(
       agentConnection.client.request(acp.methods.client.session.requestPermission, {
@@ -134,7 +325,7 @@ describe('AcpAgentConnectionAdapter', () => {
       data: { details: 'permission hook failed' }
     })
 
-    connection.close()
+    await close()
     agentConnection.close()
   })
 
@@ -157,10 +348,7 @@ describe('AcpAgentConnectionAdapter', () => {
       actions.push('permission')
       return { outcome: { outcome: 'cancelled' } }
     })
-    const connection = new AcpAgentConnectionAdapter().open(
-      { process: asAgentProcess(process) },
-      connectionHooks
-    )
+    const { close } = await openConnection(process, connectionHooks)
 
     const notification = {
       sessionId: 'provider-session',
@@ -181,7 +369,7 @@ describe('AcpAgentConnectionAdapter', () => {
     expect(connectionHooks.observeSessionUpdate).toHaveBeenCalledWith(notification)
     expect(actions).toEqual(['update', 'permission'])
 
-    connection.close()
+    await close()
     agentConnection.close()
   })
 
@@ -196,10 +384,7 @@ describe('AcpAgentConnectionAdapter', () => {
         )
       )
     const connectionHooks = hooks()
-    const connection = new AcpAgentConnectionAdapter().open(
-      { process: asAgentProcess(process) },
-      connectionHooks
-    )
+    const { close } = await openConnection(process, connectionHooks)
     const notification = {
       sessionId: 'provider-session',
       message: { type: 'result', num_turns: 2, origin: { kind: 'human' } }
@@ -211,7 +396,7 @@ describe('AcpAgentConnectionAdapter', () => {
       expect(connectionHooks.observeClaudeSdkMessage).toHaveBeenCalledWith(notification)
     )
 
-    connection.close()
+    await close()
     agentConnection.close()
   })
 
@@ -230,10 +415,7 @@ describe('AcpAgentConnectionAdapter', () => {
       )
     const connectionHooks = hooks()
     vi.mocked(connectionHooks.filesystem.resolveSessionCwd).mockReturnValue(workspace)
-    const connection = new AcpAgentConnectionAdapter().open(
-      { process: asAgentProcess(process) },
-      connectionHooks
-    )
+    const { close } = await openConnection(process, connectionHooks)
 
     await expect(
       agentConnection.client.request(acp.methods.client.fs.readTextFile, {
@@ -246,7 +428,7 @@ describe('AcpAgentConnectionAdapter', () => {
     expect(connectionHooks.filesystem.resolveSessionCwd).toHaveBeenCalledWith('provider-session')
     expect(connectionHooks.filesystem.protectedReadRoots).toHaveBeenCalledOnce()
 
-    connection.close()
+    await close()
     agentConnection.close()
     await rm(workspace, { recursive: true, force: true })
   })
@@ -269,10 +451,7 @@ describe('AcpAgentConnectionAdapter', () => {
     const connectionHooks = hooks()
     vi.mocked(connectionHooks.filesystem.resolveSessionCwd).mockReturnValue(workspace)
     vi.mocked(connectionHooks.filesystem.protectedReadRoots).mockReturnValue([protectedRoot])
-    const connection = new AcpAgentConnectionAdapter().open(
-      { process: asAgentProcess(process) },
-      connectionHooks
-    )
+    const { close } = await openConnection(process, connectionHooks)
 
     await expect(
       agentConnection.client.request(acp.methods.client.fs.readTextFile, {
@@ -286,7 +465,7 @@ describe('AcpAgentConnectionAdapter', () => {
       }
     })
 
-    connection.close()
+    await close()
     agentConnection.close()
     await rm(workspace, { recursive: true, force: true })
   })
@@ -305,10 +484,7 @@ describe('AcpAgentConnectionAdapter', () => {
       )
     const connectionHooks = hooks()
     vi.mocked(connectionHooks.filesystem.resolveSessionCwd).mockReturnValue(workspace)
-    const connection = new AcpAgentConnectionAdapter().open(
-      { process: asAgentProcess(process) },
-      connectionHooks
-    )
+    const { close } = await openConnection(process, connectionHooks)
 
     await expect(
       agentConnection.client.request(acp.methods.client.fs.writeTextFile, {
@@ -320,7 +496,7 @@ describe('AcpAgentConnectionAdapter', () => {
     await expect(readFile(filePath, 'utf8')).resolves.toBe('written through ACP')
     expect(connectionHooks.filesystem.resolveSessionCwd).toHaveBeenCalledWith('provider-session')
 
-    connection.close()
+    await close()
     agentConnection.close()
     await rm(workspace, { recursive: true, force: true })
   })

--- a/src/main/acp/agent-connection-adapter.test.ts
+++ b/src/main/acp/agent-connection-adapter.test.ts
@@ -59,6 +59,7 @@ const hooks = (): AcpAgentConnectionHooks => ({
   onBackendResolved: vi.fn(),
   onProcessSpawned: vi.fn(),
   onBackendPublished: vi.fn(),
+  onProcessTreeReaped: vi.fn(),
   attachProcessDiagnostics: vi.fn(),
   onConnectionClosed: vi.fn(),
   reportCleanupFailure: vi.fn(),

--- a/src/main/acp/agent-connection-adapter.ts
+++ b/src/main/acp/agent-connection-adapter.ts
@@ -37,6 +37,7 @@ type AcpAgentConnectionHooks = Readonly<{
   onBackendResolved: (framework: AgentFramework['id']) => void
   onProcessSpawned: (framework: AgentFramework['id']) => void
   onBackendPublished: (backend: AcpBackendGenerationView) => void
+  onProcessTreeReaped: (reaped: boolean) => void
   attachProcessDiagnostics: (
     process: ChildProcessWithoutNullStreams,
     framework: AgentFramework['id'],
@@ -102,9 +103,10 @@ class AcpAgentConnectionAdapter {
       }
       if (process) {
         try {
-          await terminateProcessTree(process, undefined, {
+          const result = await terminateProcessTree(process, undefined, {
             error: (message, error) => hooks.reportProcessTreeError(message, error)
           })
+          hooks.onProcessTreeReaped(result.reaped)
         } catch (error) {
           reportCleanupFailure('agent-process', error)
         }

--- a/src/main/acp/agent-connection-adapter.ts
+++ b/src/main/acp/agent-connection-adapter.ts
@@ -1,14 +1,28 @@
 import * as acp from '@agentclientprotocol/sdk'
 import type {
+  AuthenticateRequest,
   ClientConnection,
+  InitializeRequest,
+  InitializeResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
+  SetProviderRequest,
   SessionNotification
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { Readable, Writable } from 'node:stream'
 
+import type { AgentFramework, ResolvedAgentBackend } from '../agent-framework'
+import { terminateProcessTree } from '../process-tree'
+import type {
+  AcpBackendGenerationAttempt,
+  AcpBackendGenerationView
+} from './backend-generation-owner'
+import type { AcpConnectionResourceAttempt } from './connection-resource-owner'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
+
+type ResponsesBridgeLease = ResolvedAgentBackend['responsesBridgeLease']
+type CandidateCleanupStage = 'connection' | 'agent-process' | 'bridge-lease'
 
 type AcpAgentConnectionHooks = Readonly<{
   requestPermission: (
@@ -20,19 +34,174 @@ type AcpAgentConnectionHooks = Readonly<{
     resolveSessionCwd: (sessionId: string) => string
     protectedReadRoots: () => readonly string[]
   }>
+  onBackendResolved: (framework: AgentFramework['id']) => void
+  onProcessSpawned: (framework: AgentFramework['id']) => void
+  onBackendPublished: (backend: AcpBackendGenerationView) => void
+  attachProcessDiagnostics: (
+    process: ChildProcessWithoutNullStreams,
+    framework: AgentFramework['id'],
+    epoch: number
+  ) => void
+  onConnectionClosed: () => void
+  reportCleanupFailure: (
+    stage: CandidateCleanupStage,
+    error: unknown,
+    framework: AgentFramework['id'],
+    epoch: number
+  ) => void
+  reportProcessTreeError: (message: string, error?: unknown) => void
 }>
 
-type AcpAgentConnectionInput = Readonly<{
-  process: ChildProcessWithoutNullStreams
+type AcpAgentConnectionCandidateInput = Readonly<{
+  epoch: number
+  resolveBackend: () => Promise<ResolvedAgentBackend>
+  prepareBackend: (backend: ResolvedAgentBackend) => AcpBackendGenerationAttempt
+  isCurrent: () => boolean
+  isShuttingDown: () => boolean
+  spawnAgent?: () => ChildProcessWithoutNullStreams
 }>
 
-// Translates one spawned agent's stdio and client-side protocol callbacks into an ACP connection.
-// Process, connection, bridge-lease, and transition ownership remain with the Runtime/resource owner.
+type AcpTransferredAgentConnection = Readonly<{
+  backendAttempt: AcpBackendGenerationAttempt
+  initialize: (request: InitializeRequest) => Promise<InitializeResponse>
+  authenticate: (request: AuthenticateRequest) => Promise<void>
+  setProvider: (request: SetProviderRequest) => Promise<void>
+}>
+
+type AcpAgentConnectionCandidate = Readonly<{
+  transferTo: (attempt: AcpConnectionResourceAttempt) => AcpTransferredAgentConnection
+  dispose: () => Promise<void>
+}>
+
+// Owns one spawned provider process, ACP client/stream, and bridge lease until their single transfer
+// to the existing resource owner. Runtime supplies policy/projection hooks but never receives those
+// provisional physical resources.
 class AcpAgentConnectionAdapter {
-  open(input: AcpAgentConnectionInput, hooks: AcpAgentConnectionHooks): ClientConnection {
+  async open(
+    input: AcpAgentConnectionCandidateInput,
+    hooks: AcpAgentConnectionHooks
+  ): Promise<AcpAgentConnectionCandidate> {
+    let process: ChildProcessWithoutNullStreams | undefined
+    let connection: ReturnType<AcpAgentConnectionAdapter['createClientConnection']> | undefined
+    let bridgeLease: ResponsesBridgeLease
+    let backendAttempt: AcpBackendGenerationAttempt | undefined
+    let framework: AgentFramework['id'] = 'claude-code'
+
+    const reportCleanupFailure = (stage: CandidateCleanupStage, error: unknown): void => {
+      try {
+        hooks.reportCleanupFailure(stage, error, framework, input.epoch)
+      } catch {
+        // Cleanup and the original failure take precedence over diagnostic sinks.
+      }
+    }
+    const cleanup = async (): Promise<void> => {
+      try {
+        connection?.close()
+      } catch (error) {
+        reportCleanupFailure('connection', error)
+      }
+      if (process) {
+        try {
+          await terminateProcessTree(process, undefined, {
+            error: (message, error) => hooks.reportProcessTreeError(message, error)
+          })
+        } catch (error) {
+          reportCleanupFailure('agent-process', error)
+        }
+      }
+      if (bridgeLease) {
+        try {
+          await bridgeLease.release()
+        } catch (error) {
+          reportCleanupFailure('bridge-lease', error)
+        }
+      }
+    }
+
+    try {
+      const backend = await input.resolveBackend()
+      framework = backend.framework.id
+      bridgeLease = backend.responsesBridgeLease
+      backendAttempt = input.prepareBackend(backend)
+      hooks.onBackendResolved(framework)
+      process = input.spawnAgent
+        ? input.spawnAgent()
+        : backend.framework.spawn({
+            executablePath: backend.executablePath,
+            env: backend.env,
+            args: backend.args ?? [],
+            proxyEnvironmentMode: backend.proxyEnvironmentMode
+          })
+      hooks.onProcessSpawned(framework)
+      if (input.isShuttingDown() || !input.isCurrent()) {
+        throw new Error(
+          input.isShuttingDown()
+            ? 'ACP runtime is shutting down.'
+            : 'ACP connection superseded during spawn.'
+        )
+      }
+      hooks.onBackendPublished(backendAttempt.publish())
+      hooks.attachProcessDiagnostics(process, framework, input.epoch)
+      connection = this.createClientConnection(process, hooks)
+    } catch (error) {
+      backendAttempt?.fail()
+      await cleanup()
+      throw error
+    }
+
+    const openedProcess = process
+    const openedConnection = connection
+    const openedAttempt = backendAttempt
+    if (!openedProcess || !openedConnection || !openedAttempt) {
+      throw new Error('ACP agent connection candidate did not open.')
+    }
+    let state: 'open' | 'transferred' | 'disposed' = 'open'
+
+    return Object.freeze({
+      transferTo: (attempt) => {
+        if (state === 'disposed') throw new Error('ACP agent connection candidate is disposed.')
+        if (state === 'transferred') {
+          throw new Error('ACP agent connection candidate was already transferred.')
+        }
+        if (attempt.epoch !== input.epoch) throw new Error('ACP connection was superseded.')
+        attempt.attach({
+          process: openedProcess,
+          connection: openedConnection,
+          framework,
+          bridgeLease
+        })
+        state = 'transferred'
+        openedConnection.closed.then(() => {
+          if (attempt.owns(openedConnection)) hooks.onConnectionClosed()
+        })
+        return Object.freeze({
+          backendAttempt: openedAttempt,
+          initialize: (request) =>
+            openedConnection.agent.request(acp.methods.agent.initialize, request),
+          authenticate: async (request) => {
+            await openedConnection.agent.request(acp.methods.agent.authenticate, request)
+          },
+          setProvider: async (request) => {
+            await openedConnection.agent.request(acp.methods.agent.providers.set, request)
+          }
+        })
+      },
+      dispose: async () => {
+        if (state !== 'open') return
+        state = 'disposed'
+        openedAttempt.fail()
+        await cleanup()
+      }
+    })
+  }
+
+  private createClientConnection(
+    process: ChildProcessWithoutNullStreams,
+    hooks: AcpAgentConnectionHooks
+  ): ClientConnection {
     const stream = acp.ndJsonStream(
-      Writable.toWeb(input.process.stdin) as WritableStream<Uint8Array>,
-      Readable.toWeb(input.process.stdout) as ReadableStream<Uint8Array>
+      Writable.toWeb(process.stdin) as WritableStream<Uint8Array>,
+      Readable.toWeb(process.stdout) as ReadableStream<Uint8Array>
     )
 
     return acp
@@ -66,4 +235,4 @@ class AcpAgentConnectionAdapter {
 }
 
 export { AcpAgentConnectionAdapter }
-export type { AcpAgentConnectionHooks, AcpAgentConnectionInput }
+export type { AcpAgentConnectionCandidate, AcpAgentConnectionHooks }

--- a/src/main/acp/agent-connection-adapter.ts
+++ b/src/main/acp/agent-connection-adapter.ts
@@ -42,7 +42,7 @@ type AcpAgentConnectionHooks = Readonly<{
     process: ChildProcessWithoutNullStreams,
     framework: AgentFramework['id'],
     epoch: number
-  ) => void
+  ) => () => void
   onConnectionClosed: () => void
   reportCleanupFailure: (
     stage: CandidateCleanupStage,
@@ -86,6 +86,7 @@ class AcpAgentConnectionAdapter {
     let connection: ReturnType<AcpAgentConnectionAdapter['createClientConnection']> | undefined
     let bridgeLease: ResponsesBridgeLease
     let backendAttempt: AcpBackendGenerationAttempt | undefined
+    let expectProcessExit: (() => void) | undefined
     let framework: AgentFramework['id'] = 'claude-code'
 
     const reportCleanupFailure = (stage: CandidateCleanupStage, error: unknown): void => {
@@ -102,6 +103,7 @@ class AcpAgentConnectionAdapter {
         reportCleanupFailure('connection', error)
       }
       if (process) {
+        expectProcessExit?.()
         try {
           const result = await terminateProcessTree(process, undefined, {
             error: (message, error) => hooks.reportProcessTreeError(message, error)
@@ -143,7 +145,7 @@ class AcpAgentConnectionAdapter {
         )
       }
       hooks.onBackendPublished(backendAttempt.publish())
-      hooks.attachProcessDiagnostics(process, framework, input.epoch)
+      expectProcessExit = hooks.attachProcessDiagnostics(process, framework, input.epoch)
       connection = this.createClientConnection(process, hooks)
     } catch (error) {
       backendAttempt?.fail()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -5544,6 +5544,7 @@ describe('ACP runtime session management', () => {
   })
 
   it('releases a spawned resource superseded immediately before owner attach', async () => {
+    infoLogSpy.mockClear()
     const process = new FakeAgentProcess()
     startFakeAgent(process, [])
     const { lease, release } = createBackendLeaseHarness()
@@ -5572,6 +5573,9 @@ describe('ACP runtime session management', () => {
     expect(process.killed).toBe(true)
     expect(release).toHaveBeenCalledOnce()
     expect(runtime.getSnapshot().sessionIds).toEqual([])
+    expect(
+      infoLogSpy.mock.calls.find(([message]) => message === 'agent process exit')?.[1]
+    ).toMatchObject({ expected: true })
   })
 
   it('drops the process candidate immediately after transfer to the resource owner', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2223,6 +2223,10 @@ describe('ACP runtime session management', () => {
 
   it('shutdownForUpdateGate reaps a mid-spawn child, then stays non-latching so the app can reconnect', async () => {
     const midSpawn = new FakeAgentProcess()
+    vi.mocked(terminateProcessTree).mockImplementationOnce(async (child) => {
+      child?.kill()
+      return { reaped: false }
+    })
     let gatePromise: Promise<{ reaped: boolean }> | undefined
     let spawnCount = 0
     const reconnectSpawns: FakeAgentProcess[] = []
@@ -2252,7 +2256,7 @@ describe('ACP runtime session management', () => {
     await expect(runtime.createSession({ cwd: '/workspace' })).rejects.toThrow(/superseded/)
     expect(gatePromise).toBeDefined()
     const outcome = await gatePromise
-    expect(outcome).toHaveProperty('reaped')
+    expect(outcome).toEqual({ reaped: false })
     // The mid-spawn child was reaped, not left orphaned holding the install dir open.
     expect(midSpawn.killed).toBe(true)
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2232,7 +2232,7 @@ describe('ACP runtime session management', () => {
       spawnAgent: () => {
         spawnCount += 1
         if (spawnCount === 1) {
-          // Model the update gate landing while a connect is inside spawnAgentProcess: start the gate
+          // Model the update gate landing while a connect is inside provider spawn: start the gate
           // teardown, then hand back the freshly-spawned child. The gate must latch shutting-down for
           // its duration so connectFresh's check reaps this child; otherwise it is assigned after the
           // generation bump and outlives a clean-reported gate, holding the very files the NSIS
@@ -2262,7 +2262,7 @@ describe('ACP runtime session management', () => {
   })
 
   it('shutdownForUpdateGate never latches shutting-down, so an abandoned (hung) teardown still reconnects', async () => {
-    // Models the P2 timeout shape: the gate's in-flight connect hangs inside spawnAgentProcess, so the
+    // Models the P2 timeout shape: the gate's in-flight connect hangs inside provider spawn, so the
     // gate's own await never settles and runBounded abandons it once the budget elapses. Because the gate
     // must NOT set a shutting-down latch (it would never clear on an abandoned teardown), a fresh connect
     // afterward has to succeed instead of self-aborting forever.
@@ -5556,10 +5556,10 @@ describe('ACP runtime session management', () => {
     const internal = runtime as unknown as { connectionAdapter: AcpAgentConnectionAdapter }
     const openConnection = internal.connectionAdapter.open.bind(internal.connectionAdapter)
     let disconnect: Promise<unknown> | undefined
-    vi.spyOn(internal.connectionAdapter, 'open').mockImplementation((input, hooks) => {
-      const connection = openConnection(input, hooks)
+    vi.spyOn(internal.connectionAdapter, 'open').mockImplementation(async (input, hooks) => {
+      const candidate = await openConnection(input, hooks)
       disconnect = runtime.disconnect()
-      return connection
+      return candidate
     })
 
     await expect(runtime.connect({ cwd: '/workspace' })).rejects.toThrow(/superseded/i)
@@ -5568,6 +5568,32 @@ describe('ACP runtime session management', () => {
     expect(process.killed).toBe(true)
     expect(release).toHaveBeenCalledOnce()
     expect(runtime.getSnapshot().sessionIds).toEqual([])
+  })
+
+  it('drops the process candidate immediately after transfer to the resource owner', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, [])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const internal = runtime as unknown as { connectionAdapter: AcpAgentConnectionAdapter }
+    const openCandidate = internal.connectionAdapter.open.bind(internal.connectionAdapter)
+    const candidateDispose = vi.fn(async () => undefined)
+    vi.spyOn(internal.connectionAdapter, 'open').mockImplementation(async (input, hooks) => {
+      const candidate = await openCandidate(input, hooks)
+      return Object.freeze({
+        transferTo: candidate.transferTo,
+        dispose: candidateDispose
+      })
+    })
+
+    await runtime.connect({ cwd: '/workspace' })
+    await runtime.disconnect()
+
+    expect(candidateDispose).not.toHaveBeenCalled()
+    expect(process.killed).toBe(true)
   })
 
   it('invalidates an in-flight connection when disconnect is requested before initialization finishes', async () => {
@@ -16337,7 +16363,7 @@ describe('ACP runtime — connect failure logging', () => {
     errorLogSpy.mockClear()
     const { lease, release } = createBackendLeaseHarness()
     // The runtime defaults to claude-code; this reconnect resolves a *different* backend whose real
-    // framework.spawn() throws. spawnAgentProcess sets this.framework to opencode before spawning, so
+    // framework.spawn() throws after resolving opencode, so
     // the failure must be attributed to opencode — the backend actually launched — via the spawn tag,
     // exercising the real resolveBackend + framework switch + framework.spawn() path (no injected spawn).
     const runtime = new AcpRuntime({

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -120,13 +120,16 @@ import {
   type AcpConnectionResourceAttempt,
   type AcpConnectionResourceReadyHandle
 } from './connection-resource-owner'
-import { AcpAgentConnectionAdapter } from './agent-connection-adapter'
+import {
+  AcpAgentConnectionAdapter,
+  type AcpAgentConnectionCandidate,
+  type AcpAgentConnectionHooks
+} from './agent-connection-adapter'
 import { AcpConnectionTransitionOwner } from './connection-transition-owner'
 import { AcpGenerationActivityOwner } from './generation-activity-owner'
 import { AcpHandoffContinuityOwner } from './handoff-continuity-owner'
 import {
   AcpBackendGenerationOwner,
-  type AcpBackendGenerationAttempt,
   type AcpBackendGenerationView
 } from './backend-generation-owner'
 import { AcpSessionConfigurator, type AcpSessionConfigurationFacts } from './session-configurator'
@@ -357,17 +360,6 @@ const acpErrorKind = (error: unknown): string | undefined => {
   } catch {
     return undefined
   }
-}
-
-// Internal wrapper thrown when framework.spawn() fails, carrying the framework the spawn targeted so
-// connectFresh can label the failure with the right backend. It never mutates the original throwable
-// (which may be a frozen/non-extensible Error, a write-rejecting Proxy, or a non-Error value) and holds
-// the original `cause` verbatim so connectFresh can re-throw exactly what was thrown.
-class SpawnFailure {
-  constructor(
-    readonly framework: AgentFramework['id'],
-    readonly cause: unknown
-  ) {}
 }
 
 const log = createLogger('acp')
@@ -908,17 +900,9 @@ class AcpRuntime {
     // Resolve up front rather than reading this.cwd after the pre-connect teardown, which may still be
     // mutating runtime state.
     const cwd = resolve(request.cwd || this.options.defaultCwd)
-    // Captured at function scope so the catch can clean up the spawned child on every failure path —
-    // including "superseded during spawn", before it can be attached to the resource owner.
-    let agentProcess: ChildProcessWithoutNullStreams | undefined
-    let unattachedConnection: ClientConnection | undefined
-    let unattachedBridgeLease: ResolvedAgentBackend['responsesBridgeLease']
-    let backendAttempt: AcpBackendGenerationAttempt | undefined
-    let resourceAttached = false
-    // The framework THIS connect spawned under, bound atomically to the spawn (spawnAgentProcess returns
-    // it alongside the process, and tags a spawn-throw with it) rather than re-read from the mutable
-    // this.framework, which an overlapping reconnect can move before the failure log is written. Seeded
-    // with the current value in case we throw before spawning at all (e.g. a pre-spawn teardown failure).
+    let candidate: AcpAgentConnectionCandidate | undefined
+    let transferred: ReturnType<AcpAgentConnectionCandidate['transferTo']> | undefined
+    // Capture the framework resolved for this attempt so a later reconnect cannot relabel its failure.
     let spawnedFramework = this.framework.id
 
     try {
@@ -933,79 +917,14 @@ class AcpRuntime {
       this.setStatus('connecting')
       log.info('connecting agent', this.diagnosticContext(this.framework.id, generation))
 
-      const spawned = await this.spawnAgentProcess(attempt)
-      agentProcess = spawned.process
-      spawnedFramework = spawned.framework
-      backendAttempt = spawned.backendAttempt
-      unattachedBridgeLease = spawned.bridgeLease
-
-      // spawnAgentProcess resolves the provider config asynchronously, so the connection may have been
-      // torn down or superseded during the spawn: a quit latched shuttingDown, or any teardown/reconnect
-      // bumped the generation past ours (e.g. the pre-update-install gate calls disconnect()). Either way
-      // this freshly-spawned child was never assigned, so the teardown that ran saw no process to reap —
-      // tree-kill it now and abort, or it would outlive that teardown as an orphan holding file handles.
-      // Keying off the generation (not just shuttingDown) lets the NON-LATCHING update gate collect a
-      // late spawn without holding a shuttingDown latch it might never release if it is itself abandoned
-      // on timeout. Awaited (not a bare kill) so a teardown that awaits this in-flight connect does not
-      // resolve before the child's whole tree is reaped on Windows.
-      if (this.connectionResources.isShuttingDown || generation !== this.connectionGeneration) {
-        await this.connectionResources.cleanupUnattached(
-          { process: agentProcess, bridgeLease: unattachedBridgeLease },
-          (stage, error) => {
-            safeLogError(`unattached ACP ${stage} cleanup failed`, {
-              ...diagnosticErrorFields(error),
-              ...this.diagnosticContext(spawnedFramework, generation)
-            })
-          }
-        )
-        agentProcess = undefined
-        unattachedBridgeLease = undefined
-        throw new Error(
-          this.connectionResources.isShuttingDown
-            ? 'ACP runtime is shutting down.'
-            : 'ACP connection superseded during spawn.'
-        )
-      }
-
-      const backend = backendAttempt.publish()
-      this.sessionUpdateProjector.beginGeneration(
-        backend.adapter.codexHome ? join(backend.adapter.codexHome, 'skills') : undefined
-      )
-      this.attachAgentProcessEvents(agentProcess, generation)
-
-      const connection = this.connectionAdapter.open(
-        { process: agentProcess },
-        {
-          requestPermission: (params) => this.handlePermissionRequest(params),
-          observeSessionUpdate: (notification) => this.observePermissionToolContext(notification),
-          observeClaudeSdkMessage: (params) => this.observeClaudeSdkMessage(params),
-          filesystem: {
-            resolveSessionCwd: (sessionId) => this.resolveSessionCwd(sessionId),
-            protectedReadRoots: () => this.protectedReadRoots()
-          }
-        }
-      )
-      unattachedConnection = connection
-      attempt.attach({
-        process: agentProcess,
-        connection,
-        framework: spawned.framework,
-        bridgeLease: spawned.bridgeLease
+      candidate = await this.openAgentConnection(attempt, (framework) => {
+        spawnedFramework = framework
       })
-      resourceAttached = true
-      unattachedConnection = undefined
-      unattachedBridgeLease = undefined
-      connection.closed.then(() => {
-        if (
-          attempt.owns(connection) &&
-          (this.snapshotOwner.status === 'connected' || this.snapshotOwner.status === 'connecting')
-        ) {
-          this.handleConnectionClosed()
-        }
-      })
+      transferred = candidate.transferTo(attempt)
+      candidate = undefined
 
       // Initialization tells the agent which client-side services this app can handle.
-      const initResult = await connection.agent.request(acp.methods.agent.initialize, {
+      const initResult = await transferred.initialize({
         protocolVersion: acp.PROTOCOL_VERSION,
         clientInfo: {
           name: 'open-science',
@@ -1025,19 +944,13 @@ class AcpRuntime {
         }
       })
       attempt.assertCurrent()
-      const initializeMaterial = backendAttempt.consumeInitializeMaterial()
+      const initializeMaterial = transferred.backendAttempt.consumeInitializeMaterial()
       if (initializeMaterial?.authentication) {
-        await connection.agent.request(
-          acp.methods.agent.authenticate,
-          initializeMaterial.authentication
-        )
+        await transferred.authenticate(initializeMaterial.authentication)
         attempt.assertCurrent()
       }
       if (initializeMaterial?.providerConfiguration) {
-        await connection.agent.request(
-          acp.methods.agent.providers.set,
-          initializeMaterial.providerConfiguration
-        )
+        await transferred.setProvider(initializeMaterial.providerConfiguration)
         attempt.assertCurrent()
       }
       const handle = attempt.publish({
@@ -1065,40 +978,9 @@ class AcpRuntime {
       this.setStatus('connected')
       return handle
     } catch (thrown) {
-      backendAttempt?.fail()
-      // A spawn failure arrives wrapped so it can name the framework it targeted without mutating the
-      // original throwable; unwrap to the real cause (logged and re-thrown) and prefer its framework
-      // (the process never returned to update spawnedFramework). `instanceof` is guarded because a
-      // hostile thrown value's getPrototypeOf trap could otherwise throw here. Every other failure is
-      // its own cause.
-      let spawnFailure: SpawnFailure | undefined
-      try {
-        if (thrown instanceof SpawnFailure) spawnFailure = thrown
-      } catch {
-        spawnFailure = undefined
-      }
-      const cause = spawnFailure ? spawnFailure.cause : thrown
-
-      // Before attach(), the owner cannot detach the candidate for failure cleanup. Keep that
-      // pre-publication resource local and transfer-or-release it exactly once.
-      if (!resourceAttached && agentProcess) {
-        await this.connectionResources.cleanupUnattached(
-          {
-            process: agentProcess,
-            connection: unattachedConnection,
-            bridgeLease: unattachedBridgeLease
-          },
-          (stage, cleanupError) => {
-            safeLogError(`unattached ACP ${stage} cleanup failed`, {
-              ...diagnosticErrorFields(cleanupError),
-              ...this.diagnosticContext(spawnedFramework, generation)
-            })
-          }
-        )
-        unattachedConnection = undefined
-        agentProcess = undefined
-        unattachedBridgeLease = undefined
-      }
+      transferred?.backendAttempt.fail()
+      await candidate?.dispose()
+      const cause = thrown
 
       // The entire failure-handling body is best-effort: logging, notification sinks (pushEvent/
       // emitState), and cleanup are each isolated so that whatever throws — a hostile error value, a
@@ -1107,10 +989,7 @@ class AcpRuntime {
       try {
         // Shared lifecycle context keeps the resolved framework and attempted generation attached to
         // both the abandoned and failed paths without retaining process or workspace details.
-        const processFields = this.diagnosticContext(
-          spawnFailure ? spawnFailure.framework : spawnedFramework,
-          generation
-        )
+        const processFields = this.diagnosticContext(spawnedFramework, generation)
 
         if (generation !== this.connectionGeneration) {
           // Superseded (a newer reconnect bumped the generation) or shutting down: the fast-path re-throw
@@ -1176,10 +1055,7 @@ class AcpRuntime {
         try {
           log.error('error while handling agent connection failure', {
             ...diagnosticErrorFields(handlingError),
-            ...this.diagnosticContext(
-              spawnFailure ? spawnFailure.framework : spawnedFramework,
-              generation
-            )
+            ...this.diagnosticContext(spawnedFramework, generation)
           })
         } catch {
           /* nothing more we can safely do */
@@ -2300,7 +2176,7 @@ class AcpRuntime {
   // Teardown for the pre-update-install gate. Reaps the current agent tree (so the NSIS installer can
   // delete files the agent held) but, unlike shutdownForQuit, does NOT latch shuttingDown: a refused
   // install (degraded or timed-out teardown) must leave the runtime able to lazily reconnect. Crucially
-  // it does not rely on a latch to catch a connect racing inside spawnAgentProcess either — this teardown
+  // it does not rely on a latch to catch a connect racing inside provider spawn either — this teardown
   // can itself be abandoned by its caller (runBounded) once the budget elapses, and a latch set here
   // would then never clear, wedging every future connect. Instead disconnect() bumps the connection
   // generation, and connectFresh reaps any freshly-spawned child whose generation is now stale,
@@ -2431,89 +2307,76 @@ class AcpRuntime {
     return this.getSnapshot()
   }
 
-  // Creates the agent process, preferring an injected spawner (tests) and otherwise resolving the
-  // active agent backend so each reconnect uses the current framework + up-to-date credentials. Returns
-  // the child paired with the framework it was spawned under so the caller labels lifecycle/failure logs
-  // atomically — never by re-reading the current generation view after an overlapping reconnect.
-  private async spawnAgentProcess(identity: AcpConnectionResourceAttempt): Promise<{
-    process: ChildProcessWithoutNullStreams
-    framework: AgentFramework['id']
-    bridgeLease: ResolvedAgentBackend['responsesBridgeLease']
-    backendAttempt: AcpBackendGenerationAttempt
-  }> {
-    if (this.spawnAgent) {
-      const backend: ResolvedAgentBackend = {
-        framework: this.framework,
-        executablePath: '',
-        env: {}
-      }
-      const backendAttempt = this.backendGeneration.prepare(identity, backend)
-      let process: ChildProcessWithoutNullStreams
-      try {
-        process = this.spawnAgent()
-      } catch (error) {
-        backendAttempt.fail()
-        throw error
-      }
-      return {
-        process,
-        framework: this.framework.id,
-        bridgeLease: undefined,
-        backendAttempt
-      }
-    }
-
-    const backend = this.options.resolveBackend
-      ? await this.options.resolveBackend({
-          forcedSkillIds: [...this.turnSkills.backendPreparation().forcedSkillIds],
-          systemPromptAppends: await this.getBackendSystemPromptAppends()
+  private openAgentConnection(
+    identity: AcpConnectionResourceAttempt,
+    onFrameworkResolved: (framework: AgentFramework['id']) => void
+  ): Promise<AcpAgentConnectionCandidate> {
+    const hooks: AcpAgentConnectionHooks = {
+      requestPermission: (params) => this.handlePermissionRequest(params),
+      observeSessionUpdate: (notification) => this.observePermissionToolContext(notification),
+      observeClaudeSdkMessage: (params) => this.observeClaudeSdkMessage(params),
+      filesystem: {
+        resolveSessionCwd: (sessionId) => this.resolveSessionCwd(sessionId),
+        protectedReadRoots: () => this.protectedReadRoots()
+      },
+      onBackendResolved: (framework) => {
+        onFrameworkResolved(framework)
+        if (!this.spawnAgent) {
+          // Keep spawn configuration and provider identifiers out of diagnostics.
+          log.info('agent backend resolved', this.diagnosticContext(framework))
+        }
+      },
+      onProcessSpawned: (framework) => {
+        if (!this.spawnAgent) log.info('agent process spawned', this.diagnosticContext(framework))
+      },
+      onBackendPublished: (backend) => {
+        this.sessionUpdateProjector.beginGeneration(
+          backend.adapter.codexHome ? join(backend.adapter.codexHome, 'skills') : undefined
+        )
+      },
+      attachProcessDiagnostics: (process, _framework, epoch) =>
+        this.attachAgentProcessEvents(process, epoch),
+      onConnectionClosed: () => {
+        if (
+          this.snapshotOwner.status === 'connected' ||
+          this.snapshotOwner.status === 'connecting'
+        ) {
+          this.handleConnectionClosed()
+        }
+      },
+      reportCleanupFailure: (stage, error, framework, epoch) => {
+        if (stage === 'bridge-lease') {
+          safeLogError('responses bridge lease release failed', errorLogFields(error))
+          return
+        }
+        safeLogError(`unattached ACP ${stage} cleanup failed`, {
+          ...diagnosticErrorFields(error),
+          ...this.diagnosticContext(framework, epoch)
         })
-      : undefined
-
-    if (!backend) {
-      throw new Error('ACP agent spawn configuration is not available.')
-    }
-    let backendAttempt: AcpBackendGenerationAttempt
-    try {
-      backendAttempt = this.backendGeneration.prepare(identity, backend)
-    } catch (error) {
-      await this.connectionResources.cleanupUnattached({
-        bridgeLease: backend.responsesBridgeLease
-      })
-      throw error
+      },
+      reportProcessTreeError: (message, error) => log.error(message, error)
     }
 
-    // Record the resolved framework without retaining executable paths, arguments, environment names,
-    // provider identifiers, or model selections from the spawn configuration.
-    log.info('agent backend resolved', this.diagnosticContext(backend.framework.id))
-
-    let process: ChildProcessWithoutNullStreams
-    try {
-      process = backend.framework.spawn({
-        executablePath: backend.executablePath,
-        env: backend.env,
-        args: backend.args ?? [],
-        proxyEnvironmentMode: backend.proxyEnvironmentMode
-      })
-    } catch (error) {
-      // Wrap (never mutate) the failure with the framework this spawn targeted: the connect-level catch
-      // would otherwise fall back to this.framework.id, which an overlapping reconnect could move before
-      // the log is written. connectFresh unwraps this and re-throws the original `error` value.
-      await this.connectionResources.cleanupUnattached({
-        bridgeLease: backend.responsesBridgeLease
-      })
-      backendAttempt.fail()
-      throw new SpawnFailure(backend.framework.id, error)
-    }
-
-    log.info('agent process spawned', this.diagnosticContext(backend.framework.id))
-
-    return {
-      process,
-      framework: backend.framework.id,
-      bridgeLease: backend.responsesBridgeLease,
-      backendAttempt
-    }
+    return this.connectionAdapter.open(
+      {
+        epoch: identity.epoch,
+        resolveBackend: async () => {
+          const backend: ResolvedAgentBackend | undefined = this.spawnAgent
+            ? { framework: this.framework, executablePath: '', env: {} }
+            : await this.options.resolveBackend?.({
+                forcedSkillIds: [...this.turnSkills.backendPreparation().forcedSkillIds],
+                systemPromptAppends: await this.getBackendSystemPromptAppends()
+              })
+          if (!backend) throw new Error('ACP agent spawn configuration is not available.')
+          return backend
+        },
+        prepareBackend: (backend) => this.backendGeneration.prepare(identity, backend),
+        isCurrent: () => identity.epoch === this.connectionGeneration,
+        isShuttingDown: () => this.connectionResources.isShuttingDown,
+        ...(this.spawnAgent ? { spawnAgent: this.spawnAgent } : {})
+      },
+      hooks
+    )
   }
 
   // Sends one prompt turn to the targeted session and streams updates until stop.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -479,6 +479,7 @@ class AcpRuntime {
   private readonly contextUsageTracker: ContextUsageTracker
   private readonly connectionAdapter = new AcpAgentConnectionAdapter()
   private readonly connectionResources: AcpConnectionResourceOwner
+  private candidateTreeKillReaped = true
   private readonly connectionTransitions: AcpConnectionTransitionOwner
   private readonly generationActivity: AcpGenerationActivityOwner
   // Stable app identities, provider aliases, publication order, selection, and startup/delete
@@ -2161,6 +2162,7 @@ class AcpRuntime {
   // remains — assigned, connecting, or mid-spawn. Returns { reaped } so the caller can tell a clean
   // teardown from a degraded one (taskkill fallback left grandchildren) before committing to app.exit.
   async shutdownForQuit(): Promise<{ reaped: boolean }> {
+    this.candidateTreeKillReaped = true
     const shutdown = this.connectionResources.beginAwaitableShutdown(true)
     // Kill the currently-assigned agent tree right away. Do NOT wait on the in-flight connect first: it
     // may be stalled on ACP initialize with the child already assigned, and waiting would let
@@ -2170,7 +2172,8 @@ class AcpRuntime {
     // Cover the child that had not been assigned yet when disconnect ran: a connect still mid-spawn hits
     // the shutting-down check and tree-kills its freshly-spawned child. Await it (swallowing its
     // rejection, bounded by shutdownBackends' timeout) so that kill completes before we resolve.
-    return shutdown.finish()
+    const outcome = await shutdown.finish()
+    return { reaped: outcome.reaped && this.candidateTreeKillReaped }
   }
 
   // Teardown for the pre-update-install gate. Reaps the current agent tree (so the NSIS installer can
@@ -2184,10 +2187,12 @@ class AcpRuntime {
   // signal (so a degraded reap makes the caller refuse the install); if that await is abandoned on
   // timeout the caller refuses on !completed and the stale-generation self-reap still collects the child.
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
+    this.candidateTreeKillReaped = true
     const shutdown = this.connectionResources.beginAwaitableShutdown(false)
     await this.disconnect(false)
     // Await so the mid-spawn child's kill settles before we report the reaped signal.
-    return shutdown.finish()
+    const outcome = await shutdown.finish()
+    return { reaped: outcome.reaped && this.candidateTreeKillReaped }
   }
 
   // Retires this framework generation without interrupting active turns or background workflows. The
@@ -2333,6 +2338,9 @@ class AcpRuntime {
         this.sessionUpdateProjector.beginGeneration(
           backend.adapter.codexHome ? join(backend.adapter.codexHome, 'skills') : undefined
         )
+      },
+      onProcessTreeReaped: (reaped) => {
+        this.candidateTreeKillReaped = this.candidateTreeKillReaped && reaped
       },
       attachProcessDiagnostics: (process, _framework, epoch) =>
         this.attachAgentProcessEvents(process, epoch),

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -3802,11 +3802,16 @@ class AcpRuntime {
   private attachAgentProcessEvents(
     agentProcess: ChildProcessWithoutNullStreams,
     generation: number
-  ): void {
+  ): () => void {
     // Bind the framework this process was spawned under now. During a reconnect the runtime's
     // The current generation view may already name a new backend, so reading it in async handlers would
     // mislabel a late stderr/exit from the old process.
     const framework = this.framework.id
+    let expectedExit = false
+    const disposition = (): ReturnType<AcpConnectionResourceOwner['processEventDisposition']> =>
+      expectedExit
+        ? 'expected'
+        : this.connectionResources.processEventDisposition(agentProcess, generation)
 
     agentProcess.stderr.on('data', (data: Buffer) => {
       const text = data.toString('utf8').trim()
@@ -3822,8 +3827,7 @@ class AcpRuntime {
         })
       }
 
-      if (this.connectionResources.processEventDisposition(agentProcess, generation) !== 'current')
-        return
+      if (disposition() !== 'current') return
 
       if (text) {
         // Attribute stderr to a session only when exactly one prompt is in flight — then it's
@@ -3846,8 +3850,7 @@ class AcpRuntime {
         ...this.diagnosticContext(framework, generation)
       })
 
-      if (this.connectionResources.processEventDisposition(agentProcess, generation) !== 'current')
-        return
+      if (disposition() !== 'current') return
 
       this.snapshotOwner.updateError(errorMessage(error))
       this.pushEvent({
@@ -3860,18 +3863,18 @@ class AcpRuntime {
     })
 
     agentProcess.on('exit', (code, signal) => {
-      const disposition = this.connectionResources.processEventDisposition(agentProcess, generation)
+      const processDisposition = disposition()
       log.info('agent process exit', {
         code,
         signal,
         framework,
         status: this.snapshotOwner.status,
-        expected: disposition === 'expected',
+        expected: processDisposition === 'expected',
         sessionCount: this.activeSessionIds().length,
         pid: agentProcess.pid
       })
 
-      if (disposition !== 'current') return
+      if (processDisposition !== 'current') return
 
       if (this.snapshotOwner.status === 'connected' || this.snapshotOwner.status === 'connecting') {
         this.pushEvent({
@@ -3882,6 +3885,10 @@ class AcpRuntime {
         })
       }
     })
+
+    return () => {
+      expectedExit = true
+    }
   }
 
   // Clears local state after the protocol connection closes unexpectedly.


### PR DESCRIPTION
## Problem

Runtime directly held provisional provider process, ACP client/stream, and bridge-lease cleanup before attachment, leaving the ownership-transfer seam implicit and risking double cleanup.

Related: #458 (forward-compatibility constraint only; this PR added no orchestration data model or public interface).

## Proposed change

- Open an opaque process candidate that solely owns provisional process/client/stream/bridge-lease cleanup.
- Transfer the candidate exactly once into the existing `AcpConnectionResourceOwner`.
- Make pre-transfer disposal idempotent and post-transfer disposal a no-op.
- Preserve cross-platform process-tree reap, bridge-lease release, degraded Windows reap outcomes, and expected-exit classification.
- Drop the Runtime candidate reference immediately after successful transfer.

## Scope and non-goals

- ARD-15B1 only; `AcpConnectionResourceOwner` and transition-owner implementations were unchanged.
- Runtime retained stderr/error/exit diagnostics, redaction, late-process-event classification, reconnect policy, and protocol sequencing for ARD-15B2.
- No SDK, NDJSON, callback, spawn-input, protected-root, filesystem, Permission, Reviewer, Projector, Electron, Web, CLI, or IPC behavior change.
- Exact production raw: **543 / 550** against recorded base `104dcb9c`.

## Ownership and sequence

```mermaid
stateDiagram-v2
  [*] --> CandidateOwns: open candidate
  CandidateOwns --> CandidateOwns: dispose (idempotent cleanup)
  CandidateOwns --> ResourceOwnerOwns: transferTo once
  ResourceOwnerOwns --> ResourceOwnerOwns: candidate dispose is no-op
  ResourceOwnerOwns --> [*]: AcpConnectionResourceOwner teardown
```

Before transfer, the opaque candidate is the sole physical-resource owner. After the one-shot transfer, `AcpConnectionResourceOwner` is the sole owner; Runtime retains orchestration and diagnostics policy, not resource ownership.

## Acceptance criteria and validation

The historical PR record states:

- Candidate/Runtime impact set -> focused tests -> **4 files, 437 tests passed**. Exact focused argv was not retained.
- Portable suite -> `npm test` -> **757 files passed, 14 skipped; 11,212 tests passed, 184 skipped**.
- Node contracts -> `npm run typecheck:node` -> **passed**.
- Source lint -> `npm run lint` -> **passed with 0 errors and 17 unrelated baseline warnings**.
- Formatting -> targeted Prettier checks -> **passed**; exact argv unavailable.
- Diff integrity -> `git diff --check` -> **passed**.
- Independent review -> **Standards final PASS, 0 findings; Spec initial Windows reap-outcome finding fixed and final PASS**.
- AI expected-exit finding -> reproduced RED, fixed GREEN, and covered by a Runtime integration test; final-head AI comment records **mergeable / no actionable findings**.
- Final online gates -> GitHub records **PR Gate, Unit tests, Static checks, Coverage macOS, macOS build and E2E, Windows E2E, CodeQL, and AI review workflow success**.

## Review focus

- Single-owner cleanup before and after transfer.
- One-shot transfer state and post-transfer no-op disposal.
- Shutdown reap-outcome propagation and expected-exit classification.
- Boundary that keeps diagnostics policy in Runtime.

## Uncovered risks

- Historical focused-test argv was not retained.
- Diagnostics/late-event policy remained in Runtime by design and was deferred to ARD-15B2.

