### PR TITLE
ci(pr-gate): extend macOS coverage timeout

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -373,7 +373,7 @@ jobs:
     needs: preflight
     if: ${{ needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'coverage_macos') }}
     runs-on: macos-14
-    timeout-minutes: 8
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
## Problem

PR #858 reached the `Coverage macOS` job's eight-minute workflow limit twice on exact head `150199716893eee2d60f83bb92134a223d348a4c`. Both runs were cancelled while the portable coverage suite was still producing passing test output; neither reported a test assertion failure nor a coverage-threshold failure.

- first attempt: cancelled after 8m41s
- failed-job rerun: cancelled after 8m39s
- #858's new settings-store architecture suite: 27 tests passed in 1.669s, so it is not the material source of the exhausted budget

## Proposed change

Increase only `jobs.coverage_macos.timeout-minutes` in `.github/workflows/pr-gate.yml` from 8 to 15 minutes. The existing runner, classifier condition, install command, coverage command, thresholds, artifact upload, and final PR Gate evaluation remain unchanged.

## Scope and non-goals

- One workflow file and one scalar value change; production source change: 0 lines.
- No changes to other CI job budgets.
- No attempt to optimize, shard, skip, or weaken the coverage suite.
- No changes to #858's settings-store certification patch.

## Compatibility and risk

This is CI-only and does not change architecture, data models, persisted data, user interaction, Electron/Web/CLI/Task behavior, IPC contracts, or Specialist/Permission/Compute capability boundaries. The only operational effect is allowing the already-blocking macOS coverage job up to seven additional minutes before GitHub cancels it.

Residual risk: actual completion of the full macOS coverage suite within the new budget is delegated to exact-head CI. If it still exceeds 15 minutes, that should be handled as a separate performance/sharding change rather than increasing scope here.

## Acceptance criteria and validation

All listed local checks ran after the final material edit:

- workflow syntax and exact value -> `js-yaml` parse plus assertion that `jobs.coverage_macos.timeout-minutes === 15` -> passed
- workflow contracts -> `npm test -- scripts/ci/pr-gate-workflow.test.ts scripts/ci/check-ci-integrity.test.ts` -> 2 files / 51 tests passed
- repository lint -> `npm run lint` -> 0 errors / 17 pre-existing warnings outside this diff
- formatting -> `npx prettier --check .github/workflows/pr-gate.yml` -> passed
- patch integrity -> `git diff --check` -> passed
- independent Standards/Spec review -> 0 findings / 0 findings

CI authority: exact-head PR Gate must show the macOS coverage job completing successfully before squash merge.

## Review focus

- Confirm the base-to-head diff changes only `coverage_macos.timeout-minutes` from 8 to 15.
- Confirm no other timeout, coverage behavior, or merge-gate behavior changed.
- Confirm the additional budget addresses cancellation without weakening the existing coverage command or thresholds.
