### PR TITLE
test(notebook): characterize runtime facade contracts

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -737,16 +737,15 @@ describe('notebook runtime service', () => {
 
   it('announces agent notebook availability once while publishing notebook changes', async () => {
     const root = await createStorageRoot()
-    const availableSessions: string[] = []
-    const changedSessions: string[] = []
+    const notifications: string[] = []
     const service = new NotebookRuntimeService({
       configRoot: root,
       dataRoot: root,
       projectName: 'default-project',
       repository: new NotebookRunRepository(root),
       callbacks: {
-        onNotebookAvailable: (event) => availableSessions.push(event.sessionId),
-        onNotebookChanged: (event) => changedSessions.push(event.sessionId)
+        onNotebookAvailable: (event) => notifications.push(`available:${event.sessionId}`),
+        onNotebookChanged: (event) => notifications.push(`changed:${event.sessionId}`)
       },
       executorFactory: () => ({
         execute: async (request) => ({
@@ -768,7 +767,7 @@ describe('notebook runtime service', () => {
       source: 'user'
     })
 
-    expect(availableSessions).toEqual([])
+    expect(notifications).toEqual(['changed:user-session'])
 
     const begin = await service.beginCodeCell({
       projectName: 'default-project',
@@ -797,9 +796,15 @@ describe('notebook runtime service', () => {
       cellId: begin.cellId
     })
 
-    expect(availableSessions).toEqual(['agent-session'])
-    expect(changedSessions).toContain('agent-session')
-    expect(changedSessions.filter((sessionId) => sessionId === 'agent-session').length).toBe(5)
+    expect(notifications).toEqual([
+      'changed:user-session',
+      'available:agent-session',
+      'changed:agent-session',
+      'changed:agent-session',
+      'changed:agent-session',
+      'changed:agent-session',
+      'changed:agent-session'
+    ])
   })
 
   it('keeps agent notebook availability process-scoped across session shutdown', async () => {


### PR DESCRIPTION
## Problem

The planned Notebook Runtime ownership refactor needs stable facade-level behavior contracts before package, repair, read-model, and Session lifecycle ownership moves. Existing focused tests already characterize the requested target selection, recovery, verification, reload, shutdown, stale-callback, projection, workflow, local-RPC, and Windows access-violation behavior. The remaining observable gap was callback ordering.

## Proposed change

- Strengthen the existing runtime facade characterization to record one ordered notification stream.
- Assert that a user-authored cell emits only `changed`.
- Assert that the first agent-authored cell emits `available` before its first `changed`, announces availability once, and preserves the existing five change notifications through completion.

The Notebook facade remains the tested interface. No production owner or interface is introduced in N0.

## Scope and non-goals

- Test-only change in `src/main/notebook/runtime-service.test.ts`.
- Production raw changes: **0**; the 600-line split trigger did not fire.
- No production logic, broad snapshots, new helpers, or duplicated package/recovery assertions.
- No changes to persisted data, wire payloads, IPC/local-RPC/MCP methods, authorization, or runtime selection.

## Compatibility

- Electron, Web, CLI/Task, IPC, local RPC, and MCP behavior is unchanged.
- Notebook run history, Session identity, package and environment behavior are unchanged.
- The Windows `STATUS_ACCESS_VIOLATION` and MAX_PATH-wrapped recovery cases remain covered by the provisioner regression suite, including surgical cache repair/reseed and the one-retry ceiling.

## Acceptance criteria and validation

All checks below ran on exact HEAD `fb27ef2` after the last material edit.

- Facade notifications and Notebook/package/recovery contracts → `npm test -- src/main/notebook/runtime-service.test.ts src/main/notebook/runtime-service.export.test.ts src/main/notebook/provisioner.test.ts src/main/notebook/notebook-workflows.test.ts src/main/notebook/application-commands.test.ts src/main/notebook/local-rpc-notebook-adapter.test.ts` → **6 files, 310 tests passed**.
- Node-process type safety → `npm run typecheck:node` → **passed**.
- Repository lint → `npm run lint -- src/main/notebook/runtime-service.test.ts` → **0 errors**; 17 pre-existing warnings outside this diff, with no warning in the changed file.
- Independent review → Standards **0 findings**; Spec **0 findings**.

Actual Windows process behavior is not exercised locally; the portable provisioner regressions passed, and the PR Gate's selected platform lanes remain authoritative. Linux E2E is outside this test-only change's local impact set.

## Review focus

- Confirm the ordered assertion captures the public notification contract without testing implementation details.
- Confirm the PR remains characterization-only and does not duplicate the existing package, repair, Session, workflow, or local-RPC cases.
- Squash merge only; preserve the PR title as the squash commit subject.
