### PR TITLE
refactor(settings-store): extract Skills slice

### DIFF
--- a/src/renderer/src/stores/settings-skills-slice.test.ts
+++ b/src/renderer/src/stores/settings-skills-slice.test.ts
@@ -1,0 +1,257 @@
+import { createStore, type StoreApi } from 'zustand/vanilla'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  AgentHomeSkillRef,
+  AgentHomeSkillView,
+  ImportAgentHomeSkillsResult,
+  ImportSkillResult,
+  ImportSkillZipBatchResult,
+  ScanRepoResult,
+  SkillBundlePreviewResult,
+  SkillImportPreviewContent,
+  SkillView
+} from '../../../shared/settings'
+import {
+  createInitialSettingsSkillsState,
+  createSettingsSkillsSlice,
+  type SettingsSkillsActions,
+  type SettingsSkillsState
+} from './settings-skills-slice'
+
+type TestStore = SettingsSkillsState & SettingsSkillsActions
+type SkillCommands = Parameters<
+  typeof createSettingsSkillsSlice
+>[0]['getCommands'] extends () => infer T
+  ? T
+  : never
+
+const skill = (id: string, enabled = true): SkillView => ({
+  id,
+  name: id,
+  description: `${id} description`,
+  source: 'personal',
+  updatedAt: '2026-08-06T00:00:00.000Z',
+  enabled
+})
+
+const preview: SkillImportPreviewContent = {
+  name: 'Preview',
+  description: 'Preview description',
+  sourceLabel: 'owner/repo',
+  metadata: {},
+  body: '# Preview',
+  files: ['SKILL.md']
+}
+
+const createCommands = (): SkillCommands => ({
+  listSkills: vi.fn(async () => []),
+  setSkillEnabled: vi.fn(async () => []),
+  createSkill: vi.fn(async () => []),
+  updateSkill: vi.fn(async () => []),
+  deleteSkill: vi.fn(async () => []),
+  importSkill: vi.fn(async (): Promise<ImportSkillResult> => ({
+    status: 'imported',
+    id: 'imported',
+    skills: []
+  })),
+  importSkillZip: vi.fn(async (): Promise<ImportSkillResult> => ({
+    status: 'imported',
+    id: 'zipped',
+    skills: []
+  })),
+  importSkillZipBatch: vi.fn(async (): Promise<ImportSkillZipBatchResult> => ({
+    results: [],
+    skills: []
+  })),
+  previewSkillZip: vi.fn(async (): Promise<SkillBundlePreviewResult> => ({
+    previews: [],
+    skipped: []
+  })),
+  previewGitHubSkill: vi.fn(async () => preview),
+  scanRepoSkills: vi.fn(async (): Promise<ScanRepoResult> => ({ skills: [] })),
+  listAgentHomeSkills: vi.fn(async (): Promise<AgentHomeSkillView[]> => []),
+  previewAgentHomeSkill: vi.fn(async () => preview),
+  importAgentHomeSkills: vi.fn(async (): Promise<ImportAgentHomeSkillsResult> => ({
+    results: [],
+    skills: []
+  }))
+})
+
+const createHarness = (
+  commands: SkillCommands
+): { store: StoreApi<TestStore>; commands: SkillCommands } => {
+  const store = createStore<TestStore>((set, get) => ({
+    ...createInitialSettingsSkillsState(),
+    ...createSettingsSkillsSlice({
+      getState: get,
+      setState: (patch) => set(patch),
+      getCommands: () => commands
+    })
+  }))
+
+  return { store, commands }
+}
+
+describe('settings Skills slice', () => {
+  let store: StoreApi<TestStore>
+  let commands: SkillCommands
+
+  beforeEach(() => {
+    ;({ store, commands } = createHarness(createCommands()))
+  })
+
+  it('loads the authoritative catalog', async () => {
+    vi.mocked(commands.listSkills).mockResolvedValue([skill('loaded')])
+
+    await store.getState().loadSkills()
+
+    expect(store.getState().skills).toEqual([skill('loaded')])
+  })
+
+  it('optimistically toggles a Skill before reconciling the authoritative catalog', async () => {
+    let settle!: (skills: SkillView[]) => void
+    vi.mocked(commands.setSkillEnabled).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve
+      })
+    )
+    store.setState({ skills: [skill('target')] })
+
+    const pending = store.getState().setSkillEnabled('target', false)
+
+    expect(store.getState().skills).toEqual([skill('target', false)])
+    expect(commands.setSkillEnabled).toHaveBeenCalledWith({ id: 'target', enabled: false })
+
+    settle([skill('authoritative', false)])
+    await pending
+    expect(store.getState().skills).toEqual([skill('authoritative', false)])
+  })
+
+  it('propagates a toggle failure without rolling back the existing optimistic behavior', async () => {
+    vi.mocked(commands.setSkillEnabled).mockRejectedValue(new Error('toggle failed'))
+    store.setState({ skills: [skill('target')] })
+
+    await expect(store.getState().setSkillEnabled('target', false)).rejects.toThrow('toggle failed')
+
+    expect(store.getState().skills).toEqual([skill('target', false)])
+  })
+
+  it.each([
+    ['createSkill', 'createSkill', { name: 'New', description: '', body: '' }],
+    ['updateSkill', 'updateSkill', { id: 'target', name: 'Updated', description: '', body: '' }],
+    ['deleteSkill', 'deleteSkill', 'target']
+  ] as const)('reconciles the catalog after %s', async (_label, actionName, input) => {
+    const commandName = actionName as 'createSkill' | 'updateSkill' | 'deleteSkill'
+    vi.mocked(commands[commandName]).mockResolvedValue([skill('authoritative')])
+
+    if (actionName === 'createSkill') await store.getState().createSkill(input)
+    if (actionName === 'updateSkill') await store.getState().updateSkill(input)
+    if (actionName === 'deleteSkill') await store.getState().deleteSkill(input)
+
+    const expectedInput = actionName === 'deleteSkill' ? { id: input } : input
+    expect(commands[commandName]).toHaveBeenCalledWith(expectedInput)
+    expect(store.getState().skills).toEqual([skill('authoritative')])
+  })
+
+  it('returns import results and reconciles their catalogs', async () => {
+    const githubResult: ImportSkillResult = {
+      status: 'imported',
+      id: 'github',
+      skills: [skill('github')]
+    }
+    const zipResult: ImportSkillResult = {
+      status: 'updated',
+      id: 'zip',
+      skills: [skill('zip')]
+    }
+    vi.mocked(commands.importSkill).mockResolvedValue(githubResult)
+    vi.mocked(commands.importSkillZip).mockResolvedValue(zipResult)
+
+    await expect(store.getState().importSkill('https://github.com/owner/repo')).resolves.toBe(
+      githubResult
+    )
+    await expect(
+      store.getState().importSkillZip('base64', { subPath: 'skills/one', replaceId: 'old' })
+    ).resolves.toBe(zipResult)
+
+    expect(commands.importSkill).toHaveBeenCalledWith({ url: 'https://github.com/owner/repo' })
+    expect(commands.importSkillZip).toHaveBeenCalledWith({
+      dataBase64: 'base64',
+      subPath: 'skills/one',
+      replaceId: 'old'
+    })
+    expect(store.getState().skills).toEqual(zipResult.skills)
+  })
+
+  it('returns batch import results and reconciles their catalogs', async () => {
+    const result: ImportSkillZipBatchResult = {
+      results: [{ subPath: 'skills/one', status: 'imported', id: 'one' }],
+      skills: [skill('one')]
+    }
+    const items = [{ subPath: 'skills/one', replaceId: 'old' }]
+    vi.mocked(commands.importSkillZipBatch).mockResolvedValue(result)
+
+    await expect(store.getState().importSkillZipBatch('base64', items)).resolves.toBe(result)
+
+    expect(commands.importSkillZipBatch).toHaveBeenCalledWith({ dataBase64: 'base64', items })
+    expect(store.getState().skills).toEqual(result.skills)
+  })
+
+  it('passes preview and discovery results through without mutating the catalog', async () => {
+    const zipPreview: SkillBundlePreviewResult = { previews: [], skipped: [] }
+    const scan: ScanRepoResult = { skills: [] }
+    const installed: AgentHomeSkillView[] = [
+      {
+        source: 'agents',
+        slug: 'installed',
+        name: 'Installed',
+        description: '',
+        alreadyImported: false
+      }
+    ]
+    const ref: AgentHomeSkillRef = { source: 'agents', slug: 'installed' }
+    vi.mocked(commands.previewSkillZip).mockResolvedValue(zipPreview)
+    vi.mocked(commands.previewGitHubSkill).mockResolvedValue(preview)
+    vi.mocked(commands.scanRepoSkills).mockResolvedValue(scan)
+    vi.mocked(commands.listAgentHomeSkills).mockResolvedValue(installed)
+    vi.mocked(commands.previewAgentHomeSkill).mockResolvedValue(preview)
+    store.setState({ skills: [skill('existing')] })
+
+    await expect(store.getState().previewSkillZip('base64')).resolves.toBe(zipPreview)
+    await expect(store.getState().previewGitHubSkill('owner/repo')).resolves.toBe(preview)
+    await expect(store.getState().scanRepoSkills('owner/repo')).resolves.toBe(scan)
+    await expect(store.getState().listAgentHomeSkills()).resolves.toBe(installed)
+    await expect(store.getState().previewAgentHomeSkill(ref)).resolves.toBe(preview)
+
+    expect(commands.previewSkillZip).toHaveBeenCalledWith({ dataBase64: 'base64' })
+    expect(commands.previewGitHubSkill).toHaveBeenCalledWith({ url: 'owner/repo' })
+    expect(commands.scanRepoSkills).toHaveBeenCalledWith({ repo: 'owner/repo' })
+    expect(commands.previewAgentHomeSkill).toHaveBeenCalledWith(ref)
+    expect(store.getState().skills).toEqual([skill('existing')])
+  })
+
+  it('keeps synchronous preview command failures on the asynchronous rejection boundary', async () => {
+    vi.mocked(commands.previewGitHubSkill).mockImplementation(() => {
+      throw new Error('preview failed')
+    })
+
+    await expect(store.getState().previewGitHubSkill('owner/repo')).rejects.toThrow(
+      'preview failed'
+    )
+  })
+
+  it('imports Agent-home Skills and reconciles the returned catalog', async () => {
+    const refs: AgentHomeSkillRef[] = [{ source: 'codex', slug: 'installed' }]
+    const result: ImportAgentHomeSkillsResult = {
+      results: [{ ...refs[0], status: 'imported', id: 'installed' }],
+      skills: [skill('installed')]
+    }
+    vi.mocked(commands.importAgentHomeSkills).mockResolvedValue(result)
+
+    await expect(store.getState().importAgentHomeSkills(refs)).resolves.toBe(result)
+
+    expect(commands.importAgentHomeSkills).toHaveBeenCalledWith({ skills: refs })
+    expect(store.getState().skills).toEqual(result.skills)
+  })
+})

--- a/src/renderer/src/stores/settings-skills-slice.ts
+++ b/src/renderer/src/stores/settings-skills-slice.ts
@@ -1,0 +1,115 @@
+import type {
+  AgentHomeSkillRef,
+  AgentHomeSkillView,
+  CreateSkillRequest,
+  ImportAgentHomeSkillsResult,
+  ImportSkillResult,
+  ImportSkillZipBatchResult,
+  ScanRepoResult,
+  SkillBundlePreviewResult,
+  SkillImportPreviewContent,
+  SkillView,
+  UpdateSkillRequest
+} from '../../../shared/settings'
+
+export type SettingsSkillsState = { skills: SkillView[] }
+
+export type SettingsSkillsActions = {
+  loadSkills: () => Promise<void>
+  setSkillEnabled: (id: string, enabled: boolean) => Promise<void>
+  createSkill: (request: CreateSkillRequest) => Promise<void>
+  updateSkill: (request: UpdateSkillRequest) => Promise<void>
+  deleteSkill: (id: string) => Promise<void>
+  importSkill: (url: string) => Promise<ImportSkillResult>
+  importSkillZip: (
+    dataBase64: string,
+    opts?: { subPath?: string; replaceId?: string }
+  ) => Promise<ImportSkillResult>
+  importSkillZipBatch: (
+    dataBase64: string,
+    items: { subPath: string; replaceId?: string }[]
+  ) => Promise<ImportSkillZipBatchResult>
+  previewSkillZip: (dataBase64: string) => Promise<SkillBundlePreviewResult>
+  previewGitHubSkill: (url: string) => Promise<SkillImportPreviewContent>
+  scanRepoSkills: (repo: string) => Promise<ScanRepoResult>
+  listAgentHomeSkills: () => Promise<AgentHomeSkillView[]>
+  previewAgentHomeSkill: (skill: AgentHomeSkillRef) => Promise<SkillImportPreviewContent>
+  importAgentHomeSkills: (skills: AgentHomeSkillRef[]) => Promise<ImportAgentHomeSkillsResult>
+}
+
+type SettingsSkillsCommands = Pick<
+  Window['api']['settings'],
+  | 'listSkills'
+  | 'setSkillEnabled'
+  | 'createSkill'
+  | 'updateSkill'
+  | 'deleteSkill'
+  | 'importSkill'
+  | 'importSkillZip'
+  | 'importSkillZipBatch'
+  | 'previewSkillZip'
+  | 'previewGitHubSkill'
+  | 'scanRepoSkills'
+  | 'listAgentHomeSkills'
+  | 'previewAgentHomeSkill'
+  | 'importAgentHomeSkills'
+>
+
+type SettingsSkillsSliceOptions = {
+  getState: () => SettingsSkillsState
+  setState: (patch: Partial<SettingsSkillsState>) => void
+  getCommands: () => SettingsSkillsCommands
+}
+
+export const createInitialSettingsSkillsState = (): SettingsSkillsState => ({ skills: [] })
+
+// Owns the renderer Skill catalog projection and its command settlement. Preview-only commands keep
+// their detail state with callers, while catalog-returning imports reconcile this single projection.
+export const createSettingsSkillsSlice = ({
+  getState,
+  setState,
+  getCommands
+}: SettingsSkillsSliceOptions): SettingsSkillsActions => {
+  const reconcileCatalog = async (command: () => Promise<SkillView[]>): Promise<void> => {
+    setState({ skills: await command() })
+  }
+
+  const reconcileImport = async <Result extends { skills: SkillView[] }>(
+    command: () => Promise<Result>
+  ): Promise<Result> => {
+    const result = await command()
+    setState({ skills: result.skills })
+    return result
+  }
+
+  return {
+    loadSkills: () => reconcileCatalog(() => getCommands().listSkills()),
+    setSkillEnabled: async (id, enabled) => {
+      setState({
+        skills: getState().skills.map((skill) => (skill.id === id ? { ...skill, enabled } : skill))
+      })
+      await reconcileCatalog(() => getCommands().setSkillEnabled({ id, enabled }))
+    },
+    createSkill: (request) => reconcileCatalog(() => getCommands().createSkill(request)),
+    updateSkill: (request) => reconcileCatalog(() => getCommands().updateSkill(request)),
+    deleteSkill: (id) => reconcileCatalog(() => getCommands().deleteSkill({ id })),
+    importSkill: (url) => reconcileImport(() => getCommands().importSkill({ url })),
+    importSkillZip: (dataBase64, opts) =>
+      reconcileImport(() =>
+        getCommands().importSkillZip({
+          dataBase64,
+          subPath: opts?.subPath,
+          replaceId: opts?.replaceId
+        })
+      ),
+    importSkillZipBatch: (dataBase64, items) =>
+      reconcileImport(() => getCommands().importSkillZipBatch({ dataBase64, items })),
+    previewSkillZip: async (dataBase64) => getCommands().previewSkillZip({ dataBase64 }),
+    previewGitHubSkill: async (url) => getCommands().previewGitHubSkill({ url }),
+    scanRepoSkills: async (repo) => getCommands().scanRepoSkills({ repo }),
+    listAgentHomeSkills: async () => getCommands().listAgentHomeSkills(),
+    previewAgentHomeSkill: async (skill) => getCommands().previewAgentHomeSkill(skill),
+    importAgentHomeSkills: (skills) =>
+      reconcileImport(() => getCommands().importAgentHomeSkills({ skills }))
+  }
+}

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -28,6 +28,12 @@ import {
   type SettingsPreferencesActions
 } from './settings-preferences-slice'
 import {
+  createInitialSettingsSkillsState,
+  createSettingsSkillsSlice,
+  type SettingsSkillsActions,
+  type SettingsSkillsState
+} from './settings-skills-slice'
+import {
   createProviderAuthSlice,
   type ProviderAuthActions,
   type SaveProviderResult
@@ -53,17 +59,6 @@ import type {
   ReasoningEffort,
   SettingsSnapshot,
   AppIconVariant,
-  SkillView,
-  AgentHomeSkillRef,
-  AgentHomeSkillView,
-  ImportAgentHomeSkillsResult,
-  CreateSkillRequest,
-  UpdateSkillRequest,
-  ImportSkillResult,
-  ImportSkillZipBatchResult,
-  SkillBundlePreviewResult,
-  SkillImportPreviewContent,
-  ScanRepoResult,
   ConnectorView,
   ConnectorDetailView,
   CustomServerView,
@@ -78,7 +73,8 @@ import type {
 } from '../../../shared/settings'
 
 type SettingsStoreData = RuntimeSetupState &
-  SettingsNavigationState & {
+  SettingsNavigationState &
+  SettingsSkillsState & {
     isLoaded: boolean
     isLoading: boolean
     loadError: string | undefined
@@ -103,8 +99,6 @@ type SettingsStoreData = RuntimeSetupState &
     opencodeManaged: boolean
     codexManaged: boolean
     onboardingCompletedAt: number | undefined
-    // Bundled skills with their enabled state, loaded lazily when the Skills panel opens.
-    skills: SkillView[]
     // Bundled connectors with their enabled/auto-allow state, loaded lazily when the Connectors panel opens.
     connectors: ConnectorView[]
     // User-added custom MCP servers, reconciled alongside the connectors list.
@@ -132,47 +126,12 @@ type SettingsStoreCore = SettingsStoreData &
   ProviderAuthActions &
   SettingsPreferencesActions &
   SettingsNavigationActions &
+  SettingsSkillsActions &
   SettingsStoreActions
 
 type SettingsStoreActions = {
   load: (options?: { force?: boolean }) => Promise<boolean>
   clearSettingsWriteError: () => void
-  // Loads the bundled-skill list (enabled state included) from the main process.
-  loadSkills: () => Promise<void>
-  // Toggles one skill; optimistic, then reconciled with the authoritative list from main.
-  setSkillEnabled: (id: string, enabled: boolean) => Promise<void>
-  // Creates a personal skill, returning its refreshed list.
-  createSkill: (request: CreateSkillRequest) => Promise<void>
-  // Updates a personal skill in place.
-  updateSkill: (request: UpdateSkillRequest) => Promise<void>
-  // Deletes a personal or imported skill.
-  deleteSkill: (id: string) => Promise<void>
-  // Imports a skill from a public GitHub URL, returning the import outcome.
-  importSkill: (url: string) => Promise<ImportSkillResult>
-  // Imports a skill from an uploaded .zip / .skill bundle (base64), returning the outcome.
-  // Imports a skill from an uploaded .zip / .skill bundle (base64). With `replaceId`, the bundle
-  // overwrites that already-imported skill in place instead of creating a new one.
-  importSkillZip: (
-    dataBase64: string,
-    opts?: { subPath?: string; replaceId?: string }
-  ) => Promise<ImportSkillResult>
-  // Imports several skills from ONE uploaded bundle in a single call (decoded/unpacked once), returning
-  // a per-item outcome. Per-item failures are reported inline without aborting the rest.
-  importSkillZipBatch: (
-    dataBase64: string,
-    items: { subPath: string; replaceId?: string }[]
-  ) => Promise<ImportSkillZipBatchResult>
-  // Parses an uploaded bundle without importing it, for a confirm-before-import preview. Returns the
-  // importable skills plus any the bundle contained that were skipped and why.
-  previewSkillZip: (dataBase64: string) => Promise<SkillBundlePreviewResult>
-  previewGitHubSkill: (url: string) => Promise<SkillImportPreviewContent>
-  // Scans a GitHub repo for importable skill directories (does not mutate state).
-  scanRepoSkills: (repo: string) => Promise<ScanRepoResult>
-  // Lists the shared global skills plus the active framework's installed skills.
-  listAgentHomeSkills: () => Promise<AgentHomeSkillView[]>
-  previewAgentHomeSkill: (skill: AgentHomeSkillRef) => Promise<SkillImportPreviewContent>
-  // Copies checked installed skills into the imported-skill store in one batch.
-  importAgentHomeSkills: (skills: AgentHomeSkillRef[]) => Promise<ImportAgentHomeSkillsResult>
   // Loads the bundled-connector list (enabled/auto-allow + NCBI credential state) from main.
   loadConnectors: () => Promise<void>
   // Toggles one connector; optimistic, then reconciled with the authoritative snapshot from main.
@@ -205,6 +164,7 @@ type SettingsStore = SettingsStoreCore & RuntimeSetupActions
 export const createInitialSettingsState = (): SettingsStoreData => ({
   ...createInitialRuntimeSetupState(),
   ...createInitialSettingsNavigationState(),
+  ...createInitialSettingsSkillsState(),
   isLoaded: false,
   isLoading: false,
   loadError: undefined,
@@ -223,7 +183,6 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   opencodeManaged: false,
   codexManaged: false,
   onboardingCompletedAt: undefined,
-  skills: [],
   connectors: [],
   customServers: [],
   pendingApprovals: [],
@@ -372,6 +331,11 @@ const createSettingsStoreState = (
     writeCoordinator
   }),
   ...createSettingsNavigationSlice({ setState: (patch) => set(patch) }),
+  ...createSettingsSkillsSlice({
+    getState: get,
+    setState: (patch) => set(patch),
+    getCommands: () => window.api.settings
+  }),
 
   // Loads settings, preflight, and encryption availability in one startup pass.
   load: (options) => {
@@ -423,73 +387,6 @@ const createSettingsStoreState = (
   },
 
   clearSettingsWriteError: () => writeCoordinator.clearFailures(),
-
-  loadSkills: async () => {
-    const skills = await window.api.settings.listSkills()
-    set({ skills })
-  },
-
-  // Optimistically flips the toggle, then reconciles with the authoritative list from main.
-  setSkillEnabled: async (id, enabled) => {
-    set((state) => ({
-      skills: state.skills.map((skill) => (skill.id === id ? { ...skill, enabled } : skill))
-    }))
-    const skills = await window.api.settings.setSkillEnabled({ id, enabled })
-    set({ skills })
-  },
-
-  createSkill: async (request) => {
-    const skills = await window.api.settings.createSkill(request)
-    set({ skills })
-  },
-
-  updateSkill: async (request) => {
-    const skills = await window.api.settings.updateSkill(request)
-    set({ skills })
-  },
-
-  deleteSkill: async (id) => {
-    const skills = await window.api.settings.deleteSkill({ id })
-    set({ skills })
-  },
-
-  importSkill: async (url) => {
-    const result = await window.api.settings.importSkill({ url })
-    set({ skills: result.skills })
-    return result
-  },
-
-  importSkillZip: async (dataBase64, opts) => {
-    const result = await window.api.settings.importSkillZip({
-      dataBase64,
-      subPath: opts?.subPath,
-      replaceId: opts?.replaceId
-    })
-    set({ skills: result.skills })
-    return result
-  },
-
-  importSkillZipBatch: async (dataBase64, items) => {
-    const result = await window.api.settings.importSkillZipBatch({ dataBase64, items })
-    set({ skills: result.skills })
-    return result
-  },
-
-  previewSkillZip: async (dataBase64) => window.api.settings.previewSkillZip({ dataBase64 }),
-
-  previewGitHubSkill: async (url) => window.api.settings.previewGitHubSkill({ url }),
-
-  scanRepoSkills: async (repo) => window.api.settings.scanRepoSkills({ repo }),
-
-  // Installed-skill discovery is read-only. Batch import returns the refreshed catalog directly.
-  listAgentHomeSkills: async () => window.api.settings.listAgentHomeSkills(),
-  previewAgentHomeSkill: async (skill) => window.api.settings.previewAgentHomeSkill(skill),
-  importAgentHomeSkills: async (skills) => {
-    const result = await window.api.settings.importAgentHomeSkills({ skills })
-    set({ skills: result.skills })
-
-    return result
-  },
 
   loadConnectors: async () => {
     const { connectors, customServers, ncbi } = await window.api.settings.listConnectors()


### PR DESCRIPTION
## Problem

`settings-store.ts` still owned the complete renderer Skill catalog lifecycle alongside unrelated Settings state. Its lazy load, optimistic toggle, CRUD, import, preview, repository discovery, and Agent-home import commands made the entry store a growing coordination module with no isolated owner-level contract tests.

## Proposed change

- Add `settings-skills-slice.ts` as the single renderer owner for the `skills` catalog projection and Skill command settlement.
- Compose the slice through the existing Settings Store without changing its public hook or action names.
- Keep preview and discovery results caller-owned, while reconciling the catalog only from authoritative command results.
- Add direct slice tests for load, optimistic settlement, failure propagation, CRUD reconciliation, GitHub/ZIP/batch imports, previews, repository discovery, and Agent-home import.
- Reduce `settings-store.ts` from 607 to 504 lines. Production raw is 248 lines (`15 + 118 + 115`), below the 660 hard limit.

## Scope and non-goals

This is a renderer ownership extraction only. It does not change shared data models, persisted data, main-process Skill storage/catalog behavior, filesystem or trust rules, conversation Skill approval state, preload/IPC contracts, or user interaction. It does not add capabilities to any runtime surface.

## Compatibility

- Electron keeps the same `window.api.settings` commands, payloads, results, optimistic toggle timing, and error propagation.
- Web, CLI, and Task retain their current capability exposure and existing asymmetries; no new direct Skill management API is introduced.
- Specialist, Permission, and Compute state and behavior are untouched.
- GitHub, ZIP, batch, and Agent-home imports continue to reconcile the exact authoritative `result.skills` catalog.
- Preview and discovery data remain component-owned and are not added to the global Settings Store.

## Acceptance criteria and validation

All listed checks ran after the last material edit and the mechanical rebase on exact base `525f3383` and head `0404644f`.

- Skill catalog ownership and command settlement -> `npm test -- --run src/renderer/src/stores/settings-skills-slice.test.ts` -> 11 passed.
- Existing Settings Store interface and settlement behavior -> `npm test -- --run src/renderer/src/stores/settings-store.test.ts` -> 88 passed.
- Settings Skill consumers, detail/upload flows, and Specialist Skill dependency -> `npm test -- --run src/renderer/src/pages/settings/SkillDetailView.render.test.tsx src/renderer/src/pages/settings/SkillUploadView.render.test.tsx src/renderer/src/pages/settings/SkillsPanel.render.test.tsx src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx` -> 64 passed.
- Node and renderer type contracts -> `npm run typecheck` -> passed.
- Repository lint policy -> `npm run lint` -> passed.
- Changed-file formatting -> `prettier --check` for all three changed files -> passed.
- Diff hygiene -> `git diff --check` -> passed.
- Independent exact-head review -> Standards 0 findings / Spec 0 findings.
- Merge policy -> squash merge only after exact-head CI and AI review pass.

The final Test Impact Set covers the new owner, the unchanged public Store interface, every Settings test consumer found for the moved actions, and both affected compile-time surfaces. No platform-specific, persistence, migration, build, or E2E lane was added locally because the change preserves the renderer-to-preload interface and introduces no platform or storage behavior; PR Gate remains authoritative for selected CI lanes. Residual risk is limited to cross-surface runtime integration covered by online CI and the pre-existing last-completion-wins behavior for concurrent catalog mutations.

## Review focus

- Confirm `skills` has one renderer owner and `settings-store.ts` only composes it.
- Confirm optimistic toggle settlement and rejection behavior exactly match the previous inline implementation.
- Confirm every command payload and returned result remains unchanged, especially ZIP options, batch items, and Agent-home references.
- Confirm preview/discovery state remains caller-owned and the refactor does not widen Electron/Web/CLI/Task capabilities.
- Confirm the final evidence mapping covers the owner, interface, and consumers.
