### PR TITLE
test(notebook): certify runtime facade ownership

### DIFF
--- a/src/main/notebook/runtime-service.architecture.test.ts
+++ b/src/main/notebook/runtime-service.architecture.test.ts
@@ -1,0 +1,311 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import {
+  canHaveModifiers,
+  createSourceFile,
+  forEachChild,
+  getModifiers,
+  isArrowFunction,
+  isClassDeclaration,
+  isConstructorDeclaration,
+  isFunctionDeclaration,
+  isFunctionExpression,
+  isIdentifier,
+  isMethodDeclaration,
+  isNewExpression,
+  isParameter,
+  isPropertyDeclaration,
+  isVariableStatement,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  type ClassDeclaration,
+  type NewExpression,
+  type SourceFile,
+  type Node
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const facadePath = resolve(__dirname, 'runtime-service.ts')
+const facadeSource = readFileSync(facadePath, 'utf8')
+const sourceFileFor = (source: string): SourceFile =>
+  createSourceFile(facadePath, source, ScriptTarget.Latest, true, ScriptKind.TS)
+const facadeClassFrom = (sourceFile: SourceFile): ClassDeclaration => {
+  const candidate = sourceFile.statements.find(
+    (statement) =>
+      isClassDeclaration(statement) && statement.name?.text === 'NotebookRuntimeService'
+  )
+  if (!candidate || !isClassDeclaration(candidate)) {
+    throw new Error('NotebookRuntimeService class not found')
+  }
+  return candidate
+}
+const facadeFile = sourceFileFor(facadeSource)
+const facadeClass = facadeClassFrom(facadeFile)
+
+const hasModifier = (node: Node, kind: SyntaxKind): boolean =>
+  canHaveModifiers(node) &&
+  (getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false)
+
+const identifierName = (node: Node | undefined): string | undefined =>
+  node && isIdentifier(node) ? node.text : undefined
+
+const facadeFields = (): readonly string[] => {
+  const fields = facadeClass.members
+    .filter(isPropertyDeclaration)
+    .map((member) => identifierName(member.name))
+    .filter((name): name is string => name !== undefined)
+
+  for (const constructor of facadeClass.members.filter(isConstructorDeclaration)) {
+    fields.push(
+      ...constructor.parameters
+        .filter(
+          (parameter) =>
+            isParameter(parameter) &&
+            (hasModifier(parameter, SyntaxKind.PrivateKeyword) ||
+              hasModifier(parameter, SyntaxKind.PublicKeyword) ||
+              hasModifier(parameter, SyntaxKind.ProtectedKeyword))
+        )
+        .map((parameter) => identifierName(parameter.name))
+        .filter((name): name is string => name !== undefined)
+    )
+  }
+
+  return fields.sort()
+}
+
+const mutableFacadeFields = (): readonly string[] =>
+  facadeClass.members
+    .filter(isPropertyDeclaration)
+    .filter((member) => !hasModifier(member, SyntaxKind.ReadonlyKeyword))
+    .map((member) => identifierName(member.name))
+    .filter((name): name is string => name !== undefined)
+    .sort()
+
+const facadeMethods = (
+  visibility: 'public' | 'private',
+  target: ClassDeclaration = facadeClass
+): readonly string[] =>
+  target.members
+    .filter(isMethodDeclaration)
+    .filter((member) =>
+      visibility === 'private'
+        ? hasModifier(member, SyntaxKind.PrivateKeyword)
+        : !hasModifier(member, SyntaxKind.PrivateKeyword) &&
+          !hasModifier(member, SyntaxKind.ProtectedKeyword)
+    )
+    .map((member) => identifierName(member.name))
+    .filter((name): name is string => name !== undefined)
+    .sort()
+
+const topLevelValueNames = (sourceFile: SourceFile = facadeFile): readonly string[] =>
+  sourceFile.statements
+    .flatMap((statement) => {
+      if (isVariableStatement(statement)) {
+        return statement.declarationList.declarations.map((declaration) =>
+          declaration.name.getText(sourceFile)
+        )
+      }
+      if (isFunctionDeclaration(statement)) return [statement.name?.text ?? '<anonymous>']
+      return []
+    })
+    .sort()
+
+const constructionSite = (expression: NewExpression): string => {
+  let current: Node | undefined = expression.parent
+  while (current) {
+    if (isConstructorDeclaration(current)) return 'constructor'
+    if (isMethodDeclaration(current)) {
+      return `method:${identifierName(current.name) ?? '<computed>'}`
+    }
+    if (
+      isArrowFunction(current) ||
+      isFunctionExpression(current) ||
+      isFunctionDeclaration(current)
+    ) {
+      return 'nested-function'
+    }
+    current = current.parent
+  }
+  return 'module'
+}
+
+const ownerConstructionSites = (
+  sourceFile: SourceFile = facadeFile
+): ReadonlyMap<string, readonly string[]> => {
+  const sites = new Map<string, string[]>()
+  const visit = (node: Node): void => {
+    if (isNewExpression(node) && isIdentifier(node.expression)) {
+      const ownerSites = sites.get(node.expression.text) ?? []
+      ownerSites.push(constructionSite(node))
+      sites.set(node.expression.text, ownerSites)
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return sites
+}
+
+describe('Notebook runtime facade architecture', () => {
+  it('keeps the compatibility facade within its completion gate', () => {
+    const physicalLines = facadeSource.split(/\r?\n/).length - Number(facadeSource.endsWith('\n'))
+
+    expect(physicalLines).toBeLessThanOrEqual(1200)
+  })
+
+  it('keeps package, repair, and Session lifecycle state behind owners', () => {
+    expect(topLevelValueNames()).toEqual(
+      [
+        'DEFAULT_LOCALE',
+        'EMPTY_NOTEBOOK_RUNTIME_SETTINGS',
+        'dataProcessKey',
+        'resolveDefaultExecutorOptions',
+        'resolveLoopScript',
+        'resolveLoopScriptPaths',
+        'saveIpynbWithDialog'
+      ].sort()
+    )
+    expect(facadeFields()).toEqual(
+      [
+        'dataExecutionAdmission',
+        'disposalPromise',
+        'environmentManagement',
+        'environmentOperations',
+        'environmentStateTracker',
+        'executionOwner',
+        'exportReader',
+        'mcpRpcConnectionResolver',
+        'options',
+        'packageOperations',
+        'recoveryCoordinator',
+        'repairPolicy',
+        'repository',
+        'runTerminalization',
+        'runtimeBindingOwner',
+        'runtimeEnablementResolver',
+        'runtimeLogger',
+        'runtimeRepair',
+        'sessionLifecycle',
+        'sessionReadModel',
+        'sessions'
+      ].sort()
+    )
+    expect(mutableFacadeFields()).toEqual(['disposalPromise', 'mcpRpcConnectionResolver'])
+  })
+
+  it('composes each state owner exactly once', () => {
+    const sites = ownerConstructionSites()
+    const owners = [
+      'NotebookDataExecutionAdmissionOwner',
+      'NotebookEnvironmentManagementOwner',
+      'NotebookEnvironmentOperations',
+      'NotebookExecutionOwner',
+      'NotebookExportReader',
+      'NotebookPackageOperations',
+      'NotebookRecoveryCoordinator',
+      'NotebookRunTerminalizationOwner',
+      'NotebookRuntimeBindingOwner',
+      'NotebookRuntimeRepairOwner',
+      'NotebookRuntimeRepairPolicy',
+      'NotebookSessionLifecycleOwner',
+      'NotebookSessionReadModel',
+      'NotebookSessionRegistry'
+    ]
+
+    for (const owner of owners) expect(sites.get(owner), owner).toEqual(['constructor'])
+  })
+
+  it('keeps the established public facade surface', () => {
+    expect(facadeMethods('public')).toEqual(
+      [
+        'appendCodeCell',
+        'beginCodeCell',
+        'bindRuntime',
+        'blockPrefixRecovery',
+        'clearCorruptRecoveryBlock',
+        'clearRecoveryBlock',
+        'clearRuntimeRecoveryBlock',
+        'completeRuntimeRepair',
+        'describeRuntimeUsage',
+        'dispose',
+        'ensureRecovered',
+        'execute',
+        'executeControl',
+        'executeShell',
+        'exportIpynb',
+        'exportIpynbAll',
+        'finishCodeCell',
+        'getActiveNotebookSessions',
+        'getSessionReference',
+        'inspectPackages',
+        'isDefaultEnvRecoveryBlocked',
+        'isPrefixLiveUnconfirmed',
+        'isPrefixRecoveryBlocked',
+        'listRuntimes',
+        'manageEnvironments',
+        'managePackages',
+        'peekHandoffContext',
+        'recoverInterruptedOperations',
+        'restart',
+        'revokeRuntime',
+        'runCell',
+        'setControlCompletionInterceptor',
+        'setDefaultEnvProvisioner',
+        'setEnvironmentManager',
+        'setMcpRpcConnectionResolver',
+        'shutdown',
+        'shutdownAll',
+        'shutdownSession',
+        'state',
+        'switchRuntime',
+        'withEnvLock'
+      ].sort()
+    )
+  })
+
+  it('keeps only stateless policy helpers in the facade', () => {
+    expect(facadeMethods('private')).toEqual(
+      [
+        'assertPrefixRecoverable',
+        'defaultEnvNameFor',
+        'environmentCaptureTarget',
+        'isDefaultEnvDisabled',
+        'resolveRunEnv',
+        'resolveRuntimeEnablement',
+        'tearDownLanguageBinding'
+      ].sort()
+    )
+  })
+
+  it('rejects module state, duplicate or lazy owners, and protected public methods', () => {
+    const moduleStateFile = sourceFileFor(`${facadeSource}\nconst leakedSessions = new Map()\n`)
+    expect(topLevelValueNames(moduleStateFile)).toContain('leakedSessions')
+
+    const duplicateOwnerFile = sourceFileFor(
+      `${facadeSource}\nnew NotebookSessionLifecycleOwner({} as never)\n`
+    )
+    expect(ownerConstructionSites(duplicateOwnerFile).get('NotebookSessionLifecycleOwner')).toEqual(
+      ['constructor', 'module']
+    )
+
+    const lazyOwnerFile = sourceFileFor(`
+      class NotebookRuntimeService {
+        constructor() {
+          const createOwner = () => new NotebookSessionLifecycleOwner({} as never)
+          void createOwner
+        }
+      }
+    `)
+    expect(ownerConstructionSites(lazyOwnerFile).get('NotebookSessionLifecycleOwner')).toEqual([
+      'nested-function'
+    ])
+
+    const protectedMethodFile = sourceFileFor(
+      facadeSource.replace('  async listRuntimes(', '  protected async listRuntimes(')
+    )
+    expect(facadeMethods('public', facadeClassFrom(protectedMethodFile))).not.toContain(
+      'listRuntimes'
+    )
+  })
+})

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -16,8 +16,6 @@ import type {
   ExportNotebookResult,
   FinishNotebookCodeCellRequest,
   NotebookLanguage,
-  NotebookRunRecord,
-  NotebookRunSource,
   NotebookRunSummary,
   NotebookSessionRequest,
   NotebookSessionReference,
@@ -370,7 +368,7 @@ class NotebookRuntimeService {
       recovery: this.recoveryCoordinator,
       bindings: this.runtimeBindingOwner,
       sessions: () => this.sessions.values(),
-      notifyChanged: (session) => this.notifyNotebookChanged(session as RuntimeSession),
+      notifyChanged: (session) => this.sessionLifecycle.notifyChanged(session as RuntimeSession),
       logger: this.runtimeLogger
     })
     this.sessionReadModel = new NotebookSessionReadModel({
@@ -401,7 +399,7 @@ class NotebookRuntimeService {
       environmentOperations: this.environmentOperations,
       sessions: () => this.sessions.values(),
       findSession: (sessionId) => this.sessions.get(sessionId),
-      notifyChanged: (session) => this.notifyNotebookChanged(session)
+      notifyChanged: (session) => this.sessionLifecycle.notifyChanged(session)
     })
     this.environmentManagement = new NotebookEnvironmentManagementOwner({
       runtimeRoot,
@@ -426,10 +424,10 @@ class NotebookRuntimeService {
       mirrorProbe: options.mirrorProbe,
       resolvePackageMirror: options.getPackageMirror,
       ensureRecovered: () => this.ensureRecovered(),
-      loadSession: (request) => this.ensureSession(request),
+      loadSession: (request) => this.sessionLifecycle.ensure(request),
       findSession: (sessionId) => this.sessions.get(sessionId),
       sessions: () => this.sessions.values(),
-      notifyChanged: (session) => this.notifyNotebookChanged(session),
+      notifyChanged: (session) => this.sessionLifecycle.notifyChanged(session),
       resolveRuntimeEnablement: (language) => this.resolveRuntimeEnablement(language),
       isDefaultEnvironmentDisabled: (language, candidateRuntimeRoot) =>
         this.isDefaultEnvDisabled(language, candidateRuntimeRoot),
@@ -451,7 +449,7 @@ class NotebookRuntimeService {
     })
     this.runTerminalization = new NotebookRunTerminalizationOwner({
       repository: this.repository,
-      notifyChanged: (session) => this.notifyNotebookChanged(session as RuntimeSession)
+      notifyChanged: (session) => this.sessionLifecycle.notifyChanged(session as RuntimeSession)
     })
     this.executionOwner = new NotebookExecutionOwner({
       configRoot: options.configRoot,
@@ -463,7 +461,8 @@ class NotebookRuntimeService {
       persistKernelStatus: (session, status, processKey) =>
         this.sessionLifecycle.persistKernelStatus(session as RuntimeSession, status, processKey),
       getMcpRpcConnectionResolver: () => this.mcpRpcConnectionResolver,
-      notifyAvailable: (session, source) => this.notifyNotebookAvailable(session, source),
+      notifyAvailable: (session, source) =>
+        this.sessionLifecycle.notifyAvailable(session as RuntimeSession, source),
       platform: options.platform,
       shellProcess: options.shellProcess
     })
@@ -564,7 +563,7 @@ class NotebookRuntimeService {
     runtimes: NotebookRuntimeListing[]
     bindings: NotebookRuntimeBindings
   }> {
-    const session = await this.ensureSession(request)
+    const session = await this.sessionLifecycle.ensure(request)
     return this.runtimeBindingOwner.list(session)
   }
 
@@ -574,7 +573,7 @@ class NotebookRuntimeService {
     request: NotebookSessionRequest & { language: NotebookLanguage; runtimeId: string }
   ): Promise<{ bound: NotebookRuntimeBinding; bindings: NotebookRuntimeBindings }> {
     return this.runtimeBindingOwner.runWrite(request.sessionId, async () => {
-      const session = await this.ensureSession(request)
+      const session = await this.sessionLifecycle.ensure(request)
       return this.runtimeBindingOwner.bind(session, request.language, request.runtimeId)
     })
   }
@@ -585,7 +584,7 @@ class NotebookRuntimeService {
     request: NotebookSessionRequest & { language: NotebookLanguage; runtimeId: string }
   ): Promise<{ bound: NotebookRuntimeBinding; bindings: NotebookRuntimeBindings }> {
     return this.runtimeBindingOwner.runWrite(request.sessionId, async () => {
-      const session = await this.ensureSession(request)
+      const session = await this.sessionLifecycle.ensure(request)
       const result = await this.runtimeBindingOwner.switch(
         session,
         request.language,
@@ -599,7 +598,7 @@ class NotebookRuntimeService {
           this.tearDownLanguageBinding(session, request.language, oldEnv)
         }
       )
-      this.notifyNotebookChanged(session)
+      this.sessionLifecycle.notifyChanged(session)
       return result
     })
   }
@@ -661,7 +660,7 @@ class NotebookRuntimeService {
     writeId: string
     status: NotebookCell['status']
   }> {
-    const session = await this.ensureSession(request)
+    const session = await this.sessionLifecycle.ensure(request)
     const cellId = request.cellId ?? `cell-${randomUUID()}`
     const writeId = `write-${randomUUID()}`
     const source = request.source ?? 'agent'
@@ -673,8 +672,8 @@ class NotebookRuntimeService {
       startedAt: Date.now()
     })
 
-    this.notifyNotebookAvailable(session, source)
-    this.notifyNotebookChanged(session)
+    this.sessionLifecycle.notifyAvailable(session, source)
+    this.sessionLifecycle.notifyChanged(session)
 
     return { sessionId: session.sessionId, cellId, writeId, status: cell.status }
   }
@@ -686,9 +685,9 @@ class NotebookRuntimeService {
     writeId: string
     receivedBytes: number
   }> {
-    const session = await this.ensureSession(request)
+    const session = await this.sessionLifecycle.ensure(request)
     const cell = session.appendCellCode(request.cellId, request.writeId, request.delta)
-    this.notifyNotebookChanged(session)
+    this.sessionLifecycle.notifyChanged(session)
 
     return {
       sessionId: session.sessionId,
@@ -705,18 +704,18 @@ class NotebookRuntimeService {
     code: string
     status: NotebookCell['status']
   }> {
-    const session = await this.ensureSession(request)
+    const session = await this.sessionLifecycle.ensure(request)
     const cell = session.finishCellWrite(request.cellId, request.writeId)
-    this.notifyNotebookChanged(session)
+    this.sessionLifecycle.notifyChanged(session)
 
     return { sessionId: session.sessionId, cellId: cell.id, code: cell.code, status: cell.status }
   }
 
   // Compatibility facade: Session lookup and public summary projection stay here; lifecycle is owned.
   async runCell(request: RunNotebookCellRequest): Promise<NotebookRunSummary> {
-    const session = await this.ensureSession(request)
+    const session = await this.sessionLifecycle.ensure(request)
     const run = await this.executionOwner.executeDataCell(session, request)
-    return this.toRunSummary(session, run)
+    return this.sessionReadModel.toRunSummary(session, run)
   }
 
   // Convenience path used by the terminal and MCP to write a temporary cell and run it.
@@ -744,14 +743,14 @@ class NotebookRuntimeService {
   // Compatibility facade for the control-plane REPL. Admission, capability lifetime, dispatch,
   // terminalization, and completion interception belong to NotebookExecutionOwner.
   async executeControl(request: ExecuteNotebookControlRequest): Promise<NotebookControlResult> {
-    const session = await this.ensureSession(request)
+    const session = await this.sessionLifecycle.ensure(request)
     return this.executionOwner.executeControl(session, request)
   }
 
   // Compatibility facade for stateless shell execution. The owner deliberately admits calls without
   // a per-Session queue while the repository continues to serialize durable run writes.
   async executeShell(request: ExecuteShellRequest): Promise<NotebookShellResult> {
-    const session = await this.ensureSession(request)
+    const session = await this.sessionLifecycle.ensure(request)
     return this.executionOwner.executeShell(session, request)
   }
 
@@ -766,7 +765,7 @@ class NotebookRuntimeService {
   async state(
     request: NotebookSessionRequest
   ): Promise<NotebookSessionState & { runtimeBindings: NotebookRuntimeBindings }> {
-    const session = await this.ensureSession(request)
+    const session = await this.sessionLifecycle.ensure(request)
     return this.sessionReadModel.state(session)
   }
 
@@ -801,7 +800,7 @@ class NotebookRuntimeService {
   // and lazily respawns its loops) and only shuts down + recreates for executors that don't support it.
   // Reports 'restarting' for the duration and settles back to 'idle' once the fresh process is ready.
   async restart(request: NotebookSessionRequest): Promise<NotebookSessionState> {
-    const session = await this.ensureSession(request)
+    const session = await this.sessionLifecycle.ensure(request)
 
     // A restart respawns fresh loops, so any pending R-restart recommendation for this session's envs
     // is cleared. Snapshot the keys before teardown drops them from kernelStatuses.
@@ -812,7 +811,7 @@ class NotebookRuntimeService {
       sessionId: session.sessionId,
       status: 'restarting'
     })
-    this.notifyNotebookChanged(session)
+    this.sessionLifecycle.notifyChanged(session)
 
     try {
       await session.restartExecutor(() => this.sessionLifecycle.createExecutor(session.sessionId))
@@ -824,7 +823,7 @@ class NotebookRuntimeService {
         status: 'idle'
       })
     }
-    this.notifyNotebookChanged(session)
+    this.sessionLifecycle.notifyChanged(session)
 
     return this.state(request)
   }
@@ -1026,26 +1025,6 @@ class NotebookRuntimeService {
   // Lists sessions with a cell mid-execution, for the pre-migration active-session warning.
   getActiveNotebookSessions(): { projectName: string; sessionId: string }[] {
     return this.sessionLifecycle.activeSessions()
-  }
-
-  // Creates or returns the runtime session bound to an ACP/chat session id.
-  private async ensureSession(request: NotebookSessionRequest): Promise<RuntimeSession> {
-    return this.sessionLifecycle.ensure(request)
-  }
-
-  // Announces notebook availability only once per agent-started session.
-  private notifyNotebookAvailable(session: RuntimeSession, source: NotebookRunSource): void {
-    this.sessionLifecycle.notifyAvailable(session, source)
-  }
-
-  // Broadcasts state invalidation so the renderer can reload run.json and in-memory cell data.
-  private notifyNotebookChanged(session: RuntimeSession): void {
-    this.sessionLifecycle.notifyChanged(session)
-  }
-
-  // Adds notebook roots and kernel metadata to the run returned to MCP callers.
-  private toRunSummary(session: RuntimeSession, run: NotebookRunRecord): NotebookRunSummary {
-    return this.sessionReadModel.toRunSummary(session, run)
   }
 }
 


### PR DESCRIPTION
## Problem

The Notebook runtime owners are extracted, but the 1,046-line compatibility facade had no executable boundary preventing package, repair, or Session lifecycle state from drifting back. Four private pass-through helpers also obscured direct owner delegation.

## Proposed change

- Remove the four shallow lifecycle/read-model forwarding helpers and delegate directly to the existing owners.
- Add a portable TypeScript-AST architecture certification that enforces the 1,200-line completion gate, exact top-level and facade field ownership, the two intentional mutable facade references, one direct constructor composition per owner, the established public method surface, and the remaining stateless private policy helpers.
- Add synthetic guard regressions for module-level state, duplicate owner construction, lazy owner construction, and public-to-protected surface drift.

The facade now measures 1,046 physical lines. It passes the 1,200-line completion gate and remains 146 lines above the 900-line stretch target.

## Scope and non-goals

- Changed files: `src/main/notebook/runtime-service.ts` and `src/main/notebook/runtime-service.architecture.test.ts`.
- Production raw: 73 lines, 26 additions and 47 deletions. Test raw: 311 lines. The 600-line production split trigger did not fire.
- No new owner, dependency, transport adapter, compatibility branch, or speculative abstraction.
- No redesign of execution, package mutation, repair, runtime selection, environment management, export, or Session lifecycle behavior.

## Compatibility

- Internal composition only; no public or wire contract change.
- Persisted Notebook data, run history, operation journals, identifiers, and data relationships are unchanged.
- User interaction is unchanged.
- Electron, local Web, remote Web, local RPC, MCP, Task, and CLI retain their existing commands, payloads, ordering, authorization, errors, and capability asymmetries.
- Specialist, Permission, and Compute behavior is unchanged.

## Acceptance criteria and validation

All listed checks ran against the final material state. The facade/application/adapter checks ran after the final production edit; the architecture and type checks ran again after the final architecture-guard edit.

- Facade ownership and surface guards -> `npm test -- src/main/notebook/runtime-service.architecture.test.ts` -> 6 passed.
- Facade, export, logging, application, and IPC behavior -> `npm test -- src/main/notebook/runtime-service.architecture.test.ts src/main/notebook/runtime-service.test.ts src/main/notebook/runtime-service.export.test.ts src/main/notebook/runtime-service-logging.integration.test.ts src/main/notebook/application.test.ts src/main/notebook/ipc.test.ts` -> 6 files, 212 passed.
- Application-command, local-RPC, and MCP adapters -> `npm test -- src/main/notebook/application-commands.test.ts src/main/notebook/runtime-application-commands.test.ts src/main/notebook/local-rpc-notebook-adapter.test.ts src/main/notebook/local-rpc-server.test.ts src/main/notebook/local-rpc-server.agents.test.ts src/main/notebook/local-rpc-server.mcpcall.test.ts src/main/notebook/local-rpc-server.skill-import.test.ts src/main/notebook/mcp-server.test.ts` -> 8 files, 135 passed outside the sandbox transport restriction.
- Extracted package, repair, Session, and end-to-end owner coverage -> `npm test -- src/main/notebook/e2e.certification.test.ts src/main/notebook/session-lifecycle.test.ts src/main/notebook/session-read-model.test.ts src/main/notebook/session-aggregate.test.ts src/main/notebook/package-operations.test.ts src/main/notebook/runtime-repair.test.ts` -> 4 files passed, 1 host-runtime file skipped; 15 passed and 9 `RUN_KERNEL_TESTS`-gated tests skipped.
- Node contracts -> `npm run typecheck:node` -> passed.
- Changed-file style -> targeted ESLint and Prettier checks -> passed.
- Patch integrity -> `git diff --check` -> passed.
- Independent final review -> Standards: 0 findings; Spec: 0 findings.

Uncovered local risk is limited to real Python/R kernel execution and operating-system platform lanes. Exact-head CI remains authoritative for the full portable suite and selected macOS/Windows platform checks. This PR must be squash-merged only after exact-head CI and AI review are green.

## Review focus

- Confirm the architecture test rejects state outside the documented facade fields and top-level values.
- Confirm every state owner is constructed exactly once and directly in the service constructor.
- Confirm direct delegation is observationally identical to the removed private wrappers.
- Confirm the public method inventory preserves all supported surfaces without adding parity.