### PR TITLE
refactor(acp-runtime): compose independent base owners

### DIFF
--- a/src/main/acp/codex-completion-handoff.integration.test.ts
+++ b/src/main/acp/codex-completion-handoff.integration.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import * as acp from '@agentclientprotocol/sdk'
 
-import { AcpRuntime } from './runtime'
+import { AcpRuntime } from './runtime.test-utils'
 import { AcpRuntimeCoordinator } from './runtime-coordinator'
 import { createCodexCompletionGateRuntime } from './codex-completion-handoff'
 import {

--- a/src/main/acp/opencode-immediate-handoff.integration.test.ts
+++ b/src/main/acp/opencode-immediate-handoff.integration.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import * as acp from '@agentclientprotocol/sdk'
 
-import { AcpRuntime } from './runtime'
+import { AcpRuntime } from './runtime.test-utils'
 import { AcpRuntimeCoordinator } from './runtime-coordinator'
 import { opencodeFramework } from '../agent-framework'
 import { createOpenCodeImmediateHandoffRuntime } from './opencode-immediate-handoff'

--- a/src/main/acp/runtime-base-composition.test.ts
+++ b/src/main/acp/runtime-base-composition.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { ContextUsageTracker } from './context-usage-tracker'
+import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+
+const projectRoot = resolve(__dirname, '../../..')
+
+describe('ACP Runtime base composition', () => {
+  it('builds a fresh closed owner graph and preserves injected shared dependencies', () => {
+    const contextUsageTracker = new ContextUsageTracker()
+    const setTimer = vi.fn(() => 1 as never)
+    const clearTimer = vi.fn()
+    const options = {
+      appVersion: 'test',
+      defaultCwd: '/workspace/..//workspace',
+      contextUsageTracker,
+      setTimer,
+      clearTimer
+    }
+
+    const first = composeAcpRuntimeBaseOwners(options)
+    const second = composeAcpRuntimeBaseOwners(options)
+
+    expect(Object.isFrozen(first)).toBe(true)
+    expect(first.snapshotOwner.cwd).toBe(resolve(options.defaultCwd))
+    expect(first.contextUsageTracker).toBe(contextUsageTracker)
+    expect(first.setTimer).toBe(setTimer)
+    expect(first.clearTimer).toBe(clearTimer)
+    expect(first.artifactTurns).toBeUndefined()
+    expect(first.planService).toBeUndefined()
+    expect(first.snapshotOwner).not.toBe(second.snapshotOwner)
+    expect(first.connectionResources).not.toBe(second.connectionResources)
+  })
+
+  it('keeps the canonical composer outside Runtime and Electron dependencies outside the composer', () => {
+    const runtime = readFileSync(resolve(projectRoot, 'src/main/acp/runtime.ts'), 'utf8')
+    const composer = readFileSync(
+      resolve(projectRoot, 'src/main/acp/runtime-base-composition.ts'),
+      'utf8'
+    )
+    const applicationComposition = readFileSync(
+      resolve(projectRoot, 'src/main/acp/runtime-composition.ts'),
+      'utf8'
+    )
+
+    expect(runtime).not.toMatch(
+      /new (?:AcpRuntimeSnapshotOwner|AcpConnectionResourceOwner|AcpBackendGenerationOwner|ContextUsageTracker|AcpSessionInteractionOwner|AcpSessionCapabilityOwner|ArtifactTurnOwner|SessionPlanInteractionOwner|AcpPromptContentOwner|AcpSessionPresentationPolicy|AcpPromptOutcomeFinalizer)/
+    )
+    expect(composer).not.toMatch(/from ['"]electron['"]|import \{ AcpRuntime \}/)
+    expect(composer).toContain("import type { AcpRuntimeOptions } from './runtime'")
+    expect(applicationComposition).toContain(
+      'new AcpRuntime(runtimeOptions, composeAcpRuntimeBaseOwners(runtimeOptions))'
+    )
+    expect(runtime + applicationComposition).not.toContain('runtime.test-utils')
+  })
+})

--- a/src/main/acp/runtime-base-composition.ts
+++ b/src/main/acp/runtime-base-composition.ts
@@ -1,0 +1,127 @@
+import { resolve } from 'node:path'
+
+import { claudeCodeFramework } from '../agent-framework'
+import { ArtifactRepository } from '../artifacts/repository'
+import { ArtifactRunRegistry } from '../artifacts/run-registry'
+import { createProductionPlanService } from '../session-plan/production-plan-service'
+import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
+import { AcpAgentConnectionAdapter } from './agent-connection-adapter'
+import { AcpBackendGenerationOwner } from './backend-generation-owner'
+import { AcpConnectionResourceOwner } from './connection-resource-owner'
+import { ContextUsageTracker } from './context-usage-tracker'
+import { createManagedFileReferenceResolver } from './file-reference-resolver'
+import { AcpHandoffContinuityOwner } from './handoff-continuity-owner'
+import { AcpPromptContentOwner } from './prompt-content-owner'
+import { AcpPromptOutcomeFinalizer } from './prompt-outcome-finalizer'
+import { AcpProviderPromptExecutor } from './provider-prompt-executor'
+import type { AcpRuntimeOptions } from './runtime'
+import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
+import { AcpSessionCapabilityOwner } from './session-capability-owner'
+import { AcpSessionInteractionOwner } from './session-interaction-owner'
+import { AcpSessionPresentationPolicy } from './session-presentation-policy'
+import { ArtifactTurnOwner } from './artifact-turn-owner'
+
+// Composes only owners whose construction does not depend on Runtime callbacks. Callback-cycle owner
+// groups remain explicit in Runtime until their own composition seam is cut over.
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
+  const connectionResources = new AcpConnectionResourceOwner({
+    closeMcpHost: async () => {
+      await options.mcpHttpHost?.close()
+    }
+  })
+  const backendGeneration = new AcpBackendGenerationOwner(options.framework ?? claudeCodeFramework)
+  const contextUsageTracker = options.contextUsageTracker ?? new ContextUsageTracker()
+  const setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
+  const clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
+  const sessionInteractions = new AcpSessionInteractionOwner({
+    cancelTimeoutMs: options.cancelTimeoutMs,
+    setTimer,
+    clearTimer
+  })
+  const sessionCapabilities = new AcpSessionCapabilityOwner({
+    artifacts: options.artifacts,
+    notebook: options.notebook,
+    skillImport: options.skillImport,
+    plan: options.plan,
+    mcpHttpHost: options.mcpHttpHost
+  })
+  const artifactRepository = options.artifacts
+    ? (options.artifacts.repository ?? new ArtifactRepository(options.artifacts.dataRoot))
+    : undefined
+  const artifactRunRegistry = options.artifacts
+    ? (options.artifacts.runRegistry ?? new ArtifactRunRegistry())
+    : undefined
+  const artifactTurns =
+    options.artifacts && artifactRepository && artifactRunRegistry
+      ? new ArtifactTurnOwner({
+          dataRoot: options.artifacts.dataRoot,
+          repository: artifactRepository,
+          runRegistry: artifactRunRegistry,
+          issueRpcCapability: options.artifacts.issueRpcCapability,
+          revokeRpcCapability: options.artifacts.revokeRpcCapability,
+          provenance: options.artifacts.provenance,
+          ...(options.notebook
+            ? {
+                notebook: {
+                  setArtifactProvenanceContext: options.notebook.setArtifactProvenanceContext
+                }
+              }
+            : {})
+        })
+      : undefined
+  const planInteractions = new SessionPlanInteractionOwner()
+  const planService =
+    options.plan && artifactTurns && options.artifacts?.provenance?.resolveVersionContent
+      ? createProductionPlanService({
+          interactions: planInteractions,
+          artifactTurns,
+          provenance: {
+            resolveVersionContent: (request) =>
+              options.artifacts!.provenance!.resolveVersionContent!(request)
+          },
+          sessions: options.plan.sessions
+        })
+      : undefined
+  const uploadRepository = options.uploads?.repository
+  const fileReferenceResolver = createManagedFileReferenceResolver({
+    uploads: uploadRepository,
+    artifacts: artifactRepository,
+    artifactVersions: options.artifacts?.provenance
+  })
+
+  return Object.freeze({
+    snapshotOwner: new AcpRuntimeSnapshotOwner(resolve(options.defaultCwd)),
+    connectionAdapter: new AcpAgentConnectionAdapter(),
+    connectionResources,
+    handoffContinuity: new AcpHandoffContinuityOwner(),
+    backendGeneration,
+    providerPromptExecutor: new AcpProviderPromptExecutor({
+      backendGeneration,
+      opencodeUsageFetch: options.opencodeUsageFetch
+    }),
+    contextUsageTracker,
+    setTimer,
+    clearTimer,
+    sessionInteractions,
+    sessionCapabilities,
+    artifactRepository,
+    artifactRunRegistry,
+    artifactTurns,
+    planInteractions,
+    planService,
+    promptContentOwner: new AcpPromptContentOwner({
+      uploadRepository,
+      fileReferenceResolver,
+      inlineImageBudgetBytes: options.inlineImageBudgetBytes
+    }),
+    sessionPresentationPolicy: new AcpSessionPresentationPolicy(),
+    promptOutcomeFinalizer: new AcpPromptOutcomeFinalizer()
+  })
+}
+/* eslint-enable @typescript-eslint/explicit-function-return-type */
+
+type AcpRuntimeBaseOwners = ReturnType<typeof composeAcpRuntimeBaseOwners>
+
+export { composeAcpRuntimeBaseOwners }
+export type { AcpRuntimeBaseOwners }

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -31,7 +31,8 @@ import type { UploadRepository } from '../uploads/repository'
 import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { projectRegistrySessionGrants } from './permission-broker'
-import { AcpRuntime, type AcpRuntimeCallbacks } from './runtime'
+import { AcpRuntime, type AcpRuntimeCallbacks, type AcpRuntimeOptions } from './runtime'
+import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
 import { AcpRuntimeCoordinator } from './runtime-coordinator'
 
 const log = createLogger('acp')
@@ -137,7 +138,7 @@ const createAcpRuntime = ({
   return new AcpRuntimeCoordinator(
     (runtimeCallbacks, permissionGrantStore) => {
       const selection = settingsService.captureActiveAgentBackendSelection()
-      return new AcpRuntime({
+      const runtimeOptions: AcpRuntimeOptions = {
         appVersion: app.getVersion(),
         // Packaged macOS apps often start with cwd at "/" or the app bundle; use home instead.
         defaultCwd,
@@ -249,7 +250,8 @@ const createAcpRuntime = ({
               }
             }
           : undefined
-      })
+      }
+      return new AcpRuntime(runtimeOptions, composeAcpRuntimeBaseOwners(runtimeOptions))
     },
     callbacks,
     defaultCwd,

--- a/src/main/acp/runtime.test-utils.ts
+++ b/src/main/acp/runtime.test-utils.ts
@@ -1,0 +1,12 @@
+import { AcpRuntime as ProductionAcpRuntime, type AcpRuntimeOptions } from './runtime'
+import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+
+class AcpRuntime extends ProductionAcpRuntime {
+  constructor(options: AcpRuntimeOptions) {
+    const owners = composeAcpRuntimeBaseOwners(options)
+    super(options, owners)
+    Object.defineProperty(this, 'artifactRunRegistry', { value: owners.artifactRunRegistry })
+  }
+}
+
+export { AcpRuntime }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -15,7 +15,7 @@ import { join, resolve } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { AcpRuntime } from './runtime'
+import { AcpRuntime } from './runtime.test-utils'
 import type { AcpAgentConnectionAdapter } from './agent-connection-adapter'
 import { AcpPermissionContext } from './permission-context'
 import { ContextUsageTracker, type TokenCounter } from './context-usage-tracker'

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1,7 +1,7 @@
 import * as acp from '@agentclientprotocol/sdk'
 import type { ActiveSession, ClientConnection, PromptResponse } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 
 import type {
   AcpCancelPromptRequest,
@@ -26,7 +26,6 @@ import type { EffectiveSpecialistSkills } from '../../shared/specialist'
 import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import type { ApprovedSwitchReadBack, ClaudeCodeReplayInput } from '../agents/claude-code-handoff'
 import {
-  claudeCodeFramework,
   type AgentFramework,
   type AgentModelChangeTarget,
   type ResolvedAgentBackend
@@ -51,7 +50,6 @@ import { withDataRootWrite } from '../storage/migration-state'
 import { opencodeStorageDir } from '../agent-framework/opencode'
 import { ContextUsageTracker } from './context-usage-tracker'
 import { AcpContextUsagePolicy } from './context-usage-policy'
-import { createManagedFileReferenceResolver } from './file-reference-resolver'
 import type { UploadRepository } from '../uploads/repository'
 import { DEFAULT_UPLOAD_PROJECT_NAME, type UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, FileReference } from '../../shared/artifacts'
@@ -107,11 +105,8 @@ import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
 import { AcpPromptPreparationOwner } from './prompt-preparation-owner'
 import { AcpPromptTurnWorkflow, type AcpPromptTurnPlanContext } from './prompt-turn-workflow'
 import { AcpContextCompactionWorkflow } from './context-compaction-workflow'
-import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import { AcpProviderPromptExecutor } from './provider-prompt-executor'
-import { AcpPromptOutcomeFinalizer } from './prompt-outcome-finalizer'
 import { AcpTurnSkillOwner, type AcpTurnSkillHooks } from './turn-skill-owner'
-import { createProductionPlanService } from '../session-plan/production-plan-service'
 import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { SESSION_PLAN_SYSTEM_PROMPT_APPEND } from '../session-plan/guidance'
 import type { PlanResponseResult, PlanService } from '../session-plan/plan-service'
@@ -123,6 +118,7 @@ import type {
 import { PlanCommandError } from '../../shared/session-plan/contract'
 import type { SessionPlanStepStatus } from '../../shared/session-persistence'
 import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -361,7 +357,7 @@ class AcpRuntime {
   private readonly snapshotOwner: AcpRuntimeSnapshotOwner
   private readonly contextUsageTracker: ContextUsageTracker
   private readonly contextUsagePolicy: AcpContextUsagePolicy
-  private readonly connectionAdapter = new AcpAgentConnectionAdapter()
+  private readonly connectionAdapter: AcpAgentConnectionAdapter
   private readonly connectionResources: AcpConnectionResourceOwner
   private readonly connectionTransitions: AcpConnectionTransitionOwner
   private readonly generationActivity: AcpGenerationActivityOwner
@@ -375,7 +371,7 @@ class AcpRuntime {
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
   private readonly turnSkills: AcpTurnSkillOwner
-  private readonly handoffContinuity = new AcpHandoffContinuityOwner()
+  private readonly handoffContinuity: AcpHandoffContinuityOwner
   private readonly permissionContext: AcpPermissionContext
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
@@ -387,10 +383,8 @@ class AcpRuntime {
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private readonly artifactOptions: AcpRuntimeArtifactOptions | undefined
-  private readonly artifactRepository: ArtifactRepository | undefined
-  private readonly artifactRunRegistry: ArtifactRunRegistry | undefined
   private readonly artifactTurns: ArtifactTurnOwner | undefined
-  private readonly planInteractions = new SessionPlanInteractionOwner()
+  private readonly planInteractions: SessionPlanInteractionOwner
   private readonly planService: PlanService | undefined
   private readonly planSessions: AcpRuntimePlanOptions['sessions'] | undefined
   private readonly promptContentOwner: AcpPromptContentOwner
@@ -407,14 +401,29 @@ class AcpRuntime {
   private readonly sessionDeletion: AcpSessionDeletionWorkflow
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
-  constructor(private readonly options: AcpRuntimeOptions) {
-    this.snapshotOwner = new AcpRuntimeSnapshotOwner(resolve(options.defaultCwd))
+  constructor(
+    private readonly options: AcpRuntimeOptions,
+    base: AcpRuntimeBaseOwners
+  ) {
     this.callbacks = options.callbacks ?? {}
-    this.connectionResources = new AcpConnectionResourceOwner({
-      closeMcpHost: async () => {
-        await options.mcpHttpHost?.close()
-      }
-    })
+    this.spawnAgent = options.spawnAgent
+    this.artifactOptions = options.artifacts
+    this.planSessions = options.plan?.sessions
+    this.snapshotOwner = base.snapshotOwner
+    this.connectionAdapter = base.connectionAdapter
+    this.connectionResources = base.connectionResources
+    this.backendGeneration = base.backendGeneration
+    this.providerPromptExecutor = base.providerPromptExecutor
+    this.contextUsageTracker = base.contextUsageTracker
+    this.setTimer = base.setTimer
+    this.clearTimer = base.clearTimer
+    this.sessionInteractions = base.sessionInteractions
+    this.sessionCapabilities = base.sessionCapabilities
+    this.artifactTurns = base.artifactTurns
+    this.planInteractions = base.planInteractions
+    this.planService = base.planService
+    this.promptContentOwner = base.promptContentOwner
+    this.handoffContinuity = base.handoffContinuity
     this.generationActivity = new AcpGenerationActivityOwner({
       activityChanged: () => this.generationActivityChanged(),
       hasActivePrompts: () => this.sessionInteractions.snapshot().length > 0,
@@ -434,83 +443,13 @@ class AcpRuntime {
       skills: options.skills,
       requestSkillsReload: () => this.connectionTransitions.requestSkillsReload()
     })
-    this.spawnAgent = options.spawnAgent
-    this.backendGeneration = new AcpBackendGenerationOwner(options.framework ?? claudeCodeFramework)
-    this.providerPromptExecutor = new AcpProviderPromptExecutor({
-      backendGeneration: this.backendGeneration,
-      opencodeUsageFetch: options.opencodeUsageFetch
-    })
     this.sessionConfigurator = new AcpSessionConfigurator({
       assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
       diagnosticContext: (backend) => this.diagnosticContext(backend.framework.id)
     })
-    this.contextUsageTracker = options.contextUsageTracker ?? new ContextUsageTracker()
-    this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms))
-    this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle))
-    this.sessionInteractions = new AcpSessionInteractionOwner({
-      cancelTimeoutMs: options.cancelTimeoutMs,
-      setTimer: this.setTimer,
-      clearTimer: this.clearTimer
-    })
-    this.artifactOptions = options.artifacts
-    this.sessionCapabilities = new AcpSessionCapabilityOwner({
-      artifacts: options.artifacts,
-      notebook: options.notebook,
-      skillImport: options.skillImport,
-      plan: options.plan,
-      mcpHttpHost: options.mcpHttpHost
-    })
-    this.artifactRepository = options.artifacts
-      ? (options.artifacts.repository ?? new ArtifactRepository(options.artifacts.dataRoot))
-      : undefined
-    this.artifactRunRegistry = options.artifacts
-      ? (options.artifacts.runRegistry ?? new ArtifactRunRegistry())
-      : undefined
-    this.artifactTurns =
-      options.artifacts && this.artifactRepository && this.artifactRunRegistry
-        ? new ArtifactTurnOwner({
-            dataRoot: options.artifacts.dataRoot,
-            repository: this.artifactRepository,
-            runRegistry: this.artifactRunRegistry,
-            issueRpcCapability: options.artifacts.issueRpcCapability,
-            revokeRpcCapability: options.artifacts.revokeRpcCapability,
-            provenance: options.artifacts.provenance,
-            ...(options.notebook
-              ? {
-                  notebook: {
-                    setArtifactProvenanceContext: options.notebook.setArtifactProvenanceContext
-                  }
-                }
-              : {})
-          })
-        : undefined
-    this.planSessions = options.plan?.sessions
-    this.planService =
-      options.plan && this.artifactTurns && options.artifacts?.provenance?.resolveVersionContent
-        ? createProductionPlanService({
-            interactions: this.planInteractions,
-            artifactTurns: this.artifactTurns,
-            provenance: {
-              resolveVersionContent: (request) =>
-                options.artifacts!.provenance!.resolveVersionContent!(request)
-            },
-            sessions: options.plan.sessions
-          })
-        : undefined
-    const uploadRepository = options.uploads?.repository
-    const fileReferenceResolver = createManagedFileReferenceResolver({
-      uploads: uploadRepository,
-      artifacts: this.artifactRepository,
-      artifactVersions: options.artifacts?.provenance
-    })
-    this.promptContentOwner = new AcpPromptContentOwner({
-      uploadRepository,
-      fileReferenceResolver,
-      inlineImageBudgetBytes: options.inlineImageBudgetBytes
-    })
     this.promptPreparation = new AcpPromptPreparationOwner({
       promptContent: this.promptContentOwner,
-      presentation: new AcpSessionPresentationPolicy(),
+      presentation: base.sessionPresentationPolicy,
       contextUsage: this.contextUsageTracker,
       selectBridgeSkills: async (text, catalog, signal) =>
         (await this.connectionResources.selectBridgeSkills(text, catalog, signal)) ?? [],
@@ -677,7 +616,7 @@ class AcpRuntime {
       executor: this.providerPromptExecutor,
       contextUsage: this.contextUsageTracker,
       providerReconnectPending: () => this.pendingProviderReconnect,
-      finalizer: new AcpPromptOutcomeFinalizer(),
+      finalizer: base.promptOutcomeFinalizer,
       permission: this.permissionContext,
       environment: {
         backend: () => this.backend,
@@ -2273,4 +2212,5 @@ class AcpRuntime {
 }
 
 export { AcpRuntime }
+export type { AcpRuntimeOptions }
 export type { ReviewerSessionDisposition } from './reviewer-session-owner'

--- a/src/main/reviewer/correction.test.ts
+++ b/src/main/reviewer/correction.test.ts
@@ -18,7 +18,7 @@ import { join } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { AcpRuntime } from '../acp/runtime'
+import { AcpRuntime } from '../acp/runtime.test-utils'
 import { ReviewRepository } from './repository'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import { runReview } from './orchestrator'

--- a/src/main/reviewer/fix-loop.test.ts
+++ b/src/main/reviewer/fix-loop.test.ts
@@ -21,7 +21,7 @@ import { join } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { AcpRuntime } from '../acp/runtime'
+import { AcpRuntime } from '../acp/runtime.test-utils'
 import { ReviewRepository } from './repository'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import { runReview } from './orchestrator'

--- a/src/main/reviewer/lifecycle.test.ts
+++ b/src/main/reviewer/lifecycle.test.ts
@@ -18,7 +18,7 @@ import { join } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { AcpRuntime } from '../acp/runtime'
+import { AcpRuntime } from '../acp/runtime.test-utils'
 import { ReviewRepository } from './repository'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import { runReview } from './orchestrator'

--- a/src/main/reviewer/orchestrator.test.ts
+++ b/src/main/reviewer/orchestrator.test.ts
@@ -18,7 +18,7 @@ import { join } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { AcpRuntime } from '../acp/runtime'
+import { AcpRuntime } from '../acp/runtime.test-utils'
 import { ReviewRepository } from './repository'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import { runReview } from './orchestrator'

--- a/src/main/specialist/specialist-identity-injection.test.ts
+++ b/src/main/specialist/specialist-identity-injection.test.ts
@@ -7,7 +7,7 @@ import {
   buildSpecialistIdentityPrefix,
   SPECIALIST_IDENTITY_TAG
 } from './identity'
-import { AcpRuntime } from '../acp/runtime'
+import { AcpRuntime } from '../acp/runtime.test-utils'
 import { claudeCodeFramework, codexFramework, opencodeFramework } from '../agent-framework'
 import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
 import type { SpecialistProfileView } from '../../shared/specialist'


### PR DESCRIPTION
## Problem

`AcpRuntime` still constructed independent generation-scoped owners and stateless policies even though
the application composition root already owns Runtime creation. That kept construction ownership in
the facade and made the remaining callback-cycle cutover harder to review safely.

The first combined prototype measured 637 production raw and required a cross-domain 20-hook bag.
This PR applies the approved owner-group split: it moves only owners with no Runtime callback
dependency and leaves callback-cycle groups for the immediately following ARD-28E2 leaf.

## Proposed change

- Add a pure Node `runtime-base-composition.ts` that creates the independent closed owner graph for one
  backend generation, preserving injected repositories, timers, Context tracker, framework, fetch,
  cwd, MCP close ownership, and optional Artifact/Plan behavior.
- Make `runtime-composition.ts` construct that frozen graph before creating `AcpRuntime`; Runtime now
  receives composed modules instead of constructing them or receiving a composer function.
- Move Snapshot, connection adapter/resources, handoff continuity, backend generation/provider prompt
  executor, Context tracker, timers/interactions/capabilities, Artifact/Plan owners, prompt content,
  Session presentation, and prompt finalization into the composition module.
- Add ownership assertions and an explicit test-only Runtime composition helper so existing direct
  test construction follows the same canonical production composer without a production fallback.

```mermaid
flowchart LR
  App["Electron application composition"] --> Base["Independent base-owner composition"]
  Base --> Graph["Frozen owner graph"]
  Graph --> Runtime["AcpRuntime generation facade"]
  Runtime --> Workflows["Existing lifecycle and prompt workflows"]
  Runtime -. "ARD-28E2: narrow callback-cycle groups" .-> Cycles["Transition / Session / Permission / Reviewer owners"]
```

Runtime is now 2,216 lines, a net reduction of 60 lines. Exact production raw is 255, below the
approved 600-line split limit.

## Scope and non-goals

- No IPC, wire, shared data model, persistence, UI, or public product API changes.
- No Electron, Web, CLI, or Task capability changes; the current surface asymmetry remains.
- No Specialist, Permission, Reviewer, Compute, provider adoption, Context, Artifact, or cleanup
  behavior changes.
- No Issue #458 orchestration state, schema, event, or interface is introduced.
- Callback-cycle owner construction and workflow construction are explicitly deferred to ARD-28E2
  and ARD-28F; this PR adds no general dependency container, hooks bag, or compatibility facade.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Canonical composition, injected identity/default preservation, optional-resource behavior, and
  production/test dependency boundaries -> `runtime-base-composition.test.ts` -> passed.
- Runtime behavior and direct construction migration -> `runtime.test.ts` and Session Plan seam ->
  passed.
- Coordinator, IPC application composition, and consumer contracts -> coordinator/IPC tests ->
  passed.
- Specialist/Permission/Reviewer and Codex/OpenCode handoff compatibility -> affected consumer and
  integration tests -> passed.
- Final Test Impact Set: 12 files, 604 tests passed.
- `npm run typecheck:node` -> passed.
- `npm run lint` -> 0 errors; 17 pre-existing warnings outside this change.
- `git diff --check` -> passed.
- Independent Standards review -> 0 findings.
- Independent Spec/compatibility review -> 0 findings after the owner-group split.

The complete portable suite and platform lanes are delegated to PR Gate/online CI per the approved
workflow. No platform-specific process, persistence, migration, renderer, or transport behavior was
changed locally.

## Review focus

- Confirm application composition constructs the closed graph before Runtime creation and no Runtime
  self-composition fallback remains.
- Confirm every moved owner retains the exact production default or injected identity used before the
  cutover.
- Confirm the test helper is imported only by tests and cannot enter production composition or IPC.
- Confirm callback-cycle groups remain unchanged in Runtime and the E1 seam does not pre-empt E2 with
  a wide cross-domain port.
