### PR TITLE
docs(contributing): document merge queue workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,8 +238,11 @@ ci(review): unify automated AI reviews
   checks ran after the last material edit, and call out uncovered risks.
 - Keep PRs reasonably small and scoped so they are easy to review.
 - Ensure the final Test Impact Set, or the full fallback when required, passes.
-- Merge pull requests using **squash merge only**. The squash commit subject must
-  keep the pull request title's Conventional Commit format.
+- After the pull request checks pass, add the pull request to the merge queue. Do not update the
+  branch only because `main` advanced; the queue validates the change against the latest `main`.
+  Update the branch when it has merge conflicts or a maintainer requests it.
+- The merge queue uses **squash merge only**. The squash commit subject must keep the pull request
+  title's Conventional Commit format.
 
 ## Reporting Issues
 


### PR DESCRIPTION
## Problem

The `main` ruleset used strict required status checks, so a pull request had to update or rebase whenever `main` advanced even after its checks passed.

## Proposed change

Document the merge queue workflow and clarify that contributors do not need to update a branch solely because `main` advanced. The repository ruleset has been updated separately to use loose pull-request checks plus an `ALLGREEN`, squash-only merge queue, which validates queued changes against the latest `main`.

## Scope and non-goals

- Documentation only in this pull request.
- No PR Gate or CI Integrity workflow logic changes; both workflows already handle `merge_group` events.
- Branch updates are still required for merge conflicts or when requested by a maintainer.

## Acceptance criteria and validation

Checks ran after the last material edit:

- Contributor guidance formatting -> `npx prettier --check CONTRIBUTING.md` -> passed.
- PR Gate merge-group contract -> `npm test -- scripts/ci/pr-gate-workflow.test.ts scripts/ci/ci-integrity-workflow.test.ts` -> 2 files and 18 tests passed.
- Main ruleset behavior -> GitHub ruleset API readback -> `strict_required_status_checks_policy: false`; merge queue is `SQUASH`, `ALLGREEN`, one entry per build and merge.

Consumer/platform lanes were excluded because the tracked diff is documentation-only and runtime behavior is unchanged. The operational ruleset change relies on the existing tested `merge_group` workflow paths. Uncovered risk: the first real queued pull request remains the end-to-end GitHub-hosted validation of repository permissions and queue execution.

## Review focus

Confirm that the guidance clearly distinguishes unnecessary base-branch updates from conflict resolution and maintainer-requested updates.
