### PR TITLE
feat(settings): add settings keyboard shortcut

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -447,6 +447,22 @@ describe('App startup routing', () => {
     dialog.remove()
   })
 
+  it('ignores a closed dialog portal when opening Settings', async () => {
+    mocks.settings.isLoaded = true
+    await render()
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    dialog.dataset.state = 'closed'
+    document.body.appendChild(dialog)
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', metaKey: true, cancelable: true })
+    )
+
+    dialog.remove()
+    expect(mocks.settings.openSettings).toHaveBeenCalledOnce()
+  })
+
   it('closes the update dialog before underlying surfaces', async () => {
     mocks.settings.isLoaded = true
     mocks.settings.isSettingsOpen = true

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -35,7 +35,10 @@ const mocks = vi.hoisted(() => {
       init: vi.fn().mockResolvedValue(undefined),
       retry: vi.fn().mockResolvedValue(undefined)
     },
-    preview: { fileDialogItem: undefined as unknown | undefined },
+    preview: {
+      fileDialogItem: undefined as unknown | undefined,
+      expandedToolItemId: null as string | null
+    },
     loadProjects: vi.fn().mockResolvedValue(undefined),
     deepLinkNavigation: vi.fn(),
     lifecycleSync: vi.fn(() => ({
@@ -291,6 +294,7 @@ describe('App startup routing', () => {
     mocks.compute.pendingApprovals = []
     mocks.skillImport.pending = []
     mocks.preview.fileDialogItem = undefined
+    mocks.preview.expandedToolItemId = null
     mocks.deepLinkNavigation.mockClear()
     mocks.lifecycleSync.mockClear()
     mocks.syncWindowFindAppearance.mockClear()
@@ -450,6 +454,18 @@ describe('App startup routing', () => {
     })
 
     expect(mocks.globalSearch.props?.open).toBe(false)
+  })
+
+  it('does not open Settings under an expanded preview modal', async () => {
+    mocks.settings.isLoaded = true
+    mocks.preview.expandedToolItemId = 'project-files'
+    await render()
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', metaKey: true, cancelable: true })
+    )
+
+    expect(mocks.settings.openSettings).not.toHaveBeenCalled()
   })
 
   it('shows startup progress until settings have loaded', async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => {
       enqueueApproval: vi.fn(),
       load: vi.fn().mockResolvedValue(true),
       checkEnvironment: vi.fn().mockResolvedValue(undefined),
+      openSettings: vi.fn(),
       closeSettings: vi.fn()
     },
     skillImport: { enqueue: vi.fn(), dismiss: vi.fn(), pending: [] as unknown[] },
@@ -251,6 +252,7 @@ describe('App startup routing', () => {
     mocks.settings.isSettingsOpen = false
     mocks.settings.load.mockReset().mockResolvedValue(true)
     mocks.settings.checkEnvironment.mockReset().mockResolvedValue(undefined)
+    mocks.settings.openSettings.mockClear()
     mocks.settings.closeSettings.mockClear()
     mocks.skillImport.enqueue.mockClear()
     mocks.skillImport.dismiss.mockClear()
@@ -318,6 +320,27 @@ describe('App startup routing', () => {
     root = createRoot(container)
     await act(async () => root.render(<App />))
   }
+
+  it('opens Settings with Cmd/Ctrl+, after startup is interactive', async () => {
+    await render()
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', metaKey: true, cancelable: true })
+    )
+    expect(mocks.settings.openSettings).not.toHaveBeenCalled()
+
+    mocks.settings.isLoaded = true
+    await act(async () => root.render(<App />))
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', metaKey: true, cancelable: true })
+    )
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', ctrlKey: true, cancelable: true })
+    )
+
+    expect(mocks.settings.openSettings).toHaveBeenCalledTimes(2)
+  })
 
   it('toggles global search with Cmd/Ctrl+K after startup is interactive', async () => {
     mocks.settings.isLoaded = true

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -72,7 +72,8 @@ const mocks = vi.hoisted(() => {
     getInfo: vi.fn(),
     syncWindowFindAppearance: vi.fn(),
     syncUnreadTaskView: vi.fn(),
-    globalSearch: { props: undefined as { open: boolean } | undefined }
+    globalSearch: { props: undefined as { open: boolean } | undefined },
+    closeActiveModal: { handler: undefined as (() => boolean) | undefined }
   }
 })
 
@@ -83,7 +84,9 @@ vi.mock('@/lib/deep-link', () => ({
   useDeepLinkNavigation: mocks.deepLinkNavigation
 }))
 vi.mock('@/hooks/useCloseActivePaneShortcut', () => ({
-  useCloseActivePaneShortcut: vi.fn()
+  useCloseActivePaneShortcut: (handler?: () => boolean) => {
+    mocks.closeActiveModal.handler = handler
+  }
 }))
 vi.mock('@/hooks/useLifecycleSync', () => ({
   useLifecycleSync: mocks.lifecycleSync
@@ -309,6 +312,7 @@ describe('App startup routing', () => {
     mocks.notifications.takePendingOpenSession.mockReset().mockResolvedValue(null)
     mocks.notificationNudgeBox.current = undefined
     mocks.globalSearch.props = undefined
+    mocks.closeActiveModal.handler = undefined
   })
 
   afterEach(async () => {
@@ -378,6 +382,29 @@ describe('App startup routing', () => {
       window.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, cancelable: true })
       )
+    })
+    expect(mocks.globalSearch.props?.open).toBe(false)
+  })
+
+  it('does not open Settings over global search', async () => {
+    mocks.settings.isLoaded = true
+    await render()
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, cancelable: true })
+      )
+    })
+    expect(mocks.globalSearch.props?.open).toBe(true)
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', metaKey: true, cancelable: true })
+    )
+
+    expect(mocks.settings.openSettings).not.toHaveBeenCalled()
+
+    act(() => {
+      expect(mocks.closeActiveModal.handler?.()).toBe(true)
     })
     expect(mocks.globalSearch.props?.open).toBe(false)
   })

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -330,6 +330,26 @@ describe('App startup routing', () => {
     expect(mocks.settings.openSettings).not.toHaveBeenCalled()
 
     mocks.settings.isLoaded = true
+    mocks.sessionPersistence.isHydrated = false
+    mocks.sessionPersistence.isLoading = true
+    mocks.sessionPersistence.isReady = false
+    await act(async () => root.render(<App />))
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', metaKey: true, cancelable: true })
+    )
+    expect(mocks.settings.openSettings).not.toHaveBeenCalled()
+
+    mocks.sessionPersistence.isLoading = false
+    mocks.sessionPersistence.loadError = 'saved conversations unavailable'
+    await act(async () => root.render(<App />))
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', ctrlKey: true, cancelable: true })
+    )
+    expect(mocks.settings.openSettings).not.toHaveBeenCalled()
+
+    mocks.sessionPersistence.isHydrated = true
     await act(async () => root.render(<App />))
 
     window.dispatchEvent(

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -68,6 +68,11 @@ const mocks = vi.hoisted(() => {
       retryLoad: vi.fn(),
       retryWrites: vi.fn()
     },
+    update: {
+      isDialogOpen: false,
+      status: { state: 'idle' },
+      closeDialog: vi.fn()
+    },
     startupView: 'app' as 'app' | 'onboarding',
     getInfo: vi.fn(),
     syncWindowFindAppearance: vi.fn(),
@@ -144,11 +149,18 @@ vi.mock('@/stores/skill-import-store', () => ({
   useSkillImportStore: <T,>(selector: (state: typeof mocks.skillImport) => T): T =>
     selector(mocks.skillImport)
 }))
-vi.mock('@/stores/update-store', () => ({
-  useUpdateStore: <T,>(
-    selector: (state: { init: typeof mocks.initUpdates; isDialogOpen: boolean }) => T
-  ): T => selector({ init: mocks.initUpdates, isDialogOpen: false })
-}))
+vi.mock('@/stores/update-store', () => {
+  const getState = (): typeof mocks.update & { init: typeof mocks.initUpdates } => ({
+    init: mocks.initUpdates,
+    ...mocks.update
+  })
+  return {
+    useUpdateStore: Object.assign(
+      <T,>(selector: (state: ReturnType<typeof getState>) => T): T => selector(getState()),
+      { getState }
+    )
+  }
+})
 vi.mock('@/pages/onboarding/startup-gate', () => ({
   resolveStartupView: vi.fn(() => mocks.startupView)
 }))
@@ -269,6 +281,9 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.loadError = undefined
     mocks.sessionPersistence.loadWarning = undefined
     mocks.sessionPersistence.writeError = undefined
+    mocks.update.isDialogOpen = false
+    mocks.update.status.state = 'idle'
+    mocks.update.closeDialog.mockClear()
     mocks.sessionPersistence.dismissLoadWarning.mockClear()
     mocks.sessionPersistence.retryLoad.mockClear()
     mocks.sessionPersistence.retryWrites.mockClear()
@@ -407,6 +422,20 @@ describe('App startup routing', () => {
       expect(mocks.closeActiveModal.handler?.()).toBe(true)
     })
     expect(mocks.globalSearch.props?.open).toBe(false)
+  })
+
+  it('closes the update dialog before underlying surfaces', async () => {
+    mocks.settings.isLoaded = true
+    mocks.settings.isSettingsOpen = true
+    mocks.update.isDialogOpen = true
+    await render()
+
+    act(() => {
+      expect(mocks.closeActiveModal.handler?.()).toBe(true)
+    })
+
+    expect(mocks.update.closeDialog).toHaveBeenCalledOnce()
+    expect(mocks.settings.closeSettings).not.toHaveBeenCalled()
   })
 
   it('does not open global search while a file preview modal is open', async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -37,7 +37,9 @@ const mocks = vi.hoisted(() => {
     },
     preview: {
       fileDialogItem: undefined as unknown | undefined,
-      expandedToolItemId: null as string | null
+      expandedToolItemId: null as string | null,
+      activeItemId: undefined as string | undefined,
+      panelState: 'collapsed' as 'open' | 'collapsed'
     },
     loadProjects: vi.fn().mockResolvedValue(undefined),
     deepLinkNavigation: vi.fn(),
@@ -295,6 +297,8 @@ describe('App startup routing', () => {
     mocks.skillImport.pending = []
     mocks.preview.fileDialogItem = undefined
     mocks.preview.expandedToolItemId = null
+    mocks.preview.activeItemId = undefined
+    mocks.preview.panelState = 'collapsed'
     mocks.deepLinkNavigation.mockClear()
     mocks.lifecycleSync.mockClear()
     mocks.syncWindowFindAppearance.mockClear()
@@ -472,10 +476,12 @@ describe('App startup routing', () => {
     expect(mocks.globalSearch.props?.open).toBe(false)
   })
 
-  it('does not open Settings under an expanded preview modal', async () => {
+  it('does not open Settings under the active expanded preview modal', async () => {
     mocks.settings.isLoaded = true
     mocks.navigation.view = 'workspace'
     mocks.preview.expandedToolItemId = 'project-files'
+    mocks.preview.activeItemId = 'project-files'
+    mocks.preview.panelState = 'open'
     await render()
 
     window.dispatchEvent(
@@ -483,6 +489,21 @@ describe('App startup routing', () => {
     )
 
     expect(mocks.settings.openSettings).not.toHaveBeenCalled()
+  })
+
+  it('ignores a stale expansion after another preview becomes active', async () => {
+    mocks.settings.isLoaded = true
+    mocks.navigation.view = 'workspace'
+    mocks.preview.expandedToolItemId = 'project-files'
+    mocks.preview.activeItemId = 'paper'
+    mocks.preview.panelState = 'open'
+    await render()
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', metaKey: true, cancelable: true })
+    )
+
+    expect(mocks.settings.openSettings).toHaveBeenCalledOnce()
   })
 
   it('ignores stale workspace preview modals when opening Settings from Home', async () => {

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -428,6 +428,21 @@ describe('App startup routing', () => {
     expect(mocks.globalSearch.props?.open).toBe(false)
   })
 
+  it('does not open Settings over an active dialog', async () => {
+    mocks.settings.isLoaded = true
+    await render()
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    document.body.appendChild(dialog)
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', metaKey: true, cancelable: true })
+    )
+
+    expect(mocks.settings.openSettings).not.toHaveBeenCalled()
+    dialog.remove()
+  })
+
   it('closes the update dialog before underlying surfaces', async () => {
     mocks.settings.isLoaded = true
     mocks.settings.isSettingsOpen = true

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -491,6 +491,21 @@ describe('App startup routing', () => {
     expect(mocks.settings.openSettings).not.toHaveBeenCalled()
   })
 
+  it('does not open Settings under a Streamdown fullscreen viewer', async () => {
+    mocks.settings.isLoaded = true
+    await render()
+    const fullscreen = document.createElement('div')
+    fullscreen.dataset.streamdown = 'table-fullscreen'
+    document.body.appendChild(fullscreen)
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', metaKey: true, cancelable: true })
+    )
+
+    fullscreen.remove()
+    expect(mocks.settings.openSettings).not.toHaveBeenCalled()
+  })
+
   it('ignores a stale expansion after another preview becomes active', async () => {
     mocks.settings.isLoaded = true
     mocks.navigation.view = 'workspace'

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -444,6 +444,7 @@ describe('App startup routing', () => {
 
   it('does not open global search while a file preview modal is open', async () => {
     mocks.settings.isLoaded = true
+    mocks.navigation.view = 'workspace'
     mocks.preview.fileDialogItem = { id: 'previewed-file' }
     await render()
 
@@ -458,6 +459,7 @@ describe('App startup routing', () => {
 
   it('does not open Settings under an expanded preview modal', async () => {
     mocks.settings.isLoaded = true
+    mocks.navigation.view = 'workspace'
     mocks.preview.expandedToolItemId = 'project-files'
     await render()
 
@@ -466,6 +468,19 @@ describe('App startup routing', () => {
     )
 
     expect(mocks.settings.openSettings).not.toHaveBeenCalled()
+  })
+
+  it('ignores stale workspace preview modals when opening Settings from Home', async () => {
+    mocks.settings.isLoaded = true
+    mocks.preview.fileDialogItem = { id: 'previewed-file' }
+    mocks.preview.expandedToolItemId = 'project-files'
+    await render()
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ',', metaKey: true, cancelable: true })
+    )
+
+    expect(mocks.settings.openSettings).toHaveBeenCalledOnce()
   })
 
   it('shows startup progress until settings have loaded', async () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -12,6 +12,7 @@ import { PermissionUndoSnackbar } from '@/components/PermissionUndoSnackbar'
 import { SessionPersistenceAlert } from '@/components/SessionPersistenceAlert'
 import { UpdateDialog } from '@/components/UpdateDialog'
 import { GlobalSearchDialog } from '@/components/global-search/GlobalSearchDialog'
+import { STREAMDOWN_FULLSCREEN_SELECTOR } from '@/components/streamdown/dom-selectors'
 import { Button } from '@/components/ui/button'
 import { HomePage } from '@/pages/home/HomePage'
 import { OnboardingWizard } from '@/pages/onboarding/OnboardingWizard'
@@ -162,7 +163,9 @@ const App = (): React.JSX.Element | null => {
         event.isComposing ||
         event.key !== ',' ||
         !(event.metaKey || event.ctrlKey) ||
-        document.querySelector('[role="dialog"], [role="alertdialog"]') !== null ||
+        document.querySelector(
+          `[role="dialog"], [role="alertdialog"], ${STREAMDOWN_FULLSCREEN_SELECTOR}`
+        ) !== null ||
         startupView !== 'app' ||
         !isSessionPersistenceHydrated ||
         isSettingsOpen ||

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -19,7 +19,7 @@ import { resolveStartupView } from '@/pages/onboarding/startup-gate'
 import { ComputeApprovalDialog } from '@/pages/settings/ComputeApprovalDialog'
 import { ConnectorApprovalDialog } from '@/pages/settings/ConnectorApprovalDialog'
 import { SkillImportApprovalDialog } from '@/pages/settings/SkillImportApprovalDialog'
-import { SettingsPage } from '@/pages/settings/SettingsPage'
+import { SettingsPage, type SettingsPageHandle } from '@/pages/settings/SettingsPage'
 import { EnvStatusBanner } from '@/pages/workspace/EnvStatusBanner'
 import { WorkspacePage } from '@/pages/workspace/WorkspacePage'
 import { useCloseActivePaneShortcut } from '@/hooks/useCloseActivePaneShortcut'
@@ -57,8 +57,7 @@ const App = (): React.JSX.Element | null => {
     isReady: isSessionPersistenceReady
   })
   const view = useNavigationStore((state) => state.view)
-  // Cmd+W / Ctrl+W closes the open preview panel before it closes the window.
-  useCloseActivePaneShortcut()
+  const settingsPageRef = useRef<SettingsPageHandle>(null)
   useWindowFindAppearanceSync()
   const loadProjects = useProjectStore((state) => state.loadProjects)
   const isSettingsLoaded = useSettingsStore((state) => state.isLoaded)
@@ -112,6 +111,15 @@ const App = (): React.JSX.Element | null => {
   })
   const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false)
   const [isGlobalSearchOpen, setIsGlobalSearchOpen] = useState(false)
+  // Cmd+W / Ctrl+W closes transient modals before falling through to preview panes/window.
+  const closeActiveModal = useCallback((): boolean => {
+    if (isGlobalSearchOpen) {
+      setIsGlobalSearchOpen(false)
+      return true
+    }
+    return settingsPageRef.current?.closeActivePane() ?? false
+  }, [isGlobalSearchOpen])
+  useCloseActivePaneShortcut(closeActiveModal)
   const startupView = isSettingsLoaded
     ? resolveStartupView({ onboardingDone: onboardingCompletedAt !== undefined })
     : undefined
@@ -146,7 +154,17 @@ const App = (): React.JSX.Element | null => {
         event.key !== ',' ||
         !(event.metaKey || event.ctrlKey) ||
         startupView !== 'app' ||
-        !isSessionPersistenceHydrated
+        !isSessionPersistenceHydrated ||
+        isSettingsOpen ||
+        isGlobalSearchOpen ||
+        hasConnectorApproval ||
+        hasComputeApproval ||
+        hasSkillImportApproval ||
+        isUpdateDialogOpen ||
+        isFilePreviewOpen ||
+        isCloseConfirmOpen ||
+        missingDataRoot !== undefined ||
+        legacyMove !== undefined
       ) {
         return
       }
@@ -156,7 +174,21 @@ const App = (): React.JSX.Element | null => {
 
     window.addEventListener('keydown', openSettingsFromShortcut)
     return () => window.removeEventListener('keydown', openSettingsFromShortcut)
-  }, [isSessionPersistenceHydrated, openSettings, startupView])
+  }, [
+    hasComputeApproval,
+    hasConnectorApproval,
+    hasSkillImportApproval,
+    isCloseConfirmOpen,
+    isFilePreviewOpen,
+    isGlobalSearchOpen,
+    isSessionPersistenceHydrated,
+    isSettingsOpen,
+    isUpdateDialogOpen,
+    legacyMove,
+    missingDataRoot,
+    openSettings,
+    startupView
+  ])
 
   useEffect(() => {
     const toggleGlobalSearch = (event: KeyboardEvent): void => {
@@ -498,6 +530,7 @@ const App = (): React.JSX.Element | null => {
         />
       )}
       <SettingsPage
+        ref={settingsPageRef}
         open={isSettingsOpen}
         onClose={closeSettings}
         onOpenSession={openPermissionSession}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -164,7 +164,7 @@ const App = (): React.JSX.Element | null => {
         event.key !== ',' ||
         !(event.metaKey || event.ctrlKey) ||
         document.querySelector(
-          `[role="dialog"], [role="alertdialog"], ${STREAMDOWN_FULLSCREEN_SELECTOR}`
+          `[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"]), ${STREAMDOWN_FULLSCREEN_SELECTOR}`
         ) !== null ||
         startupView !== 'app' ||
         !isSessionPersistenceHydrated ||

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -68,6 +68,7 @@ const App = (): React.JSX.Element | null => {
   const loadSettings = useSettingsStore((state) => state.load)
   const checkEnvironment = useSettingsStore((state) => state.checkEnvironment)
   const isSettingsOpen = useSettingsStore((state) => state.isSettingsOpen)
+  const openSettings = useSettingsStore((state) => state.openSettings)
   const hasConnectorApproval = useSettingsStore((state) => state.pendingApprovals.length > 0)
   const closeSettings = useSettingsStore((state) => state.closeSettings)
   const enqueueApproval = useSettingsStore((state) => state.enqueueApproval)
@@ -136,6 +137,25 @@ const App = (): React.JSX.Element | null => {
     legacyMove === undefined
 
   useUnreadTaskViewSync({ isSessionContentVisible })
+
+  useEffect(() => {
+    const openSettingsFromShortcut = (event: KeyboardEvent): void => {
+      if (
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.key !== ',' ||
+        !(event.metaKey || event.ctrlKey) ||
+        startupView !== 'app'
+      ) {
+        return
+      }
+      event.preventDefault()
+      openSettings()
+    }
+
+    window.addEventListener('keydown', openSettingsFromShortcut)
+    return () => window.removeEventListener('keydown', openSettingsFromShortcut)
+  }, [openSettings, startupView])
 
   useEffect(() => {
     const toggleGlobalSearch = (event: KeyboardEvent): void => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -83,6 +83,7 @@ const App = (): React.JSX.Element | null => {
   const isExpandedPreviewOpen = usePreviewWorkbenchStore(
     (state) => state.expandedToolItemId !== null
   )
+  const isPreviewModalOpen = view === 'workspace' && (isFilePreviewOpen || isExpandedPreviewOpen)
   const initEnv = useNotebookEnvStore((state) => state.init)
   const envUi = useNotebookEnvStore((state) => state.ui)
   const listenForPermissionChanges = usePermissionGrantsStore((state) => state.listen)
@@ -169,8 +170,7 @@ const App = (): React.JSX.Element | null => {
         hasComputeApproval ||
         hasSkillImportApproval ||
         isUpdateDialogOpen ||
-        isFilePreviewOpen ||
-        isExpandedPreviewOpen ||
+        isPreviewModalOpen ||
         isCloseConfirmOpen ||
         missingDataRoot !== undefined ||
         legacyMove !== undefined
@@ -188,9 +188,8 @@ const App = (): React.JSX.Element | null => {
     hasConnectorApproval,
     hasSkillImportApproval,
     isCloseConfirmOpen,
-    isExpandedPreviewOpen,
-    isFilePreviewOpen,
     isGlobalSearchOpen,
+    isPreviewModalOpen,
     isSessionPersistenceHydrated,
     isSettingsOpen,
     isUpdateDialogOpen,
@@ -215,7 +214,7 @@ const App = (): React.JSX.Element | null => {
         hasComputeApproval ||
         hasSkillImportApproval ||
         isUpdateDialogOpen ||
-        isFilePreviewOpen ||
+        isPreviewModalOpen ||
         isCloseConfirmOpen ||
         missingDataRoot !== undefined ||
         legacyMove !== undefined
@@ -234,7 +233,7 @@ const App = (): React.JSX.Element | null => {
     hasSkillImportApproval,
     isCloseConfirmOpen,
     isSessionPersistenceHydrated,
-    isFilePreviewOpen,
+    isPreviewModalOpen,
     isSettingsLoaded,
     isSettingsOpen,
     isUpdateDialogOpen,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -162,6 +162,7 @@ const App = (): React.JSX.Element | null => {
         event.isComposing ||
         event.key !== ',' ||
         !(event.metaKey || event.ctrlKey) ||
+        document.querySelector('[role="dialog"], [role="alertdialog"]') !== null ||
         startupView !== 'app' ||
         !isSessionPersistenceHydrated ||
         isSettingsOpen ||

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -113,6 +113,11 @@ const App = (): React.JSX.Element | null => {
   const [isGlobalSearchOpen, setIsGlobalSearchOpen] = useState(false)
   // Cmd+W / Ctrl+W closes transient modals before falling through to preview panes/window.
   const closeActiveModal = useCallback((): boolean => {
+    const update = useUpdateStore.getState()
+    if (update.isDialogOpen) {
+      if (update.status.state !== 'applying') update.closeDialog()
+      return true
+    }
     if (isGlobalSearchOpen) {
       setIsGlobalSearchOpen(false)
       return true

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -145,7 +145,8 @@ const App = (): React.JSX.Element | null => {
         event.isComposing ||
         event.key !== ',' ||
         !(event.metaKey || event.ctrlKey) ||
-        startupView !== 'app'
+        startupView !== 'app' ||
+        !isSessionPersistenceHydrated
       ) {
         return
       }
@@ -155,7 +156,7 @@ const App = (): React.JSX.Element | null => {
 
     window.addEventListener('keydown', openSettingsFromShortcut)
     return () => window.removeEventListener('keydown', openSettingsFromShortcut)
-  }, [openSettings, startupView])
+  }, [isSessionPersistenceHydrated, openSettings, startupView])
 
   useEffect(() => {
     const toggleGlobalSearch = (event: KeyboardEvent): void => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -81,7 +81,7 @@ const App = (): React.JSX.Element | null => {
   const isUpdateDialogOpen = useUpdateStore((state) => state.isDialogOpen)
   const isFilePreviewOpen = usePreviewWorkbenchStore((state) => state.fileDialogItem !== undefined)
   const isExpandedPreviewOpen = usePreviewWorkbenchStore(
-    (state) => state.expandedToolItemId !== null
+    (state) => state.panelState === 'open' && state.expandedToolItemId === state.activeItemId
   )
   const isPreviewModalOpen = view === 'workspace' && (isFilePreviewOpen || isExpandedPreviewOpen)
   const initEnv = useNotebookEnvStore((state) => state.init)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -80,6 +80,9 @@ const App = (): React.JSX.Element | null => {
   const initUpdates = useUpdateStore((state) => state.init)
   const isUpdateDialogOpen = useUpdateStore((state) => state.isDialogOpen)
   const isFilePreviewOpen = usePreviewWorkbenchStore((state) => state.fileDialogItem !== undefined)
+  const isExpandedPreviewOpen = usePreviewWorkbenchStore(
+    (state) => state.expandedToolItemId !== null
+  )
   const initEnv = useNotebookEnvStore((state) => state.init)
   const envUi = useNotebookEnvStore((state) => state.ui)
   const listenForPermissionChanges = usePermissionGrantsStore((state) => state.listen)
@@ -167,6 +170,7 @@ const App = (): React.JSX.Element | null => {
         hasSkillImportApproval ||
         isUpdateDialogOpen ||
         isFilePreviewOpen ||
+        isExpandedPreviewOpen ||
         isCloseConfirmOpen ||
         missingDataRoot !== undefined ||
         legacyMove !== undefined
@@ -184,6 +188,7 @@ const App = (): React.JSX.Element | null => {
     hasConnectorApproval,
     hasSkillImportApproval,
     isCloseConfirmOpen,
+    isExpandedPreviewOpen,
     isFilePreviewOpen,
     isGlobalSearchOpen,
     isSessionPersistenceHydrated,

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
@@ -41,7 +41,7 @@ const renderHook = (hook: () => void): { unmount: () => void } => {
 }
 
 // Minimal previewable file tab; only identity fields matter for the close ladder.
-const fileTab = (id: string): PreviewItem => ({
+const fileTab = (id: string): Extract<PreviewItem, { type: 'file' }> => ({
   id,
   sessionId: 'session',
   type: 'file',
@@ -150,6 +150,39 @@ describe('useCloseActivePaneShortcut', () => {
     act(() => closeActivePane?.())
 
     expect(usePreviewWorkbenchStore.getState().panelState).toBe('collapsed')
+    expect(close).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('lets an active modal handle the shortcut before preview panes or the window', () => {
+    useNavigationStore.setState({ view: 'workspace' })
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(fileTab('kept-open'))
+    const closeActiveModal = vi.fn(() => true)
+
+    const { unmount } = renderHook(() => useCloseActivePaneShortcut(closeActiveModal))
+    act(() => closeActivePane?.())
+
+    expect(closeActiveModal).toHaveBeenCalledOnce()
+    expect(usePreviewWorkbenchStore.getState().items).toHaveLength(1)
+    expect(close).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('closes transient preview modals before preview tabs or the window', () => {
+    useNavigationStore.setState({ view: 'workspace' })
+    const preview = usePreviewWorkbenchStore.getState()
+    preview.upsertAndActivateItem(fileTab('kept-open'))
+    preview.setToolItemExpanded('expanded-tool')
+    preview.openFileDialog(fileTab('dialog'))
+
+    const { unmount } = renderHook(() => useCloseActivePaneShortcut())
+    act(() => closeActivePane?.())
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBe('expanded-tool')
+
+    act(() => closeActivePane?.())
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
+    expect(usePreviewWorkbenchStore.getState().items).toHaveLength(1)
     expect(close).not.toHaveBeenCalled()
     unmount()
   })

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
@@ -187,6 +187,21 @@ describe('useCloseActivePaneShortcut', () => {
     unmount()
   })
 
+  it('closes the window without consuming stale preview modals on Home', () => {
+    useNavigationStore.setState({ view: 'home' })
+    const preview = usePreviewWorkbenchStore.getState()
+    preview.setToolItemExpanded('expanded-tool')
+    preview.openFileDialog(fileTab('dialog'))
+
+    const { unmount } = renderHook(() => useCloseActivePaneShortcut())
+    act(() => closeActivePane?.())
+
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem?.id).toBe('dialog')
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBe('expanded-tool')
+    expect(close).toHaveBeenCalledOnce()
+    unmount()
+  })
+
   it('closes the window when no panel is open', () => {
     useNavigationStore.setState({ view: 'workspace' })
     usePreviewWorkbenchStore.getState().collapsePanel()

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
@@ -51,6 +51,14 @@ const fileTab = (id: string): Extract<PreviewItem, { type: 'file' }> => ({
   title: id
 })
 
+const toolTab = (id: string): Extract<PreviewItem, { type: 'tool' }> => ({
+  id,
+  sessionId: 'session',
+  type: 'tool',
+  toolKind: 'files',
+  title: id
+})
+
 describe('decideCloseActivePaneAction', () => {
   it('closes the active tab when the pane is open in the workspace with a tab', () => {
     expect(
@@ -172,6 +180,7 @@ describe('useCloseActivePaneShortcut', () => {
     useNavigationStore.setState({ view: 'workspace' })
     const preview = usePreviewWorkbenchStore.getState()
     preview.upsertAndActivateItem(fileTab('kept-open'))
+    preview.upsertAndActivateItem(toolTab('expanded-tool'))
     preview.setToolItemExpanded('expanded-tool')
     preview.openFileDialog(fileTab('dialog'))
 
@@ -182,7 +191,25 @@ describe('useCloseActivePaneShortcut', () => {
 
     act(() => closeActivePane?.())
     expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
-    expect(usePreviewWorkbenchStore.getState().items).toHaveLength(1)
+    expect(usePreviewWorkbenchStore.getState().items).toHaveLength(2)
+    expect(close).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('ignores a stale expansion after another preview becomes active', () => {
+    useNavigationStore.setState({ view: 'workspace' })
+    const preview = usePreviewWorkbenchStore.getState()
+    preview.upsertAndActivateItem(toolTab('expanded-tool'))
+    preview.setToolItemExpanded('expanded-tool')
+    preview.upsertAndActivateItem(fileTab('active-file'))
+
+    const { unmount } = renderHook(() => useCloseActivePaneShortcut())
+    act(() => closeActivePane?.())
+
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBe('expanded-tool')
+    expect(usePreviewWorkbenchStore.getState().items.map((item) => item.id)).toEqual([
+      'expanded-tool'
+    ])
     expect(close).not.toHaveBeenCalled()
     unmount()
   })

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
@@ -35,18 +35,21 @@ export const useCloseActivePaneShortcut = (closeActiveModal?: () => boolean): vo
         if (closeActiveModalRef.current?.()) return
 
         const preview = usePreviewWorkbenchStore.getState()
-        if (preview.fileDialogItem) {
-          preview.closeFileDialog()
-          return
-        }
-        if (preview.expandedToolItemId) {
-          preview.setToolItemExpanded(null)
-          return
+        const view = useNavigationStore.getState().view
+        if (view === 'workspace') {
+          if (preview.fileDialogItem) {
+            preview.closeFileDialog()
+            return
+          }
+          if (preview.expandedToolItemId) {
+            preview.setToolItemExpanded(null)
+            return
+          }
         }
         const activeItem = preview.items.find((item) => item.id === preview.activeItemId)
 
         const action = decideCloseActivePaneAction({
-          view: useNavigationStore.getState().view,
+          view,
           panelState: preview.panelState,
           hasActiveTab: activeItem !== undefined
         })

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
@@ -36,17 +36,17 @@ export const useCloseActivePaneShortcut = (closeActiveModal?: () => boolean): vo
 
         const preview = usePreviewWorkbenchStore.getState()
         const view = useNavigationStore.getState().view
+        const activeItem = preview.items.find((item) => item.id === preview.activeItemId)
         if (view === 'workspace') {
           if (preview.fileDialogItem) {
             preview.closeFileDialog()
             return
           }
-          if (preview.expandedToolItemId) {
+          if (preview.panelState === 'open' && preview.expandedToolItemId === activeItem?.id) {
             preview.setToolItemExpanded(null)
             return
           }
         }
-        const activeItem = preview.items.find((item) => item.id === preview.activeItemId)
 
         const action = decideCloseActivePaneAction({
           view,

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { useNavigationStore, type NavigationView } from '@/stores/navigation-store'
 import { usePreviewWorkbenchStore, type PreviewPanelState } from '@/stores/preview-workbench-store'
@@ -23,11 +23,26 @@ export const decideCloseActivePaneAction = (input: {
 
 // Wires the main-process close chord to the tab-vs-pane-vs-window decision. Store state is read
 // imperatively so the subscription is installed once yet always sees the current view and panel state.
-export const useCloseActivePaneShortcut = (): void => {
+export const useCloseActivePaneShortcut = (closeActiveModal?: () => boolean): void => {
+  const closeActiveModalRef = useRef(closeActiveModal)
+  useEffect(() => {
+    closeActiveModalRef.current = closeActiveModal
+  }, [closeActiveModal])
+
   useEffect(
     () =>
       window.api.window.onCloseActivePane(() => {
+        if (closeActiveModalRef.current?.()) return
+
         const preview = usePreviewWorkbenchStore.getState()
+        if (preview.fileDialogItem) {
+          preview.closeFileDialog()
+          return
+        }
+        if (preview.expandedToolItemId) {
+          preview.setToolItemExpanded(null)
+          return
+        }
         const activeItem = preview.items.find((item) => item.id === preview.activeItemId)
 
         const action = decideCloseActivePaneAction({

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -725,6 +725,13 @@ describe('SettingsPage layout', () => {
       )
     ).toBe(true)
 
+    await act(async () => navButton('Model')?.click())
+    const addProvider = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button')
+    ).find((button) => button.textContent?.trim() === 'Add provider')
+    act(() => addProvider?.click())
+    expect(document.body.querySelector('[aria-label="Provider type"]')).not.toBeNull()
+
     await act(async () => {
       document.body
         .querySelector<HTMLButtonElement>('[aria-label="Open settings navigation"]')
@@ -734,7 +741,8 @@ describe('SettingsPage layout', () => {
       expect(settingsRef.current?.closeActivePane()).toBe(true)
     })
     expect(nav?.getAttribute('aria-hidden')).toBe('true')
-    expect(onClose).toHaveBeenCalledOnce()
+    expect(document.body.querySelector('[aria-label="Provider type"]')).not.toBeNull()
+    expect(onClose).not.toHaveBeenCalled()
   })
 
   it('opens Add provider as a history-driven sub-page and returns via the back arrow', () => {

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -824,9 +824,14 @@ describe('SettingsPage layout', () => {
     expect(document.body.querySelector('[aria-label="Provider type"]')).not.toBeNull()
     expect(onClose).not.toHaveBeenCalled()
 
+    const inlineDialog = document.createElement('div')
+    inlineDialog.setAttribute('role', 'dialog')
+    inlineDialog.setAttribute('aria-modal', 'true')
+    document.body.appendChild(inlineDialog)
     act(() => {
       expect(settingsRef.current?.closeActivePane()).toBe(true)
     })
+    inlineDialog.remove()
     expect(document.body.querySelector('section[aria-label="Providers"]')).not.toBeNull()
     expect(document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.disabled).toBe(
       true

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
-import { act } from 'react'
+import { act, createRef } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { SettingsPage } from './SettingsPage'
+import { SettingsPage, type SettingsPageHandle } from './SettingsPage'
 import { clickRadixMenuItem, openRadixMenu } from './test-utils'
 import type { SpecialistProfileView } from '../../../../shared/specialist'
 import { useSpecialistStore } from '@/stores/specialist-store'
@@ -764,6 +764,31 @@ describe('SettingsPage layout', () => {
     const rootCrumb = document.body.querySelector<HTMLButtonElement>('[aria-label="Back to model"]')
     act(() => rootCrumb?.click())
     expect(document.body.querySelector('section[aria-label="Providers"]')).not.toBeNull()
+  })
+
+  it('backs out of a breadcrumb before closing Settings with the close-pane shortcut', () => {
+    const onClose = vi.fn()
+    const settingsRef = createRef<SettingsPageHandle>()
+    act(() => {
+      root.render(<SettingsPage ref={settingsRef} open onClose={onClose} />)
+    })
+
+    const addProvider = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button')
+    ).find((button) => button.textContent?.trim() === 'Add provider')
+    act(() => addProvider?.click())
+    expect(document.body.querySelector('[aria-label="Provider type"]')).not.toBeNull()
+
+    act(() => {
+      expect(settingsRef.current?.closeActivePane()).toBe(true)
+    })
+    expect(document.body.querySelector('section[aria-label="Providers"]')).not.toBeNull()
+    expect(onClose).not.toHaveBeenCalled()
+
+    act(() => {
+      expect(settingsRef.current?.closeActivePane()).toBe(true)
+    })
+    expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('defaults the Add provider type to the framework vendor (Codex → OpenAI, OpenCode → DeepSeek)', async () => {

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -828,6 +828,9 @@ describe('SettingsPage layout', () => {
       expect(settingsRef.current?.closeActivePane()).toBe(true)
     })
     expect(document.body.querySelector('section[aria-label="Providers"]')).not.toBeNull()
+    expect(document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.disabled).toBe(
+      true
+    )
     expect(onClose).not.toHaveBeenCalled()
 
     act(() => {
@@ -1684,8 +1687,9 @@ describe('SettingsPage layout', () => {
     // A skill mention sets the pending id before the dialog opens.
     useSettingsStore.setState({ pendingSkillId: 'alpha' })
 
+    const settingsRef = createRef<SettingsPageHandle>()
     await act(async () => {
-      root.render(<SettingsPage open onClose={vi.fn()} />)
+      root.render(<SettingsPage ref={settingsRef} open onClose={vi.fn()} />)
     })
     // Flush the seeding effect, the skills-list load, and the skill-detail fetch.
     await act(async () => {
@@ -1701,6 +1705,14 @@ describe('SettingsPage layout', () => {
     expect(document.body.querySelector('section[aria-label="Providers"]')).toBeNull()
     // The pending id is consumed so a later normal open won't jump back to it.
     expect(useSettingsStore.getState().pendingSkillId).toBeUndefined()
+
+    act(() => {
+      expect(settingsRef.current?.closeActivePane()).toBe(true)
+    })
+    expect(document.body.querySelector('[aria-label="Back to skills"]')).toBeNull()
+    expect(document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.disabled).toBe(
+      true
+    )
   })
 
   it('opens directly on a requested settings panel and consumes the target', async () => {

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -4,11 +4,12 @@ import { createRoot, type Root } from 'react-dom/client'
 import { Dialog } from 'radix-ui'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { SettingsPage, type SettingsPageHandle } from './SettingsPage'
-import { clickRadixMenuItem, openRadixMenu } from './test-utils'
+import { LinkSafetyModal } from '@/components/streamdown/LinkSafetyModal'
 import type { SpecialistProfileView } from '../../../../shared/specialist'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { SettingsPage, type SettingsPageHandle } from './SettingsPage'
+import { clickRadixMenuItem, openRadixMenu } from './test-utils'
 
 if (!Element.prototype.hasPointerCapture) {
   Element.prototype.hasPointerCapture = (): boolean => false
@@ -842,6 +843,30 @@ describe('SettingsPage layout', () => {
       expect(settingsRef.current?.closeActivePane()).toBe(true)
     })
     expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('dispatches the close-pane Escape to an active link-safety dialog', () => {
+    const settingsRef = createRef<SettingsPageHandle>()
+    const onLinkClose = vi.fn()
+    act(() => {
+      root.render(
+        <>
+          <SettingsPage ref={settingsRef} open onClose={vi.fn()} />
+          <LinkSafetyModal
+            url="https://example.com/paper"
+            isOpen
+            onClose={onLinkClose}
+            onConfirm={vi.fn()}
+          />
+        </>
+      )
+    })
+
+    act(() => {
+      expect(settingsRef.current?.closeActivePane()).toBe(true)
+    })
+
+    expect(onLinkClose).toHaveBeenCalledOnce()
   })
 
   it('defaults the Add provider type to the framework vendor (Codex → OpenAI, OpenCode → DeepSeek)', async () => {

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { act, createRef } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import { Dialog } from 'radix-ui'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SettingsPage, type SettingsPageHandle } from './SettingsPage'
@@ -695,8 +696,10 @@ describe('SettingsPage layout', () => {
       }))
     )
 
+    const onClose = vi.fn()
+    const settingsRef = createRef<SettingsPageHandle>()
     await act(async () => {
-      root.render(<SettingsPage open onClose={vi.fn()} />)
+      root.render(<SettingsPage ref={settingsRef} open onClose={onClose} />)
     })
     const nav = document.body.querySelector<HTMLElement>('nav[aria-label="Settings"]')
     expect(nav?.getAttribute('aria-hidden')).toBe('true')
@@ -721,6 +724,17 @@ describe('SettingsPage layout', () => {
         heading.textContent?.includes('General')
       )
     ).toBe(true)
+
+    await act(async () => {
+      document.body
+        .querySelector<HTMLButtonElement>('[aria-label="Open settings navigation"]')
+        ?.click()
+    })
+    act(() => {
+      expect(settingsRef.current?.closeActivePane()).toBe(true)
+    })
+    expect(nav?.getAttribute('aria-hidden')).toBe('true')
+    expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('opens Add provider as a history-driven sub-page and returns via the back arrow', () => {
@@ -766,7 +780,7 @@ describe('SettingsPage layout', () => {
     expect(document.body.querySelector('section[aria-label="Providers"]')).not.toBeNull()
   })
 
-  it('backs out of a breadcrumb before closing Settings with the close-pane shortcut', () => {
+  it('closes a nested dialog, then a breadcrumb, then Settings with the close-pane shortcut', () => {
     const onClose = vi.fn()
     const settingsRef = createRef<SettingsPageHandle>()
     act(() => {
@@ -778,6 +792,29 @@ describe('SettingsPage layout', () => {
     ).find((button) => button.textContent?.trim() === 'Add provider')
     act(() => addProvider?.click())
     expect(document.body.querySelector('[aria-label="Provider type"]')).not.toBeNull()
+
+    act(() => {
+      root.render(
+        <>
+          <SettingsPage ref={settingsRef} open onClose={onClose} />
+          <Dialog.Root defaultOpen>
+            <Dialog.Portal>
+              <Dialog.Content>
+                <Dialog.Title>Nested Settings dialog</Dialog.Title>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog.Root>
+        </>
+      )
+    })
+    expect(document.body.textContent).toContain('Nested Settings dialog')
+
+    act(() => {
+      expect(settingsRef.current?.closeActivePane()).toBe(true)
+    })
+    expect(document.body.textContent).not.toContain('Nested Settings dialog')
+    expect(document.body.querySelector('[aria-label="Provider type"]')).not.toBeNull()
+    expect(onClose).not.toHaveBeenCalled()
 
     act(() => {
       expect(settingsRef.current?.closeActivePane()).toBe(true)

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -546,6 +546,10 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
         )
         return true
       }
+      if (isMobileNavOpen) {
+        setIsMobileNavOpen(false)
+        return true
+      }
       if (breadcrumb) navigate(breadcrumb.rootTo)
       else {
         setIsMobileNavOpen(false)

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -538,7 +538,9 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
     closeActivePane: () => {
       if (!open) return false
       const hasNestedDialog = Array.from(
-        document.querySelectorAll<HTMLElement>('[role="dialog"], [role="alertdialog"]')
+        document.querySelectorAll<HTMLElement>(
+          '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]'
+        )
       ).some((dialog) => dialog.dataset.slot !== 'settings-surface')
       if (hasNestedDialog) {
         document.dispatchEvent(

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -550,8 +550,14 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
         setIsMobileNavOpen(false)
         return true
       }
-      if (breadcrumb) navigate(breadcrumb.rootTo)
-      else {
+      if (breadcrumb) {
+        if (canGoBack) setHistoryIndex((index) => index - 1)
+        else {
+          setHistory((entries) =>
+            entries.map((entry, index) => (index === historyIndex ? breadcrumb.rootTo : entry))
+          )
+        }
+      } else {
         setIsMobileNavOpen(false)
         onClose()
       }

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -19,7 +19,7 @@ import {
   Zap
 } from 'lucide-react'
 import { Dialog } from 'radix-ui'
-import { useEffect, useState } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useState } from 'react'
 
 import {
   resolveCodexSubscriptionType,
@@ -69,6 +69,10 @@ type SettingsPageProps = {
   open: boolean
   onClose: () => void
   onOpenSession?: (sessionId: string) => void
+}
+
+type SettingsPageHandle = {
+  closeActivePane: () => boolean
 }
 
 // The model panel sub-view, driven by the settings navigation history so add/edit is a breadcrumb page.
@@ -184,7 +188,10 @@ const INITIAL_LOCATION: NavLocation = {
 
 // App-level model settings surface. Reuses the onboarding cards/form; manages providers (CRUD +
 // activate + test). Opened from the Home/Workspace gear entry.
-const SettingsPage = ({ open, onClose, onOpenSession }: SettingsPageProps): React.JSX.Element => {
+const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function SettingsPage(
+  { open, onClose, onOpenSession },
+  ref
+): React.JSX.Element {
   const providers = useSettingsStore((state) => state.providers)
   const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
@@ -526,6 +533,15 @@ const SettingsPage = ({ open, onClose, onOpenSession }: SettingsPageProps): Reac
     if (!canGoForward) return
     setHistoryIndex((index) => index + 1)
   }
+
+  useImperativeHandle(ref, () => ({
+    closeActivePane: () => {
+      if (!open) return false
+      if (breadcrumb) navigate(breadcrumb.rootTo)
+      else onClose()
+      return true
+    }
+  }))
 
   // A provider form (add/edit) is open when the model panel is on a non-list sub-view.
   const isProviderFormOpen = activePanel === 'model' && modelView.kind !== 'list'
@@ -991,6 +1007,6 @@ const SettingsPage = ({ open, onClose, onOpenSession }: SettingsPageProps): Reac
       </Dialog.Portal>
     </Dialog.Root>
   )
-}
+})
 
-export { SettingsPage }
+export { SettingsPage, type SettingsPageHandle }

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -537,13 +537,15 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   useImperativeHandle(ref, () => ({
     closeActivePane: () => {
       if (!open) return false
-      const hasNestedDialog = Array.from(
+      const activeDialog = Array.from(
         document.querySelectorAll<HTMLElement>(
           '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]'
         )
-      ).some((dialog) => dialog.dataset.slot !== 'settings-surface')
-      if (hasNestedDialog) {
-        document.dispatchEvent(
+      )
+        .filter((dialog) => dialog.dataset.slot !== 'settings-surface')
+        .at(-1)
+      if (activeDialog) {
+        activeDialog.dispatchEvent(
           new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
         )
         return true

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -537,8 +537,20 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   useImperativeHandle(ref, () => ({
     closeActivePane: () => {
       if (!open) return false
+      const hasNestedDialog = Array.from(
+        document.querySelectorAll<HTMLElement>('[role="dialog"], [role="alertdialog"]')
+      ).some((dialog) => dialog.dataset.slot !== 'settings-surface')
+      if (hasNestedDialog) {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+        )
+        return true
+      }
       if (breadcrumb) navigate(breadcrumb.rootTo)
-      else onClose()
+      else {
+        setIsMobileNavOpen(false)
+        onClose()
+      }
       return true
     }
   }))


### PR DESCRIPTION
## Problem

Settings can only be opened through visible UI controls, without the standard platform keyboard shortcut. Cmd/Ctrl+W also falls through to preview or window handling while transient modals are active.

## Proposed change

- Open the existing Settings panel with Cmd+, on macOS and Ctrl+, on Windows and Linux.
- Ignore the open shortcut until startup is interactive or while another top-level modal is active.
- Route Cmd/Ctrl+W through dismissible surfaces before preview panes and the window.
- Return a Settings breadcrumb page to its current panel root before closing Settings on the next chord.

## Scope and non-goals

- Renderer-only interaction change.
- No IPC, data model, persistence, settings content, dependency, or application-menu framework changes.
- Blocking approval, recovery, and quit-confirm dialogs keep their explicit decision semantics and are not silently dismissed.

## Acceptance criteria and validation

All listed local checks ran after the last material edit.

- Settings open shortcut, startup/modal gates, close precedence, and breadcrumb navigation -> npm test -- src/renderer/src/App.test.tsx src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts src/renderer/src/pages/settings/SettingsPage.render.test.tsx -> passed, 96 tests.
- Renderer types -> npm run typecheck:web -> passed.
- Source lint -> npm run lint -> passed with 0 errors and 17 pre-existing warnings outside the changed files.

The final PR Gate run provides the complete portable-suite and platform evidence. Native OS accelerator delivery remains the only uncovered manual risk.

## Review focus

Please review the top-level modal guard, close-shortcut precedence, and Settings breadcrumb-to-root behavior.