### PR TITLE
refactor(settings-store): extract write coordinator

### DIFF
--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -18,6 +18,11 @@ import type { PackageMirror } from '../../../shared/mirror'
 import type { CloseActionPreference } from '../../../shared/window-controls'
 import { isMirrorConfigured } from '../pages/settings/mirror-view'
 import type { SettingsPanelId } from '../pages/settings/settings-navigation'
+import {
+  createSettingsWriteCoordinator,
+  type SettingsWriteCoordinator,
+  type SettingsWriteKey
+} from './settings-write-coordinator'
 import type {
   ClaudeDetectResult,
   ClaudeInfo,
@@ -603,7 +608,7 @@ const reportSettingsLoadError = (error: unknown): void => {
 }
 
 // Visible copy stays stable and path-safe; raw IPC failures remain in the console for diagnostics.
-const SETTINGS_WRITE_ERRORS = {
+const SETTINGS_WRITE_ERRORS: Record<SettingsWriteKey, string> = {
   activeProvider: 'Could not switch active provider or model. Try again.',
   agentFramework: 'Could not switch agent framework. Try again.',
   reasoningEffort: 'Could not save reasoning effort. Try again.',
@@ -611,141 +616,15 @@ const SETTINGS_WRITE_ERRORS = {
   conversationSkillImport: 'Could not save conversation Skill import preference. Try again.',
   closePreference: 'Could not save window close preference. Try again.',
   appIcon: 'Could not save app icon preference. Try again.'
-} as const
-
-type SettingsWriteKey = keyof typeof SETTINGS_WRITE_ERRORS
-
-type SettingsWriteToken = {
-  key: SettingsWriteKey
-  generation: number
-  failuresAtStart: ReadonlyMap<SettingsWriteKey, number>
-}
-
-type SettingsWriteFailure = {
-  id: number
-  message: string
-}
-
-type OptimisticSettingsWriteKey =
-  'reasoningEffort' | 'notifications' | 'conversationSkillImport' | 'closePreference' | 'appIcon'
-
-type OptimisticSettingsWriteState<T> = {
-  confirmedValue: T
-  pendingCount: number
-}
-
-const settingsWriteGenerations = new Map<SettingsWriteKey, number>()
-const settingsWriteFailures = new Map<SettingsWriteKey, SettingsWriteFailure>()
-const settingsWriteQueues = new Map<OptimisticSettingsWriteKey, Promise<unknown>>()
-const optimisticSettingsWriteStates = new Map<
-  OptimisticSettingsWriteKey,
-  OptimisticSettingsWriteState<unknown>
->()
-let settingsWriteFailureId = 0
-
-const currentSettingsWriteError = (): string | undefined => {
-  const messages = [...settingsWriteFailures.values()]
-    .sort((left, right) => left.id - right.id)
-    .map((failure) => failure.message)
-
-  return messages.length > 0 ? messages.join(' ') : undefined
-}
-
-// Generations are isolated per preference: a newer write supersedes stale work for that same
-// preference without hiding a failure from a different concurrent write. The token also remembers
-// errors visible when the user started this write so a success clears only those stale errors, not a
-// different failure that arrived while the write was pending.
-const beginSettingsWrite = (key: SettingsWriteKey): SettingsWriteToken => {
-  const generation = (settingsWriteGenerations.get(key) ?? 0) + 1
-  settingsWriteGenerations.set(key, generation)
-  return {
-    key,
-    generation,
-    failuresAtStart: new Map(
-      [...settingsWriteFailures].map(([failureKey, failure]) => [failureKey, failure.id])
-    )
-  }
-}
-
-const isCurrentSettingsWrite = (token: SettingsWriteToken): boolean =>
-  settingsWriteGenerations.get(token.key) === token.generation
-
-// Preserve click order for one optimistic preference while unrelated preferences still write in
-// parallel. This makes the last confirmed value deterministic even when users change one control
-// repeatedly before its previous IPC round trip finishes.
-const runOptimisticSettingsWrite = async <T>(
-  key: OptimisticSettingsWriteKey,
-  write: () => Promise<T>
-): Promise<T> => {
-  const previous = settingsWriteQueues.get(key)
-  const current = previous ? previous.catch(() => undefined).then(write) : write()
-  settingsWriteQueues.set(key, current)
-
-  try {
-    return await current
-  } finally {
-    if (settingsWriteQueues.get(key) === current) settingsWriteQueues.delete(key)
-  }
-}
-
-const beginOptimisticSettingsWrite = <T>(
-  key: OptimisticSettingsWriteKey,
-  confirmedValue: T
-): { writeToken: SettingsWriteToken; optimisticState: OptimisticSettingsWriteState<T> } => {
-  let optimisticState = optimisticSettingsWriteStates.get(key) as
-    OptimisticSettingsWriteState<T> | undefined
-
-  if (!optimisticState) {
-    optimisticState = { confirmedValue, pendingCount: 0 }
-    optimisticSettingsWriteStates.set(key, optimisticState as OptimisticSettingsWriteState<unknown>)
-  }
-  optimisticState.pendingCount += 1
-
-  return { writeToken: beginSettingsWrite(key), optimisticState }
-}
-
-const completeOptimisticSettingsWrite = <T>(
-  key: OptimisticSettingsWriteKey,
-  optimisticState: OptimisticSettingsWriteState<T>,
-  confirmedValue?: { value: T }
-): T => {
-  if (confirmedValue) optimisticState.confirmedValue = confirmedValue.value
-  optimisticState.pendingCount -= 1
-
-  if (
-    optimisticState.pendingCount === 0 &&
-    optimisticSettingsWriteStates.get(key) === optimisticState
-  ) {
-    optimisticSettingsWriteStates.delete(key)
-  }
-
-  return optimisticState.confirmedValue
-}
-
-const finishSettingsWrite = (
-  set: StoreApi<SettingsStore>['setState'],
-  token: SettingsWriteToken,
-  error?: string
-): void => {
-  if (!isCurrentSettingsWrite(token)) return
-
-  if (error) {
-    settingsWriteFailureId += 1
-    settingsWriteFailures.set(token.key, { id: settingsWriteFailureId, message: error })
-  } else {
-    for (const [failureKey, failureId] of token.failuresAtStart) {
-      if (settingsWriteFailures.get(failureKey)?.id === failureId) {
-        settingsWriteFailures.delete(failureKey)
-      }
-    }
-  }
-
-  set({ settingsWriteError: currentSettingsWriteError() })
 }
 
 // Renderer cache of the main-process settings service. The main process stays the source of truth
 // for secrets; this store only ever holds masked provider views.
-export const useSettingsStore = create<SettingsStore>((set, get) => ({
+const createSettingsStoreState = (
+  set: StoreApi<SettingsStore>['setState'],
+  get: StoreApi<SettingsStore>['getState'],
+  writeCoordinator: SettingsWriteCoordinator
+): SettingsStore => ({
   ...createInitialSettingsState(),
 
   // Loads settings, preflight, and encryption availability in one startup pass.
@@ -1119,7 +998,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // Switches the active provider/model (main drops the agent connection so the next prompt reconnects).
   // An empty model string is treated as "no specific model" so main uses the provider default.
   setActiveProvider: async (providerId, model) => {
-    const writeToken = beginSettingsWrite('activeProvider')
+    const write = writeCoordinator.begin('activeProvider')
     let snapshot: SettingsSnapshot
     try {
       snapshot = await window.api.settings.setActiveProvider({
@@ -1127,34 +1006,34 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         model: model || undefined
       })
     } catch (error) {
-      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.activeProvider)
+      write.fail(SETTINGS_WRITE_ERRORS.activeProvider)
       console.error('Failed to set active provider', error)
       throw error
     }
 
-    if (!isCurrentSettingsWrite(writeToken)) return
+    if (!write.isCurrent()) return
     set(applySnapshot(snapshot))
-    finishSettingsWrite(set, writeToken)
+    write.succeed()
     await get().refreshPreflight()
   },
 
   // Switches the agent backend; main reconnects so the choice applies on the next prompt. A failed
   // write leaves the previous framework selected and feeds the shared Settings error banner.
   setAgentFramework: async (id) => {
-    const writeToken = beginSettingsWrite('agentFramework')
+    const write = writeCoordinator.begin('agentFramework')
 
     let snapshot: SettingsSnapshot
     try {
       snapshot = await window.api.settings.setAgentFramework({ id })
     } catch (error) {
-      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.agentFramework)
+      write.fail(SETTINGS_WRITE_ERRORS.agentFramework)
       console.error('Failed to switch agent framework', error)
       throw error
     }
 
-    if (!isCurrentSettingsWrite(writeToken)) return
+    if (!write.isCurrent()) return
     set(applySnapshot(snapshot))
-    finishSettingsWrite(set, writeToken)
+    write.succeed()
 
     try {
       // Live-detect the newly-selected framework so a binary installed (or deleted) since the last
@@ -1179,26 +1058,19 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // optimistically, reconcile from the returned snapshot, and revert if the write fails.
   setReasoningEffort: async (effort) => {
     const previous = get().reasoningEffort
-    const { writeToken, optimisticState } = beginOptimisticSettingsWrite(
-      'reasoningEffort',
-      previous
-    )
+    const write = writeCoordinator.beginOptimistic('reasoningEffort', previous)
     set({ reasoningEffort: effort })
 
     try {
-      const snapshot = await runOptimisticSettingsWrite('reasoningEffort', () =>
-        window.api.settings.setReasoningEffort({ effort })
-      )
-      completeOptimisticSettingsWrite('reasoningEffort', optimisticState, {
-        value: snapshot.reasoningEffort
-      })
-      if (!isCurrentSettingsWrite(writeToken)) return
+      const snapshot = await write.run(() => window.api.settings.setReasoningEffort({ effort }))
+      write.complete({ value: snapshot.reasoningEffort })
+      if (!write.isCurrent()) return
       set(applySnapshot(snapshot))
-      finishSettingsWrite(set, writeToken)
+      write.succeed()
     } catch (error) {
-      const confirmedValue = completeOptimisticSettingsWrite('reasoningEffort', optimisticState)
-      if (isCurrentSettingsWrite(writeToken)) set({ reasoningEffort: confirmedValue })
-      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.reasoningEffort)
+      const confirmedValue = write.complete()
+      if (write.isCurrent()) set({ reasoningEffort: confirmedValue })
+      write.fail(SETTINGS_WRITE_ERRORS.reasoningEffort)
       console.error('Failed to set reasoning effort', error)
     }
   },
@@ -1207,80 +1079,63 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // reconcile from the returned snapshot, and revert if the write fails.
   setNotificationsEnabled: async (enabled) => {
     const previous = get().notificationsEnabled
-    const { writeToken, optimisticState } = beginOptimisticSettingsWrite('notifications', previous)
+    const write = writeCoordinator.beginOptimistic('notifications', previous)
     set({ notificationsEnabled: enabled })
 
     try {
-      const snapshot = await runOptimisticSettingsWrite('notifications', () =>
+      const snapshot = await write.run(() =>
         window.api.settings.setNotificationsEnabled({ enabled })
       )
-      completeOptimisticSettingsWrite('notifications', optimisticState, {
-        value: snapshot.notificationsEnabled
-      })
-      if (!isCurrentSettingsWrite(writeToken)) return
+      write.complete({ value: snapshot.notificationsEnabled })
+      if (!write.isCurrent()) return
       set(applySnapshot(snapshot))
-      finishSettingsWrite(set, writeToken)
+      write.succeed()
     } catch (error) {
-      const confirmedValue = completeOptimisticSettingsWrite('notifications', optimisticState)
-      if (isCurrentSettingsWrite(writeToken)) set({ notificationsEnabled: confirmedValue })
-      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.notifications)
+      const confirmedValue = write.complete()
+      if (write.isCurrent()) set({ notificationsEnabled: confirmedValue })
+      write.fail(SETTINGS_WRITE_ERRORS.notifications)
       console.error('Failed to set notifications enabled', error)
     }
   },
 
   setConversationSkillImportEnabled: async (enabled) => {
     const previous = get().conversationSkillImportEnabled
-    const { writeToken, optimisticState } = beginOptimisticSettingsWrite(
-      'conversationSkillImport',
-      previous
-    )
+    const write = writeCoordinator.beginOptimistic('conversationSkillImport', previous)
     set({ conversationSkillImportEnabled: enabled })
 
     try {
-      const snapshot = await runOptimisticSettingsWrite('conversationSkillImport', () =>
+      const snapshot = await write.run(() =>
         window.api.settings.setConversationSkillImportEnabled({ enabled })
       )
-      completeOptimisticSettingsWrite('conversationSkillImport', optimisticState, {
-        value: snapshot.conversationSkillImportEnabled
-      })
-      if (!isCurrentSettingsWrite(writeToken)) return
+      write.complete({ value: snapshot.conversationSkillImportEnabled })
+      if (!write.isCurrent()) return
       set(applySnapshot(snapshot))
-      finishSettingsWrite(set, writeToken)
+      write.succeed()
     } catch (error) {
-      const confirmedValue = completeOptimisticSettingsWrite(
-        'conversationSkillImport',
-        optimisticState
-      )
-      if (isCurrentSettingsWrite(writeToken)) {
+      const confirmedValue = write.complete()
+      if (write.isCurrent()) {
         set({ conversationSkillImportEnabled: confirmedValue })
       }
-      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.conversationSkillImport)
+      write.fail(SETTINGS_WRITE_ERRORS.conversationSkillImport)
       console.error('Failed to set conversation Skill import enabled', error)
     }
   },
 
   setClosePreference: async (preference) => {
     const previous = get().closePreference
-    const { writeToken, optimisticState } = beginOptimisticSettingsWrite(
-      'closePreference',
-      previous
-    )
+    const write = writeCoordinator.beginOptimistic('closePreference', previous)
     set({ closePreference: preference })
 
     try {
-      const snapshot = await runOptimisticSettingsWrite('closePreference', () =>
-        window.api.settings.setClosePreference({ preference })
-      )
-      completeOptimisticSettingsWrite('closePreference', optimisticState, {
-        value: snapshot.closePreference
-      })
-      if (!isCurrentSettingsWrite(writeToken)) return
+      const snapshot = await write.run(() => window.api.settings.setClosePreference({ preference }))
+      write.complete({ value: snapshot.closePreference })
+      if (!write.isCurrent()) return
       set(applySnapshot(snapshot))
-      finishSettingsWrite(set, writeToken)
+      write.succeed()
     } catch (error) {
-      const confirmedValue = completeOptimisticSettingsWrite('closePreference', optimisticState)
-      if (isCurrentSettingsWrite(writeToken)) set({ closePreference: confirmedValue })
-      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.closePreference)
+      const confirmedValue = write.complete()
+      if (write.isCurrent()) set({ closePreference: confirmedValue })
+      write.fail(SETTINGS_WRITE_ERRORS.closePreference)
       console.error('Failed to set close preference', error)
     }
   },
@@ -1289,31 +1144,24 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   // from the returned snapshot, and revert if the write fails.
   setAppIconVariant: async (variant) => {
     const previous = get().appIconVariant
-    const { writeToken, optimisticState } = beginOptimisticSettingsWrite('appIcon', previous)
+    const write = writeCoordinator.beginOptimistic('appIcon', previous)
     set({ appIconVariant: variant })
 
     try {
-      const snapshot = await runOptimisticSettingsWrite('appIcon', () =>
-        window.api.settings.setAppIconVariant({ variant })
-      )
-      completeOptimisticSettingsWrite('appIcon', optimisticState, {
-        value: snapshot.appIconVariant
-      })
-      if (!isCurrentSettingsWrite(writeToken)) return
+      const snapshot = await write.run(() => window.api.settings.setAppIconVariant({ variant }))
+      write.complete({ value: snapshot.appIconVariant })
+      if (!write.isCurrent()) return
       set(applySnapshot(snapshot))
-      finishSettingsWrite(set, writeToken)
+      write.succeed()
     } catch (error) {
-      const confirmedValue = completeOptimisticSettingsWrite('appIcon', optimisticState)
-      if (isCurrentSettingsWrite(writeToken)) set({ appIconVariant: confirmedValue })
-      finishSettingsWrite(set, writeToken, SETTINGS_WRITE_ERRORS.appIcon)
+      const confirmedValue = write.complete()
+      if (write.isCurrent()) set({ appIconVariant: confirmedValue })
+      write.fail(SETTINGS_WRITE_ERRORS.appIcon)
       console.error('Failed to set app icon variant', error)
     }
   },
 
-  clearSettingsWriteError: () => {
-    settingsWriteFailures.clear()
-    set({ settingsWriteError: undefined })
-  },
+  clearSettingsWriteError: () => writeCoordinator.clearFailures(),
 
   // Detects the opencode executable and refreshes its status card.
   detectOpencode: async () => {
@@ -1575,6 +1423,14 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     const saved = await window.api.settings.setPackageMirror(mirror)
     set({ packageMirror: isMirrorConfigured(saved) ? saved : undefined })
   }
-}))
+})
+
+export const useSettingsStore = create<SettingsStore>((set, get) =>
+  createSettingsStoreState(
+    set,
+    get,
+    createSettingsWriteCoordinator((settingsWriteError) => set({ settingsWriteError }))
+  )
+)
 
 export type { SaveProviderResult }

--- a/src/renderer/src/stores/settings-write-coordinator.test.ts
+++ b/src/renderer/src/stores/settings-write-coordinator.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createSettingsWriteCoordinator } from './settings-write-coordinator'
+
+const deferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} => {
+  let resolve: (value: T) => void = () => undefined
+  const promise = new Promise<T>((complete) => {
+    resolve = complete
+  })
+  return { promise, resolve }
+}
+
+describe('settings write coordinator', () => {
+  it('fences stale same-key writes and preserves later cross-key failures', () => {
+    const errors: Array<string | undefined> = []
+    const writes = createSettingsWriteCoordinator((error) => errors.push(error))
+
+    const stale = writes.begin('reasoningEffort')
+    const current = writes.begin('reasoningEffort')
+    stale.fail('stale reasoning failure')
+    current.fail('reasoning failure')
+
+    const clearsExisting = writes.begin('notifications')
+    writes.begin('appIcon').fail('app icon failure')
+    clearsExisting.succeed()
+
+    expect(errors).toEqual([
+      'reasoning failure',
+      'reasoning failure app icon failure',
+      'app icon failure'
+    ])
+  })
+
+  it('serializes one preference while unrelated preferences remain independent', async () => {
+    const writes = createSettingsWriteCoordinator(vi.fn())
+    const firstGate = deferred<string>()
+    const order: string[] = []
+    const first = writes.beginOptimistic<string>('reasoningEffort', 'default')
+    const second = writes.beginOptimistic<string>('reasoningEffort', 'default')
+
+    const firstPending = first.run(() => {
+      order.push('reasoning:first')
+      return firstGate.promise
+    })
+    const secondPending = second.run(async () => {
+      order.push('reasoning:second')
+      return 'max'
+    })
+    const unrelatedPending = writes
+      .beginOptimistic<boolean>('notifications', true)
+      .run(async () => {
+        order.push('notifications')
+        return false
+      })
+
+    await unrelatedPending
+    expect(order).toEqual(['reasoning:first', 'notifications'])
+
+    firstGate.resolve('high')
+    await Promise.all([firstPending, secondPending])
+    expect(order).toEqual(['reasoning:first', 'notifications', 'reasoning:second'])
+  })
+
+  it('rolls back to the last confirmed value after a queued write fails', async () => {
+    const writes = createSettingsWriteCoordinator(vi.fn())
+    const first = writes.beginOptimistic<string>('reasoningEffort', 'default')
+    const second = writes.beginOptimistic<string>('reasoningEffort', 'default')
+
+    const confirmed = await first.run(async () => 'high')
+    first.complete({ value: confirmed })
+    await expect(
+      second.run(async () => {
+        throw new Error('write failed')
+      })
+    ).rejects.toThrow('write failed')
+
+    expect(second.complete()).toBe('high')
+  })
+
+  it('keeps coordinator instances isolated', () => {
+    const firstError = vi.fn()
+    const secondError = vi.fn()
+    const first = createSettingsWriteCoordinator(firstError)
+    const second = createSettingsWriteCoordinator(secondError)
+
+    first.begin('notifications').fail('first failure')
+    second.begin('notifications').succeed()
+
+    expect(firstError).toHaveBeenLastCalledWith('first failure')
+    expect(secondError).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('clears visible failures without cancelling an in-flight write', () => {
+    const onError = vi.fn()
+    const writes = createSettingsWriteCoordinator(onError)
+    const pending = writes.begin('notifications')
+
+    writes.begin('appIcon').fail('app icon failure')
+    writes.clearFailures()
+    pending.fail('notification failure')
+
+    expect(onError.mock.calls.map(([error]) => error)).toEqual([
+      'app icon failure',
+      undefined,
+      'notification failure'
+    ])
+  })
+})

--- a/src/renderer/src/stores/settings-write-coordinator.ts
+++ b/src/renderer/src/stores/settings-write-coordinator.ts
@@ -1,0 +1,163 @@
+export type SettingsWriteKey =
+  | 'activeProvider'
+  | 'agentFramework'
+  | 'reasoningEffort'
+  | 'notifications'
+  | 'conversationSkillImport'
+  | 'closePreference'
+  | 'appIcon'
+
+export type OptimisticSettingsWriteKey =
+  'reasoningEffort' | 'notifications' | 'conversationSkillImport' | 'closePreference' | 'appIcon'
+
+type SettingsWriteToken = {
+  key: SettingsWriteKey
+  generation: number
+  failuresAtStart: ReadonlyMap<SettingsWriteKey, number>
+}
+
+type SettingsWriteFailure = {
+  id: number
+  message: string
+}
+
+type OptimisticSettingsWriteState<T> = {
+  confirmedValue: T
+  pendingCount: number
+}
+
+export type SettingsWrite = {
+  isCurrent: () => boolean
+  succeed: () => void
+  fail: (message: string) => void
+}
+
+export type OptimisticSettingsWrite<T> = SettingsWrite & {
+  run: <Result>(write: () => Promise<Result>) => Promise<Result>
+  complete: (confirmedValue?: { value: T }) => T
+}
+
+export type SettingsWriteCoordinator = {
+  begin: (key: SettingsWriteKey) => SettingsWrite
+  beginOptimistic: <T>(
+    key: OptimisticSettingsWriteKey,
+    confirmedValue: T
+  ) => OptimisticSettingsWrite<T>
+  clearFailures: () => void
+}
+
+// Owns the process-local ordering, staleness and failure state for one Settings Store instance.
+// Callers retain their existing command-specific settlement policy: only preference commands use
+// beginOptimistic and its confirmed-value rollback; Connector commands remain outside this owner.
+export const createSettingsWriteCoordinator = (
+  onVisibleError: (error: string | undefined) => void
+): SettingsWriteCoordinator => {
+  const generations = new Map<SettingsWriteKey, number>()
+  const failures = new Map<SettingsWriteKey, SettingsWriteFailure>()
+  const queues = new Map<OptimisticSettingsWriteKey, Promise<unknown>>()
+  const optimisticStates = new Map<
+    OptimisticSettingsWriteKey,
+    OptimisticSettingsWriteState<unknown>
+  >()
+  let failureId = 0
+
+  const currentError = (): string | undefined => {
+    const messages = [...failures.values()]
+      .sort((left, right) => left.id - right.id)
+      .map((failure) => failure.message)
+
+    return messages.length > 0 ? messages.join(' ') : undefined
+  }
+
+  const isCurrent = (token: SettingsWriteToken): boolean =>
+    generations.get(token.key) === token.generation
+
+  const settle = (token: SettingsWriteToken, error?: string): void => {
+    if (!isCurrent(token)) return
+
+    if (error) {
+      failureId += 1
+      failures.set(token.key, { id: failureId, message: error })
+    } else {
+      for (const [failureKey, failureAtStart] of token.failuresAtStart) {
+        if (failures.get(failureKey)?.id === failureAtStart) failures.delete(failureKey)
+      }
+    }
+
+    onVisibleError(currentError())
+  }
+
+  const begin = (key: SettingsWriteKey): SettingsWrite => {
+    const generation = (generations.get(key) ?? 0) + 1
+    generations.set(key, generation)
+    const token: SettingsWriteToken = {
+      key,
+      generation,
+      failuresAtStart: new Map(
+        [...failures].map(([failureKey, failure]) => [failureKey, failure.id])
+      )
+    }
+
+    return {
+      isCurrent: () => isCurrent(token),
+      succeed: () => settle(token),
+      fail: (message) => settle(token, message)
+    }
+  }
+
+  const runQueued = async <T>(
+    key: OptimisticSettingsWriteKey,
+    write: () => Promise<T>
+  ): Promise<T> => {
+    const previous = queues.get(key)
+    const current = previous ? previous.catch(() => undefined).then(write) : write()
+    queues.set(key, current)
+
+    try {
+      return await current
+    } finally {
+      if (queues.get(key) === current) queues.delete(key)
+    }
+  }
+
+  const completeOptimistic = <T>(
+    key: OptimisticSettingsWriteKey,
+    state: OptimisticSettingsWriteState<T>,
+    confirmedValue?: { value: T }
+  ): T => {
+    if (confirmedValue) state.confirmedValue = confirmedValue.value
+    state.pendingCount -= 1
+
+    if (state.pendingCount === 0 && optimisticStates.get(key) === state) {
+      optimisticStates.delete(key)
+    }
+
+    return state.confirmedValue
+  }
+
+  return {
+    begin,
+    beginOptimistic: <T>(
+      key: OptimisticSettingsWriteKey,
+      confirmedValue: T
+    ): OptimisticSettingsWrite<T> => {
+      let state = optimisticStates.get(key) as OptimisticSettingsWriteState<T> | undefined
+
+      if (!state) {
+        state = { confirmedValue, pendingCount: 0 }
+        optimisticStates.set(key, state as OptimisticSettingsWriteState<unknown>)
+      }
+      state.pendingCount += 1
+
+      return {
+        ...begin(key),
+        run: (write) => runQueued(key, write),
+        complete: (value) => completeOptimistic(key, state, value)
+      }
+    },
+    clearFailures: () => {
+      failures.clear()
+      onVisibleError(undefined)
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The renderer Settings Store kept write generations, optimistic queues, confirmed rollback values,
and visible failure precedence in module-global Maps inside the 1,580-line compatibility store. That
made write ownership implicit and prevented isolated construction tests ahead of slice extraction.

## Proposed change

Add a process-local Settings write coordinator constructed once per `useSettingsStore` instance.
Its small internal interface starts ordinary or optimistic writes, exposes current-generation status,
settles success/failure, serializes each rollback preference, and clears acknowledged failures.

```mermaid
flowchart LR
  Commands["Active provider / framework / preference commands"] --> Coordinator["Settings write coordinator"]
  Coordinator --> State["Generations / per-key queues / failures / confirmed values"]
  Coordinator --> Banner["settingsWriteError projection"]
  Connectors["Connector optimistic toggles"] -. "existing reject + retain value" .-> Main["existing renderer commands"]
```

The command callers continue to own their settlement policy, snapshot application, logging, and
throw-versus-resolve behavior.

## Scope and non-goals

- Production raw changes: 445 (`settings-store.ts` +69/-213; coordinator +163). The 600-line split
  trigger did not fire.
- Settings Store physical size: 1,580 -> 1,436 lines.
- Add five focused coordinator interface tests; retain the existing compatibility-store race tests.
- Do not change public actions, selectors, error strings, IPC calls, transport, UI, or dependencies.
- Do not introduce a generic async framework.
- Connector enabled, auto-allow, and custom-server enabled commands remain outside the coordinator:
  failures still reject and retain their optimistic value without a Settings error banner.

## Compatibility

- Preference writes retain per-key serialization, cross-key independence, stale fencing, failure
  precedence, and rollback to the last confirmed value.
- Active provider and framework failures still reject; preference failures still resolve after
  rollback.
- No architecture outside renderer-internal state ownership changes.
- No persisted data model, data relationship, user interaction, IPC/preload, Electron/Web/CLI/Task,
  Specialist, Permission, or Compute capability change.

## Acceptance criteria and validation

All checks ran on exact head `82ffa307` after rebasing onto `origin/main` at `439e66f4`:

- Coordinator owner and compatibility-store contracts -> targeted two-file Vitest run -> 93/93 passed.
- General Settings, model/framework, Settings navigation, and onboarding consumers -> targeted
  six-file renderer run -> 138/138 passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Changed files -> targeted ESLint -> passed.
- Independent review -> Standards 0 findings; Spec 0 findings.

The change is process-local and platform-neutral. Full portable, build, and platform checks remain
authoritative in PR Gate CI; Linux E2E was not run locally.

## Review focus

- Confirm the coordinator owns all former module-global write Maps and is constructed per store.
- Confirm stale completion, failure ordering, queue independence, and last-confirmed rollback match
  the previous implementation.
- Confirm command-specific settlement remains in callers and Connector commands remain untouched.

Merge with squash only; retain the Conventional Commit PR title as the squash subject.
