### PR TITLE
refactor(acp): bind process diagnostics in adapter

### DIFF
--- a/src/main/acp/agent-connection-adapter.test.ts
+++ b/src/main/acp/agent-connection-adapter.test.ts
@@ -60,7 +60,10 @@ const hooks = (): AcpAgentConnectionHooks => ({
   onProcessSpawned: vi.fn(),
   onBackendPublished: vi.fn(),
   onProcessTreeReaped: vi.fn(),
-  attachProcessDiagnostics: vi.fn(() => vi.fn()),
+  markProcessExitExpected: vi.fn(),
+  onProcessStderr: vi.fn(),
+  onProcessError: vi.fn(),
+  onProcessExit: vi.fn(),
   onConnectionClosed: vi.fn(),
   reportCleanupFailure: vi.fn(),
   reportProcessTreeError: vi.fn()
@@ -100,7 +103,8 @@ const openCandidate = async (
     framework: claudeCodeFramework,
     executablePath: '',
     env: {}
-  }
+  },
+  connectionHooks: AcpAgentConnectionHooks = hooks()
 ): Promise<AcpAgentConnectionCandidate> => {
   const backendOwner = new AcpBackendGenerationOwner(claudeCodeFramework)
   const identity = { epoch: 1, assertCurrent: vi.fn() }
@@ -113,11 +117,42 @@ const openCandidate = async (
       isShuttingDown: () => false,
       spawnAgent: () => asAgentProcess(process)
     },
-    hooks()
+    connectionHooks
   )
 }
 
 describe('AcpAgentConnectionAdapter', () => {
+  it('binds process diagnostics and forwards the process epoch context', async () => {
+    const process = new FakeAgentProcess()
+    const connectionHooks = hooks()
+    const candidate = await openCandidate(process, undefined, connectionHooks)
+
+    process.stderr.emit('data', Buffer.from(' provider auth failed\n'))
+    const error = new Error('pipe failed')
+    process.emit('error', error)
+    process.emit('exit', 1, 'SIGTERM')
+
+    expect(connectionHooks.onProcessStderr).toHaveBeenCalledWith('provider auth failed', {
+      process,
+      framework: 'claude-code',
+      epoch: 1
+    })
+    expect(connectionHooks.onProcessError).toHaveBeenCalledWith(error, {
+      process,
+      framework: 'claude-code',
+      epoch: 1
+    })
+    expect(connectionHooks.onProcessExit).toHaveBeenCalledWith(1, 'SIGTERM', {
+      process,
+      framework: 'claude-code',
+      epoch: 1,
+      pid: 1234
+    })
+
+    await candidate.dispose()
+    expect(connectionHooks.markProcessExitExpected).toHaveBeenCalledWith(process, 1)
+  })
+
   it('reaps an untransferred process tree and releases its bridge lease exactly once', async () => {
     const process = new FakeAgentProcess()
     const release = vi.fn(async () => undefined)

--- a/src/main/acp/agent-connection-adapter.ts
+++ b/src/main/acp/agent-connection-adapter.ts
@@ -23,6 +23,15 @@ import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 
 type ResponsesBridgeLease = ResolvedAgentBackend['responsesBridgeLease']
 type CandidateCleanupStage = 'connection' | 'agent-process' | 'bridge-lease'
+type AcpProcessEventContext = Readonly<{
+  process: ChildProcessWithoutNullStreams
+  framework: AgentFramework['id']
+  epoch: number
+}>
+type AcpProcessExitContext = AcpProcessEventContext &
+  Readonly<{
+    pid: number | undefined
+  }>
 
 type AcpAgentConnectionHooks = Readonly<{
   requestPermission: (
@@ -38,11 +47,14 @@ type AcpAgentConnectionHooks = Readonly<{
   onProcessSpawned: (framework: AgentFramework['id']) => void
   onBackendPublished: (backend: AcpBackendGenerationView) => void
   onProcessTreeReaped: (reaped: boolean) => void
-  attachProcessDiagnostics: (
-    process: ChildProcessWithoutNullStreams,
-    framework: AgentFramework['id'],
-    epoch: number
-  ) => () => void
+  markProcessExitExpected: (process: ChildProcessWithoutNullStreams, epoch: number) => void
+  onProcessStderr: (text: string, context: AcpProcessEventContext) => void
+  onProcessError: (error: unknown, context: AcpProcessEventContext) => void
+  onProcessExit: (
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    context: AcpProcessExitContext
+  ) => void
   onConnectionClosed: () => void
   reportCleanupFailure: (
     stage: CandidateCleanupStage,
@@ -86,7 +98,6 @@ class AcpAgentConnectionAdapter {
     let connection: ReturnType<AcpAgentConnectionAdapter['createClientConnection']> | undefined
     let bridgeLease: ResponsesBridgeLease
     let backendAttempt: AcpBackendGenerationAttempt | undefined
-    let expectProcessExit: (() => void) | undefined
     let framework: AgentFramework['id'] = 'claude-code'
 
     const reportCleanupFailure = (stage: CandidateCleanupStage, error: unknown): void => {
@@ -103,7 +114,7 @@ class AcpAgentConnectionAdapter {
         reportCleanupFailure('connection', error)
       }
       if (process) {
-        expectProcessExit?.()
+        hooks.markProcessExitExpected(process, input.epoch)
         try {
           const result = await terminateProcessTree(process, undefined, {
             error: (message, error) => hooks.reportProcessTreeError(message, error)
@@ -144,9 +155,32 @@ class AcpAgentConnectionAdapter {
             : 'ACP connection superseded during spawn.'
         )
       }
+      if (!process) throw new Error('ACP agent process did not spawn.')
+      const spawnedProcess = process
       hooks.onBackendPublished(backendAttempt.publish())
-      expectProcessExit = hooks.attachProcessDiagnostics(process, framework, input.epoch)
-      connection = this.createClientConnection(process, hooks)
+      spawnedProcess.stderr.on('data', (data: Buffer) => {
+        hooks.onProcessStderr(data.toString('utf8').trim(), {
+          process: spawnedProcess,
+          framework,
+          epoch: input.epoch
+        })
+      })
+      spawnedProcess.on('error', (error) => {
+        hooks.onProcessError(error, {
+          process: spawnedProcess,
+          framework,
+          epoch: input.epoch
+        })
+      })
+      spawnedProcess.on('exit', (code, signal) => {
+        hooks.onProcessExit(code, signal, {
+          process: spawnedProcess,
+          framework,
+          epoch: input.epoch,
+          pid: spawnedProcess.pid
+        })
+      })
+      connection = this.createClientConnection(spawnedProcess, hooks)
     } catch (error) {
       backendAttempt?.fail()
       await cleanup()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -480,6 +480,7 @@ class AcpRuntime {
   private readonly connectionAdapter = new AcpAgentConnectionAdapter()
   private readonly connectionResources: AcpConnectionResourceOwner
   private candidateTreeKillReaped = true
+  private readonly expectedProcessExits = new WeakSet<ChildProcessWithoutNullStreams>()
   private readonly connectionTransitions: AcpConnectionTransitionOwner
   private readonly generationActivity: AcpGenerationActivityOwner
   // Stable app identities, provider aliases, publication order, selection, and startup/delete
@@ -2342,8 +2343,10 @@ class AcpRuntime {
       onProcessTreeReaped: (reaped) => {
         this.candidateTreeKillReaped = this.candidateTreeKillReaped && reaped
       },
-      attachProcessDiagnostics: (process, _framework, epoch) =>
-        this.attachAgentProcessEvents(process, epoch),
+      markProcessExitExpected: (process) => this.expectedProcessExits.add(process),
+      onProcessStderr: (text, context) => this.handleAgentProcessStderr(text, context),
+      onProcessError: (error, context) => this.handleAgentProcessError(error, context),
+      onProcessExit: (code, signal, context) => this.handleAgentProcessExit(code, signal, context),
       onConnectionClosed: () => {
         if (
           this.snapshotOwner.status === 'connected' ||
@@ -3798,96 +3801,91 @@ class AcpRuntime {
     )
   }
 
-  // Captures process stderr/errors/exits and converts unexpected ones to events.
-  private attachAgentProcessEvents(
-    agentProcess: ChildProcessWithoutNullStreams,
-    generation: number
-  ): () => void {
-    // Bind the framework this process was spawned under now. During a reconnect the runtime's
-    // The current generation view may already name a new backend, so reading it in async handlers would
-    // mislabel a late stderr/exit from the old process.
-    const framework = this.framework.id
-    let expectedExit = false
-    const disposition = (): ReturnType<AcpConnectionResourceOwner['processEventDisposition']> =>
-      expectedExit
-        ? 'expected'
-        : this.connectionResources.processEventDisposition(agentProcess, generation)
+  private processEventDisposition(
+    process: ChildProcessWithoutNullStreams,
+    epoch: number
+  ): ReturnType<AcpConnectionResourceOwner['processEventDisposition']> {
+    if (this.expectedProcessExits.has(process)) return 'expected'
+    return this.connectionResources.processEventDisposition(process, epoch)
+  }
 
-    agentProcess.stderr.on('data', (data: Buffer) => {
-      const text = data.toString('utf8').trim()
-
-      // Always capture agent stderr in the log — it's the primary clue when a turn stalls or the
-      // agent misbehaves (auth loops, MCP connection failures, tool errors) in a packaged build.
-      if (text) {
-        log.warn('agent stderr', {
-          text,
-          framework,
-          status: this.snapshotOwner.status,
-          sessionCount: this.activeSessionIds().length
-        })
-      }
-
-      if (disposition() !== 'current') return
-
-      if (text) {
-        // Attribute stderr to a session only when exactly one prompt is in flight — then it's
-        // unambiguously that turn's. With zero or multiple concurrent prompts, omit the sessionId
-        // rather than risk pinning it to the wrong conversation's waiting indicator.
-        const inFlight = this.getInFlightSessionIds()
-        this.pushEvent({
-          kind: 'system',
-          level: 'warning',
-          sessionId: inFlight.length === 1 ? inFlight[0] : undefined,
-          title: 'agent',
-          text
-        })
-      }
-    })
-
-    agentProcess.on('error', (error) => {
-      log.error('agent process error event', {
-        ...diagnosticErrorFields(error),
-        ...this.diagnosticContext(framework, generation)
-      })
-
-      if (disposition() !== 'current') return
-
-      this.snapshotOwner.updateError(errorMessage(error))
-      this.pushEvent({
-        kind: 'error',
-        level: 'error',
-        title: 'Agent process error',
-        text: this.snapshotOwner.error
-      })
-      this.setStatus('error')
-    })
-
-    agentProcess.on('exit', (code, signal) => {
-      const processDisposition = disposition()
-      log.info('agent process exit', {
-        code,
-        signal,
-        framework,
+  // Projects adapter-bound process diagnostics while retaining epoch classification and event state.
+  private handleAgentProcessStderr(
+    text: string,
+    context: Parameters<AcpAgentConnectionHooks['onProcessStderr']>[1]
+  ): void {
+    // Always capture agent stderr in the log — it's the primary clue when a turn stalls or the
+    // agent misbehaves (auth loops, MCP connection failures, tool errors) in a packaged build.
+    if (text) {
+      log.warn('agent stderr', {
+        text,
+        framework: context.framework,
         status: this.snapshotOwner.status,
-        expected: processDisposition === 'expected',
-        sessionCount: this.activeSessionIds().length,
-        pid: agentProcess.pid
+        sessionCount: this.activeSessionIds().length
       })
+    }
 
-      if (processDisposition !== 'current') return
+    if (this.processEventDisposition(context.process, context.epoch) !== 'current' || !text) return
 
-      if (this.snapshotOwner.status === 'connected' || this.snapshotOwner.status === 'connecting') {
-        this.pushEvent({
-          kind: 'system',
-          level: code === 0 ? 'info' : 'warning',
-          title: 'Agent process exited',
-          text: signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`
-        })
-      }
+    // Attribute stderr to a session only when exactly one prompt is in flight — then it's
+    // unambiguously that turn's. With zero or multiple concurrent prompts, omit the sessionId
+    // rather than risk pinning it to the wrong conversation's waiting indicator.
+    const inFlight = this.getInFlightSessionIds()
+    this.pushEvent({
+      kind: 'system',
+      level: 'warning',
+      sessionId: inFlight.length === 1 ? inFlight[0] : undefined,
+      title: 'agent',
+      text
+    })
+  }
+
+  private handleAgentProcessError(
+    error: unknown,
+    context: Parameters<AcpAgentConnectionHooks['onProcessError']>[1]
+  ): void {
+    log.error('agent process error event', {
+      ...diagnosticErrorFields(error),
+      ...this.diagnosticContext(context.framework, context.epoch)
     })
 
-    return () => {
-      expectedExit = true
+    if (this.processEventDisposition(context.process, context.epoch) !== 'current') return
+
+    this.snapshotOwner.updateError(errorMessage(error))
+    this.pushEvent({
+      kind: 'error',
+      level: 'error',
+      title: 'Agent process error',
+      text: this.snapshotOwner.error
+    })
+    this.setStatus('error')
+  }
+
+  private handleAgentProcessExit(
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    context: Parameters<AcpAgentConnectionHooks['onProcessExit']>[2]
+  ): void {
+    const processDisposition = this.processEventDisposition(context.process, context.epoch)
+    log.info('agent process exit', {
+      code,
+      signal,
+      framework: context.framework,
+      status: this.snapshotOwner.status,
+      expected: processDisposition === 'expected',
+      sessionCount: this.activeSessionIds().length,
+      pid: context.pid
+    })
+
+    if (processDisposition !== 'current') return
+
+    if (this.snapshotOwner.status === 'connected' || this.snapshotOwner.status === 'connecting') {
+      this.pushEvent({
+        kind: 'system',
+        level: code === 0 ? 'info' : 'warning',
+        title: 'Agent process exited',
+        text: signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`
+      })
     }
   }
 


### PR DESCRIPTION
## Problem

ACP process stderr/error/exit listeners were still bound in `AcpRuntime`, mixing external process binding with Runtime-owned state and event projection.

Related: #458 (forward-compatibility constraint only; this PR added no orchestration data model or public interface).

## Proposed change

- Bind child-process stderr, error, and exit events in `AcpAgentConnectionAdapter`.
- Forward narrow raw process/framework/epoch diagnostic hooks.
- Keep Runtime ownership of process-event disposition/epoch classification, expected-exit classification, snapshot/status/event writing, `handleConnectionClosed`, reconnect/transition policy, and resource teardown.

## Scope and non-goals

- ARD-15B2 listener-binding cut only.
- No change to ResourceOwner, Backend/Transition owners, composition/coordinator, IPC, transports, schema, Electron/Web/CLI/Task behavior, or user-visible event semantics.
- Production raw churn: **214** (123 additions + 91 deletions).

## Ownership and sequence

```mermaid
flowchart LR
  P[Child process stderr / error / exit] --> A[AcpAgentConnectionAdapter: listener binding]
  A --> H[Narrow raw diagnostic hooks]
  H --> R[AcpRuntime: epoch and expected-exit policy]
  R --> S[Snapshot / status / renderer events]
  R --> O[Existing resource and transition owners]
```

The adapter owns only external listener binding and forwarding. Runtime remains the sole diagnostics classifier/projector; existing owners retain teardown and transition state.

## Acceptance criteria and validation

The historical PR record states that checks ran after the last material edit:

- Adapter listener-binding behavior -> focused adapter tests -> **13 passed**. Exact argv was not retained.
- ACP diagnostics/lifecycle behavior -> focused tests -> **9 passed**. Exact argv was not retained.
- Node contracts -> `npm run typecheck:node` -> **passed**.
- Source lint -> `npm run lint` -> **passed with 0 errors; existing repository warnings remained**.
- Diff integrity -> `git diff --check` -> **passed**.
- Portable suite -> `npm test` -> **attempted after the last material edit but locally blocked by loopback `listen EPERM`**; Runtime otherwise recorded 396/399 with the same three loopback-dependent failures.
- Final online gates -> GitHub records **PR Gate, Unit tests, Static checks, Coverage macOS, macOS build and E2E, Windows E2E, CodeQL, and final-head AI review workflow success**; the final AI comment records mergeable with no actionable findings.

## Review focus

- Adapter ownership stops at listener binding and raw-hook forwarding.
- Runtime remains the sole epoch/expected-exit classifier and renderer-facing state/event projector.
- No duplicate cleanup or reconnect authority.

## Uncovered risks

- Local full-suite evidence was environment-limited by loopback permissions.
- The retained historical record does not contain the exact focused-test argv; online CI is the authoritative complete-suite/platform evidence.

