### PR TITLE
refactor(acp): extract prompt turn admission workflow

### DIFF
--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -1,0 +1,270 @@
+import type { ActiveSession, PromptResponse } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi, type Mock } from 'vitest'
+
+import type { AcpPromptRequest } from '../../shared/acp'
+import {
+  AcpPromptTurnWorkflow,
+  type AcpActivatedPromptTurn,
+  type AcpPromptTurnWorkflowOptions
+} from './prompt-turn-workflow'
+import { AcpSessionInteractionOwner } from './session-interaction-owner'
+import type { TurnSkillHandle } from './turn-skill-owner'
+
+type Deferred<T> = { promise: Promise<T>; resolve: (value: T) => void }
+type Harness = {
+  admitPlan: Mock<AcpPromptTurnWorkflowOptions['admitPlan']>
+  authorize: Mock<AcpPromptTurnWorkflowOptions['skills']['authorize']>
+  continueTurn: Mock<AcpPromptTurnWorkflowOptions['continueTurn']>
+  interactions: {
+    current: Mock<AcpSessionInteractionOwner['current']>
+    reservePrompt: Mock<AcpSessionInteractionOwner['reservePrompt']>
+    activatePrompt: Mock<AcpSessionInteractionOwner['activatePrompt']>
+    release: Mock<AcpSessionInteractionOwner['release']>
+  }
+  journal: string[]
+  owner: AcpSessionInteractionOwner
+  preflightPlan: Mock<AcpPromptTurnWorkflowOptions['preflightPlan']>
+  resumeAfterReload: Mock<AcpPromptTurnWorkflowOptions['resumeAfterReload']>
+  setSession: (replacement: ActiveSession) => void
+  workflow: AcpPromptTurnWorkflow
+}
+
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => (resolve = done))
+  return { promise, resolve }
+}
+
+const skillHandle = (kind: 'continue' | 'reload' = 'continue'): TurnSkillHandle => ({
+  reloadDecision: { kind },
+  prepareProvider: vi.fn(async ({ promptText }) => ({ text: promptText, codexSkillInputs: [] })),
+  close: vi.fn()
+})
+
+const createHarness = (
+  input: {
+    authorize?: () => TurnSkillHandle | Promise<TurnSkillHandle>
+    preflightPlan?: AcpPromptTurnWorkflowOptions['preflightPlan']
+    onPromptStarted?: () => void
+  } = {}
+): Harness => {
+  const journal: string[] = []
+  const owner = new AcpSessionInteractionOwner()
+  let session = { sessionId: 'provider-1' } as ActiveSession
+  const snapshot = (): {
+    cwd: string
+    specialistId: string
+    permissionProfile: { selectedProfile: 'ask' }
+  } => ({
+    cwd: '/session',
+    specialistId: 'specialist-1',
+    permissionProfile: { selectedProfile: 'ask' }
+  })
+  const lookup = vi.fn(() => ({ aggregate: { snapshot }, attachment: { session } }))
+  const interactions = {
+    current: vi.fn((sessionId: string) => owner.current(sessionId)),
+    reservePrompt: vi.fn((request: Parameters<typeof owner.reservePrompt>[0]) => {
+      journal.push('reserve')
+      return owner.reservePrompt(request)
+    }),
+    activatePrompt: vi.fn((scope: Parameters<typeof owner.activatePrompt>[0]) => {
+      journal.push('activate')
+      return owner.activatePrompt(scope)
+    }),
+    release: vi.fn((scope: Parameters<typeof owner.release>[0]) => owner.release(scope))
+  }
+  const authorize = vi.fn(() => {
+    journal.push('authorize')
+    return input.authorize?.() ?? skillHandle()
+  })
+  const preflightPlan = vi.fn((request: AcpPromptRequest) => {
+    journal.push('preflight')
+    return input.preflightPlan?.(request) ?? {}
+  })
+  const admitPlan = vi.fn(() => {
+    journal.push('admit')
+    return {}
+  })
+  const continueTurn = vi.fn(async (_turn: AcpActivatedPromptTurn): Promise<PromptResponse> => {
+    void _turn
+    journal.push('continue')
+    return { stopReason: 'end_turn' }
+  })
+  const resumeAfterReload = vi.fn(async () => ({ contextReset: false }))
+  const workflow = new AcpPromptTurnWorkflow({
+    registry: {
+      lookup,
+      select: vi.fn(() => journal.push('select'))
+    },
+    interactions,
+    skills: { authorize },
+    currentCwd: () => '/default',
+    resolveProjectName: () => 'project-1',
+    preflightPlan,
+    admitPlan,
+    disconnectForReload: vi.fn(async () => journal.push('disconnect')),
+    resumeAfterReload,
+    recordAdmittedPrompt: vi.fn(() => journal.push('handoff')),
+    onPromptStarted: vi.fn(() => {
+      journal.push('start')
+      input.onPromptStarted?.()
+    }),
+    emitState: vi.fn(() => journal.push('state')),
+    continueTurn
+  } as unknown as AcpPromptTurnWorkflowOptions)
+  return {
+    admitPlan,
+    authorize,
+    continueTurn,
+    interactions,
+    journal,
+    owner,
+    preflightPlan,
+    resumeAfterReload,
+    setSession: (replacement: ActiveSession) => (session = replacement),
+    workflow
+  }
+}
+
+const request = (): AcpPromptRequest => ({
+  sessionId: 's1',
+  text: 'analyze',
+  forcedSkillIds: ['research'],
+  provenanceContext: { promptMessageId: 'message-1' }
+})
+
+describe('AcpPromptTurnWorkflow', () => {
+  it('admits one user turn in owner order and transfers its opaque handles', async () => {
+    const harness = createHarness()
+
+    const turn = harness.workflow.run(request(), {
+      kind: 'user',
+      promptAttemptId: 'attempt-1'
+    })
+
+    // Ordinary prompts reserve and publish admission callbacks synchronously; callers observe both
+    // before awaiting the provider result.
+    expect(harness.interactions.reservePrompt).toHaveBeenCalledOnce()
+    expect(harness.journal).toEqual([
+      'preflight',
+      'reserve',
+      'authorize',
+      'activate',
+      'admit',
+      'select',
+      'handoff',
+      'start',
+      'state',
+      'continue'
+    ])
+    await expect(turn).resolves.toEqual({ stopReason: 'end_turn' })
+    expect(harness.continueTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: expect.objectContaining({ sessionId: 's1' }),
+        mode: { kind: 'user', promptAttemptId: 'attempt-1' },
+        interaction: expect.objectContaining({ kind: 'prompt', promptMessageId: 'message-1' })
+      })
+    )
+  })
+
+  it('propagates app-continuation mode and its originating turn token unchanged', async () => {
+    const harness = createHarness()
+    const continuation = request()
+    continuation.continuation = {
+      kind: 'specialist-handoff',
+      originatingTurnToken: 'origin-turn',
+      targetName: 'Reviewer',
+      completion: { kind: 'returned', value: 'done' }
+    }
+
+    await harness.workflow.run(continuation, {
+      kind: 'app-continuation',
+      promptAttemptId: 'attempt-2'
+    })
+
+    expect(harness.continueTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: continuation,
+        mode: { kind: 'app-continuation', promptAttemptId: 'attempt-2' },
+        interaction: expect.objectContaining({ turnToken: 'origin-turn' })
+      })
+    )
+  })
+
+  it('cannot let delayed admission clear a newer active interaction', async () => {
+    const authorization = deferred<TurnSkillHandle>()
+    const staleSkill = skillHandle()
+    const harness = createHarness({ authorize: () => authorization.promise })
+    const stale = harness.workflow.run(request(), { kind: 'user' })
+    await vi.waitFor(() => expect(harness.authorize).toHaveBeenCalledOnce())
+    const staleReservation = harness.interactions.reservePrompt.mock.results[0].value
+    const replacement = harness.owner.activatePrompt(
+      harness.owner.reservePrompt({ sessionId: 's1', kind: 'prompt' })
+    )
+
+    authorization.resolve(staleSkill)
+
+    await expect(stale).rejects.toThrow('already running')
+    expect(staleSkill.close).toHaveBeenCalledWith('failed')
+    expect(harness.interactions.release).toHaveBeenCalledWith(staleReservation)
+    expect(harness.owner.current('s1')).toBe(replacement)
+    expect(harness.continueTurn).not.toHaveBeenCalled()
+  })
+
+  it('refreshes reservation, session, and replay context after a Skill reload', async () => {
+    const harness = createHarness({ authorize: () => skillHandle('reload') })
+    const reloaded = { sessionId: 'provider-2' } as ActiveSession
+    harness.resumeAfterReload.mockImplementation(async () => {
+      harness.setSession(reloaded)
+      return { contextReset: true }
+    })
+    const turn = request()
+    turn.resumeFallback = { historyPreamble: 'restored transcript' }
+
+    await harness.workflow.run(turn, { kind: 'user' })
+
+    expect(harness.interactions.reservePrompt).toHaveBeenCalledTimes(2)
+    expect(harness.resumeAfterReload).toHaveBeenCalledWith({
+      sessionId: 's1',
+      cwd: '/session',
+      projectName: 'project-1',
+      permissionProfile: 'ask'
+    })
+    expect(turn).toMatchObject({ contextReset: true, historyPreamble: 'restored transcript' })
+    expect(harness.continueTurn.mock.calls[0][0].session).toBe(reloaded)
+  })
+
+  it('finishes Plan preflight before reserving and admits only an activated interaction', async () => {
+    const harness = createHarness()
+
+    await harness.workflow.run(request(), { kind: 'user' })
+
+    expect(harness.journal.indexOf('preflight')).toBeLessThan(harness.journal.indexOf('reserve'))
+    expect(harness.journal.indexOf('activate')).toBeLessThan(harness.journal.indexOf('admit'))
+    expect(harness.admitPlan.mock.calls[0][1]).toBe(
+      harness.interactions.activatePrompt.mock.results[0].value
+    )
+
+    const rejected = createHarness({
+      preflightPlan: async () => {
+        throw new Error('stale Plan')
+      }
+    })
+    await expect(rejected.workflow.run(request(), { kind: 'user' })).rejects.toThrow('stale Plan')
+    expect(rejected.interactions.reservePrompt).not.toHaveBeenCalled()
+  })
+
+  it('keeps an admitted turn running when the prompt-start callback throws', async () => {
+    const harness = createHarness({
+      onPromptStarted: () => {
+        throw new Error('renderer unavailable')
+      }
+    })
+
+    await expect(harness.workflow.run(request(), { kind: 'user' })).resolves.toEqual({
+      stopReason: 'end_turn'
+    })
+    expect(harness.continueTurn).toHaveBeenCalledOnce()
+    expect(harness.journal.slice(-3)).toEqual(['start', 'state', 'continue'])
+  })
+})

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -1,0 +1,198 @@
+import type { ActiveSession, PromptResponse } from '@agentclientprotocol/sdk'
+
+import type { AcpPromptRequest } from '../../shared/acp'
+import type { ActivePlanProjection } from '../../shared/session-plan/contract'
+import {
+  DEFAULT_PERMISSION_PROFILE,
+  type PermissionProfileId
+} from '../../shared/permission-profiles'
+import { createLogger, errorLogFields } from '../logger'
+import type { AcpSessionInteractionOwner } from './session-interaction-owner'
+import type { AcpPromptSessionInteractionScope } from './session-interaction-owner'
+import type { AcpSessionRegistry } from './session-registry'
+import type { AcpTurnSkillOwner, TurnSkillHandle } from './turn-skill-owner'
+
+const log = createLogger('acp-prompt-turn-workflow')
+
+type AcpPromptTurnMode =
+  | Readonly<{ kind: 'user'; promptAttemptId?: string }>
+  | Readonly<{ kind: 'app-continuation'; promptAttemptId?: string }>
+
+type AcpPromptTurnPlanContext = Readonly<{
+  authorized?: ActivePlanProjection
+  protectedPending?: ActivePlanProjection
+}>
+
+type AcpActivatedPromptTurn = Readonly<{
+  request: AcpPromptRequest
+  mode: AcpPromptTurnMode
+  session: ActiveSession
+  interaction: AcpPromptSessionInteractionScope
+  skill: TurnSkillHandle
+  plan: AcpPromptTurnPlanContext
+}>
+
+type AcpPromptTurnWorkflowOptions = Readonly<{
+  registry: Pick<AcpSessionRegistry, 'lookup' | 'select'>
+  interactions: Pick<
+    AcpSessionInteractionOwner,
+    'activatePrompt' | 'current' | 'release' | 'reservePrompt'
+  >
+  skills: Pick<AcpTurnSkillOwner, 'authorize'>
+  currentCwd: () => string
+  resolveProjectName: (sessionId: string) => string
+  preflightPlan: (
+    request: AcpPromptRequest
+  ) => AcpPromptTurnPlanContext | Promise<AcpPromptTurnPlanContext>
+  admitPlan: (
+    request: AcpPromptRequest,
+    interaction: AcpPromptSessionInteractionScope,
+    plan: AcpPromptTurnPlanContext
+  ) => AcpPromptTurnPlanContext | Promise<AcpPromptTurnPlanContext>
+  disconnectForReload: () => Promise<unknown>
+  resumeAfterReload: (input: {
+    sessionId: string
+    cwd: string
+    projectName: string
+    permissionProfile: PermissionProfileId
+  }) => Promise<{ contextReset?: boolean }>
+  recordAdmittedPrompt: (request: AcpPromptRequest) => void
+  onPromptStarted: (sessionId: string, turnToken: string, promptAttemptId?: string) => void
+  emitState: () => void
+  continueTurn: (turn: AcpActivatedPromptTurn) => Promise<PromptResponse>
+}>
+
+class AcpPromptTurnWorkflow {
+  constructor(private readonly options: AcpPromptTurnWorkflowOptions) {}
+
+  async run(request: AcpPromptRequest, mode: AcpPromptTurnMode): Promise<PromptResponse> {
+    let activeSession = this.activeSession(request.sessionId)
+    if (!activeSession) throw new Error(`ACP session not found: ${request.sessionId}`)
+    this.assertSessionIdle(request.sessionId)
+
+    const planPreflight = this.options.preflightPlan(request)
+    let plan = planPreflight instanceof Promise ? await planPreflight : planPreflight
+    let reservation = this.reserve(request)
+    let skill: TurnSkillHandle
+    try {
+      const authorization = this.options.skills.authorize({
+        specialistId: this.options.registry.lookup(request.sessionId)?.aggregate.snapshot()
+          .specialistId,
+        selectedSkillIds: request.forcedSkillIds,
+        signal: reservation.signal
+      })
+      skill = authorization instanceof Promise ? await authorization : authorization
+    } catch (error) {
+      this.options.interactions.release(reservation)
+      throw error
+    }
+    const rejectedSkillOutcome =
+      skill.reloadDecision.kind === 'reload' ? 'reload-restored' : 'failed'
+
+    try {
+      if (skill.reloadDecision.kind === 'reload') {
+        this.assertSessionIdle(request.sessionId)
+        const snapshot = this.options.registry.lookup(request.sessionId)?.aggregate.snapshot()
+        const projectName = this.options.resolveProjectName(request.sessionId)
+        await this.options.disconnectForReload()
+        const resumed = await this.options.resumeAfterReload({
+          sessionId: request.sessionId,
+          cwd: snapshot?.cwd ?? this.options.currentCwd(),
+          projectName,
+          permissionProfile:
+            snapshot?.permissionProfile?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE
+        })
+        if (resumed.contextReset) {
+          request.historyPreamble = request.resumeFallback?.historyPreamble
+          request.historyAttachments = request.resumeFallback?.historyAttachments
+          request.historyImages = request.resumeFallback?.historyImages
+          request.contextReset = true
+        }
+        activeSession = this.activeSession(request.sessionId)
+        if (!activeSession) {
+          throw new Error(`ACP session not found after force-load: ${request.sessionId}`)
+        }
+        reservation = this.reserve(request)
+      }
+    } catch (error) {
+      skill.close('reload-restored')
+      this.options.interactions.release(reservation)
+      throw error
+    }
+
+    if (this.options.interactions.current(request.sessionId)) {
+      skill.close(rejectedSkillOutcome)
+      this.options.interactions.release(reservation)
+      throw new Error('An ACP prompt is already running for this session')
+    }
+    activeSession = this.activeSession(request.sessionId)
+    if (!activeSession) {
+      skill.close(rejectedSkillOutcome)
+      this.options.interactions.release(reservation)
+      throw new Error(`ACP session not found: ${request.sessionId}`)
+    }
+
+    let interaction: AcpPromptSessionInteractionScope | undefined
+    try {
+      interaction = this.options.interactions.activatePrompt(reservation)
+      const admittedPlan = this.options.admitPlan(request, interaction, plan)
+      plan = admittedPlan instanceof Promise ? await admittedPlan : admittedPlan
+      this.options.registry.select(request.sessionId)
+      this.options.recordAdmittedPrompt(request)
+    } catch (error) {
+      skill.close(rejectedSkillOutcome)
+      this.options.interactions.release(interaction ?? reservation)
+      throw error
+    }
+
+    try {
+      this.options.onPromptStarted(request.sessionId, interaction.turnToken, mode.promptAttemptId)
+    } catch (error) {
+      try {
+        log.error('prompt-start callback failed', errorLogFields(error))
+      } catch {
+        // Diagnostics must not replace the admitted prompt.
+      }
+    }
+    this.options.emitState()
+    log.info('prompt start', {
+      sessionId: request.sessionId,
+      textLength: request.text?.length ?? 0
+    })
+    return this.options.continueTurn({
+      request,
+      mode,
+      session: activeSession,
+      interaction,
+      skill,
+      plan
+    })
+  }
+
+  private activeSession(sessionId: string): ActiveSession | undefined {
+    return this.options.registry.lookup(sessionId)?.attachment?.session
+  }
+
+  private assertSessionIdle(sessionId: string): void {
+    if (this.options.interactions.current(sessionId)) {
+      throw new Error('An ACP prompt is already running for this session')
+    }
+  }
+
+  private reserve(request: AcpPromptRequest): AcpPromptSessionInteractionScope {
+    return this.options.interactions.reservePrompt({
+      sessionId: request.sessionId,
+      kind: 'prompt',
+      promptMessageId: request.provenanceContext?.promptMessageId,
+      turnToken: request.continuation?.originatingTurnToken
+    })
+  }
+}
+
+export { AcpPromptTurnWorkflow }
+export type {
+  AcpActivatedPromptTurn,
+  AcpPromptTurnMode,
+  AcpPromptTurnPlanContext,
+  AcpPromptTurnWorkflowOptions
+}

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -129,6 +129,11 @@ import { AcpProviderSessionResumer } from './provider-session-resumer'
 import { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
 import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
 import { AcpPromptPreparationOwner, type PreparedPromptHandle } from './prompt-preparation-owner'
+import {
+  AcpPromptTurnWorkflow,
+  type AcpActivatedPromptTurn,
+  type AcpPromptTurnPlanContext
+} from './prompt-turn-workflow'
 import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import { AcpProviderPromptExecutor } from './provider-prompt-executor'
 import {
@@ -139,7 +144,7 @@ import type { AcpProviderTurnAdapter } from './provider-turn-adapter'
 import { claudeCodeTurnAdapter } from './claude-turn-adapter'
 import { createCodexTurnAdapter } from './codex-turn-adapter'
 import { AcpOpenCodeTurnAdapter } from './opencode-turn-adapter'
-import { AcpTurnSkillOwner, type AcpTurnSkillHooks, type TurnSkillHandle } from './turn-skill-owner'
+import { AcpTurnSkillOwner, type AcpTurnSkillHooks } from './turn-skill-owner'
 import { createProductionPlanService } from '../session-plan/production-plan-service'
 import {
   PLAN_FIRST_TURN_PROMPT_REMINDER,
@@ -433,6 +438,7 @@ class AcpRuntime {
   >()
   private readonly promptContentOwner: AcpPromptContentOwner
   private readonly promptPreparation: AcpPromptPreparationOwner
+  private readonly promptTurnWorkflow: AcpPromptTurnWorkflow
   private readonly connectionClose: AcpConnectionCloseWorkflow
   private readonly connectionLifecycle: AcpConnectionLifecycleWorkflow
   private readonly modelChanges: AcpModelChangeWorkflow
@@ -613,6 +619,22 @@ class AcpRuntime {
       removeStartupBlocker: (token) => this.generationActivity.releaseStartup(token),
       unregisterBridgeSession: (sessionId) =>
         this.connectionResources.unregisterBridgeReviewerSession(sessionId)
+    })
+    this.promptTurnWorkflow = new AcpPromptTurnWorkflow({
+      registry: this.sessionRegistry,
+      interactions: this.sessionInteractions,
+      skills: this.turnSkills,
+      currentCwd: () => this.snapshotOwner.cwd,
+      resolveProjectName: (sessionId) => this.resolveSessionProjectName(sessionId),
+      preflightPlan: (request) => this.preflightPromptPlan(request),
+      admitPlan: (request, interaction, plan) => this.admitPromptPlan(request, interaction, plan),
+      disconnectForReload: () => this.disconnect(false),
+      resumeAfterReload: (request) => this.resumeSession(request),
+      recordAdmittedPrompt: (request) => this.handoffContinuity.recordAdmittedPrompt(request),
+      onPromptStarted: (sessionId, turnToken, promptAttemptId) =>
+        this.callbacks.onPromptStarted?.(sessionId, turnToken, promptAttemptId),
+      emitState: () => this.emitState(),
+      continueTurn: (turn) => this.continuePromptTurn(turn)
     })
     const closeState: CloseState = {
       invalidatePendingSessionStartups: () => this.invalidatePendingSessionStartups(),
@@ -1871,40 +1893,9 @@ class AcpRuntime {
     )
   }
 
-  // Sends one prompt turn to the targeted session and streams updates until stop.
-  async sendPrompt(request: AcpPromptRequest, promptAttemptId?: string): Promise<PromptResponse> {
-    return this.withOperationLease(() =>
-      withDataRootWrite(() => this.sendPromptTurn(request, promptAttemptId, true))
-    )
-  }
-
-  // App-owned continuations participate in the same prompt ownership, cancellation, provenance, and
-  // accounting lifecycle as user turns. Their synthesized control text is provider input, however,
-  // and must never be projected into the transcript as a second user-authored message.
-  async sendAppContinuation(
-    request: AcpPromptRequest,
-    promptAttemptId?: string
-  ): Promise<PromptResponse> {
-    return this.withOperationLease(() =>
-      withDataRootWrite(() => this.sendPromptTurn(request, promptAttemptId, false))
-    )
-  }
-
-  private async sendPromptTurn(
-    request: AcpPromptRequest,
-    promptAttemptId: string | undefined,
-    publishUserMessage: boolean
-  ): Promise<PromptResponse> {
-    let activeSession = this.activeSessionFor(request.sessionId)
-
-    if (!activeSession) {
-      throw new Error(`ACP session not found: ${request.sessionId}`)
-    }
-
-    if (this.hasSessionInteractionInFlight(request.sessionId)) {
-      throw new Error('An ACP prompt is already running for this session')
-    }
-
+  private preflightPromptPlan(
+    request: AcpPromptRequest
+  ): AcpPromptTurnPlanContext | Promise<AcpPromptTurnPlanContext> {
     if (
       request.planContinuation &&
       request.planContinuation.projectId !== this.resolveSessionProjectName(request.sessionId)
@@ -1917,179 +1908,118 @@ class AcpRuntime {
     if (request.planContinuation && !this.planService) {
       throw new Error('Session Plan capability is not configured.')
     }
-    let authorizedPlanContinuation =
-      request.planContinuation && request.planContinuation.pendingAction === undefined
-        ? await this.planService!.authorizeContinuation({
-            projectId: request.planContinuation.projectId,
-            sessionId: request.sessionId,
-            artifactVersionId: request.planContinuation.artifactVersionId,
-            expectedRevision: request.planContinuation.expectedRevision
-          })
-        : undefined
-    let protectedPendingPlan: ActivePlanProjection | undefined
-    if (request.planContinuation?.pendingAction === 'review') {
-      const projection = await this.planService!.getProjection(
-        request.planContinuation.projectId,
-        request.sessionId,
-        { interactionIsLive: false }
-      )
-      if (!projection) {
+    const continuation = request.planContinuation
+    if (continuation?.pendingAction === undefined && continuation) {
+      return this.planService!.authorizeContinuation({
+        projectId: continuation.projectId,
+        sessionId: request.sessionId,
+        artifactVersionId: continuation.artifactVersionId,
+        expectedRevision: continuation.expectedRevision
+      }).then((authorized) => Object.freeze({ authorized }))
+    }
+    if (continuation?.pendingAction !== 'review') return Object.freeze({})
+    return this.planService!.getProjection(continuation.projectId, request.sessionId, {
+      interactionIsLive: false
+    }).then((protectedPending) => {
+      if (!protectedPending) {
         throw new PlanCommandError('no-active-plan', 'The Session has no active Plan.')
       }
-      if (projection.artifactVersionId !== request.planContinuation.artifactVersionId) {
+      if (protectedPending.artifactVersionId !== continuation.artifactVersionId) {
         throw new PlanCommandError('stale-plan', 'A newer Plan is active.')
       }
-      if (projection.revision !== request.planContinuation.expectedRevision) {
+      if (protectedPending.revision !== continuation.expectedRevision) {
         throw new PlanCommandError('revision-conflict', 'The Plan revision is stale.')
       }
-      if (projection.approval !== 'pending') {
+      if (protectedPending.approval !== 'pending') {
         throw new PlanCommandError('approval-already-decided', 'Plan approval is irreversible.')
       }
-      protectedPendingPlan = projection
-    }
-
-    // Reserve this attempt before Specialist/skill authorization can yield. A newer preflight may
-    // supersede the reservation without publishing an in-flight turn, preserving the existing
-    // last-admitted-preflight behavior while preventing a stale attempt from using a replaced session.
-    let promptReservation = this.sessionInteractions.reservePrompt({
-      sessionId: request.sessionId,
-      kind: 'prompt',
-      promptMessageId: request.provenanceContext?.promptMessageId,
-      turnToken: request.continuation?.originatingTurnToken
+      return Object.freeze({ protectedPending })
     })
+  }
 
-    let turnSkillHandle: TurnSkillHandle
-    try {
-      const authorization = this.turnSkills.authorize({
-        specialistId: this.sessionRegistry.lookup(request.sessionId)?.aggregate.snapshot()
-          .specialistId,
-        selectedSkillIds: request.forcedSkillIds,
-        signal: promptReservation.signal
-      })
-      turnSkillHandle = authorization instanceof Promise ? await authorization : authorization
-    } catch (error) {
-      this.sessionInteractions.release(promptReservation)
-      throw error
-    }
-    const rejectedSkillOutcome =
-      turnSkillHandle.reloadDecision.kind === 'reload' ? 'reload-restored' : 'failed'
-
-    try {
-      if (turnSkillHandle.reloadDecision.kind === 'reload') {
-        if (this.hasSessionInteractionInFlight(request.sessionId)) {
-          throw new Error('An ACP prompt is already running for this session')
-        }
-
-        const aggregateSnapshot = this.sessionRegistry
-          .lookup(request.sessionId)
-          ?.aggregate.snapshot()
-        const sessionCwd = aggregateSnapshot?.cwd ?? this.snapshotOwner.cwd
-        const projectName = this.resolveSessionProjectName(request.sessionId)
-        const permissionProfile =
-          aggregateSnapshot?.permissionProfile?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE
-        await this.disconnect(false)
-        const reloadResume = await this.resumeSession({
-          sessionId: request.sessionId,
-          cwd: sessionCwd,
-          projectName,
-          permissionProfile
-        })
-        if (reloadResume.contextReset) {
-          request.historyPreamble = request.resumeFallback?.historyPreamble
-          request.historyAttachments = request.resumeFallback?.historyAttachments
-          request.historyImages = request.resumeFallback?.historyImages
-          request.contextReset = true
-        }
-
-        const reloaded = this.activeSessionFor(request.sessionId)
-        if (!reloaded) {
-          throw new Error(`ACP session not found after force-load: ${request.sessionId}`)
-        }
-        activeSession = reloaded
-        promptReservation = this.sessionInteractions.reservePrompt({
-          sessionId: request.sessionId,
-          kind: 'prompt',
-          promptMessageId: request.provenanceContext?.promptMessageId,
-          turnToken: request.continuation?.originatingTurnToken
+  private admitPromptPlan(
+    request: AcpPromptRequest,
+    interaction: AcpPromptSessionInteractionScope,
+    plan: AcpPromptTurnPlanContext
+  ): AcpPromptTurnPlanContext | Promise<AcpPromptTurnPlanContext> {
+    let { authorized, protectedPending } = plan
+    const continuation = request.planContinuation
+    const decision = continuation?.pendingAction
+    const committed = (): AcpPromptTurnPlanContext => {
+      if (authorized) {
+        this.planExecutionBindings.set(request.sessionId, {
+          interactionSequence: interaction.sequence,
+          artifactVersionId: authorized.artifactVersionId
         })
       }
-    } catch (error) {
-      turnSkillHandle.close('reload-restored')
-      this.sessionInteractions.release(promptReservation)
-      throw error
+      return Object.freeze({
+        ...(authorized ? { authorized } : {}),
+        ...(protectedPending ? { protectedPending } : {})
+      })
     }
-
-    // Another prompt can claim this session while authorization preflight is awaiting. Activate only
-    // the newest reservation so a delayed attempt cannot overwrite a newer turn's lifecycle state.
-    if (this.hasSessionInteractionInFlight(request.sessionId)) {
-      turnSkillHandle.close(rejectedSkillOutcome)
-      this.sessionInteractions.release(promptReservation)
-      throw new Error('An ACP prompt is already running for this session')
-    }
-
-    const refreshedActiveSession = this.activeSessionFor(request.sessionId)
-    if (!refreshedActiveSession) {
-      turnSkillHandle.close(rejectedSkillOutcome)
-      this.sessionInteractions.release(promptReservation)
-      throw new Error(`ACP session not found: ${request.sessionId}`)
-    }
-    activeSession = refreshedActiveSession
-
-    let promptInteraction: AcpPromptSessionInteractionScope | undefined
-    try {
-      promptInteraction = this.sessionInteractions.activatePrompt(promptReservation)
-      const pendingPlanContinuation = request.planContinuation
-      const pendingDecision = pendingPlanContinuation?.pendingAction
-      if (
-        pendingPlanContinuation &&
-        (pendingDecision === 'approve' || pendingDecision === 'reject')
-      ) {
-        const decision = await this.planService!.respond({
-          projectId: pendingPlanContinuation.projectId,
-          sessionId: request.sessionId,
-          artifactVersionId: pendingPlanContinuation.artifactVersionId,
-          expectedRevision: pendingPlanContinuation.expectedRevision,
-          decision: pendingDecision === 'approve' ? 'approved' : 'rejected',
-          interactionIsLive: true
-        })
-        if (pendingDecision === 'approve') {
-          authorizedPlanContinuation = decision.projection
-        } else {
-          protectedPendingPlan = decision.projection
+    if (continuation && (decision === 'approve' || decision === 'reject')) {
+      return this.planService!.respond({
+        projectId: continuation.projectId,
+        sessionId: request.sessionId,
+        artifactVersionId: continuation.artifactVersionId,
+        expectedRevision: continuation.expectedRevision,
+        decision: decision === 'approve' ? 'approved' : 'rejected',
+        interactionIsLive: true
+      }).then((result) => {
+        if (decision === 'approve') authorized = result.projection
+        else {
+          protectedPending = result.projection
           this.planExecutionBindings.delete(request.sessionId)
         }
-        this.resolvePlanApprovalWaiter(request.sessionId, decision)
-        this.publishPlanProjection(request.sessionId, decision.projection)
-      }
-      if (authorizedPlanContinuation) {
-        this.planExecutionBindings.set(request.sessionId, {
-          interactionSequence: promptInteraction.sequence,
-          artifactVersionId: authorizedPlanContinuation.artifactVersionId
-        })
-      }
-      this.sessionRegistry.select(request.sessionId)
-      this.handoffContinuity.recordAdmittedPrompt(request)
-    } catch (error) {
-      turnSkillHandle.close(rejectedSkillOutcome)
-      this.sessionInteractions.release(promptInteraction ?? promptReservation)
-      throw error
+        this.resolvePlanApprovalWaiter(request.sessionId, result)
+        this.publishPlanProjection(request.sessionId, result.projection)
+        return committed()
+      })
     }
-    if (!promptInteraction) throw new Error('ACP prompt interaction was not activated.')
+    return committed()
+  }
+
+  // Sends one prompt turn to the targeted session and streams updates until stop.
+  async sendPrompt(request: AcpPromptRequest, promptAttemptId?: string): Promise<PromptResponse> {
+    return this.withOperationLease(() =>
+      withDataRootWrite(() =>
+        this.promptTurnWorkflow.run(request, {
+          kind: 'user',
+          ...(promptAttemptId === undefined ? {} : { promptAttemptId })
+        })
+      )
+    )
+  }
+
+  // App-owned continuations participate in the same prompt ownership, cancellation, provenance, and
+  // accounting lifecycle as user turns. Their synthesized control text is provider input, however,
+  // and must never be projected into the transcript as a second user-authored message.
+  async sendAppContinuation(
+    request: AcpPromptRequest,
+    promptAttemptId?: string
+  ): Promise<PromptResponse> {
+    return this.withOperationLease(() =>
+      withDataRootWrite(() =>
+        this.promptTurnWorkflow.run(request, {
+          kind: 'app-continuation',
+          ...(promptAttemptId === undefined ? {} : { promptAttemptId })
+        })
+      )
+    )
+  }
+
+  private async continuePromptTurn(turn: AcpActivatedPromptTurn): Promise<PromptResponse> {
+    const { request, session: activeSession, interaction: promptInteraction } = turn
+    const turnSkillHandle = turn.skill
+    const authorizedPlanContinuation = turn.plan.authorized
+    const protectedPendingPlan = turn.plan.protectedPending
+    const publishUserMessage = turn.mode.kind === 'user'
+    const promptAttemptId = turn.mode.promptAttemptId
     const promptTurn = promptInteraction.sequence
     const skillImportTurnToken = promptInteraction.turnToken
     const promptEventIdentity = promptInteraction.promptMessageId
       ? { promptMessageId: promptInteraction.promptMessageId }
       : {}
-    try {
-      this.callbacks.onPromptStarted?.(request.sessionId, skillImportTurnToken, promptAttemptId)
-    } catch (error) {
-      safeLogError('prompt-start callback failed', errorLogFields(error))
-    }
-    this.emitState()
-    log.info('prompt start', {
-      sessionId: request.sessionId,
-      textLength: request.text?.length ?? 0
-    })
     let artifactRun: ArtifactTurnHandle | undefined
     let skillActivityInputs: Array<{ name: string; path: string }> = []
     let skillActivitiesStarted = false


### PR DESCRIPTION
## Problem

`AcpRuntime.sendPromptTurn` still owned prompt admission and activation sequencing alongside provider execution. Session availability, Plan preflight, Interaction reservation, Specialist/Skill reload, Session selection, Handoff continuity, and prompt-start callbacks therefore remained coupled to the Runtime composition root.

The latest Session Plan integration expanded this boundary enough that the complete ARD-26 cutover would exceed the approved 600-line production ceiling. This PR is ARD-26A: the admission/activation half of the workflow extraction. ARD-26B will move execution and finalization after this foundation is merged.

## Proposed change

- Add a stateless `AcpPromptTurnWorkflow` with `run(request, mode)` and a discriminated `user` / `app-continuation` mode.
- Move Session availability and concurrency checks, Plan preflight, Interaction reservation, Specialist/Skill authorization and force-load replay, activation, Plan admission/binding, Session selection, Handoff recording, and prompt-start publication into the workflow.
- Preserve ordinary-turn synchronous reservation and admission callback timing by yielding only when Plan or Skill work is actually asynchronous.
- Transfer only opaque Session, Interaction, Skill, and Plan context handles into Runtime's temporary continuation seam.
- Keep PlanService and Runtime maps as the sole Plan state owners; the workflow owns no persistent state.

```mermaid
sequenceDiagram
  participant Caller
  participant Workflow as Prompt turn workflow
  participant Plan as Runtime + PlanService
  participant Interaction as Interaction owner
  participant Skill as Skill owner
  participant Runtime as Runtime continuation

  Caller->>Workflow: run(request, mode)
  Workflow->>Plan: preflight (interactionIsLive=false)
  Workflow->>Interaction: reserve prompt
  Workflow->>Skill: authorize / optional reload
  Workflow->>Interaction: activate exact reservation
  Workflow->>Plan: admit / bind exact interaction
  Workflow->>Runtime: continue with opaque handles
  Runtime-->>Caller: PromptResponse
```

## Scope and non-goals

- No public ACP, preload, IPC, Web, Electron, CLI, or Task API changes.
- No persistence schema, Session Plan contract, orchestration data, or renderer interaction changes.
- Specialist, Permission, and Compute capability asymmetries remain unchanged.
- Provider execution, Artifact/Context orchestration, terminal finalization, deferred reconnect, and reviewer correction remain in the existing Runtime continuation until ARD-26B.
- Related forward-compatibility context: #458. The implemented Session Plan ownership remains authoritative; this PR does not introduce another Plan owner.

## Acceptance criteria and validation

All listed checks ran against the final material state after the last edit.

- Workflow admission ordering, app-continuation mode, stale cleanup, force-load replay, Plan sequencing, synchronous timing, and callback robustness → `npm test -- src/main/acp/prompt-turn-workflow.test.ts` → 1 file / 6 tests passed.
- Interaction reservation and Specialist/Skill ownership contracts → `npm test -- src/main/acp/session-interaction-owner.test.ts src/main/acp/turn-skill-owner.test.ts` → 2 files / 36 tests passed.
- Runtime integration across app continuation, concurrency, stale replacement, Artifact handoff, Skill cancellation, Plan activation/completion, and deferred reconnect → focused `src/main/acp/runtime.test.ts` impact pattern → 17 tests passed.
- Session Plan waiter, version, and interaction binding seam → `npm test -- src/main/acp/runtime-session-plan.test.ts` → 1 file / 9 tests passed.
- Coordinator prompt admission, callback, attempt ordering, and reviewer correction consumers → focused `src/main/acp/runtime-coordinator.test.ts` impact pattern → 7 tests passed.
- Node-process contracts → `npm run typecheck:node` → passed.
- Changed TypeScript files → targeted ESLint → passed.
- Changed files → Prettier check and `git diff --check` → passed.
- Independent review → Standards 0 findings; Spec 0 findings.

Renderer, Web, CLI, E2E, persistence migration, and platform lanes were excluded locally because the final diff changes only ACP main-process internals and their tests; no cross-process contract or platform/process primitive changed. The authoritative PR Gate remains responsible for classified consumer and platform lanes.

Production raw is 498 lines, within the approved 600-line ceiling.

## Review focus

- Plan preflight before reservation and approve/reject admission only after exact Interaction activation.
- Last-admitted Skill preflight behavior and exact stale-reservation cleanup across force-load replay.
- Synchronous ordinary-turn reservation, Session selection, Handoff, and prompt-start callback timing.
- Ownership boundary: the workflow must remain stateless and must not become a second owner for Session, Interaction, Skill, or Plan data.
- `user` versus `app-continuation` discrimination without changing wire requests or transcript publication behavior.
