### PR TITLE
docs(readme): clarify scientific coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 **Open Science is an open-source, local-first, model-agnostic, self-hosted AI research workbench for reproducible scientific discovery.** Built for researchers, it runs on your own computer (macOS, Windows, Linux). Create a project, describe a task in plain language, and let the AI agent read files, run Python and R code, search the web, call scientific data connectors, and return reproducible reports, tables, and figures linked to an inspectable activity history in one workspace.
 
+Open Science currently includes 18 featured research skills and 24 built-in scientific connectors, with its strongest coverage in bioinformatics, computational biology, biomedical research, genomics, structural biology, and computational drug discovery—and an extensible architecture designed to support more scientific disciplines over time.
+
 > 💡 **[Open Science v0.11.0 released](https://github.com/aipoch/open-science/releases/latest)** _(last updated August 5, 2026)_. Highlights include review-gated session plans, hot-switching models and providers without reconnect, agent-aware context replay, prompt history navigation, and a settings keyboard shortcut. See the [latest release notes](https://github.com/aipoch/open-science/releases/latest) for the full changelog.
 
 <p align="center">
@@ -128,6 +130,8 @@ It also includes **24 built-in** research connectors: Literature Graph, PubMed, 
 </table>
 
 ## Why Open Science
+
+Open Science brings research tasks, execution, files, and evidence into one local, inspectable desktop workspace.
 
 Research work is usually split across chat windows, notebooks, local scripts, scientific databases, file browsers, and reporting tools. Context is lost at every handoff, and the answer is often separated from the code and files that produced it.
 


### PR DESCRIPTION
## Problem

The README opening did not summarize the breadth of the built-in scientific catalog, and the "Why Open Science" section began with context before stating the product's answer.

## Proposed change

- State that Open Science includes 18 featured research skills and 24 built-in scientific connectors, using the counts already documented later in the README.
- Add an answer-first lead sentence to "Why Open Science."

## Scope and non-goals

- README documentation only.
- No application behavior, catalog entries, dependencies, or release metadata change.

## Acceptance criteria and validation

- Catalog breadth is visible near the opening and remains consistent with the detailed catalog sections.
- "Why Open Science" opens with a concise value statement.
- The PR title and commit subject follow `<type>(<scope>): <description>`.

Final evidence mapping:

- README Markdown formatting -> `prettier --check README.md` -> pass
- Patch whitespace integrity -> `git diff --check origin/main...HEAD` -> pass
- PR title and commit policy -> `node scripts/ci/check-pr-policy.mjs` with the final base/head and title -> pass
- Trusted repository checks -> `CI Integrity`, `PR policy`, `Static checks`, and aggregate `PR Gate` -> pass

All listed local checks ran after the last material edit, and the trusted checks ran against final head `203a421cfb4de981e957ef3152df30a197db96cc`. `npm test` was not run because this is documentation-only and changes neither `src/` nor code logic. Consumer, platform, build, and E2E lanes were excluded for the same reason.

Independent review remains pending; this change should not be treated as fully verified until that review confirms the final evidence mapping.

## Review focus

Please confirm that the coverage statement accurately reflects the existing 18-skill and 24-connector catalogs and that the added lead sentence improves scanability without overstating product behavior.

## Uncovered risks

The numeric catalog counts are intentionally duplicated from later sections and may need coordinated updates if the catalogs change.
