### PR TITLE
fix(acp): guide users through authentication recovery

### DIFF
--- a/src/main/acp/prompt-error.test.ts
+++ b/src/main/acp/prompt-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { describePromptError, isProviderPromptError } from './prompt-error'
+import { classifyPromptError, describePromptError, isProviderPromptError } from './prompt-error'
 
 // Builds an ACP RequestError-shaped value: an Error carrying the JSON-RPC code + data the agent attaches.
 const agentError = (
@@ -10,6 +10,31 @@ const agentError = (
 ): Error => Object.assign(new Error(message), { code, data, name: 'RequestError' })
 
 describe('describePromptError', () => {
+  it('classifies the exact ACP authentication RequestError as actionable provider recovery', () => {
+    const error = agentError('  Authentication   required\n', {}, -32000)
+
+    expect(classifyPromptError(error)).toEqual({
+      text: 'Sign in to your model provider in Settings → Model, then try again.',
+      providerError: true,
+      userAction: 'provider-authentication'
+    })
+  })
+
+  it.each([
+    Object.assign(new Error('Authentication required'), { name: 'Error', code: -32000 }),
+    Object.assign(new Error('Authentication required'), { name: 'RequestError', code: -32603 }),
+    Object.assign(new Error('Authentication required now'), {
+      name: 'RequestError',
+      code: -32000
+    }),
+    Object.assign(new Error('provider authentication required'), {
+      name: 'RequestError',
+      code: -32000
+    })
+  ])('does not promote an auth-like error without the exact ACP shape', (error) => {
+    expect(classifyPromptError(error)).toEqual({ text: error.message, providerError: false })
+  })
+
   it('rewords a provider JSON resource_not_found into an actionable message with the model name', () => {
     const error = agentError(
       'Internal error: Not Found: {"error":{"message":"The requested resource was not found","type":"resource_not_found_error"}}'

--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -1,4 +1,5 @@
 import { PROVIDER_RESOURCE_NOT_FOUND_PREFIX } from '../../shared/run-error-classification'
+import type { AcpErrorUserAction } from '../../shared/acp'
 
 // Turns an agent prompt failure into user-visible text. Agents (opencode) relay an upstream provider
 // HTTP error wrapped as a JSON-RPC failure like
@@ -36,6 +37,15 @@ const errorCode = (error: unknown): number | undefined => {
 
   return typeof code === 'number' ? code : undefined
 }
+
+const normalizeProtocolMessage = (message: string): string => message.trim().replace(/\s+/g, ' ')
+
+const isAuthenticationRequired = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  (error as { name?: unknown }).name === 'RequestError' &&
+  errorCode(error) === -32000 &&
+  normalizeProtocolMessage(rawErrorMessage(error)) === 'Authentication required'
 
 // True when the agent tagged the failure as an upstream provider API error (vs. an ACP protocol
 // error such as a missing session, which the resume path handles separately).
@@ -179,10 +189,37 @@ const isProviderErrorKind = (error: unknown): boolean => {
 //   - it is a provider "resource not found" (wrong model id / endpoint), which requires the same
 //     upstream signal (see isProviderNotFound) and is never a bare ACP protocol not-found.
 export const isProviderPromptError = (error: unknown): boolean => {
+  if (isAuthenticationRequired(error)) return true
   if (isApiError(error)) return true
   if (isProviderErrorKind(error)) return true
 
   const raw = rawErrorMessage(error)
 
   return isProviderNotFound(error, raw, extractUpstreamDetail(raw))
+}
+
+export type PromptErrorClassification = Readonly<{
+  text: string
+  providerError: boolean
+  userAction?: AcpErrorUserAction
+}>
+
+// The single owner for prompt-failure presentation and recovery. Exact protocol authentication is
+// converted into app-authored guidance; all other failures retain the existing provider classifier.
+export const classifyPromptError = (
+  error: unknown,
+  ctx: PromptErrorContext = {}
+): PromptErrorClassification => {
+  if (isAuthenticationRequired(error)) {
+    return {
+      text: 'Sign in to your model provider in Settings → Model, then try again.',
+      providerError: true,
+      userAction: 'provider-authentication'
+    }
+  }
+
+  return {
+    text: describePromptError(error, ctx),
+    providerError: isProviderPromptError(error)
+  }
 }

--- a/src/main/acp/prompt-outcome-finalizer.test.ts
+++ b/src/main/acp/prompt-outcome-finalizer.test.ts
@@ -295,6 +295,16 @@ describe('AcpPromptOutcomeFinalizer', () => {
       providerError: true
     },
     {
+      name: 'provider authentication required',
+      error: Object.assign(new Error('Authentication required'), {
+        name: 'RequestError',
+        code: -32000
+      }),
+      recoverable: undefined,
+      providerError: true,
+      userAction: 'provider-authentication'
+    },
+    {
       name: 'ACP error',
       error: new Error('protocol failed'),
       recoverable: undefined,
@@ -318,7 +328,8 @@ describe('AcpPromptOutcomeFinalizer', () => {
         kind: 'error',
         timestamp: 321,
         recoverable: testCase.recoverable,
-        providerError: testCase.providerError
+        providerError: testCase.providerError,
+        ...(testCase.userAction ? { userAction: testCase.userAction } : {})
       })
     )
     expect(harness.context.fail).toHaveBeenCalledOnce()

--- a/src/main/acp/prompt-outcome-finalizer.ts
+++ b/src/main/acp/prompt-outcome-finalizer.ts
@@ -6,7 +6,7 @@ import { createLogger, errorLogFields } from '../logger'
 import type { ContextUsageTurnHandle } from './context-usage-tracker'
 import type { AcpPermissionContext } from './permission-context'
 import type { PreparedPromptHandle } from './prompt-preparation-owner'
-import { describePromptError, isProviderPromptError } from './prompt-error'
+import { classifyPromptError } from './prompt-error'
 import type { ProviderPromptOutcome } from './provider-prompt-executor'
 import type { AcpPromptSessionInteractionScope } from './session-interaction-owner'
 import type { AcpSessionInteractionOwner as InteractionOwner } from './session-interaction-owner'
@@ -162,7 +162,8 @@ export class AcpPromptOutcomeFinalizer {
       context?.fail()
       safeCleanup('skill activity cleanup failed', handles.failPendingSkillActivities)
       safeLog('error', 'prompt failed', errorLogFields(error))
-      const text = describePromptError(error, { model: handles.model })
+      const classification = classifyPromptError(error, { model: handles.model })
+      const { text } = classification
       const recoverable =
         isMediaOverflowError(text) ||
         isMediaOverflowError(handles.errorMessage(error)) ||
@@ -175,7 +176,8 @@ export class AcpPromptOutcomeFinalizer {
         kind: 'error',
         level: 'error',
         recoverable,
-        providerError: isProviderPromptError(error),
+        providerError: classification.providerError,
+        userAction: classification.userAction,
         sessionId,
         ...eventIdentity,
         timestamp: terminal.timestamp,

--- a/src/main/acp/runtime-snapshot-owner.test.ts
+++ b/src/main/acp/runtime-snapshot-owner.test.ts
@@ -24,6 +24,30 @@ const planProjection: ActivePlanProjection = {
 }
 
 describe('AcpRuntimeSnapshotOwner', () => {
+  it('retains a structured prompt recovery action in the renderer-visible snapshot', () => {
+    const owner = new AcpRuntimeSnapshotOwner('/workspace')
+    owner.appendEvent({
+      kind: 'error',
+      level: 'error',
+      sessionId: 'session-1',
+      text: 'Sign in to your model provider in Settings → Model, then try again.',
+      providerError: true,
+      userAction: 'provider-authentication'
+    })
+
+    expect(
+      owner.snapshot({
+        sessionIds: ['session-1'],
+        pendingPermissions: [],
+        permissionProfiles: {},
+        permissionGrants: {},
+        contextUsageBySession: {},
+        promptInFlight: false,
+        promptInFlightSessionIds: []
+      }).events[0]
+    ).toMatchObject({ userAction: 'provider-authentication' })
+  })
+
   it('retains a Plan projection in the renderer-visible event snapshot', () => {
     const owner = new AcpRuntimeSnapshotOwner('/workspace')
 

--- a/src/main/acp/runtime-snapshot-owner.ts
+++ b/src/main/acp/runtime-snapshot-owner.ts
@@ -77,6 +77,7 @@ class AcpRuntimeSnapshotOwner {
       compactionReason: event.compactionReason,
       recoverable: event.recoverable,
       providerError: event.providerError,
+      userAction: event.userAction,
       turnUsage: event.turnUsage,
       sessionId: event.sessionId,
       messageId: event.messageId,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -16012,6 +16012,38 @@ describe('ACP runtime session management', () => {
     expect(events).toContainEqual({ kind: 'error', providerError: true })
   })
 
+  it('keeps the connection attached and publishes actionable recovery when authentication is required', async () => {
+    const process = new FakeAgentProcess()
+    const events: AcpRuntimeEvent[] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: () => {
+        throw new acp.RequestError(-32000, 'Authentication required')
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onEvent: (event) => events.push(event) }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+    await expect(runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'hi' })).rejects.toThrow(
+      'Authentication required'
+    )
+
+    expect(runtime.getSnapshot().status).toBe('connected')
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: 'error',
+        sessionId: 'remote-session-1',
+        text: 'Sign in to your model provider in Settings → Model, then try again.',
+        providerError: true,
+        userAction: 'provider-authentication'
+      })
+    )
+  })
+
   it('does not tag an ACP-layer prompt failure as providerError (stays reportable)', async () => {
     const process = new FakeAgentProcess()
     const events: Array<{ kind: string; providerError?: boolean }> = []

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -393,6 +393,70 @@ describe('TaskRunner', () => {
     ])
   })
 
+  it('clears stale authentication recovery when a resumed Session starts and fails generically', async () => {
+    const existing: PersistedChatSession = {
+      ...session,
+      status: 'error',
+      error: 'Sign in first',
+      errorReportable: false,
+      errorUserAction: 'provider-authentication'
+    }
+    const savedSessions: PersistedChatSession[] = []
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    const ids = ['new-user', 'new-run']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [existing],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'unused' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'generic-error',
+            timestamp: 10,
+            kind: 'error',
+            level: 'error',
+            sessionId: existing.id,
+            text: 'ACP transport rejected the prompt.'
+          })
+          throw new Error('opaque failure')
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'Try again'
+    })
+    expect(savedSessions[0]).toMatchObject({ status: 'running', error: undefined })
+    expect(savedSessions[0]).toHaveProperty('errorReportable', undefined)
+    expect(savedSessions[0]).toHaveProperty('errorUserAction', undefined)
+
+    await runner.waitForRun(started.id)
+
+    const failed = savedSessions.at(-1)
+    expect(failed).toMatchObject({
+      status: 'error',
+      error: 'ACP transport rejected the prompt.'
+    })
+    expect(failed).toHaveProperty('errorReportable', undefined)
+    expect(failed).toHaveProperty('errorUserAction', undefined)
+  })
+
   it('provides transcript fallback for skill-triggered reconnects', async () => {
     const existing: PersistedChatSession = {
       ...session,
@@ -735,7 +799,8 @@ describe('TaskRunner', () => {
             level: 'error',
             sessionId: 'session-tool',
             text: 'Provider quota exceeded.',
-            providerError: true
+            providerError: true,
+            userAction: 'provider-authentication'
           })
           throw new Error('opaque provider error')
         }
@@ -759,6 +824,7 @@ describe('TaskRunner', () => {
       status: 'error',
       error: 'Provider quota exceeded.',
       errorReportable: false,
+      errorUserAction: 'provider-authentication',
       activities: [
         {
           id: 'tool-call-1',

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -438,6 +438,8 @@ class TaskRunner {
           messages: [...existing.messages, userMessage],
           activeRun: { promptMessageId: userMessageId, startedAt: now },
           error: undefined,
+          errorReportable: undefined,
+          errorUserAction: undefined,
           updatedAt: now
         }
       : {
@@ -539,7 +541,8 @@ class TaskRunner {
       status: 'error',
       activeRun: undefined,
       error: message,
-      ...(runtimeError?.providerError ? { errorReportable: false } : {}),
+      errorReportable: runtimeError?.providerError ? false : undefined,
+      errorUserAction: runtimeError?.userAction,
       updatedAt: this.dependencies.now()
     }
     run.status = 'failed'

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -2386,6 +2386,59 @@ describe('workspace agent message sending', () => {
     expect(session.errorReportable).toBe(false)
   })
 
+  it('converges a rejected authentication prompt on the canonical runtime recovery event', async () => {
+    const authenticationEvent: AcpRuntimeEvent = {
+      id: 'error-auth-1',
+      timestamp: Date.now(),
+      kind: 'error',
+      level: 'error',
+      sessionId: 'session-1',
+      providerError: true,
+      userAction: 'provider-authentication',
+      title: 'Prompt failed',
+      text: 'Sign in to your model provider in Settings → Model, then try again.'
+    }
+    vi.stubGlobal('window', {
+      api: {
+        acp: {
+          getState: vi
+            .fn()
+            .mockResolvedValue({ ...createSnapshot(['session-1']), events: [authenticationEvent] })
+        }
+      }
+    })
+
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockRejectedValue(new Error('Authentication required'))
+    }
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'earlier turn',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'hello',
+      cwd: '/workspace/project'
+    })
+    await flushRuntimeTasks()
+    await flushRuntimeTasks()
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error: authenticationEvent.text,
+      errorReportable: false,
+      errorUserAction: 'provider-authentication'
+    })
+  })
+
   it('marks an untagged (ACP-layer) prompt failure reportable', async () => {
     // No providerError tag on the run's error event → an app-layer failure the user should be able to
     // report as a bug.

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -305,6 +305,8 @@ const failOrMarkDisconnected = async (
   // keeps a non-recovered overflow (providerError=false) non-reportable via the text tier instead of
   // being mislabeled reportable. Undefined also covers no NEW event (a stale prior-turn event is ignored).
   let reportable: boolean | undefined
+  let projectedMessage = message
+  let userAction: AcpRuntimeEvent['userAction']
   try {
     const snapshot = await window.api.acp.getState()
 
@@ -320,12 +322,18 @@ const failOrMarkDisconnected = async (
       .find((event) => event.kind === 'error' && event.sessionId === sessionId)
     // Only trust an event that is NEW for this turn, so a provider-error tag from an earlier turn can
     // neither hide this failure's report button nor mislabel it.
-    if (runError && runError.id !== priorErrorEventId && runError.providerError) reportable = false
+    if (runError && runError.id !== priorErrorEventId) {
+      // The main-process prompt classifier owns canonical guidance and recovery. Converge the
+      // rejection path on that same event instead of replacing it with the IPC-thrown raw message.
+      projectedMessage = runError.text?.trim() || message
+      if (runError.providerError) reportable = false
+      userAction = runError.userAction
+    }
   } catch {
     // Fall back to a plain error if the live status read fails.
   }
 
-  useSessionStore.getState().failRun(sessionId, message, { reportable })
+  useSessionStore.getState().failRun(sessionId, projectedMessage, { reportable, userAction })
 }
 
 // Moves staged uploads into the session directory and updates the already-visible user message.

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -102,6 +102,24 @@ describe('workspace runtime events', () => {
     })
   })
 
+  it('projects provider authentication recovery onto the failed Session', async () => {
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        kind: 'error',
+        title: 'Prompt failed',
+        text: 'Sign in to your model provider in Settings → Model, then try again.',
+        providerError: true,
+        userAction: 'provider-authentication'
+      })
+    )
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      errorReportable: false,
+      errorUserAction: 'provider-authentication'
+    })
+  })
+
   it('projects Plan feedback runtime events as settled user Messages', async () => {
     const sessionBefore = useSessionStore.getState().sessions[0]
     useSessionStore.setState({

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -637,7 +637,8 @@ const applyWorkspaceRuntimeEvent = async (
     // forcing true here would wrongly show and persist the report button over it. Opaque ACP-layer
     // failures still fall through the text tier to reportable.
     store.failRun(event.sessionId, getEventErrorText(event), {
-      reportable: event.providerError ? false : undefined
+      reportable: event.providerError ? false : undefined,
+      userAction: event.userAction
     })
     const failedSession = useSessionStore
       .getState()

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -12,6 +12,7 @@ import {
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
 import type { ChatSession } from '@/stores/session-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import type { ActivePlanProjection } from '../../../../shared/session-plan/contract'
 
 // React's act() refuses to run unless the environment opts in to act-aware scheduling.
@@ -1360,6 +1361,27 @@ describe('ConversationPanel error box + report affordance', () => {
     container.querySelector('[aria-label="Report this error"]')
 
   const errorBoxText = (): string => container.querySelector('.border-red-200')?.textContent ?? ''
+
+  it('offers Model sign-in settings instead of Report or Resume for provider authentication', () => {
+    const openSettingsToPanel = vi.fn()
+    useSettingsStore.setState({ openSettingsToPanel })
+    renderPanel({
+      activeSession: {
+        ...errorSession,
+        error: 'Sign in to your model provider in Settings → Model, then try again.',
+        errorReportable: false,
+        errorUserAction: 'provider-authentication'
+      }
+    })
+
+    const authButton = container.querySelector('[aria-label="Sign in or open Model settings"]')
+    expect(authButton?.textContent).toContain('Sign in / Open Settings')
+    expect(reportButton()).toBeNull()
+    expect(container.querySelector('[aria-label="Resume session"]')).toBeNull()
+
+    act(() => (authButton as HTMLElement).click())
+    expect(openSettingsToPanel).toHaveBeenCalledWith('model')
+  })
 
   it('shows the error and a Report button for a failed run (status === error)', () => {
     renderPanel({ activeSession: errorSession })

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -269,6 +269,7 @@ const ConversationPanel = ({
 }: ConversationPanelProps): React.JSX.Element => {
   const specialistItems = useSpecialistStore((state) => state.items)
   const catalogSkills = useSettingsStore((state) => state.skills)
+  const openSettingsToPanel = useSettingsStore((state) => state.openSettingsToPanel)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const globalSearchShortcut = window.api?.platform === 'darwin' ? '⌘K' : 'Ctrl+K'
   // Local so the interrupted banner can show a spinner and block a double-resume until the request settles.
@@ -498,7 +499,16 @@ const ConversationPanel = ({
                             text and the reported text are always the same error. Shown only for an
                             unknown failure — a recognized one (app guidance or a known provider error)
                             keeps its message but is not a bug worth a GitHub issue. */}
-                        {isRunErrorReportable ? (
+                        {activeSession.errorUserAction === 'provider-authentication' ? (
+                          <button
+                            type="button"
+                            onClick={() => openSettingsToPanel('model')}
+                            className="inline-flex h-6 shrink-0 items-center rounded-md border border-red-200 bg-red-100/60 px-2 font-medium text-red-700 hover:bg-red-100 dark:border-red-800/50 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/40"
+                            aria-label="Sign in or open Model settings"
+                          >
+                            Sign in / Open Settings
+                          </button>
+                        ) : isRunErrorReportable ? (
                           <button
                             type="button"
                             onClick={openReportDialog}

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -947,10 +947,12 @@ describe('session store', () => {
 
     // A model-provider failure: opaque text that WOULD derive reportable=true, but the ACP layer
     // structurally tagged it non-reportable, and the explicit flag wins.
-    useSessionStore.getState().failRun('transport-session-1', 'Invalid API key', {
-      reportable: false
+    useSessionStore.getState().failRun('transport-session-1', 'Sign in first', {
+      reportable: false,
+      userAction: 'provider-authentication'
     })
     expect(useSessionStore.getState().sessions[0].errorReportable).toBe(false)
+    expect(useSessionStore.getState().sessions[0].errorUserAction).toBe('provider-authentication')
   })
 
   it('clears errorReportable when a new run starts, so a later error cannot inherit it', () => {
@@ -959,10 +961,12 @@ describe('session store', () => {
       content: 'first turn'
     })
     // A model-provider failure hides the report button.
-    useSessionStore.getState().failRun('transport-session-1', 'Invalid API key', {
-      reportable: false
+    useSessionStore.getState().failRun('transport-session-1', 'Sign in first', {
+      reportable: false,
+      userAction: 'provider-authentication'
     })
     expect(useSessionStore.getState().sessions[0].errorReportable).toBe(false)
+    expect(useSessionStore.getState().sessions[0].errorUserAction).toBe('provider-authentication')
 
     // A new turn clears the prior error + flag.
     useSessionStore.getState().appendUserMessage({
@@ -970,11 +974,13 @@ describe('session store', () => {
       content: 'second turn'
     })
     expect(useSessionStore.getState().sessions[0].errorReportable).toBeUndefined()
+    expect(useSessionStore.getState().sessions[0].errorUserAction).toBeUndefined()
 
     // A later ACP-layer failure with no explicit flag derives reportable=true — it never inherits the
     // earlier provider error's false.
     useSessionStore.getState().failRun('transport-session-1', 'Agent cancellation failed')
     expect(useSessionStore.getState().sessions[0].errorReportable).toBe(true)
+    expect(useSessionStore.getState().sessions[0].errorUserAction).toBeUndefined()
   })
 
   it('records an artifact finalization error as reportable (an app-layer failure)', () => {

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -14,6 +14,7 @@ import {
   normalizeClaudeCodeRefusalText,
   sanitizeAcpMessageImage,
   type AcpContextUsage,
+  type AcpErrorUserAction,
   type AcpMessageImage,
   type AcpTurnTokenUsage
 } from '../../../shared/acp'
@@ -283,7 +284,11 @@ type SessionStore = SessionStoreData & {
   // opts.reportable overrides the report-affordance decision: pass false for a model-provider failure
   // (the agent relayed an upstream LLM/HTTP error), true to force it, or omit to let the store derive it
   // from the message (an app-crafted reminder → not reportable; anything else → reportable).
-  failRun: (sessionId: string, error: string, opts?: { reportable?: boolean }) => void
+  failRun: (
+    sessionId: string,
+    error: string,
+    opts?: { reportable?: boolean; userAction?: AcpErrorUserAction }
+  ) => void
   // Sets the transient agent status line shown in the waiting indicator; only applies while running.
   setAgentStatus: (sessionId: string, text: string) => void
   // Enters the auto-recovery "compacting" state after a request-size overflow: clears the error so the
@@ -633,6 +638,7 @@ const settleConversationGraphSyncFailure = (
       ? `${input.runError}\n\n${CONVERSATION_GRAPH_SYNC_ERROR}`
       : CONVERSATION_GRAPH_SYNC_ERROR,
     errorReportable: true,
+    errorUserAction: undefined,
     messages: input.messages,
     activities: input.activities,
     activityGroups: input.activityGroups,
@@ -1170,6 +1176,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
                 // Clear the prior failure's report flag alongside its text so a later internal error
                 // cannot inherit a stale `false` and wrongly hide its Report button.
                 errorReportable: undefined,
+                errorUserAction: undefined,
                 compacting: undefined,
                 messages: nextMessages,
                 pendingContextReplayMessageId: replayPromptIndex >= 0 ? userMessage.id : undefined,
@@ -1995,6 +2002,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               // An app-layer finalization failure IS a reportable bug; set it explicitly so it never
               // inherits a stale `false` from a prior provider error on the same session.
               errorReportable: true,
+              errorUserAction: undefined,
               updatedAt: Date.now()
             }
           : session
@@ -2017,6 +2025,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           status: session.activeRun ? 'running' : 'idle',
           error: undefined,
           errorReportable: undefined,
+          errorUserAction: undefined,
           updatedAt: Date.now()
         }
       })
@@ -2301,6 +2310,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           compacting: undefined,
           error: keepArtifactError ? session.error : undefined,
           errorReportable: keepArtifactError ? session.errorReportable : undefined,
+          errorUserAction: keepArtifactError ? session.errorUserAction : undefined,
           messages,
           activities,
           activityGroups,
@@ -2357,6 +2367,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           compacting: undefined,
           error: message,
           errorReportable,
+          errorUserAction: opts?.userAction,
           messages,
           activities,
           activityGroups,
@@ -2398,6 +2409,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               agentStatus: undefined,
               error: undefined,
               errorReportable: undefined,
+              errorUserAction: undefined,
               compacting: true,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
@@ -2432,6 +2444,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               compacting: undefined,
               error: message,
               errorReportable: false,
+              errorUserAction: undefined,
               updatedAt: Date.now()
             }
           : session
@@ -2449,6 +2462,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               status: 'idle',
               error: undefined,
               errorReportable: undefined,
+              errorUserAction: undefined,
               interrupted: undefined,
               agentFrameworkId: agentFrameworkId ?? session.agentFrameworkId,
               agentBackendId: agentBackendId ?? session.agentBackendId,
@@ -2482,6 +2496,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
               // Cleared so a prior run's report flag can't bleed onto this disconnect (the interrupted
               // banner owns this path anyway; the report button never shows for it).
               errorReportable: undefined,
+              errorUserAction: undefined,
               messages: failStreamingMessages(session.messages),
               activities: failOpenActivities(session.activities),
               activityGroups: completeOpenActivityGroups(session.activityGroups, Date.now()),
@@ -2581,6 +2596,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           agentStatus: undefined,
           error: undefined,
           errorReportable: undefined,
+          errorUserAction: undefined,
           interrupted: undefined,
           branchContextResetRequired: true,
           pendingContextReplayMessageId: removed.some(
@@ -2634,6 +2650,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           activeRun: undefined,
           error: undefined,
           errorReportable: undefined,
+          errorUserAction: undefined,
           branchContextResetRequired: true,
           filesRevision: (session.filesRevision ?? 0) + 1,
           updatedAt: Date.now()

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -335,6 +335,9 @@ export type AcpRuntimeEvent = {
   // from the ACP layer itself (our runtime) and stays reportable unless it is one of our own crafted,
   // actionable reminder messages.
   providerError?: boolean
+  // App-owned recovery action for a recognized prompt failure. This is deliberately narrower than
+  // provider error classification: most provider failures have no safe one-click recovery.
+  userAction?: AcpErrorUserAction
   sessionId?: string
   messageId?: string
   role?: 'assistant' | 'user'
@@ -362,6 +365,8 @@ export type AcpRuntimeEvent = {
   artifacts?: ArtifactFile[]
   raw?: unknown
 }
+
+export type AcpErrorUserAction = 'provider-authentication'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -1038,4 +1038,26 @@ describe('normalizeSessionFile with activities', () => {
     expect(legacy?.errorReportable).toBeUndefined()
     expect(noError?.errorReportable).toBeUndefined()
   })
+
+  it('persists only the recognized recovery action alongside an error', () => {
+    const base = { ...createSessionWithActivity(undefined), activities: undefined, status: 'error' }
+    expect(
+      normalizeSessionFile({
+        ...base,
+        error: 'Sign in first',
+        errorUserAction: 'provider-authentication'
+      })?.errorUserAction
+    ).toBe('provider-authentication')
+    expect(
+      normalizeSessionFile({ ...base, error: 'Unknown', errorUserAction: 'open-danger-zone' })
+        ?.errorUserAction
+    ).toBeUndefined()
+    expect(
+      normalizeSessionFile({
+        ...createSessionWithActivity(undefined),
+        activities: undefined,
+        errorUserAction: 'provider-authentication'
+      })?.errorUserAction
+    ).toBeUndefined()
+  })
 })

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -8,6 +8,7 @@ import {
   sanitizeAcpMessageImage,
   sanitizeAcpTurnTokenUsage,
   type AcpContextUsage,
+  type AcpErrorUserAction,
   type AcpMessageImage,
   type AcpTurnTokenUsage
 } from './acp'
@@ -251,6 +252,9 @@ export type PersistedChatSession = {
   // unknown ACP-layer failure. Resolved once when the run fails and persisted so the "Report error"
   // gate survives a reload. Absent on older files — treated as reportable (the prior behavior).
   errorReportable?: boolean
+  // Structured app-owned recovery for the current error. Persisted so reload does not turn an
+  // actionable provider-authentication failure back into a generic dead end.
+  errorUserAction?: AcpErrorUserAction
   artifacts?: PersistedArtifact[]
   // Incremented only when finalized file metadata changes; text streaming leaves it untouched.
   filesRevision?: number
@@ -628,6 +632,7 @@ const normalizeSessionAfterRestore = (session: PersistedChatSession): PersistedC
       activeRun: undefined,
       error: undefined,
       errorReportable: undefined,
+      errorUserAction: undefined,
       messages: session.messages.map(normalizeMessageAfterRestore)
     }
   }
@@ -1466,6 +1471,9 @@ const sanitizeSession = (
   if (error) sanitized.error = error
   // Only meaningful alongside an error; persisted only when explicitly false (absent = reportable).
   if (error && session.errorReportable === false) sanitized.errorReportable = false
+  if (error && session.errorUserAction === 'provider-authentication') {
+    sanitized.errorUserAction = 'provider-authentication'
+  }
   if (agentFrameworkId && AGENT_FRAMEWORK_IDS.has(agentFrameworkId)) {
     sanitized.agentFrameworkId = agentFrameworkId
   }


### PR DESCRIPTION
## Problem

When an ACP provider rejects a prompt because authentication is required, the failure is currently surfaced as a generic prompt error. Users are not told that the connection itself remains usable, what action is needed, or where to complete provider authentication. Stale recovery actions can also survive after the failure state changes.

## Proposed change

- Recognize the provider authentication failure precisely as `RequestError` code `-32000` with the message `Authentication required`.
- Keep the ACP connection in the connected state while projecting the prompt failure as an actionable provider-authentication state.
- Carry that state through the event, snapshot, session, persistence, Task, and Workspace projections.
- Present an authentication recovery CTA that opens **Settings > Model**.
- Hide unrelated **Report** and **Resume** actions while provider authentication is required.
- Clear stale recovery actions when the active failure no longer requires authentication.

## Scope and non-goals

This is a focused recovery-path fix. It does not automatically start OAuth or other provider authentication, retry the failed prompt, add a new connection status, introduce a database migration, or change the IPC contract. The branch is based directly on `origin/main` and contains one Conventional Commit; it should be merged using squash merge as required by `CONTRIBUTING.md`.

## Acceptance criteria and validation

The final Test Impact Set and independent reviews were run after the last material edit:

- Exact ACP authentication-failure recognition and runtime recovery projection -> migrated-branch targeted tests -> **865 passed**.
- Event, snapshot, session, persistence, Task, Workspace, and recovery-UI consumers -> independent Spec review test set -> **424 passed; no findings**.
- Repository conventions and architectural boundaries -> independent Standards review -> **no findings**.
- Affected Node and renderer type surfaces -> `npm run typecheck` -> **passed**.
- Changed source and UI code -> `npm run lint` -> **0 errors; 17 existing warnings**.
- Cross-runtime regression fallback -> `npm test` -> **11,669 passed; 190 skipped**.

Local verification ran under Node.js 23.11, while the repository standard is Node.js 22. GitHub Actions is the authority for the Node.js 22 and platform lanes. No database, migration, IPC, or connection-status platform lane was added because those contracts are unchanged.

Acceptance behavior:

- Only the exact `RequestError` / `-32000` / `Authentication required` combination activates provider-authentication recovery.
- The provider remains connected and the failure becomes actionable instead of generic.
- The CTA navigates to Settings > Model, Report and Resume are suppressed, and stale actions are removed after state transitions.

Uncovered residual risk: the CTA navigation has not been manually exercised in a real Electron window; GitHub Actions covers automated checks but not that signed-in desktop interaction.

## Review focus

- Confirm the exact error predicate does not broaden authentication handling to unrelated ACP failures.
- Trace the recovery state across runtime events, snapshots, persisted sessions, and Task/Workspace projections.
- Verify the UI action lifecycle: Settings > Model navigation, Report/Resume suppression, and stale-action cleanup.
- Confirm the change preserves the existing connection-status, persistence, database, and IPC contracts.
