### PR TITLE
fix(ci): install Windows upgrade smoke dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --omit=dev --omit=optional --no-audit --no-fund
+
       - name: Download current Windows installer
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -100,6 +100,9 @@ describe('post-merge Windows validation', () => {
       uses: 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020',
       with: { 'node-version': 22 }
     })
+    expect(findStep(upgrade, 'Install dependencies').run).toBe(
+      'npm ci --ignore-scripts --omit=dev --omit=optional --no-audit --no-fund'
+    )
     expect(findStep(upgrade, 'Download current Windows installer').uses).toBe(
       'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c'
     )


### PR DESCRIPTION
## Problem

The tagged `v0.11.0` release failed before the Windows upgrade smoke could start because the isolated job ran `scripts/windows-installer-smoke.mjs` without installing its `@modelcontextprotocol/sdk` dependency.

## Proposed change

- Install locked production dependencies before the upgrade smoke.
- Skip dev/optional packages, lifecycle scripts, audits, and funding checks because this job only executes the repository smoke script.
- Assert the exact install contract in the existing release workflow test.

## Scope and non-goals

- Changes only the Windows upgrade-smoke release job and its workflow contract test.
- Does not change application architecture, data models, data relationships, or user interactions.
- Does not move or recreate the `v0.11.0` tag.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- Windows upgrade-smoke dependency bootstrap -> `npm test -- scripts/windows-release-workflows.test.ts` -> 7/7 passed.
- Node and renderer type safety -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors (17 pre-existing warnings).
- Global release-workflow impact fallback -> `npm test` -> 780 files / 11,582 tests passed; 14 files / 184 tests skipped by the suite.

Consumer/platform selection: the release workflow contract test is the direct consumer check; the full portable suite covers global workflow-input risk. The actual previous-version Windows installer upgrade remains covered only by the tagged Windows Actions lane and cannot be reproduced on this macOS host.

## Review focus

- Confirm the dependency install is sufficient for the standalone smoke script without running the repository's heavy `postinstall` hooks.
- Confirm the tag recovery procedure should recreate `v0.11.0` after this fix merges rather than rerun the old tagged SHA.

Related failed run: https://github.com/aipoch/open-science/actions/runs/31009918356
