### PR TITLE
refactor(notebook): compose package operations

### DIFF
--- a/src/main/notebook/package-operations.test.ts
+++ b/src/main/notebook/package-operations.test.ts
@@ -1,0 +1,225 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { NotebookLanguage } from '../../shared/notebook'
+import { NotebookPackageOperations } from './package-operations'
+import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
+import { NotebookSessionAggregate, type NotebookSessionRuntimeBinding } from './session-aggregate'
+
+type PackageOptions = ConstructorParameters<typeof NotebookPackageOperations>[0]
+
+const roots: string[] = []
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+const binding = (
+  language: NotebookLanguage,
+  runtimeId: string,
+  source: 'managed' | 'external',
+  envName?: string
+): NotebookSessionRuntimeBinding => ({
+  language,
+  runtimeId,
+  source,
+  provenance: source === 'managed' ? 'agent-created' : 'user-own',
+  interpreterPath: runtimeId,
+  label: runtimeId,
+  ...(envName ? { envName } : {})
+})
+
+const session = (
+  sessionId: string,
+  runtimeBinding?: NotebookSessionRuntimeBinding
+): NotebookSessionAggregate => {
+  const value = new NotebookSessionAggregate({
+    sessionId,
+    projectName: 'project',
+    cwd: '/workspace',
+    notebookSessionRoot: '/workspace',
+    dataRoot: '/data',
+    runtimeRoot: '/runtime',
+    runJsonPath: `/workspace/${sessionId}.json`,
+    executionCount: 0,
+    executorGeneration: Symbol(sessionId),
+    executor: {
+      execute: async () => ({
+        status: 'completed' as const,
+        stdout: '',
+        stderr: '',
+        traceback: '',
+        cwdAfter: '/workspace',
+        outputs: []
+      }),
+      shutdown: async () => ({ reaped: true })
+    }
+  })
+  if (runtimeBinding) value.setRuntimeBinding(runtimeBinding.language, runtimeBinding)
+  return value
+}
+
+const harness = (
+  activeSession: NotebookSessionAggregate,
+  overrides: Partial<PackageOptions> = {}
+): {
+  owner: NotebookPackageOperations
+  options: PackageOptions
+  runtimeRoot: string
+  sharedCalls: Array<readonly ['execution' | 'inspection', string]>
+} => {
+  const storageRoot = mkdtempSync(join(tmpdir(), 'notebook-package-operations-'))
+  roots.push(storageRoot)
+  const runtimeRoot = join(storageRoot, 'runtime')
+  const sharedCalls: Array<readonly ['execution' | 'inspection', string]> = []
+  const options: PackageOptions = {
+    storageRoot,
+    runtimeRoot,
+    locale: 'en-US',
+    resolvePackageMirror: vi.fn(() => ({ pypiIndex: 'https://mirror/simple' })),
+    ensureRecovered: vi.fn().mockResolvedValue(undefined),
+    loadSession: vi.fn().mockResolvedValue(activeSession),
+    findSession: vi.fn((sessionId) =>
+      sessionId === activeSession.sessionId ? activeSession : undefined
+    ),
+    sessions: () => [activeSession],
+    notifyChanged: vi.fn(),
+    resolveRuntimeEnablement: vi.fn().mockResolvedValue(undefined),
+    isDefaultEnvironmentDisabled: vi.fn().mockResolvedValue(false),
+    repairPolicy: new NotebookRuntimeRepairPolicy(runtimeRoot),
+    runtimeRepair: {
+      quarantineProtectedIdentity: vi.fn().mockResolvedValue(undefined),
+      completeInterruptedInstall: vi.fn().mockResolvedValue(undefined)
+    },
+    recovery: {
+      isGloballyBlocked: vi.fn(() => false),
+      isPrefixBlocked: vi.fn(() => false),
+      isRuntimeIdBlocked: vi.fn(() => false),
+      markLiveUnconfirmed: vi.fn(),
+      markRuntimeLiveUnconfirmed: vi.fn()
+    },
+    environmentOperations: {
+      isRepairBlocked: vi.fn(() => false),
+      logPackageFailure: vi.fn(),
+      logPackageResult: vi.fn(),
+      recommendRestart: vi.fn(),
+      runMutation: async <Result>(
+        _environment: string,
+        operation: () => Promise<Result>
+      ): Promise<Result> => operation(),
+      runShared: async <Result>(
+        kind: 'execution' | 'inspection',
+        environment: string,
+        operation: () => Promise<Result>
+      ): Promise<Result> => {
+        sharedCalls.push([kind, environment])
+        return operation()
+      }
+    },
+    environmentStateTracker: {
+      inspectPackages: vi.fn().mockResolvedValue({
+        inventory: { source: 'full-scan', validation: 'full-scan' },
+        packages: []
+      }),
+      markPackageMutationDirty: vi.fn().mockResolvedValue(undefined),
+      refreshAfterPackageMutation: vi.fn().mockResolvedValue({ result: 'success' })
+    },
+    installPackages: vi.fn().mockResolvedValue({
+      ok: true,
+      needsRestart: false,
+      log: 'installed',
+      method: 'conda'
+    }),
+    createEnvironmentCaptureTarget: (language, environmentName, candidate) => ({
+      language,
+      environmentName,
+      runtimeSource: candidate?.source === 'external' ? 'external' : 'managed',
+      command: candidate?.interpreterPath ?? `${runtimeRoot}/${environmentName}/${language}`
+    }),
+    ...overrides
+  }
+  return { owner: new NotebookPackageOperations(options), options, runtimeRoot, sharedCalls }
+}
+
+describe('NotebookPackageOperations', () => {
+  it('inspects the Session-bound managed environment through the shared read slot', async () => {
+    const managed = binding('python', '/runtime/analysis/python', 'managed', 'analysis')
+    const activeSession = session('session-1', managed)
+    const { owner, options, sharedCalls } = harness(activeSession)
+    vi.mocked(options.environmentStateTracker.inspectPackages).mockResolvedValue({
+      inventory: { source: 'full-scan', validation: 'full-scan' },
+      packages: [
+        {
+          requested: 'numpy',
+          name: 'numpy',
+          status: 'installed',
+          version: '2.2.0',
+          versionStatus: 'known'
+        }
+      ]
+    })
+
+    const result = await owner.inspect({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      language: 'python',
+      packages: ['numpy']
+    })
+
+    expect(result).toMatchObject({
+      language: 'python',
+      environmentName: 'analysis',
+      runtimeSource: 'managed',
+      runtimeId: managed.runtimeId,
+      packages: [{ name: 'numpy', version: '2.2.0' }]
+    })
+    expect(sharedCalls).toEqual([['inspection', 'analysis']])
+    expect(options.installPackages).not.toHaveBeenCalled()
+  })
+
+  it('keeps external inspection behind notebook execution approval', async () => {
+    const external = binding('python', '/usr/bin/python3', 'external')
+    const { owner, options } = harness(session('session-1', external))
+
+    await expect(
+      owner.inspect({
+        sessionId: 'session-1',
+        workspaceCwd: '/workspace',
+        language: 'python',
+        packages: ['numpy']
+      })
+    ).rejects.toThrow(/EXTERNAL_RUNTIME_INSPECTION_REQUIRES_EXECUTION/)
+
+    expect(options.environmentStateTracker.inspectPackages).not.toHaveBeenCalled()
+  })
+
+  it('composes admission, mutation, repair completion and R restart publication', async () => {
+    const activeSession = session('session-1')
+    const { owner, options } = harness(activeSession, {
+      resolvePackageMirror: vi.fn(() => ({ cranMirror: 'https://mirror/cran' })),
+      installPackages: vi.fn().mockResolvedValue({
+        ok: true,
+        needsRestart: true,
+        log: 'installed',
+        method: 'conda'
+      })
+    })
+
+    const result = await owner.manage({ language: 'r', packages: ['dplyr'] })
+
+    expect(result).toMatchObject({ ok: true, needsRestart: true })
+    expect(options.installPackages).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'r', environment: 'default-r' }),
+      expect.objectContaining({ cranMirror: 'https://mirror/cran' })
+    )
+    expect(options.runtimeRepair.completeInterruptedInstall).toHaveBeenCalledWith(
+      expect.objectContaining({ environmentName: 'default-r' })
+    )
+    expect(options.environmentOperations.recommendRestart).toHaveBeenCalledWith('r', 'default-r')
+    expect(options.notifyChanged).toHaveBeenCalledWith(activeSession)
+  })
+})

--- a/src/main/notebook/package-operations.ts
+++ b/src/main/notebook/package-operations.ts
@@ -1,0 +1,241 @@
+import type { NotebookLanguage, NotebookSessionRequest } from '../../shared/notebook'
+import type { PackageMirror } from '../../shared/mirror'
+import type { RuntimeEnablement } from '../../shared/notebook-runtime'
+import type { NotebookEnvironmentOperations } from './environment-operations'
+import type {
+  EnvironmentCaptureTarget,
+  EnvironmentStateTracker,
+  PackageInspectionResult
+} from './environment-state-tracker'
+import { effectiveMirrorAsync, type ProbeDeps } from './mirror-probe'
+import { NotebookPackageAdmissionOwner } from './package-admission'
+import type { InstallDeps, InstallRequest, InstallResult } from './package-manager'
+import { NotebookPackageMutationOwner } from './package-mutation'
+import type { NotebookRecoveryCoordinator } from './recovery-coordinator'
+import {
+  DEFAULT_ENV_VERSION,
+  DEFAULT_PY_ENV,
+  DEFAULT_R_ENV,
+  envPrefix,
+  pythonReady,
+  rReady
+} from './runtime-paths'
+import type { NotebookRuntimeRepairOwner } from './runtime-repair'
+import type { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
+import type {
+  NotebookSessionAggregate,
+  NotebookSessionResolvedInterpreter,
+  NotebookSessionRuntimeBinding
+} from './session-aggregate'
+
+type InspectPackagesRequest = NotebookSessionRequest & {
+  language: NotebookLanguage
+  packages: string[]
+}
+
+type InspectPackagesResult = PackageInspectionResult & {
+  language: NotebookLanguage
+  environmentName: string
+  runtimeSource: 'managed' | 'external'
+  runtimeId?: string
+  runtimeLabel?: string
+}
+
+type PackageSession = NotebookSessionAggregate
+
+type NotebookPackageOperationsOptions = {
+  storageRoot: string
+  runtimeRoot: string
+  locale: string
+  mirrorProbe?: ProbeDeps
+  resolvePackageMirror?: () => PackageMirror | undefined | Promise<PackageMirror | undefined>
+  ensureRecovered: () => Promise<void>
+  loadSession: (request: NotebookSessionRequest) => Promise<PackageSession>
+  findSession: (sessionId: string) => PackageSession | undefined
+  sessions: () => Iterable<PackageSession>
+  notifyChanged: (session: PackageSession) => void
+  resolveRuntimeEnablement: (language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>
+  isDefaultEnvironmentDisabled: (
+    language: NotebookLanguage,
+    runtimeRoot: string
+  ) => Promise<boolean>
+  repairPolicy: NotebookRuntimeRepairPolicy
+  runtimeRepair: Pick<
+    NotebookRuntimeRepairOwner,
+    'quarantineProtectedIdentity' | 'completeInterruptedInstall'
+  >
+  recovery: Pick<
+    NotebookRecoveryCoordinator,
+    | 'isGloballyBlocked'
+    | 'isPrefixBlocked'
+    | 'isRuntimeIdBlocked'
+    | 'markLiveUnconfirmed'
+    | 'markRuntimeLiveUnconfirmed'
+  >
+  environmentOperations: Pick<
+    NotebookEnvironmentOperations,
+    | 'isRepairBlocked'
+    | 'logPackageFailure'
+    | 'logPackageResult'
+    | 'recommendRestart'
+    | 'runMutation'
+    | 'runShared'
+  >
+  environmentStateTracker: Pick<
+    EnvironmentStateTracker,
+    'inspectPackages' | 'markPackageMutationDirty' | 'refreshAfterPackageMutation'
+  >
+  installPackages: (request: InstallRequest, deps?: Partial<InstallDeps>) => Promise<InstallResult>
+  createEnvironmentCaptureTarget: (
+    language: NotebookLanguage,
+    environmentName: string,
+    binding: NotebookSessionRuntimeBinding | undefined,
+    resolvedInterpreter: NotebookSessionResolvedInterpreter | undefined,
+    runtimeRoot: string
+  ) => EnvironmentCaptureTarget
+}
+
+const defaultEnvironment = (language: NotebookLanguage): string =>
+  language === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
+
+/** Composes package inspection and mutation behind two stable operations. */
+class NotebookPackageOperations {
+  private readonly admission: NotebookPackageAdmissionOwner
+  private readonly mutation: NotebookPackageMutationOwner
+
+  constructor(private readonly options: NotebookPackageOperationsOptions) {
+    this.admission = new NotebookPackageAdmissionOwner({
+      runtimeRoot: options.runtimeRoot,
+      loadSession: options.loadSession,
+      findSession: options.findSession,
+      resolveRuntimeEnablement: options.resolveRuntimeEnablement,
+      isDefaultEnvironmentDisabled: options.isDefaultEnvironmentDisabled,
+      repairPolicy: options.repairPolicy,
+      environmentOperations: options.environmentOperations,
+      recovery: options.recovery,
+      createEnvironmentCaptureTarget: options.createEnvironmentCaptureTarget
+    })
+    this.mutation = new NotebookPackageMutationOwner({
+      storageRoot: options.storageRoot,
+      runtimeRoot: options.runtimeRoot,
+      environmentOperations: options.environmentOperations,
+      environmentStateTracker: options.environmentStateTracker,
+      installPackages: options.installPackages,
+      recheckRepair: (target) => this.admission.recheckRepair(target),
+      runtimeRepair: options.runtimeRepair,
+      blockUnconfirmedChild: ({ repairRuntimeId, journalTarget }) => {
+        options.recovery.markRuntimeLiveUnconfirmed(repairRuntimeId)
+        if (journalTarget) options.recovery.markLiveUnconfirmed(journalTarget)
+      }
+    })
+  }
+
+  async inspect(request: InspectPackagesRequest): Promise<InspectPackagesResult> {
+    await this.options.ensureRecovered()
+    const session = await this.options.loadSession(request)
+    const binding = session.runtimeBinding(request.language)
+    const environmentName =
+      binding?.source === 'managed' && binding.envName
+        ? binding.envName
+        : defaultEnvironment(request.language)
+    const isExternal = binding?.source === 'external'
+    if (isExternal) {
+      throw new Error(
+        'EXTERNAL_RUNTIME_INSPECTION_REQUIRES_EXECUTION: inspect_packages cannot run a bound ' +
+          'external interpreter under package-metadata permission. Use notebook_execute in this ' +
+          'runtime to query package metadata so interpreter execution receives notebook approval.'
+      )
+    }
+    if (
+      (binding?.runtimeId && this.options.recovery.isRuntimeIdBlocked(binding.runtimeId)) ||
+      this.options.recovery.isPrefixBlocked(envPrefix(this.options.runtimeRoot, environmentName)) ||
+      (isExternal && this.options.recovery.isGloballyBlocked())
+    ) {
+      throw new Error(
+        `RUNTIME_RECOVERY_BLOCKED: the ${request.language} environment is recovering from an ` +
+          'interrupted operation whose process could not be confirmed stopped. Restart the app to ' +
+          're-check and recover it before inspecting packages.'
+      )
+    }
+    if (binding && (binding.status ?? 'active') !== 'active') {
+      throw new Error(
+        `RUNTIME_BINDING_UNAVAILABLE: the bound ${request.language} runtime is ${binding.status}` +
+          (binding.reason ? ` (${binding.reason})` : '') +
+          '. Switch to another runtime (list_notebook_runtimes → notebook_switch_runtime) before ' +
+          'inspecting packages.'
+      )
+    }
+    if (
+      !binding &&
+      (await this.options.isDefaultEnvironmentDisabled(request.language, this.options.runtimeRoot))
+    ) {
+      throw new Error(
+        `No enabled ${request.language} runtime: the app-managed default is disabled and no runtime ` +
+          'is bound. Enable a runtime in Settings → Runtimes, or bind one with ' +
+          'list_notebook_runtimes then notebook_bind_runtime, before inspecting packages.'
+      )
+    }
+
+    const isDefaultEnvironment = environmentName === defaultEnvironment(request.language)
+    const isDefaultReady =
+      request.language === 'r'
+        ? rReady(this.options.runtimeRoot, DEFAULT_ENV_VERSION)
+        : pythonReady(this.options.runtimeRoot, DEFAULT_ENV_VERSION)
+    if (isDefaultEnvironment && !isDefaultReady) {
+      throw new Error(
+        `DEFAULT_RUNTIME_NOT_READY: the app-managed ${request.language} runtime is not prepared, and ` +
+          'inspect_packages cannot create it under read-only package-metadata permission. Use ' +
+          `notebook_execute with language "${request.language}" to prepare the runtime under notebook ` +
+          'execution approval, then retry inspect_packages.'
+      )
+    }
+
+    const target = this.options.createEnvironmentCaptureTarget(
+      request.language,
+      environmentName,
+      binding,
+      binding?.resolvedInterpreter,
+      this.options.runtimeRoot
+    )
+    const inspection = await this.options.environmentOperations.runShared(
+      'inspection',
+      environmentName,
+      () => this.options.environmentStateTracker.inspectPackages(target, request.packages)
+    )
+    return {
+      language: request.language,
+      environmentName,
+      runtimeSource: target.runtimeSource,
+      ...(binding?.runtimeId ? { runtimeId: binding.runtimeId } : {}),
+      ...(binding?.label ? { runtimeLabel: binding.label } : {}),
+      ...inspection
+    }
+  }
+
+  async manage(request: InstallRequest): Promise<InstallResult> {
+    await this.options.ensureRecovered()
+    const mirror = await effectiveMirrorAsync(
+      await this.resolvePackageMirror(),
+      this.options.locale,
+      this.options.mirrorProbe
+    )
+    const admission = await this.admission.admit(request)
+    if (admission.status === 'refused') return admission.result
+    const result = await this.mutation.mutate({ target: admission.target, mirror })
+    if (result.ok && result.needsRestart && request.language === 'r') {
+      this.options.environmentOperations.recommendRestart('r', admission.target.environmentName)
+      for (const session of this.options.sessions()) this.options.notifyChanged(session)
+    }
+    return result
+  }
+
+  private async resolvePackageMirror(): Promise<PackageMirror | undefined> {
+    try {
+      return await this.options.resolvePackageMirror?.()
+    } catch {
+      return undefined
+    }
+  }
+}
+
+export { NotebookPackageOperations, type InspectPackagesRequest, type InspectPackagesResult }

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -38,27 +38,27 @@ import { NotebookExportReader } from './export-reader'
 import { NotebookKernelExecutor, type NotebookKernelExecutorOptions } from './kernel-executor'
 import { saveIpynbAll } from './save-ipynb-all'
 import type { KernelProcessKind } from './kernel-executor'
-import { effectiveMirrorAsync, type ProbeDeps } from './mirror-probe'
+import type { ProbeDeps } from './mirror-probe'
 import {
   installPackages as installPackagesDefault,
   type InstallDeps,
   type InstallRequest,
   type InstallResult
 } from './package-manager'
-import { NotebookPackageAdmissionOwner } from './package-admission'
-import { NotebookPackageMutationOwner } from './package-mutation'
+import {
+  NotebookPackageOperations,
+  type InspectPackagesRequest,
+  type InspectPackagesResult
+} from './package-operations'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
 import {
   assertSafeEnvName,
-  DEFAULT_ENV_VERSION,
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
   envPrefix,
   pythonBin,
-  pythonReady,
   rBin,
   rScriptBin,
-  rReady,
   resolveEnvName
 } from './runtime-paths'
 import type {
@@ -88,11 +88,7 @@ import {
 } from './session-aggregate'
 import { NotebookSessionRegistry } from './session-registry'
 import { createLogger, getLogFilePath } from '../logger'
-import {
-  EnvironmentStateTracker,
-  type EnvironmentCaptureTarget,
-  type PackageInspectionResult
-} from './environment-state-tracker'
+import { EnvironmentStateTracker, type EnvironmentCaptureTarget } from './environment-state-tracker'
 import { NotebookRuntimeBindingOwner } from './runtime-binding'
 import type { RuntimeDiagnosticLogger } from './runtime-diagnostics'
 import { NotebookRunTerminalizationOwner } from './run-terminalization'
@@ -157,19 +153,6 @@ const namedEnvProvenance = (name: string): EnvProvenance =>
 type ResolvedInterpreter = NotebookSessionResolvedInterpreter
 type NotebookExecutionRequest = NotebookSessionExecutionRequest
 type NotebookExecutionResult = NotebookSessionExecutionResult
-
-type InspectPackagesRequest = NotebookSessionRequest & {
-  language: NotebookLanguage
-  packages: string[]
-}
-
-type InspectPackagesResult = PackageInspectionResult & {
-  language: NotebookLanguage
-  environmentName: string
-  runtimeSource: 'managed' | 'external'
-  runtimeId?: string
-  runtimeLabel?: string
-}
 
 type NotebookExecutor = NotebookSessionExecutor
 
@@ -396,8 +379,7 @@ class NotebookRuntimeService {
   private readonly runTerminalization: NotebookRunTerminalizationOwner
   private readonly executionOwner: NotebookExecutionOwner
   private readonly dataExecutionAdmission: NotebookDataExecutionAdmissionOwner
-  private readonly packageAdmission: NotebookPackageAdmissionOwner
-  private readonly packageMutation: NotebookPackageMutationOwner
+  private readonly packageOperations: NotebookPackageOperations
   private readonly repairPolicy: NotebookRuntimeRepairPolicy
   private readonly runtimeRepair: NotebookRuntimeRepairOwner
   private readonly sessions: NotebookSessionRegistry<RuntimeSession>
@@ -408,8 +390,6 @@ class NotebookRuntimeService {
   private readonly environmentOperations: NotebookEnvironmentOperations
   private mcpRpcConnectionResolver:
     ((binding: McpRpcConnectionBinding) => Promise<McpRpcConnection>) | undefined
-  private readonly packageMirrorResolver:
-    (() => PackageMirror | undefined | Promise<PackageMirror | undefined>) | undefined
   private readonly runtimeEnablementResolver:
     ((language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>) | undefined
   private readonly runtimeBindingOwner: NotebookRuntimeBindingOwner
@@ -447,7 +427,6 @@ class NotebookRuntimeService {
     this.repairPolicy = new NotebookRuntimeRepairPolicy(runtimeRoot)
     this.recoveryCoordinator = new NotebookRecoveryCoordinator(runtimeRoot, this.repairPolicy)
     this.mcpRpcConnectionResolver = options.getMcpRpcConnection
-    this.packageMirrorResolver = options.getPackageMirror
     const runtimeSettings = options.notebookRuntimeSettings ?? EMPTY_NOTEBOOK_RUNTIME_SETTINGS
     this.runtimeEnablementResolver = async (language) =>
       (await runtimeSettings.getSnapshot(language)).runtimeEnablement
@@ -484,30 +463,27 @@ class NotebookRuntimeService {
         platform: options.platform,
         logger: this.runtimeLogger
       })
-    this.packageAdmission = new NotebookPackageAdmissionOwner({
-      runtimeRoot: getRuntimeRoot(options.dataRoot),
+    this.packageOperations = new NotebookPackageOperations({
+      storageRoot: options.dataRoot,
+      runtimeRoot,
+      locale: options.locale ?? DEFAULT_LOCALE,
+      mirrorProbe: options.mirrorProbe,
+      resolvePackageMirror: options.getPackageMirror,
+      ensureRecovered: () => this.ensureRecovered(),
       loadSession: (request) => this.ensureSession(request),
       findSession: (sessionId) => this.sessions.get(sessionId),
+      sessions: () => this.sessions.values(),
+      notifyChanged: (session) => this.notifyNotebookChanged(session),
       resolveRuntimeEnablement: (language) => this.resolveRuntimeEnablement(language),
-      isDefaultEnvironmentDisabled: (language, runtimeRoot) =>
-        this.isDefaultEnvDisabled(language, runtimeRoot),
+      isDefaultEnvironmentDisabled: (language, candidateRuntimeRoot) =>
+        this.isDefaultEnvDisabled(language, candidateRuntimeRoot),
       repairPolicy: this.repairPolicy,
+      runtimeRepair: this.runtimeRepair,
       environmentOperations: this.environmentOperations,
       recovery: this.recoveryCoordinator,
-      createEnvironmentCaptureTarget: (...args) => this.environmentCaptureTarget(...args)
-    })
-    this.packageMutation = new NotebookPackageMutationOwner({
-      storageRoot: options.dataRoot,
-      runtimeRoot: getRuntimeRoot(options.dataRoot),
-      environmentOperations: this.environmentOperations,
       environmentStateTracker: this.environmentStateTracker,
       installPackages: options.installPackagesImpl ?? installPackagesDefault,
-      recheckRepair: (target) => this.packageAdmission.recheckRepair(target),
-      runtimeRepair: this.runtimeRepair,
-      blockUnconfirmedChild: ({ repairRuntimeId, journalTarget }) => {
-        this.recoveryCoordinator.markRuntimeLiveUnconfirmed(repairRuntimeId)
-        if (journalTarget) this.blockPrefixRecovery(journalTarget)
-      }
+      createEnvironmentCaptureTarget: (...args) => this.environmentCaptureTarget(...args)
     })
     this.dataExecutionAdmission = new NotebookDataExecutionAdmissionOwner({
       runtimeRoot: getRuntimeRoot(options.dataRoot),
@@ -1021,85 +997,7 @@ class NotebookRuntimeService {
   // ordinary notebook runs to proceed. External runtimes are rejected because inventory capture must
   // execute their interpreter; notebookExecute provides the explicit execution approval for that case.
   async inspectPackages(request: InspectPackagesRequest): Promise<InspectPackagesResult> {
-    await this.ensureRecovered()
-    const session = await this.ensureSession(request)
-    const binding = session.runtimeBinding(request.language)
-    const envName = this.resolveRunEnv(session, request.language)
-    const runtimeRoot = getRuntimeRoot(this.options.dataRoot)
-    const isExternal = binding?.source === 'external'
-    if (isExternal) {
-      throw new Error(
-        'EXTERNAL_RUNTIME_INSPECTION_REQUIRES_EXECUTION: inspect_packages cannot run a bound ' +
-          'external interpreter under package-metadata permission. Use notebook_execute in this ' +
-          'runtime to query package metadata so interpreter execution receives notebook approval.'
-      )
-    }
-    const prefixBlocked =
-      !isExternal && this.isPrefixRecoveryBlocked(envPrefix(runtimeRoot, envName))
-
-    if (
-      (binding?.runtimeId && this.recoveryCoordinator.isRuntimeIdBlocked(binding.runtimeId)) ||
-      prefixBlocked ||
-      (isExternal && this.recoveryCoordinator.isGloballyBlocked())
-    ) {
-      throw new Error(
-        `RUNTIME_RECOVERY_BLOCKED: the ${request.language} environment is recovering from an ` +
-          'interrupted operation whose process could not be confirmed stopped. Restart the app to ' +
-          're-check and recover it before inspecting packages.'
-      )
-    }
-    if (binding && (binding.status ?? 'active') !== 'active') {
-      throw new Error(
-        `RUNTIME_BINDING_UNAVAILABLE: the bound ${request.language} runtime is ${binding.status}` +
-          (binding.reason ? ` (${binding.reason})` : '') +
-          '. Switch to another runtime (list_notebook_runtimes → notebook_switch_runtime) before ' +
-          'inspecting packages.'
-      )
-    }
-    if (!binding && (await this.isDefaultEnvDisabled(request.language, runtimeRoot))) {
-      throw new Error(
-        `No enabled ${request.language} runtime: the app-managed default is disabled and no runtime ` +
-          'is bound. Enable a runtime in Settings → Runtimes, or bind one with ' +
-          'list_notebook_runtimes then notebook_bind_runtime, before inspecting packages.'
-      )
-    }
-
-    // Inspection is approved as a read-only action, so it must not materialize a missing default env
-    // (which can download packages and write the runtime prefix). Refuse with an actionable boundary
-    // instead of silently returning `unknown` from a nonexistent interpreter. Notebook execution owns
-    // the existing mutating/first-use approval path; once it prepares the runtime, inspection can retry.
-    const isDefaultEnv = envName === this.defaultEnvNameFor(request.language)
-    const isDefaultReady =
-      request.language === 'r'
-        ? rReady(runtimeRoot, DEFAULT_ENV_VERSION)
-        : pythonReady(runtimeRoot, DEFAULT_ENV_VERSION)
-    if (isDefaultEnv && !isDefaultReady) {
-      throw new Error(
-        `DEFAULT_RUNTIME_NOT_READY: the app-managed ${request.language} runtime is not prepared, and ` +
-          'inspect_packages cannot create it under read-only package-metadata permission. Use ' +
-          `notebook_execute with language "${request.language}" to prepare the runtime under notebook ` +
-          'execution approval, then retry inspect_packages.'
-      )
-    }
-
-    const target = this.environmentCaptureTarget(
-      request.language,
-      envName,
-      binding,
-      binding?.resolvedInterpreter,
-      runtimeRoot
-    )
-    const inspection = await this.environmentOperations.runShared('inspection', envName, () =>
-      this.environmentStateTracker.inspectPackages(target, request.packages)
-    )
-    return {
-      language: request.language,
-      environmentName: envName,
-      runtimeSource: target.runtimeSource,
-      ...(binding?.runtimeId ? { runtimeId: binding.runtimeId } : {}),
-      ...(binding?.label ? { runtimeLabel: binding.label } : {}),
-      ...inspection
-    }
+    return this.packageOperations.inspect(request)
   }
 
   // Installs packages into the shared global environments (never inside a session/kernel). Resolves
@@ -1109,30 +1007,7 @@ class NotebookRuntimeService {
   // env — a pip/conda/CRAN install can never overlap a cell mid-import (§5, G2/D5). Installs into
   // DIFFERENT envs proceed concurrently (the lock is keyed by resolved env name, not language).
   async managePackages(request: InstallRequest): Promise<InstallResult> {
-    // Let startup recovery finish before installing, so recovery's repair-flagging / prefix cleanup
-    // can't race this install writing into the same env.
-    await this.ensureRecovered()
-    const configured = await this.resolvePackageMirror()
-    const mirror = await effectiveMirrorAsync(
-      configured,
-      this.options.locale ?? DEFAULT_LOCALE,
-      this.options.mirrorProbe
-    )
-
-    const admission = await this.packageAdmission.admit(request)
-    if (admission.status === 'refused') return admission.result
-    const result = await this.packageMutation.mutate({ target: admission.target, mirror })
-
-    // R installs/uninstalls don't take effect in a live R session (attached namespaces, held DLLs), so
-    // flag the env for a restart prompt and refresh every session's env view. Python needs no restart.
-    if (result.ok && result.needsRestart && request.language === 'r') {
-      this.environmentOperations.recommendRestart('r', admission.target.environmentName)
-      for (const session of this.sessions.values()) {
-        this.notifyNotebookChanged(session)
-      }
-    }
-
-    return result
+    return this.packageOperations.manage(request)
   }
 
   // Named-environment management (design D2), delegating to the injected provisioner-backed manager.
@@ -1580,18 +1455,6 @@ class NotebookRuntimeService {
       })
     } catch {
       return
-    }
-  }
-
-  // Best-effort lookup of the configured package mirror: an install falls back to the region default
-  // (never a hard failure) when no resolver is wired or the settings read throws.
-  private async resolvePackageMirror(): Promise<PackageMirror | undefined> {
-    if (!this.packageMirrorResolver) return undefined
-
-    try {
-      return await this.packageMirrorResolver()
-    } catch {
-      return undefined
     }
   }
 


### PR DESCRIPTION
## Problem

The Notebook runtime facade still owned package inspection orchestration, package admission/mutation
composition, mirror fallback, repair completion routing, and R restart publication. Although N1-N3
had extracted the individual owners, callers could still only use them by reconstructing their target,
journal, repair, and notification relationships inside the facade.

Exact base: `9209f776b979aae0be03580c2374ada1b7ba9448`  
Exact head: `a9b42aec1758e344f472e654d824920de1249ad3`

## Proposed change

Add `NotebookPackageOperations`, a deep two-operation module:

- `inspect(request)` owns recovery/readiness gates, Session-bound environment selection, the shared
  inspection slot, and the existing result projection;
- `manage(request)` owns recovery, mirror fallback, admission, mutation, permanent repair completion,
  and R restart publication.

The runtime service now constructs the module once and keeps `inspectPackages` / `managePackages` as
stable compatibility delegates.

```mermaid
flowchart LR
  Facade["NotebookRuntimeService facade"] -->|"inspect / manage"| Packages["NotebookPackageOperations"]
  Packages --> Inspection["Environment inspection"]
  Packages --> Admission["Package admission"]
  Admission --> Mutation["Package mutation"]
  Mutation --> Repair["Permanent repair owner"]
  Packages --> Recovery["Recovery gates"]
  Packages --> Restart["R restart publication"]
```

Production raw diff: `424` lines (`+264/-160`), below the approved 600 target and 660 hard limit.

## Scope and non-goals

- No application-command, IPC, preload, local-RPC, MCP, or package UI changes.
- No request/result shape, repair registry, operation journal, persisted data, or data relationship
  changes.
- `NotebookPackageAdmissionOwner`, `NotebookPackageMutationOwner`, and
  `NotebookRuntimeRepairOwner` retain their existing responsibilities; this module composes them
  without exposing their internal targets.
- Environment provisioning, physical package installation, generic startup recovery, and Session
  lifecycle ownership do not move.
- Electron, local/remote Web, CLI/Task, Specialist, Permission, and Compute behavior and existing
  surface asymmetries are unchanged.
- This remains forward-compatible with #458 without adding orchestration state or public contracts.
- Squash merge only.

## Compatibility and risk

- Inspection still rejects external runtimes so interpreter execution requires notebook approval.
- Read-only inspection still refuses to materialize a missing default runtime.
- Mirror resolver errors still fall back to the locale/auto mirror and retain configured overrides.
- Admission is still rechecked inside the environment mutation lock before journal/dirty/spawn side
  effects.
- Successful mutation still completes interrupted repair before returning; protected repair remains
  fail-closed.
- Successful R mutations still recommend restart for the admitted environment and notify every live
  Session; Python remains unchanged.
- Incoming #847 was audited before rebase: it changes only renderer Settings Skills files and has
  zero file/semantic overlap.
- Incoming #846 was audited before the final rebase: it changes release workflows and package smoke
  validation only, has zero Notebook package-runtime overlap, and the final mechanical range-diff is
  `=`. The exact-head online PR Gate remains authoritative for its validation-infrastructure changes.

## Acceptance criteria and validation

All checks below ran after the last material edit and on the exact base/head above.

- Package owner interface, admission, mutation, repair/environment workflows, Notebook workflows,
  runtime selection, full runtime facade, logging, and export consumers ->
  `npm test -- --run src/main/notebook/package-operations.test.ts src/main/notebook/package-admission.test.ts src/main/notebook/package-mutation.test.ts src/main/notebook/environment-lifecycle-workflows.test.ts src/main/notebook/notebook-workflows.test.ts src/main/notebook/runtime-selection-workflows.test.ts src/main/notebook/runtime-service.test.ts src/main/notebook/runtime-service-logging.integration.test.ts src/main/notebook/runtime-service.export.test.ts`
  -> `9 files / 280 tests passed`.
- Earlier isolated owner-interface rerun ->
  `npm test -- --run src/main/notebook/package-operations.test.ts` -> `1 file / 3 tests passed`.
  The final exact-head suite above reran these tests as part of its `280` unique tests.
- Main-process contracts and consumers -> `npm run typecheck:node` -> passed.
- Changed Notebook sources/tests -> targeted ESLint -> passed with zero findings.
- Changed Notebook sources/tests -> targeted Prettier check -> passed.
- Final diff -> `git diff --check origin/main..HEAD` -> passed.
- Independent exact-range review -> `Standards 0 / Spec 0`.

The final impact set covers both public facade delegates, the deep owner interface, every composed
owner, recovery and mirror seams, restart publication, workflow consumers, and runtime-service export
compatibility. No local platform E2E was run because process, IPC, renderer, and platform routing are
unchanged; repository PR Gate remains authoritative for selected online lanes.

## Review focus

- Verify package targets, repair identities, and journal structures remain private to the module.
- Verify inspection preserves external/default-readiness and recovery gate ordering.
- Verify manage preserves mirror-before-admission ordering, lock-boundary repair recheck, and
  mutation/repair completion semantics.
- Verify R restart publication uses the admitted environment and still invalidates every Session.
- Verify the runtime service contains only stable delegates rather than a duplicate compatibility
  path.
