### PR TITLE
refactor(acp): extract provider session creator

### DIFF
--- a/src/main/acp/provider-session-creator.test.ts
+++ b/src/main/acp/provider-session-creator.test.ts
@@ -1,0 +1,218 @@
+import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
+import { claudeCodeFramework } from '../agent-framework'
+import { SKILL_IMPORT_SYSTEM_PROMPT_APPEND } from '../skills/mcp-server'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import { AcpProviderSessionCreator } from './provider-session-creator'
+import type { SessionCapabilityName } from './session-capability-owner'
+import { AcpSessionRegistry } from './session-registry'
+
+const permissionProfile: SessionPermissionProfileState = {
+  selectedProfile: 'ask',
+  effectiveProfile: 'ask',
+  currentModeId: 'default',
+  availableModeIds: ['default'],
+  fullAccessAvailable: false
+}
+
+type CreatorHarness = {
+  commit: ReturnType<typeof vi.fn>
+  creator: AcpProviderSessionCreator
+  order: string[]
+  registry: AcpSessionRegistry
+  release: ReturnType<typeof vi.fn>
+  session: ActiveSession
+  sessionSetupAppends: string[][]
+}
+
+const createHarness = (options: {
+  configure?: () => Promise<{
+    permissionProfile: SessionPermissionProfileState
+    appliedModel: undefined
+    configOptions: undefined
+  }>
+  registerSessionSpecialist?: () => void
+  pushEvent?: () => void
+  emitState?: () => void
+  order?: string[]
+  descriptorCapabilities?: SessionCapabilityName[]
+}): CreatorHarness => {
+  const order = options.order ?? []
+  const sessionSetupAppends: string[][] = []
+  const session = {
+    sessionId: 'provider-session',
+    dispose: vi.fn()
+  } as unknown as ActiveSession
+  const connection = {
+    agent: {
+      buildSession: vi.fn(() => ({
+        start: vi.fn(async () => {
+          order.push('session/new')
+          return session
+        })
+      }))
+    }
+  } as unknown as ClientConnection
+  const registry = new AcpSessionRegistry()
+  vi.spyOn(registry, 'publish').mockImplementation((...args) => {
+    order.push('registry publish')
+    return AcpSessionRegistry.prototype.publish.call(registry, ...args)
+  })
+  const backend: AcpBackendGenerationView = {
+    framework: {
+      ...claudeCodeFramework,
+      buildSessionSetup: (input) => {
+        order.push('presentation preflight')
+        sessionSetupAppends.push([...(input.systemPromptAppends ?? [])])
+        return claudeCodeFramework.buildSessionSetup(input)
+      }
+    },
+    backendId: 'claude-code',
+    session: { modelRequired: false },
+    prompt: { systemPromptAppends: [] },
+    context: { supportsImageInput: false },
+    adapter: { nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false }
+  }
+  const commit = vi.fn(() => order.push('capability commit'))
+  const release = vi.fn()
+  const creator = new AcpProviderSessionCreator({
+    defaultCwd: '/default',
+    defaultProjectName: 'default-project',
+    currentCwd: () => '/current',
+    ensureConnected: vi.fn(async () => {
+      order.push('ensure connection')
+      return connection
+    }),
+    assertCurrentConnection: vi.fn(),
+    currentBackend: () => backend,
+    registry,
+    reserveIdentity: (sessionId, startupGeneration) => {
+      order.push('identity reservation')
+      return registry.reserve({
+        sessionIds: [sessionId],
+        startupGeneration,
+        mayRenewAfterConnectionSetup: true,
+        blockStartup: false
+      })
+    },
+    capabilities: {
+      provision: vi.fn(async () => {
+        order.push('capability provision')
+        return {
+          mcpServers: [],
+          descriptor: {
+            role: 'primary' as const,
+            delegation: 'denied' as const,
+            transport: 'none' as const,
+            capabilities: options.descriptorCapabilities ?? [],
+            canonicalMcpServerNames: [],
+            modelFacingMcpServerNames: [],
+            controlRpcMethods: []
+          },
+          commit,
+          release
+        }
+      })
+    },
+    configurator: {
+      configure:
+        options.configure ??
+        vi.fn(async () => {
+          order.push('configure')
+          return { permissionProfile, appliedModel: undefined, configOptions: undefined }
+        })
+    },
+    registerSessionSpecialist: () => {
+      order.push('notebook callback')
+      options.registerSessionSpecialist?.()
+    },
+    updateCwd: () => order.push('cwd callback'),
+    pushEvent: () => {
+      order.push('event callback')
+      options.pushEvent?.()
+    },
+    emitState: () => {
+      order.push('state callback')
+      options.emitState?.()
+    },
+    diagnosticContext: () => ({})
+  })
+  return { commit, creator, order, registry, release, session, sessionSetupAppends }
+}
+
+describe('AcpProviderSessionCreator', () => {
+  it('publishes the provider-returned id as the fresh application Session id', async () => {
+    const harness = createHarness({ order: [] })
+
+    const result = await harness.creator.create({ cwd: '/workspace', projectName: 'project-a' })
+
+    expect(result).toEqual({
+      sessionId: 'provider-session',
+      cwd: '/workspace',
+      frameworkId: 'claude-code',
+      backendId: 'claude-code'
+    })
+    expect(harness.registry.lookup('provider-session')?.attachment?.session).toBe(harness.session)
+    expect(harness.commit).toHaveBeenCalledWith('provider-session')
+    expect(harness.order).toEqual([
+      'ensure connection',
+      'capability provision',
+      'presentation preflight',
+      'session/new',
+      'identity reservation',
+      'configure',
+      'registry publish',
+      'capability commit',
+      'notebook callback',
+      'cwd callback',
+      'event callback',
+      'state callback'
+    ])
+  })
+
+  it('disposes the provisional Session and releases capabilities when configuration fails', async () => {
+    const failure = new Error('configuration failed')
+    const harness = createHarness({ configure: vi.fn().mockRejectedValue(failure) })
+
+    await expect(harness.creator.create({ cwd: '/workspace' })).rejects.toBe(failure)
+
+    expect(harness.session.dispose).toHaveBeenCalledOnce()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.registry.lookup('provider-session')).toBeUndefined()
+    expect(harness.commit).not.toHaveBeenCalled()
+  })
+
+  it('does not roll back a published Session when observer callbacks fail', async () => {
+    const harness = createHarness({
+      registerSessionSpecialist: () => {
+        throw new Error('notebook observer failed')
+      },
+      pushEvent: () => {
+        throw new Error('event observer failed')
+      },
+      emitState: () => {
+        throw new Error('state observer failed')
+      }
+    })
+
+    await expect(harness.creator.create({ cwd: '/workspace' })).resolves.toMatchObject({
+      sessionId: 'provider-session'
+    })
+    expect(harness.registry.lookup('provider-session')?.attachment?.session).toBe(harness.session)
+    expect(harness.session.dispose).not.toHaveBeenCalled()
+    expect(harness.release).not.toHaveBeenCalled()
+  })
+
+  it('builds prompt guidance from the effective provisioned capability descriptor', async () => {
+    const harness = createHarness({ descriptorCapabilities: [] })
+    const enabledHarness = createHarness({ descriptorCapabilities: ['skill-import'] })
+
+    await harness.creator.create({ cwd: '/workspace' })
+    await enabledHarness.creator.create({ cwd: '/workspace' })
+
+    expect(harness.sessionSetupAppends.flat()).not.toContain(SKILL_IMPORT_SYSTEM_PROMPT_APPEND)
+    expect(enabledHarness.sessionSetupAppends.flat()).toContain(SKILL_IMPORT_SYSTEM_PROMPT_APPEND)
+  })
+})

--- a/src/main/acp/provider-session-creator.ts
+++ b/src/main/acp/provider-session-creator.ts
@@ -1,0 +1,265 @@
+import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+import { resolve } from 'node:path'
+
+import type {
+  AcpCreateSessionRequest,
+  AcpCreateSessionResponse,
+  AcpRuntimeEvent
+} from '../../shared/acp'
+import { normalizePermissionProfile } from '../../shared/permission-profiles'
+import type { EffectiveSpecialistSkills } from '../../shared/specialist'
+import { createLogger, diagnosticErrorFields } from '../logger'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import {
+  CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+  type AcpSessionCapabilityOwner,
+  type SessionCapabilityProvision
+} from './session-capability-owner'
+import type { AcpSessionConfigurator } from './session-configurator'
+import { AcpSessionPresentationPolicy } from './session-presentation-policy'
+import type {
+  AcpPrimarySessionIdentityReservationResult,
+  AcpSessionRegistry
+} from './session-registry'
+
+const log = createLogger('acp')
+
+type CreationEvent = Omit<AcpRuntimeEvent, 'id' | 'timestamp'>
+
+type AcpProviderSessionCreatorDependencies = Readonly<{
+  defaultCwd: string
+  defaultProjectName: string
+  currentCwd: () => string | undefined
+  ensureConnected: (cwd: string) => Promise<ClientConnection>
+  assertCurrentConnection: (connection: ClientConnection) => void
+  currentBackend: () => AcpBackendGenerationView
+  registry: AcpSessionRegistry
+  reserveIdentity: (
+    sessionId: string,
+    startupGeneration: number
+  ) => AcpPrimarySessionIdentityReservationResult
+  capabilities: Pick<AcpSessionCapabilityOwner, 'provision'>
+  configurator: Pick<AcpSessionConfigurator, 'configure'>
+  resolveSpecialistIdentity?: (
+    specialistId: string,
+    frameworkId: string
+  ) => Promise<{ append: string; prefix: string } | undefined>
+  resolveSpecialistSkills?: (specialistId: string) => Promise<EffectiveSpecialistSkills>
+  registerSessionSpecialist?: (sessionId: string, specialistId: string | undefined) => void
+  updateCwd: (cwd: string) => void
+  pushEvent: (event: CreationEvent) => void
+  emitState: () => void
+  diagnosticContext: () => Readonly<Record<string, unknown>>
+}>
+
+export class AcpProviderSessionCreator {
+  private readonly presentation = new AcpSessionPresentationPolicy()
+
+  constructor(private readonly deps: AcpProviderSessionCreatorDependencies) {}
+
+  async create(request: AcpCreateSessionRequest = {}): Promise<AcpCreateSessionResponse> {
+    let capability: SessionCapabilityProvision | undefined
+    let provisionalSession: ActiveSession | undefined
+    let reservation: ReturnType<AcpSessionRegistry['reserve']>['reservation']
+    try {
+      log.info('createSession: starting', this.deps.diagnosticContext())
+      const cwd = resolve(request.cwd || this.deps.currentCwd() || this.deps.defaultCwd)
+      const projectName = request.projectName?.trim() || this.deps.defaultProjectName
+      log.info('createSession: ensureConnected', this.deps.diagnosticContext())
+      const connection = await this.deps.ensureConnected(cwd)
+      this.deps.assertCurrentConnection(connection)
+      const startupBackend = this.deps.currentBackend()
+      const startupGeneration = this.deps.registry.startupGeneration
+      const specialist = await this.resolveSpecialist(request.specialistId, startupBackend)
+
+      log.info('createSession: createMcpServers', this.deps.diagnosticContext())
+      capability = await this.deps.capabilities.provision({
+        framework: startupBackend.framework,
+        nativeMcpEnabled: startupBackend.adapter.nativeMcpEnabled,
+        bridgeMcpAliasesEnabled: startupBackend.adapter.bridgeMcpAliasesEnabled,
+        policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+        sessionCwd: cwd,
+        projectName
+      })
+      const setup = this.presentation.buildSessionSetup({
+        framework: startupBackend.framework,
+        tooling: {
+          artifacts: capability.descriptor.capabilities.includes('artifacts'),
+          notebook: capability.descriptor.capabilities.includes('notebook'),
+          skillImport: capability.descriptor.capabilities.includes('skill-import')
+        },
+        backendSystemPromptAppends: startupBackend.prompt.systemPromptAppends,
+        extraSystemPromptAppends: specialist.append ? [specialist.append] : [],
+        persistentSystemPrompt: startupBackend.prompt.persistentSystemPrompt,
+        sessionOptions: startupBackend.session.options,
+        specialistSkills: specialist.skills
+      })
+      log.info('createSession: buildSession', this.deps.diagnosticContext())
+      const session = await connection.agent
+        .buildSession({ cwd, mcpServers: capability.mcpServers, ...setup.metaArg })
+        .start()
+      provisionalSession = session
+
+      const reserved = this.deps.reserveIdentity(session.sessionId, startupGeneration)
+      if (reserved.collision) {
+        this.disposeProvisional(session, 'primary collision session disposal failed')
+        provisionalSession = undefined
+        throw reserved.collision
+      }
+      const identityReservation = reserved.reservation
+      const provisionedCapability = capability
+      reservation = identityReservation
+
+      log.info('createSession: configurePermissionProfile', this.deps.diagnosticContext())
+      log.info('createSession: applySessionModel', this.deps.diagnosticContext())
+      const permissionProfile = normalizePermissionProfile(request.permissionProfile)
+      let backend = this.deps.currentBackend()
+      let configuration = await this.deps.configurator.configure({
+        backend,
+        connection,
+        session,
+        permissionProfile
+      })
+      for (;;) {
+        // A live effort change can overlap the provider request above. Replay against the newest
+        // immutable backend view until it is stable, then publish synchronously so the change either
+        // precedes configuration or observes this Session in the Registry.
+        const currentBackend = this.deps.currentBackend()
+        if (currentBackend !== backend) {
+          backend = currentBackend
+          configuration = await this.deps.configurator.configure({
+            backend,
+            connection,
+            session,
+            permissionProfile
+          })
+          continue
+        }
+        identityReservation.assertCurrent()
+        const { aggregate } = this.deps.registry.publish(identityReservation, session.sessionId, {
+          session,
+          cwd,
+          projectName,
+          frameworkId: backend.framework.id,
+          backendId: backend.backendId,
+          permissionProfile: structuredClone(configuration.permissionProfile),
+          appliedModel: configuration.appliedModel,
+          configOptions: structuredClone(configuration.configOptions)
+        })
+        aggregate.setSpecialistPrefix(specialist.prefix || undefined)
+        aggregate.setSpecialistId(request.specialistId)
+        provisionedCapability.commit(session.sessionId)
+        provisionalSession = undefined
+        identityReservation.release()
+        reservation = undefined
+        capability = undefined
+        break
+      }
+
+      this.publish(request, session.sessionId, cwd)
+      log.info('createSession: completed successfully', this.deps.diagnosticContext())
+      return {
+        sessionId: session.sessionId,
+        cwd,
+        frameworkId: backend.framework.id,
+        ...(backend.backendId ? { backendId: backend.backendId } : {})
+      }
+    } catch (caught) {
+      let startupError = caught
+      if (reservation) {
+        try {
+          reservation.assertCurrent()
+        } catch (supersededError) {
+          startupError = supersededError
+        }
+      }
+      this.disposeProvisional(provisionalSession, 'primary startup session disposal failed')
+      if (capability) {
+        try {
+          capability.release({ ownsStableIdentity: true })
+        } catch (cleanupError) {
+          this.safeLogError('primary capability release failed', cleanupError, undefined, false)
+        }
+      }
+      this.safeLogError('createSession: failed', startupError)
+      throw startupError
+    } finally {
+      reservation?.release()
+    }
+  }
+
+  private async resolveSpecialist(
+    specialistId: string | undefined,
+    backend: AcpBackendGenerationView
+  ): Promise<{ append?: string; prefix?: string; skills?: EffectiveSpecialistSkills }> {
+    if (!specialistId) return {}
+    if (!this.deps.resolveSpecialistIdentity) {
+      throw new Error('Specialist identity resolution is unavailable.')
+    }
+    const identity = await this.deps.resolveSpecialistIdentity(specialistId, backend.framework.id)
+    if (!identity) {
+      throw new Error(`Specialist ${specialistId} is unavailable (disabled, deleted, or corrupt).`)
+    }
+    return {
+      append: identity.append || undefined,
+      prefix: identity.prefix || undefined,
+      skills: await this.deps.resolveSpecialistSkills?.(specialistId)
+    }
+  }
+
+  private publish(request: AcpCreateSessionRequest, sessionId: string, cwd: string): void {
+    this.tryPostPublish(
+      'register session specialist failed',
+      () => this.deps.registerSessionSpecialist?.(sessionId, request.specialistId),
+      sessionId
+    )
+    this.deps.updateCwd(cwd)
+    this.tryPostPublish(
+      'session created event callback failed',
+      () =>
+        this.deps.pushEvent({
+          kind: 'system',
+          level: 'info',
+          sessionId,
+          title: 'Session created',
+          text: cwd
+        }),
+      sessionId
+    )
+    this.tryPostPublish('session created state callback failed', this.deps.emitState, sessionId)
+  }
+
+  private disposeProvisional(session: ActiveSession | undefined, message: string): void {
+    if (!session) return
+    try {
+      session.dispose()
+    } catch (error) {
+      this.safeLogError(message, error, session.sessionId, false)
+    }
+  }
+
+  private tryPostPublish(message: string, callback: () => void, sessionId: string): void {
+    try {
+      callback()
+    } catch (error) {
+      this.safeLogError(message, error, sessionId, false)
+    }
+  }
+
+  private safeLogError(
+    message: string,
+    error: unknown,
+    sessionId?: string,
+    includeContext = true
+  ): void {
+    try {
+      log.error(message, {
+        ...diagnosticErrorFields(error),
+        ...(includeContext ? this.deps.diagnosticContext() : {}),
+        ...(sessionId ? { sessionId } : {})
+      })
+    } catch {
+      // Diagnostics must never replace the provider or cleanup failure.
+    }
+  }
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -8675,6 +8675,66 @@ describe('ACP runtime session management', () => {
     await vi.waitFor(() => expect(process.killed).toBe(true))
   })
 
+  it('does not let a startup reserved behind an armed reconnect barrier publish on the old connection', async () => {
+    const process = new FakeAgentProcess()
+    const promptGate = createDeferred()
+    const secondNewStarted = createDeferred()
+    const releaseSecondNew = createDeferred()
+    const secondModeStarted = createDeferred()
+    const releaseSecondMode = createDeferred()
+    let modeRequestCount = 0
+    const fakeAgent = startFakeAgent(process, ['first-session', 'barrier-session'], {
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      onNewSession: async ({ index }) => {
+        if (index !== 1) return
+        secondNewStarted.resolve()
+        await releaseSecondNew.promise
+      },
+      onSetMode: async () => {
+        modeRequestCount += 1
+        if (modeRequestCount !== 2) return
+        secondModeStarted.resolve()
+        await releaseSecondMode.promise
+      },
+      onPrompt: () => promptGate.promise
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      })
+    })
+    const first = await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: first.sessionId, text: 'stay active' })
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    const second = runtime.createSession({ cwd: '/workspace' })
+    await secondNewStarted.promise
+
+    try {
+      await runtime.requestProviderReconnect()
+      releaseSecondNew.resolve()
+      await secondModeStarted.promise
+
+      promptGate.resolve()
+      await prompt
+      await vi.waitFor(() => expect(process.killed).toBe(true))
+
+      releaseSecondMode.resolve()
+      await expect(second).rejects.toThrow('ACP session startup was superseded.')
+      expect(runtime.getSnapshot().sessionIds).not.toContain('barrier-session')
+    } finally {
+      promptGate.resolve()
+      releaseSecondNew.resolve()
+      releaseSecondMode.resolve()
+      await prompt.catch(() => undefined)
+      await second.catch(() => undefined)
+      await runtime.disconnect().catch(() => undefined)
+    }
+  })
+
   it('defers a provider reconnect until a pending reviewer startup activates', async () => {
     const { lease, runtime, reviewer, releaseReviewerMode } = await startPendingReviewerRace([
       'pending-reviewer'
@@ -17032,6 +17092,71 @@ describe('ACP runtime — model hot switch', () => {
     expect(fakeAgent.prompts.map(({ text }) => text)).toEqual(['old-model turn', 'new-model turn'])
   })
 
+  it('holds a new session behind a queued model switch', async () => {
+    const process = new FakeAgentProcess()
+    const promptStarted = createDeferred()
+    const finishPrompt = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['s-existing', 's-created-after-switch'], {
+      configOptions: [modelOption()],
+      onPrompt: async () => {
+        promptStarted.resolve()
+        await finishPrompt.promise
+        return { stopReason: 'end_turn' }
+      }
+    })
+    const { runtime } = createModelRuntime(process)
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    const prompt = runtime.sendPrompt({ sessionId: 's-existing', text: 'old-model turn' })
+    await promptStarted.promise
+    await runtime.applyModelChange(modelTarget('model-b'))
+    const create = runtime.createSession({ cwd: '/workspace' })
+
+    await Promise.resolve()
+    expect(fakeAgent.newSessions).toHaveLength(1)
+
+    finishPrompt.resolve()
+    await prompt
+    await create
+
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-existing', configId: 'model', value: 'model-b' },
+      { sessionId: 's-created-after-switch', configId: 'model', value: 'model-b' }
+    ])
+  })
+
+  it('includes a session whose creation is in progress when draining a queued model switch', async () => {
+    const process = new FakeAgentProcess()
+    const creationStarted = createDeferred()
+    const finishCreation = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['s-existing', 's-creating'], {
+      configOptions: [modelOption()],
+      onNewSession: async ({ index }) => {
+        if (index !== 1) return
+        creationStarted.resolve()
+        await finishCreation.promise
+      }
+    })
+    const { runtime } = createModelRuntime(process)
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    const create = runtime.createSession({ cwd: '/workspace' })
+    await creationStarted.promise
+    await runtime.applyModelChange(modelTarget('model-b'))
+    expect(fakeAgent.configChanges).toEqual([])
+
+    finishCreation.resolve()
+    await create
+    await vi.waitFor(() => expect(fakeAgent.configChanges).toHaveLength(2))
+
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-existing', configId: 'model', value: 'model-b' },
+      { sessionId: 's-creating', configId: 'model', value: 'model-b' }
+    ])
+  })
+
   it('applies a newer effort change after a queued model switch', async () => {
     const process = new FakeAgentProcess()
     const promptStarted = createDeferred()
@@ -17360,6 +17485,44 @@ describe('ACP runtime — session effort', () => {
     // Sessions created later in the same process inherit the new level.
     await runtime.createSession({ cwd: '/workspace' })
     expect(fakeAgent.configChanges[1]).toMatchObject({ configId: 'effort', value: 'high' })
+  })
+
+  it('keeps a session created concurrently with a live effort change on the new level', async () => {
+    const process = new FakeAgentProcess()
+    const staleConfigurationStarted = createDeferred()
+    const finishStaleConfiguration = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['s-existing', 's-creating'], {
+      configOptions: [thoughtLevelOption(['default', 'low', 'high'])],
+      onSetConfigOption: async ({ sessionId, value }) => {
+        if (sessionId !== 's-creating' || value !== 'low') return
+        staleConfigurationStarted.resolve()
+        await finishStaleConfiguration.promise
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/claude',
+        env: {},
+        sessionEffort: 'low'
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    const create = runtime.createSession({ cwd: '/workspace' })
+    await staleConfigurationStarted.promise
+    await runtime.applyReasoningEffortChange('high')
+    finishStaleConfiguration.resolve()
+    await create
+
+    expect(fakeAgent.configChanges).toEqual([
+      { sessionId: 's-creating', configId: 'effort', value: 'low' },
+      { sessionId: 's-existing', configId: 'effort', value: 'high' },
+      { sessionId: 's-creating', configId: 'effort', value: 'high' }
+    ])
   })
 
   it('updates only the runtime-owned Responses bridge with a live effort change', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -138,6 +138,7 @@ import { AcpSessionUpdateProjector, type AcpSessionUpdateEffect } from './sessio
 import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
 import { AcpConnectionCloseWorkflow, type CloseState } from './connection-close-workflow'
 import { AcpModelChangeWorkflow } from './model-change-workflow'
+import { AcpProviderSessionCreator } from './provider-session-creator'
 import {
   AcpTurnSkillOwner,
   type AcpTurnSkillHooks,
@@ -516,6 +517,7 @@ class AcpRuntime {
   private readonly connectionClose: AcpConnectionCloseWorkflow
   private readonly connectionLifecycle: AcpConnectionLifecycleWorkflow
   private readonly modelChanges: AcpModelChangeWorkflow
+  private readonly providerSessionCreator: AcpProviderSessionCreator
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -768,6 +770,26 @@ class AcpRuntime {
       diagnosticContext: (framework, generation) => this.diagnosticContext(framework, generation),
       openCandidate: (attempt, onFrameworkResolved) =>
         this.openAgentConnection(attempt, onFrameworkResolved)
+    })
+    this.providerSessionCreator = new AcpProviderSessionCreator({
+      defaultCwd: options.defaultCwd,
+      defaultProjectName: options.artifacts?.projectName || DEFAULT_UPLOAD_PROJECT_NAME,
+      currentCwd: () => this.snapshotOwner.cwd,
+      ensureConnected: (cwd) => this.ensureConnected(cwd),
+      assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
+      currentBackend: () => this.backend,
+      registry: this.sessionRegistry,
+      reserveIdentity: (sessionId, startupGeneration) =>
+        this.reservePrimarySessionIds(undefined, [sessionId], undefined, startupGeneration),
+      capabilities: this.sessionCapabilities,
+      configurator: this.sessionConfigurator,
+      resolveSpecialistIdentity: options.resolveSpecialistIdentity,
+      resolveSpecialistSkills: options.resolveSpecialistSkills,
+      registerSessionSpecialist: options.notebook?.registerSessionSpecialist,
+      updateCwd: (cwd) => this.snapshotOwner.updateCwd(cwd),
+      pushEvent: (event) => this.pushEvent(event),
+      emitState: () => this.emitState(),
+      diagnosticContext: () => this.diagnosticContext()
     })
   }
 
@@ -1180,197 +1202,7 @@ class AcpRuntime {
 
   // Creates a protocol session, injects artifact tooling, and uses the returned id as the app session id.
   async createSession(request: AcpCreateSessionRequest = {}): Promise<AcpCreateSessionResponse> {
-    return this.withOperationLease(() => this.createSessionOperation(request))
-  }
-
-  private async createSessionOperation(
-    request: AcpCreateSessionRequest = {}
-  ): Promise<AcpCreateSessionResponse> {
-    let capabilityProvision: SessionCapabilityProvision | undefined
-    let primaryIdentityReservation: AcpPrimarySessionIdentityReservation | undefined
-    let provisionalSession: ActiveSession | undefined
-    try {
-      log.info('createSession: starting', this.diagnosticContext())
-      const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
-      const projectName = this.normalizeProjectName(request.projectName)
-      log.info('createSession: ensureConnected', this.diagnosticContext())
-      const connection = await this.ensureConnected(sessionCwd)
-      this.assertCurrentConnectedConnection(connection)
-      const sessionStartupGeneration = this.sessionRegistry.startupGeneration
-
-      // Resolve specialist identity before starting the ACP session so the identity append is
-      // included in session/new. Main process reads the latest Profile — renderer only sends the UUID.
-      let specialistAppend: string | undefined
-      let specialistPrefix: string | undefined
-      let specialistSkills: EffectiveSpecialistSkills | undefined
-      if (request.specialistId) {
-        if (!this.options.resolveSpecialistIdentity) {
-          // A UUID must never quietly fall back to Main Agent just because startup omitted the
-          // ProfileService wiring. Failing closed preserves the user's selected identity.
-          throw new Error('Specialist identity resolution is unavailable.')
-        }
-        const identity = await this.options.resolveSpecialistIdentity(
-          request.specialistId,
-          this.framework.id
-        )
-        if (!identity) {
-          // Profile is unavailable (disabled, deleted, or corrupt): fail fast.
-          throw new Error(
-            `Specialist ${request.specialistId} is unavailable (disabled, deleted, or corrupt).`
-          )
-        }
-        specialistAppend = identity.append || undefined
-        specialistPrefix = identity.prefix || undefined
-        specialistSkills = await this.options.resolveSpecialistSkills?.(request.specialistId)
-      }
-
-      log.info('createSession: createMcpServers', this.diagnosticContext())
-      capabilityProvision = await this.sessionCapabilities.provision({
-        framework: this.framework,
-        nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
-        bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
-        policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-        sessionCwd,
-        projectName
-      })
-      const { mcpServers } = capabilityProvision
-      log.info('createSession: buildSession', this.diagnosticContext())
-      const extraAppends = specialistAppend ? [specialistAppend] : []
-      const session = await connection.agent
-        .buildSession({
-          cwd: sessionCwd,
-          mcpServers,
-          ...this.buildSessionMetaArg(extraAppends, specialistSkills)
-        })
-        .start()
-      provisionalSession = session
-
-      // New-session requests have no app id on their interface: the provider-returned id becomes the
-      // stable app id. Reserve that first known identity synchronously before any later setup awaits.
-      const reservationResult = this.reservePrimarySessionIds(
-        undefined,
-        [session.sessionId],
-        undefined,
-        sessionStartupGeneration
-      )
-      if (reservationResult.collision) {
-        this.disposeSessionAfterFailure(session, 'primary collision session disposal failed')
-        provisionalSession = undefined
-        throw reservationResult.collision
-      }
-      primaryIdentityReservation = reservationResult.reservation
-
-      log.info('createSession: configurePermissionProfile', this.diagnosticContext())
-      log.info('createSession: applySessionModel', this.diagnosticContext())
-      const backend = this.backend
-      const configuration = await this.sessionConfigurator.configure({
-        backend,
-        connection,
-        session,
-        permissionProfile: normalizePermissionProfile(request.permissionProfile)
-      })
-
-      this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
-      // Commit app-owned projections only after the reservation is known to still own this id. No
-      // await separates this assertion from publication, so an invalidated startup cannot overwrite a
-      // same-id successor's Specialist, Permission, or model state.
-      const { aggregate } = this.attachSessionAggregate(
-        primaryIdentityReservation,
-        session.sessionId,
-        {
-          session,
-          cwd: sessionCwd,
-          projectName,
-          frameworkId: backend.framework.id,
-          backendId: backend.backendId,
-          permissionProfile: structuredClone(configuration.permissionProfile),
-          appliedModel: configuration.appliedModel,
-          configOptions: structuredClone(configuration.configOptions)
-        }
-      )
-      if (specialistPrefix) {
-        aggregate.setSpecialistPrefix(specialistPrefix)
-      } else {
-        aggregate.setSpecialistPrefix(undefined)
-      }
-      if (request.specialistId) {
-        aggregate.setSpecialistId(request.specialistId)
-      } else {
-        aggregate.setSpecialistId(undefined)
-      }
-      capabilityProvision.commit(session.sessionId)
-      provisionalSession = undefined
-      this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      primaryIdentityReservation = undefined
-      // Route and bearer ownership is now represented by the committed app-session maps. End the
-      // provisional rollback window before invoking external observers so their failures cannot tear
-      // down a Session that has already been published.
-      capabilityProvision = undefined
-      try {
-        this.notebookOptions?.registerSessionSpecialist?.(session.sessionId, request.specialistId)
-      } catch (error) {
-        safeLogError('register session specialist failed', {
-          ...diagnosticErrorFields(error),
-          sessionId: session.sessionId
-        })
-      }
-      this.snapshotOwner.updateCwd(sessionCwd)
-      try {
-        this.pushEvent({
-          kind: 'system',
-          level: 'info',
-          sessionId: session.sessionId,
-          title: 'Session created',
-          text: sessionCwd
-        })
-      } catch (error) {
-        safeLogError('session created event callback failed', {
-          ...diagnosticErrorFields(error),
-          sessionId: session.sessionId
-        })
-      }
-      try {
-        this.emitState()
-      } catch (error) {
-        safeLogError('session created state callback failed', {
-          ...diagnosticErrorFields(error),
-          sessionId: session.sessionId
-        })
-      }
-
-      log.info('createSession: completed successfully', this.diagnosticContext())
-      return {
-        sessionId: session.sessionId,
-        cwd: sessionCwd,
-        frameworkId: this.framework.id,
-        ...(this.backendId ? { backendId: this.backendId } : {})
-      }
-    } catch (error) {
-      let startupError = error
-      if (primaryIdentityReservation) {
-        try {
-          this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
-        } catch (supersededError) {
-          startupError = supersededError
-        }
-      }
-      if (provisionalSession) {
-        this.disposeSessionAfterFailure(
-          provisionalSession,
-          'primary startup session disposal failed'
-        )
-      }
-      capabilityProvision?.release({ ownsStableIdentity: true })
-      safeLogError('createSession: failed', {
-        ...diagnosticErrorFields(startupError),
-        ...this.diagnosticContext()
-      })
-      throw startupError
-    } finally {
-      if (primaryIdentityReservation) {
-        this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      }
-    }
+    return this.withOperationLease(() => this.providerSessionCreator.create(request))
   }
 
   // Registers a freshly-built agent session under an app-facing id (used when adopting a conversation


### PR DESCRIPTION
## Problem

Fresh provider Session creation still lived inside the `AcpRuntime` facade. The facade directly sequenced Specialist presentation, Session capability provisioning, provider `session/new`, Permission/model/effort configuration, Registry publication, Notebook projection, event publication, and rollback of provisional resources.

That left transaction ownership and cleanup knowledge in the facade, while making the interaction between fresh Session creation and the model/provider hot-switch workflow from #751 difficult to reason about.

Related: #458

## Proposed change

- add `AcpProviderSessionCreator` with one `create(request)` operation;
- move Specialist/presentation preflight, capability provisioning, provider `session/new`, configuration, Registry publication, capability commit, post-publication observers, and pre-publication rollback into the creator;
- keep the provider-returned Session ID as the stable application Session ID for fresh creation;
- preserve Runtime's reconnect-aware identity-reservation policy behind a narrow `reserveIdentity` hook;
- preserve #751 model/provider hot-switch admission through the existing Runtime operation lease;
- build prompt tooling guidance from the same effective descriptor returned by capability provisioning, avoiding a second dynamic Skill Import availability snapshot;
- re-read the immutable backend generation view after `session/new` and replay configuration when a concurrent live-effort update overlaps the provider request, then synchronously publish the stable result;
- reduce `AcpRuntime.createSession` to the existing operation lease plus creator delegation.

Production raw churn is 479 lines (`provider-session-creator.ts`: +265; `runtime.ts`: +23/-191), within the approved 550-line ARD leaf limit. `runtime.ts` decreases from 3,984 to 3,816 physical lines.

## Scope and non-goals

This is an internal, behavior-preserving ownership refactor.

- Architecture: creation transaction ownership moves from the facade to one internal owner; no new public orchestration owner or #458 interface is introduced.
- Data model and relationships: no Prisma schema, migration, persistence, Session JSON, identifier, or relationship changes.
- User interaction: no UI, command, prompt, event payload, error-copy, or workflow change.
- Cross-surface contracts: no IPC, preload, Web RPC, Task HTTP/WebSocket, CLI, or SDK contract changes.
- Compatibility: existing Electron/Web/CLI capability asymmetry is unchanged. Specialist, Permission, Compute, Reviewer, Artifact, and Notebook behavior remains as implemented today.
- Transport: no Registry, Capability, Configurator, Presentation, connection, or provider transport implementation changes.

## Ownership and sequence

```mermaid
sequenceDiagram
  participant Runtime as AcpRuntime
  participant Creator as AcpProviderSessionCreator
  participant Capability as AcpSessionCapabilityOwner
  participant Provider as ACP provider
  participant Config as AcpSessionConfigurator
  participant Registry as AcpSessionRegistry
  participant Observers as Notebook / events / state

  Runtime->>Creator: create(request) under operation lease
  Creator->>Creator: resolve cwd, project, Specialist
  Creator->>Capability: provision provisional capability
  Capability-->>Creator: MCP servers + effective descriptor
  Creator->>Creator: build presentation from effective descriptor
  Creator->>Provider: session/new
  Provider-->>Creator: provisional provider Session
  Creator->>Runtime: reserveIdentity(provider ID, startup generation)
  Runtime->>Registry: apply reconnect-aware reservation policy
  Creator->>Config: configure Permission → model → effort
  Creator->>Creator: compare current immutable backend view
  alt live effort changed during provider request
    Creator->>Config: replay against latest backend view
  end
  Creator->>Registry: synchronously publish stable App Session
  Creator->>Capability: commit(App Session ID)
  Creator->>Observers: publish post-commit callbacks

  Note over Creator,Registry: Before publication, Creator disposes the Session and releases capability on failure
  Note over Registry,Observers: After publication, observer failures do not roll back the Session
```

## Acceptance criteria and validation

All commands below ran after the last material edit on local head `a1434fcce08cdaa557eb36a53b743a1110c0d363`, rebased onto `origin/main` `2498ad3452232003a9aa81e12cbf05bdb6da6aee`.

- Creator ownership, effective capability/presentation snapshot, ordering, cleanup, callback isolation, Runtime creation/collision/supersession/reconnect-barrier behavior, and #751 cross-races → `npm test -- --run src/main/acp/provider-session-creator.test.ts src/main/acp/runtime.test.ts` → 423/423 passed.
- Capability/presentation contracts, model-change, connection-close/resource, backend-generation, session-configurator, coordinator, workspace, and Specialist consumers → `npm test -- --run src/main/acp/session-capability-owner.test.ts src/main/acp/session-presentation-policy.test.ts src/main/acp/model-change-workflow.test.ts src/main/acp/connection-close-workflow.test.ts src/main/acp/connection-resource-owner.test.ts src/main/acp/backend-generation-owner.test.ts src/main/acp/session-configurator.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/managed-session-workspace.test.ts src/main/acp/workspace-path.test.ts src/main/specialist/specialist-identity-injection.test.ts` → 150/150 passed.
- Concurrent hot-switch compatibility → dedicated tests prove a queued model change blocks new creation, an in-progress creation joins the subsequent model drain, and a live-effort update overlapping provider configuration is replayed before publication.
- Affected Node process types → `npm run typecheck:node` → passed.
- #753 dependency patch-integrity baseline → `npm run check:claude-acp-patch` → passed for `@agentclientprotocol/claude-agent-acp@0.60.0`.
- Changed-file lint → targeted ESLint command → passed with 0 findings.
- Repository lint policy → `npm run lint` → passed with 0 errors and 17 pre-existing warnings outside this diff.
- Formatting and patch hygiene → targeted `prettier --check` and `git diff --check` → passed.
- Independent final Standards and Spec/compatibility reviews → 0 actionable findings.

PR Gate remains authoritative for cross-platform and complete online validation. Local macOS exercised the portable Runtime suite, including loopback capability paths. Windows/Linux process and transport behavior is not changed directly and remains covered by selected online lanes.

## Review focus

- the single-use transition from provisional Session/capability ownership to Registry/Capability ownership;
- the reconnect-aware reservation hook remaining a Runtime policy seam rather than transition state owned by the creator;
- prompt tooling guidance and provisioned MCP servers sharing one effective capability descriptor;
- the immutable-backend stability loop preventing a concurrent live-effort update from publishing a stale Session without serializing unrelated generations;
- #751 model-change barrier compatibility in both orderings around `createSession`;
- collision and startup-supersession cleanup without touching a same-ID successor;
- Specialist fail-closed presentation and Permission → model → effort ordering;
- the post-publication point after which callback failures must not roll back the Session;
- confirmation that `AcpRuntime` remains a compatibility facade and does not retain a second creation workflow.

## Uncovered risks

- No local Windows/Linux process lane was run; CI owns those platform checks.
- No full local portable suite was run by agreement; the final impact set covers the changed owner, Runtime facade, #751 workflows, and known consumers, while PR Gate selects broader online coverage.
