### PR TITLE
refactor(settings-store): extract navigation slice

### DIFF
--- a/src/renderer/src/stores/settings-navigation-slice.test.ts
+++ b/src/renderer/src/stores/settings-navigation-slice.test.ts
@@ -1,0 +1,113 @@
+import { createStore, type StoreApi } from 'zustand/vanilla'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  createInitialSettingsNavigationState,
+  createSettingsNavigationSlice,
+  type SettingsNavigationActions,
+  type SettingsNavigationState
+} from './settings-navigation-slice'
+
+type TestStore = SettingsNavigationState & SettingsNavigationActions
+
+const createHarness = (): StoreApi<TestStore> =>
+  createStore<TestStore>((set) => ({
+    ...createInitialSettingsNavigationState(),
+    ...createSettingsNavigationSlice({ setState: (patch) => set(patch) })
+  }))
+
+describe('settings navigation slice', () => {
+  let store: StoreApi<TestStore>
+
+  beforeEach(() => {
+    store = createHarness()
+  })
+
+  it('opens normally without replacing a pending landing target', () => {
+    store.setState({ pendingSettingsPanel: 'storage' })
+
+    store.getState().openSettings()
+
+    expect(store.getState()).toMatchObject({
+      isSettingsOpen: true,
+      pendingSettingsPanel: 'storage'
+    })
+  })
+
+  it.each([
+    [
+      'panel',
+      () => store.getState().openSettingsToPanel('storage'),
+      'storage',
+      undefined,
+      undefined
+    ],
+    [
+      'Skill',
+      () => store.getState().openSettingsToSkill('skill-1'),
+      undefined,
+      'skill-1',
+      undefined
+    ],
+    [
+      'Specialist',
+      () => store.getState().openSettingsToSpecialist('specialist-1'),
+      undefined,
+      undefined,
+      'specialist-1'
+    ],
+    ['Compute', () => store.getState().openSettingsToCompute(), 'compute', undefined, undefined]
+  ] as const)(
+    'opens the %s target and clears every competing target',
+    (_label, open, panel, skillId, specialistId) => {
+      store.setState({
+        pendingSettingsPanel: 'agent',
+        pendingSkillId: 'stale-skill',
+        pendingSpecialistId: 'stale-specialist'
+      })
+
+      open()
+
+      expect(store.getState()).toMatchObject({
+        isSettingsOpen: true,
+        pendingSettingsPanel: panel,
+        pendingSkillId: skillId,
+        pendingSpecialistId: specialistId
+      })
+    }
+  )
+
+  it('consumes each landing target exactly once without closing the dialog', () => {
+    store.setState({
+      isSettingsOpen: true,
+      pendingSettingsPanel: 'storage',
+      pendingSkillId: 'skill-1',
+      pendingSpecialistId: 'specialist-1'
+    })
+
+    store.getState().consumePendingSettingsPanel()
+    store.getState().consumePendingSkill()
+    store.getState().consumePendingSpecialist()
+
+    expect(store.getState()).toMatchObject({
+      isSettingsOpen: true,
+      pendingSettingsPanel: undefined,
+      pendingSkillId: undefined,
+      pendingSpecialistId: undefined
+    })
+  })
+
+  it('clears stale targets on close so a normal reopen starts fresh', () => {
+    store.getState().openSettingsToSpecialist('specialist-1')
+
+    store.getState().closeSettings()
+    store.getState().openSettings()
+
+    expect(store.getState()).toMatchObject({
+      isSettingsOpen: true,
+      pendingSettingsPanel: undefined,
+      pendingSkillId: undefined,
+      pendingSpecialistId: undefined
+    })
+  })
+})

--- a/src/renderer/src/stores/settings-navigation-slice.ts
+++ b/src/renderer/src/stores/settings-navigation-slice.ts
@@ -1,0 +1,83 @@
+import type { SettingsPanelId } from '../pages/settings/settings-navigation'
+
+export type SettingsNavigationState = {
+  isSettingsOpen: boolean
+  pendingSettingsPanel?: SettingsPanelId
+  pendingSkillId?: string
+  pendingSpecialistId?: string
+}
+
+export type SettingsNavigationActions = {
+  openSettings: () => void
+  openSettingsToPanel: (panel: SettingsPanelId) => void
+  closeSettings: () => void
+  openSettingsToSkill: (skillId: string) => void
+  openSettingsToSpecialist: (specialistId: string) => void
+  openSettingsToCompute: () => void
+  consumePendingSettingsPanel: () => void
+  consumePendingSkill: () => void
+  consumePendingSpecialist: () => void
+}
+
+type SettingsNavigationSliceOptions = {
+  setState: (patch: Partial<SettingsNavigationState>) => void
+}
+
+export const createInitialSettingsNavigationState = (): SettingsNavigationState => ({
+  isSettingsOpen: false,
+  pendingSettingsPanel: undefined,
+  pendingSkillId: undefined,
+  pendingSpecialistId: undefined
+})
+
+// Owns only the global dialog visibility and one-shot external landing targets. SettingsPage keeps
+// its local breadcrumb/history stack and consumes these targets through the compatibility store.
+export const createSettingsNavigationSlice = ({
+  setState
+}: SettingsNavigationSliceOptions): SettingsNavigationActions => ({
+  openSettings: () => setState({ isSettingsOpen: true }),
+
+  openSettingsToPanel: (panel) =>
+    setState({
+      isSettingsOpen: true,
+      pendingSettingsPanel: panel,
+      pendingSkillId: undefined,
+      pendingSpecialistId: undefined
+    }),
+
+  closeSettings: () =>
+    setState({
+      isSettingsOpen: false,
+      pendingSettingsPanel: undefined,
+      pendingSkillId: undefined,
+      pendingSpecialistId: undefined
+    }),
+
+  openSettingsToSkill: (skillId) =>
+    setState({
+      isSettingsOpen: true,
+      pendingSettingsPanel: undefined,
+      pendingSkillId: skillId,
+      pendingSpecialistId: undefined
+    }),
+
+  openSettingsToSpecialist: (specialistId) =>
+    setState({
+      isSettingsOpen: true,
+      pendingSettingsPanel: undefined,
+      pendingSkillId: undefined,
+      pendingSpecialistId: specialistId
+    }),
+
+  openSettingsToCompute: () =>
+    setState({
+      isSettingsOpen: true,
+      pendingSettingsPanel: 'compute',
+      pendingSkillId: undefined,
+      pendingSpecialistId: undefined
+    }),
+
+  consumePendingSettingsPanel: () => setState({ pendingSettingsPanel: undefined }),
+  consumePendingSkill: () => setState({ pendingSkillId: undefined }),
+  consumePendingSpecialist: () => setState({ pendingSpecialistId: undefined })
+})

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -13,11 +13,16 @@ import {
 import type { PackageMirror } from '../../../shared/mirror'
 import type { CloseActionPreference } from '../../../shared/window-controls'
 import { isMirrorConfigured } from '../pages/settings/mirror-view'
-import type { SettingsPanelId } from '../pages/settings/settings-navigation'
 import {
   createSettingsWriteCoordinator,
   type SettingsWriteCoordinator
 } from './settings-write-coordinator'
+import {
+  createInitialSettingsNavigationState,
+  createSettingsNavigationSlice,
+  type SettingsNavigationActions,
+  type SettingsNavigationState
+} from './settings-navigation-slice'
 import {
   createSettingsPreferencesSlice,
   type SettingsPreferencesActions
@@ -72,87 +77,66 @@ import type {
   ApprovalDecision
 } from '../../../shared/settings'
 
-type SettingsStoreData = RuntimeSetupState & {
-  isLoaded: boolean
-  isLoading: boolean
-  loadError: string | undefined
-  // Latest failed Settings write, shown by the dialog until dismissed or another write starts.
-  settingsWriteError: string | undefined
-  settingsLoadGeneration: number
-  claude: ClaudeInfo
-  activeProviderId: string | undefined
-  claudeSubscriptionProviderId: ClaudeSubscriptionProviderId | undefined
-  // Active model within the active provider; undefined means the provider's own default.
-  activeModel: string | undefined
-  providers: ProviderView[]
-  // Selected agent backend and the frameworks available to choose from.
-  agentFrameworkId: AgentFrameworkId
-  agentFrameworks: AgentFrameworkView[]
-  // Detected opencode executable, for the framework-aware detection card.
-  opencode: OpencodeInfo
-  codex: CodexInfo
-  // Whether each framework's detected runtime is the app-managed install (only these can be uninstalled
-  // in-app). Mirrored from the main-process snapshot; a PATH/npm binary reads false.
-  claudeManaged: boolean
-  opencodeManaged: boolean
-  codexManaged: boolean
-  onboardingCompletedAt: number | undefined
-  // Bundled skills with their enabled state, loaded lazily when the Skills panel opens.
-  skills: SkillView[]
-  // Bundled connectors with their enabled/auto-allow state, loaded lazily when the Connectors panel opens.
-  connectors: ConnectorView[]
-  // User-added custom MCP servers, reconciled alongside the connectors list.
-  customServers: CustomServerView[]
-  // Pending per-call connector approval requests (external data-egress gate), oldest first.
-  pendingApprovals: ConnectorApprovalRequest[]
-  // Shared NCBI credential state (never the plaintext key), reconciled alongside the connectors list.
-  ncbi: NcbiCredentialsView
-  encryptionAvailable: boolean
-  // Whether the settings dialog is open (rendered at the app root, over Home/Workspace).
-  isSettingsOpen: boolean
-  // Panel requested by an external entry point; Settings consumes it after seeding navigation.
-  pendingSettingsPanel?: SettingsPanelId
-  // Skill to land on when the dialog opens from a skill mention; consumed once its detail is seeded.
-  pendingSkillId?: string
-  // Specialist to land on when the dialog opens from the switch approval card; consumed once its
-  // editor is seeded. Uses the stable profile id, never the renameable public name.
-  pendingSpecialistId?: string
-  // Configured package mirror (conda/pip); undefined means public hosts (unconfigured).
-  packageMirror?: PackageMirror
-  // Reasoning-effort preference applied to agent requests; 'default' leaves the agent's own default.
-  reasoningEffort: ReasoningEffort
-  // Whether the app posts an OS notification when an agent task finishes or fails while unfocused.
-  notificationsEnabled: boolean
-  // Whether conversations receive the app-owned Skill package import tool and instructions.
-  conversationSkillImportEnabled: boolean
-  // Saved Windows titlebar-close behavior. Undefined means ask every time.
-  closePreference: CloseActionPreference | undefined
-  // Selected built-in app-icon look, applied to the window and dock/taskbar. Defaults to 'light'.
-  appIconVariant: AppIconVariant
-}
+type SettingsStoreData = RuntimeSetupState &
+  SettingsNavigationState & {
+    isLoaded: boolean
+    isLoading: boolean
+    loadError: string | undefined
+    // Latest failed Settings write, shown by the dialog until dismissed or another write starts.
+    settingsWriteError: string | undefined
+    settingsLoadGeneration: number
+    claude: ClaudeInfo
+    activeProviderId: string | undefined
+    claudeSubscriptionProviderId: ClaudeSubscriptionProviderId | undefined
+    // Active model within the active provider; undefined means the provider's own default.
+    activeModel: string | undefined
+    providers: ProviderView[]
+    // Selected agent backend and the frameworks available to choose from.
+    agentFrameworkId: AgentFrameworkId
+    agentFrameworks: AgentFrameworkView[]
+    // Detected opencode executable, for the framework-aware detection card.
+    opencode: OpencodeInfo
+    codex: CodexInfo
+    // Whether each framework's detected runtime is the app-managed install (only these can be uninstalled
+    // in-app). Mirrored from the main-process snapshot; a PATH/npm binary reads false.
+    claudeManaged: boolean
+    opencodeManaged: boolean
+    codexManaged: boolean
+    onboardingCompletedAt: number | undefined
+    // Bundled skills with their enabled state, loaded lazily when the Skills panel opens.
+    skills: SkillView[]
+    // Bundled connectors with their enabled/auto-allow state, loaded lazily when the Connectors panel opens.
+    connectors: ConnectorView[]
+    // User-added custom MCP servers, reconciled alongside the connectors list.
+    customServers: CustomServerView[]
+    // Pending per-call connector approval requests (external data-egress gate), oldest first.
+    pendingApprovals: ConnectorApprovalRequest[]
+    // Shared NCBI credential state (never the plaintext key), reconciled alongside the connectors list.
+    ncbi: NcbiCredentialsView
+    encryptionAvailable: boolean
+    // Configured package mirror (conda/pip); undefined means public hosts (unconfigured).
+    packageMirror?: PackageMirror
+    // Reasoning-effort preference applied to agent requests; 'default' leaves the agent's own default.
+    reasoningEffort: ReasoningEffort
+    // Whether the app posts an OS notification when an agent task finishes or fails while unfocused.
+    notificationsEnabled: boolean
+    // Whether conversations receive the app-owned Skill package import tool and instructions.
+    conversationSkillImportEnabled: boolean
+    // Saved Windows titlebar-close behavior. Undefined means ask every time.
+    closePreference: CloseActionPreference | undefined
+    // Selected built-in app-icon look, applied to the window and dock/taskbar. Defaults to 'light'.
+    appIconVariant: AppIconVariant
+  }
 
 type SettingsStoreCore = SettingsStoreData &
   ProviderAuthActions &
   SettingsPreferencesActions &
+  SettingsNavigationActions &
   SettingsStoreActions
 
 type SettingsStoreActions = {
   load: (options?: { force?: boolean }) => Promise<boolean>
   clearSettingsWriteError: () => void
-  openSettings: () => void
-  openSettingsToPanel: (panel: SettingsPanelId) => void
-  closeSettings: () => void
-  // Opens the dialog straight onto a skill's detail page (used by clickable skill mentions).
-  openSettingsToSkill: (skillId: string) => void
-  // Opens the dialog straight onto one specialist's editor (used by the switch approval card).
-  openSettingsToSpecialist: (specialistId: string) => void
-  // Opens the dialog straight to the Compute panel (used by Files panel "Add SSH host…" link).
-  openSettingsToCompute: () => void
-  // Clears the requested panel after Settings has seeded its local navigation history.
-  consumePendingSettingsPanel: () => void
-  // Clears the pending skill once its detail view has been seeded, so a later open starts fresh.
-  consumePendingSkill: () => void
-  consumePendingSpecialist: () => void
   // Loads the bundled-skill list (enabled state included) from the main process.
   loadSkills: () => Promise<void>
   // Toggles one skill; optimistic, then reconciled with the authoritative list from main.
@@ -220,6 +204,7 @@ type SettingsStore = SettingsStoreCore & RuntimeSetupActions
 
 export const createInitialSettingsState = (): SettingsStoreData => ({
   ...createInitialRuntimeSetupState(),
+  ...createInitialSettingsNavigationState(),
   isLoaded: false,
   isLoading: false,
   loadError: undefined,
@@ -244,10 +229,6 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   pendingApprovals: [],
   ncbi: { hasApiKey: false },
   encryptionAvailable: true,
-  isSettingsOpen: false,
-  pendingSettingsPanel: undefined,
-  pendingSkillId: undefined,
-  pendingSpecialistId: undefined,
   packageMirror: undefined,
   reasoningEffort: DEFAULT_REASONING_EFFORT,
   notificationsEnabled: DEFAULT_NOTIFICATIONS_ENABLED,
@@ -390,6 +371,7 @@ const createSettingsStoreState = (
     reconcileSnapshot: (snapshot) => set(applySnapshot(snapshot)),
     writeCoordinator
   }),
+  ...createSettingsNavigationSlice({ setState: (patch) => set(patch) }),
 
   // Loads settings, preflight, and encryption availability in one startup pass.
   load: (options) => {
@@ -441,57 +423,6 @@ const createSettingsStoreState = (
   },
 
   clearSettingsWriteError: () => writeCoordinator.clearFailures(),
-
-  openSettings: () => set({ isSettingsOpen: true }),
-
-  openSettingsToPanel: (panel) =>
-    set({
-      isSettingsOpen: true,
-      pendingSettingsPanel: panel,
-      pendingSkillId: undefined,
-      pendingSpecialistId: undefined
-    }),
-
-  // Clearing the pending targets on close stops a later normal open from jumping back to stale state.
-  closeSettings: () =>
-    set({
-      isSettingsOpen: false,
-      pendingSkillId: undefined,
-      pendingSpecialistId: undefined,
-      pendingSettingsPanel: undefined
-    }),
-
-  openSettingsToSkill: (skillId) =>
-    set({
-      isSettingsOpen: true,
-      pendingSkillId: skillId,
-      pendingSpecialistId: undefined,
-      pendingSettingsPanel: undefined
-    }),
-
-  // Deep-link straight to one specialist's editor (used by the specialist switch approval card).
-  openSettingsToSpecialist: (specialistId) =>
-    set({
-      isSettingsOpen: true,
-      pendingSpecialistId: specialistId,
-      pendingSkillId: undefined,
-      pendingSettingsPanel: undefined
-    }),
-
-  // Keep the domain-specific caller API while routing it through the shared panel target.
-  openSettingsToCompute: () =>
-    set({
-      isSettingsOpen: true,
-      pendingSettingsPanel: 'compute',
-      pendingSkillId: undefined,
-      pendingSpecialistId: undefined
-    }),
-
-  consumePendingSettingsPanel: () => set({ pendingSettingsPanel: undefined }),
-
-  consumePendingSkill: () => set({ pendingSkillId: undefined }),
-
-  consumePendingSpecialist: () => set({ pendingSpecialistId: undefined }),
 
   loadSkills: async () => {
     const skills = await window.api.settings.listSkills()


### PR DESCRIPTION
## Problem

After preference workflows moved behind their owner, `settings-store.ts` still directly owned global Settings dialog visibility and all externally requested landing targets. The state and transitions were small but mixed into the remaining Skill and Connector workflows, making their exact consume/close/reopen semantics harder to review in isolation.

## Proposed change

- Add one Settings navigation slice that owns dialog visibility plus pending panel, Skill, and Specialist landing targets.
- Move normal open, named panel, Skill, Specialist, Compute, close, and one-shot consume transitions behind that slice without changing their public action names.
- Move the four navigation state fields and their initial values into the slice while keeping the existing Zustand store as the compatibility interface.
- Keep SettingsPage local breadcrumb/history state and every Specialist, Compute, and Skill business workflow in their existing owners.
- Reduce `settings-store.ts` from 676 to 607 physical lines. Production raw is 270 lines: 83 additions in the new owner plus 59 additions and 128 deletions in the compatibility store. The 660 split trigger did not fire.

```mermaid
flowchart LR
  Entrypoints["Home / workspace / approval entry points"] --> Store["useSettingsStore compatibility interface"]
  Store --> Navigation["Settings navigation owner"]
  Navigation --> Dialog["visibility"]
  Navigation --> Targets["one-shot panel / Skill / Specialist target"]
  Store --> Page["SettingsPage local breadcrumb/history"]
  Targets --> Page
```

## Scope and non-goals

In scope: normal open, close, named-panel landing, Skill landing, Specialist landing, Compute landing, target competition/clearing, one-shot consumption, and close-then-normal-reopen behavior.

Out of scope: SettingsPage breadcrumb/history stacks, a route library, URL state, a second Zustand store, Specialist/Compute/Skill business state, persisted Settings data, transport commands, new entry points, or visual/interaction changes.

## Compatibility

- Public Settings state/action names, selectors, `getState`/`setState`, component call sites, IPC channels, payloads, preload types, generated Web maps, persisted data, and user interactions are unchanged.
- Normal open still changes only visibility and leaves any pending target intact for the current landing pass.
- Panel, Skill, Specialist, and Compute opens still make the dialog visible and clear all competing target types.
- Close still clears every pending target. A later normal reopen therefore starts fresh.
- Each consume action still clears only its own target and does not close the dialog or alter another target.
- Electron, Web, CLI, and Task capability boundaries are unchanged; this slice has no transport dependency. Specialist, Permission, Compute, provider/auth, preferences, runtime installation, local RPC, MCP, and Issue #458 boundaries are untouched.

## Acceptance criteria and validation

All checks ran after the last material edit and were refreshed after the patch-identical docs-only rebase on exact commit `e7945211` based on `d2a57240`:

- initial state, normal open, every target, competing-target clearing, per-target consumption, close, and fresh reopen -> `npm test -- --run src/renderer/src/stores/settings-navigation-slice.test.ts` -> 7/7 passed
- composed compatibility store and retained R0 navigation behavior -> `npm test -- --run src/renderer/src/stores/settings-store.test.ts` -> 88/88 passed
- SettingsPage landing/consumption and App, Home, permission approval, Compute menu, and Project Files entry-point consumers -> targeted six renderer test files -> 206/206 passed
- combined final Test Impact Set -> 8 files, 301/301 passed
- renderer type safety -> `npm run typecheck:web` -> passed
- changed TypeScript files -> targeted `npx eslint` -> passed
- patch hygiene and changed-file formatting -> `git diff --check`, Prettier check, and `scripts/ci/check-changed-format.mjs` -> passed
- independent exact-diff review and verification reproduction -> Standards 0 findings; Spec 0 findings; raw 270 independently confirmed; 152 focused tests, `typecheck:web`, targeted ESLint, Prettier, and changed-format diff-check passed. The later #842 rebase touched only `CONTRIBUTING.md`; `git range-diff` reported `=` and the implementation agent reran the 301-test set plus `typecheck:web` on the new exact head.

Uncovered locally: the full portable suite and platform/E2E lanes were not run. The slice has no IPC or platform dependency; PR Gate remains authoritative for the final exact-head impact plan.

## Review focus

- Confirm the slice owns only global visibility and one-shot external landing targets.
- Confirm normal open preserves a pending target, while every targeted open clears competing target types.
- Confirm close clears every pending target and normal reopen does not resurrect stale navigation.
- Confirm consume actions clear exactly one target without changing visibility.
- Confirm SettingsPage local breadcrumb/history and Specialist/Compute/Skill business state did not move.
- Confirm all public interfaces and Electron/Web/CLI/Task capability boundaries remain unchanged.

Merge with squash only after exact-head CI and AI review are green.
