### PR TITLE
test(ci): stabilize platform-sensitive workflow tests

### DIFF
--- a/src/main/acp/provider-session-creator.test.ts
+++ b/src/main/acp/provider-session-creator.test.ts
@@ -1,4 +1,5 @@
 import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
@@ -150,7 +151,7 @@ describe('AcpProviderSessionCreator', () => {
 
     expect(result).toEqual({
       sessionId: 'provider-session',
-      cwd: '/workspace',
+      cwd: resolve('/workspace'),
       frameworkId: 'claude-code',
       backendId: 'claude-code'
     })

--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -1,4 +1,5 @@
 import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { AcpCreateSessionResponse, AcpResumeSessionRequest } from '../../shared/acp'
@@ -238,7 +239,7 @@ describe('AcpProviderSessionResumer', () => {
 
     expect(response).toEqual({
       sessionId: 'stable-app-session',
-      cwd: '/workspace',
+      cwd: resolve('/workspace'),
       frameworkId: 'claude-code',
       backendId: 'claude-code'
     })

--- a/src/main/acp/session-replacement-workflow.test.ts
+++ b/src/main/acp/session-replacement-workflow.test.ts
@@ -1,4 +1,5 @@
 import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
+import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { AcpCreateSessionResponse } from '../../shared/acp'
@@ -83,7 +84,7 @@ describe('AcpSessionReplacementWorkflow', () => {
     expect(supersedeInteraction).toHaveBeenCalledWith('app-session')
     expect(adopt).toHaveBeenCalledWith('app-session', {
       connection,
-      cwd: '/new-workspace',
+      cwd: resolve('/new-workspace'),
       projectName: 'new-project',
       identity: expect.any(Object),
       permissionProfile: 'ask',

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -7788,6 +7788,6 @@ describe('v4 runtime bindings & agent tools', () => {
 
       await rm(manualDir, { recursive: true, force: true })
     },
-    30_000
+    60_000
   )
 })


### PR DESCRIPTION
## Problem

The Windows full-test lane on main fails because newly extracted ACP workflow tests expect Unix cwd literals, while production intentionally normalizes cwd values with `node:path.resolve()` and returns drive-qualified paths on Windows.

Initial failed run: https://github.com/aipoch/open-science/actions/runs/30988121436/job/92247548055

A branch-level Windows full-suite run exposed the same root cause in the provider session resumer and session replacement workflow tests, so this PR covers all three affected assertions.

After rebasing onto the latest main, the Linux unit lane also hit the same 30-second timeout twice in a POSIX-only notebook integration test that intentionally performs repeated real PATH and Conda interpreter discovery.

## Proposed change

- Use the same standard-library `resolve()` semantics in the creator, resumer, and replacement workflow assertions, matching production and the existing ACP runtime test convention.
- Give the existing real-interpreter discovery test a 60-second budget, matching other slow notebook integration tests.

## Scope and non-goals

Test-only changes. No production logic, dependencies, architecture, data model, data relationship, or user interaction changes.

## Acceptance criteria and validation

All local checks below ran after the last material edit:

- ACP creator/resumer/replacement portable cwd behavior -> 3 files and 21 tests passed
- complete notebook runtime test file -> 1 file and 181 tests passed in 19.33 seconds
- `npm run typecheck:node` -> passed
- `npm run lint` -> passed with 0 errors and 17 pre-existing warnings
- complete real-Windows suite -> https://github.com/aipoch/open-science/actions/runs/30997310575 -> both 1/2 and 2/2 test shards passed

No production interface or logic changed. The manually dispatched Windows full suite covers the reported platform risk, while PR Gate validates the increased POSIX integration-test budget under the original CI load.

## Review focus

- Confirm the ACP assertions follow production's `node:path.resolve()` semantics.
- Confirm 60 seconds is appropriate for the existing real-discovery integration test, whose runtime varies with host PATH and Conda environments.
