### PR TITLE
fix(artifact-provenance): bind context to prompt runtime segment

### DIFF
--- a/src/shared/conversation-graph.test.ts
+++ b/src/shared/conversation-graph.test.ts
@@ -112,6 +112,9 @@ describe('conversation graph', () => {
       ...message('a1', 'agent', 'done', 3),
       responseToMessageId: prompt.id
     }
+    expect(getActiveConversationContext(runtimeChangedBeforeResponse, prompt.id)).toMatchObject({
+      runtimeSegmentId: resumed.runtimeSegments[0].id
+    })
     const completed = synchronizeActiveConversationMessages(
       runtimeChangedBeforeResponse,
       [prompt, response],

--- a/src/shared/conversation-graph.ts
+++ b/src/shared/conversation-graph.ts
@@ -564,10 +564,15 @@ export const getActiveConversationContext = (
   const frame = graph.frames.find((candidate) => candidate.id === graph.activeFrameId)
   if (!frame) throw new Error('Active Agent Frame not found.')
   const branch = graph.branches.find((candidate) => candidate.id === frame.activeBranchId)
-  const runtimeSegment = graph.runtimeSegments
-    .filter((segment) => segment.agentFrameId === frame.id)
-    .at(-1)
-  if (!branch || !runtimeSegment) throw new Error('Conversation execution context is incomplete.')
+  if (!branch) throw new Error('Conversation execution context is incomplete.')
+  const path = resolveMessageBranchPath(graph, branch.id)
+  const prompt = path.find((message) => message.id === promptMessageId)
+  // A later runtime switch may already have opened a Segment; durable provenance still follows the
+  // Segment that owns this prompt rather than whichever Segment happens to be newest.
+  const runtimeSegment = prompt?.runtimeSegmentId
+    ? graph.runtimeSegments.find((segment) => segment.id === prompt.runtimeSegmentId)
+    : graph.runtimeSegments.filter((segment) => segment.agentFrameId === frame.id).at(-1)
+  if (!runtimeSegment) throw new Error('Conversation execution context is incomplete.')
   const branchesById = indexById(graph.branches)
   const messageBranchAncestry: string[] = []
   let cursor: PersistedMessageBranch | undefined = branch
@@ -575,7 +580,7 @@ export const getActiveConversationContext = (
     messageBranchAncestry.unshift(cursor.id)
     cursor = cursor.parentBranchId ? branchesById.get(cursor.parentBranchId) : undefined
   }
-  const messageAncestry = resolveMessageBranchPath(graph, branch.id).map((message) => message.id)
+  const messageAncestry = path.map((message) => message.id)
   // The renderer normally synchronizes the just-appended prompt into the graph before asking for
   // context. Keep direct/legacy callers safe when they bind the prompt one step earlier.
   if (!messageAncestry.includes(promptMessageId)) messageAncestry.push(promptMessageId)


### PR DESCRIPTION
## Problem

Artifact finalization could declare the newest Runtime Segment even when the durable prompt already belonged to an earlier Segment. A runtime switch or resume between prompt persistence and delayed artifact handoff then made the finalization claim disagree with the durable Conversation Graph and raised `ArtifactFinalizationProofError`.

Closes #776.

## Proposed change

- Resolve finalization provenance from the requested prompt node's persisted Runtime Segment.
- Preserve the existing latest-Segment fallback for synthetic or legacy prompts that are not yet present in the graph.
- Keep the downstream durable ownership validation unchanged and fail-closed.

## Scope and non-goals

- No architecture, schema, data-model, data-relation, IPC-contract, or UI-flow changes.
- No relaxation of Branch, Agent Frame, message order, role, or Runtime Segment ownership checks.

## Acceptance criteria and validation

All checks below ran after the final material edit.

- Prompt provenance remains bound to its persisted Segment after a later Segment starts -> `npm test -- src/shared/conversation-graph.test.ts` -> 6 passed.
- Runtime-switch prompt context remains aligned with its durable prompt -> targeted `src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts` case -> 1 passed.
- Artifact finalization still rejects forged message ownership -> targeted `src/main/artifacts/provenance-repository.test.ts` case -> 1 passed.
- Shared main/renderer contracts typecheck -> `npm run typecheck` -> passed.
- Repository lint gate -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings.
- Complete portable suite -> `npm test` -> 769 files and 11,389 tests passed; 14 files and 184 tests skipped by project configuration.
- Changed-file formatting and patch hygiene -> Prettier check and `git diff --check` -> passed.

The renderer and artifact-finalization consumers were included because they produce and validate this context. The reviewer consumer uses a synthetic prompt that is not yet in the graph, so it retains the existing latest-Segment fallback. No platform-specific lane was added because the fix is pure graph selection logic; the complete portable suite passed.

## Review focus

Please verify that an existing prompt selects its own persisted Runtime Segment while a not-yet-persisted synthetic prompt still selects the active Segment.

## Uncovered risk

The reported Windows + Codex + DeepSeek flow is represented by deterministic graph and consumer tests, but was not rerun as a live provider end-to-end test.
