### PR TITLE
refactor(acp): extract prompt turn execution workflow

### DIFF
--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -2,30 +2,53 @@ import type { ActiveSession, PromptResponse } from '@agentclientprotocol/sdk'
 import { describe, expect, it, vi, type Mock } from 'vitest'
 
 import type { AcpPromptRequest } from '../../shared/acp'
-import {
-  AcpPromptTurnWorkflow,
-  type AcpActivatedPromptTurn,
-  type AcpPromptTurnWorkflowOptions
-} from './prompt-turn-workflow'
+import type { ActivePlanProjection } from '../../shared/session-plan/contract'
+import { opencodeFramework } from '../agent-framework'
+import type { ArtifactTurnHandle } from './artifact-turn-owner'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import type { ContextUsageTurnHandle } from './context-usage-tracker'
+import type { ReadyPreparedPromptHandle } from './prompt-preparation-owner'
+import { AcpPromptTurnWorkflow, type AcpPromptTurnWorkflowOptions } from './prompt-turn-workflow'
+import { AcpSessionAggregate } from './session-aggregate'
 import { AcpSessionInteractionOwner } from './session-interaction-owner'
 import type { TurnSkillHandle } from './turn-skill-owner'
 
 type Deferred<T> = { promise: Promise<T>; resolve: (value: T) => void }
 type Harness = {
   admitPlan: Mock<AcpPromptTurnWorkflowOptions['admitPlan']>
+  artifacts: {
+    open: Mock<AcpPromptTurnWorkflowOptions['artifacts']['open']>
+    promptMessageIdFor: Mock<AcpPromptTurnWorkflowOptions['artifacts']['promptMessageIdFor']>
+  }
   authorize: Mock<AcpPromptTurnWorkflowOptions['skills']['authorize']>
-  continueTurn: Mock<AcpPromptTurnWorkflowOptions['continueTurn']>
+  context: ContextUsageTurnHandle
+  emitSkillActivities: Mock<AcpPromptTurnWorkflowOptions['environment']['emitSkillActivities']>
+  executor: Mock<AcpPromptTurnWorkflowOptions['executor']['execute']>
+  finalizeTurn: Mock<AcpPromptTurnWorkflowOptions['finalizeTurn']>
   interactions: {
     current: Mock<AcpSessionInteractionOwner['current']>
     reservePrompt: Mock<AcpSessionInteractionOwner['reservePrompt']>
     activatePrompt: Mock<AcpSessionInteractionOwner['activatePrompt']>
+    cancellationCheckpoint: Mock<AcpSessionInteractionOwner['cancellationCheckpoint']>
+    captureTerminal: Mock<AcpSessionInteractionOwner['captureTerminal']>
+    settle: Mock<AcpSessionInteractionOwner['settle']>
     release: Mock<AcpSessionInteractionOwner['release']>
   }
   journal: string[]
+  onProviderPromptAccepted: Mock<
+    NonNullable<AcpPromptTurnWorkflowOptions['environment']['onProviderPromptAccepted']>
+  >
   owner: AcpSessionInteractionOwner
+  planLifecycle: {
+    beforeStop: Mock<AcpPromptTurnWorkflowOptions['planLifecycle']['beforeStop']>
+  }
+  preparation: Mock<AcpPromptTurnWorkflowOptions['preparation']['prepare']>
   preflightPlan: Mock<AcpPromptTurnWorkflowOptions['preflightPlan']>
+  prepared: ReadyPreparedPromptHandle
+  pushUserMessage: Mock<AcpPromptTurnWorkflowOptions['environment']['pushUserMessage']>
   resumeAfterReload: Mock<AcpPromptTurnWorkflowOptions['resumeAfterReload']>
   setSession: (replacement: ActiveSession) => void
+  skill: TurnSkillHandle
   workflow: AcpPromptTurnWorkflow
 }
 
@@ -41,27 +64,87 @@ const skillHandle = (kind: 'continue' | 'reload' = 'continue'): TurnSkillHandle 
   close: vi.fn()
 })
 
+const backend: AcpBackendGenerationView = {
+  framework: opencodeFramework,
+  session: { model: 'test-model', modelRequired: false },
+  prompt: { systemPromptAppends: [] },
+  context: { supportsImageInput: false },
+  adapter: { nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false }
+}
+
+const planProjection = (): ActivePlanProjection => ({
+  artifactId: 'plan-1',
+  artifactVersionId: 'plan-version-1',
+  artifactChecksum: 'a'.repeat(64),
+  revision: 2,
+  approval: 'approved',
+  lifecycle: 'approved',
+  requiresExplicitContinuation: false,
+  document: {
+    schema_version: 1,
+    task_summary: 'Analyze the result',
+    phases: [
+      {
+        name: 'Analysis',
+        delegations: [
+          {
+            name: 'Primary',
+            steps: [{ title: 'Analyze', description: 'Analyze the result.' }]
+          }
+        ]
+      }
+    ],
+    desired_outputs: ['Result'],
+    feasibility: { confidence: 'high', rationale: 'Inputs are available.' }
+  },
+  stepStatuses: {},
+  stepStates: { Analyze: { status: 'not_started' } },
+  counts: { phases: 1, delegations: 1, steps: 1, completed: 0, inProgress: 0 }
+})
+
 const createHarness = (
   input: {
+    admitPlan?: AcpPromptTurnWorkflowOptions['admitPlan']
     authorize?: () => TurnSkillHandle | Promise<TurnSkillHandle>
-    preflightPlan?: AcpPromptTurnWorkflowOptions['preflightPlan']
+    cancellationCheckpoint?: AcpPromptTurnWorkflowOptions['interactions']['cancellationCheckpoint']
+    execute?: AcpPromptTurnWorkflowOptions['executor']['execute']
+    finalizeTurn?: AcpPromptTurnWorkflowOptions['finalizeTurn']
     onPromptStarted?: () => void
+    preflightPlan?: AcpPromptTurnWorkflowOptions['preflightPlan']
+    prepare?: AcpPromptTurnWorkflowOptions['preparation']['prepare']
   } = {}
 ): Harness => {
   const journal: string[] = []
   const owner = new AcpSessionInteractionOwner()
   let session = { sessionId: 'provider-1' } as ActiveSession
-  const snapshot = (): {
-    cwd: string
-    specialistId: string
-    permissionProfile: { selectedProfile: 'ask' }
-  } => ({
+  const aggregate = new AcpSessionAggregate('app-1')
+  aggregate.attach({
+    session,
     cwd: '/session',
-    specialistId: 'specialist-1',
-    permissionProfile: { selectedProfile: 'ask' }
+    projectName: 'project-1',
+    frameworkId: 'opencode',
+    permissionProfile: {
+      selectedProfile: 'ask',
+      effectiveProfile: 'ask',
+      currentModeId: 'default',
+      availableModeIds: ['default'],
+      fullAccessAvailable: false
+    }
   })
-  const lookup = vi.fn(() => ({ aggregate: { snapshot }, attachment: { session } }))
-  const interactions = {
+  aggregate.setSpecialistId('specialist-1')
+  aggregate.setSpecialistPrefix('[Analyst]')
+  const lookup = vi.fn(() => ({
+    appSessionId: 'app-1',
+    generation: 1,
+    aggregate,
+    attachment: {
+      appSessionId: 'app-1',
+      providerSessionId: session.sessionId,
+      generation: 1,
+      session
+    }
+  }))
+  const interactions: Harness['interactions'] = {
     current: vi.fn((sessionId: string) => owner.current(sessionId)),
     reservePrompt: vi.fn((request: Parameters<typeof owner.reservePrompt>[0]) => {
       journal.push('reserve')
@@ -71,33 +154,123 @@ const createHarness = (
       journal.push('activate')
       return owner.activatePrompt(scope)
     }),
+    cancellationCheckpoint: vi.fn(
+      async (scope: Parameters<typeof owner.cancellationCheckpoint>[0]) => {
+        journal.push('checkpoint')
+        return input.cancellationCheckpoint?.(scope) ?? owner.cancellationCheckpoint(scope)
+      }
+    ),
+    captureTerminal: vi.fn((...args: Parameters<typeof owner.captureTerminal>) =>
+      owner.captureTerminal(...args)
+    ),
+    settle: vi.fn((...args: Parameters<typeof owner.settle>) => owner.settle(...args)),
     release: vi.fn((scope: Parameters<typeof owner.release>[0]) => owner.release(scope))
   }
-  const authorize = vi.fn(() => {
+  const skill = skillHandle()
+  const authorize: Harness['authorize'] = vi.fn(() => {
     journal.push('authorize')
-    return input.authorize?.() ?? skillHandle()
+    return input.authorize?.() ?? skill
   })
-  const preflightPlan = vi.fn((request: AcpPromptRequest) => {
+  const preflightPlan: Harness['preflightPlan'] = vi.fn((request: AcpPromptRequest) => {
     journal.push('preflight')
     return input.preflightPlan?.(request) ?? {}
   })
-  const admitPlan = vi.fn(() => {
-    journal.push('admit')
-    return {}
+  const admitPlan: Harness['admitPlan'] = vi.fn(
+    (...args: Parameters<AcpPromptTurnWorkflowOptions['admitPlan']>) => {
+      journal.push('admit')
+      return input.admitPlan?.(...args) ?? {}
+    }
+  )
+  const context = {
+    complete: vi.fn(() => true),
+    fail: vi.fn(),
+    supersede: vi.fn()
+  } as unknown as ContextUsageTurnHandle
+  const prepared = {
+    status: 'ready',
+    content: 'provider content',
+    skillActivityInputs: [{ name: 'Research', path: '/skills/research/SKILL.md' }],
+    transferContextTurn: vi.fn(() => context),
+    close: vi.fn()
+  } satisfies ReadyPreparedPromptHandle
+  const preparation: Harness['preparation'] = vi.fn(async (request) => {
+    journal.push('prepare')
+    return input.prepare?.(request) ?? prepared
   })
-  const continueTurn = vi.fn(async (_turn: AcpActivatedPromptTurn): Promise<PromptResponse> => {
-    void _turn
-    journal.push('continue')
-    return { stopReason: 'end_turn' }
+  const planLifecycle: Harness['planLifecycle'] = {
+    beforeStop: vi.fn(async () => {
+      journal.push('plan:before-stop')
+    })
+  }
+  const onProviderPromptAccepted: Harness['onProviderPromptAccepted'] = vi.fn(() => {
+    journal.push('accepted')
   })
-  const resumeAfterReload = vi.fn(async () => ({ contextReset: false }))
-  const workflow = new AcpPromptTurnWorkflow({
+  const executor: Harness['executor'] = vi.fn(async (request) => {
+    journal.push('execute')
+    if (input.execute) return input.execute(request)
+    request.onAccepted()
+    const response: PromptResponse = { stopReason: 'end_turn' }
+    await request.beforeStop?.(response)
+    request.captureStop()
+    return { kind: 'stopped' as const, response, facts: {} }
+  })
+  const finalizeTurn: Harness['finalizeTurn'] = vi.fn(async (execution) => {
+    journal.push('finalize')
+    if (input.finalizeTurn) return input.finalizeTurn(execution)
+    if (execution.outcome.kind === 'failed') throw execution.outcome.error
+    if (execution.outcome.kind === 'not-dispatched') return { stopReason: 'cancelled' }
+    return execution.outcome.response
+  })
+  const artifact = {} as ArtifactTurnHandle
+  const artifacts: Harness['artifacts'] = {
+    open: vi.fn(async () => {
+      journal.push('artifact:open')
+      return artifact
+    }),
+    promptMessageIdFor: vi.fn(() => 'fallback-message-1')
+  }
+  const pushUserMessage: Harness['pushUserMessage'] = vi.fn(() => {
+    journal.push('event:message')
+  })
+  const emitSkillActivities: Harness['emitSkillActivities'] = vi.fn(
+    (_sessionId, _turn, _skills, status) => {
+      journal.push(`skills:${status}`)
+    }
+  )
+  const resumeAfterReload: Harness['resumeAfterReload'] = vi.fn(async () => ({
+    contextReset: false
+  }))
+  const workflowOptions = {
     registry: {
       lookup,
       select: vi.fn(() => journal.push('select'))
     },
     interactions,
     skills: { authorize },
+    preparation: { prepare: preparation },
+    executor: { execute: executor },
+    environment: {
+      backend: () => backend,
+      tooling: () => ({ artifacts: true, notebook: true, skillImport: true }),
+      bridgeSkillsAvailable: () => true,
+      skillImportEnabled: () => true,
+      contextEstimateInput: () => ({ frameworkId: 'opencode' }),
+      selectedContextWindow: () => 128_000,
+      providerAdapter: vi.fn(() => ({
+        begin: vi.fn(() => ({
+          finalize: vi.fn(() => ({})),
+          cancel: vi.fn()
+        }))
+      })),
+      emitSkillActivities,
+      onProviderPromptAccepted,
+      routeNotification: vi.fn(),
+      diagnosticContext: () => ({}),
+      pushUserMessage
+    },
+    artifacts,
+    planLifecycle,
+    finalizeTurn,
     currentCwd: () => '/default',
     resolveProjectName: () => 'project-1',
     preflightPlan,
@@ -109,19 +282,29 @@ const createHarness = (
       journal.push('start')
       input.onPromptStarted?.()
     }),
-    emitState: vi.fn(() => journal.push('state')),
-    continueTurn
-  } as unknown as AcpPromptTurnWorkflowOptions)
+    emitState: vi.fn(() => journal.push('state'))
+  } satisfies AcpPromptTurnWorkflowOptions
+  const workflow = new AcpPromptTurnWorkflow(workflowOptions)
   return {
     admitPlan,
+    artifacts,
     authorize,
-    continueTurn,
+    context,
+    emitSkillActivities,
+    executor,
+    finalizeTurn,
     interactions,
     journal,
+    onProviderPromptAccepted,
     owner,
+    planLifecycle,
+    preparation,
     preflightPlan,
+    prepared,
+    pushUserMessage,
     resumeAfterReload,
     setSession: (replacement: ActiveSession) => (session = replacement),
+    skill,
     workflow
   }
 }
@@ -134,7 +317,7 @@ const request = (): AcpPromptRequest => ({
 })
 
 describe('AcpPromptTurnWorkflow', () => {
-  it('admits one user turn in owner order and transfers its opaque handles', async () => {
+  it('admits and executes one user turn in owner order with its opaque handles', async () => {
     const harness = createHarness()
 
     const turn = harness.workflow.run(request(), {
@@ -142,9 +325,18 @@ describe('AcpPromptTurnWorkflow', () => {
       promptAttemptId: 'attempt-1'
     })
 
-    // Ordinary prompts reserve and publish admission callbacks synchronously; callers observe both
-    // before awaiting the provider result.
-    expect(harness.interactions.reservePrompt).toHaveBeenCalledOnce()
+    expect(harness.journal.slice(0, 9)).toEqual([
+      'preflight',
+      'reserve',
+      'authorize',
+      'activate',
+      'admit',
+      'select',
+      'handoff',
+      'start',
+      'state'
+    ])
+    await expect(turn).resolves.toEqual({ stopReason: 'end_turn' })
     expect(harness.journal).toEqual([
       'preflight',
       'reserve',
@@ -155,19 +347,36 @@ describe('AcpPromptTurnWorkflow', () => {
       'handoff',
       'start',
       'state',
-      'continue'
+      'artifact:open',
+      'checkpoint',
+      'prepare',
+      'event:message',
+      'skills:in_progress',
+      'execute',
+      'accepted',
+      'skills:completed',
+      'plan:before-stop',
+      'finalize'
     ])
-    await expect(turn).resolves.toEqual({ stopReason: 'end_turn' })
-    expect(harness.continueTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
+    const execution = harness.finalizeTurn.mock.calls[0][0]
+    expect(execution).toMatchObject({
+      artifact: expect.any(Object),
+      context: harness.context,
+      prepared: harness.prepared,
+      skillInputs: [{ name: 'Research', path: '/skills/research/SKILL.md' }],
+      skillStarted: true,
+      skillFinalized: true,
+      outcome: { kind: 'stopped', response: { stopReason: 'end_turn' } },
+      turn: {
         request: expect.objectContaining({ sessionId: 's1' }),
         mode: { kind: 'user', promptAttemptId: 'attempt-1' },
-        interaction: expect.objectContaining({ kind: 'prompt', promptMessageId: 'message-1' })
-      })
-    )
+        interaction: expect.objectContaining({ promptMessageId: 'message-1' }),
+        skill: harness.skill
+      }
+    })
   })
 
-  it('propagates app-continuation mode and its originating turn token unchanged', async () => {
+  it('propagates app-continuation identity without publishing its synthetic text', async () => {
     const harness = createHarness()
     const continuation = request()
     continuation.continuation = {
@@ -182,13 +391,11 @@ describe('AcpPromptTurnWorkflow', () => {
       promptAttemptId: 'attempt-2'
     })
 
-    expect(harness.continueTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        request: continuation,
-        mode: { kind: 'app-continuation', promptAttemptId: 'attempt-2' },
-        interaction: expect.objectContaining({ turnToken: 'origin-turn' })
-      })
-    )
+    const execution = harness.finalizeTurn.mock.calls[0][0]
+    execution.emitUserMessage()
+    expect(execution.turn.interaction.turnToken).toBe('origin-turn')
+    expect(harness.pushUserMessage).not.toHaveBeenCalled()
+    expect(harness.onProviderPromptAccepted).toHaveBeenCalledWith('s1', 'attempt-2')
   })
 
   it('cannot let delayed admission clear a newer active interaction', async () => {
@@ -208,11 +415,13 @@ describe('AcpPromptTurnWorkflow', () => {
     expect(staleSkill.close).toHaveBeenCalledWith('failed')
     expect(harness.interactions.release).toHaveBeenCalledWith(staleReservation)
     expect(harness.owner.current('s1')).toBe(replacement)
-    expect(harness.continueTurn).not.toHaveBeenCalled()
+    expect(harness.preparation).not.toHaveBeenCalled()
+    expect(harness.finalizeTurn).not.toHaveBeenCalled()
   })
 
   it('refreshes reservation, session, and replay context after a Skill reload', async () => {
-    const harness = createHarness({ authorize: () => skillHandle('reload') })
+    const reloadedSkill = skillHandle('reload')
+    const harness = createHarness({ authorize: () => reloadedSkill })
     const reloaded = { sessionId: 'provider-2' } as ActiveSession
     harness.resumeAfterReload.mockImplementation(async () => {
       harness.setSession(reloaded)
@@ -231,7 +440,7 @@ describe('AcpPromptTurnWorkflow', () => {
       permissionProfile: 'ask'
     })
     expect(turn).toMatchObject({ contextReset: true, historyPreamble: 'restored transcript' })
-    expect(harness.continueTurn.mock.calls[0][0].session).toBe(reloaded)
+    expect(harness.executor.mock.calls[0][0].session).toBe(reloaded)
   })
 
   it('finishes Plan preflight before reserving and admits only an activated interaction', async () => {
@@ -264,7 +473,68 @@ describe('AcpPromptTurnWorkflow', () => {
     await expect(harness.workflow.run(request(), { kind: 'user' })).resolves.toEqual({
       stopReason: 'end_turn'
     })
-    expect(harness.continueTurn).toHaveBeenCalledOnce()
-    expect(harness.journal.slice(-3)).toEqual(['start', 'state', 'continue'])
+    expect(harness.finalizeTurn).toHaveBeenCalledOnce()
+    expect(harness.journal.slice(6, 10)).toEqual(['handoff', 'start', 'state', 'artifact:open'])
+  })
+
+  it('finalizes a cancellation after Artifact activation without preparing or dispatching', async () => {
+    const harness = createHarness({ cancellationCheckpoint: async () => 'cancelled' })
+
+    await expect(harness.workflow.run(request(), { kind: 'user' })).resolves.toEqual({
+      stopReason: 'cancelled'
+    })
+
+    expect(harness.artifacts.open).toHaveBeenCalledWith('s1', {
+      promptMessageId: 'message-1'
+    })
+    expect(harness.preparation).not.toHaveBeenCalled()
+    expect(harness.executor).not.toHaveBeenCalled()
+    const execution = harness.finalizeTurn.mock.calls[0][0]
+    expect(execution.outcome).toEqual({ kind: 'not-dispatched' })
+    expect(execution).not.toHaveProperty('prepared')
+    expect(execution).not.toHaveProperty('context')
+  })
+
+  it('turns execution failure into one finalization outcome with pending Skill state', async () => {
+    const failure = new Error('provider failed')
+    const harness = createHarness({
+      execute: async () => {
+        throw failure
+      }
+    })
+
+    await expect(harness.workflow.run(request(), { kind: 'user' })).rejects.toBe(failure)
+
+    expect(harness.finalizeTurn).toHaveBeenCalledOnce()
+    const execution = harness.finalizeTurn.mock.calls[0][0]
+    expect(execution).toMatchObject({
+      outcome: { kind: 'failed', error: failure },
+      skillStarted: true,
+      skillFinalized: false
+    })
+    execution.emitUserMessage()
+    expect(harness.pushUserMessage).toHaveBeenCalledOnce()
+    expect(harness.emitSkillActivities.mock.calls.map((call) => call[3])).toEqual(['in_progress'])
+    expect(harness.onProviderPromptAccepted).not.toHaveBeenCalled()
+  })
+
+  it('passes protected Plan guidance through the interaction-scoped completion gate', async () => {
+    const projection = planProjection()
+    const harness = createHarness({ admitPlan: () => ({ authorized: projection }) })
+    const prompt = request()
+    prompt.turnIntent = 'plan-first'
+
+    await harness.workflow.run(prompt, { kind: 'user' })
+
+    expect(harness.preparation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        protectedContext: expect.stringContaining('artifact_version_id=plan-version-1'),
+        turnPromptReminders: [expect.stringContaining('Plan mode (ACTIVE')]
+      })
+    )
+    const interaction = harness.finalizeTurn.mock.calls[0][0].turn.interaction
+    expect(harness.planLifecycle.beforeStop).toHaveBeenCalledWith('s1', interaction, {
+      stopReason: 'end_turn'
+    })
   })
 })

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -1,14 +1,25 @@
-import type { ActiveSession, PromptResponse } from '@agentclientprotocol/sdk'
+import type { ActiveSession, PromptResponse, SessionNotification } from '@agentclientprotocol/sdk'
 
 import type { AcpPromptRequest } from '../../shared/acp'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
+import { formatPlanProtectedContext } from '../../shared/session-plan/contract'
+import type { AgentFrameworkId } from '../../shared/settings'
 import {
   DEFAULT_PERMISSION_PROFILE,
   type PermissionProfileId
 } from '../../shared/permission-profiles'
 import { createLogger, errorLogFields } from '../logger'
+import { PLAN_FIRST_TURN_PROMPT_REMINDER } from '../session-plan/guidance'
+import type { ArtifactTurnHandle } from './artifact-turn-owner'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import type { ContextUsageTurnHandle, SessionEstimateInput } from './context-usage-tracker'
+import type { AcpPromptFinalizationOutcome } from './prompt-outcome-finalizer'
+import type { AcpPromptPreparationOwner, PreparedPromptHandle } from './prompt-preparation-owner'
+import type { AcpProviderPromptExecutor, ProviderPromptOutcome } from './provider-prompt-executor'
+import type { AcpProviderTurnAdapter } from './provider-turn-adapter'
 import type { AcpSessionInteractionOwner } from './session-interaction-owner'
 import type { AcpPromptSessionInteractionScope } from './session-interaction-owner'
+import type { AcpSessionToolingAvailability } from './session-presentation-policy'
 import type { AcpSessionRegistry } from './session-registry'
 import type { AcpTurnSkillOwner, TurnSkillHandle } from './turn-skill-owner'
 
@@ -32,13 +43,74 @@ type AcpActivatedPromptTurn = Readonly<{
   plan: AcpPromptTurnPlanContext
 }>
 
+type AcpExecutedPromptTurn = Readonly<{
+  turn: AcpActivatedPromptTurn
+  artifact?: ArtifactTurnHandle
+  prepared?: PreparedPromptHandle
+  context?: ContextUsageTurnHandle
+  skillInputs: ReadonlyArray<{ name: string; path: string }>
+  skillStarted: boolean
+  skillFinalized: boolean
+  emitUserMessage: () => void
+  outcome: AcpPromptFinalizationOutcome
+}>
+
+type AcpPromptTurnEnvironment = Readonly<{
+  backend: () => AcpBackendGenerationView
+  tooling: () => AcpSessionToolingAvailability
+  bridgeSkillsAvailable: () => boolean
+  skillImportEnabled: () => boolean
+  contextEstimateInput: (sessionId: string) => SessionEstimateInput
+  selectedContextWindow: (sessionId: string) => number | undefined
+  providerAdapter: (frameworkId: AgentFrameworkId) => AcpProviderTurnAdapter
+  emitSkillActivities: (
+    sessionId: string,
+    promptTurn: number,
+    inputs: ReadonlyArray<{ name: string }>,
+    status: 'in_progress' | 'completed' | 'failed'
+  ) => void
+  onSkillImportAttachmentEligible?: (sessionId: string, turnToken: string, uri: string) => void
+  onProviderPromptAccepted?: (sessionId: string, promptAttemptId?: string) => void
+  routeNotification: (notification: SessionNotification, sessionId: string) => void
+  diagnosticContext: () => Record<string, unknown>
+  pushUserMessage: (input: { sessionId: string; promptMessageId?: string; text: string }) => void
+}>
+
+type AcpPromptTurnArtifacts = Readonly<{
+  open: (
+    sessionId: string,
+    provenance: AcpPromptRequest['provenanceContext']
+  ) => Promise<ArtifactTurnHandle | undefined>
+  promptMessageIdFor: (sessionId: string) => string | undefined
+}>
+
+type AcpPromptTurnPlanLifecycle = Readonly<{
+  beforeStop: (
+    sessionId: string,
+    interaction: AcpPromptSessionInteractionScope,
+    response: PromptResponse
+  ) => Promise<void>
+}>
+
 type AcpPromptTurnWorkflowOptions = Readonly<{
   registry: Pick<AcpSessionRegistry, 'lookup' | 'select'>
   interactions: Pick<
     AcpSessionInteractionOwner,
-    'activatePrompt' | 'current' | 'release' | 'reservePrompt'
+    | 'activatePrompt'
+    | 'cancellationCheckpoint'
+    | 'captureTerminal'
+    | 'current'
+    | 'release'
+    | 'reservePrompt'
+    | 'settle'
   >
   skills: Pick<AcpTurnSkillOwner, 'authorize'>
+  preparation: Pick<AcpPromptPreparationOwner, 'prepare'>
+  executor: Pick<AcpProviderPromptExecutor, 'execute'>
+  environment: AcpPromptTurnEnvironment
+  artifacts: AcpPromptTurnArtifacts
+  planLifecycle: AcpPromptTurnPlanLifecycle
+  finalizeTurn: (execution: AcpExecutedPromptTurn) => Promise<PromptResponse>
   currentCwd: () => string
   resolveProjectName: (sessionId: string) => string
   preflightPlan: (
@@ -59,7 +131,6 @@ type AcpPromptTurnWorkflowOptions = Readonly<{
   recordAdmittedPrompt: (request: AcpPromptRequest) => void
   onPromptStarted: (sessionId: string, turnToken: string, promptAttemptId?: string) => void
   emitState: () => void
-  continueTurn: (turn: AcpActivatedPromptTurn) => Promise<PromptResponse>
 }>
 
 class AcpPromptTurnWorkflow {
@@ -145,27 +216,164 @@ class AcpPromptTurnWorkflow {
       throw error
     }
 
-    try {
+    this.safeCallback('prompt-start callback failed', () =>
       this.options.onPromptStarted(request.sessionId, interaction.turnToken, mode.promptAttemptId)
-    } catch (error) {
-      try {
-        log.error('prompt-start callback failed', errorLogFields(error))
-      } catch {
-        // Diagnostics must not replace the admitted prompt.
-      }
-    }
+    )
     this.options.emitState()
     log.info('prompt start', {
       sessionId: request.sessionId,
       textLength: request.text?.length ?? 0
     })
-    return this.options.continueTurn({
+    return this.executeTurn({
       request,
       mode,
       session: activeSession,
       interaction,
       skill,
       plan
+    })
+  }
+
+  private async executeTurn(turn: AcpActivatedPromptTurn): Promise<PromptResponse> {
+    const { request, session, interaction, skill } = turn
+    const {
+      artifacts,
+      environment: env,
+      executor,
+      interactions,
+      planLifecycle,
+      preparation,
+      registry
+    } = this.options
+    const sessionId = request.sessionId
+    const promptTurn = interaction.sequence
+    const turnToken = interaction.turnToken
+    const eventIdentity = interaction.promptMessageId
+      ? { promptMessageId: interaction.promptMessageId }
+      : {}
+    let artifact: ArtifactTurnHandle | undefined
+    let prepared: PreparedPromptHandle | undefined
+    let context: ContextUsageTurnHandle | undefined
+    let skillInputs: Array<{ name: string; path: string }> = []
+    let skillStarted = false
+    let skillFinalized = false
+    let userMessageEmitted = false
+    const emitUserMessage = (): void => {
+      if (
+        turn.mode.kind !== 'user' ||
+        request.continuation ||
+        request.suppressUserMessage ||
+        userMessageEmitted
+      )
+        return
+      userMessageEmitted = true
+      env.pushUserMessage({
+        sessionId,
+        ...eventIdentity,
+        text: request.text
+      })
+    }
+    const execute = async (): Promise<ProviderPromptOutcome> => {
+      artifact = await artifacts.open(sessionId, request.provenanceContext)
+      if ((await this.checkpoint(interaction)) === 'cancelled') {
+        return Object.freeze({ kind: 'not-dispatched' })
+      }
+      const snapshot = registry.lookup(sessionId)?.aggregate.snapshot()
+      const backend = env.backend()
+      const planContext = turn.plan.authorized ?? turn.plan.protectedPending
+      prepared = await preparation.prepare({
+        request,
+        backend,
+        tooling: env.tooling(),
+        specialistPrefix: snapshot?.specialistPrefix,
+        projectId: this.options.resolveProjectName(sessionId),
+        fallbackPromptMessageId: artifacts.promptMessageIdFor(sessionId),
+        bridgeSkillsAvailable: env.bridgeSkillsAvailable(),
+        skillImportEnabled: env.skillImportEnabled(),
+        skillImportTurnToken: turnToken,
+        turnSkill: skill,
+        ...(planContext ? { protectedContext: formatPlanProtectedContext(planContext) } : {}),
+        ...(request.turnIntent === 'plan-first'
+          ? { turnPromptReminders: [PLAN_FIRST_TURN_PROMPT_REMINDER] }
+          : {}),
+        signal: interaction.signal,
+        isCurrent: () => this.isCurrent(turn),
+        cancellationCheckpoint: () => this.checkpoint(interaction),
+        contextEstimateInput: env.contextEstimateInput(sessionId),
+        selectedContextWindow: env.selectedContextWindow(sessionId),
+        ...(env.onSkillImportAttachmentEligible
+          ? {
+              onSkillImportAttachmentEligible: (uri: string) =>
+                this.safeCallback('skill import attachment callback failed', () =>
+                  env.onSkillImportAttachmentEligible?.(sessionId, turnToken, uri)
+                )
+            }
+          : {})
+      })
+      if (prepared.status === 'cancelled') return Object.freeze({ kind: 'not-dispatched' })
+      skillInputs = [...prepared.skillActivityInputs]
+      context = prepared.transferContextTurn()
+      emitUserMessage()
+      if (skillInputs.length > 0) {
+        env.emitSkillActivities(sessionId, promptTurn, skillInputs, 'in_progress')
+        skillStarted = true
+      }
+      const promptSnapshot = registry.lookup(sessionId)?.aggregate.snapshot()
+      return executor.execute({
+        session,
+        content: prepared.content,
+        cwd: promptSnapshot?.cwd ?? this.options.currentCwd(),
+        adapter: env.providerAdapter(promptSnapshot?.frameworkId ?? env.backend().framework.id),
+        isCurrent: () => this.isCurrent(turn),
+        beforeDispatch: async () => {
+          if ((await this.checkpoint(interaction)) === 'cancelled') return 'cancelled'
+          if (request.historyPreamble) {
+            log.info('session transcript replay dispatched', {
+              sessionId,
+              historyTextLength: request.historyPreamble.length,
+              historyAttachmentCount: request.historyAttachments?.length ?? 0,
+              historyImageCount: request.historyImages?.length ?? 0,
+              ...env.diagnosticContext()
+            })
+          }
+          return 'active'
+        },
+        captureStop: () => interactions.captureTerminal(interaction, 'stop'),
+        onAccepted: () => {
+          this.safeCallback('provider-prompt-accepted callback failed', () =>
+            env.onProviderPromptAccepted?.(sessionId, turn.mode.promptAttemptId)
+          )
+          if (skillStarted && !skillFinalized) {
+            env.emitSkillActivities(sessionId, promptTurn, skillInputs, 'completed')
+            skillFinalized = true
+          }
+        },
+        beforeStop: (response) => planLifecycle.beforeStop(sessionId, interaction, response),
+        routeNotification: (notification) => env.routeNotification(notification, sessionId),
+        reportBestEffortFailure: (stage, error) =>
+          log.warn('provider prompt observation failed', {
+            sessionId,
+            stage,
+            ...errorLogFields(error)
+          })
+      })
+    }
+    let outcome: AcpPromptFinalizationOutcome
+    try {
+      outcome = await execute()
+    } catch (error) {
+      outcome = Object.freeze({ kind: 'failed', error })
+    }
+    return this.options.finalizeTurn({
+      turn,
+      ...(artifact ? { artifact } : {}),
+      ...(prepared ? { prepared } : {}),
+      ...(context ? { context } : {}),
+      skillInputs,
+      skillStarted,
+      skillFinalized,
+      emitUserMessage,
+      outcome
     })
   }
 
@@ -187,11 +395,36 @@ class AcpPromptTurnWorkflow {
       turnToken: request.continuation?.originatingTurnToken
     })
   }
+
+  private checkpoint(
+    interaction: AcpPromptSessionInteractionScope
+  ): Promise<'active' | 'cancelled'> {
+    return this.options.interactions.cancellationCheckpoint(interaction)
+  }
+
+  private isCurrent(turn: AcpActivatedPromptTurn): boolean {
+    return (
+      this.options.interactions.current(turn.request.sessionId) === turn.interaction &&
+      this.activeSession(turn.request.sessionId) === turn.session
+    )
+  }
+
+  private safeCallback(message: string, action: () => void): void {
+    try {
+      action()
+    } catch (error) {
+      try {
+        log.error(message, errorLogFields(error))
+      } catch {
+        // Diagnostics must not replace the prompt lifecycle.
+      }
+    }
+  }
 }
 
 export { AcpPromptTurnWorkflow }
 export type {
-  AcpActivatedPromptTurn,
+  AcpExecutedPromptTurn,
   AcpPromptTurnMode,
   AcpPromptTurnPlanContext,
   AcpPromptTurnWorkflowOptions

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -69,11 +69,7 @@ import { getAppClaudeConfigDir } from '../settings/provider-env'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { withDataRootWrite } from '../storage/migration-state'
 import { opencodeStorageDir } from '../agent-framework/opencode'
-import {
-  ContextUsageTracker,
-  type ContextUsageTurnHandle,
-  type SessionEstimateInput
-} from './context-usage-tracker'
+import { ContextUsageTracker, type SessionEstimateInput } from './context-usage-tracker'
 import { contextUsageMcpSections } from './context-usage-static-context'
 import { createManagedFileReferenceResolver } from './file-reference-resolver'
 import type { UploadRepository } from '../uploads/repository'
@@ -128,35 +124,29 @@ import { AcpProviderSessionAdopter } from './provider-session-adopter'
 import { AcpProviderSessionResumer } from './provider-session-resumer'
 import { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
 import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
-import { AcpPromptPreparationOwner, type PreparedPromptHandle } from './prompt-preparation-owner'
+import { AcpPromptPreparationOwner } from './prompt-preparation-owner'
 import {
   AcpPromptTurnWorkflow,
-  type AcpActivatedPromptTurn,
+  type AcpExecutedPromptTurn,
   type AcpPromptTurnPlanContext
 } from './prompt-turn-workflow'
 import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import { AcpProviderPromptExecutor } from './provider-prompt-executor'
-import {
-  AcpPromptOutcomeFinalizer,
-  type AcpPromptFinalizationOutcome
-} from './prompt-outcome-finalizer'
+import { AcpPromptOutcomeFinalizer } from './prompt-outcome-finalizer'
 import type { AcpProviderTurnAdapter } from './provider-turn-adapter'
 import { claudeCodeTurnAdapter } from './claude-turn-adapter'
 import { createCodexTurnAdapter } from './codex-turn-adapter'
 import { AcpOpenCodeTurnAdapter } from './opencode-turn-adapter'
 import { AcpTurnSkillOwner, type AcpTurnSkillHooks } from './turn-skill-owner'
 import { createProductionPlanService } from '../session-plan/production-plan-service'
-import {
-  PLAN_FIRST_TURN_PROMPT_REMINDER,
-  SESSION_PLAN_SYSTEM_PROMPT_APPEND
-} from '../session-plan/guidance'
+import { SESSION_PLAN_SYSTEM_PROMPT_APPEND } from '../session-plan/guidance'
 import type { PlanResponseResult, PlanService } from '../session-plan/plan-service'
 import type {
   ActivePlanProjection,
   GeneratePlanContent,
   PlanResponseCommand
 } from '../../shared/session-plan/contract'
-import { formatPlanProtectedContext, PlanCommandError } from '../../shared/session-plan/contract'
+import { PlanCommandError } from '../../shared/session-plan/contract'
 import type { SessionPlanStepStatus } from '../../shared/session-persistence'
 import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
 
@@ -624,6 +614,42 @@ class AcpRuntime {
       registry: this.sessionRegistry,
       interactions: this.sessionInteractions,
       skills: this.turnSkills,
+      preparation: this.promptPreparation,
+      executor: this.providerPromptExecutor,
+      environment: {
+        backend: () => this.backend,
+        tooling: () => this.currentCapabilityAvailability(),
+        bridgeSkillsAvailable: () => this.connectionResources.bridgeSkillsAvailable,
+        skillImportEnabled: () => this.sessionCapabilities.isSkillImportEnabled(),
+        contextEstimateInput: (sessionId) => this.contextUsageEstimateInput(sessionId),
+        selectedContextWindow: (sessionId) => this.selectedContextWindowFor(sessionId),
+        providerAdapter: (frameworkId) => this.providerTurnAdapter(frameworkId),
+        emitSkillActivities: (sessionId, turn, inputs, status) =>
+          this.emitCodexSkillInputActivities(sessionId, turn, inputs, status),
+        onSkillImportAttachmentEligible: this.callbacks.onSkillImportAttachmentEligible,
+        onProviderPromptAccepted: this.callbacks.onProviderPromptAccepted,
+        routeNotification: (notification, sessionId) =>
+          this.handleSessionUpdate(notification, sessionId),
+        diagnosticContext: () => this.diagnosticContext(),
+        pushUserMessage: ({ sessionId, promptMessageId, text }) =>
+          this.pushEvent({
+            kind: 'message',
+            level: 'info',
+            sessionId,
+            ...(promptMessageId ? { promptMessageId } : {}),
+            role: 'user',
+            text
+          })
+      },
+      artifacts: {
+        open: (sessionId, provenance) => this.activateArtifactRun(sessionId, provenance),
+        promptMessageIdFor: (sessionId) => this.artifactTurns?.promptMessageIdFor(sessionId)
+      },
+      planLifecycle: {
+        beforeStop: (sessionId, interaction, response) =>
+          this.checkPromptPlanCompletion(sessionId, interaction, response)
+      },
+      finalizeTurn: (execution) => this.finalizePromptTurn(execution),
       currentCwd: () => this.snapshotOwner.cwd,
       resolveProjectName: (sessionId) => this.resolveSessionProjectName(sessionId),
       preflightPlan: (request) => this.preflightPromptPlan(request),
@@ -633,8 +659,7 @@ class AcpRuntime {
       recordAdmittedPrompt: (request) => this.handoffContinuity.recordAdmittedPrompt(request),
       onPromptStarted: (sessionId, turnToken, promptAttemptId) =>
         this.callbacks.onPromptStarted?.(sessionId, turnToken, promptAttemptId),
-      emitState: () => this.emitState(),
-      continueTurn: (turn) => this.continuePromptTurn(turn)
+      emitState: () => this.emitState()
     })
     const closeState: CloseState = {
       invalidatePendingSessionStartups: () => this.invalidatePendingSessionStartups(),
@@ -1979,6 +2004,47 @@ class AcpRuntime {
     return committed()
   }
 
+  private async checkPromptPlanCompletion(
+    sessionId: string,
+    interaction: AcpPromptSessionInteractionScope,
+    response: PromptResponse
+  ): Promise<void> {
+    const binding = this.planExecutionBindings.get(sessionId)
+    if (
+      response.stopReason !== 'end_turn' ||
+      !this.planService ||
+      binding?.interactionSequence !== interaction.sequence
+    ) {
+      return
+    }
+    const completion = await this.planService.checkTurnCompletion({
+      projectId: this.resolveSessionProjectName(sessionId),
+      sessionId
+    })
+    if (!completion.allow) {
+      throw new Error(
+        `The active Session Plan is not complete (${completion.lifecycle ?? 'incomplete'}).`
+      )
+    }
+  }
+
+  private releasePromptPlanBinding(
+    sessionId: string,
+    interaction: AcpPromptSessionInteractionScope
+  ): void {
+    const binding = this.planExecutionBindings.get(sessionId)
+    if (binding?.interactionSequence === interaction.sequence) {
+      this.planExecutionBindings.delete(sessionId)
+    }
+    const waiter = this.planApprovalWaiters.get(sessionId)
+    if (waiter?.interactionId === interaction.promptMessageId) {
+      this.rejectPlanApprovalWaiter(
+        sessionId,
+        'The Session Plan interaction ended before approval.'
+      )
+    }
+  }
+
   // Sends one prompt turn to the targeted session and streams updates until stop.
   async sendPrompt(request: AcpPromptRequest, promptAttemptId?: string): Promise<PromptResponse> {
     return this.withOperationLease(() =>
@@ -2008,256 +2074,54 @@ class AcpRuntime {
     )
   }
 
-  private async continuePromptTurn(turn: AcpActivatedPromptTurn): Promise<PromptResponse> {
-    const { request, session: activeSession, interaction: promptInteraction } = turn
-    const turnSkillHandle = turn.skill
-    const authorizedPlanContinuation = turn.plan.authorized
-    const protectedPendingPlan = turn.plan.protectedPending
-    const publishUserMessage = turn.mode.kind === 'user'
-    const promptAttemptId = turn.mode.promptAttemptId
-    const promptTurn = promptInteraction.sequence
-    const skillImportTurnToken = promptInteraction.turnToken
-    const promptEventIdentity = promptInteraction.promptMessageId
-      ? { promptMessageId: promptInteraction.promptMessageId }
+  private finalizePromptTurn(execution: AcpExecutedPromptTurn): Promise<PromptResponse> {
+    const { turn, artifact, prepared, context, skillInputs, skillStarted, outcome } = execution
+    const { request, session, interaction, skill } = turn
+    const sessionId = request.sessionId
+    const promptTurn = interaction.sequence
+    const eventIdentity = interaction.promptMessageId
+      ? { promptMessageId: interaction.promptMessageId }
       : {}
-    let artifactRun: ArtifactTurnHandle | undefined
-    let skillActivityInputs: Array<{ name: string; path: string }> = []
-    let skillActivitiesStarted = false
-    let skillActivitiesFinalized = false
-    let preparedPromptHandle: PreparedPromptHandle | undefined
-    let contextUsageTurn: ContextUsageTurnHandle | undefined
-    let userMessageEmitted = false
-    const emitUserMessage = (): void => {
-      if (
-        !publishUserMessage ||
-        request.continuation ||
-        request.suppressUserMessage ||
-        userMessageEmitted
-      )
-        return
-      userMessageEmitted = true
-      this.pushEvent({
-        kind: 'message',
-        level: 'info',
-        sessionId: request.sessionId,
-        ...promptEventIdentity,
-        role: 'user',
-        text: request.text
-      })
-    }
-    const executePrompt = async (): Promise<AcpPromptFinalizationOutcome> => {
-      // Create a fresh run context before prompting so MCP writes can be attributed to this turn.
-      artifactRun = await this.activateArtifactRun(request.sessionId, request.provenanceContext)
-      if (
-        (await this.sessionInteractions.cancellationCheckpoint(promptInteraction)) === 'cancelled'
-      ) {
-        return Object.freeze({ kind: 'not-dispatched' })
-      }
-
-      const sessionSpecialistPrefix = this.sessionRegistry
-        .lookup(request.sessionId)
-        ?.aggregate.snapshot().specialistPrefix
-      const planContextProjection = authorizedPlanContinuation ?? protectedPendingPlan
-      const projectId = this.resolveSessionProjectName(request.sessionId)
-      preparedPromptHandle = await this.promptPreparation.prepare({
-        request,
-        backend: this.backend,
-        tooling: this.currentCapabilityAvailability(),
-        specialistPrefix: sessionSpecialistPrefix,
-        projectId,
-        fallbackPromptMessageId: this.artifactTurns?.promptMessageIdFor(request.sessionId),
-        bridgeSkillsAvailable: this.connectionResources.bridgeSkillsAvailable,
-        skillImportEnabled: this.sessionCapabilities.isSkillImportEnabled(),
-        skillImportTurnToken,
-        turnSkill: turnSkillHandle,
-        ...(planContextProjection
-          ? { protectedContext: formatPlanProtectedContext(planContextProjection) }
-          : {}),
-        ...(request.turnIntent === 'plan-first'
-          ? { turnPromptReminders: [PLAN_FIRST_TURN_PROMPT_REMINDER] }
-          : {}),
-        signal: promptInteraction.signal,
-        isCurrent: () =>
-          this.sessionInteractions.current(request.sessionId) === promptInteraction &&
-          this.activeSessionFor(request.sessionId) === activeSession,
-        cancellationCheckpoint: () =>
-          this.sessionInteractions.cancellationCheckpoint(promptInteraction),
-        contextEstimateInput: this.contextUsageEstimateInput(request.sessionId),
-        selectedContextWindow: this.selectedContextWindowFor(request.sessionId),
-        ...(this.callbacks.onSkillImportAttachmentEligible
-          ? {
-              onSkillImportAttachmentEligible: (attachmentUri: string) => {
-                try {
-                  this.callbacks.onSkillImportAttachmentEligible?.(
-                    request.sessionId,
-                    skillImportTurnToken,
-                    attachmentUri
-                  )
-                } catch (error) {
-                  safeLogError('skill import attachment callback failed', errorLogFields(error))
-                }
-              }
-            }
-          : {})
-      })
-      if (preparedPromptHandle.status === 'cancelled') {
-        return Object.freeze({ kind: 'not-dispatched' })
-      }
-      const promptContent = preparedPromptHandle.content
-      skillActivityInputs = [...preparedPromptHandle.skillActivityInputs]
-      contextUsageTurn = preparedPromptHandle.transferContextTurn()
-
-      emitUserMessage()
-      if (skillActivityInputs.length > 0) {
-        this.emitCodexSkillInputActivities(
-          request.sessionId,
-          promptTurn,
-          skillActivityInputs,
-          'in_progress'
-        )
-        skillActivitiesStarted = true
-      }
-
-      const promptSessionSnapshot = this.sessionRegistry
-        .lookup(request.sessionId)
-        ?.aggregate.snapshot()
-      const promptFramework = promptSessionSnapshot?.frameworkId ?? this.framework.id
-      return this.providerPromptExecutor.execute({
-        session: activeSession,
-        content: promptContent,
-        cwd: promptSessionSnapshot?.cwd ?? this.snapshotOwner.cwd,
-        adapter: this.providerTurnAdapter(promptFramework),
-        isCurrent: () =>
-          this.sessionInteractions.current(request.sessionId) === promptInteraction &&
-          this.activeSessionFor(request.sessionId) === activeSession,
-        beforeDispatch: async () => {
-          if (
-            (await this.sessionInteractions.cancellationCheckpoint(promptInteraction)) ===
-            'cancelled'
-          ) {
-            return 'cancelled'
-          }
-          if (request.historyPreamble) {
-            log.info('session transcript replay dispatched', {
-              sessionId: request.sessionId,
-              historyTextLength: request.historyPreamble.length,
-              historyAttachmentCount: request.historyAttachments?.length ?? 0,
-              historyImageCount: request.historyImages?.length ?? 0,
-              ...this.diagnosticContext()
-            })
-          }
-          return 'active'
-        },
-        captureStop: () => this.sessionInteractions.captureTerminal(promptInteraction, 'stop'),
-        onAccepted: () => {
-          try {
-            this.callbacks.onProviderPromptAccepted?.(request.sessionId, promptAttemptId)
-          } catch (error) {
-            safeLogError('provider-prompt-accepted callback failed', errorLogFields(error))
-          }
-          if (skillActivitiesStarted && !skillActivitiesFinalized) {
-            this.emitCodexSkillInputActivities(
-              request.sessionId,
-              promptTurn,
-              skillActivityInputs,
-              'completed'
-            )
-            skillActivitiesFinalized = true
-          }
-        },
-        beforeStop: async (response) => {
-          const planExecutionBinding = this.planExecutionBindings.get(request.sessionId)
-          if (
-            response.stopReason === 'end_turn' &&
-            this.planService &&
-            planExecutionBinding?.interactionSequence === promptInteraction.sequence
-          ) {
-            const completion = await this.planService.checkTurnCompletion({
-              projectId: this.resolveSessionProjectName(request.sessionId),
-              sessionId: request.sessionId
-            })
-            if (!completion.allow) {
-              throw new Error(
-                `The active Session Plan is not complete (${completion.lifecycle ?? 'incomplete'}).`
-              )
-            }
-          }
-        },
-        routeNotification: (notification) =>
-          this.handleSessionUpdate(notification, request.sessionId),
-        reportBestEffortFailure: (stage, error) =>
-          log.warn('provider prompt observation failed', {
-            sessionId: request.sessionId,
-            stage,
-            ...errorLogFields(error)
-          })
-      })
-    }
-
-    let outcome: AcpPromptFinalizationOutcome
-    try {
-      outcome = await executePrompt()
-    } catch (error) {
-      outcome = Object.freeze({ kind: 'failed', error })
-    }
+    let skillFinalized = execution.skillFinalized
     return this.promptOutcomeFinalizer.finalize(
       {
-        sessionId: request.sessionId,
-        ...promptEventIdentity,
-        interaction: promptInteraction,
+        sessionId,
+        ...eventIdentity,
+        interaction,
         interactions: this.sessionInteractions,
         permission: this.permissionContext,
-        ...(preparedPromptHandle ? { prepared: preparedPromptHandle } : {}),
-        ...(contextUsageTurn ? { context: contextUsageTurn } : {}),
-        skill: turnSkillHandle,
+        ...(prepared ? { prepared } : {}),
+        ...(context ? { context } : {}),
+        skill,
         ...(this.backend.session.model ? { model: this.backend.session.model } : {}),
-        emitUserMessage,
-        emitArtifact: (onPublished) =>
-          this.emitArtifactRunEvent(request.sessionId, artifactRun, onPublished),
-        disposeArtifact: () => this.clearArtifactRun(artifactRun),
+        emitUserMessage: execution.emitUserMessage,
+        emitArtifact: (onPublished) => this.emitArtifactRunEvent(sessionId, artifact, onPublished),
+        disposeArtifact: () => this.clearArtifactRun(artifact),
         failPendingSkillActivities: () => {
-          if (!skillActivitiesStarted || skillActivitiesFinalized) return
-          this.emitCodexSkillInputActivities(
-            request.sessionId,
-            promptTurn,
-            skillActivityInputs,
-            'failed'
-          )
-          skillActivitiesFinalized = true
+          if (!skillStarted || skillFinalized) return
+          this.emitCodexSkillInputActivities(sessionId, promptTurn, skillInputs, 'failed')
+          skillFinalized = true
         },
         recordContextUsed: (used) =>
-          this.recordProviderPromptContextUsage(request.sessionId, used, promptTurn),
+          this.recordProviderPromptContextUsage(sessionId, used, promptTurn),
         errorMessage,
         errorKind: acpErrorKind,
         pushEvent: (event) => this.pushEvent(event),
         emitState: () => this.emitState(),
-        onPromptEnded: () =>
-          this.callbacks.onPromptEnded?.(request.sessionId, skillImportTurnToken),
+        onPromptEnded: () => this.callbacks.onPromptEnded?.(sessionId, interaction.turnToken),
         generationActivityChanged: () => this.generationActivityChanged(),
         autoCompactIfNeeded: () => {
           if (
-            this.sessionInteractions.current(request.sessionId) !== promptInteraction ||
-            this.activeSessionFor(request.sessionId) !== activeSession ||
-            !this.shouldAutoCompactContext(request.sessionId)
+            this.sessionInteractions.current(sessionId) !== interaction ||
+            this.activeSessionFor(sessionId) !== session ||
+            !this.shouldAutoCompactContext(sessionId)
           ) {
             return Promise.resolve()
           }
-          return this.performNativeContextCompaction(activeSession, request.sessionId, 'automatic')
+          return this.performNativeContextCompaction(session, sessionId, 'automatic')
         },
-        beforeInteractionRelease: () => {
-          const planBinding = this.planExecutionBindings.get(request.sessionId)
-          if (planBinding?.interactionSequence === promptInteraction.sequence) {
-            this.planExecutionBindings.delete(request.sessionId)
-          }
-          const planWaiter = this.planApprovalWaiters.get(request.sessionId)
-          if (planWaiter?.interactionId === promptInteraction.promptMessageId) {
-            this.rejectPlanApprovalWaiter(
-              request.sessionId,
-              'The Session Plan interaction ended before approval.'
-            )
-          }
-        },
-        afterInteractionRelease: () => this.publishTerminalPlanProjection(request.sessionId)
+        beforeInteractionRelease: () => this.releasePromptPlanBinding(sessionId, interaction),
+        afterInteractionRelease: () => this.publishTerminalPlanProjection(sessionId)
       },
       outcome
     )


### PR DESCRIPTION
## Problem

`AcpRuntime` still owned the complete prompt execution sequence after admission: Artifact activation, cancellation checkpointing, prompt preparation, user/Skill projection, provider dispatch, Plan stop gating, and terminal handoff. That kept execution state and ordering coupled to the Runtime even after prompt admission moved into `AcpPromptTurnWorkflow`.

## Proposed change

Extend the stateless `AcpPromptTurnWorkflow` so one admitted turn owns the execution sequence and carries opaque turn handles into a typed Runtime finalization seam.

```mermaid
sequenceDiagram
    participant Caller
    participant Workflow as AcpPromptTurnWorkflow
    participant Artifact
    participant Preparation
    participant Provider
    participant Plan
    participant Runtime

    Caller->>Workflow: run(request, mode)
    Workflow->>Artifact: open turn
    Workflow->>Workflow: cancellation checkpoint
    Workflow->>Preparation: prepare prompt
    Workflow->>Workflow: publish user message / Skill in_progress
    Workflow->>Provider: execute prepared prompt
    Provider-->>Workflow: accepted / stopped / failed
    Workflow->>Workflow: Skill completed when accepted
    Workflow->>Plan: beforeStop(response)
    Workflow->>Runtime: finalizeTurn(execution handles + outcome)
    Runtime-->>Caller: PromptResponse
```

The Workflow receives three cohesive adapter facets for environment, Artifact, and Plan lifecycle behavior. Runtime retains PlanService/maps, low-level provider observation, terminal cleanup, and final response composition.

## Scope and non-goals

- This is the ARD-26B execution/resource/provider cutover leaf.
- Production raw diff is 619 lines, within the approved 600-line limit plus 10% tolerance (660).
- The temporary typed `AcpExecutedPromptTurn` / `finalizeTurn` seam is intentional; the next leaf will move finalizer-handle composition and remove it.
- No public API, IPC contract, persistence schema, data model, or user interaction changes.
- Electron, Web, CLI, and Task behavior remain unchanged.
- Specialist, Permission, and Compute capability asymmetries remain unchanged.
- Issue #458 remains a forward-compatibility constraint only; this PR does not introduce orchestration state or public orchestration interfaces.

Context: #458

## Acceptance criteria and validation

All checks below ran after the final material edit.

| Behavior / risk | Final check | Result |
| --- | --- | --- |
| Workflow admission and execution contract, including cancellation, app continuation, provider failure, and Plan gating | `npm test -- --run src/main/acp/prompt-turn-workflow.test.ts` | 9/9 passed |
| Workflow and owned execution adapters | `npm test -- --run src/main/acp/prompt-turn-workflow.test.ts src/main/acp/prompt-preparation-owner.test.ts src/main/acp/provider-prompt-executor.test.ts src/main/acp/prompt-outcome-finalizer.test.ts src/main/acp/artifact-turn-owner.test.ts src/main/acp/turn-skill-owner.test.ts` | 56/56 passed |
| Runtime consumers, cleanup, reconnect, Artifact, context, Plan, and cancellation slices | targeted `src/main/acp/runtime.test.ts` Test Impact Set | 43/43 passed; 395 unrelated tests skipped |
| Node process type contracts | `npm run typecheck:node` | passed |
| Repository lint policy | `npm run lint` | passed with 0 errors; 17 pre-existing warnings outside this diff |
| Formatting and whitespace | targeted Prettier check plus `git diff --check` | passed |

Independent final reviews:

- Standards: 0 actionable findings after the typed test-harness correction.
- Spec: 0 actionable findings.

Consumer/platform rationale: the public Runtime entry points and IPC/cross-surface contracts are unchanged, so Web typecheck and UI/E2E lanes were excluded locally. Provider integration tests had already passed for this implementation outside the restricted loopback sandbox; authoritative PR Gate remains responsible for full selected platform coverage.

Uncovered local risk: provider process/platform permutations not selected by the focused local set rely on PR Gate.

## Review focus

- Verify the strict Artifact → cancellation → preparation → publication → provider → Plan → finalization order.
- Verify all cleanup and settlement paths still use the exact active interaction and opaque owner handles.
- Confirm Runtime keeps only terminal finalization and owner-specific adapters, without duplicating turn state.
- Confirm the temporary finalization seam is narrow enough for the next cutover leaf.
