### PR TITLE
feat(workspace): show tool activity elapsed time

### DIFF
--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -783,8 +783,17 @@ describe('TaskRunner', () => {
             terminalExitCode: 0
           })
           emitEvent?.({
-            id: 'provider-error',
+            id: 'tool-metadata',
             timestamp: 12,
+            kind: 'tool',
+            level: 'info',
+            sessionId: 'session-tool',
+            toolCallId: 'tool-call-1',
+            rawOutput: { stdout: 'done' }
+          })
+          emitEvent?.({
+            id: 'provider-error',
+            timestamp: 13,
             kind: 'error',
             level: 'error',
             sessionId: 'session-tool',
@@ -818,9 +827,12 @@ describe('TaskRunner', () => {
           id: 'tool-call-1',
           title: 'Run analysis',
           status: 'completed',
-          eventIds: ['tool-start', 'tool-complete'],
+          eventIds: ['tool-start', 'tool-complete', 'tool-metadata'],
+          rawOutput: { stdout: 'done' },
           terminalOutput: 'done\n',
-          terminalExitCode: 0
+          terminalExitCode: 0,
+          createdAt: 10,
+          updatedAt: 11
         }
       ]
     })

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -670,12 +670,14 @@ class TaskRunner {
     for (const event of events) {
       if (event.kind !== 'tool' || !event.toolCallId) continue
       const existing = activities.get(event.toolCallId)
+      const isTerminal = existing?.status === 'completed' || existing?.status === 'failed'
       activities.set(event.toolCallId, {
         id: event.toolCallId,
         kind: 'tool',
         title: event.title?.trim() || existing?.title || 'Tool call',
-        status:
-          event.status === 'failed'
+        status: isTerminal
+          ? existing.status
+          : event.status === 'failed'
             ? 'failed'
             : event.status === 'completed'
               ? 'completed'
@@ -690,8 +692,8 @@ class TaskRunner {
         rawOutput: event.rawOutput ?? existing?.rawOutput,
         terminalOutput: event.terminalOutput ?? existing?.terminalOutput,
         terminalExitCode: event.terminalExitCode ?? existing?.terminalExitCode,
-        createdAt: existing?.createdAt ?? now,
-        updatedAt: now
+        createdAt: existing?.createdAt ?? event.timestamp,
+        updatedAt: isTerminal ? existing.updatedAt : event.timestamp
       })
     }
     return [...activities.values()]

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -863,6 +863,7 @@ describe('workspace runtime events', () => {
     const wasApplied = await applyWorkspaceRuntimeEvent(
       createEvent({
         id: 'event-1',
+        timestamp: 10,
         kind: 'tool',
         toolCallId: 'tool-web-1',
         toolKind: 'fetch',
@@ -889,6 +890,7 @@ describe('workspace runtime events', () => {
     await applyWorkspaceRuntimeEvent(
       createEvent({
         id: 'event-2',
+        timestamp: 25,
         kind: 'tool',
         toolCallId: 'tool-web-1',
         status: 'completed'
@@ -904,6 +906,8 @@ describe('workspace runtime events', () => {
         providerToolName: 'WebSearch',
         title: '"open science repositories"',
         status: 'completed',
+        createdAt: 10,
+        updatedAt: 25,
         eventIds: ['event-1', 'event-2'],
         toolContent: [
           {

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -501,6 +501,7 @@ const applyWorkspaceRuntimeEvent = async (
       sessionId: event.sessionId,
       toolCallId: event.toolCallId,
       eventId: event.id,
+      timestamp: event.timestamp,
       promptMessageId: event.promptMessageId,
       title: event.title,
       status: event.status,

--- a/src/renderer/src/pages/workspace/ArtifactProvenanceMessages.integration.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenanceMessages.integration.test.tsx
@@ -78,8 +78,10 @@ describe('ProvenanceMessagesTimeline integration', () => {
     expect(container.textContent).toContain('Plot a sine curve')
     expect(container.textContent).toContain('Notebook execution')
 
-    const transcriptRows = Array.from(
-      container.querySelectorAll<HTMLElement>('[class~="pb-1"][class~="pt-5"]')
+    const messageRow = container.querySelector<HTMLElement>('[class~="pb-1"][class~="pt-5"]')
+    const activityGroup = container.querySelector<HTMLElement>('[data-testid="tool-group"]')
+    const transcriptRows = [messageRow, activityGroup?.parentElement].filter(
+      (row): row is HTMLElement => row instanceof HTMLElement
     )
     expect(transcriptRows).toHaveLength(2)
     for (const row of transcriptRows) {

--- a/src/renderer/src/pages/workspace/WorkspaceActivityGroup.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceActivityGroup.tsx
@@ -1,6 +1,8 @@
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { cn } from '@/lib/utils'
 import { ChevronRight } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 import type { JobSummary } from '../../../../shared/compute'
 import { RemoteJobRow } from '@/components/RemoteJobRow'
@@ -10,8 +12,10 @@ import { WorkspaceToolDetailsRow } from './WorkspaceToolDetailsRow'
 import { WorkspaceWebSearchActivityRow } from './WorkspaceWebSearchActivityRow'
 import { buildToolActivityDetails } from './workspace-tool-activity-details'
 import {
+  formatActivityGroupElapsed,
   formatActivityGroupTitle,
   formatStepCount,
+  getActivityGroupElapsedMs,
   getRenderableActivityEntries,
   isSearchActivity
 } from './workspace-tool-activity-groups'
@@ -19,6 +23,7 @@ import type {
   ActivityExpansionOverrides,
   ConversationActivityGroupItem
 } from './workspace-tool-activity-groups'
+import { isActivityActive } from './workspace-conversation-items'
 import { formatWebSearchDetails } from './workspace-web-search-details'
 
 type WorkspaceActivityGroupProps = {
@@ -32,6 +37,27 @@ type WorkspaceActivityGroupProps = {
   // Map of job_id → JobSummary for jobs bound to activities in this group.
   jobsByActivityId?: Map<string, JobSummary>
   onOpenJobDetail?: (job: JobSummary) => void
+}
+
+const ACTIVE_ELAPSED_TICK_MS = 100
+
+// Isolates the ticking clock so active tools do not re-render the group's expanded detail rows.
+const ActivityGroupElapsed = ({
+  activities
+}: {
+  activities: ConversationActivityGroupItem['activities']
+}): React.JSX.Element => {
+  const isActive = activities.some(isActivityActive)
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (!isActive) return undefined
+
+    const timer = setInterval(() => setNow(Date.now()), ACTIVE_ELAPSED_TICK_MS)
+    return () => clearInterval(timer)
+  }, [isActive])
+
+  return <>{formatActivityGroupElapsed(getActivityGroupElapsedMs(activities, now))}</>
 }
 
 // Renders adjacent tool calls as one collapsible transcript row group.
@@ -75,7 +101,8 @@ const WorkspaceActivityGroup = ({
               {formatActivityGroupTitle(group.activities, group.title)}
             </span>
             <span className="ml-auto shrink-0 whitespace-nowrap text-[12px] tabular-nums text-text-100">
-              {formatStepCount(visibleActivities)}
+              {formatStepCount(visibleActivities)} ·{' '}
+              <ActivityGroupElapsed activities={visibleActivities} />
             </span>
           </button>
           {isExpanded ? (

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -178,6 +178,34 @@ const renderScroller = async (session: ChatSession): Promise<string> => {
 }
 
 describe('WorkspaceMessageScroller loading render', () => {
+  it('renders elapsed time beside the activity step count', async () => {
+    const html = await renderScroller(
+      createSession({
+        status: 'idle',
+        messages: [createMessage({ id: 'prompt-1' })],
+        activities: [
+          createActivity({
+            id: 'tool-read-1',
+            title: 'Read file',
+            toolKind: 'read',
+            createdAt: 1_000,
+            updatedAt: 1_250
+          }),
+          createActivity({
+            id: 'tool-read-2',
+            title: 'Read file',
+            toolKind: 'read',
+            sortIndex: 3,
+            createdAt: 1_300,
+            updatedAt: 2_650
+          })
+        ]
+      })
+    )
+
+    expect(html).toContain('2 steps · 1s')
+  })
+
   it('renders a coordinator-owned handoff status in the original turn timeline', async () => {
     const source: HandoffLifecycleEventSource = {
       getEvents: (): readonly HandoffLifecycleEvent[] => [

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
@@ -298,7 +298,7 @@ describe('activity group elapsed time', () => {
     expect(formatActivityGroupElapsed(3_723_000)).toBe('1h 2m 3s')
   })
 
-  it('keeps counting while any tool is active', () => {
+  it('adds completed work and keeps counting the active tool', () => {
     const activities = [
       createActivity({ id: 's1', createdAt: 1_000, updatedAt: 1_400 }),
       createActivity({
@@ -309,15 +309,15 @@ describe('activity group elapsed time', () => {
       })
     ]
 
-    expect(getActivityGroupElapsedMs(activities, 2_750)).toBe(1_750)
+    expect(getActivityGroupElapsedMs(activities, 2_750)).toBe(1_650)
   })
 
-  it('freezes at the latest update after every tool settles', () => {
+  it('excludes idle gaps between completed tools', () => {
     const activities = [
       createActivity({ id: 's1', createdAt: 1_000, updatedAt: 1_400 }),
       createActivity({ id: 's2', createdAt: 1_500, updatedAt: 2_600 })
     ]
 
-    expect(getActivityGroupElapsedMs(activities, 9_000)).toBe(1_600)
+    expect(getActivityGroupElapsedMs(activities, 9_000)).toBe(1_500)
   })
 })

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest'
 import type { ChatMessage, ToolActivity } from '@/stores/session-store'
 import type { ConversationItem } from './workspace-conversation-items'
 import {
+  formatActivityGroupElapsed,
   formatActivityGroupTitle,
   formatStepCount,
+  getActivityGroupElapsedMs,
   getRenderableActivityEntries,
   groupConversationItems,
   isSearchActivity
@@ -285,5 +287,37 @@ describe('formatStepCount', () => {
     expect(formatStepCount([createActivity({ id: 's1' }), createActivity({ id: 's2' })])).toBe(
       '2 steps'
     )
+  })
+})
+
+describe('activity group elapsed time', () => {
+  it('uses milliseconds for short work and compact larger units', () => {
+    expect(formatActivityGroupElapsed(412.9)).toBe('412ms')
+    expect(formatActivityGroupElapsed(12_900)).toBe('12s')
+    expect(formatActivityGroupElapsed(192_000)).toBe('3m 12s')
+    expect(formatActivityGroupElapsed(3_723_000)).toBe('1h 2m 3s')
+  })
+
+  it('keeps counting while any tool is active', () => {
+    const activities = [
+      createActivity({ id: 's1', createdAt: 1_000, updatedAt: 1_400 }),
+      createActivity({
+        id: 's2',
+        status: 'in_progress',
+        createdAt: 1_500,
+        updatedAt: 1_500
+      })
+    ]
+
+    expect(getActivityGroupElapsedMs(activities, 2_750)).toBe(1_750)
+  })
+
+  it('freezes at the latest update after every tool settles', () => {
+    const activities = [
+      createActivity({ id: 's1', createdAt: 1_000, updatedAt: 1_400 }),
+      createActivity({ id: 's2', createdAt: 1_500, updatedAt: 2_600 })
+    ]
+
+    expect(getActivityGroupElapsedMs(activities, 9_000)).toBe(1_600)
   })
 })

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
@@ -282,17 +282,14 @@ const formatStepCount = (activities: ToolActivity[]): string => {
   return failedCount > 0 ? `${stepLabel} · ${failedCount} failed` : stepLabel
 }
 
-// Measures a group from its first tool start until now, or its final update once every tool settles.
-const getActivityGroupElapsedMs = (activities: ToolActivity[], now: number): number => {
-  if (activities.length === 0) return 0
-
-  const startedAt = Math.min(...activities.map((activity) => activity.createdAt))
-  const endedAt = activities.some(isActivityActive)
-    ? now
-    : Math.max(...activities.map((activity) => activity.updatedAt))
-
-  return Math.max(0, endedAt - startedAt)
-}
+// Adds each tool's own runtime, excluding idle gaps between tools in the same group.
+const getActivityGroupElapsedMs = (activities: ToolActivity[], now: number): number =>
+  activities.reduce(
+    (total, activity) =>
+      total +
+      Math.max(0, (isActivityActive(activity) ? now : activity.updatedAt) - activity.createdAt),
+    0
+  )
 
 // Keeps short work precise, then switches to compact clock units as the elapsed span grows.
 const formatActivityGroupElapsed = (elapsedMs: number): string => {

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
@@ -282,9 +282,38 @@ const formatStepCount = (activities: ToolActivity[]): string => {
   return failedCount > 0 ? `${stepLabel} · ${failedCount} failed` : stepLabel
 }
 
+// Measures a group from its first tool start until now, or its final update once every tool settles.
+const getActivityGroupElapsedMs = (activities: ToolActivity[], now: number): number => {
+  if (activities.length === 0) return 0
+
+  const startedAt = Math.min(...activities.map((activity) => activity.createdAt))
+  const endedAt = activities.some(isActivityActive)
+    ? now
+    : Math.max(...activities.map((activity) => activity.updatedAt))
+
+  return Math.max(0, endedAt - startedAt)
+}
+
+// Keeps short work precise, then switches to compact clock units as the elapsed span grows.
+const formatActivityGroupElapsed = (elapsedMs: number): string => {
+  const milliseconds = Math.max(0, Math.floor(elapsedMs))
+  if (milliseconds < 1000) return `${milliseconds}ms`
+
+  const totalSeconds = Math.floor(milliseconds / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`
+  if (minutes > 0) return `${minutes}m ${seconds}s`
+  return `${seconds}s`
+}
+
 export {
+  formatActivityGroupElapsed,
   formatActivityGroupTitle,
   formatStepCount,
+  getActivityGroupElapsedMs,
   getRenderableActivityEntries,
   groupConversationItems,
   isSearchActivity

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1510,8 +1510,16 @@ describe('session store', () => {
       sessionId: 'transport-session-1',
       toolCallId: 'tool-web-1',
       eventId: 'event-1',
+      timestamp: 10,
       toolKind: 'fetch',
       title: '"open science repositories"',
+      status: 'in_progress'
+    })
+    useSessionStore.getState().upsertToolActivity({
+      sessionId: 'transport-session-1',
+      toolCallId: 'tool-web-1',
+      eventId: 'event-terminal',
+      timestamp: 20,
       status: 'completed'
     })
     useSessionStore.getState().finishRun('transport-session-1')
@@ -1520,6 +1528,7 @@ describe('session store', () => {
       sessionId: 'transport-session-1',
       toolCallId: 'tool-web-1',
       eventId: 'event-2',
+      timestamp: 30,
       status: 'pending'
     })
 
@@ -1528,7 +1537,9 @@ describe('session store', () => {
       activities: [
         expect.objectContaining({
           status: 'completed',
-          eventIds: ['event-1', 'event-2']
+          eventIds: ['event-1', 'event-terminal', 'event-2'],
+          createdAt: 10,
+          updatedAt: 20
         })
       ]
     })

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -203,6 +203,7 @@ type UpsertToolActivityInput = {
   sessionId: string
   toolCallId: string
   eventId: string
+  timestamp?: number
   promptMessageId?: string
   title?: string
   status?: string
@@ -2151,6 +2152,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     sessionId,
     toolCallId,
     eventId,
+    timestamp,
     promptMessageId,
     title,
     status,
@@ -2167,6 +2169,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
 
     const nextStatus = normalizeToolActivityStatus(status)
     const now = Date.now()
+    const eventTimestamp = timestamp ?? now
 
     set((state) => ({
       sessions: state.sessions.map((session) => {
@@ -2202,7 +2205,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
                     terminalOutput: terminalOutput ?? activity.terminalOutput,
                     terminalExitCode: terminalExitCode ?? activity.terminalExitCode,
                     eventIds: [...activity.eventIds, eventId],
-                    updatedAt: activityWasTerminal ? activity.updatedAt : now
+                    updatedAt: activityWasTerminal ? activity.updatedAt : eventTimestamp
                   }
                 : activity
             ),
@@ -2238,8 +2241,8 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           rawOutput,
           terminalOutput,
           terminalExitCode,
-          createdAt: now,
-          updatedAt: now
+          createdAt: eventTimestamp,
+          updatedAt: eventTimestamp
         }
 
         return {


### PR DESCRIPTION
## Problem

Tool activity groups only showed the number of steps, so users could not tell how much time the tools themselves spent running.

## Proposed change

- show elapsed tool runtime beside the existing step count in the tool-group header
- sum each visible tool's own `updatedAt - createdAt` duration instead of measuring the wall-clock span of the whole group
- exclude idle gaps between tools, including time the agent spends composing between tool calls
- use milliseconds below one second, then compact seconds, minutes, and hours
- update active tools every 100 ms and freeze each completed tool at its terminal activity timestamp
- isolate the ticking clock so expanded tool details do not re-render on every tick
- preserve the existing typography, semantic colors, spacing, and single-line responsive behavior

## AI review follow-up

- headless TaskRunner activities now use their ACP event start and terminal timestamps instead of run-finalization time
- live and headless activities preserve the first terminal timestamp when later metadata events arrive
- later events can still enrich tool output without inflating the displayed runtime or regressing terminal status

## Scope and non-goals

This is a presentation and timestamp-semantics change. It does not change IPC contracts, persistence schemas, data relationships, or tool execution behavior. It does not add dependencies or introduce a new design system.

## Acceptance criteria and validation

Final checks ran after rebasing onto the latest `main` and resolving its concurrent terminal-timestamp change.

- activity timing, headless persistence, late-event handling, idle-gap exclusion, and output rendering -> focused tests -> 251 tests passed
- provenance and workspace renderer integration after the latest `main` spacing change -> focused tests -> 62 tests passed
- renderer and main-process type safety -> `npm run typecheck:web` and `npm run typecheck:node` -> passed
- changed-file formatting -> Prettier -> passed
- linted source -> `npm run lint` -> passed with 0 errors and 17 warnings outside this change
- portable suite -> `npm test` outside the sandbox -> 812 files passed, 14 skipped; 11,942 tests passed, 184 skipped
- GitHub PR Gate, CodeQL, CI Integrity, and AI review -> passed; latest AI verdict is mergeable with no actionable findings

No visual-regression suite was run locally: the output contract is covered by server rendering, and the change reuses the existing header classes without layout or theme changes. CI and independent review remain the authority for the final merge decision.

## Review focus

- whether summing each visible activity's own timestamps matches the intended definition of tool runtime
- whether event-derived start and immutable terminal timestamps cover every live and headless persistence path
- whether the `ms -> s -> m -> h` thresholds match the desired transcript density
