### PR TITLE
refactor(notebook): extract package admission policy

### DIFF
--- a/src/main/notebook/package-admission.test.ts
+++ b/src/main/notebook/package-admission.test.ts
@@ -1,0 +1,365 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import type { NotebookLanguage } from '../../shared/notebook'
+import { NotebookPackageAdmissionOwner } from './package-admission'
+import { managedRepairRegistryKey, repairRegistryPath } from './runtime-paths'
+import type { NotebookSessionRuntimeBinding } from './session-aggregate'
+
+type AdmissionOptions = ConstructorParameters<typeof NotebookPackageAdmissionOwner>[0]
+
+const managedBinding = (language: NotebookLanguage = 'python'): NotebookSessionRuntimeBinding => ({
+  language,
+  runtimeId: `${language}-analysis-id`,
+  source: 'managed',
+  provenance: 'agent-created',
+  interpreterPath: `/runtime/envs/analysis/bin/${language}`,
+  label: 'analysis',
+  status: 'active',
+  envName: 'analysis'
+})
+
+const externalBinding = (
+  language: NotebookLanguage = 'python',
+  overrides: Partial<NotebookSessionRuntimeBinding> = {}
+): NotebookSessionRuntimeBinding => ({
+  language,
+  runtimeId: `${language}-external-id`,
+  source: 'external',
+  provenance: 'user-own',
+  interpreterPath: `/usr/local/bin/${language}`,
+  label: `External ${language}`,
+  status: 'active',
+  resolvedInterpreter: { command: `/usr/local/bin/${language}` },
+  ...overrides
+})
+
+const ownerHarness = (
+  binding: NotebookSessionRuntimeBinding | undefined,
+  overrides: Partial<AdmissionOptions> = {}
+): {
+  owner: NotebookPackageAdmissionOwner
+  options: AdmissionOptions
+} => {
+  const session = { runtimeBinding: vi.fn(() => binding) }
+  const options: AdmissionOptions = {
+    runtimeRoot: '/runtime',
+    loadSession: vi.fn(async () => session),
+    findSession: vi.fn(() => undefined),
+    resolveRuntimeEnablement: vi.fn(async () => ({
+      enabled: {},
+      installAuthorized: binding ? { [binding.runtimeId]: true } : {}
+    })),
+    isDefaultEnvironmentDisabled: vi.fn(async () => false),
+    repairRegistryKeys: vi.fn((language, environment, selectedBinding) =>
+      selectedBinding?.source === 'external'
+        ? [selectedBinding.runtimeId]
+        : [environment, managedRepairRegistryKey(environment, language)]
+    ),
+    environmentOperations: { isRepairBlocked: vi.fn(() => false) },
+    recovery: {
+      isGloballyBlocked: vi.fn(() => false),
+      isPrefixBlocked: vi.fn(() => false),
+      isRuntimeIdBlocked: vi.fn(() => false)
+    },
+    createEnvironmentCaptureTarget: vi.fn(
+      (language, environmentName, selectedBinding, resolvedInterpreter) => ({
+        language,
+        environmentName,
+        runtimeSource:
+          selectedBinding?.source === 'external' ? ('external' as const) : ('managed' as const),
+        command: resolvedInterpreter?.command ?? `${environmentName}/${language}`
+      })
+    ),
+    ...overrides
+  }
+  return { owner: new NotebookPackageAdmissionOwner(options), options }
+}
+
+describe('NotebookPackageAdmissionOwner', () => {
+  it('admits the managed default and pins every mutation target to it', async () => {
+    const { owner } = ownerHarness(undefined)
+
+    const admission = await owner.admit({
+      language: 'python',
+      packages: ['numpy'],
+      environment: 'stale-caller-target'
+    })
+
+    expect(admission).toEqual({
+      status: 'admitted',
+      target: expect.objectContaining({
+        request: expect.objectContaining({ environment: 'default-python' }),
+        environmentName: 'default-python',
+        environmentCaptureTarget: expect.objectContaining({
+          environmentName: 'default-python',
+          runtimeSource: 'managed'
+        }),
+        repairRuntimeId: 'default-python',
+        repairMarkerKey: managedRepairRegistryKey('default-python', 'python'),
+        journalTarget: '/runtime/envs/default-python'
+      })
+    })
+  })
+
+  it('loads the Session and pins a managed named target instead of trusting the request', async () => {
+    const binding = managedBinding()
+    const { owner, options } = ownerHarness(binding)
+
+    const admission = await owner.admit({
+      language: 'python',
+      packages: ['numpy'],
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      projectName: 'project-1',
+      environment: 'stale-caller-target'
+    })
+
+    expect(options.loadSession).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      projectName: 'project-1'
+    })
+    expect(admission).toMatchObject({
+      status: 'admitted',
+      target: {
+        request: { environment: 'analysis' },
+        environmentName: 'analysis',
+        binding: { runtimeId: binding.runtimeId },
+        repairRuntimeId: 'analysis',
+        repairMarkerKey: managedRepairRegistryKey('analysis', 'python'),
+        journalTarget: '/runtime/envs/analysis'
+      }
+    })
+  })
+
+  it('admits an authorized external Python interpreter without a managed journal target', async () => {
+    const binding = externalBinding()
+    const { owner } = ownerHarness(binding)
+
+    const admission = await owner.admit({
+      language: 'python',
+      packages: ['numpy'],
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace'
+    })
+
+    expect(admission).toMatchObject({
+      status: 'admitted',
+      target: {
+        environmentName: 'default-python',
+        interpreter: { command: '/usr/local/bin/python' },
+        environmentCaptureTarget: { runtimeSource: 'external' },
+        repairRuntimeId: binding.runtimeId,
+        repairMarkerKey: binding.runtimeId,
+        repairRegistryKeys: [binding.runtimeId]
+      }
+    })
+    expect(admission.status === 'admitted' && admission.target.journalTarget).toBeUndefined()
+  })
+
+  it('refuses an unloaded named Session without silently selecting the default', async () => {
+    const { owner, options } = ownerHarness(undefined)
+
+    const admission = await owner.admit({
+      language: 'python',
+      packages: ['numpy'],
+      sessionId: 'session-1'
+    })
+
+    expect(admission).toMatchObject({
+      status: 'refused',
+      result: { ok: false, error: expect.stringContaining('RUNTIME_SESSION_UNAVAILABLE') }
+    })
+    expect(options.loadSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps protected identity refusal ahead of binding, authorization and recovery gates', async () => {
+    const binding = externalBinding('python', { status: 'unavailable', reason: 'disabled' })
+    const resolveRuntimeEnablement = vi.fn(async () => ({
+      enabled: {},
+      installAuthorized: {}
+    }))
+    const { owner, options } = ownerHarness(binding, {
+      resolveRuntimeEnablement,
+      environmentOperations: { isRepairBlocked: vi.fn(() => true) },
+      recovery: {
+        isGloballyBlocked: vi.fn(() => true),
+        isPrefixBlocked: vi.fn(() => true),
+        isRuntimeIdBlocked: vi.fn(() => true)
+      }
+    })
+
+    const admission = await owner.admit({
+      language: 'python',
+      packages: ['numpy'],
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace'
+    })
+
+    expect(admission).toMatchObject({
+      status: 'refused',
+      result: {
+        repairRequired: true,
+        error: expect.stringContaining('RUNTIME_REPAIR_REQUIRED')
+      }
+    })
+    expect(resolveRuntimeEnablement).not.toHaveBeenCalled()
+    expect(options.recovery.isRuntimeIdBlocked).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      name: 'binding unavailable before uninstall',
+      binding: externalBinding('python', { status: 'unavailable', reason: 'disabled' }),
+      operation: 'uninstall' as const,
+      authorized: false,
+      error: 'RUNTIME_BINDING_UNAVAILABLE'
+    },
+    {
+      name: 'external uninstall before authorization',
+      binding: externalBinding(),
+      operation: 'uninstall' as const,
+      authorized: false,
+      error: 'Uninstalling packages from your own environment is disabled'
+    },
+    {
+      name: 'authorization before unsupported external R',
+      binding: externalBinding('r'),
+      operation: 'install' as const,
+      authorized: false,
+      error: 'not authorized'
+    },
+    {
+      name: 'unsupported external R after authorization',
+      binding: externalBinding('r'),
+      operation: 'install' as const,
+      authorized: true,
+      error: 'external R runtime is not supported'
+    }
+  ])('preserves $name refusal ordering', async ({ binding, operation, authorized, error }) => {
+    const { owner } = ownerHarness(binding, {
+      resolveRuntimeEnablement: vi.fn(async () => ({
+        enabled: {},
+        installAuthorized: { [binding.runtimeId]: authorized }
+      }))
+    })
+
+    const admission = await owner.admit({
+      language: binding.language,
+      packages: ['package'],
+      operation,
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace'
+    })
+
+    expect(admission).toMatchObject({
+      status: 'refused',
+      result: { error: expect.stringContaining(error) }
+    })
+  })
+
+  it('keeps default-disabled refusal ahead of the recovery gate', async () => {
+    const { owner, options } = ownerHarness(undefined, {
+      isDefaultEnvironmentDisabled: vi.fn(async () => true),
+      recovery: {
+        isGloballyBlocked: vi.fn(() => true),
+        isPrefixBlocked: vi.fn(() => true),
+        isRuntimeIdBlocked: vi.fn(() => true)
+      }
+    })
+
+    const admission = await owner.admit({ language: 'python', packages: ['numpy'] })
+
+    expect(admission).toMatchObject({
+      status: 'refused',
+      result: { error: expect.stringContaining('No enabled python runtime') }
+    })
+    expect(options.recovery.isPrefixBlocked).not.toHaveBeenCalled()
+  })
+
+  it('refuses an authorized external target blocked by runtime recovery', async () => {
+    const binding = externalBinding()
+    const { owner } = ownerHarness(binding, {
+      recovery: {
+        isGloballyBlocked: vi.fn(() => false),
+        isPrefixBlocked: vi.fn(() => false),
+        isRuntimeIdBlocked: vi.fn(() => true)
+      }
+    })
+
+    const admission = await owner.admit({
+      language: 'python',
+      packages: ['numpy'],
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace'
+    })
+
+    expect(admission).toMatchObject({
+      status: 'refused',
+      result: { error: expect.stringContaining('RUNTIME_RECOVERY_BLOCKED') }
+    })
+  })
+
+  it('does not apply a managed-prefix recovery block to an external target', async () => {
+    const binding = externalBinding()
+    const isPrefixBlocked = vi.fn(() => true)
+    const { owner } = ownerHarness(binding, {
+      recovery: {
+        isGloballyBlocked: vi.fn(() => false),
+        isPrefixBlocked,
+        isRuntimeIdBlocked: vi.fn(() => false)
+      }
+    })
+
+    await expect(
+      owner.admit({
+        language: 'python',
+        packages: ['numpy'],
+        sessionId: 'session-1',
+        workspaceCwd: '/workspace'
+      })
+    ).resolves.toMatchObject({ status: 'admitted' })
+    expect(isPrefixBlocked).not.toHaveBeenCalled()
+  })
+
+  it('treats a legacy managed marker as protected while an external marker stays repairable', async () => {
+    const runtimeRoot = mkdtempSync(join(tmpdir(), 'open-science-package-admission-'))
+    const managed = managedBinding()
+    const external = externalBinding()
+    try {
+      mkdirSync(runtimeRoot, { recursive: true })
+      writeFileSync(
+        repairRegistryPath(runtimeRoot),
+        `${JSON.stringify({ runtimeIds: [managed.runtimeId, external.runtimeId] })}\n`,
+        'utf8'
+      )
+      const managedOwner = ownerHarness(managed, {
+        runtimeRoot,
+        repairRegistryKeys: vi.fn(() => [managed.runtimeId])
+      }).owner
+      const externalOwner = ownerHarness(external, {
+        runtimeRoot,
+        repairRegistryKeys: vi.fn(() => [external.runtimeId])
+      }).owner
+      const request = {
+        packages: ['package'],
+        sessionId: 'session-1',
+        workspaceCwd: '/workspace'
+      }
+
+      await expect(managedOwner.admit({ ...request, language: 'python' })).resolves.toMatchObject({
+        status: 'refused',
+        result: { error: expect.stringContaining('RUNTIME_REPAIR_REQUIRED') }
+      })
+      await expect(externalOwner.admit({ ...request, language: 'python' })).resolves.toMatchObject({
+        status: 'admitted'
+      })
+    } finally {
+      rmSync(runtimeRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/notebook/package-admission.ts
+++ b/src/main/notebook/package-admission.ts
@@ -1,0 +1,261 @@
+import type { NotebookLanguage, NotebookSessionRequest } from '../../shared/notebook'
+import type { RuntimeEnablement } from '../../shared/notebook-runtime'
+import type { NotebookEnvironmentOperations } from './environment-operations'
+import type { EnvironmentCaptureTarget } from './environment-state-tracker'
+import type { InstallRequest, InstallResult } from './package-manager'
+import type { NotebookRecoveryCoordinator } from './recovery-coordinator'
+import {
+  DEFAULT_PY_ENV,
+  DEFAULT_R_ENV,
+  envPrefix,
+  managedRepairRegistryKey,
+  readRepairRequiredReason,
+  resolveEnvName
+} from './runtime-paths'
+import type {
+  NotebookSessionAggregate,
+  NotebookSessionResolvedInterpreter,
+  NotebookSessionRuntimeBinding
+} from './session-aggregate'
+
+type PackageAdmissionSession = Pick<NotebookSessionAggregate, 'runtimeBinding'>
+
+type NotebookPackageAdmissionOwnerOptions = {
+  runtimeRoot: string
+  loadSession: (request: NotebookSessionRequest) => Promise<PackageAdmissionSession>
+  findSession: (sessionId: string) => PackageAdmissionSession | undefined
+  resolveRuntimeEnablement: (language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>
+  isDefaultEnvironmentDisabled: (
+    language: NotebookLanguage,
+    runtimeRoot: string
+  ) => Promise<boolean>
+  repairRegistryKeys: (
+    language: NotebookLanguage,
+    environment: string,
+    binding: NotebookSessionRuntimeBinding | undefined,
+    runtimeRoot: string
+  ) => string[]
+  environmentOperations: Pick<NotebookEnvironmentOperations, 'isRepairBlocked'>
+  recovery: Pick<
+    NotebookRecoveryCoordinator,
+    'isGloballyBlocked' | 'isPrefixBlocked' | 'isRuntimeIdBlocked'
+  >
+  createEnvironmentCaptureTarget: (
+    language: NotebookLanguage,
+    environmentName: string,
+    binding: NotebookSessionRuntimeBinding | undefined,
+    resolvedInterpreter: NotebookSessionResolvedInterpreter | undefined,
+    runtimeRoot: string
+  ) => EnvironmentCaptureTarget
+}
+
+type NotebookPackageAdmittedTarget = Readonly<{
+  request: InstallRequest
+  environmentName: string
+  binding?: NotebookSessionRuntimeBinding
+  interpreter?: Pick<NotebookSessionResolvedInterpreter, 'command' | 'args'>
+  environmentCaptureTarget: EnvironmentCaptureTarget
+  repairRuntimeId: string
+  repairMarkerKey: string
+  repairRegistryKeys: readonly string[]
+  journalTarget?: string
+}>
+
+type NotebookPackageRefusal = Readonly<{ status: 'refused'; result: InstallResult }>
+
+type NotebookPackageAdmission =
+  NotebookPackageRefusal | Readonly<{ status: 'admitted'; target: NotebookPackageAdmittedTarget }>
+
+const defaultEnvironment = (language: NotebookLanguage): string =>
+  language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
+
+const processKey = (language: NotebookLanguage, environment: string): string =>
+  `${language === 'r' ? 'r' : 'python'}:${resolveEnvName(language, environment)}`
+
+const repairBlockKey = (
+  language: NotebookLanguage,
+  environment: string,
+  binding: NotebookSessionRuntimeBinding | undefined
+): string =>
+  binding?.source === 'external'
+    ? `external:${language}:${binding.runtimeId}`
+    : processKey(language, environment)
+
+const refusal = (error: string, repairRequired = false): NotebookPackageRefusal => ({
+  status: 'refused',
+  result: {
+    ok: false,
+    needsRestart: false,
+    ...(repairRequired ? { repairRequired: true } : {}),
+    log: '',
+    error
+  }
+})
+
+/** Owns package target resolution and every fail-closed decision before mutation may begin. */
+class NotebookPackageAdmissionOwner {
+  constructor(private readonly options: NotebookPackageAdmissionOwnerOptions) {}
+
+  async admit(request: InstallRequest): Promise<NotebookPackageAdmission> {
+    const session = await this.resolveSession(request)
+    if (session.status === 'refused') return session
+
+    const binding = session.value?.runtimeBinding(request.language)
+    const environmentName =
+      binding?.source === 'managed' && binding.envName
+        ? binding.envName
+        : defaultEnvironment(request.language)
+    const runtimeRoot = this.options.runtimeRoot
+    const repairRegistryKeys = this.options.repairRegistryKeys(
+      request.language,
+      environmentName,
+      binding,
+      runtimeRoot
+    )
+
+    const protectedRepairRequired =
+      this.options.environmentOperations.isRepairBlocked(
+        repairBlockKey(request.language, environmentName, binding)
+      ) ||
+      repairRegistryKeys.some((key) => {
+        const reason = readRepairRequiredReason(runtimeRoot, key)
+        return (
+          reason === 'protected-identity-change' ||
+          (reason === 'legacy-unknown' && binding?.source !== 'external')
+        )
+      })
+    if (protectedRepairRequired) {
+      return refusal(
+        `RUNTIME_REPAIR_REQUIRED: the ${request.language} runtime's protected interpreter identity ` +
+          'changed. Use Repair/Reset in Settings → Runtimes to rebuild and verify it before installing ' +
+          'packages.',
+        true
+      )
+    }
+
+    let interpreter: NotebookPackageAdmittedTarget['interpreter']
+    if (binding?.source === 'external') {
+      const blocked =
+        (binding.status ?? 'active') !== 'active' && binding.reason !== 'repair-required'
+      if (blocked) return this.unavailable(request.language, binding)
+      if (request.operation === 'uninstall') {
+        return refusal(
+          'Uninstalling packages from your own environment is disabled. Manage it yourself, or ' +
+            'switch to the managed environment.'
+        )
+      }
+      const enablement = await this.options.resolveRuntimeEnablement(request.language)
+      if (!(enablement?.installAuthorized[binding.runtimeId] ?? false)) {
+        return refusal(
+          `Installing packages into your own ${request.language} environment is not authorized. ` +
+            'Turn on "Allow package install" for this runtime in Settings → Runtimes first (installs ' +
+            'go into your own environment, not the app-managed storage).'
+        )
+      }
+      if (request.language !== 'python') {
+        return refusal(
+          'Package management for an external R runtime is not supported yet. Use the managed R ' +
+            'environment, or install the package yourself.'
+        )
+      }
+      interpreter = binding.resolvedInterpreter
+    } else if (binding) {
+      const blocked =
+        (binding.status ?? 'active') !== 'active' && binding.reason !== 'repair-required'
+      if (blocked) return this.unavailable(request.language, binding)
+    } else if (
+      environmentName === defaultEnvironment(request.language) &&
+      (await this.options.isDefaultEnvironmentDisabled(request.language, runtimeRoot))
+    ) {
+      return refusal(
+        `No enabled ${request.language} runtime: the app-managed default is disabled and no ` +
+          'runtime is bound. Enable a runtime in Settings → Runtimes, or bind one with ' +
+          'list_notebook_runtimes then notebook_bind_runtime, before installing packages.'
+      )
+    }
+
+    const isExternal = binding?.source === 'external'
+    const runtimeIdBlocked =
+      binding?.runtimeId !== undefined &&
+      this.options.recovery.isRuntimeIdBlocked(binding.runtimeId)
+    const prefixBlocked =
+      !isExternal && this.options.recovery.isPrefixBlocked(envPrefix(runtimeRoot, environmentName))
+    const corruptBlockedExternal = isExternal && this.options.recovery.isGloballyBlocked()
+    if (runtimeIdBlocked || prefixBlocked || corruptBlockedExternal) {
+      return refusal(
+        `RUNTIME_RECOVERY_BLOCKED: the ${request.language} environment is recovering from an ` +
+          'interrupted operation whose process could not be confirmed stopped. Restart the app to ' +
+          're-check and recover it before installing packages.'
+      )
+    }
+
+    const repairRuntimeId = isExternal ? binding.runtimeId : environmentName
+    const repairMarkerKey = isExternal
+      ? repairRuntimeId
+      : managedRepairRegistryKey(environmentName, request.language)
+    const journalTarget = isExternal ? undefined : envPrefix(runtimeRoot, environmentName)
+    return {
+      status: 'admitted',
+      target: {
+        request: { ...request, environment: environmentName },
+        environmentName,
+        binding,
+        interpreter,
+        environmentCaptureTarget: this.options.createEnvironmentCaptureTarget(
+          request.language,
+          environmentName,
+          binding,
+          binding?.resolvedInterpreter,
+          runtimeRoot
+        ),
+        repairRuntimeId,
+        repairMarkerKey,
+        repairRegistryKeys,
+        journalTarget
+      }
+    }
+  }
+
+  private async resolveSession(
+    request: InstallRequest
+  ): Promise<
+    Readonly<{ status: 'resolved'; value?: PackageAdmissionSession }> | NotebookPackageRefusal
+  > {
+    if (!request.sessionId) return { status: 'resolved', value: undefined }
+    if (request.workspaceCwd) {
+      return {
+        status: 'resolved',
+        value: await this.options.loadSession({
+          sessionId: request.sessionId,
+          workspaceCwd: request.workspaceCwd,
+          projectName: request.projectName
+        })
+      }
+    }
+    const session = this.options.findSession(request.sessionId)
+    if (session) return { status: 'resolved', value: session }
+    return refusal(
+      'RUNTIME_SESSION_UNAVAILABLE: cannot resolve this session to honor its runtime binding ' +
+        '(no workspaceCwd to load it). Retry with the notebook session context so any bound ' +
+        'runtime is applied instead of silently installing into the default environment.'
+    )
+  }
+
+  private unavailable(
+    language: NotebookLanguage,
+    binding: NotebookSessionRuntimeBinding
+  ): NotebookPackageAdmission {
+    return refusal(
+      `RUNTIME_BINDING_UNAVAILABLE: the bound ${language} runtime is ${binding.status}` +
+        (binding.reason ? ` (${binding.reason})` : '') +
+        '. Switch to another runtime (list_notebook_runtimes → notebook_switch_runtime) before ' +
+        'installing packages.'
+    )
+  }
+}
+
+export {
+  NotebookPackageAdmissionOwner,
+  type NotebookPackageAdmission,
+  type NotebookPackageAdmittedTarget
+}

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -48,6 +48,7 @@ import {
   envPrefix,
   isProtectedIdentityRepairRequired,
   isRepairRequired,
+  managedRepairRegistryKey,
   pythonBin,
   rBin,
   repairRegistryPath,
@@ -4179,6 +4180,31 @@ describe('notebook runtime service', () => {
       expect(calls[0][1]?.cranMirror).toBeUndefined()
     })
 
+    it('resolves the mirror before returning a package admission refusal', async () => {
+      const root = await createStorageRoot()
+      const probe = vi.fn(async () => {
+        throw new Error('probe unreachable (test)')
+      })
+      const service = new NotebookRuntimeService({
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'default-project',
+        repository: new NotebookRunRepository(root),
+        getPackageMirror: () => undefined,
+        mirrorProbe: { probe }
+      })
+
+      resetAutoMirrorCache()
+      const result = await service.managePackages({
+        language: 'python',
+        packages: ['numpy'],
+        sessionId: 'unloaded-session'
+      })
+
+      expect(probe).toHaveBeenCalled()
+      expect(result.error).toContain('RUNTIME_SESSION_UNAVAILABLE')
+    })
+
     it('falls back to the region default mirror when nothing is configured', async () => {
       const root = await createStorageRoot()
       const calls: Array<Partial<InstallDepsForTest> | undefined> = []
@@ -6898,6 +6924,40 @@ describe('v4 runtime bindings & agent tools', () => {
     expect(result.ok).toBe(true)
     expect(installPackagesImpl).toHaveBeenCalledOnce()
     expect(isRepairRequired(runtimeRoot, userPyA.envId)).toBe(false)
+  })
+
+  it('recomputes repair aliases after installation before clearing legacy markers', async () => {
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    const postInstallAlias = 'post-install-canonical-runtime'
+    addRepairRequired(runtimeRoot, postInstallAlias)
+    const service = bindingService(root, {
+      installPackagesImpl: async () => ({ ok: true, needsRestart: false, log: 'repaired' })
+    })
+    const repairRegistryKeys = vi.spyOn(
+      service as unknown as {
+        repairRegistryKeys: (
+          language: 'python' | 'r',
+          environment: string,
+          binding: unknown,
+          runtimeRoot: string
+        ) => string[]
+      },
+      'repairRegistryKeys'
+    )
+    repairRegistryKeys
+      .mockReturnValueOnce([DEFAULT_PY_ENV, managedRepairRegistryKey(DEFAULT_PY_ENV, 'python')])
+      .mockReturnValueOnce([
+        DEFAULT_PY_ENV,
+        managedRepairRegistryKey(DEFAULT_PY_ENV, 'python'),
+        postInstallAlias
+      ])
+
+    const result = await service.managePackages({ language: 'python', packages: ['numpy'] })
+
+    expect(result.ok).toBe(true)
+    expect(repairRegistryKeys).toHaveBeenCalledTimes(2)
+    expect(isRepairRequired(runtimeRoot, postInstallAlias)).toBe(false)
   })
 
   it('does not quarantine an external binding that shares the managed default env key', async () => {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -45,6 +45,7 @@ import {
   type InstallRequest,
   type InstallResult
 } from './package-manager'
+import { NotebookPackageAdmissionOwner } from './package-admission'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
 import {
   addRepairRequired,
@@ -139,15 +140,6 @@ const dataProcessKey = (language: NotebookLanguage, environment?: string): strin
 
 const externalRepairBlockKey = (language: NotebookLanguage, runtimeId: string): string =>
   `external:${language}:${runtimeId}`
-
-const repairBlockKey = (
-  language: NotebookLanguage,
-  environment: string,
-  binding: NotebookRuntimeBinding | undefined
-): string =>
-  binding?.source === 'external'
-    ? externalRepairBlockKey(language, binding.runtimeId)
-    : dataProcessKey(language, environment)
 
 // The process key the executor reports through onIdleShutdown/onTerminated(kind, env): `${kind}:${env}`
 // for python/r, bare 'repl' for the env-agnostic control kernel. A missing kind/env (direct callers /
@@ -423,6 +415,7 @@ class NotebookRuntimeService {
   private readonly runTerminalization: NotebookRunTerminalizationOwner
   private readonly executionOwner: NotebookExecutionOwner
   private readonly dataExecutionAdmission: NotebookDataExecutionAdmissionOwner
+  private readonly packageAdmission: NotebookPackageAdmissionOwner
   private readonly sessions: NotebookSessionRegistry<RuntimeSession>
   private readonly announcedAgentSessionIds = new Set<string>()
   // Owns process-global operation admission, provisioning progress, restart recommendations,
@@ -492,6 +485,18 @@ class NotebookRuntimeService {
       sessions: () => this.sessions.values(),
       notifyChanged: (session) => this.notifyNotebookChanged(session as RuntimeSession),
       logger: this.runtimeLogger
+    })
+    this.packageAdmission = new NotebookPackageAdmissionOwner({
+      runtimeRoot: getRuntimeRoot(options.dataRoot),
+      loadSession: (request) => this.ensureSession(request),
+      findSession: (sessionId) => this.sessions.get(sessionId),
+      resolveRuntimeEnablement: (language) => this.resolveRuntimeEnablement(language),
+      isDefaultEnvironmentDisabled: (language, runtimeRoot) =>
+        this.isDefaultEnvDisabled(language, runtimeRoot),
+      repairRegistryKeys: (...args) => this.repairRegistryKeys(...args),
+      environmentOperations: this.environmentOperations,
+      recovery: this.recoveryCoordinator,
+      createEnvironmentCaptureTarget: (...args) => this.environmentCaptureTarget(...args)
     })
     this.environmentStateTracker =
       options.environmentStateTracker ??
@@ -1132,235 +1137,21 @@ class NotebookRuntimeService {
       this.options.mirrorProbe
     )
 
-    // Install target env comes from the SESSION BINDING (v4: no per-call environment argument). A
-    // managed binding installs into its conda env by name; an external binding pips into the user's own
-    // interpreter; no session context -> the language default env.
-    //
-    // ensureSession() (not a bare sessions.get) so the FIRST manage_packages after an app restart loads
-    // the session and REHYDRATES its persisted runtime bindings before we read them — otherwise the
-    // session isn't in memory yet, the binding reads as undefined, and the install silently targets the
-    // default env (bypassing a bound named/external/unavailable runtime and its install-authorization,
-    // while pinnedRequest below would then guarantee the wrong target). Mirrors execute(), which already
-    // ensureSession()s. The MCP bridge and local RPC always carry workspaceCwd, so this is the real path.
-    let bindingSession: RuntimeSession | undefined
-    if (request.sessionId) {
-      if (request.workspaceCwd) {
-        bindingSession = await this.ensureSession({
-          sessionId: request.sessionId,
-          workspaceCwd: request.workspaceCwd,
-          projectName: request.projectName
-        })
-      } else {
-        // A sessionId was given but there's no workspaceCwd to LOAD the session, and it isn't already in
-        // memory. A persisted binding may exist that we can't see, so installing would silently bypass
-        // it and target the default env. Refuse rather than fall back — no silent default. (Real callers
-        // always send workspaceCwd; this only guards a malformed/legacy request that names a session.)
-        bindingSession = this.sessions.get(request.sessionId)
-        if (!bindingSession) {
-          return {
-            ok: false,
-            needsRestart: false,
-            log: '',
-            error:
-              'RUNTIME_SESSION_UNAVAILABLE: cannot resolve this session to honor its runtime binding ' +
-              '(no workspaceCwd to load it). Retry with the notebook session context so any bound ' +
-              'runtime is applied instead of silently installing into the default environment.'
-          }
-        }
-      }
-    }
-    // No sessionId at all -> a caller with no session context -> the language default env (unchanged).
-    const binding = bindingSession ? bindingSession.runtimeBinding(request.language) : undefined
-    const envName = bindingSession
-      ? this.resolveRunEnv(bindingSession, request.language)
-      : resolveEnvName(request.language, undefined)
+    const admission = await this.packageAdmission.admit(request)
+    if (admission.status === 'refused') return admission.result
+    const {
+      binding,
+      environmentName: envName,
+      environmentCaptureTarget: environmentTarget,
+      interpreter,
+      journalTarget,
+      repairMarkerKey,
+      repairRuntimeId,
+      request: pinnedRequest
+    } = admission.target
     const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
-
-    // A protected interpreter identity change is not repairable by installing another ordinary
-    // package. Doing so would let the package manager capture the already-replaced r-base as its new
-    // baseline and then clear quarantine after an unrelated successful install. Only the explicit UI
-    // Runtime Reset rebuilds and verifies the environment before clearing this stronger marker.
-    const protectedRepairRequired =
-      this.environmentOperations.isRepairBlocked(
-        repairBlockKey(request.language, envName, binding)
-      ) ||
-      this.repairRegistryKeys(request.language, envName, binding, runtimeRoot).some((key) => {
-        const reason = readRepairRequiredReason(runtimeRoot, key)
-        return (
-          reason === 'protected-identity-change' ||
-          (reason === 'legacy-unknown' && binding?.source !== 'external')
-        )
-      })
-    if (protectedRepairRequired) {
-      return {
-        ok: false,
-        needsRestart: false,
-        repairRequired: true,
-        log: '',
-        error:
-          `RUNTIME_REPAIR_REQUIRED: the ${request.language} runtime's protected interpreter identity ` +
-          'changed. Use Repair/Reset in Settings → Runtimes to rebuild and verify it before installing ' +
-          'packages.'
-      }
-    }
-
-    // Gate the install on that binding. An EXTERNAL binding is read-only unless the user turned on
-    // "Allow package install" for THAT runtime in Settings (per-env installAuthorized) — then pip
-    // installs into the user's OWN interpreter (installs land in the user's env, not app storage), and
-    // external uninstall stays disabled. A managed binding / no session -> micromamba into the app
-    // prefix. This replaces the removed pre-v4 RuntimeSelection gate.
-    let interpreter: { command: string; args?: string[] } | undefined
-    if (binding?.source === 'external') {
-      // An interrupted-install repair marker remains installable: re-running the authorized install
-      // to completion clears it. The stronger protected-identity marker was refused above.
-      const blocked =
-        (binding.status ?? 'active') !== 'active' && binding.reason !== 'repair-required'
-      if (blocked) {
-        return {
-          ok: false,
-          needsRestart: false,
-          log: '',
-          error:
-            `RUNTIME_BINDING_UNAVAILABLE: the bound ${request.language} runtime is ${binding.status}` +
-            (binding.reason ? ` (${binding.reason})` : '') +
-            '. Switch to another runtime (list_notebook_runtimes → notebook_switch_runtime) before ' +
-            'installing packages.'
-        }
-      }
-      if (request.operation === 'uninstall') {
-        return {
-          ok: false,
-          needsRestart: false,
-          log: '',
-          error:
-            'Uninstalling packages from your own environment is disabled. Manage it yourself, or ' +
-            'switch to the managed environment.'
-        }
-      }
-      const enablement = await this.resolveRuntimeEnablement(request.language)
-      const authorized = enablement?.installAuthorized[binding.runtimeId] ?? false
-      if (!authorized) {
-        return {
-          ok: false,
-          needsRestart: false,
-          log: '',
-          error:
-            `Installing packages into your own ${request.language} environment is not authorized. ` +
-            'Turn on "Allow package install" for this runtime in Settings → Runtimes first (installs ' +
-            'go into your own environment, not the app-managed storage).'
-        }
-      }
-      if (request.language !== 'python') {
-        return {
-          ok: false,
-          needsRestart: false,
-          log: '',
-          error:
-            'Package management for an external R runtime is not supported yet. Use the managed R ' +
-            'environment, or install the package yourself.'
-        }
-      }
-      // Install directly into the user's own interpreter (pip). No app-owned overlay: the user
-      // explicitly authorized installing into their own environment.
-      interpreter = binding.resolvedInterpreter
-    } else if (binding) {
-      // A MANAGED binding (app-managed default or an agent-created named env). Same no-silent-fallback
-      // guarantee as execute() and the external path: a disabled/unavailable managed binding refuses the
-      // install rather than quietly installing into a different env. An interrupted-install marker
-      // stays installable; the stronger protected-identity marker was refused above. Without this,
-      // disabling a managed runtime blocked execution but still let manage_packages install into it
-      // (the gate was external-only).
-      const blocked =
-        (binding.status ?? 'active') !== 'active' && binding.reason !== 'repair-required'
-      if (blocked) {
-        return {
-          ok: false,
-          needsRestart: false,
-          log: '',
-          error:
-            `RUNTIME_BINDING_UNAVAILABLE: the bound ${request.language} runtime is ${binding.status}` +
-            (binding.reason ? ` (${binding.reason})` : '') +
-            '. Switch to another runtime (list_notebook_runtimes → notebook_switch_runtime) before ' +
-            'installing packages.'
-        }
-      }
-    } else if (envName === this.defaultEnvNameFor(request.language)) {
-      // No binding and the target is the app-managed default: refuse if that default is disabled, so
-      // manage_packages can't provision + install into a runtime the user turned off in Settings
-      // (mirrors execute()'s disabled-default gate). A managed named env is never reached here (it always
-      // has a binding), so this only guards the default.
-      if (await this.isDefaultEnvDisabled(request.language, runtimeRoot)) {
-        return {
-          ok: false,
-          needsRestart: false,
-          log: '',
-          error:
-            `No enabled ${request.language} runtime: the app-managed default is disabled and no ` +
-            'runtime is bound. Enable a runtime in Settings → Runtimes, or bind one with ' +
-            'list_notebook_runtimes then notebook_bind_runtime, before installing packages.'
-        }
-      }
-    }
-
-    // Refuse if recovery left this install's target possibly-live (an unknown-liveness orphan may still
-    // be writing it). An EXTERNAL binding is keyed by runtimeId (its real target is the user's own env,
-    // not a path under runtimeRoot — so the app-managed default prefix must NOT gate it); a managed/
-    // default target is keyed by its real prefix, plus its runtimeId for a bound managed named env.
-    // Returned as a structured error (not thrown) to match managePackages' other refusals.
-    const isExternal = binding?.source === 'external'
-    const runtimeIdBlocked =
-      binding?.runtimeId !== undefined &&
-      this.recoveryCoordinator.isRuntimeIdBlocked(binding.runtimeId)
-    // A managed/default install is gated by its real prefix via isPrefixRecoveryBlocked, which already
-    // folds in the corrupt-journal barrier AND honours a force Reset's per-prefix allowlist — so a reset
-    // (allowlisted) default env can be installed into again while other envs stay blocked. An EXTERNAL
-    // install has no managed prefix to key that allowlist on, so it keeps the raw corrupt catch-all.
-    const prefixBlocked =
-      !isExternal && this.isPrefixRecoveryBlocked(envPrefix(runtimeRoot, envName))
-    const corruptBlockedExternal = isExternal && this.recoveryCoordinator.isGloballyBlocked()
-    if (runtimeIdBlocked || prefixBlocked || corruptBlockedExternal) {
-      return {
-        ok: false,
-        needsRestart: false,
-        log: '',
-        error:
-          `RUNTIME_RECOVERY_BLOCKED: the ${request.language} environment is recovering from an ` +
-          'interrupted operation whose process could not be confirmed stopped. Restart the app to ' +
-          're-check and recover it before installing packages.'
-      }
-    }
-
-    // Journal the install so a process death mid-install (killed conda/pip, half-applied packages) is
-    // reconciled at next startup by flagging this runtime repair-required — an interrupted install is
-    // never silently assumed to have succeeded. External runtimes use their runtime identity; managed
-    // interrupted installs use an (env, language) key so repairing Python cannot release R in a shared
-    // prefix. Best-effort journal I/O; cleared in the finally on completion.
-    const repairRuntimeId = binding?.source === 'external' ? binding.runtimeId : envName
-    const repairMarkerKey =
-      binding?.source === 'external'
-        ? repairRuntimeId
-        : managedRepairRegistryKey(envName, request.language)
-    // targetPath is the app-managed prefix ONLY for a managed/default install — an EXTERNAL install
-    // writes the user's own env (outside runtimeRoot), so recording the default prefix here would make
-    // recovery wrongly clean/block the unrelated managed default. Recovery then blocks an external
-    // install by its runtimeId (blockUnknownChildTarget) instead of a prefix.
-    const journalTarget =
-      binding?.source === 'external' ? undefined : envPrefix(runtimeRoot, envName)
     const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
     const operationId = randomUUID()
-    // The install target is the binding-resolved envName — NOT request.environment. v4 dropped the
-    // per-call environment argument, but the package manager still reads req.environment (and the local
-    // RPC forwards the raw request), so an old/direct caller could otherwise install into a DIFFERENT
-    // env than the one whose lock, journal target, and repair flag we resolved above. Pin it here so all
-    // four agree.
-    const pinnedRequest = { ...request, environment: envName }
-    const environmentTarget = this.environmentCaptureTarget(
-      request.language,
-      envName,
-      binding,
-      binding?.resolvedInterpreter,
-      runtimeRoot
-    )
     let result: InstallResult
     let retainForRecovery = false
     let begun = false // did journal.begin() succeed? distinguishes a begin failure from an install error
@@ -1587,6 +1378,8 @@ class NotebookRuntimeService {
       // Clear aliases only for the repaired language. A successful Python install must not release an R
       // interrupted-install marker (or vice versa) merely because both bindings share one Conda prefix.
       if (managedRepair) {
+        // Recompute after installation: the interpreter may have appeared or canonicalized during the
+        // mutation, and the fresh real path can name an older interrupted-install marker to clear.
         const legacyAliases = new Set(
           this.repairRegistryKeys(request.language, envName, binding, runtimeRoot)
         )


### PR DESCRIPTION
## Problem

`NotebookRuntimeService.managePackages` still combined package target resolution and every pre-install refusal with the mutation lifecycle. That made the compatibility Facade own Session loading, binding interpretation, Settings authorization, repair state, and recovery routing before it could reach the existing lock/journal/installer path.

## Proposed change

- Add `NotebookPackageAdmissionOwner`, an in-process Module with one `admit(request)` Interface.
- Return either the existing structured `InstallResult` refusal or a readonly admitted target containing the pinned request/environment, binding and interpreter identity, capture target, journal target, and repair keys.
- Delegate the Facade's target/admission block to this owner while leaving mirror resolution ahead of admission and all mutation lifecycle code in place.
- Add owner-level tests for managed default/named and authorized external targets, no-silent-default Session loading, protected/unavailable/uninstall/authorization/external-R/default-disabled/recovery precedence, legacy marker treatment, and external recovery-key isolation.
- Add Facade regressions proving mirror resolution still precedes refusal and post-install repair aliases are recomputed after the interpreter can appear/canonicalize.

The deepened owner hides Session, binding, Settings, and recovery decisions behind one operation; the Facade remains the unchanged compatibility Interface for application, local-RPC, MCP, Electron, Web, and CLI/Task callers.

## Scope and non-goals

- Production raw changes: **524** (`package-admission.ts` 261 additions; `runtime-service.ts` 28 additions / 235 deletions). The 600-line target and 660 hard ceiling were not exceeded.
- Test raw changes: **425** (`package-admission.test.ts` 365 additions; `runtime-service.test.ts` 60 additions).
- `NotebookRuntimeService` decreases from 2,350 to **2,143 physical lines**.
- Environment locking, journal I/O, installer spawning, child identity, verification, quarantine, repair restoration, runtime selection, request/wire shapes, and Settings storage are unchanged.
- The successful-install path deliberately recomputes repair aliases instead of reusing the pre-install admission snapshot, preserving the existing post-install `realpath` behavior.
- No provisioner logic moves into admission. Windows `STATUS_ACCESS_VIOLATION`, MAX_PATH-wrapped cache recovery, surgical repair/reseed, and the one-retry ceiling remain owned by the provisioner.
- Rebasing onto `439e66f4` keeps its short Windows cache fallback in `micromamba-cache`: the PUBLIC candidate still uses the existing per-user leaf, ACL/marker verification, and uninstall cleanup, independently of package admission.

## Compatibility

- `managePackages(request): Promise<InstallResult>` and every current refusal string/result shape remain unchanged.
- Evaluation order remains: startup recovery → mirror resolution/probe → Session resolution → protected identity → binding/uninstall/authorization/external-R/default-disabled gates → recovery/live-unconfirmed gate → mutation lifecycle.
- Managed default/named and external target selection, persisted binding reload, no-silent-default behavior, journal/repair identities, and current Electron/Web/CLI/Task/local-RPC/MCP capability asymmetries are unchanged.
- No persisted data model, data relationship, IPC payload, authorization rule, or user interaction changes.

## Acceptance criteria and validation

All checks ran after the last material edit on exact HEAD `7a633969c23d2b367fbe65a2a4d74d4f086fd7b2`, rebased onto `origin/main` at `439e66f4ce99934f1c285b5dcc9b6a70a6c04362`.

- Package owner/Facade behavior plus the #823 short-cache and uninstall/config portable contracts → `npm test -- src/main/notebook/package-admission.test.ts src/main/notebook/runtime-service.test.ts src/main/notebook/micromamba-cache.test.ts scripts/electron-builder-config.test.ts` → **4 files, 219 tests passed**.
- Downstream package-manager contract → `npm test -- src/main/notebook/package-manager.test.ts` → **1 file, 73 tests passed**.
- Existing Windows access-violation and MAX_PATH provisioner ownership → `npm test -- src/main/notebook/provisioner.test.ts -t 'access violation|MAX_PATH|MaxPath'` → **5 tests passed, 82 skipped by the name filter**.
- Node-process type safety → `npm run typecheck:node` → **passed**.
- Changed-file lint → `npx eslint --no-cache src/main/notebook/package-admission.ts src/main/notebook/package-admission.test.ts src/main/notebook/runtime-service.ts src/main/notebook/runtime-service.test.ts` → **passed, 0 findings**.
- Independent review → **Standards 0 findings / Spec 0 findings**.

This refactor does not execute a real installer or Windows process locally. The portable Facade tests exercise routing and recovery semantics; unchanged provisioner tests and the PR Gate's selected Windows/platform lanes remain authoritative for native access-violation and MAX_PATH behavior. Linux E2E is not a local blocker for this internal Node-process refactor.

## Review focus

- Confirm the owner has one deep admission Interface and the Facade no longer duplicates target/refusal policy.
- Confirm mirror probing and the non-intuitive external refusal order are observationally unchanged.
- Confirm lock, journal, spawn, verification, quarantine, post-install fresh repair-key computation, and Windows provisioner recovery remain outside admission.
- Squash merge only; preserve `refactor(notebook): extract package admission policy` as the squash commit subject.
