### PR TITLE
ci(pr-gate): enforce portable suite outcome

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -316,12 +316,14 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Test complete portable suite (advisory)
+      # Both selected unit lanes are blocking through the final enforcement step. Step-level
+      # continue-on-error lets both suites report their outcomes in the same run.
+      - name: Test complete portable suite (blocking)
         id: unit_linux
         if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'unit_linux') }}
         continue-on-error: true
         run: npm test
-      - name: Test Renderer
+      - name: Test Renderer (blocking)
         id: unit_renderer
         if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'unit_renderer') }}
         continue-on-error: true
@@ -330,13 +332,20 @@ jobs:
         if: ${{ always() }}
         shell: bash
         env:
+          UNIT_LINUX_OUTCOME: ${{ steps.unit_linux.outcome }}
           UNIT_RENDERER_OUTCOME: ${{ steps.unit_renderer.outcome }}
         run: |
           set -euo pipefail
-          if [[ "$UNIT_RENDERER_OUTCOME" == "failure" || "$UNIT_RENDERER_OUTCOME" == "cancelled" ]]; then
-            echo "unit_renderer ended with $UNIT_RENDERER_OUTCOME" >&2
-            exit 1
-          fi
+          failed=0
+          check() {
+            if [[ "$2" == "failure" || "$2" == "cancelled" ]]; then
+              echo "$1 ended with $2" >&2
+              failed=1
+            fi
+          }
+          check unit_linux "$UNIT_LINUX_OUTCOME"
+          check unit_renderer "$UNIT_RENDERER_OUTCOME"
+          exit "$failed"
 
   coverage_macos:
     name: Coverage macOS

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -207,7 +207,7 @@ describe('PR Gate workflow', () => {
   })
 
   it('collects independent bundle failures before failing the shared runner', () => {
-    for (const bundle of ['static', 'windows_core', 'macos_e2e', 'windows_e2e']) {
+    for (const bundle of ['static', 'unit', 'windows_core', 'macos_e2e', 'windows_e2e']) {
       const enforce = workflow.jobs[bundle].steps?.find(({ name }) => name?.startsWith('Enforce'))
       expect(enforce, `${bundle} must enforce collected step outcomes`).toMatchObject({
         if: '${{ always() }}'
@@ -226,22 +226,27 @@ describe('PR Gate workflow', () => {
     }
 
     const portable = workflow.jobs.unit.steps?.find(
-      ({ name }) => name === 'Test complete portable suite (advisory)'
+      ({ name }) => name === 'Test complete portable suite (blocking)'
     )
-    const renderer = workflow.jobs.unit.steps?.find(({ name }) => name === 'Test Renderer')
+    const renderer = workflow.jobs.unit.steps?.find(
+      ({ name }) => name === 'Test Renderer (blocking)'
+    )
     const enforceUnit = workflow.jobs.unit.steps?.find(
       ({ name }) => name === 'Enforce selected unit checks'
     )
     expect(portable?.['continue-on-error']).toBe(true)
     expect(renderer?.['continue-on-error']).toBe(true)
     expect(enforceUnit?.env).toEqual({
+      UNIT_LINUX_OUTCOME: '${{ steps.unit_linux.outcome }}',
       UNIT_RENDERER_OUTCOME: '${{ steps.unit_renderer.outcome }}'
     })
+    expect(enforceUnit?.run).toContain('check unit_linux "$UNIT_LINUX_OUTCOME"')
+    expect(enforceUnit?.run).toContain('check unit_renderer "$UNIT_RENDERER_OUTCOME"')
   })
 
-  it('preserves the advisory portable suite and hard Windows contracts', () => {
+  it('preserves the complete portable suite and hard Windows contracts', () => {
     const portable = workflow.jobs.unit.steps?.find(
-      ({ name }) => name === 'Test complete portable suite (advisory)'
+      ({ name }) => name === 'Test complete portable suite (blocking)'
     )
     expect(portable).toMatchObject({
       'continue-on-error': true,


### PR DESCRIPTION
## Problem

The `unit_linux` lane runs the complete portable Vitest suite with step-level `continue-on-error`, but the unit bundle only enforced `UNIT_RENDERER_OUTCOME`. A selected Linux suite failure could therefore leave the `Unit tests` bundle successful, and the required aggregate `PR Gate` check could not detect the swallowed failure.

## Proposed change

- Mark both unit lanes as blocking through the bundle's final enforcement step.
- Preserve step-level `continue-on-error` so both suites report their outcomes in one run.
- Add `UNIT_LINUX_OUTCOME` to the existing unit outcome aggregator and fail for either selected lane on `failure` or `cancelled`.
- Extend the workflow contract test to pin both blocking outcomes.

## Scope and non-goals

- No new jobs, runners, dependencies, or test commands.
- No classifier, lane-to-bundle, branch-ruleset, application architecture, data-model, or user-interaction changes.
- PR duration should remain effectively unchanged because both suites already ran before this change.

## Acceptance criteria and validation

The checks below ran after the last material edit.

- Unit lane enforcement contract -> `npm test -- scripts/ci/pr-gate-workflow.test.ts scripts/ci/check-ci-integrity.test.ts` -> passed (2 files, 50 tests).
- Workflow and test formatting -> `npx prettier --check .github/workflows/pr-gate.yml scripts/ci/pr-gate-workflow.test.ts` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings.
- Full typecheck -> `npm run typecheck` -> existing baseline failure: TS2554 at `src/main/acp/claude-agent-acp-patch.test.ts:65` and `:82`; this PR does not modify that file.
- Complete portable suite -> `npm test -- --reporter=dot` outside the restricted sandbox -> existing baseline failure: 3 tests in `src/main/acp/claude-agent-acp-patch.test.ts`; this PR does not modify that file.

Consumer/platform rationale: this change only affects GitHub Actions outcome aggregation. No runtime consumer or additional platform lane is introduced. The complete portable suite and macOS coverage selection remain unchanged.

Uncovered risk: the repository's existing ACP patch baseline prevents a fully green local fallback and may surface as a now-correct blocking portable-suite result until repaired separately.

## Review focus

- Confirm that `steps.unit_linux.outcome` is enforced alongside the renderer outcome.
- Confirm that skipped, unselected unit lanes remain non-failing while selected failed or cancelled lanes block `PR Gate`.
- Confirm that retaining step-level `continue-on-error` only collects independent outcomes and no longer makes the portable suite advisory.
