### PR TITLE
fix(session-plan): decouple turn completion from plan status

### DIFF
--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -54,7 +54,6 @@ type Harness = {
   >
   owner: AcpSessionInteractionOwner
   planLifecycle: {
-    beforeStop: Mock<AcpPromptTurnWorkflowOptions['plan']['beforeStop']>
     beforeRelease: Mock<AcpPromptTurnWorkflowOptions['plan']['beforeRelease']>
     afterRelease: Mock<AcpPromptTurnWorkflowOptions['plan']['afterRelease']>
   }
@@ -216,9 +215,6 @@ const createHarness = (
     return input.prepare?.(request) ?? prepared
   })
   const planLifecycle: Harness['planLifecycle'] = {
-    beforeStop: vi.fn(async () => {
-      journal.push('plan:before-stop')
-    }),
     beforeRelease: vi.fn(() => {
       journal.push('plan:before-release')
     }),
@@ -234,7 +230,6 @@ const createHarness = (
     if (input.execute) return input.execute(request)
     request.onAccepted()
     const response: PromptResponse = { stopReason: 'end_turn' }
-    await request.beforeStop?.(response)
     request.captureStop()
     return { kind: 'stopped' as const, response, facts: {} }
   })
@@ -395,7 +390,6 @@ describe('AcpPromptTurnWorkflow', () => {
       'execute',
       'accepted',
       'skills:completed',
-      'plan:before-stop',
       'finalize'
     ])
     const [handles, outcome] = harness.finalizer.mock.calls[0]
@@ -605,7 +599,7 @@ describe('AcpPromptTurnWorkflow', () => {
     expect(harness.onProviderPromptAccepted).not.toHaveBeenCalled()
   })
 
-  it('passes protected Plan guidance through the interaction-scoped completion gate', async () => {
+  it('passes protected Plan guidance through the interaction-scoped lifecycle', async () => {
     const projection = planProjection()
     const harness = createHarness({ admitPlan: () => ({ authorized: projection }) })
     const prompt = request()
@@ -621,9 +615,6 @@ describe('AcpPromptTurnWorkflow', () => {
     )
     const handles = harness.finalizer.mock.calls[0][0]
     const interaction = handles.interaction
-    expect(harness.planLifecycle.beforeStop).toHaveBeenCalledWith('s1', interaction, {
-      stopReason: 'end_turn'
-    })
     handles.beforeInteractionRelease()
     await handles.afterInteractionRelease()
     expect(harness.planLifecycle.beforeRelease).toHaveBeenCalledWith('s1', interaction)

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -93,11 +93,6 @@ type AcpPromptTurnPlanWorkflow = Readonly<{
     interaction: AcpPromptSessionInteractionScope,
     plan: AcpPromptTurnPlanContext
   ) => AcpPromptTurnPlanContext | Promise<AcpPromptTurnPlanContext>
-  beforeStop: (
-    sessionId: string,
-    interaction: AcpPromptSessionInteractionScope,
-    response: PromptResponse
-  ) => Promise<void>
   beforeRelease: (sessionId: string, interaction: AcpPromptSessionInteractionScope) => void
   afterRelease: (sessionId: string) => Promise<void>
 }>
@@ -370,7 +365,6 @@ class AcpPromptTurnWorkflow {
             skillFinalized = true
           }
         },
-        beforeStop: (response) => plan.beforeStop(sessionId, interaction, response),
         routeNotification: (notification) => env.routeNotification(notification, sessionId),
         reportBestEffortFailure: (stage, error) =>
           log.warn('provider prompt observation failed', {

--- a/src/main/acp/provider-prompt-executor.test.ts
+++ b/src/main/acp/provider-prompt-executor.test.ts
@@ -284,24 +284,6 @@ describe('AcpProviderPromptExecutor', () => {
     expect(fixture.probe.cancel).toHaveBeenCalledOnce()
   })
 
-  it('runs terminal validation before capture and cancels the probe when validation fails', async () => {
-    const response: PromptResponse = { stopReason: 'end_turn' }
-    const fixture = setup([stop(response)])
-    const validationFailure = new Error('terminal validation failed')
-    const beforeStop = vi.fn(async () => {
-      throw validationFailure
-    })
-
-    await expect(fixture.executor.execute({ ...fixture.input, beforeStop })).rejects.toBe(
-      validationFailure
-    )
-
-    expect(beforeStop).toHaveBeenCalledWith(response)
-    expect(fixture.captureStop).not.toHaveBeenCalled()
-    expect(fixture.probe.finalize).not.toHaveBeenCalled()
-    expect(fixture.probe.cancel).toHaveBeenCalledOnce()
-  })
-
   it('captures stop before slow finalization and falls back when finalization fails', async () => {
     const response: PromptResponse = {
       stopReason: 'end_turn',

--- a/src/main/acp/provider-prompt-executor.ts
+++ b/src/main/acp/provider-prompt-executor.ts
@@ -27,7 +27,6 @@ type ProviderPromptExecutionInput = Readonly<{
   frameworkId: AgentFrameworkId
   isCurrent: () => boolean
   beforeDispatch: () => Promise<'active' | 'cancelled'>
-  beforeStop?: (response: PromptResponse) => Promise<void>
   captureStop: () => boolean
   onAccepted: () => void
   routeNotification: (notification: SessionNotification) => void
@@ -173,7 +172,6 @@ class AcpProviderPromptExecutor {
           input.routeNotification(message.notification)
           continue
         }
-        await input.beforeStop?.(message.response)
         if (!input.captureStop()) {
           await cancelProbe()
           return Object.freeze({ kind: 'superseded', response: message.response })

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -1,5 +1,3 @@
-import type { PromptResponse } from '@agentclientprotocol/sdk'
-
 import type { AcpPromptRequest, AcpRuntimeEvent } from '../../shared/acp'
 import type {
   ActivePlanProjection,
@@ -348,29 +346,6 @@ const composeAcpRuntimePlanWorkflow = (
     }
     return committed()
   }
-  const beforeStop = async (
-    sessionId: string,
-    interaction: AcpPromptSessionInteractionScope,
-    response: PromptResponse
-  ): Promise<void> => {
-    const binding = interactions.executionBindingFor(sessionId)
-    if (
-      response.stopReason !== 'end_turn' ||
-      !service ||
-      binding?.interactionSequence !== interaction.sequence
-    ) {
-      return
-    }
-    const completion = await service.checkTurnCompletion({
-      projectId: session.sessionEnvironment.projectName(sessionId),
-      sessionId
-    })
-    if (!completion.allow) {
-      throw new Error(
-        `The active Session Plan is not complete (${completion.lifecycle ?? 'incomplete'}).`
-      )
-    }
-  }
   const beforeRelease = (
     sessionId: string,
     interaction: AcpPromptSessionInteractionScope
@@ -400,7 +375,6 @@ const composeAcpRuntimePlanWorkflow = (
   const prompt: AcpPromptTurnPlanWorkflow = Object.freeze({
     preflight,
     admit,
-    beforeStop,
     beforeRelease,
     afterRelease
   })

--- a/src/main/acp/runtime-prompt-composition.test.ts
+++ b/src/main/acp/runtime-prompt-composition.test.ts
@@ -18,7 +18,6 @@ describe('ACP Runtime Prompt composition', () => {
         plan: {
           preflight: vi.fn(() => ({})),
           admit: vi.fn((_request, _interaction, plan) => plan),
-          beforeStop: vi.fn(async () => undefined),
           beforeRelease: vi.fn(),
           afterRelease: vi.fn(async () => undefined)
         },
@@ -31,7 +30,6 @@ describe('ACP Runtime Prompt composition', () => {
 
       expect(host.plan.preflight).not.toHaveBeenCalled()
       expect(host.plan.admit).not.toHaveBeenCalled()
-      expect(host.plan.beforeStop).not.toHaveBeenCalled()
       expect(host.plan.beforeRelease).not.toHaveBeenCalled()
       expect(host.plan.afterRelease).not.toHaveBeenCalled()
       expect(host.reload.disconnect).not.toHaveBeenCalled()

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -41,7 +41,7 @@ const projection = (
 })
 
 type PlanServiceMock = Record<
-  'generate' | 'respond' | 'getProjection' | 'updateStepStatus' | 'checkTurnCompletion',
+  'generate' | 'respond' | 'getProjection' | 'updateStepStatus',
   ReturnType<typeof vi.fn>
 >
 
@@ -103,8 +103,7 @@ const createRuntimeHarness = (options: {
           : current
       }
     ),
-    updateStepStatus,
-    checkTurnCompletion: vi.fn(async () => ({ allow: true }))
+    updateStepStatus
   }
   let currentInteraction = {
     kind: 'prompt' as const,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1713,10 +1713,8 @@ describe('ACP runtime session management', () => {
     const approved = restoredPlanProjection('approved', 5)
     const pending = restoredPlanProjection('pending', 4)
     const respond = vi.fn(async () => ({ projection: approved, changed: true }))
-    const checkTurnCompletion = vi.fn(async () => ({ allow: true }))
     installPromptPlanTestWorkflow(runtime, {
       respond,
-      checkTurnCompletion,
       getProjection: vi.fn(async () => pending)
     })
 
@@ -1744,10 +1742,6 @@ describe('ACP runtime session management', () => {
       })
     )
     expect(fakeAgent.prompts[0]?.text).toContain('artifact_version_id=version-1')
-    expect(checkTurnCompletion).toHaveBeenCalledWith({
-      projectId: 'project-1',
-      sessionId: 's1'
-    })
     expect(events).toContainEqual(
       expect.objectContaining({
         kind: 'plan',
@@ -12773,7 +12767,6 @@ describe('ACP runtime session management', () => {
       const authorizeContinuation = vi.fn(async () => active)
       installPromptPlanTestWorkflow(runtime, {
         authorizeContinuation,
-        checkTurnCompletion: vi.fn(async () => ({ allow: true })),
         getProjection: vi.fn(async () => active)
       })
 
@@ -12845,7 +12838,7 @@ describe('ACP runtime session management', () => {
     ['Codex', codexFramework],
     ['OpenCode', opencodeFramework]
   ] as const)(
-    'routes %s normal terminal stops through the Session Plan completion gate',
+    'lets %s finish a Conversation Turn while its Session Plan remains incomplete',
     async (_name, framework) => {
       const process = new FakeAgentProcess()
       startFakeAgent(process, ['s1'], {
@@ -12861,10 +12854,6 @@ describe('ACP runtime session management', () => {
         spawnAgent: () => asAgentProcess(process),
         framework
       })
-      const checkTurnCompletion = vi.fn(async () => ({
-        allow: false,
-        lifecycle: 'in_progress' as const
-      }))
       const getProjection = vi.fn(async () => null)
       const authorized = {
         artifactId: 'artifact-1',
@@ -12898,7 +12887,6 @@ describe('ACP runtime session management', () => {
       } satisfies ActivePlanProjection
       installPromptPlanTestWorkflow(runtime, {
         authorizeContinuation: vi.fn(async () => authorized),
-        checkTurnCompletion,
         getProjection
       })
 
@@ -12906,7 +12894,7 @@ describe('ACP runtime session management', () => {
       await expect(
         runtime.sendPrompt({
           sessionId: 's1',
-          text: 'finish early',
+          text: 'finish this turn',
           planContinuation: {
             projectId: 'project-1',
             artifactVersionId: 'version-1',
@@ -12917,11 +12905,7 @@ describe('ACP runtime session management', () => {
             messageAncestry: ['plan-origin', 'completion-message']
           }
         })
-      ).rejects.toThrow('The active Session Plan is not complete (in_progress).')
-      expect(checkTurnCompletion).toHaveBeenCalledWith({
-        projectId: 'project-1',
-        sessionId: 's1'
-      })
+      ).resolves.toMatchObject({ stopReason: 'end_turn' })
     }
   )
 
@@ -12934,12 +12918,7 @@ describe('ACP runtime session management', () => {
       spawnAgent: () => asAgentProcess(process),
       framework: opencodeFramework
     })
-    const checkTurnCompletion = vi.fn(async () => ({
-      allow: false,
-      lifecycle: 'approved' as const
-    }))
     installPromptPlanTestWorkflow(runtime, {
-      checkTurnCompletion,
       getProjection: vi.fn(async () => null)
     })
 
@@ -12948,11 +12927,10 @@ describe('ACP runtime session management', () => {
       runtime.sendPrompt({ sessionId: 's1', text: 'What is the weather?' })
     ).resolves.toMatchObject({ stopReason: 'end_turn' })
 
-    expect(checkTurnCompletion).not.toHaveBeenCalled()
     expect(fakeAgent.prompts[0]?.text).not.toContain('<open_science_protected_plan_context>')
   })
 
-  it('projects an abnormal provider terminal stop as interrupted instead of checking normal completion', async () => {
+  it('projects an abnormal provider terminal stop as interrupted', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['s1'], {
       modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
@@ -12966,21 +12944,19 @@ describe('ACP runtime session management', () => {
       framework: codexFramework,
       callbacks: { onEvent: (event) => events.push(event) }
     })
-    const checkTurnCompletion = vi.fn(async () => ({ allow: true }))
     const getProjection = vi.fn(
       async () =>
         ({
           lifecycle: 'interrupted'
         }) as ActivePlanProjection
     )
-    installPromptPlanTestWorkflow(runtime, { checkTurnCompletion, getProjection })
+    installPromptPlanTestWorkflow(runtime, { getProjection })
 
     await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
     await expect(
       runtime.sendPrompt({ sessionId: 's1', text: 'run the plan' })
     ).resolves.toMatchObject({ stopReason: 'max_tokens' })
 
-    expect(checkTurnCompletion).not.toHaveBeenCalled()
     expect(getProjection).toHaveBeenCalledWith('project-1', 's1', {
       interactionIsLive: false
     })

--- a/src/main/agent-framework/app-mcp-names.test.ts
+++ b/src/main/agent-framework/app-mcp-names.test.ts
@@ -42,6 +42,14 @@ describe('resolveCanonicalMcpToolIdentity', () => {
     )
   })
 
+  it('keeps Conversation Turn completion independent from Session Plan status', () => {
+    expect(SESSION_PLAN_SYSTEM_PROMPT_APPEND).not.toContain('Do not call `end_turn`')
+    expect(SESSION_PLAN_SYSTEM_PROMPT_APPEND).not.toContain('do not end the turn')
+    expect(SESSION_PLAN_SYSTEM_PROMPT_APPEND).toContain(
+      'If an irreversible blocker makes later steps unreachable'
+    )
+  })
+
   it.each([
     [
       'claude-code',

--- a/src/main/session-plan/guidance.ts
+++ b/src/main/session-plan/guidance.ts
@@ -6,11 +6,11 @@ const SESSION_PLAN_SYSTEM_PROMPT_APPEND = [
   'When a Plan is useful, generation supplies all four Plan fields (`task_summary`, `phases`, `desired_outputs`, and `feasibility`) in one call to `generate_plan` from the `open-science-plan` server.',
   'After generating a Plan, wait inside the `generate_plan` call until Open Science returns the user response. Do not report the Plan separately or execute any Plan step while waiting.',
   'Every text entered into the Plan card returns as `kind: feedback` and is a normal user Message, never an automatic Plan decision. Interpret the full meaning yourself: for an unambiguous approval or dismissal, call `generate_plan` again with only `decision: "approved"` or `decision: "rejected"`; for requested changes, revise and regenerate the Plan; for ambiguous or conditional language, do not grant execution authority.',
-  'After `kind: feedback`, do not end the turn while that Plan remains pending. If the Message is not an unambiguous decision, address it and call `generate_plan` again so the user receives a fresh review interaction.',
+  'After `kind: feedback`, if the Message is not an unambiguous decision, address it and call `generate_plan` again when a fresh Plan review interaction is appropriate.',
   'Only a Plan projection with `approval: approved` grants execution authority. Never call `update_step_status` while approval is pending, even if the feedback text sounds approving.',
   'After a restart or interruption, do not resume an approved unfinished Plan from an unrelated user Message. If the user explicitly asks to continue or resume that Plan, call `generate_plan` with only `decision: "approved"` to bind it to the current interaction before updating steps.',
   'After approval, call `update_step_status` with the exact step title when work starts and when it completes, is blocked, or is skipped.',
-  'Do not call `end_turn` while an approved Session Plan has runnable or in-progress work. If an irreversible blocker makes later steps unreachable, record the blocker, settle every already-started peer step, and end with the blocked outcome.',
+  'If an irreversible blocker makes later steps unreachable, record the blocker, settle every already-started peer step, and end with the blocked outcome.',
   '</open_science_session_plan_instructions>'
 ].join('\n')
 

--- a/src/main/session-plan/plan-service.test.ts
+++ b/src/main/session-plan/plan-service.test.ts
@@ -860,9 +860,6 @@ describe('PlanService', () => {
       title: 'Find evidence',
       status: 'completed'
     })
-    await expect(
-      service.checkTurnCompletion({ projectId: 'project-1', sessionId: 'session-1' })
-    ).resolves.toEqual({ allow: false, lifecycle: 'blocked' })
     const reviewRunning = await service.updateStepStatus({
       ...identity,
       expectedRevision: evidenceFound.projection.revision,
@@ -887,42 +884,11 @@ describe('PlanService', () => {
       'Draft report': { status: 'not_run' }
     })
     await expect(
-      service.checkTurnCompletion({ projectId: 'project-1', sessionId: 'session-1' })
-    ).resolves.toEqual({ allow: true, lifecycle: 'blocked' })
-    await expect(
       service.authorizeContinuation({
         ...identity,
         expectedRevision: settled.projection.revision
       })
     ).rejects.toMatchObject({ code: 'invalid-transition' })
-  })
-
-  it('fails the completion gate closed without clearing approved authority when its Artifact is unavailable', async () => {
-    const { service, dependencies, context } = setup()
-    const generated = await service.generate({
-      projectId: 'project-1',
-      sessionId: 'session-1',
-      interactionId: 'interaction-1',
-      content
-    })
-    await service.respond({
-      projectId: 'project-1',
-      sessionId: 'session-1',
-      artifactVersionId: generated.projection.artifactVersionId,
-      expectedRevision: generated.projection.revision,
-      decision: 'approved'
-    })
-    vi.mocked(dependencies.readArtifactVersion).mockRejectedValueOnce(
-      new Error('Artifact storage is unavailable.')
-    )
-
-    await expect(
-      service.checkTurnCompletion({ projectId: 'project-1', sessionId: 'session-1' })
-    ).rejects.toMatchObject({ code: 'artifact-unavailable' })
-    expect(context().plan).toMatchObject({
-      artifactVersionId: generated.projection.artifactVersionId,
-      approval: 'approved'
-    })
   })
 
   it('supports primary-agent sequential fallback without changing the delegation schema', async () => {

--- a/src/main/session-plan/plan-service.ts
+++ b/src/main/session-plan/plan-service.ts
@@ -316,20 +316,6 @@ class PlanService {
     return this.project(document, plan, context.revision, true)
   }
 
-  async checkTurnCompletion(input: {
-    projectId: string
-    sessionId: string
-  }): Promise<{ allow: boolean; lifecycle?: ActivePlanProjection['lifecycle'] }> {
-    const context = await this.dependencies.readRuntimeContext(input.projectId, input.sessionId)
-    if (!context.plan || context.plan.approval !== 'approved') return { allow: true }
-    const document = await this.readDocument(input.projectId, input.sessionId, context.plan)
-    const projection = this.project(document, context.plan, context.revision, true)
-    return {
-      allow: isPlanTerminalOutcome(document, context.plan.stepStatuses),
-      lifecycle: projection.lifecycle
-    }
-  }
-
   private async loadActive(
     input: PlanIdentityCommand,
     idempotentDecision?: 'approved' | 'rejected',


### PR DESCRIPTION
## Problem

An agent's normal Conversation Turn could be rejected when its approved Session Plan was still unfinished. The Plan completion barrier converted `end_turn` into a fatal `acp:send-prompt` error, preventing delivery of the agent's response.

## Proposed change

- Remove Session Plan completion validation from the provider stop path.
- Remove the now-unused Plan `beforeStop` hook and `checkTurnCompletion` service API.
- Keep Conversation Turn completion independent from Session Plan status across Claude Code, Codex, and OpenCode.
- Remove guidance that prohibited ending a turn while a Plan was pending or unfinished.

## Scope and non-goals

- Step transition rules, including `blocked`, are unchanged.
- No UI, automatic Plan recovery, extra prompting, or implicit Plan status updates are added.
- Plan terminal-state projection and explicit continuation behavior remain unchanged.

## Acceptance criteria and validation

All checks below ran after the final material edit.

- Incomplete Session Plan → normal Conversation Turn completion across all three frameworks:
  `npm test -- src/main/acp/runtime.test.ts src/main/acp/runtime-session-plan.test.ts src/main/acp/runtime-prompt-composition.test.ts src/main/acp/prompt-turn-workflow.test.ts src/main/acp/provider-prompt-executor.test.ts src/main/session-plan/plan-service.test.ts src/main/agent-framework/app-mcp-names.test.ts --reporter=dot`
  → 7 files passed, 574 tests passed.
- ACP and Session Plan type contracts:
  `npm run typecheck:node`
  → passed.
- Source standards:
  `npm run lint`
  → passed with 0 errors; 17 existing warnings are in files outside this diff.

The final Test Impact Set covers the ACP owner, provider/prompt workflow consumers, Session Plan service, framework guidance adapter, and all three supported agent frameworks. Full portable and OS-specific lanes are deferred to the PR Gate/GitHub Actions.

## Review focus

Please focus on the removal of the turn-to-Plan completion coupling and confirmation that Plan lifecycle/step semantics remain intact.

Closes #820
