### PR TITLE
refactor(acp): extract provider session resumer

### DIFF
--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -1,0 +1,401 @@
+import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpCreateSessionResponse, AcpResumeSessionRequest } from '../../shared/acp'
+import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
+import { claudeCodeFramework } from '../agent-framework'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import { AcpProviderSessionResumer } from './provider-session-resumer'
+import { AcpSessionRegistry } from './session-registry'
+
+const permissionProfile: SessionPermissionProfileState = {
+  selectedProfile: 'ask',
+  effectiveProfile: 'ask',
+  currentModeId: 'default',
+  availableModeIds: ['default'],
+  fullAccessAvailable: false
+}
+
+const backend: AcpBackendGenerationView = {
+  framework: claudeCodeFramework,
+  backendId: 'claude-code',
+  session: { modelRequired: false },
+  prompt: { systemPromptAppends: [] },
+  context: { supportsImageInput: false },
+  adapter: { nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false }
+}
+
+type HarnessOptions = {
+  attachError?: Error
+  backendAfterFirstConfigure?: AcpBackendGenerationView
+  configureError?: Error
+  ensureConnected?: () => Promise<ClientConnection>
+  foreignIdentityCollision?: (sessionIds: readonly string[]) => Error | undefined
+  invalidateDuringResume?: boolean
+  observerError?: Error
+  resumeError?: unknown
+  supportsResume?: boolean
+}
+
+type ResumerHarness = {
+  adopt: ReturnType<typeof vi.fn>
+  attachSession: ReturnType<typeof vi.fn>
+  commit: ReturnType<typeof vi.fn>
+  configure: ReturnType<typeof vi.fn>
+  connection: ClientConnection
+  disconnectTimedOutConnection: ReturnType<typeof vi.fn>
+  fireTimeout: () => void
+  identityClaimedAtAdoption: () => boolean
+  order: string[]
+  providerSession: ActiveSession
+  registry: AcpSessionRegistry
+  release: ReturnType<typeof vi.fn>
+  request: ReturnType<typeof vi.fn>
+  resume: (request?: Partial<AcpResumeSessionRequest>) => Promise<AcpCreateSessionResponse>
+  successorSession: ActiveSession
+}
+
+const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
+  const order: string[] = []
+  let timerCallback: (() => void) | undefined
+  let identityClaimedAtAdoption = false
+  let currentBackend = backend
+  const providerSession = {
+    sessionId: 'provider-session',
+    dispose: vi.fn(() => order.push('session dispose'))
+  } as unknown as ActiveSession
+  const successorSession = {
+    sessionId: 'successor-provider-session',
+    dispose: vi.fn()
+  } as unknown as ActiveSession
+  const registry = new AcpSessionRegistry({
+    foreignIdentityCollision: options.foreignIdentityCollision
+  })
+  vi.spyOn(registry, 'reserve').mockImplementation((input) => {
+    order.push(input.reservation ? 'extend identity' : 'reserve identity')
+    return AcpSessionRegistry.prototype.reserve.call(registry, input)
+  })
+  vi.spyOn(registry, 'publish').mockImplementation((...args) => {
+    order.push('registry publish')
+    return AcpSessionRegistry.prototype.publish.call(registry, ...args)
+  })
+  const request = vi.fn(async () => {
+    order.push('session/resume')
+    if (options.invalidateDuringResume) {
+      registry.invalidatePending()
+      const successor = registry.reserve({
+        sessionIds: ['stable-app-session', successorSession.sessionId],
+        blockStartup: false
+      })
+      if (successor.collision) throw successor.collision
+      registry.publish(successor.reservation, 'stable-app-session', {
+        session: successorSession,
+        cwd: '/successor-workspace',
+        projectName: 'successor-project',
+        frameworkId: 'claude-code',
+        backendId: 'claude-code',
+        permissionProfile
+      })
+      successor.reservation.release()
+    }
+    if (options.resumeError !== undefined) throw options.resumeError
+    return { sessionId: providerSession.sessionId }
+  })
+  const attachSession = vi.fn(() => {
+    order.push('sdk attach')
+    if (options.attachError) throw options.attachError
+    return providerSession
+  })
+  const connection = { agent: { request, attachSession } } as unknown as ClientConnection
+  const commit = vi.fn(() => order.push('capability commit'))
+  const release = vi.fn(() => order.push('capability release'))
+  const adopt = vi.fn(
+    async (
+      stableAppSessionId: string,
+      adoption: { identity: { release: () => void }; cwd: string }
+    ) => {
+      order.push('adopt fresh')
+      identityClaimedAtAdoption = registry.isIdentityClaimed(stableAppSessionId)
+      adoption.identity.release()
+      return {
+        sessionId: stableAppSessionId,
+        cwd: adoption.cwd,
+        frameworkId: 'claude-code' as const,
+        backendId: 'claude-code',
+        contextReset: true as const
+      }
+    }
+  )
+  const disconnectTimedOutConnection = vi.fn(async () => {
+    order.push('disconnect')
+    registry.invalidatePending()
+  })
+  const configure = vi.fn(async (input: { backend: AcpBackendGenerationView }) => {
+    order.push('configure')
+    if (options.configureError) throw options.configureError
+    if (configure.mock.calls.length === 1 && options.backendAfterFirstConfigure) {
+      currentBackend = options.backendAfterFirstConfigure
+    }
+    return {
+      permissionProfile,
+      appliedModel: input.backend.session.effort,
+      configOptions: undefined
+    }
+  })
+  const resumer = new AcpProviderSessionResumer({
+    defaultCwd: '/default',
+    defaultProjectName: 'default-project',
+    currentCwd: () => undefined,
+    ensureConnected:
+      options.ensureConnected ??
+      vi.fn(async () => {
+        order.push('connect')
+        return connection
+      }),
+    assertCurrentConnection: vi.fn(),
+    disconnectTimedOutConnection,
+    resumeCapabilityAdvertised: () => options.supportsResume !== false,
+    currentBackend: () => currentBackend,
+    registry,
+    reserveIdentity: (sessionId) =>
+      registry.reserve({
+        sessionIds: [sessionId],
+        mayRenewAfterConnectionSetup: true,
+        blockStartup: false
+      }),
+    capabilities: {
+      provision: vi.fn(async () => {
+        order.push('capability provision')
+        return {
+          mcpServers: [],
+          descriptor: {
+            role: 'primary' as const,
+            delegation: 'denied' as const,
+            transport: 'none' as const,
+            capabilities: [],
+            canonicalMcpServerNames: [],
+            modelFacingMcpServerNames: [],
+            controlRpcMethods: []
+          },
+          commit,
+          release
+        }
+      })
+    },
+    configurator: { configure },
+    adopter: { adopt },
+    updateCwd: () => order.push('cwd callback'),
+    pushEvent: () => {
+      order.push('event callback')
+      if (options.observerError) throw options.observerError
+    },
+    emitState: () => {
+      order.push('state callback')
+      if (options.observerError) throw options.observerError
+    },
+    resumeTimeoutMs: 30_000,
+    setTimer: (callback) => {
+      timerCallback = callback
+      return {} as ReturnType<typeof setTimeout>
+    },
+    clearTimer: () => undefined,
+    diagnosticContext: () => ({})
+  })
+  const resume = (
+    request: Partial<AcpResumeSessionRequest> = {}
+  ): Promise<AcpCreateSessionResponse> =>
+    resumer.resume({
+      sessionId: 'stable-app-session',
+      cwd: '/workspace',
+      projectName: 'project-a',
+      ...request
+    })
+
+  return {
+    adopt,
+    attachSession,
+    commit,
+    configure,
+    connection,
+    disconnectTimedOutConnection,
+    fireTimeout: () => timerCallback?.(),
+    identityClaimedAtAdoption: () => identityClaimedAtAdoption,
+    order,
+    providerSession,
+    registry,
+    release,
+    request,
+    resume,
+    successorSession
+  }
+}
+
+describe('AcpProviderSessionResumer', () => {
+  it('resumes and publishes a provider Session under its stable application id', async () => {
+    const harness = createHarness()
+
+    const response = await harness.resume()
+
+    expect(response).toEqual({
+      sessionId: 'stable-app-session',
+      cwd: '/workspace',
+      frameworkId: 'claude-code',
+      backendId: 'claude-code'
+    })
+    expect(harness.registry.lookup('stable-app-session')?.attachment?.session).toBe(
+      harness.providerSession
+    )
+    expect(harness.registry.resolveAppSessionId('provider-session')).toBe('stable-app-session')
+    expect(harness.order).toEqual([
+      'reserve identity',
+      'connect',
+      'extend identity',
+      'capability provision',
+      'session/resume',
+      'sdk attach',
+      'extend identity',
+      'configure',
+      'registry publish',
+      'capability commit',
+      'cwd callback',
+      'event callback',
+      'state callback'
+    ])
+  })
+
+  it('times out a stalled reconnect and tears down its half-open connection', async () => {
+    const harness = createHarness({
+      ensureConnected: () => new Promise<ClientConnection>(() => undefined)
+    })
+
+    const resumed = harness.resume()
+    harness.fireTimeout()
+
+    await expect(resumed).rejects.toThrow('ACP session resume timed out.')
+    expect(harness.disconnectTimedOutConnection).toHaveBeenCalledOnce()
+    expect(harness.registry.isIdentityClaimed('stable-app-session')).toBe(false)
+  })
+
+  it('transfers its reservation to fresh adoption when Resume Policy rejects the backend', async () => {
+    const harness = createHarness()
+
+    await expect(harness.resume({ previousFrameworkId: 'opencode' })).resolves.toMatchObject({
+      sessionId: 'stable-app-session',
+      contextReset: true
+    })
+
+    expect(harness.request).not.toHaveBeenCalled()
+    expect(harness.adopt).toHaveBeenCalledOnce()
+    expect(harness.identityClaimedAtAdoption()).toBe(true)
+    expect(harness.registry.isIdentityClaimed('stable-app-session')).toBe(false)
+  })
+
+  it('releases only the failed Resume provision before adopting an unresumable session', async () => {
+    const harness = createHarness({ resumeError: { code: -32002, message: 'Resource not found' } })
+
+    await expect(harness.resume()).resolves.toMatchObject({ contextReset: true })
+
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.order.indexOf('capability release')).toBeLessThan(
+      harness.order.indexOf('adopt fresh')
+    )
+    expect(harness.adopt).toHaveBeenCalledOnce()
+  })
+
+  it('releases the provision when the SDK cannot attach the resumed Session', async () => {
+    const failure = new Error('SDK attach failed')
+    const harness = createHarness({ attachError: failure })
+
+    await expect(harness.resume()).rejects.toBe(failure)
+
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.registry.lookup('stable-app-session')).toBeUndefined()
+    expect(harness.adopt).not.toHaveBeenCalled()
+  })
+
+  it('disposes the attached provider Session when its provider id collides', async () => {
+    const collision = new Error('provider identity collision')
+    const harness = createHarness({
+      foreignIdentityCollision: (sessionIds) =>
+        sessionIds.includes('provider-session') ? collision : undefined
+    })
+
+    await expect(harness.resume()).rejects.toBe(collision)
+
+    expect(harness.providerSession.dispose).toHaveBeenCalledOnce()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.registry.lookup('stable-app-session')).toBeUndefined()
+  })
+
+  it('does not clean or overwrite a same-id successor after the Resume attempt is superseded', async () => {
+    const harness = createHarness({
+      invalidateDuringResume: true,
+      resumeError: { code: -32002, message: 'Resource not found' }
+    })
+
+    await expect(harness.resume()).rejects.toThrow('ACP session startup was superseded.')
+
+    expect(harness.release).toHaveBeenCalledTimes(1)
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: false })
+    expect(harness.adopt).not.toHaveBeenCalled()
+    expect(harness.registry.lookup('stable-app-session')?.attachment?.session).toBe(
+      harness.successorSession
+    )
+    expect(harness.successorSession.dispose).not.toHaveBeenCalled()
+  })
+
+  it('disposes the attached-but-unpublished Session when configuration fails', async () => {
+    const failure = new Error('configuration failed')
+    const harness = createHarness({ configureError: failure })
+
+    await expect(harness.resume()).rejects.toBe(failure)
+
+    expect(harness.providerSession.dispose).toHaveBeenCalledOnce()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.commit).not.toHaveBeenCalled()
+    expect(harness.registry.lookup('stable-app-session')).toBeUndefined()
+  })
+
+  it('publishes ownership before fallible observers without rolling back their Session', async () => {
+    const harness = createHarness({ observerError: new Error('observer failed') })
+
+    await expect(harness.resume()).resolves.toMatchObject({ sessionId: 'stable-app-session' })
+
+    expect(harness.registry.lookup('stable-app-session')?.attachment?.session).toBe(
+      harness.providerSession
+    )
+    expect(harness.order.indexOf('registry publish')).toBeLessThan(
+      harness.order.indexOf('capability commit')
+    )
+    expect(harness.order.indexOf('capability commit')).toBeLessThan(
+      harness.order.indexOf('event callback')
+    )
+    expect(harness.order).toContain('state callback')
+  })
+
+  it('preserves the advertised-resume failure without allocating capabilities', async () => {
+    const harness = createHarness({ supportsResume: false })
+
+    await expect(harness.resume()).rejects.toThrow('ACP agent does not support session resume.')
+
+    expect(harness.request).not.toHaveBeenCalled()
+    expect(harness.adopt).not.toHaveBeenCalled()
+    expect(harness.order).not.toContain('capability provision')
+    expect(harness.registry.isIdentityClaimed('stable-app-session')).toBe(false)
+  })
+
+  it('replays configuration against a live effort change before publication', async () => {
+    const nextBackend: AcpBackendGenerationView = {
+      ...backend,
+      session: { ...backend.session, effort: 'high' }
+    }
+    const harness = createHarness({ backendAfterFirstConfigure: nextBackend })
+
+    await harness.resume()
+
+    expect(harness.configure).toHaveBeenCalledTimes(2)
+    expect(harness.registry.lookup('stable-app-session')?.aggregate.snapshot().appliedModel).toBe(
+      'high'
+    )
+  })
+})

--- a/src/main/acp/provider-session-resumer.ts
+++ b/src/main/acp/provider-session-resumer.ts
@@ -1,0 +1,349 @@
+import * as acp from '@agentclientprotocol/sdk'
+import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+import { resolve } from 'node:path'
+
+import type {
+  AcpCreateSessionResponse,
+  AcpResumeSessionRequest,
+  AcpRuntimeEvent
+} from '../../shared/acp'
+import { normalizePermissionProfile } from '../../shared/permission-profiles'
+import type { EffectiveSpecialistSkills } from '../../shared/specialist'
+import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import type { AcpProviderSessionAdopter } from './provider-session-adopter'
+import {
+  CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+  type AcpSessionCapabilityOwner,
+  type SessionCapabilityProvision
+} from './session-capability-owner'
+import type { AcpSessionConfigurator } from './session-configurator'
+import { AcpSessionPresentationPolicy } from './session-presentation-policy'
+import type {
+  AcpPrimarySessionIdentityReservation,
+  AcpPrimarySessionIdentityReservationResult,
+  AcpSessionRegistry
+} from './session-registry'
+import { AcpSessionResumePolicy } from './session-resume-policy'
+
+const log = createLogger('acp')
+
+type SessionAttachmentResponse = {
+  sessionId: string
+  modes?: ActiveSession['modes'] | null
+  configOptions?: unknown
+  _meta?: unknown
+}
+
+type ClientContextSessionAttacher = {
+  attachSession: (response: SessionAttachmentResponse) => ActiveSession
+}
+
+type ResumeEvent = Omit<AcpRuntimeEvent, 'id' | 'timestamp'>
+
+type AcpProviderSessionResumerDependencies = Readonly<{
+  defaultCwd: string
+  defaultProjectName: string
+  currentCwd: () => string | undefined
+  ensureConnected: (cwd: string) => Promise<ClientConnection>
+  assertCurrentConnection: (connection: ClientConnection) => void
+  disconnectTimedOutConnection: () => Promise<void>
+  resumeCapabilityAdvertised: () => boolean
+  currentBackend: () => AcpBackendGenerationView
+  registry: AcpSessionRegistry
+  reserveIdentity: (sessionId: string) => AcpPrimarySessionIdentityReservationResult
+  capabilities: Pick<AcpSessionCapabilityOwner, 'provision'>
+  configurator: Pick<AcpSessionConfigurator, 'configure'>
+  adopter: Pick<AcpProviderSessionAdopter, 'adopt'>
+  resolveSpecialistSkills?: (specialistId: string) => Promise<EffectiveSpecialistSkills>
+  updateCwd: (cwd: string) => void
+  pushEvent: (event: ResumeEvent) => void
+  emitState: () => void
+  resumeTimeoutMs: number
+  setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimer: (handle: ReturnType<typeof setTimeout>) => void
+  diagnosticContext: () => Readonly<Record<string, unknown>>
+}>
+
+export class AcpProviderSessionResumer {
+  private readonly policy = new AcpSessionResumePolicy()
+  private readonly presentation = new AcpSessionPresentationPolicy()
+
+  constructor(private readonly deps: AcpProviderSessionResumerDependencies) {}
+
+  async resume(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
+    const cwd = resolve(request.cwd || this.deps.currentCwd() || this.deps.defaultCwd)
+    const projectName = request.projectName?.trim() || this.deps.defaultProjectName
+    const reserved = this.deps.reserveIdentity(request.sessionId)
+    if (reserved.collision) throw reserved.collision
+    const identity = reserved.reservation
+
+    try {
+      return await this.withTimeout(() => this.resumeReserved(request, cwd, projectName, identity))
+    } finally {
+      identity.release()
+    }
+  }
+
+  private async withTimeout(
+    operation: () => Promise<AcpCreateSessionResponse>
+  ): Promise<AcpCreateSessionResponse> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let timedOut = false
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = this.deps.setTimer(() => {
+        timedOut = true
+        reject(new Error('ACP session resume timed out.'))
+      }, this.deps.resumeTimeoutMs)
+    })
+
+    try {
+      return await Promise.race([operation(), timeout])
+    } catch (error) {
+      if (timedOut) await this.deps.disconnectTimedOutConnection()
+      throw error
+    } finally {
+      if (timer !== undefined) this.deps.clearTimer(timer)
+    }
+  }
+
+  private async resumeReserved(
+    request: AcpResumeSessionRequest,
+    cwd: string,
+    projectName: string,
+    identity: AcpPrimarySessionIdentityReservation
+  ): Promise<AcpCreateSessionResponse> {
+    const connection = await this.deps.ensureConnected(cwd)
+    this.deps.assertCurrentConnection(connection)
+    identity.renew()
+
+    const affinity = this.deps.registry.lookup(request.sessionId)?.aggregate.snapshot()
+    const backend = this.deps.currentBackend()
+    const decision = this.policy.decide({
+      appSessionId: request.sessionId,
+      previousFrameworkId: affinity?.frameworkId ?? request.previousFrameworkId,
+      currentFrameworkId: backend.framework.id,
+      previousBackendId: affinity?.backendId ?? request.previousBackendId,
+      currentBackendId: backend.backendId,
+      resumeCapabilityAdvertised: this.deps.resumeCapabilityAdvertised()
+    })
+
+    if (decision.action === 'adopt') {
+      log.info('skipping incompatible provider resume; adopting a fresh session', {
+        sessionId: request.sessionId,
+        reason: decision.reason,
+        ...this.deps.diagnosticContext()
+      })
+      return this.adopt(request, connection, cwd, projectName, identity)
+    }
+    if (decision.action === 'fail') throw new Error(decision.message)
+
+    return this.resumeCompatible(request, connection, cwd, projectName, identity)
+  }
+
+  private async resumeCompatible(
+    request: AcpResumeSessionRequest,
+    connection: ClientConnection,
+    cwd: string,
+    projectName: string,
+    identity: AcpPrimarySessionIdentityReservation
+  ): Promise<AcpCreateSessionResponse> {
+    let capability: SessionCapabilityProvision | undefined
+    let provisionalSession: ActiveSession | undefined
+    try {
+      let backend = this.deps.currentBackend()
+      capability = await this.deps.capabilities.provision({
+        stableAppSessionId: request.sessionId,
+        framework: backend.framework,
+        nativeMcpEnabled: backend.adapter.nativeMcpEnabled,
+        bridgeMcpAliasesEnabled: backend.adapter.bridgeMcpAliasesEnabled,
+        policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+        sessionCwd: cwd,
+        projectName
+      })
+      const specialistId =
+        request.specialistId ??
+        this.deps.registry.lookup(request.sessionId)?.aggregate.snapshot().specialistId
+      const setup = this.presentation.buildSessionSetup({
+        framework: backend.framework,
+        tooling: {
+          artifacts: capability.descriptor.capabilities.includes('artifacts'),
+          notebook: capability.descriptor.capabilities.includes('notebook'),
+          skillImport: capability.descriptor.capabilities.includes('skill-import')
+        },
+        backendSystemPromptAppends: backend.prompt.systemPromptAppends,
+        sessionOptions: backend.session.options,
+        specialistSkills: await this.resolveSpecialistSkills(specialistId)
+      })
+
+      let resumeResponse: unknown
+      try {
+        resumeResponse = await connection.agent.request(acp.methods.agent.session.resume, {
+          sessionId: request.sessionId,
+          cwd,
+          mcpServers: capability.mcpServers,
+          ...setup.metaArg
+        })
+      } catch (error) {
+        if (this.policy.classifyFailure(error).disposition !== 'adoptable') throw error
+        try {
+          identity.assertCurrent()
+        } catch (supersededError) {
+          capability.release({ ownsStableIdentity: false })
+          capability = undefined
+          throw supersededError
+        }
+        capability.release({ ownsStableIdentity: true })
+        capability = undefined
+        log.info('resumed session adopted after unrecoverable resume error', {
+          sessionId: request.sessionId,
+          ...errorLogFields(error)
+        })
+        return await this.adopt(request, connection, cwd, projectName, identity)
+      }
+
+      provisionalSession = (
+        connection.agent as unknown as ClientContextSessionAttacher
+      ).attachSession({ sessionId: request.sessionId, ...(resumeResponse as object) })
+      const extended = this.deps.registry.reserve({
+        reservation: identity,
+        sessionIds: [provisionalSession.sessionId]
+      })
+      if (extended.collision) {
+        this.disposeProvisional(provisionalSession, 'primary collision session disposal failed')
+        provisionalSession = undefined
+        throw extended.collision
+      }
+
+      const permission = normalizePermissionProfile(request.permissionProfile)
+      let configuration = await this.deps.configurator.configure({
+        backend,
+        connection,
+        session: provisionalSession,
+        permissionProfile: permission
+      })
+      for (;;) {
+        const currentBackend = this.deps.currentBackend()
+        if (currentBackend !== backend) {
+          backend = currentBackend
+          configuration = await this.deps.configurator.configure({
+            backend,
+            connection,
+            session: provisionalSession,
+            permissionProfile: permission
+          })
+          continue
+        }
+        identity.assertCurrent()
+        const { aggregate } = this.deps.registry.publish(identity, request.sessionId, {
+          session: provisionalSession,
+          cwd,
+          projectName,
+          frameworkId: backend.framework.id,
+          backendId: backend.backendId,
+          permissionProfile: structuredClone(configuration.permissionProfile),
+          appliedModel: configuration.appliedModel,
+          configOptions: structuredClone(configuration.configOptions)
+        })
+        if (request.specialistId) aggregate.setSpecialistId(request.specialistId)
+        capability.commit(request.sessionId)
+        capability = undefined
+        provisionalSession = undefined
+        identity.release()
+        this.publish(request.sessionId, cwd)
+        return {
+          sessionId: request.sessionId,
+          cwd,
+          frameworkId: backend.framework.id,
+          ...(backend.backendId ? { backendId: backend.backendId } : {})
+        }
+      }
+    } catch (caught) {
+      let startupError = caught
+      let ownsStableIdentity = true
+      try {
+        identity.assertCurrent()
+      } catch (supersededError) {
+        startupError = supersededError
+        ownsStableIdentity = false
+      }
+      capability?.release({ ownsStableIdentity })
+      this.disposeProvisional(provisionalSession, 'resumed startup session disposal failed')
+      throw startupError
+    }
+  }
+
+  private adopt(
+    request: AcpResumeSessionRequest,
+    connection: ClientConnection,
+    cwd: string,
+    projectName: string,
+    identity: AcpPrimarySessionIdentityReservation
+  ): Promise<AcpCreateSessionResponse> {
+    return this.deps.adopter.adopt(request.sessionId, {
+      connection,
+      cwd,
+      projectName,
+      identity,
+      permissionProfile: request.permissionProfile,
+      specialistId: request.specialistId
+    })
+  }
+
+  private async resolveSpecialistSkills(
+    specialistId: string | undefined
+  ): Promise<EffectiveSpecialistSkills | undefined> {
+    if (!specialistId || !this.deps.resolveSpecialistSkills) return undefined
+    try {
+      return await this.deps.resolveSpecialistSkills(specialistId)
+    } catch {
+      return { kind: 'unavailable', reason: 'The bound specialist is unavailable.' }
+    }
+  }
+
+  private publish(sessionId: string, cwd: string): void {
+    this.deps.updateCwd(cwd)
+    try {
+      this.deps.pushEvent({
+        kind: 'system',
+        level: 'info',
+        sessionId,
+        title: 'Session resumed',
+        text: cwd
+      })
+    } catch (error) {
+      this.safeLogError('session resumed event callback failed', error, sessionId)
+    }
+    try {
+      this.deps.emitState()
+    } catch (error) {
+      this.safeLogError('session resumed state callback failed', error, sessionId)
+    }
+  }
+
+  private disposeProvisional(session: ActiveSession | undefined, message: string): void {
+    if (!session) return
+    try {
+      session.dispose()
+    } catch (error) {
+      this.safeLogError(message, error, session.sessionId, false)
+    }
+  }
+
+  private safeLogError(
+    message: string,
+    error: unknown,
+    sessionId: string,
+    includeContext = true
+  ): void {
+    try {
+      log.error(message, {
+        ...diagnosticErrorFields(error),
+        ...(includeContext ? this.deps.diagnosticContext() : {}),
+        sessionId
+      })
+    } catch {
+      // Diagnostics must never replace provider, cleanup, or observer outcomes.
+    }
+  }
+}

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -7,7 +7,6 @@ import type {
   RequestPermissionRequest,
   RequestPermissionResponse,
   SessionConfigOption,
-  SessionModeState,
   SessionNotification
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
@@ -102,8 +101,7 @@ import {
 } from './reviewer-session-owner'
 import {
   AcpSessionCapabilityOwner,
-  CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-  type SessionCapabilityProvision
+  CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY
 } from './session-capability-owner'
 import { ArtifactTurnOwner, type ArtifactTurnHandle } from './artifact-turn-owner'
 import { AcpPromptContentOwner } from './prompt-content-owner'
@@ -111,13 +109,11 @@ import {
   AcpSessionInteractionOwner,
   type AcpPromptSessionInteractionScope
 } from './session-interaction-owner'
-import type { AcpSessionAggregateAttachInput } from './session-aggregate'
 import {
   AcpSessionRegistry,
   type AcpPrimarySessionIdentityReservation,
   type AcpPrimarySessionIdentityReservationResult,
-  type AcpSessionDeletion,
-  type AcpSessionRegistryEntry
+  type AcpSessionDeletion
 } from './session-registry'
 import {
   AcpConnectionResourceOwner,
@@ -142,6 +138,7 @@ import { AcpConnectionCloseWorkflow, type CloseState } from './connection-close-
 import { AcpModelChangeWorkflow } from './model-change-workflow'
 import { AcpProviderSessionCreator } from './provider-session-creator'
 import { AcpProviderSessionAdopter } from './provider-session-adopter'
+import { AcpProviderSessionResumer } from './provider-session-resumer'
 import {
   AcpTurnSkillOwner,
   type AcpTurnSkillHooks,
@@ -287,17 +284,6 @@ type AcpRuntimeSkillImportOptions = {
   ) => Promise<() => void>
 }
 
-type SessionAttachmentResponse = {
-  sessionId: string
-  modes?: SessionModeState | null
-  configOptions?: unknown
-  _meta?: unknown
-}
-
-type ClientContextSessionAttacher = {
-  attachSession: (response: SessionAttachmentResponse) => ActiveSession
-}
-
 // Mirror claude-agent-acp's autonomous result lanes. Unknown future origins stay eligible so a
 // newly introduced user lane does not silently lose the terminal SDK `num_turns` value.
 const CLAUDE_AUTONOMOUS_RESULT_ORIGINS = new Set([
@@ -390,104 +376,6 @@ const safeLogError = (message: string, data?: unknown): void => {
   }
 }
 
-const UNRESUMABLE_SESSION_ERROR_KINDS = new Set([
-  'session_not_found',
-  'conversation_not_found',
-  'session_missing',
-  'conversation_missing',
-  'session_resume_failed',
-  'conversation_restore_failed'
-])
-
-const isUnresumableSessionErrorKind = (errorKind: unknown): boolean =>
-  typeof errorKind === 'string' &&
-  UNRESUMABLE_SESSION_ERROR_KINDS.has(
-    errorKind
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '_')
-      .replace(/^_|_$/g, '')
-  )
-
-const isCodexProtocolSessionId = (sessionId: string): boolean =>
-  /^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)
-
-const isOpenCodeProtocolSessionId = (sessionId: string): boolean => sessionId.startsWith('ses_')
-
-// Legacy agents may expose only an English diagnostic. Keep this fallback deliberately narrow: a
-// false positive silently resets agent-side context, while a false negative leaves the real error
-// visible and can be fixed by teaching the backend to emit a machine-readable errorKind.
-const describesUnresumableSession = (details: unknown): boolean => {
-  if (typeof details !== 'string') return false
-  if (
-    /\b(?:auth|authentication|authorization|credential|provider|mcp|model|tool|server)\b/i.test(
-      details
-    )
-  )
-    return false
-
-  const describesMissingSession =
-    /\b(?:session|conversation)(?:\s+(?:id|identifier))?\s+(?:(?:was|is)\s+)?(?:not found|missing|unknown)\b/i.test(
-      details
-    ) ||
-    /\b(?:session|conversation)(?:\s+(?:id|identifier))?\s+does not exist\b/i.test(details) ||
-    /\b(?:no|missing|unknown)\s+(?:saved\s+|previous\s+)?(?:session|conversation)\b/i.test(details)
-  const describesFailedResume =
-    /\b(?:failed|unable|cannot|can't|could not)\s+to\s+(?:resume|restore|reopen|reattach)\b.{0,80}\b(?:session|conversation)\b/i.test(
-      details
-    ) ||
-    /\b(?:session|conversation)\b.{0,40}\b(?:failed|was unable)\s+to\s+(?:resume|restore|reopen|reattach)\b/i.test(
-      details
-    ) ||
-    /\b(?:session|conversation)\b.{0,40}\b(?:could not|cannot|can't)\s+be\s+(?:resumed|restored|reopened|reattached)\b/i.test(
-      details
-    )
-
-  return describesMissingSession || describesFailedResume
-}
-
-// Detects an agent-side resume failure that means the session cannot be reattached, so the thread
-// should adopt a fresh agent session instead of dead-ending. A spec-compliant agent returns
-// "Resource not found" (-32002) for a session id it no longer holds (e.g. after a provider switch);
-// some agents instead return a generic "Internal error" (-32603) after an app restart replaced their
-// process. Both mean resume is impossible here. Other failures (invalid params, transport errors)
-// still propagate so genuinely fatal problems stay visible.
-const isUnresumableSessionError = (error: unknown): boolean => {
-  if (typeof error !== 'object' || error === null) return false
-
-  const candidate = error as {
-    code?: number
-    message?: string
-    data?: { details?: unknown; errorKind?: unknown; service?: unknown }
-  }
-  const message = candidate.message ?? ''
-
-  if (candidate.code === -32002 || /resource not found|session not found/i.test(message))
-    return true
-
-  if (candidate.code !== -32603) return false
-
-  // opencode reports a lost session as an Internal error tagged with the failing service
-  // (`{ service: 'session' }`) and a descriptive message suffix, rather than the bare message or the
-  // details string the fallbacks below expect. This marker is machine-readable and language-
-  // independent, so a session-service failure is authoritative — adopt a fresh session regardless of
-  // the suffix. A non-session service (provider, mcp, …) still propagates as a genuine failure.
-  if (candidate.data?.service === 'session') return true
-
-  if (!/^internal error\.?$/i.test(message.trim())) return false
-
-  // A structured reason is authoritative and language-independent. Unknown reasons propagate even when
-  // their detail happens to look session-related, preventing provider/MCP errors from being swallowed.
-  if (candidate.data?.errorKind !== undefined) {
-    return isUnresumableSessionErrorKind(candidate.data.errorKind)
-  }
-
-  // Detail-free Internal errors keep the existing fallback because some agents discard the cause.
-  return (
-    candidate.data?.details === undefined || describesUnresumableSession(candidate.data.details)
-  )
-}
-
 // ACP Session facade. Connection publication and physical teardown live behind their epoch owner;
 // Runtime retains protocol startup, Session/Permission/Notebook cleanup, and status/event projection.
 class AcpRuntime {
@@ -514,8 +402,7 @@ class AcpRuntime {
   private readonly backendGeneration: AcpBackendGenerationOwner
   private readonly sessionConfigurator: AcpSessionConfigurator
   private readonly sessionUpdateProjector = new AcpSessionUpdateProjector()
-  // Bounded resume network timeout + injectable timers (defaults to real setTimeout/clearTimeout).
-  private readonly resumeTimeoutMs: number
+  // Injectable lifecycle timers (defaults to real setTimeout/clearTimeout).
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private readonly artifactOptions: AcpRuntimeArtifactOptions | undefined
@@ -530,6 +417,7 @@ class AcpRuntime {
   private readonly modelChanges: AcpModelChangeWorkflow
   private readonly providerSessionCreator: AcpProviderSessionCreator
   private readonly providerSessionAdopter: AcpProviderSessionAdopter
+  private readonly providerSessionResumer: AcpProviderSessionResumer
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -565,7 +453,6 @@ class AcpRuntime {
       assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
       diagnosticContext: (backend) => this.diagnosticContext(backend.framework.id)
     })
-    this.resumeTimeoutMs = options.resumeTimeoutMs ?? 30_000
     this.contextUsageTracker = options.contextUsageTracker ?? new ContextUsageTracker()
     this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
     this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
@@ -818,6 +705,31 @@ class AcpRuntime {
       emitState: () => this.emitState(),
       diagnosticContext: () => this.diagnosticContext()
     })
+    this.providerSessionResumer = new AcpProviderSessionResumer({
+      defaultCwd: options.defaultCwd,
+      defaultProjectName: options.artifacts?.projectName || DEFAULT_UPLOAD_PROJECT_NAME,
+      currentCwd: () => this.snapshotOwner.cwd,
+      ensureConnected: (cwd) => this.ensureConnected(cwd),
+      assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
+      disconnectTimedOutConnection: async () => {
+        await this.disconnect(false)
+      },
+      resumeCapabilityAdvertised: () => this.connectionResources.capabilities.resume,
+      currentBackend: () => this.backend,
+      registry: this.sessionRegistry,
+      reserveIdentity: (sessionId) => this.reservePrimarySessionIds(undefined, [sessionId]),
+      capabilities: this.sessionCapabilities,
+      configurator: this.sessionConfigurator,
+      adopter: this.providerSessionAdopter,
+      resolveSpecialistSkills: options.resolveSpecialistSkills,
+      updateCwd: (cwd) => this.snapshotOwner.updateCwd(cwd),
+      pushEvent: (event) => this.pushEvent(event),
+      emitState: () => this.emitState(),
+      resumeTimeoutMs: options.resumeTimeoutMs ?? 30_000,
+      setTimer: this.setTimer,
+      clearTimer: this.clearTimer,
+      diagnosticContext: () => this.diagnosticContext()
+    })
   }
 
   private get backend(): AcpBackendGenerationView {
@@ -859,18 +771,6 @@ class AcpRuntime {
 
   private get supportsSessionDelete(): boolean {
     return this.connectionResources.capabilities.delete
-  }
-
-  private get supportsSessionResume(): boolean {
-    return this.connectionResources.capabilities.resume
-  }
-
-  private attachSessionAggregate(
-    reservation: AcpPrimarySessionIdentityReservation,
-    appSessionId: string,
-    input: AcpSessionAggregateAttachInput
-  ): AcpSessionRegistryEntry {
-    return this.sessionRegistry.publish(reservation, appSessionId, input)
   }
 
   private activeSessionFor(appSessionId: string): ActiveSession | undefined {
@@ -1282,9 +1182,7 @@ class AcpRuntime {
       }
     }
 
-    // The reconnect + session/resume handshake spawns a fresh agent and is network-bound, so it is
-    // wrapped in a bounded timeout that tears down the half-open connection if the agent stalls.
-    return this.resumeSessionWithTimeout(request, sessionCwd, projectName)
+    return this.providerSessionResumer.resume(request)
   }
 
   // Forcibly drops the agent-side context for a session whose accumulated history can no longer be sent
@@ -1603,292 +1501,6 @@ class AcpRuntime {
         text: errorMessage(error)
       })
       throw error
-    }
-  }
-
-  // Races the network-bound resume against a timeout so a stalled agent handshake cannot hang Resume
-  // forever. On timeout the half-open connection is torn down so the next Resume reconnects cleanly.
-  private async resumeSessionWithTimeout(
-    request: AcpResumeSessionRequest,
-    sessionCwd: string,
-    projectName: string
-  ): Promise<AcpCreateSessionResponse> {
-    let timer: ReturnType<typeof setTimeout> | undefined
-    let timedOut = false
-    const timeout = new Promise<never>((_resolve, reject) => {
-      timer = this.setTimer(() => {
-        timedOut = true
-        reject(new Error('ACP session resume timed out.'))
-      }, this.resumeTimeoutMs)
-    })
-
-    try {
-      return await Promise.race([
-        this.resumeSessionNetwork(request, sessionCwd, projectName),
-        timeout
-      ])
-    } catch (error) {
-      if (timedOut) {
-        await this.disconnect(false)
-      }
-
-      throw error
-    } finally {
-      if (timer !== undefined) {
-        this.clearTimer(timer)
-      }
-    }
-  }
-
-  // Performs the connect + session/resume handshake for a session the runtime does not yet hold.
-  private async resumeSessionNetwork(
-    request: AcpResumeSessionRequest,
-    sessionCwd: string,
-    projectName: string
-  ): Promise<AcpCreateSessionResponse> {
-    // request.sessionId is the known stable app identity. Reserve it synchronously, before connection
-    // setup can await, then let the network path extend the same owner with the provider protocol id.
-    const reservationResult = this.reservePrimarySessionIds(undefined, [request.sessionId])
-    if (reservationResult.collision) throw reservationResult.collision
-    const reservation = reservationResult.reservation
-
-    try {
-      return await this.resumeReservedSessionNetwork(request, sessionCwd, projectName, reservation)
-    } finally {
-      this.releasePrimarySessionIdentityReservation(reservation)
-    }
-  }
-
-  private async resumeReservedSessionNetwork(
-    request: AcpResumeSessionRequest,
-    sessionCwd: string,
-    projectName: string,
-    primaryIdentityReservation: AcpPrimarySessionIdentityReservation
-  ): Promise<AcpCreateSessionResponse> {
-    const connection = await this.ensureConnected(sessionCwd)
-    this.assertCurrentConnectedConnection(connection)
-    this.renewPrimarySessionIdentityReservation(primaryIdentityReservation)
-    // A session created under a different framework can never be resumed by the current agent — each
-    // framework keeps its own session store, so the request is guaranteed to fail and only makes the
-    // agent log a scary internal error. Skip straight to adopting a fresh session (context still
-    // resets, so the caller replays the transcript) when we know it last ran under another framework.
-    const priorAffinity = this.sessionRegistry.lookup(request.sessionId)?.aggregate.snapshot()
-    const priorFramework = priorAffinity?.frameworkId ?? request.previousFrameworkId
-    const priorBackend = priorAffinity?.backendId ?? request.previousBackendId
-
-    if (
-      (priorFramework && priorFramework !== this.framework.id) ||
-      (priorBackend && this.backendId && priorBackend !== this.backendId)
-    ) {
-      log.info('skipping incompatible backend resume; adopting a fresh session', {
-        sessionId: request.sessionId,
-        fromFramework: priorFramework,
-        toFramework: this.framework.id,
-        fromBackend: priorBackend,
-        toBackend: this.backendId
-      })
-
-      return this.adoptFreshSession(
-        connection,
-        request,
-        sessionCwd,
-        projectName,
-        primaryIdentityReservation
-      )
-    }
-
-    // A conversation adopted from another framework keeps its app-facing id. After restart the
-    // in-memory agent-id mapping is gone, and Codex cannot parse non-UUID ids such as OpenCode's
-    // `ses_...` form. The resume call is guaranteed to fail, so adopt a fresh Codex session directly
-    // and let the caller replay the visible transcript under the stable app id.
-    if (this.framework.id === 'codex' && !isCodexProtocolSessionId(request.sessionId)) {
-      log.info('skipping invalid Codex session resume; adopting a fresh session', {
-        sessionId: request.sessionId
-      })
-      return this.adoptFreshSession(
-        connection,
-        request,
-        sessionCwd,
-        projectName,
-        primaryIdentityReservation
-      )
-    }
-
-    // Persisted sessions created before framework provenance was recorded may restore without a
-    // previousFrameworkId. OpenCode ids use the `ses_...` namespace, which Claude Code rejects before
-    // it can return a resumable session-not-found result. Avoid the guaranteed failing request and
-    // preserve the app-facing conversation by adopting a fresh Claude session for transcript replay.
-    if (this.framework.id === 'claude-code' && isOpenCodeProtocolSessionId(request.sessionId)) {
-      log.info('skipping OpenCode session id for Claude resume; adopting a fresh session', {
-        sessionId: request.sessionId
-      })
-      return this.adoptFreshSession(
-        connection,
-        request,
-        sessionCwd,
-        projectName,
-        primaryIdentityReservation
-      )
-    }
-
-    // Resume is optional in ACP. A cross-framework session was handled above and can always be
-    // adopted fresh; same-framework sessions require the advertised resume capability.
-    if (!this.supportsSessionResume) {
-      throw new Error('ACP agent does not support session resume.')
-    }
-
-    let capabilityProvision: SessionCapabilityProvision | undefined
-    let session: ActiveSession | undefined
-    try {
-      // Resumed sessions already have stable ids, so the artifact session mirrors the runtime session
-      // id.
-      capabilityProvision = await this.sessionCapabilities.provision({
-        stableAppSessionId: request.sessionId,
-        framework: this.framework,
-        nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
-        bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
-        policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
-        sessionCwd,
-        projectName
-      })
-      const { mcpServers } = capabilityProvision
-      let resumeResponse
-      try {
-        resumeResponse = await connection.agent.request(acp.methods.agent.session.resume, {
-          sessionId: request.sessionId,
-          cwd: sessionCwd,
-          mcpServers,
-          ...this.buildSessionMetaArg(
-            [],
-            await this.resolveCurrentSpecialistSkills(
-              request.sessionId,
-              request.specialistId ?? priorAffinity?.specialistId
-            )
-          )
-        })
-      } catch (error) {
-        if (!isUnresumableSessionError(error)) throw error
-
-        // The failed resume crossed a network await. If teardown replaced this startup meanwhile,
-        // release only its concrete bearer lease and stop: broad app-id cleanup or fresh adoption
-        // could otherwise revoke or overwrite the same-id successor.
-        try {
-          this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
-        } catch (supersededError) {
-          capabilityProvision.release({ ownsStableIdentity: false })
-          capabilityProvision = undefined
-          throw supersededError
-        }
-
-        // The agent could not resume this session (an app restart spawned a fresh agent process that no
-        // longer holds it — surfacing as -32002 not-found or a generic -32603 Internal error). Revoke
-        // the token handed to that failed attempt before adopting a brand-new agent session under the
-        // SAME app id; adoptFreshSession owns the replacement token's lifecycle.
-        capabilityProvision.release({ ownsStableIdentity: true })
-        capabilityProvision = undefined
-        log.info('resumed session adopted after unrecoverable resume error', {
-          sessionId: request.sessionId,
-          ...errorLogFields(error)
-        })
-
-        return await this.adoptFreshSession(
-          connection,
-          request,
-          sessionCwd,
-          projectName,
-          primaryIdentityReservation
-        )
-      }
-      // The SDK exposes public helpers for new sessions only. The runtime keeps this adapter
-      // narrow so resume can reuse the same update routing surface as newly-created sessions.
-      session = (connection.agent as unknown as ClientContextSessionAttacher).attachSession({
-        sessionId: request.sessionId,
-        ...resumeResponse
-      })
-
-      const reservationResult = this.reservePrimarySessionIds(primaryIdentityReservation, [
-        session.sessionId
-      ])
-      if (reservationResult.collision) {
-        this.disposeSessionAfterFailure(session, 'primary collision session disposal failed')
-        session = undefined
-        throw reservationResult.collision
-      }
-
-      const backend = this.backend
-      const configuration = await this.sessionConfigurator.configure({
-        backend,
-        connection,
-        session,
-        permissionProfile: normalizePermissionProfile(request.permissionProfile)
-      })
-
-      this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
-      const { aggregate } = this.attachSessionAggregate(
-        primaryIdentityReservation,
-        request.sessionId,
-        {
-          session,
-          cwd: sessionCwd,
-          projectName,
-          frameworkId: backend.framework.id,
-          backendId: backend.backendId,
-          permissionProfile: structuredClone(configuration.permissionProfile),
-          appliedModel: configuration.appliedModel,
-          configOptions: structuredClone(configuration.configOptions)
-        }
-      )
-      if (request.specialistId) {
-        aggregate.setSpecialistId(request.specialistId)
-      }
-      capabilityProvision.commit(request.sessionId)
-      this.releasePrimarySessionIdentityReservation(primaryIdentityReservation)
-      capabilityProvision = undefined
-      this.snapshotOwner.updateCwd(sessionCwd)
-      try {
-        this.pushEvent({
-          kind: 'system',
-          level: 'info',
-          sessionId: request.sessionId,
-          title: 'Session resumed',
-          text: sessionCwd
-        })
-      } catch (error) {
-        safeLogError('session resumed event callback failed', {
-          ...diagnosticErrorFields(error),
-          sessionId: request.sessionId
-        })
-      }
-      try {
-        this.emitState()
-      } catch (error) {
-        safeLogError('session resumed state callback failed', {
-          ...diagnosticErrorFields(error),
-          sessionId: request.sessionId
-        })
-      }
-
-      return {
-        sessionId: request.sessionId,
-        cwd: sessionCwd,
-        frameworkId: this.framework.id,
-        ...(this.backendId ? { backendId: this.backendId } : {})
-      }
-    } catch (error) {
-      let startupError = error
-      let ownsStableIdentity = true
-      try {
-        this.assertPrimarySessionIdentityReservation(primaryIdentityReservation)
-      } catch (supersededError) {
-        startupError = supersededError
-        ownsStableIdentity = false
-      }
-      capabilityProvision?.release({ ownsStableIdentity })
-      capabilityProvision = undefined
-      if (session) {
-        this.disposeSessionAfterFailure(session, 'resumed startup session disposal failed')
-      }
-      throw startupError
     }
   }
 
@@ -3007,18 +2619,6 @@ class AcpRuntime {
     ]
   }
 
-  private async resolveCurrentSpecialistSkills(
-    sessionId: string,
-    specialistId = this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().specialistId
-  ): Promise<EffectiveSpecialistSkills | undefined> {
-    if (!specialistId || !this.options.resolveSpecialistSkills) return undefined
-    try {
-      return await this.options.resolveSpecialistSkills(specialistId)
-    } catch {
-      return { kind: 'unavailable', reason: 'The bound specialist is unavailable.' }
-    }
-  }
-
   private buildSpecialistHandoffContinuationText(request: AcpPromptRequest): string {
     const continuation = request.continuation
     if (!continuation) return request.text
@@ -3043,30 +2643,6 @@ class AcpRuntime {
     } catch {
       return String(value)
     }
-  }
-
-  // Builds the ACP `_meta` argument for session/new and session/resume, delegating the framework-specific
-  // shape to the active framework. Claude applies its settingSources restriction, resolved backend
-  // options, and system-prompt appends; opencode returns no meta and uses a prompt prefix instead.
-  // `extraAppends` lets createSession inject a one-off specialist identity without touching the
-  // shared generation appends that apply to every session on this runtime generation.
-  private buildSessionMetaArg(
-    extraAppends: string[] = [],
-    specialistSkills?: EffectiveSpecialistSkills
-  ): { _meta?: Record<string, unknown> } {
-    const skillWhitelist =
-      specialistSkills?.kind === 'specialist'
-        ? specialistSkills.frameworkNames
-        : specialistSkills?.kind === 'unavailable'
-          ? []
-          : undefined
-    const setup = this.framework.buildSessionSetup({
-      systemPromptAppends: [...this.getSystemPromptAppends(), ...extraAppends],
-      sessionOptions: this.backend.session.options,
-      ...(skillWhitelist !== undefined ? { skillWhitelist } : {})
-    })
-
-    return setup.meta ? { _meta: setup.meta } : {}
   }
 
   // Resolves the artifact/notebook storage project for a session, defaulting to the runtime constant.
@@ -3664,12 +3240,6 @@ class AcpRuntime {
     return reservation.renew(publishedAppSessionId)
   }
 
-  private assertPrimarySessionIdentityReservation(
-    reservation: AcpPrimarySessionIdentityReservation
-  ): void {
-    reservation.assertCurrent()
-  }
-
   private assertCurrentConnectedConnection(connection: ClientConnection): void {
     if (this.connection !== connection || this.snapshotOwner.status !== 'connected') {
       throw new Error('ACP session startup was superseded.')
@@ -3680,17 +3250,6 @@ class AcpRuntime {
     reservation: AcpPrimarySessionIdentityReservation
   ): void {
     reservation.release()
-  }
-
-  private disposeSessionAfterFailure(session: ActiveSession, logMessage: string): void {
-    try {
-      session.dispose()
-    } catch (cleanupError) {
-      safeLogError(logMessage, {
-        ...diagnosticErrorFields(cleanupError),
-        sessionId: session.sessionId
-      })
-    }
   }
 
   // Disposes an ephemeral reviewer session and unregisters it from the auto-approve set. Safe to call


### PR DESCRIPTION
## Problem

The network-bound provider Session resume lifecycle still lived in `AcpRuntime`, combining stable application identity reservation, bounded reconnect, Resume Policy, ACP `session/resume`, SDK attachment, capability/configuration transactions, Registry publication, fresh adoption, and stale-attempt cleanup. This kept lifecycle ownership in the Runtime facade and duplicated failure classification already owned by `AcpSessionResumePolicy`.

Related #458 is a forward-compatibility constraint only. This change does not add orchestration state, schema, public commands, wire contracts, or UI.

## Proposed change

Add the deep `AcpProviderSessionResumer` module with one `resume(request)` interface. It now owns the complete network-bound transaction:

- reserve the stable application Session ID before the first network await;
- bound reconnect/resume with the existing timeout and half-open teardown behavior;
- consume `AcpSessionResumePolicy` for resume, fresh-adopt, and advertised-capability failure decisions;
- provision current Session capabilities, issue ACP `session/resume`, and attach the SDK Session;
- configure Permission/model/effort against a stable backend view, then publish through `AcpSessionRegistry`;
- transfer the opaque reservation once to `AcpProviderSessionAdopter` for incompatible or unresumable Sessions;
- dispose/release only provisional resources owned by the failed or superseded attempt.

`AcpRuntime` retains its already-attached metadata refresh path and delegates only the network-bound path.

## Scope and non-goals

- No public ACP, Electron IPC, Web, CLI, Task, persistence, data-model, or user-interaction changes.
- Stable application Session IDs remain separate from replaceable provider protocol Session IDs.
- Registry remains the sole identity/aggregate writer; Capability Owner, Configurator, and Adopter retain their existing single-writer responsibilities.
- Specialist, Permission, Compute, Notebook, and current Electron/Web/CLI/Task capability asymmetries are unchanged.
- Codex non-UUID adoption, cross-backend adoption, OpenCode-to-Claude fallback, `contextReset`, replay, cwd/project metadata, events, and exact timeout/unsupported messages are preserved.
- The Claude ACP patch and MCP SDK dependency versions are not changed.

The original material patch was independently reviewed, then rebased without conflict and remained patch-equivalent on latest main. Exact base: `7388d3f0826ae6cda0d9deefda6f2041434552c7`. Exact head: `c8b5778820bc17bdcd0454b4c6fbb6de81a2d5e3`. This base includes #754 agent-aware replay/handoff, #761 Artifact lineage routing, #762 Notebook POSIX process-group cleanup, and #764 connector result handoff.

Production raw is **380 / 550** added lines (349 in the new owner plus 31 Runtime composition/cutover lines). `src/main/acp/runtime.ts` is **3,267 lines**, down from the latest-main baseline of 3,708.

## Ownership and sequence

```mermaid
flowchart TD
  Caller["Electron / Web / CLI / Task via existing Runtime interface"] --> Runtime["AcpRuntime.resumeSession"]
  Runtime -->|"already attached"| Refresh["Existing Runtime metadata refresh"]
  Runtime -->|"network-bound"| Resumer["AcpProviderSessionResumer.resume"]
  Resumer --> Policy["AcpSessionResumePolicy"]
  Policy -->|"adopt"| Adopter["AcpProviderSessionAdopter"]
  Policy -->|"resume"| Capability["AcpSessionCapabilityOwner provision"]
  Capability --> Protocol["ACP session/resume"]
  Protocol --> Attach["SDK attachSession"]
  Attach --> Configure["AcpSessionConfigurator"]
  Configure --> Registry["AcpSessionRegistry publish"]
  Registry --> Commit["Capability commit"]
  Commit --> Observers["cwd / event / state observers"]
```

The Resumer owns an attached-but-unpublished SDK Session. Publication transfers identity/aggregate ownership to Registry; fresh fallback transfers the same opaque reservation to Adopter. A stale attempt releases only its concrete provision and cannot revoke or overwrite a same-ID successor.

## Acceptance criteria and validation

All listed checks ran after the final rebase onto the stated exact base. Final independent Standards code review and Spec/compatibility review each completed with **0 findings**.

- Resume interface: success/order, timeout teardown, unsupported capability, policy adoption, unresumable fallback, SDK attach failure, provider-ID collision, supersession, configuration cleanup, observer isolation, and live-effort replay -> `npm test -- --run src/main/acp/provider-session-resumer.test.ts` -> **11/11 passed**.
- Runtime cutover and existing ACP behavior, including hot-switch/reconnect/adoption/Notebook/Specialist/Permission paths -> `npm test -- --run src/main/acp/runtime.test.ts` -> **420/420 passed** (run with loopback binding enabled for MCP tests).
- Resume owners and consumers across Policy, Registry, Capability, Adopter, Coordinator, application commands, IPC, Task port/runner, and Web controller/Task API -> focused 12-file Vitest command -> **205/205 passed**.
- Latest-main #754 replay, workspace-agent runtime, and prompt behavior -> focused tests -> **146/146 passed**.
- Latest-main #754/#762 Notebook handoff and process-group behavior -> focused tests -> **193/193 passed**.
- Latest-main #761 Artifact provenance and owner behavior -> provenance **32/32** plus owner set **91/91 passed**.
- Node contracts -> `npm run typecheck:node` -> **passed**.
- Claude ACP patch integrity (#753) -> `npm run check:claude-acp-patch` -> **passed** (`@agentclientprotocol/claude-agent-acp@0.60.0`).
- Changed-file formatting/lint and patch hygiene -> Prettier check, ESLint on the three changed files, and `git diff --check` -> **passed**.

CI remains authoritative for the complete portable suite and platform lanes, as agreed for this serialized refactor.

## Review focus

- Reservation ownership across timeout, unresumable fallback, and supersession.
- The ACP `session/resume` -> SDK `attachSession` -> configuration -> Registry publication order.
- Preservation of stable application ID versus provider protocol ID aliasing.
- Stable-view configuration replay when live effort changes overlap startup.
- Compatibility with the #751 model/provider hot-switch barriers, #753 Claude ACP patch integrity, #754 agent-aware replay/handoff, #761 Artifact routing, #762 Notebook process-group cleanup, #764 connector handoff, and the MCP SDK 1.30 dependency baseline from #755.
- Confirm the already-attached Runtime path remains outside the new interface.

## Uncovered risks

- Local validation intentionally used the final focused Test Impact Set rather than the complete portable suite; PR Gate and platform CI are the authority for full coverage.
- Timeout cleanup still relies on the existing connection teardown invalidating the in-flight reservation; both the Resumer interface test and full Runtime timeout regression cover this, but OS-specific process timing remains CI-owned.
- Issue #458 orchestration is not implemented, so only the declared ownership seams—not a future orchestrator—can be reviewed here.
