### PR TITLE
ci(test-impact): publish module shadow evidence

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -170,6 +170,62 @@ jobs:
           }
           NODE
 
+      - name: Prepare trusted module shadow
+        id: trusted_module_shadow
+        continue-on-error: true
+        shell: bash
+        env:
+          BASE_SHA: ${{ steps.revisions.outputs.base }}
+        run: |
+          set -euo pipefail
+          trusted_dir="$RUNNER_TEMP/pr-gate-trusted-module-shadow"
+          mkdir -p "$trusted_dir"
+          echo "dir=$trusted_dir" >> "$GITHUB_OUTPUT"
+
+          required=(
+            scripts/ci/module-impact-shadow.mjs
+            scripts/ci/module-test-impact.mjs
+            scripts/ci/module-impact.json
+            scripts/ci/validate-module-impact.mjs
+            scripts/ci/classify-pr-changes.mjs
+            scripts/ci/change-impact.json
+          )
+          for file in "${required[@]}"; do
+            if ! git cat-file -e "${BASE_SHA}:${file}" 2>/dev/null; then
+              echo "source=bootstrap" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          for file in "${required[@]}"; do
+            git show "${BASE_SHA}:${file}" > "$trusted_dir/${file##*/}"
+          done
+          echo "source=base" >> "$GITHUB_OUTPUT"
+
+      - name: Publish module impact shadow
+        continue-on-error: true
+        env:
+          AUTHORITATIVE_PLAN: ${{ steps.classify.outputs.plan }}
+          BASE_SHA: ${{ steps.revisions.outputs.base }}
+          HEAD_SHA: ${{ steps.revisions.outputs.head }}
+          TRUSTED_MODULE_SHADOW_DIR: ${{ steps.trusted_module_shadow.outputs.dir }}
+          TRUSTED_MODULE_SHADOW_SOURCE: ${{ steps.trusted_module_shadow.outputs.source }}
+        run: |
+          if [[ "$TRUSTED_MODULE_SHADOW_SOURCE" == "base" ]]; then
+            node "$TRUSTED_MODULE_SHADOW_DIR/module-impact-shadow.mjs" \
+              --base "$BASE_SHA" \
+              --head "$HEAD_SHA" \
+              --authoritative-plan "$AUTHORITATIVE_PLAN"
+            exit 0
+          fi
+
+          printf '%s\n' \
+            '## Module impact shadow' \
+            '' \
+            'Status: **bootstrap pending**' \
+            '' \
+            'The base revision does not yet contain the trusted shadow reporter. Module evidence will be published for subsequent changes after this control-plane update merges.' \
+            >> "$GITHUB_STEP_SUMMARY"
+
   policy:
     name: PR policy
     needs: preflight

--- a/scripts/ci/module-impact-shadow.mjs
+++ b/scripts/ci/module-impact-shadow.mjs
@@ -1,0 +1,264 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { execFileSync } from 'node:child_process'
+import { appendFileSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { parseNameStatus } from './classify-pr-changes.mjs'
+import { createAffectedTestPlan } from './module-test-impact.mjs'
+
+const defaultChangeImpactManifest = JSON.parse(
+  readFileSync(new URL('./change-impact.json', import.meta.url), 'utf8')
+)
+
+const manifestOnlyGraph = Object.freeze({
+  status: 'unavailable-manifest-only',
+  reason: 'CI shadow uses the repository manifest only',
+  testFiles: []
+})
+
+function unique(values) {
+  return [...new Set(values)]
+}
+
+function ordered(values, order) {
+  const positions = new Map(order.map((value, index) => [value, index]))
+  return unique(values).sort((left, right) => {
+    const leftPosition = positions.get(left)
+    const rightPosition = positions.get(right)
+    if (leftPosition !== undefined && rightPosition !== undefined) {
+      return leftPosition - rightPosition
+    }
+    if (leftPosition !== undefined) return -1
+    if (rightPosition !== undefined) return 1
+    return left < right ? -1 : left > right ? 1 : 0
+  })
+}
+
+function strings(value) {
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === 'string') : []
+}
+
+function capabilityLanes(capabilityIds, manifest) {
+  const lanes = new Set(manifest.alwaysLanes)
+  const visited = new Set()
+
+  const visit = (capabilityId, visiting) => {
+    if (visiting.has(capabilityId)) {
+      throw new Error(`Change-impact capability cycle: ${[...visiting, capabilityId].join(' -> ')}`)
+    }
+    if (visited.has(capabilityId)) return
+    const capability = manifest.capabilities[capabilityId]
+    if (!capability) throw new Error(`Unknown change-impact capability: ${capabilityId}`)
+
+    const nextVisiting = new Set(visiting).add(capabilityId)
+    for (const lane of capability.lanes) lanes.add(lane)
+    for (const consumer of capability.consumers) visit(consumer, nextVisiting)
+    visited.add(capabilityId)
+  }
+
+  for (const capabilityId of capabilityIds) visit(capabilityId, new Set())
+  return ordered(lanes, manifest.laneOrder)
+}
+
+export function requiredLanesForModulePlan(
+  modulePlan,
+  changeImpactManifest = defaultChangeImpactManifest
+) {
+  if (modulePlan.mode === 'full') return [...changeImpactManifest.laneOrder]
+  return capabilityLanes(
+    [...strings(modulePlan.fallbackCapabilities), ...strings(modulePlan.capabilityOverlays)],
+    changeImpactManifest
+  )
+}
+
+export function createModuleImpactShadowReport(
+  authoritativePlan,
+  modulePlan,
+  changeImpactManifest = defaultChangeImpactManifest
+) {
+  if (
+    !authoritativePlan ||
+    typeof authoritativePlan !== 'object' ||
+    Array.isArray(authoritativePlan)
+  ) {
+    throw new Error('Authoritative plan must be an object')
+  }
+  if (!modulePlan || typeof modulePlan !== 'object' || Array.isArray(modulePlan)) {
+    throw new Error('Module plan must be an object')
+  }
+
+  const requiredLanes = requiredLanesForModulePlan(modulePlan, changeImpactManifest)
+  const selectedLanes = ordered(strings(authoritativePlan.lanes), changeImpactManifest.laneOrder)
+  const selectedLaneSet = new Set(selectedLanes)
+  const requiredLaneSet = new Set(requiredLanes)
+  const missingLanes = requiredLanes.filter((lane) => !selectedLaneSet.has(lane))
+  const additionalAuthoritativeLanes = selectedLanes.filter((lane) => !requiredLaneSet.has(lane))
+  const modeAgreement = authoritativePlan.mode === modulePlan.mode
+  const disagreements = []
+
+  if (!modeAgreement) {
+    disagreements.push(
+      `mode: authoritative ${String(authoritativePlan.mode)} != shadow ${String(modulePlan.mode)}`
+    )
+  }
+  if (missingLanes.length > 0) {
+    disagreements.push(`missing authoritative lanes: ${missingLanes.join(', ')}`)
+  }
+  if (additionalAuthoritativeLanes.length > 0) {
+    disagreements.push(`additional authoritative lanes: ${additionalAuthoritativeLanes.join(', ')}`)
+  }
+
+  return {
+    schemaVersion: 1,
+    enforcement: 'non-blocking',
+    authoritative: {
+      mode: authoritativePlan.mode,
+      roots: strings(authoritativePlan.roots).sort(),
+      lanes: selectedLanes,
+      bundles: ordered(strings(authoritativePlan.bundles), changeImpactManifest.bundleOrder),
+      reasonChains: strings(authoritativePlan.reasonChains).sort()
+    },
+    shadow: {
+      mode: modulePlan.mode,
+      modules: strings(modulePlan.modules).sort(),
+      testFiles: strings(modulePlan.testFiles).sort(),
+      capabilityOverlays: strings(modulePlan.capabilityOverlays).sort(),
+      fallbackCapabilities: strings(modulePlan.fallbackCapabilities).sort(),
+      graphStatus: modulePlan.graphStatus,
+      graphReason: modulePlan.graphReason,
+      reasonChains: strings(modulePlan.reasonChains).sort()
+    },
+    comparison: {
+      modeAgreement,
+      coverage: missingLanes.length === 0 ? 'covered' : 'gap',
+      requiredLanes,
+      selectedLanes,
+      missingLanes,
+      additionalAuthoritativeLanes,
+      disagreements
+    }
+  }
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;')
+}
+
+function inlineList(values) {
+  return values.length === 0
+    ? '_none_'
+    : values.map((value) => `<code>${escapeHtml(value)}</code>`).join(', ')
+}
+
+function bulletList(values) {
+  return values.length === 0
+    ? '- None'
+    : values.map((value) => `- <code>${escapeHtml(value)}</code>`).join('\n')
+}
+
+export function formatModuleImpactShadowSummary(report) {
+  return `## Module impact shadow
+
+- Enforcement: **non-blocking**
+- Authoritative mode: **${escapeHtml(report.authoritative.mode)}**
+- Shadow mode: **${escapeHtml(report.shadow.mode)}**
+- Planned coverage: **${escapeHtml(report.comparison.coverage)}**
+- CodeGraph: **${escapeHtml(report.shadow.graphStatus)}**${report.shadow.graphReason ? ` (${escapeHtml(report.shadow.graphReason)})` : ''}
+
+### Shadow selection
+
+- Modules: ${inlineList(report.shadow.modules)}
+- Tests: ${inlineList(report.shadow.testFiles)}
+- Capability overlays: ${inlineList(report.shadow.capabilityOverlays)}
+- Fallback capabilities: ${inlineList(report.shadow.fallbackCapabilities)}
+
+### Required versus authoritative lanes
+
+- Required lanes: ${inlineList(report.comparison.requiredLanes)}
+- Selected lanes: ${inlineList(report.comparison.selectedLanes)}
+- Missing lanes: ${inlineList(report.comparison.missingLanes)}
+- Additional authoritative lanes: ${inlineList(report.comparison.additionalAuthoritativeLanes)}
+
+### Disagreements
+
+${bulletList(report.comparison.disagreements)}
+
+### Authoritative reason chains
+
+${bulletList(report.authoritative.reasonChains)}
+
+### Shadow reason chains
+
+${bulletList(report.shadow.reasonChains)}
+`
+}
+
+function argumentValue(arguments_, name) {
+  const index = arguments_.indexOf(name)
+  return index === -1 ? undefined : arguments_[index + 1]
+}
+
+function requireCommit(value, name) {
+  if (!value || !/^[0-9a-f]{40}$/i.test(value)) {
+    throw new Error(`${name} must be a full 40-character Git commit SHA`)
+  }
+  return value
+}
+
+function changesFromGit(base, head, { cwd = process.cwd(), execute = execFileSync } = {}) {
+  const diff = execute('git', ['diff', '--name-status', '-z', base, head], { cwd })
+  return parseNameStatus(diff.toString('utf8'))
+}
+
+function parseAuthoritativePlan(value) {
+  if (!value) throw new Error('Authoritative plan JSON is required')
+  try {
+    return JSON.parse(value)
+  } catch {
+    throw new Error('Authoritative plan must be valid JSON')
+  }
+}
+
+export function runModuleImpactShadowCli(
+  arguments_ = process.argv.slice(2),
+  environment = process.env,
+  { cwd = process.cwd(), execute = execFileSync, append = appendFileSync, write } = {}
+) {
+  const base = requireCommit(argumentValue(arguments_, '--base') ?? environment.BASE_SHA, '--base')
+  const head = requireCommit(argumentValue(arguments_, '--head') ?? environment.HEAD_SHA, '--head')
+  const authoritativePlan = parseAuthoritativePlan(
+    argumentValue(arguments_, '--authoritative-plan') ??
+      environment.AUTHORITATIVE_PLAN ??
+      environment.PR_GATE_PLAN
+  )
+  const changes = changesFromGit(base, head, { cwd, execute })
+  const modulePlan = createAffectedTestPlan(changes, manifestOnlyGraph)
+  const report = createModuleImpactShadowReport(authoritativePlan, modulePlan)
+  const output = `${JSON.stringify(report)}\n`
+
+  if (write) write(output)
+  else process.stdout.write(output)
+  if (environment.GITHUB_STEP_SUMMARY) {
+    append(environment.GITHUB_STEP_SUMMARY, formatModuleImpactShadowSummary(report))
+  }
+  return report
+}
+
+const isDirectExecution =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isDirectExecution) {
+  try {
+    runModuleImpactShadowCli()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}

--- a/scripts/ci/module-impact-shadow.test.ts
+++ b/scripts/ci/module-impact-shadow.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { classifyChanges } from './classify-pr-changes.mjs'
+import {
+  createModuleImpactShadowReport,
+  formatModuleImpactShadowSummary,
+  requiredLanesForModulePlan,
+  runModuleImpactShadowCli
+} from './module-impact-shadow.mjs'
+import { createAffectedTestPlan } from './module-test-impact.mjs'
+
+const manifestOnlyGraph = {
+  status: 'unavailable-manifest-only',
+  reason: 'CI shadow uses the repository manifest only',
+  testFiles: []
+}
+
+function reportFor(
+  changes: Array<{ path: string; previousPath?: string; status: string }>
+): ReturnType<typeof createModuleImpactShadowReport> {
+  return createModuleImpactShadowReport(
+    classifyChanges(changes),
+    createAffectedTestPlan(changes, manifestOnlyGraph)
+  )
+}
+
+describe('module impact shadow', () => {
+  it('compares deterministic module evidence with the authoritative plan', () => {
+    const report = reportFor([
+      { path: 'src/renderer/src/stores/session-store.ts', status: 'modified' }
+    ])
+
+    expect(report.enforcement).toBe('non-blocking')
+    expect(report.authoritative.mode).toBe('selective')
+    expect(report.shadow).toMatchObject({
+      mode: 'selective',
+      graphStatus: 'unavailable-manifest-only',
+      modules: ['project_files_view', 'session_renderer', 'workspace_page', 'workspace_runtime']
+    })
+    expect(report.shadow.testFiles).toEqual([...report.shadow.testFiles].sort())
+    expect(report.shadow.capabilityOverlays).toEqual(['renderer_state'])
+    expect(report.shadow.fallbackCapabilities).toEqual(['renderer_view'])
+    expect(report.comparison.requiredLanes).toContain('typecheck_web')
+    expect(report.comparison.selectedLanes).toEqual(report.authoritative.lanes)
+    expect(report.comparison.missingLanes).toEqual([])
+    expect(report.comparison.coverage).toBe('covered')
+  })
+
+  it('records mode and lane disagreements without making them blocking', () => {
+    const modulePlan = createAffectedTestPlan(
+      [{ path: 'src/main/artifacts/repository.ts', status: 'modified' }],
+      manifestOnlyGraph
+    )
+    const authoritativePlan = {
+      mode: 'full',
+      roots: ['global'],
+      lanes: ['policy'],
+      bundles: ['policy'],
+      reasonChains: ['global -> full']
+    }
+    const report = createModuleImpactShadowReport(authoritativePlan, modulePlan)
+
+    expect(report.enforcement).toBe('non-blocking')
+    expect(report.comparison.modeAgreement).toBe(false)
+    expect(report.comparison.coverage).toBe('gap')
+    expect(report.comparison.missingLanes).toContain('unit_macos')
+    expect(report.comparison.disagreements).toEqual([
+      'mode: authoritative full != shadow selective',
+      expect.stringContaining('missing authoritative lanes:')
+    ])
+    expect(formatModuleImpactShadowSummary(report)).toContain('Planned coverage: **gap**')
+  })
+
+  it.each([
+    ['global full', { path: 'package.json', status: 'modified' }, 'full'],
+    ['unknown', { path: 'src/main/unowned-module.ts', status: 'added' }, 'selective'],
+    ['delete', { path: 'src/main/artifacts/repository.ts', status: 'deleted' }, 'full'],
+    [
+      'rename',
+      {
+        path: 'src/main/artifacts/repository-renamed.ts',
+        previousPath: 'src/main/artifacts/repository.ts',
+        status: 'renamed'
+      },
+      'full'
+    ],
+    [
+      'Windows separator',
+      { path: 'src\\main\\artifacts\\repository.ts', status: 'modified' },
+      'full'
+    ],
+    [
+      'Windows drive',
+      { path: 'C:\\repo\\src\\main\\artifacts\\repository.ts', status: 'modified' },
+      'full'
+    ]
+  ])('fails closed for a %s path change', (_case, change, authoritativeMode) => {
+    const report = reportFor([change])
+
+    expect(report.authoritative.mode).toBe(authoritativeMode)
+    expect(report.shadow.mode).toBe('full')
+    expect(report.comparison.requiredLanes).toHaveLength(18)
+    expect(report.comparison.coverage).toBe(authoritativeMode === 'full' ? 'covered' : 'gap')
+  })
+
+  it('keeps slash-based macOS and Linux fixtures portable and handles no diff', () => {
+    for (const path of [
+      'src/main/artifacts/repository.ts',
+      'src/renderer/src/stores/session-store.ts'
+    ]) {
+      expect(reportFor([{ path, status: 'modified' }]).shadow.mode).toBe('selective')
+    }
+
+    const noDiff = reportFor([])
+    expect(noDiff.shadow).toMatchObject({ mode: 'selective', modules: [], testFiles: [] })
+    expect(noDiff.comparison).toMatchObject({
+      requiredLanes: ['policy'],
+      selectedLanes: ['policy'],
+      missingLanes: [],
+      coverage: 'covered'
+    })
+  })
+
+  it('preserves authoritative owner-ambiguity evidence in a full report', () => {
+    const fullLanes = requiredLanesForModulePlan({ mode: 'full' })
+    const modulePlan = createAffectedTestPlan(
+      [{ path: 'src/main/unowned-module.ts', status: 'added' }],
+      manifestOnlyGraph
+    )
+    const report = createModuleImpactShadowReport(
+      {
+        mode: 'full',
+        roots: ['owner_ambiguity'],
+        lanes: fullLanes,
+        bundles: [],
+        reasonChains: ['ambiguous.ts -> owner ambiguity: a, b -> full']
+      },
+      modulePlan
+    )
+
+    expect(report.authoritative.roots).toEqual(['owner_ambiguity'])
+    expect(report.authoritative.reasonChains).toEqual([
+      'ambiguous.ts -> owner ambiguity: a, b -> full'
+    ])
+    expect(report.comparison).toMatchObject({ modeAgreement: true, missingLanes: [] })
+  })
+
+  it('expands fallback and overlay capability consumers into required lanes', () => {
+    const lanes = requiredLanesForModulePlan({
+      mode: 'selective',
+      fallbackCapabilities: ['main_runtime'],
+      capabilityOverlays: ['windows_sensitive']
+    })
+
+    expect(lanes).toEqual(
+      expect.arrayContaining([
+        'policy',
+        'typecheck_node',
+        'typecheck_web',
+        'unit_macos',
+        'windows_runtime',
+        'e2e_workspace_windows'
+      ])
+    )
+    expect(lanes.indexOf('policy')).toBeLessThan(lanes.indexOf('unit_macos'))
+  })
+
+  it('supports base/head and authoritative JSON while forcing manifest-only graph evidence', () => {
+    const base = '1'.repeat(40)
+    const head = '2'.repeat(40)
+    const authoritativePlan = classifyChanges([
+      { path: 'src/main/artifacts/repository.ts', status: 'modified' }
+    ])
+    const execute = vi.fn().mockReturnValue(Buffer.from('M\0src/main/artifacts/repository.ts\0'))
+    const write = vi.fn()
+    const append = vi.fn()
+
+    const report = runModuleImpactShadowCli(
+      ['--base', base, '--head', head, '--authoritative-plan', JSON.stringify(authoritativePlan)],
+      { GITHUB_STEP_SUMMARY: '/summary' },
+      { cwd: '/repo', execute, write, append }
+    )
+
+    expect(execute).toHaveBeenCalledWith(
+      'git',
+      ['diff', '--name-status', '-z', base, head],
+      expect.objectContaining({ cwd: '/repo' })
+    )
+    expect(execute).not.toHaveBeenCalledWith('codegraph', expect.anything(), expect.anything())
+    expect(report.shadow.graphStatus).toBe('unavailable-manifest-only')
+    expect(write).toHaveBeenCalledWith(`${JSON.stringify(report)}\n`)
+    expect(append).toHaveBeenCalledWith(
+      '/summary',
+      expect.stringContaining('## Module impact shadow')
+    )
+  })
+
+  it('sorts and escapes report evidence before publishing a summary', () => {
+    const report = createModuleImpactShadowReport(
+      {
+        mode: 'selective',
+        roots: ['z', '<unsafe>'],
+        lanes: ['unit_macos', 'policy'],
+        bundles: ['unit', 'policy'],
+        reasonChains: ['z', '<unsafe>']
+      },
+      {
+        mode: 'selective',
+        modules: [],
+        testFiles: [],
+        capabilityOverlays: [],
+        fallbackCapabilities: [],
+        graphStatus: 'unavailable-manifest-only',
+        graphReason: '<unavailable>',
+        reasonChains: ['z', '<unsafe>']
+      }
+    )
+    const summary = formatModuleImpactShadowSummary(report)
+
+    expect(report.authoritative.roots).toEqual(['<unsafe>', 'z'])
+    expect(report.authoritative.lanes).toEqual(['policy', 'unit_macos'])
+    expect(summary).toContain('&lt;unsafe&gt;')
+    expect(summary).not.toContain('<unsafe>')
+  })
+})

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -139,6 +139,39 @@ describe('PR Gate workflow', () => {
     )
   })
 
+  it('publishes base-trusted module evidence without changing authoritative outputs', () => {
+    const prepare = workflow.jobs.preflight.steps?.find(
+      ({ name }) => name === 'Prepare trusted module shadow'
+    )
+    const publish = workflow.jobs.preflight.steps?.find(
+      ({ name }) => name === 'Publish module impact shadow'
+    )
+
+    expect(workflow.jobs.preflight.outputs).toEqual({
+      base: '${{ steps.revisions.outputs.base }}',
+      head: '${{ steps.revisions.outputs.head }}',
+      lanes: '${{ steps.classify.outputs.lanes }}',
+      plan: '${{ steps.classify.outputs.plan }}'
+    })
+    expect(prepare).toMatchObject({ 'continue-on-error': true })
+    expect(prepare?.run).toContain('scripts/ci/module-impact-shadow.mjs')
+    expect(prepare?.run).toContain('git show "${BASE_SHA}:${file}"')
+    expect(prepare?.run).toContain('source=bootstrap')
+    expect(publish).toMatchObject({
+      'continue-on-error': true,
+      env: {
+        AUTHORITATIVE_PLAN: '${{ steps.classify.outputs.plan }}',
+        BASE_SHA: '${{ steps.revisions.outputs.base }}',
+        HEAD_SHA: '${{ steps.revisions.outputs.head }}',
+        TRUSTED_MODULE_SHADOW_DIR: '${{ steps.trusted_module_shadow.outputs.dir }}',
+        TRUSTED_MODULE_SHADOW_SOURCE: '${{ steps.trusted_module_shadow.outputs.source }}'
+      }
+    })
+    expect(publish?.run).toContain('node "$TRUSTED_MODULE_SHADOW_DIR/module-impact-shadow.mjs"')
+    expect(publish?.run).toContain('Status: **bootstrap pending**')
+    expect(publish?.run).not.toContain('GITHUB_OUTPUT')
+  })
+
   it('aggregates all deterministic bundles into the stable PR Gate job', () => {
     const gate = workflow.jobs.gate
 


### PR DESCRIPTION
## Problem

The repository can explain its authoritative PR Gate lanes and can select module-owned Vitest files
locally, but CI does not yet publish both plans side by side. That leaves module-manifest gaps and
coverage disagreements invisible during the remaining deep-module refactors.

## Proposed change

- Add a non-blocking module-impact shadow reporter that compares the authoritative change plan with
  the repository-owned module plan.
- Publish module IDs, exact test files, capability overlays, fallback capabilities, reason chains,
  required lanes, selected lanes and any coverage gap in stable order.
- Use manifest-only module evidence in CI; CodeGraph remains an optional local navigation input and
  is never a CI authority.
- Invoke the base-trusted reporter after classification in the existing PR Gate Preflight summary
  without changing any authoritative output, bundle or gate decision.

## Scope and non-goals

- Shadow evidence only; no selected check becomes blocking or non-blocking because of this report.
- `npm test` remains the complete portable Vitest suite.
- No production source, public API, IPC/application command, data model, persisted shape or UI change.
- No Electron/Web/CLI/Task/local-RPC/MCP capability change and no Specialist/Permission/Compute
  parity change.
- No CodeGraph service or machine-local index is required in CI.

## Compatibility

- Stable slash-based repository paths are used in the manifest and report.
- Windows separator and drive-path fixtures fail closed; macOS/Linux slash fixtures remain
  deterministic.
- Existing authoritative PR Gate classification, runner bundles, final evaluator and required check
  identity remain unchanged.
- The PR Gate workflow is a protected control-plane file. One maintainer ruleset bypass is explicitly
  approved for the expected `protected-gate-control-plane` result; no other CI/AI exception is
  authorized.

## Acceptance criteria and validation

- Module shadow comparison covers full/selective modes, unknown, rename, delete, owner ambiguity,
  no diff, manifest-only graph and portable path cases.
- The report records mode disagreement and missing authoritative lanes but always identifies itself
  as non-blocking.
- Local evidence: 141 focused tests, Prettier, ESLint and Node typecheck pass.
- Independent final review: Standards 0 findings; Spec 0 findings.
- Final PR: run focused PR Gate/CI Integrity/classifier/manifest/shadow suites, then require all
  non-excepted exact-head CI/AI checks green before squash merge.

## Review focus

- Confirm capability-consumer expansion cannot understate required authoritative lanes.
- Confirm output ordering and HTML escaping keep summaries deterministic and safe.
- Confirm the Preflight hook is fail-open for telemetry and cannot alter authoritative outputs,
  selected bundles or the final PR Gate conclusion.
- Confirm the expected protected-control-plane exception is limited to the reviewed workflow hook.
