### PR TITLE
refactor(acp): delegate permission and reviewer routing

### DIFF
--- a/src/main/acp/permission-context.test.ts
+++ b/src/main/acp/permission-context.test.ts
@@ -5,13 +5,35 @@ import type {
 } from '@agentclientprotocol/sdk'
 import { describe, expect, it, vi } from 'vitest'
 
+import { opencodeFramework } from '../agent-framework'
 import {
   AcpPermissionContext,
   AGENT_PERMISSION_ACTION_ORIGIN,
   HUMAN_PERMISSION_ACTION_ORIGIN
 } from './permission-context'
+import type { AcpPermissionContextOptions } from './permission-context'
 
 const NOTEBOOK_SERVERS = ['open-science-notebook']
+
+const permissionRouting = (
+  overrides: Partial<NonNullable<AcpPermissionContextOptions['routing']>> = {}
+): NonNullable<AcpPermissionContextOptions['routing']> => ({
+  resolveAppSessionId: (sessionId) => sessionId,
+  sessionSnapshot: () => ({
+    cwd: '/workspace',
+    frameworkId: 'opencode',
+    permissionProfile: { selectedProfile: 'ask' }
+  }),
+  hasActivePrimarySession: () => true,
+  capturePrompt: () => undefined,
+  currentInteractionSequence: () => undefined,
+  mcpServerNamesFor: () => NOTEBOOK_SERVERS,
+  reviewerContextFor: () => undefined,
+  resolveReviewerPermission: () => undefined,
+  currentFramework: () => opencodeFramework,
+  resolveProjectId: () => 'default-project',
+  ...overrides
+})
 
 const permissionRequest = (
   sessionId: string,
@@ -46,8 +68,88 @@ const observe = (
 }
 
 describe('ACP permission context', () => {
+  it('cancels a late OpenCode primary request when no prompt owns the active Session', async () => {
+    const emitPermissionRequest = vi.fn()
+    const resolveReviewerPermission = vi.fn()
+    const context = new AcpPermissionContext({
+      emitPermissionRequest,
+      routing: permissionRouting({ resolveReviewerPermission })
+    })
+
+    await expect(
+      context.handleProviderRequest(
+        permissionRequest('primary-session', 'late-call', { title: 'Bash', kind: 'execute' })
+      )
+    ).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+    expect(resolveReviewerPermission).not.toHaveBeenCalled()
+    expect(emitPermissionRequest).not.toHaveBeenCalled()
+  })
+
+  it('routes an isolated OpenCode reviewer request without a primary attachment', async () => {
+    const reviewerResponse = {
+      outcome: { outcome: 'selected' as const, optionId: 'reject-once' }
+    }
+    const resolveReviewerPermission = vi.fn(() => reviewerResponse)
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: vi.fn(),
+      routing: permissionRouting({
+        hasActivePrimarySession: () => false,
+        reviewerContextFor: () => ({
+          frameworkId: 'opencode',
+          mcpServerNames: ['open-science-reviewer']
+        }),
+        resolveReviewerPermission
+      })
+    })
+    const request = permissionRequest('reviewer-session', 'reviewer-call', {
+      title: 'Bash',
+      kind: 'execute'
+    })
+
+    await expect(context.handleProviderRequest(request)).resolves.toEqual(reviewerResponse)
+    expect(resolveReviewerPermission).toHaveBeenCalledWith(request)
+  })
+
+  it('correlates provider updates under the stable adopted Session identity', () => {
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: vi.fn(),
+      routing: permissionRouting({
+        resolveAppSessionId: () => 'stable-session',
+        sessionSnapshot: () => ({
+          frameworkId: 'codex',
+          permissionProfile: { selectedProfile: 'ask' }
+        })
+      })
+    })
+
+    context.observeProviderUpdate({
+      sessionId: 'provider-session',
+      update: {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'call-1',
+        title: 'mcp.open-science-notebook.notebook_execute',
+        kind: 'execute',
+        status: 'pending',
+        rawInput: {
+          server: 'open-science-notebook',
+          tool: 'notebook_execute',
+          arguments: { language: 'python', code: 'print(1)' }
+        },
+        _meta: { is_mcp_tool_call: true }
+      }
+    })
+
+    expect(context.snapshot().sessions).toMatchObject({
+      'stable-session': { codexMcpIdentities: 1 }
+    })
+    expect(context.snapshot().sessions).not.toHaveProperty('provider-session')
+  })
+
   it('correlates sparse Codex approvals and bounds retained provider aliases', async () => {
-    const context = new AcpPermissionContext({ emitPermissionRequest: vi.fn() })
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: vi.fn(),
+      routing: permissionRouting()
+    })
 
     for (let index = 0; index < 40; index += 1) {
       observe(
@@ -111,7 +213,10 @@ describe('ACP permission context', () => {
   })
 
   it('rendezvouses an OpenCode request with a bounded late preview and removes its waiter', async () => {
-    const context = new AcpPermissionContext({ emitPermissionRequest: vi.fn() })
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: vi.fn(),
+      routing: permissionRouting()
+    })
     const code = 'x <- 1\n'.repeat(2_000)
 
     observe(
@@ -165,7 +270,8 @@ describe('ACP permission context', () => {
   it('keeps a human-only decision parked when an agent-origin action tries to resolve it', async () => {
     const emitted: Array<{ requestId: string }> = []
     const context = new AcpPermissionContext({
-      emitPermissionRequest: (request) => emitted.push(request)
+      emitPermissionRequest: (request) => emitted.push(request),
+      routing: permissionRouting()
     })
     const pending = context.requestPermission(permissionRequest('session-1', 'call-1'))
 
@@ -201,6 +307,7 @@ describe('ACP permission context', () => {
       const onOpenCodeWaitTimeout = vi.fn()
       const context = new AcpPermissionContext({
         emitPermissionRequest: vi.fn(),
+        routing: permissionRouting(),
         onOpenCodeWaitTimeout
       })
       observe(
@@ -244,7 +351,8 @@ describe('ACP permission context', () => {
   it('cancels pending correlation waiters and decisions on session cleanup', async () => {
     const emitted: Array<{ requestId: string }> = []
     const context = new AcpPermissionContext({
-      emitPermissionRequest: (request) => emitted.push(request)
+      emitPermissionRequest: (request) => emitted.push(request),
+      routing: permissionRouting()
     })
 
     observe(
@@ -279,7 +387,10 @@ describe('ACP permission context', () => {
   })
 
   it('disposes every session without retaining preview or waiter metadata', async () => {
-    const context = new AcpPermissionContext({ emitPermissionRequest: vi.fn() })
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: vi.fn(),
+      routing: permissionRouting()
+    })
     observe(
       context,
       {

--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -9,8 +9,13 @@ import type {
   AcpPermissionRequest,
   AcpPermissionResponse
 } from '../../shared/acp'
+import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
+import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
+import type { AgentFrameworkId } from '../../shared/settings'
+import { getAgentFramework, type AgentFramework } from '../agent-framework'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
+import { createLogger } from '../logger'
 import {
   AcpPermissionBroker,
   ConversationPermissionGrantStore,
@@ -23,6 +28,8 @@ import {
   withTrustedNativeToolIdentity
 } from './permission-policy'
 import { extractProviderToolName, toAcpRuntimeEvent } from './runtime-events'
+
+const log = createLogger('acp')
 
 type PermissionFramework = 'codex' | 'opencode' | 'claude-code' | string | undefined
 
@@ -66,6 +73,38 @@ type AuthorizedPermissionActionOrigin = Readonly<{
 
 type AcpPermissionContextOptions = {
   emitPermissionRequest: (request: AcpPermissionRequest) => void
+  routing: {
+    resolveAppSessionId: (providerSessionId: string) => string
+    sessionSnapshot: (sessionId: string) =>
+      | {
+          cwd?: string
+          frameworkId?: AgentFrameworkId
+          permissionProfile?: Readonly<
+            Pick<SessionPermissionProfileState, 'selectedProfile' | 'autoReviewStrategy'>
+          >
+        }
+      | undefined
+    hasActivePrimarySession: (sessionId: string) => boolean
+    capturePrompt: (sessionId: string) =>
+      | {
+          sequence: number
+          isCancellationAccepted: () => boolean
+        }
+      | undefined
+    currentInteractionSequence: (sessionId: string) => number | undefined
+    mcpServerNamesFor: (sessionId: string) => readonly string[]
+    reviewerContextFor: (providerSessionId: string) =>
+      | {
+          frameworkId: AgentFrameworkId
+          mcpServerNames: readonly string[]
+        }
+      | undefined
+    resolveReviewerPermission: (
+      request: RequestPermissionRequest
+    ) => RequestPermissionResponse | undefined
+    currentFramework: () => AgentFramework
+    resolveProjectId: (sessionId: string) => string
+  }
   conversationGrants?: ConversationPermissionGrantStore
   permissionGrantRegistry?: PermissionGrantRegistry
   setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
@@ -105,6 +144,15 @@ const MAX_CLAUDE_CODE_MCP_TOOL_INPUTS_PER_SESSION = 32
 const MAX_OPENCODE_MCP_TOOL_INPUTS_PER_SESSION = 32
 const MAX_PERMISSION_CODE_PREVIEW_CHARS = 7_500
 const OPENCODE_PERMISSION_CONTEXT_WAIT_MS = 1_000
+
+const errorMessage = (error: unknown): string => {
+  try {
+    const raw = error instanceof Error ? (error as { message?: unknown }).message : error
+    return typeof raw === 'string' ? raw : String(raw)
+  } catch {
+    return 'unknown error'
+  }
+}
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -198,8 +246,8 @@ const codexMcpToolIdentity = (
 const countNested = <T>(contexts: Map<string, Map<string, T>>, sessionId: string): number =>
   contexts.get(sessionId)?.size ?? 0
 
-// Owns permission-specific provider correlation and pending decisions. It receives already-classified
-// framework/session context from the runtime and never infers human authority from protocol messages.
+// Owns provider permission routing, correlation, and pending decisions. Protocol messages never infer
+// human authority; only the explicit response origin can release a human-owned decision.
 class AcpPermissionContext {
   private readonly broker: AcpPermissionBroker
   private readonly humanOnlyRequestIds = new Set<string>()
@@ -219,13 +267,123 @@ class AcpPermissionContext {
     this.broker = new AcpPermissionBroker(
       (request) => {
         this.humanOnlyRequestIds.add(request.requestId)
-        options.emitPermissionRequest(request)
+        const sessionId = options.routing.resolveAppSessionId(request.sessionId)
+        options.emitPermissionRequest(
+          sessionId && sessionId !== request.sessionId ? { ...request, sessionId } : request
+        )
       },
       options.conversationGrants,
       options.permissionGrantRegistry
     )
     this.setTimer = options.setTimer ?? setTimeout
     this.clearTimer = options.clearTimer ?? clearTimeout
+  }
+
+  async handleProviderRequest(
+    params: RequestPermissionRequest
+  ): Promise<RequestPermissionResponse> {
+    const routing = this.options.routing
+
+    const appSessionId = routing.resolveAppSessionId(params.sessionId)
+    const reviewerContext = routing.reviewerContextFor(params.sessionId)
+    const mcpServerNames =
+      reviewerContext?.mcpServerNames ?? routing.mcpServerNamesFor(appSessionId)
+    const promptInteraction = routing.capturePrompt(appSessionId)
+    const promptTurn = promptInteraction?.sequence
+    const aggregateSnapshot = routing.sessionSnapshot(appSessionId)
+    const framework = reviewerContext?.frameworkId ?? aggregateSnapshot?.frameworkId
+    const isCancelled = (): boolean =>
+      framework === 'opencode' &&
+      (promptTurn === undefined
+        ? routing.hasActivePrimarySession(appSessionId)
+        : routing.currentInteractionSequence(appSessionId) !== promptTurn ||
+          promptInteraction?.isCancellationAccepted() === true)
+    const restoreContext = {
+      sessionId: appSessionId,
+      framework,
+      mcpServerNames,
+      isCancelled
+    }
+    const normalizedParams = await this.restoreToolCall(params, restoreContext)
+    if (
+      !normalizedParams ||
+      this.isPermissionRequestCancelled(params.toolCall.toolCallId, restoreContext)
+    ) {
+      return { outcome: { outcome: 'cancelled' } }
+    }
+
+    // Keep the audit record useful without logging titles, URLs, raw input, or provider payloads.
+    const toolName = extractProviderToolName(normalizedParams.toolCall)
+    const isMcp =
+      isMcpToolName(normalizedParams.toolCall.title, mcpServerNames) ||
+      isMcpToolName(toolName, mcpServerNames)
+    log.info('permission request received', {
+      tool:
+        this.toolIdentityForDiagnostics(toolName, appSessionId) ?? normalizedParams.toolCall.kind,
+      isMcp,
+      toolCallId: normalizedParams.toolCall.toolCallId,
+      sessionId: params.sessionId,
+      optionCount: params.options.length
+    })
+
+    try {
+      if (reviewerContext) {
+        const response = routing.resolveReviewerPermission(normalizedParams)
+        if (response) return response
+        throw new Error(`Unknown ACP reviewer session: ${params.sessionId}`)
+      }
+
+      if (!routing.hasActivePrimarySession(appSessionId)) {
+        throw new Error(`Unknown ACP session: ${appSessionId}`)
+      }
+
+      const profileState = aggregateSnapshot?.permissionProfile
+      const currentFramework = routing.currentFramework()
+      const frameworkId = aggregateSnapshot?.frameworkId ?? currentFramework.id
+      const permissionFramework =
+        frameworkId === currentFramework.id ? currentFramework : getAgentFramework(frameworkId)
+
+      return await this.requestPermission(
+        appSessionId === normalizedParams.sessionId
+          ? normalizedParams
+          : { ...normalizedParams, sessionId: appSessionId },
+        {
+          profile: profileState?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE,
+          frameworkId,
+          shellDialect: permissionFramework.commandShellDialect,
+          autoReviewStrategy: profileState?.autoReviewStrategy,
+          cwd: aggregateSnapshot?.cwd,
+          mcpServerNames,
+          projectId: routing.resolveProjectId(appSessionId)
+        }
+      )
+    } catch (error) {
+      log.error('permission request failed', {
+        message: errorMessage(error),
+        tool:
+          this.toolIdentityForDiagnostics(
+            extractProviderToolName(normalizedParams.toolCall),
+            appSessionId
+          ) ?? normalizedParams.toolCall.kind,
+        toolCallId: params.toolCall.toolCallId,
+        sessionId: params.sessionId
+      })
+      throw error
+    }
+  }
+
+  observeProviderUpdate(notification: SessionNotification): void {
+    const routing = this.options.routing
+
+    const sessionId = routing.resolveAppSessionId(notification.sessionId)
+    const reviewerContext = routing.reviewerContextFor(notification.sessionId)
+    const routed = structuredClone(notification)
+    routed.sessionId = sessionId
+    this.observeToolCall(routed, {
+      sessionId,
+      framework: reviewerContext?.frameworkId ?? routing.sessionSnapshot(sessionId)?.frameworkId,
+      mcpServerNames: reviewerContext?.mcpServerNames ?? routing.mcpServerNamesFor(sessionId)
+    })
   }
 
   getPendingRequests(): AcpPermissionRequest[] {
@@ -753,6 +911,15 @@ class AcpPermissionContext {
       if (calls?.size === 0) sessions.delete(sessionId)
     }
     this.resolveOpenCodeWaiters(sessionId, toolCallId, 'cancelled')
+  }
+
+  private toolIdentityForDiagnostics(
+    providerToolName: string | undefined,
+    sessionId: string
+  ): string | undefined {
+    if (!providerToolName) return undefined
+    const mcpServerNames = this.options.routing.mcpServerNamesFor(sessionId)
+    return resolveCanonicalMcpToolIdentity(providerToolName, mcpServerNames) ?? providerToolName
   }
 }
 

--- a/src/main/acp/reviewer-session-owner.ts
+++ b/src/main/acp/reviewer-session-owner.ts
@@ -114,17 +114,16 @@ type ActiveReviewerSessionOwner = ReviewerSessionContext & {
   token: symbol
 }
 
-type ReviewerSessionCreationContext = {
-  connection: ClientConnection
-  framework: AgentFramework
-  sessionOptions: Record<string, unknown> | undefined
-  startupGeneration: number
-}
-
 export type ReviewerSessionOwnerDependencies = {
   addStartupBlocker: (token: symbol) => void
+  assertCurrentConnection: (connection: ClientConnection) => void
   clearPermissionCorrelations: (sessionId: string) => void
+  currentSessionSetup: () => {
+    framework: AgentFramework
+    sessionOptions: Record<string, unknown> | undefined
+  }
   currentStartupGeneration: () => number
+  ensureConnected: (cwd: string) => Promise<ClientConnection>
   isPrimarySessionIdClaimed: (sessionId: string) => boolean
   onActiveSessionReleased: () => void
   registerBridgeSession: (sessionId: string) => void
@@ -132,8 +131,8 @@ export type ReviewerSessionOwnerDependencies = {
   unregisterBridgeSession: (sessionId: string) => boolean | undefined
 }
 
-// Owns every ephemeral Reviewer identity and resource. Primary session state remains in AcpRuntime;
-// the two owners collaborate only through the narrow collision and startup-blocker ports above.
+// Owns every ephemeral Reviewer startup, identity, and resource. Runtime supplies only current
+// connection/setup facts plus narrow collision, bridge, cleanup, and startup-blocker ports.
 export class ReviewerSessionOwner {
   private readonly activeById = new Map<string, ActiveReviewerSessionOwner>()
   private readonly activeBySession = new WeakMap<ActiveSession, ActiveReviewerSessionOwner>()
@@ -142,12 +141,12 @@ export class ReviewerSessionOwner {
 
   constructor(private readonly dependencies: ReviewerSessionOwnerDependencies) {}
 
-  async create(
-    request: ReviewerSessionRequest,
-    prepare: () => Promise<ReviewerSessionCreationContext>
-  ): Promise<ReviewerSessionResult> {
+  async create(request: ReviewerSessionRequest): Promise<ReviewerSessionResult> {
     const mcpServerNames = this.validateRequest(request)
-    const { connection, framework, sessionOptions, startupGeneration } = await prepare()
+    const connection = await this.dependencies.ensureConnected(request.cwd)
+    this.dependencies.assertCurrentConnection(connection)
+    const { framework, sessionOptions } = this.dependencies.currentSessionSetup()
+    const startupGeneration = this.dependencies.currentStartupGeneration()
     const reviewerCwd = await mkdtemp(join(tmpdir(), 'open-science-reviewer-'))
     const setup = framework.buildSessionSetup({
       systemPromptAppends: request.systemPromptAppend ? [request.systemPromptAppend] : [],

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -906,12 +906,7 @@ const waitForOpenCodeMcpToolInput = (
 const observePermissionToolContext = (
   runtime: AcpRuntime,
   notification: SessionNotification
-): void =>
-  (
-    runtime as unknown as {
-      observePermissionToolContext: (value: SessionNotification) => void
-    }
-  ).observePermissionToolContext(notification)
+): void => permissionContext(runtime).observeProviderUpdate(notification)
 
 // Finds the isMcp flag the runtime logged for a given permission request (identified by toolCallId).
 const auditedIsMcp = (toolCallId: string): boolean | undefined => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -3,8 +3,6 @@ import type {
   ActiveSession,
   ClientConnection,
   PromptResponse,
-  RequestPermissionRequest,
-  RequestPermissionResponse,
   SessionNotification
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
@@ -28,28 +26,21 @@ import type {
   AcpStateSnapshot
 } from '../../shared/acp'
 import { ACP_PROMPT_FAILED_EVENT_TITLE } from '../../shared/acp'
-import {
-  DEFAULT_PERMISSION_PROFILE,
-  type SessionPermissionProfileState
-} from '../../shared/permission-profiles'
+import { type SessionPermissionProfileState } from '../../shared/permission-profiles'
 import { type AgentFrameworkId } from '../../shared/settings'
 import type { EffectiveSpecialistSkills } from '../../shared/specialist'
 import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import type { ApprovedSwitchReadBack, ClaudeCodeReplayInput } from '../agents/claude-code-handoff'
 import {
   claudeCodeFramework,
-  getAgentFramework,
   type AgentFramework,
   type AgentModelChangeTarget,
   type ResolvedAgentBackend
 } from '../agent-framework'
-import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
-import { extractProviderToolName } from './runtime-events'
 import { fetchOpenCodeUsageSnapshot } from './opencode-turn-usage'
 import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { ConversationPermissionGrantStore } from './permission-broker'
-import { isMcpToolName } from './permission-policy'
 import { AcpPermissionContext, HUMAN_PERMISSION_ACTION_ORIGIN } from './permission-context'
 import { applyCurrentModeUpdate } from './permission-profile-controller'
 import { AgentMcpHttpHost } from './mcp-http-host'
@@ -563,21 +554,47 @@ class AcpRuntime {
     })
     this.permissionContext = new AcpPermissionContext({
       emitPermissionRequest: (request) => {
-        // Relabel to the app-facing id when this session was adopted onto a replaced agent.
-        const sessionId = this.sessionRegistry.resolveAppSessionId(request.sessionId)
-        const routed = sessionId === request.sessionId ? request : { ...request, sessionId }
-
         this.pushEvent({
           kind: 'permission',
           level: 'warning',
-          sessionId: routed.sessionId,
-          toolCallId: routed.toolCallId,
+          sessionId: request.sessionId,
+          toolCallId: request.toolCallId,
           title: 'Permission requested',
-          text: routed.title,
-          raw: routed
+          text: request.title,
+          raw: request
         })
-        this.callbacks.onPermissionRequest?.(routed)
+        this.callbacks.onPermissionRequest?.(request)
         this.emitState()
+      },
+      routing: {
+        resolveAppSessionId: (sessionId) => this.sessionRegistry.resolveAppSessionId(sessionId),
+        sessionSnapshot: (sessionId) => {
+          const snapshot = this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot()
+          return snapshot
+            ? {
+                cwd: snapshot.cwd,
+                frameworkId: snapshot.frameworkId,
+                permissionProfile: snapshot.permissionProfile
+              }
+            : undefined
+        },
+        hasActivePrimarySession: (sessionId) => this.activeSessionFor(sessionId) !== undefined,
+        capturePrompt: (sessionId) => {
+          const scope = this.currentPromptInteraction(sessionId)
+          return scope
+            ? {
+                sequence: scope.sequence,
+                isCancellationAccepted: () => this.sessionInteractions.isCancellationAccepted(scope)
+              }
+            : undefined
+        },
+        currentInteractionSequence: (sessionId) =>
+          this.sessionInteractions.current(sessionId)?.sequence,
+        mcpServerNamesFor: (sessionId) => this.sessionCapabilities.mcpServerNamesFor(sessionId),
+        reviewerContextFor: (sessionId) => this.reviewerSessions.contextFor(sessionId),
+        resolveReviewerPermission: (request) => this.reviewerSessions.resolvePermission(request),
+        currentFramework: () => this.framework,
+        resolveProjectId: (sessionId) => this.resolveSessionProjectName(sessionId)
       },
       conversationGrants: options.permissionGrantStore,
       permissionGrantRegistry: options.permissionGrantRegistry,
@@ -589,9 +606,15 @@ class AcpRuntime {
     })
     this.reviewerSessions = new ReviewerSessionOwner({
       addStartupBlocker: (token) => this.generationActivity.acquireStartup(token),
+      assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
       clearPermissionCorrelations: (sessionId) =>
         this.permissionContext.clearCorrelationsForSession(sessionId),
+      currentSessionSetup: () => ({
+        framework: this.framework,
+        sessionOptions: this.backend.session.options
+      }),
       currentStartupGeneration: () => this.sessionRegistry.startupGeneration,
+      ensureConnected: (cwd) => this.ensureConnected(cwd),
       isPrimarySessionIdClaimed: (sessionId) => this.sessionRegistry.isIdentityClaimed(sessionId),
       onActiveSessionReleased: () => this.generationActivityChanged(),
       registerBridgeSession: (sessionId) =>
@@ -1514,8 +1537,9 @@ class AcpRuntime {
     onFrameworkResolved: (framework: AgentFramework['id']) => void
   ): Promise<AcpAgentConnectionCandidate> {
     const hooks: AcpAgentConnectionHooks = {
-      requestPermission: (params) => this.handlePermissionRequest(params),
-      observeSessionUpdate: (notification) => this.observePermissionToolContext(notification),
+      requestPermission: (params) => this.permissionContext.handleProviderRequest(params),
+      observeSessionUpdate: (notification) =>
+        this.permissionContext.observeProviderUpdate(notification),
       observeClaudeSdkMessage: (params) => this.observeClaudeSdkMessage(params),
       filesystem: {
         resolveSessionCwd: (sessionId) => this.resolveSessionCwd(sessionId),
@@ -2048,135 +2072,6 @@ class AcpRuntime {
     )
   }
 
-  // Hands permission requests to the broker so the renderer can answer later. Any failure is logged with
-  // its real message before it propagates: the ACP SDK collapses a thrown handler error into a bare
-  // -32603 "Internal error" (real detail buried in `data.details`), so this is the only place the true
-  // cause is captured in the app log. The error is rethrown unchanged to preserve protocol behavior.
-  private async handlePermissionRequest(
-    params: RequestPermissionRequest
-  ): Promise<RequestPermissionResponse> {
-    // Fork point: a WebFetch/server-side tool that never reaches this line means the "Internal error"
-    // originated elsewhere. Info level so it's a visible audit line (one per prompt): if an MCP call
-    // runs without this appearing, the agent never asked (e.g. an un-gated permission config). Log the
-    // tool identity (name/kind) and whether it looks like MCP — never the title (a WebFetch title is the
-    // full URL with query params, i.e. user data).
-    const appSessionId = this.sessionRegistry.resolveAppSessionId(params.sessionId)
-    const reviewerContext = this.reviewerSessions.contextFor(params.sessionId)
-    const mcpServerNames =
-      reviewerContext?.mcpServerNames ?? this.sessionCapabilities.mcpServerNamesFor(appSessionId)
-    const promptInteraction = this.currentPromptInteraction(appSessionId)
-    const promptTurn = promptInteraction?.sequence
-    const aggregateSnapshot = this.sessionRegistry.lookup(appSessionId)?.aggregate.snapshot()
-    const framework = reviewerContext?.frameworkId ?? aggregateSnapshot?.frameworkId
-    const isPermissionContextCancelled = (): boolean =>
-      framework === 'opencode' &&
-      (promptTurn === undefined
-        ? this.activeSessionFor(appSessionId) !== undefined
-        : this.currentPromptInteraction(appSessionId)?.sequence !== promptTurn ||
-          (promptInteraction !== undefined &&
-            this.sessionInteractions.isCancellationAccepted(promptInteraction)))
-    const restoreContext = {
-      sessionId: appSessionId,
-      framework,
-      mcpServerNames,
-      isCancelled: isPermissionContextCancelled
-    }
-    const normalizedParams = await this.permissionContext.restoreToolCall(params, restoreContext)
-    if (
-      !normalizedParams ||
-      this.permissionContext.isPermissionRequestCancelled(
-        params.toolCall.toolCallId,
-        restoreContext
-      )
-    ) {
-      return { outcome: { outcome: 'cancelled' } }
-    }
-    const toolName = extractProviderToolName(normalizedParams.toolCall)
-    const isMcp =
-      isMcpToolName(normalizedParams.toolCall?.title, mcpServerNames) ||
-      isMcpToolName(toolName, mcpServerNames)
-    log.info('permission request received', {
-      tool:
-        this.toolIdentityForDiagnostics(toolName, appSessionId) ?? normalizedParams.toolCall?.kind,
-      isMcp,
-      toolCallId: normalizedParams.toolCall?.toolCallId,
-      sessionId: params.sessionId,
-      optionCount: params.options?.length
-    })
-
-    try {
-      // Background reviewer sessions run unattended and are intentionally absent from the primary
-      // Session Aggregate collection.
-      // Approve only their dedicated, scope-bounded MCP. Bash, filesystem, network, other MCP servers,
-      // and unknown tools are rejected without involving the renderer.
-      if (reviewerContext) {
-        const response = this.reviewerSessions.resolvePermission(normalizedParams)
-        if (response) return response
-        throw new Error(`Unknown ACP reviewer session: ${params.sessionId}`)
-      }
-
-      if (!this.activeSessionFor(appSessionId)) {
-        throw new Error(`Unknown ACP session: ${appSessionId}`)
-      }
-
-      const profileState = aggregateSnapshot?.permissionProfile
-      const permissionFrameworkId = aggregateSnapshot?.frameworkId ?? this.framework.id
-      const permissionFramework =
-        permissionFrameworkId === this.framework.id
-          ? this.framework
-          : getAgentFramework(permissionFrameworkId)
-
-      return await this.permissionContext.requestPermission(
-        appSessionId === normalizedParams.sessionId
-          ? normalizedParams
-          : { ...normalizedParams, sessionId: appSessionId },
-        {
-          profile: profileState?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE,
-          // Source the framework from the per-session map, not the current generation view — an
-          // overlapping reconnect can move it off Codex mid-request and leak the amendment options.
-          frameworkId: permissionFrameworkId,
-          shellDialect: permissionFramework.commandShellDialect,
-          autoReviewStrategy: profileState?.autoReviewStrategy,
-          cwd: aggregateSnapshot?.cwd,
-          mcpServerNames,
-          projectId: this.resolveSessionProjectName(appSessionId)
-        }
-      )
-    } catch (error) {
-      log.error('permission request failed', {
-        message: errorMessage(error),
-        tool:
-          this.toolIdentityForDiagnostics(
-            extractProviderToolName(normalizedParams.toolCall),
-            appSessionId
-          ) ?? normalizedParams.toolCall?.kind,
-        toolCallId: params.toolCall?.toolCallId,
-        sessionId: params.sessionId
-      })
-      throw error
-    }
-  }
-
-  // Observes every ACP update before framework-specific consumers drain their ActiveSession queue.
-  // Reviewer updates are consumed outside handleSessionUpdate, so this shared boundary is the only
-  // place where a preceding tool_call can reliably enrich a later sparse permission request.
-  private observePermissionToolContext(notification: SessionNotification): void {
-    const sessionId = this.sessionRegistry.resolveAppSessionId(notification.sessionId)
-    const reviewerContext = this.reviewerSessions.contextFor(notification.sessionId)
-    const framework =
-      reviewerContext?.frameworkId ??
-      this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().frameworkId
-    this.applySessionUpdateEffects(
-      this.sessionUpdateProjector.project(notification, {
-        kind: 'permission',
-        appSessionId: sessionId,
-        framework,
-        mcpServerNames:
-          reviewerContext?.mcpServerNames ?? this.sessionCapabilities.mcpServerNamesFor(sessionId)
-      })
-    )
-  }
-
   private cancelPermissionFlowForSession(sessionId: string): void {
     this.permissionContext.cancelForSession(sessionId)
   }
@@ -2292,7 +2187,6 @@ class AcpRuntime {
     const sessionId = appSessionId ?? notification.sessionId
     this.applySessionUpdateEffects(
       this.sessionUpdateProjector.project(notification, {
-        kind: 'runtime',
         framework:
           this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().frameworkId ??
           this.framework.id,
@@ -2312,9 +2206,6 @@ class AcpRuntime {
   ): void {
     for (const effect of effects) {
       switch (effect.kind) {
-        case 'permission-tool-correlation':
-          this.permissionContext.observeToolCall(effect.notification, effect.context)
-          break
         case 'context-observation':
           this.ensureContextUsageTracking(effect.sessionId)
           this.contextUsageTracker.observeSessionUpdate(
@@ -2365,20 +2256,6 @@ class AcpRuntime {
           break
       }
     }
-  }
-
-  private toolIdentityForDiagnostics(
-    providerToolName: string | undefined,
-    sessionId: string
-  ): string | undefined {
-    if (!providerToolName) return undefined
-
-    return (
-      resolveCanonicalMcpToolIdentity(
-        providerToolName,
-        this.sessionCapabilities.mcpServerNamesFor(sessionId)
-      ) ?? providerToolName
-    )
   }
 
   private processEventDisposition(
@@ -2508,18 +2385,7 @@ class AcpRuntime {
   // appear in the snapshot, and callers are responsible for disposing it. This allows background
   // review to run in parallel with the main session without affecting the main state machine.
   async buildReviewerSession(request: ReviewerSessionRequest): Promise<ReviewerSessionResult> {
-    return this.withOperationLease(() =>
-      this.reviewerSessions.create(request, async () => {
-        const connection = await this.ensureConnected(request.cwd)
-        this.assertCurrentConnectedConnection(connection)
-        return {
-          connection,
-          framework: this.framework,
-          sessionOptions: this.backend.session.options,
-          startupGeneration: this.sessionRegistry.startupGeneration
-        }
-      })
-    )
+    return this.withOperationLease(() => this.reviewerSessions.create(request))
   }
 
   private invalidatePendingSessionStartups(): void {

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -17,7 +17,6 @@ describe('AcpSessionUpdateProjector', () => {
     }
 
     const effects = projector.project(notification, {
-      kind: 'runtime',
       appSessionId: 'stable-session',
       eventId: 'event-1',
       timestamp: 1710000000000,
@@ -57,7 +56,6 @@ describe('AcpSessionUpdateProjector', () => {
       update: { sessionUpdate: 'usage_update', used: 42, size: 128_000 }
     }
     const routing = {
-      kind: 'runtime' as const,
       eventId: 'event-usage',
       visible: true,
       reconnectPending: false,
@@ -89,7 +87,6 @@ describe('AcpSessionUpdateProjector', () => {
         }
       },
       {
-        kind: 'runtime',
         framework: 'claude-code',
         eventId: 'event-refusal',
         visible: true,
@@ -117,7 +114,6 @@ describe('AcpSessionUpdateProjector', () => {
       update: { sessionUpdate: 'current_mode_update', currentModeId: 'bypassPermissions' }
     }
     const routing = {
-      kind: 'runtime' as const,
       eventId: 'event-mode',
       visible: false,
       reconnectPending: true,
@@ -155,7 +151,6 @@ describe('AcpSessionUpdateProjector', () => {
     }
 
     const effects = projector.project(notification, {
-      kind: 'runtime',
       eventId: 'event-tool',
       visible: true,
       reconnectPending: false,
@@ -191,7 +186,6 @@ describe('AcpSessionUpdateProjector', () => {
         }
       },
       {
-        kind: 'runtime',
         eventId: 'event-empty',
         visible: true,
         reconnectPending: false,
@@ -208,7 +202,6 @@ describe('AcpSessionUpdateProjector', () => {
     const skillPath = join(skillsRoot, 'mcp-pubmed', 'SKILL.md')
     projector.beginGeneration(skillsRoot)
     const routing = {
-      kind: 'runtime' as const,
       eventId: 'event-skill',
       visible: true,
       reconnectPending: false,
@@ -283,7 +276,6 @@ describe('AcpSessionUpdateProjector', () => {
     const skillsRoot = resolve('/data', 'codex-home', 'skills')
     projector.beginGeneration(skillsRoot)
     const routing = {
-      kind: 'runtime' as const,
       eventId: 'event-skill',
       visible: true,
       reconnectPending: false,
@@ -330,49 +322,5 @@ describe('AcpSessionUpdateProjector', () => {
     expect(complete('session-b').at(-1)).toMatchObject({
       event: { title: 'Loaded skill: mcp-chemistry' }
     })
-  })
-
-  it('projects Permission tool correlation first with the stable Session identity', () => {
-    const projector = new AcpSessionUpdateProjector()
-    const effects = projector.project(
-      {
-        sessionId: 'provider-session',
-        update: {
-          sessionUpdate: 'tool_call',
-          toolCallId: 'mcp-1',
-          title: 'Run notebook cell',
-          kind: 'execute',
-          status: 'pending'
-        }
-      },
-      {
-        kind: 'permission',
-        appSessionId: 'stable-session',
-        framework: 'codex',
-        mcpServerNames: ['open-science-notebook']
-      }
-    )
-
-    expect(effects).toEqual([
-      {
-        kind: 'permission-tool-correlation',
-        notification: {
-          sessionId: 'stable-session',
-          update: {
-            sessionUpdate: 'tool_call',
-            toolCallId: 'mcp-1',
-            title: 'Run notebook cell',
-            kind: 'execute',
-            status: 'pending'
-          }
-        },
-        context: {
-          sessionId: 'stable-session',
-          framework: 'codex',
-          mcpServerNames: ['open-science-notebook']
-        }
-      }
-    ])
-    expect(Object.isFrozen(effects[0])).toBe(true)
   })
 })

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -1,10 +1,10 @@
 import type { SessionNotification } from '@agentclientprotocol/sdk'
 
 import type { AcpContextUsage, AcpRuntimeEvent } from '../../shared/acp'
+import type { AgentFrameworkId } from '../../shared/settings'
 import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
 import { CodexSkillActivityProjector } from './codex-skill-activity'
 import type { SessionUpdateObservation } from './context-usage-tracker'
-import type { PermissionToolContext } from './permission-context'
 import { isMcpToolName } from './permission-policy'
 import {
   extractProviderToolName,
@@ -12,9 +12,8 @@ import {
   toAcpRuntimeEvent
 } from './runtime-events'
 
-type RuntimeProjectionRouting = Readonly<{
-  kind: 'runtime'
-  framework?: PermissionToolContext['framework']
+type AcpSessionUpdateRouting = Readonly<{
+  framework?: AgentFrameworkId
   appSessionId?: string
   eventId: string
   timestamp?: number
@@ -23,21 +22,7 @@ type RuntimeProjectionRouting = Readonly<{
   mcpServerNames: readonly string[]
 }>
 
-type PermissionProjectionRouting = Readonly<{
-  kind: 'permission'
-  appSessionId: string
-  framework: PermissionToolContext['framework']
-  mcpServerNames: readonly string[]
-}>
-
-type AcpSessionUpdateRouting = RuntimeProjectionRouting | PermissionProjectionRouting
-
 type AcpSessionUpdateEffect =
-  | Readonly<{
-      kind: 'permission-tool-correlation'
-      notification: Readonly<SessionNotification>
-      context: Readonly<PermissionToolContext>
-    }>
   | Readonly<{
       kind: 'context-observation'
       sessionId: string
@@ -123,20 +108,6 @@ class AcpSessionUpdateProjector {
     const routed = structuredClone(notification)
     if (routing.appSessionId) routed.sessionId = routing.appSessionId
     deepFreeze(routed)
-
-    if (routing.kind === 'permission') {
-      return Object.freeze([
-        deepFreeze({
-          kind: 'permission-tool-correlation' as const,
-          notification: routed,
-          context: {
-            sessionId: routed.sessionId,
-            framework: routing.framework,
-            mcpServerNames: [...routing.mcpServerNames]
-          }
-        })
-      ])
-    }
 
     const projection = this.codexSkillActivity.projectWithContext(
       toAcpRuntimeEvent(

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -353,6 +353,17 @@ describe('runtime state ownership architecture', () => {
     expect(source).toContain('currentConnection: () => this.connection')
   })
 
+  it('keeps provider permission routing and reviewer preparation behind their owners', () => {
+    const source = readSource('src/main/acp/runtime.ts')
+
+    expect(source).not.toContain('private async handlePermissionRequest')
+    expect(source).not.toContain('private observePermissionToolContext')
+    expect(source).not.toContain('reviewerSessions.create(request, async')
+    expect(source).toContain('this.permissionContext.handleProviderRequest(params)')
+    expect(source).toContain('this.permissionContext.observeProviderUpdate(notification)')
+    expect(source).toContain('this.reviewerSessions.create(request)')
+  })
+
   it('accepts declared interface imports for a future orchestration module', () => {
     const source = `
       import type { AcpApplicationCommandDependencies } from '../acp/application-commands'


### PR DESCRIPTION
## Problem

`AcpRuntime` still owned provider permission routing, correlation projection, and fixed Reviewer connection preparation. That left permission state transitions split across Runtime, `AcpPermissionContext`, and a permission-only projector path.

## Proposed change

- Move provider permission request routing, stable App Session ID mapping, correlation restoration, cancellation checks, policy construction, and safe diagnostics behind `AcpPermissionContext`.
- Route provider updates directly to `AcpPermissionContext` and remove the superseded permission-only `AcpSessionUpdateProjector` effect.
- Move the fixed validate/connect/assert/setup/generation preparation sequence into `ReviewerSessionOwner.create(request)`.
- Keep Runtime as the composition boundary and public facade.

```mermaid
flowchart LR
  Agent[ACP provider] -->|permission request or update| Context[AcpPermissionContext]
  Runtime[AcpRuntime fact ports] --> Context
  Context -->|primary decision| Broker[Permission broker and policy]
  Context -->|isolated reviewer decision| Reviewer[ReviewerSessionOwner]
  Runtime -->|build reviewer command| Reviewer
  Reviewer -->|connection and setup facts| Runtime
```

## Scope and non-goals

- Ownership-only refactor: no IPC, wire, UI, data model, persistence, or user-interaction changes.
- Electron, Web, CLI, and Task capability asymmetry remains unchanged.
- Specialist, Permission, Compute, Reviewer strict allowlist, remembered grants, and human-only response origin remain unchanged.
- Issue #458 remains a forward type boundary only; this PR adds no orchestration state or public API. Related: #458.
- Production raw: 461, below the 600 split limit.
- `src/main/acp/runtime.ts`: 2,567 -> 2,433 lines.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Permission owner, projector contract, and ownership architecture -> `npm test -- --run src/main/acp/permission-context.test.ts src/main/acp/session-update-projector.test.ts src/main/runtime-state-ownership.architecture.test.ts` -> 49 passed.
- Runtime permission, Reviewer, cancellation, reconnect, collision, and rollback behavior -> `npm test -- --run src/main/acp/runtime.test.ts -t permission|Permission|reviewer|Reviewer` -> 60 passed.
- Node and Web consumers -> `npm run typecheck` -> passed.
- Repository standards -> `npm run lint` -> 0 errors; 17 pre-existing unrelated warnings.
- Patch integrity -> `git diff --check` -> passed.
- Independent Standards review -> 0 findings after both review items were fixed.
- Independent Spec/Test Impact review -> 0 findings.

A full local Runtime-file attempt passed 437/440 tests; the remaining three required loopback `listen` permission unavailable in the local sandbox. The targeted impacted set is green, and online PR Gate remains authoritative for full portable/platform coverage.

## Review focus

- OpenCode no-prompt and prompt-replacement cancellation semantics.
- Stable App Session ID routing across adopted provider IDs.
- Reviewer isolation and strict tool allow/deny behavior.
- Post-restore active-session and project resolution timing.
- Reviewer startup collision, reconnect, bridge rollback, and cleanup ordering.