### PR TITLE
refactor(acp-runtime): compose connection lifecycle owners

### DIFF
--- a/src/main/acp/runtime-lifecycle-composition.test.ts
+++ b/src/main/acp/runtime-lifecycle-composition.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { composeAcpRuntimeBaseOwners, type AcpRuntimeBaseOwners } from './runtime-base-composition'
+import {
+  composeAcpRuntimeLifecycleOwners,
+  type AcpRuntimeLifecycleOwners
+} from './runtime-lifecycle-composition'
+import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
+
+describe('ACP Runtime lifecycle composition', () => {
+  it('builds a fresh frozen graph and routes the bound lifecycle cycle', async () => {
+    const options = { appVersion: 'test', defaultCwd: '/workspace' }
+    const create = (): {
+      base: AcpRuntimeBaseOwners
+      disconnect: ReturnType<typeof vi.fn>
+      lifecycle: AcpRuntimeLifecycleOwners
+    } => {
+      const base = composeAcpRuntimeBaseOwners(options)
+      const session = composeAcpRuntimeSessionOwners(options, base)
+      const host = {
+        connect: vi.fn(async () => session.publication.getSnapshot()),
+        disconnect: vi.fn(async () => session.publication.getSnapshot()),
+        openAgentConnection: vi.fn(async () => {
+          throw new Error('not called during composition')
+        })
+      }
+      const lifecycle = composeAcpRuntimeLifecycleOwners(options, base, session, host)
+      expect(host.connect).not.toHaveBeenCalled()
+      expect(host.disconnect).not.toHaveBeenCalled()
+      expect(host.openAgentConnection).not.toHaveBeenCalled()
+      return { base, disconnect: host.disconnect, lifecycle }
+    }
+
+    const first = create()
+    const second = create()
+
+    expect(Object.isFrozen(first.lifecycle)).toBe(true)
+    expect(first.lifecycle.modelChanges).not.toBe(second.lifecycle.modelChanges)
+    expect(first.lifecycle.connectionClose).not.toBe(second.lifecycle.connectionClose)
+    expect(first.lifecycle.connectionLifecycle).not.toBe(second.lifecycle.connectionLifecycle)
+    expect(first.base.generationActivity.blockers()).toEqual({
+      reconnect: false,
+      retirement: false
+    })
+
+    await first.base.connectionTransitions.requestProviderReconnect()
+    expect(first.disconnect).toHaveBeenCalledOnce()
+    expect(first.disconnect).toHaveBeenCalledWith(false)
+    await expect(first.lifecycle.connectionClose.disconnect(false)).resolves.toMatchObject({
+      status: 'idle'
+    })
+    expect(first.disconnect).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/acp/runtime-lifecycle-composition.ts
+++ b/src/main/acp/runtime-lifecycle-composition.ts
@@ -1,0 +1,194 @@
+import type { ClientConnection } from '@agentclientprotocol/sdk'
+
+import { ACP_PROMPT_FAILED_EVENT_TITLE, type AcpConnectRequest } from '../../shared/acp'
+import type { AgentFramework } from '../agent-framework'
+import { createLogger, errorLogFields } from '../logger'
+import type { AcpAgentConnectionCandidate } from './agent-connection-adapter'
+import { AcpConnectionCloseWorkflow, type CloseState } from './connection-close-workflow'
+import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
+import type { AcpConnectionResourceAttempt } from './connection-resource-owner'
+import { AcpModelChangeWorkflow } from './model-change-workflow'
+import type { AcpRuntimeOptions } from './runtime'
+import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
+import type { AcpRuntimeSessionOwners } from './runtime-session-composition'
+import type { AcpSessionInteractionOwner } from './session-interaction-owner'
+
+const log = createLogger('acp')
+
+const safeLogError = (message: string, error: unknown): void => {
+  try {
+    log.error(message, error)
+  } catch {
+    // Lifecycle recovery and the original failure take precedence over diagnostic sinks.
+  }
+}
+
+type AcpRuntimeLifecycleHost = Readonly<{
+  connect: (request: AcpConnectRequest) => ReturnType<AcpConnectionLifecycleWorkflow['connect']>
+  disconnect: (emitClosedStatus?: boolean) => ReturnType<AcpConnectionCloseWorkflow['disconnect']>
+  openAgentConnection: (
+    attempt: AcpConnectionResourceAttempt,
+    onFrameworkResolved: (framework: AgentFramework['id']) => void
+  ) => Promise<AcpAgentConnectionCandidate>
+}>
+
+// Composes the model/connection lifecycle cycle around authoritative base and Session owners.
+// Host callbacks retain only structural facade operations and are never invoked during construction.
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+const composeAcpRuntimeLifecycleOwners = (
+  options: Pick<AcpRuntimeOptions, 'appVersion' | 'defaultCwd'>,
+  base: AcpRuntimeBaseOwners,
+  session: AcpRuntimeSessionOwners,
+  host: AcpRuntimeLifecycleHost
+) => {
+  const currentConnection = (): ClientConnection | undefined => base.connectionResources.connection
+  const currentFramework = (): AgentFramework => base.backendGeneration.current.framework
+  const diagnosticContext = (
+    framework: AgentFramework['id'] = currentFramework().id,
+    generation = base.connectionResources.epoch
+  ) => ({ framework, generation, status: base.snapshotOwner.status })
+  const setStatus = (status: Parameters<typeof base.snapshotOwner.transitionStatus>[0]): void => {
+    base.snapshotOwner.transitionStatus(status)
+    session.publication.emitState()
+  }
+  const invalidatePendingSessionStartups = (): void => {
+    base.generationActivity.invalidateStartups()
+    session.sessionRegistry.invalidatePending()
+    session.reviewerSessions.invalidatePending()
+  }
+  const activeSessionIds = (): string[] =>
+    session.sessionRegistry.entries(true).map(({ appSessionId }) => appSessionId)
+  const closeState: CloseState = {
+    invalidatePendingSessionStartups,
+    disposePermissionContext: () => session.permissionContext.dispose(),
+    clearReviewerState: () => session.reviewerSessions.clear(),
+    clearPlanInteractions: () =>
+      base.planInteractions.clearAll('The Session Plan interaction was disconnected.'),
+    settleActivePrompts: () => base.sessionInteractions.settleActivePrompts(),
+    supersedeInteractions: () => base.sessionInteractions.supersedeAll(),
+    clearContextUsage: () => base.contextUsageTracker.clear(),
+    clearAppliedSessionModels: () => session.sessionRegistry.clearAppliedModels(),
+    activeSessionIds,
+    disposeSessionCapabilities: (sessionIds) => base.sessionCapabilities.dispose(sessionIds),
+    disposeActiveSessions: (recordFailure) => {
+      for (const { attachment } of session.sessionRegistry.entries(true)) {
+        if (!attachment) continue
+        try {
+          attachment.session.dispose()
+        } catch (error) {
+          recordFailure('primary-session', error)
+        }
+      }
+    },
+    detachSessionConnections: (clearPermissionProfile) => {
+      for (const entry of session.sessionRegistry.entries()) {
+        if (entry.attachment) session.sessionRegistry.detach(entry.attachment, 'connection')
+        else entry.aggregate.detachConnection()
+        if (clearPermissionProfile) entry.aggregate.setPermissionProfile(undefined)
+      }
+    },
+    clearPromptContent: () => base.promptContentOwner.clear(),
+    clearHandoffContinuity: () => base.handoffContinuity.clearGeneration(),
+    clearSessionProjection: () => session.sessionUpdateProjector.clearGeneration(),
+    disposeSessionProjection: () => session.sessionUpdateProjector.dispose(),
+    clearHttpRoutes: () => base.sessionCapabilities.clearHttpRoutes(),
+    selectSession: () => session.sessionRegistry.select(undefined),
+    publishInterruptedPromptFailures: (prompts) => {
+      for (const { scope, terminal } of prompts as ReturnType<
+        AcpSessionInteractionOwner['settleActivePrompts']
+      >) {
+        try {
+          session.publication.pushEvent({
+            kind: 'error',
+            level: 'error',
+            providerError: false,
+            sessionId: scope.sessionId,
+            ...(scope.promptMessageId ? { promptMessageId: scope.promptMessageId } : {}),
+            timestamp: terminal.timestamp,
+            title: ACP_PROMPT_FAILED_EVENT_TITLE,
+            text: 'ACP connection closed'
+          })
+        } catch (error) {
+          safeLogError('connection-close prompt event failed', errorLogFields(error))
+        }
+      }
+    },
+    setStatus,
+    transitionStatus: (status) => base.snapshotOwner.transitionStatus(status),
+    emitState: () => session.publication.emitState(),
+    hasContextUsage: () => base.contextUsageTracker.hasUsage()
+  }
+
+  const modelChanges = new AcpModelChangeWorkflow({
+    backendGeneration: base.backendGeneration,
+    connectionResources: base.connectionResources,
+    registry: session.sessionRegistry,
+    configurator: base.sessionConfigurator,
+    contextUsage: base.contextUsageTracker,
+    currentStatus: () => base.snapshotOwner.status,
+    providerReconnectPending: () => base.connectionTransitions.providerReconnectPending,
+    isGenerationBusy: () => base.generationActivity.blockers().retirement,
+    contextEstimateInput: (sessionId) =>
+      session.contextUsagePolicy.resolve(sessionId).estimateInput,
+    emitState: () => session.publication.emitState(),
+    requestReconnect: () => base.connectionTransitions.requestProviderReconnect(),
+    recoverFailedReconnect: () => connectionClose.recoverFailedDeferredDisconnect(),
+    reportReconnectFailure: (error) =>
+      safeLogError('model-change reconnect failed', errorLogFields(error)),
+    diagnosticContext
+  })
+  const connectionClose: AcpConnectionCloseWorkflow = new AcpConnectionCloseWorkflow({
+    currentGeneration: () => base.connectionResources.epoch,
+    currentStatus: () => base.snapshotOwner.status,
+    getSnapshot: () => session.publication.getSnapshot(),
+    transitions: base.connectionTransitions,
+    resources: base.connectionResources,
+    backendGeneration: base.backendGeneration,
+    modelChanges,
+    state: closeState,
+    reportFailure: (message, error) => safeLogError(message, errorLogFields(error))
+  })
+
+  base.bindGenerationConnectionEffects({
+    reviewerSessions: session.reviewerSessions,
+    modelChanges,
+    connectionClose: {
+      disconnect: (emitClosedStatus) => host.disconnect(emitClosedStatus),
+      recoverFailedDeferredDisconnect: () => connectionClose.recoverFailedDeferredDisconnect()
+    },
+    publishIdle: () => setStatus('idle')
+  })
+
+  const connectionLifecycle = new AcpConnectionLifecycleWorkflow({
+    appVersion: options.appVersion,
+    defaultCwd: options.defaultCwd,
+    currentConnection,
+    currentStatus: () => base.snapshotOwner.status,
+    currentGeneration: () => base.connectionResources.epoch,
+    currentFramework: () => currentFramework().id,
+    reconnectBarrier: () => base.connectionTransitions.barrier,
+    connect: (request) => host.connect(request),
+    getSnapshot: () => session.publication.getSnapshot(),
+    connectResources: base.connectionResources,
+    invalidatePendingSessionStartups,
+    disconnectCurrent: (emitClosedStatus, generation) =>
+      connectionClose.disconnectCurrent(emitClosedStatus, generation),
+    updateCwd: (cwd) => base.snapshotOwner.updateCwd(cwd),
+    updateError: (error) => base.snapshotOwner.updateError(error),
+    setStatus,
+    pushEvent: (event) => session.publication.pushEvent(event),
+    transitionStatus: (status) => base.snapshotOwner.transitionStatus(status),
+    emitState: () => session.publication.emitState(),
+    diagnosticContext,
+    openCandidate: (attempt, onFrameworkResolved) =>
+      host.openAgentConnection(attempt, onFrameworkResolved)
+  })
+
+  return Object.freeze({ modelChanges, connectionClose, connectionLifecycle })
+}
+/* eslint-enable @typescript-eslint/explicit-function-return-type */
+
+type AcpRuntimeLifecycleOwners = ReturnType<typeof composeAcpRuntimeLifecycleOwners>
+
+export { composeAcpRuntimeLifecycleOwners }
+export type { AcpRuntimeLifecycleHost, AcpRuntimeLifecycleOwners }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -17,6 +17,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AcpRuntime } from './runtime.test-utils'
 import type { AcpAgentConnectionAdapter } from './agent-connection-adapter'
+import type { AcpConnectionCloseWorkflow } from './connection-close-workflow'
 import { AcpPermissionContext } from './permission-context'
 import { ContextUsageTracker, type TokenCounter } from './context-usage-tracker'
 import {
@@ -855,6 +856,22 @@ const openCodeUsageApiForTest = (runtime: AcpRuntime): unknown =>
     }
   ).backendGeneration.openCodeUsageApi()
 
+const connectionCloseForTest = (
+  runtime: AcpRuntime
+): Pick<AcpConnectionCloseWorkflow, 'disconnectCurrent'> =>
+  (runtime as unknown as { connectionClose: AcpConnectionCloseWorkflow }).connectionClose
+
+const invalidatePendingSessionStartupsForTest = (runtime: AcpRuntime): void => {
+  const owners = runtime as unknown as {
+    generationActivity: { invalidateStartups: () => void }
+    reviewerSessions: { invalidatePending: () => void }
+    sessionRegistry: { invalidatePending: () => void }
+  }
+  owners.generationActivity.invalidateStartups()
+  owners.sessionRegistry.invalidatePending()
+  owners.reviewerSessions.invalidatePending()
+}
+
 const codexMcpToolIdentitiesMap = (runtime: AcpRuntime): Map<string, Map<string, unknown>> =>
   (
     permissionContext(runtime) as unknown as {
@@ -1103,11 +1120,8 @@ describe('ACP runtime migration write-gate', () => {
       spawnAgent
     })
     await runtime.createSession({ cwd: '/workspace' })
-    const internal = runtime as unknown as {
-      disconnectCurrent: (emitClosedStatus?: boolean) => Promise<AcpStateSnapshot>
-    }
     const disconnectCurrentSpy = vi
-      .spyOn(internal, 'disconnectCurrent')
+      .spyOn(connectionCloseForTest(runtime), 'disconnectCurrent')
       .mockRejectedValueOnce(new Error('disconnect failed before detach'))
 
     try {
@@ -1953,12 +1967,9 @@ describe('ACP runtime session management', () => {
       })
     })
     await runtime.connect({ cwd: '/workspace' })
-    vi.spyOn(
-      runtime as unknown as {
-        disconnectCurrent: () => Promise<AcpStateSnapshot>
-      },
-      'disconnectCurrent'
-    ).mockRejectedValueOnce(new Error('disconnect teardown failed'))
+    vi.spyOn(connectionCloseForTest(runtime), 'disconnectCurrent').mockRejectedValueOnce(
+      new Error('disconnect teardown failed')
+    )
 
     await expect(runtime.disconnect()).rejects.toThrow('disconnect teardown failed')
 
@@ -8916,12 +8927,7 @@ describe('ACP runtime session management', () => {
     })
     await runtime.connect({ cwd: '/workspace' })
     const disconnectCurrentSpy = vi
-      .spyOn(
-        runtime as unknown as {
-          disconnectCurrent: (emitClosedStatus?: boolean) => Promise<AcpStateSnapshot>
-        },
-        'disconnectCurrent'
-      )
+      .spyOn(connectionCloseForTest(runtime), 'disconnectCurrent')
       .mockRejectedValueOnce(new Error('disconnect teardown failed'))
     const stale = runtime.createSession({
       cwd: '/workspace',
@@ -9040,12 +9046,7 @@ describe('ACP runtime session management', () => {
     await runtime.connect({ cwd: '/workspace' })
     const disposeSpy = vi.spyOn(acp.ActiveSession.prototype, 'dispose')
     const disconnectCurrentSpy = vi
-      .spyOn(
-        runtime as unknown as {
-          disconnectCurrent: (emitClosedStatus?: boolean) => Promise<AcpStateSnapshot>
-        },
-        'disconnectCurrent'
-      )
+      .spyOn(connectionCloseForTest(runtime), 'disconnectCurrent')
       .mockRejectedValueOnce(new Error('disconnect teardown failed'))
     const pending = runtime.createSession({ cwd: '/workspace' })
     await pendingModeStarted.promise
@@ -9599,12 +9600,7 @@ describe('ACP runtime session management', () => {
       })
       await runtime.connect({ cwd: '/workspace' })
       const disconnectCurrentSpy = vi
-        .spyOn(
-          runtime as unknown as {
-            disconnectCurrent: (emitClosedStatus?: boolean) => Promise<AcpStateSnapshot>
-          },
-          'disconnectCurrent'
-        )
+        .spyOn(connectionCloseForTest(runtime), 'disconnectCurrent')
         .mockRejectedValueOnce(new Error('disconnect teardown failed'))
       const sessionId = '123e4567-e89b-42d3-a456-426614174000'
       const stale = runtime.resumeSession({
@@ -9694,9 +9690,7 @@ describe('ACP runtime session management', () => {
       (error: unknown) => ({ value: undefined, error })
     )
     await staleResumeStarted.promise
-    ;(
-      runtime as unknown as { invalidatePendingSessionStartups: () => void }
-    ).invalidatePendingSessionStartups()
+    invalidatePendingSessionStartupsForTest(runtime)
     const successor = await runtime.resumeSession({ sessionId, cwd: '/workspace' })
 
     try {
@@ -18940,10 +18934,7 @@ describe('ACP runtime — session-creation and spawn diagnostics', () => {
       }
     })
     // First disconnectCurrent (pre-connect teardown) succeeds; the catch-path cleanup then throws.
-    const disconnectSpy = vi.spyOn(
-      runtime as unknown as { disconnectCurrent: () => Promise<unknown> },
-      'disconnectCurrent'
-    )
+    const disconnectSpy = vi.spyOn(connectionCloseForTest(runtime), 'disconnectCurrent')
     disconnectSpy.mockResolvedValueOnce(runtime.getSnapshot())
     disconnectSpy.mockRejectedValueOnce(new Error('cleanup boom'))
 
@@ -19295,10 +19286,7 @@ describe('ACP runtime — failure-path robustness (errorMessage coercion + sync-
         env: {}
       })
     })
-    const disconnectSpy = vi.spyOn(
-      runtime as unknown as { disconnectCurrent: () => Promise<unknown> },
-      'disconnectCurrent'
-    )
+    const disconnectSpy = vi.spyOn(connectionCloseForTest(runtime), 'disconnectCurrent')
     errorLogSpy.mockImplementation(() => {
       throw new Error('logger boom')
     })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -19,7 +19,6 @@ import type {
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../shared/acp'
-import { ACP_PROMPT_FAILED_EVENT_TITLE } from '../../shared/acp'
 import { type AgentFrameworkId } from '../../shared/settings'
 import type { EffectiveSpecialistSkills } from '../../shared/specialist'
 import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
@@ -88,9 +87,9 @@ import type {
 } from './backend-generation-owner'
 import type { AcpSessionConfigurator } from './session-configurator'
 import type { AcpSessionUpdateProjector } from './session-update-projector'
-import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
-import { AcpConnectionCloseWorkflow, type CloseState } from './connection-close-workflow'
-import { AcpModelChangeWorkflow } from './model-change-workflow'
+import type { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
+import type { AcpConnectionCloseWorkflow } from './connection-close-workflow'
+import type { AcpModelChangeWorkflow } from './model-change-workflow'
 import { AcpProviderSessionCreator } from './provider-session-creator'
 import { AcpProviderSessionAdopter } from './provider-session-adopter'
 import { AcpProviderSessionResumer } from './provider-session-resumer'
@@ -115,6 +114,7 @@ import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
 import type { AcpRuntimePublicationOwner } from './runtime-publication-owner'
 import type { AcpRuntimeSessionOwners } from './runtime-session-composition'
 import type { AcpSessionEnvironmentPolicy } from './session-environment-policy'
+import { composeAcpRuntimeLifecycleOwners } from './runtime-lifecycle-composition'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -517,131 +517,15 @@ class AcpRuntime {
         this.callbacks.onPromptStarted?.(sessionId, turnToken, promptAttemptId),
       emitState: () => this.emitState()
     })
-    const closeState: CloseState = {
-      invalidatePendingSessionStartups: () => this.invalidatePendingSessionStartups(),
-      disposePermissionContext: () => this.permissionContext.dispose(),
-      clearReviewerState: () => this.reviewerSessions.clear(),
-      clearPlanInteractions: () =>
-        this.planInteractions.clearAll('The Session Plan interaction was disconnected.'),
-      settleActivePrompts: () => this.sessionInteractions.settleActivePrompts(),
-      supersedeInteractions: () => this.sessionInteractions.supersedeAll(),
-      clearContextUsage: () => this.contextUsageTracker.clear(),
-      clearAppliedSessionModels: () => this.clearAppliedSessionModels(),
-      activeSessionIds: () => this.activeSessionIds(),
-      disposeSessionCapabilities: (sessionIds) => this.sessionCapabilities.dispose(sessionIds),
-      disposeActiveSessions: (recordFailure) => {
-        for (const session of this.activeSessions()) {
-          try {
-            session.dispose()
-          } catch (error) {
-            recordFailure('primary-session', error)
-          }
-        }
-      },
-      detachSessionConnections: (clearPermissionProfile) => {
-        for (const entry of this.sessionRegistry.entries()) {
-          if (entry.attachment) this.sessionRegistry.detach(entry.attachment, 'connection')
-          else entry.aggregate.detachConnection()
-          if (clearPermissionProfile) entry.aggregate.setPermissionProfile(undefined)
-        }
-      },
-      clearPromptContent: () => this.promptContentOwner.clear(),
-      clearHandoffContinuity: () => this.handoffContinuity.clearGeneration(),
-      clearSessionProjection: () => this.sessionUpdateProjector.clearGeneration(),
-      disposeSessionProjection: () => this.sessionUpdateProjector.dispose(),
-      clearHttpRoutes: () => this.sessionCapabilities.clearHttpRoutes(),
-      selectSession: () => this.sessionRegistry.select(undefined),
-      publishInterruptedPromptFailures: (prompts) => {
-        for (const { scope, terminal } of prompts as ReturnType<
-          AcpSessionInteractionOwner['settleActivePrompts']
-        >) {
-          try {
-            this.pushEvent({
-              kind: 'error',
-              level: 'error',
-              providerError: false,
-              sessionId: scope.sessionId,
-              ...(scope.promptMessageId ? { promptMessageId: scope.promptMessageId } : {}),
-              timestamp: terminal.timestamp,
-              title: ACP_PROMPT_FAILED_EVENT_TITLE,
-              text: 'ACP connection closed'
-            })
-          } catch (error) {
-            safeLogError('connection-close prompt event failed', errorLogFields(error))
-          }
-        }
-      },
-      setStatus: (status) => this.setStatus(status),
-      transitionStatus: (status) => this.snapshotOwner.transitionStatus(status),
-      emitState: () => this.emitState(),
-      hasContextUsage: () => this.contextUsageTracker.hasUsage()
-    }
-    this.modelChanges = new AcpModelChangeWorkflow({
-      backendGeneration: this.backendGeneration,
-      connectionResources: this.connectionResources,
-      registry: this.sessionRegistry,
-      configurator: this.sessionConfigurator,
-      contextUsage: this.contextUsageTracker,
-      currentStatus: () => this.snapshotOwner.status,
-      providerReconnectPending: () => this.pendingProviderReconnect,
-      isGenerationBusy: () => this.generationActivity.blockers().retirement,
-      contextEstimateInput: (sessionId) => this.contextUsagePolicy.resolve(sessionId).estimateInput,
-      emitState: () => this.emitState(),
-      // Model-change fallback already owns its drain. Calling the close workflow here would ask the
-      // same drain to await itself, so arm the authoritative transition directly.
-      requestReconnect: () => this.connectionTransitions.requestProviderReconnect(),
-      recoverFailedReconnect: () => this.connectionClose.recoverFailedDeferredDisconnect(),
-      reportReconnectFailure: (error) =>
-        safeLogError('model-change reconnect failed', errorLogFields(error)),
-      diagnosticContext: () => this.diagnosticContext()
-    })
-    this.connectionClose = new AcpConnectionCloseWorkflow({
-      currentGeneration: () => this.connectionGeneration,
-      currentStatus: () => this.snapshotOwner.status,
-      getSnapshot: () => this.getSnapshot(),
-      disconnectCurrent: (emitClosedStatus, generation) =>
-        this.disconnectCurrent(emitClosedStatus, generation),
-      transitions: this.connectionTransitions,
-      resources: this.connectionResources,
-      backendGeneration: this.backendGeneration,
-      modelChanges: this.modelChanges,
-      state: closeState,
-      reportFailure: (message, error) => safeLogError(message, errorLogFields(error))
-    })
-    base.bindGenerationConnectionEffects({
-      reviewerSessions: this.reviewerSessions,
-      modelChanges: this.modelChanges,
-      connectionClose: {
-        disconnect: (emitClosedStatus) => this.disconnect(emitClosedStatus),
-        recoverFailedDeferredDisconnect: () =>
-          this.connectionClose.recoverFailedDeferredDisconnect()
-      },
-      publishIdle: () => this.setStatus('idle')
-    })
-    this.connectionLifecycle = new AcpConnectionLifecycleWorkflow({
-      appVersion: options.appVersion,
-      defaultCwd: options.defaultCwd,
-      currentConnection: () => this.connection,
-      currentStatus: () => this.snapshotOwner.status,
-      currentGeneration: () => this.connectionGeneration,
-      currentFramework: () => this.framework.id,
-      reconnectBarrier: () => this.reconnectBarrier,
+    const lifecycle = composeAcpRuntimeLifecycleOwners(options, base, session, {
       connect: (request) => this.connect(request),
-      getSnapshot: () => this.getSnapshot(),
-      connectResources: this.connectionResources,
-      invalidatePendingSessionStartups: () => this.invalidatePendingSessionStartups(),
-      disconnectCurrent: (emitClosedStatus, generation) =>
-        this.disconnectCurrent(emitClosedStatus, generation),
-      updateCwd: (cwd) => this.snapshotOwner.updateCwd(cwd),
-      updateError: (error) => this.snapshotOwner.updateError(error),
-      setStatus: (status) => this.setStatus(status),
-      pushEvent: (event) => this.pushEvent(event),
-      transitionStatus: (status) => this.snapshotOwner.transitionStatus(status),
-      emitState: () => this.emitState(),
-      diagnosticContext: (framework, generation) => this.diagnosticContext(framework, generation),
-      openCandidate: (attempt, onFrameworkResolved) =>
+      disconnect: (emitClosedStatus) => this.disconnect(emitClosedStatus),
+      openAgentConnection: (attempt, onFrameworkResolved) =>
         this.openAgentConnection(attempt, onFrameworkResolved)
     })
+    this.modelChanges = lifecycle.modelChanges
+    this.connectionClose = lifecycle.connectionClose
+    this.connectionLifecycle = lifecycle.connectionLifecycle
     this.providerSessionCreator = new AcpProviderSessionCreator({
       defaultCwd: options.defaultCwd,
       defaultProjectName: options.artifacts?.projectName || DEFAULT_UPLOAD_PROJECT_NAME,
@@ -782,14 +666,6 @@ class AcpRuntime {
 
   private activeSessionIds(): string[] {
     return this.activeSessionEntries().map(([appSessionId]) => appSessionId)
-  }
-
-  private activeSessions(): ActiveSession[] {
-    return this.activeSessionEntries().map(([, session]) => session)
-  }
-
-  private clearAppliedSessionModels(): void {
-    this.sessionRegistry.clearAppliedModels()
   }
 
   // Boundary-safe context for session-creation and process-spawn diagnostics. Keep this list explicit:
@@ -1312,13 +1188,6 @@ class AcpRuntime {
       return barrier.then(() => this.withOperationLease(work))
     }
     return this.generationActivity.withOperation(work)
-  }
-
-  private disconnectCurrent(
-    emitClosedStatus = true,
-    teardownGeneration = this.connectionGeneration
-  ): Promise<AcpStateSnapshot> {
-    return this.connectionClose.disconnectCurrent(emitClosedStatus, teardownGeneration)
   }
 
   private openAgentConnection(
@@ -1928,12 +1797,6 @@ class AcpRuntime {
         ensureConnected: (cwd) => this.ensureConnected(cwd)
       })
     )
-  }
-
-  private invalidatePendingSessionStartups(): void {
-    this.generationActivity.invalidateStartups()
-    this.sessionRegistry.invalidatePending()
-    this.reviewerSessions.invalidatePending()
   }
 
   private reservePrimarySessionIds(

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -356,6 +356,20 @@ describe('runtime state ownership architecture', () => {
     expect(source).toContain('currentConnection: () => this.connection')
   })
 
+  it('constructs the model and connection lifecycle cycle outside Runtime', () => {
+    const runtime = readSource('src/main/acp/runtime.ts')
+    const composition = readSource('src/main/acp/runtime-lifecycle-composition.ts')
+
+    expect(runtime).not.toMatch(
+      /new (?:AcpModelChangeWorkflow|AcpConnectionCloseWorkflow|AcpConnectionLifecycleWorkflow)/
+    )
+    expect(runtime).toContain('composeAcpRuntimeLifecycleOwners(options, base, session, {')
+    expect(composition.match(/new AcpModelChangeWorkflow\(/g)).toHaveLength(1)
+    expect(composition.match(/new AcpConnectionCloseWorkflow\(/g)).toHaveLength(1)
+    expect(composition.match(/new AcpConnectionLifecycleWorkflow\(/g)).toHaveLength(1)
+    expect(composition).not.toContain('AcpRuntime.prototype')
+  })
+
   it('keeps provider permission routing and reviewer preparation behind their owners', () => {
     const source = readSource('src/main/acp/runtime.ts')
 


### PR DESCRIPTION
## Problem

`AcpRuntime` still constructed and wired the model-change, connection-close, and connection-lifecycle workflow cycle inline. That left lifecycle ownership assembly inside the facade and made further Runtime reduction harder to review safely.

## Proposed change

- Add `composeAcpRuntimeLifecycleOwners` to build the three lifecycle workflows from the authoritative base and Session owner groups.
- Move close-state derivation and generation/connection effect binding into that composer without adding mirrored state.
- Keep only three structural facade callbacks in Runtime: `connect`, `disconnect`, and `openAgentConnection`.
- Add composition and architecture tests that lock construction location, bind-once routing, construction-time callback safety, and direct close execution.
- Reduce `runtime.ts` from 1,976 to 1,839 lines. Production raw change is 351 lines, below the approved 600-line leaf limit.

```mermaid
flowchart LR
  Runtime["AcpRuntime facade"] -->|"connect / disconnect / open candidate"| Composer["Lifecycle composer"]
  Base["Base owners"] --> Composer
  Session["Session owners"] --> Composer
  Composer --> Model["Model-change workflow"]
  Composer --> Close["Connection-close workflow"]
  Composer --> Lifecycle["Connection-lifecycle workflow"]
  Model -->|"failed deferred reconnect recovery"| Close
  Base -->|"generation transition effects"| Runtime
  Lifecycle --> Close
```

## Scope and non-goals

- No public API, IPC, wire contract, UI, data model, data relationship, or persistence change.
- No change to Specialist, Permission, or Compute behavior.
- No capability expansion or normalization across Electron, Web, CLI, or Task surfaces; their existing asymmetry remains intact.
- No orchestration data or public interface from #458 is introduced. This leaf only preserves a future composition seam.
- Provider-session workflows and turn/compaction/Artifact workflows remain in their separately bounded follow-up leaves.

## Acceptance criteria and validation

All commands below ran after the last material edit.

| Behavior / risk | Final check | Result |
| --- | --- | --- |
| Lifecycle owner construction, close workflow, model changes, base/session composition, architecture boundary | `npm test -- --run src/main/acp/model-change-workflow.test.ts src/main/acp/connection-close-workflow.test.ts src/main/acp/connection-lifecycle-workflow.test.ts src/main/acp/runtime-lifecycle-composition.test.ts src/main/acp/runtime-base-composition.test.ts src/main/acp/runtime-session-composition.test.ts src/main/runtime-state-ownership.architecture.test.ts` | 7 files, 60 tests passed |
| Unexpected close, prompt terminal failures, reviewer cleanup, deferred provider reconnect and recovery | focused `src/main/acp/runtime.test.ts` selection | 7 tests passed |
| Runtime tests that inject teardown/startup invalidation failures through the moved owner seams | focused `src/main/acp/runtime.test.ts` selection | 13 tests passed |
| Electron/Web/CLI/Task consumers and IPC/wire compatibility | ACP coordinator/IPC/wiring/task-port, surface matrix, web RPC, preload adapter, SDK client and CLI tests | 9 files, 145 tests passed |
| Node process types | `npm run typecheck:node` | passed |
| Repository lint | `npm run lint` | passed with 0 errors; 17 pre-existing warnings on unchanged files |
| Patch integrity | `git diff --check` | passed |

Independent Standards and Spec reviews both completed with 0 findings. The Standards review identified and verified fixes for one redundant self-delegation seam and one missing post-construction routing assertion before final approval.

The first exact-head AI/CI run correctly found that legacy Runtime tests still spied the removed facade helpers. The follow-up test-only commit points those tests at the authoritative close and startup owners; the 10 reported failures were 8 removed-close-seam cases, 1 removed-startup-seam case, and 1 cleanup cascade from that startup failure. No production code changed in the fix.

The full portable suite and platform-specific consumers are intentionally delegated to exact-head PR Gate/CI. Residual risk is limited to a future workflow constructor adding synchronous callback side effects; the new composition test locks the current no-host-callback construction contract.

## Review focus

- Confirm the composer derives every close-state operation from the existing authoritative owners and does not introduce a second state holder.
- Confirm generation effects are bound only after ModelChange and ConnectionClose are both constructed.
- Confirm the Runtime host seam remains structural and does not become a general callback bag.
- Confirm interrupted prompt failure publication and delayed reconnect recovery preserve their previous ordering and payloads.

Related context: #458.
