### PR TITLE
refactor(acp-runtime): compose prompt workflows

### DIFF
--- a/src/main/acp/runtime-prompt-composition.test.ts
+++ b/src/main/acp/runtime-prompt-composition.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+import {
+  composeAcpRuntimePromptOwners,
+  type AcpRuntimePromptHost,
+  type AcpRuntimePromptOwners
+} from './runtime-prompt-composition'
+import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
+
+describe('ACP Runtime Prompt composition', () => {
+  it('builds a fresh frozen graph without invoking Plan or reload hosts', () => {
+    const options = { appVersion: 'test', defaultCwd: '/workspace' }
+    const create = (): AcpRuntimePromptOwners => {
+      const base = composeAcpRuntimeBaseOwners(options)
+      const session = composeAcpRuntimeSessionOwners(options, base)
+      const host: AcpRuntimePromptHost = {
+        plan: {
+          preflight: vi.fn(() => ({})),
+          admit: vi.fn((_request, _interaction, plan) => plan),
+          beforeStop: vi.fn(async () => undefined),
+          beforeRelease: vi.fn(),
+          afterRelease: vi.fn(async () => undefined)
+        },
+        reload: {
+          disconnect: vi.fn(async () => undefined),
+          resume: vi.fn(async () => ({}))
+        }
+      }
+      const owners = composeAcpRuntimePromptOwners(options, base, session, host)
+
+      expect(host.plan.preflight).not.toHaveBeenCalled()
+      expect(host.plan.admit).not.toHaveBeenCalled()
+      expect(host.plan.beforeStop).not.toHaveBeenCalled()
+      expect(host.plan.beforeRelease).not.toHaveBeenCalled()
+      expect(host.plan.afterRelease).not.toHaveBeenCalled()
+      expect(host.reload.disconnect).not.toHaveBeenCalled()
+      expect(host.reload.resume).not.toHaveBeenCalled()
+      return owners
+    }
+
+    const first = create()
+    const second = create()
+
+    expect(Object.isFrozen(first)).toBe(true)
+    expect(first.contextCompactionWorkflow).not.toBe(second.contextCompactionWorkflow)
+    expect(first.promptTurnWorkflow).not.toBe(second.promptTurnWorkflow)
+  })
+})

--- a/src/main/acp/runtime-prompt-composition.ts
+++ b/src/main/acp/runtime-prompt-composition.ts
@@ -1,0 +1,258 @@
+import type { AcpPromptRequest } from '../../shared/acp'
+import type { ArtifactTurnHandle } from './artifact-turn-owner'
+import { AcpContextCompactionWorkflow } from './context-compaction-workflow'
+import { createLogger, errorLogFields } from '../logger'
+import { AcpPromptPreparationOwner } from './prompt-preparation-owner'
+import { AcpPromptTurnWorkflow, type AcpPromptTurnWorkflowOptions } from './prompt-turn-workflow'
+import type { AcpRuntimeOptions } from './runtime'
+import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
+import type { AcpRuntimeSessionOwners } from './runtime-session-composition'
+
+type AcpRuntimePromptPlanHost = Readonly<{
+  preflight: AcpPromptTurnWorkflowOptions['preflightPlan']
+  admit: AcpPromptTurnWorkflowOptions['admitPlan']
+  beforeStop: AcpPromptTurnWorkflowOptions['planLifecycle']['beforeStop']
+  beforeRelease: AcpPromptTurnWorkflowOptions['planLifecycle']['beforeRelease']
+  afterRelease: AcpPromptTurnWorkflowOptions['planLifecycle']['afterRelease']
+}>
+
+type AcpRuntimePromptReloadHost = Readonly<{
+  disconnect: AcpPromptTurnWorkflowOptions['disconnectForReload']
+  resume: AcpPromptTurnWorkflowOptions['resumeAfterReload']
+}>
+
+type AcpRuntimePromptHost = Readonly<{
+  plan: AcpRuntimePromptPlanHost
+  reload: AcpRuntimePromptReloadHost
+}>
+
+const log = createLogger('acp')
+
+const errorMessage = (error: unknown): string => {
+  try {
+    const raw = error instanceof Error ? (error as { message?: unknown }).message : error
+    return typeof raw === 'string' ? raw : String(raw)
+  } catch {
+    return 'unknown error'
+  }
+}
+
+const acpErrorKind = (error: unknown): string | undefined => {
+  try {
+    const data = (error as { data?: unknown } | null)?.data
+    const kind = (data as { errorKind?: unknown } | null | undefined)?.errorKind
+    return typeof kind === 'string' ? kind : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const safeLogError = (message: string, error: unknown): void => {
+  try {
+    log.error(message, errorLogFields(error))
+  } catch {
+    // Prompt projection and the original provider outcome take precedence over diagnostics.
+  }
+}
+
+// Composes the complete Prompt workflow around authoritative Base and Session owners. The host is
+// limited to Plan application policy and public reload re-entry; constructors never invoke it.
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+const composeAcpRuntimePromptOwners = (
+  options: AcpRuntimeOptions,
+  base: AcpRuntimeBaseOwners,
+  session: AcpRuntimeSessionOwners,
+  host: AcpRuntimePromptHost
+) => {
+  const callbacks = options.callbacks ?? {}
+  const activeSession = (sessionId: string) =>
+    session.sessionRegistry.lookup(sessionId)?.attachment?.session
+  const currentFramework = () => base.backendGeneration.current.framework
+  const projectName = (sessionId: string): string =>
+    session.sessionEnvironment.projectName(sessionId)
+  const emitState = (): void => session.publication.emitState()
+  const diagnosticContext = () => ({
+    framework: currentFramework().id,
+    generation: base.connectionResources.epoch,
+    status: base.snapshotOwner.status
+  })
+  const emitSkillActivities = (
+    sessionId: string,
+    promptTurn: number,
+    inputs: ReadonlyArray<{ name: string }>,
+    status: 'in_progress' | 'completed' | 'failed'
+  ): void => {
+    for (const [index, { name }] of inputs.entries()) {
+      session.publication.pushEvent({
+        kind: 'tool',
+        level: status === 'failed' ? 'error' : 'info',
+        sessionId,
+        toolCallId: `open-science-skill-${promptTurn}-${index}`,
+        providerToolName: 'skill',
+        title: `Loaded skill: ${name}`,
+        status
+      })
+    }
+  }
+  const openArtifact = async (
+    sessionId: string,
+    provenanceContext: AcpPromptRequest['provenanceContext']
+  ): Promise<ArtifactTurnHandle | undefined> => {
+    if (!base.artifactTurns) return undefined
+    return base.artifactTurns.open({
+      appSessionId: sessionId,
+      artifactStorageSessionId:
+        base.sessionCapabilities.artifactRoutingIdFor(sessionId) ?? sessionId,
+      projectId: projectName(sessionId),
+      agentName: currentFramework().displayName,
+      provenanceContext
+    })
+  }
+  const publishArtifact = async (
+    sessionId: string,
+    artifact: ArtifactTurnHandle | undefined,
+    onPublished?: () => void
+  ): Promise<void> => {
+    if (!artifact || !base.artifactTurns) return
+    const publication = await base.artifactTurns.finalize(artifact)
+    if (!publication) return
+    session.publication.pushEvent(
+      {
+        kind: 'artifact',
+        level: 'info',
+        sessionId,
+        title: 'Generated files',
+        runId: publication.runId,
+        promptMessageId: publication.promptMessageId,
+        artifactSessionId: publication.artifactStorageSessionId,
+        artifactClaimId: publication.artifactClaimId,
+        artifacts: publication.artifacts
+      },
+      onPublished
+    )
+  }
+  const disposeArtifact = async (artifact: ArtifactTurnHandle | undefined): Promise<void> => {
+    if (artifact) await base.artifactTurns?.dispose(artifact)
+  }
+
+  const promptPreparation = new AcpPromptPreparationOwner({
+    promptContent: base.promptContentOwner,
+    presentation: base.sessionPresentationPolicy,
+    contextUsage: base.contextUsageTracker,
+    selectBridgeSkills: async (text, catalog, signal) =>
+      (await base.connectionResources.selectBridgeSkills(text, catalog, signal)) ?? [],
+    authorizeReferencedUploads: options.skillImport?.authorizeReferencedUploads,
+    ...(options.notebook
+      ? {
+          notebook: {
+            peekHandoffContext: options.notebook.peekHandoffContext,
+            registerTurnInputs: options.notebook.registerTurnInputs
+          }
+        }
+      : {}),
+    emitState
+  })
+  const contextCompactionWorkflow = new AcpContextCompactionWorkflow({
+    sessions: { activeSession, currentFramework },
+    interactions: base.sessionInteractions,
+    context: base.contextUsageTracker,
+    promptContent: base.promptContentOwner,
+    contextEstimateInput: (sessionId) =>
+      session.contextUsagePolicy.resolve(sessionId).estimateInput,
+    selectedContextWindow: (sessionId) =>
+      session.contextUsagePolicy.resolve(sessionId).selectedWindow,
+    routeHiddenNotification: (notification, sessionId) =>
+      session.sessionUpdateProjector.route(notification, {
+        appSessionId: sessionId,
+        visible: false,
+        emitState: () => {
+          try {
+            emitState()
+          } catch (error) {
+            safeLogError('compaction state callback failed', error)
+          }
+        }
+      }),
+    pushEvent: (event) => session.publication.pushEvent(event),
+    emitState,
+    errorMessage
+  })
+  const promptTurnWorkflow = new AcpPromptTurnWorkflow({
+    registry: session.sessionRegistry,
+    interactions: base.sessionInteractions,
+    skills: base.turnSkills,
+    preparation: promptPreparation,
+    executor: base.providerPromptExecutor,
+    contextUsage: base.contextUsageTracker,
+    providerReconnectPending: () => base.connectionTransitions.providerReconnectPending,
+    finalizer: base.promptOutcomeFinalizer,
+    permission: session.permissionContext,
+    environment: {
+      backend: () => base.backendGeneration.current,
+      tooling: () => session.sessionEnvironment.toolingAvailability(),
+      bridgeSkillsAvailable: () => base.connectionResources.bridgeSkillsAvailable,
+      skillImportEnabled: () => base.sessionCapabilities.isSkillImportEnabled(),
+      contextEstimateInput: (sessionId) =>
+        session.contextUsagePolicy.resolve(sessionId).estimateInput,
+      selectedContextWindow: (sessionId) =>
+        session.contextUsagePolicy.resolve(sessionId).selectedWindow,
+      emitSkillActivities,
+      onSkillImportAttachmentEligible: callbacks.onSkillImportAttachmentEligible,
+      onProviderPromptAccepted: callbacks.onProviderPromptAccepted,
+      routeNotification: (notification, sessionId) =>
+        session.sessionUpdateProjector.route(notification, { appSessionId: sessionId }),
+      diagnosticContext,
+      pushUserMessage: ({ sessionId, promptMessageId, text }) =>
+        session.publication.pushEvent({
+          kind: 'message',
+          level: 'info',
+          sessionId,
+          ...(promptMessageId ? { promptMessageId } : {}),
+          role: 'user',
+          text
+        })
+    },
+    artifacts: {
+      open: openArtifact,
+      promptMessageIdFor: (sessionId) => base.artifactTurns?.promptMessageIdFor(sessionId),
+      publish: publishArtifact,
+      dispose: disposeArtifact
+    },
+    planLifecycle: {
+      beforeStop: host.plan.beforeStop,
+      beforeRelease: host.plan.beforeRelease,
+      afterRelease: host.plan.afterRelease
+    },
+    finalization: {
+      errorMessage,
+      errorKind: acpErrorKind,
+      pushEvent: (event) => session.publication.pushEvent(event),
+      onPromptEnded: (sessionId, turnToken) => callbacks.onPromptEnded?.(sessionId, turnToken),
+      generationActivityChanged: base.notifyGenerationActivityChanged,
+      autoCompact: (sessionId, active, interaction) =>
+        contextCompactionWorkflow.compactAutomatic({
+          sessionId,
+          session: active,
+          interaction
+        })
+    },
+    currentCwd: () => base.snapshotOwner.cwd,
+    resolveProjectName: projectName,
+    preflightPlan: host.plan.preflight,
+    admitPlan: host.plan.admit,
+    disconnectForReload: host.reload.disconnect,
+    resumeAfterReload: host.reload.resume,
+    recordAdmittedPrompt: (request) => base.handoffContinuity.recordAdmittedPrompt(request),
+    onPromptStarted: (sessionId, turnToken, promptAttemptId) =>
+      callbacks.onPromptStarted?.(sessionId, turnToken, promptAttemptId),
+    emitState
+  })
+
+  return Object.freeze({ contextCompactionWorkflow, promptTurnWorkflow })
+}
+/* eslint-enable @typescript-eslint/explicit-function-return-type */
+
+type AcpRuntimePromptOwners = ReturnType<typeof composeAcpRuntimePromptOwners>
+
+export { composeAcpRuntimePromptOwners }
+export type { AcpRuntimePromptHost, AcpRuntimePromptOwners }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -765,9 +765,13 @@ const startPermissionProbeAgent = (
 const mcpServerNamesFor = (runtime: AcpRuntime, sessionId: string): readonly string[] =>
   (
     runtime as unknown as {
-      sessionCapabilities: { mcpServerNamesFor: (sessionId: string) => readonly string[] }
+      providerSessionCreator: {
+        deps: {
+          capabilities: { mcpServerNamesFor: (sessionId: string) => readonly string[] }
+        }
+      }
     }
-  ).sessionCapabilities.mcpServerNamesFor(sessionId)
+  ).providerSessionCreator.deps.capabilities.mcpServerNamesFor(sessionId)
 
 const activeSessionForTest = (
   runtime: AcpRuntime,
@@ -779,11 +783,21 @@ const activeSessionForTest = (
     }
   ).activeSessionFor(sessionId)
 
+const providerReconnectPending = (runtime: AcpRuntime): boolean =>
+  (
+    runtime as unknown as {
+      connectionTransitions: { providerReconnectPending: boolean }
+    }
+  ).connectionTransitions.providerReconnectPending
+
 const contextUsageMap = (
   runtime: AcpRuntime
 ): { set: (sessionId: string, usage: AcpContextUsage) => void } => {
-  const tracker = (runtime as unknown as { contextUsageTracker: ContextUsageTracker })
-    .contextUsageTracker
+  const tracker = (
+    runtime as unknown as {
+      contextCompactionWorkflow: { options: { context: ContextUsageTracker } }
+    }
+  ).contextCompactionWorkflow.options.context
   return {
     set: (sessionId, usage) => tracker.reconcileProviderUsage(sessionId, usage)
   }
@@ -794,16 +808,20 @@ const promptContentLifecycle = (
 ): { resetSession: (sessionId: string) => void } =>
   (
     runtime as unknown as {
-      promptContentOwner: { resetSession: (sessionId: string) => void }
+      contextCompactionWorkflow: {
+        options: { promptContent: { resetSession: (sessionId: string) => void } }
+      }
     }
-  ).promptContentOwner
+  ).contextCompactionWorkflow.options.promptContent
 
 const resolveArtifactRunClaim = (runtime: AcpRuntime, claimId: string): ArtifactRunClaim =>
   (
     runtime as unknown as {
-      artifactRunRegistry: { resolve: (id: string) => ArtifactRunClaim }
+      artifactTurns: {
+        options: { runRegistry: { resolve: (id: string) => ArtifactRunClaim } }
+      }
     }
-  ).artifactRunRegistry.resolve(claimId)
+  ).artifactTurns.options.runRegistry.resolve(claimId)
 
 const handleSessionUpdate = (runtime: AcpRuntime, notification: SessionNotification): void =>
   (
@@ -9095,9 +9113,7 @@ describe('ACP runtime session management', () => {
     await runtime.requestProviderReconnect()
 
     expect(process.killed).toBe(false)
-    expect(
-      (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
-    ).toBe(true)
+    expect(providerReconnectPending(runtime)).toBe(true)
 
     releasePendingMode.resolve()
     await expect(pending).resolves.toMatchObject({ sessionId: 'pending-primary' })
@@ -9172,9 +9188,7 @@ describe('ACP runtime session management', () => {
     try {
       await runtime.requestProviderReconnect()
 
-      expect(
-        (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
-      ).toBe(true)
+      expect(providerReconnectPending(runtime)).toBe(true)
       expect(pendingReviewerSessionIds(runtime).has('pending-reviewer')).toBe(true)
 
       releaseReviewerMode.resolve()
@@ -9233,9 +9247,7 @@ describe('ACP runtime session management', () => {
     expect(
       (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
     ).toBeUndefined()
-    expect(
-      (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
-    ).toBe(false)
+    expect(providerReconnectPending(runtime)).toBe(false)
     await expect(runtime.createSession({ cwd: '/workspace' })).resolves.toMatchObject({
       sessionId: 'fresh-primary'
     })
@@ -9315,18 +9327,14 @@ describe('ACP runtime session management', () => {
 
     try {
       await runtime.requestProviderReconnect()
-      expect(
-        (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
-      ).toBe(true)
+      expect(providerReconnectPending(runtime)).toBe(true)
       expect(
         (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
       ).toBeDefined()
 
       releaseOldClose.resolve()
       await oldDisconnect
-      expect(
-        (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
-      ).toBe(true)
+      expect(providerReconnectPending(runtime)).toBe(true)
       expect(
         (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
       ).toBeDefined()
@@ -9490,9 +9498,7 @@ describe('ACP runtime session management', () => {
     expect(
       (runtime as unknown as { reconnectBarrier?: Promise<void> }).reconnectBarrier
     ).toBeUndefined()
-    expect(
-      (runtime as unknown as { pendingProviderReconnect: boolean }).pendingProviderReconnect
-    ).toBe(false)
+    expect(providerReconnectPending(runtime)).toBe(false)
     expect(runtime.getSnapshot().sessionIds).toEqual([])
   })
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -44,22 +44,19 @@ import { getAppClaudeConfigDir } from '../settings/provider-env'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { withDataRootWrite } from '../storage/migration-state'
 import { opencodeStorageDir } from '../agent-framework/opencode'
-import type { ContextUsageTracker } from './context-usage-tracker'
-import type { AcpContextUsagePolicy } from './context-usage-policy'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, FileReference } from '../../shared/artifacts'
 import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
+import type { ContextUsageTracker } from './context-usage-tracker'
 import type {
   ReviewerSessionOwner,
   ReviewerSessionDisposition,
   ReviewerSessionRequest,
   ReviewerSessionResult
 } from './reviewer-session-owner'
-import type { AcpSessionCapabilityOwner } from './session-capability-owner'
-import type { ArtifactTurnHandle, ArtifactTurnOwner } from './artifact-turn-owner'
-import type { AcpPromptContentOwner } from './prompt-content-owner'
+import type { ArtifactTurnOwner } from './artifact-turn-owner'
 import type {
   AcpSessionInteractionOwner,
   AcpPromptSessionInteractionScope
@@ -90,9 +87,8 @@ import type { AcpProviderSessionCreator } from './provider-session-creator'
 import type { AcpProviderSessionResumer } from './provider-session-resumer'
 import type { AcpSessionReplacementWorkflow } from './session-replacement-workflow'
 import type { AcpSessionDeletionWorkflow } from './session-deletion-workflow'
-import { AcpPromptPreparationOwner } from './prompt-preparation-owner'
-import { AcpPromptTurnWorkflow, type AcpPromptTurnPlanContext } from './prompt-turn-workflow'
-import { AcpContextCompactionWorkflow } from './context-compaction-workflow'
+import type { AcpPromptTurnWorkflow, AcpPromptTurnPlanContext } from './prompt-turn-workflow'
+import type { AcpContextCompactionWorkflow } from './context-compaction-workflow'
 import type { AcpProviderPromptExecutor } from './provider-prompt-executor'
 import type { AcpTurnSkillHooks, AcpTurnSkillOwner } from './turn-skill-owner'
 import type { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
@@ -111,6 +107,7 @@ import type { AcpRuntimeSessionOwners } from './runtime-session-composition'
 import type { AcpSessionEnvironmentPolicy } from './session-environment-policy'
 import { composeAcpRuntimeLifecycleOwners } from './runtime-lifecycle-composition'
 import { composeAcpRuntimeProviderSessionOwners } from './runtime-provider-session-composition'
+import { composeAcpRuntimePromptOwners } from './runtime-prompt-composition'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -282,21 +279,6 @@ const errorMessage = (error: unknown): string => {
   }
 }
 
-// The ACP agent tags a provider-relayed failure with the upstream error type in `data.errorKind`
-// (e.g. `request_too_large` for an HTTP 413). Read it so the overflow check can match the slug even
-// when the message text comes in a wording the pattern does not cover. Total: any shape but a string
-// kind collapses to undefined, and a hostile getter never escapes.
-const acpErrorKind = (error: unknown): string | undefined => {
-  try {
-    const data = (error as { data?: unknown } | null)?.data
-    const kind = (data as { errorKind?: unknown } | null | undefined)?.errorKind
-
-    return typeof kind === 'string' ? kind : undefined
-  } catch {
-    return undefined
-  }
-}
-
 const log = createLogger('acp')
 
 // Logs an error without ever throwing back into the caller. Used on failure paths where a throwing
@@ -313,19 +295,15 @@ const safeLogError = (message: string, data?: unknown): void => {
 // Runtime retains protocol startup, Session/Permission/Notebook cleanup, and status/event projection.
 class AcpRuntime {
   private readonly snapshotOwner: AcpRuntimeSnapshotOwner
-  private readonly contextUsageTracker: ContextUsageTracker
-  private readonly contextUsagePolicy: AcpContextUsagePolicy
   private readonly connectionAdapter: AcpAgentConnectionAdapter
   private readonly connectionResources: AcpConnectionResourceOwner
   private readonly connectionTransitions: AcpConnectionTransitionOwner
   private readonly generationActivity: AcpGenerationActivityOwner
-  private readonly notifyGenerationActivityChanged: () => void
   // Stable app identities, provider aliases, publication order, selection, and startup/delete
   // arbitration share one owner. The runtime retains only protocol/resource orchestration.
   private readonly sessionRegistry: AcpSessionRegistry
   // App-owned MCP construction, routing aliases, and bearer lease ownership are kept behind one
   // explicit role policy. Connection/process lifetime remains with the connection resource owner.
-  private readonly sessionCapabilities: AcpSessionCapabilityOwner
   private readonly sessionInteractions: AcpSessionInteractionOwner
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
@@ -334,7 +312,6 @@ class AcpRuntime {
   private readonly permissionContext: AcpPermissionContext
   private readonly publication: AcpRuntimePublicationOwner
   private readonly sessionEnvironment: AcpSessionEnvironmentPolicy
-  private readonly callbacks: AcpRuntimeCallbacks
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
   private readonly backendGeneration: AcpBackendGenerationOwner
   private readonly sessionConfigurator: AcpSessionConfigurator
@@ -345,8 +322,6 @@ class AcpRuntime {
   private readonly planInteractions: SessionPlanInteractionOwner
   private readonly planService: PlanService | undefined
   private readonly planSessions: AcpRuntimePlanOptions['sessions'] | undefined
-  private readonly promptContentOwner: AcpPromptContentOwner
-  private readonly promptPreparation: AcpPromptPreparationOwner
   private readonly contextCompactionWorkflow: AcpContextCompactionWorkflow
   private readonly promptTurnWorkflow: AcpPromptTurnWorkflow
   private readonly connectionClose: AcpConnectionCloseWorkflow
@@ -363,7 +338,6 @@ class AcpRuntime {
     base: AcpRuntimeBaseOwners,
     session: AcpRuntimeSessionOwners
   ) {
-    this.callbacks = options.callbacks ?? {}
     this.spawnAgent = options.spawnAgent
     this.artifactOptions = options.artifacts
     this.planSessions = options.plan?.sessions
@@ -372,141 +346,38 @@ class AcpRuntime {
     this.connectionResources = base.connectionResources
     this.backendGeneration = base.backendGeneration
     this.providerPromptExecutor = base.providerPromptExecutor
-    this.contextUsageTracker = base.contextUsageTracker
     this.sessionInteractions = base.sessionInteractions
-    this.sessionCapabilities = base.sessionCapabilities
     this.artifactTurns = base.artifactTurns
     this.planInteractions = base.planInteractions
     this.planService = base.planService
-    this.promptContentOwner = base.promptContentOwner
     this.handoffContinuity = base.handoffContinuity
     this.generationActivity = base.generationActivity
-    this.notifyGenerationActivityChanged = base.notifyGenerationActivityChanged
     this.connectionTransitions = base.connectionTransitions
     this.turnSkills = base.turnSkills
     this.sessionConfigurator = base.sessionConfigurator
     this.sessionRegistry = session.sessionRegistry
     this.sessionEnvironment = session.sessionEnvironment
-    this.contextUsagePolicy = session.contextUsagePolicy
     this.publication = session.publication
     this.permissionContext = session.permissionContext
     this.reviewerSessions = session.reviewerSessions
     this.sessionUpdateProjector = session.sessionUpdateProjector
-    this.promptPreparation = new AcpPromptPreparationOwner({
-      promptContent: this.promptContentOwner,
-      presentation: base.sessionPresentationPolicy,
-      contextUsage: this.contextUsageTracker,
-      selectBridgeSkills: async (text, catalog, signal) =>
-        (await this.connectionResources.selectBridgeSkills(text, catalog, signal)) ?? [],
-      authorizeReferencedUploads: options.skillImport?.authorizeReferencedUploads,
-      ...(options.notebook
-        ? {
-            notebook: {
-              peekHandoffContext: options.notebook.peekHandoffContext,
-              registerTurnInputs: options.notebook.registerTurnInputs
-            }
-          }
-        : {}),
-      emitState: () => this.emitState()
-    })
-    this.contextCompactionWorkflow = new AcpContextCompactionWorkflow({
-      sessions: {
-        activeSession: (sessionId) => this.activeSessionFor(sessionId),
-        currentFramework: () => this.framework
-      },
-      interactions: this.sessionInteractions,
-      context: this.contextUsageTracker,
-      promptContent: this.promptContentOwner,
-      contextEstimateInput: (sessionId) => this.contextUsagePolicy.resolve(sessionId).estimateInput,
-      selectedContextWindow: (sessionId) =>
-        this.contextUsagePolicy.resolve(sessionId).selectedWindow,
-      routeHiddenNotification: (notification, sessionId) =>
-        this.sessionUpdateProjector.route(notification, {
-          appSessionId: sessionId,
-          visible: false,
-          emitState: () => {
-            try {
-              this.emitState()
-            } catch (error) {
-              safeLogError('compaction state callback failed', errorLogFields(error))
-            }
-          }
-        }),
-      pushEvent: (event) => this.pushEvent(event),
-      emitState: () => this.emitState(),
-      errorMessage
-    })
-    this.promptTurnWorkflow = new AcpPromptTurnWorkflow({
-      registry: this.sessionRegistry,
-      interactions: this.sessionInteractions,
-      skills: this.turnSkills,
-      preparation: this.promptPreparation,
-      executor: this.providerPromptExecutor,
-      contextUsage: this.contextUsageTracker,
-      providerReconnectPending: () => this.pendingProviderReconnect,
-      finalizer: base.promptOutcomeFinalizer,
-      permission: this.permissionContext,
-      environment: {
-        backend: () => this.backend,
-        tooling: () => this.sessionEnvironment.toolingAvailability(),
-        bridgeSkillsAvailable: () => this.connectionResources.bridgeSkillsAvailable,
-        skillImportEnabled: () => this.sessionCapabilities.isSkillImportEnabled(),
-        contextEstimateInput: (sessionId) =>
-          this.contextUsagePolicy.resolve(sessionId).estimateInput,
-        selectedContextWindow: (sessionId) =>
-          this.contextUsagePolicy.resolve(sessionId).selectedWindow,
-        emitSkillActivities: (sessionId, turn, inputs, status) =>
-          this.emitCodexSkillInputActivities(sessionId, turn, inputs, status),
-        onSkillImportAttachmentEligible: this.callbacks.onSkillImportAttachmentEligible,
-        onProviderPromptAccepted: this.callbacks.onProviderPromptAccepted,
-        routeNotification: (notification, sessionId) =>
-          this.sessionUpdateProjector.route(notification, { appSessionId: sessionId }),
-        diagnosticContext: () => this.diagnosticContext(),
-        pushUserMessage: ({ sessionId, promptMessageId, text }) =>
-          this.pushEvent({
-            kind: 'message',
-            level: 'info',
-            sessionId,
-            ...(promptMessageId ? { promptMessageId } : {}),
-            role: 'user',
-            text
-          })
-      },
-      artifacts: {
-        open: (sessionId, provenance) => this.activateArtifactRun(sessionId, provenance),
-        promptMessageIdFor: (sessionId) => this.artifactTurns?.promptMessageIdFor(sessionId),
-        publish: (sessionId, artifact, onPublished) =>
-          this.emitArtifactRunEvent(sessionId, artifact, onPublished),
-        dispose: (artifact) => this.clearArtifactRun(artifact)
-      },
-      planLifecycle: {
+    const prompt = composeAcpRuntimePromptOwners(options, base, session, {
+      plan: {
+        preflight: (request) => this.preflightPromptPlan(request),
+        admit: (request, interaction, plan) => this.admitPromptPlan(request, interaction, plan),
         beforeStop: (sessionId, interaction, response) =>
           this.checkPromptPlanCompletion(sessionId, interaction, response),
         beforeRelease: (sessionId, interaction) =>
           this.releasePromptPlanBinding(sessionId, interaction),
         afterRelease: (sessionId) => this.publishTerminalPlanProjection(sessionId)
       },
-      finalization: {
-        errorMessage,
-        errorKind: acpErrorKind,
-        pushEvent: (event) => this.pushEvent(event),
-        onPromptEnded: (sessionId, turnToken) =>
-          this.callbacks.onPromptEnded?.(sessionId, turnToken),
-        generationActivityChanged: () => this.generationActivityChanged(),
-        autoCompact: (sessionId, session, interaction) =>
-          this.contextCompactionWorkflow.compactAutomatic({ sessionId, session, interaction })
-      },
-      currentCwd: () => this.snapshotOwner.cwd,
-      resolveProjectName: (sessionId) => this.resolveSessionProjectName(sessionId),
-      preflightPlan: (request) => this.preflightPromptPlan(request),
-      admitPlan: (request, interaction, plan) => this.admitPromptPlan(request, interaction, plan),
-      disconnectForReload: () => this.disconnect(false),
-      resumeAfterReload: (request) => this.resumeSession(request),
-      recordAdmittedPrompt: (request) => this.handoffContinuity.recordAdmittedPrompt(request),
-      onPromptStarted: (sessionId, turnToken, promptAttemptId) =>
-        this.callbacks.onPromptStarted?.(sessionId, turnToken, promptAttemptId),
-      emitState: () => this.emitState()
+      reload: {
+        disconnect: () => this.disconnect(false),
+        resume: (request) => this.resumeSession(request)
+      }
     })
+    this.contextCompactionWorkflow = prompt.contextCompactionWorkflow
+    this.promptTurnWorkflow = prompt.promptTurnWorkflow
     const lifecycle = composeAcpRuntimeLifecycleOwners(options, base, session, {
       connect: (request) => this.connect(request),
       disconnect: (emitClosedStatus) => this.disconnect(emitClosedStatus),
@@ -540,16 +411,8 @@ class AcpRuntime {
     return this.connectionResources.connection
   }
 
-  private get pendingProviderReconnect(): boolean {
-    return this.connectionTransitions.providerReconnectPending
-  }
-
   private get reconnectBarrier(): Promise<void> | undefined {
     return this.connectionTransitions.barrier
-  }
-
-  private generationActivityChanged(): void {
-    this.notifyGenerationActivityChanged()
   }
 
   private get connectionGeneration(): number {
@@ -1453,28 +1316,6 @@ class AcpRuntime {
     return this.permissionContext.requestAppApproval(input)
   }
 
-  // Native UserInput::Skill entries are consumed inside Codex and may not emit a filesystem read
-  // lifecycle over ACP. Project the same compact activity explicitly so selected and auto-routed
-  // Skills remain visible without sending their path or document to renderer state or persistence.
-  private emitCodexSkillInputActivities(
-    sessionId: string,
-    promptTurn: number,
-    inputs: ReadonlyArray<{ name: string }>,
-    status: 'in_progress' | 'completed' | 'failed'
-  ): void {
-    for (const [index, { name }] of inputs.entries()) {
-      this.pushEvent({
-        kind: 'tool',
-        level: status === 'failed' ? 'error' : 'info',
-        sessionId,
-        toolCallId: `open-science-skill-${promptTurn}-${index}`,
-        providerToolName: 'skill',
-        title: `Loaded skill: ${name}`,
-        status
-      })
-    }
-  }
-
   // Lazily initializes the process connection before session creation.
   private async ensureConnected(cwd: string): Promise<ClientConnection> {
     return this.connectionLifecycle.ensureConnected(cwd)
@@ -1515,28 +1356,6 @@ class AcpRuntime {
     return this.sessionEnvironment.projectName(sessionId)
   }
 
-  // Marks a new assistant turn as the active artifact run before the model can call the MCP tool.
-  private async activateArtifactRun(
-    sessionId: string,
-    provenanceContext: AcpPromptRequest['provenanceContext']
-  ): Promise<ArtifactTurnHandle | undefined> {
-    if (!this.artifactTurns) return undefined
-
-    return this.artifactTurns.open({
-      appSessionId: sessionId,
-      artifactStorageSessionId:
-        this.sessionCapabilities.artifactRoutingIdFor(sessionId) ?? sessionId,
-      projectId: this.resolveSessionProjectName(sessionId),
-      agentName: this.framework.displayName,
-      provenanceContext
-    })
-  }
-
-  // Clears the handoff file after the prompt so late MCP writes cannot attach to a completed turn.
-  private async clearArtifactRun(artifactRun: ArtifactTurnHandle | undefined): Promise<void> {
-    if (artifactRun) await this.artifactTurns?.dispose(artifactRun)
-  }
-
   // Writes an inline file into the in-flight turn's pending artifact run so it attaches to the resulting
   // message and surfaces to the renderer like any generated artifact. Used by app-side connector tools
   // (e.g. molecule preview). Throws when no assistant turn is active (e.g. a user-run notebook cell).
@@ -1552,32 +1371,6 @@ class AcpRuntime {
       throw new Error('No active assistant turn to attach a generated file to.')
     }
     return this.artifactTurns.writeForActiveTurn(sessionId, input)
-  }
-
-  // Publishes pending files as a claim event; the renderer later supplies the final message id.
-  private async emitArtifactRunEvent(
-    sessionId: string,
-    artifactRun: ArtifactTurnHandle | undefined,
-    onPublished?: () => void
-  ): Promise<void> {
-    if (!artifactRun || !this.artifactTurns) return
-    const publication = await this.artifactTurns.finalize(artifactRun)
-    if (!publication) return
-
-    this.pushEvent(
-      {
-        kind: 'artifact',
-        level: 'info',
-        sessionId,
-        title: 'Generated files',
-        runId: publication.runId,
-        promptMessageId: publication.promptMessageId,
-        artifactSessionId: publication.artifactStorageSessionId,
-        artifactClaimId: publication.artifactClaimId,
-        artifacts: publication.artifacts
-      },
-      onPublished
-    )
   }
 
   private cancelPermissionFlowForSession(sessionId: string): void {

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -392,6 +392,23 @@ describe('runtime state ownership architecture', () => {
     expect(composition).not.toMatch(/AcpRuntime\.prototype|from ['"]electron['"]/)
   })
 
+  it('constructs Prompt workflows outside Runtime with a private preparation owner', () => {
+    const runtime = readSource('src/main/acp/runtime.ts')
+    const composition = readSource('src/main/acp/runtime-prompt-composition.ts')
+
+    expect(runtime).not.toMatch(
+      /new (?:AcpPromptPreparationOwner|AcpContextCompactionWorkflow|AcpPromptTurnWorkflow)/
+    )
+    expect(runtime).toContain('composeAcpRuntimePromptOwners(options, base, session, {')
+    expect(composition.match(/new AcpPromptPreparationOwner\(/g)).toHaveLength(1)
+    expect(composition.match(/new AcpContextCompactionWorkflow\(/g)).toHaveLength(1)
+    expect(composition.match(/new AcpPromptTurnWorkflow\(/g)).toHaveLength(1)
+    expect(composition).toContain(
+      'return Object.freeze({ contextCompactionWorkflow, promptTurnWorkflow })'
+    )
+    expect(composition).not.toMatch(/AcpRuntime\.prototype|from ['"]electron['"]/)
+  })
+
   it('keeps provider permission routing and reviewer preparation behind their owners', () => {
     const source = readSource('src/main/acp/runtime.ts')
 
@@ -405,7 +422,9 @@ describe('runtime state ownership architecture', () => {
   })
 
   it('keeps provider selection and Context routing behind their prompt owners', () => {
-    const source = readSource('src/main/acp/runtime.ts')
+    const runtime = readSource('src/main/acp/runtime.ts')
+    const promptComposition = readSource('src/main/acp/runtime-prompt-composition.ts')
+    const source = runtime + promptComposition
 
     expect(source).not.toContain('private providerTurnAdapter')
     expect(source).not.toContain('private recordProviderPromptContextUsage')
@@ -414,8 +433,8 @@ describe('runtime state ownership architecture', () => {
     expect(source).not.toContain('private selectedContextWindowFor')
     expect(source).not.toContain('private handleSessionUpdate')
     expect(source).not.toContain('private applySessionUpdateEffects')
-    expect(source).toContain('this.contextUsagePolicy.resolve(sessionId)')
-    expect(source).toContain('this.sessionUpdateProjector.route(notification')
+    expect(promptComposition).toContain('session.contextUsagePolicy.resolve(sessionId)')
+    expect(promptComposition).toContain('session.sessionUpdateProjector.route(notification')
   })
 
   it('accepts declared interface imports for a future orchestration module', () => {


### PR DESCRIPTION
## Problem

`AcpRuntime` still constructed Prompt preparation, context compaction, and Prompt turn workflows directly. It also retained duplicate references to Context, capability, callback, and Prompt-content owners solely to wire those workflows. That kept Prompt orchestration coupled to the Runtime facade and left the Runtime at 1,725 lines.

## Proposed change

- Add a frozen `runtime-prompt-composition` root that constructs one private `AcpPromptPreparationOwner`, one `AcpContextCompactionWorkflow`, and one `AcpPromptTurnWorkflow`.
- Derive Context, Artifact-turn, Skill-activity, callback, Session, and publication dependencies from the authoritative Base and Session owner graphs.
- Keep only two narrow Runtime host boundaries:
  - Session Plan lifecycle policy (`preflight`, `admit`, `beforeStop`, `beforeRelease`, `afterRelease`).
  - public forced-Skill reload re-entry (`disconnect(false)`, then `resumeSession`).
- Move tests away from removed Runtime shadow fields so they inspect the authoritative owner that owns each state.
- Add executable composition and architecture constraints for a fresh, frozen, side-effect-free Prompt graph.

```mermaid
flowchart LR
  Runtime["AcpRuntime facade"] -->|"sendPrompt / compactSession"| Prompt["Prompt composition"]
  Prompt --> Preparation["Prompt preparation owner"]
  Prompt --> Turn["Prompt turn workflow"]
  Prompt --> Compaction["Context compaction workflow"]
  Preparation --> Base["Base owners"]
  Turn --> Base
  Turn --> Session["Session owners"]
  Compaction --> Base
  Compaction --> Session
  Turn -->|"Plan lifecycle port"| Runtime
  Turn -->|"forced-Skill reload port"| Runtime
```

The Runtime drops from 1,725 to 1,518 lines. Production raw churn is 495 lines, below the approved 600-line boundary.

## Scope and non-goals

- No IPC, preload, Web RPC, CLI/Task, wire, persistence, or public API changes.
- No data-model, data-relationship, or user-interaction changes.
- No change to existing Electron/Web/CLI/Task capability asymmetry.
- No change to Specialist, Permission, Compute, or Notebook capability policy.
- No change to Codex/OpenCode reload, fresh adoption, context reset, compaction, Artifact publication/disposal, or terminal callback ordering.
- No orchestration data or public interface for #458 is introduced; this only preserves a narrower forward-compatible internal boundary.
- Runtime-owned Session Plan policy is intentionally not moved in this PR.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Prompt composition, Preparation, Compaction, Turn, Plan, and ownership constraints -> `npm test -- --run src/main/acp/runtime-prompt-composition.test.ts src/main/runtime-state-ownership.architecture.test.ts src/main/acp/prompt-preparation-owner.test.ts src/main/acp/context-compaction-workflow.test.ts src/main/acp/prompt-turn-workflow.test.ts src/main/acp/runtime-session-plan.test.ts` -> passed as part of the final 572-test set.
- Runtime facade, Coordinator/IPC consumers, and Codex/OpenCode handoff paths -> `npm test -- --run src/main/acp/runtime.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/runtime-ipc.test.ts src/main/acp/codex-completion-handoff.integration.test.ts src/main/acp/opencode-immediate-handoff.integration.test.ts` -> passed as part of the final 572-test set; Runtime itself is 440/440.
- Combined final Test Impact Set -> the ten test files above -> 10 files / 572 tests passed.
- Node interfaces -> `npm run typecheck:node` -> passed.
- Repository standards -> `npm run lint` -> 0 errors; 17 pre-existing unrelated warnings.
- Changed-file formatting and patch hygiene -> Prettier check and `git diff --check` -> passed.
- Independent ownership review -> Standards 0 findings / Spec 0 findings.
- Independent cross-surface compatibility review -> Standards 0 findings / Spec 0 findings.

The first sandboxed consumer run could not bind `127.0.0.1`; the identical Runtime/handoff set passed outside the sandbox. Web typecheck and local platform E2E were excluded because no shared, preload, renderer, transport, process-spawn, or platform contract changed. Online CI remains authoritative; Linux E2E is explicitly outside this refactor's merge decision.

## Review focus

- Confirm Prompt preparation remains private to the composition root and automatic/manual compaction share the same workflow instance.
- Confirm the Plan and reload ports remain semantic and preserve their previous call order and error propagation.
- Confirm Artifact `open -> finalize/publish(onAppended) -> dispose` and Prompt terminal callbacks retain their previous ordering.
- Confirm Runtime no longer keeps Context/capability/callback/Prompt-content shadow references.

Related: #458
