### PR TITLE
fix(release): stabilize package certification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,8 @@ name: Build
 # place. Publishing is done by the caller, not here.
 #
 # `npm ci` on each runner installs the native binaries it needs (claude-agent-sdk optional package,
-# Prisma query engine). Both macOS archs build on Apple Silicon (macos-14) — x64 is cross-packaged and
-# its Prisma engine comes from binaryTargets, pruned per-arch below; Linux on ubuntu-latest; Windows
-# x64 on windows-latest.
+# Prisma query engine). macOS uses native ARM64 and Intel runners so packaged-app certification does
+# not execute across architectures; Linux runs on ubuntu-latest and Windows x64 on windows-latest.
 on:
   workflow_call:
     inputs:
@@ -76,17 +75,15 @@ jobs:
       - id: set
         shell: bash
         run: |
-          # Both mac archs build on Apple Silicon (macos-14). x64 is cross-packaged — electron pulls
-          # the x64 runtime and the only per-arch native artifact we ship (the Prisma query engine)
-          # comes from the schema's binaryTargets, pruned per-arch in the build job. This avoids the
-          # scarce Intel macos-13 runner. Windows' engine is query_engine-windows.dll.node (no `lib`
+          # Run each macOS package on its native architecture so P0, visual, and package smoke can
+          # execute the produced app. Windows' engine is query_engine-windows.dll.node (no `lib`
           # prefix, .dll.node not .so/.dylib). engine_keep = substring of the engine file to keep.
           # subdir/bin_os/bin_arch drive the notebook runtime staging step: `subdir` is the conda
           # platform whose micromamba + offline bundle to fetch, and bin_os/bin_arch are the
           # resources/bin/<os>/<arch> path electron-builder.yml reads the micromamba binary from.
           mac='[
             {"name":"macos-arm64","os":"macos-14","platform":"mac","eb_args":"--mac --arm64","engine_keep":"darwin-arm64","subdir":"osx-arm64","bin_os":"mac","bin_arch":"arm64"},
-            {"name":"macos-x64","os":"macos-14","platform":"mac","eb_args":"--mac --x64","engine_keep":"darwin.dylib","subdir":"osx-64","bin_os":"mac","bin_arch":"x64"}
+            {"name":"macos-x64","os":"macos-15-intel","platform":"mac","eb_args":"--mac --x64","engine_keep":"darwin.dylib","subdir":"osx-64","bin_os":"mac","bin_arch":"x64"}
           ]'
           rest='[
             {"name":"linux-x64","os":"ubuntu-latest","platform":"linux","eb_args":"--linux","engine_keep":".so.node","subdir":"linux-64","bin_os":"linux","bin_arch":"x64"},

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,10 @@ jobs:
       # Don't let one platform's failure cancel the others.
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    # Keep native dependencies and packaged binaries compatible with the app's declared macOS 12
+    # minimum even though the native Intel builder runs on macOS 15.
+    env:
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.platform == 'mac' && '12.0' || '' }}
 
     steps:
       - name: Checkout

--- a/scripts/linux-package-smoke.mjs
+++ b/scripts/linux-package-smoke.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-const APPIMAGE_PATTERN = /^aipoch-open-science-(.+)-linux-x64\.AppImage$/
+const APPIMAGE_PATTERN = /^aipoch-open-science-(.+)-linux-x86_64\.AppImage$/
 const SMOKE_ROOT_PREFIX = 'open-science-linux-package-smoke-'
 const STARTUP_TIMEOUT_MS = 60_000
 

--- a/scripts/linux-package-smoke.test.ts
+++ b/scripts/linux-package-smoke.test.ts
@@ -15,7 +15,7 @@ import {
 describe('Linux package smoke', () => {
   it('discovers one AppImage and derives stable or nightly versions', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-linux-artifacts-'))
-    const appImage = join(root, 'aipoch-open-science-0.11.0-nightly.abc1234-linux-x64.AppImage')
+    const appImage = join(root, 'aipoch-open-science-0.11.0-nightly.abc1234-linux-x86_64.AppImage')
     await writeFile(appImage, '')
 
     await expect(findOne(root, /\.AppImage$/, 'AppImage')).resolves.toBe(appImage)

--- a/scripts/macos-package-smoke.mjs
+++ b/scripts/macos-package-smoke.mjs
@@ -93,8 +93,14 @@ const assertPackagedResources = async (appBundle) => {
   return { executable: paths[0], micromamba: paths[2] }
 }
 
-const launchAndProbe = async ({ executable, expectedVersion, env }) => {
-  const child = spawn(executable, ['--open-science-headless', '--serve=0'], {
+const packagedLaunchArguments = (userDataRoot) => [
+  `--user-data-dir=${userDataRoot}`,
+  '--open-science-headless',
+  '--serve=0'
+]
+
+const launchAndProbe = async ({ executable, expectedVersion, env, userDataRoot }) => {
+  const child = spawn(executable, packagedLaunchArguments(userDataRoot), {
     env,
     stdio: ['ignore', 'pipe', 'pipe']
   })
@@ -148,7 +154,7 @@ const launchAndProbe = async ({ executable, expectedVersion, env }) => {
   }
 }
 
-const smokeAppBundle = async ({ appBundle, expectedVersion, env, gatekeeper }) => {
+const smokeAppBundle = async ({ appBundle, expectedVersion, env, gatekeeper, userDataRoot }) => {
   await runProcess(
     '/usr/bin/codesign',
     ['--verify', '--deep', '--strict', '--verbose=2', appBundle],
@@ -167,7 +173,7 @@ const smokeAppBundle = async ({ appBundle, expectedVersion, env, gatekeeper }) =
   }
   const { executable, micromamba } = await assertPackagedResources(appBundle)
   await runProcess(micromamba, ['--version'], { env })
-  await launchAndProbe({ executable, expectedVersion, env })
+  await launchAndProbe({ executable, expectedVersion, env, userDataRoot })
 }
 
 const parseArguments = (argv) => {
@@ -197,19 +203,15 @@ const main = async () => {
   const root = await mkdtemp(join(process.env.RUNNER_TEMP || tmpdir(), SMOKE_ROOT_PREFIX))
   const mount = join(root, 'dmg-mount')
   const extracted = join(root, 'zip-extracted')
+  const storageRoot = join(root, 'storage')
+  const userDataRoot = join(root, 'electron-profile')
   const env = {
     ...process.env,
-    HOME: join(root, 'home'),
-    OPEN_SCIENCE_STORAGE_ROOT: join(root, 'storage')
+    OPEN_SCIENCE_E2E_STORAGE_ROOT: storageRoot
   }
 
   try {
-    await Promise.all([
-      mkdir(mount),
-      mkdir(extracted),
-      mkdir(env.HOME),
-      mkdir(env.OPEN_SCIENCE_STORAGE_ROOT)
-    ])
+    await Promise.all([mkdir(mount), mkdir(extracted), mkdir(storageRoot)])
     if (options.gatekeeper) {
       await runProcess(
         '/usr/sbin/spctl',
@@ -238,10 +240,11 @@ const main = async () => {
         appBundle: await findAppBundle(mount),
         expectedVersion,
         env,
-        gatekeeper: false
+        gatekeeper: false,
+        userDataRoot
       })
     } finally {
-      await runProcess('/usr/bin/hdiutil', ['detach', mount])
+      await runProcess('/usr/bin/hdiutil', ['detach', '-force', mount])
     }
 
     await runProcess('/usr/bin/ditto', ['-x', '-k', zip, extracted], { env })
@@ -249,7 +252,8 @@ const main = async () => {
       appBundle: await findAppBundle(extracted),
       expectedVersion,
       env,
-      gatekeeper: options.gatekeeper
+      gatekeeper: options.gatekeeper,
+      userDataRoot
     })
     console.log('macOS DMG and ZIP launch smoke completed successfully.')
   } finally {
@@ -271,6 +275,7 @@ export {
   assertPackagedResources,
   findAppBundle,
   findArtifact,
+  packagedLaunchArguments,
   parseArguments,
   parsePackagedAppEndpoint
 }

--- a/scripts/macos-package-smoke.test.ts
+++ b/scripts/macos-package-smoke.test.ts
@@ -8,6 +8,7 @@ import {
   artifactVersion,
   findAppBundle,
   findArtifact,
+  packagedLaunchArguments,
   parseArguments,
   parsePackagedAppEndpoint
 } from './macos-package-smoke.mjs'
@@ -63,5 +64,13 @@ describe('macOS package smoke', () => {
       parsePackagedAppEndpoint('Open Science Web: http://127.0.0.1:3210/?token=abc_123')
     ).toEqual({ endpoint: 'http://127.0.0.1:3210', auth: 'token=abc_123' })
     expect(parsePackagedAppEndpoint('not ready')).toBeUndefined()
+  })
+
+  it('isolates Electron state without replacing the macOS home directory', () => {
+    expect(packagedLaunchArguments('/tmp/open-science-profile')).toEqual([
+      '--user-data-dir=/tmp/open-science-profile',
+      '--open-science-headless',
+      '--serve=0'
+    ])
   })
 })

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -96,6 +96,7 @@ describe('post-merge Windows validation', () => {
   })
 
   it('runs cross-platform P0 and visual against packaged apps before recording evidence', () => {
+    const setup = readWorkflow('build.yml').jobs.setup.steps?.find(({ id }) => id === 'set')
     const job = readWorkflow('build.yml').jobs.build
     const names = job.steps?.map(({ name }) => name) ?? []
     const packaged = findStep(job, 'Resolve packaged Electron executable')
@@ -108,6 +109,8 @@ describe('post-merge Windows validation', () => {
     const finalMacos = findStep(notarize, 'Smoke test final macOS packages')
     const refreshedMacosEvidence = findStep(notarize, 'Refresh macOS certification evidence')
 
+    expect(setup.run).toContain('"name":"macos-arm64","os":"macos-14"')
+    expect(setup.run).toContain('"name":"macos-x64","os":"macos-15-intel"')
     expect(packaged.id).toBe('packaged_app')
     expect(packaged.run).toContain('Open Science.app/Contents/MacOS/Open Science')
     expect(packaged.run).toContain('win-unpacked/open-science.exe')

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -17,6 +17,7 @@ type WorkflowStep = {
 
 type WorkflowJob = {
   'continue-on-error'?: boolean
+  env?: Record<string, string>
   if?: string
   needs?: string | string[]
   permissions?: Record<string, string>
@@ -111,6 +112,9 @@ describe('post-merge Windows validation', () => {
 
     expect(setup.run).toContain('"name":"macos-arm64","os":"macos-14"')
     expect(setup.run).toContain('"name":"macos-x64","os":"macos-15-intel"')
+    expect(job.env?.MACOSX_DEPLOYMENT_TARGET).toBe(
+      "${{ matrix.platform == 'mac' && '12.0' || '' }}"
+    )
     expect(packaged.id).toBe('packaged_app')
     expect(packaged.run).toContain('Open Science.app/Contents/MacOS/Open Science')
     expect(packaged.run).toContain('win-unpacked/open-science.exe')


### PR DESCRIPTION
## Problem

Nightly run https://github.com/aipoch/open-science/actions/runs/31097697704 failed or stalled in three release-certification lanes:

- macOS ARM64 package smoke failed while removing a still-mounted DMG (`EBUSY`).
- Linux package smoke found no AppImage because electron-builder emits `linux-x86_64`, while the script required `linux-x64`.
- macOS x64 P0 certification launched the cross-packaged x64 app on an ARM64 runner; all five packaged Electron journeys timed out after their app processes closed.

The macOS smoke also replaced `HOME`, contrary to the existing packaged-certification storage contract and its Keychain-safety requirement.

## Proposed change

- Run the macOS x64 lane natively on the standard `macos-15-intel` runner while keeping ARM64 on `macos-14`, and pin `MACOSX_DEPLOYMENT_TARGET=12.0` across the macOS build job.
- Match the real electron-builder `linux-x86_64.AppImage` filename.
- Keep the real macOS home directory, isolate packaged certification through `OPEN_SCIENCE_E2E_STORAGE_ROOT` and `--user-data-dir`, and force-detach the readonly test DMG.
- Pin the native runner selection and launch arguments in focused tests.

## Scope and non-goals

This changes release CI and package-smoke adapters only. It does not change application architecture, data models, persisted data, product behavior, or user interactions.

## Acceptance criteria and validation

All listed checks ran after the final material edit:

- Linux AppImage discovery -> `npm test -- scripts/linux-package-smoke.test.ts scripts/macos-package-smoke.test.ts scripts/windows-release-workflows.test.ts` -> 18 passed.
- macOS Keychain-safe isolation and DMG detach -> `node scripts/macos-package-smoke.mjs --artifact-dir /Users/ewen/projects/aipoch/open-science/dist` -> passed for DMG and ZIP after the final edit.
- Node and renderer types -> `npm run typecheck` -> passed.
- Linted CI and smoke changes -> `npm run lint` -> passed with 0 errors; 17 pre-existing repository warnings remain.
- Full portable regression suite -> `npm test` -> 815 files passed, 14 skipped; 12,001 tests passed, 184 skipped.

Linux installer/AppImage execution and the Intel-hosted macOS x64 lane require GitHub-hosted runners and remain for PR CI to verify. The original logs and public release asset names directly confirm the corrected Linux filename and cross-architecture macOS failure mode.

## Review focus

- Confirm `macos-15-intel` is the intended native x64 certification runner and the macOS 12 deployment target remains explicit.
- Confirm forced detach is acceptable for the readonly temporary DMG mount.
- Confirm packaged smoke uses the established E2E storage boundary without changing `HOME`.
