### PR TITLE
refactor(acp-runtime): extract session environment policy

### DIFF
--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -37,12 +37,9 @@ import { AcpPermissionContext, HUMAN_PERMISSION_ACTION_ORIGIN } from './permissi
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
-import { NOTEBOOK_SYSTEM_PROMPT_APPEND, type NotebookRpcConnection } from '../notebook/mcp-server'
+import type { NotebookRpcConnection } from '../notebook/mcp-server'
 import type { NotebookHandoffContext } from '../notebook/runtime-service'
-import {
-  SKILL_IMPORT_SYSTEM_PROMPT_APPEND,
-  type SkillImportRpcConnection
-} from '../skills/mcp-server'
+import type { SkillImportRpcConnection } from '../skills/mcp-server'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
@@ -61,10 +58,7 @@ import {
   type ReviewerSessionRequest,
   type ReviewerSessionResult
 } from './reviewer-session-owner'
-import {
-  AcpSessionCapabilityOwner,
-  CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY
-} from './session-capability-owner'
+import { AcpSessionCapabilityOwner } from './session-capability-owner'
 import { ArtifactTurnOwner, type ArtifactTurnHandle } from './artifact-turn-owner'
 import { AcpPromptContentOwner } from './prompt-content-owner'
 import {
@@ -119,6 +113,7 @@ import { PlanCommandError } from '../../shared/session-plan/contract'
 import type { SessionPlanStepStatus } from '../../shared/session-persistence'
 import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
 import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
+import { AcpSessionEnvironmentPolicy } from './session-environment-policy'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -275,40 +270,6 @@ type AcpRuntimePlanOptions = {
     | 'containsMessageOnActiveBranch'
   >
 }
-// An end_turn is final from the runtime's perspective, so promised work must be a tool call in the
-// current turn or an explicit request for user input rather than text that implies later execution.
-const TURN_CONTINUITY_SYSTEM_PROMPT_APPEND = [
-  '<open_science_turn_continuity_instructions>',
-  'Do not describe a tool-backed action as future work and then end the turn. If you say you will download, install, run, edit, analyze, or otherwise perform an action that needs a tool, issue the corresponding tool call in this same turn.',
-  'If a required tool cannot be used or its operation fails, do not promise another attempt. Clearly state that the turn has stopped, what prevented progress, and what the user can do next.',
-  '</open_science_turn_continuity_instructions>'
-].join('\n')
-// Appends artifact tool guidance as system prompt metadata so user prompts stay untouched.
-const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
-  '<open_science_artifact_instructions>',
-  'When this turn creates or saves local user-facing files such as images, documents, reports, data exports, XML, SVG, HTML, CSV, PDF, or archives, you MUST save them through the MCP tool `write_artifact_file` from the `open-science-artifacts` server.',
-  'Do not save generated user-facing files directly into the workspace or current directory unless the user explicitly asks to modify project files.',
-  'Pass the filename, MIME type, and either inline content or a local source path to `write_artifact_file`; the app assigns the project, session, Artifact run, and final message location.',
-  'If a Notebook, REPL, or shell execution produced the file, also pass `producerRunId` with the exact `runId` returned by the execution that created or last modified it. Omit `producerRunId` only when no Notebook execution produced the file; never use the Artifact run ID as the producer.',
-  'Only claim a generated file is available after `write_artifact_file` succeeds. If it fails or is denied, state that the local file may exist but was not saved as an Artifact, and do not present it as downloadable.',
-  'After using the tool, mention the generated filename rather than an absolute filesystem path. The app will display the generated file list below your message.',
-  'Never write files inside a skill directory — loaded skills are read-only; route any file a skill generates through `write_artifact_file`.',
-  '</open_science_artifact_instructions>'
-].join('\n')
-
-// Steers the agent away from reading large attached data files in their entirety, since a single big
-// read (esp. under frameworks whose read/bash tools do not hard-cap output) can exceed the provider's
-// request-size limit and break the conversation. Framework-neutral: Claude carries it in the system
-// prompt preset, opencode as a prompt prefix.
-const LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND = [
-  '<open_science_large_file_instructions>',
-  'Large attached data files (CSV, TSV, TXT, JSON, FASTA/FASTQ, VCF, and similar tabular or text data) are provided as a file reference plus a short preview, not as full inline content.',
-  'Never read, cat, or print such a file in its entirety — a single large read can exceed the request-size limit and break the conversation.',
-  'Inspect structure first (columns, row count, a few sample rows), then read only the specific line ranges, rows, or columns you need.',
-  'To analyze, filter, or aggregate over a large file, load it in the notebook (e.g. pandas) and compute there instead of reading its contents into the conversation.',
-  '</open_science_large_file_instructions>'
-].join('\n')
-
 // Converts unknown thrown values into user-visible error text. Total AND always returns a string: a
 // hostile message getter or a throwing String() coercion (e.g. a Proxy-wrapped Error) must not escape,
 // and a non-string message (object/bigint/Symbol/undefined) must be coerced — this text flows into the
@@ -373,6 +334,7 @@ class AcpRuntime {
   private readonly turnSkills: AcpTurnSkillOwner
   private readonly handoffContinuity: AcpHandoffContinuityOwner
   private readonly permissionContext: AcpPermissionContext
+  private readonly sessionEnvironment: AcpSessionEnvironmentPolicy
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
   private readonly backendGeneration: AcpBackendGenerationOwner
@@ -465,12 +427,20 @@ class AcpRuntime {
       },
       removeStartupBlocker: (token) => this.generationActivity.releaseStartup(token)
     })
+    this.sessionEnvironment = new AcpSessionEnvironmentPolicy({
+      backendGeneration: this.backendGeneration,
+      capabilities: this.sessionCapabilities,
+      presentation: base.sessionPresentationPolicy,
+      registry: this.sessionRegistry,
+      defaultProjectName: options.artifacts?.projectName,
+      ...(this.planService ? { planSystemPromptAppend: SESSION_PLAN_SYSTEM_PROMPT_APPEND } : {})
+    })
     this.contextUsagePolicy = new AcpContextUsagePolicy({
       backend: () => this.backend,
       appliedModel: (sessionId) =>
         this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().appliedModel,
-      systemPromptAppends: () => this.getSystemPromptAppends(),
-      tooling: () => this.currentCapabilityAvailability()
+      systemPromptAppends: () => this.sessionEnvironment.systemPromptAppends(),
+      tooling: () => this.sessionEnvironment.toolingAvailability()
     })
     this.sessionUpdateProjector = new AcpSessionUpdateProjector({
       registry: this.sessionRegistry,
@@ -601,7 +571,7 @@ class AcpRuntime {
       permission: this.permissionContext,
       environment: {
         backend: () => this.backend,
-        tooling: () => this.currentCapabilityAvailability(),
+        tooling: () => this.sessionEnvironment.toolingAvailability(),
         bridgeSkillsAvailable: () => this.connectionResources.bridgeSkillsAvailable,
         skillImportEnabled: () => this.sessionCapabilities.isSkillImportEnabled(),
         contextEstimateInput: (sessionId) =>
@@ -1552,7 +1522,9 @@ class AcpRuntime {
             ? { framework: this.framework, executablePath: '', env: {} }
             : await this.options.resolveBackend?.({
                 forcedSkillIds: [...this.turnSkills.backendPreparation().forcedSkillIds],
-                systemPromptAppends: await this.getBackendSystemPromptAppends()
+                systemPromptAppends: [
+                  ...(await this.sessionEnvironment.backendSystemPromptAppends())
+                ]
               })
           if (!backend) throw new Error('ACP agent spawn configuration is not available.')
           return backend
@@ -1901,65 +1873,9 @@ class AcpRuntime {
     ]
   }
 
-  // Collects the system-prompt guidance appended to every session, plus app tooling
-  // instructions when those services are wired. Skill privacy is enforced at the presentation layer;
-  // agent prompts must not block native progressive loading of a selected SKILL.md.
-  private notebookToolingAvailable(): boolean {
-    return this.currentCapabilityAvailability().notebook
-  }
-
-  private skillImportToolingAvailable(): boolean {
-    return this.currentCapabilityAvailability().skillImport
-  }
-
-  private artifactToolingAvailable(): boolean {
-    return this.currentCapabilityAvailability().artifacts
-  }
-
-  private currentCapabilityAvailability(): ReturnType<
-    AcpSessionCapabilityOwner['toolingAvailability']
-  > {
-    return this.sessionCapabilities.toolingAvailability({
-      framework: this.framework,
-      nativeMcpEnabled: this.backend.adapter.nativeMcpEnabled,
-      bridgeMcpAliasesEnabled: this.backend.adapter.bridgeMcpAliasesEnabled,
-      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY
-    })
-  }
-
-  private getAppSystemPromptAppends(): string[] {
-    return [
-      TURN_CONTINUITY_SYSTEM_PROMPT_APPEND,
-      LARGE_DATA_FILE_SYSTEM_PROMPT_APPEND,
-      ...(this.artifactToolingAvailable() ? [ARTIFACT_FILE_SYSTEM_PROMPT_APPEND] : []),
-      ...(this.notebookToolingAvailable() ? [NOTEBOOK_SYSTEM_PROMPT_APPEND] : []),
-      ...(this.skillImportToolingAvailable() ? [SKILL_IMPORT_SYSTEM_PROMPT_APPEND] : []),
-      ...(this.planService ? [SESSION_PLAN_SYSTEM_PROMPT_APPEND] : [])
-    ]
-  }
-
-  private async getBackendSystemPromptAppends(): Promise<string[]> {
-    await this.sessionCapabilities.refreshDynamicAvailability()
-    return this.getAppSystemPromptAppends()
-  }
-
-  private getSystemPromptAppends(skillGuidance?: string): string[] {
-    // Each append names MCP tools that only exist when that tooling is actually wired for this session;
-    // omit it otherwise so the agent isn't told to use tools it wasn't given.
-    return [
-      ...this.getAppSystemPromptAppends(),
-      ...this.backend.prompt.systemPromptAppends,
-      ...(skillGuidance ? [skillGuidance] : [])
-    ]
-  }
-
   // Resolves the artifact/notebook storage project for a session, defaulting to the runtime constant.
   private resolveSessionProjectName(sessionId: string): string {
-    return (
-      this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().projectName ??
-      this.artifactOptions?.projectName ??
-      DEFAULT_UPLOAD_PROJECT_NAME
-    )
+    return this.sessionEnvironment.projectName(sessionId)
   }
 
   // Marks a new assistant turn as the active artifact run before the model can call the MCP tool.

--- a/src/main/acp/session-environment-policy.test.ts
+++ b/src/main/acp/session-environment-policy.test.ts
@@ -1,0 +1,142 @@
+import type { ActiveSession } from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
+import { DEFAULT_UPLOAD_PROJECT_NAME } from '../../shared/uploads'
+import { codexFramework, opencodeFramework } from '../agent-framework'
+import { AcpBackendGenerationOwner } from './backend-generation-owner'
+import { AcpSessionEnvironmentPolicy } from './session-environment-policy'
+import { AcpSessionRegistry } from './session-registry'
+
+const permissionProfile = (): SessionPermissionProfileState => ({
+  selectedProfile: 'ask',
+  effectiveProfile: 'ask',
+  currentModeId: 'default',
+  availableModeIds: ['default'],
+  fullAccessAvailable: false
+})
+
+const publishSession = (
+  registry: AcpSessionRegistry,
+  appSessionId: string,
+  projectName: string
+): void => {
+  const reservation = registry.reserve({ sessionIds: [appSessionId] })
+  if (reservation.collision) throw reservation.collision
+  registry.publish(reservation.reservation, appSessionId, {
+    session: { sessionId: appSessionId } as unknown as ActiveSession,
+    cwd: '/workspace',
+    projectName,
+    frameworkId: 'codex',
+    permissionProfile: permissionProfile()
+  })
+  reservation.reservation.release()
+}
+
+type SessionEnvironmentFixture = Readonly<{
+  backendGeneration: AcpBackendGenerationOwner
+  refreshDynamicAvailability: ReturnType<typeof vi.fn>
+  toolingAvailability: ReturnType<typeof vi.fn>
+  applicationSystemPromptAppends: ReturnType<typeof vi.fn>
+  registry: AcpSessionRegistry
+  policy: AcpSessionEnvironmentPolicy
+}>
+
+const createPolicy = (
+  defaultProjectName: string | undefined = 'default-project'
+): SessionEnvironmentFixture => {
+  const backendGeneration = new AcpBackendGenerationOwner(codexFramework)
+  const refreshDynamicAvailability = vi.fn(async () => undefined)
+  const toolingAvailability = vi.fn(() =>
+    Object.freeze({
+      artifacts: true,
+      notebook: false,
+      skillImport: true,
+      plan: false,
+      hostAgents: false
+    })
+  )
+  const applicationSystemPromptAppends = vi.fn(() => Object.freeze(['Application guidance.']))
+  const registry = new AcpSessionRegistry()
+  const policy = new AcpSessionEnvironmentPolicy({
+    backendGeneration,
+    capabilities: { refreshDynamicAvailability, toolingAvailability },
+    presentation: { applicationSystemPromptAppends },
+    registry,
+    ...(defaultProjectName ? { defaultProjectName } : {}),
+    planSystemPromptAppend: 'Plan guidance.'
+  })
+
+  return {
+    backendGeneration,
+    refreshDynamicAvailability,
+    toolingAvailability,
+    applicationSystemPromptAppends,
+    registry,
+    policy
+  }
+}
+
+describe('ACP Session environment policy', () => {
+  it('derives immutable prompt appends and current tooling without caching backend facts', () => {
+    const fixture = createPolicy()
+
+    expect(fixture.policy.systemPromptAppends('Skill guidance.')).toEqual([
+      'Application guidance.',
+      'Plan guidance.',
+      'Skill guidance.'
+    ])
+    expect(Object.isFrozen(fixture.policy.systemPromptAppends())).toBe(true)
+    expect(fixture.toolingAvailability).toHaveBeenLastCalledWith({
+      framework: codexFramework,
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: { role: 'primary', delegation: 'denied' }
+    })
+
+    fixture.backendGeneration
+      .prepare(
+        { epoch: 1, assertCurrent: vi.fn() },
+        {
+          framework: opencodeFramework,
+          executablePath: '/bin/opencode',
+          env: {},
+          systemPromptAppends: ['Backend guidance.']
+        }
+      )
+      .publish()
+
+    expect(fixture.policy.systemPromptAppends()).toEqual([
+      'Application guidance.',
+      'Plan guidance.',
+      'Backend guidance.'
+    ])
+    expect(fixture.toolingAvailability).toHaveBeenLastCalledWith(
+      expect.objectContaining({ framework: opencodeFramework })
+    )
+  })
+
+  it('refreshes dynamic capability state before backend-native prompt projection', async () => {
+    const fixture = createPolicy()
+
+    await expect(fixture.policy.backendSystemPromptAppends()).resolves.toEqual([
+      'Application guidance.',
+      'Plan guidance.'
+    ])
+    expect(fixture.refreshDynamicAvailability).toHaveBeenCalledOnce()
+    expect(fixture.applicationSystemPromptAppends).toHaveBeenCalledAfter(
+      fixture.refreshDynamicAvailability
+    )
+  })
+
+  it('resolves live Session projects before the configured and runtime fallbacks', () => {
+    const fixture = createPolicy()
+
+    expect(fixture.policy.projectName('missing')).toBe('default-project')
+    publishSession(fixture.registry, 'session-1', 'session-project')
+    expect(fixture.policy.projectName('session-1')).toBe('session-project')
+
+    const runtimeFallback = createPolicy(undefined).policy
+    expect(runtimeFallback.projectName('missing')).toBe(DEFAULT_UPLOAD_PROJECT_NAME)
+  })
+})

--- a/src/main/acp/session-environment-policy.ts
+++ b/src/main/acp/session-environment-policy.ts
@@ -1,0 +1,66 @@
+import { DEFAULT_UPLOAD_PROJECT_NAME } from '../../shared/uploads'
+import type { AcpBackendGenerationOwner } from './backend-generation-owner'
+import type { AcpSessionCapabilityOwner } from './session-capability-owner'
+import { CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY } from './session-capability-owner'
+import type { AcpSessionPresentationPolicy } from './session-presentation-policy'
+import type { AcpSessionRegistry } from './session-registry'
+
+type AcpSessionEnvironmentPolicyOptions = Readonly<{
+  backendGeneration: Pick<AcpBackendGenerationOwner, 'current'>
+  capabilities: Pick<
+    AcpSessionCapabilityOwner,
+    'refreshDynamicAvailability' | 'toolingAvailability'
+  >
+  presentation: Pick<AcpSessionPresentationPolicy, 'applicationSystemPromptAppends'>
+  registry: Pick<AcpSessionRegistry, 'lookup'>
+  defaultProjectName?: string
+  planSystemPromptAppend?: string
+}>
+
+// Derives current Session environment facts directly from their owners; no framework, tooling, or
+// project selection is mirrored or cached here.
+class AcpSessionEnvironmentPolicy {
+  constructor(private readonly options: AcpSessionEnvironmentPolicyOptions) {}
+
+  toolingAvailability(): ReturnType<AcpSessionCapabilityOwner['toolingAvailability']> {
+    const backend = this.options.backendGeneration.current
+    return this.options.capabilities.toolingAvailability({
+      framework: backend.framework,
+      nativeMcpEnabled: backend.adapter.nativeMcpEnabled,
+      bridgeMcpAliasesEnabled: backend.adapter.bridgeMcpAliasesEnabled,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY
+    })
+  }
+
+  applicationSystemPromptAppends(): readonly string[] {
+    return Object.freeze([
+      ...this.options.presentation.applicationSystemPromptAppends(this.toolingAvailability()),
+      ...(this.options.planSystemPromptAppend ? [this.options.planSystemPromptAppend] : [])
+    ])
+  }
+
+  async backendSystemPromptAppends(): Promise<readonly string[]> {
+    await this.options.capabilities.refreshDynamicAvailability()
+    return this.applicationSystemPromptAppends()
+  }
+
+  systemPromptAppends(skillGuidance?: string): readonly string[] {
+    const backend = this.options.backendGeneration.current
+    return Object.freeze([
+      ...this.applicationSystemPromptAppends(),
+      ...backend.prompt.systemPromptAppends,
+      ...(skillGuidance ? [skillGuidance] : [])
+    ])
+  }
+
+  projectName(sessionId: string): string {
+    return (
+      this.options.registry.lookup(sessionId)?.aggregate.snapshot().projectName ??
+      this.options.defaultProjectName ??
+      DEFAULT_UPLOAD_PROJECT_NAME
+    )
+  }
+}
+
+export { AcpSessionEnvironmentPolicy }
+export type { AcpSessionEnvironmentPolicyOptions }


### PR DESCRIPTION
## Problem

`AcpRuntime` still derived Session environment facts itself: current tooling availability, application/backend prompt appends, and the Session project fallback. That kept presentation constants duplicated in the Runtime facade and mixed live owner reads with protocol workflow wiring.

## Proposed change

Add `AcpSessionEnvironmentPolicy` as the single read-only derivation boundary for those facts and delegate the existing Runtime call sites to it.

```mermaid
flowchart LR
  R["AcpRuntime"] --> E["SessionEnvironmentPolicy"]
  E --> B["BackendGenerationOwner"]
  E --> C["SessionCapabilityOwner"]
  E --> P["SessionPresentationPolicy"]
  E --> S["SessionRegistry"]
```

The policy reads every value live from the authoritative owner. It does not cache framework, capability, prompt, or project state. Backend-native prompt projection still refreshes dynamic Skill Import availability before it derives appends.

This is ARD-28E2b1, split automatically from the larger Session owner-composition leaf because the first combined compile measured about 688 production raw lines, above the approved 600-line limit. This leaf measures 190 production raw lines and reduces `runtime.ts` from 2,207 to 2,136 lines.

## Scope and non-goals

- Preserve prompt append order: application guidance, optional Session Plan guidance, backend guidance, then optional Skill guidance.
- Preserve project resolution: live Session project, configured Artifact project, then `DEFAULT_UPLOAD_PROJECT_NAME`.
- Preserve `CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY` and dynamic Skill Import refresh ordering.
- Do not change IPC, wire contracts, persistence, data models, UI, or user interaction.
- Do not change Specialist, Permission, or Compute behavior.
- Do not change the existing Electron/Web/CLI/Task capability asymmetry.
- Do not introduce Issue #458 orchestration state or public interfaces.
- Session registry, Permission, Reviewer, publication, and final Runtime composition remain for the serial E2b2 leaf.

## Acceptance criteria and validation

All commands below ran against the final committed content after the last material edit.

- Environment ownership and immutable/live derivation -> `npm test -- --run src/main/acp/session-environment-policy.test.ts src/main/acp/session-presentation-policy.test.ts src/main/acp/context-usage-policy.test.ts src/main/acp/runtime-base-composition.test.ts src/main/runtime-state-ownership.architecture.test.ts` -> 5 files, 54 tests passed.
- Backend prompt projection and reconnect-sensitive guidance -> focused `src/main/acp/runtime.test.ts` run covering Claude large-file/connector guidance, Codex/OpenCode persistent guidance, and OpenCode MCP restoration -> 5 tests passed, 435 skipped by explicit filter.
- Electron/Web/CLI/Task and IPC surface compatibility -> focused 8-file surface set covering ACP IPC/application commands/task port, renderer matrix, Web RPC, preload adapter, client, and CLI -> 8 files, 99 tests passed.
- Node process contracts -> `npm run typecheck:node` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings outside this diff.
- Changed-file format and whitespace -> Prettier check and `git diff --check` -> passed.
- Independent review -> Standards: 0 findings; Spec: 0 findings.

Online PR Gate remains authoritative for the full portable suite and platform lanes. No local packaged Electron or Windows E2E run was performed because this leaf changes no transport, renderer, native process, or platform-specific path.

## Review focus

- Confirm the policy only derives live values and owns no mutable state.
- Confirm prompt append and dynamic refresh ordering are byte-for-byte compatible with the former Runtime implementation.
- Confirm project and tooling fallbacks still read the same authoritative owners.
- Confirm Runtime loses derivation responsibility without gaining a generic hooks bag or a second state writer.
