### PR TITLE
refactor(acp): complete prompt turn finalization cutover

### DIFF
--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -7,6 +7,7 @@ import { opencodeFramework } from '../agent-framework'
 import type { ArtifactTurnHandle } from './artifact-turn-owner'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
 import type { ContextUsageTurnHandle } from './context-usage-tracker'
+import type { AcpPromptOutcomeFinalizer } from './prompt-outcome-finalizer'
 import type { ReadyPreparedPromptHandle } from './prompt-preparation-owner'
 import { AcpPromptTurnWorkflow, type AcpPromptTurnWorkflowOptions } from './prompt-turn-workflow'
 import { AcpSessionAggregate } from './session-aggregate'
@@ -19,12 +20,25 @@ type Harness = {
   artifacts: {
     open: Mock<AcpPromptTurnWorkflowOptions['artifacts']['open']>
     promptMessageIdFor: Mock<AcpPromptTurnWorkflowOptions['artifacts']['promptMessageIdFor']>
+    publish: Mock<AcpPromptTurnWorkflowOptions['artifacts']['publish']>
+    dispose: Mock<AcpPromptTurnWorkflowOptions['artifacts']['dispose']>
   }
   authorize: Mock<AcpPromptTurnWorkflowOptions['skills']['authorize']>
   context: ContextUsageTurnHandle
   emitSkillActivities: Mock<AcpPromptTurnWorkflowOptions['environment']['emitSkillActivities']>
   executor: Mock<AcpPromptTurnWorkflowOptions['executor']['execute']>
-  finalizeTurn: Mock<AcpPromptTurnWorkflowOptions['finalizeTurn']>
+  finalization: {
+    recordContextUsed: Mock<AcpPromptTurnWorkflowOptions['finalization']['recordContextUsed']>
+    errorMessage: AcpPromptTurnWorkflowOptions['finalization']['errorMessage']
+    errorKind: AcpPromptTurnWorkflowOptions['finalization']['errorKind']
+    pushEvent: Mock<AcpPromptTurnWorkflowOptions['finalization']['pushEvent']>
+    onPromptEnded: Mock<AcpPromptTurnWorkflowOptions['finalization']['onPromptEnded']>
+    generationActivityChanged: Mock<
+      AcpPromptTurnWorkflowOptions['finalization']['generationActivityChanged']
+    >
+    autoCompact: Mock<AcpPromptTurnWorkflowOptions['finalization']['autoCompact']>
+  }
+  finalizer: Mock<AcpPromptOutcomeFinalizer['finalize']>
   interactions: {
     current: Mock<AcpSessionInteractionOwner['current']>
     reservePrompt: Mock<AcpSessionInteractionOwner['reservePrompt']>
@@ -41,7 +55,10 @@ type Harness = {
   owner: AcpSessionInteractionOwner
   planLifecycle: {
     beforeStop: Mock<AcpPromptTurnWorkflowOptions['planLifecycle']['beforeStop']>
+    beforeRelease: Mock<AcpPromptTurnWorkflowOptions['planLifecycle']['beforeRelease']>
+    afterRelease: Mock<AcpPromptTurnWorkflowOptions['planLifecycle']['afterRelease']>
   }
+  permission: AcpPromptTurnWorkflowOptions['permission']
   preparation: Mock<AcpPromptTurnWorkflowOptions['preparation']['prepare']>
   preflightPlan: Mock<AcpPromptTurnWorkflowOptions['preflightPlan']>
   prepared: ReadyPreparedPromptHandle
@@ -108,7 +125,7 @@ const createHarness = (
     authorize?: () => TurnSkillHandle | Promise<TurnSkillHandle>
     cancellationCheckpoint?: AcpPromptTurnWorkflowOptions['interactions']['cancellationCheckpoint']
     execute?: AcpPromptTurnWorkflowOptions['executor']['execute']
-    finalizeTurn?: AcpPromptTurnWorkflowOptions['finalizeTurn']
+    finalize?: AcpPromptOutcomeFinalizer['finalize']
     onPromptStarted?: () => void
     preflightPlan?: AcpPromptTurnWorkflowOptions['preflightPlan']
     prepare?: AcpPromptTurnWorkflowOptions['preparation']['prepare']
@@ -200,6 +217,12 @@ const createHarness = (
   const planLifecycle: Harness['planLifecycle'] = {
     beforeStop: vi.fn(async () => {
       journal.push('plan:before-stop')
+    }),
+    beforeRelease: vi.fn(() => {
+      journal.push('plan:before-release')
+    }),
+    afterRelease: vi.fn(async () => {
+      journal.push('plan:after-release')
     })
   }
   const onProviderPromptAccepted: Harness['onProviderPromptAccepted'] = vi.fn(() => {
@@ -214,12 +237,12 @@ const createHarness = (
     request.captureStop()
     return { kind: 'stopped' as const, response, facts: {} }
   })
-  const finalizeTurn: Harness['finalizeTurn'] = vi.fn(async (execution) => {
+  const finalizer: Harness['finalizer'] = vi.fn(async (handles, outcome) => {
     journal.push('finalize')
-    if (input.finalizeTurn) return input.finalizeTurn(execution)
-    if (execution.outcome.kind === 'failed') throw execution.outcome.error
-    if (execution.outcome.kind === 'not-dispatched') return { stopReason: 'cancelled' }
-    return execution.outcome.response
+    if (input.finalize) return input.finalize(handles, outcome)
+    if (outcome.kind === 'failed') throw outcome.error
+    if (outcome.kind === 'not-dispatched') return { stopReason: 'cancelled' }
+    return outcome.response
   })
   const artifact = {} as ArtifactTurnHandle
   const artifacts: Harness['artifacts'] = {
@@ -227,7 +250,24 @@ const createHarness = (
       journal.push('artifact:open')
       return artifact
     }),
-    promptMessageIdFor: vi.fn(() => 'fallback-message-1')
+    promptMessageIdFor: vi.fn(() => 'fallback-message-1'),
+    publish: vi.fn(async (_sessionId, _artifact, onPublished) => {
+      journal.push('artifact:publish')
+      onPublished()
+    }),
+    dispose: vi.fn(async () => {
+      journal.push('artifact:dispose')
+    })
+  }
+  const permission = { clearCorrelationsForSession: vi.fn() }
+  const finalization: Harness['finalization'] = {
+    recordContextUsed: vi.fn(),
+    errorMessage: (error) => (error instanceof Error ? error.message : String(error)),
+    errorKind: (error) => (error as { data?: { errorKind?: string } } | undefined)?.data?.errorKind,
+    pushEvent: vi.fn(),
+    onPromptEnded: vi.fn(),
+    generationActivityChanged: vi.fn(),
+    autoCompact: vi.fn(async () => undefined)
   }
   const pushUserMessage: Harness['pushUserMessage'] = vi.fn(() => {
     journal.push('event:message')
@@ -270,7 +310,9 @@ const createHarness = (
     },
     artifacts,
     planLifecycle,
-    finalizeTurn,
+    finalizer: { finalize: finalizer },
+    permission,
+    finalization,
     currentCwd: () => '/default',
     resolveProjectName: () => 'project-1',
     preflightPlan,
@@ -292,12 +334,14 @@ const createHarness = (
     context,
     emitSkillActivities,
     executor,
-    finalizeTurn,
+    finalization,
+    finalizer,
     interactions,
     journal,
     onProviderPromptAccepted,
     owner,
     planLifecycle,
+    permission,
     preparation,
     preflightPlan,
     prepared,
@@ -358,22 +402,49 @@ describe('AcpPromptTurnWorkflow', () => {
       'plan:before-stop',
       'finalize'
     ])
-    const execution = harness.finalizeTurn.mock.calls[0][0]
-    expect(execution).toMatchObject({
-      artifact: expect.any(Object),
+    const [handles, outcome] = harness.finalizer.mock.calls[0]
+    expect(handles).toMatchObject({
+      sessionId: 's1',
+      promptMessageId: 'message-1',
+      interaction: expect.objectContaining({ promptMessageId: 'message-1' }),
+      interactions: harness.interactions,
+      permission: harness.permission,
       context: harness.context,
       prepared: harness.prepared,
-      skillInputs: [{ name: 'Research', path: '/skills/research/SKILL.md' }],
-      skillStarted: true,
-      skillFinalized: true,
-      outcome: { kind: 'stopped', response: { stopReason: 'end_turn' } },
-      turn: {
-        request: expect.objectContaining({ sessionId: 's1' }),
-        mode: { kind: 'user', promptAttemptId: 'attempt-1' },
-        interaction: expect.objectContaining({ promptMessageId: 'message-1' }),
-        skill: harness.skill
-      }
+      skill: harness.skill,
+      model: 'test-model'
     })
+    expect(outcome).toMatchObject({
+      kind: 'stopped',
+      response: { stopReason: 'end_turn' }
+    })
+
+    const onPublished = vi.fn()
+    await handles.emitArtifact(onPublished)
+    await handles.disposeArtifact()
+    handles.recordContextUsed(42)
+    handles.onPromptEnded()
+    handles.generationActivityChanged()
+    await handles.autoCompactIfNeeded()
+    handles.failPendingSkillActivities()
+
+    expect(harness.artifacts.publish).toHaveBeenCalledWith('s1', expect.any(Object), onPublished)
+    expect(harness.artifacts.dispose).toHaveBeenCalledWith(expect.any(Object))
+    expect(harness.finalization.recordContextUsed).toHaveBeenCalledWith('s1', 42, 1)
+    expect(harness.finalization.onPromptEnded).toHaveBeenCalledWith(
+      's1',
+      handles.interaction.turnToken
+    )
+    expect(harness.finalization.generationActivityChanged).toHaveBeenCalledOnce()
+    expect(harness.finalization.autoCompact).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ sessionId: 'provider-1' }),
+      handles.interaction
+    )
+    expect(harness.emitSkillActivities.mock.calls.map((call) => call[3])).toEqual([
+      'in_progress',
+      'completed'
+    ])
   })
 
   it('propagates app-continuation identity without publishing its synthetic text', async () => {
@@ -391,9 +462,9 @@ describe('AcpPromptTurnWorkflow', () => {
       promptAttemptId: 'attempt-2'
     })
 
-    const execution = harness.finalizeTurn.mock.calls[0][0]
-    execution.emitUserMessage()
-    expect(execution.turn.interaction.turnToken).toBe('origin-turn')
+    const handles = harness.finalizer.mock.calls[0][0]
+    handles.emitUserMessage()
+    expect(handles.interaction.turnToken).toBe('origin-turn')
     expect(harness.pushUserMessage).not.toHaveBeenCalled()
     expect(harness.onProviderPromptAccepted).toHaveBeenCalledWith('s1', 'attempt-2')
   })
@@ -416,7 +487,7 @@ describe('AcpPromptTurnWorkflow', () => {
     expect(harness.interactions.release).toHaveBeenCalledWith(staleReservation)
     expect(harness.owner.current('s1')).toBe(replacement)
     expect(harness.preparation).not.toHaveBeenCalled()
-    expect(harness.finalizeTurn).not.toHaveBeenCalled()
+    expect(harness.finalizer).not.toHaveBeenCalled()
   })
 
   it('refreshes reservation, session, and replay context after a Skill reload', async () => {
@@ -473,7 +544,7 @@ describe('AcpPromptTurnWorkflow', () => {
     await expect(harness.workflow.run(request(), { kind: 'user' })).resolves.toEqual({
       stopReason: 'end_turn'
     })
-    expect(harness.finalizeTurn).toHaveBeenCalledOnce()
+    expect(harness.finalizer).toHaveBeenCalledOnce()
     expect(harness.journal.slice(6, 10)).toEqual(['handoff', 'start', 'state', 'artifact:open'])
   })
 
@@ -489,10 +560,12 @@ describe('AcpPromptTurnWorkflow', () => {
     })
     expect(harness.preparation).not.toHaveBeenCalled()
     expect(harness.executor).not.toHaveBeenCalled()
-    const execution = harness.finalizeTurn.mock.calls[0][0]
-    expect(execution.outcome).toEqual({ kind: 'not-dispatched' })
-    expect(execution).not.toHaveProperty('prepared')
-    expect(execution).not.toHaveProperty('context')
+    const [handles, outcome] = harness.finalizer.mock.calls[0]
+    expect(outcome).toEqual({ kind: 'not-dispatched' })
+    expect(handles).not.toHaveProperty('prepared')
+    expect(handles).not.toHaveProperty('context')
+    await handles.disposeArtifact()
+    expect(harness.artifacts.dispose).toHaveBeenCalledWith(expect.any(Object))
   })
 
   it('turns execution failure into one finalization outcome with pending Skill state', async () => {
@@ -505,16 +578,17 @@ describe('AcpPromptTurnWorkflow', () => {
 
     await expect(harness.workflow.run(request(), { kind: 'user' })).rejects.toBe(failure)
 
-    expect(harness.finalizeTurn).toHaveBeenCalledOnce()
-    const execution = harness.finalizeTurn.mock.calls[0][0]
-    expect(execution).toMatchObject({
-      outcome: { kind: 'failed', error: failure },
-      skillStarted: true,
-      skillFinalized: false
-    })
-    execution.emitUserMessage()
+    expect(harness.finalizer).toHaveBeenCalledOnce()
+    const [handles, outcome] = harness.finalizer.mock.calls[0]
+    expect(outcome).toEqual({ kind: 'failed', error: failure })
+    handles.emitUserMessage()
+    handles.failPendingSkillActivities()
+    handles.failPendingSkillActivities()
     expect(harness.pushUserMessage).toHaveBeenCalledOnce()
-    expect(harness.emitSkillActivities.mock.calls.map((call) => call[3])).toEqual(['in_progress'])
+    expect(harness.emitSkillActivities.mock.calls.map((call) => call[3])).toEqual([
+      'in_progress',
+      'failed'
+    ])
     expect(harness.onProviderPromptAccepted).not.toHaveBeenCalled()
   })
 
@@ -532,9 +606,14 @@ describe('AcpPromptTurnWorkflow', () => {
         turnPromptReminders: [expect.stringContaining('Plan mode (ACTIVE')]
       })
     )
-    const interaction = harness.finalizeTurn.mock.calls[0][0].turn.interaction
+    const handles = harness.finalizer.mock.calls[0][0]
+    const interaction = handles.interaction
     expect(harness.planLifecycle.beforeStop).toHaveBeenCalledWith('s1', interaction, {
       stopReason: 'end_turn'
     })
+    handles.beforeInteractionRelease()
+    await handles.afterInteractionRelease()
+    expect(harness.planLifecycle.beforeRelease).toHaveBeenCalledWith('s1', interaction)
+    expect(harness.planLifecycle.afterRelease).toHaveBeenCalledWith('s1')
   })
 })

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -13,7 +13,12 @@ import { PLAN_FIRST_TURN_PROMPT_REMINDER } from '../session-plan/guidance'
 import type { ArtifactTurnHandle } from './artifact-turn-owner'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
 import type { ContextUsageTurnHandle, SessionEstimateInput } from './context-usage-tracker'
-import type { AcpPromptFinalizationOutcome } from './prompt-outcome-finalizer'
+import type { AcpPermissionContext } from './permission-context'
+import {
+  AcpPromptOutcomeFinalizer,
+  type AcpPromptFinalizationHandles,
+  type AcpPromptFinalizationOutcome
+} from './prompt-outcome-finalizer'
 import type { AcpPromptPreparationOwner, PreparedPromptHandle } from './prompt-preparation-owner'
 import type { AcpProviderPromptExecutor, ProviderPromptOutcome } from './provider-prompt-executor'
 import type { AcpProviderTurnAdapter } from './provider-turn-adapter'
@@ -43,18 +48,6 @@ type AcpActivatedPromptTurn = Readonly<{
   plan: AcpPromptTurnPlanContext
 }>
 
-type AcpExecutedPromptTurn = Readonly<{
-  turn: AcpActivatedPromptTurn
-  artifact?: ArtifactTurnHandle
-  prepared?: PreparedPromptHandle
-  context?: ContextUsageTurnHandle
-  skillInputs: ReadonlyArray<{ name: string; path: string }>
-  skillStarted: boolean
-  skillFinalized: boolean
-  emitUserMessage: () => void
-  outcome: AcpPromptFinalizationOutcome
-}>
-
 type AcpPromptTurnEnvironment = Readonly<{
   backend: () => AcpBackendGenerationView
   tooling: () => AcpSessionToolingAvailability
@@ -82,6 +75,12 @@ type AcpPromptTurnArtifacts = Readonly<{
     provenance: AcpPromptRequest['provenanceContext']
   ) => Promise<ArtifactTurnHandle | undefined>
   promptMessageIdFor: (sessionId: string) => string | undefined
+  publish: (
+    sessionId: string,
+    artifact: ArtifactTurnHandle | undefined,
+    onPublished: () => void
+  ) => Promise<void>
+  dispose: (artifact: ArtifactTurnHandle | undefined) => Promise<void>
 }>
 
 type AcpPromptTurnPlanLifecycle = Readonly<{
@@ -90,6 +89,22 @@ type AcpPromptTurnPlanLifecycle = Readonly<{
     interaction: AcpPromptSessionInteractionScope,
     response: PromptResponse
   ) => Promise<void>
+  beforeRelease: (sessionId: string, interaction: AcpPromptSessionInteractionScope) => void
+  afterRelease: (sessionId: string) => Promise<void>
+}>
+
+type AcpPromptTurnFinalization = Readonly<{
+  recordContextUsed: (sessionId: string, used: number, promptTurn: number) => void
+  errorMessage: AcpPromptFinalizationHandles['errorMessage']
+  errorKind: AcpPromptFinalizationHandles['errorKind']
+  pushEvent: AcpPromptFinalizationHandles['pushEvent']
+  onPromptEnded: (sessionId: string, turnToken: string) => void
+  generationActivityChanged: () => void
+  autoCompact: (
+    sessionId: string,
+    session: ActiveSession,
+    interaction: AcpPromptSessionInteractionScope
+  ) => Promise<unknown>
 }>
 
 type AcpPromptTurnWorkflowOptions = Readonly<{
@@ -107,10 +122,12 @@ type AcpPromptTurnWorkflowOptions = Readonly<{
   skills: Pick<AcpTurnSkillOwner, 'authorize'>
   preparation: Pick<AcpPromptPreparationOwner, 'prepare'>
   executor: Pick<AcpProviderPromptExecutor, 'execute'>
+  finalizer: Pick<AcpPromptOutcomeFinalizer, 'finalize'>
+  permission: Pick<AcpPermissionContext, 'clearCorrelationsForSession'>
   environment: AcpPromptTurnEnvironment
   artifacts: AcpPromptTurnArtifacts
   planLifecycle: AcpPromptTurnPlanLifecycle
-  finalizeTurn: (execution: AcpExecutedPromptTurn) => Promise<PromptResponse>
+  finalization: AcpPromptTurnFinalization
   currentCwd: () => string
   resolveProjectName: (sessionId: string) => string
   preflightPlan: (
@@ -240,8 +257,11 @@ class AcpPromptTurnWorkflow {
       artifacts,
       environment: env,
       executor,
+      finalization,
+      finalizer,
       interactions,
       planLifecycle,
+      permission,
       preparation,
       registry
     } = this.options
@@ -364,17 +384,39 @@ class AcpPromptTurnWorkflow {
     } catch (error) {
       outcome = Object.freeze({ kind: 'failed', error })
     }
-    return this.options.finalizeTurn({
-      turn,
-      ...(artifact ? { artifact } : {}),
-      ...(prepared ? { prepared } : {}),
-      ...(context ? { context } : {}),
-      skillInputs,
-      skillStarted,
-      skillFinalized,
-      emitUserMessage,
+    const model = env.backend().session.model
+    return finalizer.finalize(
+      {
+        sessionId,
+        ...eventIdentity,
+        interaction,
+        interactions,
+        permission,
+        ...(prepared ? { prepared } : {}),
+        ...(context ? { context } : {}),
+        skill,
+        ...(model ? { model } : {}),
+        emitUserMessage,
+        emitArtifact: (onPublished) => artifacts.publish(sessionId, artifact, onPublished),
+        disposeArtifact: () => artifacts.dispose(artifact),
+        failPendingSkillActivities: () => {
+          if (!skillStarted || skillFinalized) return
+          env.emitSkillActivities(sessionId, promptTurn, skillInputs, 'failed')
+          skillFinalized = true
+        },
+        recordContextUsed: (used) => finalization.recordContextUsed(sessionId, used, promptTurn),
+        errorMessage: finalization.errorMessage,
+        errorKind: finalization.errorKind,
+        pushEvent: finalization.pushEvent,
+        emitState: this.options.emitState,
+        onPromptEnded: () => finalization.onPromptEnded(sessionId, turnToken),
+        generationActivityChanged: finalization.generationActivityChanged,
+        autoCompactIfNeeded: () => finalization.autoCompact(sessionId, session, interaction),
+        beforeInteractionRelease: () => planLifecycle.beforeRelease(sessionId, interaction),
+        afterInteractionRelease: () => planLifecycle.afterRelease(sessionId)
+      },
       outcome
-    })
+    )
   }
 
   private activeSession(sessionId: string): ActiveSession | undefined {
@@ -423,9 +465,4 @@ class AcpPromptTurnWorkflow {
 }
 
 export { AcpPromptTurnWorkflow }
-export type {
-  AcpExecutedPromptTurn,
-  AcpPromptTurnMode,
-  AcpPromptTurnPlanContext,
-  AcpPromptTurnWorkflowOptions
-}
+export type { AcpPromptTurnMode, AcpPromptTurnPlanContext, AcpPromptTurnWorkflowOptions }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -125,11 +125,7 @@ import { AcpProviderSessionResumer } from './provider-session-resumer'
 import { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
 import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
 import { AcpPromptPreparationOwner } from './prompt-preparation-owner'
-import {
-  AcpPromptTurnWorkflow,
-  type AcpExecutedPromptTurn,
-  type AcpPromptTurnPlanContext
-} from './prompt-turn-workflow'
+import { AcpPromptTurnWorkflow, type AcpPromptTurnPlanContext } from './prompt-turn-workflow'
 import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import { AcpProviderPromptExecutor } from './provider-prompt-executor'
 import { AcpPromptOutcomeFinalizer } from './prompt-outcome-finalizer'
@@ -405,7 +401,6 @@ class AcpRuntime {
   private readonly sessionConfigurator: AcpSessionConfigurator
   private readonly sessionUpdateProjector = new AcpSessionUpdateProjector()
   private readonly providerPromptExecutor = new AcpProviderPromptExecutor()
-  private readonly promptOutcomeFinalizer = new AcpPromptOutcomeFinalizer()
   // Injectable lifecycle timers (defaults to real setTimeout/clearTimeout).
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
@@ -616,6 +611,8 @@ class AcpRuntime {
       skills: this.turnSkills,
       preparation: this.promptPreparation,
       executor: this.providerPromptExecutor,
+      finalizer: new AcpPromptOutcomeFinalizer(),
+      permission: this.permissionContext,
       environment: {
         backend: () => this.backend,
         tooling: () => this.currentCapabilityAvailability(),
@@ -643,13 +640,38 @@ class AcpRuntime {
       },
       artifacts: {
         open: (sessionId, provenance) => this.activateArtifactRun(sessionId, provenance),
-        promptMessageIdFor: (sessionId) => this.artifactTurns?.promptMessageIdFor(sessionId)
+        promptMessageIdFor: (sessionId) => this.artifactTurns?.promptMessageIdFor(sessionId),
+        publish: (sessionId, artifact, onPublished) =>
+          this.emitArtifactRunEvent(sessionId, artifact, onPublished),
+        dispose: (artifact) => this.clearArtifactRun(artifact)
       },
       planLifecycle: {
         beforeStop: (sessionId, interaction, response) =>
-          this.checkPromptPlanCompletion(sessionId, interaction, response)
+          this.checkPromptPlanCompletion(sessionId, interaction, response),
+        beforeRelease: (sessionId, interaction) =>
+          this.releasePromptPlanBinding(sessionId, interaction),
+        afterRelease: (sessionId) => this.publishTerminalPlanProjection(sessionId)
       },
-      finalizeTurn: (execution) => this.finalizePromptTurn(execution),
+      finalization: {
+        recordContextUsed: (sessionId, used, promptTurn) =>
+          this.recordProviderPromptContextUsage(sessionId, used, promptTurn),
+        errorMessage,
+        errorKind: acpErrorKind,
+        pushEvent: (event) => this.pushEvent(event),
+        onPromptEnded: (sessionId, turnToken) =>
+          this.callbacks.onPromptEnded?.(sessionId, turnToken),
+        generationActivityChanged: () => this.generationActivityChanged(),
+        autoCompact: (sessionId, session, interaction) => {
+          if (
+            this.sessionInteractions.current(sessionId) !== interaction ||
+            this.activeSessionFor(sessionId) !== session ||
+            !this.shouldAutoCompactContext(sessionId)
+          ) {
+            return Promise.resolve()
+          }
+          return this.performNativeContextCompaction(session, sessionId, 'automatic')
+        }
+      },
       currentCwd: () => this.snapshotOwner.cwd,
       resolveProjectName: (sessionId) => this.resolveSessionProjectName(sessionId),
       preflightPlan: (request) => this.preflightPromptPlan(request),
@@ -2108,59 +2130,6 @@ class AcpRuntime {
           ...(promptAttemptId === undefined ? {} : { promptAttemptId })
         })
       )
-    )
-  }
-
-  private finalizePromptTurn(execution: AcpExecutedPromptTurn): Promise<PromptResponse> {
-    const { turn, artifact, prepared, context, skillInputs, skillStarted, outcome } = execution
-    const { request, session, interaction, skill } = turn
-    const sessionId = request.sessionId
-    const promptTurn = interaction.sequence
-    const eventIdentity = interaction.promptMessageId
-      ? { promptMessageId: interaction.promptMessageId }
-      : {}
-    let skillFinalized = execution.skillFinalized
-    return this.promptOutcomeFinalizer.finalize(
-      {
-        sessionId,
-        ...eventIdentity,
-        interaction,
-        interactions: this.sessionInteractions,
-        permission: this.permissionContext,
-        ...(prepared ? { prepared } : {}),
-        ...(context ? { context } : {}),
-        skill,
-        ...(this.backend.session.model ? { model: this.backend.session.model } : {}),
-        emitUserMessage: execution.emitUserMessage,
-        emitArtifact: (onPublished) => this.emitArtifactRunEvent(sessionId, artifact, onPublished),
-        disposeArtifact: () => this.clearArtifactRun(artifact),
-        failPendingSkillActivities: () => {
-          if (!skillStarted || skillFinalized) return
-          this.emitCodexSkillInputActivities(sessionId, promptTurn, skillInputs, 'failed')
-          skillFinalized = true
-        },
-        recordContextUsed: (used) =>
-          this.recordProviderPromptContextUsage(sessionId, used, promptTurn),
-        errorMessage,
-        errorKind: acpErrorKind,
-        pushEvent: (event) => this.pushEvent(event),
-        emitState: () => this.emitState(),
-        onPromptEnded: () => this.callbacks.onPromptEnded?.(sessionId, interaction.turnToken),
-        generationActivityChanged: () => this.generationActivityChanged(),
-        autoCompactIfNeeded: () => {
-          if (
-            this.sessionInteractions.current(sessionId) !== interaction ||
-            this.activeSessionFor(sessionId) !== session ||
-            !this.shouldAutoCompactContext(sessionId)
-          ) {
-            return Promise.resolve()
-          }
-          return this.performNativeContextCompaction(session, sessionId, 'automatic')
-        },
-        beforeInteractionRelease: () => this.releasePromptPlanBinding(sessionId, interaction),
-        afterInteractionRelease: () => this.publishTerminalPlanProjection(sessionId)
-      },
-      outcome
     )
   }
 


### PR DESCRIPTION
## Problem

After #787 moved prompt execution into `AcpPromptTurnWorkflow`, Runtime still received a temporary `AcpExecutedPromptTurn` package and composed every terminal-finalizer handle in `finalizePromptTurn`. That seam exposed per-turn execution state back to the coordinator and left finalization split across two modules.

## Proposed change

Complete the cutover by composing the existing `AcpPromptOutcomeFinalizer` handles inside `AcpPromptTurnWorkflow`.

```mermaid
flowchart LR
  Workflow["AcpPromptTurnWorkflow"] -->|"opaque turn handles + outcome"| Finalizer["AcpPromptOutcomeFinalizer"]
  Runtime["AcpRuntime"] -->|"Artifact adapters"| Workflow
  Runtime -->|"Plan lifecycle adapters"| Workflow
  Runtime -->|"events / usage / compaction adapters"| Workflow
  Owners["Interaction / Permission / Context / Skill owners"] --> Workflow
  Finalizer -->|"settle / publish / cleanup"| Owners
```

The temporary `AcpExecutedPromptTurn`, `finalizeTurn` option, Runtime `finalizePromptTurn`, and Runtime finalizer field are removed. Existing Artifact and Plan facets gain their terminal hooks; a narrow finalization facet supplies only Runtime-owned event, usage, callback, and auto-compaction adapters.

## Scope and non-goals

- This is the ARD-26C finalization cutover leaf following #787.
- Three files changed; total raw diff is 353 lines and production raw is 190, below the approved 600-line limit.
- Runtime continues to own PlanService/maps, Artifact/Permission/Session owners, usage projection, and low-level adapters; no state owner moved.
- No public API, IPC contract, persistence schema, data model, or user interaction changes.
- Electron, Web, CLI, and Task behavior remain unchanged.
- Specialist, Permission, and Compute capability asymmetries remain unchanged.
- Issue #458 remains a forward-compatibility constraint only; no orchestration state or public orchestration interface is introduced.

Context: #458

## Acceptance criteria and validation

All checks below ran after rebasing onto `origin/main@df71d377` (including #786) and after the final material edit.

| Behavior / risk | Final check | Result |
| --- | --- | --- |
| Workflow-to-Finalizer contract, exact opaque handles, cancel/failure/app-continuation/Plan hooks | `npm test -- --run src/main/acp/prompt-turn-workflow.test.ts src/main/acp/prompt-outcome-finalizer.test.ts` | 19/19 passed |
| Workflow plus preparation/provider/Artifact/Skill owners | six-file focused ACP owner bundle | 56/56 passed |
| Latest Session Plan authority changes plus continuation/coordinator consumers | `npm test -- --run src/main/acp/runtime-session-plan.test.ts src/main/acp/runtime-coordinator.test.ts` | 65/65 passed |
| Runtime finalization, Artifact, context, Plan, cancellation, reconnect, stale-turn, and latest branch-authority slices | targeted `src/main/acp/runtime.test.ts` Test Impact Set | 44/44 passed; 395 unrelated tests skipped |
| Node process type contracts | `npm run typecheck:node` | passed |
| Repository lint policy | `npm run lint` | passed with 0 errors; 17 pre-existing warnings outside this diff |
| Formatting and whitespace | targeted Prettier check plus `git diff --check` | passed |

Independent final reviews:

- Standards: 0 actionable findings.
- Spec: 0 actionable findings.

Consumer/platform rationale: `sendPrompt` / `sendAppContinuation`, operation leases, data-root writes, public Runtime methods, and all IPC/cross-surface contracts are unchanged. Web typecheck and UI/E2E were therefore excluded locally; authoritative PR Gate supplies the selected full/platform coverage.

Uncovered local risk: provider process/platform permutations outside the focused Node set rely on PR Gate.

## Review focus

- Confirm the Workflow now owns all per-turn finalization-handle composition without retaining state between runs.
- Verify Artifact publish/dispose, Context completion/failure/supersession, Skill close/activity, Plan release/projection, and Interaction/Permission cleanup preserve their prior order and exact-current guards.
- Verify auto-compaction still requires the same current interaction and provider Session.
- Confirm Runtime retains only narrow owner adapters and no replacement execution package was introduced.
