### PR TITLE
feat(agent-runtime): hot-switch ACP models and providers

### DIFF
--- a/src/main/acp/agent-connection-adapter.test.ts
+++ b/src/main/acp/agent-connection-adapter.test.ts
@@ -153,9 +153,11 @@ describe('AcpAgentConnectionAdapter', () => {
     expect(connectionHooks.markProcessExitExpected).toHaveBeenCalledWith(process, 1)
   })
 
-  it('reaps an untransferred process tree and releases its bridge lease exactly once', async () => {
+  it('reaps an untransferred process tree and releases every transport lease exactly once', async () => {
     const process = new FakeAgentProcess()
-    const release = vi.fn(async () => undefined)
+    const releaseBridge = vi.fn(async () => undefined)
+    const releaseAnthropic = vi.fn(async () => undefined)
+    const releaseProviderTransport = vi.fn(async () => undefined)
     const backend: ResolvedAgentBackend = {
       framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
       executablePath: '/bin/agent',
@@ -164,7 +166,15 @@ describe('AcpAgentConnectionAdapter', () => {
         selectSkills: vi.fn(async () => []),
         registerReviewerSession: vi.fn(),
         unregisterReviewerSession: vi.fn(() => false),
-        release
+        release: releaseBridge
+      },
+      anthropicBridgeLease: {
+        setTarget: vi.fn(() => true),
+        release: releaseAnthropic
+      },
+      providerTransportLease: {
+        setTarget: vi.fn(() => true),
+        release: releaseProviderTransport
       }
     }
     const candidate = await openCandidate(process, backend)
@@ -174,7 +184,9 @@ describe('AcpAgentConnectionAdapter', () => {
 
     expect(terminateProcessTree).toHaveBeenCalledOnce()
     expect(terminateProcessTree.mock.calls[0]?.[0]).toBe(process)
-    expect(release).toHaveBeenCalledOnce()
+    expect(releaseBridge).toHaveBeenCalledOnce()
+    expect(releaseAnthropic).toHaveBeenCalledOnce()
+    expect(releaseProviderTransport).toHaveBeenCalledOnce()
   })
 
   it('rejects a transfer to a different owner epoch without consuming the candidate', async () => {
@@ -198,7 +210,9 @@ describe('AcpAgentConnectionAdapter', () => {
 
   it('transfers once without exposing resources and leaves teardown solely to the owner', async () => {
     const process = new FakeAgentProcess()
-    const release = vi.fn(async () => undefined)
+    const releaseBridge = vi.fn(async () => undefined)
+    const releaseAnthropic = vi.fn(async () => undefined)
+    const releaseProviderTransport = vi.fn(async () => undefined)
     const owner = new AcpConnectionResourceOwner()
     let candidateDispose: (() => Promise<void>) | undefined
     await owner.connect(async (attempt) => {
@@ -210,7 +224,15 @@ describe('AcpAgentConnectionAdapter', () => {
           selectSkills: vi.fn(async () => []),
           registerReviewerSession: vi.fn(),
           unregisterReviewerSession: vi.fn(() => false),
-          release
+          release: releaseBridge
+        },
+        anthropicBridgeLease: {
+          setTarget: vi.fn(() => true),
+          release: releaseAnthropic
+        },
+        providerTransportLease: {
+          setTarget: vi.fn(() => true),
+          release: releaseProviderTransport
         }
       })
       candidateDispose = candidate.dispose
@@ -233,17 +255,23 @@ describe('AcpAgentConnectionAdapter', () => {
       await candidate.dispose()
 
       expect(terminateProcessTree).not.toHaveBeenCalled()
-      expect(release).not.toHaveBeenCalled()
+      expect(releaseBridge).not.toHaveBeenCalled()
+      expect(releaseAnthropic).not.toHaveBeenCalled()
+      expect(releaseProviderTransport).not.toHaveBeenCalled()
       return attempt.publish({ close: false, delete: false, resume: false })
     })
 
     await candidateDispose?.()
     expect(terminateProcessTree).not.toHaveBeenCalled()
-    expect(release).not.toHaveBeenCalled()
+    expect(releaseBridge).not.toHaveBeenCalled()
+    expect(releaseAnthropic).not.toHaveBeenCalled()
+    expect(releaseProviderTransport).not.toHaveBeenCalled()
 
     await owner.teardown(owner.epoch)
     expect(terminateProcessTree).toHaveBeenCalledOnce()
-    expect(release).toHaveBeenCalledOnce()
+    expect(releaseBridge).toHaveBeenCalledOnce()
+    expect(releaseAnthropic).toHaveBeenCalledOnce()
+    expect(releaseProviderTransport).toHaveBeenCalledOnce()
   })
 
   it('retains cleanup ownership when the resource owner rejects transfer', async () => {

--- a/src/main/acp/agent-connection-adapter.ts
+++ b/src/main/acp/agent-connection-adapter.ts
@@ -22,7 +22,12 @@ import type { AcpConnectionResourceAttempt } from './connection-resource-owner'
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 
 type ResponsesBridgeLease = ResolvedAgentBackend['responsesBridgeLease']
-type CandidateCleanupStage = 'connection' | 'agent-process' | 'bridge-lease'
+type AnthropicBridgeLease = ResolvedAgentBackend['anthropicBridgeLease']
+type CandidateCleanupStage =
+  | 'connection'
+  | 'agent-process'
+  | 'bridge-lease'
+  | 'anthropic-bridge-lease'
 type AcpProcessEventContext = Readonly<{
   process: ChildProcessWithoutNullStreams
   framework: AgentFramework['id']
@@ -97,6 +102,7 @@ class AcpAgentConnectionAdapter {
     let process: ChildProcessWithoutNullStreams | undefined
     let connection: ReturnType<AcpAgentConnectionAdapter['createClientConnection']> | undefined
     let bridgeLease: ResponsesBridgeLease
+    let anthropicBridgeLease: AnthropicBridgeLease
     let backendAttempt: AcpBackendGenerationAttempt | undefined
     let framework: AgentFramework['id'] = 'claude-code'
 
@@ -131,12 +137,20 @@ class AcpAgentConnectionAdapter {
           reportCleanupFailure('bridge-lease', error)
         }
       }
+      if (anthropicBridgeLease) {
+        try {
+          await anthropicBridgeLease.release()
+        } catch (error) {
+          reportCleanupFailure('anthropic-bridge-lease', error)
+        }
+      }
     }
 
     try {
       const backend = await input.resolveBackend()
       framework = backend.framework.id
       bridgeLease = backend.responsesBridgeLease
+      anthropicBridgeLease = backend.anthropicBridgeLease
       backendAttempt = input.prepareBackend(backend)
       hooks.onBackendResolved(framework)
       process = input.spawnAgent
@@ -206,7 +220,8 @@ class AcpAgentConnectionAdapter {
           process: openedProcess,
           connection: openedConnection,
           framework,
-          bridgeLease
+          bridgeLease,
+          anthropicBridgeLease
         })
         state = 'transferred'
         openedConnection.closed.then(() => {

--- a/src/main/acp/agent-connection-adapter.ts
+++ b/src/main/acp/agent-connection-adapter.ts
@@ -23,11 +23,13 @@ import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 
 type ResponsesBridgeLease = ResolvedAgentBackend['responsesBridgeLease']
 type AnthropicBridgeLease = ResolvedAgentBackend['anthropicBridgeLease']
+type ProviderTransportLease = ResolvedAgentBackend['providerTransportLease']
 type CandidateCleanupStage =
   | 'connection'
   | 'agent-process'
   | 'bridge-lease'
   | 'anthropic-bridge-lease'
+  | 'provider-transport-lease'
 type AcpProcessEventContext = Readonly<{
   process: ChildProcessWithoutNullStreams
   framework: AgentFramework['id']
@@ -103,6 +105,7 @@ class AcpAgentConnectionAdapter {
     let connection: ReturnType<AcpAgentConnectionAdapter['createClientConnection']> | undefined
     let bridgeLease: ResponsesBridgeLease
     let anthropicBridgeLease: AnthropicBridgeLease
+    let providerTransportLease: ProviderTransportLease
     let backendAttempt: AcpBackendGenerationAttempt | undefined
     let framework: AgentFramework['id'] = 'claude-code'
 
@@ -144,6 +147,13 @@ class AcpAgentConnectionAdapter {
           reportCleanupFailure('anthropic-bridge-lease', error)
         }
       }
+      if (providerTransportLease) {
+        try {
+          await providerTransportLease.release()
+        } catch (error) {
+          reportCleanupFailure('provider-transport-lease', error)
+        }
+      }
     }
 
     try {
@@ -151,6 +161,7 @@ class AcpAgentConnectionAdapter {
       framework = backend.framework.id
       bridgeLease = backend.responsesBridgeLease
       anthropicBridgeLease = backend.anthropicBridgeLease
+      providerTransportLease = backend.providerTransportLease
       backendAttempt = input.prepareBackend(backend)
       hooks.onBackendResolved(framework)
       process = input.spawnAgent
@@ -221,7 +232,8 @@ class AcpAgentConnectionAdapter {
           connection: openedConnection,
           framework,
           bridgeLease,
-          anthropicBridgeLease
+          anthropicBridgeLease,
+          providerTransportLease
         })
         state = 'transferred'
         openedConnection.closed.then(() => {

--- a/src/main/acp/backend-generation-owner.test.ts
+++ b/src/main/acp/backend-generation-owner.test.ts
@@ -23,6 +23,7 @@ describe('AcpBackendGenerationOwner', () => {
         systemPromptAppends,
         persistentSystemPrompt: 'Stable instructions.',
         contextWindow: 1_000_000,
+        supportsImageInput: true,
         contextUsageModel: 'provider-model',
         authentication: { methodId: 'codex-login' },
         providerConfiguration: {
@@ -58,7 +59,7 @@ describe('AcpBackendGenerationOwner', () => {
         systemPromptAppends: ['Use the app tools.'],
         persistentSystemPrompt: 'Stable instructions.'
       },
-      context: { window: 1_000_000, model: 'provider-model' },
+      context: { window: 1_000_000, model: 'provider-model', supportsImageInput: true },
       adapter: {
         codexHome: '/data/codex',
         nativeMcpEnabled: false,

--- a/src/main/acp/backend-generation-owner.ts
+++ b/src/main/acp/backend-generation-owner.ts
@@ -154,6 +154,7 @@ export class AcpBackendGenerationOwner {
     else session.effort = target.reasoningEffort
     this.currentView = Object.freeze({
       ...this.currentView,
+      backendId: target.backendId,
       modelRoute: target.route,
       session: Object.freeze(session),
       context: Object.freeze({

--- a/src/main/acp/backend-generation-owner.ts
+++ b/src/main/acp/backend-generation-owner.ts
@@ -28,6 +28,7 @@ export type AcpBackendGenerationView = Readonly<{
   context: Readonly<{
     window?: number
     model?: string
+    supportsImageInput: boolean
   }>
   adapter: Readonly<{
     codexHome?: string
@@ -92,7 +93,8 @@ const generationView = (backend: ResolvedAgentBackend): AcpBackendGenerationView
     }),
     context: Object.freeze({
       ...(backend.contextWindow ? { window: backend.contextWindow } : {}),
-      ...(backend.contextUsageModel ? { model: backend.contextUsageModel } : {})
+      ...(backend.contextUsageModel ? { model: backend.contextUsageModel } : {}),
+      supportsImageInput: backend.supportsImageInput === true
     }),
     adapter: Object.freeze({
       ...(codexHome ? { codexHome } : {}),
@@ -156,7 +158,8 @@ export class AcpBackendGenerationOwner {
       session: Object.freeze(session),
       context: Object.freeze({
         model: target.model,
-        ...(target.contextWindow ? { window: target.contextWindow } : {})
+        ...(target.contextWindow ? { window: target.contextWindow } : {}),
+        supportsImageInput: target.supportsImageInput
       })
     })
     return this.currentView

--- a/src/main/acp/backend-generation-owner.ts
+++ b/src/main/acp/backend-generation-owner.ts
@@ -1,5 +1,10 @@
 import type { ModelReasoningEffort, ResolvedReasoningEffort } from '../../shared/reasoning-effort'
-import type { AgentFramework, ResolvedAgentBackend } from '../agent-framework'
+import type {
+  AgentFramework,
+  AgentModelChangeTarget,
+  AgentModelRoute,
+  ResolvedAgentBackend
+} from '../agent-framework'
 
 type AcpBackendGenerationAttemptIdentity = Readonly<{
   epoch: number
@@ -9,6 +14,7 @@ type AcpBackendGenerationAttemptIdentity = Readonly<{
 export type AcpBackendGenerationView = Readonly<{
   framework: AgentFramework
   backendId?: string
+  modelRoute?: AgentModelRoute
   session: Readonly<{
     model?: string
     modelRequired: boolean
@@ -69,6 +75,7 @@ const generationView = (backend: ResolvedAgentBackend): AcpBackendGenerationView
   return Object.freeze({
     framework: backend.framework,
     ...(backend.backendId ? { backendId: backend.backendId } : {}),
+    ...(backend.modelRoute ? { modelRoute: backend.modelRoute } : {}),
     session: Object.freeze({
       ...(backend.sessionModel ? { model: backend.sessionModel } : {}),
       modelRequired: backend.sessionModelRequired ?? false,
@@ -131,6 +138,26 @@ export class AcpBackendGenerationOwner {
     this.currentView = Object.freeze({
       ...this.currentView,
       session: Object.freeze(session)
+    })
+    return this.currentView
+  }
+
+  updateModel(target: AgentModelChangeTarget): AcpBackendGenerationView {
+    const session = {
+      ...this.currentView.session,
+      model: target.sessionModel,
+      modelRequired: target.sessionModelRequired
+    }
+    if (target.reasoningEffort === 'default') delete session.effort
+    else session.effort = target.reasoningEffort
+    this.currentView = Object.freeze({
+      ...this.currentView,
+      modelRoute: target.route,
+      session: Object.freeze(session),
+      context: Object.freeze({
+        model: target.model,
+        ...(target.contextWindow ? { window: target.contextWindow } : {})
+      })
     })
     return this.currentView
   }

--- a/src/main/acp/connection-close-workflow.test.ts
+++ b/src/main/acp/connection-close-workflow.test.ts
@@ -11,6 +11,7 @@ type TestHarness = {
   state: Record<string, ReturnType<typeof vi.fn>>
   resources: Record<string, ReturnType<typeof vi.fn>>
   transitions: Record<string, ReturnType<typeof vi.fn>>
+  modelChanges: Record<string, ReturnType<typeof vi.fn>>
 }
 
 const createWorkflow = (overrides: Record<string, unknown> = {}): TestHarness => {
@@ -59,8 +60,18 @@ const createWorkflow = (overrides: Record<string, unknown> = {}): TestHarness =>
     settleTeardown: vi.fn(async <T>(teardown: () => Promise<T>) => teardown()),
     resetReconnect: vi.fn(),
     activityChanged: vi.fn(),
-    requestProviderReconnect: vi.fn(async () => undefined),
-    requestRetirement: vi.fn(async () => undefined)
+    requestProviderReconnect: vi.fn(async () => {
+      actions.push('provider-reconnect')
+    }),
+    requestRetirement: vi.fn(async () => {
+      actions.push('retirement')
+    })
+  }
+  const modelChanges = {
+    cancel: vi.fn(() => actions.push('model-cancel')),
+    cancelAndDrain: vi.fn(async () => {
+      actions.push('model-drain')
+    })
   }
   const workflow = new AcpConnectionCloseWorkflow({
     currentGeneration: () => generation,
@@ -68,6 +79,7 @@ const createWorkflow = (overrides: Record<string, unknown> = {}): TestHarness =>
     getSnapshot: () => snapshot,
     transitions,
     resources,
+    modelChanges,
     backendGeneration: {
       supersede: vi.fn((throughEpoch: number) => actions.push(`backend:${throughEpoch}`))
     },
@@ -75,7 +87,15 @@ const createWorkflow = (overrides: Record<string, unknown> = {}): TestHarness =>
     reportFailure: vi.fn(),
     ...overrides
   } as never)
-  return { workflow, actions, generation: () => generation, state, resources, transitions }
+  return {
+    workflow,
+    actions,
+    generation: () => generation,
+    state,
+    resources,
+    transitions,
+    modelChanges
+  }
 }
 
 describe('AcpConnectionCloseWorkflow', () => {
@@ -89,6 +109,7 @@ describe('AcpConnectionCloseWorkflow', () => {
     expect(resources.teardown).toHaveBeenCalledOnce()
     expect(resources.closeMcp).toHaveBeenCalledOnce()
     expect(actions).toEqual([
+      'model-cancel',
       'invalidate',
       'permission',
       'reviewer',
@@ -118,6 +139,7 @@ describe('AcpConnectionCloseWorkflow', () => {
     expect(transitions.resetReconnect).toHaveBeenCalledOnce()
     expect(transitions.activityChanged).toHaveBeenCalledOnce()
     expect(actions).toEqual([
+      'model-cancel',
       'invalidate',
       'permission',
       'reviewer',
@@ -150,13 +172,25 @@ describe('AcpConnectionCloseWorkflow', () => {
   })
 
   it('clears usage before deferring provider reconnect and delegates intent ownership', async () => {
-    const { workflow, state, transitions } = createWorkflow()
+    const { workflow, actions, state, transitions, modelChanges } = createWorkflow()
 
     await workflow.requestProviderReconnect()
 
+    expect(modelChanges.cancelAndDrain).toHaveBeenCalledOnce()
     expect(state.clearContextUsage).toHaveBeenCalledOnce()
     expect(state.clearAppliedSessionModels).toHaveBeenCalledOnce()
     expect(state.emitState).toHaveBeenCalledOnce()
     expect(transitions.requestProviderReconnect).toHaveBeenCalledOnce()
+    expect(actions).toEqual(['model-drain', 'usage', 'models', 'emit', 'provider-reconnect'])
+  })
+
+  it('drains model changes before delegating retirement intent', async () => {
+    const { workflow, actions, transitions, modelChanges } = createWorkflow()
+
+    await workflow.requestRetirement()
+
+    expect(modelChanges.cancelAndDrain).toHaveBeenCalledOnce()
+    expect(transitions.requestRetirement).toHaveBeenCalledOnce()
+    expect(actions).toEqual(['model-drain', 'retirement'])
   })
 })

--- a/src/main/acp/connection-close-workflow.ts
+++ b/src/main/acp/connection-close-workflow.ts
@@ -3,6 +3,7 @@ import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import type { AcpBackendGenerationOwner } from './backend-generation-owner'
 import type { AcpConnectionResourceOwner } from './connection-resource-owner'
 import type { AcpConnectionTransitionOwner } from './connection-transition-owner'
+import type { AcpModelChangeWorkflow } from './model-change-workflow'
 type CleanupFailure = (stage: string, error: unknown) => void
 type CloseStatus = AcpStateSnapshot['status']
 type DisconnectCurrent = (...args: [boolean, number]) => Promise<AcpStateSnapshot>
@@ -54,6 +55,7 @@ type AcpConnectionCloseWorkflowOptions = Readonly<{
     | 'beginAwaitableShutdown'
   >
   backendGeneration: Pick<AcpBackendGenerationOwner, 'supersede'>
+  modelChanges: Pick<AcpModelChangeWorkflow, 'cancel' | 'cancelAndDrain'>
   state: CloseState
   reportFailure: (message: string, error: unknown) => void
 }>
@@ -62,6 +64,7 @@ class AcpConnectionCloseWorkflow {
   private readonly expectedProcessExits = new WeakSet<ChildProcessWithoutNullStreams>()
   constructor(private readonly options: AcpConnectionCloseWorkflowOptions) {}
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
+    this.options.modelChanges.cancel()
     return this.options.transitions.settleTeardown(async () => {
       const teardownGeneration = this.options.resources.supersede()
       this.options.state.invalidatePendingSessionStartups()
@@ -125,6 +128,7 @@ class AcpConnectionCloseWorkflow {
     ) {
       return
     }
+    this.options.modelChanges.cancel()
     const teardownGeneration = this.options.currentGeneration()
     const interruptedPrompts = this.options.state.settleActivePrompts()
     this.options.state.invalidatePendingSessionStartups()
@@ -151,6 +155,7 @@ class AcpConnectionCloseWorkflow {
     }
   }
   shutdown(): void {
+    this.options.modelChanges.cancel()
     this.options.resources.shutdownSynchronously(() => {
       this.options.state.invalidatePendingSessionStartups()
       this.options.backendGeneration.supersede(this.options.currentGeneration() - 1)
@@ -175,6 +180,7 @@ class AcpConnectionCloseWorkflow {
     return { reaped: outcome.reaped && this.candidateTreeKillReaped }
   }
   async requestProviderReconnect(): Promise<void> {
+    await this.options.modelChanges.cancelAndDrain()
     if (this.options.state.hasContextUsage()) {
       this.options.state.clearContextUsage()
       this.options.state.clearAppliedSessionModels()
@@ -182,8 +188,9 @@ class AcpConnectionCloseWorkflow {
     }
     await this.options.transitions.requestProviderReconnect()
   }
-  requestRetirement(): Promise<void> {
-    return this.options.transitions.requestRetirement()
+  async requestRetirement(): Promise<void> {
+    await this.options.modelChanges.cancelAndDrain()
+    await this.options.transitions.requestRetirement()
   }
   recoverFailedDeferredDisconnect(): void {
     const teardownGeneration = this.options.resources.supersede()

--- a/src/main/acp/connection-resource-owner.test.ts
+++ b/src/main/acp/connection-resource-owner.test.ts
@@ -284,6 +284,31 @@ describe('AcpConnectionResourceOwner', () => {
     expect(release).toHaveBeenCalledOnce()
   })
 
+  it('selects and releases the generation-scoped provider transport', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const setTarget = vi.fn(() => true)
+    const release = vi.fn(async () => undefined)
+    await owner.connect(async (attempt) => {
+      attempt.attach({
+        process: process('provider-transport'),
+        connection: { close: vi.fn() } as unknown as ClientConnection,
+        framework: 'opencode',
+        bridgeLease: undefined,
+        providerTransportLease: { setTarget, release }
+      })
+      return attempt.publish({ close: true, delete: false, resume: true })
+    })
+
+    expect(owner.providerTransportAvailable).toBe(true)
+    expect(owner.setProviderTransportTarget('provider-b/model-b')).toBe(true)
+    expect(setTarget).toHaveBeenCalledWith('provider-b/model-b')
+
+    await owner.teardown(owner.supersede(), vi.fn())
+
+    expect(owner.providerTransportAvailable).toBe(false)
+    expect(release).toHaveBeenCalledOnce()
+  })
+
   it('keeps synchronous shutdown terminal when close and kill both throw', async () => {
     const owner = new AcpConnectionResourceOwner()
     const close = vi.fn(() => {

--- a/src/main/acp/connection-resource-owner.test.ts
+++ b/src/main/acp/connection-resource-owner.test.ts
@@ -258,6 +258,32 @@ describe('AcpConnectionResourceOwner', () => {
     expect(release).toHaveBeenCalledOnce()
   })
 
+  it('retargets and releases the generation-scoped Anthropic bridge', async () => {
+    const owner = new AcpConnectionResourceOwner()
+    const setTarget = vi.fn(() => true)
+    const release = vi.fn(async () => undefined)
+    await owner.connect(async (attempt) => {
+      attempt.attach({
+        process: process('anthropic-bridge'),
+        connection: { close: vi.fn() } as unknown as ClientConnection,
+        framework: 'claude-code',
+        bridgeLease: undefined,
+        anthropicBridgeLease: { setTarget, release }
+      })
+      return attempt.publish({ close: true, delete: false, resume: true })
+    })
+
+    expect(owner.anthropicBridgeAvailable).toBe(true)
+    expect(owner.setAnthropicBridgeTarget('kimi/kimi-k3')).toBe(true)
+    expect(setTarget).toHaveBeenCalledWith('kimi/kimi-k3')
+
+    const teardownEpoch = owner.supersede()
+    await owner.teardown(teardownEpoch, vi.fn())
+
+    expect(owner.anthropicBridgeAvailable).toBe(false)
+    expect(release).toHaveBeenCalledOnce()
+  })
+
   it('keeps synchronous shutdown terminal when close and kill both throw', async () => {
     const owner = new AcpConnectionResourceOwner()
     const close = vi.fn(() => {

--- a/src/main/acp/connection-resource-owner.ts
+++ b/src/main/acp/connection-resource-owner.ts
@@ -7,6 +7,7 @@ import { terminateProcessTree } from '../process-tree'
 
 type ResponsesBridgeLease = ResolvedAgentBackend['responsesBridgeLease']
 type AnthropicBridgeLease = ResolvedAgentBackend['anthropicBridgeLease']
+type ProviderTransportLease = ResolvedAgentBackend['providerTransportLease']
 type CleanupFailure = (stage: 'connection' | 'agent-process', error: unknown) => void
 
 const log = createLogger('acp')
@@ -30,6 +31,7 @@ export type AcpAttachedConnectionResource = {
   framework: AgentFramework['id']
   bridgeLease: ResponsesBridgeLease
   anthropicBridgeLease?: AnthropicBridgeLease
+  providerTransportLease?: ProviderTransportLease
 }
 
 export type AcpConnectionResourceReadyHandle = Readonly<{
@@ -53,6 +55,7 @@ export type AcpUnattachedConnectionResource = Readonly<{
   connection?: ClientConnection
   bridgeLease?: ResponsesBridgeLease
   anthropicBridgeLease?: AnthropicBridgeLease
+  providerTransportLease?: ProviderTransportLease
 }>
 
 export type AcpConnectionShutdownHandle = Readonly<{
@@ -106,6 +109,10 @@ export class AcpConnectionResourceOwner {
 
   get anthropicBridgeAvailable(): boolean {
     return Boolean(this.currentResource()?.anthropicBridgeLease)
+  }
+
+  get providerTransportAvailable(): boolean {
+    return Boolean(this.currentResource()?.providerTransportLease)
   }
 
   get isShuttingDown(): boolean {
@@ -177,6 +184,7 @@ export class AcpConnectionResourceOwner {
     }
     await this.releaseBridgeLease(resource.bridgeLease)
     await this.releaseAnthropicBridgeLease(resource.anthropicBridgeLease)
+    await this.releaseProviderTransportLease(resource.providerTransportLease)
   }
 
   async cleanupUnattached(
@@ -200,6 +208,7 @@ export class AcpConnectionResourceOwner {
     }
     await this.releaseBridgeLease(resource.bridgeLease)
     await this.releaseAnthropicBridgeLease(resource.anthropicBridgeLease)
+    await this.releaseProviderTransportLease(resource.providerTransportLease)
   }
 
   cleanupUnexpectedClose(expectedEpoch: number): void {
@@ -211,6 +220,7 @@ export class AcpConnectionResourceOwner {
     })
     void this.releaseBridgeLease(resource.bridgeLease)
     void this.releaseAnthropicBridgeLease(resource.anthropicBridgeLease)
+    void this.releaseProviderTransportLease(resource.providerTransportLease)
   }
 
   shutdownSynchronously(onSuperseded: () => void): void {
@@ -235,6 +245,7 @@ export class AcpConnectionResourceOwner {
       }
       void this.releaseBridgeLease(resource?.bridgeLease)
       void this.releaseAnthropicBridgeLease(resource?.anthropicBridgeLease)
+      void this.releaseProviderTransportLease(resource?.providerTransportLease)
       void this.closeMcp()
     }
   }
@@ -317,6 +328,10 @@ export class AcpConnectionResourceOwner {
     return this.currentResource()?.anthropicBridgeLease?.setTarget(targetId) ?? false
   }
 
+  setProviderTransportTarget(targetId: string): boolean {
+    return this.currentResource()?.providerTransportLease?.setTarget(targetId) ?? false
+  }
+
   async selectBridgeSkills(
     text: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[0],
     catalog: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[1],
@@ -348,6 +363,16 @@ export class AcpConnectionResourceOwner {
       await lease.release()
     } catch (error) {
       safeLogCleanupError('Anthropic bridge lease release failed', error)
+    }
+  }
+
+  private async releaseProviderTransportLease(lease: ProviderTransportLease): Promise<void> {
+    if (!lease || this.releasedBridgeLeases.has(lease)) return
+    this.releasedBridgeLeases.add(lease)
+    try {
+      await lease.release()
+    } catch (error) {
+      safeLogCleanupError('provider transport lease release failed', error)
     }
   }
 

--- a/src/main/acp/connection-resource-owner.ts
+++ b/src/main/acp/connection-resource-owner.ts
@@ -293,6 +293,15 @@ export class AcpConnectionResourceOwner {
     this.currentResource()?.bridgeLease?.setReasoningEffort?.(effort)
   }
 
+  setBridgeModelTarget(
+    target: Parameters<NonNullable<NonNullable<ResponsesBridgeLease>['setModelTarget']>>[0]
+  ): boolean {
+    const setModelTarget = this.currentResource()?.bridgeLease?.setModelTarget
+    if (!setModelTarget) return false
+    setModelTarget(target)
+    return true
+  }
+
   async selectBridgeSkills(
     text: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[0],
     catalog: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[1],

--- a/src/main/acp/connection-resource-owner.ts
+++ b/src/main/acp/connection-resource-owner.ts
@@ -6,6 +6,7 @@ import { createLogger, errorLogFields } from '../logger'
 import { terminateProcessTree } from '../process-tree'
 
 type ResponsesBridgeLease = ResolvedAgentBackend['responsesBridgeLease']
+type AnthropicBridgeLease = ResolvedAgentBackend['anthropicBridgeLease']
 type CleanupFailure = (stage: 'connection' | 'agent-process', error: unknown) => void
 
 const log = createLogger('acp')
@@ -28,6 +29,7 @@ export type AcpAttachedConnectionResource = {
   connection: ClientConnection
   framework: AgentFramework['id']
   bridgeLease: ResponsesBridgeLease
+  anthropicBridgeLease?: AnthropicBridgeLease
 }
 
 export type AcpConnectionResourceReadyHandle = Readonly<{
@@ -50,6 +52,7 @@ export type AcpUnattachedConnectionResource = Readonly<{
   process?: ChildProcessWithoutNullStreams
   connection?: ClientConnection
   bridgeLease?: ResponsesBridgeLease
+  anthropicBridgeLease?: AnthropicBridgeLease
 }>
 
 export type AcpConnectionShutdownHandle = Readonly<{
@@ -99,6 +102,10 @@ export class AcpConnectionResourceOwner {
 
   get bridgeSkillsAvailable(): boolean {
     return Boolean(this.currentResource()?.bridgeLease?.selectSkills)
+  }
+
+  get anthropicBridgeAvailable(): boolean {
+    return Boolean(this.currentResource()?.anthropicBridgeLease)
   }
 
   get isShuttingDown(): boolean {
@@ -169,6 +176,7 @@ export class AcpConnectionResourceOwner {
       this.reportCleanupFailure(onFailure, 'agent-process', error)
     }
     await this.releaseBridgeLease(resource.bridgeLease)
+    await this.releaseAnthropicBridgeLease(resource.anthropicBridgeLease)
   }
 
   async cleanupUnattached(
@@ -191,6 +199,7 @@ export class AcpConnectionResourceOwner {
       }
     }
     await this.releaseBridgeLease(resource.bridgeLease)
+    await this.releaseAnthropicBridgeLease(resource.anthropicBridgeLease)
   }
 
   cleanupUnexpectedClose(expectedEpoch: number): void {
@@ -201,6 +210,7 @@ export class AcpConnectionResourceOwner {
       safeLogCleanupError('agent process cleanup after unexpected close failed', error)
     })
     void this.releaseBridgeLease(resource.bridgeLease)
+    void this.releaseAnthropicBridgeLease(resource.anthropicBridgeLease)
   }
 
   shutdownSynchronously(onSuperseded: () => void): void {
@@ -224,6 +234,7 @@ export class AcpConnectionResourceOwner {
         }
       }
       void this.releaseBridgeLease(resource?.bridgeLease)
+      void this.releaseAnthropicBridgeLease(resource?.anthropicBridgeLease)
       void this.closeMcp()
     }
   }
@@ -302,6 +313,10 @@ export class AcpConnectionResourceOwner {
     return true
   }
 
+  setAnthropicBridgeTarget(targetId: string): boolean {
+    return this.currentResource()?.anthropicBridgeLease?.setTarget(targetId) ?? false
+  }
+
   async selectBridgeSkills(
     text: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[0],
     catalog: Parameters<NonNullable<ResponsesBridgeLease>['selectSkills']>[1],
@@ -323,6 +338,16 @@ export class AcpConnectionResourceOwner {
       await lease.release()
     } catch (error) {
       safeLogCleanupError('responses bridge lease release failed', error)
+    }
+  }
+
+  private async releaseAnthropicBridgeLease(lease: AnthropicBridgeLease): Promise<void> {
+    if (!lease || this.releasedBridgeLeases.has(lease)) return
+    this.releasedBridgeLeases.add(lease)
+    try {
+      await lease.release()
+    } catch (error) {
+      safeLogCleanupError('Anthropic bridge lease release failed', error)
     }
   }
 

--- a/src/main/acp/model-change-workflow.test.ts
+++ b/src/main/acp/model-change-workflow.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, type Mock, vi } from 'vitest'
+
+import type { AgentModelChangeTarget } from '../agent-framework'
+import { AcpModelChangeWorkflow } from './model-change-workflow'
+
+const target = (model: string): AgentModelChangeTarget => ({
+  frameworkId: 'claude-code',
+  backendId: 'claude-code:provider',
+  route: 'claude-anthropic',
+  model,
+  sessionModel: model,
+  sessionModelRequired: false,
+  reasoningEffort: 'default',
+  supportsImageInput: false
+})
+
+type WorkflowHarness = {
+  workflow: AcpModelChangeWorkflow
+  canApply: Mock<(target: AgentModelChangeTarget) => boolean>
+  matchesCurrent: Mock<(target: AgentModelChangeTarget) => boolean>
+  applyTarget: Mock<(target: AgentModelChangeTarget) => Promise<boolean>>
+  requestReconnect: Mock<() => Promise<void>>
+  recoverFailedReconnect: Mock<() => void>
+  reportReconnectFailure: Mock<(error: unknown) => void>
+  setBusy: (value: boolean) => void
+}
+
+const createHarness = (): WorkflowHarness => {
+  let busy = false
+  const canApply = vi.fn(() => true)
+  const matchesCurrent = vi.fn(() => false)
+  const applyTarget = vi.fn(async () => true)
+  const requestReconnect = vi.fn(async () => undefined)
+  const recoverFailedReconnect = vi.fn()
+  const reportReconnectFailure = vi.fn()
+  const workflow = new AcpModelChangeWorkflow({
+    canApply,
+    matchesCurrent,
+    isGenerationBusy: () => busy,
+    applyTarget,
+    requestReconnect,
+    recoverFailedReconnect,
+    reportReconnectFailure
+  })
+  return {
+    workflow,
+    canApply,
+    matchesCurrent,
+    applyTarget,
+    requestReconnect,
+    recoverFailedReconnect,
+    reportReconnectFailure,
+    setBusy: (value: boolean) => {
+      busy = value
+    }
+  }
+}
+
+describe('ACP model-change workflow', () => {
+  it('rejects an incompatible target without arming admission', async () => {
+    const harness = createHarness()
+    harness.canApply.mockReturnValue(false)
+
+    await expect(harness.workflow.apply(target('model-b'))).resolves.toBe(false)
+
+    expect(harness.workflow.barrier).toBeUndefined()
+    expect(harness.applyTarget).not.toHaveBeenCalled()
+  })
+
+  it('keeps only the latest target while the generation is busy', async () => {
+    const harness = createHarness()
+    harness.setBusy(true)
+
+    await harness.workflow.apply(target('model-b'))
+    await harness.workflow.apply(target('model-c'))
+    expect(harness.applyTarget).not.toHaveBeenCalled()
+    expect(harness.workflow.barrier).toBeDefined()
+
+    harness.setBusy(false)
+    harness.workflow.activityChanged()
+    await harness.workflow.barrier
+
+    expect(harness.applyTarget).toHaveBeenCalledOnce()
+    expect(harness.applyTarget).toHaveBeenCalledWith(target('model-c'))
+    expect(harness.workflow.barrier).toBeUndefined()
+  })
+
+  it('cancels a pending target when the current target is selected again', async () => {
+    const harness = createHarness()
+    harness.setBusy(true)
+    await harness.workflow.apply(target('model-b'))
+    harness.matchesCurrent.mockReturnValue(true)
+    harness.setBusy(false)
+
+    await expect(harness.workflow.apply(target('model-a'))).resolves.toBe(true)
+
+    expect(harness.workflow.barrier).toBeUndefined()
+    expect(harness.applyTarget).not.toHaveBeenCalled()
+  })
+
+  it('falls back to reconnect and recovers a failed reconnect before releasing admission', async () => {
+    const harness = createHarness()
+    const failure = new Error('reconnect failed')
+    harness.applyTarget.mockResolvedValue(false)
+    harness.requestReconnect.mockRejectedValue(failure)
+
+    await expect(harness.workflow.apply(target('model-b'))).resolves.toBe(true)
+
+    expect(harness.requestReconnect).toHaveBeenCalledOnce()
+    expect(harness.reportReconnectFailure).toHaveBeenCalledWith(failure)
+    expect(harness.recoverFailedReconnect).toHaveBeenCalledOnce()
+    expect(harness.workflow.barrier).toBeUndefined()
+  })
+})

--- a/src/main/acp/model-change-workflow.ts
+++ b/src/main/acp/model-change-workflow.ts
@@ -1,0 +1,109 @@
+import type { AgentModelChangeTarget } from '../agent-framework'
+
+type AcpModelChangeWorkflowOptions = Readonly<{
+  canApply: (target: AgentModelChangeTarget) => boolean
+  matchesCurrent: (target: AgentModelChangeTarget) => boolean
+  isGenerationBusy: () => boolean
+  applyTarget: (target: AgentModelChangeTarget) => Promise<boolean>
+  requestReconnect: () => Promise<void>
+  recoverFailedReconnect: () => void
+  reportReconnectFailure: (error: unknown) => void
+}>
+
+// Owns the generation-local latest-wins queue and its prompt-admission barrier. Runtime supplies
+// target policy and transport application; callers only need to apply, cancel, or signal activity.
+class AcpModelChangeWorkflow {
+  private pending: AgentModelChangeTarget | undefined
+  private barrierPromise: Promise<void> | undefined
+  private resolveBarrier: (() => void) | undefined
+  private drainPromise: Promise<void> | undefined
+
+  constructor(private readonly options: AcpModelChangeWorkflowOptions) {}
+
+  get barrier(): Promise<void> | undefined {
+    return this.barrierPromise
+  }
+
+  async apply(target: AgentModelChangeTarget): Promise<boolean> {
+    if (!this.options.canApply(target)) return false
+
+    if (!this.drainPromise && this.options.matchesCurrent(target)) {
+      this.cancel()
+      return true
+    }
+
+    this.pending = target
+    this.armBarrier()
+    if (this.options.isGenerationBusy()) return true
+
+    await this.drain()
+    return true
+  }
+
+  activityChanged(): void {
+    if (this.pending && !this.options.isGenerationBusy()) void this.drain()
+  }
+
+  cancel(): void {
+    this.pending = undefined
+    if (!this.drainPromise) this.completeBarrier()
+  }
+
+  async cancelAndDrain(): Promise<void> {
+    this.cancel()
+    await this.drainPromise
+  }
+
+  private armBarrier(): void {
+    if (this.barrierPromise) return
+    this.barrierPromise = new Promise<void>((resolve) => {
+      this.resolveBarrier = resolve
+    })
+  }
+
+  private completeBarrier(): void {
+    const resolve = this.resolveBarrier
+    this.barrierPromise = undefined
+    this.resolveBarrier = undefined
+    resolve?.()
+  }
+
+  private drain(): Promise<void> {
+    if (this.drainPromise) return this.drainPromise
+
+    const drain = this.drainQueue()
+    this.drainPromise = drain
+    const finalize = (): void => {
+      if (this.drainPromise !== drain) return
+      this.drainPromise = undefined
+      if (this.pending && !this.options.isGenerationBusy()) {
+        void this.drain()
+      } else if (!this.pending) {
+        this.completeBarrier()
+      }
+    }
+    void drain.then(finalize, finalize)
+    return drain
+  }
+
+  private async drainQueue(): Promise<void> {
+    while (this.pending && !this.options.isGenerationBusy()) {
+      const target = this.pending
+      this.pending = undefined
+
+      if (!this.options.canApply(target) || !(await this.options.applyTarget(target))) {
+        this.pending = undefined
+        try {
+          await this.options.requestReconnect()
+        } catch (error) {
+          this.options.reportReconnectFailure(error)
+          this.options.recoverFailedReconnect()
+        }
+        return
+      }
+    }
+  }
+}
+
+export { AcpModelChangeWorkflow }
+export type { AcpModelChangeWorkflowOptions }

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -4,6 +4,7 @@ import type { AcpPermissionRequest, AcpRuntimeEvent, AcpStateSnapshot } from '..
 import { AcpRuntimeCoordinator } from './runtime-coordinator'
 import type { AcpRuntime, AcpRuntimeCallbacks } from './runtime'
 import type { ConversationPermissionGrantStore } from './permission-broker'
+import type { AgentModelChangeTarget } from '../agent-framework'
 
 const createDeferred = <Value = void>(): {
   promise: Promise<Value>
@@ -60,6 +61,7 @@ const createFakeRuntime = (options: {
   sendPrompt: ReturnType<typeof vi.fn>
   sendAppContinuation: ReturnType<typeof vi.fn>
   applyReasoningEffortChange: ReturnType<typeof vi.fn>
+  applyModelChange: ReturnType<typeof vi.fn>
   respondToPermission: ReturnType<typeof vi.fn>
   emitEvent: (event: AcpRuntimeEvent) => void
   emitPermission: (request: AcpPermissionRequest) => void
@@ -119,6 +121,7 @@ const createFakeRuntime = (options: {
   const requestRetirement = vi.fn(async () => undefined)
   const requestProviderReconnect = vi.fn(async () => undefined)
   const applyReasoningEffortChange = vi.fn(async () => true)
+  const applyModelChange = vi.fn(async () => true)
   const respondToPermission = vi.fn(() => snapshot)
   const shutdown = vi.fn()
   const shutdownForQuit = vi.fn(async () => ({ reaped: true }))
@@ -204,6 +207,7 @@ const createFakeRuntime = (options: {
     requestRetirement,
     requestProviderReconnect,
     applyReasoningEffortChange,
+    applyModelChange,
     respondToPermission,
     shutdown,
     shutdownForQuit,
@@ -226,6 +230,7 @@ const createFakeRuntime = (options: {
     sendPrompt,
     sendAppContinuation,
     applyReasoningEffortChange,
+    applyModelChange,
     respondToPermission,
     emitEvent: (event) => {
       snapshot = { ...snapshot, events: [...snapshot.events, event] }
@@ -1047,6 +1052,35 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created[1].requestRetirement).toHaveBeenCalledOnce()
     expect(created[1].applyReasoningEffortChange).not.toHaveBeenCalled()
     expect(created[2].applyReasoningEffortChange).toHaveBeenCalledWith('high')
+  })
+
+  it('routes a model hot-switch only to the active runtime generation', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({
+        frameworkId: created.length === 0 ? 'claude-code' : 'codex',
+        sessionIds: [`session-${created.length + 1}`],
+        callbacks
+      })
+      created.push(fake)
+      return fake.runtime
+    })
+    const target: AgentModelChangeTarget = {
+      frameworkId: 'codex',
+      backendId: 'codex:provider-a',
+      route: 'codex-responses',
+      model: 'model-b',
+      sessionModel: 'model-b',
+      sessionModelRequired: false,
+      reasoningEffort: 'high'
+    }
+
+    await coordinator.createSession()
+    await coordinator.requestAgentFrameworkSwitch()
+    await expect(coordinator.applyModelChange(target)).resolves.toBe(true)
+
+    expect(created[0].applyModelChange).not.toHaveBeenCalled()
+    expect(created[1].applyModelChange).toHaveBeenCalledWith(target)
   })
 
   it('detaches idle sessions while an active turn retires and resumes them on a fresh runtime', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1072,6 +1072,7 @@ describe('AcpRuntimeCoordinator', () => {
       model: 'model-b',
       sessionModel: 'model-b',
       sessionModelRequired: false,
+      supportsImageInput: true,
       reasoningEffort: 'high'
     }
 

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -24,6 +24,7 @@ import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-ac
 import { ConversationPermissionGrantStore } from './permission-broker'
 import type { ApprovedSwitchReadBack, ClaudeCodeReplayInput } from '../agents/claude-code-handoff'
 import type { ShutdownStepOutcome } from '../lifecycle-shutdown'
+import type { AgentModelChangeTarget } from '../agent-framework'
 
 const MAX_EVENTS = 500
 const QUIT_PREPARATION_TIMEOUT_MS = 4_000
@@ -734,6 +735,10 @@ class AcpRuntimeCoordinator {
     // generations stay pinned to their own provider/model and therefore must not receive a value
     // resolved for a different model profile.
     return this.getActiveRuntime().applyReasoningEffortChange(effort)
+  }
+
+  async applyModelChange(target: AgentModelChangeTarget): Promise<boolean> {
+    return this.getActiveRuntime().applyModelChange(target)
   }
 
   writeArtifactForCurrentRun(

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16606,6 +16606,65 @@ describe('ACP runtime — model hot switch', () => {
     ])
   })
 
+  it('hot-switches an advertised model across compatible Claude backend identities', async () => {
+    const process = new FakeAgentProcess()
+    const configOptions = [modelOption()]
+    const fakeAgent = startFakeAgent(process, ['s-model'], {
+      configOptions,
+      onSetConfigOption: ({ value }) => {
+        const model = configOptions[0]
+        if (model.type === 'select' && typeof value === 'string') model.currentValue = value
+      }
+    })
+    const spawn = vi.fn(() => asAgentProcess(process))
+    const setTarget = vi.fn(() => true)
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn },
+        backendId: 'claude-code:provider-a',
+        modelRoute: 'claude-anthropic',
+        executablePath: '/bin/claude',
+        env: {},
+        sessionModel: 'model-a',
+        supportsImageInput: false,
+        contextUsageModel: 'model-a',
+        anthropicBridgeLease: {
+          setTarget,
+          release: vi.fn(async () => undefined)
+        }
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    await expect(
+      runtime.applyModelChange(
+        modelTarget('model-b', {
+          backendId: 'claude-code:provider-b',
+          anthropicBridgeTargetId: 'provider-b/model-b'
+        })
+      )
+    ).resolves.toBe(true)
+    await expect(
+      runtime.applyModelChange(
+        modelTarget('model-a', {
+          backendId: 'claude-code:provider-a',
+          anthropicBridgeTargetId: 'provider-a/model-a'
+        })
+      )
+    ).resolves.toBe(true)
+
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-model', configId: 'model', value: 'model-b' },
+      { sessionId: 's-model', configId: 'model', value: 'model-a' }
+    ])
+    expect(spawn).toHaveBeenCalledOnce()
+    expect(setTarget.mock.calls).toEqual([['provider-b/model-b'], ['provider-a/model-a']])
+    expect(process.killed).toBe(false)
+  })
+
   it('falls back when no primary session can verify that the agent advertises the model', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, [], { configOptions: [modelOption()] })
@@ -16791,6 +16850,76 @@ describe('ACP runtime — model hot switch', () => {
       { sessionId: 's-model', configId: 'model', value: 'model-c' }
     ])
     expect(fakeAgent.prompts.map(({ text }) => text)).toEqual(['old-model turn', 'new-model turn'])
+  })
+
+  it('waits for a generating Claude message before retargeting its upstream provider', async () => {
+    const process = new FakeAgentProcess()
+    const promptStarted = createDeferred()
+    const finishPrompt = createDeferred()
+    const setTarget = vi.fn(() => true)
+    const configOptions = [modelOption()]
+    const fakeAgent = startFakeAgent(process, ['s-provider-switch'], {
+      configOptions,
+      onPrompt: async () => {
+        promptStarted.resolve()
+        await finishPrompt.promise
+        return { stopReason: 'end_turn' }
+      },
+      onSetConfigOption: ({ value }) => {
+        const model = configOptions[0]
+        if (model.type === 'select' && typeof value === 'string') model.currentValue = value
+      }
+    })
+    const spawn = vi.fn(() => asAgentProcess(process))
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn },
+        backendId: 'claude-code:provider-a',
+        modelRoute: 'claude-anthropic',
+        executablePath: '/bin/claude',
+        env: {},
+        sessionModel: 'model-a',
+        supportsImageInput: true,
+        contextUsageModel: 'model-a',
+        anthropicBridgeLease: {
+          setTarget,
+          release: vi.fn(async () => undefined)
+        }
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+    const prompt = runtime.sendPrompt({
+      sessionId: 's-provider-switch',
+      text: 'stay on provider a'
+    })
+    await promptStarted.promise
+
+    await runtime.applyModelChange(
+      modelTarget('model-b', {
+        backendId: 'claude-code:provider-b',
+        anthropicBridgeTargetId: 'provider-b/model-b'
+      })
+    )
+
+    expect(setTarget).not.toHaveBeenCalled()
+    expect(fakeAgent.configChanges).toEqual([])
+    expect(process.killed).toBe(false)
+
+    finishPrompt.resolve()
+    await prompt
+    await vi.waitFor(() => {
+      expect(setTarget).toHaveBeenCalledWith('provider-b/model-b')
+      expect(fakeAgent.configChanges).toHaveLength(1)
+    })
+
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-provider-switch', configId: 'model', value: 'model-b' }
+    ])
+    expect(spawn).toHaveBeenCalledOnce()
+    expect(process.killed).toBe(false)
   })
 
   it('cancels a queued switch when the user selects the currently applied model again', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -17032,6 +17032,50 @@ describe('ACP runtime — model hot switch', () => {
     expect(fakeAgent.prompts.map(({ text }) => text)).toEqual(['old-model turn', 'new-model turn'])
   })
 
+  it('applies a newer effort change after a queued model switch', async () => {
+    const process = new FakeAgentProcess()
+    const promptStarted = createDeferred()
+    const finishPrompt = createDeferred()
+    const effortOption = {
+      type: 'select',
+      id: 'effort',
+      name: 'Effort',
+      category: 'thought_level',
+      currentValue: 'default',
+      options: ['default', 'low', 'high'].map((value) => ({ value, name: value }))
+    } as SessionConfigOption
+    const fakeAgent = startFakeAgent(process, ['s-model-effort'], {
+      configOptions: [modelOption(), effortOption],
+      onPrompt: async ({ text }) => {
+        if (text === 'old-model turn') {
+          promptStarted.resolve()
+          await finishPrompt.promise
+        }
+        return { stopReason: 'end_turn' }
+      }
+    })
+    const { runtime } = createModelRuntime(process)
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    const prompt = runtime.sendPrompt({ sessionId: 's-model-effort', text: 'old-model turn' })
+    await promptStarted.promise
+
+    await runtime.applyModelChange(modelTarget('model-b', { reasoningEffort: 'high' }))
+    const effortChange = runtime.applyReasoningEffortChange('low')
+
+    finishPrompt.resolve()
+    await prompt
+    await expect(effortChange).resolves.toBe(true)
+    await runtime.sendPrompt({ sessionId: 's-model-effort', text: 'new-model turn' })
+
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-model-effort', configId: 'model', value: 'model-b' },
+      { sessionId: 's-model-effort', configId: 'effort', value: 'high' },
+      { sessionId: 's-model-effort', configId: 'effort', value: 'low' }
+    ])
+  })
+
   it('waits for a generating Claude message before retargeting its upstream provider', async () => {
     const process = new FakeAgentProcess()
     const promptStarted = createDeferred()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -10758,6 +10758,7 @@ describe('ACP runtime session management', () => {
   })
 
   it('prepends a history preamble to the agent content but not the user-facing message', async () => {
+    infoLogSpy.mockClear()
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['adopted-session-1'], { resumeNotFound: true })
     const messageEvents: Array<{ role?: string; text?: string }> = []
@@ -10786,6 +10787,18 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.prompts[0]?.text).toContain('keep going')
     // ...but the conversation bubble records only what the user actually typed.
     expect(messageEvents).toEqual([{ role: 'user', text: 'keep going' }])
+    expect(
+      infoLogSpy.mock.calls.find(
+        ([message]) => message === 'session transcript replay dispatched'
+      )?.[1]
+    ).toMatchObject({
+      sessionId: 'switched-session',
+      historyTextLength: 43,
+      historyAttachmentCount: 0,
+      historyImageCount: 0,
+      framework: 'claude-code',
+      status: 'connected'
+    })
   })
 
   it('sends an app-owned continuation without publishing its synthetic text as a user message', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16544,19 +16544,25 @@ describe('ACP runtime — model hot switch', () => {
       options: ['model-a', 'model-b', 'model-c'].map((value) => ({ value, name: value }))
     }) as SessionConfigOption
 
-  const modelTarget = (model: string): AgentModelChangeTarget => ({
+  const modelTarget = (
+    model: string,
+    overrides: Partial<AgentModelChangeTarget> = {}
+  ): AgentModelChangeTarget => ({
     frameworkId: 'claude-code',
     backendId: 'claude-code:provider-a',
     route: 'claude-anthropic',
     model,
     sessionModel: model,
     sessionModelRequired: false,
-    reasoningEffort: 'default'
+    supportsImageInput: true,
+    reasoningEffort: 'default',
+    ...overrides
   })
 
   const createModelRuntime = (
     process: FakeAgentProcess,
-    spawn = vi.fn()
+    spawn = vi.fn(),
+    supportsImageInput = true
   ): { spawn: ReturnType<typeof vi.fn>; runtime: AcpRuntime } => {
     spawn.mockImplementation(() => asAgentProcess(process))
     return {
@@ -16571,6 +16577,7 @@ describe('ACP runtime — model hot switch', () => {
           executablePath: '/bin/claude',
           env: {},
           sessionModel: 'model-a',
+          supportsImageInput,
           contextUsageModel: 'model-a'
         })
       })
@@ -16610,7 +16617,71 @@ describe('ACP runtime — model hot switch', () => {
     expect(process.killed).toBe(false)
   })
 
-  it('retargets the existing Codex bridge while keeping its transport model fixed', async () => {
+  it('hot-switches from a text-only model to an image-capable model in place', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-model'], { configOptions: [modelOption()] })
+    const { runtime } = createModelRuntime(process, vi.fn(), false)
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    await runtime.applyModelChange(modelTarget('model-b'))
+
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-model', configId: 'model', value: 'model-b' }
+    ])
+    expect(process.killed).toBe(false)
+  })
+
+  it.each([
+    ['OpenCode', opencodeFramework, 'opencode-openai', 'opencode:provider-a'],
+    ['native Codex', codexFramework, 'codex-responses', 'codex:provider-a']
+  ] as const)(
+    'lets %s filter historical images while hot-switching to a text-only model',
+    async (_name, framework, route, backendId) => {
+      const process = new FakeAgentProcess()
+      const fakeAgent = startFakeAgent(process, ['s-model'], {
+        configOptions: [modelOption()],
+        ...(framework.id === 'codex'
+          ? { modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent') }
+          : {})
+      })
+      const spawn = vi.fn(() => asAgentProcess(process))
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: () => ({
+          framework: { ...framework, spawn },
+          backendId,
+          modelRoute: route,
+          executablePath: '/bin/agent',
+          env: {},
+          sessionModel: 'model-a',
+          supportsImageInput: true,
+          contextUsageModel: 'model-a'
+        })
+      })
+      await runtime.createSession({ cwd: '/workspace' })
+      fakeAgent.configChanges.length = 0
+
+      await runtime.applyModelChange({
+        frameworkId: framework.id,
+        backendId,
+        route,
+        model: 'model-b',
+        sessionModel: 'model-b',
+        sessionModelRequired: false,
+        supportsImageInput: false,
+        reasoningEffort: 'default'
+      })
+
+      expect(fakeAgent.configChanges).toEqual([
+        { sessionId: 's-model', configId: 'model', value: 'model-b' }
+      ])
+      expect(process.killed).toBe(false)
+    }
+  )
+
+  it('retargets an image-capable Codex bridge but reconnects before an image downgrade', async () => {
     const process = new FakeAgentProcess()
     const setModelTarget = vi.fn()
     const fakeAgent = startFakeAgent(process, ['s-bridge-model'], {
@@ -16627,6 +16698,7 @@ describe('ACP runtime — model hot switch', () => {
         executablePath: '/bin/codex-acp',
         env: {},
         sessionModel: CODEX_BRIDGE_MODEL,
+        supportsImageInput: true,
         contextUsageModel: 'model-a',
         responsesBridgeLease: {
           selectSkills: vi.fn(async () => []),
@@ -16647,6 +16719,7 @@ describe('ACP runtime — model hot switch', () => {
       model: 'model-b',
       sessionModel: CODEX_BRIDGE_MODEL,
       sessionModelRequired: false,
+      supportsImageInput: true,
       reasoningEffort: 'high',
       bridge: {
         model: 'model-b',
@@ -16664,6 +16737,22 @@ describe('ACP runtime — model hot switch', () => {
     expect(fakeAgent.configChanges).toEqual([])
     expect(spawn).toHaveBeenCalledOnce()
     expect(process.killed).toBe(false)
+
+    setModelTarget.mockClear()
+    await runtime.applyModelChange({
+      frameworkId: 'codex',
+      backendId: 'codex:provider-a',
+      route: 'codex-bridge',
+      model: 'model-c',
+      sessionModel: CODEX_BRIDGE_MODEL,
+      sessionModelRequired: false,
+      supportsImageInput: false,
+      reasoningEffort: 'default',
+      bridge: { model: 'model-c' }
+    })
+
+    expect(setModelTarget).not.toHaveBeenCalled()
+    expect(process.killed).toBe(true)
   })
 
   it('keeps the generating message on its model and applies only the latest queued selection', async () => {
@@ -16722,13 +16811,43 @@ describe('ACP runtime — model hot switch', () => {
     const prompt = runtime.sendPrompt({ sessionId: 's-model', text: 'keep model a' })
     await promptStarted.promise
 
-    await runtime.applyModelChange(modelTarget('model-b'))
+    await runtime.applyModelChange(modelTarget('model-b', { supportsImageInput: false }))
     await runtime.applyModelChange(modelTarget('model-a'))
     finishPrompt.resolve()
     await prompt
 
     expect(fakeAgent.configChanges).toEqual([])
     expect(process.killed).toBe(false)
+  })
+
+  it('waits for the active Claude message before reconnecting for an image downgrade', async () => {
+    const process = new FakeAgentProcess()
+    const promptStarted = createDeferred()
+    const finishPrompt = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['s-model'], {
+      configOptions: [modelOption()],
+      onPrompt: async () => {
+        promptStarted.resolve()
+        await finishPrompt.promise
+        return { stopReason: 'end_turn' }
+      }
+    })
+    const { runtime } = createModelRuntime(process)
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+    const prompt = runtime.sendPrompt({ sessionId: 's-model', text: 'finish before downgrade' })
+    await promptStarted.promise
+
+    await runtime.applyModelChange(modelTarget('model-b', { supportsImageInput: false }))
+
+    expect(fakeAgent.configChanges).toEqual([])
+    expect(process.killed).toBe(false)
+
+    finishPrompt.resolve()
+    await prompt
+    await vi.waitFor(() => expect(runtime.getSnapshot().status).toBe('idle'))
+    expect(process.killed).toBe(true)
+    expect(fakeAgent.configChanges).toEqual([])
   })
 
   it('falls back to a reconnect instead of leaving a partially switched generation', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16907,6 +16907,93 @@ describe('ACP runtime — model hot switch', () => {
     expect(process.killed).toBe(true)
   })
 
+  it('reconnects native Codex before switching providers that share one model slug', async () => {
+    const process = new FakeAgentProcess()
+    const setProviderTarget = vi.fn(() => true)
+    const fakeAgent = startFakeAgent(process, ['s-native-model'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      configOptions: [modelOption()]
+    })
+    const spawn = vi.fn(() => asAgentProcess(process))
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn },
+        backendId: 'codex:provider-a',
+        modelRoute: 'codex-responses',
+        executablePath: '/bin/codex-acp',
+        env: {},
+        sessionModel: 'model-a',
+        supportsImageInput: true,
+        contextUsageModel: 'model-a',
+        providerTransportLease: {
+          setTarget: setProviderTarget,
+          release: vi.fn(async () => undefined)
+        }
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    await runtime.applyModelChange({
+      frameworkId: 'codex',
+      backendId: 'codex:provider-b',
+      route: 'codex-responses',
+      model: 'model-a',
+      sessionModel: 'model-a',
+      sessionModelRequired: false,
+      supportsImageInput: false,
+      reasoningEffort: 'default',
+      providerTransportTargetId: JSON.stringify(['codex', 'provider-b', 'model-a'])
+    })
+
+    expect(setProviderTarget).not.toHaveBeenCalled()
+    expect(fakeAgent.configChanges).toEqual([])
+    expect(process.killed).toBe(true)
+  })
+
+  it('clears an advertised effort override when the switched model resolves to default', async () => {
+    const process = new FakeAgentProcess()
+    const effortOption = {
+      type: 'select',
+      id: 'effort',
+      name: 'Effort',
+      category: 'thought_level',
+      currentValue: 'high',
+      options: ['default', 'high'].map((value) => ({ value, name: value }))
+    } as SessionConfigOption
+    const fakeAgent = startFakeAgent(process, ['s-default-effort'], {
+      configOptions: [modelOption(), effortOption]
+    })
+    const spawn = vi.fn(() => asAgentProcess(process))
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn },
+        backendId: 'claude-code:provider-a',
+        modelRoute: 'claude-anthropic',
+        executablePath: '/bin/claude',
+        env: {},
+        sessionModel: 'model-a',
+        sessionEffort: 'high',
+        supportsImageInput: true,
+        contextUsageModel: 'model-a'
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    await runtime.applyModelChange(modelTarget('model-b'))
+
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-default-effort', configId: 'model', value: 'model-b' },
+      { sessionId: 's-default-effort', configId: 'effort', value: 'default' }
+    ])
+    expect(process.killed).toBe(false)
+  })
+
   it('keeps the generating message on its model and applies only the latest queued selection', async () => {
     const process = new FakeAgentProcess()
     const promptStarted = createDeferred()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -33,8 +33,10 @@ import {
   claudeCodeFramework,
   codexFramework,
   opencodeFramework,
+  type AgentModelChangeTarget,
   type ResolvedAgentBackend
 } from '../agent-framework'
+import { CODEX_BRIDGE_MODEL } from '../agent-framework/codex'
 import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
 import type { ArtifactRunClaim } from '../artifacts/run-registry'
@@ -16528,6 +16530,221 @@ describe('ACP runtime — connect failure logging', () => {
 
     const call = errorLogSpy.mock.calls.find(([message]) => message === 'agent connection failed')
     expect((call?.[1] as { framework: string }).framework).toBe('opencode')
+  })
+})
+
+describe('ACP runtime — model hot switch', () => {
+  const modelOption = (): SessionConfigOption =>
+    ({
+      type: 'select',
+      id: 'model',
+      name: 'Model',
+      category: 'model',
+      currentValue: 'model-a',
+      options: ['model-a', 'model-b', 'model-c'].map((value) => ({ value, name: value }))
+    }) as SessionConfigOption
+
+  const modelTarget = (model: string): AgentModelChangeTarget => ({
+    frameworkId: 'claude-code',
+    backendId: 'claude-code:provider-a',
+    route: 'claude-anthropic',
+    model,
+    sessionModel: model,
+    sessionModelRequired: false,
+    reasoningEffort: 'default'
+  })
+
+  const createModelRuntime = (
+    process: FakeAgentProcess,
+    spawn = vi.fn()
+  ): { spawn: ReturnType<typeof vi.fn>; runtime: AcpRuntime } => {
+    spawn.mockImplementation(() => asAgentProcess(process))
+    return {
+      spawn,
+      runtime: new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: () => ({
+          framework: { ...claudeCodeFramework, spawn },
+          backendId: 'claude-code:provider-a',
+          modelRoute: 'claude-anthropic',
+          executablePath: '/bin/claude',
+          env: {},
+          sessionModel: 'model-a',
+          contextUsageModel: 'model-a'
+        })
+      })
+    }
+  }
+
+  it('switches every idle session and the generation default without replacing the process', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-model-1', 's-model-2', 's-model-3'], {
+      configOptions: [modelOption()]
+    })
+    const { runtime, spawn } = createModelRuntime(process)
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    await expect(runtime.applyModelChange(modelTarget('model-b'))).resolves.toBe(true)
+    await runtime.createSession({ cwd: '/workspace' })
+
+    expect(spawn).toHaveBeenCalledOnce()
+    expect(process.killed).toBe(false)
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-model-1', configId: 'model', value: 'model-b' },
+      { sessionId: 's-model-2', configId: 'model', value: 'model-b' },
+      { sessionId: 's-model-3', configId: 'model', value: 'model-b' }
+    ])
+  })
+
+  it('falls back when no primary session can verify that the agent advertises the model', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, [], { configOptions: [modelOption()] })
+    const { runtime } = createModelRuntime(process)
+    await runtime.connect({ cwd: '/workspace' })
+
+    await expect(runtime.applyModelChange(modelTarget('model-b'))).resolves.toBe(false)
+
+    expect(process.killed).toBe(false)
+  })
+
+  it('retargets the existing Codex bridge while keeping its transport model fixed', async () => {
+    const process = new FakeAgentProcess()
+    const setModelTarget = vi.fn()
+    const fakeAgent = startFakeAgent(process, ['s-bridge-model'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
+    })
+    const spawn = vi.fn(() => asAgentProcess(process))
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn },
+        backendId: 'codex:provider-a',
+        modelRoute: 'codex-bridge',
+        executablePath: '/bin/codex-acp',
+        env: {},
+        sessionModel: CODEX_BRIDGE_MODEL,
+        contextUsageModel: 'model-a',
+        responsesBridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => false),
+          setModelTarget,
+          release: vi.fn(async () => undefined)
+        }
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    await runtime.applyModelChange({
+      frameworkId: 'codex',
+      backendId: 'codex:provider-a',
+      route: 'codex-bridge',
+      model: 'model-b',
+      sessionModel: CODEX_BRIDGE_MODEL,
+      sessionModelRequired: false,
+      reasoningEffort: 'high',
+      bridge: {
+        model: 'model-b',
+        vendorId: 'deepseek',
+        reasoningEffortTransport: 'deepseek'
+      }
+    })
+
+    expect(setModelTarget).toHaveBeenCalledWith({
+      model: 'model-b',
+      vendorId: 'deepseek',
+      reasoningEffortTransport: 'deepseek',
+      reasoningEffort: 'high'
+    })
+    expect(fakeAgent.configChanges).toEqual([])
+    expect(spawn).toHaveBeenCalledOnce()
+    expect(process.killed).toBe(false)
+  })
+
+  it('keeps the generating message on its model and applies only the latest queued selection', async () => {
+    const process = new FakeAgentProcess()
+    const promptStarted = createDeferred()
+    const finishPrompt = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['s-model'], {
+      configOptions: [modelOption()],
+      onPrompt: async ({ text }) => {
+        if (text === 'old-model turn') {
+          promptStarted.resolve()
+          await finishPrompt.promise
+        }
+        return { stopReason: 'end_turn' }
+      }
+    })
+    const { runtime } = createModelRuntime(process)
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    const oldPrompt = runtime.sendPrompt({ sessionId: 's-model', text: 'old-model turn' })
+    await promptStarted.promise
+
+    await expect(runtime.applyModelChange(modelTarget('model-b'))).resolves.toBe(true)
+    await expect(runtime.applyModelChange(modelTarget('model-c'))).resolves.toBe(true)
+    const nextPrompt = runtime.sendPrompt({ sessionId: 's-model', text: 'new-model turn' })
+
+    expect(fakeAgent.configChanges).toEqual([])
+    expect(fakeAgent.prompts.map(({ text }) => text)).toEqual(['old-model turn'])
+
+    finishPrompt.resolve()
+    await oldPrompt
+    await nextPrompt
+
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-model', configId: 'model', value: 'model-c' }
+    ])
+    expect(fakeAgent.prompts.map(({ text }) => text)).toEqual(['old-model turn', 'new-model turn'])
+  })
+
+  it('cancels a queued switch when the user selects the currently applied model again', async () => {
+    const process = new FakeAgentProcess()
+    const promptStarted = createDeferred()
+    const finishPrompt = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['s-model'], {
+      configOptions: [modelOption()],
+      onPrompt: async () => {
+        promptStarted.resolve()
+        await finishPrompt.promise
+        return { stopReason: 'end_turn' }
+      }
+    })
+    const { runtime } = createModelRuntime(process)
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+    const prompt = runtime.sendPrompt({ sessionId: 's-model', text: 'keep model a' })
+    await promptStarted.promise
+
+    await runtime.applyModelChange(modelTarget('model-b'))
+    await runtime.applyModelChange(modelTarget('model-a'))
+    finishPrompt.resolve()
+    await prompt
+
+    expect(fakeAgent.configChanges).toEqual([])
+    expect(process.killed).toBe(false)
+  })
+
+  it('falls back to a reconnect instead of leaving a partially switched generation', async () => {
+    const process = new FakeAgentProcess()
+    const agentOptions: Parameters<typeof startFakeAgent>[2] = {
+      configOptions: [modelOption()]
+    }
+    startFakeAgent(process, ['s-model'], agentOptions)
+    const { runtime } = createModelRuntime(process)
+    await runtime.createSession({ cwd: '/workspace' })
+    agentOptions.rejectSetConfigOption = true
+
+    await expect(runtime.applyModelChange(modelTarget('model-b'))).resolves.toBe(true)
+
+    expect(process.killed).toBe(true)
+    expect(runtime.getSnapshot().status).toBe('idle')
   })
 })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16678,6 +16678,75 @@ describe('ACP runtime — model hot switch', () => {
     expect(process.killed).toBe(false)
   })
 
+  it('hot-switches OpenCode across pre-registered provider transports', async () => {
+    const process = new FakeAgentProcess()
+    const configOptions = [
+      {
+        type: 'select',
+        id: 'model',
+        name: 'Model',
+        category: 'model',
+        currentValue: 'open-science-a/model-a',
+        options: ['open-science-a/model-a', 'open-science-b/model-b'].map((value) => ({
+          value,
+          name: value
+        }))
+      } as SessionConfigOption
+    ]
+    const fakeAgent = startFakeAgent(process, ['s-opencode-provider'], {
+      configOptions,
+      onSetConfigOption: ({ value }) => {
+        const model = configOptions[0]
+        if (model.type === 'select' && typeof value === 'string') model.currentValue = value
+      }
+    })
+    const spawn = vi.fn(() => asAgentProcess(process))
+    const setTarget = vi.fn(() => true)
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...opencodeFramework, spawn },
+        backendId: 'opencode:provider-a',
+        modelRoute: 'opencode-openai',
+        executablePath: '/bin/opencode',
+        env: {},
+        sessionModel: 'open-science-a/model-a',
+        supportsImageInput: false,
+        contextUsageModel: 'model-a',
+        providerTransportLease: {
+          setTarget,
+          release: vi.fn(async () => undefined)
+        }
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    await runtime.applyModelChange({
+      frameworkId: 'opencode',
+      backendId: 'opencode:provider-b',
+      route: 'opencode-openai',
+      model: 'model-b',
+      sessionModel: 'open-science-b/model-b',
+      sessionModelRequired: false,
+      supportsImageInput: false,
+      reasoningEffort: 'default',
+      providerTransportTargetId: JSON.stringify(['opencode', 'provider-b', 'model-b'])
+    })
+
+    expect(setTarget).toHaveBeenCalledWith(JSON.stringify(['opencode', 'provider-b', 'model-b']))
+    expect(fakeAgent.configChanges).toEqual([
+      {
+        sessionId: 's-opencode-provider',
+        configId: 'model',
+        value: 'open-science-b/model-b'
+      }
+    ])
+    expect(spawn).toHaveBeenCalledOnce()
+    expect(process.killed).toBe(false)
+  })
+
   it('falls back when no primary session can verify that the agent advertises the model', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, [], { configOptions: [modelOption()] })
@@ -16756,6 +16825,7 @@ describe('ACP runtime — model hot switch', () => {
   it('retargets an image-capable Codex bridge but reconnects before an image downgrade', async () => {
     const process = new FakeAgentProcess()
     const setModelTarget = vi.fn()
+    const setProviderTarget = vi.fn(() => true)
     const fakeAgent = startFakeAgent(process, ['s-bridge-model'], {
       modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent')
     })
@@ -16778,6 +16848,10 @@ describe('ACP runtime — model hot switch', () => {
           unregisterReviewerSession: vi.fn(() => false),
           setModelTarget,
           release: vi.fn(async () => undefined)
+        },
+        providerTransportLease: {
+          setTarget: setProviderTarget,
+          release: vi.fn(async () => undefined)
         }
       })
     })
@@ -16786,13 +16860,14 @@ describe('ACP runtime — model hot switch', () => {
 
     await runtime.applyModelChange({
       frameworkId: 'codex',
-      backendId: 'codex:provider-a',
+      backendId: 'codex:provider-b',
       route: 'codex-bridge',
       model: 'model-b',
       sessionModel: CODEX_BRIDGE_MODEL,
       sessionModelRequired: false,
       supportsImageInput: true,
       reasoningEffort: 'high',
+      providerTransportTargetId: JSON.stringify(['codex', 'provider-b', 'model-b']),
       bridge: {
         model: 'model-b',
         vendorId: 'deepseek',
@@ -16806,6 +16881,9 @@ describe('ACP runtime — model hot switch', () => {
       reasoningEffortTransport: 'deepseek',
       reasoningEffort: 'high'
     })
+    expect(setProviderTarget).toHaveBeenCalledWith(
+      JSON.stringify(['codex', 'provider-b', 'model-b'])
+    )
     expect(fakeAgent.configChanges).toEqual([])
     expect(spawn).toHaveBeenCalledOnce()
     expect(process.killed).toBe(false)
@@ -16820,10 +16898,12 @@ describe('ACP runtime — model hot switch', () => {
       sessionModelRequired: false,
       supportsImageInput: false,
       reasoningEffort: 'default',
+      providerTransportTargetId: JSON.stringify(['codex', 'provider-a', 'model-c']),
       bridge: { model: 'model-c' }
     })
 
     expect(setModelTarget).not.toHaveBeenCalled()
+    expect(setProviderTarget).toHaveBeenCalledOnce()
     expect(process.killed).toBe(true)
   })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -137,6 +137,7 @@ import { AcpSessionConfigurator, type AcpSessionConfigurationFacts } from './ses
 import { AcpSessionUpdateProjector, type AcpSessionUpdateEffect } from './session-update-projector'
 import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
 import { AcpConnectionCloseWorkflow, type CloseState } from './connection-close-workflow'
+import { AcpModelChangeWorkflow } from './model-change-workflow'
 import {
   AcpTurnSkillOwner,
   type AcpTurnSkillHooks,
@@ -514,10 +515,7 @@ class AcpRuntime {
   private readonly promptContentOwner: AcpPromptContentOwner
   private readonly connectionClose: AcpConnectionCloseWorkflow
   private readonly connectionLifecycle: AcpConnectionLifecycleWorkflow
-  private pendingModelChange: AgentModelChangeTarget | undefined
-  private modelChangeBarrier: Promise<void> | undefined
-  private resolveModelChangeBarrier: (() => void) | undefined
-  private modelChangeDrain: Promise<void> | undefined
+  private readonly modelChanges: AcpModelChangeWorkflow
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -722,6 +720,18 @@ class AcpRuntime {
       emitState: () => this.emitState(),
       hasContextUsage: () => this.contextUsageTracker.hasUsage()
     }
+    this.modelChanges = new AcpModelChangeWorkflow({
+      canApply: (target) => this.canApplyModelChange(target),
+      matchesCurrent: (target) => this.modelChangeMatchesCurrent(target),
+      isGenerationBusy: () => this.generationActivity.blockers().retirement,
+      applyTarget: (target) => this.applyModelTarget(target),
+      // Model-change fallback already owns its drain. Calling the close workflow here would ask the
+      // same drain to await itself, so arm the authoritative transition directly.
+      requestReconnect: () => this.connectionTransitions.requestProviderReconnect(),
+      recoverFailedReconnect: () => this.connectionClose.recoverFailedDeferredDisconnect(),
+      reportReconnectFailure: (error) =>
+        safeLogError('model-change reconnect failed', errorLogFields(error))
+    })
     this.connectionClose = new AcpConnectionCloseWorkflow({
       currentGeneration: () => this.connectionGeneration,
       currentStatus: () => this.snapshotOwner.status,
@@ -731,6 +741,7 @@ class AcpRuntime {
       transitions: this.connectionTransitions,
       resources: this.connectionResources,
       backendGeneration: this.backendGeneration,
+      modelChanges: this.modelChanges,
       state: closeState,
       reportFailure: (message, error) => safeLogError(message, errorLogFields(error))
     })
@@ -786,9 +797,7 @@ class AcpRuntime {
 
   private generationActivityChanged(): void {
     this.connectionTransitions.activityChanged()
-    if (this.pendingModelChange && !this.generationActivity.blockers().retirement) {
-      void this.drainModelChanges()
-    }
+    this.modelChanges.activityChanged()
   }
 
   private get connectionGeneration(): number {
@@ -954,20 +963,7 @@ class AcpRuntime {
   // operations wait on the barrier, while the operation that was already admitted finishes against
   // the old model.
   async applyModelChange(target: AgentModelChangeTarget): Promise<boolean> {
-    if (!this.canApplyModelChange(target)) return false
-
-    if (!this.modelChangeDrain && this.modelChangeMatchesCurrent(target)) {
-      this.pendingModelChange = undefined
-      this.completeModelChangeBarrier()
-      return true
-    }
-
-    this.pendingModelChange = target
-    this.armModelChangeBarrier()
-    if (this.generationActivity.blockers().retirement) return true
-
-    await this.drainModelChanges()
-    return true
+    return this.modelChanges.apply(target)
   }
 
   private canApplyModelChange(target: AgentModelChangeTarget): boolean {
@@ -999,63 +995,6 @@ class AcpRuntime {
       this.backend.context.supportsImageInput === target.supportsImageInput &&
       (this.backend.session.effort ?? 'default') === target.reasoningEffort
     )
-  }
-
-  private armModelChangeBarrier(): void {
-    if (this.modelChangeBarrier) return
-    this.modelChangeBarrier = new Promise<void>((resolve) => {
-      this.resolveModelChangeBarrier = resolve
-    })
-  }
-
-  private completeModelChangeBarrier(): void {
-    const resolveBarrier = this.resolveModelChangeBarrier
-    this.modelChangeBarrier = undefined
-    this.resolveModelChangeBarrier = undefined
-    resolveBarrier?.()
-  }
-
-  private cancelPendingModelChange(): void {
-    this.pendingModelChange = undefined
-    if (!this.modelChangeDrain) this.completeModelChangeBarrier()
-  }
-
-  private drainModelChanges(): Promise<void> {
-    if (this.modelChangeDrain) return this.modelChangeDrain
-
-    const drain = this.drainModelChangeQueue()
-    this.modelChangeDrain = drain
-    const finalize = (): void => {
-      if (this.modelChangeDrain !== drain) return
-      this.modelChangeDrain = undefined
-      if (this.pendingModelChange && !this.generationActivity.blockers().retirement) {
-        void this.drainModelChanges()
-      } else if (!this.pendingModelChange) {
-        this.completeModelChangeBarrier()
-      }
-    }
-    void drain.then(finalize, finalize)
-    return drain
-  }
-
-  private async drainModelChangeQueue(): Promise<void> {
-    while (this.pendingModelChange && !this.generationActivity.blockers().retirement) {
-      const target = this.pendingModelChange
-      this.pendingModelChange = undefined
-
-      if (!this.canApplyModelChange(target) || !(await this.applyModelTarget(target))) {
-        this.pendingModelChange = undefined
-        // Arm the existing reconnect barrier before releasing model admission. A failed or
-        // incompatible live apply must never admit a prompt onto a partially switched generation.
-        try {
-          await this.connectionTransitions.requestProviderReconnect()
-        } catch (error) {
-          safeLogError('model-change reconnect failed', errorLogFields(error))
-          this.connectionClose.recoverFailedDeferredDisconnect()
-        }
-        return
-      }
-    }
   }
 
   private async applyModelTarget(target: AgentModelChangeTarget): Promise<boolean> {
@@ -2289,7 +2228,6 @@ class AcpRuntime {
 
   // Tears down every local session route and closes the underlying agent process.
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
-    this.cancelPendingModelChange()
     return this.connectionClose.disconnect(emitClosedStatus)
   }
 
@@ -2298,7 +2236,6 @@ class AcpRuntime {
   // the app is gone would be an orphaned process still holding its network connection open. The OS
   // reclaims the remaining connection/session state as the process exits.
   shutdown(): void {
-    this.cancelPendingModelChange()
     this.connectionClose.shutdown()
   }
 
@@ -2328,8 +2265,6 @@ class AcpRuntime {
   // Retires this framework generation without interrupting active turns or background workflows. The
   // coordinator stops routing new work here immediately; teardown waits for every prompt and lease.
   async requestRetirement(): Promise<void> {
-    this.cancelPendingModelChange()
-    await this.modelChangeDrain
     await this.connectionClose.requestRetirement()
   }
 
@@ -2338,8 +2273,6 @@ class AcpRuntime {
   // until the session goes idle. Because every provider shares one config dir, the reconnect resumes the
   // conversation on the new provider with full context. Called when the active provider changes.
   async requestProviderReconnect(): Promise<void> {
-    this.cancelPendingModelChange()
-    await this.modelChangeDrain
     await this.connectionClose.requestProviderReconnect()
   }
 
@@ -2352,7 +2285,7 @@ class AcpRuntime {
   }
 
   private withOperationLease<T>(work: () => Promise<T>): Promise<T> {
-    const barrier = this.modelChangeBarrier ?? this.reconnectBarrier
+    const barrier = this.modelChanges.barrier ?? this.reconnectBarrier
     if (barrier) {
       return barrier.then(() => this.withOperationLease(work))
     }
@@ -2400,10 +2333,7 @@ class AcpRuntime {
       onProcessStderr: (text, context) => this.handleAgentProcessStderr(text, context),
       onProcessError: (error, context) => this.handleAgentProcessError(error, context),
       onProcessExit: (code, signal, context) => this.handleAgentProcessExit(code, signal, context),
-      onConnectionClosed: () => {
-        this.cancelPendingModelChange()
-        this.connectionClose.handleUnexpectedClose()
-      },
+      onConnectionClosed: () => this.connectionClose.handleUnexpectedClose(),
       reportCleanupFailure: (stage, error, framework, epoch) => {
         if (stage === 'bridge-lease') {
           safeLogError('responses bridge lease release failed', errorLogFields(error))

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -51,6 +51,7 @@ import {
   claudeCodeFramework,
   getAgentFramework,
   type AgentFramework,
+  type AgentModelChangeTarget,
   type ResolvedAgentBackend
 } from '../agent-framework'
 import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
@@ -58,6 +59,10 @@ import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import { extractProviderToolName } from './runtime-events'
 import { toCodexTurnTokenUsage } from './codex-turn-usage'
 import { fetchOpenCodeUsageSnapshot, sumOpenCodeTurnUsage } from './opencode-turn-usage'
+import {
+  matchSessionModelOption,
+  resolveSessionEffortOption
+} from './session-config'
 import { describePromptError, isProviderPromptError } from './prompt-error'
 import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { ConversationPermissionGrantStore } from './permission-broker'
@@ -512,6 +517,10 @@ class AcpRuntime {
   private readonly promptContentOwner: AcpPromptContentOwner
   private readonly connectionClose: AcpConnectionCloseWorkflow
   private readonly connectionLifecycle: AcpConnectionLifecycleWorkflow
+  private pendingModelChange: AgentModelChangeTarget | undefined
+  private modelChangeBarrier: Promise<void> | undefined
+  private resolveModelChangeBarrier: (() => void) | undefined
+  private modelChangeDrain: Promise<void> | undefined
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -523,7 +532,7 @@ class AcpRuntime {
       }
     })
     this.generationActivity = new AcpGenerationActivityOwner({
-      activityChanged: () => this.connectionTransitions.activityChanged(),
+      activityChanged: () => this.generationActivityChanged(),
       hasActivePrompts: () => this.sessionInteractions.snapshot().length > 0,
       hasActiveReviewerSessions: () => this.reviewerSessions.hasActiveSessions()
     })
@@ -652,7 +661,7 @@ class AcpRuntime {
         this.permissionContext.clearCorrelationsForSession(sessionId),
       currentStartupGeneration: () => this.sessionRegistry.startupGeneration,
       isPrimarySessionIdClaimed: (sessionId) => this.sessionRegistry.isIdentityClaimed(sessionId),
-      onActiveSessionReleased: () => this.connectionTransitions.activityChanged(),
+      onActiveSessionReleased: () => this.generationActivityChanged(),
       registerBridgeSession: (sessionId) =>
         this.connectionResources.registerBridgeReviewerSession(sessionId),
       removeStartupBlocker: (token) => this.generationActivity.releaseStartup(token),
@@ -776,6 +785,13 @@ class AcpRuntime {
 
   private get reconnectBarrier(): Promise<void> | undefined {
     return this.connectionTransitions.barrier
+  }
+
+  private generationActivityChanged(): void {
+    this.connectionTransitions.activityChanged()
+    if (this.pendingModelChange && !this.generationActivity.blockers().retirement) {
+      void this.drainModelChanges()
+    }
   }
 
   private get connectionGeneration(): number {
@@ -934,6 +950,198 @@ class AcpRuntime {
   // turn is still writing, while a crashed run — absent here — correctly surfaces as orphaned.
   getActiveArtifactRunIds(): string[] {
     return this.artifactTurns?.activeRunIds() ?? []
+  }
+
+  // Accepts a model selection without interrupting a live generation. The picker may keep changing
+  // while work is active; one pending slot deliberately makes the latest selection win. New runtime
+  // operations wait on the barrier, while the operation that was already admitted finishes against
+  // the old model.
+  async applyModelChange(target: AgentModelChangeTarget): Promise<boolean> {
+    if (!this.canApplyModelChange(target)) return false
+
+    if (!this.modelChangeDrain && this.modelChangeMatchesCurrent(target)) {
+      this.pendingModelChange = undefined
+      this.completeModelChangeBarrier()
+      return true
+    }
+
+    this.pendingModelChange = target
+    this.armModelChangeBarrier()
+    if (this.generationActivity.blockers().retirement) return true
+
+    await this.drainModelChanges()
+    return true
+  }
+
+  private canApplyModelChange(target: AgentModelChangeTarget): boolean {
+    return (
+      !this.connectionResources.isShuttingDown &&
+      !this.pendingProviderReconnect &&
+      this.snapshotOwner.status === 'connected' &&
+      this.connection !== undefined &&
+      this.activeSessionEntries().length > 0 &&
+      this.framework.id === target.frameworkId &&
+      this.backendId === target.backendId &&
+      this.backend.modelRoute === target.route
+    )
+  }
+
+  private modelChangeMatchesCurrent(target: AgentModelChangeTarget): boolean {
+    return (
+      this.backend.context.model === target.model &&
+      this.backend.session.model === target.sessionModel &&
+      (this.backend.session.effort ?? 'default') === target.reasoningEffort
+    )
+  }
+
+  private armModelChangeBarrier(): void {
+    if (this.modelChangeBarrier) return
+    this.modelChangeBarrier = new Promise<void>((resolve) => {
+      this.resolveModelChangeBarrier = resolve
+    })
+  }
+
+  private completeModelChangeBarrier(): void {
+    const resolveBarrier = this.resolveModelChangeBarrier
+    this.modelChangeBarrier = undefined
+    this.resolveModelChangeBarrier = undefined
+    resolveBarrier?.()
+  }
+
+  private cancelPendingModelChange(): void {
+    this.pendingModelChange = undefined
+    if (!this.modelChangeDrain) this.completeModelChangeBarrier()
+  }
+
+  private drainModelChanges(): Promise<void> {
+    if (this.modelChangeDrain) return this.modelChangeDrain
+
+    const drain = this.drainModelChangeQueue()
+    this.modelChangeDrain = drain
+    const finalize = (): void => {
+      if (this.modelChangeDrain !== drain) return
+      this.modelChangeDrain = undefined
+      if (this.pendingModelChange && !this.generationActivity.blockers().retirement) {
+        void this.drainModelChanges()
+      } else if (!this.pendingModelChange) {
+        this.completeModelChangeBarrier()
+      }
+    }
+    void drain.then(finalize, finalize)
+    return drain
+  }
+
+  private async drainModelChangeQueue(): Promise<void> {
+    while (this.pendingModelChange && !this.generationActivity.blockers().retirement) {
+      const target = this.pendingModelChange
+      this.pendingModelChange = undefined
+
+      if (!this.canApplyModelChange(target) || !(await this.applyModelTarget(target))) {
+        this.pendingModelChange = undefined
+        // Arm the existing reconnect barrier before releasing model admission. A failed or
+        // incompatible live apply must never admit a prompt onto a partially switched generation.
+        try {
+          await this.connectionTransitions.requestProviderReconnect()
+        } catch (error) {
+          safeLogError('model-change reconnect failed', errorLogFields(error))
+          this.connectionClose.recoverFailedDeferredDisconnect()
+        }
+        return
+      }
+    }
+  }
+
+  private async applyModelTarget(target: AgentModelChangeTarget): Promise<boolean> {
+    const connection = this.connection
+    if (!connection) return false
+
+    try {
+      if (target.bridge) {
+        const bridgeUpdated = this.connectionResources.setBridgeModelTarget({
+          ...target.bridge,
+          ...(target.reasoningEffort === 'default'
+            ? { reasoningEffort: undefined }
+            : { reasoningEffort: target.reasoningEffort })
+        })
+        if (!bridgeUpdated) return false
+      }
+
+      const results = new Map<
+        string,
+        { appliedModel: string; configOptions: SessionConfigOption[] | null | undefined }
+      >()
+
+      for (const [appSessionId, session] of this.activeSessionEntries()) {
+        const priorOptions =
+          (this.sessionRegistry.lookup(appSessionId)?.aggregate.snapshot().configOptions as
+            readonly SessionConfigOption[] | undefined) ??
+          (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
+            .newSessionResponse?.configOptions
+        let configOptions: SessionConfigOption[] | null | undefined = priorOptions
+          ? structuredClone([...priorOptions])
+          : priorOptions
+        let appliedModel = target.sessionModel
+
+        // The Chat-to-Responses bridge keeps the ACP transport model fixed; only its upstream target
+        // changes. Other routes switch the session's advertised model option in place.
+        if (target.route !== 'codex-bridge') {
+          const selection = matchSessionModelOption(configOptions, target.sessionModel)
+          if (!selection) return false
+          appliedModel = selection.value
+
+          if (!selection.alreadyCurrent) {
+            this.assertCurrentConnectedConnection(connection)
+            const response = (await connection.agent.request(
+              acp.methods.agent.session.setConfigOption,
+              {
+                sessionId: session.sessionId,
+                configId: selection.configId,
+                value: selection.value
+              }
+            )) as { configOptions?: SessionConfigOption[] | null }
+            configOptions = response?.configOptions ?? configOptions
+          }
+
+          if (this.framework.supportsLiveEffortChange && target.reasoningEffort !== 'default') {
+            const effortSelection = resolveSessionEffortOption(
+              configOptions,
+              target.reasoningEffort
+            )
+            if (!effortSelection) return false
+            const response = (await connection.agent.request(
+              acp.methods.agent.session.setConfigOption,
+              {
+                sessionId: session.sessionId,
+                configId: effortSelection.configId,
+                value: effortSelection.value
+              }
+            )) as { configOptions?: SessionConfigOption[] | null }
+            configOptions = response?.configOptions ?? configOptions
+          }
+        }
+
+        results.set(appSessionId, { appliedModel, configOptions })
+      }
+
+      this.assertCurrentConnectedConnection(connection)
+      this.backendGeneration.updateModel(target)
+      for (const [appSessionId, result] of results) {
+        this.sessionRegistry
+          .lookup(appSessionId)
+          ?.aggregate.updateModel(result.appliedModel, result.configOptions)
+      }
+      this.contextUsageTracker.clear()
+      for (const appSessionId of results.keys()) this.ensureContextUsageTracking(appSessionId)
+      this.emitState()
+      log.info('session model change applied', this.diagnosticContext())
+      return true
+    } catch (error) {
+      log.warn('live session model change failed', {
+        ...diagnosticErrorFields(error),
+        ...this.diagnosticContext()
+      })
+      return false
+    }
   }
 
   // Live-applies a reasoning-effort change to every open session — the ACP equivalent of a model
@@ -2038,6 +2246,7 @@ class AcpRuntime {
 
   // Tears down every local session route and closes the underlying agent process.
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
+    this.cancelPendingModelChange()
     return this.connectionClose.disconnect(emitClosedStatus)
   }
 
@@ -2046,6 +2255,7 @@ class AcpRuntime {
   // the app is gone would be an orphaned process still holding its network connection open. The OS
   // reclaims the remaining connection/session state as the process exits.
   shutdown(): void {
+    this.cancelPendingModelChange()
     this.connectionClose.shutdown()
   }
 
@@ -2075,6 +2285,8 @@ class AcpRuntime {
   // Retires this framework generation without interrupting active turns or background workflows. The
   // coordinator stops routing new work here immediately; teardown waits for every prompt and lease.
   async requestRetirement(): Promise<void> {
+    this.cancelPendingModelChange()
+    await this.modelChangeDrain
     await this.connectionClose.requestRetirement()
   }
 
@@ -2083,6 +2295,8 @@ class AcpRuntime {
   // until the session goes idle. Because every provider shares one config dir, the reconnect resumes the
   // conversation on the new provider with full context. Called when the active provider changes.
   async requestProviderReconnect(): Promise<void> {
+    this.cancelPendingModelChange()
+    await this.modelChangeDrain
     await this.connectionClose.requestProviderReconnect()
   }
 
@@ -2094,7 +2308,11 @@ class AcpRuntime {
     return this.generationActivity.withActivity(() => work(this))
   }
 
-  private async withOperationLease<T>(work: () => Promise<T>): Promise<T> {
+  private withOperationLease<T>(work: () => Promise<T>): Promise<T> {
+    const barrier = this.modelChangeBarrier ?? this.reconnectBarrier
+    if (barrier) {
+      return barrier.then(() => this.withOperationLease(work))
+    }
     return this.generationActivity.withOperation(work)
   }
 
@@ -2139,7 +2357,10 @@ class AcpRuntime {
       onProcessStderr: (text, context) => this.handleAgentProcessStderr(text, context),
       onProcessError: (error, context) => this.handleAgentProcessError(error, context),
       onProcessExit: (code, signal, context) => this.handleAgentProcessExit(code, signal, context),
-      onConnectionClosed: () => this.connectionClose.handleUnexpectedClose(),
+      onConnectionClosed: () => {
+        this.cancelPendingModelChange()
+        this.connectionClose.handleUnexpectedClose()
+      },
       reportCleanupFailure: (stage, error, framework, epoch) => {
         if (stage === 'bridge-lease') {
           safeLogError('responses bridge lease release failed', errorLogFields(error))
@@ -2756,7 +2977,7 @@ class AcpRuntime {
       }
       turnSkillHandle.close(turnSkillOutcome)
       if (turnSkillHandle.reloadDecision.kind === 'continue') {
-        this.connectionTransitions.activityChanged()
+        this.generationActivityChanged()
       }
     }
   }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -990,6 +990,7 @@ class AcpRuntime {
     return (
       this.backend.context.model === target.model &&
       this.backend.session.model === target.sessionModel &&
+      this.backend.context.supportsImageInput === target.supportsImageInput &&
       (this.backend.session.effort ?? 'default') === target.reasoningEffort
     )
   }
@@ -1054,6 +1055,16 @@ class AcpRuntime {
   private async applyModelTarget(target: AgentModelChangeTarget): Promise<boolean> {
     const connection = this.connection
     if (!connection) return false
+    if (
+      this.backend.context.supportsImageInput &&
+      !target.supportsImageInput &&
+      (target.route === 'claude-anthropic' || target.route === 'codex-bridge')
+    ) {
+      // Claude retains opaque SDK history, while the Codex bridge keeps an image-capable transport
+      // model. Neither can prove that images from earlier turns will be removed for a text-only
+      // upstream model, so reuse the reconnect/resume path that already filters image history.
+      return false
+    }
 
     try {
       if (target.bridge) {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1062,6 +1062,17 @@ class AcpRuntime {
     const connection = this.connection
     if (!connection) return false
     if (
+      this.framework.id === 'codex' &&
+      target.route !== 'codex-bridge' &&
+      this.backendId !== target.backendId &&
+      this.backend.session.model === target.sessionModel
+    ) {
+      // Native Codex catalogs capability metadata by model slug. Two providers may reuse one slug
+      // for models with different image, context, or effort capabilities, which the live session
+      // cannot distinguish. Reconnect so the newly selected provider owns a fresh catalog entry.
+      return false
+    }
+    if (
       this.backend.context.supportsImageInput &&
       !target.supportsImageInput &&
       (target.route === 'claude-anthropic' || target.route === 'codex-bridge')
@@ -1131,7 +1142,10 @@ class AcpRuntime {
             configOptions = response?.configOptions ?? configOptions
           }
 
-          if (this.framework.supportsLiveEffortChange && target.reasoningEffort !== 'default') {
+          const shouldApplyEffort =
+            this.framework.supportsLiveEffortChange &&
+            (target.reasoningEffort !== 'default' || this.backend.session.effort !== undefined)
+          if (shouldApplyEffort) {
             const effortSelection = resolveSessionEffortOption(
               configOptions,
               target.reasoningEffort

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -59,10 +59,7 @@ import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import { extractProviderToolName } from './runtime-events'
 import { toCodexTurnTokenUsage } from './codex-turn-usage'
 import { fetchOpenCodeUsageSnapshot, sumOpenCodeTurnUsage } from './opencode-turn-usage'
-import {
-  matchSessionModelOption,
-  resolveSessionEffortOption
-} from './session-config'
+import { matchSessionModelOption, resolveSessionEffortOption } from './session-config'
 import { describePromptError, isProviderPromptError } from './prompt-error'
 import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { ConversationPermissionGrantStore } from './permission-broker'

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -971,6 +971,12 @@ class AcpRuntime {
   }
 
   private canApplyModelChange(target: AgentModelChangeTarget): boolean {
+    const backendCompatible =
+      this.backendId === target.backendId ||
+      (this.framework.id === 'claude-code' &&
+        target.route === 'claude-anthropic' &&
+        target.anthropicBridgeTargetId !== undefined &&
+        this.connectionResources.anthropicBridgeAvailable)
     return (
       !this.connectionResources.isShuttingDown &&
       !this.pendingProviderReconnect &&
@@ -978,13 +984,14 @@ class AcpRuntime {
       this.connection !== undefined &&
       this.activeSessionEntries().length > 0 &&
       this.framework.id === target.frameworkId &&
-      this.backendId === target.backendId &&
+      backendCompatible &&
       this.backend.modelRoute === target.route
     )
   }
 
   private modelChangeMatchesCurrent(target: AgentModelChangeTarget): boolean {
     return (
+      this.backendId === target.backendId &&
       this.backend.context.model === target.model &&
       this.backend.session.model === target.sessionModel &&
       this.backend.context.supportsImageInput === target.supportsImageInput &&
@@ -1064,6 +1071,11 @@ class AcpRuntime {
     }
 
     try {
+      if (target.anthropicBridgeTargetId) {
+        if (!this.connectionResources.setAnthropicBridgeTarget(target.anthropicBridgeTargetId)) {
+          return false
+        }
+      }
       if (target.bridge) {
         const bridgeUpdated = this.connectionResources.setBridgeModelTarget({
           ...target.bridge,
@@ -1136,7 +1148,7 @@ class AcpRuntime {
       for (const [appSessionId, result] of results) {
         this.sessionRegistry
           .lookup(appSessionId)
-          ?.aggregate.updateModel(result.appliedModel, result.configOptions)
+          ?.aggregate.updateModel(result.appliedModel, result.configOptions, target.backendId)
       }
       this.contextUsageTracker.clear()
       for (const appSessionId of results.keys()) this.ensureContextUsageTracking(appSessionId)
@@ -2372,6 +2384,10 @@ class AcpRuntime {
       reportCleanupFailure: (stage, error, framework, epoch) => {
         if (stage === 'bridge-lease') {
           safeLogError('responses bridge lease release failed', errorLogFields(error))
+          return
+        }
+        if (stage === 'anthropic-bridge-lease') {
+          safeLogError('Anthropic bridge lease release failed', errorLogFields(error))
           return
         }
         safeLogError(`unattached ACP ${stage} cleanup failed`, {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -976,7 +976,9 @@ class AcpRuntime {
       (this.framework.id === 'claude-code' &&
         target.route === 'claude-anthropic' &&
         target.anthropicBridgeTargetId !== undefined &&
-        this.connectionResources.anthropicBridgeAvailable)
+        this.connectionResources.anthropicBridgeAvailable) ||
+      (target.providerTransportTargetId !== undefined &&
+        this.connectionResources.providerTransportAvailable)
     return (
       !this.connectionResources.isShuttingDown &&
       !this.pendingProviderReconnect &&
@@ -1071,6 +1073,13 @@ class AcpRuntime {
     }
 
     try {
+      if (target.providerTransportTargetId) {
+        if (
+          !this.connectionResources.setProviderTransportTarget(target.providerTransportTargetId)
+        ) {
+          return false
+        }
+      }
       if (target.anthropicBridgeTargetId) {
         if (!this.connectionResources.setAnthropicBridgeTarget(target.anthropicBridgeTargetId)) {
           return false
@@ -2388,6 +2397,10 @@ class AcpRuntime {
         }
         if (stage === 'anthropic-bridge-lease') {
           safeLogError('Anthropic bridge lease release failed', errorLogFields(error))
+          return
+        }
+        if (stage === 'provider-transport-lease') {
+          safeLogError('provider transport lease release failed', errorLogFields(error))
           return
         }
         safeLogError(`unattached ACP ${stage} cleanup failed`, {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1136,6 +1136,12 @@ class AcpRuntime {
   // either). On success the generation view tracks the new level, so sessions created later in
   // this process inherit it; the persisted setting covers the next respawn.
   async applyReasoningEffortChange(effort: ResolvedReasoningEffort): Promise<boolean> {
+    const modelChangeBarrier = this.modelChanges.barrier
+    if (modelChangeBarrier) {
+      await modelChangeBarrier
+      return this.applyReasoningEffortChange(effort)
+    }
+
     // A provider/model switch may be waiting for an in-flight turn to finish. The incoming effort was
     // resolved against that newly selected model, while this connection still owns the old one. Let
     // the persisted setting reach the fresh backend after reconnect instead of leaking it here.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2774,6 +2774,15 @@ class AcpRuntime {
       }
 
       // Start the prompt and race it against routed updates from the active session queue.
+      if (request.historyPreamble) {
+        log.info('session transcript replay dispatched', {
+          sessionId: request.sessionId,
+          historyTextLength: request.historyPreamble.length,
+          historyAttachmentCount: request.historyAttachments?.length ?? 0,
+          historyImageCount: request.historyImages?.length ?? 0,
+          ...this.diagnosticContext()
+        })
+      }
       const promptFailure = new Promise<never>((_, reject) => {
         activeSession.prompt(promptContent).catch(reject)
       })

--- a/src/main/acp/session-aggregate.ts
+++ b/src/main/acp/session-aggregate.ts
@@ -131,7 +131,12 @@ class AcpSessionAggregate {
     this.refreshSnapshot()
   }
 
-  updateModel(appliedModel: string, configOptions: SessionConfigOption[] | null | undefined): void {
+  updateModel(
+    appliedModel: string,
+    configOptions: SessionConfigOption[] | null | undefined,
+    backendId?: string
+  ): void {
+    if (backendId !== undefined) this.backendId = backendId
     this.appliedModel = appliedModel
     this.configOptions = cloneConfigOptions(configOptions)
     this.refreshSnapshot()

--- a/src/main/acp/session-aggregate.ts
+++ b/src/main/acp/session-aggregate.ts
@@ -131,6 +131,12 @@ class AcpSessionAggregate {
     this.refreshSnapshot()
   }
 
+  updateModel(appliedModel: string, configOptions: SessionConfigOption[] | null | undefined): void {
+    this.appliedModel = appliedModel
+    this.configOptions = cloneConfigOptions(configOptions)
+    this.refreshSnapshot()
+  }
+
   detachProvider(): void {
     this.session = undefined
     this.appliedModel = undefined

--- a/src/main/acp/session-configurator.test.ts
+++ b/src/main/acp/session-configurator.test.ts
@@ -14,7 +14,7 @@ const backendView = (
     framework,
     session: Object.freeze(session),
     prompt: Object.freeze({ systemPromptAppends: Object.freeze([]) }),
-    context: Object.freeze({}),
+    context: Object.freeze({ supportsImageInput: false }),
     adapter: Object.freeze({ nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false })
   })
 

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -412,6 +412,60 @@ describe('codexFramework', () => {
     expect(JSON.parse(second.env?.CODEX_CONFIG ?? '').model_catalog_json).toBe(secondCatalog?.path)
   })
 
+  it('advertises every same-route native model in one catalog for live ACP switching', () => {
+    const framework = createCodexFramework()
+    const activeProvider = {
+      type: 'custom' as const,
+      apiEndpoints: ['responses' as const],
+      baseUrl: 'https://gateway.example/v1',
+      model: 'vendor-model-a',
+      contextWindow: 128_000,
+      key: 'secret'
+    }
+    const config = framework.prepareModelConfig(activeProvider, {
+      storageRoot: '/data',
+      executablePath: '/runtime/codex-acp',
+      providerModelCatalog: [
+        {
+          provider: activeProvider,
+          reasoningEffort: 'high',
+          reasoningEfforts: ['low', 'high']
+        },
+        {
+          provider: {
+            ...activeProvider,
+            model: 'vendor-model-b',
+            contextWindow: 64_000,
+            supportsImageInput: true
+          },
+          reasoningEffort: 'low',
+          reasoningEfforts: ['low', 'medium']
+        }
+      ]
+    })
+
+    const codexConfig = JSON.parse(config.env?.CODEX_CONFIG ?? '')
+    const modelCatalogFile = config.configFiles?.find(
+      (file) => file.path === codexConfig.model_catalog_json
+    )
+    const models = JSON.parse(modelCatalogFile?.content ?? '').models
+
+    expect(models.map(({ slug }: { slug: string }) => slug)).toEqual([
+      'vendor-model-a',
+      'vendor-model-b'
+    ])
+    expect(models[0]).toMatchObject({
+      default_reasoning_level: 'high',
+      context_window: 128_000,
+      input_modalities: ['text']
+    })
+    expect(models[1]).toMatchObject({
+      default_reasoning_level: 'low',
+      context_window: 64_000,
+      input_modalities: ['text', 'image']
+    })
+  })
+
   it('maps the legacy shared subscription to the app-owned subscription home', () => {
     const framework = createCodexFramework({ platform: 'darwin' })
     const config = framework.prepareModelConfig(

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -18,6 +18,7 @@ import type { OfficialVendorId } from '../../shared/provider-registry'
 import type {
   AgentFramework,
   AgentAuthentication,
+  AgentModelCatalogEntry,
   AgentProviderConfiguration,
   AgentModelConfig,
   AgentSpawnInput,
@@ -180,7 +181,7 @@ const buildCodexConfig = (provider: {
   }
 }
 
-const buildCodexNativeModelCatalog = (provider: {
+type CodexNativeModelCatalogInput = {
   model?: string
   vendorId?: OfficialVendorId
   baseUrl?: string
@@ -190,7 +191,9 @@ const buildCodexNativeModelCatalog = (provider: {
   supportsImageInput?: boolean
   reasoningEffort?: ModelReasoningEffort
   reasoningEfforts?: readonly ModelReasoningEffort[]
-}): Record<string, unknown> | undefined => {
+}
+
+const buildCodexNativeModelCatalogEntry = (provider: CodexNativeModelCatalogInput): unknown => {
   const model = provider.model?.trim()
   // Bundled capabilities are trustworthy only for an exact model/version pair on OpenAI's official
   // backend. A custom provider may represent the real api.openai.com endpoint, so vendor identity
@@ -217,56 +220,83 @@ const buildCodexNativeModelCatalog = (provider: {
       : null
 
   return {
-    models: [
-      {
-        slug: model,
-        display_name: model,
-        description: null,
-        default_reasoning_level: defaultReasoningEffort,
-        supported_reasoning_levels: supportedReasoningEfforts.map((effort) => ({
-          effort,
-          description: `${effort === 'xhigh' ? 'Extra high' : effort.charAt(0).toUpperCase() + effort.slice(1)} reasoning effort`
-        })),
-        shell_type: 'shell_command',
-        // codex-acp obtains its session model options from app-server model/list. A hidden-only
-        // static catalog produces an empty list and makes session/new fail before the first prompt.
-        visibility: 'list',
-        supported_in_api: true,
-        priority: 99,
-        additional_speed_tiers: [],
-        service_tiers: [],
-        default_service_tier: null,
-        availability_nux: null,
-        upgrade: null,
-        base_instructions: codexNativeModelInstructions,
-        // Skill discovery is an app/runtime capability, not an optional upstream Responses tool.
-        // Keep Codex's native Skill guidance so materialized mcp-* connector skills remain usable.
-        include_skills_usage_instructions: true,
-        supports_reasoning_summaries: false,
-        default_reasoning_summary: 'none',
-        support_verbosity: false,
-        default_verbosity: null,
-        // Native Responses support does not imply support for OpenAI custom/freeform tools, hosted
-        // search, or parallel calls. Advertise only the function-shaped shell tool until the provider
-        // registry can express and verify those capabilities explicitly.
-        apply_patch_tool_type: null,
-        truncation_policy: { mode: 'tokens', limit: 10_000 },
-        supports_parallel_tool_calls: false,
-        supports_image_detail_original: false,
-        context_window: contextWindow,
-        max_context_window: contextWindow,
-        comp_hash: null,
-        effective_context_window_percent: CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
-        experimental_supported_tools: [],
-        input_modalities: provider.supportsImageInput ? ['text', 'image'] : ['text'],
-        supports_search_tool: false,
-        use_responses_lite: false,
-        auto_review_model_override: null,
-        tool_mode: null,
-        multi_agent_version: null
-      }
-    ]
+    slug: model,
+    display_name: model,
+    description: null,
+    default_reasoning_level: defaultReasoningEffort,
+    supported_reasoning_levels: supportedReasoningEfforts.map((effort) => ({
+      effort,
+      description: `${effort === 'xhigh' ? 'Extra high' : effort.charAt(0).toUpperCase() + effort.slice(1)} reasoning effort`
+    })),
+    shell_type: 'shell_command',
+    // codex-acp obtains its session model options from app-server model/list. A hidden-only
+    // static catalog produces an empty list and makes session/new fail before the first prompt.
+    visibility: 'list',
+    supported_in_api: true,
+    priority: 99,
+    additional_speed_tiers: [],
+    service_tiers: [],
+    default_service_tier: null,
+    availability_nux: null,
+    upgrade: null,
+    base_instructions: codexNativeModelInstructions,
+    // Skill discovery is an app/runtime capability, not an optional upstream Responses tool.
+    // Keep Codex's native Skill guidance so materialized mcp-* connector skills remain usable.
+    include_skills_usage_instructions: true,
+    supports_reasoning_summaries: false,
+    default_reasoning_summary: 'none',
+    support_verbosity: false,
+    default_verbosity: null,
+    // Native Responses support does not imply support for OpenAI custom/freeform tools, hosted
+    // search, or parallel calls. Advertise only the function-shaped shell tool until the provider
+    // registry can express and verify those capabilities explicitly.
+    apply_patch_tool_type: null,
+    truncation_policy: { mode: 'tokens', limit: 10_000 },
+    supports_parallel_tool_calls: false,
+    supports_image_detail_original: false,
+    context_window: contextWindow,
+    max_context_window: contextWindow,
+    comp_hash: null,
+    effective_context_window_percent: CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+    experimental_supported_tools: [],
+    input_modalities: provider.supportsImageInput ? ['text', 'image'] : ['text'],
+    supports_search_tool: false,
+    use_responses_lite: false,
+    auto_review_model_override: null,
+    tool_mode: null,
+    multi_agent_version: null
   }
+}
+
+const buildCodexNativeModelCatalog = (
+  provider: CodexNativeModelCatalogInput,
+  catalog: readonly AgentModelCatalogEntry[] = []
+): Record<string, unknown> | undefined => {
+  const candidates = new Map<string, CodexNativeModelCatalogInput>()
+  for (const entry of catalog) {
+    const model = entry.provider.model?.trim()
+    if (!model) continue
+    candidates.set(model, {
+      ...entry.provider,
+      nativeVersion: provider.nativeVersion,
+      reasoningEffort: entry.reasoningEffort,
+      reasoningEfforts: entry.reasoningEfforts
+    })
+  }
+  if (provider.model) {
+    const catalogEntry = candidates.get(provider.model)
+    candidates.set(provider.model, {
+      ...catalogEntry,
+      ...provider,
+      reasoningEffort: provider.reasoningEffort ?? catalogEntry?.reasoningEffort,
+      reasoningEfforts: provider.reasoningEfforts ?? catalogEntry?.reasoningEfforts
+    })
+  }
+
+  const models = [...candidates.values()]
+    .map(buildCodexNativeModelCatalogEntry)
+    .filter((entry) => entry !== undefined)
+  return models.length > 0 ? { models } : undefined
 }
 
 const buildSpawnEnvironment = (
@@ -425,12 +455,15 @@ export const createCodexFramework = ({
     const codexHome = codexStorageDir(ctx.storageRoot)
     const modelCatalog = useChatBridge
       ? undefined
-      : buildCodexNativeModelCatalog({
-          ...provider,
-          nativeVersion: ctx.nativeVersion,
-          reasoningEffort: ctx.reasoningEffort,
-          reasoningEfforts: ctx.reasoningEfforts
-        })
+      : buildCodexNativeModelCatalog(
+          {
+            ...provider,
+            nativeVersion: ctx.nativeVersion,
+            reasoningEffort: ctx.reasoningEffort,
+            reasoningEfforts: ctx.reasoningEfforts
+          },
+          ctx.providerModelCatalog
+        )
     const modelCatalogContent = modelCatalog
       ? `${JSON.stringify(modelCatalog, null, 2)}\n`
       : undefined

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -370,6 +370,56 @@ describe('opencodeFramework.prepareModelConfig', () => {
     expect(fileConfig.provider.anthropic.models).toEqual({ m: {} })
     expect(content.provider.anthropic.models).toEqual({ m: {} })
   })
+
+  it('registers every same-route provider model so ACP can switch without a respawn', () => {
+    const activeProvider = {
+      type: 'official' as const,
+      vendorId: 'deepseek' as const,
+      baseUrl: 'https://api.deepseek.com/v1',
+      apiEndpoints: ['anthropic' as const],
+      model: 'deepseek-v4-pro',
+      contextWindow: 128_000,
+      key: 'k'
+    }
+    const config = opencodeFramework.prepareModelConfig(activeProvider, {
+      storageRoot: '/data',
+      executablePath: '/bin/opencode',
+      reasoningEffort: 'high',
+      providerModelCatalog: [
+        { provider: activeProvider, reasoningEffort: 'high' },
+        {
+          provider: {
+            ...activeProvider,
+            model: 'deepseek-v3.2',
+            contextWindow: 64_000,
+            supportsImageInput: true
+          },
+          reasoningEffort: 'low'
+        }
+      ]
+    })
+
+    const fileConfig = JSON.parse(
+      config.configFiles?.find((file) => file.path.endsWith('opencode.json'))?.content ?? '{}'
+    )
+    const pinnedConfig = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    const expectedModels = {
+      'deepseek-v4-pro': {
+        options: { reasoningEffort: 'high', thinking: { type: 'enabled' } },
+        limit: { context: 128_000, output: 32_000 }
+      },
+      'deepseek-v3.2': {
+        attachment: true,
+        modalities: { input: ['text', 'image'] },
+        options: { reasoningEffort: 'low', thinking: { type: 'enabled' } },
+        limit: { context: 64_000, output: 32_000 }
+      }
+    }
+
+    expect(fileConfig.model).toBe('anthropic/deepseek-v4-pro')
+    expect(fileConfig.provider.anthropic.models).toEqual(expectedModels)
+    expect(pinnedConfig.provider.anthropic.models).toEqual(expectedModels)
+  })
 })
 
 describe('buildOpencodeConfig', () => {

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -420,6 +420,52 @@ describe('opencodeFramework.prepareModelConfig', () => {
     expect(fileConfig.provider.anthropic.models).toEqual(expectedModels)
     expect(pinnedConfig.provider.anthropic.models).toEqual(expectedModels)
   })
+
+  it('registers immutable provider/model routes with separate local credentials', () => {
+    const activeProvider = {
+      type: 'custom' as const,
+      agentProviderId: 'open-science-a',
+      baseUrl: 'http://127.0.0.1:41001/v1',
+      apiEndpoints: ['openai' as const],
+      model: 'model-a',
+      key: 'local-token-a'
+    }
+    const secondProvider = {
+      type: 'custom' as const,
+      agentProviderId: 'open-science-b',
+      baseUrl: 'http://127.0.0.1:41002/v1',
+      apiEndpoints: ['openai' as const],
+      model: 'model-b',
+      key: 'local-token-b'
+    }
+    const config = opencodeFramework.prepareModelConfig(activeProvider, {
+      storageRoot: '/data',
+      executablePath: '/bin/opencode',
+      providerModelCatalog: [{ provider: activeProvider }, { provider: secondProvider }]
+    })
+
+    const fileConfig = JSON.parse(
+      config.configFiles?.find((file) => file.path.endsWith('opencode.json'))?.content ?? '{}'
+    )
+    const pinnedConfig = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+
+    expect(config.sessionModel).toBe('open-science-a/model-a')
+    expect(fileConfig.model).toBe('open-science-a/model-a')
+    expect(Object.keys(fileConfig.provider)).toEqual(['open-science-a', 'open-science-b'])
+    expect(fileConfig.provider['open-science-a'].options).toEqual({
+      baseURL: 'http://127.0.0.1:41001/v1',
+      apiKey: '{env:OPENCODE_APP_API_KEY_OPEN_SCIENCE_A}'
+    })
+    expect(fileConfig.provider['open-science-b'].options).toEqual({
+      baseURL: 'http://127.0.0.1:41002/v1',
+      apiKey: '{env:OPENCODE_APP_API_KEY_OPEN_SCIENCE_B}'
+    })
+    expect(fileConfig.provider['open-science-a'].models).toEqual({ 'model-a': {} })
+    expect(fileConfig.provider['open-science-b'].models).toEqual({ 'model-b': {} })
+    expect(pinnedConfig.provider).toEqual(fileConfig.provider)
+    expect(config.env?.OPENCODE_APP_API_KEY_OPEN_SCIENCE_A).toBe('local-token-a')
+    expect(config.env?.OPENCODE_APP_API_KEY_OPEN_SCIENCE_B).toBe('local-token-b')
+  })
 })
 
 describe('buildOpencodeConfig', () => {

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -15,6 +15,7 @@ import type { ResolvedProvider } from '../settings/provider-env'
 import { resolveChatReasoningTransport } from '../settings/reasoning-transport'
 import type {
   AgentFramework,
+  AgentModelCatalogEntry,
   AgentModelConfig,
   AgentSpawnInput,
   ModelConfigContext,
@@ -182,67 +183,30 @@ const buildModelCapabilities = (
   }
 }
 
-// The app-authoritative config layer (model + provider block + permission policy) passed verbatim to
-// opencode via OPENCODE_CONFIG_CONTENT, which opencode deep-merges ABOVE both the app-owned global config
-// and any project config. Pinning the provider/model/baseURL here (not just permission) means a
-// lower-precedence config — e.g. the user's own ~/.opencode — cannot repoint the active provider's
-// baseURL or switch the model to an attacker-defined provider while inheriting the app's key ref, so the
-// real key can only ever go to the app's own endpoint. The key stays an env reference, never plaintext.
-const buildAppConfigContent = (
+const opencodeModelCatalog = (
   provider: ResolvedProvider,
-  reasoningEffort?: ModelReasoningEffort
-): Record<string, unknown> => {
-  const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
-  const modelConfig = {
-    ...buildModelCapabilities(provider, reasoningEffort),
-    ...(provider.contextWindow === undefined
-      ? {}
-      : {
-          limit: {
-            context: provider.contextWindow,
-            output: opencodeOutputLimit(provider.contextWindow)
-          }
-        })
+  reasoningEffort: ModelReasoningEffort | undefined,
+  catalog: readonly AgentModelCatalogEntry[] = []
+): AgentModelCatalogEntry[] => {
+  const active: AgentModelCatalogEntry = { provider, reasoningEffort }
+  const providerId = resolveOpencodeEndpoint(provider).providerId
+  const models = new Map<string, AgentModelCatalogEntry>()
+  for (const entry of [...catalog, active]) {
+    const endpoint = resolveOpencodeEndpoint(entry.provider)
+    if (!endpoint.bareModel || endpoint.providerId !== providerId) continue
+    models.set(endpoint.bareModel, entry)
   }
-
-  return {
-    ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
-    permission: { ...OPENCODE_PERMISSION_RULES },
-    provider: {
-      [providerId]: {
-        ...(npm ? { npm } : {}),
-        options: {
-          ...(baseURL ? { baseURL } : {}),
-          ...(provider.key ? { apiKey: `{env:${OPENCODE_API_KEY_ENV}}` } : {})
-        },
-        ...(bareModel ? { models: { [bareModel]: modelConfig } } : {})
-      }
-    }
-  }
+  return [...models.values()]
 }
 
-// Builds opencode's config by MERGING the app's active provider/model onto the user's existing config
-// so their own providers, mcp servers, and auth are preserved. The model is both selected (top-level
-// `model`) and registered under the provider's `models` map — without the registration opencode does
-// not recognize a non-catalog model id (e.g. a custom gateway's `deepseek-v4-pro`) and silently falls
-// back to its own default. Verified against opencode 1.17.13.
-const buildOpencodeConfig = (
+const buildOpencodeModelConfig = (
   provider: ResolvedProvider,
-  baseConfig: Record<string, unknown> = {},
-  instructionPaths: string[] = [],
-  reasoningEffort?: ModelReasoningEffort
-): string => {
-  const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
-
-  const baseProviders = asRecord(baseConfig.provider)
-  const baseProvider = asRecord(baseProviders[providerId])
-  const baseOptions = asRecord(baseProvider.options)
-  const baseModels = asRecord(baseProvider.models)
-  const baseModel = bareModel ? asRecord(baseModels[bareModel]) : {}
+  reasoningEffort: ModelReasoningEffort | undefined,
+  baseModel: Record<string, unknown> = {}
+): Record<string, unknown> => {
   const baseLimit = asRecord(baseModel.limit)
-  const basePermission = asRecord(baseConfig.permission)
   const modelCapabilities = buildModelCapabilities(provider, reasoningEffort)
-  const modelConfig = {
+  return {
     ...baseModel,
     ...modelCapabilities,
     ...(modelCapabilities.options
@@ -262,6 +226,72 @@ const buildOpencodeConfig = (
             output: opencodeOutputLimit(provider.contextWindow, baseLimit.output)
           }
         })
+  }
+}
+
+// The app-authoritative config layer (model + provider block + permission policy) passed verbatim to
+// opencode via OPENCODE_CONFIG_CONTENT, which opencode deep-merges ABOVE both the app-owned global config
+// and any project config. Pinning the provider/model/baseURL here (not just permission) means a
+// lower-precedence config — e.g. the user's own ~/.opencode — cannot repoint the active provider's
+// baseURL or switch the model to an attacker-defined provider while inheriting the app's key ref, so the
+// real key can only ever go to the app's own endpoint. The key stays an env reference, never plaintext.
+const buildAppConfigContent = (
+  provider: ResolvedProvider,
+  reasoningEffort?: ModelReasoningEffort,
+  catalog: readonly AgentModelCatalogEntry[] = []
+): Record<string, unknown> => {
+  const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
+  const models = Object.fromEntries(
+    opencodeModelCatalog(provider, reasoningEffort, catalog).flatMap((entry) => {
+      const model = resolveOpencodeEndpoint(entry.provider).bareModel
+      return model ? [[model, buildOpencodeModelConfig(entry.provider, entry.reasoningEffort)]] : []
+    })
+  )
+
+  return {
+    ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
+    permission: { ...OPENCODE_PERMISSION_RULES },
+    provider: {
+      [providerId]: {
+        ...(npm ? { npm } : {}),
+        options: {
+          ...(baseURL ? { baseURL } : {}),
+          ...(provider.key ? { apiKey: `{env:${OPENCODE_API_KEY_ENV}}` } : {})
+        },
+        ...(Object.keys(models).length > 0 ? { models } : {})
+      }
+    }
+  }
+}
+
+// Builds opencode's config by MERGING the app's active provider/model onto the user's existing config
+// so their own providers, mcp servers, and auth are preserved. The model is both selected (top-level
+// `model`) and registered under the provider's `models` map — without the registration opencode does
+// not recognize a non-catalog model id (e.g. a custom gateway's `deepseek-v4-pro`) and silently falls
+// back to its own default. Verified against opencode 1.17.13.
+const buildOpencodeConfig = (
+  provider: ResolvedProvider,
+  baseConfig: Record<string, unknown> = {},
+  instructionPaths: string[] = [],
+  reasoningEffort?: ModelReasoningEffort,
+  catalog: readonly AgentModelCatalogEntry[] = []
+): string => {
+  const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
+
+  const baseProviders = asRecord(baseConfig.provider)
+  const baseProvider = asRecord(baseProviders[providerId])
+  const baseOptions = asRecord(baseProvider.options)
+  const baseModels = asRecord(baseProvider.models)
+  const basePermission = asRecord(baseConfig.permission)
+  const models = { ...baseModels }
+  for (const entry of opencodeModelCatalog(provider, reasoningEffort, catalog)) {
+    const model = resolveOpencodeEndpoint(entry.provider).bareModel
+    if (!model) continue
+    models[model] = buildOpencodeModelConfig(
+      entry.provider,
+      entry.reasoningEffort,
+      asRecord(baseModels[model])
+    )
   }
   // Preserve any instructions the base config already declared, then append ours (de-duplicated).
   const baseInstructions = Array.isArray(baseConfig.instructions)
@@ -297,12 +327,9 @@ const buildOpencodeConfig = (
         },
         // Register the model so opencode treats a non-catalog id as a real, selectable model, declaring
         // its image capability when the active model is multimodal (else opencode strips image parts).
-        ...(bareModel
+        ...(Object.keys(models).length > 0
           ? {
-              models: {
-                ...baseModels,
-                [bareModel]: modelConfig
-              }
+              models
             }
           : {})
       }
@@ -389,7 +416,8 @@ export const opencodeFramework: AgentFramework = {
       provider,
       {},
       instructionPaths,
-      ctx.reasoningEffort
+      ctx.reasoningEffort,
+      ctx.providerModelCatalog
     )
 
     return {
@@ -422,7 +450,7 @@ export const opencodeFramework: AgentFramework = {
         // active provider's baseURL or swap the model to an attacker provider while inheriting the app's
         // `{env:...}` key ref. The key itself never rides this layer, only its env reference.
         OPENCODE_CONFIG_CONTENT: JSON.stringify(
-          buildAppConfigContent(provider, ctx.reasoningEffort)
+          buildAppConfigContent(provider, ctx.reasoningEffort, ctx.providerModelCatalog)
         ),
         // Pass the decrypted key ONLY via the environment; the config references it as `{env:...}`.
         ...(provider.key ? { [OPENCODE_API_KEY_ENV]: provider.key } : {})

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { join } from 'node:path'
 import type { SessionModeState } from '@agentclientprotocol/sdk'
 
@@ -54,6 +55,12 @@ const opencodeHomeDir = (storageRoot: string): string =>
 export const opencodeConfigDir = (storageRoot: string): string =>
   join(opencodeConfigHome(storageRoot), 'opencode')
 
+export const opencodeTransportProviderId = (providerId: string, model: string): string =>
+  `open-science-${createHash('sha256')
+    .update(JSON.stringify([providerId, model]))
+    .digest('hex')
+    .slice(0, 16)}`
+
 // The opencode provider block used for each endpoint. Anthropic /v1/messages maps to opencode's
 // built-in `anthropic` provider; OpenAI /v1/chat/completions maps to a custom provider backed by the
 // `@ai-sdk/openai-compatible` package. opencode drives both, so the endpoint is chosen from the
@@ -67,6 +74,11 @@ const OPENCODE_ENDPOINT_PROVIDER: Record<'anthropic' | 'openai', { id: string; n
 // generated config as `{env:...}` (opencode substitutes env refs at config-load time). This keeps the
 // plaintext key OFF disk — opencode.json only ever holds the reference, never the secret.
 const OPENCODE_API_KEY_ENV = 'OPENCODE_APP_API_KEY'
+
+const opencodeApiKeyEnv = (provider: ResolvedProvider): string =>
+  provider.agentProviderId
+    ? `${OPENCODE_API_KEY_ENV}_${provider.agentProviderId.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`
+    : OPENCODE_API_KEY_ENV
 
 // opencode's model `limit` block requires BOTH `context` and `output` (its config schema rejects a
 // limit that carries only one — "Missing key ...limit.output" and the ACP connection closes). We set
@@ -119,13 +131,20 @@ const asRecord = (value: unknown): Record<string, unknown> =>
 // provider/model they pin can never diverge.
 const resolveOpencodeEndpoint = (
   provider: ResolvedProvider
-): { bareModel: string | undefined; providerId: string; npm?: string; baseURL?: string } => {
+): {
+  apiKeyEnv: string
+  bareModel: string | undefined
+  providerId: string
+  npm?: string
+  baseURL?: string
+} => {
   const bareModel = provider.model
   // opencode drives both endpoints; pick the one for this provider (openai wins when it offers both).
   const endpoint =
     preferredEndpoint(provider.apiEndpoints ?? ['anthropic'], ['anthropic', 'openai']) ??
     'anthropic'
-  const { id: providerId, npm } = OPENCODE_ENDPOINT_PROVIDER[endpoint]
+  const { id: defaultProviderId, npm } = OPENCODE_ENDPOINT_PROVIDER[endpoint]
+  const providerId = provider.agentProviderId ?? defaultProviderId
   // The @ai-sdk/openai-compatible client appends `/chat/completions` to baseURL, so hand it the
   // resolved OpenAI completions base — an official vendor's exact versioned base (GLM's /api/paas/v4,
   // DeepSeek/Kimi /v1), or a custom gateway root normalized to `<root>/v1`. Matches the validator and
@@ -138,7 +157,7 @@ const resolveOpencodeEndpoint = (
         ? anthropicMessagesBase(provider.baseUrl)
         : undefined
 
-  return { bareModel, providerId, npm, baseURL }
+  return { apiKeyEnv: opencodeApiKeyEnv(provider), bareModel, providerId, npm, baseURL }
 }
 
 // Current OpenCode accepts the provider-neutral ladder through `reasoningEffort` up to `max`.
@@ -193,8 +212,13 @@ const opencodeModelCatalog = (
   const models = new Map<string, AgentModelCatalogEntry>()
   for (const entry of [...catalog, active]) {
     const endpoint = resolveOpencodeEndpoint(entry.provider)
-    if (!endpoint.bareModel || endpoint.providerId !== providerId) continue
-    models.set(endpoint.bareModel, entry)
+    if (
+      !endpoint.bareModel ||
+      (!entry.provider.agentProviderId && endpoint.providerId !== providerId)
+    ) {
+      continue
+    }
+    models.set(`${endpoint.providerId}/${endpoint.bareModel}`, entry)
   }
   return [...models.values()]
 }
@@ -229,6 +253,60 @@ const buildOpencodeModelConfig = (
   }
 }
 
+const buildOpencodeProviders = (
+  provider: ResolvedProvider,
+  reasoningEffort: ModelReasoningEffort | undefined,
+  catalog: readonly AgentModelCatalogEntry[],
+  baseProviders: Record<string, unknown> = {}
+): Record<string, unknown> => {
+  const providers: Record<string, unknown> = { ...baseProviders }
+  for (const entry of opencodeModelCatalog(provider, reasoningEffort, catalog)) {
+    const { apiKeyEnv, bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(
+      entry.provider
+    )
+    if (!bareModel) continue
+    const baseProvider = asRecord(baseProviders[providerId])
+    const currentProvider = asRecord(providers[providerId])
+    const baseOptions = asRecord(baseProvider.options)
+    const baseModels = asRecord(baseProvider.models)
+    const currentModels = asRecord(currentProvider.models)
+    providers[providerId] = {
+      ...baseProvider,
+      ...currentProvider,
+      ...(npm ? { npm } : {}),
+      options: {
+        ...baseOptions,
+        ...asRecord(currentProvider.options),
+        ...(baseURL ? { baseURL } : {}),
+        ...(entry.provider.key ? { apiKey: `{env:${apiKeyEnv}}` } : {})
+      },
+      models: {
+        ...baseModels,
+        ...currentModels,
+        [bareModel]: buildOpencodeModelConfig(
+          entry.provider,
+          entry.reasoningEffort,
+          asRecord(currentModels[bareModel] ?? baseModels[bareModel])
+        )
+      }
+    }
+  }
+  const active = resolveOpencodeEndpoint(provider)
+  if (!Object.hasOwn(providers, active.providerId)) {
+    const baseProvider = asRecord(baseProviders[active.providerId])
+    providers[active.providerId] = {
+      ...baseProvider,
+      ...(active.npm ? { npm: active.npm } : {}),
+      options: {
+        ...asRecord(baseProvider.options),
+        ...(active.baseURL ? { baseURL: active.baseURL } : {}),
+        ...(provider.key ? { apiKey: `{env:${active.apiKeyEnv}}` } : {})
+      }
+    }
+  }
+  return providers
+}
+
 // The app-authoritative config layer (model + provider block + permission policy) passed verbatim to
 // opencode via OPENCODE_CONFIG_CONTENT, which opencode deep-merges ABOVE both the app-owned global config
 // and any project config. Pinning the provider/model/baseURL here (not just permission) means a
@@ -240,27 +318,12 @@ const buildAppConfigContent = (
   reasoningEffort?: ModelReasoningEffort,
   catalog: readonly AgentModelCatalogEntry[] = []
 ): Record<string, unknown> => {
-  const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
-  const models = Object.fromEntries(
-    opencodeModelCatalog(provider, reasoningEffort, catalog).flatMap((entry) => {
-      const model = resolveOpencodeEndpoint(entry.provider).bareModel
-      return model ? [[model, buildOpencodeModelConfig(entry.provider, entry.reasoningEffort)]] : []
-    })
-  )
+  const { bareModel, providerId } = resolveOpencodeEndpoint(provider)
 
   return {
     ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
     permission: { ...OPENCODE_PERMISSION_RULES },
-    provider: {
-      [providerId]: {
-        ...(npm ? { npm } : {}),
-        options: {
-          ...(baseURL ? { baseURL } : {}),
-          ...(provider.key ? { apiKey: `{env:${OPENCODE_API_KEY_ENV}}` } : {})
-        },
-        ...(Object.keys(models).length > 0 ? { models } : {})
-      }
-    }
+    provider: buildOpencodeProviders(provider, reasoningEffort, catalog)
   }
 }
 
@@ -276,23 +339,10 @@ const buildOpencodeConfig = (
   reasoningEffort?: ModelReasoningEffort,
   catalog: readonly AgentModelCatalogEntry[] = []
 ): string => {
-  const { bareModel, providerId, npm, baseURL } = resolveOpencodeEndpoint(provider)
+  const { bareModel, providerId } = resolveOpencodeEndpoint(provider)
 
   const baseProviders = asRecord(baseConfig.provider)
-  const baseProvider = asRecord(baseProviders[providerId])
-  const baseOptions = asRecord(baseProvider.options)
-  const baseModels = asRecord(baseProvider.models)
   const basePermission = asRecord(baseConfig.permission)
-  const models = { ...baseModels }
-  for (const entry of opencodeModelCatalog(provider, reasoningEffort, catalog)) {
-    const model = resolveOpencodeEndpoint(entry.provider).bareModel
-    if (!model) continue
-    models[model] = buildOpencodeModelConfig(
-      entry.provider,
-      entry.reasoningEffort,
-      asRecord(baseModels[model])
-    )
-  }
   // Preserve any instructions the base config already declared, then append ours (de-duplicated).
   const baseInstructions = Array.isArray(baseConfig.instructions)
     ? baseConfig.instructions.filter((entry): entry is string => typeof entry === 'string')
@@ -312,28 +362,7 @@ const buildOpencodeConfig = (
       ...basePermission,
       ...OPENCODE_PERMISSION_RULES
     },
-    provider: {
-      ...baseProviders,
-      [providerId]: {
-        ...baseProvider,
-        // A custom (openai-compatible) provider needs its npm package declared; anthropic is built-in.
-        ...(npm ? { npm } : {}),
-        options: {
-          ...baseOptions,
-          ...(baseURL ? { baseURL } : {}),
-          // Reference the key via env interpolation; the real value is passed in the spawn env only,
-          // so the decrypted key is never persisted to opencode.json (see prepareModelConfig).
-          ...(provider.key ? { apiKey: `{env:${OPENCODE_API_KEY_ENV}}` } : {})
-        },
-        // Register the model so opencode treats a non-catalog id as a real, selectable model, declaring
-        // its image capability when the active model is multimodal (else opencode strips image parts).
-        ...(Object.keys(models).length > 0
-          ? {
-              models
-            }
-          : {})
-      }
-    }
+    provider: buildOpencodeProviders(provider, reasoningEffort, catalog, baseProviders)
   }
 
   return JSON.stringify(merged, null, 2)
@@ -452,10 +481,21 @@ export const opencodeFramework: AgentFramework = {
         OPENCODE_CONFIG_CONTENT: JSON.stringify(
           buildAppConfigContent(provider, ctx.reasoningEffort, ctx.providerModelCatalog)
         ),
-        // Pass the decrypted key ONLY via the environment; the config references it as `{env:...}`.
-        ...(provider.key ? { [OPENCODE_API_KEY_ENV]: provider.key } : {})
+        // Pass credentials only through referenced environment values. Generation-local transport
+        // routes use distinct variables so late OpenCode background work cannot inherit a new route.
+        ...Object.fromEntries(
+          opencodeModelCatalog(provider, ctx.reasoningEffort, ctx.providerModelCatalog).flatMap(
+            (entry) =>
+              entry.provider.key
+                ? [[opencodeApiKeyEnv(entry.provider), entry.provider.key] as const]
+                : []
+          )
+        )
       },
       configFiles,
+      ...(provider.agentProviderId && provider.model
+        ? { sessionModel: `${provider.agentProviderId}/${provider.model}` }
+        : {}),
       ...(persistentInstructions.length > 0
         ? { persistentSystemPrompt: persistentInstructions.join('\n\n') }
         : {})

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -90,6 +90,7 @@ export type AgentModelChangeTarget = Readonly<{
   sessionModel: string
   sessionModelRequired: boolean
   reasoningEffort: ResolvedReasoningEffort
+  supportsImageInput: boolean
   contextWindow?: number
   bridge?: Readonly<{
     model: string
@@ -264,6 +265,9 @@ export type ResolvedAgentBackend = {
   // Exact context-window limit for the selected upstream provider model. Framework adapters may
   // report a fallback or bridge transport model instead, so the runtime treats this as authoritative.
   contextWindow?: number
+  // Whether the selected upstream model accepts image input. Kept on the generation so a model-only
+  // switch can fail closed when an adapter cannot remove images already retained in native history.
+  supportsImageInput?: boolean
   // Upstream provider model used for local context tokenization. This is deliberately separate from
   // `sessionModel`: a framework may select its model through env rather than ACP, or use a bridge
   // transport model whose id differs from the provider model that ultimately tokenizes the request.

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -92,6 +92,9 @@ export type AgentModelChangeTarget = Readonly<{
   reasoningEffort: ResolvedReasoningEffort
   supportsImageInput: boolean
   contextWindow?: number
+  // Opaque, secret-free id for one provider/model already registered in the current Claude
+  // generation's loopback Anthropic bridge. Absent means this target cannot cross a provider env.
+  anthropicBridgeTargetId?: string
   bridge?: Readonly<{
     model: string
     vendorId?: OfficialVendorId
@@ -294,6 +297,13 @@ export type ResolvedAgentBackend = {
     // lease prevents an active-model value from leaking into bridges owned by retiring generations.
     setReasoningEffort?: (effort?: ModelReasoningEffort) => void
     setModelTarget?: (target: ResponsesBridgeModelTarget) => void
+    release: () => Promise<void>
+  }
+  // API-key Claude generations keep their process environment stable by talking to an app-owned
+  // loopback Anthropic bridge. The bridge owns endpoint/token/model routing in memory; live model
+  // targets carry only an opaque id into this lease.
+  anthropicBridgeLease?: {
+    setTarget: (targetId: string) => boolean
     release: () => Promise<void>
   }
 }

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -95,6 +95,9 @@ export type AgentModelChangeTarget = Readonly<{
   // Opaque, secret-free id for one provider/model already registered in the current Claude
   // generation's loopback Anthropic bridge. Absent means this target cannot cross a provider env.
   anthropicBridgeTargetId?: string
+  // Opaque, secret-free id for a provider/model route pre-registered in the generation transport.
+  // The lease decides whether selecting it is validation-only (OpenCode) or retargets a route.
+  providerTransportTargetId?: string
   bridge?: Readonly<{
     model: string
     vendorId?: OfficialVendorId
@@ -303,6 +306,10 @@ export type ResolvedAgentBackend = {
   // loopback Anthropic bridge. The bridge owns endpoint/token/model routing in memory; live model
   // targets carry only an opaque id into this lease.
   anthropicBridgeLease?: {
+    setTarget: (targetId: string) => boolean
+    release: () => Promise<void>
+  }
+  providerTransportLease?: {
     setTarget: (targetId: string) => boolean
     release: () => Promise<void>
   }

--- a/src/main/agent-framework/types.ts
+++ b/src/main/agent-framework/types.ts
@@ -4,10 +4,16 @@ import type { SessionModeState } from '@agentclientprotocol/sdk'
 import type { PermissionProfileApplication } from '../acp/permission-profile-controller'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import type { AgentFrameworkId, ChatApiEndpoint } from '../../shared/settings'
-import type { ModelReasoningEffort } from '../../shared/reasoning-effort'
+import type {
+  CustomReasoningEffortTransport,
+  ModelReasoningEffort,
+  ResolvedReasoningEffort
+} from '../../shared/reasoning-effort'
+import type { OfficialVendorId } from '../../shared/provider-registry'
 import type { ResolvedProvider } from '../settings/provider-env'
 import type {
   ResponsesBridgeConnection,
+  ResponsesBridgeModelTarget,
   ResponsesBridgeSkillCandidate,
   ResponsesBridgeSkillInput
 } from '../settings/responses-bridge'
@@ -59,6 +65,39 @@ export type AgentModelConfig = {
   persistentSystemPrompt?: string
 }
 
+export type AgentModelRoute =
+  | 'claude-anthropic'
+  | 'opencode-anthropic'
+  | 'opencode-openai'
+  | 'codex-responses'
+  | 'codex-responses-compatibility'
+  | 'codex-bridge'
+
+export type AgentModelCatalogEntry = Readonly<{
+  provider: ResolvedProvider
+  reasoningEffort?: ModelReasoningEffort
+  reasoningEfforts?: readonly ModelReasoningEffort[]
+}>
+
+// Secret-free, side-effect-free projection of one persisted model selection onto the live runtime.
+// Settings owns provider/vendor/route resolution; AcpRuntime only compares this identity with its
+// current generation and applies the already-resolved session or bridge values.
+export type AgentModelChangeTarget = Readonly<{
+  frameworkId: AgentFrameworkId
+  backendId: string
+  route: AgentModelRoute
+  model: string
+  sessionModel: string
+  sessionModelRequired: boolean
+  reasoningEffort: ResolvedReasoningEffort
+  contextWindow?: number
+  bridge?: Readonly<{
+    model: string
+    vendorId?: OfficialVendorId
+    reasoningEffortTransport?: CustomReasoningEffortTransport
+  }>
+}>
+
 // Inputs for translating a provider; paths differ per framework (Claude wants its executable + config
 // dir root, opencode wants a location to write its generated config into).
 export type ModelConfigContext = {
@@ -83,6 +122,9 @@ export type ModelConfigContext = {
   // register custom model metadata use this to keep their capability catalog consistent with the
   // selected effort above.
   reasoningEfforts?: readonly ModelReasoningEffort[]
+  // Same-provider models that keep the active backend route. Frameworks may pre-register these in
+  // their native catalog so a later session configOption switch does not require a process respawn.
+  providerModelCatalog?: readonly AgentModelCatalogEntry[]
 }
 
 // System-prompt guidance the runtime wants appended for a session (artifact routing, notebook, skill
@@ -197,6 +239,7 @@ export type ResolvedAgentBackend = {
   // Stable identity of the framework/provider storage boundary. Two providers can use the same
   // framework while keeping incompatible session stores (for example Codex shared vs isolated login).
   backendId?: string
+  modelRoute?: AgentModelRoute
   executablePath: string
   env: Record<string, string>
   args?: string[]
@@ -246,6 +289,7 @@ export type ResolvedAgentBackend = {
     // Updates the concrete effort on this runtime's own bridged provider/model. Keeping it on the
     // lease prevents an active-model value from leaking into bridges owned by retiring generations.
     setReasoningEffort?: (effort?: ModelReasoningEffort) => void
+    setModelTarget?: (target: ResponsesBridgeModelTarget) => void
     release: () => Promise<void>
   }
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1220,7 +1220,8 @@ const createApplicationModules = async (
     runtime: {
       requestProviderReconnect: () => void runtime.requestProviderReconnect(),
       requestAgentFrameworkSwitch: () => void runtime.requestAgentFrameworkSwitch(),
-      applyReasoningEffort: (effort) => runtime.applyReasoningEffortChange(effort)
+      applyReasoningEffort: (effort) => runtime.applyReasoningEffortChange(effort),
+      applyModelChange: (target) => runtime.applyModelChange(target)
     },
     skills: { requestSkillsReload: () => void runtime.requestSkillsReload() },
     connectors: {

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -45,6 +45,7 @@ import {
 } from './codex-detect'
 import { detectNpmAvailable, runInstallWithFallback, type InstallTarget } from './claude-install'
 import { OPENCODE_INSTALL_TARGET } from './opencode-install'
+import type { ClaudeRuntimeModelConfig } from './claude-config-provision'
 import {
   DEFAULT_REGISTRIES,
   installManagedClaude,
@@ -619,13 +620,14 @@ export class AgentRuntimeManager {
 
   async provisionClaudeRuntimeConfig(
     settings: StoredSettings,
-    forcedSkillIds: ReadonlySet<string> = new Set()
+    forcedSkillIds: ReadonlySet<string> = new Set(),
+    modelConfig?: ClaudeRuntimeModelConfig | null
   ): Promise<string> {
     const configDir = getAppClaudeConfigDir(this.storageRoot)
     const disabledSkillIds = (settings.disabledSkillIds ?? []).filter(
       (id) => !forcedSkillIds.has(id)
     )
-    await this.skills.provisionClaudeConfig(configDir, disabledSkillIds)
+    await this.skills.provisionClaudeConfig(configDir, disabledSkillIds, modelConfig)
     const connectors = await this.connectors.getConnectors()
     await syncConnectorSkillDocs(
       join(configDir, 'skills'),

--- a/src/main/settings/anthropic-provider-bridge.test.ts
+++ b/src/main/settings/anthropic-provider-bridge.test.ts
@@ -1,0 +1,148 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  AnthropicProviderBridge,
+  type AnthropicProviderBridgeTarget
+} from './anthropic-provider-bridge'
+
+type CapturedRequest = {
+  authorization?: string
+  body: Record<string, unknown>
+  path?: string
+}
+
+const listen = async (server: Server): Promise<string> => {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address() as AddressInfo
+  return `http://127.0.0.1:${address.port}`
+}
+
+const close = async (server: Server): Promise<void> => {
+  if (!server.listening) return
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  )
+}
+
+const createUpstream = (): {
+  requests: CapturedRequest[]
+  server: Server
+} => {
+  const requests: CapturedRequest[] = []
+  const server = createServer((request, response) => {
+    const chunks: Buffer[] = []
+    request.on('data', (chunk: Buffer) => chunks.push(chunk))
+    request.on('end', () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>
+      requests.push({
+        authorization: request.headers.authorization,
+        body,
+        path: request.url
+      })
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ model: body.model }))
+    })
+  })
+  return { requests, server }
+}
+
+describe('AnthropicProviderBridge', () => {
+  const servers: Server[] = []
+  const bridges: AnthropicProviderBridge[] = []
+
+  afterEach(async () => {
+    await Promise.all(bridges.splice(0).map((bridge) => bridge.close()))
+    await Promise.all(servers.splice(0).map(close))
+  })
+
+  it('retargets endpoint, credential, and model without replacing the loopback connection', async () => {
+    const first = createUpstream()
+    const second = createUpstream()
+    servers.push(first.server, second.server)
+    const firstBaseUrl = await listen(first.server)
+    const secondBaseUrl = await listen(second.server)
+    const targets: AnthropicProviderBridgeTarget[] = [
+      { id: 'deepseek/model-a', baseUrl: firstBaseUrl, key: 'key-a', model: 'model-a' },
+      { id: 'kimi/model-b', baseUrl: secondBaseUrl, key: 'key-b', model: 'model-b' }
+    ]
+    const bridge = new AnthropicProviderBridge(targets, targets[0].id)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+
+    const send = (model: string): Promise<Response> =>
+      fetch(`${connection.baseUrl}/v1/messages?beta=1`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model, messages: [] })
+      })
+
+    await expect((await send('untrusted-model')).json()).resolves.toEqual({ model: 'model-a' })
+    expect(bridge.setTarget(targets[1].id)).toBe(true)
+    await expect((await send('still-untrusted')).json()).resolves.toEqual({ model: 'model-b' })
+    await expect(
+      (
+        await fetch(`${connection.baseUrl}/v1/messages/count_tokens`, {
+          method: 'POST',
+          headers: {
+            'x-api-key': connection.token,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({ model: 'ignored-count-model', messages: [] })
+        })
+      ).json()
+    ).resolves.toEqual({ model: 'model-b' })
+
+    expect(first.requests).toEqual([
+      {
+        authorization: 'Bearer key-a',
+        body: { model: 'model-a', messages: [] },
+        path: '/v1/messages?beta=1'
+      }
+    ])
+    expect(second.requests).toEqual([
+      {
+        authorization: 'Bearer key-b',
+        body: { model: 'model-b', messages: [] },
+        path: '/v1/messages?beta=1'
+      },
+      {
+        authorization: 'Bearer key-b',
+        body: { model: 'model-b', messages: [] },
+        path: '/v1/messages/count_tokens'
+      }
+    ])
+  })
+
+  it('fails closed for unknown targets and unauthenticated callers', async () => {
+    const upstream = createUpstream()
+    servers.push(upstream.server)
+    const target = {
+      id: 'provider/model-a',
+      baseUrl: await listen(upstream.server),
+      key: 'key-a',
+      model: 'model-a'
+    }
+    const bridge = new AnthropicProviderBridge([target], target.id)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+
+    expect(bridge.setTarget('missing/model')).toBe(false)
+    const response = await fetch(`${connection.baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'model-a', messages: [] })
+    })
+
+    expect(response.status).toBe(401)
+    expect(upstream.requests).toEqual([])
+  })
+})

--- a/src/main/settings/anthropic-provider-bridge.ts
+++ b/src/main/settings/anthropic-provider-bridge.ts
@@ -1,0 +1,220 @@
+import { randomBytes } from 'node:crypto'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+
+import { normalizeAnthropicBaseUrl } from './base-url'
+
+const MAX_REQUEST_BYTES = 64 * 1024 * 1024
+const ALLOWED_PATHS = new Set(['/v1/messages', '/v1/messages/count_tokens'])
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'content-encoding',
+  'content-length',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade'
+])
+
+export type AnthropicProviderBridgeTarget = Readonly<{
+  id: string
+  baseUrl: string
+  key?: string
+  model: string
+}>
+
+export type AnthropicProviderBridgeConnection = Readonly<{
+  baseUrl: string
+  token: string
+}>
+
+const json = (response: ServerResponse, status: number, body: unknown): void => {
+  response.writeHead(status, { 'content-type': 'application/json' })
+  response.end(JSON.stringify(body))
+}
+
+const readBody = (request: IncomingMessage): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let size = 0
+    request.on('data', (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      size += buffer.length
+      if (size > MAX_REQUEST_BYTES) {
+        reject(new Error('Anthropic bridge request exceeds the size limit.'))
+        request.destroy()
+        return
+      }
+      chunks.push(buffer)
+    })
+    request.once('end', () => resolve(Buffer.concat(chunks)))
+    request.once('error', reject)
+    request.once('aborted', () => reject(new Error('Anthropic bridge request was aborted.')))
+  })
+
+const requestHeaders = (request: IncomingMessage, key?: string): Headers => {
+  const headers = new Headers()
+  for (const [name, value] of Object.entries(request.headers)) {
+    const normalized = name.toLowerCase()
+    if (
+      HOP_BY_HOP_HEADERS.has(normalized) ||
+      normalized === 'authorization' ||
+      normalized === 'x-api-key' ||
+      value === undefined
+    ) {
+      continue
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(name, item)
+    } else {
+      headers.set(name, value)
+    }
+  }
+  if (key) headers.set('authorization', `Bearer ${key}`)
+  headers.set('content-type', 'application/json')
+  return headers
+}
+
+const copyResponseHeaders = (source: Headers, response: ServerResponse): void => {
+  for (const [name, value] of source) {
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) response.setHeader(name, value)
+  }
+}
+
+export class AnthropicProviderBridge {
+  private readonly targets: ReadonlyMap<string, AnthropicProviderBridgeTarget>
+  private target: AnthropicProviderBridgeTarget
+  private server: Server | undefined
+  private connection: AnthropicProviderBridgeConnection | undefined
+
+  constructor(targets: readonly AnthropicProviderBridgeTarget[], initialTargetId: string) {
+    this.targets = new Map(targets.map((target) => [target.id, target]))
+    const initial = this.targets.get(initialTargetId)
+    if (!initial) throw new Error('The initial Anthropic bridge target is not registered.')
+    this.target = initial
+  }
+
+  setTarget(targetId: string): boolean {
+    const target = this.targets.get(targetId)
+    if (!target) return false
+    this.target = target
+    return true
+  }
+
+  async start(): Promise<AnthropicProviderBridgeConnection> {
+    if (this.connection) return this.connection
+    const token = randomBytes(24).toString('hex')
+    const server = createServer((request, response) => {
+      void this.handle(request, response, token).catch((error: unknown) => {
+        if (response.destroyed || response.writableEnded) return
+        if (response.headersSent) {
+          response.destroy(error instanceof Error ? error : undefined)
+          return
+        }
+        json(response, 502, {
+          error: {
+            type: 'api_error',
+            message: error instanceof Error ? error.message : 'Anthropic provider request failed.'
+          }
+        })
+      })
+    })
+    this.server = server
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', resolve)
+      })
+      server.unref()
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('Anthropic provider bridge did not bind a port.')
+      }
+      this.connection = Object.freeze({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        token
+      })
+      return this.connection
+    } catch (error) {
+      await this.close().catch(() => undefined)
+      throw error
+    }
+  }
+
+  async close(): Promise<void> {
+    const server = this.server
+    this.server = undefined
+    this.connection = undefined
+    if (!server) return
+    const closing = new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    )
+    server.closeAllConnections()
+    await closing
+  }
+
+  private async handle(
+    request: IncomingMessage,
+    response: ServerResponse,
+    token: string
+  ): Promise<void> {
+    const authorization = request.headers.authorization
+    const apiKey = request.headers['x-api-key']
+    if (authorization !== `Bearer ${token}` && apiKey !== token) {
+      json(response, 401, { error: { type: 'authentication_error', message: 'Unauthorized' } })
+      return
+    }
+    if (request.method !== 'POST') {
+      json(response, 405, {
+        error: { type: 'invalid_request_error', message: 'Method not allowed' }
+      })
+      return
+    }
+
+    const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1')
+    if (!ALLOWED_PATHS.has(requestUrl.pathname)) {
+      json(response, 404, { error: { type: 'not_found_error', message: 'Not found' } })
+      return
+    }
+
+    const rawBody = await readBody(request)
+    const parsed = JSON.parse(rawBody.toString('utf8')) as unknown
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      json(response, 400, {
+        error: { type: 'invalid_request_error', message: 'Expected a JSON object request body.' }
+      })
+      return
+    }
+
+    const target = this.target
+    const body = JSON.stringify({ ...(parsed as Record<string, unknown>), model: target.model })
+    const baseUrl = normalizeAnthropicBaseUrl(target.baseUrl)
+    if (!baseUrl) throw new Error('The Anthropic provider target has no valid base URL.')
+    const controller = new AbortController()
+    const abort = (): void => controller.abort()
+    response.once('close', () => {
+      if (!response.writableEnded) abort()
+    })
+
+    const upstream = await fetch(`${baseUrl}${requestUrl.pathname}${requestUrl.search}`, {
+      method: 'POST',
+      headers: requestHeaders(request, target.key),
+      body,
+      redirect: 'manual',
+      signal: controller.signal
+    })
+    response.statusCode = upstream.status
+    response.statusMessage = upstream.statusText
+    copyResponseHeaders(upstream.headers, response)
+    if (!upstream.body) {
+      response.end()
+      return
+    }
+    await pipeline(Readable.from(upstream.body as AsyncIterable<Uint8Array>), response)
+  }
+}

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -20,6 +20,7 @@ type NativeResponsesProxyFactory = NonNullable<
 >
 type NativeResponsesProxyDouble = ReturnType<NativeResponsesProxyFactory>
 type ResolveRuntimeTarget = AgentBackendProviderPort['resolveRuntimeTarget']
+type ResolveRuntimeModelCatalog = AgentBackendProviderPort['resolveRuntimeModelCatalog']
 type TargetOverride = Omit<Partial<ProviderRuntimeTarget>, 'provider'> & {
   provider?: Partial<ResolvedProvider>
 }
@@ -78,7 +79,8 @@ const makeResponsesBridgeDouble = (
   selectSkills: vi.fn(async () => []),
   registerReviewerSession: vi.fn(),
   unregisterReviewerSession: vi.fn(() => false),
-  setReasoningEffort: vi.fn()
+  setReasoningEffort: vi.fn(),
+  setModelTarget: vi.fn()
 })
 
 const makeNativeResponsesProxyDouble = (
@@ -100,7 +102,8 @@ const makeNativeResponsesProxyDouble = (
   }),
   selectSkills: vi.fn(async () => []),
   registerReviewerSession: vi.fn(),
-  unregisterReviewerSession: vi.fn(() => false)
+  unregisterReviewerSession: vi.fn(() => false),
+  setModelTarget: vi.fn()
 })
 
 type HarnessOptions = {
@@ -171,8 +174,19 @@ const makeHarness = (options: HarnessOptions = {}) => {
     supported: true as const,
     slots: ['low', 'medium', 'high', 'xhigh', 'max'] as const
   }))
+  const resolveRuntimeModelCatalog = vi.fn(
+    (
+      storedProvider: Parameters<ResolveRuntimeModelCatalog>[0],
+      framework: Parameters<ResolveRuntimeModelCatalog>[1]
+    ): ProviderRuntimeTarget[] => {
+      void storedProvider
+      void framework
+      return []
+    }
+  )
   const providers: AgentBackendProviderPort = {
     resolveRuntimeTarget,
+    resolveRuntimeModelCatalog,
     resolveRuntimeReasoningEffortProfile
   }
 
@@ -228,6 +242,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
     ensureCodexSubscriptionHome,
     nextGenerationId,
     resolveRuntimeTarget,
+    resolveRuntimeModelCatalog,
     resolveRuntimeReasoningEffortProfile,
     runtime,
     connectors,
@@ -296,6 +311,94 @@ describe('AgentBackendResolver construction and selection', () => {
 })
 
 describe('AgentBackendResolver configured and explicit targets', () => {
+  it('registers third-party Claude model ids through canonical override lanes', async () => {
+    const provider: StoredProvider = {
+      ...makeStoredProvider('provider-a', 'third-party/model-a'),
+      type: 'official',
+      vendorId: 'deepseek',
+      fetchedModels: ['third-party/model-a', 'third-party/model-b']
+    }
+    const harness = makeHarness({
+      settings: makeSettings({
+        providers: [provider],
+        activeProviderId: provider.id,
+        activeModel: provider.model,
+        agentFrameworkId: 'claude-code'
+      }),
+      targetOverride: () => ({
+        apiEndpoints: ['anthropic'],
+        provider: { type: 'custom', apiEndpoints: ['anthropic'], vendorId: 'deepseek' }
+      })
+    })
+    harness.resolveRuntimeModelCatalog.mockImplementation((storedProvider, framework) =>
+      ['third-party/model-a', 'third-party/model-b'].map((model) =>
+        harness.resolveRuntimeTarget(storedProvider, { kind: 'required', model }, framework)
+      )
+    )
+
+    const backend = await harness.resolver.resolveActiveBackend()
+    const modelConfig = (backend.sessionOptions as { settings?: unknown })?.settings
+
+    expect(modelConfig).toMatchObject({
+      availableModels: ['sonnet', 'opus'],
+      modelOverrides: {
+        sonnet: 'third-party/model-a',
+        opus: 'third-party/model-b'
+      }
+    })
+    expect(JSON.stringify(modelConfig)).not.toContain('plain:key-a')
+  })
+
+  it('resolves a secret-free live model target without starting runtime resources', async () => {
+    const harness = makeHarness({
+      settings: makeSettings({ agentFrameworkId: 'codex', reasoningEffort: 'max' }),
+      targetOverride: () => ({
+        apiEndpoints: ['openai'],
+        needsChatResponsesBridge: true,
+        provider: {
+          apiEndpoints: ['openai'],
+          vendorId: 'deepseek',
+          reasoningEffortTransport: 'deepseek'
+        }
+      })
+    })
+
+    const target = await harness.resolver.resolveActiveModelChangeTarget()
+
+    expect(target).toEqual({
+      frameworkId: 'codex',
+      backendId: 'codex:provider-a',
+      route: 'codex-bridge',
+      model: 'model-a',
+      sessionModel: 'gpt-5.4',
+      sessionModelRequired: false,
+      reasoningEffort: 'max',
+      contextWindow: 128_000,
+      bridge: {
+        model: 'model-a',
+        vendorId: 'deepseek',
+        reasoningEffortTransport: 'deepseek'
+      }
+    })
+    expect(JSON.stringify(target)).not.toContain('plain:key-a')
+    expect(harness.createResponsesBridge).not.toHaveBeenCalled()
+    expectRuntimeNotStarted(harness.runtime)
+  })
+
+  it('distinguishes OpenCode endpoint routes so cross-route model changes reconnect', async () => {
+    const harness = makeHarness({
+      settings: makeSettings({ agentFrameworkId: 'opencode' }),
+      targetOverride: () => ({
+        apiEndpoints: ['openai'],
+        provider: { apiEndpoints: ['openai'] }
+      })
+    })
+
+    await expect(harness.resolver.resolveActiveModelChangeTarget()).resolves.toMatchObject({
+      route: 'opencode-openai'
+    })
+  })
+
   it('produces equivalent stable backends for configured and provider-default explicit targets', async () => {
     const settings = makeSettings()
     const harness = makeHarness({ settings })

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
-import type { AgentFrameworkId } from '../agent-framework'
+import type { AgentConfigFile, AgentFrameworkId } from '../agent-framework'
+import { opencodeTransportProviderId } from '../agent-framework/opencode'
 import type { ResolvedProvider } from './provider-env'
 import type { ProviderRuntimeTarget, RuntimeProviderModelSelection } from './provider-accounts'
 import type { StoredProvider, StoredSettings } from './types'
@@ -23,6 +24,10 @@ type AnthropicProviderBridgeFactory = NonNullable<
   AgentBackendResolverOptions['createAnthropicProviderBridge']
 >
 type AnthropicProviderBridgeDouble = ReturnType<AnthropicProviderBridgeFactory>
+type OpenAiProviderBridgeFactory = NonNullable<
+  AgentBackendResolverOptions['createOpenAiProviderBridge']
+>
+type OpenAiProviderBridgeDouble = ReturnType<OpenAiProviderBridgeFactory>
 type ResolveRuntimeTarget = AgentBackendProviderPort['resolveRuntimeTarget']
 type ResolveRuntimeModelCatalog = AgentBackendProviderPort['resolveRuntimeModelCatalog']
 type TargetOverride = Omit<Partial<ProviderRuntimeTarget>, 'provider'> & {
@@ -83,6 +88,7 @@ const makeResponsesBridgeDouble = (
   selectSkills: vi.fn(async () => []),
   registerReviewerSession: vi.fn(),
   unregisterReviewerSession: vi.fn(() => false),
+  setTarget: vi.fn(),
   setReasoningEffort: vi.fn(),
   setModelTarget: vi.fn()
 })
@@ -107,6 +113,7 @@ const makeNativeResponsesProxyDouble = (
   selectSkills: vi.fn(async () => []),
   registerReviewerSession: vi.fn(),
   unregisterReviewerSession: vi.fn(() => false),
+  setTarget: vi.fn(),
   setModelTarget: vi.fn()
 })
 
@@ -114,6 +121,15 @@ const makeAnthropicProviderBridgeDouble = (): AnthropicProviderBridgeDouble => (
   start: vi.fn(async () => ({
     baseUrl: 'http://127.0.0.1:41003',
     token: 'anthropic-bridge-token'
+  })),
+  close: vi.fn(async () => undefined),
+  setTarget: vi.fn(() => true)
+})
+
+const makeOpenAiProviderBridgeDouble = (index: number): OpenAiProviderBridgeDouble => ({
+  start: vi.fn(async () => ({
+    baseUrl: `http://127.0.0.1:${42000 + index}`,
+    token: `openai-bridge-token-${index}`
   })),
   close: vi.fn(async () => undefined),
   setTarget: vi.fn(() => true)
@@ -132,6 +148,7 @@ type HarnessOptions = {
   responsesBridgeBuilder?: (index: number) => ResponsesBridgeDouble
   nativeResponsesProxyBuilder?: (index: number) => NativeResponsesProxyDouble
   anthropicProviderBridgeBuilder?: (index: number) => AnthropicProviderBridgeDouble
+  openAiProviderBridgeBuilder?: (index: number) => OpenAiProviderBridgeDouble
   nextGenerationId?: () => string
 }
 
@@ -211,7 +228,9 @@ const makeHarness = (options: HarnessOptions = {}) => {
     probeCodexNativeVersion: vi.fn(async () => '0.144.6'),
     provisionClaudeRuntimeConfig: vi.fn(async () => '/storage/claude-config'),
     materializeAgentSkills: vi.fn(async () => undefined),
-    materializeAgentConfigFiles: vi.fn(async () => undefined),
+    materializeAgentConfigFiles: vi.fn(async (files?: AgentConfigFile[]) => {
+      void files
+    }),
     reserveOpenCodeUsagePort: vi.fn(async () => 42_424),
     resolveCodexProxyEnvironment: vi.fn(async () => undefined)
   } satisfies AgentBackendRuntimePort
@@ -242,6 +261,14 @@ const makeHarness = (options: HarnessOptions = {}) => {
     anthropicProviderBridges.push(bridge)
     return bridge
   })
+  const openAiProviderBridges: OpenAiProviderBridgeDouble[] = []
+  const createOpenAiProviderBridge = vi.fn((): OpenAiProviderBridgeDouble => {
+    const bridge =
+      options.openAiProviderBridgeBuilder?.(openAiProviderBridges.length) ??
+      makeOpenAiProviderBridgeDouble(openAiProviderBridges.length)
+    openAiProviderBridges.push(bridge)
+    return bridge
+  })
 
   const resolver = new AgentBackendResolver({
     readSettings,
@@ -254,6 +281,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
     createResponsesBridge,
     createNativeResponsesProxy,
     createAnthropicProviderBridge,
+    createOpenAiProviderBridge,
     ensureCodexSubscriptionHome,
     nextGenerationId
   })
@@ -272,9 +300,11 @@ const makeHarness = (options: HarnessOptions = {}) => {
     createResponsesBridge,
     createNativeResponsesProxy,
     createAnthropicProviderBridge,
+    createOpenAiProviderBridge,
     responsesBridges,
     nativeResponsesProxies,
     anthropicProviderBridges,
+    openAiProviderBridges,
     getSettings: () => currentSettings,
     setSettings: (settings: StoredSettings) => {
       currentSettings = settings
@@ -505,6 +535,281 @@ describe('AgentBackendResolver configured and explicit targets', () => {
     })
   })
 
+  it('pre-registers immutable OpenCode provider routes without exposing upstream credentials', async () => {
+    const providerA = {
+      ...makeStoredProvider('provider-a', 'model-a'),
+      baseUrl: 'https://provider-a.example/v1'
+    }
+    const providerB = {
+      ...makeStoredProvider('provider-b', 'model-b'),
+      baseUrl: 'https://provider-b.example/custom'
+    }
+    const harness = makeHarness({
+      settings: makeSettings({
+        providers: [providerA, providerB],
+        activeProviderId: providerA.id,
+        activeModel: providerA.model,
+        agentFrameworkId: 'opencode'
+      }),
+      targetOverride: () => ({
+        apiEndpoints: ['openai'],
+        provider: { apiEndpoints: ['openai'] }
+      })
+    })
+
+    const backend = await harness.resolver.resolveActiveBackend()
+    const providerAId = opencodeTransportProviderId(providerA.id, 'model-a')
+    const providerBId = opencodeTransportProviderId(providerB.id, 'model-b')
+    const configFiles = harness.runtime.materializeAgentConfigFiles.mock.calls[0]?.[0] ?? []
+    const opencodeConfig = configFiles.find((file) => file.path.endsWith('opencode.json'))
+
+    expect(harness.createOpenAiProviderBridge).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          id: JSON.stringify(['opencode', 'provider-a', 'model-a']),
+          wire: 'chat-completions',
+          endpoint: 'https://provider-a.example/v1/chat/completions',
+          key: 'plain:provider-a-key-ref',
+          model: 'model-a'
+        }
+      ],
+      JSON.stringify(['opencode', 'provider-a', 'model-a'])
+    )
+    expect(harness.createOpenAiProviderBridge).toHaveBeenNthCalledWith(
+      2,
+      [
+        {
+          id: JSON.stringify(['opencode', 'provider-b', 'model-b']),
+          wire: 'chat-completions',
+          endpoint: 'https://provider-b.example/custom/chat/completions',
+          key: 'plain:provider-b-key-ref',
+          model: 'model-b'
+        }
+      ],
+      JSON.stringify(['opencode', 'provider-b', 'model-b'])
+    )
+    expect(backend.sessionModel).toBe(`${providerAId}/model-a`)
+    expect(opencodeConfig?.content).toContain(providerAId)
+    expect(opencodeConfig?.content).toContain(providerBId)
+    expect(JSON.stringify(backend)).not.toContain('plain:provider-a-key-ref')
+    expect(JSON.stringify(backend)).not.toContain('plain:provider-b-key-ref')
+    expect(
+      backend.providerTransportLease?.setTarget(
+        JSON.stringify(['opencode', 'provider-b', 'model-b'])
+      )
+    ).toBe(true)
+
+    harness.setSettings({
+      ...harness.getSettings(),
+      activeProviderId: providerB.id,
+      activeModel: providerB.model
+    })
+    await expect(harness.resolver.resolveActiveModelChangeTarget()).resolves.toMatchObject({
+      backendId: 'opencode:provider-b',
+      route: 'opencode-openai',
+      sessionModel: `${providerBId}/model-b`,
+      providerTransportTargetId: JSON.stringify(['opencode', 'provider-b', 'model-b'])
+    })
+
+    await backend.providerTransportLease?.release()
+    expect(harness.openAiProviderBridges[0].close).toHaveBeenCalledOnce()
+    expect(harness.openAiProviderBridges[1].close).toHaveBeenCalledOnce()
+  })
+
+  it('pre-registers immutable Anthropic routes for OpenCode providers', async () => {
+    const providerA = {
+      ...makeStoredProvider('provider-a', 'model-a'),
+      baseUrl: 'https://provider-a.example/anthropic'
+    }
+    const providerB = {
+      ...makeStoredProvider('provider-b', 'model-b'),
+      baseUrl: 'https://provider-b.example/anthropic'
+    }
+    const harness = makeHarness({
+      settings: makeSettings({
+        providers: [providerA, providerB],
+        activeProviderId: providerA.id,
+        activeModel: providerA.model,
+        agentFrameworkId: 'opencode'
+      }),
+      targetOverride: () => ({
+        apiEndpoints: ['anthropic'],
+        provider: { apiEndpoints: ['anthropic'] }
+      })
+    })
+
+    const backend = await harness.resolver.resolveActiveBackend()
+    const providerATargetId = JSON.stringify(['opencode', 'provider-a', 'model-a'])
+    const providerBTargetId = JSON.stringify(['opencode', 'provider-b', 'model-b'])
+
+    expect(harness.createAnthropicProviderBridge).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          id: providerATargetId,
+          baseUrl: 'https://provider-a.example/anthropic',
+          key: 'plain:provider-a-key-ref',
+          model: 'model-a'
+        }
+      ],
+      providerATargetId
+    )
+    expect(harness.createAnthropicProviderBridge).toHaveBeenNthCalledWith(
+      2,
+      [
+        {
+          id: providerBTargetId,
+          baseUrl: 'https://provider-b.example/anthropic',
+          key: 'plain:provider-b-key-ref',
+          model: 'model-b'
+        }
+      ],
+      providerBTargetId
+    )
+    expect(backend.providerTransportLease?.setTarget(providerBTargetId)).toBe(true)
+    expect(JSON.stringify(backend)).not.toContain('plain:provider-a-key-ref')
+    expect(JSON.stringify(backend)).not.toContain('plain:provider-b-key-ref')
+  })
+
+  it('retargets a Codex Chat bridge across pre-registered providers', async () => {
+    const providerA = {
+      ...makeStoredProvider('provider-a', 'model-a'),
+      baseUrl: 'https://provider-a.example/v1'
+    }
+    const providerB = {
+      ...makeStoredProvider('provider-b', 'model-b'),
+      baseUrl: 'https://provider-b.example/custom'
+    }
+    const harness = makeHarness({
+      settings: makeSettings({
+        providers: [providerA, providerB],
+        activeProviderId: providerA.id,
+        activeModel: providerA.model,
+        agentFrameworkId: 'codex'
+      }),
+      targetOverride: () => ({
+        apiEndpoints: ['openai'],
+        needsChatResponsesBridge: true,
+        provider: { apiEndpoints: ['openai'] }
+      })
+    })
+
+    const backend = await harness.resolver.resolveActiveBackend()
+    const providerBTargetId = JSON.stringify(['codex', 'provider-b', 'model-b'])
+
+    expect(backend.providerTransportLease?.setTarget(providerBTargetId)).toBe(true)
+    expect(harness.responsesBridges[0].setTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: 'https://provider-b.example/custom',
+        key: 'plain:provider-b-key-ref',
+        model: 'model-b'
+      })
+    )
+
+    harness.setSettings({
+      ...harness.getSettings(),
+      activeProviderId: providerB.id,
+      activeModel: providerB.model
+    })
+    await expect(harness.resolver.resolveActiveModelChangeTarget()).resolves.toMatchObject({
+      backendId: 'codex:provider-b',
+      route: 'codex-bridge',
+      providerTransportTargetId: providerBTargetId
+    })
+  })
+
+  it('retargets Codex Responses compatibility across pre-registered providers', async () => {
+    const providerA = {
+      ...makeStoredProvider('provider-a', 'model-a'),
+      baseUrl: 'https://provider-a.example/v1'
+    }
+    const providerB = {
+      ...makeStoredProvider('provider-b', 'model-b'),
+      baseUrl: 'https://provider-b.example/custom'
+    }
+    const harness = makeHarness({
+      settings: makeSettings({
+        providers: [providerA, providerB],
+        activeProviderId: providerA.id,
+        activeModel: providerA.model,
+        agentFrameworkId: 'codex'
+      }),
+      targetOverride: () => ({
+        apiEndpoints: ['responses'],
+        needsNativeResponsesCompatibility: true,
+        provider: { apiEndpoints: ['responses'] }
+      })
+    })
+
+    const backend = await harness.resolver.resolveActiveBackend()
+    const providerBTargetId = JSON.stringify(['codex', 'provider-b', 'model-b'])
+
+    expect(backend.providerTransportLease?.setTarget(providerBTargetId)).toBe(true)
+    expect(harness.nativeResponsesProxies[0].setTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: 'https://provider-b.example/custom',
+        key: 'plain:provider-b-key-ref',
+        model: 'model-b'
+      })
+    )
+  })
+
+  it('routes native Codex Responses providers through one retargetable loopback', async () => {
+    const providerA = {
+      ...makeStoredProvider('provider-a', 'model-a'),
+      baseUrl: 'https://provider-a.example/v1'
+    }
+    const providerB = {
+      ...makeStoredProvider('provider-b', 'model-b'),
+      baseUrl: 'https://provider-b.example/custom'
+    }
+    const harness = makeHarness({
+      settings: makeSettings({
+        providers: [providerA, providerB],
+        activeProviderId: providerA.id,
+        activeModel: providerA.model,
+        agentFrameworkId: 'codex'
+      }),
+      targetOverride: () => ({
+        apiEndpoints: ['responses'],
+        provider: { apiEndpoints: ['responses'], vendorId: 'openai' }
+      })
+    })
+
+    const backend = await harness.resolver.resolveActiveBackend()
+    const providerATargetId = JSON.stringify(['codex', 'provider-a', 'model-a'])
+    const providerBTargetId = JSON.stringify(['codex', 'provider-b', 'model-b'])
+
+    expect(harness.createOpenAiProviderBridge).toHaveBeenCalledWith(
+      [
+        {
+          id: providerATargetId,
+          wire: 'responses',
+          endpoint: 'https://provider-a.example/v1/responses',
+          key: 'plain:provider-a-key-ref',
+          model: 'model-a'
+        },
+        {
+          id: providerBTargetId,
+          wire: 'responses',
+          endpoint: 'https://provider-b.example/custom/responses',
+          key: 'plain:provider-b-key-ref',
+          model: 'model-b'
+        }
+      ],
+      providerATargetId
+    )
+    expect(backend.authentication).toEqual({
+      methodId: 'api-key',
+      _meta: { 'api-key': { apiKey: 'openai-bridge-token-0' } }
+    })
+    expect(backend.providerTransportLease?.setTarget(providerBTargetId)).toBe(true)
+    expect(harness.openAiProviderBridges[0].setTarget).toHaveBeenCalledWith(providerBTargetId)
+    expect(JSON.stringify(backend)).not.toContain('plain:provider-a-key-ref')
+    expect(JSON.stringify(backend)).not.toContain('plain:provider-b-key-ref')
+  })
+
   it('produces equivalent stable backends for configured and provider-default explicit targets', async () => {
     const settings = makeSettings()
     const harness = makeHarness({ settings })
@@ -568,7 +873,10 @@ describe('AgentBackendResolver configured and explicit targets', () => {
       backendId: 'codex:provider-b',
       sessionModel: 'model-b-current',
       sessionEffort: 'low',
-      authentication: { methodId: 'api-key', _meta: { 'api-key': { apiKey: 'plain:key-b' } } }
+      authentication: {
+        methodId: 'api-key',
+        _meta: { 'api-key': { apiKey: 'openai-bridge-token-0' } }
+      }
     })
     expect(fixed).toMatchObject({
       backendId: 'codex:provider-a',
@@ -576,17 +884,17 @@ describe('AgentBackendResolver configured and explicit targets', () => {
       sessionEffort: 'max',
       authentication: {
         methodId: 'api-key',
-        _meta: { 'api-key': { apiKey: 'plain:key-a-rotated' } }
+        _meta: { 'api-key': { apiKey: 'openai-bridge-token-1' } }
       }
     })
-    expect(harness.resolveRuntimeTarget).toHaveBeenNthCalledWith(
-      1,
+    expect(JSON.stringify(lateBound)).not.toContain('plain:key-b')
+    expect(JSON.stringify(fixed)).not.toContain('plain:key-a-rotated')
+    expect(harness.resolveRuntimeTarget).toHaveBeenCalledWith(
       providerB,
       { kind: 'configured', requestedModel: 'model-b-current' },
       expect.objectContaining({ id: 'codex' })
     )
-    expect(harness.resolveRuntimeTarget).toHaveBeenNthCalledWith(
-      2,
+    expect(harness.resolveRuntimeTarget).toHaveBeenCalledWith(
       rotatedProviderA,
       { kind: 'required', model: 'model-a-fixed' },
       expect.objectContaining({ id: 'codex' })

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -358,6 +358,7 @@ describe('AgentBackendResolver configured and explicit targets', () => {
         provider: {
           apiEndpoints: ['openai'],
           vendorId: 'deepseek',
+          supportsImageInput: true,
           reasoningEffortTransport: 'deepseek'
         }
       })
@@ -372,6 +373,7 @@ describe('AgentBackendResolver configured and explicit targets', () => {
       model: 'model-a',
       sessionModel: 'gpt-5.4',
       sessionModelRequired: false,
+      supportsImageInput: true,
       reasoningEffort: 'max',
       contextWindow: 128_000,
       bridge: {

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -416,6 +416,17 @@ describe('AgentBackendResolver configured and explicit targets', () => {
     expect(JSON.stringify(modelConfig)).not.toContain('plain:key-a')
   })
 
+  it('omits an Anthropic bridge target when the active generation has no bridge', async () => {
+    const harness = makeHarness()
+    const backend = await harness.resolver.resolveActiveBackend()
+
+    expect(backend.anthropicBridgeLease).toBeUndefined()
+    expect(harness.createAnthropicProviderBridge).not.toHaveBeenCalled()
+    await expect(harness.resolver.resolveActiveModelChangeTarget()).resolves.not.toHaveProperty(
+      'anthropicBridgeTargetId'
+    )
+  })
+
   it('routes configured Claude API providers through one retargetable loopback generation', async () => {
     const deepseek = {
       ...makeStoredProvider('deepseek', 'deepseek-v4-pro'),

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -19,6 +19,10 @@ type NativeResponsesProxyFactory = NonNullable<
   AgentBackendResolverOptions['createNativeResponsesProxy']
 >
 type NativeResponsesProxyDouble = ReturnType<NativeResponsesProxyFactory>
+type AnthropicProviderBridgeFactory = NonNullable<
+  AgentBackendResolverOptions['createAnthropicProviderBridge']
+>
+type AnthropicProviderBridgeDouble = ReturnType<AnthropicProviderBridgeFactory>
 type ResolveRuntimeTarget = AgentBackendProviderPort['resolveRuntimeTarget']
 type ResolveRuntimeModelCatalog = AgentBackendProviderPort['resolveRuntimeModelCatalog']
 type TargetOverride = Omit<Partial<ProviderRuntimeTarget>, 'provider'> & {
@@ -106,6 +110,15 @@ const makeNativeResponsesProxyDouble = (
   setModelTarget: vi.fn()
 })
 
+const makeAnthropicProviderBridgeDouble = (): AnthropicProviderBridgeDouble => ({
+  start: vi.fn(async () => ({
+    baseUrl: 'http://127.0.0.1:41003',
+    token: 'anthropic-bridge-token'
+  })),
+  close: vi.fn(async () => undefined),
+  setTarget: vi.fn(() => true)
+})
+
 type HarnessOptions = {
   settings?: StoredSettings
   frameworkOverride?: string
@@ -118,6 +131,7 @@ type HarnessOptions = {
   ) => TargetOverride
   responsesBridgeBuilder?: (index: number) => ResponsesBridgeDouble
   nativeResponsesProxyBuilder?: (index: number) => NativeResponsesProxyDouble
+  anthropicProviderBridgeBuilder?: (index: number) => AnthropicProviderBridgeDouble
   nextGenerationId?: () => string
 }
 
@@ -220,6 +234,14 @@ const makeHarness = (options: HarnessOptions = {}) => {
     nativeResponsesProxies.push(proxy)
     return proxy
   })
+  const anthropicProviderBridges: AnthropicProviderBridgeDouble[] = []
+  const createAnthropicProviderBridge = vi.fn((): AnthropicProviderBridgeDouble => {
+    const bridge =
+      options.anthropicProviderBridgeBuilder?.(anthropicProviderBridges.length) ??
+      makeAnthropicProviderBridgeDouble()
+    anthropicProviderBridges.push(bridge)
+    return bridge
+  })
 
   const resolver = new AgentBackendResolver({
     readSettings,
@@ -231,6 +253,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
     readFrameworkOverride,
     createResponsesBridge,
     createNativeResponsesProxy,
+    createAnthropicProviderBridge,
     ensureCodexSubscriptionHome,
     nextGenerationId
   })
@@ -248,8 +271,10 @@ const makeHarness = (options: HarnessOptions = {}) => {
     connectors,
     createResponsesBridge,
     createNativeResponsesProxy,
+    createAnthropicProviderBridge,
     responsesBridges,
     nativeResponsesProxies,
+    anthropicProviderBridges,
     getSettings: () => currentSettings,
     setSettings: (settings: StoredSettings) => {
       currentSettings = settings
@@ -282,6 +307,7 @@ describe('AgentBackendResolver construction and selection', () => {
     expect(harness.connectors.enabledConnectorIds).not.toHaveBeenCalled()
     expect(harness.createResponsesBridge).not.toHaveBeenCalled()
     expect(harness.createNativeResponsesProxy).not.toHaveBeenCalled()
+    expect(harness.createAnthropicProviderBridge).not.toHaveBeenCalled()
     expect(harness.ensureCodexSubscriptionHome).not.toHaveBeenCalled()
     expect(harness.nextGenerationId).not.toHaveBeenCalled()
     expectRuntimeNotStarted(harness.runtime)
@@ -340,24 +366,91 @@ describe('AgentBackendResolver configured and explicit targets', () => {
     const modelConfig = (backend.sessionOptions as { settings?: unknown })?.settings
 
     expect(modelConfig).toMatchObject({
-      availableModels: ['sonnet', 'opus'],
+      availableModels: ['third-party/model-a', 'third-party/model-b'],
       modelOverrides: {
-        sonnet: 'third-party/model-a',
-        opus: 'third-party/model-b'
+        'third-party/model-a': 'third-party/model-a',
+        'third-party/model-b': 'third-party/model-b'
       }
     })
     expect(harness.runtime.provisionClaudeRuntimeConfig).toHaveBeenCalledWith(
       harness.getSettings(),
       new Set(),
       {
-        availableModels: ['sonnet', 'opus'],
+        availableModels: ['third-party/model-a', 'third-party/model-b'],
         modelOverrides: {
-          sonnet: 'third-party/model-a',
-          opus: 'third-party/model-b'
+          'third-party/model-a': 'third-party/model-a',
+          'third-party/model-b': 'third-party/model-b'
         }
       }
     )
     expect(JSON.stringify(modelConfig)).not.toContain('plain:key-a')
+  })
+
+  it('routes configured Claude API providers through one retargetable loopback generation', async () => {
+    const deepseek = {
+      ...makeStoredProvider('deepseek', 'deepseek-v4-pro'),
+      baseUrl: 'https://api.deepseek.example'
+    }
+    const kimi = {
+      ...makeStoredProvider('kimi', 'kimi-k3'),
+      baseUrl: 'https://api.kimi.example'
+    }
+    const harness = makeHarness({
+      settings: makeSettings({
+        providers: [deepseek, kimi],
+        activeProviderId: deepseek.id,
+        activeModel: deepseek.model,
+        agentFrameworkId: 'claude-code'
+      }),
+      targetOverride: (_provider, _selection, frameworkId) => ({
+        apiEndpoints: frameworkId === 'claude-code' ? ['anthropic'] : ['openai'],
+        provider: { apiEndpoints: ['anthropic'] }
+      })
+    })
+
+    const backend = await harness.resolver.resolveActiveBackend()
+
+    expect(harness.createAnthropicProviderBridge).toHaveBeenCalledWith(
+      [
+        {
+          id: JSON.stringify(['deepseek', 'deepseek-v4-pro']),
+          baseUrl: 'https://api.deepseek.example',
+          key: 'plain:deepseek-key-ref',
+          model: 'deepseek-v4-pro'
+        },
+        {
+          id: JSON.stringify(['kimi', 'kimi-k3']),
+          baseUrl: 'https://api.kimi.example',
+          key: 'plain:kimi-key-ref',
+          model: 'kimi-k3'
+        }
+      ],
+      JSON.stringify(['deepseek', 'deepseek-v4-pro'])
+    )
+    expect(backend.env).toMatchObject({
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:41003',
+      ANTHROPIC_AUTH_TOKEN: 'anthropic-bridge-token'
+    })
+    expect(JSON.stringify(backend)).not.toContain('plain:deepseek-key-ref')
+    expect(JSON.stringify(backend)).not.toContain('plain:kimi-key-ref')
+
+    harness.setSettings({
+      ...harness.getSettings(),
+      activeProviderId: kimi.id,
+      activeModel: kimi.model
+    })
+    await expect(harness.resolver.resolveActiveModelChangeTarget()).resolves.toMatchObject({
+      backendId: 'claude-code:kimi',
+      model: 'kimi-k3',
+      anthropicBridgeTargetId: JSON.stringify(['kimi', 'kimi-k3'])
+    })
+
+    backend.anthropicBridgeLease?.setTarget(JSON.stringify(['kimi', 'kimi-k3']))
+    expect(harness.anthropicProviderBridges[0].setTarget).toHaveBeenCalledWith(
+      JSON.stringify(['kimi', 'kimi-k3'])
+    )
+    await backend.anthropicBridgeLease?.release()
+    expect(harness.anthropicProviderBridges[0].close).toHaveBeenCalledOnce()
   })
 
   it('resolves a secret-free live model target without starting runtime resources', async () => {

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -346,6 +346,17 @@ describe('AgentBackendResolver configured and explicit targets', () => {
         opus: 'third-party/model-b'
       }
     })
+    expect(harness.runtime.provisionClaudeRuntimeConfig).toHaveBeenCalledWith(
+      harness.getSettings(),
+      new Set(),
+      {
+        availableModels: ['sonnet', 'opus'],
+        modelOverrides: {
+          sonnet: 'third-party/model-a',
+          opus: 'third-party/model-b'
+        }
+      }
+    )
     expect(JSON.stringify(modelConfig)).not.toContain('plain:key-a')
   })
 
@@ -559,7 +570,8 @@ describe('AgentBackendResolver runtime delegation', () => {
     if (testCase.frameworkId === 'claude-code') {
       expect(harness.runtime.provisionClaudeRuntimeConfig).toHaveBeenCalledWith(
         harness.getSettings(),
-        new Set(['forced-skill'])
+        new Set(['forced-skill']),
+        null
       )
       expect(harness.runtime.materializeAgentSkills).not.toHaveBeenCalled()
       expect(harness.runtime.materializeAgentConfigFiles).not.toHaveBeenCalled()

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -66,6 +66,7 @@ import {
 import { ensureCodexAuthHome } from './codex-auth'
 import { loopbackProxyBypassEnvironment } from './system-proxy'
 import type { StoredSettings } from './types'
+import type { ClaudeRuntimeModelConfig } from './claude-config-provision'
 
 export type AgentBackendSelection = Readonly<{
   frameworkId: AgentFrameworkId
@@ -161,11 +162,6 @@ const resolvedModelEffort = (
   intent === DEFAULT_REASONING_EFFORT
     ? DEFAULT_REASONING_EFFORT
     : resolveReasoningEffortValue(intent, target.reasoningEffortProfile)
-
-type ClaudeModelConfig = Readonly<{
-  availableModels: readonly string[]
-  modelOverrides: Readonly<Record<string, string>>
-}>
 
 const CLAUDE_MODEL_OVERRIDE_ALIASES = ['sonnet', 'opus', 'haiku'] as const
 
@@ -641,9 +637,13 @@ export class AgentBackendResolver {
     if (target.providerType === 'claude-shared' && target.disconnectedAt !== undefined) {
       throw new Error(CLAUDE_SHARED_DISCONNECTED_MESSAGE)
     }
-    const appConfigDir = await this.runtime.provisionClaudeRuntimeConfig(settings, forcedSkillIds)
     const provider = target.provider
     const modelConfig = this.resolveClaudeModelConfig(settings, target)
+    const appConfigDir = await this.runtime.provisionClaudeRuntimeConfig(
+      settings,
+      forcedSkillIds,
+      modelConfig ?? null
+    )
     const envOverrides = buildProviderEnv(provider, {
       storageRoot: this.storageRoot,
       claudeExecutablePath: executablePath,
@@ -676,7 +676,7 @@ export class AgentBackendResolver {
   private resolveClaudeModelConfig(
     settings: StoredSettings,
     target: ProviderRuntimeTarget
-  ): ClaudeModelConfig | undefined {
+  ): ClaudeRuntimeModelConfig | undefined {
     // Subscription and Anthropic-native sessions already get an authoritative SDK catalog. The
     // override lanes are needed only for third-party Anthropic-compatible model ids, which Claude's
     // SDK otherwise advertises but rejects when setModel receives an unregistered opaque id.

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -23,11 +23,15 @@ import {
 import {
   DEFAULT_AGENT_FRAMEWORK_ID,
   getAgentFramework,
+  type AgentModelCatalogEntry,
+  type AgentModelChangeTarget,
+  type AgentModelRoute,
   type AgentFrameworkId,
   type ResolvedAgentBackend
 } from '../agent-framework'
 import { opencodeConfigDir } from '../agent-framework/opencode'
 import {
+  CODEX_BRIDGE_MODEL,
   codexStorageDir,
   codexSubscriptionStorageDir,
   normalizeResponsesBaseUrl
@@ -101,7 +105,7 @@ export type AgentBackendRuntimePort = Pick<
 
 export type AgentBackendProviderPort = Pick<
   ProviderAccountsModule,
-  'resolveRuntimeTarget' | 'resolveRuntimeReasoningEffortProfile'
+  'resolveRuntimeTarget' | 'resolveRuntimeModelCatalog' | 'resolveRuntimeReasoningEffortProfile'
 >
 
 export type AgentBackendConnectorPort = Pick<ConnectorSettingsModule, 'enabledConnectorIds'>
@@ -111,8 +115,10 @@ type BridgeBasePort = Pick<
   'start' | 'close' | 'selectSkills' | 'registerReviewerSession' | 'unregisterReviewerSession'
 >
 
-type ResponsesBridgePort = BridgeBasePort & Pick<ResponsesBridge, 'setReasoningEffort'>
-type NativeResponsesProxyPort = BridgeBasePort
+type ResponsesBridgePort = BridgeBasePort &
+  Pick<ResponsesBridge, 'setReasoningEffort' | 'setModelTarget'>
+type NativeResponsesProxyPort = BridgeBasePort &
+  Pick<NativeResponsesCompatibilityProxy, 'setModelTarget'>
 
 type NativeResponsesProxyTarget = {
   baseUrl: string
@@ -134,6 +140,34 @@ type NativeResponsesCompatibilityEntry = {
 type LeasedResponsesBridgeConnection = ResponsesBridgeConnection & {
   lease: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>
 }
+
+const modelRouteFor = (
+  frameworkId: AgentFrameworkId,
+  target: ProviderRuntimeTarget
+): AgentModelRoute => {
+  if (frameworkId === 'claude-code') return 'claude-anthropic'
+  if (frameworkId === 'opencode') {
+    return target.apiEndpoints.includes('openai') ? 'opencode-openai' : 'opencode-anthropic'
+  }
+  if (target.needsChatResponsesBridge) return 'codex-bridge'
+  if (target.needsNativeResponsesCompatibility) return 'codex-responses-compatibility'
+  return 'codex-responses'
+}
+
+const resolvedModelEffort = (
+  intent: ReasoningEffort,
+  target: ProviderRuntimeTarget
+): ResolvedReasoningEffort =>
+  intent === DEFAULT_REASONING_EFFORT
+    ? DEFAULT_REASONING_EFFORT
+    : resolveReasoningEffortValue(intent, target.reasoningEffortProfile)
+
+type ClaudeModelConfig = Readonly<{
+  availableModels: readonly string[]
+  modelOverrides: Readonly<Record<string, string>>
+}>
+
+const CLAUDE_MODEL_OVERRIDE_ALIASES = ['sonnet', 'opus', 'haiku'] as const
 
 export type AgentBackendResolverOptions = {
   readSettings: () => Promise<StoredSettings>
@@ -269,6 +303,59 @@ export class AgentBackendResolver {
     )
   }
 
+  async resolveActiveModelChangeTarget(): Promise<AgentModelChangeTarget | undefined> {
+    const settings = await this.readSettings()
+    const frameworkId = this.resolveConfiguredFrameworkId(settings)
+    const framework = getAgentFramework(frameworkId)
+    const storedProvider = settings.activeProviderId
+      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
+      : undefined
+    if (!storedProvider) return undefined
+
+    const target = this.providers.resolveRuntimeTarget(
+      storedProvider,
+      { kind: 'configured', requestedModel: settings.activeModel },
+      framework
+    )
+    if (!target.frameworkCompatible || (frameworkId === 'codex' && !target.modelBridgeSupported)) {
+      return undefined
+    }
+
+    const model = target.effectiveModel ?? target.provider.model
+    if (!model) return undefined
+    const route = modelRouteFor(frameworkId, target)
+    const backendProviderId =
+      frameworkId === 'codex' && isCodexSubscriptionProvider(target.provider.type)
+        ? CODEX_ISOLATED_PROVIDER_ID
+        : target.providerId
+
+    return Object.freeze({
+      frameworkId,
+      backendId: `${frameworkId}:${backendProviderId}`,
+      route,
+      model,
+      sessionModel: route === 'codex-bridge' ? CODEX_BRIDGE_MODEL : model,
+      sessionModelRequired:
+        frameworkId === 'codex' && isCodexSubscriptionProvider(target.provider.type),
+      reasoningEffort: resolvedModelEffort(
+        settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+        target
+      ),
+      ...(target.provider.contextWindow ? { contextWindow: target.provider.contextWindow } : {}),
+      ...(route === 'codex-bridge' || route === 'codex-responses-compatibility'
+        ? {
+            bridge: Object.freeze({
+              model,
+              ...(target.provider.vendorId ? { vendorId: target.provider.vendorId } : {}),
+              ...(target.provider.reasoningEffortTransport
+                ? { reasoningEffortTransport: target.provider.reasoningEffortTransport }
+                : {})
+            })
+          }
+        : {})
+    })
+  }
+
   async captureConfiguredSelection(): Promise<AgentBackendSelection> {
     const settings = await this.readSettings()
     return { frameworkId: this.resolveConfiguredFrameworkId(settings) }
@@ -367,10 +454,8 @@ export class AgentBackendResolver {
       throw new Error(CODEX_BRIDGE_UNSUPPORTED_MESSAGE)
     }
 
-    const resolvedEffort =
-      effortIntent === DEFAULT_REASONING_EFFORT
-        ? DEFAULT_REASONING_EFFORT
-        : resolveReasoningEffortValue(effortIntent, target.reasoningEffortProfile)
+    const modelRoute = modelRouteFor(frameworkId, target)
+    const resolvedEffort = resolvedModelEffort(effortIntent, target)
     const sessionEffort: ModelReasoningEffort | undefined =
       resolvedEffort === 'default' ? undefined : resolvedEffort
     const supportedReasoningEfforts = target.reasoningEffortProfile.supported
@@ -387,6 +472,7 @@ export class AgentBackendResolver {
       return {
         framework,
         backendId: `${framework.id}:${target.providerId}`,
+        modelRoute,
         executablePath,
         env: envOverrides,
         sessionOptions,
@@ -409,6 +495,24 @@ export class AgentBackendResolver {
         ? await this.runtime.probeCodexNativeVersion(settings.codex?.nativePath)
         : undefined
     const provider = target.provider
+    const providerModelCatalog: AgentModelCatalogEntry[] = this.providers
+      .resolveRuntimeModelCatalog(storedProvider, framework)
+      .filter(
+        (candidate) =>
+          candidate.frameworkCompatible &&
+          (framework.id !== 'codex' || candidate.modelBridgeSupported) &&
+          modelRouteFor(framework.id, candidate) === modelRoute
+      )
+      .map((candidate) => {
+        const candidateEffort = resolvedModelEffort(effortIntent, candidate)
+        return Object.freeze({
+          provider: candidate.provider,
+          ...(candidateEffort === 'default' ? {} : { reasoningEffort: candidateEffort }),
+          ...(candidate.reasoningEffortProfile.supported
+            ? { reasoningEfforts: [...new Set(candidate.reasoningEffortProfile.slots)] }
+            : {})
+        })
+      })
     if (framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)) {
       await this.ensureCodexSubscriptionHome()
     }
@@ -446,6 +550,7 @@ export class AgentBackendResolver {
         responsesBridge,
         reasoningEffort: sessionEffort,
         reasoningEfforts: supportedReasoningEfforts,
+        providerModelCatalog,
         instructions: connectorInstructions,
         ...(persistentSystemPromptAppends.length > 0
           ? { systemPromptAppends: persistentSystemPromptAppends }
@@ -471,6 +576,7 @@ export class AgentBackendResolver {
       return {
         framework,
         backendId: `${framework.id}:${backendProviderId}`,
+        modelRoute,
         executablePath,
         env: {
           ...(modelConfig.env ?? {}),
@@ -534,6 +640,7 @@ export class AgentBackendResolver {
     }
     const appConfigDir = await this.runtime.provisionClaudeRuntimeConfig(settings, forcedSkillIds)
     const provider = target.provider
+    const modelConfig = this.resolveClaudeModelConfig(settings, target)
     const envOverrides = buildProviderEnv(provider, {
       storageRoot: this.storageRoot,
       claudeExecutablePath: executablePath,
@@ -549,7 +656,8 @@ export class AgentBackendResolver {
           ? {
               settings: {
                 skipWebFetchPreflight: true,
-                permissions: { ask: ['WebFetch'] }
+                permissions: { ask: ['WebFetch'] },
+                ...(modelConfig ?? {})
               }
             }
           : undefined
@@ -560,6 +668,43 @@ export class AgentBackendResolver {
       sessionOptions,
       contextWindow: provider.contextWindow
     }
+  }
+
+  private resolveClaudeModelConfig(
+    settings: StoredSettings,
+    target: ProviderRuntimeTarget
+  ): ClaudeModelConfig | undefined {
+    // Subscription and Anthropic-native sessions already get an authoritative SDK catalog. The
+    // override lanes are needed only for third-party Anthropic-compatible model ids, which Claude's
+    // SDK otherwise advertises but rejects when setModel receives an unregistered opaque id.
+    if (
+      target.providerType === 'claude-shared' ||
+      target.providerType === 'claude-isolated' ||
+      target.provider.vendorId === 'anthropic'
+    ) {
+      return undefined
+    }
+    const storedProvider = settings.providers.find((provider) => provider.id === target.providerId)
+    if (!storedProvider || storedProvider.type !== 'official') return undefined
+
+    const framework = getAgentFramework('claude-code')
+    const models = [
+      target.effectiveModel,
+      ...this.providers
+        .resolveRuntimeModelCatalog(storedProvider, framework)
+        .filter((candidate) => candidate.frameworkCompatible)
+        .map((candidate) => candidate.effectiveModel)
+    ].filter((model): model is string => Boolean(model))
+    const registered = [...new Set(models)].slice(0, CLAUDE_MODEL_OVERRIDE_ALIASES.length)
+    if (registered.length < 2) return undefined
+
+    const availableModels = CLAUDE_MODEL_OVERRIDE_ALIASES.slice(0, registered.length)
+    return Object.freeze({
+      availableModels: Object.freeze([...availableModels]),
+      modelOverrides: Object.freeze(
+        Object.fromEntries(availableModels.map((alias, index) => [alias, registered[index]]))
+      )
+    })
   }
 
   private async ensureResponsesBridge(
@@ -609,6 +754,7 @@ export class AgentBackendResolver {
         unregisterReviewerSession: (promptCacheKey) =>
           leasedEntry.bridge.unregisterReviewerSession(promptCacheKey),
         setReasoningEffort: (effort) => leasedEntry.bridge.setReasoningEffort(effort),
+        setModelTarget: (target) => leasedEntry.bridge.setModelTarget(target),
         release: async () => {
           if (released) return
           released = true
@@ -657,6 +803,7 @@ export class AgentBackendResolver {
           leasedEntry.proxy.registerReviewerSession(promptCacheKey),
         unregisterReviewerSession: (promptCacheKey) =>
           leasedEntry.proxy.unregisterReviewerSession(promptCacheKey),
+        setModelTarget: (target) => leasedEntry.proxy.setModelTarget(target),
         release: async () => {
           if (released) return
           released = true

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -46,8 +46,12 @@ import {
   REQUEST_SKILL_IMPORT_TOOL_NAME,
   SKILL_IMPORT_MCP_SERVER_NAME
 } from '../../shared/skill-import'
-import { openAiCompletionsBase } from './base-url'
+import { normalizeAnthropicBaseUrl, openAiCompletionsBase } from './base-url'
 import { buildProviderEnv } from './provider-env'
+import {
+  AnthropicProviderBridge,
+  type AnthropicProviderBridgeTarget
+} from './anthropic-provider-bridge'
 import {
   ResponsesBridge,
   type ResponsesBridgeConnection,
@@ -120,6 +124,7 @@ type ResponsesBridgePort = BridgeBasePort &
   Pick<ResponsesBridge, 'setReasoningEffort' | 'setModelTarget'>
 type NativeResponsesProxyPort = BridgeBasePort &
   Pick<NativeResponsesCompatibilityProxy, 'setModelTarget'>
+type AnthropicProviderBridgePort = Pick<AnthropicProviderBridge, 'start' | 'close' | 'setTarget'>
 
 type NativeResponsesProxyTarget = {
   baseUrl: string
@@ -163,7 +168,13 @@ const resolvedModelEffort = (
     ? DEFAULT_REASONING_EFFORT
     : resolveReasoningEffortValue(intent, target.reasoningEffortProfile)
 
-const CLAUDE_MODEL_OVERRIDE_ALIASES = ['sonnet', 'opus', 'haiku'] as const
+const claudeBridgeTargetId = (providerId: string, model: string): string =>
+  JSON.stringify([providerId, model])
+
+type ClaudeBridgeCatalog = Readonly<{
+  targets: readonly AnthropicProviderBridgeTarget[]
+  initialTargetId: string
+}>
 
 export type AgentBackendResolverOptions = {
   readSettings: () => Promise<StoredSettings>
@@ -175,6 +186,10 @@ export type AgentBackendResolverOptions = {
   readFrameworkOverride?: () => string | undefined
   createResponsesBridge?: (target: ResponsesBridgeTarget) => ResponsesBridgePort
   createNativeResponsesProxy?: (target: NativeResponsesProxyTarget) => NativeResponsesProxyPort
+  createAnthropicProviderBridge?: (
+    targets: readonly AnthropicProviderBridgeTarget[],
+    initialTargetId: string
+  ) => AnthropicProviderBridgePort
   ensureCodexSubscriptionHome?: () => Promise<void>
   nextGenerationId?: () => string
 }
@@ -242,6 +257,10 @@ export class AgentBackendResolver {
   private readonly createNativeResponsesProxy: (
     target: NativeResponsesProxyTarget
   ) => NativeResponsesProxyPort
+  private readonly createAnthropicProviderBridge: (
+    targets: readonly AnthropicProviderBridgeTarget[],
+    initialTargetId: string
+  ) => AnthropicProviderBridgePort
   private readonly ensureCodexSubscriptionHome: () => Promise<void>
   private readonly nextGenerationId: () => string
   private readonly responsesBridges = new Map<string, ResponsesBridgeEntry>()
@@ -264,6 +283,9 @@ export class AgentBackendResolver {
     this.createNativeResponsesProxy =
       options.createNativeResponsesProxy ??
       ((target) => new NativeResponsesCompatibilityProxy(target))
+    this.createAnthropicProviderBridge =
+      options.createAnthropicProviderBridge ??
+      ((targets, initialTargetId) => new AnthropicProviderBridge(targets, initialTargetId))
     this.ensureCodexSubscriptionHome =
       options.ensureCodexSubscriptionHome ??
       (() => ensureCodexAuthHome('isolated', this.storageRoot))
@@ -338,6 +360,9 @@ export class AgentBackendResolver {
         settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
         target
       ),
+      ...(frameworkId === 'claude-code' && target.provider.type === 'custom'
+        ? { anthropicBridgeTargetId: claudeBridgeTargetId(target.providerId, model) }
+        : {}),
       ...(target.provider.contextWindow ? { contextWindow: target.provider.contextWindow } : {}),
       ...(route === 'codex-bridge' || route === 'codex-responses-compatibility'
         ? {
@@ -466,18 +491,49 @@ export class AgentBackendResolver {
     if (framework.id === 'claude-code') {
       const { envOverrides, executablePath, sessionOptions, contextWindow } =
         await this.resolveClaudeSpawnConfig(settings, target, forcedSkillIds)
-      return {
-        framework,
-        backendId: `${framework.id}:${target.providerId}`,
-        modelRoute,
-        executablePath,
-        env: envOverrides,
-        sessionOptions,
-        sessionEffort,
-        contextWindow,
-        ...(target.provider.supportsImageInput ? { supportsImageInput: true } : {}),
-        contextUsageModel: target.effectiveModel,
-        ...(connectorInstructions ? { systemPromptAppends: [connectorInstructions] } : {})
+      const bridgeCatalog = this.resolveClaudeBridgeCatalog(settings, target)
+      let bridge: AnthropicProviderBridgePort | undefined
+      try {
+        const bridgeConnection = bridgeCatalog
+          ? await (bridge = this.createAnthropicProviderBridge(
+              bridgeCatalog.targets,
+              bridgeCatalog.initialTargetId
+            )).start()
+          : undefined
+        const startedBridge = bridge
+        const bridgeLease = startedBridge
+          ? {
+              setTarget: (targetId: string) => startedBridge.setTarget(targetId),
+              release: () => startedBridge.close()
+            }
+          : undefined
+        return {
+          framework,
+          backendId: `${framework.id}:${target.providerId}`,
+          modelRoute,
+          executablePath,
+          env: {
+            ...envOverrides,
+            ...(bridgeConnection
+              ? {
+                  ANTHROPIC_BASE_URL: bridgeConnection.baseUrl,
+                  ANTHROPIC_AUTH_TOKEN: bridgeConnection.token,
+                  ANTHROPIC_API_KEY: bridgeConnection.token,
+                  ...loopbackProxyBypassEnvironment(process.env)
+                }
+              : {})
+          },
+          sessionOptions,
+          sessionEffort,
+          contextWindow,
+          ...(target.provider.supportsImageInput ? { supportsImageInput: true } : {}),
+          contextUsageModel: target.effectiveModel,
+          ...(connectorInstructions ? { systemPromptAppends: [connectorInstructions] } : {}),
+          ...(bridgeLease ? { anthropicBridgeLease: bridgeLease } : {})
+        }
+      } catch (error) {
+        await bridge?.close().catch(() => undefined)
+        throw error
       }
     }
 
@@ -677,36 +733,96 @@ export class AgentBackendResolver {
     settings: StoredSettings,
     target: ProviderRuntimeTarget
   ): ClaudeRuntimeModelConfig | undefined {
-    // Subscription and Anthropic-native sessions already get an authoritative SDK catalog. The
-    // override lanes are needed only for third-party Anthropic-compatible model ids, which Claude's
-    // SDK otherwise advertises but rejects when setModel receives an unregistered opaque id.
-    if (
-      target.providerType === 'claude-shared' ||
-      target.providerType === 'claude-isolated' ||
-      target.provider.vendorId === 'anthropic'
-    ) {
-      return undefined
-    }
-    const storedProvider = settings.providers.find((provider) => provider.id === target.providerId)
-    if (!storedProvider || storedProvider.type !== 'official') return undefined
-
-    const framework = getAgentFramework('claude-code')
-    const models = [
-      target.effectiveModel,
-      ...this.providers
-        .resolveRuntimeModelCatalog(storedProvider, framework)
-        .filter((candidate) => candidate.frameworkCompatible)
-        .map((candidate) => candidate.effectiveModel)
+    if (target.provider.type !== 'custom') return undefined
+    const registered = [
+      ...new Set(
+        this.resolveClaudeApiTargets(settings, target).map(
+          (candidate) => candidate.effectiveModel ?? candidate.provider.model
+        )
+      )
     ].filter((model): model is string => Boolean(model))
-    const registered = [...new Set(models)].slice(0, CLAUDE_MODEL_OVERRIDE_ALIASES.length)
     if (registered.length < 2) return undefined
 
-    const availableModels = CLAUDE_MODEL_OVERRIDE_ALIASES.slice(0, registered.length)
     return Object.freeze({
-      availableModels: Object.freeze([...availableModels]),
+      availableModels: Object.freeze([...registered]),
       modelOverrides: Object.freeze(
-        Object.fromEntries(availableModels.map((alias, index) => [alias, registered[index]]))
+        // Identity overrides deliberately register opaque third-party ids with Claude's SDK. A real
+        // adapter spike verifies that this has no three-alias ceiling and setModel accepts every row.
+        Object.fromEntries(registered.map((model) => [model, model]))
       )
+    })
+  }
+
+  private resolveClaudeBridgeCatalog(
+    settings: StoredSettings,
+    target: ProviderRuntimeTarget
+  ): ClaudeBridgeCatalog | undefined {
+    if (target.provider.type !== 'custom') return undefined
+    const apiTargets = this.resolveClaudeApiTargets(settings, target)
+    if (new Set(apiTargets.map((candidate) => candidate.providerId)).size < 2) return undefined
+    const targets = apiTargets.flatMap((candidate): AnthropicProviderBridgeTarget[] => {
+      const model = candidate.effectiveModel ?? candidate.provider.model
+      const baseUrl = normalizeAnthropicBaseUrl(candidate.provider.baseUrl ?? '')
+      if (!model || !baseUrl) return []
+      return [
+        Object.freeze({
+          id: claudeBridgeTargetId(candidate.providerId, model),
+          baseUrl,
+          ...(candidate.provider.key ? { key: candidate.provider.key } : {}),
+          model
+        })
+      ]
+    })
+    const initialModel = target.effectiveModel ?? target.provider.model
+    if (!initialModel) return undefined
+    const initialTargetId = claudeBridgeTargetId(target.providerId, initialModel)
+    if (!targets.some((candidate) => candidate.id === initialTargetId)) return undefined
+
+    return Object.freeze({ targets: Object.freeze(targets), initialTargetId })
+  }
+
+  private resolveClaudeApiTargets(
+    settings: StoredSettings,
+    activeTarget: ProviderRuntimeTarget
+  ): ProviderRuntimeTarget[] {
+    const framework = getAgentFramework('claude-code')
+    const candidates: ProviderRuntimeTarget[] = [activeTarget]
+
+    for (const storedProvider of settings.providers) {
+      try {
+        const configured =
+          storedProvider.id === activeTarget.providerId
+            ? activeTarget
+            : this.providers.resolveRuntimeTarget(
+                storedProvider,
+                { kind: 'configured', requestedModel: storedProvider.model },
+                framework
+              )
+        candidates.push(configured)
+        candidates.push(...this.providers.resolveRuntimeModelCatalog(storedProvider, framework))
+      } catch {
+        // Another configured provider may have stale/missing credentials. It must not prevent the
+        // active backend from starting; selecting it later falls back to reconnect and validation.
+      }
+    }
+
+    const seen = new Set<string>()
+    return candidates.filter((candidate) => {
+      const model = candidate.effectiveModel ?? candidate.provider.model
+      if (
+        !candidate.frameworkCompatible ||
+        candidate.provider.type !== 'custom' ||
+        !candidate.apiEndpoints.includes('anthropic') ||
+        !model ||
+        !candidate.provider.baseUrl ||
+        !candidate.provider.key
+      ) {
+        return false
+      }
+      const id = claudeBridgeTargetId(candidate.providerId, model)
+      if (seen.has(id)) return false
+      seen.add(id)
+      return true
     })
   }
 

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -385,6 +385,9 @@ export class AgentBackendResolver {
       frameworkId === 'codex' ? this.resolveCodexApiTargets(settings, target, route) : []
     const hasCodexProviderTransport =
       new Set(codexTransportTargets.map((candidate) => candidate.providerId)).size >= 2
+    const hasClaudeProviderTransport =
+      frameworkId === 'claude-code' &&
+      this.resolveClaudeBridgeCatalog(settings, target) !== undefined
     const backendProviderId =
       frameworkId === 'codex' && isCodexSubscriptionProvider(target.provider.type)
         ? CODEX_ISOLATED_PROVIDER_ID
@@ -408,7 +411,7 @@ export class AgentBackendResolver {
         settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
         target
       ),
-      ...(frameworkId === 'claude-code' && target.provider.type === 'custom'
+      ...(hasClaudeProviderTransport
         ? { anthropicBridgeTargetId: claudeBridgeTargetId(target.providerId, model) }
         : {}),
       ...(hasOpenCodeProviderTransport || hasCodexProviderTransport

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -337,6 +337,7 @@ export class AgentBackendResolver {
       sessionModel: route === 'codex-bridge' ? CODEX_BRIDGE_MODEL : model,
       sessionModelRequired:
         frameworkId === 'codex' && isCodexSubscriptionProvider(target.provider.type),
+      supportsImageInput: target.provider.supportsImageInput === true,
       reasoningEffort: resolvedModelEffort(
         settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
         target
@@ -478,6 +479,7 @@ export class AgentBackendResolver {
         sessionOptions,
         sessionEffort,
         contextWindow,
+        ...(target.provider.supportsImageInput ? { supportsImageInput: true } : {}),
         contextUsageModel: target.effectiveModel,
         ...(connectorInstructions ? { systemPromptAppends: [connectorInstructions] } : {})
       }
@@ -606,6 +608,7 @@ export class AgentBackendResolver {
           : {}),
         sessionEffort,
         contextWindow: provider.contextWindow,
+        ...(provider.supportsImageInput ? { supportsImageInput: true } : {}),
         contextUsageModel: provider.model,
         authentication: modelConfig.authentication,
         providerConfiguration: modelConfig.providerConfiguration,

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -29,7 +29,7 @@ import {
   type AgentFrameworkId,
   type ResolvedAgentBackend
 } from '../agent-framework'
-import { opencodeConfigDir } from '../agent-framework/opencode'
+import { opencodeConfigDir, opencodeTransportProviderId } from '../agent-framework/opencode'
 import {
   CODEX_BRIDGE_MODEL,
   codexStorageDir,
@@ -46,19 +46,27 @@ import {
   REQUEST_SKILL_IMPORT_TOOL_NAME,
   SKILL_IMPORT_MCP_SERVER_NAME
 } from '../../shared/skill-import'
-import { normalizeAnthropicBaseUrl, openAiCompletionsBase } from './base-url'
+import {
+  normalizeAnthropicBaseUrl,
+  openAiChatCompletionsUrl,
+  openAiCompletionsBase
+} from './base-url'
 import { buildProviderEnv } from './provider-env'
 import {
   AnthropicProviderBridge,
   type AnthropicProviderBridgeTarget
 } from './anthropic-provider-bridge'
+import { OpenAiProviderBridge, type OpenAiProviderBridgeTarget } from './openai-provider-bridge'
 import {
   ResponsesBridge,
   type ResponsesBridgeConnection,
   type ResponsesBridgeNamespacedTool,
   type ResponsesBridgeTarget
 } from './responses-bridge'
-import { NativeResponsesCompatibilityProxy } from './native-responses-compatibility'
+import {
+  NativeResponsesCompatibilityProxy,
+  type NativeResponsesCompatibilityTarget
+} from './native-responses-compatibility'
 import type { AgentRuntimeManager } from './agent-runtime-manager'
 import type { ConnectorSettingsModule } from './connector-settings'
 import {
@@ -121,15 +129,13 @@ type BridgeBasePort = Pick<
 >
 
 type ResponsesBridgePort = BridgeBasePort &
-  Pick<ResponsesBridge, 'setReasoningEffort' | 'setModelTarget'>
+  Pick<ResponsesBridge, 'setReasoningEffort' | 'setModelTarget' | 'setTarget'>
 type NativeResponsesProxyPort = BridgeBasePort &
-  Pick<NativeResponsesCompatibilityProxy, 'setModelTarget'>
+  Pick<NativeResponsesCompatibilityProxy, 'setModelTarget' | 'setTarget'>
 type AnthropicProviderBridgePort = Pick<AnthropicProviderBridge, 'start' | 'close' | 'setTarget'>
+type OpenAiProviderBridgePort = Pick<OpenAiProviderBridge, 'start' | 'close' | 'setTarget'>
 
-type NativeResponsesProxyTarget = {
-  baseUrl: string
-  key?: string
-  model?: string
+type NativeResponsesProxyTarget = NativeResponsesCompatibilityTarget & {
   reviewerScope: { namespacedTools: ResponsesBridgeNamespacedTool[] }
 }
 
@@ -145,7 +151,19 @@ type NativeResponsesCompatibilityEntry = {
 
 type LeasedResponsesBridgeConnection = ResponsesBridgeConnection & {
   lease: NonNullable<ResolvedAgentBackend['responsesBridgeLease']>
+  providerTransportLease?: NonNullable<ResolvedAgentBackend['providerTransportLease']>
 }
+
+type OpenCodeProviderTransport = Readonly<{
+  provider: ProviderRuntimeTarget['provider']
+  providerModelCatalog: readonly AgentModelCatalogEntry[]
+  lease: NonNullable<ResolvedAgentBackend['providerTransportLease']>
+}>
+
+type NativeCodexProviderTransport = Readonly<{
+  provider: ProviderRuntimeTarget['provider']
+  lease: NonNullable<ResolvedAgentBackend['providerTransportLease']>
+}>
 
 const modelRouteFor = (
   frameworkId: AgentFrameworkId,
@@ -171,6 +189,12 @@ const resolvedModelEffort = (
 const claudeBridgeTargetId = (providerId: string, model: string): string =>
   JSON.stringify([providerId, model])
 
+const providerTransportTargetId = (
+  frameworkId: AgentFrameworkId,
+  providerId: string,
+  model: string
+): string => JSON.stringify([frameworkId, providerId, model])
+
 type ClaudeBridgeCatalog = Readonly<{
   targets: readonly AnthropicProviderBridgeTarget[]
   initialTargetId: string
@@ -190,6 +214,10 @@ export type AgentBackendResolverOptions = {
     targets: readonly AnthropicProviderBridgeTarget[],
     initialTargetId: string
   ) => AnthropicProviderBridgePort
+  createOpenAiProviderBridge?: (
+    targets: readonly OpenAiProviderBridgeTarget[],
+    initialTargetId: string
+  ) => OpenAiProviderBridgePort
   ensureCodexSubscriptionHome?: () => Promise<void>
   nextGenerationId?: () => string
 }
@@ -261,6 +289,10 @@ export class AgentBackendResolver {
     targets: readonly AnthropicProviderBridgeTarget[],
     initialTargetId: string
   ) => AnthropicProviderBridgePort
+  private readonly createOpenAiProviderBridge: (
+    targets: readonly OpenAiProviderBridgeTarget[],
+    initialTargetId: string
+  ) => OpenAiProviderBridgePort
   private readonly ensureCodexSubscriptionHome: () => Promise<void>
   private readonly nextGenerationId: () => string
   private readonly responsesBridges = new Map<string, ResponsesBridgeEntry>()
@@ -286,6 +318,9 @@ export class AgentBackendResolver {
     this.createAnthropicProviderBridge =
       options.createAnthropicProviderBridge ??
       ((targets, initialTargetId) => new AnthropicProviderBridge(targets, initialTargetId))
+    this.createOpenAiProviderBridge =
+      options.createOpenAiProviderBridge ??
+      ((targets, initialTargetId) => new OpenAiProviderBridge(targets, initialTargetId))
     this.ensureCodexSubscriptionHome =
       options.ensureCodexSubscriptionHome ??
       (() => ensureCodexAuthHome('isolated', this.storageRoot))
@@ -342,6 +377,14 @@ export class AgentBackendResolver {
     const model = target.effectiveModel ?? target.provider.model
     if (!model) return undefined
     const route = modelRouteFor(frameworkId, target)
+    const openCodeTransportTargets =
+      frameworkId === 'opencode' ? this.resolveOpenCodeApiTargets(settings, target, route) : []
+    const hasOpenCodeProviderTransport =
+      new Set(openCodeTransportTargets.map((candidate) => candidate.providerId)).size >= 2
+    const codexTransportTargets =
+      frameworkId === 'codex' ? this.resolveCodexApiTargets(settings, target, route) : []
+    const hasCodexProviderTransport =
+      new Set(codexTransportTargets.map((candidate) => candidate.providerId)).size >= 2
     const backendProviderId =
       frameworkId === 'codex' && isCodexSubscriptionProvider(target.provider.type)
         ? CODEX_ISOLATED_PROVIDER_ID
@@ -352,7 +395,12 @@ export class AgentBackendResolver {
       backendId: `${frameworkId}:${backendProviderId}`,
       route,
       model,
-      sessionModel: route === 'codex-bridge' ? CODEX_BRIDGE_MODEL : model,
+      sessionModel:
+        route === 'codex-bridge'
+          ? CODEX_BRIDGE_MODEL
+          : hasOpenCodeProviderTransport
+            ? `${opencodeTransportProviderId(target.providerId, model)}/${model}`
+            : model,
       sessionModelRequired:
         frameworkId === 'codex' && isCodexSubscriptionProvider(target.provider.type),
       supportsImageInput: target.provider.supportsImageInput === true,
@@ -362,6 +410,15 @@ export class AgentBackendResolver {
       ),
       ...(frameworkId === 'claude-code' && target.provider.type === 'custom'
         ? { anthropicBridgeTargetId: claudeBridgeTargetId(target.providerId, model) }
+        : {}),
+      ...(hasOpenCodeProviderTransport || hasCodexProviderTransport
+        ? {
+            providerTransportTargetId: providerTransportTargetId(
+              frameworkId,
+              target.providerId,
+              model
+            )
+          }
         : {}),
       ...(target.provider.contextWindow ? { contextWindow: target.provider.contextWindow } : {}),
       ...(route === 'codex-bridge' || route === 'codex-responses-compatibility'
@@ -548,9 +605,15 @@ export class AgentBackendResolver {
       framework.id === 'codex'
         ? await this.runtime.probeCodexNativeVersion(settings.codex?.nativePath)
         : undefined
-    const provider = target.provider
-    const providerModelCatalog: AgentModelCatalogEntry[] = this.providers
-      .resolveRuntimeModelCatalog(storedProvider, framework)
+    let provider = target.provider
+    const codexProviderTargets =
+      framework.id === 'codex' ? this.resolveCodexApiTargets(settings, target, modelRoute) : []
+    const hasCodexProviderTransport =
+      new Set(codexProviderTargets.map((candidate) => candidate.providerId)).size >= 2
+    const catalogTargets = hasCodexProviderTransport
+      ? codexProviderTargets
+      : this.providers.resolveRuntimeModelCatalog(storedProvider, framework)
+    let providerModelCatalog: readonly AgentModelCatalogEntry[] = catalogTargets
       .filter(
         (candidate) =>
           candidate.frameworkCompatible &&
@@ -582,14 +645,33 @@ export class AgentBackendResolver {
         : opencodeConfigDir(this.storageRoot)
     await this.runtime.materializeAgentSkills(settings, skillsRoot, forcedSkillIds)
 
+    const openCodeProviderTransport =
+      framework.id === 'opencode'
+        ? await this.ensureOpenCodeProviderTransports(settings, target, modelRoute, effortIntent)
+        : undefined
+    if (openCodeProviderTransport) {
+      provider = openCodeProviderTransport.provider
+      providerModelCatalog = openCodeProviderTransport.providerModelCatalog
+    }
+    const nativeCodexProviderTransport =
+      framework.id === 'codex' && modelRoute === 'codex-responses' && hasCodexProviderTransport
+        ? await this.ensureNativeCodexProviderTransport(target, codexProviderTargets)
+        : undefined
+    if (nativeCodexProviderTransport) provider = nativeCodexProviderTransport.provider
+
     const responsesBridge = target.needsChatResponsesBridge
       ? await this.ensureResponsesBridge(
-          provider,
+          target,
           sessionEffort,
-          settings.conversationSkillImportEnabled ?? DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED
+          settings.conversationSkillImportEnabled ?? DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
+          hasCodexProviderTransport ? codexProviderTargets : undefined,
+          effortIntent
         )
       : target.needsNativeResponsesCompatibility
-        ? await this.ensureNativeResponsesCompatibility(provider)
+        ? await this.ensureNativeResponsesCompatibility(
+            target,
+            hasCodexProviderTransport ? codexProviderTargets : undefined
+          )
         : undefined
     const persistentSystemPromptAppends = [
       ...(context.systemPromptAppends ?? []),
@@ -622,9 +704,10 @@ export class AgentBackendResolver {
       // Only the Codex child talks to the app-owned bridge at loopback. Add a bypass override for
       // that local hop without copying or clearing proxy variables. This leaves the main-process
       // bridge's upstream network route untouched.
-      const loopbackProxyBypass = responsesBridge
-        ? loopbackProxyBypassEnvironment(process.env)
-        : undefined
+      const loopbackProxyBypass =
+        responsesBridge || openCodeProviderTransport || nativeCodexProviderTransport
+          ? loopbackProxyBypassEnvironment(process.env)
+          : undefined
       const sessionModel = modelConfig.sessionModel ?? provider.model
 
       return {
@@ -673,10 +756,16 @@ export class AgentBackendResolver {
                 authorization: `Basic ${Buffer.from(`opencode:${opencodeUsagePassword}`).toString('base64')}`
               }
             }),
-        responsesBridgeLease: responsesBridge?.lease
+        responsesBridgeLease: responsesBridge?.lease,
+        providerTransportLease:
+          openCodeProviderTransport?.lease ??
+          nativeCodexProviderTransport?.lease ??
+          responsesBridge?.providerTransportLease
       }
     } catch (error) {
       await responsesBridge?.lease.release()
+      await openCodeProviderTransport?.lease.release()
+      await nativeCodexProviderTransport?.lease.release()
       throw error
     }
   }
@@ -826,27 +915,310 @@ export class AgentBackendResolver {
     })
   }
 
-  private async ensureResponsesBridge(
-    provider: ProviderRuntimeTarget['provider'],
-    reasoningEffort: ModelReasoningEffort | undefined,
-    conversationSkillImportEnabled: boolean
-  ): Promise<LeasedResponsesBridgeConnection> {
-    const targetBaseUrl = openAiCompletionsBase(provider)
-    if (!targetBaseUrl) throw new Error('The Chat Completions provider has no base URL.')
-    const target: ResponsesBridgeTarget = {
-      baseUrl: targetBaseUrl,
-      key: provider.key,
-      vendorId: provider.vendorId,
-      reasoningEffortTransport: provider.reasoningEffortTransport,
-      model: provider.model,
-      reasoningEffort,
-      namespacedTools: [
-        ...CODEX_BRIDGE_NOTEBOOK_TOOLS,
-        ...CODEX_BRIDGE_ARTIFACT_TOOLS,
-        ...(conversationSkillImportEnabled ? CODEX_BRIDGE_SKILL_IMPORT_TOOLS : [])
-      ],
-      reviewerScope: { namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS }
+  private resolveOpenCodeApiTargets(
+    settings: StoredSettings,
+    activeTarget: ProviderRuntimeTarget,
+    route: AgentModelRoute
+  ): ProviderRuntimeTarget[] {
+    if (route !== 'opencode-anthropic' && route !== 'opencode-openai') return []
+    const framework = getAgentFramework('opencode')
+    const candidates: ProviderRuntimeTarget[] = [activeTarget]
+
+    for (const storedProvider of settings.providers) {
+      try {
+        const configured =
+          storedProvider.id === activeTarget.providerId
+            ? activeTarget
+            : this.providers.resolveRuntimeTarget(
+                storedProvider,
+                { kind: 'configured', requestedModel: storedProvider.model },
+                framework
+              )
+        candidates.push(configured)
+        candidates.push(...this.providers.resolveRuntimeModelCatalog(storedProvider, framework))
+      } catch {
+        // A stale provider must not stop the active generation. If selected later it reconnects.
+      }
     }
+
+    const seen = new Set<string>()
+    return candidates.filter((candidate) => {
+      const model = candidate.effectiveModel ?? candidate.provider.model
+      const endpoint =
+        route === 'opencode-openai'
+          ? openAiChatCompletionsUrl(candidate.provider)
+          : normalizeAnthropicBaseUrl(candidate.provider.baseUrl ?? '')
+      const id = model
+        ? providerTransportTargetId('opencode', candidate.providerId, model)
+        : undefined
+      if (
+        !candidate.frameworkCompatible ||
+        modelRouteFor('opencode', candidate) !== route ||
+        !model ||
+        !endpoint ||
+        !id ||
+        seen.has(id)
+      ) {
+        return false
+      }
+      seen.add(id)
+      return true
+    })
+  }
+
+  private resolveCodexApiTargets(
+    settings: StoredSettings,
+    activeTarget: ProviderRuntimeTarget,
+    route: AgentModelRoute
+  ): ProviderRuntimeTarget[] {
+    if (
+      route !== 'codex-bridge' &&
+      route !== 'codex-responses-compatibility' &&
+      route !== 'codex-responses'
+    ) {
+      return []
+    }
+    const framework = getAgentFramework('codex')
+    const candidates: ProviderRuntimeTarget[] = [activeTarget]
+
+    for (const storedProvider of settings.providers) {
+      try {
+        const configured =
+          storedProvider.id === activeTarget.providerId
+            ? activeTarget
+            : this.providers.resolveRuntimeTarget(
+                storedProvider,
+                { kind: 'configured', requestedModel: storedProvider.model },
+                framework
+              )
+        candidates.push(configured)
+        candidates.push(...this.providers.resolveRuntimeModelCatalog(storedProvider, framework))
+      } catch {
+        // A stale provider remains a reconnect-only target until it resolves successfully.
+      }
+    }
+
+    const seen = new Set<string>()
+    return candidates.filter((candidate) => {
+      const model = candidate.effectiveModel ?? candidate.provider.model
+      const baseUrl =
+        route === 'codex-bridge'
+          ? openAiCompletionsBase(candidate.provider)
+          : normalizeResponsesBaseUrl(
+              candidate.provider.openaiBaseUrl ?? candidate.provider.baseUrl
+            )
+      const id = model ? providerTransportTargetId('codex', candidate.providerId, model) : undefined
+      if (
+        !candidate.frameworkCompatible ||
+        !candidate.modelBridgeSupported ||
+        modelRouteFor('codex', candidate) !== route ||
+        !model ||
+        !baseUrl ||
+        !id ||
+        seen.has(id)
+      ) {
+        return false
+      }
+      seen.add(id)
+      return true
+    })
+  }
+
+  private async ensureOpenCodeProviderTransports(
+    settings: StoredSettings,
+    activeTarget: ProviderRuntimeTarget,
+    route: AgentModelRoute,
+    effortIntent: ReasoningEffort
+  ): Promise<OpenCodeProviderTransport | undefined> {
+    const candidates = this.resolveOpenCodeApiTargets(settings, activeTarget, route)
+    if (new Set(candidates.map((candidate) => candidate.providerId)).size < 2) return undefined
+
+    const bridges: Array<AnthropicProviderBridgePort | OpenAiProviderBridgePort> = []
+    const targetIds = new Set<string>()
+    const catalog: AgentModelCatalogEntry[] = []
+    let activeProvider: ProviderRuntimeTarget['provider'] | undefined
+
+    try {
+      for (const candidate of candidates) {
+        const model = candidate.effectiveModel ?? candidate.provider.model
+        if (!model) continue
+        const targetId = providerTransportTargetId('opencode', candidate.providerId, model)
+        const bridge =
+          route === 'opencode-openai'
+            ? this.createOpenAiProviderBridge(
+                [
+                  {
+                    id: targetId,
+                    wire: 'chat-completions',
+                    endpoint: openAiChatCompletionsUrl(candidate.provider)!,
+                    ...(candidate.provider.key ? { key: candidate.provider.key } : {}),
+                    model
+                  }
+                ],
+                targetId
+              )
+            : this.createAnthropicProviderBridge(
+                [
+                  {
+                    id: targetId,
+                    baseUrl: normalizeAnthropicBaseUrl(candidate.provider.baseUrl ?? ''),
+                    ...(candidate.provider.key ? { key: candidate.provider.key } : {}),
+                    model
+                  }
+                ],
+                targetId
+              )
+        bridges.push(bridge)
+        const connection = await bridge.start()
+        const apiEndpoints = [
+          route === 'opencode-openai' ? ('openai' as const) : ('anthropic' as const)
+        ]
+        const localProvider = Object.freeze({
+          ...candidate.provider,
+          agentProviderId: opencodeTransportProviderId(candidate.providerId, model),
+          baseUrl: connection.baseUrl,
+          ...(route === 'opencode-openai'
+            ? { openaiBaseUrl: `${connection.baseUrl}/v1` }
+            : { openaiBaseUrl: undefined }),
+          model,
+          key: connection.token,
+          apiEndpoints
+        })
+        const effort = resolvedModelEffort(effortIntent, candidate)
+        catalog.push(
+          Object.freeze({
+            provider: localProvider,
+            ...(effort === 'default' ? {} : { reasoningEffort: effort }),
+            ...(candidate.reasoningEffortProfile.supported
+              ? { reasoningEfforts: [...new Set(candidate.reasoningEffortProfile.slots)] }
+              : {})
+          })
+        )
+        targetIds.add(targetId)
+        if (
+          candidate.providerId === activeTarget.providerId &&
+          model === (activeTarget.effectiveModel ?? activeTarget.provider.model)
+        ) {
+          activeProvider = localProvider
+        }
+      }
+
+      if (!activeProvider)
+        throw new Error('The active OpenCode transport target was not registered.')
+      let released = false
+      return Object.freeze({
+        provider: activeProvider,
+        providerModelCatalog: Object.freeze(catalog),
+        lease: {
+          setTarget: (targetId: string) => targetIds.has(targetId),
+          release: async () => {
+            if (released) return
+            released = true
+            await Promise.all(bridges.map((bridge) => bridge.close()))
+          }
+        }
+      })
+    } catch (error) {
+      await Promise.all(bridges.map((bridge) => bridge.close().catch(() => undefined)))
+      throw error
+    }
+  }
+
+  private async ensureNativeCodexProviderTransport(
+    activeTarget: ProviderRuntimeTarget,
+    candidates: readonly ProviderRuntimeTarget[]
+  ): Promise<NativeCodexProviderTransport> {
+    const targets = candidates.map((candidate): OpenAiProviderBridgeTarget => {
+      const model = candidate.effectiveModel ?? candidate.provider.model
+      const baseUrl = normalizeResponsesBaseUrl(
+        candidate.provider.openaiBaseUrl ?? candidate.provider.baseUrl
+      )
+      if (!model || !baseUrl) throw new Error('The native Responses provider target is incomplete.')
+      return Object.freeze({
+        id: providerTransportTargetId('codex', candidate.providerId, model),
+        wire: 'responses',
+        endpoint: `${baseUrl}/responses`,
+        ...(candidate.provider.key ? { key: candidate.provider.key } : {}),
+        model
+      })
+    })
+    const activeModel = activeTarget.effectiveModel ?? activeTarget.provider.model
+    if (!activeModel) throw new Error('The active native Responses model is unavailable.')
+    const initialTargetId = providerTransportTargetId('codex', activeTarget.providerId, activeModel)
+    const bridge = this.createOpenAiProviderBridge(targets, initialTargetId)
+
+    try {
+      const connection = await bridge.start()
+      let released = false
+      return Object.freeze({
+        provider: Object.freeze({
+          ...activeTarget.provider,
+          baseUrl: connection.baseUrl,
+          openaiBaseUrl: `${connection.baseUrl}/v1`,
+          model: activeModel,
+          key: connection.token,
+          apiEndpoints: ['responses'] as const
+        }),
+        lease: {
+          setTarget: (targetId: string) => bridge.setTarget(targetId),
+          release: async () => {
+            if (released) return
+            released = true
+            await bridge.close()
+          }
+        }
+      })
+    } catch (error) {
+      await bridge.close().catch(() => undefined)
+      throw error
+    }
+  }
+
+  private async ensureResponsesBridge(
+    activeTarget: ProviderRuntimeTarget,
+    reasoningEffort: ModelReasoningEffort | undefined,
+    conversationSkillImportEnabled: boolean,
+    providerTargets?: readonly ProviderRuntimeTarget[],
+    effortIntent: ReasoningEffort = DEFAULT_REASONING_EFFORT
+  ): Promise<LeasedResponsesBridgeConnection> {
+    const createTarget = (
+      candidate: ProviderRuntimeTarget,
+      effort: ModelReasoningEffort | undefined
+    ): ResponsesBridgeTarget => {
+      const targetBaseUrl = openAiCompletionsBase(candidate.provider)
+      if (!targetBaseUrl) throw new Error('The Chat Completions provider has no base URL.')
+      return {
+        baseUrl: targetBaseUrl,
+        key: candidate.provider.key,
+        vendorId: candidate.provider.vendorId,
+        reasoningEffortTransport: candidate.provider.reasoningEffortTransport,
+        model: candidate.effectiveModel ?? candidate.provider.model,
+        reasoningEffort: effort,
+        namespacedTools: [
+          ...CODEX_BRIDGE_NOTEBOOK_TOOLS,
+          ...CODEX_BRIDGE_ARTIFACT_TOOLS,
+          ...(conversationSkillImportEnabled ? CODEX_BRIDGE_SKILL_IMPORT_TOOLS : [])
+        ],
+        reviewerScope: { namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS }
+      }
+    }
+    const targets = new Map<string, ResponsesBridgeTarget>()
+    for (const candidate of providerTargets ?? []) {
+      const model = candidate.effectiveModel ?? candidate.provider.model
+      if (!model) continue
+      const resolvedEffort = resolvedModelEffort(effortIntent, candidate)
+      targets.set(
+        providerTransportTargetId('codex', candidate.providerId, model),
+        createTarget(candidate, resolvedEffort === 'default' ? undefined : resolvedEffort)
+      )
+    }
+    const activeModel = activeTarget.effectiveModel ?? activeTarget.provider.model
+    const initialTargetId = activeModel
+      ? providerTransportTargetId('codex', activeTarget.providerId, activeModel)
+      : undefined
+    const target =
+      (initialTargetId ? targets.get(initialTargetId) : undefined) ??
+      createTarget(activeTarget, reasoningEffort)
     const bridgeId = this.nextGenerationId()
     const bridge = this.createResponsesBridge(target)
     const entry = { bridge, connection: bridge.start() }
@@ -863,6 +1235,13 @@ export class AgentBackendResolver {
 
     let released = false
     const leasedEntry = entry
+    const release = async (): Promise<void> => {
+      if (released) return
+      released = true
+      if (this.responsesBridges.get(bridgeId) !== leasedEntry) return
+      this.responsesBridges.delete(bridgeId)
+      await leasedEntry.bridge.close()
+    }
     return {
       ...connection,
       lease: {
@@ -874,29 +1253,57 @@ export class AgentBackendResolver {
           leasedEntry.bridge.unregisterReviewerSession(promptCacheKey),
         setReasoningEffort: (effort) => leasedEntry.bridge.setReasoningEffort(effort),
         setModelTarget: (target) => leasedEntry.bridge.setModelTarget(target),
-        release: async () => {
-          if (released) return
-          released = true
-          if (this.responsesBridges.get(bridgeId) !== leasedEntry) return
-          this.responsesBridges.delete(bridgeId)
-          await leasedEntry.bridge.close()
-        }
-      }
+        release
+      },
+      ...(targets.size > 0
+        ? {
+            providerTransportLease: {
+              setTarget: (targetId: string) => {
+                const providerTarget = targets.get(targetId)
+                if (!providerTarget) return false
+                leasedEntry.bridge.setTarget(providerTarget)
+                return true
+              },
+              release
+            }
+          }
+        : {})
     }
   }
 
   private async ensureNativeResponsesCompatibility(
-    provider: ProviderRuntimeTarget['provider']
+    activeTarget: ProviderRuntimeTarget,
+    providerTargets?: readonly ProviderRuntimeTarget[]
   ): Promise<LeasedResponsesBridgeConnection> {
-    const targetBaseUrl = normalizeResponsesBaseUrl(provider.openaiBaseUrl ?? provider.baseUrl)
-    if (!targetBaseUrl) throw new Error('The native Responses provider has no base URL.')
+    const createTarget = (candidate: ProviderRuntimeTarget): NativeResponsesProxyTarget => {
+      const targetBaseUrl = normalizeResponsesBaseUrl(
+        candidate.provider.openaiBaseUrl ?? candidate.provider.baseUrl
+      )
+      if (!targetBaseUrl) throw new Error('The native Responses provider has no base URL.')
+      return {
+        baseUrl: targetBaseUrl,
+        key: candidate.provider.key,
+        model: candidate.effectiveModel ?? candidate.provider.model,
+        reviewerScope: { namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS }
+      }
+    }
+    const targets = new Map<string, NativeResponsesProxyTarget>()
+    for (const candidate of providerTargets ?? []) {
+      const model = candidate.effectiveModel ?? candidate.provider.model
+      if (!model) continue
+      targets.set(
+        providerTransportTargetId('codex', candidate.providerId, model),
+        createTarget(candidate)
+      )
+    }
+    const activeModel = activeTarget.effectiveModel ?? activeTarget.provider.model
+    const initialTargetId = activeModel
+      ? providerTransportTargetId('codex', activeTarget.providerId, activeModel)
+      : undefined
     const proxyId = this.nextGenerationId()
-    const proxy = this.createNativeResponsesProxy({
-      baseUrl: targetBaseUrl,
-      key: provider.key,
-      model: provider.model,
-      reviewerScope: { namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS }
-    })
+    const proxy = this.createNativeResponsesProxy(
+      (initialTargetId ? targets.get(initialTargetId) : undefined) ?? createTarget(activeTarget)
+    )
     const entry = { proxy, connection: proxy.start() }
     this.nativeResponsesCompatibilityProxies.set(proxyId, entry)
 
@@ -913,6 +1320,13 @@ export class AgentBackendResolver {
 
     let released = false
     const leasedEntry = entry
+    const release = async (): Promise<void> => {
+      if (released) return
+      released = true
+      if (this.nativeResponsesCompatibilityProxies.get(proxyId) !== leasedEntry) return
+      this.nativeResponsesCompatibilityProxies.delete(proxyId)
+      await leasedEntry.proxy.close()
+    }
     return {
       ...connection,
       lease: {
@@ -923,14 +1337,21 @@ export class AgentBackendResolver {
         unregisterReviewerSession: (promptCacheKey) =>
           leasedEntry.proxy.unregisterReviewerSession(promptCacheKey),
         setModelTarget: (target) => leasedEntry.proxy.setModelTarget(target),
-        release: async () => {
-          if (released) return
-          released = true
-          if (this.nativeResponsesCompatibilityProxies.get(proxyId) !== leasedEntry) return
-          this.nativeResponsesCompatibilityProxies.delete(proxyId)
-          await leasedEntry.proxy.close()
-        }
-      }
+        release
+      },
+      ...(targets.size > 0
+        ? {
+            providerTransportLease: {
+              setTarget: (targetId: string) => {
+                const providerTarget = targets.get(targetId)
+                if (!providerTarget) return false
+                leasedEntry.proxy.setTarget(providerTarget)
+                return true
+              },
+              release
+            }
+          }
+        : {})
     }
   }
 }

--- a/src/main/settings/claude-config-provision.test.ts
+++ b/src/main/settings/claude-config-provision.test.ts
@@ -165,6 +165,37 @@ describe('provisionAppClaudeConfigDir', () => {
     }
   })
 
+  it('projects and explicitly clears the app-owned model catalog', async () => {
+    root = await mkdtemp(join(tmpdir(), 'os-claude-config-'))
+    const configDir = join(root, 'claude')
+
+    await provisionAppClaudeConfigDir(configDir, {
+      modelConfig: {
+        availableModels: ['sonnet', 'opus'],
+        modelOverrides: {
+          sonnet: 'deepseek-v4-flash',
+          opus: 'deepseek-v4-pro'
+        }
+      }
+    })
+
+    expect(JSON.parse(await readFile(join(configDir, 'settings.json'), 'utf8'))).toMatchObject({
+      availableModels: ['sonnet', 'opus'],
+      modelOverrides: {
+        sonnet: 'deepseek-v4-flash',
+        opus: 'deepseek-v4-pro'
+      }
+    })
+
+    await provisionAppClaudeConfigDir(configDir, { modelConfig: null })
+
+    const cleared = JSON.parse(await readFile(join(configDir, 'settings.json'), 'utf8'))
+    expect(cleared.availableModels).toBeUndefined()
+    expect(cleared.modelOverrides).toBeUndefined()
+    expect(cleared.permissions.deny).toEqual(configDenyRules(configDir))
+    expect(cleared.disableBundledSkills).toBe(true)
+  })
+
   it('materializes enabled bundled skills, honoring disabledSkillIds', async () => {
     root = await mkdtemp(join(tmpdir(), 'os-claude-config-'))
     const configDir = join(root, 'claude')

--- a/src/main/settings/claude-config-provision.ts
+++ b/src/main/settings/claude-config-provision.ts
@@ -54,7 +54,15 @@ const configDenyRules = (configDir: string): string[] => {
 // Claude Code's own bundled skills/workflows (dataviz, deep-research, …) never leak in — the app
 // injects its OWN curated skill set into `<configDir>/skills`, which disableBundledSkills leaves
 // untouched.
-const writeAppSettings = async (configDir: string): Promise<void> => {
+export type ClaudeRuntimeModelConfig = Readonly<{
+  availableModels: readonly string[]
+  modelOverrides: Readonly<Record<string, string>>
+}>
+
+const writeAppSettings = async (
+  configDir: string,
+  modelConfig?: ClaudeRuntimeModelConfig | null
+): Promise<void> => {
   const settingsPath = join(configDir, 'settings.json')
 
   let settings: Record<string, unknown> = {}
@@ -80,6 +88,15 @@ const writeAppSettings = async (configDir: string): Promise<void> => {
 
   settings.permissions = { ...permissions, deny }
   settings.disableBundledSkills = true
+  if (modelConfig !== undefined) {
+    if (modelConfig) {
+      settings.availableModels = [...modelConfig.availableModels]
+      settings.modelOverrides = { ...modelConfig.modelOverrides }
+    } else {
+      delete settings.availableModels
+      delete settings.modelOverrides
+    }
+  }
   await writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
 }
 
@@ -88,6 +105,9 @@ type ProvisionOptions = {
   skills?: BundledSkill[]
   materializer?: SkillMaterializer
   disabledSkillIds?: string[]
+  // `undefined` preserves the existing projection (validation probes must not perturb a live
+  // backend); `null` explicitly clears a catalog owned by a previously active provider.
+  modelConfig?: ClaudeRuntimeModelConfig | null
 }
 
 // Ensures the app config dir + asset subdirs exist, writes the file-tool deny rules, then materializes
@@ -109,7 +129,7 @@ const provisionAppClaudeConfigDir = async (
     'utf8'
   )
 
-  await writeAppSettings(configDir)
+  await writeAppSettings(configDir, options.modelConfig)
 
   const materializer = options.materializer ?? new ClaudeCodeSkillMaterializer()
   const skills = options.skills ?? (await new SkillRegistry().list())

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -198,7 +198,8 @@ const registerTestSettingsIpcHandlers = ({
       runtime: {
         requestProviderReconnect: onActiveProviderChanged ?? (() => undefined),
         requestAgentFrameworkSwitch: onAgentFrameworkChanged ?? (() => undefined),
-        applyReasoningEffort: onReasoningEffortChanged ?? (async () => false)
+        applyReasoningEffort: onReasoningEffortChanged ?? (async () => false),
+        applyModelChange: async () => false
       },
       skills: { requestSkillsReload: onSkillsChanged ?? (() => undefined) },
       connectors: {
@@ -435,6 +436,8 @@ describe('settings IPC handlers', () => {
   it('drops the agent connection when the active provider changes', async () => {
     handlers.clear()
     const service = createFakeService()
+    service.getSettingsView.mockResolvedValue({ activeProviderId: 'p0', providers: [] })
+    service.setActiveProvider.mockResolvedValue({ activeProviderId: 'p1', providers: [] })
     const onActiveProviderChanged = vi.fn()
     registerTestSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
 

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -43,6 +43,7 @@ type FakeSettingsService = Record<
   | 'setAgentFramework'
   | 'setReasoningEffort'
   | 'resolveActiveReasoningEffort'
+  | 'resolveActiveModelChangeTarget'
   | 'setNotificationsEnabled'
   | 'setConversationSkillImportEnabled'
   | 'setClosePreference'
@@ -111,6 +112,7 @@ const createFakeService = (): FakeSettingsService => ({
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], reasoningEffort: 'high' }),
   resolveActiveReasoningEffort: vi.fn().mockResolvedValue('high'),
+  resolveActiveModelChangeTarget: vi.fn().mockResolvedValue(undefined),
   setNotificationsEnabled: vi
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], notificationsEnabled: false }),

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -23,6 +23,53 @@ afterEach(() => {
 })
 
 describe('native Responses compatibility', () => {
+  it('retargets endpoint, credential, and model without replacing the loopback connection', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ id: 'response', output: [], usage: { input_tokens: 1, output_tokens: 1 } })
+    )
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://a.example/v1', key: 'key-a', model: 'model-a' },
+      fetchImpl
+    )
+    const connection = await proxy.start()
+    const send = async (): Promise<void> => {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'untrusted', input: 'hello', stream: false })
+      })
+      expect(response.status).toBe(200)
+    }
+
+    try {
+      await send()
+      proxy.setTarget({ baseUrl: 'https://b.example/custom', key: 'key-b', model: 'model-b' })
+      await send()
+
+      expect(fetchImpl).toHaveBeenNthCalledWith(
+        1,
+        'https://a.example/v1/responses',
+        expect.objectContaining({
+          headers: expect.objectContaining({ authorization: 'Bearer key-a' }),
+          body: expect.stringContaining('"model":"model-a"')
+        })
+      )
+      expect(fetchImpl).toHaveBeenNthCalledWith(
+        2,
+        'https://b.example/custom/responses',
+        expect.objectContaining({
+          headers: expect.objectContaining({ authorization: 'Bearer key-b' }),
+          body: expect.stringContaining('"model":"model-b"')
+        })
+      )
+    } finally {
+      await proxy.close()
+    }
+  })
+
   it('retargets the upstream model without replacing endpoint credentials', () => {
     const proxy = new NativeResponsesCompatibilityProxy({
       baseUrl: 'https://api.minimaxi.com/v1',

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -23,6 +23,22 @@ afterEach(() => {
 })
 
 describe('native Responses compatibility', () => {
+  it('retargets the upstream model without replacing endpoint credentials', () => {
+    const proxy = new NativeResponsesCompatibilityProxy({
+      baseUrl: 'https://api.minimaxi.com/v1',
+      key: 'secret',
+      model: 'MiniMax-M3'
+    })
+
+    proxy.setModelTarget({ model: 'MiniMax-M4' })
+
+    expect((proxy as unknown as { target: Record<string, unknown> }).target).toEqual({
+      baseUrl: 'https://api.minimaxi.com/v1',
+      key: 'secret',
+      model: 'MiniMax-M4'
+    })
+  })
+
   it('flattens namespace tools and matching history without changing plain functions', () => {
     const { request, aliases } = flattenNativeResponsesRequest({
       model: 'MiniMax-M3',

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -337,8 +337,12 @@ export class NativeResponsesCompatibilityProxy {
     private readonly options: NativeResponsesCompatibilityOptions = {}
   ) {}
 
+  setTarget(target: NativeResponsesCompatibilityTarget): void {
+    this.target = target
+  }
+
   setModelTarget(target: ResponsesBridgeModelTarget): void {
-    this.target = { ...this.target, model: target.model }
+    this.setTarget({ ...this.target, model: target.model })
   }
 
   async selectSkills(
@@ -544,7 +548,10 @@ export class NativeResponsesCompatibilityProxy {
             tool_choice: 'auto'
           }
         : body
-      const { request: upstreamRequest, aliases } = flattenNativeResponsesRequest(scopedBody)
+      const routedBody = this.target.model
+        ? { ...scopedBody, model: this.target.model }
+        : scopedBody
+      const { request: upstreamRequest, aliases } = flattenNativeResponsesRequest(routedBody)
       log.info('native Responses compatibility request', {
         requestId,
         namespaceToolCount: aliases.size,

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -4,6 +4,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { createLogger, diagnosticErrorFields } from '../logger'
 import type {
   ResponsesBridgeConnection,
+  ResponsesBridgeModelTarget,
   ResponsesBridgeNamespacedTool,
   ResponsesBridgeSkillCandidate,
   ResponsesBridgeSkillInput
@@ -331,10 +332,14 @@ export class NativeResponsesCompatibilityProxy {
   private readonly scopedReviewerSessionKeys = new Set<string>()
 
   constructor(
-    private readonly target: NativeResponsesCompatibilityTarget,
+    private target: NativeResponsesCompatibilityTarget,
     private readonly fetchImpl: NativeFetch = fetch,
     private readonly options: NativeResponsesCompatibilityOptions = {}
   ) {}
+
+  setModelTarget(target: ResponsesBridgeModelTarget): void {
+    this.target = { ...this.target, model: target.model }
+  }
 
   async selectSkills(
     text: string,

--- a/src/main/settings/openai-provider-bridge.test.ts
+++ b/src/main/settings/openai-provider-bridge.test.ts
@@ -1,0 +1,154 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { OpenAiProviderBridge, type OpenAiProviderBridgeTarget } from './openai-provider-bridge'
+
+type CapturedRequest = {
+  authorization?: string
+  body: Record<string, unknown>
+  path?: string
+}
+
+const listen = async (server: Server): Promise<string> => {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address() as AddressInfo
+  return `http://127.0.0.1:${address.port}`
+}
+
+const close = async (server: Server): Promise<void> => {
+  if (!server.listening) return
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  )
+}
+
+const createUpstream = (): { requests: CapturedRequest[]; server: Server } => {
+  const requests: CapturedRequest[] = []
+  const server = createServer((request, response) => {
+    const chunks: Buffer[] = []
+    request.on('data', (chunk: Buffer) => chunks.push(chunk))
+    request.on('end', () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>
+      requests.push({
+        authorization: request.headers.authorization,
+        body,
+        path: request.url
+      })
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ model: body.model }))
+    })
+  })
+  return { requests, server }
+}
+
+describe('OpenAiProviderBridge', () => {
+  const servers: Server[] = []
+  const bridges: OpenAiProviderBridge[] = []
+
+  afterEach(async () => {
+    await Promise.all(bridges.splice(0).map((bridge) => bridge.close()))
+    await Promise.all(servers.splice(0).map(close))
+  })
+
+  it('retargets endpoint, credential, and model without replacing the loopback connection', async () => {
+    const first = createUpstream()
+    const second = createUpstream()
+    servers.push(first.server, second.server)
+    const targets: OpenAiProviderBridgeTarget[] = [
+      {
+        id: 'provider-a/model-a',
+        wire: 'chat-completions',
+        endpoint: `${await listen(first.server)}/v1/chat/completions`,
+        key: 'key-a',
+        model: 'model-a'
+      },
+      {
+        id: 'provider-b/model-b',
+        wire: 'chat-completions',
+        endpoint: `${await listen(second.server)}/custom/chat/completions`,
+        key: 'key-b',
+        model: 'model-b'
+      }
+    ]
+    const bridge = new OpenAiProviderBridge(targets, targets[0].id)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+
+    const send = (model: string): Promise<Response> =>
+      fetch(`${connection.baseUrl}/v1/chat/completions?ignored=1`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model, messages: [] })
+      })
+
+    await expect((await send('untrusted-model')).json()).resolves.toEqual({ model: 'model-a' })
+    expect(bridge.setTarget(targets[1].id)).toBe(true)
+    await expect((await send('still-untrusted')).json()).resolves.toEqual({ model: 'model-b' })
+
+    expect(first.requests).toEqual([
+      {
+        authorization: 'Bearer key-a',
+        body: { model: 'model-a', messages: [] },
+        path: '/v1/chat/completions'
+      }
+    ])
+    expect(second.requests).toEqual([
+      {
+        authorization: 'Bearer key-b',
+        body: { model: 'model-b', messages: [] },
+        path: '/custom/chat/completions'
+      }
+    ])
+  })
+
+  it('forwards the Responses wire and fails closed for other paths and unknown targets', async () => {
+    const upstream = createUpstream()
+    servers.push(upstream.server)
+    const target: OpenAiProviderBridgeTarget = {
+      id: 'provider/model-a',
+      wire: 'responses',
+      endpoint: `${await listen(upstream.server)}/v1/responses`,
+      key: 'key-a',
+      model: 'model-a'
+    }
+    const bridge = new OpenAiProviderBridge([target], target.id)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+
+    expect(bridge.setTarget('missing/model')).toBe(false)
+    const wrongPath = await fetch(`${connection.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${connection.token}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ model: 'ignored', input: [] })
+    })
+    const response = await fetch(`${connection.baseUrl}/v1/responses`, {
+      method: 'POST',
+      headers: {
+        'x-api-key': connection.token,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ model: 'ignored', input: [] })
+    })
+
+    expect(wrongPath.status).toBe(404)
+    expect(response.status).toBe(200)
+    expect(upstream.requests).toEqual([
+      {
+        authorization: 'Bearer key-a',
+        body: { model: 'model-a', input: [] },
+        path: '/v1/responses'
+      }
+    ])
+  })
+})

--- a/src/main/settings/openai-provider-bridge.ts
+++ b/src/main/settings/openai-provider-bridge.ts
@@ -1,0 +1,225 @@
+import { randomBytes } from 'node:crypto'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+
+const MAX_REQUEST_BYTES = 64 * 1024 * 1024
+const WIRE_PATH = {
+  'chat-completions': '/v1/chat/completions',
+  responses: '/v1/responses'
+} as const
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'content-encoding',
+  'content-length',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade'
+])
+
+export type OpenAiProviderBridgeTarget = Readonly<{
+  id: string
+  wire: keyof typeof WIRE_PATH
+  endpoint: string
+  key?: string
+  model: string
+}>
+
+export type OpenAiProviderBridgeConnection = Readonly<{
+  baseUrl: string
+  token: string
+}>
+
+const json = (response: ServerResponse, status: number, body: unknown): void => {
+  response.writeHead(status, { 'content-type': 'application/json' })
+  response.end(JSON.stringify(body))
+}
+
+const readBody = (request: IncomingMessage): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let size = 0
+    request.on('data', (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      size += buffer.length
+      if (size > MAX_REQUEST_BYTES) {
+        reject(new Error('OpenAI bridge request exceeds the size limit.'))
+        request.destroy()
+        return
+      }
+      chunks.push(buffer)
+    })
+    request.once('end', () => resolve(Buffer.concat(chunks)))
+    request.once('error', reject)
+    request.once('aborted', () => reject(new Error('OpenAI bridge request was aborted.')))
+  })
+
+const requestHeaders = (request: IncomingMessage, key?: string): Headers => {
+  const headers = new Headers()
+  for (const [name, value] of Object.entries(request.headers)) {
+    const normalized = name.toLowerCase()
+    if (
+      HOP_BY_HOP_HEADERS.has(normalized) ||
+      normalized === 'authorization' ||
+      normalized === 'x-api-key' ||
+      value === undefined
+    ) {
+      continue
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(name, item)
+    } else {
+      headers.set(name, value)
+    }
+  }
+  if (key) headers.set('authorization', `Bearer ${key}`)
+  headers.set('content-type', 'application/json')
+  return headers
+}
+
+const copyResponseHeaders = (source: Headers, response: ServerResponse): void => {
+  for (const [name, value] of source) {
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) response.setHeader(name, value)
+  }
+}
+
+export class OpenAiProviderBridge {
+  private readonly targets: ReadonlyMap<string, OpenAiProviderBridgeTarget>
+  private readonly wire: OpenAiProviderBridgeTarget['wire']
+  private target: OpenAiProviderBridgeTarget
+  private server: Server | undefined
+  private connection: OpenAiProviderBridgeConnection | undefined
+
+  constructor(targets: readonly OpenAiProviderBridgeTarget[], initialTargetId: string) {
+    this.targets = new Map(targets.map((target) => [target.id, target]))
+    const initial = this.targets.get(initialTargetId)
+    if (!initial) throw new Error('The initial OpenAI bridge target is not registered.')
+    this.target = initial
+    this.wire = initial.wire
+  }
+
+  setTarget(targetId: string): boolean {
+    const target = this.targets.get(targetId)
+    if (!target || target.wire !== this.wire) return false
+    this.target = target
+    return true
+  }
+
+  async start(): Promise<OpenAiProviderBridgeConnection> {
+    if (this.connection) return this.connection
+    const token = randomBytes(24).toString('hex')
+    const server = createServer((request, response) => {
+      void this.handle(request, response, token).catch((error: unknown) => {
+        if (response.destroyed || response.writableEnded) return
+        if (response.headersSent) {
+          response.destroy(error instanceof Error ? error : undefined)
+          return
+        }
+        json(response, 502, {
+          error: {
+            type: 'api_error',
+            message: error instanceof Error ? error.message : 'OpenAI provider request failed.'
+          }
+        })
+      })
+    })
+    this.server = server
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', resolve)
+      })
+      server.unref()
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('OpenAI provider bridge did not bind a port.')
+      }
+      this.connection = Object.freeze({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        token
+      })
+      return this.connection
+    } catch (error) {
+      await this.close().catch(() => undefined)
+      throw error
+    }
+  }
+
+  async close(): Promise<void> {
+    const server = this.server
+    this.server = undefined
+    this.connection = undefined
+    if (!server) return
+    const closing = new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    )
+    server.closeAllConnections()
+    await closing
+  }
+
+  private async handle(
+    request: IncomingMessage,
+    response: ServerResponse,
+    token: string
+  ): Promise<void> {
+    const authorization = request.headers.authorization
+    const apiKey = request.headers['x-api-key']
+    if (authorization !== `Bearer ${token}` && apiKey !== token) {
+      json(response, 401, { error: { type: 'authentication_error', message: 'Unauthorized' } })
+      return
+    }
+    if (request.method !== 'POST') {
+      json(response, 405, {
+        error: { type: 'invalid_request_error', message: 'Method not allowed' }
+      })
+      return
+    }
+
+    const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1')
+    if (requestUrl.pathname !== WIRE_PATH[this.wire]) {
+      json(response, 404, { error: { type: 'not_found_error', message: 'Not found' } })
+      return
+    }
+
+    const rawBody = await readBody(request)
+    const parsed = JSON.parse(rawBody.toString('utf8')) as unknown
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      json(response, 400, {
+        error: { type: 'invalid_request_error', message: 'Expected a JSON object request body.' }
+      })
+      return
+    }
+
+    const target = this.target
+    const endpoint = new URL(target.endpoint)
+    if (endpoint.protocol !== 'http:' && endpoint.protocol !== 'https:') {
+      throw new Error('The OpenAI provider target has no valid endpoint URL.')
+    }
+    const body = JSON.stringify({ ...(parsed as Record<string, unknown>), model: target.model })
+    const controller = new AbortController()
+    response.once('close', () => {
+      if (!response.writableEnded) controller.abort()
+    })
+
+    const upstream = await fetch(endpoint, {
+      method: 'POST',
+      headers: requestHeaders(request, target.key),
+      body,
+      redirect: 'manual',
+      signal: controller.signal
+    })
+    response.statusCode = upstream.status
+    response.statusMessage = upstream.statusText
+    copyResponseHeaders(upstream.headers, response)
+    if (!upstream.body) {
+      response.end()
+      return
+    }
+    await pipeline(Readable.from(upstream.body as AsyncIterable<Uint8Array>), response)
+  }
+}

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -1108,6 +1108,15 @@ class ProviderAccountsModule {
     }
   }
 
+  resolveRuntimeModelCatalog(
+    storedProvider: StoredProvider,
+    framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
+  ): ProviderRuntimeTarget[] {
+    return this.availableModels(storedProvider).map((model) =>
+      this.resolveRuntimeTarget(storedProvider, { kind: 'required', model }, framework)
+    )
+  }
+
   resolveRuntimeReasoningEffortProfile(
     storedProvider: StoredProvider,
     requestedModel?: string

--- a/src/main/settings/provider-env.ts
+++ b/src/main/settings/provider-env.ts
@@ -16,6 +16,9 @@ import { normalizeAnthropicBaseUrl } from './base-url'
 // A provider resolved for spawning: the plaintext key is already decrypted by the caller.
 export type ResolvedProvider = {
   type: ProviderType
+  // Framework-local provider id used only for a generation's pre-registered transport routes.
+  // It is derived from the persisted provider/model identity and never contains a credential.
+  agentProviderId?: string
   codexAuthMode?: CodexSubscriptionAuthMode
   // Retained for official providers even though they use the custom credential path at runtime.
   // Transport adapters need this stable identity because `none` has vendor-specific wire semantics.

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -1637,6 +1637,31 @@ describe('Responses-compatible bridge conversion', () => {
     bridge.setTarget({ baseUrl: 'https://b.example/v1', model: 'm2', key: 'k2' })
     expect(cache.size).toBe(0)
   })
+
+  it('retargets only model-owned fields and preserves the live endpoint credentials', () => {
+    const bridge = new ResponsesBridge({
+      baseUrl: 'https://gateway.example/v1',
+      model: 'model-a',
+      key: 'secret',
+      vendorId: 'deepseek'
+    })
+
+    bridge.setModelTarget({
+      model: 'model-b',
+      vendorId: 'minimax',
+      reasoningEffortTransport: 'minimax',
+      reasoningEffort: 'high'
+    })
+
+    expect((bridge as unknown as { target: Record<string, unknown> }).target).toEqual({
+      baseUrl: 'https://gateway.example/v1',
+      key: 'secret',
+      model: 'model-b',
+      vendorId: 'minimax',
+      reasoningEffortTransport: 'minimax',
+      reasoningEffort: 'high'
+    })
+  })
 })
 
 describe('Responses bridge Skill selector', () => {

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -44,6 +44,11 @@ export type ResponsesBridgeTarget = {
   }
 }
 
+export type ResponsesBridgeModelTarget = Pick<
+  ResponsesBridgeTarget,
+  'model' | 'vendorId' | 'reasoningEffortTransport' | 'reasoningEffort'
+>
+
 export type ResponsesBridgeNamespacedTool = {
   namespace: string
   name: string
@@ -1176,6 +1181,10 @@ export class ResponsesBridge {
       this.target.key !== target.key
     this.target = target
     if (changed) this.reasoningByCallId.clear()
+  }
+
+  setModelTarget(target: ResponsesBridgeModelTarget): void {
+    this.setTarget({ ...this.target, ...target })
   }
 
   // Updates only the resolved upstream effort on the live target. Deliberately not a setTarget: the

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2971,19 +2971,21 @@ describe('SettingsService: preflight & spawn config', () => {
     })
     expect(codexConfig.model_providers['open-science']).not.toHaveProperty('requires_openai_auth')
     const modelCatalog = JSON.parse(await readFile(codexConfig.model_catalog_json, 'utf8'))
-    expect(modelCatalog.models).toEqual([
-      expect.objectContaining({
-        slug: 'MiniMax-M3',
-        context_window: 1_000_000,
-        max_context_window: 1_000_000,
-        supported_in_api: true,
-        default_reasoning_level: null,
-        supported_reasoning_levels: [
-          { effort: 'none', description: 'None reasoning effort' },
-          { effort: 'high', description: 'High reasoning effort' }
-        ]
-      })
-    ])
+    expect(modelCatalog.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slug: 'MiniMax-M3',
+          context_window: 1_000_000,
+          max_context_window: 1_000_000,
+          supported_in_api: true,
+          default_reasoning_level: null,
+          supported_reasoning_levels: [
+            { effort: 'none', description: 'None reasoning effort' },
+            { effort: 'high', description: 'High reasoning effort' }
+          ]
+        })
+      ])
+    )
     expect(backend.authentication).toBeUndefined()
     expect(backend.env.CODEX_CONFIG).not.toContain('mm-secret')
 
@@ -3142,7 +3144,13 @@ describe('SettingsService: official vendors', () => {
     expect(config.sessionOptions).toEqual({
       settings: {
         skipWebFetchPreflight: true,
-        permissions: { ask: ['WebFetch'] }
+        permissions: { ask: ['WebFetch'] },
+        availableModels: ['sonnet', 'opus', 'haiku'],
+        modelOverrides: {
+          sonnet: 'deepseek-v4-flash',
+          opus: 'deepseek-v4-pro',
+          haiku: 'deepseek-v4-pro[1m]'
+        }
       }
     })
     expect(config.contextWindow).toBe(1_000_000)

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3153,6 +3153,16 @@ describe('SettingsService: official vendors', () => {
         }
       }
     })
+    await expect(
+      readFile(join(getAppClaudeConfigDir(storageRoot), 'settings.json'), 'utf8').then(JSON.parse)
+    ).resolves.toMatchObject({
+      availableModels: ['sonnet', 'opus', 'haiku'],
+      modelOverrides: {
+        sonnet: 'deepseek-v4-flash',
+        opus: 'deepseek-v4-pro',
+        haiku: 'deepseek-v4-pro[1m]'
+      }
+    })
     expect(config.contextWindow).toBe(1_000_000)
   })
 

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3145,22 +3145,22 @@ describe('SettingsService: official vendors', () => {
       settings: {
         skipWebFetchPreflight: true,
         permissions: { ask: ['WebFetch'] },
-        availableModels: ['sonnet', 'opus', 'haiku'],
+        availableModels: ['deepseek-v4-flash', 'deepseek-v4-pro', 'deepseek-v4-pro[1m]'],
         modelOverrides: {
-          sonnet: 'deepseek-v4-flash',
-          opus: 'deepseek-v4-pro',
-          haiku: 'deepseek-v4-pro[1m]'
+          'deepseek-v4-flash': 'deepseek-v4-flash',
+          'deepseek-v4-pro': 'deepseek-v4-pro',
+          'deepseek-v4-pro[1m]': 'deepseek-v4-pro[1m]'
         }
       }
     })
     await expect(
       readFile(join(getAppClaudeConfigDir(storageRoot), 'settings.json'), 'utf8').then(JSON.parse)
     ).resolves.toMatchObject({
-      availableModels: ['sonnet', 'opus', 'haiku'],
+      availableModels: ['deepseek-v4-flash', 'deepseek-v4-pro', 'deepseek-v4-pro[1m]'],
       modelOverrides: {
-        sonnet: 'deepseek-v4-flash',
-        opus: 'deepseek-v4-pro',
-        haiku: 'deepseek-v4-pro[1m]'
+        'deepseek-v4-flash': 'deepseek-v4-flash',
+        'deepseek-v4-pro': 'deepseek-v4-pro',
+        'deepseek-v4-pro[1m]': 'deepseek-v4-pro[1m]'
       }
     })
     expect(config.contextWindow).toBe(1_000_000)

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -62,6 +62,7 @@ import { resolveStorageRoot } from '../storage-root'
 import {
   DEFAULT_AGENT_FRAMEWORK_ID,
   listAgentFrameworks,
+  type AgentModelChangeTarget,
   type AgentFrameworkId,
   type ResolvedAgentBackend
 } from '../agent-framework'
@@ -382,6 +383,10 @@ class SettingsService {
   // is synchronous and never performs provider discovery or a network request.
   async resolveActiveReasoningEffort(intent: ReasoningEffort): Promise<ResolvedReasoningEffort> {
     return this.backendResolver.resolveActiveReasoningEffort(intent)
+  }
+
+  async resolveActiveModelChangeTarget(): Promise<AgentModelChangeTarget | undefined> {
+    return this.backendResolver.resolveActiveModelChangeTarget()
   }
 
   // Whether desktop notifications for finished/failed agent tasks are on, read fresh so the

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -41,7 +41,10 @@ import { netFetch } from '../skills/net-fetch'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { readSkillFile } from '../skills/skill-files'
 import { SAFE_SLUG, UserSkillRepository } from '../skills/user-skill-repository'
-import { provisionAppClaudeConfigDir } from './claude-config-provision'
+import {
+  provisionAppClaudeConfigDir,
+  type ClaudeRuntimeModelConfig
+} from './claude-config-provision'
 import type { SettingsRepository } from './repository'
 import type { StoredSettings } from './types'
 
@@ -658,10 +661,15 @@ class SkillCatalogModule {
     )
   }
 
-  async provisionClaudeConfig(configDir: string, disabledSkillIds: string[]): Promise<void> {
+  async provisionClaudeConfig(
+    configDir: string,
+    disabledSkillIds: string[],
+    modelConfig?: ClaudeRuntimeModelConfig | null
+  ): Promise<void> {
     await provisionAppClaudeConfigDir(configDir, {
       skills: await this.catalog(),
-      disabledSkillIds
+      disabledSkillIds,
+      ...(modelConfig === undefined ? {} : { modelConfig })
     })
   }
 

--- a/src/main/settings/workflows.test.ts
+++ b/src/main/settings/workflows.test.ts
@@ -237,6 +237,46 @@ describe('SettingsWorkflows runtime effects', () => {
     expect(requestProviderReconnect).not.toHaveBeenCalled()
   })
 
+  it('attempts a live model switch before reconnecting across providers', async () => {
+    const calls: string[] = []
+    const { store, capability } = fakeStore()
+    const target: AgentModelChangeTarget = {
+      frameworkId: 'claude-code',
+      backendId: 'claude-code:kimi',
+      route: 'claude-anthropic',
+      model: 'kimi-k3',
+      sessionModel: 'kimi-k3',
+      sessionModelRequired: false,
+      supportsImageInput: true,
+      reasoningEffort: 'default'
+    }
+    store.getSettingsView.mockResolvedValue(
+      snapshot({ activeProviderId: 'deepseek', activeModel: 'deepseek-v4-pro' })
+    )
+    store.setActiveProvider.mockImplementation(async () => {
+      calls.push('persist')
+      return snapshot({ activeProviderId: 'kimi', activeModel: 'kimi-k3' })
+    })
+    store.resolveActiveModelChangeTarget.mockImplementation(async () => {
+      calls.push('resolve')
+      return target
+    })
+    const applyModelChange = vi.fn(async () => {
+      calls.push('apply')
+      return true
+    })
+    const requestProviderReconnect = vi.fn(() => calls.push('reconnect'))
+
+    await createSettingsWorkflows(
+      capability,
+      testEffects({ applyModelChange, requestProviderReconnect })
+    ).runtime.setActiveProvider({ id: 'kimi', model: 'kimi-k3' })
+
+    expect(calls).toEqual(['persist', 'resolve', 'apply'])
+    expect(applyModelChange).toHaveBeenCalledWith(target)
+    expect(requestProviderReconnect).not.toHaveBeenCalled()
+  })
+
   it('falls back to reconnect when the active generation cannot switch models live', async () => {
     const { store, capability } = fakeStore()
     store.getSettingsView.mockResolvedValue(

--- a/src/main/settings/workflows.test.ts
+++ b/src/main/settings/workflows.test.ts
@@ -11,6 +11,7 @@ import {
   type SettingsWorkflowEffects,
   type SettingsWorkflowStore
 } from './workflows'
+import type { AgentModelChangeTarget } from '../agent-framework'
 
 type TestSettingsWorkflowEffects = Partial<
   SettingsWorkflowEffects['runtime'] &
@@ -25,7 +26,8 @@ const testEffects = (effects: TestSettingsWorkflowEffects = {}): SettingsWorkflo
   runtime: {
     requestProviderReconnect: effects.requestProviderReconnect ?? (() => undefined),
     requestAgentFrameworkSwitch: effects.requestAgentFrameworkSwitch ?? (() => undefined),
-    applyReasoningEffort: effects.applyReasoningEffort ?? (async () => false)
+    applyReasoningEffort: effects.applyReasoningEffort ?? (async () => false),
+    applyModelChange: effects.applyModelChange ?? (async () => false)
   },
   skills: { requestSkillsReload: effects.requestSkillsReload ?? (() => undefined) },
   connectors: {
@@ -70,6 +72,7 @@ const fakeStore = () => {
     setAgentFramework: vi.fn().mockResolvedValue(snapshot()),
     setReasoningEffort: vi.fn().mockResolvedValue(snapshot()),
     resolveActiveReasoningEffort: vi.fn().mockResolvedValue('high'),
+    resolveActiveModelChangeTarget: vi.fn().mockResolvedValue(undefined),
     setConversationSkillImportEnabled: vi.fn().mockResolvedValue(snapshot()),
     setAppIconVariant: vi.fn().mockResolvedValue(snapshot()),
     loginClaudeShared: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
@@ -185,12 +188,97 @@ describe('SettingsWorkflows runtime effects', () => {
       'read',
       'upsert',
       'reconnect',
+      'read',
       'select',
       'reconnect',
       'read',
       'delete',
       'reconnect'
     ])
+  })
+
+  it('persists a same-provider model selection before applying it live', async () => {
+    const calls: string[] = []
+    const { store, capability } = fakeStore()
+    const target: AgentModelChangeTarget = {
+      frameworkId: 'claude-code',
+      backendId: 'claude-code:active',
+      route: 'claude-anthropic',
+      model: 'model-b',
+      sessionModel: 'model-b',
+      sessionModelRequired: false,
+      reasoningEffort: 'high'
+    }
+    store.getSettingsView.mockResolvedValue(
+      snapshot({ activeProviderId: 'active', activeModel: 'model-a' })
+    )
+    store.setActiveProvider.mockImplementation(async () => {
+      calls.push('persist')
+      return snapshot({ activeProviderId: 'active', activeModel: 'model-b' })
+    })
+    store.resolveActiveModelChangeTarget.mockImplementation(async () => {
+      calls.push('resolve')
+      return target
+    })
+    const applyModelChange = vi.fn(async () => {
+      calls.push('apply')
+      return true
+    })
+    const requestProviderReconnect = vi.fn(() => calls.push('reconnect'))
+
+    await createSettingsWorkflows(
+      capability,
+      testEffects({ applyModelChange, requestProviderReconnect })
+    ).runtime.setActiveProvider({ id: 'active', model: 'model-b' })
+
+    expect(calls).toEqual(['persist', 'resolve', 'apply'])
+    expect(applyModelChange).toHaveBeenCalledWith(target)
+    expect(requestProviderReconnect).not.toHaveBeenCalled()
+  })
+
+  it('falls back to reconnect when the active generation cannot switch models live', async () => {
+    const { store, capability } = fakeStore()
+    store.getSettingsView.mockResolvedValue(
+      snapshot({ activeProviderId: 'active', activeModel: 'model-a' })
+    )
+    store.setActiveProvider.mockResolvedValue(
+      snapshot({ activeProviderId: 'active', activeModel: 'model-b' })
+    )
+    store.resolveActiveModelChangeTarget.mockResolvedValue({
+      frameworkId: 'opencode',
+      backendId: 'opencode:active',
+      route: 'opencode-openai',
+      model: 'model-b',
+      sessionModel: 'model-b',
+      sessionModelRequired: false,
+      reasoningEffort: 'default'
+    })
+    const requestProviderReconnect = vi.fn()
+
+    await createSettingsWorkflows(
+      capability,
+      testEffects({ applyModelChange: async () => false, requestProviderReconnect })
+    ).runtime.setActiveProvider({ id: 'active', model: 'model-b' })
+
+    expect(requestProviderReconnect).toHaveBeenCalledOnce()
+  })
+
+  it('does not resolve or reconnect when the persisted effective model is unchanged', async () => {
+    const { store, capability } = fakeStore()
+    const unchanged = snapshot({ activeProviderId: 'active', activeModel: 'model-a' })
+    store.getSettingsView.mockResolvedValue(unchanged)
+    store.setActiveProvider.mockResolvedValue(unchanged)
+    const applyModelChange = vi.fn(async () => true)
+    const requestProviderReconnect = vi.fn()
+
+    await createSettingsWorkflows(
+      capability,
+      testEffects({ applyModelChange, requestProviderReconnect })
+    ).runtime.setActiveProvider({ id: 'active', model: 'model-a' })
+
+    expect(store.resolveActiveModelChangeTarget).not.toHaveBeenCalled()
+    expect(applyModelChange).not.toHaveBeenCalled()
+    expect(requestProviderReconnect).not.toHaveBeenCalled()
   })
 
   it('does not reconnect for a new or inactive provider edit or a failed mutation', async () => {

--- a/src/main/settings/workflows.test.ts
+++ b/src/main/settings/workflows.test.ts
@@ -207,6 +207,7 @@ describe('SettingsWorkflows runtime effects', () => {
       model: 'model-b',
       sessionModel: 'model-b',
       sessionModelRequired: false,
+      supportsImageInput: true,
       reasoningEffort: 'high'
     }
     store.getSettingsView.mockResolvedValue(
@@ -251,6 +252,7 @@ describe('SettingsWorkflows runtime effects', () => {
       model: 'model-b',
       sessionModel: 'model-b',
       sessionModelRequired: false,
+      supportsImageInput: false,
       reasoningEffort: 'default'
     })
     const requestProviderReconnect = vi.fn()

--- a/src/main/settings/workflows/runtime.ts
+++ b/src/main/settings/workflows/runtime.ts
@@ -101,11 +101,12 @@ class RuntimeSettingsWorkflows {
   ): Promise<Awaited<ReturnType<RuntimeSettingsWorkflowStore['setActiveProvider']>>> {
     const before = await this.settings.getSettingsView()
     const snapshot = await this.settings.setActiveProvider(request.id, request.model)
-    if (before.activeProviderId !== snapshot.activeProviderId) {
-      this.effects.requestProviderReconnect()
+    if (
+      before.activeProviderId === snapshot.activeProviderId &&
+      before.activeModel === snapshot.activeModel
+    ) {
       return snapshot
     }
-    if (before.activeModel === snapshot.activeModel) return snapshot
 
     const target = await this.settings.resolveActiveModelChangeTarget()
     const appliedLive = target ? await this.effects.applyModelChange(target) : false

--- a/src/main/settings/workflows/runtime.ts
+++ b/src/main/settings/workflows/runtime.ts
@@ -8,7 +8,7 @@ import {
   type UpsertProviderRequest
 } from '../../../shared/settings'
 import type { ResolvedReasoningEffort } from '../../../shared/reasoning-effort'
-import type { AgentFrameworkId } from '../../agent-framework'
+import type { AgentFrameworkId, AgentModelChangeTarget } from '../../agent-framework'
 import type { SettingsService } from '../service'
 
 type RuntimeSettingsWorkflowStore = Pick<
@@ -23,6 +23,7 @@ type RuntimeSettingsWorkflowStore = Pick<
   | 'setAgentFramework'
   | 'setReasoningEffort'
   | 'resolveActiveReasoningEffort'
+  | 'resolveActiveModelChangeTarget'
   | 'loginClaudeShared'
   | 'logoutClaudeShared'
   | 'loginIsolatedClaude'
@@ -36,6 +37,7 @@ type RuntimeSettingsWorkflowEffects = {
   requestProviderReconnect: () => void
   requestAgentFrameworkSwitch: () => void
   applyReasoningEffort: (effort: ResolvedReasoningEffort) => Promise<boolean>
+  applyModelChange: (target: AgentModelChangeTarget) => Promise<boolean>
 }
 
 type RuntimeUninstallMethod = 'uninstallClaude' | 'uninstallOpencode' | 'uninstallCodex'
@@ -97,8 +99,17 @@ class RuntimeSettingsWorkflows {
   async setActiveProvider(
     request: SetActiveProviderRequest
   ): Promise<Awaited<ReturnType<RuntimeSettingsWorkflowStore['setActiveProvider']>>> {
+    const before = await this.settings.getSettingsView()
     const snapshot = await this.settings.setActiveProvider(request.id, request.model)
-    this.effects.requestProviderReconnect()
+    if (before.activeProviderId !== snapshot.activeProviderId) {
+      this.effects.requestProviderReconnect()
+      return snapshot
+    }
+    if (before.activeModel === snapshot.activeModel) return snapshot
+
+    const target = await this.settings.resolveActiveModelChangeTarget()
+    const appliedLive = target ? await this.effects.applyModelChange(target) : false
+    if (!appliedLive) this.effects.requestProviderReconnect()
     return snapshot
   }
 


### PR DESCRIPTION
## Problem

Changing an ACP model or API provider currently reconnects the agent process even when the active
adapter can update the existing session. That loses the lightweight transition, may trigger native
resume or transcript replay, and makes a model-only selection look like a process failure in logs.

The four supported routes have different constraints: Claude Code, OpenCode, Codex Responses, and
Codex bridge cannot safely share one unconditional switching rule. Provider base URLs, credentials,
image capabilities, adapter catalogs, and transport type all affect whether a live switch is valid.

## Proposed change

- Apply registered, compatible model/provider targets to the existing ACP generation and sessions.
- Keep the current in-flight message on its original model. User selections remain enabled; a
  latest-wins pending target is applied after generation activity drains, while new prompts wait at
  an admission barrier.
- Route compatible Claude, OpenCode, and Codex API-key providers through generation-owned loopback
  transports so endpoint, credential, and model changes can occur without exposing real keys to the
  ACP child process.
- Preserve existing fail-closed reconnect behavior for framework, auth-lane, or wire-route changes;
  unregistered targets; unsafe image downgrades; and Codex same-slug capability conflicts.
- Emit `session transcript replay dispatched` only when a history preamble is actually sent to ACP.
- Isolate the pending/barrier/drain/fallback state machine in `AcpModelChangeWorkflow`. Connection
  bootstrap remains in `AcpConnectionLifecycleWorkflow`; the mainline `AcpConnectionCloseWorkflow`
  coordinates model-change cancellation/drain during close, reconnect, and retirement; and the
  connection adapter transfers transport leases to the connection resource owner.

```mermaid
flowchart LR
  Select["Persist provider/model selection"] --> Eligible{"Registered compatible target?"}
  Eligible -->|No| Reconnect["Existing deferred reconnect"]
  Eligible -->|Yes| Busy{"Generation busy?"}
  Busy -->|Yes| Pending["Replace pending target; latest wins"]
  Pending --> Drain["Wait for current activity to finish"]
  Busy -->|No| Apply["Retarget transport and session config"]
  Drain --> Apply
  Apply --> Same["Same process and session; no replay"]
  Apply -->|Rejected| Reconnect
```

## Scope and non-goals

- No Prisma migration, persisted settings schema change, renderer IPC contract change, or new UI.
- The current message is never moved between models mid-generation.
- Framework changes, subscription/shared/isolated auth changes, and
  `codex-response`/`codex-bridge` route changes still reconnect.
- Custom providers still expose the existing configured model shape; this does not add a persistent
  multi-model provider catalog.
- The local design record under `docs/internal/` is intentionally Git-ignored and is not part of this
  pull request.

## Acceptance criteria and validation

All listed checks ran after the last material edit and after rebasing onto `origin/main@ab70b78`.

| Behavior / risk | Final check | Result |
| --- | --- | --- |
| Busy latest-wins switching, prompt admission barrier, close/reconnect ordering, fallback recovery | `npm test -- src/main/settings/backend-resolver.test.ts src/main/acp/model-change-workflow.test.ts src/main/acp/connection-close-workflow.test.ts src/main/acp/agent-connection-adapter.test.ts src/main/acp/connection-lifecycle-workflow.test.ts src/main/acp/connection-resource-owner.test.ts src/main/acp/runtime.test.ts` | 7 files and 494 tests passed |
| Connection adapter and transport lease ownership | Same affected-ACP test command | Covered by the 494 passing tests |
| Node and renderer type consumers | `npm run typecheck` | Passed |
| Source lint | `npm run lint` | Passed with 0 errors; 17 pre-existing warnings are in unchanged files |
| Cross-module and loopback transport regression coverage | `npm test` | 762 files passed, 14 skipped; 11,273 tests passed, 184 skipped |

The complete suite was run outside the restricted filesystem sandbox because project-owned bridge
and RPC tests must listen on `127.0.0.1`; the sandbox run failed with `listen EPERM` before the same
suite passed with loopback access.

Independent review identified four compatibility gaps: Codex cross-provider same-slug capability
metadata, clearing a previous reasoning override when the new target resolves to `default`, avoiding
inactive Claude bridge targets, and preserving a newer effort selection behind a queued model
switch. All now fail closed, reset explicitly, or serialize through the existing barrier and have
regression coverage.

Uncovered risk: real third-party provider credentials were not used in automated tests. Transport
behavior was validated with loopback upstreams and fake keys; existing reconnect remains the fallback
when a live adapter rejects a target.

## Review focus

- The boundary between `AcpModelChangeWorkflow`, runtime target policy, connection lifecycle, and
  the newly extracted connection-close workflow from #750.
- Atomic ordering of transport retargeting, ACP config-option updates, generation state commit, and
  reconnect recovery.
- Image downgrade and Codex same-slug fail-closed conditions.
- Lease transfer/release behavior across failed connection candidates, retirement, and shutdown.
