### PR TITLE
fix(notebook): add short Windows cache fallback

### DIFF
--- a/build/windows-runtime-cache-uninstall.ps1
+++ b/build/windows-runtime-cache-uninstall.ps1
@@ -112,8 +112,11 @@ foreach ($root in $roots) {
     $leaf = Get-CacheLeaf $canonicalRoot $userIdentity
     $compactLeaf = Get-CompactCacheLeaf $canonicalRoot $userIdentity
     $candidates = @(
-      (Join-Path ([System.IO.Path]::GetPathRoot($canonicalRoot)) $leaf),
-      (Join-Path $env:USERPROFILE $leaf),
+      (Join-Path ([System.IO.Path]::GetPathRoot($canonicalRoot)) $leaf)
+      if (-not [string]::IsNullOrWhiteSpace($env:PUBLIC)) {
+        (Join-Path $env:PUBLIC $leaf)
+      }
+      (Join-Path $env:USERPROFILE $leaf)
       (Join-Path $env:USERPROFILE $compactLeaf)
     ) | Select-Object -Unique
     foreach ($candidate in $candidates) {

--- a/scripts/electron-builder-config.test.ts
+++ b/scripts/electron-builder-config.test.ts
@@ -34,6 +34,7 @@ describe('electron-builder Windows targets', () => {
     expect(cleanup).toContain('.open-science-cache.json')
     expect(cleanup).toContain('Get-CompactCacheLeaf')
     expect(cleanup).toContain('$compactLeaf = Get-CompactCacheLeaf $canonicalRoot $userIdentity')
+    expect(cleanup).toContain('(Join-Path $env:PUBLIC $leaf)')
     expect(cleanup).toContain('(Join-Path $env:USERPROFILE $compactLeaf)')
     expect(cleanup).toContain('S-1-5-32-544')
     expect(cleanup).toContain('$trustedWriteSids -notcontains $sid')

--- a/src/main/notebook/micromamba-cache.test.ts
+++ b/src/main/notebook/micromamba-cache.test.ts
@@ -72,7 +72,10 @@ describe('selectMicromambaCache', () => {
     const selected = selectMicromambaCache(
       'D:\\OpenScience\\runtime',
       DEFAULT_MAX_CACHE_RELATIVE_PATH,
-      windowsDeps({ prepare })
+      windowsDeps({
+        env: { USERNAME: 'alice', PUBLIC: 'C:\\Users\\Public', USERPROFILE: 'C:\\Users\\alice' },
+        prepare
+      })
     )
 
     expect(selected.path).toMatch(/^C:\\Users\\alice\\osp[0-9a-f]{10}$/)
@@ -97,6 +100,27 @@ describe('selectMicromambaCache', () => {
 
     expect(selected.path).toMatch(/^C:\\Users\\peipeidamowang\\os[0-9a-hjkmnp-tv-z]{8}$/)
     expect(selected.path.length + DEFAULT_MAX_CACHE_RELATIVE_PATH).toBe(WINDOWS_MAX_USABLE_PATH)
+    expect(prepare).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the public directory when the runtime volume is untrusted and the profile path is too long', () => {
+    const prepare = vi.fn((path: string) =>
+      path.startsWith('E:\\') ? undefined : win32.normalize(path)
+    )
+    const selected = selectMicromambaCache(
+      'E:\\deeply\\nested\\storage\\OpenScience\\runtime',
+      DEFAULT_MAX_CACHE_RELATIVE_PATH,
+      windowsDeps({
+        env: {
+          USERNAME: 'peipeidamowang',
+          PUBLIC: 'C:\\Users\\Public',
+          USERPROFILE: 'C:\\Users\\peipeidamowang-with-a-long-profile'
+        },
+        prepare
+      })
+    )
+
+    expect(selected.path).toMatch(/^C:\\Users\\Public\\osp[0-9a-f]{10}$/)
     expect(prepare).toHaveBeenCalledTimes(2)
   })
 
@@ -198,7 +222,11 @@ describe('selectMicromambaCache', () => {
 
 describe('removeMicromambaCacheForRoot', () => {
   const root = 'D:\\OpenScience\\runtime'
-  const env = { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' }
+  const env = {
+    USERNAME: 'alice',
+    PUBLIC: 'C:\\Users\\Public',
+    USERPROFILE: 'C:\\Users\\alice'
+  }
   const marker = {
     schema: 1,
     canonicalRoot: root.toLowerCase(),
@@ -258,7 +286,8 @@ describe('removeMicromambaCacheForRoot', () => {
       remove: (path) => removed.push(path)
     })
 
-    expect(removed).toHaveLength(3)
+    expect(removed).toHaveLength(4)
+    expect(removed).toContainEqual(expect.stringMatching(/^C:\\Users\\Public\\osp[0-9a-f]{10}$/))
     expect(removed).toContainEqual(
       expect.stringMatching(/^C:\\Users\\alice\\os[0-9a-hjkmnp-tv-z]{8}$/)
     )

--- a/src/main/notebook/micromamba-cache.ts
+++ b/src/main/notebook/micromamba-cache.ts
@@ -335,14 +335,17 @@ const candidatePaths = (
   canonicalize: (path: string) => string
 ): Array<{ path: string; profileBoundary?: string }> => {
   const profile = env.USERPROFILE ? win32.normalize(canonicalize(env.USERPROFILE)) : undefined
+  const publicRoot = env.PUBLIC ? win32.normalize(canonicalize(env.PUBLIC)) : undefined
+  const runtimeVolume = win32.parse(canonicalRoot).root
   return [
-    { path: win32.join(win32.parse(canonicalRoot).root, leaf) },
+    { path: win32.join(runtimeVolume, leaf) },
     ...(profile
       ? [
           { path: win32.join(profile, leaf), profileBoundary: profile },
           { path: win32.join(profile, compactLeaf), profileBoundary: profile }
         ]
-      : [])
+      : []),
+    ...(publicRoot ? [{ path: win32.join(publicRoot, leaf) }] : [])
   ]
 }
 


### PR DESCRIPTION
## Problem

On Windows, managed runtime provisioning can still fail when the runtime-volume cache candidate cannot be prepared and both user-profile candidates exceed the pack's fixed path budget. A deeply nested storage location commonly exposes this when it lives on a restricted or network volume, while a long Windows profile leaves no short writable fallback.

The failure is:

```text
No trusted writable package cache fits the managed runtime path budget.
```

## Proposed change

- Preserve the existing candidate priority: runtime volume root, legacy profile cache, then compact profile cache.
- Add `%PUBLIC%\osp<10 hex>` as a final Windows-only fallback.
- Reuse the existing per-user/runtime identity, path-budget check, protected DACL hardening, marker validation, physical-path verification, write probe, and canonical lock key.
- Include the new candidate in data-root cleanup and the packaged Windows uninstall cleanup.
- Cover both the reported long-profile/restricted-volume failure and existing candidate priority.

## Scope and non-goals

- No architecture, schema, data-model, IPC, renderer, or user-interaction change.
- No relocation of managed environment prefixes and no change to storage migration validation.
- No relaxation of cache ownership or ACL trust.
- No dependency or Windows policy change.
- If `%PUBLIC%` is absent, too long, unwritable, or cannot be hardened, selection still fails closed with candidate diagnostics.

## Acceptance criteria and validation

The listed checks ran after the last material edit.

- Long profile + untrusted runtime volume -> `npm test -- src/main/notebook/micromamba-cache.test.ts src/main/notebook/micromamba-cache-preparation.test.ts scripts/electron-builder-config.test.ts` -> passed (3 files, 26 tests).
- Existing candidate priority and cleanup parity -> same targeted command -> passed.
- Source and packaging lint -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings.
- Touched TypeScript formatting -> Prettier check -> passed.
- Windows uninstall script syntax -> PowerShell scriptblock parse -> passed.
- Node typecheck -> `npm run typecheck:node` -> blocked by the shared generated Prisma client missing the already-present `Project.archivedAt` field; all four errors are under `src/main/projects/repository.ts`, outside this diff.
- Portable full suite -> `npm test -- --maxWorkers=4` -> 797 files / 11,742 tests passed; 9 files / 35 tests failed and 13 files / 260 tests skipped. Failures are confined to existing environment constraints: stale Prisma generation, Windows symlink privilege, workflow shell assumptions, local RPC/platform behavior, and provisioner ACL/timing timeouts. No changed cache or packaging test failed.

Uncovered risk: an end-to-end managed runtime install has not been reproduced on the reporting user's exact Windows policy/profile/storage combination. The fallback uses the existing production ACL hardening and trust verifier rather than a relaxed test-only path.

## Review focus

- Existing cache-candidate compatibility and final-fallback ordering.
- Security of creating a per-user, protected cache below the shared Windows Public parent.
- Cleanup parity across data-root migration and packaged uninstall.
- Whether CI's Windows lane confirms the real ACL behavior that the local full suite could not exercise cleanly.
