### PR TITLE
refactor(acp): delegate model and attached resume workflows

### DIFF
--- a/src/main/acp/model-change-workflow.test.ts
+++ b/src/main/acp/model-change-workflow.test.ts
@@ -1,9 +1,41 @@
-import { describe, expect, it, type Mock, vi } from 'vitest'
+import type { ActiveSession, ClientConnection, SessionConfigOption } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
 
+import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
 import type { AgentModelChangeTarget } from '../agent-framework'
+import { claudeCodeFramework } from '../agent-framework'
+import type {
+  AcpBackendGenerationOwner,
+  AcpBackendGenerationView
+} from './backend-generation-owner'
+import type { AcpConnectionResourceOwner } from './connection-resource-owner'
+import type { ContextUsageTracker } from './context-usage-tracker'
 import { AcpModelChangeWorkflow } from './model-change-workflow'
+import type { AcpSessionConfigurator } from './session-configurator'
+import { AcpSessionRegistry } from './session-registry'
 
-const target = (model: string): AgentModelChangeTarget => ({
+const permissionProfile: SessionPermissionProfileState = {
+  selectedProfile: 'ask',
+  effectiveProfile: 'ask',
+  currentModeId: 'default',
+  availableModeIds: ['default'],
+  fullAccessAvailable: false
+}
+
+const modelOption = (currentValue = 'model-a'): SessionConfigOption =>
+  ({
+    type: 'select',
+    id: 'model',
+    name: 'Model',
+    category: 'model',
+    currentValue,
+    options: ['model-a', 'model-b', 'model-c'].map((value) => ({ value, name: value }))
+  }) as SessionConfigOption
+
+const target = (
+  model: string,
+  overrides: Partial<AgentModelChangeTarget> = {}
+): AgentModelChangeTarget => ({
   frameworkId: 'claude-code',
   backendId: 'claude-code:provider',
   route: 'claude-anthropic',
@@ -11,47 +43,192 @@ const target = (model: string): AgentModelChangeTarget => ({
   sessionModel: model,
   sessionModelRequired: false,
   reasoningEffort: 'default',
-  supportsImageInput: false
+  supportsImageInput: false,
+  ...overrides
 })
 
 type WorkflowHarness = {
   workflow: AcpModelChangeWorkflow
-  canApply: Mock<(target: AgentModelChangeTarget) => boolean>
-  matchesCurrent: Mock<(target: AgentModelChangeTarget) => boolean>
-  applyTarget: Mock<(target: AgentModelChangeTarget) => Promise<boolean>>
-  requestReconnect: Mock<() => Promise<void>>
-  recoverFailedReconnect: Mock<() => void>
-  reportReconnectFailure: Mock<(error: unknown) => void>
+  request: ReturnType<typeof vi.fn>
+  requestReconnect: ReturnType<typeof vi.fn>
+  recoverFailedReconnect: ReturnType<typeof vi.fn>
+  reportReconnectFailure: ReturnType<typeof vi.fn>
+  updateModel: ReturnType<typeof vi.fn>
+  updateReasoningEffort: ReturnType<typeof vi.fn>
+  updateAggregateModel: ReturnType<typeof vi.fn>
+  setBridgeReasoningEffort: ReturnType<typeof vi.fn>
+  applyLiveEffort: ReturnType<typeof vi.fn>
+  clearContext: ReturnType<typeof vi.fn>
+  beginContext: ReturnType<typeof vi.fn>
+  emitState: ReturnType<typeof vi.fn>
   setBusy: (value: boolean) => void
+  setConnected: (value: boolean) => void
+  setProviderReconnectPending: (value: boolean) => void
+  setSupportsImageInput: (value: boolean) => void
 }
 
 const createHarness = (): WorkflowHarness => {
   let busy = false
-  const canApply = vi.fn(() => true)
-  const matchesCurrent = vi.fn(() => false)
-  const applyTarget = vi.fn(async () => true)
+  let connected = true
+  let providerReconnectPending = false
+  let backend: AcpBackendGenerationView = {
+    framework: claudeCodeFramework,
+    backendId: 'claude-code:provider',
+    modelRoute: 'claude-anthropic',
+    session: { model: 'model-a', modelRequired: false },
+    prompt: { systemPromptAppends: [] },
+    context: { model: 'model-a', supportsImageInput: false },
+    adapter: { nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false }
+  }
+  let options = [modelOption()]
+  const request = vi.fn(async (_method: unknown, params: unknown) => {
+    const value = (params as { value: string }).value
+    options = [modelOption(value)]
+    return { configOptions: options }
+  })
+  const connection = { agent: { request } } as unknown as ClientConnection
+  const session = {
+    sessionId: 'provider-session',
+    newSessionResponse: { configOptions: options },
+    dispose: vi.fn()
+  } as unknown as ActiveSession
+  const registry = new AcpSessionRegistry()
+  const reserved = registry.reserve({ sessionIds: ['app-session', session.sessionId] })
+  if (reserved.collision) throw reserved.collision
+  const entry = registry.publish(reserved.reservation, 'app-session', {
+    session,
+    cwd: '/workspace',
+    projectName: 'project-a',
+    frameworkId: 'claude-code',
+    backendId: backend.backendId,
+    permissionProfile,
+    appliedModel: 'model-a',
+    configOptions: options
+  })
+  reserved.reservation.release()
+  const updateAggregateModel = vi.spyOn(entry.aggregate, 'updateModel')
+
+  const updateModel = vi.fn((next: AgentModelChangeTarget) => {
+    backend = {
+      ...backend,
+      backendId: next.backendId,
+      modelRoute: next.route,
+      session: {
+        ...backend.session,
+        model: next.sessionModel,
+        modelRequired: next.sessionModelRequired,
+        ...(next.reasoningEffort === 'default' ? {} : { effort: next.reasoningEffort })
+      },
+      context: {
+        model: next.model,
+        ...(next.contextWindow ? { window: next.contextWindow } : {}),
+        supportsImageInput: next.supportsImageInput
+      }
+    }
+    return backend
+  })
+  const updateReasoningEffort = vi.fn((effort: 'default' | 'low' | 'medium' | 'high' | 'max') => {
+    backend = {
+      ...backend,
+      session: {
+        ...backend.session,
+        ...(effort === 'default' ? {} : { effort })
+      }
+    }
+    return backend
+  })
+  const backendGeneration = {
+    get current() {
+      return backend
+    },
+    updateModel,
+    updateReasoningEffort
+  } as Pick<AcpBackendGenerationOwner, 'current' | 'updateModel' | 'updateReasoningEffort'>
+
+  const setBridgeReasoningEffort = vi.fn()
+  const connectionResources = {
+    get connection() {
+      return connected ? connection : undefined
+    },
+    get isShuttingDown() {
+      return false
+    },
+    get anthropicBridgeAvailable() {
+      return false
+    },
+    get providerTransportAvailable() {
+      return false
+    },
+    assertCurrentConnection: vi.fn(),
+    setProviderTransportTarget: vi.fn(() => true),
+    setAnthropicBridgeTarget: vi.fn(() => true),
+    setBridgeModelTarget: vi.fn(() => true),
+    setBridgeReasoningEffort
+  } as Pick<
+    AcpConnectionResourceOwner,
+    | 'connection'
+    | 'isShuttingDown'
+    | 'anthropicBridgeAvailable'
+    | 'providerTransportAvailable'
+    | 'assertCurrentConnection'
+    | 'setProviderTransportTarget'
+    | 'setAnthropicBridgeTarget'
+    | 'setBridgeModelTarget'
+    | 'setBridgeReasoningEffort'
+  >
+
+  const applyLiveEffort = vi.fn(async () => ({ reconnectRequired: false }))
+  const clearContext = vi.fn()
+  const beginContext = vi.fn()
+  const emitState = vi.fn()
   const requestReconnect = vi.fn(async () => undefined)
   const recoverFailedReconnect = vi.fn()
   const reportReconnectFailure = vi.fn()
   const workflow = new AcpModelChangeWorkflow({
-    canApply,
-    matchesCurrent,
+    backendGeneration,
+    connectionResources,
+    registry,
+    configurator: { applyLiveEffort } as Pick<AcpSessionConfigurator, 'applyLiveEffort'>,
+    contextUsage: {
+      clear: clearContext,
+      beginSession: beginContext
+    } as Pick<ContextUsageTracker, 'clear' | 'beginSession'>,
+    currentStatus: () => (connected ? 'connected' : 'closed'),
+    providerReconnectPending: () => providerReconnectPending,
     isGenerationBusy: () => busy,
-    applyTarget,
-    requestReconnect,
-    recoverFailedReconnect,
-    reportReconnectFailure
-  })
-  return {
-    workflow,
-    canApply,
-    matchesCurrent,
-    applyTarget,
+    contextEstimateInput: () => ({ frameworkId: 'claude-code', model: backend.context.model }),
+    emitState,
     requestReconnect,
     recoverFailedReconnect,
     reportReconnectFailure,
-    setBusy: (value: boolean) => {
+    diagnosticContext: () => ({})
+  })
+
+  return {
+    workflow,
+    request,
+    requestReconnect,
+    recoverFailedReconnect,
+    reportReconnectFailure,
+    updateModel,
+    updateReasoningEffort,
+    updateAggregateModel,
+    setBridgeReasoningEffort,
+    applyLiveEffort,
+    clearContext,
+    beginContext,
+    emitState,
+    setBusy: (value) => {
       busy = value
+    },
+    setConnected: (value) => {
+      connected = value
+    },
+    setProviderReconnectPending: (value) => {
+      providerReconnectPending = value
+    },
+    setSupportsImageInput: (value) => {
+      backend = { ...backend, context: { ...backend.context, supportsImageInput: value } }
     }
   }
 }
@@ -59,12 +236,12 @@ const createHarness = (): WorkflowHarness => {
 describe('ACP model-change workflow', () => {
   it('rejects an incompatible target without arming admission', async () => {
     const harness = createHarness()
-    harness.canApply.mockReturnValue(false)
+    harness.setConnected(false)
 
     await expect(harness.workflow.apply(target('model-b'))).resolves.toBe(false)
 
     expect(harness.workflow.barrier).toBeUndefined()
-    expect(harness.applyTarget).not.toHaveBeenCalled()
+    expect(harness.request).not.toHaveBeenCalled()
   })
 
   it('keeps only the latest target while the generation is busy', async () => {
@@ -73,42 +250,94 @@ describe('ACP model-change workflow', () => {
 
     await harness.workflow.apply(target('model-b'))
     await harness.workflow.apply(target('model-c'))
-    expect(harness.applyTarget).not.toHaveBeenCalled()
-    expect(harness.workflow.barrier).toBeDefined()
+    expect(harness.request).not.toHaveBeenCalled()
+    const barrier = harness.workflow.barrier
+    expect(barrier).toBeDefined()
 
     harness.setBusy(false)
     harness.workflow.activityChanged()
-    await harness.workflow.barrier
+    await barrier
 
-    expect(harness.applyTarget).toHaveBeenCalledOnce()
-    expect(harness.applyTarget).toHaveBeenCalledWith(target('model-c'))
-    expect(harness.workflow.barrier).toBeUndefined()
+    expect(harness.request).toHaveBeenCalledOnce()
+    expect(harness.request.mock.calls[0]?.[1]).toMatchObject({ value: 'model-c' })
+    expect(harness.updateModel).toHaveBeenCalledWith(target('model-c'))
+    expect(harness.updateAggregateModel).toHaveBeenCalledWith(
+      'model-c',
+      expect.any(Array),
+      'claude-code:provider'
+    )
   })
 
   it('cancels a pending target when the current target is selected again', async () => {
     const harness = createHarness()
     harness.setBusy(true)
     await harness.workflow.apply(target('model-b'))
-    harness.matchesCurrent.mockReturnValue(true)
     harness.setBusy(false)
 
     await expect(harness.workflow.apply(target('model-a'))).resolves.toBe(true)
 
     expect(harness.workflow.barrier).toBeUndefined()
-    expect(harness.applyTarget).not.toHaveBeenCalled()
+    expect(harness.request).not.toHaveBeenCalled()
   })
 
-  it('falls back to reconnect and recovers a failed reconnect before releasing admission', async () => {
+  it('commits model and context facts only after every live Session is configured', async () => {
     const harness = createHarness()
-    const failure = new Error('reconnect failed')
-    harness.applyTarget.mockResolvedValue(false)
-    harness.requestReconnect.mockRejectedValue(failure)
 
     await expect(harness.workflow.apply(target('model-b'))).resolves.toBe(true)
 
+    expect(harness.updateModel).toHaveBeenCalledOnce()
+    expect(harness.clearContext).toHaveBeenCalledOnce()
+    expect(harness.beginContext).toHaveBeenCalledWith(
+      'app-session',
+      expect.objectContaining({ model: 'model-b' })
+    )
+    expect(harness.emitState).toHaveBeenCalledOnce()
+  })
+
+  it('reconnects instead of committing an image downgrade with opaque provider history', async () => {
+    const harness = createHarness()
+    harness.setSupportsImageInput(true)
+
+    await expect(
+      harness.workflow.apply(target('model-b', { supportsImageInput: false }))
+    ).resolves.toBe(true)
+
     expect(harness.requestReconnect).toHaveBeenCalledOnce()
+    expect(harness.updateModel).not.toHaveBeenCalled()
+  })
+
+  it('recovers a failed reconnect before releasing admission', async () => {
+    const harness = createHarness()
+    const failure = new Error('reconnect failed')
+    harness.setSupportsImageInput(true)
+    harness.requestReconnect.mockRejectedValue(failure)
+
+    await expect(
+      harness.workflow.apply(target('model-b', { supportsImageInput: false }))
+    ).resolves.toBe(true)
+
     expect(harness.reportReconnectFailure).toHaveBeenCalledWith(failure)
     expect(harness.recoverFailedReconnect).toHaveBeenCalledOnce()
     expect(harness.workflow.barrier).toBeUndefined()
+  })
+
+  it('applies effort through the same model barrier and live configurator', async () => {
+    const harness = createHarness()
+
+    await expect(harness.workflow.applyReasoningEffort('high')).resolves.toBe(true)
+
+    expect(harness.updateReasoningEffort).toHaveBeenCalledWith('high')
+    expect(harness.setBridgeReasoningEffort).toHaveBeenCalledWith('high')
+    expect(harness.applyLiveEffort).toHaveBeenCalledOnce()
+  })
+
+  it('does not leak effort into the old generation while reconnect is pending', async () => {
+    const harness = createHarness()
+    harness.setProviderReconnectPending(true)
+
+    await expect(harness.workflow.applyReasoningEffort('high')).resolves.toBe(false)
+
+    expect(harness.updateReasoningEffort).not.toHaveBeenCalled()
+    expect(harness.applyLiveEffort).not.toHaveBeenCalled()
   })
 })

--- a/src/main/acp/model-change-workflow.ts
+++ b/src/main/acp/model-change-workflow.ts
@@ -1,17 +1,52 @@
+import * as acp from '@agentclientprotocol/sdk'
+import type { ActiveSession, SessionConfigOption } from '@agentclientprotocol/sdk'
+
+import type { AcpStateSnapshot } from '../../shared/acp'
+import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import type { AgentModelChangeTarget } from '../agent-framework'
+import { createLogger, diagnosticErrorFields } from '../logger'
+import type { AcpBackendGenerationOwner } from './backend-generation-owner'
+import type { AcpConnectionResourceOwner } from './connection-resource-owner'
+import type { ContextUsageTracker, SessionEstimateInput } from './context-usage-tracker'
+import { matchSessionModelOption, resolveSessionEffortOption } from './session-config'
+import type { AcpSessionConfigurator } from './session-configurator'
+import type { AcpSessionRegistry } from './session-registry'
+
+const log = createLogger('acp')
 
 type AcpModelChangeWorkflowOptions = Readonly<{
-  canApply: (target: AgentModelChangeTarget) => boolean
-  matchesCurrent: (target: AgentModelChangeTarget) => boolean
+  backendGeneration: Pick<
+    AcpBackendGenerationOwner,
+    'current' | 'updateModel' | 'updateReasoningEffort'
+  >
+  connectionResources: Pick<
+    AcpConnectionResourceOwner,
+    | 'connection'
+    | 'isShuttingDown'
+    | 'anthropicBridgeAvailable'
+    | 'providerTransportAvailable'
+    | 'assertCurrentConnection'
+    | 'setProviderTransportTarget'
+    | 'setAnthropicBridgeTarget'
+    | 'setBridgeModelTarget'
+    | 'setBridgeReasoningEffort'
+  >
+  registry: Pick<AcpSessionRegistry, 'entries' | 'lookup'>
+  configurator: Pick<AcpSessionConfigurator, 'applyLiveEffort'>
+  contextUsage: Pick<ContextUsageTracker, 'clear' | 'beginSession'>
+  currentStatus: () => AcpStateSnapshot['status']
+  providerReconnectPending: () => boolean
   isGenerationBusy: () => boolean
-  applyTarget: (target: AgentModelChangeTarget) => Promise<boolean>
+  contextEstimateInput: (sessionId: string) => SessionEstimateInput
+  emitState: () => void
   requestReconnect: () => Promise<void>
   recoverFailedReconnect: () => void
   reportReconnectFailure: (error: unknown) => void
+  diagnosticContext: () => Readonly<Record<string, unknown>>
 }>
 
-// Owns the generation-local latest-wins queue and its prompt-admission barrier. Runtime supplies
-// target policy and transport application; callers only need to apply, cancel, or signal activity.
+// Owns generation-local model/effort policy, the latest-wins queue, transport application, and the
+// prompt-admission barrier; callers only apply, cancel, or signal activity.
 class AcpModelChangeWorkflow {
   private pending: AgentModelChangeTarget | undefined
   private barrierPromise: Promise<void> | undefined
@@ -25,9 +60,9 @@ class AcpModelChangeWorkflow {
   }
 
   async apply(target: AgentModelChangeTarget): Promise<boolean> {
-    if (!this.options.canApply(target)) return false
+    if (!this.canApply(target)) return false
 
-    if (!this.drainPromise && this.options.matchesCurrent(target)) {
+    if (!this.drainPromise && this.matchesCurrent(target)) {
       this.cancel()
       return true
     }
@@ -52,6 +87,43 @@ class AcpModelChangeWorkflow {
   async cancelAndDrain(): Promise<void> {
     this.cancel()
     await this.drainPromise
+  }
+
+  async applyReasoningEffort(effort: ResolvedReasoningEffort): Promise<boolean> {
+    const barrier = this.barrier
+    if (barrier) {
+      await barrier
+      return this.applyReasoningEffort(effort)
+    }
+
+    // The incoming effort belongs to the provider/model waiting behind reconnect, not the old
+    // generation that is still published while its in-flight turn drains.
+    if (this.options.providerReconnectPending()) return false
+
+    const backend = this.options.backendGeneration.updateReasoningEffort(effort)
+    this.options.connectionResources.setBridgeReasoningEffort(backend.session.effort)
+    const connection = this.options.connectionResources.connection
+    if (!connection) return backend.framework.supportsLiveEffortChange
+
+    const facts = await this.options.configurator.applyLiveEffort({
+      backend,
+      connection,
+      effort,
+      sessions: this.activeSessions().map(([appSessionId, session]) => ({
+        session,
+        configOptions:
+          (this.options.registry.lookup(appSessionId)?.aggregate.snapshot().configOptions as
+            readonly SessionConfigOption[] | undefined) ??
+          (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
+            .newSessionResponse?.configOptions,
+        assertCurrent: () => {
+          if (this.activeSession(appSessionId) !== session) {
+            throw new Error('ACP session startup was superseded.')
+          }
+        }
+      }))
+    })
+    return !facts.reconnectRequired
   }
 
   private armBarrier(): void {
@@ -91,7 +163,7 @@ class AcpModelChangeWorkflow {
       const target = this.pending
       this.pending = undefined
 
-      if (!this.options.canApply(target) || !(await this.options.applyTarget(target))) {
+      if (!this.canApply(target) || !(await this.applyTarget(target))) {
         this.pending = undefined
         try {
           await this.options.requestReconnect()
@@ -102,6 +174,182 @@ class AcpModelChangeWorkflow {
         return
       }
     }
+  }
+
+  private canApply(target: AgentModelChangeTarget): boolean {
+    const backend = this.options.backendGeneration.current
+    const resources = this.options.connectionResources
+    const backendCompatible =
+      backend.backendId === target.backendId ||
+      (backend.framework.id === 'claude-code' &&
+        target.route === 'claude-anthropic' &&
+        target.anthropicBridgeTargetId !== undefined &&
+        resources.anthropicBridgeAvailable) ||
+      (target.providerTransportTargetId !== undefined && resources.providerTransportAvailable)
+    return (
+      !resources.isShuttingDown &&
+      !this.options.providerReconnectPending() &&
+      this.options.currentStatus() === 'connected' &&
+      resources.connection !== undefined &&
+      this.activeSessions().length > 0 &&
+      backend.framework.id === target.frameworkId &&
+      backendCompatible &&
+      backend.modelRoute === target.route
+    )
+  }
+
+  private matchesCurrent(target: AgentModelChangeTarget): boolean {
+    const backend = this.options.backendGeneration.current
+    return (
+      backend.backendId === target.backendId &&
+      backend.context.model === target.model &&
+      backend.session.model === target.sessionModel &&
+      backend.context.supportsImageInput === target.supportsImageInput &&
+      (backend.session.effort ?? 'default') === target.reasoningEffort
+    )
+  }
+
+  private async applyTarget(target: AgentModelChangeTarget): Promise<boolean> {
+    const connection = this.options.connectionResources.connection
+    if (!connection) return false
+    const backend = this.options.backendGeneration.current
+    if (
+      backend.framework.id === 'codex' &&
+      target.route !== 'codex-bridge' &&
+      backend.backendId !== target.backendId &&
+      backend.session.model === target.sessionModel
+    ) {
+      return false
+    }
+    if (
+      backend.context.supportsImageInput &&
+      !target.supportsImageInput &&
+      (target.route === 'claude-anthropic' || target.route === 'codex-bridge')
+    ) {
+      return false
+    }
+
+    try {
+      if (
+        target.providerTransportTargetId &&
+        !this.options.connectionResources.setProviderTransportTarget(
+          target.providerTransportTargetId
+        )
+      ) {
+        return false
+      }
+      if (
+        target.anthropicBridgeTargetId &&
+        !this.options.connectionResources.setAnthropicBridgeTarget(target.anthropicBridgeTargetId)
+      ) {
+        return false
+      }
+      if (
+        target.bridge &&
+        !this.options.connectionResources.setBridgeModelTarget({
+          ...target.bridge,
+          ...(target.reasoningEffort === 'default'
+            ? { reasoningEffort: undefined }
+            : { reasoningEffort: target.reasoningEffort })
+        })
+      ) {
+        return false
+      }
+
+      const results = new Map<
+        string,
+        { appliedModel: string; configOptions: SessionConfigOption[] | null | undefined }
+      >()
+      for (const [appSessionId, session] of this.activeSessions()) {
+        const priorOptions =
+          (this.options.registry.lookup(appSessionId)?.aggregate.snapshot().configOptions as
+            readonly SessionConfigOption[] | undefined) ??
+          (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
+            .newSessionResponse?.configOptions
+        let configOptions: SessionConfigOption[] | null | undefined = priorOptions
+          ? structuredClone([...priorOptions])
+          : priorOptions
+        let appliedModel = target.sessionModel
+
+        if (target.route !== 'codex-bridge') {
+          const selection = matchSessionModelOption(configOptions, target.sessionModel)
+          if (!selection) return false
+          appliedModel = selection.value
+
+          if (!selection.alreadyCurrent) {
+            this.options.connectionResources.assertCurrentConnection(connection)
+            const response = (await connection.agent.request(
+              acp.methods.agent.session.setConfigOption,
+              {
+                sessionId: session.sessionId,
+                configId: selection.configId,
+                value: selection.value
+              }
+            )) as { configOptions?: SessionConfigOption[] | null }
+            configOptions = response?.configOptions ?? configOptions
+          }
+
+          const shouldApplyEffort =
+            backend.framework.supportsLiveEffortChange &&
+            (target.reasoningEffort !== 'default' || backend.session.effort !== undefined)
+          if (shouldApplyEffort) {
+            const effortSelection = resolveSessionEffortOption(
+              configOptions,
+              target.reasoningEffort
+            )
+            if (!effortSelection) return false
+            const response = (await connection.agent.request(
+              acp.methods.agent.session.setConfigOption,
+              {
+                sessionId: session.sessionId,
+                configId: effortSelection.configId,
+                value: effortSelection.value
+              }
+            )) as { configOptions?: SessionConfigOption[] | null }
+            configOptions = response?.configOptions ?? configOptions
+          }
+        }
+        results.set(appSessionId, { appliedModel, configOptions })
+      }
+
+      this.options.connectionResources.assertCurrentConnection(connection)
+      this.options.backendGeneration.updateModel(target)
+      for (const [appSessionId, result] of results) {
+        this.options.registry
+          .lookup(appSessionId)
+          ?.aggregate.updateModel(result.appliedModel, result.configOptions, target.backendId)
+      }
+      this.options.contextUsage.clear()
+      for (const appSessionId of results.keys()) {
+        if (this.activeSession(appSessionId)) {
+          this.options.contextUsage.beginSession(
+            appSessionId,
+            this.options.contextEstimateInput(appSessionId)
+          )
+        }
+      }
+      this.options.emitState()
+      log.info('session model change applied', this.options.diagnosticContext())
+      return true
+    } catch (error) {
+      log.warn('live session model change failed', {
+        ...diagnosticErrorFields(error),
+        ...this.options.diagnosticContext()
+      })
+      return false
+    }
+  }
+
+  private activeSession(appSessionId: string): ActiveSession | undefined {
+    return this.options.registry.lookup(appSessionId)?.attachment?.session
+  }
+
+  private activeSessions(): Array<readonly [string, ActiveSession]> {
+    return this.options.registry
+      .entries(true)
+      .flatMap(({ appSessionId, attachment }) =>
+        attachment ? [[appSessionId, attachment.session] as const] : []
+      )
   }
 }
 

--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -27,6 +27,7 @@ const backend: AcpBackendGenerationView = {
 }
 
 type HarnessOptions = {
+  attached?: boolean
   attachError?: Error
   backendAfterFirstConfigure?: AcpBackendGenerationView
   configureError?: Error
@@ -40,9 +41,11 @@ type HarnessOptions = {
 
 type ResumerHarness = {
   adopt: ReturnType<typeof vi.fn>
+  assertCurrentConnection: ReturnType<typeof vi.fn>
   attachSession: ReturnType<typeof vi.fn>
   commit: ReturnType<typeof vi.fn>
   configure: ReturnType<typeof vi.fn>
+  configurePermissionProfile: ReturnType<typeof vi.fn>
   connection: ClientConnection
   disconnectTimedOutConnection: ReturnType<typeof vi.fn>
   fireTimeout: () => void
@@ -53,6 +56,7 @@ type ResumerHarness = {
   release: ReturnType<typeof vi.fn>
   request: ReturnType<typeof vi.fn>
   resume: (request?: Partial<AcpResumeSessionRequest>) => Promise<AcpCreateSessionResponse>
+  setTimer: ReturnType<typeof vi.fn>
   successorSession: ActiveSession
 }
 
@@ -143,17 +147,44 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
       configOptions: undefined
     }
   })
+  const configurePermissionProfile = vi.fn(async () => {
+    order.push('configure permission')
+    return permissionProfile
+  })
+  if (options.attached) {
+    const attached = registry.reserve({
+      sessionIds: ['stable-app-session', providerSession.sessionId],
+      blockStartup: false
+    })
+    if (attached.collision) throw attached.collision
+    registry.publish(attached.reservation, 'stable-app-session', {
+      session: providerSession,
+      cwd: '/old-workspace',
+      projectName: 'old-project',
+      frameworkId: 'claude-code',
+      backendId: 'claude-code',
+      permissionProfile
+    })
+    attached.reservation.release()
+    order.length = 0
+  }
+  const setTimer = vi.fn((callback: () => void) => {
+    timerCallback = callback
+    return {} as ReturnType<typeof setTimeout>
+  })
+  const assertCurrentConnection = vi.fn()
   const resumer = new AcpProviderSessionResumer({
     defaultCwd: '/default',
     defaultProjectName: 'default-project',
     currentCwd: () => undefined,
+    currentConnection: () => connection,
     ensureConnected:
       options.ensureConnected ??
       vi.fn(async () => {
         order.push('connect')
         return connection
       }),
-    assertCurrentConnection: vi.fn(),
+    assertCurrentConnection,
     disconnectTimedOutConnection,
     resumeCapabilityAdvertised: () => options.supportsResume !== false,
     currentBackend: () => currentBackend,
@@ -183,7 +214,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
         }
       })
     },
-    configurator: { configure },
+    configurator: { configure, configurePermissionProfile },
     adopter: { adopt },
     updateCwd: () => order.push('cwd callback'),
     pushEvent: () => {
@@ -195,10 +226,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
       if (options.observerError) throw options.observerError
     },
     resumeTimeoutMs: 30_000,
-    setTimer: (callback) => {
-      timerCallback = callback
-      return {} as ReturnType<typeof setTimeout>
-    },
+    setTimer,
     clearTimer: () => undefined,
     diagnosticContext: () => ({})
   })
@@ -214,9 +242,11 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
 
   return {
     adopt,
+    assertCurrentConnection,
     attachSession,
     commit,
     configure,
+    configurePermissionProfile,
     connection,
     disconnectTimedOutConnection,
     fireTimeout: () => timerCallback?.(),
@@ -227,11 +257,131 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
     release,
     request,
     resume,
+    setTimer,
     successorSession
   }
 }
 
 describe('AcpProviderSessionResumer', () => {
+  it('refreshes an attached Session without entering provider startup', async () => {
+    const harness = createHarness({ attached: true })
+
+    const response = await harness.resume({
+      cwd: '/moved-workspace',
+      projectName: 'moved-project',
+      specialistId: 'specialist-1',
+      permissionProfile: 'full'
+    })
+
+    expect(response).toEqual({
+      sessionId: 'stable-app-session',
+      cwd: resolve('/moved-workspace'),
+      frameworkId: 'claude-code',
+      backendId: 'claude-code'
+    })
+    expect(harness.configurePermissionProfile).toHaveBeenCalledWith({
+      backend,
+      connection: harness.connection,
+      session: harness.providerSession,
+      permissionProfile: 'full'
+    })
+    expect(harness.registry.lookup('stable-app-session')?.aggregate.snapshot()).toMatchObject({
+      cwd: resolve('/moved-workspace'),
+      projectName: 'moved-project',
+      specialistId: 'specialist-1',
+      permissionProfile
+    })
+    expect(harness.registry.currentSessionId).toBe('stable-app-session')
+    expect(harness.order).toEqual(['configure permission', 'cwd callback', 'state callback'])
+    expect(harness.request).not.toHaveBeenCalled()
+    expect(harness.adopt).not.toHaveBeenCalled()
+    expect(harness.setTimer).not.toHaveBeenCalled()
+    expect(harness.assertCurrentConnection).toHaveBeenCalledWith(harness.connection)
+  })
+
+  it('does not update a successor attachment after permission configuration', async () => {
+    const harness = createHarness({ attached: true })
+    let markConfigureStarted!: () => void
+    let finishConfigure!: () => void
+    const configureStarted = new Promise<void>((resolve) => {
+      markConfigureStarted = resolve
+    })
+    const configureGate = new Promise<void>((resolve) => {
+      finishConfigure = resolve
+    })
+    harness.configurePermissionProfile.mockImplementationOnce(async () => {
+      markConfigureStarted()
+      await configureGate
+      return { ...permissionProfile, selectedProfile: 'full' as const }
+    })
+
+    const resumed = harness.resume({
+      cwd: '/stale-workspace',
+      projectName: 'stale-project',
+      specialistId: 'stale-specialist'
+    })
+    await configureStarted
+    const oldAttachment = harness.registry.lookup('stable-app-session')?.attachment
+    if (!oldAttachment) throw new Error('expected attached Session')
+    harness.registry.detach(oldAttachment, 'connection')
+    const successor = harness.registry.reserve({
+      sessionIds: ['stable-app-session', harness.successorSession.sessionId],
+      blockStartup: false
+    })
+    if (successor.collision) throw successor.collision
+    harness.registry.publish(successor.reservation, 'stable-app-session', {
+      session: harness.successorSession,
+      cwd: '/successor-workspace',
+      projectName: 'successor-project',
+      frameworkId: 'claude-code',
+      backendId: 'claude-code',
+      permissionProfile
+    })
+    successor.reservation.release()
+    harness.order.length = 0
+    finishConfigure()
+
+    await expect(resumed).rejects.toThrow('ACP session startup was superseded.')
+    expect(harness.configurePermissionProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ permissionProfile: 'ask' })
+    )
+    expect(harness.registry.lookup('stable-app-session')?.aggregate.snapshot()).toMatchObject({
+      cwd: '/successor-workspace',
+      projectName: 'successor-project',
+      specialistId: 'stale-specialist',
+      permissionProfile
+    })
+    expect(harness.registry.currentSessionId).toBe('stable-app-session')
+    expect(harness.assertCurrentConnection).not.toHaveBeenCalled()
+    expect(harness.order).toEqual([])
+  })
+
+  it('does not commit attached metadata when the connection is superseded', async () => {
+    const harness = createHarness({ attached: true })
+    const select = vi.spyOn(harness.registry, 'select')
+    harness.configurePermissionProfile.mockResolvedValueOnce({
+      ...permissionProfile,
+      selectedProfile: 'full',
+      effectiveProfile: 'full'
+    })
+    harness.assertCurrentConnection.mockImplementationOnce(() => {
+      throw new Error('ACP session startup was superseded.')
+    })
+
+    await expect(
+      harness.resume({ cwd: '/stale-workspace', projectName: 'stale-project' })
+    ).rejects.toThrow('ACP session startup was superseded.')
+
+    expect(harness.registry.lookup('stable-app-session')?.aggregate.snapshot()).toMatchObject({
+      cwd: '/old-workspace',
+      projectName: 'old-project',
+      permissionProfile
+    })
+    expect(select).not.toHaveBeenCalled()
+    expect(harness.order).not.toContain('cwd callback')
+    expect(harness.order).not.toContain('state callback')
+  })
+
   it('resumes and publishes a provider Session under its stable application id', async () => {
     const harness = createHarness()
 

--- a/src/main/acp/provider-session-resumer.ts
+++ b/src/main/acp/provider-session-resumer.ts
@@ -7,7 +7,10 @@ import type {
   AcpResumeSessionRequest,
   AcpRuntimeEvent
 } from '../../shared/acp'
-import { normalizePermissionProfile } from '../../shared/permission-profiles'
+import {
+  DEFAULT_PERMISSION_PROFILE,
+  normalizePermissionProfile
+} from '../../shared/permission-profiles'
 import type { EffectiveSpecialistSkills } from '../../shared/specialist'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
@@ -22,6 +25,7 @@ import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import type {
   AcpPrimarySessionIdentityReservation,
   AcpPrimarySessionIdentityReservationResult,
+  AcpSessionAttachment,
   AcpSessionRegistry
 } from './session-registry'
 import { AcpSessionResumePolicy } from './session-resume-policy'
@@ -45,6 +49,7 @@ type AcpProviderSessionResumerDependencies = Readonly<{
   defaultCwd: string
   defaultProjectName: string
   currentCwd: () => string | undefined
+  currentConnection: () => ClientConnection | undefined
   ensureConnected: (cwd: string) => Promise<ClientConnection>
   assertCurrentConnection: (connection: ClientConnection) => void
   disconnectTimedOutConnection: () => Promise<void>
@@ -53,7 +58,7 @@ type AcpProviderSessionResumerDependencies = Readonly<{
   registry: AcpSessionRegistry
   reserveIdentity: (sessionId: string) => AcpPrimarySessionIdentityReservationResult
   capabilities: Pick<AcpSessionCapabilityOwner, 'provision'>
-  configurator: Pick<AcpSessionConfigurator, 'configure'>
+  configurator: Pick<AcpSessionConfigurator, 'configure' | 'configurePermissionProfile'>
   adopter: Pick<AcpProviderSessionAdopter, 'adopt'>
   resolveSpecialistSkills?: (specialistId: string) => Promise<EffectiveSpecialistSkills>
   updateCwd: (cwd: string) => void
@@ -72,6 +77,9 @@ export class AcpProviderSessionResumer {
   constructor(private readonly deps: AcpProviderSessionResumerDependencies) {}
 
   async resume(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
+    const attached = this.deps.registry.lookup(request.sessionId)?.attachment
+    if (attached) return this.resumeAttached(request, attached)
+
     const cwd = resolve(request.cwd || this.deps.currentCwd() || this.deps.defaultCwd)
     const projectName = request.projectName?.trim() || this.deps.defaultProjectName
     const reserved = this.deps.reserveIdentity(request.sessionId)
@@ -82,6 +90,52 @@ export class AcpProviderSessionResumer {
       return await this.withTimeout(() => this.resumeReserved(request, cwd, projectName, identity))
     } finally {
       identity.release()
+    }
+  }
+
+  private async resumeAttached(
+    request: AcpResumeSessionRequest,
+    attachment: AcpSessionAttachment
+  ): Promise<AcpCreateSessionResponse> {
+    const entry = this.deps.registry.lookup(request.sessionId)
+    if (!entry) throw new Error(`ACP session is not registered: ${request.sessionId}`)
+    const connection = this.deps.currentConnection()
+    if (!connection) throw new Error('ACP connection is not available.')
+
+    const cwd = resolve(request.cwd || this.deps.currentCwd() || this.deps.defaultCwd)
+    const projectName = request.projectName?.trim() || this.deps.defaultProjectName
+    const backend = this.deps.currentBackend()
+    if (request.specialistId) entry.aggregate.setSpecialistId(request.specialistId)
+    const permissionProfile = await this.deps.configurator.configurePermissionProfile({
+      backend,
+      connection,
+      session: attachment.session,
+      permissionProfile: normalizePermissionProfile(
+        request.permissionProfile ??
+          entry.aggregate.snapshot().permissionProfile?.selectedProfile ??
+          DEFAULT_PERMISSION_PROFILE
+      )
+    })
+    const current = this.deps.registry.lookup(request.sessionId)
+    if (
+      current?.attachment?.generation !== attachment.generation ||
+      current.attachment.session !== attachment.session
+    ) {
+      throw new Error('ACP session startup was superseded.')
+    }
+    this.deps.assertCurrentConnection(connection)
+    current.aggregate.setPermissionProfile(structuredClone(permissionProfile))
+    this.deps.registry.select(request.sessionId)
+    this.deps.updateCwd(cwd)
+    current.aggregate.updateLocation(cwd, projectName)
+    this.deps.emitState()
+
+    const responseBackend = this.deps.currentBackend()
+    return {
+      sessionId: request.sessionId,
+      cwd,
+      frameworkId: responseBackend.framework.id,
+      ...(responseBackend.backendId ? { backendId: responseBackend.backendId } : {})
     }
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -5,7 +5,6 @@ import type {
   PromptResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
-  SessionConfigOption,
   SessionNotification
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
@@ -31,7 +30,6 @@ import type {
 import { ACP_PROMPT_FAILED_EVENT_TITLE } from '../../shared/acp'
 import {
   DEFAULT_PERMISSION_PROFILE,
-  normalizePermissionProfile,
   type SessionPermissionProfileState
 } from '../../shared/permission-profiles'
 import { type AgentFrameworkId } from '../../shared/settings'
@@ -49,7 +47,6 @@ import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-name
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
 import { extractProviderToolName } from './runtime-events'
 import { fetchOpenCodeUsageSnapshot } from './opencode-turn-usage'
-import { matchSessionModelOption, resolveSessionEffortOption } from './session-config'
 import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { ConversationPermissionGrantStore } from './permission-broker'
 import { isMcpToolName } from './permission-policy'
@@ -755,16 +752,23 @@ class AcpRuntime {
       hasContextUsage: () => this.contextUsageTracker.hasUsage()
     }
     this.modelChanges = new AcpModelChangeWorkflow({
-      canApply: (target) => this.canApplyModelChange(target),
-      matchesCurrent: (target) => this.modelChangeMatchesCurrent(target),
+      backendGeneration: this.backendGeneration,
+      connectionResources: this.connectionResources,
+      registry: this.sessionRegistry,
+      configurator: this.sessionConfigurator,
+      contextUsage: this.contextUsageTracker,
+      currentStatus: () => this.snapshotOwner.status,
+      providerReconnectPending: () => this.pendingProviderReconnect,
       isGenerationBusy: () => this.generationActivity.blockers().retirement,
-      applyTarget: (target) => this.applyModelTarget(target),
+      contextEstimateInput: (sessionId) => this.contextUsageEstimateInput(sessionId),
+      emitState: () => this.emitState(),
       // Model-change fallback already owns its drain. Calling the close workflow here would ask the
       // same drain to await itself, so arm the authoritative transition directly.
       requestReconnect: () => this.connectionTransitions.requestProviderReconnect(),
       recoverFailedReconnect: () => this.connectionClose.recoverFailedDeferredDisconnect(),
       reportReconnectFailure: (error) =>
-        safeLogError('model-change reconnect failed', errorLogFields(error))
+        safeLogError('model-change reconnect failed', errorLogFields(error)),
+      diagnosticContext: () => this.diagnosticContext()
     })
     this.connectionClose = new AcpConnectionCloseWorkflow({
       currentGeneration: () => this.connectionGeneration,
@@ -877,6 +881,7 @@ class AcpRuntime {
       defaultCwd: options.defaultCwd,
       defaultProjectName: options.artifacts?.projectName || DEFAULT_UPLOAD_PROJECT_NAME,
       currentCwd: () => this.snapshotOwner.cwd,
+      currentConnection: () => this.connection,
       ensureConnected: (cwd) => this.ensureConnected(cwd),
       assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
       disconnectTimedOutConnection: async () => {
@@ -906,10 +911,6 @@ class AcpRuntime {
 
   private get framework(): AgentFramework {
     return this.backend.framework
-  }
-
-  private get backendId(): string | undefined {
-    return this.backend.backendId
   }
 
   private get connection(): ClientConnection | undefined {
@@ -1322,166 +1323,6 @@ class AcpRuntime {
     return this.modelChanges.apply(target)
   }
 
-  private canApplyModelChange(target: AgentModelChangeTarget): boolean {
-    const backendCompatible =
-      this.backendId === target.backendId ||
-      (this.framework.id === 'claude-code' &&
-        target.route === 'claude-anthropic' &&
-        target.anthropicBridgeTargetId !== undefined &&
-        this.connectionResources.anthropicBridgeAvailable) ||
-      (target.providerTransportTargetId !== undefined &&
-        this.connectionResources.providerTransportAvailable)
-    return (
-      !this.connectionResources.isShuttingDown &&
-      !this.pendingProviderReconnect &&
-      this.snapshotOwner.status === 'connected' &&
-      this.connection !== undefined &&
-      this.activeSessionEntries().length > 0 &&
-      this.framework.id === target.frameworkId &&
-      backendCompatible &&
-      this.backend.modelRoute === target.route
-    )
-  }
-
-  private modelChangeMatchesCurrent(target: AgentModelChangeTarget): boolean {
-    return (
-      this.backendId === target.backendId &&
-      this.backend.context.model === target.model &&
-      this.backend.session.model === target.sessionModel &&
-      this.backend.context.supportsImageInput === target.supportsImageInput &&
-      (this.backend.session.effort ?? 'default') === target.reasoningEffort
-    )
-  }
-
-  private async applyModelTarget(target: AgentModelChangeTarget): Promise<boolean> {
-    const connection = this.connection
-    if (!connection) return false
-    if (
-      this.framework.id === 'codex' &&
-      target.route !== 'codex-bridge' &&
-      this.backendId !== target.backendId &&
-      this.backend.session.model === target.sessionModel
-    ) {
-      // Native Codex catalogs capability metadata by model slug. Two providers may reuse one slug
-      // for models with different image, context, or effort capabilities, which the live session
-      // cannot distinguish. Reconnect so the newly selected provider owns a fresh catalog entry.
-      return false
-    }
-    if (
-      this.backend.context.supportsImageInput &&
-      !target.supportsImageInput &&
-      (target.route === 'claude-anthropic' || target.route === 'codex-bridge')
-    ) {
-      // Claude retains opaque SDK history, while the Codex bridge keeps an image-capable transport
-      // model. Neither can prove that images from earlier turns will be removed for a text-only
-      // upstream model, so reuse the reconnect/resume path that already filters image history.
-      return false
-    }
-
-    try {
-      if (target.providerTransportTargetId) {
-        if (
-          !this.connectionResources.setProviderTransportTarget(target.providerTransportTargetId)
-        ) {
-          return false
-        }
-      }
-      if (target.anthropicBridgeTargetId) {
-        if (!this.connectionResources.setAnthropicBridgeTarget(target.anthropicBridgeTargetId)) {
-          return false
-        }
-      }
-      if (target.bridge) {
-        const bridgeUpdated = this.connectionResources.setBridgeModelTarget({
-          ...target.bridge,
-          ...(target.reasoningEffort === 'default'
-            ? { reasoningEffort: undefined }
-            : { reasoningEffort: target.reasoningEffort })
-        })
-        if (!bridgeUpdated) return false
-      }
-
-      const results = new Map<
-        string,
-        { appliedModel: string; configOptions: SessionConfigOption[] | null | undefined }
-      >()
-
-      for (const [appSessionId, session] of this.activeSessionEntries()) {
-        const priorOptions =
-          (this.sessionRegistry.lookup(appSessionId)?.aggregate.snapshot().configOptions as
-            readonly SessionConfigOption[] | undefined) ??
-          (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
-            .newSessionResponse?.configOptions
-        let configOptions: SessionConfigOption[] | null | undefined = priorOptions
-          ? structuredClone([...priorOptions])
-          : priorOptions
-        let appliedModel = target.sessionModel
-
-        // The Chat-to-Responses bridge keeps the ACP transport model fixed; only its upstream target
-        // changes. Other routes switch the session's advertised model option in place.
-        if (target.route !== 'codex-bridge') {
-          const selection = matchSessionModelOption(configOptions, target.sessionModel)
-          if (!selection) return false
-          appliedModel = selection.value
-
-          if (!selection.alreadyCurrent) {
-            this.assertCurrentConnectedConnection(connection)
-            const response = (await connection.agent.request(
-              acp.methods.agent.session.setConfigOption,
-              {
-                sessionId: session.sessionId,
-                configId: selection.configId,
-                value: selection.value
-              }
-            )) as { configOptions?: SessionConfigOption[] | null }
-            configOptions = response?.configOptions ?? configOptions
-          }
-
-          const shouldApplyEffort =
-            this.framework.supportsLiveEffortChange &&
-            (target.reasoningEffort !== 'default' || this.backend.session.effort !== undefined)
-          if (shouldApplyEffort) {
-            const effortSelection = resolveSessionEffortOption(
-              configOptions,
-              target.reasoningEffort
-            )
-            if (!effortSelection) return false
-            const response = (await connection.agent.request(
-              acp.methods.agent.session.setConfigOption,
-              {
-                sessionId: session.sessionId,
-                configId: effortSelection.configId,
-                value: effortSelection.value
-              }
-            )) as { configOptions?: SessionConfigOption[] | null }
-            configOptions = response?.configOptions ?? configOptions
-          }
-        }
-
-        results.set(appSessionId, { appliedModel, configOptions })
-      }
-
-      this.assertCurrentConnectedConnection(connection)
-      this.backendGeneration.updateModel(target)
-      for (const [appSessionId, result] of results) {
-        this.sessionRegistry
-          .lookup(appSessionId)
-          ?.aggregate.updateModel(result.appliedModel, result.configOptions, target.backendId)
-      }
-      this.contextUsageTracker.clear()
-      for (const appSessionId of results.keys()) this.ensureContextUsageTracking(appSessionId)
-      this.emitState()
-      log.info('session model change applied', this.diagnosticContext())
-      return true
-    } catch (error) {
-      log.warn('live session model change failed', {
-        ...diagnosticErrorFields(error),
-        ...this.diagnosticContext()
-      })
-      return false
-    }
-  }
-
   // Live-applies a reasoning-effort change to every open session — the ACP equivalent of a model
   // switch, no respawn. Returns false when the active framework only carries effort in its baked
   // spawn config (opencode advertises no thought_level option), or when applying to a session
@@ -1492,41 +1333,7 @@ class AcpRuntime {
   // either). On success the generation view tracks the new level, so sessions created later in
   // this process inherit it; the persisted setting covers the next respawn.
   async applyReasoningEffortChange(effort: ResolvedReasoningEffort): Promise<boolean> {
-    const modelChangeBarrier = this.modelChanges.barrier
-    if (modelChangeBarrier) {
-      await modelChangeBarrier
-      return this.applyReasoningEffortChange(effort)
-    }
-
-    // A provider/model switch may be waiting for an in-flight turn to finish. The incoming effort was
-    // resolved against that newly selected model, while this connection still owns the old one. Let
-    // the persisted setting reach the fresh backend after reconnect instead of leaking it here.
-    if (this.pendingProviderReconnect) return false
-
-    const backend = this.backendGeneration.updateReasoningEffort(effort)
-    this.connectionResources.setBridgeReasoningEffort(backend.session.effort)
-    const connection = this.connection
-    if (!connection) return backend.framework.supportsLiveEffortChange
-
-    const facts = await this.sessionConfigurator.applyLiveEffort({
-      backend,
-      connection,
-      effort,
-      sessions: this.activeSessionEntries().map(([appSessionId, session]) => ({
-        session,
-        configOptions:
-          (this.sessionRegistry.lookup(appSessionId)?.aggregate.snapshot().configOptions as
-            readonly SessionConfigOption[] | undefined) ??
-          (session as { newSessionResponse?: { configOptions?: SessionConfigOption[] | null } })
-            .newSessionResponse?.configOptions,
-        assertCurrent: () => {
-          if (this.activeSessionFor(appSessionId) !== session) {
-            throw new Error('ACP session startup was superseded.')
-          }
-        }
-      }))
-    })
-    return !facts.reconnectRequired
+    return this.modelChanges.applyReasoningEffort(effort)
   }
 
   // Starts a fresh agent process connection and initializes protocol capabilities.
@@ -1541,55 +1348,7 @@ class AcpRuntime {
 
   // Reattaches a persisted protocol session after an app restart so later prompts can stream.
   async resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
-    return this.withOperationLease(() => this.resumeSessionOperation(request))
-  }
-
-  private async resumeSessionOperation(
-    request: AcpResumeSessionRequest
-  ): Promise<AcpCreateSessionResponse> {
-    const sessionCwd = resolve(request.cwd || this.snapshotOwner.cwd || this.options.defaultCwd)
-    const projectName = this.normalizeProjectName(request.projectName)
-
-    // If the runtime already attached this session, only refresh routing metadata.
-    const attachedSession = this.activeSessionFor(request.sessionId)
-
-    if (attachedSession) {
-      const aggregate = this.sessionRegistry.lookup(request.sessionId)?.aggregate
-      if (!aggregate) throw new Error(`ACP session is not registered: ${request.sessionId}`)
-      if (request.specialistId) {
-        aggregate.setSpecialistId(request.specialistId)
-      }
-      const connection = this.connection
-      if (!connection) throw new Error('ACP connection is not available.')
-      const permissionProfile = await this.sessionConfigurator.configurePermissionProfile({
-        backend: this.backend,
-        connection,
-        session: attachedSession,
-        permissionProfile: normalizePermissionProfile(
-          request.permissionProfile ??
-            aggregate.snapshot().permissionProfile?.selectedProfile ??
-            DEFAULT_PERMISSION_PROFILE
-        )
-      })
-      if (this.activeSessionFor(request.sessionId) !== attachedSession) {
-        throw new Error('ACP session startup was superseded.')
-      }
-      this.assertCurrentConnectedConnection(connection)
-      aggregate.setPermissionProfile(structuredClone(permissionProfile))
-      this.sessionRegistry.select(request.sessionId)
-      this.snapshotOwner.updateCwd(sessionCwd)
-      aggregate.updateLocation(sessionCwd, projectName)
-      this.emitState()
-
-      return {
-        sessionId: request.sessionId,
-        cwd: sessionCwd,
-        frameworkId: this.framework.id,
-        ...(this.backendId ? { backendId: this.backendId } : {})
-      }
-    }
-
-    return this.providerSessionResumer.resume(request)
+    return this.withOperationLease(() => this.providerSessionResumer.resume(request))
   }
 
   // Forcibly drops the agent-side context for a session whose accumulated history can no longer be sent
@@ -2220,15 +1979,6 @@ class AcpRuntime {
     return (
       this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().projectName ??
       this.artifactOptions?.projectName ??
-      DEFAULT_UPLOAD_PROJECT_NAME
-    )
-  }
-
-  // Normalizes a requested project name, falling back to the runtime default when absent.
-  private normalizeProjectName(requestedProjectName: string | undefined): string {
-    return (
-      requestedProjectName?.trim() ||
-      this.artifactOptions?.projectName ||
       DEFAULT_UPLOAD_PROJECT_NAME
     )
   }

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -341,6 +341,18 @@ describe('runtime state ownership architecture', () => {
     expect(source).toContain('interactions: this.planInteractions')
   })
 
+  it('keeps model application and attached resume behavior behind their workflows', () => {
+    const source = readSource('src/main/acp/runtime.ts')
+
+    expect(source).not.toContain('canApplyModelChange')
+    expect(source).not.toContain('modelChangeMatchesCurrent')
+    expect(source).not.toContain('applyModelTarget')
+    expect(source).not.toContain('resumeSessionOperation')
+    expect(source).toContain('return this.modelChanges.applyReasoningEffort(effort)')
+    expect(source).toContain('this.providerSessionResumer.resume(request)')
+    expect(source).toContain('currentConnection: () => this.connection')
+  })
+
   it('accepts declared interface imports for a future orchestration module', () => {
     const source = `
       import type { AcpApplicationCommandDependencies } from '../acp/application-commands'


### PR DESCRIPTION
## Problem

`AcpRuntime` still interpreted and applied live model/provider targets, sequenced effort changes, and refreshed already-attached Session metadata itself. The existing `AcpModelChangeWorkflow` and `AcpProviderSessionResumer` therefore exposed workflow-shaped interfaces while Runtime retained the underlying ownership and race handling.

## Proposed change

- deepen `AcpModelChangeWorkflow` so it owns target compatibility, current-target matching, transport retargeting, multi-Session configuration, owner-fact commits, context-usage rebuilds, reconnect fallback, and effort ordering;
- delegate Runtime's model and effort public methods to that workflow;
- move the already-attached resume fast path into `AcpProviderSessionResumer`, before identity reservation, timeout, connection setup, provider resume, adoption, and capability provisioning;
- guard attached metadata commits by both attachment generation/session identity and current connection;
- add module, Runtime-consumer, race, and architecture tests that keep those responsibilities out of Runtime.

```mermaid
flowchart LR
  Commands["Settings / runtime commands"] --> Runtime["AcpRuntime public facade"]
  Runtime --> Model["AcpModelChangeWorkflow"]
  Model --> Backend["Backend generation owner"]
  Model --> Resources["Connection resource owner"]
  Model --> Registry["Session registry"]
  Model --> Config["Session configurator"]
  Model --> Context["Context usage owner"]
  Runtime --> Resumer["AcpProviderSessionResumer"]
  Resumer --> Guard["attachment + connection current guards"]
  Guard --> Registry
  Guard --> Config
```

## Scope and non-goals

- Serial predecessor: #792.
- Production raw: **600/600**; total diff is test-heavy because workflow contracts and races are characterized directly.
- `src/main/acp/runtime.ts` is **2,567 lines**, down from 2,817 after #792.
- No shared contract, IPC, preload, Web RPC, CLI, Task, SDK, wire envelope, renderer/UI, persistence, data-model, Artifact relationship, or Issue #458 orchestration change.
- Existing Electron/Web/CLI/Task capability asymmetry remains unchanged.
- Specialist and Permission behavior remains unchanged: Specialist metadata is still written before permission configuration; Permission facts commit only after current attachment and connection checks.
- Detached resume/adoption, stable application IDs, provider IDs, transcript replay, `contextReset`, image-downgrade safety, and reconnect behavior remain unchanged.

## Acceptance criteria and validation

All listed checks cover the final material state.

| Behavior / risk | Final command | Result |
| --- | --- | --- |
| Model workflow, attached/detached resumer, configurator, coordinator, adopter, handoff continuity, and architecture seams | `npm test -- src/main/acp/model-change-workflow.test.ts src/main/acp/provider-session-resumer.test.ts src/main/acp/session-configurator.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/provider-session-adopter.test.ts src/main/acp/handoff-continuity-owner.test.ts src/main/runtime-state-ownership.architecture.test.ts` | 7 files, 129 tests passed |
| Claude/Codex/OpenCode model routes, image downgrade, partial apply/reconnect, model/effort barriers, and attached metadata ordering | `npm test -- src/main/acp/runtime.test.ts -t 'ACP runtime — model hot switch|ACP runtime — session effort|keeps active ordering stable when resume only refreshes metadata'` | 36 passed, 404 skipped |
| Affected Node process types | `npm run typecheck:node` | passed |
| Cross-surface type compatibility | `npm run typecheck:web` | passed in independent Test Impact review |
| Repository lint | `npm run lint` | 0 errors; 17 pre-existing warnings outside this diff |
| Changed source and tests | focused `eslint --no-cache` over all 6 changed files | no issues |
| Patch hygiene | `git diff --check` | passed |

The impact set includes every changed owner/interface and the Runtime, coordinator, adoption, resume, effort, handoff, and architecture consumers. No renderer, IPC, platform adapter, persistence, build, or configuration interface changed, so local platform E2E was excluded; PR Gate remains authoritative for repository-selected and platform checks.

Independent Standards and Spec/Test Impact reviews completed on the final diff with **0 P0–P3 findings**.

## Review focus

- latest-wins model selection and prompt/startup admission barriers;
- transport retarget and all-Session configuration before backend, aggregate, context, and state commits;
- native Codex same-slug provider reconnect and Claude/Codex bridge image-downgrade reconnect;
- effort changes waiting behind queued model changes and refusing the old generation during reconnect;
- attached resume skipping provider startup while preserving stable IDs, Specialist/Permission timing, metadata ordering, and successor safety;
- the exact **600 production raw** boundary: any production amendment must be offset by an equal deletion.
