### PR TITLE
fix(session-plan): authorize plans from durable branches

### DIFF
--- a/src/main/acp/artifact-turn-owner.test.ts
+++ b/src/main/acp/artifact-turn-owner.test.ts
@@ -88,8 +88,6 @@ describe('ArtifactTurnOwner', () => {
 
     expect(owner.activeRunIds()).toEqual(['artifact-run-123-1'])
     expect(owner.promptMessageIdFor('session-1')).toBe('prompt-1')
-    expect(owner.containsMessageForActiveTurn('session-1', 'message-parent')).toBe(true)
-    expect(owner.containsMessageForActiveTurn('session-1', 'message-sibling')).toBe(false)
     expect(issuedBindings).toEqual([
       expect.objectContaining({
         projectId: 'project-1',

--- a/src/main/acp/artifact-turn-owner.ts
+++ b/src/main/acp/artifact-turn-owner.ts
@@ -218,10 +218,6 @@ class ArtifactTurnOwner {
     return this.activeTurnsBySession.get(sessionId)?.promptMessageId
   }
 
-  containsMessageForActiveTurn(sessionId: string, messageId: string): boolean {
-    return this.activeTurnsBySession.get(sessionId)?.messageAncestry.includes(messageId) ?? false
-  }
-
   snapshot(handle: ArtifactTurnHandle): ArtifactTurnSnapshot {
     const turn = this.resolve(handle)
     return {

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -75,7 +75,10 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
   profileService?: ProfileService
   sessionPersistenceCoordinator?: Pick<
     SessionPersistenceCoordinator,
-    'readSessionRuntimeContext' | 'patchSessionRuntimeContext' | 'appendUserMessageToInteraction'
+    | 'readSessionRuntimeContext'
+    | 'patchSessionRuntimeContext'
+    | 'appendUserMessageToInteraction'
+    | 'containsMessageOnActiveBranch'
   >
 }
 

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -52,7 +52,7 @@ type RuntimeHarness = Readonly<{
 const createRuntimeHarness = (options: {
   onEvent?: (event?: unknown) => void
   activeProjection?: ActivePlanProjection
-  messageAncestry?: string[]
+  durableMessageIds?: string[]
 }): RuntimeHarness => {
   const generated = projection('version-1')
   const approved = { ...generated, approval: 'approved' as const, lifecycle: 'approved' as const }
@@ -109,10 +109,14 @@ const createRuntimeHarness = (options: {
     },
     planExecutionBindings: new Map(),
     planApprovalWaiters: new Map(),
+    planSessions: {
+      containsMessageOnActiveBranch: vi.fn(
+        async (_projectId: string, _sessionId: string, messageId: string) =>
+          (options.durableMessageIds ?? ['interaction-1']).includes(messageId)
+      )
+    },
     artifactTurns: {
-      promptMessageIdFor: () => 'interaction-1',
-      containsMessageForActiveTurn: (_sessionId: string, messageId: string) =>
-        (options.messageAncestry ?? ['interaction-1']).includes(messageId)
+      promptMessageIdFor: () => 'interaction-1'
     },
     callbacks: { onEvent: options.onEvent },
     pushEvent: (event: unknown) => options.onEvent?.(event),
@@ -193,7 +197,7 @@ describe('AcpRuntime Session Plan seam', () => {
   it('rejects an MCP Plan decision when the Plan originated on a sibling Message Branch', async () => {
     const { runtime, service } = createRuntimeHarness({
       activeProjection: projection('version-2', 4, 'sibling-message'),
-      messageAncestry: ['parent-message', 'interaction-1']
+      durableMessageIds: ['parent-message', 'interaction-1']
     })
 
     await expect(
@@ -224,7 +228,7 @@ describe('AcpRuntime Session Plan seam', () => {
   it('rejects a renderer Plan decision when the Plan originated on a sibling Message Branch', async () => {
     const { runtime, service } = createRuntimeHarness({
       activeProjection: projection('version-2', 4, 'sibling-message'),
-      messageAncestry: ['parent-message', 'interaction-1']
+      durableMessageIds: ['parent-message', 'interaction-1']
     })
 
     await expect(
@@ -242,7 +246,7 @@ describe('AcpRuntime Session Plan seam', () => {
   it('rejects renderer Plan feedback when the Plan originated on a sibling Message Branch', async () => {
     const { runtime, service } = createRuntimeHarness({
       activeProjection: projection('version-2', 4, 'sibling-message'),
-      messageAncestry: ['parent-message', 'interaction-1']
+      durableMessageIds: ['parent-message', 'interaction-1']
     })
     const pending = runtime.callSessionPlan({
       projectId: 'project-1',

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1623,6 +1623,21 @@ describe('ACP runtime session management', () => {
     counts: { phases: 1, delegations: 1, steps: 1, completed: 0, inProgress: 0 }
   })
 
+  const durablePlanSessions = (
+    messageIds: string[] = ['plan-origin']
+  ): {
+    containsMessageOnActiveBranch(
+      projectId: string,
+      sessionId: string,
+      messageId: string
+    ): Promise<boolean>
+  } => ({
+    containsMessageOnActiveBranch: vi.fn(
+      async (_projectId: string, _sessionId: string, messageId: string) =>
+        messageIds.includes(messageId)
+    )
+  })
+
   it('activates one interaction before durably approving a restored Plan', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['s1'])
@@ -1639,6 +1654,7 @@ describe('ACP runtime session management', () => {
     const respond = vi.fn(async () => ({ projection: approved, changed: true }))
     const checkTurnCompletion = vi.fn(async () => ({ allow: true }))
     Object.assign(runtime as unknown as { planService: unknown }, {
+      planSessions: durablePlanSessions(),
       planService: {
         respond,
         checkTurnCompletion,
@@ -1695,6 +1711,7 @@ describe('ACP runtime session management', () => {
     const getProjection = vi.fn(async () => pending)
     const respond = vi.fn()
     Object.assign(runtime as unknown as { planService: unknown }, {
+      planSessions: durablePlanSessions(),
       planService: { getProjection, respond }
     })
 
@@ -1753,6 +1770,7 @@ describe('ACP runtime session management', () => {
     const pending = restoredPlanProjection('pending', 4)
     const respond = vi.fn(async () => ({ projection: rejected, changed: true }))
     Object.assign(runtime as unknown as { planService: unknown }, {
+      planSessions: durablePlanSessions(),
       planService: {
         respond,
         getProjection: vi.fn(async () => pending)
@@ -12706,6 +12724,7 @@ describe('ACP runtime session management', () => {
       } satisfies ActivePlanProjection
       const authorizeContinuation = vi.fn(async () => active)
       Object.assign(runtime as unknown as { planService: unknown }, {
+        planSessions: durablePlanSessions(),
         planService: {
           authorizeContinuation,
           checkTurnCompletion: vi.fn(async () => ({ allow: true })),
@@ -12752,6 +12771,7 @@ describe('ACP runtime session management', () => {
     })
     const active = restoredPlanProjection('approved', 4)
     Object.assign(runtime as unknown as { planService: unknown }, {
+      planSessions: durablePlanSessions(['branch-b-root', 'branch-b-message']),
       planService: { authorizeContinuation: vi.fn(async () => active) }
     })
 
@@ -12767,7 +12787,7 @@ describe('ACP runtime session management', () => {
         },
         provenanceContext: {
           promptMessageId: 'branch-b-message',
-          messageAncestry: ['branch-b-root', 'branch-b-message']
+          messageAncestry: ['plan-origin', 'branch-b-root', 'branch-b-message']
         }
       })
     ).rejects.toMatchObject({ code: 'interaction-mismatch' })
@@ -12831,6 +12851,7 @@ describe('ACP runtime session management', () => {
         counts: { phases: 1, delegations: 1, steps: 1, completed: 0, inProgress: 0 }
       } satisfies ActivePlanProjection
       Object.assign(runtime as unknown as { planService: unknown }, {
+        planSessions: durablePlanSessions(),
         planService: {
           authorizeContinuation: vi.fn(async () => authorized),
           checkTurnCompletion,
@@ -19828,7 +19849,8 @@ describe('Specialist Skill scoping', () => {
           },
           appendUserMessageToInteraction: async () => {
             throw new Error('not used in this test')
-          }
+          },
+          containsMessageOnActiveBranch: async () => true
         }
       }
     })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -296,7 +296,10 @@ type AcpRuntimePlanOptions = {
   registerSessionAlias?: (aliasSessionId: string, sessionId: string) => void
   sessions: Pick<
     SessionPersistenceCoordinator,
-    'readSessionRuntimeContext' | 'patchSessionRuntimeContext' | 'appendUserMessageToInteraction'
+    | 'readSessionRuntimeContext'
+    | 'patchSessionRuntimeContext'
+    | 'appendUserMessageToInteraction'
+    | 'containsMessageOnActiveBranch'
   >
 }
 // An end_turn is final from the runtime's perspective, so promised work must be a tool call in the
@@ -410,6 +413,7 @@ class AcpRuntime {
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly artifactTurns: ArtifactTurnOwner | undefined
   private readonly planService: PlanService | undefined
+  private readonly planSessions: AcpRuntimePlanOptions['sessions'] | undefined
   private readonly planApprovalWaiters = new Map<
     string,
     {
@@ -509,6 +513,7 @@ class AcpRuntime {
               : {})
           })
         : undefined
+    this.planSessions = options.plan?.sessions
     this.planService =
       options.plan && this.artifactTurns && options.artifacts?.provenance?.resolveVersionContent
         ? createProductionPlanService({
@@ -1033,7 +1038,7 @@ class AcpRuntime {
       interactionIsLive: this.sessionInteractions.current(input.sessionId) !== undefined
     })
     if (!projection) throw new Error('The Session has no active Plan.')
-    this.assertPlanVisibleToActiveTurn(input.sessionId, projection)
+    await this.assertPlanVisibleToDurableBranch(input.projectId, input.sessionId, projection)
     const identity = {
       projectId: input.projectId,
       sessionId: input.sessionId,
@@ -1128,7 +1133,7 @@ class AcpRuntime {
       interactionIsLive
     })
     if (!projection) throw new Error('The Session has no active Plan.')
-    this.assertPlanVisibleToActiveTurn(input.sessionId, projection)
+    await this.assertPlanVisibleToDurableBranch(input.projectId, input.sessionId, projection)
     const result = await this.planService.respond({ ...input, interactionIsLive })
     if ('projection' in result) {
       if (interactionIsLive && result.projection.approval === 'approved') {
@@ -1216,29 +1221,20 @@ class AcpRuntime {
     })
   }
 
-  private assertPlanVisibleToActiveTurn(sessionId: string, projection: ActivePlanProjection): void {
-    const origin = projection.originatingPromptMessageId
-    if (!origin || !this.artifactTurns?.containsMessageForActiveTurn(sessionId, origin)) {
-      throw new PlanCommandError(
-        'interaction-mismatch',
-        'The active Session Plan does not belong to this Message Branch.'
-      )
-    }
-  }
-
-  private assertPlanVisibleToPrompt(
-    request: AcpPromptRequest,
+  private async assertPlanVisibleToDurableBranch(
+    projectId: string,
+    sessionId: string,
     projection: ActivePlanProjection
-  ): void {
+  ): Promise<void> {
     const origin = projection.originatingPromptMessageId
-    const visibleMessageIds = new Set(request.provenanceContext?.messageAncestry ?? [])
-    if (request.provenanceContext?.promptMessageId) {
-      visibleMessageIds.add(request.provenanceContext.promptMessageId)
-    }
-    if (!origin || !visibleMessageIds.has(origin)) {
+    if (
+      !origin ||
+      !this.planSessions ||
+      !(await this.planSessions.containsMessageOnActiveBranch(projectId, sessionId, origin))
+    ) {
       throw new PlanCommandError(
         'interaction-mismatch',
-        'The Session Plan continuation does not belong to this Message Branch.'
+        'The active Session Plan does not belong to the durable active Message Branch.'
       )
     }
   }
@@ -1862,15 +1858,19 @@ class AcpRuntime {
         sessionId: request.sessionId,
         artifactVersionId: continuation.artifactVersionId,
         expectedRevision: continuation.expectedRevision
-      }).then((authorized) => {
-        this.assertPlanVisibleToPrompt(request, authorized)
+      }).then(async (authorized) => {
+        await this.assertPlanVisibleToDurableBranch(
+          continuation.projectId,
+          request.sessionId,
+          authorized
+        )
         return Object.freeze({ authorized })
       })
     }
     if (!continuation) return Object.freeze({})
     return this.planService!.getProjection(continuation.projectId, request.sessionId, {
       interactionIsLive: false
-    }).then((protectedPending) => {
+    }).then(async (protectedPending) => {
       if (!protectedPending) {
         throw new PlanCommandError('no-active-plan', 'The Session has no active Plan.')
       }
@@ -1883,7 +1883,11 @@ class AcpRuntime {
       if (protectedPending.approval !== 'pending') {
         throw new PlanCommandError('approval-already-decided', 'Plan approval is irreversible.')
       }
-      this.assertPlanVisibleToPrompt(request, protectedPending)
+      await this.assertPlanVisibleToDurableBranch(
+        continuation.projectId,
+        request.sessionId,
+        protectedPending
+      )
       return Object.freeze({ protectedPending })
     })
   }

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -59,6 +59,7 @@ describe('ACP Task Agent port', () => {
     await port.setPermissionProfile('session-stable', 'full')
     await port.prompt({
       sessionId: 'session-stable',
+      promptMessageId: 'persisted-prompt',
       text: 'Continue the research.',
       skillIds: ['literature-review'],
       historyPreamble: 'Previous conversation.',
@@ -85,6 +86,7 @@ describe('ACP Task Agent port', () => {
     expect(runtime.sendPrompt).toHaveBeenCalledWith({
       sessionId: 'session-stable',
       text: 'Continue the research.',
+      provenanceContext: { promptMessageId: 'persisted-prompt' },
       forcedSkillIds: ['literature-review'],
       historyPreamble: 'Previous conversation.',
       contextReset: true,
@@ -95,6 +97,7 @@ describe('ACP Task Agent port', () => {
   it('keeps Task prompt notification tracking equivalent on success and failure', async () => {
     const prompt = {
       sessionId: 'session-1',
+      promptMessageId: 'persisted-prompt',
       text: 'Research this.',
       skillIds: ['literature-review']
     }
@@ -118,6 +121,7 @@ describe('ACP Task Agent port', () => {
     expect(trackPrompt).toHaveBeenCalledWith({
       sessionId: 'session-1',
       text: 'Research this.',
+      provenanceContext: { promptMessageId: 'persisted-prompt' },
       forcedSkillIds: ['literature-review']
     })
     expect(untrackPrompt).not.toHaveBeenCalled()

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -20,6 +20,7 @@ type TaskPromptNotifications = Pick<TaskNotificationService, 'trackPrompt' | 'un
 const toAcpPromptRequest = (request: TaskAgentPromptRequest): AcpPromptRequest => ({
   sessionId: request.sessionId,
   text: request.text,
+  provenanceContext: { promptMessageId: request.promptMessageId },
   ...(request.skillIds?.length ? { forcedSkillIds: request.skillIds } : {}),
   ...(request.historyPreamble ? { historyPreamble: request.historyPreamble } : {}),
   ...(request.contextReset ? { contextReset: true } : {}),

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -5,8 +5,14 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
 import {
+  createLinearConversationGraph,
+  forkEditedConversationMessage,
+  synchronizeActiveConversationMessages
+} from '../../shared/conversation-graph'
+import {
   materializeSessionConversationGraph,
   type PersistedArtifact,
+  type PersistedChatMessage,
   type PersistedChatSession,
   type SessionPlanRuntimeContext
 } from '../../shared/session-persistence'
@@ -154,6 +160,87 @@ const createProjectReconciliationSnapshot = (): ArtifactProjectReconciliationSna
   ({}) as ArtifactProjectReconciliationSnapshot
 
 describe('SessionPersistenceCoordinator', () => {
+  it('resolves Message membership from the durable active Branch', async () => {
+    const prompt = (id: string, createdAt: number): PersistedChatMessage => ({
+      id,
+      role: 'user',
+      content: id,
+      status: 'complete',
+      eventIds: [],
+      createdAt,
+      updatedAt: createdAt
+    })
+    const promptA = prompt('prompt-a', 1)
+    const promptB = prompt('prompt-b', 2)
+    const original = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [promptA],
+      createdAt: 1,
+      updatedAt: 1
+    })
+    const branchB = synchronizeActiveConversationMessages(
+      forkEditedConversationMessage(original, promptA.id, 'branch-b', 2),
+      [promptB],
+      2
+    )
+    const durable = createSession({ messages: [promptB], conversationGraph: branchB })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      }))
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.containsMessageOnActiveBranch('project-1', 'session-1', promptB.id)
+    ).resolves.toBe(true)
+    await expect(
+      coordinator.containsMessageOnActiveBranch('project-1', 'session-1', promptA.id)
+    ).resolves.toBe(false)
+  })
+
+  it('materializes a legacy linear Session before checking its active Branch', async () => {
+    const durable = createSession({
+      messages: [
+        {
+          id: 'legacy-prompt',
+          role: 'user',
+          content: 'Legacy prompt',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      }))
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.containsMessageOnActiveBranch('project-1', 'session-1', 'legacy-prompt')
+    ).resolves.toBe(true)
+  })
+
+  it.each(['missing', 'unreadable'] as const)(
+    'fails closed when the durable Session is %s',
+    async (status) => {
+      const repository = createSessionRepository({
+        loadSessionWithDiagnostics: vi.fn(async () => ({ status }))
+      })
+      const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+      await expect(
+        coordinator.containsMessageOnActiveBranch('project-1', 'session-1', 'prompt-a')
+      ).rejects.toThrow(`Cannot read active Message Branch for a ${status} Session.`)
+    }
+  )
+
   it('persists blocked Plan feedback as a standard user Message without changing Plan authority', async () => {
     let durable = createSession({
       status: 'waiting-plan-approval',

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto'
 
+import { resolveActiveConversationMessages } from '../../shared/conversation-graph'
 import type { ProjectFilesChangedEvent } from '../../shared/project-files'
 import type { ProjectFileSource } from '../../shared/project-files'
 import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
@@ -405,6 +406,23 @@ class SessionPersistenceCoordinator {
     private readonly permissionGrants?: SessionPermissionGrantReconciliation,
     private readonly log: Logger = createLogger('session-persistence')
   ) {}
+
+  containsMessageOnActiveBranch(
+    projectId: string,
+    sessionId: string,
+    messageId: string
+  ): Promise<boolean> {
+    return this.enqueue(async () => {
+      const loaded = await this.repository.loadSessionWithDiagnostics(projectId, sessionId)
+      if (loaded.status !== 'found') {
+        throw new Error(`Cannot read active Message Branch for a ${loaded.status} Session.`)
+      }
+      const graph = materializeSessionConversationGraph(loaded.session).conversationGraph
+      return graph
+        ? resolveActiveConversationMessages(graph).some((message) => message.id === messageId)
+        : false
+    })
+  }
 
   // Binds unread cleanup to authoritative Session mutations. Reconciliation is called only with a
   // complete live Session catalog, while commit runs only after deletion succeeds.

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -384,6 +384,7 @@ describe('TaskRunner', () => {
     expect(prompts).toEqual([
       {
         sessionId: existing.id,
+        promptMessageId: 'new-user',
         text: 'Follow-up question',
         contextReset: true,
         historyPreamble:
@@ -443,6 +444,7 @@ describe('TaskRunner', () => {
     expect(prompts).toEqual([
       {
         sessionId: existing.id,
+        promptMessageId: 'skill-user',
         text: 'Use the selected skill.',
         skillIds: ['literature-review'],
         resumeFallback: {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -77,6 +77,7 @@ type TaskAgentResumeSessionRequest = {
 
 type TaskAgentPromptRequest = {
   sessionId: string
+  promptMessageId: string
   text: string
   skillIds?: string[]
   historyPreamble?: string
@@ -480,6 +481,7 @@ class TaskRunner {
     try {
       await this.dependencies.agent.prompt({
         sessionId: session.id,
+        promptMessageId: session.activeRun!.promptMessageId,
         text: prompt,
         ...(request.skillIds?.length ? { skillIds: request.skillIds } : {}),
         ...(historyPreamble ? { historyPreamble } : {}),

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -199,6 +199,7 @@ describe('HeadlessTaskApi adapter', () => {
     expect(agent.setPermissionProfile).toHaveBeenCalledWith(existing.id, 'auto')
     expect(agent.prompt).toHaveBeenCalledWith({
       sessionId: existing.id,
+      promptMessageId: 'attached-user',
       text: 'Continue research.'
     })
     expect(invoke.mock.calls.every(([channel]) => !String(channel).startsWith('acp:'))).toBe(true)
@@ -298,6 +299,7 @@ describe('HeadlessTaskApi adapter', () => {
     })
     expect(agent.prompt).toHaveBeenCalledWith({
       sessionId: 'session-context',
+      promptMessageId: expect.any(String),
       text: 'Research with remote context.'
     })
     expect(context.isAuthorizationCurrent()).toBe(false)


### PR DESCRIPTION
## Problem

PR #786 hardened Session Plan identity and revision checks, but branch membership was still authorized from request-scoped provenance or the in-memory active Artifact turn. Those sources are not the durable Session authority, so supplied ancestry could claim a Plan from a sibling Message Branch and restarted interactions could disagree with persisted state.

## Proposed change

- add one queued Session persistence query that materializes the durable conversation graph and checks the active Branch with the existing graph resolver
- use that query for MCP Plan commands, renderer Plan responses/feedback, and prompt continuation preflight
- preserve the existing persisted Task prompt ID when adapting Task requests to ACP provenance
- fail closed for missing, unreadable, legacy-without-origin, or sibling-Branch Plans
- remove the superseded in-memory Artifact-turn ancestry helper

```mermaid
flowchart LR
  A["Plan action or continuation"] --> B["SessionPersistenceCoordinator queue"]
  B --> C["Load durable Session"]
  C --> D["Materialize conversation graph"]
  D --> E["Resolve active Message Branch"]
  E --> F{"Originating Message present?"}
  F -->|yes| G["Continue existing identity, revision, and interaction checks"]
  F -->|no| H["Reject interaction mismatch"]
```

## Scope and non-goals

- No Session schema, database, data relationship, dependency, IPC, renderer, or user-interaction changes.
- No token/signing layer or new authorization service.
- Legacy linear Sessions are handled by the existing conversation-graph materializer.
- Broader Session Plan changes remain out of scope and should use a separate PR.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Durable active-Branch lookup, legacy materialization, and missing/unreadable fail-closed behavior -> `npm test -- --run src/main/session-persistence/coordinator.test.ts` -> 92 passed
- MCP, renderer, continuation, and forged request-ancestry behavior plus affected contracts -> `npm test -- --run src/main/acp/runtime-session-plan.test.ts src/main/acp/runtime.test.ts src/main/acp/artifact-turn-owner.test.ts src/main/session-persistence/coordinator.test.ts` -> 557 passed
- Task prompt identity propagation and direct consumers -> `npm test -- --run src/main/tasks/task-runner.test.ts src/main/acp/task-agent-port.test.ts src/main/web-service/task-api.test.ts` -> 25 passed
- Node and renderer type consumers -> `npm run typecheck` -> passed
- Static checks -> `npm run lint` -> passed with 17 pre-existing warnings and 0 errors
- Portable regression suite -> `npm test` -> 11,603 passed, 184 skipped; 781 files passed, 14 skipped

No platform-specific UI or E2E lane is added because this changes only main-process authorization against existing persisted Session data and does not alter UI, preload, IPC, schema, filesystem format, or platform integration. CI and independent PR review remain authoritative for uncovered platform risk.

## Review focus

- Confirm the durable active Branch is the correct authority at all three Plan entry seams.
- Confirm failures occur before Plan mutation while existing Artifact identity, revision, and interaction bindings remain intact.
- Confirm the coordinator query stays within the existing serialization boundary.

Follow-up to #786.
