### PR TITLE
fix(updater): restore silent Windows auto-update

### DIFF
--- a/src/main/update/create-strategy.test.ts
+++ b/src/main/update/create-strategy.test.ts
@@ -84,7 +84,7 @@ describe('createUpdateStrategy', () => {
     await strategy.apply()
 
     expect(installGate).toHaveBeenCalledTimes(1)
-    expect(quitAndInstall).toHaveBeenCalledWith(false, true)
+    expect(quitAndInstall).toHaveBeenCalledWith(true, true)
   })
 
   it('uses ElectronUpdaterStrategy on darwin for a packaged stable build', () => {

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -378,7 +378,7 @@ describe('ElectronUpdaterStrategy', () => {
     expect(JSON.stringify(records)).not.toContain('raw provider diagnostic detail')
   })
 
-  it('apply shows installer progress and relaunches (quitAndInstall(false, true))', async () => {
+  it('apply installs silently and relaunches (quitAndInstall(true, true))', async () => {
     const updater = new FakeUpdater()
     const log = createLogSpy()
     const strategy = new ElectronUpdaterStrategy({
@@ -389,7 +389,7 @@ describe('ElectronUpdaterStrategy', () => {
     })
     await strategy.apply()
     expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
-    expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true)
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true)
     expect(currentApplicationShutdownTrigger()).toBe('update')
     expect(diagnosticRecords(log)).toEqual(
       expect.arrayContaining([
@@ -415,7 +415,7 @@ describe('ElectronUpdaterStrategy', () => {
 
     const status = await strategy.apply()
     expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
-    expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true)
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true)
     expect(status.state).toBe('error')
     expect(currentApplicationShutdownTrigger()).toBe('quit')
   })

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -443,8 +443,8 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   }
 
   // Triggered by the user's "Restart to update" click once the download is ready. On Windows,
-  // isSilent=false keeps the assisted NSIS progress page visible while the app files are unavailable;
-  // isForceRunAfter=true relaunches into the new version. Other updaters ignore isSilent.
+  // isSilent=true bypasses the assisted NSIS wizard and isForceRunAfter=true relaunches into the new
+  // version. Other updaters ignore isSilent.
   async apply(): Promise<UpdateStatus> {
     // Claim the update synchronously so repeat clicks or concurrent renderers cannot start a second
     // teardown/install. The broadcast also gives the renderer immediate feedback during the shutdown
@@ -508,7 +508,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.pendingInstallRollback = rollbackTrigger
     this.installerStarted = true
     try {
-      this.updater.quitAndInstall(false, true)
+      this.updater.quitAndInstall(true, true)
     } catch (error) {
       rollbackTrigger()
       this.pendingInstallRollback = undefined


### PR DESCRIPTION
## Problem

Windows in-app updates handed off to electron-updater with isSilent=false. Because the Windows package uses assisted NSIS, electron-updater omitted the /S flag and opened the installer wizard instead of completing the update and relaunching automatically.

## Proposed change

- Pass true for both isSilent and isForceRunAfter when applying an in-place update.
- Update the strategy and factory contract tests to require the silent relaunch handoff.

## Scope and non-goals

- No architecture, data model, data relationship, updater feed, or installer packaging changes.
- Preserve the existing in-app preparation state and backend process teardown gate.
- Do not change the interactive behavior of a setup executable launched manually.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Silent Windows updater handoff -> npm test -- src/main/update/electron-updater-strategy.test.ts src/main/update/create-strategy.test.ts -> 2 files passed, 46 tests passed.
- Main-process TypeScript contract -> npm run typecheck:node -> passed.
- Linted source and tests -> npm run lint -> passed with 0 errors and 17 existing warnings outside this change.
- Portable regression suite -> npm test -> 769 files passed, 14 skipped; 11,389 tests passed, 184 skipped.

The create-strategy consumer contract is included because it owns Windows strategy selection. Renderer tests are excluded because update status, IPC, and dialog behavior are unchanged.

Uncovered risk: the real NSIS install and relaunch cannot be exercised on the current macOS host; Windows CI or release-candidate validation must cover the packaged end-to-end flow.

## Review focus

Confirm that restoring quitAndInstall(true, true) correctly adds /S for the in-app Windows path while preserving the forced relaunch and the existing preparation gate.