### PR TITLE
fix(notebook-runtime): terminate timed-out process groups

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
@@ -1830,51 +1829,88 @@ describe('notebook runtime service', () => {
       expect(new Set(state.runs.map((run) => run.runId)).size).toBe(2)
     })
 
-    // POSIX-only: relies on `trap '' TERM` (a SIGTERM-ignoring shell) and pgrep to inspect the real
-    // process table — neither exists on Windows, where signal semantics differ entirely.
+    // POSIX-only: relies on `trap '' TERM` and signal-0 process probes. Windows signal semantics
+    // differ entirely and use taskkill-backed tree termination instead.
     it.skipIf(process.platform === 'win32')(
       'SIGKILLs a timed-out command that ignores SIGTERM instead of leaving it running',
       async () => {
         const root = await createStorageRoot()
         const service = createShellService(root)
-        // A marker unique to this test run, embedded as a harmless shell comment so it shows up in the
-        // spawned process's command line (visible to pgrep -f) without affecting what the shell runs.
+        // A marker unique to this test run. It appears on both the shell and its real Node descendant,
+        // so the observable contract requires the whole timed-out command tree to disappear.
         const marker = `os-notebook-shell-test-${randomUUID()}`
+        const descendantPidPath = join(root, `${marker}.pid`)
+        const quoteForShell = (value: string): string => `'${value.replaceAll("'", `'\\''`)}'`
 
-        const result = await service.executeShell({
+        const execution = service.executeShell({
           sessionId: 'session-1',
           workspaceCwd: root,
-          // Ignores SIGTERM; only SIGKILL can end it before its own 30s sleep completes.
-          command: `trap '' TERM; sleep 30 # ${marker}`,
-          timeoutMs: 100
+          // The shell records its real descendant's PID before waiting. Both ignore SIGTERM, so the
+          // timeout cleanup must escalate and reap the whole tree rather than only the direct shell.
+          command: `trap '' TERM; ${quoteForShell(process.execPath)} -e ${quoteForShell(
+            "process.on('SIGTERM', () => {}); setTimeout(() => {}, 30_000)"
+          )} ${quoteForShell(marker)} & descendant_pid=$!; printf '%s' "$descendant_pid" > ${quoteForShell(
+            descendantPidPath
+          )}; wait "$descendant_pid" # ${marker}`,
+          timeoutMs: 2_000
         })
+
+        // Start the execution first, then require the descendant to be observable well before the
+        // timeout. This prevents a loaded runner from taking the process-tree snapshot before the
+        // fixture has spawned the process that the cleanup contract is meant to cover.
+        const readinessDeadline = Date.now() + 1_500
+        let descendantPid: number | undefined
+        while (descendantPid === undefined && Date.now() < readinessDeadline) {
+          try {
+            const candidate = Number((await readFile(descendantPidPath, 'utf8')).trim())
+            if (Number.isInteger(candidate) && candidate > 0) descendantPid = candidate
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+          }
+          if (descendantPid === undefined) await new Promise((r) => setTimeout(r, 20))
+        }
+        if (descendantPid === undefined) {
+          throw new Error(
+            'timed-out shell descendant did not become ready before the fixture deadline'
+          )
+        }
+
+        const result = await execution
 
         // The RPC promise settles at the timeout, well before either the grace period or the sleep.
         expect(result.exitCode).toBeNull()
 
-        // Poll the real process table until the marked process is gone -- not child.killed, which Node
-        // sets as soon as SIGTERM is delivered regardless of whether the (SIGTERM-ignoring) process
-        // actually died. Polling (rather than a single fixed sleep) absorbs SIGKILL-escalation +
-        // process-teardown latency on a loaded CI runner, so the test isn't timing-flaky; if SIGKILL
-        // never worked, it stays non-empty until the deadline and the assertion fails.
-        const pgrepMarker = async (): Promise<string> =>
-          new Promise<string>((resolve) => {
-            const check = spawn('sh', ['-c', `pgrep -f '${marker}' || true`])
-            let out = ''
-            check.stdout.on('data', (chunk: Buffer) => {
-              out += chunk.toString('utf8')
-            })
-            check.once('exit', () => resolve(out.trim()))
-          })
-
-        let stillRunning = await pgrepMarker()
-        const deadline = Date.now() + 10_000
-        while (stillRunning !== '' && Date.now() < deadline) {
-          await new Promise((r) => setTimeout(r, 500))
-          stillRunning = await pgrepMarker()
+        // Probe the exact descendant instead of searching the process table. The former pgrep fixture
+        // wrapped the query in `sh -c`, whose own argv contained the marker and self-matched on Linux.
+        const descendantIsRunning = (): boolean => {
+          try {
+            process.kill(descendantPid, 0)
+            return true
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false
+            throw error
+          }
         }
 
-        expect(stillRunning).toBe('')
+        let stillRunning = descendantIsRunning()
+        const deadline = Date.now() + 10_000
+        while (stillRunning && Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, 500))
+          stillRunning = descendantIsRunning()
+        }
+
+        try {
+          expect(stillRunning).toBe(false)
+        } finally {
+          // A RED run must not leak the process whose survival it proves.
+          if (stillRunning) {
+            try {
+              process.kill(descendantPid, 'SIGKILL')
+            } catch {
+              // It exited between the final probe and cleanup.
+            }
+          }
+        }
       },
       15_000
     )

--- a/src/main/notebook/shell-process.test.ts
+++ b/src/main/notebook/shell-process.test.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from 'node:child_process'
+import { EventEmitter } from 'node:events'
 import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -83,7 +84,7 @@ describe('notebook shell process behavior', () => {
     })
   })
 
-  describe('Windows support', () => {
+  describe('platform support', () => {
     const completedProgressClixml =
       '#< CLIXML\n' +
       '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">' +
@@ -161,6 +162,46 @@ describe('notebook shell process behavior', () => {
       expect(terminateTree).toHaveBeenCalledWith(child)
       finishTermination?.({ reaped: true })
       return expect(termination).resolves.toBe(true)
+    })
+
+    it('terminates the dedicated POSIX process group even after its shell leader exits', async () => {
+      vi.useFakeTimers()
+      const signal = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      const child = Object.assign(new EventEmitter(), { pid: 4321 }) as unknown as ChildProcess
+      const terminateTree = vi.fn(async () => ({ reaped: true }))
+
+      try {
+        await expect(terminateShellOnTimeout(child, 'linux', terminateTree)).resolves.toBe(false)
+        expect(signal).toHaveBeenCalledWith(-4321, 'SIGTERM')
+        expect(terminateTree).not.toHaveBeenCalled()
+
+        child.emit('exit', 0, 'SIGTERM')
+        await vi.advanceTimersByTimeAsync(2_000)
+
+        expect(signal).toHaveBeenCalledWith(-4321, 'SIGKILL')
+      } finally {
+        vi.useRealTimers()
+        signal.mockRestore()
+      }
+    })
+
+    it('never derives a POSIX process-group id from a missing or non-positive child pid', async () => {
+      vi.useFakeTimers()
+      const signal = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      const kill = vi.fn(() => true)
+      const child = { pid: 0, kill } as unknown as ChildProcess
+
+      try {
+        await expect(terminateShellOnTimeout(child, 'darwin')).resolves.toBe(false)
+        expect(signal).not.toHaveBeenCalled()
+        expect(kill).toHaveBeenCalledWith('SIGTERM')
+
+        await vi.advanceTimersByTimeAsync(2_000)
+        expect(kill).toHaveBeenCalledWith('SIGKILL')
+      } finally {
+        vi.useRealTimers()
+        signal.mockRestore()
+      }
     })
   })
 

--- a/src/main/notebook/shell-process.ts
+++ b/src/main/notebook/shell-process.ts
@@ -7,7 +7,7 @@ import { resolveWindowsPowerShellExecutable } from '../windows-powershell'
 
 // Default bash_execute timeout, matching the data/repl kernels' own default.
 const DEFAULT_SHELL_TIMEOUT_MS = 120_000
-// Grace period between SIGTERM and SIGKILL when a timed-out shell command ignores the polite signal.
+// Grace between the POSIX process group's polite termination and an uncatchable group kill.
 const SHELL_KILL_GRACE_MS = 2_000
 
 // Result of one stateless bash_execute run. No status/traceback classification: the shell is
@@ -205,13 +205,40 @@ const resolveShellInvocation = (
       }
     : { executable: 'sh', args: ['-c', command] }
 
-// Waits for Windows tree termination so taskkill no longer holds workspace files open on return.
+// Signals only the independently spawned POSIX shell group. A validated positive child pid is also its
+// process-group id because POSIX spawn uses detached:true below. If group signaling is unavailable, fall
+// back to the direct handle without allowing timeout cleanup to reject.
+const signalPosixShellGroup = (child: ChildProcess, signal: NodeJS.Signals): void => {
+  const groupId = child.pid
+  if (groupId !== undefined && Number.isSafeInteger(groupId) && groupId > 0) {
+    try {
+      process.kill(-groupId, signal)
+      return
+    } catch {
+      // The group may already be gone or the platform may reject group signaling; try the leader.
+    }
+  }
+
+  try {
+    child.kill(signal)
+  } catch {
+    // It exited between the timeout and this best-effort signal.
+  }
+}
+
+// POSIX returns immediately after arming bounded group teardown. Windows continues to await taskkill so
+// callers can safely inspect or remove cwd after PowerShell and every descendant release their handles.
 const terminateShellOnTimeout = async (
   child: ChildProcess,
   platform: NodeJS.Platform = process.platform,
   terminateTree: (process: ChildProcess) => Promise<unknown> = terminateProcessTree
 ): Promise<boolean> => {
-  if (platform !== 'win32') return false
+  if (platform !== 'win32') {
+    signalPosixShellGroup(child, 'SIGTERM')
+    setTimeout(() => signalPosixShellGroup(child, 'SIGKILL'), SHELL_KILL_GRACE_MS)
+    return false
+  }
+
   try {
     await terminateTree(child)
   } catch {
@@ -237,14 +264,15 @@ const runShellCommand = (
     )
     const child = spawn(invocation.executable, invocation.args, {
       cwd: options.cwd,
-      env: buildShellEnv(options.handoffDir)
+      env: buildShellEnv(options.handoffDir),
+      // On POSIX this makes the shell the leader of a private process group/session. Keep its handle
+      // and stdio referenced (no unref), preserving normal completion while enabling safe -PGID kills.
+      detached: platform !== 'win32'
     })
 
     let stdout = ''
     let stderr = ''
     let settled = false
-    // child.killed means a signal was delivered, not that a SIGTERM-ignoring process exited.
-    let exited = false
     // Timeout owns settlement even if Windows taskkill emits exit before its promise resolves.
     let timedOut = false
 
@@ -273,14 +301,8 @@ const runShellCommand = (
           return
         }
 
-        // Escalate SIGTERM -> SIGKILL if the process ignores the polite signal; the promise itself
-        // settles immediately so a wedged process can never hang the caller past the timeout.
-        child.kill('SIGTERM')
-        const killTimer = setTimeout(() => {
-          if (!exited) child.kill('SIGKILL')
-        }, SHELL_KILL_GRACE_MS)
-        child.once('exit', () => clearTimeout(killTimer))
-
+        // POSIX group teardown continues in the background so a wedged command tree cannot delay the
+        // timeout result. Its SIGKILL timer intentionally survives the shell leader's exit.
         finish(timeoutResult)
       })
     }, timeoutMs)
@@ -297,7 +319,6 @@ const runShellCommand = (
       if (!timedOut) finish({ stdout, stderr: stderr || error.message, exitCode: null })
     })
     child.once('exit', (code) => {
-      exited = true
       if (!timedOut) finish({ stdout, stderr, exitCode: code })
     })
   })


### PR DESCRIPTION
## Problem

The portable Unit gate exposed two defects in the Notebook shell timeout path:

1. The former `pgrep -f` test wrapped its probe in `sh -c`, so the probe could match its own marker and did not prove which process survived.
2. Production timeout cleanup signaled only the direct POSIX shell. A real descendant that ignored SIGTERM could remain alive after the RPC had returned.

An intermediate shared `process-tree` implementation was rejected because signaling the root before the `ps` snapshot completed could reparent and hide descendants, and could report `reaped: true` without an honest tree snapshot. That approach would also have changed ACP, Settings, and Notebook Kernel semantics.

## Proposed change

Give each POSIX Notebook shell command a private process group and make the Notebook shell adapter own its timeout cleanup:

```mermaid
sequenceDiagram
  participant Caller
  participant Notebook as Notebook shell owner
  participant Group as Private POSIX process group

  Notebook->>Group: spawn detached, retain stdio and child handle
  Caller->>Notebook: executeShell timeout
  Notebook->>Group: SIGTERM to validated -PGID
  Notebook-->>Caller: timeout result immediately
  Note over Notebook,Group: leader exit does not cancel escalation
  Notebook->>Group: SIGKILL to -PGID after 2 seconds
```

- POSIX uses `detached: true` without `unref`, preserving normal stdout, stderr, and exit handling.
- Only a safe positive child PID is converted to a negative PGID.
- Missing, invalid, or failed group signaling falls back to the direct child handle without rejecting.
- Windows continues to await the existing `terminateProcessTree` / `taskkill` path.

## Scope and non-goals

- Change only the Notebook shell process owner and its tests.
- Keep the shared `process-tree` implementation byte-equivalent to `main`; ACP, Settings, and Notebook Kernel retain their existing teardown and `reaped` semantics.
- Preserve Electron, local/remote Web, CLI, Task, and IPC contracts.
- Do not change schema, data models, data relationships, public APIs, or user interaction.
- Do not introduce Issue #458 orchestration.
- Do not attempt to contain commands that deliberately escape into a new session with `setsid` or equivalent daemonization.

## Ownership and sequence

`NotebookShellProcessAdapter` owns the lifecycle of each shell command it spawns. On POSIX the spawned shell is the leader of its private session/process group, so timeout cleanup targets only that owned group. Windows remains owned by the existing taskkill-backed tree terminator.

Base: `cdac36edc03178b72e05ee45254e365a289f907a`
Head: `7d5c4b8b0b253932dbd86e1002fc90f3cfbc3db2`

Final diff: 3 Notebook files, +141/-43.
Production diff: `shell-process.ts` +36/-15; production raw 51/550.

## Acceptance criteria and validation

TDD RED evidence:

- The previous implementation made zero negative-PGID SIGTERM calls in the dedicated-group unit test.
- The exact descendant PID scenario repeatedly left its descendant alive under the rejected shared implementation.

Final evidence after the last material edit and rebase onto the stated base:

- Dedicated POSIX process-group behavior: GREEN, including immediate `-PGID` SIGTERM, leader-exit-independent SIGKILL, and invalid-PID direct fallback.
- Exact ready descendant PID integration scenario: 3/3 passed.
- Notebook runtime service: 181/181 passed, including the #754 agent-aware handoff coverage.
- Latest-main #764 Notebook MCP and connector skill-doc coverage: 63/63 passed; OPEN_SCIENCE_HANDOFF_DIR guidance and compact-result budgets remain byte-equivalent to the new base.
- Notebook shell plus shared process-tree: 24/24 passed.
- ACP focused consumers: 29/29 passed.
- Settings focused consumers: 82/82 passed.
- Notebook Kernel shutdown coverage: 2/2 passed.
- `npm run typecheck:node`: passed.
- ESLint on changed files: passed.
- Prettier check on changed files: passed.
- `git diff --check`: passed.
- Independent Standards code review: 0 code findings.
- Independent Spec/compatibility review: 0 findings.

Review-history closure:

- The readiness finding on `268fbd67` was closed by bounded PID-file readiness before timeout.
- The delayed direct-signal finding on `3ccffa95` led to a shared-helper attempt that final review rejected.
- The three P1 findings on `d01fbcede` were closed by removing all shared process-tree changes and adopting the approved Notebook-private process-group boundary.

Exact-head online CI passed: CI Integrity, PR Gate, Unit, Static, Coverage, CodeQL, macOS build/E2E, and Windows E2E are green. The exact-head AI review exception is documented below.

## Review focus

- Confirm `detached: true` is POSIX-only and no `unref` or stdio behavior changed.
- Confirm negative PGIDs derive only from the owned child's safe positive PID.
- Confirm SIGKILL remains armed after the shell leader exits.
- Confirm Windows still awaits the existing taskkill-backed terminator.
- Confirm no shared process-tree, ACP, Settings, Kernel, IPC, renderer, Web, or CLI production file changed.
- Confirm the PID-file test observes and cleans up the exact descendant instead of searching by command text.

## Uncovered risks

POSIX process-group identifiers can theoretically be reused during the two-second escalation window, although the group identifier remains occupied while any owned member survives and an absent group returns ESRCH. A command that deliberately starts a new session can escape this ownership boundary; containing hostile daemonization is out of scope.

The real descendant scenario passed three local runs on macOS. Online Linux Unit and platform lanes remain authoritative for portable behavior, and Windows E2E remains authoritative for the unchanged taskkill path.

### Exact-head AI finding disposition

The first exact-head AI review reported that a descendant can deliberately call `setsid` and leave the private process group. The scenario is real but is not introduced by this pull request: base `cdac36ed` terminated only the direct POSIX shell, so ordinary descendants and session-escaping daemons could both survive. This change strictly improves the owned boundary by terminating the complete private group.

The public `bash_execute` contract provides a fresh stateless shell, output, and an exit result; it is not an operating-system sandbox for hostile native code. Reliable containment of `setsid` plus double-fork daemonization would require a separate cross-platform supervisor design (for example Linux cgroups and a macOS native process owner), not a portable Node process-tree patch. That capability remains the explicit non-goal above and must be evaluated as a separate architecture change. A manual AI rerun on the unchanged exact head repeated the same finding and introduced no additional concern. After exact-head CI passed and independent Standards/Spec reviews returned 0 findings, the maintainer explicitly approved treating this setsid finding as a non-regression, declared-non-goal AI exception and authorized an administrator squash merge on 2026-08-05.