### PR TITLE
refactor(acp): extract provider session adopter

### DIFF
--- a/src/main/acp/provider-session-adopter.test.ts
+++ b/src/main/acp/provider-session-adopter.test.ts
@@ -1,0 +1,328 @@
+import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpCreateSessionResponse } from '../../shared/acp'
+import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
+import type { EffectiveSpecialistSkills } from '../../shared/specialist'
+import { claudeCodeFramework } from '../agent-framework'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import { AcpProviderSessionAdopter } from './provider-session-adopter'
+import { AcpSessionRegistry, type AcpPrimarySessionIdentityReservation } from './session-registry'
+
+const permissionProfile: SessionPermissionProfileState = {
+  selectedProfile: 'ask',
+  effectiveProfile: 'ask',
+  currentModeId: 'default',
+  availableModeIds: ['default'],
+  fullAccessAvailable: false
+}
+
+type ConfigurationFacts = {
+  permissionProfile: SessionPermissionProfileState
+  appliedModel: string | undefined
+  configOptions: undefined
+}
+
+type AdopterHarness = {
+  adopt: (specialistId?: string) => Promise<AcpCreateSessionResponse>
+  commit: ReturnType<typeof vi.fn>
+  commitClaudeReplay: ReturnType<typeof vi.fn>
+  configure: ReturnType<typeof vi.fn>
+  connection: ClientConnection
+  order: string[]
+  providerSession: ActiveSession
+  registry: AcpSessionRegistry
+  release: ReturnType<typeof vi.fn>
+  reservation: AcpPrimarySessionIdentityReservation
+  sessionSetupAppends: string[][]
+  setBackend: (next: AcpBackendGenerationView) => void
+}
+
+const createHarness = (
+  options: {
+    configure?: (
+      input: Parameters<
+        ConstructorParameters<typeof AcpProviderSessionAdopter>[0]['configurator']['configure']
+      >[0]
+    ) => Promise<ConfigurationFacts>
+    emitState?: () => void
+    foreignIdentityCollision?: (sessionIds: readonly string[]) => Error | undefined
+    handoffAppend?: string
+    specialistIdentity?: { append: string; prefix: string }
+    specialistSkills?: EffectiveSpecialistSkills
+  } = {}
+): AdopterHarness => {
+  const order: string[] = []
+  const sessionSetupAppends: string[][] = []
+  const providerSession = {
+    sessionId: 'fresh-provider-session',
+    dispose: vi.fn()
+  } as unknown as ActiveSession
+  const connection = {
+    agent: {
+      buildSession: vi.fn(() => {
+        order.push('session/new prepared')
+        return {
+          start: vi.fn(async () => {
+            order.push('session/new')
+            return providerSession
+          })
+        }
+      })
+    }
+  } as unknown as ClientConnection
+  let backend: AcpBackendGenerationView = {
+    framework: {
+      ...claudeCodeFramework,
+      buildSessionSetup: (input) => {
+        sessionSetupAppends.push([...(input.systemPromptAppends ?? [])])
+        return claudeCodeFramework.buildSessionSetup(input)
+      }
+    },
+    backendId: 'claude-code',
+    session: { modelRequired: false },
+    prompt: { systemPromptAppends: [] },
+    context: { supportsImageInput: false },
+    adapter: { nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false }
+  }
+  const registry = new AcpSessionRegistry({
+    foreignIdentityCollision: options.foreignIdentityCollision
+  })
+  vi.spyOn(registry, 'publish').mockImplementation((...args) => {
+    order.push('registry publish')
+    return AcpSessionRegistry.prototype.publish.call(registry, ...args)
+  })
+  const reservation = registry.reserve({
+    sessionIds: ['stable-app-session'],
+    mayRenewAfterConnectionSetup: true,
+    blockStartup: false
+  })
+  if (reservation.collision) throw reservation.collision
+  const commit = vi.fn(() => order.push('capability commit'))
+  const release = vi.fn(() => order.push('capability release'))
+  const commitClaudeReplay = vi.fn(() => order.push('handoff commit'))
+  const configure = vi.fn(
+    options.configure ??
+      (async () => {
+        order.push('configure')
+        return { permissionProfile, appliedModel: undefined, configOptions: undefined }
+      })
+  )
+  const adopter = new AcpProviderSessionAdopter({
+    currentBackend: () => backend,
+    registry,
+    reserveIdentity: (current, sessionIds) =>
+      registry.reserve({ reservation: current, sessionIds }),
+    capabilities: {
+      provision: vi.fn(async () => {
+        order.push('capability provision')
+        return {
+          mcpServers: [],
+          descriptor: {
+            role: 'primary' as const,
+            delegation: 'denied' as const,
+            transport: 'none' as const,
+            capabilities: [],
+            canonicalMcpServerNames: [],
+            modelFacingMcpServerNames: [],
+            controlRpcMethods: []
+          },
+          commit,
+          release
+        }
+      })
+    },
+    configurator: { configure },
+    resolveSpecialistIdentity: options.specialistIdentity
+      ? vi.fn(async () => options.specialistIdentity)
+      : undefined,
+    resolveSpecialistSkills: options.specialistSkills
+      ? vi.fn(async () => options.specialistSkills as EffectiveSpecialistSkills)
+      : undefined,
+    peekClaudeReplay: () => options.handoffAppend,
+    commitClaudeReplay,
+    updateCwd: () => order.push('cwd callback'),
+    emitState: () => {
+      order.push('state callback')
+      options.emitState?.()
+    },
+    diagnosticContext: () => ({})
+  })
+  const adopt = (specialistId?: string): Promise<AcpCreateSessionResponse> =>
+    adopter.adopt('stable-app-session', {
+      connection,
+      cwd: '/workspace',
+      projectName: 'project-a',
+      identity: reservation.reservation,
+      specialistId
+    })
+  return {
+    adopt,
+    commit,
+    commitClaudeReplay,
+    configure,
+    connection,
+    order,
+    providerSession,
+    registry,
+    release,
+    reservation: reservation.reservation,
+    sessionSetupAppends,
+    setBackend: (next: AcpBackendGenerationView) => {
+      backend = next
+    }
+  }
+}
+
+describe('AcpProviderSessionAdopter', () => {
+  it('publishes a fresh provider Session under the stable application Session id', async () => {
+    const harness = createHarness()
+
+    const response = await harness.adopt()
+
+    expect(response).toEqual({
+      sessionId: 'stable-app-session',
+      cwd: '/workspace',
+      frameworkId: 'claude-code',
+      backendId: 'claude-code',
+      contextReset: true
+    })
+    expect(harness.registry.lookup('stable-app-session')?.attachment?.session).toBe(
+      harness.providerSession
+    )
+    expect(harness.registry.resolveAppSessionId('fresh-provider-session')).toBe(
+      'stable-app-session'
+    )
+    expect(harness.commit).toHaveBeenCalledWith('stable-app-session')
+    expect(harness.order).toEqual([
+      'capability provision',
+      'session/new prepared',
+      'session/new',
+      'configure',
+      'registry publish',
+      'cwd callback',
+      'capability commit',
+      'handoff commit',
+      'state callback'
+    ])
+  })
+
+  it('disposes the provisional Session and capability when configuration fails', async () => {
+    const failure = new Error('configuration failed')
+    const harness = createHarness({ configure: vi.fn().mockRejectedValue(failure) })
+
+    await expect(harness.adopt()).rejects.toBe(failure)
+
+    expect(harness.providerSession.dispose).toHaveBeenCalledOnce()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.registry.lookup('stable-app-session')).toBeUndefined()
+    expect(harness.commitClaudeReplay).not.toHaveBeenCalled()
+    expect(harness.registry.isIdentityClaimed('stable-app-session')).toBe(false)
+  })
+
+  it('cleans provisional ownership when the provider Session id collides', async () => {
+    const collision = new Error('provider identity collision')
+    const harness = createHarness({
+      foreignIdentityCollision: (sessionIds) =>
+        sessionIds.includes('fresh-provider-session') ? collision : undefined
+    })
+
+    await expect(harness.adopt()).rejects.toBe(collision)
+
+    expect(harness.providerSession.dispose).toHaveBeenCalledOnce()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.registry.lookup('stable-app-session')).toBeUndefined()
+    expect(harness.commitClaudeReplay).not.toHaveBeenCalled()
+    expect(harness.registry.isIdentityClaimed('stable-app-session')).toBe(false)
+  })
+
+  it('does not revoke stable identity state after adoption is superseded', async () => {
+    const state = { registry: undefined as AcpSessionRegistry | undefined }
+    const harness = createHarness({
+      configure: async () => {
+        state.registry?.invalidatePending()
+        return { permissionProfile, appliedModel: undefined, configOptions: undefined }
+      }
+    })
+    state.registry = harness.registry
+
+    await expect(harness.adopt()).rejects.toThrow('ACP session startup was superseded.')
+
+    expect(harness.providerSession.dispose).toHaveBeenCalledOnce()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: false })
+    expect(harness.registry.lookup('stable-app-session')).toBeUndefined()
+    expect(harness.commitClaudeReplay).not.toHaveBeenCalled()
+    expect(harness.registry.isIdentityClaimed('stable-app-session')).toBe(false)
+  })
+
+  it('replays Specialist identity and staged handoff before committing continuity', async () => {
+    const harness = createHarness({
+      handoffAppend: 'staged handoff continuity',
+      specialistIdentity: {
+        append: 'specialist identity append',
+        prefix: 'specialist turn prefix'
+      },
+      specialistSkills: {
+        kind: 'specialist',
+        skillIds: ['skill-1'],
+        frameworkNames: ['literature-review'],
+        missingSkillIds: []
+      }
+    })
+
+    await harness.adopt('specialist-1')
+
+    expect(harness.sessionSetupAppends.flat()).toEqual(
+      expect.arrayContaining(['specialist identity append', 'staged handoff continuity'])
+    )
+    expect(harness.registry.lookup('stable-app-session')?.aggregate.snapshot()).toMatchObject({
+      specialistId: 'specialist-1',
+      specialistPrefix: 'specialist turn prefix'
+    })
+    expect(harness.order.indexOf('handoff commit')).toBeGreaterThan(
+      harness.order.indexOf('registry publish')
+    )
+  })
+
+  it('reconfigures against a live effort update before publishing the adopted Session', async () => {
+    const harness = createHarness()
+    let configuration = 0
+    harness.configure.mockImplementation(async (input) => {
+      configuration += 1
+      if (configuration === 1) {
+        harness.setBackend({
+          ...input.backend,
+          session: { ...input.backend.session, effort: 'high' }
+        })
+      }
+      return {
+        permissionProfile,
+        appliedModel: configuration === 1 ? 'stale-model-fact' : 'current-model-fact',
+        configOptions: undefined
+      }
+    })
+
+    await harness.adopt()
+
+    expect(harness.configure).toHaveBeenCalledTimes(2)
+    expect(harness.registry.lookup('stable-app-session')?.aggregate.snapshot().appliedModel).toBe(
+      'current-model-fact'
+    )
+  })
+
+  it('does not roll back publication when the state observer fails', async () => {
+    const harness = createHarness({
+      emitState: () => {
+        throw new Error('state observer failed')
+      }
+    })
+
+    await expect(harness.adopt()).resolves.toMatchObject({ sessionId: 'stable-app-session' })
+
+    expect(harness.registry.lookup('stable-app-session')?.attachment?.session).toBe(
+      harness.providerSession
+    )
+    expect(harness.providerSession.dispose).not.toHaveBeenCalled()
+    expect(harness.release).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/acp/provider-session-adopter.ts
+++ b/src/main/acp/provider-session-adopter.ts
@@ -1,0 +1,253 @@
+import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+
+import type { AcpCreateSessionResponse } from '../../shared/acp'
+import {
+  normalizePermissionProfile,
+  type PermissionProfileId
+} from '../../shared/permission-profiles'
+import type { EffectiveSpecialistSkills } from '../../shared/specialist'
+import { createLogger, diagnosticErrorFields } from '../logger'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import {
+  CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+  type AcpSessionCapabilityOwner,
+  type SessionCapabilityProvision
+} from './session-capability-owner'
+import type { AcpSessionConfigurator } from './session-configurator'
+import { AcpSessionPresentationPolicy } from './session-presentation-policy'
+import type {
+  AcpPrimarySessionIdentityReservation,
+  AcpPrimarySessionIdentityReservationResult,
+  AcpSessionRegistry
+} from './session-registry'
+
+const log = createLogger('acp')
+
+type AcpProviderSessionAdoptionRequest = Readonly<{
+  connection: ClientConnection
+  cwd: string
+  projectName: string
+  // The enclosing resume/reset transaction transfers its opaque stable-ID reservation here after
+  // reconnect renewal. Adoption owns extension, publication, and terminal release; the caller's
+  // finally may release the same handle only as an idempotent fallback.
+  identity: AcpPrimarySessionIdentityReservation
+  permissionProfile?: PermissionProfileId
+  specialistId?: string
+}>
+
+type AcpProviderSessionAdopterDependencies = Readonly<{
+  currentBackend: () => AcpBackendGenerationView
+  registry: AcpSessionRegistry
+  reserveIdentity: (
+    reservation: AcpPrimarySessionIdentityReservation,
+    sessionIds: string[]
+  ) => AcpPrimarySessionIdentityReservationResult
+  capabilities: Pick<AcpSessionCapabilityOwner, 'provision'>
+  configurator: Pick<AcpSessionConfigurator, 'configure'>
+  resolveSpecialistIdentity?: (
+    specialistId: string,
+    frameworkId: string
+  ) => Promise<{ append: string; prefix: string } | undefined>
+  resolveSpecialistSkills?: (specialistId: string) => Promise<EffectiveSpecialistSkills>
+  peekClaudeReplay: (sessionId: string) => string | undefined
+  commitClaudeReplay: (sessionId: string) => void
+  updateCwd: (cwd: string) => void
+  emitState: () => void
+  diagnosticContext: () => Readonly<Record<string, unknown>>
+}>
+
+export class AcpProviderSessionAdopter {
+  private readonly presentation = new AcpSessionPresentationPolicy()
+
+  constructor(private readonly deps: AcpProviderSessionAdopterDependencies) {}
+
+  async adopt(
+    stableAppSessionId: string,
+    request: AcpProviderSessionAdoptionRequest
+  ): Promise<AcpCreateSessionResponse> {
+    let capability: SessionCapabilityProvision | undefined
+    let provisionalSession: ActiveSession | undefined
+    let identity = request.identity
+    try {
+      const startupBackend = this.deps.currentBackend()
+      capability = await this.deps.capabilities.provision({
+        stableAppSessionId,
+        framework: startupBackend.framework,
+        nativeMcpEnabled: startupBackend.adapter.nativeMcpEnabled,
+        bridgeMcpAliasesEnabled: startupBackend.adapter.bridgeMcpAliasesEnabled,
+        policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+        sessionCwd: request.cwd,
+        projectName: request.projectName
+      })
+      const specialistId =
+        request.specialistId ??
+        this.deps.registry.lookup(stableAppSessionId)?.aggregate.snapshot().specialistId
+      const [specialistIdentity, specialistSkills] = await Promise.all([
+        this.resolveSpecialistIdentity(specialistId, startupBackend),
+        this.resolveSpecialistSkills(specialistId)
+      ])
+      const handoffAppend = this.deps.peekClaudeReplay(stableAppSessionId)
+      const setup = this.presentation.buildSessionSetup({
+        framework: startupBackend.framework,
+        tooling: {
+          artifacts: capability.descriptor.capabilities.includes('artifacts'),
+          notebook: capability.descriptor.capabilities.includes('notebook'),
+          skillImport: capability.descriptor.capabilities.includes('skill-import')
+        },
+        backendSystemPromptAppends: startupBackend.prompt.systemPromptAppends,
+        extraSystemPromptAppends: [specialistIdentity?.append, handoffAppend].filter(
+          (append): append is string => Boolean(append)
+        ),
+        persistentSystemPrompt: startupBackend.prompt.persistentSystemPrompt,
+        sessionOptions: startupBackend.session.options,
+        specialistSkills
+      })
+      provisionalSession = await request.connection.agent
+        .buildSession({ cwd: request.cwd, mcpServers: capability.mcpServers, ...setup.metaArg })
+        .start()
+
+      const reserved = this.deps.reserveIdentity(identity, [
+        stableAppSessionId,
+        provisionalSession.sessionId
+      ])
+      if (reserved.collision) {
+        this.disposeProvisional(provisionalSession, 'primary collision session disposal failed')
+        provisionalSession = undefined
+        throw reserved.collision
+      }
+      identity = reserved.reservation
+
+      const permissionProfile = normalizePermissionProfile(request.permissionProfile)
+      let backend = this.deps.currentBackend()
+      let configuration = await this.deps.configurator.configure({
+        backend,
+        connection: request.connection,
+        session: provisionalSession,
+        permissionProfile
+      })
+      for (;;) {
+        // Live effort may change outside the operation lease. Replay against the newest immutable
+        // generation view before synchronous publication, matching fresh creation semantics.
+        const currentBackend = this.deps.currentBackend()
+        if (currentBackend !== backend) {
+          backend = currentBackend
+          configuration = await this.deps.configurator.configure({
+            backend,
+            connection: request.connection,
+            session: provisionalSession,
+            permissionProfile
+          })
+          continue
+        }
+        identity.assertCurrent()
+        const { aggregate } = this.deps.registry.publish(identity, stableAppSessionId, {
+          session: provisionalSession,
+          cwd: request.cwd,
+          projectName: request.projectName,
+          frameworkId: backend.framework.id,
+          backendId: backend.backendId,
+          permissionProfile: structuredClone(configuration.permissionProfile),
+          appliedModel: configuration.appliedModel,
+          configOptions: structuredClone(configuration.configOptions)
+        })
+        this.deps.updateCwd(request.cwd)
+        if (specialistIdentity) {
+          aggregate.setSpecialistPrefix(specialistIdentity.prefix || undefined)
+        } else if (!specialistId) {
+          aggregate.setSpecialistPrefix(undefined)
+        }
+        if (request.specialistId) aggregate.setSpecialistId(request.specialistId)
+        capability.commit(stableAppSessionId)
+        this.deps.commitClaudeReplay(stableAppSessionId)
+        provisionalSession = undefined
+        capability = undefined
+        identity.release()
+        break
+      }
+
+      try {
+        this.deps.emitState()
+      } catch (error) {
+        this.safeLogError('adopted session state callback failed', error, stableAppSessionId)
+      }
+      return {
+        sessionId: stableAppSessionId,
+        cwd: request.cwd,
+        frameworkId: backend.framework.id,
+        ...(backend.backendId ? { backendId: backend.backendId } : {}),
+        contextReset: true
+      }
+    } catch (caught) {
+      let startupError = caught
+      let ownsStableIdentity = true
+      try {
+        identity.assertCurrent()
+      } catch (supersededError) {
+        startupError = supersededError
+        ownsStableIdentity = false
+      }
+      if (capability) {
+        try {
+          capability.release({ ownsStableIdentity })
+        } catch (cleanupError) {
+          this.safeLogError('adopted capability release failed', cleanupError, stableAppSessionId)
+        }
+      }
+      this.disposeProvisional(provisionalSession, 'adopted startup session disposal failed')
+      throw startupError
+    } finally {
+      identity.release()
+    }
+  }
+
+  private async resolveSpecialistIdentity(
+    specialistId: string | undefined,
+    backend: AcpBackendGenerationView
+  ): Promise<{ append: string; prefix: string } | undefined> {
+    if (!specialistId || !this.deps.resolveSpecialistIdentity) return undefined
+    try {
+      return await this.deps.resolveSpecialistIdentity(specialistId, backend.framework.id)
+    } catch {
+      return undefined
+    }
+  }
+
+  private async resolveSpecialistSkills(
+    specialistId: string | undefined
+  ): Promise<EffectiveSpecialistSkills | undefined> {
+    if (!specialistId || !this.deps.resolveSpecialistSkills) return undefined
+    try {
+      return await this.deps.resolveSpecialistSkills(specialistId)
+    } catch {
+      return { kind: 'unavailable', reason: 'The bound specialist is unavailable.' }
+    }
+  }
+
+  private disposeProvisional(session: ActiveSession | undefined, message: string): void {
+    if (!session) return
+    try {
+      session.dispose()
+    } catch (error) {
+      this.safeLogError(message, error, session.sessionId, false)
+    }
+  }
+
+  private safeLogError(
+    message: string,
+    error: unknown,
+    sessionId: string,
+    includeContext = true
+  ): void {
+    try {
+      log.error(message, {
+        ...diagnosticErrorFields(error),
+        ...(includeContext ? this.deps.diagnosticContext() : {}),
+        sessionId
+      })
+    } catch {
+      // Diagnostics must never replace provider, cleanup, or observer outcomes.
+    }
+  }
+}
+
+export type { AcpProviderSessionAdoptionRequest }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -133,12 +133,13 @@ import {
   AcpBackendGenerationOwner,
   type AcpBackendGenerationView
 } from './backend-generation-owner'
-import { AcpSessionConfigurator, type AcpSessionConfigurationFacts } from './session-configurator'
+import { AcpSessionConfigurator } from './session-configurator'
 import { AcpSessionUpdateProjector, type AcpSessionUpdateEffect } from './session-update-projector'
 import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
 import { AcpConnectionCloseWorkflow, type CloseState } from './connection-close-workflow'
 import { AcpModelChangeWorkflow } from './model-change-workflow'
 import { AcpProviderSessionCreator } from './provider-session-creator'
+import { AcpProviderSessionAdopter } from './provider-session-adopter'
 import {
   AcpTurnSkillOwner,
   type AcpTurnSkillHooks,
@@ -518,6 +519,7 @@ class AcpRuntime {
   private readonly connectionLifecycle: AcpConnectionLifecycleWorkflow
   private readonly modelChanges: AcpModelChangeWorkflow
   private readonly providerSessionCreator: AcpProviderSessionCreator
+  private readonly providerSessionAdopter: AcpProviderSessionAdopter
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -788,6 +790,21 @@ class AcpRuntime {
       registerSessionSpecialist: options.notebook?.registerSessionSpecialist,
       updateCwd: (cwd) => this.snapshotOwner.updateCwd(cwd),
       pushEvent: (event) => this.pushEvent(event),
+      emitState: () => this.emitState(),
+      diagnosticContext: () => this.diagnosticContext()
+    })
+    this.providerSessionAdopter = new AcpProviderSessionAdopter({
+      currentBackend: () => this.backend,
+      registry: this.sessionRegistry,
+      reserveIdentity: (reservation, sessionIds) =>
+        this.reservePrimarySessionIds(reservation, sessionIds),
+      capabilities: this.sessionCapabilities,
+      configurator: this.sessionConfigurator,
+      resolveSpecialistIdentity: options.resolveSpecialistIdentity,
+      resolveSpecialistSkills: options.resolveSpecialistSkills,
+      peekClaudeReplay: (sessionId) => this.handoffContinuity.peekClaudeReplay(sessionId),
+      commitClaudeReplay: (sessionId) => this.handoffContinuity.commitClaudeReplay(sessionId),
+      updateCwd: (cwd) => this.snapshotOwner.updateCwd(cwd),
       emitState: () => this.emitState(),
       diagnosticContext: () => this.diagnosticContext()
     })
@@ -1203,33 +1220,6 @@ class AcpRuntime {
   // Creates a protocol session, injects artifact tooling, and uses the returned id as the app session id.
   async createSession(request: AcpCreateSessionRequest = {}): Promise<AcpCreateSessionResponse> {
     return this.withOperationLease(() => this.providerSessionCreator.create(request))
-  }
-
-  // Registers a freshly-built agent session under an app-facing id (used when adopting a conversation
-  // onto a replaced agent after a provider switch). Remaps the agent's own id so later updates and
-  // permission requests relabel into the same conversation.
-  private adoptSession(
-    primaryIdentityReservation: AcpPrimarySessionIdentityReservation,
-    appSessionId: string,
-    session: ActiveSession,
-    cwd: string,
-    projectName: string,
-    backend: AcpBackendGenerationView,
-    configuration: AcpSessionConfigurationFacts
-  ): AcpSessionRegistryEntry {
-    const entry = this.attachSessionAggregate(primaryIdentityReservation, appSessionId, {
-      session,
-      cwd,
-      projectName,
-      frameworkId: backend.framework.id,
-      backendId: backend.backendId,
-      permissionProfile: structuredClone(configuration.permissionProfile),
-      appliedModel: configuration.appliedModel,
-      configOptions: structuredClone(configuration.configOptions)
-    })
-
-    this.snapshotOwner.updateCwd(cwd)
-    return entry
   }
 
   // Reattaches a persisted protocol session after an app restart so later prompts can stream.
@@ -1903,118 +1893,14 @@ class AcpRuntime {
     projectName: string,
     primaryIdentityReservation: AcpPrimarySessionIdentityReservation
   ): Promise<AcpCreateSessionResponse> {
-    // Fresh adoption also receives provisional app capability tokens. Transfer ownership only after
-    // adoptSession has registered the replacement; every earlier failure revokes them and disposes any
-    // partially-created Agent session.
-    let capabilityProvision: SessionCapabilityProvision | undefined
-    let adopted: ActiveSession | undefined
-    try {
-      capabilityProvision = await this.sessionCapabilities.provision({
-        stableAppSessionId: request.sessionId,
-        framework: this.framework,
-        nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
-        bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
-        policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-        sessionCwd,
-        projectName
-      })
-      const { mcpServers } = capabilityProvision
-      // A freshly adopted session carries no prior _meta, so the specialist identity append (Claude)
-      // must be re-resolved from the live binding. Without this, a context reset or specialist switch
-      // would silently drop the session's specialist identity.
-      const stagedSpecialistId =
-        request.specialistId ??
-        this.sessionRegistry.lookup(request.sessionId)?.aggregate.snapshot().specialistId
-      const specialistIdentity = await this.resolveCurrentSpecialistIdentity(
-        request.sessionId,
-        stagedSpecialistId
-      )
-      const handoffAppend = this.handoffContinuity.peekClaudeReplay(request.sessionId)
-      adopted = await connection.agent
-        .buildSession({
-          cwd: sessionCwd,
-          mcpServers,
-          ...this.buildSessionMetaArg(
-            [specialistIdentity?.append, handoffAppend].filter((append): append is string =>
-              Boolean(append)
-            ),
-            await this.resolveCurrentSpecialistSkills(request.sessionId, stagedSpecialistId)
-          )
-        })
-        .start()
-
-      const reservationResult = this.reservePrimarySessionIds(primaryIdentityReservation, [
-        request.sessionId,
-        adopted.sessionId
-      ])
-      if (reservationResult.collision) {
-        this.disposeSessionAfterFailure(adopted, 'primary collision session disposal failed')
-        adopted = undefined
-        throw reservationResult.collision
-      }
-      primaryIdentityReservation = reservationResult.reservation
-
-      const backend = this.backend
-      const configuration = await this.sessionConfigurator.configure({
-        backend,
-        connection,
-        session: adopted,
-        permissionProfile: normalizePermissionProfile(request.permissionProfile)
-      })
-      this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
-      const { aggregate } = this.adoptSession(
-        primaryIdentityReservation,
-        request.sessionId,
-        adopted,
-        sessionCwd,
-        projectName,
-        backend,
-        configuration
-      )
-      if (specialistIdentity) {
-        aggregate.setSpecialistPrefix(specialistIdentity.prefix || undefined)
-      } else if (!stagedSpecialistId) {
-        aggregate.setSpecialistPrefix(undefined)
-      }
-      if (request.specialistId) {
-        aggregate.setSpecialistId(request.specialistId)
-      }
-      capabilityProvision.commit(request.sessionId)
-      this.handoffContinuity.commitClaudeReplay(request.sessionId)
-      this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      capabilityProvision = undefined
-      try {
-        this.emitState()
-      } catch (error) {
-        safeLogError('adopted session state callback failed', {
-          ...diagnosticErrorFields(error),
-          sessionId: request.sessionId
-        })
-      }
-
-      return {
-        sessionId: request.sessionId,
-        cwd: sessionCwd,
-        frameworkId: this.framework.id,
-        ...(this.backendId ? { backendId: this.backendId } : {}),
-        contextReset: true
-      }
-    } catch (error) {
-      let startupError = error
-      let ownsStableIdentity = true
-      try {
-        this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
-      } catch (supersededError) {
-        startupError = supersededError
-        ownsStableIdentity = false
-      }
-      capabilityProvision?.release({ ownsStableIdentity })
-      capabilityProvision = undefined
-      if (adopted) {
-        this.disposeSessionAfterFailure(adopted, 'adopted startup session disposal failed')
-      }
-      throw startupError
-    }
+    return this.providerSessionAdopter.adopt(request.sessionId, {
+      connection,
+      cwd: sessionCwd,
+      projectName,
+      identity: primaryIdentityReservation,
+      permissionProfile: request.permissionProfile,
+      specialistId: request.specialistId
+    })
   }
 
   // Changes approval behavior only while the conversation is idle. Applying the ACP mode before the
@@ -3109,21 +2995,6 @@ class AcpRuntime {
       return await this.options.resolveSpecialistSkills(specialistId)
     } catch {
       return { kind: 'unavailable', reason: 'The bound specialist is unavailable.' }
-    }
-  }
-
-  // Re-resolves the current Specialist identity when a stable app Session adopts a fresh provider
-  // Session. Claude re-bakes the append into Session metadata; Codex/OpenCode retain the prefix for
-  // subsequent prompts.
-  private async resolveCurrentSpecialistIdentity(
-    sessionId: string,
-    specialistId = this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().specialistId
-  ): Promise<{ append: string; prefix: string } | undefined> {
-    if (!specialistId || !this.options.resolveSpecialistIdentity) return undefined
-    try {
-      return await this.options.resolveSpecialistIdentity(specialistId, this.framework.id)
-    } catch {
-      return undefined
     }
   }
 


### PR DESCRIPTION
## Problem

`AcpRuntime` still owned the full fresh-provider Session adoption transaction: capability provisioning, Specialist and handoff presentation, provider `session/new`, stable App/provider identity arbitration, configuration, publication, rollback, and observer ordering. That kept identity and cleanup knowledge in the Runtime facade and made adoption changes difficult to review independently.

Base: `d8b9c7899e50b195cfb93de7b76ad6029199d2af`  
Head: `7d282dcd1005484889ab57fd41d5521e5d617a2c`

## Proposed change

- Add the deep `AcpProviderSessionAdopter.adopt(stableAppSessionId, request)` module.
- Transfer the enclosing resume/reset transaction's opaque, reconnect-renewed identity reservation into the adopter. The adopter extends it with the provider ID, publishes through `AcpSessionRegistry`, and owns terminal release; Runtime's outer `finally` remains an idempotent fallback.
- Keep provisional provider Session and capability ownership local until Registry/capability transfer, including configuration, collision, and supersession rollback.
- Preserve Specialist identity/Skill presentation, staged Claude replay commit ordering, permission/model/effort configuration, cwd projection, and post-publication observer isolation.
- Re-read the immutable backend view before publication and replay configuration when a live effort update overlaps startup.
- Replace Runtime's adoption implementation with narrow composition wiring and delegation.

Production raw churn is **434/550**: 253 lines in the adopter plus Runtime `+26/-155`. `src/main/acp/runtime.ts` decreases from **3,816** to **3,687** lines.

## Scope and non-goals

- Internal behavior-preserving ACP refactor only.
- No Prisma/schema, persistence, Session JSON, Artifact/provenance, or data-relationship change.
- No public ACP, IPC/preload, Web RPC, Task HTTP/WebSocket, CLI/SDK, event-envelope, or user-interaction change.
- Specialist, Permission, Notebook, and Compute behavior and the existing Electron/Web/CLI/Task capability asymmetry remain unchanged.
- Preserves the model/provider hot-switch operation barriers from #751 and the Claude ACP patch/package integrity from #753.
- Related #458 is a forward-compatibility constraint only; this PR adds no orchestration state, Session tree, schema, command, event, wire method, UI, or Compute scheduling.

## Ownership and sequence

```mermaid
sequenceDiagram
  participant Runtime as AcpRuntime resume/reset
  participant Adopter as AcpProviderSessionAdopter
  participant Capability as Capability owner
  participant Provider as ACP provider
  participant Registry as AcpSessionRegistry
  participant Handoff as Handoff continuity owner

  Runtime->>Adopter: adopt(stableAppId, opaque renewed reservation)
  Adopter->>Capability: provision(stableAppId)
  Adopter->>Provider: session/new(metadata, MCP servers)
  Adopter->>Registry: extend reservation(stableAppId, providerId)
  Adopter->>Provider: configure permission/model/effort
  Adopter->>Registry: publish stableAppId -> provider Session
  Adopter->>Capability: commit(stableAppId)
  Adopter->>Handoff: commit staged Claude replay
  Adopter->>Registry: release reservation
  Adopter-->>Runtime: stableAppId + contextReset=true
  Note over Adopter,Registry: Every failure releases provisional capability, Session, and reservation; Registry remains the sole identity/alias writer.
```

## Acceptance criteria and validation

All listed checks ran after the last material production edit.

- Stable App ID/provider alias publication, `contextReset`, ordering, failure cleanup, supersession, replay/Specialist presentation, observer isolation, and live-effort race -> `npm test -- src/main/acp/provider-session-adopter.test.ts` -> **7/7 passed**.
- Registry, capability, handoff, configurator, creator, and model-change owner contracts -> `npm test -- src/main/acp/provider-session-adopter.test.ts src/main/acp/session-registry.test.ts src/main/acp/session-capability-owner.test.ts src/main/acp/handoff-continuity-owner.test.ts src/main/acp/session-configurator.test.ts src/main/acp/provider-session-creator.test.ts src/main/acp/model-change-workflow.test.ts` -> **57/57 passed**.
- Runtime adoption, Codex non-UUID, OpenCode-to-Claude, replay, reconnect/model barriers, collision/supersession, Permission/Notebook cleanup, and existing ACP behavior -> `npm test -- src/main/acp/runtime.test.ts` -> **419/419 passed**.
- Node process types -> `npm run typecheck:node` -> **passed**.
- Changed source lint -> `npx eslint src/main/acp/provider-session-adopter.ts src/main/acp/provider-session-adopter.test.ts src/main/acp/runtime.ts` -> **passed**.
- Changed source format -> `npx prettier --check src/main/acp/provider-session-adopter.ts src/main/acp/provider-session-adopter.test.ts src/main/acp/runtime.ts` -> **passed**.
- #753 package patch integrity -> `npm run check:claude-acp-patch` -> **passed**.
- Patch hygiene -> `git diff --cached --check` before commit -> **passed**.
- Independent fixed-point review -> Standards **0 findings**; Spec **0 findings** after reservation-cleanup remediation.

The full portable `npm test` suite was not run locally; the authoritative PR Gate supplies the complete selected CI/platform plan.

## Review focus

- Opaque reservation ownership transfer: extension returns the retained handle; success releases before observer notification; terminal `finally` releases on every failure; caller cleanup is only idempotent fallback.
- Publication order and one-writer invariants: Registry remains the only stable ID/provider alias/aggregate writer; capability and handoff owners retain their commit/release authority.
- Failure semantics before and after publication, especially collision, supersession, provisional capability/Session cleanup, and observer failure.
- Live effort overlap: configuration must be replayed against a stable backend view without bypassing #751 model/reconnect operation leases.
- Specialist metadata, Claude staged replay, Codex non-UUID fresh adoption, and current cross-surface behavior remain unchanged.

## Uncovered risks

- Local validation covered one host only; macOS/Windows and the complete classified suite are delegated to CI.
- Real provider processes and credentials were not exercised locally; tests use the repository's ACP fakes and owner contracts.
- Capability publication relies on the existing provision handle's atomic, idempotent terminal contract; that owner is unchanged and its focused tests pass.

Related #458.
