### PR TITLE
fix(e2e): isolate packaged certification state

### DIFF
--- a/e2e/certification/artifact-provenance.spec.ts
+++ b/e2e/certification/artifact-provenance.spec.ts
@@ -2,6 +2,8 @@ import { expect } from '@playwright/test'
 import { test } from '../fixtures/electron-app'
 import { createProject, sendPrompt } from './helpers'
 
+test.setTimeout(180_000)
+
 test('retains an Artifact Version producer across Electron relaunch', async ({ app }) => {
   let page = await app.completeOnboarding()
   page = await app.configureFakeAgent()
@@ -9,7 +11,8 @@ test('retains an Artifact Version producer across Electron relaunch', async ({ a
   await sendPrompt(
     page,
     'Create a provenance artifact.',
-    'Artifact provenance verified for session'
+    'Artifact provenance verified for session',
+    90_000
   )
 
   const receipt = await page.getByText(/^Artifact provenance verified for session /).innerText()

--- a/e2e/certification/helpers.ts
+++ b/e2e/certification/helpers.ts
@@ -2,29 +2,58 @@ import { expect } from '@playwright/test'
 import type { Page } from 'playwright'
 
 const createProject = async (page: Page, name: string): Promise<string> => {
+  const existingProjectIds = await page.evaluate(async () => {
+    const bridge = globalThis as unknown as {
+      api: { projects: { list: () => Promise<Array<{ id: string }>> } }
+    }
+    return (await bridge.api.projects.list()).map((project) => project.id)
+  })
   await page.getByRole('button', { name: 'New project' }).click()
   const dialog = page.getByRole('dialog', { name: 'New project' })
   await dialog.getByLabel('Name').fill(name)
   await dialog.getByRole('button', { name: 'Create project' }).click()
   await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
 
-  return page.evaluate(async (projectName) => {
-    const bridge = globalThis as unknown as {
-      api: { projects: { list: () => Promise<Array<{ id: string; name: string }>> } }
-    }
-    const project = (await bridge.api.projects.list()).find((item) => item.name === projectName)
-    if (!project) throw new Error(`Project was not persisted: ${projectName}`)
-    return project.id
-  }, name)
+  let projectId: string | undefined
+  await expect
+    .poll(
+      async () => {
+        projectId = await page.evaluate(async (existingIds) => {
+          const bridge = globalThis as unknown as {
+            api: { projects: { list: () => Promise<Array<{ id: string }>> } }
+          }
+          return (await bridge.api.projects.list()).find(
+            (project) => !existingIds.includes(project.id)
+          )?.id
+        }, existingProjectIds)
+        return projectId
+      },
+      { timeout: 30_000 }
+    )
+    .toEqual(expect.any(String))
+  return projectId!
 }
 
-const sendPrompt = async (page: Page, prompt: string, reply: string): Promise<void> => {
+const sendPrompt = async (
+  page: Page,
+  prompt: string,
+  reply: string,
+  timeout = 30_000
+): Promise<void> => {
   await page.getByRole('textbox', { name: 'Ask anything' }).fill(prompt)
   await page.getByRole('button', { name: 'Send message' }).click()
   const expectedReply = page.getByText(reply, { exact: false })
   const fixtureFailure = page.getByText(/^E2E fixture failure:/)
-  await expect(expectedReply.or(fixtureFailure)).toBeVisible({ timeout: 30_000 })
+  await expect(expectedReply.or(fixtureFailure)).toBeVisible({ timeout })
   if (await fixtureFailure.isVisible()) throw new Error(await fixtureFailure.innerText())
 }
 
-export { createProject, sendPrompt }
+const openRecentSession = async (page: Page, prompt: string): Promise<void> => {
+  const session = page
+    .getByRole('region', { name: 'Recent sessions' })
+    .getByRole('button', { name: prompt })
+  await expect(session).toBeVisible({ timeout: 60_000 })
+  await session.click()
+}
+
+export { createProject, openRecentSession, sendPrompt }

--- a/e2e/certification/notebook-lifecycle.spec.ts
+++ b/e2e/certification/notebook-lifecycle.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from '../fixtures/electron-app'
-import { createProject, sendPrompt } from './helpers'
+import { createProject, openRecentSession, sendPrompt } from './helpers'
 
 test('runs and shuts down a Notebook session through its packaged MCP boundary', async ({
   app
@@ -11,9 +11,6 @@ test('runs and shuts down a Notebook session through its packaged MCP boundary',
   await sendPrompt(page, 'Verify the notebook lifecycle.', 'Notebook lifecycle verified for')
 
   page = await app.restart()
-  await page
-    .getByRole('region', { name: 'Recent sessions' })
-    .getByRole('button', { name: 'Verify the notebook lifecycle.' })
-    .click()
+  await openRecentSession(page, 'Verify the notebook lifecycle.')
   await expect(page.getByText('Notebook lifecycle verified for', { exact: false })).toBeVisible()
 })

--- a/e2e/certification/provider-bridge.spec.ts
+++ b/e2e/certification/provider-bridge.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from '../fixtures/electron-app'
-import { createProject, sendPrompt } from './helpers'
+import { createProject, openRecentSession, sendPrompt } from './helpers'
 
 test('re-enters a persisted provider route through the real Agent process', async ({ app }) => {
   let page = await app.completeOnboarding()
@@ -13,9 +13,6 @@ test('re-enters a persisted provider route through the real Agent process', asyn
   )
 
   page = await app.restart()
-  await page
-    .getByRole('region', { name: 'Recent sessions' })
-    .getByRole('button', { name: 'Verify the provider bridge.' })
-    .click()
+  await openRecentSession(page, 'Verify the provider bridge.')
   await expect(page.getByText('Provider bridge verified through the Agent process.')).toBeVisible()
 })

--- a/e2e/certification/storage-migration.spec.ts
+++ b/e2e/certification/storage-migration.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from '../fixtures/electron-app'
-import { createProject, sendPrompt } from './helpers'
+import { createProject, openRecentSession, sendPrompt } from './helpers'
 
 test('stages a verified data-root move and recovers on discard', async ({ app }) => {
   let page = await app.completeOnboarding()
@@ -31,9 +31,5 @@ test('stages a verified data-root move and recovers on discard', async ({ app })
   expect(result.discarded.kind).toBe('move')
 
   page = await app.restart()
-  await expect(
-    page
-      .getByRole('region', { name: 'Recent sessions' })
-      .getByRole('button', { name: 'Persist the migration fixture.' })
-  ).toBeVisible()
+  await openRecentSession(page, 'Persist the migration fixture.')
 })

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -64,6 +64,9 @@ const launchEnvironment = (
   }
 
   environment.OPEN_SCIENCE_STORAGE_ROOT = storageRoot
+  if (environment.OPEN_SCIENCE_E2E_EXECUTABLE) {
+    environment.OPEN_SCIENCE_E2E_STORAGE_ROOT = storageRoot
+  }
   if (fakeRemoteItRoot) {
     environment.OPEN_SCIENCE_FAKE_REMOTEIT_STATE = join(storageRoot, 'fake-remoteit-state.json')
     environment.OPEN_SCIENCE_REMOTEIT_BIN = process.execPath
@@ -184,12 +187,17 @@ class ElectronAppHarness implements ElectronApp {
       storageRoot: join(testRoot, 'storage'),
       userDataRoot: join(testRoot, 'electron-profile')
     })
-    await mkdir(harness.roots.storageRoot, { recursive: true })
-    await writeFile(harness.roots.fakeRemoteItState, JSON.stringify({ services: [] }), 'utf8')
-    await writeFakeAgentLauncher(harness.roots.fakeAgentBinRoot)
-    await writeFakeRemoteItCommands(harness.roots.fakeRemoteItRoot)
-    await harness.launch()
-    return harness
+    try {
+      await mkdir(harness.roots.storageRoot, { recursive: true })
+      await writeFile(harness.roots.fakeRemoteItState, JSON.stringify({ services: [] }), 'utf8')
+      await writeFakeAgentLauncher(harness.roots.fakeAgentBinRoot)
+      await writeFakeRemoteItCommands(harness.roots.fakeRemoteItRoot)
+      await harness.launch()
+      return harness
+    } catch (error) {
+      await harness.dispose().catch(() => undefined)
+      throw error
+    }
   }
 
   get page(): Page {

--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -61,13 +61,19 @@ const withMcpClient = async (sessionId, serverName, operation) => {
 const verifyProviderBridge = () => {
   const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT ?? '{}')
   const providers = Object.values(config.provider ?? {})
-  const route = providers.find((provider) => provider?.options?.baseURL)
-  const credential = Object.entries(process.env).find(([name]) =>
-    name.startsWith('OPENCODE_APP_API_KEY')
-  )
-  if (route?.options?.baseURL !== 'http://127.0.0.1:9/v1' || credential?.[1] !== 'e2e-key') {
+  const route = providers.find((provider) => provider?.models?.['e2e-model'])
+  const credentialName = route?.options?.apiKey?.match(/^\{env:([^}]+)\}$/)?.[1]
+  const credential = credentialName ? process.env[credentialName] : undefined
+  if (!route?.options?.baseURL || !credential)
     throw new Error('The persisted provider route did not reach the Agent process.')
-  }
+  const direct = route.options.baseURL === 'http://127.0.0.1:9/v1' && credential === 'e2e-key'
+  const url = new URL(route.options.baseURL)
+  const bridged = url.hostname === '127.0.0.1' && url.pathname === '/v1' && url.port !== '9'
+  if (!direct && !bridged)
+    throw new Error(
+      `The persisted provider route did not reach the Agent process ` +
+        `(base URL: ${route.options.baseURL}, credential: present).`
+    )
   return 'Provider bridge verified through the Agent process.'
 }
 

--- a/e2e/launch-environment.spec.ts
+++ b/e2e/launch-environment.spec.ts
@@ -11,6 +11,17 @@ test('normalizes a Windows-style Path before injecting the fake Agent directory'
   expect(environment.PATH).toBe(`fake-agent-bin${delimiter}system-bin`)
   expect(environment.Path).toBeUndefined()
   expect(environment.ELECTRON_RENDERER_URL).toBeUndefined()
+  expect(environment.OPEN_SCIENCE_E2E_STORAGE_ROOT).toBeUndefined()
+  expect(environment.OPEN_SCIENCE_STORAGE_ROOT).toBe('storage-root')
+})
+
+test('isolates packaged certification storage without changing the process home', () => {
+  const environment = launchEnvironment('storage-root', undefined, {
+    OPEN_SCIENCE_E2E_EXECUTABLE: '/artifacts/Open Science'
+  })
+
+  expect(environment.OPEN_SCIENCE_E2E_STORAGE_ROOT).toBe('storage-root')
+  expect(environment.OPEN_SCIENCE_STORAGE_ROOT).toBe('storage-root')
 })
 
 test('enables the basic password store only for Linux E2E profiles', () => {

--- a/src/main/storage-root.test.ts
+++ b/src/main/storage-root.test.ts
@@ -152,12 +152,21 @@ describe('computeDefaultDataRoot', () => {
 
   afterEach(async () => {
     appMock.isPackaged = false
+    vi.unstubAllEnvs()
     await rm(homeDir, { recursive: true, force: true })
   })
 
   it('defaults to <home>/OpenScience for a fresh config root', () => {
     // resolveConfigRoot() resolves under homeDir but nothing has been created there.
     expect(computeDefaultDataRoot()).toBe(join(homeDir, 'OpenScience'))
+  })
+
+  it('keeps packaged E2E config and data under the disposable certification root', () => {
+    const e2eRoot = join(homeDir, 'certification')
+    vi.stubEnv('OPEN_SCIENCE_E2E_STORAGE_ROOT', e2eRoot)
+
+    expect(resolveConfigRoot()).toBe(e2eRoot)
+    expect(computeDefaultDataRoot()).toBe(join(e2eRoot, 'OpenScience'))
   })
 
   it('stays at the config root when it already has legacy data and no OpenScience subdir', async () => {
@@ -340,6 +349,22 @@ describe('resolveStorageRoot', () => {
 
     expect(resolveStorageRoot()).toBe(normalize('/tmp/open-science-preview/storage'))
     expect(appMock.getPath).not.toHaveBeenCalled()
+  })
+
+  it('uses an absolute disposable E2E root in packaged builds', () => {
+    appMock.isPackaged = true
+    vi.stubEnv('OPEN_SCIENCE_E2E_STORAGE_ROOT', '/tmp/open-science-certification/storage')
+
+    expect(resolveStorageRoot()).toBe(normalize('/tmp/open-science-certification/storage'))
+    expect(appMock.getPath).not.toHaveBeenCalled()
+  })
+
+  it('rejects an ambiguous relative E2E root', () => {
+    vi.stubEnv('OPEN_SCIENCE_E2E_STORAGE_ROOT', 'certification/storage')
+
+    expect(() => resolveStorageRoot()).toThrow(
+      'OPEN_SCIENCE_E2E_STORAGE_ROOT must be an absolute path'
+    )
   })
 
   it('rejects an ambiguous relative preview override', () => {

--- a/src/main/storage-root.ts
+++ b/src/main/storage-root.ts
@@ -11,11 +11,23 @@ import {
 import { hasPendingMigrationMarker } from './storage/migration-marker'
 import { RELOCATABLE_DATA_DIRS } from './storage/data-directories'
 
+const resolveE2eStorageRoot = (): string | undefined => {
+  const root = process.env.OPEN_SCIENCE_E2E_STORAGE_ROOT?.trim()
+  if (!root) return undefined
+  if (!isAbsolute(root)) {
+    throw new Error('OPEN_SCIENCE_E2E_STORAGE_ROOT must be an absolute path.')
+  }
+  return normalize(root)
+}
+
 // Fixed, dev-aware config root (DB, sessions, claude, skills, settings live here). Never relocated.
 // A development-only absolute override supports truly isolated onboarding previews without changing
 // HOME — changing HOME breaks the macOS default-keychain lookup and can trigger a dangerous "restore
-// default keychain" dialog. Packaged builds always ignore the override.
+// default keychain" dialog. Packaged certification uses its own explicit, disposable E2E root.
 const resolveStorageRoot = (): string => {
+  const e2eRoot = resolveE2eStorageRoot()
+  if (e2eRoot) return e2eRoot
+
   const previewRoot = process.env.OPEN_SCIENCE_STORAGE_ROOT?.trim()
 
   if (!app.isPackaged && previewRoot) {
@@ -44,6 +56,8 @@ const dataFolderName = (): string => (app.isPackaged ? 'OpenScience' : 'OpenScie
 // at its parent - so this join is the single source of truth for the final path.
 const dataRootForParent = (parent: string): string => join(parent, dataFolderName())
 
+const defaultDataParent = (): string => resolveE2eStorageRoot() ?? app.getPath('home')
+
 // Converts a user-PICKED directory into the data root. Normally appends the data folder name
 // (`<picked>/OpenScience`), but when the user navigated INTO and selected the OpenScience folder
 // itself (its basename already equals the data folder name), it is used as-is. Without this,
@@ -71,7 +85,7 @@ const dataRootForPicked = (picked: string): string => {
 // because a failed copy cleanup may leave a markerless partial tree behind.
 const computeDefaultDataRoot = (): string => {
   const configRoot = resolveConfigRoot()
-  const homeDefault = dataRootForParent(app.getPath('home'))
+  const homeDefault = dataRootForParent(defaultDataParent())
   // A marker-bearing homeDefault is a half-copied/uncommitted staging dir, NOT the committed default:
   // treat it as "not there yet" so a crashed or in-flight migration can't fool the legacy fallback into
   // thinking the modern data folder already exists (which would split a legacy user's data).
@@ -97,8 +111,6 @@ const computeDefaultDataRoot = (): string => {
 // only default that is NOT `<parent>/dataFolderName()` is an untouched legacy install (default =
 // config root), and that case never reaches the reset UI — it is already the default, so no reset
 // is offered.
-const defaultDataParent = (): string => app.getPath('home')
-
 // Path equality that respects the platform filesystem: case-insensitive on Windows (NTFS paths are
 // case-insensitive), exact elsewhere. Used for the isDefault check and the same/inside-folder
 // guards so a differently-cased path to the SAME folder on Windows isn't mistaken for a different


### PR DESCRIPTION
## Problem

Nightly packaged certification reused the runner's production config and data directories because packaged builds intentionally ignored the development storage override. State leaked between P0 specs, producing duplicate or missing recent sessions and restart failures across macOS, Linux, and Windows. The provider fixture also rejected the packaged runtime's dynamic loopback bridge.

## Proposed change

- add a dedicated absolute `OPEN_SCIENCE_E2E_STORAGE_ROOT` used only by packaged certification for config and default data
- inject it from the packaged Electron fixture without changing `HOME`
- validate the selected `e2e-model` provider route and its referenced credential across direct and bridged routes
- make project and session persistence waits durable, clean up failed launches, and budget artifact cold startup at the fixture level

## Scope and non-goals

This does not change normal packaged storage resolution or user `HOME` behavior. It does not alter provider routing; it updates certification to verify the route produced by the application.

## Acceptance criteria and validation

Final checks ran after the last material edit and after rebasing onto `origin/main`.

- storage-root isolation -> `npm test -- --run src/main/storage-root.test.ts` -> 33 passed
- packaged launch environment -> `npx playwright test e2e/launch-environment.spec.ts` -> 4 passed
- Node and renderer type contracts -> `npm run typecheck` -> passed
- linted source -> `npm run lint` -> 0 errors (17 pre-existing warnings)
- portable regression suite -> `npm test` -> 11,906 passed, 184 skipped
- source certification journeys -> `npm run build:e2e && npm run test:e2e:p0` -> 5 passed
- macOS arm64 packaged certification -> `electron-builder --mac --arm64` plus `npm run test:e2e:p0` with `OPEN_SCIENCE_E2E_EXECUTABLE` -> 5 passed

Uncovered risk: Windows and Linux packaged lanes were not reproduced locally; CI remains authoritative for those native platforms.

## Review focus

Please review the packaged-only isolation gate, provider-route credential lookup, and the persistence and cold-start waits for accidental production impact.

Related nightly failure: https://github.com/aipoch/open-science/actions/runs/31082053853/job/92554362290
