### PR TITLE
refactor(acp): extract prompt outcome finalizer

### DIFF
--- a/src/main/acp/prompt-outcome-finalizer.test.ts
+++ b/src/main/acp/prompt-outcome-finalizer.test.ts
@@ -1,0 +1,365 @@
+import type { PromptResponse } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpRuntimeEvent } from '../../shared/acp'
+import type { ContextUsageTurnHandle } from './context-usage-tracker'
+import {
+  AcpPromptOutcomeFinalizer,
+  type AcpPromptFinalizationHandles,
+  type AcpPromptFinalizationOutcome
+} from './prompt-outcome-finalizer'
+import { AcpSessionInteractionOwner } from './session-interaction-owner'
+import type { AcpPromptSessionInteractionScope } from './session-interaction-owner'
+
+type MutableHandles = {
+  -readonly [Key in keyof AcpPromptFinalizationHandles]: AcpPromptFinalizationHandles[Key]
+}
+
+const deferred = <T = void>(): {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+} => {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+const createHarness = (
+  options: { now?: () => number } = {}
+): {
+  context: ContextUsageTurnHandle
+  events: Array<Partial<AcpRuntimeEvent>>
+  handles: MutableHandles
+  interaction: AcpPromptSessionInteractionScope
+  interactions: AcpSessionInteractionOwner
+  journal: string[]
+} => {
+  const journal: string[] = []
+  const events: Array<Partial<AcpRuntimeEvent>> = []
+  const interactions = new AcpSessionInteractionOwner({ now: options.now })
+  const interaction = interactions.claim({ sessionId: 's1', kind: 'prompt' })
+  const context = {
+    complete: vi.fn(() => {
+      journal.push('context:complete')
+      return true
+    }),
+    fail: vi.fn(() => journal.push('context:fail')),
+    supersede: vi.fn(() => journal.push('context:supersede'))
+  } as unknown as ContextUsageTurnHandle
+  const handles = {
+    sessionId: 's1',
+    promptMessageId: 'prompt-1',
+    interaction,
+    interactions,
+    permission: {
+      clearCorrelationsForSession: vi.fn(() => journal.push('permission:clear'))
+    },
+    prepared: { close: vi.fn(() => journal.push('prepared:close')) },
+    context,
+    skill: {
+      reloadDecision: { kind: 'continue' },
+      close: vi.fn((outcome) => journal.push(`skill:${outcome}`))
+    },
+    model: 'test-model',
+    emitUserMessage: vi.fn(() => journal.push('user')),
+    emitArtifact: vi.fn(async (onPublished) => {
+      journal.push('artifact:publish')
+      onPublished()
+    }),
+    disposeArtifact: vi.fn(async () => {
+      journal.push('artifact:dispose')
+    }),
+    failPendingSkillActivities: vi.fn(() => journal.push('skills:fail')),
+    recordContextUsed: vi.fn((used) => journal.push(`context:used:${used}`)),
+    errorMessage: (error) => (error instanceof Error ? error.message : String(error)),
+    errorKind: (error) => (error as { data?: { errorKind?: string } } | undefined)?.data?.errorKind,
+    pushEvent: vi.fn((event) => {
+      events.push(event)
+      journal.push(`event:${event.kind}`)
+    }),
+    emitState: vi.fn(() => journal.push('state')),
+    beforeInteractionRelease: vi.fn(() => journal.push('interaction:before-release')),
+    afterInteractionRelease: vi.fn(async () => {
+      journal.push('interaction:after-release')
+    }),
+    onPromptEnded: vi.fn(() => journal.push('prompt:end')),
+    generationActivityChanged: vi.fn(() => journal.push('activity')),
+    autoCompactIfNeeded: vi.fn(async () => {
+      journal.push('compact')
+    })
+  } satisfies AcpPromptFinalizationHandles
+  return { context, events, handles, interaction, interactions, journal }
+}
+
+const stopped = (
+  response: PromptResponse = { stopReason: 'end_turn' }
+): AcpPromptFinalizationOutcome => ({
+  kind: 'stopped',
+  response,
+  facts: {
+    turnUsage: { inputTokens: 10, cacheTokens: 2, outputTokens: 3 },
+    modelTurnCount: 4,
+    contextUsedTokens: 12
+  }
+})
+
+describe('AcpPromptOutcomeFinalizer', () => {
+  it('sequences provider facts, context, Artifact, stop publication, and cleanup', async () => {
+    const harness = createHarness({ now: () => 1234 })
+    expect(harness.interactions.captureTerminal(harness.interaction, 'stop')).toBe(true)
+
+    await expect(
+      new AcpPromptOutcomeFinalizer().finalize(harness.handles, stopped())
+    ).resolves.toEqual({ stopReason: 'end_turn' })
+
+    expect(harness.events).toEqual([
+      expect.objectContaining({
+        kind: 'stop',
+        timestamp: 1234,
+        turnUsage: {
+          inputTokens: 10,
+          cacheTokens: 2,
+          outputTokens: 3,
+          turnCount: 4
+        }
+      })
+    ])
+    expect(harness.journal).toEqual([
+      'context:used:12',
+      'context:complete',
+      'state',
+      'artifact:publish',
+      'event:stop',
+      'compact',
+      'prepared:close',
+      'artifact:dispose',
+      'interaction:before-release',
+      'permission:clear',
+      'context:supersede',
+      'interaction:after-release',
+      'prompt:end',
+      'state',
+      'skill:completed',
+      'activity'
+    ])
+    expect(harness.interactions.current('s1')).toBeUndefined()
+  })
+
+  it('keeps the captured terminal timestamp while Artifact publication is slow', async () => {
+    let now = 100
+    const harness = createHarness({ now: () => now })
+    const artifactStarted = deferred()
+    const releaseArtifact = deferred()
+    harness.handles.emitArtifact = vi.fn(async (onPublished) => {
+      artifactStarted.resolve()
+      await releaseArtifact.promise
+      onPublished()
+    })
+    expect(harness.interactions.captureTerminal(harness.interaction, 'stop')).toBe(true)
+
+    const finalization = new AcpPromptOutcomeFinalizer().finalize(harness.handles, stopped())
+    await artifactStarted.promise
+    now = 999
+    releaseArtifact.resolve()
+    await finalization
+
+    expect(harness.events).toContainEqual(expect.objectContaining({ kind: 'stop', timestamp: 100 }))
+  })
+
+  it('does not rewrite an observed stop when its callback throws and still cleans up once', async () => {
+    const harness = createHarness()
+    const callbackError = new Error('stop callback failed')
+    harness.handles.pushEvent = vi.fn((event) => {
+      harness.events.push(event)
+      throw callbackError
+    })
+    harness.handles.onPromptEnded = vi.fn(() => {
+      throw new Error('prompt-end callback failed')
+    })
+    harness.handles.prepared = {
+      close: vi.fn(() => {
+        throw new Error('prompt preparation cleanup failed')
+      })
+    }
+    harness.handles.skill = {
+      ...harness.handles.skill,
+      close: vi.fn(() => {
+        throw new Error('prompt skill cleanup failed')
+      })
+    }
+    const clearPermission = harness.handles.permission.clearCorrelationsForSession
+    harness.handles.permission = {
+      clearCorrelationsForSession: vi.fn((sessionId) => {
+        clearPermission(sessionId)
+        throw new Error('permission cleanup failed')
+      })
+    }
+    harness.handles.context = {
+      ...harness.context,
+      supersede: vi.fn(() => {
+        harness.context.supersede()
+        throw new Error('context cleanup failed')
+      })
+    }
+    harness.handles.interactions = {
+      captureTerminal: harness.interactions.captureTerminal.bind(harness.interactions),
+      current: harness.interactions.current.bind(harness.interactions),
+      settle: harness.interactions.settle.bind(harness.interactions),
+      release: vi.fn((scope) => {
+        harness.interactions.release(scope)
+        throw new Error('interaction cleanup failed')
+      })
+    }
+    harness.handles.beforeInteractionRelease = vi.fn(() => {
+      throw new Error('interaction pre-release failed')
+    })
+    harness.handles.afterInteractionRelease = vi.fn(async () => {
+      throw new Error('interaction post-release failed')
+    })
+    expect(harness.interactions.captureTerminal(harness.interaction, 'stop')).toBe(true)
+
+    await expect(new AcpPromptOutcomeFinalizer().finalize(harness.handles, stopped())).rejects.toBe(
+      callbackError
+    )
+
+    expect(harness.events.map((event) => event.kind)).toEqual(['stop'])
+    expect(harness.handles.prepared.close).toHaveBeenCalledOnce()
+    expect(harness.handles.disposeArtifact).toHaveBeenCalledOnce()
+    expect(harness.handles.beforeInteractionRelease).toHaveBeenCalledOnce()
+    expect(harness.handles.afterInteractionRelease).toHaveBeenCalledOnce()
+    expect(harness.handles.permission.clearCorrelationsForSession).toHaveBeenCalledOnce()
+    expect(harness.context.supersede).toHaveBeenCalledOnce()
+    expect(harness.handles.onPromptEnded).toHaveBeenCalledOnce()
+    expect(harness.handles.skill.close).toHaveBeenCalledOnce()
+    expect(harness.handles.generationActivityChanged).toHaveBeenCalledOnce()
+  })
+
+  it('retries Artifact publication before the observed stop', async () => {
+    const harness = createHarness()
+    const artifactError = new Error('temporary Artifact failure')
+    harness.handles.emitArtifact = vi
+      .fn<(onPublished: () => void) => Promise<void>>()
+      .mockRejectedValueOnce(artifactError)
+      .mockImplementationOnce(async (onPublished) => {
+        harness.journal.push('event:artifact')
+        onPublished()
+      })
+    expect(harness.interactions.captureTerminal(harness.interaction, 'stop')).toBe(true)
+
+    await expect(new AcpPromptOutcomeFinalizer().finalize(harness.handles, stopped())).rejects.toBe(
+      artifactError
+    )
+
+    expect(harness.handles.emitArtifact).toHaveBeenCalledTimes(2)
+    expect(harness.journal.indexOf('event:artifact')).toBeLessThan(
+      harness.journal.indexOf('event:stop')
+    )
+  })
+
+  it('does not replay an Artifact appended before its callback failed', async () => {
+    const harness = createHarness()
+    const callbackError = new Error('artifact callback failed')
+    harness.handles.emitArtifact = vi.fn(async (onPublished) => {
+      harness.journal.push('event:artifact')
+      onPublished()
+      throw callbackError
+    })
+    expect(harness.interactions.captureTerminal(harness.interaction, 'stop')).toBe(true)
+
+    await expect(new AcpPromptOutcomeFinalizer().finalize(harness.handles, stopped())).rejects.toBe(
+      callbackError
+    )
+
+    expect(harness.handles.emitArtifact).toHaveBeenCalledOnce()
+    expect(harness.journal.filter((entry) => entry === 'event:artifact')).toHaveLength(1)
+    expect(harness.journal.indexOf('event:artifact')).toBeLessThan(
+      harness.journal.indexOf('event:stop')
+    )
+  })
+
+  it.each([
+    {
+      name: 'context overflow',
+      error: Object.assign(new Error('Internal error'), {
+        data: { errorKind: 'request_too_large' }
+      }),
+      recoverable: 'context-overflow',
+      providerError: false
+    },
+    {
+      name: 'provider error',
+      error: Object.assign(new Error('Invalid API key'), { data: { errorName: 'APIError' } }),
+      recoverable: undefined,
+      providerError: true
+    },
+    {
+      name: 'ACP error',
+      error: new Error('protocol failed'),
+      recoverable: undefined,
+      providerError: false
+    }
+  ])('classifies a fresh $name and cleans up once', async (testCase) => {
+    const harness = createHarness({ now: () => 321 })
+    harness.handles.failPendingSkillActivities = vi.fn(() => {
+      throw new Error('skill activity callback failed')
+    })
+
+    await expect(
+      new AcpPromptOutcomeFinalizer().finalize(harness.handles, {
+        kind: 'failed',
+        error: testCase.error
+      })
+    ).rejects.toBe(testCase.error)
+
+    expect(harness.events).toContainEqual(
+      expect.objectContaining({
+        kind: 'error',
+        timestamp: 321,
+        recoverable: testCase.recoverable,
+        providerError: testCase.providerError
+      })
+    )
+    expect(harness.context.fail).toHaveBeenCalledOnce()
+    expect(harness.handles.failPendingSkillActivities).toHaveBeenCalledOnce()
+    expect(harness.context.supersede).toHaveBeenCalledOnce()
+    expect(harness.handles.skill.close).toHaveBeenCalledWith('failed')
+  })
+
+  it('keeps a replacement interaction current when the old provider outcome is superseded', async () => {
+    const harness = createHarness()
+    harness.interactions.supersede(harness.interaction)
+    const replacement = harness.interactions.claim({ sessionId: 's1', kind: 'prompt' })
+
+    await expect(
+      new AcpPromptOutcomeFinalizer().finalize(harness.handles, {
+        kind: 'superseded',
+        response: { stopReason: 'cancelled' }
+      })
+    ).resolves.toEqual({ stopReason: 'cancelled' })
+
+    expect(harness.interactions.current('s1')).toBe(replacement)
+    expect(harness.events).toEqual([])
+    expect(harness.handles.permission.clearCorrelationsForSession).not.toHaveBeenCalled()
+    expect(harness.handles.onPromptEnded).not.toHaveBeenCalled()
+    expect(harness.context.supersede).toHaveBeenCalledOnce()
+  })
+
+  it('publishes a cancelled stop for a current prompt that was not dispatched', async () => {
+    const harness = createHarness({ now: () => 456 })
+
+    await expect(
+      new AcpPromptOutcomeFinalizer().finalize(harness.handles, {
+        kind: 'not-dispatched'
+      })
+    ).resolves.toEqual({ stopReason: 'cancelled' })
+
+    expect(harness.handles.emitUserMessage).toHaveBeenCalledOnce()
+    expect(harness.events).toContainEqual(
+      expect.objectContaining({ kind: 'stop', timestamp: 456, text: 'cancelled' })
+    )
+    expect(harness.context.fail).toHaveBeenCalledOnce()
+    expect(harness.handles.skill.close).toHaveBeenCalledWith('cancelled')
+  })
+})

--- a/src/main/acp/prompt-outcome-finalizer.ts
+++ b/src/main/acp/prompt-outcome-finalizer.ts
@@ -1,0 +1,224 @@
+import type { PromptResponse } from '@agentclientprotocol/sdk'
+
+import { ACP_PROMPT_FAILED_EVENT_TITLE, type AcpRuntimeEvent } from '../../shared/acp'
+import { isMediaOverflowError } from '../../shared/media-overflow'
+import { createLogger, errorLogFields } from '../logger'
+import type { ContextUsageTurnHandle } from './context-usage-tracker'
+import type { AcpPermissionContext } from './permission-context'
+import type { PreparedPromptHandle } from './prompt-preparation-owner'
+import { describePromptError, isProviderPromptError } from './prompt-error'
+import type { ProviderPromptOutcome } from './provider-prompt-executor'
+import type { AcpPromptSessionInteractionScope } from './session-interaction-owner'
+import type { AcpSessionInteractionOwner as InteractionOwner } from './session-interaction-owner'
+import type { TurnSkillHandle, TurnSkillOutcome } from './turn-skill-owner'
+const log = createLogger('acp')
+type LogFields = Record<string, unknown>
+type LogLevel = 'error' | 'info' | 'warn'
+type RuntimeEventInput = Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>
+export type AcpPromptFinalizationOutcome =
+  ProviderPromptOutcome | Readonly<{ kind: 'failed'; error: unknown }>
+export type AcpPromptFinalizationHandles = Readonly<{
+  sessionId: string
+  promptMessageId?: string
+  interaction: AcpPromptSessionInteractionScope
+  interactions: Pick<InteractionOwner, 'captureTerminal' | 'current' | 'release' | 'settle'>
+  permission: Pick<AcpPermissionContext, 'clearCorrelationsForSession'>
+  prepared?: Pick<PreparedPromptHandle, 'close'>
+  context?: ContextUsageTurnHandle
+  skill: Pick<TurnSkillHandle, 'close' | 'reloadDecision'>
+  model?: string
+  emitUserMessage: () => void
+  emitArtifact: (onPublished: () => void) => Promise<void>
+  disposeArtifact: () => Promise<void>
+  failPendingSkillActivities: () => void
+  recordContextUsed: (used: number) => void
+  errorMessage: (error: unknown) => string
+  errorKind: (error: unknown) => string | undefined
+  pushEvent: (event: RuntimeEventInput) => void
+  emitState: () => void
+  beforeInteractionRelease: () => void
+  afterInteractionRelease: () => Promise<void>
+  onPromptEnded: () => void
+  generationActivityChanged: () => void
+  autoCompactIfNeeded: () => Promise<unknown>
+}>
+type ObservedPromptStop = Readonly<{
+  response: PromptResponse
+  turnUsage?: Extract<ProviderPromptOutcome, { kind: 'stopped' }>['facts']['turnUsage']
+  modelTurnCount?: number
+}>
+export class AcpPromptOutcomeFinalizer {
+  async finalize(
+    handles: AcpPromptFinalizationHandles,
+    outcome: AcpPromptFinalizationOutcome
+  ): Promise<PromptResponse> {
+    let artifactPublished = false
+    let artifactRetryAttempted = false
+    let skillOutcome: TurnSkillOutcome = 'failed'
+    let observedStop: ObservedPromptStop | undefined
+    const sessionId = handles.sessionId
+    const { context, interaction, interactions, permission } = handles
+    const eventIdentity = handles.promptMessageId
+      ? { promptMessageId: handles.promptMessageId }
+      : {}
+    const interactionCurrent = (): boolean => interactions.current(sessionId) === interaction
+    const logFields = (data: LogFields): LogFields => ({ sessionId, ...data })
+    const clearPermission = (): void => permission.clearCorrelationsForSession(sessionId)
+    const safeLog = (level: LogLevel, message: string, data: LogFields): void => {
+      try {
+        log[level](message, logFields(data))
+      } catch {
+        // Logging must not replace the outcome being handled.
+      }
+    }
+    const safeCleanup = (message: string, action: () => void): void => {
+      try {
+        action()
+      } catch (error) {
+        safeLog('error', message, errorLogFields(error))
+      }
+    }
+    const emitArtifact = async (): Promise<void> => {
+      await handles.emitArtifact(() => (artifactPublished = true))
+      artifactPublished = true
+    }
+    const retryArtifact = async (): Promise<void> => {
+      artifactRetryAttempted = true
+      try {
+        await emitArtifact()
+      } catch (error) {
+        safeLog('error', 'artifact emit after prompt failure failed', errorLogFields(error))
+      }
+    }
+    const publishObservedStop = (): boolean => {
+      if (!observedStop) return false
+      const terminal = interactions.settle(interaction, {
+        ...(observedStop.turnUsage ? { turnUsage: observedStop.turnUsage } : {}),
+        ...(observedStop.modelTurnCount === undefined
+          ? {}
+          : { modelTurnCount: observedStop.modelTurnCount })
+      })
+      if (!terminal) return false
+      handles.pushEvent({
+        kind: 'stop',
+        level: 'info',
+        sessionId,
+        ...eventIdentity,
+        timestamp: terminal.timestamp,
+        title: 'Prompt stopped',
+        text: observedStop.response.stopReason,
+        turnUsage: terminal.turnUsage,
+        raw: observedStop.response
+      })
+      return true
+    }
+    try {
+      if (outcome.kind === 'failed') throw outcome.error
+      if (outcome.kind === 'superseded') return outcome.response
+      if (outcome.kind === 'not-dispatched') {
+        skillOutcome = 'cancelled'
+        const response: PromptResponse = { stopReason: 'cancelled' }
+        observedStop = { response }
+        if (!interactions.captureTerminal(interaction, 'cancelled')) return response
+        handles.emitUserMessage()
+        await emitArtifact()
+        safeLog('info', 'prompt stopped', { stopReason: response.stopReason })
+        context?.fail()
+        publishObservedStop()
+        return response
+      }
+      const { response, facts } = outcome
+      skillOutcome = response.stopReason === 'cancelled' ? 'cancelled' : 'completed'
+      observedStop = {
+        response,
+        ...(facts.turnUsage ? { turnUsage: facts.turnUsage } : {}),
+        ...(facts.modelTurnCount === undefined ? {} : { modelTurnCount: facts.modelTurnCount })
+      }
+      if (facts.contextUsedTokens !== undefined) handles.recordContextUsed(facts.contextUsedTokens)
+      if (context?.complete()) handles.emitState()
+      await emitArtifact()
+      safeLog('info', 'prompt stopped', { stopReason: response.stopReason })
+      publishObservedStop()
+      try {
+        await handles.autoCompactIfNeeded()
+      } catch (error) {
+        safeLog('warn', 'automatic context compaction failed', errorLogFields(error))
+      }
+      return response
+    } catch (error) {
+      if (observedStop) {
+        context?.complete()
+        if (!artifactPublished) await retryArtifact()
+        if (publishObservedStop()) {
+          safeLog('warn', 'prompt terminal finalization failed', errorLogFields(error))
+        }
+        throw error
+      }
+      if (!interactionCurrent()) {
+        context?.supersede()
+        throw error
+      }
+      if (!interactions.captureTerminal(interaction, 'error')) throw error
+      context?.fail()
+      safeCleanup('skill activity cleanup failed', handles.failPendingSkillActivities)
+      safeLog('error', 'prompt failed', errorLogFields(error))
+      const text = describePromptError(error, { model: handles.model })
+      const recoverable =
+        isMediaOverflowError(text) ||
+        isMediaOverflowError(handles.errorMessage(error)) ||
+        isMediaOverflowError(handles.errorKind(error))
+          ? 'context-overflow'
+          : undefined
+      const terminal = interactions.settle(interaction, {})
+      if (!terminal) throw error
+      handles.pushEvent({
+        kind: 'error',
+        level: 'error',
+        recoverable,
+        providerError: isProviderPromptError(error),
+        sessionId,
+        ...eventIdentity,
+        timestamp: terminal.timestamp,
+        title: ACP_PROMPT_FAILED_EVENT_TITLE,
+        text
+      })
+      throw error
+    } finally {
+      safeCleanup('prompt preparation cleanup failed', () => handles.prepared?.close())
+      if (!artifactPublished && !artifactRetryAttempted) await retryArtifact()
+      try {
+        await handles.disposeArtifact()
+      } catch (error) {
+        safeCleanup('Artifact cleanup event failed', () =>
+          handles.pushEvent({
+            kind: 'error',
+            level: 'error',
+            sessionId,
+            ...eventIdentity,
+            title: 'Artifact cleanup failed',
+            text: handles.errorMessage(error)
+          })
+        )
+      }
+      const ownsInteraction = interactionCurrent()
+      if (ownsInteraction) {
+        safeCleanup('interaction pre-release failed', handles.beforeInteractionRelease)
+        safeCleanup('permission cleanup failed', clearPermission)
+      }
+      safeCleanup('context cleanup failed', () => context?.supersede())
+      safeCleanup('interaction cleanup failed', () => interactions.release(interaction))
+      if (ownsInteraction) {
+        try {
+          await handles.afterInteractionRelease()
+        } catch (error) {
+          safeLog('error', 'interaction post-release failed', errorLogFields(error))
+        }
+        safeCleanup('prompt-end callback failed', handles.onPromptEnded)
+      }
+      safeCleanup('emitState after prompt turn failed', handles.emitState)
+      safeCleanup('prompt skill cleanup failed', () => handles.skill.close(skillOutcome))
+      if (handles.skill.reloadDecision.kind === 'continue')
+        safeCleanup('activity callback failed', handles.generationActivityChanged)
+    }
+  }
+}

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -15020,7 +15020,7 @@ describe('ACP runtime session management', () => {
       if (listAttempts === 1) throw new Error('temporary Artifact list failure')
       return [generatedArtifact]
     })
-    const artifactEvents: AcpRuntimeEvent[] = []
+    const terminalEvents: AcpRuntimeEvent[] = []
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['remote-session-1'])
     const runtime = new AcpRuntime({
@@ -15040,19 +15040,26 @@ describe('ACP runtime session management', () => {
       },
       callbacks: {
         onEvent: (event) => {
-          if (event.kind === 'artifact') artifactEvents.push(event)
+          if (event.kind === 'artifact' || event.kind === 'stop') terminalEvents.push(event)
         }
       }
     })
     const session = await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
 
-    await expect(
-      runtime.sendPrompt({ sessionId: session.sessionId, text: 'prepare an Artifact claim' })
-    ).rejects.toThrow('temporary Artifact list failure')
+    warnLogSpy.mockImplementation(() => {
+      throw new Error('logger failed')
+    })
+    try {
+      await expect(
+        runtime.sendPrompt({ sessionId: session.sessionId, text: 'prepare an Artifact claim' })
+      ).rejects.toThrow('temporary Artifact list failure')
+    } finally {
+      warnLogSpy.mockReset()
+    }
 
     expect(listRunVersions).toHaveBeenCalledTimes(2)
-    expect(artifactEvents).toHaveLength(1)
-    const claim = resolveArtifactRunClaim(runtime, artifactEvents[0].artifactClaimId!)
+    expect(terminalEvents.map((event) => event.kind)).toEqual(['artifact', 'stop'])
+    const claim = resolveArtifactRunClaim(runtime, terminalEvents[0].artifactClaimId!)
     expect(claim.artifactVersionIds).toEqual(['version-1'])
     await expect(
       repository.findRunFinalizationMarker('project-1', claim.runId)
@@ -15174,6 +15181,8 @@ describe('ACP runtime session management', () => {
               artifactClaimId: event.artifactClaimId,
               artifactCount: event.artifacts?.length
             })
+          } else if (event.kind === 'stop') {
+            events.push({ kind: event.kind, sessionId: event.sessionId })
           }
         }
       }
@@ -15194,6 +15203,10 @@ describe('ACP runtime session management', () => {
         promptMessageId: expect.stringMatching(/^prompt-artifact-run-/),
         artifactClaimId: expect.stringMatching(/^artifact-claim-/),
         artifactCount: 1
+      },
+      {
+        kind: 'stop',
+        sessionId: 'remote-session-1'
       }
     ])
     await expect(
@@ -15944,6 +15957,38 @@ describe('ACP runtime session management', () => {
         code: -32603,
         data: { errorKind: 'request_too_large' }
       })
+    )
+  })
+
+  it('preserves a provider failure and its terminal event when the failure logger throws', async () => {
+    const process = new FakeAgentProcess()
+    const events: AcpRuntimeEvent[] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: () => {
+        throw acp.RequestError.internalError({ errorKind: 'invalid_request' }, 'provider failed')
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onEvent: (event) => events.push(event) }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    errorLogSpy.mockImplementation(() => {
+      throw new Error('logger failed')
+    })
+    try {
+      await expect(
+        runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'hi' })
+      ).rejects.toMatchObject({ code: -32603, data: { errorKind: 'invalid_request' } })
+    } finally {
+      errorLogSpy.mockReset()
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({ kind: 'error', title: ACP_PROMPT_FAILED_EVENT_TITLE })
     )
   })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -25,7 +25,6 @@ import type {
   AcpResumeSessionRequest,
   AcpRevokePermissionGrantRequest,
   AcpContextUsage,
-  AcpTurnTokenUsage,
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
@@ -51,7 +50,6 @@ import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import { extractProviderToolName } from './runtime-events'
 import { fetchOpenCodeUsageSnapshot } from './opencode-turn-usage'
 import { matchSessionModelOption, resolveSessionEffortOption } from './session-config'
-import { describePromptError, isProviderPromptError } from './prompt-error'
 import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { ConversationPermissionGrantStore } from './permission-broker'
 import { isMcpToolName } from './permission-policy'
@@ -82,7 +80,6 @@ import type { UploadRepository } from '../uploads/repository'
 import { DEFAULT_UPLOAD_PROJECT_NAME, type UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, FileReference } from '../../shared/artifacts'
 import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
-import { isMediaOverflowError } from '../../shared/media-overflow'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
 import {
   ReviewerSessionOwner,
@@ -134,16 +131,15 @@ import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
 import { AcpPromptPreparationOwner, type PreparedPromptHandle } from './prompt-preparation-owner'
 import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import { AcpProviderPromptExecutor } from './provider-prompt-executor'
+import {
+  AcpPromptOutcomeFinalizer,
+  type AcpPromptFinalizationOutcome
+} from './prompt-outcome-finalizer'
 import type { AcpProviderTurnAdapter } from './provider-turn-adapter'
 import { claudeCodeTurnAdapter } from './claude-turn-adapter'
 import { createCodexTurnAdapter } from './codex-turn-adapter'
 import { AcpOpenCodeTurnAdapter } from './opencode-turn-adapter'
-import {
-  AcpTurnSkillOwner,
-  type AcpTurnSkillHooks,
-  type TurnSkillHandle,
-  type TurnSkillOutcome
-} from './turn-skill-owner'
+import { AcpTurnSkillOwner, type AcpTurnSkillHooks, type TurnSkillHandle } from './turn-skill-owner'
 import { createProductionPlanService } from '../session-plan/production-plan-service'
 import {
   PLAN_FIRST_TURN_PROMPT_REMINDER,
@@ -414,6 +410,7 @@ class AcpRuntime {
   private readonly sessionConfigurator: AcpSessionConfigurator
   private readonly sessionUpdateProjector = new AcpSessionUpdateProjector()
   private readonly providerPromptExecutor = new AcpProviderPromptExecutor()
+  private readonly promptOutcomeFinalizer = new AcpPromptOutcomeFinalizer()
   // Injectable lifecycle timers (defaults to real setTimeout/clearTimeout).
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
@@ -2094,87 +2091,37 @@ class AcpRuntime {
       textLength: request.text?.length ?? 0
     })
     let artifactRun: ArtifactTurnHandle | undefined
-    let artifactEmitted = false
     let skillActivityInputs: Array<{ name: string; path: string }> = []
     let skillActivitiesStarted = false
     let skillActivitiesFinalized = false
     let preparedPromptHandle: PreparedPromptHandle | undefined
     let contextUsageTurn: ContextUsageTurnHandle | undefined
-    let turnSkillOutcome: TurnSkillOutcome = 'failed'
-    let observedPromptStop:
-      | {
-          response: PromptResponse
-          turnUsage?: AcpTurnTokenUsage
-          modelTurnCount?: number
-        }
-      | undefined
-    const publishObservedPromptStop = (): boolean => {
-      if (!observedPromptStop) return false
-      const terminal = this.sessionInteractions.settle(promptInteraction, {
-        ...(observedPromptStop.turnUsage ? { turnUsage: observedPromptStop.turnUsage } : {}),
-        ...(observedPromptStop.modelTurnCount === undefined
-          ? {}
-          : { modelTurnCount: observedPromptStop.modelTurnCount })
-      })
-      if (!terminal) return false
+    let userMessageEmitted = false
+    const emitUserMessage = (): void => {
+      if (
+        !publishUserMessage ||
+        request.continuation ||
+        request.suppressUserMessage ||
+        userMessageEmitted
+      )
+        return
+      userMessageEmitted = true
       this.pushEvent({
-        kind: 'stop',
+        kind: 'message',
         level: 'info',
         sessionId: request.sessionId,
         ...promptEventIdentity,
-        timestamp: terminal.timestamp,
-        title: 'Prompt stopped',
-        text: observedPromptStop.response.stopReason,
-        turnUsage: terminal.turnUsage,
-        raw: observedPromptStop.response
+        role: 'user',
+        text: request.text
       })
-      return true
     }
-
-    try {
+    const executePrompt = async (): Promise<AcpPromptFinalizationOutcome> => {
       // Create a fresh run context before prompting so MCP writes can be attributed to this turn.
       artifactRun = await this.activateArtifactRun(request.sessionId, request.provenanceContext)
-      let userMessageEmitted = false
-      const emitUserMessage = (): void => {
-        if (
-          !publishUserMessage ||
-          request.continuation ||
-          request.suppressUserMessage ||
-          userMessageEmitted
-        )
-          return
-        userMessageEmitted = true
-        this.pushEvent({
-          kind: 'message',
-          level: 'info',
-          sessionId: request.sessionId,
-          ...promptEventIdentity,
-          role: 'user',
-          text: request.text
-        })
-      }
-      const finishCancelledBeforePrompt = async (): Promise<PromptResponse> => {
-        turnSkillOutcome = 'cancelled'
-        const response: PromptResponse = { stopReason: 'cancelled' }
-        observedPromptStop = { response }
-        if (!this.sessionInteractions.captureTerminal(promptInteraction, 'cancelled')) {
-          return response
-        }
-        emitUserMessage()
-        await this.emitArtifactRunEvent(request.sessionId, artifactRun)
-        artifactEmitted = true
-        log.info('prompt stopped', {
-          sessionId: request.sessionId,
-          stopReason: response.stopReason
-        })
-        contextUsageTurn?.fail()
-        publishObservedPromptStop()
-        return response
-      }
       if (
         (await this.sessionInteractions.cancellationCheckpoint(promptInteraction)) === 'cancelled'
       ) {
-        return finishCancelledBeforePrompt()
+        return Object.freeze({ kind: 'not-dispatched' })
       }
 
       const sessionSpecialistPrefix = this.sessionRegistry
@@ -2224,7 +2171,7 @@ class AcpRuntime {
           : {})
       })
       if (preparedPromptHandle.status === 'cancelled') {
-        return finishCancelledBeforePrompt()
+        return Object.freeze({ kind: 'not-dispatched' })
       }
       const promptContent = preparedPromptHandle.content
       skillActivityInputs = [...preparedPromptHandle.skillActivityInputs]
@@ -2245,7 +2192,7 @@ class AcpRuntime {
         .lookup(request.sessionId)
         ?.aggregate.snapshot()
       const promptFramework = promptSessionSnapshot?.frameworkId ?? this.framework.id
-      const providerOutcome = await this.providerPromptExecutor.execute({
+      return this.providerPromptExecutor.execute({
         session: activeSession,
         content: promptContent,
         cwd: promptSessionSnapshot?.cwd ?? this.snapshotOwner.cwd,
@@ -2315,180 +2262,75 @@ class AcpRuntime {
             ...errorLogFields(error)
           })
       })
+    }
 
-      if (providerOutcome.kind === 'not-dispatched') {
-        return finishCancelledBeforePrompt()
-      }
-      if (providerOutcome.kind === 'superseded') {
-        return providerOutcome.response
-      }
-      const { response, facts } = providerOutcome
-      turnSkillOutcome = response.stopReason === 'cancelled' ? 'cancelled' : 'completed'
-      observedPromptStop = {
-        response,
-        ...(facts.turnUsage ? { turnUsage: facts.turnUsage } : {}),
-        ...(facts.modelTurnCount === undefined ? {} : { modelTurnCount: facts.modelTurnCount })
-      }
-      if (facts.contextUsedTokens !== undefined) {
-        this.recordProviderPromptContextUsage(
-          request.sessionId,
-          facts.contextUsedTokens,
-          promptTurn
-        )
-      }
-      if (contextUsageTurn.complete()) this.emitState()
-      // Emit artifact metadata before stop so the renderer can attach files to the finished message.
-      await this.emitArtifactRunEvent(request.sessionId, artifactRun)
-      artifactEmitted = true
-      log.info('prompt stopped', {
-        sessionId: request.sessionId,
-        stopReason: response.stopReason
-      })
-      publishObservedPromptStop()
-      if (
-        this.sessionInteractions.current(request.sessionId) === promptInteraction &&
-        this.activeSessionFor(request.sessionId) === activeSession &&
-        this.shouldAutoCompactContext(request.sessionId)
-      ) {
-        try {
-          await this.performNativeContextCompaction(activeSession, request.sessionId, 'automatic')
-        } catch (error) {
-          log.warn('automatic context compaction failed', {
-            sessionId: request.sessionId,
-            ...errorLogFields(error)
-          })
-        }
-      }
-      return response
+    let outcome: AcpPromptFinalizationOutcome
+    try {
+      outcome = await executePrompt()
     } catch (error) {
-      if (observedPromptStop) {
-        // Provider stop/cancellation already won the outcome race. App-side finalization failure,
-        // reset, or connection teardown cannot rewrite it as a prompt failure.
-        contextUsageTurn?.complete()
-        if (publishObservedPromptStop()) {
-          log.warn('prompt terminal finalization failed', {
-            sessionId: request.sessionId,
-            ...errorLogFields(error)
-          })
-        }
-        throw error
-      }
-      if (this.sessionInteractions.current(request.sessionId) !== promptInteraction) {
-        // Reset/replacement is silent. Unexpected connection teardown settles and publishes every
-        // visible prompt in handleConnectionClosed before releasing its interaction scope.
-        contextUsageTurn?.supersede()
-        throw error
-      }
-      // A fresh provider failure captures its terminal outcome before rollback work can add latency.
-      if (!this.sessionInteractions.captureTerminal(promptInteraction, 'error')) throw error
-      contextUsageTurn?.fail()
-      if (skillActivitiesStarted && !skillActivitiesFinalized) {
-        this.emitCodexSkillInputActivities(
-          request.sessionId,
-          promptTurn,
-          skillActivityInputs,
-          'failed'
-        )
-        skillActivitiesFinalized = true
-      }
-      // errorLogFields keeps the RequestError message/code/data visible in the file log — a raw Error
-      // nested in the payload serializes without its (non-enumerable) message, which once hid the
-      // provider's real rejection reason from the log.
-      log.error('prompt failed', { sessionId: request.sessionId, ...errorLogFields(error) })
-      const text = describePromptError(error, { model: this.backend.session.model })
-      // Tag a request-size overflow as recoverable so the renderer tries native compaction, falls back
-      // to context replacement + text replay, and retries instead of dead-ending.
-      // The structured errorKind slug is checked alongside the message text: providers relay the same
-      // overflow in different wordings, and a slug-only match needs no message at all.
-      const recoverable =
-        isMediaOverflowError(text) ||
-        isMediaOverflowError(errorMessage(error)) ||
-        isMediaOverflowError(acpErrorKind(error))
-          ? 'context-overflow'
-          : undefined
-      const terminal = this.sessionInteractions.settle(promptInteraction, {})
-      if (!terminal) throw error
-      this.pushEvent({
-        kind: 'error',
-        level: 'error',
-        recoverable,
-        // Tag a model-provider failure (upstream LLM/HTTP error the agent relayed) so the renderer
-        // keeps the message but hides the "Report error" button — only ACP-layer exceptions are bugs
-        // worth a GitHub issue. Determined structurally from the agent's signals, not the message text.
-        providerError: isProviderPromptError(error),
+      outcome = Object.freeze({ kind: 'failed', error })
+    }
+    return this.promptOutcomeFinalizer.finalize(
+      {
         sessionId: request.sessionId,
         ...promptEventIdentity,
-        timestamp: terminal.timestamp,
-        title: ACP_PROMPT_FAILED_EVENT_TITLE,
-        text
-      })
-      throw error
-    } finally {
-      preparedPromptHandle?.close()
-      // A turn that fails or is aborted never reaches the stop branch; still surface any files it
-      // wrote so they are attached to a message instead of being orphaned in the pending directory.
-      if (!artifactEmitted) {
-        try {
-          await this.emitArtifactRunEvent(request.sessionId, artifactRun)
-        } catch (error) {
-          log.error('artifact emit after prompt failure failed', {
-            sessionId: request.sessionId,
-            ...errorLogFields(error)
-          })
-        }
-      }
-      try {
-        await this.clearArtifactRun(artifactRun)
-      } catch (error) {
-        this.pushEvent({
-          kind: 'error',
-          level: 'error',
-          sessionId: request.sessionId,
-          ...promptEventIdentity,
-          title: 'Artifact cleanup failed',
-          text: errorMessage(error)
-        })
-      }
-      // ArtifactTurnOwner clears only the handle that still owns this Session. A superseded turn's
-      // delayed finally therefore cannot erase the replacement turn's handoff or active-run state.
-      const ownsInteraction =
-        this.sessionInteractions.current(request.sessionId) === promptInteraction
-      if (ownsInteraction) {
-        const planBinding = this.planExecutionBindings.get(request.sessionId)
-        if (planBinding?.interactionSequence === promptInteraction.sequence) {
-          this.planExecutionBindings.delete(request.sessionId)
-        }
-        const planWaiter = this.planApprovalWaiters.get(request.sessionId)
-        if (planWaiter?.interactionId === promptInteraction.promptMessageId) {
-          this.rejectPlanApprovalWaiter(
+        interaction: promptInteraction,
+        interactions: this.sessionInteractions,
+        permission: this.permissionContext,
+        ...(preparedPromptHandle ? { prepared: preparedPromptHandle } : {}),
+        ...(contextUsageTurn ? { context: contextUsageTurn } : {}),
+        skill: turnSkillHandle,
+        ...(this.backend.session.model ? { model: this.backend.session.model } : {}),
+        emitUserMessage,
+        emitArtifact: (onPublished) =>
+          this.emitArtifactRunEvent(request.sessionId, artifactRun, onPublished),
+        disposeArtifact: () => this.clearArtifactRun(artifactRun),
+        failPendingSkillActivities: () => {
+          if (!skillActivitiesStarted || skillActivitiesFinalized) return
+          this.emitCodexSkillInputActivities(
             request.sessionId,
-            'The Session Plan interaction ended before approval.'
+            promptTurn,
+            skillActivityInputs,
+            'failed'
           )
-        }
-        this.permissionContext.clearCorrelationsForSession(request.sessionId)
-      }
-      contextUsageTurn?.supersede()
-      this.sessionInteractions.release(promptInteraction)
-      if (ownsInteraction) await this.publishTerminalPlanProjection(request.sessionId)
-      if (ownsInteraction) {
-        try {
-          this.callbacks.onPromptEnded?.(request.sessionId, skillImportTurnToken)
-        } catch (error) {
-          safeLogError('prompt-end callback failed', errorLogFields(error))
-        }
-      }
-      // emitState invokes the renderer onStateChanged callback; guard it so a throw there cannot skip
-      // transition arbitration and strand a barrier awaited by a later createSession.
-      try {
-        this.emitState()
-      } catch (error) {
-        safeLogError('emitState after prompt turn failed', errorLogFields(error))
-      }
-      turnSkillHandle.close(turnSkillOutcome)
-      if (turnSkillHandle.reloadDecision.kind === 'continue') {
-        this.generationActivityChanged()
-      }
-    }
+          skillActivitiesFinalized = true
+        },
+        recordContextUsed: (used) =>
+          this.recordProviderPromptContextUsage(request.sessionId, used, promptTurn),
+        errorMessage,
+        errorKind: acpErrorKind,
+        pushEvent: (event) => this.pushEvent(event),
+        emitState: () => this.emitState(),
+        onPromptEnded: () =>
+          this.callbacks.onPromptEnded?.(request.sessionId, skillImportTurnToken),
+        generationActivityChanged: () => this.generationActivityChanged(),
+        autoCompactIfNeeded: () => {
+          if (
+            this.sessionInteractions.current(request.sessionId) !== promptInteraction ||
+            this.activeSessionFor(request.sessionId) !== activeSession ||
+            !this.shouldAutoCompactContext(request.sessionId)
+          ) {
+            return Promise.resolve()
+          }
+          return this.performNativeContextCompaction(activeSession, request.sessionId, 'automatic')
+        },
+        beforeInteractionRelease: () => {
+          const planBinding = this.planExecutionBindings.get(request.sessionId)
+          if (planBinding?.interactionSequence === promptInteraction.sequence) {
+            this.planExecutionBindings.delete(request.sessionId)
+          }
+          const planWaiter = this.planApprovalWaiters.get(request.sessionId)
+          if (planWaiter?.interactionId === promptInteraction.promptMessageId) {
+            this.rejectPlanApprovalWaiter(
+              request.sessionId,
+              'The Session Plan interaction ended before approval.'
+            )
+          }
+        },
+        afterInteractionRelease: () => this.publishTerminalPlanProjection(request.sessionId)
+      },
+      outcome
+    )
   }
 
   // Requests cancellation without clearing in-flight state before the agent stops.
@@ -2748,23 +2590,27 @@ class AcpRuntime {
   // Publishes pending files as a claim event; the renderer later supplies the final message id.
   private async emitArtifactRunEvent(
     sessionId: string,
-    artifactRun: ArtifactTurnHandle | undefined
+    artifactRun: ArtifactTurnHandle | undefined,
+    onPublished?: () => void
   ): Promise<void> {
     if (!artifactRun || !this.artifactTurns) return
     const publication = await this.artifactTurns.finalize(artifactRun)
     if (!publication) return
 
-    this.pushEvent({
-      kind: 'artifact',
-      level: 'info',
-      sessionId,
-      title: 'Generated files',
-      runId: publication.runId,
-      promptMessageId: publication.promptMessageId,
-      artifactSessionId: publication.artifactStorageSessionId,
-      artifactClaimId: publication.artifactClaimId,
-      artifacts: publication.artifacts
-    })
+    this.pushEvent(
+      {
+        kind: 'artifact',
+        level: 'info',
+        sessionId,
+        title: 'Generated files',
+        runId: publication.runId,
+        promptMessageId: publication.promptMessageId,
+        artifactSessionId: publication.artifactStorageSessionId,
+        artifactClaimId: publication.artifactClaimId,
+        artifacts: publication.artifacts
+      },
+      onPublished
+    )
   }
 
   // Hands permission requests to the broker so the renderer can answer later. Any failure is logged with
@@ -3191,7 +3037,8 @@ class AcpRuntime {
 
   // Adds a bounded event entry and notifies all renderer listeners.
   private pushEvent(
-    event: Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>
+    event: Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>,
+    onAppended?: () => void
   ): void {
     const currentPromptMessageId = event.sessionId
       ? this.currentPromptInteraction(event.sessionId)?.promptMessageId
@@ -3201,6 +3048,7 @@ class AcpRuntime {
         ? { ...event, promptMessageId: currentPromptMessageId }
         : event
     const runtimeEvent = this.snapshotOwner.appendEvent(scopedEvent)
+    onAppended?.()
     this.callbacks.onEvent?.(runtimeEvent)
     this.emitState()
   }


### PR DESCRIPTION
## Problem

`AcpRuntime.sendPromptTurn` still owned provider-outcome interpretation, terminal event publication, context settlement, Artifact finalization, and cross-owner cleanup. That kept state-transition policy embedded in the Runtime composition root and made callback failures capable of obscuring terminal outcomes.

## Proposed change

- Add a stateless `AcpPromptOutcomeFinalizer` that consumes the provider outcome and narrow owner handles.
- Preserve the captured terminal timestamp, token usage, model-turn count, context settlement, overflow/provider-error classification, and stale-interaction behavior.
- Publish Artifact claims before stop events, retry a transient pre-publication failure before stop, and acknowledge Snapshot append so callback failures cannot duplicate Artifact events.
- Isolate logging and cleanup callbacks so they cannot replace the provider outcome or prevent later cleanup.
- Keep #777 Session Plan state in `PlanService`/Runtime. The Finalizer receives only release lifecycle hooks: Runtime clears the matching binding/waiter before interaction release and publishes the terminal projection after release.

```mermaid
flowchart LR
  Executor["Provider prompt executor"] --> Runtime["Runtime adapters"]
  Runtime --> Finalizer["Prompt outcome finalizer"]
  Finalizer --> Interaction["Interaction owner"]
  Finalizer --> Context["Context usage owner"]
  Finalizer --> Artifact["Artifact turn owner"]
  Finalizer --> Snapshot["Runtime snapshot events"]
  Finalizer -. "release hooks only" .-> Plan["Runtime + PlanService"]
```

## Scope and non-goals

- No public ACP, preload, IPC, Web, Electron, CLI, or Task API changes.
- No persistence schema, Session Plan contract, orchestration data, or renderer interaction changes.
- Specialist, Permission, and Compute capability asymmetries remain unchanged.
- Reviewer sessions and provider-specific Session adoption/replay behavior remain unchanged.
- Related forward-compatibility context: #458. The implemented #777 Plan ownership remains authoritative; this PR does not introduce another Plan owner.

## Acceptance criteria and validation

All listed checks ran against the final material state after the last edit.

- Outcome sequencing, owner cleanup, stale replacement, callback failures, and Plan release hooks → `npm test -- --run src/main/acp/prompt-outcome-finalizer.test.ts src/main/acp/provider-prompt-executor.test.ts src/main/acp/session-interaction-owner.test.ts src/main/acp/context-usage-tracker.test.ts src/main/acp/turn-skill-owner.test.ts src/main/acp/prompt-preparation-owner.test.ts src/main/acp/runtime-session-plan.test.ts` → 7 files / 103 tests passed.
- Runtime integration, Artifact ordering/retry, hostile logger behavior, provider errors, and #777 Plan completion/projection flows → `npm test -- --run src/main/acp/runtime.test.ts` → 438 tests passed.
- Node-process contracts → `npm run typecheck:node` → passed.
- Changed TypeScript files → targeted ESLint → passed.
- Changed files → Prettier check and `git diff --check` → passed.

Renderer, Web, CLI, E2E, persistence migration, and platform lanes were excluded locally because the final diff changes only ACP main-process internals and their tests; no cross-process contract or platform/process primitive changed. The authoritative PR Gate remains responsible for its classified consumer and platform lanes.

Production raw is 586 lines, within the explicitly approved 600-line ceiling for the #777 compatibility adjustment.

## Review focus

- Artifact append acknowledgement and Artifact-before-stop ordering under transient and callback failures.
- Exact-once terminal settlement and preservation of the original provider error when callbacks or logging throw.
- Session Plan binding/waiter cleanup before interaction release and terminal projection after release, without moving Plan state into the Finalizer.
- Ownership boundaries: the Finalizer must remain stateless and must not become a second owner for Interaction, Context, Artifact, Permission, Skill, Snapshot, or Plan data.
