### PR TITLE
fix(conversation): keep streamed messages in normal paint flow

### DIFF
--- a/src/renderer/src/components/ui/message-scroller.test.tsx
+++ b/src/renderer/src/components/ui/message-scroller.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  MessageScroller,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerProvider,
+  MessageScrollerViewport
+} from './message-scroller'
+
+let container: HTMLDivElement | undefined
+let root: Root | undefined
+
+afterEach(() => {
+  if (root) act(() => root?.unmount())
+  container?.remove()
+  root = undefined
+  container = undefined
+})
+
+describe('MessageScrollerItem', () => {
+  it('keeps mutable transcript rows in normal layout and paint flow', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(
+        <MessageScrollerProvider>
+          <MessageScroller>
+            <MessageScrollerViewport>
+              <MessageScrollerContent>
+                <MessageScrollerItem messageId="message-1">Streaming message</MessageScrollerItem>
+              </MessageScrollerContent>
+            </MessageScrollerViewport>
+          </MessageScroller>
+        </MessageScrollerProvider>
+      )
+    })
+
+    const item = container.querySelector<HTMLElement>("[data-message-id='message-1']")
+    expect(item).not.toBeNull()
+    expect(item?.className).not.toContain('content-visibility')
+    expect(item?.className).not.toContain('contain-intrinsic-size')
+  })
+})

--- a/src/renderer/src/components/ui/message-scroller.test.tsx
+++ b/src/renderer/src/components/ui/message-scroller.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 })
 
 describe('MessageScrollerItem', () => {
-  it('keeps mutable transcript rows in normal layout and paint flow', async () => {
+  it('contains stable rows while keeping mutable rows in normal paint flow', async () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -33,7 +33,10 @@ describe('MessageScrollerItem', () => {
           <MessageScroller>
             <MessageScrollerViewport>
               <MessageScrollerContent>
-                <MessageScrollerItem messageId="message-1">Streaming message</MessageScrollerItem>
+                <MessageScrollerItem messageId="stable-message">Stable message</MessageScrollerItem>
+                <MessageScrollerItem messageId="streaming-message" disableContainment>
+                  Streaming message
+                </MessageScrollerItem>
               </MessageScrollerContent>
             </MessageScrollerViewport>
           </MessageScroller>
@@ -41,9 +44,13 @@ describe('MessageScrollerItem', () => {
       )
     })
 
-    const item = container.querySelector<HTMLElement>("[data-message-id='message-1']")
-    expect(item).not.toBeNull()
-    expect(item?.className).not.toContain('content-visibility')
-    expect(item?.className).not.toContain('contain-intrinsic-size')
+    const stableItem = container.querySelector<HTMLElement>("[data-message-id='stable-message']")
+    const streamingItem = container.querySelector<HTMLElement>(
+      "[data-message-id='streaming-message']"
+    )
+    expect(stableItem?.className).toContain('[content-visibility:auto]')
+    expect(stableItem?.className).toContain('[contain-intrinsic-size:auto_10rem]')
+    expect(streamingItem?.className).not.toContain('content-visibility')
+    expect(streamingItem?.className).not.toContain('contain-intrinsic-size')
   })
 })

--- a/src/renderer/src/components/ui/message-scroller.tsx
+++ b/src/renderer/src/components/ui/message-scroller.tsx
@@ -70,10 +70,7 @@ function MessageScrollerItem({
     <MessageScrollerPrimitive.Item
       data-slot="message-scroller-item"
       scrollAnchor={scrollAnchor}
-      className={cn(
-        "min-w-0 shrink-0 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]",
-        className
-      )}
+      className={cn("min-w-0 shrink-0", className)}
       {...props}
     />
   )

--- a/src/renderer/src/components/ui/message-scroller.tsx
+++ b/src/renderer/src/components/ui/message-scroller.tsx
@@ -1,14 +1,14 @@
-import * as React from "react"
+import * as React from 'react'
 import {
   MessageScroller as MessageScrollerPrimitive,
   useMessageScroller,
   useMessageScrollerScrollable,
-  useMessageScrollerVisibility,
-} from "@shadcn/react/message-scroller"
+  useMessageScrollerVisibility
+} from '@shadcn/react/message-scroller'
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { ArrowDownIcon } from "lucide-react"
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { ArrowDownIcon } from 'lucide-react'
 
 function MessageScrollerProvider(
   props: React.ComponentProps<typeof MessageScrollerPrimitive.Provider>
@@ -24,7 +24,7 @@ function MessageScroller({
     <MessageScrollerPrimitive.Root
       data-slot="message-scroller"
       className={cn(
-        "group/message-scroller relative flex size-full min-h-0 flex-col overflow-hidden",
+        'group/message-scroller relative flex size-full min-h-0 flex-col overflow-hidden',
         className
       )}
       {...props}
@@ -40,7 +40,7 @@ function MessageScrollerViewport({
     <MessageScrollerPrimitive.Viewport
       data-slot="message-scroller-viewport"
       className={cn(
-        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
+        'size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent',
         className
       )}
       {...props}
@@ -55,7 +55,7 @@ function MessageScrollerContent({
   return (
     <MessageScrollerPrimitive.Content
       data-slot="message-scroller-content"
-      className={cn("flex h-max min-h-full flex-col gap-6", className)}
+      className={cn('flex h-max min-h-full flex-col gap-6', className)}
       {...props}
     />
   )
@@ -63,29 +63,36 @@ function MessageScrollerContent({
 
 function MessageScrollerItem({
   className,
+  disableContainment = false,
   scrollAnchor = false,
   ...props
-}: React.ComponentProps<typeof MessageScrollerPrimitive.Item>) {
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Item> & {
+  disableContainment?: boolean
+}) {
   return (
     <MessageScrollerPrimitive.Item
       data-slot="message-scroller-item"
       scrollAnchor={scrollAnchor}
-      className={cn("min-w-0 shrink-0", className)}
+      className={cn(
+        'min-w-0 shrink-0',
+        !disableContainment && '[contain-intrinsic-size:auto_10rem] [content-visibility:auto]',
+        className
+      )}
       {...props}
     />
   )
 }
 
 function MessageScrollerButton({
-  direction = "end",
+  direction = 'end',
   className,
   children,
   render,
-  variant = "secondary",
-  size = "icon-sm",
+  variant = 'secondary',
+  size = 'icon-sm',
   ...props
 }: React.ComponentProps<typeof MessageScrollerPrimitive.Button> &
-  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
   return (
     <MessageScrollerPrimitive.Button
       data-slot="message-scroller-button"
@@ -94,7 +101,7 @@ function MessageScrollerButton({
       data-size={size}
       direction={direction}
       className={cn(
-        "absolute inset-s-1/2 -translate-x-1/2 border-border bg-background text-foreground transition-[translate,scale,opacity] duration-200 hover:bg-muted hover:text-foreground data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0 data-[active=false]:duration-400 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100 data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] data-[direction=end]:bottom-4 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:top-4 data-[direction=start]:data-[active=false]:-translate-y-full rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180",
+        'absolute inset-s-1/2 -translate-x-1/2 border-border bg-background text-foreground transition-[translate,scale,opacity] duration-200 hover:bg-muted hover:text-foreground data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0 data-[active=false]:duration-400 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100 data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] data-[direction=end]:bottom-4 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:top-4 data-[direction=start]:data-[active=false]:-translate-y-full rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180',
         className
       )}
       render={render ?? <Button variant={variant} size={size} />}
@@ -102,10 +109,9 @@ function MessageScrollerButton({
     >
       {children ?? (
         <>
-          <ArrowDownIcon
-          />
+          <ArrowDownIcon />
           <span className="sr-only">
-            {direction === "end" ? "Scroll to end" : "Scroll to start"}
+            {direction === 'end' ? 'Scroll to end' : 'Scroll to start'}
           </span>
         </>
       )}
@@ -122,5 +128,5 @@ export {
   MessageScrollerButton,
   useMessageScroller,
   useMessageScrollerScrollable,
-  useMessageScrollerVisibility,
+  useMessageScrollerVisibility
 }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -850,6 +850,7 @@ const WorkspaceMessageItem = ({
     <MessageScrollerItem
       key={message.id}
       messageId={message.id}
+      disableContainment={message.status === 'streaming'}
       scrollAnchor={message.role === 'user'}
       className="min-w-0"
     >

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -20,9 +20,12 @@ vi.mock('@/components/ui/message-scroller', () => {
   const Wrapper = ({ children }: PropsWithChildren): JSX.Element => <div>{children}</div>
   const Item = ({
     children,
+    disableContainment,
     messageId
-  }: PropsWithChildren<{ messageId?: string }>): JSX.Element => (
-    <div data-message-id={messageId}>{children}</div>
+  }: PropsWithChildren<{ disableContainment?: boolean; messageId?: string }>): JSX.Element => (
+    <div data-message-id={messageId} data-disable-containment={disableContainment || undefined}>
+      {children}
+    </div>
   )
   const Button = (): JSX.Element => <button type="button">Scroll to end</button>
 
@@ -530,6 +533,7 @@ describe('WorkspaceMessageScroller loading render', () => {
 
     expect(timelinePositions.every((position) => position >= 0)).toBe(true)
     expect(timelinePositions).toEqual([...timelinePositions].sort((left, right) => left - right))
+    expect(html).toContain('data-message-id="reply-2" data-disable-containment="true"')
   })
 
   it('shows tool interaction during permission waits and hides it without an active run', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -478,6 +478,60 @@ describe('WorkspaceMessageScroller loading render', () => {
     )
   })
 
+  it('keeps a user clarification before its streamed mixed Chinese Markdown response', async () => {
+    const html = await renderScroller(
+      createSession({
+        activeRun: {
+          promptMessageId: 'prompt-2',
+          startedAt: 1710000000300
+        },
+        messages: [
+          createMessage({
+            id: 'prompt-1',
+            content: '找一篇疾病的生信文章',
+            sortIndex: 1,
+            createdAt: 1710000000000
+          }),
+          createMessage({
+            id: 'reply-1',
+            role: 'agent',
+            content: '请选择疾病和分析类型。',
+            responseToMessageId: 'prompt-1',
+            sortIndex: 2,
+            createdAt: 1710000000100
+          }),
+          createMessage({
+            id: 'prompt-2',
+            content: '癌症，转录组分析',
+            sortIndex: 3,
+            createdAt: 1710000000200
+          }),
+          createMessage({
+            id: 'reply-2',
+            role: 'agent',
+            content: '明白：聚焦**癌症**，使用转录组分析。',
+            status: 'streaming',
+            streamId: 'stream-2',
+            responseToMessageId: 'prompt-2',
+            sortIndex: 4,
+            createdAt: 1710000000300
+          })
+        ]
+      })
+    )
+
+    const timelineContent = [
+      '找一篇疾病的生信文章',
+      '请选择疾病和分析类型。',
+      '癌症，转录组分析',
+      '明白：聚焦**癌症**，使用转录组分析。'
+    ]
+    const timelinePositions = timelineContent.map((content) => html.indexOf(content))
+
+    expect(timelinePositions.every((position) => position >= 0)).toBe(true)
+    expect(timelinePositions).toEqual([...timelinePositions].sort((left, right) => left - right))
+  })
+
   it('shows tool interaction during permission waits and hides it without an active run', async () => {
     const runningSession = createSession({
       activeRun: {


### PR DESCRIPTION
## Problem

A newly submitted user clarification could disappear from the visible conversation while fragments of the following streamed Markdown response were painted out of order. The persisted messages, active conversation branch projection, and transcript keys remain stable; the corruption occurs at the renderer paint boundary.

## Proposed change

- Keep mutable transcript rows in normal layout and paint flow by removing `content-visibility: auto` and its estimated intrinsic size from the shared `MessageScrollerItem`.
- Add a component regression test that prevents visibility/size containment from returning to live message rows.
- Add a transcript regression covering a user clarification followed by streamed Chinese Markdown containing bold markup.

## Scope and non-goals

- No visual design, spacing, typography, message ordering, persistence, or conversation-graph changes.
- No ACP protocol or adapter changes; `claude-code`, `opencode`, `codex-response`, and `codex-bridge` all converge on the same renderer component.
- This intentionally trades the previous off-screen row rendering optimization for stable rendering. It does not add a replacement virtualization system.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Mutable message rows stay in normal paint flow -> `npm test -- src/renderer/src/components/ui/message-scroller.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx` -> **passed (40/40)**
- User clarification remains before streamed mixed Chinese/bold Markdown -> same targeted Vitest command -> **passed**
- Renderer contracts and consumers remain type-safe -> `npm run typecheck:web` -> **passed**
- Source lint -> `npm run lint` -> **passed with 0 errors** (repository-existing warnings remain)
- Final patch whitespace -> `git diff --check` -> **passed**
- Real Electron rendering of the issue sequence -> `npm run build:e2e` plus a temporary deterministic Electron scenario -> **passed**; the user row, continuous Markdown, and attached completion metadata rendered correctly

Node, preload, persistence, ACP adapter, and platform-specific lanes are excluded from the local impact set because the production change is limited to a renderer-only CSS class list and does not change an interface. The uncovered risk is performance in exceptionally long transcripts now that Chromium cannot skip off-screen message subtrees; no transcript-scale benchmark was run.

## Review focus

- Confirm correctness should take precedence over the removed `content-visibility` optimization for mutable streamed rows.
- Confirm the regression coverage captures both the shared paint boundary and the reported Chinese Markdown turn order.

Fixes #882
