### PR TITLE
feat(acp): make context replay agent aware

### DIFF
--- a/src/main/acp/attachment-content.ts
+++ b/src/main/acp/attachment-content.ts
@@ -165,33 +165,7 @@ export const isDatasetAttachment = (name: string, mimeType?: string): boolean =>
   )
 }
 
-// Raster image extensions that vision-capable agents can read as pixels, mapped to the MIME type to
-// inline them as. SVG is deliberately absent: it is vector/text, not a raster type the providers accept
-// as image content. Matches the accepted set in ACP_MESSAGE_IMAGE_MIME_TYPES.
-const IMAGE_EXTENSION_MIME = new Map<string, string>([
-  ['png', 'image/png'],
-  ['jpg', 'image/jpeg'],
-  ['jpeg', 'image/jpeg'],
-  ['gif', 'image/gif'],
-  ['webp', 'image/webp'],
-  ['avif', 'image/avif']
-])
-
-// The image MIME type to inline a file as, or undefined when it is not a supported raster image. A
-// concrete image/* MIME wins; a missing or generic MIME (browsers omit it for some drag/drop and paste
-// sources) falls back to the file extension — so a `.png` upload is still sent as pixels rather than a
-// bare file link the model can only reach by writing code. A concrete non-image MIME is authoritative.
-export const imageAttachmentMimeType = (name: string, mimeType?: string): string | undefined => {
-  const essence = mimeEssence(mimeType)
-
-  if (essence && essence.startsWith('image/')) {
-    return essence === 'image/svg+xml' ? undefined : essence
-  }
-
-  if (essence && !GENERIC_MIME_TYPES.has(essence)) return undefined
-
-  return IMAGE_EXTENSION_MIME.get(fileExtension(name))
-}
+export { imageAttachmentMimeType } from '../../shared/uploads'
 
 // Human-readable byte size for the notice (binary units, one decimal past KB).
 export const formatBytes = (bytes: number): string => {

--- a/src/main/acp/prompt-content-owner.test.ts
+++ b/src/main/acp/prompt-content-owner.test.ts
@@ -230,7 +230,7 @@ describe('AcpPromptContentOwner', () => {
       references: [],
       codexSkillInputs: [],
       skillImportEnabled: false,
-      fileTextBudget: 500
+      fileTextBudget: 2_000
     })
 
     const fileText = contentBlocks(result.content)
@@ -244,7 +244,7 @@ describe('AcpPromptContentOwner', () => {
     expect(fileText.join('\n')).toContain('END-TWO')
     expect(
       fileText.reduce((total, text) => total + estimateHistoryTokens(text), 0)
-    ).toBeLessThanOrEqual(500)
+    ).toBeLessThanOrEqual(2_000)
     expect(fileText.join('\n')).not.toContain('a'.repeat(1_000))
     expect(fileText.join('\n')).not.toContain('b'.repeat(1_000))
   })

--- a/src/main/acp/prompt-content-owner.test.ts
+++ b/src/main/acp/prompt-content-owner.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { UploadedAttachment } from '../../shared/uploads'
+import { estimateHistoryTokens } from '../../shared/history-preamble'
 import { UploadRepository } from '../uploads/repository'
 import { stageUploadFixtures } from '../uploads/repository.test-utils'
 import { createManagedFileReferenceResolver } from './file-reference-resolver'
@@ -165,16 +166,13 @@ describe('AcpPromptContentOwner', () => {
     expect(blocks.map((block) => block.type)).toEqual([
       'text',
       'image',
-      'resource',
+      'resource_link',
       'resource',
       'resource'
     ])
     expect(blocks[0]).toEqual({ type: 'text', text: 'combined prompt' })
     expect(blocks[1]).toMatchObject({ type: 'image', mimeType: 'image/png' })
-    expect(blocks[2]).toMatchObject({
-      type: 'resource',
-      resource: { text: 'history body' }
-    })
+    expect(blocks[2]).toMatchObject({ type: 'resource_link', name: 'history.txt' })
     expect(blocks[3]).toMatchObject({
       type: 'resource',
       resource: { text: 'current body' }
@@ -198,6 +196,57 @@ describe('AcpPromptContentOwner', () => {
       'default-project'
     )
     expect(result.turnInputs?.references).toEqual([reference])
+  })
+
+  it('shares one text budget across current files and keeps both ends of prose previews', async () => {
+    const root = await createRoot()
+    const uploads = new UploadRepository(root)
+    const staged = await stageUploadFixtures(uploads, {
+      files: [
+        {
+          name: 'one.txt',
+          mimeType: 'text/plain',
+          content: Buffer.from(`BEGIN-ONE\n${'a'.repeat(4_000)}\nEND-ONE`).toString('base64')
+        },
+        {
+          name: 'two.txt',
+          mimeType: 'text/plain',
+          content: Buffer.from(`BEGIN-TWO\n${'b'.repeat(4_000)}\nEND-TWO`).toString('base64')
+        }
+      ]
+    })
+    const owner = new AcpPromptContentOwner({
+      uploadRepository: uploads,
+      fileReferenceResolver: createManagedFileReferenceResolver({ uploads })
+    })
+
+    const result = await owner.prepare({
+      appSessionId: 'target-session',
+      projectId: 'default-project',
+      text: 'compare these files',
+      historyImages: [],
+      historyUploads: [],
+      currentUploads: staged,
+      references: [],
+      codexSkillInputs: [],
+      skillImportEnabled: false,
+      fileTextBudget: 500
+    })
+
+    const fileText = contentBlocks(result.content)
+      .filter((block): block is Extract<ContentBlock, { type: 'text' }> => block.type === 'text')
+      .slice(1)
+      .map((block) => block.text)
+    expect(fileText).toHaveLength(2)
+    expect(fileText.join('\n')).toContain('BEGIN-ONE')
+    expect(fileText.join('\n')).toContain('END-ONE')
+    expect(fileText.join('\n')).toContain('BEGIN-TWO')
+    expect(fileText.join('\n')).toContain('END-TWO')
+    expect(
+      fileText.reduce((total, text) => total + estimateHistoryTokens(text), 0)
+    ).toBeLessThanOrEqual(500)
+    expect(fileText.join('\n')).not.toContain('a'.repeat(1_000))
+    expect(fileText.join('\n')).not.toContain('b'.repeat(1_000))
   })
 
   it('finalizes a genuinely staged history upload for the target Session', async () => {
@@ -233,10 +282,7 @@ describe('AcpPromptContentOwner', () => {
       expect.objectContaining({ sessionId: 'target-session', id: stagedHistory.id })
     ])
     expect(contentBlocks(result.content)).toContainEqual(
-      expect.objectContaining({
-        type: 'resource',
-        resource: expect.objectContaining({ text: 'history body' })
-      })
+      expect.objectContaining({ type: 'resource_link', name: 'history.txt' })
     )
   })
 
@@ -276,10 +322,7 @@ describe('AcpPromptContentOwner', () => {
     })
 
     expect(contentBlocks(result.content)).toContainEqual(
-      expect.objectContaining({
-        type: 'resource',
-        resource: expect.objectContaining({ text: 'history body' })
-      })
+      expect.objectContaining({ type: 'resource_link', name: 'history.txt' })
     )
     expect(finalizeUploads).not.toHaveBeenCalled()
   })

--- a/src/main/acp/prompt-content-owner.test.ts
+++ b/src/main/acp/prompt-content-owner.test.ts
@@ -278,9 +278,7 @@ describe('AcpPromptContentOwner', () => {
       skillImportEnabled: false
     })
 
-    expect(result.turnInputs?.uploads).toEqual([
-      expect.objectContaining({ sessionId: 'target-session', id: stagedHistory.id })
-    ])
+    expect(result.turnInputs).toBeUndefined()
     expect(contentBlocks(result.content)).toContainEqual(
       expect.objectContaining({ type: 'resource_link', name: 'history.txt' })
     )
@@ -314,7 +312,7 @@ describe('AcpPromptContentOwner', () => {
       projectId: 'default-project',
       text: 'continue',
       historyImages: [],
-      historyUploads: [legacyHistory],
+      historyUploads: [{ ...legacyHistory, versionId: undefined }],
       currentUploads: [],
       references: [],
       codexSkillInputs: [],
@@ -324,6 +322,7 @@ describe('AcpPromptContentOwner', () => {
     expect(contentBlocks(result.content)).toContainEqual(
       expect.objectContaining({ type: 'resource_link', name: 'history.txt' })
     )
+    expect(result.turnInputs).toBeUndefined()
     expect(finalizeUploads).not.toHaveBeenCalled()
   })
 

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -206,14 +206,17 @@ class AcpPromptContentOwner {
     }
 
     const preparedContent = this.attachCodexSkillInputs(content, input.codexSkillInputs)
-    const hasTurnInputs = promptUploads.length > 0 || input.references.length > 0
+    const turnInputUploads = promptUploads.filter(
+      (upload, index) => index >= input.historyUploads.length || upload.versionId
+    )
+    const hasTurnInputs = turnInputUploads.length > 0 || input.references.length > 0
 
     return {
       content: preparedContent,
       ...(hasTurnInputs
         ? {
             turnInputs: {
-              uploads: promptUploads,
+              uploads: turnInputUploads,
               references: [...input.references]
             }
           }

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -5,7 +5,11 @@ import { pathToFileURL } from 'node:url'
 import type { AcpMessageImage } from '../../shared/acp'
 import type { FileReference } from '../../shared/artifacts'
 import { estimateHistoryTokens, truncateTextToEstimatedTokens } from '../../shared/history-preamble'
-import { PENDING_UPLOAD_SESSION_ID, type UploadedAttachment } from '../../shared/uploads'
+import {
+  imageAttachmentMimeType,
+  PENDING_UPLOAD_SESSION_ID,
+  type UploadedAttachment
+} from '../../shared/uploads'
 import { readBoundedManagedFilePreview } from '../managed-file-preview'
 import {
   buildImageContentData,
@@ -26,7 +30,6 @@ import {
   buildDatasetAttachmentNotice,
   buildDeferredMediaNotice,
   buildOversizedAttachmentNotice,
-  imageAttachmentMimeType,
   isDatasetAttachment,
   isTabularAttachment,
   isTextLikeAttachment,

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'node:url'
 
 import type { AcpMessageImage } from '../../shared/acp'
 import type { FileReference } from '../../shared/artifacts'
+import { estimateHistoryTokens, truncateTextToEstimatedTokens } from '../../shared/history-preamble'
 import { PENDING_UPLOAD_SESSION_ID, type UploadedAttachment } from '../../shared/uploads'
 import { readBoundedManagedFilePreview } from '../managed-file-preview'
 import {
@@ -54,6 +55,7 @@ type PrepareAcpPromptContentInput = {
   references: ReadonlyArray<FileReference>
   codexSkillInputs: ReadonlyArray<CodexSkillInput>
   skillImportEnabled: boolean
+  fileTextBudget?: number
   skillImportTurnToken?: string
   onSkillImportAttachmentEligible?: (attachmentUri: string) => void
 }
@@ -75,6 +77,11 @@ type ResolvedPromptFile = {
   mimeType?: string
   size: number
   allowSkillImportReference: boolean
+}
+
+type PromptFileTextBudget = {
+  remaining: number
+  perFileLimit: number
 }
 
 const errorMessage = (error: unknown): string => {
@@ -110,6 +117,11 @@ class AcpPromptContentOwner {
         ? [{ type: 'text', text: input.text }]
         : []
       let imageBudget: InlineImageBudget = { imageCount: 0, base64Bytes: 0 }
+      const totalFileTextBudget = Math.max(1, Math.floor(input.fileTextBudget ?? 12_000))
+      const fileTextBudget: PromptFileTextBudget = {
+        remaining: totalFileTextBudget,
+        perFileLimit: Math.max(1, Math.floor(totalFileTextBudget / 2))
+      }
       const appendBlock = (block: ContentBlock, overflowFallback?: ContentBlock): void => {
         if (block.type === 'image') {
           try {
@@ -167,7 +179,8 @@ class AcpPromptContentOwner {
           const blocks = await this.createAttachmentContentBlocks(
             input,
             attachment,
-            index < input.historyUploads.length
+            index < input.historyUploads.length,
+            fileTextBudget
           )
           for (const block of blocks) {
             appendBlock(
@@ -179,7 +192,11 @@ class AcpPromptContentOwner {
       }
 
       for (const reference of input.references) {
-        const blocks = await this.createReferencedArtifactContentBlocks(input, reference)
+        const blocks = await this.createReferencedArtifactContentBlocks(
+          input,
+          reference,
+          fileTextBudget
+        )
         for (const block of blocks) {
           appendBlock(block, this.imageOverflowResourceLink(block, reference.name))
         }
@@ -244,7 +261,8 @@ class AcpPromptContentOwner {
   private async createAttachmentContentBlocks(
     input: PrepareAcpPromptContentInput,
     attachment: UploadedAttachment,
-    isHistoryUpload: boolean
+    isHistoryUpload: boolean,
+    fileTextBudget: PromptFileTextBudget
   ): Promise<ContentBlock[]> {
     if (!this.options.uploadRepository) throw new Error('Upload storage is not configured.')
 
@@ -257,31 +275,39 @@ class AcpPromptContentOwner {
     )
     const { size } = await stat(filePath)
 
-    return this.buildFileContentBlocks(input, {
-      absolutePath: filePath,
-      uri: pathToFileURL(filePath).href,
-      name: attachment.originalName || attachment.name,
-      mimeType: attachment.mimeType,
-      size,
-      allowSkillImportReference: true
-    })
+    return this.buildFileContentBlocks(
+      input,
+      {
+        absolutePath: filePath,
+        uri: pathToFileURL(filePath).href,
+        name: attachment.originalName || attachment.name,
+        mimeType: attachment.mimeType,
+        size,
+        allowSkillImportReference: true
+      },
+      fileTextBudget,
+      isHistoryUpload
+    )
   }
 
   private async createReferencedArtifactContentBlocks(
     input: PrepareAcpPromptContentInput,
-    reference: FileReference
+    reference: FileReference,
+    fileTextBudget: PromptFileTextBudget
   ): Promise<ContentBlock[]> {
     const resolvedReference = await this.options.fileReferenceResolver.resolve(
       { sessionId: input.appSessionId, projectId: input.projectId },
       reference
     )
 
-    return this.buildFileContentBlocks(input, resolvedReference)
+    return this.buildFileContentBlocks(input, resolvedReference, fileTextBudget, false)
   }
 
   private async buildFileContentBlocks(
     input: PrepareAcpPromptContentInput,
-    descriptor: ResolvedPromptFile
+    descriptor: ResolvedPromptFile,
+    fileTextBudget: PromptFileTextBudget,
+    isHistoryUpload: boolean
   ): Promise<ContentBlock[]> {
     const { absolutePath, uri, name, mimeType, size, allowSkillImportReference } = descriptor
 
@@ -313,6 +339,12 @@ class AcpPromptContentOwner {
         '</attached_local_file>'
       ].join('\n')
     })
+
+    // A replayed raster may still be required by the selected conversational turn. Every other
+    // historical file is a descriptor only: do not re-import archives or re-embed text/PDF bytes.
+    if (isHistoryUpload && !imageAttachmentMimeType(name, mimeType)) {
+      return [{ type: 'resource_link', uri, name, title: name, mimeType, size }]
+    }
 
     if (
       input.skillImportEnabled &&
@@ -379,36 +411,28 @@ class AcpPromptContentOwner {
           { type: 'resource_link', uri, name, title: name, mimeType: 'application/pdf', size }
         ]
       }
-      return [await this.createPdfContentBlock(name, absolutePath, uri)]
+      const block = await this.createPdfContentBlock(name, absolutePath, uri)
+      return this.admitTextResource(block, descriptor, fileTextBudget, false)
     }
 
     if (isTextLikeAttachment(name, mimeType)) {
       if (size <= MAX_EMBEDDED_TEXT_UPLOAD_BYTES) {
-        return [
-          {
-            type: 'resource',
-            resource: { uri, mimeType, text: await readFile(absolutePath, 'utf8') }
-          }
-        ]
-      }
-
-      const preview = await readBoundedManagedFilePreview(
-        absolutePath,
-        { path: absolutePath, maxBytes: ATTACHMENT_PREVIEW_BYTES, encoding: 'utf8' },
-        'Attachment preview requires UTF-8 encoding.'
-      )
-
-      return [
-        localFileTextReference(
-          buildOversizedAttachmentNotice({
-            name,
-            size,
-            preview: preview.content,
-            truncated: preview.truncated,
-            tabular: isTabularAttachment(name, mimeType)
-          })
+        const block: ContentBlock = {
+          type: 'resource',
+          resource: { uri, mimeType, text: await readFile(absolutePath, 'utf8') }
+        }
+        return this.admitTextResource(
+          block,
+          descriptor,
+          fileTextBudget,
+          isTabularAttachment(name, mimeType)
         )
-      ]
+      }
+      return this.createBudgetedTextPreview(
+        descriptor,
+        fileTextBudget,
+        isTabularAttachment(name, mimeType)
+      )
     }
 
     if (isDatasetAttachment(name, mimeType)) {
@@ -416,6 +440,107 @@ class AcpPromptContentOwner {
     }
 
     return [{ type: 'resource_link', uri, name, title: name, mimeType, size }]
+  }
+
+  private async admitTextResource(
+    block: ContentBlock,
+    descriptor: ResolvedPromptFile,
+    budget: PromptFileTextBudget,
+    tabular: boolean
+  ): Promise<ContentBlock[]> {
+    if (block.type !== 'resource' || !('text' in block.resource)) return [block]
+
+    const cost = estimateHistoryTokens(block.resource.text)
+    const allowance = Math.min(budget.remaining, budget.perFileLimit)
+    if (cost <= allowance) {
+      budget.remaining -= cost
+      return [block]
+    }
+
+    return this.createBudgetedTextPreview(descriptor, budget, tabular, block.resource.text)
+  }
+
+  private async createBudgetedTextPreview(
+    descriptor: ResolvedPromptFile,
+    budget: PromptFileTextBudget,
+    tabular: boolean,
+    sourceText?: string
+  ): Promise<ContentBlock[]> {
+    const { absolutePath, uri, name, mimeType, size } = descriptor
+    const fallback: ContentBlock[] = [
+      { type: 'resource_link', uri, name, title: name, mimeType, size }
+    ]
+    const allowance = Math.min(budget.remaining, budget.perFileLimit)
+    if (allowance <= 0) return fallback
+
+    const toBlock = (preview: string): Extract<ContentBlock, { type: 'text' }> => ({
+      type: 'text',
+      text: [
+        buildOversizedAttachmentNotice({
+          name,
+          size,
+          preview,
+          truncated: true,
+          tabular
+        }),
+        '<attached_local_file>',
+        JSON.stringify({ name, uri, mimeType, size }),
+        '</attached_local_file>'
+      ].join('\n')
+    })
+    const fixedCost = estimateHistoryTokens(toBlock('').text)
+    if (fixedCost >= allowance) return fallback
+
+    const previewBudget = allowance - fixedCost
+    let rawPreview: string
+    if (sourceText !== undefined) {
+      rawPreview = sourceText
+    } else {
+      const previewBytes = Math.min(ATTACHMENT_PREVIEW_BYTES, Math.max(256, previewBudget * 3))
+      const startBytes = tabular ? previewBytes : Math.ceil(previewBytes / 2)
+      const start = await readBoundedManagedFilePreview(
+        absolutePath,
+        { path: absolutePath, maxBytes: startBytes, encoding: 'utf8' },
+        'Attachment preview requires UTF-8 encoding.'
+      )
+      if (tabular) {
+        rawPreview = start.content
+      } else {
+        const endBytes = Math.max(1, previewBytes - startBytes)
+        const end = await readBoundedManagedFilePreview(
+          absolutePath,
+          {
+            path: absolutePath,
+            offset: Math.max(0, size - endBytes),
+            maxBytes: endBytes,
+            encoding: 'utf8'
+          },
+          'Attachment preview requires UTF-8 encoding.'
+        )
+        rawPreview = `${start.content}\n\n[…middle of file omitted…]\n\n${end.content}`
+      }
+    }
+
+    let preview = truncateTextToEstimatedTokens(
+      rawPreview,
+      previewBudget,
+      tabular ? 'start' : 'both'
+    )
+    let block = toBlock(preview)
+    let cost = estimateHistoryTokens(block.text)
+    if (cost > allowance) {
+      preview = truncateTextToEstimatedTokens(
+        preview,
+        Math.max(0, previewBudget - (cost - allowance)),
+        tabular ? 'start' : 'both'
+      )
+      block = toBlock(preview)
+      cost = estimateHistoryTokens(block.text)
+    }
+    if (cost > allowance) return fallback
+
+    budget.remaining -= cost
+    return [block]
   }
 
   private imageOverflowResourceLink(

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -13,6 +13,7 @@ import { ArtifactRepository } from '../artifacts/repository'
 import type { ArtifactRunRegistry } from '../artifacts/run-registry'
 import { createLogger, errorLogFields } from '../logger'
 import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
+import type { NotebookHandoffContext } from '../notebook/runtime-service'
 import {
   runTaskNotificationInBackground,
   type TaskNotificationService
@@ -48,6 +49,7 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
   mcpEntryPath: string
   uploadRepository: UploadRepository
   notebookRpcServer: NotebookLocalRpcServer
+  peekNotebookHandoffContext?: (sessionId: string) => NotebookHandoffContext | undefined
   authorizeSkillImportReferencedUploads: (
     projectId: string,
     sessionId: string,
@@ -80,6 +82,7 @@ const createAcpRuntime = ({
   provenanceRepository,
   uploadRepository,
   notebookRpcServer,
+  peekNotebookHandoffContext,
   authorizeSkillImportReferencedUploads,
   settingsService,
   permissionGrantRegistry,
@@ -165,7 +168,8 @@ const createAcpRuntime = ({
             notebookRpcServer.registerSessionSpecialist(sessionId, specialistId),
           setArtifactProvenanceContext: (sessionId, context) =>
             notebookRpcServer.setArtifactProvenanceContext(sessionId, context),
-          registerTurnInputs: (request) => notebookRpcServer.registerNotebookTurnInputs(request)
+          registerTurnInputs: (request) => notebookRpcServer.registerNotebookTurnInputs(request),
+          peekHandoffContext: peekNotebookHandoffContext
         },
         skillImport: {
           mcpEntryPath,

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -2274,6 +2274,7 @@ describe('AcpRuntimeCoordinator', () => {
         sessionId: 'old-session',
         text: '[Auditor] fix this',
         historyPreamble: 'prior transcript',
+        contextReset: true,
         provenanceContext: { promptMessageId: expect.stringMatching(/^prompt-/u) }
       },
       'prompt-attempt-1'

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -817,8 +817,12 @@ class AcpRuntimeCoordinator {
         const contextReset = await ensureActivitySession(request.sessionId)
         const historyPreamble = options.session?.historyPreamble
         return this.dispatchPrompt(
-          contextReset && historyPreamble && !request.historyPreamble
-            ? { ...request, historyPreamble }
+          contextReset
+            ? {
+                ...request,
+                contextReset: true,
+                ...(historyPreamble && !request.historyPreamble ? { historyPreamble } : {})
+              }
             : request,
           undefined,
           'sendPrompt',

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2552,7 +2552,7 @@ describe('ACP runtime session management', () => {
     expect(receivedPrompts[0]).toMatchObject([
       { type: 'text', text: 'inspect all context' },
       { type: 'image', mimeType: 'image/png', data: historyImageData },
-      { type: 'resource', resource: { text: 'history upload' } },
+      { type: 'resource_link', name: 'history.txt' },
       { type: 'resource', resource: { text: 'current upload' } },
       { type: 'resource', resource: { text: 'mentioned upload' } }
     ])
@@ -10822,10 +10822,25 @@ describe('ACP runtime session management', () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['adopted-session-1'], { resumeNotFound: true })
     const messageEvents: Array<{ role?: string; text?: string }> = []
+    const peekHandoffContext = vi.fn(() => ({
+      executionCount: 2,
+      cells: [{ id: 'cell-1', language: 'python' as const, status: 'completed' as const }],
+      kernels: [{ kind: 'python' as const, status: 'idle' as const }],
+      runtimes: []
+    }))
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:1/notebook',
+          token: 'notebook-token'
+        }),
+        peekHandoffContext
+      },
       callbacks: {
         onEvent: (event) => {
           if (event.kind === 'message' && event.role === 'user') {
@@ -10844,6 +10859,8 @@ describe('ACP runtime session management', () => {
 
     // The agent sees the replayed context ahead of the user's text...
     expect(fakeAgent.prompts[0]?.text).toContain('PRIOR CONTEXT: the user asked to plot data.')
+    expect(fakeAgent.prompts[0]?.text).toContain('<open_science_notebook_continuity>')
+    expect(fakeAgent.prompts[0]?.text).toContain('"executionCount":2')
     expect(fakeAgent.prompts[0]?.text).toContain('keep going')
     // ...but the conversation bubble records only what the user actually typed.
     expect(messageEvents).toEqual([{ role: 'user', text: 'keep going' }])
@@ -10859,6 +10876,10 @@ describe('ACP runtime session management', () => {
       framework: 'claude-code',
       status: 'connected'
     })
+
+    await runtime.sendPrompt({ sessionId: 'switched-session', text: 'ordinary continuation' })
+    expect(peekHandoffContext).toHaveBeenCalledOnce()
+    expect(fakeAgent.prompts[1]?.text).not.toContain('<open_science_notebook_continuity>')
   })
 
   it('sends an app-owned continuation without publishing its synthetic text as a user message', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -10882,6 +10882,43 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.prompts[1]?.text).not.toContain('<open_science_notebook_continuity>')
   })
 
+  it('hands off live Notebook state after a context reset with no replayable transcript', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['session-1'])
+    const peekHandoffContext = vi.fn(() => ({
+      executionCount: 1,
+      cells: [{ id: 'cell-1', language: 'python' as const, status: 'completed' as const }],
+      kernels: [{ kind: 'python' as const, status: 'idle' as const }],
+      runtimes: []
+    }))
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      notebook: {
+        projectName: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({
+          endpoint: 'http://127.0.0.1:1/notebook',
+          token: 'notebook-token'
+        }),
+        peekHandoffContext
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await runtime.sendPrompt({
+      sessionId: 'session-1',
+      text: 'retry the interrupted first turn',
+      contextReset: true
+    })
+
+    expect(peekHandoffContext).toHaveBeenCalledOnce()
+    expect(fakeAgent.prompts[0]?.text).toContain('<open_science_notebook_continuity>')
+    expect(fakeAgent.prompts[0]?.text).toContain('"executionCount":1')
+    expect(fakeAgent.prompts[0]?.text).not.toContain('Previous conversation')
+  })
+
   it('sends an app-owned continuation without publishing its synthetic text as a user message', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['session-1'], {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2195,6 +2195,7 @@ class AcpRuntime {
           request.historyPreamble = request.resumeFallback?.historyPreamble
           request.historyAttachments = request.resumeFallback?.historyAttachments
           request.historyImages = request.resumeFallback?.historyImages
+          request.contextReset = true
         }
 
         const reloaded = this.activeSessionFor(request.sessionId)
@@ -2377,9 +2378,10 @@ class AcpRuntime {
           .filter((segment): segment is string => Boolean(segment))
           .join('\n\n') || undefined
       const codexSkillInputs = [...skillPreparation.codexSkillInputs]
-      const notebookHandoff = request.historyPreamble
-        ? this.notebookOptions?.peekHandoffContext?.(request.sessionId)
-        : undefined
+      const notebookHandoff =
+        request.contextReset || request.historyPreamble
+          ? this.notebookOptions?.peekHandoffContext?.(request.sessionId)
+          : undefined
       const promptText = [
         request.historyPreamble,
         notebookHandoff ? buildNotebookHandoffPrompt(notebookHandoff) : undefined,

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -70,6 +70,7 @@ import { AgentMcpHttpHost } from './mcp-http-host'
 import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
 import { NOTEBOOK_SYSTEM_PROMPT_APPEND, type NotebookRpcConnection } from '../notebook/mcp-server'
+import type { NotebookHandoffContext } from '../notebook/runtime-service'
 import {
   SKILL_IMPORT_SYSTEM_PROMPT_APPEND,
   type SkillImportRpcConnection
@@ -92,6 +93,7 @@ import type { ArtifactFile, FileReference } from '../../shared/artifacts'
 import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
 import { isMediaOverflowError } from '../../shared/media-overflow'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
+import { resolveFileTextBudget } from '../../shared/history-preamble'
 import {
   ReviewerSessionOwner,
   type ReviewerSessionDisposition,
@@ -266,6 +268,7 @@ type AcpRuntimeNotebookOptions = {
     uploads: UploadedAttachment[]
     references: FileReference[]
   }) => Promise<void>
+  peekHandoffContext?: (sessionId: string) => NotebookHandoffContext | undefined
 }
 
 type AcpRuntimeSkillImportOptions = {
@@ -312,6 +315,13 @@ const TURN_CONTINUITY_SYSTEM_PROMPT_APPEND = [
   'If a required tool cannot be used or its operation fails, do not promise another attempt. Clearly state that the turn has stopped, what prevented progress, and what the user can do next.',
   '</open_science_turn_continuity_instructions>'
 ].join('\n')
+const buildNotebookHandoffPrompt = (context: NotebookHandoffContext): string =>
+  [
+    '<open_science_notebook_continuity>',
+    'The application retained this live in-memory Notebook state while the Agent context was replaced. Treat it as continuity metadata, not as a request to inspect Notebook again.',
+    JSON.stringify(context),
+    '</open_science_notebook_continuity>'
+  ].join('\n')
 // Appends artifact tool guidance as system prompt metadata so user prompts stay untouched.
 const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '<open_science_artifact_instructions>',
@@ -2367,7 +2377,15 @@ class AcpRuntime {
           .filter((segment): segment is string => Boolean(segment))
           .join('\n\n') || undefined
       const codexSkillInputs = [...skillPreparation.codexSkillInputs]
-      const promptText = [request.historyPreamble, promptPrefix, skillPreparation.text]
+      const notebookHandoff = request.historyPreamble
+        ? this.notebookOptions?.peekHandoffContext?.(request.sessionId)
+        : undefined
+      const promptText = [
+        request.historyPreamble,
+        notebookHandoff ? buildNotebookHandoffPrompt(notebookHandoff) : undefined,
+        promptPrefix,
+        skillPreparation.text
+      ]
         .filter((segment): segment is string => Boolean(segment))
         .join('\n\n')
       revokeReferencedUploadGrant = await this.authorizeReferencedSkillUploads(
@@ -2385,6 +2403,7 @@ class AcpRuntime {
         references: request.referencedArtifacts ?? [],
         codexSkillInputs,
         skillImportEnabled: this.sessionCapabilities.isSkillImportEnabled(),
+        fileTextBudget: resolveFileTextBudget(this.backend.context.window),
         skillImportTurnToken,
         onSkillImportAttachmentEligible: this.callbacks.onSkillImportAttachmentEligible
           ? (attachmentUri) => {

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -62,6 +62,7 @@ describe('ACP Task Agent port', () => {
       text: 'Continue the research.',
       skillIds: ['literature-review'],
       historyPreamble: 'Previous conversation.',
+      contextReset: true,
       resumeFallback: { historyPreamble: 'Fallback conversation.' }
     })
 
@@ -86,6 +87,7 @@ describe('ACP Task Agent port', () => {
       text: 'Continue the research.',
       forcedSkillIds: ['literature-review'],
       historyPreamble: 'Previous conversation.',
+      contextReset: true,
       resumeFallback: { historyPreamble: 'Fallback conversation.' }
     })
   })

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -22,6 +22,7 @@ const toAcpPromptRequest = (request: TaskAgentPromptRequest): AcpPromptRequest =
   text: request.text,
   ...(request.skillIds?.length ? { forcedSkillIds: request.skillIds } : {}),
   ...(request.historyPreamble ? { historyPreamble: request.historyPreamble } : {}),
+  ...(request.contextReset ? { contextReset: true } : {}),
   ...(request.resumeFallback ? { resumeFallback: request.resumeFallback } : {})
 })
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1040,6 +1040,7 @@ const createApplicationModules = async (
       provenanceRepository: artifactProvenanceRepository,
       uploadRepository,
       notebookRpcServer,
+      peekNotebookHandoffContext: (sessionId) => notebookService.peekHandoffContext(sessionId),
       authorizeSkillImportReferencedUploads: (projectId, sessionId, paths) =>
         conversationSkillImporter.authorizeReferencedUploads(projectId, sessionId, paths),
       settingsService,

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -142,6 +142,33 @@ const lifecycleCallbackHarness = (
 }
 
 describe('notebook runtime service', () => {
+  it('peeks only actionable in-memory handoff state without creating or reloading a Session', async () => {
+    const root = await createStorageRoot()
+    const { service } = lifecycleCallbackHarness(root)
+    const sessionRoot = join(root, 'notebooks', 'default-project', 'session-1')
+
+    expect(service.peekHandoffContext('session-1')).toBeUndefined()
+    expect(existsSync(sessionRoot)).toBe(false)
+
+    const begin = await service.beginCodeCell({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace'
+    })
+    const handoff = service.peekHandoffContext('session-1')
+
+    expect(handoff).toMatchObject({
+      executionCount: 0,
+      activeWriteCellId: begin.cellId,
+      cells: [{ id: begin.cellId, language: 'python', status: 'receiving-code' }]
+    })
+    expect(JSON.stringify(handoff)).not.toContain('notebookSessionRoot')
+    expect(JSON.stringify(handoff)).not.toContain('runtimeRoot')
+
+    await service.shutdownSession('session-1')
+    expect(service.peekHandoffContext('session-1')).toBeUndefined()
+  })
+
   it('streams agent code into a locked cell and runs it through the shared executor', async () => {
     const root = await createStorageRoot()
     const executions: NotebookExecutionRequest[] = []

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -210,6 +210,30 @@ type NotebookRuntimeServiceCallbacks = {
   onNotebookChanged?: (event: NotebookSessionReference) => void
 }
 
+type NotebookHandoffContext = {
+  activeRunId?: string
+  activeWriteCellId?: string
+  executionCount: number
+  cells: Array<{
+    id: string
+    language: NotebookLanguage
+    status: NotebookCell['status']
+    executionCount?: number
+    latestRunId?: string
+  }>
+  kernels: Array<{
+    kind: NotebookLanguage | 'repl'
+    status: NotebookKernelMetadata['lastKnownStatus']
+  }>
+  runtimes: Array<{
+    language: NotebookLanguage
+    label: string
+    version?: string
+    status?: NotebookRuntimeBinding['status']
+    reason?: NotebookRuntimeBinding['reason']
+  }>
+}
+
 // Provisioner-backed environment manager injected into the service (mirrors installPackagesImpl /
 // getPackageMirror injection). DefaultRuntimeProvisioner satisfies this structurally; tests inject a
 // fake so manageEnvironments never spawns real micromamba.
@@ -811,6 +835,60 @@ class NotebookRuntimeService {
   async executeShell(request: ExecuteShellRequest): Promise<NotebookShellResult> {
     const session = await this.ensureSession(request)
     return this.executionOwner.executeShell(session, request)
+  }
+
+  // Read-only handoff projection for a fresh Agent context. A missing aggregate means Notebook was
+  // never used (or was intentionally shut down for a Branch change), so this must not call
+  // ensureSession(), load run.json, discover runtimes, or create an executor.
+  peekHandoffContext(sessionId: string): NotebookHandoffContext | undefined {
+    const session = this.sessions.get(sessionId)
+    if (!session) return undefined
+
+    const snapshot = session.snapshot()
+    const kernels: NotebookHandoffContext['kernels'] = snapshot.kernelStatuses
+      .filter(([, status]) => status !== 'terminated')
+      .slice(-6)
+      .map(([processKey, status]) => ({
+        kind: processKey === 'repl' ? 'repl' : processKey.startsWith('r:') ? 'r' : 'python',
+        status
+      }))
+    const runtimes = session
+      .runtimeBindingEntries()
+      .slice(-4)
+      .map(([language, binding]) => ({
+        language,
+        label: binding.label,
+        ...(binding.version ? { version: binding.version } : {}),
+        ...(binding.status ? { status: binding.status } : {}),
+        ...(binding.reason ? { reason: binding.reason } : {})
+      }))
+    const cells = snapshot.cells.slice(-6).map((cell) => ({
+      id: cell.id,
+      language: cell.language,
+      status: cell.status,
+      ...(cell.executionCount === undefined ? {} : { executionCount: cell.executionCount }),
+      ...(cell.latestRunId ? { latestRunId: cell.latestRunId } : {})
+    }))
+
+    if (
+      snapshot.executionCount === 0 &&
+      !snapshot.activeRunId &&
+      !snapshot.activeWrite &&
+      cells.length === 0 &&
+      kernels.length === 0 &&
+      runtimes.length === 0
+    ) {
+      return undefined
+    }
+
+    return {
+      executionCount: snapshot.executionCount,
+      ...(snapshot.activeRunId ? { activeRunId: snapshot.activeRunId } : {}),
+      ...(snapshot.activeWrite ? { activeWriteCellId: snapshot.activeWrite.cellId } : {}),
+      cells,
+      kernels,
+      runtimes
+    }
   }
 
   // Returns the current in-memory cells plus the complete persisted run history.
@@ -2266,6 +2344,7 @@ export type {
   NotebookExecutor,
   NotebookExecutorLifecycleCallbacks,
   NotebookEnvironmentManager,
+  NotebookHandoffContext,
   NotebookRuntimeServiceCallbacks,
   NotebookRuntimeServiceOptions
 }

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -385,6 +385,7 @@ describe('TaskRunner', () => {
       {
         sessionId: existing.id,
         text: 'Follow-up question',
+        contextReset: true,
         historyPreamble:
           'Previous conversation:\n\nUser: Initial question\n\nAssistant: Initial answer'
       }

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -76,6 +76,7 @@ type TaskAgentPromptRequest = {
   text: string
   skillIds?: string[]
   historyPreamble?: string
+  contextReset?: boolean
   resumeFallback?: { historyPreamble?: string }
 }
 
@@ -341,6 +342,7 @@ class TaskRunner {
       request,
       prompt,
       prepared.historyPreamble,
+      prepared.contextReset,
       prepared.resumeFallback
     ).finally(() => this.releaseSession(session.id, runId))
     return cloneRun(run)
@@ -382,6 +384,7 @@ class TaskRunner {
   ): Promise<{
     session: PersistedChatSession
     historyPreamble?: string
+    contextReset?: boolean
     resumeFallback?: TaskAgentPromptRequest['resumeFallback']
   }> {
     const now = this.dependencies.now()
@@ -452,6 +455,7 @@ class TaskRunner {
     return {
       session,
       historyPreamble: sessionInfo.contextReset ? previousHistoryPreamble : undefined,
+      contextReset: sessionInfo.contextReset,
       resumeFallback:
         request.skillIds?.length && previousHistoryPreamble
           ? { historyPreamble: previousHistoryPreamble }
@@ -465,6 +469,7 @@ class TaskRunner {
     request: StartTaskRunRequest,
     prompt: string,
     historyPreamble?: string,
+    contextReset?: boolean,
     resumeFallback?: TaskAgentPromptRequest['resumeFallback']
   ): Promise<void> {
     let promptError: unknown
@@ -474,6 +479,7 @@ class TaskRunner {
         text: prompt,
         ...(request.skillIds?.length ? { skillIds: request.skillIds } : {}),
         ...(historyPreamble ? { historyPreamble } : {}),
+        ...(contextReset ? { contextReset: true } : {}),
         ...(resumeFallback ? { resumeFallback } : {})
       })
     } catch (error) {

--- a/src/renderer/src/lib/acp/history-preamble.test.ts
+++ b/src/renderer/src/lib/acp/history-preamble.test.ts
@@ -218,6 +218,59 @@ describe('agent-aware history replay', () => {
     expect(attachmentIds).toContain('document-9')
   })
 
+  it('fills the upload cap with documents after omitting images for a text-only model', () => {
+    const messages = [
+      ...Array.from({ length: 10 }, (_, index) =>
+        message({
+          role: 'user',
+          content: `image turn ${index}`,
+          uploads: [
+            {
+              id: `image-${index}`,
+              versionId: `image-version-${index}`,
+              sessionId: 'session-1',
+              name: `image-${index}.png`,
+              originalName: `image-${index}.png`,
+              path: `/uploads/image-${index}.png`,
+              mimeType: index === 0 ? 'application/octet-stream' : 'image/png',
+              size: 10
+            }
+          ]
+        })
+      ),
+      ...Array.from({ length: 10 }, (_, index) =>
+        message({
+          role: 'user',
+          content: `document turn ${index}`,
+          uploads: [
+            {
+              id: `document-${index}`,
+              versionId: `document-version-${index}`,
+              sessionId: 'session-1',
+              name: `document-${index}.txt`,
+              originalName: `document-${index}.txt`,
+              path: `/uploads/document-${index}.txt`,
+              mimeType: 'text/plain',
+              size: 10
+            }
+          ]
+        })
+      )
+    ]
+
+    const replay = buildWorkspaceHistoryReplay(
+      messages,
+      { target: 'claude-code' },
+      'project-1',
+      false
+    )!
+
+    expect(replay.historyAttachments.map((attachment) => attachment.id)).toEqual(
+      Array.from({ length: 10 }, (_, index) => `document-${index}`)
+    )
+    expect(replay.historyImages).toEqual([])
+  })
+
   it('keeps media-only Assistant output when an oversized turn is projected', () => {
     const replay = buildWorkspaceHistoryReplay(
       [

--- a/src/renderer/src/lib/acp/history-preamble.test.ts
+++ b/src/renderer/src/lib/acp/history-preamble.test.ts
@@ -144,6 +144,16 @@ describe('agent-aware history replay', () => {
                   path: `/uploads/plot-${turn}.png`,
                   mimeType: 'image/png',
                   size: 10
+                },
+                {
+                  id: `document-${turn}`,
+                  versionId: `document-version-${turn}`,
+                  sessionId: 'session-1',
+                  name: `notes-${turn}.pdf`,
+                  originalName: `notes-${turn}.pdf`,
+                  path: `/uploads/notes-${turn}.pdf`,
+                  mimeType: 'application/pdf',
+                  size: 20
                 }
               ]
             : undefined
@@ -158,7 +168,27 @@ describe('agent-aware history replay', () => {
 
     expect(replay.historyPreamble).toContain('user-9 ')
     expect(replay.historyPreamble).not.toContain('user-4 ')
-    expect(replay.historyAttachments.map((item) => item.id)).toEqual(['upload-9'])
+    expect(replay.historyAttachments.map((item) => item.id)).toEqual(['upload-9', 'document-9'])
+  })
+
+  it('keeps media-only Assistant output when an oversized turn is projected', () => {
+    const replay = buildWorkspaceHistoryReplay(
+      [
+        message({ role: 'user', content: 'original task' }),
+        message({ role: 'agent', content: 'original answer' }),
+        message({ role: 'user', content: 'keep the generated screenshot' }),
+        message({ role: 'agent', content: 'working '.repeat(300) }),
+        message({
+          role: 'agent',
+          content: '',
+          images: [{ id: 'result-image', mimeType: 'image/png', data: 'AQID', byteLength: 3 }]
+        })
+      ],
+      { target: 'codex-bridge', budget: 230 }
+    )!
+
+    expect(replay.historyPreamble).toContain('**Assistant:** [media attached]')
+    expect(replay.historyImages).toEqual([expect.objectContaining({ data: 'AQID' })])
   })
 })
 

--- a/src/renderer/src/lib/acp/history-preamble.test.ts
+++ b/src/renderer/src/lib/acp/history-preamble.test.ts
@@ -6,7 +6,8 @@ import {
   buildWorkspaceHistoryReplay,
   estimateHistoryTokens,
   resolveHistoryReplayBudget,
-  resolveHistoryReplayTarget
+  resolveHistoryReplayTarget,
+  resolveSessionHistoryReplayDescriptor
 } from './history-preamble'
 import type { ChatMessage } from '../../stores/session-store'
 import type { AgentFrameworkView, ProviderView } from '../../../../shared/settings'
@@ -67,6 +68,14 @@ describe('agent-aware history replay', () => {
     expect(resolveHistoryReplayBudget({ target: 'codex-bridge', contextWindow: 100_000 })).toBe(
       5_000
     )
+  })
+
+  it('uses the conservative bridge cap when a caller omits its runtime descriptor', () => {
+    const preamble = buildHistoryPreamble([
+      message({ role: 'user', content: 'large history '.repeat(2_000) })
+    ])!
+
+    expect(estimateHistoryTokens(preamble)).toBeLessThanOrEqual(8_000)
   })
 
   it('keeps the original task and a contiguous recent suffix without orphan replies', () => {
@@ -310,5 +319,39 @@ describe('history replay target resolution', () => {
       'codex-response'
     )
     expect(resolveHistoryReplayTarget('codex', provider(['openai']), codex)).toBe('codex-bridge')
+  })
+
+  it('derives persisted session policy from its backend instead of active settings', () => {
+    const bridgeProvider = {
+      id: 'persisted-provider',
+      apiEndpoints: ['openai'],
+      contextWindow: 100_000
+    } as ProviderView
+
+    expect(
+      resolveSessionHistoryReplayDescriptor(
+        {
+          agentFrameworkId: 'codex',
+          agentBackendId: 'codex:persisted-provider',
+          agentModel: 'persisted-model'
+        },
+        [bridgeProvider],
+        [codex]
+      )
+    ).toEqual({ target: 'codex-bridge', contextWindow: 100_000 })
+  })
+
+  it('falls back to the conservative bridge policy when a persisted Codex provider is gone', () => {
+    expect(
+      resolveSessionHistoryReplayDescriptor(
+        {
+          agentFrameworkId: 'codex',
+          agentBackendId: 'codex:removed-provider',
+          agentModel: 'persisted-model'
+        },
+        [],
+        [codex]
+      )
+    ).toEqual({ target: 'codex-bridge', contextWindow: undefined })
   })
 })

--- a/src/renderer/src/lib/acp/history-preamble.test.ts
+++ b/src/renderer/src/lib/acp/history-preamble.test.ts
@@ -171,6 +171,53 @@ describe('agent-aware history replay', () => {
     expect(replay.historyAttachments.map((item) => item.id)).toEqual(['upload-9', 'document-9'])
   })
 
+  it('reserves capped upload replay for an older selected image before recent documents', () => {
+    const messages = [
+      message({
+        role: 'user',
+        content: 'original task with image',
+        uploads: [
+          {
+            id: 'original-image',
+            versionId: 'original-image-version',
+            sessionId: 'session-1',
+            name: 'original.png',
+            originalName: 'original.png',
+            path: '/uploads/original.png',
+            mimeType: 'image/png',
+            size: 10
+          }
+        ]
+      }),
+      ...Array.from({ length: 10 }, (_, index) =>
+        message({
+          role: 'user',
+          content: `document turn ${index}`,
+          uploads: [
+            {
+              id: `document-${index}`,
+              versionId: `document-version-${index}`,
+              sessionId: 'session-1',
+              name: `document-${index}.txt`,
+              originalName: `document-${index}.txt`,
+              path: `/uploads/document-${index}.txt`,
+              mimeType: 'text/plain',
+              size: 10
+            }
+          ]
+        })
+      )
+    ]
+
+    const replay = buildWorkspaceHistoryReplay(messages, { target: 'claude-code' }, 'project-1')!
+    const attachmentIds = replay.historyAttachments.map((attachment) => attachment.id)
+
+    expect(attachmentIds).toHaveLength(10)
+    expect(attachmentIds).toContain('original-image')
+    expect(attachmentIds).not.toContain('document-0')
+    expect(attachmentIds).toContain('document-9')
+  })
+
   it('keeps media-only Assistant output when an oversized turn is projected', () => {
     const replay = buildWorkspaceHistoryReplay(
       [

--- a/src/renderer/src/lib/acp/history-preamble.test.ts
+++ b/src/renderer/src/lib/acp/history-preamble.test.ts
@@ -1,13 +1,22 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildHistoryPreamble, buildHistoryReplayMedia } from './history-preamble'
+import {
+  buildHistoryPreamble,
+  buildHistoryReplay,
+  buildWorkspaceHistoryReplay,
+  estimateHistoryTokens,
+  resolveHistoryReplayBudget,
+  resolveHistoryReplayTarget
+} from './history-preamble'
 import type { ChatMessage } from '../../stores/session-store'
+import type { AgentFrameworkView, ProviderView } from '../../../../shared/settings'
 
+let messageId = 0
 const message = (
   partial: Partial<ChatMessage> & Pick<ChatMessage, 'role' | 'content'>
 ): ChatMessage =>
   ({
-    id: Math.random().toString(36).slice(2),
+    id: `message-${messageId++}`,
     status: 'complete',
     eventIds: [],
     createdAt: 0,
@@ -15,7 +24,7 @@ const message = (
     ...partial
   }) as ChatMessage
 
-describe('buildHistoryPreamble', () => {
+describe('agent-aware history replay', () => {
   it('returns undefined when there is nothing meaningful to replay', () => {
     expect(buildHistoryPreamble([])).toBeUndefined()
     expect(
@@ -26,91 +35,149 @@ describe('buildHistoryPreamble', () => {
     ).toBeUndefined()
   })
 
-  it('renders labelled user/assistant turns in order', () => {
+  it('renders labelled user-led turns in order and skips failed content', () => {
     const preamble = buildHistoryPreamble([
+      message({ role: 'agent', content: 'orphaned leading reply' }),
       message({ role: 'user', content: 'plot the data' }),
+      message({ role: 'agent', content: 'failed draft', status: 'error' }),
       message({ role: 'agent', content: 'done, see chart.png' })
     ])
 
     expect(preamble).toContain('before you joined it')
+    expect(preamble).not.toContain('orphaned leading reply')
+    expect(preamble).not.toContain('failed draft')
     expect(preamble).toContain('**User:** plot the data')
     expect(preamble).toContain('**Assistant:** done, see chart.png')
-    const userIndex = preamble!.indexOf('**User:**')
-    const agentIndex = preamble!.indexOf('**Assistant:**')
-    expect(userIndex).toBeLessThan(agentIndex)
+    expect(preamble!.indexOf('**User:**')).toBeLessThan(preamble!.indexOf('**Assistant:**'))
   })
 
-  it('skips failed and empty turns', () => {
-    const preamble = buildHistoryPreamble([
-      message({ role: 'user', content: 'first' }),
-      message({ role: 'agent', content: 'half a reply', status: 'error' }),
-      message({ role: 'user', content: 'second' })
-    ])
+  it('uses distinct budgets for all four target classes', () => {
+    expect(resolveHistoryReplayBudget({ target: 'claude-code' })).toBe(16_000)
+    expect(resolveHistoryReplayBudget({ target: 'opencode' })).toBe(12_000)
+    expect(resolveHistoryReplayBudget({ target: 'codex-response' })).toBe(16_000)
+    expect(resolveHistoryReplayBudget({ target: 'codex-bridge' })).toBe(8_000)
 
-    expect(preamble).not.toContain('half a reply')
-    expect(preamble).toContain('**User:** first')
-    expect(preamble).toContain('**User:** second')
-  })
-
-  it('keeps the most recent turns within budget and marks omissions', () => {
-    const messages = Array.from({ length: 10 }, (_, index) =>
-      message({
-        role: index % 2 === 0 ? 'user' : 'agent',
-        content: `turn-${index} ${'x'.repeat(50)}`
-      })
+    expect(resolveHistoryReplayBudget({ target: 'claude-code', contextWindow: 100_000 })).toBe(
+      10_000
     )
-
-    const preamble = buildHistoryPreamble(messages, 200)
-
-    expect(preamble).toContain('earlier turns omitted')
-    // The newest turn survives; the oldest is dropped.
-    expect(preamble).toContain('turn-9')
-    expect(preamble).not.toContain('turn-0 ')
-  })
-
-  it('hard-bounds a single oversized latest turn', () => {
-    const budget = 80
-    const preamble = buildHistoryPreamble(
-      [message({ role: 'user', content: `start-${'a'.repeat(500)}-end` })],
-      budget
+    expect(resolveHistoryReplayBudget({ target: 'opencode', contextWindow: 100_000 })).toBe(8_000)
+    expect(resolveHistoryReplayBudget({ target: 'codex-response', contextWindow: 100_000 })).toBe(
+      10_000
     )
-    const transcript = preamble?.split('\n\n').slice(1).join('\n\n') ?? ''
-
-    expect(transcript.length).toBeLessThanOrEqual(budget)
-    expect(transcript).toContain('-end')
-    expect(transcript).not.toContain('start-')
+    expect(resolveHistoryReplayBudget({ target: 'codex-bridge', contextWindow: 100_000 })).toBe(
+      5_000
+    )
   })
 
-  it('collects bounded recent image uploads and inline assistant images for replay', () => {
-    const media = buildHistoryReplayMedia(
+  it('keeps the original task and a contiguous recent suffix without orphan replies', () => {
+    const messages = Array.from({ length: 20 }, (_, turn) => [
+      message({ role: 'user', content: `user-${turn} ${'u'.repeat(80)}` }),
+      message({ role: 'agent', content: `assistant-${turn} ${'a'.repeat(80)}` })
+    ]).flat()
+    const replay = buildHistoryReplay(messages, { target: 'codex-bridge', budget: 360 })!
+
+    expect(replay.estimatedTokens).toBeLessThanOrEqual(replay.budget)
+    expect(replay.preamble).toContain('user-0 ')
+    expect(replay.preamble).toContain('user-19 ')
+    expect(replay.preamble).toContain('assistant-19 ')
+    expect(replay.preamble).toContain('middle turns omitted')
+    expect(replay.preamble).not.toContain('assistant-10 ')
+
+    const selectedRoles = replay.selectedMessageIndexes.map((index) => messages[index].role)
+    expect(selectedRoles[0]).toBe('user')
+    for (let index = 0; index < selectedRoles.length; index += 1) {
+      if (selectedRoles[index] === 'agent') expect(selectedRoles.slice(0, index)).toContain('user')
+    }
+  })
+
+  it('preserves both ends of a physically oversized user request inside its role', () => {
+    const replay = buildHistoryReplay(
+      [message({ role: 'user', content: `BEGIN-CONSTRAINT ${'界'.repeat(500)} END-CONSTRAINT` })],
+      { target: 'codex-bridge', budget: 190 }
+    )!
+
+    expect(replay.estimatedTokens).toBeLessThanOrEqual(190)
+    expect(replay.preamble).toContain('**User:** BEGIN-CONSTRAINT')
+    expect(replay.preamble).toContain('END-CONSTRAINT')
+    expect(replay.preamble).toContain('middle of this message omitted')
+  })
+
+  it('keeps a full latest user request plus a marked Assistant conclusion tail', () => {
+    const replay = buildHistoryReplay(
       [
-        message({
-          role: 'user',
-          content: 'look',
-          uploads: [
-            {
-              id: 'u1',
-              versionId: 'v1',
-              sessionId: 's1',
-              name: 'plot.png',
-              originalName: 'plot.png',
-              path: '/uploads/plot.png',
-              mimeType: 'image/png',
-              size: 10
-            }
-          ]
-        }),
+        message({ role: 'user', content: 'original task' }),
+        message({ role: 'agent', content: 'original response' }),
+        message({ role: 'user', content: 'please finish the analysis' }),
         message({
           role: 'agent',
-          content: '',
-          images: [{ id: 'i1', mimeType: 'image/png', data: 'aGVsbG8=', byteLength: 5 }]
+          content: `${'working '.repeat(300)}FINAL-CONCLUSION`
         })
       ],
-      'project-1'
-    )
+      { target: 'codex-bridge', budget: 230 }
+    )!
 
-    expect(media.attachments.map((item) => item.id)).toEqual(['u1'])
-    expect(media.attachments[0].path).toBe('upload-version:project-1/s1/v1')
-    expect(media.images).toHaveLength(1)
+    expect(replay.estimatedTokens).toBeLessThanOrEqual(230)
+    expect(replay.preamble).toContain('**User:** please finish the analysis')
+    expect(replay.preamble).toContain('earlier response omitted')
+    expect(replay.preamble).toContain('FINAL-CONCLUSION')
+  })
+
+  it('counts CJK conservatively', () => {
+    expect(estimateHistoryTokens('a'.repeat(40))).toBe(10)
+    expect(estimateHistoryTokens('界'.repeat(40))).toBe(40)
+  })
+
+  it('replays media only from text-selected messages', () => {
+    const turns = Array.from({ length: 10 }, (_, turn) => [
+      message({
+        role: 'user',
+        content: `user-${turn} ${'x'.repeat(100)}`,
+        uploads:
+          turn === 4 || turn === 9
+            ? [
+                {
+                  id: `upload-${turn}`,
+                  versionId: `version-${turn}`,
+                  sessionId: 'session-1',
+                  name: `plot-${turn}.png`,
+                  originalName: `plot-${turn}.png`,
+                  path: `/uploads/plot-${turn}.png`,
+                  mimeType: 'image/png',
+                  size: 10
+                }
+              ]
+            : undefined
+      }),
+      message({ role: 'agent', content: `assistant-${turn} ${'y'.repeat(100)}` })
+    ]).flat()
+    const replay = buildWorkspaceHistoryReplay(
+      turns,
+      { target: 'codex-bridge', budget: 280 },
+      'project-1'
+    )!
+
+    expect(replay.historyPreamble).toContain('user-9 ')
+    expect(replay.historyPreamble).not.toContain('user-4 ')
+    expect(replay.historyAttachments.map((item) => item.id)).toEqual(['upload-9'])
+  })
+})
+
+describe('history replay target resolution', () => {
+  const provider = (apiEndpoints: ProviderView['apiEndpoints']): ProviderView =>
+    ({ apiEndpoints }) as ProviderView
+  const codex = {
+    id: 'codex',
+    displayName: 'Codex',
+    supportsSkills: true,
+    supportedApiTypes: ['responses']
+  } as AgentFrameworkView
+
+  it('uses the provider endpoint contract to distinguish direct Responses and bridge Codex', () => {
+    expect(resolveHistoryReplayTarget('claude-code')).toBe('claude-code')
+    expect(resolveHistoryReplayTarget('opencode')).toBe('opencode')
+    expect(resolveHistoryReplayTarget('codex', provider(['responses']), codex)).toBe(
+      'codex-response'
+    )
+    expect(resolveHistoryReplayTarget('codex', provider(['openai']), codex)).toBe('codex-bridge')
   })
 })

--- a/src/renderer/src/lib/acp/history-preamble.test.ts
+++ b/src/renderer/src/lib/acp/history-preamble.test.ts
@@ -74,7 +74,7 @@ describe('agent-aware history replay', () => {
       message({ role: 'user', content: `user-${turn} ${'u'.repeat(80)}` }),
       message({ role: 'agent', content: `assistant-${turn} ${'a'.repeat(80)}` })
     ]).flat()
-    const replay = buildHistoryReplay(messages, { target: 'codex-bridge', budget: 360 })!
+    const replay = buildHistoryReplay(messages, { target: 'codex-bridge', budget: 1_440 })!
 
     expect(replay.estimatedTokens).toBeLessThanOrEqual(replay.budget)
     expect(replay.preamble).toContain('user-0 ')
@@ -93,10 +93,10 @@ describe('agent-aware history replay', () => {
   it('preserves both ends of a physically oversized user request inside its role', () => {
     const replay = buildHistoryReplay(
       [message({ role: 'user', content: `BEGIN-CONSTRAINT ${'界'.repeat(500)} END-CONSTRAINT` })],
-      { target: 'codex-bridge', budget: 190 }
+      { target: 'codex-bridge', budget: 760 }
     )!
 
-    expect(replay.estimatedTokens).toBeLessThanOrEqual(190)
+    expect(replay.estimatedTokens).toBeLessThanOrEqual(760)
     expect(replay.preamble).toContain('**User:** BEGIN-CONSTRAINT')
     expect(replay.preamble).toContain('END-CONSTRAINT')
     expect(replay.preamble).toContain('middle of this message omitted')
@@ -113,18 +113,19 @@ describe('agent-aware history replay', () => {
           content: `${'working '.repeat(300)}FINAL-CONCLUSION`
         })
       ],
-      { target: 'codex-bridge', budget: 230 }
+      { target: 'codex-bridge', budget: 920 }
     )!
 
-    expect(replay.estimatedTokens).toBeLessThanOrEqual(230)
+    expect(replay.estimatedTokens).toBeLessThanOrEqual(920)
     expect(replay.preamble).toContain('**User:** please finish the analysis')
     expect(replay.preamble).toContain('earlier response omitted')
     expect(replay.preamble).toContain('FINAL-CONCLUSION')
   })
 
-  it('counts CJK conservatively', () => {
-    expect(estimateHistoryTokens('a'.repeat(40))).toBe(10)
-    expect(estimateHistoryTokens('界'.repeat(40))).toBe(40)
+  it('uses UTF-8 bytes as a conservative tokenizer-independent upper bound', () => {
+    expect(estimateHistoryTokens('a'.repeat(40))).toBe(40)
+    expect(estimateHistoryTokens('界'.repeat(40))).toBe(120)
+    expect(estimateHistoryTokens('😀'.repeat(10))).toBe(40)
   })
 
   it('replays media only from text-selected messages', () => {
@@ -162,7 +163,7 @@ describe('agent-aware history replay', () => {
     ]).flat()
     const replay = buildWorkspaceHistoryReplay(
       turns,
-      { target: 'codex-bridge', budget: 280 },
+      { target: 'codex-bridge', budget: 1_120 },
       'project-1'
     )!
 
@@ -284,7 +285,7 @@ describe('agent-aware history replay', () => {
           images: [{ id: 'result-image', mimeType: 'image/png', data: 'AQID', byteLength: 3 }]
         })
       ],
-      { target: 'codex-bridge', budget: 230 }
+      { target: 'codex-bridge', budget: 920 }
     )!
 
     expect(replay.historyPreamble).toContain('**Assistant:** [media attached]')

--- a/src/renderer/src/lib/acp/history-preamble.ts
+++ b/src/renderer/src/lib/acp/history-preamble.ts
@@ -45,18 +45,22 @@ export const buildHistoryReplayMedia = (
   messages: ChatMessage[],
   projectId?: string
 ): { attachments: UploadedAttachment[]; images: AcpMessageImage[] } => {
-  const attachments: UploadedAttachment[] = []
   const images: AcpMessageImage[] = []
   let imageBytes = 0
 
+  const uploads = messages.flatMap((message) => message.uploads ?? [])
+  const newestUploads = [...uploads].reverse()
+  const selectedUploads = [
+    ...newestUploads.filter((upload) => upload.mimeType?.startsWith('image/')),
+    ...newestUploads.filter((upload) => !upload.mimeType?.startsWith('image/'))
+  ].slice(0, MAX_COMPOSER_ATTACHMENTS)
+  const selectedUploadSet = new Set(selectedUploads)
+  const attachments = uploads
+    .filter((upload) => selectedUploadSet.has(upload))
+    .map((upload) => toRuntimeUploadedAttachment(upload, projectId))
+
   for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
     const message = messages[messageIndex]
-    for (let index = (message.uploads?.length ?? 0) - 1; index >= 0; index -= 1) {
-      const upload = message.uploads?.[index]
-      if (upload && attachments.length < MAX_COMPOSER_ATTACHMENTS) {
-        attachments.unshift(toRuntimeUploadedAttachment(upload, projectId))
-      }
-    }
     for (let index = (message.images?.length ?? 0) - 1; index >= 0; index -= 1) {
       const image = message.images?.[index]
       if (

--- a/src/renderer/src/lib/acp/history-preamble.ts
+++ b/src/renderer/src/lib/acp/history-preamble.ts
@@ -1,5 +1,10 @@
 import type { ChatMessage } from '../../stores/session-store'
 import {
+  buildHistoryReplay,
+  type HistoryReplayDescriptor,
+  type HistoryReplayTarget
+} from '../../../../shared/history-preamble'
+import {
   MAX_ACP_MESSAGE_IMAGE_BYTES_PER_MESSAGE,
   MAX_ACP_MESSAGE_IMAGES_PER_MESSAGE,
   type AcpMessageImage
@@ -9,7 +14,32 @@ import {
   toRuntimeUploadedAttachment,
   type UploadedAttachment
 } from '../../../../shared/uploads'
-export { buildHistoryPreamble } from '../../../../shared/history-preamble'
+import {
+  requiresChatCompletionsBridge,
+  type AgentFrameworkId,
+  type AgentFrameworkView,
+  type ProviderView
+} from '../../../../shared/settings'
+
+export const resolveHistoryReplayTarget = (
+  frameworkId: AgentFrameworkId | undefined,
+  provider?: ProviderView,
+  framework?: AgentFrameworkView
+): HistoryReplayTarget => {
+  if (frameworkId === 'opencode') return 'opencode'
+  if (frameworkId !== 'codex') return 'claude-code'
+  if (
+    provider &&
+    framework &&
+    requiresChatCompletionsBridge(provider, {
+      id: framework.id,
+      supportedApiTypes: framework.supportedApiTypes ?? ['responses']
+    })
+  ) {
+    return 'codex-bridge'
+  }
+  return 'codex-response'
+}
 
 export const buildHistoryReplayMedia = (
   messages: ChatMessage[],
@@ -42,3 +72,43 @@ export const buildHistoryReplayMedia = (
 
   return { attachments, images }
 }
+
+export const buildWorkspaceHistoryReplay = (
+  messages: ChatMessage[],
+  descriptor: HistoryReplayDescriptor,
+  projectId?: string
+):
+  | {
+      historyPreamble: string
+      historyAttachments: UploadedAttachment[]
+      historyImages: AcpMessageImage[]
+    }
+  | undefined => {
+  const replay = buildHistoryReplay(
+    messages.map((message) => ({
+      ...message,
+      hasReplayMedia: (message.images?.length ?? 0) > 0 || (message.uploads?.length ?? 0) > 0
+    })),
+    descriptor
+  )
+  if (!replay) return undefined
+
+  const selected = replay.selectedMessageIndexes.map((index) => messages[index]).filter(Boolean)
+  const media = buildHistoryReplayMedia(selected, projectId)
+  return {
+    historyPreamble: replay.preamble,
+    historyAttachments: media.attachments,
+    historyImages: media.images
+  }
+}
+
+export {
+  buildHistoryPreamble,
+  buildHistoryReplay,
+  estimateHistoryTokens,
+  resolveHistoryReplayBudget
+} from '../../../../shared/history-preamble'
+export type {
+  HistoryReplayDescriptor,
+  HistoryReplayTarget
+} from '../../../../shared/history-preamble'

--- a/src/renderer/src/lib/acp/history-preamble.ts
+++ b/src/renderer/src/lib/acp/history-preamble.ts
@@ -10,6 +10,7 @@ import {
   type AcpMessageImage
 } from '../../../../shared/acp'
 import {
+  imageAttachmentMimeType,
   MAX_COMPOSER_ATTACHMENTS,
   toRuntimeUploadedAttachment,
   type UploadedAttachment
@@ -43,17 +44,23 @@ export const resolveHistoryReplayTarget = (
 
 export const buildHistoryReplayMedia = (
   messages: ChatMessage[],
-  projectId?: string
+  projectId?: string,
+  supportsImageInput?: boolean
 ): { attachments: UploadedAttachment[]; images: AcpMessageImage[] } => {
   const images: AcpMessageImage[] = []
   let imageBytes = 0
 
   const uploads = messages.flatMap((message) => message.uploads ?? [])
   const newestUploads = [...uploads].reverse()
-  const selectedUploads = [
-    ...newestUploads.filter((upload) => upload.mimeType?.startsWith('image/')),
-    ...newestUploads.filter((upload) => !upload.mimeType?.startsWith('image/'))
-  ].slice(0, MAX_COMPOSER_ATTACHMENTS)
+  const imageUploads = newestUploads.filter((upload) =>
+    imageAttachmentMimeType(upload.name, upload.mimeType)
+  )
+  const fileUploads = newestUploads.filter(
+    (upload) => !imageAttachmentMimeType(upload.name, upload.mimeType)
+  )
+  const selectedUploads = (
+    supportsImageInput === false ? fileUploads : [...imageUploads, ...fileUploads]
+  ).slice(0, MAX_COMPOSER_ATTACHMENTS)
   const selectedUploadSet = new Set(selectedUploads)
   const attachments = uploads
     .filter((upload) => selectedUploadSet.has(upload))
@@ -61,6 +68,7 @@ export const buildHistoryReplayMedia = (
 
   for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
     const message = messages[messageIndex]
+    if (supportsImageInput === false) continue
     for (let index = (message.images?.length ?? 0) - 1; index >= 0; index -= 1) {
       const image = message.images?.[index]
       if (
@@ -80,7 +88,8 @@ export const buildHistoryReplayMedia = (
 export const buildWorkspaceHistoryReplay = (
   messages: ChatMessage[],
   descriptor: HistoryReplayDescriptor,
-  projectId?: string
+  projectId?: string,
+  supportsImageInput?: boolean
 ):
   | {
       historyPreamble: string
@@ -98,7 +107,7 @@ export const buildWorkspaceHistoryReplay = (
   if (!replay) return undefined
 
   const selected = replay.selectedMessageIndexes.map((index) => messages[index]).filter(Boolean)
-  const media = buildHistoryReplayMedia(selected, projectId)
+  const media = buildHistoryReplayMedia(selected, projectId, supportsImageInput)
   return {
     historyPreamble: replay.preamble,
     historyAttachments: media.attachments,

--- a/src/renderer/src/lib/acp/history-preamble.ts
+++ b/src/renderer/src/lib/acp/history-preamble.ts
@@ -53,7 +53,7 @@ export const buildHistoryReplayMedia = (
     const message = messages[messageIndex]
     for (let index = (message.uploads?.length ?? 0) - 1; index >= 0; index -= 1) {
       const upload = message.uploads?.[index]
-      if (upload?.mimeType?.startsWith('image/') && attachments.length < MAX_COMPOSER_ATTACHMENTS) {
+      if (upload && attachments.length < MAX_COMPOSER_ATTACHMENTS) {
         attachments.unshift(toRuntimeUploadedAttachment(upload, projectId))
       }
     }

--- a/src/renderer/src/lib/acp/history-preamble.ts
+++ b/src/renderer/src/lib/acp/history-preamble.ts
@@ -21,6 +21,7 @@ import {
   type AgentFrameworkView,
   type ProviderView
 } from '../../../../shared/settings'
+import { resolveModelContextWindow } from '../../../../shared/provider-registry'
 
 export const resolveHistoryReplayTarget = (
   frameworkId: AgentFrameworkId | undefined,
@@ -40,6 +41,36 @@ export const resolveHistoryReplayTarget = (
     return 'codex-bridge'
   }
   return 'codex-response'
+}
+
+export const resolveSessionHistoryReplayDescriptor = (
+  session: {
+    agentFrameworkId?: AgentFrameworkId
+    agentBackendId?: string
+    agentModel?: string
+  },
+  providers: ProviderView[],
+  frameworks: AgentFrameworkView[]
+): HistoryReplayDescriptor => {
+  const frameworkId = session.agentFrameworkId
+  const provider = providers.find(
+    (candidate) => session.agentBackendId === `${frameworkId}:${candidate.id}`
+  )
+  const framework = frameworks.find((candidate) => candidate.id === frameworkId)
+  const target =
+    frameworkId === 'codex' && (!provider || !framework)
+      ? 'codex-bridge'
+      : resolveHistoryReplayTarget(frameworkId, provider, framework)
+
+  return {
+    target,
+    contextWindow: provider?.vendorId
+      ? resolveModelContextWindow(
+          provider.vendorId,
+          session.agentModel ?? provider.model ?? provider.models[0]
+        )
+      : provider?.contextWindow
+  }
 }
 
 export const buildHistoryReplayMedia = (

--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -309,7 +309,9 @@ describe('useAcpRuntime payload construction', () => {
         'prior transcript',
         [attachment] as never,
         [image] as never,
-        resumeFallback as never
+        resumeFallback as never,
+        undefined,
+        true
       )
     })
 
@@ -320,7 +322,8 @@ describe('useAcpRuntime payload construction', () => {
       historyPreamble: 'prior transcript',
       historyAttachments: [attachment],
       historyImages: [image],
-      resumeFallback
+      resumeFallback,
+      contextReset: true
     })
   })
 
@@ -346,7 +349,8 @@ describe('useAcpRuntime payload construction', () => {
       'historyPreamble',
       'historyAttachments',
       'historyImages',
-      'resumeFallback'
+      'resumeFallback',
+      'contextReset'
     ]) {
       expect(field in payload).toBe(false)
     }

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -79,7 +79,8 @@ const useAcpRuntime = (): {
     historyAttachments?: AcpPromptRequest['historyAttachments'],
     historyImages?: AcpPromptRequest['historyImages'],
     resumeFallback?: AcpPromptRequest['resumeFallback'],
-    provenanceContext?: AcpPromptRequest['provenanceContext']
+    provenanceContext?: AcpPromptRequest['provenanceContext'],
+    contextReset?: AcpPromptRequest['contextReset']
   ) => Promise<AcpStateSnapshot>
   respondToPermission: (requestId: string, optionId?: string) => Promise<AcpStateSnapshot>
   setPermissionProfile: (
@@ -294,7 +295,8 @@ const useAcpRuntime = (): {
       historyAttachments?: AcpPromptRequest['historyAttachments'],
       historyImages?: AcpPromptRequest['historyImages'],
       resumeFallback?: AcpPromptRequest['resumeFallback'],
-      provenanceContext?: AcpPromptRequest['provenanceContext']
+      provenanceContext?: AcpPromptRequest['provenanceContext'],
+      contextReset?: AcpPromptRequest['contextReset']
     ) =>
       runSendPromptAction(() =>
         window.api.acp.sendPrompt({
@@ -310,7 +312,8 @@ const useAcpRuntime = (): {
           ...(historyAttachments && historyAttachments.length > 0 ? { historyAttachments } : {}),
           ...(historyImages && historyImages.length > 0 ? { historyImages } : {}),
           ...(resumeFallback ? { resumeFallback } : {}),
-          ...(provenanceContext ? { provenanceContext } : {})
+          ...(provenanceContext ? { provenanceContext } : {}),
+          ...(contextReset ? { contextReset: true } : {})
         })
       ),
     [runSendPromptAction]

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1,6 +1,5 @@
 import type { AcpRuntimeEvent, AcpStateSnapshot } from '../../../../shared/acp'
 import type { UploadedAttachment } from '../../../../shared/uploads'
-import { IMAGE_REPLAY_UNSUPPORTED_MESSAGE } from '../../../../shared/run-error-classification'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -1206,7 +1205,7 @@ describe('workspace agent message sending', () => {
     )
   })
 
-  it('keeps the immediately created branched Session in an error state when history images cannot replay', async () => {
+  it('omits history images when branching into a text-only model', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'source-session',
       content: 'Inspect this chart',
@@ -1223,10 +1222,13 @@ describe('workspace agent message sending', () => {
     const sourceBeforeBranch = useSessionStore.getState().sessions[0]
     const runtime = {
       state: createSnapshot(['source-session']),
-      createSession: vi.fn(),
+      createSession: vi.fn().mockResolvedValue({
+        sessionId: 'branched-runtime-session',
+        cwd: '/workspace/project'
+      }),
       resumeSession: vi.fn(),
       resetSessionContext: vi.fn(),
-      sendPrompt: vi.fn()
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['branched-runtime-session']))
     }
 
     const branched = await sendWorkspaceMessage(runtime, {
@@ -1236,22 +1238,17 @@ describe('workspace agent message sending', () => {
     })
 
     expect(branched).toBeDefined()
-    expect(runtime.createSession).not.toHaveBeenCalled()
-    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    await flushRuntimeTasks()
+
+    expect(runtime.createSession).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt.mock.calls[0]?.[5]).toContain('Inspect this chart')
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toEqual([])
+    expect(runtime.sendPrompt.mock.calls[0]?.[7]).toEqual([])
     expect(
       useSessionStore.getState().sessions.find((session) => session.id === 'source-session')
     ).toEqual(sourceBeforeBranch)
-    expect(useSessionStore.getState().selectedSessionId).toBe(branched?.sessionId)
-    expect(
-      useSessionStore.getState().sessions.find((session) => session.id === branched?.sessionId)
-    ).toMatchObject({
-      id: branched?.sessionId,
-      status: 'error',
-      error: IMAGE_REPLAY_UNSUPPORTED_MESSAGE,
-      messages: expect.arrayContaining([
-        expect.objectContaining({ content: 'Try another chart explanation' })
-      ])
-    })
+    expect(useSessionStore.getState().selectedSessionId).toBe('branched-runtime-session')
   })
 
   it('publishes a path-only legacy history upload under the source Session before replay', async () => {
@@ -1591,6 +1588,12 @@ describe('workspace agent message sending', () => {
       eventId: 'source-event',
       content: 'The original analysis is complete.'
     })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'source-session',
+      streamId: 'source-stream',
+      eventId: 'source-image-event',
+      image: { mimeType: 'image/png', data: 'aGVsbG8=', byteLength: 5 }
+    })
     useSessionStore.getState().finishRun('source-session')
     const runtime = {
       state: createSnapshot(['source-session', 'branched-runtime-session']),
@@ -1623,7 +1626,8 @@ describe('workspace agent message sending', () => {
 
     const retried = await sendWorkspaceMessage(runtime, {
       sessionId: 'branched-runtime-session',
-      text: 'Try a different interpretation'
+      text: 'Try a different interpretation',
+      supportsImageInput: false
     })
     await flushRuntimeTasks()
 
@@ -1641,6 +1645,7 @@ describe('workspace agent message sending', () => {
     expect(retryPromptCall[5]).toContain('Inspect the original data')
     expect(retryPromptCall[5]).toContain('The original analysis is complete.')
     expect(retryPromptCall[5]).not.toContain('Try a different interpretation')
+    expect(retryPromptCall[7]).toBeUndefined()
     expect(finalizeSession).toHaveBeenCalledTimes(2)
     expect(child.messages.at(-1)?.uploads).toEqual([
       expect.objectContaining({ versionId: 'upload-version-1' })
@@ -4139,7 +4144,7 @@ describe('resendEditedWorkspaceMessage', () => {
     expect(runtime.sendPrompt).not.toHaveBeenCalled()
   })
 
-  it('refuses the edit before truncating when the kept history needs image replay the model cannot take', async () => {
+  it('omits agent images when resending an edit into a text-only model', async () => {
     useSessionStore.setState({
       ...createInitialSessionState(),
       sessions: [
@@ -4168,8 +4173,8 @@ describe('resendEditedWorkspaceMessage', () => {
       state: createSnapshot(['session-1']),
       createSession: vi.fn(),
       resumeSession: vi.fn(),
-      resetSessionContext: vi.fn(),
-      sendPrompt: vi.fn()
+      resetSessionContext: vi.fn().mockResolvedValue({ contextReset: true }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
     const resent = await resendEditedWorkspaceMessage(
@@ -4177,19 +4182,24 @@ describe('resendEditedWorkspaceMessage', () => {
       { sessionId: 'session-1', messageId: 'user-2', text: 'second prompt, edited' },
       { supportsImageInput: false }
     )
+    await flushRuntimeTasks()
 
-    // The incompatible replay is rejected before the destructive cut: no reset, no prompt, and the
-    // transcript is untouched apart from the visible error.
-    expect(resent).toBe(false)
-    expect(runtime.resetSessionContext).not.toHaveBeenCalled()
-    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    expect(resent).toBe(true)
+    expect(runtime.resetSessionContext).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt.mock.calls[0]?.[5]).toContain('first prompt')
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toBeUndefined()
+    expect(runtime.sendPrompt.mock.calls[0]?.[7]).toBeUndefined()
     const session = useSessionStore.getState().sessions[0]
-    expect(session?.messages.map((message) => message.id)).toEqual(['user-1', 'agent-1', 'user-2'])
-    expect(session?.status).toBe('error')
-    expect(session?.error).toContain('image replay')
+    expect(session?.messages.slice(0, 2).map((message) => message.id)).toEqual([
+      'user-1',
+      'agent-1'
+    ])
+    expect(session?.messages.at(-1)?.content).toBe('second prompt, edited')
+    expect(session?.error).toBeUndefined()
   })
 
-  it('refuses the edit before truncating when the kept history has user-uploaded images', async () => {
+  it('classifies generic image uploads by extension before a text-only edited resend', async () => {
     useSessionStore.setState({
       ...createInitialSessionState(),
       sessions: [
@@ -4202,7 +4212,14 @@ describe('resendEditedWorkspaceMessage', () => {
           messages: [
             {
               ...createMessage('user-1', 'user', 'first prompt', baseTime),
-              uploads: [createAttachment({ name: 'photo.png', mimeType: 'image/png' })]
+              uploads: [
+                createAttachment({
+                  id: 'photo',
+                  name: 'photo.png',
+                  mimeType: 'application/octet-stream'
+                }),
+                createAttachment({ id: 'notes', name: 'notes.txt', mimeType: 'text/plain' })
+              ]
             },
             createMessage('agent-1', 'agent', 'first answer', baseTime + 100),
             createMessage('user-2', 'user', 'second prompt', baseTime + 200)
@@ -4218,8 +4235,8 @@ describe('resendEditedWorkspaceMessage', () => {
       state: createSnapshot(['session-1']),
       createSession: vi.fn(),
       resumeSession: vi.fn(),
-      resetSessionContext: vi.fn(),
-      sendPrompt: vi.fn()
+      resetSessionContext: vi.fn().mockResolvedValue({ contextReset: true }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
     }
 
     const resent = await resendEditedWorkspaceMessage(
@@ -4227,15 +4244,17 @@ describe('resendEditedWorkspaceMessage', () => {
       { sessionId: 'session-1', messageId: 'user-2', text: 'second prompt, edited' },
       { supportsImageInput: false }
     )
+    await flushRuntimeTasks()
 
-    // User uploads replay as image attachments, so they are gated exactly like agent-emitted images.
-    expect(resent).toBe(false)
-    expect(runtime.resetSessionContext).not.toHaveBeenCalled()
-    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    expect(resent).toBe(true)
+    expect(runtime.resetSessionContext).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toEqual([
+      expect.objectContaining({ id: 'notes', name: 'notes.txt' })
+    ])
+    expect(runtime.sendPrompt.mock.calls[0]?.[7]).toBeUndefined()
     const session = useSessionStore.getState().sessions[0]
-    expect(session?.messages.map((message) => message.id)).toEqual(['user-1', 'agent-1', 'user-2'])
-    expect(session?.status).toBe('error')
-    expect(session?.error).toContain('image replay')
+    expect(session?.error).toBeUndefined()
   })
 
   it('replays earlier uploaded images with their Project-scoped Version locator after an edit', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -651,7 +651,8 @@ describe('workspace agent message sending', () => {
       [],
       [],
       undefined,
-      expect.objectContaining({ promptMessageId: expect.any(String) })
+      expect.objectContaining({ promptMessageId: expect.any(String) }),
+      true
     )
     expect(useSessionStore.getState().sessions[0].branchContextResetRequired).toBeUndefined()
   })
@@ -1125,7 +1126,8 @@ describe('workspace agent message sending', () => {
       undefined,
       undefined,
       undefined,
-      expect.objectContaining({ promptMessageId: expect.any(String) })
+      expect.objectContaining({ promptMessageId: expect.any(String) }),
+      false
     )
   })
 
@@ -1201,7 +1203,8 @@ describe('workspace agent message sending', () => {
       [],
       [],
       undefined,
-      expect.objectContaining({ promptMessageId: branched?.messageId })
+      expect.objectContaining({ promptMessageId: branched?.messageId }),
+      true
     )
   })
 
@@ -1341,7 +1344,8 @@ describe('workspace agent message sending', () => {
       [finalizedHistory],
       [],
       undefined,
-      expect.objectContaining({ promptMessageId: branched?.messageId })
+      expect.objectContaining({ promptMessageId: branched?.messageId }),
+      true
     )
   })
 
@@ -1469,7 +1473,8 @@ describe('workspace agent message sending', () => {
       [finalizedHistory],
       [],
       undefined,
-      expect.objectContaining({ promptMessageId: branched?.messageId })
+      expect.objectContaining({ promptMessageId: branched?.messageId }),
+      true
     )
   })
 
@@ -1851,7 +1856,8 @@ describe('workspace agent message sending', () => {
       undefined,
       undefined,
       undefined,
-      expect.objectContaining({ promptMessageId: expect.any(String) })
+      expect.objectContaining({ promptMessageId: expect.any(String) }),
+      false
     )
     expect(useSessionStore.getState().sessions[0].messages[0].uploads?.[0]).not.toHaveProperty(
       'path'
@@ -1957,7 +1963,8 @@ describe('workspace agent message sending', () => {
       undefined,
       undefined,
       undefined,
-      expect.objectContaining({ promptMessageId: expect.any(String) })
+      expect.objectContaining({ promptMessageId: expect.any(String) }),
+      false
     )
     expect(useSessionStore.getState().selectedSessionId).toBe('transport-session-1')
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
@@ -2895,7 +2902,8 @@ describe('resuming an interrupted session on demand', () => {
       undefined,
       undefined,
       undefined,
-      expect.objectContaining({ promptMessageId: expect.any(String) })
+      expect.objectContaining({ promptMessageId: expect.any(String) }),
+      false
     )
 
     const session = useSessionStore.getState().sessions[0]
@@ -3034,6 +3042,39 @@ describe('resuming an interrupted session on demand', () => {
     expect(preamble).toContain('Done, saved chart.png')
     // The re-sent interrupted turn is prior-context only: it is not folded into its own preamble.
     expect(preamble).not.toContain('now add a trend line')
+    expect(runtime.sendPrompt.mock.calls[0]?.[10]).toBe(true)
+  })
+
+  it('marks a fresh-context retry even when the interrupted first turn has no replayable history', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Run the first notebook cell',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'ask'
+    })
+    useSessionStore.getState().markDisconnected('session-1')
+
+    const runtime = {
+      state: createSnapshot([]),
+      createSession: vi.fn(),
+      resumeSession: vi
+        .fn()
+        .mockResolvedValueOnce({
+          sessionId: 'session-1',
+          cwd: '/workspace/project',
+          contextReset: true
+        })
+        .mockResolvedValue({ sessionId: 'session-1', cwd: '/workspace/project' }),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await resumeInterruptedWorkspaceSession(runtime, 'session-1')
+    await flushRuntimeTasks()
+
+    expect(runtime.sendPrompt.mock.calls[0]?.[5]).toBeUndefined()
+    expect(runtime.sendPrompt.mock.calls[0]?.[10]).toBe(true)
   })
 
   it('does not replay a history preamble when the interrupted resume kept agent context', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -4431,7 +4431,7 @@ describe('sendWorkspaceMessage replay image filtering', () => {
     vi.unstubAllGlobals()
   })
 
-  it('omits user-uploaded images when replaying into a text-only model', async () => {
+  it('omits uploaded images but keeps other files when replaying into a text-only model', async () => {
     useSessionStore.setState({
       ...createInitialSessionState(),
       sessions: [
@@ -4444,7 +4444,10 @@ describe('sendWorkspaceMessage replay image filtering', () => {
           messages: [
             {
               ...createMessage('user-1', 'user', 'first prompt', baseTime),
-              uploads: [createAttachment({ name: 'photo.png', mimeType: 'image/png' })]
+              uploads: [
+                createAttachment({ id: 'photo', name: 'photo.png', mimeType: 'image/png' }),
+                createAttachment({ id: 'notes', name: 'notes.txt', mimeType: 'text/plain' })
+              ]
             },
             createMessage('agent-1', 'agent', 'first answer', baseTime + 100)
           ],
@@ -4475,7 +4478,9 @@ describe('sendWorkspaceMessage replay image filtering', () => {
     expect(sent).toBeDefined()
     expect(runtime.sendPrompt).toHaveBeenCalledOnce()
     expect(runtime.sendPrompt.mock.calls[0]?.[5]).toContain('first prompt')
-    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toBeUndefined()
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toEqual([
+      expect.objectContaining({ id: 'notes', name: 'notes.txt' })
+    ])
     expect(runtime.sendPrompt.mock.calls[0]?.[7]).toBeUndefined()
     const session = useSessionStore.getState().sessions[0]
     expect(session?.error).toBeUndefined()

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -3286,6 +3286,67 @@ describe('resuming an interrupted session on demand', () => {
     expect(useSessionStore.getState().sessions[0].agentFrameworkId).toBe('codex')
   })
 
+  it('resets text-only context when replay budgeting omits an older image turn', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: `Original task ${'a'.repeat(500)}`,
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Middle image turn that should be omitted from the replay packet',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'omitted-image',
+      eventId: 'omitted-image-event',
+      image: { mimeType: 'image/png', data: 'aGVsbG8=', byteLength: 5 }
+    })
+    useSessionStore.getState().finishRun('session-1')
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: `Latest turn ${'b'.repeat(500)}`,
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    const runtime = {
+      state: createSnapshot([]),
+      createSession: vi.fn(),
+      resumeSession: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        cwd: '/workspace/project',
+        frameworkId: 'codex'
+      }),
+      resetSessionContext: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        cwd: '/workspace/project',
+        contextReset: true,
+        frameworkId: 'codex'
+      }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'continue',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      supportsImageInput: false,
+      historyReplayDescriptor: { target: 'codex-response', budget: 600 }
+    })
+    await flushRuntimeTasks()
+
+    expect(runtime.resetSessionContext).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt.mock.calls[0]?.[5]).not.toContain('Middle image turn')
+    expect(runtime.sendPrompt.mock.calls[0]?.[7]).toBeUndefined()
+  })
+
   it('reconnects without re-sending when the last turn was already answered', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -39,6 +39,7 @@ import { useAcpRuntime } from './useAcpRuntime'
 import {
   buildWorkspaceHistoryReplay,
   resolveHistoryReplayTarget,
+  resolveSessionHistoryReplayDescriptor,
   type HistoryReplayDescriptor
 } from './history-preamble'
 import { applyWorkspaceRuntimeEvent, syncWorkspacePermissionState } from './workspace-events'
@@ -1829,6 +1830,8 @@ const useWorkspaceAgentRuntime = (): {
   const agentFramework = useSettingsStore((state) =>
     state.agentFrameworks.find((candidate) => candidate.id === state.agentFrameworkId)
   )
+  const providers = useSettingsStore((state) => state.providers)
+  const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
   const agentBackendId = activeProviderId ? `${agentFrameworkId}:${activeProviderId}` : undefined
   const historyReplayDescriptor = useMemo<HistoryReplayDescriptor>(
     () => ({
@@ -1841,6 +1844,17 @@ const useWorkspaceAgentRuntime = (): {
         : activeProvider?.contextWindow
     }),
     [activeModel, activeProvider, agentFramework, agentFrameworkId]
+  )
+  const getSessionHistoryReplayDescriptor = useCallback(
+    (sessionId: string): HistoryReplayDescriptor => {
+      const session = useSessionStore
+        .getState()
+        .sessions.find((candidate) => candidate.id === sessionId)
+      return session
+        ? resolveSessionHistoryReplayDescriptor(session, providers, agentFrameworks)
+        : { target: 'codex-bridge' }
+    },
+    [agentFrameworks, providers]
   )
   const [sendPreparationInFlightSessionIds, setSendPreparationInFlightSessionIds] = useState<
     string[]
@@ -1887,12 +1901,12 @@ const useWorkspaceAgentRuntime = (): {
           sessionId,
           supportsImageInput,
           cancelledOverflowRecoverySessionIds.current,
-          historyReplayDescriptor
+          getSessionHistoryReplayDescriptor(sessionId)
         )
       }
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps -- runtime is read fresh; fire on new events.
-  }, [runtime.state.events, historyReplayDescriptor, supportsImageInput])
+  }, [runtime.state.events, getSessionHistoryReplayDescriptor, supportsImageInput])
 
   // Applies each visible runtime event once and trims ids that fell out of the runtime window.
   useEffect(() => {
@@ -1988,19 +2002,22 @@ const useWorkspaceAgentRuntime = (): {
   // Explicitly re-attaches an interrupted session's ACP runtime so the user can keep chatting. On
   // success the composer is unlocked; on failure the interrupted banner stays so a retry stays possible.
   const resumeInterruptedSession = useCallback(
-    (sessionId: string): Promise<void> =>
-      resumeInterruptedWorkspaceSession(runtime, sessionId, {
+    (sessionId: string): Promise<void> => {
+      const session = useSessionStore
+        .getState()
+        .sessions.find((candidate) => candidate.id === sessionId)
+      return resumeInterruptedWorkspaceSession(runtime, sessionId, {
         supportsImageInput,
-        agentModel: activeModel,
-        historyReplayDescriptor,
+        agentModel: session?.agentModel,
+        historyReplayDescriptor: getSessionHistoryReplayDescriptor(sessionId),
         onSendPreparationStateChange: handleSendPreparationStateChange,
         drainRuntimeEvents
-      }),
+      })
+    },
     [
       runtime,
       supportsImageInput,
-      activeModel,
-      historyReplayDescriptor,
+      getSessionHistoryReplayDescriptor,
       handleSendPreparationStateChange,
       drainRuntimeEvents
     ]

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type {
   AcpConnectionStatus,
@@ -22,6 +22,7 @@ import type { FileReference } from '../../../../shared/artifacts'
 import type { MessagePart } from '../../../../shared/session-persistence'
 import { getActiveConversationContext } from '../../../../shared/conversation-graph'
 import type { AgentFrameworkId } from '../../../../shared/settings'
+import { resolveModelContextWindow } from '../../../../shared/provider-registry'
 import { isMediaOverflowError } from '../../../../shared/media-overflow'
 import {
   IMAGE_REPLAY_UNSUPPORTED_MESSAGE,
@@ -35,7 +36,11 @@ import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { useSessionStore, type ChatMessage, type ChatSession } from '../../stores/session-store'
 import { useSettingsStore } from '../../stores/settings-store'
 import { useAcpRuntime } from './useAcpRuntime'
-import { buildHistoryPreamble, buildHistoryReplayMedia } from './history-preamble'
+import {
+  buildWorkspaceHistoryReplay,
+  resolveHistoryReplayTarget,
+  type HistoryReplayDescriptor
+} from './history-preamble'
 import { applyWorkspaceRuntimeEvent, syncWorkspacePermissionState } from './workspace-events'
 
 type SendWorkspaceMessageInput = {
@@ -56,6 +61,7 @@ type SendWorkspaceMessageInput = {
   agentFrameworkId?: AgentFrameworkId
   agentBackendId?: string
   agentModel?: string
+  historyReplayDescriptor?: HistoryReplayDescriptor
   // Skills the user picked in the composer; force-loaded and nudged for this turn only.
   forcedSkillIds?: string[]
   // Existing files referenced via `@` mentions; attached to the prompt as content blocks.
@@ -94,6 +100,18 @@ type HistoryReplayContext = {
   historyImages?: AcpMessageImage[]
 }
 
+const buildWorkspaceReplay = (
+  messages: ChatMessage[],
+  descriptor: HistoryReplayDescriptor | undefined,
+  frameworkId: AgentFrameworkId | undefined,
+  projectId?: string
+): HistoryReplayContext | undefined =>
+  buildWorkspaceHistoryReplay(
+    messages,
+    descriptor ?? { target: resolveHistoryReplayTarget(frameworkId) },
+    projectId
+  )
+
 type SendPreparationStateChange = (sessionId: string, inFlight: boolean) => void
 type RuntimeEventDrain = (sessionId?: string) => Promise<void>
 
@@ -114,6 +132,7 @@ type ResendEditedWorkspaceMessageOptions = {
   agentFrameworkId?: AgentFrameworkId
   agentBackendId?: string
   agentModel?: string
+  historyReplayDescriptor?: HistoryReplayDescriptor
   onSendPreparationStateChange?: SendPreparationStateChange
   drainRuntimeEvents?: RuntimeEventDrain
 }
@@ -121,6 +140,7 @@ type ResendEditedWorkspaceMessageOptions = {
 type ResumeInterruptedWorkspaceSessionOptions = {
   supportsImageInput?: boolean
   agentModel?: string
+  historyReplayDescriptor?: HistoryReplayDescriptor
   onSendPreparationStateChange?: SendPreparationStateChange
   drainRuntimeEvents?: RuntimeEventDrain
 }
@@ -704,6 +724,7 @@ const sendWorkspaceMessage = async (
     agentFrameworkId,
     agentBackendId,
     agentModel,
+    historyReplayDescriptor,
     forcedSkillIds,
     referencedArtifacts,
     parts,
@@ -788,12 +809,14 @@ const sendWorkspaceMessage = async (
       useSessionStore.getState().failRun(pending.sessionId, getErrorMessage(error))
       return pending
     }
-    const historyReplay: HistoryReplayContext = {
-      historyPreamble: buildHistoryPreamble(historyMessages)
-    }
-    let replayMedia: ReturnType<typeof buildHistoryReplayMedia>
+    let historyReplay: HistoryReplayContext | undefined
     try {
-      replayMedia = buildHistoryReplayMedia(historyMessages, sessionProjectName)
+      historyReplay = buildWorkspaceReplay(
+        historyMessages,
+        historyReplayDescriptor,
+        agentFrameworkId,
+        sessionProjectName
+      )
     } catch (error) {
       useSessionStore.getState().failRun(pending.sessionId, getErrorMessage(error))
       return pending
@@ -803,14 +826,12 @@ const sendWorkspaceMessage = async (
     // on the selected pending Session and must never silently dispatch the new prompt without history.
     if (
       supportsImageInput === false &&
-      (replayMedia.images.length > 0 || replayMedia.attachments.length > 0)
+      ((historyReplay?.historyImages?.length ?? 0) > 0 ||
+        (historyReplay?.historyAttachments?.length ?? 0) > 0)
     ) {
       useSessionStore.getState().failRun(pending.sessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
       return pending
     }
-
-    historyReplay.historyAttachments = replayMedia.attachments
-    historyReplay.historyImages = replayMedia.images
 
     startPendingSessionPrompt(
       runtime,
@@ -857,9 +878,14 @@ const sendWorkspaceMessage = async (
         const historyMessages = currentSession.messages.filter(
           (message) => message.id !== currentSession.pendingContextReplayMessageId
         )
-        let replayMedia: ReturnType<typeof buildHistoryReplayMedia>
+        let replay: HistoryReplayContext | undefined
         try {
-          replayMedia = buildHistoryReplayMedia(historyMessages, sessionProjectName)
+          replay = buildWorkspaceReplay(
+            historyMessages,
+            historyReplayDescriptor,
+            agentFrameworkId,
+            sessionProjectName
+          )
         } catch (error) {
           useSessionStore.getState().failRun(currentSession.id, getErrorMessage(error))
           return {
@@ -871,7 +897,8 @@ const sendWorkspaceMessage = async (
         // Keep the original pending prompt intact until the selected model can accept its history.
         if (
           supportsImageInput === false &&
-          (replayMedia.images.length > 0 || replayMedia.attachments.length > 0)
+          ((replay?.historyImages?.length ?? 0) > 0 ||
+            (replay?.historyAttachments?.length ?? 0) > 0)
         ) {
           useSessionStore.getState().failRun(currentSession.id, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
           return {
@@ -880,11 +907,7 @@ const sendWorkspaceMessage = async (
           }
         }
 
-        historyReplay = {
-          historyPreamble: buildHistoryPreamble(historyMessages),
-          historyAttachments: replayMedia.attachments,
-          historyImages: replayMedia.images
-        }
+        historyReplay = replay
       }
 
       const appended = useSessionStore.getState().appendUserMessage({
@@ -939,8 +962,15 @@ const sendWorkspaceMessage = async (
       runtimeMustAdoptSession &&
       supportsImageInput === false &&
       (() => {
-        const media = buildHistoryReplayMedia(currentSession?.messages ?? [], sessionProjectName)
-        return media.images.length > 0 || media.attachments.length > 0
+        const replay = buildWorkspaceReplay(
+          currentSession?.messages ?? [],
+          historyReplayDescriptor,
+          agentFrameworkId,
+          sessionProjectName
+        )
+        return (
+          (replay?.historyImages?.length ?? 0) > 0 || (replay?.historyAttachments?.length ?? 0) > 0
+        )
       })()
     const sendPreparationRequired = branchResetRequired || runtimeMustAdoptSession
 
@@ -1105,20 +1135,31 @@ const sendWorkspaceMessage = async (
         preparedSession?.pendingContextReplayMessageId) &&
       historyMessages
     ) {
-      historyPreamble = buildHistoryPreamble(historyMessages)
-      const media = buildHistoryReplayMedia(historyMessages, sessionProjectName)
-      historyAttachments = supportsImageInput === false ? undefined : media.attachments
-      historyImages = supportsImageInput === false ? undefined : media.images
+      const replay = buildWorkspaceReplay(
+        historyMessages,
+        historyReplayDescriptor,
+        agentFrameworkId,
+        sessionProjectName
+      )
+      historyPreamble = replay?.historyPreamble
+      historyAttachments = supportsImageInput === false ? undefined : replay?.historyAttachments
+      historyImages = supportsImageInput === false ? undefined : replay?.historyImages
     }
 
     const resumeFallback =
       forcedSkillIds && forcedSkillIds.length > 0 && historyMessages
         ? (() => {
-            const media = buildHistoryReplayMedia(historyMessages, sessionProjectName)
+            const replay = buildWorkspaceReplay(
+              historyMessages,
+              historyReplayDescriptor,
+              agentFrameworkId,
+              sessionProjectName
+            )
             return {
-              historyPreamble: buildHistoryPreamble(historyMessages),
-              historyAttachments: supportsImageInput === false ? undefined : media.attachments,
-              historyImages: supportsImageInput === false ? undefined : media.images
+              historyPreamble: replay?.historyPreamble,
+              historyAttachments:
+                supportsImageInput === false ? undefined : replay?.historyAttachments,
+              historyImages: supportsImageInput === false ? undefined : replay?.historyImages
             }
           })()
         : undefined
@@ -1269,6 +1310,7 @@ const resumeInterruptedWorkspaceSession = async (
   {
     supportsImageInput,
     agentModel,
+    historyReplayDescriptor,
     onSendPreparationStateChange,
     drainRuntimeEvents
   }: ResumeInterruptedWorkspaceSessionOptions = {}
@@ -1345,7 +1387,8 @@ const resumeInterruptedWorkspaceSession = async (
       forceHistoryReplay: contextReset,
       requireExistingSession: true,
       supportsImageInput,
-      agentModel
+      agentModel,
+      historyReplayDescriptor
     },
     onSendPreparationStateChange,
     drainRuntimeEvents
@@ -1416,7 +1459,8 @@ const recoverContextOverflowWorkspaceSession = async (
   runtime: WorkspaceMessageRuntime,
   sessionId: string,
   supportsImageInput?: boolean,
-  cancelledSessionIds?: Set<string>
+  cancelledSessionIds?: Set<string>,
+  historyReplayDescriptor?: HistoryReplayDescriptor
 ): Promise<boolean> => {
   const session = useSessionStore.getState().sessions.find((item) => item.id === sessionId)
 
@@ -1522,7 +1566,8 @@ const recoverContextOverflowWorkspaceSession = async (
     forceHistoryReplay: !nativeCompacted,
     allowCompactionRecovery: true,
     supportsImageInput,
-    agentModel: session.agentModel
+    agentModel: session.agentModel,
+    historyReplayDescriptor
   })
 
   if (!retried) restoreRemovedTurnProjection(session)
@@ -1572,6 +1617,7 @@ const resendEditedWorkspaceMessage = async (
     agentFrameworkId,
     agentBackendId,
     agentModel,
+    historyReplayDescriptor,
     onSendPreparationStateChange,
     drainRuntimeEvents
   }: ResendEditedWorkspaceMessageOptions = {}
@@ -1596,14 +1642,16 @@ const resendEditedWorkspaceMessage = async (
   // Validate replay compatibility before the Branch switch: a kept history with images — whether
   // agent-emitted blocks or user uploads — cannot be replayed on a model without image input, and
   // discovering that after the truncation would leave the later turns dropped with no prompt dispatched.
-  const replayMedia = buildHistoryReplayMedia(
+  const replay = buildWorkspaceReplay(
     session.messages.slice(0, cutIndex),
+    historyReplayDescriptor,
+    agentFrameworkId,
     session.projectId
   )
 
   if (
     supportsImageInput === false &&
-    (replayMedia.images.length > 0 || replayMedia.attachments.length > 0)
+    ((replay?.historyImages?.length ?? 0) > 0 || (replay?.historyAttachments?.length ?? 0) > 0)
   ) {
     useSessionStore.getState().failRun(input.sessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
     return false
@@ -1624,6 +1672,7 @@ const resendEditedWorkspaceMessage = async (
       agentFrameworkId,
       agentBackendId,
       agentModel,
+      historyReplayDescriptor,
       // Reset/adopt while the old Branch remains visible, then replace it only after preparation.
       truncateFromMessageId: input.messageId,
       supportsImageInput
@@ -1800,14 +1849,29 @@ const useWorkspaceAgentRuntime = (): {
   revokePermissionGrant: (sessionId: string, categoryKey: string) => Promise<void>
 } => {
   const runtime = useAcpRuntime()
-  const supportsImageInput = useSettingsStore((state) => {
-    const provider = state.providers.find((candidate) => candidate.id === state.activeProviderId)
-    return provider?.supportsImageInput ?? false
-  })
+  const activeProvider = useSettingsStore((state) =>
+    state.providers.find((candidate) => candidate.id === state.activeProviderId)
+  )
+  const supportsImageInput = activeProvider?.supportsImageInput ?? false
   const activeModel = useSettingsStore((state) => state.activeModel)
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const agentFramework = useSettingsStore((state) =>
+    state.agentFrameworks.find((candidate) => candidate.id === state.agentFrameworkId)
+  )
   const agentBackendId = activeProviderId ? `${agentFrameworkId}:${activeProviderId}` : undefined
+  const historyReplayDescriptor = useMemo<HistoryReplayDescriptor>(
+    () => ({
+      target: resolveHistoryReplayTarget(agentFrameworkId, activeProvider, agentFramework),
+      contextWindow: activeProvider?.vendorId
+        ? resolveModelContextWindow(
+            activeProvider.vendorId,
+            activeModel ?? activeProvider.model ?? activeProvider.models[0]
+          )
+        : activeProvider?.contextWindow
+    }),
+    [activeModel, activeProvider, agentFramework, agentFrameworkId]
+  )
   const [sendPreparationInFlightSessionIds, setSendPreparationInFlightSessionIds] = useState<
     string[]
   >([])
@@ -1852,12 +1916,13 @@ const useWorkspaceAgentRuntime = (): {
           recoveryRuntime,
           sessionId,
           supportsImageInput,
-          cancelledOverflowRecoverySessionIds.current
+          cancelledOverflowRecoverySessionIds.current,
+          historyReplayDescriptor
         )
       }
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps -- runtime is read fresh; fire on new events.
-  }, [runtime.state.events])
+  }, [runtime.state.events, historyReplayDescriptor, supportsImageInput])
 
   // Applies each visible runtime event once and trims ids that fell out of the runtime window.
   useEffect(() => {
@@ -1898,7 +1963,8 @@ const useWorkspaceAgentRuntime = (): {
           supportsImageInput,
           agentFrameworkId,
           agentBackendId,
-          agentModel: activeModel
+          agentModel: activeModel,
+          historyReplayDescriptor
         },
         handleSendPreparationStateChange,
         drainRuntimeEvents
@@ -1909,6 +1975,7 @@ const useWorkspaceAgentRuntime = (): {
       agentFrameworkId,
       agentBackendId,
       activeModel,
+      historyReplayDescriptor,
       handleSendPreparationStateChange,
       drainRuntimeEvents
     ]
@@ -1926,6 +1993,7 @@ const useWorkspaceAgentRuntime = (): {
           agentFrameworkId,
           agentBackendId,
           agentModel: activeModel,
+          historyReplayDescriptor,
           onSendPreparationStateChange: handleSendPreparationStateChange,
           drainRuntimeEvents
         }
@@ -1936,6 +2004,7 @@ const useWorkspaceAgentRuntime = (): {
       agentFrameworkId,
       agentBackendId,
       activeModel,
+      historyReplayDescriptor,
       handleSendPreparationStateChange,
       drainRuntimeEvents
     ]
@@ -1953,10 +2022,18 @@ const useWorkspaceAgentRuntime = (): {
       resumeInterruptedWorkspaceSession(runtime, sessionId, {
         supportsImageInput,
         agentModel: activeModel,
+        historyReplayDescriptor,
         onSendPreparationStateChange: handleSendPreparationStateChange,
         drainRuntimeEvents
       }),
-    [runtime, supportsImageInput, activeModel, handleSendPreparationStateChange, drainRuntimeEvents]
+    [
+      runtime,
+      supportsImageInput,
+      activeModel,
+      historyReplayDescriptor,
+      handleSendPreparationStateChange,
+      drainRuntimeEvents
+    ]
   )
 
   // Sends a cancellation request while the runtime waits for the eventual stop event.

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -630,7 +630,8 @@ const startPendingSessionPrompt = (
   forcedSkillIds: string[] | undefined,
   referencedArtifacts: FileReference[] | undefined,
   specialistId: string | undefined,
-  historyReplay?: HistoryReplayContext
+  historyReplay?: HistoryReplayContext,
+  contextReset = false
 ): void => {
   void (async () => {
     if (!sessionOwnsActivePrompt(pending.sessionId, pending.messageId)) return
@@ -714,7 +715,8 @@ const startPendingSessionPrompt = (
         historyReplay?.historyAttachments,
         historyReplay?.historyImages,
         undefined,
-        getPromptProvenanceContext(runtimeSessionId, bound.messageId)
+        getPromptProvenanceContext(runtimeSessionId, bound.messageId),
+        contextReset
       )
       .then((snapshot) => {
         useSessionStore.getState().clearPendingContextReplay(runtimeSessionId, bound.messageId)
@@ -854,7 +856,8 @@ const sendWorkspaceMessage = async (
       forcedSkillIds,
       referencedArtifacts,
       pendingSession.specialistId,
-      historyReplay
+      historyReplay,
+      true
     )
 
     return pending
@@ -933,7 +936,8 @@ const sendWorkspaceMessage = async (
         forcedSkillIds,
         referencedArtifacts,
         currentSession.pendingContextReplayMessageId ? currentSession.specialistId : undefined,
-        historyReplay
+        historyReplay,
+        Boolean(currentSession.pendingContextReplayMessageId)
       )
       return appended
     }
@@ -1152,6 +1156,13 @@ const sendWorkspaceMessage = async (
             }
           })()
         : undefined
+    const contextReset = Boolean(
+      branchContextResetPerformed ||
+      contextResetFromResume ||
+      forceHistoryReplay ||
+      specialistSwitchReplay ||
+      preparedSession?.pendingContextReplayMessageId
+    )
 
     let promptAttachments = effectiveAttachments
 
@@ -1186,7 +1197,8 @@ const sendWorkspaceMessage = async (
         historyAttachments,
         historyImages,
         resumeFallback,
-        getPromptProvenanceContext(targetSessionId, appended.messageId)
+        getPromptProvenanceContext(targetSessionId, appended.messageId),
+        contextReset
       )
       .then((snapshot) => {
         if (branchContextResetPerformed) {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -100,6 +100,22 @@ type HistoryReplayContext = {
   historyImages?: AcpMessageImage[]
 }
 
+const isReplayImage = (attachment: UploadedAttachment): boolean =>
+  attachment.mimeType?.startsWith('image/') === true
+
+const hasReplayImages = (replay?: HistoryReplayContext): boolean =>
+  (replay?.historyImages?.length ?? 0) > 0 ||
+  replay?.historyAttachments?.some(isReplayImage) === true
+
+const replayAttachmentsForModel = (
+  replay: HistoryReplayContext | undefined,
+  supportsImageInput: boolean | undefined
+): UploadedAttachment[] | undefined => {
+  if (supportsImageInput !== false) return replay?.historyAttachments
+  const attachments = replay?.historyAttachments?.filter((attachment) => !isReplayImage(attachment))
+  return attachments?.length ? attachments : undefined
+}
+
 const buildWorkspaceReplay = (
   messages: ChatMessage[],
   descriptor: HistoryReplayDescriptor | undefined,
@@ -824,11 +840,7 @@ const sendWorkspaceMessage = async (
 
     // Branch creation is intentionally immediate. A model incompatibility remains a recoverable error
     // on the selected pending Session and must never silently dispatch the new prompt without history.
-    if (
-      supportsImageInput === false &&
-      ((historyReplay?.historyImages?.length ?? 0) > 0 ||
-        (historyReplay?.historyAttachments?.length ?? 0) > 0)
-    ) {
+    if (supportsImageInput === false && hasReplayImages(historyReplay)) {
       useSessionStore.getState().failRun(pending.sessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
       return pending
     }
@@ -895,11 +907,7 @@ const sendWorkspaceMessage = async (
         }
 
         // Keep the original pending prompt intact until the selected model can accept its history.
-        if (
-          supportsImageInput === false &&
-          ((replay?.historyImages?.length ?? 0) > 0 ||
-            (replay?.historyAttachments?.length ?? 0) > 0)
-        ) {
+        if (supportsImageInput === false && hasReplayImages(replay)) {
           useSessionStore.getState().failRun(currentSession.id, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
           return {
             sessionId: currentSession.id,
@@ -968,9 +976,7 @@ const sendWorkspaceMessage = async (
           agentFrameworkId,
           sessionProjectName
         )
-        return (
-          (replay?.historyImages?.length ?? 0) > 0 || (replay?.historyAttachments?.length ?? 0) > 0
-        )
+        return hasReplayImages(replay)
       })()
     const sendPreparationRequired = branchResetRequired || runtimeMustAdoptSession
 
@@ -1142,7 +1148,7 @@ const sendWorkspaceMessage = async (
         sessionProjectName
       )
       historyPreamble = replay?.historyPreamble
-      historyAttachments = supportsImageInput === false ? undefined : replay?.historyAttachments
+      historyAttachments = replayAttachmentsForModel(replay, supportsImageInput)
       historyImages = supportsImageInput === false ? undefined : replay?.historyImages
     }
 
@@ -1157,8 +1163,7 @@ const sendWorkspaceMessage = async (
             )
             return {
               historyPreamble: replay?.historyPreamble,
-              historyAttachments:
-                supportsImageInput === false ? undefined : replay?.historyAttachments,
+              historyAttachments: replayAttachmentsForModel(replay, supportsImageInput),
               historyImages: supportsImageInput === false ? undefined : replay?.historyImages
             }
           })()
@@ -1649,10 +1654,7 @@ const resendEditedWorkspaceMessage = async (
     session.projectId
   )
 
-  if (
-    supportsImageInput === false &&
-    ((replay?.historyImages?.length ?? 0) > 0 || (replay?.historyAttachments?.length ?? 0) > 0)
-  ) {
+  if (supportsImageInput === false && hasReplayImages(replay)) {
     useSessionStore.getState().failRun(input.sessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
     return false
   }

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -14,6 +14,7 @@ import {
   type SessionPermissionProfileState
 } from '../../../../shared/permission-profiles'
 import {
+  imageAttachmentMimeType,
   toPersistedUploadedAttachment,
   toRuntimeUploadedAttachment,
   type UploadedAttachment
@@ -25,7 +26,6 @@ import type { AgentFrameworkId } from '../../../../shared/settings'
 import { resolveModelContextWindow } from '../../../../shared/provider-registry'
 import { isMediaOverflowError } from '../../../../shared/media-overflow'
 import {
-  IMAGE_REPLAY_UNSUPPORTED_MESSAGE,
   RESUME_MODEL_INCOMPATIBLE_MESSAGE,
   RESUME_RECONNECT_FAILED_MESSAGE,
   RESUME_TIMED_OUT_MESSAGE,
@@ -101,7 +101,7 @@ type HistoryReplayContext = {
 }
 
 const isReplayImage = (attachment: UploadedAttachment): boolean =>
-  attachment.mimeType?.startsWith('image/') === true
+  imageAttachmentMimeType(attachment.name, attachment.mimeType) !== undefined
 
 const hasReplayImages = (replay?: HistoryReplayContext): boolean =>
   (replay?.historyImages?.length ?? 0) > 0 ||
@@ -120,12 +120,14 @@ const buildWorkspaceReplay = (
   messages: ChatMessage[],
   descriptor: HistoryReplayDescriptor | undefined,
   frameworkId: AgentFrameworkId | undefined,
-  projectId?: string
+  projectId?: string,
+  supportsImageInput?: boolean
 ): HistoryReplayContext | undefined =>
   buildWorkspaceHistoryReplay(
     messages,
     descriptor ?? { target: resolveHistoryReplayTarget(frameworkId) },
-    projectId
+    projectId,
+    supportsImageInput
   )
 
 type SendPreparationStateChange = (sessionId: string, inFlight: boolean) => void
@@ -831,17 +833,11 @@ const sendWorkspaceMessage = async (
         historyMessages,
         historyReplayDescriptor,
         agentFrameworkId,
-        sessionProjectName
+        sessionProjectName,
+        supportsImageInput
       )
     } catch (error) {
       useSessionStore.getState().failRun(pending.sessionId, getErrorMessage(error))
-      return pending
-    }
-
-    // Branch creation is intentionally immediate. A model incompatibility remains a recoverable error
-    // on the selected pending Session and must never silently dispatch the new prompt without history.
-    if (supportsImageInput === false && hasReplayImages(historyReplay)) {
-      useSessionStore.getState().failRun(pending.sessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
       return pending
     }
 
@@ -896,19 +892,11 @@ const sendWorkspaceMessage = async (
             historyMessages,
             historyReplayDescriptor,
             agentFrameworkId,
-            sessionProjectName
+            sessionProjectName,
+            supportsImageInput
           )
         } catch (error) {
           useSessionStore.getState().failRun(currentSession.id, getErrorMessage(error))
-          return {
-            sessionId: currentSession.id,
-            messageId: currentSession.pendingContextReplayMessageId
-          }
-        }
-
-        // Keep the original pending prompt intact until the selected model can accept its history.
-        if (supportsImageInput === false && hasReplayImages(replay)) {
-          useSessionStore.getState().failRun(currentSession.id, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
           return {
             sessionId: currentSession.id,
             messageId: currentSession.pendingContextReplayMessageId
@@ -1145,7 +1133,8 @@ const sendWorkspaceMessage = async (
         historyMessages,
         historyReplayDescriptor,
         agentFrameworkId,
-        sessionProjectName
+        sessionProjectName,
+        supportsImageInput
       )
       historyPreamble = replay?.historyPreamble
       historyAttachments = replayAttachmentsForModel(replay, supportsImageInput)
@@ -1159,7 +1148,8 @@ const sendWorkspaceMessage = async (
               historyMessages,
               historyReplayDescriptor,
               agentFrameworkId,
-              sessionProjectName
+              sessionProjectName,
+              supportsImageInput
             )
             return {
               historyPreamble: replay?.historyPreamble,
@@ -1641,21 +1631,6 @@ const resendEditedWorkspaceMessage = async (
     cutIndex < 0 ||
     runtime.state.promptInFlightSessionIds.includes(input.sessionId)
   ) {
-    return false
-  }
-
-  // Validate replay compatibility before the Branch switch: a kept history with images — whether
-  // agent-emitted blocks or user uploads — cannot be replayed on a model without image input, and
-  // discovering that after the truncation would leave the later turns dropped with no prompt dispatched.
-  const replay = buildWorkspaceReplay(
-    session.messages.slice(0, cutIndex),
-    historyReplayDescriptor,
-    agentFrameworkId,
-    session.projectId
-  )
-
-  if (supportsImageInput === false && hasReplayImages(replay)) {
-    useSessionStore.getState().failRun(input.sessionId, IMAGE_REPLAY_UNSUPPORTED_MESSAGE)
     return false
   }
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -100,12 +100,13 @@ type HistoryReplayContext = {
   historyImages?: AcpMessageImage[]
 }
 
-const isReplayImage = (attachment: UploadedAttachment): boolean =>
+const isReplayImage = (attachment: Pick<UploadedAttachment, 'name' | 'mimeType'>): boolean =>
   imageAttachmentMimeType(attachment.name, attachment.mimeType) !== undefined
 
-const hasReplayImages = (replay?: HistoryReplayContext): boolean =>
-  (replay?.historyImages?.length ?? 0) > 0 ||
-  replay?.historyAttachments?.some(isReplayImage) === true
+const hasHistoryImages = (messages: ChatMessage[]): boolean =>
+  messages.some(
+    (message) => (message.images?.length ?? 0) > 0 || message.uploads?.some(isReplayImage) === true
+  )
 
 const replayAttachmentsForModel = (
   replay: HistoryReplayContext | undefined,
@@ -957,15 +958,7 @@ const sendWorkspaceMessage = async (
     const resumeNeedsImageFiltering =
       runtimeMustAdoptSession &&
       supportsImageInput === false &&
-      (() => {
-        const replay = buildWorkspaceReplay(
-          currentSession?.messages ?? [],
-          historyReplayDescriptor,
-          agentFrameworkId,
-          sessionProjectName
-        )
-        return hasReplayImages(replay)
-      })()
+      hasHistoryImages(currentSession?.messages ?? [])
     const sendPreparationRequired = branchResetRequired || runtimeMustAdoptSession
 
     if (sendPreparationRequired) {

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -530,6 +530,9 @@ export type AcpPromptRequest = {
   historyPreamble?: string
   historyAttachments?: UploadedAttachment[]
   historyImages?: AcpMessageImage[]
+  // Transient prompt-boundary signal: the provider context was replaced, so live application state
+  // must be handed off even when there are no replayable transcript turns. Never persisted.
+  contextReset?: boolean
   // Prepared by the renderer for an internal skill-triggered reconnect. Used only if that reconnect
   // cannot resume the agent session and must adopt a fresh one.
   resumeFallback?: {

--- a/src/shared/history-preamble.ts
+++ b/src/shared/history-preamble.ts
@@ -29,6 +29,7 @@ const HEADER =
 const OMISSION_NOTE = '[…middle turns omitted for replay budget…]'
 const RESPONSE_OMISSION_NOTE = '[…earlier response omitted for replay budget…]'
 const MESSAGE_OMISSION_NOTE = '[…middle of this message omitted for replay budget…]'
+const MEDIA_PLACEHOLDER = '[media attached]'
 
 export type HistoryMessage = {
   role: string
@@ -52,7 +53,7 @@ const isUserMessage = (message: HistoryMessage): boolean => message.role === 'us
 const speakerFor = (message: HistoryMessage): 'User' | 'Assistant' =>
   isUserMessage(message) ? 'User' : 'Assistant'
 const formatMessage = (message: HistoryMessage): string =>
-  `**${speakerFor(message)}:** ${message.content.trim() || '[media attached]'}`
+  `**${speakerFor(message)}:** ${message.content.trim() || MEDIA_PLACEHOLDER}`
 
 // Stable conservative admission estimate: ASCII-heavy text gets the usual four-bytes-per-token
 // approximation, while every non-ASCII code point costs at least one token.
@@ -189,6 +190,17 @@ const projectTurn = (turn: HistoryTurn, budget: number): ProjectedTurn | undefin
   const assistant = turn.messages.at(-1)
   if (!assistant || isUserMessage(assistant))
     return { index: turn.index, text: fullUser, selectedMessageIndexes }
+
+  if (!assistant.content.trim() && assistant.hasReplayMedia) {
+    const text = `${fullUser}\n\n${formatMessage(assistant)}`
+    return estimateHistoryTokens(text) <= budget
+      ? {
+          index: turn.index,
+          text,
+          selectedMessageIndexes: [...selectedMessageIndexes, assistant.index]
+        }
+      : { index: turn.index, text: fullUser, selectedMessageIndexes }
+  }
 
   const assistantPrefix = `**Assistant:** ${RESPONSE_OMISSION_NOTE}\n`
   const assistantBudget =

--- a/src/shared/history-preamble.ts
+++ b/src/shared/history-preamble.ts
@@ -380,9 +380,9 @@ export const buildHistoryReplay = (
 // use buildHistoryReplay() so media selection follows the admitted message indexes.
 export const buildHistoryPreamble = (
   messages: HistoryMessage[],
-  descriptor: HistoryReplayDescriptor | number = { target: 'claude-code' }
+  descriptor: HistoryReplayDescriptor | number = { target: 'codex-bridge' }
 ): string | undefined =>
   buildHistoryReplay(
     messages,
-    typeof descriptor === 'number' ? { target: 'claude-code', budget: descriptor } : descriptor
+    typeof descriptor === 'number' ? { target: 'codex-bridge', budget: descriptor } : descriptor
   )?.preamble

--- a/src/shared/history-preamble.ts
+++ b/src/shared/history-preamble.ts
@@ -52,21 +52,29 @@ type ProjectedTurn = { index: number; text: string; selectedMessageIndexes: numb
 const isUserMessage = (message: HistoryMessage): boolean => message.role === 'user'
 const speakerFor = (message: HistoryMessage): 'User' | 'Assistant' =>
   isUserMessage(message) ? 'User' : 'Assistant'
+const speakerPrefixFor = (message: HistoryMessage): string => `**${speakerFor(message)}:** `
 const formatMessage = (message: HistoryMessage): string =>
-  `**${speakerFor(message)}:** ${message.content.trim() || MEDIA_PLACEHOLDER}`
+  `${speakerPrefixFor(message)}${message.content.trim() || MEDIA_PLACEHOLDER}`
 
-// Stable conservative admission estimate: ASCII-heavy text gets the usual four-bytes-per-token
-// approximation, while every non-ASCII code point costs at least one token.
+const utf8BytesForCodePoint = (codePoint: number): number => {
+  if (codePoint <= 0x7f) return 1
+  if (codePoint <= 0x7ff) return 2
+  if (codePoint <= 0xffff) return 3
+  return 4
+}
+
+// Provider tokenizers can split down to individual UTF-8 bytes. Counting bytes is therefore a
+// dependency-free upper bound for admission instead of an average-case chars-per-token guess.
 export const estimateHistoryTokens = (text: string): number => {
-  let asciiBytes = 0
-  let nonAsciiCodePoints = 0
+  let bytes = 0
 
-  for (const codePoint of text) {
-    if (codePoint.codePointAt(0)! <= 0x7f) asciiBytes += 1
-    else nonAsciiCodePoints += 1
+  for (let index = 0; index < text.length;) {
+    const codePoint = text.codePointAt(index)!
+    bytes += utf8BytesForCodePoint(codePoint)
+    index += codePoint > 0xffff ? 2 : 1
   }
 
-  return Math.ceil(asciiBytes / 4) + nonAsciiCodePoints
+  return bytes
 }
 
 export const resolveHistoryReplayBudget = ({
@@ -90,32 +98,42 @@ export const resolveFileTextBudget = (contextWindow?: number): number => {
 
 const takePrefixWithinTokens = (text: string, budget: number): string => {
   if (budget <= 0) return ''
-  const codePoints = Array.from(text)
-  let low = 0
-  let high = codePoints.length
+  let spent = 0
+  let end = 0
 
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2)
-    if (estimateHistoryTokens(codePoints.slice(0, middle).join('')) <= budget) low = middle
-    else high = middle - 1
+  while (end < text.length) {
+    const codePoint = text.codePointAt(end)!
+    const cost = utf8BytesForCodePoint(codePoint)
+    if (spent + cost > budget) break
+    spent += cost
+    end += codePoint > 0xffff ? 2 : 1
   }
 
-  return codePoints.slice(0, low).join('')
+  return text.slice(0, end)
 }
 
 const takeSuffixWithinTokens = (text: string, budget: number): string => {
   if (budget <= 0) return ''
-  const codePoints = Array.from(text)
-  let low = 0
-  let high = codePoints.length
+  let spent = 0
+  let start = text.length
 
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2)
-    if (estimateHistoryTokens(codePoints.slice(-middle).join('')) <= budget) low = middle
-    else high = middle - 1
+  while (start > 0) {
+    let codePoint = text.charCodeAt(start - 1)
+    let width = 1
+    if (codePoint >= 0xdc00 && codePoint <= 0xdfff && start > 1) {
+      const high = text.charCodeAt(start - 2)
+      if (high >= 0xd800 && high <= 0xdbff) {
+        codePoint = text.codePointAt(start - 2)!
+        width = 2
+      }
+    }
+    const cost = utf8BytesForCodePoint(codePoint)
+    if (spent + cost > budget) break
+    spent += cost
+    start -= width
   }
 
-  return codePoints.slice(-low).join('')
+  return text.slice(start)
 }
 
 export const truncateTextToEstimatedTokens = (
@@ -167,17 +185,27 @@ const fullTurn = (turn: HistoryTurn): ProjectedTurn => ({
   selectedMessageIndexes: turn.messages.map((message) => message.index)
 })
 
+const estimateFormattedMessageTokens = (message: HistoryMessage): number =>
+  estimateHistoryTokens(speakerPrefixFor(message)) +
+  estimateHistoryTokens(message.content.trim() || MEDIA_PLACEHOLDER)
+
+const estimateFullTurnTokens = (turn: HistoryTurn): number =>
+  turn.messages.reduce(
+    (total, message, index) =>
+      total + estimateFormattedMessageTokens(message) + (index > 0 ? 2 : 0),
+    0
+  )
+
 const projectTurn = (turn: HistoryTurn, budget: number): ProjectedTurn | undefined => {
-  const full = fullTurn(turn)
-  if (estimateHistoryTokens(full.text) <= budget) return full
+  if (estimateFullTurnTokens(turn) <= budget) return fullTurn(turn)
 
   const user = turn.messages[0]
   if (!user) return undefined
-  const fullUser = formatMessage(user)
+  const fullUserCost = estimateFormattedMessageTokens(user)
   const selectedMessageIndexes = [user.index]
 
-  if (estimateHistoryTokens(fullUser) > budget) {
-    const label = '**User:** '
+  if (fullUserCost > budget) {
+    const label = speakerPrefixFor(user)
     const contentBudget = budget - estimateHistoryTokens(label)
     if (contentBudget <= estimateHistoryTokens(MESSAGE_OMISSION_NOTE)) return undefined
     return {
@@ -187,6 +215,7 @@ const projectTurn = (turn: HistoryTurn, budget: number): ProjectedTurn | undefin
     }
   }
 
+  const fullUser = formatMessage(user)
   const assistant = turn.messages.at(-1)
   if (!assistant || isUserMessage(assistant))
     return { index: turn.index, text: fullUser, selectedMessageIndexes }
@@ -264,17 +293,23 @@ export const buildHistoryReplay = (
   if (turns.length === 0) return undefined
 
   const budget = resolveHistoryReplayBudget(descriptor)
-  const fullConversation = `${HEADER}\n\n## Conversation\n${turns
-    .map((turn) => fullTurn(turn).text)
-    .join('\n\n')}`
-  if (estimateHistoryTokens(fullConversation) <= budget) {
+  const fullConversationPrefix = `${HEADER}\n\n## Conversation\n`
+  let fullConversationCost = estimateHistoryTokens(fullConversationPrefix)
+  const fullTurns: ProjectedTurn[] = []
+  for (const turn of turns) {
+    fullConversationCost += estimateFullTurnTokens(turn) + (fullTurns.length > 0 ? 2 : 0)
+    if (fullConversationCost > budget) break
+    fullTurns.push(fullTurn(turn))
+  }
+  if (fullTurns.length === turns.length) {
+    const fullConversation = `${fullConversationPrefix}${fullTurns
+      .map((turn) => turn.text)
+      .join('\n\n')}`
     return {
       preamble: fullConversation,
-      selectedMessageIndexes: turns.flatMap((turn) =>
-        turn.messages.map((message) => message.index)
-      ),
+      selectedMessageIndexes: fullTurns.flatMap((turn) => turn.selectedMessageIndexes),
       budget,
-      estimatedTokens: estimateHistoryTokens(fullConversation)
+      estimatedTokens: fullConversationCost
     }
   }
 
@@ -294,18 +329,23 @@ export const buildHistoryReplay = (
 
   const anchorTurn = turns[0]
   const anchorProjectionBudget = Math.max(1, Math.floor(budget * 0.3))
+  const preferredAnchor = projectTurn(anchorTurn, anchorProjectionBudget)
   const anchor =
-    projectTurn(anchorTurn, anchorProjectionBudget) ??
-    fitTurnForPacket(anchorTurn, budget, (projection) =>
-      renderLongPacket(projection, [], turns.length)
-    )
+    preferredAnchor &&
+    estimateHistoryTokens(renderLongPacket(preferredAnchor, [], turns.length)) <= budget
+      ? preferredAnchor
+      : fitTurnForPacket(anchorTurn, budget, (projection) =>
+          renderLongPacket(projection, [], turns.length)
+        )
   if (!anchor) return undefined
 
   const recent: ProjectedTurn[] = []
   const latestTurn = turns.at(-1)!
-  const latestFull = fullTurn(latestTurn)
-  const latestCandidate = renderLongPacket(anchor, [latestFull], turns.length)
-  if (estimateHistoryTokens(latestCandidate) <= budget) {
+  const latestFull = estimateFullTurnTokens(latestTurn) <= budget ? fullTurn(latestTurn) : undefined
+  const latestCandidate = latestFull
+    ? renderLongPacket(anchor, [latestFull], turns.length)
+    : undefined
+  if (latestFull && latestCandidate && estimateHistoryTokens(latestCandidate) <= budget) {
     recent.unshift(latestFull)
   } else {
     const latest = fitTurnForPacket(latestTurn, budget, (projection) =>
@@ -315,6 +355,7 @@ export const buildHistoryReplay = (
   }
 
   for (let index = turns.length - 2; index > 0; index -= 1) {
+    if (estimateFullTurnTokens(turns[index]) > budget) break
     const turn = fullTurn(turns[index])
     const candidate = renderLongPacket(anchor, [turn, ...recent], turns.length)
     if (estimateHistoryTokens(candidate) > budget) break
@@ -322,6 +363,8 @@ export const buildHistoryReplay = (
   }
 
   const preamble = renderLongPacket(anchor, recent, turns.length)
+  const estimatedTokens = estimateHistoryTokens(preamble)
+  if (estimatedTokens > budget) return undefined
   return {
     preamble,
     selectedMessageIndexes: [
@@ -329,7 +372,7 @@ export const buildHistoryReplay = (
       ...recent.flatMap((turn) => turn.selectedMessageIndexes)
     ],
     budget,
-    estimatedTokens: estimateHistoryTokens(preamble)
+    estimatedTokens
   }
 }
 

--- a/src/shared/history-preamble.ts
+++ b/src/shared/history-preamble.ts
@@ -1,56 +1,333 @@
-// Character budget for the replayed transcript. Kept modest so a long conversation cannot blow the new
-// agent's context window on its first turn after a framework switch or unresumable restart.
-const DEFAULT_PREAMBLE_BUDGET = 12_000
+export type HistoryReplayTarget = 'claude-code' | 'opencode' | 'codex-response' | 'codex-bridge'
+
+export type HistoryReplayDescriptor = {
+  target: HistoryReplayTarget
+  contextWindow?: number
+  // Test/diagnostic override; production callers use the target policy above.
+  budget?: number
+}
+
+type HistoryReplayPolicy = {
+  contextShare: number
+  cap: number
+}
+
+const HISTORY_REPLAY_POLICIES: Record<HistoryReplayTarget, HistoryReplayPolicy> = {
+  'claude-code': { contextShare: 0.1, cap: 16_000 },
+  opencode: { contextShare: 0.08, cap: 12_000 },
+  'codex-response': { contextShare: 0.1, cap: 16_000 },
+  'codex-bridge': { contextShare: 0.05, cap: 8_000 }
+}
+
+const MIN_REPLAY_BUDGET = 2_000
 
 const HEADER =
-  'The conversation below happened earlier in this session, before you joined it. Treat it as prior' +
-  ' context — do not reply to it directly; continue from the user message that follows.'
+  'The conversation below happened earlier in this session, before you joined it. It is an ' +
+  'application-generated handoff; continue from the new user message after it and do not reply to ' +
+  'this history directly.'
 
-const OMISSION_NOTE = '[…earlier turns omitted for length…]'
+const OMISSION_NOTE = '[…middle turns omitted for replay budget…]'
+const RESPONSE_OMISSION_NOTE = '[…earlier response omitted for replay budget…]'
+const MESSAGE_OMISSION_NOTE = '[…middle of this message omitted for replay budget…]'
 
-type HistoryMessage = {
+export type HistoryMessage = {
   role: string
   content: string
   status?: string
+  hasReplayMedia?: boolean
 }
 
-const formatMessage = (message: HistoryMessage): string => {
-  const speaker = message.role === 'user' ? 'User' : 'Assistant'
-  return `**${speaker}:** ${message.content.trim()}`
+export type HistoryReplaySelection = {
+  preamble: string
+  selectedMessageIndexes: number[]
+  budget: number
+  estimatedTokens: number
 }
 
-// Builds a bounded text-only transcript. Tool effects already live on disk and are intentionally omitted.
-export const buildHistoryPreamble = (
-  messages: HistoryMessage[],
-  budget: number = DEFAULT_PREAMBLE_BUDGET
-): string | undefined => {
-  const usable = messages.filter(
-    (message) => message.status !== 'error' && message.content.trim().length > 0
-  )
+type IndexedHistoryMessage = HistoryMessage & { index: number }
+type HistoryTurn = { index: number; messages: IndexedHistoryMessage[] }
+type ProjectedTurn = { index: number; text: string; selectedMessageIndexes: number[] }
 
-  if (usable.length === 0) return undefined
+const isUserMessage = (message: HistoryMessage): boolean => message.role === 'user'
+const speakerFor = (message: HistoryMessage): 'User' | 'Assistant' =>
+  isUserMessage(message) ? 'User' : 'Assistant'
+const formatMessage = (message: HistoryMessage): string =>
+  `**${speakerFor(message)}:** ${message.content.trim() || '[media attached]'}`
 
-  const kept: HistoryMessage[] = []
-  let used = 0
+// Stable conservative admission estimate: ASCII-heavy text gets the usual four-bytes-per-token
+// approximation, while every non-ASCII code point costs at least one token.
+export const estimateHistoryTokens = (text: string): number => {
+  let asciiBytes = 0
+  let nonAsciiCodePoints = 0
 
-  for (let index = usable.length - 1; index >= 0; index -= 1) {
-    const line = formatMessage(usable[index])
-    const cost = line.length + 2
-
-    if (kept.length > 0 && used + cost > budget) break
-
-    kept.unshift(usable[index])
-    used += cost
+  for (const codePoint of text) {
+    if (codePoint.codePointAt(0)! <= 0x7f) asciiBytes += 1
+    else nonAsciiCodePoints += 1
   }
 
-  const omittedSome = kept.length < usable.length
-  const body = kept.map(formatMessage).join('\n\n')
-  const transcript = omittedSome ? `${OMISSION_NOTE}\n\n${body}` : body
-  const omissionPrefix = `${OMISSION_NOTE}\n\n`
-  const boundedTranscript =
-    transcript.length <= budget
-      ? transcript
-      : `${omissionPrefix}${transcript.slice(-Math.max(0, budget - omissionPrefix.length))}`
-
-  return `${HEADER}\n\n${boundedTranscript}`
+  return Math.ceil(asciiBytes / 4) + nonAsciiCodePoints
 }
+
+export const resolveHistoryReplayBudget = ({
+  target,
+  contextWindow,
+  budget
+}: HistoryReplayDescriptor): number => {
+  if (budget !== undefined && Number.isFinite(budget) && budget > 0) return Math.floor(budget)
+  const policy = HISTORY_REPLAY_POLICIES[target]
+  if (!contextWindow || !Number.isFinite(contextWindow) || contextWindow <= 0) return policy.cap
+
+  const proportional = Math.floor(contextWindow * policy.contextShare)
+  const floor = contextWindow >= MIN_REPLAY_BUDGET * 2 ? MIN_REPLAY_BUDGET : proportional
+  return Math.max(1, Math.min(policy.cap, Math.max(floor, proportional)))
+}
+
+export const resolveFileTextBudget = (contextWindow?: number): number => {
+  if (!contextWindow || !Number.isFinite(contextWindow) || contextWindow <= 0) return 12_000
+  return Math.max(1, Math.min(32_000, Math.floor(contextWindow * 0.2)))
+}
+
+const takePrefixWithinTokens = (text: string, budget: number): string => {
+  if (budget <= 0) return ''
+  const codePoints = Array.from(text)
+  let low = 0
+  let high = codePoints.length
+
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2)
+    if (estimateHistoryTokens(codePoints.slice(0, middle).join('')) <= budget) low = middle
+    else high = middle - 1
+  }
+
+  return codePoints.slice(0, low).join('')
+}
+
+const takeSuffixWithinTokens = (text: string, budget: number): string => {
+  if (budget <= 0) return ''
+  const codePoints = Array.from(text)
+  let low = 0
+  let high = codePoints.length
+
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2)
+    if (estimateHistoryTokens(codePoints.slice(-middle).join('')) <= budget) low = middle
+    else high = middle - 1
+  }
+
+  return codePoints.slice(-low).join('')
+}
+
+export const truncateTextToEstimatedTokens = (
+  text: string,
+  budget: number,
+  mode: 'start' | 'end' | 'both' = 'end'
+): string => {
+  if (estimateHistoryTokens(text) <= budget) return text
+  if (budget <= 0) return ''
+
+  if (mode === 'start') return takePrefixWithinTokens(text, budget)
+  if (mode === 'end') return takeSuffixWithinTokens(text, budget)
+
+  const markerCost = estimateHistoryTokens(MESSAGE_OMISSION_NOTE)
+  const contentBudget = Math.max(0, budget - markerCost - 2)
+  const prefixBudget = Math.ceil(contentBudget / 2)
+  const suffixBudget = Math.floor(contentBudget / 2)
+  const prefix = takePrefixWithinTokens(text, prefixBudget)
+  const suffix = takeSuffixWithinTokens(text, suffixBudget)
+  return [prefix, MESSAGE_OMISSION_NOTE, suffix].filter(Boolean).join('\n')
+}
+
+const groupUserLedTurns = (messages: HistoryMessage[]): HistoryTurn[] => {
+  const usable = messages
+    .map((message, index) => ({ ...message, index }))
+    .filter(
+      (message) =>
+        message.status !== 'error' &&
+        (message.content.trim().length > 0 || message.hasReplayMedia === true)
+    )
+  const turns: HistoryTurn[] = []
+
+  for (const message of usable) {
+    if (isUserMessage(message)) {
+      turns.push({ index: turns.length, messages: [message] })
+      continue
+    }
+
+    // Never replay an Assistant message without the user-led turn it answers.
+    turns.at(-1)?.messages.push(message)
+  }
+
+  return turns
+}
+
+const fullTurn = (turn: HistoryTurn): ProjectedTurn => ({
+  index: turn.index,
+  text: turn.messages.map(formatMessage).join('\n\n'),
+  selectedMessageIndexes: turn.messages.map((message) => message.index)
+})
+
+const projectTurn = (turn: HistoryTurn, budget: number): ProjectedTurn | undefined => {
+  const full = fullTurn(turn)
+  if (estimateHistoryTokens(full.text) <= budget) return full
+
+  const user = turn.messages[0]
+  if (!user) return undefined
+  const fullUser = formatMessage(user)
+  const selectedMessageIndexes = [user.index]
+
+  if (estimateHistoryTokens(fullUser) > budget) {
+    const label = '**User:** '
+    const contentBudget = budget - estimateHistoryTokens(label)
+    if (contentBudget <= estimateHistoryTokens(MESSAGE_OMISSION_NOTE)) return undefined
+    return {
+      index: turn.index,
+      text: `${label}${truncateTextToEstimatedTokens(user.content.trim(), contentBudget, 'both')}`,
+      selectedMessageIndexes
+    }
+  }
+
+  const assistant = turn.messages.at(-1)
+  if (!assistant || isUserMessage(assistant))
+    return { index: turn.index, text: fullUser, selectedMessageIndexes }
+
+  const assistantPrefix = `**Assistant:** ${RESPONSE_OMISSION_NOTE}\n`
+  const assistantBudget =
+    budget - estimateHistoryTokens(fullUser) - estimateHistoryTokens(assistantPrefix) - 2
+  if (assistantBudget <= 0) return { index: turn.index, text: fullUser, selectedMessageIndexes }
+
+  const tail = truncateTextToEstimatedTokens(assistant.content.trim(), assistantBudget, 'end')
+  if (!tail) return { index: turn.index, text: fullUser, selectedMessageIndexes }
+
+  return {
+    index: turn.index,
+    text: `${fullUser}\n\n${assistantPrefix}${tail}`,
+    selectedMessageIndexes: [...selectedMessageIndexes, assistant.index]
+  }
+}
+
+const renderLongPacket = (
+  anchor: ProjectedTurn,
+  recent: ProjectedTurn[],
+  totalTurns: number
+): string => {
+  if (totalTurns === 1) return `${HEADER}\n\n## Conversation\n${anchor.text}`
+
+  const sections = [`${HEADER}\n\n## Original task\n${anchor.text}`]
+  const recentStartsAt = recent[0]?.index
+  if (recentStartsAt === undefined || recentStartsAt > anchor.index + 1)
+    sections.push(OMISSION_NOTE)
+  if (recent.length > 0)
+    sections.push(`## Recent conversation\n${recent.map((turn) => turn.text).join('\n\n')}`)
+  return sections.join('\n\n')
+}
+
+const fitTurnForPacket = (
+  turn: HistoryTurn,
+  budget: number,
+  render: (projection: ProjectedTurn) => string
+): ProjectedTurn | undefined => {
+  let low = 1
+  let high = budget
+  let best: ProjectedTurn | undefined
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2)
+    const projection = projectTurn(turn, middle)
+    if (projection && estimateHistoryTokens(render(projection)) <= budget) {
+      best = projection
+      low = middle + 1
+    } else {
+      high = middle - 1
+    }
+  }
+
+  return best
+}
+
+export const buildHistoryReplay = (
+  messages: HistoryMessage[],
+  descriptor: HistoryReplayDescriptor
+): HistoryReplaySelection | undefined => {
+  const turns = groupUserLedTurns(messages)
+  if (turns.length === 0) return undefined
+
+  const budget = resolveHistoryReplayBudget(descriptor)
+  const fullConversation = `${HEADER}\n\n## Conversation\n${turns
+    .map((turn) => fullTurn(turn).text)
+    .join('\n\n')}`
+  if (estimateHistoryTokens(fullConversation) <= budget) {
+    return {
+      preamble: fullConversation,
+      selectedMessageIndexes: turns.flatMap((turn) =>
+        turn.messages.map((message) => message.index)
+      ),
+      budget,
+      estimatedTokens: estimateHistoryTokens(fullConversation)
+    }
+  }
+
+  if (turns.length === 1) {
+    const anchor = fitTurnForPacket(turns[0], budget, (projection) =>
+      renderLongPacket(projection, [], 1)
+    )
+    if (!anchor) return undefined
+    const preamble = renderLongPacket(anchor, [], 1)
+    return {
+      preamble,
+      selectedMessageIndexes: anchor.selectedMessageIndexes,
+      budget,
+      estimatedTokens: estimateHistoryTokens(preamble)
+    }
+  }
+
+  const anchorTurn = turns[0]
+  const anchorProjectionBudget = Math.max(1, Math.floor(budget * 0.3))
+  const anchor =
+    projectTurn(anchorTurn, anchorProjectionBudget) ??
+    fitTurnForPacket(anchorTurn, budget, (projection) =>
+      renderLongPacket(projection, [], turns.length)
+    )
+  if (!anchor) return undefined
+
+  const recent: ProjectedTurn[] = []
+  const latestTurn = turns.at(-1)!
+  const latestFull = fullTurn(latestTurn)
+  const latestCandidate = renderLongPacket(anchor, [latestFull], turns.length)
+  if (estimateHistoryTokens(latestCandidate) <= budget) {
+    recent.unshift(latestFull)
+  } else {
+    const latest = fitTurnForPacket(latestTurn, budget, (projection) =>
+      renderLongPacket(anchor, [projection], turns.length)
+    )
+    if (latest) recent.unshift(latest)
+  }
+
+  for (let index = turns.length - 2; index > 0; index -= 1) {
+    const turn = fullTurn(turns[index])
+    const candidate = renderLongPacket(anchor, [turn, ...recent], turns.length)
+    if (estimateHistoryTokens(candidate) > budget) break
+    recent.unshift(turn)
+  }
+
+  const preamble = renderLongPacket(anchor, recent, turns.length)
+  return {
+    preamble,
+    selectedMessageIndexes: [
+      ...anchor.selectedMessageIndexes,
+      ...recent.flatMap((turn) => turn.selectedMessageIndexes)
+    ],
+    budget,
+    estimatedTokens: estimateHistoryTokens(preamble)
+  }
+}
+
+// Compatibility wrapper for non-workspace consumers that need text only. New workspace replay paths
+// use buildHistoryReplay() so media selection follows the admitted message indexes.
+export const buildHistoryPreamble = (
+  messages: HistoryMessage[],
+  descriptor: HistoryReplayDescriptor | number = { target: 'claude-code' }
+): string | undefined =>
+  buildHistoryReplay(
+    messages,
+    typeof descriptor === 'number' ? { target: 'claude-code', budget: descriptor } : descriptor
+  )?.preamble

--- a/src/shared/uploads.ts
+++ b/src/shared/uploads.ts
@@ -14,6 +14,31 @@ export const MAX_UPLOAD_CHUNK_BYTES = 8 * 1024 * 1024
 // Composer total attachment cap; enforced renderer-side since main is stateless about composer state.
 export const MAX_COMPOSER_ATTACHMENTS = 10
 
+const GENERIC_UPLOAD_MIME_TYPES = new Set(['application/octet-stream', 'binary/octet-stream'])
+const RASTER_IMAGE_MIME_BY_EXTENSION = new Map<string, string>([
+  ['png', 'image/png'],
+  ['jpg', 'image/jpeg'],
+  ['jpeg', 'image/jpeg'],
+  ['gif', 'image/gif'],
+  ['webp', 'image/webp'],
+  ['avif', 'image/avif']
+])
+
+// Shared by renderer replay selection and main-process prompt materialization so generic or missing
+// MIME metadata cannot make the two layers disagree about whether an upload is a supported image.
+export const imageAttachmentMimeType = (name: string, mimeType?: string): string | undefined => {
+  const essence = mimeType?.split(';', 1)[0]?.trim().toLowerCase()
+
+  if (essence?.startsWith('image/')) {
+    return essence === 'image/svg+xml' ? undefined : essence
+  }
+  if (essence && !GENERIC_UPLOAD_MIME_TYPES.has(essence)) return undefined
+
+  const dot = name.lastIndexOf('.')
+  const extension = dot >= 0 ? name.slice(dot + 1).toLowerCase() : ''
+  return RASTER_IMAGE_MIME_BY_EXTENSION.get(extension)
+}
+
 export const formatUploadSizeLimit = (bytes: number): string => {
   const gibibytes = bytes / (1024 * 1024 * 1024)
   if (bytes >= 1024 * 1024 * 1024) {


### PR DESCRIPTION
## Problem

When an ACP session cannot be resumed after switching agents or starting a replacement session, the app currently replays a character-truncated tail of the transcript. That can lose the original task, split user/assistant turns, replay unrelated media, and spend the same context budget across Claude Code, OpenCode, direct Codex Responses, and the Codex bridge even though their context paths differ.

Notebook continuity is also only available through a later tool call, so a replacement agent can begin its first turn without the small amount of live execution state needed to continue safely.

## Proposed change

- classify replay targets as `claude-code`, `opencode`, `codex-response`, or `codex-bridge` and derive a bounded token budget from the target and advertised context window
- build replay from user-led turns, retaining the original task plus a contiguous recent suffix instead of slicing the final characters
- preserve role labels, avoid orphan assistant replies, account conservatively for CJK text, and truncate oversized messages within their role
- replay attachments and images only when their source message survives text selection
- share one cumulative text budget across injected file contents
- peek at already-loaded Notebook execution state and inject a compact, one-shot continuity block on the first replayed prompt
- keep replay and Notebook continuity private to the agent prompt; the user-facing message remains the text the user entered

```mermaid
flowchart LR
  A["ACP context reset"] --> B["Resolve target agent"]
  B --> C["Select original task + recent turns"]
  C --> D["Select media from admitted messages"]
  B --> E["Peek loaded Notebook state"]
  D --> F["Compose private replay prompt"]
  E --> F
  F --> G["Replacement agent first turn"]
  H["Current user message"] --> F
  H --> I["User-facing conversation bubble"]
```

## Scope and non-goals

- This changes context assembly and first-turn injection behavior.
- It does not change database fields, schemas, relationships, migrations, or persisted session data.
- Notebook state is read only from an already-loaded in-memory session; the peek does not create or reload a session.
- It does not change Notebook/MCP/function-call return projections, permission-message presentation, connector Skill materialization, or connector result schemas.

## Acceptance criteria and validation

The checks below ran after the final rebase/conflict resolution.

- target-specific replay budgets, original-task anchoring, contiguous recent turns, CJK accounting, and media correlation -> `npm test -- --exclude docs/internal/2026-08-05-context-lifecycle-replay-spike.test.ts` -> 11,283 passed, 184 skipped
- cumulative file-content admission and one-shot Notebook continuity -> same complete tracked Vitest suite -> passed
- context-reset runtime composition and private prompt/user-message separation -> `npm test -- --run src/main/acp/runtime.test.ts` -> 415 passed
- Node and renderer contracts -> `npm run typecheck` -> passed
- linted source/configuration -> `npm run lint` -> 0 errors; 17 existing warnings outside this diff

The excluded `docs/internal` spike is gitignored, absent from this PR and clean CI checkouts, and intentionally captures pre-implementation behavior. No platform-specific persistence or migration lane is required because the change adds neither.

## Review focus

- whether the four target policies leave sufficient headroom for the active turn and agent-owned system context
- whether turn grouping and oversized-message fallback always preserve a usable user instruction
- whether media selection stays aligned with admitted transcript messages
- whether Notebook continuity remains one-shot, read-only, compact, and invisible in the user-facing message

Uncovered risk: provider behavior is verified at local interfaces and runtime fakes, not with live end-to-end sessions against every external ACP agent.
