### PR TITLE
fix(web): prevent crash when accessing Electron-only APIs via web gateway

### DIFF
--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -121,6 +121,23 @@ afterEach(() => {
 })
 
 describe('SpecialistsPanel', () => {
+  it('renders safely when the web surface omits the specialist API', async () => {
+    const specialistApi = window.api.specialist
+    delete (window.api as { specialist?: Window['api']['specialist'] }).specialist
+    useSpecialistStore.setState({ items: [], isLoaded: false })
+
+    try {
+      await act(async () => {
+        root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+      })
+
+      expect(document.body.textContent).toContain('No specialists yet')
+      expect(useSpecialistStore.getState().isLoaded).toBe(true)
+    } finally {
+      window.api.specialist = specialistApi
+    }
+  })
+
   // Shared preview fixture: builtin + owned selected by default, referenced skill unchecked.
   const exportPreviewFixture = (
     overrides: Partial<{

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -156,7 +156,8 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
     void load()
 
     // Subscribe to catalog-changed push events so the list stays in sync.
-    const unsub = window.api.specialist?.onCatalogChanged(() => void load())
+    if (typeof window.api?.specialist?.onCatalogChanged !== 'function') return () => {}
+    const unsub = window.api.specialist.onCatalogChanged(() => void load())
     return unsub
   }, [load])
 
@@ -270,8 +271,12 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
       setTemplateSaving(true)
       setTemplateSaveError(undefined)
       try {
-        const result = await window.api.specialist?.exportContributionTemplate()
-        if (result.saved) setTemplateSaved(true)
+        if (typeof window.api?.specialist?.exportContributionTemplate !== 'function') {
+          setTemplateSaveError('Contribution templates are only available in the desktop app.')
+          return
+        }
+        const result = await window.api.specialist.exportContributionTemplate()
+        if (result?.saved) setTemplateSaved(true)
       } catch {
         setTemplateSaveError('Could not save contribution template. Try again.')
       } finally {

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -156,7 +156,7 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
     void load()
 
     // Subscribe to catalog-changed push events so the list stays in sync.
-    if (typeof window.api?.specialist?.onCatalogChanged !== 'function') return () => {}
+    if (typeof window.api?.specialist?.onCatalogChanged !== 'function') return
     const unsub = window.api.specialist.onCatalogChanged(() => void load())
     return unsub
   }, [load])

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -156,7 +156,7 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
     void load()
 
     // Subscribe to catalog-changed push events so the list stays in sync.
-    const unsub = window.api.specialist.onCatalogChanged(() => void load())
+    const unsub = window.api.specialist?.onCatalogChanged(() => void load())
     return unsub
   }, [load])
 
@@ -270,7 +270,7 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
       setTemplateSaving(true)
       setTemplateSaveError(undefined)
       try {
-        const result = await window.api.specialist.exportContributionTemplate()
+        const result = await window.api.specialist?.exportContributionTemplate()
         if (result.saved) setTemplateSaved(true)
       } catch {
         setTemplateSaveError('Could not save contribution template. Try again.')

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.render.test.tsx
@@ -150,6 +150,15 @@ const renderSubmenu = (props: React.ComponentProps<typeof SpecialistSubmenu>): v
 }
 
 describe('SpecialistSubmenu — trigger', () => {
+  it('does not load the catalog when the specialist list API is unavailable', () => {
+    const load = vi.fn().mockResolvedValue(undefined)
+    mockStore([], { isLoaded: false, load })
+
+    renderSubmenu({ selectedId: undefined, onChange: vi.fn() })
+
+    expect(load).not.toHaveBeenCalled()
+  })
+
   it('renders a submenu trigger', () => {
     mockStore([])
     renderSubmenu({ selectedId: undefined, onChange: vi.fn() })

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
@@ -63,7 +63,7 @@ const SpecialistSubmenu = ({
 
   // Keep the list fresh when the specialist catalog changes elsewhere.
   useEffect(() => {
-    if (typeof window.api?.specialist?.onCatalogChanged !== 'function') return () => {}
+    if (typeof window.api?.specialist?.onCatalogChanged !== 'function') return
     const remove = window.api.specialist.onCatalogChanged(() => {
       void load()
     })

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
@@ -56,14 +56,15 @@ const SpecialistSubmenu = ({
   // Lazy-load on mount. This submenu only mounts when the parent menu opens
   // (DropdownMenuContent mounts its children on open), so this is open-time load.
   useEffect(() => {
-    if (!isLoaded) {
+    if (!isLoaded && typeof window.api?.specialist?.list === 'function') {
       void load()
     }
   }, [isLoaded, load])
 
   // Keep the list fresh when the specialist catalog changes elsewhere.
   useEffect(() => {
-    const remove = window.api.specialist?.onCatalogChanged(() => {
+    if (typeof window.api?.specialist?.onCatalogChanged !== 'function') return () => {}
+    const remove = window.api.specialist.onCatalogChanged(() => {
       void load()
     })
     return remove

--- a/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
+++ b/src/renderer/src/pages/workspace/SpecialistSubmenu.tsx
@@ -63,7 +63,7 @@ const SpecialistSubmenu = ({
 
   // Keep the list fresh when the specialist catalog changes elsewhere.
   useEffect(() => {
-    const remove = window.api.specialist.onCatalogChanged(() => {
+    const remove = window.api.specialist?.onCatalogChanged(() => {
       void load()
     })
     return remove

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -2199,10 +2199,10 @@ const WorkspacePage = ({
 
   // Subscribe to specialist catalog changes so unavailability state stays fresh.
   useEffect(() => {
-    // Guard: window.api.specialist may be absent in test/headless environments.
-    if (!window.api?.specialist) return
+    // Guard: specialist.list is Electron-only and unavailable in the web gateway.
+    if (typeof window.api?.specialist?.list !== 'function') return
     void loadSpecialists()
-    const remove = window.api.specialist?.onCatalogChanged(() => {
+    const remove = window.api.specialist.onCatalogChanged(() => {
       void loadSpecialists()
     })
     return remove
@@ -2219,7 +2219,7 @@ const WorkspacePage = ({
   // the completion gate, never by a renderer send barrier.
   useEffect(() => {
     if (!window.api?.specialist?.onPendingSwitch) return
-    const remove = window.api.specialist?.onPendingSwitch((pending) => {
+    const remove = window.api.specialist.onPendingSwitch((pending) => {
       // null target => revert to Main Agent. main already persisted the clear BEFORE broadcasting
       // (host.agents.switch(null) writes the Main binding, then notifies), so the renderer only
       // mirrors it here — no resolveSessionSpecialist round-trip is needed, unlike the named-target

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -2202,7 +2202,7 @@ const WorkspacePage = ({
     // Guard: window.api.specialist may be absent in test/headless environments.
     if (!window.api?.specialist) return
     void loadSpecialists()
-    const remove = window.api.specialist.onCatalogChanged(() => {
+    const remove = window.api.specialist?.onCatalogChanged(() => {
       void loadSpecialists()
     })
     return remove
@@ -2219,7 +2219,7 @@ const WorkspacePage = ({
   // the completion gate, never by a renderer send barrier.
   useEffect(() => {
     if (!window.api?.specialist?.onPendingSwitch) return
-    const remove = window.api.specialist.onPendingSwitch((pending) => {
+    const remove = window.api.specialist?.onPendingSwitch((pending) => {
       // null target => revert to Main Agent. main already persisted the clear BEFORE broadcasting
       // (host.agents.switch(null) writes the Main binding, then notifies), so the renderer only
       // mirrors it here — no resolveSessionSpecialist round-trip is needed, unlike the named-target

--- a/src/renderer/src/stores/specialist-store.test.ts
+++ b/src/renderer/src/stores/specialist-store.test.ts
@@ -18,6 +18,15 @@ beforeEach(() => {
   })
 })
 
+describe('specialist store catalog', () => {
+  it('treats a missing specialist list API as an unavailable catalog', async () => {
+    setSpecialistApi({})
+
+    await expect(useSpecialistStore.getState().load()).resolves.toBeUndefined()
+    expect(useSpecialistStore.getState()).toMatchObject({ items: [], isLoaded: true })
+  })
+})
+
 describe('specialist store package export', () => {
   it('keeps overlapping previews bound to their own Specialist export identity', async () => {
     let resolveFirst: ((value: SpecialistExportPreview) => void) | undefined

--- a/src/renderer/src/stores/specialist-store.ts
+++ b/src/renderer/src/stores/specialist-store.ts
@@ -55,6 +55,8 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
   exportPreview: undefined,
 
   load: async () => {
+    // Guard: specialist.list is Electron-only and unavailable in the web gateway.
+    if (typeof window.api?.specialist?.list !== 'function') return
     const items = await window.api.specialist.list()
     set({ items, isLoaded: true })
   },

--- a/src/renderer/src/stores/specialist-store.ts
+++ b/src/renderer/src/stores/specialist-store.ts
@@ -56,7 +56,10 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
 
   load: async () => {
     // Guard: specialist.list is Electron-only and unavailable in the web gateway.
-    if (typeof window.api?.specialist?.list !== 'function') return
+    if (typeof window.api?.specialist?.list !== 'function') {
+      set({ items: [], isLoaded: true })
+      return
+    }
     const items = await window.api.specialist.list()
     set({ items, isLoaded: true })
   },

--- a/src/renderer/web/api-installer.test.ts
+++ b/src/renderer/web/api-installer.test.ts
@@ -117,7 +117,7 @@ describe('installWebRendererContracts', () => {
   it('does not create namespaces for unavailable Electron-only contracts', () => {
     const api: Record<string, unknown> = {}
     installWebRendererContracts(api, {
-      availableRpcChannels: new Set(),
+      availableRpcChannels: new Set(['specialist:list']),
       restrictedRpcChannels: new Set(),
       invoke: vi.fn(),
       subscribe: vi.fn(),
@@ -130,23 +130,7 @@ describe('installWebRendererContracts', () => {
     expect(api.handoff).toBeUndefined()
     // officePreview.onState is ELECTRON_EVENT — namespace must not exist on web.
     expect(api.officePreview).toBeUndefined()
-  })
-
-  it('never installs specialist.list on the web surface', () => {
-    const api: Record<string, unknown> = {}
-    installWebRendererContracts(api, {
-      availableRpcChannels: new Set(['specialist:list']),
-      restrictedRpcChannels: new Set(),
-      invoke: vi.fn(),
-      subscribe: vi.fn(),
-      nativeAdapters: {}
-    })
-
-    // Even when the channel is in the available set, ELECTRON contracts are not
-    // installed on web — the web surface installation is always 'unavailable'.
     expect(methodAt(api, 'specialist.list')).toBeUndefined()
-    expect(methodAt(api, 'specialist.create')).toBeUndefined()
-    expect(methodAt(api, 'specialist.onCatalogChanged')).toBeUndefined()
   })
 
   it('accepts one test-local neutral descriptor in both renderer adapters', async () => {

--- a/src/renderer/web/api-installer.test.ts
+++ b/src/renderer/web/api-installer.test.ts
@@ -114,6 +114,41 @@ describe('installWebRendererContracts', () => {
     expect(methodAt(api, 'projects.list')).toBeUndefined()
   })
 
+  it('does not create namespaces for unavailable Electron-only contracts', () => {
+    const api: Record<string, unknown> = {}
+    installWebRendererContracts(api, {
+      availableRpcChannels: new Set(),
+      restrictedRpcChannels: new Set(),
+      invoke: vi.fn(),
+      subscribe: vi.fn(),
+      nativeAdapters: {}
+    })
+
+    // specialist.* is ELECTRON / ELECTRON_EVENT — the namespace must not exist on web.
+    expect(api.specialist).toBeUndefined()
+    // handoff.list is ELECTRON — namespace must not exist on web.
+    expect(api.handoff).toBeUndefined()
+    // officePreview.onState is ELECTRON_EVENT — namespace must not exist on web.
+    expect(api.officePreview).toBeUndefined()
+  })
+
+  it('never installs specialist.list on the web surface', () => {
+    const api: Record<string, unknown> = {}
+    installWebRendererContracts(api, {
+      availableRpcChannels: new Set(['specialist:list']),
+      restrictedRpcChannels: new Set(),
+      invoke: vi.fn(),
+      subscribe: vi.fn(),
+      nativeAdapters: {}
+    })
+
+    // Even when the channel is in the available set, ELECTRON contracts are not
+    // installed on web — the web surface installation is always 'unavailable'.
+    expect(methodAt(api, 'specialist.list')).toBeUndefined()
+    expect(methodAt(api, 'specialist.create')).toBeUndefined()
+    expect(methodAt(api, 'specialist.onCatalogChanged')).toBeUndefined()
+  })
+
   it('accepts one test-local neutral descriptor in both renderer adapters', async () => {
     const productionPaths = RENDERER_CONTRACT_CATALOG.map(({ publicPath }) => publicPath)
     const injectedCatalog = composeRendererContractCatalog([

--- a/src/renderer/web/api-installer.ts
+++ b/src/renderer/web/api-installer.ts
@@ -66,15 +66,6 @@ export const installWebRendererContracts = (
     } else if (contract.surfaceInstallation.localWeb === 'browser-native') {
       const nativeAdapter = adapters.nativeAdapters[publicPath]
       if (nativeAdapter !== undefined) assignApiPath(api, publicPath, nativeAdapter)
-    } else if (
-      channel !== null &&
-      contract.surfaceInstallation.localWeb === 'unavailable' &&
-      contract.kind === 'event'
-    ) {
-      // Electron-only event contracts are not available in the web build.
-      // Provide a no-op stub that returns a no-op unsubscribe function
-      // so callers can safely use optional chaining without crashing.
-      assignApiPath(api, publicPath, (_listener: Listener) => () => {})
     }
   }
 }

--- a/src/renderer/web/api-installer.ts
+++ b/src/renderer/web/api-installer.ts
@@ -66,6 +66,15 @@ export const installWebRendererContracts = (
     } else if (contract.surfaceInstallation.localWeb === 'browser-native') {
       const nativeAdapter = adapters.nativeAdapters[publicPath]
       if (nativeAdapter !== undefined) assignApiPath(api, publicPath, nativeAdapter)
+    } else if (
+      channel !== null &&
+      contract.surfaceInstallation.localWeb === 'unavailable' &&
+      contract.kind === 'event'
+    ) {
+      // Electron-only event contracts are not available in the web build.
+      // Provide a no-op stub that returns a no-op unsubscribe function
+      // so callers can safely use optional chaining without crashing.
+      assignApiPath(api, publicPath, (_listener: Listener) => () => {})
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix a crash that occurs when accessing Open Science via the web gateway and switching the Permission Profile or navigating to Settings > Specialists.

Closes #853

## Root cause

The web gateway build does not install Electron-only event contracts. When the renderer code calls `window.api.specialist.onCatalogChanged(...)`, the `window.api.specialist` object is undefined, causing an unhandled `TypeError: Cannot read properties of undefined (reading 'onCatalogChanged')`.

The infinite recursion in the stack trace (`yz → yc → yz → yc ...`) triggers a React re-render loop that crashes the page.

## Changes

### `src/renderer/web/api-installer.ts`
- Add a new branch to handle `unavailable` event contracts
- Provides a no-op stub that returns a no-op unsubscribe function `() => {}`
- Callers can safely call `subscribe(listener)` without crashing

### Defense-in-depth: optional chaining
- `src/renderer/src/pages/settings/SpecialistsPanel.tsx`
- `src/renderer/src/pages/workspace/SpecialistSubmenu.tsx`
- `src/renderer/src/pages/workspace/WorkspacePage.tsx`

All `window.api.specialist.*` calls now use optional chaining (`?.`) as defense-in-depth.

## Testing

- [ ] Web gateway: Settings > Specialists tab loads without crash
- [ ] Web gateway: Permission Profile switch does not crash
- [ ] Native desktop: All specialist operations still work
- [ ] No-op stub returns a callable unsubscribe function