### PR TITLE
test(project-files): characterize repository contracts

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -104,7 +104,11 @@
       "testFiles": {
         "owner": ["src/main/project-files/repository.test.ts"],
         "contract": ["src/main/project-files/ipc.test.ts"],
-        "consumer": ["src/main/session-persistence/deletion-integration.test.ts"]
+        "consumer": [
+          "src/main/session-persistence/coordinator.test.ts",
+          "src/main/session-persistence/deletion-integration.test.ts",
+          "src/main/session-persistence/artifact-finalization-recovery.integration.test.ts"
+        ]
       },
       "capabilityOverlays": ["windows_sensitive"],
       "fallbackCapability": "main_runtime"

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1068,7 +1068,12 @@ describe('ManagedFileIndexRepository', () => {
       'message-1',
       'result.txt'
     )
-    await writeManagedFile(artifactPath, 'result')
+    const uploadSessionId = 'session-upload'
+    const uploadPath = join(storageRoot, 'uploads', 'default-project', uploadSessionId, 'input.csv')
+    await Promise.all([
+      writeManagedFile(artifactPath, 'result'),
+      writeManagedFile(uploadPath, 'sample,value')
+    ])
     await repository.syncSession(
       createSession({
         artifacts: [
@@ -1076,12 +1081,47 @@ describe('ManagedFileIndexRepository', () => {
         ]
       })
     )
+    await repository.syncSession(
+      createSession({
+        id: uploadSessionId,
+        messages: [
+          {
+            id: 'message-upload',
+            role: 'user',
+            content: 'Analyze this upload',
+            status: 'complete',
+            eventIds: [],
+            uploads: [
+              {
+                id: 'upload-1',
+                sessionId: uploadSessionId,
+                name: 'input.csv',
+                originalName: 'input.csv',
+                path: uploadPath,
+                size: 12
+              }
+            ],
+            createdAt: 1_710_000_000_100,
+            updatedAt: 1_710_000_000_200
+          }
+        ]
+      })
+    )
+    await expect(repository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      totalCount: 2,
+      uploadCount: 1,
+      artifactCount: 1
+    })
 
     const token = await repository.softDeleteProject(PROJECT_ID)
     expect((await repository.getOverview(PROJECT_ID)).totalCount).toBe(0)
 
     await repository.restoreProject(PROJECT_ID, token)
-    expect((await repository.getOverview(PROJECT_ID)).totalCount).toBe(1)
+    await expect(repository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      totalCount: 2,
+      uploadCount: 1,
+      artifactCount: 1
+    })
   })
 
   it('preserves incomplete state when session and project deletion are compensated', async () => {
@@ -1179,6 +1219,145 @@ describe('ManagedFileIndexRepository', () => {
       limit: 24
     })
     expect(files.items.map((file) => file.name)).toEqual(['current.txt'])
+  })
+
+  it('keeps an indexed revision as an idempotent no-op until the revision advances', async () => {
+    const originalPath = join(
+      storageRoot,
+      'artifacts',
+      'default-project',
+      SESSION_ID,
+      'message-1',
+      'original.txt'
+    )
+    const replacementPath = join(
+      storageRoot,
+      'artifacts',
+      'default-project',
+      SESSION_ID,
+      'message-2',
+      'replacement.txt'
+    )
+    await Promise.all([
+      writeManagedFile(originalPath, 'original'),
+      writeManagedFile(replacementPath, 'replacement')
+    ])
+    const original = createSession({
+      filesRevision: 4,
+      artifacts: [
+        { id: 'original', kind: 'managed-file', path: originalPath, name: 'original.txt' }
+      ]
+    })
+    const replacement = createSession({
+      filesRevision: 4,
+      artifacts: [
+        {
+          id: 'replacement',
+          kind: 'managed-file',
+          path: replacementPath,
+          name: 'replacement.txt'
+        }
+      ]
+    })
+
+    await expect(repository.syncSession(original)).resolves.toEqual(['artifact'])
+    await expect(repository.syncSession(replacement)).resolves.toEqual([])
+    await expect(
+      repository.listFiles({
+        projectId: PROJECT_ID,
+        collection: { kind: 'sessionArtifacts', sessionId: SESSION_ID },
+        limit: 24
+      })
+    ).resolves.toMatchObject({
+      items: [expect.objectContaining({ sourceFileId: 'original', name: 'original.txt' })],
+      totalCount: 1
+    })
+
+    await expect(repository.syncSession({ ...replacement, filesRevision: 5 })).resolves.toEqual([
+      'artifact'
+    ])
+    await expect(
+      repository.listFiles({
+        projectId: PROJECT_ID,
+        collection: { kind: 'sessionArtifacts', sessionId: SESSION_ID },
+        limit: 24
+      })
+    ).resolves.toMatchObject({
+      items: [expect.objectContaining({ sourceFileId: 'replacement', name: 'replacement.txt' })],
+      totalCount: 1
+    })
+  })
+
+  it('restores session and project deletions only for their matching operation token', async () => {
+    const artifactPath = join(
+      storageRoot,
+      'artifacts',
+      'default-project',
+      SESSION_ID,
+      'message-1',
+      'result.txt'
+    )
+    await writeManagedFile(artifactPath, 'result')
+    await repository.syncSession(
+      createSession({
+        artifacts: [
+          { id: 'artifact-1', kind: 'managed-file', path: artifactPath, name: 'result.txt' }
+        ]
+      })
+    )
+
+    const sessionToken = await repository.softDeleteSession(PROJECT_ID, SESSION_ID)
+    await repository.restoreSession(PROJECT_ID, SESSION_ID, 'different-session-operation')
+    expect((await repository.getOverview(PROJECT_ID)).totalCount).toBe(0)
+    await repository.restoreSession(PROJECT_ID, SESSION_ID, sessionToken)
+    await repository.restoreSession(PROJECT_ID, SESSION_ID, sessionToken)
+    expect((await repository.getOverview(PROJECT_ID)).totalCount).toBe(1)
+
+    const projectToken = await repository.softDeleteProject(PROJECT_ID)
+    await repository.restoreProject(PROJECT_ID, 'different-project-operation')
+    expect((await repository.getOverview(PROJECT_ID)).totalCount).toBe(0)
+    await repository.restoreProject(PROJECT_ID, projectToken)
+    await repository.restoreProject(PROJECT_ID, projectToken)
+    expect((await repository.getOverview(PROJECT_ID)).totalCount).toBe(1)
+  })
+
+  it('reconciles repeated complete scans without changing the visible projection', async () => {
+    const artifactPath = join(
+      storageRoot,
+      'artifacts',
+      'default-project',
+      SESSION_ID,
+      'message-1',
+      'result.txt'
+    )
+    await writeManagedFile(artifactPath, 'result')
+    const session = createSession({
+      artifacts: [
+        { id: 'artifact-1', kind: 'managed-file', path: artifactPath, name: 'result.txt' }
+      ]
+    })
+    await repository.syncSession(session)
+
+    await repository.reconcileActiveSessions([session])
+    await repository.reconcileActiveSessions([session])
+    await expect(repository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      totalCount: 1,
+      isIndexComplete: true
+    })
+
+    await repository.reconcileActiveSessions([])
+    await repository.reconcileActiveSessions([])
+    await expect(repository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      totalCount: 0,
+      isIndexComplete: true
+    })
+
+    await repository.reconcileActiveSessions([session])
+    await repository.reconcileActiveSessions([session])
+    await expect(repository.getOverview(PROJECT_ID)).resolves.toMatchObject({
+      totalCount: 1,
+      isIndexComplete: true
+    })
   })
 
   it('updates file ordering metadata when an indexed file changes revision', async () => {
@@ -1386,6 +1565,22 @@ describe('ManagedFileIndexRepository', () => {
         limit: 2
       })
     ).rejects.toThrow(/cursor.*collection/i)
+    await expect(
+      repository.listFiles({
+        projectId: PROJECT_ID,
+        collection: { kind: 'sessionArtifacts', sessionId: 'session-b' },
+        cursor: first.nextCursor,
+        limit: 2
+      })
+    ).rejects.toThrow(/cursor.*collection/i)
+    await expect(
+      repository.listFiles({
+        projectId: 'project-b',
+        collection: { kind: 'sessionArtifacts', sessionId: SESSION_ID },
+        cursor: first.nextCursor,
+        limit: 2
+      })
+    ).rejects.toThrow(/cursor.*collection/i)
   })
 
   it('paginates the flat picker collection and binds its cursor to that collection', async () => {
@@ -1468,6 +1663,13 @@ describe('ManagedFileIndexRepository', () => {
     expect(new Set([...first.items, ...second.items].map((group) => group.sessionId))).toEqual(
       new Set(['session-a', 'session-b'])
     )
+    await expect(
+      repository.listArtifactGroups({
+        projectId: 'project-b',
+        cursor: first.nextCursor,
+        limit: 1
+      })
+    ).rejects.toThrow(/cursor.*collection/i)
   })
 
   it('loads all search overview counts with one database query', async () => {
@@ -1832,6 +2034,17 @@ describe('ManagedFileIndexRepository', () => {
       otherFiles.slice(0, 5).map((file) => file.name)
     )
     expect(first.isIndexComplete).toBe(true)
+
+    await expect(
+      repository.searchArtifacts({
+        primaryProjectId: 'project-b',
+        otherProjectIds: [],
+        filenameContains: 'SIN',
+        primaryLimit: 2,
+        primaryCursor: first.primary.nextCursor,
+        otherLimit: 0
+      })
+    ).rejects.toThrow(/cursor.*global artifact search/i)
 
     await expect(
       repository.searchArtifacts({

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -2865,6 +2865,7 @@ describe('SessionPersistenceCoordinator', () => {
 
     expect(fileIndex.syncSession).toHaveBeenCalledTimes(1)
     expect(fileIndex.syncSession).toHaveBeenCalledWith(survivor)
+    expect(onFilesChanged).toHaveBeenCalledTimes(2)
     expect(onFilesChanged).toHaveBeenNthCalledWith(1, {
       projectId: 'project-1',
       sessionId: 'session-2',
@@ -3585,6 +3586,7 @@ describe('SessionPersistenceCoordinator', () => {
 
     await coordinator.saveSession(createSession())
 
+    expect(onFilesChanged).toHaveBeenCalledOnce()
     expect(onFilesChanged).toHaveBeenCalledWith({
       projectId: 'project-1',
       sessionId: 'session-1',
@@ -3609,6 +3611,7 @@ describe('SessionPersistenceCoordinator', () => {
     )
 
     expect(repository.saveSession).toHaveBeenCalledOnce()
+    expect(onFilesChanged).toHaveBeenCalledOnce()
     expect(onFilesChanged).toHaveBeenCalledWith({
       projectId: 'project-1',
       sources: ['artifact', 'upload'],


### PR DESCRIPTION
## Problem

The 1,827-line Project Files Repository mixes durable projection/reconciliation, soft delete/restore,
query pagination/search/group read models and `project-files:changed` publication. Before extracting
owners, Prisma row, cursor, revision, filtering and event contracts need explicit characterization.

## Proposed change

- Add characterization tests at the existing Project Files Repository interface for projection,
  reconciliation, soft delete/restore, overview/list/search/group queries and change publication.
- Lock cursor/pagination ordering, revision conflict behavior, exclusion filters, artifact grouping and
  idempotent reconciliation outcomes.
- Register or refine the existing `project_files_repository` Test Impact Set only when current
  ownership evidence requires it.
- Add 220 net test lines and no production lines; include coordinator/deletion/artifact-finalization
  consumers in the module Test Impact Set.

## Scope and non-goals

- Test and impact-evidence changes only; production behavior and facade size remain unchanged.
- No Prisma schema/row, migration, revision, cursor, event payload/name, filtering or query result
  change.
- No IPC/preload/public command, UI, MCP or cross-surface capability change.
- No owner extraction; FI1–FI2 remain separate implementation PRs.

## Compatibility

- Preserve Electron/Web/CLI/Task/local-RPC/MCP behavior and Specialist/Permission/Compute asymmetry.
- Use repository test databases and platform-portable temporary paths; no host-specific path literals.
- Preserve event count/order and exact emitted `project-files:changed` behavior.

## Acceptance criteria and validation

- Characterization covers projection/reconciliation, deletion/restore, revision conflicts, pagination,
  overview/list/search/group queries, exclusion filters and change events including no-op/idempotent
  cases.
- Production raw change is 0 and tests are portable across Windows, macOS and Linux.
- Project files repository/IPC and artifact/session consumers, Node typecheck, lint/format and
  independent Standards/Spec pass on the final diff.
- Exact-head PR Gate, CI Integrity, CodeQL and AI pass before squash merge.

Final local Test Impact Set after the last material edit:

- Projection/revision, token restore, reconcile idempotency, cursor ownership and project deletion/
  restore contracts -> `npm run test:module -- project_files_repository` -> 5 files, 176 tests passed.
- Module-impact structure and selection -> validator -> passed; the final plan selects repository,
  IPC, coordinator, deletion and artifact-finalization recovery tests.
- Node type compatibility -> `npm run typecheck:node` -> passed.
- Changed-file lint/format/whitespace -> ESLint, Prettier and `git diff --check` -> passed.
- Independent review -> the initial Standards P1 for missing coordinator/artifact-finalization
  consumers was fixed; final Standards 0 findings and Spec 0 findings.

Production raw change is 0. The module-impact manifest is a global validation input, so exact-head PR
Gate is the authoritative full fallback under the approved local-focused/online-full policy. The
existing `windows_sensitive` overlay keeps database/path behavior certified on online platform lanes.

## Review focus

- Confirm tests assert observable interface, Prisma and event outcomes rather than private structure.
- Confirm cursor/revision cases distinguish ordering from incidental generated IDs/timestamps.
- Confirm the suite is strong enough to protect FI1–FI2 without freezing query implementation details.
