### PR TITLE
fix(release): retry transient DMG detach failures

### DIFF
--- a/patches/dmg-builder+26.15.3.patch
+++ b/patches/dmg-builder+26.15.3.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/dmg-builder/out/dmgUtil.js b/node_modules/dmg-builder/out/dmgUtil.js
+--- a/node_modules/dmg-builder/out/dmgUtil.js
++++ b/node_modules/dmg-builder/out/dmgUtil.js
+@@ -191,7 +191,7 @@ async function customizeDmg({ appPath, artifactPath, volumeName, specification,
+     const settingsFile = await packager.getTempFile(".json");
+     await (0, fs_extra_1.writeFile)(settingsFile, JSON.stringify(settings, null, 2));
+     const dmgbuild = await getDmgVendorPath();
+-    await (0, toolsetLock_1.withToolsetLock)(() => (0, builder_util_1.exec)(dmgbuild, ["-s", settingsFile, path.basename(volumePath), artifactPath], {
++    await (0, toolsetLock_1.withToolsetLock)(() => (0, builder_util_1.exec)(dmgbuild, ["--detach-retries", "30", "-s", settingsFile, path.basename(volumePath), artifactPath], {
+         env: {
+             ...process.env,
+             PYTHONIOENCODING: "utf8",


### PR DESCRIPTION
## Problem

The merged package-certification change moved macOS x64 onto the native `macos-15-intel` runner, but Nightly run https://github.com/aipoch/open-science/actions/runs/31105311449 failed while `electron-builder` generated the DMG. The bundled `dmgbuild` process exhausted its default five detach attempts with `hdiutil: couldn't eject "disk2" - Resource busy`.

This occurs inside DMG creation, before the package smoke script and independently of keychain access.

## Proposed change

Patch the locked `dmg-builder@26.15.3` package through the repository's existing `patch-package` flow so it invokes the upstream-supported `--detach-retries 30` option. Thirty is the tool's supported maximum.

## Scope and non-goals

- Changes only macOS DMG construction retry tolerance.
- Adds no dependency and does not retry unrelated build failures.
- Does not change application architecture, data models, data relationships, or user interaction.
- Does not alter Windows/Linux packaging or runtime behavior.

## Acceptance criteria and validation

Final checks ran after the last material edit:

- `dmg-builder` patch compatibility -> `patch --dry-run -p1 ...` -> passed.
- Type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 17 pre-existing warnings and no errors.
- Portable suite -> `npm test` -> 821 files passed, 12,063 tests passed, 184 skipped.

The first sandboxed test attempt was discarded because sandbox policy denied loopback and Unix socket listeners with `EPERM`; the same command passed outside that restriction.

## Review focus

Please verify that extending the supported detach retry count is preferable to retrying the entire `electron-builder` command. The remaining platform-specific risk is the actual hosted Intel DMG path, which can only be proven by the macOS x64 CI lane.
