### PR TITLE
refactor(notebook): extract session lifecycle owner

### DIFF
--- a/src/main/notebook/e2e.certification.test.ts
+++ b/src/main/notebook/e2e.certification.test.ts
@@ -101,8 +101,6 @@ const makeHarness = async (opts: { idleTimeoutMs?: number } = {}): Promise<Harne
     runnable: true
   }
 
-  // executorFactory runs lazily (first ensureSession), never during construction, so the closure can
-  // safely reference `service` even though it is declared in this same statement.
   const service: NotebookRuntimeService = new NotebookRuntimeService({
     configRoot: storageRoot,
     dataRoot: storageRoot,
@@ -128,7 +126,7 @@ const makeHarness = async (opts: { idleTimeoutMs?: number } = {}): Promise<Harne
     // the MANAGED path with its prefix symlinked to the system R (see makeHarness). This certifies both
     // the external-interpreter seam and the managed launch path end-to-end. (The pythonBin/rEnvPrefix
     // constructor options are legacy no-ops kept for signature parity with the default createExecutor.)
-    executorFactory: (sessionId) =>
+    executorFactory: (_sessionId, lifecycle) =>
       new NotebookKernelExecutor({
         pythonBin: pyBin,
         rEnvPrefix,
@@ -136,13 +134,8 @@ const makeHarness = async (opts: { idleTimeoutMs?: number } = {}): Promise<Harne
         rLoopPath: loops.rLoopPath,
         replLoopPath: loops.replLoopPath,
         idleTimeoutMs: opts.idleTimeoutMs,
-        onIdleShutdown: () => {
-          void (
-            service as unknown as {
-              handleKernelIdleShutdown: (sessionId: string, projectName: string) => Promise<void>
-            }
-          ).handleKernelIdleShutdown(sessionId, PROJECT)
-        }
+        onIdleShutdown: (kind, env) => void lifecycle.onIdleShutdown(kind, env),
+        onTerminated: (kind, env) => void lifecycle.onTerminated(kind, env)
       })
   })
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -2503,6 +2503,7 @@ describe('notebook runtime service', () => {
   it('idle-shutdown reports a terminated kernel status and notifies listeners', async () => {
     const root = await createStorageRoot()
     const changedSessions: string[] = []
+    let lifecycle!: NotebookExecutorLifecycleCallbacks
     const service = new NotebookRuntimeService({
       configRoot: root,
       dataRoot: root,
@@ -2511,30 +2512,27 @@ describe('notebook runtime service', () => {
       callbacks: {
         onNotebookChanged: (event) => changedSessions.push(event.sessionId)
       },
-      executorFactory: () => ({
-        execute: async (request): Promise<NotebookExecutionResult> => ({
-          status: 'completed',
-          stdout: '',
-          stderr: '',
-          traceback: '',
-          cwdAfter: request.cwd,
-          outputs: []
-        }),
-        shutdown: async () => ({ reaped: true })
-      })
+      executorFactory: (_sessionId, callbacks) => {
+        lifecycle = callbacks
+        return {
+          execute: async (request): Promise<NotebookExecutionResult> => ({
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }),
+          shutdown: async () => ({ reaped: true })
+        }
+      }
     })
 
     // Establishes the runtime session (and its persisted run.json) the idle-shutdown hook targets.
     await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '1' })
 
-    // Simulates NotebookKernelExecutor's onIdleShutdown firing after its idle window elapses. The
-    // executorFactory branch above never wires this callback (only the default real-executor branch
-    // does, see createExecutor); this exercises the persistence+notify logic it calls directly.
-    await (
-      service as unknown as {
-        handleKernelIdleShutdown: (sessionId: string, projectName: string) => Promise<void>
-      }
-    ).handleKernelIdleShutdown('session-1', 'default-project')
+    // Simulates NotebookKernelExecutor's onIdleShutdown firing after its idle window elapses.
+    await lifecycle.onIdleShutdown('python', DEFAULT_PY_ENV)
 
     const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
     expect(state.kernelStatus).toBe('terminated')
@@ -2727,22 +2725,26 @@ describe('notebook runtime service', () => {
 
   it('clears a stale terminated status once a run completes on the transparently respawned kernel', async () => {
     const root = await createStorageRoot()
+    let lifecycle!: NotebookExecutorLifecycleCallbacks
     const service = new NotebookRuntimeService({
       configRoot: root,
       dataRoot: root,
       projectName: 'default-project',
       repository: new NotebookRunRepository(root),
-      executorFactory: () => ({
-        execute: async (request): Promise<NotebookExecutionResult> => ({
-          status: 'completed',
-          stdout: '',
-          stderr: '',
-          traceback: '',
-          cwdAfter: request.cwd,
-          outputs: []
-        }),
-        shutdown: async () => ({ reaped: true })
-      })
+      executorFactory: (_sessionId, callbacks) => {
+        lifecycle = callbacks
+        return {
+          execute: async (request): Promise<NotebookExecutionResult> => ({
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }),
+          shutdown: async () => ({ reaped: true })
+        }
+      }
     })
 
     // Establishes the runtime session and persisted run.json the idle-shutdown hook targets.
@@ -2750,11 +2752,7 @@ describe('notebook runtime service', () => {
 
     // Simulates the executor's own idle timer dropping the proc between runs (see the
     // 'idle-shutdown reports a terminated kernel status' test above for the same mechanism).
-    await (
-      service as unknown as {
-        handleKernelIdleShutdown: (sessionId: string, projectName: string) => Promise<void>
-      }
-    ).handleKernelIdleShutdown('session-1', 'default-project')
+    await lifecycle.onIdleShutdown('python', DEFAULT_PY_ENV)
 
     const afterShutdown = await service.state({ sessionId: 'session-1', workspaceCwd: root })
     expect(afterShutdown.kernelStatus).toBe('terminated')
@@ -2769,32 +2767,32 @@ describe('notebook runtime service', () => {
 
   it('clears a stale terminated status once a control-plane run completes on the respawned kernel', async () => {
     const root = await createStorageRoot()
+    let lifecycle!: NotebookExecutorLifecycleCallbacks
     const service = new NotebookRuntimeService({
       configRoot: root,
       dataRoot: root,
       projectName: 'default-project',
       repository: new NotebookRunRepository(root),
-      executorFactory: () => ({
-        execute: async (request): Promise<NotebookExecutionResult> => ({
-          status: 'completed',
-          stdout: '',
-          stderr: '',
-          traceback: '',
-          cwdAfter: request.cwd,
-          outputs: []
-        }),
-        shutdown: async () => ({ reaped: true })
-      })
+      executorFactory: (_sessionId, callbacks) => {
+        lifecycle = callbacks
+        return {
+          execute: async (request): Promise<NotebookExecutionResult> => ({
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }),
+          shutdown: async () => ({ reaped: true })
+        }
+      }
     })
 
     // Establishes the runtime session and persisted run.json the idle-shutdown hook targets.
     await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '1' })
 
-    await (
-      service as unknown as {
-        handleKernelIdleShutdown: (sessionId: string, projectName: string) => Promise<void>
-      }
-    ).handleKernelIdleShutdown('session-1', 'default-project')
+    await lifecycle.onIdleShutdown('python', DEFAULT_PY_ENV)
 
     const afterShutdown = await service.state({ sessionId: 'session-1', workspaceCwd: root })
     expect(afterShutdown.kernelStatus).toBe('terminated')
@@ -3207,28 +3205,23 @@ describe('notebook runtime service', () => {
 
     it('leaves a terminated kernel status after a run whose kernel rejected (G3)', async () => {
       const root = await createStorageRoot()
-      // eslint-disable-next-line prefer-const -- forward ref: the executor closure captures svc before `service` exists
-      let svc: NotebookRuntimeService | undefined
+      let lifecycle!: NotebookExecutorLifecycleCallbacks
       const service = new NotebookRuntimeService({
         configRoot: root,
         dataRoot: root,
         projectName: 'default-project',
         repository: new NotebookRunRepository(root),
-        executorFactory: () => ({
+        executorFactory: (_sessionId, callbacks) => ({
           execute: async (): Promise<NotebookExecutionResult> => {
+            lifecycle = callbacks
             // Simulate the executor's onTerminated firing mid-run (crash), then the run rejecting so
             // the runtime service's executor-rejection path sets executedOnLiveKernel false.
-            await (
-              svc as unknown as {
-                handleKernelTerminated: (s: string, p: string, k: string) => Promise<void>
-              }
-            ).handleKernelTerminated('session-1', 'default-project', 'python')
+            await lifecycle.onTerminated('python', DEFAULT_PY_ENV)
             throw new Error('Notebook kernel process exited.')
           },
           shutdown: async () => ({ reaped: true })
         })
       })
-      svc = service
 
       const summary = await service.execute({
         sessionId: 'session-1',
@@ -3244,22 +3237,18 @@ describe('notebook runtime service', () => {
 
     it('does not overwrite a mid-run termination with idle when the executor resolves (G3)', async () => {
       const root = await createStorageRoot()
-      // eslint-disable-next-line prefer-const -- forward ref: the executor closure captures svc before `service` exists
-      let svc: NotebookRuntimeService | undefined
+      let lifecycle!: NotebookExecutorLifecycleCallbacks
       const service = new NotebookRuntimeService({
         configRoot: root,
         dataRoot: root,
         projectName: 'default-project',
         repository: new NotebookRunRepository(root),
-        executorFactory: () => ({
+        executorFactory: (_sessionId, callbacks) => ({
           execute: async (request): Promise<NotebookExecutionResult> => {
+            lifecycle = callbacks
             // The real executor catches a crash internally and RESOLVES a failed result while its
             // onTerminated callback fires — the terminatedKernels guard must still keep 'terminated'.
-            await (
-              svc as unknown as {
-                handleKernelTerminated: (s: string, p: string, k: string) => Promise<void>
-              }
-            ).handleKernelTerminated('session-1', 'default-project', 'python')
+            await lifecycle.onTerminated('python', DEFAULT_PY_ENV)
             return {
               status: 'failed',
               stdout: '',
@@ -3272,7 +3261,6 @@ describe('notebook runtime service', () => {
           shutdown: async () => ({ reaped: true })
         })
       })
-      svc = service
 
       await service.execute({
         sessionId: 'session-1',
@@ -3288,21 +3276,17 @@ describe('notebook runtime service', () => {
     it('clears a crash terminated status once a clean run of that kind completes (G3)', async () => {
       const root = await createStorageRoot()
       let mode: 'crash' | 'ok' = 'crash'
-      // eslint-disable-next-line prefer-const -- forward ref: the executor closure captures svc before `service` exists
-      let svc: NotebookRuntimeService | undefined
+      let lifecycle!: NotebookExecutorLifecycleCallbacks
       const service = new NotebookRuntimeService({
         configRoot: root,
         dataRoot: root,
         projectName: 'default-project',
         repository: new NotebookRunRepository(root),
-        executorFactory: () => ({
+        executorFactory: (_sessionId, callbacks) => ({
           execute: async (request): Promise<NotebookExecutionResult> => {
+            lifecycle = callbacks
             if (mode === 'crash') {
-              await (
-                svc as unknown as {
-                  handleKernelTerminated: (s: string, p: string, k: string) => Promise<void>
-                }
-              ).handleKernelTerminated('session-1', 'default-project', 'python')
+              await lifecycle.onTerminated('python', DEFAULT_PY_ENV)
               return {
                 status: 'failed',
                 stdout: '',
@@ -3324,7 +3308,6 @@ describe('notebook runtime service', () => {
           shutdown: async () => ({ reaped: true })
         })
       })
-      svc = service
 
       await service.execute({
         sessionId: 'session-1',

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -15,7 +15,6 @@ import type {
   ExportNotebookKernelRequest,
   ExportNotebookResult,
   FinishNotebookCodeCellRequest,
-  NotebookKernelMetadata,
   NotebookLanguage,
   NotebookRunRecord,
   NotebookRunSource,
@@ -37,9 +36,8 @@ import {
   type NotebookEnvironmentManager
 } from './environment-management'
 import { NotebookExportReader } from './export-reader'
-import { NotebookKernelExecutor, type NotebookKernelExecutorOptions } from './kernel-executor'
+import type { NotebookKernelExecutorOptions } from './kernel-executor'
 import { saveIpynbAll } from './save-ipynb-all'
-import type { KernelProcessKind } from './kernel-executor'
 import type { ProbeDeps } from './mirror-probe'
 import {
   installPackages as installPackagesDefault,
@@ -52,7 +50,7 @@ import {
   type InspectPackagesRequest,
   type InspectPackagesResult
 } from './package-operations'
-import { NotebookRunRepository, getNotebookRunJsonPath, getRuntimeRoot } from './repository'
+import { NotebookRunRepository, getRuntimeRoot } from './repository'
 import {
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
@@ -76,9 +74,7 @@ import { NotebookRuntimeRepairOwner } from './runtime-repair'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import { NotebookEnvironmentOperations, type DefaultEnvProvisioner } from './environment-operations'
 import {
-  NotebookSessionAggregate,
-  type NotebookSessionExecutorGeneration,
-  type NotebookSessionOwnedExecutor,
+  type NotebookSessionAggregate,
   type NotebookSessionExecutionRequest,
   type NotebookSessionExecutionResult,
   type NotebookSessionExecutor,
@@ -99,6 +95,11 @@ import {
   type NotebookControlResult
 } from './execution-owner'
 import { NotebookSessionReadModel, type NotebookHandoffContext } from './session-read-model'
+import {
+  NotebookSessionLifecycleOwner,
+  type NotebookExecutorLifecycleCallbacks,
+  type NotebookSessionLifecycleCallbacks
+} from './session-lifecycle'
 
 // Locale fallback when no explicit locale is injected (see shared/mirror.ts: non-CN locales resolve
 // to public hosts, so this default never silently forces a CN mirror).
@@ -119,40 +120,13 @@ const EMPTY_NOTEBOOK_RUNTIME_SETTINGS: Pick<NotebookRuntimeSettings, 'getSnapsho
 const dataProcessKey = (language: NotebookLanguage, environment?: string): string =>
   `${language === 'r' ? 'r' : 'python'}:${resolveEnvName(language, environment)}`
 
-// The process key the executor reports through onIdleShutdown/onTerminated(kind, env): `${kind}:${env}`
-// for python/r, bare 'repl' for the env-agnostic control kernel. A missing kind/env (direct callers /
-// tests that omit them) resolves to the DEFAULT env for the kind so run.json stays consistent.
-const kernelProcessKey = (kind: KernelProcessKind | undefined, env: string | undefined): string => {
-  const resolvedKind = kind ?? 'python'
-  if (resolvedKind === 'repl') return 'repl'
-  const resolvedEnv =
-    env && env.length > 0 ? env : resolvedKind === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
-  return `${resolvedKind}:${resolvedEnv}`
-}
-
-// True when a process key's status is the one persisted into run.json's single kernel.lastKnownStatus:
-// the two DEFAULT data envs and the control repl (backward compat — run.json shape is unchanged).
-// Named-env statuses live only in memory / state() until a later task persists the environments map.
-const persistsToRunJson = (processKey: string): boolean =>
-  processKey === 'repl' ||
-  processKey === `python:${DEFAULT_PY_ENV}` ||
-  processKey === `r:${DEFAULT_R_ENV}`
-
 type ResolvedInterpreter = NotebookSessionResolvedInterpreter
 type NotebookExecutionRequest = NotebookSessionExecutionRequest
 type NotebookExecutionResult = NotebookSessionExecutionResult
 
 type NotebookExecutor = NotebookSessionExecutor
 
-type NotebookExecutorLifecycleCallbacks = {
-  onIdleShutdown: (kind?: KernelProcessKind, env?: string) => Promise<void>
-  onTerminated: (kind: KernelProcessKind, env?: string) => Promise<void>
-}
-
-type NotebookRuntimeServiceCallbacks = {
-  onNotebookAvailable?: (event: NotebookSessionReference) => void
-  onNotebookChanged?: (event: NotebookSessionReference) => void
-}
+type NotebookRuntimeServiceCallbacks = NotebookSessionLifecycleCallbacks
 
 // The session-scoped connector RPC capability injected into the persistent control-plane REPL. The
 // service caches it for the RuntimeSession lifetime because the child captures it only when spawned;
@@ -335,7 +309,7 @@ class NotebookRuntimeService {
   private readonly runtimeRepair: NotebookRuntimeRepairOwner
   private readonly sessions: NotebookSessionRegistry<RuntimeSession>
   private readonly sessionReadModel: NotebookSessionReadModel<RuntimeSession>
-  private readonly announcedAgentSessionIds = new Set<string>()
+  private readonly sessionLifecycle: NotebookSessionLifecycleOwner
   // Owns process-global operation admission, provisioning progress, restart recommendations,
   // revocation drains, repair blocks, and installer diagnostics. The service remains the compatibility
   // facade and chooses which execution/package path enters each environment operation.
@@ -408,6 +382,18 @@ class NotebookRuntimeService {
       isRestartRecommended: (processKey) =>
         this.environmentOperations.isRestartRecommended(processKey)
     })
+    this.sessionLifecycle = new NotebookSessionLifecycleOwner({
+      storageRoot: options.dataRoot,
+      defaultProjectName: options.projectName,
+      repository: this.repository,
+      sessions: this.sessions,
+      runtimeBindings: this.runtimeBindingOwner,
+      executorFactory: options.executorFactory,
+      defaultExecutorOptions: resolveDefaultExecutorOptions,
+      platform: options.platform,
+      callbacks: options.callbacks,
+      toSessionReference: (session) => this.sessionReadModel.toSessionReference(session)
+    })
     this.runtimeRepair = new NotebookRuntimeRepairOwner({
       runtimeRoot,
       policy: this.repairPolicy,
@@ -475,7 +461,7 @@ class NotebookRuntimeService {
       environmentStateTracker: this.environmentStateTracker,
       createEnvironmentCaptureTarget: (...args) => this.environmentCaptureTarget(...args),
       persistKernelStatus: (session, status, processKey) =>
-        this.persistKernelStatus(session, status, processKey),
+        this.sessionLifecycle.persistKernelStatus(session as RuntimeSession, status, processKey),
       getMcpRpcConnectionResolver: () => this.mcpRpcConnectionResolver,
       notifyAvailable: (session, source) => this.notifyNotebookAvailable(session, source),
       platform: options.platform,
@@ -829,9 +815,7 @@ class NotebookRuntimeService {
     this.notifyNotebookChanged(session)
 
     try {
-      await session.restartExecutor(() =>
-        this.createExecutor(session.sessionId, session.projectName)
-      )
+      await session.restartExecutor(() => this.sessionLifecycle.createExecutor(session.sessionId))
       this.environmentOperations.clearRestartRecommendations(envKeys)
     } finally {
       await this.repository.updateKernelStatus({
@@ -879,11 +863,7 @@ class NotebookRuntimeService {
   }
 
   async shutdownSession(sessionId: string): Promise<{ sessionId: string; status: 'shutdown' }> {
-    await this.runtimeBindingOwner.withSessionTeardown(sessionId, async () => {
-      await this.runtimeBindingOwner.waitForWrites(sessionId)
-      await this.sessions.remove(sessionId)
-    })
-    return { sessionId, status: 'shutdown' }
+    return this.sessionLifecycle.shutdownSession(sessionId)
   }
 
   // Crash recovery (WS13): reconcile any runtime operation the previous process left in flight. Run at
@@ -1006,7 +986,7 @@ class NotebookRuntimeService {
   // when every kernel tree was cleanly reaped, so the update-install gate can refuse to trigger the
   // NSIS uninstall while a kernel may still hold file handles under the install dir.
   shutdownAll(): Promise<{ reaped: boolean }> {
-    return this.runtimeBindingOwner.withGlobalTeardown(() => this.sessions.shutdownAll())
+    return this.sessionLifecycle.shutdownAll()
   }
 
   // Permanently closes process-owned recovery work before the final kernel teardown. Unlike
@@ -1023,7 +1003,7 @@ class NotebookRuntimeService {
     // quit budget before kernel teardown even starts. Await both so non-quit module disposal still leaves
     // no recovery work behind once this terminal operation resolves.
     const recoveryDisposal = this.recoveryCoordinator.dispose()
-    const shutdown = this.runtimeBindingOwner.withGlobalTeardown(() => this.sessions.dispose())
+    const shutdown = this.sessionLifecycle.dispose()
     const disposal = Promise.allSettled([shutdown, recoveryDisposal]).then(
       ([shutdownResult, recoveryResult]) => {
         const failures = [shutdownResult, recoveryResult]
@@ -1045,209 +1025,22 @@ class NotebookRuntimeService {
 
   // Lists sessions with a cell mid-execution, for the pre-migration active-session warning.
   getActiveNotebookSessions(): { projectName: string; sessionId: string }[] {
-    return Array.from(this.sessions.values())
-      .filter((session) => session.hasActiveRun())
-      .map((session) => ({ projectName: session.projectName, sessionId: session.sessionId }))
+    return this.sessionLifecycle.activeSessions()
   }
 
   // Creates or returns the runtime session bound to an ACP/chat session id.
   private async ensureSession(request: NotebookSessionRequest): Promise<RuntimeSession> {
-    const projectName = request.projectName ?? this.options.projectName
-    return this.sessions.getOrCreate(request.sessionId, async () => {
-      let document = await this.repository.loadOrCreate({
-        projectName,
-        sessionId: request.sessionId,
-        workspaceCwd: request.workspaceCwd
-      })
-      // Crash recovery (WS12): the FIRST time this process loads a session, any run still marked
-      // 'running'/'queued' was in flight when a previous process died — its kernel is gone. Reconcile it
-      // to 'interrupted' so history is truthful and the UI/agent see it ended. Only reconcile when such a
-      // stale run exists (avoids rewriting a clean doc), and only here at session creation (never in
-      // state()/loadOrCreate), so a run that is genuinely live in THIS process is never mislabeled.
-      if (document.runs.some((run) => run.status === 'running' || run.status === 'queued')) {
-        document = await this.repository.reconcileInterruptedRuns(projectName, request.sessionId)
-      }
-      // Runtime session roots come from run.json normalization so UI, MCP, and Python agree.
-      const ownedExecutor = this.createExecutor(request.sessionId, projectName)
-      const session: RuntimeSession = new NotebookSessionAggregate({
-        sessionId: request.sessionId,
-        projectName,
-        // Start the interpreter in the session's writable data dir (like a Jupyter notebook's cwd), not
-        // the outer workspace. Relative writes — e.g. plt.savefig("plot.png") — then land in a directory
-        // that is inside the artifact import roots, so the agent never has to guess an absolute path.
-        // dataRoot lives under notebookSessionRoot (an allowed import root) and is created before this.
-        cwd: document.dataRoot,
-        notebookSessionRoot: document.notebookSessionRoot,
-        dataRoot: document.dataRoot,
-        runtimeRoot: document.kernel.runtimeRoot,
-        runJsonPath: getNotebookRunJsonPath(this.options.dataRoot, projectName, request.sessionId),
-        executionCount: document.runs.length,
-        executor: ownedExecutor.executor,
-        executorGeneration: ownedExecutor.generation
-      })
-
-      try {
-        // Rehydrate + revalidate any persisted runtime bindings (WS1-rest/WS12): a still-usable binding
-        // is restored active; one whose runtime is now disabled/missing is kept as unavailable (no
-        // silent fallback). Publish only after this initialization completes so same-ID callers cannot
-        // observe a partially hydrated aggregate.
-        await this.runtimeBindingOwner.reload(session, document.runtimeBindings)
-        return session
-      } catch (error) {
-        // Initialization failures stay retryable. Best-effort cleanup must not replace the repository /
-        // binding error that callers already observe.
-        await session.shutdownExecutor().catch(() => undefined)
-        try {
-          session.releaseMcpRpcConnection()
-        } catch {
-          // Preserve the initialization failure.
-        }
-        throw error
-      }
-    })
-  }
-
-  // Builds the interpreter backend, allowing tests to inject a fake executor. The default (D-B4)
-  // builds a real NotebookKernelExecutor from the storage root's runtime paths, wired so an idle-
-  // shutdown proc (kernel-executor.ts's own idle timer) surfaces as a 'terminated' kernel status; this
-  // branch is not exercised by unit tests (see resolveDefaultExecutorOptions for the tested,
-  // spawn-free portion).
-  private createExecutor(sessionId: string, projectName: string): NotebookSessionOwnedExecutor {
-    const generation = Symbol(`notebook-executor:${sessionId}`)
-    const lifecycle: NotebookExecutorLifecycleCallbacks = {
-      onIdleShutdown: (kind, env) =>
-        this.handleKernelIdleShutdown(sessionId, projectName, kind, env, generation),
-      onTerminated: (kind, env) =>
-        this.handleKernelTerminated(sessionId, projectName, kind, env, generation)
-    }
-
-    if (this.options.executorFactory) {
-      return { executor: this.options.executorFactory(sessionId, lifecycle), generation }
-    }
-
-    const executor = new NotebookKernelExecutor({
-      ...resolveDefaultExecutorOptions(),
-      platform: this.options.platform,
-      onIdleShutdown: (kind, env) => {
-        void lifecycle.onIdleShutdown(kind, env)
-      },
-      onTerminated: (kind, env) => {
-        void lifecycle.onTerminated(kind, env)
-      }
-    })
-    return { executor, generation }
-  }
-
-  // Persists 'terminated' for a proc the executor dropped after its idle window, then notifies the
-  // renderer so a reload picks up the fresh status. Keyed by the (kind, env) the executor reports so a
-  // named env's idle shutdown marks only that env, not the whole session. Never throws: this runs off
-  // an executor-owned timer with nothing waiting on it, so a persistence failure here must not surface
-  // anywhere louder than a swallowed no-op.
-  private async handleKernelIdleShutdown(
-    sessionId: string,
-    projectName: string,
-    kind?: KernelProcessKind,
-    env?: string,
-    generation?: NotebookSessionExecutorGeneration
-  ): Promise<void> {
-    const session = this.sessions.get(sessionId)
-    const processKey = kernelProcessKey(kind, env)
-    if (session) {
-      if (generation) {
-        await session.runExecutorLifecycleCallback(generation, async () => {
-          await this.persistKernelStatus(session, 'terminated', processKey)
-          this.notifyNotebookChanged(session)
-        })
-        return
-      }
-      await this.persistKernelStatus(session, 'terminated', processKey)
-      this.notifyNotebookChanged(session)
-      return
-    }
-    // Executor-owned callbacks are valid only while their Aggregate generation is published. Once
-    // teardown removes that owner, do not fall through to the legacy rehydration path and rewrite the
-    // durable state a same-ID successor will load.
-    if (generation) return
-    // No live session (rehydrated after relaunch): still persist the default env's run.json status.
-    if (!persistsToRunJson(processKey)) return
-    try {
-      await this.repository.updateKernelStatus({ projectName, sessionId, status: 'terminated' })
-    } catch {
-      return
-    }
-  }
-
-  // Persists 'terminated' for a proc lost to a crash or hard-timeout (§4 "crash → [terminated]"),
-  // then notifies. Flags the process key on the session so an in-flight run whose kernel died mid-
-  // execution does not overwrite this back to 'idle' on completion; the next clean run of that key
-  // clears it. Best-effort like handleKernelIdleShutdown: it runs off an executor callback.
-  private async handleKernelTerminated(
-    sessionId: string,
-    projectName: string,
-    kind: KernelProcessKind,
-    env?: string,
-    generation?: NotebookSessionExecutorGeneration
-  ): Promise<void> {
-    const session = this.sessions.get(sessionId)
-    const processKey = kernelProcessKey(kind, env)
-    if (session) {
-      if (generation) {
-        await session.runExecutorLifecycleCallback(generation, async () => {
-          session.markKernelTerminated(processKey)
-          await this.persistKernelStatus(session, 'terminated', processKey)
-          this.notifyNotebookChanged(session)
-        })
-        return
-      }
-      session.markKernelTerminated(processKey)
-      await this.persistKernelStatus(session, 'terminated', processKey)
-      this.notifyNotebookChanged(session)
-      return
-    }
-    if (generation) return
-    if (!persistsToRunJson(processKey)) return
-    try {
-      await this.repository.updateKernelStatus({ projectName, sessionId, status: 'terminated' })
-    } catch {
-      return
-    }
-  }
-
-  // Records a kernel-level lifecycle status for one process key. Always updates the in-memory per-env
-  // map (source for state().environments and the refuse-if-live check); additionally persists into
-  // run.json's single kernel.lastKnownStatus ONLY for the DEFAULT envs / repl (persistsToRunJson), so
-  // run.json's shape stays unchanged — named-env status persistence is a separate later task. Does not
-  // notify: callers persist a status alongside a run record whose own append/update notify already
-  // surfaces the change. A persistence failure must never surface as a run failure.
-  private async persistKernelStatus(
-    session: RuntimeSession,
-    status: NotebookKernelMetadata['lastKnownStatus'],
-    processKey: string
-  ): Promise<void> {
-    session.setKernelStatus(processKey, status)
-    if (!persistsToRunJson(processKey)) return
-    try {
-      await this.repository.updateKernelStatus({
-        projectName: session.projectName,
-        sessionId: session.sessionId,
-        status
-      })
-    } catch {
-      return
-    }
+    return this.sessionLifecycle.ensure(request)
   }
 
   // Announces notebook availability only once per agent-started session.
   private notifyNotebookAvailable(session: RuntimeSession, source: NotebookRunSource): void {
-    if (source !== 'agent' || this.announcedAgentSessionIds.has(session.sessionId)) return
-
-    this.announcedAgentSessionIds.add(session.sessionId)
-    this.options.callbacks?.onNotebookAvailable?.(this.sessionReadModel.toSessionReference(session))
+    this.sessionLifecycle.notifyAvailable(session, source)
   }
 
   // Broadcasts state invalidation so the renderer can reload run.json and in-memory cell data.
   private notifyNotebookChanged(session: RuntimeSession): void {
-    this.options.callbacks?.onNotebookChanged?.(this.sessionReadModel.toSessionReference(session))
+    this.sessionLifecycle.notifyChanged(session)
   }
 
   // Adds notebook roots and kernel metadata to the run returned to MCP callers.

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -1,0 +1,224 @@
+import type {
+  NotebookKernelMetadata,
+  NotebookRunSource,
+  NotebookSessionReference,
+  NotebookSessionRequest
+} from '../../shared/notebook'
+import { NotebookKernelExecutor, type NotebookKernelExecutorOptions } from './kernel-executor'
+import { NotebookRunRepository, getNotebookRunJsonPath } from './repository'
+import {
+  NotebookSessionAggregate,
+  type NotebookSessionExecutor,
+  type NotebookSessionExecutorGeneration,
+  type NotebookSessionOwnedExecutor
+} from './session-aggregate'
+import { NotebookSessionRegistry } from './session-registry'
+import type { NotebookRuntimeBindingOwner } from './runtime-binding'
+import { DEFAULT_PY_ENV, DEFAULT_R_ENV } from './runtime-paths'
+import type { KernelProcessKind } from './kernel-executor'
+
+type RuntimeSession = NotebookSessionAggregate
+
+type NotebookExecutorLifecycleCallbacks = {
+  onIdleShutdown: (kind?: KernelProcessKind, env?: string) => Promise<void>
+  onTerminated: (kind: KernelProcessKind, env?: string) => Promise<void>
+}
+
+type NotebookSessionLifecycleCallbacks = {
+  onNotebookAvailable?: (event: NotebookSessionReference) => void
+  onNotebookChanged?: (event: NotebookSessionReference) => void
+}
+
+type NotebookSessionLifecycleOptions = {
+  storageRoot: string
+  defaultProjectName: string
+  repository: NotebookRunRepository
+  sessions: NotebookSessionRegistry<RuntimeSession>
+  runtimeBindings: NotebookRuntimeBindingOwner
+  executorFactory?: (
+    sessionId: string,
+    lifecycle: NotebookExecutorLifecycleCallbacks
+  ) => NotebookSessionExecutor
+  defaultExecutorOptions: () => NotebookKernelExecutorOptions
+  platform?: NodeJS.Platform
+  callbacks?: NotebookSessionLifecycleCallbacks
+  toSessionReference: (session: RuntimeSession) => NotebookSessionReference
+}
+
+const processKeyFor = (kind: KernelProcessKind | undefined, env: string | undefined): string => {
+  const resolvedKind = kind ?? 'python'
+  if (resolvedKind === 'repl') return 'repl'
+  const resolvedEnv =
+    env && env.length > 0 ? env : resolvedKind === 'r' ? DEFAULT_R_ENV : DEFAULT_PY_ENV
+  return `${resolvedKind}:${resolvedEnv}`
+}
+
+const persistsToRunJson = (processKey: string): boolean =>
+  processKey === 'repl' ||
+  processKey === `python:${DEFAULT_PY_ENV}` ||
+  processKey === `r:${DEFAULT_R_ENV}`
+
+// Orchestrates one Registry generation without duplicating Registry or Aggregate state.
+class NotebookSessionLifecycleOwner {
+  private readonly announcedAgentSessionIds = new Set<string>()
+
+  constructor(private readonly options: NotebookSessionLifecycleOptions) {}
+
+  ensure(request: NotebookSessionRequest): Promise<RuntimeSession> {
+    const projectName = request.projectName ?? this.options.defaultProjectName
+    return this.options.sessions.getOrCreate(request.sessionId, async () => {
+      let document = await this.options.repository.loadOrCreate({
+        projectName,
+        sessionId: request.sessionId,
+        workspaceCwd: request.workspaceCwd
+      })
+      if (document.runs.some((run) => run.status === 'running' || run.status === 'queued')) {
+        document = await this.options.repository.reconcileInterruptedRuns(
+          projectName,
+          request.sessionId
+        )
+      }
+
+      const ownedExecutor = this.createExecutor(request.sessionId)
+      const session = new NotebookSessionAggregate({
+        sessionId: request.sessionId,
+        projectName,
+        cwd: document.dataRoot,
+        notebookSessionRoot: document.notebookSessionRoot,
+        dataRoot: document.dataRoot,
+        runtimeRoot: document.kernel.runtimeRoot,
+        runJsonPath: getNotebookRunJsonPath(
+          this.options.storageRoot,
+          projectName,
+          request.sessionId
+        ),
+        executionCount: document.runs.length,
+        executor: ownedExecutor.executor,
+        executorGeneration: ownedExecutor.generation
+      })
+
+      try {
+        await this.options.runtimeBindings.reload(session, document.runtimeBindings)
+        return session
+      } catch (error) {
+        await session.shutdownExecutor().catch(() => undefined)
+        try {
+          session.releaseMcpRpcConnection()
+        } catch {
+          // Preserve the initialization failure.
+        }
+        throw error
+      }
+    })
+  }
+
+  createExecutor(sessionId: string): NotebookSessionOwnedExecutor {
+    const generation = Symbol(`notebook-executor:${sessionId}`)
+    const lifecycle: NotebookExecutorLifecycleCallbacks = {
+      onIdleShutdown: (kind, env) => this.handleIdleShutdown(sessionId, kind, env, generation),
+      onTerminated: (kind, env) => this.handleTerminated(sessionId, kind, env, generation)
+    }
+    const injected = this.options.executorFactory
+    if (injected) return { executor: injected(sessionId, lifecycle), generation }
+
+    return {
+      generation,
+      executor: new NotebookKernelExecutor({
+        ...this.options.defaultExecutorOptions(),
+        platform: this.options.platform,
+        onIdleShutdown: (kind, env) => void lifecycle.onIdleShutdown(kind, env),
+        onTerminated: (kind, env) => void lifecycle.onTerminated(kind, env)
+      })
+    }
+  }
+
+  async shutdownSession(sessionId: string): Promise<{ sessionId: string; status: 'shutdown' }> {
+    await this.options.runtimeBindings.withSessionTeardown(sessionId, async () => {
+      await this.options.runtimeBindings.waitForWrites(sessionId)
+      await this.options.sessions.remove(sessionId)
+    })
+    return { sessionId, status: 'shutdown' }
+  }
+
+  shutdownAll(): Promise<{ reaped: boolean }> {
+    return this.options.runtimeBindings.withGlobalTeardown(() =>
+      this.options.sessions.shutdownAll()
+    )
+  }
+
+  dispose(): Promise<{ reaped: boolean }> {
+    return this.options.runtimeBindings.withGlobalTeardown(() => this.options.sessions.dispose())
+  }
+
+  activeSessions(): { projectName: string; sessionId: string }[] {
+    return Array.from(this.options.sessions.values())
+      .filter((session) => session.hasActiveRun())
+      .map((session) => ({ projectName: session.projectName, sessionId: session.sessionId }))
+  }
+
+  notifyAvailable(session: RuntimeSession, source: NotebookRunSource): void {
+    if (source !== 'agent' || this.announcedAgentSessionIds.has(session.sessionId)) return
+    this.announcedAgentSessionIds.add(session.sessionId)
+    this.options.callbacks?.onNotebookAvailable?.(this.options.toSessionReference(session))
+  }
+
+  notifyChanged(session: RuntimeSession): void {
+    this.options.callbacks?.onNotebookChanged?.(this.options.toSessionReference(session))
+  }
+
+  async persistKernelStatus(
+    session: RuntimeSession,
+    status: NotebookKernelMetadata['lastKnownStatus'],
+    processKey: string
+  ): Promise<void> {
+    session.setKernelStatus(processKey, status)
+    if (!persistsToRunJson(processKey)) return
+    try {
+      await this.options.repository.updateKernelStatus({
+        projectName: session.projectName,
+        sessionId: session.sessionId,
+        status
+      })
+    } catch {
+      return
+    }
+  }
+
+  private async handleIdleShutdown(
+    sessionId: string,
+    kind: KernelProcessKind | undefined,
+    env: string | undefined,
+    generation: NotebookSessionExecutorGeneration
+  ): Promise<void> {
+    const session = this.options.sessions.get(sessionId)
+    if (!session) return
+    const processKey = processKeyFor(kind, env)
+    await session.runExecutorLifecycleCallback(generation, async () => {
+      await this.persistKernelStatus(session, 'terminated', processKey)
+      this.notifyChanged(session)
+    })
+  }
+
+  private async handleTerminated(
+    sessionId: string,
+    kind: KernelProcessKind,
+    env: string | undefined,
+    generation: NotebookSessionExecutorGeneration
+  ): Promise<void> {
+    const session = this.options.sessions.get(sessionId)
+    if (!session) return
+    const processKey = processKeyFor(kind, env)
+    await session.runExecutorLifecycleCallback(generation, async () => {
+      session.markKernelTerminated(processKey)
+      await this.persistKernelStatus(session, 'terminated', processKey)
+      this.notifyChanged(session)
+    })
+  }
+}
+
+export { NotebookSessionLifecycleOwner }
+export type {
+  NotebookExecutorLifecycleCallbacks,
+  NotebookSessionLifecycleCallbacks,
+  NotebookSessionLifecycleOptions
+}


### PR DESCRIPTION
## Problem

`NotebookRuntimeService` still orchestrated Session initialization, executor generation callbacks, process-scoped notifications, and Registry teardown. Those responsibilities obscured the boundary between the Registry's collection/admission state, the Aggregate's per-Session mutable state, and the compatibility facade.

Related context: #458. This PR preserves a forward-compatible ownership seam only; it does not add orchestration state or public interfaces.

## Proposed change

Extract `NotebookSessionLifecycleOwner` to orchestrate one Registry generation while leaving state in the existing Registry and Aggregate.

```mermaid
flowchart LR
  A["Electron / Web / CLI adapters"] --> F["NotebookRuntimeService facade"]
  F --> L["NotebookSessionLifecycleOwner"]
  L --> R["Session Registry: admission and collection"]
  L --> S["Session Aggregate: mutable Session state"]
  L --> E["Executor generation callbacks"]
  E --> S
```

The owner loads/reconciles durable history, constructs the Aggregate/executor, routes generation-fenced idle/terminated callbacks, publishes existing references, and delegates teardown through Registry/runtime-binding gates.

## Scope and non-goals

- Preserve exact-once durable load, interrupted-run reconciliation, and binding rehydration per Registry generation.
- Preserve executor generation ownership, stale callback suppression, callback persistence ordering, and per-process status semantics.
- Preserve MCP capability release, shutdown failure/retry behavior, reusable `shutdownAll`, and terminal disposal ordering.
- Preserve process-scoped Notebook availability and change notifications.
- Keep Registry and Aggregate interfaces/state ownership unchanged; add no second map, lock, generation, or shutdown promise.
- Keep public methods and Electron/Web/CLI, IPC/RPC/MCP, Specialist, Permission, and Compute contracts/asymmetries unchanged.
- Keep shared/preload schemas, persistence shape, data relationships, and user interaction unchanged.
- Audited #835 and #855: no Notebook lifecycle production overlap; #855's cross-platform path-testing convention is preserved.
- Rebased onto #861 without altering its transport-aware `fetchLocalRpc` or platform-neutral `envPrefix` test intent; this PR changes neither local-RPC transport selection nor runtime path construction.
- Audited #862 and #863: they modify only CI workflows/classifier tests and the macOS coverage timeout. They have no N7 file or runtime-semantic overlap; the range-diff of the N7 commit is identical.

## Acceptance criteria and validation

Final local evidence mapping on exact base `b8ef367c` and exact head `4d82f9f9`:

- Lifecycle/facade, generation fencing, package-admission path fixtures, read model, Aggregate, application composition and real-kernel harness wiring -> `npm test -- src/main/notebook/runtime-service.test.ts src/main/notebook/e2e.certification.test.ts src/main/notebook/package-admission.test.ts src/main/notebook/session-read-model.test.ts src/main/notebook/session-aggregate.test.ts src/main/notebook/application.test.ts` -> 209 passed / 9 environment-gated skipped.
- #861 transport-aware local-RPC surface, dispatch and error identity -> `npm test -- src/main/notebook/local-rpc-server.test.ts` outside the filesystem/network sandbox -> 25/25 passed.
- Local socket/TCP transport portability -> `npm test -- src/main/local-rpc-transport.test.ts` outside the filesystem/network sandbox -> 3/3 passed.
- Runtime path and package-admission portability -> `npm test -- src/main/notebook/runtime-paths.test.ts src/main/notebook/package-admission.test.ts` -> 49/49 passed.
- Node process types -> `npm run typecheck:node` -> passed.
- Changed-file lint/style -> targeted ESLint and Prettier checks -> passed.
- Patch integrity -> `git diff --check` -> passed.
- Rebase integrity -> `git range-diff 2571eabd..1ba0afa3 b8ef367c..4d82f9f9` -> the N7 commit is identical.
- Independent review before dependency-only rebases -> Standards 0 findings / Spec 0 findings after closing one gated-harness P1; the rebases introduced no textual production overlap.

Production raw is 493 lines (`runtime-service.ts` 31 additions + 238 deletions; owner 224 additions), below the 600 target without using the 660 tolerance. Test raw is 152 lines; total raw is 645. `runtime-service.ts` drops from 1,274 to 1,067 lines; the owner is 224 lines.

Uncovered local risk: real Python/R kernel certification needs `RUN_KERNEL` and installed interpreter environments. The gated harness is typechecked and correctly wired; online platform lanes remain authoritative for Windows/macOS/Linux integration.

Squash merge only after exact-head CI and AI review are green.

## Review focus

- Confirm Registry/Aggregate remain the only state owners and lifecycle adds no shadow admission state.
- Confirm stale executor callbacks cannot mutate a replacement generation.
- Confirm initialization and teardown failure ordering is unchanged.
- Confirm real/default executors both route lifecycle callbacks through the generation token.
- Confirm #861's Windows transport-aware/local-path fixtures remain intact after the rebase.
