### PR TITLE
fix(permissions): restore Plan tool approval scopes

### DIFF
--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -678,6 +678,76 @@ describe('ACP permission broker with durable grants', () => {
     ])
   })
 
+  it('offers durable Ask scopes for Plan capabilities without sharing their grants', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-plan-grants-'))
+    client = createProjectDbClient(storageRoot)
+    await ensureProjectSchema(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
+    const registry = await createPermissionGrantRegistry({ getClient: async () => client! })
+    const emitted: Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0][] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request), undefined, registry)
+    const context = {
+      profile: 'ask' as const,
+      projectId: 'project-1',
+      mcpServerNames: ['open-science-plan']
+    }
+
+    const generate = broker.requestPermission(
+      mcpRequest('session-plan', 'mcp__open_science_plan__generate_plan'),
+      context
+    )
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(emitted[0].options.map((option) => option.scope).filter(Boolean)).toEqual([
+      'once',
+      'session',
+      'project',
+      'global'
+    ])
+    broker.respond({
+      requestId: emitted[0].requestId,
+      optionId: emitted[0].options.find((option) => option.scope === 'session')?.optionId
+    })
+    await expect(generate).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'provider-allow-once' }
+    })
+
+    const update = broker.requestPermission(
+      mcpRequest('session-plan', 'mcp__open_science_plan__update_step_status'),
+      context
+    )
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(emitted).toHaveLength(2)
+    expect(emitted[1].options.map((option) => option.scope).filter(Boolean)).toEqual([
+      'once',
+      'session',
+      'project',
+      'global'
+    ])
+    broker.respond({ requestId: emitted[1].requestId, optionId: 'provider-allow-once' })
+    await expect(update).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'provider-allow-once' }
+    })
+
+    await expect(
+      broker.requestPermission(
+        mcpRequest('session-plan', 'mcp__open_science_plan__generate_plan'),
+        context
+      )
+    ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'provider-allow-once' } })
+    expect(emitted).toHaveLength(2)
+    await expect(registry.list()).resolves.toEqual([
+      expect.objectContaining({
+        capability: {
+          kind: 'mcp_tool',
+          key: 'mcp:open-science-plan/generate_plan'
+        },
+        scope: { kind: 'session', projectId: 'project-1', sessionId: 'session-plan' }
+      })
+    ])
+  })
+
   it('uses runtime-trusted identity to align sparse dynamic MCP requests', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-dynamic-mcp-aliases-'))
     client = createProjectDbClient(storageRoot)

--- a/src/main/agent-framework/app-mcp-names.test.ts
+++ b/src/main/agent-framework/app-mcp-names.test.ts
@@ -3,13 +3,13 @@ import { describe, expect, it } from 'vitest'
 import { PRE_REGISTERED_PERMISSION_IDENTITIES } from '../permission-grants/identity-catalog'
 import { SESSION_PLAN_SYSTEM_PROMPT_APPEND } from '../session-plan/guidance'
 import {
+  appMcpToolIdentities,
   appMcpServerAliases,
   renderAppMcpToolReferences,
   resolveCanonicalMcpToolIdentity
 } from './app-mcp-names'
 
-const APP_MCP_CODEC_CASES = PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool.flatMap((key) => {
-  const identity = key.slice('mcp:'.length)
+const APP_MCP_CODEC_CASES = appMcpToolIdentities().flatMap((identity) => {
   const separator = identity.indexOf('/')
   const server = identity.slice(0, separator)
   const tool = identity.slice(separator + 1)
@@ -22,6 +22,14 @@ const APP_MCP_CODEC_CASES = PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool.flatMa
 })
 
 describe('resolveCanonicalMcpToolIdentity', () => {
+  it('keeps the app MCP inventory aligned with the remembered-permission catalog', () => {
+    expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool.toSorted()).toEqual(
+      appMcpToolIdentities()
+        .map((identity) => `mcp:${identity}`)
+        .toSorted()
+    )
+  })
+
   it('documents complete generation and approval call shapes', () => {
     expect(SESSION_PLAN_SYSTEM_PROMPT_APPEND).toContain(
       'generation supplies all four Plan fields (`task_summary`, `phases`, `desired_outputs`, and `feasibility`) in one call'

--- a/src/main/agent-framework/app-mcp-names.ts
+++ b/src/main/agent-framework/app-mcp-names.ts
@@ -81,6 +81,13 @@ const appMcpServerAliases = (name: string): readonly string[] => {
   ]
 }
 
+// Canonical inventory used at cross-module policy seams. Callers receive identities only, keeping
+// framework aliases and rendering details owned by this module.
+const appMcpToolIdentities = (): readonly string[] =>
+  APP_MCP_SERVERS.flatMap(({ canonicalName, tools }) =>
+    tools.map((tool) => `${canonicalName}/${tool}`)
+  )
+
 const resolveCanonicalMcpToolIdentity = (
   name: string | null | undefined,
   mcpServerNames: readonly string[]
@@ -162,6 +169,7 @@ const renderAppMcpToolReferences = (frameworkId: AgentFrameworkId, text: string)
 }
 
 export {
+  appMcpToolIdentities,
   appMcpServerAliases,
   canonicalAppMcpServerName,
   modelFacingAppMcpServerName,

--- a/src/main/permission-grants/capability.test.ts
+++ b/src/main/permission-grants/capability.test.ts
@@ -227,6 +227,16 @@ describe('capabilityFromLegacyCategory', () => {
     ).toBeUndefined()
   })
 
+  it.each(['generate_plan', 'update_step_status'])(
+    'admits the registered Session Plan method %s to remembered permission scopes',
+    (method) => {
+      expect(capabilityFromLegacyCategory(`mcp:open-science-plan/${method}`)).toMatchObject({
+        kind: 'mcp_tool',
+        key: `mcp:open-science-plan/${method}`
+      })
+    }
+  )
+
   it.each([
     ['CreateAgent', 'customize:agent_create'],
     ['agent_update', 'customize:agent_update'],

--- a/src/main/permission-grants/identity-catalog.test.ts
+++ b/src/main/permission-grants/identity-catalog.test.ts
@@ -6,14 +6,23 @@ import {
 } from './identity-catalog'
 
 describe('permission identity catalog', () => {
-  it('contains the closed 32-identity v1 bootstrap inventory', () => {
-    expect(PRE_REGISTERED_PERMISSION_IDENTITY_COUNT).toBe(32)
+  it('contains the closed 34-identity v1 bootstrap inventory', () => {
+    expect(PRE_REGISTERED_PERMISSION_IDENTITY_COUNT).toBe(34)
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.builtin_tool).toEqual([])
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.customize_mutation).toHaveLength(8)
-    expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).toHaveLength(15)
+    expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).toHaveLength(17)
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.execution).toHaveLength(2)
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.file_operation).toHaveLength(6)
     expect(PRE_REGISTERED_PERMISSION_IDENTITIES.skill_operation).toHaveLength(1)
+  })
+
+  it('admits both Session Plan capabilities to remembered permission scopes', () => {
+    expect(PRE_REGISTERED_PERMISSION_IDENTITIES.mcp_tool).toEqual(
+      expect.arrayContaining([
+        'mcp:open-science-plan/generate_plan',
+        'mcp:open-science-plan/update_step_status'
+      ])
+    )
   })
 
   it('does not expose internal Reviewer MCP identities', () => {

--- a/src/main/permission-grants/identity-catalog.ts
+++ b/src/main/permission-grants/identity-catalog.ts
@@ -30,7 +30,9 @@ const PRE_REGISTERED_PERMISSION_IDENTITIES: Readonly<
     'mcp:open-science-notebook/manage_environments',
     'mcp:open-science-artifacts/write_artifact_file',
     'mcp:open-science-activity/begin_activity_group',
-    'mcp:open-science-skills/request_skill_import'
+    'mcp:open-science-skills/request_skill_import',
+    'mcp:open-science-plan/generate_plan',
+    'mcp:open-science-plan/update_step_status'
   ],
   execution: ['exec:local/python', 'exec:local/bash'],
   file_operation: [

--- a/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.test.ts
@@ -140,6 +140,41 @@ describe('describePermissionRequest', () => {
     })
   })
 
+  it('distinguishes permission to create and decide Plans from approval of a specific Plan', () => {
+    expect(
+      describePermissionRequest(
+        request({
+          title: 'mcp__open-science-plan__generate_plan',
+          isMcp: true,
+          mcpIdentity: 'open-science-plan/generate_plan'
+        })
+      )
+    ).toMatchObject({
+      actionTitle: 'Allow Plan creation and recording your decisions?',
+      categoryLabel: 'Plan control',
+      description:
+        'Creates Plans and records decisions you make during review. This Permission Grant never approves a Plan; you must approve each Plan separately.',
+      hideToolIdentity: true
+    })
+  })
+
+  it('distinguishes permission to update approved Plan progress from Plan approval', () => {
+    expect(
+      describePermissionRequest(
+        request({
+          title: 'mcp__open-science-plan__update_step_status',
+          isMcp: true,
+          mcpIdentity: 'open-science-plan/update_step_status'
+        })
+      )
+    ).toMatchObject({
+      actionTitle: 'Allow updates to approved Plan progress?',
+      categoryLabel: 'Plan control',
+      description: 'Updates progress for an approved Plan. This does not approve Plans.',
+      hideToolIdentity: true
+    })
+  })
+
   it('does not classify an artifact-looking provider title without the broker identity', () => {
     expect(
       describePermissionRequest(

--- a/src/renderer/src/pages/workspace/permission-request-presentation.ts
+++ b/src/renderer/src/pages/workspace/permission-request-presentation.ts
@@ -217,6 +217,8 @@ const specialistDeletePresentation = (
 
 const ARTIFACT_SERVER_SEGMENT = 'open-science-artifacts'
 const ARTIFACT_WRITE_TOOL = 'write_artifact_file'
+const PLAN_GENERATE_IDENTITY = 'open-science-plan/generate_plan'
+const PLAN_UPDATE_STEP_STATUS_IDENTITY = 'open-science-plan/update_step_status'
 
 const isArtifactWriteToolName = (toolName: string | undefined): boolean => {
   const name = toolName?.trim().toLowerCase() ?? ''
@@ -237,6 +239,32 @@ const isArtifactWriteToolName = (toolName: string | undefined): boolean => {
 
 const isArtifactWriteRequest = (request: AcpPermissionRequest): boolean =>
   isMcpPermissionRequest(request) && isArtifactWriteToolName(request.mcpIdentity)
+
+const planPermissionPresentation = (
+  request: AcpPermissionRequest
+): PermissionPresentation | undefined => {
+  if (!isMcpPermissionRequest(request)) return undefined
+
+  switch (request.mcpIdentity) {
+    case PLAN_GENERATE_IDENTITY:
+      return {
+        actionTitle: 'Allow Plan creation and recording your decisions?',
+        categoryLabel: 'Plan control',
+        description:
+          'Creates Plans and records decisions you make during review. This Permission Grant never approves a Plan; you must approve each Plan separately.',
+        hideToolIdentity: true
+      }
+    case PLAN_UPDATE_STEP_STATUS_IDENTITY:
+      return {
+        actionTitle: 'Allow updates to approved Plan progress?',
+        categoryLabel: 'Plan control',
+        description: 'Updates progress for an approved Plan. This does not approve Plans.',
+        hideToolIdentity: true
+      }
+    default:
+      return undefined
+  }
+}
 
 const humanizeMcpName = (name: string | undefined): string | undefined => {
   const normalized = name?.trim().replace(/^mcp(?:__|\.)/iu, '') ?? ''
@@ -297,6 +325,9 @@ const describePermissionRequest = (request: AcpPermissionRequest): PermissionPre
       description: 'Saves a file as an artifact for this conversation.'
     }
   }
+
+  const planPresentation = planPermissionPresentation(request)
+  if (planPresentation) return planPresentation
 
   // MCP metadata describes the provider's tool, not a trusted local capability. Only the
   // explicitly modeled notebook tools above receive a more specific native classification.


### PR DESCRIPTION
## Problem

Ask mode omitted canonical `open-science-plan/generate_plan` and `open-science-plan/update_step_status` from the closed permission identity catalog, so Plan tool requests exposed only **Allow once** instead of **once / session / project / global**.

## Proposed change

- Register both Plan tools as exact capabilities.
- Expose a narrow canonical app MCP inventory owner seam and enforce permission-catalog alignment.
- Verify Broker Ask scope projection, exact grant isolation, and Session grant reuse.
- Add Plan-specific permission presentation that clearly distinguishes a Permission Grant from per-Plan Approval.

## Scope and non-goals

No core data model, database, schema, migration, IPC, wire, or provider-response changes. This does not add a server-wide grant, split a tool, reclassify the Settings family, or introduce a giant test matrix. Settings may continue grouping Plan grants under Connectors.

## Acceptance criteria and validation

- Both Plan tools expose `once / session / project / global` in Ask mode.
- A `generate_plan` grant never authorizes `update_step_status`; an Allow once update does not persist; a Session generate grant is reused.
- Grant copy explicitly states that it never approves a Plan and that each Plan requires separate approval.
- Final targeted Test Impact Set: five test files, 337 tests passed.
- Node and web typechecks passed; lint passed; diff check was clean.
- Independent Standards review: no findings. Independent Spec review: no findings.
- The branch contains one squash-ready commit. Use **Squash and merge** per `CONTRIBUTING.md`.
- Remaining PR and platform gates are delegated to GitHub Actions.

All listed local checks ran after the last material edit. The targeted set covers the changed permission catalog, canonical MCP owner interface, Broker projection and grant semantics, and renderer presentation. Platform lanes are excluded locally because this change does not alter platform-specific runtime, persistence, schema, build, or packaging behavior.

Uncovered, non-blocking risks: there is no real provider-to-renderer E2E click journey; the Plan-specific persistence exercise covers Session while Project and Global rely on existing generic Broker/registry coverage; the Settings family remains unchanged.

## Review focus

Please focus on closed identity-inventory ownership and alignment, exact capability separation and Broker projection, and the Permission Grant versus Plan Approval wording.