### PR TITLE
refactor(acp-runtime): compose session owner graph

### DIFF
--- a/src/main/acp/reviewer-session-owner.ts
+++ b/src/main/acp/reviewer-session-owner.ts
@@ -123,13 +123,16 @@ export type ReviewerSessionOwnerDependencies = {
     sessionOptions: Record<string, unknown> | undefined
   }
   currentStartupGeneration: () => number
-  ensureConnected: (cwd: string) => Promise<ClientConnection>
   isPrimarySessionIdClaimed: (sessionId: string) => boolean
   onActiveSessionReleased: () => void
   registerBridgeSession: (sessionId: string) => void
   removeStartupBlocker: (token: symbol) => void
   unregisterBridgeSession: (sessionId: string) => boolean | undefined
 }
+
+export type ReviewerSessionCreateCapability = Readonly<{
+  ensureConnected: (cwd: string) => Promise<ClientConnection>
+}>
 
 // Owns every ephemeral Reviewer startup, identity, and resource. Runtime supplies only current
 // connection/setup facts plus narrow collision, bridge, cleanup, and startup-blocker ports.
@@ -141,9 +144,12 @@ export class ReviewerSessionOwner {
 
   constructor(private readonly dependencies: ReviewerSessionOwnerDependencies) {}
 
-  async create(request: ReviewerSessionRequest): Promise<ReviewerSessionResult> {
+  async create(
+    request: ReviewerSessionRequest,
+    capability: ReviewerSessionCreateCapability
+  ): Promise<ReviewerSessionResult> {
     const mcpServerNames = this.validateRequest(request)
-    const connection = await this.dependencies.ensureConnected(request.cwd)
+    const connection = await capability.ensureConnected(request.cwd)
     this.dependencies.assertCurrentConnection(connection)
     const { framework, sessionOptions } = this.dependencies.currentSessionSetup()
     const startupGeneration = this.dependencies.currentStartupGeneration()

--- a/src/main/acp/runtime-base-composition.test.ts
+++ b/src/main/acp/runtime-base-composition.test.ts
@@ -95,8 +95,9 @@ describe('ACP Runtime base composition', () => {
     )
     expect(composer).not.toMatch(/from ['"]electron['"]|import \{ AcpRuntime \}/)
     expect(composer).toContain("import type { AcpRuntimeOptions } from './runtime'")
+    expect(applicationComposition).toContain('composeAcpRuntimeBaseOwners(runtimeOptions)')
     expect(applicationComposition).toContain(
-      'new AcpRuntime(runtimeOptions, composeAcpRuntimeBaseOwners(runtimeOptions))'
+      'composeAcpRuntimeSessionOwners(runtimeOptions, baseOwners)'
     )
     expect(runtime + applicationComposition).not.toContain('runtime.test-utils')
   })

--- a/src/main/acp/runtime-base-composition.ts
+++ b/src/main/acp/runtime-base-composition.ts
@@ -185,6 +185,7 @@ const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
     sessionInteractions,
     sessionCapabilities,
     generationActivity,
+    notifyGenerationActivityChanged: generationActivityChanged,
     connectionTransitions,
     bindGenerationConnectionEffects,
     turnSkills,

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -34,6 +34,7 @@ import { projectRegistrySessionGrants } from './permission-broker'
 import { AcpRuntime, type AcpRuntimeCallbacks, type AcpRuntimeOptions } from './runtime'
 import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
 import { AcpRuntimeCoordinator } from './runtime-coordinator'
+import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
 
 const log = createLogger('acp')
 
@@ -251,7 +252,12 @@ const createAcpRuntime = ({
             }
           : undefined
       }
-      return new AcpRuntime(runtimeOptions, composeAcpRuntimeBaseOwners(runtimeOptions))
+      const baseOwners = composeAcpRuntimeBaseOwners(runtimeOptions)
+      return new AcpRuntime(
+        runtimeOptions,
+        baseOwners,
+        composeAcpRuntimeSessionOwners(runtimeOptions, baseOwners)
+      )
     },
     callbacks,
     defaultCwd,

--- a/src/main/acp/runtime-publication-owner.test.ts
+++ b/src/main/acp/runtime-publication-owner.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpPermissionRequest } from '../../shared/acp'
+import { AcpRuntimePublicationOwner } from './runtime-publication-owner'
+import { AcpRuntimeSnapshotOwner, type RuntimeSnapshotProjection } from './runtime-snapshot-owner'
+import { AcpSessionInteractionOwner } from './session-interaction-owner'
+
+const createProjection = (): RuntimeSnapshotProjection => ({
+  sessionIds: ['session-1'],
+  pendingPermissions: [],
+  permissionProfiles: {},
+  permissionGrants: { 'session-1': [] },
+  contextUsageBySession: {},
+  promptInFlight: false,
+  promptInFlightSessionIds: []
+})
+
+describe('AcpRuntimePublicationOwner', () => {
+  it('publishes an event only after append hooks and before the resulting state', () => {
+    const order: string[] = []
+    const snapshotOwner = new AcpRuntimeSnapshotOwner('/workspace')
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner,
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection: createProjection,
+      callbacks: {
+        onEvent: () => order.push('event'),
+        onStateChanged: () => order.push('state')
+      }
+    })
+
+    owner.pushEvent({ kind: 'message', level: 'info', text: 'hello' }, () => order.push('appended'))
+
+    expect(order).toEqual(['appended', 'event', 'state'])
+    expect(owner.getSnapshot().events).toEqual([
+      expect.objectContaining({ id: 'acp-event-1', kind: 'message', text: 'hello' })
+    ])
+  })
+
+  it('keeps the established permission event-state-callback-state order', () => {
+    const order: string[] = []
+    const request: AcpPermissionRequest = {
+      requestId: 'request-1',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Run command',
+      options: []
+    }
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection: createProjection,
+      callbacks: {
+        onEvent: () => order.push('event'),
+        onStateChanged: () => order.push('state'),
+        onPermissionRequest: () => order.push('permission')
+      }
+    })
+
+    owner.publishPermissionRequest(request)
+
+    expect(order).toEqual(['event', 'state', 'permission', 'state'])
+    expect(owner.getSnapshot().events[0]).toMatchObject({
+      kind: 'permission',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      raw: request
+    })
+  })
+
+  it('attaches only the active prompt id and preserves an explicit event id', () => {
+    const interactions = new AcpSessionInteractionOwner()
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+      interactions,
+      snapshotProjection: createProjection,
+      callbacks: {}
+    })
+    const prompt = interactions.claim({
+      sessionId: 'session-1',
+      kind: 'prompt',
+      promptMessageId: 'active-prompt'
+    })
+
+    owner.pushEvent({
+      kind: 'message',
+      level: 'info',
+      sessionId: 'session-1',
+      text: 'inherited'
+    })
+    owner.pushEvent({
+      kind: 'message',
+      level: 'info',
+      sessionId: 'session-1',
+      promptMessageId: 'explicit-prompt',
+      text: 'explicit'
+    })
+    interactions.release(prompt)
+    const compaction = interactions.claim({ sessionId: 'session-1', kind: 'compaction' })
+    owner.pushEvent({
+      kind: 'message',
+      level: 'info',
+      sessionId: 'session-1',
+      text: 'compaction'
+    })
+    interactions.release(compaction)
+
+    expect(owner.getSnapshot().events).toEqual([
+      expect.objectContaining({ text: 'inherited', promptMessageId: 'active-prompt' }),
+      expect.objectContaining({ text: 'explicit', promptMessageId: 'explicit-prompt' }),
+      expect.objectContaining({ text: 'compaction', promptMessageId: undefined })
+    ])
+  })
+
+  it('reads every snapshot projection live and shares the snapshot event sequence', () => {
+    const snapshotOwner = new AcpRuntimeSnapshotOwner('/workspace')
+    const snapshotProjection = vi
+      .fn<() => RuntimeSnapshotProjection>()
+      .mockReturnValueOnce(createProjection())
+      .mockReturnValue({ ...createProjection(), sessionIds: ['session-2'] })
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner,
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection,
+      callbacks: {}
+    })
+
+    expect(owner.getSnapshot().sessionIds).toEqual(['session-1'])
+    expect(owner.nextEventId()).toBe('acp-event-1')
+    owner.pushEvent({ kind: 'message', level: 'info', text: 'after reservation' })
+
+    expect(owner.getSnapshot().sessionIds).toEqual(['session-2'])
+    expect(owner.getSnapshot().events[0]?.id).toBe('acp-event-2')
+    expect(snapshotProjection).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/main/acp/runtime-publication-owner.ts
+++ b/src/main/acp/runtime-publication-owner.ts
@@ -1,0 +1,68 @@
+import type { AcpPermissionRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
+import type { AcpSessionInteractionOwner } from './session-interaction-owner'
+import type {
+  AcpRuntimeSnapshotOwner,
+  RuntimeEventInput,
+  RuntimeSnapshotProjection
+} from './runtime-snapshot-owner'
+
+type AcpRuntimePublicationCallbacks = Readonly<{
+  onEvent?: (event: AcpRuntimeEvent) => void
+  onPermissionRequest?: (request: AcpPermissionRequest) => void
+  onStateChanged?: (snapshot: AcpStateSnapshot) => void
+}>
+
+type AcpRuntimePublicationOwnerOptions = Readonly<{
+  snapshotOwner: Pick<AcpRuntimeSnapshotOwner, 'appendEvent' | 'nextEventId' | 'snapshot'>
+  interactions: Pick<AcpSessionInteractionOwner, 'current'>
+  snapshotProjection: () => RuntimeSnapshotProjection
+  callbacks: AcpRuntimePublicationCallbacks
+}>
+
+// Owns renderer publication order while AcpRuntimeSnapshotOwner remains the sole event/status writer.
+// Every projection is read live from the authoritative owners; this owner caches no runtime facts.
+class AcpRuntimePublicationOwner {
+  constructor(private readonly options: AcpRuntimePublicationOwnerOptions) {}
+
+  getSnapshot(): AcpStateSnapshot {
+    return this.options.snapshotOwner.snapshot(this.options.snapshotProjection())
+  }
+
+  nextEventId(): string {
+    return this.options.snapshotOwner.nextEventId()
+  }
+
+  pushEvent(event: RuntimeEventInput, onAppended?: () => void): void {
+    const interaction = event.sessionId
+      ? this.options.interactions.current(event.sessionId)
+      : undefined
+    const promptMessageId = interaction?.kind === 'prompt' ? interaction.promptMessageId : undefined
+    const scopedEvent =
+      promptMessageId && !event.promptMessageId ? { ...event, promptMessageId } : event
+    const runtimeEvent = this.options.snapshotOwner.appendEvent(scopedEvent)
+    onAppended?.()
+    this.options.callbacks.onEvent?.(runtimeEvent)
+    this.emitState()
+  }
+
+  publishPermissionRequest(request: AcpPermissionRequest): void {
+    this.pushEvent({
+      kind: 'permission',
+      level: 'warning',
+      sessionId: request.sessionId,
+      toolCallId: request.toolCallId,
+      title: 'Permission requested',
+      text: request.title,
+      raw: request
+    })
+    this.options.callbacks.onPermissionRequest?.(request)
+    this.emitState()
+  }
+
+  emitState(): void {
+    this.options.callbacks.onStateChanged?.(this.getSnapshot())
+  }
+}
+
+export { AcpRuntimePublicationOwner }
+export type { AcpRuntimePublicationCallbacks, AcpRuntimePublicationOwnerOptions }

--- a/src/main/acp/runtime-session-composition.test.ts
+++ b/src/main/acp/runtime-session-composition.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { ContextUsageTracker } from './context-usage-tracker'
+import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
+
+describe('ACP Runtime session composition', () => {
+  it('builds a fresh frozen owner graph around the supplied base owners', () => {
+    const contextUsageTracker = new ContextUsageTracker()
+    const options = {
+      appVersion: 'test',
+      defaultCwd: '/workspace',
+      contextUsageTracker
+    }
+    const firstBase = composeAcpRuntimeBaseOwners(options)
+    const secondBase = composeAcpRuntimeBaseOwners(options)
+    const first = composeAcpRuntimeSessionOwners(options, firstBase)
+    const second = composeAcpRuntimeSessionOwners(options, secondBase)
+
+    expect(Object.isFrozen(first)).toBe(true)
+    expect(first.sessionRegistry).not.toBe(second.sessionRegistry)
+    expect(first.sessionEnvironment).not.toBe(second.sessionEnvironment)
+    expect(first.contextUsagePolicy).not.toBe(second.contextUsagePolicy)
+    expect(first.publication).not.toBe(second.publication)
+    expect(first.permissionContext).not.toBe(second.permissionContext)
+    expect(first.reviewerSessions).not.toBe(second.reviewerSessions)
+    expect(first.sessionUpdateProjector).not.toBe(second.sessionUpdateProjector)
+    expect(first.publication.getSnapshot()).toMatchObject({
+      cwd: '/workspace',
+      sessionIds: [],
+      contextUsageBySession: {}
+    })
+  })
+})

--- a/src/main/acp/runtime-session-composition.ts
+++ b/src/main/acp/runtime-session-composition.ts
@@ -1,0 +1,197 @@
+import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
+import { SESSION_PLAN_SYSTEM_PROMPT_APPEND } from '../session-plan/guidance'
+import { createLogger } from '../logger'
+import { AcpContextUsagePolicy } from './context-usage-policy'
+import { AcpPermissionContext } from './permission-context'
+import { ReviewerSessionOwner } from './reviewer-session-owner'
+import type { AcpRuntimeOptions } from './runtime'
+import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
+import { AcpRuntimePublicationOwner } from './runtime-publication-owner'
+import type { RuntimeSnapshotProjection } from './runtime-snapshot-owner'
+import { AcpSessionEnvironmentPolicy } from './session-environment-policy'
+import { AcpSessionRegistry } from './session-registry'
+import { AcpSessionUpdateProjector } from './session-update-projector'
+
+const log = createLogger('acp')
+
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRuntimeBaseOwners) => {
+  const callbacks = options.callbacks ?? {}
+  const activeSessionIds = (): string[] =>
+    sessionRegistry.entries(true).map(({ appSessionId }) => appSessionId)
+  const promptInFlightSessionIds = (): string[] => {
+    const interactions = base.sessionInteractions.snapshot()
+    return [
+      ...interactions.filter(({ kind }) => kind === 'prompt'),
+      ...interactions.filter(({ kind }) => kind === 'compaction')
+    ].map(({ sessionId }) => sessionId)
+  }
+  const snapshotProjection = (): RuntimeSnapshotProjection => {
+    const sessionIds = activeSessionIds()
+    const promptInFlightIds = promptInFlightSessionIds()
+    const permissionProfiles: Record<string, SessionPermissionProfileState> = {}
+    for (const { appSessionId: sessionId, aggregate } of sessionRegistry.entries()) {
+      const profile = aggregate.snapshot().permissionProfile
+      if (profile) permissionProfiles[sessionId] = profile as SessionPermissionProfileState
+    }
+
+    return {
+      sessionId: sessionRegistry.currentSessionId,
+      sessionIds,
+      pendingPermissions: permissionContext.getPendingRequests(),
+      permissionProfiles,
+      permissionGrants: Object.fromEntries(
+        sessionIds.map((sessionId) => [sessionId, permissionContext.listGrants(sessionId)])
+      ),
+      contextUsageBySession: base.contextUsageTracker.usageSnapshot(),
+      nativeContextCompactionSessionIds:
+        base.backendGeneration.current.framework.contextCompaction.kind === 'native-command'
+          ? sessionIds
+          : [],
+      promptInFlight: promptInFlightIds.length > 0,
+      promptInFlightSessionIds: promptInFlightIds
+    }
+  }
+  const publication = new AcpRuntimePublicationOwner({
+    snapshotOwner: base.snapshotOwner,
+    interactions: base.sessionInteractions,
+    snapshotProjection,
+    callbacks
+  })
+  const sessionRegistry = new AcpSessionRegistry({
+    addStartupBlocker: (token) => base.generationActivity.acquireStartup(token),
+    foreignIdentityCollision: (sessionIds) => {
+      const pendingReviewerCollision = sessionIds.find((sessionId) =>
+        reviewerSessions.hasPendingSessionId(sessionId)
+      )
+      if (pendingReviewerCollision) {
+        return new Error(
+          `Primary session id collision with pending reviewer: ${pendingReviewerCollision}`
+        )
+      }
+      const activeReviewerCollision = sessionIds.find((sessionId) =>
+        reviewerSessions.hasActiveSessionId(sessionId)
+      )
+      return activeReviewerCollision
+        ? new Error(`Primary session id collision with reviewer: ${activeReviewerCollision}`)
+        : undefined
+    },
+    removeStartupBlocker: (token) => base.generationActivity.releaseStartup(token)
+  })
+  const sessionEnvironment = new AcpSessionEnvironmentPolicy({
+    backendGeneration: base.backendGeneration,
+    capabilities: base.sessionCapabilities,
+    presentation: base.sessionPresentationPolicy,
+    registry: sessionRegistry,
+    defaultProjectName: options.artifacts?.projectName,
+    ...(base.planService ? { planSystemPromptAppend: SESSION_PLAN_SYSTEM_PROMPT_APPEND } : {})
+  })
+  const contextUsagePolicy = new AcpContextUsagePolicy({
+    backend: () => base.backendGeneration.current,
+    appliedModel: (sessionId) =>
+      sessionRegistry.lookup(sessionId)?.aggregate.snapshot().appliedModel,
+    systemPromptAppends: () => sessionEnvironment.systemPromptAppends(),
+    tooling: () => sessionEnvironment.toolingAvailability()
+  })
+  const permissionContext = new AcpPermissionContext({
+    emitPermissionRequest: (request) => publication.publishPermissionRequest(request),
+    routing: {
+      resolveAppSessionId: (sessionId) => sessionRegistry.resolveAppSessionId(sessionId),
+      sessionSnapshot: (sessionId) => {
+        const snapshot = sessionRegistry.lookup(sessionId)?.aggregate.snapshot()
+        return snapshot
+          ? {
+              cwd: snapshot.cwd,
+              frameworkId: snapshot.frameworkId,
+              permissionProfile: snapshot.permissionProfile
+            }
+          : undefined
+      },
+      hasActivePrimarySession: (sessionId) =>
+        sessionRegistry.lookup(sessionId)?.attachment !== undefined,
+      capturePrompt: (sessionId) => {
+        const scope = base.sessionInteractions.current(sessionId)
+        return scope?.kind === 'prompt'
+          ? {
+              sequence: scope.sequence,
+              isCancellationAccepted: () => base.sessionInteractions.isCancellationAccepted(scope)
+            }
+          : undefined
+      },
+      currentInteractionSequence: (sessionId) =>
+        base.sessionInteractions.current(sessionId)?.sequence,
+      mcpServerNamesFor: (sessionId) => base.sessionCapabilities.mcpServerNamesFor(sessionId),
+      reviewerContextFor: (sessionId) => reviewerSessions.contextFor(sessionId),
+      resolveReviewerPermission: (request) => reviewerSessions.resolvePermission(request),
+      currentFramework: () => base.backendGeneration.current.framework,
+      resolveProjectId: (sessionId) => sessionEnvironment.projectName(sessionId)
+    },
+    conversationGrants: options.permissionGrantStore,
+    permissionGrantRegistry: options.permissionGrantRegistry,
+    setTimer: base.setTimer,
+    clearTimer: base.clearTimer,
+    onOpenCodeWaitTimeout: ({ sessionId, toolCallId, waitMs }) => {
+      log.warn('OpenCode permission context wait timed out', { sessionId, toolCallId, waitMs })
+    }
+  })
+  const reviewerSessions = new ReviewerSessionOwner({
+    addStartupBlocker: (token) => base.generationActivity.acquireStartup(token),
+    assertCurrentConnection: (connection) => {
+      if (
+        base.connectionResources.connection !== connection ||
+        base.snapshotOwner.status !== 'connected'
+      ) {
+        throw new Error('ACP session startup was superseded.')
+      }
+    },
+    clearPermissionCorrelations: (sessionId) =>
+      permissionContext.clearCorrelationsForSession(sessionId),
+    currentSessionSetup: () => ({
+      framework: base.backendGeneration.current.framework,
+      sessionOptions: base.backendGeneration.current.session.options
+    }),
+    currentStartupGeneration: () => sessionRegistry.startupGeneration,
+    isPrimarySessionIdClaimed: (sessionId) => sessionRegistry.isIdentityClaimed(sessionId),
+    onActiveSessionReleased: base.notifyGenerationActivityChanged,
+    registerBridgeSession: (sessionId) =>
+      base.connectionResources.registerBridgeReviewerSession(sessionId),
+    removeStartupBlocker: (token) => base.generationActivity.releaseStartup(token),
+    unregisterBridgeSession: (sessionId) =>
+      base.connectionResources.unregisterBridgeReviewerSession(sessionId)
+  })
+  const sessionUpdateProjector = new AcpSessionUpdateProjector({
+    registry: sessionRegistry,
+    contextUsage: base.contextUsageTracker,
+    contextPolicy: contextUsagePolicy,
+    hasActiveSession: (sessionId) => sessionRegistry.lookup(sessionId)?.attachment !== undefined,
+    currentFramework: () => base.backendGeneration.current.framework.id,
+    reconnectPending: () => base.connectionTransitions.providerReconnectPending,
+    mcpServerNamesFor: (sessionId) => base.sessionCapabilities.mcpServerNamesFor(sessionId),
+    nextEventId: () => publication.nextEventId(),
+    emitState: () => publication.emitState(),
+    pushEvent: (event) => publication.pushEvent(event),
+    reportToolFailure: (effect) =>
+      log.warn('tool call failed', {
+        tool: effect.tool,
+        toolCallId: effect.toolCallId,
+        sessionId: effect.sessionId,
+        reason: effect.reason
+      })
+  })
+
+  return Object.freeze({
+    sessionRegistry,
+    sessionEnvironment,
+    contextUsagePolicy,
+    publication,
+    permissionContext,
+    reviewerSessions,
+    sessionUpdateProjector
+  })
+}
+/* eslint-enable @typescript-eslint/explicit-function-return-type */
+
+type AcpRuntimeSessionOwners = ReturnType<typeof composeAcpRuntimeSessionOwners>
+
+export { composeAcpRuntimeSessionOwners }
+export type { AcpRuntimeSessionOwners }

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -145,6 +145,7 @@ const createRuntimeHarness = (options: {
       delete: vi.fn(async () => ({ status: 'closed' }))
     },
     permissionContext: { cancelForSession: vi.fn() },
+    publication: { emitState: vi.fn() },
     callbacks: { onEvent: options.onEvent },
     pushEvent: (event: unknown) => options.onEvent?.(event),
     getSnapshot: () => ({ status: 'connected' }),

--- a/src/main/acp/runtime.test-utils.ts
+++ b/src/main/acp/runtime.test-utils.ts
@@ -1,11 +1,14 @@
 import { AcpRuntime as ProductionAcpRuntime, type AcpRuntimeOptions } from './runtime'
 import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
 
 class AcpRuntime extends ProductionAcpRuntime {
   constructor(options: AcpRuntimeOptions) {
-    const owners = composeAcpRuntimeBaseOwners(options)
-    super(options, owners)
-    Object.defineProperty(this, 'artifactRunRegistry', { value: owners.artifactRunRegistry })
+    const baseOwners = composeAcpRuntimeBaseOwners(options)
+    super(options, baseOwners, composeAcpRuntimeSessionOwners(options, baseOwners))
+    Object.defineProperty(this, 'artifactRunRegistry', {
+      value: baseOwners.artifactRunRegistry
+    })
   }
 }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -20,7 +20,6 @@ import type {
   AcpStateSnapshot
 } from '../../shared/acp'
 import { ACP_PROMPT_FAILED_EVENT_TITLE } from '../../shared/acp'
-import { type SessionPermissionProfileState } from '../../shared/permission-profiles'
 import { type AgentFrameworkId } from '../../shared/settings'
 import type { EffectiveSpecialistSkills } from '../../shared/specialist'
 import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
@@ -31,9 +30,10 @@ import {
   type ResolvedAgentBackend
 } from '../agent-framework'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
-import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
+import type { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { ConversationPermissionGrantStore } from './permission-broker'
-import { AcpPermissionContext, HUMAN_PERMISSION_ACTION_ORIGIN } from './permission-context'
+import { HUMAN_PERMISSION_ACTION_ORIGIN } from './permission-context'
+import type { AcpPermissionContext } from './permission-context'
 import { AgentMcpHttpHost } from './mcp-http-host'
 import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
@@ -45,34 +45,34 @@ import { getAppClaudeConfigDir } from '../settings/provider-env'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { withDataRootWrite } from '../storage/migration-state'
 import { opencodeStorageDir } from '../agent-framework/opencode'
-import { ContextUsageTracker } from './context-usage-tracker'
-import { AcpContextUsagePolicy } from './context-usage-policy'
+import type { ContextUsageTracker } from './context-usage-tracker'
+import type { AcpContextUsagePolicy } from './context-usage-policy'
 import type { UploadRepository } from '../uploads/repository'
 import { DEFAULT_UPLOAD_PROJECT_NAME, type UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, FileReference } from '../../shared/artifacts'
 import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
-import {
+import type {
   ReviewerSessionOwner,
-  type ReviewerSessionDisposition,
-  type ReviewerSessionRequest,
-  type ReviewerSessionResult
+  ReviewerSessionDisposition,
+  ReviewerSessionRequest,
+  ReviewerSessionResult
 } from './reviewer-session-owner'
-import { AcpSessionCapabilityOwner } from './session-capability-owner'
-import { ArtifactTurnOwner, type ArtifactTurnHandle } from './artifact-turn-owner'
-import { AcpPromptContentOwner } from './prompt-content-owner'
-import {
+import type { AcpSessionCapabilityOwner } from './session-capability-owner'
+import type { ArtifactTurnHandle, ArtifactTurnOwner } from './artifact-turn-owner'
+import type { AcpPromptContentOwner } from './prompt-content-owner'
+import type {
   AcpSessionInteractionOwner,
-  type AcpPromptSessionInteractionScope
+  AcpPromptSessionInteractionScope
 } from './session-interaction-owner'
-import {
+import type {
   AcpSessionRegistry,
-  type AcpPrimarySessionIdentityReservation,
-  type AcpPrimarySessionIdentityReservationResult
+  AcpPrimarySessionIdentityReservation,
+  AcpPrimarySessionIdentityReservationResult
 } from './session-registry'
-import {
+import type {
   AcpConnectionResourceOwner,
-  type AcpConnectionResourceAttempt
+  AcpConnectionResourceAttempt
 } from './connection-resource-owner'
 import {
   AcpAgentConnectionAdapter,
@@ -81,13 +81,13 @@ import {
 } from './agent-connection-adapter'
 import type { AcpConnectionTransitionOwner } from './connection-transition-owner'
 import type { AcpGenerationActivityOwner } from './generation-activity-owner'
-import { AcpHandoffContinuityOwner } from './handoff-continuity-owner'
-import {
+import type { AcpHandoffContinuityOwner } from './handoff-continuity-owner'
+import type {
   AcpBackendGenerationOwner,
-  type AcpBackendGenerationView
+  AcpBackendGenerationView
 } from './backend-generation-owner'
 import type { AcpSessionConfigurator } from './session-configurator'
-import { AcpSessionUpdateProjector } from './session-update-projector'
+import type { AcpSessionUpdateProjector } from './session-update-projector'
 import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
 import { AcpConnectionCloseWorkflow, type CloseState } from './connection-close-workflow'
 import { AcpModelChangeWorkflow } from './model-change-workflow'
@@ -99,10 +99,9 @@ import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
 import { AcpPromptPreparationOwner } from './prompt-preparation-owner'
 import { AcpPromptTurnWorkflow, type AcpPromptTurnPlanContext } from './prompt-turn-workflow'
 import { AcpContextCompactionWorkflow } from './context-compaction-workflow'
-import { AcpProviderPromptExecutor } from './provider-prompt-executor'
+import type { AcpProviderPromptExecutor } from './provider-prompt-executor'
 import type { AcpTurnSkillHooks, AcpTurnSkillOwner } from './turn-skill-owner'
-import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
-import { SESSION_PLAN_SYSTEM_PROMPT_APPEND } from '../session-plan/guidance'
+import type { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import type { PlanResponseResult, PlanService } from '../session-plan/plan-service'
 import type {
   ActivePlanProjection,
@@ -113,7 +112,9 @@ import { PlanCommandError } from '../../shared/session-plan/contract'
 import type { SessionPlanStepStatus } from '../../shared/session-persistence'
 import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
 import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
-import { AcpSessionEnvironmentPolicy } from './session-environment-policy'
+import type { AcpRuntimePublicationOwner } from './runtime-publication-owner'
+import type { AcpRuntimeSessionOwners } from './runtime-session-composition'
+import type { AcpSessionEnvironmentPolicy } from './session-environment-policy'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -322,6 +323,7 @@ class AcpRuntime {
   private readonly connectionResources: AcpConnectionResourceOwner
   private readonly connectionTransitions: AcpConnectionTransitionOwner
   private readonly generationActivity: AcpGenerationActivityOwner
+  private readonly notifyGenerationActivityChanged: () => void
   // Stable app identities, provider aliases, publication order, selection, and startup/delete
   // arbitration share one owner. The runtime retains only protocol/resource orchestration.
   private readonly sessionRegistry: AcpSessionRegistry
@@ -334,6 +336,7 @@ class AcpRuntime {
   private readonly turnSkills: AcpTurnSkillOwner
   private readonly handoffContinuity: AcpHandoffContinuityOwner
   private readonly permissionContext: AcpPermissionContext
+  private readonly publication: AcpRuntimePublicationOwner
   private readonly sessionEnvironment: AcpSessionEnvironmentPolicy
   private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
@@ -365,7 +368,8 @@ class AcpRuntime {
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(
     private readonly options: AcpRuntimeOptions,
-    base: AcpRuntimeBaseOwners
+    base: AcpRuntimeBaseOwners,
+    session: AcpRuntimeSessionOwners
   ) {
     this.callbacks = options.callbacks ?? {}
     this.spawnAgent = options.spawnAgent
@@ -387,9 +391,17 @@ class AcpRuntime {
     this.promptContentOwner = base.promptContentOwner
     this.handoffContinuity = base.handoffContinuity
     this.generationActivity = base.generationActivity
+    this.notifyGenerationActivityChanged = base.notifyGenerationActivityChanged
     this.connectionTransitions = base.connectionTransitions
     this.turnSkills = base.turnSkills
     this.sessionConfigurator = base.sessionConfigurator
+    this.sessionRegistry = session.sessionRegistry
+    this.sessionEnvironment = session.sessionEnvironment
+    this.contextUsagePolicy = session.contextUsagePolicy
+    this.publication = session.publication
+    this.permissionContext = session.permissionContext
+    this.reviewerSessions = session.reviewerSessions
+    this.sessionUpdateProjector = session.sessionUpdateProjector
     this.promptPreparation = new AcpPromptPreparationOwner({
       promptContent: this.promptContentOwner,
       presentation: base.sessionPresentationPolicy,
@@ -406,131 +418,6 @@ class AcpRuntime {
           }
         : {}),
       emitState: () => this.emitState()
-    })
-    this.sessionRegistry = new AcpSessionRegistry({
-      addStartupBlocker: (token) => this.generationActivity.acquireStartup(token),
-      foreignIdentityCollision: (sessionIds) => {
-        const pendingReviewerCollision = sessionIds.find((sessionId) =>
-          this.reviewerSessions.hasPendingSessionId(sessionId)
-        )
-        if (pendingReviewerCollision) {
-          return new Error(
-            `Primary session id collision with pending reviewer: ${pendingReviewerCollision}`
-          )
-        }
-        const activeReviewerCollision = sessionIds.find((sessionId) =>
-          this.reviewerSessions.hasActiveSessionId(sessionId)
-        )
-        return activeReviewerCollision
-          ? new Error(`Primary session id collision with reviewer: ${activeReviewerCollision}`)
-          : undefined
-      },
-      removeStartupBlocker: (token) => this.generationActivity.releaseStartup(token)
-    })
-    this.sessionEnvironment = new AcpSessionEnvironmentPolicy({
-      backendGeneration: this.backendGeneration,
-      capabilities: this.sessionCapabilities,
-      presentation: base.sessionPresentationPolicy,
-      registry: this.sessionRegistry,
-      defaultProjectName: options.artifacts?.projectName,
-      ...(this.planService ? { planSystemPromptAppend: SESSION_PLAN_SYSTEM_PROMPT_APPEND } : {})
-    })
-    this.contextUsagePolicy = new AcpContextUsagePolicy({
-      backend: () => this.backend,
-      appliedModel: (sessionId) =>
-        this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().appliedModel,
-      systemPromptAppends: () => this.sessionEnvironment.systemPromptAppends(),
-      tooling: () => this.sessionEnvironment.toolingAvailability()
-    })
-    this.sessionUpdateProjector = new AcpSessionUpdateProjector({
-      registry: this.sessionRegistry,
-      contextUsage: this.contextUsageTracker,
-      contextPolicy: this.contextUsagePolicy,
-      hasActiveSession: (sessionId) => this.activeSessionFor(sessionId) !== undefined,
-      currentFramework: () => this.framework.id,
-      reconnectPending: () => this.pendingProviderReconnect,
-      mcpServerNamesFor: (sessionId) => this.sessionCapabilities.mcpServerNamesFor(sessionId),
-      nextEventId: () => this.nextEventId(),
-      emitState: () => this.emitState(),
-      pushEvent: (event) => this.pushEvent(event),
-      reportToolFailure: (effect) =>
-        log.warn('tool call failed', {
-          tool: effect.tool,
-          toolCallId: effect.toolCallId,
-          sessionId: effect.sessionId,
-          reason: effect.reason
-        })
-    })
-    this.permissionContext = new AcpPermissionContext({
-      emitPermissionRequest: (request) => {
-        this.pushEvent({
-          kind: 'permission',
-          level: 'warning',
-          sessionId: request.sessionId,
-          toolCallId: request.toolCallId,
-          title: 'Permission requested',
-          text: request.title,
-          raw: request
-        })
-        this.callbacks.onPermissionRequest?.(request)
-        this.emitState()
-      },
-      routing: {
-        resolveAppSessionId: (sessionId) => this.sessionRegistry.resolveAppSessionId(sessionId),
-        sessionSnapshot: (sessionId) => {
-          const snapshot = this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot()
-          return snapshot
-            ? {
-                cwd: snapshot.cwd,
-                frameworkId: snapshot.frameworkId,
-                permissionProfile: snapshot.permissionProfile
-              }
-            : undefined
-        },
-        hasActivePrimarySession: (sessionId) => this.activeSessionFor(sessionId) !== undefined,
-        capturePrompt: (sessionId) => {
-          const scope = this.currentPromptInteraction(sessionId)
-          return scope
-            ? {
-                sequence: scope.sequence,
-                isCancellationAccepted: () => this.sessionInteractions.isCancellationAccepted(scope)
-              }
-            : undefined
-        },
-        currentInteractionSequence: (sessionId) =>
-          this.sessionInteractions.current(sessionId)?.sequence,
-        mcpServerNamesFor: (sessionId) => this.sessionCapabilities.mcpServerNamesFor(sessionId),
-        reviewerContextFor: (sessionId) => this.reviewerSessions.contextFor(sessionId),
-        resolveReviewerPermission: (request) => this.reviewerSessions.resolvePermission(request),
-        currentFramework: () => this.framework,
-        resolveProjectId: (sessionId) => this.resolveSessionProjectName(sessionId)
-      },
-      conversationGrants: options.permissionGrantStore,
-      permissionGrantRegistry: options.permissionGrantRegistry,
-      setTimer: this.setTimer,
-      clearTimer: this.clearTimer,
-      onOpenCodeWaitTimeout: ({ sessionId, toolCallId, waitMs }) => {
-        log.warn('OpenCode permission context wait timed out', { sessionId, toolCallId, waitMs })
-      }
-    })
-    this.reviewerSessions = new ReviewerSessionOwner({
-      addStartupBlocker: (token) => this.generationActivity.acquireStartup(token),
-      assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
-      clearPermissionCorrelations: (sessionId) =>
-        this.permissionContext.clearCorrelationsForSession(sessionId),
-      currentSessionSetup: () => ({
-        framework: this.framework,
-        sessionOptions: this.backend.session.options
-      }),
-      currentStartupGeneration: () => this.sessionRegistry.startupGeneration,
-      ensureConnected: (cwd) => this.ensureConnected(cwd),
-      isPrimarySessionIdClaimed: (sessionId) => this.sessionRegistry.isIdentityClaimed(sessionId),
-      onActiveSessionReleased: () => this.generationActivityChanged(),
-      registerBridgeSession: (sessionId) =>
-        this.connectionResources.registerBridgeReviewerSession(sessionId),
-      removeStartupBlocker: (token) => this.generationActivity.releaseStartup(token),
-      unregisterBridgeSession: (sessionId) =>
-        this.connectionResources.unregisterBridgeReviewerSession(sessionId)
     })
     this.contextCompactionWorkflow = new AcpContextCompactionWorkflow({
       sessions: {
@@ -874,8 +761,7 @@ class AcpRuntime {
   }
 
   private generationActivityChanged(): void {
-    this.connectionTransitions.activityChanged()
-    this.modelChanges.activityChanged()
+    this.notifyGenerationActivityChanged()
   }
 
   private get connectionGeneration(): number {
@@ -918,29 +804,7 @@ class AcpRuntime {
 
   // Returns an immutable renderer-facing view of connection and session state.
   getSnapshot(): AcpStateSnapshot {
-    const sessionIds = this.activeSessionIds()
-    const promptInFlightSessionIds = this.getInFlightSessionIds()
-    const permissionProfiles: Record<string, SessionPermissionProfileState> = {}
-    for (const { appSessionId: sessionId, aggregate } of this.sessionRegistry.entries()) {
-      const profile = aggregate.snapshot().permissionProfile
-      // getSnapshot() is an immutable projection even though the legacy shared shape is mutable.
-      if (profile) permissionProfiles[sessionId] = profile as SessionPermissionProfileState
-    }
-
-    return this.snapshotOwner.snapshot({
-      sessionId: this.sessionRegistry.currentSessionId,
-      sessionIds,
-      pendingPermissions: this.permissionContext.getPendingRequests(),
-      permissionProfiles,
-      permissionGrants: Object.fromEntries(
-        sessionIds.map((sessionId) => [sessionId, this.permissionContext.listGrants(sessionId)])
-      ),
-      contextUsageBySession: this.contextUsageTracker.usageSnapshot(),
-      nativeContextCompactionSessionIds:
-        this.framework.contextCompaction.kind === 'native-command' ? sessionIds : [],
-      promptInFlight: promptInFlightSessionIds.length > 0,
-      promptInFlightSessionIds
-    })
+    return this.publication.getSnapshot()
   }
 
   async callSessionPlan(input: {
@@ -2046,27 +1910,12 @@ class AcpRuntime {
     event: Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>,
     onAppended?: () => void
   ): void {
-    const currentPromptMessageId = event.sessionId
-      ? this.currentPromptInteraction(event.sessionId)?.promptMessageId
-      : undefined
-    const scopedEvent =
-      currentPromptMessageId && !event.promptMessageId
-        ? { ...event, promptMessageId: currentPromptMessageId }
-        : event
-    const runtimeEvent = this.snapshotOwner.appendEvent(scopedEvent)
-    onAppended?.()
-    this.callbacks.onEvent?.(runtimeEvent)
-    this.emitState()
-  }
-
-  // Generates monotonically increasing event ids for this runtime instance.
-  private nextEventId(): string {
-    return this.snapshotOwner.nextEventId()
+    this.publication.pushEvent(event, onAppended)
   }
 
   // Broadcasts the latest runtime snapshot if a listener is registered.
   private emitState(): void {
-    this.callbacks.onStateChanged?.(this.getSnapshot())
+    this.publication.emitState()
   }
 
   // Creates an ephemeral reviewer ACP session using the existing agent connection. The reviewer
@@ -2074,7 +1923,11 @@ class AcpRuntime {
   // appear in the snapshot, and callers are responsible for disposing it. This allows background
   // review to run in parallel with the main session without affecting the main state machine.
   async buildReviewerSession(request: ReviewerSessionRequest): Promise<ReviewerSessionResult> {
-    return this.withOperationLease(() => this.reviewerSessions.create(request))
+    return this.withOperationLease(() =>
+      this.reviewerSessions.create(request, {
+        ensureConnected: (cwd) => this.ensureConnected(cwd)
+      })
+    )
   }
 
   private invalidatePendingSessionStartups(): void {

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -364,7 +364,8 @@ describe('runtime state ownership architecture', () => {
     expect(source).not.toContain('reviewerSessions.create(request, async')
     expect(source).toContain('this.permissionContext.handleProviderRequest(params)')
     expect(source).toContain('this.permissionContext.observeProviderUpdate(notification)')
-    expect(source).toContain('this.reviewerSessions.create(request)')
+    expect(source).toContain('this.reviewerSessions.create(request, {')
+    expect(source).toContain('ensureConnected: (cwd) => this.ensureConnected(cwd)')
   })
 
   it('keeps provider selection and Context routing behind their prompt owners', () => {


### PR DESCRIPTION
## Problem

`AcpRuntime` still constructed the Session registry, Context policy/projector, Permission context, and Reviewer owner itself. It also implemented renderer event/state publication inline. Those responsibilities formed a construction-time cycle around Runtime and kept unrelated state owners coupled to the facade.

This is the serial successor to #801. The combined prototype was split because it measured about 688 production raw lines; this remainder measures 531 raw lines on the merged #801 baseline.

## Proposed change

- Add a frozen `composeAcpRuntimeSessionOwners()` graph for Session, Context, Permission, Reviewer, environment, and publication ownership.
- Add `AcpRuntimePublicationOwner` as the single publication seam over the existing snapshot owner. It preserves event IDs, snapshot cloning, retention/image budgets, prompt attribution, callback order, and live projections.
- Pass Reviewer connection acquisition as a call-time capability to `ReviewerSessionOwner.create()`, keeping lazy connection workflow in Runtime without a construction-time Runtime callback.
- Use the same base/session composition path in production and Runtime tests.
- Lock the new composition and Reviewer capability seam in architecture tests.

```mermaid
flowchart LR
  C["Production or test composition"] --> B["Base owner graph"]
  C --> S["Session owner graph"]
  B --> S
  S --> R["AcpRuntime facade"]
  B --> R

  S --> SR["Session registry"]
  S --> ENV["Session environment policy"]
  S --> CTX["Context policy and projector"]
  S --> PERM["Permission context"]
  S --> REV["Reviewer owner"]
  S --> PUB["Publication owner"]
  PUB --> SNAP["Snapshot owner: sole event/status writer"]
```

Publication order remains unchanged:

```mermaid
sequenceDiagram
  participant Caller
  participant Publication
  participant Snapshot
  participant Callbacks

  Caller->>Publication: pushEvent(event, onAppended)
  Publication->>Snapshot: appendEvent
  Publication->>Caller: onAppended
  Publication->>Callbacks: onEvent
  Publication->>Callbacks: onStateChanged(live snapshot)

  Caller->>Publication: publishPermissionRequest
  Publication->>Callbacks: permission event then state
  Publication->>Callbacks: onPermissionRequest
  Publication->>Callbacks: second state
```

## Scope and non-goals

- No public API, IPC/preload, Web RPC, Task transport, CLI/SDK, UI, schema, persistence, or data relationship changes.
- No Specialist, Permission, or Compute behavior/capability changes.
- Electron, Web, CLI, and Task retain their current capability asymmetry.
- Stable App Session IDs, replaceable Provider Session IDs, Codex adoption/context reset, transcript replay, Context usage, and cleanup semantics are unchanged.
- Issue #458 remains only a forward compatibility boundary; this PR adds no orchestration state or interface.
- Connection/session/prompt workflow construction remains for the next serial composition leaf.

## Acceptance criteria and validation

All listed local checks ran after the final material implementation edit.

| Behavior / risk | Check | Result |
| --- | --- | --- |
| Closed owner graph, live publication, prompt attribution, architecture seams | `npm test -- --run` with 9 ACP owner files plus `runtime-state-ownership.architecture.test.ts` | 10 files, 95 tests passed |
| Session Plan private Runtime harness after publication cutover | `npm test -- --run src/main/acp/runtime-session-plan.test.ts` | 1 file, 20 tests passed |
| Runtime snapshot, Context/OpenCode gating, Reviewer identity/collision/cleanup | Focused `runtime.test.ts -t` impact set | 12 passed, 428 skipped |
| Electron/Web/CLI/Task and IPC/RPC surfaces | Focused 8-file surface contract set | 8 files, 99 tests passed |
| Node process types | `npm run typecheck:node` | passed |
| Repository lint | `npm run lint` | 0 errors; 17 unrelated pre-existing warnings |
| Changed-file format and whitespace | targeted ESLint, `prettier --check`, `git diff --check` | passed |
| Independent review | Standards review; Spec review | 0 findings; 0 findings |

Production raw is 531 (tests and `runtime.test-utils.ts` excluded), below the approved 600 limit. `src/main/acp/runtime.ts` decreases from 2,136 to 1,976 lines.

Uncovered locally: full portable suite and OS-specific Electron lanes. PR Gate is authoritative for those checks.

## Review focus

- Confirm the module-local lazy closures cannot publish during construction and do not create mirrored state.
- Confirm exact ordinary event and Permission callback/state ordering.
- Confirm Reviewer `ensureConnected` remains call-time, operation-leased, and precedes identity ownership.
- Confirm no cross-surface or Specialist/Permission/Compute capability boundary changed.
