### PR TITLE
fix(remote-access): prevent Web session re-entry failures

### DIFF
--- a/src/main/remote-access/pairing.test.ts
+++ b/src/main/remote-access/pairing.test.ts
@@ -103,6 +103,8 @@ describe('RemoteSessionPairingManager', () => {
     )
     expect(JSON.parse(statusResponse.body())).toEqual({ status: 'approved' })
     const setCookies = statusResponse.headers.get('set-cookie') as string[]
+    expect(setCookies[0]).toContain('SameSite=Strict')
+    expect(setCookies[0]).not.toContain('Max-Age')
     const sessionCookie = cookiePair(setCookies[0])
 
     const authorizedResponse = response()
@@ -145,7 +147,25 @@ describe('RemoteSessionPairingManager', () => {
       new URL('https://home.example.ts.net/__open_science_remote/pair/status')
     )
     const setCookies = statusResponse.headers.get('set-cookie') as string[]
+    expect(setCookies[0]).toContain('SameSite=Lax')
+    expect(setCookies[0]).toContain('Max-Age=15552000')
     const sessionCookie = cookiePair(setCookies[0])
+
+    const restartedManager = await RemoteSessionPairingManager.create({
+      repository,
+      isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn()
+    })
+    await expect(
+      restartedManager.webAccess.authorizeHttp(
+        request('/', { cookie: sessionCookie }),
+        response().response,
+        new URL('https://home.example.ts.net/')
+      )
+    ).resolves.toMatchObject({ kind: 'authorized-pairing-manager' })
+    expect(restartedManager.pendingViews()).toHaveLength(0)
+
     await expect(
       manager.webAccess.authorizeHttp(
         request(

--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -84,7 +84,7 @@ const readCookies = (request: IncomingMessage): Map<string, string> => {
 }
 
 const sessionCookie = (value: string, persistent: boolean): string =>
-  `${SESSION_COOKIE}=${encodeURIComponent(value)}; HttpOnly; Secure; SameSite=Strict; Path=/${
+  `${SESSION_COOKIE}=${encodeURIComponent(value)}; HttpOnly; Secure; SameSite=${persistent ? 'Lax' : 'Strict'}; Path=/${
     persistent ? `; Max-Age=${TRUSTED_COOKIE_MAX_AGE_SECONDS}` : ''
   }`
 

--- a/src/renderer/src/pages/workspace/previews/renderers/OfficePreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/OfficePreview.test.tsx
@@ -138,6 +138,16 @@ describe('OfficePreviewRenderer', () => {
     document.querySelectorAll('[data-test-overlay]').forEach((element) => element.remove())
   })
 
+  it('falls back to download when the Web renderer has no native Office preview API', async () => {
+    Object.defineProperty(window, 'api', { configurable: true, value: {} })
+
+    await renderPreview()
+
+    expect(container.textContent).toContain('Preview unavailable')
+    expect(container.textContent).toContain('Office preview is only available in the desktop app')
+    expect(open).not.toHaveBeenCalled()
+  })
+
   it('shows the authoritative file-check stage while opening', async () => {
     open.mockReturnValue(new Promise(() => undefined))
 

--- a/src/renderer/src/pages/workspace/previews/renderers/OfficePreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/OfficePreview.tsx
@@ -349,6 +349,16 @@ export const OfficePreviewContent = ({
       />
     )
   }
+  if (!window.api.officePreview) {
+    return (
+      <OfficeDownloadFallback
+        item={item}
+        source={source}
+        title="Preview unavailable"
+        message="Office preview is only available in the desktop app. Download this file to view it."
+      />
+    )
+  }
   return <RemoteOfficePreviewContent item={item} source={source} />
 }
 


### PR DESCRIPTION
## Problem

- Re-entering Web access from Remote.It after choosing **Always trust** could prompt for pairing again. The persistent session cookie used `SameSite=Strict`, so the browser withheld it on the cross-site top-level navigation from Remote.It.
- Opening a conversation could briefly render and then go white when persisted workspace state restored an Office preview. The Web runtime intentionally has no native `officePreview` API, but the renderer called it unconditionally and crashed the React tree.

## Proposed change

- Use `SameSite=Lax` only for persistent trusted-session cookies, while keeping one-time session cookies `SameSite=Strict`. Existing same-origin checks continue to protect RPC mutations.
- Detect the missing native Office preview API in the Web renderer and show the existing download fallback instead of mounting the desktop-only preview path.
- Add regression coverage for trusted-session reuse after pairing-manager restart and for Web Office fallback rendering.

## Scope and non-goals

- No architecture, data model, data relationship, persistence format, or dependency changes.
- No general renderer error boundary or unrelated remote-access refactor.
- Desktop Office preview behavior is unchanged.

## Acceptance criteria and validation

- [x] Always-trusted cookies survive manager restart and are accepted on Web re-entry: `rtk npm test -- src/main/remote-access/pairing.test.ts src/renderer/src/pages/workspace/previews/renderers/OfficePreview.test.tsx` (27 passed).
- [x] Web Office previews without the native API render a download fallback instead of throwing (covered by the same targeted run).
- [x] Node types: `rtk npm run typecheck:node`.
- [x] Web types: `rtk npm run typecheck:web`.
- [x] Lint: `rtk npm run lint` (0 errors; 17 pre-existing warnings in unrelated files).
- [x] Portable suite: `rtk npm test -- --maxWorkers=4` (765 files / 11,329 tests passed; 14 files / 184 tests skipped).

High-parallel full-suite runs exposed unrelated timing flakes in `StoragePanel.render.test.tsx`, `shell-process.test.ts`, and `job-poller.test.ts`; all affected tests passed when rerun directly, and the reduced-worker full suite passed cleanly.

## Review focus

- Confirm the cookie boundary is appropriate: persistent trust uses `Lax`; one-time access remains `Strict`.
- Confirm the Web-only Office fallback preserves desktop preview behavior and the existing download path.
