### PR TITLE
refactor(acp-runtime): compose provider session workflows

### DIFF
--- a/src/main/acp/runtime-provider-session-composition.test.ts
+++ b/src/main/acp/runtime-provider-session-composition.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+import { composeAcpRuntimeLifecycleOwners } from './runtime-lifecycle-composition'
+import {
+  composeAcpRuntimeProviderSessionOwners,
+  type AcpRuntimeProviderSessionOwners
+} from './runtime-provider-session-composition'
+import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
+
+describe('ACP Runtime Provider Session composition', () => {
+  it('builds a fresh frozen graph without invoking host operations', async () => {
+    const options = { appVersion: 'test', defaultCwd: '/workspace' }
+    const create = (): {
+      base: ReturnType<typeof composeAcpRuntimeBaseOwners>
+      lifecycle: ReturnType<typeof composeAcpRuntimeLifecycleOwners>
+      owners: AcpRuntimeProviderSessionOwners
+    } => {
+      const base = composeAcpRuntimeBaseOwners(options)
+      const session = composeAcpRuntimeSessionOwners(options, base)
+      const lifecycleHost = {
+        connect: vi.fn(async () => session.publication.getSnapshot()),
+        disconnect: vi.fn(async () => session.publication.getSnapshot()),
+        openAgentConnection: vi.fn(async () => {
+          throw new Error('not called during composition')
+        })
+      }
+      const lifecycle = composeAcpRuntimeLifecycleOwners(options, base, session, lifecycleHost)
+      const owners = composeAcpRuntimeProviderSessionOwners(options, base, session, lifecycle)
+
+      expect(lifecycleHost.connect).not.toHaveBeenCalled()
+      expect(lifecycleHost.disconnect).not.toHaveBeenCalled()
+      expect(lifecycleHost.openAgentConnection).not.toHaveBeenCalled()
+      return { base, lifecycle, owners }
+    }
+
+    const first = create()
+    const second = create()
+
+    expect(Object.isFrozen(first.owners)).toBe(true)
+    expect(first.owners.providerSessionCreator).not.toBe(second.owners.providerSessionCreator)
+    expect(first.owners.providerSessionResumer).not.toBe(second.owners.providerSessionResumer)
+    expect(first.owners.sessionReplacement).not.toBe(second.owners.sessionReplacement)
+    expect(first.owners.sessionDeletion).not.toBe(second.owners.sessionDeletion)
+
+    const barrier = vi
+      .spyOn(first.lifecycle.modelChanges, 'barrier', 'get')
+      .mockReturnValueOnce(Promise.resolve())
+      .mockReturnValue(undefined)
+    const withOperation = vi.spyOn(first.base.generationActivity, 'withOperation')
+    await first.owners.sessionDeletion.delete('detached-session')
+    expect(barrier).toHaveBeenCalledTimes(2)
+    expect(withOperation).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/acp/runtime-provider-session-composition.ts
+++ b/src/main/acp/runtime-provider-session-composition.ts
@@ -1,0 +1,175 @@
+import type { ClientConnection } from '@agentclientprotocol/sdk'
+
+import { DEFAULT_UPLOAD_PROJECT_NAME } from '../../shared/uploads'
+import type { AgentFramework } from '../agent-framework'
+import { AcpProviderSessionAdopter } from './provider-session-adopter'
+import { AcpProviderSessionCreator } from './provider-session-creator'
+import { AcpProviderSessionResumer } from './provider-session-resumer'
+import type { AcpRuntimeOptions } from './runtime'
+import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
+import type { AcpRuntimeLifecycleOwners } from './runtime-lifecycle-composition'
+import type { AcpRuntimeSessionOwners } from './runtime-session-composition'
+import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
+import { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
+import type { AcpPrimarySessionIdentityReservation } from './session-registry'
+
+// Composes the five workflows that create, adopt, replace, delete, and resume Provider Sessions.
+// Stable app identity remains Registry-owned; operation admission and timeout teardown derive from
+// the completed lifecycle graph so no callback can observe a partially constructed Runtime.
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+const composeAcpRuntimeProviderSessionOwners = (
+  options: AcpRuntimeOptions,
+  base: AcpRuntimeBaseOwners,
+  session: AcpRuntimeSessionOwners,
+  lifecycle: AcpRuntimeLifecycleOwners
+) => {
+  const currentConnection = (): ClientConnection | undefined => base.connectionResources.connection
+  const currentFramework = (): AgentFramework => base.backendGeneration.current.framework
+  const ensureConnected = (cwd: string): Promise<ClientConnection> =>
+    lifecycle.connectionLifecycle.ensureConnected(cwd)
+  const assertCurrentConnection = (connection: ClientConnection): void => {
+    if (currentConnection() !== connection || base.snapshotOwner.status !== 'connected') {
+      throw new Error('ACP session startup was superseded.')
+    }
+  }
+  const diagnosticContext = () => ({
+    framework: currentFramework().id,
+    generation: base.connectionResources.epoch,
+    status: base.snapshotOwner.status
+  })
+  const reserveIdentity = (
+    reservation: AcpPrimarySessionIdentityReservation | undefined,
+    sessionIds: string[],
+    publishedAppSessionId?: string,
+    startupGeneration = session.sessionRegistry.startupGeneration
+  ) =>
+    session.sessionRegistry.reserve({
+      reservation,
+      sessionIds,
+      publishedAppSessionId,
+      startupGeneration,
+      mayRenewAfterConnectionSetup: Boolean(
+        base.connectionTransitions.barrier ||
+        !currentConnection() ||
+        base.snapshotOwner.status !== 'connected'
+      ),
+      blockStartup: !base.connectionTransitions.barrier
+    })
+  const defaultProjectName = options.artifacts?.projectName || DEFAULT_UPLOAD_PROJECT_NAME
+  const updateCwd = (cwd: string): void => base.snapshotOwner.updateCwd(cwd)
+  const emitState = (): void => session.publication.emitState()
+  const withOperation = <Result>(work: () => Promise<Result>): Promise<Result> => {
+    const barrier = lifecycle.modelChanges.barrier ?? base.connectionTransitions.barrier
+    if (barrier) return barrier.then(() => withOperation(work))
+    return base.generationActivity.withOperation(work)
+  }
+
+  const providerSessionCreator = new AcpProviderSessionCreator({
+    defaultCwd: options.defaultCwd,
+    defaultProjectName,
+    currentCwd: () => base.snapshotOwner.cwd,
+    ensureConnected,
+    assertCurrentConnection,
+    currentBackend: () => base.backendGeneration.current,
+    registry: session.sessionRegistry,
+    reserveIdentity: (sessionId, startupGeneration) =>
+      reserveIdentity(undefined, [sessionId], undefined, startupGeneration),
+    capabilities: base.sessionCapabilities,
+    configurator: base.sessionConfigurator,
+    resolveSpecialistIdentity: options.resolveSpecialistIdentity,
+    resolveSpecialistSkills: options.resolveSpecialistSkills,
+    registerSessionSpecialist: options.notebook?.registerSessionSpecialist,
+    updateCwd,
+    pushEvent: (event) => session.publication.pushEvent(event),
+    emitState,
+    diagnosticContext
+  })
+  const providerSessionAdopter = new AcpProviderSessionAdopter({
+    currentBackend: () => base.backendGeneration.current,
+    registry: session.sessionRegistry,
+    reserveIdentity: (reservation, sessionIds) => reserveIdentity(reservation, sessionIds),
+    capabilities: base.sessionCapabilities,
+    configurator: base.sessionConfigurator,
+    resolveSpecialistIdentity: options.resolveSpecialistIdentity,
+    resolveSpecialistSkills: options.resolveSpecialistSkills,
+    peekClaudeReplay: (sessionId) => base.handoffContinuity.peekClaudeReplay(sessionId),
+    commitClaudeReplay: (sessionId) => base.handoffContinuity.commitClaudeReplay(sessionId),
+    updateCwd,
+    emitState,
+    diagnosticContext
+  })
+  const sessionReplacement = new AcpSessionReplacementWorkflow({
+    defaultCwd: options.defaultCwd,
+    defaultProjectName,
+    currentCwd: () => base.snapshotOwner.cwd,
+    currentFrameworkId: () => currentFramework().id,
+    ensureConnected,
+    assertCurrentConnection,
+    registry: session.sessionRegistry,
+    reserveIdentity: (sessionId, publishedAppSessionId) =>
+      reserveIdentity(undefined, [sessionId], publishedAppSessionId),
+    adopter: providerSessionAdopter,
+    permission: session.permissionContext,
+    promptContent: base.promptContentOwner,
+    contextUsage: base.contextUsageTracker,
+    interactions: base.sessionInteractions,
+    resolveSpecialistIdentity: options.resolveSpecialistIdentity,
+    registerSessionSpecialist: options.notebook?.registerSessionSpecialist
+  })
+  const sessionDeletion = new AcpSessionDeletionWorkflow({
+    registry: session.sessionRegistry,
+    withOperation,
+    currentConnection,
+    supportsSessionDelete: () => base.connectionResources.capabilities.delete,
+    supportsSessionClose: () => base.connectionResources.capabilities.close,
+    permission: session.permissionContext,
+    interactions: base.sessionInteractions,
+    capabilities: base.sessionCapabilities,
+    promptContent: base.promptContentOwner,
+    handoff: base.handoffContinuity,
+    contextUsage: base.contextUsageTracker,
+    projector: session.sessionUpdateProjector,
+    pushEvent: (event) => session.publication.pushEvent(event),
+    emitState,
+    getSnapshot: () => session.publication.getSnapshot()
+  })
+  const providerSessionResumer = new AcpProviderSessionResumer({
+    defaultCwd: options.defaultCwd,
+    defaultProjectName,
+    currentCwd: () => base.snapshotOwner.cwd,
+    currentConnection,
+    ensureConnected,
+    assertCurrentConnection,
+    disconnectTimedOutConnection: async () => {
+      await lifecycle.connectionClose.disconnect(false)
+    },
+    resumeCapabilityAdvertised: () => base.connectionResources.capabilities.resume,
+    currentBackend: () => base.backendGeneration.current,
+    registry: session.sessionRegistry,
+    reserveIdentity: (sessionId) => reserveIdentity(undefined, [sessionId]),
+    capabilities: base.sessionCapabilities,
+    configurator: base.sessionConfigurator,
+    adopter: providerSessionAdopter,
+    resolveSpecialistSkills: options.resolveSpecialistSkills,
+    updateCwd,
+    pushEvent: (event) => session.publication.pushEvent(event),
+    emitState,
+    resumeTimeoutMs: options.resumeTimeoutMs ?? 30_000,
+    setTimer: base.setTimer,
+    clearTimer: base.clearTimer,
+    diagnosticContext
+  })
+
+  return Object.freeze({
+    providerSessionCreator,
+    providerSessionResumer,
+    sessionReplacement,
+    sessionDeletion
+  })
+}
+/* eslint-enable @typescript-eslint/explicit-function-return-type */
+
+type AcpRuntimeProviderSessionOwners = ReturnType<typeof composeAcpRuntimeProviderSessionOwners>
+
+export { composeAcpRuntimeProviderSessionOwners }
+export type { AcpRuntimeProviderSessionOwners }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -10066,9 +10066,9 @@ describe('ACP runtime session management', () => {
     const replacementConnection = createDeferred<unknown>()
     const internal = runtime as unknown as {
       connection: unknown
-      ensureConnected: (cwd: string) => Promise<unknown>
+      connectionLifecycle: { ensureConnected: (cwd: string) => Promise<unknown> }
     }
-    vi.spyOn(internal, 'ensureConnected').mockImplementationOnce(async () => {
+    vi.spyOn(internal.connectionLifecycle, 'ensureConnected').mockImplementationOnce(async () => {
       ensureConnectedStarted.resolve()
       return replacementConnection.promise
     })
@@ -14347,15 +14347,19 @@ describe('ACP runtime session management', () => {
       const connectionReady = createDeferred()
       const releaseEnsureConnected = createDeferred()
       const internal = runtime as unknown as {
-        ensureConnected: (cwd: string) => Promise<unknown>
+        connectionLifecycle: { ensureConnected: (cwd: string) => Promise<unknown> }
       }
-      const ensureConnected = internal.ensureConnected.bind(runtime)
-      vi.spyOn(internal, 'ensureConnected').mockImplementationOnce(async (cwd) => {
-        const connection = await ensureConnected(cwd)
-        connectionReady.resolve()
-        await releaseEnsureConnected.promise
-        return connection
-      })
+      const ensureConnected = internal.connectionLifecycle.ensureConnected.bind(
+        internal.connectionLifecycle
+      )
+      vi.spyOn(internal.connectionLifecycle, 'ensureConnected').mockImplementationOnce(
+        async (cwd) => {
+          const connection = await ensureConnected(cwd)
+          connectionReady.resolve()
+          await releaseEnsureConnected.promise
+          return connection
+        }
+      )
 
       const pending =
         operation === 'context reset'

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -47,7 +47,7 @@ import { opencodeStorageDir } from '../agent-framework/opencode'
 import type { ContextUsageTracker } from './context-usage-tracker'
 import type { AcpContextUsagePolicy } from './context-usage-policy'
 import type { UploadRepository } from '../uploads/repository'
-import { DEFAULT_UPLOAD_PROJECT_NAME, type UploadedAttachment } from '../../shared/uploads'
+import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, FileReference } from '../../shared/artifacts'
 import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
@@ -64,11 +64,7 @@ import type {
   AcpSessionInteractionOwner,
   AcpPromptSessionInteractionScope
 } from './session-interaction-owner'
-import type {
-  AcpSessionRegistry,
-  AcpPrimarySessionIdentityReservation,
-  AcpPrimarySessionIdentityReservationResult
-} from './session-registry'
+import type { AcpSessionRegistry } from './session-registry'
 import type {
   AcpConnectionResourceOwner,
   AcpConnectionResourceAttempt
@@ -90,11 +86,10 @@ import type { AcpSessionUpdateProjector } from './session-update-projector'
 import type { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
 import type { AcpConnectionCloseWorkflow } from './connection-close-workflow'
 import type { AcpModelChangeWorkflow } from './model-change-workflow'
-import { AcpProviderSessionCreator } from './provider-session-creator'
-import { AcpProviderSessionAdopter } from './provider-session-adopter'
-import { AcpProviderSessionResumer } from './provider-session-resumer'
-import { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
-import { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
+import type { AcpProviderSessionCreator } from './provider-session-creator'
+import type { AcpProviderSessionResumer } from './provider-session-resumer'
+import type { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
+import type { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
 import { AcpPromptPreparationOwner } from './prompt-preparation-owner'
 import { AcpPromptTurnWorkflow, type AcpPromptTurnPlanContext } from './prompt-turn-workflow'
 import { AcpContextCompactionWorkflow } from './context-compaction-workflow'
@@ -115,6 +110,7 @@ import type { AcpRuntimePublicationOwner } from './runtime-publication-owner'
 import type { AcpRuntimeSessionOwners } from './runtime-session-composition'
 import type { AcpSessionEnvironmentPolicy } from './session-environment-policy'
 import { composeAcpRuntimeLifecycleOwners } from './runtime-lifecycle-composition'
+import { composeAcpRuntimeProviderSessionOwners } from './runtime-provider-session-composition'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -344,9 +340,6 @@ class AcpRuntime {
   private readonly sessionConfigurator: AcpSessionConfigurator
   private readonly sessionUpdateProjector: AcpSessionUpdateProjector
   private readonly providerPromptExecutor: AcpProviderPromptExecutor
-  // Injectable lifecycle timers (defaults to real setTimeout/clearTimeout).
-  private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
-  private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private readonly artifactOptions: AcpRuntimeArtifactOptions | undefined
   private readonly artifactTurns: ArtifactTurnOwner | undefined
   private readonly planInteractions: SessionPlanInteractionOwner
@@ -360,7 +353,6 @@ class AcpRuntime {
   private readonly connectionLifecycle: AcpConnectionLifecycleWorkflow
   private readonly modelChanges: AcpModelChangeWorkflow
   private readonly providerSessionCreator: AcpProviderSessionCreator
-  private readonly providerSessionAdopter: AcpProviderSessionAdopter
   private readonly providerSessionResumer: AcpProviderSessionResumer
   private readonly sessionReplacement: AcpSessionReplacementWorkflow
   private readonly sessionDeletion: AcpSessionDeletionWorkflow
@@ -381,8 +373,6 @@ class AcpRuntime {
     this.backendGeneration = base.backendGeneration
     this.providerPromptExecutor = base.providerPromptExecutor
     this.contextUsageTracker = base.contextUsageTracker
-    this.setTimer = base.setTimer
-    this.clearTimer = base.clearTimer
     this.sessionInteractions = base.sessionInteractions
     this.sessionCapabilities = base.sessionCapabilities
     this.artifactTurns = base.artifactTurns
@@ -526,102 +516,16 @@ class AcpRuntime {
     this.modelChanges = lifecycle.modelChanges
     this.connectionClose = lifecycle.connectionClose
     this.connectionLifecycle = lifecycle.connectionLifecycle
-    this.providerSessionCreator = new AcpProviderSessionCreator({
-      defaultCwd: options.defaultCwd,
-      defaultProjectName: options.artifacts?.projectName || DEFAULT_UPLOAD_PROJECT_NAME,
-      currentCwd: () => this.snapshotOwner.cwd,
-      ensureConnected: (cwd) => this.ensureConnected(cwd),
-      assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
-      currentBackend: () => this.backend,
-      registry: this.sessionRegistry,
-      reserveIdentity: (sessionId, startupGeneration) =>
-        this.reservePrimarySessionIds(undefined, [sessionId], undefined, startupGeneration),
-      capabilities: this.sessionCapabilities,
-      configurator: this.sessionConfigurator,
-      resolveSpecialistIdentity: options.resolveSpecialistIdentity,
-      resolveSpecialistSkills: options.resolveSpecialistSkills,
-      registerSessionSpecialist: options.notebook?.registerSessionSpecialist,
-      updateCwd: (cwd) => this.snapshotOwner.updateCwd(cwd),
-      pushEvent: (event) => this.pushEvent(event),
-      emitState: () => this.emitState(),
-      diagnosticContext: () => this.diagnosticContext()
-    })
-    this.providerSessionAdopter = new AcpProviderSessionAdopter({
-      currentBackend: () => this.backend,
-      registry: this.sessionRegistry,
-      reserveIdentity: (reservation, sessionIds) =>
-        this.reservePrimarySessionIds(reservation, sessionIds),
-      capabilities: this.sessionCapabilities,
-      configurator: this.sessionConfigurator,
-      resolveSpecialistIdentity: options.resolveSpecialistIdentity,
-      resolveSpecialistSkills: options.resolveSpecialistSkills,
-      peekClaudeReplay: (sessionId) => this.handoffContinuity.peekClaudeReplay(sessionId),
-      commitClaudeReplay: (sessionId) => this.handoffContinuity.commitClaudeReplay(sessionId),
-      updateCwd: (cwd) => this.snapshotOwner.updateCwd(cwd),
-      emitState: () => this.emitState(),
-      diagnosticContext: () => this.diagnosticContext()
-    })
-    this.sessionReplacement = new AcpSessionReplacementWorkflow({
-      defaultCwd: options.defaultCwd,
-      defaultProjectName: options.artifacts?.projectName || DEFAULT_UPLOAD_PROJECT_NAME,
-      currentCwd: () => this.snapshotOwner.cwd,
-      currentFrameworkId: () => this.framework.id,
-      ensureConnected: (cwd) => this.ensureConnected(cwd),
-      assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
-      registry: this.sessionRegistry,
-      reserveIdentity: (sessionId, publishedAppSessionId) =>
-        this.reservePrimarySessionIds(undefined, [sessionId], publishedAppSessionId),
-      adopter: this.providerSessionAdopter,
-      permission: this.permissionContext,
-      promptContent: this.promptContentOwner,
-      contextUsage: this.contextUsageTracker,
-      interactions: this.sessionInteractions,
-      resolveSpecialistIdentity: options.resolveSpecialistIdentity,
-      registerSessionSpecialist: options.notebook?.registerSessionSpecialist
-    })
-    this.sessionDeletion = new AcpSessionDeletionWorkflow({
-      registry: this.sessionRegistry,
-      withOperation: (work) => this.withOperationLease(work),
-      currentConnection: () => this.connection,
-      supportsSessionDelete: () => this.connectionResources.capabilities.delete,
-      supportsSessionClose: () => this.connectionResources.capabilities.close,
-      permission: this.permissionContext,
-      interactions: this.sessionInteractions,
-      capabilities: this.sessionCapabilities,
-      promptContent: this.promptContentOwner,
-      handoff: this.handoffContinuity,
-      contextUsage: this.contextUsageTracker,
-      projector: this.sessionUpdateProjector,
-      pushEvent: (event) => this.pushEvent(event),
-      emitState: () => this.emitState(),
-      getSnapshot: () => this.getSnapshot()
-    })
-    this.providerSessionResumer = new AcpProviderSessionResumer({
-      defaultCwd: options.defaultCwd,
-      defaultProjectName: options.artifacts?.projectName || DEFAULT_UPLOAD_PROJECT_NAME,
-      currentCwd: () => this.snapshotOwner.cwd,
-      currentConnection: () => this.connection,
-      ensureConnected: (cwd) => this.ensureConnected(cwd),
-      assertCurrentConnection: (connection) => this.assertCurrentConnectedConnection(connection),
-      disconnectTimedOutConnection: async () => {
-        await this.disconnect(false)
-      },
-      resumeCapabilityAdvertised: () => this.connectionResources.capabilities.resume,
-      currentBackend: () => this.backend,
-      registry: this.sessionRegistry,
-      reserveIdentity: (sessionId) => this.reservePrimarySessionIds(undefined, [sessionId]),
-      capabilities: this.sessionCapabilities,
-      configurator: this.sessionConfigurator,
-      adopter: this.providerSessionAdopter,
-      resolveSpecialistSkills: options.resolveSpecialistSkills,
-      updateCwd: (cwd) => this.snapshotOwner.updateCwd(cwd),
-      pushEvent: (event) => this.pushEvent(event),
-      emitState: () => this.emitState(),
-      resumeTimeoutMs: options.resumeTimeoutMs ?? 30_000,
-      setTimer: this.setTimer,
-      clearTimer: this.clearTimer,
-      diagnosticContext: () => this.diagnosticContext()
-    })
+    const providerSessions = composeAcpRuntimeProviderSessionOwners(
+      options,
+      base,
+      session,
+      lifecycle
+    )
+    this.providerSessionCreator = providerSessions.providerSessionCreator
+    this.providerSessionResumer = providerSessions.providerSessionResumer
+    this.sessionReplacement = providerSessions.sessionReplacement
+    this.sessionDeletion = providerSessions.sessionDeletion
   }
 
   private get backend(): AcpBackendGenerationView {
@@ -1797,24 +1701,6 @@ class AcpRuntime {
         ensureConnected: (cwd) => this.ensureConnected(cwd)
       })
     )
-  }
-
-  private reservePrimarySessionIds(
-    reservation: AcpPrimarySessionIdentityReservation | undefined,
-    sessionIds: string[],
-    publishedAppSessionId?: string,
-    startupGeneration = this.sessionRegistry.startupGeneration
-  ): AcpPrimarySessionIdentityReservationResult {
-    return this.sessionRegistry.reserve({
-      reservation,
-      sessionIds,
-      publishedAppSessionId,
-      startupGeneration,
-      mayRenewAfterConnectionSetup: Boolean(
-        this.reconnectBarrier || !this.connection || this.snapshotOwner.status !== 'connected'
-      ),
-      blockStartup: !this.reconnectBarrier
-    })
   }
 
   private assertCurrentConnectedConnection(connection: ClientConnection): void {

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -345,7 +345,9 @@ describe('runtime state ownership architecture', () => {
   })
 
   it('keeps model application and attached resume behavior behind their workflows', () => {
-    const source = readSource('src/main/acp/runtime.ts')
+    const runtime = readSource('src/main/acp/runtime.ts')
+    const providerSessions = readSource('src/main/acp/runtime-provider-session-composition.ts')
+    const source = runtime + providerSessions
 
     expect(source).not.toContain('canApplyModelChange')
     expect(source).not.toContain('modelChangeMatchesCurrent')
@@ -353,7 +355,9 @@ describe('runtime state ownership architecture', () => {
     expect(source).not.toContain('resumeSessionOperation')
     expect(source).toContain('return this.modelChanges.applyReasoningEffort(effort)')
     expect(source).toContain('this.providerSessionResumer.resume(request)')
-    expect(source).toContain('currentConnection: () => this.connection')
+    expect(providerSessions).toContain(
+      'const currentConnection = (): ClientConnection | undefined => base.connectionResources.connection'
+    )
   })
 
   it('constructs the model and connection lifecycle cycle outside Runtime', () => {
@@ -368,6 +372,24 @@ describe('runtime state ownership architecture', () => {
     expect(composition.match(/new AcpConnectionCloseWorkflow\(/g)).toHaveLength(1)
     expect(composition.match(/new AcpConnectionLifecycleWorkflow\(/g)).toHaveLength(1)
     expect(composition).not.toContain('AcpRuntime.prototype')
+  })
+
+  it('constructs Provider Session workflows outside Runtime with one shared adopter', () => {
+    const runtime = readSource('src/main/acp/runtime.ts')
+    const composition = readSource('src/main/acp/runtime-provider-session-composition.ts')
+
+    expect(runtime).not.toMatch(
+      /new (?:AcpProviderSessionCreator|AcpProviderSessionAdopter|AcpProviderSessionResumer|AcpSessionReplacementWorkflow|AcpSessionDeletionWorkflow)/
+    )
+    expect(runtime).toContain('composeAcpRuntimeProviderSessionOwners(')
+    expect(composition.match(/new AcpProviderSessionCreator\(/g)).toHaveLength(1)
+    expect(composition.match(/new AcpProviderSessionAdopter\(/g)).toHaveLength(1)
+    expect(composition.match(/new AcpProviderSessionResumer\(/g)).toHaveLength(1)
+    expect(composition.match(/new AcpSessionReplacementWorkflow\(/g)).toHaveLength(1)
+    expect(composition.match(/new AcpSessionDeletionWorkflow\(/g)).toHaveLength(1)
+    expect(composition.match(/adopter: providerSessionAdopter/g)).toHaveLength(2)
+    expect(composition).toContain('await lifecycle.connectionClose.disconnect(false)')
+    expect(composition).not.toMatch(/AcpRuntime\.prototype|from ['"]electron['"]/)
   })
 
   it('keeps provider permission routing and reviewer preparation behind their owners', () => {


### PR DESCRIPTION
## Problem

`AcpRuntime` still constructed and wired all five Provider Session workflows directly. That kept stable app identity reservation, Provider Session adoption, deletion admission, and resume timeout teardown coupled to the facade even though the underlying state already belonged to dedicated owners.

## Proposed change

- Add a frozen Provider Session composition module for Creator, Adopter, Resumer, Replacement, and Deletion.
- Keep one internal Adopter shared by Replacement and Resumer.
- Derive identity reservation, lifecycle barriers, operation leases, diagnostics, and publication from the existing base/session/lifecycle owner graph.
- Leave `AcpRuntime` with only four workflow references and public delegation.
- Update architecture assertions and two race tests to observe the authoritative lifecycle owner instead of the removed Runtime forwarding seam.

```mermaid
flowchart LR
  B["Base owners"] --> C["Provider Session composer"]
  S["Session owners"] --> C
  L["Lifecycle owners"] --> C
  C --> CR["Creator"]
  C --> AD["Adopter (internal, shared)"]
  AD --> RP["Replacement"]
  AD --> RS["Resumer"]
  C --> DL["Deletion"]
  CR --> RT["Runtime facade"]
  RP --> RT
  RS --> RT
  DL --> RT
```

## Scope and non-goals

- No public API, IPC, wire, UI, data-model, persistence, or user-interaction change.
- Stable app Session IDs remain distinct from replaceable Provider protocol Session IDs.
- Codex fresh adoption, Claude replay commit timing, context reset, deletion cleanup, and resume timeout behavior remain unchanged.
- Specialist, Permission, Compute, and Electron/Web/CLI/Task capability boundaries remain unchanged.
- No attempt is made to address Linux E2E or other platform infrastructure.

The production raw diff is 323 lines (additions plus deletions), below the 600-line cutover limit. `src/main/acp/runtime.ts` decreases from 1,839 to 1,725 lines.

## Acceptance criteria and validation

All checks below ran against the final material state:

- Provider Session graph, identity reservation, resume/adoption/replacement/deletion ownership -> targeted 12-file Vitest set -> **152/152 passed**.
- Runtime session compatibility and concurrency races -> `npm test -- --run src/main/acp/runtime.test.ts` -> **440/440 passed**; three localhost-dependent cases required running outside the restricted sandbox.
- Coordinator, IPC, Codex handoff, and OpenCode handoff consumers -> targeted 4-file Vitest set -> **92/92 passed**.
- Node process types -> `npm run typecheck:node` -> **passed**.
- Repository lint -> `npm run lint` -> **passed with 0 errors**; 17 unrelated warnings already present on the latest main baseline.
- Formatting and patch integrity -> targeted Prettier check plus `git diff --check` -> **passed**.
- Two independent read-only Standards/Spec reviews -> **0 findings**.

Cross-platform PR Gate remains authoritative for platform lanes; this change does not modify process spawning or platform-specific code.

## Review focus

- The reservation formula preserves startup generation, reconnect renewal, and startup blocking semantics.
- Deletion still calls `beginDelete` synchronously before operation admission.
- Replacement and Resumer share exactly one Adopter.
- Resume timeout still tears down through `connectionClose.disconnect(false)`.
- No capability or transport surface is added for Electron, Web, CLI, or Task.
