### PR TITLE
feat(session): render persistent Plan call records

### DIFF
--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -36,6 +36,7 @@ import {
 import { NotebookInputDataStrip } from './NotebookInputDataStrip'
 import { NotebookDialogCell } from './SessionNotebookDialog'
 import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
+import { WorkspacePlanActivityRecord } from './WorkspacePlanActivityRecord'
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
 import { createConversationItems } from './workspace-conversation-items'
 import { groupConversationItems } from './workspace-tool-activity-groups'
@@ -338,6 +339,16 @@ const ProvenanceMessagesTimeline = ({
                 // Artifact provenance builds its immutable transcript from persisted messages and
                 // activities only, so no live coordinator lifecycle rows are supplied here.
                 if (conversationItem.type === 'handoff') return null
+
+                if (conversationItem.type === 'plan-activity') {
+                  return (
+                    <WorkspacePlanActivityRecord
+                      key={conversationItem.id}
+                      activity={conversationItem.activity}
+                      contentPaddingClassName="px-0 md:px-0"
+                    />
+                  )
+                }
 
                 return (
                   <WorkspaceActivityGroup

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -1203,6 +1203,55 @@ describe('WorkspaceMessageScroller tool detail rows', () => {
 })
 
 describe('WorkspaceActivityGroup header summaries', () => {
+  it('renders generate_plan outside ordinary tool groups without counting it as a tool step', async () => {
+    const html = await renderScroller(
+      createSession({
+        status: 'idle',
+        messages: [createMessage({ id: 'prompt-1' })],
+        activities: [
+          createActivity({
+            id: 'read-1',
+            title: 'Read source',
+            toolKind: 'read',
+            sortIndex: 2,
+            createdAt: 1710000000001
+          }),
+          createActivity({
+            id: 'plan-1',
+            title: 'generate_plan',
+            providerToolName: 'mcp__open-science-plan__generate_plan',
+            sortIndex: 3,
+            createdAt: 1710000000002,
+            rawInput: {
+              arguments: {
+                task_summary: 'Prepare the report',
+                phases: [
+                  {
+                    name: 'Delivery',
+                    delegations: [
+                      {
+                        name: 'Writing',
+                        steps: [{ title: 'Draft report', description: 'Write the findings.' }]
+                      }
+                    ]
+                  }
+                ],
+                desired_outputs: ['Report'],
+                feasibility: { confidence: 'high', rationale: 'Inputs are ready.' }
+              }
+            }
+          })
+        ]
+      })
+    )
+
+    expect(html).toContain('data-testid="plan-call-record"')
+    expect(html).toContain('Prepare the report')
+    expect(html).toContain('Read a file')
+    expect(html.match(/1 step/g)).toHaveLength(2)
+    expect(html).not.toContain('2 steps')
+  })
+
   it('summarizes a mixed group by tool category', async () => {
     const html = await renderScroller(
       createSession({

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -29,6 +29,7 @@ import { extractJobIdFromActivity } from '@/components/job-binding-utils'
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { ReviewerCard } from '@/components/ReviewerCard'
 import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
+import { WorkspacePlanActivityRecord } from './WorkspacePlanActivityRecord'
 import { WorkspaceAgentLoadingRow } from './WorkspaceAgentLoadingRow'
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
 import type { ArtifactMentionPart } from './WorkspaceMessageItem'
@@ -842,6 +843,10 @@ const WorkspaceMessageScrollerImpl = ({
                         </div>
                       </MessageScrollerItem>
                     )
+                  }
+
+                  if (item.type === 'plan-activity') {
+                    return <WorkspacePlanActivityRecord key={item.id} activity={item.activity} />
                   }
 
                   return (

--- a/src/renderer/src/pages/workspace/WorkspacePlanActivityRecord.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePlanActivityRecord.test.tsx
@@ -1,0 +1,316 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { PropsWithChildren } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ToolActivity } from '@/stores/session-store'
+import { WorkspacePlanActivityRecord } from './WorkspacePlanActivityRecord'
+
+vi.mock('@/components/ui/message-scroller', () => ({
+  MessageScrollerItem: ({ children }: PropsWithChildren) => <div>{children}</div>
+}))
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const createActivity = (
+  rawInput: unknown,
+  overrides: Partial<ToolActivity> = {}
+): ToolActivity => ({
+  id: 'plan/activity:1',
+  kind: 'tool',
+  title: 'generate_plan',
+  providerToolName: 'generate_plan',
+  status: 'completed',
+  eventIds: [],
+  sortIndex: 1,
+  rawInput,
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+const planArguments = {
+  task_summary: 'Polish the example paragraph',
+  phases: [
+    {
+      name: 'Work',
+      delegations: [
+        {
+          name: 'Writing',
+          steps: [
+            { title: 'Inspect wording', description: 'Find unclear phrases.' },
+            { title: 'Polish prose', description: 'Rewrite the paragraph.' }
+          ]
+        }
+      ]
+    }
+  ],
+  desired_outputs: [],
+  feasibility: { confidence: 'high', rationale: 'The paragraph is available.' }
+}
+
+const createPreviewPlanArguments = (
+  stepCount: number,
+  taskSummary: string
+): typeof planArguments => ({
+  ...planArguments,
+  task_summary: taskSummary,
+  phases: [
+    {
+      name: 'Work',
+      delegations: [
+        {
+          name: 'Writing',
+          steps: Array.from({ length: stepCount }, (_, index) => ({
+            title:
+              index === 0
+                ? 'Step 1 with a deliberately long title that must remain fully wrapped without clamping'
+                : `Step ${index + 1}`,
+            description: `Description ${index + 1}`
+          }))
+        }
+      ]
+    }
+  ]
+})
+
+// jsdom does not synthesize a native button's click default action from keyboard events. Dispatch
+// the browser event at the correct phase, then perform that default action only when it was not
+// cancelled. Product code remains on native button semantics with no redundant key handler.
+const activateNativeButtonWithKeyboard = (button: HTMLButtonElement, key: 'Enter' | ' '): void => {
+  button.focus()
+  const event = new KeyboardEvent(key === 'Enter' ? 'keydown' : 'keyup', {
+    key,
+    bubbles: true,
+    cancelable: true
+  })
+  if (button.dispatchEvent(event)) button.click()
+}
+
+const getStepButtons = (container: ParentNode): HTMLButtonElement[] =>
+  Array.from(container.querySelectorAll<HTMLButtonElement>('button[aria-controls^="plan-step-"]'))
+
+describe('WorkspacePlanActivityRecord', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let notifyResize: (() => void) | undefined
+  const originalResizeObserver = globalThis.ResizeObserver
+
+  beforeEach(() => {
+    globalThis.ResizeObserver = class {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+      observe(): void {
+        notifyResize = () => this.callback([], this as unknown as ResizeObserver)
+      }
+      disconnect(): void {
+        notifyResize = undefined
+      }
+      unobserve(): void {
+        notifyResize = undefined
+      }
+    }
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    notifyResize = undefined
+    if (originalResizeObserver) globalThis.ResizeObserver = originalResizeObserver
+    else delete (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver
+  })
+
+  it('shows task, count, and feasibility while descriptions start collapsed', () => {
+    act(() => root.render(<WorkspacePlanActivityRecord activity={createActivity(planArguments)} />))
+
+    expect(container.textContent).toContain('Created execution Plan')
+    expect(container.textContent).toContain('2 steps')
+    expect(container.textContent).toContain('Polish the example paragraph')
+    expect(container.textContent).toContain('high confidence')
+    expect(container.textContent).toContain('The paragraph is available.')
+    expect(container.textContent).not.toContain('Find unclear phrases.')
+
+    const buttons = getStepButtons(container)
+    expect(buttons.map((button) => button.textContent?.trim())).toEqual([
+      'Inspect wording',
+      'Polish prose'
+    ])
+    expect(buttons.every((button) => button.getAttribute('aria-expanded') === 'false')).toBe(true)
+    expect(buttons.every((button) => Boolean(button.getAttribute('aria-controls')))).toBe(true)
+  })
+
+  it('expands step descriptions independently with native button controls', () => {
+    act(() => root.render(<WorkspacePlanActivityRecord activity={createActivity(planArguments)} />))
+    const [first, second] = getStepButtons(container)
+
+    expect(first.tagName).toBe('BUTTON')
+    act(() => first.click())
+    expect(first.getAttribute('aria-expanded')).toBe('true')
+    expect(container.textContent).toContain('Find unclear phrases.')
+    expect(container.textContent).not.toContain('Rewrite the paragraph.')
+    expect(first.querySelector('span')?.className).toContain('text-[12px] text-text-000')
+    expect(document.getElementById(first.getAttribute('aria-controls') ?? '')?.className).toContain(
+      'text-[10.5px] leading-[1.5] text-text-300'
+    )
+
+    act(() => second.click())
+    expect(first.getAttribute('aria-expanded')).toBe('true')
+    expect(second.getAttribute('aria-expanded')).toBe('true')
+    expect(container.textContent).toContain('Find unclear phrases.')
+    expect(container.textContent).toContain('Rewrite the paragraph.')
+  })
+
+  it.each([
+    ['Enter', 'Enter'],
+    ['Space', ' ']
+  ] as const)('expands a step through native %s activation', (_label, key) => {
+    act(() => root.render(<WorkspacePlanActivityRecord activity={createActivity(planArguments)} />))
+    const first = getStepButtons(container)[0]
+    expect(first?.getAttribute('aria-expanded')).toBe('false')
+
+    act(() => {
+      if (first) activateNativeButtonWithKeyboard(first, key)
+    })
+
+    expect(first?.getAttribute('aria-expanded')).toBe('true')
+    expect(container.textContent).toContain('Find unclear phrases.')
+  })
+
+  it('renders compact decisions and an explicit unavailable fallback', () => {
+    act(() =>
+      root.render(
+        <div>
+          <WorkspacePlanActivityRecord activity={createActivity({ decision: 'approved' })} />
+          <WorkspacePlanActivityRecord
+            activity={createActivity({ arguments: { decision: 'rejected' } }, { id: 'dismiss' })}
+          />
+          <WorkspacePlanActivityRecord activity={createActivity(undefined, { id: 'missing' })} />
+        </div>
+      )
+    )
+
+    expect(container.textContent).toContain('Approved execution Plan')
+    expect(container.textContent).toContain('Dismissed execution Plan')
+    expect(container.textContent).toContain('Plan details unavailable')
+  })
+
+  it('keeps failed tool details available from the Plan record', () => {
+    act(() =>
+      root.render(
+        <WorkspacePlanActivityRecord
+          activity={createActivity(planArguments, {
+            status: 'failed',
+            rawOutput: { error: 'Plan service unavailable' }
+          })}
+        />
+      )
+    )
+
+    expect(container.textContent).toContain('Failed to create execution Plan')
+    const detailsButton = container.querySelector<HTMLButtonElement>('button')
+    expect(detailsButton?.getAttribute('aria-expanded')).toBe('false')
+
+    act(() => detailsButton?.click())
+    expect(detailsButton?.getAttribute('aria-expanded')).toBe('true')
+    expect(container.textContent).toContain('Plan service unavailable')
+  })
+
+  it('offers an independent three-line task preview only when the summary overflows', () => {
+    act(() => root.render(<WorkspacePlanActivityRecord activity={createActivity(planArguments)} />))
+    expect(container.querySelector('[data-testid="plan-task-summary-toggle"]')).toBeNull()
+
+    const longPlan = createPreviewPlanArguments(
+      2,
+      'Prepare and polish a long task summary while preserving meaning, terminology, tone, evidence, and every required output.'
+    )
+    act(() => root.render(<WorkspacePlanActivityRecord activity={createActivity(longPlan)} />))
+    const summary = container.querySelector<HTMLElement>('[data-testid="plan-task-summary"]')
+    Object.defineProperties(summary, {
+      clientHeight: { configurable: true, value: 60 },
+      scrollHeight: { configurable: true, value: 120 }
+    })
+    act(() => notifyResize?.())
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="plan-task-summary-toggle"]'
+    )
+    expect(summary?.className).toContain('line-clamp-3')
+    expect(toggle?.textContent).toContain('Show full task')
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false')
+
+    act(() => toggle?.click())
+    expect(summary?.className).not.toContain('line-clamp-3')
+    expect(toggle?.textContent).toContain('Show less')
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true')
+    expect(container.querySelector('[data-testid="plan-expand-all"]')?.textContent).toContain(
+      'Expand all'
+    )
+    expect(container.textContent).not.toContain('Find unclear phrases.')
+  })
+
+  it('shows five unclamped step titles and a dynamic compact remainder', () => {
+    const previewPlan = createPreviewPlanArguments(8, 'Prepare the report')
+    act(() => root.render(<WorkspacePlanActivityRecord activity={createActivity(previewPlan)} />))
+
+    const stepButtons = getStepButtons(container)
+    expect(stepButtons).toHaveLength(5)
+    expect(container.textContent).toContain('+ 3 more steps')
+    expect(container.textContent).not.toContain('Step 6')
+    expect(stepButtons[0].textContent).toContain(
+      'Step 1 with a deliberately long title that must remain fully wrapped without clamping'
+    )
+    expect(stepButtons[0].querySelector('span')?.className).not.toMatch(/truncate|line-clamp/u)
+
+    act(() =>
+      root.render(
+        <WorkspacePlanActivityRecord
+          activity={createActivity(createPreviewPlanArguments(6, 'Prepare the report'))}
+        />
+      )
+    )
+    expect(container.textContent).toContain('+ 1 more step')
+  })
+
+  it('expands and collapses the whole card from compact or partially expanded state', () => {
+    const previewPlan = createPreviewPlanArguments(
+      8,
+      'Prepare and polish a long task summary while preserving meaning, terminology, tone, evidence, and every required output.'
+    )
+    act(() => root.render(<WorkspacePlanActivityRecord activity={createActivity(previewPlan)} />))
+    const summary = container.querySelector<HTMLElement>('[data-testid="plan-task-summary"]')
+    Object.defineProperties(summary, {
+      clientHeight: { configurable: true, value: 60 },
+      scrollHeight: { configurable: true, value: 120 }
+    })
+    act(() => notifyResize?.())
+
+    const firstStep = getStepButtons(container)[0]
+    const expandAll = container.querySelector<HTMLButtonElement>('[data-testid="plan-expand-all"]')
+    act(() => firstStep?.click())
+    expect(container.textContent).toContain('Description 1')
+    expect(expandAll?.textContent).toContain('Expand all')
+
+    act(() => expandAll?.click())
+    const allStepButtons = getStepButtons(container)
+    expect(allStepButtons).toHaveLength(8)
+    expect(allStepButtons.every((button) => button.getAttribute('aria-expanded') === 'true')).toBe(
+      true
+    )
+    expect(container.textContent).toContain('Description 8')
+    expect(container.textContent).not.toContain('+ 3 more steps')
+    expect(container.textContent).toContain('Show less')
+    expect(expandAll?.textContent).toContain('Collapse all')
+    expect(expandAll?.getAttribute('aria-expanded')).toBe('true')
+
+    act(() => expandAll?.click())
+    expect(getStepButtons(container)).toHaveLength(5)
+    expect(container.textContent).not.toContain('Description 1')
+    expect(container.textContent).toContain('+ 3 more steps')
+    expect(container.textContent).toContain('Show full task')
+    expect(expandAll?.textContent).toContain('Expand all')
+    expect(expandAll?.getAttribute('aria-expanded')).toBe('false')
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspacePlanActivityRecord.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePlanActivityRecord.tsx
@@ -1,0 +1,246 @@
+import { MessageScrollerItem } from '@/components/ui/message-scroller'
+import type { ToolActivity } from '@/stores/session-store'
+import { AlertCircle, Check, ChevronRight, LoaderCircle, X } from 'lucide-react'
+import { useLayoutEffect, useRef, useState } from 'react'
+
+import { projectGeneratePlanActivity } from './generate-plan-activity-projection'
+import { WorkspaceToolDetailsRow } from './WorkspaceToolDetailsRow'
+import { buildToolActivityDetails } from './workspace-tool-activity-details'
+
+type WorkspacePlanActivityRecordProps = Readonly<{
+  activity: ToolActivity
+  contentPaddingClassName?: string
+}>
+
+const domToken = (value: string): string => value.replace(/[^A-Za-z0-9_-]/gu, '_') || 'plan'
+const COMPACT_STEP_COUNT = 5
+
+const WorkspacePlanActivityRecord = ({
+  activity,
+  contentPaddingClassName = 'px-4 md:px-6'
+}: WorkspacePlanActivityRecordProps): React.JSX.Element => {
+  const projection = projectGeneratePlanActivity(activity)
+  const [expandedSteps, setExpandedSteps] = useState<Set<number>>(() => new Set())
+  const [showAllSteps, setShowAllSteps] = useState(false)
+  const [taskSummaryExpanded, setTaskSummaryExpanded] = useState(false)
+  const [taskSummaryOverflows, setTaskSummaryOverflows] = useState(false)
+  const [failureDetailsExpanded, setFailureDetailsExpanded] = useState(false)
+  const taskSummaryRef = useRef<HTMLParagraphElement>(null)
+  const isActive = activity.status === 'pending' || activity.status === 'in_progress'
+  const failureDetails =
+    projection.kind === 'failed' ? buildToolActivityDetails(activity) : undefined
+  const projectedTaskSummary = projection.kind === 'content' ? projection.taskSummary : undefined
+
+  const toggleStep = (stepNumber: number): void => {
+    setExpandedSteps((current) => {
+      const next = new Set(current)
+      if (next.has(stepNumber)) next.delete(stepNumber)
+      else next.add(stepNumber)
+      return next
+    })
+  }
+
+  useLayoutEffect(() => {
+    const summary = taskSummaryRef.current
+    if (!summary || projectedTaskSummary === undefined) return
+
+    const measureOverflow = (): void => {
+      const style = window.getComputedStyle(summary)
+      const parsedLineHeight = Number.parseFloat(style.lineHeight)
+      const parsedFontSize = Number.parseFloat(style.fontSize)
+      const lineHeight =
+        Number.isFinite(parsedLineHeight) && parsedLineHeight > 0
+          ? parsedLineHeight < 4 && Number.isFinite(parsedFontSize)
+            ? parsedLineHeight * parsedFontSize
+            : parsedLineHeight
+          : undefined
+      const previewHeight = lineHeight ? lineHeight * 3 : summary.clientHeight
+      const overflows = summary.scrollHeight > previewHeight + 1
+      setTaskSummaryOverflows(overflows)
+      if (!overflows) setTaskSummaryExpanded(false)
+    }
+
+    measureOverflow()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measureOverflow)
+    observer.observe(summary)
+    return () => observer.disconnect()
+  }, [projectedTaskSummary])
+
+  const contentProjection = projection.kind === 'content' ? projection : undefined
+  const visibleSteps = contentProjection
+    ? showAllSteps
+      ? contentProjection.steps
+      : contentProjection.steps.slice(0, COMPACT_STEP_COUNT)
+    : []
+  const remainingStepCount = contentProjection
+    ? contentProjection.steps.length - visibleSteps.length
+    : 0
+  const allDescriptionsExpanded = Boolean(
+    contentProjection?.steps.every((step) => expandedSteps.has(step.number))
+  )
+  const everythingExpanded = Boolean(
+    contentProjection &&
+    showAllSteps &&
+    allDescriptionsExpanded &&
+    (!taskSummaryOverflows || taskSummaryExpanded)
+  )
+
+  const toggleAll = (): void => {
+    if (!contentProjection) return
+    if (everythingExpanded) {
+      setShowAllSteps(false)
+      setTaskSummaryExpanded(false)
+      setExpandedSteps(new Set())
+      return
+    }
+
+    setShowAllSteps(true)
+    setTaskSummaryExpanded(taskSummaryOverflows)
+    setExpandedSteps(new Set(contentProjection.steps.map((step) => step.number)))
+  }
+
+  const statusIcon = isActive ? (
+    <LoaderCircle className="size-3.5 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+  ) : projection.kind === 'failed' ? (
+    <AlertCircle className="size-3.5" aria-hidden="true" />
+  ) : projection.kind === 'rejected' ? (
+    <X className="size-3.5" aria-hidden="true" />
+  ) : (
+    <Check className="size-3.5" aria-hidden="true" />
+  )
+
+  return (
+    <MessageScrollerItem messageId={`plan-activity-${activity.id}`} className="min-w-0">
+      <div className={`${contentPaddingClassName} pb-1 pt-5`}>
+        <section
+          aria-label="Plan call record"
+          aria-live={isActive ? 'polite' : undefined}
+          className="w-full overflow-hidden rounded-[12px] border border-border-200 bg-bg-200/70"
+          data-testid="plan-call-record"
+        >
+          <div className="flex min-h-10 items-center gap-2 px-3 py-2 text-[12px] text-text-100">
+            <span className="inline-flex size-[17px] shrink-0 items-center justify-center text-text-100">
+              {statusIcon}
+            </span>
+            <span>{projection.heading}</span>
+            {projection.kind === 'content' ? (
+              <>
+                <span className="ml-auto shrink-0 tabular-nums text-text-300">
+                  {projection.steps.length} {projection.steps.length === 1 ? 'step' : 'steps'}
+                </span>
+                <button
+                  type="button"
+                  data-testid="plan-expand-all"
+                  aria-expanded={everythingExpanded}
+                  aria-controls={`plan-content-${domToken(activity.id)}`}
+                  className="rounded-[5px] px-1.5 py-0.5 text-[11px] text-text-100 transition-colors duration-150 hover:bg-bg-000/70 hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 motion-reduce:transition-none"
+                  onClick={toggleAll}
+                >
+                  {everythingExpanded ? 'Collapse all' : 'Expand all'}
+                </button>
+              </>
+            ) : null}
+          </div>
+
+          {projection.kind === 'content' ? (
+            <div
+              id={`plan-content-${domToken(activity.id)}`}
+              className="mb-[7px] ml-[31px] mr-[7px] rounded-[9px] border border-border-200 bg-bg-000 px-[13px] py-[11px] shadow-sm"
+            >
+              <div className="mb-[9px]">
+                <p
+                  ref={taskSummaryRef}
+                  id={`plan-task-summary-${domToken(activity.id)}`}
+                  data-testid="plan-task-summary"
+                  className={`m-0 text-[13px] font-semibold leading-[1.45] text-text-000 ${taskSummaryOverflows && !taskSummaryExpanded ? 'line-clamp-3' : ''}`}
+                >
+                  {projection.taskSummary}
+                </p>
+                {taskSummaryOverflows ? (
+                  <button
+                    type="button"
+                    data-testid="plan-task-summary-toggle"
+                    aria-expanded={taskSummaryExpanded}
+                    aria-controls={`plan-task-summary-${domToken(activity.id)}`}
+                    className="mt-1 rounded-[4px] p-0 text-[11px] text-text-300 transition-colors duration-150 hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 motion-reduce:transition-none"
+                    onClick={() => setTaskSummaryExpanded((expanded) => !expanded)}
+                  >
+                    {taskSummaryExpanded ? 'Show less' : 'Show full task'}
+                  </button>
+                ) : null}
+              </div>
+              <ol className="grid list-none gap-[7px] p-0">
+                {visibleSteps.map((step) => {
+                  const expanded = expandedSteps.has(step.number)
+                  const detailsId = `plan-step-${domToken(activity.id)}-${step.number}`
+                  return (
+                    <li
+                      key={step.number}
+                      className="grid grid-cols-[20px_minmax(0,1fr)] items-start text-[12px] text-text-100"
+                    >
+                      <span className="pt-0.5 text-[10px] font-semibold text-text-300">
+                        {step.number}.
+                      </span>
+                      <div className="min-w-0">
+                        <button
+                          type="button"
+                          aria-expanded={expanded}
+                          aria-controls={detailsId}
+                          className="flex w-full min-w-0 items-center gap-2 rounded-[5px] text-left text-text-100 hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                          onClick={() => toggleStep(step.number)}
+                        >
+                          <span className="min-w-0 flex-1 text-[12px] text-text-000">
+                            {step.title}
+                          </span>
+                          <ChevronRight
+                            className={`size-3.5 shrink-0 text-text-300 transition-transform motion-reduce:transition-none ${expanded ? 'rotate-90' : ''}`}
+                            aria-hidden="true"
+                          />
+                        </button>
+                        {expanded ? (
+                          <p
+                            id={detailsId}
+                            className="mb-[3px] mr-[18px] mt-[5px] text-[10.5px] leading-[1.5] text-text-300"
+                          >
+                            {step.description}
+                          </p>
+                        ) : null}
+                      </div>
+                    </li>
+                  )
+                })}
+              </ol>
+              {remainingStepCount > 0 ? (
+                <div className="ml-5 mt-[7px] text-[11px] text-text-300">
+                  + {remainingStepCount} more {remainingStepCount === 1 ? 'step' : 'steps'}
+                </div>
+              ) : null}
+              <div className="mt-3 flex items-start gap-2 border-t border-border-200 pt-[9px] text-[11px] text-text-300">
+                <span className="shrink-0 whitespace-nowrap rounded-[5px] bg-accent/10 px-1.5 py-0.5 text-[10px] text-text-100">
+                  {projection.feasibility.confidence} confidence
+                </span>
+                <span>{projection.feasibility.summary}</span>
+              </div>
+            </div>
+          ) : projection.kind === 'unavailable' ? (
+            <div className="mb-[7px] ml-[31px] mr-[7px] rounded-[9px] border border-border-200 bg-bg-000 px-[13px] py-[11px] text-[12px] text-text-300">
+              Plan details unavailable
+            </div>
+          ) : projection.kind === 'failed' && failureDetails ? (
+            <div className="mb-1.5 px-1.5">
+              <WorkspaceToolDetailsRow
+                activity={activity}
+                details={failureDetails}
+                isExpanded={failureDetailsExpanded}
+                onToggle={(_activityId, nextExpanded) => setFailureDetailsExpanded(nextExpanded)}
+              />
+            </div>
+          ) : null}
+        </section>
+      </div>
+    </MessageScrollerItem>
+  )
+}
+
+export { WorkspacePlanActivityRecord }

--- a/src/renderer/src/pages/workspace/generate-plan-activity-projection.test.ts
+++ b/src/renderer/src/pages/workspace/generate-plan-activity-projection.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ToolActivity } from '@/stores/session-store'
+import { projectGeneratePlanActivity } from './generate-plan-activity-projection'
+
+const createActivity = (overrides: Partial<ToolActivity> = {}): ToolActivity => ({
+  id: 'plan-1',
+  kind: 'tool',
+  title: 'generate_plan',
+  providerToolName: 'mcp__open-science-plan__generate_plan',
+  status: 'completed',
+  eventIds: [],
+  sortIndex: 1,
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+const planArguments = {
+  task_summary: 'Prepare the publication package',
+  phases: [
+    {
+      name: 'Analysis',
+      delegations: [
+        {
+          name: 'Evidence',
+          steps: [
+            { title: 'Inspect sources', description: 'Check every primary source.' },
+            { title: 'Draft findings', description: 'Write the evidence summary.' }
+          ]
+        },
+        {
+          name: 'Figures',
+          steps: [{ title: 'Build chart', description: 'Create the final chart.' }]
+        }
+      ]
+    },
+    {
+      name: 'Delivery',
+      delegations: [
+        {
+          name: 'Package',
+          steps: [{ title: 'Export report', description: 'Produce the PDF.' }]
+        }
+      ]
+    }
+  ],
+  desired_outputs: ['PDF report'],
+  feasibility: { confidence: 'medium', rationale: 'One source may need confirmation.' }
+}
+
+describe('projectGeneratePlanActivity', () => {
+  it('validates direct Plan arguments and flattens steps in source order', () => {
+    expect(projectGeneratePlanActivity(createActivity({ rawInput: planArguments }))).toEqual({
+      kind: 'content',
+      heading: 'Created execution Plan',
+      taskSummary: 'Prepare the publication package',
+      steps: [
+        { number: 1, title: 'Inspect sources', description: 'Check every primary source.' },
+        { number: 2, title: 'Draft findings', description: 'Write the evidence summary.' },
+        { number: 3, title: 'Build chart', description: 'Create the final chart.' },
+        { number: 4, title: 'Export report', description: 'Produce the PDF.' }
+      ],
+      feasibility: { confidence: 'medium', summary: 'One source may need confirmation.' }
+    })
+  })
+
+  it('unwraps an MCP arguments envelope and reflects an active call', () => {
+    const projection = projectGeneratePlanActivity(
+      createActivity({ status: 'in_progress', rawInput: { arguments: planArguments } })
+    )
+
+    expect(projection).toMatchObject({
+      kind: 'content',
+      heading: 'Creating execution Plan',
+      taskSummary: 'Prepare the publication package'
+    })
+  })
+
+  it('projects approval and dismissal calls as compact decisions', () => {
+    expect(
+      projectGeneratePlanActivity(createActivity({ rawInput: { decision: 'approved' } }))
+    ).toEqual({ kind: 'approved', heading: 'Approved execution Plan' })
+    expect(
+      projectGeneratePlanActivity(
+        createActivity({ rawInput: { arguments: { decision: 'rejected' } } })
+      )
+    ).toEqual({ kind: 'rejected', heading: 'Dismissed execution Plan' })
+    expect(projectGeneratePlanActivity(createActivity({ rawInput: { approve: true } }))).toEqual({
+      kind: 'approved',
+      heading: 'Approved execution Plan'
+    })
+  })
+
+  it('rejects decisions combined with Plan content or contradictory legacy approval', () => {
+    expect(
+      projectGeneratePlanActivity(
+        createActivity({ rawInput: { decision: 'approved', task_summary: 'Do the work' } })
+      )
+    ).toEqual({ kind: 'unavailable', heading: 'Created execution Plan' })
+    expect(
+      projectGeneratePlanActivity(
+        createActivity({ rawInput: { decision: 'rejected', phases: planArguments.phases } })
+      )
+    ).toEqual({ kind: 'unavailable', heading: 'Created execution Plan' })
+    expect(
+      projectGeneratePlanActivity(
+        createActivity({ rawInput: { approve: true, feasibility: planArguments.feasibility } })
+      )
+    ).toEqual({ kind: 'unavailable', heading: 'Created execution Plan' })
+    expect(
+      projectGeneratePlanActivity(
+        createActivity({ rawInput: { decision: 'approved', desired_outputs: ['Report'] } })
+      )
+    ).toEqual({ kind: 'unavailable', heading: 'Created execution Plan' })
+    expect(
+      projectGeneratePlanActivity(
+        createActivity({ rawInput: { decision: 'approved', approve: true } })
+      )
+    ).toEqual({ kind: 'unavailable', heading: 'Created execution Plan' })
+    expect(
+      projectGeneratePlanActivity(
+        createActivity({ rawInput: { decision: 'rejected', approve: true } })
+      )
+    ).toEqual({ kind: 'unavailable', heading: 'Created execution Plan' })
+  })
+
+  it('keeps missing and invalid content visible as unavailable', () => {
+    expect(projectGeneratePlanActivity(createActivity({ rawInput: undefined }))).toEqual({
+      kind: 'unavailable',
+      heading: 'Created execution Plan'
+    })
+    expect(
+      projectGeneratePlanActivity(createActivity({ rawInput: { ...planArguments, phases: [] } }))
+    ).toEqual({ kind: 'unavailable', heading: 'Created execution Plan' })
+  })
+
+  it('projects failures independently of recoverable input', () => {
+    expect(
+      projectGeneratePlanActivity(createActivity({ status: 'failed', rawInput: planArguments }))
+    ).toEqual({ kind: 'failed', heading: 'Failed to create execution Plan' })
+  })
+})

--- a/src/renderer/src/pages/workspace/generate-plan-activity-projection.ts
+++ b/src/renderer/src/pages/workspace/generate-plan-activity-projection.ts
@@ -1,0 +1,80 @@
+import type { ToolActivity } from '@/stores/session-store'
+import { createPlanDocumentV1 } from '../../../../shared/session-plan/contract'
+
+type PlanTranscriptStep = Readonly<{
+  number: number
+  title: string
+  description: string
+}>
+
+type GeneratePlanActivityProjection =
+  | Readonly<{
+      kind: 'content'
+      heading: string
+      taskSummary: string
+      steps: readonly PlanTranscriptStep[]
+      feasibility: Readonly<{
+        confidence: 'high' | 'medium' | 'low'
+        summary: string
+      }>
+    }>
+  | Readonly<{ kind: 'approved' | 'rejected' | 'unavailable' | 'failed'; heading: string }>
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const PLAN_CONTENT_FIELDS = ['task_summary', 'phases', 'desired_outputs', 'feasibility'] as const
+
+// ACP providers either expose the MCP arguments directly or retain the protocol envelope.
+const unwrapArguments = (rawInput: unknown): unknown =>
+  isRecord(rawInput) && isRecord(rawInput.arguments) ? rawInput.arguments : rawInput
+
+const contentHeading = (activity: ToolActivity): string =>
+  activity.status === 'pending' || activity.status === 'in_progress'
+    ? 'Creating execution Plan'
+    : 'Created execution Plan'
+
+const projectGeneratePlanActivity = (activity: ToolActivity): GeneratePlanActivityProjection => {
+  if (activity.status === 'failed') {
+    return { kind: 'failed', heading: 'Failed to create execution Plan' }
+  }
+
+  const input = unwrapArguments(activity.rawInput)
+  if (isRecord(input)) {
+    const hasPlanContent = PLAN_CONTENT_FIELDS.some((field) => input[field] !== undefined)
+    const hasDecisionInput = input.decision !== undefined || 'approve' in input
+    const hasDecisionAndLegacyApproval = input.decision !== undefined && 'approve' in input
+    if ((hasDecisionInput && hasPlanContent) || hasDecisionAndLegacyApproval) {
+      return { kind: 'unavailable', heading: contentHeading(activity) }
+    }
+    if (input.decision === 'approved' || input.approve === true) {
+      return { kind: 'approved', heading: 'Approved execution Plan' }
+    }
+    if (input.decision === 'rejected') {
+      return { kind: 'rejected', heading: 'Dismissed execution Plan' }
+    }
+  }
+
+  try {
+    const document = createPlanDocumentV1(input)
+    const steps = document.phases.flatMap((phase) =>
+      phase.delegations.flatMap((delegation) => delegation.steps)
+    )
+
+    return {
+      kind: 'content',
+      heading: contentHeading(activity),
+      taskSummary: document.task_summary,
+      steps: steps.map((step, index) => ({ number: index + 1, ...step })),
+      feasibility: {
+        confidence: document.feasibility.confidence,
+        summary: document.feasibility.rationale
+      }
+    }
+  } catch {
+    return { kind: 'unavailable', heading: contentHeading(activity) }
+  }
+}
+
+export { projectGeneratePlanActivity }
+export type { GeneratePlanActivityProjection, PlanTranscriptStep }

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
@@ -88,28 +88,86 @@ describe('workspace conversation items', () => {
     ])
   })
 
-  it('projects successful Plan tools through the Plan surface instead of generic activity rows', () => {
+  it('projects every generate_plan status as a standalone item and hides step status updates', () => {
     const session: ChatSession = {
       ...baseSession,
       activities: [
         createActivity({
           id: 'plan-generate',
-          providerToolName: 'mcp__open-science-plan__generate_plan'
+          providerToolName: 'mcp__open-science-plan__generate_plan',
+          status: 'pending',
+          sortIndex: 1
         }),
         createActivity({
           id: 'plan-status',
-          providerToolName: 'mcp.open-science-plan.update_step_status'
+          providerToolName: 'mcp.open-science-plan.update_step_status',
+          sortIndex: 2
         }),
         createActivity({
           id: 'plan-opencode',
-          providerToolName: 'open_science_plan_generate_plan'
+          providerToolName: 'open_science_plan_generate_plan',
+          status: 'in_progress',
+          sortIndex: 3
         }),
-        createActivity({ id: 'failed-plan', providerToolName: 'generate_plan', status: 'failed' })
+        createActivity({
+          id: 'completed-plan',
+          title: 'generate_plan',
+          status: 'completed',
+          sortIndex: 4
+        }),
+        createActivity({
+          id: 'failed-plan',
+          providerToolName: 'generate_plan',
+          status: 'failed',
+          sortIndex: 5
+        }),
+        createActivity({
+          id: 'failed-status',
+          providerToolName: 'update_step_status',
+          status: 'failed',
+          sortIndex: 6
+        })
+      ]
+    }
+
+    expect(createConversationItems(session).map((item) => [item.id, item.type])).toEqual([
+      ['plan-activity-plan-generate', 'plan-activity'],
+      ['plan-activity-plan-opencode', 'plan-activity'],
+      ['plan-activity-completed-plan', 'plan-activity'],
+      ['plan-activity-failed-plan', 'plan-activity']
+    ])
+  })
+
+  it('keeps a generate_plan revision at its chronological position between messages and tools', () => {
+    const session: ChatSession = {
+      ...baseSession,
+      messages: [
+        {
+          id: 'feedback',
+          role: 'user',
+          content: 'Please revise step two',
+          status: 'complete',
+          eventIds: [],
+          sortIndex: 2,
+          createdAt: 1710000000000,
+          updatedAt: 1710000000000
+        }
+      ],
+      activities: [
+        createActivity({ id: 'read', toolKind: 'read', sortIndex: 1 }),
+        createActivity({
+          id: 'revision',
+          providerToolName: 'mcp.open_science_plan.generate_plan',
+          status: 'in_progress',
+          sortIndex: 3
+        })
       ]
     }
 
     expect(createConversationItems(session).map((item) => item.id)).toEqual([
-      'activity-failed-plan'
+      'activity-read',
+      'feedback',
+      'plan-activity-revision'
     ])
   })
 

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.ts
@@ -15,13 +15,16 @@ type ConversationMessageItem = {
   message: ChatMessage
 }
 
-type ConversationActivityItem = {
+type ConversationActivityItemBase<ItemType extends 'activity' | 'plan-activity'> = {
   id: string
-  type: 'activity'
+  type: ItemType
   createdAt: number
   sortIndex: number
   activity: ToolActivity
 }
+
+type ConversationActivityItem = ConversationActivityItemBase<'activity'>
+type ConversationPlanActivityItem = ConversationActivityItemBase<'plan-activity'>
 
 // A lifecycle row is a read-only annotation on its originating user turn. It is not another user
 // message and cannot own a separate continuation identity.
@@ -31,7 +34,11 @@ type ConversationHandoffItem = HandoffTranscriptProjection & {
   sortIndex: number
 }
 
-type ConversationItem = ConversationMessageItem | ConversationActivityItem | ConversationHandoffItem
+type ConversationItem =
+  | ConversationMessageItem
+  | ConversationActivityItem
+  | ConversationPlanActivityItem
+  | ConversationHandoffItem
 
 const KNOWN_TITLE_TOOL_NAMES = new Set(['ToolSearch'])
 
@@ -40,11 +47,18 @@ const KNOWN_TITLE_TOOL_NAMES = new Set(['ToolSearch'])
 const NOTEBOOK_PROVIDER_TOOL_PATTERN =
   /^(?:mcp__|mcp\.)?open[-_]science[-_]notebook(?:__|\.)([^.]+)$/iu
 const PLAN_PROVIDER_TOOL_PATTERN =
-  /^(?:(?:mcp__|mcp\.)?open[-_]science[-_]plan(?:__|\.|_)|)(?:generate_plan|update_step_status)$/iu
+  /^(?:(?:mcp__|mcp\.)?open[-_]science[-_]plan(?:__|\.|_)|)(generate_plan|update_step_status)$/iu
 
-const isSuccessfulPlanActivity = (activity: ToolActivity): boolean =>
-  activity.status !== 'failed' &&
-  PLAN_PROVIDER_TOOL_PATTERN.test(activity.providerToolName?.trim() ?? activity.title.trim())
+const getPlanToolKind = (
+  activity: ToolActivity
+): 'generate_plan' | 'update_step_status' | undefined => {
+  const names = [activity.providerToolName, activity.title]
+  for (const name of names) {
+    const match = PLAN_PROVIDER_TOOL_PATTERN.exec(name?.trim() ?? '')
+    if (match?.[1] === 'generate_plan' || match?.[1] === 'update_step_status') return match[1]
+  }
+  return undefined
+}
 
 // Returns the notebook tool suffix (e.g. "notebook_execute") for a notebook MCP tool identity, or
 // undefined when the name is not a notebook tool. Framework-agnostic across the two server-name forms.
@@ -151,15 +165,22 @@ const createConversationItems = (
       message
     })) ?? []
   const activities: ConversationItem[] =
-    session?.activities
-      ?.filter((activity) => !isSuccessfulPlanActivity(activity))
-      .map((activity) => ({
-        id: `activity-${activity.id}`,
-        type: 'activity',
-        createdAt: activity.createdAt,
-        sortIndex: activity.sortIndex,
-        activity
-      })) ?? []
+    session?.activities?.flatMap((activity): ConversationItem[] => {
+      const planToolKind = getPlanToolKind(activity)
+      if (planToolKind === 'update_step_status') return []
+      return [
+        {
+          id:
+            planToolKind === 'generate_plan'
+              ? `plan-activity-${activity.id}`
+              : `activity-${activity.id}`,
+          type: planToolKind === 'generate_plan' ? 'plan-activity' : 'activity',
+          createdAt: activity.createdAt,
+          sortIndex: activity.sortIndex,
+          activity
+        }
+      ]
+    }) ?? []
   const handoffs: ConversationItem[] = projectHandoffLifecycle(handoffEvents).map((handoff) => ({
     ...handoff,
     type: 'handoff',

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
@@ -50,6 +50,14 @@ const activityItem = (activity: ToolActivity): ConversationItem => ({
   activity
 })
 
+const planActivityItem = (activity: ToolActivity): ConversationItem => ({
+  id: `plan-activity-${activity.id}`,
+  type: 'plan-activity',
+  createdAt: activity.createdAt,
+  sortIndex: activity.sortIndex,
+  activity
+})
+
 // The ToolSearch wrapper row that can precede concrete search entries.
 const toolSearchWrapper = (overrides: Partial<ToolActivity> = {}): ToolActivity =>
   createActivity({ id: 'tool-search-wrapper', title: 'ToolSearch', ...overrides })
@@ -132,6 +140,27 @@ describe('groupConversationItems', () => {
       expect.objectContaining({ id: 'activity-group-g1', title: 'Inspect files' }),
       expect.objectContaining({ id: 'activity-group-g2', title: 'Apply changes' })
     ])
+  })
+
+  it('keeps Plan call records standalone and out of adjacent tool counts', () => {
+    const grouped = groupConversationItems([
+      activityItem(createActivity({ id: 'read-1', toolKind: 'read', sortIndex: 1 })),
+      planActivityItem(
+        createActivity({ id: 'plan-1', providerToolName: 'generate_plan', sortIndex: 2 })
+      ),
+      activityItem(createActivity({ id: 'read-2', toolKind: 'read', sortIndex: 3 }))
+    ])
+
+    expect(grouped.map((item) => item.type)).toEqual([
+      'activity-group',
+      'plan-activity',
+      'activity-group'
+    ])
+    expect(
+      grouped
+        .filter((item) => item.type === 'activity-group')
+        .map((item) => formatStepCount(item.activities))
+    ).toEqual(['1 step', '1 step'])
   })
 })
 

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
@@ -20,7 +20,8 @@ type ConversationActivityGroupItem = {
 }
 
 type GroupedConversationItem =
-  Extract<ConversationItem, { type: 'message' | 'handoff' }> | ConversationActivityGroupItem
+  | Extract<ConversationItem, { type: 'message' | 'handoff' | 'plan-activity' }>
+  | ConversationActivityGroupItem
 type ActivityExpansionOverrides = Record<string, boolean>
 type RenderableActivityEntry = {
   activity: ToolActivity
@@ -38,9 +39,9 @@ const groupConversationItems = (
   const groupsById = new Map(activityGroups.map((group) => [group.id, group]))
 
   for (const item of items) {
-    // Handoff lifecycle rows are transcript annotations, not tool activities. Keep their timeline
-    // position and prevent them from merging into an adjacent tool group.
-    if (item.type === 'message' || item.type === 'handoff') {
+    // Handoff annotations and Plan call records are standalone transcript items. Keep their
+    // timeline position and prevent them from merging into an adjacent ordinary-tool group.
+    if (item.type === 'message' || item.type === 'handoff' || item.type === 'plan-activity') {
       groupedItems.push(item)
       continue
     }

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -2775,6 +2775,51 @@ describe('truncateSessionFromMessage', () => {
     expect(useSessionStore.getState().sessions[0].branchContextResetRequired).toBe(true)
   })
 
+  it('materializes only the selected Message Branch Plan activities', () => {
+    // Transcript projection receives this already-selected compatibility view. Exercise the public
+    // Branch switch here, where the Graph is resolved into Session messages and activities.
+    seedSession({
+      activities: [
+        {
+          ...createActivity('original-plan', baseTime + 250),
+          title: 'generate_plan',
+          providerToolName: 'generate_plan',
+          rawInput: { decision: 'approved' }
+        }
+      ]
+    })
+    useSessionStore.getState().truncateSessionFromMessage('session-1', 'user-2')
+    const edited = useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'edited user-2'
+    })
+    useSessionStore.getState().upsertToolActivity({
+      sessionId: 'session-1',
+      toolCallId: 'edited-plan',
+      eventId: 'edited-plan-event',
+      promptMessageId: edited?.messageId,
+      title: 'generate_plan',
+      providerToolName: 'generate_plan',
+      status: 'completed',
+      rawInput: { decision: 'rejected' }
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    const editedSession = useSessionStore.getState().sessions[0]
+    const originalBranchId = editedSession.conversationGraph?.branches[0].id
+    const editedBranchId = editedSession.conversationGraph?.frames[0].activeBranchId
+
+    useSessionStore.getState().activateMessageBranch('session-1', originalBranchId ?? '')
+    expect(
+      useSessionStore.getState().sessions[0].activities?.map((activity) => activity.id)
+    ).toEqual(['original-plan'])
+
+    useSessionStore.getState().activateMessageBranch('session-1', editedBranchId ?? '')
+    expect(
+      useSessionStore.getState().sessions[0].activities?.map((activity) => activity.id)
+    ).toEqual(['edited-plan'])
+  })
+
   it('does not replay an original Branch event onto an edited Branch', () => {
     seedSession({
       messages: [


### PR DESCRIPTION
## Problem

`generate_plan` tool activities are observed and persisted, but successful and in-progress calls are filtered out of the Session transcript. After the transient approval surface disappears, the durable Conversation Turn no longer shows that a Plan was created or decided.

## Proposed change

- Project every `generate_plan` activity as a standalone transcript item while keeping `update_step_status` out of scope.
- Render validated content calls as compact Plan records with task summary, steps, feasibility, status, and failure details.
- Support direct and MCP-wrapped arguments, decision-only calls, provider naming variants, and an explicit unavailable-details fallback.
- Keep the compact record readable with a three-line task preview, five-step preview, independent controls, and an accessible expand-all/collapse-all action.
- Preserve chronological placement, selected Message Branch behavior, provenance rendering, and ordinary tool-group counts.

## Scope and non-goals

- No main-process, shared persistence, or Plan Artifact contract changes.
- `update_step_status` remains hidden and requires a separate execution-progress design.
- Transcript Plan records are read-only; the existing approval surface remains responsible for approve, dismiss, and feedback actions.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Plan activity classification, provider variants, chronology, grouping, provenance consumption, compact rendering, keyboard/accessibility behavior, and selected-branch materialization -> `npm test -- src/renderer/src/pages/workspace/workspace-conversation-items.test.ts src/renderer/src/pages/workspace/generate-plan-activity-projection.test.ts src/renderer/src/pages/workspace/WorkspacePlanActivityRecord.test.tsx src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx src/renderer/src/stores/session-store.test.ts` -> 7 files, 197 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors; 17 warnings are pre-existing in `origin/main` and none are in this PR's changed files.
- Final independent Standards review -> no hard violations or code-smell findings.
- Final independent Spec review -> no missing, partial, incorrect, or out-of-scope behavior.

Node-process, persistence, platform, and E2E lanes were excluded because the final diff is renderer-only and does not change a cross-process interface. Pixel-level visual regression remains uncovered; focused component tests cover DOM structure, state transitions, native keyboard controls, ARIA relationships, focus treatment, and reduced-motion behavior.

## Review focus

- Classification of overloaded `generate_plan` content and decision calls.
- Degraded behavior when durable `rawInput` is absent or invalid.
- Compact/partial/full expansion state transitions.
- Separation from ordinary tool groups and branch-aware transcript ordering.
