### PR TITLE
refactor(notebook): own package mutation lifecycle

### DIFF
--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -1,0 +1,353 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { NotebookPackageAdmittedTarget } from './package-admission'
+import { NotebookPackageMutationOwner } from './package-mutation'
+import { CHILD_UNCONFIRMED } from './provisioner-runtime'
+import {
+  operationJournalPath,
+  readOperationChild,
+  RuntimeOperationJournal
+} from './operation-journal'
+
+type MutationOptions = ConstructorParameters<typeof NotebookPackageMutationOwner>[0]
+
+const tempRoots: string[] = []
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+const admittedTarget = (
+  runtimeRoot: string,
+  overrides: Partial<NotebookPackageAdmittedTarget> = {}
+): NotebookPackageAdmittedTarget => ({
+  request: { language: 'python', packages: ['numpy'], environment: 'analysis' },
+  environmentName: 'analysis',
+  environmentCaptureTarget: {
+    language: 'python',
+    environmentName: 'analysis',
+    runtimeSource: 'managed',
+    command: '/runtime/envs/analysis/bin/python'
+  },
+  repairRuntimeId: 'analysis',
+  repairMarkerKey: 'analysis::python',
+  repairRegistryKeys: ['analysis', 'analysis::python'],
+  journalTarget: join(runtimeRoot, 'envs', 'analysis'),
+  ...overrides
+})
+
+const ownerHarness = (
+  optionOverrides: Partial<MutationOptions> = {},
+  targetOverrides: Partial<NotebookPackageAdmittedTarget> = {}
+): {
+  owner: NotebookPackageMutationOwner
+  options: MutationOptions
+  target: NotebookPackageAdmittedTarget
+  runtimeRoot: string
+} => {
+  const storageRoot = mkdtempSync(join(tmpdir(), 'notebook-package-mutation-'))
+  tempRoots.push(storageRoot)
+  const runtimeRoot = join(storageRoot, 'runtime')
+  mkdirSync(runtimeRoot, { recursive: true })
+  const target = admittedTarget(runtimeRoot, targetOverrides)
+  const options: MutationOptions = {
+    storageRoot,
+    runtimeRoot,
+    environmentOperations: {
+      runMutation: async <T>(_environment: string, operation: () => Promise<T>): Promise<T> =>
+        operation(),
+      logPackageFailure: vi.fn(),
+      logPackageResult: vi.fn()
+    },
+    environmentStateTracker: {
+      markPackageMutationDirty: vi.fn().mockResolvedValue(undefined),
+      refreshAfterPackageMutation: vi.fn().mockResolvedValue({ result: 'success' })
+    },
+    installPackages: vi.fn().mockResolvedValue({
+      ok: true,
+      needsRestart: false,
+      log: 'installed',
+      method: 'conda'
+    }),
+    quarantineProtectedIdentity: vi.fn().mockResolvedValue(undefined),
+    completeInterruptedInstallRepair: vi.fn().mockResolvedValue(undefined),
+    blockUnconfirmedChild: vi.fn(),
+    ...optionOverrides
+  }
+  return { owner: new NotebookPackageMutationOwner(options), options, target, runtimeRoot }
+}
+
+const pending = (runtimeRoot: string): ReturnType<RuntimeOperationJournal['pending']> =>
+  RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot)).pending()
+
+describe('NotebookPackageMutationOwner', () => {
+  it('owns lock, journal, child evidence, verification and successful repair completion', async () => {
+    const order: string[] = []
+    let operationId = ''
+    const { owner, options, target, runtimeRoot } = ownerHarness({
+      environmentOperations: {
+        runMutation: async <T>(environment: string, operation: () => Promise<T>): Promise<T> => {
+          expect(environment).toBe('analysis')
+          order.push('lock')
+          const result = await operation()
+          order.push('unlock')
+          return result
+        },
+        logPackageFailure: vi.fn(),
+        logPackageResult: vi.fn(() => order.push('diagnostic'))
+      },
+      environmentStateTracker: {
+        markPackageMutationDirty: vi.fn(async (_target, mutation) => {
+          operationId = mutation.operationId
+          expect((await pending(runtimeRoot))[0]).toMatchObject({
+            operationId,
+            runtimeId: 'analysis::python',
+            targetPath: target.journalTarget,
+            repairReason: 'interrupted-install'
+          })
+          order.push('dirty')
+        }),
+        refreshAfterPackageMutation: vi.fn(async () => {
+          order.push('verify')
+          return {
+            result: 'success' as const,
+            packageChanges: [
+              {
+                name: 'numpy',
+                ecosystem: 'python' as const,
+                relationship: 'requested' as const,
+                change: 'installed' as const,
+                afterVersion: '2.0'
+              },
+              {
+                name: 'python-dateutil',
+                ecosystem: 'python' as const,
+                relationship: 'dependency' as const,
+                change: 'installed' as const,
+                afterVersion: '2.9'
+              }
+            ]
+          }
+        })
+      },
+      installPackages: vi.fn(async (request, deps) => {
+        expect(request.environment).toBe('analysis')
+        expect(deps).toMatchObject({
+          storageRoot: expect.any(String),
+          condaChannel: 'https://mirror/conda-forge/',
+          pypiIndex: 'https://mirror/pypi/simple',
+          cranMirror: 'https://mirror/cran/',
+          caBundle: '/certs/corporate.pem',
+          interpreter: undefined
+        })
+        order.push('spawn-1')
+        deps?.onBeforeSpawn?.()
+        expect(readOperationChild(runtimeRoot, operationId)).toMatchObject({ spawning: true })
+        deps?.onChild?.(process.pid)
+        expect(readOperationChild(runtimeRoot, operationId)).toMatchObject({
+          childPid: process.pid
+        })
+        order.push('spawn-2')
+        deps?.onBeforeSpawn?.()
+        expect(readOperationChild(runtimeRoot, operationId)).toMatchObject({ spawning: true })
+        return { ok: true, needsRestart: false, log: 'installed', method: 'conda' as const }
+      }),
+      completeInterruptedInstallRepair: vi.fn(async () => {
+        expect(await pending(runtimeRoot)).toEqual([])
+        expect(readOperationChild(runtimeRoot, operationId)).toBeUndefined()
+        order.push('repair-complete')
+      })
+    })
+
+    const result = await owner.mutate({
+      target,
+      mirror: {
+        condaChannel: 'https://mirror/conda-forge/',
+        pypiIndex: 'https://mirror/pypi/simple',
+        cranMirror: 'https://mirror/cran/',
+        caBundle: '/certs/corporate.pem'
+      }
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      packageChanges: [{ name: 'numpy', relationship: 'requested' }]
+    })
+    expect(order).toEqual([
+      'lock',
+      'dirty',
+      'spawn-1',
+      'spawn-2',
+      'verify',
+      'diagnostic',
+      'unlock',
+      'repair-complete'
+    ])
+    expect(options.quarantineProtectedIdentity).not.toHaveBeenCalled()
+  })
+
+  it('fails closed without dirtying or spawning when the journal cannot begin', async () => {
+    const { owner, options, target, runtimeRoot } = ownerHarness()
+    writeFileSync(operationJournalPath(runtimeRoot), '{not-json', 'utf8')
+
+    const result = await owner.mutate({ target, mirror: {} })
+
+    expect(result).toMatchObject({
+      ok: false,
+      needsRestart: false,
+      error: expect.stringContaining('RUNTIME_JOURNAL_UNWRITABLE')
+    })
+    expect(options.environmentStateTracker.markPackageMutationDirty).not.toHaveBeenCalled()
+    expect(options.installPackages).not.toHaveBeenCalled()
+    expect(options.completeInterruptedInstallRepair).not.toHaveBeenCalled()
+  })
+
+  it('clears journal evidence after a pre-spawn dirty-marker failure', async () => {
+    const dirtyFailure = new Error('dirty marker denied')
+    const { owner, options, target, runtimeRoot } = ownerHarness({
+      environmentStateTracker: {
+        markPackageMutationDirty: vi.fn().mockRejectedValue(dirtyFailure),
+        refreshAfterPackageMutation: vi.fn()
+      }
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).rejects.toBe(dirtyFailure)
+
+    expect(options.installPackages).not.toHaveBeenCalled()
+    expect(options.environmentStateTracker.refreshAfterPackageMutation).not.toHaveBeenCalled()
+    expect(await pending(runtimeRoot)).toEqual([])
+  })
+
+  it('logs installer failure, refreshes failed inventory and clears completed evidence', async () => {
+    const installFailure = new Error('installer failed')
+    const { owner, options, target, runtimeRoot } = ownerHarness({
+      installPackages: vi.fn().mockRejectedValue(installFailure)
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).rejects.toBe(installFailure)
+
+    expect(options.environmentOperations.logPackageFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ error: installFailure, environmentName: 'analysis' })
+    )
+    expect(options.environmentStateTracker.refreshAfterPackageMutation).toHaveBeenCalledWith(
+      target.environmentCaptureTarget,
+      expect.objectContaining({ result: 'failure', attempts: [], fallbackUsed: false })
+    )
+    expect(options.environmentOperations.logPackageResult).not.toHaveBeenCalled()
+    expect(await pending(runtimeRoot)).toEqual([])
+  })
+
+  it('turns an unverifiable successful installer result into the existing structured failure', async () => {
+    const { owner, options, target } = ownerHarness({
+      environmentStateTracker: {
+        markPackageMutationDirty: vi.fn().mockResolvedValue(undefined),
+        refreshAfterPackageMutation: vi.fn().mockRejectedValue(new Error('scan failed'))
+      }
+    })
+
+    const result = await owner.mutate({ target, mirror: {} })
+
+    expect(result).toMatchObject({
+      ok: false,
+      needsRestart: false,
+      error: expect.stringContaining('inventory refresh failed')
+    })
+    expect(options.environmentOperations.logPackageResult).toHaveBeenCalledWith(
+      expect.objectContaining({ result })
+    )
+    expect(options.completeInterruptedInstallRepair).not.toHaveBeenCalled()
+  })
+
+  it('upgrades evidence before quarantining a protected identity', async () => {
+    const { owner, options, target, runtimeRoot } = ownerHarness({
+      installPackages: vi.fn().mockResolvedValue({
+        ok: false,
+        needsRestart: false,
+        repairRequired: true,
+        log: 'protected interpreter changed'
+      }),
+      quarantineProtectedIdentity: vi.fn(async () => {
+        expect(await pending(runtimeRoot)).toEqual([
+          expect.objectContaining({
+            runtimeId: 'analysis',
+            repairReason: 'protected-identity-change'
+          })
+        ])
+      })
+    })
+
+    const result = await owner.mutate({ target, mirror: {} })
+
+    expect(result).toMatchObject({ ok: false, repairRequired: true })
+    expect(options.quarantineProtectedIdentity).toHaveBeenCalledWith(target)
+    expect(await pending(runtimeRoot)).toEqual([])
+  })
+
+  it('retains evidence when protected-identity quarantine is not durable', async () => {
+    const quarantineFailure = new Error('REPAIR_QUARANTINE_FAILED: registry denied')
+    const { owner, target, runtimeRoot } = ownerHarness({
+      installPackages: vi.fn().mockResolvedValue({
+        ok: false,
+        needsRestart: false,
+        repairRequired: true,
+        log: 'protected interpreter changed'
+      }),
+      quarantineProtectedIdentity: vi.fn().mockRejectedValue(quarantineFailure)
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).rejects.toBe(quarantineFailure)
+    expect(await pending(runtimeRoot)).toEqual([
+      expect.objectContaining({ repairReason: 'protected-identity-change' })
+    ])
+  })
+
+  it('quarantines but retains the original evidence when its stronger journal update fails', async () => {
+    const updateFailure = new Error('journal update denied')
+    vi.spyOn(RuntimeOperationJournal.prototype, 'update').mockRejectedValueOnce(updateFailure)
+    const { owner, options, target, runtimeRoot } = ownerHarness({
+      installPackages: vi.fn().mockResolvedValue({
+        ok: false,
+        needsRestart: false,
+        repairRequired: true,
+        log: 'protected interpreter changed'
+      })
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).rejects.toThrow(
+      /could not be upgraded.*journal update denied/
+    )
+
+    expect(options.quarantineProtectedIdentity).toHaveBeenCalledWith(target)
+    expect(await pending(runtimeRoot)).toEqual([
+      expect.objectContaining({ repairReason: 'interrupted-install' })
+    ])
+  })
+
+  it('retains sidecar and journal and blocks the target for an unconfirmed child', async () => {
+    let operationId = ''
+    const childFailure = new Error(`install failed: ${CHILD_UNCONFIRMED}`)
+    const { owner, options, target, runtimeRoot } = ownerHarness({
+      environmentStateTracker: {
+        markPackageMutationDirty: vi.fn(async (_target, mutation) => {
+          operationId = mutation.operationId
+        }),
+        refreshAfterPackageMutation: vi.fn().mockResolvedValue({ result: 'failure' })
+      },
+      installPackages: vi.fn(async (_request, deps) => {
+        deps?.onBeforeSpawn?.()
+        throw childFailure
+      })
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).rejects.toBe(childFailure)
+
+    expect(options.blockUnconfirmedChild).toHaveBeenCalledWith(target)
+    expect(await pending(runtimeRoot)).toEqual([expect.objectContaining({ operationId })])
+    expect(readOperationChild(runtimeRoot, operationId)).toMatchObject({ spawning: true })
+  })
+})

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -1,0 +1,251 @@
+import { randomUUID } from 'node:crypto'
+
+import type { PackageMirror } from '../../shared/mirror'
+import type { NotebookEnvironmentOperations } from './environment-operations'
+import type {
+  EnvironmentStateTracker,
+  PackageMutationVerification
+} from './environment-state-tracker'
+import {
+  operationJournalPath,
+  recordOperationChildSync,
+  recordSpawnIntentSync,
+  removeOperationChildSync,
+  RuntimeOperationJournal
+} from './operation-journal'
+import type { NotebookPackageAdmittedTarget } from './package-admission'
+import type { InstallDeps, InstallResult } from './package-manager'
+import { readProcessStartToken } from './operation-recovery'
+import { isChildUnconfirmedError } from './provisioner-runtime'
+
+const REPAIR_QUARANTINE_FAILED = 'REPAIR_QUARANTINE_FAILED'
+
+const isRepairQuarantineError = (error: unknown): boolean =>
+  error instanceof Error && error.message.includes(REPAIR_QUARANTINE_FAILED)
+
+type NotebookPackageMutationInput = Readonly<{
+  target: NotebookPackageAdmittedTarget
+  mirror: PackageMirror
+}>
+
+type NotebookPackageMutationOwnerOptions = {
+  storageRoot: string
+  runtimeRoot: string
+  environmentOperations: Pick<
+    NotebookEnvironmentOperations,
+    'runMutation' | 'logPackageFailure' | 'logPackageResult'
+  >
+  environmentStateTracker: Pick<
+    EnvironmentStateTracker,
+    'markPackageMutationDirty' | 'refreshAfterPackageMutation'
+  >
+  installPackages: (
+    request: NotebookPackageAdmittedTarget['request'],
+    deps?: Partial<InstallDeps>
+  ) => Promise<InstallResult>
+  quarantineProtectedIdentity: (target: NotebookPackageAdmittedTarget) => Promise<void>
+  completeInterruptedInstallRepair: (target: NotebookPackageAdmittedTarget) => Promise<void>
+  blockUnconfirmedChild: (target: NotebookPackageAdmittedTarget) => void
+}
+
+/** Owns the complete crash-recoverable transaction for one admitted package mutation. */
+class NotebookPackageMutationOwner {
+  constructor(private readonly options: NotebookPackageMutationOwnerOptions) {}
+
+  async mutate({ target, mirror }: NotebookPackageMutationInput): Promise<InstallResult> {
+    const {
+      environmentCaptureTarget,
+      environmentName,
+      interpreter,
+      journalTarget,
+      repairMarkerKey,
+      repairRuntimeId,
+      request
+    } = target
+    const { runtimeRoot } = this.options
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    const operationId = randomUUID()
+    let result: InstallResult
+    let retainForRecovery = false
+    let begun = false
+    try {
+      // The journal begins inside the environment lock so Reset cannot clear this new operation
+      // between intent recording and the first installer spawn.
+      result = await this.options.environmentOperations.runMutation(environmentName, async () => {
+        await journal.begin({
+          operationId,
+          kind: 'install',
+          runtimeId: repairMarkerKey,
+          phase: `install-${request.language}`,
+          startedAt: Date.now(),
+          targetPath: journalTarget,
+          repairReason: 'interrupted-install'
+        })
+        begun = true
+        const mutation = {
+          operationId,
+          operation: request.operation ?? ('install' as const),
+          packages: request.packages
+        }
+        // A durable dirty marker is required before spawn so a crash cannot leave stale inventory
+        // presented as a clean environment snapshot.
+        await this.options.environmentStateTracker.markPackageMutationDirty(
+          environmentCaptureTarget,
+          mutation
+        )
+        let installResult: InstallResult | undefined
+        let deferredQuarantineError: Error | undefined
+        const installerStartedAt = Date.now()
+        let installerDurationMs = 0
+        try {
+          try {
+            installResult = await this.options.installPackages(request, {
+              storageRoot: this.options.storageRoot,
+              condaChannel: mirror.condaChannel,
+              pypiIndex: mirror.pypiIndex,
+              cranMirror: mirror.cranMirror,
+              caBundle: mirror.caBundle,
+              interpreter,
+              // Re-arm before every installer spawn. A later spawn intent must supersede an earlier PID
+              // so recovery never treats the operation as stopped while another child may be starting.
+              onBeforeSpawn: () => recordSpawnIntentSync(runtimeRoot, operationId),
+              onChild: (childPid) => {
+                const childStartedAt = Date.now()
+                const childStartToken = readProcessStartToken(childPid)
+                recordOperationChildSync(runtimeRoot, operationId, {
+                  childPid,
+                  childStartedAt,
+                  childStartToken
+                })
+                void journal
+                  .update(operationId, { childPid, childStartedAt, childStartToken })
+                  .catch(() => undefined)
+              }
+            })
+            installerDurationMs = Date.now() - installerStartedAt
+          } catch (error) {
+            this.options.environmentOperations.logPackageFailure({
+              operationId,
+              operation: mutation.operation,
+              language: request.language,
+              environmentName,
+              runtimeSource: environmentCaptureTarget.runtimeSource,
+              packages: request.packages,
+              error,
+              durationMs: Date.now() - installerStartedAt
+            })
+            throw error
+          }
+        } finally {
+          let inventoryRefreshError: unknown
+          const verification: PackageMutationVerification | undefined =
+            await this.options.environmentStateTracker
+              .refreshAfterPackageMutation(environmentCaptureTarget, {
+                ...mutation,
+                result: installResult?.ok ? 'success' : 'failure',
+                attempts: installResult?.attempts ?? [],
+                fallbackUsed: installResult?.fallbackUsed ?? false
+              })
+              .catch((error: unknown) => {
+                inventoryRefreshError = error
+                return { result: 'failure' as const, reason: 'inventory-refresh-failed' as const }
+              })
+          if (installResult && verification?.packageChanges) {
+            installResult = {
+              ...installResult,
+              packageChanges: verification.packageChanges.filter(
+                (change) => change.relationship === 'requested'
+              )
+            }
+          }
+          if (installResult?.ok && verification?.result === 'failure') {
+            const packages =
+              verification.unsatisfiedPackages?.join(', ') || request.packages.join(', ')
+            const inventoryFailure =
+              verification.reason === 'inventory-refresh-failed' || inventoryRefreshError
+            installResult = {
+              ...installResult,
+              ok: false,
+              needsRestart: false,
+              error: inventoryFailure
+                ? `Package installation could not be verified in the target runtime: ${packages}. ` +
+                  'The installer exited successfully, but the environment inventory refresh failed.'
+                : `Package installation could not be verified in the target runtime: ${packages}. ` +
+                  'The installer exited successfully, but the refreshed environment inventory does not show the requested package(s).'
+            }
+          }
+          // Publish the strong repair reason before quarantine and before releasing the environment
+          // lock. Retain both journal and sidecar unless the durable gate is fully established.
+          if (installResult?.repairRequired) {
+            retainForRecovery = true
+            let journalUpdateError: unknown
+            try {
+              await journal.update(operationId, {
+                runtimeId: repairRuntimeId,
+                repairReason: 'protected-identity-change'
+              })
+            } catch (error) {
+              journalUpdateError = error
+            }
+            await this.options.quarantineProtectedIdentity(target)
+            if (journalUpdateError) {
+              deferredQuarantineError = new Error(
+                `${REPAIR_QUARANTINE_FAILED}: the runtime was quarantined, but its operation journal ` +
+                  `could not be upgraded to the protected-identity reason. ${
+                    journalUpdateError instanceof Error
+                      ? journalUpdateError.message
+                      : String(journalUpdateError)
+                  }`,
+                { cause: journalUpdateError }
+              )
+            } else {
+              retainForRecovery = false
+            }
+          }
+        }
+        if (deferredQuarantineError) throw deferredQuarantineError
+        if (installResult) {
+          this.options.environmentOperations.logPackageResult({
+            operationId,
+            operation: mutation.operation,
+            language: request.language,
+            environmentName,
+            runtimeSource: environmentCaptureTarget.runtimeSource,
+            packages: request.packages,
+            result: installResult,
+            durationMs: installerDurationMs
+          })
+        }
+        return installResult
+      })
+    } catch (error) {
+      if (!begun) {
+        return {
+          ok: false,
+          needsRestart: false,
+          log: '',
+          error:
+            'RUNTIME_JOURNAL_UNWRITABLE: could not record this install for crash recovery, so it was ' +
+            `not started (installing without a recovery record could strand a worker process). ${
+              error instanceof Error ? error.message : String(error)
+            }`
+        }
+      }
+      if (isRepairQuarantineError(error)) retainForRecovery = true
+      if (isChildUnconfirmedError(error)) {
+        retainForRecovery = true
+        this.options.blockUnconfirmedChild(target)
+      }
+      throw error
+    } finally {
+      if (begun && !retainForRecovery) {
+        removeOperationChildSync(runtimeRoot, operationId)
+        await journal.complete(operationId).catch(() => undefined)
+      }
+    }
+    if (result.ok) await this.options.completeInterruptedInstallRepair(target)
+    return result
+  }
+}
+
+export { NotebookPackageMutationOwner }

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -45,7 +45,11 @@ import {
   type InstallRequest,
   type InstallResult
 } from './package-manager'
-import { NotebookPackageAdmissionOwner } from './package-admission'
+import {
+  NotebookPackageAdmissionOwner,
+  type NotebookPackageAdmittedTarget
+} from './package-admission'
+import { NotebookPackageMutationOwner } from './package-mutation'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
 import {
   addRepairRequired,
@@ -74,15 +78,6 @@ import type {
   RuntimeUsage
 } from '../../shared/notebook-runtime'
 import type { NotebookRuntimeSettings } from '../settings/capabilities'
-import {
-  operationJournalPath,
-  recordOperationChildSync,
-  recordSpawnIntentSync,
-  removeOperationChildSync,
-  RuntimeOperationJournal
-} from './operation-journal'
-import { readProcessStartToken } from './operation-recovery'
-import { isChildUnconfirmedError } from './provisioner-runtime'
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
 import { NotebookEnvironmentOperations, type DefaultEnvProvisioner } from './environment-operations'
 import {
@@ -101,8 +96,7 @@ import { createLogger, getLogFilePath } from '../logger'
 import {
   EnvironmentStateTracker,
   type EnvironmentCaptureTarget,
-  type PackageInspectionResult,
-  type PackageMutationVerification
+  type PackageInspectionResult
 } from './environment-state-tracker'
 import { NotebookRuntimeBindingOwner } from './runtime-binding'
 import type { RuntimeDiagnosticLogger } from './runtime-diagnostics'
@@ -128,9 +122,6 @@ const EMPTY_NOTEBOOK_RUNTIME_SETTINGS: Pick<NotebookRuntimeSettings, 'getSnapsho
 }
 
 const REPAIR_QUARANTINE_FAILED = 'REPAIR_QUARANTINE_FAILED'
-
-const isRepairQuarantineError = (error: unknown): boolean =>
-  error instanceof Error && error.message.includes(REPAIR_QUARANTINE_FAILED)
 
 // Composite routing key for a data run, matching the executor's resolveProcessKey: `${kind}:${env}`
 // where kind is the language and env is the resolved env name. python:default-python and
@@ -416,6 +407,7 @@ class NotebookRuntimeService {
   private readonly executionOwner: NotebookExecutionOwner
   private readonly dataExecutionAdmission: NotebookDataExecutionAdmissionOwner
   private readonly packageAdmission: NotebookPackageAdmissionOwner
+  private readonly packageMutation: NotebookPackageMutationOwner
   private readonly sessions: NotebookSessionRegistry<RuntimeSession>
   private readonly announcedAgentSessionIds = new Set<string>()
   // Owns process-global operation admission, provisioning progress, restart recommendations,
@@ -433,10 +425,6 @@ class NotebookRuntimeService {
   // allowlisting, and same-process live-unconfirmed tracking. The service retains its public recovery
   // facade so Electron, Web, CLI, and IPC adapters keep the same contract.
   private readonly recoveryCoordinator: NotebookRecoveryCoordinator
-  private readonly installPackagesImpl: (
-    request: InstallRequest,
-    deps?: Partial<InstallDeps>
-  ) => Promise<InstallResult>
   private readonly runtimeLogger?: RuntimeDiagnosticLogger
   private readonly environmentStateTracker: Pick<
     EnvironmentStateTracker,
@@ -476,7 +464,6 @@ class NotebookRuntimeService {
       discoverRuntimes: options.discoverRuntimes,
       platform: options.platform
     })
-    this.installPackagesImpl = options.installPackagesImpl ?? installPackagesDefault
     this.runtimeLogger =
       options.logger ?? (getLogFilePath() ? createLogger('notebook:runtime') : undefined)
     this.environmentOperations = new NotebookEnvironmentOperations({
@@ -486,6 +473,13 @@ class NotebookRuntimeService {
       notifyChanged: (session) => this.notifyNotebookChanged(session as RuntimeSession),
       logger: this.runtimeLogger
     })
+    this.environmentStateTracker =
+      options.environmentStateTracker ??
+      new EnvironmentStateTracker({
+        dataRoot: options.dataRoot,
+        platform: options.platform,
+        logger: this.runtimeLogger
+      })
     this.packageAdmission = new NotebookPackageAdmissionOwner({
       runtimeRoot: getRuntimeRoot(options.dataRoot),
       loadSession: (request) => this.ensureSession(request),
@@ -498,13 +492,19 @@ class NotebookRuntimeService {
       recovery: this.recoveryCoordinator,
       createEnvironmentCaptureTarget: (...args) => this.environmentCaptureTarget(...args)
     })
-    this.environmentStateTracker =
-      options.environmentStateTracker ??
-      new EnvironmentStateTracker({
-        dataRoot: options.dataRoot,
-        platform: options.platform,
-        logger: this.runtimeLogger
-      })
+    this.packageMutation = new NotebookPackageMutationOwner({
+      storageRoot: options.dataRoot,
+      runtimeRoot: getRuntimeRoot(options.dataRoot),
+      environmentOperations: this.environmentOperations,
+      environmentStateTracker: this.environmentStateTracker,
+      installPackages: options.installPackagesImpl ?? installPackagesDefault,
+      quarantineProtectedIdentity: (target) => this.quarantinePackageTarget(target),
+      completeInterruptedInstallRepair: (target) => this.completePackageTargetRepair(target),
+      blockUnconfirmedChild: ({ repairRuntimeId, journalTarget }) => {
+        this.recoveryCoordinator.markRuntimeLiveUnconfirmed(repairRuntimeId)
+        if (journalTarget) this.blockPrefixRecovery(journalTarget)
+      }
+    })
     this.dataExecutionAdmission = new NotebookDataExecutionAdmissionOwner({
       runtimeRoot: getRuntimeRoot(options.dataRoot),
       environmentOperations: this.environmentOperations,
@@ -1139,287 +1139,73 @@ class NotebookRuntimeService {
 
     const admission = await this.packageAdmission.admit(request)
     if (admission.status === 'refused') return admission.result
-    const {
-      binding,
-      environmentName: envName,
-      environmentCaptureTarget: environmentTarget,
-      interpreter,
-      journalTarget,
-      repairMarkerKey,
-      repairRuntimeId,
-      request: pinnedRequest
-    } = admission.target
-    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
-    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
-    const operationId = randomUUID()
-    let result: InstallResult
-    let retainForRecovery = false
-    let begun = false // did journal.begin() succeed? distinguishes a begin failure from an install error
-    try {
-      // Record the install intent INSIDE the env lock, not before it. A concurrent Reset holds this same
-      // env lock while it clearQuarantine()s the prefix's journal records; recording before acquiring the
-      // lock let the Reset delete THIS record between our begin() and the install starting, after which
-      // journal.update() no-ops and a crash would strand a sidecar with no journal record recovery scans.
-      result = await this.environmentOperations.runMutation(envName, async () => {
-        // Fail CLOSED, like the provisioner's prefix writes: if we can't record the intent (journal
-        // begin — also throws on a corrupt journal), do NOT spawn the installer; a crash would otherwise
-        // leave an unrecorded child recovery can't reap. The begun flag routes this to a structured
-        // refusal below. (The per-spawn intent sidecar is re-armed by onBeforeSpawn, before EACH spawn.)
-        await journal.begin({
-          operationId,
-          kind: 'install',
-          runtimeId: repairMarkerKey,
-          phase: `install-${request.language}`,
-          startedAt: Date.now(),
-          targetPath: journalTarget,
-          repairReason: 'interrupted-install'
-        })
-        begun = true
-        const mutation = {
-          operationId,
-          operation: request.operation ?? ('install' as const),
-          packages: request.packages
-        }
-        // Fail closed before the installer can spawn. If the durable dirty marker cannot be
-        // published, a crash during installation would leave the Environment snapshot cache
-        // looking clean even though package state may have changed.
-        await this.environmentStateTracker.markPackageMutationDirty(environmentTarget, mutation)
-        let installResult: InstallResult | undefined
-        let deferredQuarantineError: Error | undefined
-        const installerStartedAt = Date.now()
-        let installerDurationMs = 0
-        try {
-          try {
-            installResult = await this.installPackagesImpl(pinnedRequest, {
-              storageRoot: this.options.dataRoot,
-              condaChannel: mirror.condaChannel,
-              pypiIndex: mirror.pypiIndex,
-              cranMirror: mirror.cranMirror,
-              caBundle: mirror.caBundle,
-              interpreter,
-              // Re-arm the per-spawn intent immediately before EACH installer spawn (conda then CRAN), so a
-              // second spawn whose PID isn't recorded yet blocks rather than trusting the first's PID.
-              onBeforeSpawn: () => recordSpawnIntentSync(runtimeRoot, operationId),
-              // Record each installer child's PID so startup recovery can block on a surviving conda/pip/R
-              // install (never reconcile the env under it) until it is provably gone. Recovery never signals
-              // the child. Persisted SYNCHRONOUSLY (crash-safe) so a spawned child is always probeable; the
-              // async journal update is the normal read path.
-              onChild: (childPid) => {
-                const childStartedAt = Date.now()
-                // Kernel-native identity token captured while the child is alive, so recovery can FALSIFY
-                // pid reuse (a changed token proves the pid is no longer ours); undefined off Linux — see
-                // readProcessStartToken. Never used to authorize a signal.
-                const childStartToken = readProcessStartToken(childPid)
-                recordOperationChildSync(runtimeRoot, operationId, {
-                  childPid,
-                  childStartedAt,
-                  childStartToken
-                })
-                void journal
-                  .update(operationId, { childPid, childStartedAt, childStartToken })
-                  .catch(() => undefined)
-              }
-            })
-            installerDurationMs = Date.now() - installerStartedAt
-          } catch (error) {
-            this.environmentOperations.logPackageFailure({
-              operationId,
-              operation: mutation.operation,
-              language: request.language,
-              environmentName: envName,
-              runtimeSource: environmentTarget.runtimeSource,
-              packages: request.packages,
-              error,
-              durationMs: Date.now() - installerStartedAt
-            })
-            throw error
-          }
-        } finally {
-          let inventoryRefreshError: unknown
-          const verification: PackageMutationVerification | undefined =
-            await this.environmentStateTracker
-              .refreshAfterPackageMutation(environmentTarget, {
-                ...mutation,
-                result: installResult?.ok ? 'success' : 'failure',
-                attempts: installResult?.attempts ?? [],
-                fallbackUsed: installResult?.fallbackUsed ?? false
-              })
-              .catch((error: unknown) => {
-                inventoryRefreshError = error
-                return { result: 'failure' as const, reason: 'inventory-refresh-failed' as const }
-              })
-          if (installResult && verification?.packageChanges) {
-            installResult = {
-              ...installResult,
-              packageChanges: verification.packageChanges.filter(
-                (change) => change.relationship === 'requested'
-              )
-            }
-          }
-          if (installResult?.ok && verification?.result === 'failure') {
-            const packages =
-              verification?.unsatisfiedPackages?.join(', ') || request.packages.join(', ')
-            const inventoryFailure =
-              verification?.reason === 'inventory-refresh-failed' || inventoryRefreshError
-            installResult = {
-              ...installResult,
-              ok: false,
-              needsRestart: false,
-              error: inventoryFailure
-                ? `Package installation could not be verified in the target runtime: ${packages}. ` +
-                  'The installer exited successfully, but the environment inventory refresh failed.'
-                : `Package installation could not be verified in the target runtime: ${packages}. ` +
-                  'The installer exited successfully, but the refreshed environment inventory does not show the requested package(s).'
-            }
-          }
-          // Publish and enforce the repair gate before releasing the environment install lock. A
-          // failed conda transaction may already have replaced r-base; no queued work may observe the
-          // damaged prefix between the transaction finishing and quarantine becoming durable.
-          if (installResult?.repairRequired) {
-            // Upgrade the retained operation evidence BEFORE publishing the registry marker. If the
-            // registry write fails, startup recovery must replay this exact stronger reason instead of
-            // treating the changed interpreter as a repairable interrupted install. Keep the record on
-            // either failure; only a fully durable quarantine lets the normal finally clear it.
-            retainForRecovery = true
-            let journalUpdateError: unknown
-            try {
-              await journal.update(operationId, {
-                runtimeId: repairRuntimeId,
-                repairReason: 'protected-identity-change'
-              })
-            } catch (error) {
-              journalUpdateError = error
-            }
-            // Even when the journal cannot be upgraded (ENOSPC/EACCES/I/O), publish the in-process
-            // gate, terminate live kernels, and attempt the independent repair registry marker before
-            // the install lock is released. The registry then remains the durable strong reason; the
-            // retained journal is additional recovery evidence rather than the only active guard.
-            await this.quarantineRuntimeForRepair(
-              repairRuntimeId,
-              request.language,
-              envName,
-              runtimeRoot,
-              binding?.source !== 'external'
-            )
-            if (journalUpdateError) {
-              deferredQuarantineError = new Error(
-                `${REPAIR_QUARANTINE_FAILED}: the runtime was quarantined, but its operation journal ` +
-                  `could not be upgraded to the protected-identity reason. ${
-                    journalUpdateError instanceof Error
-                      ? journalUpdateError.message
-                      : String(journalUpdateError)
-                  }`,
-                { cause: journalUpdateError }
-              )
-            } else {
-              retainForRecovery = false
-            }
-          }
-        }
-        if (deferredQuarantineError) throw deferredQuarantineError
-        if (installResult) {
-          this.environmentOperations.logPackageResult({
-            operationId,
-            operation: mutation.operation,
-            language: request.language,
-            environmentName: envName,
-            runtimeSource: environmentTarget.runtimeSource,
-            packages: request.packages,
-            result: installResult,
-            durationMs: installerDurationMs
-          })
-        }
-        return installResult
-      })
-    } catch (error) {
-      // begin() failed (nothing spawned) → structured fail-closed refusal, no cleanup needed.
-      if (!begun) {
-        return {
-          ok: false,
-          needsRestart: false,
-          log: '',
-          error:
-            'RUNTIME_JOURNAL_UNWRITABLE: could not record this install for crash recovery, so it was ' +
-            `not started (installing without a recovery record could strand a worker process). ${
-              error instanceof Error ? error.message : String(error)
-            }`
-        }
-      }
-      // A recording failure whose installer couldn't be confirmed stopped: keep the sidecar + journal
-      // record so recovery blocks (a worker may still be writing) instead of clearing the evidence.
-      if (isRepairQuarantineError(error)) retainForRecovery = true
-      if (isChildUnconfirmedError(error)) {
-        retainForRecovery = true
-        // Block IN THIS PROCESS now, not just via the retained journal entry (which only guards the next
-        // boot): otherwise an in-session retry would pass the guard above and begin() a SECOND install,
-        // spawning an installer that races the first's possibly-live orphan. Block the bound runtimeId
-        // (the install's identity — external or managed named) and, for a managed install, its prefix.
-        // blockPrefixRecovery ALSO marks the prefix live-unconfirmed, so a force Reset this session
-        // refuses to delete + rebuild it out from under the possibly-live installer (clearQuarantine).
-        this.recoveryCoordinator.markRuntimeLiveUnconfirmed(repairRuntimeId)
-        if (journalTarget) this.blockPrefixRecovery(journalTarget)
-      }
-      throw error
-    } finally {
-      if (begun && !retainForRecovery) {
-        removeOperationChildSync(runtimeRoot, operationId)
-        await journal.complete(operationId).catch(() => undefined)
-      }
-    }
-    // A completed install clears an interrupted-install repair flag (a protected-identity flag was
-    // refused before any installer ran). Clearing the disk flag alone isn't enough — bindings that were
-    // resolved while repair-required (in THIS and OTHER sessions) are still held in memory as
-    // unavailable/repair-required and would keep refusing execution until a rebind/reload. Restore every
-    // matching binding to active and refresh its UI so the repaired runtime is usable immediately.
-    if (result.ok) {
-      const managedRepair = binding?.source !== 'external'
-      clearRepairRequired(runtimeRoot, repairMarkerKey)
-      // A pre-canonicalization registry may still key this same managed prefix by an interpreter path.
-      // Clear aliases only for the repaired language. A successful Python install must not release an R
-      // interrupted-install marker (or vice versa) merely because both bindings share one Conda prefix.
-      if (managedRepair) {
-        // Recompute after installation: the interpreter may have appeared or canonicalized during the
-        // mutation, and the fresh real path can name an older interrupted-install marker to clear.
-        const legacyAliases = new Set(
-          this.repairRegistryKeys(request.language, envName, binding, runtimeRoot)
-        )
-        legacyAliases.delete(envName)
-        legacyAliases.delete(repairMarkerKey)
-        for (const session of this.sessions.values()) {
-          for (const [language, candidate] of session.runtimeBindingEntries()) {
-            if (
-              language === request.language &&
-              candidate.source === 'managed' &&
-              this.resolveRunEnv(session, language) === envName
-            ) {
-              legacyAliases.add(candidate.runtimeId)
-            }
-          }
-        }
-        for (const alias of legacyAliases) {
-          if (readRepairRequiredReason(runtimeRoot, alias) === 'interrupted-install') {
-            clearRepairRequired(runtimeRoot, alias)
-          }
-        }
-      }
-      if (!managedRepair) {
-        this.environmentOperations.clearRepair(
-          externalRepairBlockKey(request.language, repairRuntimeId)
-        )
-      }
-      await this.restoreRepairedBindings(repairRuntimeId, request.language, envName, managedRepair)
-    }
+    const result = await this.packageMutation.mutate({ target: admission.target, mirror })
 
     // R installs/uninstalls don't take effect in a live R session (attached namespaces, held DLLs), so
     // flag the env for a restart prompt and refresh every session's env view. Python needs no restart.
     if (result.ok && result.needsRestart && request.language === 'r') {
-      this.environmentOperations.recommendRestart('r', envName)
+      this.environmentOperations.recommendRestart('r', admission.target.environmentName)
       for (const session of this.sessions.values()) {
         this.notifyNotebookChanged(session)
       }
     }
 
     return result
+  }
+
+  private quarantinePackageTarget(target: NotebookPackageAdmittedTarget): Promise<void> {
+    return this.quarantineRuntimeForRepair(
+      target.repairRuntimeId,
+      target.request.language,
+      target.environmentName,
+      getRuntimeRoot(this.options.dataRoot),
+      target.binding?.source !== 'external'
+    )
+  }
+
+  // N3 will move registry compatibility and binding restoration behind the permanent repair owner.
+  // Until then this injected port preserves the existing post-install behavior without giving the
+  // mutation owner direct access to Session state or repair registries.
+  private async completePackageTargetRepair(target: NotebookPackageAdmittedTarget): Promise<void> {
+    const { binding, environmentName, repairMarkerKey, repairRuntimeId, request } = target
+    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
+    const managedRepair = binding?.source !== 'external'
+    clearRepairRequired(runtimeRoot, repairMarkerKey)
+    if (managedRepair) {
+      // Recompute after installation: the interpreter may have appeared or canonicalized during the
+      // mutation, and the fresh real path can name an older interrupted-install marker to clear.
+      const legacyAliases = new Set(
+        this.repairRegistryKeys(request.language, environmentName, binding, runtimeRoot)
+      )
+      legacyAliases.delete(environmentName)
+      legacyAliases.delete(repairMarkerKey)
+      for (const session of this.sessions.values()) {
+        for (const [language, candidate] of session.runtimeBindingEntries()) {
+          if (
+            language === request.language &&
+            candidate.source === 'managed' &&
+            this.resolveRunEnv(session, language) === environmentName
+          ) {
+            legacyAliases.add(candidate.runtimeId)
+          }
+        }
+      }
+      for (const alias of legacyAliases) {
+        if (readRepairRequiredReason(runtimeRoot, alias) === 'interrupted-install') {
+          clearRepairRequired(runtimeRoot, alias)
+        }
+      }
+    } else {
+      this.environmentOperations.clearRepair(
+        externalRepairBlockKey(request.language, repairRuntimeId)
+      )
+    }
+    await this.restoreRepairedBindings(
+      repairRuntimeId,
+      request.language,
+      environmentName,
+      managedRepair
+    )
   }
 
   // Named-environment management (design D2), delegating to the injected provisioner-backed manager.


### PR DESCRIPTION
## Problem

`NotebookRuntimeService.managePackages` still owned the complete admitted package mutation transaction: environment locking, crash journal and child sidecars, installer invocation, inventory verification, diagnostic timing, and recovery-evidence retention. That kept crash-safety state and lifecycle ordering inside the compatibility facade instead of behind one deep owner.

## Proposed change

Add `NotebookPackageMutationOwner` with one operation:

```ts
mutate({ target, mirror }): Promise<InstallResult>
```

The N1 admitted target remains the pinned source of environment, interpreter, repair and journal identities. The facade still resolves/probes the effective mirror before admission, then delegates the admitted transaction to the owner.

```mermaid
sequenceDiagram
  participant F as NotebookRuntimeService
  participant A as Package admission
  participant M as Package mutation owner
  participant E as Environment operations
  participant I as Existing installer

  F->>F: ensure recovery and resolve mirror
  F->>A: admit(request)
  A-->>F: pinned target or existing refusal
  F->>M: mutate(target, mirror)
  M->>E: acquire exclusive environment mutation
  M->>M: journal begin → dirty marker
  M->>I: install with per-spawn intent / child identity
  I-->>M: existing InstallResult
  M->>M: inventory verify → quarantine/evidence → journal complete
  M-->>F: existing InstallResult
```

Quarantine and successful interrupted-install repair restoration remain injected ports. N3 can replace those ports with the permanent repair owner without giving this mutation module Session or repair-registry ownership.

## Scope and non-goals

- Production raw: **633** lines — `package-mutation.ts` 251 additions; `runtime-service.ts` 84 additions / 298 deletions. This uses the approved 10% tolerance above the 600-line target but remains below the **660 hard ceiling**, so the split trigger did not fire.
- Test raw: **353** additions in `package-mutation.test.ts`.
- `runtime-service.ts` falls from **2,143 to 1,929 physical lines**.
- No request/result/error, IPC, local-RPC, MCP, Electron/Web/CLI/Task, authorization, persisted journal, Session, Settings, database, or UI contract changes.
- No retry, cancellation, progress, package-manager, cache-selection, or provisioner behavior changes.
- The already resolved post-merge PR #827 AI checkout exception is outside this PR and is neither changed nor reopened here.

## Compatibility

- Preserves `ensureRecovered → mirror probe → admission → mutation`, including the existing mirror-before-refusal ordering.
- Preserves lock-scoped journal begin, fail-closed dirty marking, per-spawn sidecar re-arming, synchronous child identity evidence, requested-only package change projection, and best-effort completion cleanup.
- Preserves evidence when child liveness or quarantine durability is uncertain.
- Successful repair cleanup still freshly recomputes legacy aliases after installation; it does not trust N1's pre-install alias snapshot, because the interpreter may have appeared or canonicalized during mutation.
- `package-manager` remains the owner of physical cache selection, cache locks, and MAX_PATH package recovery. The provisioner remains the owner of bundle path budgets and retry/reseed cleanup. The #823 Windows PUBLIC short-cache fallback and uninstall cleanup are untouched.
- Existing Specialist, Permission and Compute capability asymmetries remain unchanged across Electron, Web and CLI/Task.

## Acceptance criteria and validation

Exact baseline: `a8c298ddb870a7e62a1c23d8628c0a65f857ce2`  
Exact head: `ec0f826ce2816327aac69fad0f14a444647684ad`

All listed checks ran on the final material state:

- Mutation owner + admission + facade contracts → `npm test -- src/main/notebook/package-mutation.test.ts src/main/notebook/package-admission.test.ts src/main/notebook/runtime-service.test.ts` → **3 files, 205 tests passed** (owner 9/9; runtime facade 183/183).
- Package-manager / #823 cache / portable Electron uninstall-config boundary → `npm test -- src/main/notebook/package-manager.test.ts src/main/notebook/micromamba-cache.test.ts scripts/electron-builder-config.test.ts` → **3 files, 96 tests passed**.
- Windows access-violation and MAX_PATH retry contract → `npm test -- src/main/notebook/provisioner.test.ts -t 'access violation|MAX_PATH|MaxPath'` → **5 passed, 82 skipped by filter**.
- Node main-process types → `npm run typecheck:node` → **passed**.
- Changed-file lint → `npx eslint --no-cache src/main/notebook/package-mutation.ts src/main/notebook/package-mutation.test.ts src/main/notebook/runtime-service.ts` → **passed, 0 findings**.
- Patch integrity → `git diff --check` → **passed**.
- Independent review → **Standards 0 findings / Spec 0 findings**.

The remaining platform risk is real Windows filesystem/ACL and process behavior, which local portable tests cannot reproduce. The PR Gate's Windows/platform lanes remain authoritative; full portable validation is delegated to CI as allowed by the project plan.

## Review focus

- Verify that the owner keeps the invariant ordering: exclusive lock → journal begin → dirty marker → per-spawn evidence → installer → inventory verification → quarantine/evidence decision → cleanup.
- Verify that journal/sidecar evidence is retained for child-unconfirmed and repair-quarantine failures, but cleared for completed and pre-spawn-settled operations.
- Verify the two temporary repair callbacks preserve fresh alias recomputation and are narrow enough for N3 replacement.
- Verify no cache selection, #823 PUBLIC fallback, Windows provisioner retry, adapter or public contract moved into the new owner.
- **Squash merge only** with `refactor(notebook): own package mutation lifecycle` as the squash commit subject.
