### PR TITLE
refactor(notebook): own runtime repair lifecycle

### DIFF
--- a/src/main/notebook/package-admission.test.ts
+++ b/src/main/notebook/package-admission.test.ts
@@ -152,8 +152,7 @@ describe('NotebookPackageAdmissionOwner', () => {
         interpreter: { command: '/usr/local/bin/python' },
         environmentCaptureTarget: { runtimeSource: 'external' },
         repairRuntimeId: binding.runtimeId,
-        repairMarkerKey: binding.runtimeId,
-        repairRegistryKeys: [binding.runtimeId]
+        repairMarkerKey: binding.runtimeId
       }
     })
     expect(admission.status === 'admitted' && admission.target.journalTarget).toBeUndefined()

--- a/src/main/notebook/package-admission.ts
+++ b/src/main/notebook/package-admission.ts
@@ -49,7 +49,6 @@ type NotebookPackageAdmittedTarget = Readonly<{
   environmentCaptureTarget: EnvironmentCaptureTarget
   repairRuntimeId: string
   repairMarkerKey: string
-  repairRegistryKeys: readonly string[]
   journalTarget?: string
 }>
 
@@ -172,7 +171,6 @@ class NotebookPackageAdmissionOwner {
         ),
         repairRuntimeId,
         repairMarkerKey,
-        repairRegistryKeys: repair.keys,
         journalTarget
       }
     }

--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -36,7 +36,6 @@ const admittedTarget = (
   },
   repairRuntimeId: 'analysis',
   repairMarkerKey: 'analysis::python',
-  repairRegistryKeys: ['analysis', 'analysis::python'],
   journalTarget: join(runtimeRoot, 'envs', 'analysis'),
   ...overrides
 })
@@ -75,8 +74,10 @@ const ownerHarness = (
       method: 'conda'
     }),
     recheckRepair: vi.fn(() => undefined),
-    quarantineProtectedIdentity: vi.fn().mockResolvedValue(undefined),
-    completeInterruptedInstallRepair: vi.fn().mockResolvedValue(undefined),
+    runtimeRepair: {
+      quarantineProtectedIdentity: vi.fn().mockResolvedValue(undefined),
+      completeInterruptedInstall: vi.fn().mockResolvedValue(undefined)
+    },
     blockUnconfirmedChild: vi.fn(),
     ...optionOverrides
   }
@@ -193,11 +194,14 @@ describe('NotebookPackageMutationOwner', () => {
         expect(readOperationChild(runtimeRoot, operationId)).toMatchObject({ spawning: true })
         return { ok: true, needsRestart: false, log: 'installed', method: 'conda' as const }
       }),
-      completeInterruptedInstallRepair: vi.fn(async () => {
-        expect(await pending(runtimeRoot)).toEqual([])
-        expect(readOperationChild(runtimeRoot, operationId)).toBeUndefined()
-        order.push('repair-complete')
-      })
+      runtimeRepair: {
+        quarantineProtectedIdentity: vi.fn().mockResolvedValue(undefined),
+        completeInterruptedInstall: vi.fn(async () => {
+          expect(await pending(runtimeRoot)).toEqual([])
+          expect(readOperationChild(runtimeRoot, operationId)).toBeUndefined()
+          order.push('repair-complete')
+        })
+      }
     })
 
     const result = await owner.mutate({
@@ -224,7 +228,7 @@ describe('NotebookPackageMutationOwner', () => {
       'unlock',
       'repair-complete'
     ])
-    expect(options.quarantineProtectedIdentity).not.toHaveBeenCalled()
+    expect(options.runtimeRepair.quarantineProtectedIdentity).not.toHaveBeenCalled()
   })
 
   it('fails closed without dirtying or spawning when the journal cannot begin', async () => {
@@ -240,7 +244,7 @@ describe('NotebookPackageMutationOwner', () => {
     })
     expect(options.environmentStateTracker.markPackageMutationDirty).not.toHaveBeenCalled()
     expect(options.installPackages).not.toHaveBeenCalled()
-    expect(options.completeInterruptedInstallRepair).not.toHaveBeenCalled()
+    expect(options.runtimeRepair.completeInterruptedInstall).not.toHaveBeenCalled()
   })
 
   it('clears journal evidence after a pre-spawn dirty-marker failure', async () => {
@@ -296,7 +300,7 @@ describe('NotebookPackageMutationOwner', () => {
     expect(options.environmentOperations.logPackageResult).toHaveBeenCalledWith(
       expect.objectContaining({ result })
     )
-    expect(options.completeInterruptedInstallRepair).not.toHaveBeenCalled()
+    expect(options.runtimeRepair.completeInterruptedInstall).not.toHaveBeenCalled()
   })
 
   it('upgrades evidence before quarantining a protected identity', async () => {
@@ -307,20 +311,23 @@ describe('NotebookPackageMutationOwner', () => {
         repairRequired: true,
         log: 'protected interpreter changed'
       }),
-      quarantineProtectedIdentity: vi.fn(async () => {
-        expect(await pending(runtimeRoot)).toEqual([
-          expect.objectContaining({
-            runtimeId: 'analysis',
-            repairReason: 'protected-identity-change'
-          })
-        ])
-      })
+      runtimeRepair: {
+        completeInterruptedInstall: vi.fn().mockResolvedValue(undefined),
+        quarantineProtectedIdentity: vi.fn(async () => {
+          expect(await pending(runtimeRoot)).toEqual([
+            expect.objectContaining({
+              runtimeId: 'analysis',
+              repairReason: 'protected-identity-change'
+            })
+          ])
+        })
+      }
     })
 
     const result = await owner.mutate({ target, mirror: {} })
 
     expect(result).toMatchObject({ ok: false, repairRequired: true })
-    expect(options.quarantineProtectedIdentity).toHaveBeenCalledWith(target)
+    expect(options.runtimeRepair.quarantineProtectedIdentity).toHaveBeenCalledWith(target)
     expect(await pending(runtimeRoot)).toEqual([])
   })
 
@@ -333,7 +340,10 @@ describe('NotebookPackageMutationOwner', () => {
         repairRequired: true,
         log: 'protected interpreter changed'
       }),
-      quarantineProtectedIdentity: vi.fn().mockRejectedValue(quarantineFailure)
+      runtimeRepair: {
+        completeInterruptedInstall: vi.fn().mockResolvedValue(undefined),
+        quarantineProtectedIdentity: vi.fn().mockRejectedValue(quarantineFailure)
+      }
     })
 
     await expect(owner.mutate({ target, mirror: {} })).rejects.toBe(quarantineFailure)
@@ -358,7 +368,7 @@ describe('NotebookPackageMutationOwner', () => {
       /could not be upgraded.*journal update denied/
     )
 
-    expect(options.quarantineProtectedIdentity).toHaveBeenCalledWith(target)
+    expect(options.runtimeRepair.quarantineProtectedIdentity).toHaveBeenCalledWith(target)
     expect(await pending(runtimeRoot)).toEqual([
       expect.objectContaining({ repairReason: 'interrupted-install' })
     ])

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -17,6 +17,7 @@ import type { NotebookPackageAdmission, NotebookPackageAdmittedTarget } from './
 import type { InstallDeps, InstallResult } from './package-manager'
 import { readProcessStartToken } from './operation-recovery'
 import { isChildUnconfirmedError } from './provisioner-runtime'
+import type { NotebookRuntimeRepairOwner } from './runtime-repair'
 
 const REPAIR_QUARANTINE_FAILED = 'REPAIR_QUARANTINE_FAILED'
 
@@ -46,8 +47,10 @@ type NotebookPackageMutationOwnerOptions = {
   recheckRepair: (
     target: NotebookPackageAdmittedTarget
   ) => Extract<NotebookPackageAdmission, { status: 'refused' }> | undefined
-  quarantineProtectedIdentity: (target: NotebookPackageAdmittedTarget) => Promise<void>
-  completeInterruptedInstallRepair: (target: NotebookPackageAdmittedTarget) => Promise<void>
+  runtimeRepair: Pick<
+    NotebookRuntimeRepairOwner,
+    'quarantineProtectedIdentity' | 'completeInterruptedInstall'
+  >
   blockUnconfirmedChild: (target: NotebookPackageAdmittedTarget) => void
 }
 
@@ -192,7 +195,7 @@ class NotebookPackageMutationOwner {
             } catch (error) {
               journalUpdateError = error
             }
-            await this.options.quarantineProtectedIdentity(target)
+            await this.options.runtimeRepair.quarantineProtectedIdentity(target)
             if (journalUpdateError) {
               deferredQuarantineError = new Error(
                 `${REPAIR_QUARANTINE_FAILED}: the runtime was quarantined, but its operation journal ` +
@@ -248,7 +251,7 @@ class NotebookPackageMutationOwner {
         await journal.complete(operationId).catch(() => undefined)
       }
     }
-    if (result.ok) await this.options.completeInterruptedInstallRepair(target)
+    if (result.ok) await this.options.runtimeRepair.completeInterruptedInstall(target)
     return result
   }
 }

--- a/src/main/notebook/runtime-repair.test.ts
+++ b/src/main/notebook/runtime-repair.test.ts
@@ -1,0 +1,292 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { NotebookLanguage } from '../../shared/notebook'
+import type { NotebookPackageAdmittedTarget } from './package-admission'
+import {
+  addRepairRequired,
+  managedRepairRegistryKey,
+  readRepairRequiredReason,
+  repairRegistryPath
+} from './runtime-paths'
+import { NotebookRuntimeRepairOwner } from './runtime-repair'
+import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
+import { NotebookSessionAggregate, type NotebookSessionRuntimeBinding } from './session-aggregate'
+
+type RepairOptions = ConstructorParameters<typeof NotebookRuntimeRepairOwner>[0]
+
+const roots: string[] = []
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+const binding = (
+  language: NotebookLanguage,
+  runtimeId: string,
+  source: 'managed' | 'external',
+  envName?: string,
+  repairRequired = false
+): NotebookSessionRuntimeBinding => ({
+  language,
+  runtimeId,
+  source,
+  provenance: source === 'managed' ? 'app-managed' : 'user-own',
+  interpreterPath: runtimeId,
+  label: runtimeId,
+  ...(envName ? { envName } : {}),
+  ...(repairRequired ? { status: 'unavailable' as const, reason: 'repair-required' as const } : {})
+})
+
+const session = (
+  sessionId: string,
+  bindings: readonly NotebookSessionRuntimeBinding[] = []
+): { value: NotebookSessionAggregate; terminate: ReturnType<typeof vi.fn> } => {
+  const terminate = vi.fn().mockResolvedValue(undefined)
+  const value = new NotebookSessionAggregate({
+    sessionId,
+    projectName: 'project',
+    cwd: '/workspace',
+    notebookSessionRoot: '/workspace',
+    dataRoot: '/data',
+    runtimeRoot: '/runtime',
+    runJsonPath: `/workspace/${sessionId}.json`,
+    executionCount: 0,
+    executorGeneration: Symbol(sessionId),
+    executor: {
+      execute: async () => ({
+        status: 'completed' as const,
+        stdout: '',
+        stderr: '',
+        traceback: '',
+        cwdAfter: '/workspace',
+        outputs: []
+      }),
+      shutdown: async () => ({ reaped: true }),
+      terminate
+    }
+  })
+  for (const candidate of bindings) value.setRuntimeBinding(candidate.language, candidate)
+  return { value, terminate }
+}
+
+const admittedTarget = (
+  runtimeRoot: string,
+  candidate: NotebookSessionRuntimeBinding,
+  environmentName: string
+): NotebookPackageAdmittedTarget => {
+  const policy = new NotebookRuntimeRepairPolicy(runtimeRoot)
+  return {
+    request: { language: candidate.language, packages: ['numpy'], environment: environmentName },
+    environmentName,
+    binding: candidate,
+    environmentCaptureTarget: {
+      language: candidate.language,
+      environmentName,
+      runtimeSource: candidate.source,
+      command: candidate.interpreterPath
+    },
+    repairRuntimeId: policy.runtimeId(environmentName, candidate),
+    repairMarkerKey: policy.markerKey(candidate.language, environmentName, candidate),
+    ...(candidate.source === 'managed'
+      ? { journalTarget: join(runtimeRoot, 'envs', environmentName) }
+      : {})
+  }
+}
+
+const harness = (
+  sessions: readonly NotebookSessionAggregate[]
+): {
+  owner: NotebookRuntimeRepairOwner
+  options: RepairOptions
+  runtimeRoot: string
+} => {
+  const runtimeRoot = mkdtempSync(join(tmpdir(), 'notebook-runtime-repair-'))
+  roots.push(runtimeRoot)
+  const byId = new Map(sessions.map((candidate) => [candidate.sessionId, candidate]))
+  const options: RepairOptions = {
+    runtimeRoot,
+    policy: new NotebookRuntimeRepairPolicy(runtimeRoot),
+    bindings: {
+      runWrites: vi.fn(async (_sessionIds, operation) => operation()),
+      markUnavailable: vi.fn((candidate, language, reason) => {
+        const current = candidate.runtimeBinding(language)
+        if (!current) return false
+        candidate.setRuntimeBinding(language, { ...current, status: 'unavailable', reason })
+        return true
+      }),
+      markAvailable: vi.fn((candidate, language) => {
+        const current = candidate.runtimeBinding(language)
+        if (!current || current.status === 'active') return false
+        candidate.setRuntimeBinding(language, {
+          ...current,
+          status: 'active',
+          reason: undefined
+        })
+        return true
+      }),
+      persist: vi.fn().mockResolvedValue(undefined)
+    },
+    environmentOperations: {
+      blockRepair: vi.fn(),
+      clearRepair: vi.fn()
+    },
+    sessions: () => sessions,
+    findSession: (sessionId) => byId.get(sessionId),
+    notifyChanged: vi.fn()
+  }
+  return { owner: new NotebookRuntimeRepairOwner(options), options, runtimeRoot }
+}
+
+describe('NotebookRuntimeRepairOwner', () => {
+  it('quarantines both languages sharing a managed prefix and persists every changed Session', async () => {
+    const managedPython = binding('python', '/runtime/analysis/python', 'managed', 'analysis')
+    const managedR = binding('r', '/runtime/analysis/R', 'managed', 'analysis')
+    const first = session('first', [managedPython, managedR])
+    const second = session('second', [managedPython])
+    const { owner, options, runtimeRoot } = harness([first.value, second.value])
+
+    await owner.quarantineProtectedIdentity(admittedTarget(runtimeRoot, managedPython, 'analysis'))
+
+    expect(options.environmentOperations.blockRepair).toHaveBeenCalledWith('python:analysis')
+    expect(options.environmentOperations.blockRepair).toHaveBeenCalledWith('r:analysis')
+    expect(readRepairRequiredReason(runtimeRoot, 'analysis')).toBe('protected-identity-change')
+    expect(first.value.runtimeBinding('python')).toMatchObject({ reason: 'repair-required' })
+    expect(first.value.runtimeBinding('r')).toMatchObject({ reason: 'repair-required' })
+    expect(second.value.runtimeBinding('python')).toMatchObject({ reason: 'repair-required' })
+    expect(first.terminate).toHaveBeenCalledTimes(2)
+    expect(second.terminate).toHaveBeenCalledTimes(1)
+    expect(options.bindings.persist).toHaveBeenCalledTimes(2)
+  })
+
+  it('isolates an external quarantine by language and runtime identity', async () => {
+    const targetBinding = binding('python', '/usr/bin/python3', 'external')
+    const otherBinding = binding('python', '/opt/python', 'external')
+    const targetSession = session('target', [targetBinding])
+    const otherSession = session('other', [otherBinding])
+    const { owner, options, runtimeRoot } = harness([targetSession.value, otherSession.value])
+
+    await owner.quarantineProtectedIdentity(
+      admittedTarget(runtimeRoot, targetBinding, 'default-python')
+    )
+
+    expect(options.environmentOperations.blockRepair).toHaveBeenCalledOnce()
+    expect(options.environmentOperations.blockRepair).toHaveBeenCalledWith(
+      'external:python:/usr/bin/python3'
+    )
+    expect(targetSession.value.runtimeBinding('python')).toMatchObject({
+      reason: 'repair-required'
+    })
+    expect(otherSession.value.runtimeBinding('python')).not.toMatchObject({
+      reason: 'repair-required'
+    })
+    expect(targetSession.terminate).toHaveBeenCalledOnce()
+    expect(otherSession.terminate).not.toHaveBeenCalled()
+  })
+
+  it('keeps the durable gate armed and tags a binding persistence failure', async () => {
+    const managedR = binding('r', '/runtime/analysis/R', 'managed', 'analysis')
+    const affected = session('affected', [managedR])
+    const { owner, options, runtimeRoot } = harness([affected.value])
+    vi.mocked(options.bindings.persist).mockRejectedValueOnce(new Error('persist denied'))
+
+    await expect(
+      owner.quarantineProtectedIdentity(admittedTarget(runtimeRoot, managedR, 'analysis'))
+    ).rejects.toThrow(/REPAIR_QUARANTINE_FAILED.*persist denied/)
+
+    expect(readRepairRequiredReason(runtimeRoot, 'analysis')).toBe('protected-identity-change')
+    expect(affected.value.runtimeBinding('r')).toMatchObject({ reason: 'repair-required' })
+    expect(options.environmentOperations.blockRepair).toHaveBeenCalledWith('python:analysis')
+    expect(options.environmentOperations.blockRepair).toHaveBeenCalledWith('r:analysis')
+  })
+
+  it('adopts a successful external legacy repair and restores every matching binding', async () => {
+    const external = binding('python', '/usr/bin/python3', 'external', undefined, true)
+    const first = session('first', [external])
+    const second = session('second', [external])
+    const { owner, options, runtimeRoot } = harness([first.value, second.value])
+    mkdirSync(dirname(repairRegistryPath(runtimeRoot)), { recursive: true })
+    writeFileSync(
+      repairRegistryPath(runtimeRoot),
+      `${JSON.stringify({ runtimeIds: [external.runtimeId] })}\n`,
+      'utf8'
+    )
+
+    await owner.completeInterruptedInstall(admittedTarget(runtimeRoot, external, 'default-python'))
+
+    expect(readRepairRequiredReason(runtimeRoot, external.runtimeId)).toBeUndefined()
+    expect(options.environmentOperations.clearRepair).toHaveBeenCalledWith(
+      'external:python:/usr/bin/python3'
+    )
+    expect(first.value.runtimeBinding('python')).toMatchObject({ status: 'active' })
+    expect(second.value.runtimeBinding('python')).toMatchObject({ status: 'active' })
+    expect(options.bindings.persist).toHaveBeenCalledTimes(2)
+  })
+
+  it('marks every matching binding active before the first restore persistence attempt', async () => {
+    const external = binding('python', '/usr/bin/python3', 'external', undefined, true)
+    const first = session('first', [external])
+    const second = session('second', [external])
+    const { owner, options, runtimeRoot } = harness([first.value, second.value])
+    const order: string[] = []
+    vi.mocked(options.bindings.markAvailable).mockImplementation((candidate, language) => {
+      order.push(`mark:${candidate.sessionId}`)
+      const current = candidate.runtimeBinding(language)
+      if (!current || current.status === 'active') return false
+      candidate.setRuntimeBinding(language, { ...current, status: 'active', reason: undefined })
+      return true
+    })
+    vi.mocked(options.bindings.persist).mockImplementation(async (candidate) => {
+      order.push(`persist:${candidate.sessionId}`)
+      throw new Error('persist denied')
+    })
+
+    await expect(
+      owner.completeInterruptedInstall(admittedTarget(runtimeRoot, external, 'default-python'))
+    ).rejects.toThrow('persist denied')
+
+    expect(order).toEqual(['mark:first', 'mark:second', 'persist:first'])
+    expect(first.value.runtimeBinding('python')).toMatchObject({ status: 'active' })
+    expect(second.value.runtimeBinding('python')).toMatchObject({ status: 'active' })
+    expect(options.notifyChanged).not.toHaveBeenCalled()
+  })
+
+  it('keeps managed legacy protection while clearing interrupted aliases after repair', async () => {
+    const managed = binding('python', '/runtime/analysis/python', 'managed', 'analysis', true)
+    const active = session('active', [managed])
+    const { owner, runtimeRoot } = harness([active.value])
+    addRepairRequired(runtimeRoot, 'analysis', 'protected-identity-change')
+    addRepairRequired(runtimeRoot, managedRepairRegistryKey('analysis', 'python'))
+    addRepairRequired(runtimeRoot, managed.runtimeId)
+
+    await owner.completeInterruptedInstall(admittedTarget(runtimeRoot, managed, 'analysis'))
+
+    expect(readRepairRequiredReason(runtimeRoot, 'analysis')).toBe('protected-identity-change')
+    expect(
+      readRepairRequiredReason(runtimeRoot, managedRepairRegistryKey('analysis', 'python'))
+    ).toBeUndefined()
+    expect(readRepairRequiredReason(runtimeRoot, managed.runtimeId)).toBeUndefined()
+    expect(active.value.runtimeBinding('python')).toMatchObject({ status: 'active' })
+  })
+
+  it('clears a removed managed environment without restoring its unavailable binding', () => {
+    const managed = binding('r', '/runtime/analysis/R', 'managed', 'analysis', true)
+    const active = session('active', [managed])
+    const { owner, options, runtimeRoot } = harness([active.value])
+    addRepairRequired(runtimeRoot, 'analysis', 'protected-identity-change')
+    addRepairRequired(runtimeRoot, managed.runtimeId)
+
+    owner.completeRemovedManagedEnvironment('analysis')
+
+    expect(readRepairRequiredReason(runtimeRoot, 'analysis')).toBeUndefined()
+    expect(readRepairRequiredReason(runtimeRoot, managed.runtimeId)).toBeUndefined()
+    expect(options.environmentOperations.clearRepair).toHaveBeenCalledWith('python:analysis')
+    expect(options.environmentOperations.clearRepair).toHaveBeenCalledWith('r:analysis')
+    expect(active.value.runtimeBinding('r')).toMatchObject({ reason: 'repair-required' })
+    expect(options.bindings.markAvailable).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/notebook/runtime-repair.ts
+++ b/src/main/notebook/runtime-repair.ts
@@ -1,0 +1,270 @@
+import type { NotebookLanguage } from '../../shared/notebook'
+import type { NotebookEnvironmentOperations } from './environment-operations'
+import type { NotebookPackageAdmittedTarget } from './package-admission'
+import type { NotebookRuntimeBindingOwner } from './runtime-binding'
+import {
+  addRepairRequired,
+  clearRepairRequired,
+  DEFAULT_PY_ENV,
+  DEFAULT_R_ENV,
+  readRepairRequiredReason,
+  resolveEnvName
+} from './runtime-paths'
+import type { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
+import type { NotebookSessionAggregate, NotebookSessionRuntimeBinding } from './session-aggregate'
+
+const REPAIR_QUARANTINE_FAILED = 'REPAIR_QUARANTINE_FAILED'
+
+type RuntimeRepairTarget = Readonly<{
+  language: NotebookLanguage
+  environmentName: string
+  binding?: NotebookSessionRuntimeBinding
+}>
+
+type RepairSession = NotebookSessionAggregate
+
+type NotebookRuntimeRepairOwnerOptions = {
+  runtimeRoot: string
+  policy: Pick<NotebookRuntimeRepairPolicy, 'blockKey' | 'registryKeys'>
+  bindings: Pick<
+    NotebookRuntimeBindingOwner,
+    'runWrites' | 'markUnavailable' | 'markAvailable' | 'persist'
+  >
+  environmentOperations: Pick<NotebookEnvironmentOperations, 'blockRepair' | 'clearRepair'>
+  sessions: () => Iterable<RepairSession>
+  findSession: (sessionId: string) => RepairSession | undefined
+  notifyChanged: (session: RepairSession) => void
+}
+
+const defaultEnvironment = (language: NotebookLanguage): string =>
+  language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
+
+const processKey = (language: NotebookLanguage, environment: string): string =>
+  `${language === 'r' ? 'r' : 'python'}:${resolveEnvName(language, environment)}`
+
+/** Owns runtime quarantine and repaired-binding restoration without exposing Session state. */
+class NotebookRuntimeRepairOwner {
+  constructor(private readonly options: NotebookRuntimeRepairOwnerOptions) {}
+
+  async quarantineProtectedIdentity(target: NotebookPackageAdmittedTarget): Promise<void> {
+    const repairTarget = this.target(target)
+    const managed = repairTarget.binding?.source !== 'external'
+    const languages: readonly NotebookLanguage[] = managed
+      ? ['python', 'r']
+      : [repairTarget.language]
+    const sessions = this.matchingSessions(repairTarget, managed)
+    await this.options.bindings.runWrites(
+      sessions.map((session) => session.sessionId),
+      async () => {
+        const changed = new Set<RepairSession>()
+        if (managed) {
+          for (const language of languages) {
+            this.options.environmentOperations.blockRepair(
+              this.options.policy.blockKey(language, repairTarget.environmentName)
+            )
+          }
+        } else {
+          this.options.environmentOperations.blockRepair(this.blockKey(repairTarget))
+        }
+        try {
+          for (const session of sessions) {
+            if (this.options.findSession(session.sessionId) !== session) continue
+            for (const language of languages) {
+              if (!this.matches(session, language, repairTarget, managed)) continue
+              if (
+                session.runtimeBinding(language) &&
+                this.options.bindings.markUnavailable(session, language, 'repair-required')
+              ) {
+                changed.add(session)
+              }
+              const environment = this.environmentFor(session, language)
+              await session.terminateExecutor(language === 'r' ? 'r' : 'python', environment)
+              session.clearProcessState(processKey(language, environment))
+              this.options.notifyChanged(session)
+            }
+          }
+          addRepairRequired(
+            this.options.runtimeRoot,
+            target.repairRuntimeId,
+            'protected-identity-change'
+          )
+          for (const session of changed) await this.options.bindings.persist(session)
+        } catch (error) {
+          throw new Error(
+            `${REPAIR_QUARANTINE_FAILED}: could not durably quarantine the runtime after its protected ` +
+              `interpreter changed. ${error instanceof Error ? error.message : String(error)}`,
+            { cause: error }
+          )
+        }
+      }
+    )
+  }
+
+  async completeInterruptedInstall(target: NotebookPackageAdmittedTarget): Promise<void> {
+    const repairTarget = this.target(target)
+    const managed = repairTarget.binding?.source !== 'external'
+
+    // The admitted marker is the operation's authoritative repair identity. Clearing it also adopts
+    // a successful external install from legacy registries, while managed legacy markers never reach
+    // this callback because admission and its post-lock recheck keep them fail-closed.
+    clearRepairRequired(this.options.runtimeRoot, target.repairMarkerKey)
+    if (managed) {
+      const aliases = this.registryKeys(repairTarget)
+      aliases.delete(repairTarget.environmentName)
+      aliases.delete(target.repairMarkerKey)
+      for (const session of this.options.sessions()) {
+        if (!this.matches(session, repairTarget.language, repairTarget, false)) continue
+        const binding = session.runtimeBinding(repairTarget.language)
+        if (binding) aliases.add(binding.runtimeId)
+      }
+      for (const alias of aliases) {
+        if (readRepairRequiredReason(this.options.runtimeRoot, alias) === 'interrupted-install') {
+          clearRepairRequired(this.options.runtimeRoot, alias)
+        }
+      }
+    } else {
+      this.options.environmentOperations.clearRepair(this.blockKey(repairTarget))
+    }
+    await this.restoreBindings(repairTarget, false)
+  }
+
+  async completeExplicitRepair(language: NotebookLanguage): Promise<void> {
+    const environmentName = defaultEnvironment(language)
+    const target = { language, environmentName } satisfies RuntimeRepairTarget
+    const aliases = new Set<string>()
+    for (const affectedLanguage of ['python', 'r'] as const) {
+      for (const key of this.options.policy.registryKeys(affectedLanguage, environmentName)) {
+        aliases.add(key)
+      }
+    }
+    for (const session of this.options.sessions()) {
+      for (const [boundLanguage, binding] of session.runtimeBindingEntries()) {
+        if (this.matches(session, boundLanguage, target, true)) aliases.add(binding.runtimeId)
+      }
+    }
+
+    // Keep the primary durable gate armed until every compatibility alias has been cleared.
+    aliases.delete(environmentName)
+    for (const alias of aliases) clearRepairRequired(this.options.runtimeRoot, alias)
+    clearRepairRequired(this.options.runtimeRoot, environmentName)
+    for (const affectedLanguage of ['python', 'r'] as const) {
+      this.options.environmentOperations.clearRepair(
+        this.options.policy.blockKey(affectedLanguage, environmentName)
+      )
+    }
+    await this.restoreBindings(target, true)
+  }
+
+  completeRemovedManagedEnvironment(environmentName: string): void {
+    const target = { language: 'python', environmentName } satisfies RuntimeRepairTarget
+    const aliases = new Set<string>()
+    for (const language of ['python', 'r'] as const) {
+      for (const key of this.options.policy.registryKeys(language, environmentName))
+        aliases.add(key)
+      this.options.environmentOperations.clearRepair(
+        this.options.policy.blockKey(language, environmentName)
+      )
+    }
+    for (const session of this.options.sessions()) {
+      for (const [language, binding] of session.runtimeBindingEntries()) {
+        if (this.matches(session, language, target, true)) aliases.add(binding.runtimeId)
+      }
+    }
+    for (const alias of aliases) clearRepairRequired(this.options.runtimeRoot, alias)
+  }
+
+  private target(target: NotebookPackageAdmittedTarget): RuntimeRepairTarget {
+    return {
+      language: target.request.language,
+      environmentName: target.environmentName,
+      binding: target.binding
+    }
+  }
+
+  private registryKeys(target: RuntimeRepairTarget): Set<string> {
+    return new Set(
+      this.options.policy.registryKeys(target.language, target.environmentName, target.binding)
+    )
+  }
+
+  private blockKey(target: RuntimeRepairTarget): string {
+    return this.options.policy.blockKey(target.language, target.environmentName, target.binding)
+  }
+
+  private environmentFor(session: RepairSession, language: NotebookLanguage): string {
+    const binding = session.runtimeBinding(language)
+    return binding?.source === 'managed' && binding.envName
+      ? binding.envName
+      : defaultEnvironment(language)
+  }
+
+  private matches(
+    session: RepairSession,
+    language: NotebookLanguage,
+    target: RuntimeRepairTarget,
+    crossLanguage: boolean
+  ): boolean {
+    const binding = session.runtimeBinding(language)
+    if (target.binding?.source === 'external') {
+      return (
+        language === target.language &&
+        binding?.source === 'external' &&
+        binding.runtimeId === target.binding.runtimeId
+      )
+    }
+    return (
+      (crossLanguage || language === target.language) &&
+      binding?.source !== 'external' &&
+      this.environmentFor(session, language) === target.environmentName
+    )
+  }
+
+  private matchingSessions(target: RuntimeRepairTarget, crossLanguage: boolean): RepairSession[] {
+    const languages: readonly NotebookLanguage[] = crossLanguage
+      ? ['python', 'r']
+      : [target.language]
+    return Array.from(this.options.sessions()).filter((session) =>
+      languages.some((language) => this.matches(session, language, target, crossLanguage))
+    )
+  }
+
+  private async restoreBindings(
+    target: RuntimeRepairTarget,
+    crossLanguage: boolean
+  ): Promise<void> {
+    const sessions = this.matchingSessions(target, crossLanguage).filter((session) =>
+      session
+        .runtimeBindingEntries()
+        .some(
+          ([language, binding]) =>
+            binding.reason === 'repair-required' &&
+            this.matches(session, language, target, crossLanguage)
+        )
+    )
+    await this.options.bindings.runWrites(
+      sessions.map((session) => session.sessionId),
+      async () => {
+        const changedSessions: RepairSession[] = []
+        for (const session of sessions) {
+          if (this.options.findSession(session.sessionId) !== session) continue
+          let changed = false
+          for (const [language, binding] of session.runtimeBindingEntries()) {
+            if (
+              binding.reason === 'repair-required' &&
+              this.matches(session, language, target, crossLanguage)
+            ) {
+              changed = this.options.bindings.markAvailable(session, language) || changed
+            }
+          }
+          if (changed) changedSessions.push(session)
+        }
+        for (const session of changedSessions) {
+          await this.options.bindings.persist(session)
+          this.options.notifyChanged(session)
+        }
+      }
+    )
+  }
+}
+
+export { NotebookRuntimeRepairOwner }

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -45,26 +45,19 @@ import {
   type InstallRequest,
   type InstallResult
 } from './package-manager'
-import {
-  NotebookPackageAdmissionOwner,
-  type NotebookPackageAdmittedTarget
-} from './package-admission'
+import { NotebookPackageAdmissionOwner } from './package-admission'
 import { NotebookPackageMutationOwner } from './package-mutation'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
 import {
-  addRepairRequired,
   assertSafeEnvName,
-  clearRepairRequired,
   DEFAULT_ENV_VERSION,
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
   envPrefix,
-  managedRepairRegistryKey,
   pythonBin,
   pythonReady,
   rBin,
   rScriptBin,
-  readRepairRequiredReason,
   rReady,
   resolveEnvName
 } from './runtime-paths'
@@ -79,6 +72,7 @@ import type {
 } from '../../shared/notebook-runtime'
 import type { NotebookRuntimeSettings } from '../settings/capabilities'
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
+import { NotebookRuntimeRepairOwner } from './runtime-repair'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import { NotebookEnvironmentOperations, type DefaultEnvProvisioner } from './environment-operations'
 import {
@@ -122,16 +116,11 @@ const EMPTY_NOTEBOOK_RUNTIME_SETTINGS: Pick<NotebookRuntimeSettings, 'getSnapsho
   })
 }
 
-const REPAIR_QUARANTINE_FAILED = 'REPAIR_QUARANTINE_FAILED'
-
 // Composite routing key for a data run, matching the executor's resolveProcessKey: `${kind}:${env}`
 // where kind is the language and env is the resolved env name. python:default-python and
 // python:my-analysis are independent processes/queues; runs on the same key serialize.
 const dataProcessKey = (language: NotebookLanguage, environment?: string): string =>
   `${language === 'r' ? 'r' : 'python'}:${resolveEnvName(language, environment)}`
-
-const externalRepairBlockKey = (language: NotebookLanguage, runtimeId: string): string =>
-  `external:${language}:${runtimeId}`
 
 // The process key the executor reports through onIdleShutdown/onTerminated(kind, env): `${kind}:${env}`
 // for python/r, bare 'repl' for the env-agnostic control kernel. A missing kind/env (direct callers /
@@ -410,6 +399,7 @@ class NotebookRuntimeService {
   private readonly packageAdmission: NotebookPackageAdmissionOwner
   private readonly packageMutation: NotebookPackageMutationOwner
   private readonly repairPolicy: NotebookRuntimeRepairPolicy
+  private readonly runtimeRepair: NotebookRuntimeRepairOwner
   private readonly sessions: NotebookSessionRegistry<RuntimeSession>
   private readonly announcedAgentSessionIds = new Set<string>()
   // Owns process-global operation admission, provisioning progress, restart recommendations,
@@ -478,6 +468,15 @@ class NotebookRuntimeService {
       notifyChanged: (session) => this.notifyNotebookChanged(session as RuntimeSession),
       logger: this.runtimeLogger
     })
+    this.runtimeRepair = new NotebookRuntimeRepairOwner({
+      runtimeRoot,
+      policy: this.repairPolicy,
+      bindings: this.runtimeBindingOwner,
+      environmentOperations: this.environmentOperations,
+      sessions: () => this.sessions.values(),
+      findSession: (sessionId) => this.sessions.get(sessionId),
+      notifyChanged: (session) => this.notifyNotebookChanged(session)
+    })
     this.environmentStateTracker =
       options.environmentStateTracker ??
       new EnvironmentStateTracker({
@@ -504,8 +503,7 @@ class NotebookRuntimeService {
       environmentStateTracker: this.environmentStateTracker,
       installPackages: options.installPackagesImpl ?? installPackagesDefault,
       recheckRepair: (target) => this.packageAdmission.recheckRepair(target),
-      quarantineProtectedIdentity: (target) => this.quarantinePackageTarget(target),
-      completeInterruptedInstallRepair: (target) => this.completePackageTargetRepair(target),
+      runtimeRepair: this.runtimeRepair,
       blockUnconfirmedChild: ({ repairRuntimeId, journalTarget }) => {
         this.recoveryCoordinator.markRuntimeLiveUnconfirmed(repairRuntimeId)
         if (journalTarget) this.blockPrefixRecovery(journalTarget)
@@ -1137,61 +1135,6 @@ class NotebookRuntimeService {
     return result
   }
 
-  private quarantinePackageTarget(target: NotebookPackageAdmittedTarget): Promise<void> {
-    return this.quarantineRuntimeForRepair(
-      target.repairRuntimeId,
-      target.request.language,
-      target.environmentName,
-      getRuntimeRoot(this.options.dataRoot),
-      target.binding?.source !== 'external'
-    )
-  }
-
-  // N3 will move registry compatibility and binding restoration behind the permanent repair owner.
-  // Until then this injected port preserves the existing post-install behavior without giving the
-  // mutation owner direct access to Session state or repair registries.
-  private async completePackageTargetRepair(target: NotebookPackageAdmittedTarget): Promise<void> {
-    const { binding, environmentName, repairMarkerKey, repairRuntimeId, request } = target
-    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
-    const managedRepair = binding?.source !== 'external'
-    clearRepairRequired(runtimeRoot, repairMarkerKey)
-    if (managedRepair) {
-      // Recompute after installation: the interpreter may have appeared or canonicalized during the
-      // mutation, and the fresh real path can name an older interrupted-install marker to clear.
-      const legacyAliases = new Set(
-        this.repairPolicy.registryKeys(request.language, environmentName, binding)
-      )
-      legacyAliases.delete(environmentName)
-      legacyAliases.delete(repairMarkerKey)
-      for (const session of this.sessions.values()) {
-        for (const [language, candidate] of session.runtimeBindingEntries()) {
-          if (
-            language === request.language &&
-            candidate.source === 'managed' &&
-            this.resolveRunEnv(session, language) === environmentName
-          ) {
-            legacyAliases.add(candidate.runtimeId)
-          }
-        }
-      }
-      for (const alias of legacyAliases) {
-        if (readRepairRequiredReason(runtimeRoot, alias) === 'interrupted-install') {
-          clearRepairRequired(runtimeRoot, alias)
-        }
-      }
-    } else {
-      this.environmentOperations.clearRepair(
-        externalRepairBlockKey(request.language, repairRuntimeId)
-      )
-    }
-    await this.restoreRepairedBindings(
-      repairRuntimeId,
-      request.language,
-      environmentName,
-      managedRepair
-    )
-  }
-
   // Named-environment management (design D2), delegating to the injected provisioner-backed manager.
   // create/list return the full current env set; remove REFUSES if any session currently has a live
   // executor process bound to that env name (locked decision — the on-disk env can't be rm-rf'd out
@@ -1253,7 +1196,7 @@ class NotebookRuntimeService {
         // Serialize the rm -rf against a concurrent install into the same env (design D4 / review A).
         return this.environmentOperations.runMutation(name, async () => {
           const environments = manager.removeEnvironment(name)
-          this.clearRemovedManagedEnvironmentRepair(name)
+          this.runtimeRepair.completeRemovedManagedEnvironment(name)
           return { environments }
         })
       }
@@ -1272,28 +1215,6 @@ class NotebookRuntimeService {
       }
     }
     return false
-  }
-
-  // Removing an agent-created prefix is the recovery path for a protected named environment. Release
-  // its durable/process-local quarantine only AFTER removeEnvironment succeeds; clearing it earlier
-  // would make a failed deletion look repaired. A later create of the same name then starts from a new
-  // prefix and can be rebound normally.
-  private clearRemovedManagedEnvironmentRepair(envName: string): void {
-    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
-    clearRepairRequired(runtimeRoot, envName)
-    for (const language of ['python', 'r'] as const) {
-      clearRepairRequired(runtimeRoot, managedRepairRegistryKey(envName, language))
-      this.environmentOperations.clearRepair(dataProcessKey(language, envName))
-    }
-    // Releases before env-name canonicalization could persist an interpreter path instead. Once the
-    // owning prefix has been deleted, those aliases are stale and safe to discard as well.
-    for (const session of this.sessions.values()) {
-      for (const [language, binding] of session.runtimeBindingEntries()) {
-        if (binding.source === 'managed' && this.resolveRunEnv(session, language) === envName) {
-          clearRepairRequired(runtimeRoot, binding.runtimeId)
-        }
-      }
-    }
   }
 
   // Shuts down one session executor and removes its in-memory routing state.
@@ -1385,37 +1306,7 @@ class NotebookRuntimeService {
   // This is deliberately separate from managePackages(): an ordinary install may clear an
   // interrupted-install marker, but it must never release a protected-identity quarantine.
   async completeRuntimeRepair(language: NotebookLanguage): Promise<void> {
-    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
-    const envName = this.defaultEnvNameFor(language)
-    const registryKeys = new Set<string>()
-
-    for (const affectedLanguage of ['python', 'r'] as const) {
-      for (const key of this.repairPolicy.registryKeys(affectedLanguage, envName)) {
-        registryKeys.add(key)
-      }
-    }
-
-    // Older registries and loaded sessions may key this prefix by a discovered interpreter runtimeId.
-    // Clear those aliases too before restoring and persisting every affected binding. Keep the
-    // canonical env-name marker until LAST: if clearing an alias fails, the durable primary gate remains
-    // armed across restart and the process-local gate below is not released.
-    for (const session of this.sessions.values()) {
-      for (const [boundLanguage, binding] of session.runtimeBindingEntries()) {
-        if (
-          binding.source === 'managed' &&
-          this.resolveRunEnv(session, boundLanguage) === envName
-        ) {
-          registryKeys.add(binding.runtimeId)
-        }
-      }
-    }
-    registryKeys.delete(envName)
-    for (const key of registryKeys) clearRepairRequired(runtimeRoot, key)
-    clearRepairRequired(runtimeRoot, envName)
-    for (const affectedLanguage of ['python', 'r'] as const) {
-      this.environmentOperations.clearRepair(dataProcessKey(affectedLanguage, envName))
-    }
-    await this.restoreRepairedBindings(envName, language, envName, true, true)
+    await this.runtimeRepair.completeExplicitRepair(language)
   }
 
   // Releases ONE prefix from the global corrupt-journal write barrier. Called by a force Reset (via the
@@ -1728,135 +1619,6 @@ class NotebookRuntimeService {
   // Broadcasts state invalidation so the renderer can reload run.json and in-memory cell data.
   private notifyNotebookChanged(session: RuntimeSession): void {
     this.options.callbacks?.onNotebookChanged?.(this.toSessionReference(session))
-  }
-
-  // After a repair install clears the repair-required flag, bring every in-memory binding for that
-  // runtime (across ALL sessions) back to active — they were held unavailable/repair-required from when
-  // they were resolved, and clearing only the disk flag would leave them refusing execution until a
-  // rebind. Persist every restored binding before notifying its session, so both the live UI and a later
-  // reload observe the active state after the durable marker is cleared.
-  private async restoreRepairedBindings(
-    runtimeId: string,
-    repairedLanguage: NotebookLanguage,
-    envName: string,
-    managedRepair: boolean,
-    crossLanguageRepair = false
-  ): Promise<void> {
-    const targetSessions = Array.from(this.sessions.values()).filter((session) =>
-      Array.from(session.runtimeBindingEntries()).some(([language, binding]) => {
-        const targetMatches =
-          binding.source === 'external'
-            ? !managedRepair && language === repairedLanguage && binding.runtimeId === runtimeId
-            : managedRepair &&
-              (crossLanguageRepair || language === repairedLanguage) &&
-              this.resolveRunEnv(session, language) === envName
-        return targetMatches && binding.reason === 'repair-required'
-      })
-    )
-    await this.runtimeBindingOwner.runWrites(
-      targetSessions.map((session) => session.sessionId),
-      async () => {
-        const changedSessions: RuntimeSession[] = []
-        for (const session of targetSessions) {
-          if (this.sessions.get(session.sessionId) !== session) continue
-          let changed = false
-          for (const [language, binding] of session.runtimeBindingEntries()) {
-            const targetMatches =
-              binding.source === 'external'
-                ? !managedRepair && language === repairedLanguage && binding.runtimeId === runtimeId
-                : managedRepair &&
-                  (crossLanguageRepair || language === repairedLanguage) &&
-                  this.resolveRunEnv(session, language) === envName
-            if (targetMatches && binding.reason === 'repair-required') {
-              changed = this.runtimeBindingOwner.markAvailable(session, language) || changed
-            }
-          }
-          if (changed) changedSessions.push(session)
-        }
-        for (const session of changedSessions) {
-          await this.runtimeBindingOwner.persist(session)
-          this.notifyNotebookChanged(session)
-        }
-      }
-    )
-  }
-
-  // A protected interpreter identity changed after an installer transaction despite the approved
-  // dry-run. Persist the repair gate before returning, stop every live process using that env, and
-  // mark matching bindings unavailable so neither the current session nor another open session can
-  // execute the compromised runtime before Repair rebuilds it.
-  private async quarantineRuntimeForRepair(
-    runtimeId: string,
-    language: NotebookLanguage,
-    envName: string,
-    runtimeRoot: string,
-    managedRuntime: boolean
-  ): Promise<void> {
-    const affectedLanguages: readonly NotebookLanguage[] = managedRuntime
-      ? ['python', 'r']
-      : [language]
-    const targetSessions = Array.from(this.sessions.values()).filter((session) =>
-      affectedLanguages.some((affectedLanguage) => {
-        const binding = session.runtimeBinding(affectedLanguage)
-        const sessionEnv = this.resolveRunEnv(session, affectedLanguage)
-        return managedRuntime
-          ? binding?.source !== 'external' && sessionEnv === envName
-          : binding?.source === 'external' && binding.runtimeId === runtimeId
-      })
-    )
-    await this.runtimeBindingOwner.runWrites(
-      targetSessions.map((session) => session.sessionId),
-      async () => {
-        const affectedBindings = new Set<RuntimeSession>()
-        if (managedRuntime) {
-          for (const affectedLanguage of affectedLanguages) {
-            this.environmentOperations.blockRepair(dataProcessKey(affectedLanguage, envName))
-          }
-        } else {
-          this.environmentOperations.blockRepair(externalRepairBlockKey(language, runtimeId))
-        }
-        try {
-          for (const session of targetSessions) {
-            if (this.sessions.get(session.sessionId) !== session) continue
-            for (const affectedLanguage of affectedLanguages) {
-              const binding = session.runtimeBinding(affectedLanguage)
-              const sessionEnv = this.resolveRunEnv(session, affectedLanguage)
-              const targetMatches = managedRuntime
-                ? binding?.source !== 'external' && sessionEnv === envName
-                : binding?.source === 'external' && binding.runtimeId === runtimeId
-              if (!targetMatches) continue
-
-              if (
-                binding &&
-                this.runtimeBindingOwner.markUnavailable(
-                  session,
-                  affectedLanguage,
-                  'repair-required'
-                )
-              ) {
-                affectedBindings.add(session)
-              }
-              const kind = affectedLanguage === 'r' ? 'r' : 'python'
-              await session.terminateExecutor(kind, sessionEnv)
-              this.tearDownLanguageBinding(session, affectedLanguage, sessionEnv)
-              this.notifyNotebookChanged(session)
-            }
-          }
-
-          // The operation journal stays live until both the durable repair registry and the binding state
-          // are committed. A tagged failure makes the caller retain journal + sidecar evidence for startup
-          // recovery, while the process-local gate above continues blocking execution immediately.
-          addRepairRequired(runtimeRoot, runtimeId, 'protected-identity-change')
-          for (const session of affectedBindings) await this.runtimeBindingOwner.persist(session)
-        } catch (error) {
-          throw new Error(
-            `${REPAIR_QUARANTINE_FAILED}: could not durably quarantine the runtime after its protected ` +
-              `interpreter changed. ${error instanceof Error ? error.message : String(error)}`,
-            { cause: error }
-          )
-        }
-      }
-    )
   }
 
   // Adds notebook roots and kernel metadata to the run returned to MCP callers.


### PR DESCRIPTION
## Problem

Notebook runtime repair lifecycle state still lived inside the 4k-line runtime facade. Package
mutation reached it through two temporary N2 callbacks, while protected-identity quarantine,
interrupted-install completion, explicit Repair/Reset restoration, and named-environment cleanup all
had to coordinate the same repair aliases, Session bindings, kernels, persistence, and notifications.

Exact base: `586aa95a3c13d572f78f4404448ab86d28c9cd2d`  
Exact head: `0434131a7737f43bf8a7aff41e3593f63be3cd4e`

## Proposed change

Add `NotebookRuntimeRepairOwner` as the permanent lifecycle owner and cut the N2 mutation seam plus
the runtime facade over atomically:

- quarantine a protected managed prefix across Python/R or an isolated external runtime;
- terminate matching kernels, mark bindings unavailable, persist them, and retain fail-closed gates;
- clear successful interrupted-install/legacy aliases and restore every matching live Session;
- complete verified explicit Repair/Reset across the shared managed prefix;
- clear removed named-environment repair state without restoring the deleted binding.

```mermaid
flowchart LR
  Mutation["Package mutation"] --> Repair["NotebookRuntimeRepairOwner"]
  Explicit["Verified Repair / Reset"] --> Repair
  Removal["Named environment removal"] --> Repair
  Repair --> Policy["NotebookRuntimeRepairPolicy"]
  Repair --> Bindings["Runtime binding writes"]
  Repair --> Sessions["Session kernels + notifications"]
  Recovery["RecoveryCoordinator generic child gates"] -. "unchanged ownership" .-> Mutation
```

Production raw diff: `551` lines (`+292/-259`), below the approved 600 target and 660 hard limit.

## Scope and non-goals

- No public API, IPC payload, persistence schema, repair registry shape, data relationship, or UI
  interaction changes.
- Electron, local/remote Web, CLI/Task, local RPC, and MCP continue through the same Notebook service
  interfaces.
- Specialist, Permission, and Compute behavior and existing surface asymmetries are unchanged.
- `NotebookRuntimeRepairPolicy` remains the stateless identity/key/reason owner; this PR does not
  duplicate or widen policy.
- `RecoveryCoordinator` retains generic startup recovery and unknown-child gates; environment leases
  and provisioner Reset behavior do not move.
- This remains forward-compatible with #458 without adding orchestration state, public contracts, or
  framework abstractions.
- The frozen 765-raw measurement draft was not reused or committed. Squash merge only.

## Compatibility and risk

- External `legacy-unknown` markers remain adoptable and are cleared only after an authorized
  successful reinstall.
- Managed legacy markers remain fail-closed and require the verified Repair/Reset path.
- Managed quarantine still spans Python and R bindings sharing a prefix; external quarantine stays
  scoped by language and runtime ID.
- Every matching Session binding is persisted before its restored state is notified.
- Named removal clears repair state only after physical removal succeeds and intentionally does not
  reactivate the deleted binding.
- Incoming #842, #824, and #843 were audited before the final push. #842 changes contribution docs;
  #824 owns artifact code reconstruction plus its separate IPC/UI surface; #843 owns the Settings
  navigation slice. None changes Notebook runtime repair files, ownership, or semantics. The final
  mechanical rebase range-diff is `=`.

## Acceptance criteria and validation

All listed checks ran after the final material edit and after rebasing onto the exact base above.

- Managed/external Python/R aliases, multi-Session restore, durability failure, and removal no-restore
  -> `npm test -- --run src/main/notebook/runtime-repair.test.ts src/main/notebook/package-mutation.test.ts src/main/notebook/package-admission.test.ts src/main/notebook/runtime-repair-policy.test.ts src/main/notebook/environment-lifecycle-workflows.test.ts`
  -> `5 files / 70 tests passed`.
- Complete runtime facade and recovery compatibility ->
  `npm test -- --run src/main/notebook/runtime-service.test.ts src/main/notebook/recovery-coordinator.test.ts src/main/notebook/runtime-binding.test.ts`
  -> `2 files / 187 tests passed`.
- Main-process contracts and consumers -> `npm run typecheck:node` -> passed.
- Changed Notebook sources/tests -> targeted ESLint -> passed with zero findings.
- Changed Notebook sources/tests -> targeted Prettier check -> passed.
- Final diff -> `git diff --check HEAD^ HEAD` -> passed.

The final impact set covers the new owner, its N2 caller, all facade cutover paths, repair policy
compatibility, environment workflows, Session restoration, and recovery consumers. Platform process,
IPC, and renderer behavior is unchanged; no local E2E was run, and the repository PR Gate remains the
authority for platform lanes. Independent review is final at `Standards 0 / Spec 0`; its initial P2
restore-order finding is closed by preserving the prior two-phase mark-all-then-persist sequence and a
multi-Session persistence-failure regression.

## Review focus

- Verify marker clearing preserves the managed/external legacy asymmetry.
- Verify quarantine remains fail-closed when registry or binding persistence fails.
- Verify all matching bindings restore under serialized binding writes and removed environments never
  restore.
- Verify the facade exposes no new public behavior and N2 now depends on one permanent lifecycle port.
