### PR TITLE
fix(acp): preserve routed prompt ownership

### DIFF
--- a/src/main/acp/runtime-prompt-composition.ts
+++ b/src/main/acp/runtime-prompt-composition.ts
@@ -207,7 +207,10 @@ const composeAcpRuntimePromptOwners = (
           kind: 'message',
           level: 'info',
           sessionId,
-          ...(promptMessageId ? { promptMessageId } : {}),
+          // App-routed prompts (for example an Auditor correction) do not already exist in the
+          // renderer store. Reuse the provenance id so the durable graph and Artifact claim share
+          // one Prompt owner instead of inventing two identities for the same turn.
+          ...(promptMessageId ? { promptMessageId, messageId: promptMessageId } : {}),
           role: 'user',
           text
         })

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -11470,6 +11470,35 @@ describe('ACP runtime session management', () => {
     })
   })
 
+  it('publishes an explicit provenance prompt as the routed user message identity', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['session-1'])
+    const messageEvents: AcpRuntimeEvent[] = []
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: {
+        onEvent: (event) => {
+          if (event.kind === 'message') messageEvents.push(event)
+        }
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace' })
+
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: '[Auditor] Correct the generated file.',
+      provenanceContext: { promptMessageId: 'auditor-prompt-1' }
+    })
+
+    expect(messageEvents.find((event) => event.role === 'user')).toMatchObject({
+      messageId: 'auditor-prompt-1',
+      promptMessageId: 'auditor-prompt-1',
+      text: '[Auditor] Correct the generated file.'
+    })
+  })
+
   it('retains staged Claude replay after failed adoption and commits it after success', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(


### PR DESCRIPTION
## Problem

App-routed prompts such as an automatic Reviewer correction received a synthetic provenance Prompt id, but the corresponding user-message event did not expose that id as its Message identity. The renderer therefore ignored the event, never persisted the Prompt node, and later rejected generated Artifact finalization because the claim's Prompt owner was absent from the durable Conversation Graph.

On Windows this surfaced as `ArtifactFinalizationProofError: Artifact finalization prompt does not match the declared durable ownership.` The same visible Artifact event was retried repeatedly, leaving the session in an error state.

## Proposed change

Publish an explicit provenance Prompt id as both `promptMessageId` and `messageId` on routed user-message events. This lets the renderer project and persist the exact Prompt owner before it processes the later Artifact event. Add a runtime regression test covering the identity contract used by Auditor correction turns.

## Scope and non-goals

- No database schema, data relationship, or architecture changes.
- No change to ordinary renderer-originated prompts or app continuations that intentionally suppress their synthetic text.
- No new UI; the only user-visible change is that generated files from routed correction turns finalize normally instead of showing an error.

## Acceptance criteria and validation

Checks ran after the final material edit.

- routed Prompt identity -> targeted runtime regression -> `vitest run src/main/acp/runtime.test.ts -t "publishes an explicit provenance prompt as the routed user message identity"` -> passed (1 test)
- ACP prompt/event behavior and consumers -> `vitest run src/main/acp/runtime.test.ts` -> passed (441 tests)
- Node process type safety -> `tsc --noEmit -p tsconfig.node.json --composite false` -> passed
- linted source/configuration -> `eslint --cache .` -> passed with 0 errors and 17 pre-existing warnings outside the changed files
- patch hygiene -> `git diff --check` -> passed

Renderer, Web, E2E, persistence migration, and platform build lanes were excluded because the wire shape already supports `messageId`, the renderer already consumes routed user events with that field, and this change does not alter schemas, public interfaces, or platform-specific code. Remaining risk is timing in a packaged correction turn; event-lane ordering is existing behavior and was not reproduced end-to-end with a packaged Windows build.

## Review focus

- Confirm that reusing `promptMessageId` as the routed user event's `messageId` preserves the one-owner provenance invariant.
- Confirm that app continuations remain suppressed and unaffected.
