### PR TITLE
ci(test-impact): define module ownership manifest

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -1,0 +1,128 @@
+{
+  "schemaVersion": 1,
+  "modules": {
+    "session_renderer": {
+      "ownerPaths": ["src/renderer/src/stores/session-store.ts"],
+      "interfacePaths": ["src/renderer/src/stores/session-store.ts"],
+      "consumerModules": ["workspace_runtime", "project_files_view", "workspace_page"],
+      "testFiles": {
+        "owner": ["src/renderer/src/stores/session-store.test.ts"],
+        "contract": ["src/shared/session-persistence.test.ts"],
+        "consumer": ["src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts"]
+      },
+      "capabilityOverlays": ["renderer_state"],
+      "fallbackCapability": "renderer_view"
+    },
+    "workspace_runtime": {
+      "ownerPaths": ["src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts"],
+      "interfacePaths": ["src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts"],
+      "consumerModules": ["workspace_page"],
+      "testFiles": {
+        "owner": ["src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts"],
+        "contract": [
+          "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.first-output.render.test.tsx"
+        ],
+        "consumer": ["src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx"]
+      },
+      "capabilityOverlays": ["renderer_state"],
+      "fallbackCapability": "renderer_view"
+    },
+    "project_files_view": {
+      "ownerPaths": ["src/renderer/src/pages/workspace/ProjectFilesView.tsx"],
+      "interfacePaths": ["src/renderer/src/pages/workspace/ProjectFilesView.tsx"],
+      "consumerModules": ["workspace_page"],
+      "testFiles": {
+        "owner": ["src/renderer/src/pages/workspace/ProjectFilesView.test.tsx"],
+        "contract": ["src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx"],
+        "consumer": []
+      },
+      "capabilityOverlays": ["renderer_state"],
+      "fallbackCapability": "renderer_view"
+    },
+    "workspace_page": {
+      "ownerPaths": ["src/renderer/src/pages/workspace/WorkspacePage.tsx"],
+      "interfacePaths": ["src/renderer/src/pages/workspace/WorkspacePage.tsx"],
+      "consumerModules": [],
+      "testFiles": {
+        "owner": [
+          "src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx",
+          "src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx",
+          "src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx",
+          "src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx"
+        ],
+        "contract": [],
+        "consumer": []
+      },
+      "capabilityOverlays": ["renderer_state"],
+      "fallbackCapability": "renderer_view"
+    },
+    "artifact_storage": {
+      "ownerPaths": ["src/main/artifacts/repository.ts"],
+      "interfacePaths": ["src/main/artifacts/repository.ts"],
+      "consumerModules": ["artifact_provenance"],
+      "testFiles": {
+        "owner": [
+          "src/main/artifacts/repository.test.ts",
+          "src/main/artifacts/repository.rollback.test.ts"
+        ],
+        "contract": ["src/main/artifacts/ipc.test.ts"],
+        "consumer": ["src/main/artifacts/provenance-repository.test.ts"]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
+    "upload_repository": {
+      "ownerPaths": ["src/main/uploads/repository.ts"],
+      "interfacePaths": ["src/main/uploads/repository.ts"],
+      "consumerModules": ["session_persistence"],
+      "testFiles": {
+        "owner": ["src/main/uploads/repository.test.ts"],
+        "contract": ["src/main/uploads/ipc.test.ts"],
+        "consumer": ["src/main/session-persistence/deletion-integration.test.ts"]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
+    "project_files_repository": {
+      "ownerPaths": ["src/main/project-files/repository.ts"],
+      "interfacePaths": ["src/main/project-files/repository.ts"],
+      "consumerModules": ["session_persistence"],
+      "testFiles": {
+        "owner": ["src/main/project-files/repository.test.ts"],
+        "contract": ["src/main/project-files/ipc.test.ts"],
+        "consumer": ["src/main/session-persistence/deletion-integration.test.ts"]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
+    "artifact_provenance": {
+      "ownerPaths": ["src/main/artifacts/provenance-repository.ts"],
+      "interfacePaths": ["src/main/artifacts/provenance-repository.ts"],
+      "consumerModules": ["session_persistence"],
+      "testFiles": {
+        "owner": ["src/main/artifacts/provenance-repository.test.ts"],
+        "contract": ["src/main/artifacts/ipc.test.ts"],
+        "consumer": [
+          "src/main/session-persistence/artifact-finalization-recovery.integration.test.ts"
+        ]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
+    "session_persistence": {
+      "ownerPaths": ["src/main/session-persistence/coordinator.ts"],
+      "interfacePaths": ["src/main/session-persistence/coordinator.ts"],
+      "consumerModules": [],
+      "testFiles": {
+        "owner": ["src/main/session-persistence/coordinator.test.ts"],
+        "contract": ["src/shared/session-persistence.test.ts"],
+        "consumer": [
+          "src/main/session-persistence/artifact-finalization-recovery.integration.test.ts",
+          "src/main/session-persistence/deletion-integration.test.ts"
+        ]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    }
+  }
+}

--- a/scripts/ci/validate-module-impact.mjs
+++ b/scripts/ci/validate-module-impact.mjs
@@ -1,0 +1,149 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const defaultManifest = JSON.parse(
+  readFileSync(new URL('./module-impact.json', import.meta.url), 'utf8')
+)
+const changeImpactManifest = JSON.parse(
+  readFileSync(new URL('./change-impact.json', import.meta.url), 'utf8')
+)
+const defaultCapabilities = new Set(Object.keys(changeImpactManifest.capabilities))
+const moduleTestKinds = ['owner', 'contract', 'consumer']
+
+function requireStringArray(value, label, { nonEmpty = false } = {}) {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    throw new Error(`${label} must be an array of strings`)
+  }
+  if (nonEmpty && value.length === 0) throw new Error(`${label} must not be empty`)
+  if (new Set(value).size !== value.length) throw new Error(`${label} contains duplicate entries`)
+  return value
+}
+
+function validateRepositoryPath(path, label, pathExists) {
+  if (
+    path.length === 0 ||
+    path.startsWith('/') ||
+    path.includes('\\') ||
+    path.includes('//') ||
+    /^[A-Za-z]:/.test(path) ||
+    path.split('/').some((segment) => segment === '.' || segment === '..')
+  ) {
+    throw new Error(`${label} must be a portable repository-relative path: ${path}`)
+  }
+  if (pathExists && !pathExists(path)) throw new Error(`${label} does not exist: ${path}`)
+}
+
+export function validateModuleImpactManifest(
+  manifest = defaultManifest,
+  { pathExists, knownCapabilities = defaultCapabilities } = {}
+) {
+  if (!manifest || manifest.schemaVersion !== 1) {
+    throw new Error('Module-impact manifest schemaVersion must be 1')
+  }
+  if (
+    !manifest.modules ||
+    typeof manifest.modules !== 'object' ||
+    Array.isArray(manifest.modules) ||
+    Object.keys(manifest.modules).length === 0
+  ) {
+    throw new Error('Module-impact manifest must declare modules')
+  }
+
+  const modules = manifest.modules
+  const moduleIds = new Set(Object.keys(modules))
+  const ownedPaths = new Map()
+
+  for (const [moduleId, module] of Object.entries(modules)) {
+    if (!/^[a-z][a-z0-9_]*$/.test(moduleId)) {
+      throw new Error(`Invalid module-impact module id: ${moduleId}`)
+    }
+
+    const ownerPaths = requireStringArray(module.ownerPaths, `${moduleId}.ownerPaths`, {
+      nonEmpty: true
+    })
+    const interfacePaths = requireStringArray(module.interfacePaths, `${moduleId}.interfacePaths`, {
+      nonEmpty: true
+    })
+    const consumers = requireStringArray(module.consumerModules, `${moduleId}.consumerModules`)
+    const overlays = requireStringArray(module.capabilityOverlays, `${moduleId}.capabilityOverlays`)
+
+    for (const ownerPath of ownerPaths) {
+      validateRepositoryPath(ownerPath, `${moduleId}.ownerPaths`, pathExists)
+      const existingOwner = ownedPaths.get(ownerPath)
+      if (existingOwner) {
+        throw new Error(
+          `Module owner path ${ownerPath} is shared by ${existingOwner} and ${moduleId}`
+        )
+      }
+      ownedPaths.set(ownerPath, moduleId)
+    }
+    for (const interfacePath of interfacePaths) {
+      validateRepositoryPath(interfacePath, `${moduleId}.interfacePaths`, pathExists)
+    }
+
+    for (const consumer of consumers) {
+      if (!moduleIds.has(consumer)) {
+        throw new Error(`Unknown consumer module for ${moduleId}: ${consumer}`)
+      }
+      if (consumer === moduleId) throw new Error(`Module ${moduleId} cannot consume itself`)
+    }
+    for (const overlay of overlays) {
+      if (!knownCapabilities.has(overlay)) {
+        throw new Error(`Unknown capability overlay for ${moduleId}: ${overlay}`)
+      }
+    }
+    if (!knownCapabilities.has(module.fallbackCapability)) {
+      throw new Error(
+        `Unknown fallback capability for ${moduleId}: ${String(module.fallbackCapability)}`
+      )
+    }
+
+    if (
+      !module.testFiles ||
+      typeof module.testFiles !== 'object' ||
+      Array.isArray(module.testFiles)
+    ) {
+      throw new Error(`${moduleId}.testFiles must declare owner, contract, and consumer tests`)
+    }
+    const unexpectedTestKinds = Object.keys(module.testFiles).filter(
+      (kind) => !moduleTestKinds.includes(kind)
+    )
+    if (unexpectedTestKinds.length > 0) {
+      throw new Error(`${moduleId}.testFiles has unknown kinds: ${unexpectedTestKinds.join(', ')}`)
+    }
+    const declaredTests = moduleTestKinds.flatMap((kind) =>
+      requireStringArray(module.testFiles[kind], `${moduleId}.testFiles.${kind}`)
+    )
+    if (declaredTests.length === 0) throw new Error(`${moduleId}.testFiles must not be empty`)
+    for (const testFile of declaredTests) {
+      validateRepositoryPath(testFile, `${moduleId}.testFiles`, pathExists)
+      if (!/\.(?:test|spec)\.[cm]?[jt]sx?$/.test(testFile)) {
+        throw new Error(`${moduleId}.testFiles must reference a test file: ${testFile}`)
+      }
+    }
+  }
+
+  const visited = new Set()
+  const visitConsumers = (moduleId, path, visiting) => {
+    if (visiting.has(moduleId)) {
+      throw new Error(`Module-impact consumer cycle: ${[...path, moduleId].join(' -> ')}`)
+    }
+    if (visited.has(moduleId)) return
+
+    const nextVisiting = new Set(visiting).add(moduleId)
+    const nextPath = [...path, moduleId]
+    for (const consumer of modules[moduleId].consumerModules) {
+      visitConsumers(consumer, nextPath, nextVisiting)
+    }
+    visited.add(moduleId)
+  }
+  for (const moduleId of moduleIds) visitConsumers(moduleId, [], new Set())
+
+  return manifest
+}
+
+export const moduleImpactManifestPath = fileURLToPath(
+  new URL('./module-impact.json', import.meta.url)
+)

--- a/scripts/ci/validate-module-impact.test.ts
+++ b/scripts/ci/validate-module-impact.test.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { validateModuleImpactManifest } from './validate-module-impact.mjs'
+
+const readManifest = (): ReturnType<JSON['parse']> =>
+  JSON.parse(readFileSync(resolve('scripts/ci/module-impact.json'), 'utf8'))
+
+describe('module ownership and test impact manifest', () => {
+  it('validates the repository manifest and every declared evidence path', () => {
+    const manifest = readManifest()
+
+    expect(
+      validateModuleImpactManifest(manifest, {
+        pathExists: (repoPath: string) => existsSync(resolve(repoPath))
+      })
+    ).toBe(manifest)
+  })
+
+  it('rejects ambiguous module owners', () => {
+    const manifest = readManifest()
+    manifest.modules.workspace_runtime.ownerPaths = ['src/renderer/src/stores/session-store.ts']
+
+    expect(() => validateModuleImpactManifest(manifest)).toThrow(
+      'Module owner path src/renderer/src/stores/session-store.ts is shared by session_renderer and workspace_runtime'
+    )
+  })
+
+  it('rejects unknown and cyclic module consumers', () => {
+    const unknownManifest = readManifest()
+    unknownManifest.modules.workspace_page.consumerModules = ['unknown_module']
+    expect(() => validateModuleImpactManifest(unknownManifest)).toThrow(
+      'Unknown consumer module for workspace_page: unknown_module'
+    )
+
+    const cyclicManifest = readManifest()
+    cyclicManifest.modules.workspace_page.consumerModules = ['session_renderer']
+    expect(() => validateModuleImpactManifest(cyclicManifest)).toThrow(
+      'Module-impact consumer cycle: session_renderer -> workspace_runtime -> workspace_page -> session_renderer'
+    )
+  })
+
+  it.each([
+    'src\\renderer\\session-store.test.ts',
+    'C:/repo/session-store.test.ts',
+    '/repo/session-store.test.ts',
+    '../session-store.test.ts'
+  ])('rejects non-portable evidence path %s', (testFile) => {
+    const manifest = readManifest()
+    manifest.modules.session_renderer.testFiles.owner = [testFile]
+
+    expect(() => validateModuleImpactManifest(manifest)).toThrow(
+      'session_renderer.testFiles must be a portable repository-relative path'
+    )
+  })
+
+  it('rejects missing module evidence paths', () => {
+    const manifest = readManifest()
+
+    expect(() =>
+      validateModuleImpactManifest(manifest, {
+        pathExists: (repoPath: string) => repoPath !== 'src/main/artifacts/repository.test.ts'
+      })
+    ).toThrow('artifact_storage.testFiles does not exist: src/main/artifacts/repository.test.ts')
+  })
+
+  it('rejects unknown module capability references', () => {
+    const overlayManifest = readManifest()
+    overlayManifest.modules.artifact_storage.capabilityOverlays = ['unknown_overlay']
+    expect(() => validateModuleImpactManifest(overlayManifest)).toThrow(
+      'Unknown capability overlay for artifact_storage: unknown_overlay'
+    )
+
+    const fallbackManifest = readManifest()
+    fallbackManifest.modules.workspace_page.fallbackCapability = 'unknown_fallback'
+    expect(() => validateModuleImpactManifest(fallbackManifest)).toThrow(
+      'Unknown fallback capability for workspace_page: unknown_fallback'
+    )
+  })
+})


### PR DESCRIPTION
## Problem

The remaining deep-module refactors have no repository-owned map from a stable Module ID to its
current owner, external interface, downstream Modules, or test evidence. CodeGraph can help discover
relationships locally, but its broad affected-test output is not a deterministic CI contract by
itself.

## Proposed change

- add a standalone, versioned, repository-owned `module-impact.json` manifest;
- declare nine approved Renderer and persistence Modules with owner/interface paths, consumer edges,
  owner/contract/consumer tests, capability overlays, and fail-closed fallback capabilities;
- add a pure manifest validator for unique ownership, known acyclic consumers, known capabilities,
  complete test declarations, existing files, and portable repository-relative paths;
- add repository tests for the valid manifest and rejection cases.

## Scope and non-goals

This is T0 only. It does not add `test:module` or `test:affected`, consume CodeGraph output, alter PR
Gate execution, or enable selective blocking. Production raw is `0`; the new manifest, validator, and
tests add `359` lines. Existing protected classifier/control-plane files and the top-level PR Gate
plan schema remain unchanged.

## Compatibility

Product behavior is unchanged. Public methods, renderer selectors, IPC/application-command names,
HTTP/RPC/CLI payloads, persisted data, and UI behavior are untouched. Electron, Web, CLI, Task,
local-RPC, and MCP capability boundaries remain unchanged, including existing Specialist,
Permission, and Compute asymmetries. Manifest paths use portable `/`-separated repository-relative
forms and are validated independently of host path separators.

## Acceptance criteria and validation

- module manifest -> focused manifest/classifier/PR Gate tests -> `116 passed`;
- final exact diff -> local CI Integrity policy -> passed with no violations;
- changed JavaScript/TypeScript -> focused ESLint -> passed;
- manifest, validator, tests -> Prettier check and `git diff --check` -> passed;
- final diff -> trusted classifier -> full plan with policy/static/unit/Windows/macOS bundles;
- independent Standards review -> `0 findings`;
- independent Spec review -> `0 findings`.

Because trusted classifier inputs changed, exact-head PR Gate full fallback remains authoritative for
typecheck, lint, complete `npm test`, platform, CI integrity, CodeQL, and AI review before squash
merge. No administrator exception is requested.

## Review focus

Please verify that Module ownership is unique, consumer edges follow the current dependency direction,
declared tests are sufficient seeds for T1, and validation fails closed without changing current
classification behavior. This PR must be squash merged only after exact-head CI and AI are green.
