### PR TITLE
refactor(session-plan): cut runtime over to plan owner

### DIFF
--- a/src/main/acp/connection-close-workflow.test.ts
+++ b/src/main/acp/connection-close-workflow.test.ts
@@ -21,6 +21,7 @@ const createWorkflow = (overrides: Record<string, unknown> = {}): TestHarness =>
     invalidatePendingSessionStartups: vi.fn(() => actions.push('invalidate')),
     disposePermissionContext: vi.fn(() => actions.push('permission')),
     clearReviewerState: vi.fn(() => actions.push('reviewer')),
+    clearPlanInteractions: vi.fn(() => actions.push('plan')),
     settleActivePrompts: vi.fn(() => ['prompt'] as unknown[]),
     supersedeInteractions: vi.fn(() => actions.push('interactions')),
     clearContextUsage: vi.fn(() => actions.push('usage')),
@@ -113,6 +114,7 @@ describe('AcpConnectionCloseWorkflow', () => {
       'invalidate',
       'permission',
       'reviewer',
+      'plan',
       'interactions',
       'usage',
       'models',
@@ -143,6 +145,7 @@ describe('AcpConnectionCloseWorkflow', () => {
       'invalidate',
       'permission',
       'reviewer',
+      'plan',
       'backend:2',
       'capabilities',
       'detach',
@@ -168,7 +171,16 @@ describe('AcpConnectionCloseWorkflow', () => {
     await expect(workflow.shutdownForQuit()).resolves.toEqual({ reaped: false })
 
     expect(resources.beginAwaitableShutdown).toHaveBeenCalledWith(true)
+    expect(state.clearPlanInteractions).toHaveBeenCalledOnce()
     expect(state.clearSessionProjection).toHaveBeenCalledOnce()
+  })
+
+  it('clears Plan interactions during synchronous shutdown', () => {
+    const { workflow, state } = createWorkflow()
+
+    workflow.shutdown()
+
+    expect(state.clearPlanInteractions).toHaveBeenCalledOnce()
   })
 
   it('clears usage before deferring provider reconnect and delegates intent ownership', async () => {

--- a/src/main/acp/connection-close-workflow.ts
+++ b/src/main/acp/connection-close-workflow.ts
@@ -11,6 +11,7 @@ type CloseState = Readonly<{
   invalidatePendingSessionStartups: () => void
   disposePermissionContext: () => void
   clearReviewerState: () => void
+  clearPlanInteractions: () => void
   settleActivePrompts: () => readonly unknown[]
   supersedeInteractions: () => void
   clearContextUsage: () => void
@@ -102,6 +103,7 @@ class AcpConnectionCloseWorkflow {
     }
     runCleanup('permission-context', this.options.state.disposePermissionContext)
     runCleanup('reviewer-state', this.options.state.clearReviewerState)
+    runCleanup('plan-interactions', this.options.state.clearPlanInteractions)
     this.options.state.supersedeInteractions()
     this.options.state.clearContextUsage()
     this.options.state.clearAppliedSessionModels()
@@ -134,6 +136,7 @@ class AcpConnectionCloseWorkflow {
     this.options.state.invalidatePendingSessionStartups()
     this.options.state.disposePermissionContext()
     this.options.state.clearReviewerState()
+    this.options.state.clearPlanInteractions()
     this.options.resources.cleanupUnexpectedClose(teardownGeneration)
     this.options.backendGeneration.supersede(teardownGeneration)
     this.options.state.disposeSessionCapabilities(this.options.state.activeSessionIds())
@@ -161,6 +164,7 @@ class AcpConnectionCloseWorkflow {
       this.options.backendGeneration.supersede(this.options.currentGeneration() - 1)
     })
     this.options.transitions.resetReconnect()
+    this.options.state.clearPlanInteractions()
     this.options.state.clearSessionProjection()
     this.options.state.clearContextUsage()
     this.options.state.clearAppliedSessionModels()

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
+import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { AcpRuntime } from './runtime'
 
 const projection = (
@@ -46,6 +47,8 @@ type PlanServiceMock = Record<
 type RuntimeHarness = Readonly<{
   runtime: AcpRuntime
   service: PlanServiceMock
+  interactions: SessionPlanInteractionOwner
+  setCurrentInteraction: (interaction: { sequence: number; promptMessageId: string }) => void
   updateStepStatus: ReturnType<typeof vi.fn>
 }>
 
@@ -53,10 +56,12 @@ const createRuntimeHarness = (options: {
   onEvent?: (event?: unknown) => void
   activeProjection?: ActivePlanProjection
   durableMessageIds?: string[]
+  cancelNotify?: () => Promise<void>
 }): RuntimeHarness => {
   const generated = projection('version-1')
   const approved = { ...generated, approval: 'approved' as const, lifecycle: 'approved' as const }
   const updateStepStatus = vi.fn(async () => ({ projection: approved, changed: true }))
+  const interactions = new SessionPlanInteractionOwner()
   const service = {
     generate: vi.fn(async () => ({ projection: generated, pauseInteraction: true as const })),
     respond: vi.fn(async (input: { feedback?: string; decision?: 'approved' | 'rejected' }) =>
@@ -100,15 +105,33 @@ const createRuntimeHarness = (options: {
     updateStepStatus,
     checkTurnCompletion: vi.fn(async () => ({ allow: true }))
   }
+  let currentInteraction = {
+    kind: 'prompt' as const,
+    sessionId: 'session-1',
+    sequence: 7,
+    promptMessageId: 'interaction-1'
+  }
+  const sessionInteractions = {
+    snapshot: () => [{ kind: 'prompt', sessionId: 'session-1' }],
+    current: () => currentInteraction,
+    cancelPrompt: vi.fn(
+      async ({ notify, onAccepted }: { notify: () => Promise<void>; onAccepted: () => void }) => {
+        await notify()
+        onAccepted()
+      }
+    )
+  }
   const target = Object.create(AcpRuntime.prototype) as Record<string, unknown>
   Object.assign(target, {
     planService: service,
-    sessionInteractions: {
-      snapshot: () => [{ kind: 'prompt', sessionId: 'session-1' }],
-      current: () => ({ kind: 'prompt', sessionId: 'session-1', sequence: 7 })
+    planInteractions: interactions,
+    sessionInteractions,
+    connectionResources: {
+      connection: { agent: { notify: vi.fn(options.cancelNotify ?? (async () => undefined)) } }
     },
-    planExecutionBindings: new Map(),
-    planApprovalWaiters: new Map(),
+    sessionRegistry: {
+      lookup: () => ({ attachment: { session: { sessionId: 'provider-session-1' } } })
+    },
     planSessions: {
       containsMessageOnActiveBranch: vi.fn(
         async (_projectId: string, _sessionId: string, messageId: string) =>
@@ -118,11 +141,24 @@ const createRuntimeHarness = (options: {
     artifactTurns: {
       promptMessageIdFor: () => 'interaction-1'
     },
+    sessionDeletion: {
+      delete: vi.fn(async () => ({ status: 'closed' }))
+    },
+    permissionContext: { cancelForSession: vi.fn() },
     callbacks: { onEvent: options.onEvent },
     pushEvent: (event: unknown) => options.onEvent?.(event),
+    getSnapshot: () => ({ status: 'connected' }),
     resolveSessionProjectName: () => 'project-1'
   })
-  return { runtime: target as unknown as AcpRuntime, service, updateStepStatus }
+  return {
+    runtime: target as unknown as AcpRuntime,
+    service,
+    interactions,
+    setCurrentInteraction: ({ sequence, promptMessageId }) => {
+      currentInteraction = { ...currentInteraction, sequence, promptMessageId }
+    },
+    updateStepStatus
+  }
 }
 
 describe('AcpRuntime Session Plan seam', () => {
@@ -159,22 +195,210 @@ describe('AcpRuntime Session Plan seam', () => {
     )
   })
 
+  it('rejects duplicate generation before writing a replacement Plan', async () => {
+    const { runtime, service, interactions } = createRuntimeHarness({})
+    let markGenerateStarted!: () => void
+    let finishGenerate!: () => void
+    const generateStarted = new Promise<void>((resolve) => {
+      markGenerateStarted = resolve
+    })
+    const generateGate = new Promise<void>((resolve) => {
+      finishGenerate = resolve
+    })
+    service.generate.mockImplementation(async () => {
+      markGenerateStarted()
+      await generateGate
+      return { projection: projection('version-1'), pauseInteraction: true as const }
+    })
+    const pending = runtime.callSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'generate',
+      input: {}
+    })
+    await generateStarted
+    const duplicate = runtime
+      .callSessionPlan({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'generate',
+        input: {}
+      })
+      .catch((error) => error)
+    await Promise.resolve()
+
+    expect(service.generate).toHaveBeenCalledOnce()
+    await expect(duplicate).resolves.toMatchObject({
+      message: 'A Session Plan is already awaiting approval.'
+    })
+    finishGenerate()
+    await vi.waitFor(() => {
+      expect(interactions.approvalInteractionIdFor('session-1')).toBe('interaction-1')
+    })
+
+    await runtime.respondSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      expectedRevision: 1,
+      decision: 'approved'
+    })
+    await expect(pending).resolves.toMatchObject({ changed: true })
+  })
+
+  it('releases generation admission when durable Plan creation fails', async () => {
+    const { runtime, service, interactions } = createRuntimeHarness({})
+    service.generate.mockRejectedValueOnce(new Error('artifact write failed'))
+    service.getProjection.mockResolvedValueOnce(null)
+
+    await expect(
+      runtime.callSessionPlan({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'generate',
+        input: {}
+      })
+    ).rejects.toThrow('artifact write failed')
+
+    const retry = runtime.callSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'generate',
+      input: {}
+    })
+    await vi.waitFor(() => {
+      expect(interactions.approvalInteractionIdFor('session-1')).toBe('interaction-1')
+    })
+    await runtime.respondSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      expectedRevision: 1,
+      decision: 'approved'
+    })
+    await expect(retry).resolves.toMatchObject({ changed: true })
+  })
+
+  it('does not park a Plan after its generating interaction is cancelled', async () => {
+    const { runtime, service, interactions } = createRuntimeHarness({})
+    let markGenerateStarted!: () => void
+    let finishGenerate!: () => void
+    const generateStarted = new Promise<void>((resolve) => {
+      markGenerateStarted = resolve
+    })
+    const generateGate = new Promise<void>((resolve) => {
+      finishGenerate = resolve
+    })
+    service.generate.mockImplementationOnce(async () => {
+      markGenerateStarted()
+      await generateGate
+      return { projection: projection('version-1'), pauseInteraction: true as const }
+    })
+    const cancelled = runtime
+      .callSessionPlan({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'generate',
+        input: {}
+      })
+      .catch((error) => error)
+    await generateStarted
+
+    await runtime.cancelPrompt({ sessionId: 'session-1' })
+    finishGenerate()
+
+    await expect(cancelled).resolves.toMatchObject({
+      message: 'The Session Plan approval reservation is no longer available.'
+    })
+    expect(interactions.approvalInteractionIdFor('session-1')).toBeUndefined()
+
+    const retry = runtime.callSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'generate',
+      input: {}
+    })
+    await vi.waitFor(() => {
+      expect(interactions.approvalInteractionIdFor('session-1')).toBe('interaction-1')
+    })
+    await runtime.respondSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      expectedRevision: 1,
+      decision: 'approved'
+    })
+    await expect(retry).resolves.toMatchObject({ changed: true })
+  })
+
+  it('does not cancel a successor approval when the older cancel acknowledgement arrives late', async () => {
+    let markNotifyStarted!: () => void
+    let finishNotify!: () => void
+    const notifyStarted = new Promise<void>((resolve) => {
+      markNotifyStarted = resolve
+    })
+    const notifyGate = new Promise<void>((resolve) => {
+      finishNotify = resolve
+    })
+    const { runtime, interactions, setCurrentInteraction } = createRuntimeHarness({
+      cancelNotify: async () => {
+        markNotifyStarted()
+        await notifyGate
+      }
+    })
+    const oldApproval = interactions
+      .parkApproval('session-1', 'interaction-1')
+      .catch((error) => error)
+    const cancellation = runtime.cancelPrompt({ sessionId: 'session-1' })
+    await notifyStarted
+
+    interactions.rejectApproval('session-1', 'older interaction ended')
+    await expect(oldApproval).resolves.toMatchObject({ message: 'older interaction ended' })
+    setCurrentInteraction({ sequence: 8, promptMessageId: 'interaction-2' })
+    const successorApproval = interactions.parkApproval('session-1', 'interaction-2')
+    finishNotify()
+    await cancellation
+
+    expect(interactions.approvalInteractionIdFor('session-1')).toBe('interaction-2')
+    interactions.resolveApproval('session-1', { decision: 'approved' })
+    await expect(successorApproval).resolves.toEqual({ decision: 'approved' })
+  })
+
+  it('updates a Plan only through its exact execution binding', async () => {
+    const { runtime, interactions, updateStepStatus } = createRuntimeHarness({
+      activeProjection: {
+        ...projection('version-1', 4),
+        approval: 'approved',
+        lifecycle: 'approved'
+      }
+    })
+    interactions.bindExecution({
+      sessionId: 'session-1',
+      interactionSequence: 7,
+      artifactVersionId: 'version-1'
+    })
+
+    await expect(
+      runtime.callSessionPlan({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'updateStepStatus',
+        input: { title: 'Analyze the data', status: 'in_progress' }
+      })
+    ).resolves.toMatchObject({ changed: true })
+    expect(updateStepStatus).toHaveBeenCalledOnce()
+  })
+
   it('rejects an MCP server-bound execution version after a replacement became active', async () => {
-    const { runtime, updateStepStatus } = createRuntimeHarness({
+    const { runtime, interactions, updateStepStatus } = createRuntimeHarness({
       activeProjection: {
         ...projection('version-2', 4),
         approval: 'approved',
         lifecycle: 'approved'
       }
     })
-    ;(
-      runtime as unknown as {
-        planExecutionBindings: Map<
-          string,
-          { interactionSequence: number; artifactVersionId: string }
-        >
-      }
-    ).planExecutionBindings.set('session-1', {
+    interactions.bindExecution({
+      sessionId: 'session-1',
       interactionSequence: 7,
       artifactVersionId: 'version-1'
     })
@@ -289,7 +513,7 @@ describe('AcpRuntime Session Plan seam', () => {
   })
 
   it('rejects a Plan version bound to a different interaction', async () => {
-    const { runtime, updateStepStatus } = createRuntimeHarness({
+    const { runtime, interactions, updateStepStatus } = createRuntimeHarness({
       activeProjection: {
         ...projection('version-2', 4),
         approval: 'approved',
@@ -297,14 +521,8 @@ describe('AcpRuntime Session Plan seam', () => {
         requiresExplicitContinuation: true
       }
     })
-    ;(
-      runtime as unknown as {
-        planExecutionBindings: Map<
-          string,
-          { interactionSequence: number; artifactVersionId: string }
-        >
-      }
-    ).planExecutionBindings.set('session-1', {
+    interactions.bindExecution({
+      sessionId: 'session-1',
       interactionSequence: 6,
       artifactVersionId: 'version-2'
     })
@@ -318,6 +536,54 @@ describe('AcpRuntime Session Plan seam', () => {
       })
     ).rejects.toMatchObject({ code: 'interaction-mismatch' })
     expect(updateStepStatus).not.toHaveBeenCalled()
+  })
+
+  it('does not release a successor execution when an older rejection finishes late', async () => {
+    const { runtime, interactions, service } = createRuntimeHarness({})
+    interactions.bindExecution({
+      sessionId: 'session-1',
+      interactionSequence: 6,
+      artifactVersionId: 'version-1'
+    })
+    let markRespondStarted!: () => void
+    let finishRespond!: () => void
+    const respondStarted = new Promise<void>((resolve) => {
+      markRespondStarted = resolve
+    })
+    const respondGate = new Promise<void>((resolve) => {
+      finishRespond = resolve
+    })
+    service.respond.mockImplementationOnce(async () => {
+      markRespondStarted()
+      await respondGate
+      return {
+        projection: {
+          ...projection('version-1'),
+          approval: 'rejected' as const,
+          lifecycle: 'rejected' as const
+        },
+        changed: true
+      }
+    })
+
+    const rejected = runtime.callSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'reject'
+    })
+    await respondStarted
+    interactions.bindExecution({
+      sessionId: 'session-1',
+      interactionSequence: 8,
+      artifactVersionId: 'version-2'
+    })
+    finishRespond()
+
+    await rejected
+    expect(interactions.executionBindingFor('session-1')).toEqual({
+      artifactVersionId: 'version-2',
+      interactionSequence: 8
+    })
   })
 
   it('routes feedback as a visible user Message and resumes the blocked interaction', async () => {
@@ -434,5 +700,37 @@ describe('AcpRuntime Session Plan seam', () => {
     expect(service.respond).toHaveBeenCalledWith(
       expect.objectContaining({ interactionIsLive: false })
     )
+  })
+
+  it('clears only the deleted Session Plan interaction state', async () => {
+    const { runtime, interactions } = createRuntimeHarness({})
+    interactions.register({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionId: 'interaction-1'
+    })
+    interactions.bindExecution({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionSequence: 7
+    })
+    interactions.bindExecution({
+      sessionId: 'session-2',
+      artifactVersionId: 'version-2',
+      interactionSequence: 8
+    })
+    const approval = interactions.parkApproval('session-1', 'interaction-1').catch((error) => error)
+
+    await runtime.deleteSession({ sessionId: 'session-1' })
+
+    await expect(approval).resolves.toMatchObject({
+      message: 'The Session Plan interaction was deleted.'
+    })
+    expect(interactions.interactionIdFor('session-1', 'version-1')).toBeUndefined()
+    expect(interactions.executionBindingFor('session-1')).toBeUndefined()
+    expect(interactions.executionBindingFor('session-2')).toEqual({
+      artifactVersionId: 'version-2',
+      interactionSequence: 8
+    })
   })
 })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -136,6 +136,7 @@ import { createCodexTurnAdapter } from './codex-turn-adapter'
 import { AcpOpenCodeTurnAdapter } from './opencode-turn-adapter'
 import { AcpTurnSkillOwner, type AcpTurnSkillHooks } from './turn-skill-owner'
 import { createProductionPlanService } from '../session-plan/production-plan-service'
+import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { SESSION_PLAN_SYSTEM_PROMPT_APPEND } from '../session-plan/guidance'
 import type { PlanResponseResult, PlanService } from '../session-plan/plan-service'
 import type {
@@ -412,20 +413,9 @@ class AcpRuntime {
   private readonly artifactRepository: ArtifactRepository | undefined
   private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly artifactTurns: ArtifactTurnOwner | undefined
+  private readonly planInteractions = new SessionPlanInteractionOwner()
   private readonly planService: PlanService | undefined
   private readonly planSessions: AcpRuntimePlanOptions['sessions'] | undefined
-  private readonly planApprovalWaiters = new Map<
-    string,
-    {
-      interactionId: string
-      resolve: (result: unknown) => void
-      reject: (error: Error) => void
-    }
-  >()
-  private readonly planExecutionBindings = new Map<
-    string,
-    { interactionSequence: number; artifactVersionId: string }
-  >()
   private readonly promptContentOwner: AcpPromptContentOwner
   private readonly promptPreparation: AcpPromptPreparationOwner
   private readonly contextCompactionWorkflow: AcpContextCompactionWorkflow
@@ -517,6 +507,7 @@ class AcpRuntime {
     this.planService =
       options.plan && this.artifactTurns && options.artifacts?.provenance?.resolveVersionContent
         ? createProductionPlanService({
+            interactions: this.planInteractions,
             artifactTurns: this.artifactTurns,
             provenance: {
               resolveVersionContent: (request) =>
@@ -708,6 +699,8 @@ class AcpRuntime {
       invalidatePendingSessionStartups: () => this.invalidatePendingSessionStartups(),
       disposePermissionContext: () => this.permissionContext.dispose(),
       clearReviewerState: () => this.reviewerSessions.clear(),
+      clearPlanInteractions: () =>
+        this.planInteractions.clearAll('The Session Plan interaction was disconnected.'),
       settleActivePrompts: () => this.sessionInteractions.settleActivePrompts(),
       supersedeInteractions: () => this.sessionInteractions.supersedeAll(),
       clearContextUsage: () => this.contextUsageTracker.clear(),
@@ -1010,11 +1003,9 @@ class AcpRuntime {
     const service = this.planService
     if (!service) throw new Error('Session Plan capability is not configured.')
     if (input.operation === 'generate') {
-      if (this.planApprovalWaiters.has(input.sessionId)) {
-        throw new Error('A Session Plan is already awaiting approval.')
-      }
       const interactionId = this.artifactTurns?.promptMessageIdFor(input.sessionId)
       if (!interactionId) throw new Error('No active interaction can generate a Session Plan.')
+      this.planInteractions.reserveApproval(input.sessionId, interactionId)
       let result: Awaited<ReturnType<PlanService['generate']>>
       try {
         result = await service.generate({
@@ -1024,13 +1015,18 @@ class AcpRuntime {
           content: input.input as GeneratePlanContent
         })
       } catch (error) {
+        this.planInteractions.releaseApprovalReservation(input.sessionId, interactionId)
         const current = await service.getProjection(input.projectId, input.sessionId)
         if (current) this.publishPlanProjection(input.sessionId, current)
         throw error
       }
-      const approval = new Promise((resolve, reject) => {
-        this.planApprovalWaiters.set(input.sessionId, { interactionId, resolve, reject })
-      })
+      let approval: Promise<unknown>
+      try {
+        approval = this.planInteractions.parkReservedApproval(input.sessionId, interactionId)
+      } catch (error) {
+        this.planInteractions.release(input.sessionId, result.projection.artifactVersionId)
+        throw error
+      }
       this.publishPlanProjection(input.sessionId, result.projection)
       return approval
     }
@@ -1048,6 +1044,7 @@ class AcpRuntime {
     if (input.operation === 'approve' || input.operation === 'reject') {
       const interactionIsLive = this.sessionInteractions.current(input.sessionId) !== undefined
       const decision = input.operation === 'approve' ? 'approved' : 'rejected'
+      const executionBinding = this.planInteractions.executionBindingFor(input.sessionId)
       const result = await service.respond({
         ...identity,
         decision,
@@ -1059,9 +1056,14 @@ class AcpRuntime {
           result.projection.artifactVersionId
         )
       } else {
-        this.planExecutionBindings.delete(input.sessionId)
+        if (executionBinding) {
+          this.planInteractions.releaseExecution(
+            input.sessionId,
+            executionBinding.interactionSequence
+          )
+        }
       }
-      this.resolvePlanApprovalWaiter(input.sessionId, result)
+      this.planInteractions.resolveApproval(input.sessionId, result)
       this.publishPlanProjection(input.sessionId, result.projection)
       return result
     }
@@ -1078,7 +1080,7 @@ class AcpRuntime {
       )
     }
     const interaction = this.sessionInteractions.current(input.sessionId)
-    const binding = this.planExecutionBindings.get(input.sessionId)
+    const binding = this.planInteractions.executionBindingFor(input.sessionId)
     if (!binding) {
       throw new PlanCommandError(
         'continuation-required',
@@ -1125,10 +1127,14 @@ class AcpRuntime {
 
   async respondSessionPlan(input: PlanResponseCommand): Promise<PlanResponseResult> {
     if (!this.planService) throw new Error('Session Plan capability is not configured.')
-    if (input.decision === undefined && !this.planApprovalWaiters.has(input.sessionId)) {
+    if (
+      input.decision === undefined &&
+      !this.planInteractions.approvalInteractionIdFor(input.sessionId)
+    ) {
       throw new Error('The paused Session Plan interaction is no longer available.')
     }
-    const interactionIsLive = this.planApprovalWaiters.has(input.sessionId)
+    const interactionIsLive =
+      this.planInteractions.approvalInteractionIdFor(input.sessionId) !== undefined
     const projection = await this.planService.getProjection(input.projectId, input.sessionId, {
       interactionIsLive
     })
@@ -1142,12 +1148,14 @@ class AcpRuntime {
           result.projection.artifactVersionId
         )
       }
-      if (interactionIsLive) this.resolvePlanApprovalWaiter(input.sessionId, result)
+      if (interactionIsLive) this.planInteractions.resolveApproval(input.sessionId, result)
       this.publishPlanProjection(input.sessionId, result.projection)
       return result
     }
-    const waiter = this.planApprovalWaiters.get(input.sessionId)
-    if (!waiter || waiter.interactionId !== result.routeToInteractionId) {
+    if (
+      this.planInteractions.approvalInteractionIdFor(input.sessionId) !==
+      result.routeToInteractionId
+    ) {
       throw new Error('The paused Session Plan interaction is no longer available.')
     }
     try {
@@ -1165,7 +1173,7 @@ class AcpRuntime {
     } catch (error) {
       safeLogError('Routed user Message projection callback failed', errorLogFields(error))
     }
-    this.resolvePlanApprovalWaiter(input.sessionId, result)
+    this.planInteractions.resolveApproval(input.sessionId, result)
     return result
   }
 
@@ -1202,20 +1210,14 @@ class AcpRuntime {
     }
   }
 
-  private resolvePlanApprovalWaiter(sessionId: string, result: unknown): void {
-    const waiter = this.planApprovalWaiters.get(sessionId)
-    if (!waiter) return
-    this.planApprovalWaiters.delete(sessionId)
-    waiter.resolve(result)
-  }
-
   private bindPlanExecutionToCurrentInteraction(
     sessionId: string,
     artifactVersionId: string
   ): void {
     const interaction = this.sessionInteractions.current(sessionId)
     if (!interaction || interaction.kind !== 'prompt') return
-    this.planExecutionBindings.set(sessionId, {
+    this.planInteractions.bindExecution({
+      sessionId,
       interactionSequence: interaction.sequence,
       artifactVersionId
     })
@@ -1237,13 +1239,6 @@ class AcpRuntime {
         'The active Session Plan does not belong to the durable active Message Branch.'
       )
     }
-  }
-
-  private rejectPlanApprovalWaiter(sessionId: string, reason: string): void {
-    const waiter = this.planApprovalWaiters.get(sessionId)
-    if (!waiter) return
-    this.planApprovalWaiters.delete(sessionId)
-    waiter.reject(new Error(reason))
   }
 
   // Lists sessions with an in-flight prompt, for the pre-migration active-session warning.
@@ -1752,9 +1747,6 @@ class AcpRuntime {
     emitClosedStatus = true,
     teardownGeneration = this.connectionGeneration
   ): Promise<AcpStateSnapshot> {
-    for (const sessionId of this.planApprovalWaiters.keys()) {
-      this.rejectPlanApprovalWaiter(sessionId, 'The Session Plan interaction was disconnected.')
-    }
     return this.connectionClose.disconnectCurrent(emitClosedStatus, teardownGeneration)
   }
 
@@ -1902,7 +1894,8 @@ class AcpRuntime {
     const decision = continuation?.pendingAction
     const committed = (): AcpPromptTurnPlanContext => {
       if (authorized) {
-        this.planExecutionBindings.set(request.sessionId, {
+        this.planInteractions.bindExecution({
+          sessionId: request.sessionId,
           interactionSequence: interaction.sequence,
           artifactVersionId: authorized.artifactVersionId
         })
@@ -1913,6 +1906,7 @@ class AcpRuntime {
       })
     }
     if (continuation && (decision === 'approve' || decision === 'reject')) {
+      const executionBinding = this.planInteractions.executionBindingFor(request.sessionId)
       return this.planService!.respond({
         projectId: continuation.projectId,
         sessionId: request.sessionId,
@@ -1924,9 +1918,14 @@ class AcpRuntime {
         if (decision === 'approve') authorized = result.projection
         else {
           protectedPending = result.projection
-          this.planExecutionBindings.delete(request.sessionId)
+          if (executionBinding) {
+            this.planInteractions.releaseExecution(
+              request.sessionId,
+              executionBinding.interactionSequence
+            )
+          }
         }
-        this.resolvePlanApprovalWaiter(request.sessionId, result)
+        this.planInteractions.resolveApproval(request.sessionId, result)
         this.publishPlanProjection(request.sessionId, result.projection)
         return committed()
       })
@@ -1939,7 +1938,7 @@ class AcpRuntime {
     interaction: AcpPromptSessionInteractionScope,
     response: PromptResponse
   ): Promise<void> {
-    const binding = this.planExecutionBindings.get(sessionId)
+    const binding = this.planInteractions.executionBindingFor(sessionId)
     if (
       response.stopReason !== 'end_turn' ||
       !this.planService ||
@@ -1962,17 +1961,24 @@ class AcpRuntime {
     sessionId: string,
     interaction: AcpPromptSessionInteractionScope
   ): void {
-    const binding = this.planExecutionBindings.get(sessionId)
-    if (binding?.interactionSequence === interaction.sequence) {
-      this.planExecutionBindings.delete(sessionId)
-    }
-    const waiter = this.planApprovalWaiters.get(sessionId)
-    if (waiter?.interactionId === interaction.promptMessageId) {
-      this.rejectPlanApprovalWaiter(
+    this.planInteractions.releaseExecution(sessionId, interaction.sequence)
+    if (interaction.promptMessageId) {
+      this.rejectPlanApprovalForInteraction(
         sessionId,
+        interaction.promptMessageId,
         'The Session Plan interaction ended before approval.'
       )
     }
+  }
+
+  private rejectPlanApprovalForInteraction(
+    sessionId: string,
+    interactionId: string,
+    reason: string
+  ): void {
+    this.planInteractions.releaseApprovalReservation(sessionId, interactionId)
+    if (this.planInteractions.approvalInteractionIdFor(sessionId) !== interactionId) return
+    this.planInteractions.rejectApproval(sessionId, reason)
   }
 
   // Sends one prompt turn to the targeted session and streams updates until stop.
@@ -2008,6 +2014,9 @@ class AcpRuntime {
   async cancelPrompt(request: AcpCancelPromptRequest): Promise<AcpStateSnapshot> {
     const connection = this.connection
     const activeSession = this.activeSessionFor(request.sessionId)
+    const planInteractionId =
+      this.currentPromptInteraction(request.sessionId)?.promptMessageId ??
+      this.planInteractions.approvalInteractionIdFor(request.sessionId)
 
     if (connection && activeSession) {
       await this.sessionInteractions.cancelPrompt({
@@ -2017,10 +2026,13 @@ class AcpRuntime {
             sessionId: activeSession.sessionId
           }),
         onAccepted: () => {
-          this.rejectPlanApprovalWaiter(
-            request.sessionId,
-            'The Session Plan interaction was cancelled.'
-          )
+          if (planInteractionId) {
+            this.rejectPlanApprovalForInteraction(
+              request.sessionId,
+              planInteractionId,
+              'The Session Plan interaction was cancelled.'
+            )
+          }
           this.cancelPermissionFlowForSession(request.sessionId)
           this.pushEvent({
             kind: 'system',
@@ -2048,8 +2060,10 @@ class AcpRuntime {
 
   // Closes the agent-side session when supported, then removes local routing state.
   async deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot> {
-    this.rejectPlanApprovalWaiter(request.sessionId, 'The Session Plan interaction was deleted.')
-    this.planExecutionBindings.delete(request.sessionId)
+    this.planInteractions.clearSession(
+      request.sessionId,
+      'The Session Plan interaction was deleted.'
+    )
     return this.sessionDeletion.delete(request.sessionId)
   }
 

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -332,6 +332,15 @@ describe('runtime state ownership architecture', () => {
     }
   })
 
+  it('keeps live Session Plan state behind one Runtime owner', () => {
+    const source = readSource('src/main/acp/runtime.ts')
+
+    expect(source).not.toContain('planApprovalWaiters')
+    expect(source).not.toContain('planExecutionBindings')
+    expect(source.match(/new SessionPlanInteractionOwner\(\)/g)).toHaveLength(1)
+    expect(source).toContain('interactions: this.planInteractions')
+  })
+
   it('accepts declared interface imports for a future orchestration module', () => {
     const source = `
       import type { AcpApplicationCommandDependencies } from '../acp/application-commands'

--- a/src/main/session-plan/session-plan-interaction-owner.test.ts
+++ b/src/main/session-plan/session-plan-interaction-owner.test.ts
@@ -49,6 +49,36 @@ describe('SessionPlanInteractionOwner', () => {
     await expect(approval).resolves.toEqual({ decision: 'approved' })
   })
 
+  it('reserves approval generation atomically before parking becomes visible', async () => {
+    const owner = new SessionPlanInteractionOwner()
+
+    owner.reserveApproval('session-1', 'interaction-1')
+
+    expect(owner.approvalInteractionIdFor('session-1')).toBeUndefined()
+    expect(() => owner.reserveApproval('session-1', 'interaction-2')).toThrow(
+      'A Session Plan is already awaiting approval.'
+    )
+    expect(() => owner.parkApproval('session-1', 'interaction-2')).toThrow(
+      'A Session Plan is already awaiting approval.'
+    )
+    const approval = owner.parkReservedApproval('session-1', 'interaction-1')
+    expect(owner.approvalInteractionIdFor('session-1')).toBe('interaction-1')
+    owner.resolveApproval('session-1', { decision: 'approved' })
+    await expect(approval).resolves.toEqual({ decision: 'approved' })
+  })
+
+  it('releases a failed approval generation reservation for retry', () => {
+    const owner = new SessionPlanInteractionOwner()
+    owner.reserveApproval('session-1', 'interaction-1')
+
+    expect(owner.releaseApprovalReservation('session-1', 'interaction-1')).toBe(true)
+    expect(owner.releaseApprovalReservation('session-1', 'interaction-1')).toBe(false)
+    expect(() => owner.parkReservedApproval('session-1', 'interaction-1')).toThrow(
+      'The Session Plan approval reservation is no longer available.'
+    )
+    expect(() => owner.reserveApproval('session-1', 'interaction-2')).not.toThrow()
+  })
+
   it('rejects a parked approval exactly once', async () => {
     const owner = new SessionPlanInteractionOwner()
     const approval = owner.parkApproval('session-1', 'interaction-1')

--- a/src/main/session-plan/session-plan-interaction-owner.ts
+++ b/src/main/session-plan/session-plan-interaction-owner.ts
@@ -16,6 +16,7 @@ type SessionPlanExecutionBinding = Readonly<{
 
 type SessionPlanInteractionRow = {
   identity?: SessionPlanInteractionIdentity
+  approvalReservation?: string
   approval?: SessionPlanApprovalParking
   execution?: SessionPlanExecutionBinding
 }
@@ -46,9 +47,37 @@ class SessionPlanInteractionOwner {
     return true
   }
 
+  reserveApproval(sessionId: string, interactionId: string): void {
+    const row = this.rows.get(sessionId) ?? {}
+    if (row.approvalReservation || row.approval) {
+      throw new Error('A Session Plan is already awaiting approval.')
+    }
+    row.approvalReservation = interactionId
+    this.rows.set(sessionId, row)
+  }
+
+  releaseApprovalReservation(sessionId: string, interactionId: string): boolean {
+    const row = this.rows.get(sessionId)
+    if (row?.approvalReservation !== interactionId) return false
+    delete row.approvalReservation
+    this.prune(sessionId, row)
+    return true
+  }
+
+  parkReservedApproval(sessionId: string, interactionId: string): Promise<unknown> {
+    const row = this.rows.get(sessionId)
+    if (row?.approvalReservation !== interactionId) {
+      throw new Error('The Session Plan approval reservation is no longer available.')
+    }
+    delete row.approvalReservation
+    return this.parkApproval(sessionId, interactionId)
+  }
+
   parkApproval(sessionId: string, interactionId: string): Promise<unknown> {
     const row = this.rows.get(sessionId) ?? {}
-    if (row.approval) throw new Error('A Session Plan is already awaiting approval.')
+    if (row.approvalReservation || row.approval) {
+      throw new Error('A Session Plan is already awaiting approval.')
+    }
     this.rows.set(sessionId, row)
     return new Promise((resolve, reject) => {
       row.approval = { interactionId, resolve, reject }
@@ -116,7 +145,9 @@ class SessionPlanInteractionOwner {
   }
 
   private prune(sessionId: string, row: SessionPlanInteractionRow): void {
-    if (!row.identity && !row.approval && !row.execution) this.rows.delete(sessionId)
+    if (!row.identity && !row.approvalReservation && !row.approval && !row.execution) {
+      this.rows.delete(sessionId)
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

`AcpRuntime` still mirrored Session Plan approval and execution state in two private Maps after the Plan service adopted `SessionPlanInteractionOwner`. That left two ownership paths and made prompt, cancel, delete, and disconnect races depend on Runtime-local cleanup.

## Proposed change

- use one Runtime-owned `SessionPlanInteractionOwner` and inject the same instance into `PlanService`;
- reserve approval identity before asynchronous generation, then atomically park or release it;
- bind prompt execution and approval cleanup by exact interaction identity so late completion, rejection, or cancel acknowledgements cannot clear a successor;
- route delete and expected, unexpected, and synchronous connection shutdown cleanup through the owner;
- remove the legacy `planApprovalWaiters` and `planExecutionBindings` Maps and private-map test injection.

```mermaid
flowchart LR
  Runtime["AcpRuntime commands and prompt lifecycle"] --> Owner["SessionPlanInteractionOwner"]
  PlanService["PlanService generation and responses"] --> Owner
  Close["cancel / delete / connection close"] --> Owner
  Owner --> Approval["approval reservation / parked approval"]
  Owner --> Execution["exact prompt execution binding"]
```

## Scope and non-goals

- Production diff: **177 raw**; total diff: **574 raw**, within the Phase 6 limit of 600.
- `src/main/acp/runtime.ts` is **2,817 lines** after this cutover.
- No IPC, Web, Task, CLI, SDK, wire-envelope, persistence, Artifact relationship, data-model, or UI change.
- Electron/Web Plan behavior and existing CLI capability asymmetry remain unchanged.
- This PR does not introduce orchestration state or Issue #458 interfaces.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

| Behavior / risk | Final command | Result |
| --- | --- | --- |
| Plan owner, service, Runtime commands, prompt workflows, coordinator, close cleanup, and architecture guard | `npm test -- src/main/session-plan/session-plan-interaction-owner.test.ts src/main/session-plan/plan-service.test.ts src/main/acp/runtime-session-plan.test.ts src/main/acp/prompt-turn-workflow.test.ts src/main/acp/prompt-outcome-finalizer.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/connection-close-workflow.test.ts src/main/runtime-state-ownership.architecture.test.ts` | 8 files, 167 tests passed |
| Restored Plan, continuation, completion gate, ordinary message, and abnormal terminal-stop consumers | `npm test -- src/main/acp/runtime.test.ts -t 'restored Plan|Plan continuation|Session Plan completion gate|ordinary message|abnormal provider terminal stop'` | 8 passed, 432 skipped |
| Affected Node process types | `npm run typecheck:node` | passed |
| Changed source and tests | focused `eslint --no-cache` over all 7 changed files | no issues |
| Patch hygiene | `git diff --check` | passed |

The selected impact set includes every changed owner/interface, its Runtime and workflow consumers, and connection cleanup paths. Renderer/platform lanes are excluded locally because no renderer, IPC, platform adapter, build, persistence, or configuration interface changed; PR Gate remains authoritative for repository-selected and platform checks. No uncovered compatibility risk is known.

Independent Standards and Spec reviews completed with **0 findings** after the final cancel-acknowledgement race fix.

## Review focus

- generation reservation rollback when generation fails or is cancelled before parking;
- exact interaction guards when an older prompt rejection or cancel acknowledgement arrives after a successor starts;
- cleanup parity across delete, expected disconnect, unexpected close, and synchronous shutdown;
- proof that Runtime owns one Plan interaction owner and no legacy Plan Maps remain.
