### PR TITLE
fix(notebook): recover Windows runtime access violations

### DIFF
--- a/scripts/fetch-micromamba.test.ts
+++ b/scripts/fetch-micromamba.test.ts
@@ -24,7 +24,7 @@ describe('micromamba pinning', () => {
 
   it('downloads the pinned archive from the matching official GitHub release', () => {
     expect(resolveDownloadUrl('osx-arm64')).toBe(
-      'https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-osx-arm64.tar.bz2'
+      'https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-1/micromamba-osx-arm64.tar.bz2'
     )
   })
 })

--- a/scripts/micromamba-versions.json
+++ b/scripts/micromamba-versions.json
@@ -9,7 +9,7 @@
     "it may re-package an existing version URL with different bytes and break reproducible builds.",
     "",
     "To repin (bump `version` and `releaseTag`, then regenerate every digest below):",
-    "  tag=2.8.1-0",
+    "  tag=2.8.1-1",
     "  for s in osx-arm64 osx-64 linux-64 linux-aarch64 win-64; do",
     "    curl -fsSL \"https://github.com/mamba-org/micromamba-releases/releases/download/$tag/micromamba-$s.tar.bz2\" | shasum -a 256 | awk -v s=$s '{print s, $1}'",
     "  done",
@@ -17,12 +17,12 @@
     "Before accepting a micromamba bump, revalidate the Windows managed-runtime fixtures for multi-cache search, URL-derived cache layout, and flat-cache fallback with LongPathsEnabled=0."
   ],
   "version": "2.8.1",
-  "releaseTag": "2.8.1-0",
+  "releaseTag": "2.8.1-1",
   "sha256": {
-    "osx-arm64": "a28588c79e96436c2001c87e3b8360bf2eb5c380fb288871389197b9150caf0a",
-    "osx-64": "146abdea8793c6ccf1b8600ae2b03cf2a0f1506a2846eeafc34ae3ebe1123fe6",
-    "linux-64": "a934c3709c997feae403a27fd1e321c106d26ffa4f294800ffb11cbc9a3e8515",
-    "linux-aarch64": "70c60a36609ee8bcc07a3a1a66b2c3a65cff7c1053466963437f1bda72e5210f",
-    "win-64": "8648c6d302bb6d7432e5d620bc862c2be14c00f39ddd7e10c5eb6d73250dbba1"
+    "osx-arm64": "cf94f0d56cd38393ccbe12543e0378f77e6581dee8c4428d1fc563a859a0b070",
+    "osx-64": "cd3c10cec65704c0a96195b46002d45350d0dd43a52d940e9dc17c517b7ee439",
+    "linux-64": "8528263837623551a44464a372e5bd6b0b856479a83d2a77490a19dd98da3b06",
+    "linux-aarch64": "daa4d5c7c5d688ce0deed4ff7887a4ff95429c89d80c76e39ab1ee3d5f66b913",
+    "win-64": "e82874c473688860d087dfe825e1a52ae9deaf8099c7edaf3caff80e2687ed5d"
   }
 }

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -424,7 +424,6 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     expect(events).toContainEqual(
       expect.objectContaining({ message: expect.stringMatching(/repair/i) })
     )
-    expect(existsSync(bin)).toBe(true)
   })
 
   it('re-arms the spawn intent before EACH create attempt (incl. the cache-repair retry)', async () => {

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -382,6 +382,51 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     expect(readReadyMarker(root)?.defaultEnvVersion).toBe(DEFAULT_ENV_VERSION)
   })
 
+  it('repairs and retries after a Windows native access violation leaves an incomplete cache', async () => {
+    const root = makeRoot()
+    const cache = pkgsCache(root)
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(cache, 'interrupted-pkg'), { recursive: true })
+    writeFileSync(join(cache, 'interrupted-pkg', 'partial'), 'x')
+
+    let creates = 0
+    const fetchBundle = vi.fn(async (): Promise<FetchedBundle> => ({
+      lockPath: join(root, 'python-3.12.lock'),
+      pathBudget: { maxCacheRelativePath: 1, maxEnvRelativePath: 1 }
+    }))
+    const runArgv = vi.fn(async () => {
+      creates += 1
+      if (creates === 1) {
+        throw Object.assign(new Error('micromamba failed (exit 3221225477; mm create)'), {
+          code: 'MICROMAMBA_EXIT',
+          data: { argv: ['mm', 'create'], exitCode: 3221225477 }
+        })
+      }
+      expect(existsSync(join(cache, 'interrupted-pkg'))).toBe(false)
+      mkdirSync(dirname(bin), { recursive: true })
+      writeFileSync(bin, 'ok')
+    })
+    const events: ProvisionProgress[] = []
+    const provisioner = new DefaultRuntimeProvisioner(
+      makeDeps(root, {
+        platform: 'win32',
+        cache: { path: cache, lockKey: cache },
+        fetchBundle,
+        runArgv
+      })
+    )
+
+    await provisioner.provisionPython((event) => events.push(event))
+
+    expect(creates).toBe(2)
+    expect(fetchBundle).toHaveBeenCalledTimes(2)
+    expect(events).toContainEqual(
+      expect.objectContaining({ message: expect.stringMatching(/repair/i) })
+    )
+    expect(existsSync(bin)).toBe(true)
+  })
+
   it('re-arms the spawn intent before EACH create attempt (incl. the cache-repair retry)', async () => {
     // A single materialize can spawn twice (create, then retry after a cache repair). The intent must be
     // re-armed before EACH spawn — writing it once per op would leave the first spawn's exited PID in

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -398,11 +398,15 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     const runArgv = vi.fn(async () => {
       creates += 1
       if (creates === 1) {
+        mkdirSync(join(prefix, 'conda-meta'), { recursive: true })
+        mkdirSync(dirname(bin), { recursive: true })
+        writeFileSync(bin, 'partial')
         throw Object.assign(new Error('micromamba failed (exit 3221225477; mm create)'), {
           code: 'MICROMAMBA_EXIT',
           data: { argv: ['mm', 'create'], exitCode: 3221225477 }
         })
       }
+      expect(existsSync(prefix)).toBe(false)
       expect(existsSync(join(cache, 'interrupted-pkg'))).toBe(false)
       mkdirSync(dirname(bin), { recursive: true })
       writeFileSync(bin, 'ok')
@@ -424,6 +428,56 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     expect(events).toContainEqual(
       expect.objectContaining({ message: expect.stringMatching(/repair/i) })
     )
+  })
+
+  it('repairs an access violation from the short-cache MAX_PATH retry', async () => {
+    const root = makeRoot()
+    const cache = pkgsCache(root)
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    const leaf = 'broken-package-1.0-0'
+    const packageDir = join(cache, 'https', 'host', 'channel', 'noarch', leaf)
+    const missing = join(packageDir, 'Library', 'x'.repeat(280))
+    mkdirSync(packageDir, { recursive: true })
+
+    let creates = 0
+    const fetchBundle = vi.fn(async (): Promise<FetchedBundle> => ({
+      lockPath: join(root, 'python-3.12.lock'),
+      pathBudget: { maxCacheRelativePath: 1, maxEnvRelativePath: 1 }
+    }))
+    const runArgv = vi.fn(async () => {
+      creates += 1
+      if (creates === 1) {
+        throw new Error(
+          `Invalid package cache, file '${missing}' is missing for '${leaf}.conda'; Package cache error`
+        )
+      }
+      if (creates === 2) {
+        mkdirSync(join(prefix, 'conda-meta'), { recursive: true })
+        mkdirSync(dirname(bin), { recursive: true })
+        writeFileSync(bin, 'partial')
+        throw Object.assign(new Error('micromamba failed (exit 3221225477; mm create)'), {
+          code: 'MICROMAMBA_EXIT',
+          data: { argv: ['mm', 'create'], exitCode: 3221225477 }
+        })
+      }
+      expect(existsSync(prefix)).toBe(false)
+      mkdirSync(dirname(bin), { recursive: true })
+      writeFileSync(bin, 'ok')
+    })
+    const provisioner = new DefaultRuntimeProvisioner(
+      makeDeps(root, {
+        platform: 'win32',
+        cache: { path: cache, lockKey: cache },
+        fetchBundle,
+        runArgv
+      })
+    )
+
+    await provisioner.provisionPython(() => {})
+
+    expect(creates).toBe(3)
+    expect(fetchBundle).toHaveBeenCalledTimes(2)
   })
 
   it('re-arms the spawn intent before EACH create attempt (incl. the cache-repair retry)', async () => {

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1351,22 +1351,31 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           // shared cache — that would delete other envs' (and the other language's) tarballs needed for
           // offline rebuild. Instead take the cache EXCLUSIVE and remove only INCOMPLETE extracted
           // package dirs (missing info/index.json), preserving every tarball and complete package; then
-          // re-seed and retry the create ONCE. If nothing was incomplete, this isn't a corrupt-cache
-          // fault we can repair, so surface the original error rather than churn. A cancel is never
-          // retried.
+          // re-seed and retry the create ONCE. A Windows native access violation is also recoverable:
+          // it carries no stderr signature, and a transient crash may leave only a partial prefix after
+          // micromamba already removed its cache leaf. Other failures still surface without retrying.
+          const windowsAccessViolation = isWindowsAccessViolationError(
+            error,
+            this.deps.platform ?? process.platform
+          )
           if (
             this.abort?.signal.aborted ||
             error instanceof MaxPathRetryError ||
-            !isCorruptPkgsCacheError(error)
+            (!windowsAccessViolation && !isCorruptPkgsCacheError(error))
           )
             throw error
           const repaired = await withExclusiveCacheLocks(this.cacheLockKeys(selected.cache), () =>
             Promise.resolve(removeIncompleteExtractedPackages(this.cacheRoots(selected.cache)))
           )
-          if (!repaired) throw error
+          // A native access violation has no stderr signature and may happen after micromamba has
+          // already removed its incomplete cache leaf. Retry it once even when there is nothing left
+          // to delete; runCreate still clears the partial prefix before the retry.
+          if (!repaired && !windowsAccessViolation) throw error
           onProgress({
             phase: `create-${spec.language}`,
-            message: `Repairing ${spec.name} package cache…`,
+            message: windowsAccessViolation
+              ? `Repairing ${spec.name} after a Windows runtime crash…`
+              : `Repairing ${spec.name} package cache…`,
             progress: CREATE_FLOOR
           })
           const reseeded = await this.deps.fetchBundle(
@@ -1409,6 +1418,13 @@ const isCorruptPkgsCacheError = (error: unknown): boolean => {
     /error when extracting package/i.test(message) ||
     /remove_all[^]*not empty/i.test(message)
   )
+}
+
+const WINDOWS_STATUS_ACCESS_VIOLATION = 0xc0000005
+const isWindowsAccessViolationError = (error: unknown, platform: NodeJS.Platform): boolean => {
+  if (platform !== 'win32' || !(error instanceof Error)) return false
+  const exitCode = (error as Error & { data?: { exitCode?: unknown } }).data?.exitCode
+  return typeof exitCode === 'number' && exitCode >>> 0 === WINDOWS_STATUS_ACCESS_VIOLATION
 }
 
 // Removes only INCOMPLETE extracted package directories from the shared pkgs cache — a complete conda

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1360,8 +1360,8 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           )
           if (
             this.abort?.signal.aborted ||
-            error instanceof MaxPathRetryError ||
-            (!windowsAccessViolation && !isCorruptPkgsCacheError(error))
+            (!windowsAccessViolation &&
+              (error instanceof MaxPathRetryError || !isCorruptPkgsCacheError(error)))
           )
             throw error
           const repaired = await withExclusiveCacheLocks(this.cacheLockKeys(selected.cache), () =>
@@ -1369,8 +1369,12 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           )
           // A native access violation has no stderr signature and may happen after micromamba has
           // already removed its incomplete cache leaf. Retry it once even when there is nothing left
-          // to delete; runCreate still clears the partial prefix before the retry.
+          // to delete; the failed prefix is cleared below before the retry.
           if (!repaired && !windowsAccessViolation) throw error
+          // Micromamba never reported a successful transaction, so even a prefix that already has
+          // conda-meta + an interpreter may be only partially linked. Do not let clearIncompletePrefix's
+          // normal fast path mistake those two artifacts for a committed environment on the retry.
+          if (windowsAccessViolation) rmSync(prefix, { recursive: true, force: true })
           onProgress({
             phase: `create-${spec.language}`,
             message: windowsAccessViolation
@@ -1424,7 +1428,9 @@ const WINDOWS_STATUS_ACCESS_VIOLATION = 0xc0000005
 const isWindowsAccessViolationError = (error: unknown, platform: NodeJS.Platform): boolean => {
   if (platform !== 'win32' || !(error instanceof Error)) return false
   const exitCode = (error as Error & { data?: { exitCode?: unknown } }).data?.exitCode
-  return typeof exitCode === 'number' && exitCode >>> 0 === WINDOWS_STATUS_ACCESS_VIOLATION
+  if (typeof exitCode === 'number' && exitCode >>> 0 === WINDOWS_STATUS_ACCESS_VIOLATION)
+    return true
+  return error instanceof MaxPathRetryError && isWindowsAccessViolationError(error.cause, platform)
 }
 
 // Removes only INCOMPLETE extracted package directories from the shared pkgs cache — a complete conda


### PR DESCRIPTION
## Problem

Windows managed-runtime creation can terminate with native status `0xC0000005` (`3221225477`). Because that access violation usually has no stderr signature, the existing corrupt-cache recovery does not run. A partial package extraction or prefix can then make **Retry setup** repeat the same failure.

The packaged binary was also pinned to micromamba `2.8.1-0`, before conda-forge's `2.8.1-1` rebuild added the missing static `libpsl` dependency.

## Proposed change

- Repin every packaged micromamba archive to the official `2.8.1-1` release and update all five verified SHA-256 digests.
- Recognize Windows `STATUS_ACCESS_VIOLATION` from structured exit data, including an access violation wrapped by the bounded MAX_PATH recovery.
- Remove only incomplete extracted package directories, preserve complete packages and offline tarballs, and re-seed the verified bundle.
- Discard the failed environment prefix before the access-violation retry even if it already contains `conda-meta` and an interpreter, because micromamba never committed the transaction successfully.
- Retry the access-violation recovery once and keep a repeated failure visible.

The user-visible change is limited to recovery behavior: the first access violation now shows a repair/retry progress state instead of immediately surfacing the raw error. There are no architecture, data-model, data-relation, IPC-contract, or path-migration changes.

## Scope and non-goals

- Does not wipe complete package caches or user-installed packages from committed environments.
- Does not retry arbitrary micromamba failures.
- Does not treat non-Windows exit codes as access violations.
- Does not claim to resolve endpoint-security injection or machine-specific native faults if the bounded retry also fails.

## Acceptance criteria and validation

- Access violation, complete-looking partial prefix, MAX_PATH-wrapped access violation, and unchanged MAX_PATH failure semantics: targeted provisioner regression set -> **4 passed**.
- Micromamba release URL and pin contract: `npm test -- scripts/fetch-micromamba.test.ts` -> **9 passed**.
- Node runtime type boundary: `npm run typecheck:node` -> **passed**.
- Changed-file lint -> **passed**; full lint -> **0 errors** (warnings remain outside this change).
- Official archive integrity: all five `2.8.1-1` archives matched the committed SHA-256 values.
- Packaged runtime behavior: the verified Windows binary ran successfully from a Chinese-character installation path against a real offline explicit lock and cache.
- GitHub CI on final head -> **all required checks passed**, including Unit tests, Coverage macOS, Static checks, Windows core/E2E, Linux E2E, macOS build/E2E, and PR Gate.

The required local full `npm test` was also run. In this restricted Windows host it reported 11,596 passed, 127 failed, and 260 skipped: the sandbox denies short-cache creation, ACL changes, and symlink setup, while several unrelated stress tests time out under full parallel load. The targeted regressions pass, and the independent GitHub multi-platform suite is green.

Path-matrix diagnosis passed for ASCII/Unicode executable and runtime combinations, so this change intentionally does not force users to move installations out of Chinese-character paths.

## Review focus

- Is `0xC0000005` classified only from structured micromamba exit data and only on Windows?
- Does every access-violation recovery discard its uncommitted prefix and get only one clean re-seeded attempt?
- Do non-access-violation MAX_PATH retry failures retain their existing two-attempt bound and diagnostics?
- Do the five pinned digests match the official `2.8.1-1` archives?

Upstream references: [micromamba 2.8.1-1 release](https://github.com/mamba-org/micromamba-releases/releases/tag/2.8.1-1), [conda-forge rebuild adding libpsl](https://github.com/conda-forge/micromamba-feedstock/pull/304).
