### PR TITLE
refactor(acp-runtime): compose session plan commands

### DIFF
--- a/src/main/acp/runtime-plan-composition.test.ts
+++ b/src/main/acp/runtime-plan-composition.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+import { composeAcpRuntimePlanWorkflow } from './runtime-plan-composition'
+import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
+
+describe('ACP Runtime Session Plan composition', () => {
+  it('builds a fresh frozen workflow without publishing or requiring Plan capability', async () => {
+    const options = { appVersion: 'test', defaultCwd: '/workspace' }
+    const create = (): ReturnType<typeof composeAcpRuntimePlanWorkflow> => {
+      const base = composeAcpRuntimeBaseOwners(options)
+      const session = composeAcpRuntimeSessionOwners(options, base)
+      const workflow = composeAcpRuntimePlanWorkflow(options, base, session)
+
+      expect(session.publication.getSnapshot().events).toEqual([])
+      return workflow
+    }
+
+    const first = create()
+    const second = create()
+
+    expect(Object.isFrozen(first)).toBe(true)
+    expect(first).not.toBe(second)
+    await expect(first.projection('project', 'session')).resolves.toBeNull()
+    await expect(
+      first.call({ projectId: 'project', sessionId: 'session', operation: 'approve' })
+    ).rejects.toThrow('Session Plan capability is not configured.')
+    await expect(
+      first.respond({ projectId: 'project', sessionId: 'session', feedback: 'continue' })
+    ).rejects.toThrow('Session Plan capability is not configured.')
+  })
+})

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -1,0 +1,251 @@
+import type { AcpRuntimeEvent } from '../../shared/acp'
+import type {
+  ActivePlanProjection,
+  GeneratePlanContent,
+  PlanResponseCommand
+} from '../../shared/session-plan/contract'
+import { PlanCommandError } from '../../shared/session-plan/contract'
+import type { SessionPlanStepStatus } from '../../shared/session-persistence'
+import { createLogger, errorLogFields } from '../logger'
+import type { PlanResponseResult } from '../session-plan/plan-service'
+import type { AcpRuntimeOptions } from './runtime'
+import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
+import type { AcpRuntimeSessionOwners } from './runtime-session-composition'
+
+type AcpSessionPlanCall = Readonly<{
+  projectId: string
+  sessionId: string
+  operation: 'generate' | 'approve' | 'reject' | 'updateStepStatus'
+  input?: unknown
+}>
+
+const log = createLogger('acp')
+
+const safeLogError = (message: string, error: unknown): void => {
+  try {
+    log.error(message, errorLogFields(error))
+  } catch {
+    // Plan projection and the original operation result take precedence over diagnostics.
+  }
+}
+
+// Composes ACP-facing Session Plan application policy around the authoritative Plan, interaction,
+// Artifact, durable-branch, and publication owners. It owns no mutable state of its own.
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+const composeAcpRuntimePlanWorkflow = (
+  options: AcpRuntimeOptions,
+  base: AcpRuntimeBaseOwners,
+  session: AcpRuntimeSessionOwners
+) => {
+  const service = base.planService
+  const interactions = base.planInteractions
+  const sessionInteractions = base.sessionInteractions
+  const planSessions = options.plan?.sessions
+  const pushEvent = (
+    event: Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>
+  ): void => session.publication.pushEvent(event)
+  const publishProjection = (sessionId: string, projection: ActivePlanProjection): void => {
+    try {
+      pushEvent({
+        id: `session-plan-${projection.artifactVersionId}-${projection.revision}`,
+        timestamp: Date.now(),
+        kind: 'plan',
+        level: 'info',
+        sessionId,
+        title: 'Session Plan updated',
+        planProjection: projection
+      })
+    } catch (error) {
+      safeLogError('Session Plan projection callback failed', error)
+    }
+  }
+  const assertVisibleToDurableBranch = async (
+    projectId: string,
+    sessionId: string,
+    projection: ActivePlanProjection
+  ): Promise<void> => {
+    const origin = projection.originatingPromptMessageId
+    if (
+      !origin ||
+      !planSessions ||
+      !(await planSessions.containsMessageOnActiveBranch(projectId, sessionId, origin))
+    ) {
+      throw new PlanCommandError(
+        'interaction-mismatch',
+        'The active Session Plan does not belong to the durable active Message Branch.'
+      )
+    }
+  }
+  const bindExecutionToCurrentInteraction = (
+    sessionId: string,
+    artifactVersionId: string
+  ): void => {
+    const interaction = sessionInteractions.current(sessionId)
+    if (!interaction || interaction.kind !== 'prompt') return
+    interactions.bindExecution({
+      sessionId,
+      interactionSequence: interaction.sequence,
+      artifactVersionId
+    })
+  }
+  const call = async (input: AcpSessionPlanCall): Promise<unknown> => {
+    if (!service) throw new Error('Session Plan capability is not configured.')
+    if (input.operation === 'generate') {
+      const interactionId = base.artifactTurns?.promptMessageIdFor(input.sessionId)
+      if (!interactionId) throw new Error('No active interaction can generate a Session Plan.')
+      interactions.reserveApproval(input.sessionId, interactionId)
+      let result: Awaited<ReturnType<NonNullable<typeof service>['generate']>>
+      try {
+        result = await service.generate({
+          projectId: input.projectId,
+          sessionId: input.sessionId,
+          interactionId,
+          content: input.input as GeneratePlanContent
+        })
+      } catch (error) {
+        interactions.releaseApprovalReservation(input.sessionId, interactionId)
+        const current = await service.getProjection(input.projectId, input.sessionId)
+        if (current) publishProjection(input.sessionId, current)
+        throw error
+      }
+      let approval: Promise<unknown>
+      try {
+        approval = interactions.parkReservedApproval(input.sessionId, interactionId)
+      } catch (error) {
+        interactions.release(input.sessionId, result.projection.artifactVersionId)
+        throw error
+      }
+      publishProjection(input.sessionId, result.projection)
+      return approval
+    }
+    const projection = await service.getProjection(input.projectId, input.sessionId, {
+      interactionIsLive: sessionInteractions.current(input.sessionId) !== undefined
+    })
+    if (!projection) throw new Error('The Session has no active Plan.')
+    await assertVisibleToDurableBranch(input.projectId, input.sessionId, projection)
+    const identity = {
+      projectId: input.projectId,
+      sessionId: input.sessionId,
+      artifactVersionId: projection.artifactVersionId,
+      expectedRevision: projection.revision
+    }
+    if (input.operation === 'approve' || input.operation === 'reject') {
+      const interactionIsLive = sessionInteractions.current(input.sessionId) !== undefined
+      const decision = input.operation === 'approve' ? 'approved' : 'rejected'
+      const executionBinding = interactions.executionBindingFor(input.sessionId)
+      const result = await service.respond({ ...identity, decision, interactionIsLive })
+      if (decision === 'approved') {
+        bindExecutionToCurrentInteraction(input.sessionId, result.projection.artifactVersionId)
+      } else if (executionBinding) {
+        interactions.releaseExecution(input.sessionId, executionBinding.interactionSequence)
+      }
+      interactions.resolveApproval(input.sessionId, result)
+      publishProjection(input.sessionId, result.projection)
+      return result
+    }
+    const update = input.input as {
+      title: string
+      status: SessionPlanStepStatus
+      notes?: string
+      expectedArtifactVersionId?: string
+    }
+    if (projection.approval !== 'approved') {
+      throw new PlanCommandError(
+        'plan-not-approved',
+        'The Plan is still pending. Interpret the user Message, then call generate_plan with decision:"approved" or decision:"rejected" before updating steps.'
+      )
+    }
+    const interaction = sessionInteractions.current(input.sessionId)
+    const binding = interactions.executionBindingFor(input.sessionId)
+    if (!binding) {
+      throw new PlanCommandError(
+        'continuation-required',
+        'Continuing this Plan requires an explicit user continuation.'
+      )
+    }
+    if (!interaction || binding.interactionSequence !== interaction.sequence) {
+      throw new PlanCommandError(
+        'interaction-mismatch',
+        'This interaction is not authorized to execute the active Plan.'
+      )
+    }
+    if (
+      binding.artifactVersionId !== projection.artifactVersionId ||
+      (update.expectedArtifactVersionId !== undefined &&
+        update.expectedArtifactVersionId !== binding.artifactVersionId)
+    ) {
+      throw new PlanCommandError(
+        'interaction-mismatch',
+        'This interaction is bound to a different Plan Artifact Version.'
+      )
+    }
+    const result = await service.updateStepStatus({
+      ...identity,
+      artifactVersionId: update.expectedArtifactVersionId ?? identity.artifactVersionId,
+      title: update.title,
+      status: update.status,
+      ...(update.notes ? { notes: update.notes } : {})
+    })
+    publishProjection(input.sessionId, result.projection)
+    return result
+  }
+  const projection = (projectId: string, sessionId: string): Promise<ActivePlanProjection | null> =>
+    service?.getProjection(projectId, sessionId, {
+      interactionIsLive: sessionInteractions.current(sessionId) !== undefined
+    }) ?? Promise.resolve(null)
+  const respond = async (input: PlanResponseCommand): Promise<PlanResponseResult> => {
+    if (!service) throw new Error('Session Plan capability is not configured.')
+    if (input.decision === undefined && !interactions.approvalInteractionIdFor(input.sessionId)) {
+      throw new Error('The paused Session Plan interaction is no longer available.')
+    }
+    const interactionIsLive = interactions.approvalInteractionIdFor(input.sessionId) !== undefined
+    const current = await service.getProjection(input.projectId, input.sessionId, {
+      interactionIsLive
+    })
+    if (!current) throw new Error('The Session has no active Plan.')
+    await assertVisibleToDurableBranch(input.projectId, input.sessionId, current)
+    const result = await service.respond({ ...input, interactionIsLive })
+    if ('projection' in result) {
+      if (interactionIsLive && result.projection.approval === 'approved') {
+        bindExecutionToCurrentInteraction(input.sessionId, result.projection.artifactVersionId)
+      }
+      if (interactionIsLive) interactions.resolveApproval(input.sessionId, result)
+      publishProjection(input.sessionId, result.projection)
+      return result
+    }
+    if (interactions.approvalInteractionIdFor(input.sessionId) !== result.routeToInteractionId) {
+      throw new Error('The paused Session Plan interaction is no longer available.')
+    }
+    try {
+      pushEvent({
+        id: `session-user-message-${result.message.id}`,
+        timestamp: result.message.createdAt,
+        kind: 'message',
+        level: 'info',
+        sessionId: input.sessionId,
+        promptMessageId: result.message.responseToMessageId,
+        messageId: result.message.id,
+        role: 'user',
+        text: result.message.content
+      })
+    } catch (error) {
+      safeLogError('Routed user Message projection callback failed', error)
+    }
+    interactions.resolveApproval(input.sessionId, result)
+    return result
+  }
+
+  return Object.freeze({
+    call,
+    projection,
+    respond,
+    publishProjection,
+    assertVisibleToDurableBranch
+  })
+}
+/* eslint-enable @typescript-eslint/explicit-function-return-type */
+
+type AcpRuntimePlanWorkflow = ReturnType<typeof composeAcpRuntimePlanWorkflow>
+
+export { composeAcpRuntimePlanWorkflow }
+export type { AcpRuntimePlanWorkflow, AcpSessionPlanCall }

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
 import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { AcpRuntime } from './runtime'
+import { composeAcpRuntimePlanWorkflow } from './runtime-plan-composition'
 
 const projection = (
   artifactVersionId: string,
@@ -121,6 +122,26 @@ const createRuntimeHarness = (options: {
       }
     )
   }
+  const planSessions = {
+    containsMessageOnActiveBranch: vi.fn(
+      async (_projectId: string, _sessionId: string, messageId: string) =>
+        (options.durableMessageIds ?? ['interaction-1']).includes(messageId)
+    )
+  }
+  const sessionPlanWorkflow = composeAcpRuntimePlanWorkflow(
+    { plan: { sessions: planSessions } } as unknown as Parameters<
+      typeof composeAcpRuntimePlanWorkflow
+    >[0],
+    {
+      planService: service,
+      planInteractions: interactions,
+      sessionInteractions,
+      artifactTurns: { promptMessageIdFor: () => 'interaction-1' }
+    } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[1],
+    {
+      publication: { pushEvent: (event: unknown) => options.onEvent?.(event) }
+    } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[2]
+  )
   const target = Object.create(AcpRuntime.prototype) as Record<string, unknown>
   Object.assign(target, {
     planService: service,
@@ -132,12 +153,7 @@ const createRuntimeHarness = (options: {
     sessionRegistry: {
       lookup: () => ({ attachment: { session: { sessionId: 'provider-session-1' } } })
     },
-    planSessions: {
-      containsMessageOnActiveBranch: vi.fn(
-        async (_projectId: string, _sessionId: string, messageId: string) =>
-          (options.durableMessageIds ?? ['interaction-1']).includes(messageId)
-      )
-    },
+    sessionPlanWorkflow,
     artifactTurns: {
       promptMessageIdFor: () => 'interaction-1'
     },

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AcpRuntime } from './runtime.test-utils'
 import type { AcpAgentConnectionAdapter } from './agent-connection-adapter'
 import type { AcpConnectionCloseWorkflow } from './connection-close-workflow'
+import { composeAcpRuntimePlanWorkflow } from './runtime-plan-composition'
 import { AcpPermissionContext } from './permission-context'
 import { ContextUsageTracker, type TokenCounter } from './context-usage-tracker'
 import {
@@ -1665,6 +1666,34 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  const installPromptPlanTestWorkflow = (
+    runtime: AcpRuntime,
+    planService: unknown,
+    sessions = durablePlanSessions()
+  ): void => {
+    const internals = runtime as unknown as {
+      planInteractions: unknown
+      sessionInteractions: unknown
+      artifactTurns: unknown
+      publication: unknown
+      planService: unknown
+      sessionPlanWorkflow: unknown
+    }
+    const sessionPlanWorkflow = composeAcpRuntimePlanWorkflow(
+      { plan: { sessions } } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[0],
+      {
+        planService,
+        planInteractions: internals.planInteractions,
+        sessionInteractions: internals.sessionInteractions,
+        artifactTurns: internals.artifactTurns
+      } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[1],
+      { publication: internals.publication } as unknown as Parameters<
+        typeof composeAcpRuntimePlanWorkflow
+      >[2]
+    )
+    Object.assign(internals, { planService, sessionPlanWorkflow })
+  }
+
   it('activates one interaction before durably approving a restored Plan', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['s1'])
@@ -1680,13 +1709,10 @@ describe('ACP runtime session management', () => {
     const pending = restoredPlanProjection('pending', 4)
     const respond = vi.fn(async () => ({ projection: approved, changed: true }))
     const checkTurnCompletion = vi.fn(async () => ({ allow: true }))
-    Object.assign(runtime as unknown as { planService: unknown }, {
-      planSessions: durablePlanSessions(),
-      planService: {
-        respond,
-        checkTurnCompletion,
-        getProjection: vi.fn(async () => pending)
-      }
+    installPromptPlanTestWorkflow(runtime, {
+      respond,
+      checkTurnCompletion,
+      getProjection: vi.fn(async () => pending)
     })
 
     await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
@@ -1737,10 +1763,7 @@ describe('ACP runtime session management', () => {
     const pending = restoredPlanProjection('pending', 4)
     const getProjection = vi.fn(async () => pending)
     const respond = vi.fn()
-    Object.assign(runtime as unknown as { planService: unknown }, {
-      planSessions: durablePlanSessions(),
-      planService: { getProjection, respond }
-    })
+    installPromptPlanTestWorkflow(runtime, { getProjection, respond })
 
     await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
     await runtime.sendPrompt({
@@ -1796,12 +1819,9 @@ describe('ACP runtime session management', () => {
     const rejected = restoredPlanProjection('rejected', 5)
     const pending = restoredPlanProjection('pending', 4)
     const respond = vi.fn(async () => ({ projection: rejected, changed: true }))
-    Object.assign(runtime as unknown as { planService: unknown }, {
-      planSessions: durablePlanSessions(),
-      planService: {
-        respond,
-        getProjection: vi.fn(async () => pending)
-      }
+    installPromptPlanTestWorkflow(runtime, {
+      respond,
+      getProjection: vi.fn(async () => pending)
     })
 
     await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
@@ -12718,13 +12738,10 @@ describe('ACP runtime session management', () => {
         counts: { phases: 1, delegations: 1, steps: 1, completed: 0, inProgress: 0 }
       } satisfies ActivePlanProjection
       const authorizeContinuation = vi.fn(async () => active)
-      Object.assign(runtime as unknown as { planService: unknown }, {
-        planSessions: durablePlanSessions(),
-        planService: {
-          authorizeContinuation,
-          checkTurnCompletion: vi.fn(async () => ({ allow: true })),
-          getProjection: vi.fn(async () => active)
-        }
+      installPromptPlanTestWorkflow(runtime, {
+        authorizeContinuation,
+        checkTurnCompletion: vi.fn(async () => ({ allow: true })),
+        getProjection: vi.fn(async () => active)
       })
 
       await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
@@ -12765,10 +12782,11 @@ describe('ACP runtime session management', () => {
       framework: opencodeFramework
     })
     const active = restoredPlanProjection('approved', 4)
-    Object.assign(runtime as unknown as { planService: unknown }, {
-      planSessions: durablePlanSessions(['branch-b-root', 'branch-b-message']),
-      planService: { authorizeContinuation: vi.fn(async () => active) }
-    })
+    installPromptPlanTestWorkflow(
+      runtime,
+      { authorizeContinuation: vi.fn(async () => active) },
+      durablePlanSessions(['branch-b-root', 'branch-b-message'])
+    )
 
     await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
     await expect(
@@ -12845,13 +12863,10 @@ describe('ACP runtime session management', () => {
         stepStates: { Analyze: { status: 'not_started' } },
         counts: { phases: 1, delegations: 1, steps: 1, completed: 0, inProgress: 0 }
       } satisfies ActivePlanProjection
-      Object.assign(runtime as unknown as { planService: unknown }, {
-        planSessions: durablePlanSessions(),
-        planService: {
-          authorizeContinuation: vi.fn(async () => authorized),
-          checkTurnCompletion,
-          getProjection
-        }
+      installPromptPlanTestWorkflow(runtime, {
+        authorizeContinuation: vi.fn(async () => authorized),
+        checkTurnCompletion,
+        getProjection
       })
 
       await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -93,13 +93,8 @@ import type { AcpProviderPromptExecutor } from './provider-prompt-executor'
 import type { AcpTurnSkillHooks, AcpTurnSkillOwner } from './turn-skill-owner'
 import type { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import type { PlanResponseResult, PlanService } from '../session-plan/plan-service'
-import type {
-  ActivePlanProjection,
-  GeneratePlanContent,
-  PlanResponseCommand
-} from '../../shared/session-plan/contract'
+import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
 import { PlanCommandError } from '../../shared/session-plan/contract'
-import type { SessionPlanStepStatus } from '../../shared/session-persistence'
 import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
 import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
 import type { AcpRuntimePublicationOwner } from './runtime-publication-owner'
@@ -108,6 +103,11 @@ import type { AcpSessionEnvironmentPolicy } from './session-environment-policy'
 import { composeAcpRuntimeLifecycleOwners } from './runtime-lifecycle-composition'
 import { composeAcpRuntimeProviderSessionOwners } from './runtime-provider-session-composition'
 import { composeAcpRuntimePromptOwners } from './runtime-prompt-composition'
+import {
+  composeAcpRuntimePlanWorkflow,
+  type AcpRuntimePlanWorkflow,
+  type AcpSessionPlanCall
+} from './runtime-plan-composition'
 
 export type AcpRuntimeCallbacks = {
   onStateChanged?: (state: AcpStateSnapshot) => void
@@ -321,7 +321,7 @@ class AcpRuntime {
   private readonly artifactTurns: ArtifactTurnOwner | undefined
   private readonly planInteractions: SessionPlanInteractionOwner
   private readonly planService: PlanService | undefined
-  private readonly planSessions: AcpRuntimePlanOptions['sessions'] | undefined
+  private readonly sessionPlanWorkflow: AcpRuntimePlanWorkflow
   private readonly contextCompactionWorkflow: AcpContextCompactionWorkflow
   private readonly promptTurnWorkflow: AcpPromptTurnWorkflow
   private readonly connectionClose: AcpConnectionCloseWorkflow
@@ -340,7 +340,6 @@ class AcpRuntime {
   ) {
     this.spawnAgent = options.spawnAgent
     this.artifactOptions = options.artifacts
-    this.planSessions = options.plan?.sessions
     this.snapshotOwner = base.snapshotOwner
     this.connectionAdapter = base.connectionAdapter
     this.connectionResources = base.connectionResources
@@ -361,6 +360,7 @@ class AcpRuntime {
     this.permissionContext = session.permissionContext
     this.reviewerSessions = session.reviewerSessions
     this.sessionUpdateProjector = session.sessionUpdateProjector
+    this.sessionPlanWorkflow = composeAcpRuntimePlanWorkflow(options, base, session)
     const prompt = composeAcpRuntimePromptOwners(options, base, session, {
       plan: {
         preflight: (request) => this.preflightPromptPlan(request),
@@ -450,206 +450,19 @@ class AcpRuntime {
     return this.publication.getSnapshot()
   }
 
-  async callSessionPlan(input: {
-    projectId: string
-    sessionId: string
-    operation: 'generate' | 'approve' | 'reject' | 'updateStepStatus'
-    input?: unknown
-  }): Promise<unknown> {
-    const service = this.planService
-    if (!service) throw new Error('Session Plan capability is not configured.')
-    if (input.operation === 'generate') {
-      const interactionId = this.artifactTurns?.promptMessageIdFor(input.sessionId)
-      if (!interactionId) throw new Error('No active interaction can generate a Session Plan.')
-      this.planInteractions.reserveApproval(input.sessionId, interactionId)
-      let result: Awaited<ReturnType<PlanService['generate']>>
-      try {
-        result = await service.generate({
-          projectId: input.projectId,
-          sessionId: input.sessionId,
-          interactionId,
-          content: input.input as GeneratePlanContent
-        })
-      } catch (error) {
-        this.planInteractions.releaseApprovalReservation(input.sessionId, interactionId)
-        const current = await service.getProjection(input.projectId, input.sessionId)
-        if (current) this.publishPlanProjection(input.sessionId, current)
-        throw error
-      }
-      let approval: Promise<unknown>
-      try {
-        approval = this.planInteractions.parkReservedApproval(input.sessionId, interactionId)
-      } catch (error) {
-        this.planInteractions.release(input.sessionId, result.projection.artifactVersionId)
-        throw error
-      }
-      this.publishPlanProjection(input.sessionId, result.projection)
-      return approval
-    }
-    const projection = await service.getProjection(input.projectId, input.sessionId, {
-      interactionIsLive: this.sessionInteractions.current(input.sessionId) !== undefined
-    })
-    if (!projection) throw new Error('The Session has no active Plan.')
-    await this.assertPlanVisibleToDurableBranch(input.projectId, input.sessionId, projection)
-    const identity = {
-      projectId: input.projectId,
-      sessionId: input.sessionId,
-      artifactVersionId: projection.artifactVersionId,
-      expectedRevision: projection.revision
-    }
-    if (input.operation === 'approve' || input.operation === 'reject') {
-      const interactionIsLive = this.sessionInteractions.current(input.sessionId) !== undefined
-      const decision = input.operation === 'approve' ? 'approved' : 'rejected'
-      const executionBinding = this.planInteractions.executionBindingFor(input.sessionId)
-      const result = await service.respond({
-        ...identity,
-        decision,
-        interactionIsLive
-      })
-      if (decision === 'approved') {
-        this.bindPlanExecutionToCurrentInteraction(
-          input.sessionId,
-          result.projection.artifactVersionId
-        )
-      } else {
-        if (executionBinding) {
-          this.planInteractions.releaseExecution(
-            input.sessionId,
-            executionBinding.interactionSequence
-          )
-        }
-      }
-      this.planInteractions.resolveApproval(input.sessionId, result)
-      this.publishPlanProjection(input.sessionId, result.projection)
-      return result
-    }
-    const update = input.input as {
-      title: string
-      status: SessionPlanStepStatus
-      notes?: string
-      expectedArtifactVersionId?: string
-    }
-    if (projection.approval !== 'approved') {
-      throw new PlanCommandError(
-        'plan-not-approved',
-        'The Plan is still pending. Interpret the user Message, then call generate_plan with decision:"approved" or decision:"rejected" before updating steps.'
-      )
-    }
-    const interaction = this.sessionInteractions.current(input.sessionId)
-    const binding = this.planInteractions.executionBindingFor(input.sessionId)
-    if (!binding) {
-      throw new PlanCommandError(
-        'continuation-required',
-        'Continuing this Plan requires an explicit user continuation.'
-      )
-    }
-    if (!interaction || binding.interactionSequence !== interaction.sequence) {
-      throw new PlanCommandError(
-        'interaction-mismatch',
-        'This interaction is not authorized to execute the active Plan.'
-      )
-    }
-    if (
-      binding.artifactVersionId !== projection.artifactVersionId ||
-      (update.expectedArtifactVersionId !== undefined &&
-        update.expectedArtifactVersionId !== binding.artifactVersionId)
-    ) {
-      throw new PlanCommandError(
-        'interaction-mismatch',
-        'This interaction is bound to a different Plan Artifact Version.'
-      )
-    }
-    const result = await service.updateStepStatus({
-      ...identity,
-      artifactVersionId: update.expectedArtifactVersionId ?? identity.artifactVersionId,
-      title: update.title,
-      status: update.status,
-      ...(update.notes ? { notes: update.notes } : {})
-    })
-    this.publishPlanProjection(input.sessionId, result.projection)
-    return result
+  callSessionPlan(input: AcpSessionPlanCall): Promise<unknown> {
+    return this.sessionPlanWorkflow.call(input)
   }
 
   getSessionPlanProjection(
     projectId: string,
     sessionId: string
   ): Promise<ActivePlanProjection | null> {
-    return (
-      this.planService?.getProjection(projectId, sessionId, {
-        interactionIsLive: this.sessionInteractions.current(sessionId) !== undefined
-      }) ?? Promise.resolve(null)
-    )
+    return this.sessionPlanWorkflow.projection(projectId, sessionId)
   }
 
-  async respondSessionPlan(input: PlanResponseCommand): Promise<PlanResponseResult> {
-    if (!this.planService) throw new Error('Session Plan capability is not configured.')
-    if (
-      input.decision === undefined &&
-      !this.planInteractions.approvalInteractionIdFor(input.sessionId)
-    ) {
-      throw new Error('The paused Session Plan interaction is no longer available.')
-    }
-    const interactionIsLive =
-      this.planInteractions.approvalInteractionIdFor(input.sessionId) !== undefined
-    const projection = await this.planService.getProjection(input.projectId, input.sessionId, {
-      interactionIsLive
-    })
-    if (!projection) throw new Error('The Session has no active Plan.')
-    await this.assertPlanVisibleToDurableBranch(input.projectId, input.sessionId, projection)
-    const result = await this.planService.respond({ ...input, interactionIsLive })
-    if ('projection' in result) {
-      if (interactionIsLive && result.projection.approval === 'approved') {
-        this.bindPlanExecutionToCurrentInteraction(
-          input.sessionId,
-          result.projection.artifactVersionId
-        )
-      }
-      if (interactionIsLive) this.planInteractions.resolveApproval(input.sessionId, result)
-      this.publishPlanProjection(input.sessionId, result.projection)
-      return result
-    }
-    if (
-      this.planInteractions.approvalInteractionIdFor(input.sessionId) !==
-      result.routeToInteractionId
-    ) {
-      throw new Error('The paused Session Plan interaction is no longer available.')
-    }
-    try {
-      this.pushEvent({
-        id: `session-user-message-${result.message.id}`,
-        timestamp: result.message.createdAt,
-        kind: 'message',
-        level: 'info',
-        sessionId: input.sessionId,
-        promptMessageId: result.message.responseToMessageId,
-        messageId: result.message.id,
-        role: 'user',
-        text: result.message.content
-      })
-    } catch (error) {
-      safeLogError('Routed user Message projection callback failed', errorLogFields(error))
-    }
-    this.planInteractions.resolveApproval(input.sessionId, result)
-    return result
-  }
-
-  private publishPlanProjection(
-    sessionId: string,
-    projection: import('../../shared/session-plan/contract').ActivePlanProjection
-  ): void {
-    try {
-      this.pushEvent({
-        id: `session-plan-${projection.artifactVersionId}-${projection.revision}`,
-        timestamp: Date.now(),
-        kind: 'plan',
-        level: 'info',
-        sessionId,
-        title: 'Session Plan updated',
-        planProjection: projection
-      })
-    } catch (error) {
-      safeLogError('Session Plan projection callback failed', errorLogFields(error))
-    }
+  respondSessionPlan(input: PlanResponseCommand): Promise<PlanResponseResult> {
+    return this.sessionPlanWorkflow.respond(input)
   }
 
   private async publishTerminalPlanProjection(sessionId: string): Promise<void> {
@@ -660,40 +473,9 @@ class AcpRuntime {
         sessionId,
         { interactionIsLive: false }
       )
-      if (projection) this.publishPlanProjection(sessionId, projection)
+      if (projection) this.sessionPlanWorkflow.publishProjection(sessionId, projection)
     } catch (error) {
       safeLogError('Session Plan terminal projection failed', errorLogFields(error))
-    }
-  }
-
-  private bindPlanExecutionToCurrentInteraction(
-    sessionId: string,
-    artifactVersionId: string
-  ): void {
-    const interaction = this.sessionInteractions.current(sessionId)
-    if (!interaction || interaction.kind !== 'prompt') return
-    this.planInteractions.bindExecution({
-      sessionId,
-      interactionSequence: interaction.sequence,
-      artifactVersionId
-    })
-  }
-
-  private async assertPlanVisibleToDurableBranch(
-    projectId: string,
-    sessionId: string,
-    projection: ActivePlanProjection
-  ): Promise<void> {
-    const origin = projection.originatingPromptMessageId
-    if (
-      !origin ||
-      !this.planSessions ||
-      !(await this.planSessions.containsMessageOnActiveBranch(projectId, sessionId, origin))
-    ) {
-      throw new PlanCommandError(
-        'interaction-mismatch',
-        'The active Session Plan does not belong to the durable active Message Branch.'
-      )
     }
   }
 
@@ -1061,7 +843,7 @@ class AcpRuntime {
         artifactVersionId: continuation.artifactVersionId,
         expectedRevision: continuation.expectedRevision
       }).then(async (authorized) => {
-        await this.assertPlanVisibleToDurableBranch(
+        await this.sessionPlanWorkflow.assertVisibleToDurableBranch(
           continuation.projectId,
           request.sessionId,
           authorized
@@ -1085,7 +867,7 @@ class AcpRuntime {
       if (protectedPending.approval !== 'pending') {
         throw new PlanCommandError('approval-already-decided', 'Plan approval is irreversible.')
       }
-      await this.assertPlanVisibleToDurableBranch(
+      await this.sessionPlanWorkflow.assertVisibleToDurableBranch(
         continuation.projectId,
         request.sessionId,
         protectedPending
@@ -1136,7 +918,7 @@ class AcpRuntime {
           }
         }
         this.planInteractions.resolveApproval(request.sessionId, result)
-        this.publishPlanProjection(request.sessionId, result.projection)
+        this.sessionPlanWorkflow.publishProjection(request.sessionId, result.projection)
         return committed()
       })
     }

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -332,16 +332,23 @@ describe('runtime state ownership architecture', () => {
     }
   })
 
-  it('keeps live Session Plan state behind one Runtime owner', () => {
+  it('keeps live Session Plan state behind one owner and application workflow', () => {
     const runtime = readSource('src/main/acp/runtime.ts')
     const composition = readSource('src/main/acp/runtime-base-composition.ts')
-    const source = runtime + composition
+    const planComposition = readSource('src/main/acp/runtime-plan-composition.ts')
+    const source = runtime + composition + planComposition
 
     expect(source).not.toContain('planApprovalWaiters')
     expect(source).not.toContain('planExecutionBindings')
     expect(source.match(/new SessionPlanInteractionOwner\(\)/g)).toHaveLength(1)
     expect(composition).toContain('interactions: planInteractions')
     expect(runtime).toContain('this.planInteractions = base.planInteractions')
+    expect(runtime).not.toContain('private readonly planSessions')
+    expect(runtime).toContain('composeAcpRuntimePlanWorkflow(options, base, session)')
+    expect(runtime).toContain('return this.sessionPlanWorkflow.call(input)')
+    expect(runtime).toContain('return this.sessionPlanWorkflow.projection(projectId, sessionId)')
+    expect(runtime).toContain('return this.sessionPlanWorkflow.respond(input)')
+    expect(planComposition).not.toMatch(/AcpRuntime\.prototype|from ['"]electron['"]/)
   })
 
   it('keeps model application and attached resume behavior behind their workflows', () => {


### PR DESCRIPTION
## Problem

After Prompt workflow composition, `AcpRuntime` still implemented the complete public Session Plan application policy: generation admission, approval parking, durable-branch authorization, execution binding, feedback routing, step updates, and event projection. Moving that policy together with the Prompt Plan lifecycle would measure roughly 760–820 production raw lines, above the approved Phase 6 limit of 600.

## Proposed change

- Add one frozen `runtime-plan-composition` workflow for the three existing public Plan operations:
  - `callSessionPlan`
  - `getSessionPlanProjection`
  - `respondSessionPlan`
- Derive its dependencies from the authoritative Plan interaction, Plan service, prompt interaction, Artifact turn, durable Session, and publication owners.
- Keep the three `AcpRuntime` methods as signature-compatible facade delegates.
- Reuse the workflow's durable-branch and projection policy from the still-serial Prompt Plan lifecycle until G2 internalizes those callers.
- Replace Runtime private-field Plan test setup with workflow-interface composition.

```mermaid
flowchart LR
  Electron["Electron IPC"] --> Commands["Application commands"]
  Web["Web RPC"] --> Commands
  Task["Task / CLI subset"] --> Commands
  Commands --> Runtime["AcpRuntime facade"]
  Runtime -->|"call / projection / respond"| Plan["Session Plan workflow"]
  Plan --> Service["PlanService"]
  Plan --> Interaction["SessionPlanInteractionOwner"]
  Plan --> Durable["Durable active branch"]
  Plan --> Publication["Runtime publication owner"]
```

This is ARD-28G1, the first approved in-seam split of facade certification. Production raw churn is 503, below 600. Runtime drops from 1,518 to 1,300 lines. G2 will move Prompt Plan preflight/admission/completion/release into the same workflow and bring Runtime below the 1,200 completion gate.

## Scope and non-goals

- No IPC, preload, Web RPC, Task HTTP/WebSocket, CLI/SDK, wire, persistence, schema, or public method change.
- No user interaction, Plan document, approval, feedback, error text/code, or event payload change.
- No change to Session Plan state ownership: `SessionPlanInteractionOwner` remains the sole mutable interaction owner.
- No change to Specialist, Permission, Compute, Notebook, Artifact, or Electron/Web/CLI/Task capability asymmetry.
- No Issue #458 orchestration implementation or public interface.
- Prompt Plan lifecycle remains in Runtime only until the serial G2 cutover; this PR does not create a second state writer.

## Acceptance criteria and validation

All listed checks ran after the final material production/test-seam edit.

- Public Plan workflow and direct construction -> `runtime-plan-composition.test.ts` -> 1/1 passed.
- Plan approval, rejection, feedback, update-step, durable-branch, cancellation, and deletion behavior -> `runtime-session-plan.test.ts` -> 20/20 passed.
- Complete Runtime prompt/Plan consumers, including localhost paths outside the sandbox -> `runtime.test.ts` -> 440/440 passed.
- Runtime Coordinator, transport-neutral application commands, ACP IPC, Prompt composition, and ownership architecture -> focused seven-file set -> 154/154 passed.
- Node interfaces -> `npm run typecheck:node` -> passed.
- Repository standards -> `npm run lint` -> 0 errors; 17 pre-existing unrelated warnings.
- Changed-file formatting and patch hygiene -> Prettier check and `git diff --check` -> passed.
- Independent ownership review -> Standards 0 findings / Spec 0 findings.
- Independent cross-surface compatibility review -> Standards 0 findings / Spec 0 findings.

The final local impact map covers the changed Plan module, Runtime facade, prompt consumer, Coordinator, command adapter, and IPC adapter. Web typecheck and local platform E2E were excluded because no shared/preload/renderer/transport/platform contract changed. Online CI remains authoritative; Linux E2E is explicitly outside this refactor's merge decision.

## Review focus

- Confirm generate ordering remains `reserve -> durable write -> park -> publish`, including both rollback paths.
- Confirm approve/reject ordering remains `durable check -> respond -> bind/release -> resolve -> publish`.
- Confirm feedback validates its route before publishing the user Message and resolving the waiter.
- Confirm Runtime retains only public facade delegation for these three operations and no Plan state was copied.
- Confirm the temporary G1 shared Prompt seam is removed by G2 rather than becoming a general helper interface.

Related: #458
