### PR TITLE
test(uploads): characterize repository contracts

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -90,8 +90,11 @@
       "interfacePaths": ["src/main/uploads/repository.ts"],
       "consumerModules": ["session_persistence"],
       "testFiles": {
-        "owner": ["src/main/uploads/repository.test.ts"],
-        "contract": ["src/main/uploads/ipc.test.ts"],
+        "owner": [
+          "src/main/uploads/repository.test.ts",
+          "src/main/uploads/repository.characterization.test.ts"
+        ],
+        "contract": ["src/main/uploads/ipc.test.ts", "src/main/uploads/command-owner.test.ts"],
         "consumer": ["src/main/session-persistence/deletion-integration.test.ts"]
       },
       "capabilityOverlays": ["windows_sensitive"],

--- a/src/main/uploads/repository.characterization.test.ts
+++ b/src/main/uploads/repository.characterization.test.ts
@@ -1,0 +1,133 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PENDING_UPLOAD_SESSION_ID } from '../../shared/uploads'
+import { UploadRepository } from './repository'
+import { stageUploadFixtures } from './repository.test-utils'
+
+let storageRoot: string | undefined
+
+const createStorageRoot = async (): Promise<string> => {
+  storageRoot = await mkdtemp(join(tmpdir(), 'open-science-upload-characterization-'))
+  return storageRoot
+}
+
+afterEach(async () => {
+  if (storageRoot) {
+    await rm(storageRoot, { recursive: true, force: true })
+    storageRoot = undefined
+  }
+})
+
+describe('upload repository public characterization', () => {
+  it('resumes an incomplete remote transfer while making matching begin requests idempotent', async () => {
+    const root = await createStorageRoot()
+    const repository = new UploadRepository(root)
+    const content = Buffer.from('sample,value\na,1\n')
+    const request = {
+      transferId: 'remote-retry',
+      name: 'dataset.csv',
+      mimeType: 'text/csv',
+      size: content.byteLength
+    }
+
+    const initial = await repository.beginTransfer(request)
+
+    await expect(repository.beginTransfer(request)).resolves.toEqual(initial)
+    await expect(repository.beginTransfer({ ...request, size: request.size + 1 })).rejects.toThrow(
+      /metadata does not match/i
+    )
+
+    const splitAt = 8
+    await repository.appendTransfer({
+      transferId: request.transferId,
+      offset: 0,
+      chunk: content.subarray(0, splitAt)
+    })
+
+    await expect(repository.finishTransfer({ transferId: request.transferId })).rejects.toThrow(
+      /incomplete/i
+    )
+    await expect(repository.getTransferStatus({ transferId: request.transferId })).resolves.toEqual(
+      {
+        transferId: request.transferId,
+        name: request.name,
+        receivedBytes: splitAt,
+        totalBytes: content.byteLength
+      }
+    )
+
+    await repository.appendTransfer({
+      transferId: request.transferId,
+      offset: splitAt,
+      chunk: content.subarray(splitAt)
+    })
+    const attachment = await repository.finishTransfer({ transferId: request.transferId })
+
+    expect(attachment).toMatchObject({
+      sessionId: PENDING_UPLOAD_SESSION_ID,
+      name: request.name,
+      originalName: request.name,
+      mimeType: request.mimeType,
+      size: content.byteLength
+    })
+    await repository.abortTransfer({ transferId: request.transferId })
+    await repository.abortTransfer({ transferId: request.transferId })
+    await expect(readFile(attachment.path)).resolves.toEqual(content)
+    await expect(
+      repository.getTransferStatus({ transferId: request.transferId })
+    ).resolves.toBeNull()
+  })
+
+  it('cleans a failed local staging attempt and permits the same transfer id to retry', async () => {
+    const root = await createStorageRoot()
+    const repository = new UploadRepository(root)
+    const sourcePath = join(root, 'dataset.csv')
+    const content = Buffer.from('sample,value\na,1\n')
+    const request = {
+      transferId: 'local-retry',
+      sourcePath,
+      name: 'dataset.csv',
+      mimeType: 'text/csv',
+      size: content.byteLength
+    }
+    await writeFile(sourcePath, content)
+
+    await expect(repository.stageLocalFile({ ...request, size: request.size + 1 })).rejects.toThrow(
+      /changed before it could be staged/i
+    )
+    await expect(
+      stat(join(root, 'uploads', 'default-project', '.staging', `${request.transferId}.part`))
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+
+    const attachment = await repository.stageLocalFile(request)
+
+    expect(attachment).toMatchObject({
+      sessionId: PENDING_UPLOAD_SESSION_ID,
+      name: request.name,
+      size: content.byteLength
+    })
+    await expect(readFile(attachment.path)).resolves.toEqual(content)
+  })
+
+  it('makes pending deletion retries harmless without widening cleanup authority', async () => {
+    const root = await createStorageRoot()
+    const repository = new UploadRepository(root)
+    const outsidePath = join(root, 'outside.txt')
+    await writeFile(outsidePath, 'caller-owned')
+    const [attachment] = await stageUploadFixtures(repository, {
+      files: [{ name: 'remove-me.txt', content: Buffer.from('temporary').toString('base64') }]
+    })
+
+    await repository.deleteUpload({ path: attachment.path })
+    await repository.deleteUpload({ path: attachment.path })
+
+    await expect(stat(attachment.path)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(repository.deleteUpload({ path: outsidePath })).rejects.toThrow(
+      /outside upload storage/i
+    )
+    await expect(readFile(outsidePath, 'utf8')).resolves.toBe('caller-owned')
+  })
+})


### PR DESCRIPTION
## Problem

The 1,852-line Upload Repository owns byte/chunk transfers, local-file staging, pending-to-durable
publication, managed preview/path resolution, deletion and legacy recovery in one facade. Before moving
state ownership, the ordering, retry, cleanup and persisted-reference contracts need explicit
black-box characterization.

## Proposed change

- Add characterization tests at the existing Upload Repository interface for remote chunk transfer,
  local streaming, staging/finalization, preview/path admission, deletion and legacy upgrade/recovery.
- Lock active-transfer idempotency/races, checksum and size validation, atomic publish/rollback,
  pending/session identity projection and cleanup authority.
- Register or refine the existing `upload_repository` Test Impact Set only when current ownership
  evidence requires it.
- Add 133 test lines and no production lines; include the existing command-owner contract in the
  module Test Impact Set.

## Scope and non-goals

- Test and impact-evidence changes only; production behavior and facade size remain unchanged.
- No upload identity, persisted attachment shape, storage layout, checksum, safe-path, Session
  reference, rename/delete or crash-recovery change.
- No IPC/preload/public command, UI, MCP or cross-surface capability change.
- No owner extraction; UP1–UP3 remain separate implementation PRs.

## Compatibility

- Preserve Electron/Web/CLI/Task/local-RPC/MCP behavior and Specialist/Permission/Compute asymmetry.
- Use `tmpdir()`/`mkdtemp()`, `node:path` and platform-aware assertions; never hard-code POSIX paths or
  separators in executable tests.
- Preserve current renderer transfer progress, cancellation and retry-observable behavior.

## Acceptance criteria and validation

- Characterization covers transfer begin/append/status/finish/abort, local staging, pending
  publication, managed resolver/preview, deletion and legacy recovery including representative failure
  and retry paths.
- Production raw change is 0 and all test files are portable across Windows, macOS and Linux.
- Upload repository owner/IPC/command and persistence consumers, Node typecheck, lint/format and
  independent Standards/Spec pass on the final diff.
- Exact-head PR Gate, CI Integrity, CodeQL and AI pass before squash merge.

Final local Test Impact Set after the last material edit:

- Transfer, cleanup, retry and deletion contracts ->
  `npm run test:module -- upload_repository` -> 5 files, 80 tests passed.
- Main and renderer type compatibility -> `npm run typecheck:node` and `npm run typecheck:web` ->
  passed.
- Changed-file lint/format/whitespace -> ESLint, Prettier and `git diff --check` -> passed.
- Independent review -> Standards 0 findings; Spec 0 missing, 0 incorrect and 0 scope creep.

Production raw change is 0. The module-impact manifest is a global validation input, so exact-head PR
Gate is the authoritative full fallback under the approved local-focused/online-full policy. The
existing `windows_sensitive` overlay keeps Windows/macOS/Linux destructive-cleanup verification in
online CI; no cleanup outside repository-owned temporary roots is authorized.

## Review focus

- Confirm tests assert observable interface/data/filesystem outcomes rather than private structure.
- Confirm destructive cleanup assertions are confined to repository-owned temporary roots.
- Confirm the suite is strong enough to protect UP1–UP3 without freezing incidental implementation.
