### PR TITLE
fix(global-search): respect page context in search dialog

### DIFF
--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1689,20 +1689,25 @@ describe('ManagedFileIndexRepository', () => {
     ).rejects.toThrow(/cursor.*search/i)
   })
 
-  it('searches generated artifacts with a primary cursor and one combined other-project result', async () => {
+  it('searches generated artifacts with a primary cursor and bounded other-project results', async () => {
     const primaryFiles = [
       ['sin-old', 'sin-old.png', 100],
       ['sin-new', 'sin-new.png', 300],
       ['sin-mid', 'sin-mid.csv', 200]
     ] as const
-    const otherPath = join(
-      storageRoot,
-      'artifacts',
-      'project-b',
-      'session-b',
-      'message-1',
-      'sin-other.png'
-    )
+    const otherFiles = Array.from({ length: 6 }, (_, index) => ({
+      id: `sin-other-${index}`,
+      name: `sin-other-${index}.png`,
+      path: join(
+        storageRoot,
+        'artifacts',
+        'project-b',
+        'session-b',
+        'message-1',
+        `sin-other-${index}.png`
+      ),
+      mtimeMs: 400 - index
+    }))
     const uploadPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'sin-input.csv')
 
     await Promise.all([
@@ -1719,7 +1724,7 @@ describe('ManagedFileIndexRepository', () => {
           id
         )
       ),
-      writeManagedFile(otherPath, 'other'),
+      ...otherFiles.map((file) => writeManagedFile(file.path, file.id)),
       writeManagedFile(uploadPath, 'upload')
     ])
     await repository.syncSession(
@@ -1765,15 +1770,13 @@ describe('ManagedFileIndexRepository', () => {
       createSession({
         id: 'session-b',
         projectId: 'project-b',
-        artifacts: [
-          {
-            id: 'sin-other',
-            kind: 'managed-file',
-            path: otherPath,
-            name: 'sin-other.png',
-            mtimeMs: 400
-          }
-        ]
+        artifacts: otherFiles.map((file) => ({
+          id: file.id,
+          kind: 'managed-file' as const,
+          path: file.path,
+          name: file.name,
+          mtimeMs: file.mtimeMs
+        }))
       })
     )
 
@@ -1782,7 +1785,7 @@ describe('ManagedFileIndexRepository', () => {
       otherProjectIds: ['project-b'],
       filenameContains: 'SIN',
       primaryLimit: 2,
-      otherLimit: 1
+      otherLimit: 5
     })
 
     expect(first.primary).toMatchObject({
@@ -1793,8 +1796,19 @@ describe('ManagedFileIndexRepository', () => {
       ]
     })
     expect(first.primary.nextCursor).toBeDefined()
-    expect(first.other).toEqual([expect.objectContaining({ name: 'sin-other.png' })])
+    expect(first.other.map((item) => item.name)).toEqual(
+      otherFiles.slice(0, 5).map((file) => file.name)
+    )
     expect(first.isIndexComplete).toBe(true)
+
+    await expect(
+      repository.searchArtifacts({
+        primaryProjectId: PROJECT_ID,
+        otherProjectIds: ['project-b'],
+        primaryLimit: 2,
+        otherLimit: 6
+      } as never)
+    ).rejects.toThrow('otherLimit must be between 0 and 5')
 
     await expect(
       repository.searchArtifacts({

--- a/src/main/project-files/repository.ts
+++ b/src/main/project-files/repository.ts
@@ -747,7 +747,7 @@ class ManagedFileIndexRepository {
   }
 
   // Global search keeps its cross-project scope deliberately bounded: the primary project is
-  // independently paged while every other project shares a single latest-artifact sample.
+  // independently paged while every other project shares a small latest-artifact sample.
   async searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult> {
     requireIdentifier(request.primaryProjectId, 'primaryProjectId')
     if (!Array.isArray(request.otherProjectIds)) {
@@ -759,8 +759,8 @@ class ManagedFileIndexRepository {
         requireIdentifier(projectId, 'otherProjectId')
         return projectId
       })
-    if (request.otherLimit !== 0 && request.otherLimit !== 1) {
-      throw new Error('Project files otherLimit must be 0 or 1.')
+    if (!Number.isInteger(request.otherLimit) || request.otherLimit < 0 || request.otherLimit > 5) {
+      throw new Error('Project files otherLimit must be between 0 and 5.')
     }
 
     const primaryLimit = normalizeLimit(request.primaryLimit)
@@ -775,8 +775,8 @@ class ManagedFileIndexRepository {
     const [primaryRows, primaryTotalCount, otherRows] = await Promise.all([
       listMatchingArtifacts(client, request.primaryProjectId, search, cursor, primaryLimit),
       countMatchingArtifacts(client, request.primaryProjectId, search),
-      request.otherLimit === 1 && otherProjectIds.length > 0
-        ? listOtherProjectArtifacts(client, otherProjectIds, search)
+      request.otherLimit > 0 && otherProjectIds.length > 0
+        ? listOtherProjectArtifacts(client, otherProjectIds, search, request.otherLimit)
         : Promise.resolve([])
     ])
     const primaryPageRows = primaryRows.slice(0, primaryLimit)
@@ -1421,7 +1421,8 @@ const countMatchingArtifacts = async (
 const listOtherProjectArtifacts = async (
   client: ProjectFilesClient,
   projectIds: string[],
-  search: NormalizedSearch | undefined
+  search: NormalizedSearch | undefined,
+  limit: number
 ): Promise<ManagedFile[]> => {
   const filenamePredicate = search
     ? Prisma.sql`AND ${filenameContainsPredicate(Prisma.sql`"displayName"`, search)}`
@@ -1439,7 +1440,7 @@ const listOtherProjectArtifacts = async (
       AND "deletedAt" IS NULL
       ${filenamePredicate}
     ORDER BY "sortAtMs" DESC, "seq" DESC
-    LIMIT 1
+    LIMIT ${limit}
   `)
 }
 

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -92,6 +92,7 @@ beforeEach(() => {
     userNavigationRevision: 0,
     explicitNavigationRevision: 0,
     pendingCustomizePrefill: undefined,
+    pendingProjectCreation: false,
     pendingArtifactMention: undefined,
     artifactMentionAvailability: { projectId: 'project-a', canMention: true }
   })
@@ -134,6 +135,12 @@ describe('GlobalSearchDialog', () => {
     expect(document.body.textContent).toContain('Recent artifacts')
     expect(document.body.textContent).toContain('Recent sessions')
     expect(document.body.textContent).toContain('New session')
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    expect(input?.placeholder).toBe('Search this project…')
+    expect(input?.parentElement?.textContent).toContain('Alpha')
+    expect(
+      document.body.querySelector('[data-testid="global-search-footer"]')?.textContent
+    ).toContain('mention')
 
     const artifactRow = [...document.body.querySelectorAll('[role="option"]')].find((element) =>
       element.textContent?.includes('sin.png')
@@ -178,6 +185,7 @@ describe('GlobalSearchDialog', () => {
 
     expect(groupHeadings.slice(0, 2)).toEqual(['Artifacts', 'Sessions'])
     expect(selectedOption?.textContent).toContain('sin.png')
+    expect(document.body.textContent).toContain('New session')
 
     await act(async () => {
       input?.dispatchEvent(
@@ -481,7 +489,59 @@ describe('GlobalSearchDialog', () => {
     expect(useNavigationStore.getState().pendingArtifactMention).toBeUndefined()
   })
 
-  it('uses the valid last-opened Project as Home search scope', async () => {
+  it('limits Other projects to five mixed Session and Artifact results', async () => {
+    const now = Date.now()
+    useSessionStore.setState((state) => ({
+      sessions: [
+        ...state.sessions,
+        ...Array.from({ length: 5 }, (_, index) => ({
+          ...state.sessions[1],
+          id: `other-session-${index}`,
+          title: `Other sin ${index}`,
+          updatedAt: now - (index + 1) * 20
+        }))
+      ] as ChatSession[]
+    }))
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockResolvedValue({
+      primary: { items: [artifact], totalCount: 1 },
+      other: Array.from({ length: 3 }, (_, index) => ({
+        ...artifact,
+        id: `other-artifact-${index}`,
+        sourceFileId: `other-artifact-${index}`,
+        sourceVersionId: `other-version-${index}`,
+        projectId: 'project-b',
+        sessionId: 'session-b',
+        name: `other-sin-${index}.png`,
+        path: `artifact-version:project-b/session-b/other-artifact-${index}/other-version-${index}`,
+        sortAtMs: now - index * 30
+      })),
+      isIndexComplete: true
+    })
+
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )?.set
+    await act(async () => {
+      valueSetter?.call(input, 'sin')
+      input?.dispatchEvent(new Event('input', { bubbles: true }))
+      await new Promise((resolve) => window.setTimeout(resolve, 180))
+    })
+
+    const otherGroup = document.body.querySelector<HTMLElement>(
+      '[role="group"][aria-label="Other projects"]'
+    )
+    expect(otherGroup?.querySelectorAll('[role="option"]')).toHaveLength(5)
+    expect(otherGroup?.textContent).toContain('other-sin-0.png')
+    expect(otherGroup?.textContent).toContain('Other sin session')
+  })
+
+  it('uses the global Home context and offers New Project without mention', async () => {
     window.localStorage.setItem('open-science:last-opened-project', 'project-b')
     useNavigationStore.setState({ view: 'home', activeProjectId: undefined })
     await act(async () => {
@@ -489,6 +549,34 @@ describe('GlobalSearchDialog', () => {
       await new Promise((resolve) => window.setTimeout(resolve, 20))
     })
 
-    expect(document.body.textContent).toContain('Beta')
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    const footer = document.body.querySelector<HTMLElement>('[data-testid="global-search-footer"]')
+    expect(input?.placeholder).toBe('Search sessions and artifacts…')
+    expect(input?.parentElement?.textContent).not.toContain('Beta')
+    expect(footer?.textContent).not.toContain('mention')
+    expect(footer?.querySelectorAll('kbd')).toHaveLength(3)
+    expect(window.api.projectFiles.searchArtifacts).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryProjectId: 'project-b', otherLimit: 5 })
+    )
+
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )?.set
+    await act(async () => {
+      valueSetter?.call(input, 'sin')
+      input?.dispatchEvent(new Event('input', { bubbles: true }))
+      await new Promise((resolve) => window.setTimeout(resolve, 180))
+    })
+    expect(document.body.querySelector('[role="group"][aria-label="Other projects"]')).toBeNull()
+
+    const newProject = [...document.body.querySelectorAll<HTMLElement>('[role="option"]')].find(
+      (element) => element.textContent?.includes('New project')
+    )
+    await act(async () => newProject?.click())
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'home',
+      pendingProjectCreation: true
+    })
   })
 })

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -5,7 +5,7 @@
  * contrast: inherited from the app's verified semantic tokens · slop: pass
  */
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
-import { ArrowUpRight, AtSign, Hash, MessageCircle, Search } from 'lucide-react'
+import { ArrowUpRight, AtSign, Hash, MessageCircle, Search, Zap } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 
 import type { ProjectFileItem } from '../../../../shared/project-files'
@@ -28,6 +28,7 @@ import {
   getNextBatchCount,
   getRecentSessions,
   GLOBAL_SEARCH_PAGE_SIZE,
+  OTHER_PROJECT_RESULT_LIMIT,
   searchSessionTitles,
   type SessionSearchResult
 } from './global-search-catalog'
@@ -53,6 +54,7 @@ type SelectableRow =
   | { kind: 'more-artifacts' }
   | { kind: 'retry-artifacts' }
   | { kind: 'new-session' }
+  | { kind: 'new-project' }
 
 const emptyArtifactState: ArtifactState = {
   items: [],
@@ -141,14 +143,16 @@ export const GlobalSearchDialog = ({
   const openProject = useNavigationStore((state) => state.openProject)
   const openSession = useNavigationStore((state) => state.openSession)
   const requestArtifactMention = useNavigationStore((state) => state.requestArtifactMention)
+  const requestProjectCreation = useNavigationStore((state) => state.requestProjectCreation)
   const artifactMentionAvailability = useNavigationStore(
     (state) => state.artifactMentionAvailability
   )
   const openFileDialog = usePreviewWorkbenchStore((state) => state.openFileDialog)
 
+  const isProjectScope = view === 'workspace' && activeProjectId !== undefined
   const primaryProjectId = useMemo(
-    () => activeProjectId ?? resolveCustomizeProjectId(projects),
-    [activeProjectId, projects]
+    () => (isProjectScope ? activeProjectId : resolveCustomizeProjectId(projects)),
+    [activeProjectId, isProjectScope, projects]
   )
   const primaryProject = useMemo(
     () => projects.find((project) => project.id === primaryProjectId),
@@ -196,12 +200,20 @@ export const GlobalSearchDialog = ({
               isPending: session.isPending
             })),
             projectNames,
-            primaryProjectId: primaryProject.id,
+            primaryProjectId: isProjectScope ? primaryProject.id : undefined,
             query: trimmedQuery,
             visiblePrimaryCount: visibleSessionCount
           })
         : undefined,
-    [isSearchMode, primaryProject, projectNames, sessions, trimmedQuery, visibleSessionCount]
+    [
+      isProjectScope,
+      isSearchMode,
+      primaryProject,
+      projectNames,
+      sessions,
+      trimmedQuery,
+      visibleSessionCount
+    ]
   )
   const recentSessions = useMemo(
     () =>
@@ -215,14 +227,14 @@ export const GlobalSearchDialog = ({
               artifactCount: session.artifacts?.length ?? 0,
               isPending: session.isPending
             })),
-            primaryProject.id
+            isProjectScope ? primaryProject.id : undefined
           ).map((session) => ({
             ...session,
             kind: 'session' as const,
-            projectName: primaryProject.name
+            projectName: projectNames.get(session.projectId) ?? 'Unknown project'
           }))
         : [],
-    [primaryProject, sessions]
+    [isProjectScope, primaryProject, projectNames, sessions]
   )
 
   const reloadArtifacts = useCallback(
@@ -242,7 +254,7 @@ export const GlobalSearchDialog = ({
           ...(trimmedQuery ? { filenameContains: trimmedQuery } : {}),
           primaryLimit: GLOBAL_SEARCH_PAGE_SIZE,
           ...(cursor ? { primaryCursor: cursor } : {}),
-          otherLimit: isSearchMode && !cursor ? 1 : 0
+          otherLimit: !cursor && (!isProjectScope || isSearchMode) ? OTHER_PROJECT_RESULT_LIMIT : 0
         })
         if (version !== requestVersionRef.current) return
         setArtifacts((current) =>
@@ -271,7 +283,7 @@ export const GlobalSearchDialog = ({
         setFailedArtifactCursor(cursor)
       }
     },
-    [isSearchMode, otherProjectIds, primaryProject, trimmedQuery]
+    [isProjectScope, isSearchMode, otherProjectIds, primaryProject, trimmedQuery]
   )
 
   useEffect(() => {
@@ -314,33 +326,59 @@ export const GlobalSearchDialog = ({
   const artifactMoreCount = getNextBatchCount(artifacts.totalCount, artifacts.items.length)
   const canLoadMoreArtifacts =
     artifactError === undefined && artifactMoreCount > 0 && artifacts.nextCursor !== undefined
+  const displayedArtifacts = useMemo(
+    () =>
+      isProjectScope
+        ? artifacts.items
+        : [...artifacts.items, ...artifacts.other].sort(
+            (left, right) => right.sortAtMs - left.sortAtMs
+          ),
+    [artifacts.items, artifacts.other, isProjectScope]
+  )
+  const otherRows = useMemo<SelectableRow[]>(() => {
+    if (!isProjectScope || !isSearchMode) return []
+    return [
+      ...artifacts.other.map((artifact) => ({ kind: 'artifact' as const, artifact })),
+      ...(sessionGroups?.other.map((session) => ({ kind: 'session' as const, session })) ?? [])
+    ]
+      .sort((left, right) => {
+        const leftTime = left.kind === 'artifact' ? left.artifact.sortAtMs : left.session.updatedAt
+        const rightTime =
+          right.kind === 'artifact' ? right.artifact.sortAtMs : right.session.updatedAt
+        return rightTime - leftTime
+      })
+      .slice(0, OTHER_PROJECT_RESULT_LIMIT)
+  }, [artifacts.other, isProjectScope, isSearchMode, sessionGroups?.other])
   const selectableRows = useMemo<SelectableRow[]>(() => {
-    if (!primaryProject) return []
+    const command = isProjectScope
+      ? ({ kind: 'new-session' } as const)
+      : ({ kind: 'new-project' } as const)
+    if (!primaryProject) return isProjectScope ? [] : [command]
     if (!isSearchMode) {
       return [
-        ...artifacts.items.map((artifact) => ({ kind: 'artifact' as const, artifact })),
+        ...displayedArtifacts.map((artifact) => ({ kind: 'artifact' as const, artifact })),
         ...recentSessions.map((session) => ({ kind: 'session' as const, session })),
-        { kind: 'new-session' as const }
+        command
       ]
     }
     return [
-      ...artifacts.items.map((artifact) => ({ kind: 'artifact' as const, artifact })),
+      ...displayedArtifacts.map((artifact) => ({ kind: 'artifact' as const, artifact })),
       ...(artifactError ? [{ kind: 'retry-artifacts' as const }] : []),
       ...(canLoadMoreArtifacts ? [{ kind: 'more-artifacts' as const }] : []),
       ...(sessionGroups?.primary.map((session) => ({ kind: 'session' as const, session })) ?? []),
       ...(sessionMoreCount > 0 ? [{ kind: 'more-sessions' as const }] : []),
-      ...artifacts.other.map((artifact) => ({ kind: 'artifact' as const, artifact })),
-      ...(sessionGroups?.other.map((session) => ({ kind: 'session' as const, session })) ?? [])
+      ...otherRows,
+      command
     ]
   }, [
     canLoadMoreArtifacts,
-    artifacts.items,
-    artifacts.other,
     artifactError,
+    displayedArtifacts,
+    isProjectScope,
     isSearchMode,
+    otherRows,
     primaryProject,
     recentSessions,
-    sessionGroups?.other,
     sessionGroups?.primary,
     sessionMoreCount
   ])
@@ -428,6 +466,11 @@ export const GlobalSearchDialog = ({
         openProject(primaryProject.id, 'user')
         useSessionStore.getState().clearSelection()
         close()
+        return
+      }
+      if (row.kind === 'new-project') {
+        requestProjectCreation()
+        close()
       }
     },
     [
@@ -442,6 +485,7 @@ export const GlobalSearchDialog = ({
       previewArtifact,
       primaryProject,
       reloadArtifacts,
+      requestProjectCreation,
       sessions
     ]
   )
@@ -482,10 +526,8 @@ export const GlobalSearchDialog = ({
 
   const resultCount = isSearchMode
     ? (sessionGroups?.primaryTotalCount ?? 0) +
-      artifacts.totalCount +
-      (sessionGroups?.other.length ?? 0) +
-      artifacts.other.length
-    : artifacts.items.length + recentSessions.length + (primaryProject ? 1 : 0)
+      (isProjectScope ? artifacts.totalCount + otherRows.length : displayedArtifacts.length)
+    : displayedArtifacts.length + recentSessions.length
   const renderSessionRow = (session: SessionSearchResult, rowIndex: number): React.JSX.Element => {
     const active = rowIndex === activeRowIndex
     return (
@@ -505,7 +547,9 @@ export const GlobalSearchDialog = ({
             {session.title}
           </span>
           <span className="block truncate text-xs text-muted-foreground">
-            {session.projectId !== primaryProject?.id ? `${session.projectName} · ` : ''}
+            {!isProjectScope || session.projectId !== primaryProject?.id
+              ? `${session.projectName} · `
+              : ''}
             {session.artifactCount} artifact{session.artifactCount === 1 ? '' : 's'} ·{' '}
             {formatRelativeTime(session.updatedAt)}
           </span>
@@ -560,7 +604,7 @@ export const GlobalSearchDialog = ({
             {artifact.name}
           </span>
           <span className="block truncate text-xs text-muted-foreground">
-            {artifact.projectId !== primaryProject?.id
+            {!isProjectScope || artifact.projectId !== primaryProject?.id
               ? `${projectNames.get(artifact.projectId) ?? 'Unknown project'} · `
               : ''}
             {artifact.originSession?.title ??
@@ -653,11 +697,13 @@ export const GlobalSearchDialog = ({
               aria-autocomplete="list"
               aria-controls={listboxId}
               aria-activedescendant={selectableRows.length > 0 ? activeRowId : undefined}
-              placeholder="Search this project…"
+              placeholder={
+                isProjectScope ? 'Search this project…' : 'Search sessions and artifacts…'
+              }
               maxLength={256}
               className="h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 text-xl text-foreground placeholder:text-muted-foreground focus-visible:border-transparent focus-visible:ring-0"
             />
-            {primaryProject ? (
+            {isProjectScope && primaryProject ? (
               <span className="max-w-[35%] shrink-0 truncate rounded-lg bg-bg-200 px-3 py-1.5 text-sm font-medium text-muted-foreground">
                 {primaryProject.name}
               </span>
@@ -682,10 +728,12 @@ export const GlobalSearchDialog = ({
                 </p>
               ) : !isSearchMode ? (
                 <>
-                  {artifacts.items.length > 0 ? (
+                  {displayedArtifacts.length > 0 ? (
                     <section role="group" aria-label="Recent artifacts">
                       <h2 className={sectionTitleClassName}>Recent artifacts</h2>
-                      {artifacts.items.map((artifact) => renderArtifactRow(artifact, nextIndex()))}
+                      {displayedArtifacts.map((artifact) =>
+                        renderArtifactRow(artifact, nextIndex())
+                      )}
                     </section>
                   ) : null}
                   {recentSessions.length > 0 ? (
@@ -694,35 +742,16 @@ export const GlobalSearchDialog = ({
                       {recentSessions.map((session) => renderSessionRow(session, nextIndex()))}
                     </section>
                   ) : null}
-                  <section role="group" aria-label="Commands">
-                    <h2 className={sectionTitleClassName}>Commands</h2>
-                    <Button
-                      id={`global-search-option-${nextIndex()}`}
-                      type="button"
-                      role="option"
-                      aria-selected={activeRowIndex === rowIndex - 1}
-                      variant="ghost"
-                      disabled={!isSessionPersistenceReady}
-                      className={cn(
-                        rowClassName,
-                        activeRowIndex === rowIndex - 1 && 'bg-bg-200 before:opacity-100',
-                        !isSessionPersistenceReady && 'opacity-50'
-                      )}
-                      onMouseEnter={() => setActiveIndex(rowIndex - 1)}
-                      onClick={() => activate({ kind: 'new-session' })}
-                    >
-                      <MessageCircle className="size-5 text-primary" aria-hidden="true" />
-                      <span className="text-sm font-medium">New session</span>
-                    </Button>
-                  </section>
                 </>
               ) : (
                 <>
-                  {artifacts.items.length || artifactStatus === 'loading' || artifactError ? (
+                  {displayedArtifacts.length || artifactStatus === 'loading' || artifactError ? (
                     <section role="group" aria-label="Artifacts">
                       <h2 className={sectionTitleClassName}>Artifacts</h2>
-                      {artifacts.items.map((artifact) => renderArtifactRow(artifact, nextIndex()))}
-                      {artifactStatus === 'loading' && artifacts.items.length === 0 ? (
+                      {displayedArtifacts.map((artifact) =>
+                        renderArtifactRow(artifact, nextIndex())
+                      )}
+                      {artifactStatus === 'loading' && displayedArtifacts.length === 0 ? (
                         <p className="px-4 py-3 text-sm text-muted-foreground">
                           Searching artifacts…
                         </p>
@@ -788,22 +817,60 @@ export const GlobalSearchDialog = ({
                       ) : null}
                     </section>
                   ) : null}
-                  {sessionGroups?.other.length || artifacts.other.length ? (
+                  {otherRows.length > 0 ? (
                     <section role="group" aria-label="Other projects">
                       <h2 className={sectionTitleClassName}>Other projects</h2>
-                      {artifacts.other.map((artifact) => renderArtifactRow(artifact, nextIndex()))}
-                      {sessionGroups?.other.map((session) =>
-                        renderSessionRow(session, nextIndex())
+                      {otherRows.map((row) =>
+                        row.kind === 'artifact'
+                          ? renderArtifactRow(row.artifact, nextIndex())
+                          : row.kind === 'session'
+                            ? renderSessionRow(row.session, nextIndex())
+                            : null
                       )}
                     </section>
                   ) : null}
-                  {selectableRows.length === 0 && artifactStatus !== 'loading' ? (
+                  {displayedArtifacts.length === 0 &&
+                  !sessionGroups?.primary.length &&
+                  otherRows.length === 0 &&
+                  artifactStatus !== 'loading' &&
+                  !artifactError ? (
                     <p className="px-4 py-8 text-center text-sm text-muted-foreground">
                       No sessions or artifacts match “{query}”.
                     </p>
                   ) : null}
                 </>
               )}
+              {!isProjectScope || primaryProject ? (
+                <section role="group" aria-label="Commands">
+                  <h2 className={sectionTitleClassName}>Commands</h2>
+                  <Button
+                    id={`global-search-option-${nextIndex()}`}
+                    type="button"
+                    role="option"
+                    aria-selected={activeRowIndex === rowIndex - 1}
+                    variant="ghost"
+                    disabled={isProjectScope && !isSessionPersistenceReady}
+                    className={cn(
+                      rowClassName,
+                      activeRowIndex === rowIndex - 1 && 'bg-bg-200 before:opacity-100',
+                      isProjectScope && !isSessionPersistenceReady && 'opacity-50'
+                    )}
+                    onMouseEnter={() => setActiveIndex(rowIndex - 1)}
+                    onClick={() =>
+                      activate({ kind: isProjectScope ? 'new-session' : 'new-project' })
+                    }
+                  >
+                    {isProjectScope ? (
+                      <MessageCircle className="size-5 text-primary" aria-hidden="true" />
+                    ) : (
+                      <Zap className="size-5 text-primary" aria-hidden="true" />
+                    )}
+                    <span className="text-sm font-medium">
+                      {isProjectScope ? 'New session' : 'New project'}
+                    </span>
+                  </Button>
+                </section>
+              ) : null}
               {!artifacts.isIndexComplete ? (
                 <p className="px-4 py-2 text-xs text-muted-foreground">
                   Some artifact results may be missing.
@@ -823,10 +890,12 @@ export const GlobalSearchDialog = ({
               <kbd className={keycapClassName}>↵</kbd>
               <span>open</span>
             </span>
-            <span className={shortcutClassName}>
-              <kbd className={keycapClassName}>⇧↵</kbd>
-              <span>mention</span>
-            </span>
+            {isProjectScope ? (
+              <span className={shortcutClassName}>
+                <kbd className={keycapClassName}>⇧↵</kbd>
+                <span>mention</span>
+              </span>
+            ) : null}
             <span className={shortcutClassName}>
               <kbd className={keycapClassName}>esc</kbd>
               <span>close</span>

--- a/src/renderer/src/components/global-search/global-search-catalog.test.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.test.ts
@@ -22,7 +22,7 @@ describe('global search catalog', () => {
     const result = searchSessionTitles({
       sessions: [
         ...sessions(14),
-        ...sessions(2, 'project-b'),
+        ...sessions(7, 'project-b'),
         {
           id: 'pending-match',
           projectId: 'project-a',
@@ -51,10 +51,28 @@ describe('global search catalog', () => {
 
     expect(result.primary).toHaveLength(8)
     expect(result.primaryTotalCount).toBe(14)
-    expect(result.other).toEqual([
+    expect(result.other).toHaveLength(5)
+    expect(result.other[0]).toEqual(
       expect.objectContaining({ id: 'session-0', projectId: 'project-b', projectName: 'Beta' })
-    ])
+    )
     expect(getNextBatchCount(result.primaryTotalCount, result.primary.length)).toBe(6)
+  })
+
+  it('searches every Project as the primary result set when no Project scope is active', () => {
+    const result = searchSessionTitles({
+      sessions: [...sessions(3), ...sessions(3, 'project-b')],
+      projectNames: new Map([
+        ['project-a', 'Alpha'],
+        ['project-b', 'Beta']
+      ]),
+      primaryProjectId: undefined,
+      query: 'sin',
+      visiblePrimaryCount: 5
+    })
+
+    expect(result.primary).toHaveLength(5)
+    expect(result.primaryTotalCount).toBe(6)
+    expect(result.other).toEqual([])
   })
 
   it('returns recent non-pending sessions in recency order with a five-row cap', () => {

--- a/src/renderer/src/components/global-search/global-search-catalog.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.ts
@@ -1,5 +1,6 @@
 export const GLOBAL_SEARCH_PAGE_SIZE = 8
 export const RECENT_SESSION_LIMIT = 5
+export const OTHER_PROJECT_RESULT_LIMIT = 5
 
 export type SearchableSession = {
   id: string
@@ -47,7 +48,7 @@ export const searchSessionTitles = ({
 }: {
   sessions: SearchableSession[]
   projectNames: Map<string, string>
-  primaryProjectId: string
+  primaryProjectId: string | undefined
   query: string
   visiblePrimaryCount: number
 }): SessionSearchGroups => {
@@ -60,26 +61,30 @@ export const searchSessionTitles = ({
         foldAsciiCase(session.title).includes(foldedQuery)
     )
     .sort(compareByRecency)
-  const primaryMatches = matches.filter((session) => session.projectId === primaryProjectId)
+  const primaryMatches = primaryProjectId
+    ? matches.filter((session) => session.projectId === primaryProjectId)
+    : matches
 
   return {
     primary: primaryMatches
       .slice(0, visiblePrimaryCount)
       .map((session) => toResult(session, projectNames)),
     primaryTotalCount: primaryMatches.length,
-    other: matches
-      .filter((session) => session.projectId !== primaryProjectId)
-      .slice(0, 1)
-      .map((session) => toResult(session, projectNames))
+    other: primaryProjectId
+      ? matches
+          .filter((session) => session.projectId !== primaryProjectId)
+          .slice(0, OTHER_PROJECT_RESULT_LIMIT)
+          .map((session) => toResult(session, projectNames))
+      : []
   }
 }
 
 export const getRecentSessions = (
   sessions: SearchableSession[],
-  projectId: string
+  projectId?: string
 ): SearchableSession[] =>
   sessions
-    .filter((session) => session.projectId === projectId && !session.isPending)
+    .filter((session) => !session.isPending && (!projectId || session.projectId === projectId))
     .sort(compareByRecency)
     .slice(0, RECENT_SESSION_LIMIT)
 

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { EnvironmentCheckResult } from '../../../../shared/settings'
 import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
+import { useNavigationStore } from '@/stores/navigation-store'
 import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import { HomePage } from './HomePage'
@@ -28,6 +29,7 @@ const environment = (checks: EnvironmentCheckResult['checks']): EnvironmentCheck
 
 beforeEach(() => {
   useProjectStore.setState(createInitialProjectState())
+  useNavigationStore.setState({ pendingProjectCreation: false })
   useSessionStore.setState(createInitialSessionState())
   useSettingsStore.setState(createInitialSettingsState())
   container = document.createElement('div')
@@ -42,6 +44,15 @@ afterEach(() => {
 })
 
 describe('HomePage environment repair notice', () => {
+  it('consumes a global-search request and opens the New Project dialog', async () => {
+    useNavigationStore.setState({ pendingProjectCreation: true })
+
+    await act(async () => root.render(<HomePage canDeleteProjects hasCompleteSessionCatalog />))
+
+    expect(document.body.textContent).toContain('Group related sessions under a project.')
+    expect(useNavigationStore.getState().pendingProjectCreation).toBe(false)
+  })
+
   it('does not alert for optional Python or secure-storage warnings', async () => {
     useSettingsStore.setState({
       environmentCheck: environment([

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -9,7 +9,7 @@ import {
   Trash2
 } from 'lucide-react'
 import { DropdownMenu } from 'radix-ui'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { formatRelativeTime } from '@/lib/format-relative-time'
 import { cn } from '@/lib/utils'
@@ -91,6 +91,8 @@ const HomePage = ({
   const sessions = useSessionStore((state) => state.sessions)
   const openProject = useNavigationStore((state) => state.openProject)
   const openSession = useNavigationStore((state) => state.openSession)
+  const pendingProjectCreation = useNavigationStore((state) => state.pendingProjectCreation)
+  const consumeProjectCreation = useNavigationStore((state) => state.consumeProjectCreation)
   const openSettings = useSettingsStore((state) => state.openSettings)
   const environmentCheck = useSettingsStore((state) => state.environmentCheck)
   const openSettingsToPanel = useSettingsStore((state) => state.openSettingsToPanel)
@@ -151,6 +153,17 @@ const HomePage = ({
     setDescriptionDraft('')
     setFormError(undefined)
   }
+
+  useEffect(() => {
+    if (!pendingProjectCreation) return
+    queueMicrotask(() => {
+      setFormState({ mode: 'create' })
+      setNameDraft('')
+      setDescriptionDraft('')
+      setFormError(undefined)
+      consumeProjectCreation()
+    })
+  }, [consumeProjectCreation, pendingProjectCreation])
 
   const openEditDialog = (project: Project): void => {
     setFormState({ mode: 'edit', projectId: project.id })

--- a/src/renderer/src/stores/navigation-store.test.ts
+++ b/src/renderer/src/stores/navigation-store.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
     userNavigationRevision: 0,
     explicitNavigationRevision: 0,
     pendingCustomizePrefill: undefined,
+    pendingProjectCreation: false,
     pendingArtifactMention: undefined,
     artifactMentionAvailability: undefined
   })
@@ -119,6 +120,19 @@ describe('navigation store', () => {
     useNavigationStore.getState().goHome('user')
 
     expect(useNavigationStore.getState().view).toBe('home')
+  })
+
+  it('routes a New Project request home as a one-shot intent', () => {
+    useNavigationStore.getState().openProject('project-a', 'automatic')
+
+    useNavigationStore.getState().requestProjectCreation()
+
+    expect(useNavigationStore.getState()).toMatchObject({
+      view: 'home',
+      pendingProjectCreation: true
+    })
+    useNavigationStore.getState().consumeProjectCreation()
+    expect(useNavigationStore.getState().pendingProjectCreation).toBe(false)
   })
 
   it('advances user navigation revision only for explicit user actions', () => {

--- a/src/renderer/src/stores/navigation-store.ts
+++ b/src/renderer/src/stores/navigation-store.ts
@@ -27,6 +27,8 @@ type NavigationStore = {
   // Project id targeted by a pending `Chat with agent` prefill, consumed once by WorkspacePage when it
   // opens that project's New Conversation draft. Undefined means no prefill is pending.
   pendingCustomizePrefill: string | undefined
+  // Home consumes this one-shot intent to open its existing New Project dialog.
+  pendingProjectCreation: boolean
   // A same-Project Artifact selected from global search. WorkspacePage consumes it once and appends
   // its immutable Version reference to the currently active composer draft.
   pendingArtifactMention: ProjectFileItem | undefined
@@ -44,6 +46,8 @@ type NavigationStore = {
   // prefill once and clears it.
   startCustomizeConversation: (projectId: string) => void
   consumeCustomizePrefill: () => void
+  requestProjectCreation: () => void
+  consumeProjectCreation: () => void
   requestArtifactMention: (file: ProjectFileItem) => void
   consumeArtifactMention: () => ProjectFileItem | undefined
   setArtifactMentionAvailability: (availability: ArtifactMentionAvailability | undefined) => void
@@ -83,6 +87,7 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
   userNavigationRevision: 0,
   explicitNavigationRevision: 0,
   pendingCustomizePrefill: undefined,
+  pendingProjectCreation: false,
   pendingArtifactMention: undefined,
   artifactMentionAvailability: undefined,
 
@@ -162,6 +167,14 @@ export const useNavigationStore = create<NavigationStore>((set) => ({
 
   // Clears the consumed prefill intent so a later normal open starts fresh.
   consumeCustomizePrefill: () => set({ pendingCustomizePrefill: undefined }),
+
+  requestProjectCreation: () =>
+    set((state) => ({
+      ...navigationState(state, 'user', { view: 'home' }),
+      pendingProjectCreation: true
+    })),
+
+  consumeProjectCreation: () => set({ pendingProjectCreation: false }),
 
   // Mentions never route between Projects. Keeping this guard at the Navigation boundary prevents a
   // dialog caller from leaking an Artifact locator into whichever composer happens to mount next.

--- a/src/shared/project-files.ts
+++ b/src/shared/project-files.ts
@@ -62,7 +62,7 @@ export type SearchArtifactsRequest = {
   filenameContains?: string
   primaryLimit: number
   primaryCursor?: string
-  otherLimit: 0 | 1
+  otherLimit: 0 | 1 | 2 | 3 | 4 | 5
 }
 
 export type SearchArtifactsResult = {


### PR DESCRIPTION
## Problem

Global Search always reused the last-opened Project as its primary scope. On Home this leaked a Project badge and Other projects grouping into a global result view, while the page-specific creation command was wrong. Project detail search also limited cross-Project results to one item.

## Proposed change

- Treat Home as a global Sessions and Artifacts search with no Project badge or Other projects section.
- Keep Project detail search scoped to the active Project and show its name.
- Cap Other projects at five recency-sorted mixed Session and Artifact rows.
- Keep mention in the Project footer and show New session; show New project on Home.
- Extend the existing Project Files otherLimit contract from 0-1 to 0-5.

## Scope and non-goals

No persistence schema, data relationship, dependency, or architecture change. Artifact paging remains anchored to the existing primary-Project query contract.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Search context, commands, footer shortcuts, and mixed result cap -> npm test -- src/renderer/src/components/global-search/global-search-catalog.test.ts src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx src/renderer/src/stores/navigation-store.test.ts src/renderer/src/pages/home/HomePage.render.test.tsx src/main/project-files/repository.test.ts -> 74 passed.
- Final dialog assertions -> npm test -- src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx -> 13 passed.
- Renderer types -> npm run typecheck:web -> passed.
- Lint -> npm run lint -> 0 errors; 17 pre-existing warnings in unrelated files.
- Portable suite -> npm test -> 11,289 passed, 184 skipped, 3 pre-existing failures in src/main/acp/claude-agent-acp-patch.test.ts. The same 3 failures reproduce on main.
- Node types -> npm run typecheck:node -> 2 pre-existing errors in src/main/acp/claude-agent-acp-patch.test.ts. The same errors reproduce on main.

Local browser visual verification was not available because the Web dev server exits with its Electron child process in this environment; jsdom interaction tests cover both search contexts.

## Review focus

Please focus on the Home versus Project context split, the five-row mixed Other projects ordering, and the bounded otherLimit contract validation.