### PR TITLE
test(notebook): make Windows tests transport-aware

### DIFF
--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -89,18 +89,22 @@ describe('notebook local RPC server', () => {
     })
     const connection = await server.issuePlanConnection('session-1', 'project-1')
     const request = (token: string): Promise<Response> =>
-      fetch(connection.endpoint, {
-        method: 'POST',
-        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-        body: JSON.stringify({
-          method: 'planCall',
-          params: {
-            projectId: 'forged-project',
-            sessionId: 'forged-session',
-            operation: 'approve'
-          }
-        })
-      })
+      fetchLocalRpc(
+        connection,
+        {
+          method: 'POST',
+          headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+          body: JSON.stringify({
+            method: 'planCall',
+            params: {
+              projectId: 'forged-project',
+              sessionId: 'forged-session',
+              operation: 'approve'
+            }
+          })
+        },
+        'Notebook Plan capability RPC'
+      )
 
     try {
       expect((await request('master-token')).status).toBe(401)
@@ -148,17 +152,21 @@ describe('notebook local RPC server', () => {
     const connection = await server.issuePlanConnection('session-1', 'project-1')
 
     try {
-      const response = await fetch(connection.endpoint, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${connection.token}`,
-          'content-type': 'application/json'
+      const response = await fetchLocalRpc(
+        connection,
+        {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${connection.token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({
+            method: 'planCall',
+            params: { operation: 'updateStepStatus', input: { title: 'Old step' } }
+          })
         },
-        body: JSON.stringify({
-          method: 'planCall',
-          params: { operation: 'updateStepStatus', input: { title: 'Old step' } }
-        })
-      })
+        'Notebook Plan capability RPC'
+      )
 
       expect(response.status).toBe(500)
       await expect(response.json()).resolves.toEqual({

--- a/src/main/notebook/package-admission.test.ts
+++ b/src/main/notebook/package-admission.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { NotebookLanguage } from '../../shared/notebook'
 import { NotebookPackageAdmissionOwner } from './package-admission'
-import { managedRepairRegistryKey, repairRegistryPath } from './runtime-paths'
+import { envPrefix, managedRepairRegistryKey, repairRegistryPath } from './runtime-paths'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import type { NotebookSessionRuntimeBinding } from './session-aggregate'
 
@@ -98,7 +98,7 @@ describe('NotebookPackageAdmissionOwner', () => {
         }),
         repairRuntimeId: 'default-python',
         repairMarkerKey: managedRepairRegistryKey('default-python', 'python'),
-        journalTarget: '/runtime/envs/default-python'
+        journalTarget: envPrefix('/runtime', 'default-python')
       })
     })
   })
@@ -129,7 +129,7 @@ describe('NotebookPackageAdmissionOwner', () => {
         binding: { runtimeId: binding.runtimeId },
         repairRuntimeId: 'analysis',
         repairMarkerKey: managedRepairRegistryKey('analysis', 'python'),
-        journalTarget: '/runtime/envs/analysis'
+        journalTarget: envPrefix('/runtime', 'analysis')
       }
     })
   })


### PR DESCRIPTION
## Problem

Windows Full Test run [31112200792](https://github.com/aipoch/open-science/actions/runs/31112200792) failed four Notebook tests:

- two Plan RPC tests bypassed the Windows named-pipe transport by calling native `fetch` directly
- two package-admission tests hard-coded POSIX runtime prefixes instead of using the production path mapping

## Proposed change

- Route the Plan capability requests through the existing `fetchLocalRpc()` transport adapter.
- Build expected managed journal targets with the existing `envPrefix()` helper.

The assertions now exercise the same transport and path seams used by production on Windows, macOS, and Linux.

## Scope and non-goals

- Test-only change; no production behavior changes.
- No architecture, data model, data relationship, or user interaction changes.
- Does not alter local RPC authorization or managed environment naming.

## Acceptance criteria and validation

Checks ran after the last material edit.

- Reported Windows failures -> `vitest run src/main/notebook/local-rpc-server.test.ts src/main/notebook/package-admission.test.ts` -> passed (2 files, 38 tests).
- Repository lint -> `eslint --cache .` -> passed with 0 errors (17 existing warnings outside the changed files).
- Node typecheck -> `tsc --noEmit -p tsconfig.node.json --composite false` -> blocked by an existing stale generated Prisma client that lacks `Project.archivedAt`; no reported error touches this diff.
- Complete portable suite -> `vitest run` -> not green locally: 814 files passed and 11 failed (35 tests), with unrelated environment/baseline failures including missing Bash, Windows symlink privilege, stale Prisma output, process timeouts, and timing-sensitive tests. The two changed test files passed and are absent from the failure list.

No production interface or consumer changed. Windows CI remains the authority for the complete real-Windows lane.

## Review focus

Confirm the Plan tests use the same named-pipe-aware request adapter as production callers and the package-admission expectations use the production managed-prefix mapping.