### PR TITLE
refactor(settings-store): extract preferences slice

### DIFF
--- a/src/renderer/src/stores/settings-preferences-slice.test.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.test.ts
@@ -1,0 +1,197 @@
+import { createStore, type StoreApi } from 'zustand/vanilla'
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+import type { PackageMirror } from '../../../shared/mirror'
+import type { AppIconVariant, ReasoningEffort, SettingsSnapshot } from '../../../shared/settings'
+import type { CloseActionPreference } from '../../../shared/window-controls'
+import {
+  createSettingsPreferencesSlice,
+  type SettingsPreferencesActions
+} from './settings-preferences-slice'
+import { createSettingsWriteCoordinator } from './settings-write-coordinator'
+
+type PreferencesCommands = Pick<
+  Window['api']['settings'],
+  | 'setReasoningEffort'
+  | 'setNotificationsEnabled'
+  | 'setConversationSkillImportEnabled'
+  | 'setClosePreference'
+  | 'setAppIconVariant'
+  | 'markOnboardingComplete'
+  | 'setPackageMirror'
+>
+
+type CommandMocks = { [Command in keyof PreferencesCommands]: Mock }
+
+type TestStore = SettingsPreferencesActions & {
+  onboardingCompletedAt?: number
+  packageMirror?: PackageMirror
+  reasoningEffort: ReasoningEffort
+  notificationsEnabled: boolean
+  conversationSkillImportEnabled: boolean
+  closePreference: CloseActionPreference | undefined
+  appIconVariant: AppIconVariant
+  settingsWriteError: string | undefined
+}
+
+const snapshot = (patch: Partial<SettingsSnapshot> = {}): SettingsSnapshot => ({
+  claude: {},
+  activeProviderId: undefined,
+  providers: [],
+  agentFrameworkId: 'claude-code',
+  agentFrameworks: [],
+  opencode: {},
+  codex: {},
+  claudeManaged: false,
+  opencodeManaged: false,
+  codexManaged: false,
+  reasoningEffort: 'default',
+  notificationsEnabled: true,
+  conversationSkillImportEnabled: true,
+  appIconVariant: 'light',
+  ...patch
+})
+
+const deferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} => {
+  let resolve: (value: T) => void = () => undefined
+  let reject: (error: unknown) => void = () => undefined
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+const createCommands = (): CommandMocks => ({
+  setReasoningEffort: vi.fn(({ effort }) => Promise.resolve(snapshot({ reasoningEffort: effort }))),
+  setNotificationsEnabled: vi.fn(({ enabled }) =>
+    Promise.resolve(snapshot({ notificationsEnabled: enabled }))
+  ),
+  setConversationSkillImportEnabled: vi.fn(({ enabled }) =>
+    Promise.resolve(snapshot({ conversationSkillImportEnabled: enabled }))
+  ),
+  setClosePreference: vi.fn(({ preference }) =>
+    Promise.resolve(snapshot({ closePreference: preference }))
+  ),
+  setAppIconVariant: vi.fn(({ variant }) => Promise.resolve(snapshot({ appIconVariant: variant }))),
+  markOnboardingComplete: vi.fn().mockResolvedValue(snapshot({ onboardingCompletedAt: 42 })),
+  setPackageMirror: vi.fn((mirror) => Promise.resolve(mirror))
+})
+
+const createHarness = (): {
+  commands: CommandMocks
+  reconcileSnapshot: Mock
+  store: StoreApi<TestStore>
+} => {
+  const commands = createCommands()
+  const reconcileSnapshot = vi.fn((next: SettingsSnapshot) => {
+    store.setState({
+      onboardingCompletedAt: next.onboardingCompletedAt,
+      packageMirror: next.packageMirror,
+      reasoningEffort: next.reasoningEffort,
+      notificationsEnabled: next.notificationsEnabled,
+      conversationSkillImportEnabled: next.conversationSkillImportEnabled,
+      closePreference: next.closePreference,
+      appIconVariant: next.appIconVariant
+    })
+  })
+  const store = createStore<TestStore>((set, get) => ({
+    reasoningEffort: 'default',
+    notificationsEnabled: true,
+    conversationSkillImportEnabled: true,
+    closePreference: undefined,
+    appIconVariant: 'light',
+    settingsWriteError: undefined,
+    ...createSettingsPreferencesSlice({
+      getState: get,
+      setState: (patch) => set(patch),
+      getCommands: () => commands as unknown as PreferencesCommands,
+      reconcileSnapshot,
+      writeCoordinator: createSettingsWriteCoordinator((settingsWriteError) =>
+        set({ settingsWriteError })
+      )
+    })
+  }))
+
+  return { commands, reconcileSnapshot, store }
+}
+
+describe('settings preferences slice', () => {
+  let commands: CommandMocks
+  let reconcileSnapshot: Mock
+  let store: StoreApi<TestStore>
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    ;({ commands, reconcileSnapshot, store } = createHarness())
+  })
+
+  it('forwards preference writes and reconciles each returned snapshot', async () => {
+    await store.getState().setReasoningEffort('high')
+    await store.getState().setNotificationsEnabled(false)
+    await store.getState().setConversationSkillImportEnabled(false)
+    await store.getState().setClosePreference('minimize')
+    await store.getState().setAppIconVariant('dark')
+
+    expect(commands.setReasoningEffort).toHaveBeenCalledWith({ effort: 'high' })
+    expect(commands.setNotificationsEnabled).toHaveBeenCalledWith({ enabled: false })
+    expect(commands.setConversationSkillImportEnabled).toHaveBeenCalledWith({ enabled: false })
+    expect(commands.setClosePreference).toHaveBeenCalledWith({ preference: 'minimize' })
+    expect(commands.setAppIconVariant).toHaveBeenCalledWith({ variant: 'dark' })
+    expect(reconcileSnapshot).toHaveBeenCalledTimes(5)
+  })
+
+  it('applies immediately, then rolls back and exposes the unchanged failure copy', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const pending = deferred<SettingsSnapshot>()
+    commands.setReasoningEffort.mockReturnValue(pending.promise)
+
+    const write = store.getState().setReasoningEffort('max')
+    expect(store.getState().reasoningEffort).toBe('max')
+
+    pending.reject(new Error('ipc down'))
+    await write
+
+    expect(store.getState().reasoningEffort).toBe('default')
+    expect(store.getState().settingsWriteError).toBe('Could not save reasoning effort. Try again.')
+    expect(consoleError).toHaveBeenCalledWith('Failed to set reasoning effort', expect.any(Error))
+  })
+
+  it('serializes same-key writes and keeps the last confirmed value when the newer write fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const first = deferred<SettingsSnapshot>()
+    commands.setReasoningEffort
+      .mockReturnValueOnce(first.promise)
+      .mockRejectedValueOnce(new Error('newer failure'))
+
+    const olderWrite = store.getState().setReasoningEffort('high')
+    const newerWrite = store.getState().setReasoningEffort('max')
+
+    expect(commands.setReasoningEffort).toHaveBeenCalledTimes(1)
+    first.resolve(snapshot({ reasoningEffort: 'high' }))
+    await Promise.all([olderWrite, newerWrite])
+
+    expect(commands.setReasoningEffort).toHaveBeenCalledTimes(2)
+    expect(store.getState().reasoningEffort).toBe('high')
+    expect(store.getState().settingsWriteError).toBe('Could not save reasoning effort. Try again.')
+    expect(consoleError).toHaveBeenCalledOnce()
+  })
+
+  it('keeps onboarding and package-mirror settlement non-optimistic', async () => {
+    await store.getState().completeOnboarding()
+    await store.getState().setPackageMirror({ pypiIndex: 'https://mirror.example/simple' })
+
+    expect(store.getState().onboardingCompletedAt).toBe(42)
+    expect(store.getState().packageMirror).toEqual({
+      pypiIndex: 'https://mirror.example/simple'
+    })
+
+    commands.setPackageMirror.mockResolvedValueOnce({})
+    await store.getState().setPackageMirror({})
+    expect(store.getState().packageMirror).toBeUndefined()
+  })
+})

--- a/src/renderer/src/stores/settings-preferences-slice.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.ts
@@ -1,0 +1,154 @@
+import type { PackageMirror } from '../../../shared/mirror'
+import type { AppIconVariant, ReasoningEffort, SettingsSnapshot } from '../../../shared/settings'
+import type { CloseActionPreference } from '../../../shared/window-controls'
+import { isMirrorConfigured } from '../pages/settings/mirror-view'
+import type {
+  OptimisticSettingsWriteKey,
+  SettingsWriteCoordinator
+} from './settings-write-coordinator'
+
+type SettingsPreferencesState = {
+  onboardingCompletedAt?: number
+  packageMirror?: PackageMirror
+  reasoningEffort: ReasoningEffort
+  notificationsEnabled: boolean
+  conversationSkillImportEnabled: boolean
+  closePreference: CloseActionPreference | undefined
+  appIconVariant: AppIconVariant
+}
+
+type OptimisticPreferenceField =
+  | 'reasoningEffort'
+  | 'notificationsEnabled'
+  | 'conversationSkillImportEnabled'
+  | 'closePreference'
+  | 'appIconVariant'
+
+export type SettingsPreferencesActions = {
+  setReasoningEffort: (effort: ReasoningEffort) => Promise<void>
+  setNotificationsEnabled: (enabled: boolean) => Promise<void>
+  setConversationSkillImportEnabled: (enabled: boolean) => Promise<void>
+  setClosePreference: (preference: CloseActionPreference | undefined) => Promise<void>
+  setAppIconVariant: (variant: AppIconVariant) => Promise<void>
+  completeOnboarding: () => Promise<void>
+  setPackageMirror: (mirror: PackageMirror) => Promise<void>
+}
+
+type SettingsPreferencesCommands = Pick<
+  Window['api']['settings'],
+  | 'setReasoningEffort'
+  | 'setNotificationsEnabled'
+  | 'setConversationSkillImportEnabled'
+  | 'setClosePreference'
+  | 'setAppIconVariant'
+  | 'markOnboardingComplete'
+  | 'setPackageMirror'
+>
+
+type SettingsPreferencesSliceOptions = {
+  getState: () => SettingsPreferencesState
+  setState: (patch: Partial<SettingsPreferencesState>) => void
+  getCommands: () => SettingsPreferencesCommands
+  reconcileSnapshot: (snapshot: SettingsSnapshot) => void
+  writeCoordinator: SettingsWriteCoordinator
+}
+
+const SETTINGS_WRITE_ERRORS: Record<OptimisticSettingsWriteKey, string> = {
+  reasoningEffort: 'Could not save reasoning effort. Try again.',
+  notifications: 'Could not save notification preference. Try again.',
+  conversationSkillImport: 'Could not save conversation Skill import preference. Try again.',
+  closePreference: 'Could not save window close preference. Try again.',
+  appIcon: 'Could not save app icon preference. Try again.'
+}
+
+// Owns renderer preference commands and their optimistic settlement. Core remains the sole owner of
+// full Settings snapshots so every successful preference write still reconciles atomically.
+export const createSettingsPreferencesSlice = ({
+  getState,
+  setState,
+  getCommands,
+  reconcileSnapshot,
+  writeCoordinator
+}: SettingsPreferencesSliceOptions): SettingsPreferencesActions => {
+  const runOptimisticWrite = async <Field extends OptimisticPreferenceField>(
+    field: Field,
+    key: OptimisticSettingsWriteKey,
+    value: SettingsPreferencesState[Field],
+    command: () => Promise<SettingsSnapshot>,
+    consoleMessage: string
+  ): Promise<void> => {
+    const write = writeCoordinator.beginOptimistic(key, getState()[field])
+    setState({ [field]: value } as Partial<SettingsPreferencesState>)
+
+    try {
+      const snapshot = await write.run(command)
+      write.complete({ value: snapshot[field] as SettingsPreferencesState[Field] })
+      if (!write.isCurrent()) return
+      reconcileSnapshot(snapshot)
+      write.succeed()
+    } catch (error) {
+      const confirmedValue = write.complete()
+      if (write.isCurrent()) {
+        setState({ [field]: confirmedValue } as Partial<SettingsPreferencesState>)
+      }
+      write.fail(SETTINGS_WRITE_ERRORS[key])
+      console.error(consoleMessage, error)
+    }
+  }
+
+  return {
+    setReasoningEffort: (effort) =>
+      runOptimisticWrite(
+        'reasoningEffort',
+        'reasoningEffort',
+        effort,
+        () => getCommands().setReasoningEffort({ effort }),
+        'Failed to set reasoning effort'
+      ),
+
+    setNotificationsEnabled: (enabled) =>
+      runOptimisticWrite(
+        'notificationsEnabled',
+        'notifications',
+        enabled,
+        () => getCommands().setNotificationsEnabled({ enabled }),
+        'Failed to set notifications enabled'
+      ),
+
+    setConversationSkillImportEnabled: (enabled) =>
+      runOptimisticWrite(
+        'conversationSkillImportEnabled',
+        'conversationSkillImport',
+        enabled,
+        () => getCommands().setConversationSkillImportEnabled({ enabled }),
+        'Failed to set conversation Skill import enabled'
+      ),
+
+    setClosePreference: (preference) =>
+      runOptimisticWrite(
+        'closePreference',
+        'closePreference',
+        preference,
+        () => getCommands().setClosePreference({ preference }),
+        'Failed to set close preference'
+      ),
+
+    setAppIconVariant: (variant) =>
+      runOptimisticWrite(
+        'appIconVariant',
+        'appIcon',
+        variant,
+        () => getCommands().setAppIconVariant({ variant }),
+        'Failed to set app icon variant'
+      ),
+
+    completeOnboarding: async () => {
+      reconcileSnapshot(await getCommands().markOnboardingComplete())
+    },
+
+    setPackageMirror: async (mirror) => {
+      const saved = await getCommands().setPackageMirror(mirror)
+      setState({ packageMirror: isMirrorConfigured(saved) ? saved : undefined })
+    }
+  }
+}

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -16,9 +16,12 @@ import { isMirrorConfigured } from '../pages/settings/mirror-view'
 import type { SettingsPanelId } from '../pages/settings/settings-navigation'
 import {
   createSettingsWriteCoordinator,
-  type OptimisticSettingsWriteKey,
   type SettingsWriteCoordinator
 } from './settings-write-coordinator'
+import {
+  createSettingsPreferencesSlice,
+  type SettingsPreferencesActions
+} from './settings-preferences-slice'
 import {
   createProviderAuthSlice,
   type ProviderAuthActions,
@@ -128,18 +131,13 @@ type SettingsStoreData = RuntimeSetupState & {
   appIconVariant: AppIconVariant
 }
 
-type SettingsStoreCore = SettingsStoreData & ProviderAuthActions & SettingsStoreActions
+type SettingsStoreCore = SettingsStoreData &
+  ProviderAuthActions &
+  SettingsPreferencesActions &
+  SettingsStoreActions
 
 type SettingsStoreActions = {
   load: (options?: { force?: boolean }) => Promise<boolean>
-  // Sets the reasoning-effort level (main reconnects so subsequent requests run at it).
-  setReasoningEffort: (effort: ReasoningEffort) => Promise<void>
-  // Toggles desktop notifications for finished/failed agent tasks; applies immediately.
-  setNotificationsEnabled: (enabled: boolean) => Promise<void>
-  setConversationSkillImportEnabled: (enabled: boolean) => Promise<void>
-  setClosePreference: (preference: CloseActionPreference | undefined) => Promise<void>
-  // Sets the app-icon look; main applies it live to the window and dock/taskbar.
-  setAppIconVariant: (variant: AppIconVariant) => Promise<void>
   clearSettingsWriteError: () => void
   openSettings: () => void
   openSettingsToPanel: (panel: SettingsPanelId) => void
@@ -216,10 +214,6 @@ type SettingsStoreActions = {
   enqueueApproval: (request: ConnectorApprovalRequest) => void
   // Sends the user's decision to main and drops the request from the queue.
   respondApproval: (id: string, decision: ApprovalDecision) => Promise<void>
-  // Persists the first-run completion marker and caches it so the startup gate falls through to Home.
-  completeOnboarding: () => Promise<void>
-  // Persists the package mirror config; caches it as undefined when cleared back to unconfigured.
-  setPackageMirror: (mirror: PackageMirror) => Promise<void>
 }
 
 type SettingsStore = SettingsStoreCore & RuntimeSetupActions
@@ -350,15 +344,6 @@ const reportSettingsLoadError = (error: unknown): void => {
   console.warn('Settings startup loading failed', error)
 }
 
-// Visible copy stays stable and path-safe; raw IPC failures remain in the console for diagnostics.
-const SETTINGS_WRITE_ERRORS: Record<OptimisticSettingsWriteKey, string> = {
-  reasoningEffort: 'Could not save reasoning effort. Try again.',
-  notifications: 'Could not save notification preference. Try again.',
-  conversationSkillImport: 'Could not save conversation Skill import preference. Try again.',
-  closePreference: 'Could not save window close preference. Try again.',
-  appIcon: 'Could not save app icon preference. Try again.'
-}
-
 // Renderer cache of the main-process settings service. The main process stays the source of truth
 // for secrets; this store only ever holds masked provider views.
 const createSettingsStoreState = (
@@ -396,6 +381,13 @@ const createSettingsStoreState = (
       }
       await get().refreshPreflight()
     },
+    writeCoordinator
+  }),
+  ...createSettingsPreferencesSlice({
+    getState: get,
+    setState: (patch) => set(patch),
+    getCommands: () => window.api.settings,
+    reconcileSnapshot: (snapshot) => set(applySnapshot(snapshot)),
     writeCoordinator
   }),
 
@@ -446,114 +438,6 @@ const createSettingsStoreState = (
       if (settingsLoadPromise === loadPromise) settingsLoadPromise = undefined
     })
     return loadPromise
-  },
-
-  // Sets the reasoning-effort level; main reconnects so subsequent requests run at it. The IPC round
-  // trip includes that reconnect, which is too slow to gate the selector on — apply the pick
-  // optimistically, reconcile from the returned snapshot, and revert if the write fails.
-  setReasoningEffort: async (effort) => {
-    const previous = get().reasoningEffort
-    const write = writeCoordinator.beginOptimistic('reasoningEffort', previous)
-    set({ reasoningEffort: effort })
-
-    try {
-      const snapshot = await write.run(() => window.api.settings.setReasoningEffort({ effort }))
-      write.complete({ value: snapshot.reasoningEffort })
-      if (!write.isCurrent()) return
-      set(applySnapshot(snapshot))
-      write.succeed()
-    } catch (error) {
-      const confirmedValue = write.complete()
-      if (write.isCurrent()) set({ reasoningEffort: confirmedValue })
-      write.fail(SETTINGS_WRITE_ERRORS.reasoningEffort)
-      console.error('Failed to set reasoning effort', error)
-    }
-  },
-
-  // Toggles desktop notifications. Optimistic like the other preference setters: apply the pick,
-  // reconcile from the returned snapshot, and revert if the write fails.
-  setNotificationsEnabled: async (enabled) => {
-    const previous = get().notificationsEnabled
-    const write = writeCoordinator.beginOptimistic('notifications', previous)
-    set({ notificationsEnabled: enabled })
-
-    try {
-      const snapshot = await write.run(() =>
-        window.api.settings.setNotificationsEnabled({ enabled })
-      )
-      write.complete({ value: snapshot.notificationsEnabled })
-      if (!write.isCurrent()) return
-      set(applySnapshot(snapshot))
-      write.succeed()
-    } catch (error) {
-      const confirmedValue = write.complete()
-      if (write.isCurrent()) set({ notificationsEnabled: confirmedValue })
-      write.fail(SETTINGS_WRITE_ERRORS.notifications)
-      console.error('Failed to set notifications enabled', error)
-    }
-  },
-
-  setConversationSkillImportEnabled: async (enabled) => {
-    const previous = get().conversationSkillImportEnabled
-    const write = writeCoordinator.beginOptimistic('conversationSkillImport', previous)
-    set({ conversationSkillImportEnabled: enabled })
-
-    try {
-      const snapshot = await write.run(() =>
-        window.api.settings.setConversationSkillImportEnabled({ enabled })
-      )
-      write.complete({ value: snapshot.conversationSkillImportEnabled })
-      if (!write.isCurrent()) return
-      set(applySnapshot(snapshot))
-      write.succeed()
-    } catch (error) {
-      const confirmedValue = write.complete()
-      if (write.isCurrent()) {
-        set({ conversationSkillImportEnabled: confirmedValue })
-      }
-      write.fail(SETTINGS_WRITE_ERRORS.conversationSkillImport)
-      console.error('Failed to set conversation Skill import enabled', error)
-    }
-  },
-
-  setClosePreference: async (preference) => {
-    const previous = get().closePreference
-    const write = writeCoordinator.beginOptimistic('closePreference', previous)
-    set({ closePreference: preference })
-
-    try {
-      const snapshot = await write.run(() => window.api.settings.setClosePreference({ preference }))
-      write.complete({ value: snapshot.closePreference })
-      if (!write.isCurrent()) return
-      set(applySnapshot(snapshot))
-      write.succeed()
-    } catch (error) {
-      const confirmedValue = write.complete()
-      if (write.isCurrent()) set({ closePreference: confirmedValue })
-      write.fail(SETTINGS_WRITE_ERRORS.closePreference)
-      console.error('Failed to set close preference', error)
-    }
-  },
-
-  // Sets the app-icon look. Optimistic like the other preference setters: apply the pick, reconcile
-  // from the returned snapshot, and revert if the write fails.
-  setAppIconVariant: async (variant) => {
-    const previous = get().appIconVariant
-    const write = writeCoordinator.beginOptimistic('appIcon', previous)
-    set({ appIconVariant: variant })
-
-    try {
-      const snapshot = await write.run(() => window.api.settings.setAppIconVariant({ variant }))
-      write.complete({ value: snapshot.appIconVariant })
-      if (!write.isCurrent()) return
-      set(applySnapshot(snapshot))
-      write.succeed()
-    } catch (error) {
-      const confirmedValue = write.complete()
-      if (write.isCurrent()) set({ appIconVariant: confirmedValue })
-      write.fail(SETTINGS_WRITE_ERRORS.appIcon)
-      console.error('Failed to set app icon variant', error)
-    }
   },
 
   clearSettingsWriteError: () => writeCoordinator.clearFailures(),
@@ -778,17 +662,6 @@ const createSettingsStoreState = (
     // Drop it from the queue immediately so the card can't be double-answered, then notify main.
     set((state) => ({ pendingApprovals: state.pendingApprovals.filter((r) => r.id !== id) }))
     await window.api.settings.respondConnectorApproval({ id, decision })
-  },
-
-  completeOnboarding: async () => {
-    const snapshot = await window.api.settings.markOnboardingComplete()
-
-    set(applySnapshot(snapshot))
-  },
-
-  setPackageMirror: async (mirror) => {
-    const saved = await window.api.settings.setPackageMirror(mirror)
-    set({ packageMirror: isMirrorConfigured(saved) ? saved : undefined })
   }
 })
 


### PR DESCRIPTION
## Problem

After provider/auth workflows moved behind their owner, `settings-store.ts` still directly coordinated five optimistic renderer preference writes plus onboarding completion and package-mirror settlement. The repeated ordering, rollback, visible-error, and full-snapshot reconciliation policy had no single renderer owner and remained mixed with unrelated dialog, Skill, and Connector actions.

## Proposed change

- Add one stateless preferences action slice that owns reasoning effort, notifications, conversation Skill import, window close, app icon, onboarding completion, and package-mirror writes.
- Centralize the existing five optimistic writes behind one same-key queued settlement helper using the existing R1 write coordinator. Their command payloads, confirmed-value rollback, stale-completion fencing, visible error copy, and console diagnostics remain unchanged.
- Keep the core store as the sole owner of the full Settings snapshot. Successful optimistic writes and onboarding completion still reconcile through the existing core projector; package mirror still applies only its normalized local projection.
- Keep onboarding completion and package-mirror writes non-optimistic and outside the coordinator, matching their prior settlement behavior.
- Reduce `settings-store.ts` from 803 to 676 physical lines. Production raw is 311 lines: 154 additions in the new owner plus 15 additions and 142 deletions in the compatibility store. The 660 split trigger did not fire.

```mermaid
flowchart LR
  Consumers["Settings / onboarding / workspace consumers"] --> Store["useSettingsStore compatibility interface"]
  Store --> Preferences["stateless preferences action owner"]
  Store --> Core["full snapshot projector"]
  Preferences --> Commands["existing Settings renderer commands"]
  Preferences --> Writes["existing R1 write coordinator"]
  Preferences --> Core
```

## Scope and non-goals

In scope: reasoning-effort, notifications, conversation Skill import, window-close, and app-icon optimistic writes; onboarding completion; package-mirror persistence and normalization; unchanged visible failure messages; success, failure, same-key concurrency, stale completion, and rollback behavior.

Out of scope: dialog open/close or navigation state, new preference fields, persisted Settings schema changes, main-process ownership, new concurrency policy, new transport commands, UI or interaction changes, runtime/provider/auth workflows, Skills catalog operations, Connectors, or permission policy. The compatibility store remains the public Zustand interface and the sole full-snapshot owner.

## Compatibility

- Public Settings state/action names, selectors, `getState`/`setState`, IPC channels, payloads, preload types, generated Web maps, persisted data, and user interactions are unchanged.
- The five optimistic writes retain R1 same-key serialization, confirmed-value rollback, stale-completion fencing, path-safe visible errors, and atomic full-snapshot reconciliation.
- Onboarding completion still awaits main and then applies the returned full snapshot. Package mirror still awaits main, normalizes an empty configuration to `undefined`, and does not use optimistic rollback or visible write-error state.
- Dialog open/close, deep links, pending Settings/Skill/Specialist targets, and Compute navigation remain in the compatibility store and are not routed through the new owner.
- Electron, local Web, remote Web, CLI, and Task keep their current command availability and rejection behavior; this renderer-only extraction adds no transport or capability surface.
- Specialist, Permission, Compute, provider/auth, runtime installation, local RPC, MCP, and Issue #458 boundaries are untouched.

## Acceptance criteria and validation

All checks ran after the last material edit on exact commit `c1d205b9` based on `449abc75`:

- preference success, immediate optimistic projection, failure copy, confirmed-value rollback, same-key serialization, newer failure after older success, onboarding completion, and package-mirror normalization -> `npm test -- --run src/renderer/src/stores/settings-preferences-slice.test.ts` -> 4/4 passed
- composed compatibility store and retained R0 behavior -> `npm test -- --run src/renderer/src/stores/settings-store.test.ts` -> 88/88 passed
- General Settings, Skills, reasoning selector, composer model picker, onboarding wizard/location, and Settings package-mirror consumers -> targeted seven renderer test files -> 149/149 passed
- combined final Test Impact Set -> 9 files, 241/241 passed
- renderer type safety -> `npm run typecheck:web` -> passed
- changed TypeScript files -> targeted `npx eslint` -> passed
- patch hygiene and changed-file formatting -> `git diff --check`, Prettier check, and `scripts/ci/check-changed-format.mjs` -> passed
- independent exact-diff review and verification reproduction -> Standards 0 findings; Spec 0 findings; raw 311 independently confirmed; the 92 owner/store and 149 consumer tests, `typecheck:web`, targeted ESLint, Prettier, and changed-format diff-check all passed

Uncovered locally: the full portable suite, platform/E2E lanes, Electron's actual preference side effects, and cross-surface runtime exercise were not run. Their command boundaries are unchanged; PR Gate remains authoritative for the final exact-head impact plan and cross-platform lanes.

## Review focus

- Confirm the owner is action-only and the core remains the sole full Settings snapshot projector.
- Confirm all five optimistic commands retain their exact payload, same-key queue, confirmed-value rollback, stale-completion fencing, visible error copy, and console message.
- Confirm onboarding and package mirror did not accidentally acquire optimistic or coordinator behavior.
- Confirm package-mirror empty-state normalization and full-snapshot reconciliation are unchanged.
- Confirm dialog/navigation actions and every public renderer interface remain outside and unchanged.
- Confirm Electron/Web/CLI/Task capability asymmetries plus Specialist/Permission/Compute boundaries are unchanged.

Merge with squash only after exact-head CI and AI review are green.
