### PR TITLE
fix(settings): enable multimodal input for MiniMax M3

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3416,6 +3416,16 @@ describe('SettingsService: image-input capability', () => {
     const claude = claudeSnapshot.providers.find((p) => p.vendorId === 'anthropic')
     expect(claude?.supportsImageInput).toBe(true)
 
+    // MiniMax defaults to the natively multimodal M3 model.
+    const minimaxSnapshot = await service.upsertProvider({
+      type: 'official',
+      name: 'MiniMax',
+      vendorId: 'minimax',
+      key: 'k'
+    })
+    const minimax = minimaxSnapshot.providers.find((p) => p.vendorId === 'minimax')
+    expect(minimax?.supportsImageInput).toBe(true)
+
     // DeepSeek's default model is text-only.
     const deepseekSnapshot = await service.upsertProvider({
       type: 'official',

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -532,9 +532,11 @@ describe('provider registry', () => {
       expect(isVendorModelMultimodal('zhipu', 'glm-5-turbo')).toBe(false)
     })
 
-    it('returns false for MiniMax models (no vision support)', () => {
-      expect(isVendorModelMultimodal('minimax', 'MiniMax-M3')).toBe(false)
+    it('returns true only for MiniMax M3 models', () => {
+      expect(isVendorModelMultimodal('minimax', 'MiniMax-M3')).toBe(true)
+      expect(isVendorModelMultimodal('minimax', 'MiniMax-M3[1m]')).toBe(true)
       expect(isVendorModelMultimodal('minimax', 'MiniMax-M2.7')).toBe(false)
+      expect(isVendorModelMultimodal('minimax', 'MiniMax-M2.5')).toBe(false)
     })
 
     it('returns true only for Kimi k3 model', () => {

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -463,8 +463,9 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       { id: 'MiniMax-M3[1m]', contextWindow: 1_000_000, reasoningEffort: 'none-high' },
       { id: 'MiniMax-M2.7', contextWindow: 204_800 },
       { id: 'MiniMax-M2.5', contextWindow: 204_800 }
-    ]
-    // MiniMax's chat models are text-only, so no `multimodal` rule (image input stays disabled).
+    ],
+    // M3 is natively multimodal; older M2 models remain text-only.
+    multimodal: { multimodalModels: ['MiniMax-M3', 'MiniMax-M3[1m]'] }
   },
   {
     id: 'stepfun',


### PR DESCRIPTION
## Problem

MiniMax M3 is natively multimodal and supports image input, but the provider registry classified every MiniMax chat model as text-only. As a result, Open Science disabled image attachments when M3 was selected.

Official references:
- https://www.minimax.io/blog/minimax-m3
- https://www.minimax.io/models/text/m3

## Proposed change

- Mark `MiniMax-M3` and `MiniMax-M3[1m]` as multimodal in the shared provider registry.
- Keep MiniMax M2.7 and M2.5 classified as text-only.
- Add registry and SettingsService coverage for the corrected capability.

## Scope and non-goals

This changes only model capability metadata and its regression coverage. It does not change API routing, request translation, model selection, UI layout, or video attachment support.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- MiniMax M3 capability and Settings propagation -> `npm test -- src/shared/provider-registry.test.ts src/main/settings/service.test.ts -t 'image-input capability|isVendorModelMultimodal'` -> passed (24 tests)
- Node and renderer type safety -> `npm run typecheck` -> passed
- Lint -> `npm run lint` -> passed
- Complete portable Vitest suite -> `npm test` -> passed

The complete suite covers the shared `supportsImageInput` consumer contract used by Claude Code, OpenCode, Codex Responses, and Codex Bridge. Platform/E2E lanes were excluded because the change does not affect paths, persistence, packaging, or UI interaction.

Uncovered risk: no live MiniMax API call was made with project credentials.

## Review focus

- Confirm the explicit multimodal allowlist is limited to the two shipped M3 identifiers.
- Confirm M2.7 and M2.5 remain text-only in Open Science.
