### PR TITLE
docs(contributing): document nightly post-merge validation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,11 +238,11 @@ ci(review): unify automated AI reviews
   checks ran after the last material edit, and call out uncovered risks.
 - Keep PRs reasonably small and scoped so they are easy to review.
 - Ensure the final Test Impact Set, or the full fallback when required, passes.
-- After the pull request checks pass, add the pull request to the merge queue. Do not update the
-  branch only because `main` advanced; the queue validates the change against the latest `main`.
-  Update the branch when it has merge conflicts or a maintainer requests it.
-- The merge queue uses **squash merge only**. The squash commit subject must keep the pull request
-  title's Conventional Commit format.
+- After the pull request checks pass, merge it directly using **squash merge only**. Do not update the
+  branch only because `main` advanced; update it when it has merge conflicts or a maintainer requests
+  it. The squash commit subject must keep the pull request title's Conventional Commit format.
+- Non-documentation changes merged into `main` trigger the [Nightly workflow](.github/workflows/nightly.yml),
+  which runs post-merge verification and cross-platform package certification on the resulting commit.
 
 ## Reporting Issues
 


### PR DESCRIPTION
## Problem

The required merge queue reruns PR Gate against a merge-group commit after the pull request already passed its checks. The second full pass and serialized queue add substantial merge latency.

## Proposed change

Document direct squash merging after required pull request checks pass. Non-documentation changes are then validated on the resulting `main` commit by the existing Nightly workflow, which already runs verification and cross-platform package certification on every push to `main`.

The `main` ruleset has been updated separately to remove the merge queue rule while retaining loose required status checks (`strict=false`).

## Scope and non-goals

- Documentation only in this pull request.
- No PR Gate, CI Integrity, Nightly, or build workflow changes.
- Required `CI Integrity` and `PR Gate` checks remain enabled for pull requests.
- Post-merge Nightly detection does not prevent a regression from reaching `main`; it detects failures after the merge.

## Acceptance criteria and validation

Checks ran after the last material edit:

- Contributor guidance formatting -> `npx prettier --check CONTRIBUTING.md` -> passed.
- Diff whitespace validation -> `git diff --check` -> passed.
- Existing Nightly/build coverage contract -> `npm test -- scripts/windows-release-workflows.test.ts` -> 1 file and 9 tests passed.
- Main ruleset behavior -> GitHub ruleset API readback -> `merge_queue_count: 0`, `strict: false`, required checks remain `CI Integrity` and `PR Gate`.

Runtime consumer lanes were excluded because the tracked diff is documentation-only and no workflow logic changed. The uncovered risk is the intentional shift from pre-merge merge-group validation to post-merge Nightly detection.

## Review focus

Confirm that the guidance accurately describes direct squash merging and the existing Nightly workflow's post-merge role.
