### PR TITLE
README SEO/GEO polish: answer-first leads

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Open Science is an independent product built from scratch. It is not a proxy, un
 
 ## Design Principles
 
+Open Science is shaped by a small set of principles that govern how code, data, models, and human oversight fit together.
+
 - **Open by default.** Source code, formats, connectors, and skills should remain inspectable and forkable.
 - **Multi-provider with explicit compatibility.** The app validates provider configuration and makes endpoint requirements visible instead of treating every API protocol as interchangeable.
 - **Local-first and data-aware.** Keep project state local, surface external data flows, and make autonomy opt-in.
@@ -161,7 +163,7 @@ Open Science is an independent product built from scratch. It is not a proxy, un
 
 ## Core Capabilities
 
-This section describes durable product capabilities rather than a version-specific inventory. The installed app and [latest release notes](https://github.com/aipoch/open-science/releases/latest) are the source of truth for changing catalogs, packaging details, and newly added options.
+Open Science combines project management, multi-model agent execution, Python and R notebooks, scientific data connectors, immutable artifact versions with provenance, and permissioned human-in-the-loop control in one local workspace. The installed app and [latest release notes](https://github.com/aipoch/open-science/releases/latest) are the source of truth for changing catalogs, packaging details, and newly added options.
 
 | Area                         | Core capability                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -324,6 +326,8 @@ The product roadmap and capability status are maintained in [ROADMAP.md](ROADMAP
 Skills and connectors can execute code or send data externally. Review their source, license, scripts, and network behavior before enabling them.
 
 ## What This Is Not
+
+Open Science is a research execution and record-keeping tool, not a generic chat wrapper, unofficial client, or substitute for scientific review.
 
 - **Not just a chat UI.** The product is organized around persistent projects, execution, files, artifacts, and reviewable tool activity.
 - **Not an unofficial client for another product.** It is an independent implementation with its own codebase, data model, interface, and roadmap.


### PR DESCRIPTION
## Summary

Documentation-only, content-preserving README polish. Adds answer-first lead sentences to three major sections so AI engines and readers can extract a one-sentence summary before context/detail.

## Changes grouped by checklist item

- **Answer-first section leads**
  - **Design Principles**: added a concise lead explaining that the section covers the principles shaping code, data, models, and human oversight.
  - **Core Capabilities**: replaced the meta opening sentence with a direct summary of the capability areas (project management, multi-model execution, Python/R notebooks, connectors, provenance, permissions).
  - **What This Is Not**: added a lead stating the product is a research execution/record-keeping tool rather than a chat wrapper, unofficial client, or substitute for scientific review.

## Removed line

The following stale meta-line was replaced by the new Core Capabilities lead:

- `This section describes durable product capabilities rather than a version-specific inventory.`

No product claims were added or dropped.