### PR TITLE
build(dependency-security): remediate production audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
         "@lobehub/icons": "^5.14.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@prisma/client": "^6.19.3",
         "@radix-ui/react-focus-scope": "^1.1.11",
         "@rc-component/qrcode": "^2.0.0",
@@ -28,7 +28,7 @@
         "marked": "^17.0.6",
         "openchemlib": "^9.24.0",
         "pdfjs-dist": "5.4.624",
-        "tar": "^7.5.20",
+        "tar": "^7.5.22",
         "tiff": "7.1.3",
         "ws": "^8.21.1",
         "zod": "^4.4.3"
@@ -2800,10 +2800,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -3395,10 +3397,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -10589,7 +10593,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -12053,7 +12059,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -13066,7 +13074,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -13319,7 +13329,9 @@
       "license": "MIT"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -20247,9 +20259,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@lobehub/icons": "^5.14.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@prisma/client": "^6.19.3",
     "@radix-ui/react-focus-scope": "^1.1.11",
     "@rc-component/qrcode": "^2.0.0",
@@ -65,7 +65,7 @@
     "marked": "^17.0.6",
     "openchemlib": "^9.24.0",
     "pdfjs-dist": "5.4.624",
-    "tar": "^7.5.20",
+    "tar": "^7.5.22",
     "tiff": "7.1.3",
     "ws": "^8.21.1",
     "zod": "^4.4.3"


### PR DESCRIPTION
## Problem

`npm audit --omit=dev` reported seven production dependency vulnerabilities: two high, four moderate, and one low. The vulnerable tree included direct dependencies `@modelcontextprotocol/sdk@1.29.0` and `tar@7.5.20`, plus their Hono, IP parsing, URI parsing, and sanitization transitive dependencies.

## Proposed change

- Raise `@modelcontextprotocol/sdk` to `^1.30.0`.
- Raise `tar` to `^7.5.22`.
- Refresh only the affected lockfile tree, resolving patched versions of `@hono/node-server`, Hono, `fast-uri`, `ip-address`, and DOMPurify.

## Scope and non-goals

- No application source, architecture, data model, persistence, or user-interaction changes.
- No Dependabot, GitHub security setting, CI workflow, or scheduled audit changes.
- Do not hide or broaden the existing `@emoji-mart/react@1.1.1` / React 19 peer warning; renderer and editor compatibility are verified locally instead.
- Dev-only audit findings are outside this production-dependency fix.

## Acceptance criteria and validation

All checks below ran after the final dependency edit. `npm ci` and the production audit were repeated after rebasing onto the latest `main`.

- Production dependency safety -> `npm audit --omit=dev --json` -> 0 vulnerabilities.
- Reproducible installation and patch integrity -> `npm ci` -> passed, including patch-package, the Claude ACP patch integrity check, Prisma generation, and Electron native dependency rebuild.
- MCP, archive, Settings, and editor compatibility -> targeted Vitest command covering nine files -> 180/180 tests passed.
- Node and renderer contracts -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings.
- Portable behavior -> `npm test` -> 762 files and 11,273 tests passed; 14 files and 184 tests skipped by project conditions; 0 failures.
- Electron production compilation -> `npm run build:e2e` -> passed.

Local macOS validation cannot replace the PR Gate's Windows lanes. The full dev tree still reports three high-severity findings, while the production tree targeted here reports zero.

## Review focus

- Confirm the direct dependency floors are the intended patched releases.
- Confirm the lockfile diff is limited to the affected vulnerable dependency chains.
- Confirm retaining the existing React peer warning as a separate concern is acceptable.
