### PR TITLE
refactor(acp): extract prompt preparation owner

### DIFF
--- a/src/main/acp/prompt-preparation-owner.test.ts
+++ b/src/main/acp/prompt-preparation-owner.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpPromptRequest } from '../../shared/acp'
+import { codexFramework } from '../agent-framework/codex'
+import type { ContextUsageTurnHandle } from './context-usage-tracker'
+import { AcpPromptPreparationOwner, type PreparedPromptHandle } from './prompt-preparation-owner'
+import { AcpSessionPresentationPolicy } from './session-presentation-policy'
+
+type Mock = ReturnType<typeof vi.fn>
+type TestContextTurn = ContextUsageTurnHandle & {
+  complete: Mock
+  fail: Mock
+  supersede: Mock
+}
+type Fixture = {
+  owner: AcpPromptPreparationOwner
+  prepare: (overrides?: Record<string, unknown>) => Promise<PreparedPromptHandle>
+  promptContent: { prepare: Mock }
+  contextUsage: { beginTurn: Mock; replacePromptSkillDocuments: Mock }
+  turn: TestContextTurn
+  turnSkill: { prepareProvider: Mock }
+  authorizeReferencedUploads: Mock
+  releaseGrant: Mock
+  registerTurnInputs: Mock
+}
+
+const request = (overrides: Partial<AcpPromptRequest> = {}): AcpPromptRequest => ({
+  sessionId: 'session-1',
+  text: 'Analyze the result.',
+  ...overrides
+})
+
+const contextTurn = (): TestContextTurn => {
+  const handle = {
+    complete: vi.fn(() => false),
+    fail: vi.fn(),
+    supersede: vi.fn()
+  } as unknown as TestContextTurn
+  return handle
+}
+
+const setup = (): Fixture => {
+  const turn = contextTurn()
+  const promptContent = {
+    prepare: vi.fn(async () => ({
+      content: 'provider-content',
+      turnInputs: { uploads: [], references: [] }
+    }))
+  }
+  const contextUsage = {
+    beginSession: vi.fn(),
+    beginTurn: vi.fn(() => turn),
+    commitPendingAssistantOutput: vi.fn(),
+    appendText: vi.fn(),
+    appendPromptContent: vi.fn(),
+    replacePromptSkillDocuments: vi.fn(),
+    usage: vi.fn(() => undefined),
+    refreshUsage: vi.fn(() => true)
+  }
+  const releaseGrant = vi.fn()
+  const authorizeReferencedUploads = vi.fn(async () => releaseGrant)
+  const registerTurnInputs = vi.fn(async () => undefined)
+  const owner = new AcpPromptPreparationOwner({
+    promptContent,
+    presentation: new AcpSessionPresentationPolicy(),
+    contextUsage,
+    selectBridgeSkills: vi.fn(async () => []),
+    authorizeReferencedUploads,
+    notebook: {
+      peekHandoffContext: vi.fn(() => ({
+        executionCount: 1,
+        cells: [],
+        kernels: [],
+        runtimes: [{ language: 'python' as const, label: 'dataset' }]
+      })),
+      registerTurnInputs
+    },
+    emitState: vi.fn()
+  })
+  const turnSkill = {
+    reloadDecision: { kind: 'continue' as const },
+    prepareProvider: vi.fn(async () => ({
+      text: 'prepared task',
+      specialistSkillGuidance: 'Allowed Specialist Skills for this session:\n- Research',
+      codexSkillInputs: [{ name: 'Research', path: '/missing/Research/SKILL.md' }]
+    })),
+    close: vi.fn()
+  }
+  const prepare = (overrides: Record<string, unknown> = {}): Promise<PreparedPromptHandle> =>
+    owner.prepare({
+      request: request({
+        contextReset: true,
+        historyPreamble: 'replayed history',
+        referencedArtifacts: [
+          {
+            id: 'skill-1',
+            name: 'Research.skill',
+            path: '/uploads/Research.skill',
+            source: 'upload'
+          }
+        ]
+      }),
+      backend: {
+        framework: codexFramework,
+        session: { modelRequired: false },
+        prompt: { systemPromptAppends: [], persistentSystemPrompt: 'baked instructions' },
+        context: { window: 100_000, supportsImageInput: true },
+        adapter: {
+          nativeMcpEnabled: true,
+          bridgeMcpAliasesEnabled: false,
+          codexHome: '/codex'
+        }
+      },
+      tooling: { artifacts: true, notebook: true, skillImport: true },
+      specialistPrefix: 'Specialist identity.',
+      projectId: 'project-1',
+      fallbackPromptMessageId: 'prompt-fallback',
+      bridgeSkillsAvailable: true,
+      skillImportEnabled: true,
+      skillImportTurnToken: 'turn-1',
+      turnSkill,
+      signal: new AbortController().signal,
+      isCurrent: () => true,
+      cancellationCheckpoint: async () => 'active' as const,
+      contextEstimateInput: { frameworkId: 'codex' as const },
+      selectedContextWindow: 100_000,
+      ...overrides
+    })
+
+  return {
+    owner,
+    prepare,
+    promptContent,
+    contextUsage,
+    turn,
+    turnSkill,
+    authorizeReferencedUploads,
+    releaseGrant,
+    registerTurnInputs
+  }
+}
+
+describe('AcpPromptPreparationOwner', () => {
+  it('composes handoff, presentation, Notebook and prompt content and transfers Context once', async () => {
+    const fixture = setup()
+
+    const handle = await fixture.prepare()
+
+    expect(handle.status).toBe('ready')
+    if (handle.status !== 'ready') throw new Error('expected a ready prompt')
+    expect(fixture.turnSkill.prepareProvider).toHaveBeenCalledWith({
+      frameworkId: 'codex',
+      selectionText: 'Analyze the result.',
+      promptText: 'Analyze the result.',
+      codex: {
+        home: '/codex',
+        bridgeSkillsAvailable: true,
+        selectSkills: expect.any(Function),
+        signal: expect.any(AbortSignal)
+      }
+    })
+    expect(fixture.promptContent.prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appSessionId: 'session-1',
+        projectId: 'project-1',
+        codexSkillInputs: [{ name: 'Research', path: '/missing/Research/SKILL.md' }],
+        fileTextBudget: expect.any(Number)
+      })
+    )
+    const preparedCalls = fixture.promptContent.prepare.mock.calls as unknown as Array<
+      [{ text: string }]
+    >
+    const preparedText = preparedCalls[0]?.[0].text
+    expect(preparedText).toEqual(expect.stringContaining('<open_science_notebook_continuity>'))
+    expect(preparedText).toEqual(expect.stringContaining('"label":"dataset"'))
+    expect(preparedText).toMatch(
+      /^replayed history[\s\S]+Specialist identity\.\n\nAllowed Specialist Skills for this session:\n- Research\n\nprepared task$/
+    )
+    expect(fixture.authorizeReferencedUploads).toHaveBeenCalledWith('project-1', 'session-1', [
+      '/uploads/Research.skill'
+    ])
+    expect(fixture.registerTurnInputs).toHaveBeenCalledWith(
+      expect.objectContaining({ promptMessageId: 'prompt-fallback' })
+    )
+    expect(handle.content).toBe('provider-content')
+    expect(handle.promptPrefix).toBe(
+      'Specialist identity.\n\nAllowed Specialist Skills for this session:\n- Research'
+    )
+    expect(handle.skillActivityInputs).toEqual([
+      { name: 'Research', path: '/missing/Research/SKILL.md' }
+    ])
+    expect(Object.isFrozen(handle.skillActivityInputs)).toBe(true)
+    expect(handle.transferContextTurn()).toBe(fixture.turn)
+    expect(() => handle.transferContextTurn()).toThrow('already transferred')
+    handle.close()
+    handle.close()
+    expect(fixture.releaseGrant).toHaveBeenCalledTimes(1)
+    expect(fixture.turn.fail).not.toHaveBeenCalled()
+  })
+
+  it('stops a superseded prompt after stalled content preparation and releases its grant', async () => {
+    const fixture = setup()
+    let resolveContent!: () => void
+    fixture.promptContent.prepare.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveContent = () =>
+            resolve({
+              content: 'stale-provider-content',
+              turnInputs: { uploads: [], references: [] }
+            })
+        })
+    )
+    let current = true
+    const pending = fixture.prepare({ isCurrent: () => current })
+    await vi.waitFor(() => expect(fixture.promptContent.prepare).toHaveBeenCalled())
+
+    current = false
+    resolveContent()
+    const handle = await pending
+
+    expect(handle.status).toBe('cancelled')
+    expect(fixture.releaseGrant).toHaveBeenCalledTimes(1)
+    expect(fixture.contextUsage.beginTurn).not.toHaveBeenCalled()
+    expect(fixture.registerTurnInputs).not.toHaveBeenCalled()
+  })
+
+  it('fails and supersedes a preparation-owned Context turn when cancellation wins preflight', async () => {
+    const fixture = setup()
+    let current = true
+    fixture.contextUsage.replacePromptSkillDocuments.mockImplementationOnce(() => {
+      current = false
+    })
+
+    const handle = await fixture.prepare({ isCurrent: () => current })
+
+    expect(handle.status).toBe('cancelled')
+    expect(fixture.turn.fail).toHaveBeenCalledTimes(1)
+    expect(fixture.turn.supersede).toHaveBeenCalledTimes(1)
+    expect(fixture.releaseGrant).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/acp/prompt-preparation-owner.ts
+++ b/src/main/acp/prompt-preparation-owner.ts
@@ -1,0 +1,299 @@
+import type { ContentBlock } from '@agentclientprotocol/sdk'
+import { readFile } from 'node:fs/promises'
+
+import type { AcpPromptRequest } from '../../shared/acp'
+import type { UploadedAttachment } from '../../shared/uploads'
+import type { FileReference } from '../../shared/artifacts'
+import { resolveFileTextBudget } from '../../shared/history-preamble'
+import type { NotebookHandoffContext } from '../notebook/runtime-service'
+import type { ResolvedAgentBackend } from '../agent-framework'
+import { createLogger, errorLogFields } from '../logger'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import type {
+  ContextUsageTracker,
+  ContextUsageTurnHandle,
+  SessionEstimateInput
+} from './context-usage-tracker'
+import type { AcpPromptContentOwner } from './prompt-content-owner'
+import type {
+  AcpSessionPresentationPolicy,
+  AcpSessionToolingAvailability
+} from './session-presentation-policy'
+import type { TurnSkillHandle } from './turn-skill-owner'
+
+const log = createLogger('acp-prompt-preparation-owner')
+type SelectBridgeSkills = NonNullable<ResolvedAgentBackend['responsesBridgeLease']>['selectSkills']
+type NotebookTurnInputs = Readonly<{
+  projectId: string
+  appSessionId: string
+  promptMessageId: string
+  uploads: UploadedAttachment[]
+  references: FileReference[]
+}>
+type AcpPromptPreparationOwnerOptions = Readonly<{
+  promptContent: Pick<AcpPromptContentOwner, 'prepare'>
+  presentation: Pick<AcpSessionPresentationPolicy, 'buildTurnPromptPrefix' | 'continuationText'>
+  contextUsage: Pick<
+    ContextUsageTracker,
+    | 'beginSession'
+    | 'beginTurn'
+    | 'commitPendingAssistantOutput'
+    | 'appendText'
+    | 'appendPromptContent'
+    | 'replacePromptSkillDocuments'
+    | 'usage'
+    | 'refreshUsage'
+  >
+  selectBridgeSkills: SelectBridgeSkills
+  authorizeReferencedUploads?: (
+    projectId: string,
+    sessionId: string,
+    paths: string[]
+  ) => Promise<() => void>
+  notebook?: Readonly<{
+    peekHandoffContext?: (sessionId: string) => NotebookHandoffContext | undefined
+    registerTurnInputs?: (input: NotebookTurnInputs) => Promise<void>
+  }>
+  emitState: () => void
+}>
+type AcpPromptPreparationInput = Readonly<{
+  request: AcpPromptRequest
+  backend: AcpBackendGenerationView
+  tooling: AcpSessionToolingAvailability
+  specialistPrefix?: string
+  projectId: string
+  fallbackPromptMessageId?: string
+  bridgeSkillsAvailable: boolean
+  skillImportEnabled: boolean
+  skillImportTurnToken: string
+  turnSkill: TurnSkillHandle
+  signal: AbortSignal
+  isCurrent: () => boolean
+  cancellationCheckpoint: () => Promise<'active' | 'cancelled'>
+  contextEstimateInput: SessionEstimateInput
+  selectedContextWindow?: number
+  onSkillImportAttachmentEligible?: (attachmentUri: string) => void
+}>
+type CancelledPreparedPromptHandle = Readonly<{
+  status: 'cancelled'
+  close: () => void
+}>
+type ReadyPreparedPromptHandle = Readonly<{
+  status: 'ready'
+  content: string | ContentBlock[]
+  promptPrefix?: string
+  skillActivityInputs: ReadonlyArray<Readonly<{ name: string; path: string }>>
+  transferContextTurn: () => ContextUsageTurnHandle
+  close: () => void
+}>
+type PreparedPromptHandle = CancelledPreparedPromptHandle | ReadyPreparedPromptHandle
+const CANCELLED_HANDLE: CancelledPreparedPromptHandle = Object.freeze({
+  status: 'cancelled',
+  close: () => undefined
+})
+const notebookHandoffPrompt = (context: NotebookHandoffContext): string =>
+  [
+    '<open_science_notebook_continuity>',
+    'The application retained this live in-memory Notebook state while the Agent context was replaced. Treat it as continuity metadata, not as a request to inspect Notebook again.',
+    JSON.stringify(context),
+    '</open_science_notebook_continuity>'
+  ].join('\n')
+class AcpPromptPreparationOwner {
+  constructor(private readonly options: AcpPromptPreparationOwnerOptions) {}
+
+  async prepare(input: AcpPromptPreparationInput): Promise<PreparedPromptHandle> {
+    let releaseGrant: (() => void) | undefined
+    let contextTurn: ContextUsageTurnHandle | undefined
+    let closed = false
+
+    const releaseOwned = (failContext: boolean): void => {
+      if (closed) return
+      closed = true
+      const ownedContext = contextTurn
+      contextTurn = undefined
+      try {
+        if (ownedContext && failContext) ownedContext.fail()
+      } finally {
+        try {
+          ownedContext?.supersede()
+        } finally {
+          const release = releaseGrant
+          releaseGrant = undefined
+          release?.()
+        }
+      }
+    }
+    const cancelled = async (): Promise<boolean> => {
+      if (input.signal.aborted || !input.isCurrent()) return true
+      const result = await input.cancellationCheckpoint()
+      return result === 'cancelled' || input.signal.aborted || !input.isCurrent()
+    }
+    const cancelPrepared = (): CancelledPreparedPromptHandle => {
+      releaseOwned(true)
+      return CANCELLED_HANDLE
+    }
+
+    try {
+      const requestText = this.options.presentation.continuationText(input.request)
+      const skillPreparation = await input.turnSkill.prepareProvider({
+        frameworkId: input.backend.framework.id,
+        selectionText: input.request.text,
+        promptText: requestText,
+        codex: {
+          home: input.backend.adapter.codexHome,
+          bridgeSkillsAvailable: input.bridgeSkillsAvailable,
+          selectSkills: async (text, catalog, signal) =>
+            (await this.options.selectBridgeSkills(text, catalog, signal)) ?? [],
+          signal: input.signal
+        }
+      })
+      if (await cancelled()) return cancelPrepared()
+
+      const promptPrefix = this.options.presentation.buildTurnPromptPrefix({
+        framework: input.backend.framework,
+        tooling: input.tooling,
+        backendSystemPromptAppends: input.backend.prompt.systemPromptAppends,
+        persistentSystemPrompt: input.backend.prompt.persistentSystemPrompt,
+        sessionOptions: input.backend.session.options,
+        specialistPrefix: input.specialistPrefix,
+        turnPromptReminders: skillPreparation.specialistSkillGuidance
+          ? [skillPreparation.specialistSkillGuidance]
+          : []
+      })
+      const skillActivityInputs = Object.freeze(
+        skillPreparation.codexSkillInputs.map((skill) => Object.freeze({ ...skill }))
+      )
+      const notebookHandoff =
+        input.request.contextReset || input.request.historyPreamble
+          ? this.options.notebook?.peekHandoffContext?.(input.request.sessionId)
+          : undefined
+      const promptText = [
+        input.request.historyPreamble,
+        notebookHandoff ? notebookHandoffPrompt(notebookHandoff) : undefined,
+        promptPrefix,
+        skillPreparation.text
+      ]
+        .filter((segment): segment is string => Boolean(segment))
+        .join('\n\n')
+
+      if (input.skillImportEnabled && this.options.authorizeReferencedUploads) {
+        const paths = (input.request.referencedArtifacts ?? []).flatMap((reference) => {
+          if (reference.source !== 'upload') return []
+          const name = reference.name.toLowerCase()
+          return name.endsWith('.skill') || name.endsWith('.zip') ? [reference.path] : []
+        })
+        releaseGrant = await this.options.authorizeReferencedUploads(
+          input.projectId,
+          input.request.sessionId,
+          paths
+        )
+        if (await cancelled()) return cancelPrepared()
+      }
+
+      const prepared = await this.options.promptContent.prepare({
+        appSessionId: input.request.sessionId,
+        projectId: input.projectId,
+        text: promptText,
+        historyImages: input.request.historyImages ?? [],
+        historyUploads: input.request.historyAttachments ?? [],
+        currentUploads: input.request.attachments ?? [],
+        references: input.request.referencedArtifacts ?? [],
+        codexSkillInputs: skillActivityInputs,
+        skillImportEnabled: input.skillImportEnabled,
+        fileTextBudget: resolveFileTextBudget(input.backend.context.window),
+        skillImportTurnToken: input.skillImportTurnToken,
+        onSkillImportAttachmentEligible: input.onSkillImportAttachmentEligible
+      })
+      if (await cancelled()) return cancelPrepared()
+
+      if (this.options.notebook?.registerTurnInputs && prepared.turnInputs) {
+        await this.options.notebook.registerTurnInputs({
+          projectId: input.projectId,
+          appSessionId: input.request.sessionId,
+          promptMessageId:
+            input.request.provenanceContext?.promptMessageId ??
+            input.fallbackPromptMessageId ??
+            `prompt-unbound-${input.request.sessionId}`,
+          uploads: prepared.turnInputs.uploads,
+          references: prepared.turnInputs.references
+        })
+        if (await cancelled()) return cancelPrepared()
+      }
+
+      contextTurn = this.options.contextUsage.beginTurn(input.request.sessionId)
+      const contextEstimateCurrent = await this.recordContextEstimate(
+        input,
+        prepared.content,
+        promptPrefix,
+        skillActivityInputs
+      )
+      if (!contextEstimateCurrent) return cancelPrepared()
+      if (await cancelled()) return cancelPrepared()
+
+      let transferred = false
+      return Object.freeze({
+        status: 'ready' as const,
+        content: prepared.content,
+        ...(promptPrefix ? { promptPrefix } : {}),
+        skillActivityInputs,
+        transferContextTurn: (): ContextUsageTurnHandle => {
+          if (closed) throw new Error('Prepared prompt is already closed.')
+          if (transferred || !contextTurn) {
+            throw new Error('Prepared prompt Context turn was already transferred.')
+          }
+          transferred = true
+          const transferredTurn = contextTurn
+          contextTurn = undefined
+          return transferredTurn
+        },
+        close: () => releaseOwned(true)
+      })
+    } catch (error) {
+      releaseOwned(true)
+      throw error
+    }
+  }
+
+  private async recordContextEstimate(
+    input: AcpPromptPreparationInput,
+    content: string | ContentBlock[],
+    promptPrefix: string | undefined,
+    skillActivityInputs: ReadonlyArray<{ name: string; path: string }>
+  ): Promise<boolean> {
+    const sessionId = input.request.sessionId
+    this.options.contextUsage.beginSession(sessionId, input.contextEstimateInput)
+    this.options.contextUsage.commitPendingAssistantOutput(sessionId)
+    this.options.contextUsage.appendText(sessionId, 'system', promptPrefix ?? '')
+    this.options.contextUsage.appendPromptContent(sessionId, content, promptPrefix)
+    const documents = (
+      await Promise.all(
+        skillActivityInputs.map(async ({ path }) => {
+          try {
+            return { path, text: await readFile(path, 'utf8') }
+          } catch (error) {
+            log.warn('context estimate could not read Codex Skill input', {
+              sessionId,
+              ...errorLogFields(error)
+            })
+            return undefined
+          }
+        })
+      )
+    ).filter((document): document is { path: string; text: string } => document !== undefined)
+    if (input.signal.aborted || !input.isCurrent()) return false
+    this.options.contextUsage.replacePromptSkillDocuments(sessionId, documents)
+    const size = input.selectedContextWindow ?? this.options.contextUsage.usage(sessionId)?.size
+    if (this.options.contextUsage.refreshUsage(sessionId, 'preflight', size)) {
+      this.options.emitState()
+    }
+    return true
+  }
+}
+
+export { AcpPromptPreparationOwner }
+export type {
+  AcpPromptPreparationInput,
+  AcpPromptPreparationOwnerOptions,
+  PreparedPromptHandle,
+  ReadyPreparedPromptHandle
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3766,6 +3766,39 @@ describe('ACP runtime session management', () => {
     ).resolves.toBeDefined()
   })
 
+  it('does not dispatch a superseded prompt after its preparation finishes', async () => {
+    const process = new FakeAgentProcess()
+    const agent = startFakeAgent(process, ['remote-session-1', 'remote-session-2'])
+    const namesGate = createDeferred<string[]>()
+    const namesForIds = vi.fn(() => namesGate.promise)
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      skills: {
+        needForceLoad: vi.fn(async () => []),
+        namesForIds
+      }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    const stalePrompt = runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'stale turn',
+      forcedSkillIds: ['research']
+    })
+    await vi.waitFor(() => expect(namesForIds).toHaveBeenCalledTimes(1))
+
+    await runtime.resetSessionContext({ sessionId: session.sessionId, cwd: '/workspace' })
+    namesGate.resolve(['research'])
+    await expect(stalePrompt).resolves.toMatchObject({ stopReason: 'cancelled' })
+    expect(agent.prompts).toHaveLength(0)
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'replacement turn' })
+    expect(agent.prompts).toHaveLength(1)
+    expect(agent.prompts[0]?.text).toContain('replacement turn')
+  })
+
   it('does not let a superseded turn finally clear the replay turn in-flight lock', async () => {
     const root = await createTemporaryRoot()
     const artifactRepository = new ArtifactRepository(root)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -2,7 +2,6 @@ import * as acp from '@agentclientprotocol/sdk'
 import type {
   ActiveSession,
   ClientConnection,
-  ContentBlock,
   PromptResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
@@ -10,7 +9,6 @@ import type {
   SessionNotification
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 
 import type {
@@ -92,7 +90,6 @@ import type { ArtifactFile, FileReference } from '../../shared/artifacts'
 import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
 import { isMediaOverflowError } from '../../shared/media-overflow'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
-import { resolveFileTextBudget } from '../../shared/history-preamble'
 import {
   ReviewerSessionOwner,
   type ReviewerSessionDisposition,
@@ -140,6 +137,8 @@ import { AcpProviderSessionAdopter } from './provider-session-adopter'
 import { AcpProviderSessionResumer } from './provider-session-resumer'
 import { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
 import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
+import { AcpPromptPreparationOwner, type PreparedPromptHandle } from './prompt-preparation-owner'
+import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import {
   AcpTurnSkillOwner,
   type AcpTurnSkillHooks,
@@ -302,13 +301,6 @@ const TURN_CONTINUITY_SYSTEM_PROMPT_APPEND = [
   'If a required tool cannot be used or its operation fails, do not promise another attempt. Clearly state that the turn has stopped, what prevented progress, and what the user can do next.',
   '</open_science_turn_continuity_instructions>'
 ].join('\n')
-const buildNotebookHandoffPrompt = (context: NotebookHandoffContext): string =>
-  [
-    '<open_science_notebook_continuity>',
-    'The application retained this live in-memory Notebook state while the Agent context was replaced. Treat it as continuity metadata, not as a request to inspect Notebook again.',
-    JSON.stringify(context),
-    '</open_science_notebook_continuity>'
-  ].join('\n')
 // Appends artifact tool guidance as system prompt metadata so user prompts stay untouched.
 const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '<open_science_artifact_instructions>',
@@ -407,12 +399,11 @@ class AcpRuntime {
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private readonly artifactOptions: AcpRuntimeArtifactOptions | undefined
-  private readonly notebookOptions: AcpRuntimeNotebookOptions | undefined
-  private readonly skillImportOptions: AcpRuntimeSkillImportOptions | undefined
   private readonly artifactRepository: ArtifactRepository | undefined
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly artifactTurns: ArtifactTurnOwner | undefined
   private readonly promptContentOwner: AcpPromptContentOwner
+  private readonly promptPreparation: AcpPromptPreparationOwner
   private readonly connectionClose: AcpConnectionCloseWorkflow
   private readonly connectionLifecycle: AcpConnectionLifecycleWorkflow
   private readonly modelChanges: AcpModelChangeWorkflow
@@ -465,8 +456,6 @@ class AcpRuntime {
       clearTimer: this.clearTimer
     })
     this.artifactOptions = options.artifacts
-    this.notebookOptions = options.notebook
-    this.skillImportOptions = options.skillImport
     this.sessionCapabilities = new AcpSessionCapabilityOwner({
       artifacts: options.artifacts,
       notebook: options.notebook,
@@ -507,6 +496,23 @@ class AcpRuntime {
       uploadRepository,
       fileReferenceResolver,
       inlineImageBudgetBytes: options.inlineImageBudgetBytes
+    })
+    this.promptPreparation = new AcpPromptPreparationOwner({
+      promptContent: this.promptContentOwner,
+      presentation: new AcpSessionPresentationPolicy(),
+      contextUsage: this.contextUsageTracker,
+      selectBridgeSkills: async (text, catalog, signal) =>
+        (await this.connectionResources.selectBridgeSkills(text, catalog, signal)) ?? [],
+      authorizeReferencedUploads: options.skillImport?.authorizeReferencedUploads,
+      ...(options.notebook
+        ? {
+            notebook: {
+              peekHandoffContext: options.notebook.peekHandoffContext,
+              registerTurnInputs: options.notebook.registerTurnInputs
+            }
+          }
+        : {}),
+      emitState: () => this.emitState()
     })
     this.sessionRegistry = new AcpSessionRegistry({
       addStartupBlocker: (token) => this.generationActivity.acquireStartup(token),
@@ -1751,7 +1757,7 @@ class AcpRuntime {
     let skillActivityInputs: Array<{ name: string; path: string }> = []
     let skillActivitiesStarted = false
     let skillActivitiesFinalized = false
-    let revokeReferencedUploadGrant: (() => void) | undefined
+    let preparedPromptHandle: PreparedPromptHandle | undefined
     let contextUsageTurn: ContextUsageTurnHandle | undefined
     let turnSkillOutcome: TurnSkillOutcome = 'failed'
     let observedPromptStop:
@@ -1833,107 +1839,50 @@ class AcpRuntime {
       const sessionSpecialistPrefix = this.sessionRegistry
         .lookup(request.sessionId)
         ?.aggregate.snapshot().specialistPrefix
-      const promptRequestText = request.continuation
-        ? this.buildSpecialistHandoffContinuationText(request)
-        : request.text
-      const skillPreparation = await turnSkillHandle.prepareProvider({
-        frameworkId: this.framework.id,
-        selectionText: request.text,
-        promptText: promptRequestText,
-        codex: {
-          home: this.backend.adapter.codexHome,
-          bridgeSkillsAvailable: this.connectionResources.bridgeSkillsAvailable,
-          selectSkills: async (text, catalog, signal) =>
-            (await this.connectionResources.selectBridgeSkills(text, catalog, signal)) ?? [],
-          signal: promptInteraction.signal
-        }
-      })
-      if (
-        (await this.sessionInteractions.cancellationCheckpoint(promptInteraction)) === 'cancelled'
-      ) {
-        return finishCancelledBeforePrompt()
-      }
-      const { promptPrefix: frameworkPromptPrefix } = this.framework.buildSessionSetup({
-        systemPromptAppends: this.backend.prompt.persistentSystemPrompt
-          ? []
-          : this.getSystemPromptAppends(),
-        turnPromptReminders: skillPreparation.specialistSkillGuidance
-          ? [skillPreparation.specialistSkillGuidance]
-          : [],
-        sessionOptions: this.backend.session.options
-      })
-      const promptPrefix =
-        [sessionSpecialistPrefix, frameworkPromptPrefix]
-          .filter((segment): segment is string => Boolean(segment))
-          .join('\n\n') || undefined
-      const codexSkillInputs = [...skillPreparation.codexSkillInputs]
-      const notebookHandoff =
-        request.contextReset || request.historyPreamble
-          ? this.notebookOptions?.peekHandoffContext?.(request.sessionId)
-          : undefined
-      const promptText = [
-        request.historyPreamble,
-        notebookHandoff ? buildNotebookHandoffPrompt(notebookHandoff) : undefined,
-        promptPrefix,
-        skillPreparation.text
-      ]
-        .filter((segment): segment is string => Boolean(segment))
-        .join('\n\n')
-      revokeReferencedUploadGrant = await this.authorizeReferencedSkillUploads(
-        request.sessionId,
-        request.referencedArtifacts ?? []
-      )
       const projectId = this.resolveSessionProjectName(request.sessionId)
-      const preparedPrompt = await this.promptContentOwner.prepare({
-        appSessionId: request.sessionId,
+      preparedPromptHandle = await this.promptPreparation.prepare({
+        request,
+        backend: this.backend,
+        tooling: this.currentCapabilityAvailability(),
+        specialistPrefix: sessionSpecialistPrefix,
         projectId,
-        text: promptText,
-        historyImages: request.historyImages ?? [],
-        historyUploads: request.historyAttachments ?? [],
-        currentUploads: request.attachments ?? [],
-        references: request.referencedArtifacts ?? [],
-        codexSkillInputs,
+        fallbackPromptMessageId: this.artifactTurns?.promptMessageIdFor(request.sessionId),
+        bridgeSkillsAvailable: this.connectionResources.bridgeSkillsAvailable,
         skillImportEnabled: this.sessionCapabilities.isSkillImportEnabled(),
-        fileTextBudget: resolveFileTextBudget(this.backend.context.window),
         skillImportTurnToken,
-        onSkillImportAttachmentEligible: this.callbacks.onSkillImportAttachmentEligible
-          ? (attachmentUri) => {
-              try {
-                this.callbacks.onSkillImportAttachmentEligible?.(
-                  request.sessionId,
-                  skillImportTurnToken,
-                  attachmentUri
-                )
-              } catch (error) {
-                safeLogError('skill import attachment callback failed', errorLogFields(error))
+        turnSkill: turnSkillHandle,
+        signal: promptInteraction.signal,
+        isCurrent: () =>
+          this.sessionInteractions.current(request.sessionId) === promptInteraction &&
+          this.activeSessionFor(request.sessionId) === activeSession,
+        cancellationCheckpoint: () =>
+          this.sessionInteractions.cancellationCheckpoint(promptInteraction),
+        contextEstimateInput: this.contextUsageEstimateInput(request.sessionId),
+        selectedContextWindow: this.selectedContextWindowFor(request.sessionId),
+        ...(this.callbacks.onSkillImportAttachmentEligible
+          ? {
+              onSkillImportAttachmentEligible: (attachmentUri: string) => {
+                try {
+                  this.callbacks.onSkillImportAttachmentEligible?.(
+                    request.sessionId,
+                    skillImportTurnToken,
+                    attachmentUri
+                  )
+                } catch (error) {
+                  safeLogError('skill import attachment callback failed', errorLogFields(error))
+                }
               }
             }
-          : undefined
+          : {})
       })
-      if (this.notebookOptions?.registerTurnInputs && preparedPrompt.turnInputs) {
-        await this.notebookOptions.registerTurnInputs({
-          projectId,
-          appSessionId: request.sessionId,
-          promptMessageId:
-            request.provenanceContext?.promptMessageId ??
-            this.artifactTurns?.promptMessageIdFor(request.sessionId) ??
-            `prompt-unbound-${request.sessionId}`,
-          uploads: preparedPrompt.turnInputs.uploads,
-          references: preparedPrompt.turnInputs.references
-        })
+      if (preparedPromptHandle.status === 'cancelled') {
+        return finishCancelledBeforePrompt()
       }
-      const promptContent = preparedPrompt.content
-
-      contextUsageTurn = this.contextUsageTracker.beginTurn(request.sessionId)
-      await this.recordPromptContextEstimate(
-        request.sessionId,
-        promptContent,
-        promptPrefix,
-        codexSkillInputs
-      )
+      const promptContent = preparedPromptHandle.content
+      skillActivityInputs = [...preparedPromptHandle.skillActivityInputs]
+      contextUsageTurn = preparedPromptHandle.transferContextTurn()
 
       emitUserMessage()
-      skillActivityInputs = codexSkillInputs
       if (skillActivityInputs.length > 0) {
         this.emitCodexSkillInputActivities(
           request.sessionId,
@@ -2151,7 +2100,7 @@ class AcpRuntime {
       })
       throw error
     } finally {
-      revokeReferencedUploadGrant?.()
+      preparedPromptHandle?.close()
       // A turn that fails or is aborted never reaches the stop branch; still surface any files it
       // wrote so they are attached to a message instead of being orphaned in the pending directory.
       if (!artifactEmitted) {
@@ -2310,29 +2259,6 @@ class AcpRuntime {
     }
   }
 
-  // Converts the user's explicit `@` selections into a turn-scoped capability for Skill import.
-  // Generic managed-path validation happens before the grant; the importer retains the stricter
-  // session-owner check for every path that was not selected in this turn.
-  private async authorizeReferencedSkillUploads(
-    sessionId: string,
-    references: FileReference[]
-  ): Promise<(() => void) | undefined> {
-    if (!this.sessionCapabilities.isSkillImportEnabled()) return undefined
-
-    const authorize = this.skillImportOptions?.authorizeReferencedUploads
-    if (!authorize) return undefined
-
-    const paths = references.flatMap((reference) => {
-      if (reference.source !== 'upload') return []
-      const normalizedName = reference.name.toLowerCase()
-      return normalizedName.endsWith('.skill') || normalizedName.endsWith('.zip')
-        ? [reference.path]
-        : []
-    })
-
-    return authorize(this.resolveSessionProjectName(sessionId), sessionId, paths)
-  }
-
   // Lazily initializes the process connection before session creation.
   private async ensureConnected(cwd: string): Promise<ClientConnection> {
     return this.connectionLifecycle.ensureConnected(cwd)
@@ -2432,32 +2358,6 @@ class AcpRuntime {
       ...this.backend.prompt.systemPromptAppends,
       ...(skillGuidance ? [skillGuidance] : [])
     ]
-  }
-
-  private buildSpecialistHandoffContinuationText(request: AcpPromptRequest): string {
-    const continuation = request.continuation
-    if (!continuation) return request.text
-
-    const outcome =
-      continuation.completion.kind === 'returned'
-        ? this.serializeHandoffValue(continuation.completion.value)
-        : continuation.completion.errorMessage
-    const outcomeLabel = continuation.completion.kind === 'returned' ? 'result' : 'error'
-    const target = continuation.targetName ?? 'Main Agent'
-    return [
-      `Continue the original user task as ${target}. Do not repeat work already shown before the handoff.`,
-      `Original user request:\n${request.text}`,
-      `Captured outer tool ${outcomeLabel}:\n${outcome}`
-    ].join('\n\n')
-  }
-
-  private serializeHandoffValue(value: unknown): string {
-    if (typeof value === 'string') return value
-    try {
-      return JSON.stringify(value)
-    } catch {
-      return String(value)
-    }
   }
 
   // Resolves the artifact/notebook storage project for a session, defaulting to the runtime constant.
@@ -2761,37 +2661,6 @@ class AcpRuntime {
     const selectedSize = this.selectedContextWindowFor(sessionId)
     const size = selectedSize ?? this.contextUsageTracker.usage(sessionId)?.size
     return this.contextUsageTracker.refreshUsage(sessionId, status, size)
-  }
-
-  private async recordPromptContextEstimate(
-    sessionId: string,
-    promptContent: string | ContentBlock[],
-    promptPrefix: string | undefined,
-    codexSkillInputs: ReadonlyArray<{ name: string; path: string }>
-  ): Promise<void> {
-    this.ensureContextUsageTracking(sessionId)
-    this.contextUsageTracker.commitPendingAssistantOutput(sessionId)
-    this.contextUsageTracker.appendText(sessionId, 'system', promptPrefix ?? '')
-    this.contextUsageTracker.appendPromptContent(sessionId, promptContent, promptPrefix)
-
-    const promptSkillDocuments = (
-      await Promise.all(
-        codexSkillInputs.map(async ({ path }) => {
-          try {
-            return { path, text: await readFile(path, 'utf8') }
-          } catch (error) {
-            log.warn('context estimate could not read Codex Skill input', {
-              sessionId,
-              ...errorLogFields(error)
-            })
-            return undefined
-          }
-        })
-      )
-    ).filter((document): document is { path: string; text: string } => document !== undefined)
-    this.contextUsageTracker.replacePromptSkillDocuments(sessionId, promptSkillDocuments)
-
-    if (this.refreshEstimatedContextUsage(sessionId, 'preflight')) this.emitState()
   }
 
   // Normalizes low-level session notifications into runtime/workspace events.

--- a/src/main/acp/session-presentation-policy.ts
+++ b/src/main/acp/session-presentation-policy.ts
@@ -32,7 +32,7 @@ type AcpSpecialistIdentityPresentation = Readonly<{
 }>
 
 type AcpTurnPromptPrefixInput = AcpSessionSetupPresentationInput &
-  Readonly<{ specialistPrefix?: string }>
+  Readonly<{ specialistPrefix?: string; turnPromptReminders?: readonly string[] }>
 
 type AcpCodexSkillInput = Readonly<{ name: string; path: string }>
 
@@ -159,7 +159,10 @@ class AcpSessionPresentationPolicy {
     )
     const setup = input.framework.buildSessionSetup({
       systemPromptAppends: this.systemPromptAppends(input),
-      turnPromptReminders: specialistSkillGuidance ? [specialistSkillGuidance] : [],
+      turnPromptReminders: [
+        ...(specialistSkillGuidance ? [specialistSkillGuidance] : []),
+        ...(input.turnPromptReminders ?? [])
+      ],
       sessionOptions: input.sessionOptions
     })
 


### PR DESCRIPTION
## Problem

ACP Runtime still owned prompt text assembly, Skill preparation, upload authorization, Notebook input registration, and Context preflight in one orchestration method. That mixed state ownership with provider execution and left a supersession window where a prompt replaced during slow preparation could still reach the old Provider session.

## Proposed change

Introduce `AcpPromptPreparationOwner.prepare(...) -> PreparedPromptHandle` as the owner of prompt preparation resources and ordering. The handle exposes immutable provider content and activity facts, transfers the Context turn exactly once, and releases the referenced-upload grant idempotently.

Runtime now keeps admission, Provider dispatch/update streaming, event publication, and terminal finalization. Every asynchronous preparation boundary checks both interaction and active-Session identity before dispatch.

```mermaid
flowchart LR
  A["Runtime admission"] --> B["PromptPreparationOwner"]
  B --> C["Presentation + Skill"]
  C --> D["PromptContentOwner"]
  D --> E["Notebook provenance"]
  E --> F["Context preflight"]
  F --> G["PreparedPromptHandle"]
  G --> H["Runtime Provider execution"]
  H --> I["Runtime terminal finalization"]
```

## Scope and non-goals

- Preserve prompt ordering: replay preamble -> Notebook handoff -> Specialist/framework prefix -> prepared Skill text.
- Preserve attachment/reference lineage, Skill descriptor metadata, Notebook prompt-message precedence, Context estimates, and upload-grant lifetime.
- Preserve Electron/Web/CLI/Task IPC behavior and the existing Specialist/Permission/Compute capability asymmetries.
- No public API, wire contract, persistence schema, data relationship, or user-interaction change.
- Related to #458 only as a forward compatibility constraint; this PR adds no orchestration state or interface.
- Provider execution and terminal publication remain Runtime responsibilities.

Production raw is 549 lines, within the approved 10% float on the 500-line target. `runtime.ts` decreases from 3,069 to 2,938 lines.

## Ownership and sequence

1. Runtime admits and activates the prompt interaction.
2. `AcpPromptPreparationOwner` prepares Skill/presentation/content/Notebook/Context state and owns the upload lease.
3. A ready handle transfers the Context turn once; cancellation or failure cleans preparation-owned resources.
4. Runtime verifies current interaction/Session identity, dispatches the Provider prompt, streams updates, and finalizes the turn.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Prompt ownership, content, presentation, Skill, and Context contracts -> `npm test -- --run src/main/acp/prompt-preparation-owner.test.ts src/main/acp/prompt-content-owner.test.ts src/main/acp/session-presentation-policy.test.ts src/main/acp/turn-skill-owner.test.ts src/main/acp/context-usage-tracker.test.ts` -> 5 files, 71 tests passed.
- Runtime supersession, continuation, Notebook provenance, text-only prompts, and Codex Skill metadata -> `npm test -- --run src/main/acp/runtime.test.ts -t 'does not dispatch a superseded prompt|keeps a text-only prompt|registers every finalized prompt|sends a picked Codex Skill|selects a bridged Codex Skill|updates Codex native Skill selection|adds allowed-Skill guidance|sends an app-owned continuation'` -> 9 tests passed.
- Node-side interface and consumer compatibility -> `npm run typecheck:node` -> passed.
- Changed source/tests -> targeted ESLint -> passed.
- Patch integrity -> `git diff --check` -> passed.
- Independent Standards review -> 0 findings after the Skill descriptor correction.
- Independent Spec/compatibility review -> 0 findings.

Web typecheck and UI/E2E lanes are excluded locally because no shared renderer/preload/IPC interface or UI behavior changed. CI PR Gate remains authoritative for the complete classified test plan.

## Review focus

- `PreparedPromptHandle` one-shot Context transfer and idempotent cleanup.
- Stale checks after preparation awaits and before Context writes/Provider dispatch.
- Exact prompt segment ordering and preservation of full Codex Skill descriptors.
- Notebook provenance fallback and referenced-upload grant lifetime.

## Uncovered risks

The focused suite does not directly suspend a Skill document `readFile` at the exact reset boundary. A write-before-stale guard plus the end-to-end supersession test covers the resulting behavior, while CI carries the complete Runtime and network-listener suite.
