### PR TITLE
fix(agent-runtime): harden Plan approval and Connector discovery

### DIFF
--- a/src/main/acp/runtime-plan-composition.test.ts
+++ b/src/main/acp/runtime-plan-composition.test.ts
@@ -253,6 +253,23 @@ describe('ACP Session Plan approval causality', () => {
 })
 
 describe('ACP Runtime Session Plan composition', () => {
+  it('clears exact decision authorization when prompt supersession releases first', () => {
+    const harness = createHarness()
+    if (harness.interaction.kind !== 'prompt') throw new Error('Expected a prompt interaction.')
+    const authorization = {
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionSequence: harness.interaction.sequence
+    }
+    harness.interactions.authorizeAgentDecision(authorization)
+    const cancel = harness.workflow.capturePromptCancellation('session-1')
+
+    harness.sessionInteractions.release(harness.interaction)
+    cancel()
+
+    expect(harness.interactions.isAgentDecisionAuthorized(authorization)).toBe(false)
+  })
+
   it('authorizes one Agent decision from restored pending Plan feedback without execution authority', async () => {
     const harness = createHarness()
     const request: AcpPromptRequest = {

--- a/src/main/acp/runtime-plan-composition.test.ts
+++ b/src/main/acp/runtime-plan-composition.test.ts
@@ -17,6 +17,7 @@ vi.mock('../logger', async (importOriginal) => {
   }
 })
 
+import type { AcpPromptRequest } from '../../shared/acp'
 import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
 import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
@@ -252,6 +253,38 @@ describe('ACP Session Plan approval causality', () => {
 })
 
 describe('ACP Runtime Session Plan composition', () => {
+  it('authorizes one Agent decision from restored pending Plan feedback without execution authority', async () => {
+    const harness = createHarness()
+    const request: AcpPromptRequest = {
+      sessionId: 'session-1',
+      text: 'The restored Plan looks good.',
+      planContinuation: {
+        projectId: 'project-1',
+        artifactVersionId: 'version-1',
+        expectedRevision: 1,
+        pendingAction: 'review'
+      }
+    }
+
+    const protectedPlan = await harness.workflow.prompt.preflight(request)
+    if (harness.interaction.kind !== 'prompt') throw new Error('Expected a prompt interaction.')
+    const interaction = harness.interaction
+    const admitted = await harness.workflow.prompt.admit(request, interaction, protectedPlan)
+
+    expect(admitted.protectedPending).toMatchObject({ approval: 'pending' })
+    expect(
+      harness.interactions.isAgentDecisionAuthorized({
+        sessionId: 'session-1',
+        artifactVersionId: 'version-1',
+        interactionSequence: interaction.sequence
+      })
+    ).toBe(true)
+    expect(harness.interactions.executionBindingFor('session-1')).toBeUndefined()
+
+    harness.workflow.prompt.beforeRelease('session-1', interaction)
+    harness.sessionInteractions.release(interaction)
+  })
+
   it('builds a fresh frozen workflow without publishing or requiring Plan capability', async () => {
     const options = { appVersion: 'test', defaultCwd: '/workspace' }
     const create = (): ReturnType<typeof composeAcpRuntimePlanWorkflow> => {

--- a/src/main/acp/runtime-plan-composition.test.ts
+++ b/src/main/acp/runtime-plan-composition.test.ts
@@ -1,13 +1,255 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const loggerSpies = vi.hoisted(() => ({ info: vi.fn(), error: vi.fn() }))
+vi.mock('../logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logger')>()
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: loggerSpies.info,
+      warn: vi.fn(),
+      error: loggerSpies.error
+    })
+  }
+})
+
+import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
+import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+import { AcpSessionInteractionOwner } from './session-interaction-owner'
 import { composeAcpRuntimePlanWorkflow } from './runtime-plan-composition'
 import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
 
 const projectRoot = resolve(__dirname, '../../..')
+
+const pendingProjection = (): ActivePlanProjection => ({
+  artifactId: 'artifact-1',
+  artifactVersionId: 'version-1',
+  artifactChecksum: 'a'.repeat(64),
+  originatingPromptMessageId: 'prompt-1',
+  revision: 1,
+  approval: 'pending',
+  lifecycle: 'awaiting_approval',
+  requiresExplicitContinuation: false,
+  document: {
+    schema_version: 1,
+    task_summary: 'private-task-summary-marker',
+    phases: [
+      {
+        name: 'Analysis',
+        delegations: [
+          {
+            name: 'Primary agent',
+            steps: [
+              { title: 'private-step-title-marker', description: 'private-step-description-marker' }
+            ]
+          }
+        ]
+      }
+    ],
+    desired_outputs: ['Result'],
+    feasibility: { confidence: 'high', rationale: 'Ready.' }
+  },
+  stepStatuses: {},
+  stepStates: { 'private-step-title-marker': { status: 'not_started' } },
+  counts: { phases: 1, delegations: 1, steps: 1, completed: 0, inProgress: 0 }
+})
+
+const approvedProjection = (revision: number): ActivePlanProjection => ({
+  ...pendingProjection(),
+  revision,
+  approval: 'approved',
+  lifecycle: 'approved'
+})
+
+const createHarness = (): {
+  workflow: ReturnType<typeof composeAcpRuntimePlanWorkflow>
+  interactions: SessionPlanInteractionOwner
+  sessionInteractions: AcpSessionInteractionOwner
+  interaction: ReturnType<AcpSessionInteractionOwner['claim']>
+  respond: ReturnType<typeof vi.fn>
+} => {
+  const interactions = new SessionPlanInteractionOwner()
+  const sessionInteractions = new AcpSessionInteractionOwner()
+  const interaction = sessionInteractions.claim({
+    sessionId: 'session-1',
+    kind: 'prompt',
+    promptMessageId: 'prompt-1'
+  })
+  let current = pendingProjection()
+  const generate = vi.fn(async () => {
+    interactions.register({
+      sessionId: 'session-1',
+      artifactVersionId: current.artifactVersionId,
+      interactionId: 'prompt-1'
+    })
+    return { projection: current, pauseInteraction: true as const }
+  })
+  const respond = vi.fn(async (rawInput: unknown) => {
+    const input = rawInput as { feedback?: string; decision?: 'approved' | 'rejected' }
+    if (input.feedback !== undefined) {
+      interactions.release('session-1', current.artifactVersionId)
+      return {
+        kind: 'feedback' as const,
+        routeToInteractionId: 'prompt-1',
+        artifactVersionId: current.artifactVersionId,
+        text: input.feedback,
+        message: {
+          id: 'feedback-message-1',
+          role: 'user' as const,
+          content: input.feedback,
+          createdAt: 42,
+          responseToMessageId: 'prompt-1'
+        }
+      }
+    }
+    current =
+      input.decision === 'approved'
+        ? approvedProjection(current.revision + 1)
+        : { ...current, approval: 'rejected' as const, lifecycle: 'rejected' as const }
+    return { projection: current, changed: true }
+  })
+  const updateStepStatus = vi.fn(async () => {
+    current = approvedProjection(current.revision + 1)
+    return { projection: current, changed: true }
+  })
+  const service = {
+    generate,
+    respond,
+    updateStepStatus,
+    getProjection: vi.fn(async () => current)
+  }
+  const publication = { pushEvent: vi.fn() }
+  const workflow = composeAcpRuntimePlanWorkflow(
+    {
+      plan: {
+        sessions: { containsMessageOnActiveBranch: vi.fn(async () => true) }
+      }
+    } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[0],
+    {
+      planService: service,
+      planInteractions: interactions,
+      sessionInteractions,
+      artifactTurns: { promptMessageIdFor: vi.fn(() => 'prompt-1') }
+    } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[1],
+    {
+      publication,
+      sessionEnvironment: { projectName: vi.fn(() => 'project-1') }
+    } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[2]
+  )
+
+  return { workflow, interactions, sessionInteractions, interaction, respond }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ACP Session Plan approval causality', () => {
+  it('rejects concurrent Agent self-approval, then accepts one decision after routed human feedback', async () => {
+    const harness = createHarness()
+    const generation = harness.workflow.call({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'generate',
+      input: {}
+    })
+    await vi.waitFor(() =>
+      expect(harness.interactions.approvalInteractionIdFor('session-1')).toBe('prompt-1')
+    )
+
+    await expect(
+      harness.workflow.call({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'approve'
+      })
+    ).rejects.toMatchObject({ code: 'interaction-mismatch' })
+    expect(harness.respond).not.toHaveBeenCalled()
+
+    const feedback = await harness.workflow.respond({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      feedback: 'private-feedback-marker'
+    })
+    await expect(generation).resolves.toEqual(feedback)
+
+    await expect(
+      harness.workflow.call({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'approve'
+      })
+    ).resolves.toMatchObject({ projection: { approval: 'approved' } })
+
+    await harness.workflow.call({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'updateStepStatus',
+      input: { title: 'private-step-title-marker', status: 'in_progress' }
+    })
+
+    expect(loggerSpies.info).toHaveBeenCalledWith(
+      'Session Plan response accepted',
+      expect.objectContaining({ source: 'agent-after-feedback', decision: 'approved' })
+    )
+    expect(loggerSpies.info).toHaveBeenCalledWith(
+      'Session Plan step status updated',
+      expect.objectContaining({ status: 'in_progress', changed: true })
+    )
+    const auditPayload = JSON.stringify(loggerSpies.info.mock.calls)
+    expect(auditPayload).not.toContain('private-feedback-marker')
+    expect(auditPayload).not.toContain('private-task-summary-marker')
+    expect(auditPayload).not.toContain('private-step-title-marker')
+    expect(auditPayload).not.toContain('private-step-description-marker')
+    harness.sessionInteractions.release(harness.interaction)
+  })
+
+  it('keeps a direct human Plan button authoritative and audits its source', async () => {
+    const harness = createHarness()
+    const generation = harness.workflow.call({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'generate',
+      input: {}
+    })
+    await vi.waitFor(() =>
+      expect(harness.interactions.approvalInteractionIdFor('session-1')).toBe('prompt-1')
+    )
+    harness.interactions.authorizeAgentDecision({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionSequence: harness.interaction.sequence
+    })
+
+    const decision: PlanResponseCommand = {
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      expectedRevision: 1,
+      decision: 'approved'
+    }
+    const result = await harness.workflow.respond(decision)
+
+    await expect(generation).resolves.toEqual(result)
+    expect(
+      harness.interactions.isAgentDecisionAuthorized({
+        sessionId: 'session-1',
+        artifactVersionId: 'version-1',
+        interactionSequence: harness.interaction.sequence
+      })
+    ).toBe(false)
+    expect(loggerSpies.info).toHaveBeenCalledWith(
+      'Session Plan response accepted',
+      expect.objectContaining({ source: 'human-button', decision: 'approved' })
+    )
+    harness.sessionInteractions.release(harness.interaction)
+  })
+})
 
 describe('ACP Runtime Session Plan composition', () => {
   it('builds a fresh frozen workflow without publishing or requiring Plan capability', async () => {

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -210,11 +210,18 @@ const composeAcpRuntimePlanWorkflow = (
         })
       if (decision === 'approved') {
         if (requiresHumanFeedback && authorization) {
-          interactions.bindExecution({
-            sessionId: input.sessionId,
-            interactionSequence: authorization.interactionSequence,
-            artifactVersionId: result.projection.artifactVersionId
-          })
+          if (result.changed) {
+            interactions.bindExecution({
+              sessionId: input.sessionId,
+              interactionSequence: authorization.interactionSequence,
+              artifactVersionId: result.projection.artifactVersionId
+            })
+          } else {
+            interactions.releaseAgentDecisionAuthorization(
+              input.sessionId,
+              authorization.interactionSequence
+            )
+          }
         } else {
           bindExecutionToCurrentInteraction(input.sessionId, result.projection.artifactVersionId)
         }

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -211,11 +211,17 @@ const composeAcpRuntimePlanWorkflow = (
       if (decision === 'approved') {
         if (requiresHumanFeedback && authorization) {
           if (result.changed) {
-            interactions.bindExecution({
-              sessionId: input.sessionId,
-              interactionSequence: authorization.interactionSequence,
-              artifactVersionId: result.projection.artifactVersionId
-            })
+            const currentExecution = interactions.executionBindingFor(input.sessionId)
+            if (
+              !currentExecution ||
+              currentExecution.interactionSequence <= authorization.interactionSequence
+            ) {
+              interactions.bindExecution({
+                sessionId: input.sessionId,
+                interactionSequence: authorization.interactionSequence,
+                artifactVersionId: result.projection.artifactVersionId
+              })
+            }
           } else {
             interactions.releaseAgentDecisionAuthorization(
               input.sessionId,

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -586,10 +586,14 @@ const composeAcpRuntimePlanWorkflow = (
   })
   const capturePromptCancellation = (sessionId: string): (() => void) => {
     const interaction = sessionInteractions.current(sessionId)
+    const interactionSequence = interaction?.kind === 'prompt' ? interaction.sequence : undefined
     const interactionId =
       (interaction?.kind === 'prompt' ? interaction.promptMessageId : undefined) ??
       interactions.approvalInteractionIdFor(sessionId)
     return () => {
+      if (interactionSequence !== undefined) {
+        interactions.releaseAgentDecisionAuthorization(sessionId, interactionSequence)
+      }
       if (interactionId) {
         rejectApprovalForInteraction(
           sessionId,

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -294,10 +294,26 @@ const composeAcpRuntimePlanWorkflow = (
     }) ?? Promise.resolve(null)
   const respond = async (input: PlanResponseCommand): Promise<PlanResponseResult> => {
     if (!service) throw new Error('Session Plan capability is not configured.')
-    if (input.decision === undefined && !interactions.approvalInteractionIdFor(input.sessionId)) {
-      throw new Error('The paused Session Plan interaction is no longer available.')
+    const approvalInteractionId = interactions.approvalInteractionIdFor(input.sessionId)
+    const feedbackInteraction =
+      input.decision === undefined ? sessionInteractions.current(input.sessionId) : undefined
+    if (input.decision === undefined) {
+      if (
+        !approvalInteractionId ||
+        feedbackInteraction?.kind !== 'prompt' ||
+        feedbackInteraction.promptMessageId !== approvalInteractionId
+      ) {
+        if (approvalInteractionId) {
+          rejectApprovalForInteraction(
+            input.sessionId,
+            approvalInteractionId,
+            'The paused Session Plan interaction was superseded before feedback was routed.'
+          )
+        }
+        throw new Error('The paused Session Plan interaction is no longer available.')
+      }
     }
-    const interactionIsLive = interactions.approvalInteractionIdFor(input.sessionId) !== undefined
+    const interactionIsLive = approvalInteractionId !== undefined
     const current = await service.getProjection(input.projectId, input.sessionId, {
       interactionIsLive
     })
@@ -325,9 +341,6 @@ const composeAcpRuntimePlanWorkflow = (
       publishProjection(input.sessionId, result.projection)
       return result
     }
-    if (interactions.approvalInteractionIdFor(input.sessionId) !== result.routeToInteractionId) {
-      throw new Error('The paused Session Plan interaction is no longer available.')
-    }
     try {
       pushEvent({
         id: `session-user-message-${result.message.id}`,
@@ -343,18 +356,34 @@ const composeAcpRuntimePlanWorkflow = (
     } catch (error) {
       safeLogError('Routed user Message projection callback failed', error)
     }
-    const interaction = sessionInteractions.current(input.sessionId)
-    if (!interaction || interaction.kind !== 'prompt') {
+    const currentInteraction = sessionInteractions.current(input.sessionId)
+    if (
+      !approvalInteractionId ||
+      !feedbackInteraction ||
+      feedbackInteraction.kind !== 'prompt' ||
+      result.routeToInteractionId !== approvalInteractionId ||
+      interactions.approvalInteractionIdFor(input.sessionId) !== approvalInteractionId ||
+      currentInteraction?.kind !== 'prompt' ||
+      currentInteraction.sequence !== feedbackInteraction.sequence ||
+      currentInteraction.promptMessageId !== feedbackInteraction.promptMessageId
+    ) {
+      if (approvalInteractionId) {
+        rejectApprovalForInteraction(
+          input.sessionId,
+          approvalInteractionId,
+          'The paused Session Plan interaction was superseded while feedback was routed.'
+        )
+      }
       throw new Error('The paused Session Plan interaction is no longer available.')
     }
     const authorization = {
       sessionId: input.sessionId,
       artifactVersionId: result.artifactVersionId,
-      interactionSequence: interaction.sequence
+      interactionSequence: feedbackInteraction.sequence
     }
     interactions.authorizeAgentDecision(authorization)
     if (!interactions.resolveApproval(input.sessionId, result)) {
-      interactions.releaseAgentDecisionAuthorization(input.sessionId, interaction.sequence)
+      interactions.releaseAgentDecisionAuthorization(input.sessionId, feedbackInteraction.sequence)
       throw new Error('The paused Session Plan interaction is no longer available.')
     }
     safeLogInfo('Session Plan feedback routed', {

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -177,32 +177,33 @@ const composeAcpRuntimePlanWorkflow = (
         )
       }
       const executionBinding = interactions.executionBindingFor(input.sessionId)
-      const result = await service.respond({ ...identity, decision, interactionIsLive })
-      if (requiresHumanFeedback && authorization) {
-        const authorizationConsumed = interactions.consumeAgentDecisionAuthorization(authorization)
-        const currentInteraction = sessionInteractions.current(input.sessionId)
-        if (
-          !authorizationConsumed ||
-          currentInteraction?.kind !== 'prompt' ||
-          currentInteraction.sequence !== authorization.interactionSequence
-        ) {
-          safeLogInfo('Session Plan response discarded', {
-            projectId: input.projectId,
-            sessionId: input.sessionId,
-            artifactVersionId: result.projection.artifactVersionId,
-            revision: result.projection.revision,
-            source: 'agent-after-feedback',
-            decision,
-            reason: 'authorization-revoked'
-          })
-          throw new PlanCommandError(
-            'interaction-mismatch',
-            'The Session Plan decision authorization was revoked before the response completed.'
-          )
-        }
-      }
+      const beforeDecisionCommit =
+        requiresHumanFeedback && authorization
+          ? (): boolean => {
+              const currentInteraction = sessionInteractions.current(input.sessionId)
+              return (
+                currentInteraction?.kind === 'prompt' &&
+                currentInteraction.sequence === authorization.interactionSequence &&
+                interactions.consumeAgentDecisionAuthorization(authorization)
+              )
+            }
+          : undefined
+      const result = await service.respond({
+        ...identity,
+        decision,
+        interactionIsLive,
+        ...(beforeDecisionCommit ? { beforeDecisionCommit } : {})
+      })
       if (decision === 'approved') {
-        bindExecutionToCurrentInteraction(input.sessionId, result.projection.artifactVersionId)
+        if (requiresHumanFeedback && authorization) {
+          interactions.bindExecution({
+            sessionId: input.sessionId,
+            interactionSequence: authorization.interactionSequence,
+            artifactVersionId: result.projection.artifactVersionId
+          })
+        } else {
+          bindExecutionToCurrentInteraction(input.sessionId, result.projection.artifactVersionId)
+        }
       } else if (executionBinding) {
         interactions.releaseExecution(input.sessionId, executionBinding.interactionSequence)
       }

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -511,6 +511,13 @@ const composeAcpRuntimePlanWorkflow = (
           return committed()
         })
     }
+    if (continuation?.pendingAction === 'review' && protectedPending) {
+      interactions.authorizeAgentDecision({
+        sessionId: request.sessionId,
+        interactionSequence: interaction.sequence,
+        artifactVersionId: protectedPending.artifactVersionId
+      })
+    }
     return committed()
   }
   const beforeRelease = (

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -326,7 +326,38 @@ const composeAcpRuntimePlanWorkflow = (
     })
     if (!current) throw new Error('The Session has no active Plan.')
     await assertVisibleToDurableBranch(input.projectId, input.sessionId, current)
-    const result = await service.respond({ ...input, interactionIsLive })
+    const beforeFeedbackPersist =
+      input.decision === undefined &&
+      approvalInteractionId &&
+      feedbackInteraction?.kind === 'prompt'
+        ? (): void => {
+            const activeInteraction = sessionInteractions.current(input.sessionId)
+            if (
+              interactions.approvalInteractionIdFor(input.sessionId) === approvalInteractionId &&
+              interactions.interactionIdFor(input.sessionId, current.artifactVersionId) ===
+                approvalInteractionId &&
+              activeInteraction?.kind === 'prompt' &&
+              activeInteraction.sequence === feedbackInteraction.sequence &&
+              activeInteraction.promptMessageId === feedbackInteraction.promptMessageId
+            ) {
+              return
+            }
+            rejectApprovalForInteraction(
+              input.sessionId,
+              approvalInteractionId,
+              'The paused Session Plan interaction was superseded before feedback was persisted.'
+            )
+            throw new PlanCommandError(
+              'interaction-mismatch',
+              'The paused Session Plan interaction is no longer available.'
+            )
+          }
+        : undefined
+    const result = await service.respond({
+      ...input,
+      interactionIsLive,
+      ...(beforeFeedbackPersist ? { beforeFeedbackPersist } : {})
+    })
     if ('projection' in result) {
       const interaction = sessionInteractions.current(input.sessionId)
       if (interactionIsLive && result.projection.approval === 'approved') {
@@ -348,16 +379,11 @@ const composeAcpRuntimePlanWorkflow = (
       publishProjection(input.sessionId, result.projection)
       return result
     }
-    const currentInteraction = sessionInteractions.current(input.sessionId)
     if (
       !approvalInteractionId ||
       !feedbackInteraction ||
       feedbackInteraction.kind !== 'prompt' ||
-      result.routeToInteractionId !== approvalInteractionId ||
-      interactions.approvalInteractionIdFor(input.sessionId) !== approvalInteractionId ||
-      currentInteraction?.kind !== 'prompt' ||
-      currentInteraction.sequence !== feedbackInteraction.sequence ||
-      currentInteraction.promptMessageId !== feedbackInteraction.promptMessageId
+      result.routeToInteractionId !== approvalInteractionId
     ) {
       if (approvalInteractionId) {
         rejectApprovalForInteraction(
@@ -368,6 +394,11 @@ const composeAcpRuntimePlanWorkflow = (
       }
       throw new Error('The paused Session Plan interaction is no longer available.')
     }
+    const currentInteraction = sessionInteractions.current(input.sessionId)
+    const interactionIsCurrent =
+      currentInteraction?.kind === 'prompt' &&
+      currentInteraction.sequence === feedbackInteraction.sequence &&
+      currentInteraction.promptMessageId === feedbackInteraction.promptMessageId
     try {
       pushEvent({
         id: `session-user-message-${result.message.id}`,
@@ -383,15 +414,15 @@ const composeAcpRuntimePlanWorkflow = (
     } catch (error) {
       safeLogError('Routed user Message projection callback failed', error)
     }
-    const authorization = {
-      sessionId: input.sessionId,
-      artifactVersionId: result.artifactVersionId,
-      interactionSequence: feedbackInteraction.sequence
+    if (interactionIsCurrent) {
+      interactions.authorizeAgentDecision({
+        sessionId: input.sessionId,
+        artifactVersionId: result.artifactVersionId,
+        interactionSequence: feedbackInteraction.sequence
+      })
     }
-    interactions.authorizeAgentDecision(authorization)
-    if (!interactions.resolveApproval(input.sessionId, result)) {
+    if (!interactions.resolveApproval(input.sessionId, result) && interactionIsCurrent) {
       interactions.releaseAgentDecisionAuthorization(input.sessionId, feedbackInteraction.sequence)
-      throw new Error('The paused Session Plan interaction is no longer available.')
     }
     safeLogInfo('Session Plan feedback routed', {
       projectId: input.projectId,

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -31,6 +31,14 @@ const safeLogError = (message: string, error: unknown): void => {
   }
 }
 
+const safeLogInfo = (message: string, fields: Record<string, unknown>): void => {
+  try {
+    log.info(message, fields)
+  } catch {
+    // Plan state and the original operation result take precedence over diagnostics.
+  }
+}
+
 // Composes ACP-facing Session Plan application policy around the authoritative Plan, interaction,
 // Artifact, durable-branch, and publication owners. It owns no mutable state of its own.
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
@@ -126,6 +134,12 @@ const composeAcpRuntimePlanWorkflow = (
         interactions.release(input.sessionId, result.projection.artifactVersionId)
         throw error
       }
+      safeLogInfo('Session Plan generated', {
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        artifactVersionId: result.projection.artifactVersionId,
+        revision: result.projection.revision
+      })
       publishProjection(input.sessionId, result.projection)
       return approval
     }
@@ -141,16 +155,47 @@ const composeAcpRuntimePlanWorkflow = (
       expectedRevision: projection.revision
     }
     if (input.operation === 'approve' || input.operation === 'reject') {
-      const interactionIsLive = sessionInteractions.current(input.sessionId) !== undefined
+      const interaction = sessionInteractions.current(input.sessionId)
+      const interactionIsLive = interaction !== undefined
       const decision = input.operation === 'approve' ? 'approved' : 'rejected'
+      const requiresHumanFeedback = projection.approval === 'pending'
+      const authorization =
+        interaction?.kind === 'prompt'
+          ? {
+              sessionId: input.sessionId,
+              artifactVersionId: projection.artifactVersionId,
+              interactionSequence: interaction.sequence
+            }
+          : undefined
+      if (
+        requiresHumanFeedback &&
+        (!authorization || !interactions.isAgentDecisionAuthorized(authorization))
+      ) {
+        throw new PlanCommandError(
+          'interaction-mismatch',
+          'A pending Session Plan decision requires post-generation human feedback.'
+        )
+      }
       const executionBinding = interactions.executionBindingFor(input.sessionId)
       const result = await service.respond({ ...identity, decision, interactionIsLive })
+      if (requiresHumanFeedback && authorization) {
+        interactions.consumeAgentDecisionAuthorization(authorization)
+      }
       if (decision === 'approved') {
         bindExecutionToCurrentInteraction(input.sessionId, result.projection.artifactVersionId)
       } else if (executionBinding) {
         interactions.releaseExecution(input.sessionId, executionBinding.interactionSequence)
       }
       interactions.resolveApproval(input.sessionId, result)
+      safeLogInfo('Session Plan response accepted', {
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        artifactVersionId: result.projection.artifactVersionId,
+        revision: result.projection.revision,
+        source: requiresHumanFeedback ? 'agent-after-feedback' : 'agent-continuation',
+        decision,
+        changed: result.changed
+      })
       publishProjection(input.sessionId, result.projection)
       return result
     }
@@ -197,6 +242,14 @@ const composeAcpRuntimePlanWorkflow = (
       status: update.status,
       ...(update.notes ? { notes: update.notes } : {})
     })
+    safeLogInfo('Session Plan step status updated', {
+      projectId: input.projectId,
+      sessionId: input.sessionId,
+      artifactVersionId: result.projection.artifactVersionId,
+      revision: result.projection.revision,
+      status: update.status,
+      changed: result.changed
+    })
     publishProjection(input.sessionId, result.projection)
     return result
   }
@@ -217,10 +270,23 @@ const composeAcpRuntimePlanWorkflow = (
     await assertVisibleToDurableBranch(input.projectId, input.sessionId, current)
     const result = await service.respond({ ...input, interactionIsLive })
     if ('projection' in result) {
+      const interaction = sessionInteractions.current(input.sessionId)
       if (interactionIsLive && result.projection.approval === 'approved') {
         bindExecutionToCurrentInteraction(input.sessionId, result.projection.artifactVersionId)
       }
+      if (interaction?.kind === 'prompt') {
+        interactions.releaseAgentDecisionAuthorization(input.sessionId, interaction.sequence)
+      }
       if (interactionIsLive) interactions.resolveApproval(input.sessionId, result)
+      safeLogInfo('Session Plan response accepted', {
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        artifactVersionId: result.projection.artifactVersionId,
+        revision: result.projection.revision,
+        source: 'human-button',
+        decision: result.projection.approval,
+        changed: result.changed
+      })
       publishProjection(input.sessionId, result.projection)
       return result
     }
@@ -242,7 +308,27 @@ const composeAcpRuntimePlanWorkflow = (
     } catch (error) {
       safeLogError('Routed user Message projection callback failed', error)
     }
-    interactions.resolveApproval(input.sessionId, result)
+    const interaction = sessionInteractions.current(input.sessionId)
+    if (!interaction || interaction.kind !== 'prompt') {
+      throw new Error('The paused Session Plan interaction is no longer available.')
+    }
+    const authorization = {
+      sessionId: input.sessionId,
+      artifactVersionId: result.artifactVersionId,
+      interactionSequence: interaction.sequence
+    }
+    interactions.authorizeAgentDecision(authorization)
+    if (!interactions.resolveApproval(input.sessionId, result)) {
+      interactions.releaseAgentDecisionAuthorization(input.sessionId, interaction.sequence)
+      throw new Error('The paused Session Plan interaction is no longer available.')
+    }
+    safeLogInfo('Session Plan feedback routed', {
+      projectId: input.projectId,
+      sessionId: input.sessionId,
+      artifactVersionId: result.artifactVersionId,
+      revision: current.revision,
+      source: 'human-feedback'
+    })
     return result
   }
 
@@ -332,6 +418,7 @@ const composeAcpRuntimePlanWorkflow = (
           interactionIsLive: true
         })
         .then((result) => {
+          interactions.releaseAgentDecisionAuthorization(request.sessionId, interaction.sequence)
           if (decision === 'approve') authorized = result.projection
           else {
             protectedPending = result.projection
@@ -340,6 +427,15 @@ const composeAcpRuntimePlanWorkflow = (
             }
           }
           interactions.resolveApproval(request.sessionId, result)
+          safeLogInfo('Session Plan response accepted', {
+            projectId: continuation.projectId,
+            sessionId: request.sessionId,
+            artifactVersionId: result.projection.artifactVersionId,
+            revision: result.projection.revision,
+            source: 'human-button',
+            decision: result.projection.approval,
+            changed: result.changed
+          })
           publishProjection(request.sessionId, result.projection)
           return committed()
         })
@@ -351,6 +447,7 @@ const composeAcpRuntimePlanWorkflow = (
     interaction: AcpPromptSessionInteractionScope
   ): void => {
     interactions.releaseExecution(sessionId, interaction.sequence)
+    interactions.releaseAgentDecisionAuthorization(sessionId, interaction.sequence)
     if (interaction.promptMessageId) {
       rejectApprovalForInteraction(
         sessionId,

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -177,23 +177,37 @@ const composeAcpRuntimePlanWorkflow = (
         )
       }
       const executionBinding = interactions.executionBindingFor(input.sessionId)
+      let decisionAuthorizationConsumed = false
       const beforeDecisionCommit =
         requiresHumanFeedback && authorization
           ? (): boolean => {
               const currentInteraction = sessionInteractions.current(input.sessionId)
-              return (
+              decisionAuthorizationConsumed =
                 currentInteraction?.kind === 'prompt' &&
                 currentInteraction.sequence === authorization.interactionSequence &&
                 interactions.consumeAgentDecisionAuthorization(authorization)
-              )
+              return decisionAuthorizationConsumed
             }
           : undefined
-      const result = await service.respond({
-        ...identity,
-        decision,
-        interactionIsLive,
-        ...(beforeDecisionCommit ? { beforeDecisionCommit } : {})
-      })
+      const result = await service
+        .respond({
+          ...identity,
+          decision,
+          interactionIsLive,
+          ...(beforeDecisionCommit ? { beforeDecisionCommit } : {})
+        })
+        .catch((error: unknown) => {
+          const currentInteraction = sessionInteractions.current(input.sessionId)
+          if (
+            decisionAuthorizationConsumed &&
+            authorization &&
+            currentInteraction?.kind === 'prompt' &&
+            currentInteraction.sequence === authorization.interactionSequence
+          ) {
+            interactions.authorizeAgentDecision(authorization)
+          }
+          throw error
+        })
       if (decision === 'approved') {
         if (requiresHumanFeedback && authorization) {
           interactions.bindExecution({

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -179,7 +179,27 @@ const composeAcpRuntimePlanWorkflow = (
       const executionBinding = interactions.executionBindingFor(input.sessionId)
       const result = await service.respond({ ...identity, decision, interactionIsLive })
       if (requiresHumanFeedback && authorization) {
-        interactions.consumeAgentDecisionAuthorization(authorization)
+        const authorizationConsumed = interactions.consumeAgentDecisionAuthorization(authorization)
+        const currentInteraction = sessionInteractions.current(input.sessionId)
+        if (
+          !authorizationConsumed ||
+          currentInteraction?.kind !== 'prompt' ||
+          currentInteraction.sequence !== authorization.interactionSequence
+        ) {
+          safeLogInfo('Session Plan response discarded', {
+            projectId: input.projectId,
+            sessionId: input.sessionId,
+            artifactVersionId: result.projection.artifactVersionId,
+            revision: result.projection.revision,
+            source: 'agent-after-feedback',
+            decision,
+            reason: 'authorization-revoked'
+          })
+          throw new PlanCommandError(
+            'interaction-mismatch',
+            'The Session Plan decision authorization was revoked before the response completed.'
+          )
+        }
       }
       if (decision === 'approved') {
         bindExecutionToCurrentInteraction(input.sessionId, result.projection.artifactVersionId)

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -348,21 +348,6 @@ const composeAcpRuntimePlanWorkflow = (
       publishProjection(input.sessionId, result.projection)
       return result
     }
-    try {
-      pushEvent({
-        id: `session-user-message-${result.message.id}`,
-        timestamp: result.message.createdAt,
-        kind: 'message',
-        level: 'info',
-        sessionId: input.sessionId,
-        promptMessageId: result.message.responseToMessageId,
-        messageId: result.message.id,
-        role: 'user',
-        text: result.message.content
-      })
-    } catch (error) {
-      safeLogError('Routed user Message projection callback failed', error)
-    }
     const currentInteraction = sessionInteractions.current(input.sessionId)
     if (
       !approvalInteractionId ||
@@ -382,6 +367,21 @@ const composeAcpRuntimePlanWorkflow = (
         )
       }
       throw new Error('The paused Session Plan interaction is no longer available.')
+    }
+    try {
+      pushEvent({
+        id: `session-user-message-${result.message.id}`,
+        timestamp: result.message.createdAt,
+        kind: 'message',
+        level: 'info',
+        sessionId: input.sessionId,
+        promptMessageId: result.message.responseToMessageId,
+        messageId: result.message.id,
+        role: 'user',
+        text: result.message.content
+      })
+    } catch (error) {
+      safeLogError('Routed user Message projection callback failed', error)
     }
     const authorization = {
       sessionId: input.sessionId,

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -690,6 +690,51 @@ describe('AcpRuntime Session Plan seam', () => {
     })
   })
 
+  it('restores decision authorization after persistence fails so the same interaction can retry', async () => {
+    const { runtime, interactions, service } = createRuntimeHarness({})
+    const authorization = {
+      sessionId: 'session-1',
+      interactionSequence: 7,
+      artifactVersionId: 'version-1'
+    }
+    interactions.authorizeAgentDecision(authorization)
+    let attempts = 0
+    service.respond.mockImplementation(async (input) => {
+      expect(input.beforeDecisionCommit?.()).toBe(true)
+      attempts += 1
+      if (attempts === 1) {
+        throw new PlanCommandError('revision-conflict', 'The Plan revision changed concurrently.')
+      }
+      return {
+        projection: {
+          ...projection('version-1'),
+          approval: 'approved' as const,
+          lifecycle: 'approved' as const
+        },
+        changed: true
+      }
+    })
+
+    await expect(
+      runtime.callSessionPlan({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'approve'
+      })
+    ).rejects.toMatchObject({ code: 'revision-conflict' })
+    expect(interactions.isAgentDecisionAuthorized(authorization)).toBe(true)
+
+    await expect(
+      runtime.callSessionPlan({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'approve'
+      })
+    ).resolves.toMatchObject({ projection: { approval: 'approved' } })
+    expect(interactions.isAgentDecisionAuthorized(authorization)).toBe(false)
+    expect(attempts).toBe(2)
+  })
+
   it('routes feedback as a visible user Message and resumes the blocked interaction', async () => {
     const onEvent = vi.fn()
     const { runtime } = createRuntimeHarness({ onEvent })

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { ActivePlanProjection } from '../../shared/session-plan/contract'
+import { PlanCommandError, type ActivePlanProjection } from '../../shared/session-plan/contract'
 import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { AcpRuntime } from './runtime'
 import { composeAcpRuntimePlanWorkflow } from './runtime-plan-composition'
@@ -574,9 +574,12 @@ describe('AcpRuntime Session Plan seam', () => {
     const respondGate = new Promise<void>((resolve) => {
       finishRespond = resolve
     })
-    service.respond.mockImplementationOnce(async () => {
+    service.respond.mockImplementationOnce(async (input) => {
       markRespondStarted()
       await respondGate
+      if (input.beforeDecisionCommit && !input.beforeDecisionCommit()) {
+        throw new PlanCommandError('interaction-mismatch', 'Decision authorization was revoked.')
+      }
       return {
         projection: {
           ...projection('version-1'),
@@ -622,9 +625,14 @@ describe('AcpRuntime Session Plan seam', () => {
     const respondGate = new Promise<void>((resolve) => {
       finishRespond = resolve
     })
-    service.respond.mockImplementationOnce(async () => {
+    let decisionPersisted = false
+    service.respond.mockImplementationOnce(async (input) => {
       markRespondStarted()
       await respondGate
+      if (input.beforeDecisionCommit && !input.beforeDecisionCommit()) {
+        throw new PlanCommandError('interaction-mismatch', 'Decision authorization was revoked.')
+      }
+      decisionPersisted = true
       return {
         projection: {
           ...projection('version-1'),
@@ -646,7 +654,40 @@ describe('AcpRuntime Session Plan seam', () => {
     finishRespond()
 
     await expect(approved).rejects.toMatchObject({ code: 'interaction-mismatch' })
+    expect(decisionPersisted).toBe(false)
     expect(interactions.executionBindingFor('session-1')).toBeUndefined()
+  })
+
+  it('binds an Agent decision to its authorizing interaction when cancellation follows commit', async () => {
+    const { runtime, interactions, service, setCurrentInteraction } = createRuntimeHarness({})
+    interactions.authorizeAgentDecision({
+      sessionId: 'session-1',
+      interactionSequence: 7,
+      artifactVersionId: 'version-1'
+    })
+    service.respond.mockImplementationOnce(async (input) => {
+      expect(input.beforeDecisionCommit?.()).toBe(true)
+      setCurrentInteraction({ sequence: 8, promptMessageId: 'interaction-2' })
+      return {
+        projection: {
+          ...projection('version-1'),
+          approval: 'approved' as const,
+          lifecycle: 'approved' as const
+        },
+        changed: true
+      }
+    })
+
+    await runtime.callSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'approve'
+    })
+
+    expect(interactions.executionBindingFor('session-1')).toEqual({
+      artifactVersionId: 'version-1',
+      interactionSequence: 7
+    })
   })
 
   it('routes feedback as a visible user Message and resumes the blocked interaction', async () => {

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -690,6 +690,43 @@ describe('AcpRuntime Session Plan seam', () => {
     })
   })
 
+  it('preserves a successor execution binding when an older Agent approval commits late', async () => {
+    const { runtime, interactions, service, setCurrentInteraction } = createRuntimeHarness({})
+    interactions.authorizeAgentDecision({
+      sessionId: 'session-1',
+      interactionSequence: 7,
+      artifactVersionId: 'version-1'
+    })
+    service.respond.mockImplementationOnce(async (input) => {
+      expect(input.beforeDecisionCommit?.()).toBe(true)
+      setCurrentInteraction({ sequence: 8, promptMessageId: 'interaction-2' })
+      interactions.bindExecution({
+        sessionId: 'session-1',
+        interactionSequence: 8,
+        artifactVersionId: 'version-1'
+      })
+      return {
+        projection: {
+          ...projection('version-1'),
+          approval: 'approved' as const,
+          lifecycle: 'approved' as const
+        },
+        changed: true
+      }
+    })
+
+    await runtime.callSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'approve'
+    })
+
+    expect(interactions.executionBindingFor('session-1')).toEqual({
+      artifactVersionId: 'version-1',
+      interactionSequence: 8
+    })
+  })
+
   it('restores decision authorization after persistence fails so the same interaction can retry', async () => {
     const { runtime, interactions, service } = createRuntimeHarness({})
     const authorization = {

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -556,6 +556,11 @@ describe('AcpRuntime Session Plan seam', () => {
 
   it('does not release a successor execution when an older rejection finishes late', async () => {
     const { runtime, interactions, service } = createRuntimeHarness({})
+    interactions.authorizeAgentDecision({
+      sessionId: 'session-1',
+      interactionSequence: 7,
+      artifactVersionId: 'version-1'
+    })
     interactions.bindExecution({
       sessionId: 'session-1',
       interactionSequence: 6,

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -607,6 +607,48 @@ describe('AcpRuntime Session Plan seam', () => {
     })
   })
 
+  it('rejects an Agent decision whose authorization is revoked while the response is pending', async () => {
+    const { runtime, interactions, service, setCurrentInteraction } = createRuntimeHarness({})
+    interactions.authorizeAgentDecision({
+      sessionId: 'session-1',
+      interactionSequence: 7,
+      artifactVersionId: 'version-1'
+    })
+    let markRespondStarted!: () => void
+    let finishRespond!: () => void
+    const respondStarted = new Promise<void>((resolve) => {
+      markRespondStarted = resolve
+    })
+    const respondGate = new Promise<void>((resolve) => {
+      finishRespond = resolve
+    })
+    service.respond.mockImplementationOnce(async () => {
+      markRespondStarted()
+      await respondGate
+      return {
+        projection: {
+          ...projection('version-1'),
+          approval: 'approved' as const,
+          lifecycle: 'approved' as const
+        },
+        changed: true
+      }
+    })
+
+    const approved = runtime.callSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'approve'
+    })
+    await respondStarted
+    interactions.releaseAgentDecisionAuthorization('session-1', 7)
+    setCurrentInteraction({ sequence: 8, promptMessageId: 'interaction-2' })
+    finishRespond()
+
+    await expect(approved).rejects.toMatchObject({ code: 'interaction-mismatch' })
+    expect(interactions.executionBindingFor('session-1')).toBeUndefined()
+  })
+
   it('routes feedback as a visible user Message and resumes the blocked interaction', async () => {
     const onEvent = vi.fn()
     const { runtime } = createRuntimeHarness({ onEvent })

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -805,7 +805,10 @@ describe('AcpRuntime Session Plan seam', () => {
   })
 
   it('rejects and settles feedback when its owning interaction is superseded during persistence', async () => {
-    const { runtime, interactions, service, setCurrentInteraction } = createRuntimeHarness({})
+    const onEvent = vi.fn()
+    const { runtime, interactions, service, setCurrentInteraction } = createRuntimeHarness({
+      onEvent
+    })
     const pendingApproval = runtime
       .callSessionPlan({
         projectId: 'project-1',
@@ -815,6 +818,7 @@ describe('AcpRuntime Session Plan seam', () => {
       })
       .catch((error: unknown) => error)
     await Promise.resolve()
+    onEvent.mockClear()
     let markRespondStarted!: () => void
     let finishRespond!: () => void
     const respondStarted = new Promise<void>((resolve) => {
@@ -864,6 +868,9 @@ describe('AcpRuntime Session Plan seam', () => {
         interactionSequence: 8
       })
     ).toBe(false)
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'message', messageId: 'message-1' })
+    )
   })
 
   it('lets the resumed Agent explicitly approve after interpreting a user Message', async () => {

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -765,6 +765,68 @@ describe('AcpRuntime Session Plan seam', () => {
     )
   })
 
+  it('rejects and settles feedback when its owning interaction is superseded during persistence', async () => {
+    const { runtime, interactions, service, setCurrentInteraction } = createRuntimeHarness({})
+    const pendingApproval = runtime
+      .callSessionPlan({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'generate',
+        input: {}
+      })
+      .catch((error: unknown) => error)
+    await Promise.resolve()
+    let markRespondStarted!: () => void
+    let finishRespond!: () => void
+    const respondStarted = new Promise<void>((resolve) => {
+      markRespondStarted = resolve
+    })
+    const respondGate = new Promise<void>((resolve) => {
+      finishRespond = resolve
+    })
+    service.respond.mockImplementationOnce(async (input) => {
+      markRespondStarted()
+      await respondGate
+      interactions.release('session-1', 'version-1')
+      return {
+        kind: 'feedback' as const,
+        routeToInteractionId: 'interaction-1',
+        artifactVersionId: 'version-1',
+        text: input.feedback,
+        message: {
+          id: 'message-1',
+          role: 'user' as const,
+          content: input.feedback,
+          status: 'complete' as const,
+          eventIds: [],
+          responseToMessageId: 'interaction-1',
+          createdAt: 10,
+          updatedAt: 10
+        }
+      }
+    })
+
+    const response = runtime.respondSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      feedback: 'Split the analysis by cohort.'
+    })
+    await respondStarted
+    setCurrentInteraction({ sequence: 8, promptMessageId: 'interaction-2' })
+    finishRespond()
+
+    await expect(response).rejects.toThrow('no longer available')
+    await expect(pendingApproval).resolves.toBeInstanceOf(Error)
+    expect(interactions.approvalInteractionIdFor('session-1')).toBeUndefined()
+    expect(
+      interactions.isAgentDecisionAuthorized({
+        sessionId: 'session-1',
+        artifactVersionId: 'version-1',
+        interactionSequence: 8
+      })
+    ).toBe(false)
+  })
+
   it('lets the resumed Agent explicitly approve after interpreting a user Message', async () => {
     const { runtime, service } = createRuntimeHarness({})
     const pending = runtime.callSessionPlan({

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -827,9 +827,12 @@ describe('AcpRuntime Session Plan seam', () => {
     const respondGate = new Promise<void>((resolve) => {
       finishRespond = resolve
     })
+    let messagePersisted = false
     service.respond.mockImplementationOnce(async (input) => {
       markRespondStarted()
       await respondGate
+      input.beforeFeedbackPersist?.()
+      messagePersisted = true
       interactions.release('session-1', 'version-1')
       return {
         kind: 'feedback' as const,
@@ -860,6 +863,7 @@ describe('AcpRuntime Session Plan seam', () => {
 
     await expect(response).rejects.toThrow('no longer available')
     await expect(pendingApproval).resolves.toBeInstanceOf(Error)
+    expect(messagePersisted).toBe(false)
     expect(interactions.approvalInteractionIdFor('session-1')).toBeUndefined()
     expect(
       interactions.isAgentDecisionAuthorized({

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -735,6 +735,45 @@ describe('AcpRuntime Session Plan seam', () => {
     expect(attempts).toBe(2)
   })
 
+  it('preserves a successor execution binding after an idempotent Agent approval', async () => {
+    const { runtime, interactions, service, setCurrentInteraction } = createRuntimeHarness({})
+    const authorization = {
+      sessionId: 'session-1',
+      interactionSequence: 7,
+      artifactVersionId: 'version-1'
+    }
+    interactions.authorizeAgentDecision(authorization)
+    service.respond.mockImplementationOnce(async (input) => {
+      expect(input.beforeDecisionCommit).toBeTypeOf('function')
+      setCurrentInteraction({ sequence: 8, promptMessageId: 'interaction-2' })
+      interactions.bindExecution({
+        sessionId: 'session-1',
+        interactionSequence: 8,
+        artifactVersionId: 'version-1'
+      })
+      return {
+        projection: {
+          ...projection('version-1'),
+          approval: 'approved' as const,
+          lifecycle: 'approved' as const
+        },
+        changed: false
+      }
+    })
+
+    await runtime.callSessionPlan({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      operation: 'approve'
+    })
+
+    expect(interactions.executionBindingFor('session-1')).toEqual({
+      artifactVersionId: 'version-1',
+      interactionSequence: 8
+    })
+    expect(interactions.isAgentDecisionAuthorized(authorization)).toBe(false)
+  })
+
   it('routes feedback as a visible user Message and resumes the blocked interaction', async () => {
     const onEvent = vi.fn()
     const { runtime } = createRuntimeHarness({ onEvent })

--- a/src/main/connectors/runtime-settings-projection.test.ts
+++ b/src/main/connectors/runtime-settings-projection.test.ts
@@ -58,6 +58,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
     expect(listTools).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'server-id', command: 'mcp', transport: 'stdio' })
     )
+    expect(projection.materializedCustomSkillNames()).toEqual(['mcp-enabled'])
   })
 
   it('contains refresh errors while retaining the last snapshot reached by the refresh', async () => {
@@ -87,6 +88,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
 
     await projection.refresh()
     expect(projection.current()).toBe(second)
+    expect(projection.materializedCustomSkillNames()).toEqual([])
     expect(reportError).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ message: 'sync failed' })

--- a/src/main/connectors/runtime-settings-projection.ts
+++ b/src/main/connectors/runtime-settings-projection.ts
@@ -1,6 +1,7 @@
 import { toCustomMcpConfig, selectEnabledCustomServers } from './custom-mcp-bootstrap'
 import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './provision'
 import { ALL_CONNECTOR_IDS } from './registry'
+import { customConnectorSlug } from '../../shared/custom-connector'
 import type { McpClientManager } from './mcp-client-manager'
 import type { StoredConnectors } from '../settings/types'
 
@@ -18,6 +19,7 @@ type ConnectorRuntimeSettingsProjectionOptions = {
 // bootstrap and Settings mutations exactly as before.
 class ConnectorRuntimeSettingsProjection {
   private snapshot: StoredConnectors | undefined
+  private materializedCustomSkills: string[] = []
   private refreshQueue: Promise<void> = Promise.resolve()
   private readonly syncBundledSkillDocs: typeof syncConnectorSkillDocs
   private readonly syncCustomSkillDocs: typeof syncCustomServerSkillDocs
@@ -37,6 +39,10 @@ class ConnectorRuntimeSettingsProjection {
     return this.snapshot
   }
 
+  materializedCustomSkillNames(): string[] {
+    return [...this.materializedCustomSkills]
+  }
+
   async refresh(): Promise<void> {
     const queued = this.refreshQueue.then(() => this.refreshOnce())
     this.refreshQueue = queued
@@ -44,6 +50,7 @@ class ConnectorRuntimeSettingsProjection {
   }
 
   private async refreshOnce(): Promise<void> {
+    this.materializedCustomSkills = []
     try {
       const connectors = await this.options.readConnectors()
       this.snapshot = connectors
@@ -52,10 +59,12 @@ class ConnectorRuntimeSettingsProjection {
       const enabledIds = ALL_CONNECTOR_IDS.filter((id) => !disabled.has(id))
 
       await this.syncBundledSkillDocs(this.options.skillsDir, enabledIds)
-      await this.syncCustomSkillDocs(
-        this.options.skillsDir,
-        selectEnabledCustomServers(connectors),
-        (server) => this.options.mcpClientManager.listTools(toCustomMcpConfig(server))
+      const customServers = selectEnabledCustomServers(connectors)
+      await this.syncCustomSkillDocs(this.options.skillsDir, customServers, (server) =>
+        this.options.mcpClientManager.listTools(toCustomMcpConfig(server))
+      )
+      this.materializedCustomSkills = customServers.map(
+        (server) => `mcp-${customConnectorSlug(server)}`
       )
     } catch (error) {
       this.reportError(error)

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -8,7 +8,7 @@ const tokenizer = new Tiktoken(cl100kBase)
 
 describe('renderConnectorInstructions', () => {
   it('keeps only shared host.mcp conventions in opencode baseline instructions', () => {
-    const md = renderConnectorInstructions(['chemistry'])
+    const md = renderConnectorInstructions(['mcp-chemistry'])
 
     expect(md).toContain('host.mcp(')
     // The "do not reimplement with raw HTTP" rule is what steers opencode away from raw requests.
@@ -32,20 +32,31 @@ describe('renderConnectorInstructions', () => {
   })
 
   it('forbids connector calls until the matching skill supplies the exact method name', () => {
-    const md = renderConnectorInstructions(['pubmed'])
+    const md = renderConnectorInstructions(['mcp-pubmed'])
 
     expect(md).toContain('Load the matching `mcp-*` skill before the first `host.mcp` call')
     expect(md).toContain('Never guess a connector server or method name')
   })
 
   it('lists the exact enabled Connector Skill names without duplicates or guessed aliases', () => {
-    const md = renderConnectorInstructions(['pubmed', 'literature', 'pubmed', 'openalex'])
+    const md = renderConnectorInstructions([
+      'mcp-pubmed',
+      'mcp-literature',
+      'mcp-pubmed',
+      'not-a-skill'
+    ])
 
     expect(md).toContain('Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`.')
     expect(md).toContain('Allowed Specialist Skills for this session')
     expect(md).toContain('do not load or call any `mcp-*` skill absent from that list')
     expect(md.match(/`mcp-pubmed`/g)).toHaveLength(1)
     expect(md).not.toContain('`mcp-openalex`')
+  })
+
+  it('includes canonical custom MCP Skill names in the global catalog', () => {
+    const md = renderConnectorInstructions(['mcp-pubmed', 'mcp-custom-chemistry'])
+
+    expect(md).toContain('Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-custom-chemistry`.')
   })
 })
 

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -41,7 +41,9 @@ describe('renderConnectorInstructions', () => {
   it('lists the exact enabled Connector Skill names without duplicates or guessed aliases', () => {
     const md = renderConnectorInstructions(['pubmed', 'literature', 'pubmed', 'openalex'])
 
-    expect(md).toContain('Available Connector Skills: `mcp-pubmed`, `mcp-literature`.')
+    expect(md).toContain('Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`.')
+    expect(md).toContain('Allowed Specialist Skills for this session')
+    expect(md).toContain('do not load or call any `mcp-*` skill absent from that list')
     expect(md.match(/`mcp-pubmed`/g)).toHaveLength(1)
     expect(md).not.toContain('`mcp-openalex`')
   })

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -37,6 +37,14 @@ describe('renderConnectorInstructions', () => {
     expect(md).toContain('Load the matching `mcp-*` skill before the first `host.mcp` call')
     expect(md).toContain('Never guess a connector server or method name')
   })
+
+  it('lists the exact enabled Connector Skill names without duplicates or guessed aliases', () => {
+    const md = renderConnectorInstructions(['pubmed', 'literature', 'pubmed', 'openalex'])
+
+    expect(md).toContain('Available Connector Skills: `mcp-pubmed`, `mcp-literature`.')
+    expect(md.match(/`mcp-pubmed`/g)).toHaveLength(1)
+    expect(md).not.toContain('`mcp-openalex`')
+  })
 })
 
 describe('renderSkillDoc', () => {

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -114,12 +114,17 @@ export function renderSkillDoc(connectorId: string): string {
 // from consuming the initial context window while still steering calls through the approved host.mcp
 // path instead of raw HTTP.
 export function renderConnectorInstructions(connectorIds: string[]): string {
-  if (!connectorIds.some((id) => CONNECTOR_CATALOG.some((connector) => connector.id === id))) {
-    return ''
-  }
+  const enabledConnectorIds = [
+    ...new Set(
+      connectorIds.filter((id) => CONNECTOR_CATALOG.some((connector) => connector.id === id))
+    )
+  ]
+  if (enabledConnectorIds.length === 0) return ''
+  const availableSkills = enabledConnectorIds.map((id) => `\`mcp-${id}\``).join(', ')
 
   return (
     `# Open Science data connector conventions\n\n` +
+    `Available Connector Skills: ${availableSkills}.\n\n` +
     `Detailed instructions, exact server/method names, schemas, return shapes, and examples are available through the matching \`mcp-*\` skill. Load the matching \`mcp-*\` skill before the first \`host.mcp\` call. Never guess a connector server or method name; if the matching skill is not loaded, do not call the connector.\n\n` +
     CONVENTIONS
   )

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -113,14 +113,10 @@ export function renderSkillDoc(connectorId: string): string {
 // loads the matching connector. Keeping this document to conventions prevents every enabled connector
 // from consuming the initial context window while still steering calls through the approved host.mcp
 // path instead of raw HTTP.
-export function renderConnectorInstructions(connectorIds: string[]): string {
-  const enabledConnectorIds = [
-    ...new Set(
-      connectorIds.filter((id) => CONNECTOR_CATALOG.some((connector) => connector.id === id))
-    )
-  ]
-  if (enabledConnectorIds.length === 0) return ''
-  const availableSkills = enabledConnectorIds.map((id) => `\`mcp-${id}\``).join(', ')
+export function renderConnectorInstructions(skillNames: string[]): string {
+  const enabledSkillNames = [...new Set(skillNames.filter((name) => /^mcp-[a-z0-9-]+$/.test(name)))]
+  if (enabledSkillNames.length === 0) return ''
+  const availableSkills = enabledSkillNames.map((name) => `\`${name}\``).join(', ')
 
   return (
     `# Open Science data connector conventions\n\n` +

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -124,7 +124,8 @@ export function renderConnectorInstructions(connectorIds: string[]): string {
 
   return (
     `# Open Science data connector conventions\n\n` +
-    `Available Connector Skills: ${availableSkills}.\n\n` +
+    `Globally Enabled Connector Skills: ${availableSkills}.\n\n` +
+    `A Specialist session may narrow this catalog. When an \`Allowed Specialist Skills for this session\` list is present, it is authoritative: do not load or call any \`mcp-*\` skill absent from that list.\n\n` +
     `Detailed instructions, exact server/method names, schemas, return shapes, and examples are available through the matching \`mcp-*\` skill. Load the matching \`mcp-*\` skill before the first \`host.mcp\` call. Never guess a connector server or method name; if the matching skill is not loaded, do not call the connector.\n\n` +
     CONVENTIONS
   )

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -818,6 +818,9 @@ const createApplicationModules = async (
     skillsDir: join(getAppClaudeConfigDir(resolveStorageRoot()), 'skills'),
     mcpClientManager
   })
+  settingsService.setMaterializedCustomSkillNamesProvider(() =>
+    connectorRuntimeSettings.materializedCustomSkillNames()
+  )
   settingsService.setCustomServerAuthenticator(
     async (serverId) => {
       const server = (await settingsService.getConnectors())?.customMcpServers?.find(

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -280,6 +280,36 @@ describe('SessionPersistenceCoordinator', () => {
     expect(durable.status).toBe('waiting-plan-approval')
   })
 
+  it('does not persist Plan feedback when its interaction commit precondition fails', async () => {
+    const durable = createSession({
+      status: 'waiting-plan-approval',
+      runtimeContext: { version: 1, revision: 2, plan: createRuntimePlan() }
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn()
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.appendUserMessageToInteraction({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        interactionId: 'interaction-1',
+        content: 'Stale feedback.',
+        beforePersist: () => {
+          throw new Error('interaction superseded')
+        }
+      })
+    ).rejects.toThrow('interaction superseded')
+
+    expect(repository.saveSession).not.toHaveBeenCalled()
+    expect(durable.messages).toEqual([])
+  })
+
   it('atomically reads and patches main-owned runtime context with a new revision', async () => {
     const previousUpdatedAt = Date.now() + 10_000
     let durable = createSession({ updatedAt: previousUpdatedAt })

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -348,6 +348,39 @@ describe('SessionPersistenceCoordinator', () => {
     expect(durable.updatedAt).toBeGreaterThan(previousUpdatedAt)
   })
 
+  it('does not persist a runtime context patch when its commit precondition fails', async () => {
+    const durable = createSession({
+      runtimeContext: { version: 1, revision: 2, plan: createRuntimePlan() }
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn()
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.patchSessionRuntimeContext({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        expectedRevision: 2,
+        patch: { plan: createRuntimePlan({ approval: 'approved' }) },
+        beforePersist: () => {
+          throw new Error('interaction superseded')
+        }
+      })
+    ).rejects.toThrow('interaction superseded')
+
+    expect(repository.saveSession).not.toHaveBeenCalled()
+    expect(durable.runtimeContext).toEqual({
+      version: 1,
+      revision: 2,
+      plan: createRuntimePlan()
+    })
+  })
+
   it('rejects stale and duplicate runtime context patches without overwriting durable authority', async () => {
     let durable = createSession({
       runtimeContext: { version: 1, revision: 4, plan: createRuntimePlan() }

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -165,6 +165,7 @@ type PatchSessionRuntimeContextCommand = Readonly<{
   expectedRevision: number
   patch: SessionRuntimeContextPatch
   sessionStatus?: PersistedSessionStatus
+  beforePersist?: () => void
 }>
 
 type AppendUserMessageToInteractionCommand = Readonly<{
@@ -773,6 +774,7 @@ class SessionPersistenceCoordinator {
       if (current.revision !== expectedRevision) {
         throw new SessionRuntimeContextRevisionConflictError(expectedRevision, current.revision)
       }
+      command.beforePersist?.()
 
       const candidate: Record<string, unknown> = { ...current }
       for (const [owner, value] of Object.entries(patch)) {

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -172,6 +172,7 @@ type AppendUserMessageToInteractionCommand = Readonly<{
   sessionId: string
   interactionId: string
   content: string
+  beforePersist?: () => void
 }>
 
 class SessionRuntimeContextRevisionConflictError extends Error {
@@ -806,6 +807,7 @@ class SessionPersistenceCoordinator {
         throw new Error('Cannot mutate a session that has been deleted.')
       }
       const session = await this.loadRuntimeContextSession(projectId, sessionId, 'patch')
+      command.beforePersist?.()
       const timestamp = Math.max(session.updatedAt + 1, Date.now())
       const message: PersistedChatMessage = {
         id: `message-${randomUUID()}`,

--- a/src/main/session-plan/plan-service.test.ts
+++ b/src/main/session-plan/plan-service.test.ts
@@ -91,8 +91,9 @@ const setup = (): PlanServiceHarness => {
       checksum: createHash('sha256').update(bytes).digest('hex')
     })),
     readRuntimeContext: vi.fn(async () => context),
-    patchRuntimeContext: vi.fn(async ({ expectedRevision, plan, sessionStatus }) => {
+    patchRuntimeContext: vi.fn(async ({ expectedRevision, plan, sessionStatus, beforePersist }) => {
       if (expectedRevision !== context.revision) throw new Error('revision conflict')
+      beforePersist?.()
       context = {
         version: 1,
         revision: context.revision + 1,
@@ -279,7 +280,10 @@ describe('PlanService', () => {
       })
     ).rejects.toMatchObject({ code: 'interaction-mismatch' })
 
-    expect(dependencies.patchRuntimeContext).not.toHaveBeenCalled()
+    expect(dependencies.patchRuntimeContext).toHaveBeenCalledOnce()
+    expect(dependencies.patchRuntimeContext).toHaveBeenCalledWith(
+      expect.objectContaining({ beforePersist: expect.any(Function) })
+    )
     expect(context().plan?.approval).toBe('pending')
   })
 

--- a/src/main/session-plan/plan-service.test.ts
+++ b/src/main/session-plan/plan-service.test.ts
@@ -258,6 +258,31 @@ describe('PlanService', () => {
     ).rejects.toMatchObject({ code: 'approval-already-decided' })
   })
 
+  it('does not persist a Plan decision when its commit precondition is revoked', async () => {
+    const { service, context, dependencies } = setup()
+    const generated = await service.generate({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      interactionId: 'interaction-1',
+      content
+    })
+    vi.mocked(dependencies.patchRuntimeContext).mockClear()
+
+    await expect(
+      service.respond({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        artifactVersionId: generated.projection.artifactVersionId,
+        expectedRevision: generated.projection.revision,
+        decision: 'approved',
+        beforeDecisionCommit: () => false
+      })
+    ).rejects.toMatchObject({ code: 'interaction-mismatch' })
+
+    expect(dependencies.patchRuntimeContext).not.toHaveBeenCalled()
+    expect(context().plan?.approval).toBe('pending')
+  })
+
   it.each(['approved', 'rejected'] as const)(
     'releases the live interaction after a %s decision',
     async (decision) => {

--- a/src/main/session-plan/plan-service.ts
+++ b/src/main/session-plan/plan-service.ts
@@ -71,6 +71,10 @@ type PlanIdentityCommand = Readonly<{
   expectedRevision: number
 }>
 
+type PlanDecisionCommitPrecondition = Readonly<{
+  beforeDecisionCommit?: () => boolean
+}>
+
 type PlanDecisionResult = { projection: ActivePlanProjection; changed: boolean }
 type PlanFeedbackResult = {
   kind: 'feedback'
@@ -175,16 +179,21 @@ class PlanService {
 
   async respond(
     input: PlanIdentityCommand &
-      Readonly<{ decision: 'approved' | 'rejected'; interactionIsLive?: boolean }>
+      Readonly<{ decision: 'approved' | 'rejected'; interactionIsLive?: boolean }> &
+      PlanDecisionCommitPrecondition
   ): Promise<PlanDecisionResult>
   async respond(
     input: Readonly<{ projectId: string; sessionId: string; feedback: string }>
   ): Promise<PlanFeedbackResult>
   async respond(
-    input: PlanResponseCommand & Readonly<{ interactionIsLive?: boolean }>
+    input: PlanResponseCommand &
+      Readonly<{ interactionIsLive?: boolean }> &
+      PlanDecisionCommitPrecondition
   ): Promise<PlanResponseResult>
   async respond(
-    input: PlanResponseCommand & Readonly<{ interactionIsLive?: boolean }>
+    input: PlanResponseCommand &
+      Readonly<{ interactionIsLive?: boolean }> &
+      PlanDecisionCommitPrecondition
   ): Promise<PlanResponseResult> {
     if (input.decision === undefined) {
       const context = await this.dependencies.readRuntimeContext(input.projectId, input.sessionId)
@@ -230,6 +239,12 @@ class PlanService {
     }
     if (plan.approval !== 'pending') {
       throw new PlanCommandError('approval-already-decided', 'Plan approval is irreversible.')
+    }
+    if (input.beforeDecisionCommit && !input.beforeDecisionCommit()) {
+      throw new PlanCommandError(
+        'interaction-mismatch',
+        'The Session Plan decision authorization was revoked before commit.'
+      )
     }
     const updated = { ...plan, approval: input.decision }
     const next = await this.patch(input, updated, input.interactionIsLive ? 'running' : 'idle')

--- a/src/main/session-plan/plan-service.ts
+++ b/src/main/session-plan/plan-service.ts
@@ -59,6 +59,7 @@ type PlanServiceDependencies = Readonly<{
     sessionId: string
     content: string
     interactionId: string
+    beforePersist?: () => void
   }) => Promise<PersistedChatMessage>
   now?: () => number
   createId?: () => string
@@ -73,6 +74,10 @@ type PlanIdentityCommand = Readonly<{
 
 type PlanDecisionCommitPrecondition = Readonly<{
   beforeDecisionCommit?: () => boolean
+}>
+
+type PlanFeedbackCommitPrecondition = Readonly<{
+  beforeFeedbackPersist?: () => void
 }>
 
 type PlanDecisionResult = { projection: ActivePlanProjection; changed: boolean }
@@ -183,17 +188,20 @@ class PlanService {
       PlanDecisionCommitPrecondition
   ): Promise<PlanDecisionResult>
   async respond(
-    input: Readonly<{ projectId: string; sessionId: string; feedback: string }>
+    input: Readonly<{ projectId: string; sessionId: string; feedback: string }> &
+      PlanFeedbackCommitPrecondition
   ): Promise<PlanFeedbackResult>
   async respond(
     input: PlanResponseCommand &
       Readonly<{ interactionIsLive?: boolean }> &
-      PlanDecisionCommitPrecondition
+      PlanDecisionCommitPrecondition &
+      PlanFeedbackCommitPrecondition
   ): Promise<PlanResponseResult>
   async respond(
     input: PlanResponseCommand &
       Readonly<{ interactionIsLive?: boolean }> &
-      PlanDecisionCommitPrecondition
+      PlanDecisionCommitPrecondition &
+      PlanFeedbackCommitPrecondition
   ): Promise<PlanResponseResult> {
     if (input.decision === undefined) {
       const context = await this.dependencies.readRuntimeContext(input.projectId, input.sessionId)
@@ -218,7 +226,8 @@ class PlanService {
         projectId: input.projectId,
         sessionId: input.sessionId,
         content: text,
-        interactionId
+        interactionId,
+        ...(input.beforeFeedbackPersist ? { beforePersist: input.beforeFeedbackPersist } : {})
       })
       this.dependencies.interactions.release(input.sessionId, plan.artifactVersionId)
       return {

--- a/src/main/session-plan/plan-service.ts
+++ b/src/main/session-plan/plan-service.ts
@@ -52,6 +52,7 @@ type PlanServiceDependencies = Readonly<{
     expectedRevision: number
     plan: SessionPlanRuntimeContext | undefined
     sessionStatus: 'waiting-plan-approval' | 'running' | 'idle'
+    beforePersist?: () => void
   }) => Promise<SessionRuntimeContext>
   isRevisionConflict: (error: unknown) => boolean
   persistUserMessage: (input: {
@@ -249,14 +250,23 @@ class PlanService {
     if (plan.approval !== 'pending') {
       throw new PlanCommandError('approval-already-decided', 'Plan approval is irreversible.')
     }
-    if (input.beforeDecisionCommit && !input.beforeDecisionCommit()) {
-      throw new PlanCommandError(
-        'interaction-mismatch',
-        'The Session Plan decision authorization was revoked before commit.'
-      )
-    }
     const updated = { ...plan, approval: input.decision }
-    const next = await this.patch(input, updated, input.interactionIsLive ? 'running' : 'idle')
+    const beforePersist = input.beforeDecisionCommit
+      ? (): void => {
+          if (!input.beforeDecisionCommit?.()) {
+            throw new PlanCommandError(
+              'interaction-mismatch',
+              'The Session Plan decision authorization was revoked before commit.'
+            )
+          }
+        }
+      : undefined
+    const next = await this.patch(
+      input,
+      updated,
+      input.interactionIsLive ? 'running' : 'idle',
+      beforePersist
+    )
     this.dependencies.interactions.release(input.sessionId, plan.artifactVersionId)
     return {
       projection: this.project(document, updated, next.revision, input.interactionIsLive),
@@ -436,7 +446,8 @@ class PlanService {
   private async patch(
     input: PlanIdentityCommand,
     plan: SessionPlanRuntimeContext,
-    sessionStatus: 'waiting-plan-approval' | 'running' | 'idle'
+    sessionStatus: 'waiting-plan-approval' | 'running' | 'idle',
+    beforePersist?: () => void
   ): Promise<SessionRuntimeContext> {
     try {
       return await this.dependencies.patchRuntimeContext({
@@ -444,7 +455,8 @@ class PlanService {
         sessionId: input.sessionId,
         expectedRevision: input.expectedRevision,
         plan,
-        sessionStatus
+        sessionStatus,
+        ...(beforePersist ? { beforePersist } : {})
       })
     } catch (error) {
       if (this.dependencies.isRevisionConflict(error)) {

--- a/src/main/session-plan/production-plan-service.ts
+++ b/src/main/session-plan/production-plan-service.ts
@@ -39,13 +39,21 @@ const createProductionPlanService = ({
     },
     readRuntimeContext: (projectId, sessionId) =>
       sessions.readSessionRuntimeContext(projectId, sessionId),
-    patchRuntimeContext: ({ projectId, sessionId, expectedRevision, plan, sessionStatus }) =>
+    patchRuntimeContext: ({
+      projectId,
+      sessionId,
+      expectedRevision,
+      plan,
+      sessionStatus,
+      beforePersist
+    }) =>
       sessions.patchSessionRuntimeContext({
         projectId,
         sessionId,
         expectedRevision,
         patch: { plan },
-        sessionStatus
+        sessionStatus,
+        ...(beforePersist ? { beforePersist } : {})
       }),
     persistUserMessage: (input) =>
       sessions.appendUserMessageToInteraction({

--- a/src/main/session-plan/production-plan-service.ts
+++ b/src/main/session-plan/production-plan-service.ts
@@ -52,7 +52,8 @@ const createProductionPlanService = ({
         projectId: input.projectId,
         sessionId: input.sessionId,
         interactionId: input.interactionId,
-        content: input.content
+        content: input.content,
+        ...(input.beforePersist ? { beforePersist: input.beforePersist } : {})
       }),
     isRevisionConflict: (error) => error instanceof SessionRuntimeContextRevisionConflictError
   })

--- a/src/main/session-plan/session-plan-interaction-owner.test.ts
+++ b/src/main/session-plan/session-plan-interaction-owner.test.ts
@@ -36,6 +36,76 @@ describe('SessionPlanInteractionOwner', () => {
     expect(owner.interactionIdFor('session-1', 'version-2')).toBeUndefined()
   })
 
+  it('authorizes an Agent decision only for one exact Artifact Version and interaction', () => {
+    const owner = new SessionPlanInteractionOwner()
+
+    owner.authorizeAgentDecision({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionSequence: 7
+    })
+
+    expect(
+      owner.isAgentDecisionAuthorized({
+        sessionId: 'session-1',
+        artifactVersionId: 'version-1',
+        interactionSequence: 7
+      })
+    ).toBe(true)
+    expect(
+      owner.isAgentDecisionAuthorized({
+        sessionId: 'session-1',
+        artifactVersionId: 'version-2',
+        interactionSequence: 7
+      })
+    ).toBe(false)
+    expect(
+      owner.consumeAgentDecisionAuthorization({
+        sessionId: 'session-1',
+        artifactVersionId: 'version-1',
+        interactionSequence: 7
+      })
+    ).toBe(true)
+    expect(
+      owner.consumeAgentDecisionAuthorization({
+        sessionId: 'session-1',
+        artifactVersionId: 'version-1',
+        interactionSequence: 7
+      })
+    ).toBe(false)
+  })
+
+  it('invalidates Agent decision authority on Plan replacement and exact interaction release', () => {
+    const owner = new SessionPlanInteractionOwner()
+    owner.authorizeAgentDecision({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-1',
+      interactionSequence: 7
+    })
+
+    expect(owner.releaseAgentDecisionAuthorization('session-1', 6)).toBe(false)
+    owner.register({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-2',
+      interactionId: 'interaction-2'
+    })
+    expect(
+      owner.isAgentDecisionAuthorized({
+        sessionId: 'session-1',
+        artifactVersionId: 'version-1',
+        interactionSequence: 7
+      })
+    ).toBe(false)
+
+    owner.authorizeAgentDecision({
+      sessionId: 'session-1',
+      artifactVersionId: 'version-2',
+      interactionSequence: 8
+    })
+    expect(owner.releaseAgentDecisionAuthorization('session-1', 7)).toBe(false)
+    expect(owner.releaseAgentDecisionAuthorization('session-1', 8)).toBe(true)
+  })
+
   it('settles a parked approval exactly once', async () => {
     const owner = new SessionPlanInteractionOwner()
     const approval = owner.parkApproval('session-1', 'interaction-1')

--- a/src/main/session-plan/session-plan-interaction-owner.ts
+++ b/src/main/session-plan/session-plan-interaction-owner.ts
@@ -14,10 +14,13 @@ type SessionPlanExecutionBinding = Readonly<{
   interactionSequence: number
 }>
 
+type SessionPlanAgentDecisionAuthorization = SessionPlanExecutionBinding
+
 type SessionPlanInteractionRow = {
   identity?: SessionPlanInteractionIdentity
   approvalReservation?: string
   approval?: SessionPlanApprovalParking
+  agentDecisionAuthorization?: SessionPlanAgentDecisionAuthorization
   execution?: SessionPlanExecutionBinding
 }
 
@@ -31,6 +34,7 @@ class SessionPlanInteractionOwner {
   }: SessionPlanInteractionIdentity & Readonly<{ sessionId: string }>): void {
     const row = this.rows.get(sessionId) ?? {}
     row.identity = { artifactVersionId, interactionId }
+    delete row.agentDecisionAuthorization
     this.rows.set(sessionId, row)
   }
 
@@ -108,6 +112,47 @@ class SessionPlanInteractionOwner {
     return true
   }
 
+  authorizeAgentDecision({
+    sessionId,
+    artifactVersionId,
+    interactionSequence
+  }: SessionPlanAgentDecisionAuthorization & Readonly<{ sessionId: string }>): void {
+    const row = this.rows.get(sessionId) ?? {}
+    row.agentDecisionAuthorization = { artifactVersionId, interactionSequence }
+    this.rows.set(sessionId, row)
+  }
+
+  isAgentDecisionAuthorized({
+    sessionId,
+    artifactVersionId,
+    interactionSequence
+  }: SessionPlanAgentDecisionAuthorization & Readonly<{ sessionId: string }>): boolean {
+    const authorization = this.rows.get(sessionId)?.agentDecisionAuthorization
+    return (
+      authorization?.artifactVersionId === artifactVersionId &&
+      authorization.interactionSequence === interactionSequence
+    )
+  }
+
+  consumeAgentDecisionAuthorization(
+    input: SessionPlanAgentDecisionAuthorization & Readonly<{ sessionId: string }>
+  ): boolean {
+    if (!this.isAgentDecisionAuthorized(input)) return false
+    const row = this.rows.get(input.sessionId)
+    if (!row) return false
+    delete row.agentDecisionAuthorization
+    this.prune(input.sessionId, row)
+    return true
+  }
+
+  releaseAgentDecisionAuthorization(sessionId: string, interactionSequence: number): boolean {
+    const row = this.rows.get(sessionId)
+    if (row?.agentDecisionAuthorization?.interactionSequence !== interactionSequence) return false
+    delete row.agentDecisionAuthorization
+    this.prune(sessionId, row)
+    return true
+  }
+
   bindExecution({
     sessionId,
     artifactVersionId,
@@ -145,7 +190,13 @@ class SessionPlanInteractionOwner {
   }
 
   private prune(sessionId: string, row: SessionPlanInteractionRow): void {
-    if (!row.identity && !row.approvalReservation && !row.approval && !row.execution) {
+    if (
+      !row.identity &&
+      !row.approvalReservation &&
+      !row.approval &&
+      !row.agentDecisionAuthorization &&
+      !row.execution
+    ) {
       this.rows.delete(sessionId)
     }
   }

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -1138,7 +1138,10 @@ describe('AgentBackendResolver bridge predicates', () => {
         ? backend.systemPromptAppends?.join('\n\n')
         : backend.persistentSystemPrompt
 
-    expect(instructions).toContain('Available Connector Skills: `mcp-pubmed`, `mcp-literature`.')
+    expect(instructions).toContain(
+      'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`.'
+    )
+    expect(instructions).toContain('Allowed Specialist Skills for this session')
     expect(instructions).not.toContain('`mcp-openalex`')
     await backend.anthropicBridgeLease?.release()
     await backend.responsesBridgeLease?.release()

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -142,7 +142,7 @@ const makeOpenAiProviderBridgeDouble = (index: number): OpenAiProviderBridgeDoub
 type HarnessOptions = {
   settings?: StoredSettings
   frameworkOverride?: string
-  connectorIds?: string[]
+  connectorSkillNames?: string[]
   rejectRequiredModels?: ReadonlySet<string>
   targetOverride?: (
     provider: StoredProvider,
@@ -239,7 +239,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
     resolveCodexProxyEnvironment: vi.fn(async () => undefined)
   } satisfies AgentBackendRuntimePort
   const connectors = {
-    enabledConnectorIds: vi.fn(() => options.connectorIds ?? [])
+    provisionedConnectorSkillNames: vi.fn(async () => options.connectorSkillNames ?? [])
   } satisfies AgentBackendConnectorPort
 
   const responsesBridges: ResponsesBridgeDouble[] = []
@@ -338,7 +338,7 @@ describe('AgentBackendResolver construction and selection', () => {
     expect(harness.readFrameworkOverride).not.toHaveBeenCalled()
     expect(harness.resolveRuntimeTarget).not.toHaveBeenCalled()
     expect(harness.resolveRuntimeReasoningEffortProfile).not.toHaveBeenCalled()
-    expect(harness.connectors.enabledConnectorIds).not.toHaveBeenCalled()
+    expect(harness.connectors.provisionedConnectorSkillNames).not.toHaveBeenCalled()
     expect(harness.createResponsesBridge).not.toHaveBeenCalled()
     expect(harness.createNativeResponsesProxy).not.toHaveBeenCalled()
     expect(harness.createAnthropicProviderBridge).not.toHaveBeenCalled()
@@ -1123,7 +1123,7 @@ describe('AgentBackendResolver bridge predicates', () => {
     }
   ])('advertises exact enabled Connector Skill names to $name', async (testCase) => {
     const harness = makeHarness({
-      connectorIds: ['pubmed', 'literature'],
+      connectorSkillNames: ['mcp-pubmed', 'mcp-literature', 'mcp-custom-chemistry'],
       targetOverride: () => testCase.target
     })
 
@@ -1139,7 +1139,7 @@ describe('AgentBackendResolver bridge predicates', () => {
         : backend.persistentSystemPrompt
 
     expect(instructions).toContain(
-      'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`.'
+      'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`, `mcp-custom-chemistry`.'
     )
     expect(instructions).toContain('Allowed Specialist Skills for this session')
     expect(instructions).not.toContain('`mcp-openalex`')
@@ -1159,7 +1159,7 @@ describe('AgentBackendResolver bridge predicates', () => {
     }
   ])('persists skill-first connector guidance for Codex $name', async (testCase) => {
     const harness = makeHarness({
-      connectorIds: ['pubmed'],
+      connectorSkillNames: ['mcp-pubmed'],
       targetOverride: () => ({
         needsChatResponsesBridge: testCase.chat,
         needsNativeResponsesCompatibility: testCase.native,

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -1106,6 +1106,46 @@ describe('AgentBackendResolver runtime delegation', () => {
 
 describe('AgentBackendResolver bridge predicates', () => {
   it.each([
+    { name: 'Claude Code', frameworkId: 'claude-code' as const, target: {} },
+    { name: 'OpenCode', frameworkId: 'opencode' as const, target: {} },
+    {
+      name: 'Codex Responses',
+      frameworkId: 'codex' as const,
+      target: { provider: { apiEndpoints: ['responses'] as const } }
+    },
+    {
+      name: 'Codex bridge',
+      frameworkId: 'codex' as const,
+      target: {
+        needsChatResponsesBridge: true,
+        provider: { apiEndpoints: ['openai'] as const }
+      }
+    }
+  ])('advertises exact enabled Connector Skill names to $name', async (testCase) => {
+    const harness = makeHarness({
+      connectorIds: ['pubmed', 'literature'],
+      targetOverride: () => testCase.target
+    })
+
+    const backend = await harness.resolver.resolveExplicitTarget({
+      frameworkId: testCase.frameworkId,
+      providerId: 'provider-a',
+      model: { kind: 'provider-default' },
+      reasoningEffort: 'high'
+    })
+    const instructions =
+      testCase.frameworkId === 'claude-code'
+        ? backend.systemPromptAppends?.join('\n\n')
+        : backend.persistentSystemPrompt
+
+    expect(instructions).toContain('Available Connector Skills: `mcp-pubmed`, `mcp-literature`.')
+    expect(instructions).not.toContain('`mcp-openalex`')
+    await backend.anthropicBridgeLease?.release()
+    await backend.responsesBridgeLease?.release()
+    await backend.providerTransportLease?.release()
+  })
+
+  it.each([
     { name: 'direct Responses', chat: false, native: false, apiEndpoints: ['responses'] as const },
     { name: 'Chat bridge', chat: true, native: false, apiEndpoints: ['openai'] as const },
     {

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -142,6 +142,7 @@ const makeOpenAiProviderBridgeDouble = (index: number): OpenAiProviderBridgeDoub
 type HarnessOptions = {
   settings?: StoredSettings
   frameworkOverride?: string
+  connectorIds?: string[]
   connectorSkillNames?: string[]
   rejectRequiredModels?: ReadonlySet<string>
   targetOverride?: (
@@ -239,6 +240,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
     resolveCodexProxyEnvironment: vi.fn(async () => undefined)
   } satisfies AgentBackendRuntimePort
   const connectors = {
+    enabledConnectorIds: vi.fn(() => options.connectorIds ?? []),
     provisionedConnectorSkillNames: vi.fn(async () => options.connectorSkillNames ?? [])
   } satisfies AgentBackendConnectorPort
 
@@ -338,6 +340,7 @@ describe('AgentBackendResolver construction and selection', () => {
     expect(harness.readFrameworkOverride).not.toHaveBeenCalled()
     expect(harness.resolveRuntimeTarget).not.toHaveBeenCalled()
     expect(harness.resolveRuntimeReasoningEffortProfile).not.toHaveBeenCalled()
+    expect(harness.connectors.enabledConnectorIds).not.toHaveBeenCalled()
     expect(harness.connectors.provisionedConnectorSkillNames).not.toHaveBeenCalled()
     expect(harness.createResponsesBridge).not.toHaveBeenCalled()
     expect(harness.createNativeResponsesProxy).not.toHaveBeenCalled()
@@ -1123,6 +1126,7 @@ describe('AgentBackendResolver bridge predicates', () => {
     }
   ])('advertises exact enabled Connector Skill names to $name', async (testCase) => {
     const harness = makeHarness({
+      connectorIds: ['pubmed', 'literature'],
       connectorSkillNames: ['mcp-pubmed', 'mcp-literature', 'mcp-custom-chemistry'],
       targetOverride: () => testCase.target
     })
@@ -1139,9 +1143,14 @@ describe('AgentBackendResolver bridge predicates', () => {
         : backend.persistentSystemPrompt
 
     expect(instructions).toContain(
-      'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`, `mcp-custom-chemistry`.'
+      testCase.frameworkId === 'claude-code'
+        ? 'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`, `mcp-custom-chemistry`.'
+        : 'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`.'
     )
     expect(instructions).toContain('Allowed Specialist Skills for this session')
+    if (testCase.frameworkId !== 'claude-code') {
+      expect(instructions).not.toContain('`mcp-custom-chemistry`')
+    }
     expect(instructions).not.toContain('`mcp-openalex`')
     await backend.anthropicBridgeLease?.release()
     await backend.responsesBridgeLease?.release()
@@ -1159,7 +1168,7 @@ describe('AgentBackendResolver bridge predicates', () => {
     }
   ])('persists skill-first connector guidance for Codex $name', async (testCase) => {
     const harness = makeHarness({
-      connectorSkillNames: ['mcp-pubmed'],
+      connectorIds: ['pubmed'],
       targetOverride: () => ({
         needsChatResponsesBridge: testCase.chat,
         needsNativeResponsesCompatibility: testCase.native,

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -122,7 +122,10 @@ export type AgentBackendProviderPort = Pick<
   'resolveRuntimeTarget' | 'resolveRuntimeModelCatalog' | 'resolveRuntimeReasoningEffortProfile'
 >
 
-export type AgentBackendConnectorPort = Pick<ConnectorSettingsModule, 'enabledConnectorIds'>
+export type AgentBackendConnectorPort = Pick<
+  ConnectorSettingsModule,
+  'provisionedConnectorSkillNames'
+>
 
 type BridgeBasePort = Pick<
   ResponsesBridge,
@@ -577,7 +580,7 @@ export class AgentBackendResolver {
       : undefined
     const forcedSkillIds = new Set(context.forcedSkillIds ?? [])
     const connectorInstructions = renderConnectorInstructions(
-      this.connectors.enabledConnectorIds(settings.connectors)
+      await this.connectors.provisionedConnectorSkillNames()
     )
     if (framework.id === 'claude-code') {
       const { envOverrides, executablePath, sessionOptions, contextWindow } =

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -124,7 +124,7 @@ export type AgentBackendProviderPort = Pick<
 
 export type AgentBackendConnectorPort = Pick<
   ConnectorSettingsModule,
-  'provisionedConnectorSkillNames'
+  'enabledConnectorIds' | 'provisionedConnectorSkillNames'
 >
 
 type BridgeBasePort = Pick<
@@ -579,9 +579,11 @@ export class AgentBackendResolver {
       ? [...new Set(target.reasoningEffortProfile.slots)]
       : undefined
     const forcedSkillIds = new Set(context.forcedSkillIds ?? [])
-    const connectorInstructions = renderConnectorInstructions(
-      await this.connectors.provisionedConnectorSkillNames()
-    )
+    const connectorSkillNames =
+      framework.id === 'claude-code'
+        ? await this.connectors.provisionedConnectorSkillNames()
+        : this.connectors.enabledConnectorIds(settings.connectors).map((id) => `mcp-${id}`)
+    const connectorInstructions = renderConnectorInstructions(connectorSkillNames)
     if (framework.id === 'claude-code') {
       const { envOverrides, executablePath, sessionOptions, contextWindow } =
         await this.resolveClaudeSpawnConfig(settings, target, forcedSkillIds)

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -169,6 +169,20 @@ describe('ConnectorSettingsModule', () => {
     expect(afterRemoval?.askToolIds ?? []).not.toContain(`${added.slug}/lookup`)
   })
 
+  it('advertises custom Connector Skills only from the successful materialization projection', async () => {
+    await service.addCustomServer({
+      name: 'custom-catalog',
+      transport: 'stdio',
+      command: 'example-mcp'
+    })
+
+    expect(await service.provisionedConnectorSkillNames()).not.toContain('mcp-custom-catalog')
+
+    service.setMaterializedCustomSkillNamesProvider(() => ['mcp-custom-catalog'])
+
+    expect(await service.provisionedConnectorSkillNames()).toContain('mcp-custom-catalog')
+  })
+
   it('rejects duplicate and built-in custom connector names', async () => {
     await service.addCustomServer({
       name: 'example-server',

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -54,7 +54,13 @@ const normalizeOAuthConfig = (
 // Owns durable Connector policy, secret migration/projection, and custom-server mutation. Live MCP
 // clients, approval decisions, Specialist bindings, and refresh workflows remain outside this module.
 class ConnectorSettingsModule {
+  private materializedCustomSkillNamesProvider: () => readonly string[] = () => []
+
   constructor(private readonly repository: SettingsRepository) {}
+
+  setMaterializedCustomSkillNamesProvider(provider: () => readonly string[]): void {
+    this.materializedCustomSkillNamesProvider = provider
+  }
 
   // Bundled connectors are default-on. Keep this projection on the durable owner so runtime
   // configuration, Skill provisioning, and renderer views all apply the same opt-out rule.
@@ -114,18 +120,8 @@ class ConnectorSettingsModule {
 
   async provisionedConnectorSkillNames(): Promise<string[]> {
     const connectors = await this.getConnectors()
-    const bundled = this.enabledConnectorIds(connectors)
-    const customServers = connectors?.customMcpServers ?? []
-    const custom = customServers
-      .filter(
-        (server) =>
-          server.enabled &&
-          isCustomMcpServerRouteSafe(server, customServers) &&
-          (!server.oauth || Boolean(server.oauthState?.tokens?.access_token))
-      )
-      .map(customConnectorSlug)
-
-    return Array.from(new Set([...bundled, ...custom].map((id) => `mcp-${id}`)))
+    const bundled = this.enabledConnectorIds(connectors).map((id) => `mcp-${id}`)
+    return Array.from(new Set([...bundled, ...this.materializedCustomSkillNamesProvider()]))
   }
 
   async listConnectors(): Promise<ConnectorsSnapshot> {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -489,6 +489,10 @@ class SettingsService {
     return this.connectors.provisionedConnectorSkillNames()
   }
 
+  setMaterializedCustomSkillNamesProvider(provider: () => readonly string[]): void {
+    this.connectors.setMaterializedCustomSkillNamesProvider(provider)
+  }
+
   // Returns the subset of forced ids that are currently disabled in settings — i.e. the picks that need
   // a respawn to materialize. Enabled picks are already present and need no reconnect.
   async skillsNeedingForceLoad(forcedIds: string[]): Promise<string[]> {


### PR DESCRIPTION
## Problem

The incident artifacts showed that all PubMed Connector calls succeeded while probes of guessed server names were rejected locally. The shared Connector guidance says not to guess, but did not expose the exact enabled `mcp-*` Skill names.

A pending Session Plan could also be approved or rejected through the Agent RPC without evidence that the current Plan Artifact had first received human feedback. Existing logs did not record the response source, which made the missing approval-card report impossible to attribute. The observed `0/13` remained explained by the absence of `update_step_status` calls.

## Proposed change

- List the exact enabled Connector Skill names in the compact baseline instructions delivered to Claude Code, OpenCode, Codex Responses, and Codex bridge sessions.
- Record a live, one-shot Agent decision authorization for the exact Plan Artifact Version and prompt interaction after routed human feedback.
- Reject Agent decisions for a pending Plan when that authorization is absent; keep direct human Approve/Dismiss commands authoritative.
- Consume or invalidate authorization on decision, Plan replacement, direct human decision, interaction release, or Session cleanup.
- Add structured, content-free audit logs for Plan generation, response source, decision, revision, and step-status updates.

## Scope and non-goals

- No persistence schema change; decision authorization remains owned by the existing in-process Session Plan interaction owner.
- No renderer change for `0/N` progress and no inferred or automatic step completion.
- Does not duplicate the Session Plan completion and persistent call-record fixes already present in v0.11.1.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- Exact Connector discovery and delivery across all four backend routes -> focused Vitest set -> passed.
- Human-feedback causality, direct human authority, replacement/release cleanup, concurrency, audit redaction, and step updates -> focused Vitest set -> passed.
- Combined focused command covering 5 files -> 94 tests passed.
- Node and web TypeScript projects -> `tsc --noEmit -p tsconfig.node.json --composite false` and `tsc --noEmit -p tsconfig.web.json --composite false` -> passed.
- Changed-file ESLint -> passed; full ESLint completed with 0 errors and 17 unrelated existing warnings.
- Full Vitest fallback was attempted on Windows: 12,063 tests passed; 34 tests in 9 unrelated files failed because this host cannot create required symlinks/ACLs, lacks Bash for workflow fixtures, or timed out in unrelated long-running concurrency cases. No Connector or Session Plan test failed.

## Review focus

- Confirm that Agent decision authority cannot outlive its exact Artifact Version or interaction sequence.
- Confirm direct human decisions remain authoritative and clear any stale Agent authorization.
- Confirm audit payloads contain identifiers and fixed-vocabulary state only, never user feedback, Plan text, step titles, or notes.
- Confirm exact Connector Skill names reach all four supported execution paths.

Independent review is still required before marking the change verified under the repository verification policy.
