### PR TITLE
refactor(settings-store): extract runtime install lifecycle

### DIFF
--- a/src/renderer/src/stores/settings-runtime-slice.test.ts
+++ b/src/renderer/src/stores/settings-runtime-slice.test.ts
@@ -1,0 +1,315 @@
+import type { StoreApi } from 'zustand'
+import { createStore } from 'zustand/vanilla'
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+import type {
+  ClaudeInstallEvent,
+  ClaudeInstallResult,
+  Preflight,
+  SettingsSnapshot
+} from '../../../shared/settings'
+import {
+  createRuntimeSetupSlice,
+  type RuntimeSetupSlice,
+  selectAnyInstalling
+} from './settings-runtime-slice'
+
+type RuntimeCommands = Pick<
+  Window['api']['settings'],
+  | 'getSettings'
+  | 'installClaude'
+  | 'installOpencode'
+  | 'installCodex'
+  | 'uninstallClaude'
+  | 'uninstallOpencode'
+  | 'uninstallCodex'
+  | 'onInstallLog'
+>
+
+type RuntimeCommandMocks = {
+  [Command in keyof RuntimeCommands]: Mock<RuntimeCommands[Command]>
+}
+
+type TestStore = RuntimeSetupSlice & {
+  refreshPreflight: () => Promise<Preflight>
+}
+
+const snapshot = (): SettingsSnapshot => ({
+  claude: {},
+  activeProviderId: undefined,
+  providers: [],
+  agentFrameworkId: 'claude-code',
+  agentFrameworks: [],
+  opencode: {},
+  codex: {},
+  claudeManaged: false,
+  opencodeManaged: false,
+  codexManaged: false,
+  reasoningEffort: 'default',
+  notificationsEnabled: true,
+  conversationSkillImportEnabled: true,
+  appIconVariant: 'light'
+})
+
+const preflight = (): Preflight => ({
+  claudeReady: false,
+  opencodeReady: false,
+  codexReady: false,
+  agentFrameworkId: 'claude-code',
+  agentReady: false,
+  activeProviderReady: false
+})
+
+const deferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} => {
+  let resolve: (value: T) => void = () => undefined
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+const createCommands = (): RuntimeCommandMocks => ({
+  getSettings: vi.fn().mockResolvedValue(snapshot()),
+  installClaude: vi.fn().mockResolvedValue({ installId: 'claude-1', ok: true }),
+  installOpencode: vi.fn().mockResolvedValue({ installId: 'opencode-1', ok: true }),
+  installCodex: vi.fn().mockResolvedValue({ installId: 'codex-1', ok: true }),
+  uninstallClaude: vi.fn().mockResolvedValue(snapshot()),
+  uninstallOpencode: vi.fn().mockResolvedValue(snapshot()),
+  uninstallCodex: vi.fn().mockResolvedValue(snapshot()),
+  onInstallLog: vi.fn().mockReturnValue(vi.fn())
+})
+
+describe('runtime setup slice: install lifecycle', () => {
+  let commands: ReturnType<typeof createCommands>
+  let refreshPreflight: Mock<() => Promise<Preflight>>
+  let reconcileSnapshot: Mock<(snapshot: SettingsSnapshot) => void>
+  let store: StoreApi<TestStore>
+
+  beforeEach(() => {
+    commands = createCommands()
+    refreshPreflight = vi.fn<() => Promise<Preflight>>().mockResolvedValue(preflight())
+    reconcileSnapshot = vi.fn<(snapshot: SettingsSnapshot) => void>()
+    store = createStore<TestStore>((set, get) => ({
+      refreshPreflight,
+      ...createRuntimeSetupSlice({
+        set,
+        get,
+        commands: commands as RuntimeCommands,
+        reconcileSnapshot
+      })
+    }))
+  })
+
+  it('subscribes before invoking and attributes the shared event stream to one runtime', async () => {
+    const calls: string[] = []
+    const install = deferred<ClaudeInstallResult>()
+    const unsubscribe = vi.fn(() => calls.push('unsubscribe'))
+    let emit: (event: ClaudeInstallEvent) => void = () => undefined
+
+    commands.onInstallLog.mockImplementation((listener) => {
+      calls.push('subscribe')
+      emit = listener
+      return unsubscribe
+    })
+    commands.installCodex.mockImplementation(() => {
+      calls.push('invoke')
+      return install.promise
+    })
+
+    const pending = store.getState().installCodex()
+    expect(calls).toEqual(['subscribe', 'invoke'])
+
+    emit({ kind: 'progress', installId: 'codex-1', phase: 'installing' })
+    emit({ kind: 'log', installId: 'codex-1', stream: 'stdout', chunk: 'downloaded\n' })
+
+    expect(store.getState().installStates.codex).toMatchObject({
+      isInstalling: true,
+      installLogs: ['downloaded\n'],
+      installProgress: { kind: 'progress', installId: 'codex-1', phase: 'installing' }
+    })
+    expect(store.getState().installStates.opencode.installLogs).toEqual([])
+    expect(store.getState().installStates['claude-code'].installProgress).toBeNull()
+
+    install.resolve({ installId: 'codex-1', ok: true })
+    await pending
+
+    expect(commands.onInstallLog).toHaveBeenCalledOnce()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(reconcileSnapshot).toHaveBeenCalledWith(snapshot())
+    expect(refreshPreflight).toHaveBeenCalledOnce()
+    expect(store.getState().installStates.codex).toMatchObject({
+      isInstalling: false,
+      installProgress: null,
+      installError: undefined
+    })
+  })
+
+  it('keeps the global guard while logs are cleared and silently refuses a second install', async () => {
+    const install = deferred<ClaudeInstallResult>()
+    commands.installClaude.mockReturnValue(install.promise)
+
+    const first = store.getState().installClaude('managed')
+    expect(selectAnyInstalling(store.getState())).toBe(true)
+
+    store.setState((state) => ({
+      installStates: {
+        ...state.installStates,
+        'claude-code': {
+          ...state.installStates['claude-code'],
+          installLogs: ['line'],
+          installError: 'stale'
+        },
+        opencode: { ...state.installStates.opencode, installLogs: ['other line'] },
+        codex: { ...state.installStates.codex, installError: 'other stale error' }
+      }
+    }))
+    store.getState().clearInstallLogs()
+
+    const blocked = await store.getState().installCodex()
+    expect(blocked).toEqual({
+      installId: '',
+      ok: false,
+      error: 'Another install is already in progress.'
+    })
+    expect(commands.installCodex).not.toHaveBeenCalled()
+    expect(commands.onInstallLog).toHaveBeenCalledOnce()
+    expect(store.getState().installStates['claude-code']).toMatchObject({
+      isInstalling: true,
+      installLogs: [],
+      installProgress: null,
+      installError: undefined
+    })
+    expect(store.getState().installStates.codex.installError).toBeUndefined()
+    expect(store.getState().installStates.opencode.installLogs).toEqual([])
+
+    install.resolve({ installId: 'claude-1', ok: true })
+    await first
+  })
+
+  it('records an invoked error, unsubscribes, and rethrows it', async () => {
+    const failure = new Error('installer unavailable')
+    const unsubscribe = vi.fn()
+    commands.onInstallLog.mockReturnValue(unsubscribe)
+    commands.installOpencode.mockRejectedValue(failure)
+
+    await expect(store.getState().installOpencode()).rejects.toBe(failure)
+
+    expect(commands.getSettings).not.toHaveBeenCalled()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(store.getState().installStates.opencode).toMatchObject({
+      isInstalling: false,
+      installProgress: null,
+      installError: 'installer unavailable'
+    })
+  })
+
+  it('settles a non-ok result with its own error and still performs best-effort reconciliation', async () => {
+    commands.installCodex.mockResolvedValue({ installId: 'codex-1', ok: false })
+
+    await expect(store.getState().installCodex()).resolves.toEqual({
+      installId: 'codex-1',
+      ok: false
+    })
+
+    expect(store.getState().installStates.codex).toMatchObject({
+      isInstalling: false,
+      installError: 'Install failed.'
+    })
+    expect(reconcileSnapshot).toHaveBeenCalledOnce()
+    expect(refreshPreflight).toHaveBeenCalledOnce()
+  })
+
+  it.each(['snapshot', 'preflight'] as const)(
+    'does not relabel a successful install when %s reconciliation fails',
+    async (failurePoint) => {
+      if (failurePoint === 'snapshot') {
+        commands.getSettings.mockRejectedValue(new Error('snapshot unavailable'))
+      } else {
+        refreshPreflight.mockRejectedValue(new Error('preflight unavailable'))
+      }
+
+      await expect(store.getState().installCodex()).resolves.toEqual({
+        installId: 'codex-1',
+        ok: true
+      })
+
+      expect(store.getState().installStates.codex).toMatchObject({
+        isInstalling: false,
+        installProgress: null,
+        installError: undefined
+      })
+      expect(commands.onInstallLog).toHaveBeenCalledOnce()
+      expect(commands.onInstallLog.mock.results[0]?.value).toHaveBeenCalledOnce()
+    }
+  )
+})
+
+describe('runtime setup slice: uninstall lifecycle', () => {
+  it.each([
+    ['uninstallClaude', 'uninstallClaude'],
+    ['uninstallOpencode', 'uninstallOpencode'],
+    ['uninstallCodex', 'uninstallCodex']
+  ] as const)('reconciles and refreshes after %s', async (action, command) => {
+    const commands = createCommands()
+    const refreshPreflight = vi.fn().mockResolvedValue(preflight())
+    const reconcileSnapshot = vi.fn()
+    const store = createStore<TestStore>((set, get) => ({
+      refreshPreflight,
+      ...createRuntimeSetupSlice({
+        set,
+        get,
+        commands: commands as RuntimeCommands,
+        reconcileSnapshot
+      })
+    }))
+
+    await store.getState()[action]()
+
+    expect(commands[command]).toHaveBeenCalledOnce()
+    expect(reconcileSnapshot).toHaveBeenCalledWith(snapshot())
+    expect(refreshPreflight).toHaveBeenCalledOnce()
+  })
+
+  it('propagates an uninstall error without reconciling stale state', async () => {
+    const commands = createCommands()
+    const failure = new Error('uninstall rejected')
+    commands.uninstallCodex.mockRejectedValue(failure)
+    const refreshPreflight = vi.fn().mockResolvedValue(preflight())
+    const reconcileSnapshot = vi.fn()
+    const store = createStore<TestStore>((set, get) => ({
+      refreshPreflight,
+      ...createRuntimeSetupSlice({
+        set,
+        get,
+        commands: commands as RuntimeCommands,
+        reconcileSnapshot
+      })
+    }))
+
+    await expect(store.getState().uninstallCodex()).rejects.toBe(failure)
+    expect(reconcileSnapshot).not.toHaveBeenCalled()
+    expect(refreshPreflight).not.toHaveBeenCalled()
+  })
+
+  it('propagates a post-uninstall preflight failure after applying the returned snapshot', async () => {
+    const commands = createCommands()
+    const failure = new Error('preflight unavailable')
+    const refreshPreflight = vi.fn<() => Promise<Preflight>>().mockRejectedValue(failure)
+    const reconcileSnapshot = vi.fn<(snapshot: SettingsSnapshot) => void>()
+    const store = createStore<TestStore>((set, get) => ({
+      refreshPreflight,
+      ...createRuntimeSetupSlice({
+        set,
+        get,
+        commands: commands as RuntimeCommands,
+        reconcileSnapshot
+      })
+    }))
+
+    await expect(store.getState().uninstallClaude()).rejects.toBe(failure)
+    expect(reconcileSnapshot).toHaveBeenCalledWith(snapshot())
+  })
+})

--- a/src/renderer/src/stores/settings-runtime-slice.ts
+++ b/src/renderer/src/stores/settings-runtime-slice.ts
@@ -1,0 +1,216 @@
+import type { StoreApi } from 'zustand'
+
+import type {
+  AgentFrameworkId,
+  ClaudeInstallProgressEvent,
+  ClaudeInstallResult,
+  ClaudeInstallSource,
+  CodexInstallSource,
+  ManagedClaudeRegistry,
+  Preflight,
+  SettingsSnapshot
+} from '../../../shared/settings'
+
+export type RuntimeInstallState = {
+  isInstalling: boolean
+  installLogs: string[]
+  installProgress: ClaudeInstallProgressEvent | null
+  installError: string | undefined
+}
+
+export type RuntimeSetupState = {
+  installStates: Record<AgentFrameworkId, RuntimeInstallState>
+}
+
+export type RuntimeSetupActions = {
+  installClaude: (
+    source: ClaudeInstallSource,
+    managedRegistry?: ManagedClaudeRegistry
+  ) => Promise<ClaudeInstallResult>
+  installOpencode: (source?: ClaudeInstallSource) => Promise<ClaudeInstallResult>
+  installCodex: (source?: CodexInstallSource) => Promise<ClaudeInstallResult>
+  uninstallClaude: () => Promise<void>
+  uninstallOpencode: () => Promise<void>
+  uninstallCodex: () => Promise<void>
+  clearInstallLogs: (runtime?: AgentFrameworkId) => void
+}
+
+export type RuntimeSetupSlice = RuntimeSetupState & RuntimeSetupActions
+
+type RuntimeSetupHost = RuntimeSetupState & {
+  refreshPreflight: () => Promise<Preflight>
+}
+
+type RuntimeSetupCommands = Pick<
+  Window['api']['settings'],
+  | 'getSettings'
+  | 'installClaude'
+  | 'installOpencode'
+  | 'installCodex'
+  | 'uninstallClaude'
+  | 'uninstallOpencode'
+  | 'uninstallCodex'
+  | 'onInstallLog'
+>
+
+type RuntimeSetupSliceOptions<Store extends RuntimeSetupHost> = {
+  set: StoreApi<Store>['setState']
+  get: StoreApi<Store>['getState']
+  commands: RuntimeSetupCommands
+  reconcileSnapshot: (snapshot: SettingsSnapshot) => void
+}
+
+const createInitialRuntimeInstallState = (): RuntimeInstallState => ({
+  isInstalling: false,
+  installLogs: [],
+  installProgress: null,
+  installError: undefined
+})
+
+export const createInitialRuntimeSetupState = (): RuntimeSetupState => ({
+  installStates: {
+    'claude-code': createInitialRuntimeInstallState(),
+    opencode: createInitialRuntimeInstallState(),
+    codex: createInitialRuntimeInstallState()
+  }
+})
+
+export const selectAnyInstalling = (state: RuntimeSetupState): boolean =>
+  state.installStates['claude-code'].isInstalling ||
+  state.installStates.opencode.isInstalling ||
+  state.installStates.codex.isInstalling
+
+const updateInstallStates = <Store extends RuntimeSetupHost>(
+  set: StoreApi<Store>['setState'],
+  update: (installStates: RuntimeSetupState['installStates']) => RuntimeSetupState['installStates']
+): void => set((state) => ({ installStates: update(state.installStates) }) as Partial<Store>)
+
+const patchInstallState = <Store extends RuntimeSetupHost>(
+  set: StoreApi<Store>['setState'],
+  runtime: AgentFrameworkId,
+  patch: Partial<RuntimeInstallState>
+): void =>
+  updateInstallStates(set, (installStates) => ({
+    ...installStates,
+    [runtime]: { ...installStates[runtime], ...patch }
+  }))
+
+const runRuntimeInstall = async <Store extends RuntimeSetupHost>(
+  set: StoreApi<Store>['setState'],
+  get: StoreApi<Store>['getState'],
+  commands: RuntimeSetupCommands,
+  reconcileSnapshot: (snapshot: SettingsSnapshot) => void,
+  runtime: AgentFrameworkId,
+  invoke: () => Promise<ClaudeInstallResult>
+): Promise<ClaudeInstallResult> => {
+  // Install events are broadcast without a runtime id. The synchronous global guard guarantees that
+  // exactly one subscription is live, so every event can be attributed to this runtime.
+  if (selectAnyInstalling(get())) {
+    return { installId: '', ok: false, error: 'Another install is already in progress.' }
+  }
+
+  patchInstallState(set, runtime, {
+    isInstalling: true,
+    installLogs: [],
+    installProgress: null,
+    installError: undefined
+  })
+
+  const unsubscribe = commands.onInstallLog((event) => {
+    if (event.kind === 'progress') {
+      patchInstallState(set, runtime, { installProgress: event })
+      return
+    }
+
+    updateInstallStates(set, (installStates) => ({
+      ...installStates,
+      [runtime]: {
+        ...installStates[runtime],
+        installLogs: [...installStates[runtime].installLogs, event.chunk]
+      }
+    }))
+  })
+
+  try {
+    let result: ClaudeInstallResult
+    try {
+      result = await invoke()
+    } catch (error) {
+      patchInstallState(set, runtime, {
+        installError: error instanceof Error ? error.message : 'Install failed.'
+      })
+      throw error
+    }
+
+    patchInstallState(set, runtime, {
+      installError: result.ok ? undefined : (result.error ?? 'Install failed.')
+    })
+
+    // Snapshot/preflight reconciliation is best-effort and must not relabel the install outcome.
+    try {
+      reconcileSnapshot(await commands.getSettings())
+      await get().refreshPreflight()
+    } catch {
+      // The next detection or refresh repairs a briefly stale renderer projection.
+    }
+
+    return result
+  } finally {
+    unsubscribe()
+    patchInstallState(set, runtime, { isInstalling: false, installProgress: null })
+  }
+}
+
+export const createRuntimeSetupSlice = <Store extends RuntimeSetupHost>({
+  set,
+  get,
+  commands,
+  reconcileSnapshot
+}: RuntimeSetupSliceOptions<Store>): RuntimeSetupSlice => ({
+  ...createInitialRuntimeSetupState(),
+
+  installClaude: (source, managedRegistry) =>
+    runRuntimeInstall(set, get, commands, reconcileSnapshot, 'claude-code', () =>
+      commands.installClaude({ source, managedRegistry })
+    ),
+  installOpencode: (source = 'managed') =>
+    runRuntimeInstall(set, get, commands, reconcileSnapshot, 'opencode', () =>
+      commands.installOpencode({ source })
+    ),
+  installCodex: (source = 'managed') =>
+    runRuntimeInstall(set, get, commands, reconcileSnapshot, 'codex', () =>
+      commands.installCodex({ source })
+    ),
+
+  uninstallClaude: async () => {
+    reconcileSnapshot(await commands.uninstallClaude())
+    await get().refreshPreflight()
+  },
+  uninstallOpencode: async () => {
+    reconcileSnapshot(await commands.uninstallOpencode())
+    await get().refreshPreflight()
+  },
+  uninstallCodex: async () => {
+    reconcileSnapshot(await commands.uninstallCodex())
+    await get().refreshPreflight()
+  },
+
+  clearInstallLogs: (runtime) =>
+    updateInstallStates(set, (current) => {
+      const runtimes: AgentFrameworkId[] = runtime
+        ? [runtime]
+        : ['claude-code', 'opencode', 'codex']
+      const installStates = { ...current }
+
+      for (const id of runtimes) {
+        installStates[id] = {
+          ...installStates[id],
+          installLogs: [],
+          installProgress: null,
+          installError: undefined
+        }
+      }
+
+      return installStates
+    })
+})

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -23,17 +23,19 @@ import {
   type SettingsWriteCoordinator,
   type SettingsWriteKey
 } from './settings-write-coordinator'
+import {
+  createInitialRuntimeSetupState,
+  createRuntimeSetupSlice,
+  type RuntimeSetupActions,
+  type RuntimeSetupState
+} from './settings-runtime-slice'
+export { selectAnyInstalling } from './settings-runtime-slice'
 import type {
   ClaudeDetectResult,
   ClaudeInfo,
-  ClaudeInstallProgressEvent,
-  ClaudeInstallResult,
-  ClaudeInstallSource,
   ClaudeSubscriptionProviderId,
   CodexInfo,
-  CodexInstallSource,
   EnvironmentCheckResult,
-  ManagedClaudeRegistry,
   Preflight,
   AgentFrameworkId,
   AgentFrameworkView,
@@ -78,19 +80,7 @@ type SaveProviderResult = {
   validation: ValidateProviderResult
 }
 
-// One runtime's install state. Each framework (Claude / OpenCode / Codex) owns an isolated copy, so an
-// install event is attributed to its runtime and rendered by that card only — starting a Codex install
-// never drives the OpenCode or Claude card (issue #278).
-type RuntimeInstallState = {
-  isInstalling: boolean
-  installLogs: string[]
-  // Latest progress tick driving this runtime's install bar; null when no install is active for it.
-  installProgress: ClaudeInstallProgressEvent | null
-  // Error message from this runtime's last install attempt; drives auto-expansion of its log pane.
-  installError: string | undefined
-}
-
-type SettingsStoreData = {
+type SettingsStoreData = RuntimeSetupState & {
   isLoaded: boolean
   isLoading: boolean
   loadError: string | undefined
@@ -144,9 +134,6 @@ type SettingsStoreData = {
   isDetectingClaude: boolean
   isDetectingOpencode: boolean
   isDetectingCodex: boolean
-  // Per-runtime install state, keyed by framework id. Each runtime's install writes only to its own
-  // slice so its progress/logs/error render in its own card alone — never mirrored onto the others.
-  installStates: Record<AgentFrameworkId, RuntimeInstallState>
   // Whether the settings dialog is open (rendered at the app root, over Home/Workspace).
   isSettingsOpen: boolean
   // Panel requested by an external entry point; Settings consumes it after seeding navigation.
@@ -170,7 +157,7 @@ type SettingsStoreData = {
   appIconVariant: AppIconVariant
 }
 
-type SettingsStore = SettingsStoreData & {
+type SettingsStoreCore = SettingsStoreData & {
   load: (options?: { force?: boolean }) => Promise<boolean>
   refreshPreflight: () => Promise<Preflight>
   checkEnvironment: (options?: { force?: boolean }) => Promise<EnvironmentCheckResult | undefined>
@@ -178,20 +165,6 @@ type SettingsStore = SettingsStoreData & {
   // Detects the opencode executable and refreshes its status card.
   detectOpencode: () => Promise<void>
   detectCodex: () => Promise<void>
-  installClaude: (
-    source: ClaudeInstallSource,
-    managedRegistry?: ManagedClaudeRegistry
-  ) => Promise<ClaudeInstallResult>
-  // App-managed OpenCode install; writes only to the OpenCode install slice.
-  installOpencode: (source?: ClaudeInstallSource) => Promise<ClaudeInstallResult>
-  installCodex: (source?: CodexInstallSource) => Promise<ClaudeInstallResult>
-  // Removes the app-managed runtime for a framework (guarded main-side to app-managed installs) and
-  // applies the refreshed snapshot; main reconnects the agent so the next prompt uses the new state.
-  uninstallClaude: () => Promise<void>
-  uninstallOpencode: () => Promise<void>
-  uninstallCodex: () => Promise<void>
-  // Clears the transient logs/progress/error for one runtime (or every runtime when omitted).
-  clearInstallLogs: (runtime?: AgentFrameworkId) => void
   // Persists the draft (create/update) without testing it, returning the affected provider id. The
   // Settings page uses this to return to the list immediately, then tests in the background.
   persistProvider: (request: UpsertProviderRequest) => Promise<string>
@@ -323,19 +296,7 @@ type SettingsStore = SettingsStoreData & {
   setPackageMirror: (mirror: PackageMirror) => Promise<void>
 }
 
-const createInitialRuntimeInstallState = (): RuntimeInstallState => ({
-  isInstalling: false,
-  installLogs: [],
-  installProgress: null,
-  installError: undefined
-})
-
-// True while any runtime install is running. Only one install runs at a time, so the settings/onboarding
-// pages use this to lock the framework selector and every card's uninstall button during an install.
-export const selectAnyInstalling = (state: SettingsStoreData): boolean =>
-  state.installStates['claude-code'].isInstalling ||
-  state.installStates.opencode.isInstalling ||
-  state.installStates.codex.isInstalling
+type SettingsStore = SettingsStoreCore & RuntimeSetupActions
 
 const createInitialPreflight = (): Preflight => ({
   claudeReady: false,
@@ -347,6 +308,7 @@ const createInitialPreflight = (): Preflight => ({
 })
 
 export const createInitialSettingsState = (): SettingsStoreData => ({
+  ...createInitialRuntimeSetupState(),
   isLoaded: false,
   isLoading: false,
   loadError: undefined,
@@ -381,11 +343,6 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   isDetectingClaude: false,
   isDetectingOpencode: false,
   isDetectingCodex: false,
-  installStates: {
-    'claude-code': createInitialRuntimeInstallState(),
-    opencode: createInitialRuntimeInstallState(),
-    codex: createInitialRuntimeInstallState()
-  },
   isSettingsOpen: false,
   pendingSettingsPanel: undefined,
   pendingSkillId: undefined,
@@ -423,106 +380,6 @@ const applySnapshot = (snapshot: SettingsSnapshot): Partial<SettingsStoreData> =
   opencodeManaged: snapshot.opencodeManaged,
   codexManaged: snapshot.codexManaged ?? false
 })
-
-// Merges a patch into one runtime's install slice, leaving the other runtimes' slices untouched. This
-// isolation is the fix for issue #278: an install event only ever mutates the runtime it belongs to.
-const patchInstallState = (
-  set: StoreApi<SettingsStore>['setState'],
-  runtime: AgentFrameworkId,
-  patch: Partial<RuntimeInstallState>
-): void =>
-  set((state) => ({
-    installStates: {
-      ...state.installStates,
-      [runtime]: { ...state.installStates[runtime], ...patch }
-    }
-  }))
-
-// Shared install driver for all three runtimes. Streams the (single-channel) install events into the
-// given runtime's slice only, then reconciles the snapshot/preflight and records that runtime's error.
-// `onInstallLog` is a broadcast channel, so correct attribution requires exactly one live subscription:
-// the guard below enforces the single-install invariant in the store itself (not just via the UI lock),
-// so even a stray caller or a mid-switch UI race can't start a second install that cross-contaminates
-// another runtime's slice (issue #278). Every event the lone subscription sees therefore belongs to
-// `runtime`.
-const runRuntimeInstall = async (
-  set: StoreApi<SettingsStore>['setState'],
-  get: StoreApi<SettingsStore>['getState'],
-  runtime: AgentFrameworkId,
-  invoke: () => Promise<ClaudeInstallResult>
-): Promise<ClaudeInstallResult> => {
-  // Refuse to start a second concurrent install. The check + set is synchronous (no await between them),
-  // so it's atomic against the single-threaded event loop: two callers can't both pass the guard.
-  //
-  // This is a safety backstop, not a user-facing path: the UI already disables every Install button while
-  // any runtime installs (selectAnyInstalling + the cards' busy/installBusy props), so a user cannot reach
-  // this branch. It exists only for a stray/programmatic caller or a mid-switch race. The rejection is
-  // therefore intentionally silent — it writes to no slice (writing an error here would surface a phantom
-  // failure on a runtime the user never touched, the inverse of the #278 bug) and callers ignore the
-  // result. If a real UI trigger for this path is ever added, surface the error on the target slice then.
-  if (selectAnyInstalling(get())) {
-    return { installId: '', ok: false, error: 'Another install is already in progress.' }
-  }
-
-  patchInstallState(set, runtime, {
-    isInstalling: true,
-    installLogs: [],
-    installProgress: null,
-    installError: undefined
-  })
-
-  const unsubscribe = window.api.settings.onInstallLog((event) => {
-    if (event.kind === 'progress') {
-      patchInstallState(set, runtime, { installProgress: event })
-    } else {
-      set((state) => ({
-        installStates: {
-          ...state.installStates,
-          [runtime]: {
-            ...state.installStates[runtime],
-            installLogs: [...state.installStates[runtime].installLogs, event.chunk]
-          }
-        }
-      }))
-    }
-  })
-
-  try {
-    // The install itself and the post-install snapshot reconcile are distinct concerns. Only an install
-    // failure (invoke throwing, or a non-ok result) may set installError; a reconcile that throws AFTER
-    // a successful install must not relabel it as failed (that would be a phantom failure on a runtime
-    // that actually installed).
-    let result: ClaudeInstallResult
-    try {
-      result = await invoke()
-    } catch (error) {
-      patchInstallState(set, runtime, {
-        installError: error instanceof Error ? error.message : 'Install failed.'
-      })
-      throw error
-    }
-
-    // Record the outcome from the install result itself, before the (best-effort) reconcile below.
-    patchInstallState(set, runtime, {
-      installError: result.ok ? undefined : (result.error ?? 'Install failed.')
-    })
-
-    // A successful install re-detected/persisted the runtime in main; reload so the card reflects it.
-    // Best-effort: a transient snapshot/preflight error leaves the card briefly stale (corrected on the
-    // next detect/refresh), which is preferable to overwriting a good install result with a failure.
-    try {
-      set(applySnapshot(await window.api.settings.getSettings()))
-      await get().refreshPreflight()
-    } catch {
-      // Intentionally swallowed — the install succeeded; installError already reflects `result`.
-    }
-
-    return result
-  } finally {
-    unsubscribe()
-    patchInstallState(set, runtime, { isInstalling: false, installProgress: null })
-  }
-}
 
 // Stable fallback reference so the selector returns the same array identity across renders
 // (a fresh literal would make useSettingsStore re-render every tick and loop).
@@ -626,6 +483,22 @@ const createSettingsStoreState = (
   writeCoordinator: SettingsWriteCoordinator
 ): SettingsStore => ({
   ...createInitialSettingsState(),
+  ...createRuntimeSetupSlice({
+    set,
+    get,
+    // Keep browser globals lazy so importing the store remains safe in node-based renderer tests.
+    commands: {
+      getSettings: () => window.api.settings.getSettings(),
+      installClaude: (request) => window.api.settings.installClaude(request),
+      installOpencode: (request) => window.api.settings.installOpencode(request),
+      installCodex: (request) => window.api.settings.installCodex(request),
+      uninstallClaude: () => window.api.settings.uninstallClaude(),
+      uninstallOpencode: () => window.api.settings.uninstallOpencode(),
+      uninstallCodex: () => window.api.settings.uninstallCodex(),
+      onInstallLog: (listener) => window.api.settings.onInstallLog(listener)
+    },
+    reconcileSnapshot: (snapshot) => set(applySnapshot(snapshot))
+  }),
 
   // Loads settings, preflight, and encryption availability in one startup pass.
   load: (options) => {
@@ -785,59 +658,6 @@ const createSettingsStoreState = (
       set({ isDetectingClaude: false })
     }
   },
-
-  // Runs a one-click Claude install, streaming events into the Claude slice only, then refreshes
-  // settings/preflight. Log and progress share one channel, routed by `kind` into this runtime's card.
-  installClaude: async (source, managedRegistry) =>
-    runRuntimeInstall(set, get, 'claude-code', () =>
-      window.api.settings.installClaude({ source, managedRegistry })
-    ),
-
-  // App-managed OpenCode install; streams into the OpenCode slice only.
-  installOpencode: async (source = 'managed') =>
-    runRuntimeInstall(set, get, 'opencode', () => window.api.settings.installOpencode({ source })),
-
-  // App-managed / npm Codex install; streams into the Codex slice only.
-  installCodex: async (source = 'managed') =>
-    runRuntimeInstall(set, get, 'codex', () => window.api.settings.installCodex({ source })),
-
-  // Removes the app-managed Claude runtime; main deletes it, re-detects, and may auto-switch the active
-  // framework. Applies the refreshed snapshot and re-evaluates the readiness gate.
-  uninstallClaude: async () => {
-    set(applySnapshot(await window.api.settings.uninstallClaude()))
-    await get().refreshPreflight()
-  },
-
-  // Removes the app-managed OpenCode runtime, mirroring uninstallClaude.
-  uninstallOpencode: async () => {
-    set(applySnapshot(await window.api.settings.uninstallOpencode()))
-    await get().refreshPreflight()
-  },
-
-  uninstallCodex: async () => {
-    set(applySnapshot(await window.api.settings.uninstallCodex()))
-    await get().refreshPreflight()
-  },
-
-  clearInstallLogs: (runtime) =>
-    set((state) => {
-      const runtimes: AgentFrameworkId[] = runtime
-        ? [runtime]
-        : ['claude-code', 'opencode', 'codex']
-      const installStates = { ...state.installStates }
-      // Clear only the transient display fields; preserve isInstalling. Resetting the whole slice would
-      // flip isInstalling to false mid-install, dropping the single-install lock (selectAnyInstalling)
-      // and letting a second install start — the exact invariant this store guards.
-      for (const id of runtimes) {
-        installStates[id] = {
-          ...installStates[id],
-          installLogs: [],
-          installProgress: null,
-          installError: undefined
-        }
-      }
-      return { installStates }
-    }),
 
   // Persists a provider draft (create/update) and refreshes derived state, without testing it.
   persistProvider: async (request) => {


### PR DESCRIPTION
## Problem

`settings-store.ts` still owned runtime installation arbitration, event attribution, transient progress/log/error state, reconciliation, and uninstall settlement alongside unrelated Settings responsibilities. That kept the compatibility store broad and made the single-subscription invariant difficult to review in isolation.

## Proposed change

- Add one internal runtime setup slice owner for the global install guard, captured-runtime event subscription, per-runtime progress/log/error state, install/uninstall settlement, best-effort snapshot/preflight reconciliation, and log clearing.
- Compose that slice into the existing `useSettingsStore`; keep the same state fields, action names, selector export, and Zustand instance.
- Inject the existing renderer Settings commands through lazy wrappers so importing the store remains safe in node-based renderer tests.
- Reduce `settings-store.ts` from 1,436 to 1,256 physical lines. Production raw is 450 lines (`27 additions + 207 deletions` in the store and `216 additions` in the owner), below the 600 target and 660 ceiling.

```mermaid
flowchart LR
  UI["Settings and onboarding consumers"] --> Store["useSettingsStore compatibility interface"]
  Store --> Runtime["runtime setup slice owner"]
  Runtime --> Commands["existing Settings renderer commands"]
  Commands --> Surfaces["Electron / local Web adapters"]
```

## Scope and non-goals

In scope: install guard and subscription ownership, event attribution, per-runtime transient state, install/uninstall completion semantics, reconciliation, and `clearInstallLogs`.

Out of scope for this R2a PR: preflight ownership, environment inspection, same-framework de-duplication, ABA generation fencing, Claude/OpenCode/Codex discovery, provider/auth, preferences, navigation, Skills, Connectors, UI changes, or a second store. Those runtime discovery concerns remain in `settings-store.ts` for R2b.

## Compatibility

- No public Settings actions, state fields, selector names, IPC payloads, preload contracts, generated Web maps, persisted data, or user interactions change.
- Install events still have no runtime id; the synchronous global guard permits exactly one live subscription, created before invoke and removed in `finally`, so captured-runtime attribution is unchanged.
- Invoke throws still set the target error and propagate; non-ok results retain their result error; snapshot/preflight failures remain best-effort for installs; uninstall failures continue to propagate; clearing logs never clears `isInstalling`.
- Electron and local Web retain their current install/uninstall capability. Remote Web continues to use its existing rejecting local-command stubs. CLI/Task do not instantiate this renderer store. Specialist, Permission, and Compute behavior and capability asymmetry are untouched.

## Acceptance criteria and validation

All listed checks ran after the last material edit on commit `fba497f9`:

- runtime owner lifecycle semantics -> `npm test -- src/renderer/src/stores/settings-runtime-slice.test.ts` -> 11/11 passed
- public store compatibility and R0 contracts -> `npm test -- src/renderer/src/stores/settings-store.test.ts` -> 88/88 passed
- affected Settings/onboarding consumers -> `npm test -- src/renderer/src/pages/settings/SettingsPage.render.test.tsx src/renderer/src/pages/onboarding/AgentStep.render.test.tsx` -> 83/83 passed
- renderer type safety -> `npm run typecheck:web` -> passed
- changed TypeScript files -> `npx eslint src/renderer/src/stores/settings-store.ts src/renderer/src/stores/settings-runtime-slice.ts src/renderer/src/stores/settings-runtime-slice.test.ts` -> passed
- patch hygiene -> `git diff --check` -> passed
- independent exact-diff review -> Standards 0 findings; Spec 0 findings

Uncovered locally: the full portable suite and platform/E2E lanes were not run; PR Gate remains authoritative for the final impact plan.

## Review focus

- Confirm the guard check and `isInstalling` update remain synchronous, and rejected overlapping installs neither subscribe nor mutate the target slice.
- Confirm every accepted install subscribes before invoking, routes the shared stream only to its captured runtime, and always unsubscribes/settles in `finally`.
- Confirm install reconciliation stays best-effort while uninstall reconciliation errors propagate.
- Confirm R2b discovery/environment state remains outside this PR and the slice does not import the write coordinator.

Merge with squash only after exact-head CI and AI review are green.
