### PR TITLE
refactor(settings-store): extract runtime discovery slice

### DIFF
--- a/src/renderer/src/stores/settings-runtime-slice.test.ts
+++ b/src/renderer/src/stores/settings-runtime-slice.test.ts
@@ -3,12 +3,17 @@ import { createStore } from 'zustand/vanilla'
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 import type {
+  AgentFrameworkId,
+  ClaudeDetectResult,
+  ClaudeInfo,
   ClaudeInstallEvent,
   ClaudeInstallResult,
+  EnvironmentCheckResult,
   Preflight,
   SettingsSnapshot
 } from '../../../shared/settings'
 import {
+  createRuntimeSetupLoadPatch,
   createRuntimeSetupSlice,
   type RuntimeSetupSlice,
   selectAnyInstalling
@@ -17,6 +22,12 @@ import {
 type RuntimeCommands = Pick<
   Window['api']['settings'],
   | 'getSettings'
+  | 'getPreflight'
+  | 'isNpmAvailable'
+  | 'checkEnvironment'
+  | 'detectClaude'
+  | 'detectOpencode'
+  | 'detectCodex'
   | 'installClaude'
   | 'installOpencode'
   | 'installCodex'
@@ -31,8 +42,13 @@ type RuntimeCommandMocks = {
 }
 
 type TestStore = RuntimeSetupSlice & {
-  refreshPreflight: () => Promise<Preflight>
+  agentFrameworkId: AgentFrameworkId
+  claude: ClaudeInfo
 }
+
+type EnvironmentReconcilePatch = Partial<
+  Pick<RuntimeSetupSlice, 'environmentCheck' | 'preflight' | 'npmAvailable'>
+>
 
 const snapshot = (): SettingsSnapshot => ({
   claude: {},
@@ -60,19 +76,42 @@ const preflight = (): Preflight => ({
   activeProviderReady: false
 })
 
+const environment = (
+  agentFrameworkId: AgentFrameworkId = 'claude-code',
+  checkedAt = 1
+): EnvironmentCheckResult => ({
+  checkedAt,
+  platform: 'darwin',
+  architecture: 'arm64',
+  checks: [],
+  ready: true,
+  canAutoInstall: false,
+  agentFrameworkId,
+  runtime: { found: true, path: `/bin/${agentFrameworkId}` }
+})
+
 const deferred = <T>(): {
   promise: Promise<T>
   resolve: (value: T) => void
+  reject: (error: unknown) => void
 } => {
   let resolve: (value: T) => void = () => undefined
-  const promise = new Promise<T>((done) => {
+  let reject: (error: unknown) => void = () => undefined
+  const promise = new Promise<T>((done, fail) => {
     resolve = done
+    reject = fail
   })
-  return { promise, resolve }
+  return { promise, resolve, reject }
 }
 
 const createCommands = (): RuntimeCommandMocks => ({
   getSettings: vi.fn().mockResolvedValue(snapshot()),
+  getPreflight: vi.fn().mockResolvedValue(preflight()),
+  isNpmAvailable: vi.fn().mockResolvedValue(true),
+  checkEnvironment: vi.fn().mockResolvedValue(environment()),
+  detectClaude: vi.fn().mockResolvedValue({ found: true, path: '/bin/claude', version: '1.0.0' }),
+  detectOpencode: vi.fn().mockResolvedValue(snapshot()),
+  detectCodex: vi.fn().mockResolvedValue(snapshot()),
   installClaude: vi.fn().mockResolvedValue({ installId: 'claude-1', ok: true }),
   installOpencode: vi.fn().mockResolvedValue({ installId: 'opencode-1', ok: true }),
   installCodex: vi.fn().mockResolvedValue({ installId: 'codex-1', ok: true }),
@@ -82,25 +121,56 @@ const createCommands = (): RuntimeCommandMocks => ({
   onInstallLog: vi.fn().mockReturnValue(vi.fn())
 })
 
+const createHarness = (): {
+  commands: RuntimeCommandMocks
+  reconcileSnapshot: Mock<
+    (snapshot: SettingsSnapshot, runtimePatch?: EnvironmentReconcilePatch) => void
+  >
+  reconcileClaudeDetection: Mock<(result: ClaudeDetectResult, npmAvailable: boolean) => void>
+  store: StoreApi<TestStore>
+} => {
+  const commands = createCommands()
+  const reconcileSnapshot = vi.fn(
+    (nextSnapshot: SettingsSnapshot, runtimePatch: EnvironmentReconcilePatch = {}) => {
+      store.setState({ agentFrameworkId: nextSnapshot.agentFrameworkId, ...runtimePatch })
+    }
+  )
+  const reconcileClaudeDetection = vi.fn((result: ClaudeDetectResult, npmAvailable: boolean) => {
+    store.setState(
+      result.found && result.path
+        ? { npmAvailable, claude: { resolvedPath: result.path, version: result.version } }
+        : { npmAvailable }
+    )
+  })
+
+  const store = createStore<TestStore>((set, get) => ({
+    agentFrameworkId: 'claude-code',
+    claude: {},
+    ...createRuntimeSetupSlice({
+      set,
+      get,
+      getCommands: () => commands as RuntimeCommands,
+      reconcileSnapshot,
+      reconcileClaudeDetection
+    })
+  }))
+
+  return { commands, reconcileSnapshot, reconcileClaudeDetection, store }
+}
+
 describe('runtime setup slice: install lifecycle', () => {
   let commands: ReturnType<typeof createCommands>
   let refreshPreflight: Mock<() => Promise<Preflight>>
-  let reconcileSnapshot: Mock<(snapshot: SettingsSnapshot) => void>
+  let reconcileSnapshot: ReturnType<typeof createHarness>['reconcileSnapshot']
   let store: StoreApi<TestStore>
 
   beforeEach(() => {
-    commands = createCommands()
+    const harness = createHarness()
+    commands = harness.commands
+    reconcileSnapshot = harness.reconcileSnapshot
+    store = harness.store
     refreshPreflight = vi.fn<() => Promise<Preflight>>().mockResolvedValue(preflight())
-    reconcileSnapshot = vi.fn<(snapshot: SettingsSnapshot) => void>()
-    store = createStore<TestStore>((set, get) => ({
-      refreshPreflight,
-      ...createRuntimeSetupSlice({
-        set,
-        get,
-        commands: commands as RuntimeCommands,
-        reconcileSnapshot
-      })
-    }))
+    store.setState({ refreshPreflight })
   })
 
   it('subscribes before invoking and attributes the shared event stream to one runtime', async () => {
@@ -247,24 +317,248 @@ describe('runtime setup slice: install lifecycle', () => {
   )
 })
 
+describe('runtime setup slice: discovery lifecycle', () => {
+  let commands: RuntimeCommandMocks
+  let reconcileSnapshot: ReturnType<typeof createHarness>['reconcileSnapshot']
+  let reconcileClaudeDetection: ReturnType<typeof createHarness>['reconcileClaudeDetection']
+  let store: StoreApi<TestStore>
+
+  beforeEach(() => {
+    const harness = createHarness()
+    commands = harness.commands
+    reconcileSnapshot = harness.reconcileSnapshot
+    reconcileClaudeDetection = harness.reconcileClaudeDetection
+    store = harness.store
+  })
+
+  it('creates the runtime-owned startup hydration patch without resetting transient state', () => {
+    const ready = { ...preflight(), claudeReady: true }
+    expect(createRuntimeSetupLoadPatch(ready, false)).toEqual({
+      preflight: ready,
+      npmAvailable: false
+    })
+  })
+
+  it('refreshes preflight and propagates a failed refresh without replacing the cached value', async () => {
+    const ready = { ...preflight(), claudeReady: true }
+    commands.getPreflight.mockResolvedValueOnce(ready)
+
+    await expect(store.getState().refreshPreflight()).resolves.toBe(ready)
+    expect(store.getState().preflight).toBe(ready)
+
+    const failure = new Error('preflight unavailable')
+    commands.getPreflight.mockRejectedValueOnce(failure)
+    await expect(store.getState().refreshPreflight()).rejects.toBe(failure)
+    expect(store.getState().preflight).toBe(ready)
+  })
+
+  it('returns the cached environment value instead of reusing an in-flight Promise', async () => {
+    const cached = environment('opencode', 10)
+    const probe = deferred<EnvironmentCheckResult>()
+    store.setState({ agentFrameworkId: 'opencode', environmentCheck: cached })
+    commands.checkEnvironment.mockReturnValue(probe.promise)
+    commands.getSettings.mockResolvedValue({ ...snapshot(), agentFrameworkId: 'opencode' })
+
+    const first = store.getState().checkEnvironment()
+    const duplicate = store.getState().checkEnvironment()
+
+    expect(duplicate).not.toBe(first)
+    await expect(duplicate).resolves.toBe(cached)
+    expect(commands.checkEnvironment).toHaveBeenCalledOnce()
+    expect(store.getState()).toMatchObject({
+      isCheckingEnvironment: true,
+      checkingFramework: 'opencode',
+      isDetectingClaude: true
+    })
+
+    probe.resolve(environment('opencode', 20))
+    await first
+    expect(commands.getSettings).toHaveBeenCalledOnce()
+    expect(commands.getPreflight).toHaveBeenCalledOnce()
+    expect(commands.isNpmAvailable).toHaveBeenCalledOnce()
+  })
+
+  it('fences an ABA late success after all stale post-probe reads have completed', async () => {
+    const probes = [
+      deferred<EnvironmentCheckResult>(),
+      deferred<EnvironmentCheckResult>(),
+      deferred<EnvironmentCheckResult>()
+    ]
+    commands.checkEnvironment
+      .mockReturnValueOnce(probes[0].promise)
+      .mockReturnValueOnce(probes[1].promise)
+      .mockReturnValueOnce(probes[2].promise)
+
+    const first = store.getState().checkEnvironment()
+    store.setState({ agentFrameworkId: 'opencode' })
+    const second = store.getState().checkEnvironment()
+    store.setState({ agentFrameworkId: 'claude-code' })
+    const third = store.getState().checkEnvironment()
+    expect(commands.checkEnvironment).toHaveBeenCalledTimes(3)
+
+    probes[2].resolve(environment('claude-code', 30))
+    await third
+    expect(store.getState().environmentCheck?.checkedAt).toBe(30)
+    expect(reconcileSnapshot).toHaveBeenCalledTimes(1)
+
+    probes[0].resolve(environment('claude-code', 10))
+    await first
+    probes[1].resolve(environment('opencode', 20))
+    await second
+
+    expect(commands.getSettings).toHaveBeenCalledTimes(3)
+    expect(commands.getPreflight).toHaveBeenCalledTimes(3)
+    expect(commands.isNpmAvailable).toHaveBeenCalledTimes(3)
+    expect(reconcileSnapshot).toHaveBeenCalledTimes(1)
+    expect(store.getState()).toMatchObject({
+      envCheckGeneration: 3,
+      environmentCheck: { checkedAt: 30, agentFrameworkId: 'claude-code' },
+      environmentCheckError: undefined,
+      isCheckingEnvironment: false,
+      checkingFramework: undefined,
+      isDetectingClaude: false
+    })
+  })
+
+  it('keeps a newer ABA pass loading when the stale same-framework pass rejects', async () => {
+    const probes = [
+      deferred<EnvironmentCheckResult>(),
+      deferred<EnvironmentCheckResult>(),
+      deferred<EnvironmentCheckResult>()
+    ]
+    commands.checkEnvironment
+      .mockReturnValueOnce(probes[0].promise)
+      .mockReturnValueOnce(probes[1].promise)
+      .mockReturnValueOnce(probes[2].promise)
+
+    const first = store.getState().checkEnvironment()
+    store.setState({ agentFrameworkId: 'opencode' })
+    const second = store.getState().checkEnvironment()
+    store.setState({ agentFrameworkId: 'claude-code' })
+    const third = store.getState().checkEnvironment()
+
+    probes[0].reject(new Error('stale Claude failed'))
+    await first
+    expect(store.getState()).toMatchObject({
+      isCheckingEnvironment: true,
+      isDetectingClaude: true,
+      environmentCheckError: undefined
+    })
+
+    probes[2].resolve(environment('claude-code', 30))
+    await third
+    probes[1].resolve(environment('opencode', 20))
+    await second
+
+    expect(store.getState()).toMatchObject({
+      environmentCheck: { checkedAt: 30 },
+      environmentCheckError: undefined,
+      isCheckingEnvironment: false,
+      isDetectingClaude: false
+    })
+  })
+
+  it('surfaces a current environment failure and always clears its loading ownership', async () => {
+    commands.checkEnvironment.mockRejectedValue(new Error('environment IPC unavailable'))
+
+    await expect(store.getState().checkEnvironment()).resolves.toBeUndefined()
+
+    expect(store.getState()).toMatchObject({
+      isCheckingEnvironment: false,
+      checkingFramework: undefined,
+      isDetectingClaude: false,
+      environmentCheckError: 'environment IPC unavailable'
+    })
+    expect(reconcileSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('does every post-probe read but rejects a result for the no-longer-selected framework', async () => {
+    const probe = deferred<EnvironmentCheckResult>()
+    commands.checkEnvironment.mockReturnValue(probe.promise)
+
+    const pending = store.getState().checkEnvironment()
+    store.setState({ agentFrameworkId: 'opencode' })
+    probe.resolve(environment('claude-code'))
+
+    await expect(pending).resolves.toEqual(environment('claude-code'))
+    expect(commands.getSettings).toHaveBeenCalledOnce()
+    expect(commands.getPreflight).toHaveBeenCalledOnce()
+    expect(commands.isNpmAvailable).toHaveBeenCalledOnce()
+    expect(reconcileSnapshot).not.toHaveBeenCalled()
+    expect(store.getState().isCheckingEnvironment).toBe(false)
+  })
+
+  it('reconciles Claude and npm, refreshes preflight, and keeps the old Claude on not-found', async () => {
+    await store.getState().detectClaude()
+
+    expect(reconcileClaudeDetection).toHaveBeenCalledWith(
+      { found: true, path: '/bin/claude', version: '1.0.0' },
+      true
+    )
+    expect(store.getState()).toMatchObject({
+      claude: { resolvedPath: '/bin/claude', version: '1.0.0' },
+      npmAvailable: true,
+      isDetectingClaude: false
+    })
+    expect(commands.getPreflight).toHaveBeenCalledOnce()
+
+    commands.detectClaude.mockResolvedValueOnce({ found: false })
+    commands.isNpmAvailable.mockResolvedValueOnce(false)
+    await store.getState().detectClaude()
+
+    expect(store.getState()).toMatchObject({
+      claude: { resolvedPath: '/bin/claude', version: '1.0.0' },
+      npmAvailable: false,
+      isDetectingClaude: false
+    })
+  })
+
+  it('propagates Claude preflight failure after applying detection and clears the flag', async () => {
+    const failure = new Error('preflight unavailable')
+    commands.getPreflight.mockRejectedValue(failure)
+
+    await expect(store.getState().detectClaude()).rejects.toBe(failure)
+
+    expect(store.getState()).toMatchObject({
+      claude: { resolvedPath: '/bin/claude' },
+      isDetectingClaude: false
+    })
+  })
+
+  it.each([
+    ['detectOpencode', 'isDetectingOpencode'],
+    ['detectCodex', 'isDetectingCodex']
+  ] as const)('reconciles the snapshot and clears the flag after %s', async (action, flag) => {
+    await store.getState()[action]()
+
+    expect(commands[action]).toHaveBeenCalledOnce()
+    expect(reconcileSnapshot).toHaveBeenCalledWith(snapshot())
+    expect(store.getState()[flag]).toBe(false)
+    expect(commands.getPreflight).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['detectOpencode', 'isDetectingOpencode'],
+    ['detectCodex', 'isDetectingCodex']
+  ] as const)('propagates %s failure and still clears its flag', async (action, flag) => {
+    const failure = new Error(`${action} unavailable`)
+    commands[action].mockRejectedValue(failure)
+
+    await expect(store.getState()[action]()).rejects.toBe(failure)
+    expect(store.getState()[flag]).toBe(false)
+    expect(reconcileSnapshot).not.toHaveBeenCalled()
+  })
+})
+
 describe('runtime setup slice: uninstall lifecycle', () => {
   it.each([
     ['uninstallClaude', 'uninstallClaude'],
     ['uninstallOpencode', 'uninstallOpencode'],
     ['uninstallCodex', 'uninstallCodex']
   ] as const)('reconciles and refreshes after %s', async (action, command) => {
-    const commands = createCommands()
+    const { commands, reconcileSnapshot, store } = createHarness()
     const refreshPreflight = vi.fn().mockResolvedValue(preflight())
-    const reconcileSnapshot = vi.fn()
-    const store = createStore<TestStore>((set, get) => ({
-      refreshPreflight,
-      ...createRuntimeSetupSlice({
-        set,
-        get,
-        commands: commands as RuntimeCommands,
-        reconcileSnapshot
-      })
-    }))
+    store.setState({ refreshPreflight })
 
     await store.getState()[action]()
 
@@ -274,20 +568,11 @@ describe('runtime setup slice: uninstall lifecycle', () => {
   })
 
   it('propagates an uninstall error without reconciling stale state', async () => {
-    const commands = createCommands()
+    const { commands, reconcileSnapshot, store } = createHarness()
     const failure = new Error('uninstall rejected')
     commands.uninstallCodex.mockRejectedValue(failure)
     const refreshPreflight = vi.fn().mockResolvedValue(preflight())
-    const reconcileSnapshot = vi.fn()
-    const store = createStore<TestStore>((set, get) => ({
-      refreshPreflight,
-      ...createRuntimeSetupSlice({
-        set,
-        get,
-        commands: commands as RuntimeCommands,
-        reconcileSnapshot
-      })
-    }))
+    store.setState({ refreshPreflight })
 
     await expect(store.getState().uninstallCodex()).rejects.toBe(failure)
     expect(reconcileSnapshot).not.toHaveBeenCalled()
@@ -295,19 +580,10 @@ describe('runtime setup slice: uninstall lifecycle', () => {
   })
 
   it('propagates a post-uninstall preflight failure after applying the returned snapshot', async () => {
-    const commands = createCommands()
+    const { reconcileSnapshot, store } = createHarness()
     const failure = new Error('preflight unavailable')
     const refreshPreflight = vi.fn<() => Promise<Preflight>>().mockRejectedValue(failure)
-    const reconcileSnapshot = vi.fn<(snapshot: SettingsSnapshot) => void>()
-    const store = createStore<TestStore>((set, get) => ({
-      refreshPreflight,
-      ...createRuntimeSetupSlice({
-        set,
-        get,
-        commands: commands as RuntimeCommands,
-        reconcileSnapshot
-      })
-    }))
+    store.setState({ refreshPreflight })
 
     await expect(store.getState().uninstallClaude()).rejects.toBe(failure)
     expect(reconcileSnapshot).toHaveBeenCalledWith(snapshot())

--- a/src/renderer/src/stores/settings-runtime-slice.ts
+++ b/src/renderer/src/stores/settings-runtime-slice.ts
@@ -2,10 +2,12 @@ import type { StoreApi } from 'zustand'
 
 import type {
   AgentFrameworkId,
+  ClaudeDetectResult,
   ClaudeInstallProgressEvent,
   ClaudeInstallResult,
   ClaudeInstallSource,
   CodexInstallSource,
+  EnvironmentCheckResult,
   ManagedClaudeRegistry,
   Preflight,
   SettingsSnapshot
@@ -19,10 +21,25 @@ export type RuntimeInstallState = {
 }
 
 export type RuntimeSetupState = {
+  preflight: Preflight
+  npmAvailable: boolean
+  environmentCheck: EnvironmentCheckResult | undefined
+  environmentCheckError: string | undefined
+  isCheckingEnvironment: boolean
+  checkingFramework: AgentFrameworkId | undefined
+  envCheckGeneration: number
+  isDetectingClaude: boolean
+  isDetectingOpencode: boolean
+  isDetectingCodex: boolean
   installStates: Record<AgentFrameworkId, RuntimeInstallState>
 }
 
 export type RuntimeSetupActions = {
+  refreshPreflight: () => Promise<Preflight>
+  checkEnvironment: (options?: { force?: boolean }) => Promise<EnvironmentCheckResult | undefined>
+  detectClaude: () => Promise<ClaudeDetectResult>
+  detectOpencode: () => Promise<void>
+  detectCodex: () => Promise<void>
   installClaude: (
     source: ClaudeInstallSource,
     managedRegistry?: ManagedClaudeRegistry
@@ -38,12 +55,19 @@ export type RuntimeSetupActions = {
 export type RuntimeSetupSlice = RuntimeSetupState & RuntimeSetupActions
 
 type RuntimeSetupHost = RuntimeSetupState & {
-  refreshPreflight: () => Promise<Preflight>
+  agentFrameworkId: AgentFrameworkId
+  refreshPreflight: RuntimeSetupActions['refreshPreflight']
 }
 
 type RuntimeSetupCommands = Pick<
   Window['api']['settings'],
   | 'getSettings'
+  | 'getPreflight'
+  | 'isNpmAvailable'
+  | 'checkEnvironment'
+  | 'detectClaude'
+  | 'detectOpencode'
+  | 'detectCodex'
   | 'installClaude'
   | 'installOpencode'
   | 'installCodex'
@@ -53,11 +77,22 @@ type RuntimeSetupCommands = Pick<
   | 'onInstallLog'
 >
 
+type EnvironmentReconcilePatch = Pick<
+  RuntimeSetupState,
+  'environmentCheck' | 'preflight' | 'npmAvailable'
+>
+
+export type RuntimeSetupLoadPatch = Pick<RuntimeSetupState, 'preflight' | 'npmAvailable'>
+
 type RuntimeSetupSliceOptions<Store extends RuntimeSetupHost> = {
   set: StoreApi<Store>['setState']
   get: StoreApi<Store>['getState']
-  commands: RuntimeSetupCommands
-  reconcileSnapshot: (snapshot: SettingsSnapshot) => void
+  getCommands: () => RuntimeSetupCommands
+  reconcileSnapshot: (
+    snapshot: SettingsSnapshot,
+    runtimePatch?: Partial<EnvironmentReconcilePatch>
+  ) => void
+  reconcileClaudeDetection: (result: ClaudeDetectResult, npmAvailable: boolean) => void
 }
 
 const createInitialRuntimeInstallState = (): RuntimeInstallState => ({
@@ -67,7 +102,26 @@ const createInitialRuntimeInstallState = (): RuntimeInstallState => ({
   installError: undefined
 })
 
+const createInitialPreflight = (): Preflight => ({
+  claudeReady: false,
+  opencodeReady: false,
+  codexReady: false,
+  agentFrameworkId: 'claude-code',
+  agentReady: false,
+  activeProviderReady: false
+})
+
 export const createInitialRuntimeSetupState = (): RuntimeSetupState => ({
+  preflight: createInitialPreflight(),
+  npmAvailable: true,
+  environmentCheck: undefined,
+  environmentCheckError: undefined,
+  isCheckingEnvironment: false,
+  checkingFramework: undefined,
+  envCheckGeneration: 0,
+  isDetectingClaude: false,
+  isDetectingOpencode: false,
+  isDetectingCodex: false,
   installStates: {
     'claude-code': createInitialRuntimeInstallState(),
     opencode: createInitialRuntimeInstallState(),
@@ -75,10 +129,20 @@ export const createInitialRuntimeSetupState = (): RuntimeSetupState => ({
   }
 })
 
+export const createRuntimeSetupLoadPatch = (
+  preflight: Preflight,
+  npmAvailable: boolean
+): RuntimeSetupLoadPatch => ({ preflight, npmAvailable })
+
 export const selectAnyInstalling = (state: RuntimeSetupState): boolean =>
   state.installStates['claude-code'].isInstalling ||
   state.installStates.opencode.isInstalling ||
   state.installStates.codex.isInstalling
+
+const patchRuntimeSetupState = <Store extends RuntimeSetupHost>(
+  set: StoreApi<Store>['setState'],
+  patch: Partial<RuntimeSetupState>
+): void => set(patch as Partial<Store>)
 
 const updateInstallStates = <Store extends RuntimeSetupHost>(
   set: StoreApi<Store>['setState'],
@@ -98,10 +162,10 @@ const patchInstallState = <Store extends RuntimeSetupHost>(
 const runRuntimeInstall = async <Store extends RuntimeSetupHost>(
   set: StoreApi<Store>['setState'],
   get: StoreApi<Store>['getState'],
-  commands: RuntimeSetupCommands,
-  reconcileSnapshot: (snapshot: SettingsSnapshot) => void,
+  getCommands: () => RuntimeSetupCommands,
+  reconcileSnapshot: RuntimeSetupSliceOptions<Store>['reconcileSnapshot'],
   runtime: AgentFrameworkId,
-  invoke: () => Promise<ClaudeInstallResult>
+  invoke: (commands: RuntimeSetupCommands) => Promise<ClaudeInstallResult>
 ): Promise<ClaudeInstallResult> => {
   // Install events are broadcast without a runtime id. The synchronous global guard guarantees that
   // exactly one subscription is live, so every event can be attributed to this runtime.
@@ -116,6 +180,7 @@ const runRuntimeInstall = async <Store extends RuntimeSetupHost>(
     installError: undefined
   })
 
+  const commands = getCommands()
   const unsubscribe = commands.onInstallLog((event) => {
     if (event.kind === 'progress') {
       patchInstallState(set, runtime, { installProgress: event })
@@ -134,7 +199,7 @@ const runRuntimeInstall = async <Store extends RuntimeSetupHost>(
   try {
     let result: ClaudeInstallResult
     try {
-      result = await invoke()
+      result = await invoke(commands)
     } catch (error) {
       patchInstallState(set, runtime, {
         installError: error instanceof Error ? error.message : 'Install failed.'
@@ -164,34 +229,137 @@ const runRuntimeInstall = async <Store extends RuntimeSetupHost>(
 export const createRuntimeSetupSlice = <Store extends RuntimeSetupHost>({
   set,
   get,
-  commands,
-  reconcileSnapshot
+  getCommands,
+  reconcileSnapshot,
+  reconcileClaudeDetection
 }: RuntimeSetupSliceOptions<Store>): RuntimeSetupSlice => ({
   ...createInitialRuntimeSetupState(),
 
+  refreshPreflight: async () => {
+    const preflight = await getCommands().getPreflight()
+    patchRuntimeSetupState(set, { preflight })
+    return preflight
+  },
+
+  checkEnvironment: async (options) => {
+    const framework = get().agentFrameworkId
+    // Strict Mode duplicates return the cached value immediately; they do not share the first Promise.
+    if (!options?.force && get().isCheckingEnvironment && get().checkingFramework === framework) {
+      return get().environmentCheck
+    }
+
+    const generation = get().envCheckGeneration + 1
+    patchRuntimeSetupState(set, {
+      envCheckGeneration: generation,
+      isCheckingEnvironment: true,
+      checkingFramework: framework,
+      // Preserve the existing shared detection indicator even for OpenCode and Codex checks.
+      isDetectingClaude: true,
+      environmentCheckError: undefined
+    })
+
+    try {
+      const commands = getCommands()
+      const environmentCheck = await commands.checkEnvironment()
+      // Preserve the existing ordering: even a pass that became stale while probing performs these
+      // reads before generation/framework fencing decides whether it may update visible state.
+      const [snapshot, preflight, npmAvailable] = await Promise.all([
+        commands.getSettings(),
+        commands.getPreflight(),
+        commands.isNpmAvailable()
+      ])
+
+      if (
+        get().envCheckGeneration !== generation ||
+        environmentCheck.agentFrameworkId !== get().agentFrameworkId
+      ) {
+        return environmentCheck
+      }
+
+      reconcileSnapshot(snapshot, { environmentCheck, preflight, npmAvailable })
+      return environmentCheck
+    } catch (error) {
+      if (get().envCheckGeneration === generation) {
+        patchRuntimeSetupState(set, {
+          environmentCheckError:
+            error instanceof Error ? error.message : 'Environment detection could not be completed.'
+        })
+      }
+      return undefined
+    } finally {
+      set(
+        (state) =>
+          (state.envCheckGeneration === generation
+            ? {
+                isCheckingEnvironment: false,
+                checkingFramework: undefined,
+                isDetectingClaude: false
+              }
+            : {}) as Partial<Store>
+      )
+    }
+  },
+
+  detectClaude: async () => {
+    patchRuntimeSetupState(set, { isDetectingClaude: true })
+
+    try {
+      const commands = getCommands()
+      const [result, npmAvailable] = await Promise.all([
+        commands.detectClaude(),
+        commands.isNpmAvailable()
+      ])
+
+      // Core retains the stable Claude projection; a not-found result intentionally leaves it intact.
+      reconcileClaudeDetection(result, npmAvailable)
+      await get().refreshPreflight()
+      return result
+    } finally {
+      patchRuntimeSetupState(set, { isDetectingClaude: false })
+    }
+  },
+
+  detectOpencode: async () => {
+    patchRuntimeSetupState(set, { isDetectingOpencode: true })
+    try {
+      reconcileSnapshot(await getCommands().detectOpencode())
+    } finally {
+      patchRuntimeSetupState(set, { isDetectingOpencode: false })
+    }
+  },
+
+  detectCodex: async () => {
+    patchRuntimeSetupState(set, { isDetectingCodex: true })
+    try {
+      reconcileSnapshot(await getCommands().detectCodex())
+    } finally {
+      patchRuntimeSetupState(set, { isDetectingCodex: false })
+    }
+  },
+
   installClaude: (source, managedRegistry) =>
-    runRuntimeInstall(set, get, commands, reconcileSnapshot, 'claude-code', () =>
+    runRuntimeInstall(set, get, getCommands, reconcileSnapshot, 'claude-code', (commands) =>
       commands.installClaude({ source, managedRegistry })
     ),
   installOpencode: (source = 'managed') =>
-    runRuntimeInstall(set, get, commands, reconcileSnapshot, 'opencode', () =>
+    runRuntimeInstall(set, get, getCommands, reconcileSnapshot, 'opencode', (commands) =>
       commands.installOpencode({ source })
     ),
   installCodex: (source = 'managed') =>
-    runRuntimeInstall(set, get, commands, reconcileSnapshot, 'codex', () =>
+    runRuntimeInstall(set, get, getCommands, reconcileSnapshot, 'codex', (commands) =>
       commands.installCodex({ source })
     ),
 
   uninstallClaude: async () => {
-    reconcileSnapshot(await commands.uninstallClaude())
+    reconcileSnapshot(await getCommands().uninstallClaude())
     await get().refreshPreflight()
   },
   uninstallOpencode: async () => {
-    reconcileSnapshot(await commands.uninstallOpencode())
+    reconcileSnapshot(await getCommands().uninstallOpencode())
     await get().refreshPreflight()
   },
   uninstallCodex: async () => {
-    reconcileSnapshot(await commands.uninstallCodex())
+    reconcileSnapshot(await getCommands().uninstallCodex())
     await get().refreshPreflight()
   },
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -25,18 +25,16 @@ import {
 } from './settings-write-coordinator'
 import {
   createInitialRuntimeSetupState,
+  createRuntimeSetupLoadPatch,
   createRuntimeSetupSlice,
   type RuntimeSetupActions,
   type RuntimeSetupState
 } from './settings-runtime-slice'
 export { selectAnyInstalling } from './settings-runtime-slice'
 import type {
-  ClaudeDetectResult,
   ClaudeInfo,
   ClaudeSubscriptionProviderId,
   CodexInfo,
-  EnvironmentCheckResult,
-  Preflight,
   AgentFrameworkId,
   AgentFrameworkView,
   ChatApiEndpoint,
@@ -115,25 +113,7 @@ type SettingsStoreData = RuntimeSetupState & {
   pendingApprovals: ConnectorApprovalRequest[]
   // Shared NCBI credential state (never the plaintext key), reconciled alongside the connectors list.
   ncbi: NcbiCredentialsView
-  preflight: Preflight
   encryptionAvailable: boolean
-  npmAvailable: boolean
-  environmentCheck: EnvironmentCheckResult | undefined
-  environmentCheckError: string | undefined
-  // Transient UI state for the wizard/settings page.
-  isCheckingEnvironment: boolean
-  // Framework the in-flight environment check was issued for. Used ONLY for the React Strict Mode
-  // de-dup: a same-framework duplicate mount reuses the running pass instead of double-probing.
-  // Staleness/ownership is decided by envCheckGeneration, never by this field.
-  checkingFramework: AgentFrameworkId | undefined
-  // Monotonic token stamped by each checkEnvironment call. The success/catch/finally branches only
-  // mutate shared state when their captured generation is still current, so an older pass (even one
-  // for the same framework, as in a Claude -> OpenCode -> Claude ABA sequence) can never overwrite,
-  // fail, or clear the loading flags of a newer pass.
-  envCheckGeneration: number
-  isDetectingClaude: boolean
-  isDetectingOpencode: boolean
-  isDetectingCodex: boolean
   // Whether the settings dialog is open (rendered at the app root, over Home/Workspace).
   isSettingsOpen: boolean
   // Panel requested by an external entry point; Settings consumes it after seeding navigation.
@@ -159,12 +139,6 @@ type SettingsStoreData = RuntimeSetupState & {
 
 type SettingsStoreCore = SettingsStoreData & {
   load: (options?: { force?: boolean }) => Promise<boolean>
-  refreshPreflight: () => Promise<Preflight>
-  checkEnvironment: (options?: { force?: boolean }) => Promise<EnvironmentCheckResult | undefined>
-  detectClaude: () => Promise<ClaudeDetectResult>
-  // Detects the opencode executable and refreshes its status card.
-  detectOpencode: () => Promise<void>
-  detectCodex: () => Promise<void>
   // Persists the draft (create/update) without testing it, returning the affected provider id. The
   // Settings page uses this to return to the list immediately, then tests in the background.
   persistProvider: (request: UpsertProviderRequest) => Promise<string>
@@ -298,15 +272,6 @@ type SettingsStoreCore = SettingsStoreData & {
 
 type SettingsStore = SettingsStoreCore & RuntimeSetupActions
 
-const createInitialPreflight = (): Preflight => ({
-  claudeReady: false,
-  opencodeReady: false,
-  codexReady: false,
-  agentFrameworkId: 'claude-code',
-  agentReady: false,
-  activeProviderReady: false
-})
-
 export const createInitialSettingsState = (): SettingsStoreData => ({
   ...createInitialRuntimeSetupState(),
   isLoaded: false,
@@ -332,17 +297,7 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   customServers: [],
   pendingApprovals: [],
   ncbi: { hasApiKey: false },
-  preflight: createInitialPreflight(),
   encryptionAvailable: true,
-  npmAvailable: true,
-  environmentCheck: undefined,
-  environmentCheckError: undefined,
-  isCheckingEnvironment: false,
-  checkingFramework: undefined,
-  envCheckGeneration: 0,
-  isDetectingClaude: false,
-  isDetectingOpencode: false,
-  isDetectingCodex: false,
   isSettingsOpen: false,
   pendingSettingsPanel: undefined,
   pendingSkillId: undefined,
@@ -486,18 +441,16 @@ const createSettingsStoreState = (
   ...createRuntimeSetupSlice({
     set,
     get,
-    // Keep browser globals lazy so importing the store remains safe in node-based renderer tests.
-    commands: {
-      getSettings: () => window.api.settings.getSettings(),
-      installClaude: (request) => window.api.settings.installClaude(request),
-      installOpencode: (request) => window.api.settings.installOpencode(request),
-      installCodex: (request) => window.api.settings.installCodex(request),
-      uninstallClaude: () => window.api.settings.uninstallClaude(),
-      uninstallOpencode: () => window.api.settings.uninstallOpencode(),
-      uninstallCodex: () => window.api.settings.uninstallCodex(),
-      onInstallLog: (listener) => window.api.settings.onInstallLog(listener)
-    },
-    reconcileSnapshot: (snapshot) => set(applySnapshot(snapshot))
+    // Resolve browser globals only when an action runs; node-based renderer tests import this store.
+    getCommands: () => window.api.settings,
+    reconcileSnapshot: (snapshot, runtimePatch = {}) =>
+      set({ ...applySnapshot(snapshot), ...runtimePatch }),
+    reconcileClaudeDetection: (result, npmAvailable) =>
+      set(
+        result.found && result.path
+          ? { npmAvailable, claude: { resolvedPath: result.path, version: result.version } }
+          : { npmAvailable }
+      )
   }),
 
   // Loads settings, preflight, and encryption availability in one startup pass.
@@ -523,9 +476,8 @@ const createSettingsStoreState = (
 
         set({
           ...applySnapshot(snapshot),
-          preflight,
+          ...createRuntimeSetupLoadPatch(preflight, npmAvailable),
           encryptionAvailable,
-          npmAvailable,
           isLoaded: true,
           isLoading: false,
           loadError: undefined
@@ -548,115 +500,6 @@ const createSettingsStoreState = (
       if (settingsLoadPromise === loadPromise) settingsLoadPromise = undefined
     })
     return loadPromise
-  },
-
-  // Re-checks the two startup gates without reloading the whole snapshot.
-  refreshPreflight: async () => {
-    const preflight = await window.api.settings.getPreflight()
-
-    set({ preflight })
-
-    return preflight
-  },
-
-  // Full startup inspection: main owns filesystem/network/runtime probes; the renderer caches only
-  // their structured, non-secret result. Refresh settings/preflight afterwards because detection may
-  // have discovered and persisted a Claude installation that appeared since the previous launch.
-  checkEnvironment: async (options) => {
-    // React Strict Mode intentionally re-runs mount effects in development. Reuse the in-flight pass
-    // only when it targets the currently-selected framework: an auto-switch (e.g. Claude -> a detected
-    // OpenCode) changes the target mid-flight, and that call must issue its own probe rather than reuse
-    // the previous framework's, or Continue stays disabled on a result that no longer matches.
-    const framework = get().agentFrameworkId
-    if (!options?.force && get().isCheckingEnvironment && get().checkingFramework === framework) {
-      return get().environmentCheck
-    }
-
-    // Stamp a fresh generation; only the branch whose captured token is still current may mutate
-    // shared state. This defeats an ABA sequence (Claude -> OpenCode -> Claude) where an older pass
-    // shares the framework id of the newest one and would otherwise pass a framework-only staleness
-    // check.
-    const generation = get().envCheckGeneration + 1
-
-    set({
-      envCheckGeneration: generation,
-      isCheckingEnvironment: true,
-      checkingFramework: framework,
-      isDetectingClaude: true,
-      environmentCheckError: undefined
-    })
-
-    try {
-      const environmentCheck = await window.api.settings.checkEnvironment()
-      const [snapshot, preflight, npmAvailable] = await Promise.all([
-        window.api.settings.getSettings(),
-        window.api.settings.getPreflight(),
-        window.api.settings.isNpmAvailable()
-      ])
-
-      // Discard a stale result: a newer pass has stamped a later generation and now owns the visible
-      // state, so this older probe must not overwrite it (defensively also require the result to
-      // still match the selected framework).
-      if (
-        get().envCheckGeneration !== generation ||
-        environmentCheck.agentFrameworkId !== get().agentFrameworkId
-      ) {
-        return environmentCheck
-      }
-
-      set({
-        ...applySnapshot(snapshot),
-        environmentCheck,
-        preflight,
-        npmAvailable
-      })
-
-      return environmentCheck
-    } catch (error) {
-      // A late failure from a superseded pass must not clobber a newer pass's successful result.
-      if (get().envCheckGeneration === generation) {
-        set({
-          environmentCheckError:
-            error instanceof Error ? error.message : 'Environment detection could not be completed.'
-        })
-      }
-      return undefined
-    } finally {
-      // Only clear the loading flags when this pass is still the current one; a newer pass may
-      // already be running and now owns them.
-      set((state) =>
-        state.envCheckGeneration === generation
-          ? { isCheckingEnvironment: false, checkingFramework: undefined, isDetectingClaude: false }
-          : {}
-      )
-    }
-  },
-
-  // Detects claude and folds the resolved path/version back into the cache.
-  detectClaude: async () => {
-    set({ isDetectingClaude: true })
-
-    try {
-      // Re-detect claude and npm together so a mid-onboarding Node.js install is picked up by the same
-      // Re-detect action. npm has no separate refresh; it was previously latched at load() only, so
-      // users who installed Node.js after opening onboarding were stuck until an app restart.
-      const [result, npmAvailable] = await Promise.all([
-        window.api.settings.detectClaude(),
-        window.api.settings.isNpmAvailable()
-      ])
-
-      set(() =>
-        result.found && result.path
-          ? { npmAvailable, claude: { resolvedPath: result.path, version: result.version } }
-          : { npmAvailable }
-      )
-
-      await get().refreshPreflight()
-
-      return result
-    } finally {
-      set({ isDetectingClaude: false })
-    }
   },
 
   // Persists a provider draft (create/update) and refreshes derived state, without testing it.
@@ -982,27 +825,6 @@ const createSettingsStoreState = (
   },
 
   clearSettingsWriteError: () => writeCoordinator.clearFailures(),
-
-  // Detects the opencode executable and refreshes its status card.
-  detectOpencode: async () => {
-    set({ isDetectingOpencode: true })
-
-    try {
-      set(applySnapshot(await window.api.settings.detectOpencode()))
-    } finally {
-      set({ isDetectingOpencode: false })
-    }
-  },
-
-  detectCodex: async () => {
-    set({ isDetectingCodex: true })
-
-    try {
-      set(applySnapshot(await window.api.settings.detectCodex()))
-    } finally {
-      set({ isDetectingCodex: false })
-    }
-  },
 
   deleteProvider: async (providerId) => {
     const snapshot = await window.api.settings.deleteProvider({ id: providerId })


### PR DESCRIPTION
## Problem

After R2a moved runtime install lifecycle ownership, `settings-store.ts` still owned runtime preflight refresh, launch environment inspection, ABA generation fencing, and Claude/OpenCode/Codex detection. These related state transitions remained separated from the runtime install state they coordinate and kept the compatibility store broader than necessary.

## Proposed change

- Extend the existing runtime setup slice owner with preflight, npm availability, environment inspection state, generation fencing, and three runtime detection actions.
- Keep `agentFrameworkId` and the full Settings snapshot projection in the core store. The owner passes environment state through the existing composition seam so snapshot and runtime fields still land in one atomic Zustand update.
- Route startup hydration through a runtime-owned load patch while keeping `load()` as the core aggregate.
- Resolve the existing Settings command interface lazily when an action runs, preserving node-based store imports without maintaining one wrapper per command.
- Reduce `settings-store.ts` from 1,256 to 1,078 physical lines. Production raw is 400 lines: `183 additions + 15 deletions` in the runtime owner and `12 additions + 190 deletions` in the compatibility store.

```mermaid
flowchart LR
  Consumers["Settings / onboarding / startup consumers"] --> Store["useSettingsStore compatibility interface"]
  Store --> Runtime["runtime setup slice owner"]
  Store --> Core["core load and snapshot projection"]
  Runtime --> Commands["existing Settings renderer commands"]
  Runtime --> Core
```

## Scope and non-goals

In scope: preflight refresh, runtime-owned startup hydration fields, cached-value environment-check de-duplication, generation/ABA fencing, and Claude/OpenCode/Codex detection state and settlement.

Out of scope: provider/auth, preferences, navigation, Skills, Connectors, install behavior changes, new detection concurrency policy, UI changes, a second store, transport changes, or moving `agentFrameworkId`, managed-runtime snapshot fields, and the full snapshot projector out of core. This PR intentionally does not fix the existing overlap between standalone detection and environment-check flags.

## Compatibility

- Public state fields, actions, selectors, IPC channels, payloads, preload contracts, generated Web maps, persisted data, and user interactions are unchanged.
- Same-framework duplicate environment checks still return the currently cached value immediately; they do not reuse the first request's Promise. Forced checks and different-framework checks still start a new generation.
- Stale passes still complete the post-probe Settings/preflight/npm reads before generation and selected-framework fencing. Stale success, catch, and finally branches cannot overwrite or clear newer state.
- Every framework environment check temporarily uses `isDetectingClaude`, preserving the existing UI behavior.
- Claude detection still probes Claude and npm in parallel, preserves the old Claude projection when not found, refreshes preflight, and propagates failures after clearing its flag. The existing extra preflight refresh in the framework-switch caller remains. OpenCode/Codex detection still applies a snapshot without refreshing preflight itself.
- R2a install/uninstall guard, event attribution, subscription ordering, settlement, and remote-Web rejecting install stubs are unchanged.
- Discovery commands retain their current Web profile across Electron, local Web, and remote Web. CLI/Task do not instantiate this renderer store. Specialist, Permission, and Compute behavior is untouched.

## Acceptance criteria and validation

All checks ran after the clean mechanical rebase onto `06ef6dfe` and the last material edit on commit `5beaf8d2`:

- runtime discovery/install owner semantics -> `npm test -- src/renderer/src/stores/settings-runtime-slice.test.ts` -> 24/24 passed
- public store and R0 compatibility -> `npm test -- src/renderer/src/stores/settings-store.test.ts` -> 88/88 passed
- onboarding, Settings, startup, and storage consumers -> `npm test -- src/renderer/src/pages/onboarding/AgentStep.render.test.tsx src/renderer/src/pages/onboarding/EnvironmentStep.render.test.tsx src/renderer/src/pages/settings/SettingsPage.render.test.tsx src/renderer/src/App.test.tsx src/renderer/src/pages/settings/StoragePanel.render.test.tsx` -> 149/149 passed
- combined final impact set -> 7 files, 261/261 passed
- renderer type safety -> `npm run typecheck:web` -> passed
- changed TypeScript files -> `npx eslint src/renderer/src/stores/settings-store.ts src/renderer/src/stores/settings-runtime-slice.ts src/renderer/src/stores/settings-runtime-slice.test.ts` -> passed
- patch hygiene -> `git diff --check` -> passed
- independent exact-diff review -> Standards 0 findings; Spec 0 findings

Uncovered locally: the full portable suite and platform/E2E lanes were not run. PR Gate remains authoritative for the final exact-head impact plan.

## Review focus

- Confirm same-framework de-duplication returns cached state rather than sharing the in-flight Promise.
- Confirm current/stale success, catch, and finally branches retain generation ownership through Claude → OpenCode → Claude ABA sequences.
- Confirm the stale check occurs only after the post-probe Settings/preflight/npm reads and that successful reconciliation remains one atomic set.
- Confirm Claude not-found does not clear its previous stable projection, OpenCode/Codex do not refresh preflight themselves, and framework switching retains its existing refresh ordering.
- Confirm the slice remains a sibling of the write coordinator and no transport or cross-surface capability changed.

Merge with squash only after exact-head CI and AI review are green.
