### PR TITLE
fix(runtimes): keep setup actions pending until refresh

### DIFF
--- a/src/main/notebook/application-commands.test.ts
+++ b/src/main/notebook/application-commands.test.ts
@@ -268,15 +268,18 @@ describe('Notebook application commands', () => {
     await expect(
       router.dispatcher.invoke(notebookEnvironmentStatusCommand, invocation([] as const))
     ).resolves.toMatchObject({ pythonReady: true })
-    await router.dispatcher.invoke(notebookEnvironmentProvisionCommand, invocation(['r'] as const))
+    await router.dispatcher.invoke(
+      notebookEnvironmentProvisionCommand,
+      invocation(['r', 'provision-operation'] as const)
+    )
     await router.dispatcher.invoke(
       notebookEnvironmentRepairCommand,
-      invocation(['python'] as const)
+      invocation(['python', 'repair-operation'] as const)
     )
     await router.dispatcher.invoke(notebookEnvironmentCancelCommand, invocation([] as const))
 
-    expect(provision).toHaveBeenCalledWith('r')
-    expect(repair).toHaveBeenCalledWith('python')
+    expect(provision).toHaveBeenCalledWith('r', 'provision-operation')
+    expect(repair).toHaveBeenCalledWith('python', 'repair-operation')
     expect(cancel).toHaveBeenCalledWith(undefined)
     expect(lifecycle.startup).not.toHaveBeenCalled()
     expect(router.dispatcher.commandNames()).toEqual(

--- a/src/main/notebook/env-ipc.test.ts
+++ b/src/main/notebook/env-ipc.test.ts
@@ -89,17 +89,29 @@ describe('registerNotebookEnvIpcHandlers', () => {
     })
     registerNotebookEnvIpcHandlers(createLifecycle(provisioner))
 
-    await registered.get('notebook-env:provision')?.({}, 'r')
-    await registered.get('notebook-env:repair')?.({}, 'python')
+    await registered.get('notebook-env:provision')?.({}, 'r', 'provision-operation')
+    await registered.get('notebook-env:repair')?.({}, 'python', 'repair-operation')
 
     expect(sent).toEqual([
       {
         channel: 'notebook-env:progress',
-        progress: { phase: 'fetch-r', message: 'Downloading R', progress: 0.4, scope: 'r' }
+        progress: {
+          phase: 'fetch-r',
+          message: 'Downloading R',
+          progress: 0.4,
+          scope: 'r',
+          operationId: 'provision-operation'
+        }
       },
       {
         channel: 'notebook-env:progress',
-        progress: { phase: 'repair', message: 'Repairing Python', progress: 0.2, scope: 'python' }
+        progress: {
+          phase: 'repair',
+          message: 'Repairing Python',
+          progress: 0.2,
+          scope: 'python',
+          operationId: 'repair-operation'
+        }
       }
     ])
     expect(destroyedSend).not.toHaveBeenCalled()

--- a/src/main/notebook/env-ipc.ts
+++ b/src/main/notebook/env-ipc.ts
@@ -16,11 +16,13 @@ export const broadcastNotebookEnvProgress = (progress: ProvisionProgress): void 
 // interface. An unavailable provisioner still yields registered handlers with actionable results.
 export const registerNotebookEnvIpcHandlers = (lifecycle: NotebookEnvironmentLifecycle): void => {
   ipcMainHandle('notebook-env:status', () => lifecycle.status())
-  ipcMainHandle('notebook-env:provision', (_event, language: NotebookLanguage) =>
-    lifecycle.provision(language)
+  ipcMainHandle(
+    'notebook-env:provision',
+    (_event, language: NotebookLanguage, operationId?: string) =>
+      lifecycle.provision(language, operationId)
   )
-  ipcMainHandle('notebook-env:repair', (_event, language: NotebookLanguage) =>
-    lifecycle.repair(language)
+  ipcMainHandle('notebook-env:repair', (_event, language: NotebookLanguage, operationId?: string) =>
+    lifecycle.repair(language, operationId)
   )
   ipcMainHandle('notebook-env:cancel', (_event, language?: NotebookLanguage) =>
     lifecycle.cancel(language)

--- a/src/main/notebook/environment-application-commands.ts
+++ b/src/main/notebook/environment-application-commands.ts
@@ -64,11 +64,11 @@ const installNotebookEnvironmentApplicationCommands = (
       'notebook-env:status': () => lifecycle.status(),
       'notebook-env:provision': (invocation) => {
         assertLocalCaller(invocation.callerContext, notebookEnvironmentProvisionCommand.name)
-        return lifecycle.provision(invocation.args[0])
+        return lifecycle.provision(invocation.args[0], invocation.args[1])
       },
       'notebook-env:repair': (invocation) => {
         assertLocalCaller(invocation.callerContext, notebookEnvironmentRepairCommand.name)
-        return lifecycle.repair(invocation.args[0])
+        return lifecycle.repair(invocation.args[0], invocation.args[1])
       },
       'notebook-env:cancel': (invocation) => {
         assertLocalCaller(invocation.callerContext, notebookEnvironmentCancelCommand.name)

--- a/src/main/notebook/environment-lifecycle-workflows.test.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.test.ts
@@ -99,6 +99,25 @@ describe('createNotebookEnvironmentLifecycle', () => {
     expect(provisioner.provisionR).toHaveBeenCalledOnce()
   })
 
+  it('tags a failure that occurs before provision progress is emitted', async () => {
+    const failure = new Error('provision rejected before startup')
+    const provisioner = fakeProvisioner({ provisionPython: vi.fn().mockRejectedValue(failure) })
+    const emitted: ProvisionProgress[] = []
+    const lifecycle = createLifecycle(provisioner, { projectProgress: (p) => emitted.push(p) })
+
+    await expect(lifecycle.provision('python', 'explicit-operation')).rejects.toBe(failure)
+    expect(emitted).toEqual([
+      {
+        phase: 'error',
+        message: failure.message,
+        progress: 0,
+        language: 'python',
+        scope: 'python',
+        operationId: 'explicit-operation'
+      }
+    ])
+  })
+
   it('repair delegates by language as an explicit force-recovery', async () => {
     const provisioner = fakeProvisioner()
     const lifecycle = createLifecycle(provisioner)

--- a/src/main/notebook/environment-lifecycle-workflows.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.ts
@@ -17,8 +17,8 @@ import { DEFAULT_ENV_VERSION, DEFAULT_PY_ENV, envPrefix, readReadyMarker } from 
 
 type NotebookEnvironmentLifecycle = {
   status: () => Promise<ProvisionStatus>
-  provision: (language: NotebookLanguage) => Promise<void>
-  repair: (language: NotebookLanguage) => Promise<void>
+  provision: (language: NotebookLanguage, operationId?: string) => Promise<void>
+  repair: (language: NotebookLanguage, operationId?: string) => Promise<void>
   cancel: (language?: NotebookLanguage) => void
   startup: () => Promise<void>
 }
@@ -38,14 +38,20 @@ const RUNTIME_UNAVAILABLE_MESSAGE =
 const runUnavailableOperation = (
   deps: NotebookEnvironmentLifecycleDeps,
   operation: 'provision' | 'repair',
-  language: NotebookLanguage
+  language: NotebookLanguage,
+  operationId?: string
 ): Promise<void> =>
   runLoggedRuntimeOperation(
     operation,
     language,
     deps.root,
     () => Promise.reject(new Error(RUNTIME_UNAVAILABLE_MESSAGE)),
-    () => undefined
+    (progress) =>
+      deps.projectProgress({
+        ...progress,
+        scope: language,
+        ...(operationId === undefined ? {} : { operationId })
+      })
   )
 
 const createUnavailableLifecycle = (
@@ -58,8 +64,9 @@ const createUnavailableLifecycle = (
       version: DEFAULT_ENV_VERSION,
       provisioning: false
     }),
-  provision: (language) => runUnavailableOperation(deps, 'provision', language),
-  repair: (language) => runUnavailableOperation(deps, 'repair', language),
+  provision: (language, operationId) =>
+    runUnavailableOperation(deps, 'provision', language, operationId),
+  repair: (language, operationId) => runUnavailableOperation(deps, 'repair', language, operationId),
   cancel: () => undefined,
   startup: () => Promise.resolve()
 })
@@ -77,7 +84,7 @@ const createNotebookEnvironmentLifecycle = (
       return provisioner.status()
     })
 
-  const provision = (language: NotebookLanguage): Promise<void> =>
+  const provision = (language: NotebookLanguage, operationId?: string): Promise<void> =>
     runLoggedRuntimeOperation(
       'provision',
       language,
@@ -90,10 +97,15 @@ const createNotebookEnvironmentLifecycle = (
             ? provisioner.provisionR(report)
             : provisioner.provisionPython(report))
         }),
-      (progress) => deps.projectProgress({ ...progress, scope: language })
+      (progress) =>
+        deps.projectProgress({
+          ...progress,
+          scope: language,
+          ...(operationId === undefined ? {} : { operationId })
+        })
     )
 
-  const repair = (language: NotebookLanguage): Promise<void> =>
+  const repair = (language: NotebookLanguage, operationId?: string): Promise<void> =>
     runLoggedRuntimeOperation(
       'repair',
       language,
@@ -104,7 +116,12 @@ const createNotebookEnvironmentLifecycle = (
           await provisioner.repair(language, report, { force: true })
           await deps.onRepairCompleted?.(language)
         }),
-      (progress) => deps.projectProgress({ ...progress, scope: language })
+      (progress) =>
+        deps.projectProgress({
+          ...progress,
+          scope: language,
+          ...(operationId === undefined ? {} : { operationId })
+        })
     )
 
   const startup = async (): Promise<void> => {

--- a/src/main/notebook/environment-operation-foundation.test.ts
+++ b/src/main/notebook/environment-operation-foundation.test.ts
@@ -123,9 +123,16 @@ describe('runLoggedRuntimeOperation', () => {
       )
     ).rejects.toBe(failure)
 
-    expect(projected).toHaveLength(4)
+    expect(projected).toHaveLength(5)
+    expect(projected.at(-1)).toMatchObject({
+      phase: 'error',
+      progress: 0,
+      language: 'python'
+    })
+    expect(projected.at(-1)?.message).not.toContain('basic-secret')
     expect(loggerSpies.info.mock.calls.map(([message]) => message)).toEqual([
       'runtime operation started',
+      'runtime operation progress',
       'runtime operation progress',
       'runtime operation progress',
       'runtime operation progress'

--- a/src/main/notebook/environment-operation-foundation.ts
+++ b/src/main/notebook/environment-operation-foundation.ts
@@ -97,6 +97,18 @@ const runLoggedRuntimeOperation = async (
       lastPhase
     })
   } catch (error) {
+    if (lastPhase !== 'error') {
+      try {
+        report({
+          phase: 'error',
+          message: redactRuntimeLogText(error instanceof Error ? error.message : String(error)),
+          progress: 0,
+          language
+        })
+      } catch {
+        // Progress projection is best-effort and must never replace the operation failure.
+      }
+    }
     try {
       log.error('runtime operation failed', {
         ...runtimeErrorLogFields(error),

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -96,6 +96,8 @@ type PreloadApi = {
   }
   notebookEnv: {
     cancel: (language?: unknown) => unknown
+    provision: (language: unknown, operationId?: unknown) => unknown
+    repair: (language: unknown, operationId?: unknown) => unknown
   }
   notifications: {
     peekPendingOpenSession: () => unknown
@@ -580,16 +582,30 @@ describe('preload bridge — runtime renderer contract catalog', () => {
     }
   })
 
-  it('preserves ACP defaults and the notebook cancellation argument slot', async () => {
+  it('preserves ACP defaults and notebook environment operation arguments', async () => {
     await api.acp.connect()
     await api.acp.connect(undefined)
     await api.notebookEnv.cancel()
     await api.notebookEnv.cancel(undefined)
+    await api.notebookEnv.provision('r', 'provision-operation')
+    await api.notebookEnv.repair('python', 'repair-operation')
 
     expect(invokeMock).toHaveBeenNthCalledWith(1, 'acp:connect', {})
     expect(invokeMock).toHaveBeenNthCalledWith(2, 'acp:connect', {})
     expect(invokeMock).toHaveBeenNthCalledWith(3, 'notebook-env:cancel', undefined)
     expect(invokeMock).toHaveBeenNthCalledWith(4, 'notebook-env:cancel', undefined)
+    expect(invokeMock).toHaveBeenNthCalledWith(
+      5,
+      'notebook-env:provision',
+      'r',
+      'provision-operation'
+    )
+    expect(invokeMock).toHaveBeenNthCalledWith(
+      6,
+      'notebook-env:repair',
+      'python',
+      'repair-operation'
+    )
   })
 })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -588,8 +588,10 @@ const api: OpenScienceAPI = {
   },
   notebookEnv: {
     getStatus: () => electronRendererContracts.invoke('notebookEnv.getStatus'),
-    provision: (lang) => electronRendererContracts.invoke('notebookEnv.provision', lang),
-    repair: (lang) => electronRendererContracts.invoke('notebookEnv.repair', lang),
+    provision: (lang, operationId) =>
+      electronRendererContracts.invoke('notebookEnv.provision', lang, operationId),
+    repair: (lang, operationId) =>
+      electronRendererContracts.invoke('notebookEnv.repair', lang, operationId),
     cancel: (lang?: NotebookLanguage) =>
       electronRendererContracts.invoke('notebookEnv.cancel', lang),
     onProgress: (listener) =>

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -713,8 +713,8 @@ export interface OpenScienceAPI {
   }
   notebookEnv: {
     getStatus(): Promise<ProvisionStatus>
-    provision(lang: NotebookLanguage): Promise<void>
-    repair(lang: NotebookLanguage): Promise<void>
+    provision(lang: NotebookLanguage, operationId?: string): Promise<void>
+    repair(lang: NotebookLanguage, operationId?: string): Promise<void>
     cancel(lang?: NotebookLanguage): Promise<void>
     onProgress(listener: (progress: ProvisionProgress) => void): RemoveListener
   }

--- a/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
@@ -455,6 +455,47 @@ describe('RuntimesPanel', () => {
 
     resolveProvision?.()
   })
+
+  it('does not re-enable setup while refreshing environments after provision completes', async () => {
+    let resolveRefresh:
+      ((value: { python: DiscoveredInterpreter[]; r: DiscoveredInterpreter[] }) => void) | undefined
+    const installedR: DiscoveredInterpreter = {
+      language: 'r',
+      provenance: 'app-managed',
+      envId: '/data/runtime/envs/default-r/bin/R',
+      interpreterPath: '/data/runtime/envs/default-r/bin/R',
+      label: 'R 4.4.3 (managed)',
+      version: '4.4.3',
+      runnable: true
+    }
+    provision.mockResolvedValue(undefined)
+    listEnvironments.mockResolvedValueOnce({ python: pythonEnvs, r: rEnvs }).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRefresh = resolve
+        })
+    )
+    await render()
+
+    const setupButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      /download and set up/i.test(button.textContent ?? '')
+    )
+    await click(setupButton ?? null)
+
+    const finishingButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      /^finishing setup…$/i.test((button.textContent ?? '').trim())
+    )
+    const finishingDisabled = (finishingButton as HTMLButtonElement | undefined)?.disabled
+    const setupWasReenabled = container.textContent?.includes('Download and set up')
+
+    resolveRefresh?.({ python: pythonEnvs, r: [installedR, ...rEnvs] })
+    await act(async () => {})
+
+    expect(finishingButton).toBeDefined()
+    expect(finishingDisabled).toBe(true)
+    expect(setupWasReenabled).toBe(false)
+    expect(container.textContent).toContain('R 4.4.3 (managed)')
+  })
 })
 
 describe('RuntimesPanel packages dialog', () => {

--- a/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
@@ -304,7 +304,7 @@ describe('RuntimesPanel', () => {
       /download and set up/i.test(b.textContent ?? '')
     )
     await click(setupBtn ?? null)
-    expect(provision).toHaveBeenCalledWith('r')
+    expect(provision).toHaveBeenCalledWith('r', expect.any(String))
     // The failure surfaces on R's OWN card (per-language error), and its button offers a retry.
     expect(
       container.querySelector('[data-testid="runtimes-provision-error-r"]')?.textContent
@@ -400,7 +400,7 @@ describe('RuntimesPanel', () => {
     expect(resetBtn).toBeDefined()
     expect(resetBtn?.getAttribute('data-variant')).toBe('default')
     await click(resetBtn ?? null)
-    expect(repairBridge).toHaveBeenCalledWith('r')
+    expect(repairBridge).toHaveBeenCalledWith('r', expect.any(String))
   })
 
   it('surfaces Reset even when a runnable managed env is still present (interrupted upgrade/install)', async () => {
@@ -426,7 +426,7 @@ describe('RuntimesPanel', () => {
     expect(resetBtn).toBeDefined()
     expect(resetBtn?.getAttribute('data-variant')).toBe('default')
     await click(resetBtn ?? null)
-    expect(repairBridge).toHaveBeenCalledWith('python')
+    expect(repairBridge).toHaveBeenCalledWith('python', expect.any(String))
   })
 
   it('keeps Cancel clickable while a real Download-and-set-up is in flight (not locked by busy)', async () => {

--- a/src/renderer/src/pages/settings/RuntimesPanel.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.tsx
@@ -72,6 +72,9 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
   const [loaded, setLoaded] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [managedOperations, setManagedOperations] = useState<
+    Partial<Record<NotebookLanguage, boolean>>
+  >({})
   // Set while confirming a disable that would affect live sessions (WS11): the runtime being disabled
   // plus its current usage, so the dialog can warn before revoking.
   const [disableImpact, setDisableImpact] = useState<{
@@ -313,6 +316,7 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
   const provisionManaged = async (language: NotebookLanguage): Promise<void> => {
     // Provisioning deliberately avoids the panel-wide busy flag. Per-language store state marks only
     // the active runtime as preparing and leaves its Cancel action available throughout the download.
+    setManagedOperations((current) => ({ ...current, [language]: true }))
     setError(null)
     try {
       await provisionEnv(language)
@@ -321,18 +325,23 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
       applyAll(await fetchAll())
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not refresh runtime readiness.')
+    } finally {
+      setManagedOperations((current) => ({ ...current, [language]: false }))
     }
   }
 
   // Explicit recovery for a recovery-BLOCKED runtime (a prior setup's worker couldn't be confirmed
   // stopped, so plain provision keeps refusing). Reset force-clears the quarantine and rebuilds.
   const resetManaged = async (language: NotebookLanguage): Promise<void> => {
+    setManagedOperations((current) => ({ ...current, [language]: true }))
     setError(null)
     try {
       await resetEnv(language)
       applyAll(await fetchAll())
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not reset the runtime.')
+    } finally {
+      setManagedOperations((current) => ({ ...current, [language]: false }))
     }
   }
 
@@ -487,7 +496,10 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
             // run settles, independent of the other language (fixes the concurrent python/R phantom-cancel).
             const langState = byLang[id]
             const preparing = langState?.preparing ?? false
+            const finishing = managedOperations[id] === true && !preparing
+            const settingUp = preparing || finishing
             const langProgress = langState?.progress
+            const progress = finishing ? 1 : (langProgress?.progress ?? 0)
             const langError = langState?.error
             const managedRunnable = managedRunnableFor(id)
 
@@ -537,7 +549,7 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
                         card above still renders), but recovery may have quarantined its prefix. Surface
                         the block + Reset here too, or the recovery entry would be unreachable whenever a
                         runnable managed env exists. */}
-                      {!preparing && langError?.includes('RUNTIME_RECOVERY_BLOCKED') ? (
+                      {!settingUp && langError?.includes('RUNTIME_RECOVERY_BLOCKED') ? (
                         <div
                           data-testid={`runtimes-recovery-blocked-${id}`}
                           className="flex items-start justify-between gap-4 rounded-lg border border-destructive/40 bg-card p-3"
@@ -576,26 +588,30 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
                             <Badge variant="secondary">App-managed</Badge>
                           </div>
                           <div className="mt-0.5 text-[13px] text-muted-foreground">
-                            {managedLine(managedRunnable, preparing, langProgress?.message)}
+                            {managedLine(
+                              managedRunnable,
+                              settingUp,
+                              finishing ? 'Finishing setup…' : langProgress?.message
+                            )}
                           </div>
-                          {preparing ? (
+                          {settingUp ? (
                             <div
                               className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted"
                               role="progressbar"
                               aria-label={`Setting up ${label} runtime`}
-                              aria-valuenow={Math.round((langProgress?.progress ?? 0) * 100)}
+                              aria-valuenow={Math.round(progress * 100)}
                               aria-valuemin={0}
                               aria-valuemax={100}
                             >
                               <div
                                 className="h-full rounded-full bg-primary transition-[width] duration-300"
                                 style={{
-                                  width: `${Math.max(2, Math.min(100, Math.round((langProgress?.progress ?? 0) * 100)))}%`
+                                  width: `${Math.max(2, Math.min(100, Math.round(progress * 100)))}%`
                                 }}
                               />
                             </div>
                           ) : null}
-                          {!preparing && langError ? (
+                          {!settingUp && langError ? (
                             <p
                               role="alert"
                               className="mt-1 text-[13px] text-destructive"
@@ -616,6 +632,16 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
                             onClick={() => void cancelProvision(id)}
                           >
                             Cancel
+                          </Button>
+                        ) : finishing ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="shrink-0"
+                            disabled
+                          >
+                            Finishing setup…
                           </Button>
                         ) : (
                           <Button

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -97,7 +97,7 @@ describe('notebook-env-store', () => {
   it('records the scope and forwards provision(lang) to the bridge', async () => {
     const { api } = installApi()
     await useNotebookEnvStore.getState().provision('r')
-    expect(api.provision).toHaveBeenCalledWith('r')
+    expect(api.provision).toHaveBeenCalledWith('r', expect.any(String))
     expect(useNotebookEnvStore.getState().scope).toBe('r')
   })
 
@@ -200,11 +200,12 @@ describe('notebook-env-store', () => {
           resolveProvision = resolve
         })
     )
-    const { emit } = installApi({ provision })
+    const { api, emit } = installApi({ provision })
     await useNotebookEnvStore.getState().init()
 
     const setup = useNotebookEnvStore.getState().provision('r')
-    emit({ phase: 'done', message: 'R environment ready', progress: 1, language: 'r' })
+    const operationId = api.provision.mock.calls[0]?.[1] as string
+    emit({ phase: 'done', message: 'R environment ready', progress: 1, language: 'r', operationId })
 
     expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(true)
     resolveProvision?.()
@@ -220,11 +221,12 @@ describe('notebook-env-store', () => {
           rejectProvision = reject
         })
     )
-    const { emit } = installApi({ provision })
+    const { api, emit } = installApi({ provision })
     await useNotebookEnvStore.getState().init()
 
     const setup = useNotebookEnvStore.getState().provision('r')
-    emit({ phase: 'error', message: 'R setup failed', progress: 0, language: 'r' })
+    const operationId = api.provision.mock.calls[0]?.[1] as string
+    emit({ phase: 'error', message: 'R setup failed', progress: 0, language: 'r', operationId })
 
     expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(true)
     rejectProvision?.(new Error('R setup failed'))
@@ -264,11 +266,18 @@ describe('notebook-env-store', () => {
           resolveProvision = resolve
         })
     )
-    const { emit } = installApi({ provision })
+    const { api, emit } = installApi({ provision })
     await useNotebookEnvStore.getState().init()
 
     const explicit = useNotebookEnvStore.getState().provision('r')
-    emit({ phase: 'done', message: 'Explicit R setup ready', progress: 1, language: 'r' })
+    const operationId = api.provision.mock.calls[0]?.[1] as string
+    emit({
+      phase: 'done',
+      message: 'Explicit R setup ready',
+      progress: 1,
+      language: 'r',
+      operationId
+    })
     emit({ phase: 'create-r', message: 'Automatic R setup started', progress: 0.1, language: 'r' })
     resolveProvision?.()
     await explicit
@@ -278,6 +287,41 @@ describe('notebook-env-store', () => {
       progress: { phase: 'create-r', message: 'Automatic R setup started' }
     })
     emit({ phase: 'done', message: 'Automatic R setup ready', progress: 1, language: 'r' })
+    expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
+  })
+
+  it('does not let an automatic terminal event claim a queued explicit setup', async () => {
+    let resolveProvision: (() => void) | undefined
+    const provision = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveProvision = resolve
+        })
+    )
+    const { api, emit } = installApi({ provision })
+    await useNotebookEnvStore.getState().init()
+
+    emit({ phase: 'create-r', message: 'Automatic R setup started', progress: 0.1, language: 'r' })
+    const explicit = useNotebookEnvStore.getState().provision('r')
+    const operationId = api.provision.mock.calls[0]?.[1] as string
+    emit({ phase: 'done', message: 'Automatic R setup ready', progress: 1, language: 'r' })
+    emit({
+      phase: 'create-r',
+      message: 'Explicit R setup started',
+      progress: 0.1,
+      language: 'r',
+      operationId
+    })
+    emit({
+      phase: 'done',
+      message: 'Explicit R setup ready',
+      progress: 1,
+      language: 'r',
+      operationId
+    })
+
+    resolveProvision?.()
+    await explicit
     expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
   })
 
@@ -355,7 +399,7 @@ describe('notebook-env-store', () => {
       byLang: { python: { preparing: false, error: 'RUNTIME_RECOVERY_BLOCKED: …' } }
     })
     await useNotebookEnvStore.getState().reset('python')
-    expect(repair).toHaveBeenCalledWith('python') // force-recovery via the repair IPC
+    expect(repair).toHaveBeenCalledWith('python', expect.any(String)) // force-recovery via repair IPC
     const { python } = useNotebookEnvStore.getState().byLang
     expect(python?.preparing).toBe(false)
     expect(python?.error).toBeUndefined() // cleared on success

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -290,6 +290,36 @@ describe('notebook-env-store', () => {
     expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
   })
 
+  it('settles local preparing after newer automatic terminal progress', async () => {
+    let resolveProvision: (() => void) | undefined
+    const provision = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveProvision = resolve
+        })
+    )
+    const { api, emit } = installApi({ provision })
+    await useNotebookEnvStore.getState().init()
+
+    const explicit = useNotebookEnvStore.getState().provision('r')
+    const operationId = api.provision.mock.calls[0]?.[1] as string
+    emit({
+      phase: 'done',
+      message: 'Explicit R setup ready',
+      progress: 1,
+      language: 'r',
+      operationId
+    })
+    emit({ phase: 'done', message: 'Automatic R setup ready', progress: 1, language: 'r' })
+    resolveProvision?.()
+    await explicit
+
+    expect(useNotebookEnvStore.getState().byLang.r).toMatchObject({
+      preparing: false,
+      progress: { phase: 'done', message: 'Automatic R setup ready' }
+    })
+  })
+
   it('does not let an automatic terminal event claim a queued explicit setup', async () => {
     let resolveProvision: (() => void) | undefined
     const provision = vi.fn(

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -212,6 +212,27 @@ describe('notebook-env-store', () => {
     expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
   })
 
+  it('keeps a language preparing until its last overlapping provision call returns', async () => {
+    const resolvers: Array<() => void> = []
+    const provision = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+    installApi({ provision })
+
+    const first = useNotebookEnvStore.getState().provision('r')
+    const second = useNotebookEnvStore.getState().provision('r')
+    resolvers[0]?.()
+    await first
+
+    expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(true)
+    resolvers[1]?.()
+    await second
+    expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
+  })
+
   it('keeps python preparing when R is requested concurrently (no phantom cancel — issue 3.1)', async () => {
     // The reported bug: requesting python then R made python look cancelled. Model the serialized
     // provisioner: python's request is still in flight (pending) when R is requested; both languages

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -212,6 +212,29 @@ describe('notebook-env-store', () => {
     expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
   })
 
+  it('keeps an explicit setup preparing after tagged error progress until its call returns', async () => {
+    let rejectProvision: ((reason: Error) => void) | undefined
+    const provision = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectProvision = reject
+        })
+    )
+    const { emit } = installApi({ provision })
+    await useNotebookEnvStore.getState().init()
+
+    const setup = useNotebookEnvStore.getState().provision('r')
+    emit({ phase: 'error', message: 'R setup failed', progress: 0, language: 'r' })
+
+    expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(true)
+    rejectProvision?.(new Error('R setup failed'))
+    await setup
+    expect(useNotebookEnvStore.getState().byLang.r).toMatchObject({
+      preparing: false,
+      error: 'R setup failed'
+    })
+  })
+
   it('keeps a language preparing until its last overlapping provision call returns', async () => {
     const resolvers: Array<() => void> = []
     const provision = vi.fn(

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -320,6 +320,67 @@ describe('notebook-env-store', () => {
     })
   })
 
+  it('keeps an explicit failure when newer automatic progress completes successfully', async () => {
+    let rejectProvision: ((reason: Error) => void) | undefined
+    const provision = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectProvision = reject
+        })
+    )
+    const { api, emit } = installApi({ provision })
+    await useNotebookEnvStore.getState().init()
+
+    const explicit = useNotebookEnvStore.getState().provision('r')
+    const operationId = api.provision.mock.calls[0]?.[1] as string
+    emit({
+      phase: 'error',
+      message: 'Explicit R setup failed',
+      progress: 0,
+      language: 'r',
+      operationId
+    })
+    emit({ phase: 'done', message: 'Automatic R setup ready', progress: 1, language: 'r' })
+    rejectProvision?.(new Error('Explicit R setup failed'))
+    await explicit
+
+    expect(useNotebookEnvStore.getState().byLang.r).toMatchObject({
+      preparing: false,
+      error: 'Explicit R setup failed',
+      progress: { phase: 'done', message: 'Automatic R setup ready' }
+    })
+  })
+
+  it('preserves a newer automatic error over an explicit failure', async () => {
+    let rejectProvision: ((reason: Error) => void) | undefined
+    const provision = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectProvision = reject
+        })
+    )
+    const { api, emit } = installApi({ provision })
+    await useNotebookEnvStore.getState().init()
+
+    const explicit = useNotebookEnvStore.getState().provision('r')
+    const operationId = api.provision.mock.calls[0]?.[1] as string
+    emit({
+      phase: 'error',
+      message: 'Explicit R setup failed',
+      progress: 0,
+      language: 'r',
+      operationId
+    })
+    emit({ phase: 'error', message: 'Automatic R setup failed', progress: 0, language: 'r' })
+    rejectProvision?.(new Error('Explicit R setup failed'))
+    await explicit
+
+    expect(useNotebookEnvStore.getState().byLang.r).toMatchObject({
+      preparing: false,
+      error: 'Automatic R setup failed'
+    })
+  })
+
   it('does not let an automatic terminal event claim a queued explicit setup', async () => {
     let resolveProvision: (() => void) | undefined
     const provision = vi.fn(

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -192,6 +192,26 @@ describe('notebook-env-store', () => {
     expect(useNotebookEnvStore.getState().byLang.python?.preparing).toBe(false)
   })
 
+  it('keeps an explicit setup preparing until its provision call returns after done progress', async () => {
+    let resolveProvision: (() => void) | undefined
+    const provision = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveProvision = resolve
+        })
+    )
+    const { emit } = installApi({ provision })
+    await useNotebookEnvStore.getState().init()
+
+    const setup = useNotebookEnvStore.getState().provision('r')
+    emit({ phase: 'done', message: 'R environment ready', progress: 1, language: 'r' })
+
+    expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(true)
+    resolveProvision?.()
+    await setup
+    expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
+  })
+
   it('keeps python preparing when R is requested concurrently (no phantom cancel — issue 3.1)', async () => {
     // The reported bug: requesting python then R made python look cancelled. Model the serialized
     // provisioner: python's request is still in flight (pending) when R is requested; both languages

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -325,6 +325,37 @@ describe('notebook-env-store', () => {
     expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
   })
 
+  it('settles a queued explicit failure after an older automatic run', async () => {
+    let rejectProvision: ((reason: Error) => void) | undefined
+    const provision = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectProvision = reject
+        })
+    )
+    const { api, emit } = installApi({ provision })
+    await useNotebookEnvStore.getState().init()
+
+    emit({ phase: 'create-r', message: 'Automatic R setup started', progress: 0.1, language: 'r' })
+    const explicit = useNotebookEnvStore.getState().provision('r')
+    const operationId = api.provision.mock.calls[0]?.[1] as string
+    emit({ phase: 'done', message: 'Automatic R setup ready', progress: 1, language: 'r' })
+    emit({
+      phase: 'error',
+      message: 'Explicit R setup failed',
+      progress: 0,
+      language: 'r',
+      operationId
+    })
+    rejectProvision?.(new Error('Explicit R setup failed'))
+
+    await explicit
+    expect(useNotebookEnvStore.getState().byLang.r).toMatchObject({
+      preparing: false,
+      error: 'Explicit R setup failed'
+    })
+  })
+
   it('keeps python preparing when R is requested concurrently (no phantom cancel — issue 3.1)', async () => {
     // The reported bug: requesting python then R made python look cancelled. Model the serialized
     // provisioner: python's request is still in flight (pending) when R is requested; both languages

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -256,6 +256,31 @@ describe('notebook-env-store', () => {
     expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
   })
 
+  it('does not let an older explicit call settle a newer automatic run', async () => {
+    let resolveProvision: (() => void) | undefined
+    const provision = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveProvision = resolve
+        })
+    )
+    const { emit } = installApi({ provision })
+    await useNotebookEnvStore.getState().init()
+
+    const explicit = useNotebookEnvStore.getState().provision('r')
+    emit({ phase: 'done', message: 'Explicit R setup ready', progress: 1, language: 'r' })
+    emit({ phase: 'create-r', message: 'Automatic R setup started', progress: 0.1, language: 'r' })
+    resolveProvision?.()
+    await explicit
+
+    expect(useNotebookEnvStore.getState().byLang.r).toMatchObject({
+      preparing: true,
+      progress: { phase: 'create-r', message: 'Automatic R setup started' }
+    })
+    emit({ phase: 'done', message: 'Automatic R setup ready', progress: 1, language: 'r' })
+    expect(useNotebookEnvStore.getState().byLang.r?.preparing).toBe(false)
+  })
+
   it('keeps python preparing when R is requested concurrently (no phantom cancel — issue 3.1)', async () => {
     // The reported bug: requesting python then R made python look cancelled. Model the serialized
     // provisioner: python's request is still in flight (pending) when R is requested; both languages

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -162,8 +162,8 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
           const language = progress.language
           if (language) {
             const settled =
-              progress.phase === 'error' ||
-              (progress.phase === 'done' && !explicitRuns.has(language))
+              (progress.phase === 'done' || progress.phase === 'error') &&
+              !explicitRuns.has(language)
             applyLang(language, {
               progress,
               error: progress.phase === 'error' ? progress.message : undefined,

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -80,10 +80,11 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
   const beginExplicitRun = (language: NotebookLanguage): void => {
     explicitRuns.set(language, (explicitRuns.get(language) ?? 0) + 1)
   }
-  const endExplicitRun = (language: NotebookLanguage): void => {
+  const endExplicitRun = (language: NotebookLanguage): boolean => {
     const remaining = (explicitRuns.get(language) ?? 1) - 1
     if (remaining > 0) explicitRuns.set(language, remaining)
     else explicitRuns.delete(language)
+    return remaining === 0
   }
 
   // Merges a partial update into state, then re-derives `ui` from the resulting status/scope/
@@ -204,21 +205,22 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         return
       }
       beginExplicitRun(lang)
+      let status: ProvisionStatus | undefined
+      let failure: string | undefined
       try {
         await bridge.provision(lang)
-        const status = await bridge.getStatus()
+        status = await bridge.getStatus()
         applyUi({ status })
-        // Clear preparing BEFORE applyRecoveryBlocks: it skips setting the block message while preparing
-        // is true (so it never stomps a LIVE rebuild's progress) — but this run has already finished, so
-        // the stale optimistic preparing:true set at entry must clear first or a lingering block would
-        // never surface.
-        applyLang(lang, { preparing: false })
-        applyRecoveryBlocks(status)
       } catch (e) {
-        applyUi({ error: errorText(e) })
-        applyLang(lang, { preparing: false, error: errorText(e) })
+        failure = errorText(e)
       } finally {
-        endExplicitRun(lang)
+        if (endExplicitRun(lang)) {
+          applyUi({ error: failure })
+          // Only the last overlapping request settles the shared language card. Clear preparing before
+          // applying recovery state so a completed rebuild can surface a still-active quarantine.
+          applyLang(lang, { preparing: false, error: failure })
+          if (status) applyRecoveryBlocks(status)
+        }
       }
     },
 
@@ -260,17 +262,20 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         return
       }
       beginExplicitRun(lang)
+      let status: ProvisionStatus | undefined
+      let failure: string | undefined
       try {
         await bridge.repair(lang)
-        const status = await bridge.getStatus()
+        status = await bridge.getStatus()
         applyUi({ status })
-        applyLang(lang, { preparing: false })
-        applyRecoveryBlocks(status)
       } catch (e) {
-        applyUi({ error: errorText(e) })
-        applyLang(lang, { preparing: false, error: errorText(e) })
+        failure = errorText(e)
       } finally {
-        endExplicitRun(lang)
+        if (endExplicitRun(lang)) {
+          applyUi({ error: failure })
+          applyLang(lang, { preparing: false, error: failure })
+          if (status) applyRecoveryBlocks(status)
+        }
       }
     }
   }

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -76,6 +76,16 @@ const RECOVERY_BLOCKED_MESSAGE =
 const subscribedBridges = new WeakSet<object>()
 
 export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
+  const explicitRuns = new Map<NotebookLanguage, number>()
+  const beginExplicitRun = (language: NotebookLanguage): void => {
+    explicitRuns.set(language, (explicitRuns.get(language) ?? 0) + 1)
+  }
+  const endExplicitRun = (language: NotebookLanguage): void => {
+    const remaining = (explicitRuns.get(language) ?? 1) - 1
+    if (remaining > 0) explicitRuns.set(language, remaining)
+    else explicitRuns.delete(language)
+  }
+
   // Merges a partial update into state, then re-derives `ui` from the resulting status/scope/
   // progress/error so every consumer of `ui` (onboarding step, launch banner, notebook gate) sees a
   // view that always matches the latest mirrored state (reuses provisioning-view's pure reducer).
@@ -146,11 +156,13 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
             error: progress.phase === 'error' ? progress.message : undefined
           })
           // Route a language-tagged event into that language's slot so its card advances/settles on its
-          // own. A run is done when it reports 'done' or 'error'; language-agnostic events (upgrade/
-          // restore) carry no language and only feed the single-slot ui above.
+          // own. Explicit UI runs stay preparing until their IPC call returns; `done` can arrive before
+          // that boundary. Automatic runs have no awaiting caller, so their terminal event settles them.
           const language = progress.language
           if (language) {
-            const settled = progress.phase === 'done' || progress.phase === 'error'
+            const settled =
+              progress.phase === 'error' ||
+              (progress.phase === 'done' && !explicitRuns.has(language))
             applyLang(language, {
               progress,
               error: progress.phase === 'error' ? progress.message : undefined,
@@ -191,6 +203,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         applyLang(lang, { preparing: false })
         return
       }
+      beginExplicitRun(lang)
       try {
         await bridge.provision(lang)
         const status = await bridge.getStatus()
@@ -204,6 +217,8 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
       } catch (e) {
         applyUi({ error: errorText(e) })
         applyLang(lang, { preparing: false, error: errorText(e) })
+      } finally {
+        endExplicitRun(lang)
       }
     },
 
@@ -244,6 +259,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         applyLang(lang, { preparing: false })
         return
       }
+      beginExplicitRun(lang)
       try {
         await bridge.repair(lang)
         const status = await bridge.getStatus()
@@ -253,6 +269,8 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
       } catch (e) {
         applyUi({ error: errorText(e) })
         applyLang(lang, { preparing: false, error: errorText(e) })
+      } finally {
+        endExplicitRun(lang)
       }
     }
   }

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -106,14 +106,15 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
   const endExplicitRun = (
     language: NotebookLanguage,
     run: ExplicitRun
-  ): { last: boolean; ownsLatestProgress: boolean; latestProgressTerminal: boolean } => {
+  ): { last: boolean; ownsLatestProgress: boolean; newerProgressTerminal: boolean } => {
     const remaining = (explicitRuns.get(language) ?? []).filter((candidate) => candidate !== run)
     if (remaining.length > 0) explicitRuns.set(language, remaining)
     else explicitRuns.delete(language)
     const latest = latestProgress.get(language)
     const completion = {
       last: remaining.length === 0,
-      latestProgressTerminal: latest?.terminal ?? false,
+      newerProgressTerminal:
+        latest?.terminal === true && latest.revision > run.startProgressRevision,
       // An unchanged cursor or another locally queued explicit operation owns the visible state once
       // this renderer's queue drains. Newer automatic or another window's progress must survive.
       ownsLatestProgress:
@@ -259,15 +260,15 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         const completion = endExplicitRun(lang, run)
         if (
           completion.last &&
-          (completion.ownsLatestProgress || completion.latestProgressTerminal)
+          (completion.ownsLatestProgress || completion.newerProgressTerminal)
         ) {
-          if (completion.ownsLatestProgress) applyUi({ error: failure })
+          const error = completion.ownsLatestProgress
+            ? failure
+            : (get().byLang[lang]?.error ?? failure)
+          applyUi({ error })
           // Only the last overlapping request settles the shared language card. Clear preparing before
           // applying recovery state so a completed rebuild can surface a still-active quarantine.
-          applyLang(lang, {
-            preparing: false,
-            ...(completion.ownsLatestProgress ? { error: failure } : {})
-          })
+          applyLang(lang, { preparing: false, error })
           if (status) applyRecoveryBlocks(status)
         }
       }
@@ -323,13 +324,13 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         const completion = endExplicitRun(lang, run)
         if (
           completion.last &&
-          (completion.ownsLatestProgress || completion.latestProgressTerminal)
+          (completion.ownsLatestProgress || completion.newerProgressTerminal)
         ) {
-          if (completion.ownsLatestProgress) applyUi({ error: failure })
-          applyLang(lang, {
-            preparing: false,
-            ...(completion.ownsLatestProgress ? { error: failure } : {})
-          })
+          const error = completion.ownsLatestProgress
+            ? failure
+            : (get().byLang[lang]?.error ?? failure)
+          applyUi({ error })
+          applyLang(lang, { preparing: false, error })
           if (status) applyRecoveryBlocks(status)
         }
       }

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -76,24 +76,27 @@ const RECOVERY_BLOCKED_MESSAGE =
 const subscribedBridges = new WeakSet<object>()
 
 export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
-  type ExplicitRun = { latestProgressRevision: number; terminal: boolean }
-  const progressRevisions = new Map<NotebookLanguage, number>()
+  type ExplicitRun = { operationId: string; startProgressRevision: number }
+  type ProgressCursor = { revision: number; operationId?: string }
+  const latestProgress = new Map<NotebookLanguage, ProgressCursor>()
   const explicitRuns = new Map<NotebookLanguage, ExplicitRun[]>()
+  const localOperationIds = new Map<NotebookLanguage, Set<string>>()
   const beginExplicitRun = (language: NotebookLanguage): ExplicitRun => {
     const run = {
-      latestProgressRevision: progressRevisions.get(language) ?? 0,
-      terminal: false
+      operationId: crypto.randomUUID(),
+      startProgressRevision: latestProgress.get(language)?.revision ?? 0
     }
     explicitRuns.set(language, [...(explicitRuns.get(language) ?? []), run])
+    const operationIds = localOperationIds.get(language) ?? new Set<string>()
+    operationIds.add(run.operationId)
+    localOperationIds.set(language, operationIds)
     return run
   }
-  const trackLanguageProgress = (language: NotebookLanguage, terminal: boolean): void => {
-    const revision = (progressRevisions.get(language) ?? 0) + 1
-    progressRevisions.set(language, revision)
-    const owner = explicitRuns.get(language)?.find((run) => !run.terminal)
-    if (!owner) return
-    owner.latestProgressRevision = revision
-    if (terminal) owner.terminal = true
+  const trackLanguageProgress = (language: NotebookLanguage, operationId?: string): void => {
+    latestProgress.set(language, {
+      revision: (latestProgress.get(language)?.revision ?? 0) + 1,
+      operationId
+    })
   }
   const endExplicitRun = (
     language: NotebookLanguage,
@@ -102,10 +105,20 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
     const remaining = (explicitRuns.get(language) ?? []).filter((candidate) => candidate !== run)
     if (remaining.length > 0) explicitRuns.set(language, remaining)
     else explicitRuns.delete(language)
-    return {
+    const latest = latestProgress.get(language)
+    const completion = {
       last: remaining.length === 0,
-      ownsLatestProgress: run.latestProgressRevision === (progressRevisions.get(language) ?? 0)
+      // An unchanged cursor or another locally queued explicit operation owns the visible state once
+      // this renderer's queue drains. Newer automatic or another window's progress must survive.
+      ownsLatestProgress:
+        !latest ||
+        latest.revision === run.startProgressRevision ||
+        latest.operationId === run.operationId ||
+        (latest.operationId !== undefined &&
+          (localOperationIds.get(language)?.has(latest.operationId) ?? false))
     }
+    if (completion.last) localOperationIds.delete(language)
+    return completion
   }
 
   // Merges a partial update into state, then re-derives `ui` from the resulting status/scope/
@@ -183,7 +196,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
           const language = progress.language
           if (language) {
             const terminal = progress.phase === 'done' || progress.phase === 'error'
-            trackLanguageProgress(language, terminal)
+            trackLanguageProgress(language, progress.operationId)
             const settled = terminal && !explicitRuns.has(language)
             applyLang(language, {
               progress,
@@ -198,7 +211,9 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
               byLang: Object.fromEntries(
                 Object.entries(s.byLang).map(([lang, state]) => [
                   lang,
-                  { ...(state as LangProvisionState), preparing: false }
+                  explicitRuns.has(lang as NotebookLanguage)
+                    ? state
+                    : { ...(state as LangProvisionState), preparing: false }
                 ])
               )
             }))
@@ -229,7 +244,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
       let status: ProvisionStatus | undefined
       let failure: string | undefined
       try {
-        await bridge.provision(lang)
+        await bridge.provision(lang, run.operationId)
         status = await bridge.getStatus()
         applyUi({ status })
       } catch (e) {
@@ -287,7 +302,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
       let status: ProvisionStatus | undefined
       let failure: string | undefined
       try {
-        await bridge.repair(lang)
+        await bridge.repair(lang, run.operationId)
         status = await bridge.getStatus()
         applyUi({ status })
       } catch (e) {

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -77,7 +77,7 @@ const subscribedBridges = new WeakSet<object>()
 
 export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
   type ExplicitRun = { operationId: string; startProgressRevision: number }
-  type ProgressCursor = { revision: number; operationId?: string }
+  type ProgressCursor = { revision: number; operationId?: string; terminal: boolean }
   const latestProgress = new Map<NotebookLanguage, ProgressCursor>()
   const explicitRuns = new Map<NotebookLanguage, ExplicitRun[]>()
   const localOperationIds = new Map<NotebookLanguage, Set<string>>()
@@ -92,22 +92,28 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
     localOperationIds.set(language, operationIds)
     return run
   }
-  const trackLanguageProgress = (language: NotebookLanguage, operationId?: string): void => {
+  const trackLanguageProgress = (
+    language: NotebookLanguage,
+    operationId: string | undefined,
+    terminal: boolean
+  ): void => {
     latestProgress.set(language, {
       revision: (latestProgress.get(language)?.revision ?? 0) + 1,
-      operationId
+      operationId,
+      terminal
     })
   }
   const endExplicitRun = (
     language: NotebookLanguage,
     run: ExplicitRun
-  ): { last: boolean; ownsLatestProgress: boolean } => {
+  ): { last: boolean; ownsLatestProgress: boolean; latestProgressTerminal: boolean } => {
     const remaining = (explicitRuns.get(language) ?? []).filter((candidate) => candidate !== run)
     if (remaining.length > 0) explicitRuns.set(language, remaining)
     else explicitRuns.delete(language)
     const latest = latestProgress.get(language)
     const completion = {
       last: remaining.length === 0,
+      latestProgressTerminal: latest?.terminal ?? false,
       // An unchanged cursor or another locally queued explicit operation owns the visible state once
       // this renderer's queue drains. Newer automatic or another window's progress must survive.
       ownsLatestProgress:
@@ -196,7 +202,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
           const language = progress.language
           if (language) {
             const terminal = progress.phase === 'done' || progress.phase === 'error'
-            trackLanguageProgress(language, progress.operationId)
+            trackLanguageProgress(language, progress.operationId, terminal)
             const settled = terminal && !explicitRuns.has(language)
             applyLang(language, {
               progress,
@@ -251,11 +257,17 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         failure = errorText(e)
       } finally {
         const completion = endExplicitRun(lang, run)
-        if (completion.last && completion.ownsLatestProgress) {
-          applyUi({ error: failure })
+        if (
+          completion.last &&
+          (completion.ownsLatestProgress || completion.latestProgressTerminal)
+        ) {
+          if (completion.ownsLatestProgress) applyUi({ error: failure })
           // Only the last overlapping request settles the shared language card. Clear preparing before
           // applying recovery state so a completed rebuild can surface a still-active quarantine.
-          applyLang(lang, { preparing: false, error: failure })
+          applyLang(lang, {
+            preparing: false,
+            ...(completion.ownsLatestProgress ? { error: failure } : {})
+          })
           if (status) applyRecoveryBlocks(status)
         }
       }
@@ -309,9 +321,15 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         failure = errorText(e)
       } finally {
         const completion = endExplicitRun(lang, run)
-        if (completion.last && completion.ownsLatestProgress) {
-          applyUi({ error: failure })
-          applyLang(lang, { preparing: false, error: failure })
+        if (
+          completion.last &&
+          (completion.ownsLatestProgress || completion.latestProgressTerminal)
+        ) {
+          if (completion.ownsLatestProgress) applyUi({ error: failure })
+          applyLang(lang, {
+            preparing: false,
+            ...(completion.ownsLatestProgress ? { error: failure } : {})
+          })
           if (status) applyRecoveryBlocks(status)
         }
       }

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -76,15 +76,36 @@ const RECOVERY_BLOCKED_MESSAGE =
 const subscribedBridges = new WeakSet<object>()
 
 export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
-  const explicitRuns = new Map<NotebookLanguage, number>()
-  const beginExplicitRun = (language: NotebookLanguage): void => {
-    explicitRuns.set(language, (explicitRuns.get(language) ?? 0) + 1)
+  type ExplicitRun = { latestProgressRevision: number; terminal: boolean }
+  const progressRevisions = new Map<NotebookLanguage, number>()
+  const explicitRuns = new Map<NotebookLanguage, ExplicitRun[]>()
+  const beginExplicitRun = (language: NotebookLanguage): ExplicitRun => {
+    const run = {
+      latestProgressRevision: progressRevisions.get(language) ?? 0,
+      terminal: false
+    }
+    explicitRuns.set(language, [...(explicitRuns.get(language) ?? []), run])
+    return run
   }
-  const endExplicitRun = (language: NotebookLanguage): boolean => {
-    const remaining = (explicitRuns.get(language) ?? 1) - 1
-    if (remaining > 0) explicitRuns.set(language, remaining)
+  const trackLanguageProgress = (language: NotebookLanguage, terminal: boolean): void => {
+    const revision = (progressRevisions.get(language) ?? 0) + 1
+    progressRevisions.set(language, revision)
+    const owner = explicitRuns.get(language)?.find((run) => !run.terminal)
+    if (!owner) return
+    owner.latestProgressRevision = revision
+    if (terminal) owner.terminal = true
+  }
+  const endExplicitRun = (
+    language: NotebookLanguage,
+    run: ExplicitRun
+  ): { last: boolean; ownsLatestProgress: boolean } => {
+    const remaining = (explicitRuns.get(language) ?? []).filter((candidate) => candidate !== run)
+    if (remaining.length > 0) explicitRuns.set(language, remaining)
     else explicitRuns.delete(language)
-    return remaining === 0
+    return {
+      last: remaining.length === 0,
+      ownsLatestProgress: run.latestProgressRevision === (progressRevisions.get(language) ?? 0)
+    }
   }
 
   // Merges a partial update into state, then re-derives `ui` from the resulting status/scope/
@@ -161,9 +182,9 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
           // that boundary. Automatic runs have no awaiting caller, so their terminal event settles them.
           const language = progress.language
           if (language) {
-            const settled =
-              (progress.phase === 'done' || progress.phase === 'error') &&
-              !explicitRuns.has(language)
+            const terminal = progress.phase === 'done' || progress.phase === 'error'
+            trackLanguageProgress(language, terminal)
+            const settled = terminal && !explicitRuns.has(language)
             applyLang(language, {
               progress,
               error: progress.phase === 'error' ? progress.message : undefined,
@@ -204,7 +225,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         applyLang(lang, { preparing: false })
         return
       }
-      beginExplicitRun(lang)
+      const run = beginExplicitRun(lang)
       let status: ProvisionStatus | undefined
       let failure: string | undefined
       try {
@@ -214,7 +235,8 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
       } catch (e) {
         failure = errorText(e)
       } finally {
-        if (endExplicitRun(lang)) {
+        const completion = endExplicitRun(lang, run)
+        if (completion.last && completion.ownsLatestProgress) {
           applyUi({ error: failure })
           // Only the last overlapping request settles the shared language card. Clear preparing before
           // applying recovery state so a completed rebuild can surface a still-active quarantine.
@@ -261,7 +283,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
         applyLang(lang, { preparing: false })
         return
       }
-      beginExplicitRun(lang)
+      const run = beginExplicitRun(lang)
       let status: ProvisionStatus | undefined
       let failure: string | undefined
       try {
@@ -271,7 +293,8 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
       } catch (e) {
         failure = errorText(e)
       } finally {
-        if (endExplicitRun(lang)) {
+        const completion = endExplicitRun(lang, run)
+        if (completion.last && completion.ownsLatestProgress) {
           applyUi({ error: failure })
           applyLang(lang, { preparing: false, error: failure })
           if (status) applyRecoveryBlocks(status)

--- a/src/shared/notebook-env.ts
+++ b/src/shared/notebook-env.ts
@@ -8,6 +8,9 @@ export type ProvisionProgress = {
   phase: string
   message: string
   progress: number
+  // Correlates renderer-requested provision/repair progress with the originating IPC call. Automatic
+  // maintenance omits it so its terminal event cannot accidentally settle a queued explicit request.
+  operationId?: string
   // Explicit at process boundaries so an automatic R provision is not inferred as a global upgrade.
   scope?: ProvisionOperationScope
   // Present for a provision triggered by one notebook run; other sessions remain visible and usable.


### PR DESCRIPTION
## Problem

During app-managed Python or R setup, the renderer can receive the terminal `done` progress event before the provisioning IPC call returns. After the call returns, runtime discovery can also take a few seconds to refresh. Both gaps allowed the shared runtime panel to fall back to an enabled **Download and set up** action even though the original setup was still settling.

The panel is reused by both Settings → Runtimes and the onboarding Notebook runtime step, so both surfaces were affected.

## Proposed change

- Keep explicit per-language provision/repair runs in the preparing state until their IPC call returns, without changing automatic provision completion semantics.
- Track the panel's post-provision discovery refresh per language.
- Keep **Cancel** available while provisioning is still in flight.
- Show a disabled **Finishing setup…** action while the environment list refreshes, preventing a duplicate install request.
- Add regression coverage for the early `done` event and the delayed discovery refresh.

## Scope and non-goals

- No architecture, persistence, data-model, or data-relationship changes.
- No changes to the Windows cache ACL implementation or provisioning backend.
- The interaction change is limited to accurately preserving the setup lifecycle in the existing shared UI.

## Acceptance criteria and validation

Checks below ran after the last material edit.

- Explicit setup remains pending after an early `done` event → targeted store regression → passed.
- Setup is not re-enabled during environment refresh → targeted shared-panel regression → passed.
- Settings and onboarding consumers remain compatible → four-file impact set → **57/57 passed**.
- Renderer types → `tsc --noEmit -p tsconfig.web.json --composite false` → passed.
- Changed source/tests lint → ESLint on the four changed files → passed.
- Full portable Vitest suite → **11,701 passed, 260 skipped, 38 failed** out of 11,999 tests. The remaining failures are outside the changed renderer files and are tied to the local Windows/CI environment: symlink creation permissions, `SetAccessControl` denial, Linux/CI script assumptions, local RPC proxy behavior, and unrelated 15-second timeouts.

Uncovered risk: a packaged Windows build was not manually driven through a real runtime download in this environment. The deterministic renderer/store regressions cover the two state gaps directly.

## Review focus

- The boundary between terminal progress events and explicit IPC completion in `notebook-env-store`.
- The disabled finishing state during the shared panel's environment refresh.
