### PR TITLE
refactor(uploads): extract active transfer owner

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -90,7 +90,11 @@
       "fallbackCapability": "main_runtime"
     },
     "upload_repository": {
-      "ownerPaths": ["src/main/uploads/repository.ts"],
+      "ownerPaths": [
+        "src/main/uploads/repository.ts",
+        "src/main/uploads/active-transfer-owner.ts",
+        "src/main/uploads/storage-helpers.ts"
+      ],
       "interfacePaths": ["src/main/uploads/repository.ts"],
       "consumerModules": ["session_persistence"],
       "testFiles": {
@@ -99,7 +103,11 @@
           "src/main/uploads/repository.characterization.test.ts"
         ],
         "contract": ["src/main/uploads/ipc.test.ts", "src/main/uploads/command-owner.test.ts"],
-        "consumer": ["src/main/session-persistence/deletion-integration.test.ts"]
+        "consumer": [
+          "src/main/session-persistence/deletion-integration.test.ts",
+          "src/main/acp/file-reference-resolver.test.ts",
+          "src/main/acp/prompt-content-owner.test.ts"
+        ]
       },
       "capabilityOverlays": ["windows_sensitive"],
       "fallbackCapability": "main_runtime"

--- a/src/main/uploads/active-transfer-owner.ts
+++ b/src/main/uploads/active-transfer-owner.ts
@@ -1,0 +1,391 @@
+import { createReadStream } from 'node:fs'
+import { mkdir, open, rm, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+import {
+  MAX_UPLOAD_CHUNK_BYTES,
+  MAX_UPLOAD_FILE_BYTES,
+  PENDING_UPLOAD_SESSION_ID,
+  formatUploadSizeLimit,
+  type AppendUploadTransferRequest,
+  type BeginUploadTransferRequest,
+  type StageLocalUploadRequest,
+  type UploadTransferProgress,
+  type UploadTransferRequest,
+  type UploadTransferStatus,
+  type UploadedAttachment
+} from '../../shared/uploads'
+import {
+  STAGING_UPLOAD_SESSION_ID,
+  assertSafePathSegment,
+  createUploadedAttachment,
+  getSessionUploadDir,
+  moveToUniqueUploadFile,
+  toSafeUploadFilename
+} from './storage-helpers'
+
+type ActiveTransferOwnerOptions = {
+  maxFileBytes?: number
+  createLocalReadStream?: (
+    sourcePath: string,
+    options: { highWaterMark: number; signal: AbortSignal }
+  ) => ReturnType<typeof createReadStream>
+}
+
+type ActiveUploadTransfer = {
+  transferId: string
+  name: string
+  mimeType?: string
+  totalBytes: number
+  receivedBytes: number
+  stagingPath: string
+  writing: boolean
+  cancelled: boolean
+}
+
+type ActiveLocalTransfer = {
+  stagingPath: string
+  cancelled: boolean
+  abortController: AbortController
+  settled: Promise<void>
+  resolveSettled: () => void
+}
+
+// Sole owner of live remote/local transfer state and its staging cleanup decisions.
+class ActiveTransferOwner {
+  private readonly activeTransfers = new Map<string, ActiveUploadTransfer>()
+  private readonly activeLocalTransfers = new Map<string, ActiveLocalTransfer>()
+  private stagingReady: Promise<void> | undefined
+
+  constructor(
+    private readonly storageRoot: string,
+    private readonly options: ActiveTransferOwnerOptions = {}
+  ) {}
+
+  // Allocates an empty temporary file for sources that can only provide bytes (Web, clipboard,
+  // synthetic File objects). Chunks are appended through appendTransfer and committed by finish.
+  async beginTransfer(request: BeginUploadTransferRequest): Promise<UploadTransferStatus> {
+    const transferId = assertSafePathSegment(request.transferId)
+    const name = request.name.trim() || 'upload'
+    const maxFileBytes = this.options.maxFileBytes ?? MAX_UPLOAD_FILE_BYTES
+
+    if (!Number.isSafeInteger(request.size) || request.size < 0) {
+      throw new Error(`Invalid upload size: ${name}`)
+    }
+    if (request.size > maxFileBytes) {
+      throw new Error(
+        `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${name}`
+      )
+    }
+
+    const existing = this.activeTransfers.get(transferId)
+    if (existing) {
+      if (
+        existing.name !== name ||
+        existing.mimeType !== request.mimeType ||
+        existing.totalBytes !== request.size
+      ) {
+        throw new Error(`Upload transfer metadata does not match: ${transferId}`)
+      }
+      return this.toTransferStatus(existing)
+    }
+    if (this.activeLocalTransfers.has(transferId)) {
+      throw new Error(`Upload transfer already exists: ${transferId}`)
+    }
+
+    const stagingPath = join(
+      getSessionUploadDir(this.storageRoot, STAGING_UPLOAD_SESSION_ID),
+      `${transferId}.part`
+    )
+    await this.ensureStagingDirectory()
+
+    const file = await open(stagingPath, 'wx')
+    await file.close()
+
+    const transfer: ActiveUploadTransfer = {
+      transferId,
+      name,
+      mimeType: request.mimeType,
+      totalBytes: request.size,
+      receivedBytes: 0,
+      stagingPath,
+      writing: false,
+      cancelled: false
+    }
+    this.activeTransfers.set(transferId, transfer)
+    return this.toTransferStatus(transfer)
+  }
+
+  // Accepts exactly one bounded chunk at the caller's expected offset. This makes retries safe:
+  // callers query status and resume from receivedBytes instead of duplicating data.
+  async appendTransfer(request: AppendUploadTransferRequest): Promise<UploadTransferStatus> {
+    const transfer = this.getActiveTransfer(request.transferId)
+    if (!(request.chunk instanceof Uint8Array)) {
+      throw new Error('Upload chunk must be binary data.')
+    }
+    if (request.chunk.byteLength > MAX_UPLOAD_CHUNK_BYTES) {
+      throw new Error('Upload chunk exceeds the maximum allowed chunk size.')
+    }
+    if (request.chunk.byteLength === 0) {
+      throw new Error('Upload chunk must not be empty.')
+    }
+    if (request.offset !== transfer.receivedBytes) {
+      throw new Error(
+        `Upload chunk offset mismatch: expected ${transfer.receivedBytes}, received ${request.offset}.`
+      )
+    }
+    if (transfer.writing) {
+      throw new Error(`Upload transfer is already receiving a chunk: ${transfer.transferId}`)
+    }
+    if (transfer.receivedBytes + request.chunk.byteLength > transfer.totalBytes) {
+      throw new Error(`Upload chunk exceeds the declared file size: ${transfer.name}`)
+    }
+
+    transfer.writing = true
+    let file: Awaited<ReturnType<typeof open>> | undefined
+    try {
+      file = await open(transfer.stagingPath, 'r+')
+      const bytes = Buffer.from(
+        request.chunk.buffer,
+        request.chunk.byteOffset,
+        request.chunk.byteLength
+      )
+      let written = 0
+      while (written < bytes.byteLength) {
+        const result = await file.write(
+          bytes,
+          written,
+          bytes.byteLength - written,
+          transfer.receivedBytes + written
+        )
+        written += result.bytesWritten
+      }
+      transfer.receivedBytes += written
+      if (transfer.cancelled) throw new Error(`Upload cancelled: ${transfer.name}`)
+      return this.toTransferStatus(transfer)
+    } finally {
+      transfer.writing = false
+      await file?.close()
+      if (transfer.cancelled) {
+        this.activeTransfers.delete(transfer.transferId)
+        await rm(transfer.stagingPath, { force: true })
+      }
+    }
+  }
+
+  async getTransferStatus(request: UploadTransferRequest): Promise<UploadTransferStatus | null> {
+    const transferId = assertSafePathSegment(request.transferId)
+    const transfer = this.activeTransfers.get(transferId)
+    return transfer ? this.toTransferStatus(transfer) : null
+  }
+
+  // Publishes a fully received temporary file into the same pending attachment namespace used by
+  // desktop-path uploads. Incomplete transfers remain resumable until explicitly aborted.
+  async finishTransfer(request: UploadTransferRequest): Promise<UploadedAttachment> {
+    const transfer = this.getActiveTransfer(request.transferId)
+    if (transfer.writing) {
+      throw new Error(`Upload transfer is still receiving a chunk: ${transfer.transferId}`)
+    }
+    if (transfer.receivedBytes !== transfer.totalBytes) {
+      throw new Error(
+        `Upload transfer is incomplete: received ${transfer.receivedBytes} of ${transfer.totalBytes} bytes.`
+      )
+    }
+
+    const pendingDir = getSessionUploadDir(this.storageRoot, PENDING_UPLOAD_SESSION_ID)
+    await mkdir(pendingDir, { recursive: true })
+    const { filename, filePath } = await moveToUniqueUploadFile(
+      transfer.stagingPath,
+      pendingDir,
+      toSafeUploadFilename(transfer.name)
+    )
+    this.activeTransfers.delete(transfer.transferId)
+
+    return createUploadedAttachment({
+      id: randomUUID(),
+      sessionId: PENDING_UPLOAD_SESSION_ID,
+      filename,
+      originalName: transfer.name,
+      filePath,
+      mimeType: transfer.mimeType
+    })
+  }
+
+  // Cancellation is idempotent so renderer cleanup can safely race a failed transfer.
+  async abortTransfer(request: UploadTransferRequest): Promise<void> {
+    const transferId = assertSafePathSegment(request.transferId)
+    const localTransfer = this.activeLocalTransfers.get(transferId)
+    if (localTransfer) {
+      localTransfer.cancelled = true
+      localTransfer.abortController.abort()
+      await localTransfer.settled
+      return
+    }
+    const transfer = this.activeTransfers.get(transferId)
+    if (transfer?.writing) {
+      transfer.cancelled = true
+      return
+    }
+    this.activeTransfers.delete(transferId)
+    if (transfer) await rm(transfer.stagingPath, { force: true })
+  }
+
+  // Streams an existing desktop file into managed staging without routing its bytes through the
+  // renderer or a single IPC message. The temporary file is committed only after all bytes arrive.
+  async stageLocalFile(
+    request: StageLocalUploadRequest,
+    onProgress?: (progress: UploadTransferProgress) => void
+  ): Promise<UploadedAttachment> {
+    const transferId = assertSafePathSegment(request.transferId)
+    const originalName = request.name.trim() || 'upload'
+    const maxFileBytes = this.options.maxFileBytes ?? MAX_UPLOAD_FILE_BYTES
+    if (this.activeLocalTransfers.has(transferId) || this.activeTransfers.has(transferId)) {
+      throw new Error(`Upload transfer already exists: ${transferId}`)
+    }
+
+    const stagingPath = join(
+      getSessionUploadDir(this.storageRoot, STAGING_UPLOAD_SESSION_ID),
+      `${transferId}.part`
+    )
+    const pendingDir = getSessionUploadDir(this.storageRoot, PENDING_UPLOAD_SESSION_ID)
+    let resolveSettled = (): void => undefined
+    const settled = new Promise<void>((resolve) => {
+      resolveSettled = resolve
+    })
+    const localTransfer: ActiveLocalTransfer = {
+      stagingPath,
+      cancelled: false,
+      abortController: new AbortController(),
+      settled,
+      resolveSettled
+    }
+    let receivedBytes = 0
+    let output: Awaited<ReturnType<typeof open>> | undefined
+
+    // Register before the first await so renderer teardown can cancel validation/directory setup too.
+    this.activeLocalTransfers.set(transferId, localTransfer)
+
+    try {
+      const sourceInfo = await stat(request.sourcePath)
+
+      if (!sourceInfo.isFile()) {
+        throw new Error(`Upload source is not a file: ${originalName}`)
+      }
+      if (sourceInfo.size > maxFileBytes || request.size > maxFileBytes) {
+        throw new Error(
+          `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${originalName}`
+        )
+      }
+      if (sourceInfo.size !== request.size) {
+        throw new Error(`Upload source changed before it could be staged: ${originalName}`)
+      }
+      if (localTransfer.cancelled) throw new Error(`Upload cancelled: ${originalName}`)
+
+      await this.ensureStagingDirectory()
+      await mkdir(pendingDir, { recursive: true })
+      if (localTransfer.cancelled) throw new Error(`Upload cancelled: ${originalName}`)
+      output = await open(stagingPath, 'wx')
+
+      const sourceStream = (this.options.createLocalReadStream ?? createReadStream)(
+        request.sourcePath,
+        {
+          highWaterMark: MAX_UPLOAD_CHUNK_BYTES,
+          signal: localTransfer.abortController.signal
+        }
+      )
+      for await (const chunk of sourceStream) {
+        if (localTransfer.cancelled) throw new Error(`Upload cancelled: ${originalName}`)
+        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+        const nextReceivedBytes = receivedBytes + bytes.byteLength
+
+        if (nextReceivedBytes > maxFileBytes) {
+          throw new Error(
+            `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${originalName}`
+          )
+        }
+
+        let written = 0
+        while (written < bytes.byteLength) {
+          const result = await output.write(
+            bytes,
+            written,
+            bytes.byteLength - written,
+            receivedBytes + written
+          )
+          written += result.bytesWritten
+        }
+        receivedBytes = nextReceivedBytes
+        onProgress?.({
+          transferId,
+          name: originalName,
+          receivedBytes,
+          totalBytes: request.size
+        })
+      }
+
+      await output.close()
+      output = undefined
+
+      if (receivedBytes !== request.size) {
+        throw new Error(`Upload source changed while it was being staged: ${originalName}`)
+      }
+
+      const { filename, filePath } = await moveToUniqueUploadFile(
+        stagingPath,
+        pendingDir,
+        toSafeUploadFilename(originalName)
+      )
+
+      return createUploadedAttachment({
+        id: randomUUID(),
+        sessionId: PENDING_UPLOAD_SESSION_ID,
+        filename,
+        originalName,
+        filePath,
+        mimeType: request.mimeType
+      })
+    } catch (error) {
+      await output?.close().catch(() => undefined)
+      await rm(stagingPath, { force: true })
+      throw error
+    } finally {
+      if (this.activeLocalTransfers.get(transferId) === localTransfer) {
+        this.activeLocalTransfers.delete(transferId)
+      }
+      localTransfer.resolveSettled()
+    }
+  }
+
+  // Transfers cannot survive a main-process restart. Clear crash-orphaned partial files before the
+  // first transfer in this owner instance; concurrent first calls share the cleanup promise.
+  private ensureStagingDirectory(): Promise<void> {
+    if (!this.stagingReady) {
+      const stagingDir = getSessionUploadDir(this.storageRoot, STAGING_UPLOAD_SESSION_ID)
+      this.stagingReady = (async () => {
+        await rm(stagingDir, { recursive: true, force: true })
+        await mkdir(stagingDir, { recursive: true })
+      })()
+    }
+
+    return this.stagingReady
+  }
+
+  private getActiveTransfer(transferId: string): ActiveUploadTransfer {
+    const safeTransferId = assertSafePathSegment(transferId)
+    const transfer = this.activeTransfers.get(safeTransferId)
+    if (!transfer) throw new Error(`Unknown upload transfer: ${safeTransferId}`)
+    return transfer
+  }
+
+  private toTransferStatus(transfer: ActiveUploadTransfer): UploadTransferStatus {
+    return {
+      transferId: transfer.transferId,
+      name: transfer.name,
+      receivedBytes: transfer.receivedBytes,
+      totalBytes: transfer.totalBytes
+    }
+  }
+}
+
+export { ActiveTransferOwner }

--- a/src/main/uploads/repository.ts
+++ b/src/main/uploads/repository.ts
@@ -4,7 +4,6 @@ import {
   link,
   lstat,
   mkdir,
-  open,
   readdir,
   realpath,
   rename,
@@ -12,7 +11,7 @@ import {
   rmdir,
   stat
 } from 'node:fs/promises'
-import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { basename, dirname, join, relative, resolve, sep } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
 
 import type { PrismaClient } from '@prisma/client'
@@ -20,10 +19,7 @@ import type { PrismaClient } from '@prisma/client'
 import type { ArtifactPreviewResult, ReadArtifactPreviewRequest } from '../../shared/artifacts'
 import {
   DEFAULT_UPLOAD_PROJECT_NAME,
-  MAX_UPLOAD_CHUNK_BYTES,
-  MAX_UPLOAD_FILE_BYTES,
   PENDING_UPLOAD_SESSION_ID,
-  formatUploadSizeLimit,
   parseUploadVersionReference,
   toPersistedUploadedAttachment,
   toRuntimeUploadedAttachment,
@@ -39,13 +35,22 @@ import {
 } from '../../shared/uploads'
 import type { PersistedChatMessage, PersistedChatSession } from '../../shared/session-persistence'
 import { readBoundedManagedFilePreview } from '../managed-file-preview'
+import { ActiveTransferOwner } from './active-transfer-owner'
+import {
+  UPLOADS_DIR,
+  assertPathInsideRoot,
+  assertSafePathSegment,
+  createUploadedAttachment,
+  getSessionUploadDir,
+  getUploadRoot,
+  isFileExistsError,
+  isMissingFileError,
+  moveToUniqueUploadFile
+} from './storage-helpers'
 
-const UPLOADS_DIR = 'uploads'
-const STAGING_UPLOAD_SESSION_ID = '.staging'
 const LIVE_COPY_TEMP_SUFFIX = '.live-copy.tmp'
 const LEGACY_CLEANUP_PRIVATE_SUFFIX = '.legacy-cleanup.private'
 const LEGACY_CLEANUP_CANDIDATE = 'candidate'
-const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 
 type UploadRepositoryOptions = {
   maxFileBytes?: number
@@ -61,25 +66,6 @@ type UploadRepositoryOptions = {
 type ResolvedManagedUpload = {
   path: string
   name: string
-}
-
-type ActiveUploadTransfer = {
-  transferId: string
-  name: string
-  mimeType?: string
-  totalBytes: number
-  receivedBytes: number
-  stagingPath: string
-  writing: boolean
-  cancelled: boolean
-}
-
-type ActiveLocalTransfer = {
-  stagingPath: string
-  cancelled: boolean
-  abortController: AbortController
-  settled: Promise<void>
-  resolveSettled: () => void
 }
 
 type CreateAttachmentInput = {
@@ -98,73 +84,6 @@ type LegacyUploadUpgradeOptions = {
   // recreating identity after provenance succeeded could claim unrelated residual bytes.
   mode?: 'reconcile' | 'live-save' | 'orphan-recovery' | 'terminal-delete'
 }
-
-// Accepts only path segments that cannot escape the managed upload layout.
-const assertSafePathSegment = (segment: string): string => {
-  if (!SAFE_SEGMENT_PATTERN.test(segment)) {
-    throw new Error(`Invalid upload path segment: ${segment}`)
-  }
-
-  return segment
-}
-
-// Allows the temporary staging directory while still validating durable session ids.
-const assertSafeSessionId = (sessionId: string): string => {
-  if (sessionId === PENDING_UPLOAD_SESSION_ID) return sessionId
-
-  return assertSafePathSegment(sessionId)
-}
-
-// Converts user-provided or clipboard filenames into safe, display-friendly basenames.
-const toSafeUploadFilename = (filename: string): string => {
-  const leafName = basename((filename.trim() || 'upload').replace(/\\/g, '/'))
-  const safeName = leafName
-    .replace(/[^A-Za-z0-9._ -]/gu, '_')
-    .replace(/_+/g, '_')
-    .replace(/^\.+/g, '')
-    .replace(/[. ]+$/g, '')
-    .trim()
-
-  return safeName && safeName !== PENDING_UPLOAD_SESSION_ID ? safeName : 'upload'
-}
-
-// Keeps duplicate upload names stable by suffixing before the original extension.
-const appendFilenameSuffix = (filename: string, suffix: number): string => {
-  const extension = extname(filename)
-  const baseName = basename(filename, extension)
-
-  return `${baseName}-${suffix}${extension}`
-}
-
-// Rejects direct traversal and absolute-path escapes before and after canonicalization.
-const assertPathInsideRoot = (
-  rootPath: string,
-  filePath: string,
-  errorMessage = 'Upload file is outside upload storage.'
-): void => {
-  const relativePath = relative(rootPath, filePath)
-
-  if (relativePath === '' || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
-    throw new Error(errorMessage)
-  }
-  if (isAbsolute(relativePath)) {
-    throw new Error(errorMessage)
-  }
-}
-
-// Narrows platform file errors without depending on Node-specific exception classes.
-const isMissingFileError = (error: unknown): boolean =>
-  typeof error === 'object' &&
-  error !== null &&
-  'code' in error &&
-  (error as { code?: unknown }).code === 'ENOENT'
-
-// Detects exclusive-write collisions so callers can allocate the next available filename.
-const isFileExistsError = (error: unknown): boolean =>
-  typeof error === 'object' &&
-  error !== null &&
-  'code' in error &&
-  (error as { code?: unknown }).code === 'EEXIST'
 
 const sha256File = async (filePath: string): Promise<string> => {
   const hash = createHash('sha256')
@@ -216,180 +135,41 @@ type LegacyCleanupResult =
 
 // Owns app-managed uploads so renderer paths are always validated in the main process.
 class UploadRepository {
-  private readonly activeTransfers = new Map<string, ActiveUploadTransfer>()
-  private readonly activeLocalTransfers = new Map<string, ActiveLocalTransfer>()
-  private stagingReady: Promise<void> | undefined
+  private readonly transferOwner: ActiveTransferOwner
 
   // The storage root is the app persistence root; this class appends uploads/project/session.
   constructor(
     private readonly storageRoot: string,
     private readonly options: UploadRepositoryOptions = {}
-  ) {}
+  ) {
+    this.transferOwner = new ActiveTransferOwner(storageRoot, options)
+  }
 
   // Allocates an empty temporary file for sources that can only provide bytes (Web, clipboard,
   // synthetic File objects). Chunks are appended through appendTransfer and committed by finish.
   async beginTransfer(request: BeginUploadTransferRequest): Promise<UploadTransferStatus> {
-    const transferId = assertSafePathSegment(request.transferId)
-    const name = request.name.trim() || 'upload'
-    const maxFileBytes = this.options.maxFileBytes ?? MAX_UPLOAD_FILE_BYTES
-
-    if (!Number.isSafeInteger(request.size) || request.size < 0) {
-      throw new Error(`Invalid upload size: ${name}`)
-    }
-    if (request.size > maxFileBytes) {
-      throw new Error(
-        `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${name}`
-      )
-    }
-
-    const existing = this.activeTransfers.get(transferId)
-    if (existing) {
-      if (
-        existing.name !== name ||
-        existing.mimeType !== request.mimeType ||
-        existing.totalBytes !== request.size
-      ) {
-        throw new Error(`Upload transfer metadata does not match: ${transferId}`)
-      }
-      return this.toTransferStatus(existing)
-    }
-    if (this.activeLocalTransfers.has(transferId)) {
-      throw new Error(`Upload transfer already exists: ${transferId}`)
-    }
-
-    const stagingDir = this.getSessionUploadDir(STAGING_UPLOAD_SESSION_ID)
-    const stagingPath = join(stagingDir, `${transferId}.part`)
-    await this.ensureStagingDirectory()
-
-    const file = await open(stagingPath, 'wx')
-    await file.close()
-
-    const transfer: ActiveUploadTransfer = {
-      transferId,
-      name,
-      mimeType: request.mimeType,
-      totalBytes: request.size,
-      receivedBytes: 0,
-      stagingPath,
-      writing: false,
-      cancelled: false
-    }
-    this.activeTransfers.set(transferId, transfer)
-    return this.toTransferStatus(transfer)
+    return this.transferOwner.beginTransfer(request)
   }
 
   // Accepts exactly one bounded chunk at the caller's expected offset. This makes retries safe:
   // callers query status and resume from receivedBytes instead of duplicating data.
   async appendTransfer(request: AppendUploadTransferRequest): Promise<UploadTransferStatus> {
-    const transfer = this.getActiveTransfer(request.transferId)
-    if (!(request.chunk instanceof Uint8Array)) {
-      throw new Error('Upload chunk must be binary data.')
-    }
-    if (request.chunk.byteLength > MAX_UPLOAD_CHUNK_BYTES) {
-      throw new Error('Upload chunk exceeds the maximum allowed chunk size.')
-    }
-    if (request.chunk.byteLength === 0) {
-      throw new Error('Upload chunk must not be empty.')
-    }
-    if (request.offset !== transfer.receivedBytes) {
-      throw new Error(
-        `Upload chunk offset mismatch: expected ${transfer.receivedBytes}, received ${request.offset}.`
-      )
-    }
-    if (transfer.writing) {
-      throw new Error(`Upload transfer is already receiving a chunk: ${transfer.transferId}`)
-    }
-    if (transfer.receivedBytes + request.chunk.byteLength > transfer.totalBytes) {
-      throw new Error(`Upload chunk exceeds the declared file size: ${transfer.name}`)
-    }
-
-    transfer.writing = true
-    let file: Awaited<ReturnType<typeof open>> | undefined
-    try {
-      file = await open(transfer.stagingPath, 'r+')
-      const bytes = Buffer.from(
-        request.chunk.buffer,
-        request.chunk.byteOffset,
-        request.chunk.byteLength
-      )
-      let written = 0
-      while (written < bytes.byteLength) {
-        const result = await file.write(
-          bytes,
-          written,
-          bytes.byteLength - written,
-          transfer.receivedBytes + written
-        )
-        written += result.bytesWritten
-      }
-      transfer.receivedBytes += written
-      if (transfer.cancelled) throw new Error(`Upload cancelled: ${transfer.name}`)
-      return this.toTransferStatus(transfer)
-    } finally {
-      transfer.writing = false
-      await file?.close()
-      if (transfer.cancelled) {
-        this.activeTransfers.delete(transfer.transferId)
-        await rm(transfer.stagingPath, { force: true })
-      }
-    }
+    return this.transferOwner.appendTransfer(request)
   }
 
   async getTransferStatus(request: UploadTransferRequest): Promise<UploadTransferStatus | null> {
-    const transferId = assertSafePathSegment(request.transferId)
-    const transfer = this.activeTransfers.get(transferId)
-    return transfer ? this.toTransferStatus(transfer) : null
+    return this.transferOwner.getTransferStatus(request)
   }
 
   // Publishes a fully received temporary file into the same pending attachment namespace used by
   // desktop-path uploads. Incomplete transfers remain resumable until explicitly aborted.
   async finishTransfer(request: UploadTransferRequest): Promise<UploadedAttachment> {
-    const transfer = this.getActiveTransfer(request.transferId)
-    if (transfer.writing) {
-      throw new Error(`Upload transfer is still receiving a chunk: ${transfer.transferId}`)
-    }
-    if (transfer.receivedBytes !== transfer.totalBytes) {
-      throw new Error(
-        `Upload transfer is incomplete: received ${transfer.receivedBytes} of ${transfer.totalBytes} bytes.`
-      )
-    }
-
-    const pendingDir = this.getSessionUploadDir(PENDING_UPLOAD_SESSION_ID)
-    await mkdir(pendingDir, { recursive: true })
-    const { filename, filePath } = await this.moveToUniqueFile(
-      transfer.stagingPath,
-      pendingDir,
-      toSafeUploadFilename(transfer.name)
-    )
-    this.activeTransfers.delete(transfer.transferId)
-
-    return this.createAttachment({
-      id: randomUUID(),
-      sessionId: PENDING_UPLOAD_SESSION_ID,
-      filename,
-      originalName: transfer.name,
-      filePath,
-      mimeType: transfer.mimeType
-    })
+    return this.transferOwner.finishTransfer(request)
   }
 
   // Cancellation is idempotent so renderer cleanup can safely race a failed transfer.
   async abortTransfer(request: UploadTransferRequest): Promise<void> {
-    const transferId = assertSafePathSegment(request.transferId)
-    const localTransfer = this.activeLocalTransfers.get(transferId)
-    if (localTransfer) {
-      localTransfer.cancelled = true
-      localTransfer.abortController.abort()
-      await localTransfer.settled
-      return
-    }
-    const transfer = this.activeTransfers.get(transferId)
-    if (transfer?.writing) {
-      transfer.cancelled = true
-      return
-    }
-    this.activeTransfers.delete(transferId)
-    if (transfer) await rm(transfer.stagingPath, { force: true })
+    return this.transferOwner.abortTransfer(request)
   }
 
   // Streams an existing desktop file into managed staging without routing its bytes through the
@@ -398,122 +178,7 @@ class UploadRepository {
     request: StageLocalUploadRequest,
     onProgress?: (progress: UploadTransferProgress) => void
   ): Promise<UploadedAttachment> {
-    const transferId = assertSafePathSegment(request.transferId)
-    const originalName = request.name.trim() || 'upload'
-    const maxFileBytes = this.options.maxFileBytes ?? MAX_UPLOAD_FILE_BYTES
-    if (this.activeLocalTransfers.has(transferId) || this.activeTransfers.has(transferId)) {
-      throw new Error(`Upload transfer already exists: ${transferId}`)
-    }
-
-    const stagingDir = this.getSessionUploadDir(STAGING_UPLOAD_SESSION_ID)
-    const pendingDir = this.getSessionUploadDir(PENDING_UPLOAD_SESSION_ID)
-    const stagingPath = join(stagingDir, `${transferId}.part`)
-    let resolveSettled = (): void => undefined
-    const settled = new Promise<void>((resolve) => {
-      resolveSettled = resolve
-    })
-    const localTransfer: ActiveLocalTransfer = {
-      stagingPath,
-      cancelled: false,
-      abortController: new AbortController(),
-      settled,
-      resolveSettled
-    }
-    let receivedBytes = 0
-    let output: Awaited<ReturnType<typeof open>> | undefined
-
-    // Register before the first await so renderer teardown can cancel validation/directory setup too.
-    this.activeLocalTransfers.set(transferId, localTransfer)
-
-    try {
-      const sourceInfo = await stat(request.sourcePath)
-
-      if (!sourceInfo.isFile()) {
-        throw new Error(`Upload source is not a file: ${originalName}`)
-      }
-      if (sourceInfo.size > maxFileBytes || request.size > maxFileBytes) {
-        throw new Error(
-          `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${originalName}`
-        )
-      }
-      if (sourceInfo.size !== request.size) {
-        throw new Error(`Upload source changed before it could be staged: ${originalName}`)
-      }
-      if (localTransfer.cancelled) throw new Error(`Upload cancelled: ${originalName}`)
-
-      await this.ensureStagingDirectory()
-      await mkdir(pendingDir, { recursive: true })
-      if (localTransfer.cancelled) throw new Error(`Upload cancelled: ${originalName}`)
-      output = await open(stagingPath, 'wx')
-
-      const sourceStream = (this.options.createLocalReadStream ?? createReadStream)(
-        request.sourcePath,
-        {
-          highWaterMark: MAX_UPLOAD_CHUNK_BYTES,
-          signal: localTransfer.abortController.signal
-        }
-      )
-      for await (const chunk of sourceStream) {
-        if (localTransfer.cancelled) throw new Error(`Upload cancelled: ${originalName}`)
-        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
-        const nextReceivedBytes = receivedBytes + bytes.byteLength
-
-        if (nextReceivedBytes > maxFileBytes) {
-          throw new Error(
-            `Upload exceeds the ${formatUploadSizeLimit(maxFileBytes)} per-file limit: ${originalName}`
-          )
-        }
-
-        let written = 0
-        while (written < bytes.byteLength) {
-          const result = await output.write(
-            bytes,
-            written,
-            bytes.byteLength - written,
-            receivedBytes + written
-          )
-          written += result.bytesWritten
-        }
-        receivedBytes = nextReceivedBytes
-        onProgress?.({
-          transferId,
-          name: originalName,
-          receivedBytes,
-          totalBytes: request.size
-        })
-      }
-
-      await output.close()
-      output = undefined
-
-      if (receivedBytes !== request.size) {
-        throw new Error(`Upload source changed while it was being staged: ${originalName}`)
-      }
-
-      const { filename, filePath } = await this.moveToUniqueFile(
-        stagingPath,
-        pendingDir,
-        toSafeUploadFilename(originalName)
-      )
-
-      return this.createAttachment({
-        id: randomUUID(),
-        sessionId: PENDING_UPLOAD_SESSION_ID,
-        filename,
-        originalName,
-        filePath,
-        mimeType: request.mimeType
-      })
-    } catch (error) {
-      await output?.close().catch(() => undefined)
-      await rm(stagingPath, { force: true })
-      throw error
-    } finally {
-      if (this.activeLocalTransfers.get(transferId) === localTransfer) {
-        this.activeLocalTransfers.delete(transferId)
-      }
-      localTransfer.resolveSettled()
-    }
+    return this.transferOwner.stageLocalFile(request, onProgress)
   }
 
   // Moves pending attachments into their durable session directory once the runtime id is known.
@@ -1753,49 +1418,12 @@ class UploadRepository {
 
   // Returns the top-level upload directory under the app persistence root.
   private getUploadRoot(): string {
-    return resolve(this.storageRoot, UPLOADS_DIR)
-  }
-
-  // Returns the per-project upload directory for the current workspace project.
-  private getProjectUploadDir(): string {
-    return join(this.getUploadRoot(), DEFAULT_UPLOAD_PROJECT_NAME)
+    return getUploadRoot(this.storageRoot)
   }
 
   // Returns the staging or durable directory for one upload session.
   private getSessionUploadDir(sessionId: string): string {
-    const safeSessionId =
-      sessionId === STAGING_UPLOAD_SESSION_ID ? sessionId : assertSafeSessionId(sessionId)
-    return join(this.getProjectUploadDir(), safeSessionId)
-  }
-
-  // Transfers cannot survive a main-process restart. Clear crash-orphaned partial files before the
-  // first transfer in this repository instance; concurrent first calls share the cleanup promise.
-  private ensureStagingDirectory(): Promise<void> {
-    if (!this.stagingReady) {
-      const stagingDir = this.getSessionUploadDir(STAGING_UPLOAD_SESSION_ID)
-      this.stagingReady = (async () => {
-        await rm(stagingDir, { recursive: true, force: true })
-        await mkdir(stagingDir, { recursive: true })
-      })()
-    }
-
-    return this.stagingReady
-  }
-
-  private getActiveTransfer(transferId: string): ActiveUploadTransfer {
-    const safeTransferId = assertSafePathSegment(transferId)
-    const transfer = this.activeTransfers.get(safeTransferId)
-    if (!transfer) throw new Error(`Unknown upload transfer: ${safeTransferId}`)
-    return transfer
-  }
-
-  private toTransferStatus(transfer: ActiveUploadTransfer): UploadTransferStatus {
-    return {
-      transferId: transfer.transferId,
-      name: transfer.name,
-      receivedBytes: transfer.receivedBytes,
-      totalBytes: transfer.totalBytes
-    }
+    return getSessionUploadDir(this.storageRoot, sessionId)
   }
 
   // Moves an already-staged file into a target directory while preserving unique filenames.
@@ -1804,44 +1432,12 @@ class UploadRepository {
     targetDir: string,
     filename: string
   ): Promise<{ filename: string; filePath: string }> {
-    const safeFilename = toSafeUploadFilename(filename)
-
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const candidate =
-        attempt === 0 ? safeFilename : appendFilenameSuffix(safeFilename, attempt + 1)
-      const filePath = join(targetDir, candidate)
-
-      try {
-        // A same-volume hard link commits the staged inode without a multi-GB second copy. Cross-
-        // device or unsupported filesystems fall back to exclusive copy, preserving old behavior.
-        try {
-          await link(sourcePath, filePath)
-        } catch (linkError) {
-          if (isFileExistsError(linkError)) throw linkError
-          await copyFile(sourcePath, filePath, constants.COPYFILE_EXCL)
-        }
-        await rm(sourcePath, { force: true })
-        return { filename: candidate, filePath }
-      } catch (error) {
-        if (isFileExistsError(error)) continue
-        throw error
-      }
-    }
-
-    throw new Error(`Could not allocate upload filename: ${safeFilename}`)
+    return moveToUniqueUploadFile(sourcePath, targetDir, filename)
   }
 
   // Builds the renderer-safe attachment metadata from the trusted file on disk.
   private async createAttachment(input: CreateAttachmentInput): Promise<UploadedAttachment> {
-    return {
-      id: input.id,
-      sessionId: input.sessionId,
-      name: input.filename,
-      originalName: input.originalName,
-      path: input.filePath,
-      mimeType: input.mimeType,
-      size: (await stat(input.filePath)).size
-    }
+    return createUploadedAttachment(input)
   }
 }
 

--- a/src/main/uploads/storage-helpers.ts
+++ b/src/main/uploads/storage-helpers.ts
@@ -1,0 +1,156 @@
+import { constants } from 'node:fs'
+import { copyFile, link, rm, stat } from 'node:fs/promises'
+import { basename, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+import {
+  DEFAULT_UPLOAD_PROJECT_NAME,
+  PENDING_UPLOAD_SESSION_ID,
+  type UploadedAttachment
+} from '../../shared/uploads'
+
+const UPLOADS_DIR = 'uploads'
+const STAGING_UPLOAD_SESSION_ID = '.staging'
+const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+type CreateAttachmentInput = {
+  id: string
+  sessionId: string
+  filename: string
+  originalName: string
+  filePath: string
+  mimeType?: string
+}
+
+// Accepts only path segments that cannot escape the managed upload layout.
+const assertSafePathSegment = (segment: string): string => {
+  if (!SAFE_SEGMENT_PATTERN.test(segment)) {
+    throw new Error(`Invalid upload path segment: ${segment}`)
+  }
+
+  return segment
+}
+
+// Allows the temporary staging directory while still validating durable session ids.
+const assertSafeSessionId = (sessionId: string): string => {
+  if (sessionId === PENDING_UPLOAD_SESSION_ID) return sessionId
+
+  return assertSafePathSegment(sessionId)
+}
+
+// Converts user-provided or clipboard filenames into safe, display-friendly basenames.
+const toSafeUploadFilename = (filename: string): string => {
+  const leafName = basename((filename.trim() || 'upload').replace(/\\/g, '/'))
+  const safeName = leafName
+    .replace(/[^A-Za-z0-9._ -]/gu, '_')
+    .replace(/_+/g, '_')
+    .replace(/^\.+/g, '')
+    .replace(/[. ]+$/g, '')
+    .trim()
+
+  return safeName && safeName !== PENDING_UPLOAD_SESSION_ID ? safeName : 'upload'
+}
+
+// Keeps duplicate upload names stable by suffixing before the original extension.
+const appendFilenameSuffix = (filename: string, suffix: number): string => {
+  const extension = extname(filename)
+  const baseName = basename(filename, extension)
+
+  return `${baseName}-${suffix}${extension}`
+}
+
+// Rejects direct traversal and absolute-path escapes before and after canonicalization.
+const assertPathInsideRoot = (
+  rootPath: string,
+  filePath: string,
+  errorMessage = 'Upload file is outside upload storage.'
+): void => {
+  const relativePath = relative(rootPath, filePath)
+
+  if (relativePath === '' || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
+    throw new Error(errorMessage)
+  }
+  if (isAbsolute(relativePath)) {
+    throw new Error(errorMessage)
+  }
+}
+
+// Narrows platform file errors without depending on Node-specific exception classes.
+const isMissingFileError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: unknown }).code === 'ENOENT'
+
+// Detects exclusive-write collisions so callers can allocate the next available filename.
+const isFileExistsError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: unknown }).code === 'EEXIST'
+
+const getUploadRoot = (storageRoot: string): string => resolve(storageRoot, UPLOADS_DIR)
+
+const getSessionUploadDir = (storageRoot: string, sessionId: string): string => {
+  const safeSessionId =
+    sessionId === STAGING_UPLOAD_SESSION_ID ? sessionId : assertSafeSessionId(sessionId)
+  return join(getUploadRoot(storageRoot), DEFAULT_UPLOAD_PROJECT_NAME, safeSessionId)
+}
+
+// Moves an already-staged file into a target directory while preserving unique filenames.
+const moveToUniqueUploadFile = async (
+  sourcePath: string,
+  targetDir: string,
+  filename: string
+): Promise<{ filename: string; filePath: string }> => {
+  const safeFilename = toSafeUploadFilename(filename)
+
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const candidate = attempt === 0 ? safeFilename : appendFilenameSuffix(safeFilename, attempt + 1)
+    const filePath = join(targetDir, candidate)
+
+    try {
+      // A same-volume hard link commits the staged inode without a multi-GB second copy. Cross-
+      // device or unsupported filesystems fall back to exclusive copy, preserving old behavior.
+      try {
+        await link(sourcePath, filePath)
+      } catch (linkError) {
+        if (isFileExistsError(linkError)) throw linkError
+        await copyFile(sourcePath, filePath, constants.COPYFILE_EXCL)
+      }
+      await rm(sourcePath, { force: true })
+      return { filename: candidate, filePath }
+    } catch (error) {
+      if (isFileExistsError(error)) continue
+      throw error
+    }
+  }
+
+  throw new Error(`Could not allocate upload filename: ${safeFilename}`)
+}
+
+// Builds renderer-safe attachment metadata from a trusted managed file on disk.
+const createUploadedAttachment = async (
+  input: CreateAttachmentInput
+): Promise<UploadedAttachment> => ({
+  id: input.id,
+  sessionId: input.sessionId,
+  name: input.filename,
+  originalName: input.originalName,
+  path: input.filePath,
+  mimeType: input.mimeType,
+  size: (await stat(input.filePath)).size
+})
+
+export {
+  STAGING_UPLOAD_SESSION_ID,
+  UPLOADS_DIR,
+  assertPathInsideRoot,
+  assertSafePathSegment,
+  createUploadedAttachment,
+  getSessionUploadDir,
+  getUploadRoot,
+  isFileExistsError,
+  isMissingFileError,
+  moveToUniqueUploadFile,
+  toSafeUploadFilename
+}


### PR DESCRIPTION
## Problem

The 1,852-line Upload Repository still owns active remote/local transfer maps, chunk offset/write
serialization, cancellation, staging cleanup and transfer-to-pending finalization alongside durable
Session publication, managed preview and legacy recovery. The live transfer state needs one explicit
owner protected by UP0 contracts.

## Proposed change

- Extract one internal active-transfer owner for begin/append/status/finish/abort and local-file
  streaming into the pending upload namespace.
- Keep `UploadRepository` as the stable public facade and delegate each existing transfer method.
- Move pure filename/status/size calculations and filesystem primitives to stateless internal helpers
  only when needed to keep every newly extracted production module <=660 lines; the legacy facade
  continues shrinking in UP2/UP3.
- Register extracted files under the existing `upload_repository` module-impact owner.

## Scope and non-goals

- Internal ownership extraction only; no public method or caller migration.
- No upload ID, checksum, chunk/size limit, offset, staging/pending layout, atomic rename, retry,
  cancellation, cleanup or progress semantic change.
- No pending-to-durable Session publication/managed resolver extraction (UP2) and no legacy recovery
  extraction (UP3).
- No IPC/preload/data model/UI/MCP/cross-surface capability change.

## Compatibility

- Preserve synchronous registration-before-await, single-writer behavior, idempotent status/abort,
  incomplete-transfer resumability and failure cleanup boundaries.
- Preserve Electron/Web/CLI/Task/local-RPC/MCP behavior and Specialist/Permission/Compute asymmetry.
- Use `node:path` and repository-owned temporary roots; tests remain portable on Windows, macOS and
  Linux.

## Acceptance criteria and validation

- Exactly one owner holds both remote and local active-transfer mutable state; facade has no shadow
  maps, duplicate cancellation or cleanup decisions.
- Every new production module is <=660 lines and the final facade/owner counts are reported.
- UP0 characterization, upload repository/IPC/command, persistence deletion and ACP consumers,
  module-impact validation, Node/Web typecheck, lint/format and independent Standards/Spec pass.
- Exact-head PR Gate, CI Integrity, CodeQL and AI pass before squash merge.

Implementation evidence before final rebase:

- `repository.ts`: 1,852 -> 1,448 raw lines; stable public facade retained.
- `active-transfer-owner.ts`: 391 raw lines; sole owner of both active transfer maps and staging
  readiness.
- `storage-helpers.ts`: 156 raw lines; stateless path, filename, move and attachment helpers.
- Final module-impact selection: 7 files / 92 tests pass, including persistence deletion and ACP
  resolver/prompt consumers.
- ACP file resolver, prompt owner and runtime: 459 tests pass (three loopback cases required a
  precise out-of-sandbox rerun after local `EPERM`).
- Node/Web typecheck, no-cache ESLint, Prettier and diff-check pass.
- Standards review initially found the module-impact consumer set too narrow; adding the ACP file
  resolver and prompt owner tests closed the P1, and Standards re-review plus Spec review completed
  with 0 findings.

## Review focus

- Confirm chunk/write/cancel races and cleanup order are byte-for-byte compatible.
- Confirm finish moves only complete transfers to the same pending namespace and failure remains
  retryable where the baseline was retryable.
- Confirm durable publication, preview and legacy responsibilities remain outside this owner.
