### PR TITLE
refactor(settings-store): extract Connectors slice

### DIFF
--- a/src/renderer/src/stores/settings-connectors-slice.test.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.test.ts
@@ -1,0 +1,321 @@
+import { createStore, type StoreApi } from 'zustand/vanilla'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  ConnectorApprovalRequest,
+  ConnectorDetailView,
+  ConnectorView,
+  ConnectorsSnapshot,
+  CustomServerView
+} from '../../../shared/settings'
+import {
+  createInitialSettingsConnectorsState,
+  createSettingsConnectorsSlice,
+  type SettingsConnectorsActions,
+  type SettingsConnectorsState
+} from './settings-connectors-slice'
+
+type TestStore = SettingsConnectorsState & SettingsConnectorsActions
+type ConnectorCommands = Parameters<
+  typeof createSettingsConnectorsSlice
+>[0]['getCommands'] extends () => infer T
+  ? T
+  : never
+
+const connector = (
+  id: string,
+  { enabled = true, autoAllow = false }: { enabled?: boolean; autoAllow?: boolean } = {}
+): ConnectorView => ({
+  id,
+  displayName: id,
+  description: `${id} description`,
+  sources: [],
+  requiresNcbi: false,
+  enabled,
+  autoAllow,
+  group: 'featured'
+})
+
+const server = (id: string, enabled = true): CustomServerView => ({
+  id,
+  slug: id,
+  name: id,
+  transport: 'stdio',
+  enabled,
+  command: 'npx'
+})
+
+const snapshot = (
+  connectors: ConnectorView[] = [],
+  customServers: CustomServerView[] = []
+): ConnectorsSnapshot => ({ connectors, customServers, ncbi: { hasApiKey: false } })
+
+const detail: ConnectorDetailView = {
+  ...connector('pubmed'),
+  useWhen: 'searching PubMed',
+  tools: []
+}
+
+const createCommands = (): ConnectorCommands => ({
+  listConnectors: vi.fn(async () => snapshot()),
+  setConnectorEnabled: vi.fn(async () => snapshot()),
+  setConnectorAutoAllow: vi.fn(async () => snapshot()),
+  setToolPermission: vi.fn(async () => detail),
+  setNcbiCredentials: vi.fn(async () => snapshot()),
+  addCustomServer: vi.fn(async () => snapshot()),
+  updateCustomServer: vi.fn(async () => snapshot()),
+  authenticateCustomServer: vi.fn(async () => snapshot()),
+  cancelCustomServerAuthentication: vi.fn(async () => undefined),
+  setCustomServerEnabled: vi.fn(async () => snapshot()),
+  removeCustomServer: vi.fn(async () => snapshot()),
+  respondConnectorApproval: vi.fn(async () => undefined)
+})
+
+const createHarness = (
+  commands: ConnectorCommands
+): { store: StoreApi<TestStore>; commands: ConnectorCommands } => {
+  const store = createStore<TestStore>((set) => ({
+    ...createInitialSettingsConnectorsState(),
+    ...createSettingsConnectorsSlice({
+      setState: (patch) => set(patch),
+      getCommands: () => commands
+    })
+  }))
+
+  return { store, commands }
+}
+
+describe('settings Connectors slice', () => {
+  let store: StoreApi<TestStore>
+  let commands: ConnectorCommands
+
+  beforeEach(() => {
+    ;({ store, commands } = createHarness(createCommands()))
+  })
+
+  it('loads the authoritative Connector, custom-server, and NCBI projection', async () => {
+    const result: ConnectorsSnapshot = {
+      ...snapshot([connector('pubmed')], [server('custom')]),
+      ncbi: { contactEmail: 'science@example.test', hasApiKey: true }
+    }
+    vi.mocked(commands.listConnectors).mockResolvedValue(result)
+
+    await store.getState().loadConnectors()
+
+    expect(store.getState()).toMatchObject(result)
+  })
+
+  it('optimistically enables a Connector before authoritative reconciliation', async () => {
+    let settle!: (result: ConnectorsSnapshot) => void
+    vi.mocked(commands.setConnectorEnabled).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve
+      })
+    )
+    store.setState({ connectors: [connector('pubmed', { enabled: false })] })
+
+    const pending = store.getState().setConnectorEnabled('pubmed', true)
+
+    expect(store.getState().connectors).toEqual([connector('pubmed')])
+    expect(commands.setConnectorEnabled).toHaveBeenCalledWith({ id: 'pubmed', enabled: true })
+
+    settle(snapshot([connector('authoritative')]))
+    await pending
+    expect(store.getState().connectors).toEqual([connector('authoritative')])
+  })
+
+  it('retains an optimistic Connector toggle when main rejects it', async () => {
+    vi.mocked(commands.setConnectorEnabled).mockRejectedValue(new Error('toggle failed'))
+    store.setState({ connectors: [connector('pubmed')] })
+
+    await expect(store.getState().setConnectorEnabled('pubmed', false)).rejects.toThrow(
+      'toggle failed'
+    )
+
+    expect(store.getState().connectors).toEqual([connector('pubmed', { enabled: false })])
+  })
+
+  it('optimistically changes auto-allow and retains it after rejection', async () => {
+    vi.mocked(commands.setConnectorAutoAllow).mockRejectedValue(new Error('policy failed'))
+    store.setState({ connectors: [connector('pubmed')] })
+
+    await expect(store.getState().setConnectorAutoAllow('pubmed', true)).rejects.toThrow(
+      'policy failed'
+    )
+
+    expect(commands.setConnectorAutoAllow).toHaveBeenCalledWith({
+      id: 'pubmed',
+      autoAllow: true
+    })
+    expect(store.getState().connectors).toEqual([connector('pubmed', { autoAllow: true })])
+  })
+
+  it('returns tool permission detail without adding component-owned detail state', async () => {
+    store.setState({ connectors: [connector('pubmed')] })
+
+    await expect(store.getState().setToolPermission('pubmed/search', 'ask')).resolves.toBe(detail)
+
+    expect(commands.setToolPermission).toHaveBeenCalledWith({
+      toolId: 'pubmed/search',
+      permission: 'ask'
+    })
+    expect(store.getState().connectors).toEqual([connector('pubmed')])
+  })
+
+  it('reconciles credentials and custom-server CRUD from authoritative snapshots', async () => {
+    const withCredentials: ConnectorsSnapshot = {
+      ...snapshot(),
+      ncbi: { contactEmail: 'science@example.test', hasApiKey: true }
+    }
+    const created = server('created')
+    const updated = { ...created, description: 'Updated' }
+    vi.mocked(commands.setNcbiCredentials).mockResolvedValue(withCredentials)
+    vi.mocked(commands.addCustomServer).mockResolvedValue(snapshot([], [created]))
+    vi.mocked(commands.updateCustomServer).mockResolvedValue(snapshot([], [updated]))
+    vi.mocked(commands.removeCustomServer).mockResolvedValue(snapshot())
+
+    await store
+      .getState()
+      .setNcbiCredentials({ contactEmail: 'science@example.test', apiKey: 'secret' })
+    expect(store.getState().ncbi).toEqual(withCredentials.ncbi)
+
+    await store.getState().addCustomServer({ name: 'Created', transport: 'stdio', command: 'npx' })
+    expect(store.getState().customServers).toEqual([created])
+
+    await store.getState().updateCustomServer({
+      id: 'created',
+      description: 'Updated',
+      transport: 'stdio',
+      command: 'npx'
+    })
+    expect(store.getState().customServers).toEqual([updated])
+
+    await store.getState().removeCustomServer('created')
+    expect(commands.removeCustomServer).toHaveBeenCalledWith({ id: 'created' })
+    expect(store.getState().customServers).toEqual([])
+  })
+
+  it('reconciles successful custom-server authentication', async () => {
+    const authenticated = {
+      ...server('oauth'),
+      transport: 'streamable_http' as const,
+      url: 'https://mcp.example.test',
+      oauth: { hasTokens: true }
+    }
+    vi.mocked(commands.authenticateCustomServer).mockResolvedValue(snapshot([], [authenticated]))
+
+    await store.getState().authenticateCustomServer({ id: 'oauth' })
+
+    expect(commands.authenticateCustomServer).toHaveBeenCalledWith({ id: 'oauth' })
+    expect(store.getState().customServers).toEqual([authenticated])
+  })
+
+  it('refreshes invalidated OAuth state and rethrows the authentication failure', async () => {
+    const unauthenticated = {
+      ...server('oauth'),
+      transport: 'streamable_http' as const,
+      url: 'https://mcp.example.test',
+      oauth: { hasTokens: false }
+    }
+    const failure = new Error('authorization denied')
+    vi.mocked(commands.authenticateCustomServer).mockRejectedValue(failure)
+    vi.mocked(commands.listConnectors).mockResolvedValue(snapshot([], [unauthenticated]))
+
+    await expect(store.getState().authenticateCustomServer({ id: 'oauth' })).rejects.toBe(failure)
+
+    expect(commands.listConnectors).toHaveBeenCalledOnce()
+    expect(store.getState().customServers).toEqual([unauthenticated])
+  })
+
+  it('keeps the authentication error when the fallback refresh also fails', async () => {
+    const failure = new Error('authorization denied')
+    vi.mocked(commands.authenticateCustomServer).mockRejectedValue(failure)
+    vi.mocked(commands.listConnectors).mockRejectedValue(new Error('refresh failed'))
+
+    await expect(store.getState().authenticateCustomServer({ id: 'oauth' })).rejects.toBe(failure)
+  })
+
+  it('forwards custom-server authentication cancellation', async () => {
+    await store.getState().cancelCustomServerAuthentication({ id: 'oauth' })
+
+    expect(commands.cancelCustomServerAuthentication).toHaveBeenCalledWith({ id: 'oauth' })
+  })
+
+  it('optimistically toggles a custom server before authoritative reconciliation', async () => {
+    let settle!: (result: ConnectorsSnapshot) => void
+    vi.mocked(commands.setCustomServerEnabled).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve
+      })
+    )
+    store.setState({ customServers: [server('custom')] })
+
+    const pending = store.getState().setCustomServerEnabled('custom', false)
+
+    expect(store.getState().customServers).toEqual([server('custom', false)])
+    expect(commands.setCustomServerEnabled).toHaveBeenCalledWith({ id: 'custom', enabled: false })
+
+    settle(snapshot([], [server('authoritative', false)]))
+    await pending
+    expect(store.getState().customServers).toEqual([server('authoritative', false)])
+  })
+
+  it('retains an optimistic custom-server toggle when main rejects it', async () => {
+    vi.mocked(commands.setCustomServerEnabled).mockRejectedValue(new Error('toggle failed'))
+    store.setState({ customServers: [server('custom')] })
+
+    await expect(store.getState().setCustomServerEnabled('custom', false)).rejects.toThrow(
+      'toggle failed'
+    )
+
+    expect(store.getState().customServers).toEqual([server('custom', false)])
+  })
+
+  it('keeps approval ordering, ignores duplicates, and removes a response immediately', async () => {
+    const first: ConnectorApprovalRequest = {
+      id: 'first',
+      connector: 'pubmed',
+      method: 'search',
+      argsPreview: '{}'
+    }
+    const second = { ...first, id: 'second' }
+    let settle!: () => void
+    vi.mocked(commands.respondConnectorApproval).mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve
+      })
+    )
+
+    store.getState().enqueueApproval(first)
+    store.getState().enqueueApproval(second)
+    store.getState().enqueueApproval(first)
+    expect(store.getState().pendingApprovals).toEqual([first, second])
+
+    const pending = store.getState().respondApproval('first', 'session')
+    expect(store.getState().pendingApprovals).toEqual([second])
+    expect(commands.respondConnectorApproval).toHaveBeenCalledWith({
+      id: 'first',
+      decision: 'session'
+    })
+
+    settle()
+    await pending
+  })
+
+  it('retains immediate approval removal when main rejects the response', async () => {
+    const request: ConnectorApprovalRequest = {
+      id: 'request',
+      connector: 'pubmed',
+      method: 'search',
+      argsPreview: '{}'
+    }
+    vi.mocked(commands.respondConnectorApproval).mockRejectedValue(new Error('response failed'))
+    store.getState().enqueueApproval(request)
+
+    await expect(store.getState().respondApproval('request', 'once')).rejects.toThrow(
+      'response failed'
+    )
+
+    expect(store.getState().pendingApprovals).toEqual([])
+  })
+})

--- a/src/renderer/src/stores/settings-connectors-slice.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.ts
@@ -1,0 +1,141 @@
+import type {
+  AddCustomServerRequest,
+  ApprovalDecision,
+  AuthenticateCustomServerRequest,
+  ConnectorApprovalRequest,
+  ConnectorDetailView,
+  ConnectorView,
+  CustomServerView,
+  NcbiCredentialsView,
+  SetNcbiCredentialsRequest,
+  ToolPermission,
+  UpdateCustomServerRequest
+} from '../../../shared/settings'
+
+type SettingsConnectorsProjection = {
+  connectors: ConnectorView[]
+  customServers: CustomServerView[]
+  ncbi: NcbiCredentialsView
+}
+
+export type SettingsConnectorsState = SettingsConnectorsProjection & {
+  pendingApprovals: ConnectorApprovalRequest[]
+}
+
+export type SettingsConnectorsActions = {
+  loadConnectors: () => Promise<void>
+  setConnectorEnabled: (id: string, enabled: boolean) => Promise<void>
+  setConnectorAutoAllow: (id: string, autoAllow: boolean) => Promise<void>
+  setToolPermission: (toolId: string, permission: ToolPermission) => Promise<ConnectorDetailView>
+  setNcbiCredentials: (request: SetNcbiCredentialsRequest) => Promise<void>
+  addCustomServer: (request: AddCustomServerRequest) => Promise<void>
+  updateCustomServer: (request: UpdateCustomServerRequest) => Promise<void>
+  authenticateCustomServer: (request: AuthenticateCustomServerRequest) => Promise<void>
+  cancelCustomServerAuthentication: (request: AuthenticateCustomServerRequest) => Promise<void>
+  setCustomServerEnabled: (id: string, enabled: boolean) => Promise<void>
+  removeCustomServer: (id: string) => Promise<void>
+  enqueueApproval: (request: ConnectorApprovalRequest) => void
+  respondApproval: (id: string, decision: ApprovalDecision) => Promise<void>
+}
+
+type SettingsConnectorsCommands = Pick<
+  Window['api']['settings'],
+  | 'listConnectors'
+  | 'setConnectorEnabled'
+  | 'setConnectorAutoAllow'
+  | 'setToolPermission'
+  | 'setNcbiCredentials'
+  | 'addCustomServer'
+  | 'updateCustomServer'
+  | 'authenticateCustomServer'
+  | 'cancelCustomServerAuthentication'
+  | 'setCustomServerEnabled'
+  | 'removeCustomServer'
+  | 'respondConnectorApproval'
+>
+
+type SettingsConnectorsSliceOptions = {
+  setState: (
+    patch:
+      | Partial<SettingsConnectorsState>
+      | ((state: SettingsConnectorsState) => Partial<SettingsConnectorsState>)
+  ) => void
+  getCommands: () => SettingsConnectorsCommands
+}
+
+export const createInitialSettingsConnectorsState = (): SettingsConnectorsState => ({
+  connectors: [],
+  customServers: [],
+  pendingApprovals: [],
+  ncbi: { hasApiKey: false }
+})
+
+// Owns the renderer projection for Connector catalogs, custom servers, NCBI credentials, and the
+// approval queue. Main remains authoritative for every catalog mutation and trust decision.
+export const createSettingsConnectorsSlice = ({
+  setState,
+  getCommands
+}: SettingsConnectorsSliceOptions): SettingsConnectorsActions => {
+  const reconcile = async (command: () => Promise<SettingsConnectorsProjection>): Promise<void> => {
+    setState(await command())
+  }
+
+  return {
+    loadConnectors: () => reconcile(() => getCommands().listConnectors()),
+    setConnectorEnabled: async (id, enabled) => {
+      setState((state) => ({
+        connectors: state.connectors.map((connector) =>
+          connector.id === id ? { ...connector, enabled } : connector
+        )
+      }))
+      await reconcile(() => getCommands().setConnectorEnabled({ id, enabled }))
+    },
+    setConnectorAutoAllow: async (id, autoAllow) => {
+      setState((state) => ({
+        connectors: state.connectors.map((connector) =>
+          connector.id === id ? { ...connector, autoAllow } : connector
+        )
+      }))
+      await reconcile(() => getCommands().setConnectorAutoAllow({ id, autoAllow }))
+    },
+    setToolPermission: async (toolId, permission) =>
+      getCommands().setToolPermission({ toolId, permission }),
+    setNcbiCredentials: (request) => reconcile(() => getCommands().setNcbiCredentials(request)),
+    addCustomServer: (request) => reconcile(() => getCommands().addCustomServer(request)),
+    updateCustomServer: (request) => reconcile(() => getCommands().updateCustomServer(request)),
+    authenticateCustomServer: async (request) => {
+      try {
+        await reconcile(() => getCommands().authenticateCustomServer(request))
+      } catch (error) {
+        // Authentication can invalidate stale tokens before failing. Refresh the projection so the
+        // connector does not remain visibly "Connected" after main has cleared its credentials.
+        await reconcile(() => getCommands().listConnectors()).catch(() => undefined)
+        throw error
+      }
+    },
+    cancelCustomServerAuthentication: (request) =>
+      getCommands().cancelCustomServerAuthentication(request),
+    setCustomServerEnabled: async (id, enabled) => {
+      setState((state) => ({
+        customServers: state.customServers.map((server) =>
+          server.id === id ? { ...server, enabled } : server
+        )
+      }))
+      await reconcile(() => getCommands().setCustomServerEnabled({ id, enabled }))
+    },
+    removeCustomServer: (id) => reconcile(() => getCommands().removeCustomServer({ id })),
+    enqueueApproval: (request) => {
+      setState((state) =>
+        state.pendingApprovals.some(({ id }) => id === request.id)
+          ? state
+          : { pendingApprovals: [...state.pendingApprovals, request] }
+      )
+    },
+    respondApproval: async (id, decision) => {
+      setState((state) => ({
+        pendingApprovals: state.pendingApprovals.filter((request) => request.id !== id)
+      }))
+      await getCommands().respondConnectorApproval({ id, decision })
+    }
+  }
+}

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -24,6 +24,12 @@ import {
   type SettingsNavigationState
 } from './settings-navigation-slice'
 import {
+  createInitialSettingsConnectorsState,
+  createSettingsConnectorsSlice,
+  type SettingsConnectorsActions,
+  type SettingsConnectorsState
+} from './settings-connectors-slice'
+import {
   createSettingsPreferencesSlice,
   type SettingsPreferencesActions
 } from './settings-preferences-slice'
@@ -58,23 +64,13 @@ import type {
   ProviderView,
   ReasoningEffort,
   SettingsSnapshot,
-  AppIconVariant,
-  ConnectorView,
-  ConnectorDetailView,
-  CustomServerView,
-  NcbiCredentialsView,
-  ToolPermission,
-  SetNcbiCredentialsRequest,
-  AddCustomServerRequest,
-  AuthenticateCustomServerRequest,
-  UpdateCustomServerRequest,
-  ConnectorApprovalRequest,
-  ApprovalDecision
+  AppIconVariant
 } from '../../../shared/settings'
 
 type SettingsStoreData = RuntimeSetupState &
   SettingsNavigationState &
-  SettingsSkillsState & {
+  SettingsSkillsState &
+  SettingsConnectorsState & {
     isLoaded: boolean
     isLoading: boolean
     loadError: string | undefined
@@ -99,14 +95,6 @@ type SettingsStoreData = RuntimeSetupState &
     opencodeManaged: boolean
     codexManaged: boolean
     onboardingCompletedAt: number | undefined
-    // Bundled connectors with their enabled/auto-allow state, loaded lazily when the Connectors panel opens.
-    connectors: ConnectorView[]
-    // User-added custom MCP servers, reconciled alongside the connectors list.
-    customServers: CustomServerView[]
-    // Pending per-call connector approval requests (external data-egress gate), oldest first.
-    pendingApprovals: ConnectorApprovalRequest[]
-    // Shared NCBI credential state (never the plaintext key), reconciled alongside the connectors list.
-    ncbi: NcbiCredentialsView
     encryptionAvailable: boolean
     // Configured package mirror (conda/pip); undefined means public hosts (unconfigured).
     packageMirror?: PackageMirror
@@ -127,36 +115,12 @@ type SettingsStoreCore = SettingsStoreData &
   SettingsPreferencesActions &
   SettingsNavigationActions &
   SettingsSkillsActions &
+  SettingsConnectorsActions &
   SettingsStoreActions
 
 type SettingsStoreActions = {
   load: (options?: { force?: boolean }) => Promise<boolean>
   clearSettingsWriteError: () => void
-  // Loads the bundled-connector list (enabled/auto-allow + NCBI credential state) from main.
-  loadConnectors: () => Promise<void>
-  // Toggles one connector; optimistic, then reconciled with the authoritative snapshot from main.
-  setConnectorEnabled: (id: string, enabled: boolean) => Promise<void>
-  // Toggles a connector's "skip approvals" flag; optimistic, then reconciled from main.
-  setConnectorAutoAllow: (id: string, autoAllow: boolean) => Promise<void>
-  // Sets one tool's permission, returning the affected connector's refreshed detail view (held
-  // locally by the component, so nothing is stored here).
-  setToolPermission: (toolId: string, permission: ToolPermission) => Promise<ConnectorDetailView>
-  // Persists NCBI credentials and reconciles the connectors list + credential state from main.
-  setNcbiCredentials: (request: SetNcbiCredentialsRequest) => Promise<void>
-  // Adds a custom MCP server (add-time trust is confirmed in the UI), reconciling from main.
-  addCustomServer: (request: AddCustomServerRequest) => Promise<void>
-  // Edits an existing custom MCP server (name is immutable), reconciling from main.
-  updateCustomServer: (request: UpdateCustomServerRequest) => Promise<void>
-  authenticateCustomServer: (request: AuthenticateCustomServerRequest) => Promise<void>
-  cancelCustomServerAuthentication: (request: AuthenticateCustomServerRequest) => Promise<void>
-  // Enables/disables one custom MCP server; optimistic, then reconciled from main.
-  setCustomServerEnabled: (id: string, enabled: boolean) => Promise<void>
-  // Removes one custom MCP server, reconciling from main.
-  removeCustomServer: (id: string) => Promise<void>
-  // Queues an incoming approval request (from the main-process connector gate).
-  enqueueApproval: (request: ConnectorApprovalRequest) => void
-  // Sends the user's decision to main and drops the request from the queue.
-  respondApproval: (id: string, decision: ApprovalDecision) => Promise<void>
 }
 
 type SettingsStore = SettingsStoreCore & RuntimeSetupActions
@@ -165,6 +129,7 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   ...createInitialRuntimeSetupState(),
   ...createInitialSettingsNavigationState(),
   ...createInitialSettingsSkillsState(),
+  ...createInitialSettingsConnectorsState(),
   isLoaded: false,
   isLoading: false,
   loadError: undefined,
@@ -183,10 +148,6 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   opencodeManaged: false,
   codexManaged: false,
   onboardingCompletedAt: undefined,
-  connectors: [],
-  customServers: [],
-  pendingApprovals: [],
-  ncbi: { hasApiKey: false },
   encryptionAvailable: true,
   packageMirror: undefined,
   reasoningEffort: DEFAULT_REASONING_EFFORT,
@@ -336,6 +297,10 @@ const createSettingsStoreState = (
     setState: (patch) => set(patch),
     getCommands: () => window.api.settings
   }),
+  ...createSettingsConnectorsSlice({
+    setState: (patch) => set(patch),
+    getCommands: () => window.api.settings
+  }),
 
   // Loads settings, preflight, and encryption availability in one startup pass.
   load: (options) => {
@@ -386,111 +351,7 @@ const createSettingsStoreState = (
     return loadPromise
   },
 
-  clearSettingsWriteError: () => writeCoordinator.clearFailures(),
-
-  loadConnectors: async () => {
-    const { connectors, customServers, ncbi } = await window.api.settings.listConnectors()
-    set({ connectors, customServers, ncbi })
-  },
-
-  // Optimistically flips the toggle, then reconciles with the authoritative snapshot from main.
-  setConnectorEnabled: async (id, enabled) => {
-    set((state) => ({
-      connectors: state.connectors.map((connector) =>
-        connector.id === id ? { ...connector, enabled } : connector
-      )
-    }))
-    const { connectors, customServers, ncbi } = await window.api.settings.setConnectorEnabled({
-      id,
-      enabled
-    })
-    set({ connectors, customServers, ncbi })
-  },
-
-  // Optimistically flips "skip approvals", then reconciles from main.
-  setConnectorAutoAllow: async (id, autoAllow) => {
-    set((state) => ({
-      connectors: state.connectors.map((connector) =>
-        connector.id === id ? { ...connector, autoAllow } : connector
-      )
-    }))
-    const { connectors, customServers, ncbi } = await window.api.settings.setConnectorAutoAllow({
-      id,
-      autoAllow
-    })
-    set({ connectors, customServers, ncbi })
-  },
-
-  setToolPermission: async (toolId, permission) =>
-    window.api.settings.setToolPermission({ toolId, permission }),
-
-  setNcbiCredentials: async (request) => {
-    const { connectors, customServers, ncbi } =
-      await window.api.settings.setNcbiCredentials(request)
-    set({ connectors, customServers, ncbi })
-  },
-
-  addCustomServer: async (request) => {
-    const { connectors, customServers, ncbi } = await window.api.settings.addCustomServer(request)
-    set({ connectors, customServers, ncbi })
-  },
-
-  updateCustomServer: async (request) => {
-    const { connectors, customServers, ncbi } =
-      await window.api.settings.updateCustomServer(request)
-    set({ connectors, customServers, ncbi })
-  },
-
-  authenticateCustomServer: async (request) => {
-    try {
-      const { connectors, customServers, ncbi } =
-        await window.api.settings.authenticateCustomServer(request)
-      set({ connectors, customServers, ncbi })
-    } catch (error) {
-      // Authentication can invalidate stale tokens before failing. Refresh the projection so the
-      // connector does not remain visibly "Connected" after main has cleared its credentials.
-      await get()
-        .loadConnectors()
-        .catch(() => undefined)
-      throw error
-    }
-  },
-
-  cancelCustomServerAuthentication: (request) =>
-    window.api.settings.cancelCustomServerAuthentication(request),
-
-  // Optimistically flips the server toggle, then reconciles from main.
-  setCustomServerEnabled: async (id, enabled) => {
-    set((state) => ({
-      customServers: state.customServers.map((server) =>
-        server.id === id ? { ...server, enabled } : server
-      )
-    }))
-    const { connectors, customServers, ncbi } = await window.api.settings.setCustomServerEnabled({
-      id,
-      enabled
-    })
-    set({ connectors, customServers, ncbi })
-  },
-
-  removeCustomServer: async (id) => {
-    const { connectors, customServers, ncbi } = await window.api.settings.removeCustomServer({ id })
-    set({ connectors, customServers, ncbi })
-  },
-
-  enqueueApproval: (request) => {
-    set((state) =>
-      state.pendingApprovals.some((r) => r.id === request.id)
-        ? state
-        : { pendingApprovals: [...state.pendingApprovals, request] }
-    )
-  },
-
-  respondApproval: async (id, decision) => {
-    // Drop it from the queue immediately so the card can't be double-answered, then notify main.
-    set((state) => ({ pendingApprovals: state.pendingApprovals.filter((r) => r.id !== id) }))
-    await window.api.settings.respondConnectorApproval({ id, decision })
-  }
+  clearSettingsWriteError: () => writeCoordinator.clearFailures()
 })
 
 export const useSettingsStore = create<SettingsStore>((set, get) =>


### PR DESCRIPTION
## Problem

`settings-store.ts` still owned the complete renderer lifecycle for Connector catalogs, custom MCP servers, NCBI credentials, and the pending approval queue. This mixed trust-sensitive command settlement and approval ordering into the compatibility facade, without an isolated owner-level contract suite.

## Proposed change

- Add `settings-connectors-slice.ts` as the single renderer owner for Connector/custom-server/NCBI projections and the approval queue.
- Compose the slice through the existing Settings Store without changing public state or action names.
- Keep main authoritative for catalog mutation results while preserving optimistic Connector and custom-server toggles.
- Preserve tool detail as caller-owned state and OAuth failure refresh/rethrow behavior.
- Add direct tests for reconciliation, optimistic success/failure settlement, CRUD, authentication/cancellation, and approval FIFO/deduplication/removal.
- Reduce `settings-store.ts` from 504 to 365 lines. Production raw is 312 lines (`16 + 155 + 141`), below the 660 hard limit.

## Scope and non-goals

This is a renderer ownership extraction only. It does not change Connector transport, OAuth, trust, secrets, permission grants, auto-allow semantics, persisted data, main-process behavior, preload/IPC contracts, or user interaction. It does not change Specialist or Permission stores.

## Compatibility

- Electron keeps the same `window.api.settings` commands, payloads, results, optimistic timing, rejection behavior, and authoritative catalog settlement.
- Web, CLI, and Task retain their current capability exposure and existing asymmetries; no direct Connector management capability is added.
- Specialist, Permission, and Compute state and behavior are unchanged.
- Tool detail remains component-owned rather than becoming global Settings state.
- OAuth failure still attempts a projection refresh, ignores refresh failure, and rethrows the original authentication error.
- Approval requests retain FIFO insertion, duplicate-id suppression, and immediate removal before response settlement.

## Acceptance criteria and validation

All listed checks ran after the last material edit and mechanical rebase on exact base `9209f776` and head `ee56da15`. The rebase over release-only #846 was patch-identical (`git range-diff` reported `=`).

- Connector owner settlement and queue behavior -> `npm test -- --run src/renderer/src/stores/settings-connectors-slice.test.ts` -> 14 passed.
- Existing Settings Store interface and settlement behavior -> `npm test -- --run src/renderer/src/stores/settings-store.test.ts` -> 88 passed.
- App wiring, Connector/approval/detail/add-form consumers, Compute approval, and Specialist dependency -> `npm test -- --run src/renderer/src/App.test.tsx src/renderer/src/pages/settings/ComputeApprovalDialog.render.test.tsx src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx src/renderer/src/pages/settings/ConnectorDetailView.render.test.tsx src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx` -> 96 passed.
- Combined final impact set -> 9 files / 198 tests passed.
- Node and renderer type contracts -> `npm run typecheck` -> passed.
- Repository lint policy -> `npm run lint` -> passed.
- Changed-file formatting -> `prettier --check` for all three changed files -> passed.
- Diff hygiene -> `git diff --check` -> passed.
- Independent exact-head review -> Standards 0 findings / Spec 0 findings; independent 9-file run -> 246 passed.
- Merge policy -> squash merge only after exact-head CI and AI review pass.

The final Test Impact Set covers the new owner, the unchanged public Store interface, every renderer test consumer found for the moved actions, and both compile-time surfaces. No local persistence, migration, build, or E2E lane was added because shared/main/preload and platform behavior are unchanged; PR Gate remains authoritative for online platform lanes. Residual risk is limited to cross-surface runtime integration and the pre-existing last-completion-wins behavior for concurrent catalog mutations.

## Review focus

- Confirm Connector/custom-server/NCBI projection and pending approvals now have one renderer owner.
- Confirm optimistic success and failure-retention behavior exactly matches the previous inline implementation.
- Confirm OAuth fallback refresh, cancellation, tool-detail ownership, and original error propagation remain exact.
- Confirm approval ordering, duplicate suppression, immediate removal, and response payloads remain exact.
- Confirm no trust, permission, auto-allow, IPC, or Electron/Web/CLI/Task capability boundary changes.
