### PR TITLE
refactor(notebook): extract environment management owner

### DIFF
--- a/src/main/notebook/environment-management.test.ts
+++ b/src/main/notebook/environment-management.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { NotebookKernelMetadata } from '../../shared/notebook'
+import type { EnvironmentInfo } from '../../shared/notebook-env'
+import {
+  NotebookEnvironmentManagementOwner,
+  type NotebookEnvironmentManager
+} from './environment-management'
+import { envPrefix } from './runtime-paths'
+
+type OwnerOptions = ConstructorParameters<typeof NotebookEnvironmentManagementOwner>[0]
+type EnvironmentSession =
+  ReturnType<OwnerOptions['sessions']> extends Iterable<infer Session> ? Session : never
+
+const manager = (): NotebookEnvironmentManager => ({
+  createNamedEnvironment: vi.fn(async (name, language) => ({
+    name,
+    language,
+    ready: true,
+    isDefault: false
+  })),
+  listEnvironments: vi.fn(() => []),
+  removeEnvironment: vi.fn(() => [])
+})
+
+const session = (
+  statuses: Array<[string, NotebookKernelMetadata['lastKnownStatus']]>
+): EnvironmentSession => ({ kernelStatusEntries: () => statuses })
+
+const harness = (
+  overrides: Partial<OwnerOptions> = {}
+): {
+  owner: NotebookEnvironmentManagementOwner
+  options: OwnerOptions
+  manager: NotebookEnvironmentManager | undefined
+} => {
+  const configuredManager = overrides.manager === undefined ? manager() : overrides.manager
+  const options: OwnerOptions = {
+    runtimeRoot: '/runtime',
+    manager: configuredManager,
+    sessions: () => [],
+    ensureRecovered: vi.fn().mockResolvedValue(undefined),
+    assertPrefixRecoverable: vi.fn(),
+    environmentOperations: {
+      runMutation: vi.fn(async (_environment, operation) => operation())
+    },
+    runtimeRepair: {
+      completeRemovedManagedEnvironment: vi.fn()
+    },
+    ...overrides
+  }
+  return {
+    owner: new NotebookEnvironmentManagementOwner(options),
+    options,
+    manager: configuredManager
+  }
+}
+
+describe('NotebookEnvironmentManagementOwner', () => {
+  it('keeps manager configuration inside the owner', async () => {
+    const configuredHarness = harness()
+    const owner = new NotebookEnvironmentManagementOwner({
+      ...configuredHarness.options,
+      manager: undefined
+    })
+
+    await expect(owner.manage({ action: 'list' })).rejects.toThrow(
+      'Environment management is unavailable (no environment manager configured).'
+    )
+
+    const configured = manager()
+    vi.mocked(configured.listEnvironments).mockReturnValue([
+      { name: 'analysis', language: 'python', ready: true, isDefault: false }
+    ])
+    owner.setManager(configured)
+
+    await expect(owner.manage({ action: 'list' })).resolves.toEqual({
+      environments: [{ name: 'analysis', language: 'python', ready: true, isDefault: false }]
+    })
+  })
+
+  it('validates and creates under recovery and the environment mutation slot', async () => {
+    const order: string[] = []
+    const configured = manager()
+    vi.mocked(configured.createNamedEnvironment).mockImplementation(
+      async (name, language, packages) => {
+        order.push(`create:${name}:${language}:${packages?.join(',')}`)
+        return { name, language, ready: true, isDefault: false }
+      }
+    )
+    const environments: EnvironmentInfo[] = [
+      { name: 'analysis', language: 'python', ready: true, isDefault: false }
+    ]
+    vi.mocked(configured.listEnvironments).mockImplementation(() => {
+      order.push('list')
+      return environments
+    })
+    const { owner, options } = harness({
+      manager: configured,
+      ensureRecovered: vi.fn(async () => {
+        order.push('recovery')
+      }),
+      assertPrefixRecoverable: vi.fn(() => {
+        order.push('recoverable')
+      }),
+      environmentOperations: {
+        runMutation: vi.fn(async (environment, operation) => {
+          order.push(`mutation:${environment}`)
+          return operation()
+        })
+      }
+    })
+
+    await expect(
+      owner.manage({
+        action: 'create',
+        name: 'analysis',
+        language: 'python',
+        packages: ['numpy']
+      })
+    ).resolves.toEqual({ environments })
+
+    expect(order).toEqual([
+      'recovery',
+      'recoverable',
+      'mutation:analysis',
+      'create:analysis:python:numpy',
+      'list'
+    ])
+    expect(options.assertPrefixRecoverable).toHaveBeenCalledWith(envPrefix('/runtime', 'analysis'))
+  })
+
+  it('rejects invalid create and remove names before lifecycle side effects', async () => {
+    const { owner, options, manager: configured } = harness()
+
+    await expect(
+      owner.manage({ action: 'create', name: 'python', language: 'python' })
+    ).rejects.toThrow(/reserved environment name/)
+    await expect(owner.manage({ action: 'create', name: 'analysis' } as never)).rejects.toThrow(
+      /requires a language/
+    )
+    await expect(
+      owner.manage({ action: 'remove', name: '../../../../tmp/victim' })
+    ).rejects.toThrow(/Invalid environment name/)
+
+    expect(options.ensureRecovered).not.toHaveBeenCalled()
+    expect(configured?.createNamedEnvironment).not.toHaveBeenCalled()
+    expect(configured?.removeEnvironment).not.toHaveBeenCalled()
+  })
+
+  it('refuses app-managed and live environments before recovery or deletion', async () => {
+    const configured = manager()
+    const { owner, options } = harness({
+      manager: configured,
+      sessions: () => [
+        session([
+          ['repl', 'idle'],
+          ['python:analysis', 'idle'],
+          ['r:finished', 'terminated']
+        ])
+      ]
+    })
+
+    await expect(owner.manage({ action: 'remove', name: 'default-python-3.13' })).rejects.toThrow(
+      /app-managed and cannot be removed/
+    )
+    await expect(owner.manage({ action: 'remove', name: 'analysis' })).rejects.toThrow(
+      /in use by a running kernel/
+    )
+
+    expect(options.ensureRecovered).not.toHaveBeenCalled()
+    expect(configured.removeEnvironment).not.toHaveBeenCalled()
+  })
+
+  it('removes an idle-free environment under recovery and clears its repair state', async () => {
+    const order: string[] = []
+    const configured = manager()
+    const remaining: EnvironmentInfo[] = [
+      { name: 'other', language: 'r', ready: true, isDefault: false }
+    ]
+    vi.mocked(configured.removeEnvironment).mockImplementation((name) => {
+      order.push(`remove:${name}`)
+      return remaining
+    })
+    const { owner, options } = harness({
+      manager: configured,
+      sessions: () => [session([['python:analysis', 'terminated']])],
+      ensureRecovered: vi.fn(async () => {
+        order.push('recovery')
+      }),
+      assertPrefixRecoverable: vi.fn(() => {
+        order.push('recoverable')
+      }),
+      environmentOperations: {
+        runMutation: vi.fn(async (environment, operation) => {
+          order.push(`mutation:${environment}`)
+          return operation()
+        })
+      },
+      runtimeRepair: {
+        completeRemovedManagedEnvironment: vi.fn((name) => {
+          order.push(`repair:${name}`)
+        })
+      }
+    })
+
+    await expect(owner.manage({ action: 'remove', name: 'analysis' })).resolves.toEqual({
+      environments: remaining
+    })
+
+    expect(order).toEqual([
+      'recovery',
+      'recoverable',
+      'mutation:analysis',
+      'remove:analysis',
+      'repair:analysis'
+    ])
+    expect(options.assertPrefixRecoverable).toHaveBeenCalledWith(envPrefix('/runtime', 'analysis'))
+  })
+
+  it('preserves repair state when physical removal fails', async () => {
+    const configured = manager()
+    vi.mocked(configured.removeEnvironment).mockImplementation(() => {
+      throw new Error('remove failed')
+    })
+    const { owner, options } = harness({ manager: configured })
+
+    await expect(owner.manage({ action: 'remove', name: 'analysis' })).rejects.toThrow(
+      'remove failed'
+    )
+
+    expect(options.runtimeRepair.completeRemovedManagedEnvironment).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/notebook/environment-management.ts
+++ b/src/main/notebook/environment-management.ts
@@ -1,0 +1,111 @@
+import type { NotebookKernelMetadata, NotebookLanguage } from '../../shared/notebook'
+import type {
+  EnvironmentInfo,
+  ManageEnvironmentsRequest,
+  ManageEnvironmentsResult
+} from '../../shared/notebook-env'
+import type { NotebookEnvironmentOperations } from './environment-operations'
+import { assertSafeEnvName, DEFAULT_PY_ENV, DEFAULT_R_ENV, envPrefix } from './runtime-paths'
+import type { NotebookRuntimeRepairOwner } from './runtime-repair'
+
+type NotebookEnvironmentManager = {
+  createNamedEnvironment: (
+    name: string,
+    language: NotebookLanguage,
+    packages?: string[]
+  ) => Promise<EnvironmentInfo>
+  listEnvironments: () => EnvironmentInfo[]
+  removeEnvironment: (name: string) => EnvironmentInfo[]
+}
+
+type EnvironmentManagementSession = {
+  kernelStatusEntries(): Array<[string, NotebookKernelMetadata['lastKnownStatus']]>
+}
+
+type NotebookEnvironmentManagementOptions = {
+  runtimeRoot: string
+  manager?: NotebookEnvironmentManager
+  sessions: () => Iterable<EnvironmentManagementSession>
+  ensureRecovered: () => Promise<void>
+  assertPrefixRecoverable: (prefix: string) => void
+  environmentOperations: Pick<NotebookEnvironmentOperations, 'runMutation'>
+  runtimeRepair: Pick<NotebookRuntimeRepairOwner, 'completeRemovedManagedEnvironment'>
+}
+
+const isAppManagedEnvironment = (name: string): boolean =>
+  name === DEFAULT_PY_ENV ||
+  name === DEFAULT_R_ENV ||
+  name.startsWith(`${DEFAULT_PY_ENV}-`) ||
+  name.startsWith(`${DEFAULT_R_ENV}-`)
+
+/** Owns named-environment validation, lifecycle ordering, and live-use protection. */
+class NotebookEnvironmentManagementOwner {
+  private manager: NotebookEnvironmentManager | undefined
+
+  constructor(private readonly options: NotebookEnvironmentManagementOptions) {
+    this.manager = options.manager
+  }
+
+  setManager(manager: NotebookEnvironmentManager): void {
+    this.manager = manager
+  }
+
+  async manage(request: ManageEnvironmentsRequest): Promise<ManageEnvironmentsResult> {
+    const manager = this.manager
+    if (!manager) {
+      throw new Error('Environment management is unavailable (no environment manager configured).')
+    }
+
+    switch (request.action) {
+      case 'create': {
+        const name = assertSafeEnvName(request.name)
+        if (request.language !== 'python' && request.language !== 'r') {
+          throw new Error('Creating an environment requires a language of "python" or "r".')
+        }
+        await this.options.ensureRecovered()
+        this.options.assertPrefixRecoverable(envPrefix(this.options.runtimeRoot, name))
+        return this.options.environmentOperations.runMutation(name, async () => {
+          await manager.createNamedEnvironment(name, request.language, request.packages)
+          return { environments: manager.listEnvironments() }
+        })
+      }
+      case 'list':
+        return { environments: manager.listEnvironments() }
+      case 'remove': {
+        const name = assertSafeEnvName(request.name)
+        if (isAppManagedEnvironment(name)) {
+          throw new Error(
+            `Environment "${name}" is app-managed and cannot be removed. Only environments you ` +
+              'created with manage_environments(action:"create") can be removed.'
+          )
+        }
+        if (this.isLive(name)) {
+          throw new Error(
+            `Environment "${name}" is in use by a running kernel — restart the notebook or ` +
+              'wait for the run to finish before removing it.'
+          )
+        }
+        await this.options.ensureRecovered()
+        this.options.assertPrefixRecoverable(envPrefix(this.options.runtimeRoot, name))
+        return this.options.environmentOperations.runMutation(name, async () => {
+          const environments = manager.removeEnvironment(name)
+          this.options.runtimeRepair.completeRemovedManagedEnvironment(name)
+          return { environments }
+        })
+      }
+    }
+  }
+
+  private isLive(name: string): boolean {
+    for (const session of this.options.sessions()) {
+      for (const [processKey, status] of session.kernelStatusEntries()) {
+        if (processKey === 'repl' || status === 'terminated') continue
+        if (processKey.slice(processKey.indexOf(':') + 1) === name) return true
+      }
+    }
+    return false
+  }
+}
+
+export { NotebookEnvironmentManagementOwner }
+export type { NotebookEnvironmentManager }

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -27,13 +27,16 @@ import type {
   RunNotebookCellRequest
 } from '../../shared/notebook'
 import type {
-  EnvironmentInfo,
   ManageEnvironmentsRequest,
   ManageEnvironmentsResult,
   ProvisionProgress
 } from '../../shared/notebook-env'
 import type { PackageMirror } from '../../shared/mirror'
 import { NotebookDataExecutionAdmissionOwner } from './data-execution-admission'
+import {
+  NotebookEnvironmentManagementOwner,
+  type NotebookEnvironmentManager
+} from './environment-management'
 import { NotebookExportReader } from './export-reader'
 import { NotebookKernelExecutor, type NotebookKernelExecutorOptions } from './kernel-executor'
 import { saveIpynbAll } from './save-ipynb-all'
@@ -52,7 +55,6 @@ import {
 } from './package-operations'
 import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
 import {
-  assertSafeEnvName,
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
   envPrefix,
@@ -63,7 +65,6 @@ import {
 } from './runtime-paths'
 import type {
   DiscoveredInterpreter,
-  EnvProvenance,
   NotebookRuntimeBinding,
   NotebookRuntimeBindings,
   NotebookRuntimeListing,
@@ -137,19 +138,6 @@ const persistsToRunJson = (processKey: string): boolean =>
   processKey === `python:${DEFAULT_PY_ENV}` ||
   processKey === `r:${DEFAULT_R_ENV}`
 
-// Provenance of a named env under runtime/envs, mirroring environment-discovery.classify's rule: the
-// two DEFAULT envs and their versioned siblings (e.g. default-python-3.13) are app-managed; any other
-// name is an agent-created env. The remove-guard uses this so remove only ever deletes agent-created
-// envs — never an app-managed default (user-own envs never live under runtime/envs, so they can't be
-// named here at all).
-const namedEnvProvenance = (name: string): EnvProvenance =>
-  name === DEFAULT_PY_ENV ||
-  name === DEFAULT_R_ENV ||
-  name.startsWith(`${DEFAULT_PY_ENV}-`) ||
-  name.startsWith(`${DEFAULT_R_ENV}-`)
-    ? 'app-managed'
-    : 'agent-created'
-
 type ResolvedInterpreter = NotebookSessionResolvedInterpreter
 type NotebookExecutionRequest = NotebookSessionExecutionRequest
 type NotebookExecutionResult = NotebookSessionExecutionResult
@@ -188,19 +176,6 @@ type NotebookHandoffContext = {
     status?: NotebookRuntimeBinding['status']
     reason?: NotebookRuntimeBinding['reason']
   }>
-}
-
-// Provisioner-backed environment manager injected into the service (mirrors installPackagesImpl /
-// getPackageMirror injection). DefaultRuntimeProvisioner satisfies this structurally; tests inject a
-// fake so manageEnvironments never spawns real micromamba.
-type NotebookEnvironmentManager = {
-  createNamedEnvironment: (
-    name: string,
-    language: NotebookLanguage,
-    packages?: string[]
-  ) => Promise<EnvironmentInfo>
-  listEnvironments: () => EnvironmentInfo[]
-  removeEnvironment: (name: string) => EnvironmentInfo[]
 }
 
 // The session-scoped connector RPC capability injected into the persistent control-plane REPL. The
@@ -388,6 +363,7 @@ class NotebookRuntimeService {
   // revocation drains, repair blocks, and installer diagnostics. The service remains the compatibility
   // facade and chooses which execution/package path enters each environment operation.
   private readonly environmentOperations: NotebookEnvironmentOperations
+  private readonly environmentManagement: NotebookEnvironmentManagementOwner
   private mcpRpcConnectionResolver:
     ((binding: McpRpcConnectionBinding) => Promise<McpRpcConnection>) | undefined
   private readonly runtimeEnablementResolver:
@@ -406,7 +382,6 @@ class NotebookRuntimeService {
     | 'markPackageMutationDirty'
     | 'refreshAfterPackageMutation'
   >
-  private environmentManager: NotebookEnvironmentManager | undefined
   private disposalPromise: Promise<{ reaped: boolean }> | undefined
 
   constructor(private readonly options: NotebookRuntimeServiceOptions) {
@@ -456,6 +431,15 @@ class NotebookRuntimeService {
       findSession: (sessionId) => this.sessions.get(sessionId),
       notifyChanged: (session) => this.notifyNotebookChanged(session)
     })
+    this.environmentManagement = new NotebookEnvironmentManagementOwner({
+      runtimeRoot,
+      manager: options.environmentManager,
+      sessions: () => this.sessions.values(),
+      ensureRecovered: () => this.ensureRecovered(),
+      assertPrefixRecoverable: (prefix) => this.assertPrefixRecoverable(prefix),
+      environmentOperations: this.environmentOperations,
+      runtimeRepair: this.runtimeRepair
+    })
     this.environmentStateTracker =
       options.environmentStateTracker ??
       new EnvironmentStateTracker({
@@ -493,7 +477,6 @@ class NotebookRuntimeService {
       resolveRuntimeEnablement: (language) => this.resolveRuntimeEnablement(language),
       repairPolicy: this.repairPolicy
     })
-    this.environmentManager = options.environmentManager
     this.runTerminalization = new NotebookRunTerminalizationOwner({
       repository: this.repository,
       notifyChanged: (session) => this.notifyNotebookChanged(session as RuntimeSession)
@@ -529,7 +512,7 @@ class NotebookRuntimeService {
   // Wires the provisioner-backed environment manager after construction (the provisioner is built in
   // main/ipc.ts alongside the env gate, after this service exists), mirroring the resolver setters.
   setEnvironmentManager(manager: NotebookEnvironmentManager): void {
-    this.environmentManager = manager
+    this.environmentManagement.setManager(manager)
   }
 
   // Wires the (serialized) default-env provisioner used to build default-python/default-r on demand.
@@ -1015,81 +998,7 @@ class NotebookRuntimeService {
   // executor process bound to that env name (locked decision — the on-disk env can't be rm-rf'd out
   // from under a running kernel). Create returns on completion (progress streaming is out of scope).
   async manageEnvironments(request: ManageEnvironmentsRequest): Promise<ManageEnvironmentsResult> {
-    const manager = this.environmentManager
-    if (!manager) {
-      throw new Error('Environment management is unavailable (no environment manager configured).')
-    }
-
-    switch (request.action) {
-      case 'create': {
-        // Validate BEFORE the name composes a filesystem path, and reject reserved/alias/default
-        // names so a created env is always reachable by execute/install (design D8 / review #1,#2).
-        const name = assertSafeEnvName(request.name)
-        if (request.language !== 'python' && request.language !== 'r') {
-          throw new Error('Creating an environment requires a language of "python" or "r".')
-        }
-        const language = request.language
-        // Let startup recovery finish before creating a prefix: its cleanup/verify must not race a
-        // fresh create writing into <root>/envs (same barrier materialize/install use).
-        await this.ensureRecovered()
-        // Refuse if recovery left this env's prefix blocked (an unknown-liveness orphan may still hold
-        // it) — creating over a possibly-live prefix could corrupt it.
-        this.assertPrefixRecoverable(envPrefix(getRuntimeRoot(this.options.dataRoot), name))
-        // Serialize create against installs / other env ops on the same env (design D4 / review A).
-        return this.environmentOperations.runMutation(name, async () => {
-          await manager.createNamedEnvironment(name, language, request.packages)
-          return { environments: manager.listEnvironments() }
-        })
-      }
-      case 'list':
-        return { environments: manager.listEnvironments() }
-      case 'remove': {
-        const name = assertSafeEnvName(request.name)
-        // Remove-guard: only agent-created envs are removable. assertSafeEnvName already rejects the
-        // bare defaults, but a versioned app-managed env (default-python-3.13) would slip past it, so
-        // classify by provenance here and refuse anything that is not agent-created.
-        if (namedEnvProvenance(name) !== 'agent-created') {
-          throw new Error(
-            `Environment "${name}" is app-managed and cannot be removed. Only environments you ` +
-              'created with manage_environments(action:"create") can be removed.'
-          )
-        }
-        if (this.isEnvironmentLive(name)) {
-          throw new Error(
-            `Environment "${name}" is in use by a running kernel — restart the notebook or ` +
-              'wait for the run to finish before removing it.'
-          )
-        }
-        // Let startup recovery finish before rm -rf'ing a prefix, same barrier create uses: recovery's
-        // verify/rebuild of an interrupted op could otherwise race this delete on the same prefix.
-        await this.ensureRecovered()
-        // Refuse if recovery flagged this prefix possibly-live (an unknown-liveness orphan may still be
-        // writing it). After a restart there is no in-memory kernel state, so isEnvironmentLive() above
-        // can't see a surviving installer — without this, rm -rf could delete a named prefix a survivor
-        // is still writing. Mirrors the 'create' guard; keyed by the same real prefix.
-        this.assertPrefixRecoverable(envPrefix(getRuntimeRoot(this.options.dataRoot), name))
-        // Serialize the rm -rf against a concurrent install into the same env (design D4 / review A).
-        return this.environmentOperations.runMutation(name, async () => {
-          const environments = manager.removeEnvironment(name)
-          this.runtimeRepair.completeRemovedManagedEnvironment(name)
-          return { environments }
-        })
-      }
-    }
-  }
-
-  // True when any session has a live (spawned, not yet terminated) executor process bound to this env
-  // name. Derived from the per-process-key status map: a key whose status is not 'terminated' has a
-  // live proc (a run set it 'running'/'idle' and no idle-shutdown/crash has dropped it since). The
-  // repl key is env-agnostic and never blocks a named-env removal.
-  private isEnvironmentLive(name: string): boolean {
-    for (const session of this.sessions.values()) {
-      for (const [processKey, status] of session.kernelStatusEntries()) {
-        if (processKey === 'repl' || status === 'terminated') continue
-        if (processKey.slice(processKey.indexOf(':') + 1) === name) return true
-      }
-    }
-    return false
+    return this.environmentManagement.manage(request)
   }
 
   // Shuts down one session executor and removes its in-memory routing state.


### PR DESCRIPTION
## Problem

`NotebookRuntimeService` still owned named-environment validation, create/list/remove ordering,
live-kernel removal protection, manager configuration, and repair cleanup. These decisions made the
compatibility facade the only place that understood how Session state, recovery, environment locks,
the provisioner-backed manager, and repair state fit together.

Exact base: `8b57d6cb7c27b0e97376a7702dd3e21078ee3142`  
Exact head: `293b6ac7344c2c3aabc83ef023d88e887e5c61d5`

## Proposed change

Add `NotebookEnvironmentManagementOwner` with two composition-facing operations:

- `manage(request)` owns create/list/remove decisions and their ordering;
- `setManager(manager)` preserves the existing late-bound production provisioner seam.

The runtime service constructs the owner once and retains `manageEnvironments` and
`setEnvironmentManager` as stable compatibility delegates.

```mermaid
flowchart LR
  Callers["Existing Electron / Web / local RPC / MCP callers"] --> Facade["NotebookRuntimeService facade"]
  Facade -->|"manage"| Owner["Environment management owner"]
  Owner --> Manager["Provisioner-backed manager"]
  Owner --> Recovery["Recovery prefix gate"]
  Owner --> Lock["Environment mutation owner"]
  Owner --> Sessions["Live Session status"]
  Owner --> Repair["Runtime repair owner"]
```

Production raw diff: `234` lines (`+127/-107`), below the approved 600 target and 660 hard limit.
The runtime facade decreases from 1,533 to 1,442 physical lines.

## Scope and non-goals

- Preserve manager-first availability errors, environment-name validation, reserved/default handling,
  language validation, package forwarding, and the returned full environment list.
- Preserve create/remove recovery barriers, prefix recovery refusal, same-environment exclusive
  mutation, live-executor removal refusal, and repair cleanup after successful physical removal.
- Do not absorb default provisioning, runtime selection, package mutation, environment recovery,
  execution, or renderer progress projection.
- No application-command, IPC, preload, local-RPC, MCP, shared request/result, persisted data, schema,
  data-relationship, Settings UI, or Notebook UI changes.
- Electron, local/remote Web, Task/CLI, Specialist, Permission, and Compute behavior and existing
  capability asymmetries remain unchanged.
- No Issue #458 orchestration state or public interface is introduced.
- Squash merge only.

## Compatibility and risk

- All actions still reject first when no manager is configured; production still late-binds the same
  provisioner from the existing composition root.
- Create remains validation -> recovery -> prefix guard -> mutation slot -> create -> list.
- List remains a synchronous manager snapshot without recovery or mutation admission.
- Remove remains validation -> app-managed/live refusal -> recovery -> prefix guard -> mutation slot ->
  physical removal -> repair cleanup.
- Live use still scans every Session process status, ignores `repl` and `terminated`, and refuses any
  matching running/idle process.
- A failed physical removal does not clear repair state.
- Incoming #849 was audited before the final mechanical rebase: it changes only renderer Settings
  Connectors files, has zero file/semantic overlap, and the range-diff is `=`.

## Acceptance criteria and validation

All checks below ran after the final material edit and on the exact base/head above.

- New owner behavior, runtime facade, environment-name guards, local-RPC adapter, MCP surface, and
  export compatibility -> targeted Vitest impact set -> `6 files / 307 tests passed`.
- Authenticated local-RPC server dispatch and capability contracts -> isolated socket-enabled Vitest
  run -> `1 file / 25 tests passed`.
- Main-process contracts and consumers -> `npm run typecheck:node` -> passed.
- Changed Notebook production/tests -> targeted ESLint -> passed with zero findings.
- Changed Notebook production/tests -> targeted Prettier check -> passed.
- Final diff -> `git diff --check origin/main..HEAD` -> passed.
- Independent final exact-range review -> `Standards 0 / Spec 0`.

The socket suite was run outside the filesystem/network sandbox because the sandbox rejects existing
loopback and Unix-socket listeners with `EPERM`; the same exact-head suite passed there. No local
platform E2E was run because process spawning, transport implementations, renderer code, and platform
routing are unchanged. Repository PR Gate remains authoritative for selected online lanes.

## Review focus

- Verify the facade contains only stable compatibility delegates and no shadow manager/live state.
- Verify create/remove preserve recovery and same-environment mutation ordering.
- Verify app-managed and live Session guards run before destructive removal.
- Verify repair state is cleared only after the manager successfully removes the environment.
- Verify manager late binding and the exported compatibility type remain unchanged.
