### PR TITLE
refactor(session-plan): own live plan interactions

### DIFF
--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -362,6 +362,7 @@ describe('runtime state ownership architecture', () => {
     ['../acp/runtime', 'AcpRuntime'],
     ['../acp/runtime-coordinator.js', 'AcpRuntimeCoordinator'],
     ['../acp/reviewer-session-owner', 'ReviewerSessionOwner'],
+    ['../session-plan/session-plan-interaction-owner', 'SessionPlanInteractionOwner'],
     ['../settings/service', 'SettingsService'],
     ['../settings/backend-resolver', 'AgentBackendResolver'],
     ['../settings/ipc', 'registerSettingsIpcHandlers'],

--- a/src/main/session-plan/plan-service.test.ts
+++ b/src/main/session-plan/plan-service.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { SessionRuntimeContext } from '../../shared/session-persistence'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
 import { PlanService, type PlanServiceDependencies } from './plan-service'
+import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
 
 const content = {
   task_summary: 'Analyze one dataset',
@@ -62,6 +63,7 @@ const executionContent = {
 
 type PlanServiceHarness = Readonly<{
   service: PlanService
+  interactions: SessionPlanInteractionOwner
   dependencies: PlanServiceDependencies
   context: () => SessionRuntimeContext
   status: () => string
@@ -72,7 +74,9 @@ const setup = (): PlanServiceHarness => {
   let context: SessionRuntimeContext = { version: 1, revision: 0 }
   let persistedStatus = 'running'
   let bytes = ''
+  const interactions = new SessionPlanInteractionOwner()
   const dependencies: PlanServiceDependencies = {
+    interactions,
     writeArtifactForActiveTurn: vi.fn(async (_sessionId, input) => {
       bytes = input.content
       return {
@@ -113,6 +117,7 @@ const setup = (): PlanServiceHarness => {
   }
   return {
     service: new PlanService(dependencies),
+    interactions,
     dependencies,
     context: () => context,
     status: () => persistedStatus,
@@ -252,6 +257,31 @@ describe('PlanService', () => {
       })
     ).rejects.toMatchObject({ code: 'approval-already-decided' })
   })
+
+  it.each(['approved', 'rejected'] as const)(
+    'releases the live interaction after a %s decision',
+    async (decision) => {
+      const { service, interactions } = setup()
+      const generated = await service.generate({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        interactionId: 'interaction-1',
+        content
+      })
+
+      await service.respond({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        artifactVersionId: generated.projection.artifactVersionId,
+        expectedRevision: generated.projection.revision,
+        decision
+      })
+
+      expect(
+        interactions.interactionIdFor('session-1', generated.projection.artifactVersionId)
+      ).toBeUndefined()
+    }
+  )
 
   it('counts a deliberately skipped step as done in completed Plan progress', async () => {
     const { service } = setup()
@@ -499,13 +529,16 @@ describe('PlanService', () => {
   })
 
   it('persists revision feedback as a standard user Message for the live blocked interaction', async () => {
-    const { service, dependencies } = setup()
-    await service.generate({
+    const { service, dependencies, interactions } = setup()
+    const generated = await service.generate({
       projectId: 'project-1',
       sessionId: 'session-1',
       interactionId: 'interaction-1',
       content
     })
+    expect(interactions.interactionIdFor('session-1', generated.projection.artifactVersionId)).toBe(
+      'interaction-1'
+    )
 
     const response = await service.respond({
       projectId: 'project-1',
@@ -525,6 +558,31 @@ describe('PlanService', () => {
       content: 'Split the analysis by cohort.',
       interactionId: 'interaction-1'
     })
+    expect(
+      interactions.interactionIdFor('session-1', generated.projection.artifactVersionId)
+    ).toBeUndefined()
+  })
+
+  it('retains the live interaction when revision feedback persistence fails', async () => {
+    const { service, dependencies, interactions } = setup()
+    const generated = await service.generate({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      interactionId: 'interaction-1',
+      content
+    })
+    vi.mocked(dependencies.persistUserMessage).mockRejectedValueOnce(new Error('disk unavailable'))
+
+    await expect(
+      service.respond({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        feedback: 'Split the analysis by cohort.'
+      })
+    ).rejects.toThrow('disk unavailable')
+    expect(interactions.interactionIdFor('session-1', generated.projection.artifactVersionId)).toBe(
+      'interaction-1'
+    )
   })
 
   it('projects retained in-progress work as interrupted after the interaction ends', async () => {
@@ -660,7 +718,10 @@ describe('PlanService', () => {
       expectedRevision: generated.projection.revision,
       decision: 'approved'
     })
-    const reconstructed = new PlanService(dependencies)
+    const reconstructed = new PlanService({
+      ...dependencies,
+      interactions: new SessionPlanInteractionOwner()
+    })
     await expect(
       reconstructed.updateStepStatus({
         projectId: 'project-1',
@@ -991,7 +1052,10 @@ describe('PlanService', () => {
       status: 'in_progress'
     })
 
-    const restarted = new PlanService(dependencies)
+    const restarted = new PlanService({
+      ...dependencies,
+      interactions: new SessionPlanInteractionOwner()
+    })
     await expect(restarted.getProjection('project-1', 'session-1')).resolves.toMatchObject({
       lifecycle: 'interrupted',
       requiresExplicitContinuation: true,

--- a/src/main/session-plan/plan-service.ts
+++ b/src/main/session-plan/plan-service.ts
@@ -19,6 +19,7 @@ import {
   type PlanDocumentV1,
   type PlanResponseCommand
 } from '../../shared/session-plan/contract'
+import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
 
 type ArtifactWriteResult = Readonly<{
   artifactId?: string
@@ -27,7 +28,13 @@ type ArtifactWriteResult = Readonly<{
   name: string
 }>
 
+type SessionPlanIdentityOwner = Pick<
+  SessionPlanInteractionOwner,
+  'register' | 'interactionIdFor' | 'release'
+>
+
 type PlanServiceDependencies = Readonly<{
+  interactions: SessionPlanIdentityOwner
   writeArtifactForActiveTurn: (
     sessionId: string,
     input: { filename: string; content: string; mimeType: string; kind: 'plan' }
@@ -96,10 +103,6 @@ const parseDocument = (content: string): PlanDocumentV1 => {
 class PlanService {
   private readonly now: () => number
   private readonly createId: () => string
-  private readonly livePlanInteractions = new Map<
-    string,
-    { artifactVersionId: string; interactionId: string }
-  >()
   constructor(private readonly dependencies: PlanServiceDependencies) {
     this.now = dependencies.now ?? Date.now
     this.createId = dependencies.createId ?? (() => randomUUID().slice(0, 8))
@@ -162,7 +165,8 @@ class PlanService {
       }
       throw error
     }
-    this.livePlanInteractions.set(input.sessionId, {
+    this.dependencies.interactions.register({
+      sessionId: input.sessionId,
       artifactVersionId: plan.artifactVersionId,
       interactionId: input.interactionId
     })
@@ -191,8 +195,11 @@ class PlanService {
       }
       const text = input.feedback.trim()
       if (!text) throw new PlanCommandError('invalid-plan', 'Plan feedback must be non-empty.')
-      const live = this.livePlanInteractions.get(input.sessionId)
-      if (!live || live.artifactVersionId !== plan.artifactVersionId) {
+      const interactionId = this.dependencies.interactions.interactionIdFor(
+        input.sessionId,
+        plan.artifactVersionId
+      )
+      if (!interactionId) {
         throw new PlanCommandError(
           'stale-plan',
           'The Plan interaction is no longer available for revision feedback.'
@@ -202,12 +209,12 @@ class PlanService {
         projectId: input.projectId,
         sessionId: input.sessionId,
         content: text,
-        interactionId: live.interactionId
+        interactionId
       })
-      this.livePlanInteractions.delete(input.sessionId)
+      this.dependencies.interactions.release(input.sessionId, plan.artifactVersionId)
       return {
         kind: 'feedback',
-        routeToInteractionId: live.interactionId,
+        routeToInteractionId: interactionId,
         artifactVersionId: plan.artifactVersionId,
         text,
         message
@@ -215,7 +222,7 @@ class PlanService {
     }
     const { context, plan, document } = await this.loadActive(input, input.decision)
     if (plan.approval === input.decision) {
-      this.livePlanInteractions.delete(input.sessionId)
+      this.dependencies.interactions.release(input.sessionId, plan.artifactVersionId)
       return {
         projection: this.project(document, plan, context.revision, input.interactionIsLive),
         changed: false
@@ -226,7 +233,7 @@ class PlanService {
     }
     const updated = { ...plan, approval: input.decision }
     const next = await this.patch(input, updated, input.interactionIsLive ? 'running' : 'idle')
-    this.livePlanInteractions.delete(input.sessionId)
+    this.dependencies.interactions.release(input.sessionId, plan.artifactVersionId)
     return {
       projection: this.project(document, updated, next.revision, input.interactionIsLive),
       changed: true

--- a/src/main/session-plan/production-plan-service.ts
+++ b/src/main/session-plan/production-plan-service.ts
@@ -5,8 +5,10 @@ import type { ArtifactProvenanceRepository } from '../artifacts/provenance-repos
 import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
 import { SessionRuntimeContextRevisionConflictError } from '../session-persistence/coordinator'
 import { PlanService } from './plan-service'
+import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
 
 type ProductionPlanServiceDependencies = Readonly<{
+  interactions?: SessionPlanInteractionOwner
   artifactTurns: Pick<ArtifactTurnOwner, 'writeForActiveTurn'>
   provenance: Pick<ArtifactProvenanceRepository, 'resolveVersionContent'>
   sessions: Pick<
@@ -16,11 +18,13 @@ type ProductionPlanServiceDependencies = Readonly<{
 }>
 
 const createProductionPlanService = ({
+  interactions = new SessionPlanInteractionOwner(),
   artifactTurns,
   provenance,
   sessions
 }: ProductionPlanServiceDependencies): PlanService =>
   new PlanService({
+    interactions,
     writeArtifactForActiveTurn: (sessionId, input) =>
       artifactTurns.writeForActiveTurn(sessionId, input),
     readArtifactVersion: async ({ projectId, sessionId, artifactId, artifactVersionId }) => {

--- a/src/main/session-plan/session-plan-interaction-owner.test.ts
+++ b/src/main/session-plan/session-plan-interaction-owner.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+
+import { SessionPlanInteractionOwner } from './session-plan-interaction-owner'
+
+describe('SessionPlanInteractionOwner', () => {
+  it('resolves only the current Artifact Version interaction', () => {
+    const owner = new SessionPlanInteractionOwner()
+
+    owner.register({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionId: 'interaction-1'
+    })
+
+    expect(owner.interactionIdFor('session-1', 'version-1')).toBe('interaction-1')
+    expect(owner.interactionIdFor('session-1', 'stale-version')).toBeUndefined()
+  })
+
+  it('does not release a replacement interaction through a stale Artifact Version', () => {
+    const owner = new SessionPlanInteractionOwner()
+    owner.register({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionId: 'interaction-1'
+    })
+    owner.register({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-2',
+      interactionId: 'interaction-2'
+    })
+
+    owner.release('session-1', 'version-1')
+
+    expect(owner.interactionIdFor('session-1', 'version-2')).toBe('interaction-2')
+    expect(owner.release('session-1', 'version-2')).toBe(true)
+    expect(owner.interactionIdFor('session-1', 'version-2')).toBeUndefined()
+  })
+
+  it('settles a parked approval exactly once', async () => {
+    const owner = new SessionPlanInteractionOwner()
+    const approval = owner.parkApproval('session-1', 'interaction-1')
+
+    expect(owner.approvalInteractionIdFor('session-1')).toBe('interaction-1')
+    expect(() => owner.parkApproval('session-1', 'interaction-2')).toThrow(
+      'A Session Plan is already awaiting approval.'
+    )
+    expect(owner.resolveApproval('session-1', { decision: 'approved' })).toBe(true)
+    expect(owner.resolveApproval('session-1', { decision: 'rejected' })).toBe(false)
+    await expect(approval).resolves.toEqual({ decision: 'approved' })
+  })
+
+  it('rejects a parked approval exactly once', async () => {
+    const owner = new SessionPlanInteractionOwner()
+    const approval = owner.parkApproval('session-1', 'interaction-1')
+    const rejected = approval.catch((error) => error)
+
+    expect(owner.rejectApproval('session-1', 'approval cancelled')).toBe(true)
+    expect(owner.rejectApproval('session-1', 'duplicate cleanup')).toBe(false)
+    await expect(rejected).resolves.toMatchObject({ message: 'approval cancelled' })
+  })
+
+  it('clears every live row and rejects a parked approval for a Session', async () => {
+    const owner = new SessionPlanInteractionOwner()
+    owner.register({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionId: 'interaction-1'
+    })
+    owner.bindExecution({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionSequence: 7
+    })
+    owner.bindExecution({
+      sessionId: 'session-2',
+      artifactVersionId: 'version-2',
+      interactionSequence: 8
+    })
+    const approval = owner.parkApproval('session-1', 'interaction-1')
+    const rejected = expect(approval).rejects.toThrow('interaction was deleted')
+
+    owner.clearSession('session-1', 'The Session Plan interaction was deleted.')
+
+    await rejected
+    expect(owner.interactionIdFor('session-1', 'version-1')).toBeUndefined()
+    expect(owner.executionBindingFor('session-1')).toBeUndefined()
+    expect(owner.rejectApproval('session-1', 'duplicate cleanup')).toBe(false)
+    expect(owner.executionBindingFor('session-2')).toEqual({
+      artifactVersionId: 'version-2',
+      interactionSequence: 8
+    })
+  })
+
+  it('does not release a successor execution through a stale interaction sequence', () => {
+    const owner = new SessionPlanInteractionOwner()
+    owner.bindExecution({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-2',
+      interactionSequence: 8
+    })
+
+    expect(owner.releaseExecution('session-1', 7)).toBe(false)
+    expect(owner.executionBindingFor('session-1')).toEqual({
+      artifactVersionId: 'version-2',
+      interactionSequence: 8
+    })
+    expect(owner.releaseExecution('session-1', 8)).toBe(true)
+    expect(owner.executionBindingFor('session-1')).toBeUndefined()
+  })
+
+  it('clears every Session when a generation disconnects', async () => {
+    const owner = new SessionPlanInteractionOwner()
+    owner.register({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionId: 'interaction-1'
+    })
+    owner.bindExecution({
+      sessionId: 'session-2',
+      artifactVersionId: 'version-2',
+      interactionSequence: 2
+    })
+    const first = owner.parkApproval('session-1', 'interaction-1').catch((error) => error)
+    const second = owner.parkApproval('session-2', 'interaction-2').catch((error) => error)
+
+    owner.clearAll('The Session Plan interaction was disconnected.')
+
+    await expect(first).resolves.toMatchObject({
+      message: 'The Session Plan interaction was disconnected.'
+    })
+    await expect(second).resolves.toMatchObject({
+      message: 'The Session Plan interaction was disconnected.'
+    })
+    expect(owner.interactionIdFor('session-1', 'version-1')).toBeUndefined()
+    expect(owner.executionBindingFor('session-2')).toBeUndefined()
+  })
+})

--- a/src/main/session-plan/session-plan-interaction-owner.ts
+++ b/src/main/session-plan/session-plan-interaction-owner.ts
@@ -1,0 +1,124 @@
+type SessionPlanInteractionIdentity = Readonly<{
+  artifactVersionId: string
+  interactionId: string
+}>
+
+type SessionPlanApprovalParking = Readonly<{
+  interactionId: string
+  resolve: (result: unknown) => void
+  reject: (error: Error) => void
+}>
+
+type SessionPlanExecutionBinding = Readonly<{
+  artifactVersionId: string
+  interactionSequence: number
+}>
+
+type SessionPlanInteractionRow = {
+  identity?: SessionPlanInteractionIdentity
+  approval?: SessionPlanApprovalParking
+  execution?: SessionPlanExecutionBinding
+}
+
+class SessionPlanInteractionOwner {
+  private readonly rows = new Map<string, SessionPlanInteractionRow>()
+
+  register({
+    sessionId,
+    artifactVersionId,
+    interactionId
+  }: SessionPlanInteractionIdentity & Readonly<{ sessionId: string }>): void {
+    const row = this.rows.get(sessionId) ?? {}
+    row.identity = { artifactVersionId, interactionId }
+    this.rows.set(sessionId, row)
+  }
+
+  interactionIdFor(sessionId: string, artifactVersionId: string): string | undefined {
+    const identity = this.rows.get(sessionId)?.identity
+    return identity?.artifactVersionId === artifactVersionId ? identity.interactionId : undefined
+  }
+
+  release(sessionId: string, artifactVersionId: string): boolean {
+    const row = this.rows.get(sessionId)
+    if (row?.identity?.artifactVersionId !== artifactVersionId) return false
+    delete row.identity
+    this.prune(sessionId, row)
+    return true
+  }
+
+  parkApproval(sessionId: string, interactionId: string): Promise<unknown> {
+    const row = this.rows.get(sessionId) ?? {}
+    if (row.approval) throw new Error('A Session Plan is already awaiting approval.')
+    this.rows.set(sessionId, row)
+    return new Promise((resolve, reject) => {
+      row.approval = { interactionId, resolve, reject }
+    })
+  }
+
+  approvalInteractionIdFor(sessionId: string): string | undefined {
+    return this.rows.get(sessionId)?.approval?.interactionId
+  }
+
+  resolveApproval(sessionId: string, result: unknown): boolean {
+    const row = this.rows.get(sessionId)
+    const approval = row?.approval
+    if (!row || !approval) return false
+    delete row.approval
+    this.prune(sessionId, row)
+    approval.resolve(result)
+    return true
+  }
+
+  rejectApproval(sessionId: string, reason: string): boolean {
+    const row = this.rows.get(sessionId)
+    const approval = row?.approval
+    if (!row || !approval) return false
+    delete row.approval
+    this.prune(sessionId, row)
+    approval.reject(new Error(reason))
+    return true
+  }
+
+  bindExecution({
+    sessionId,
+    artifactVersionId,
+    interactionSequence
+  }: SessionPlanExecutionBinding & Readonly<{ sessionId: string }>): void {
+    const row = this.rows.get(sessionId) ?? {}
+    row.execution = { artifactVersionId, interactionSequence }
+    this.rows.set(sessionId, row)
+  }
+
+  executionBindingFor(sessionId: string): SessionPlanExecutionBinding | undefined {
+    const execution = this.rows.get(sessionId)?.execution
+    return execution ? { ...execution } : undefined
+  }
+
+  releaseExecution(sessionId: string, interactionSequence: number): boolean {
+    const row = this.rows.get(sessionId)
+    if (row?.execution?.interactionSequence !== interactionSequence) return false
+    delete row.execution
+    this.prune(sessionId, row)
+    return true
+  }
+
+  clearSession(sessionId: string, approvalReason: string): void {
+    const row = this.rows.get(sessionId)
+    if (!row) return
+    this.rows.delete(sessionId)
+    row.approval?.reject(new Error(approvalReason))
+  }
+
+  clearAll(approvalReason: string): void {
+    const approvals = [...this.rows.values()].flatMap((row) => (row.approval ? [row.approval] : []))
+    this.rows.clear()
+    for (const approval of approvals) approval.reject(new Error(approvalReason))
+  }
+
+  private prune(sessionId: string, row: SessionPlanInteractionRow): void {
+    if (!row.identity && !row.approval && !row.execution) this.rows.delete(sessionId)
+  }
+}
+
+export { SessionPlanInteractionOwner }
+export type { SessionPlanExecutionBinding }


### PR DESCRIPTION
## Problem

Live Session Plan state is split across the Plan service and ACP runtime concerns. The identity of the active Artifact Version, approval parking, and execution binding therefore have no single lifecycle owner, which makes the upcoming runtime facade cutover prone to mirrored Maps and partial cleanup.

## Proposed change

- add `SessionPlanInteractionOwner` as the canonical in-memory owner for live Plan identity, approval parking, and execution binding;
- make identity and execution release compare the current Artifact Version or interaction sequence so stale cleanup cannot remove a successor;
- centralize per-Session and generation-wide cleanup, including exactly-once approval rejection;
- delegate `PlanService` live identity reads and writes through a narrow owner capability;
- allow production composition to inject one owner instance for the next runtime cutover;
- protect the boundary with ownership architecture coverage.

```mermaid
flowchart LR
  PS["PlanService"] -->|"identity capability"| O["SessionPlanInteractionOwner"]
  R["ACP runtime — next PR"] -.->|"approval and execution capability"| O
  O --> I["Artifact Version ↔ interaction identity"]
  O --> A["parked approval"]
  O --> E["execution binding"]
  C["Session/generation cleanup"] --> O
```

## Scope and non-goals

- Production raw churn: 159 lines against the approved 600-line Phase 6 cap.
- No persisted data model, wire contract, IPC shape, or user interaction changes.
- No Electron, Web, or CLI capability changes.
- No Specialist, Permission, or Compute behavior changes.
- This PR establishes the owner seam only; ACP runtime call-site cutover remains ARD-28B.

## Acceptance criteria and validation

The evidence below was collected after the last material edit:

- current Artifact Version identity, stale-release safety, exact-once approval settlement, execution-sequence safety, and cleanup isolation → `npm test -- src/main/session-plan/session-plan-interaction-owner.test.ts` → passed;
- Plan generation, feedback routing/retry, decision cleanup, and restart semantics → `npm test -- src/main/session-plan/plan-service.test.ts` → passed;
- Plan MCP adapter compatibility → `npm test -- src/main/session-plan/plan-mcp-server.test.ts` → passed;
- ownership boundary → `npm test -- src/main/runtime-state-ownership.architecture.test.ts` → passed;
- affected main-process types → `npm run typecheck:node` → passed;
- repository lint → `npm run lint` → passed with 0 errors and 17 pre-existing warnings;
- portable regression suite → `npm test` → 783 files passed, 14 skipped; 11,623 tests passed, 184 skipped.

Consumer/platform impact: the changed seam is main-process-only and preserves the existing Plan service and MCP behavior. There are no renderer, preload, platform-process, persistence-schema, or migration changes, so no Web typecheck, E2E, or migration lane is required locally. CI remains authoritative for selected platform lanes.

Uncovered risk: runtime approval and execution call sites do not consume the owner until ARD-28B; this PR tests those owner capabilities directly so the later cutover can stay mechanical.

## Review focus

- Does one row per Session correctly express the three live-state roles without allowing stale cleanup to remove replacement state?
- Are approval rejection and generation cleanup exactly-once and leak-free?
- Does the narrow `PlanService` capability avoid coupling business logic to later runtime orchestration?
- Are any existing persistence, IPC, or cross-surface semantics changed unintentionally?
