### PR TITLE
refactor(acp): isolate connection lifecycle bootstrap

### DIFF
--- a/src/main/acp/connection-lifecycle-workflow.test.ts
+++ b/src/main/acp/connection-lifecycle-workflow.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ClientConnection } from '@agentclientprotocol/sdk'
+import type { AcpConnectRequest, AcpStateSnapshot } from '../../shared/acp'
+import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
+
+const connection = {} as ClientConnection
+
+describe('AcpConnectionLifecycleWorkflow', () => {
+  it('initializes, authenticates, configures the provider, then publishes connected', async () => {
+    const actions: string[] = []
+    const ready = {
+      epoch: 1,
+      connection,
+      framework: 'claude-code' as const,
+      capabilities: { close: true, delete: false, resume: true },
+      assertCurrent: vi.fn()
+    }
+    const attempt = {
+      epoch: 1,
+      assertCurrent: vi.fn(),
+      attach: vi.fn(),
+      publish: vi.fn(() => ready),
+      owns: vi.fn(() => true)
+    }
+    const candidate = {
+      transferTo: vi.fn(() => ({
+        backendAttempt: {
+          consumeInitializeMaterial: () => ({
+            authentication: { methodId: 'api-key' },
+            providerConfiguration: {
+              providerId: 'gateway',
+              apiType: 'openai',
+              baseUrl: 'http://127.0.0.1:1234/v1',
+              headers: {}
+            }
+          }),
+          fail: vi.fn()
+        },
+        initialize: async () => {
+          actions.push('initialize')
+          return {
+            protocolVersion: 1,
+            agentCapabilities: { sessionCapabilities: { close: true, resume: true } }
+          }
+        },
+        authenticate: async () => {
+          actions.push('authenticate')
+        },
+        setProvider: async () => {
+          actions.push('provider-set')
+        }
+      })),
+      dispose: vi.fn(async () => undefined)
+    }
+    const snapshot = { status: 'connected' } as AcpStateSnapshot
+    const workflow = new AcpConnectionLifecycleWorkflow({
+      appVersion: 'test',
+      defaultCwd: '/workspace',
+      currentConnection: () => undefined,
+      currentStatus: () => 'closed',
+      currentGeneration: () => 1,
+      currentFramework: () => 'claude-code',
+      reconnectBarrier: () => undefined,
+      getSnapshot: () => snapshot,
+      invalidatePendingSessionStartups: vi.fn(),
+      disconnectCurrent: vi.fn(async () => snapshot),
+      updateCwd: vi.fn(),
+      updateError: vi.fn(),
+      setStatus: (status) => actions.push(status),
+      pushEvent: (event) => actions.push(event.title ?? ''),
+      transitionStatus: vi.fn(),
+      emitState: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'closed' }),
+      openCandidate: vi.fn(async () => candidate) as never,
+      connectResources: {
+        connect: async (operation) => operation(attempt)
+      } as never
+    })
+
+    await expect(workflow.connect({ cwd: '/workspace' } satisfies AcpConnectRequest)).resolves.toBe(
+      snapshot
+    )
+
+    expect(actions).toEqual([
+      'connecting',
+      'initialize',
+      'authenticate',
+      'provider-set',
+      'Agent initialized',
+      'connected'
+    ])
+    expect(candidate.transferTo).toHaveBeenCalledOnce()
+    expect(attempt.publish).toHaveBeenCalledWith({ close: true, delete: false, resume: true })
+  })
+
+  it('coalesces concurrent connects through the resource owner', async () => {
+    const snapshot = { status: 'connected' } as AcpStateSnapshot
+    const attempt = {
+      epoch: 1,
+      assertCurrent: vi.fn(),
+      attach: vi.fn(),
+      publish: vi.fn(() => ({
+        epoch: 1,
+        connection,
+        framework: 'claude-code' as const,
+        capabilities: { close: false, delete: false, resume: false },
+        assertCurrent: vi.fn()
+      })),
+      owns: vi.fn(() => true)
+    }
+    const candidate = {
+      transferTo: vi.fn(() => ({
+        backendAttempt: {
+          consumeInitializeMaterial: () => undefined,
+          fail: vi.fn()
+        },
+        initialize: async () => ({ protocolVersion: 1, agentCapabilities: {} }),
+        authenticate: async () => undefined,
+        setProvider: async () => undefined
+      })),
+      dispose: vi.fn(async () => undefined)
+    }
+    let inFlight: Promise<unknown> | undefined
+    const connectResources = {
+      connect: vi.fn((operation: (value: never) => Promise<unknown>) => {
+        inFlight ??= operation(attempt as never)
+        return inFlight as Promise<never>
+      })
+    }
+    const workflow = new AcpConnectionLifecycleWorkflow({
+      appVersion: 'test',
+      defaultCwd: '/workspace',
+      currentConnection: () => connection,
+      currentStatus: () => 'connected',
+      currentGeneration: () => 1,
+      currentFramework: () => 'claude-code',
+      reconnectBarrier: () => undefined,
+      getSnapshot: () => snapshot,
+      invalidatePendingSessionStartups: vi.fn(),
+      disconnectCurrent: vi.fn(async () => snapshot),
+      updateCwd: vi.fn(),
+      updateError: vi.fn(),
+      setStatus: vi.fn(),
+      pushEvent: vi.fn(),
+      transitionStatus: vi.fn(),
+      emitState: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connected' }),
+      openCandidate: vi.fn(async () => candidate) as never,
+      connectResources: connectResources as never
+    })
+
+    await expect(Promise.all([workflow.connect(), workflow.connect()])).resolves.toEqual([
+      snapshot,
+      snapshot
+    ])
+    expect(connectResources.connect).toHaveBeenCalledTimes(2)
+    expect(candidate.transferTo).toHaveBeenCalledOnce()
+  })
+
+  it('waits for a reconnect barrier before checking or opening a connection', async () => {
+    let releaseBarrier!: () => void
+    const barrier = new Promise<void>((resolveBarrier) => {
+      releaseBarrier = resolveBarrier
+    })
+    let current: ClientConnection | undefined
+    const connect = vi.fn(async () => {
+      current = connection
+      return { status: 'connected' } as AcpStateSnapshot
+    })
+    const workflow = new AcpConnectionLifecycleWorkflow({
+      appVersion: 'test',
+      defaultCwd: '/workspace',
+      currentConnection: () => current,
+      currentStatus: () => (current ? 'connected' : 'closed'),
+      currentGeneration: () => 1,
+      currentFramework: () => 'claude-code',
+      reconnectBarrier: () => barrier,
+      connect,
+      getSnapshot: () => ({ status: 'connected' }) as AcpStateSnapshot,
+      connectResources: {} as never,
+      invalidatePendingSessionStartups: vi.fn(),
+      disconnectCurrent: vi.fn(async () => ({ status: 'closed' }) as AcpStateSnapshot),
+      updateCwd: vi.fn(),
+      updateError: vi.fn(),
+      setStatus: vi.fn(),
+      pushEvent: vi.fn(),
+      transitionStatus: vi.fn(),
+      emitState: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'closed' }),
+      openCandidate: vi.fn()
+    })
+
+    const result = workflow.ensureConnected('/workspace')
+    await Promise.resolve()
+    expect(connect).not.toHaveBeenCalled()
+    releaseBarrier()
+    await expect(result).resolves.toBe(connection)
+    expect(connect).toHaveBeenCalledOnce()
+  })
+
+  it('disposes an untransferred superseded candidate exactly once', async () => {
+    const snapshot = { status: 'error' } as AcpStateSnapshot
+    const candidate = {
+      transferTo: vi.fn(() => {
+        throw new Error('ACP connection superseded.')
+      }),
+      dispose: vi.fn(async () => undefined)
+    }
+    const attempt = {
+      epoch: 1,
+      assertCurrent: vi.fn(),
+      attach: vi.fn(),
+      publish: vi.fn(),
+      owns: vi.fn(() => false)
+    }
+    const workflow = new AcpConnectionLifecycleWorkflow({
+      appVersion: 'test',
+      defaultCwd: '/workspace',
+      currentConnection: () => undefined,
+      currentStatus: () => 'closed',
+      currentGeneration: () => 1,
+      currentFramework: () => 'claude-code',
+      reconnectBarrier: () => undefined,
+      getSnapshot: () => snapshot,
+      connectResources: {
+        connect: (operation: (value: never) => Promise<unknown>) => operation(attempt as never)
+      } as never,
+      invalidatePendingSessionStartups: vi.fn(),
+      disconnectCurrent: vi.fn(async () => snapshot),
+      updateCwd: vi.fn(),
+      updateError: vi.fn(),
+      setStatus: vi.fn(),
+      pushEvent: vi.fn(),
+      transitionStatus: vi.fn(),
+      emitState: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'closed' }),
+      openCandidate: vi.fn(async () => candidate) as never
+    })
+
+    await expect(workflow.connect()).rejects.toThrow('ACP connection superseded.')
+    expect(candidate.transferTo).toHaveBeenCalledOnce()
+    expect(candidate.dispose).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the original initialize error while clearing attempt material', async () => {
+    const cause = new Error('initialize failed')
+    const fail = vi.fn()
+    const snapshot = { status: 'error' } as AcpStateSnapshot
+    let material: unknown = {
+      authentication: { methodId: 'api-key', _meta: { secret: 'redacted' } }
+    }
+    const candidate = {
+      transferTo: vi.fn(() => ({
+        backendAttempt: {
+          consumeInitializeMaterial: () => {
+            const consumed = material
+            material = undefined
+            return consumed
+          },
+          fail: () => {
+            material = undefined
+            fail()
+          }
+        },
+        initialize: async () => {
+          throw cause
+        },
+        authenticate: vi.fn(),
+        setProvider: vi.fn()
+      })),
+      dispose: vi.fn(async () => undefined)
+    }
+    const attempt = {
+      epoch: 1,
+      assertCurrent: vi.fn(),
+      attach: vi.fn(),
+      publish: vi.fn(),
+      owns: vi.fn(() => true)
+    }
+    const disconnectCurrent = vi.fn(async () => snapshot)
+    const workflow = new AcpConnectionLifecycleWorkflow({
+      appVersion: 'test',
+      defaultCwd: '/workspace',
+      currentConnection: () => connection,
+      currentStatus: () => 'connecting',
+      currentGeneration: () => 1,
+      currentFramework: () => 'claude-code',
+      reconnectBarrier: () => undefined,
+      getSnapshot: () => snapshot,
+      connectResources: {
+        connect: (operation: (value: never) => Promise<unknown>) => operation(attempt as never)
+      } as never,
+      invalidatePendingSessionStartups: vi.fn(),
+      disconnectCurrent,
+      updateCwd: vi.fn(),
+      updateError: vi.fn(),
+      setStatus: vi.fn(),
+      pushEvent: vi.fn(() => {
+        throw new Error('notification failed')
+      }),
+      transitionStatus: vi.fn(),
+      emitState: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation: 1, status: 'connecting' }),
+      openCandidate: vi.fn(async () => candidate) as never
+    })
+
+    await expect(workflow.connect()).rejects.toBe(cause)
+    expect(fail).toHaveBeenCalledOnce()
+    expect(disconnectCurrent).toHaveBeenCalledTimes(2)
+    expect(material).toBeUndefined()
+  })
+
+  it('does not publish connected after a reentrant disconnect from the initialized event', async () => {
+    let generation = 1
+    let reentrant = false
+    const snapshot = { status: 'closed' } as AcpStateSnapshot
+    const attempt = {
+      epoch: 1,
+      assertCurrent: vi.fn(() => {
+        if (generation !== 1) throw new Error('ACP connection superseded.')
+      }),
+      attach: vi.fn(),
+      publish: vi.fn(() => ({
+        epoch: 1,
+        connection,
+        framework: 'claude-code' as const,
+        capabilities: { close: true, delete: true, resume: true },
+        assertCurrent: vi.fn(() => {
+          if (generation !== 1) throw new Error('ACP connection superseded.')
+        })
+      })),
+      owns: vi.fn(() => true)
+    }
+    const candidate = {
+      transferTo: vi.fn(() => ({
+        backendAttempt: {
+          consumeInitializeMaterial: () => undefined,
+          fail: vi.fn()
+        },
+        initialize: async () => ({
+          protocolVersion: 1,
+          agentCapabilities: { sessionCapabilities: { close: true, delete: true, resume: true } }
+        }),
+        authenticate: async () => undefined,
+        setProvider: async () => undefined
+      })),
+      dispose: vi.fn(async () => undefined)
+    }
+    const disconnectCurrent = vi.fn(async (_emitClosedStatus?: boolean, _epoch?: number) => {
+      if (reentrant) generation = 2
+      return snapshot
+    })
+    const workflow = new AcpConnectionLifecycleWorkflow({
+      appVersion: 'test',
+      defaultCwd: '/workspace',
+      currentConnection: () => (generation === 1 ? undefined : connection),
+      currentStatus: () => 'connecting',
+      currentGeneration: () => generation,
+      currentFramework: () => 'claude-code',
+      reconnectBarrier: () => undefined,
+      getSnapshot: () => snapshot,
+      connectResources: {
+        connect: (operation: (value: never) => Promise<unknown>) => operation(attempt as never)
+      } as never,
+      invalidatePendingSessionStartups: vi.fn(),
+      disconnectCurrent,
+      updateCwd: vi.fn(),
+      updateError: vi.fn(),
+      setStatus: vi.fn(),
+      pushEvent: vi.fn((event) => {
+        if (event.title === 'Agent initialized') {
+          reentrant = true
+          void disconnectCurrent(false, 1)
+        }
+      }),
+      transitionStatus: vi.fn(),
+      emitState: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation, status: 'connecting' }),
+      openCandidate: vi.fn(async () => candidate) as never
+    })
+
+    await expect(workflow.connect()).rejects.toThrow('ACP connection superseded.')
+    expect(disconnectCurrent).toHaveBeenCalledTimes(2)
+  })
+
+  it('lets an external disconnect unblock a stalled initialize without publishing connected', async () => {
+    let rejectInitialize!: (error: Error) => void
+    let generation = 1
+    const snapshot = { status: 'closed' } as AcpStateSnapshot
+    const attempt = {
+      epoch: 1,
+      assertCurrent: vi.fn(),
+      attach: vi.fn(),
+      publish: vi.fn(),
+      owns: vi.fn(() => true)
+    }
+    const candidate = {
+      transferTo: vi.fn(() => ({
+        backendAttempt: { consumeInitializeMaterial: () => undefined, fail: vi.fn() },
+        initialize: () =>
+          new Promise<never>((_, reject) => {
+            rejectInitialize = reject
+          }),
+        authenticate: vi.fn(),
+        setProvider: vi.fn()
+      })),
+      dispose: vi.fn(async () => undefined)
+    }
+    let disconnectCount = 0
+    const disconnectCurrent = vi.fn(async (_emitClosedStatus?: boolean, _epoch?: number) => {
+      disconnectCount += 1
+      if (disconnectCount > 1) {
+        generation = 2
+        rejectInitialize(new Error('connection closed'))
+      }
+      return snapshot
+    })
+    const workflow = new AcpConnectionLifecycleWorkflow({
+      appVersion: 'test',
+      defaultCwd: '/workspace',
+      currentConnection: () => connection,
+      currentStatus: () => 'connecting',
+      currentGeneration: () => generation,
+      currentFramework: () => 'claude-code',
+      reconnectBarrier: () => undefined,
+      getSnapshot: () => snapshot,
+      connectResources: {
+        connect: (operation: (value: never) => Promise<unknown>) => operation(attempt as never)
+      } as never,
+      invalidatePendingSessionStartups: vi.fn(),
+      disconnectCurrent,
+      updateCwd: vi.fn(),
+      updateError: vi.fn(),
+      setStatus: vi.fn(),
+      pushEvent: vi.fn(),
+      transitionStatus: vi.fn(),
+      emitState: vi.fn(),
+      diagnosticContext: () => ({ framework: 'claude-code', generation, status: 'connecting' }),
+      openCandidate: vi.fn(async () => candidate) as never
+    })
+
+    const connectPromise = workflow.connect()
+    await new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 0))
+    await disconnectCurrent(false, 1)
+    await expect(connectPromise).rejects.toThrow('connection closed')
+    expect(attempt.publish).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/acp/connection-lifecycle-workflow.test.ts
+++ b/src/main/acp/connection-lifecycle-workflow.test.ts
@@ -347,7 +347,7 @@ describe('AcpConnectionLifecycleWorkflow', () => {
       })),
       dispose: vi.fn(async () => undefined)
     }
-    const disconnectCurrent = vi.fn(async (_emitClosedStatus?: boolean, _epoch?: number) => {
+    const disconnectCurrent = vi.fn(async () => {
       if (reentrant) generation = 2
       return snapshot
     })
@@ -371,7 +371,7 @@ describe('AcpConnectionLifecycleWorkflow', () => {
       pushEvent: vi.fn((event) => {
         if (event.title === 'Agent initialized') {
           reentrant = true
-          void disconnectCurrent(false, 1)
+          void disconnectCurrent()
         }
       }),
       transitionStatus: vi.fn(),
@@ -408,7 +408,7 @@ describe('AcpConnectionLifecycleWorkflow', () => {
       dispose: vi.fn(async () => undefined)
     }
     let disconnectCount = 0
-    const disconnectCurrent = vi.fn(async (_emitClosedStatus?: boolean, _epoch?: number) => {
+    const disconnectCurrent = vi.fn(async () => {
       disconnectCount += 1
       if (disconnectCount > 1) {
         generation = 2
@@ -442,7 +442,7 @@ describe('AcpConnectionLifecycleWorkflow', () => {
 
     const connectPromise = workflow.connect()
     await new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 0))
-    await disconnectCurrent(false, 1)
+    await disconnectCurrent()
     await expect(connectPromise).rejects.toThrow('connection closed')
     expect(attempt.publish).not.toHaveBeenCalled()
   })

--- a/src/main/acp/connection-lifecycle-workflow.ts
+++ b/src/main/acp/connection-lifecycle-workflow.ts
@@ -52,13 +52,17 @@ const log = createLogger('acp')
 const safeLogError = (message: string, error: unknown): void => {
   try {
     log.error(message, error)
-  } catch { return }
+  } catch {
+    return
+  }
 }
 
 const safeLogWarning = (message: string, data: unknown): void => {
   try {
     log.warn(message, data)
-  } catch { return }
+  } catch {
+    return
+  }
 }
 
 const errorMessage = (error: unknown): string => {

--- a/src/main/acp/connection-lifecycle-workflow.ts
+++ b/src/main/acp/connection-lifecycle-workflow.ts
@@ -6,7 +6,11 @@ import type { AcpConnectRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../..
 import type { AgentFramework } from '../agent-framework'
 import { createLogger, diagnosticErrorFields } from '../logger'
 import type { AcpAgentConnectionCandidate } from './agent-connection-adapter'
-import type { AcpConnectionResourceAttempt, AcpConnectionResourceOwner, AcpConnectionResourceReadyHandle } from './connection-resource-owner'
+import type {
+  AcpConnectionResourceAttempt,
+  AcpConnectionResourceOwner,
+  AcpConnectionResourceReadyHandle
+} from './connection-resource-owner'
 
 type LifecycleEvent = Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>
 type TransferredConnection = ReturnType<AcpAgentConnectionCandidate['transferTo']>
@@ -48,13 +52,13 @@ const log = createLogger('acp')
 const safeLogError = (message: string, error: unknown): void => {
   try {
     log.error(message, error)
-  } catch {}
+  } catch { return }
 }
 
 const safeLogWarning = (message: string, data: unknown): void => {
   try {
     log.warn(message, data)
-  } catch {}
+  } catch { return }
 }
 
 const errorMessage = (error: unknown): string => {

--- a/src/main/acp/connection-lifecycle-workflow.ts
+++ b/src/main/acp/connection-lifecycle-workflow.ts
@@ -1,0 +1,246 @@
+import * as acp from '@agentclientprotocol/sdk'
+import type { ClientConnection } from '@agentclientprotocol/sdk'
+import { resolve } from 'node:path'
+
+import type { AcpConnectRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
+import type { AgentFramework } from '../agent-framework'
+import { createLogger, diagnosticErrorFields } from '../logger'
+import type { AcpAgentConnectionCandidate } from './agent-connection-adapter'
+import type { AcpConnectionResourceAttempt, AcpConnectionResourceOwner, AcpConnectionResourceReadyHandle } from './connection-resource-owner'
+
+type LifecycleEvent = Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>
+type TransferredConnection = ReturnType<AcpAgentConnectionCandidate['transferTo']>
+
+type AcpConnectionLifecycleWorkflowOptions = Readonly<{
+  appVersion: string
+  defaultCwd: string
+  currentConnection: () => ClientConnection | undefined
+  currentStatus: () => AcpStateSnapshot['status']
+  currentGeneration: () => number
+  currentFramework: () => AgentFramework['id']
+  reconnectBarrier: () => Promise<void> | undefined
+  connect?: (request: AcpConnectRequest) => Promise<AcpStateSnapshot>
+  getSnapshot: () => AcpStateSnapshot
+  connectResources: Pick<AcpConnectionResourceOwner, 'connect'>
+  invalidatePendingSessionStartups: () => void
+  disconnectCurrent: (
+    emitClosedStatus: boolean,
+    teardownGeneration: number
+  ) => Promise<AcpStateSnapshot>
+  updateCwd: (cwd: string) => void
+  updateError: (error: string | undefined) => void
+  setStatus: (status: AcpStateSnapshot['status']) => void
+  pushEvent: (event: LifecycleEvent) => void
+  transitionStatus: (status: AcpStateSnapshot['status']) => void
+  emitState: () => void
+  diagnosticContext: (
+    framework?: AgentFramework['id'],
+    generation?: number
+  ) => { framework: AgentFramework['id']; generation: number; status: AcpStateSnapshot['status'] }
+  openCandidate: (
+    attempt: AcpConnectionResourceAttempt,
+    onFrameworkResolved: (framework: AgentFramework['id']) => void
+  ) => Promise<AcpAgentConnectionCandidate>
+}>
+
+const log = createLogger('acp')
+
+const safeLogError = (message: string, error: unknown): void => {
+  try {
+    log.error(message, error)
+  } catch {}
+}
+
+const safeLogWarning = (message: string, data: unknown): void => {
+  try {
+    log.warn(message, data)
+  } catch {}
+}
+
+const errorMessage = (error: unknown): string => {
+  try {
+    const message = error instanceof Error ? (error as { message?: unknown }).message : error
+    return typeof message === 'string' ? message : String(message)
+  } catch {
+    return 'unknown error'
+  }
+}
+
+class AcpConnectionLifecycleWorkflow {
+  constructor(private readonly options: AcpConnectionLifecycleWorkflowOptions) {}
+
+  async connect(request: AcpConnectRequest = {}): Promise<AcpStateSnapshot> {
+    await this.options.connectResources.connect((attempt) => this.connectFresh(request, attempt))
+    return this.options.getSnapshot()
+  }
+
+  async ensureConnected(cwd: string): Promise<ClientConnection> {
+    const barrier = this.options.reconnectBarrier()
+    if (barrier) await barrier
+
+    const connection = this.options.currentConnection()
+    if (connection && this.options.currentStatus() === 'connected') return connection
+
+    log.info('ensureConnected: attempting connection', this.options.diagnosticContext())
+    try {
+      await (this.options.connect?.({ cwd }) ?? this.connect({ cwd }))
+    } catch (error) {
+      safeLogError('ensureConnected: connect failed', {
+        ...diagnosticErrorFields(error),
+        ...this.options.diagnosticContext()
+      })
+      throw error
+    }
+
+    const connected = this.options.currentConnection()
+    if (!connected) {
+      const error = new Error('ACP connection failed')
+      safeLogError('ensureConnected: connection is null after connect', {
+        ...this.options.diagnosticContext(),
+        errorCategory: 'connection-unavailable'
+      })
+      throw error
+    }
+    log.info('ensureConnected: connection established', this.options.diagnosticContext())
+    return connected
+  }
+
+  private async connectFresh(
+    request: AcpConnectRequest,
+    attempt: AcpConnectionResourceAttempt
+  ): Promise<AcpConnectionResourceReadyHandle> {
+    const generation = attempt.epoch
+    attempt.assertCurrent()
+    const cwd = resolve(request.cwd || this.options.defaultCwd)
+    let candidate: AcpAgentConnectionCandidate | undefined
+    let transferred: TransferredConnection | undefined
+    let spawnedFramework = this.options.currentFramework()
+
+    try {
+      this.options.invalidatePendingSessionStartups()
+      await this.options.disconnectCurrent(false, generation)
+      attempt.assertCurrent()
+
+      this.options.updateCwd(cwd)
+      this.options.updateError(undefined)
+      this.options.setStatus('connecting')
+      log.info('connecting agent', this.options.diagnosticContext(spawnedFramework, generation))
+
+      candidate = await this.options.openCandidate(attempt, (framework) => {
+        spawnedFramework = framework
+      })
+      transferred = candidate.transferTo(attempt)
+      candidate = undefined
+
+      const initResult = await transferred.initialize({
+        protocolVersion: acp.PROTOCOL_VERSION,
+        clientInfo: {
+          name: 'open-science',
+          version: this.options.appVersion
+        },
+        clientCapabilities: {
+          fs: { readTextFile: true, writeTextFile: true },
+          session: { configOptions: { boolean: {} } },
+          plan: {}
+        }
+      })
+      attempt.assertCurrent()
+
+      const initializeMaterial = transferred.backendAttempt.consumeInitializeMaterial()
+      if (initializeMaterial?.authentication) {
+        await transferred.authenticate(initializeMaterial.authentication)
+        attempt.assertCurrent()
+      }
+      if (initializeMaterial?.providerConfiguration) {
+        await transferred.setProvider(initializeMaterial.providerConfiguration)
+        attempt.assertCurrent()
+      }
+
+      const handle = attempt.publish({
+        close: Boolean(initResult.agentCapabilities?.sessionCapabilities?.close),
+        delete: Boolean(initResult.agentCapabilities?.sessionCapabilities?.delete),
+        resume: Boolean(initResult.agentCapabilities?.sessionCapabilities?.resume)
+      })
+      log.info('agent initialized', {
+        protocolVersion: initResult.protocolVersion,
+        supportsSessionClose: handle.capabilities.close,
+        supportsSessionDelete: handle.capabilities.delete,
+        supportsSessionResume: handle.capabilities.resume
+      })
+      this.options.pushEvent({
+        kind: 'system',
+        level: 'info',
+        title: 'Agent initialized',
+        text: `ACP protocol ${initResult.protocolVersion}`
+      })
+      handle.assertCurrent()
+      this.options.setStatus('connected')
+      return handle
+    } catch (cause) {
+      try {
+        transferred?.backendAttempt.fail()
+      } catch (error) {
+        safeLogError('ACP backend attempt cleanup failed', diagnosticErrorFields(error))
+      }
+      try {
+        await candidate?.dispose()
+      } catch (error) {
+        safeLogError('ACP connection candidate cleanup failed', diagnosticErrorFields(error))
+      }
+
+      const current = generation === this.options.currentGeneration()
+      try {
+        if (current) {
+          this.options.updateError(errorMessage(cause))
+          safeLogError('agent connection failed', {
+            ...diagnosticErrorFields(cause),
+            ...this.options.diagnosticContext(spawnedFramework, generation)
+          })
+          try {
+            this.options.pushEvent({
+              kind: 'error',
+              level: 'error',
+              title: 'Connection failed',
+              text: errorMessage(cause)
+            })
+          } catch (error) {
+            safeLogError('agent connection failure notification failed', {
+              ...diagnosticErrorFields(error),
+              ...this.options.diagnosticContext(spawnedFramework, generation)
+            })
+          }
+          try {
+            await this.options.disconnectCurrent(false, generation)
+          } catch (error) {
+            safeLogError('agent connection cleanup failed', {
+              ...diagnosticErrorFields(error),
+              ...this.options.diagnosticContext(spawnedFramework, generation)
+            })
+          }
+          if (generation === this.options.currentGeneration()) {
+            this.options.transitionStatus('error')
+            try {
+              this.options.emitState()
+            } catch (error) {
+              safeLogError('agent connection emitState failed', error)
+            }
+          }
+        } else {
+          safeLogWarning('agent connection abandoned (superseded or shutting down)', {
+            ...diagnosticErrorFields(cause),
+            ...this.options.diagnosticContext(spawnedFramework, generation)
+          })
+        }
+      } catch (error) {
+        safeLogError('error while handling agent connection failure', {
+          ...diagnosticErrorFields(error),
+          ...this.options.diagnosticContext(spawnedFramework, generation)
+        })
+      }
+      throw cause
+    }
+  }
+}
+
+export { AcpConnectionLifecycleWorkflow }
+export type { AcpConnectionLifecycleWorkflowOptions }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -117,8 +117,7 @@ import {
 } from './session-registry'
 import {
   AcpConnectionResourceOwner,
-  type AcpConnectionResourceAttempt,
-  type AcpConnectionResourceReadyHandle
+  type AcpConnectionResourceAttempt
 } from './connection-resource-owner'
 import {
   AcpAgentConnectionAdapter,
@@ -134,6 +133,7 @@ import {
 } from './backend-generation-owner'
 import { AcpSessionConfigurator, type AcpSessionConfigurationFacts } from './session-configurator'
 import { AcpSessionUpdateProjector, type AcpSessionUpdateEffect } from './session-update-projector'
+import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
 import {
   AcpTurnSkillOwner,
   type AcpTurnSkillHooks,
@@ -511,6 +511,7 @@ class AcpRuntime {
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly artifactTurns: ArtifactTurnOwner | undefined
   private readonly promptContentOwner: AcpPromptContentOwner
+  private readonly connectionLifecycle: AcpConnectionLifecycleWorkflow
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -657,6 +658,30 @@ class AcpRuntime {
       removeStartupBlocker: (token) => this.generationActivity.releaseStartup(token),
       unregisterBridgeSession: (sessionId) =>
         this.connectionResources.unregisterBridgeReviewerSession(sessionId)
+    })
+    this.connectionLifecycle = new AcpConnectionLifecycleWorkflow({
+      appVersion: options.appVersion,
+      defaultCwd: options.defaultCwd,
+      currentConnection: () => this.connection,
+      currentStatus: () => this.snapshotOwner.status,
+      currentGeneration: () => this.connectionGeneration,
+      currentFramework: () => this.framework.id,
+      reconnectBarrier: () => this.reconnectBarrier,
+      connect: (request) => this.connect(request),
+      getSnapshot: () => this.getSnapshot(),
+      connectResources: this.connectionResources,
+      invalidatePendingSessionStartups: () => this.invalidatePendingSessionStartups(),
+      disconnectCurrent: (emitClosedStatus, generation) =>
+        this.disconnectCurrent(emitClosedStatus, generation),
+      updateCwd: (cwd) => this.snapshotOwner.updateCwd(cwd),
+      updateError: (error) => this.snapshotOwner.updateError(error),
+      setStatus: (status) => this.setStatus(status),
+      pushEvent: (event) => this.pushEvent(event),
+      transitionStatus: (status) => this.snapshotOwner.transitionStatus(status),
+      emitState: () => this.emitState(),
+      diagnosticContext: (framework, generation) => this.diagnosticContext(framework, generation),
+      openCandidate: (attempt, onFrameworkResolved) =>
+        this.openAgentConnection(attempt, onFrameworkResolved)
     })
   }
 
@@ -885,187 +910,7 @@ class AcpRuntime {
 
   // Starts a fresh agent process connection and initializes protocol capabilities.
   async connect(request: AcpConnectRequest = {}): Promise<AcpStateSnapshot> {
-    return this.withOperationLease(() => this.connectOperation(request))
-  }
-
-  private async connectOperation(request: AcpConnectRequest = {}): Promise<AcpStateSnapshot> {
-    await this.connectionResources.connect((attempt) => this.connectFresh(request, attempt))
-    return this.getSnapshot()
-  }
-
-  private async connectFresh(
-    request: AcpConnectRequest = {},
-    attempt: AcpConnectionResourceAttempt
-  ): Promise<AcpConnectionResourceReadyHandle> {
-    const generation = attempt.epoch
-    attempt.assertCurrent()
-    // Resolve up front rather than reading this.cwd after the pre-connect teardown, which may still be
-    // mutating runtime state.
-    const cwd = resolve(request.cwd || this.options.defaultCwd)
-    let candidate: AcpAgentConnectionCandidate | undefined
-    let transferred: ReturnType<AcpAgentConnectionCandidate['transferTo']> | undefined
-    // Capture the framework resolved for this attempt so a later reconnect cannot relabel its failure.
-    let spawnedFramework = this.framework.id
-
-    try {
-      // Inside the try so a teardown throw or the generation assertion (a supersede race) also produces
-      // an enriched failure record instead of propagating silently.
-      this.invalidatePendingSessionStartups()
-      await this.disconnectCurrent(false, generation)
-      attempt.assertCurrent()
-
-      this.snapshotOwner.updateCwd(cwd)
-      this.snapshotOwner.updateError(undefined)
-      this.setStatus('connecting')
-      log.info('connecting agent', this.diagnosticContext(this.framework.id, generation))
-
-      candidate = await this.openAgentConnection(attempt, (framework) => {
-        spawnedFramework = framework
-      })
-      transferred = candidate.transferTo(attempt)
-      candidate = undefined
-
-      // Initialization tells the agent which client-side services this app can handle.
-      const initResult = await transferred.initialize({
-        protocolVersion: acp.PROTOCOL_VERSION,
-        clientInfo: {
-          name: 'open-science',
-          version: this.options.appVersion
-        },
-        clientCapabilities: {
-          fs: {
-            readTextFile: true,
-            writeTextFile: true
-          },
-          session: {
-            configOptions: {
-              boolean: {}
-            }
-          },
-          plan: {}
-        }
-      })
-      attempt.assertCurrent()
-      const initializeMaterial = transferred.backendAttempt.consumeInitializeMaterial()
-      if (initializeMaterial?.authentication) {
-        await transferred.authenticate(initializeMaterial.authentication)
-        attempt.assertCurrent()
-      }
-      if (initializeMaterial?.providerConfiguration) {
-        await transferred.setProvider(initializeMaterial.providerConfiguration)
-        attempt.assertCurrent()
-      }
-      const handle = attempt.publish({
-        close: Boolean(initResult.agentCapabilities?.sessionCapabilities?.close),
-        delete: Boolean(initResult.agentCapabilities?.sessionCapabilities?.delete),
-        resume: Boolean(initResult.agentCapabilities?.sessionCapabilities?.resume)
-      })
-
-      log.info('agent initialized', {
-        protocolVersion: initResult.protocolVersion,
-        supportsSessionClose: handle.capabilities.close,
-        supportsSessionDelete: handle.capabilities.delete,
-        supportsSessionResume: handle.capabilities.resume
-      })
-
-      this.pushEvent({
-        kind: 'system',
-        level: 'info',
-        title: 'Agent initialized',
-        text: `ACP protocol ${initResult.protocolVersion}`
-      })
-      // Event/state listeners are external and may synchronously disconnect or replace the runtime.
-      // Re-check the concrete owner after callbacks return before committing the connected snapshot.
-      handle.assertCurrent()
-      this.setStatus('connected')
-      return handle
-    } catch (thrown) {
-      transferred?.backendAttempt.fail()
-      await candidate?.dispose()
-      const cause = thrown
-
-      // The entire failure-handling body is best-effort: logging, notification sinks (pushEvent/
-      // emitState), and cleanup are each isolated so that whatever throws — a hostile error value, a
-      // renderer broadcast, or a teardown hook — the original `cause` is still re-thrown below and never
-      // replaced by a handling-time error.
-      try {
-        // Shared lifecycle context keeps the resolved framework and attempted generation attached to
-        // both the abandoned and failed paths without retaining process or workspace details.
-        const processFields = this.diagnosticContext(spawnedFramework, generation)
-
-        if (generation !== this.connectionGeneration) {
-          // Superseded (a newer reconnect bumped the generation) or shutting down: the fast-path re-throw
-          // skips the error handling below, so log here too — these late-spawn/teardown races are exactly
-          // the failures that are otherwise invisible.
-          try {
-            log.warn('agent connection abandoned (superseded or shutting down)', {
-              ...diagnosticErrorFields(cause),
-              ...processFields
-            })
-          } catch {
-            /* a throwing logger must not mask the cause */
-          }
-        } else {
-          this.snapshotOwner.updateError(errorMessage(cause))
-          safeLogError('agent connection failed', {
-            ...diagnosticErrorFields(cause),
-            ...processFields
-          })
-          // A notification sink that throws synchronously must not skip cleanup or the re-throw.
-          try {
-            this.pushEvent({
-              kind: 'error',
-              level: 'error',
-              title: 'Connection failed',
-              text: this.snapshotOwner.error
-            })
-          } catch (notifyError) {
-            safeLogError('agent connection failure notification failed', {
-              ...diagnosticErrorFields(notifyError),
-              ...processFields
-            })
-          }
-          // Cleanup must not mask the original failure: a throw from session.dispose(),
-          // connection.close(), or a teardown hook is logged with context but never replaces `cause`.
-          if (generation === this.connectionGeneration) {
-            try {
-              await this.disconnectCurrent(false, generation)
-            } catch (cleanupError) {
-              safeLogError('agent connection cleanup failed', {
-                ...diagnosticErrorFields(cleanupError),
-                ...processFields
-              })
-            }
-          }
-          // Cleanup and external callbacks both yield or re-enter. A newer generation owns the status
-          // once either happens, so the failed connect may commit `error` only while still current.
-          if (generation === this.connectionGeneration) {
-            this.snapshotOwner.transitionStatus('error')
-            try {
-              this.emitState()
-            } catch (notifyError) {
-              safeLogError('agent connection emitState failed', {
-                ...diagnosticErrorFields(notifyError),
-                ...processFields
-              })
-            }
-          }
-        }
-      } catch (handlingError) {
-        // Last-resort guard: even the logger threw. Swallow it (best-effort re-log) so the original
-        // cause below is what propagates.
-        try {
-          log.error('error while handling agent connection failure', {
-            ...diagnosticErrorFields(handlingError),
-            ...this.diagnosticContext(spawnedFramework, generation)
-          })
-        } catch {
-          /* nothing more we can safely do */
-        }
-      }
-
-      throw cause
-    }
+    return this.withOperationLease(() => this.connectionLifecycle.connect(request))
   }
 
   // Creates a protocol session, injects artifact tooling, and uses the returned id as the app session id.
@@ -2158,7 +2003,7 @@ class AcpRuntime {
   }
 
   // Awaitable quit/relaunch teardown. Latches shuttingDown FIRST so a connect that is mid-spawn when
-  // quit lands self-aborts and kills its freshly-spawned child (see connectFresh). Unlike shutdown(),
+  // quit lands self-aborts and kills its freshly-spawned child (see the lifecycle workflow). Unlike shutdown(),
   // this can be awaited, so a caller that follows it with app.exit(0) is guaranteed no orphaned agent
   // remains — assigned, connecting, or mid-spawn. Returns { reaped } so the caller can tell a clean
   // teardown from a degraded one (taskkill fallback left grandchildren) before committing to app.exit.
@@ -2183,7 +2028,7 @@ class AcpRuntime {
   // it does not rely on a latch to catch a connect racing inside provider spawn either — this teardown
   // can itself be abandoned by its caller (runBounded) once the budget elapses, and a latch set here
   // would then never clear, wedging every future connect. Instead disconnect() bumps the connection
-  // generation, and connectFresh reaps any freshly-spawned child whose generation is now stale,
+  // generation, and the lifecycle workflow reaps any freshly-spawned child whose generation is now stale,
   // independent of shuttingDown. Awaiting the in-flight connect here only sharpens the returned reaped
   // signal (so a degraded reap makes the caller refuse the install); if that await is abandoned on
   // timeout the caller refuses on !completed and the stale-generation self-reap still collects the child.
@@ -3167,40 +3012,7 @@ class AcpRuntime {
 
   // Lazily initializes the process connection before session creation.
   private async ensureConnected(cwd: string): Promise<ClientConnection> {
-    // A deferred provider/framework/skills reconnect is pending: wait for it to
-    // complete before reusing (or opening) a connection. Without this guard a
-    // createSession called while a prompt is still running would piggy-back onto
-    // the stale connection and land on the old backend.
-    if (this.reconnectBarrier) {
-      await this.reconnectBarrier
-    }
-
-    if (this.connection && this.snapshotOwner.status === 'connected') {
-      return this.connection
-    }
-
-    log.info('ensureConnected: attempting connection', this.diagnosticContext())
-
-    try {
-      await this.connect({ cwd })
-    } catch (error) {
-      safeLogError('ensureConnected: connect failed', {
-        ...diagnosticErrorFields(error),
-        ...this.diagnosticContext()
-      })
-      throw error
-    }
-
-    if (!this.connection) {
-      safeLogError('ensureConnected: connection is null after connect', {
-        ...this.diagnosticContext(),
-        errorCategory: 'connection-unavailable'
-      })
-      throw new Error('ACP connection failed')
-    }
-
-    log.info('ensureConnected: connection established', this.diagnosticContext())
-    return this.connection
+    return this.connectionLifecycle.ensureConnected(cwd)
   }
 
   private observeClaudeSdkMessage(params: Record<string, unknown>): void {


### PR DESCRIPTION
## Problem

`AcpRuntime` still sequenced ACP connection bootstrap end to end, combining candidate preparation and transfer with initialize/auth/provider configuration, capability publication, and connected-state projection.

Related: #458 (forward-compatibility constraint only; this PR added no orchestration data model or public interface).

## Proposed change

- Add `AcpConnectionLifecycleWorkflow` and delegate Runtime connection bootstrap to it.
- Preserve candidate preparation and one-shot transfer into the existing resource owner.
- Preserve initialize, authentication, provider configuration, capability publication, status/event ordering, and generation publication.
- Supply narrow Runtime hooks rather than moving physical resources or owner state into the workflow.

## Scope and non-goals

- ACP connection-lifecycle workflow, Runtime delegation, and tests only.
- No owner implementation, adapter, composition/coordinator, IPC, transport, schema, persisted data, or Electron/Web/CLI/Task contract change.
- `TransitionOwner` retained intent/barrier state, `ResourceOwner` physical resources, `BackendGenerationOwner` generation/secrets, and `ActivityOwner` operation state.
- Production raw: **496**.

## Ownership and sequence

```mermaid
sequenceDiagram
  participant R as AcpRuntime
  participant W as AcpConnectionLifecycleWorkflow
  participant C as Process candidate
  participant O as ResourceOwner
  participant P as ACP provider
  R->>W: connect(request, narrow state hooks)
  W->>C: prepare candidate
  W->>O: transfer candidate once
  W->>P: initialize and authenticate
  W->>P: apply provider configuration
  W->>R: publish capabilities, events, and connected generation
```

The workflow owns orchestration order only. Candidate/ResourceOwner retain the physical-resource handoff; Runtime and the existing owners remain the state writers.

## Acceptance criteria and validation

The retained final local command-level evidence after the formatting edit is:

- Formatting -> `npx prettier --check src/main/acp/connection-lifecycle-workflow.ts` -> **passed**.
- Node contracts -> `npm run typecheck:node` -> **passed**.
- Lifecycle workflow plus Runtime consumer behavior -> `npm test -- src/main/acp/connection-lifecycle-workflow.test.ts src/main/acp/runtime.test.ts` -> **403 tests passed; 3 loopback-dependent Runtime tests failed locally with sandbox `listen EPERM`**.
- Source lint -> `npm run lint -- --no-cache` -> **passed with 0 errors**; the retained record shows repository warnings.
- Diff integrity -> `git diff --check` -> **passed**.
- Portable suite -> `npm test` / `rtk proxy npm test` -> **attempted locally but environment-limited by loopback permissions**; the retained record does not support claiming a local all-green full suite.
- Final online check rollup -> GitHub records **PR Gate, Unit tests, Static checks, Coverage macOS, macOS build and E2E, Windows E2E, and CodeQL success**.

Historical evidence limitation: the final-head automated review comment on `a5a03323cb608bc1fa0021e9fee96132bf7e4de9` recorded a **P1 needs-changes** finding about re-checking generation after a reentrant failure callback. Although the check-run infrastructure itself concluded successfully and the PR was merged, this normalized description does not relabel that final review as “0 findings” or claim a later fix that the PR history does not prove.

## Review focus

- Candidate preparation/transfer and initialize/auth/configuration ordering.
- Capability publication before connected-state publication.
- Generation freshness around callbacks and failure cleanup.
- Absence of duplicate owner state or cross-surface behavior changes.

## Uncovered risks

- The final-head reentrant-generation P1 remains an explicit historical evidence gap for this merged PR and must be evaluated against later ACP changes/current `main`.
- Local full-suite execution was loopback-limited; successful online cross-platform lanes are the retained platform evidence.

