### PR TITLE
fix(notebook): correct connector result handoff

### DIFF
--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -14,6 +14,8 @@ describe('renderConnectorInstructions', () => {
     // The "do not reimplement with raw HTTP" rule is what steers opencode away from raw requests.
     expect(md).toMatch(/urllib|requests|httpx|fetch/)
     expect(md).toContain('mcp-*')
+    expect(md).toContain('process.env.OPEN_SCIENCE_HANDOFF_DIR')
+    expect(md).not.toContain('./handoff/')
     expect(md).not.toContain('## chemistry')
     expect(md).not.toContain('pubchem_get_compounds')
     expect(md).not.toContain('```json')

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -7,7 +7,7 @@ const CONVENTIONS = [
   'The REPL is a persistent session: assign a result you will reuse to `globalThis` (e.g. `globalThis.hits = result`) so later `repl_execute` calls can see it, instead of running the call again. Each call hits the rate-limited upstream — never re-issue the same call to look at or reprocess a result you already have.',
   'Do NOT reimplement these calls with raw HTTP (urllib / requests / httpx / fetch) or hit the upstream endpoints directly — that bypasses the approval gate, per-tool policy, credentials, and rate limits, and can leak project data.',
   'Prefer bulk/list tools over per-item loops — the upstream API is rate-limited and shared across subagents.',
-  'To use a result in a python or r cell, have the REPL write it to `./handoff/<name>.json` (the shared `$OPEN_SCIENCE_HANDOFF_DIR`), then read that file from the data cell — not through the model context.'
+  'To use a result in a python or r cell, have the REPL write it under `process.env.OPEN_SCIENCE_HANDOFF_DIR`, then read the same `OPEN_SCIENCE_HANDOFF_DIR` path from the data cell — not through the model context or a cwd-relative handoff path.'
 ].join('\n')
 
 // A Skill may be loaded outside the bundled-connector baseline (notably for custom MCP servers), so

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -137,7 +137,8 @@ describe('notebook MCP server config', () => {
     expect(toolNames).toContain('manage_environments')
 
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('manage_environments')
-    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('./handoff/')
+    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('process.env.OPEN_SCIENCE_HANDOFF_DIR')
+    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).not.toContain('./handoff/')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND.toLowerCase()).toContain('separate')
   })
 })
@@ -228,7 +229,8 @@ describe('repl_execute tool', () => {
     expect(tool?.description).toContain('host.mcp')
     // host.compute (remote compute) is only reachable here too, same as host.mcp.
     expect(tool?.description).toContain('host.compute')
-    expect(tool?.description).toContain('./handoff/')
+    expect(tool?.description).toContain('process.env.OPEN_SCIENCE_HANDOFF_DIR')
+    expect(tool?.description).not.toContain('./handoff/')
     expect(tool?.description.toLowerCase()).toContain('connector')
     expect(tool?.description).toContain('notebook_execute')
   })
@@ -297,6 +299,7 @@ describe('bash_execute tool', () => {
     expect(windowsDoc).toContain('Windows PowerShell')
     expect(windowsDoc).not.toContain('`sh -c`')
     expect(windowsDoc).toContain('$env:OPEN_SCIENCE_HANDOFF_DIR')
+    expect(windowsDoc).not.toContain('./handoff/')
     expect(windowsDoc).toContain('Windows PowerShell 5.1')
     expect(windowsDoc).toContain('`&&` is unavailable')
     expect(windowsDoc).toContain('cmdlet failure')
@@ -756,6 +759,17 @@ describe('compactNotebookExecutionResult', () => {
     expect(compact.outputs).toEqual([{ type: 'display', data: { 'text/plain': '42' } }])
   })
 
+  it('keeps a compact connector text result inline', () => {
+    const text = 'x'.repeat(3_030)
+    const compact = compactNotebookExecutionResult({
+      ...runSummary({}),
+      outputs: [{ type: 'display', data: { 'text/plain': text } }]
+    }) as { outputs: Array<{ data: Record<string, string> }>; truncated?: boolean }
+
+    expect(compact.outputs[0].data['text/plain']).toBe(text)
+    expect(compact.truncated).toBeUndefined()
+  })
+
   it('elides an image display output while preserving its notebook-preview marker', () => {
     const base64 = 'A'.repeat(60_000)
     const result = {
@@ -796,8 +810,9 @@ describe('compactNotebookExecutionResult', () => {
       NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT
     )
 
+    expect(NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT).toBe(24_000)
     expect(serialized.length).toBeLessThanOrEqual(NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT)
-    expect(tokenizer.encode(serialized).length).toBeLessThanOrEqual(4_000)
+    expect(tokenizer.encode(serialized).length).toBeLessThanOrEqual(8_000)
     expect(JSON.parse(serialized)).toMatchObject({ status: 'completed', truncated: true })
     expect(result.stdout.length).toBe(oversized.length)
   })

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -15,9 +15,9 @@ const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
   '<open_science_notebook_instructions>',
   'Notebook tool instructions (only applies when using open-science-notebook tools).',
   'Notebook preview is only for code and execution results; keep chat, explanation, and diagnosis in the chat area.',
-  'Use `notebook_execute` for one persistent Python/R cell per call; reuse `cellId` to rerun a cell. Python/R data kernels cannot call connectors. Use `repl_execute` for `host.mcp`/`host.compute`, and exchange large data through `$OPEN_SCIENCE_HANDOFF_DIR` (`./handoff/`).',
+  'Use `notebook_execute` for one persistent Python/R cell per call; reuse `cellId` to rerun a cell. Python/R data kernels cannot call connectors. Use `repl_execute` for `host.mcp`/`host.compute`. For large cross-kernel data, write under `process.env.OPEN_SCIENCE_HANDOFF_DIR` in the REPL and read the same `OPEN_SCIENCE_HANDOFF_DIR` path from Python/R.',
   'Each runtime is a separate persistent namespace. Create named runtimes with `manage_environments`, select them with the bind/switch tools, and use files to move data across runtimes. Memory is lost on restart or app reopen; run history and files survive.',
-  'The notebook already runs inside a writable session workspace. Use plain relative paths: inputs in `./data/`, intermediate results in `./outputs/`, and connector handoff in `./handoff/`. The cwd is already the session data dir; never copy a saved file onto the same path. Do not modify original user files.',
+  'The notebook already runs inside a writable session workspace. The cwd is already the session data dir; use plain relative paths for normal inputs and outputs. The connector handoff directory is outside that cwd and must be resolved from `OPEN_SCIENCE_HANDOFF_DIR`. Never copy a saved file onto the same path. Do not modify original user files.',
   'Use `inspect_packages` for version checks and `manage_packages` for installs. Never install inside a cell or shell. App-managed runtime contents belong under `$OPEN_SCIENCE_RUNTIME_DIR`, never the project, workspace, system Python, or a user global environment.',
   'MCP execution replies are bounded summaries; full output remains in the notebook preview. Inspect stdout, stderr, traceback, outputs, and workingFiles, then revise and rerun if needed. The notebook runtime does not classify files for you.',
   'For a final user-facing file, call `write_artifact_file` from the `open-science-artifacts` server before announcing it. Use `source: { "kind": "localPath", "path": "plot.png" }` with the SAME relative filename you saved with and `producerRunId` set to the exact `runId` returned by the execution that last wrote it. Use inline content only for small text.',
@@ -115,7 +115,7 @@ const MANAGE_ENVIRONMENTS_DOC = [
   'Create, list, or remove named persistent Python/R environments. Each is a separate process and namespace.',
   `action:"create" needs language and name (optional initial packages); action:"list" reports provisioned environments in pages of at most ${MAX_ENVIRONMENT_RESULTS} using optional offset/limit and nextOffset; action:"remove" accepts a name.`,
   'Create before bind/switch. Removal is limited to agent-created, idle named environments; defaults, app-managed versioned environments, and external interpreters cannot be removed.',
-  'Named data kernels cannot call connectors; use repl_execute and ./handoff/.'
+  'Named data kernels cannot call connectors; use repl_execute and the OPEN_SCIENCE_HANDOFF_DIR environment path.'
 ].join('\n')
 
 const LIST_NOTEBOOK_RUNTIMES_DOC = [
@@ -137,7 +137,7 @@ const SWITCH_RUNTIME_DOC = [
 const REPL_EXECUTE_DOC = [
   'Run JavaScript in the persistent control-plane REPL, separate from notebook_execute Python/R data kernels.',
   'Only this kernel can call connectors (`await host.mcp(server, method, args)`) and remote compute (`host.compute`; load its skill for the API).',
-  'Globals persist and a trailing expression is returned. Do not echo large data; write it to ./handoff/ for Python/R. Use notebook_execute for analysis code.'
+  'Globals persist and a trailing expression is returned. Do not echo large data; write it under process.env.OPEN_SCIENCE_HANDOFF_DIR for Python/R. Use notebook_execute for analysis code.'
 ].join('\n')
 
 // Stateless shell contract, embedded as the bash_execute description so the agent always sees it.
@@ -161,7 +161,7 @@ const buildShellExecuteDoc = (platform: NodeJS.Platform = process.platform): str
   return [
     shellDescription,
     ...(platformContract ? [platformContract] : []),
-    `Stateless: each call is a fresh process, so cwd, variables, jobs, and functions do not persist. It starts in the data-kernel workspace and shares ./handoff/ (${handoffVariable}).`,
+    `Stateless: each call is a fresh process, so cwd, variables, jobs, and functions do not persist. It starts in the data-kernel workspace and shares the handoff directory exposed as ${handoffVariable}; do not resolve handoff relative to cwd.`,
     exitCodeContract,
     'Do NOT copy a generated notebook output into the workspace with this tool. For a final chart, image, report, CSV, or other user-facing file, call `write_artifact_file` with the same relative filename you saved with (it resolves against the notebook session data dir); it copies the file safely on every platform.',
     'Use only for one-off command inspection. Run Python/R with notebook_execute, JavaScript with repl_execute, and installs with manage_packages; never execute analysis scripts, inline code, or installers here.'
@@ -283,12 +283,12 @@ const callNotebookRpc = async (
 
 // Approximate 4k/2k-token budgets for ordinary English/JSON. The final serialized character caps are
 // deliberately conservative; full values stay in run.json and the notebook preview.
-const NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT = 12_000
+const NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT = 24_000
 const NOTEBOOK_MCP_STATE_RESULT_LIMIT = 6_000
 const NOTEBOOK_MCP_CONTROL_RESULT_LIMIT = 8_000
 const NOTEBOOK_MCP_STREAM_PREVIEW_LIMIT = 2_500
 const NOTEBOOK_MCP_STATE_OUTPUT_PREVIEW_LIMIT = 600
-const MIME_INLINE_LIMIT = 768
+const MIME_INLINE_LIMIT = 4_000
 const MAX_EXECUTION_OUTPUTS = 6
 const MAX_EXECUTION_FILES = 10
 const MAX_STATE_CELLS = 20


### PR DESCRIPTION
## Problem

Compact connector results returned by `repl_execute` were omitted once a single text/JSON output exceeded 768 UTF-16 code units. A 3,030-character PubMed result therefore disappeared from the agent-facing response and encouraged an unnecessary file-plus-shell recovery path.

The recovery then failed because agent instructions described the handoff channel as `./handoff/`, while notebook kernels start in the session `data/` directory and the real handoff directory is its sibling.

## Proposed change

- Raise the per-output text/JSON inline limit from 768 to 4,000 UTF-16 code units (characters for ordinary ASCII/English text), not tokens.
- Raise the global serialized execution-result limit from 12,000 to 24,000 characters and its token regression guard from approximately 4,000 to 8,000 tokens.
- Retain image elision and the six-output cap.
- Point notebook and connector instructions at `OPEN_SCIENCE_HANDOFF_DIR` instead of a cwd-relative `./handoff/` path.
- Add regression coverage for the observed 3,030-character text result, both output budgets, and the handoff guidance.

## Scope and non-goals

- No architecture, storage layout, data model, or data relationship changes.
- No kernel cwd change, compatibility symlink, or duplicate handoff directory.
- Larger results remain bounded; full output still remains in the notebook preview.

## Acceptance criteria and validation

Checks ran against the final material diff.

- 3,030-character connector text remains inline, 24,000-character/approximately 8,000-token global budgets remain enforced, and environment-based handoff guidance is emitted -> `npm test -- src/main/notebook/mcp-server.test.ts src/main/connectors/skill-doc.test.ts` -> passed (63/63).
- Changed Node/main-process source is lint-clean -> `npm run lint` -> passed with 0 errors (17 existing repository warnings outside this diff).
- Earlier portable-suite run under the same result-projection implementation -> `npm test` outside the restricted socket sandbox -> 11,310 passed; 3 unrelated `src/main/acp/claude-agent-acp-patch.test.ts` failures remain because the shared local `node_modules` contains an older partial project patch without the current logger parameter.
- Node type safety -> `npm run typecheck:node` -> the same stale local patched dependency causes two pre-existing argument-count errors in `src/main/acp/claude-agent-acp-patch.test.ts`; no changed file reports an error.

Consumer/platform selection: notebook MCP result projection and connector instruction consumers are covered by their project-owned unit tests, including Windows shell guidance. No renderer, persistence, migration, or filesystem lane is included because their interfaces and storage behavior are unchanged.

Uncovered risk: the exact PubMed call was not repeated end-to-end; clean-install CI provides authoritative full-suite/typecheck evidence.

## Review focus

- Whether 4,000 characters per output and 24,000 characters globally are the right balance under the approximately 8,000-token guard.
- Whether every agent-visible handoff instruction now avoids cwd-relative resolution.
