### PR TITLE
refactor(acp): extract context compaction workflow

### DIFF
--- a/src/main/acp/context-compaction-workflow.test.ts
+++ b/src/main/acp/context-compaction-workflow.test.ts
@@ -1,0 +1,312 @@
+import type { ActiveSession, PromptResponse, SessionNotification } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpRuntimeEvent } from '../../shared/acp'
+import { claudeCodeFramework } from '../agent-framework'
+import type { AgentFramework } from '../agent-framework/types'
+import { AcpContextCompactionWorkflow } from './context-compaction-workflow'
+import { ContextUsageTracker, type TokenCounter } from './context-usage-tracker'
+import { AcpSessionInteractionOwner } from './session-interaction-owner'
+
+type NextUpdate = Awaited<ReturnType<ActiveSession['nextUpdate']>>
+
+type Deferred<Value> = {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+}
+
+type FakeSession = ActiveSession & {
+  prompt: ReturnType<typeof vi.fn>
+  nextUpdate: ReturnType<typeof vi.fn>
+}
+
+const wordCounter: TokenCounter = {
+  count: (text) => text.trim().split(/\s+/).filter(Boolean).length
+}
+
+const deferred = <Value>(): Deferred<Value> => {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((done) => (resolve = done))
+  return { promise, resolve }
+}
+
+const stop = (stopReason: PromptResponse['stopReason']): NextUpdate =>
+  ({ kind: 'stop', response: { stopReason } }) as NextUpdate
+
+const notification = (text: string): SessionNotification => ({
+  sessionId: 'provider-session',
+  update: {
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text }
+  }
+})
+
+const update = (message: SessionNotification): NextUpdate =>
+  ({ kind: 'session_update', notification: message, update: message.update }) as NextUpdate
+
+const fakeSession = (messages: Array<NextUpdate | Promise<NextUpdate>> = []): FakeSession => {
+  const queue = [...messages]
+  return {
+    sessionId: 'provider-session',
+    prompt: vi.fn(async () => undefined),
+    nextUpdate: vi.fn(async () => {
+      const message = queue.shift()
+      if (!message) return new Promise<never>(() => undefined)
+      return await message
+    })
+  } as unknown as FakeSession
+}
+
+const frameworkManaged = {
+  ...claudeCodeFramework,
+  displayName: 'Managed Agent',
+  contextCompaction: { kind: 'framework-managed' }
+} satisfies AgentFramework
+
+const createHarness = (input?: {
+  framework?: AgentFramework
+  session?: FakeSession
+}): {
+  context: ContextUsageTracker
+  emitState: ReturnType<typeof vi.fn>
+  events: Array<Partial<AcpRuntimeEvent>>
+  interactions: AcpSessionInteractionOwner
+  promptContent: { resetSession: ReturnType<typeof vi.fn> }
+  pushEvent: ReturnType<typeof vi.fn>
+  routeHiddenNotification: ReturnType<typeof vi.fn>
+  session: FakeSession
+  workflow: AcpContextCompactionWorkflow
+} => {
+  const framework = input?.framework ?? claudeCodeFramework
+  const activeSession: ActiveSession | undefined = input?.session ?? fakeSession()
+  const session = activeSession as FakeSession
+  const interactions = new AcpSessionInteractionOwner()
+  const context = new ContextUsageTracker(wordCounter)
+  context.beginSession('app-session', {
+    frameworkId: framework.id,
+    model: 'test-model'
+  })
+  const events: Array<Partial<AcpRuntimeEvent>> = []
+  const promptContent = { resetSession: vi.fn() }
+  const pushEvent = vi.fn((event: Partial<AcpRuntimeEvent>) => events.push(event))
+  const routeHiddenNotification = vi.fn()
+  const emitState = vi.fn()
+  const workflow = new AcpContextCompactionWorkflow({
+    sessions: {
+      activeSession: (sessionId) => (sessionId === 'app-session' ? activeSession : undefined),
+      currentFramework: () => framework
+    },
+    interactions,
+    context,
+    promptContent,
+    contextEstimateInput: () => ({ frameworkId: framework.id, model: 'test-model' }),
+    selectedContextWindow: () => 200_000,
+    routeHiddenNotification,
+    pushEvent,
+    emitState,
+    errorMessage: (error) => (error instanceof Error ? error.message : String(error))
+  })
+
+  return {
+    context,
+    emitState,
+    events,
+    interactions,
+    promptContent,
+    pushEvent,
+    routeHiddenNotification,
+    session,
+    workflow
+  }
+}
+
+describe('AcpContextCompactionWorkflow', () => {
+  it('runs a manual native control turn without projecting its hidden output', async () => {
+    const hidden = notification('Compacting conversation history')
+    const session = fakeSession([update(hidden), stop('end_turn')])
+    const harness = createHarness({ session })
+    harness.context.reconcileProviderUsage('app-session', { used: 180_000, size: 200_000 })
+    const checkpointSession = vi.spyOn(harness.context, 'checkpointSession')
+    const resetAfterCompaction = vi.spyOn(harness.context, 'resetAfterCompaction')
+
+    await expect(harness.workflow.compact({ sessionId: 'app-session' })).resolves.toEqual({
+      stopReason: 'end_turn'
+    })
+
+    expect(session.prompt).toHaveBeenCalledWith([{ type: 'text', text: '/compact' }])
+    expect(harness.routeHiddenNotification).toHaveBeenCalledWith(hidden, 'app-session')
+    expect(checkpointSession).toHaveBeenCalledWith('app-session')
+    expect(resetAfterCompaction).toHaveBeenCalledWith(
+      'app-session',
+      { frameworkId: 'claude-code', model: 'test-model' },
+      checkpointSession.mock.results[0].value,
+      200_000
+    )
+    expect(harness.promptContent.resetSession).toHaveBeenCalledWith('app-session')
+    expect(
+      harness.events.map(({ kind, status, compactionReason }) => ({
+        kind,
+        status,
+        compactionReason
+      }))
+    ).toEqual([
+      { kind: 'compaction', status: 'in_progress', compactionReason: 'manual' },
+      { kind: 'compaction', status: 'completed', compactionReason: 'manual' }
+    ])
+    expect(harness.emitState).toHaveBeenCalledTimes(2)
+    expect(harness.interactions.current('app-session')).toBeUndefined()
+  })
+
+  it.each([
+    {
+      name: 'cancelled stop',
+      messages: [stop('cancelled')],
+      expectedStatus: 'cancelled',
+      expectedError: undefined
+    },
+    {
+      name: 'adapter failure output',
+      messages: [update(notification('  Compacting failed: media_unstrippable')), stop('end_turn')],
+      expectedStatus: 'failed',
+      expectedError: 'Compacting failed: media_unstrippable'
+    }
+  ])('restores the pre-compaction context after $name', async (testCase) => {
+    const harness = createHarness({ session: fakeSession(testCase.messages) })
+    harness.context.reconcileProviderUsage('app-session', { used: 180_000, size: 200_000 })
+    const restoreSession = vi.spyOn(harness.context, 'restoreSession')
+    const resetAfterCompaction = vi.spyOn(harness.context, 'resetAfterCompaction')
+
+    const compact = harness.workflow.compact({ sessionId: 'app-session' })
+    if (testCase.expectedError) {
+      await expect(compact).rejects.toThrow(testCase.expectedError)
+    } else {
+      await expect(compact).resolves.toEqual({ stopReason: 'cancelled' })
+    }
+
+    expect(restoreSession).toHaveBeenCalledOnce()
+    expect(resetAfterCompaction).not.toHaveBeenCalled()
+    expect(harness.promptContent.resetSession).not.toHaveBeenCalled()
+    expect(harness.events.at(-1)).toMatchObject({
+      kind: 'compaction',
+      status: testCase.expectedStatus,
+      compactionReason: 'manual'
+    })
+    expect(harness.interactions.current('app-session')).toBeUndefined()
+  })
+
+  it('rejects ordinary overlap and atomically transfers overflow recovery ownership', async () => {
+    const completion = deferred<NextUpdate>()
+    const harness = createHarness({ session: fakeSession([completion.promise]) })
+    const oldPrompt = harness.interactions.claim({ sessionId: 'app-session', kind: 'prompt' })
+
+    await expect(harness.workflow.compact({ sessionId: 'app-session' })).rejects.toThrow(
+      'An ACP prompt is already running for this session'
+    )
+
+    const recovering = harness.workflow.compact({
+      sessionId: 'app-session',
+      reason: 'overflow-recovery'
+    })
+    expect(oldPrompt.signal.aborted).toBe(true)
+    const compaction = harness.interactions.current('app-session')
+    expect(compaction).toMatchObject({ kind: 'compaction' })
+
+    harness.interactions.release(oldPrompt)
+    expect(harness.interactions.current('app-session')).toBe(compaction)
+    await expect(
+      harness.workflow.compact({ sessionId: 'app-session', reason: 'overflow-recovery' })
+    ).rejects.toThrow('Context compaction is already running for this session')
+
+    completion.resolve(stop('end_turn'))
+    await recovering
+    expect(harness.interactions.current('app-session')).toBeUndefined()
+  })
+
+  it('gates automatic compaction and preserves the current prompt interaction when eligible', async () => {
+    const session = fakeSession([stop('end_turn')])
+    const harness = createHarness({ session })
+    const staleInteraction = harness.interactions.claim({
+      sessionId: 'app-session',
+      kind: 'prompt'
+    })
+    harness.interactions.supersede(staleInteraction)
+    const interaction = harness.interactions.claim({ sessionId: 'app-session', kind: 'prompt' })
+
+    await harness.workflow.compactAutomatic({
+      sessionId: 'app-session',
+      session,
+      interaction: staleInteraction
+    })
+    await harness.workflow.compactAutomatic({
+      sessionId: 'app-session',
+      session: fakeSession(),
+      interaction
+    })
+    harness.context.appendPromptContent('app-session', 'large local estimate')
+    harness.context.refreshUsage('app-session', 'preflight', 200_000)
+    await harness.workflow.compactAutomatic({ sessionId: 'app-session', session, interaction })
+    harness.context.reconcileProviderUsage('app-session', { used: 100_000, size: 200_000 })
+    await harness.workflow.compactAutomatic({ sessionId: 'app-session', session, interaction })
+
+    expect(session.prompt).not.toHaveBeenCalled()
+
+    harness.context.reconcileProviderUsage('app-session', { used: 180_000, size: 200_000 })
+    await expect(
+      harness.workflow.compactAutomatic({ sessionId: 'app-session', session, interaction })
+    ).resolves.toEqual({ stopReason: 'end_turn' })
+
+    expect(session.prompt).toHaveBeenCalledWith([{ type: 'text', text: '/compact' }])
+    expect(
+      harness.events.map(({ compactionReason, status }) => ({
+        compactionReason,
+        status
+      }))
+    ).toEqual([
+      { compactionReason: 'automatic', status: 'in_progress' },
+      { compactionReason: 'automatic', status: 'completed' }
+    ])
+    expect(harness.interactions.current('app-session')).toBe(interaction)
+    harness.interactions.release(interaction)
+  })
+
+  it('cleans up the manual scope when the framework owns compaction', async () => {
+    const harness = createHarness({ framework: frameworkManaged })
+
+    await expect(harness.workflow.compact({ sessionId: 'app-session' })).rejects.toThrow(
+      'Managed Agent manages context compaction automatically.'
+    )
+
+    expect(harness.session.prompt).not.toHaveBeenCalled()
+    expect(harness.events).toEqual([])
+    expect(harness.emitState).toHaveBeenCalledTimes(2)
+    expect(harness.interactions.current('app-session')).toBeUndefined()
+  })
+
+  it.each([
+    { stopReason: 'end_turn' as const, terminalStatus: 'completed', reset: true },
+    { stopReason: 'cancelled' as const, terminalStatus: 'cancelled', reset: false }
+  ])(
+    'keeps $terminalStatus terminal state when projection callbacks throw',
+    async ({ stopReason, terminalStatus, reset }) => {
+      const harness = createHarness({ session: fakeSession([stop(stopReason)]) })
+      const restoreSession = vi.spyOn(harness.context, 'restoreSession')
+      harness.context.reconcileProviderUsage('app-session', { used: 180_000, size: 200_000 })
+      harness.emitState.mockImplementation(() => {
+        throw new Error('state listener failed')
+      })
+      harness.pushEvent.mockImplementation((event: Partial<AcpRuntimeEvent>) => {
+        harness.events.push(event)
+        if (event.status === terminalStatus) throw new Error('event listener failed')
+      })
+
+      await expect(harness.workflow.compact({ sessionId: 'app-session' })).resolves.toEqual({
+        stopReason
+      })
+
+      expect(harness.promptContent.resetSession).toHaveBeenCalledTimes(reset ? 1 : 0)
+      expect(restoreSession).toHaveBeenCalledTimes(reset ? 0 : 1)
+      expect(harness.events.map(({ status }) => status)).toEqual(['in_progress', terminalStatus])
+      expect(harness.interactions.current('app-session')).toBeUndefined()
+    }
+  )
+})

--- a/src/main/acp/context-compaction-workflow.ts
+++ b/src/main/acp/context-compaction-workflow.ts
@@ -1,0 +1,206 @@
+import type { ActiveSession, PromptResponse, SessionNotification } from '@agentclientprotocol/sdk'
+
+import type { AcpCompactSessionRequest, AcpRuntimeEvent } from '../../shared/acp'
+import type { AgentFramework } from '../agent-framework'
+import { createLogger, errorLogFields } from '../logger'
+import type { ContextUsageTracker, SessionEstimateInput } from './context-usage-tracker'
+import type { AcpPromptContentOwner } from './prompt-content-owner'
+import type { RuntimeEventInput } from './runtime-snapshot-owner'
+import type {
+  AcpPromptSessionInteractionScope,
+  AcpSessionInteractionOwner
+} from './session-interaction-owner'
+
+type AcpContextCompactionSessions = Readonly<{
+  activeSession: (sessionId: string) => ActiveSession | undefined
+  currentFramework: () => AgentFramework
+}>
+
+type AcpContextCompactionWorkflowOptions = Readonly<{
+  sessions: AcpContextCompactionSessions
+  interactions: Pick<AcpSessionInteractionOwner, 'claim' | 'current' | 'release' | 'supersede'>
+  context: Pick<
+    ContextUsageTracker,
+    'checkpointSession' | 'resetAfterCompaction' | 'restoreSession' | 'usage'
+  >
+  promptContent: Pick<AcpPromptContentOwner, 'resetSession'>
+  contextEstimateInput: (sessionId: string) => SessionEstimateInput
+  selectedContextWindow: (sessionId: string) => number | undefined
+  routeHiddenNotification: (notification: SessionNotification, sessionId: string) => void
+  pushEvent: (event: RuntimeEventInput) => void
+  emitState: () => void
+  errorMessage: (error: unknown) => string
+}>
+
+type AcpAutomaticCompactionRequest = Readonly<{
+  sessionId: string
+  session: ActiveSession
+  interaction: AcpPromptSessionInteractionScope
+}>
+
+type CompactionReason = NonNullable<AcpRuntimeEvent['compactionReason']>
+
+const log = createLogger('acp-context-compaction-workflow')
+
+class AcpContextCompactionWorkflow {
+  constructor(private readonly options: AcpContextCompactionWorkflowOptions) {}
+
+  async compact(request: AcpCompactSessionRequest): Promise<PromptResponse> {
+    const { interactions, sessions } = this.options
+    const session = sessions.activeSession(request.sessionId)
+    if (!session) throw new Error(`ACP session not found: ${request.sessionId}`)
+    const currentInteraction = interactions.current(request.sessionId)
+    if (currentInteraction?.kind === 'compaction') {
+      throw new Error('Context compaction is already running for this session')
+    }
+    if (currentInteraction && request.reason !== 'overflow-recovery') {
+      throw new Error('An ACP prompt is already running for this session')
+    }
+    if (request.reason === 'overflow-recovery' && currentInteraction) {
+      interactions.supersede(currentInteraction)
+    }
+
+    const interaction = interactions.claim({ sessionId: request.sessionId, kind: 'compaction' })
+    try {
+      this.safeProjection('compaction state callback failed', this.options.emitState)
+      return await this.runNative(session, request.sessionId, request.reason ?? 'manual')
+    } finally {
+      interactions.release(interaction)
+      this.safeProjection('compaction state callback failed', this.options.emitState)
+    }
+  }
+
+  async compactAutomatic(
+    request: AcpAutomaticCompactionRequest
+  ): Promise<PromptResponse | undefined> {
+    if (
+      this.options.interactions.current(request.sessionId) !== request.interaction ||
+      this.options.sessions.activeSession(request.sessionId) !== request.session ||
+      !this.shouldCompactAutomatically(request.sessionId)
+    ) {
+      return undefined
+    }
+    return this.runNative(request.session, request.sessionId, 'automatic')
+  }
+
+  private shouldCompactAutomatically(sessionId: string): boolean {
+    const strategy = this.options.sessions.currentFramework().contextCompaction
+    if (strategy.kind !== 'native-command' || strategy.triggerAtPercent === undefined) return false
+    const usage = this.options.context.usage(sessionId)
+    if (!usage || usage.size === undefined || usage.size <= 0 || usage.used < 0) return false
+    if (usage.breakdown?.status === 'preflight') return false
+    return (usage.used / usage.size) * 100 >= strategy.triggerAtPercent
+  }
+
+  private async runNative(
+    session: ActiveSession,
+    sessionId: string,
+    reason: CompactionReason
+  ): Promise<PromptResponse> {
+    const strategy = this.options.sessions.currentFramework().contextCompaction
+    if (strategy.kind !== 'native-command') {
+      throw new Error(
+        `${this.options.sessions.currentFramework().displayName} manages context compaction automatically.`
+      )
+    }
+    const checkpoint = this.options.context.checkpointSession(sessionId)
+    const restoreContext = (): void => this.options.context.restoreSession(sessionId, checkpoint)
+    this.publishEvent({
+      kind: 'compaction',
+      compactionReason: reason,
+      level: 'info',
+      sessionId,
+      status: 'in_progress',
+      title: 'Compacting context'
+    })
+
+    try {
+      let failureText: string | undefined
+      const promptFailure = new Promise<never>((_, reject) => {
+        session.prompt([{ type: 'text', text: strategy.command }]).catch(reject)
+      })
+      for (;;) {
+        const message = await Promise.race([session.nextUpdate(), promptFailure])
+        if (message.kind === 'stop') {
+          if (message.response.stopReason === 'cancelled') {
+            restoreContext()
+            this.publishEvent({
+              kind: 'compaction',
+              compactionReason: reason,
+              level: 'info',
+              sessionId,
+              status: 'cancelled',
+              title: 'Context compaction cancelled'
+            })
+            return message.response
+          }
+          if (message.response.stopReason !== 'end_turn') {
+            throw new Error(
+              `Context compaction stopped before completion: ${message.response.stopReason}`
+            )
+          }
+          if (failureText) throw new Error(failureText)
+          this.options.context.resetAfterCompaction(
+            sessionId,
+            this.options.contextEstimateInput(sessionId),
+            checkpoint,
+            this.options.selectedContextWindow(sessionId)
+          )
+          this.options.promptContent.resetSession(sessionId)
+          this.publishEvent({
+            kind: 'compaction',
+            compactionReason: reason,
+            level: 'info',
+            sessionId,
+            status: 'completed',
+            title: 'Context compacted'
+          })
+          return message.response
+        }
+
+        const update = message.notification.update
+        if (
+          !failureText &&
+          strategy.failureTextPrefix &&
+          update.sessionUpdate === 'agent_message_chunk' &&
+          update.content.type === 'text' &&
+          update.content.text.trimStart().startsWith(strategy.failureTextPrefix)
+        ) {
+          failureText = update.content.text.trim()
+        }
+        this.options.routeHiddenNotification(message.notification, sessionId)
+      }
+    } catch (error) {
+      restoreContext()
+      this.publishEvent({
+        kind: 'compaction',
+        compactionReason: reason,
+        level: 'error',
+        sessionId,
+        status: 'failed',
+        title: 'Context compaction failed',
+        text: this.options.errorMessage(error)
+      })
+      throw error
+    }
+  }
+
+  private publishEvent(event: RuntimeEventInput): void {
+    this.safeProjection('compaction event callback failed', () => this.options.pushEvent(event))
+  }
+
+  private safeProjection(message: string, action: () => void): void {
+    try {
+      action()
+    } catch (error) {
+      try {
+        log.error(message, errorLogFields(error))
+      } catch {
+        // Diagnostics must not replace the compaction lifecycle.
+      }
+    }
+  }
+}
+
+export { AcpContextCompactionWorkflow }
+export type { AcpAutomaticCompactionRequest, AcpContextCompactionWorkflowOptions }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3460,6 +3460,43 @@ describe('ACP runtime session management', () => {
     ).toEqual([])
   })
 
+  it('keeps compaction successful when a hidden usage update state callback throws', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['remote-session-1'], {
+      usageForPrompt: (text) => (text === '/compact' ? { used: 24_000, size: 200_000 } : undefined)
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: claudeCodeFramework,
+      callbacks: {
+        onStateChanged: (snapshot) => {
+          if (Object.values(snapshot.contextUsageBySession).some(({ used }) => used === 24_000)) {
+            throw new Error('state listener failed')
+          }
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+
+    await expect(runtime.compactSession({ sessionId: session.sessionId })).resolves.toEqual({
+      stopReason: 'end_turn'
+    })
+
+    expect(runtime.getSnapshot().contextUsageBySession[session.sessionId]).toMatchObject({
+      used: 24_000,
+      size: 200_000
+    })
+    expect(
+      runtime
+        .getSnapshot()
+        .events.filter((event) => event.kind === 'compaction')
+        .map(({ status }) => status)
+    ).toEqual(['in_progress', 'completed'])
+    expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([])
+  })
+
   it('serializes prompts and compaction per session without blocking another session', async () => {
     const process = new FakeAgentProcess()
     const firstPromptGate = createDeferred<PromptResponse>()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -126,6 +126,7 @@ import { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
 import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
 import { AcpPromptPreparationOwner } from './prompt-preparation-owner'
 import { AcpPromptTurnWorkflow, type AcpPromptTurnPlanContext } from './prompt-turn-workflow'
+import { AcpContextCompactionWorkflow } from './context-compaction-workflow'
 import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import { AcpProviderPromptExecutor } from './provider-prompt-executor'
 import { AcpPromptOutcomeFinalizer } from './prompt-outcome-finalizer'
@@ -423,6 +424,7 @@ class AcpRuntime {
   >()
   private readonly promptContentOwner: AcpPromptContentOwner
   private readonly promptPreparation: AcpPromptPreparationOwner
+  private readonly contextCompactionWorkflow: AcpContextCompactionWorkflow
   private readonly promptTurnWorkflow: AcpPromptTurnWorkflow
   private readonly connectionClose: AcpConnectionCloseWorkflow
   private readonly connectionLifecycle: AcpConnectionLifecycleWorkflow
@@ -605,6 +607,28 @@ class AcpRuntime {
       unregisterBridgeSession: (sessionId) =>
         this.connectionResources.unregisterBridgeReviewerSession(sessionId)
     })
+    this.contextCompactionWorkflow = new AcpContextCompactionWorkflow({
+      sessions: {
+        activeSession: (sessionId) => this.activeSessionFor(sessionId),
+        currentFramework: () => this.framework
+      },
+      interactions: this.sessionInteractions,
+      context: this.contextUsageTracker,
+      promptContent: this.promptContentOwner,
+      contextEstimateInput: (sessionId) => this.contextUsageEstimateInput(sessionId),
+      selectedContextWindow: (sessionId) => this.selectedContextWindowFor(sessionId),
+      routeHiddenNotification: (notification, sessionId) =>
+        this.handleSessionUpdate(notification, sessionId, false, () => {
+          try {
+            this.emitState()
+          } catch (error) {
+            safeLogError('compaction state callback failed', errorLogFields(error))
+          }
+        }),
+      pushEvent: (event) => this.pushEvent(event),
+      emitState: () => this.emitState(),
+      errorMessage
+    })
     this.promptTurnWorkflow = new AcpPromptTurnWorkflow({
       registry: this.sessionRegistry,
       interactions: this.sessionInteractions,
@@ -661,16 +685,8 @@ class AcpRuntime {
         onPromptEnded: (sessionId, turnToken) =>
           this.callbacks.onPromptEnded?.(sessionId, turnToken),
         generationActivityChanged: () => this.generationActivityChanged(),
-        autoCompact: (sessionId, session, interaction) => {
-          if (
-            this.sessionInteractions.current(sessionId) !== interaction ||
-            this.activeSessionFor(sessionId) !== session ||
-            !this.shouldAutoCompactContext(sessionId)
-          ) {
-            return Promise.resolve()
-          }
-          return this.performNativeContextCompaction(session, sessionId, 'automatic')
-        }
+        autoCompact: (sessionId, session, interaction) =>
+          this.contextCompactionWorkflow.compactAutomatic({ sessionId, session, interaction })
       },
       currentCwd: () => this.snapshotOwner.cwd,
       resolveProjectName: (sessionId) => this.resolveSessionProjectName(sessionId),
@@ -1620,156 +1636,7 @@ class AcpRuntime {
   // command is an internal control turn: fresh usage updates are retained, while its command
   // echo/status output is not projected into the user's conversation.
   async compactSession(request: AcpCompactSessionRequest): Promise<PromptResponse> {
-    return this.withOperationLease(() => this.compactSessionOperation(request))
-  }
-
-  private async compactSessionOperation(
-    request: AcpCompactSessionRequest
-  ): Promise<PromptResponse> {
-    const session = this.activeSessionFor(request.sessionId)
-    if (!session) throw new Error(`ACP session not found: ${request.sessionId}`)
-    const currentInteraction = this.sessionInteractions.current(request.sessionId)
-    if (currentInteraction?.kind === 'compaction') {
-      throw new Error('Context compaction is already running for this session')
-    }
-    if (currentInteraction && request.reason !== 'overflow-recovery') {
-      throw new Error('An ACP prompt is already running for this session')
-    }
-
-    // A recoverable overflow is emitted only after the provider prompt has already rejected; the old
-    // turn may still be doing artifact cleanup, but it no longer owns the agent session. Transfer its
-    // public lock to the control turn now so the retry can start immediately after compaction, while the
-    // dedicated compaction lock below keeps unrelated sends blocked during `/compact` itself.
-    if (request.reason === 'overflow-recovery' && currentInteraction) {
-      this.sessionInteractions.supersede(currentInteraction)
-    }
-
-    const compactionInteraction = this.sessionInteractions.claim({
-      sessionId: request.sessionId,
-      kind: 'compaction'
-    })
-    this.emitState()
-
-    try {
-      return await this.performNativeContextCompaction(
-        session,
-        request.sessionId,
-        request.reason ?? 'manual'
-      )
-    } finally {
-      this.sessionInteractions.release(compactionInteraction)
-      this.emitState()
-    }
-  }
-
-  private shouldAutoCompactContext(sessionId: string): boolean {
-    const strategy = this.framework.contextCompaction
-    if (strategy.kind !== 'native-command' || strategy.triggerAtPercent === undefined) return false
-
-    const usage = this.contextUsageTracker.usage(sessionId)
-    if (!usage || usage.size === undefined || usage.size <= 0 || usage.used < 0) return false
-    if (usage.breakdown?.status === 'preflight') return false
-
-    return (usage.used / usage.size) * 100 >= strategy.triggerAtPercent
-  }
-
-  private async performNativeContextCompaction(
-    session: ActiveSession,
-    appSessionId: string,
-    reason: NonNullable<AcpRuntimeEvent['compactionReason']>
-  ): Promise<PromptResponse> {
-    const strategy = this.framework.contextCompaction
-    if (strategy.kind !== 'native-command') {
-      throw new Error(`${this.framework.displayName} manages context compaction automatically.`)
-    }
-    const contextUsageCheckpoint = this.contextUsageTracker.checkpointSession(appSessionId)
-    const restoreContextEstimate = (): void => {
-      this.contextUsageTracker.restoreSession(appSessionId, contextUsageCheckpoint)
-    }
-
-    this.pushEvent({
-      kind: 'compaction',
-      compactionReason: reason,
-      level: 'info',
-      sessionId: appSessionId,
-      status: 'in_progress',
-      title: 'Compacting context'
-    })
-
-    try {
-      let failureText: string | undefined
-      const promptFailure = new Promise<never>((_, reject) => {
-        session.prompt([{ type: 'text', text: strategy.command }]).catch(reject)
-      })
-
-      for (;;) {
-        const message = await Promise.race([session.nextUpdate(), promptFailure])
-        if (message.kind === 'stop') {
-          if (message.response.stopReason === 'cancelled') {
-            restoreContextEstimate()
-            this.pushEvent({
-              kind: 'compaction',
-              compactionReason: reason,
-              level: 'info',
-              sessionId: appSessionId,
-              status: 'cancelled',
-              title: 'Context compaction cancelled'
-            })
-            return message.response
-          }
-          if (message.response.stopReason !== 'end_turn') {
-            throw new Error(
-              `Context compaction stopped before completion: ${message.response.stopReason}`
-            )
-          }
-          if (failureText) throw new Error(failureText)
-
-          // Some adapters do not emit usage_update for their compaction control turn. Invalidate only
-          // the unchanged pre-compaction reading; a fresh update received during the turn is a new
-          // object and remains available to the context meter and auto-compaction threshold.
-          this.contextUsageTracker.resetAfterCompaction(
-            appSessionId,
-            this.contextUsageEstimateInput(appSessionId),
-            contextUsageCheckpoint,
-            this.selectedContextWindowFor(appSessionId)
-          )
-          this.promptContentOwner.resetSession(appSessionId)
-          this.pushEvent({
-            kind: 'compaction',
-            compactionReason: reason,
-            level: 'info',
-            sessionId: appSessionId,
-            status: 'completed',
-            title: 'Context compacted'
-          })
-          return message.response
-        }
-
-        const update = message.notification.update
-        if (
-          !failureText &&
-          strategy.failureTextPrefix &&
-          update.sessionUpdate === 'agent_message_chunk' &&
-          update.content.type === 'text' &&
-          update.content.text.trimStart().startsWith(strategy.failureTextPrefix)
-        ) {
-          failureText = update.content.text.trim()
-        }
-        this.handleSessionUpdate(message.notification, appSessionId, false)
-      }
-    } catch (error) {
-      restoreContextEstimate()
-      this.pushEvent({
-        kind: 'compaction',
-        compactionReason: reason,
-        level: 'error',
-        sessionId: appSessionId,
-        status: 'failed',
-        title: 'Context compaction failed',
-        text: errorMessage(error)
-      })
-      throw error
-    }
+    return this.withOperationLease(() => this.contextCompactionWorkflow.compact(request))
   }
 
   // Changes approval behavior only while the conversation is idle. Applying the ACP mode before the
@@ -2651,7 +2518,8 @@ class AcpRuntime {
   private handleSessionUpdate(
     notification: SessionNotification,
     appSessionId?: string,
-    visible = true
+    visible = true,
+    emitState: () => void = () => this.emitState()
   ): void {
     const sessionId = appSessionId ?? notification.sessionId
     this.applySessionUpdateEffects(
@@ -2665,11 +2533,15 @@ class AcpRuntime {
         visible,
         reconnectPending: this.pendingProviderReconnect,
         mcpServerNames: this.sessionCapabilities.mcpServerNamesFor(sessionId)
-      })
+      }),
+      emitState
     )
   }
 
-  private applySessionUpdateEffects(effects: readonly AcpSessionUpdateEffect[]): void {
+  private applySessionUpdateEffects(
+    effects: readonly AcpSessionUpdateEffect[],
+    emitState: () => void = () => this.emitState()
+  ): void {
     for (const effect of effects) {
       switch (effect.kind) {
         case 'permission-tool-correlation':
@@ -2693,7 +2565,7 @@ class AcpRuntime {
                 effect.currentModeId
               )
             )
-            this.emitState()
+            emitState()
           }
           break
         }
@@ -2703,7 +2575,7 @@ class AcpRuntime {
             effect.usage,
             this.selectedContextWindowFor(effect.sessionId)
           )
-          this.emitState()
+          emitState()
           break
         case 'context-refresh':
           if (


### PR DESCRIPTION
## Problem

`AcpRuntime` still sequenced every native context-compaction control turn: manual admission, overflow ownership transfer, automatic threshold checks, provider command draining, ContextUsage rollback/reset, media-budget reset, hidden notification routing, and lifecycle events. This kept turn-level ordering in the coordinator after prompt execution/finalization had moved into dedicated workflows.

## Proposed change

Add a stateless `AcpContextCompactionWorkflow` and delegate all manual, overflow-recovery, and automatic native compaction sequencing to it.

```mermaid
sequenceDiagram
    participant Caller
    participant Runtime as AcpRuntime
    participant Workflow as ContextCompactionWorkflow
    participant Interaction as Interaction Owner
    participant Context as ContextUsageTracker
    participant Provider as ActiveSession
    participant Content as PromptContentOwner

    Caller->>Runtime: compactSession(request)
    Runtime->>Workflow: compact(request) under operation lease
    Workflow->>Interaction: validate / supersede overflow / claim
    Workflow->>Context: checkpointSession
    Workflow->>Provider: prompt(exact native command)
    loop hidden control updates
        Provider-->>Workflow: nextUpdate
        Workflow->>Runtime: routeHiddenNotification
    end
    alt success
        Workflow->>Context: resetAfterCompaction
        Workflow->>Content: resetSession
    else cancelled or failed
        Workflow->>Context: restoreSession(checkpoint)
    end
    Workflow->>Interaction: release exact scope
```

Automatic compaction retains the existing prompt interaction and checks the exact interaction, provider Session, reconciled usage, and framework threshold before entering the same native control-turn core. It does not claim a second interaction.

## Scope and non-goals

- This is ARD-27, based on `origin/main@9b30faa` after #788.
- Production raw diff is 408 lines, below the mandatory 500-line split threshold.
- Runtime drops 128 net lines and is now 2,804 lines.
- `AcpSessionInteractionOwner`, `ContextUsageTracker`, and `AcpPromptContentOwner` remain the only state writers.
- Runtime retains the public operation lease, Session/framework lookup, update projection, events, and composition adapters.
- `resetSessionContext` remains the separate fresh-Session fallback for native media compaction failure.
- No public API, IPC contract, persistence schema, data model, or user interaction changes.
- Electron, Web, CLI, and Task behavior remain unchanged; Specialist, Permission, and Compute asymmetries remain unchanged.
- Issue #458 remains a forward-compatibility constraint only; no orchestration state or interface is introduced.

Context: #458

## Acceptance criteria and validation

All checks below ran after the final material edit.

| Behavior / risk | Final check | Result |
| --- | --- | --- |
| Workflow admission, exact command, hidden updates, cancel/failure rollback, overflow transfer, automatic gates, projection callback isolation | `context-compaction-workflow.test.ts` plus owner tests | 75/75 passed |
| Runtime manual/automatic/overflow integration, lock transfer, media budget, usage reset, Plan command, preflight gating, hidden usage listener failure | targeted `src/main/acp/runtime.test.ts` Test Impact Set | 11/11 passed; 429 unrelated tests skipped |
| Prompt finalizer automatic-compaction consumer | `prompt-turn-workflow.test.ts` + `prompt-outcome-finalizer.test.ts` | 19/19 passed |
| Coordinator routing and stale owner event filtering | targeted `runtime-coordinator.test.ts` | 3/3 passed; 49 unrelated tests skipped |
| Node process type contracts | `npm run typecheck:node` | passed |
| Repository lint policy | `npm run lint` | passed with 0 errors; 17 pre-existing warnings outside this diff |
| Formatting and whitespace | targeted Prettier check plus staged `git diff --check` | passed |

Independent final reviews after two cleanup fixes:

- Standards: 0 remaining actionable findings.
- Spec: 0 remaining actionable findings.

The review found and this PR fixes two callback-isolation defects inherited from the prior Runtime sequence: a throwing state listener can no longer leak a claimed compaction interaction, and terminal/hidden-usage projection listener failures can no longer roll back committed owner state or turn successful provider compaction into a failed lifecycle.

Consumer/platform rationale: public Runtime/Coordinator/application-command/IPC contracts are unchanged, so Web typecheck and UI/E2E were excluded locally. Authoritative PR Gate supplies selected full/platform coverage.

Uncovered local risk: provider process/platform permutations outside the focused Node set rely on PR Gate.

## Review focus

- Verify manual rejects overlap while overflow recovery supersedes the old prompt before claiming the compaction scope.
- Verify automatic compaction neither claims nor releases a second interaction and preserves operation-lease/deferred-reconnect ordering.
- Verify success resets ContextUsage before media budget and cancel/failure restores the exact checkpoint.
- Verify hidden notifications preserve owner/projector effects without projecting control output, and listener exceptions cannot change the compaction result.
