### PR TITLE
fix(markdown): restore session link color

### DIFF
--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -547,7 +547,7 @@
   }
 
   [data-session-message-link] {
-    @apply cursor-pointer appearance-none border-0 bg-transparent p-0 text-left font-medium text-sd-link underline underline-offset-2 transition-colors duration-150 ease-out;
+    @apply cursor-pointer appearance-none border-0 bg-transparent p-0 text-left font-medium text-primary underline underline-offset-2 transition-colors duration-150 ease-out;
     display: inline;
     font: inherit;
     font-weight: 500;


### PR DESCRIPTION
## Problem

The Session Message link renderer introduced in #770 explicitly used `text-sd-link`, which maps to the warm orange-red Streamdown link token. Session links are expected to retain the app's existing green brand color.

## Proposed change

- Replace the Session Message link's default `text-sd-link` utility with the existing semantic `text-primary` utility.
- Keep favicon behavior, hover/focus/active states, caching, and the external-link safety dialog unchanged.

## Scope / non-goals

- One CSS utility change in the Session Message-only selector.
- No architecture, IPC, data-model, dependency, or non-session Markdown changes.

## Acceptance criteria / validation

- [x] Compiled CSS resolves the default Session Message link color to `var(--primary)`.
- [x] `rtk npm run typecheck:web`.
- [x] `rtk npm run lint` — 0 errors; 17 pre-existing warnings.
- [x] Renderer production build — passed; existing 3Dmol `eval` and chunk-size warnings only.
- [x] Full `rtk npm test` executed — 11,354 passed, 184 skipped, and the same 3 local baseline failures in `src/main/acp/claude-agent-acp-patch.test.ts`.

## Review focus

- Confirm the default Session Message link color now inherits the app's green `primary` token.
- Confirm hover and favicon behavior are otherwise unchanged.
