### PR TITLE
refactor(acp): extract session deletion workflow

### DIFF
--- a/src/main/acp/codex-skill-activity.test.ts
+++ b/src/main/acp/codex-skill-activity.test.ts
@@ -175,4 +175,43 @@ describe('CodexSkillActivityProjector', () => {
     expect(chemistryCompletion).not.toHaveProperty('rawOutput')
     expect(pubmedCompletion).not.toHaveProperty('rawOutput')
   })
+
+  it('clears only the deleted Session lifecycle while retaining another Session', () => {
+    const skillsRoot = join('/data', 'codex-subscription', 'skills')
+    const projector = new CodexSkillActivityProjector(skillsRoot)
+
+    for (const [sessionId, skillName] of [
+      ['session-a', 'mcp-pubmed'],
+      ['session-b', 'mcp-chemistry']
+    ] as const) {
+      projector.project(
+        toolEvent({
+          sessionId,
+          toolCallId: 'shared-call-id',
+          toolKind: 'read',
+          status: 'in_progress',
+          toolLocations: [{ path: join(skillsRoot, skillName, 'SKILL.md') }]
+        })
+      )
+    }
+
+    projector.clearSession('session-a')
+    const deletedCompletion = projector.project(
+      toolEvent({
+        sessionId: 'session-a',
+        toolCallId: 'shared-call-id',
+        status: 'completed'
+      })
+    )
+    const retainedCompletion = projector.project(
+      toolEvent({
+        sessionId: 'session-b',
+        toolCallId: 'shared-call-id',
+        status: 'completed'
+      })
+    )
+
+    expect(deletedCompletion.title).toBeUndefined()
+    expect(retainedCompletion.title).toBe('Loaded skill: mcp-chemistry')
+  })
 })

--- a/src/main/acp/codex-skill-activity.ts
+++ b/src/main/acp/codex-skill-activity.ts
@@ -68,7 +68,10 @@ const lifecycleKey = (event: AcpRuntimeEvent): string =>
 // Connector; it only replaces the exact app-owned SKILL.md read lifecycle with a name-only activity.
 class CodexSkillActivityProjector {
   private skillsRoot: string | undefined
-  private readonly activeSkills = new Map<string, CodexSkillFile>()
+  private readonly activeSkills = new Map<
+    string,
+    Readonly<{ sessionId: string; skillFile: CodexSkillFile }>
+  >()
 
   constructor(skillsRoot?: string) {
     this.skillsRoot = skillsRoot ? resolve(skillsRoot) : undefined
@@ -86,6 +89,12 @@ class CodexSkillActivityProjector {
     this.activeSkills.clear()
   }
 
+  clearSession(sessionId: string): void {
+    for (const [key, activity] of this.activeSkills) {
+      if (activity.sessionId === sessionId) this.activeSkills.delete(key)
+    }
+  }
+
   project(event: AcpRuntimeEvent): AcpRuntimeEvent {
     return this.projectWithContext(event).event
   }
@@ -95,9 +104,14 @@ class CodexSkillActivityProjector {
 
     const key = lifecycleKey(event)
     const detectedSkill = exactSkillFile(this.skillsRoot, event)
-    if (detectedSkill) this.activeSkills.set(key, detectedSkill)
+    if (detectedSkill) {
+      this.activeSkills.set(key, {
+        sessionId: event.sessionId ?? '',
+        skillFile: detectedSkill
+      })
+    }
 
-    const skillFile = detectedSkill ?? this.activeSkills.get(key)
+    const skillFile = detectedSkill ?? this.activeSkills.get(key)?.skillFile
     if (!skillFile) return { event }
 
     if (event.status === 'completed' || event.status === 'failed' || event.status === 'cancelled') {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -112,8 +112,7 @@ import {
 import {
   AcpSessionRegistry,
   type AcpPrimarySessionIdentityReservation,
-  type AcpPrimarySessionIdentityReservationResult,
-  type AcpSessionDeletion
+  type AcpPrimarySessionIdentityReservationResult
 } from './session-registry'
 import {
   AcpConnectionResourceOwner,
@@ -140,6 +139,7 @@ import { AcpProviderSessionCreator } from './provider-session-creator'
 import { AcpProviderSessionAdopter } from './provider-session-adopter'
 import { AcpProviderSessionResumer } from './provider-session-resumer'
 import { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
+import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
 import {
   AcpTurnSkillOwner,
   type AcpTurnSkillHooks,
@@ -420,6 +420,7 @@ class AcpRuntime {
   private readonly providerSessionAdopter: AcpProviderSessionAdopter
   private readonly providerSessionResumer: AcpProviderSessionResumer
   private readonly sessionReplacement: AcpSessionReplacementWorkflow
+  private readonly sessionDeletion: AcpSessionDeletionWorkflow
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(private readonly options: AcpRuntimeOptions) {
@@ -725,6 +726,23 @@ class AcpRuntime {
       resolveSpecialistIdentity: options.resolveSpecialistIdentity,
       registerSessionSpecialist: options.notebook?.registerSessionSpecialist
     })
+    this.sessionDeletion = new AcpSessionDeletionWorkflow({
+      registry: this.sessionRegistry,
+      withOperation: (work) => this.withOperationLease(work),
+      currentConnection: () => this.connection,
+      supportsSessionDelete: () => this.connectionResources.capabilities.delete,
+      supportsSessionClose: () => this.connectionResources.capabilities.close,
+      permission: this.permissionContext,
+      interactions: this.sessionInteractions,
+      capabilities: this.sessionCapabilities,
+      promptContent: this.promptContentOwner,
+      handoff: this.handoffContinuity,
+      contextUsage: this.contextUsageTracker,
+      projector: this.sessionUpdateProjector,
+      pushEvent: (event) => this.pushEvent(event),
+      emitState: () => this.emitState(),
+      getSnapshot: () => this.getSnapshot()
+    })
     this.providerSessionResumer = new AcpProviderSessionResumer({
       defaultCwd: options.defaultCwd,
       defaultProjectName: options.artifacts?.projectName || DEFAULT_UPLOAD_PROJECT_NAME,
@@ -783,14 +801,6 @@ class AcpRuntime {
 
   private get connectionGeneration(): number {
     return this.connectionResources.epoch
-  }
-
-  private get supportsSessionClose(): boolean {
-    return this.connectionResources.capabilities.close
-  }
-
-  private get supportsSessionDelete(): boolean {
-    return this.connectionResources.capabilities.delete
   }
 
   private activeSessionFor(appSessionId: string): ActiveSession | undefined {
@@ -2236,69 +2246,7 @@ class AcpRuntime {
 
   // Closes the agent-side session when supported, then removes local routing state.
   async deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot> {
-    const deletion = this.sessionRegistry.beginDelete(request.sessionId)
-    try {
-      return await this.withOperationLease(() => this.deleteSessionOperation(request, deletion))
-    } finally {
-      deletion.finish()
-    }
-  }
-
-  private async deleteSessionOperation(
-    request: AcpDeleteSessionRequest,
-    deletion: AcpSessionDeletion
-  ): Promise<AcpStateSnapshot> {
-    const target = this.sessionRegistry.lookup(request.sessionId)
-    const session = target?.attachment?.session
-
-    this.cancelPermissionFlowForSession(request.sessionId)
-
-    if (session) {
-      // Talk to the agent using its own session id: for an adopted session the underlying
-      // agent id (session.sessionId) differs from the app-facing request.sessionId.
-      if (this.connection && this.supportsSessionDelete) {
-        await this.connection.agent.request(acp.methods.agent.session.delete, {
-          sessionId: session.sessionId
-        })
-      } else if (this.connection && this.supportsSessionClose) {
-        await this.connection.agent.request(acp.methods.agent.session.close, {
-          sessionId: session.sessionId
-        })
-      } else {
-        await this.connection?.agent.notify(acp.methods.agent.session.cancel, {
-          sessionId: session.sessionId
-        })
-      }
-
-      session.dispose()
-      if (target?.attachment) this.sessionRegistry.detach(target.attachment, 'provider')
-    }
-
-    // App-session-keyed cleanup runs whether or not a live session is attached. A framework switch
-    // A disconnect detaches the provider but deliberately keeps framework/backend affinity, so deleting
-    // a session that was never re-adopted must remove its remaining Aggregate as well.
-    this.permissionContext.clearSession(request.sessionId)
-    this.sessionInteractions.supersedeCurrent(request.sessionId)
-    // Drop this session's MCP routes, aliases, and bearer ownership (idempotent for detached deletes).
-    this.sessionCapabilities.revokeSession(request.sessionId)
-    const removal = deletion.finish(target)
-    this.promptContentOwner.resetSession(request.sessionId)
-    this.handoffContinuity.clearSession(request.sessionId)
-    this.contextUsageTracker.deleteSession(request.sessionId)
-
-    // Only announce a deletion and shift the current session when something was actually attached; a
-    // detached cleanup (post-switch) must not emit a spurious event or move the current selection.
-    if (removal.wasActive) {
-      this.pushEvent({
-        kind: 'system',
-        level: 'info',
-        sessionId: request.sessionId,
-        title: 'Session deleted'
-      })
-      this.emitState()
-    }
-
-    return this.getSnapshot()
+    return this.sessionDeletion.delete(request.sessionId)
   }
 
   // Resolves or cancels one pending permission request from the renderer.

--- a/src/main/acp/session-deletion-workflow.test.ts
+++ b/src/main/acp/session-deletion-workflow.test.ts
@@ -1,0 +1,375 @@
+import * as acp from '@agentclientprotocol/sdk'
+import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpStateSnapshot } from '../../shared/acp'
+import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
+import { AcpSessionRegistry, type AcpSessionRegistryEntry } from './session-registry'
+
+const publishSession = (
+  registry: AcpSessionRegistry,
+  appSessionId: string,
+  providerSessionId: string,
+  dispose: () => void = vi.fn()
+): ActiveSession => {
+  const session = { sessionId: providerSessionId, dispose } as unknown as ActiveSession
+  const reserved = registry.reserve({ sessionIds: [appSessionId, providerSessionId] })
+  if (reserved.collision) throw reserved.collision
+  registry.publish(reserved.reservation, appSessionId, {
+    session,
+    cwd: '/workspace',
+    projectName: 'project',
+    frameworkId: 'claude-code',
+    permissionProfile: {
+      selectedProfile: 'ask',
+      effectiveProfile: 'ask',
+      availableModeIds: ['default'],
+      fullAccessAvailable: false
+    }
+  })
+  reserved.reservation.release()
+  return session
+}
+
+const snapshot = (registry: AcpSessionRegistry): AcpStateSnapshot =>
+  ({
+    sessionId: registry.currentSessionId,
+    sessionIds: registry.entries(true).map(({ appSessionId }) => appSessionId)
+  }) as AcpStateSnapshot
+
+const dependencies = (
+  registry: AcpSessionRegistry,
+  connection: ClientConnection | undefined,
+  capabilities: Readonly<{ delete: boolean; close: boolean }>
+): ConstructorParameters<typeof AcpSessionDeletionWorkflow>[0] => ({
+  registry,
+  withOperation: (work) => work(),
+  currentConnection: () => connection,
+  supportsSessionDelete: () => capabilities.delete,
+  supportsSessionClose: () => capabilities.close,
+  permission: { cancelForSession: vi.fn(), clearSession: vi.fn() },
+  interactions: { supersedeCurrent: vi.fn() },
+  capabilities: { revokeSession: vi.fn() },
+  promptContent: { resetSession: vi.fn() },
+  handoff: { clearSession: vi.fn() },
+  contextUsage: { deleteSession: vi.fn() },
+  projector: { clearSession: vi.fn() },
+  pushEvent: vi.fn(),
+  emitState: vi.fn(),
+  getSnapshot: () => snapshot(registry)
+})
+
+describe('AcpSessionDeletionWorkflow', () => {
+  it('deletes an attached provider Session and cleans each app-owned Session interface in order', async () => {
+    const actions: string[] = []
+    const registry = new AcpSessionRegistry()
+    publishSession(registry, 'app-a', 'provider-a')
+    const dispose = vi.fn(() => actions.push('dispose'))
+    publishSession(registry, 'app-b', 'provider-b', dispose)
+    const request = vi.fn(async () => {
+      actions.push('provider-request')
+      return {}
+    })
+    const notify = vi.fn(async () => undefined)
+    const connection = { agent: { request, notify } } as unknown as ClientConnection
+    const pushEvent = vi.fn(() => actions.push('event'))
+    const emitState = vi.fn(() => actions.push('emit'))
+    const workflow = new AcpSessionDeletionWorkflow({
+      registry,
+      withOperation: async (work) => {
+        actions.push('operation')
+        return work()
+      },
+      currentConnection: () => connection,
+      supportsSessionDelete: () => true,
+      supportsSessionClose: () => true,
+      permission: {
+        cancelForSession: vi.fn(() => actions.push('permission-cancel')),
+        clearSession: vi.fn(() => actions.push('permission-clear'))
+      },
+      interactions: { supersedeCurrent: vi.fn(() => actions.push('interaction')) },
+      capabilities: { revokeSession: vi.fn(() => actions.push('capability')) },
+      promptContent: { resetSession: vi.fn(() => actions.push('prompt-content')) },
+      handoff: { clearSession: vi.fn(() => actions.push('handoff')) },
+      contextUsage: { deleteSession: vi.fn(() => actions.push('context')) },
+      projector: { clearSession: vi.fn(() => actions.push('projector')) },
+      pushEvent,
+      emitState,
+      getSnapshot: () => {
+        actions.push('snapshot')
+        return snapshot(registry)
+      }
+    })
+
+    await expect(workflow.delete('app-b')).resolves.toMatchObject({
+      sessionId: 'app-a',
+      sessionIds: ['app-a']
+    })
+
+    expect(request).toHaveBeenCalledWith(acp.methods.agent.session.delete, {
+      sessionId: 'provider-b'
+    })
+    expect(notify).not.toHaveBeenCalled()
+    expect(dispose).toHaveBeenCalledOnce()
+    expect(registry.lookup('app-b')).toBeUndefined()
+    expect(pushEvent).toHaveBeenCalledWith({
+      kind: 'system',
+      level: 'info',
+      sessionId: 'app-b',
+      title: 'Session deleted'
+    })
+    expect(emitState).toHaveBeenCalledOnce()
+    expect(actions).toEqual([
+      'operation',
+      'permission-cancel',
+      'provider-request',
+      'dispose',
+      'permission-clear',
+      'interaction',
+      'capability',
+      'prompt-content',
+      'handoff',
+      'context',
+      'projector',
+      'event',
+      'emit',
+      'snapshot'
+    ])
+  })
+
+  it('uses provider close when delete is not advertised', async () => {
+    const registry = new AcpSessionRegistry()
+    publishSession(registry, 'app-session', 'provider-session')
+    const request = vi.fn(async () => ({}))
+    const notify = vi.fn(async () => undefined)
+    const connection = { agent: { request, notify } } as unknown as ClientConnection
+    const workflow = new AcpSessionDeletionWorkflow(
+      dependencies(registry, connection, { delete: false, close: true })
+    )
+
+    await workflow.delete('app-session')
+
+    expect(request).toHaveBeenCalledOnce()
+    expect(request).toHaveBeenCalledWith(acp.methods.agent.session.close, {
+      sessionId: 'provider-session'
+    })
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('uses provider cancel when neither delete nor close is advertised', async () => {
+    const registry = new AcpSessionRegistry()
+    publishSession(registry, 'app-session', 'provider-session')
+    const request = vi.fn(async () => ({}))
+    const notify = vi.fn(async () => undefined)
+    const connection = { agent: { request, notify } } as unknown as ClientConnection
+    const workflow = new AcpSessionDeletionWorkflow(
+      dependencies(registry, connection, { delete: false, close: false })
+    )
+
+    await workflow.delete('app-session')
+
+    expect(request).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledOnce()
+    expect(notify).toHaveBeenCalledWith(acp.methods.agent.session.cancel, {
+      sessionId: 'provider-session'
+    })
+  })
+
+  it('removes detached affinity and local state without publishing an active deletion', async () => {
+    const registry = new AcpSessionRegistry()
+    publishSession(registry, 'app-session', 'provider-session')
+    const attachment = registry.lookup('app-session')?.attachment
+    if (!attachment) throw new Error('expected an attached Session')
+    registry.detach(attachment, 'connection')
+    const deps = dependencies(registry, undefined, { delete: true, close: true })
+    const workflow = new AcpSessionDeletionWorkflow(deps)
+
+    await expect(workflow.delete('app-session')).resolves.toMatchObject({
+      sessionIds: []
+    })
+
+    expect(registry.lookup('app-session')).toBeUndefined()
+    expect(deps.permission.cancelForSession).toHaveBeenCalledWith('app-session')
+    expect(deps.permission.clearSession).toHaveBeenCalledWith('app-session')
+    expect(deps.interactions.supersedeCurrent).toHaveBeenCalledWith('app-session')
+    expect(deps.capabilities.revokeSession).toHaveBeenCalledWith('app-session')
+    expect(deps.promptContent.resetSession).toHaveBeenCalledWith('app-session')
+    expect(deps.handoff.clearSession).toHaveBeenCalledWith('app-session')
+    expect(deps.contextUsage.deleteSession).toHaveBeenCalledWith('app-session')
+    expect(deps.projector.clearSession).toHaveBeenCalledWith('app-session')
+    expect(deps.pushEvent).not.toHaveBeenCalled()
+    expect(deps.emitState).not.toHaveBeenCalled()
+  })
+
+  it('preserves a provider deletion failure without falling through or clearing local ownership', async () => {
+    const registry = new AcpSessionRegistry()
+    const dispose = vi.fn()
+    publishSession(registry, 'app-session', 'provider-session', dispose)
+    const providerFailure = new Error('provider delete failed')
+    const request = vi.fn(async () => {
+      throw providerFailure
+    })
+    const notify = vi.fn(async () => undefined)
+    const connection = { agent: { request, notify } } as unknown as ClientConnection
+    const deps = dependencies(registry, connection, { delete: true, close: true })
+    const workflow = new AcpSessionDeletionWorkflow(deps)
+
+    await expect(workflow.delete('app-session')).rejects.toBe(providerFailure)
+
+    expect(request).toHaveBeenCalledOnce()
+    expect(request).toHaveBeenCalledWith(acp.methods.agent.session.delete, {
+      sessionId: 'provider-session'
+    })
+    expect(notify).not.toHaveBeenCalled()
+    expect(dispose).not.toHaveBeenCalled()
+    expect(registry.lookup('app-session')?.attachment?.providerSessionId).toBe('provider-session')
+    expect(deps.permission.cancelForSession).toHaveBeenCalledWith('app-session')
+    expect(deps.permission.clearSession).not.toHaveBeenCalled()
+    expect(deps.capabilities.revokeSession).not.toHaveBeenCalled()
+    expect(deps.interactions.supersedeCurrent).not.toHaveBeenCalled()
+    expect(deps.promptContent.resetSession).not.toHaveBeenCalled()
+    expect(deps.handoff.clearSession).not.toHaveBeenCalled()
+    expect(deps.contextUsage.deleteSession).not.toHaveBeenCalled()
+    expect(deps.projector.clearSession).not.toHaveBeenCalled()
+    expect(deps.pushEvent).not.toHaveBeenCalled()
+
+    const retry = registry.reserve({
+      sessionIds: ['app-session'],
+      publishedAppSessionId: 'app-session'
+    })
+    expect(retry.collision).toBeUndefined()
+    retry.reservation?.release()
+  })
+
+  it('holds the deletion epoch while the operation lease waits behind a barrier', async () => {
+    const registry = new AcpSessionRegistry()
+    publishSession(registry, 'app-session', 'provider-session')
+    let releaseBarrier!: () => void
+    const barrier = new Promise<void>((resolve) => {
+      releaseBarrier = resolve
+    })
+    const deps = dependencies(registry, undefined, { delete: false, close: false })
+    const workflow = new AcpSessionDeletionWorkflow({
+      ...deps,
+      withOperation: async (work) => {
+        await barrier
+        return work()
+      }
+    })
+
+    const deleting = workflow.delete('app-session')
+    expect(registry.reserve({ sessionIds: ['app-session'] }).collision?.message).toBe(
+      'Primary session id collision with deletion in progress: app-session'
+    )
+
+    releaseBarrier()
+    await deleting
+
+    const afterDelete = registry.reserve({ sessionIds: ['app-session'] })
+    expect(afterDelete.collision).toBeUndefined()
+    afterDelete.reservation?.release()
+  })
+
+  it('does not let stale deletion cleanup erase a same-ID replacement', async () => {
+    const oldDispose = vi.fn()
+    const oldSession = {
+      sessionId: 'provider-old',
+      dispose: oldDispose
+    } as unknown as ActiveSession
+    const replacementSession = {
+      sessionId: 'provider-new',
+      dispose: vi.fn()
+    } as unknown as ActiveSession
+    const entry = (generation: number, session: ActiveSession): AcpSessionRegistryEntry =>
+      ({
+        appSessionId: 'app-session',
+        generation,
+        aggregate: {},
+        attachment: {
+          appSessionId: 'app-session',
+          providerSessionId: session.sessionId,
+          generation,
+          session
+        }
+      }) as unknown as AcpSessionRegistryEntry
+    const original = entry(1, oldSession)
+    const replacement = entry(2, replacementSession)
+    let current = original
+    const removal = { removed: false, wasActive: false, currentSessionId: 'app-session' }
+    const finish = vi.fn(() => removal)
+    const detach = vi.fn(() => false)
+    const fakeRegistry = {
+      beginDelete: vi.fn(() => ({ finish })),
+      lookup: vi.fn(() => current),
+      detach
+    } as unknown as AcpSessionRegistry
+    const request = vi.fn(async () => {
+      current = replacement
+      return {}
+    })
+    const connection = {
+      agent: { request, notify: vi.fn(async () => undefined) }
+    } as unknown as ClientConnection
+    const deps = {
+      ...dependencies(fakeRegistry, connection, { delete: true, close: true }),
+      getSnapshot: () =>
+        ({ sessionId: 'app-session', sessionIds: ['app-session'] }) as AcpStateSnapshot
+    }
+    const workflow = new AcpSessionDeletionWorkflow(deps)
+
+    await expect(workflow.delete('app-session')).resolves.toMatchObject({
+      sessionIds: ['app-session']
+    })
+
+    expect(oldDispose).toHaveBeenCalledOnce()
+    expect(detach).toHaveBeenCalledWith(original.attachment, 'provider')
+    expect(current).toBe(replacement)
+    expect(finish).toHaveBeenCalledWith(original)
+    expect(deps.permission.cancelForSession).toHaveBeenCalledWith('app-session')
+    expect(deps.permission.clearSession).not.toHaveBeenCalled()
+    expect(deps.interactions.supersedeCurrent).not.toHaveBeenCalled()
+    expect(deps.capabilities.revokeSession).not.toHaveBeenCalled()
+    expect(deps.promptContent.resetSession).not.toHaveBeenCalled()
+    expect(deps.handoff.clearSession).not.toHaveBeenCalled()
+    expect(deps.contextUsage.deleteSession).not.toHaveBeenCalled()
+    expect(deps.projector.clearSession).not.toHaveBeenCalled()
+    expect(deps.pushEvent).not.toHaveBeenCalled()
+    expect(deps.emitState).not.toHaveBeenCalled()
+  })
+
+  it('does not announce success or clear local owners when provider Session disposal fails', async () => {
+    const registry = new AcpSessionRegistry()
+    const disposeFailure = new Error('provider Session disposal failed')
+    publishSession(registry, 'app-session', 'provider-session', () => {
+      throw disposeFailure
+    })
+    const request = vi.fn(async () => ({}))
+    const connection = {
+      agent: { request, notify: vi.fn(async () => undefined) }
+    } as unknown as ClientConnection
+    const deps = dependencies(registry, connection, { delete: true, close: true })
+    const workflow = new AcpSessionDeletionWorkflow(deps)
+
+    await expect(workflow.delete('app-session')).rejects.toBe(disposeFailure)
+
+    expect(request).toHaveBeenCalledOnce()
+    expect(registry.lookup('app-session')?.attachment?.providerSessionId).toBe('provider-session')
+    expect(deps.permission.cancelForSession).toHaveBeenCalledWith('app-session')
+    expect(deps.permission.clearSession).not.toHaveBeenCalled()
+    expect(deps.capabilities.revokeSession).not.toHaveBeenCalled()
+    expect(deps.interactions.supersedeCurrent).not.toHaveBeenCalled()
+    expect(deps.promptContent.resetSession).not.toHaveBeenCalled()
+    expect(deps.handoff.clearSession).not.toHaveBeenCalled()
+    expect(deps.contextUsage.deleteSession).not.toHaveBeenCalled()
+    expect(deps.projector.clearSession).not.toHaveBeenCalled()
+    expect(deps.pushEvent).not.toHaveBeenCalled()
+    expect(deps.emitState).not.toHaveBeenCalled()
+
+    const retry = registry.reserve({
+      sessionIds: ['app-session'],
+      publishedAppSessionId: 'app-session'
+    })
+    expect(retry.collision).toBeUndefined()
+    retry.reservation?.release()
+  })
+})

--- a/src/main/acp/session-deletion-workflow.ts
+++ b/src/main/acp/session-deletion-workflow.ts
@@ -1,0 +1,122 @@
+import * as acp from '@agentclientprotocol/sdk'
+import type { ClientConnection } from '@agentclientprotocol/sdk'
+
+import type { AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
+import type { ContextUsageTracker } from './context-usage-tracker'
+import type { AcpHandoffContinuityOwner } from './handoff-continuity-owner'
+import type { AcpPermissionContext } from './permission-context'
+import type { AcpPromptContentOwner } from './prompt-content-owner'
+import type { AcpSessionCapabilityOwner } from './session-capability-owner'
+import type { AcpSessionInteractionOwner } from './session-interaction-owner'
+import type { AcpSessionRegistry, AcpSessionRegistryEntry } from './session-registry'
+import type { AcpSessionUpdateProjector } from './session-update-projector'
+
+type SessionDeletedEvent = Omit<AcpRuntimeEvent, 'id' | 'timestamp'>
+type OperationLease = <Result>(work: () => Promise<Result>) => Promise<Result>
+
+type AcpSessionDeletionWorkflowDependencies = Readonly<{
+  registry: Pick<AcpSessionRegistry, 'beginDelete' | 'lookup' | 'detach'>
+  withOperation: OperationLease
+  currentConnection: () => ClientConnection | undefined
+  supportsSessionDelete: () => boolean
+  supportsSessionClose: () => boolean
+  permission: Pick<AcpPermissionContext, 'cancelForSession' | 'clearSession'>
+  interactions: Pick<AcpSessionInteractionOwner, 'supersedeCurrent'>
+  capabilities: Pick<AcpSessionCapabilityOwner, 'revokeSession'>
+  promptContent: Pick<AcpPromptContentOwner, 'resetSession'>
+  handoff: Pick<AcpHandoffContinuityOwner, 'clearSession'>
+  contextUsage: Pick<ContextUsageTracker, 'deleteSession'>
+  projector: Pick<AcpSessionUpdateProjector, 'clearSession'>
+  pushEvent: (event: SessionDeletedEvent) => void
+  emitState: () => void
+  getSnapshot: () => AcpStateSnapshot
+}>
+
+// Statelessly sequences provider teardown and app-keyed cleanup. The Registry owns identity,
+// deletion epochs, and selection; each injected owner cleans only the state it created.
+class AcpSessionDeletionWorkflow {
+  constructor(private readonly deps: AcpSessionDeletionWorkflowDependencies) {}
+
+  async delete(appSessionId: string): Promise<AcpStateSnapshot> {
+    // Begin synchronously before a reconnect/model barrier can delay the operation lease. This keeps
+    // same-ID startup blocked for the entire queued deletion, not only after provider work begins.
+    const deletion = this.deps.registry.beginDelete(appSessionId)
+    try {
+      return await this.deps.withOperation(() => this.deleteWithLease(appSessionId, deletion))
+    } finally {
+      deletion.finish()
+    }
+  }
+
+  private async deleteWithLease(
+    appSessionId: string,
+    deletion: ReturnType<AcpSessionRegistry['beginDelete']>
+  ): Promise<AcpStateSnapshot> {
+    const target = this.deps.registry.lookup(appSessionId)
+    const attachment = target?.attachment
+
+    this.deps.permission.cancelForSession(appSessionId)
+    if (attachment) await this.deleteProviderSession(attachment.session.sessionId)
+
+    if (attachment) {
+      attachment.session.dispose()
+      this.deps.registry.detach(attachment, 'provider')
+    }
+
+    // No await occurs between this ownership check and local cleanup. A stale captured generation
+    // may dispose its own provider object, but cannot erase app-keyed state owned by a replacement.
+    if (!this.stillOwnsTarget(appSessionId, target)) {
+      deletion.finish(target)
+      return this.deps.getSnapshot()
+    }
+
+    this.deps.permission.clearSession(appSessionId)
+    this.deps.interactions.supersedeCurrent(appSessionId)
+    this.deps.capabilities.revokeSession(appSessionId)
+    const removal = deletion.finish(target)
+    this.deps.promptContent.resetSession(appSessionId)
+    this.deps.handoff.clearSession(appSessionId)
+    this.deps.contextUsage.deleteSession(appSessionId)
+    this.deps.projector.clearSession(appSessionId)
+
+    if (removal.wasActive) {
+      this.deps.pushEvent({
+        kind: 'system',
+        level: 'info',
+        sessionId: appSessionId,
+        title: 'Session deleted'
+      })
+      this.deps.emitState()
+    }
+
+    return this.deps.getSnapshot()
+  }
+
+  private async deleteProviderSession(providerSessionId: string): Promise<void> {
+    const connection = this.deps.currentConnection()
+    if (connection && this.deps.supportsSessionDelete()) {
+      await connection.agent.request(acp.methods.agent.session.delete, {
+        sessionId: providerSessionId
+      })
+    } else if (connection && this.deps.supportsSessionClose()) {
+      await connection.agent.request(acp.methods.agent.session.close, {
+        sessionId: providerSessionId
+      })
+    } else {
+      await connection?.agent.notify(acp.methods.agent.session.cancel, {
+        sessionId: providerSessionId
+      })
+    }
+  }
+
+  private stillOwnsTarget(
+    appSessionId: string,
+    target: AcpSessionRegistryEntry | undefined
+  ): boolean {
+    const current = this.deps.registry.lookup(appSessionId)
+    return target ? current?.generation === target.generation : current === undefined
+  }
+}
+
+export { AcpSessionDeletionWorkflow }
+export type { AcpSessionDeletionWorkflowDependencies }

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -243,6 +243,60 @@ describe('AcpSessionUpdateProjector', () => {
     projector.dispose()
   })
 
+  it('clears Codex Skill presentation state for only one Session', () => {
+    const projector = new AcpSessionUpdateProjector()
+    const skillsRoot = resolve('/data', 'codex-home', 'skills')
+    projector.beginGeneration(skillsRoot)
+    const routing = {
+      kind: 'runtime' as const,
+      eventId: 'event-skill',
+      visible: true,
+      reconnectPending: false,
+      mcpServerNames: []
+    }
+
+    for (const [sessionId, skillName] of [
+      ['session-a', 'mcp-pubmed'],
+      ['session-b', 'mcp-chemistry']
+    ] as const) {
+      projector.project(
+        {
+          sessionId,
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'shared-call-id',
+            title: `Read ${skillName}`,
+            kind: 'read',
+            status: 'in_progress',
+            locations: [{ path: join(skillsRoot, skillName, 'SKILL.md') }]
+          }
+        },
+        routing
+      )
+    }
+
+    projector.clearSession('session-a')
+    const complete = (sessionId: string): ReturnType<AcpSessionUpdateProjector['project']> =>
+      projector.project(
+        {
+          sessionId,
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'shared-call-id',
+            status: 'completed'
+          }
+        },
+        { ...routing, eventId: `event-${sessionId}` }
+      )
+
+    expect(complete('session-a').at(-1)).not.toMatchObject({
+      event: { title: expect.stringContaining('skill') }
+    })
+    expect(complete('session-b').at(-1)).toMatchObject({
+      event: { title: 'Loaded skill: mcp-chemistry' }
+    })
+  })
+
   it('projects Permission tool correlation first with the stable Session identity', () => {
     const projector = new AcpSessionUpdateProjector()
     const effects = projector.project(

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -107,6 +107,10 @@ class AcpSessionUpdateProjector {
     this.codexSkillActivity.setSkillsRoot(undefined)
   }
 
+  clearSession(sessionId: string): void {
+    this.codexSkillActivity.clearSession(sessionId)
+  }
+
   dispose(): void {
     this.clearGeneration()
   }


### PR DESCRIPTION
## Problem

ACP Runtime still owned primary Session deletion end to end: deletion-epoch arbitration, provider protocol teardown, attachment removal, owner cleanup, selection, and event publication. That made a lifecycle transaction difficult to review and kept Runtime coupled to every Session-owned state interface.

Deletion also did not clear an unfinished Codex Skill presentation lifecycle for the removed Session, so reuse of the same Session/tool-call identity could inherit stale display-only state.

## Proposed change

Add a stateless `AcpSessionDeletionWorkflow.delete(appSessionId)` and make Runtime delegate its existing public delete facade to it. The workflow:

- starts the Registry deletion epoch before any operation/reconnect barrier;
- selects the existing provider `delete`, `close`, or `cancel` path once;
- disposes and detaches the captured provider attachment;
- requests cleanup from each authoritative owner;
- lets Registry finish the captured generation and own selection changes;
- publishes the existing active-Session deletion event.

Add per-Session cleanup to `AcpSessionUpdateProjector` / `CodexSkillActivityProjector` so deletion removes only that Session's unfinished display lifecycle.

## Scope and non-goals

- Preserve the public Runtime, Coordinator, application-command, IPC, shared type, and response contracts.
- Preserve stable App Session IDs and use the attached Provider Session ID for protocol requests.
- Preserve attached/detached deletion, failure retry, selection, and event behavior.
- Preserve provider capability-select-once behavior; request failure does not fall through to a weaker protocol.
- Preserve Notebook `beforeSessionDelete` ordering in Coordinator and durable Specialist binding cleanup in persistence.
- Do not change data models, persistence, Electron/Web/CLI/Task capabilities, Permission policy, Compute behavior, or user interaction.
- Do not implement Issue #458 orchestration state, schema, wire format, or UI.

## Ownership and sequence

```mermaid
sequenceDiagram
    participant Runtime
    participant Deletion as Session Deletion Workflow
    participant Registry
    participant Provider
    participant Owners as Permission / Capability / Prompt / Context / Handoff / Projector

    Runtime->>Deletion: delete(appSessionId)
    Deletion->>Registry: beginDelete before operation barrier
    Deletion->>Provider: delete OR close OR cancel(providerSessionId)
    Deletion->>Registry: dispose and detach captured attachment
    Deletion->>Owners: clear only appSessionId-owned state
    Deletion->>Registry: finish(captured generation)
    Registry-->>Deletion: removal and selection result
    alt captured Session was active
        Deletion-->>Runtime: existing Session deleted event/state
    end
    Deletion->>Registry: finally finish() releases epoch idempotently
```

Production raw is 240 lines, below the 500 soft target and 550 hard split threshold. `runtime.ts` decreases from 3,121 to 3,069 lines.

## Acceptance criteria and validation

All checks ran after the final material edit and after rebasing onto `origin/main` `b19c65a`.

- Deletion workflow, per-Session projector cleanup, and Codex Skill lifecycle isolation -> targeted three-file Vitest set -> 24/24 passed.
- Application command, IPC, Coordinator, and Registry deletion contracts -> targeted four-file Vitest set -> 100/100 passed.
- Runtime attached/detached/provider-ID/failure/retirement/same-ID deletion integration -> targeted `runtime.test.ts` selection -> 11/11 passed.
- Node process contracts -> `npm run typecheck:node` -> passed.
- Changed source/test lint -> ESLint -> 0 findings.
- Changed source/test formatting -> Prettier check -> passed.
- Patch integrity -> `git diff --check` -> passed.
- Manual Standards review -> 0 findings.
- Manual Spec/compatibility review -> 0 findings.

## Review focus

- `beginDelete` remains synchronous and precedes any operation barrier, so same-ID startup is blocked for the complete queued deletion.
- Provider teardown targets the Provider Session ID and selects exactly one advertised protocol path.
- Request/dispose failure preserves the original failure, skips successful local cleanup/event publication, and releases the deletion epoch for retry.
- Captured-generation checks and attachment detach guards prevent stale deletion from clearing a same-ID replacement.
- Projector cleanup is Session-scoped and does not clear another Session or the whole backend generation.

## Uncovered risks

- The complete local suite was not rerun on the exact head; the online PR Gate is authoritative for the full platform and consumer matrix.
- Cross-platform provider/Electron behavior remains CI-covered rather than reproduced locally.
- Existing synchronous owner cleanup is sequenced, not transactional; this PR preserves its current partial-cleanup behavior if a future owner begins throwing.
