### PR TITLE
refactor(acp): extract session replacement workflow

### DIFF
--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -139,6 +139,7 @@ import { AcpModelChangeWorkflow } from './model-change-workflow'
 import { AcpProviderSessionCreator } from './provider-session-creator'
 import { AcpProviderSessionAdopter } from './provider-session-adopter'
 import { AcpProviderSessionResumer } from './provider-session-resumer'
+import { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
 import {
   AcpTurnSkillOwner,
   type AcpTurnSkillHooks,
@@ -418,6 +419,7 @@ class AcpRuntime {
   private readonly providerSessionCreator: AcpProviderSessionCreator
   private readonly providerSessionAdopter: AcpProviderSessionAdopter
   private readonly providerSessionResumer: AcpProviderSessionResumer
+  private readonly sessionReplacement: AcpSessionReplacementWorkflow
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -704,6 +706,24 @@ class AcpRuntime {
       updateCwd: (cwd) => this.snapshotOwner.updateCwd(cwd),
       emitState: () => this.emitState(),
       diagnosticContext: () => this.diagnosticContext()
+    })
+    this.sessionReplacement = new AcpSessionReplacementWorkflow({
+      defaultCwd: options.defaultCwd,
+      defaultProjectName: options.artifacts?.projectName || DEFAULT_UPLOAD_PROJECT_NAME,
+      currentCwd: () => this.snapshotOwner.cwd,
+      currentFrameworkId: () => this.framework.id,
+      ensureConnected: (cwd) => this.ensureConnected(cwd),
+      assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
+      registry: this.sessionRegistry,
+      reserveIdentity: (sessionId, publishedAppSessionId) =>
+        this.reservePrimarySessionIds(undefined, [sessionId], publishedAppSessionId),
+      adopter: this.providerSessionAdopter,
+      permission: this.permissionContext,
+      promptContent: this.promptContentOwner,
+      contextUsage: this.contextUsageTracker,
+      interactions: this.sessionInteractions,
+      resolveSpecialistIdentity: options.resolveSpecialistIdentity,
+      registerSessionSpecialist: options.notebook?.registerSessionSpecialist
     })
     this.providerSessionResumer = new AcpProviderSessionResumer({
       defaultCwd: options.defaultCwd,
@@ -1192,92 +1212,7 @@ class AcpRuntime {
   // transcript starts clean. Returns contextReset so the caller replays a bounded transcript into the
   // next prompt (the app-level equivalent of compaction, which — unlike the backend's — drops all media).
   async resetSessionContext(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
-    return this.withOperationLease(() => this.resetSessionContextOperation(request))
-  }
-
-  private async resetSessionContextOperation(
-    request: AcpResumeSessionRequest
-  ): Promise<AcpCreateSessionResponse> {
-    const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
-    const projectName = this.normalizeProjectName(request.projectName)
-    const publishedSession = this.activeSessionFor(request.sessionId)
-    const publishedAppSessionId = publishedSession ? request.sessionId : undefined
-    const reservationResult = this.reservePrimarySessionIds(
-      undefined,
-      [request.sessionId],
-      publishedAppSessionId
-    )
-    if (reservationResult.collision) throw reservationResult.collision
-    const reservation = reservationResult.reservation
-
-    try {
-      return await this.resetReservedSessionContextOperation(
-        request,
-        sessionCwd,
-        projectName,
-        reservation,
-        publishedSession
-      )
-    } finally {
-      this.releasePrimarySessionIdentityReservation(reservation)
-    }
-  }
-
-  private async resetReservedSessionContextOperation(
-    request: AcpResumeSessionRequest,
-    sessionCwd: string,
-    projectName: string,
-    primaryIdentityReservation: AcpPrimarySessionIdentityReservation,
-    publishedSession: ActiveSession | undefined
-  ): Promise<AcpCreateSessionResponse> {
-    const connection = await this.ensureConnected(sessionCwd)
-    this.assertCurrentConnectedConnection(connection)
-    const currentPublishedSession = this.activeSessionFor(request.sessionId)
-    const crossedGeneration = this.renewPrimarySessionIdentityReservation(
-      primaryIdentityReservation,
-      currentPublishedSession === publishedSession && currentPublishedSession
-        ? request.sessionId
-        : undefined
-    )
-    const reconnectReplacedPublishedSession =
-      publishedSession !== undefined && currentPublishedSession === undefined && crossedGeneration
-    if (currentPublishedSession !== publishedSession && !reconnectReplacedPublishedSession) {
-      throw new Error('ACP session startup was superseded.')
-    }
-
-    // Tear down the currently attached agent session (if any) before adopting a replacement, dropping
-    // its reverse routing so late events from the old agent session can no longer target this app id.
-    const attachedEntry = this.sessionRegistry.lookup(request.sessionId)
-    const attached = attachedEntry?.attachment
-
-    // A context reset replaces only the provider-side history; the app conversation continues under
-    // the same id, so retain its visible/revocable grants while cancelling requests owned by the old
-    // agent session. Provider tool context must not survive because a fresh agent may reuse call ids.
-    this.cancelPermissionFlowForSession(request.sessionId)
-
-    if (attached) {
-      attached.session.dispose()
-      this.sessionRegistry.detach(attached, 'provider')
-    }
-
-    // The fresh agent session holds no history, so the accumulated media is gone; start its budget clean.
-    this.promptContentOwner.resetSession(request.sessionId)
-    // A context reset creates a new agent-side conversation under the same app id. Do not carry the
-    // previous context size into the fresh conversation before its first usage_update arrives.
-    this.contextUsageTracker.deleteSession(request.sessionId)
-    this.sessionRegistry.lookup(request.sessionId)?.aggregate.clearAppliedModel()
-
-    // Release the failed interaction now. Its own `finally` may run only after async artifact cleanup;
-    // the generation-guarded owner prevents that stale cleanup from clearing the recovery resend.
-    this.sessionInteractions.supersedeCurrent(request.sessionId)
-
-    return this.adoptFreshSession(
-      connection,
-      request,
-      sessionCwd,
-      projectName,
-      primaryIdentityReservation
-    )
+    return this.withOperationLease(() => this.sessionReplacement.reset(request))
   }
 
   // Hot-switches the specialist bound to a live session. Updates the per-session skills and identity
@@ -1290,62 +1225,15 @@ class AcpRuntime {
     sessionId: string,
     specialistId: string | undefined
   ): Promise<{ contextReset: boolean }> {
-    return this.withOperationLease(() => this.switchSpecialistOperation(sessionId, specialistId))
+    return this.withOperationLease(() =>
+      this.sessionReplacement.switchSpecialist(sessionId, specialistId)
+    )
   }
 
   // The completion-gate adapter uses this public runtime fact to claim only the framework it owns.
   // A session keeps its original framework while a different active backend is prepared elsewhere.
   getSessionFramework(sessionId: string): AgentFrameworkId | undefined {
     return this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().frameworkId
-  }
-
-  private async switchSpecialistOperation(
-    sessionId: string,
-    specialistId: string | undefined
-  ): Promise<{ contextReset: boolean }> {
-    if (this.hasSessionInteractionInFlight(sessionId)) {
-      throw new Error('Cannot switch specialist while the Agent is running.')
-    }
-
-    // Skills map drives per-turn skill resolution for every framework.
-    const { aggregate } = this.sessionRegistry.ensureAffinity(sessionId)
-    aggregate.setSpecialistId(specialistId)
-
-    // Per-turn identity prefix (Codex / OpenCode). Claude uses a session _meta append instead, which
-    // adoptFreshSession re-bakes from sessionSpecialistIds during the context reset below.
-    if (specialistId !== undefined && this.options.resolveSpecialistIdentity) {
-      const identity = await this.options.resolveSpecialistIdentity(specialistId, this.framework.id)
-      if (identity?.prefix) {
-        aggregate.setSpecialistPrefix(identity.prefix)
-      } else {
-        aggregate.setSpecialistPrefix(undefined)
-      }
-    } else {
-      aggregate.setSpecialistPrefix(undefined)
-    }
-
-    // Keep notebook routing metadata in sync so MCP calls carry the new specialist context.
-    this.notebookOptions?.registerSessionSpecialist?.(sessionId, specialistId)
-
-    // Claude bakes the specialist identity into the session _meta at session/new. A live identity
-    // change therefore requires replacing the agent session so the new append takes effect. Only do
-    // this when a session is actually attached; an unattached session will pick up the new binding
-    // (now recorded in the maps above) when it is later created or resumed.
-    const requiresContextReset =
-      this.framework.id === 'claude-code' && this.activeSessionFor(sessionId) !== undefined
-    if (requiresContextReset) {
-      const snapshot = aggregate.snapshot()
-      await this.resetSessionContextOperation({
-        sessionId,
-        cwd: snapshot.cwd,
-        projectName: snapshot.projectName,
-        ...(snapshot.permissionProfile?.selectedProfile
-          ? { permissionProfile: snapshot.permissionProfile.selectedProfile }
-          : {})
-      } as AcpResumeSessionRequest)
-    }
-
-    return { contextReset: requiresContextReset }
   }
 
   // Invokes the framework's own context compaction command on the attached agent session. The
@@ -1502,27 +1390,6 @@ class AcpRuntime {
       })
       throw error
     }
-  }
-
-  // Builds a brand-new agent session under the SAME app id when a resume cannot reattach the original
-  // (a cross-framework switch, or an unresumable restart). Earlier turns stay visible; only agent-side
-  // context is gone, so contextReset is returned to let the caller replay a transcript into the next
-  // prompt. Shared by the cross-framework skip and the unrecoverable-error fallback.
-  private async adoptFreshSession(
-    connection: ClientConnection,
-    request: AcpResumeSessionRequest,
-    sessionCwd: string,
-    projectName: string,
-    primaryIdentityReservation: AcpPrimarySessionIdentityReservation
-  ): Promise<AcpCreateSessionResponse> {
-    return this.providerSessionAdopter.adopt(request.sessionId, {
-      connection,
-      cwd: sessionCwd,
-      projectName,
-      identity: primaryIdentityReservation,
-      permissionProfile: request.permissionProfile,
-      specialistId: request.specialistId
-    })
   }
 
   // Changes approval behavior only while the conversation is idle. Applying the ACP mode before the
@@ -3233,23 +3100,10 @@ class AcpRuntime {
     })
   }
 
-  private renewPrimarySessionIdentityReservation(
-    reservation: AcpPrimarySessionIdentityReservation,
-    publishedAppSessionId?: string
-  ): boolean {
-    return reservation.renew(publishedAppSessionId)
-  }
-
   private assertCurrentConnectedConnection(connection: ClientConnection): void {
     if (this.connection !== connection || this.snapshotOwner.status !== 'connected') {
       throw new Error('ACP session startup was superseded.')
     }
-  }
-
-  private releasePrimarySessionIdentityReservation(
-    reservation: AcpPrimarySessionIdentityReservation
-  ): void {
-    reservation.release()
   }
 
   // Disposes an ephemeral reviewer session and unregisters it from the auto-approve set. Safe to call

--- a/src/main/acp/session-replacement-workflow.test.ts
+++ b/src/main/acp/session-replacement-workflow.test.ts
@@ -1,0 +1,274 @@
+import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpCreateSessionResponse } from '../../shared/acp'
+import type { AgentFrameworkId } from '../../shared/settings'
+import { AcpSessionRegistry } from './session-registry'
+import { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
+
+const attachedSession = (sessionId: string, dispose = vi.fn()): ActiveSession =>
+  ({ sessionId, dispose }) as unknown as ActiveSession
+
+const publishSession = (
+  registry: AcpSessionRegistry,
+  appSessionId: string,
+  providerSession: ActiveSession,
+  frameworkId: AgentFrameworkId = 'claude-code'
+): void => {
+  const reserved = registry.reserve({ sessionIds: [appSessionId, providerSession.sessionId] })
+  if (reserved.collision) throw reserved.collision
+  registry.publish(reserved.reservation, appSessionId, {
+    session: providerSession,
+    cwd: '/old-workspace',
+    projectName: 'old-project',
+    frameworkId,
+    permissionProfile: {
+      selectedProfile: 'ask',
+      effectiveProfile: 'ask',
+      availableModeIds: ['default'],
+      fullAccessAvailable: false
+    }
+  })
+  reserved.reservation.release()
+}
+
+describe('AcpSessionReplacementWorkflow', () => {
+  it('replaces provider history under the stable App Session id through existing owners', async () => {
+    const registry = new AcpSessionRegistry()
+    const dispose = vi.fn()
+    publishSession(registry, 'app-session', attachedSession('provider-session', dispose))
+    const connection = {} as ClientConnection
+    const replacement: AcpCreateSessionResponse = {
+      sessionId: 'app-session',
+      cwd: '/new-workspace',
+      frameworkId: 'claude-code',
+      contextReset: true
+    }
+    const cancelPermissionFlow = vi.fn()
+    const resetPromptContent = vi.fn()
+    const resetContextUsage = vi.fn()
+    const supersedeInteraction = vi.fn()
+    const adopt = vi.fn(async () => replacement)
+    const workflow = new AcpSessionReplacementWorkflow({
+      defaultCwd: '/default-workspace',
+      defaultProjectName: 'default-project',
+      currentCwd: () => '/current-workspace',
+      currentFrameworkId: () => 'claude-code',
+      ensureConnected: vi.fn(async () => connection),
+      assertCurrentConnection: vi.fn(),
+      registry,
+      reserveIdentity: (sessionId, publishedAppSessionId) =>
+        registry.reserve({ sessionIds: [sessionId], publishedAppSessionId }),
+      adopter: { adopt },
+      permission: { cancelForSession: cancelPermissionFlow },
+      promptContent: { resetSession: resetPromptContent },
+      contextUsage: { deleteSession: resetContextUsage },
+      interactions: { current: vi.fn(), supersedeCurrent: supersedeInteraction }
+    })
+
+    await expect(
+      workflow.reset({
+        sessionId: 'app-session',
+        cwd: '/new-workspace',
+        projectName: 'new-project',
+        permissionProfile: 'ask'
+      })
+    ).resolves.toEqual(replacement)
+
+    expect(dispose).toHaveBeenCalledOnce()
+    expect(registry.lookup('app-session')?.attachment).toBeUndefined()
+    expect(cancelPermissionFlow).toHaveBeenCalledWith('app-session')
+    expect(resetPromptContent).toHaveBeenCalledWith('app-session')
+    expect(resetContextUsage).toHaveBeenCalledWith('app-session')
+    expect(supersedeInteraction).toHaveBeenCalledWith('app-session')
+    expect(adopt).toHaveBeenCalledWith('app-session', {
+      connection,
+      cwd: '/new-workspace',
+      projectName: 'new-project',
+      identity: expect.any(Object),
+      permissionProfile: 'ask',
+      specialistId: undefined
+    })
+  })
+
+  it('retains the stable identity reservation until asynchronous adoption completes', async () => {
+    const registry = new AcpSessionRegistry()
+    const connection = {} as ClientConnection
+    let continueAdoption!: () => void
+    const adoptionGate = new Promise<void>((resolve) => {
+      continueAdoption = resolve
+    })
+    const adopt = vi.fn(async (_sessionId, request) => {
+      await adoptionGate
+      request.identity.assertCurrent()
+      return {
+        sessionId: 'app-session',
+        cwd: '/workspace',
+        frameworkId: 'claude-code' as const,
+        contextReset: true as const
+      }
+    })
+    const workflow = new AcpSessionReplacementWorkflow({
+      defaultCwd: '/workspace',
+      defaultProjectName: 'project',
+      currentCwd: vi.fn(),
+      currentFrameworkId: () => 'claude-code',
+      ensureConnected: vi.fn(async () => connection),
+      assertCurrentConnection: vi.fn(),
+      registry,
+      reserveIdentity: (sessionId, publishedAppSessionId) =>
+        registry.reserve({ sessionIds: [sessionId], publishedAppSessionId }),
+      adopter: { adopt },
+      permission: { cancelForSession: vi.fn() },
+      promptContent: { resetSession: vi.fn() },
+      contextUsage: { deleteSession: vi.fn() },
+      interactions: { current: vi.fn(), supersedeCurrent: vi.fn() }
+    })
+
+    const reset = workflow.reset({ sessionId: 'app-session', cwd: '/workspace' })
+    await vi.waitFor(() => expect(adopt).toHaveBeenCalledOnce())
+    continueAdoption()
+
+    await expect(reset).resolves.toMatchObject({
+      sessionId: 'app-session',
+      contextReset: true
+    })
+  })
+
+  it('replaces a live Claude provider Session after projecting a Specialist switch', async () => {
+    const registry = new AcpSessionRegistry()
+    publishSession(registry, 'app-session', attachedSession('provider-session'))
+    const connection = {} as ClientConnection
+    const registerSessionSpecialist = vi.fn()
+    const adopt = vi.fn(async () => ({
+      sessionId: 'app-session',
+      cwd: '/old-workspace',
+      frameworkId: 'claude-code' as const,
+      contextReset: true as const
+    }))
+    const workflow = new AcpSessionReplacementWorkflow({
+      defaultCwd: '/default-workspace',
+      defaultProjectName: 'default-project',
+      currentCwd: () => '/current-workspace',
+      currentFrameworkId: () => 'claude-code',
+      ensureConnected: vi.fn(async () => connection),
+      assertCurrentConnection: vi.fn(),
+      registry,
+      reserveIdentity: (sessionId, publishedAppSessionId) =>
+        registry.reserve({ sessionIds: [sessionId], publishedAppSessionId }),
+      adopter: { adopt },
+      permission: { cancelForSession: vi.fn() },
+      promptContent: { resetSession: vi.fn() },
+      contextUsage: { deleteSession: vi.fn() },
+      interactions: { current: vi.fn(), supersedeCurrent: vi.fn() },
+      resolveSpecialistIdentity: vi.fn(async () => ({
+        append: 'New Specialist append',
+        prefix: 'New Specialist prefix'
+      })),
+      registerSessionSpecialist
+    })
+
+    await expect(workflow.switchSpecialist('app-session', 'new-specialist')).resolves.toEqual({
+      contextReset: true
+    })
+
+    expect(registry.lookup('app-session')?.aggregate.snapshot()).toMatchObject({
+      specialistId: 'new-specialist',
+      specialistPrefix: 'New Specialist prefix'
+    })
+    expect(registerSessionSpecialist).toHaveBeenCalledWith('app-session', 'new-specialist')
+    expect(adopt).toHaveBeenCalledWith(
+      'app-session',
+      expect.objectContaining({ specialistId: undefined })
+    )
+  })
+
+  it.each(['codex', 'opencode'] as const)(
+    'projects a live %s Specialist switch without replacing provider history',
+    async (frameworkId) => {
+      const registry = new AcpSessionRegistry()
+      const dispose = vi.fn()
+      publishSession(
+        registry,
+        'app-session',
+        attachedSession('provider-session', dispose),
+        frameworkId
+      )
+      const adopt = vi.fn()
+      const registerSessionSpecialist = vi.fn()
+      const workflow = new AcpSessionReplacementWorkflow({
+        defaultCwd: '/workspace',
+        defaultProjectName: 'project',
+        currentCwd: vi.fn(),
+        currentFrameworkId: () => frameworkId,
+        ensureConnected: vi.fn(),
+        assertCurrentConnection: vi.fn(),
+        registry,
+        reserveIdentity: vi.fn(),
+        adopter: { adopt },
+        permission: { cancelForSession: vi.fn() },
+        promptContent: { resetSession: vi.fn() },
+        contextUsage: { deleteSession: vi.fn() },
+        interactions: { current: vi.fn(), supersedeCurrent: vi.fn() },
+        resolveSpecialistIdentity: vi.fn(async () => ({
+          append: 'ignored session append',
+          prefix: 'New Specialist prefix'
+        })),
+        registerSessionSpecialist
+      })
+
+      await expect(workflow.switchSpecialist('app-session', 'new-specialist')).resolves.toEqual({
+        contextReset: false
+      })
+
+      expect(dispose).not.toHaveBeenCalled()
+      expect(adopt).not.toHaveBeenCalled()
+      expect(registry.lookup('app-session')?.aggregate.snapshot()).toMatchObject({
+        specialistId: 'new-specialist',
+        specialistPrefix: 'New Specialist prefix',
+        providerSessionId: 'provider-session'
+      })
+      expect(registerSessionSpecialist).toHaveBeenCalledWith('app-session', 'new-specialist')
+    }
+  )
+
+  it('rejects a Specialist switch before mutating owner state while an interaction is live', async () => {
+    const registry = new AcpSessionRegistry()
+    const aggregate = registry.ensureAffinity('app-session').aggregate
+    aggregate.setSpecialistId('old-specialist')
+    aggregate.setSpecialistPrefix('Old Specialist prefix')
+    const resolveSpecialistIdentity = vi.fn()
+    const registerSessionSpecialist = vi.fn()
+    const workflow = new AcpSessionReplacementWorkflow({
+      defaultCwd: '/default-workspace',
+      defaultProjectName: 'default-project',
+      currentCwd: vi.fn(),
+      currentFrameworkId: () => 'codex',
+      ensureConnected: vi.fn(),
+      assertCurrentConnection: vi.fn(),
+      registry,
+      reserveIdentity: vi.fn(),
+      adopter: { adopt: vi.fn() },
+      permission: { cancelForSession: vi.fn() },
+      promptContent: { resetSession: vi.fn() },
+      contextUsage: { deleteSession: vi.fn() },
+      interactions: {
+        current: vi.fn(() => ({ kind: 'prompt' }) as never),
+        supersedeCurrent: vi.fn()
+      },
+      resolveSpecialistIdentity,
+      registerSessionSpecialist
+    })
+
+    await expect(workflow.switchSpecialist('app-session', 'new-specialist')).rejects.toThrow(
+      'Cannot switch specialist while the Agent is running.'
+    )
+
+    expect(aggregate.snapshot()).toMatchObject({
+      specialistId: 'old-specialist',
+      specialistPrefix: 'Old Specialist prefix'
+    })
+    expect(resolveSpecialistIdentity).not.toHaveBeenCalled()
+    expect(registerSessionSpecialist).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/acp/session-replacement-workflow.ts
+++ b/src/main/acp/session-replacement-workflow.ts
@@ -1,0 +1,140 @@
+import type { ClientConnection } from '@agentclientprotocol/sdk'
+import { resolve } from 'node:path'
+
+import type { AcpCreateSessionResponse, AcpResumeSessionRequest } from '../../shared/acp'
+import type { AgentFrameworkId } from '../../shared/settings'
+import type { ContextUsageTracker } from './context-usage-tracker'
+import type { AcpPermissionContext } from './permission-context'
+import type { AcpPromptContentOwner } from './prompt-content-owner'
+import type { AcpProviderSessionAdopter } from './provider-session-adopter'
+import type { AcpSessionInteractionOwner } from './session-interaction-owner'
+import type {
+  AcpPrimarySessionIdentityReservationResult,
+  AcpSessionRegistry
+} from './session-registry'
+
+type AcpSessionReplacementWorkflowDependencies = Readonly<{
+  defaultCwd: string
+  defaultProjectName: string
+  currentCwd: () => string | undefined
+  currentFrameworkId: () => AgentFrameworkId
+  ensureConnected: (cwd: string) => Promise<ClientConnection>
+  assertCurrentConnection: (connection: ClientConnection) => void
+  registry: Pick<AcpSessionRegistry, 'lookup' | 'detach' | 'ensureAffinity'>
+  reserveIdentity: (
+    sessionId: string,
+    publishedAppSessionId?: string
+  ) => AcpPrimarySessionIdentityReservationResult
+  adopter: Pick<AcpProviderSessionAdopter, 'adopt'>
+  permission: Pick<AcpPermissionContext, 'cancelForSession'>
+  promptContent: Pick<AcpPromptContentOwner, 'resetSession'>
+  contextUsage: Pick<ContextUsageTracker, 'deleteSession'>
+  interactions: Pick<AcpSessionInteractionOwner, 'current' | 'supersedeCurrent'>
+  resolveSpecialistIdentity?: (
+    specialistId: string,
+    frameworkId: AgentFrameworkId
+  ) => Promise<{ append: string; prefix: string } | undefined>
+  registerSessionSpecialist?: (sessionId: string, specialistId: string | undefined) => void
+}>
+
+export class AcpSessionReplacementWorkflow {
+  constructor(private readonly deps: AcpSessionReplacementWorkflowDependencies) {}
+
+  // Coordinates owner cleanup without retaining Session facts; the Registry and each state owner
+  // remain authoritative while the Adopter publishes the replacement provider Session.
+  async reset(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
+    const cwd = resolve(request.cwd || this.deps.currentCwd() || this.deps.defaultCwd)
+    const projectName = request.projectName?.trim() || this.deps.defaultProjectName
+    const publishedSession = this.deps.registry.lookup(request.sessionId)?.attachment?.session
+    const reserved = this.deps.reserveIdentity(
+      request.sessionId,
+      publishedSession ? request.sessionId : undefined
+    )
+    if (reserved.collision) throw reserved.collision
+    const identity = reserved.reservation
+
+    try {
+      const connection = await this.deps.ensureConnected(cwd)
+      this.deps.assertCurrentConnection(connection)
+      const currentPublishedSession = this.deps.registry.lookup(request.sessionId)?.attachment
+        ?.session
+      const crossedGeneration = identity.renew(
+        currentPublishedSession === publishedSession && currentPublishedSession
+          ? request.sessionId
+          : undefined
+      )
+      const reconnectReplacedPublishedSession =
+        publishedSession !== undefined && currentPublishedSession === undefined && crossedGeneration
+      if (currentPublishedSession !== publishedSession && !reconnectReplacedPublishedSession) {
+        throw new Error('ACP session startup was superseded.')
+      }
+
+      this.deps.permission.cancelForSession(request.sessionId)
+      const attachment = this.deps.registry.lookup(request.sessionId)?.attachment
+      if (attachment) {
+        attachment.session.dispose()
+        this.deps.registry.detach(attachment, 'provider')
+      }
+      this.deps.promptContent.resetSession(request.sessionId)
+      this.deps.contextUsage.deleteSession(request.sessionId)
+      this.deps.registry.lookup(request.sessionId)?.aggregate.clearAppliedModel()
+      this.deps.interactions.supersedeCurrent(request.sessionId)
+
+      // Await inside the reservation scope: adoption extends the same identity to the new provider id.
+      return await this.deps.adopter.adopt(request.sessionId, {
+        connection,
+        cwd,
+        projectName,
+        identity,
+        permissionProfile: request.permissionProfile,
+        specialistId: request.specialistId
+      })
+    } finally {
+      identity.release()
+    }
+  }
+
+  async switchSpecialist(
+    sessionId: string,
+    specialistId: string | undefined
+  ): Promise<{ contextReset: boolean }> {
+    if (this.deps.interactions.current(sessionId)) {
+      throw new Error('Cannot switch specialist while the Agent is running.')
+    }
+
+    const { aggregate } = this.deps.registry.ensureAffinity(sessionId)
+    // Projection is intentionally eager and is not rolled back if identity resolution or reset fails.
+    aggregate.setSpecialistId(specialistId)
+
+    if (specialistId !== undefined && this.deps.resolveSpecialistIdentity) {
+      const identity = await this.deps.resolveSpecialistIdentity(
+        specialistId,
+        this.deps.currentFrameworkId()
+      )
+      aggregate.setSpecialistPrefix(identity?.prefix || undefined)
+    } else {
+      aggregate.setSpecialistPrefix(undefined)
+    }
+
+    this.deps.registerSessionSpecialist?.(sessionId, specialistId)
+
+    const requiresContextReset =
+      this.deps.currentFrameworkId() === 'claude-code' &&
+      this.deps.registry.lookup(sessionId)?.attachment !== undefined
+    if (requiresContextReset) {
+      const snapshot = aggregate.snapshot()
+      await this.reset({
+        sessionId,
+        cwd: snapshot.cwd,
+        projectName: snapshot.projectName,
+        ...(snapshot.permissionProfile?.selectedProfile
+          ? { permissionProfile: snapshot.permissionProfile.selectedProfile }
+          : {})
+      } as AcpResumeSessionRequest)
+    }
+
+    return { contextReset: requiresContextReset }
+  }
+}
+
+export type { AcpSessionReplacementWorkflowDependencies }


### PR DESCRIPTION
## Problem

ACP Runtime still owned the complete context-replacement transaction and live Specialist-switch policy. That kept stable application Session identity, provider attachment replacement, and cleanup sequencing coupled to the Runtime facade as the file continued to grow.

## Proposed change

Add a stateless `AcpSessionReplacementWorkflow` and delegate the two existing Runtime entry points to it:

- explicit context reset;
- live Specialist switch, including Claude-only provider Session replacement.

The workflow coordinates existing owners and delegates fresh provider publication to `AcpProviderSessionAdopter`; it does not become a new fact store.

## Scope and non-goals

- Preserve the public Runtime, Coordinator, IPC, shared type, and response contracts.
- Preserve stable application Session IDs and replaceable provider protocol Session IDs.
- Preserve Claude live-switch reset and Codex/OpenCode prefix-only behavior.
- Preserve Permission grants while cancelling old provider requests/correlations.
- Preserve #754 replay, Notebook continuity, and staged Claude handoff behavior in their existing owners.
- Do not change persistence, data models, Electron/Web/CLI/Task capabilities, user interaction, Specialist management, Permission policy, or Compute behavior.
- Do not implement Issue #458 orchestration interfaces or durable orchestration state.

## Ownership and sequence

```mermaid
sequenceDiagram
    participant Runtime
    participant Replacement as Session Replacement Workflow
    participant Registry
    participant Owners as Permission / Prompt / Context / Interaction
    participant Adopter as Provider Session Adopter

    Runtime->>Replacement: reset(request) under operation lease
    Replacement->>Registry: reserve stable App Session ID
    Replacement->>Registry: renew and verify generation
    Replacement->>Owners: cancel/reset/supersede old provider state
    Replacement->>Registry: dispose provider and detach reverse alias
    Replacement->>Adopter: adopt with the same App Session ID
    Adopter->>Registry: publish replacement provider attachment
    Replacement->>Registry: release reservation in finally
    Replacement-->>Runtime: existing contextReset response
```

Production raw is 334 lines, within the ARD-21 330–450 target and below the 550 hard split threshold. `runtime.ts` decreases from 3,267 to 3,121 lines.

## Acceptance criteria and validation

All listed checks ran after the final material edit and after rebasing onto `origin/main` `c3eae9d3`.

- Replacement transaction plus Runtime application-command, IPC, and Coordinator facades -> targeted four-file Vitest set -> 97/97 passed (including workflow 6/6).
- Runtime reset/Specialist/replacement integration -> targeted `src/main/acp/runtime.test.ts` selection -> 18/18 sandbox-compatible tests passed; the loopback context-reset case passed separately outside the sandbox (1/1).
- Latest-main Web remote-access compatibility (#767) -> `npm test -- --run src/main/remote-access/pairing.test.ts` -> 5/5 passed.
- Node process contracts -> `npm run typecheck:node` -> passed.
- Changed source/test lint -> ESLint -> 0 findings.
- Changed source/test formatting -> Prettier check -> passed.
- Patch integrity -> `git diff --check` -> passed.
- Manual Standards review -> 0 findings.
- Manual Spec/compatibility review -> 0 findings.

## Review focus

- The reservation remains live through asynchronous adoption and is released on every outcome.
- Cleanup order prevents old provider aliases, Permission correlation, media usage, context usage, applied model, or stale interaction cleanup from reaching the replacement turn.
- Specialist projection remains intentionally eager/non-transactional, matching existing behavior.
- The workflow coordinates owners without duplicating their state or adoption logic.

## Uncovered risks

- The complete local suite was not rerun on the exact head; the online PR Gate is authoritative for the full platform and consumer matrix.
- Cross-platform process/runtime behavior remains CI-covered rather than reproduced locally.
- Future Issue #458 orchestration remains constrained to consume existing application interfaces; this PR introduces no orchestration API, schema, wire format, or UI.
