### PR TITLE
fix(artifact-provenance): route case-folded lineage bytes

### DIFF
--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -266,6 +266,116 @@ describe('artifact provenance repository', () => {
     ])
   })
 
+  it('selects the exact pending filename when multiple files share one normalized name', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-exact-filename-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await ensureProjectSchema(client)
+
+    const compatibilityRepository = new ArtifactRepository(storageRoot)
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository
+    })
+    const oldCandidate = await compatibilityRepository.writePendingFile({
+      projectName: 'project-1',
+      sessionId: 'artifact-session-1',
+      runId: 'artifact-run-1',
+      filename: 'old-candidate.png',
+      mimeType: 'image/png',
+      source: createPngInlineSource('old bytes')
+    })
+    const exactCandidate = await compatibilityRepository.writePendingFile({
+      projectName: 'project-1',
+      sessionId: 'artifact-session-1',
+      runId: 'artifact-run-1',
+      filename: 'exact-candidate.png',
+      mimeType: 'image/png',
+      source: createPngInlineSource('exact bytes')
+    })
+    vi.spyOn(compatibilityRepository, 'listPendingRunFiles').mockResolvedValue([
+      { ...oldCandidate, name: 'Sin.png' },
+      { ...exactCandidate, name: 'SIN.PNG' }
+    ])
+    vi.spyOn(compatibilityRepository, 'ensurePendingVersionRouting').mockResolvedValue()
+
+    const version = await repository.createVersion({
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      artifactRunId: 'artifact-run-1',
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-segment-1',
+      promptMessageId: 'prompt-1',
+      agentName: 'Codex',
+      filename: 'SIN.PNG',
+      contentType: 'image/png',
+      titleSnapshot: 'Sine analysis',
+      writeOperationId: 'write-1',
+      writeRequestChecksum: 'a'.repeat(64)
+    })
+
+    expect(await readFile(version.path)).toEqual(createPngBytes('exact bytes'))
+  })
+
+  it('rejects ambiguous normalized pending filenames when none exactly matches', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-ambiguous-filename-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await ensureProjectSchema(client)
+
+    const compatibilityRepository = new ArtifactRepository(storageRoot)
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository
+    })
+    const firstCandidate = await compatibilityRepository.writePendingFile({
+      projectName: 'project-1',
+      sessionId: 'artifact-session-1',
+      runId: 'artifact-run-1',
+      filename: 'first-candidate.png',
+      mimeType: 'image/png',
+      source: createPngInlineSource('first bytes')
+    })
+    const secondCandidate = await compatibilityRepository.writePendingFile({
+      projectName: 'project-1',
+      sessionId: 'artifact-session-1',
+      runId: 'artifact-run-1',
+      filename: 'second-candidate.png',
+      mimeType: 'image/png',
+      source: createPngInlineSource('second bytes')
+    })
+    vi.spyOn(compatibilityRepository, 'listPendingRunFiles').mockResolvedValue([
+      { ...firstCandidate, name: 'Sin.png' },
+      { ...secondCandidate, name: 'sin.PNG' }
+    ])
+
+    await expect(
+      repository.createVersion({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'artifact-run-1',
+        rootFrameId: 'root-frame-1',
+        agentFrameId: 'agent-frame-1',
+        messageBranchId: 'branch-1',
+        runtimeSegmentId: 'runtime-segment-1',
+        promptMessageId: 'prompt-1',
+        agentName: 'Codex',
+        filename: 'SIN.PNG',
+        contentType: 'image/png',
+        titleSnapshot: 'Sine analysis',
+        writeOperationId: 'write-1',
+        writeRequestChecksum: 'a'.repeat(64)
+      })
+    ).rejects.toThrow('Pending artifact filename is ambiguous: SIN.PNG')
+    await expect(client.artifactVersion.count()).resolves.toBe(0)
+  })
+
   it('publishes app-generated compatibility bytes and an immutable Version together', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-app-generated-artifact-'))
     const client = createProjectDbClient(storageRoot)

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -1588,11 +1588,17 @@ class ArtifactProvenanceRepository {
       sessionId: artifactStorageSessionId,
       runId: artifactRunId
     })
-    const pendingFile = pendingFiles.find(
+    const matchingPendingFiles = pendingFiles.filter(
       (file) => normalizeFilename(file.name) === normalizedFilename
     )
+    const pendingFile =
+      matchingPendingFiles.find((file) => file.name === request.filename) ??
+      (matchingPendingFiles.length === 1 ? matchingPendingFiles[0] : undefined)
 
     if (!pendingFile) {
+      if (matchingPendingFiles.length > 1) {
+        throw new Error(`Pending artifact filename is ambiguous: ${request.filename}`)
+      }
       throw new Error(`Pending artifact file not found: ${request.filename}`)
     }
 


### PR DESCRIPTION
## Problem

PR #757 made the complete portable suite authoritative for affected pull requests. That gate exposed a production portability defect while validating PR #759: on a Linux case-sensitive filesystem, `Sin.png` and `SIN.PNG` can coexist in one pending run. Provenance intentionally folds both names into one lineage, but Version creation selected the first locale-sorted physical candidate rather than the exact requested filename. It could therefore copy stale bytes and then fail closed with `Artifact pending bytes conflict with Version routing.`

This is a portable production blocker exposed by #757. It is not related to #458.

## Proposed change

Select pending bytes with an explicit deterministic policy:

```mermaid
flowchart TD
  A["Case-folded pending candidates"] --> B{"Exact requested filename exists?"}
  B -->|"Yes"| C["Select exact filename bytes"]
  B -->|"No, one candidate"| D["Preserve compatibility fallback"]
  B -->|"No, multiple candidates"| E["Reject ambiguous routing before persistence"]
```

The production change is +7/-1 lines. Two portable repository tests construct multiple case-folded candidates through the existing ArtifactRepository adapter seam, so the behavior is deterministic even on default case-insensitive macOS filesystems.

## Scope and non-goals

- Preserve one Artifact lineage per same-session case-folded filename.
- Prefer the exact request filename when multiple physical candidates normalize to that lineage.
- Preserve the existing single-candidate case-folded fallback.
- Fail closed when multiple normalized candidates exist and none exactly matches.
- Do not change schema, data relationships, public interfaces, user interaction, or ACP behavior.
- Do not clean up legacy duplicate physical files in this pull request.
- Do not introduce any #458 orchestration or compatibility work.

## Ownership and sequence

ArtifactProvenanceRepository remains the owner of lineage identity and immutable Version creation. ArtifactRepository remains the compatibility-storage adapter. Candidate selection now happens before immutable bytes or SQLite Version state are created; routing publication and lineage allocation retain their existing owners and sequence.

Base: `b6966f3058509fe8a64e864b1220930f60d4a864`
Head: `ef72ff3230ae14ad41d6b674af63c2d8461ef162`

## Acceptance criteria and validation

TDD RED evidence on the unmodified implementation:

- Exact-name scenario copied `old bytes` instead of the requested exact candidate.
- No-exact ambiguous scenario resolved a Version instead of rejecting.

Final evidence after the last material edit, including focused reruns after rebasing onto the stated base:

- Exact selection, ambiguity rejection, and existing lineage behavior with shuffle seeds 11, 29, and 47: 3/3 passed in each run.
- Full provenance repository with shuffle seed 73: 32/32 passed.
- Provenance, compatibility repository, rollback, and message-snapshot owner set: 91/91 passed, including after final rebase.
- `npm run typecheck:node`: passed, including after final rebase.
- ESLint on both changed files: passed, including after final rebase.
- Prettier check on both changed files: passed, including after final rebase.
- `git diff origin/main...HEAD --check`: passed after final rebase.
- Independent Standards review: 0 findings.
- Independent Spec review: 0 findings.

The production owner and its compatibility adapter are covered. No consumer contract or public interface changed, so renderer, Web, CLI, Electron IPC, and ACP lanes are excluded from the local impact set.

## Review focus

- Confirm exact raw filename identity wins over earlier case-folded candidates.
- Confirm a single non-exact normalized candidate preserves compatibility behavior.
- Confirm multiple non-exact candidates fail before ArtifactVersion persistence.
- Confirm the change does not weaken routing checksum validation or lineage uniqueness.

## Uncovered risks

The local APFS workspace does not reproduce two case-distinct files in one directory. The new tests use the public repository adapter boundary to make that candidate set deterministic, while the online Linux PR Gate provides the authoritative real case-sensitive filesystem run. No full local portable suite was run; the focused impact set passed and the online gate will cover the complete portable suite.

### Authorized merge exception

The exact-head online Unit tests failed only in the independently reproduced Notebook POSIX timeout cleanup scenario; the Artifact provenance test exercised by this pull request passed in that same Linux run. Static checks, CodeQL, macOS/Windows lanes, AI review, and both independent code reviews passed. Because the independent Artifact and Notebook production fixes form a cyclic full-suite dependency, the maintainer explicitly authorized one administrator squash merge for this pull request on 2026-08-05. PR #762 owns the Notebook defect and must be rebased onto this merge, pass its focused process-lifecycle tests, and obtain exact-head full CI/AI approval before it can merge.