### PR TITLE
refactor(notebook): extract session read model

### DIFF
--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -15,7 +15,6 @@ import type {
   ExportNotebookKernelRequest,
   ExportNotebookResult,
   FinishNotebookCodeCellRequest,
-  NotebookEnvironmentStatus,
   NotebookKernelMetadata,
   NotebookLanguage,
   NotebookRunRecord,
@@ -99,6 +98,7 @@ import {
   type NotebookControlCompletionInterceptor,
   type NotebookControlResult
 } from './execution-owner'
+import { NotebookSessionReadModel, type NotebookHandoffContext } from './session-read-model'
 
 // Locale fallback when no explicit locale is injected (see shared/mirror.ts: non-CN locales resolve
 // to public hosts, so this default never silently forces a CN mirror).
@@ -152,30 +152,6 @@ type NotebookExecutorLifecycleCallbacks = {
 type NotebookRuntimeServiceCallbacks = {
   onNotebookAvailable?: (event: NotebookSessionReference) => void
   onNotebookChanged?: (event: NotebookSessionReference) => void
-}
-
-type NotebookHandoffContext = {
-  activeRunId?: string
-  activeWriteCellId?: string
-  executionCount: number
-  cells: Array<{
-    id: string
-    language: NotebookLanguage
-    status: NotebookCell['status']
-    executionCount?: number
-    latestRunId?: string
-  }>
-  kernels: Array<{
-    kind: NotebookLanguage | 'repl'
-    status: NotebookKernelMetadata['lastKnownStatus']
-  }>
-  runtimes: Array<{
-    language: NotebookLanguage
-    label: string
-    version?: string
-    status?: NotebookRuntimeBinding['status']
-    reason?: NotebookRuntimeBinding['reason']
-  }>
 }
 
 // The session-scoped connector RPC capability injected into the persistent control-plane REPL. The
@@ -358,6 +334,7 @@ class NotebookRuntimeService {
   private readonly repairPolicy: NotebookRuntimeRepairPolicy
   private readonly runtimeRepair: NotebookRuntimeRepairOwner
   private readonly sessions: NotebookSessionRegistry<RuntimeSession>
+  private readonly sessionReadModel: NotebookSessionReadModel<RuntimeSession>
   private readonly announcedAgentSessionIds = new Set<string>()
   // Owns process-global operation admission, provisioning progress, restart recommendations,
   // revocation drains, repair blocks, and installer diagnostics. The service remains the compatibility
@@ -421,6 +398,15 @@ class NotebookRuntimeService {
       sessions: () => this.sessions.values(),
       notifyChanged: (session) => this.notifyNotebookChanged(session as RuntimeSession),
       logger: this.runtimeLogger
+    })
+    this.sessionReadModel = new NotebookSessionReadModel({
+      storageRoot: options.dataRoot,
+      defaultProjectName: options.projectName,
+      repository: this.repository,
+      findSession: (sessionId) => this.sessions.get(sessionId),
+      runtimeBindings: (session) => this.runtimeBindingOwner.snapshot(session),
+      isRestartRecommended: (processKey) =>
+        this.environmentOperations.isRestartRecommended(processKey)
     })
     this.runtimeRepair = new NotebookRuntimeRepairOwner({
       runtimeRoot,
@@ -787,54 +773,7 @@ class NotebookRuntimeService {
   // never used (or was intentionally shut down for a Branch change), so this must not call
   // ensureSession(), load run.json, discover runtimes, or create an executor.
   peekHandoffContext(sessionId: string): NotebookHandoffContext | undefined {
-    const session = this.sessions.get(sessionId)
-    if (!session) return undefined
-
-    const snapshot = session.snapshot()
-    const kernels: NotebookHandoffContext['kernels'] = snapshot.kernelStatuses
-      .filter(([, status]) => status !== 'terminated')
-      .slice(-6)
-      .map(([processKey, status]) => ({
-        kind: processKey === 'repl' ? 'repl' : processKey.startsWith('r:') ? 'r' : 'python',
-        status
-      }))
-    const runtimes = session
-      .runtimeBindingEntries()
-      .slice(-4)
-      .map(([language, binding]) => ({
-        language,
-        label: binding.label,
-        ...(binding.version ? { version: binding.version } : {}),
-        ...(binding.status ? { status: binding.status } : {}),
-        ...(binding.reason ? { reason: binding.reason } : {})
-      }))
-    const cells = snapshot.cells.slice(-6).map((cell) => ({
-      id: cell.id,
-      language: cell.language,
-      status: cell.status,
-      ...(cell.executionCount === undefined ? {} : { executionCount: cell.executionCount }),
-      ...(cell.latestRunId ? { latestRunId: cell.latestRunId } : {})
-    }))
-
-    if (
-      snapshot.executionCount === 0 &&
-      !snapshot.activeRunId &&
-      !snapshot.activeWrite &&
-      cells.length === 0 &&
-      kernels.length === 0 &&
-      runtimes.length === 0
-    ) {
-      return undefined
-    }
-
-    return {
-      executionCount: snapshot.executionCount,
-      ...(snapshot.activeRunId ? { activeRunId: snapshot.activeRunId } : {}),
-      ...(snapshot.activeWrite ? { activeWriteCellId: snapshot.activeWrite.cellId } : {}),
-      cells,
-      kernels,
-      runtimes
-    }
+    return this.sessionReadModel.peekHandoffContext(sessionId)
   }
 
   // Returns the current in-memory cells plus the complete persisted run history.
@@ -842,54 +781,7 @@ class NotebookRuntimeService {
     request: NotebookSessionRequest
   ): Promise<NotebookSessionState & { runtimeBindings: NotebookRuntimeBindings }> {
     const session = await this.ensureSession(request)
-    const document = await this.repository.loadOrCreate({
-      projectName: session.projectName,
-      sessionId: session.sessionId,
-      workspaceCwd: session.cwd
-    })
-    const snapshot = session.snapshot()
-
-    return {
-      id: session.id,
-      sessionId: session.sessionId,
-      cwd: session.cwd,
-      notebookSessionRoot: session.notebookSessionRoot,
-      dataRoot: session.dataRoot,
-      runtimeRoot: session.runtimeRoot,
-      pythonPath: document.kernel.pythonPath,
-      kernelStatus: document.kernel.lastKnownStatus,
-      runJsonPath: session.runJsonPath,
-      cells: snapshot.cells.map((cell) => ({ ...cell })),
-      activeWrite: snapshot.activeWrite ? { ...snapshot.activeWrite } : undefined,
-      activeRunId: snapshot.activeRunId,
-      // run.json retains managed storage keys for later Artifact evidence, but no renderer/agent
-      // state response may expose them.
-      runs: document.runs.map((run) => this.toPublicRunRecord(run)),
-      recentRuns: document.runs.slice(-20).map((run) => this.toPublicRunRecord(run)),
-      environments: this.buildEnvironmentStatuses(session),
-      // v4 session runtime bindings (notebook_state surfaces the current python/r bindings).
-      runtimeBindings: this.runtimeBindingOwner.snapshot(session)
-    }
-  }
-
-  // Projects the session's live per-process-key status map into the wire shape state()'s consumers
-  // (the multi-env preview / T8) read: one entry per (kind, env) the session has spawned. The coarse
-  // top-level kernelStatus stays the DEFAULT env's status for backward compat; this is the per-env view.
-  private buildEnvironmentStatuses(session: RuntimeSession): NotebookEnvironmentStatus[] {
-    return session.kernelStatusEntries().map(([processKey, status]) => {
-      if (processKey === 'repl') {
-        return { processKey, kind: 'repl', status }
-      }
-      const separator = processKey.indexOf(':')
-      const kind = processKey.slice(0, separator) === 'r' ? 'r' : 'python'
-      return {
-        processKey,
-        kind,
-        environment: processKey.slice(separator + 1),
-        status,
-        restartRecommended: this.environmentOperations.isRestartRecommended(processKey)
-      }
-    })
+    return this.sessionReadModel.state(session)
   }
 
   // Resolves the durable reference for a session, preferring the live runtime session but falling
@@ -897,29 +789,7 @@ class NotebookRuntimeService {
   async getSessionReference(
     request: NotebookSessionRequest
   ): Promise<NotebookSessionReference | null> {
-    const existing = this.sessions.get(request.sessionId)
-
-    if (existing) {
-      return this.toSessionReference(existing)
-    }
-
-    const projectName = request.projectName ?? this.options.projectName
-    const document = await this.repository.findExisting(projectName, request.sessionId)
-
-    if (!document) {
-      return null
-    }
-
-    // Roots come from run.json normalization so a rehydrated entry matches the live one exactly.
-    return {
-      sessionId: request.sessionId,
-      projectName,
-      workspaceCwd: document.workspaceCwd,
-      notebookSessionRoot: document.notebookSessionRoot,
-      dataRoot: document.dataRoot,
-      runtimeRoot: document.kernel.runtimeRoot,
-      runJsonPath: getNotebookRunJsonPath(this.options.dataRoot, projectName, request.sessionId)
-    }
+    return this.sessionReadModel.getSessionReference(request)
   }
 
   // Exports the .ipynb for the kernel the caller is currently viewing (tab = choose language).
@@ -1367,60 +1237,22 @@ class NotebookRuntimeService {
     }
   }
 
-  // Creates the small event payload used by renderer listeners and preview tabs.
-  private toSessionReference(session: RuntimeSession): NotebookSessionReference {
-    return {
-      sessionId: session.sessionId,
-      projectName: session.projectName,
-      workspaceCwd: session.cwd,
-      notebookSessionRoot: session.notebookSessionRoot,
-      dataRoot: session.dataRoot,
-      runtimeRoot: session.runtimeRoot,
-      runJsonPath: session.runJsonPath
-    }
-  }
-
   // Announces notebook availability only once per agent-started session.
   private notifyNotebookAvailable(session: RuntimeSession, source: NotebookRunSource): void {
     if (source !== 'agent' || this.announcedAgentSessionIds.has(session.sessionId)) return
 
     this.announcedAgentSessionIds.add(session.sessionId)
-    this.options.callbacks?.onNotebookAvailable?.(this.toSessionReference(session))
+    this.options.callbacks?.onNotebookAvailable?.(this.sessionReadModel.toSessionReference(session))
   }
 
   // Broadcasts state invalidation so the renderer can reload run.json and in-memory cell data.
   private notifyNotebookChanged(session: RuntimeSession): void {
-    this.options.callbacks?.onNotebookChanged?.(this.toSessionReference(session))
+    this.options.callbacks?.onNotebookChanged?.(this.sessionReadModel.toSessionReference(session))
   }
 
   // Adds notebook roots and kernel metadata to the run returned to MCP callers.
   private toRunSummary(session: RuntimeSession, run: NotebookRunRecord): NotebookRunSummary {
-    const publicRun = this.toPublicRunRecord(run)
-    const inputFiles = (run.inputFiles ?? []).map((input) => {
-      const publicInput = { ...input } as Partial<typeof input>
-      delete publicInput.storageKey
-      return publicInput as NotebookRunSummary['inputFiles'][number]
-    })
-    return {
-      ...publicRun,
-      inputFiles,
-      notebookSessionRoot: session.notebookSessionRoot,
-      dataRoot: session.dataRoot,
-      runtimeRoot: getRuntimeRoot(this.options.dataRoot),
-      kernelName: 'python3'
-    }
-  }
-
-  private toPublicRunRecord(run: NotebookRunRecord): NotebookRunRecord {
-    const inputFiles = (run.inputFiles ?? []).map((input) => {
-      const publicInput = { ...input } as Partial<typeof input>
-      delete publicInput.storageKey
-      return publicInput
-    })
-    // NotebookRunRecord is also the legacy renderer shape. The boundary deliberately omits the
-    // internal-only required key while keeping every public input field; persisted records remain
-    // strongly typed and complete inside the repository.
-    return { ...run, inputFiles } as NotebookRunRecord
+    return this.sessionReadModel.toRunSummary(session, run)
   }
 }
 

--- a/src/main/notebook/session-read-model.test.ts
+++ b/src/main/notebook/session-read-model.test.ts
@@ -1,0 +1,222 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
+import { NotebookSessionReadModel, type NotebookSessionReadSource } from './session-read-model'
+import type { NotebookSessionSnapshot } from './session-aggregate'
+
+let root: string | undefined
+
+const createRoot = async (): Promise<string> => {
+  root = await mkdtemp(join(tmpdir(), 'notebook-read-model-'))
+  return root
+}
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true })
+  root = undefined
+})
+
+const makeSession = (
+  storageRoot: string,
+  snapshotOverrides: Partial<NotebookSessionSnapshot> = {},
+  withRuntimeBinding = false
+): NotebookSessionReadSource => {
+  const sessionId = 'session-1'
+  const projectName = 'default-project'
+  const notebookSessionRoot = join(storageRoot, 'notebooks', projectName, sessionId)
+  const snapshot: NotebookSessionSnapshot = {
+    id: `notebook-session-${sessionId}`,
+    sessionId,
+    projectName,
+    cwd: join(storageRoot, 'workspace'),
+    notebookSessionRoot,
+    dataRoot: join(notebookSessionRoot, 'data'),
+    runtimeRoot: getRuntimeRoot(storageRoot),
+    runJsonPath: join(notebookSessionRoot, 'run.json'),
+    cells: [],
+    executionCount: 0,
+    kernelStatuses: [],
+    ...snapshotOverrides
+  }
+  return {
+    id: snapshot.id,
+    sessionId,
+    projectName,
+    cwd: snapshot.cwd,
+    notebookSessionRoot,
+    dataRoot: snapshot.dataRoot,
+    runtimeRoot: snapshot.runtimeRoot,
+    runJsonPath: snapshot.runJsonPath,
+    snapshot: () => snapshot,
+    kernelStatusEntries: () => snapshot.kernelStatuses.map((entry) => [...entry]),
+    runtimeBindingEntries: () =>
+      withRuntimeBinding
+        ? [
+            [
+              'python',
+              {
+                runtimeId: 'managed-python',
+                language: 'python',
+                label: 'Python 3.13',
+                source: 'managed',
+                provenance: 'app-managed',
+                interpreterPath: join(getRuntimeRoot(storageRoot), 'python'),
+                status: 'active'
+              }
+            ]
+          ]
+        : []
+  }
+}
+
+const makeReadModel = (
+  storageRoot: string,
+  session: NotebookSessionReadSource | undefined,
+  repository = new NotebookRunRepository(storageRoot)
+): NotebookSessionReadModel<NotebookSessionReadSource> =>
+  new NotebookSessionReadModel({
+    storageRoot,
+    defaultProjectName: 'default-project',
+    repository,
+    findSession: vi.fn(() => session),
+    runtimeBindings: () => ({
+      python: {
+        runtimeId: 'managed-python',
+        language: 'python',
+        label: 'Python 3.13',
+        source: 'managed',
+        provenance: 'app-managed',
+        interpreterPath: join(getRuntimeRoot(storageRoot), 'python'),
+        status: 'active'
+      }
+    }),
+    isRestartRecommended: (processKey) => processKey === 'r:analysis'
+  })
+
+describe('NotebookSessionReadModel', () => {
+  it('returns only actionable live handoff data and never consults durable storage', async () => {
+    const storageRoot = await createRoot()
+    const repository = new NotebookRunRepository(storageRoot)
+    const findExisting = vi.spyOn(repository, 'findExisting')
+    const empty = makeSession(storageRoot)
+
+    expect(
+      makeReadModel(storageRoot, undefined, repository).peekHandoffContext('missing')
+    ).toBeUndefined()
+    expect(
+      makeReadModel(storageRoot, empty, repository).peekHandoffContext('session-1')
+    ).toBeUndefined()
+
+    const active = makeSession(
+      storageRoot,
+      {
+        executionCount: 8,
+        activeRunId: 'run-8',
+        cells: [
+          { id: 'cell-8', language: 'r', code: '1 + 1', status: 'running', latestRunId: 'run-8' }
+        ],
+        kernelStatuses: [
+          ['python:default-python', 'terminated'],
+          ['r:analysis', 'running']
+        ]
+      },
+      true
+    )
+    expect(makeReadModel(storageRoot, active, repository).peekHandoffContext('session-1')).toEqual({
+      activeRunId: 'run-8',
+      executionCount: 8,
+      cells: [{ id: 'cell-8', language: 'r', status: 'running', latestRunId: 'run-8' }],
+      kernels: [{ kind: 'r', status: 'running' }],
+      runtimes: [{ language: 'python', label: 'Python 3.13', status: 'active' }]
+    })
+    expect(findExisting).not.toHaveBeenCalled()
+  })
+
+  it('combines the live aggregate with durable history and preserves environment projection', async () => {
+    const storageRoot = await createRoot()
+    const repository = new NotebookRunRepository(storageRoot)
+    const session = makeSession(storageRoot, {
+      cells: [{ id: 'cell-1', language: 'python', code: '1', status: 'completed' }],
+      kernelStatuses: [
+        ['repl', 'idle'],
+        ['r:analysis', 'running']
+      ]
+    })
+    await repository.loadOrCreate({
+      projectName: session.projectName,
+      sessionId: session.sessionId,
+      workspaceCwd: session.cwd,
+      pythonPath: join(getRuntimeRoot(storageRoot), 'python')
+    })
+
+    const state = await makeReadModel(storageRoot, session, repository).state(session)
+
+    expect(state).toMatchObject({
+      id: session.id,
+      sessionId: session.sessionId,
+      pythonPath: join(getRuntimeRoot(storageRoot), 'python'),
+      cells: [{ id: 'cell-1', status: 'completed' }],
+      runs: [],
+      recentRuns: [],
+      environments: [
+        { processKey: 'repl', kind: 'repl', status: 'idle' },
+        {
+          processKey: 'r:analysis',
+          kind: 'r',
+          environment: 'analysis',
+          status: 'running',
+          restartRecommended: true
+        }
+      ],
+      runtimeBindings: { python: { runtimeId: 'managed-python' } }
+    })
+  })
+
+  it('prefers a live reference and otherwise falls back to normalized durable roots', async () => {
+    const storageRoot = await createRoot()
+    const repository = new NotebookRunRepository(storageRoot)
+    const session = makeSession(storageRoot, { cwd: String.raw`C:\Users\analyst\workspace` })
+    const liveModel = makeReadModel(storageRoot, session, repository)
+
+    await expect(
+      liveModel.getSessionReference({
+        sessionId: session.sessionId,
+        workspaceCwd: join(storageRoot, 'ignored')
+      })
+    ).resolves.toEqual(liveModel.toSessionReference(session))
+    expect(liveModel.toSessionReference(session).workspaceCwd).toBe(
+      String.raw`C:\Users\analyst\workspace`
+    )
+
+    const persistedWorkspace = join(storageRoot, 'persisted-workspace')
+    await repository.loadOrCreate({
+      projectName: session.projectName,
+      sessionId: session.sessionId,
+      workspaceCwd: persistedWorkspace
+    })
+    const durableModel = makeReadModel(storageRoot, undefined, repository)
+    await expect(
+      durableModel.getSessionReference({
+        sessionId: session.sessionId,
+        workspaceCwd: join(storageRoot, 'ignored')
+      })
+    ).resolves.toEqual({
+      sessionId: session.sessionId,
+      projectName: session.projectName,
+      workspaceCwd: persistedWorkspace,
+      notebookSessionRoot: session.notebookSessionRoot,
+      dataRoot: session.dataRoot,
+      runtimeRoot: session.runtimeRoot,
+      runJsonPath: getNotebookRunJsonPath(storageRoot, session.projectName, session.sessionId)
+    })
+    await expect(
+      durableModel.getSessionReference({
+        sessionId: 'missing',
+        workspaceCwd: join(storageRoot, 'ignored')
+      })
+    ).resolves.toBeNull()
+  })
+})

--- a/src/main/notebook/session-read-model.ts
+++ b/src/main/notebook/session-read-model.ts
@@ -1,0 +1,223 @@
+import type {
+  NotebookCell,
+  NotebookEnvironmentStatus,
+  NotebookKernelMetadata,
+  NotebookLanguage,
+  NotebookRunRecord,
+  NotebookRunSummary,
+  NotebookSessionReference,
+  NotebookSessionRequest,
+  NotebookSessionState
+} from '../../shared/notebook'
+import type { NotebookRuntimeBinding, NotebookRuntimeBindings } from '../../shared/notebook-runtime'
+import { getNotebookRunJsonPath, getRuntimeRoot, NotebookRunRepository } from './repository'
+import type { NotebookSessionSnapshot } from './session-aggregate'
+
+type NotebookHandoffContext = {
+  activeRunId?: string
+  activeWriteCellId?: string
+  executionCount: number
+  cells: Array<{
+    id: string
+    language: NotebookLanguage
+    status: NotebookCell['status']
+    executionCount?: number
+    latestRunId?: string
+  }>
+  kernels: Array<{
+    kind: NotebookLanguage | 'repl'
+    status: NotebookKernelMetadata['lastKnownStatus']
+  }>
+  runtimes: Array<{
+    language: NotebookLanguage
+    label: string
+    version?: string
+    status?: NotebookRuntimeBinding['status']
+    reason?: NotebookRuntimeBinding['reason']
+  }>
+}
+
+type NotebookSessionReadSource = {
+  readonly id: string
+  readonly sessionId: string
+  readonly projectName: string
+  readonly cwd: string
+  readonly notebookSessionRoot: string
+  readonly dataRoot: string
+  readonly runtimeRoot: string
+  readonly runJsonPath: string
+  snapshot: () => NotebookSessionSnapshot
+  kernelStatusEntries: () => Array<[string, NotebookKernelMetadata['lastKnownStatus']]>
+  runtimeBindingEntries: () => Array<[NotebookLanguage, NotebookRuntimeBinding]>
+}
+
+type NotebookSessionReadModelOptions<Session extends NotebookSessionReadSource> = {
+  storageRoot: string
+  defaultProjectName: string
+  repository: NotebookRunRepository
+  findSession: (sessionId: string) => Session | undefined
+  runtimeBindings: (session: Session) => NotebookRuntimeBindings
+  isRestartRecommended: (processKey: string) => boolean
+}
+
+// Projects live Session Aggregate state and durable run history without owning either source.
+class NotebookSessionReadModel<Session extends NotebookSessionReadSource> {
+  constructor(private readonly options: NotebookSessionReadModelOptions<Session>) {}
+
+  // A handoff peek must never create a Session or read disk: absent/non-actionable live state is absent.
+  peekHandoffContext(sessionId: string): NotebookHandoffContext | undefined {
+    const session = this.options.findSession(sessionId)
+    if (!session) return undefined
+
+    const snapshot = session.snapshot()
+    const kernels: NotebookHandoffContext['kernels'] = snapshot.kernelStatuses
+      .filter(([, status]) => status !== 'terminated')
+      .slice(-6)
+      .map(([processKey, status]) => ({
+        kind: processKey === 'repl' ? 'repl' : processKey.startsWith('r:') ? 'r' : 'python',
+        status
+      }))
+    const runtimes = session
+      .runtimeBindingEntries()
+      .slice(-4)
+      .map(([language, binding]) => ({
+        language,
+        label: binding.label,
+        ...(binding.version ? { version: binding.version } : {}),
+        ...(binding.status ? { status: binding.status } : {}),
+        ...(binding.reason ? { reason: binding.reason } : {})
+      }))
+    const cells = snapshot.cells.slice(-6).map((cell) => ({
+      id: cell.id,
+      language: cell.language,
+      status: cell.status,
+      ...(cell.executionCount === undefined ? {} : { executionCount: cell.executionCount }),
+      ...(cell.latestRunId ? { latestRunId: cell.latestRunId } : {})
+    }))
+
+    if (
+      snapshot.executionCount === 0 &&
+      !snapshot.activeRunId &&
+      !snapshot.activeWrite &&
+      cells.length === 0 &&
+      kernels.length === 0 &&
+      runtimes.length === 0
+    ) {
+      return undefined
+    }
+
+    return {
+      executionCount: snapshot.executionCount,
+      ...(snapshot.activeRunId ? { activeRunId: snapshot.activeRunId } : {}),
+      ...(snapshot.activeWrite ? { activeWriteCellId: snapshot.activeWrite.cellId } : {}),
+      cells,
+      kernels,
+      runtimes
+    }
+  }
+
+  async state(
+    session: Session
+  ): Promise<NotebookSessionState & { runtimeBindings: NotebookRuntimeBindings }> {
+    const document = await this.options.repository.loadOrCreate({
+      projectName: session.projectName,
+      sessionId: session.sessionId,
+      workspaceCwd: session.cwd
+    })
+    const snapshot = session.snapshot()
+
+    return {
+      id: session.id,
+      sessionId: session.sessionId,
+      cwd: session.cwd,
+      notebookSessionRoot: session.notebookSessionRoot,
+      dataRoot: session.dataRoot,
+      runtimeRoot: session.runtimeRoot,
+      pythonPath: document.kernel.pythonPath,
+      kernelStatus: document.kernel.lastKnownStatus,
+      runJsonPath: session.runJsonPath,
+      cells: snapshot.cells.map((cell) => ({ ...cell })),
+      activeWrite: snapshot.activeWrite ? { ...snapshot.activeWrite } : undefined,
+      activeRunId: snapshot.activeRunId,
+      runs: document.runs.map((run) => this.toPublicRunRecord(run)),
+      recentRuns: document.runs.slice(-20).map((run) => this.toPublicRunRecord(run)),
+      environments: this.environmentStatuses(session),
+      runtimeBindings: this.options.runtimeBindings(session)
+    }
+  }
+
+  async getSessionReference(
+    request: NotebookSessionRequest
+  ): Promise<NotebookSessionReference | null> {
+    const live = this.options.findSession(request.sessionId)
+    if (live) return this.toSessionReference(live)
+
+    const projectName = request.projectName ?? this.options.defaultProjectName
+    const document = await this.options.repository.findExisting(projectName, request.sessionId)
+    if (!document) return null
+
+    return {
+      sessionId: request.sessionId,
+      projectName,
+      workspaceCwd: document.workspaceCwd,
+      notebookSessionRoot: document.notebookSessionRoot,
+      dataRoot: document.dataRoot,
+      runtimeRoot: document.kernel.runtimeRoot,
+      runJsonPath: getNotebookRunJsonPath(this.options.storageRoot, projectName, request.sessionId)
+    }
+  }
+
+  toSessionReference(session: Session): NotebookSessionReference {
+    return {
+      sessionId: session.sessionId,
+      projectName: session.projectName,
+      workspaceCwd: session.cwd,
+      notebookSessionRoot: session.notebookSessionRoot,
+      dataRoot: session.dataRoot,
+      runtimeRoot: session.runtimeRoot,
+      runJsonPath: session.runJsonPath
+    }
+  }
+
+  toRunSummary(session: Session, run: NotebookRunRecord): NotebookRunSummary {
+    const inputFiles = (run.inputFiles ?? []).map((input) => {
+      const publicInput = { ...input } as Partial<typeof input>
+      delete publicInput.storageKey
+      return publicInput as NotebookRunSummary['inputFiles'][number]
+    })
+    return {
+      ...this.toPublicRunRecord(run),
+      inputFiles,
+      notebookSessionRoot: session.notebookSessionRoot,
+      dataRoot: session.dataRoot,
+      runtimeRoot: getRuntimeRoot(this.options.storageRoot),
+      kernelName: 'python3'
+    }
+  }
+
+  private environmentStatuses(session: Session): NotebookEnvironmentStatus[] {
+    return session.kernelStatusEntries().map(([processKey, status]) => {
+      if (processKey === 'repl') return { processKey, kind: 'repl', status }
+      const separator = processKey.indexOf(':')
+      return {
+        processKey,
+        kind: processKey.slice(0, separator) === 'r' ? 'r' : 'python',
+        environment: processKey.slice(separator + 1),
+        status,
+        restartRecommended: this.options.isRestartRecommended(processKey)
+      }
+    })
+  }
+
+  private toPublicRunRecord(run: NotebookRunRecord): NotebookRunRecord {
+    const inputFiles = (run.inputFiles ?? []).map((input) => {
+      const publicInput = { ...input } as Partial<typeof input>
+      delete publicInput.storageKey
+      return publicInput
+    })
+    return { ...run, inputFiles } as NotebookRunRecord
+  }
+}
+
+export { NotebookSessionReadModel }
+export type { NotebookHandoffContext, NotebookSessionReadModelOptions, NotebookSessionReadSource }


### PR DESCRIPTION
## Problem

`NotebookRuntimeService` still owned multiple read-only projections alongside command orchestration: live handoff context, notebook state, durable session references, event references, and public run summaries. This kept read-model policy coupled to the compatibility facade and made later lifecycle extraction harder to review safely.

Related context: #458. This PR only preserves a forward-compatible ownership boundary; it does not add orchestration state or public interfaces.

## Proposed change

Extract `NotebookSessionReadModel` as the single read-only projection owner. `NotebookRuntimeService` remains the public compatibility facade and continues to own Session creation/admission before delegating reads.

```mermaid
flowchart LR
  A["Electron / Web / CLI adapters"] --> F["NotebookRuntimeService facade"]
  F --> R["NotebookSessionReadModel"]
  R --> S["Live Session Aggregate"]
  R --> D["Durable run repository"]
  R --> P["Existing public payloads"]
```

The owner has no cache, subscription bus, mutable Session state, or persisted read-model state.

## Scope and non-goals

- Move live-only `peekHandoffContext` projection without disk reload or Session creation.
- Move state composition while preserving run order, `recentRuns` last-20 behavior, runtime bindings, and per-environment status/restart flags.
- Move live-first/durable-fallback Session reference projection.
- Share the existing event reference and public run-summary projection, including removal of internal `storageKey` fields.
- Keep every public method, IPC/RPC/MCP payload, filter, order, and status unchanged.
- Keep Electron, Web, CLI, Specialist, Permission, and Compute capabilities/asymmetries unchanged.
- Do not change shared/preload schemas, persistence, data relationships, user interaction, or Issue #458 orchestration contracts.

## Acceptance criteria and validation

Final evidence mapping; all commands ran after the last material edit and again after rebasing onto exact base `bda9dcc6`:

- Live/missing/actionable handoff and durable/live reference fallback -> `npm test -- --run src/main/notebook/session-read-model.test.ts` -> 3/3 passed.
- Facade state, run/reference/event projection and Electron/IPC/MCP/workflow consumers -> `npm test -- --run src/main/notebook/session-read-model.test.ts src/main/notebook/runtime-service.test.ts src/main/notebook/application.test.ts src/main/notebook/ipc.test.ts src/main/notebook/notebook-workflows.test.ts src/main/notebook/mcp-server.test.ts` -> 250/250 passed.
- Local RPC bridge compatibility -> `npm test -- --run src/main/notebook/local-rpc-server.test.ts` -> 25/25 passed; production code was unchanged after this check, and the final edit only made test path fixtures portable.
- Node process types -> `npm run typecheck:node` -> passed.
- Changed-file lint/style -> targeted ESLint and Prettier checks -> passed.
- Patch integrity -> `git diff --check` -> passed.
- Cross-platform path audit -> production uses repository/path helpers; tests use `path.join` and include a Windows-style workspace passthrough fixture -> passed.
- Independent review -> Standards 0 findings / Spec 0 findings.

Production raw is 425 lines (`runtime-service.ts` 17 additions + 185 deletions; owner 223 additions), below the 600 target without using the 660 tolerance. Test raw is 222 lines; total raw is 647. `runtime-service.ts` drops from 1,442 to 1,274 lines; the new owner is 223 lines.

Uncovered local risk: platform-specific packaging and execution lanes are delegated to PR Gate/online CI; this PR does not modify those paths.

## Review focus

- Confirm handoff remains live-only and never reads disk or creates a Session.
- Confirm run/history filtering, ordering, status, and durable fallback are byte-shape compatible.
- Confirm no new state owner, public contract, or cross-surface capability is introduced.
- Confirm the facade remains the only adapter-facing entry point.
