### PR TITLE
fix(macOS-release): stabilize signing and native notarization smoke

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,15 +204,29 @@ jobs:
 
           keychain="$RUNNER_TEMP/open-science-signing-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.name }}.keychain-db"
           certificate="$RUNNER_TEMP/open-science-signing-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.name }}.p12"
+          keychain_list="$RUNNER_TEMP/open-science-signing-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.name }}-user-keychains.txt"
           keychain_password=$(openssl rand -base64 32)
           echo "enabled=true" >> "$GITHUB_OUTPUT"
           echo "keychain=$keychain" >> "$GITHUB_OUTPUT"
           echo "certificate=$certificate" >> "$GITHUB_OUTPUT"
+          echo "keychain_list=$keychain_list" >> "$GITHUB_OUTPUT"
 
+          security list-keychains -d user > "$keychain_list"
           printf '%s' "$MAC_CSC_LINK" | base64 --decode > "$certificate"
           security create-keychain -p "$keychain_password" "$keychain"
           security set-keychain-settings -lut 21600 "$keychain"
           security unlock-keychain -p "$keychain_password" "$keychain"
+          user_keychains=()
+          while IFS= read -r entry; do
+            entry="${entry#*\"}"
+            entry="${entry%\"*}"
+            if [ -n "$entry" ] && [ "$entry" != "$keychain" ]; then
+              user_keychains+=("$entry")
+            fi
+          done < "$keychain_list"
+          # codesign ignores an explicitly selected keychain unless it is also in the user search
+          # list. Preserve the runner entries and restore them in the always-run cleanup below.
+          security list-keychains -d user -s "$keychain" "${user_keychains[@]}"
           security import "$certificate" -k "$keychain" \
             -P "${MAC_CSC_KEY_PASSWORD:-}" \
             -T /usr/bin/codesign \
@@ -288,10 +302,20 @@ jobs:
         env:
           MAC_SIGNING_CERTIFICATE: ${{ steps.mac_signing.outputs.certificate }}
           MAC_SIGNING_KEYCHAIN: ${{ steps.mac_signing.outputs.keychain }}
+          MAC_SIGNING_KEYCHAIN_LIST: ${{ steps.mac_signing.outputs.keychain_list }}
         run: |
           set -euo pipefail
+          if [ -f "$MAC_SIGNING_KEYCHAIN_LIST" ]; then
+            user_keychains=()
+            while IFS= read -r entry; do
+              entry="${entry#*\"}"
+              entry="${entry%\"*}"
+              [ -n "$entry" ] && user_keychains+=("$entry")
+            done < "$MAC_SIGNING_KEYCHAIN_LIST"
+            security list-keychains -d user -s "${user_keychains[@]}" || true
+          fi
           security delete-keychain "$MAC_SIGNING_KEYCHAIN" || true
-          rm -f "$MAC_SIGNING_CERTIFICATE"
+          rm -f "$MAC_SIGNING_CERTIFICATE" "$MAC_SIGNING_KEYCHAIN_LIST"
 
       - name: Resolve packaged Electron executable
         id: packaged_app

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -60,14 +60,20 @@ permissions:
 jobs:
   notarize:
     name: Notarize + staple ${{ matrix.arch }}
-    runs-on: macos-14
+    # The final package smoke launches the stapled app. Keep it architecture-native so the x64
+    # launch is not silently dependent on Rosetta being installed on an Apple Silicon runner.
+    runs-on: ${{ matrix.os }}
     # Hard ceiling so a stuck notarization can never run forever (see also the wait --timeout below).
     timeout-minutes: 30
     strategy:
       # One arch's Apple hiccup must not cancel the other.
       fail-fast: false
       matrix:
-        arch: [arm64, x64]
+        include:
+          - arch: arm64
+            os: macos-15
+          - arch: x64
+            os: macos-15-intel
     steps:
       # Notarization is optional: if the API key secret isn't configured, no-op so a tagged release
       # still succeeds with the ad-hoc mac build (today's behavior) instead of failing here. Every

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -98,6 +98,10 @@ describe('post-merge Windows validation', () => {
       if: "${{ matrix.platform == 'mac' && !inputs.nightly }}"
     })
     expect(prepareMacSigning.run).toContain('security create-keychain -p "$keychain_password"')
+    expect(prepareMacSigning.run).toContain('security list-keychains -d user > "$keychain_list"')
+    expect(prepareMacSigning.run).toContain(
+      'security list-keychains -d user -s "$keychain" "${user_keychains[@]}"'
+    )
     expect(prepareMacSigning.run).toContain('-P "${MAC_CSC_KEY_PASSWORD:-}"')
     expect(prepareMacSigning.run).toContain('-k "$keychain_password"')
     expect(prepareMacSigning.run).toContain("grep -q 'Developer ID Application:'")
@@ -108,10 +112,20 @@ describe('post-merge Windows validation', () => {
       'if [ "${{ steps.mac_signing.outputs.enabled }}" = "true" ]; then'
     )
     expect(cleanupMacSigning).toMatchObject({
-      if: "${{ always() && steps.mac_signing.outputs.keychain != '' }}"
+      if: "${{ always() && steps.mac_signing.outputs.keychain != '' }}",
+      env: {
+        MAC_SIGNING_CERTIFICATE: '${{ steps.mac_signing.outputs.certificate }}',
+        MAC_SIGNING_KEYCHAIN: '${{ steps.mac_signing.outputs.keychain }}',
+        MAC_SIGNING_KEYCHAIN_LIST: '${{ steps.mac_signing.outputs.keychain_list }}'
+      }
     })
+    expect(cleanupMacSigning.run).toContain(
+      'security list-keychains -d user -s "${user_keychains[@]}"'
+    )
     expect(cleanupMacSigning.run).toContain('security delete-keychain "$MAC_SIGNING_KEYCHAIN"')
-    expect(cleanupMacSigning.run).toContain('rm -f "$MAC_SIGNING_CERTIFICATE"')
+    expect(cleanupMacSigning.run).toContain(
+      'rm -f "$MAC_SIGNING_CERTIFICATE" "$MAC_SIGNING_KEYCHAIN_LIST"'
+    )
     expect(packageStep.run).toContain('unsigned_args=(-c.dmg.sign=false)')
     expect(packageStep.run).not.toContain('publisherName')
   })

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -173,6 +173,13 @@ describe('post-merge Windows validation', () => {
     expect(finalMacos.run).toBe(
       'node scripts/macos-package-smoke.mjs --artifact-dir mac --gatekeeper'
     )
+    expect(notarize['runs-on']).toBe('${{ matrix.os }}')
+    expect(notarize.strategy?.matrix).toEqual({
+      include: [
+        { arch: 'arm64', os: 'macos-15' },
+        { arch: 'x64', os: 'macos-15-intel' }
+      ]
+    })
     expect(refreshedMacosEvidence.run).toContain('--package-smoke passed')
     expect(refreshedMacosEvidence.run).toContain("matrix.arch == 'arm64'")
     expect(refreshedMacosEvidence.if).toContain('inputs.certified_build')


### PR DESCRIPTION
## Problem

The v0.11.1 release retry prepared and unlocked a deterministic temporary keychain, and `security find-identity` could see its Developer ID identity. However, both macOS packaging jobs still failed when `electron-builder` invoked `codesign --keychain ...` with `no identity found`.

macOS `codesign` only uses an explicitly selected keychain reliably when that keychain is also registered in the user keychain search list.

The first no-publish dry run also showed that the notarization workflow launched both final packages on the same Apple Silicon runner. The x64 artifact was accepted and stapled by Apple, but its launch smoke timed out because that runner did not provide a native Intel environment.

## Proposed change

- Save the runner's existing user keychain search list before release signing setup.
- Register the temporary release keychain first in that search list while preserving all existing entries.
- Restore the original search list during cleanup before deleting the temporary keychain.
- Run arm64 and x64 post-notarization package smoke on native macOS 15 runners.
- Add workflow contract coverage for the setup and cleanup pairing.

```mermaid
flowchart LR
  A["Save user keychain list"] --> B["Create and unlock temporary keychain"]
  B --> C["Import Developer ID identity"]
  C --> D["Register keychain in search list"]
  D --> E["electron-builder codesign"]
  E --> F["Apple notarization and staple"]
  F --> G["Native-architecture Gatekeeper smoke"]
  G --> H["Restore original search list"]
  H --> I["Delete temporary keychain"]
```

## Scope and non-goals

- Changes only the macOS release signing setup/cleanup, native post-notarization runner selection, and workflow contract coverage.
- Does not change Windows signing behavior; Windows remains intentionally unsigned because no certificate is configured.
- Does not publish or alter a GitHub Release.
- Does not change application runtime code.

## Validation

- `npm test -- scripts/windows-release-workflows.test.ts` — 10 tests passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed with 0 errors and 17 pre-existing warnings.
- `git diff --check` — passed.
- Full Vitest suite — 828 files and 12,183 tests passed; one unrelated timing-sensitive notebook shell test missed its pre-timeout stderr on this local run. Its file passed immediately on focused rerun (12 tests passed).
- First remote dry run — both native builds signed and packaged successfully; Apple accepted and stapled both architectures; arm64 passed final Gatekeeper smoke; x64 exposed the cross-architecture launch issue described above.
- Final remote acceptance test — [dry run 31154392301](https://github.com/aipoch/open-science/actions/runs/31154392301) passed in about 18 minutes. Both architectures signed and packaged successfully, Apple accepted and stapled both submissions, and native macOS 15 Gatekeeper/package smoke passed without publishing or modifying a Release.

## Review focus

- Confirm the search-list update preserves the runner's existing keychains.
- Confirm cleanup restores the exact original list even after a failed packaging step.
- Confirm both notarization matrix entries remain on macOS 15 and run on their native architecture.

## Risk

Actual certificate discovery and notarization can only be validated on the GitHub-hosted macOS runners with repository secrets. The no-publish notarization dry run is therefore the acceptance gate for this change.
