### PR TITLE
refactor(acp): extract connection close workflow

### DIFF
--- a/src/main/acp/connection-close-workflow.test.ts
+++ b/src/main/acp/connection-close-workflow.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpStateSnapshot } from '../../shared/acp'
+import { AcpConnectionCloseWorkflow } from './connection-close-workflow'
+
+const snapshot = { status: 'closed' } as AcpStateSnapshot
+type TestHarness = {
+  workflow: AcpConnectionCloseWorkflow
+  actions: string[]
+  generation: () => number
+  state: Record<string, ReturnType<typeof vi.fn>>
+  resources: Record<string, ReturnType<typeof vi.fn>>
+  transitions: Record<string, ReturnType<typeof vi.fn>>
+}
+
+const createWorkflow = (overrides: Record<string, unknown> = {}): TestHarness => {
+  const actions: string[] = []
+  let generation = 2
+  const state = {
+    invalidatePendingSessionStartups: vi.fn(() => actions.push('invalidate')),
+    disposePermissionContext: vi.fn(() => actions.push('permission')),
+    clearReviewerState: vi.fn(() => actions.push('reviewer')),
+    settleActivePrompts: vi.fn(() => ['prompt'] as unknown[]),
+    supersedeInteractions: vi.fn(() => actions.push('interactions')),
+    clearContextUsage: vi.fn(() => actions.push('usage')),
+    clearAppliedSessionModels: vi.fn(() => actions.push('models')),
+    activeSessionIds: vi.fn(() => ['session']),
+    disposeSessionCapabilities: vi.fn(() => actions.push('capabilities')),
+    disposeActiveSessions: vi.fn(() => actions.push('sessions')),
+    detachSessionConnections: vi.fn(() => actions.push('detach')),
+    clearPromptContent: vi.fn(() => actions.push('prompt-content')),
+    clearHandoffContinuity: vi.fn(() => actions.push('handoff')),
+    clearSessionProjection: vi.fn(() => actions.push('projection-clear')),
+    disposeSessionProjection: vi.fn(() => actions.push('projection-dispose')),
+    clearHttpRoutes: vi.fn(() => actions.push('routes')),
+    selectSession: vi.fn(() => actions.push('select')),
+    publishInterruptedPromptFailures: vi.fn(() => actions.push('prompt-failures')),
+    setStatus: vi.fn((status: AcpStateSnapshot['status']) => actions.push(status)),
+    transitionStatus: vi.fn((status: AcpStateSnapshot['status']) => actions.push(status)),
+    emitState: vi.fn(() => actions.push('emit')),
+    hasContextUsage: vi.fn(() => true)
+  }
+  const resources = {
+    supersede: vi.fn(() => {
+      generation += 1
+      return generation
+    }),
+    restorePublished: vi.fn(),
+    teardown: vi.fn(async () => undefined),
+    closeMcp: vi.fn(async () => undefined),
+    cleanupUnexpectedClose: vi.fn(),
+    shutdownSynchronously: vi.fn((onSuperseded: () => void) => {
+      generation += 1
+      onSuperseded()
+    }),
+    beginAwaitableShutdown: vi.fn(() => ({ finish: async () => ({ reaped: true }) }))
+  }
+  const transitions = {
+    settleTeardown: vi.fn(async <T>(teardown: () => Promise<T>) => teardown()),
+    resetReconnect: vi.fn(),
+    activityChanged: vi.fn(),
+    requestProviderReconnect: vi.fn(async () => undefined),
+    requestRetirement: vi.fn(async () => undefined)
+  }
+  const workflow = new AcpConnectionCloseWorkflow({
+    currentGeneration: () => generation,
+    currentStatus: () => 'connected',
+    getSnapshot: () => snapshot,
+    transitions,
+    resources,
+    backendGeneration: {
+      supersede: vi.fn((throughEpoch: number) => actions.push(`backend:${throughEpoch}`))
+    },
+    state,
+    reportFailure: vi.fn(),
+    ...overrides
+  } as never)
+  return { workflow, actions, generation: () => generation, state, resources, transitions }
+}
+
+describe('AcpConnectionCloseWorkflow', () => {
+  it('coordinates expected teardown while preserving owner ordering', async () => {
+    const { workflow, actions, resources, transitions } = createWorkflow()
+
+    await expect(workflow.disconnect()).resolves.toBe(snapshot)
+
+    expect(transitions.settleTeardown).toHaveBeenCalledOnce()
+    expect(resources.supersede).toHaveBeenCalledOnce()
+    expect(resources.teardown).toHaveBeenCalledOnce()
+    expect(resources.closeMcp).toHaveBeenCalledOnce()
+    expect(actions).toEqual([
+      'invalidate',
+      'permission',
+      'reviewer',
+      'interactions',
+      'usage',
+      'models',
+      'capabilities',
+      'sessions',
+      'detach',
+      'prompt-content',
+      'projection-clear',
+      'routes',
+      'select',
+      'closed',
+      'backend:2'
+    ])
+  })
+
+  it('cleans an unexpected close once, reports interrupted prompts, then reevaluates intents', () => {
+    const { workflow, actions, resources, transitions, state } = createWorkflow()
+
+    workflow.handleUnexpectedClose()
+
+    expect(resources.cleanupUnexpectedClose).toHaveBeenCalledOnce()
+    expect(state.settleActivePrompts).toHaveBeenCalledOnce()
+    expect(state.publishInterruptedPromptFailures).toHaveBeenCalledWith(['prompt'])
+    expect(transitions.resetReconnect).toHaveBeenCalledOnce()
+    expect(transitions.activityChanged).toHaveBeenCalledOnce()
+    expect(actions).toEqual([
+      'invalidate',
+      'permission',
+      'reviewer',
+      'backend:2',
+      'capabilities',
+      'detach',
+      'prompt-content',
+      'handoff',
+      'projection-dispose',
+      'usage',
+      'routes',
+      'select',
+      'interactions',
+      'closed',
+      'prompt-failures'
+    ])
+  })
+
+  it('keeps quit shutdown awaitable and combines candidate reap results', async () => {
+    const { workflow, resources, state } = createWorkflow()
+    resources.beginAwaitableShutdown.mockReturnValue({
+      finish: async () => ({ reaped: false })
+    })
+
+    workflow.recordProcessTreeReaped(false)
+    await expect(workflow.shutdownForQuit()).resolves.toEqual({ reaped: false })
+
+    expect(resources.beginAwaitableShutdown).toHaveBeenCalledWith(true)
+    expect(state.clearSessionProjection).toHaveBeenCalledOnce()
+  })
+
+  it('clears usage before deferring provider reconnect and delegates intent ownership', async () => {
+    const { workflow, state, transitions } = createWorkflow()
+
+    await workflow.requestProviderReconnect()
+
+    expect(state.clearContextUsage).toHaveBeenCalledOnce()
+    expect(state.clearAppliedSessionModels).toHaveBeenCalledOnce()
+    expect(state.emitState).toHaveBeenCalledOnce()
+    expect(transitions.requestProviderReconnect).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/acp/connection-close-workflow.ts
+++ b/src/main/acp/connection-close-workflow.ts
@@ -1,0 +1,220 @@
+import type { AcpStateSnapshot } from '../../shared/acp'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import type { AcpBackendGenerationOwner } from './backend-generation-owner'
+import type { AcpConnectionResourceOwner } from './connection-resource-owner'
+import type { AcpConnectionTransitionOwner } from './connection-transition-owner'
+type CleanupFailure = (stage: string, error: unknown) => void
+type CloseStatus = AcpStateSnapshot['status']
+type DisconnectCurrent = (...args: [boolean, number]) => Promise<AcpStateSnapshot>
+type CloseState = Readonly<{
+  invalidatePendingSessionStartups: () => void
+  disposePermissionContext: () => void
+  clearReviewerState: () => void
+  settleActivePrompts: () => readonly unknown[]
+  supersedeInteractions: () => void
+  clearContextUsage: () => void
+  clearAppliedSessionModels: () => void
+  activeSessionIds: () => string[]
+  disposeSessionCapabilities: (sessionIds: string[]) => void
+  disposeActiveSessions: (recordFailure: CleanupFailure) => void
+  detachSessionConnections: (clearPermissionProfile: boolean) => void
+  clearPromptContent: () => void
+  clearHandoffContinuity: () => void
+  clearSessionProjection: () => void
+  disposeSessionProjection: () => void
+  clearHttpRoutes: () => void
+  selectSession: () => void
+  publishInterruptedPromptFailures: (prompts: readonly unknown[]) => void
+  setStatus: (status: CloseStatus) => void
+  transitionStatus: (status: CloseStatus) => void
+  emitState: () => void
+  hasContextUsage: () => boolean
+}>
+type AcpConnectionCloseWorkflowOptions = Readonly<{
+  currentGeneration: () => number
+  currentStatus: () => CloseStatus
+  getSnapshot: () => AcpStateSnapshot
+  disconnectCurrent?: DisconnectCurrent
+  transitions: Pick<
+    AcpConnectionTransitionOwner,
+    | 'settleTeardown'
+    | 'resetReconnect'
+    | 'activityChanged'
+    | 'requestProviderReconnect'
+    | 'requestRetirement'
+  >
+  resources: Pick<
+    AcpConnectionResourceOwner,
+    | 'supersede'
+    | 'restorePublished'
+    | 'teardown'
+    | 'closeMcp'
+    | 'cleanupUnexpectedClose'
+    | 'shutdownSynchronously'
+    | 'beginAwaitableShutdown'
+  >
+  backendGeneration: Pick<AcpBackendGenerationOwner, 'supersede'>
+  state: CloseState
+  reportFailure: (message: string, error: unknown) => void
+}>
+class AcpConnectionCloseWorkflow {
+  private candidateTreeKillReaped = true
+  private readonly expectedProcessExits = new WeakSet<ChildProcessWithoutNullStreams>()
+  constructor(private readonly options: AcpConnectionCloseWorkflowOptions) {}
+  async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
+    return this.options.transitions.settleTeardown(async () => {
+      const teardownGeneration = this.options.resources.supersede()
+      this.options.state.invalidatePendingSessionStartups()
+      try {
+        return await (this.options.disconnectCurrent?.(emitClosedStatus, teardownGeneration) ??
+          this.disconnectCurrent(emitClosedStatus, teardownGeneration))
+      } catch (error) {
+        this.options.resources.restorePublished(teardownGeneration)
+        throw error
+      } finally {
+        await this.options.resources.closeMcp(teardownGeneration)
+      }
+    })
+  }
+  async disconnectCurrent(
+    emitClosedStatus = true,
+    teardownGeneration = this.options.currentGeneration()
+  ): Promise<AcpStateSnapshot> {
+    let teardownFailed = false
+    let teardownFailure: unknown
+    const recordFailure: CleanupFailure = (stage, error) => {
+      if (!teardownFailed) {
+        teardownFailed = true
+        teardownFailure = error
+        return
+      }
+      this.reportFailure('secondary ACP disconnect cleanup failed', { stage, error })
+    }
+    const runCleanup = (stage: string, cleanup: () => void): void => {
+      try {
+        cleanup()
+      } catch (error) {
+        recordFailure(stage, error)
+      }
+    }
+    runCleanup('permission-context', this.options.state.disposePermissionContext)
+    runCleanup('reviewer-state', this.options.state.clearReviewerState)
+    this.options.state.supersedeInteractions()
+    this.options.state.clearContextUsage()
+    this.options.state.clearAppliedSessionModels()
+    const activeSessionIds = this.options.state.activeSessionIds()
+    this.options.state.disposeSessionCapabilities(activeSessionIds)
+    this.options.state.disposeActiveSessions((stage, error) => recordFailure(stage, error))
+    this.options.state.detachSessionConnections(true)
+    this.options.state.clearPromptContent()
+    this.options.state.clearSessionProjection()
+    runCleanup('MCP HTTP routes', this.options.state.clearHttpRoutes)
+    this.options.state.selectSession()
+    await this.options.resources.teardown(teardownGeneration, recordFailure)
+    if (emitClosedStatus && teardownGeneration === this.options.currentGeneration()) {
+      runCleanup('closed-status', () => this.options.state.setStatus('closed'))
+    }
+    this.options.backendGeneration.supersede(teardownGeneration - 1)
+    if (teardownFailed) throw teardownFailure
+    return this.options.getSnapshot()
+  }
+  handleUnexpectedClose(): void {
+    if (
+      this.options.currentStatus() !== 'connected' &&
+      this.options.currentStatus() !== 'connecting'
+    ) {
+      return
+    }
+    const teardownGeneration = this.options.currentGeneration()
+    const interruptedPrompts = this.options.state.settleActivePrompts()
+    this.options.state.invalidatePendingSessionStartups()
+    this.options.state.disposePermissionContext()
+    this.options.state.clearReviewerState()
+    this.options.resources.cleanupUnexpectedClose(teardownGeneration)
+    this.options.backendGeneration.supersede(teardownGeneration)
+    this.options.state.disposeSessionCapabilities(this.options.state.activeSessionIds())
+    this.options.state.detachSessionConnections(false)
+    this.options.state.clearPromptContent()
+    this.options.state.clearHandoffContinuity()
+    this.options.state.disposeSessionProjection()
+    this.options.state.clearContextUsage()
+    this.options.state.clearHttpRoutes()
+    this.options.state.selectSession()
+    this.options.state.supersedeInteractions()
+    this.options.transitions.resetReconnect()
+    void this.options.resources.closeMcp(teardownGeneration)
+    try {
+      this.options.state.setStatus('closed')
+    } finally {
+      this.options.state.publishInterruptedPromptFailures(interruptedPrompts)
+      this.options.transitions.activityChanged()
+    }
+  }
+  shutdown(): void {
+    this.options.resources.shutdownSynchronously(() => {
+      this.options.state.invalidatePendingSessionStartups()
+      this.options.backendGeneration.supersede(this.options.currentGeneration() - 1)
+    })
+    this.options.transitions.resetReconnect()
+    this.options.state.clearSessionProjection()
+    this.options.state.clearContextUsage()
+    this.options.state.clearAppliedSessionModels()
+  }
+  async shutdownForQuit(): Promise<{ reaped: boolean }> {
+    this.candidateTreeKillReaped = true
+    const shutdown = this.options.resources.beginAwaitableShutdown(true)
+    await this.disconnect(false)
+    const outcome = await shutdown.finish()
+    return { reaped: outcome.reaped && this.candidateTreeKillReaped }
+  }
+  async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
+    this.candidateTreeKillReaped = true
+    const shutdown = this.options.resources.beginAwaitableShutdown(false)
+    await this.disconnect(false)
+    const outcome = await shutdown.finish()
+    return { reaped: outcome.reaped && this.candidateTreeKillReaped }
+  }
+  async requestProviderReconnect(): Promise<void> {
+    if (this.options.state.hasContextUsage()) {
+      this.options.state.clearContextUsage()
+      this.options.state.clearAppliedSessionModels()
+      this.options.state.emitState()
+    }
+    await this.options.transitions.requestProviderReconnect()
+  }
+  requestRetirement(): Promise<void> {
+    return this.options.transitions.requestRetirement()
+  }
+  recoverFailedDeferredDisconnect(): void {
+    const teardownGeneration = this.options.resources.supersede()
+    this.options.backendGeneration.supersede(teardownGeneration - 1)
+    void this.options.resources.teardown(teardownGeneration, (stage, error) => {
+      this.reportFailure(`${stage} cleanup after failed deferred disconnect failed`, error)
+    })
+    this.options.state.transitionStatus('closed')
+    try {
+      this.options.state.emitState()
+    } catch (error) {
+      this.reportFailure('emitState after failed deferred disconnect failed', error)
+    }
+  }
+  recordProcessTreeReaped(reaped: boolean): void {
+    this.candidateTreeKillReaped = this.candidateTreeKillReaped && reaped
+  }
+  markExpected(process: ChildProcessWithoutNullStreams): void {
+    this.expectedProcessExits.add(process)
+  }
+  isExpected(process: ChildProcessWithoutNullStreams): boolean {
+    return this.expectedProcessExits.has(process)
+  }
+  private reportFailure(message: string, error: unknown): void {
+    try {
+      this.options.reportFailure(message, error)
+    } catch {
+      // Close ordering and the original failure take precedence over diagnostics.
+    }
+  }
+}
+
+export { AcpConnectionCloseWorkflow }
+export type { AcpConnectionCloseWorkflowOptions, CloseState }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1669,18 +1669,18 @@ describe('ACP runtime session management', () => {
       (runtime: AcpRuntime) =>
         (
           runtime as unknown as {
-            handleConnectionClosed: () => void
+            connectionClose: { handleUnexpectedClose: () => void }
           }
-        ).handleConnectionClosed()
+        ).connectionClose.handleUnexpectedClose()
     ],
     [
       'failed deferred disconnect recovery',
       (runtime: AcpRuntime) =>
         (
           runtime as unknown as {
-            recoverFailedDeferredDisconnect: () => void
+            connectionClose: { recoverFailedDeferredDisconnect: () => void }
           }
-        ).recoverFailedDeferredDisconnect()
+        ).connectionClose.recoverFailedDeferredDisconnect()
     ]
   ] satisfies ReadonlyArray<readonly [string, (runtime: AcpRuntime) => void | Promise<void>]>
 
@@ -8146,8 +8146,10 @@ describe('ACP runtime session management', () => {
     const reviewerCwds = fakeAgent.newSessions.map(({ cwd }) => cwd)
     await runtime.requestProviderReconnect()
     const handleConnectionClosed = (
-      runtime as unknown as { handleConnectionClosed: () => void }
-    ).handleConnectionClosed.bind(runtime)
+      runtime as unknown as { connectionClose: { handleUnexpectedClose: () => void } }
+    ).connectionClose.handleUnexpectedClose.bind(
+      (runtime as unknown as { connectionClose: unknown }).connectionClose
+    )
 
     try {
       expect(handleConnectionClosed).not.toThrow()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -134,6 +134,7 @@ import {
 import { AcpSessionConfigurator, type AcpSessionConfigurationFacts } from './session-configurator'
 import { AcpSessionUpdateProjector, type AcpSessionUpdateEffect } from './session-update-projector'
 import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
+import { AcpConnectionCloseWorkflow, type CloseState } from './connection-close-workflow'
 import {
   AcpTurnSkillOwner,
   type AcpTurnSkillHooks,
@@ -479,8 +480,6 @@ class AcpRuntime {
   private readonly contextUsageTracker: ContextUsageTracker
   private readonly connectionAdapter = new AcpAgentConnectionAdapter()
   private readonly connectionResources: AcpConnectionResourceOwner
-  private candidateTreeKillReaped = true
-  private readonly expectedProcessExits = new WeakSet<ChildProcessWithoutNullStreams>()
   private readonly connectionTransitions: AcpConnectionTransitionOwner
   private readonly generationActivity: AcpGenerationActivityOwner
   // Stable app identities, provider aliases, publication order, selection, and startup/delete
@@ -511,6 +510,7 @@ class AcpRuntime {
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly artifactTurns: ArtifactTurnOwner | undefined
   private readonly promptContentOwner: AcpPromptContentOwner
+  private readonly connectionClose: AcpConnectionCloseWorkflow
   private readonly connectionLifecycle: AcpConnectionLifecycleWorkflow
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
@@ -533,7 +533,7 @@ class AcpRuntime {
       disconnect: (emitClosedStatus) => this.disconnect(emitClosedStatus),
       onRetired: () => this.callbacks.onRetired?.(),
       publishIdle: () => this.setStatus('idle'),
-      recoverFailedDeferredDisconnect: () => this.recoverFailedDeferredDisconnect(),
+      recoverFailedDeferredDisconnect: () => this.connectionClose.recoverFailedDeferredDisconnect(),
       reportFailure: (message, error) => safeLogError(message, errorLogFields(error))
     })
     this.turnSkills = new AcpTurnSkillOwner({
@@ -658,6 +658,75 @@ class AcpRuntime {
       removeStartupBlocker: (token) => this.generationActivity.releaseStartup(token),
       unregisterBridgeSession: (sessionId) =>
         this.connectionResources.unregisterBridgeReviewerSession(sessionId)
+    })
+    const closeState: CloseState = {
+      invalidatePendingSessionStartups: () => this.invalidatePendingSessionStartups(),
+      disposePermissionContext: () => this.permissionContext.dispose(),
+      clearReviewerState: () => this.reviewerSessions.clear(),
+      settleActivePrompts: () => this.sessionInteractions.settleActivePrompts(),
+      supersedeInteractions: () => this.sessionInteractions.supersedeAll(),
+      clearContextUsage: () => this.contextUsageTracker.clear(),
+      clearAppliedSessionModels: () => this.clearAppliedSessionModels(),
+      activeSessionIds: () => this.activeSessionIds(),
+      disposeSessionCapabilities: (sessionIds) => this.sessionCapabilities.dispose(sessionIds),
+      disposeActiveSessions: (recordFailure) => {
+        for (const session of this.activeSessions()) {
+          try {
+            session.dispose()
+          } catch (error) {
+            recordFailure('primary-session', error)
+          }
+        }
+      },
+      detachSessionConnections: (clearPermissionProfile) => {
+        for (const entry of this.sessionRegistry.entries()) {
+          if (entry.attachment) this.sessionRegistry.detach(entry.attachment, 'connection')
+          else entry.aggregate.detachConnection()
+          if (clearPermissionProfile) entry.aggregate.setPermissionProfile(undefined)
+        }
+      },
+      clearPromptContent: () => this.promptContentOwner.clear(),
+      clearHandoffContinuity: () => this.handoffContinuity.clearGeneration(),
+      clearSessionProjection: () => this.sessionUpdateProjector.clearGeneration(),
+      disposeSessionProjection: () => this.sessionUpdateProjector.dispose(),
+      clearHttpRoutes: () => this.sessionCapabilities.clearHttpRoutes(),
+      selectSession: () => this.sessionRegistry.select(undefined),
+      publishInterruptedPromptFailures: (prompts) => {
+        for (const { scope, terminal } of prompts as ReturnType<
+          AcpSessionInteractionOwner['settleActivePrompts']
+        >) {
+          try {
+            this.pushEvent({
+              kind: 'error',
+              level: 'error',
+              providerError: false,
+              sessionId: scope.sessionId,
+              ...(scope.promptMessageId ? { promptMessageId: scope.promptMessageId } : {}),
+              timestamp: terminal.timestamp,
+              title: ACP_PROMPT_FAILED_EVENT_TITLE,
+              text: 'ACP connection closed'
+            })
+          } catch (error) {
+            safeLogError('connection-close prompt event failed', errorLogFields(error))
+          }
+        }
+      },
+      setStatus: (status) => this.setStatus(status),
+      transitionStatus: (status) => this.snapshotOwner.transitionStatus(status),
+      emitState: () => this.emitState(),
+      hasContextUsage: () => this.contextUsageTracker.hasUsage()
+    }
+    this.connectionClose = new AcpConnectionCloseWorkflow({
+      currentGeneration: () => this.connectionGeneration,
+      currentStatus: () => this.snapshotOwner.status,
+      getSnapshot: () => this.getSnapshot(),
+      disconnectCurrent: (emitClosedStatus, generation) =>
+        this.disconnectCurrent(emitClosedStatus, generation),
+      transitions: this.connectionTransitions,
+      resources: this.connectionResources,
+      backendGeneration: this.backendGeneration,
+      state: closeState,
+      reportFailure: (message, error) => safeLogError(message, errorLogFields(error))
     })
     this.connectionLifecycle = new AcpConnectionLifecycleWorkflow({
       appVersion: options.appVersion,
@@ -1969,22 +2038,7 @@ class AcpRuntime {
 
   // Tears down every local session route and closes the underlying agent process.
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
-    return this.connectionTransitions.settleTeardown(async () => {
-      const teardownGeneration = this.connectionResources.supersede()
-      this.invalidatePendingSessionStartups()
-
-      try {
-        return await this.disconnectCurrent(emitClosedStatus, teardownGeneration)
-      } catch (error) {
-        // disconnectCurrent transfers the resource with detach before physical teardown. If it failed
-        // earlier, the owner still holds a live published connection: restore only that exact teardown
-        // epoch so callers retain the pre-refactor recovery behavior. Once detached, rollback is a no-op.
-        this.connectionResources.restorePublished(teardownGeneration)
-        throw error
-      } finally {
-        await this.connectionResources.closeMcp(teardownGeneration)
-      }
-    })
+    return this.connectionClose.disconnect(emitClosedStatus)
   }
 
   // Synchronously terminates the agent child for app shutdown. Electron's `will-quit` cannot await, so
@@ -1992,14 +2046,7 @@ class AcpRuntime {
   // the app is gone would be an orphaned process still holding its network connection open. The OS
   // reclaims the remaining connection/session state as the process exits.
   shutdown(): void {
-    this.connectionResources.shutdownSynchronously(() => {
-      this.invalidatePendingSessionStartups()
-      this.backendGeneration.supersede(this.connectionGeneration - 1)
-    })
-    this.connectionTransitions.resetReconnect()
-    this.sessionUpdateProjector.clearGeneration()
-    this.contextUsageTracker.clear()
-    this.clearAppliedSessionModels()
+    this.connectionClose.shutdown()
   }
 
   // Awaitable quit/relaunch teardown. Latches shuttingDown FIRST so a connect that is mid-spawn when
@@ -2008,18 +2055,7 @@ class AcpRuntime {
   // remains — assigned, connecting, or mid-spawn. Returns { reaped } so the caller can tell a clean
   // teardown from a degraded one (taskkill fallback left grandchildren) before committing to app.exit.
   async shutdownForQuit(): Promise<{ reaped: boolean }> {
-    this.candidateTreeKillReaped = true
-    const shutdown = this.connectionResources.beginAwaitableShutdown(true)
-    // Kill the currently-assigned agent tree right away. Do NOT wait on the in-flight connect first: it
-    // may be stalled on ACP initialize with the child already assigned, and waiting would let
-    // shutdownBackends time out and app.exit orphan it. disconnect() reaps that child's tree and closes
-    // the connection, which also unblocks (rejects) the stalled connect.
-    await this.disconnect(false)
-    // Cover the child that had not been assigned yet when disconnect ran: a connect still mid-spawn hits
-    // the shutting-down check and tree-kills its freshly-spawned child. Await it (swallowing its
-    // rejection, bounded by shutdownBackends' timeout) so that kill completes before we resolve.
-    const outcome = await shutdown.finish()
-    return { reaped: outcome.reaped && this.candidateTreeKillReaped }
+    return this.connectionClose.shutdownForQuit()
   }
 
   // Teardown for the pre-update-install gate. Reaps the current agent tree (so the NSIS installer can
@@ -2033,18 +2069,13 @@ class AcpRuntime {
   // signal (so a degraded reap makes the caller refuse the install); if that await is abandoned on
   // timeout the caller refuses on !completed and the stale-generation self-reap still collects the child.
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
-    this.candidateTreeKillReaped = true
-    const shutdown = this.connectionResources.beginAwaitableShutdown(false)
-    await this.disconnect(false)
-    // Await so the mid-spawn child's kill settles before we report the reaped signal.
-    const outcome = await shutdown.finish()
-    return { reaped: outcome.reaped && this.candidateTreeKillReaped }
+    return this.connectionClose.shutdownForUpdateGate()
   }
 
   // Retires this framework generation without interrupting active turns or background workflows. The
   // coordinator stops routing new work here immediately; teardown waits for every prompt and lease.
   async requestRetirement(): Promise<void> {
-    await this.connectionTransitions.requestRetirement()
+    await this.connectionClose.requestRetirement()
   }
 
   // Applies an active-provider change without interrupting the user. The agent bakes its provider env in
@@ -2052,35 +2083,7 @@ class AcpRuntime {
   // until the session goes idle. Because every provider shares one config dir, the reconnect resumes the
   // conversation on the new provider with full context. Called when the active provider changes.
   async requestProviderReconnect(): Promise<void> {
-    // The selected backend changed even if teardown must wait for an active prompt. Its old context
-    // measurement no longer describes the selected generation, so hide it immediately and let the
-    // replacement generation repopulate usage after reconnect/resume.
-    const contextUsageWasVisible = this.contextUsageTracker.hasUsage()
-    this.contextUsageTracker.clear()
-    if (contextUsageWasVisible) {
-      this.clearAppliedSessionModels()
-      this.emitState()
-    }
-
-    await this.connectionTransitions.requestProviderReconnect()
-  }
-
-  private recoverFailedDeferredDisconnect(): void {
-    // A failed Runtime teardown may still expose the stale connection. Supersede it before releasing
-    // the transition barrier so the next startup must resolve and connect a fresh backend.
-    const teardownGeneration = this.connectionResources.supersede()
-    this.backendGeneration.supersede(teardownGeneration - 1)
-    void this.connectionResources.teardown(teardownGeneration, (stage, cleanupError) => {
-      safeLogError(`${stage} cleanup after failed deferred disconnect failed`, {
-        ...diagnosticErrorFields(cleanupError)
-      })
-    })
-    this.snapshotOwner.transitionStatus('closed')
-    try {
-      this.emitState()
-    } catch (error) {
-      safeLogError('emitState after failed deferred disconnect failed', errorLogFields(error))
-    }
+    await this.connectionClose.requestProviderReconnect()
   }
 
   // Holds this generation across a multi-step background workflow, including gaps with no live session.
@@ -2095,67 +2098,11 @@ class AcpRuntime {
     return this.generationActivity.withOperation(work)
   }
 
-  private async disconnectCurrent(
+  private disconnectCurrent(
     emitClosedStatus = true,
     teardownGeneration = this.connectionGeneration
   ): Promise<AcpStateSnapshot> {
-    let teardownFailed = false
-    let teardownFailure: unknown
-    const recordFailure = (stage: string, error: unknown): void => {
-      if (!teardownFailed) {
-        teardownFailed = true
-        teardownFailure = error
-        return
-      }
-      safeLogError('secondary ACP disconnect cleanup failed', {
-        ...diagnosticErrorFields(error),
-        stage
-      })
-    }
-    const runCleanup = (stage: string, cleanup: () => void): void => {
-      try {
-        cleanup()
-      } catch (error) {
-        recordFailure(stage, error)
-      }
-    }
-
-    runCleanup('permission-context', () => this.permissionContext.dispose())
-    runCleanup('reviewer-state', () => this.reviewerSessions.clear())
-    this.sessionInteractions.supersedeAll()
-    // Context usage belongs to this live agent-context generation. Invalidate it before teardown,
-    // including when a later session.dispose throws. A reconnect may resume the native context or
-    // replay history into a fresh one; only that generation's own usage_update can repopulate it.
-    this.contextUsageTracker.clear()
-    this.clearAppliedSessionModels()
-
-    const activeSessionIds = this.activeSessionIds()
-    const activeSessions = this.activeSessions()
-    this.sessionCapabilities.dispose(activeSessionIds)
-
-    for (const session of activeSessions) {
-      runCleanup('primary-session', () => session.dispose())
-    }
-
-    for (const entry of this.sessionRegistry.entries()) {
-      if (entry.attachment) this.sessionRegistry.detach(entry.attachment, 'connection')
-      else entry.aggregate.detachConnection()
-      entry.aggregate.setPermissionProfile(undefined)
-    }
-    this.promptContentOwner.clear()
-    this.sessionUpdateProjector.clearGeneration()
-    runCleanup('MCP HTTP routes', () => this.sessionCapabilities.clearHttpRoutes())
-    this.sessionRegistry.select(undefined)
-
-    await this.connectionResources.teardown(teardownGeneration, recordFailure)
-
-    if (emitClosedStatus && teardownGeneration === this.connectionGeneration) {
-      runCleanup('closed-status', () => this.setStatus('closed'))
-    }
-
-    this.backendGeneration.supersede(teardownGeneration - 1)
-    if (teardownFailed) throw teardownFailure
-    return this.getSnapshot()
+    return this.connectionClose.disconnectCurrent(emitClosedStatus, teardownGeneration)
   }
 
   private openAgentConnection(
@@ -2186,20 +2133,13 @@ class AcpRuntime {
         )
       },
       onProcessTreeReaped: (reaped) => {
-        this.candidateTreeKillReaped = this.candidateTreeKillReaped && reaped
+        this.connectionClose.recordProcessTreeReaped(reaped)
       },
-      markProcessExitExpected: (process) => this.expectedProcessExits.add(process),
+      markProcessExitExpected: (process) => this.connectionClose.markExpected(process),
       onProcessStderr: (text, context) => this.handleAgentProcessStderr(text, context),
       onProcessError: (error, context) => this.handleAgentProcessError(error, context),
       onProcessExit: (code, signal, context) => this.handleAgentProcessExit(code, signal, context),
-      onConnectionClosed: () => {
-        if (
-          this.snapshotOwner.status === 'connected' ||
-          this.snapshotOwner.status === 'connecting'
-        ) {
-          this.handleConnectionClosed()
-        }
-      },
+      onConnectionClosed: () => this.connectionClose.handleUnexpectedClose(),
       reportCleanupFailure: (stage, error, framework, epoch) => {
         if (stage === 'bridge-lease') {
           safeLogError('responses bridge lease release failed', errorLogFields(error))
@@ -3617,7 +3557,7 @@ class AcpRuntime {
     process: ChildProcessWithoutNullStreams,
     epoch: number
   ): ReturnType<AcpConnectionResourceOwner['processEventDisposition']> {
-    if (this.expectedProcessExits.has(process)) return 'expected'
+    if (this.connectionClose.isExpected(process)) return 'expected'
     return this.connectionResources.processEventDisposition(process, epoch)
   }
 
@@ -3698,58 +3638,6 @@ class AcpRuntime {
         title: 'Agent process exited',
         text: signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`
       })
-    }
-  }
-
-  // Clears local state after the protocol connection closes unexpectedly.
-  private handleConnectionClosed(): void {
-    const teardownGeneration = this.connectionGeneration
-    const interruptedPrompts = this.sessionInteractions.settleActivePrompts()
-    this.invalidatePendingSessionStartups()
-    this.permissionContext.dispose()
-    this.reviewerSessions.clear()
-    this.connectionResources.cleanupUnexpectedClose(teardownGeneration)
-    this.backendGeneration.supersede(teardownGeneration)
-    this.sessionCapabilities.dispose(this.activeSessionIds())
-    for (const entry of this.sessionRegistry.entries()) {
-      if (entry.attachment) this.sessionRegistry.detach(entry.attachment, 'connection')
-      else entry.aggregate.detachConnection()
-    }
-    this.promptContentOwner.clear()
-    this.handoffContinuity.clearGeneration()
-    this.sessionUpdateProjector.dispose()
-    this.contextUsageTracker.clear()
-    this.sessionCapabilities.clearHttpRoutes()
-    this.sessionRegistry.select(undefined)
-    this.sessionInteractions.supersedeAll()
-    // The connection is already gone, so any ensureConnected caller waiting on
-    // the reconnect barrier must unblock now — it will fall through to connect()
-    // and pick up the new backend from resolveBackend. A fresh spawn re-provisions
-    // skills too, so clear both pending flags to avoid a spurious later reconnect.
-    this.connectionTransitions.resetReconnect()
-    void this.connectionResources.closeMcp(teardownGeneration)
-    try {
-      this.setStatus('closed')
-    } finally {
-      for (const { scope, terminal } of interruptedPrompts) {
-        try {
-          this.pushEvent({
-            kind: 'error',
-            level: 'error',
-            providerError: false,
-            sessionId: scope.sessionId,
-            ...(scope.promptMessageId ? { promptMessageId: scope.promptMessageId } : {}),
-            timestamp: terminal.timestamp,
-            title: ACP_PROMPT_FAILED_EVENT_TITLE,
-            text: 'ACP connection closed'
-          })
-        } catch (error) {
-          safeLogError('connection-close prompt event failed', errorLogFields(error))
-        }
-      }
-      // An unexpected close satisfies any pending reconnect, but retirement remains terminal. Re-run
-      // its evaluator now and again when outstanding operation/activity leases drain.
-      this.connectionTransitions.activityChanged()
     }
   }
 


### PR DESCRIPTION
## Problem

ACP Runtime still owned sequencing for expected and unexpected connection close, shutdown, reconnect, retirement, and deferred reconnect recovery.

Related: #458 (forward-compatibility constraint only; this PR added no orchestration data model or public interface).

## Proposed change

Extract that sequencing into `AcpConnectionCloseWorkflow`. Runtime supplies narrow state hooks while retaining the existing state/resource-owner boundaries.

## Scope and non-goals

- Only ACP close workflow, Runtime delegation, and tests changed.
- Adapter, owner implementations, composition/coordinator, IPC, transports, schema, persisted data, and Electron/Web/CLI/Task contracts remained unchanged.
- Production raw: **500** (approved cap: 550).

## Ownership and sequence

```mermaid
flowchart LR
  R[AcpRuntime: narrow close-state hooks] --> W[AcpConnectionCloseWorkflow: sequencing]
  W --> T[TransitionOwner: intent / barrier]
  W --> O[ResourceOwner: physical teardown]
  W --> G[BackendGenerationOwner: generation / secrets]
  W --> A[ActivityOwner: operation state]
```

The workflow owns close/shutdown/reconnect sequencing only. Each existing owner remains authoritative for its state or physical resource; Runtime retains the application cleanup hooks supplied to the workflow.

## Acceptance criteria and validation

The retained command-level evidence maps the affected behaviors as follows:

- Expected/unexpected close ordering, shutdown reap aggregation, reconnect intent/barrier, retirement, owner delegation, and Runtime integration -> `rtk npm run typecheck:node && rtk npm test -- --run src/main/acp/connection-close-workflow.test.ts src/main/acp/connection-lifecycle-workflow.test.ts src/main/acp/connection-resource-owner.test.ts src/main/acp/connection-transition-owner.test.ts src/main/acp/backend-generation-owner.test.ts src/main/acp/generation-activity-owner.test.ts src/main/acp/runtime.test.ts` -> **Node typecheck passed; 442 runnable tests passed, while 3 Runtime loopback tests hit sandbox `listen EPERM`**.
- Source lint after the final formatting edit -> `rtk npm run lint` -> **passed with 0 errors and 17 retained baseline warnings**.
- Changed-file formatting -> `npx prettier --check src/main/acp/connection-close-workflow.ts src/main/acp/connection-close-workflow.test.ts src/main/acp/runtime.test.ts src/main/acp/runtime.ts` (recorded as the check portion of the final formatting command) -> **passed**.
- Diff integrity -> `git diff --check` -> **passed**.
- Complete portable suite with local transport permission -> `rtk npm test` -> **759 files passed, 14 skipped; 11,224 tests passed, 184 skipped**.
- Independent review -> **Standards and Spec reviews recorded no hard issues**.
- Final online gates -> GitHub records **PR Gate, Unit tests, Static checks, Coverage macOS, macOS build and E2E, Windows E2E, CodeQL, and final-head AI review workflow success**; the final AI comment records mergeable with no actionable findings.

The focused run's three sandbox failures are not presented as passes; the later authorized complete suite and successful online platform lanes are the evidence for those transport-dependent paths. The retained record states the complete suite ran after the last material edit.

## Review focus

- No duplicate owner state or cleanup path.
- Expected/unexpected close order and shutdown reap aggregation.
- Stale close events cannot regress a successor generation.
- No Permission, Specialist, Compute, or cross-surface behavior change.

## Uncovered risks

- No single local OS lane reproduces every packaging/E2E variant; the successful macOS/Windows PR lanes are the retained cross-platform evidence.
- This historical normalization cannot strengthen evidence beyond the stored command outputs and GitHub check history.

