### PR TITLE
test(paths): make path assertions platform-independent

### DIFF
--- a/scripts/linux-package-smoke.test.ts
+++ b/scripts/linux-package-smoke.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -37,7 +37,7 @@ describe('Linux package smoke', () => {
   it('requires explicit package and installed executable paths', () => {
     expect(
       parseArguments(['--artifact-dir', 'dist', '--installed-executable', '/usr/bin/open-science'])
-    ).toMatchObject({ installedExecutable: '/usr/bin/open-science' })
+    ).toMatchObject({ installedExecutable: resolve('/usr/bin/open-science') })
     expect(() => parseArguments([])).toThrow(/Usage:/)
   })
 

--- a/src/main/acp/runtime-session-composition.test.ts
+++ b/src/main/acp/runtime-session-composition.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { ContextUsageTracker } from './context-usage-tracker'
@@ -26,7 +28,7 @@ describe('ACP Runtime session composition', () => {
     expect(first.reviewerSessions).not.toBe(second.reviewerSessions)
     expect(first.sessionUpdateProjector).not.toBe(second.sessionUpdateProjector)
     expect(first.publication.getSnapshot()).toMatchObject({
-      cwd: '/workspace',
+      cwd: resolve('/workspace'),
       sessionIds: [],
       contextUsageBySession: {}
     })


### PR DESCRIPTION
## Problem

The Windows Full Test run [31107540995](https://github.com/aipoch/open-science/actions/runs/31107540995) exposed two assertions that hard-coded POSIX path spellings even though the production code normalizes those paths with `node:path.resolve`.

## Proposed change

Use `resolve()` in the expected values for:

- the Linux package smoke installed executable path
- the ACP runtime publication working directory

This preserves the assertions' intent while allowing Node.js to produce the native Windows, macOS, or Linux path representation.

## Scope and non-goals

- Test-only change; no production behavior changes.
- No architecture, data model, data relationship, or user interaction changes.
- Does not address the four unrelated notebook RPC/package-admission failures in the referenced Windows run.

## Acceptance criteria and validation

Checks ran after the last material edit.

- Cross-platform normalized path assertions -> `vitest run scripts/linux-package-smoke.test.ts src/main/acp/runtime-session-composition.test.ts` -> passed (2 files, 5 tests).
- Repository lint -> `eslint --cache .` -> passed with 0 errors (17 pre-existing warnings outside the changed files).
- Complete portable suite -> `vitest run` -> not green locally: 815 files passed and 9 failed (34 tests), with unrelated existing/environment-specific failures including missing Bash, Windows symlink privilege, RPC/package-admission failures, and timeouts.

Consumer/typecheck lanes are excluded because no production interface or runtime implementation changed. Windows CI remains the authority for the complete real-Windows lane.

## Review focus

Confirm both expected values track the same `resolve()` normalization already performed by their respective production code and remain portable across Windows, macOS, and Linux.