### PR TITLE
fix(acp): suppress synthetic Codex compaction warning

### DIFF
--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -210,6 +210,50 @@ describe('AcpSessionUpdateProjector', () => {
     expect(effects.every(Object.isFrozen)).toBe(true)
   })
 
+  it('suppresses only the unscoped Codex compaction warning', () => {
+    const projector = createProjector()
+    const warning =
+      'Warning: Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted.\n\n'
+    const notification: SessionNotification = {
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: warning }
+      }
+    }
+    const routing = {
+      framework: 'codex' as const,
+      eventId: 'event-warning',
+      visible: true,
+      reconnectPending: false,
+      mcpServerNames: []
+    }
+
+    expect(projector.route(notification, routing)).toEqual([])
+    expect(
+      projector.route(
+        {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            messageId: 'model-message',
+            content: { type: 'text', text: warning }
+          }
+        },
+        routing
+      )
+    ).toMatchObject([
+      { kind: 'context-observation' },
+      { kind: 'context-refresh' },
+      { kind: 'visible-event', event: { text: warning } }
+    ])
+    expect(projector.route(notification, { ...routing, framework: 'opencode' })).toMatchObject([
+      { kind: 'context-observation' },
+      { kind: 'context-refresh' },
+      { kind: 'visible-event', event: { text: warning } }
+    ])
+  })
+
   it('projects usage to context state without a visible event and suppresses stale reconnect usage', () => {
     const projector = createProjector()
     const notification: SessionNotification = {

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -252,6 +252,22 @@ describe('AcpSessionUpdateProjector', () => {
       { kind: 'context-refresh' },
       { kind: 'visible-event', event: { text: warning } }
     ])
+    expect(
+      projector.route(
+        {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'user_message_chunk',
+            content: { type: 'text', text: warning }
+          }
+        },
+        routing
+      )
+    ).toMatchObject([
+      { kind: 'context-observation' },
+      { kind: 'context-refresh' },
+      { kind: 'visible-event', event: { text: warning } }
+    ])
   })
 
   it('projects usage to context state without a visible event and suppresses stale reconnect usage', () => {

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -16,6 +16,9 @@ import {
 } from './runtime-events'
 import type { AcpSessionRegistry } from './session-registry'
 
+const CODEX_COMPACTION_WARNING =
+  'Warning: Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted.'
+
 type AcpSessionUpdateRouting = Readonly<{
   framework?: AgentFrameworkId
   appSessionId?: string
@@ -166,6 +169,16 @@ class AcpSessionUpdateProjector {
       )
     )
     const event = deepFreeze(projection.event)
+    // codex-acp 1.1.4 flattens Codex's post-compaction warning into an unscoped assistant chunk.
+    // Keep the separate compaction notice, but do not attribute this adapter-authored warning to the model.
+    if (
+      routing.framework === 'codex' &&
+      event.kind === 'message' &&
+      event.messageId === undefined &&
+      event.text?.trim() === CODEX_COMPACTION_WARNING
+    ) {
+      return Object.freeze([])
+    }
     if (event.contextUsage && routing.reconnectPending) return Object.freeze([])
 
     const effects: AcpSessionUpdateEffect[] = []

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -173,6 +173,7 @@ class AcpSessionUpdateProjector {
     // Keep the separate compaction notice, but do not attribute this adapter-authored warning to the model.
     if (
       routing.framework === 'codex' &&
+      routed.update.sessionUpdate === 'agent_message_chunk' &&
       event.kind === 'message' &&
       event.messageId === undefined &&
       event.text?.trim() === CODEX_COMPACTION_WARNING


### PR DESCRIPTION
## Problem

Native Codex emits a warning after context compaction. `@agentclientprotocol/codex-acp` 1.1.4 flattens that warning into an unscoped `agent_message_chunk`, so Open Science persisted and rendered adapter-authored text as part of the assistant response.

## Proposed change

Suppress the exact known Codex compaction warning at the session update projection boundary only when:

- the active framework is Codex;
- the chunk has no `messageId`; and
- its normalized text exactly matches the upstream warning.

The separate context-compacted notice and all model-scoped/provider messages remain visible.

## Scope and non-goals

- No architecture, data-model, persistence-schema, or ACP protocol changes.
- No renderer or shared-interface changes.
- No change to compaction triggers, token accounting, or prompt continuation.
- Other provider warnings remain untouched; wording changes fail open.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Synthetic Codex warning is suppressed while model-scoped and non-Codex copies remain visible → `npm test -- src/main/acp/session-update-projector.test.ts` → 10/10 passed.
- Electron main-process types remain sound → `npm run typecheck:node` → passed.
- Linted source remains valid → `npm run lint` → 0 errors; 17 pre-existing warnings outside this diff.
- Full portable suite remains green → `npm test` → 802 files passed, 11,799 tests passed; 14 files / 184 tests skipped.

Renderer, preload, shared-contract, and platform lanes are excluded because the final diff changes only main-process projection behavior without changing an interface or adapter schema.

Independent review is pending the PR Reviewer.

## Review focus

Please verify the exact-text and missing-`messageId` guards are narrow enough to avoid suppressing genuine assistant output.
