### PR TITLE
refactor(settings-store): extract provider auth slice

### DIFF
--- a/src/renderer/src/stores/settings-provider-auth-slice.test.ts
+++ b/src/renderer/src/stores/settings-provider-auth-slice.test.ts
@@ -1,0 +1,390 @@
+import type { StoreApi } from 'zustand'
+import { createStore } from 'zustand/vanilla'
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+import type {
+  AgentFrameworkId,
+  ProviderView,
+  SettingsSnapshot,
+  ValidateProviderResult
+} from '../../../shared/settings'
+import { createProviderAuthSlice, type ProviderAuthActions } from './settings-provider-auth-slice'
+import { createSettingsWriteCoordinator } from './settings-write-coordinator'
+
+type ProviderCommands = Pick<
+  Window['api']['settings'],
+  | 'getSettings'
+  | 'upsertProvider'
+  | 'deleteProvider'
+  | 'setActiveProvider'
+  | 'setAgentFramework'
+  | 'validateProvider'
+  | 'cancelCodexLogin'
+  | 'cancelClaudeLogin'
+  | 'loginIsolatedCodex'
+  | 'logoutIsolatedCodex'
+  | 'loginSharedClaude'
+  | 'logoutSharedClaude'
+  | 'loginIsolatedClaude'
+  | 'loginIsolatedClaudeBrowser'
+  | 'cancelIsolatedClaudeLogin'
+  | 'logoutIsolatedClaude'
+  | 'refreshProviderModels'
+>
+
+type CommandMocks = { [Command in keyof ProviderCommands]: Mock }
+
+type TestStore = ProviderAuthActions & {
+  providers: ProviderView[]
+  activeProviderId: string | undefined
+  activeModel: string | undefined
+  agentFrameworkId: AgentFrameworkId
+  settingsWriteError: string | undefined
+}
+
+const provider = (id: string): ProviderView => ({
+  id,
+  type: 'custom',
+  name: id,
+  model: 'model-1',
+  models: ['model-1'],
+  supportsImageInput: false,
+  hasKey: true,
+  needsKey: false
+})
+
+const snapshot = (
+  providers: ProviderView[] = [],
+  patch: Partial<SettingsSnapshot> = {}
+): SettingsSnapshot => ({
+  claude: {},
+  activeProviderId: undefined,
+  providers,
+  agentFrameworkId: 'claude-code',
+  agentFrameworks: [],
+  opencode: {},
+  codex: {},
+  claudeManaged: false,
+  opencodeManaged: false,
+  codexManaged: false,
+  reasoningEffort: 'default',
+  notificationsEnabled: true,
+  conversationSkillImportEnabled: true,
+  appIconVariant: 'light',
+  ...patch
+})
+
+const deferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} => {
+  let resolve: (value: T) => void = () => undefined
+  let reject: (error: unknown) => void = () => undefined
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+const createCommands = (): CommandMocks => ({
+  getSettings: vi.fn().mockResolvedValue(snapshot()),
+  upsertProvider: vi.fn().mockResolvedValue(snapshot()),
+  deleteProvider: vi.fn().mockResolvedValue(snapshot()),
+  setActiveProvider: vi.fn().mockResolvedValue(snapshot()),
+  setAgentFramework: vi.fn().mockResolvedValue(snapshot()),
+  validateProvider: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
+  cancelCodexLogin: vi.fn().mockResolvedValue(undefined),
+  cancelClaudeLogin: vi.fn().mockResolvedValue(undefined),
+  loginIsolatedCodex: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
+  logoutIsolatedCodex: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
+  loginSharedClaude: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
+  logoutSharedClaude: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
+  loginIsolatedClaude: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
+  loginIsolatedClaudeBrowser: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
+  cancelIsolatedClaudeLogin: vi.fn().mockResolvedValue(undefined),
+  logoutIsolatedClaude: vi.fn().mockResolvedValue({ ok: true, category: 'ok' }),
+  refreshProviderModels: vi
+    .fn()
+    .mockResolvedValue({ ok: true, category: 'ok', models: ['model-1'] })
+})
+
+const createHarness = (): {
+  commands: CommandMocks
+  refreshPreflight: Mock
+  refreshFrameworkStatus: Mock
+  reconcileSnapshot: Mock
+  store: StoreApi<TestStore>
+} => {
+  const commands = createCommands()
+  const refreshPreflight = vi.fn().mockResolvedValue(undefined)
+  const refreshFrameworkStatus = vi.fn().mockResolvedValue(undefined)
+  const reconcileSnapshot = vi.fn((next: SettingsSnapshot) => {
+    store.setState({
+      providers: next.providers,
+      activeProviderId: next.activeProviderId,
+      activeModel: next.activeModel,
+      agentFrameworkId: next.agentFrameworkId
+    })
+  })
+  const store = createStore<TestStore>((set, get) => {
+    const writeCoordinator = createSettingsWriteCoordinator((settingsWriteError) =>
+      set({ settingsWriteError })
+    )
+    return {
+      providers: [],
+      activeProviderId: undefined,
+      activeModel: undefined,
+      agentFrameworkId: 'claude-code',
+      settingsWriteError: undefined,
+      ...createProviderAuthSlice({
+        get,
+        getCommands: () => commands as unknown as ProviderCommands,
+        reconcileSnapshot,
+        refreshPreflight,
+        refreshFrameworkStatus,
+        writeCoordinator
+      })
+    }
+  })
+
+  return { commands, refreshPreflight, refreshFrameworkStatus, reconcileSnapshot, store }
+}
+
+describe('provider auth slice: persistence and validation', () => {
+  let commands: CommandMocks
+  let refreshPreflight: Mock
+  let reconcileSnapshot: Mock
+  let store: StoreApi<TestStore>
+
+  beforeEach(() => {
+    ;({ commands, refreshPreflight, reconcileSnapshot, store } = createHarness())
+  })
+
+  it.each([
+    ['custom create', { type: 'custom', name: 'new' }, 'new', 'new'],
+    ['custom edit', { id: 'old', type: 'custom', name: 'old' }, 'old', 'old'],
+    ['Codex builtin', { id: 'ignored', type: 'codex-shared' }, 'old', 'builtin-codex-subscription'],
+    ['Claude shared builtin', { type: 'claude-shared' }, 'old', 'builtin-claude-shared'],
+    ['Claude isolated builtin', { type: 'claude-isolated' }, 'old', 'builtin-claude-isolated']
+  ] as const)(
+    'resolves the stable affected id for %s',
+    async (_label, request, addedId, expected) => {
+      store.setState({ providers: [provider('old')] })
+      commands.upsertProvider.mockResolvedValue(snapshot([provider('old'), provider(addedId)]))
+
+      await expect(store.getState().persistProvider(request)).resolves.toBe(expected)
+      expect(reconcileSnapshot).toHaveBeenCalledOnce()
+      expect(refreshPreflight).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('keeps failed validation, refreshes the authoritative provider, and does not roll back', async () => {
+    const failed = { ok: false, category: 'auth' } satisfies ValidateProviderResult
+    commands.upsertProvider.mockResolvedValue(snapshot([provider('new')]))
+    commands.validateProvider.mockResolvedValue(failed)
+    commands.getSettings.mockResolvedValue(snapshot([provider('new')]))
+
+    await expect(store.getState().saveProvider({ type: 'custom', name: 'new' })).resolves.toEqual({
+      providerId: 'new',
+      validation: failed
+    })
+
+    expect(commands.validateProvider).toHaveBeenCalledWith({ providerId: 'new' })
+    expect(commands.deleteProvider).not.toHaveBeenCalled()
+    expect(reconcileSnapshot).toHaveBeenCalledTimes(2)
+    expect(refreshPreflight).toHaveBeenCalledOnce()
+  })
+
+  it('returns unknown without validating or refreshing when an upsert has no affected id', async () => {
+    commands.upsertProvider.mockResolvedValue(snapshot([]))
+
+    await expect(
+      store.getState().saveProvider({ type: 'custom', name: 'missing' })
+    ).resolves.toEqual({
+      providerId: '',
+      validation: { ok: false, category: 'unknown' }
+    })
+
+    expect(commands.validateProvider).not.toHaveBeenCalled()
+    expect(commands.getSettings).not.toHaveBeenCalled()
+    expect(refreshPreflight).not.toHaveBeenCalled()
+  })
+
+  it('activates a saved provider even when its connectivity probe is advisory-failed', async () => {
+    const validation = { ok: false, category: 'network' } satisfies ValidateProviderResult
+    const saveProvider = vi.fn().mockResolvedValue({ providerId: 'new', validation })
+    const setActiveProvider = vi.fn().mockResolvedValue(undefined)
+    store.setState({ saveProvider, setActiveProvider })
+
+    await expect(
+      store.getState().saveAndActivateProvider({ type: 'custom', name: 'new' })
+    ).resolves.toEqual({ providerId: 'new', validation })
+    expect(setActiveProvider).toHaveBeenCalledWith('new')
+  })
+
+  it('refreshes saved validation outcomes but leaves draft validation projection untouched', async () => {
+    await store.getState().validateProvider({ draft: { type: 'custom', name: 'draft' } })
+    expect(commands.getSettings).not.toHaveBeenCalled()
+    expect(refreshPreflight).not.toHaveBeenCalled()
+
+    await store.getState().validateProvider({ providerId: 'saved' })
+    expect(commands.getSettings).toHaveBeenCalledOnce()
+    expect(refreshPreflight).toHaveBeenCalledOnce()
+  })
+})
+
+describe('provider auth slice: authentication and catalogs', () => {
+  let commands: CommandMocks
+  let refreshPreflight: Mock
+  let reconcileSnapshot: Mock
+  let store: StoreApi<TestStore>
+
+  beforeEach(() => {
+    ;({ commands, refreshPreflight, reconcileSnapshot, store } = createHarness())
+    commands.getSettings.mockResolvedValue(snapshot([provider('authenticated')]))
+  })
+
+  it.each([
+    ['loginIsolatedCodex', 'loginIsolatedCodex'],
+    ['logoutIsolatedCodex', 'logoutIsolatedCodex'],
+    ['loginSharedClaude', 'loginSharedClaude'],
+    ['logoutSharedClaude', 'logoutSharedClaude'],
+    ['loginIsolatedClaudeBrowser', 'loginIsolatedClaudeBrowser'],
+    ['logoutIsolatedClaude', 'logoutIsolatedClaude']
+  ] as const)('%s reconciles the recorded outcome and preflight', async (action, command) => {
+    commands[command].mockResolvedValue({ ok: false, category: 'auth' })
+
+    await expect(store.getState()[action]()).resolves.toEqual({ ok: false, category: 'auth' })
+    expect(commands[command]).toHaveBeenCalledOnce()
+    expect(reconcileSnapshot).toHaveBeenCalledOnce()
+    expect(refreshPreflight).toHaveBeenCalledOnce()
+  })
+
+  it('forwards an isolated Claude token before reconciling its recorded outcome', async () => {
+    await store.getState().loginIsolatedClaude('sk-ant-test')
+
+    expect(commands.loginIsolatedClaude).toHaveBeenCalledWith('sk-ant-test')
+    expect(reconcileSnapshot).toHaveBeenCalledOnce()
+    expect(refreshPreflight).toHaveBeenCalledOnce()
+  })
+
+  it('routes cancellation to each existing command without snapshot reconciliation', async () => {
+    await Promise.all([
+      store.getState().cancelCodexLogin(),
+      store.getState().cancelSharedClaudeLogin(),
+      store.getState().cancelIsolatedClaudeLogin()
+    ])
+
+    expect(commands.cancelCodexLogin).toHaveBeenCalledOnce()
+    expect(commands.cancelClaudeLogin).toHaveBeenCalledOnce()
+    expect(commands.cancelIsolatedClaudeLogin).toHaveBeenCalledOnce()
+    expect(commands.getSettings).not.toHaveBeenCalled()
+    expect(refreshPreflight).not.toHaveBeenCalled()
+  })
+
+  it('refreshes model catalogs only after a successful vendor fetch', async () => {
+    await store.getState().refreshProviderModels('saved')
+    expect(commands.getSettings).toHaveBeenCalledOnce()
+    expect(reconcileSnapshot).toHaveBeenCalledOnce()
+
+    commands.refreshProviderModels.mockResolvedValue({
+      ok: false,
+      category: 'auth',
+      message: 'nope'
+    })
+    await store.getState().refreshProviderModels('saved')
+    expect(commands.getSettings).toHaveBeenCalledOnce()
+    expect(reconcileSnapshot).toHaveBeenCalledOnce()
+  })
+
+  it('deletes through the authoritative snapshot and then refreshes readiness', async () => {
+    commands.deleteProvider.mockResolvedValue(snapshot([provider('remaining')]))
+
+    await store.getState().deleteProvider('removed')
+
+    expect(commands.deleteProvider).toHaveBeenCalledWith({ id: 'removed' })
+    expect(store.getState().providers.map(({ id }) => id)).toEqual(['remaining'])
+    expect(refreshPreflight).toHaveBeenCalledOnce()
+  })
+})
+
+describe('provider auth slice: active selections', () => {
+  it('normalizes an empty model and applies only the newest active-provider completion', async () => {
+    const { commands, refreshPreflight, store } = createHarness()
+    const first = deferred<SettingsSnapshot>()
+    const second = deferred<SettingsSnapshot>()
+    commands.setActiveProvider
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+
+    const stale = store.getState().setActiveProvider('first', '')
+    const current = store.getState().setActiveProvider('second', 'model-2')
+    expect(commands.setActiveProvider).toHaveBeenNthCalledWith(1, {
+      id: 'first',
+      model: undefined
+    })
+
+    second.resolve(
+      snapshot([provider('second')], { activeProviderId: 'second', activeModel: 'model-2' })
+    )
+    await current
+    first.resolve(snapshot([provider('first')], { activeProviderId: 'first' }))
+    await stale
+
+    expect(store.getState()).toMatchObject({ activeProviderId: 'second', activeModel: 'model-2' })
+    expect(refreshPreflight).toHaveBeenCalledOnce()
+  })
+
+  it('preserves rejection and exposes a path-safe active-provider write error', async () => {
+    const { commands, store } = createHarness()
+    const error = new Error('/Users/example/settings.json unavailable')
+    commands.setActiveProvider.mockRejectedValue(error)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await expect(store.getState().setActiveProvider('next')).rejects.toBe(error)
+    expect(store.getState().settingsWriteError).toBe(
+      'Could not switch active provider or model. Try again.'
+    )
+    expect(store.getState().settingsWriteError).not.toContain('/Users/example')
+  })
+
+  it('reconciles a framework before detection and keeps the saved choice if detection fails', async () => {
+    const { commands, refreshFrameworkStatus, store } = createHarness()
+    const error = new Error('probe unavailable')
+    commands.setAgentFramework.mockResolvedValue(snapshot([], { agentFrameworkId: 'codex' }))
+    refreshFrameworkStatus.mockRejectedValue(error)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await store.getState().setAgentFramework('codex')
+
+    expect(store.getState().agentFrameworkId).toBe('codex')
+    expect(refreshFrameworkStatus).toHaveBeenCalledWith('codex')
+    expect(commands.setAgentFramework.mock.invocationCallOrder[0]).toBeLessThan(
+      refreshFrameworkStatus.mock.invocationCallOrder[0]
+    )
+    expect(store.getState().settingsWriteError).toBeUndefined()
+    expect(consoleError).toHaveBeenCalledWith('Failed to refresh agent framework status', error)
+  })
+
+  it('fences an older framework completion before reconciliation and runtime detection', async () => {
+    const { commands, refreshFrameworkStatus, store } = createHarness()
+    const first = deferred<SettingsSnapshot>()
+    const second = deferred<SettingsSnapshot>()
+    commands.setAgentFramework
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+
+    const stale = store.getState().setAgentFramework('opencode')
+    const current = store.getState().setAgentFramework('codex')
+    second.resolve(snapshot([], { agentFrameworkId: 'codex' }))
+    await current
+    first.resolve(snapshot([], { agentFrameworkId: 'opencode' }))
+    await stale
+
+    expect(store.getState().agentFrameworkId).toBe('codex')
+    expect(refreshFrameworkStatus).toHaveBeenCalledOnce()
+    expect(refreshFrameworkStatus).toHaveBeenCalledWith('codex')
+  })
+})

--- a/src/renderer/src/stores/settings-provider-auth-slice.ts
+++ b/src/renderer/src/stores/settings-provider-auth-slice.ts
@@ -1,0 +1,268 @@
+import type { StoreApi } from 'zustand'
+
+import {
+  claudeIsolatedProviderIdentity,
+  claudeSharedProviderIdentity,
+  codexSubscriptionProviderIdentity,
+  isCodexSubscriptionProvider
+} from '../../../shared/settings'
+import type {
+  AgentFrameworkId,
+  ProviderView,
+  RefreshProviderModelsResult,
+  SettingsSnapshot,
+  UpsertProviderRequest,
+  ValidateProviderRequest,
+  ValidateProviderResult
+} from '../../../shared/settings'
+import type { SettingsWriteCoordinator } from './settings-write-coordinator'
+
+export type SaveProviderResult = {
+  providerId: string
+  validation: ValidateProviderResult
+}
+
+export type ProviderAuthActions = {
+  persistProvider: (request: UpsertProviderRequest) => Promise<string>
+  saveProvider: (request: UpsertProviderRequest) => Promise<SaveProviderResult>
+  saveAndActivateProvider: (request: UpsertProviderRequest) => Promise<SaveProviderResult>
+  validateProvider: (request: ValidateProviderRequest) => Promise<ValidateProviderResult>
+  cancelCodexLogin: () => Promise<void>
+  loginIsolatedCodex: () => Promise<ValidateProviderResult>
+  logoutIsolatedCodex: () => Promise<ValidateProviderResult>
+  loginSharedClaude: () => Promise<ValidateProviderResult>
+  cancelSharedClaudeLogin: () => Promise<void>
+  logoutSharedClaude: () => Promise<ValidateProviderResult>
+  loginIsolatedClaude: (token: string) => Promise<ValidateProviderResult>
+  loginIsolatedClaudeBrowser: () => Promise<ValidateProviderResult>
+  cancelIsolatedClaudeLogin: () => Promise<void>
+  logoutIsolatedClaude: () => Promise<ValidateProviderResult>
+  refreshProviderModels: (providerId: string) => Promise<RefreshProviderModelsResult>
+  setActiveProvider: (providerId: string, model?: string) => Promise<void>
+  setAgentFramework: (id: AgentFrameworkId) => Promise<void>
+  deleteProvider: (providerId: string) => Promise<void>
+}
+
+// This slice owns workflows only. Core remains the sole owner of the full Settings snapshot so
+// provider/runtime/preferences fields continue to reconcile in one atomic store update.
+
+type ProviderAuthHost = ProviderAuthActions & { providers: ProviderView[] }
+
+type ProviderAuthCommands = Pick<
+  Window['api']['settings'],
+  | 'getSettings'
+  | 'upsertProvider'
+  | 'deleteProvider'
+  | 'setActiveProvider'
+  | 'setAgentFramework'
+  | 'validateProvider'
+  | 'cancelCodexLogin'
+  | 'cancelClaudeLogin'
+  | 'loginIsolatedCodex'
+  | 'logoutIsolatedCodex'
+  | 'loginSharedClaude'
+  | 'logoutSharedClaude'
+  | 'loginIsolatedClaude'
+  | 'loginIsolatedClaudeBrowser'
+  | 'cancelIsolatedClaudeLogin'
+  | 'logoutIsolatedClaude'
+  | 'refreshProviderModels'
+>
+
+type ProviderAuthSliceOptions<Store extends ProviderAuthHost> = {
+  get: StoreApi<Store>['getState']
+  getCommands: () => ProviderAuthCommands
+  reconcileSnapshot: (snapshot: SettingsSnapshot) => void
+  refreshPreflight: () => Promise<unknown>
+  refreshFrameworkStatus: (id: AgentFrameworkId) => Promise<void>
+  writeCoordinator: SettingsWriteCoordinator
+}
+
+const resolveUpsertedProviderId = (
+  request: UpsertProviderRequest,
+  before: ProviderView[],
+  after: ProviderView[]
+): string | undefined => {
+  if (isCodexSubscriptionProvider(request.type)) {
+    return codexSubscriptionProviderIdentity().id
+  }
+  if (request.type === 'claude-shared') return claudeSharedProviderIdentity().id
+  if (request.type === 'claude-isolated') return claudeIsolatedProviderIdentity().id
+  if (request.id) return request.id
+
+  const beforeIds = new Set(before.map((provider) => provider.id))
+  return after.find((provider) => !beforeIds.has(provider.id))?.id
+}
+
+export const createProviderAuthSlice = <Store extends ProviderAuthHost>({
+  get,
+  getCommands,
+  reconcileSnapshot,
+  refreshPreflight,
+  refreshFrameworkStatus,
+  writeCoordinator
+}: ProviderAuthSliceOptions<Store>): ProviderAuthActions => ({
+  persistProvider: async (request) => {
+    const commands = getCommands()
+    const before = get().providers
+    const snapshot = await commands.upsertProvider(request)
+
+    reconcileSnapshot(snapshot)
+    await refreshPreflight()
+    return resolveUpsertedProviderId(request, before, snapshot.providers) ?? ''
+  },
+
+  saveProvider: async (request) => {
+    const commands = getCommands()
+    const before = get().providers
+    const snapshot = await commands.upsertProvider(request)
+    reconcileSnapshot(snapshot)
+
+    const providerId = resolveUpsertedProviderId(request, before, snapshot.providers)
+    if (!providerId) {
+      return { providerId: '', validation: { ok: false, category: 'unknown' } }
+    }
+
+    const validation = await commands.validateProvider({ providerId })
+    reconcileSnapshot(await commands.getSettings())
+    await refreshPreflight()
+    return { providerId, validation }
+  },
+
+  saveAndActivateProvider: async (request) => {
+    const result = await get().saveProvider(request)
+    if (result.providerId) await get().setActiveProvider(result.providerId)
+    return result
+  },
+
+  validateProvider: async (request) => {
+    const commands = getCommands()
+    const result = await commands.validateProvider(request)
+    if (request.providerId) {
+      reconcileSnapshot(await commands.getSettings())
+      await refreshPreflight()
+    }
+    return result
+  },
+
+  cancelCodexLogin: () => getCommands().cancelCodexLogin(),
+
+  loginIsolatedCodex: async () => {
+    const commands = getCommands()
+    const result = await commands.loginIsolatedCodex()
+    reconcileSnapshot(await commands.getSettings())
+    await refreshPreflight()
+    return result
+  },
+
+  logoutIsolatedCodex: async () => {
+    const commands = getCommands()
+    const result = await commands.logoutIsolatedCodex()
+    reconcileSnapshot(await commands.getSettings())
+    await refreshPreflight()
+    return result
+  },
+
+  loginSharedClaude: async () => {
+    const commands = getCommands()
+    const result = await commands.loginSharedClaude()
+    reconcileSnapshot(await commands.getSettings())
+    await refreshPreflight()
+    return result
+  },
+
+  cancelSharedClaudeLogin: async () => {
+    await getCommands().cancelClaudeLogin()
+  },
+
+  logoutSharedClaude: async () => {
+    const commands = getCommands()
+    const result = await commands.logoutSharedClaude()
+    reconcileSnapshot(await commands.getSettings())
+    await refreshPreflight()
+    return result
+  },
+
+  loginIsolatedClaude: async (token) => {
+    const commands = getCommands()
+    const result = await commands.loginIsolatedClaude(token)
+    reconcileSnapshot(await commands.getSettings())
+    await refreshPreflight()
+    return result
+  },
+
+  loginIsolatedClaudeBrowser: async () => {
+    const commands = getCommands()
+    const result = await commands.loginIsolatedClaudeBrowser()
+    reconcileSnapshot(await commands.getSettings())
+    await refreshPreflight()
+    return result
+  },
+
+  cancelIsolatedClaudeLogin: async () => {
+    await getCommands().cancelIsolatedClaudeLogin()
+  },
+
+  logoutIsolatedClaude: async () => {
+    const commands = getCommands()
+    const result = await commands.logoutIsolatedClaude()
+    reconcileSnapshot(await commands.getSettings())
+    await refreshPreflight()
+    return result
+  },
+
+  refreshProviderModels: async (providerId) => {
+    const commands = getCommands()
+    const result = await commands.refreshProviderModels({ providerId })
+    if (result.ok) reconcileSnapshot(await commands.getSettings())
+    return result
+  },
+
+  setActiveProvider: async (providerId, model) => {
+    const write = writeCoordinator.begin('activeProvider')
+    let snapshot: SettingsSnapshot
+    try {
+      snapshot = await getCommands().setActiveProvider({
+        id: providerId,
+        model: model || undefined
+      })
+    } catch (error) {
+      write.fail('Could not switch active provider or model. Try again.')
+      console.error('Failed to set active provider', error)
+      throw error
+    }
+
+    if (!write.isCurrent()) return
+    reconcileSnapshot(snapshot)
+    write.succeed()
+    await refreshPreflight()
+  },
+
+  setAgentFramework: async (id) => {
+    const write = writeCoordinator.begin('agentFramework')
+    let snapshot: SettingsSnapshot
+    try {
+      snapshot = await getCommands().setAgentFramework({ id })
+    } catch (error) {
+      write.fail('Could not switch agent framework. Try again.')
+      console.error('Failed to switch agent framework', error)
+      throw error
+    }
+
+    if (!write.isCurrent()) return
+    reconcileSnapshot(snapshot)
+    write.succeed()
+
+    try {
+      await refreshFrameworkStatus(id)
+    } catch (error) {
+      console.error('Failed to refresh agent framework status', error)
+    }
+  },
+
+  deleteProvider: async (providerId) => {
+    const snapshot = await getCommands().deleteProvider({ id: providerId })
+    reconcileSnapshot(snapshot)
+    await refreshPreflight()
+  }
+})

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -2,15 +2,11 @@ import { create, type StoreApi } from 'zustand'
 
 import type { OfficialVendorId } from '../../../shared/provider-registry'
 import {
-  codexSubscriptionProviderIdentity,
-  claudeSharedProviderIdentity,
-  claudeIsolatedProviderIdentity,
   DEFAULT_APP_ICON_VARIANT,
   DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
   DEFAULT_NOTIFICATIONS_ENABLED,
   DEFAULT_REASONING_EFFORT,
   isClaudeSubscriptionProvider,
-  isCodexSubscriptionProvider,
   providerValidationFailed,
   selectClaudeSubscriptionProvider
 } from '../../../shared/settings'
@@ -20,9 +16,14 @@ import { isMirrorConfigured } from '../pages/settings/mirror-view'
 import type { SettingsPanelId } from '../pages/settings/settings-navigation'
 import {
   createSettingsWriteCoordinator,
-  type SettingsWriteCoordinator,
-  type SettingsWriteKey
+  type OptimisticSettingsWriteKey,
+  type SettingsWriteCoordinator
 } from './settings-write-coordinator'
+import {
+  createProviderAuthSlice,
+  type ProviderAuthActions,
+  type SaveProviderResult
+} from './settings-provider-auth-slice'
 import {
   createInitialRuntimeSetupState,
   createRuntimeSetupLoadPatch,
@@ -41,7 +42,6 @@ import type {
   OpencodeInfo,
   ProviderType,
   ProviderView,
-  RefreshProviderModelsResult,
   ReasoningEffort,
   SettingsSnapshot,
   AppIconVariant,
@@ -56,9 +56,6 @@ import type {
   SkillBundlePreviewResult,
   SkillImportPreviewContent,
   ScanRepoResult,
-  UpsertProviderRequest,
-  ValidateProviderRequest,
-  ValidateProviderResult,
   ConnectorView,
   ConnectorDetailView,
   CustomServerView,
@@ -71,12 +68,6 @@ import type {
   ConnectorApprovalRequest,
   ApprovalDecision
 } from '../../../shared/settings'
-
-// Result of the combined onboarding save flow (create/edit -> validate -> activate).
-type SaveProviderResult = {
-  providerId: string
-  validation: ValidateProviderResult
-}
 
 type SettingsStoreData = RuntimeSetupState & {
   isLoaded: boolean
@@ -137,48 +128,10 @@ type SettingsStoreData = RuntimeSetupState & {
   appIconVariant: AppIconVariant
 }
 
-type SettingsStoreCore = SettingsStoreData & {
+type SettingsStoreCore = SettingsStoreData & ProviderAuthActions & SettingsStoreActions
+
+type SettingsStoreActions = {
   load: (options?: { force?: boolean }) => Promise<boolean>
-  // Persists the draft (create/update) without testing it, returning the affected provider id. The
-  // Settings page uses this to return to the list immediately, then tests in the background.
-  persistProvider: (request: UpsertProviderRequest) => Promise<string>
-  // Persists the draft and validates it, without changing the active provider.
-  saveProvider: (request: UpsertProviderRequest) => Promise<SaveProviderResult>
-  // Combined onboarding flow: persist + validate + activate only on success.
-  saveAndActivateProvider: (request: UpsertProviderRequest) => Promise<SaveProviderResult>
-  validateProvider: (request: ValidateProviderRequest) => Promise<ValidateProviderResult>
-  cancelCodexLogin: () => Promise<void>
-  // The explicit isolated sign-in — the only flow that opens the browser login. Resolves with the
-  // recorded outcome so callers can react (onboarding advances only on success).
-  loginIsolatedCodex: () => Promise<ValidateProviderResult>
-  // The explicit isolated sign-out. Resolves with the outcome so callers can surface a failure
-  // (e.g. a timeout where the credential may still be in place) rather than silently succeeding.
-  logoutIsolatedCodex: () => Promise<ValidateProviderResult>
-  // The Claude subscription's browser OAuth login (claude-shared mode). Opens the browser for sign-in
-  // via `claude auth login --claudeai`. Resolves with the recorded outcome.
-  loginSharedClaude: () => Promise<ValidateProviderResult>
-  // Cancels an in-flight claude-shared browser sign-in (mirrors cancelIsolatedClaudeLogin).
-  cancelSharedClaudeLogin: () => Promise<void>
-  // The Claude subscription's browser OAuth sign-out (claude-shared mode).
-  logoutSharedClaude: () => Promise<ValidateProviderResult>
-  // The Claude subscription's setup-token paste (claude-isolated mode). Resolves with the recorded
-  // outcome; the renderer is responsible for collecting the token from the user (copy command + paste input).
-  loginIsolatedClaude: (token: string) => Promise<ValidateProviderResult>
-  // The Claude subscription's browser OAuth for claude-isolated mode: the app runs `claude setup-token`
-  // (opens the browser) under the isolated config dir and captures the token — no manual paste.
-  loginIsolatedClaudeBrowser: () => Promise<ValidateProviderResult>
-  // Cancels an in-flight claude-isolated browser sign-in.
-  cancelIsolatedClaudeLogin: () => Promise<void>
-  // The Claude subscription's sign-out. Same failure semantics as logoutIsolatedCodex: a failed
-  // sign-out is surfaced rather than silently swallowed.
-  logoutIsolatedClaude: () => Promise<ValidateProviderResult>
-  // Fetches a saved provider's live model list from the vendor and refreshes the cache on success.
-  refreshProviderModels: (providerId: string) => Promise<RefreshProviderModelsResult>
-  // Activates a provider and, optionally, a specific model within it (composer model switch). An
-  // omitted model lets main fall back to the provider's default.
-  setActiveProvider: (providerId: string, model?: string) => Promise<void>
-  // Switches the agent backend (main reconnects so the next prompt uses it).
-  setAgentFramework: (id: AgentFrameworkId) => Promise<void>
   // Sets the reasoning-effort level (main reconnects so subsequent requests run at it).
   setReasoningEffort: (effort: ReasoningEffort) => Promise<void>
   // Toggles desktop notifications for finished/failed agent tasks; applies immediately.
@@ -188,7 +141,6 @@ type SettingsStoreCore = SettingsStoreData & {
   // Sets the app-icon look; main applies it live to the window and dock/taskbar.
   setAppIconVariant: (variant: AppIconVariant) => Promise<void>
   clearSettingsWriteError: () => void
-  deleteProvider: (providerId: string) => Promise<void>
   openSettings: () => void
   openSettingsToPanel: (panel: SettingsPanelId) => void
   closeSettings: () => void
@@ -390,27 +342,6 @@ export const selectProviderModelOptions = (
     })
 }
 
-// Finds the provider id affected by an upsert: the edited id, or the one new since `before`.
-const resolveUpsertedProviderId = (
-  request: UpsertProviderRequest,
-  before: ProviderView[],
-  after: ProviderView[]
-): string | undefined => {
-  if (isCodexSubscriptionProvider(request.type)) {
-    return codexSubscriptionProviderIdentity().id
-  }
-  // Both Claude subscription modes use fixed builtin ids; return the correct one for the new type
-  // so mode switches (shared→isolated or vice versa) resolve to the incoming record, not the old one.
-  if (request.type === 'claude-shared') return claudeSharedProviderIdentity().id
-  if (request.type === 'claude-isolated') return claudeIsolatedProviderIdentity().id
-
-  if (request.id) return request.id
-
-  const beforeIds = new Set(before.map((provider) => provider.id))
-
-  return after.find((provider) => !beforeIds.has(provider.id))?.id
-}
-
 let settingsLoadPromise: Promise<boolean> | undefined
 const SAFE_SETTINGS_LOAD_ERROR = 'Open Science could not load settings. Retry to continue.'
 
@@ -420,9 +351,7 @@ const reportSettingsLoadError = (error: unknown): void => {
 }
 
 // Visible copy stays stable and path-safe; raw IPC failures remain in the console for diagnostics.
-const SETTINGS_WRITE_ERRORS: Record<SettingsWriteKey, string> = {
-  activeProvider: 'Could not switch active provider or model. Try again.',
-  agentFramework: 'Could not switch agent framework. Try again.',
+const SETTINGS_WRITE_ERRORS: Record<OptimisticSettingsWriteKey, string> = {
   reasoningEffort: 'Could not save reasoning effort. Try again.',
   notifications: 'Could not save notification preference. Try again.',
   conversationSkillImport: 'Could not save conversation Skill import preference. Try again.',
@@ -451,6 +380,23 @@ const createSettingsStoreState = (
           ? { npmAvailable, claude: { resolvedPath: result.path, version: result.version } }
           : { npmAvailable }
       )
+  }),
+  ...createProviderAuthSlice({
+    get,
+    getCommands: () => window.api.settings,
+    reconcileSnapshot: (snapshot) => set(applySnapshot(snapshot)),
+    refreshPreflight: () => get().refreshPreflight(),
+    refreshFrameworkStatus: async (id) => {
+      if (id === 'opencode') {
+        await get().detectOpencode()
+      } else if (id === 'codex') {
+        await get().detectCodex()
+      } else {
+        await get().detectClaude()
+      }
+      await get().refreshPreflight()
+    },
+    writeCoordinator
   }),
 
   // Loads settings, preflight, and encryption availability in one startup pass.
@@ -500,220 +446,6 @@ const createSettingsStoreState = (
       if (settingsLoadPromise === loadPromise) settingsLoadPromise = undefined
     })
     return loadPromise
-  },
-
-  // Persists a provider draft (create/update) and refreshes derived state, without testing it.
-  persistProvider: async (request) => {
-    const before = get().providers
-    const afterUpsert = await window.api.settings.upsertProvider(request)
-
-    set(applySnapshot(afterUpsert))
-    await get().refreshPreflight()
-
-    return resolveUpsertedProviderId(request, before, afterUpsert.providers) ?? ''
-  },
-
-  // Persists a provider draft and validates it (without activating), refreshing derived state.
-  saveProvider: async (request) => {
-    const before = get().providers
-    const afterUpsert = await window.api.settings.upsertProvider(request)
-
-    set(applySnapshot(afterUpsert))
-
-    const providerId = resolveUpsertedProviderId(request, before, afterUpsert.providers)
-
-    if (!providerId) {
-      return { providerId: '', validation: { ok: false, category: 'unknown' } }
-    }
-
-    const validation = await window.api.settings.validateProvider({ providerId })
-
-    // Refresh so the validated-at time / recorded failure / masked key reflect the latest stored
-    // state. A failed test keeps the provider (flagged as unverified in the list and excluded from the
-    // model pickers); it is not rolled back, so the user can fix the key and retry.
-    set(applySnapshot(await window.api.settings.getSettings()))
-    await get().refreshPreflight()
-
-    return { providerId, validation }
-  },
-
-  // Persists a provider draft, validates it, and activates it. The connectivity probe is advisory,
-  // not a gate: a provider that saved is activated even if the probe failed (e.g. a custom Responses
-  // gateway the probe can't reach or that rejects the minimal ping), so it can be configured in and
-  // tested live. The validation result is still recorded and surfaced as an "unverified" warning.
-  saveAndActivateProvider: async (request) => {
-    const result = await get().saveProvider(request)
-
-    if (result.providerId) {
-      await get().setActiveProvider(result.providerId)
-    }
-
-    return result
-  },
-
-  // Validates a saved provider or draft without changing the active selection.
-  validateProvider: async (request) => {
-    const result = await window.api.settings.validateProvider(request)
-
-    // Refresh whenever a saved provider was tested, pass or fail: success stamps lastValidatedAt, a
-    // failure records the reason and surfaces the "unverified" warning. Draft validations (no
-    // providerId) change nothing stored, so they skip the refresh.
-    if (request.providerId) {
-      set(applySnapshot(await window.api.settings.getSettings()))
-      await get().refreshPreflight()
-    }
-
-    return result
-  },
-
-  cancelCodexLogin: () => window.api.settings.cancelCodexLogin(),
-
-  // Mirrors validateProvider's refresh: the recorded outcome (validated-at or failure) lives on the
-  // stored provider, so the snapshot and derived readiness are re-applied either way.
-  loginIsolatedCodex: async () => {
-    const result = await window.api.settings.loginIsolatedCodex()
-
-    set(applySnapshot(await window.api.settings.getSettings()))
-    await get().refreshPreflight()
-
-    return result
-  },
-
-  logoutIsolatedCodex: async () => {
-    const result = await window.api.settings.logoutIsolatedCodex()
-    // Refresh the snapshot regardless of outcome: a failed sign-out preserves the verified markers
-    // on the provider (credential still in place), a successful one clears them. Either way the
-    // store must reflect the true stored state rather than a stale cached view.
-    set(applySnapshot(await window.api.settings.getSettings()))
-    await get().refreshPreflight()
-    return result
-  },
-
-  // Claude subscription's paste-token sign-in. The renderer owns the modal that captures the
-  // setup-token output; this action forwards it to main, where it lands encrypted on the fixed
-  // builtin-claude-isolated provider record.
-  loginIsolatedClaude: async (token: string) => {
-    const result = await window.api.settings.loginIsolatedClaude(token)
-
-    set(applySnapshot(await window.api.settings.getSettings()))
-    await get().refreshPreflight()
-
-    return result
-  },
-
-  // Claude subscription's browser OAuth for claude-isolated mode. The app runs `claude setup-token`
-  // under the isolated config dir (opens the browser, captures the token) so there's no manual paste.
-  loginIsolatedClaudeBrowser: async () => {
-    const result = await window.api.settings.loginIsolatedClaudeBrowser()
-
-    set(applySnapshot(await window.api.settings.getSettings()))
-    await get().refreshPreflight()
-
-    return result
-  },
-
-  cancelIsolatedClaudeLogin: async () => {
-    await window.api.settings.cancelIsolatedClaudeLogin()
-  },
-
-  logoutIsolatedClaude: async () => {
-    const result = await window.api.settings.logoutIsolatedClaude()
-    // Same refresh rule as the codex path: a failed sign-out keeps the verified markers, so the
-    // store must reflect the real stored state regardless of the outcome.
-    set(applySnapshot(await window.api.settings.getSettings()))
-    await get().refreshPreflight()
-    return result
-  },
-
-  // Claude subscription's browser OAuth sign-in (claude-shared mode). Opens the browser via
-  // `claude auth login --claudeai`. The CLI stores credentials in ~/.claude.
-  loginSharedClaude: async () => {
-    const result = await window.api.settings.loginSharedClaude()
-
-    set(applySnapshot(await window.api.settings.getSettings()))
-    await get().refreshPreflight()
-
-    return result
-  },
-
-  cancelSharedClaudeLogin: async () => {
-    await window.api.settings.cancelClaudeLogin()
-  },
-
-  logoutSharedClaude: async () => {
-    const result = await window.api.settings.logoutSharedClaude()
-    set(applySnapshot(await window.api.settings.getSettings()))
-    await get().refreshPreflight()
-    return result
-  },
-
-  // Fetches a provider's live models from the vendor; on success the persisted list is reflected here.
-  refreshProviderModels: async (providerId) => {
-    const result = await window.api.settings.refreshProviderModels({ providerId })
-
-    if (result.ok) {
-      set(applySnapshot(await window.api.settings.getSettings()))
-    }
-
-    return result
-  },
-
-  // Switches the active provider/model (main drops the agent connection so the next prompt reconnects).
-  // An empty model string is treated as "no specific model" so main uses the provider default.
-  setActiveProvider: async (providerId, model) => {
-    const write = writeCoordinator.begin('activeProvider')
-    let snapshot: SettingsSnapshot
-    try {
-      snapshot = await window.api.settings.setActiveProvider({
-        id: providerId,
-        model: model || undefined
-      })
-    } catch (error) {
-      write.fail(SETTINGS_WRITE_ERRORS.activeProvider)
-      console.error('Failed to set active provider', error)
-      throw error
-    }
-
-    if (!write.isCurrent()) return
-    set(applySnapshot(snapshot))
-    write.succeed()
-    await get().refreshPreflight()
-  },
-
-  // Switches the agent backend; main reconnects so the choice applies on the next prompt. A failed
-  // write leaves the previous framework selected and feeds the shared Settings error banner.
-  setAgentFramework: async (id) => {
-    const write = writeCoordinator.begin('agentFramework')
-
-    let snapshot: SettingsSnapshot
-    try {
-      snapshot = await window.api.settings.setAgentFramework({ id })
-    } catch (error) {
-      write.fail(SETTINGS_WRITE_ERRORS.agentFramework)
-      console.error('Failed to switch agent framework', error)
-      throw error
-    }
-
-    if (!write.isCurrent()) return
-    set(applySnapshot(snapshot))
-    write.succeed()
-
-    try {
-      // Live-detect the newly-selected framework so a binary installed (or deleted) since the last
-      // check is reflected right away, then refresh the readiness gate the install prompt keys off.
-      if (id === 'opencode') {
-        await get().detectOpencode()
-      } else if (id === 'codex') {
-        await get().detectCodex()
-      } else {
-        await get().detectClaude()
-      }
-      await get().refreshPreflight()
-    } catch (error) {
-      // The preference is already saved. Keep the new selection and avoid relabelling a follow-up
-      // detection problem as a write failure; the next explicit/full environment check can retry.
-      console.error('Failed to refresh agent framework status', error)
-    }
   },
 
   // Sets the reasoning-effort level; main reconnects so subsequent requests run at it. The IPC round
@@ -825,13 +557,6 @@ const createSettingsStoreState = (
   },
 
   clearSettingsWriteError: () => writeCoordinator.clearFailures(),
-
-  deleteProvider: async (providerId) => {
-    const snapshot = await window.api.settings.deleteProvider({ id: providerId })
-
-    set(applySnapshot(snapshot))
-    await get().refreshPreflight()
-  },
 
   openSettings: () => set({ isSettingsOpen: true }),
 


### PR DESCRIPTION
## Problem

After runtime setup moved behind its owner, `settings-store.ts` still directly coordinated provider persistence, validation, subscription authentication, model refresh, deletion, and active provider/framework selection. These workflows shared the full Settings snapshot and write coordinator but had no single renderer owner.

## Proposed change

- Add one stateless provider/auth action slice that owns provider CRUD, validation, Codex and Claude authentication/cancellation/logout, model refresh, and active provider/framework selection.
- Keep the core store as the sole owner of the full Settings snapshot. Every provider action reconciles through the existing core projector, so provider, framework, runtime, and preference fields still land in one atomic Zustand update.
- Inject the existing R1 write coordinator only for active-provider and agent-framework writes. Persistence, validation, authentication, deletion, and model refresh retain their existing non-generation/non-rollback behavior.
- Keep framework settlement ordering: persist and reconcile the selected framework, then detect that runtime and refresh preflight; a follow-up probe failure is logged without rolling back or relabelling the successful write.
- Reduce `settings-store.ts` from 1,078 to 803 physical lines. Production raw is 599 lines: 268 additions in the new owner plus 28 additions and 303 deletions in the compatibility store. The 660 split trigger did not fire.

```mermaid
flowchart LR
  Consumers["Settings / onboarding / workspace consumers"] --> Store["useSettingsStore compatibility interface"]
  Store --> Provider["stateless provider/auth action owner"]
  Store --> Core["full snapshot projector"]
  Provider --> Commands["existing Settings renderer commands"]
  Provider --> Writes["existing R1 write coordinator"]
  Provider --> Core
```

## Scope and non-goals

In scope: stable affected-provider ID resolution, persist/save/save-and-activate, saved/draft validation, Codex isolated and Claude shared/isolated authentication lifecycles, model refresh, provider deletion, and active provider/model/framework writes.

Out of scope: new pending-auth state, new concurrency policy, provider/model compatibility changes, browser/OAuth changes, main-process Settings ownership, runtime installation behavior, preferences, navigation, Skills, Connectors, transport contracts, or UI changes. Public selectors remain on the compatibility facade; no second store or snapshot mirror is introduced.

## Compatibility

- Public Settings state/action names, selectors, `getState`/`setState`, IPC channels, payloads, preload types, generated Web maps, persisted data, and user interactions are unchanged.
- Provider validation remains advisory: a successfully persisted provider can still activate when its connectivity probe fails, and the failed validation remains recorded instead of rolling the provider back.
- Saved validation and every completed login/logout outcome still refresh the full snapshot and preflight. Draft validation does neither. Authentication cancellation still performs no snapshot refresh.
- Provider model refresh still reconciles only on success. Provider deletion still reconciles before refreshing preflight.
- Active provider/model and framework writes retain R1 same-key stale-completion fencing and path-safe visible errors. Other provider/auth commands intentionally remain unfenced and non-optimistic.
- Electron and local Web retain their current provider/auth commands. Remote Web retains provider CRUD/validation/model/selection/framework commands and continues to reject local-only login/logout/cancel commands before dispatch. CLI and Task do not instantiate this renderer store or gain Settings commands.
- Specialist, Permission, Compute, runtime installation, local RPC, MCP, and Issue #458 boundaries are untouched.

## Acceptance criteria and validation

All checks ran after the clean rebase onto `6c973c67` and the last material edit on exact commit `297f6486`:

- provider/auth lifecycle, stable IDs, advisory validation, auth settlement, catalog refresh, deletion, active-selection errors and stale writes -> `npm test -- src/renderer/src/stores/settings-provider-auth-slice.test.ts` -> 23/23 passed
- composed compatibility store and R0 behavior -> `npm test -- src/renderer/src/stores/settings-store.test.ts` -> 88/88 passed
- Provider onboarding, Providers race behavior, model/framework selection, Agent/Settings integration, and image capability consumers -> targeted seven renderer test files -> 140/140 passed
- combined final Test Impact Set -> 9 files, 251/251 passed
- renderer type safety -> `npm run typecheck:web` -> passed
- changed TypeScript files -> `npx eslint src/renderer/src/stores/settings-store.ts src/renderer/src/stores/settings-provider-auth-slice.ts src/renderer/src/stores/settings-provider-auth-slice.test.ts` -> passed
- patch hygiene -> `git diff --check` -> passed
- independent exact-diff review -> Standards 0 findings; Spec 0 findings; impact mapping independently reproduced

Uncovered locally: the full portable suite and platform/E2E lanes were not run. PR Gate remains authoritative for the final exact-head impact plan and cross-platform lanes.

## Review focus

- Confirm the owner is action-only and every returned Settings snapshot still flows through the core full-snapshot projector atomically.
- Confirm only active-provider and agent-framework selection use the R1 coordinator; persistence/auth/model/deletion did not acquire speculative fencing or rollback.
- Confirm custom edit/new and fixed Codex/Claude provider IDs resolve exactly as before, and failed validation remains advisory.
- Confirm every login/logout/cancel path retains its exact command, result, snapshot, and preflight ordering.
- Confirm stale active-provider/framework completions cannot reconcile or launch follow-up detection, while follow-up runtime detection failures keep the saved selection.
- Confirm Electron/local Web/remote Web restrictions and all public renderer interfaces remain unchanged.

Merge with squash only after exact-head CI and AI review are green.
