### PR TITLE
refactor(acp): deepen provider and context routing

### DIFF
--- a/src/main/acp/context-usage-policy.test.ts
+++ b/src/main/acp/context-usage-policy.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { opencodeFramework } from '../agent-framework'
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import { AcpContextUsagePolicy } from './context-usage-policy'
+
+const backend = (overrides: Partial<AcpBackendGenerationView> = {}): AcpBackendGenerationView => ({
+  framework: opencodeFramework,
+  session: { model: 'requested/model', modelRequired: false },
+  prompt: { systemPromptAppends: [] },
+  context: { model: 'tokenizer/model', window: 128_000, supportsImageInput: false },
+  adapter: { nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false },
+  ...overrides
+})
+
+describe('AcpContextUsagePolicy', () => {
+  it('rejects an OpenCode model and window until the Session confirms its applied model', () => {
+    const selection: { appliedModel?: string } = {}
+    const currentBackend = vi.fn(() => backend())
+    const policy = new AcpContextUsagePolicy({
+      backend: currentBackend,
+      appliedModel: () => selection.appliedModel,
+      systemPromptAppends: () => ['app guidance'],
+      tooling: () => ({ artifacts: false, notebook: false, skillImport: false })
+    })
+
+    expect(policy.resolve('session-1')).toEqual({
+      estimateInput: { frameworkId: 'opencode' }
+    })
+
+    selection.appliedModel = 'confirmed/model'
+    expect(policy.resolve('session-1')).toMatchObject({
+      estimateInput: { frameworkId: 'opencode', model: 'tokenizer/model' },
+      selectedWindow: 128_000
+    })
+    expect(currentBackend).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves persistent prompt and enabled MCP sections in one generation decision', () => {
+    const policy = new AcpContextUsagePolicy({
+      backend: () =>
+        backend({
+          session: { modelRequired: false },
+          prompt: {
+            systemPromptAppends: [],
+            persistentSystemPrompt: 'provider instructions'
+          },
+          context: { window: 200_000, supportsImageInput: false }
+        }),
+      appliedModel: () => 'confirmed/model',
+      systemPromptAppends: () => ['must not replace provider prompt'],
+      tooling: () => ({ artifacts: true, notebook: false, skillImport: false })
+    })
+
+    const resolved = policy.resolve('session-1')
+
+    expect(resolved.estimateInput.persistentSystemPrompt).toEqual(['provider instructions'])
+    expect(resolved.estimateInput.persistentSections?.map(({ sectionId }) => sectionId)).toEqual([
+      'mcp-schema:open-science-artifacts'
+    ])
+    expect(resolved.selectedWindow).toBe(200_000)
+  })
+})

--- a/src/main/acp/context-usage-policy.ts
+++ b/src/main/acp/context-usage-policy.ts
@@ -1,0 +1,62 @@
+import type { AcpBackendGenerationView } from './backend-generation-owner'
+import type { SessionEstimateInput } from './context-usage-tracker'
+import { contextUsageMcpSections } from './context-usage-static-context'
+import type { AcpSessionToolingAvailability } from './session-presentation-policy'
+
+type AcpContextUsagePolicyOptions = Readonly<{
+  backend: () => AcpBackendGenerationView
+  appliedModel: (sessionId: string) => string | undefined
+  systemPromptAppends: () => readonly string[]
+  tooling: () => AcpSessionToolingAvailability
+}>
+
+type AcpContextUsageResolution = Readonly<{
+  estimateInput: SessionEstimateInput
+  selectedWindow?: number
+}>
+
+// Interprets one published backend generation into the stable inputs shared by prompt preparation,
+// compaction, model changes, and Session update projection. ContextUsageTracker remains the writer.
+class AcpContextUsagePolicy {
+  constructor(private readonly options: AcpContextUsagePolicyOptions) {}
+
+  resolve(sessionId?: string): AcpContextUsageResolution {
+    const backend = this.options.backend()
+    const appliedModel = sessionId ? this.options.appliedModel(sessionId) : undefined
+    // OpenCode applies its requested model through optional ACP config. Until the Session confirms
+    // that model, neither its tokenizer nor the provider-derived window is trustworthy.
+    const selectionConfirmed = !(
+      backend.framework.id === 'opencode' &&
+      backend.session.model &&
+      !appliedModel
+    )
+    const model = selectionConfirmed ? (backend.context.model ?? appliedModel) : undefined
+    const sessionSetup = backend.framework.buildSessionSetup({
+      systemPromptAppends: backend.prompt.persistentSystemPrompt
+        ? []
+        : [...this.options.systemPromptAppends()],
+      sessionOptions: backend.session.options
+    })
+    const persistentSystemPrompt =
+      backend.prompt.persistentSystemPrompt ?? sessionSetup.persistentSystemPrompt
+    const persistentSections = contextUsageMcpSections(backend.framework.id, {
+      ...this.options.tooling(),
+      codexBridgeAliases: backend.adapter.bridgeMcpAliasesEnabled
+    }).map(({ sectionId, text }) => ({ sectionId, category: 'mcp' as const, text }))
+
+    return Object.freeze({
+      estimateInput: Object.freeze({
+        frameworkId: backend.framework.id,
+        ...(model ? { model } : {}),
+        ...(persistentSystemPrompt ? { persistentSystemPrompt: [persistentSystemPrompt] } : {}),
+        ...(persistentSections.length > 0 ? { persistentSections } : {})
+      }),
+      ...(selectionConfirmed && backend.context.window
+        ? { selectedWindow: backend.context.window }
+        : {})
+    })
+  }
+}
+
+export { AcpContextUsagePolicy }
+export type { AcpContextUsagePolicyOptions, AcpContextUsageResolution }

--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -25,10 +25,10 @@ type Harness = {
   }
   authorize: Mock<AcpPromptTurnWorkflowOptions['skills']['authorize']>
   context: ContextUsageTurnHandle
+  contextUsage: { reconcileUsed: Mock<(sessionId: string, used: number) => boolean> }
   emitSkillActivities: Mock<AcpPromptTurnWorkflowOptions['environment']['emitSkillActivities']>
   executor: Mock<AcpPromptTurnWorkflowOptions['executor']['execute']>
   finalization: {
-    recordContextUsed: Mock<AcpPromptTurnWorkflowOptions['finalization']['recordContextUsed']>
     errorMessage: AcpPromptTurnWorkflowOptions['finalization']['errorMessage']
     errorKind: AcpPromptTurnWorkflowOptions['finalization']['errorKind']
     pushEvent: Mock<AcpPromptTurnWorkflowOptions['finalization']['pushEvent']>
@@ -129,6 +129,7 @@ const createHarness = (
     onPromptStarted?: () => void
     preflightPlan?: AcpPromptTurnWorkflowOptions['preflightPlan']
     prepare?: AcpPromptTurnWorkflowOptions['preparation']['prepare']
+    providerReconnectPending?: () => boolean
   } = {}
 ): Harness => {
   const journal: string[] = []
@@ -260,8 +261,8 @@ const createHarness = (
     })
   }
   const permission = { clearCorrelationsForSession: vi.fn() }
+  const contextUsage = { reconcileUsed: vi.fn(() => true) }
   const finalization: Harness['finalization'] = {
-    recordContextUsed: vi.fn(),
     errorMessage: (error) => (error instanceof Error ? error.message : String(error)),
     errorKind: (error) => (error as { data?: { errorKind?: string } } | undefined)?.data?.errorKind,
     pushEvent: vi.fn(),
@@ -289,6 +290,8 @@ const createHarness = (
     skills: { authorize },
     preparation: { prepare: preparation },
     executor: { execute: executor },
+    contextUsage,
+    providerReconnectPending: input.providerReconnectPending ?? (() => false),
     environment: {
       backend: () => backend,
       tooling: () => ({ artifacts: true, notebook: true, skillImport: true }),
@@ -296,12 +299,6 @@ const createHarness = (
       skillImportEnabled: () => true,
       contextEstimateInput: () => ({ frameworkId: 'opencode' }),
       selectedContextWindow: () => 128_000,
-      providerAdapter: vi.fn(() => ({
-        begin: vi.fn(() => ({
-          finalize: vi.fn(() => ({})),
-          cancel: vi.fn()
-        }))
-      })),
       emitSkillActivities,
       onProviderPromptAccepted,
       routeNotification: vi.fn(),
@@ -332,6 +329,7 @@ const createHarness = (
     artifacts,
     authorize,
     context,
+    contextUsage,
     emitSkillActivities,
     executor,
     finalization,
@@ -430,7 +428,7 @@ describe('AcpPromptTurnWorkflow', () => {
 
     expect(harness.artifacts.publish).toHaveBeenCalledWith('s1', expect.any(Object), onPublished)
     expect(harness.artifacts.dispose).toHaveBeenCalledWith(expect.any(Object))
-    expect(harness.finalization.recordContextUsed).toHaveBeenCalledWith('s1', 42, 1)
+    expect(harness.contextUsage.reconcileUsed).toHaveBeenCalledWith('s1', 42)
     expect(harness.finalization.onPromptEnded).toHaveBeenCalledWith(
       's1',
       handles.interaction.turnToken
@@ -445,6 +443,23 @@ describe('AcpPromptTurnWorkflow', () => {
       'in_progress',
       'completed'
     ])
+  })
+
+  it('rejects delayed context usage after a successor or provider reconnect takes ownership', async () => {
+    const successor = createHarness()
+    await successor.workflow.run(request(), { kind: 'user' })
+    const successorHandles = successor.finalizer.mock.calls[0][0]
+    successor.interactions.current.mockReturnValue({} as never)
+
+    successorHandles.recordContextUsed(41)
+
+    expect(successor.contextUsage.reconcileUsed).not.toHaveBeenCalled()
+
+    const reconnect = createHarness({ providerReconnectPending: () => true })
+    await reconnect.workflow.run(request(), { kind: 'user' })
+    reconnect.finalizer.mock.calls[0][0].recordContextUsed(42)
+
+    expect(reconnect.contextUsage.reconcileUsed).not.toHaveBeenCalled()
   })
 
   it('propagates app-continuation identity without publishing its synthetic text', async () => {

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -3,7 +3,6 @@ import type { ActiveSession, PromptResponse, SessionNotification } from '@agentc
 import type { AcpPromptRequest } from '../../shared/acp'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
 import { formatPlanProtectedContext } from '../../shared/session-plan/contract'
-import type { AgentFrameworkId } from '../../shared/settings'
 import {
   DEFAULT_PERMISSION_PROFILE,
   type PermissionProfileId
@@ -12,7 +11,11 @@ import { createLogger, errorLogFields } from '../logger'
 import { PLAN_FIRST_TURN_PROMPT_REMINDER } from '../session-plan/guidance'
 import type { ArtifactTurnHandle } from './artifact-turn-owner'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
-import type { ContextUsageTurnHandle, SessionEstimateInput } from './context-usage-tracker'
+import type {
+  ContextUsageTracker,
+  ContextUsageTurnHandle,
+  SessionEstimateInput
+} from './context-usage-tracker'
 import type { AcpPermissionContext } from './permission-context'
 import {
   AcpPromptOutcomeFinalizer,
@@ -21,7 +24,6 @@ import {
 } from './prompt-outcome-finalizer'
 import type { AcpPromptPreparationOwner, PreparedPromptHandle } from './prompt-preparation-owner'
 import type { AcpProviderPromptExecutor, ProviderPromptOutcome } from './provider-prompt-executor'
-import type { AcpProviderTurnAdapter } from './provider-turn-adapter'
 import type { AcpSessionInteractionOwner } from './session-interaction-owner'
 import type { AcpPromptSessionInteractionScope } from './session-interaction-owner'
 import type { AcpSessionToolingAvailability } from './session-presentation-policy'
@@ -55,7 +57,6 @@ type AcpPromptTurnEnvironment = Readonly<{
   skillImportEnabled: () => boolean
   contextEstimateInput: (sessionId: string) => SessionEstimateInput
   selectedContextWindow: (sessionId: string) => number | undefined
-  providerAdapter: (frameworkId: AgentFrameworkId) => AcpProviderTurnAdapter
   emitSkillActivities: (
     sessionId: string,
     promptTurn: number,
@@ -94,7 +95,6 @@ type AcpPromptTurnPlanLifecycle = Readonly<{
 }>
 
 type AcpPromptTurnFinalization = Readonly<{
-  recordContextUsed: (sessionId: string, used: number, promptTurn: number) => void
   errorMessage: AcpPromptFinalizationHandles['errorMessage']
   errorKind: AcpPromptFinalizationHandles['errorKind']
   pushEvent: AcpPromptFinalizationHandles['pushEvent']
@@ -122,6 +122,8 @@ type AcpPromptTurnWorkflowOptions = Readonly<{
   skills: Pick<AcpTurnSkillOwner, 'authorize'>
   preparation: Pick<AcpPromptPreparationOwner, 'prepare'>
   executor: Pick<AcpProviderPromptExecutor, 'execute'>
+  contextUsage: Pick<ContextUsageTracker, 'reconcileUsed'>
+  providerReconnectPending: () => boolean
   finalizer: Pick<AcpPromptOutcomeFinalizer, 'finalize'>
   permission: Pick<AcpPermissionContext, 'clearCorrelationsForSession'>
   environment: AcpPromptTurnEnvironment
@@ -343,7 +345,7 @@ class AcpPromptTurnWorkflow {
         session,
         content: prepared.content,
         cwd: promptSnapshot?.cwd ?? this.options.currentCwd(),
-        adapter: env.providerAdapter(promptSnapshot?.frameworkId ?? env.backend().framework.id),
+        frameworkId: promptSnapshot?.frameworkId ?? env.backend().framework.id,
         isCurrent: () => this.isCurrent(turn),
         beforeDispatch: async () => {
           if ((await this.checkpoint(interaction)) === 'cancelled') return 'cancelled'
@@ -404,7 +406,15 @@ class AcpPromptTurnWorkflow {
           env.emitSkillActivities(sessionId, promptTurn, skillInputs, 'failed')
           skillFinalized = true
         },
-        recordContextUsed: (used) => finalization.recordContextUsed(sessionId, used, promptTurn),
+        recordContextUsed: (used) => {
+          if (
+            this.options.providerReconnectPending() ||
+            interactions.current(sessionId) !== interaction
+          ) {
+            return
+          }
+          if (this.options.contextUsage.reconcileUsed(sessionId, used)) this.options.emitState()
+        },
         errorMessage: finalization.errorMessage,
         errorKind: finalization.errorKind,
         pushEvent: finalization.pushEvent,

--- a/src/main/acp/provider-prompt-executor.test.ts
+++ b/src/main/acp/provider-prompt-executor.test.ts
@@ -1,6 +1,12 @@
 import type { ActiveSession, PromptResponse, SessionNotification } from '@agentclientprotocol/sdk'
 import { describe, expect, it, vi } from 'vitest'
 
+const { claudeBegin } = vi.hoisted(() => ({ claudeBegin: vi.fn() }))
+
+vi.mock('./claude-turn-adapter', () => ({
+  claudeCodeTurnAdapter: { begin: (...args: unknown[]) => claudeBegin(...args) }
+}))
+
 import {
   AcpProviderPromptExecutor,
   type ProviderPromptExecutionInput
@@ -83,8 +89,12 @@ const setup = (
   const captureStop = vi.fn(() => true)
   const routeNotification = vi.fn()
   const report = vi.fn()
+  const executor = new AcpProviderPromptExecutor({
+    backendGeneration: { openCodeUsageApi: () => undefined }
+  })
+  claudeBegin.mockImplementation((input) => adapter.begin(input))
   return {
-    executor: new AcpProviderPromptExecutor(),
+    executor,
     session,
     probe,
     adapter,
@@ -96,7 +106,7 @@ const setup = (
       session,
       content: 'prompt',
       cwd: '/workspace',
-      adapter,
+      frameworkId: 'claude-code',
       isCurrent: () => true,
       beforeDispatch: async () => 'active',
       captureStop,
@@ -108,6 +118,70 @@ const setup = (
 }
 
 describe('AcpProviderPromptExecutor', () => {
+  it('captures one OpenCode generation API for both usage snapshots', async () => {
+    const api = { baseUrl: 'https://usage.example/v1', authorization: 'Bearer generation-1' }
+    const openCodeUsageApi = vi.fn(() => api)
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              info: {
+                id: 'assistant-1',
+                role: 'assistant',
+                tokens: { input: 4, output: 2, cache: { read: 1, write: 0 } }
+              }
+            }
+          ]),
+          { status: 200 }
+        )
+      )
+    const response: PromptResponse = { stopReason: 'end_turn' }
+    const session = {
+      sessionId: 'provider-1',
+      prompt: vi.fn(async () => undefined),
+      nextUpdate: vi.fn(async () => stop(response))
+    } as unknown as ProviderPromptExecutionInput['session']
+    const executor = new AcpProviderPromptExecutor({
+      backendGeneration: { openCodeUsageApi },
+      opencodeUsageFetch: fetchImpl
+    })
+
+    const outcome = await executor.execute({
+      session,
+      content: 'prompt',
+      cwd: '/workspace',
+      frameworkId: 'opencode',
+      isCurrent: () => true,
+      beforeDispatch: async () => 'active',
+      captureStop: () => true,
+      onAccepted: () => undefined,
+      routeNotification: () => undefined
+    })
+
+    expect(openCodeUsageApi).toHaveBeenCalledOnce()
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(fetchImpl.mock.calls.map(([, init]) => init?.headers)).toEqual([
+      { authorization: 'Bearer generation-1' },
+      { authorization: 'Bearer generation-1' }
+    ])
+    expect(outcome).toMatchObject({
+      kind: 'stopped',
+      facts: {
+        turnUsage: {
+          inputTokens: 4,
+          cacheTokens: 1,
+          cachedReadTokens: 1,
+          cachedWriteTokens: 0,
+          outputTokens: 2
+        },
+        modelTurnCount: 1
+      }
+    })
+  })
+
   it('accepts once, routes updates in order, captures stop, and returns raw normalized facts', async () => {
     const response: PromptResponse = {
       stopReason: 'end_turn',

--- a/src/main/acp/provider-prompt-executor.ts
+++ b/src/main/acp/provider-prompt-executor.ts
@@ -6,6 +6,12 @@ import type {
 } from '@agentclientprotocol/sdk'
 
 import { toAcpTurnTokenUsage } from '../../shared/acp'
+import type { AgentFrameworkId } from '../../shared/settings'
+import type { AcpBackendGenerationOwner } from './backend-generation-owner'
+import { claudeCodeTurnAdapter } from './claude-turn-adapter'
+import { createCodexTurnAdapter } from './codex-turn-adapter'
+import { AcpOpenCodeTurnAdapter } from './opencode-turn-adapter'
+import { fetchOpenCodeUsageSnapshot } from './opencode-turn-usage'
 import type {
   AcpProviderTurnAdapter,
   AcpProviderTurnProbe,
@@ -18,7 +24,7 @@ type ProviderPromptExecutionInput = Readonly<{
   session: Pick<ActiveSession, 'sessionId' | 'prompt' | 'nextUpdate'>
   content: string | ContentBlock[]
   cwd: string
-  adapter: AcpProviderTurnAdapter
+  frameworkId: AgentFrameworkId
   isCurrent: () => boolean
   beforeDispatch: () => Promise<'active' | 'cancelled'>
   beforeStop?: (response: PromptResponse) => Promise<void>
@@ -26,6 +32,11 @@ type ProviderPromptExecutionInput = Readonly<{
   onAccepted: () => void
   routeNotification: (notification: SessionNotification) => void
   reportBestEffortFailure?: (stage: ProviderPromptObservationStage, error: unknown) => void
+}>
+
+type AcpProviderPromptExecutorOptions = Readonly<{
+  backendGeneration: Pick<AcpBackendGenerationOwner, 'openCodeUsageApi'>
+  opencodeUsageFetch?: typeof fetch
 }>
 
 type ProviderPromptOutcome =
@@ -72,6 +83,8 @@ const normalizeFacts = (
 class AcpProviderPromptExecutor {
   private readonly observations = new Map<string, ActiveObservation>()
 
+  constructor(private readonly options: AcpProviderPromptExecutorOptions) {}
+
   observeProviderMessage(message: unknown): void {
     if (typeof message !== 'object' || message === null || Array.isArray(message)) return
     const providerSessionId = (message as { sessionId?: unknown }).sessionId
@@ -88,9 +101,10 @@ class AcpProviderPromptExecutor {
   async execute(input: ProviderPromptExecutionInput): Promise<ProviderPromptOutcome> {
     const providerSessionId = input.session.sessionId
     const token = Symbol(providerSessionId)
+    const adapter = this.adapterFor(input.frameworkId)
     let probe = NOOP_PROBE
     try {
-      probe = await input.adapter.begin({ providerSessionId, cwd: input.cwd })
+      probe = await adapter.begin({ providerSessionId, cwd: input.cwd })
     } catch (error) {
       reportBestEffort(input.reportBestEffortFailure, 'begin', error)
     }
@@ -183,6 +197,25 @@ class AcpProviderPromptExecutor {
       await cancelProbe()
       releaseObservation()
     }
+  }
+
+  private adapterFor(frameworkId: AgentFrameworkId): AcpProviderTurnAdapter {
+    if (frameworkId === 'claude-code') return claudeCodeTurnAdapter
+    if (frameworkId === 'codex') return createCodexTurnAdapter()
+
+    // Capture one generation's immutable API before adapter.begin awaits. Re-reading the owner for
+    // the final snapshot could mix credentials or lose usage after a generation switch.
+    const usageApi = this.options.backendGeneration.openCodeUsageApi()
+    return new AcpOpenCodeTurnAdapter((providerSessionId, cwd) =>
+      usageApi
+        ? fetchOpenCodeUsageSnapshot(
+            usageApi,
+            providerSessionId,
+            cwd,
+            this.options.opencodeUsageFetch
+          )
+        : Promise.resolve(undefined)
+    )
   }
 }
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -807,9 +807,9 @@ const resolveArtifactRunClaim = (runtime: AcpRuntime, claimId: string): Artifact
 const handleSessionUpdate = (runtime: AcpRuntime, notification: SessionNotification): void =>
   (
     runtime as unknown as {
-      handleSessionUpdate: (value: SessionNotification) => void
+      sessionUpdateProjector: { route: (value: SessionNotification) => void }
     }
-  ).handleSessionUpdate(notification)
+  ).sessionUpdateProjector.route(notification)
 
 type ReviewerOwnerProbe = {
   contextFor: (sessionId: string) =>

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1,10 +1,5 @@
 import * as acp from '@agentclientprotocol/sdk'
-import type {
-  ActiveSession,
-  ClientConnection,
-  PromptResponse,
-  SessionNotification
-} from '@agentclientprotocol/sdk'
+import type { ActiveSession, ClientConnection, PromptResponse } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { join, resolve } from 'node:path'
 
@@ -21,7 +16,6 @@ import type {
   AcpPromptRequest,
   AcpResumeSessionRequest,
   AcpRevokePermissionGrantRequest,
-  AcpContextUsage,
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
@@ -38,11 +32,9 @@ import {
   type ResolvedAgentBackend
 } from '../agent-framework'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
-import { fetchOpenCodeUsageSnapshot } from './opencode-turn-usage'
 import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { ConversationPermissionGrantStore } from './permission-broker'
 import { AcpPermissionContext, HUMAN_PERMISSION_ACTION_ORIGIN } from './permission-context'
-import { applyCurrentModeUpdate } from './permission-profile-controller'
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
@@ -57,8 +49,8 @@ import { getAppClaudeConfigDir } from '../settings/provider-env'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { withDataRootWrite } from '../storage/migration-state'
 import { opencodeStorageDir } from '../agent-framework/opencode'
-import { ContextUsageTracker, type SessionEstimateInput } from './context-usage-tracker'
-import { contextUsageMcpSections } from './context-usage-static-context'
+import { ContextUsageTracker } from './context-usage-tracker'
+import { AcpContextUsagePolicy } from './context-usage-policy'
 import { createManagedFileReferenceResolver } from './file-reference-resolver'
 import type { UploadRepository } from '../uploads/repository'
 import { DEFAULT_UPLOAD_PROJECT_NAME, type UploadedAttachment } from '../../shared/uploads'
@@ -103,7 +95,7 @@ import {
   type AcpBackendGenerationView
 } from './backend-generation-owner'
 import { AcpSessionConfigurator } from './session-configurator'
-import { AcpSessionUpdateProjector, type AcpSessionUpdateEffect } from './session-update-projector'
+import { AcpSessionUpdateProjector } from './session-update-projector'
 import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
 import { AcpConnectionCloseWorkflow, type CloseState } from './connection-close-workflow'
 import { AcpModelChangeWorkflow } from './model-change-workflow'
@@ -118,10 +110,6 @@ import { AcpContextCompactionWorkflow } from './context-compaction-workflow'
 import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import { AcpProviderPromptExecutor } from './provider-prompt-executor'
 import { AcpPromptOutcomeFinalizer } from './prompt-outcome-finalizer'
-import type { AcpProviderTurnAdapter } from './provider-turn-adapter'
-import { claudeCodeTurnAdapter } from './claude-turn-adapter'
-import { createCodexTurnAdapter } from './codex-turn-adapter'
-import { AcpOpenCodeTurnAdapter } from './opencode-turn-adapter'
 import { AcpTurnSkillOwner, type AcpTurnSkillHooks } from './turn-skill-owner'
 import { createProductionPlanService } from '../session-plan/production-plan-service'
 import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
@@ -372,6 +360,7 @@ const safeLogError = (message: string, data?: unknown): void => {
 class AcpRuntime {
   private readonly snapshotOwner: AcpRuntimeSnapshotOwner
   private readonly contextUsageTracker: ContextUsageTracker
+  private readonly contextUsagePolicy: AcpContextUsagePolicy
   private readonly connectionAdapter = new AcpAgentConnectionAdapter()
   private readonly connectionResources: AcpConnectionResourceOwner
   private readonly connectionTransitions: AcpConnectionTransitionOwner
@@ -392,8 +381,8 @@ class AcpRuntime {
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
   private readonly backendGeneration: AcpBackendGenerationOwner
   private readonly sessionConfigurator: AcpSessionConfigurator
-  private readonly sessionUpdateProjector = new AcpSessionUpdateProjector()
-  private readonly providerPromptExecutor = new AcpProviderPromptExecutor()
+  private readonly sessionUpdateProjector: AcpSessionUpdateProjector
+  private readonly providerPromptExecutor: AcpProviderPromptExecutor
   // Injectable lifecycle timers (defaults to real setTimeout/clearTimeout).
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
@@ -447,6 +436,10 @@ class AcpRuntime {
     })
     this.spawnAgent = options.spawnAgent
     this.backendGeneration = new AcpBackendGenerationOwner(options.framework ?? claudeCodeFramework)
+    this.providerPromptExecutor = new AcpProviderPromptExecutor({
+      backendGeneration: this.backendGeneration,
+      opencodeUsageFetch: options.opencodeUsageFetch
+    })
     this.sessionConfigurator = new AcpSessionConfigurator({
       assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
       diagnosticContext: (backend) => this.diagnosticContext(backend.framework.id)
@@ -552,6 +545,32 @@ class AcpRuntime {
       },
       removeStartupBlocker: (token) => this.generationActivity.releaseStartup(token)
     })
+    this.contextUsagePolicy = new AcpContextUsagePolicy({
+      backend: () => this.backend,
+      appliedModel: (sessionId) =>
+        this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().appliedModel,
+      systemPromptAppends: () => this.getSystemPromptAppends(),
+      tooling: () => this.currentCapabilityAvailability()
+    })
+    this.sessionUpdateProjector = new AcpSessionUpdateProjector({
+      registry: this.sessionRegistry,
+      contextUsage: this.contextUsageTracker,
+      contextPolicy: this.contextUsagePolicy,
+      hasActiveSession: (sessionId) => this.activeSessionFor(sessionId) !== undefined,
+      currentFramework: () => this.framework.id,
+      reconnectPending: () => this.pendingProviderReconnect,
+      mcpServerNamesFor: (sessionId) => this.sessionCapabilities.mcpServerNamesFor(sessionId),
+      nextEventId: () => this.nextEventId(),
+      emitState: () => this.emitState(),
+      pushEvent: (event) => this.pushEvent(event),
+      reportToolFailure: (effect) =>
+        log.warn('tool call failed', {
+          tool: effect.tool,
+          toolCallId: effect.toolCallId,
+          sessionId: effect.sessionId,
+          reason: effect.reason
+        })
+    })
     this.permissionContext = new AcpPermissionContext({
       emitPermissionRequest: (request) => {
         this.pushEvent({
@@ -631,14 +650,19 @@ class AcpRuntime {
       interactions: this.sessionInteractions,
       context: this.contextUsageTracker,
       promptContent: this.promptContentOwner,
-      contextEstimateInput: (sessionId) => this.contextUsageEstimateInput(sessionId),
-      selectedContextWindow: (sessionId) => this.selectedContextWindowFor(sessionId),
+      contextEstimateInput: (sessionId) => this.contextUsagePolicy.resolve(sessionId).estimateInput,
+      selectedContextWindow: (sessionId) =>
+        this.contextUsagePolicy.resolve(sessionId).selectedWindow,
       routeHiddenNotification: (notification, sessionId) =>
-        this.handleSessionUpdate(notification, sessionId, false, () => {
-          try {
-            this.emitState()
-          } catch (error) {
-            safeLogError('compaction state callback failed', errorLogFields(error))
+        this.sessionUpdateProjector.route(notification, {
+          appSessionId: sessionId,
+          visible: false,
+          emitState: () => {
+            try {
+              this.emitState()
+            } catch (error) {
+              safeLogError('compaction state callback failed', errorLogFields(error))
+            }
           }
         }),
       pushEvent: (event) => this.pushEvent(event),
@@ -651,6 +675,8 @@ class AcpRuntime {
       skills: this.turnSkills,
       preparation: this.promptPreparation,
       executor: this.providerPromptExecutor,
+      contextUsage: this.contextUsageTracker,
+      providerReconnectPending: () => this.pendingProviderReconnect,
       finalizer: new AcpPromptOutcomeFinalizer(),
       permission: this.permissionContext,
       environment: {
@@ -658,15 +684,16 @@ class AcpRuntime {
         tooling: () => this.currentCapabilityAvailability(),
         bridgeSkillsAvailable: () => this.connectionResources.bridgeSkillsAvailable,
         skillImportEnabled: () => this.sessionCapabilities.isSkillImportEnabled(),
-        contextEstimateInput: (sessionId) => this.contextUsageEstimateInput(sessionId),
-        selectedContextWindow: (sessionId) => this.selectedContextWindowFor(sessionId),
-        providerAdapter: (frameworkId) => this.providerTurnAdapter(frameworkId),
+        contextEstimateInput: (sessionId) =>
+          this.contextUsagePolicy.resolve(sessionId).estimateInput,
+        selectedContextWindow: (sessionId) =>
+          this.contextUsagePolicy.resolve(sessionId).selectedWindow,
         emitSkillActivities: (sessionId, turn, inputs, status) =>
           this.emitCodexSkillInputActivities(sessionId, turn, inputs, status),
         onSkillImportAttachmentEligible: this.callbacks.onSkillImportAttachmentEligible,
         onProviderPromptAccepted: this.callbacks.onProviderPromptAccepted,
         routeNotification: (notification, sessionId) =>
-          this.handleSessionUpdate(notification, sessionId),
+          this.sessionUpdateProjector.route(notification, { appSessionId: sessionId }),
         diagnosticContext: () => this.diagnosticContext(),
         pushUserMessage: ({ sessionId, promptMessageId, text }) =>
           this.pushEvent({
@@ -693,8 +720,6 @@ class AcpRuntime {
         afterRelease: (sessionId) => this.publishTerminalPlanProjection(sessionId)
       },
       finalization: {
-        recordContextUsed: (sessionId, used, promptTurn) =>
-          this.recordProviderPromptContextUsage(sessionId, used, promptTurn),
         errorMessage,
         errorKind: acpErrorKind,
         pushEvent: (event) => this.pushEvent(event),
@@ -783,7 +808,7 @@ class AcpRuntime {
       currentStatus: () => this.snapshotOwner.status,
       providerReconnectPending: () => this.pendingProviderReconnect,
       isGenerationBusy: () => this.generationActivity.blockers().retirement,
-      contextEstimateInput: (sessionId) => this.contextUsageEstimateInput(sessionId),
+      contextEstimateInput: (sessionId) => this.contextUsagePolicy.resolve(sessionId).estimateInput,
       emitState: () => this.emitState(),
       // Model-change fallback already owns its drain. Calling the close workflow here would ask the
       // same drain to await itself, so arm the authoritative transition directly.
@@ -2074,188 +2099,6 @@ class AcpRuntime {
 
   private cancelPermissionFlowForSession(sessionId: string): void {
     this.permissionContext.cancelForSession(sessionId)
-  }
-
-  private providerTurnAdapter(frameworkId: AgentFramework['id']): AcpProviderTurnAdapter {
-    if (frameworkId === 'claude-code') return claudeCodeTurnAdapter
-    if (frameworkId === 'codex') return createCodexTurnAdapter()
-
-    const usageApi = this.backendGeneration.openCodeUsageApi()
-    return new AcpOpenCodeTurnAdapter((providerSessionId, cwd) =>
-      usageApi
-        ? fetchOpenCodeUsageSnapshot(
-            usageApi,
-            providerSessionId,
-            cwd,
-            this.options.opencodeUsageFetch
-          )
-        : Promise.resolve(undefined)
-    )
-  }
-
-  // Provider adapters normalize an exact latest-request context numerator when one exists. Apply it
-  // only while the same app turn still owns the Session so a delayed old stop cannot rewrite a reset.
-  private recordProviderPromptContextUsage(
-    sessionId: string,
-    used: number,
-    promptTurn: number
-  ): void {
-    if (
-      this.pendingProviderReconnect ||
-      this.currentPromptInteraction(sessionId)?.sequence !== promptTurn
-    ) {
-      return
-    }
-    if (this.contextUsageTracker.reconcileUsed(sessionId, used)) this.emitState()
-  }
-
-  private contextUsageSelectionFor(sessionId?: string): {
-    model?: string
-    contextWindow?: number
-  } {
-    const appliedModel = sessionId
-      ? this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().appliedModel
-      : undefined
-    // OpenCode applies the requested provider model through the optional ACP model config. If the
-    // option was absent or rejected, the agent kept its own default and the requested model is unsafe
-    // for both tokenization and window sizing. Other frameworks configure their upstream model
-    // through env or an app-owned bridge, independently of the ACP transport model.
-    const selectedModelConfirmed = !(
-      this.framework.id === 'opencode' &&
-      this.backend.session.model &&
-      !appliedModel
-    )
-    if (!selectedModelConfirmed) return {}
-
-    const model = this.backend.context.model ?? appliedModel
-    return {
-      ...(model ? { model } : {}),
-      ...(this.backend.context.window ? { contextWindow: this.backend.context.window } : {})
-    }
-  }
-
-  private contextUsageEstimateInput(sessionId?: string): SessionEstimateInput {
-    const { model } = this.contextUsageSelectionFor(sessionId)
-    const sessionSetup = this.framework.buildSessionSetup({
-      systemPromptAppends: this.backend.prompt.persistentSystemPrompt
-        ? []
-        : this.getSystemPromptAppends(),
-      sessionOptions: this.backend.session.options
-    })
-    const persistentSystemPrompt =
-      this.backend.prompt.persistentSystemPrompt ?? sessionSetup.persistentSystemPrompt
-    const persistentSections = contextUsageMcpSections(this.framework.id, {
-      artifacts: this.artifactToolingAvailable(),
-      notebook: this.notebookToolingAvailable(),
-      skillImport: this.skillImportToolingAvailable(),
-      codexBridgeAliases: this.backend.adapter.bridgeMcpAliasesEnabled
-    }).map(({ sectionId, text }) => ({ sectionId, category: 'mcp' as const, text }))
-
-    return {
-      frameworkId: this.framework.id,
-      ...(model ? { model } : {}),
-      ...(persistentSystemPrompt ? { persistentSystemPrompt: [persistentSystemPrompt] } : {}),
-      ...(persistentSections.length > 0 ? { persistentSections } : {})
-    }
-  }
-
-  private selectedContextWindowFor(sessionId: string): number | undefined {
-    return this.contextUsageSelectionFor(sessionId).contextWindow
-  }
-
-  private ensureContextUsageTracking(sessionId: string): void {
-    if (!this.activeSessionFor(sessionId)) return
-    this.contextUsageTracker.beginSession(sessionId, this.contextUsageEstimateInput(sessionId))
-  }
-
-  private refreshEstimatedContextUsage(
-    sessionId: string,
-    status: NonNullable<AcpContextUsage['breakdown']>['status']
-  ): boolean {
-    const selectedSize = this.selectedContextWindowFor(sessionId)
-    const size = selectedSize ?? this.contextUsageTracker.usage(sessionId)?.size
-    return this.contextUsageTracker.refreshUsage(sessionId, status, size)
-  }
-
-  // Normalizes low-level session notifications into runtime/workspace events.
-  private handleSessionUpdate(
-    notification: SessionNotification,
-    appSessionId?: string,
-    visible = true,
-    emitState: () => void = () => this.emitState()
-  ): void {
-    const sessionId = appSessionId ?? notification.sessionId
-    this.applySessionUpdateEffects(
-      this.sessionUpdateProjector.project(notification, {
-        framework:
-          this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().frameworkId ??
-          this.framework.id,
-        appSessionId,
-        eventId: this.nextEventId(),
-        visible,
-        reconnectPending: this.pendingProviderReconnect,
-        mcpServerNames: this.sessionCapabilities.mcpServerNamesFor(sessionId)
-      }),
-      emitState
-    )
-  }
-
-  private applySessionUpdateEffects(
-    effects: readonly AcpSessionUpdateEffect[],
-    emitState: () => void = () => this.emitState()
-  ): void {
-    for (const effect of effects) {
-      switch (effect.kind) {
-        case 'context-observation':
-          this.ensureContextUsageTracking(effect.sessionId)
-          this.contextUsageTracker.observeSessionUpdate(
-            effect.sessionId,
-            effect.notification,
-            effect.observation
-          )
-          break
-        case 'current-mode': {
-          const aggregate = this.sessionRegistry.lookup(effect.sessionId)?.aggregate
-          const profileState = aggregate?.snapshot().permissionProfile
-          if (profileState) {
-            aggregate.setPermissionProfile(
-              applyCurrentModeUpdate(
-                profileState as SessionPermissionProfileState,
-                effect.currentModeId
-              )
-            )
-            emitState()
-          }
-          break
-        }
-        case 'provider-usage':
-          this.contextUsageTracker.reconcileProviderUsage(
-            effect.sessionId,
-            effect.usage,
-            this.selectedContextWindowFor(effect.sessionId)
-          )
-          emitState()
-          break
-        case 'context-refresh':
-          if (
-            this.contextUsageTracker.usage(effect.sessionId)?.breakdown?.status !== 'reconciled'
-          ) {
-            this.refreshEstimatedContextUsage(effect.sessionId, 'preflight')
-          }
-          break
-        case 'tool-failure-diagnostic':
-          log.warn('tool call failed', {
-            tool: effect.tool,
-            toolCallId: effect.toolCallId,
-            sessionId: effect.sessionId,
-            reason: effect.reason
-          })
-          break
-        case 'visible-event':
-          this.pushEvent(effect.event)
-          break
-      }
-    }
   }
 
   private processEventDisposition(

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -1,12 +1,173 @@
 import type { SessionNotification } from '@agentclientprotocol/sdk'
 import { join, resolve } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { AcpSessionUpdateProjector } from './session-update-projector'
 
+type TestRouting = Readonly<{
+  framework?: 'claude-code' | 'codex' | 'opencode'
+  appSessionId?: string
+  eventId: string
+  timestamp?: number
+  visible: boolean
+  reconnectPending: boolean
+  mcpServerNames: readonly string[]
+}>
+
+type RecordedEffect = Readonly<Record<string, unknown> & { kind: string }>
+
+type TestProjector = Readonly<{
+  beginGeneration: (root?: string) => void
+  clearGeneration: () => void
+  clearSession: (sessionId: string) => void
+  dispose: () => void
+  route: (notification: SessionNotification, routing: TestRouting) => readonly RecordedEffect[]
+}>
+
+const createProjector = (): TestProjector => {
+  let routing: TestRouting = {
+    eventId: 'event-route',
+    visible: true,
+    reconnectPending: false,
+    mcpServerNames: []
+  }
+  let effects: RecordedEffect[] = []
+  const record = (effect: RecordedEffect): void => {
+    effects.push(Object.freeze(effect))
+  }
+  const owner = new AcpSessionUpdateProjector({
+    registry: {
+      lookup: (sessionId) =>
+        ({
+          aggregate: {
+            snapshot: () => ({
+              frameworkId: routing.framework,
+              permissionProfile: {
+                selectedProfile: 'ask',
+                effectiveProfile: 'ask',
+                currentModeId: 'default',
+                availableModeIds: ['default', 'bypassPermissions'],
+                fullAccessAvailable: true
+              }
+            }),
+            setPermissionProfile: (profile: { currentModeId?: string }) =>
+              record({
+                kind: 'current-mode',
+                sessionId,
+                currentModeId: profile.currentModeId
+              })
+          }
+        }) as never
+    },
+    contextUsage: {
+      beginSession: () => undefined,
+      observeSessionUpdate: (sessionId, notification, observation) =>
+        record({ kind: 'context-observation', sessionId, notification, observation }),
+      reconcileProviderUsage: (sessionId, usage) =>
+        record({ kind: 'provider-usage', sessionId, usage }),
+      refreshUsage: (sessionId) => {
+        record({ kind: 'context-refresh', sessionId })
+        return true
+      },
+      usage: () => undefined
+    },
+    contextPolicy: {
+      resolve: () => ({ estimateInput: { frameworkId: 'claude-code' } })
+    },
+    hasActiveSession: () => false,
+    currentFramework: () => routing.framework ?? 'claude-code',
+    reconnectPending: () => routing.reconnectPending,
+    mcpServerNamesFor: () => routing.mcpServerNames,
+    nextEventId: () => routing.eventId,
+    emitState: () => undefined,
+    pushEvent: (event) => record({ kind: 'visible-event', event }),
+    reportToolFailure: (effect) => record(effect)
+  })
+  return {
+    beginGeneration: (root?: string) => owner.beginGeneration(root),
+    clearGeneration: () => owner.clearGeneration(),
+    clearSession: (sessionId: string) => owner.clearSession(sessionId),
+    dispose: () => owner.dispose(),
+    route: (notification: SessionNotification, nextRouting: TestRouting) => {
+      routing = nextRouting
+      effects = []
+      owner.route(notification, {
+        appSessionId: routing.appSessionId,
+        visible: routing.visible
+      })
+      return Object.freeze([...effects])
+    }
+  }
+}
+
 describe('AcpSessionUpdateProjector', () => {
+  it('routes stable Session usage through context owners in projection order', () => {
+    const journal: string[] = []
+    const beginSession = vi.fn(() => journal.push('context:begin'))
+    const observeSessionUpdate = vi.fn(() => journal.push('context:observe'))
+    const reconcileProviderUsage = vi.fn(() => journal.push('context:reconcile'))
+    const nextEventId = vi.fn(() => 'event-routed')
+    const projector = new AcpSessionUpdateProjector({
+      registry: {
+        lookup: () => ({ aggregate: { snapshot: () => ({ frameworkId: 'opencode' }) } }) as never
+      },
+      contextUsage: {
+        beginSession,
+        observeSessionUpdate,
+        reconcileProviderUsage,
+        refreshUsage: () => false,
+        usage: () => undefined
+      },
+      contextPolicy: {
+        resolve: () => {
+          journal.push('context:resolve')
+          return {
+            estimateInput: { frameworkId: 'opencode', model: 'confirmed/model' },
+            selectedWindow: 200_000
+          }
+        }
+      },
+      hasActiveSession: () => true,
+      currentFramework: () => 'claude-code',
+      reconnectPending: () => false,
+      mcpServerNamesFor: () => [],
+      nextEventId,
+      emitState: () => journal.push('state:emit'),
+      pushEvent: () => journal.push('event:push'),
+      reportToolFailure: () => journal.push('diagnostic')
+    })
+
+    projector.route(
+      {
+        sessionId: 'provider-session',
+        update: { sessionUpdate: 'usage_update', used: 42, size: 128_000 }
+      },
+      { appSessionId: 'stable-session' }
+    )
+
+    expect(nextEventId).toHaveBeenCalledOnce()
+    expect(journal).toEqual([
+      'context:resolve',
+      'context:begin',
+      'context:observe',
+      'context:resolve',
+      'context:reconcile',
+      'state:emit'
+    ])
+    expect(observeSessionUpdate).toHaveBeenCalledWith(
+      'stable-session',
+      expect.objectContaining({ sessionId: 'stable-session' }),
+      {}
+    )
+    expect(reconcileProviderUsage).toHaveBeenCalledWith(
+      'stable-session',
+      { used: 42, size: 128_000 },
+      200_000
+    )
+  })
+
   it('relabels provider updates and orders context projection before the visible event', () => {
-    const projector = new AcpSessionUpdateProjector()
+    const projector = createProjector()
     const notification: SessionNotification = {
       sessionId: 'provider-session',
       update: {
@@ -16,7 +177,7 @@ describe('AcpSessionUpdateProjector', () => {
       }
     }
 
-    const effects = projector.project(notification, {
+    const effects = projector.route(notification, {
       appSessionId: 'stable-session',
       eventId: 'event-1',
       timestamp: 1710000000000,
@@ -39,7 +200,7 @@ describe('AcpSessionUpdateProjector', () => {
       kind: 'visible-event',
       event: {
         id: 'event-1',
-        timestamp: 1710000000000,
+        timestamp: expect.any(Number),
         sessionId: 'stable-session',
         kind: 'message',
         text: 'Hello'
@@ -50,7 +211,7 @@ describe('AcpSessionUpdateProjector', () => {
   })
 
   it('projects usage to context state without a visible event and suppresses stale reconnect usage', () => {
-    const projector = new AcpSessionUpdateProjector()
+    const projector = createProjector()
     const notification: SessionNotification = {
       sessionId: 'session-1',
       update: { sessionUpdate: 'usage_update', used: 42, size: 128_000 }
@@ -62,7 +223,7 @@ describe('AcpSessionUpdateProjector', () => {
       mcpServerNames: []
     }
 
-    expect(projector.project(notification, routing)).toMatchObject([
+    expect(projector.route(notification, routing)).toMatchObject([
       { kind: 'context-observation', sessionId: 'session-1' },
       {
         kind: 'provider-usage',
@@ -70,12 +231,12 @@ describe('AcpSessionUpdateProjector', () => {
         usage: { used: 42, size: 128_000 }
       }
     ])
-    expect(projector.project(notification, { ...routing, reconnectPending: true })).toEqual([])
+    expect(projector.route(notification, { ...routing, reconnectPending: true })).toEqual([])
   })
 
   it('removes Claude Code policy attribution from visible refusal messages', () => {
-    const projector = new AcpSessionUpdateProjector()
-    const [context, refresh, visible] = projector.project(
+    const projector = createProjector()
+    const [context, refresh, visible] = projector.route(
       {
         sessionId: 'session-1',
         update: {
@@ -108,7 +269,7 @@ describe('AcpSessionUpdateProjector', () => {
   })
 
   it('projects hidden current-mode updates while a reconnect suppresses stale context effects', () => {
-    const projector = new AcpSessionUpdateProjector()
+    const projector = createProjector()
     const notification: SessionNotification = {
       sessionId: 'session-1',
       update: { sessionUpdate: 'current_mode_update', currentModeId: 'bypassPermissions' }
@@ -120,7 +281,7 @@ describe('AcpSessionUpdateProjector', () => {
       mcpServerNames: []
     }
 
-    expect(projector.project(notification, routing)).toMatchObject([
+    expect(projector.route(notification, routing)).toMatchObject([
       {
         kind: 'current-mode',
         sessionId: 'session-1',
@@ -130,7 +291,7 @@ describe('AcpSessionUpdateProjector', () => {
   })
 
   it('classifies MCP context and emits a bounded canonical failure diagnostic before the event', () => {
-    const projector = new AcpSessionUpdateProjector()
+    const projector = createProjector()
     const notification: SessionNotification = {
       sessionId: 'session-1',
       update: {
@@ -150,7 +311,7 @@ describe('AcpSessionUpdateProjector', () => {
       }
     }
 
-    const effects = projector.project(notification, {
+    const effects = projector.route(notification, {
       eventId: 'event-tool',
       visible: true,
       reconnectPending: false,
@@ -176,8 +337,8 @@ describe('AcpSessionUpdateProjector', () => {
   })
 
   it('suppresses empty message events after retaining their context refresh ordering', () => {
-    const projector = new AcpSessionUpdateProjector()
-    const effects = projector.project(
+    const projector = createProjector()
+    const effects = projector.route(
       {
         sessionId: 'session-1',
         update: {
@@ -197,7 +358,7 @@ describe('AcpSessionUpdateProjector', () => {
   })
 
   it('owns Codex Skill activity state for one generation and clears sparse lifecycle correlation', () => {
-    const projector = new AcpSessionUpdateProjector()
+    const projector = createProjector()
     const skillsRoot = resolve('/data', 'codex-home', 'skills')
     const skillPath = join(skillsRoot, 'mcp-pubmed', 'SKILL.md')
     projector.beginGeneration(skillsRoot)
@@ -208,7 +369,7 @@ describe('AcpSessionUpdateProjector', () => {
       mcpServerNames: []
     }
 
-    const loading = projector.project(
+    const loading = projector.route(
       {
         sessionId: 'session-1',
         update: {
@@ -222,7 +383,7 @@ describe('AcpSessionUpdateProjector', () => {
       },
       routing
     )
-    const completed = projector.project(
+    const completed = projector.route(
       {
         sessionId: 'session-1',
         update: {
@@ -252,7 +413,7 @@ describe('AcpSessionUpdateProjector', () => {
     expect(JSON.stringify(completed.at(-1))).not.toContain('PRIVATE SKILL BODY')
 
     projector.clearGeneration()
-    const afterClear = projector.project(
+    const afterClear = projector.route(
       {
         sessionId: 'session-1',
         update: {
@@ -272,7 +433,7 @@ describe('AcpSessionUpdateProjector', () => {
   })
 
   it('clears Codex Skill presentation state for only one Session', () => {
-    const projector = new AcpSessionUpdateProjector()
+    const projector = createProjector()
     const skillsRoot = resolve('/data', 'codex-home', 'skills')
     projector.beginGeneration(skillsRoot)
     const routing = {
@@ -286,7 +447,7 @@ describe('AcpSessionUpdateProjector', () => {
       ['session-a', 'mcp-pubmed'],
       ['session-b', 'mcp-chemistry']
     ] as const) {
-      projector.project(
+      projector.route(
         {
           sessionId,
           update: {
@@ -303,8 +464,8 @@ describe('AcpSessionUpdateProjector', () => {
     }
 
     projector.clearSession('session-a')
-    const complete = (sessionId: string): ReturnType<AcpSessionUpdateProjector['project']> =>
-      projector.project(
+    const complete = (sessionId: string): ReturnType<typeof projector.route> =>
+      projector.route(
         {
           sessionId,
           update: {

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -1,16 +1,20 @@
 import type { SessionNotification } from '@agentclientprotocol/sdk'
 
 import type { AcpContextUsage, AcpRuntimeEvent } from '../../shared/acp'
+import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
 import type { AgentFrameworkId } from '../../shared/settings'
 import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
 import { CodexSkillActivityProjector } from './codex-skill-activity'
-import type { SessionUpdateObservation } from './context-usage-tracker'
+import type { AcpContextUsagePolicy } from './context-usage-policy'
+import type { ContextUsageTracker, SessionUpdateObservation } from './context-usage-tracker'
 import { isMcpToolName } from './permission-policy'
+import { applyCurrentModeUpdate } from './permission-profile-controller'
 import {
   extractProviderToolName,
   extractToolFailureText,
   toAcpRuntimeEvent
 } from './runtime-events'
+import type { AcpSessionRegistry } from './session-registry'
 
 type AcpSessionUpdateRouting = Readonly<{
   framework?: AgentFrameworkId
@@ -20,6 +24,31 @@ type AcpSessionUpdateRouting = Readonly<{
   visible: boolean
   reconnectPending: boolean
   mcpServerNames: readonly string[]
+}>
+
+type AcpSessionUpdateRouteInput = Readonly<{
+  appSessionId?: string
+  visible?: boolean
+  emitState?: () => void
+}>
+
+type AcpSessionUpdateProjectorOptions = Readonly<{
+  registry: Pick<AcpSessionRegistry, 'lookup'>
+  contextUsage: Pick<
+    ContextUsageTracker,
+    'beginSession' | 'observeSessionUpdate' | 'reconcileProviderUsage' | 'refreshUsage' | 'usage'
+  >
+  contextPolicy: Pick<AcpContextUsagePolicy, 'resolve'>
+  hasActiveSession: (sessionId: string) => boolean
+  currentFramework: () => AgentFrameworkId
+  reconnectPending: () => boolean
+  mcpServerNamesFor: (sessionId: string) => readonly string[]
+  nextEventId: () => string
+  emitState: () => void
+  pushEvent: (event: Readonly<AcpRuntimeEvent>) => void
+  reportToolFailure: (
+    effect: Extract<AcpSessionUpdateEffect, { kind: 'tool-failure-diagnostic' }>
+  ) => void
 }>
 
 type AcpSessionUpdateEffect =
@@ -80,10 +109,12 @@ const toolObservation = (
     : {}
 }
 
-// Translates provider Session notifications into immutable application-owner effects. The runtime
-// applies them once in order; event retention and context state remain with their existing owners.
+// Translates provider Session notifications into immutable effects and applies them once in order;
+// event retention, aggregates, and ContextUsageTracker remain the actual state writers.
 class AcpSessionUpdateProjector {
   private readonly codexSkillActivity = new CodexSkillActivityProjector()
+
+  constructor(private readonly options: AcpSessionUpdateProjectorOptions) {}
 
   beginGeneration(codexSkillsRoot?: string): void {
     this.codexSkillActivity.setSkillsRoot(codexSkillsRoot)
@@ -101,7 +132,24 @@ class AcpSessionUpdateProjector {
     this.clearGeneration()
   }
 
-  project(
+  route(notification: SessionNotification, input: AcpSessionUpdateRouteInput = {}): void {
+    const sessionId = input.appSessionId ?? notification.sessionId
+    const emitState = input.emitState ?? this.options.emitState
+    const effects = this.project(notification, {
+      framework:
+        this.options.registry.lookup(sessionId)?.aggregate.snapshot().frameworkId ??
+        this.options.currentFramework(),
+      appSessionId: input.appSessionId,
+      eventId: this.options.nextEventId(),
+      visible: input.visible ?? true,
+      reconnectPending: this.options.reconnectPending(),
+      mcpServerNames: this.options.mcpServerNamesFor(sessionId)
+    })
+
+    for (const effect of effects) this.apply(effect, emitState)
+  }
+
+  private project(
     notification: SessionNotification,
     routing: AcpSessionUpdateRouting
   ): readonly AcpSessionUpdateEffect[] {
@@ -181,7 +229,60 @@ class AcpSessionUpdateProjector {
 
     return Object.freeze(effects)
   }
+
+  private apply(effect: AcpSessionUpdateEffect, emitState: () => void): void {
+    switch (effect.kind) {
+      case 'context-observation':
+        if (this.options.hasActiveSession(effect.sessionId)) {
+          this.options.contextUsage.beginSession(
+            effect.sessionId,
+            this.options.contextPolicy.resolve(effect.sessionId).estimateInput
+          )
+        }
+        this.options.contextUsage.observeSessionUpdate(
+          effect.sessionId,
+          effect.notification,
+          effect.observation
+        )
+        break
+      case 'current-mode': {
+        const aggregate = this.options.registry.lookup(effect.sessionId)?.aggregate
+        const profileState = aggregate?.snapshot().permissionProfile
+        if (profileState) {
+          aggregate.setPermissionProfile(
+            applyCurrentModeUpdate(
+              profileState as SessionPermissionProfileState,
+              effect.currentModeId
+            )
+          )
+          emitState()
+        }
+        break
+      }
+      case 'provider-usage':
+        this.options.contextUsage.reconcileProviderUsage(
+          effect.sessionId,
+          effect.usage,
+          this.options.contextPolicy.resolve(effect.sessionId).selectedWindow
+        )
+        emitState()
+        break
+      case 'context-refresh':
+        if (this.options.contextUsage.usage(effect.sessionId)?.breakdown?.status !== 'reconciled') {
+          const resolved = this.options.contextPolicy.resolve(effect.sessionId)
+          const size =
+            resolved.selectedWindow ?? this.options.contextUsage.usage(effect.sessionId)?.size
+          this.options.contextUsage.refreshUsage(effect.sessionId, 'preflight', size)
+        }
+        break
+      case 'tool-failure-diagnostic':
+        this.options.reportToolFailure(effect)
+        break
+      case 'visible-event':
+        this.options.pushEvent(effect.event)
+        break
+    }
+  }
 }
 
 export { AcpSessionUpdateProjector }
-export type { AcpSessionUpdateEffect, AcpSessionUpdateRouting }

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -364,6 +364,20 @@ describe('runtime state ownership architecture', () => {
     expect(source).toContain('this.reviewerSessions.create(request)')
   })
 
+  it('keeps provider selection and Context routing behind their prompt owners', () => {
+    const source = readSource('src/main/acp/runtime.ts')
+
+    expect(source).not.toContain('private providerTurnAdapter')
+    expect(source).not.toContain('private recordProviderPromptContextUsage')
+    expect(source).not.toContain('private contextUsageSelectionFor')
+    expect(source).not.toContain('private contextUsageEstimateInput')
+    expect(source).not.toContain('private selectedContextWindowFor')
+    expect(source).not.toContain('private handleSessionUpdate')
+    expect(source).not.toContain('private applySessionUpdateEffects')
+    expect(source).toContain('this.contextUsagePolicy.resolve(sessionId)')
+    expect(source).toContain('this.sessionUpdateProjector.route(notification')
+  })
+
   it('accepts declared interface imports for a future orchestration module', () => {
     const source = `
       import type { AcpApplicationCommandDependencies } from '../acp/application-commands'


### PR DESCRIPTION
## Problem

`AcpRuntime` still selected concrete provider-turn adapters, interpreted Context model/window inputs,
applied projected Session update effects, and guarded delayed provider usage. These decisions crossed
four existing owner boundaries and kept Runtime at 2,433 lines.

## Proposed change

- Select Claude Code, Codex, and OpenCode turn adapters inside `AcpProviderPromptExecutor` from the
  stable per-Session framework fact. Capture the OpenCode usage API once per attempt before the first
  await so both snapshots stay on one backend generation.
- Add `AcpContextUsagePolicy.resolve()` as the shared interpretation of estimate input and selected
  context window for prompt preparation, compaction, model changes, and Session updates.
- Deepen `AcpSessionUpdateProjector.route()` so it projects and applies effects in owner order while
  aggregates and `ContextUsageTracker` remain the actual state writers.
- Move delayed context-used successor/reconnect guards into `AcpPromptTurnWorkflow`.
- Add owner, adapter, routing, successor, architecture, and feature-slice regression coverage.

```mermaid
flowchart LR
  W["Prompt workflow"] -->|"frameworkId"| E["Provider prompt executor"]
  E --> A["Provider turn adapter"]
  P["Context usage policy"] --> T["Context usage tracker"]
  U["Provider Session update"] --> R["Session update projector"]
  R --> T
  R --> G["Session aggregate"]
  R --> V["Runtime event sink"]
```

Runtime is now 2,276 lines, a net reduction of 157 lines. Exact production raw is 505, below the
approved 600-line split limit.

## Scope and non-goals

- No IPC, wire, shared data model, persistence, UI, or public API changes.
- No Electron, Web, CLI, or Task capability changes; the current cross-surface asymmetry remains.
- No Specialist, Permission, or Compute behavior changes.
- No Issue #458 orchestration data or interface is introduced.
- Provider observation/finalization, stable App Session IDs, reconnect suppression, Context
  reconciliation, Codex Skill privacy, and visible-event ordering remain unchanged.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Provider selection and generation-bound usage -> adapter/executor owner tests -> passed.
- Context policy, tracker, compaction, and model-change consumers -> focused owner tests -> passed.
- Session routing order, Skill privacy, and delayed successor/reconnect guards -> projector/prompt and
  Runtime feature-slice tests -> passed.
- Owner/adapter/workflow/architecture impact set:
  `npx vitest run <12 affected test files>` -> 12 files, 144 tests passed.
- Runtime Context/reconnect/Skill feature slice:
  `npx vitest run src/main/acp/runtime.test.ts -t <affected patterns>` -> 12 passed, 428 skipped.
- `npm run typecheck` -> Node and Web passed.
- `npm run lint` -> 0 errors; 17 pre-existing warnings outside this change.
- `git diff --check` -> passed.
- Independent Standards review -> 0 findings.
- Independent Spec/compatibility review -> 0 findings.

The complete portable suite and platform lanes are intentionally delegated to PR Gate/online CI per
the approved workflow. No platform-specific process, persistence, migration, or UI risk was added.

## Review focus

- Confirm OpenCode usage credentials/API are captured once before `adapter.begin()` can await.
- Confirm Session effects retain observation -> mode/usage/refresh -> diagnostic -> visible ordering.
- Confirm delayed context numerators cannot overwrite a successor turn or pending reconnect.
- Confirm the Context policy retains the OpenCode applied-model confirmation gate and MCP/bridge
  static sections.
