### PR TITLE
feat(permissions): allow live permission profile changes

### DIFF
--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -229,6 +229,38 @@ describe('ACP permission broker with durable grants', () => {
     await expect(response).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
   })
 
+  it('re-evaluates a delayed grant lookup against a provider mode downgrade', async () => {
+    const { registry, finishResolve } = controlledEmptyGrantRegistry()
+    const emitted: Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0][] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request), undefined, registry)
+    const response = broker.requestPermission(shellRequest('session-1'), {
+      profile: 'ask',
+      projectId: 'project-1'
+    })
+
+    broker.setLivePermissionProfile('session-1', {
+      selectedProfile: 'full',
+      effectiveProfile: 'full',
+      availableModeIds: ['default', 'bypassPermissions'],
+      currentModeId: 'bypassPermissions',
+      fullAccessAvailable: true
+    })
+    broker.setLivePermissionProfile('session-1', {
+      selectedProfile: 'ask',
+      effectiveProfile: 'ask',
+      availableModeIds: ['default', 'bypassPermissions'],
+      currentModeId: 'default',
+      fullAccessAvailable: true
+    })
+    finishResolve()
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(emitted).toHaveLength(1)
+    expect(broker.getPendingRequests()).toHaveLength(1)
+    broker.cancelAllPending()
+    await expect(response).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+  })
+
   it('fails closed and reports when a remembered approval cannot be persisted', async () => {
     const registry = {
       resolve: vi.fn().mockResolvedValue(undefined),

--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -108,6 +108,38 @@ const mcpRequest = (
   ]
 })
 
+const controlledEmptyGrantRegistry = (): {
+  registry: PermissionGrantRegistry
+  finishResolve: () => void
+} => {
+  let finish: (() => void) | undefined
+  const registry = {
+    resolve: vi.fn(
+      () =>
+        new Promise<undefined>((resolve) => {
+          finish = () => resolve(undefined)
+        })
+    ),
+    remember: vi.fn(),
+    list: vi.fn().mockResolvedValue([]),
+    listCached: vi.fn().mockReturnValue([]),
+    revoke: vi.fn(),
+    extendUndo: vi.fn(),
+    restore: vi.fn(),
+    prune: vi.fn(),
+    finalizeOwnerDeletion: vi.fn(),
+    subscribe: vi.fn().mockReturnValue(() => undefined)
+  } satisfies PermissionGrantRegistry
+
+  return {
+    registry,
+    finishResolve: () => {
+      if (!finish) throw new Error('Grant lookup has not started.')
+      finish()
+    }
+  }
+}
+
 describe('ACP permission broker with durable grants', () => {
   it('cancels a request while its durable grant lookup is still pending', async () => {
     let finishResolve: (() => void) | undefined
@@ -141,6 +173,60 @@ describe('ACP permission broker with durable grants', () => {
     await expect(response).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
     expect(emitted).toEqual([])
     expect(broker.hasPendingForSession('session-1')).toBe(false)
+  })
+
+  it('re-evaluates a request when grant lookup crosses a live profile change', async () => {
+    const { registry, finishResolve } = controlledEmptyGrantRegistry()
+    const emitted: Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0][] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request), undefined, registry)
+    const response = broker.requestPermission(shellRequest('session-1'), {
+      profile: 'ask',
+      projectId: 'project-1'
+    })
+    expect(emitted).toEqual([])
+
+    await broker.applyPermissionProfile('session-1', {
+      selectedProfile: 'full',
+      effectiveProfile: 'full',
+      availableModeIds: [],
+      fullAccessAvailable: true
+    })
+    finishResolve()
+
+    await expect(response).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'provider-allow-once' }
+    })
+    expect(emitted).toEqual([])
+    expect(broker.getPendingRequests()).toEqual([])
+  })
+
+  it('does not use a superseded live profile after grant lookup', async () => {
+    const { registry, finishResolve } = controlledEmptyGrantRegistry()
+    const emitted: Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0][] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request), undefined, registry)
+    const response = broker.requestPermission(shellRequest('session-1'), {
+      profile: 'ask',
+      projectId: 'project-1'
+    })
+    let current = true
+    await broker.applyPermissionProfile(
+      'session-1',
+      {
+        selectedProfile: 'full',
+        effectiveProfile: 'full',
+        availableModeIds: [],
+        fullAccessAvailable: true
+      },
+      () => current
+    )
+    current = false
+    finishResolve()
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(emitted).toHaveLength(1)
+    expect(broker.getPendingRequests()).toHaveLength(1)
+    broker.cancelAllPending()
+    await expect(response).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
   })
 
   it('fails closed and reports when a remembered approval cannot be persisted', async () => {

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -171,6 +171,69 @@ describe('ACP permission broker', () => {
     await expect(declined).resolves.toBe(false)
   })
 
+  it('re-evaluates pending tool requests after a live profile change without approving app actions', async () => {
+    const emitted: EmittedPermissionRequest[] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const policy = { profile: 'ask' as const, cwd: '/workspace' }
+
+    const read = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'Read notes.md',
+        providerToolName: 'Read',
+        kind: 'read',
+        locations: [{ path: 'notes.md' }]
+      }),
+      policy
+    )
+    const shell = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'python train.py',
+        providerToolName: 'Bash',
+        kind: 'execute',
+        rawInput: { command: 'python train.py' }
+      }),
+      policy
+    )
+    const appApproval = broker.requestAppApproval({
+      sessionId: 'session-1',
+      title: 'Switch specialist?',
+      rawInput: { specialistApproval: { kind: 'switch' } }
+    })
+
+    await broker.applyPermissionProfile('session-1', {
+      selectedProfile: 'auto',
+      effectiveProfile: 'auto',
+      availableModeIds: [],
+      autoReviewStrategy: 'conservative',
+      fullAccessAvailable: true
+    })
+    await expect(read).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(broker.getPendingRequests().map(({ title }) => title)).toEqual([
+      'python train.py',
+      'Switch specialist?'
+    ])
+
+    await broker.applyPermissionProfile('session-1', {
+      selectedProfile: 'full',
+      effectiveProfile: 'full',
+      availableModeIds: [],
+      fullAccessAvailable: true
+    })
+    await expect(shell).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(broker.getPendingRequests().map(({ title }) => title)).toEqual(['Switch specialist?'])
+
+    const appRequest = emitted.find(({ title }) => title === 'Switch specialist?')!
+    await broker.respond({
+      requestId: appRequest.requestId,
+      optionId: appRequest.options.find(({ kind }) => kind === 'reject_once')?.optionId
+    })
+    await expect(appApproval).resolves.toBe(false)
+  })
+
   it('keeps session grants app-owned while the Agent receives one-shot approvals', async () => {
     const emitted: EmittedPermissionRequest[] = []
     const broker = new AcpPermissionBroker((request) => emitted.push(request))

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -282,6 +282,39 @@ describe('ACP permission broker', () => {
     expect(broker.getPendingRequests()).toEqual([])
   })
 
+  it('uses a live Ask profile for a delayed request carrying a stale Full policy', async () => {
+    const emitted: EmittedPermissionRequest[] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    await broker.applyPermissionProfile('session-1', {
+      selectedProfile: 'full',
+      effectiveProfile: 'full',
+      availableModeIds: [],
+      fullAccessAvailable: true
+    })
+
+    const profileChange = broker.applyPermissionProfile('session-1', {
+      selectedProfile: 'ask',
+      effectiveProfile: 'ask',
+      availableModeIds: [],
+      fullAccessAvailable: true
+    })
+    const delayed = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'python delayed.py',
+        providerToolName: 'Bash',
+        kind: 'execute',
+        rawInput: { command: 'python delayed.py' }
+      }),
+      { profile: 'full', cwd: '/workspace' }
+    )
+
+    await profileChange
+    expect(emitted.map(({ title }) => title)).toEqual(['python delayed.py'])
+    expect(broker.getPendingRequests()).toHaveLength(1)
+    broker.cancelAllPending()
+    await expect(delayed).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+  })
+
   it('stops releasing pending requests when a live profile change is superseded', async () => {
     const broker = new AcpPermissionBroker(() => undefined)
     const policy = { profile: 'ask' as const, cwd: '/workspace' }

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -234,6 +234,54 @@ describe('ACP permission broker', () => {
     await expect(appApproval).resolves.toBe(false)
   })
 
+  it('applies a live profile to new provider requests after the pending snapshot', async () => {
+    const emitted: EmittedPermissionRequest[] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const policy = { profile: 'ask' as const, cwd: '/workspace' }
+    const existing = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'python existing.py',
+        providerToolName: 'Bash',
+        kind: 'execute',
+        rawInput: { command: 'python existing.py' }
+      }),
+      policy
+    )
+
+    const profileChange = broker.applyPermissionProfile('session-1', {
+      selectedProfile: 'full',
+      effectiveProfile: 'full',
+      availableModeIds: [],
+      fullAccessAvailable: true
+    })
+    const capabilityLess = broker.requestPermission(
+      createToolPermissionRequest({ title: 'Unclassified provider tool', kind: 'other' }),
+      policy
+    )
+    const legacyCategory = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'python late.py',
+        providerToolName: 'Bash',
+        kind: 'execute',
+        rawInput: { command: 'python late.py' }
+      }),
+      policy
+    )
+
+    await expect(capabilityLess).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    await expect(legacyCategory).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    await profileChange
+    await expect(existing).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(emitted.map(({ title }) => title)).toEqual(['python existing.py'])
+    expect(broker.getPendingRequests()).toEqual([])
+  })
+
   it('stops releasing pending requests when a live profile change is superseded', async () => {
     const broker = new AcpPermissionBroker(() => undefined)
     const policy = { profile: 'ask' as const, cwd: '/workspace' }

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -234,6 +234,51 @@ describe('ACP permission broker', () => {
     await expect(appApproval).resolves.toBe(false)
   })
 
+  it('stops releasing pending requests when a live profile change is superseded', async () => {
+    const broker = new AcpPermissionBroker(() => undefined)
+    const policy = { profile: 'ask' as const, cwd: '/workspace' }
+    const first = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'python first.py',
+        providerToolName: 'Bash',
+        kind: 'execute',
+        rawInput: { command: 'python first.py' }
+      }),
+      policy
+    )
+    const second = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'python second.py',
+        providerToolName: 'Bash',
+        kind: 'execute',
+        rawInput: { command: 'python second.py' }
+      }),
+      policy
+    )
+    let current = true
+    void first.then(() => {
+      current = false
+    })
+
+    await broker.applyPermissionProfile(
+      'session-1',
+      {
+        selectedProfile: 'full',
+        effectiveProfile: 'full',
+        availableModeIds: [],
+        fullAccessAvailable: true
+      },
+      () => current
+    )
+
+    await expect(first).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(broker.getPendingRequests().map(({ title }) => title)).toEqual(['python second.py'])
+    broker.cancelAllPending()
+    await expect(second).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+  })
+
   it('keeps session grants app-owned while the Agent receives one-shot approvals', async () => {
     const emitted: EmittedPermissionRequest[] = []
     const broker = new AcpPermissionBroker((request) => emitted.push(request))

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -695,10 +695,12 @@ class AcpPermissionBroker {
   // approvals do not carry an automatic request and therefore always remain human decisions.
   async applyPermissionProfile(
     sessionId: string,
-    profile: Readonly<SessionPermissionProfileState>
+    profile: Readonly<SessionPermissionProfileState>,
+    isCurrent: () => boolean = () => true
   ): Promise<string[]> {
     const resolvedRequestIds: string[] = []
     for (const [requestId, pending] of Array.from(this.pendingRequests)) {
+      if (!isCurrent()) break
       if (pending.request.sessionId !== sessionId || !pending.automaticRequest) continue
 
       const optionId = resolveAutomaticPermission(pending.automaticRequest, {
@@ -707,6 +709,7 @@ class AcpPermissionBroker {
         autoReviewStrategy: profile.autoReviewStrategy
       })
       if (!optionId) continue
+      if (!isCurrent()) break
 
       if (await this.respond({ requestId, optionId })) resolvedRequestIds.push(requestId)
     }

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -6,6 +6,7 @@ import type {
   AcpPermissionRequest,
   AcpPermissionResponse
 } from '../../shared/acp'
+import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
 import type {
   PermissionCapability,
   PermissionGrantRecord,
@@ -35,6 +36,8 @@ import type { PermissionGrantRegistry } from '../permission-grants/registry'
 
 type PendingPermission = {
   request: AcpPermissionRequest
+  automaticRequest?: RequestPermissionRequest
+  policyContext?: PermissionPolicyContext
   categoryKey?: string
   capability?: PermissionCapability
   projectId?: string
@@ -688,6 +691,28 @@ class AcpPermissionBroker {
     )
   }
 
+  // Re-evaluates provider tool requests after the user changes the live Session profile. App-owned
+  // approvals do not carry an automatic request and therefore always remain human decisions.
+  async applyPermissionProfile(
+    sessionId: string,
+    profile: Readonly<SessionPermissionProfileState>
+  ): Promise<string[]> {
+    const resolvedRequestIds: string[] = []
+    for (const [requestId, pending] of Array.from(this.pendingRequests)) {
+      if (pending.request.sessionId !== sessionId || !pending.automaticRequest) continue
+
+      const optionId = resolveAutomaticPermission(pending.automaticRequest, {
+        ...pending.policyContext,
+        profile: profile.selectedProfile,
+        autoReviewStrategy: profile.autoReviewStrategy
+      })
+      if (!optionId) continue
+
+      if (await this.respond({ requestId, optionId })) resolvedRequestIds.push(requestId)
+    }
+    return resolvedRequestIds
+  }
+
   // Lists the app conversation's grants so the composer can show and revoke them.
   listGrants(sessionId: string): AcpPermissionGrant[] {
     if (this.permissionGrantRegistry) {
@@ -855,6 +880,7 @@ class AcpPermissionBroker {
       { ...params, options: providerPermissionOptions },
       policyContext
     )
+    const automaticRequest = { ...params, options: providerPermissionOptions }
 
     if (automaticOptionId) {
       return Promise.resolve({
@@ -884,6 +910,8 @@ class AcpPermissionBroker {
           return this.enqueuePermissionRequest({
             requestId,
             request,
+            automaticRequest,
+            policyContext,
             categoryKey,
             capability,
             projectId: policyContext?.projectId,
@@ -907,6 +935,8 @@ class AcpPermissionBroker {
     return this.enqueuePermissionRequest({
       requestId,
       request,
+      automaticRequest,
+      policyContext,
       categoryKey,
       providerAllowOnceOptionId: providerAllowOnceOption?.optionId
     })

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -700,12 +700,20 @@ class AcpPermissionBroker {
 
   // Re-evaluates provider tool requests after the user changes the live Session profile. App-owned
   // approvals do not carry an automatic request and therefore always remain human decisions.
+  setLivePermissionProfile(
+    sessionId: string,
+    profile: Readonly<SessionPermissionProfileState>,
+    isCurrent: () => boolean = () => true
+  ): void {
+    this.livePermissionProfiles.set(sessionId, { profile, isCurrent })
+  }
+
   async applyPermissionProfile(
     sessionId: string,
     profile: Readonly<SessionPermissionProfileState>,
     isCurrent: () => boolean = () => true
   ): Promise<string[]> {
-    this.livePermissionProfiles.set(sessionId, { profile, isCurrent })
+    this.setLivePermissionProfile(sessionId, profile, isCurrent)
     const resolvedRequestIds: string[] = []
     for (const [requestId, pending] of Array.from(this.pendingRequests)) {
       if (!isCurrent()) break

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -725,9 +725,10 @@ class AcpPermissionBroker {
   setProviderPermissionProfile(
     sessionId: string,
     profile: Readonly<SessionPermissionProfileState>
-  ): void {
-    if (this.livePermissionProfiles.get(sessionId)?.providerUpdatesBlocked) return
+  ): boolean {
+    if (this.livePermissionProfiles.get(sessionId)?.providerUpdatesBlocked) return false
     this.setLivePermissionProfile(sessionId, profile)
+    return true
   }
 
   clearLivePermissionProfile(sessionId: string): void {

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -887,11 +887,11 @@ class AcpPermissionBroker {
     // A model-independent fallback auto-reviews only structured, workspace-contained low-risk tools.
     // Resolve against the projected options so a stripped policy amendment can never be an automatic
     // outcome — the "amendments are never selectable" invariant must hold on the auto path too.
-    const automaticOptionId = resolveAutomaticPermission(
-      { ...params, options: providerPermissionOptions },
+    const automaticRequest = { ...params, options: providerPermissionOptions }
+    const automaticOptionId = this.resolveCurrentAutomaticPermission(
+      automaticRequest,
       policyContext
     )
-    const automaticRequest = { ...params, options: providerPermissionOptions }
 
     if (automaticOptionId) {
       return Promise.resolve({
@@ -956,15 +956,9 @@ class AcpPermissionBroker {
   private resolveOrEnqueuePermissionRequest(
     pending: Omit<PendingPermission, 'resolve'> & { requestId: string }
   ): Promise<RequestPermissionResponse> {
-    const liveProfile = this.livePermissionProfiles.get(pending.request.sessionId)
-    const liveAutomaticOptionId =
-      pending.automaticRequest && liveProfile?.isCurrent()
-        ? resolveAutomaticPermission(pending.automaticRequest, {
-            ...pending.policyContext,
-            profile: liveProfile.profile.selectedProfile,
-            autoReviewStrategy: liveProfile.profile.autoReviewStrategy
-          })
-        : undefined
+    const liveAutomaticOptionId = pending.automaticRequest
+      ? this.resolveCurrentAutomaticPermission(pending.automaticRequest, pending.policyContext)
+      : undefined
 
     if (liveAutomaticOptionId) {
       return Promise.resolve({
@@ -973,6 +967,21 @@ class AcpPermissionBroker {
     }
 
     return this.enqueuePermissionRequest(pending)
+  }
+
+  private resolveCurrentAutomaticPermission(
+    request: RequestPermissionRequest,
+    policyContext?: PermissionPolicyContext
+  ): string | undefined {
+    const liveProfile = this.livePermissionProfiles.get(request.sessionId)
+    if (!liveProfile) return resolveAutomaticPermission(request, policyContext)
+    if (!liveProfile.isCurrent()) return undefined
+
+    return resolveAutomaticPermission(request, {
+      ...policyContext,
+      profile: liveProfile.profile.selectedProfile,
+      autoReviewStrategy: liveProfile.profile.autoReviewStrategy
+    })
   }
 
   private enqueuePermissionRequest(

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -918,20 +918,7 @@ class AcpPermissionBroker {
               outcome: { outcome: 'selected' as const, optionId: providerAllowOnceOption.optionId }
             }
           }
-          const liveProfile = this.livePermissionProfiles.get(params.sessionId)
-          const liveAutomaticOptionId = liveProfile?.isCurrent()
-            ? resolveAutomaticPermission(automaticRequest, {
-                ...policyContext,
-                profile: liveProfile.profile.selectedProfile,
-                autoReviewStrategy: liveProfile.profile.autoReviewStrategy
-              })
-            : undefined
-          if (liveAutomaticOptionId) {
-            return {
-              outcome: { outcome: 'selected' as const, optionId: liveAutomaticOptionId }
-            }
-          }
-          return this.enqueuePermissionRequest({
+          return this.resolveOrEnqueuePermissionRequest({
             requestId,
             request,
             automaticRequest,
@@ -956,7 +943,7 @@ class AcpPermissionBroker {
     }
 
     // The returned promise is held open until the UI selects or cancels an option.
-    return this.enqueuePermissionRequest({
+    return this.resolveOrEnqueuePermissionRequest({
       requestId,
       request,
       automaticRequest,
@@ -964,6 +951,28 @@ class AcpPermissionBroker {
       categoryKey,
       providerAllowOnceOptionId: providerAllowOnceOption?.optionId
     })
+  }
+
+  private resolveOrEnqueuePermissionRequest(
+    pending: Omit<PendingPermission, 'resolve'> & { requestId: string }
+  ): Promise<RequestPermissionResponse> {
+    const liveProfile = this.livePermissionProfiles.get(pending.request.sessionId)
+    const liveAutomaticOptionId =
+      pending.automaticRequest && liveProfile?.isCurrent()
+        ? resolveAutomaticPermission(pending.automaticRequest, {
+            ...pending.policyContext,
+            profile: liveProfile.profile.selectedProfile,
+            autoReviewStrategy: liveProfile.profile.autoReviewStrategy
+          })
+        : undefined
+
+    if (liveAutomaticOptionId) {
+      return Promise.resolve({
+        outcome: { outcome: 'selected', optionId: liveAutomaticOptionId }
+      })
+    }
+
+    return this.enqueuePermissionRequest(pending)
   }
 
   private enqueuePermissionRequest(

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -677,6 +677,7 @@ class AcpPermissionBroker {
     {
       profile: Readonly<SessionPermissionProfileState>
       isCurrent: () => boolean
+      providerUpdatesBlocked: boolean
     }
   >()
 
@@ -698,14 +699,39 @@ class AcpPermissionBroker {
     )
   }
 
-  // Re-evaluates provider tool requests after the user changes the live Session profile. App-owned
-  // approvals do not carry an automatic request and therefore always remain human decisions.
+  // Publishes the committed Session posture used by new provider permission requests.
   setLivePermissionProfile(
     sessionId: string,
     profile: Readonly<SessionPermissionProfileState>,
     isCurrent: () => boolean = () => true
   ): void {
-    this.livePermissionProfiles.set(sessionId, { profile, isCurrent })
+    this.livePermissionProfiles.set(sessionId, {
+      profile,
+      isCurrent,
+      providerUpdatesBlocked: false
+    })
+  }
+
+  beginPermissionProfileTransition(
+    sessionId: string,
+    profile: Readonly<SessionPermissionProfileState>,
+    isCurrent: () => boolean
+  ): void {
+    this.livePermissionProfiles.set(sessionId, { profile, isCurrent, providerUpdatesBlocked: true })
+  }
+
+  // A user-requested transition remains authoritative until its runtime operation commits or rolls
+  // back, so a delayed provider mode notification cannot restore stale Full access in the meantime.
+  setProviderPermissionProfile(
+    sessionId: string,
+    profile: Readonly<SessionPermissionProfileState>
+  ): void {
+    if (this.livePermissionProfiles.get(sessionId)?.providerUpdatesBlocked) return
+    this.setLivePermissionProfile(sessionId, profile)
+  }
+
+  clearLivePermissionProfile(sessionId: string): void {
+    this.livePermissionProfiles.delete(sessionId)
   }
 
   async applyPermissionProfile(
@@ -713,7 +739,9 @@ class AcpPermissionBroker {
     profile: Readonly<SessionPermissionProfileState>,
     isCurrent: () => boolean = () => true
   ): Promise<string[]> {
-    this.setLivePermissionProfile(sessionId, profile, isCurrent)
+    const providerUpdatesBlocked =
+      this.livePermissionProfiles.get(sessionId)?.providerUpdatesBlocked ?? false
+    this.livePermissionProfiles.set(sessionId, { profile, isCurrent, providerUpdatesBlocked })
     const resolvedRequestIds: string[] = []
     for (const [requestId, pending] of Array.from(this.pendingRequests)) {
       if (!isCurrent()) break

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -672,6 +672,13 @@ class AcpPermissionBroker {
   private pendingRequests = new Map<string, PendingPermission>()
   private cancellationGeneration = 0
   private readonly sessionCancellationGenerations = new Map<string, number>()
+  private readonly livePermissionProfiles = new Map<
+    string,
+    {
+      profile: Readonly<SessionPermissionProfileState>
+      isCurrent: () => boolean
+    }
+  >()
 
   // Accepts the callback used to publish new permission requests to listeners.
   constructor(
@@ -698,6 +705,7 @@ class AcpPermissionBroker {
     profile: Readonly<SessionPermissionProfileState>,
     isCurrent: () => boolean = () => true
   ): Promise<string[]> {
+    this.livePermissionProfiles.set(sessionId, { profile, isCurrent })
     const resolvedRequestIds: string[] = []
     for (const [requestId, pending] of Array.from(this.pendingRequests)) {
       if (!isCurrent()) break
@@ -910,6 +918,19 @@ class AcpPermissionBroker {
               outcome: { outcome: 'selected' as const, optionId: providerAllowOnceOption.optionId }
             }
           }
+          const liveProfile = this.livePermissionProfiles.get(params.sessionId)
+          const liveAutomaticOptionId = liveProfile?.isCurrent()
+            ? resolveAutomaticPermission(automaticRequest, {
+                ...policyContext,
+                profile: liveProfile.profile.selectedProfile,
+                autoReviewStrategy: liveProfile.profile.autoReviewStrategy
+              })
+            : undefined
+          if (liveAutomaticOptionId) {
+            return {
+              outcome: { outcome: 'selected' as const, optionId: liveAutomaticOptionId }
+            }
+          }
           return this.enqueuePermissionRequest({
             requestId,
             request,
@@ -1062,6 +1083,7 @@ class AcpPermissionBroker {
   // Cancels every pending request while preserving conversation grants across Agent reconnects.
   cancelAllPending(): void {
     this.cancellationGeneration += 1
+    this.livePermissionProfiles.clear()
     const pendingRequests = Array.from(this.pendingRequests.keys())
 
     for (const requestId of pendingRequests) {
@@ -1087,6 +1109,7 @@ class AcpPermissionBroker {
   // Ends one Agent session: cancel its outstanding prompts and discard its non-persistent grants.
   clearSession(sessionId: string): void {
     this.cancelForSession(sessionId)
+    this.livePermissionProfiles.delete(sessionId)
     this.conversationGrants.clear(sessionId)
   }
 }

--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -405,9 +405,10 @@ class AcpPermissionContext {
 
   setLivePermissionProfile(
     sessionId: string,
-    profile: Readonly<SessionPermissionProfileState>
+    profile: Readonly<SessionPermissionProfileState>,
+    isCurrent: () => boolean = () => true
   ): void {
-    this.broker.setLivePermissionProfile(sessionId, profile)
+    this.broker.setLivePermissionProfile(sessionId, profile, isCurrent)
   }
 
   listGrants(sessionId: string): AcpPermissionGrant[] {

--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -422,8 +422,8 @@ class AcpPermissionContext {
   setProviderPermissionProfile(
     sessionId: string,
     profile: Readonly<SessionPermissionProfileState>
-  ): void {
-    this.broker.setProviderPermissionProfile(sessionId, profile)
+  ): boolean {
+    return this.broker.setProviderPermissionProfile(sessionId, profile)
   }
 
   clearLivePermissionProfile(sessionId: string): void {

--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -403,6 +403,13 @@ class AcpPermissionContext {
     for (const requestId of resolvedRequestIds) this.humanOnlyRequestIds.delete(requestId)
   }
 
+  setLivePermissionProfile(
+    sessionId: string,
+    profile: Readonly<SessionPermissionProfileState>
+  ): void {
+    this.broker.setLivePermissionProfile(sessionId, profile)
+  }
+
   listGrants(sessionId: string): AcpPermissionGrant[] {
     return this.broker.listGrants(sessionId)
   }

--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -390,8 +390,12 @@ class AcpPermissionContext {
     return this.broker.getPendingRequests()
   }
 
-  hasPendingForSession(sessionId: string): boolean {
-    return this.broker.hasPendingForSession(sessionId)
+  async applyPermissionProfile(
+    sessionId: string,
+    profile: Readonly<SessionPermissionProfileState>
+  ): Promise<void> {
+    const resolvedRequestIds = await this.broker.applyPermissionProfile(sessionId, profile)
+    for (const requestId of resolvedRequestIds) this.humanOnlyRequestIds.delete(requestId)
   }
 
   listGrants(sessionId: string): AcpPermissionGrant[] {

--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -411,6 +411,25 @@ class AcpPermissionContext {
     this.broker.setLivePermissionProfile(sessionId, profile, isCurrent)
   }
 
+  beginPermissionProfileTransition(
+    sessionId: string,
+    profile: Readonly<SessionPermissionProfileState>,
+    isCurrent: () => boolean
+  ): void {
+    this.broker.beginPermissionProfileTransition(sessionId, profile, isCurrent)
+  }
+
+  setProviderPermissionProfile(
+    sessionId: string,
+    profile: Readonly<SessionPermissionProfileState>
+  ): void {
+    this.broker.setProviderPermissionProfile(sessionId, profile)
+  }
+
+  clearLivePermissionProfile(sessionId: string): void {
+    this.broker.clearLivePermissionProfile(sessionId)
+  }
+
   listGrants(sessionId: string): AcpPermissionGrant[] {
     return this.broker.listGrants(sessionId)
   }

--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -392,9 +392,14 @@ class AcpPermissionContext {
 
   async applyPermissionProfile(
     sessionId: string,
-    profile: Readonly<SessionPermissionProfileState>
+    profile: Readonly<SessionPermissionProfileState>,
+    isCurrent: () => boolean
   ): Promise<void> {
-    const resolvedRequestIds = await this.broker.applyPermissionProfile(sessionId, profile)
+    const resolvedRequestIds = await this.broker.applyPermissionProfile(
+      sessionId,
+      profile,
+      isCurrent
+    )
     for (const requestId of resolvedRequestIds) this.humanOnlyRequestIds.delete(requestId)
   }
 

--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -44,6 +44,7 @@ type ResumerHarness = {
   assertCurrentConnection: ReturnType<typeof vi.fn>
   attachSession: ReturnType<typeof vi.fn>
   commit: ReturnType<typeof vi.fn>
+  clearLivePermissionProfile: ReturnType<typeof vi.fn>
   configure: ReturnType<typeof vi.fn>
   configurePermissionProfile: ReturnType<typeof vi.fn>
   connection: ClientConnection
@@ -173,6 +174,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
     return {} as ReturnType<typeof setTimeout>
   })
   const assertCurrentConnection = vi.fn()
+  const clearLivePermissionProfile = vi.fn()
   const resumer = new AcpProviderSessionResumer({
     defaultCwd: '/default',
     defaultProjectName: 'default-project',
@@ -216,6 +218,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
     },
     configurator: { configure, configurePermissionProfile },
     adopter: { adopt },
+    clearLivePermissionProfile,
     updateCwd: () => order.push('cwd callback'),
     pushEvent: () => {
       order.push('event callback')
@@ -245,6 +248,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
     assertCurrentConnection,
     attachSession,
     commit,
+    clearLivePermissionProfile,
     configure,
     configurePermissionProfile,
     connection,
@@ -292,6 +296,7 @@ describe('AcpProviderSessionResumer', () => {
       permissionProfile
     })
     expect(harness.registry.currentSessionId).toBe('stable-app-session')
+    expect(harness.clearLivePermissionProfile).toHaveBeenCalledWith('stable-app-session')
     expect(harness.order).toEqual(['configure permission', 'cwd callback', 'state callback'])
     expect(harness.request).not.toHaveBeenCalled()
     expect(harness.adopt).not.toHaveBeenCalled()

--- a/src/main/acp/provider-session-resumer.ts
+++ b/src/main/acp/provider-session-resumer.ts
@@ -60,6 +60,7 @@ type AcpProviderSessionResumerDependencies = Readonly<{
   capabilities: Pick<AcpSessionCapabilityOwner, 'provision'>
   configurator: Pick<AcpSessionConfigurator, 'configure' | 'configurePermissionProfile'>
   adopter: Pick<AcpProviderSessionAdopter, 'adopt'>
+  clearLivePermissionProfile: (sessionId: string) => void
   resolveSpecialistSkills?: (specialistId: string) => Promise<EffectiveSpecialistSkills>
   updateCwd: (cwd: string) => void
   pushEvent: (event: ResumeEvent) => void
@@ -125,6 +126,7 @@ export class AcpProviderSessionResumer {
     }
     this.deps.assertCurrentConnection(connection)
     current.aggregate.setPermissionProfile(structuredClone(permissionProfile))
+    this.deps.clearLivePermissionProfile(request.sessionId)
     this.deps.registry.select(request.sessionId)
     this.deps.updateCwd(cwd)
     current.aggregate.updateLocation(cwd, projectName)

--- a/src/main/acp/runtime-provider-session-composition.ts
+++ b/src/main/acp/runtime-provider-session-composition.ts
@@ -150,6 +150,8 @@ const composeAcpRuntimeProviderSessionOwners = (
     capabilities: base.sessionCapabilities,
     configurator: base.sessionConfigurator,
     adopter: providerSessionAdopter,
+    clearLivePermissionProfile: (sessionId) =>
+      session.permissionContext.clearLivePermissionProfile(sessionId),
     resolveSpecialistSkills: options.resolveSpecialistSkills,
     updateCwd,
     pushEvent: (event) => session.publication.pushEvent(event),

--- a/src/main/acp/runtime-session-composition.ts
+++ b/src/main/acp/runtime-session-composition.ts
@@ -168,8 +168,8 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     reconnectPending: () => base.connectionTransitions.providerReconnectPending,
     mcpServerNamesFor: (sessionId) => base.sessionCapabilities.mcpServerNamesFor(sessionId),
     nextEventId: () => publication.nextEventId(),
-    setLivePermissionProfile: (sessionId, profile) =>
-      permissionContext.setLivePermissionProfile(sessionId, profile),
+    setProviderPermissionProfile: (sessionId, profile) =>
+      permissionContext.setProviderPermissionProfile(sessionId, profile),
     emitState: () => publication.emitState(),
     pushEvent: (event) => publication.pushEvent(event),
     reportToolFailure: (effect) =>

--- a/src/main/acp/runtime-session-composition.ts
+++ b/src/main/acp/runtime-session-composition.ts
@@ -168,6 +168,8 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     reconnectPending: () => base.connectionTransitions.providerReconnectPending,
     mcpServerNamesFor: (sessionId) => base.sessionCapabilities.mcpServerNamesFor(sessionId),
     nextEventId: () => publication.nextEventId(),
+    setLivePermissionProfile: (sessionId, profile) =>
+      permissionContext.setLivePermissionProfile(sessionId, profile),
     emitState: () => publication.emitState(),
     pushEvent: (event) => publication.pushEvent(event),
     reportToolFailure: (effect) =>

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -6306,6 +6306,46 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().pendingPermissions).toEqual([])
   })
 
+  it('changes permission profile while a prompt is waiting and releases the eligible request', async () => {
+    const process = new FakeAgentProcess()
+    const permissionSeen = createDeferred<AcpPermissionRequest>()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'live-permission-session',
+      toolCallId: 'live-permission-tool',
+      toolTitle: 'Run command',
+      modes: createModes(['default', 'bypassPermissions']),
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onPermissionRequest: (request) => permissionSeen.resolve(request) }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+
+    const prompting = runtime.sendPrompt({ sessionId: session.sessionId, text: 'run a command' })
+    await permissionSeen.promise
+    const snapshot = await runtime.setPermissionProfile({
+      sessionId: session.sessionId,
+      profile: 'full'
+    })
+
+    await expect(prompting).resolves.toMatchObject({ stopReason: 'end_turn' })
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(snapshot.pendingPermissions).toEqual([])
+    expect(snapshot.permissionProfiles[session.sessionId]).toMatchObject({
+      selectedProfile: 'full',
+      effectiveProfile: 'full',
+      currentModeId: 'bypassPermissions'
+    })
+  })
+
   it('audits OpenCode MCP calls with canonical identities without logging raw tool titles', async () => {
     infoLogSpy.mockClear()
     warnLogSpy.mockClear()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -660,7 +660,11 @@ const startPermissionProbeAgent = (
     announceToolCall?: boolean
     sparseCodexMcpApproval?: boolean
     modes?: SessionModeState
-    onSetMode?: (context: { sessionId: string; modeId: string }) => Promise<void> | void
+    onSetMode?: (context: {
+      sessionId: string
+      modeId: string
+      notifyCurrentMode: (currentModeId: string) => Promise<void>
+    }) => Promise<void> | void
     permissionOptions?: Array<{
       optionId: string
       name: string
@@ -685,7 +689,15 @@ const startPermissionProbeAgent = (
       modes: options.modes
     }))
     .onRequest(acp.methods.agent.session.setMode, async (ctx) => {
-      await options.onSetMode?.({ sessionId: ctx.params.sessionId, modeId: ctx.params.modeId })
+      await options.onSetMode?.({
+        sessionId: ctx.params.sessionId,
+        modeId: ctx.params.modeId,
+        notifyCurrentMode: async (currentModeId) =>
+          ctx.client.notify(acp.methods.client.session.update, {
+            sessionId: ctx.params.sessionId,
+            update: { sessionUpdate: 'current_mode_update', currentModeId }
+          })
+      })
       return {}
     })
     .onRequest(acp.methods.agent.session.resume, (ctx) => {
@@ -6364,8 +6376,9 @@ describe('ACP runtime session management', () => {
       toolCallId: 'live-permission-tool',
       toolTitle: 'Run command',
       modes: createModes(['default', 'bypassPermissions']),
-      onSetMode: async ({ modeId }) => {
+      onSetMode: async ({ modeId, notifyCurrentMode }) => {
         if (modeId === 'default') {
+          await notifyCurrentMode('bypassPermissions')
           askModeEntered.resolve()
           await releaseAskMode.promise
         }
@@ -6435,6 +6448,43 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().permissionProfiles[session.sessionId]).toMatchObject({
       selectedProfile: 'full',
       effectiveProfile: 'full'
+    })
+  })
+
+  it('uses the committed profile after replacing the provider session', async () => {
+    const process = new FakeAgentProcess()
+    const permissionSeen = vi.fn()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'live-permission-session',
+      toolCallId: 'live-permission-tool',
+      toolTitle: 'Run command',
+      modes: createModes(['default', 'bypassPermissions']),
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onPermissionRequest: permissionSeen }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+    await runtime.setPermissionProfile({ sessionId: session.sessionId, profile: 'full' })
+
+    await runtime.resetSessionContext({
+      sessionId: session.sessionId,
+      cwd: '/workspace',
+      permissionProfile: 'full'
+    })
+    await expect(
+      runtime.sendPrompt({ sessionId: session.sessionId, text: 'run a command' })
+    ).resolves.toMatchObject({ stopReason: 'end_turn' })
+
+    expect(permissionSeen).not.toHaveBeenCalled()
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
     })
   })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3601,6 +3601,9 @@ describe('ACP runtime session management', () => {
     await expect(
       runtime.sendPrompt({ sessionId: second.sessionId, text: 'blocked prompt' })
     ).rejects.toThrow(/already running/)
+    await expect(
+      runtime.setPermissionProfile({ sessionId: second.sessionId, profile: 'full' })
+    ).rejects.toThrow(/compacting/)
 
     const prompting = runtime.sendPrompt({ sessionId: first.sessionId, text: 'first prompt' })
     await vi.waitFor(() =>

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -660,6 +660,7 @@ const startPermissionProbeAgent = (
     announceToolCall?: boolean
     sparseCodexMcpApproval?: boolean
     modes?: SessionModeState
+    onSetMode?: (context: { sessionId: string; modeId: string }) => Promise<void> | void
     permissionOptions?: Array<{
       optionId: string
       name: string
@@ -683,7 +684,10 @@ const startPermissionProbeAgent = (
       sessionId: options.newSessionId,
       modes: options.modes
     }))
-    .onRequest(acp.methods.agent.session.setMode, () => ({}))
+    .onRequest(acp.methods.agent.session.setMode, async (ctx) => {
+      await options.onSetMode?.({ sessionId: ctx.params.sessionId, modeId: ctx.params.modeId })
+      return {}
+    })
     .onRequest(acp.methods.agent.session.resume, (ctx) => {
       if (options.resume === 'notFound') {
         throw acp.RequestError.resourceNotFound(ctx.params.sessionId)
@@ -6344,6 +6348,65 @@ describe('ACP runtime session management', () => {
       effectiveProfile: 'full',
       currentModeId: 'bypassPermissions'
     })
+  })
+
+  it('lets the latest overlapping profile change commit without releasing pending permission', async () => {
+    const process = new FakeAgentProcess()
+    const permissionSeen = createDeferred<AcpPermissionRequest>()
+    const fullModeEntered = createDeferred()
+    const releaseFullMode = createDeferred()
+    const modeChanges: string[] = []
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'live-permission-session',
+      toolCallId: 'live-permission-tool',
+      toolTitle: 'Run command',
+      modes: createModes(['default', 'bypassPermissions']),
+      onSetMode: async ({ modeId }) => {
+        modeChanges.push(modeId)
+        if (modeId === 'bypassPermissions') {
+          fullModeEntered.resolve()
+          await releaseFullMode.promise
+        }
+      },
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onPermissionRequest: (request) => permissionSeen.resolve(request) }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+    const prompting = runtime.sendPrompt({ sessionId: session.sessionId, text: 'run a command' })
+    const permission = await permissionSeen.promise
+
+    const selectingFull = runtime.setPermissionProfile({
+      sessionId: session.sessionId,
+      profile: 'full'
+    })
+    await fullModeEntered.promise
+    const selectingAsk = runtime.setPermissionProfile({
+      sessionId: session.sessionId,
+      profile: 'ask'
+    })
+    releaseFullMode.resolve()
+
+    await expect(selectingFull).resolves.toBeDefined()
+    const snapshot = await selectingAsk
+    expect(modeChanges).toEqual(['bypassPermissions', 'default'])
+    expect(permissionResponse).toBeUndefined()
+    expect(snapshot.pendingPermissions).toHaveLength(1)
+    expect(snapshot.permissionProfiles[session.sessionId]).toMatchObject({
+      selectedProfile: 'ask',
+      effectiveProfile: 'ask',
+      currentModeId: 'default'
+    })
+
+    runtime.respondToPermission({ requestId: permission.requestId, cancelled: true })
+    await expect(prompting).resolves.toMatchObject({ stopReason: 'end_turn' })
   })
 
   it('audits OpenCode MCP calls with canonical identities without logging raw tool titles', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -6353,6 +6353,91 @@ describe('ACP runtime session management', () => {
     })
   })
 
+  it('enforces a requested downgrade while the provider mode change is in flight', async () => {
+    const process = new FakeAgentProcess()
+    const askModeEntered = createDeferred()
+    const releaseAskMode = createDeferred()
+    const permissionSeen = createDeferred<AcpPermissionRequest>()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'live-permission-session',
+      toolCallId: 'live-permission-tool',
+      toolTitle: 'Run command',
+      modes: createModes(['default', 'bypassPermissions']),
+      onSetMode: async ({ modeId }) => {
+        if (modeId === 'default') {
+          askModeEntered.resolve()
+          await releaseAskMode.promise
+        }
+      },
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onPermissionRequest: (request) => permissionSeen.resolve(request) }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'full' })
+
+    const selectingAsk = runtime.setPermissionProfile({
+      sessionId: session.sessionId,
+      profile: 'ask'
+    })
+    await askModeEntered.promise
+    const prompting = runtime.sendPrompt({ sessionId: session.sessionId, text: 'run a command' })
+    const permission = await permissionSeen.promise
+
+    expect(permissionResponse).toBeUndefined()
+    releaseAskMode.resolve()
+    await expect(selectingAsk).resolves.toBeDefined()
+    runtime.respondToPermission({ requestId: permission.requestId, cancelled: true })
+    await expect(prompting).resolves.toMatchObject({ stopReason: 'end_turn' })
+  })
+
+  it('restores the committed profile when the provider mode change fails', async () => {
+    const process = new FakeAgentProcess()
+    const permissionSeen = vi.fn()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'live-permission-session',
+      toolCallId: 'live-permission-tool',
+      toolTitle: 'Run command',
+      modes: createModes(['default', 'bypassPermissions']),
+      onSetMode: ({ modeId }) => {
+        if (modeId === 'default') throw new Error('set mode failed')
+      },
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onPermissionRequest: permissionSeen }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'full' })
+
+    await expect(
+      runtime.setPermissionProfile({ sessionId: session.sessionId, profile: 'ask' })
+    ).rejects.toMatchObject({ data: { details: 'set mode failed' } })
+    await expect(
+      runtime.sendPrompt({ sessionId: session.sessionId, text: 'run a command' })
+    ).resolves.toMatchObject({ stopReason: 'end_turn' })
+
+    expect(permissionSeen).not.toHaveBeenCalled()
+    expect(permissionResponse).toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(runtime.getSnapshot().permissionProfiles[session.sessionId]).toMatchObject({
+      selectedProfile: 'full',
+      effectiveProfile: 'full'
+    })
+  })
+
   it('lets the latest overlapping profile change commit without releasing pending permission', async () => {
     const process = new FakeAgentProcess()
     const permissionSeen = createDeferred<AcpPermissionRequest>()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -6488,6 +6488,45 @@ describe('ACP runtime session management', () => {
     })
   })
 
+  it('refreshes the live profile when resuming an attached session', async () => {
+    const process = new FakeAgentProcess()
+    const permissionSeen = createDeferred<AcpPermissionRequest>()
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'live-permission-session',
+      toolCallId: 'live-permission-tool',
+      toolTitle: 'Run command',
+      modes: createModes(['default', 'bypassPermissions']),
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onPermissionRequest: (request) => permissionSeen.resolve(request) }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+    await runtime.setPermissionProfile({ sessionId: session.sessionId, profile: 'full' })
+
+    await runtime.resumeSession({
+      sessionId: session.sessionId,
+      cwd: '/workspace',
+      permissionProfile: 'ask'
+    })
+    const prompting = runtime.sendPrompt({ sessionId: session.sessionId, text: 'run a command' })
+    const permission = await permissionSeen.promise
+
+    expect(permissionResponse).toBeUndefined()
+    expect(runtime.getSnapshot().permissionProfiles[session.sessionId]).toMatchObject({
+      selectedProfile: 'ask',
+      effectiveProfile: 'ask'
+    })
+    runtime.respondToPermission({ requestId: permission.requestId, cancelled: true })
+    await expect(prompting).resolves.toMatchObject({ stopReason: 'end_turn' })
+  })
+
   it('lets the latest overlapping profile change commit without releasing pending permission', async () => {
     const process = new FakeAgentProcess()
     const permissionSeen = createDeferred<AcpPermissionRequest>()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -653,10 +653,19 @@ class AcpRuntime {
       throw new Error('ACP session startup was superseded.')
     }
     this.assertCurrentConnectedConnection(connection)
+    await this.permissionContext.applyPermissionProfile(
+      request.sessionId,
+      permissionProfile,
+      () => state.revision === revision
+    )
+    if (state.revision !== revision) return this.getSnapshot()
+    if (this.activeSessionFor(request.sessionId) !== session) {
+      throw new Error('ACP session startup was superseded.')
+    }
+    this.assertCurrentConnectedConnection(connection)
     this.sessionRegistry
       .lookup(request.sessionId)
       ?.aggregate.setPermissionProfile(structuredClone(permissionProfile))
-    await this.permissionContext.applyPermissionProfile(request.sessionId, permissionProfile)
     this.emitState()
 
     return this.getSnapshot()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -656,7 +656,7 @@ class AcpRuntime {
 
     // Make the requested posture authoritative before the provider mode request can yield. A
     // downgrade from Full must affect broker decisions immediately, even while setMode is in flight.
-    this.permissionContext.setLivePermissionProfile(
+    this.permissionContext.beginPermissionProfileTransition(
       request.sessionId,
       requestedPermissionProfile,
       isCurrent
@@ -704,6 +704,7 @@ class AcpRuntime {
     this.sessionRegistry
       .lookup(request.sessionId)
       ?.aggregate.setPermissionProfile(structuredClone(permissionProfile))
+    this.permissionContext.setLivePermissionProfile(request.sessionId, permissionProfile)
     this.emitState()
 
     return this.getSnapshot()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -507,10 +507,6 @@ class AcpRuntime {
     ].map(({ sessionId }) => sessionId)
   }
 
-  private hasSessionInteractionInFlight(sessionId: string): boolean {
-    return this.sessionInteractions.current(sessionId) !== undefined
-  }
-
   // Run ids of turns currently in flight, from live in-memory state (not the persisted current-run
   // handoff, which survives a crash). The artifact orphan scan uses this to exclude files a running
   // turn is still writing, while a crashed run — absent here — correctly surfaces as orphaned.
@@ -592,8 +588,8 @@ class AcpRuntime {
     return this.withOperationLease(() => this.contextCompactionWorkflow.compact(request))
   }
 
-  // Changes approval behavior only while the conversation is idle. Applying the ACP mode before the
-  // next prompt guarantees Full access cannot show a first-tool permission race.
+  // Applies the Agent mode first, then releases any pending provider request that the new profile can
+  // safely approve. The aggregate is committed before release so subsequent calls observe the change.
   async setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<AcpStateSnapshot> {
     return this.withOperationLease(() => this.setPermissionProfileOperation(request))
   }
@@ -604,12 +600,6 @@ class AcpRuntime {
     const session = this.activeSessionFor(request.sessionId)
 
     if (!session) throw new Error(`ACP session not found: ${request.sessionId}`)
-    if (this.hasSessionInteractionInFlight(request.sessionId)) {
-      throw new Error('Permission profile cannot be changed while the Agent is running.')
-    }
-    if (this.permissionContext.hasPendingForSession(request.sessionId)) {
-      throw new Error('Resolve the pending permission request before changing profiles.')
-    }
 
     const connection = this.connection
     if (!connection) throw new Error('ACP connection is not available.')
@@ -626,6 +616,7 @@ class AcpRuntime {
     this.sessionRegistry
       .lookup(request.sessionId)
       ?.aggregate.setPermissionProfile(structuredClone(permissionProfile))
+    await this.permissionContext.applyPermissionProfile(request.sessionId, permissionProfile)
     this.emitState()
 
     return this.getSnapshot()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -636,6 +636,9 @@ class AcpRuntime {
     const session = this.activeSessionFor(request.sessionId)
 
     if (!session) throw new Error(`ACP session not found: ${request.sessionId}`)
+    if (this.sessionInteractions.current(request.sessionId)?.kind === 'compaction') {
+      throw new Error('Permission profile cannot be changed while the Agent is compacting.')
+    }
 
     const connection = this.connection
     if (!connection) throw new Error('ACP connection is not available.')

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -642,15 +642,50 @@ class AcpRuntime {
 
     const connection = this.connection
     if (!connection) throw new Error('ACP connection is not available.')
-    const permissionProfile = await this.sessionConfigurator.configurePermissionProfile(
-      {
-        backend: this.backend,
-        connection,
-        session,
-        permissionProfile: request.profile
-      },
-      true
+    const backend = this.backend
+    const aggregate = this.sessionRegistry.lookup(request.sessionId)?.aggregate
+    const previousPermissionProfile = aggregate?.snapshot().permissionProfile
+    const requestedPermissionProfile = backend.framework.mapPermissionProfile(
+      request.profile,
+      session.modes
+    ).state
+    const isCurrent = (): boolean =>
+      state.revision === revision &&
+      this.connection === connection &&
+      this.activeSessionFor(request.sessionId) === session
+
+    // Make the requested posture authoritative before the provider mode request can yield. A
+    // downgrade from Full must affect broker decisions immediately, even while setMode is in flight.
+    this.permissionContext.setLivePermissionProfile(
+      request.sessionId,
+      requestedPermissionProfile,
+      isCurrent
     )
+
+    let permissionProfile
+    try {
+      permissionProfile = await this.sessionConfigurator.configurePermissionProfile(
+        {
+          backend,
+          connection,
+          session,
+          permissionProfile: request.profile
+        },
+        true
+      )
+    } catch (error) {
+      if (previousPermissionProfile && isCurrent()) {
+        this.permissionContext.setLivePermissionProfile(
+          request.sessionId,
+          {
+            ...previousPermissionProfile,
+            availableModeIds: [...previousPermissionProfile.availableModeIds]
+          },
+          isCurrent
+        )
+      }
+      throw error
+    }
     if (state.revision !== revision) return this.getSnapshot()
     if (this.activeSessionFor(request.sessionId) !== session) {
       throw new Error('ACP session startup was superseded.')

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -324,6 +324,10 @@ class AcpRuntime {
   private readonly providerSessionResumer: AcpProviderSessionResumer
   private readonly sessionReplacement: AcpSessionReplacementWorkflow
   private readonly sessionDeletion: AcpSessionDeletionWorkflow
+  private readonly permissionProfileChanges = new Map<
+    string,
+    { revision: number; tail: Promise<void> }
+  >()
 
   // Wires runtime dependencies and forwards permission prompts into the event stream.
   constructor(
@@ -588,27 +592,63 @@ class AcpRuntime {
     return this.withOperationLease(() => this.contextCompactionWorkflow.compact(request))
   }
 
-  // Applies the Agent mode first, then releases any pending provider request that the new profile can
-  // safely approve. The aggregate is committed before release so subsequent calls observe the change.
+  // Serializes changes per Session and coalesces queued requests so only the latest selection can
+  // commit or release a pending provider request. The operation lease covers time spent in the queue.
   async setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<AcpStateSnapshot> {
-    return this.withOperationLease(() => this.setPermissionProfileOperation(request))
+    return this.withOperationLease(() => this.enqueuePermissionProfileChange(request))
+  }
+
+  private enqueuePermissionProfileChange(
+    request: AcpSetPermissionProfileRequest
+  ): Promise<AcpStateSnapshot> {
+    const state = this.permissionProfileChanges.get(request.sessionId) ?? {
+      revision: 0,
+      tail: Promise.resolve()
+    }
+    const revision = ++state.revision
+    const operation = state.tail.then(() =>
+      this.setPermissionProfileOperation(request, state, revision)
+    )
+    state.tail = operation.then(
+      () => undefined,
+      () => undefined
+    )
+    this.permissionProfileChanges.set(request.sessionId, state)
+    void state.tail.then(() => {
+      if (
+        this.permissionProfileChanges.get(request.sessionId) === state &&
+        state.revision === revision
+      ) {
+        this.permissionProfileChanges.delete(request.sessionId)
+      }
+    })
+
+    return operation
   }
 
   private async setPermissionProfileOperation(
-    request: AcpSetPermissionProfileRequest
+    request: AcpSetPermissionProfileRequest,
+    state: { revision: number },
+    revision: number
   ): Promise<AcpStateSnapshot> {
+    if (state.revision !== revision) return this.getSnapshot()
+
     const session = this.activeSessionFor(request.sessionId)
 
     if (!session) throw new Error(`ACP session not found: ${request.sessionId}`)
 
     const connection = this.connection
     if (!connection) throw new Error('ACP connection is not available.')
-    const permissionProfile = await this.sessionConfigurator.configurePermissionProfile({
-      backend: this.backend,
-      connection,
-      session,
-      permissionProfile: request.profile
-    })
+    const permissionProfile = await this.sessionConfigurator.configurePermissionProfile(
+      {
+        backend: this.backend,
+        connection,
+        session,
+        permissionProfile: request.profile
+      },
+      true
+    )
+    if (state.revision !== revision) return this.getSnapshot()
     if (this.activeSessionFor(request.sessionId) !== session) {
       throw new Error('ACP session startup was superseded.')
     }

--- a/src/main/acp/session-configurator.ts
+++ b/src/main/acp/session-configurator.ts
@@ -87,9 +87,10 @@ export class AcpSessionConfigurator {
   }
 
   async configurePermissionProfile(
-    input: StartupConfiguration
+    input: StartupConfiguration,
+    forcePermissionMode = false
   ): Promise<Readonly<SessionPermissionProfileState>> {
-    return deepFreeze(structuredClone(await this.applyPermissionMode(input)))
+    return deepFreeze(structuredClone(await this.applyPermissionMode(input, forcePermissionMode)))
   }
 
   async applyLiveEffort(input: LiveEffortConfiguration): Promise<AcpLiveEffortConfigurationFacts> {
@@ -123,13 +124,17 @@ export class AcpSessionConfigurator {
   }
 
   private async applyPermissionMode(
-    input: StartupConfiguration
+    input: StartupConfiguration,
+    forcePermissionMode = false
   ): Promise<SessionPermissionProfileState> {
     const application = input.backend.framework.mapPermissionProfile(
       input.permissionProfile,
       input.session.modes
     )
-    if (application.modeId && application.modeId !== input.session.modes?.currentModeId) {
+    if (
+      application.modeId &&
+      (forcePermissionMode || application.modeId !== input.session.modes?.currentModeId)
+    ) {
       this.deps.assertCurrentConnection(input.connection)
       await input.connection.agent.request(acp.methods.agent.session.setMode, {
         sessionId: input.session.sessionId,

--- a/src/main/acp/session-replacement-workflow.test.ts
+++ b/src/main/acp/session-replacement-workflow.test.ts
@@ -46,6 +46,7 @@ describe('AcpSessionReplacementWorkflow', () => {
       contextReset: true
     }
     const cancelPermissionFlow = vi.fn()
+    const clearLivePermissionProfile = vi.fn()
     const resetPromptContent = vi.fn()
     const resetContextUsage = vi.fn()
     const supersedeInteraction = vi.fn()
@@ -61,7 +62,7 @@ describe('AcpSessionReplacementWorkflow', () => {
       reserveIdentity: (sessionId, publishedAppSessionId) =>
         registry.reserve({ sessionIds: [sessionId], publishedAppSessionId }),
       adopter: { adopt },
-      permission: { cancelForSession: cancelPermissionFlow },
+      permission: { cancelForSession: cancelPermissionFlow, clearLivePermissionProfile },
       promptContent: { resetSession: resetPromptContent },
       contextUsage: { deleteSession: resetContextUsage },
       interactions: { current: vi.fn(), supersedeCurrent: supersedeInteraction }
@@ -79,6 +80,7 @@ describe('AcpSessionReplacementWorkflow', () => {
     expect(dispose).toHaveBeenCalledOnce()
     expect(registry.lookup('app-session')?.attachment).toBeUndefined()
     expect(cancelPermissionFlow).toHaveBeenCalledWith('app-session')
+    expect(clearLivePermissionProfile).toHaveBeenCalledWith('app-session')
     expect(resetPromptContent).toHaveBeenCalledWith('app-session')
     expect(resetContextUsage).toHaveBeenCalledWith('app-session')
     expect(supersedeInteraction).toHaveBeenCalledWith('app-session')
@@ -120,7 +122,7 @@ describe('AcpSessionReplacementWorkflow', () => {
       reserveIdentity: (sessionId, publishedAppSessionId) =>
         registry.reserve({ sessionIds: [sessionId], publishedAppSessionId }),
       adopter: { adopt },
-      permission: { cancelForSession: vi.fn() },
+      permission: { cancelForSession: vi.fn(), clearLivePermissionProfile: vi.fn() },
       promptContent: { resetSession: vi.fn() },
       contextUsage: { deleteSession: vi.fn() },
       interactions: { current: vi.fn(), supersedeCurrent: vi.fn() }
@@ -158,7 +160,7 @@ describe('AcpSessionReplacementWorkflow', () => {
       reserveIdentity: (sessionId, publishedAppSessionId) =>
         registry.reserve({ sessionIds: [sessionId], publishedAppSessionId }),
       adopter: { adopt },
-      permission: { cancelForSession: vi.fn() },
+      permission: { cancelForSession: vi.fn(), clearLivePermissionProfile: vi.fn() },
       promptContent: { resetSession: vi.fn() },
       contextUsage: { deleteSession: vi.fn() },
       interactions: { current: vi.fn(), supersedeCurrent: vi.fn() },
@@ -207,7 +209,7 @@ describe('AcpSessionReplacementWorkflow', () => {
         registry,
         reserveIdentity: vi.fn(),
         adopter: { adopt },
-        permission: { cancelForSession: vi.fn() },
+        permission: { cancelForSession: vi.fn(), clearLivePermissionProfile: vi.fn() },
         promptContent: { resetSession: vi.fn() },
         contextUsage: { deleteSession: vi.fn() },
         interactions: { current: vi.fn(), supersedeCurrent: vi.fn() },
@@ -250,7 +252,7 @@ describe('AcpSessionReplacementWorkflow', () => {
       registry,
       reserveIdentity: vi.fn(),
       adopter: { adopt: vi.fn() },
-      permission: { cancelForSession: vi.fn() },
+      permission: { cancelForSession: vi.fn(), clearLivePermissionProfile: vi.fn() },
       promptContent: { resetSession: vi.fn() },
       contextUsage: { deleteSession: vi.fn() },
       interactions: {

--- a/src/main/acp/session-replacement-workflow.ts
+++ b/src/main/acp/session-replacement-workflow.ts
@@ -26,7 +26,7 @@ type AcpSessionReplacementWorkflowDependencies = Readonly<{
     publishedAppSessionId?: string
   ) => AcpPrimarySessionIdentityReservationResult
   adopter: Pick<AcpProviderSessionAdopter, 'adopt'>
-  permission: Pick<AcpPermissionContext, 'cancelForSession'>
+  permission: Pick<AcpPermissionContext, 'cancelForSession' | 'clearLivePermissionProfile'>
   promptContent: Pick<AcpPromptContentOwner, 'resetSession'>
   contextUsage: Pick<ContextUsageTracker, 'deleteSession'>
   interactions: Pick<AcpSessionInteractionOwner, 'current' | 'supersedeCurrent'>
@@ -70,6 +70,7 @@ export class AcpSessionReplacementWorkflow {
       }
 
       this.deps.permission.cancelForSession(request.sessionId)
+      this.deps.permission.clearLivePermissionProfile(request.sessionId)
       const attachment = this.deps.registry.lookup(request.sessionId)?.attachment
       if (attachment) {
         attachment.session.dispose()

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -2,6 +2,8 @@ import type { SessionNotification } from '@agentclientprotocol/sdk'
 import { join, resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
+import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
+
 import { AcpSessionUpdateProjector } from './session-update-projector'
 
 type TestRouting = Readonly<{
@@ -24,7 +26,15 @@ type TestProjector = Readonly<{
   route: (notification: SessionNotification, routing: TestRouting) => readonly RecordedEffect[]
 }>
 
-const createProjector = (): TestProjector => {
+const createProjector = (
+  initialPermissionProfile: SessionPermissionProfileState = {
+    selectedProfile: 'ask',
+    effectiveProfile: 'ask',
+    currentModeId: 'default',
+    availableModeIds: ['default', 'bypassPermissions'],
+    fullAccessAvailable: true
+  }
+): TestProjector => {
   let routing: TestRouting = {
     eventId: 'event-route',
     visible: true,
@@ -32,6 +42,7 @@ const createProjector = (): TestProjector => {
     mcpServerNames: []
   }
   let effects: RecordedEffect[] = []
+  let permissionProfile = initialPermissionProfile
   const record = (effect: RecordedEffect): void => {
     effects.push(Object.freeze(effect))
   }
@@ -42,20 +53,17 @@ const createProjector = (): TestProjector => {
           aggregate: {
             snapshot: () => ({
               frameworkId: routing.framework,
-              permissionProfile: {
-                selectedProfile: 'ask',
-                effectiveProfile: 'ask',
-                currentModeId: 'default',
-                availableModeIds: ['default', 'bypassPermissions'],
-                fullAccessAvailable: true
-              }
+              permissionProfile
             }),
-            setPermissionProfile: (profile: { currentModeId?: string }) =>
+            setPermissionProfile: (profile: SessionPermissionProfileState) => {
+              permissionProfile = profile
               record({
                 kind: 'current-mode',
                 sessionId,
-                currentModeId: profile.currentModeId
+                currentModeId: profile.currentModeId,
+                selectedProfile: profile.selectedProfile
               })
+            }
           }
         }) as never
     },
@@ -79,6 +87,8 @@ const createProjector = (): TestProjector => {
     reconnectPending: () => routing.reconnectPending,
     mcpServerNamesFor: () => routing.mcpServerNames,
     nextEventId: () => routing.eventId,
+    setLivePermissionProfile: (sessionId, profile) =>
+      record({ kind: 'live-profile', sessionId, selectedProfile: profile.selectedProfile }),
     emitState: () => undefined,
     pushEvent: (event) => record({ kind: 'visible-event', event }),
     reportToolFailure: (effect) => record(effect)
@@ -132,6 +142,7 @@ describe('AcpSessionUpdateProjector', () => {
       reconnectPending: () => false,
       mcpServerNamesFor: () => [],
       nextEventId,
+      setLivePermissionProfile: () => undefined,
       emitState: () => journal.push('state:emit'),
       pushEvent: () => journal.push('event:push'),
       reportToolFailure: () => journal.push('diagnostic')
@@ -328,11 +339,17 @@ describe('AcpSessionUpdateProjector', () => {
     })
   })
 
-  it('projects hidden current-mode updates while a reconnect suppresses stale context effects', () => {
-    const projector = createProjector()
+  it('synchronizes hidden current-mode downgrades with the live permission profile', () => {
+    const projector = createProjector({
+      selectedProfile: 'full',
+      effectiveProfile: 'full',
+      currentModeId: 'bypassPermissions',
+      availableModeIds: ['default', 'bypassPermissions'],
+      fullAccessAvailable: true
+    })
     const notification: SessionNotification = {
       sessionId: 'session-1',
-      update: { sessionUpdate: 'current_mode_update', currentModeId: 'bypassPermissions' }
+      update: { sessionUpdate: 'current_mode_update', currentModeId: 'default' }
     }
     const routing = {
       eventId: 'event-mode',
@@ -345,7 +362,13 @@ describe('AcpSessionUpdateProjector', () => {
       {
         kind: 'current-mode',
         sessionId: 'session-1',
-        currentModeId: 'bypassPermissions'
+        currentModeId: 'default',
+        selectedProfile: 'ask'
+      },
+      {
+        kind: 'live-profile',
+        sessionId: 'session-1',
+        selectedProfile: 'ask'
       }
     ])
   })

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -87,7 +87,7 @@ const createProjector = (
     reconnectPending: () => routing.reconnectPending,
     mcpServerNamesFor: () => routing.mcpServerNames,
     nextEventId: () => routing.eventId,
-    setLivePermissionProfile: (sessionId, profile) =>
+    setProviderPermissionProfile: (sessionId, profile) =>
       record({ kind: 'live-profile', sessionId, selectedProfile: profile.selectedProfile }),
     emitState: () => undefined,
     pushEvent: (event) => record({ kind: 'visible-event', event }),
@@ -142,7 +142,7 @@ describe('AcpSessionUpdateProjector', () => {
       reconnectPending: () => false,
       mcpServerNamesFor: () => [],
       nextEventId,
-      setLivePermissionProfile: () => undefined,
+      setProviderPermissionProfile: () => undefined,
       emitState: () => journal.push('state:emit'),
       pushEvent: () => journal.push('event:push'),
       reportToolFailure: () => journal.push('diagnostic')

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -33,7 +33,8 @@ const createProjector = (
     currentModeId: 'default',
     availableModeIds: ['default', 'bypassPermissions'],
     fullAccessAvailable: true
-  }
+  },
+  acceptProviderPermissionProfile = true
 ): TestProjector => {
   let routing: TestRouting = {
     eventId: 'event-route',
@@ -87,8 +88,11 @@ const createProjector = (
     reconnectPending: () => routing.reconnectPending,
     mcpServerNamesFor: () => routing.mcpServerNames,
     nextEventId: () => routing.eventId,
-    setProviderPermissionProfile: (sessionId, profile) =>
-      record({ kind: 'live-profile', sessionId, selectedProfile: profile.selectedProfile }),
+    setProviderPermissionProfile: (sessionId, profile) => {
+      if (!acceptProviderPermissionProfile) return false
+      record({ kind: 'live-profile', sessionId, selectedProfile: profile.selectedProfile })
+      return true
+    },
     emitState: () => undefined,
     pushEvent: (event) => record({ kind: 'visible-event', event }),
     reportToolFailure: (effect) => record(effect)
@@ -142,7 +146,7 @@ describe('AcpSessionUpdateProjector', () => {
       reconnectPending: () => false,
       mcpServerNamesFor: () => [],
       nextEventId,
-      setProviderPermissionProfile: () => undefined,
+      setProviderPermissionProfile: () => true,
       emitState: () => journal.push('state:emit'),
       pushEvent: () => journal.push('event:push'),
       reportToolFailure: () => journal.push('diagnostic')
@@ -360,17 +364,45 @@ describe('AcpSessionUpdateProjector', () => {
 
     expect(projector.route(notification, routing)).toMatchObject([
       {
+        kind: 'live-profile',
+        sessionId: 'session-1',
+        selectedProfile: 'ask'
+      },
+      {
         kind: 'current-mode',
         sessionId: 'session-1',
         currentModeId: 'default',
         selectedProfile: 'ask'
-      },
-      {
-        kind: 'live-profile',
-        sessionId: 'session-1',
-        selectedProfile: 'ask'
       }
     ])
+  })
+
+  it('does not project provider modes while a user profile transition owns the state', () => {
+    const projector = createProjector(
+      {
+        selectedProfile: 'full',
+        effectiveProfile: 'full',
+        currentModeId: 'bypassPermissions',
+        availableModeIds: ['default', 'bypassPermissions'],
+        fullAccessAvailable: true
+      },
+      false
+    )
+
+    expect(
+      projector.route(
+        {
+          sessionId: 'session-1',
+          update: { sessionUpdate: 'current_mode_update', currentModeId: 'default' }
+        },
+        {
+          eventId: 'event-mode',
+          visible: false,
+          reconnectPending: false,
+          mcpServerNames: []
+        }
+      )
+    ).toMatchObject([{ kind: 'context-observation', sessionId: 'session-1' }])
   })
 
   it('classifies MCP context and emits a bounded canonical failure diagnostic before the event', () => {

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -47,7 +47,7 @@ type AcpSessionUpdateProjectorOptions = Readonly<{
   reconnectPending: () => boolean
   mcpServerNamesFor: (sessionId: string) => readonly string[]
   nextEventId: () => string
-  setLivePermissionProfile: (
+  setProviderPermissionProfile: (
     sessionId: string,
     profile: Readonly<SessionPermissionProfileState>
   ) => void
@@ -272,7 +272,7 @@ class AcpSessionUpdateProjector {
             effect.currentModeId
           )
           aggregate.setPermissionProfile(nextProfile)
-          this.options.setLivePermissionProfile(effect.sessionId, nextProfile)
+          this.options.setProviderPermissionProfile(effect.sessionId, nextProfile)
           emitState()
         }
         break

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -47,6 +47,10 @@ type AcpSessionUpdateProjectorOptions = Readonly<{
   reconnectPending: () => boolean
   mcpServerNamesFor: (sessionId: string) => readonly string[]
   nextEventId: () => string
+  setLivePermissionProfile: (
+    sessionId: string,
+    profile: Readonly<SessionPermissionProfileState>
+  ) => void
   emitState: () => void
   pushEvent: (event: Readonly<AcpRuntimeEvent>) => void
   reportToolFailure: (
@@ -263,12 +267,12 @@ class AcpSessionUpdateProjector {
         const aggregate = this.options.registry.lookup(effect.sessionId)?.aggregate
         const profileState = aggregate?.snapshot().permissionProfile
         if (profileState) {
-          aggregate.setPermissionProfile(
-            applyCurrentModeUpdate(
-              profileState as SessionPermissionProfileState,
-              effect.currentModeId
-            )
+          const nextProfile = applyCurrentModeUpdate(
+            profileState as SessionPermissionProfileState,
+            effect.currentModeId
           )
+          aggregate.setPermissionProfile(nextProfile)
+          this.options.setLivePermissionProfile(effect.sessionId, nextProfile)
           emitState()
         }
         break

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -50,7 +50,7 @@ type AcpSessionUpdateProjectorOptions = Readonly<{
   setProviderPermissionProfile: (
     sessionId: string,
     profile: Readonly<SessionPermissionProfileState>
-  ) => void
+  ) => boolean
   emitState: () => void
   pushEvent: (event: Readonly<AcpRuntimeEvent>) => void
   reportToolFailure: (
@@ -271,8 +271,8 @@ class AcpSessionUpdateProjector {
             profileState as SessionPermissionProfileState,
             effect.currentModeId
           )
+          if (!this.options.setProviderPermissionProfile(effect.sessionId, nextProfile)) break
           aggregate.setPermissionProfile(nextProfile)
-          this.options.setProviderPermissionProfile(effect.sessionId, nextProfile)
           emitState()
         }
         break

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -26,6 +26,7 @@ import {
   resendEditedWorkspaceMessage,
   resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage,
+  setWorkspacePermissionProfile,
   syncWorkspaceContextUsage
 } from './useWorkspaceAgentRuntime'
 
@@ -79,6 +80,37 @@ const flushRuntimeTasks = async (): Promise<void> => {
   await Promise.resolve()
   await Promise.resolve()
 }
+
+describe('workspace permission profile persistence', () => {
+  it('persists the profile committed by the runtime instead of a superseded request', async () => {
+    useSessionStore.setState(createInitialSessionState())
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Test permission mode',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      permissionProfile: 'full'
+    })
+    const committedSnapshot = createSnapshot(['session-1'])
+    committedSnapshot.permissionProfiles['session-1'] = {
+      selectedProfile: 'ask',
+      effectiveProfile: 'ask',
+      availableModeIds: [],
+      fullAccessAvailable: true
+    }
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      setPermissionProfile: vi.fn().mockResolvedValue(committedSnapshot)
+    }
+
+    await expect(setWorkspacePermissionProfile(runtime, 'session-1', 'full')).resolves.toBe(true)
+
+    expect(runtime.setPermissionProfile).toHaveBeenCalledWith('session-1', 'full')
+    expect(
+      useSessionStore.getState().sessions.find(({ id }) => id === 'session-1')?.permissionProfile
+    ).toBe('ask')
+  })
+})
 
 describe('workspace agent runtime event processing', () => {
   it('does not mark failed runtime events as processed so they can retry', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -178,6 +178,10 @@ type WorkspaceMessageRuntime = Pick<
 
 type WorkspaceDeletionRuntime = Pick<ReturnType<typeof useAcpRuntime>, 'deleteSession'>
 type WorkspaceCancellationRuntime = Pick<ReturnType<typeof useAcpRuntime>, 'cancel'>
+type WorkspacePermissionProfileRuntime = Pick<
+  ReturnType<typeof useAcpRuntime>,
+  'state' | 'setPermissionProfile'
+>
 type PersistSessionDeletion = (request: { projectId: string; sessionId: string }) => Promise<void>
 
 type RuntimeEventApplier = (event: AcpRuntimeEvent) => Promise<boolean>
@@ -191,6 +195,24 @@ type WorkspaceRuntimeEventProcessor = {
 // run. Keep duplicate preparations closed during that idle-looking interval without exposing a
 // premature activeRun that a draining runtime's terminal event could settle.
 const sessionSendPreparationsInFlight = new Set<string>()
+
+const setWorkspacePermissionProfile = async (
+  runtime: WorkspacePermissionProfileRuntime,
+  sessionId: string,
+  profile: PermissionProfileId
+): Promise<boolean> => {
+  let persistedProfile = profile
+  if (runtime.state.sessionIds.includes(sessionId)) {
+    const snapshot = await runtime.setPermissionProfile(sessionId, profile)
+    const committedProfile = snapshot?.permissionProfiles[sessionId]?.selectedProfile
+
+    if (!committedProfile) return false
+    persistedProfile = committedProfile
+  }
+
+  useSessionStore.getState().setPermissionProfile(sessionId, persistedProfile)
+  return true
+}
 
 // Strips the Electron IPC wrapper ("Error invoking remote method '…': Error: <cause>") and any
 // leading "Error:" (or a lone "Error" type label) so the underlying agent message can be shown to the
@@ -2135,16 +2157,8 @@ const useWorkspaceAgentRuntime = (): {
   // Applies attached-session mode changes before persisting the selection. Detached sessions store
   // the preference now and reapply it during resume before their next prompt.
   const setPermissionProfile = useCallback(
-    async (sessionId: string, profile: PermissionProfileId): Promise<boolean> => {
-      if (runtime.state.sessionIds.includes(sessionId)) {
-        const snapshot = await runtime.setPermissionProfile(sessionId, profile)
-
-        if (!snapshot) return false
-      }
-
-      useSessionStore.getState().setPermissionProfile(sessionId, profile)
-      return true
-    },
+    (sessionId: string, profile: PermissionProfileId): Promise<boolean> =>
+      setWorkspacePermissionProfile(runtime, sessionId, profile),
     [runtime]
   )
 
@@ -2196,6 +2210,7 @@ export {
   resendEditedWorkspaceMessage,
   resumeInterruptedWorkspaceSession,
   sendWorkspaceMessage,
+  setWorkspacePermissionProfile,
   syncWorkspaceContextUsage,
   useWorkspaceAgentRuntime
 }

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
@@ -596,6 +596,39 @@ describe('ComposerAgentControlsMenu', () => {
     expect(revokeButton?.disabled).toBe(true)
   })
 
+  it('keeps only permission mode editable when other agent controls are read-only', () => {
+    act(() => {
+      root.render(
+        <ComposerAgentControlsMenu
+          profile="ask"
+          autoReviewEnabled={false}
+          readOnly={true}
+          permissionProfileReadOnly={false}
+          enabledComputeHosts={[]}
+          showSpecialist
+          onProfileChange={vi.fn()}
+          onAutoReviewChange={vi.fn()}
+          onComputeHostToggle={vi.fn()}
+        />
+      )
+    })
+
+    expect(
+      findButton(
+        'Auto-approve editsAuto-approve edits to files in the workspace. Still ask before commands, network, and MCP.'
+      ).disabled
+    ).toBe(false)
+    expect(
+      findButton('Auto-reviewA reviewer agent checks every change before it lands.').disabled
+    ).toBe(true)
+    expect(findButton('cluster-1').disabled).toBe(true)
+    expect(
+      container
+        .querySelector('[data-testid="specialist-submenu-stub"]')
+        ?.getAttribute('data-read-only')
+    ).toBe('true')
+  })
+
   it('keeps conversation grant actions available while profile controls are read-only', () => {
     const onRevokeGrant = vi.fn()
     const onClearGrants = vi.fn()

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
@@ -857,7 +857,7 @@ describe('ComposerAgentControlsMenu', () => {
         <ComposerAgentControlsMenu
           profile="ask"
           autoReviewEnabled={false}
-          readOnly // session running -> mutating controls frozen
+          readOnly
           showSpecialist
           specialistId="uuid-1"
           onSpecialistChange={vi.fn()}

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
@@ -262,7 +262,7 @@ const ComposerAgentControlsMenu = ({
       <span className="min-w-0 flex-1">
         <span className="block text-[13px] font-medium leading-5">Permission mode</span>
         <span className="block text-[11px] leading-4 text-text-300">
-          How much the agent can do without asking first.
+          Applies to future actions; completed actions are unchanged.
         </span>
       </span>
       <span

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
@@ -74,6 +74,8 @@ type ComposerAgentControlsMenuProps = {
   // Read-only while a session is running: the menu stays openable and the permission
   // submenu still expands on hover, but profiles, auto-review, and compute stay immutable.
   readOnly?: boolean
+  // Permission mode remains independently editable during a running prompt.
+  permissionProfileReadOnly?: boolean
   // Grant revocation remains independently available while a turn is running.
   grantActionsReadOnly?: boolean
   autoReviewDisabled?: boolean
@@ -140,6 +142,7 @@ const ComposerAgentControlsMenu = ({
   grants,
   autoReviewEnabled,
   readOnly = false,
+  permissionProfileReadOnly = readOnly,
   grantActionsReadOnly = readOnly,
   autoReviewDisabled = false,
   onProfileChange,
@@ -209,7 +212,7 @@ const ComposerAgentControlsMenu = ({
         return (
           <DropdownMenuItem
             key={candidate.id}
-            disabled={readOnly || isDisabled}
+            disabled={permissionProfileReadOnly || isDisabled}
             className="items-center gap-2 px-2 py-1.5"
             onSelect={() => selectProfile(candidate.id)}
           >
@@ -597,6 +600,7 @@ const ComposerAgentControlsMenu = ({
               <AlertDialog.Action asChild>
                 <Button
                   type="button"
+                  disabled={permissionProfileReadOnly || fullAccessUnavailable}
                   className="bg-amber-600 text-white hover:bg-amber-700"
                   onClick={() => onProfileChange('full')}
                 >

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -185,6 +185,7 @@ const renderPanel = (props: Partial<Parameters<typeof ConversationPanel>[0]> = {
         permissionProfileState={undefined}
         permissionGrants={[]}
         contextUsage={undefined}
+        canChangeAgentControls
         canChangePermissionProfile
         onDraftDocChange={vi.fn()}
         onSendMessage={vi.fn()}

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -146,6 +146,7 @@ type ConversationPanelProps = {
   canCompactContext?: boolean
   compactContextDisabledReason?: string
   onCompactContext?: () => void
+  canChangeAgentControls: boolean
   canChangePermissionProfile: boolean
   // Auto-review toggle: whether the current session has auto-review enabled (default false).
   autoReviewEnabled: boolean
@@ -228,6 +229,7 @@ const ConversationPanel = ({
   canCompactContext = false,
   compactContextDisabledReason,
   onCompactContext,
+  canChangeAgentControls,
   canChangePermissionProfile,
   autoReviewEnabled,
   onDraftDocChange,
@@ -896,7 +898,8 @@ const ConversationPanel = ({
                           profileState={permissionProfileState}
                           grants={permissionGrants}
                           autoReviewEnabled={autoReviewEnabled}
-                          readOnly={!canChangePermissionProfile}
+                          readOnly={!canChangeAgentControls}
+                          permissionProfileReadOnly={!canChangePermissionProfile}
                           grantActionsReadOnly={false}
                           autoReviewDisabled={!canEditDraft}
                           enabledComputeHosts={enabledComputeHosts}

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -30,6 +30,7 @@ let conversationProps: {
   canEditDraft: boolean
   canSendMessage: boolean
   canEditMessage: boolean
+  canChangeAgentControls: boolean
   canChangePermissionProfile: boolean
   canCompactContext: boolean
   compactContextDisabledReason?: string
@@ -259,6 +260,7 @@ describe('WorkspacePage send gate while compacting', () => {
 
       await renderPage()
 
+      expect(conversationProps.canChangeAgentControls).toBe(false)
       expect(conversationProps.canChangePermissionProfile).toBe(true)
     }
   )

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -548,6 +548,7 @@ describe('WorkspacePage send gate while compacting', () => {
     expect(conversationProps.canEditDraft).toBe(false)
     expect(conversationProps.canSendMessage).toBe(false)
     expect(conversationProps.canEditMessage).toBe(false)
+    expect(conversationProps.canChangePermissionProfile).toBe(false)
   })
 
   it('blocks new prompts after terminal conversation graph synchronization fails', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -30,6 +30,7 @@ let conversationProps: {
   canEditDraft: boolean
   canSendMessage: boolean
   canEditMessage: boolean
+  canChangePermissionProfile: boolean
   canCompactContext: boolean
   compactContextDisabledReason?: string
   onDraftDocChange: (doc: ComposerDoc) => void
@@ -247,6 +248,20 @@ describe('WorkspacePage send gate while compacting', () => {
     })
     expect(conversationProps.canSendMessage).toBe(true)
   })
+
+  it.each(['running', 'waiting-permission'] as const)(
+    'keeps permission mode editable while the Session is %s',
+    async (status) => {
+      useSessionStore.setState({
+        sessions: [createSession({ status })],
+        selectedSessionId: 'sess-a'
+      })
+
+      await renderPage()
+
+      expect(conversationProps.canChangePermissionProfile).toBe(true)
+    }
+  )
 
   it('unlocks a waiting Session after main drops unreadable Plan authority', async () => {
     useSessionStore.setState({

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1108,12 +1108,7 @@ const WorkspacePage = ({
     useSessionStore.getState().setBranchSwitchBlocked(sessionId, !canEditMessage)
     return () => useSessionStore.getState().setBranchSwitchBlocked(sessionId, false)
   }, [activeSession?.id, canEditMessage])
-  const canChangePermissionProfile =
-    isSessionPersistenceReady &&
-    activeSession?.status !== 'running' &&
-    activeSession?.status !== 'waiting-permission' &&
-    !activeSessionHasRuntimeInteraction &&
-    !activeSession?.compacting
+  const canChangePermissionProfile = isSessionPersistenceReady
   const canCompactContext =
     isSessionPersistenceReady &&
     activeSessionSupportsNativeCompaction &&

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1114,7 +1114,8 @@ const WorkspacePage = ({
     activeSession?.status !== 'waiting-permission' &&
     !activeSessionHasRuntimeInteraction &&
     !activeSession?.compacting
-  const canChangePermissionProfile = isSessionPersistenceReady && !activeSession?.compacting
+  const canChangePermissionProfile =
+    isSessionPersistenceReady && !activeSessionHasSendPreparation && !activeSession?.compacting
   const canCompactContext =
     isSessionPersistenceReady &&
     activeSessionSupportsNativeCompaction &&

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1108,7 +1108,13 @@ const WorkspacePage = ({
     useSessionStore.getState().setBranchSwitchBlocked(sessionId, !canEditMessage)
     return () => useSessionStore.getState().setBranchSwitchBlocked(sessionId, false)
   }, [activeSession?.id, canEditMessage])
-  const canChangePermissionProfile = isSessionPersistenceReady
+  const canChangeAgentControls =
+    isSessionPersistenceReady &&
+    activeSession?.status !== 'running' &&
+    activeSession?.status !== 'waiting-permission' &&
+    !activeSessionHasRuntimeInteraction &&
+    !activeSession?.compacting
+  const canChangePermissionProfile = isSessionPersistenceReady && !activeSession?.compacting
   const canCompactContext =
     isSessionPersistenceReady &&
     activeSessionSupportsNativeCompaction &&
@@ -2481,6 +2487,7 @@ const WorkspacePage = ({
             canCompactContext={canCompactContext}
             compactContextDisabledReason={compactContextDisabledReason}
             onCompactContext={compactActiveContext}
+            canChangeAgentControls={canChangeAgentControls}
             canChangePermissionProfile={canChangePermissionProfile}
             autoReviewEnabled={activeAutoReviewEnabled}
             onDraftDocChange={changeComposerDraftDoc}


### PR DESCRIPTION
## Problem

Permission modes were read-only while an Agent turn was running or waiting for approval. Users had to stop the turn before changing the approval posture, even though ACP sessions already support live mode updates.

Closes #828.

## Proposed change

- keep the permission mode control editable while a Session is running or waiting for permission
- apply the Agent's live ACP mode before committing the Session profile
- re-evaluate pending provider tool requests in `AcpPermissionBroker` with the existing automatic-permission policy
  - Auto releases only requests accepted by the existing conservative low-risk policy
  - Full releases eligible provider requests through the provider's one-shot allow option
  - Ask, high-risk requests, and app-owned approvals continue to require explicit user action
- clarify that permission changes affect future actions and do not change completed actions

## Scope and non-goals

- no architecture layer, database schema, data-model, or relationship changes
- no new proactive rule editor; existing session/project/global grant flows remain unchanged
- app-owned privileged confirmations, including Specialist actions, are never auto-approved

## Acceptance criteria and validation

Checks ran after the final rebase onto the latest `origin/main`.

- pending provider request re-evaluation and app-approval isolation -> `vitest run src/main/acp/permission-broker.test.ts -t "re-evaluates pending tool requests"` -> passed
- live `session/set_mode` while a prompt waits for permission -> `vitest run src/main/acp/runtime.test.ts -t "changes permission profile while a prompt is waiting"` -> passed
- running/waiting UI editability and controls interactions -> focused Workspace/Composer tests -> 41 passed
- main-process contracts -> `npm run typecheck:node` -> passed
- renderer contracts -> `npm run typecheck:web` -> passed
- lint -> `npm run lint` -> 0 errors; 17 existing warnings outside this diff
- complete portable suite -> `npm test` (`vitest run`) -> 809 files passed, 14 skipped; 11,901 tests passed, 184 skipped

Consumers and platform lanes: main ACP and renderer consumers are covered by focused tests plus both process typechecks. No persistence, migration, packaging, or platform-specific code changed, so no additional platform lane was included.

Uncovered risk: the runtime integration test uses the repository's in-memory ACP Agent. Live Claude, Codex, and OpenCode adapter processes are not launched locally in this suite; review should confirm their documented live mode behavior remains compatible.

## Review focus

- broker re-evaluation must remain session-scoped and reuse only the projected provider one-shot option
- app-owned approvals must remain human-only
- the runtime must commit the new profile before releasing a pending request so subsequent tool calls observe it
