### PR TITLE
fix(connectors): isolate unavailable custom MCP discovery

### DIFF
--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -89,6 +89,30 @@ describe('syncCustomServerSkillDocs', () => {
     expect(entries).toEqual([])
   })
 
+  it('isolates an unavailable server while materializing the remaining enabled servers', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'custom-skills-unavailable-'))
+    const unavailable = makeServer({ id: 'unavailable', slug: 'unavailable' })
+    const healthy = makeServer({ id: 'healthy', slug: 'healthy', name: 'Healthy server' })
+    await mkdir(join(dir, 'mcp-unavailable'), { recursive: true })
+    await writeFile(join(dir, 'mcp-unavailable', 'SKILL.md'), 'stale')
+
+    const result = await syncCustomServerSkillDocs(dir, [unavailable, healthy], async (server) => {
+      if (server.id === unavailable.id) {
+        throw new Error('MCP error -32000: Connection closed')
+      }
+      return FAKE_TOOLS
+    })
+
+    expect(result.materializedSlugs).toEqual(['healthy'])
+    expect(result.failures).toEqual([
+      {
+        server: unavailable,
+        error: expect.objectContaining({ message: 'MCP error -32000: Connection closed' })
+      }
+    ])
+    expect((await readdir(dir)).sort()).toEqual(['mcp-healthy'])
+  })
+
   it('never lets a malicious server name escape the skills dir or clobber a bundled connector', async () => {
     const root = await mkdtemp(join(tmpdir(), 'custom-skills-safe-'))
     const dir = join(root, 'skills')

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -62,6 +62,11 @@ export async function syncConnectorSkillDocs(
 
 export type CustomServerListTools = (server: StoredCustomMcpServer) => Promise<CustomSkillDocTool[]>
 
+export type CustomServerSkillSyncResult = {
+  materializedSlugs: string[]
+  failures: Array<{ server: StoredCustomMcpServer; error: unknown }>
+}
+
 const isSafeCustomServerSlug = (slug: string): boolean =>
   /^[a-z0-9-]+$/.test(slug) && !ALL_CONNECTOR_IDS.includes(slug)
 
@@ -73,18 +78,30 @@ export async function syncCustomServerSkillDocs(
   skillsDir: string,
   servers: StoredCustomMcpServer[],
   listTools: CustomServerListTools
-): Promise<void> {
+): Promise<CustomServerSkillSyncResult> {
   await mkdir(skillsDir, { recursive: true })
   const safeServers = servers
     .map((server) => ({ server, slug: customConnectorSlug(server) }))
     .filter(({ slug }) => isSafeCustomServerSlug(slug))
-  const enabledSlugs = new Set(safeServers.map(({ slug }) => slug))
+  const materializedSlugs: string[] = []
+  const failures: CustomServerSkillSyncResult['failures'] = []
   for (const { server, slug } of safeServers) {
-    const tools = await listTools(server)
     const dir = join(skillsDir, `mcp-${slug}`)
+    let tools: CustomSkillDocTool[]
+    try {
+      tools = await listTools(server)
+    } catch (error) {
+      failures.push({ server, error })
+      // A previously healthy Connector may have left a now-stale Skill behind. Keeping it would
+      // advertise tools that this startup could not actually discover or call.
+      await rm(dir, { recursive: true, force: true })
+      continue
+    }
     await mkdir(dir, { recursive: true })
     await writeFile(join(dir, 'SKILL.md'), renderCustomSkillDoc(server, tools), 'utf8')
+    materializedSlugs.push(slug)
   }
+  const enabledSlugs = new Set(materializedSlugs)
   const existing = await readdir(skillsDir).catch(() => [] as string[])
   for (const entry of existing) {
     const m = /^mcp-(.+)$/.exec(entry)
@@ -95,4 +112,5 @@ export async function syncCustomServerSkillDocs(
       await rm(join(skillsDir, entry), { recursive: true, force: true })
     }
   }
+  return { materializedSlugs, failures }
 }

--- a/src/main/connectors/runtime-settings-projection.test.ts
+++ b/src/main/connectors/runtime-settings-projection.test.ts
@@ -34,6 +34,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
     const syncBundledSkillDocs = vi.fn().mockResolvedValue(undefined)
     const syncCustomSkillDocs = vi.fn(async (_dir, servers, loadTools) => {
       await loadTools(servers[0])
+      return { materializedSlugs: ['enabled'], failures: [] }
     })
     const projection = new ConnectorRuntimeSettingsProjection({
       readConnectors: vi.fn().mockResolvedValue(stored),
@@ -61,6 +62,51 @@ describe('ConnectorRuntimeSettingsProjection', () => {
     expect(projection.materializedCustomSkillNames()).toEqual(['mcp-enabled'])
   })
 
+  it('advertises only custom Skills that materialized when one enabled server is unavailable', async () => {
+    const unavailable = {
+      id: 'unavailable-id',
+      slug: 'unavailable',
+      name: 'Unavailable',
+      transport: 'stdio' as const,
+      command: 'node',
+      enabled: true
+    }
+    const healthy = {
+      id: 'healthy-id',
+      slug: 'healthy',
+      name: 'Healthy',
+      transport: 'stdio' as const,
+      command: 'node',
+      enabled: true
+    }
+    const failure = new Error('MCP error -32000: Connection closed')
+    const reportError = vi.fn()
+    const projection = new ConnectorRuntimeSettingsProjection({
+      readConnectors: vi.fn().mockResolvedValue(
+        connectors({
+          customMcpServers: [unavailable, healthy]
+        })
+      ),
+      skillsDir: '/config/skills',
+      mcpClientManager: { listTools: vi.fn().mockResolvedValue([]) },
+      syncBundledSkillDocs: vi.fn().mockResolvedValue(undefined),
+      syncCustomSkillDocs: vi.fn().mockResolvedValue({
+        materializedSlugs: ['healthy'],
+        failures: [{ server: unavailable, error: failure }]
+      }),
+      reportError
+    })
+
+    await projection.refresh()
+
+    expect(projection.materializedCustomSkillNames()).toEqual(['mcp-healthy'])
+    expect(reportError).toHaveBeenCalledOnce()
+    expect(reportError.mock.calls[0]?.[0]).toMatchObject({
+      message: 'Failed to sync custom MCP server "unavailable" skill docs',
+      cause: failure
+    })
+  })
+
   it('contains refresh errors while retaining the last snapshot reached by the refresh', async () => {
     const first = connectors({ disabledConnectorIds: ['chemistry'] })
     const second = connectors({ disabledConnectorIds: ['literature'] })
@@ -79,7 +125,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
       skillsDir: '/config/skills',
       mcpClientManager: { listTools: vi.fn().mockResolvedValue([]) },
       syncBundledSkillDocs,
-      syncCustomSkillDocs: vi.fn().mockResolvedValue(undefined),
+      syncCustomSkillDocs: vi.fn().mockResolvedValue({ materializedSlugs: [], failures: [] }),
       reportError
     })
 
@@ -122,7 +168,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
       skillsDir: '/config/skills',
       mcpClientManager: { listTools: vi.fn().mockResolvedValue([]) },
       syncBundledSkillDocs,
-      syncCustomSkillDocs: vi.fn().mockResolvedValue(undefined)
+      syncCustomSkillDocs: vi.fn().mockResolvedValue({ materializedSlugs: [], failures: [] })
     })
 
     const olderRefresh = projection.refresh()
@@ -157,7 +203,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
         .fn()
         .mockRejectedValueOnce(new Error('older sync failed'))
         .mockResolvedValueOnce(undefined),
-      syncCustomSkillDocs: vi.fn().mockResolvedValue(undefined),
+      syncCustomSkillDocs: vi.fn().mockResolvedValue({ materializedSlugs: [], failures: [] }),
       reportError
     })
 

--- a/src/main/connectors/runtime-settings-projection.ts
+++ b/src/main/connectors/runtime-settings-projection.ts
@@ -68,9 +68,12 @@ class ConnectorRuntimeSettingsProjection {
       this.materializedCustomSkills = customSync.materializedSlugs.map((slug) => `mcp-${slug}`)
       for (const { server, error } of customSync.failures) {
         this.reportError(
-          new Error(`Failed to sync custom MCP server "${customConnectorSlug(server)}" skill docs`, {
-            cause: error
-          })
+          new Error(
+            `Failed to sync custom MCP server "${customConnectorSlug(server)}" skill docs`,
+            {
+              cause: error
+            }
+          )
         )
       }
     } catch (error) {

--- a/src/main/connectors/runtime-settings-projection.ts
+++ b/src/main/connectors/runtime-settings-projection.ts
@@ -60,12 +60,19 @@ class ConnectorRuntimeSettingsProjection {
 
       await this.syncBundledSkillDocs(this.options.skillsDir, enabledIds)
       const customServers = selectEnabledCustomServers(connectors)
-      await this.syncCustomSkillDocs(this.options.skillsDir, customServers, (server) =>
-        this.options.mcpClientManager.listTools(toCustomMcpConfig(server))
+      const customSync = await this.syncCustomSkillDocs(
+        this.options.skillsDir,
+        customServers,
+        (server) => this.options.mcpClientManager.listTools(toCustomMcpConfig(server))
       )
-      this.materializedCustomSkills = customServers.map(
-        (server) => `mcp-${customConnectorSlug(server)}`
-      )
+      this.materializedCustomSkills = customSync.materializedSlugs.map((slug) => `mcp-${slug}`)
+      for (const { server, error } of customSync.failures) {
+        this.reportError(
+          new Error(`Failed to sync custom MCP server "${customConnectorSlug(server)}" skill docs`, {
+            cause: error
+          })
+        )
+      }
     } catch (error) {
       this.reportError(error)
     }


### PR DESCRIPTION
## Problem

An enabled custom MCP server can retain a stdio command whose target no longer exists. Startup tool discovery then fails with `MCP error -32000: Connection closed`, aborting the remaining custom Connector Skill synchronization and leaving stale Skill documentation available for the failed server.

## Proposed change

- Isolate `listTools` failures to the unavailable custom MCP server.
- Remove stale generated Skill documentation for servers that fail discovery.
- Continue materializing healthy custom Connector Skills and advertise only the successfully materialized names.
- Preserve the discovery failure as a scoped diagnostic without mutating or disabling the saved Connector configuration.

## Scope and non-goals

- No settings schema or persisted Connector configuration changes.
- No automatic disabling or removal of an unavailable Connector.
- No changes to MCP dispatch, OAuth, bundled Connectors, renderer UI, or Agent framework session behavior.

## Acceptance criteria and validation

All checks ran after the last material edit.

- Unavailable custom MCP isolation and stale Skill cleanup -> `npm test -- src/main/connectors/custom-skill-doc.test.ts src/main/connectors/runtime-settings-projection.test.ts` -> passed (15 tests).
- Main-process type contract -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.
- Complete portable test suite -> `npm test` -> passed.
- Formatting and patch integrity -> targeted Prettier check plus `git diff --check` -> passed.

Consumer and platform lanes are excluded because the change stays within the main-process Connector Skill materialization owner, does not change a public wire contract, and introduces no platform-specific path handling. The remaining operational risk is expected: an invalid enabled command still cannot connect and remains diagnostic until the user edits, disables, or removes that Connector.

## Review focus

- Whether per-server discovery isolation preserves the intended fail-closed behavior for advertised tools.
- Whether removing stale Skill docs on discovery failure is the correct availability boundary.
