### PR TITLE
feat(network): offline detection indicator and Network status panel

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -68,6 +68,7 @@ import {
 } from './lifecycle-shutdown'
 import { registerLifecycleIpcHandlers } from './lifecycle-broadcast'
 import { createLogsCommandOwner, registerLogsIpcHandlers } from './logs-ipc'
+import { registerNetworkIpcHandlers } from './network-ipc'
 import { registerWindowIpcHandlers } from './window-ipc'
 import { registerWindowFindIpcHandlers } from './window-find-ipc'
 import { TaskNotificationService } from './notifications/task-notifications'
@@ -1110,6 +1111,7 @@ const createApplicationModules = async (
     registerFileSaveHandlers({ resolveManagedFilePath, resolveSessionArtifactFilePath })
     registerLogsIpcHandlers(logsCommandOwner)
     registerGithubIpcHandlers({}, githubCommandOwner)
+    registerNetworkIpcHandlers()
     registerCliInstallIpcHandlers(cliCommandOwner)
     registerWindowIpcHandlers()
     registerWindowFindIpcHandlers()

--- a/src/main/net/network-info.test.ts
+++ b/src/main/net/network-info.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { NetworkInterfaceInfo } from 'node:os'
+
+import { createConnectionTypeResolver, parseHardwarePorts, selectActiveIpv4 } from './network-info'
+
+const ipv4 = (address: string, internal = false): NetworkInterfaceInfo => ({
+  address,
+  netmask: '255.255.255.0',
+  family: 'IPv4',
+  mac: '00:00:00:00:00:00',
+  internal,
+  cidr: `${address}/24`
+})
+
+const ipv6 = (address: string): NetworkInterfaceInfo => ({
+  address,
+  netmask: 'ffff:ffff:ffff:ffff::',
+  family: 'IPv6',
+  mac: '00:00:00:00:00:00',
+  internal: false,
+  cidr: `${address}/64`,
+  scopeid: 0
+})
+
+const HARDWARE_PORTS_OUTPUT = `Hardware Port: Wi-Fi
+Device: en0
+Hardware Port: Ethernet
+Device: en6
+Hardware Port: Thunderbolt Bridge
+Device: bridge0
+`
+
+describe('selectActiveIpv4', () => {
+  it('returns the first non-internal IPv4 address', () => {
+    const interfaces = {
+      lo0: [ipv4('127.0.0.1', true), ipv6('::1')],
+      en0: [ipv6('fe80::1'), ipv4('192.168.1.10')]
+    }
+    expect(selectActiveIpv4(interfaces)).toBe('192.168.1.10')
+  })
+
+  it('skips interfaces without a non-internal IPv4 address', () => {
+    const interfaces = {
+      lo0: [ipv4('127.0.0.1', true)],
+      utun3: [ipv6('fe80::2')]
+    }
+    expect(selectActiveIpv4(interfaces)).toBeNull()
+  })
+
+  it('returns null when there are no interfaces', () => {
+    expect(selectActiveIpv4({})).toBeNull()
+  })
+})
+
+describe('parseHardwarePorts', () => {
+  it('maps devices to their hardware port names', () => {
+    const ports = parseHardwarePorts(HARDWARE_PORTS_OUTPUT)
+    expect(ports.get('en0')).toBe('Wi-Fi')
+    expect(ports.get('en6')).toBe('Ethernet')
+    expect(ports.get('bridge0')).toBe('Thunderbolt Bridge')
+  })
+
+  it('returns an empty map for empty output', () => {
+    expect(parseHardwarePorts('')).toEqual(new Map())
+  })
+})
+
+// The resolver shells out to networksetup, which only exists on macOS; the injected execFile
+// seam is exercised on darwin only.
+describe('createConnectionTypeResolver', () => {
+  it.runIf(process.platform === 'darwin')('classifies a Wi-Fi hardware port as wifi', async () => {
+    const execFile = vi.fn((_cmd, _args, _options, callback) => {
+      callback(null, HARDWARE_PORTS_OUTPUT, '')
+    })
+    const resolve = createConnectionTypeResolver(execFile as never)
+
+    await expect(resolve({ en0: [ipv4('192.168.1.10')] })).resolves.toBe('wifi')
+  })
+
+  it.runIf(process.platform === 'darwin')(
+    'classifies a non-Wi-Fi active interface as ethernet',
+    async () => {
+      const execFile = vi.fn((_cmd, _args, _options, callback) => {
+        callback(null, HARDWARE_PORTS_OUTPUT, '')
+      })
+      const resolve = createConnectionTypeResolver(execFile as never)
+
+      await expect(resolve({ en6: [ipv4('10.0.0.2')] })).resolves.toBe('ethernet')
+    }
+  )
+
+  it.runIf(process.platform === 'darwin')(
+    'falls back to ethernet when the port lookup fails and caches the attempt',
+    async () => {
+      const execFile = vi.fn((_cmd, _args, _options, callback) => {
+        callback(new Error('not found'), '', '')
+      })
+      const resolve = createConnectionTypeResolver(execFile as never)
+
+      await expect(resolve({ en0: [ipv4('192.168.1.10')] })).resolves.toBe('ethernet')
+      await expect(resolve({ en0: [ipv4('192.168.1.10')] })).resolves.toBe('ethernet')
+      expect(execFile).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it.runIf(process.platform === 'darwin')(
+    'returns unknown when no interface has an active IPv4 address',
+    async () => {
+      const execFile = vi.fn()
+      const resolve = createConnectionTypeResolver(execFile as never)
+
+      await expect(resolve({ lo0: [ipv4('127.0.0.1', true)] })).resolves.toBe('unknown')
+      expect(execFile).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/main/net/network-info.test.ts
+++ b/src/main/net/network-info.test.ts
@@ -3,7 +3,7 @@ import type { NetworkInterfaceInfo } from 'node:os'
 
 import {
   createConnectionTypeResolver,
-  createInternetReachabilityChecker,
+  checkInternetReachability,
   parseHardwarePorts,
   selectActiveIpv4
 } from './network-info'
@@ -121,28 +121,25 @@ describe('createConnectionTypeResolver', () => {
 })
 
 // The checker reuses the onboarding probe; tests inject a fake probe so no real HTTPS happens.
-describe('createInternetReachabilityChecker', () => {
+describe('checkInternetReachability', () => {
   it('is reachable when any registry probe succeeds', async () => {
     const probe = vi.fn((registry: string) =>
       registry === 'npmjs' ? Promise.reject(new Error('down')) : Promise.resolve(12)
     )
-    const check = createInternetReachabilityChecker(probe as never)
 
-    await expect(check()).resolves.toBe(true)
+    await expect(checkInternetReachability(probe as never)).resolves.toBe(true)
   })
 
   it('is unreachable when every registry probe fails', async () => {
     const probe = vi.fn(() => Promise.reject(new Error('down')))
-    const check = createInternetReachabilityChecker(probe as never)
 
-    await expect(check()).resolves.toBe(false)
+    await expect(checkInternetReachability(probe as never)).resolves.toBe(false)
   })
 
   it('probes every registry', async () => {
     const probe = vi.fn(() => Promise.resolve(5))
-    const check = createInternetReachabilityChecker(probe as never)
 
-    await expect(check()).resolves.toBe(true)
+    await expect(checkInternetReachability(probe as never)).resolves.toBe(true)
     expect(probe).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/net/network-info.test.ts
+++ b/src/main/net/network-info.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { NetworkInterfaceInfo } from 'node:os'
 
-import { createConnectionTypeResolver, parseHardwarePorts, selectActiveIpv4 } from './network-info'
+import {
+  createConnectionTypeResolver,
+  createInternetReachabilityChecker,
+  parseHardwarePorts,
+  selectActiveIpv4
+} from './network-info'
 
 const ipv4 = (address: string, internal = false): NetworkInterfaceInfo => ({
   address,
@@ -113,4 +118,31 @@ describe('createConnectionTypeResolver', () => {
       expect(execFile).not.toHaveBeenCalled()
     }
   )
+})
+
+// The checker reuses the onboarding probe; tests inject a fake probe so no real HTTPS happens.
+describe('createInternetReachabilityChecker', () => {
+  it('is reachable when any registry probe succeeds', async () => {
+    const probe = vi.fn((registry: string) =>
+      registry === 'npmjs' ? Promise.reject(new Error('down')) : Promise.resolve(12)
+    )
+    const check = createInternetReachabilityChecker(probe as never)
+
+    await expect(check()).resolves.toBe(true)
+  })
+
+  it('is unreachable when every registry probe fails', async () => {
+    const probe = vi.fn(() => Promise.reject(new Error('down')))
+    const check = createInternetReachabilityChecker(probe as never)
+
+    await expect(check()).resolves.toBe(false)
+  })
+
+  it('probes every registry', async () => {
+    const probe = vi.fn(() => Promise.resolve(5))
+    const check = createInternetReachabilityChecker(probe as never)
+
+    await expect(check()).resolves.toBe(true)
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/main/net/network-info.ts
+++ b/src/main/net/network-info.ts
@@ -1,0 +1,92 @@
+import { execFile } from 'node:child_process'
+import { networkInterfaces } from 'node:os'
+
+import type { NetworkConnectionType, NetworkInfo } from '../../shared/network'
+
+type NetworkInterfaceMap = ReturnType<typeof networkInterfaces>
+
+// First non-internal IPv4 address across the active interfaces. Internal (loopback) and
+// IPv6-only interfaces are skipped; a machine with no such interface is treated as unknown.
+const selectActiveIpv4 = (interfaces: NetworkInterfaceMap): string | null => {
+  for (const addresses of Object.values(interfaces)) {
+    const ipv4 = addresses?.find((address) => address.family === 'IPv4' && !address.internal)
+    if (ipv4) return ipv4.address
+  }
+  return null
+}
+
+// Parses `networksetup -listallhardwareports` output into device -> hardware port name pairs,
+// e.g. "Hardware Port: Wi-Fi\nDevice: en0" maps en0 to "Wi-Fi".
+const parseHardwarePorts = (output: string): Map<string, string> => {
+  const ports = new Map<string, string>()
+  let currentPort: string | null = null
+
+  for (const line of output.split('\n')) {
+    const portMatch = /^Hardware Port: (.+)$/.exec(line.trim())
+    const deviceMatch = /^Device: (.+)$/.exec(line.trim())
+    if (portMatch) {
+      currentPort = portMatch[1]
+    } else if (deviceMatch && currentPort !== null) {
+      ports.set(deviceMatch[1], currentPort)
+      currentPort = null
+    }
+  }
+
+  return ports
+}
+
+// macOS-only classification: the active IPv4 interface's device is looked up in the hardware
+// port map. A "Wi-Fi" port means wifi; any other active interface is assumed ethernet. The
+// hardware port list is exec'd once and the promise cached. On other platforms (or when the
+// lookup fails) classification is unknown.
+const createConnectionTypeResolver = (
+  execFileFn: typeof execFile = execFile
+): ((interfaces: NetworkInterfaceMap) => Promise<NetworkConnectionType>) => {
+  if (process.platform !== 'darwin') {
+    return () => Promise.resolve('unknown')
+  }
+
+  let cachedPorts: Promise<Map<string, string>> | null = null
+  const hardwarePorts = (): Promise<Map<string, string>> => {
+    if (!cachedPorts) {
+      cachedPorts = new Promise((resolve) => {
+        execFileFn(
+          'networksetup',
+          ['-listallhardwareports'],
+          { timeout: 5000 },
+          (error, stdout) => {
+            resolve(error ? new Map() : parseHardwarePorts(stdout))
+          }
+        )
+      })
+    }
+    return cachedPorts
+  }
+
+  return async (interfaces) => {
+    for (const [name, addresses] of Object.entries(interfaces)) {
+      const hasActiveIpv4 = addresses?.some(
+        (address) => address.family === 'IPv4' && !address.internal
+      )
+      if (!hasActiveIpv4) continue
+
+      const portName = (await hardwarePorts()).get(name)
+      if (portName === undefined) return 'ethernet'
+      return portName.includes('Wi-Fi') ? 'wifi' : 'ethernet'
+    }
+    return 'unknown'
+  }
+}
+
+const resolveConnectionType = createConnectionTypeResolver()
+
+const getNetworkInfo = async (): Promise<NetworkInfo> => {
+  const interfaces = networkInterfaces()
+  const ipAddress = selectActiveIpv4(interfaces)
+
+  if (ipAddress === null) return { connectionType: 'unknown', ipAddress: null }
+
+  return { connectionType: await resolveConnectionType(interfaces), ipAddress }
+}
+
+export { getNetworkInfo, selectActiveIpv4, parseHardwarePorts, createConnectionTypeResolver }

--- a/src/main/net/network-info.ts
+++ b/src/main/net/network-info.ts
@@ -13,21 +13,19 @@ type RegistryProbe = typeof probeRegistryReachability
 // probe against both package registries (registry root this time — the question here is "is the
 // internet usable", not "can we download a specific runtime package"). Reachable when either
 // registry answers 2xx; each probe carries the probe's own 5s timeout and they run in parallel.
-const createInternetReachabilityChecker =
-  (probe: RegistryProbe = probeRegistryReachability): (() => Promise<boolean>) =>
-  () => {
-    const registries = Object.keys(REGISTRY_URLS) as ManagedClaudeRegistry[]
-    return Promise.all(
-      registries.map((registry) =>
-        probe(registry).then(
-          () => true,
-          () => false
-        )
+const checkInternetReachability = (
+  probe: RegistryProbe = probeRegistryReachability
+): Promise<boolean> => {
+  const registries = Object.keys(REGISTRY_URLS) as ManagedClaudeRegistry[]
+  return Promise.all(
+    registries.map((registry) =>
+      probe(registry).then(
+        () => true,
+        () => false
       )
-    ).then((results) => results.some(Boolean))
-  }
-
-const checkInternetReachability = createInternetReachabilityChecker()
+    )
+  ).then((results) => results.some(Boolean))
+}
 
 // First non-internal IPv4 address across the active interfaces. Internal (loopback) and
 // IPv6-only interfaces are skipped; a machine with no such interface is treated as unknown.
@@ -118,6 +116,5 @@ export {
   selectActiveIpv4,
   parseHardwarePorts,
   createConnectionTypeResolver,
-  createInternetReachabilityChecker,
   checkInternetReachability
 }

--- a/src/main/net/network-info.ts
+++ b/src/main/net/network-info.ts
@@ -19,7 +19,7 @@ const createInternetReachabilityChecker =
     const registries = Object.keys(REGISTRY_URLS) as ManagedClaudeRegistry[]
     return Promise.all(
       registries.map((registry) =>
-        probe(registry, '').then(
+        probe(registry).then(
           () => true,
           () => false
         )

--- a/src/main/net/network-info.ts
+++ b/src/main/net/network-info.ts
@@ -2,8 +2,32 @@ import { execFile } from 'node:child_process'
 import { networkInterfaces } from 'node:os'
 
 import type { NetworkConnectionType, NetworkInfo } from '../../shared/network'
+import type { ManagedClaudeRegistry } from '../../shared/settings'
+import { REGISTRY_URLS, probeRegistryReachability } from '../settings/environment-check'
 
 type NetworkInterfaceMap = ReturnType<typeof networkInterfaces>
+
+type RegistryProbe = typeof probeRegistryReachability
+
+// Real end-to-end internet reachability, reusing the onboarding environment check's HTTPS HEAD
+// probe against both package registries (registry root this time — the question here is "is the
+// internet usable", not "can we download a specific runtime package"). Reachable when either
+// registry answers 2xx; each probe carries the probe's own 5s timeout and they run in parallel.
+const createInternetReachabilityChecker =
+  (probe: RegistryProbe = probeRegistryReachability): (() => Promise<boolean>) =>
+  () => {
+    const registries = Object.keys(REGISTRY_URLS) as ManagedClaudeRegistry[]
+    return Promise.all(
+      registries.map((registry) =>
+        probe(registry, '').then(
+          () => true,
+          () => false
+        )
+      )
+    ).then((results) => results.some(Boolean))
+  }
+
+const checkInternetReachability = createInternetReachabilityChecker()
 
 // First non-internal IPv4 address across the active interfaces. Internal (loopback) and
 // IPv6-only interfaces are skipped; a machine with no such interface is treated as unknown.
@@ -89,4 +113,11 @@ const getNetworkInfo = async (): Promise<NetworkInfo> => {
   return { connectionType: await resolveConnectionType(interfaces), ipAddress }
 }
 
-export { getNetworkInfo, selectActiveIpv4, parseHardwarePorts, createConnectionTypeResolver }
+export {
+  getNetworkInfo,
+  selectActiveIpv4,
+  parseHardwarePorts,
+  createConnectionTypeResolver,
+  createInternetReachabilityChecker,
+  checkInternetReachability
+}

--- a/src/main/network-ipc.test.ts
+++ b/src/main/network-ipc.test.ts
@@ -20,17 +20,22 @@ describe('network IPC handler', () => {
   it('delegates to an injected owner instance', async () => {
     handlers.clear()
     const info = { connectionType: 'wifi', ipAddress: '192.168.1.42' } as const
-    const owner: NetworkCommandOwner = { getInfo: vi.fn().mockResolvedValue(info) }
+    const owner: NetworkCommandOwner = {
+      getInfo: vi.fn().mockResolvedValue(info),
+      checkConnectivity: vi.fn().mockResolvedValue(false)
+    }
 
     expect(registerNetworkIpcHandlers(owner)).toBe(owner)
     await expect(invoke('network:get-info')).resolves.toEqual(info)
+    await expect(invoke('network:check-connectivity')).resolves.toBe(false)
   })
 
-  it('registers the get-info channel', () => {
+  it('registers both network channels', () => {
     handlers.clear()
     registerNetworkIpcHandlers()
 
     expect(handlers.has('network:get-info')).toBe(true)
+    expect(handlers.has('network:check-connectivity')).toBe(true)
   })
 
   it('default owner answers from local interface state', async () => {
@@ -38,7 +43,8 @@ describe('network IPC handler', () => {
     registerNetworkIpcHandlers()
 
     // No Electron app or network access needed: the default owner reads os.networkInterfaces(),
-    // so any machine (including CI) answers with the NetworkInfo shape.
+    // so any machine (including CI) answers with the NetworkInfo shape. checkConnectivity is
+    // deliberately not invoked here — the default owner would issue real HTTPS probes.
     await expect(invoke('network:get-info')).resolves.toMatchObject({
       connectionType: expect.stringMatching(/^(wifi|ethernet|unknown)$/)
     })

--- a/src/main/network-ipc.test.ts
+++ b/src/main/network-ipc.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Capture ipcMain.handle registrations so the handler can be invoked directly.
+const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown, payload: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }
+  }
+}))
+
+const { registerNetworkIpcHandlers } = await import('./network-ipc')
+type NetworkCommandOwner = import('./network-ipc').NetworkCommandOwner
+
+const invoke = (channel: string): unknown => handlers.get(channel)!(undefined, undefined)
+
+describe('network IPC handler', () => {
+  it('delegates to an injected owner instance', async () => {
+    handlers.clear()
+    const info = { connectionType: 'wifi', ipAddress: '192.168.1.42' } as const
+    const owner: NetworkCommandOwner = { getInfo: vi.fn().mockResolvedValue(info) }
+
+    expect(registerNetworkIpcHandlers(owner)).toBe(owner)
+    await expect(invoke('network:get-info')).resolves.toEqual(info)
+  })
+
+  it('registers the get-info channel', () => {
+    handlers.clear()
+    registerNetworkIpcHandlers()
+
+    expect(handlers.has('network:get-info')).toBe(true)
+  })
+
+  it('default owner answers from local interface state', async () => {
+    handlers.clear()
+    registerNetworkIpcHandlers()
+
+    // No Electron app or network access needed: the default owner reads os.networkInterfaces(),
+    // so any machine (including CI) answers with the NetworkInfo shape.
+    await expect(invoke('network:get-info')).resolves.toMatchObject({
+      connectionType: expect.stringMatching(/^(wifi|ethernet|unknown)$/)
+    })
+  })
+})

--- a/src/main/network-ipc.ts
+++ b/src/main/network-ipc.ts
@@ -1,21 +1,27 @@
 import { ipcMainHandle } from './ipc-handler-registry'
 
-import { getNetworkInfo } from './net/network-info'
+import { checkInternetReachability, getNetworkInfo } from './net/network-info'
 
 import type { NetworkInfo } from '../shared/network'
 
-type NetworkCommandOwner = Readonly<{ getInfo: () => Promise<NetworkInfo> }>
+type NetworkCommandOwner = Readonly<{
+  getInfo: () => Promise<NetworkInfo>
+  checkConnectivity: () => Promise<boolean>
+}>
 
-// Local network interface snapshot for the settings Network panel. Best-effort: the OS
-// answers from local state, so no internet access is required and failures are unlikely.
+// Network status for the settings Network panel. getInfo answers from local OS state (no
+// internet required); checkConnectivity is a real end-to-end HTTPS probe reused from the
+// onboarding environment check, so it can tell "internet broken" apart from "link is up".
 const createNetworkCommandOwner = (): NetworkCommandOwner => ({
-  getInfo: () => getNetworkInfo()
+  getInfo: () => getNetworkInfo(),
+  checkConnectivity: () => checkInternetReachability()
 })
 
 const registerNetworkIpcHandlers = (
   owner: NetworkCommandOwner = createNetworkCommandOwner()
 ): NetworkCommandOwner => {
   ipcMainHandle('network:get-info', () => owner.getInfo())
+  ipcMainHandle('network:check-connectivity', () => owner.checkConnectivity())
   return owner
 }
 

--- a/src/main/network-ipc.ts
+++ b/src/main/network-ipc.ts
@@ -13,8 +13,8 @@ type NetworkCommandOwner = Readonly<{
 // internet required); checkConnectivity is a real end-to-end HTTPS probe reused from the
 // onboarding environment check, so it can tell "internet broken" apart from "link is up".
 const createNetworkCommandOwner = (): NetworkCommandOwner => ({
-  getInfo: () => getNetworkInfo(),
-  checkConnectivity: () => checkInternetReachability()
+  getInfo: getNetworkInfo,
+  checkConnectivity: checkInternetReachability
 })
 
 const registerNetworkIpcHandlers = (

--- a/src/main/network-ipc.ts
+++ b/src/main/network-ipc.ts
@@ -1,0 +1,23 @@
+import { ipcMainHandle } from './ipc-handler-registry'
+
+import { getNetworkInfo } from './net/network-info'
+
+import type { NetworkInfo } from '../shared/network'
+
+type NetworkCommandOwner = Readonly<{ getInfo: () => Promise<NetworkInfo> }>
+
+// Local network interface snapshot for the settings Network panel. Best-effort: the OS
+// answers from local state, so no internet access is required and failures are unlikely.
+const createNetworkCommandOwner = (): NetworkCommandOwner => ({
+  getInfo: () => getNetworkInfo()
+})
+
+const registerNetworkIpcHandlers = (
+  owner: NetworkCommandOwner = createNetworkCommandOwner()
+): NetworkCommandOwner => {
+  ipcMainHandle('network:get-info', () => owner.getInfo())
+  return owner
+}
+
+export type { NetworkCommandOwner }
+export { registerNetworkIpcHandlers, createNetworkCommandOwner }

--- a/src/main/settings/environment-check.ts
+++ b/src/main/settings/environment-check.ts
@@ -33,7 +33,7 @@ const REGISTRY_PROBE_PATHS: Record<AgentFrameworkId, string> = {
 }
 const REGISTRY_PROBE_TIMEOUT_MS = 5_000
 
-type RegistryProbe = (registry: ManagedClaudeRegistry, packagePath: string) => Promise<number>
+type RegistryProbe = (registry: ManagedClaudeRegistry, packagePath?: string) => Promise<number>
 
 export type EnvironmentCheckDeps = {
   platform?: NodeJS.Platform
@@ -72,8 +72,9 @@ const verifyStorageAccess = async (storageRoot: string): Promise<void> => {
 }
 
 // Uses the same direct HTTPS route as the managed downloader and follows a small number of redirects.
-// A HEAD request keeps the required basic source check lightweight on every startup.
-const probeRegistryReachability: RegistryProbe = (registry, packagePath) => {
+// A HEAD request keeps the required basic source check lightweight on every startup. Omitting
+// packagePath probes the registry root, which answers plain internet reachability.
+const probeRegistryReachability: RegistryProbe = (registry, packagePath = '') => {
   const startedAt = Date.now()
 
   return new Promise<number>((resolve, reject) => {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -289,6 +289,7 @@ describe('preload bridge — public surface inventory', () => {
       'logs.getPath',
       'logs.openFile',
       'logs.revealInFolder',
+      'network.checkConnectivity',
       'network.getInfo',
       'notebook.appendCodeCell',
       'notebook.beginCodeCell',
@@ -617,7 +618,7 @@ describe('preload bridge — runtime renderer contract catalog', () => {
 })
 
 describe('preload bridge — core renderer contract catalog', () => {
-  it('pins the exact 22-group, 134-callable T1d complement', () => {
+  it('pins the exact 22-group, 135-callable T1d complement', () => {
     expect(coreContractGroups.map(({ capability }) => capability)).toEqual([
       'artifacts',
       'cli',
@@ -642,7 +643,7 @@ describe('preload bridge — core renderer contract catalog', () => {
       'uploads',
       'window'
     ])
-    expect(coreContracts).toHaveLength(134)
+    expect(coreContracts).toHaveLength(135)
     expect({
       requests: coreContracts.filter(
         ({ dispatchPolicy }) => dispatchPolicy.electron === 'electron-ipc-request'
@@ -654,16 +655,16 @@ describe('preload bridge — core renderer contract catalog', () => {
       surfaceNative: coreContracts.filter(
         ({ dispatchPolicy }) => dispatchPolicy.electron === 'surface-native'
       ).length
-    }).toEqual({ requests: 98, events: 25, sends: 10, surfaceNative: 1 })
+    }).toEqual({ requests: 99, events: 25, sends: 10, surfaceNative: 1 })
   })
 
-  it('routes all 98 request methods through their cataloged Electron channels', async () => {
+  it('routes all 99 request methods through their cataloged Electron channels', async () => {
     const requestContracts = coreContracts.filter(
       ({ dispatchPolicy }) => dispatchPolicy.electron === 'electron-ipc-request'
     )
     const localFile = { name: 'catalog.csv' } as File
 
-    expect(requestContracts).toHaveLength(98)
+    expect(requestContracts).toHaveLength(99)
 
     for (const contract of requestContracts) {
       invokeMock.mockClear()

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -289,6 +289,7 @@ describe('preload bridge — public surface inventory', () => {
       'logs.getPath',
       'logs.openFile',
       'logs.revealInFolder',
+      'network.getInfo',
       'notebook.appendCodeCell',
       'notebook.beginCodeCell',
       'notebook.execute',
@@ -616,7 +617,7 @@ describe('preload bridge — runtime renderer contract catalog', () => {
 })
 
 describe('preload bridge — core renderer contract catalog', () => {
-  it('pins the exact 21-group, 133-callable T1d complement', () => {
+  it('pins the exact 22-group, 134-callable T1d complement', () => {
     expect(coreContractGroups.map(({ capability }) => capability)).toEqual([
       'artifacts',
       'cli',
@@ -625,6 +626,7 @@ describe('preload bridge — core renderer contract catalog', () => {
       'lifecycle',
       'local-fs',
       'logs',
+      'network',
       'notifications',
       'office-preview',
       'platform-file-save',
@@ -640,7 +642,7 @@ describe('preload bridge — core renderer contract catalog', () => {
       'uploads',
       'window'
     ])
-    expect(coreContracts).toHaveLength(133)
+    expect(coreContracts).toHaveLength(134)
     expect({
       requests: coreContracts.filter(
         ({ dispatchPolicy }) => dispatchPolicy.electron === 'electron-ipc-request'
@@ -652,16 +654,16 @@ describe('preload bridge — core renderer contract catalog', () => {
       surfaceNative: coreContracts.filter(
         ({ dispatchPolicy }) => dispatchPolicy.electron === 'surface-native'
       ).length
-    }).toEqual({ requests: 97, events: 25, sends: 10, surfaceNative: 1 })
+    }).toEqual({ requests: 98, events: 25, sends: 10, surfaceNative: 1 })
   })
 
-  it('routes all 97 request methods through their cataloged Electron channels', async () => {
+  it('routes all 98 request methods through their cataloged Electron channels', async () => {
     const requestContracts = coreContracts.filter(
       ({ dispatchPolicy }) => dispatchPolicy.electron === 'electron-ipc-request'
     )
     const localFile = { name: 'catalog.csv' } as File
 
-    expect(requestContracts).toHaveLength(97)
+    expect(requestContracts).toHaveLength(98)
 
     for (const contract of requestContracts) {
       invokeMock.mockClear()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -375,7 +375,8 @@ const api: OpenScienceAPI = {
     getStars: () => electronRendererContracts.invoke('github.getStars')
   },
   network: {
-    getInfo: () => electronRendererContracts.invoke('network.getInfo')
+    getInfo: () => electronRendererContracts.invoke('network.getInfo'),
+    checkConnectivity: () => electronRendererContracts.invoke('network.checkConnectivity')
   },
   cli: {
     getStatus: () => electronRendererContracts.invoke('cli.getStatus'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -374,6 +374,9 @@ const api: OpenScienceAPI = {
   github: {
     getStars: () => electronRendererContracts.invoke('github.getStars')
   },
+  network: {
+    getInfo: () => electronRendererContracts.invoke('network.getInfo')
+  },
   cli: {
     getStatus: () => electronRendererContracts.invoke('cli.getStatus'),
     install: () => electronRendererContracts.invoke('cli.install'),

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -244,6 +244,7 @@ import type {
   ValidateProviderResult
 } from '../shared/settings'
 import type { PackageMirror } from '../shared/mirror'
+import type { NetworkInfo } from '../shared/network'
 import type {
   ActiveSessionInfo,
   DataRootInspection,
@@ -534,6 +535,9 @@ export interface OpenScienceAPI {
   }
   github: {
     getStars(): Promise<number | null>
+  }
+  network: {
+    getInfo(): Promise<NetworkInfo>
   }
   cli: {
     getStatus(): Promise<CliLauncherStatus>

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -538,6 +538,7 @@ export interface OpenScienceAPI {
   }
   network: {
     getInfo(): Promise<NetworkInfo>
+    checkConnectivity(): Promise<boolean>
   }
   cli: {
     getStatus(): Promise<CliLauncherStatus>

--- a/src/renderer/src/components/NetworkStatusIndicator.render.test.tsx
+++ b/src/renderer/src/components/NetworkStatusIndicator.render.test.tsx
@@ -1,14 +1,18 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 
 import { NetworkStatusIndicator } from './NetworkStatusIndicator'
-import { useNetworkStore } from '@/stores/network-store'
+import { startNetworkMonitor, useNetworkStore } from '@/stores/network-store'
 import { useSettingsStore } from '@/stores/settings-store'
 
 let container: HTMLDivElement
 let root: Root
+
+beforeAll(() => {
+  startNetworkMonitor()
+})
 
 beforeEach(() => {
   container = document.createElement('div')

--- a/src/renderer/src/components/NetworkStatusIndicator.render.test.tsx
+++ b/src/renderer/src/components/NetworkStatusIndicator.render.test.tsx
@@ -19,7 +19,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount())
   container.remove()
-  useNetworkStore.setState({ isOnline: true })
+  useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })
   useSettingsStore.setState({ isSettingsOpen: false, pendingSettingsPanel: undefined })
 })
 
@@ -85,6 +85,28 @@ describe('NetworkStatusIndicator', () => {
     await act(async () => {
       window.dispatchEvent(new Event('online'))
     })
+    expect(container.querySelector('button')).toBeNull()
+  })
+
+  it('renders the amber unreachable pill when the link is up but the internet is unreachable', async () => {
+    useNetworkStore.setState({ isOnline: true, connectivity: 'unreachable' })
+
+    await act(async () => {
+      root.render(<NetworkStatusIndicator variant="pill" />)
+    })
+
+    const button = container.querySelector('button')
+    expect(button?.getAttribute('aria-label')).toBe('Internet unreachable')
+    expect(button?.textContent).toContain('Unreachable')
+  })
+
+  it('renders nothing while the internet is reachable', async () => {
+    useNetworkStore.setState({ isOnline: true, connectivity: 'reachable' })
+
+    await act(async () => {
+      root.render(<NetworkStatusIndicator variant="pill" />)
+    })
+
     expect(container.querySelector('button')).toBeNull()
   })
 })

--- a/src/renderer/src/components/NetworkStatusIndicator.render.test.tsx
+++ b/src/renderer/src/components/NetworkStatusIndicator.render.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { NetworkStatusIndicator } from './NetworkStatusIndicator'
+import { useNetworkStore } from '@/stores/network-store'
+import { useSettingsStore } from '@/stores/settings-store'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  useNetworkStore.setState({ isOnline: true })
+  useSettingsStore.setState({ isSettingsOpen: false, pendingSettingsPanel: undefined })
+})
+
+describe('NetworkStatusIndicator', () => {
+  it('renders nothing while online', async () => {
+    useNetworkStore.setState({ isOnline: true })
+
+    await act(async () => {
+      root.render(<NetworkStatusIndicator variant="pill" />)
+    })
+
+    expect(container.querySelector('button')).toBeNull()
+  })
+
+  it('renders the offline pill with a label', async () => {
+    useNetworkStore.setState({ isOnline: false })
+
+    await act(async () => {
+      root.render(<NetworkStatusIndicator variant="pill" />)
+    })
+
+    const button = container.querySelector('button')
+    expect(button?.getAttribute('aria-label')).toBe('No internet connection')
+    expect(button?.textContent).toContain('Offline')
+  })
+
+  it('renders the icon variant without a label', async () => {
+    useNetworkStore.setState({ isOnline: false })
+
+    await act(async () => {
+      root.render(<NetworkStatusIndicator variant="icon" />)
+    })
+
+    const button = container.querySelector('button')
+    expect(button?.getAttribute('aria-label')).toBe('No internet connection')
+    expect(button?.textContent).not.toContain('Offline')
+  })
+
+  it('opens the settings Network panel on click', async () => {
+    useNetworkStore.setState({ isOnline: false })
+
+    await act(async () => {
+      root.render(<NetworkStatusIndicator variant="pill" />)
+    })
+
+    const button = container.querySelector('button') as HTMLButtonElement
+    await act(async () => {
+      button.click()
+    })
+
+    expect(useSettingsStore.getState().isSettingsOpen).toBe(true)
+    expect(useSettingsStore.getState().pendingSettingsPanel).toBe('network')
+  })
+
+  it('disappears when connectivity recovers', async () => {
+    useNetworkStore.setState({ isOnline: false })
+
+    await act(async () => {
+      root.render(<NetworkStatusIndicator variant="pill" />)
+    })
+    expect(container.querySelector('button')).not.toBeNull()
+
+    await act(async () => {
+      window.dispatchEvent(new Event('online'))
+    })
+    expect(container.querySelector('button')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/NetworkStatusIndicator.tsx
+++ b/src/renderer/src/components/NetworkStatusIndicator.tsx
@@ -10,15 +10,21 @@ type NetworkStatusIndicatorProps = {
   variant: 'pill' | 'icon'
 }
 
-// Offline warning entry point. Renders nothing while online; when offline, clicking opens
-// the settings Network panel for troubleshooting.
+// Offline / unreachable warning entry point. Renders nothing while the internet is genuinely
+// reachable; a missing link shows red ("Offline"), a live link with a broken path out shows
+// amber ("Unreachable"). Clicking opens the settings Network panel for troubleshooting.
 const NetworkStatusIndicator = ({
   variant
 }: NetworkStatusIndicatorProps): React.JSX.Element | null => {
   const isOnline = useNetworkStore((state) => state.isOnline)
+  const connectivity = useNetworkStore((state) => state.connectivity)
   const openSettingsToPanel = useSettingsStore((state) => state.openSettingsToPanel)
 
-  if (isOnline) return null
+  if (isOnline && connectivity !== 'unreachable') return null
+
+  const warning = isOnline // online but unreachable: amber instead of red
+  const label = warning ? 'Internet unreachable' : 'No internet connection'
+  const text = warning ? 'Unreachable' : 'Offline'
 
   return (
     <TooltipProvider delayDuration={300}>
@@ -27,11 +33,15 @@ const NetworkStatusIndicator = ({
           <button
             type="button"
             onClick={() => openSettingsToPanel('network')}
-            aria-label="No internet connection"
+            aria-label={label}
             className={
               variant === 'pill'
-                ? 'inline-flex h-8 items-center gap-1 rounded-full border border-danger-000/20 bg-danger-000/10 px-2.5 text-xs font-medium text-danger-000 transition-colors duration-150 ease-out hover:border-danger-000/30 hover:bg-danger-000/15'
-                : 'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-danger-000 transition-colors duration-150 ease-out hover:bg-danger-900'
+                ? warning
+                  ? 'inline-flex h-8 items-center gap-1 rounded-full border border-session-waiting/20 bg-session-waiting/10 px-2.5 text-xs font-medium text-session-waiting transition-colors duration-150 ease-out hover:border-session-waiting/30 hover:bg-session-waiting/15'
+                  : 'inline-flex h-8 items-center gap-1 rounded-full border border-danger-000/20 bg-danger-000/10 px-2.5 text-xs font-medium text-danger-000 transition-colors duration-150 ease-out hover:border-danger-000/30 hover:bg-danger-000/15'
+                : warning
+                  ? 'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-session-waiting transition-colors duration-150 ease-out hover:bg-session-waiting/10'
+                  : 'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-danger-000 transition-colors duration-150 ease-out hover:bg-danger-900'
             }
           >
             <WifiOff
@@ -39,10 +49,10 @@ const NetworkStatusIndicator = ({
               strokeWidth={2}
               aria-hidden="true"
             />
-            {variant === 'pill' ? <span>Offline</span> : null}
+            {variant === 'pill' ? <span>{text}</span> : null}
           </button>
         </TooltipTrigger>
-        <TooltipContent>No internet connection</TooltipContent>
+        <TooltipContent>{label}</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   )

--- a/src/renderer/src/components/NetworkStatusIndicator.tsx
+++ b/src/renderer/src/components/NetworkStatusIndicator.tsx
@@ -1,6 +1,7 @@
 import { WifiOff } from 'lucide-react'
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
 import { useNetworkStore } from '@/stores/network-store'
 import { useSettingsStore } from '@/stores/settings-store'
 
@@ -13,6 +14,21 @@ type NetworkStatusIndicatorProps = {
 // Offline / unreachable warning entry point. Renders nothing while the internet is genuinely
 // reachable; a missing link shows red ("Offline"), a live link with a broken path out shows
 // amber ("Unreachable"). Clicking opens the settings Network panel for troubleshooting.
+
+// Tone maps keep the Update-capsule design spec identical across states — only the palette
+// changes (danger for a missing link, session-waiting amber for unreachable).
+const pillToneClasses = {
+  danger:
+    'border-danger-000/20 bg-danger-000/10 text-danger-000 hover:border-danger-000/30 hover:bg-danger-000/15',
+  warning:
+    'border-session-waiting/20 bg-session-waiting/10 text-session-waiting hover:border-session-waiting/30 hover:bg-session-waiting/15'
+} as const
+
+const iconToneClasses = {
+  danger: 'text-danger-000 hover:bg-danger-900',
+  warning: 'text-session-waiting hover:bg-session-waiting/10'
+} as const
+
 const NetworkStatusIndicator = ({
   variant
 }: NetworkStatusIndicatorProps): React.JSX.Element | null => {
@@ -22,9 +38,10 @@ const NetworkStatusIndicator = ({
 
   if (isOnline && connectivity !== 'unreachable') return null
 
-  const warning = isOnline // online but unreachable: amber instead of red
-  const label = warning ? 'Internet unreachable' : 'No internet connection'
-  const text = warning ? 'Unreachable' : 'Offline'
+  const unreachable = isOnline // online but unreachable: amber instead of red
+  const tone = unreachable ? 'warning' : 'danger'
+  const label = unreachable ? 'Internet unreachable' : 'No internet connection'
+  const text = unreachable ? 'Unreachable' : 'Offline'
 
   return (
     <TooltipProvider delayDuration={300}>
@@ -36,12 +53,14 @@ const NetworkStatusIndicator = ({
             aria-label={label}
             className={
               variant === 'pill'
-                ? warning
-                  ? 'inline-flex h-8 items-center gap-1 rounded-full border border-session-waiting/20 bg-session-waiting/10 px-2.5 text-xs font-medium text-session-waiting transition-colors duration-150 ease-out hover:border-session-waiting/30 hover:bg-session-waiting/15'
-                  : 'inline-flex h-8 items-center gap-1 rounded-full border border-danger-000/20 bg-danger-000/10 px-2.5 text-xs font-medium text-danger-000 transition-colors duration-150 ease-out hover:border-danger-000/30 hover:bg-danger-000/15'
-                : warning
-                  ? 'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-session-waiting transition-colors duration-150 ease-out hover:bg-session-waiting/10'
-                  : 'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-danger-000 transition-colors duration-150 ease-out hover:bg-danger-900'
+                ? cn(
+                    'inline-flex h-8 items-center gap-1 rounded-full border px-2.5 text-xs font-medium transition-colors duration-150 ease-out',
+                    pillToneClasses[tone]
+                  )
+                : cn(
+                    'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md transition-colors duration-150 ease-out',
+                    iconToneClasses[tone]
+                  )
             }
           >
             <WifiOff

--- a/src/renderer/src/components/NetworkStatusIndicator.tsx
+++ b/src/renderer/src/components/NetworkStatusIndicator.tsx
@@ -1,0 +1,47 @@
+import { WifiOff } from 'lucide-react'
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { useNetworkStore } from '@/stores/network-store'
+import { useSettingsStore } from '@/stores/settings-store'
+
+type NetworkStatusIndicatorProps = {
+  // 'pill' for the home header (icon + label), 'icon' for the workspace sidebar footer
+  // where space is tight.
+  variant: 'pill' | 'icon'
+}
+
+// Offline warning entry point. Renders nothing while online; when offline, clicking opens
+// the settings Network panel for troubleshooting.
+const NetworkStatusIndicator = ({
+  variant
+}: NetworkStatusIndicatorProps): React.JSX.Element | null => {
+  const isOnline = useNetworkStore((state) => state.isOnline)
+  const openSettingsToPanel = useSettingsStore((state) => state.openSettingsToPanel)
+
+  if (isOnline) return null
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => openSettingsToPanel('network')}
+            aria-label="No internet connection"
+            className={
+              variant === 'pill'
+                ? 'inline-flex h-8 items-center gap-1.5 rounded-md border border-danger-000/35 bg-danger-900 px-2.5 text-xs font-medium text-danger-000 transition-colors duration-150 ease-out hover:border-danger-000/55 hover:bg-danger-900/80'
+                : 'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-danger-000 transition-colors duration-150 ease-out hover:bg-danger-900'
+            }
+          >
+            <WifiOff className="size-4" strokeWidth={2} aria-hidden="true" />
+            {variant === 'pill' ? <span>Offline</span> : null}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>No internet connection</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export { NetworkStatusIndicator }

--- a/src/renderer/src/components/NetworkStatusIndicator.tsx
+++ b/src/renderer/src/components/NetworkStatusIndicator.tsx
@@ -30,11 +30,15 @@ const NetworkStatusIndicator = ({
             aria-label="No internet connection"
             className={
               variant === 'pill'
-                ? 'inline-flex h-8 items-center gap-1.5 rounded-md border border-danger-000/35 bg-danger-900 px-2.5 text-xs font-medium text-danger-000 transition-colors duration-150 ease-out hover:border-danger-000/55 hover:bg-danger-900/80'
+                ? 'inline-flex h-8 items-center gap-1 rounded-full border border-danger-000/20 bg-danger-000/10 px-2.5 text-xs font-medium text-danger-000 transition-colors duration-150 ease-out hover:border-danger-000/30 hover:bg-danger-000/15'
                 : 'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-danger-000 transition-colors duration-150 ease-out hover:bg-danger-900'
             }
           >
-            <WifiOff className="size-4" strokeWidth={2} aria-hidden="true" />
+            <WifiOff
+              className={variant === 'pill' ? 'size-3.5' : 'size-4'}
+              strokeWidth={2}
+              aria-hidden="true"
+            />
             {variant === 'pill' ? <span>Offline</span> : null}
           </button>
         </TooltipTrigger>

--- a/src/renderer/src/components/environment-check-row.render.test.tsx
+++ b/src/renderer/src/components/environment-check-row.render.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { EthernetPort } from 'lucide-react'
+
+import type { EnvironmentCheckItem } from '../../../shared/settings'
+import { EnvironmentCheckRow } from './environment-check-row'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const check: EnvironmentCheckItem = {
+  id: 'install-network',
+  label: 'Internet connection',
+  status: 'passed',
+  summary: 'The internet is reachable.'
+}
+
+describe('EnvironmentCheckRow', () => {
+  it('uses the id-derived icon by default', async () => {
+    await act(async () => {
+      root.render(
+        <ul>
+          <EnvironmentCheckRow check={check} />
+        </ul>
+      )
+    })
+
+    expect(container.querySelector('svg.lucide-wifi')).not.toBeNull()
+  })
+
+  it('honours the icon override', async () => {
+    await act(async () => {
+      root.render(
+        <ul>
+          <EnvironmentCheckRow check={check} icon={EthernetPort} />
+        </ul>
+      )
+    })
+
+    expect(container.querySelector('svg.lucide-ethernet-port')).not.toBeNull()
+    expect(container.querySelector('svg.lucide-wifi')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/environment-check-row.tsx
+++ b/src/renderer/src/components/environment-check-row.tsx
@@ -1,0 +1,118 @@
+import {
+  CheckCircle2,
+  CircleAlert,
+  HardDrive,
+  KeyRound,
+  Loader2,
+  MonitorCog,
+  Wifi,
+  XCircle
+} from 'lucide-react'
+
+import type { EnvironmentCheckId, EnvironmentCheckItem } from '../../../shared/settings'
+import { cn } from '@/lib/utils'
+
+// Shared check-row rendering: the onboarding environment step and the settings Network panel
+// present the same "one requirement, one row" shape (status-tinted icon tile, label, status
+// pill, summary, optional detail).
+const CHECK_ICONS = {
+  system: MonitorCog,
+  storage: HardDrive,
+  'secure-storage': KeyRound,
+  'install-network': Wifi
+} satisfies Partial<Record<EnvironmentCheckId, typeof MonitorCog>>
+
+const STATUS_COPY = {
+  passed: 'Ready',
+  warning: 'Review',
+  failed: 'Action needed'
+} satisfies Record<EnvironmentCheckItem['status'], string>
+
+const statusIcon = (status: EnvironmentCheckItem['status']): React.JSX.Element => {
+  if (status === 'passed') {
+    return <CheckCircle2 className="size-4 text-primary" aria-hidden="true" />
+  }
+  if (status === 'warning') {
+    return <CircleAlert className="size-4 text-session-waiting" aria-hidden="true" />
+  }
+
+  return <XCircle className="size-4 text-destructive" aria-hidden="true" />
+}
+
+type PendingCheckRowProps = {
+  id: EnvironmentCheckId
+  label: string
+  pendingText?: string
+}
+
+const PendingCheckRow = ({
+  id,
+  label,
+  pendingText = 'Waiting to check…'
+}: PendingCheckRowProps): React.JSX.Element => {
+  const Icon = CHECK_ICONS[id] ?? MonitorCog
+
+  return (
+    <li className="flex items-start gap-3 py-3.5">
+      <span className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-lg bg-muted text-muted-foreground">
+        <Icon className="size-4" aria-hidden="true" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-foreground">{label}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{pendingText}</p>
+      </div>
+      <Loader2 className="mt-1 size-4 animate-spin text-muted-foreground" aria-hidden="true" />
+    </li>
+  )
+}
+
+const EnvironmentCheckRow = ({
+  check,
+  icon
+}: {
+  check: EnvironmentCheckItem
+  // Overrides the id-derived tile icon — e.g. the settings Network panel swaps it by
+  // connection type (Wi-Fi vs Ethernet) and state (WifiOff while offline).
+  icon?: typeof MonitorCog
+}): React.JSX.Element => {
+  const Icon = icon ?? CHECK_ICONS[check.id] ?? MonitorCog
+
+  return (
+    <li className="flex items-start gap-3 py-3.5">
+      <span
+        className={cn(
+          'mt-0.5 grid size-8 shrink-0 place-items-center rounded-lg',
+          check.status === 'passed' && 'bg-primary/10 text-primary',
+          check.status === 'warning' && 'bg-session-waiting/10 text-session-waiting',
+          check.status === 'failed' && 'bg-destructive/10 text-destructive'
+        )}
+      >
+        <Icon className="size-4" aria-hidden="true" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-sm font-medium text-foreground">{check.label}</p>
+          <span
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase',
+              check.status === 'passed' && 'bg-primary/10 text-primary',
+              check.status === 'warning' && 'bg-session-waiting/10 text-session-waiting',
+              check.status === 'failed' && 'bg-destructive/10 text-destructive'
+            )}
+          >
+            {statusIcon(check.status)}
+            {STATUS_COPY[check.status]}
+          </span>
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">{check.summary}</p>
+        {check.detail ? (
+          <p className="mt-1 break-words text-[11px] leading-relaxed text-muted-foreground/80">
+            {check.detail}
+          </p>
+        ) : null}
+      </div>
+    </li>
+  )
+}
+
+export { EnvironmentCheckRow, PendingCheckRow }

--- a/src/renderer/src/components/environment-check-row.tsx
+++ b/src/renderer/src/components/environment-check-row.tsx
@@ -66,15 +66,14 @@ const PendingCheckRow = ({
   )
 }
 
-const EnvironmentCheckRow = ({
-  check,
-  icon
-}: {
+type EnvironmentCheckRowProps = {
   check: EnvironmentCheckItem
   // Overrides the id-derived tile icon — e.g. the settings Network panel swaps it by
   // connection type (Wi-Fi vs Ethernet) and state (WifiOff while offline).
   icon?: typeof MonitorCog
-}): React.JSX.Element => {
+}
+
+const EnvironmentCheckRow = ({ check, icon }: EnvironmentCheckRowProps): React.JSX.Element => {
   const Icon = icon ?? CHECK_ICONS[check.id] ?? MonitorCog
 
   return (

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client'
 import App from './App'
 import { installStreamdown } from '@/components/streamdown/install-streamdown'
 import { applyTheme, resolveInitialTheme } from '@/lib/theme'
+import { startNetworkMonitor } from '@/stores/network-store'
 import { installRendererFailureDiagnostics } from './renderer-diagnostics'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -25,6 +26,10 @@ installRendererFailureDiagnostics({
 
 // Apply the saved theme to <html> before the first paint so dark mode doesn't flash light on startup.
 applyTheme(resolveInitialTheme())
+
+// Start connectivity monitoring (online/offline events + the initial reachability probe)
+// before React renders so indicators and the Network panel read a live store from first paint.
+startNetworkMonitor()
 
 // Install before React renders so Streamdown hooks work on first interaction.
 installStreamdown()

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -11,6 +11,7 @@ import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-
 import { HomePage } from './HomePage'
 
 vi.mock('@/components/GitHubStarBadge', () => ({ GitHubStarBadge: () => null }))
+vi.mock('@/components/NetworkStatusIndicator', () => ({ NetworkStatusIndicator: () => null }))
 vi.mock('@/components/ThemeControls', () => ({ ThemePreferenceMenu: () => null }))
 vi.mock('@/components/UpdateCapsule', () => ({ UpdateCapsule: () => null }))
 vi.mock('./ProjectFormDialog', () => ({ ProjectFormDialog: () => null }))

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -21,6 +21,7 @@ import { useProjectStore } from '@/stores/project-store'
 import { useArchiveUndoStore } from '@/stores/archive-undo-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { GitHubStarBadge } from '@/components/GitHubStarBadge'
+import { NetworkStatusIndicator } from '@/components/NetworkStatusIndicator'
 import { ThemePreferenceMenu } from '@/components/ThemeControls'
 import { UpdateCapsule } from '@/components/UpdateCapsule'
 import { APP } from '../../../../shared/app-config'
@@ -350,6 +351,7 @@ const HomePage = ({
                 <span className="sm:hidden">Environment</span>
               </button>
             ) : null}
+            <NetworkStatusIndicator variant="pill" />
             <span className="hidden sm:inline-flex">
               <GitHubStarBadge />
             </span>

--- a/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentSetupCard.tsx
@@ -1,20 +1,5 @@
-import {
-  CheckCircle2,
-  CircleAlert,
-  HardDrive,
-  KeyRound,
-  Loader2,
-  MonitorCog,
-  Wifi,
-  XCircle
-} from 'lucide-react'
-
-import type {
-  EnvironmentCheckId,
-  EnvironmentCheckItem,
-  EnvironmentCheckResult
-} from '../../../../shared/settings'
-import { cn } from '@/lib/utils'
+import type { EnvironmentCheckId, EnvironmentCheckResult } from '../../../../shared/settings'
+import { EnvironmentCheckRow, PendingCheckRow } from '@/components/environment-check-row'
 
 type EnvironmentSetupCardProps = {
   environment: EnvironmentCheckResult | undefined
@@ -29,88 +14,6 @@ const CHECK_LABELS: Array<{ id: EnvironmentCheckId; label: string }> = [
 ]
 
 const HOST_CHECK_IDS: readonly EnvironmentCheckId[] = CHECK_LABELS.map((check) => check.id)
-
-const CHECK_ICONS = {
-  system: MonitorCog,
-  storage: HardDrive,
-  'secure-storage': KeyRound,
-  'install-network': Wifi
-} satisfies Partial<Record<EnvironmentCheckId, typeof MonitorCog>>
-
-const STATUS_COPY = {
-  passed: 'Ready',
-  warning: 'Review',
-  failed: 'Action needed'
-} satisfies Record<EnvironmentCheckItem['status'], string>
-
-const statusIcon = (status: EnvironmentCheckItem['status']): React.JSX.Element => {
-  if (status === 'passed') {
-    return <CheckCircle2 className="size-4 text-primary" aria-hidden="true" />
-  }
-  if (status === 'warning') {
-    return <CircleAlert className="size-4 text-session-waiting" aria-hidden="true" />
-  }
-
-  return <XCircle className="size-4 text-destructive" aria-hidden="true" />
-}
-
-const PendingCheckRow = ({ id, label }: (typeof CHECK_LABELS)[number]): React.JSX.Element => {
-  const Icon = CHECK_ICONS[id] ?? MonitorCog
-
-  return (
-    <li className="flex items-start gap-3 py-3.5">
-      <span className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-lg bg-muted text-muted-foreground">
-        <Icon className="size-4" aria-hidden="true" />
-      </span>
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium text-foreground">{label}</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">Waiting to check…</p>
-      </div>
-      <Loader2 className="mt-1 size-4 animate-spin text-muted-foreground" aria-hidden="true" />
-    </li>
-  )
-}
-
-const EnvironmentCheckRow = ({ check }: { check: EnvironmentCheckItem }): React.JSX.Element => {
-  const Icon = CHECK_ICONS[check.id] ?? MonitorCog
-
-  return (
-    <li className="flex items-start gap-3 py-3.5">
-      <span
-        className={cn(
-          'mt-0.5 grid size-8 shrink-0 place-items-center rounded-lg',
-          check.status === 'passed' && 'bg-primary/10 text-primary',
-          check.status === 'warning' && 'bg-session-waiting/10 text-session-waiting',
-          check.status === 'failed' && 'bg-destructive/10 text-destructive'
-        )}
-      >
-        <Icon className="size-4" aria-hidden="true" />
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <p className="text-sm font-medium text-foreground">{check.label}</p>
-          <span
-            className={cn(
-              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase',
-              check.status === 'passed' && 'bg-primary/10 text-primary',
-              check.status === 'warning' && 'bg-session-waiting/10 text-session-waiting',
-              check.status === 'failed' && 'bg-destructive/10 text-destructive'
-            )}
-          >
-            {statusIcon(check.status)}
-            {STATUS_COPY[check.status]}
-          </span>
-        </div>
-        <p className="mt-0.5 text-xs text-muted-foreground">{check.summary}</p>
-        {check.detail ? (
-          <p className="mt-1 break-words text-[11px] leading-relaxed text-muted-foreground/80">
-            {check.detail}
-          </p>
-        ) : null}
-      </div>
-    </li>
-  )
-}
 
 // Host-only requirement list for the first onboarding step. Agent installation and notebook runtime
 // management live in their dedicated steps and must not leak back into this surface.

--- a/src/renderer/src/pages/settings/NetworkPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.render.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { NetworkPanel } from './NetworkPanel'
+import { useNetworkStore } from '@/stores/network-store'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true })
+  useNetworkStore.setState({ isOnline: false, connectivity: 'unreachable' })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.useRealTimers()
+  Object.defineProperty(window.navigator, 'onLine', { value: true, configurable: true })
+  useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })
+})
+
+const buttonWithText = (text: string): HTMLButtonElement =>
+  [...container.querySelectorAll('button')].find((button) =>
+    button.textContent?.includes(text)
+  ) as HTMLButtonElement
+
+describe('NetworkPanel offline retry', () => {
+  it('holds a checking state for at least 500ms when Check again is clicked while offline', async () => {
+    await act(async () => {
+      root.render(<NetworkPanel view={{ kind: 'list' }} onNavigate={() => {}} />)
+    })
+    expect(container.textContent).toContain('This machine is offline.')
+
+    await act(async () => {
+      buttonWithText('Check again').click()
+    })
+    expect(container.textContent).toContain('Checking…')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(499)
+    })
+    expect(container.textContent).toContain('Checking…')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(container.textContent).toContain('This machine is offline.')
+  })
+})

--- a/src/renderer/src/pages/settings/NetworkPanel.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.tsx
@@ -1,8 +1,11 @@
-import { CircleAlert, RefreshCw } from 'lucide-react'
+import { EthernetPort, RefreshCw, Wifi, WifiOff } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { PackageMirror } from '../../../../shared/mirror'
 import type { NetworkInfo } from '../../../../shared/network'
+import type { EnvironmentCheckItem } from '../../../../shared/settings'
+import { EnvironmentCheckRow, PendingCheckRow } from '@/components/environment-check-row'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 import { useNetworkStore } from '@/stores/network-store'
@@ -19,11 +22,12 @@ const actionButtonClassName =
 type NetworkView = { kind: 'list' | 'configure' }
 type NetworkPanelProps = { view: NetworkView; onNavigate: (view: NetworkView) => void }
 
-// Settings -> Network. The Network status section shows connectivity (navigator.onLine) plus the
-// local interface details reported by the main process; the Package mirror section lets a user
-// behind a firewall or on a slow route to the public conda-forge / pip hosts point package fetches
-// at a mirror instead. The "Claude Science domains" egress allowlist from the mockup is phase-3
-// (spec §14, §9) and is intentionally not built here.
+// Settings -> Network. The Network status section combines the navigator.onLine link signal
+// with a real end-to-end reachability probe (the same HTTPS HEAD check the onboarding
+// environment step uses) plus local interface details reported by the main process; the Package
+// mirror section lets a user behind a firewall or on a slow route to the public conda-forge /
+// pip hosts point package fetches at a mirror instead. The "Claude Science domains" egress
+// allowlist from the mockup is phase-3 (spec §14, §9) and is intentionally not built here.
 const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Element => {
   const packageMirror = useSettingsStore((state) => state.packageMirror)
   const setPackageMirror = useSettingsStore((state) => state.setPackageMirror)
@@ -34,6 +38,11 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
   const [isSaving, setIsSaving] = useState(false)
   const [message, setMessage] = useState<string | undefined>(undefined)
   const [networkInfo, setNetworkInfo] = useState<NetworkInfo | null>(null)
+  // Real end-to-end reachability, probed by the main process with the same HTTPS HEAD check the
+  // onboarding environment step uses. null means "no fresh answer yet" — while online that
+  // renders as Checking…; while offline the rows gate on isOnline and never read this.
+  const [connectivity, setConnectivity] = useState<'reachable' | 'unreachable' | null>(null)
+  const probeGenerationRef = useRef(0)
 
   // Local interface details come from the main process; window.api.network is Electron-only,
   // so stay with placeholders when the preload bridge is unavailable.
@@ -44,17 +53,43 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
     void getInfo().then((info) => setNetworkInfo(info))
   }, [])
 
+  // setState happens only in async callbacks, so callers (effects, the Retry button) never
+  // trigger a cascading synchronous render.
+  const probeConnectivity = useCallback((): void => {
+    const checkConnectivity = window.api?.network?.checkConnectivity
+    const generation = ++probeGenerationRef.current
+
+    if (!checkConnectivity) {
+      // Web surface has no probe bridge; fall back to the navigator.onLine signal, which is
+      // the best information available there.
+      void Promise.resolve().then(() => {
+        if (probeGenerationRef.current === generation) setConnectivity('reachable')
+      })
+      return
+    }
+
+    void checkConnectivity().then((reachable) => {
+      if (probeGenerationRef.current === generation) {
+        setConnectivity(reachable ? 'reachable' : 'unreachable')
+      }
+    })
+  }, [])
+
   // Load once when the list view mounts while online, and re-pull whenever connectivity comes
   // back; offline rows show placeholders, so a connectivity drop has nothing to refresh.
   useEffect(() => {
-    if (view.kind === 'list' && isOnline) refreshNetworkInfo()
-  }, [view.kind, isOnline, refreshNetworkInfo])
+    if (view.kind === 'list' && isOnline) {
+      refreshNetworkInfo()
+      probeConnectivity()
+    }
+  }, [view.kind, isOnline, refreshNetworkInfo, probeConnectivity])
 
   const recheckOnline = useNetworkStore((state) => state.recheckOnline)
 
   const handleRetry = (): void => {
     recheckOnline()
     refreshNetworkInfo()
+    if (useNetworkStore.getState().isOnline) probeConnectivity()
   }
 
   // Seed the draft from the saved mirror once each time the configure view is entered (including via
@@ -93,12 +128,52 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
     }
   }
 
-  const connectionLabel =
-    networkInfo?.connectionType === 'wifi'
-      ? 'Wi-Fi'
-      : networkInfo?.connectionType === 'ethernet'
-        ? 'Ethernet'
-        : '—'
+  // Connection type + IP fold into the check row's detail line, e.g. "Wi-Fi · 192.168.1.42".
+  const interfaceDetail =
+    [
+      networkInfo?.connectionType === 'wifi'
+        ? 'Wi-Fi'
+        : networkInfo?.connectionType === 'ethernet'
+          ? 'Ethernet'
+          : null,
+      networkInfo?.ipAddress ?? null
+    ]
+      .filter((part) => part !== null)
+      .join(' · ') || undefined
+
+  // The Network status row is an EnvironmentCheckItem so it renders with the exact same row
+  // component as the onboarding environment step's network check.
+  const networkCheck: EnvironmentCheckItem = !isOnline
+    ? {
+        id: 'install-network',
+        label: 'Internet connection',
+        status: 'failed',
+        summary: 'This machine is offline.'
+      }
+    : connectivity === 'unreachable'
+      ? {
+          id: 'install-network',
+          label: 'Internet connection',
+          status: 'failed',
+          summary: 'The network link is up, but the internet is unreachable.',
+          detail: interfaceDetail
+        }
+      : {
+          id: 'install-network',
+          label: 'Internet connection',
+          status: 'passed',
+          summary: 'The internet is reachable.',
+          detail: interfaceDetail
+        }
+
+  const isChecking = isOnline && connectivity === null
+
+  // Tile icon follows the actual link: WifiOff while offline, then by connection type.
+  const networkIcon = !isOnline
+    ? WifiOff
+    : networkInfo?.connectionType === 'ethernet'
+      ? EthernetPort
+      : Wifi
 
   return (
     <div className="space-y-6 p-5">
@@ -106,55 +181,40 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
         <section aria-label="Network status">
           <h3 className="mb-1 text-sm font-semibold text-foreground">Network status</h3>
           <p className="mb-3 text-xs text-muted-foreground">
-            Whether this machine is currently connected to the internet.
+            Whether this machine can currently reach the internet.
           </p>
 
-          <div className="rounded-xl border border-border p-4">
-            <dl className="space-y-2 text-sm">
-              <div className="flex items-center justify-between gap-3">
-                <dt className={fieldLabelClassName}>Status</dt>
-                <dd className="flex items-center gap-1.5 text-foreground">
-                  <span
-                    aria-hidden="true"
-                    className={cn(
-                      'size-2 rounded-full',
-                      isOnline ? 'bg-success-000' : 'bg-destructive'
-                    )}
-                  />
-                  {isOnline ? 'Connected' : 'Offline'}
-                </dd>
-              </div>
-              <div className="flex items-center justify-between gap-3">
-                <dt className={fieldLabelClassName}>Connection</dt>
-                <dd className="text-foreground">{isOnline ? connectionLabel : '—'}</dd>
-              </div>
-              <div className="flex items-center justify-between gap-3">
-                <dt className={fieldLabelClassName}>IP address</dt>
-                <dd className="text-foreground">
-                  {isOnline ? (networkInfo?.ipAddress ?? '—') : '—'}
-                </dd>
-              </div>
-            </dl>
+          <div className="rounded-xl border border-border px-4">
+            <ul aria-live="polite">
+              {isChecking ? (
+                <PendingCheckRow
+                  id="install-network"
+                  label="Internet connection"
+                  pendingText="Checking…"
+                />
+              ) : (
+                <EnvironmentCheckRow check={networkCheck} icon={networkIcon} />
+              )}
+            </ul>
 
-            {!isOnline ? (
-              <div className="mt-4 rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3">
-                <p className="flex items-center gap-1.5 text-sm font-medium text-destructive">
-                  <CircleAlert className="size-4" strokeWidth={2} aria-hidden="true" />
-                  No internet connection
-                </p>
-                <ol className="mt-2 list-decimal space-y-1 pl-5 text-xs text-muted-foreground">
-                  <li>Check your cable or Wi-Fi connection.</li>
-                  <li>Check proxy or VPN settings.</li>
+            {!isOnline || connectivity === 'unreachable' ? (
+              <div className="mb-4 rounded-lg bg-bg-10 px-4 py-4 ring-1 ring-border-200">
+                <ol className="list-decimal space-y-1 pl-5 text-xs leading-relaxed text-muted-foreground">
+                  {!isOnline ? <li>Check your cable or Wi-Fi connection.</li> : null}
+                  <li>Check proxy, VPN, or firewall settings.</li>
                   <li>Check the package mirror configuration below.</li>
                 </ol>
-                <button
+                <Button
                   type="button"
+                  variant="outline"
+                  size="sm"
+                  className="mt-3"
                   onClick={handleRetry}
-                  className="mt-3 inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+                  disabled={isChecking}
                 >
-                  <RefreshCw className="size-3.5" strokeWidth={2} aria-hidden="true" />
-                  Retry
-                </button>
+                  <RefreshCw className={cn(isChecking && 'animate-spin')} aria-hidden="true" />
+                  {isChecking ? 'Checking…' : 'Check again'}
+                </Button>
               </div>
             ) : null}
           </div>

--- a/src/renderer/src/pages/settings/NetworkPanel.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.tsx
@@ -17,6 +17,10 @@ const fieldLabelClassName = 'text-xs font-medium text-muted-foreground'
 const actionButtonClassName =
   'inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50'
 
+// Minimum time the Checking… row stays visible after a probe starts, so a fast answer reads as
+// a deliberate check instead of a flash.
+const MIN_CHECKING_MS = 500
+
 // Package-mirror list vs. configure form. The configure form is a settings-nav sub-view (not local
 // state) so the shared header shows a "Network / Package mirror" breadcrumb with back/forward.
 type NetworkView = { kind: 'list' | 'configure' }
@@ -58,21 +62,36 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
   const probeConnectivity = useCallback((): void => {
     const checkConnectivity = window.api?.network?.checkConnectivity
     const generation = ++probeGenerationRef.current
+    const startedAt = Date.now()
+
+    // Switch the row back to Checking… for this probe. A microtask keeps the effect caller
+    // free of synchronous setState and still lands well before any network probe resolves.
+    void Promise.resolve().then(() => {
+      if (probeGenerationRef.current === generation) setConnectivity(null)
+    })
+
+    const applyReachable = (reachable: boolean): void => {
+      const apply = (): void => {
+        if (probeGenerationRef.current === generation) {
+          setConnectivity(reachable ? 'reachable' : 'unreachable')
+        }
+      }
+      const remaining = MIN_CHECKING_MS - (Date.now() - startedAt)
+      if (remaining > 0) {
+        setTimeout(apply, remaining)
+      } else {
+        apply()
+      }
+    }
 
     if (!checkConnectivity) {
       // Web surface has no probe bridge; fall back to the navigator.onLine signal, which is
       // the best information available there.
-      void Promise.resolve().then(() => {
-        if (probeGenerationRef.current === generation) setConnectivity('reachable')
-      })
+      void Promise.resolve().then(() => applyReachable(true))
       return
     }
 
-    void checkConnectivity().then((reachable) => {
-      if (probeGenerationRef.current === generation) {
-        setConnectivity(reachable ? 'reachable' : 'unreachable')
-      }
-    })
+    void checkConnectivity().then(applyReachable)
   }, [])
 
   // Load once when the list view mounts while online, and re-pull whenever connectivity comes

--- a/src/renderer/src/pages/settings/NetworkPanel.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.tsx
@@ -2,7 +2,7 @@ import { EthernetPort, RefreshCw, Wifi, WifiOff } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { PackageMirror } from '../../../../shared/mirror'
-import type { NetworkInfo } from '../../../../shared/network'
+import type { NetworkConnectionType, NetworkInfo } from '../../../../shared/network'
 import type { EnvironmentCheckItem } from '../../../../shared/settings'
 import { EnvironmentCheckRow, PendingCheckRow } from '@/components/environment-check-row'
 import { Button } from '@/components/ui/button'
@@ -27,6 +27,12 @@ const NETWORK_CHECK_BASE = {
   id: 'install-network',
   label: 'Internet connection'
 } as const satisfies Pick<EnvironmentCheckItem, 'id' | 'label'>
+
+// Display labels for the main-process connection types; 'unknown' has no label and drops out.
+const CONNECTION_TYPE_LABELS: Partial<Record<NetworkConnectionType, string>> = {
+  wifi: 'Wi-Fi',
+  ethernet: 'Ethernet'
+}
 
 // Settings -> Network. The Network status section presents the network store's connectivity
 // (navigator.onLine link signal plus the store's shared end-to-end reachability probe) and the
@@ -112,15 +118,9 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
   }
 
   // Connection type + IP fold into the check row's detail line, e.g. "Wi-Fi · 192.168.1.42".
+  const typeLabel = networkInfo ? CONNECTION_TYPE_LABELS[networkInfo.connectionType] : undefined
   const interfaceDetail =
-    [
-      networkInfo?.connectionType === 'wifi'
-        ? 'Wi-Fi'
-        : networkInfo?.connectionType === 'ethernet'
-          ? 'Ethernet'
-          : null,
-      networkInfo?.ipAddress ?? null
-    ]
+    [typeLabel ?? null, networkInfo?.ipAddress ?? null]
       .filter((part) => part !== null)
       .join(' · ') || undefined
 

--- a/src/renderer/src/pages/settings/NetworkPanel.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.tsx
@@ -17,36 +17,32 @@ const fieldLabelClassName = 'text-xs font-medium text-muted-foreground'
 const actionButtonClassName =
   'inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50'
 
-// Minimum time the Checking… row stays visible after a probe starts, so a fast answer reads as
-// a deliberate check instead of a flash.
-const MIN_CHECKING_MS = 500
-
 // Package-mirror list vs. configure form. The configure form is a settings-nav sub-view (not local
 // state) so the shared header shows a "Network / Package mirror" breadcrumb with back/forward.
 type NetworkView = { kind: 'list' | 'configure' }
 type NetworkPanelProps = { view: NetworkView; onNavigate: (view: NetworkView) => void }
 
-// Settings -> Network. The Network status section combines the navigator.onLine link signal
-// with a real end-to-end reachability probe (the same HTTPS HEAD check the onboarding
-// environment step uses) plus local interface details reported by the main process; the Package
-// mirror section lets a user behind a firewall or on a slow route to the public conda-forge /
-// pip hosts point package fetches at a mirror instead. The "Claude Science domains" egress
-// allowlist from the mockup is phase-3 (spec §14, §9) and is intentionally not built here.
+// Settings -> Network. The Network status section presents the network store's connectivity
+// (navigator.onLine link signal plus the store's shared end-to-end reachability probe) and the
+// local interface details reported by the main process; the Package mirror section lets a user
+// behind a firewall or on a slow route to the public conda-forge / pip hosts point package
+// fetches at a mirror instead. The "Claude Science domains" egress allowlist from the mockup is
+// phase-3 (spec §14, §9) and is intentionally not built here.
 const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Element => {
   const packageMirror = useSettingsStore((state) => state.packageMirror)
   const setPackageMirror = useSettingsStore((state) => state.setPackageMirror)
   const isOnline = useNetworkStore((state) => state.isOnline)
+  // End-to-end reachability is owned by the network store (probed on startup, recovery, a
+  // background cadence, and Retry), so this panel and the header/sidebar indicators never
+  // disagree. 'unknown' renders as Checking….
+  const connectivity = useNetworkStore((state) => state.connectivity)
+  const probeConnectivity = useNetworkStore((state) => state.probeConnectivity)
 
   const isConfiguring = view.kind === 'configure'
   const [draft, setDraft] = useState<PackageMirror>({})
   const [isSaving, setIsSaving] = useState(false)
   const [message, setMessage] = useState<string | undefined>(undefined)
   const [networkInfo, setNetworkInfo] = useState<NetworkInfo | null>(null)
-  // Real end-to-end reachability, probed by the main process with the same HTTPS HEAD check the
-  // onboarding environment step uses. null means "no fresh answer yet" — while online that
-  // renders as Checking…; while offline the rows gate on isOnline and never read this.
-  const [connectivity, setConnectivity] = useState<'reachable' | 'unreachable' | null>(null)
-  const probeGenerationRef = useRef(0)
 
   // Local interface details come from the main process; window.api.network is Electron-only,
   // so stay with placeholders when the preload bridge is unavailable.
@@ -57,58 +53,20 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
     void getInfo().then((info) => setNetworkInfo(info))
   }, [])
 
-  // setState happens only in async callbacks, so callers (effects, the Retry button) never
-  // trigger a cascading synchronous render.
-  const probeConnectivity = useCallback((): void => {
-    const checkConnectivity = window.api?.network?.checkConnectivity
-    const generation = ++probeGenerationRef.current
-    const startedAt = Date.now()
-
-    // Switch the row back to Checking… for this probe. A microtask keeps the effect caller
-    // free of synchronous setState and still lands well before any network probe resolves.
-    void Promise.resolve().then(() => {
-      if (probeGenerationRef.current === generation) setConnectivity(null)
-    })
-
-    const applyReachable = (reachable: boolean): void => {
-      const apply = (): void => {
-        if (probeGenerationRef.current === generation) {
-          setConnectivity(reachable ? 'reachable' : 'unreachable')
-        }
-      }
-      const remaining = MIN_CHECKING_MS - (Date.now() - startedAt)
-      if (remaining > 0) {
-        setTimeout(apply, remaining)
-      } else {
-        apply()
-      }
-    }
-
-    if (!checkConnectivity) {
-      // Web surface has no probe bridge; fall back to the navigator.onLine signal, which is
-      // the best information available there.
-      void Promise.resolve().then(() => applyReachable(true))
-      return
-    }
-
-    void checkConnectivity().then(applyReachable)
-  }, [])
-
-  // Load once when the list view mounts while online, and re-pull whenever connectivity comes
-  // back; offline rows show placeholders, so a connectivity drop has nothing to refresh.
+  // Pull local interface details when the list view mounts while online, and re-pull whenever
+  // connectivity comes back; offline rows show placeholders, so a drop has nothing to refresh.
   useEffect(() => {
-    if (view.kind === 'list' && isOnline) {
-      refreshNetworkInfo()
-      probeConnectivity()
-    }
-  }, [view.kind, isOnline, refreshNetworkInfo, probeConnectivity])
+    if (view.kind === 'list' && isOnline) refreshNetworkInfo()
+  }, [view.kind, isOnline, refreshNetworkInfo])
 
   const recheckOnline = useNetworkStore((state) => state.recheckOnline)
 
   const handleRetry = (): void => {
     recheckOnline()
     refreshNetworkInfo()
-    if (useNetworkStore.getState().isOnline) probeConnectivity()
+    if (useNetworkStore.getState().isOnline) {
+      void probeConnectivity({ announce: true })
+    }
   }
 
   // Seed the draft from the saved mirror once each time the configure view is entered (including via
@@ -161,7 +119,8 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
       .join(' · ') || undefined
 
   // The Network status row is an EnvironmentCheckItem so it renders with the exact same row
-  // component as the onboarding environment step's network check.
+  // component as the onboarding environment step's network check. A live link with unreachable
+  // internet is amber (warning) rather than red — the machine is connected, the path out is not.
   const networkCheck: EnvironmentCheckItem = !isOnline
     ? {
         id: 'install-network',
@@ -173,7 +132,7 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
       ? {
           id: 'install-network',
           label: 'Internet connection',
-          status: 'failed',
+          status: 'warning',
           summary: 'The network link is up, but the internet is unreachable.',
           detail: interfaceDetail
         }
@@ -185,7 +144,7 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
           detail: interfaceDetail
         }
 
-  const isChecking = isOnline && connectivity === null
+  const isChecking = isOnline && connectivity === 'unknown'
 
   // Tile icon follows the actual link: WifiOff while offline, then by connection type.
   const networkIcon = !isOnline

--- a/src/renderer/src/pages/settings/NetworkPanel.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.tsx
@@ -1,7 +1,11 @@
-import { useEffect, useRef, useState } from 'react'
+import { CircleAlert, RefreshCw } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { PackageMirror } from '../../../../shared/mirror'
+import type { NetworkInfo } from '../../../../shared/network'
 import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import { useNetworkStore } from '@/stores/network-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { isMirrorConfigured, mirrorStatusText, MIRROR_HELP_URL } from './mirror-view'
@@ -15,18 +19,43 @@ const actionButtonClassName =
 type NetworkView = { kind: 'list' | 'configure' }
 type NetworkPanelProps = { view: NetworkView; onNavigate: (view: NetworkView) => void }
 
-// Settings -> Network. Currently just the Package mirror section: conda-forge / pip fetch packages
-// from the public hosts by default; a user behind a firewall or on a slow route to those hosts can
-// point them at a mirror instead. The "Claude Science domains" egress allowlist from the mockup is
-// phase-3 (spec §14, §9) and is intentionally not built here.
+// Settings -> Network. The Network status section shows connectivity (navigator.onLine) plus the
+// local interface details reported by the main process; the Package mirror section lets a user
+// behind a firewall or on a slow route to the public conda-forge / pip hosts point package fetches
+// at a mirror instead. The "Claude Science domains" egress allowlist from the mockup is phase-3
+// (spec §14, §9) and is intentionally not built here.
 const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Element => {
   const packageMirror = useSettingsStore((state) => state.packageMirror)
   const setPackageMirror = useSettingsStore((state) => state.setPackageMirror)
+  const isOnline = useNetworkStore((state) => state.isOnline)
 
   const isConfiguring = view.kind === 'configure'
   const [draft, setDraft] = useState<PackageMirror>({})
   const [isSaving, setIsSaving] = useState(false)
   const [message, setMessage] = useState<string | undefined>(undefined)
+  const [networkInfo, setNetworkInfo] = useState<NetworkInfo | null>(null)
+
+  // Local interface details come from the main process; window.api.network is Electron-only,
+  // so stay with placeholders when the preload bridge is unavailable.
+  const refreshNetworkInfo = useCallback((): void => {
+    const getInfo = window.api?.network?.getInfo
+    if (!getInfo) return
+
+    void getInfo().then((info) => setNetworkInfo(info))
+  }, [])
+
+  // Load once when the list view mounts while online, and re-pull whenever connectivity comes
+  // back; offline rows show placeholders, so a connectivity drop has nothing to refresh.
+  useEffect(() => {
+    if (view.kind === 'list' && isOnline) refreshNetworkInfo()
+  }, [view.kind, isOnline, refreshNetworkInfo])
+
+  const recheckOnline = useNetworkStore((state) => state.recheckOnline)
+
+  const handleRetry = (): void => {
+    recheckOnline()
+    refreshNetworkInfo()
+  }
 
   // Seed the draft from the saved mirror once each time the configure view is entered (including via
   // history / a remount), without clobbering in-progress edits on a background store refresh.
@@ -64,8 +93,74 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
     }
   }
 
+  const connectionLabel =
+    networkInfo?.connectionType === 'wifi'
+      ? 'Wi-Fi'
+      : networkInfo?.connectionType === 'ethernet'
+        ? 'Ethernet'
+        : '—'
+
   return (
     <div className="space-y-6 p-5">
+      {!isConfiguring ? (
+        <section aria-label="Network status">
+          <h3 className="mb-1 text-sm font-semibold text-foreground">Network status</h3>
+          <p className="mb-3 text-xs text-muted-foreground">
+            Whether this machine is currently connected to the internet.
+          </p>
+
+          <div className="rounded-xl border border-border p-4">
+            <dl className="space-y-2 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <dt className={fieldLabelClassName}>Status</dt>
+                <dd className="flex items-center gap-1.5 text-foreground">
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      'size-2 rounded-full',
+                      isOnline ? 'bg-success-000' : 'bg-destructive'
+                    )}
+                  />
+                  {isOnline ? 'Connected' : 'Offline'}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <dt className={fieldLabelClassName}>Connection</dt>
+                <dd className="text-foreground">{isOnline ? connectionLabel : '—'}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <dt className={fieldLabelClassName}>IP address</dt>
+                <dd className="text-foreground">
+                  {isOnline ? (networkInfo?.ipAddress ?? '—') : '—'}
+                </dd>
+              </div>
+            </dl>
+
+            {!isOnline ? (
+              <div className="mt-4 rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3">
+                <p className="flex items-center gap-1.5 text-sm font-medium text-destructive">
+                  <CircleAlert className="size-4" strokeWidth={2} aria-hidden="true" />
+                  No internet connection
+                </p>
+                <ol className="mt-2 list-decimal space-y-1 pl-5 text-xs text-muted-foreground">
+                  <li>Check your cable or Wi-Fi connection.</li>
+                  <li>Check proxy or VPN settings.</li>
+                  <li>Check the package mirror configuration below.</li>
+                </ol>
+                <button
+                  type="button"
+                  onClick={handleRetry}
+                  className="mt-3 inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+                >
+                  <RefreshCw className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                  Retry
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
       <section aria-label="Package mirror">
         <h3 className="mb-1 text-sm font-semibold text-foreground">Package mirror</h3>
         <p className="mb-3 text-xs text-muted-foreground">

--- a/src/renderer/src/pages/settings/NetworkPanel.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.tsx
@@ -22,6 +22,12 @@ const actionButtonClassName =
 type NetworkView = { kind: 'list' | 'configure' }
 type NetworkPanelProps = { view: NetworkView; onNavigate: (view: NetworkView) => void }
 
+// Shared identity of the single check row this panel renders (and its pending placeholder).
+const NETWORK_CHECK_BASE = {
+  id: 'install-network',
+  label: 'Internet connection'
+} as const satisfies Pick<EnvironmentCheckItem, 'id' | 'label'>
+
 // Settings -> Network. The Network status section presents the network store's connectivity
 // (navigator.onLine link signal plus the store's shared end-to-end reachability probe) and the
 // local interface details reported by the main process; the Package mirror section lets a user
@@ -64,9 +70,9 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
   const handleRetry = (): void => {
     recheckOnline()
     refreshNetworkInfo()
-    if (useNetworkStore.getState().isOnline) {
-      void probeConnectivity({ announce: true })
-    }
+    // Announced even while offline: the store short-circuits a link-down probe to
+    // 'unreachable', but still holds the Checking… state for its minimum delay first.
+    void probeConnectivity({ announce: true })
   }
 
   // Seed the draft from the saved mirror once each time the configure view is entered (including via
@@ -123,28 +129,27 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
   // internet is amber (warning) rather than red — the machine is connected, the path out is not.
   const networkCheck: EnvironmentCheckItem = !isOnline
     ? {
-        id: 'install-network',
-        label: 'Internet connection',
+        ...NETWORK_CHECK_BASE,
         status: 'failed',
         summary: 'This machine is offline.'
       }
     : connectivity === 'unreachable'
       ? {
-          id: 'install-network',
-          label: 'Internet connection',
+          ...NETWORK_CHECK_BASE,
           status: 'warning',
           summary: 'The network link is up, but the internet is unreachable.',
           detail: interfaceDetail
         }
       : {
-          id: 'install-network',
-          label: 'Internet connection',
+          ...NETWORK_CHECK_BASE,
           status: 'passed',
           summary: 'The internet is reachable.',
           detail: interfaceDetail
         }
 
-  const isChecking = isOnline && connectivity === 'unknown'
+  // 'unknown' only ever means a probe is in flight (offline settles on 'unreachable'), so it
+  // always renders as Checking… — including an offline Retry.
+  const isChecking = connectivity === 'unknown'
 
   // Tile icon follows the actual link: WifiOff while offline, then by connection type.
   const networkIcon = !isOnline
@@ -165,11 +170,7 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
           <div className="rounded-xl border border-border px-4">
             <ul aria-live="polite">
               {isChecking ? (
-                <PendingCheckRow
-                  id="install-network"
-                  label="Internet connection"
-                  pendingText="Checking…"
-                />
+                <PendingCheckRow {...NETWORK_CHECK_BASE} pendingText="Checking…" />
               ) : (
                 <EnvironmentCheckRow check={networkCheck} icon={networkIcon} />
               )}

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -28,6 +28,7 @@ import {
 
 import { cn } from '@/lib/utils'
 import { GitHubStarBadge } from '@/components/GitHubStarBadge'
+import { NetworkStatusIndicator } from '@/components/NetworkStatusIndicator'
 import { UpdateCapsule } from '@/components/UpdateCapsule'
 import type { ChatSession, SessionStatus } from '@/stores/session-store'
 import type { ConversationExportFormat } from '../../../../shared/conversation-export'
@@ -427,6 +428,7 @@ const WorkspaceSidebar = ({
             </button>
             <UpdateCapsule />
             <GitHubStarBadge />
+            <NetworkStatusIndicator variant="icon" />
           </div>
         </nav>
       </div>

--- a/src/renderer/src/stores/network-store.test.ts
+++ b/src/renderer/src/stores/network-store.test.ts
@@ -1,10 +1,20 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNetworkStore } from './network-store'
 
+type CheckConnectivity = () => Promise<boolean>
+
+// window.api is typed as the full preload bridge; tests replace it wholesale through an
+// unknown cast and only model the one method under test.
+const stubCheckConnectivity = (checkConnectivity?: CheckConnectivity): void => {
+  ;(window as unknown as { api: unknown }).api =
+    checkConnectivity === undefined ? undefined : { network: { checkConnectivity } }
+}
+
 afterEach(() => {
-  useNetworkStore.setState({ isOnline: true })
+  stubCheckConnectivity()
+  useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })
 })
 
 describe('useNetworkStore', () => {
@@ -31,5 +41,66 @@ describe('useNetworkStore', () => {
     useNetworkStore.getState().recheckOnline()
 
     expect(useNetworkStore.getState().isOnline).toBe(navigator.onLine)
+  })
+})
+
+describe('probeConnectivity', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('an announced probe flips to unknown, then applies the result only after the minimum delay', async () => {
+    const checkConnectivity = vi.fn().mockResolvedValue(false)
+    stubCheckConnectivity(checkConnectivity)
+    useNetworkStore.setState({ isOnline: true, connectivity: 'reachable' })
+
+    const probe = useNetworkStore.getState().probeConnectivity({ announce: true })
+    expect(useNetworkStore.getState().connectivity).toBe('unknown')
+
+    await vi.advanceTimersByTimeAsync(499)
+    expect(useNetworkStore.getState().connectivity).toBe('unknown')
+
+    await vi.advanceTimersByTimeAsync(1)
+    await probe
+    expect(useNetworkStore.getState().connectivity).toBe('unreachable')
+    expect(checkConnectivity).toHaveBeenCalledTimes(1)
+  })
+
+  it('a silent probe keeps the previous state while probing', async () => {
+    const checkConnectivity = vi.fn().mockResolvedValue(true)
+    stubCheckConnectivity(checkConnectivity)
+    useNetworkStore.setState({ isOnline: true, connectivity: 'unreachable' })
+
+    const probe = useNetworkStore.getState().probeConnectivity()
+    expect(useNetworkStore.getState().connectivity).toBe('unreachable')
+
+    await vi.advanceTimersByTimeAsync(500)
+    await probe
+    expect(useNetworkStore.getState().connectivity).toBe('reachable')
+  })
+
+  it('keeps the last known state when the bridge call rejects', async () => {
+    const checkConnectivity = vi.fn().mockRejectedValue(new Error('bridge gone'))
+    stubCheckConnectivity(checkConnectivity)
+    useNetworkStore.setState({ isOnline: true, connectivity: 'reachable' })
+
+    await useNetworkStore.getState().probeConnectivity()
+
+    expect(useNetworkStore.getState().connectivity).toBe('reachable')
+  })
+
+  it('falls back to reachable when there is no probe bridge', async () => {
+    stubCheckConnectivity()
+    useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })
+
+    const probe = useNetworkStore.getState().probeConnectivity()
+    await vi.advanceTimersByTimeAsync(500)
+    await probe
+
+    expect(useNetworkStore.getState().connectivity).toBe('reachable')
   })
 })

--- a/src/renderer/src/stores/network-store.test.ts
+++ b/src/renderer/src/stores/network-store.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useNetworkStore } from './network-store'
+import { startNetworkMonitor, useNetworkStore } from './network-store'
 
 type CheckConnectivity = () => Promise<boolean>
 
@@ -12,8 +12,17 @@ const stubCheckConnectivity = (checkConnectivity?: CheckConnectivity): void => {
     checkConnectivity === undefined ? undefined : { network: { checkConnectivity } }
 }
 
+const setNavigatorOnline = (online: boolean): void => {
+  Object.defineProperty(window.navigator, 'onLine', { value: online, configurable: true })
+}
+
+beforeAll(() => {
+  startNetworkMonitor()
+})
+
 afterEach(() => {
   stubCheckConnectivity()
+  setNavigatorOnline(true)
   useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })
 })
 
@@ -97,9 +106,33 @@ describe('probeConnectivity', () => {
     stubCheckConnectivity()
     useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })
 
-    const probe = useNetworkStore.getState().probeConnectivity()
+    await useNetworkStore.getState().probeConnectivity()
+
+    expect(useNetworkStore.getState().connectivity).toBe('reachable')
+  })
+
+  it('short-circuits to unreachable without calling the bridge when the link is down', async () => {
+    const checkConnectivity = vi.fn().mockResolvedValue(true)
+    stubCheckConnectivity(checkConnectivity)
+    setNavigatorOnline(false)
+    useNetworkStore.setState({ isOnline: false, connectivity: 'unreachable' })
+
+    const probe = useNetworkStore.getState().probeConnectivity({ announce: true })
+    expect(useNetworkStore.getState().connectivity).toBe('unknown')
+
     await vi.advanceTimersByTimeAsync(500)
     await probe
+    expect(useNetworkStore.getState().connectivity).toBe('unreachable')
+    expect(checkConnectivity).not.toHaveBeenCalled()
+  })
+
+  it('applies silent probe results without the minimum delay', async () => {
+    const checkConnectivity = vi.fn().mockResolvedValue(true)
+    stubCheckConnectivity(checkConnectivity)
+    useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })
+
+    // Resolves on microtasks alone — no timer advance needed when not announced.
+    await useNetworkStore.getState().probeConnectivity()
 
     expect(useNetworkStore.getState().connectivity).toBe('reachable')
   })

--- a/src/renderer/src/stores/network-store.test.ts
+++ b/src/renderer/src/stores/network-store.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { useNetworkStore } from './network-store'
+
+afterEach(() => {
+  useNetworkStore.setState({ isOnline: true })
+})
+
+describe('useNetworkStore', () => {
+  it('seeds from navigator.onLine', () => {
+    expect(useNetworkStore.getState().isOnline).toBe(navigator.onLine)
+  })
+
+  it('goes offline on the window offline event', () => {
+    window.dispatchEvent(new Event('offline'))
+    expect(useNetworkStore.getState().isOnline).toBe(false)
+  })
+
+  it('recovers on the window online event', () => {
+    window.dispatchEvent(new Event('offline'))
+    expect(useNetworkStore.getState().isOnline).toBe(false)
+
+    window.dispatchEvent(new Event('online'))
+    expect(useNetworkStore.getState().isOnline).toBe(true)
+  })
+
+  it('recheckOnline re-reads navigator.onLine on demand', () => {
+    useNetworkStore.setState({ isOnline: false })
+
+    useNetworkStore.getState().recheckOnline()
+
+    expect(useNetworkStore.getState().isOnline).toBe(navigator.onLine)
+  })
+})

--- a/src/renderer/src/stores/network-store.ts
+++ b/src/renderer/src/stores/network-store.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+
+type NetworkStore = {
+  // Whether the browser believes the machine has a network connection. Seeded from
+  // navigator.onLine and kept current by the window online/offline events; an 'online'
+  // event automatically clears the offline UI everywhere this store is read.
+  isOnline: boolean
+  // Re-reads navigator.onLine on demand — used by the Network panel's Retry button so the
+  // "how we know we are online" knowledge stays in this one module.
+  recheckOnline: () => void
+}
+
+export const useNetworkStore = create<NetworkStore>(() => ({
+  isOnline: typeof navigator === 'undefined' ? true : navigator.onLine,
+  recheckOnline: () => useNetworkStore.setState({ isOnline: navigator.onLine })
+}))
+
+// The listeners live at module scope (not in a component) so the store stays accurate even
+// before any subscriber mounts.
+if (typeof window !== 'undefined') {
+  window.addEventListener('online', () => useNetworkStore.setState({ isOnline: true }))
+  window.addEventListener('offline', () => useNetworkStore.setState({ isOnline: false }))
+}

--- a/src/renderer/src/stores/network-store.ts
+++ b/src/renderer/src/stores/network-store.ts
@@ -16,44 +16,49 @@ type NetworkStore = {
   // Re-reads navigator.onLine on demand — used by the Network panel's Retry button so the
   // "how we know we are online" knowledge stays in this one module.
   recheckOnline: () => void
-  // Probes real reachability through the main process. `announce` flips connectivity back to
-  // 'unknown' for the duration (user-visible re-checks); background polls stay silent so a
-  // healthy 'reachable' never flickers through a checking state.
+  // Probes real reachability. `announce` flips connectivity to 'unknown' for the duration and
+  // holds the result for MIN_CHECKING_MS (user-visible re-checks); silent probes apply as soon
+  // as the answer lands. With no link the probe short-circuits to 'unreachable' — no point
+  // issuing HTTPS requests we know cannot get out.
   probeConnectivity: (options?: { announce?: boolean }) => Promise<void>
 }
 
-// Minimum time a probe's Checking… presentation stays visible, so a fast answer reads as a
-// deliberate check instead of a flash.
+// Minimum time an announced probe's Checking… presentation stays visible, so a clicked
+// re-check reads as a deliberate check instead of a flash.
 const MIN_CHECKING_MS = 500
-// Background re-probe cadence while the machine looks online.
-const CONNECTIVITY_POLL_MS = 30_000
 
 export const useNetworkStore = create<NetworkStore>((set) => {
   let probeGeneration = 0
 
   const probeConnectivity = async ({ announce = false } = {}): Promise<void> => {
-    const checkConnectivity = window.api?.network?.checkConnectivity
     const generation = ++probeGeneration
     const startedAt = Date.now()
 
     if (announce) set({ connectivity: 'unknown' })
 
     let reachable: boolean
-    if (!checkConnectivity) {
-      // Web surface has no probe bridge; the navigator.onLine signal is all there is.
-      reachable = true
+    if (!navigator.onLine) {
+      reachable = false
     } else {
-      try {
-        reachable = await checkConnectivity()
-      } catch {
-        // Bridge failure keeps the last known state rather than crying wolf.
-        return
+      const checkConnectivity = window.api?.network?.checkConnectivity
+      if (!checkConnectivity) {
+        // Web surface has no probe bridge; the navigator.onLine signal is all there is.
+        reachable = true
+      } else {
+        try {
+          reachable = await checkConnectivity()
+        } catch {
+          // Bridge failure keeps the last known state rather than crying wolf.
+          return
+        }
       }
     }
 
-    const remaining = MIN_CHECKING_MS - (Date.now() - startedAt)
-    if (remaining > 0) {
-      await new Promise((resolve) => setTimeout(resolve, remaining))
+    if (announce) {
+      const remaining = MIN_CHECKING_MS - (Date.now() - startedAt)
+      if (remaining > 0) {
+        await new Promise((resolve) => setTimeout(resolve, remaining))
+      }
     }
     if (probeGeneration === generation) {
       set({ connectivity: reachable ? 'reachable' : 'unreachable' })
@@ -68,24 +73,29 @@ export const useNetworkStore = create<NetworkStore>((set) => {
   }
 })
 
-// The listeners live at module scope (not in a component) so the store stays accurate even
-// before any subscriber mounts. Probing starts immediately and re-runs on recovery and on a
-// slow background cadence; the offline event resets to 'unknown' so recovery always re-probes.
-if (typeof window !== 'undefined') {
+// Installs the window listeners and runs the first probe. Called once from the app entry
+// (main.tsx) — deliberately NOT at module scope, so importing the store in tests stays free
+// of side effects. Probing happens on startup, on every link recovery, and on demand (panel
+// mount / Retry); there is no background polling.
+let monitorStarted = false
+
+export const startNetworkMonitor = (): void => {
+  if (monitorStarted || typeof window === 'undefined') return
+  monitorStarted = true
+
   window.addEventListener('online', () => {
     useNetworkStore.setState({ isOnline: true })
     void useNetworkStore.getState().probeConnectivity({ announce: true })
   })
   window.addEventListener('offline', () => {
-    useNetworkStore.setState({ isOnline: false, connectivity: 'unknown' })
+    // A dropped link is a known-unreachable state, so surfaces can show it immediately.
+    useNetworkStore.setState({ isOnline: false, connectivity: 'unreachable' })
   })
 
-  if (typeof navigator === 'undefined' || navigator.onLine) {
+  if (navigator.onLine) {
     void useNetworkStore.getState().probeConnectivity()
+  } else {
+    // Starting offline is a known-down state, same as the offline event.
+    useNetworkStore.setState({ connectivity: 'unreachable' })
   }
-  window.setInterval(() => {
-    if (useNetworkStore.getState().isOnline) {
-      void useNetworkStore.getState().probeConnectivity()
-    }
-  }, CONNECTIVITY_POLL_MS)
 }

--- a/src/renderer/src/stores/network-store.ts
+++ b/src/renderer/src/stores/network-store.ts
@@ -1,23 +1,91 @@
 import { create } from 'zustand'
 
+// Real end-to-end reachability probed by the main process (the same HTTPS HEAD check the
+// onboarding environment step uses). 'unknown' means there is no fresh answer and surfaces
+// render it as "checking"; it never persists, because every probe eventually applies a result.
+export type NetworkConnectivity = 'unknown' | 'reachable' | 'unreachable'
+
 type NetworkStore = {
   // Whether the browser believes the machine has a network connection. Seeded from
   // navigator.onLine and kept current by the window online/offline events; an 'online'
   // event automatically clears the offline UI everywhere this store is read.
   isOnline: boolean
+  // End-to-end internet reachability, so a live link with a broken path out (DNS, proxy,
+  // firewall) reads differently from a healthy connection.
+  connectivity: NetworkConnectivity
   // Re-reads navigator.onLine on demand — used by the Network panel's Retry button so the
   // "how we know we are online" knowledge stays in this one module.
   recheckOnline: () => void
+  // Probes real reachability through the main process. `announce` flips connectivity back to
+  // 'unknown' for the duration (user-visible re-checks); background polls stay silent so a
+  // healthy 'reachable' never flickers through a checking state.
+  probeConnectivity: (options?: { announce?: boolean }) => Promise<void>
 }
 
-export const useNetworkStore = create<NetworkStore>(() => ({
-  isOnline: typeof navigator === 'undefined' ? true : navigator.onLine,
-  recheckOnline: () => useNetworkStore.setState({ isOnline: navigator.onLine })
-}))
+// Minimum time a probe's Checking… presentation stays visible, so a fast answer reads as a
+// deliberate check instead of a flash.
+const MIN_CHECKING_MS = 500
+// Background re-probe cadence while the machine looks online.
+const CONNECTIVITY_POLL_MS = 30_000
+
+export const useNetworkStore = create<NetworkStore>((set) => {
+  let probeGeneration = 0
+
+  const probeConnectivity = async ({ announce = false } = {}): Promise<void> => {
+    const checkConnectivity = window.api?.network?.checkConnectivity
+    const generation = ++probeGeneration
+    const startedAt = Date.now()
+
+    if (announce) set({ connectivity: 'unknown' })
+
+    let reachable: boolean
+    if (!checkConnectivity) {
+      // Web surface has no probe bridge; the navigator.onLine signal is all there is.
+      reachable = true
+    } else {
+      try {
+        reachable = await checkConnectivity()
+      } catch {
+        // Bridge failure keeps the last known state rather than crying wolf.
+        return
+      }
+    }
+
+    const remaining = MIN_CHECKING_MS - (Date.now() - startedAt)
+    if (remaining > 0) {
+      await new Promise((resolve) => setTimeout(resolve, remaining))
+    }
+    if (probeGeneration === generation) {
+      set({ connectivity: reachable ? 'reachable' : 'unreachable' })
+    }
+  }
+
+  return {
+    isOnline: typeof navigator === 'undefined' ? true : navigator.onLine,
+    connectivity: 'unknown',
+    recheckOnline: () => set({ isOnline: navigator.onLine }),
+    probeConnectivity
+  }
+})
 
 // The listeners live at module scope (not in a component) so the store stays accurate even
-// before any subscriber mounts.
+// before any subscriber mounts. Probing starts immediately and re-runs on recovery and on a
+// slow background cadence; the offline event resets to 'unknown' so recovery always re-probes.
 if (typeof window !== 'undefined') {
-  window.addEventListener('online', () => useNetworkStore.setState({ isOnline: true }))
-  window.addEventListener('offline', () => useNetworkStore.setState({ isOnline: false }))
+  window.addEventListener('online', () => {
+    useNetworkStore.setState({ isOnline: true })
+    void useNetworkStore.getState().probeConnectivity({ announce: true })
+  })
+  window.addEventListener('offline', () => {
+    useNetworkStore.setState({ isOnline: false, connectivity: 'unknown' })
+  })
+
+  if (typeof navigator === 'undefined' || navigator.onLine) {
+    void useNetworkStore.getState().probeConnectivity()
+  }
+  window.setInterval(() => {
+    if (useNetworkStore.getState().isOnline) {
+      void useNetworkStore.getState().probeConnectivity()
+    }
+  }, CONNECTIVITY_POLL_MS)
 }

--- a/src/shared/network.ts
+++ b/src/shared/network.ts
@@ -1,0 +1,9 @@
+// Best-effort network interface snapshot reported by the main process. Whether the machine is
+// online at all is decided in the renderer (navigator.onLine); this only describes the local
+// interface, which stays populated even without internet access.
+export type NetworkConnectionType = 'wifi' | 'ethernet' | 'unknown'
+
+export type NetworkInfo = {
+  connectionType: NetworkConnectionType
+  ipAddress: string | null
+}

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -12,8 +12,8 @@ describe('renderer contract catalog', () => {
   it('pins the complete capability-owned inventory and legacy map projection', () => {
     const projection = projectRendererContractMaps(RENDERER_CONTRACT_CATALOG)
 
-    expect(RENDERER_CONTRACT_GROUPS).toHaveLength(30)
-    expect(RENDERER_CONTRACT_CATALOG).toHaveLength(312)
+    expect(RENDERER_CONTRACT_GROUPS).toHaveLength(31)
+    expect(RENDERER_CONTRACT_CATALOG).toHaveLength(313)
     expect(projection.invoke).toEqual(WEB_INVOKE_CHANNELS)
     expect(projection.event).toEqual(WEB_EVENT_CHANNELS)
     expect(Object.keys(projection.invoke)).toHaveLength(231)
@@ -53,7 +53,7 @@ describe('renderer contract catalog', () => {
     })
     expect(
       paths(({ surfaceInstallation }) => surfaceInstallation.localWeb === 'unavailable')
-    ).toHaveLength(53)
+    ).toHaveLength(54)
     expect(
       paths(({ surfaceInstallation }) => surfaceInstallation.remoteWeb === 'rejecting-stub')
     ).toHaveLength(58)

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -13,7 +13,7 @@ describe('renderer contract catalog', () => {
     const projection = projectRendererContractMaps(RENDERER_CONTRACT_CATALOG)
 
     expect(RENDERER_CONTRACT_GROUPS).toHaveLength(31)
-    expect(RENDERER_CONTRACT_CATALOG).toHaveLength(313)
+    expect(RENDERER_CONTRACT_CATALOG).toHaveLength(314)
     expect(projection.invoke).toEqual(WEB_INVOKE_CHANNELS)
     expect(projection.event).toEqual(WEB_EVENT_CHANNELS)
     expect(Object.keys(projection.invoke)).toHaveLength(231)
@@ -53,7 +53,7 @@ describe('renderer contract catalog', () => {
     })
     expect(
       paths(({ surfaceInstallation }) => surfaceInstallation.localWeb === 'unavailable')
-    ).toHaveLength(54)
+    ).toHaveLength(55)
     expect(
       paths(({ surfaceInstallation }) => surfaceInstallation.remoteWeb === 'rejecting-stub')
     ).toHaveLength(58)

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -209,6 +209,9 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
   group('logs', 'logs', [
     ['getPath', 'logs:get-path'], ['openFile', 'logs:open-file', LOCAL], ['revealInFolder', 'logs:reveal-in-folder', LOCAL],
   ]),
+  group('network', 'network', [
+    ['getInfo', 'network:get-info', ELECTRON],
+  ]),
   group('notebook', 'notebook', [
     ['onAvailable', 'notebook:available', EVENT], ['onChanged', 'notebook:changed', EVENT], ['appendCodeCell', 'notebook:append-code-cell'],
     ['beginCodeCell', 'notebook:begin-code-cell'], ['execute', 'notebook:execute'], ['exportIpynb', 'notebook:export-ipynb', LOCAL],

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -210,7 +210,7 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['getPath', 'logs:get-path'], ['openFile', 'logs:open-file', LOCAL], ['revealInFolder', 'logs:reveal-in-folder', LOCAL],
   ]),
   group('network', 'network', [
-    ['getInfo', 'network:get-info', ELECTRON],
+    ['getInfo', 'network:get-info', ELECTRON], ['checkConnectivity', 'network:check-connectivity', ELECTRON],
   ]),
   group('notebook', 'notebook', [
     ['onAvailable', 'notebook:available', EVENT], ['onChanged', 'notebook:changed', EVENT], ['appendCodeCell', 'notebook:append-code-cell'],

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -58,6 +58,7 @@ const GENERATED_SOURCE_OMISSIONS = [
   'handoff.list',
   'handoff.onChanged',
   'handoff.retry',
+  'network.getInfo',
   'notifications.syncViewState',
   'officePreview.attachFrame',
   'officePreview.close',
@@ -212,7 +213,7 @@ describe('renderer surface inventory', () => {
       ...Object.keys(WEB_EVENT_CHANNELS)
     ])
 
-    expect(electronPaths).toHaveLength(312)
+    expect(electronPaths).toHaveLength(313)
     expectSameSet(
       electronPaths,
       RENDERER_CONTRACT_CATALOG.map(({ publicPath }) => publicPath)

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -58,6 +58,7 @@ const GENERATED_SOURCE_OMISSIONS = [
   'handoff.list',
   'handoff.onChanged',
   'handoff.retry',
+  'network.checkConnectivity',
   'network.getInfo',
   'notifications.syncViewState',
   'officePreview.attachFrame',
@@ -213,7 +214,7 @@ describe('renderer surface inventory', () => {
       ...Object.keys(WEB_EVENT_CHANNELS)
     ])
 
-    expect(electronPaths).toHaveLength(313)
+    expect(electronPaths).toHaveLength(314)
     expectSameSet(
       electronPaths,
       RENDERER_CONTRACT_CATALOG.map(({ publicPath }) => publicPath)


### PR DESCRIPTION
## Summary

- **Offline detection**: a renderer `network-store` tracks connectivity via `navigator.onLine` + `online`/`offline` events; the offline UI disappears automatically when connectivity returns (detection state resets on recovery).
- **Indicators**: while offline, a red `WifiOff` affordance appears — a pill (icon + "Offline") before the GitHub badge in the home header, and an icon button after the GitHub badge in the workspace sidebar footer. Both show a "No internet connection" tooltip and open the settings Network panel on click. Online renders nothing.
- **Network panel**: new "Network status" section above Package mirror showing connection state, connection type (Wi-Fi / Ethernet, best-effort via `networksetup` on macOS, `unknown` elsewhere), and local IPv4 address from a new main-process `network.getInfo` IPC; while offline it shows troubleshooting suggestions plus a Retry button that rechecks connectivity.

## Test plan

- New unit/render tests: `network-store` (event transitions, recovery reset, `recheckOnline`), `network-info` (IPv4 selection, hardware-port parsing, type classification), `network-ipc` (channel registration, owner delegation), `NetworkStatusIndicator` (hidden online, renders offline, click-through) — all passing.
- Contract catalog / surface inventory / preload bridge pin tests updated and passing.
- `typecheck` clean for the change (node-side keeps the 10 pre-existing baseline errors); eslint / prettier / `check:web-api-map` pass.
- Manual smoke: disconnect network → indicators appear in both surfaces → click opens Network panel → reconnect → indicators disappear and panel resets.