### PR TITLE
test(settings-store): characterize renderer contracts

### DIFF
--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -55,6 +55,9 @@ type SettingsApi = {
   markOnboardingComplete: ReturnType<typeof vi.fn>
   listSkills: ReturnType<typeof vi.fn>
   setSkillEnabled: ReturnType<typeof vi.fn>
+  createSkill: ReturnType<typeof vi.fn>
+  updateSkill: ReturnType<typeof vi.fn>
+  deleteSkill: ReturnType<typeof vi.fn>
   importSkillZip: ReturnType<typeof vi.fn>
   importSkillZipBatch: ReturnType<typeof vi.fn>
   previewSkillZip: ReturnType<typeof vi.fn>
@@ -107,6 +110,15 @@ const providerView = (id: string): SettingsSnapshot['providers'][number] => ({
   supportsImageInput: false,
   hasKey: true,
   needsKey: false
+})
+
+const skillView = (id: string, name: string) => ({
+  id,
+  name,
+  description: '',
+  source: 'personal' as const,
+  updatedAt: '',
+  enabled: true
 })
 
 let api: SettingsApi
@@ -201,6 +213,9 @@ beforeEach(() => {
       .mockResolvedValue({ ...snapshot([]), onboardingCompletedAt: 4242 }),
     listSkills: vi.fn().mockResolvedValue([]),
     setSkillEnabled: vi.fn().mockResolvedValue([]),
+    createSkill: vi.fn().mockResolvedValue([]),
+    updateSkill: vi.fn().mockResolvedValue([]),
+    deleteSkill: vi.fn().mockResolvedValue([]),
     importSkillZip: vi.fn().mockResolvedValue({ status: 'imported', id: 'z', skills: [] }),
     importSkillZipBatch: vi.fn().mockResolvedValue({ results: [], skills: [] }),
     previewSkillZip: vi.fn().mockResolvedValue({ previews: [], skipped: [] }),
@@ -1074,6 +1089,26 @@ describe('settings store: refreshProviderModels', () => {
     expect(api.setSkillEnabled).toHaveBeenCalledWith({ id: 'demo', enabled: false })
     expect(useSettingsStore.getState().skills[0].enabled).toBe(false)
   })
+
+  it('reconciles create, update, and delete from each authoritative catalog', async () => {
+    const created = skillView('personal-demo', 'Demo')
+    const updated = skillView('personal-demo', 'Updated demo')
+    api.createSkill.mockResolvedValue([created])
+    api.updateSkill.mockResolvedValue([updated])
+    api.deleteSkill.mockResolvedValue([])
+
+    await useSettingsStore.getState().createSkill({ name: 'Demo', description: '', body: '# Demo' })
+    expect(useSettingsStore.getState().skills).toEqual([created])
+
+    await useSettingsStore
+      .getState()
+      .updateSkill({ id: created.id, name: 'Updated demo', description: '', body: '# Demo' })
+    expect(useSettingsStore.getState().skills).toEqual([updated])
+
+    await useSettingsStore.getState().deleteSkill(created.id)
+    expect(api.deleteSkill).toHaveBeenCalledWith({ id: created.id })
+    expect(useSettingsStore.getState().skills).toEqual([])
+  })
 })
 
 describe('settings store: openSettingsToSkill', () => {
@@ -1118,6 +1153,18 @@ describe('settings store: openSettingsToPanel', () => {
 
     useSettingsStore.getState().closeSettings()
     expect(useSettingsStore.getState().isSettingsOpen).toBe(false)
+    expect(useSettingsStore.getState().pendingSettingsPanel).toBeUndefined()
+  })
+
+  it('routes Compute through the panel target and consumes it exactly once', () => {
+    useSettingsStore.getState().openSettingsToSkill('stale-skill')
+    useSettingsStore.getState().openSettingsToCompute()
+
+    expect(useSettingsStore.getState().pendingSettingsPanel).toBe('compute')
+    expect(useSettingsStore.getState().pendingSkillId).toBeUndefined()
+
+    useSettingsStore.getState().consumePendingSettingsPanel()
+    useSettingsStore.getState().openSettings()
     expect(useSettingsStore.getState().pendingSettingsPanel).toBeUndefined()
   })
 })
@@ -1286,6 +1333,17 @@ describe('settings store: connectors slice', () => {
 
     await useSettingsStore.getState().setConnectorEnabled('pubmed', false)
     expect(api.setConnectorEnabled).toHaveBeenCalledWith({ id: 'pubmed', enabled: false })
+    expect(useSettingsStore.getState().connectors[0].enabled).toBe(false)
+  })
+
+  it('keeps the optimistic connector value when main rejects the write', async () => {
+    useSettingsStore.setState({ connectors: [connectorView('pubmed', true)] })
+    api.setConnectorEnabled.mockRejectedValue(new Error('IPC unavailable'))
+
+    await expect(useSettingsStore.getState().setConnectorEnabled('pubmed', false)).rejects.toThrow(
+      'IPC unavailable'
+    )
+
     expect(useSettingsStore.getState().connectors[0].enabled).toBe(false)
   })
 

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -4,6 +4,7 @@ import type {
   ClaudeInstallEvent,
   EnvironmentCheckResult,
   SettingsSnapshot,
+  SkillView,
   ValidateProviderResult,
   ConnectorView,
   CustomServerView
@@ -112,11 +113,11 @@ const providerView = (id: string): SettingsSnapshot['providers'][number] => ({
   needsKey: false
 })
 
-const skillView = (id: string, name: string) => ({
+const skillView = (id: string, name: string): SkillView => ({
   id,
   name,
   description: '',
-  source: 'personal' as const,
+  source: 'personal',
   updatedAt: '',
   enabled: true
 })


### PR DESCRIPTION
## Problem

The renderer Settings Store will be split into internal owner slices in later PRs. A few observable
contracts were not pinned at the store interface, leaving room for accidental behavior drift during
that extraction.

## Proposed change

Add focused Settings Store contract cases for:

- authoritative Skill catalog reconciliation after create, update, and delete;
- Compute deep-link routing through the pending panel target and one-time consumption;
- the existing Connector failure contract: the action rejects while the optimistic value remains.

The existing `useSettingsStore` interface remains the only seam exercised by these tests.

## Scope and non-goals

- Test-only change: one renderer store test file, 58 added lines.
- Production raw changes: 0; the 600-line split trigger did not fire.
- No production logic, broad snapshots, component-test duplication, dependencies, or generated files.
- No attempt to change Connector rollback semantics; later slice extraction must preserve the
  characterized behavior unless a separate behavior change is approved.

## Compatibility

- No architecture, data model, data relationship, IPC, preload, or persisted Settings changes.
- No user interaction changes.
- Electron, Web, CLI, Task, Specialist, Permission, and Compute capability asymmetries are unchanged.

## Acceptance criteria and validation

All commands below ran on exact head `c7f77c9` after the final material edit:

- Settings Store contracts -> `npm test -- src/renderer/src/stores/settings-store.test.ts` -> 88/88 passed.
- Settings/Skills/Connectors/navigation and onboarding consumers -> targeted six-file renderer run ->
  145/145 passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.

The final diff is test-only and has no platform-specific implementation. Full portable and selected
platform coverage remain authoritative in PR Gate CI; Linux E2E was not run locally.

## Review focus

- Confirm the cases assert observable store behavior rather than slice implementation details.
- Confirm the Connector rejection case accurately preserves the current optimistic-state contract.
- Confirm no component behavior is duplicated by the added store-interface cases.

Merge with squash only; retain the Conventional Commit PR title as the squash subject.
