### PR TITLE
refactor(notebook): centralize runtime repair policy

### DIFF
--- a/src/main/notebook/data-execution-admission.ts
+++ b/src/main/notebook/data-execution-admission.ts
@@ -9,12 +9,11 @@ import {
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
   envPrefix,
-  isRepairRequired,
-  managedRepairRegistryKey,
   pythonBin,
   rBin,
   resolveEnvName
 } from './runtime-paths'
+import type { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import type {
   NotebookSessionAggregate,
   NotebookSessionResolvedInterpreter,
@@ -32,7 +31,6 @@ type NotebookDataExecutionAdmission = Readonly<{
   binding?: NotebookSessionRuntimeBinding
   resolvedInterpreter?: NotebookSessionResolvedInterpreter
   rejection?: unknown
-  repairKeys: readonly string[]
 }>
 
 type NotebookDataExecutionAdmissionOwnerOptions = {
@@ -47,6 +45,7 @@ type NotebookDataExecutionAdmissionOwnerOptions = {
   >
   ensureRecovered: () => Promise<void>
   resolveRuntimeEnablement: (language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>
+  repairPolicy: Pick<NotebookRuntimeRepairPolicy, 'blockKey' | 'requirement'>
 }
 
 const defaultEnvironment = (language: NotebookLanguage): string =>
@@ -54,15 +53,6 @@ const defaultEnvironment = (language: NotebookLanguage): string =>
 
 const processKey = (language: NotebookLanguage, environment: string): string =>
   `${language === 'r' ? 'r' : 'python'}:${resolveEnvName(language, environment)}`
-
-const repairBlockKey = (
-  language: NotebookLanguage,
-  environment: string,
-  binding: NotebookSessionRuntimeBinding | undefined
-): string =>
-  binding?.source === 'external'
-    ? `external:${language}:${binding.runtimeId}`
-    : processKey(language, environment)
 
 const repairRequiredError = (language: NotebookLanguage): Error =>
   new Error(
@@ -91,7 +81,7 @@ class NotebookDataExecutionAdmissionOwner {
     const runtimeRoot = this.options.runtimeRoot
     await this.options.ensureRecovered()
     const binding = session.runtimeBinding(cell.language)
-    const repairKeys = this.repairRegistryKeys(cell.language, route.environment, binding)
+    const repair = this.options.repairPolicy.requirement(cell.language, route.environment, binding)
     let resolvedInterpreter: NotebookSessionResolvedInterpreter | undefined
     let rejection: unknown
     const isExternal = binding?.source === 'external'
@@ -102,8 +92,8 @@ class NotebookDataExecutionAdmissionOwner {
       (isExternal && this.options.recovery.isGloballyBlocked())
     const repairRequired =
       this.options.environmentOperations.isRepairBlocked(
-        repairBlockKey(cell.language, route.environment, binding)
-      ) || repairKeys.some((key) => isRepairRequired(runtimeRoot, key))
+        this.options.repairPolicy.blockKey(cell.language, route.environment, binding)
+      ) || repair.required
 
     if (recoveryBlocked) {
       rejection = new Error(
@@ -150,7 +140,7 @@ class NotebookDataExecutionAdmissionOwner {
     if (blockedMutation && rejection === undefined) {
       rejection = new Error(`MANAGED_RUNTIME_MUTATION_BLOCKED: ${blockedMutation.message}`)
     }
-    return { language: cell.language, route, binding, resolvedInterpreter, rejection, repairKeys }
+    return { language: cell.language, route, binding, resolvedInterpreter, rejection }
   }
 
   runShared<Result>(
@@ -161,10 +151,19 @@ class NotebookDataExecutionAdmissionOwner {
       'execution',
       admission.route.environment,
       () => {
+        const repair = this.options.repairPolicy.requirement(
+          admission.language,
+          admission.route.environment,
+          admission.binding
+        )
         const postLockRepairRequired =
           this.options.environmentOperations.isRepairBlocked(
-            repairBlockKey(admission.language, admission.route.environment, admission.binding)
-          ) || admission.repairKeys.some((key) => isRepairRequired(this.options.runtimeRoot, key))
+            this.options.repairPolicy.blockKey(
+              admission.language,
+              admission.route.environment,
+              admission.binding
+            )
+          ) || repair.required
         return operation(
           postLockRepairRequired ? repairRequiredError(admission.language) : admission.rejection
         )
@@ -211,25 +210,6 @@ class NotebookDataExecutionAdmissionOwner {
         }
       }
     })
-  }
-
-  private repairRegistryKeys(
-    language: NotebookLanguage,
-    environment: string,
-    binding: NotebookSessionRuntimeBinding | undefined
-  ): string[] {
-    if (binding?.source === 'external') return [binding.runtimeId]
-    const keys = new Set([environment, managedRepairRegistryKey(environment, language)])
-    if (binding?.source === 'managed') keys.add(binding.runtimeId)
-    const prefix = envPrefix(this.options.runtimeRoot, environment)
-    const interpreter = language === 'r' ? rBin(prefix) : pythonBin(prefix)
-    keys.add(interpreter)
-    try {
-      keys.add(realpathSync(interpreter))
-    } catch {
-      // The raw path still covers repair markers for an unmaterialized runtime.
-    }
-    return [...keys]
   }
 }
 

--- a/src/main/notebook/package-admission.test.ts
+++ b/src/main/notebook/package-admission.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { NotebookLanguage } from '../../shared/notebook'
 import { NotebookPackageAdmissionOwner } from './package-admission'
 import { managedRepairRegistryKey, repairRegistryPath } from './runtime-paths'
+import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import type { NotebookSessionRuntimeBinding } from './session-aggregate'
 
 type AdmissionOptions = ConstructorParameters<typeof NotebookPackageAdmissionOwner>[0]
@@ -45,8 +46,9 @@ const ownerHarness = (
   options: AdmissionOptions
 } => {
   const session = { runtimeBinding: vi.fn(() => binding) }
+  const runtimeRoot = overrides.runtimeRoot ?? '/runtime'
   const options: AdmissionOptions = {
-    runtimeRoot: '/runtime',
+    runtimeRoot,
     loadSession: vi.fn(async () => session),
     findSession: vi.fn(() => undefined),
     resolveRuntimeEnablement: vi.fn(async () => ({
@@ -54,11 +56,7 @@ const ownerHarness = (
       installAuthorized: binding ? { [binding.runtimeId]: true } : {}
     })),
     isDefaultEnvironmentDisabled: vi.fn(async () => false),
-    repairRegistryKeys: vi.fn((language, environment, selectedBinding) =>
-      selectedBinding?.source === 'external'
-        ? [selectedBinding.runtimeId]
-        : [environment, managedRepairRegistryKey(environment, language)]
-    ),
+    repairPolicy: new NotebookRuntimeRepairPolicy(runtimeRoot),
     environmentOperations: { isRepairBlocked: vi.fn(() => false) },
     recovery: {
       isGloballyBlocked: vi.fn(() => false),
@@ -339,11 +337,11 @@ describe('NotebookPackageAdmissionOwner', () => {
       )
       const managedOwner = ownerHarness(managed, {
         runtimeRoot,
-        repairRegistryKeys: vi.fn(() => [managed.runtimeId])
+        repairPolicy: new NotebookRuntimeRepairPolicy(runtimeRoot)
       }).owner
       const externalOwner = ownerHarness(external, {
         runtimeRoot,
-        repairRegistryKeys: vi.fn(() => [external.runtimeId])
+        repairPolicy: new NotebookRuntimeRepairPolicy(runtimeRoot)
       }).owner
       const request = {
         packages: ['package'],

--- a/src/main/notebook/package-admission.ts
+++ b/src/main/notebook/package-admission.ts
@@ -4,14 +4,8 @@ import type { NotebookEnvironmentOperations } from './environment-operations'
 import type { EnvironmentCaptureTarget } from './environment-state-tracker'
 import type { InstallRequest, InstallResult } from './package-manager'
 import type { NotebookRecoveryCoordinator } from './recovery-coordinator'
-import {
-  DEFAULT_PY_ENV,
-  DEFAULT_R_ENV,
-  envPrefix,
-  managedRepairRegistryKey,
-  readRepairRequiredReason,
-  resolveEnvName
-} from './runtime-paths'
+import { DEFAULT_PY_ENV, DEFAULT_R_ENV, envPrefix } from './runtime-paths'
+import type { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import type {
   NotebookSessionAggregate,
   NotebookSessionResolvedInterpreter,
@@ -29,12 +23,10 @@ type NotebookPackageAdmissionOwnerOptions = {
     language: NotebookLanguage,
     runtimeRoot: string
   ) => Promise<boolean>
-  repairRegistryKeys: (
-    language: NotebookLanguage,
-    environment: string,
-    binding: NotebookSessionRuntimeBinding | undefined,
-    runtimeRoot: string
-  ) => string[]
+  repairPolicy: Pick<
+    NotebookRuntimeRepairPolicy,
+    'blockKey' | 'markerKey' | 'registryKeys' | 'requirement' | 'runtimeId'
+  >
   environmentOperations: Pick<NotebookEnvironmentOperations, 'isRepairBlocked'>
   recovery: Pick<
     NotebookRecoveryCoordinator,
@@ -69,18 +61,6 @@ type NotebookPackageAdmission =
 const defaultEnvironment = (language: NotebookLanguage): string =>
   language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
 
-const processKey = (language: NotebookLanguage, environment: string): string =>
-  `${language === 'r' ? 'r' : 'python'}:${resolveEnvName(language, environment)}`
-
-const repairBlockKey = (
-  language: NotebookLanguage,
-  environment: string,
-  binding: NotebookSessionRuntimeBinding | undefined
-): string =>
-  binding?.source === 'external'
-    ? `external:${language}:${binding.runtimeId}`
-    : processKey(language, environment)
-
 const refusal = (error: string, repairRequired = false): NotebookPackageRefusal => ({
   status: 'refused',
   result: {
@@ -106,32 +86,12 @@ class NotebookPackageAdmissionOwner {
         ? binding.envName
         : defaultEnvironment(request.language)
     const runtimeRoot = this.options.runtimeRoot
-    const repairRegistryKeys = this.options.repairRegistryKeys(
-      request.language,
-      environmentName,
-      binding,
-      runtimeRoot
+    const repair = this.options.repairPolicy.requirement(request.language, environmentName, binding)
+    const repairRefusal = this.protectedRepairRefusal(
+      { request, environmentName, binding },
+      repair.protectedIdentity
     )
-
-    const protectedRepairRequired =
-      this.options.environmentOperations.isRepairBlocked(
-        repairBlockKey(request.language, environmentName, binding)
-      ) ||
-      repairRegistryKeys.some((key) => {
-        const reason = readRepairRequiredReason(runtimeRoot, key)
-        return (
-          reason === 'protected-identity-change' ||
-          (reason === 'legacy-unknown' && binding?.source !== 'external')
-        )
-      })
-    if (protectedRepairRequired) {
-      return refusal(
-        `RUNTIME_REPAIR_REQUIRED: the ${request.language} runtime's protected interpreter identity ` +
-          'changed. Use Repair/Reset in Settings → Runtimes to rebuild and verify it before installing ' +
-          'packages.',
-        true
-      )
-    }
+    if (repairRefusal) return repairRefusal
 
     let interpreter: NotebookPackageAdmittedTarget['interpreter']
     if (binding?.source === 'external') {
@@ -189,10 +149,12 @@ class NotebookPackageAdmissionOwner {
       )
     }
 
-    const repairRuntimeId = isExternal ? binding.runtimeId : environmentName
-    const repairMarkerKey = isExternal
-      ? repairRuntimeId
-      : managedRepairRegistryKey(environmentName, request.language)
+    const repairRuntimeId = this.options.repairPolicy.runtimeId(environmentName, binding)
+    const repairMarkerKey = this.options.repairPolicy.markerKey(
+      request.language,
+      environmentName,
+      binding
+    )
     const journalTarget = isExternal ? undefined : envPrefix(runtimeRoot, environmentName)
     return {
       status: 'admitted',
@@ -210,10 +172,39 @@ class NotebookPackageAdmissionOwner {
         ),
         repairRuntimeId,
         repairMarkerKey,
-        repairRegistryKeys,
+        repairRegistryKeys: repair.keys,
         journalTarget
       }
     }
+  }
+
+  recheckRepair(
+    target: Pick<NotebookPackageAdmittedTarget, 'binding' | 'environmentName' | 'request'>
+  ): NotebookPackageRefusal | undefined {
+    const { binding, environmentName, request } = target
+    const repair = this.options.repairPolicy.requirement(request.language, environmentName, binding)
+    return this.protectedRepairRefusal(target, repair.protectedIdentity)
+  }
+
+  private protectedRepairRefusal(
+    target: Pick<NotebookPackageAdmittedTarget, 'binding' | 'environmentName' | 'request'>,
+    protectedIdentity: boolean
+  ): NotebookPackageRefusal | undefined {
+    const { binding, environmentName, request } = target
+    if (
+      !this.options.environmentOperations.isRepairBlocked(
+        this.options.repairPolicy.blockKey(request.language, environmentName, binding)
+      ) &&
+      !protectedIdentity
+    ) {
+      return undefined
+    }
+    return refusal(
+      `RUNTIME_REPAIR_REQUIRED: the ${request.language} runtime's protected interpreter identity ` +
+        'changed. Use Repair/Reset in Settings → Runtimes to rebuild and verify it before installing ' +
+        'packages.',
+      true
+    )
   }
 
   private async resolveSession(

--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -74,6 +74,7 @@ const ownerHarness = (
       log: 'installed',
       method: 'conda'
     }),
+    recheckRepair: vi.fn(() => undefined),
     quarantineProtectedIdentity: vi.fn().mockResolvedValue(undefined),
     completeInterruptedInstallRepair: vi.fn().mockResolvedValue(undefined),
     blockUnconfirmedChild: vi.fn(),
@@ -86,6 +87,41 @@ const pending = (runtimeRoot: string): ReturnType<RuntimeOperationJournal['pendi
   RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot)).pending()
 
 describe('NotebookPackageMutationOwner', () => {
+  it('rechecks repair policy after acquiring the mutation lock', async () => {
+    const refusal = {
+      status: 'refused' as const,
+      result: {
+        ok: false,
+        needsRestart: false,
+        repairRequired: true,
+        log: '',
+        error: 'RUNTIME_REPAIR_REQUIRED'
+      }
+    }
+    const order: string[] = []
+    const { owner, options, target, runtimeRoot } = ownerHarness({
+      environmentOperations: {
+        runMutation: async <T>(_environment: string, operation: () => Promise<T>): Promise<T> => {
+          order.push('lock')
+          return operation()
+        },
+        logPackageFailure: vi.fn(),
+        logPackageResult: vi.fn()
+      },
+      recheckRepair: vi.fn(() => {
+        order.push('repair-check')
+        return refusal
+      })
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).resolves.toEqual(refusal.result)
+
+    expect(order).toEqual(['lock', 'repair-check'])
+    expect(options.installPackages).not.toHaveBeenCalled()
+    expect(options.environmentStateTracker.markPackageMutationDirty).not.toHaveBeenCalled()
+    expect(await pending(runtimeRoot)).toEqual([])
+  })
+
   it('owns lock, journal, child evidence, verification and successful repair completion', async () => {
     const order: string[] = []
     let operationId = ''

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -13,7 +13,7 @@ import {
   removeOperationChildSync,
   RuntimeOperationJournal
 } from './operation-journal'
-import type { NotebookPackageAdmittedTarget } from './package-admission'
+import type { NotebookPackageAdmission, NotebookPackageAdmittedTarget } from './package-admission'
 import type { InstallDeps, InstallResult } from './package-manager'
 import { readProcessStartToken } from './operation-recovery'
 import { isChildUnconfirmedError } from './provisioner-runtime'
@@ -43,6 +43,9 @@ type NotebookPackageMutationOwnerOptions = {
     request: NotebookPackageAdmittedTarget['request'],
     deps?: Partial<InstallDeps>
   ) => Promise<InstallResult>
+  recheckRepair: (
+    target: NotebookPackageAdmittedTarget
+  ) => Extract<NotebookPackageAdmission, { status: 'refused' }> | undefined
   quarantineProtectedIdentity: (target: NotebookPackageAdmittedTarget) => Promise<void>
   completeInterruptedInstallRepair: (target: NotebookPackageAdmittedTarget) => Promise<void>
   blockUnconfirmedChild: (target: NotebookPackageAdmittedTarget) => void
@@ -72,6 +75,8 @@ class NotebookPackageMutationOwner {
       // The journal begins inside the environment lock so Reset cannot clear this new operation
       // between intent recording and the first installer spawn.
       result = await this.options.environmentOperations.runMutation(environmentName, async () => {
+        const repairRefusal = this.options.recheckRepair(target)
+        if (repairRefusal) return repairRefusal.result
         await journal.begin({
           operationId,
           kind: 'install',

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -9,7 +9,8 @@ import {
   RuntimeOperationJournal
 } from './operation-journal'
 import { defaultOperationChildLiveness, reconcileInterruptedOperations } from './operation-recovery'
-import { addRepairRequired, managedRepairRegistryKey } from './runtime-paths'
+import { addRepairRequired } from './runtime-paths'
+import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 
 export type NotebookRecoveryReadiness =
   'not-started' | 'recovering' | 'ready' | 'failed' | 'disposed'
@@ -39,7 +40,13 @@ export class NotebookRecoveryCoordinator {
   private recoveryCorrupt = false
   private disposed = false
 
-  constructor(private readonly runtimeRoot: string) {}
+  constructor(
+    private readonly runtimeRoot: string,
+    private readonly repairPolicy: Pick<
+      NotebookRuntimeRepairPolicy,
+      'recoveryMarker'
+    > = new NotebookRuntimeRepairPolicy(runtimeRoot)
+  ) {}
 
   async recover(): Promise<void> {
     if (this.disposed) throw new Error('Notebook recovery coordinator is disposed.')
@@ -186,19 +193,8 @@ export class NotebookRecoveryCoordinator {
       },
       markRepairRequired: async (record) => {
         if (!record.runtimeId) return
-        const reason = record.repairReason ?? 'interrupted-install'
-        const language =
-          record.phase === 'install-r'
-            ? 'r'
-            : record.phase === 'install-python'
-              ? 'python'
-              : undefined
-        const alreadyScoped = /^managed:(?:python|r):/u.test(record.runtimeId)
-        const repairKey =
-          reason === 'protected-identity-change' || !record.targetPath || !language || alreadyScoped
-            ? record.runtimeId
-            : managedRepairRegistryKey(record.runtimeId, language)
-        addRepairRequired(this.runtimeRoot, repairKey, reason)
+        const marker = this.repairPolicy.recoveryMarker(record)
+        addRepairRequired(this.runtimeRoot, marker.key, marker.reason)
       },
       blockUnknownChildTarget: async (record) => {
         if (record.kind === 'install') nextStartupBlockedRuntimeIds.add(record.runtimeId)

--- a/src/main/notebook/runtime-binding.ts
+++ b/src/main/notebook/runtime-binding.ts
@@ -15,12 +15,8 @@ import {
   windowsCondaPrefixForR
 } from './environment-discovery'
 import { getRuntimeRoot, type NotebookRunRepository } from './repository'
-import {
-  DEFAULT_PY_ENV,
-  DEFAULT_R_ENV,
-  isRepairRequired,
-  managedRepairRegistryKey
-} from './runtime-paths'
+import { DEFAULT_PY_ENV, DEFAULT_R_ENV } from './runtime-paths'
+import type { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import type { NotebookSessionAggregate, NotebookSessionRuntimeBinding } from './session-aggregate'
 
 type RuntimeBindingSession = Pick<
@@ -37,6 +33,7 @@ type NotebookRuntimeBindingOwnerOptions = {
   dataRoot: string
   repository: RuntimeBindingRepository
   runtimeSettings: Pick<NotebookRuntimeSettings, 'getSnapshot'>
+  repairPolicy: Pick<NotebookRuntimeRepairPolicy, 'bindingRequirement'>
   discoverRuntimes?: (language: NotebookLanguage) => Promise<DiscoveredInterpreter[]>
   platform?: NodeJS.Platform
 }
@@ -342,17 +339,8 @@ export class NotebookRuntimeBindingOwner {
       )
     }
     const binding = this.toInternalBinding(match)
-    const repairKey =
-      binding.source === 'external'
-        ? binding.runtimeId
-        : (binding.envName ?? defaultEnvironment(language))
-    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
-    const repairRequired =
-      isRepairRequired(runtimeRoot, repairKey) ||
-      (binding.source === 'managed' &&
-        isRepairRequired(runtimeRoot, managedRepairRegistryKey(repairKey, language))) ||
-      (binding.source === 'managed' && isRepairRequired(runtimeRoot, binding.runtimeId))
-    return repairRequired
+    const environment = binding.envName ?? defaultEnvironment(language)
+    return this.options.repairPolicy.bindingRequirement(language, environment, binding).required
       ? { ...binding, status: 'unavailable', reason: 'repair-required' }
       : binding
   }

--- a/src/main/notebook/runtime-repair-policy.test.ts
+++ b/src/main/notebook/runtime-repair-policy.test.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  addRepairRequired,
+  envPrefix,
+  managedRepairRegistryKey,
+  pythonBin,
+  repairRegistryPath,
+  rBin
+} from './runtime-paths'
+import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
+import type { NotebookSessionRuntimeBinding } from './session-aggregate'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+const createRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'notebook-runtime-repair-policy-'))
+  roots.push(root)
+  return root
+}
+
+const binding = (
+  source: 'managed' | 'external',
+  runtimeId: string
+): Pick<NotebookSessionRuntimeBinding, 'runtimeId' | 'source'> => ({ source, runtimeId })
+
+describe('NotebookRuntimeRepairPolicy', () => {
+  it('keeps managed compatibility aliases scoped by language and external identities isolated', () => {
+    const runtimeRoot = createRoot()
+    const policy = new NotebookRuntimeRepairPolicy(runtimeRoot)
+    const managed = binding('managed', 'analysis-python-runtime')
+
+    expect(policy.registryKeys('python', 'analysis', managed)).toEqual([
+      'analysis',
+      managedRepairRegistryKey('analysis', 'python'),
+      managed.runtimeId,
+      pythonBin(envPrefix(runtimeRoot, 'analysis'))
+    ])
+    expect(policy.registryKeys('r', 'analysis')).toEqual([
+      'analysis',
+      managedRepairRegistryKey('analysis', 'r'),
+      rBin(envPrefix(runtimeRoot, 'analysis'))
+    ])
+    expect(
+      policy.registryKeys('python', 'default-python', binding('external', '/usr/bin/python'))
+    ).toEqual(['/usr/bin/python'])
+  })
+
+  it('protects managed legacy markers while leaving external legacy markers adoptable', () => {
+    const runtimeRoot = createRoot()
+    const managed = binding('managed', 'managed-runtime')
+    const external = binding('external', 'external-runtime')
+    mkdirSync(dirname(repairRegistryPath(runtimeRoot)), { recursive: true })
+    writeFileSync(
+      repairRegistryPath(runtimeRoot),
+      `${JSON.stringify({ runtimeIds: [managed.runtimeId, external.runtimeId] })}\n`,
+      'utf8'
+    )
+    const policy = new NotebookRuntimeRepairPolicy(runtimeRoot)
+
+    expect(policy.requirement('python', 'analysis', managed)).toMatchObject({
+      required: true,
+      protectedIdentity: true
+    })
+    expect(policy.requirement('python', 'default-python', external)).toMatchObject({
+      required: true,
+      protectedIdentity: false
+    })
+  })
+
+  it('keeps raw interpreter aliases out of the public binding projection', () => {
+    const runtimeRoot = createRoot()
+    const policy = new NotebookRuntimeRepairPolicy(runtimeRoot)
+    const managed = binding('managed', 'canonical-managed-runtime')
+    addRepairRequired(runtimeRoot, pythonBin(envPrefix(runtimeRoot, 'analysis')))
+
+    expect(policy.requirement('python', 'analysis', managed).required).toBe(true)
+    expect(policy.bindingRequirement('python', 'analysis', managed).required).toBe(false)
+  })
+
+  it('treats explicit protected markers as protected for external runtimes', () => {
+    const runtimeRoot = createRoot()
+    const external = binding('external', 'external-runtime')
+    addRepairRequired(runtimeRoot, external.runtimeId, 'protected-identity-change')
+
+    expect(
+      new NotebookRuntimeRepairPolicy(runtimeRoot).requirement('python', 'default-python', external)
+    ).toMatchObject({ required: true, protectedIdentity: true })
+  })
+
+  it('projects recovery markers without widening managed language scope', () => {
+    const policy = new NotebookRuntimeRepairPolicy(createRoot())
+    const record = {
+      operationId: 'operation',
+      kind: 'install' as const,
+      runtimeId: 'analysis',
+      phase: 'install-r',
+      startedAt: 1,
+      targetPath: '/runtime/envs/analysis'
+    }
+
+    expect(policy.recoveryMarker(record)).toEqual({
+      key: managedRepairRegistryKey('analysis', 'r'),
+      reason: 'interrupted-install'
+    })
+    expect(
+      policy.recoveryMarker({
+        ...record,
+        repairReason: 'protected-identity-change'
+      })
+    ).toEqual({ key: 'analysis', reason: 'protected-identity-change' })
+    expect(
+      policy.recoveryMarker({ ...record, runtimeId: '/usr/bin/R', targetPath: undefined })
+    ).toEqual({ key: '/usr/bin/R', reason: 'interrupted-install' })
+  })
+})

--- a/src/main/notebook/runtime-repair-policy.ts
+++ b/src/main/notebook/runtime-repair-policy.ts
@@ -1,0 +1,128 @@
+import { realpathSync } from 'node:fs'
+
+import type { NotebookLanguage } from '../../shared/notebook'
+import type { RuntimeOperationRecord } from './operation-journal'
+import {
+  envPrefix,
+  managedRepairRegistryKey,
+  pythonBin,
+  rBin,
+  readRepairRequiredReason,
+  resolveEnvName,
+  type RepairRequiredReason,
+  type RepairRequiredRegistryReason
+} from './runtime-paths'
+import type { NotebookSessionRuntimeBinding } from './session-aggregate'
+
+type RuntimeRepairBinding = Pick<NotebookSessionRuntimeBinding, 'runtimeId' | 'source'>
+
+export type RuntimeRepairRequirement = Readonly<{
+  keys: readonly string[]
+  required: boolean
+  protectedIdentity: boolean
+}>
+
+export type RuntimeRecoveryRepairMarker = Readonly<{
+  key: string
+  reason: RepairRequiredReason
+}>
+
+/** Defines durable repair identities without owning repair or Session lifecycle state. */
+export class NotebookRuntimeRepairPolicy {
+  constructor(private readonly runtimeRoot: string) {}
+
+  registryKeys(
+    language: NotebookLanguage,
+    environment: string,
+    binding?: RuntimeRepairBinding
+  ): readonly string[] {
+    if (binding?.source === 'external') return [binding.runtimeId]
+    const keys = new Set<string>([environment, managedRepairRegistryKey(environment, language)])
+    if (binding?.source === 'managed') keys.add(binding.runtimeId)
+    const prefix = envPrefix(this.runtimeRoot, environment)
+    const interpreter = language === 'r' ? rBin(prefix) : pythonBin(prefix)
+    keys.add(interpreter)
+    try {
+      keys.add(realpathSync(interpreter))
+    } catch {
+      // The raw path still covers legacy markers before an interpreter is materialized.
+    }
+    return [...keys]
+  }
+
+  requirement(
+    language: NotebookLanguage,
+    environment: string,
+    binding?: RuntimeRepairBinding
+  ): RuntimeRepairRequirement {
+    return this.requirementFor(this.registryKeys(language, environment, binding), binding)
+  }
+
+  bindingRequirement(
+    language: NotebookLanguage,
+    environment: string,
+    binding: RuntimeRepairBinding
+  ): RuntimeRepairRequirement {
+    const keys =
+      binding.source === 'external'
+        ? [binding.runtimeId]
+        : [environment, managedRepairRegistryKey(environment, language), binding.runtimeId]
+    return this.requirementFor([...new Set(keys)], binding)
+  }
+
+  private requirementFor(
+    keys: readonly string[],
+    binding?: RuntimeRepairBinding
+  ): RuntimeRepairRequirement {
+    const reasons = keys
+      .map((key) => readRepairRequiredReason(this.runtimeRoot, key))
+      .filter((reason): reason is RepairRequiredRegistryReason => reason !== undefined)
+    return {
+      keys,
+      required: reasons.length > 0,
+      // Untyped external markers remain repairable by an authorized reinstall. Managed legacy
+      // markers stay fail-closed because they may represent a protected interpreter identity change.
+      protectedIdentity: reasons.some(
+        (reason) =>
+          reason === 'protected-identity-change' ||
+          (reason === 'legacy-unknown' && binding?.source !== 'external')
+      )
+    }
+  }
+
+  markerKey(
+    language: NotebookLanguage,
+    environment: string,
+    binding?: RuntimeRepairBinding
+  ): string {
+    return binding?.source === 'external'
+      ? binding.runtimeId
+      : managedRepairRegistryKey(environment, language)
+  }
+
+  runtimeId(environment: string, binding?: RuntimeRepairBinding): string {
+    return binding?.source === 'external' ? binding.runtimeId : environment
+  }
+
+  blockKey(
+    language: NotebookLanguage,
+    environment: string,
+    binding?: RuntimeRepairBinding
+  ): string {
+    return binding?.source === 'external'
+      ? `external:${language}:${binding.runtimeId}`
+      : `${language === 'r' ? 'r' : 'python'}:${resolveEnvName(language, environment)}`
+  }
+
+  recoveryMarker(record: RuntimeOperationRecord): RuntimeRecoveryRepairMarker {
+    const reason = record.repairReason ?? 'interrupted-install'
+    const language =
+      record.phase === 'install-r' ? 'r' : record.phase === 'install-python' ? 'python' : undefined
+    const alreadyScoped = /^managed:(?:python|r):/u.test(record.runtimeId)
+    const key =
+      reason === 'protected-identity-change' || !record.targetPath || !language || alreadyScoped
+        ? record.runtimeId
+        : managedRepairRegistryKey(record.runtimeId, language)
+    return { key, reason }
+  }
+}

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6609,6 +6609,32 @@ describe('v4 runtime bindings & agent tools', () => {
     expect(executions).toHaveLength(0)
   })
 
+  it('keeps raw-path-only legacy repair aliases out of the public binding projection', async () => {
+    const root = await createStorageRoot()
+    const runtimeRoot = getRuntimeRoot(root)
+    addRepairRequired(runtimeRoot, pythonBin(envPrefix(runtimeRoot, DEFAULT_PY_ENV)))
+    const executions: NotebookExecutionRequest[] = []
+    const service = bindingService(root, { discovered: [managedPy], executions })
+
+    const bound = await service.bindRuntime({
+      sessionId: 'raw-alias',
+      workspaceCwd: root,
+      language: 'python',
+      runtimeId: managedPy.envId
+    })
+    expect(bound.bound).toMatchObject({ status: 'active', reason: undefined })
+
+    const run = await service.execute({
+      sessionId: 'raw-alias',
+      workspaceCwd: root,
+      language: 'python',
+      code: '1'
+    })
+    expect(run.status).toBe('failed')
+    expect(run.text.traceback).toMatch(/RUNTIME_REPAIR_REQUIRED/)
+    expect(executions).toHaveLength(0)
+  })
+
   it('keeps an interrupted install scoped to its language in a shared managed env', async () => {
     const root = await createStorageRoot()
     const runtimeRoot = getRuntimeRoot(root)
@@ -6935,17 +6961,21 @@ describe('v4 runtime bindings & agent tools', () => {
       installPackagesImpl: async () => ({ ok: true, needsRestart: false, log: 'repaired' })
     })
     const repairRegistryKeys = vi.spyOn(
-      service as unknown as {
-        repairRegistryKeys: (
-          language: 'python' | 'r',
-          environment: string,
-          binding: unknown,
-          runtimeRoot: string
-        ) => string[]
-      },
-      'repairRegistryKeys'
+      (
+        service as unknown as {
+          repairPolicy: {
+            registryKeys: (
+              language: 'python' | 'r',
+              environment: string,
+              binding: unknown
+            ) => readonly string[]
+          }
+        }
+      ).repairPolicy,
+      'registryKeys'
     )
     repairRegistryKeys
+      .mockReturnValueOnce([DEFAULT_PY_ENV, managedRepairRegistryKey(DEFAULT_PY_ENV, 'python')])
       .mockReturnValueOnce([DEFAULT_PY_ENV, managedRepairRegistryKey(DEFAULT_PY_ENV, 'python')])
       .mockReturnValueOnce([
         DEFAULT_PY_ENV,
@@ -6956,7 +6986,7 @@ describe('v4 runtime bindings & agent tools', () => {
     const result = await service.managePackages({ language: 'python', packages: ['numpy'] })
 
     expect(result.ok).toBe(true)
-    expect(repairRegistryKeys).toHaveBeenCalledTimes(2)
+    expect(repairRegistryKeys).toHaveBeenCalledTimes(3)
     expect(isRepairRequired(runtimeRoot, postInstallAlias)).toBe(false)
   })
 

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -79,6 +79,7 @@ import type {
 } from '../../shared/notebook-runtime'
 import type { NotebookRuntimeSettings } from '../settings/capabilities'
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
+import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import { NotebookEnvironmentOperations, type DefaultEnvProvisioner } from './environment-operations'
 import {
   NotebookSessionAggregate,
@@ -408,6 +409,7 @@ class NotebookRuntimeService {
   private readonly dataExecutionAdmission: NotebookDataExecutionAdmissionOwner
   private readonly packageAdmission: NotebookPackageAdmissionOwner
   private readonly packageMutation: NotebookPackageMutationOwner
+  private readonly repairPolicy: NotebookRuntimeRepairPolicy
   private readonly sessions: NotebookSessionRegistry<RuntimeSession>
   private readonly announcedAgentSessionIds = new Set<string>()
   // Owns process-global operation admission, provisioning progress, restart recommendations,
@@ -451,7 +453,9 @@ class NotebookRuntimeService {
         await this.runtimeBindingOwner.waitForWrites()
       }
     })
-    this.recoveryCoordinator = new NotebookRecoveryCoordinator(getRuntimeRoot(options.dataRoot))
+    const runtimeRoot = getRuntimeRoot(options.dataRoot)
+    this.repairPolicy = new NotebookRuntimeRepairPolicy(runtimeRoot)
+    this.recoveryCoordinator = new NotebookRecoveryCoordinator(runtimeRoot, this.repairPolicy)
     this.mcpRpcConnectionResolver = options.getMcpRpcConnection
     this.packageMirrorResolver = options.getPackageMirror
     const runtimeSettings = options.notebookRuntimeSettings ?? EMPTY_NOTEBOOK_RUNTIME_SETTINGS
@@ -461,6 +465,7 @@ class NotebookRuntimeService {
       dataRoot: options.dataRoot,
       repository: this.repository,
       runtimeSettings,
+      repairPolicy: this.repairPolicy,
       discoverRuntimes: options.discoverRuntimes,
       platform: options.platform
     })
@@ -487,7 +492,7 @@ class NotebookRuntimeService {
       resolveRuntimeEnablement: (language) => this.resolveRuntimeEnablement(language),
       isDefaultEnvironmentDisabled: (language, runtimeRoot) =>
         this.isDefaultEnvDisabled(language, runtimeRoot),
-      repairRegistryKeys: (...args) => this.repairRegistryKeys(...args),
+      repairPolicy: this.repairPolicy,
       environmentOperations: this.environmentOperations,
       recovery: this.recoveryCoordinator,
       createEnvironmentCaptureTarget: (...args) => this.environmentCaptureTarget(...args)
@@ -498,6 +503,7 @@ class NotebookRuntimeService {
       environmentOperations: this.environmentOperations,
       environmentStateTracker: this.environmentStateTracker,
       installPackages: options.installPackagesImpl ?? installPackagesDefault,
+      recheckRepair: (target) => this.packageAdmission.recheckRepair(target),
       quarantineProtectedIdentity: (target) => this.quarantinePackageTarget(target),
       completeInterruptedInstallRepair: (target) => this.completePackageTargetRepair(target),
       blockUnconfirmedChild: ({ repairRuntimeId, journalTarget }) => {
@@ -510,7 +516,8 @@ class NotebookRuntimeService {
       environmentOperations: this.environmentOperations,
       recovery: this.recoveryCoordinator,
       ensureRecovered: () => this.ensureRecovered(),
-      resolveRuntimeEnablement: (language) => this.resolveRuntimeEnablement(language)
+      resolveRuntimeEnablement: (language) => this.resolveRuntimeEnablement(language),
+      repairPolicy: this.repairPolicy
     })
     this.environmentManager = options.environmentManager
     this.runTerminalization = new NotebookRunTerminalizationOwner({
@@ -599,29 +606,6 @@ class NotebookRuntimeService {
     const binding = session.runtimeBinding(language)
     if (binding?.source === 'managed' && binding.envName) return binding.envName
     return this.defaultEnvNameFor(language)
-  }
-
-  // Protected managed repair state is keyed by env name, while repairable interrupted installs are
-  // scoped to (env, language). Releases before that migration used the discovered interpreter id, so
-  // include raw/canonical paths to keep legacy quarantine fail-closed.
-  private repairRegistryKeys(
-    language: NotebookLanguage,
-    env: string,
-    binding: InternalRuntimeBinding | undefined,
-    runtimeRootDir: string
-  ): string[] {
-    if (binding?.source === 'external') return [binding.runtimeId]
-    const keys = new Set<string>([env, managedRepairRegistryKey(env, language)])
-    if (binding?.source === 'managed') keys.add(binding.runtimeId)
-    const prefix = envPrefix(runtimeRootDir, env)
-    const interpreter = language === 'r' ? rBin(prefix) : pythonBin(prefix)
-    keys.add(interpreter)
-    try {
-      keys.add(realpathSync(interpreter))
-    } catch {
-      // The runtime may not be materialized yet; the raw interpreter path still covers old markers.
-    }
-    return [...keys]
   }
 
   private environmentCaptureTarget(
@@ -1175,7 +1159,7 @@ class NotebookRuntimeService {
       // Recompute after installation: the interpreter may have appeared or canonicalized during the
       // mutation, and the fresh real path can name an older interrupted-install marker to clear.
       const legacyAliases = new Set(
-        this.repairRegistryKeys(request.language, environmentName, binding, runtimeRoot)
+        this.repairPolicy.registryKeys(request.language, environmentName, binding)
       )
       legacyAliases.delete(environmentName)
       legacyAliases.delete(repairMarkerKey)
@@ -1406,12 +1390,7 @@ class NotebookRuntimeService {
     const registryKeys = new Set<string>()
 
     for (const affectedLanguage of ['python', 'r'] as const) {
-      for (const key of this.repairRegistryKeys(
-        affectedLanguage,
-        envName,
-        undefined,
-        runtimeRoot
-      )) {
+      for (const key of this.repairPolicy.registryKeys(affectedLanguage, envName)) {
         registryKeys.add(key)
       }
     }


### PR DESCRIPTION
## Problem

Notebook repair identity rules were duplicated across package admission, data execution, runtime binding, startup recovery, and the runtime facade. The copies had to agree on language-scoped managed keys, legacy interpreter aliases, protected marker handling, and external-runtime adoption. Package admission also made its repair decision before waiting for the environment mutation lock, so queued work did not re-evaluate the durable gate at the lock boundary.

Exact base: `449abc75390643b51d940368e9eb3a61edae973f`  
Exact head: `bcc27fc66d98279e1bdf2e5c515324e6042a49a2`

## Proposed change

Add a stateless `NotebookRuntimeRepairPolicy` that owns only repair identity and classification rules:

- language-scoped managed registry keys plus legacy env/interpreter aliases;
- all-repair versus protected-identity requirements;
- canonical mutation marker/runtime/block keys;
- operation-journal recovery marker projection.

Cut package admission and its new post-lock recheck, data admission and post-lock recheck, runtime binding, recovery coordination, and facade alias cleanup over to that policy.

```mermaid
flowchart LR
  Policy["NotebookRuntimeRepairPolicy"]
  Package["Package admission / post-lock"] --> Policy
  Data["Data admission / post-lock"] --> Policy
  Binding["Runtime binding"] --> Policy
  Recovery["Startup recovery"] --> Policy
  Lifecycle["Quarantine / restore / Reset lifecycle"] -. "unchanged; remains in runtime facade" .-> Policy
```

Production raw diff: `385` lines (`+226/-159`), below the approved 600 target and 660 hard limit.

## Scope and non-goals

- This is the approved stateless prerequisite for N3; it does not move quarantine, binding restoration, explicit Repair/Reset completion, or named-environment removal lifecycle.
- No public API, IPC payload, persistence schema, registry file shape, data relationship, or renderer interaction changes.
- No new orchestration state or framework abstraction.
- The frozen 765-raw N3 measurement draft was not modified, copied, committed, or reused.
- Squash merge only.

## Compatibility and risk

- Electron, local/remote Web, CLI/Task, local RPC, and MCP continue through the same Notebook service interfaces.
- Specialist, Permission, and Compute capabilities and their existing surface asymmetries are unchanged.
- External `legacy-unknown` markers remain adoptable by an authorized successful reinstall and are cleared on successful completion.
- Managed legacy markers remain protected and require the existing verified Repair/Reset path.
- Managed repair aliases remain scoped by language; protected identity markers still quarantine the shared prefix.
- Incoming `#818` was audited before rebase: it changes setup progress correlation/settlement only, has no file overlap, and leaves the successful `onRepairCompleted(language)` boundary unchanged. The mechanical rebase range-diff was `=`; the final exact-head patch-id is `a3ac69c9deed1352281ee91c5b8cde14a03b9eb3`.

## Acceptance criteria and validation

All listed checks ran after the final material edit and after rebasing onto the exact base above.

- Repair key/reason compatibility, binding-specific alias projection, external legacy adoption, package lock-boundary recheck, recovery projection, runtime binding, and facade completion -> `npm test -- --run src/main/notebook/runtime-repair-policy.test.ts src/main/notebook/package-admission.test.ts src/main/notebook/package-mutation.test.ts src/main/notebook/recovery-coordinator.test.ts src/main/notebook/runtime-service.test.ts` -> `5 files / 215 tests passed`.
- Main-process contracts and consumers -> `npm run typecheck:node` -> passed.
- Changed Notebook sources/tests -> targeted ESLint -> passed with zero findings.
- Changed Notebook sources/tests -> targeted Prettier check -> passed.
- Final diff -> `git diff --check 449abc75..HEAD` -> passed.
- Independent Standards/Spec review of `449abc75...bcc27fc6` -> final `Standards 0 / Spec 0`; the initial binding alias-profile finding is closed by the binding-specific key set and public projection regression.

The final impact set covers the policy owner, every changed caller, the mutation lock seam, recovery coordinator, and the compatibility facade. Windows alias shaping relies on the existing path helpers plus online CI; platform-specific process, IPC, and renderer behavior is unchanged and no local E2E was run.

## Review focus

- Verify that `protectedIdentity` preserves the intentional managed/external `legacy-unknown` asymmetry.
- Verify that the package recheck happens inside the existing environment mutation lock and before journal/dirty/spawn side effects.
- Verify that recovery maps interrupted managed installs to `managed:<language>:<env>` while protected/external markers retain their prior identities.
- Verify that lifecycle ownership remains out of this prerequisite so the later N3 cutover can move quarantine and restoration atomically.
