### PR TITLE
fix(e2e): stabilize cross-platform E2E launches

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -13,11 +13,16 @@ const FAKE_PROVIDER_NAME = 'Electron E2E provider'
 
 const electronLaunchTarget = (
   userDataRoot: string,
-  environment: NodeJS.ProcessEnv = process.env
+  environment: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform
 ): { args: string[]; executablePath?: string } => {
   const executablePath = environment.OPEN_SCIENCE_E2E_EXECUTABLE
   return {
-    args: [`--user-data-dir=${userDataRoot}`, ...(executablePath ? [] : [APP_ROOT])],
+    args: [
+      `--user-data-dir=${userDataRoot}`,
+      ...(platform === 'linux' ? ['--password-store=basic'] : []),
+      ...(executablePath ? [] : [APP_ROOT])
+    ],
     ...(executablePath ? { executablePath } : {})
   }
 }

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -81,13 +81,13 @@ const launchEnvironment = (
   return environment
 }
 
-const launchOpenScience = (
+const launchOpenScience = async (
   { storageRoot, userDataRoot, fakeAgentBinRoot }: LaunchRoots,
   fakeAgentEnabled: boolean,
   fakeRemoteItEnabled: boolean,
   fakeRemoteItRoot: string
-): Promise<ElectronApplication> =>
-  electron.launch({
+): Promise<ElectronApplication> => {
+  const application = await electron.launch({
     ...electronLaunchTarget(userDataRoot),
     cwd: fakeRemoteItEnabled ? fakeRemoteItRoot : APP_ROOT,
     env: launchEnvironment(
@@ -97,6 +97,15 @@ const launchOpenScience = (
       fakeRemoteItEnabled ? fakeRemoteItRoot : undefined
     )
   })
+
+  if (process.platform === 'linux') {
+    await application.evaluate(({ safeStorage }) => {
+      safeStorage.setUsePlainTextEncryption(true)
+    })
+  }
+
+  return application
+}
 
 const shellQuote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`
 

--- a/e2e/launch-environment.spec.ts
+++ b/e2e/launch-environment.spec.ts
@@ -13,16 +13,32 @@ test('normalizes a Windows-style Path before injecting the fake Agent directory'
   expect(environment.ELECTRON_RENDERER_URL).toBeUndefined()
 })
 
-test('launches the packaged executable without the source application argument when configured', () => {
+test('enables the basic password store only for Linux E2E profiles', () => {
+  expect(electronLaunchTarget('profile-root', {}, 'linux')).toEqual({
+    args: ['--user-data-dir=profile-root', '--password-store=basic', expect.any(String)]
+  })
+  expect(electronLaunchTarget('profile-root', {}, 'darwin')).toEqual({
+    args: ['--user-data-dir=profile-root', expect.any(String)]
+  })
+  expect(electronLaunchTarget('profile-root', {}, 'win32')).toEqual({
+    args: ['--user-data-dir=profile-root', expect.any(String)]
+  })
+})
+
+test('launches packaged and source applications with the expected Linux arguments', () => {
   expect(
-    electronLaunchTarget('profile-root', {
-      OPEN_SCIENCE_E2E_EXECUTABLE: '/artifacts/Open Science.app/Contents/MacOS/Open Science'
-    })
+    electronLaunchTarget(
+      'profile-root',
+      {
+        OPEN_SCIENCE_E2E_EXECUTABLE: '/artifacts/Open Science.app/Contents/MacOS/Open Science'
+      },
+      'linux'
+    )
   ).toEqual({
-    args: ['--user-data-dir=profile-root'],
+    args: ['--user-data-dir=profile-root', '--password-store=basic'],
     executablePath: '/artifacts/Open Science.app/Contents/MacOS/Open Science'
   })
-  expect(electronLaunchTarget('profile-root', {})).toEqual({
-    args: ['--user-data-dir=profile-root', expect.any(String)]
+  expect(electronLaunchTarget('profile-root', {}, 'linux')).toEqual({
+    args: ['--user-data-dir=profile-root', '--password-store=basic', expect.any(String)]
   })
 })

--- a/scripts/ci/run-selected-release-e2e.mjs
+++ b/scripts/ci/run-selected-release-e2e.mjs
@@ -17,6 +17,7 @@ const platformNames = {
   linux: 'linux',
   win32: 'windows'
 }
+const playwrightCli = fileURLToPath(import.meta.resolve('@playwright/test/cli'))
 
 export function selectReleaseSpecs(lanes, platform = process.platform) {
   const platformName = platformNames[platform]
@@ -28,6 +29,13 @@ export function selectReleaseSpecs(lanes, platform = process.platform) {
     .map(([, spec]) => spec)
 }
 
+export function releaseE2ECommand(specs) {
+  return {
+    executable: process.execPath,
+    args: [playwrightCli, 'test', ...specs]
+  }
+}
+
 export function runSelectedReleaseE2E(environment = process.env) {
   const lanes = JSON.parse(environment.PR_GATE_LANES ?? '[]')
   if (!Array.isArray(lanes) || lanes.some((lane) => typeof lane !== 'string')) {
@@ -37,8 +45,8 @@ export function runSelectedReleaseE2E(environment = process.env) {
   const specs = selectReleaseSpecs(lanes)
   if (specs.length === 0) throw new Error('No release E2E specs were selected for this platform.')
 
-  const executable = process.platform === 'win32' ? 'npx.cmd' : 'npx'
-  const result = spawnSync(executable, ['playwright', 'test', ...specs], {
+  const { executable, args } = releaseE2ECommand(specs)
+  const result = spawnSync(executable, args, {
     env: environment,
     stdio: 'inherit'
   })

--- a/scripts/ci/run-selected-release-e2e.test.ts
+++ b/scripts/ci/run-selected-release-e2e.test.ts
@@ -1,6 +1,8 @@
+import { fileURLToPath } from 'node:url'
+
 import { describe, expect, it } from 'vitest'
 
-import { selectReleaseSpecs } from './run-selected-release-e2e.mjs'
+import { releaseE2ECommand, selectReleaseSpecs } from './run-selected-release-e2e.mjs'
 
 describe('selected release Electron E2E', () => {
   it('selects only journeys assigned to the current platform', () => {
@@ -23,5 +25,14 @@ describe('selected release Electron E2E', () => {
     expect(() => selectReleaseSpecs([], 'freebsd')).toThrow(
       'Unsupported Electron E2E platform: freebsd'
     )
+  })
+
+  it('launches the installed Playwright CLI directly through Node', () => {
+    const spec = 'e2e/certification/provider-bridge.spec.ts'
+
+    expect(releaseE2ECommand([spec])).toEqual({
+      executable: process.execPath,
+      args: [fileURLToPath(import.meta.resolve('@playwright/test/cli')), 'test', spec]
+    })
   })
 })


### PR DESCRIPTION
## Problem

Linux workspace E2E launches Electron with a temporary profile that has no desktop keyring. Electron therefore reports `safeStorage` as unavailable, and `configureFakeAgent()` fails at `settings:upsert-provider` before the workspace journeys reach ACP behavior.

The Linux lane introduced by #802 did not exercise this path on its introducing PR because classification used the trusted base. The failure became visible on the next full-plan PR.

That full-plan run also exposed a separate Windows P0 launcher defect: `spawnSync('npx.cmd', ...)` failed with `EINVAL` before Playwright started. The failure reproduced on an exact-head job rerun while all preceding Windows Electron journeys passed.

## Proposed change

- Select Electron's basic Linux password backend with `--password-store=basic` for Linux E2E profiles.
- Opt the Linux E2E main process into that test backend with `safeStorage.setUsePlainTextEncryption(true)` after launch.
- Keep macOS and Windows launch behavior unchanged.
- Cover Linux/non-Linux behavior and packaged/source launch semantics in `e2e/launch-environment.spec.ts`.
- Resolve the installed Playwright CLI and launch it directly with `process.execPath` on every platform, avoiding Windows command-script shims and shell execution.
- Cover the P0 command executable, CLI entry point, subcommand, and spec forwarding contract.

## Scope and non-goals

This is a test-only E2E harness and runner fix. It does not change production runtime behavior, settings behavior, workflow configuration, or the fail-closed `safeStorage` security boundary. It does not modify PR #804.

## Acceptance criteria and validation

All listed checks ran after the last material edit and the final rebase onto `origin/main@1156d16`.

- Linux-only password-store argument and packaged/source semantics -> `npm run test:e2e:workspace` -> 6 passed.
- Electron workspace harness behavior -> `npm run build:e2e` -> passed; `npm run test:e2e:workspace` -> 6 passed.
- Windows-safe P0 command contract -> `npm test -- scripts/ci/run-selected-release-e2e.test.ts` -> 4 passed; the test was observed failing before the fix.
- Real P0 dispatcher path -> `PR_GATE_LANES='["e2e_remote_pairing_macos"]' node scripts/ci/run-selected-release-e2e.mjs` -> 1 passed.
- Portable test suite -> `npm test` -> 11,799 passed, 184 skipped.
- Node and renderer type safety -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors (17 existing warnings outside this diff).
- Trusted classifier, PR Gate, and CI-integrity contracts -> focused four-file Vitest run -> 97 passed.
- Exact-head classifier -> full plan; changed-file Markdown/non-Markdown formatting and commit policy -> passed.
- Independent review -> Standards: 0 findings; Spec: 0 findings.

Linux and Windows clean runners are the authoritative platform checks: Linux covers the real safeStorage backend; Windows covers direct Playwright CLI execution for all selected P0 specs.

## Review focus

Please verify that both basic-backend opt-ins are scoped only to Linux E2E launches, source application paths remain final positional arguments while packaged launches omit them, and the P0 dispatcher no longer depends on platform command shims or a shell.
