### PR TITLE
ci(release): separate portable and native gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,37 +313,33 @@ jobs:
           executable="$(node -e 'process.stdout.write(require("path").resolve(process.argv[1]))' "$candidate")"
           echo "executable=$executable" >> "$GITHUB_OUTPUT"
 
-      # Run the release-critical desktop journeys against the packaged Electron executable on every
-      # native target. The same focused specs use the source fixture in PR Gate when owners change.
+      # Run the portable release-critical desktop journeys once against the packaged ARM64 app.
+      # Native installer/package behavior remains hard-gated below for every published target.
       - name: Run P0 Electron certification
         id: p0
-        if: ${{ !inputs.skip_verify && steps.packaged_app.outcome == 'success' }}
+        if: >-
+          ${{ !inputs.skip_verify &&
+              matrix.name == 'macos-arm64' &&
+              steps.packaged_app.outcome == 'success' }}
         continue-on-error: true
         shell: bash
         env:
           OPEN_SCIENCE_E2E_EXECUTABLE: ${{ steps.packaged_app.outputs.executable }}
-        run: |
-          if [ "${{ matrix.platform }}" = "linux" ]; then
-            xvfb-run -a npm run test:e2e:p0
-          else
-            npm run test:e2e:p0
-          fi
+        run: npm run test:e2e:p0
 
-      # All platforms compare the same canonical Chromium layout baseline. The spec keeps the strict
-      # macOS budget and a bounded cross-platform antialiasing budget.
+      # Visual behavior uses the same renderer bundle on every package. Keep one canonical hard gate
+      # beside P0 instead of multiplying antialiasing and launch variance across four native runners.
       - name: Run desktop visual regression
         id: visual
-        if: ${{ !inputs.skip_verify && steps.packaged_app.outcome == 'success' }}
+        if: >-
+          ${{ !inputs.skip_verify &&
+              matrix.name == 'macos-arm64' &&
+              steps.packaged_app.outcome == 'success' }}
         continue-on-error: true
         shell: bash
         env:
           OPEN_SCIENCE_E2E_EXECUTABLE: ${{ steps.packaged_app.outputs.executable }}
-        run: |
-          if [ "${{ matrix.platform }}" = "linux" ]; then
-            xvfb-run -a npm run test:e2e:visual
-          else
-            npm run test:e2e:visual
-          fi
+        run: npm run test:e2e:visual
 
       # Exercise both macOS distributables rather than treating the unpacked app launch above as
       # package coverage: mount the DMG, extract the ZIP, verify each bundle, and launch each app.
@@ -383,13 +379,23 @@ jobs:
         if: >-
           ${{ !inputs.skip_verify &&
               steps.packaged_app.outcome == 'success' &&
-              steps.p0.outcome == 'success' &&
-              steps.visual.outcome == 'success' &&
+              ((matrix.name == 'macos-arm64' &&
+                steps.p0.outcome == 'success' &&
+                steps.visual.outcome == 'success') ||
+               (matrix.name != 'macos-arm64' &&
+                steps.p0.outcome == 'skipped' &&
+                steps.visual.outcome == 'skipped')) &&
               ((matrix.platform == 'mac' && steps.macos_smoke.outcome == 'success') ||
                (matrix.platform == 'win' && steps.windows_smoke.outcome == 'success') ||
                (matrix.platform == 'linux' && steps.linux_smoke.outcome == 'success')) }}
         shell: bash
         run: |
+          electron_p0=not-applicable
+          visual_regression=not-applicable
+          if [ "${{ matrix.name }}" = "macos-arm64" ]; then
+            electron_p0=passed
+            visual_regression=passed
+          fi
           package_smoke=passed
           authenticode=not-applicable
           if [ "${{ matrix.platform }}" = "win" ]; then
@@ -399,6 +405,8 @@ jobs:
             --platform "${{ matrix.name }}" \
             --artifact-dir dist \
             --output "dist/certification-${{ matrix.name }}.json" \
+            --electron-p0 "$electron_p0" \
+            --visual-regression "$visual_regression" \
             --package-smoke "$package_smoke" \
             --authenticode "$authenticode"
 
@@ -427,6 +435,7 @@ jobs:
         env:
           LINUX_SMOKE_OUTCOME: ${{ steps.linux_smoke.outcome }}
           MACOS_SMOKE_OUTCOME: ${{ steps.macos_smoke.outcome }}
+          MATRIX_NAME: ${{ matrix.name }}
           P0_OUTCOME: ${{ steps.p0.outcome }}
           PACKAGED_APP_OUTCOME: ${{ steps.packaged_app.outcome }}
           PLATFORM: ${{ matrix.platform }}
@@ -442,8 +451,10 @@ jobs:
             fi
           }
           check packaged_app "$PACKAGED_APP_OUTCOME"
-          check p0 "$P0_OUTCOME"
-          check visual "$VISUAL_OUTCOME"
+          if [[ "$MATRIX_NAME" == "macos-arm64" ]]; then
+            check p0 "$P0_OUTCOME"
+            check visual "$VISUAL_OUTCOME"
+          fi
           case "$PLATFORM" in
             mac) check macos_smoke "$MACOS_SMOKE_OUTCOME" ;;
             win) check windows_smoke "$WINDOWS_SMOKE_OUTCOME" ;;

--- a/.github/workflows/notarize-dryrun.yml
+++ b/.github/workflows/notarize-dryrun.yml
@@ -37,4 +37,6 @@ jobs:
   notarize:
     needs: build
     uses: ./.github/workflows/notarize-mac.yml
+    with:
+      certified_build: false
     secrets: inherit

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -40,6 +40,13 @@ on:
         required: false
         type: boolean
         default: true
+      certified_build:
+        description: >-
+          Preserve release-certification evidence from a verified build. False for the manual
+          notarization dry run, whose build intentionally skips verification.
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       tag:
@@ -236,12 +243,17 @@ jobs:
       # Stapling changes the installer bytes. Re-hash the final artifacts while preserving the
       # platform certification signal already established by the build job.
       - name: Refresh macOS certification evidence
-        if: steps.gate.outputs.enabled == 'true' && inputs.from_run
+        if: >-
+          steps.gate.outputs.enabled == 'true' &&
+          inputs.from_run &&
+          inputs.certified_build
         run: >-
           node scripts/ci/release-certification-evidence.mjs write
           --platform "macos-${{ matrix.arch }}"
           --artifact-dir mac
           --output "mac/certification-macos-${{ matrix.arch }}.json"
+          --electron-p0 "${{ matrix.arch == 'arm64' && 'passed' || 'not-applicable' }}"
+          --visual-regression "${{ matrix.arch == 'arm64' && 'passed' || 'not-applicable' }}"
           --package-smoke passed
           --authenticode not-applicable
 

--- a/scripts/ci/release-certification-evidence.mjs
+++ b/scripts/ci/release-certification-evidence.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from 'node:url'
 
 const PLATFORMS = ['linux-x64', 'macos-arm64', 'macos-x64', 'windows-x64']
 const DISTRIBUTABLE = /\.(?:AppImage|deb|dmg|exe|zip)$/
+const CHECK_STATES = ['passed', 'not-applicable']
 
 const argumentValue = (argv, name) => {
   const index = argv.indexOf(name)
@@ -30,17 +31,23 @@ const writePlatformEvidence = async ({ argv, environment = process.env }) => {
   const platform = argumentValue(argv, '--platform')
   const artifactDirectoryArgument = argumentValue(argv, '--artifact-dir')
   const outputArgument = argumentValue(argv, '--output')
+  const electronP0 = argumentValue(argv, '--electron-p0')
+  const visualRegression = argumentValue(argv, '--visual-regression')
   const packageSmoke = argumentValue(argv, '--package-smoke')
   const authenticode = argumentValue(argv, '--authenticode')
   if (
     !PLATFORMS.includes(platform) ||
     !artifactDirectoryArgument ||
     !outputArgument ||
+    !CHECK_STATES.includes(electronP0) ||
+    !CHECK_STATES.includes(visualRegression) ||
     !['passed', 'not-applicable'].includes(packageSmoke) ||
     !['passed', 'not-required', 'not-applicable'].includes(authenticode)
   ) {
     throw new Error(
       'Usage: --platform <platform> --artifact-dir <path> --output <path> ' +
+        '--electron-p0 <passed|not-applicable> ' +
+        '--visual-regression <passed|not-applicable> ' +
         '--package-smoke <passed|not-applicable> ' +
         '--authenticode <passed|not-required|not-applicable>'
     )
@@ -62,8 +69,8 @@ const writePlatformEvidence = async ({ argv, environment = process.env }) => {
       runAttempt: environment.GITHUB_RUN_ATTEMPT
     },
     checks: {
-      electronP0: 'passed',
-      visualRegression: 'passed',
+      electronP0,
+      visualRegression,
       packageSmoke,
       authenticode
     },
@@ -190,11 +197,12 @@ const aggregateEvidence = async ({ argv }) => {
 
   for (const platform of PLATFORMS) {
     const record = byPlatform.get(platform)
+    const expectedPortableCheck = platform === 'macos-arm64' ? 'passed' : 'not-applicable'
     if (
       record.schemaVersion !== 1 ||
       record.source?.sha !== expectedSha ||
-      record.checks?.electronP0 !== 'passed' ||
-      record.checks?.visualRegression !== 'passed' ||
+      record.checks?.electronP0 !== expectedPortableCheck ||
+      record.checks?.visualRegression !== expectedPortableCheck ||
       !Array.isArray(record.artifacts) ||
       record.artifacts.length === 0
     ) {

--- a/scripts/ci/release-certification-evidence.test.ts
+++ b/scripts/ci/release-certification-evidence.test.ts
@@ -41,6 +41,10 @@ describe('release certification evidence', () => {
         root,
         '--output',
         output,
+        '--electron-p0',
+        'not-applicable',
+        '--visual-regression',
+        'not-applicable',
         '--package-smoke',
         'passed',
         '--authenticode',
@@ -58,7 +62,11 @@ describe('release certification evidence', () => {
     await expect(JSON.parse(await readFile(output, 'utf8'))).toMatchObject({
       platform: 'linux-x64',
       source: { sha: 'abc123', runId: '42', runAttempt: '2' },
-      checks: { electronP0: 'passed', packageSmoke: 'passed' }
+      checks: {
+        electronP0: 'not-applicable',
+        visualRegression: 'not-applicable',
+        packageSmoke: 'passed'
+      }
     })
   })
 
@@ -194,8 +202,8 @@ describe('release certification evidence', () => {
       platform,
       source: { sha },
       checks: {
-        electronP0: 'passed',
-        visualRegression: 'passed',
+        electronP0: platform === 'macos-arm64' ? 'passed' : 'not-applicable',
+        visualRegression: platform === 'macos-arm64' ? 'passed' : 'not-applicable',
         packageSmoke: 'passed',
         authenticode: platform === 'windows-x64' ? 'not-required' : 'not-applicable'
       },
@@ -220,6 +228,25 @@ describe('release certification evidence', () => {
       sourceSha: 'abc123',
       platforms: expect.arrayContaining([expect.objectContaining({ platform: 'windows-x64' })])
     })
+
+    await writeFile(
+      join(root, 'certification-windows-x64.json'),
+      JSON.stringify({
+        ...recordFor('windows-x64'),
+        checks: {
+          ...recordFor('windows-x64').checks,
+          electronP0: 'passed',
+          visualRegression: 'passed'
+        }
+      })
+    )
+    await expect(aggregateEvidence({ argv: args })).rejects.toThrow(
+      /Invalid release certification evidence for windows-x64/
+    )
+    await writeFile(
+      join(root, 'certification-windows-x64.json'),
+      JSON.stringify(recordFor('windows-x64'))
+    )
 
     await writeFile(
       join(root, 'certification-macos-arm64.json'),

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -116,7 +116,7 @@ describe('post-merge Windows validation', () => {
     expect(packageStep.run).not.toContain('publisherName')
   })
 
-  it('runs cross-platform P0 and visual against packaged apps before recording evidence', () => {
+  it('runs one canonical packaged P0 and visual gate plus native package smoke on every target', () => {
     const setup = readWorkflow('build.yml').jobs.setup.steps?.find(({ id }) => id === 'set')
     const job = readWorkflow('build.yml').jobs.build
     const names = job.steps?.map(({ name }) => name) ?? []
@@ -127,6 +127,7 @@ describe('post-merge Windows validation', () => {
     const linux = findStep(job, 'Smoke test Linux packages')
     const evidence = findStep(job, 'Record platform certification evidence')
     const notarize = readWorkflow('notarize-mac.yml').jobs.notarize
+    const notarizeDryRun = readWorkflow('notarize-dryrun.yml').jobs.notarize
     const finalMacos = findStep(notarize, 'Smoke test final macOS packages')
     const refreshedMacosEvidence = findStep(notarize, 'Refresh macOS certification evidence')
 
@@ -143,16 +144,25 @@ describe('post-merge Windows validation', () => {
     expect(visual.env?.OPEN_SCIENCE_E2E_EXECUTABLE).toBe(
       '${{ steps.packaged_app.outputs.executable }}'
     )
-    expect(p0.run).toContain('npm run test:e2e:p0')
-    expect(visual.run).toContain('npm run test:e2e:visual')
+    expect(p0.if).toContain("matrix.name == 'macos-arm64'")
+    expect(visual.if).toContain("matrix.name == 'macos-arm64'")
+    expect(p0.run).toBe('npm run test:e2e:p0')
+    expect(visual.run).toBe('npm run test:e2e:visual')
     expect(macos.if).toBe("${{ matrix.platform == 'mac' && !inputs.skip_verify }}")
     expect(macos.run).toBe('node scripts/macos-package-smoke.mjs --artifact-dir dist')
     expect(linux.run).toContain('scripts/linux-package-smoke.mjs')
     expect(evidence.run).toContain('package_smoke=passed')
+    expect(evidence.run).toContain('electron_p0=not-applicable')
+    expect(evidence.run).toContain('visual_regression=not-applicable')
+    expect(evidence.run).toContain('--electron-p0 "$electron_p0"')
+    expect(evidence.run).toContain('--visual-regression "$visual_regression"')
     expect(finalMacos.run).toBe(
       'node scripts/macos-package-smoke.mjs --artifact-dir mac --gatekeeper'
     )
     expect(refreshedMacosEvidence.run).toContain('--package-smoke passed')
+    expect(refreshedMacosEvidence.run).toContain("matrix.arch == 'arm64'")
+    expect(refreshedMacosEvidence.if).toContain('inputs.certified_build')
+    expect(notarizeDryRun.with?.certified_build).toBe(false)
     expect(names.indexOf('Record platform certification evidence')).toBeGreaterThan(
       names.indexOf('Smoke test macOS packages')
     )
@@ -187,12 +197,17 @@ describe('post-merge Windows validation', () => {
     }
     expect(evidence.if).toContain("steps.p0.outcome == 'success'")
     expect(evidence.if).toContain("steps.visual.outcome == 'success'")
+    expect(evidence.if).toContain("matrix.name != 'macos-arm64'")
+    expect(evidence.if).toContain("steps.p0.outcome == 'skipped'")
+    expect(evidence.if).toContain("steps.visual.outcome == 'skipped'")
     expect(upload.if).toBe("${{ always() && steps.package.outcome == 'success' }}")
     expect(enforce.if).toBe('${{ !inputs.skip_verify && always() }}')
     expect(enforce.env).toMatchObject({
+      MATRIX_NAME: '${{ matrix.name }}',
       P0_OUTCOME: '${{ steps.p0.outcome }}',
       VISUAL_OUTCOME: '${{ steps.visual.outcome }}'
     })
+    expect(enforce.run).toContain('if [[ "$MATRIX_NAME" == "macos-arm64" ]]')
     expect(enforce.run).toContain('exit "$failed"')
     expect(names.indexOf('Upload build artifacts')).toBeLessThan(
       names.indexOf('Enforce platform certification')


### PR DESCRIPTION
## Problem

The Release workflow repeated packaged Electron P0 and visual certification on macOS ARM64, macOS x64, Windows, and Linux. Those journeys exercise the same renderer and Agent behavior, while native runner startup and teardown variance made the duplicated Windows and Intel macOS lanes intermittently block otherwise valid packages.

## Proposed change

Run portable packaged-app certification once on the canonical macOS ARM64 artifact, while retaining hard native package smoke gates for every published target. Record portable checks as not-applicable on non-canonical targets so the aggregate evidence cannot mistake a skipped check for a pass.

```mermaid
flowchart TD
  A["Build all native targets"] --> B["macOS ARM64: packaged P0 + visual"]
  A --> C["Each target: native package smoke"]
  B --> D["Canonical evidence: portable checks passed"]
  C --> E["All evidence: package smoke passed"]
  A --> F["Non-canonical evidence: portable checks not-applicable"]
  D --> G["Aggregate release certification"]
  E --> G
  F --> G
  G --> H["Notarize and final Gatekeeper checks"]
```

The manual notarization dry run explicitly disables certification refresh because its build intentionally skips verification.

## Scope and non-goals

- Keeps macOS DMG/ZIP, Windows installer, Linux DEB/AppImage, notarization, and final Gatekeeper smoke checks blocking.
- Does not weaken native package validation or add Windows Authenticode as a requirement; the project currently has no Windows signing certificate.
- Does not change PR Gate classification in this focused release-workflow follow-up.

## Acceptance criteria and validation

- Canonical/native workflow boundary and reusable-workflow contract -> `npm test -- scripts/windows-release-workflows.test.ts scripts/ci/release-certification-evidence.test.ts` -> 14 tests passed.
- TypeScript consumers -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 17 existing warnings.
- Global workflow/evidence consumers -> `npm test` -> 828 test files and 12,175 tests passed; 14 files and 184 tests skipped.
- Patch integrity -> `git diff --check` -> passed.

All checks above ran after the last material edit.

Uncovered risk: native packaging and runner-specific behavior cannot be reproduced on this local macOS host. The post-merge Release run will exercise all four package smoke lanes, both notarization lanes, and final Gatekeeper assessment.

## Review focus

- Confirm macOS ARM64 is the intended single portable packaged-app authority.
- Confirm evidence aggregation fails closed unless non-canonical portable checks are explicitly not-applicable.
- Confirm dry-run notarization cannot emit release certification for an unverified build.
