### PR TITLE
fix(ci): install dependencies before Windows upgrade smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install dependencies
+        run: npm install
+
       - name: Download current Windows installer
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:


### PR DESCRIPTION
## Problem

The `windows-upgrade-smoke` job in `release.yml` runs `node scripts/windows-installer-smoke.mjs` without first installing dependencies. The script imports `@modelcontextprotocol/sdk`, so it fails with `ERR_MODULE_NOT_FOUND` on the release runner.

This caused the v0.11.0 release action to fail.

## Proposed change

Add an `Install dependencies` step (`npm install`) between `Setup Node` and `Download current Windows installer` in the `windows-upgrade-smoke` job, matching how `build.yml` runs the same smoke script inside a job that already has dependencies installed.

## Scope and non-goals

- One workflow file change: `.github/workflows/release.yml`
- No source, build, or test logic changes.

## Acceptance criteria and validation

- CI (PR Gate) on `main` → `fix/release-windows-smoke-install`.
- The release retry (after merge) should pass the `windows-upgrade-smoke` step.
