### PR TITLE
refactor(acp-runtime): compose generation and connection owners

### DIFF
--- a/src/main/acp/runtime-base-composition.test.ts
+++ b/src/main/acp/runtime-base-composition.test.ts
@@ -33,6 +33,50 @@ describe('ACP Runtime base composition', () => {
     expect(first.planService).toBeUndefined()
     expect(first.snapshotOwner).not.toBe(second.snapshotOwner)
     expect(first.connectionResources).not.toBe(second.connectionResources)
+    expect(first.generationActivity).not.toBe(second.generationActivity)
+    expect(first.connectionTransitions).not.toBe(second.connectionTransitions)
+  })
+
+  it('binds the generation and connection effects once before the graph is used', async () => {
+    const owners = composeAcpRuntimeBaseOwners({
+      appVersion: 'test',
+      defaultCwd: '/workspace'
+    })
+    const hasActiveSessions = vi.fn(() => false)
+    const activityChanged = vi.fn()
+    const disconnect = vi.fn(async () => ({}) as never)
+    const recoverFailedDeferredDisconnect = vi.fn()
+    const publishIdle = vi.fn()
+
+    expect(() => owners.generationActivity.blockers()).toThrow(
+      'ACP generation/connection effects are not bound.'
+    )
+
+    owners.bindGenerationConnectionEffects({
+      reviewerSessions: { hasActiveSessions },
+      modelChanges: { activityChanged },
+      connectionClose: { disconnect, recoverFailedDeferredDisconnect },
+      publishIdle
+    })
+
+    expect(owners.generationActivity.blockers()).toEqual({
+      reconnect: false,
+      retirement: false
+    })
+    await owners.generationActivity.withActivity(async () => undefined)
+    expect(activityChanged).toHaveBeenCalledOnce()
+
+    await owners.connectionTransitions.requestProviderReconnect()
+    expect(disconnect).toHaveBeenCalledWith(false)
+    expect(publishIdle).toHaveBeenCalledOnce()
+    expect(() =>
+      owners.bindGenerationConnectionEffects({
+        reviewerSessions: { hasActiveSessions },
+        modelChanges: { activityChanged },
+        connectionClose: { disconnect, recoverFailedDeferredDisconnect },
+        publishIdle
+      })
+    ).toThrow('ACP generation/connection effects are already bound.')
   })
 
   it('keeps the canonical composer outside Runtime and Electron dependencies outside the composer', () => {
@@ -47,7 +91,7 @@ describe('ACP Runtime base composition', () => {
     )
 
     expect(runtime).not.toMatch(
-      /new (?:AcpRuntimeSnapshotOwner|AcpConnectionResourceOwner|AcpBackendGenerationOwner|ContextUsageTracker|AcpSessionInteractionOwner|AcpSessionCapabilityOwner|ArtifactTurnOwner|SessionPlanInteractionOwner|AcpPromptContentOwner|AcpSessionPresentationPolicy|AcpPromptOutcomeFinalizer)/
+      /new (?:AcpRuntimeSnapshotOwner|AcpConnectionResourceOwner|AcpBackendGenerationOwner|ContextUsageTracker|AcpSessionInteractionOwner|AcpSessionCapabilityOwner|AcpGenerationActivityOwner|AcpConnectionTransitionOwner|AcpTurnSkillOwner|AcpSessionConfigurator|ArtifactTurnOwner|SessionPlanInteractionOwner|AcpPromptContentOwner|AcpSessionPresentationPolicy|AcpPromptOutcomeFinalizer)/
     )
     expect(composer).not.toMatch(/from ['"]electron['"]|import \{ AcpRuntime \}/)
     expect(composer).toContain("import type { AcpRuntimeOptions } from './runtime'")

--- a/src/main/acp/runtime-base-composition.ts
+++ b/src/main/acp/runtime-base-composition.ts
@@ -3,28 +3,58 @@ import { resolve } from 'node:path'
 import { claudeCodeFramework } from '../agent-framework'
 import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
+import { createLogger, errorLogFields } from '../logger'
 import { createProductionPlanService } from '../session-plan/production-plan-service'
 import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { AcpAgentConnectionAdapter } from './agent-connection-adapter'
 import { AcpBackendGenerationOwner } from './backend-generation-owner'
+import type { AcpConnectionCloseWorkflow } from './connection-close-workflow'
 import { AcpConnectionResourceOwner } from './connection-resource-owner'
+import { AcpConnectionTransitionOwner } from './connection-transition-owner'
 import { ContextUsageTracker } from './context-usage-tracker'
 import { createManagedFileReferenceResolver } from './file-reference-resolver'
+import { AcpGenerationActivityOwner } from './generation-activity-owner'
 import { AcpHandoffContinuityOwner } from './handoff-continuity-owner'
+import type { AcpModelChangeWorkflow } from './model-change-workflow'
 import { AcpPromptContentOwner } from './prompt-content-owner'
 import { AcpPromptOutcomeFinalizer } from './prompt-outcome-finalizer'
 import { AcpProviderPromptExecutor } from './provider-prompt-executor'
+import type { ReviewerSessionOwner } from './reviewer-session-owner'
 import type { AcpRuntimeOptions } from './runtime'
 import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { AcpSessionCapabilityOwner } from './session-capability-owner'
+import { AcpSessionConfigurator } from './session-configurator'
 import { AcpSessionInteractionOwner } from './session-interaction-owner'
 import { AcpSessionPresentationPolicy } from './session-presentation-policy'
 import { ArtifactTurnOwner } from './artifact-turn-owner'
+import { AcpTurnSkillOwner } from './turn-skill-owner'
 
-// Composes only owners whose construction does not depend on Runtime callbacks. Callback-cycle owner
-// groups remain explicit in Runtime until their own composition seam is cut over.
+const log = createLogger('acp')
+
+type AcpGenerationConnectionEffects = Readonly<{
+  reviewerSessions: Pick<ReviewerSessionOwner, 'hasActiveSessions'>
+  modelChanges: Pick<AcpModelChangeWorkflow, 'activityChanged'>
+  connectionClose: Pick<
+    AcpConnectionCloseWorkflow,
+    'disconnect' | 'recoverFailedDeferredDisconnect'
+  >
+  publishIdle: () => void
+}>
+
+const safeLogError = (message: string, error: unknown): void => {
+  try {
+    log.error(message, errorLogFields(error))
+  } catch {
+    // Transition recovery and the original failure take precedence over diagnostic sinks.
+  }
+}
+
+// Composes base owners before Runtime. The generation/connection group exposes one bind-once seam
+// for the workflows constructed later; no owner can observe a partial Runtime during construction.
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
+  const callbacks = options.callbacks ?? {}
+  const snapshotOwner = new AcpRuntimeSnapshotOwner(resolve(options.defaultCwd))
   const connectionResources = new AcpConnectionResourceOwner({
     closeMcpHost: async () => {
       await options.mcpHttpHost?.close()
@@ -45,6 +75,55 @@ const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
     skillImport: options.skillImport,
     plan: options.plan,
     mcpHttpHost: options.mcpHttpHost
+  })
+  let generationConnectionEffects: AcpGenerationConnectionEffects | undefined
+  const effects = (): AcpGenerationConnectionEffects => {
+    if (!generationConnectionEffects) {
+      throw new Error('ACP generation/connection effects are not bound.')
+    }
+    return generationConnectionEffects
+  }
+  const generationActivityChanged = (): void => {
+    connectionTransitions.activityChanged()
+    effects().modelChanges.activityChanged()
+  }
+  const generationActivity = new AcpGenerationActivityOwner({
+    activityChanged: generationActivityChanged,
+    hasActivePrompts: () => sessionInteractions.snapshot().length > 0,
+    hasActiveReviewerSessions: () => effects().reviewerSessions.hasActiveSessions()
+  })
+  const connectionTransitions = new AcpConnectionTransitionOwner({
+    blockers: () => generationActivity.blockers(),
+    connectionGeneration: () => connectionResources.epoch,
+    disconnect: (emitClosedStatus) => effects().connectionClose.disconnect(emitClosedStatus),
+    onRetired: () => callbacks.onRetired?.(),
+    publishIdle: () => effects().publishIdle(),
+    recoverFailedDeferredDisconnect: () =>
+      effects().connectionClose.recoverFailedDeferredDisconnect(),
+    reportFailure: safeLogError
+  })
+  const bindGenerationConnectionEffects = (next: AcpGenerationConnectionEffects): void => {
+    if (generationConnectionEffects) {
+      throw new Error('ACP generation/connection effects are already bound.')
+    }
+    generationConnectionEffects = next
+  }
+  const turnSkills = new AcpTurnSkillOwner({
+    resolveSpecialistSkills: options.resolveSpecialistSkills,
+    skills: options.skills,
+    requestSkillsReload: () => connectionTransitions.requestSkillsReload()
+  })
+  const sessionConfigurator = new AcpSessionConfigurator({
+    assertCurrentConnection: (connection) => {
+      if (connectionResources.connection !== connection || snapshotOwner.status !== 'connected') {
+        throw new Error('ACP session startup was superseded.')
+      }
+    },
+    diagnosticContext: (backend) => ({
+      framework: backend.framework.id,
+      generation: connectionResources.epoch,
+      status: snapshotOwner.status
+    })
   })
   const artifactRepository = options.artifacts
     ? (options.artifacts.repository ?? new ArtifactRepository(options.artifacts.dataRoot))
@@ -91,7 +170,7 @@ const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
   })
 
   return Object.freeze({
-    snapshotOwner: new AcpRuntimeSnapshotOwner(resolve(options.defaultCwd)),
+    snapshotOwner,
     connectionAdapter: new AcpAgentConnectionAdapter(),
     connectionResources,
     handoffContinuity: new AcpHandoffContinuityOwner(),
@@ -105,6 +184,11 @@ const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
     clearTimer,
     sessionInteractions,
     sessionCapabilities,
+    generationActivity,
+    connectionTransitions,
+    bindGenerationConnectionEffects,
+    turnSkills,
+    sessionConfigurator,
     artifactRepository,
     artifactRunRegistry,
     artifactTurns,
@@ -124,4 +208,4 @@ const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
 type AcpRuntimeBaseOwners = ReturnType<typeof composeAcpRuntimeBaseOwners>
 
 export { composeAcpRuntimeBaseOwners }
-export type { AcpRuntimeBaseOwners }
+export type { AcpGenerationConnectionEffects, AcpRuntimeBaseOwners }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -85,14 +85,14 @@ import {
   type AcpAgentConnectionCandidate,
   type AcpAgentConnectionHooks
 } from './agent-connection-adapter'
-import { AcpConnectionTransitionOwner } from './connection-transition-owner'
-import { AcpGenerationActivityOwner } from './generation-activity-owner'
+import type { AcpConnectionTransitionOwner } from './connection-transition-owner'
+import type { AcpGenerationActivityOwner } from './generation-activity-owner'
 import { AcpHandoffContinuityOwner } from './handoff-continuity-owner'
 import {
   AcpBackendGenerationOwner,
   type AcpBackendGenerationView
 } from './backend-generation-owner'
-import { AcpSessionConfigurator } from './session-configurator'
+import type { AcpSessionConfigurator } from './session-configurator'
 import { AcpSessionUpdateProjector } from './session-update-projector'
 import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
 import { AcpConnectionCloseWorkflow, type CloseState } from './connection-close-workflow'
@@ -106,7 +106,7 @@ import { AcpPromptPreparationOwner } from './prompt-preparation-owner'
 import { AcpPromptTurnWorkflow, type AcpPromptTurnPlanContext } from './prompt-turn-workflow'
 import { AcpContextCompactionWorkflow } from './context-compaction-workflow'
 import { AcpProviderPromptExecutor } from './provider-prompt-executor'
-import { AcpTurnSkillOwner, type AcpTurnSkillHooks } from './turn-skill-owner'
+import type { AcpTurnSkillHooks, AcpTurnSkillOwner } from './turn-skill-owner'
 import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { SESSION_PLAN_SYSTEM_PROMPT_APPEND } from '../session-plan/guidance'
 import type { PlanResponseResult, PlanService } from '../session-plan/plan-service'
@@ -424,29 +424,10 @@ class AcpRuntime {
     this.planService = base.planService
     this.promptContentOwner = base.promptContentOwner
     this.handoffContinuity = base.handoffContinuity
-    this.generationActivity = new AcpGenerationActivityOwner({
-      activityChanged: () => this.generationActivityChanged(),
-      hasActivePrompts: () => this.sessionInteractions.snapshot().length > 0,
-      hasActiveReviewerSessions: () => this.reviewerSessions.hasActiveSessions()
-    })
-    this.connectionTransitions = new AcpConnectionTransitionOwner({
-      blockers: () => this.generationActivity.blockers(),
-      connectionGeneration: () => this.connectionGeneration,
-      disconnect: (emitClosedStatus) => this.disconnect(emitClosedStatus),
-      onRetired: () => this.callbacks.onRetired?.(),
-      publishIdle: () => this.setStatus('idle'),
-      recoverFailedDeferredDisconnect: () => this.connectionClose.recoverFailedDeferredDisconnect(),
-      reportFailure: (message, error) => safeLogError(message, errorLogFields(error))
-    })
-    this.turnSkills = new AcpTurnSkillOwner({
-      resolveSpecialistSkills: options.resolveSpecialistSkills,
-      skills: options.skills,
-      requestSkillsReload: () => this.connectionTransitions.requestSkillsReload()
-    })
-    this.sessionConfigurator = new AcpSessionConfigurator({
-      assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
-      diagnosticContext: (backend) => this.diagnosticContext(backend.framework.id)
-    })
+    this.generationActivity = base.generationActivity
+    this.connectionTransitions = base.connectionTransitions
+    this.turnSkills = base.turnSkills
+    this.sessionConfigurator = base.sessionConfigurator
     this.promptPreparation = new AcpPromptPreparationOwner({
       promptContent: this.promptContentOwner,
       presentation: base.sessionPresentationPolicy,
@@ -769,6 +750,16 @@ class AcpRuntime {
       modelChanges: this.modelChanges,
       state: closeState,
       reportFailure: (message, error) => safeLogError(message, errorLogFields(error))
+    })
+    base.bindGenerationConnectionEffects({
+      reviewerSessions: this.reviewerSessions,
+      modelChanges: this.modelChanges,
+      connectionClose: {
+        disconnect: (emitClosedStatus) => this.disconnect(emitClosedStatus),
+        recoverFailedDeferredDisconnect: () =>
+          this.connectionClose.recoverFailedDeferredDisconnect()
+      },
+      publishIdle: () => this.setStatus('idle')
     })
     this.connectionLifecycle = new AcpConnectionLifecycleWorkflow({
       appVersion: options.appVersion,

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -333,12 +333,15 @@ describe('runtime state ownership architecture', () => {
   })
 
   it('keeps live Session Plan state behind one Runtime owner', () => {
-    const source = readSource('src/main/acp/runtime.ts')
+    const runtime = readSource('src/main/acp/runtime.ts')
+    const composition = readSource('src/main/acp/runtime-base-composition.ts')
+    const source = runtime + composition
 
     expect(source).not.toContain('planApprovalWaiters')
     expect(source).not.toContain('planExecutionBindings')
     expect(source.match(/new SessionPlanInteractionOwner\(\)/g)).toHaveLength(1)
-    expect(source).toContain('interactions: this.planInteractions')
+    expect(composition).toContain('interactions: planInteractions')
+    expect(runtime).toContain('this.planInteractions = base.planInteractions')
   })
 
   it('keeps model application and attached resume behavior behind their workflows', () => {


### PR DESCRIPTION
## Problem

`AcpRuntime` still constructed the generation-activity, connection-transition, Turn Skill, and
Session configurator owners itself. Those owners already have distinct state responsibilities, but
their construction remained coupled to Runtime callbacks and kept the facade responsible for part of
the owner graph.

## Proposed change

- construct the four owners in the canonical base composer;
- expose one bind-once generation/connection seam for the later Reviewer, ModelChange,
  ConnectionClose, and idle-publication effects;
- fail explicitly if the graph is used before binding or bound more than once;
- preserve Runtime's public `disconnect` delegation for deferred-disconnect recovery and existing
  instrumentation semantics;
- extend architecture checks so Runtime cannot resume constructing these owners, and correct the
  Session Plan assertion to inspect its canonical composition location introduced by the predecessor.

```mermaid
flowchart LR
  C["Canonical base composer"] --> G["Generation activity owner"]
  C --> T["Connection transition owner"]
  C --> S["Turn Skill owner"]
  C --> F["Session configurator"]
  R["Runtime workflow construction"] -->|"bind once"| E["Reviewer / ModelChange / ConnectionClose / idle effects"]
  E --> G
  E --> T
```

Production raw is 137. `runtime.ts` changes from 2,216 to 2,207 physical lines.

## Scope and non-goals

- No public API, IPC, wire, data model, persistence, or UI change.
- No Electron/Web/CLI/Task capability change.
- No Specialist, Permission, Compute, provider-adoption, or cleanup behavior change.
- Prompt preparation, Session/Context/Permission/Reviewer owner composition, and every workflow
  cutover remain separate follow-up leaves.
- No general dependency container, cross-domain hooks bag, Runtime lookup facade, or second state
  writer is introduced.

## Acceptance criteria and validation

All commands below ran after the final material edit.

- Fresh graph identity and bind ordering/fail-fast behavior ->
  `npm test -- --run src/main/acp/runtime-base-composition.test.ts src/main/acp/connection-transition-owner.test.ts src/main/acp/session-configurator.test.ts` -> 3 files / 20 tests passed.
- Runtime, Coordinator, IPC, Electron wiring, and architecture consumers ->
  `npm test -- --run src/main/acp/runtime-base-composition.test.ts src/main/acp/runtime.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/ipc.test.ts src/main/runtime-state-ownership.architecture.test.ts src/main/runtime-electron-wiring.test.ts src/main/application-runtime.test.ts` -> 7 files / 579 tests passed. The HTTP MCP cases ran outside the filesystem sandbox so loopback binding was available.
- Node contracts -> `npm run typecheck:node` -> passed.
- Changed-source standards -> targeted ESLint and Prettier checks -> passed.
- Patch integrity -> `git diff --check` -> passed.
- Independent review -> Standards 0 findings; Spec 0 findings.

The full cross-platform and complete portable suites are left to the authoritative online PR Gate;
there is no renderer or platform-specific production diff requiring a local E2E lane.

## Review focus

- The late seam is bind-once, fail-fast, and limited to the real generation/connection cycle.
- Deferred disconnect/recovery, `onRetired`, idle publication, and model-activity fan-out retain their
  prior ordering and public delegation.
- Session configurator current/status assertion and framework/generation/status diagnostics remain
  semantically identical.
