### PR TITLE
refactor(project-files): extract query owner

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -119,6 +119,7 @@
       "ownerPaths": [
         "src/main/project-files/mutation-owner.ts",
         "src/main/project-files/mutation-projection.ts",
+        "src/main/project-files/query-owner.ts",
         "src/main/project-files/query-support.ts",
         "src/main/project-files/repository.ts"
       ],

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -1,0 +1,333 @@
+import { Prisma, type ManagedFile } from '@prisma/client'
+
+import type {
+  ArtifactGroupPage,
+  GetProjectFilesOverviewRequest,
+  ListArtifactGroupsRequest,
+  ListProjectFilesRequest,
+  ProjectFileItem,
+  ProjectFilesOverview,
+  ProjectFilesPage,
+  SearchArtifactsRequest,
+  SearchArtifactsResult
+} from '../../shared/project-files'
+import type { ProjectFilesClientProvider } from './mutation-projection'
+import {
+  countMatchingArtifacts,
+  decodeFileCursor,
+  decodeGroupCursor,
+  decodeSearchArtifactCursor,
+  encodeCursor,
+  getMatchingOverviewCounts,
+  listMatchingArtifactGroups,
+  listMatchingArtifacts,
+  listMatchingFiles,
+  listOtherProjectArtifacts,
+  normalizeLimit,
+  normalizeSearch,
+  requireIdentifier,
+  toOriginProjection,
+  toProjectFileItem,
+  toSafeCount
+} from './query-support'
+
+type ProjectFilesIndexCompletenessReader = (projectId: string) => boolean
+
+// Owns the read-model orchestration while completeness remains authoritative in the mutation owner.
+class ProjectFilesQueryOwner {
+  constructor(
+    private readonly getClient: ProjectFilesClientProvider,
+    private readonly dataRoot: string,
+    private readonly readIndexComplete: ProjectFilesIndexCompletenessReader
+  ) {}
+
+  async getOverview(
+    request: string | GetProjectFilesOverviewRequest
+  ): Promise<ProjectFilesOverview> {
+    const { projectId, search: rawSearch } =
+      typeof request === 'string' ? { projectId: request, search: undefined } : request
+    requireIdentifier(projectId, 'projectId')
+    const search = normalizeSearch(rawSearch)
+    const client = await this.getClient()
+    const [totalCount, uploadCount, artifactCount, artifactGroupCount] = search
+      ? await getMatchingOverviewCounts(client, projectId, search)
+      : await Promise.all([
+          client.managedFile.count({ where: { projectId, deletedAt: null } }),
+          client.managedFile.count({ where: { projectId, source: 'upload', deletedAt: null } }),
+          client.managedFile.count({ where: { projectId, source: 'artifact', deletedAt: null } }),
+          client.managedFileSessionSync.count({
+            where: { projectId, deletedAt: null, artifactCount: { gt: 0 } }
+          })
+        ])
+
+    return {
+      totalCount,
+      uploadCount,
+      artifactCount,
+      artifactGroupCount,
+      isIndexComplete: this.readIndexComplete(projectId)
+    }
+  }
+
+  async listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage> {
+    requireIdentifier(request.projectId, 'projectId')
+    const collection = request.collection as { kind?: unknown; sessionId?: unknown }
+    let normalizedCollection: ListProjectFilesRequest['collection']
+    if (collection.kind === 'all') {
+      normalizedCollection = { kind: 'all' }
+    } else if (collection.kind === 'uploads') {
+      normalizedCollection = { kind: 'uploads' }
+    } else if (collection.kind === 'sessionArtifacts' && typeof collection.sessionId === 'string') {
+      requireIdentifier(collection.sessionId, 'sessionId')
+      normalizedCollection = { kind: 'sessionArtifacts', sessionId: collection.sessionId }
+    } else {
+      throw new Error('Project files collection is invalid.')
+    }
+    const normalizedRequest = { ...request, collection: normalizedCollection }
+    const client = await this.getClient()
+    const limit = normalizeLimit(request.limit)
+    const search = normalizeSearch(request.search)
+    const source =
+      normalizedCollection.kind === 'all'
+        ? undefined
+        : normalizedCollection.kind === 'uploads'
+          ? 'upload'
+          : 'artifact'
+    const sessionId =
+      normalizedCollection.kind === 'sessionArtifacts' ? normalizedCollection.sessionId : undefined
+    if (sessionId && search?.excludedSessionIds.includes(sessionId)) {
+      return { items: [], totalCount: 0 }
+    }
+    const cursor = request.cursor ? decodeFileCursor(request.cursor, normalizedRequest) : undefined
+    const where: Prisma.ManagedFileWhereInput = {
+      projectId: request.projectId,
+      ...(source ? { source } : {}),
+      deletedAt: null,
+      ...(sessionId !== undefined
+        ? { sessionId }
+        : search?.excludedSessionIds.length
+          ? { sessionId: { notIn: search.excludedSessionIds } }
+          : {}),
+      ...(cursor
+        ? {
+            OR: [
+              { sortAtMs: { lt: BigInt(cursor.sortAtMs) } },
+              { sortAtMs: BigInt(cursor.sortAtMs), seq: { lt: cursor.seq } }
+            ]
+          }
+        : {})
+    }
+    const [rows, totalCount] = search
+      ? await listMatchingFiles(client, request.projectId, source, sessionId, search, cursor, limit)
+      : await Promise.all([
+          client.managedFile.findMany({
+            where,
+            orderBy: [{ sortAtMs: 'desc' }, { seq: 'desc' }],
+            take: limit + 1
+          }),
+          client.managedFile.count({
+            where: {
+              projectId: request.projectId,
+              ...(source ? { source } : {}),
+              deletedAt: null,
+              ...(sessionId !== undefined ? { sessionId } : {})
+            }
+          })
+        ])
+    const pageRows = rows.slice(0, limit)
+    const lastRow = pageRows.at(-1)
+    const origins = await client.fileOriginSession.findMany({
+      where: {
+        projectId: request.projectId,
+        sessionId: { in: [...new Set(pageRows.map((row) => row.sessionId))] }
+      }
+    })
+    const originsBySession = new Map(origins.map((origin) => [origin.sessionId, origin]))
+
+    return {
+      items: pageRows.map((row) =>
+        toProjectFileItem(row, this.dataRoot, originsBySession.get(row.sessionId))
+      ),
+      totalCount,
+      nextCursor:
+        rows.length > limit && lastRow
+          ? encodeCursor({
+              version: 2,
+              kind: normalizedCollection.kind,
+              projectId: request.projectId,
+              sessionId,
+              queryKey: search?.queryKey ?? '',
+              sortAtMs: lastRow.sortAtMs.toString(),
+              seq: lastRow.seq
+            })
+          : undefined
+    }
+  }
+
+  async searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult> {
+    requireIdentifier(request.primaryProjectId, 'primaryProjectId')
+    if (!Array.isArray(request.otherProjectIds)) {
+      throw new Error('Project files otherProjectIds must be an array.')
+    }
+    const otherProjectIds = [...new Set(request.otherProjectIds)]
+      .filter((projectId) => projectId !== request.primaryProjectId)
+      .map((projectId) => {
+        requireIdentifier(projectId, 'otherProjectId')
+        return projectId
+      })
+    if (!Number.isInteger(request.otherLimit) || request.otherLimit < 0 || request.otherLimit > 5) {
+      throw new Error('Project files otherLimit must be between 0 and 5.')
+    }
+
+    const primaryLimit = normalizeLimit(request.primaryLimit)
+    const search = normalizeSearch({
+      filenameContains: request.filenameContains ?? '',
+      ...(request.excludedSessionIds === undefined
+        ? {}
+        : { excludedSessionIds: request.excludedSessionIds })
+    })
+    const cursor = request.primaryCursor
+      ? decodeSearchArtifactCursor(request.primaryCursor, request.primaryProjectId, search)
+      : undefined
+    const client = await this.getClient()
+    const excludedSessionIds = search?.excludedSessionIds ?? []
+    const [primaryRows, primaryTotalCount, otherRows] = await Promise.all([
+      listMatchingArtifacts(
+        client,
+        request.primaryProjectId,
+        search,
+        excludedSessionIds,
+        cursor,
+        primaryLimit
+      ),
+      countMatchingArtifacts(client, request.primaryProjectId, search, excludedSessionIds),
+      request.otherLimit > 0 && otherProjectIds.length > 0
+        ? listOtherProjectArtifacts(
+            client,
+            otherProjectIds,
+            search,
+            excludedSessionIds,
+            request.otherLimit
+          )
+        : Promise.resolve([])
+    ])
+    const primaryPageRows = primaryRows.slice(0, primaryLimit)
+    const lastPrimaryRow = primaryPageRows.at(-1)
+    const rows = [...primaryPageRows, ...otherRows]
+    const origins =
+      rows.length === 0
+        ? []
+        : await client.fileOriginSession.findMany({
+            where: {
+              OR: [
+                ...new Map(rows.map((row) => [`${row.projectId}:${row.sessionId}`, row])).values()
+              ].map((row) => ({ projectId: row.projectId, sessionId: row.sessionId }))
+            }
+          })
+    const originsBySession = new Map(
+      origins.map((origin) => [`${origin.projectId}:${origin.sessionId}`, origin])
+    )
+    const toItem = (row: ManagedFile): ProjectFileItem =>
+      toProjectFileItem(
+        row,
+        this.dataRoot,
+        originsBySession.get(`${row.projectId}:${row.sessionId}`)
+      )
+
+    return {
+      primary: {
+        items: primaryPageRows.map(toItem),
+        totalCount: primaryTotalCount,
+        nextCursor:
+          primaryRows.length > primaryLimit && lastPrimaryRow
+            ? encodeCursor({
+                version: 2,
+                kind: 'globalArtifacts',
+                primaryProjectId: request.primaryProjectId,
+                queryKey: search?.queryKey ?? '',
+                sortAtMs: lastPrimaryRow.sortAtMs.toString(),
+                seq: lastPrimaryRow.seq
+              })
+            : undefined
+      },
+      other: otherRows.map(toItem),
+      isIndexComplete: [request.primaryProjectId, ...otherProjectIds].every((projectId) =>
+        this.readIndexComplete(projectId)
+      )
+    }
+  }
+
+  async listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage> {
+    requireIdentifier(request.projectId, 'projectId')
+    const client = await this.getClient()
+    const limit = normalizeLimit(request.limit)
+    const search = normalizeSearch(request.search)
+    const cursor = request.cursor ? decodeGroupCursor(request.cursor, request) : undefined
+    const groupWhere: Prisma.ManagedFileSessionSyncWhereInput = {
+      projectId: request.projectId,
+      deletedAt: null,
+      artifactCount: { gt: 0 },
+      ...(search?.excludedSessionIds.length
+        ? { sessionId: { notIn: search.excludedSessionIds } }
+        : {})
+    }
+    const where: Prisma.ManagedFileSessionSyncWhereInput = {
+      ...groupWhere,
+      ...(cursor
+        ? {
+            OR: [
+              { groupSortAtMs: { lt: BigInt(cursor.groupSortAtMs) } },
+              {
+                groupSortAtMs: BigInt(cursor.groupSortAtMs),
+                sessionId: { lt: cursor.sessionId }
+              }
+            ]
+          }
+        : {})
+    }
+    const [rows, totalCount] = search
+      ? await listMatchingArtifactGroups(client, request.projectId, search, cursor, limit)
+      : await Promise.all([
+          client.managedFileSessionSync.findMany({
+            where,
+            orderBy: [{ groupSortAtMs: 'desc' }, { sessionId: 'desc' }],
+            take: limit + 1
+          }),
+          client.managedFileSessionSync.count({
+            where: groupWhere
+          })
+        ])
+    const pageRows = rows.slice(0, limit)
+    const lastRow = pageRows.at(-1)
+    const origins = await client.fileOriginSession.findMany({
+      where: {
+        projectId: request.projectId,
+        sessionId: { in: pageRows.map((row) => row.sessionId) }
+      }
+    })
+    const originsBySession = new Map(origins.map((origin) => [origin.sessionId, origin]))
+
+    return {
+      items: pageRows.map((row) => ({
+        sessionId: row.sessionId,
+        artifactCount: toSafeCount(row.artifactCount, 'artifact group count'),
+        ...toOriginProjection(originsBySession.get(row.sessionId))
+      })),
+      totalCount,
+      nextCursor:
+        rows.length > limit && lastRow
+          ? encodeCursor({
+              version: 2,
+              kind: 'artifactGroups',
+              projectId: request.projectId,
+              queryKey: search?.queryKey ?? '',
+              groupSortAtMs: lastRow.groupSortAtMs.toString(),
+              sessionId: lastRow.sessionId
+            })
+          : undefined
+    }
+  }
+}
+
+export { ProjectFilesQueryOwner }
+export type { ProjectFilesIndexCompletenessReader }

--- a/src/main/project-files/repository.architecture.test.ts
+++ b/src/main/project-files/repository.architecture.test.ts
@@ -8,8 +8,10 @@ import {
   getModifiers,
   isClassDeclaration,
   isConstructorDeclaration,
+  isExportDeclaration,
   isIdentifier,
   isMethodDeclaration,
+  isNamedExports,
   isNewExpression,
   isParameter,
   isPropertyDeclaration,
@@ -25,6 +27,7 @@ import { describe, expect, it } from 'vitest'
 const productionFiles = [
   'mutation-owner.ts',
   'mutation-projection.ts',
+  'query-owner.ts',
   'query-support.ts',
   'repository.ts'
 ] as const
@@ -102,10 +105,23 @@ const newExpressionSites = (sourceFile: SourceFile, className: string): string[]
   return sites
 }
 
+const namedExports = (sourceFile: SourceFile): string[] =>
+  sourceFile.statements
+    .filter(isExportDeclaration)
+    .flatMap((statement) =>
+      statement.exportClause && isNamedExports(statement.exportClause)
+        ? statement.exportClause.elements.map(
+            (element) => `${statement.isTypeOnly ? 'type' : 'value'}:${element.name.text}`
+          )
+        : []
+    )
+    .sort()
+
 describe('Project Files repository architecture', () => {
   const facadeFile = sourceFileFor('repository.ts')
   const facade = classFrom('repository.ts', 'ManagedFileIndexRepository')
-  const owner = classFrom('mutation-owner.ts', 'ProjectFilesMutationOwner')
+  const mutationOwner = classFrom('mutation-owner.ts', 'ProjectFilesMutationOwner')
+  const queryOwner = classFrom('query-owner.ts', 'ProjectFilesQueryOwner')
 
   it('keeps every production module within the completion gate', () => {
     for (const [file, source] of sources) {
@@ -132,15 +148,42 @@ describe('Project Files repository architecture', () => {
     )
   })
 
-  it('composes one mutation owner without shadow lifecycle state', () => {
+  it('keeps the established facade constructor, factory and export inventory', () => {
+    const constructors = facade.members.filter(isConstructorDeclaration)
+    expect(constructors).toHaveLength(1)
+    expect(constructors[0].parameters.map((parameter) => memberName(parameter.name))).toEqual([
+      'getClient',
+      'dataRoot'
+    ])
+    expect(newExpressionSites(facadeFile, 'ManagedFileIndexRepository')).toEqual([
+      'outside-constructor'
+    ])
+    expect(namedExports(facadeFile)).toEqual(
+      [
+        'value:createManagedFileIndexRepository',
+        'value:ManagedFileIndexRepository',
+        'type:ManagedFileSoftDeleteToken',
+        'type:ProjectFilesClient',
+        'type:ProjectFilesClientFactory',
+        'type:ProjectFilesClientProvider'
+      ].sort()
+    )
+  })
+
+  it('composes one mutation owner and one query owner without shadow lifecycle state', () => {
     expect(newExpressionSites(facadeFile, 'ProjectFilesMutationOwner')).toEqual(['constructor'])
-    expect(fields(facade)).toEqual(['dataRoot', 'getClient', 'mutationOwner'])
-    expect(fields(owner)).toEqual([
+    expect(newExpressionSites(facadeFile, 'ProjectFilesQueryOwner')).toEqual(['constructor'])
+    expect(fields(facade)).toEqual(['mutationOwner', 'queryOwner'])
+    expect(fields(mutationOwner)).toEqual([
       'dataRoot',
       'getClient',
       'incompleteSessions',
       'isReconciliationIncomplete'
     ])
+    expect(fields(queryOwner)).toEqual(['dataRoot', 'getClient', 'readIndexComplete'])
+    expect(publicMethods(queryOwner)).toEqual(
+      ['getOverview', 'listArtifactGroups', 'listFiles', 'searchArtifacts'].sort()
+    )
   })
 
   it('keeps Prisma writes and mutation state out of stateless support modules', () => {
@@ -149,5 +192,13 @@ describe('Project Files repository architecture', () => {
     expect(supportSource).not.toContain('incompleteSessions')
     expect(supportSource).not.toContain('isReconciliationIncomplete')
     expect(supportSource).not.toMatch(/from ['"].*\/repository['"]/)
+  })
+
+  it('keeps query orchestration read-only and completeness state in the mutation owner', () => {
+    const querySource = sources.get('query-owner.ts')!
+    expect(querySource).not.toMatch(/\.(?:create|delete|update|updateMany|upsert)\s*\(\s*\{/)
+    expect(querySource).not.toContain('incompleteSessions')
+    expect(querySource).not.toContain('isReconciliationIncomplete')
+    expect(querySource).not.toMatch(/from ['"].*\/repository['"]/)
   })
 })

--- a/src/main/project-files/repository.ts
+++ b/src/main/project-files/repository.ts
@@ -1,12 +1,9 @@
-import { Prisma, type ManagedFile } from '@prisma/client'
-
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import type {
   ArtifactGroupPage,
   GetProjectFilesOverviewRequest,
   ListArtifactGroupsRequest,
   ListProjectFilesRequest,
-  ProjectFileItem,
   ProjectFilesOverview,
   ProjectFilesPage,
   ProjectFileSource,
@@ -23,35 +20,19 @@ import type {
   ProjectFilesClientFactory,
   ProjectFilesClientProvider
 } from './mutation-projection'
-import {
-  countMatchingArtifacts,
-  decodeFileCursor,
-  decodeGroupCursor,
-  decodeSearchArtifactCursor,
-  encodeCursor,
-  getMatchingOverviewCounts,
-  listMatchingArtifactGroups,
-  listMatchingArtifacts,
-  listMatchingFiles,
-  listOtherProjectArtifacts,
-  normalizeLimit,
-  normalizeSearch,
-  requireIdentifier,
-  toOriginProjection,
-  toProjectFileItem,
-  toSafeCount
-} from './query-support'
+import { ProjectFilesQueryOwner } from './query-owner'
 
 // Stable public facade for the query-optimized Project Files projection. Session JSON remains
-// authoritative; one internal owner holds every mutation and completeness state transition.
+// authoritative; internal owners separate read orchestration from mutation/completeness state.
 class ManagedFileIndexRepository {
   private readonly mutationOwner: ProjectFilesMutationOwner
+  private readonly queryOwner: ProjectFilesQueryOwner
 
-  constructor(
-    private readonly getClient: ProjectFilesClientProvider,
-    private readonly dataRoot: string
-  ) {
+  constructor(getClient: ProjectFilesClientProvider, dataRoot: string) {
     this.mutationOwner = new ProjectFilesMutationOwner(getClient, dataRoot)
+    this.queryOwner = new ProjectFilesQueryOwner(getClient, dataRoot, (projectId) =>
+      this.mutationOwner.isIndexComplete(projectId)
+    )
   }
 
   syncSession(
@@ -92,288 +73,19 @@ class ManagedFileIndexRepository {
   async getOverview(
     request: string | GetProjectFilesOverviewRequest
   ): Promise<ProjectFilesOverview> {
-    const { projectId, search: rawSearch } =
-      typeof request === 'string' ? { projectId: request, search: undefined } : request
-    requireIdentifier(projectId, 'projectId')
-    const search = normalizeSearch(rawSearch)
-    const client = await this.getClient()
-    const [totalCount, uploadCount, artifactCount, artifactGroupCount] = search
-      ? await getMatchingOverviewCounts(client, projectId, search)
-      : await Promise.all([
-          client.managedFile.count({ where: { projectId, deletedAt: null } }),
-          client.managedFile.count({ where: { projectId, source: 'upload', deletedAt: null } }),
-          client.managedFile.count({ where: { projectId, source: 'artifact', deletedAt: null } }),
-          client.managedFileSessionSync.count({
-            where: { projectId, deletedAt: null, artifactCount: { gt: 0 } }
-          })
-        ])
-
-    return {
-      totalCount,
-      uploadCount,
-      artifactCount,
-      artifactGroupCount,
-      isIndexComplete: this.mutationOwner.isIndexComplete(projectId)
-    }
+    return this.queryOwner.getOverview(request)
   }
 
   async listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage> {
-    requireIdentifier(request.projectId, 'projectId')
-    const collection = request.collection as { kind?: unknown; sessionId?: unknown }
-    let normalizedCollection: ListProjectFilesRequest['collection']
-    if (collection.kind === 'all') {
-      normalizedCollection = { kind: 'all' }
-    } else if (collection.kind === 'uploads') {
-      normalizedCollection = { kind: 'uploads' }
-    } else if (collection.kind === 'sessionArtifacts' && typeof collection.sessionId === 'string') {
-      requireIdentifier(collection.sessionId, 'sessionId')
-      normalizedCollection = { kind: 'sessionArtifacts', sessionId: collection.sessionId }
-    } else {
-      throw new Error('Project files collection is invalid.')
-    }
-    const normalizedRequest = { ...request, collection: normalizedCollection }
-    const client = await this.getClient()
-    const limit = normalizeLimit(request.limit)
-    const search = normalizeSearch(request.search)
-    const source =
-      normalizedCollection.kind === 'all'
-        ? undefined
-        : normalizedCollection.kind === 'uploads'
-          ? 'upload'
-          : 'artifact'
-    const sessionId =
-      normalizedCollection.kind === 'sessionArtifacts' ? normalizedCollection.sessionId : undefined
-    if (sessionId && search?.excludedSessionIds.includes(sessionId)) {
-      return { items: [], totalCount: 0 }
-    }
-    const cursor = request.cursor ? decodeFileCursor(request.cursor, normalizedRequest) : undefined
-    const where: Prisma.ManagedFileWhereInput = {
-      projectId: request.projectId,
-      ...(source ? { source } : {}),
-      deletedAt: null,
-      ...(sessionId !== undefined
-        ? { sessionId }
-        : search?.excludedSessionIds.length
-          ? { sessionId: { notIn: search.excludedSessionIds } }
-          : {}),
-      ...(cursor
-        ? {
-            OR: [
-              { sortAtMs: { lt: BigInt(cursor.sortAtMs) } },
-              { sortAtMs: BigInt(cursor.sortAtMs), seq: { lt: cursor.seq } }
-            ]
-          }
-        : {})
-    }
-    const [rows, totalCount] = search
-      ? await listMatchingFiles(client, request.projectId, source, sessionId, search, cursor, limit)
-      : await Promise.all([
-          client.managedFile.findMany({
-            where,
-            orderBy: [{ sortAtMs: 'desc' }, { seq: 'desc' }],
-            take: limit + 1
-          }),
-          client.managedFile.count({
-            where: {
-              projectId: request.projectId,
-              ...(source ? { source } : {}),
-              deletedAt: null,
-              ...(sessionId !== undefined ? { sessionId } : {})
-            }
-          })
-        ])
-    const pageRows = rows.slice(0, limit)
-    const lastRow = pageRows.at(-1)
-    const origins = await client.fileOriginSession.findMany({
-      where: {
-        projectId: request.projectId,
-        sessionId: { in: [...new Set(pageRows.map((row) => row.sessionId))] }
-      }
-    })
-    const originsBySession = new Map(origins.map((origin) => [origin.sessionId, origin]))
-
-    return {
-      items: pageRows.map((row) =>
-        toProjectFileItem(row, this.dataRoot, originsBySession.get(row.sessionId))
-      ),
-      totalCount,
-      nextCursor:
-        rows.length > limit && lastRow
-          ? encodeCursor({
-              version: 2,
-              kind: normalizedCollection.kind,
-              projectId: request.projectId,
-              sessionId,
-              queryKey: search?.queryKey ?? '',
-              sortAtMs: lastRow.sortAtMs.toString(),
-              seq: lastRow.seq
-            })
-          : undefined
-    }
+    return this.queryOwner.listFiles(request)
   }
 
   async searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult> {
-    requireIdentifier(request.primaryProjectId, 'primaryProjectId')
-    if (!Array.isArray(request.otherProjectIds)) {
-      throw new Error('Project files otherProjectIds must be an array.')
-    }
-    const otherProjectIds = [...new Set(request.otherProjectIds)]
-      .filter((projectId) => projectId !== request.primaryProjectId)
-      .map((projectId) => {
-        requireIdentifier(projectId, 'otherProjectId')
-        return projectId
-      })
-    if (!Number.isInteger(request.otherLimit) || request.otherLimit < 0 || request.otherLimit > 5) {
-      throw new Error('Project files otherLimit must be between 0 and 5.')
-    }
-
-    const primaryLimit = normalizeLimit(request.primaryLimit)
-    const search = normalizeSearch({
-      filenameContains: request.filenameContains ?? '',
-      ...(request.excludedSessionIds === undefined
-        ? {}
-        : { excludedSessionIds: request.excludedSessionIds })
-    })
-    const cursor = request.primaryCursor
-      ? decodeSearchArtifactCursor(request.primaryCursor, request.primaryProjectId, search)
-      : undefined
-    const client = await this.getClient()
-    const excludedSessionIds = search?.excludedSessionIds ?? []
-    const [primaryRows, primaryTotalCount, otherRows] = await Promise.all([
-      listMatchingArtifacts(
-        client,
-        request.primaryProjectId,
-        search,
-        excludedSessionIds,
-        cursor,
-        primaryLimit
-      ),
-      countMatchingArtifacts(client, request.primaryProjectId, search, excludedSessionIds),
-      request.otherLimit > 0 && otherProjectIds.length > 0
-        ? listOtherProjectArtifacts(
-            client,
-            otherProjectIds,
-            search,
-            excludedSessionIds,
-            request.otherLimit
-          )
-        : Promise.resolve([])
-    ])
-    const primaryPageRows = primaryRows.slice(0, primaryLimit)
-    const lastPrimaryRow = primaryPageRows.at(-1)
-    const rows = [...primaryPageRows, ...otherRows]
-    const origins =
-      rows.length === 0
-        ? []
-        : await client.fileOriginSession.findMany({
-            where: {
-              OR: [
-                ...new Map(rows.map((row) => [`${row.projectId}:${row.sessionId}`, row])).values()
-              ].map((row) => ({ projectId: row.projectId, sessionId: row.sessionId }))
-            }
-          })
-    const originsBySession = new Map(
-      origins.map((origin) => [`${origin.projectId}:${origin.sessionId}`, origin])
-    )
-    const toItem = (row: ManagedFile): ProjectFileItem =>
-      toProjectFileItem(
-        row,
-        this.dataRoot,
-        originsBySession.get(`${row.projectId}:${row.sessionId}`)
-      )
-
-    return {
-      primary: {
-        items: primaryPageRows.map(toItem),
-        totalCount: primaryTotalCount,
-        nextCursor:
-          primaryRows.length > primaryLimit && lastPrimaryRow
-            ? encodeCursor({
-                version: 2,
-                kind: 'globalArtifacts',
-                primaryProjectId: request.primaryProjectId,
-                queryKey: search?.queryKey ?? '',
-                sortAtMs: lastPrimaryRow.sortAtMs.toString(),
-                seq: lastPrimaryRow.seq
-              })
-            : undefined
-      },
-      other: otherRows.map(toItem),
-      isIndexComplete: [request.primaryProjectId, ...otherProjectIds].every((projectId) =>
-        this.mutationOwner.isIndexComplete(projectId)
-      )
-    }
+    return this.queryOwner.searchArtifacts(request)
   }
 
   async listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage> {
-    requireIdentifier(request.projectId, 'projectId')
-    const client = await this.getClient()
-    const limit = normalizeLimit(request.limit)
-    const search = normalizeSearch(request.search)
-    const cursor = request.cursor ? decodeGroupCursor(request.cursor, request) : undefined
-    const groupWhere: Prisma.ManagedFileSessionSyncWhereInput = {
-      projectId: request.projectId,
-      deletedAt: null,
-      artifactCount: { gt: 0 },
-      ...(search?.excludedSessionIds.length
-        ? { sessionId: { notIn: search.excludedSessionIds } }
-        : {})
-    }
-    const where: Prisma.ManagedFileSessionSyncWhereInput = {
-      ...groupWhere,
-      ...(cursor
-        ? {
-            OR: [
-              { groupSortAtMs: { lt: BigInt(cursor.groupSortAtMs) } },
-              {
-                groupSortAtMs: BigInt(cursor.groupSortAtMs),
-                sessionId: { lt: cursor.sessionId }
-              }
-            ]
-          }
-        : {})
-    }
-    const [rows, totalCount] = search
-      ? await listMatchingArtifactGroups(client, request.projectId, search, cursor, limit)
-      : await Promise.all([
-          client.managedFileSessionSync.findMany({
-            where,
-            orderBy: [{ groupSortAtMs: 'desc' }, { sessionId: 'desc' }],
-            take: limit + 1
-          }),
-          client.managedFileSessionSync.count({
-            where: groupWhere
-          })
-        ])
-    const pageRows = rows.slice(0, limit)
-    const lastRow = pageRows.at(-1)
-    const origins = await client.fileOriginSession.findMany({
-      where: {
-        projectId: request.projectId,
-        sessionId: { in: pageRows.map((row) => row.sessionId) }
-      }
-    })
-    const originsBySession = new Map(origins.map((origin) => [origin.sessionId, origin]))
-
-    return {
-      items: pageRows.map((row) => ({
-        sessionId: row.sessionId,
-        artifactCount: toSafeCount(row.artifactCount, 'artifact group count'),
-        ...toOriginProjection(originsBySession.get(row.sessionId))
-      })),
-      totalCount,
-      nextCursor:
-        rows.length > limit && lastRow
-          ? encodeCursor({
-              version: 2,
-              kind: 'artifactGroups',
-              projectId: request.projectId,
-              queryKey: search?.queryKey ?? '',
-              groupSortAtMs: lastRow.groupSortAtMs.toString(),
-              sessionId: lastRow.sessionId
-            })
-          : undefined
-    }
+    return this.queryOwner.listArtifactGroups(request)
   }
 }
 


### PR DESCRIPTION
## Problem

After FI1, the Project Files Repository facade is within the line gate but still owns all
overview/list/search/group query orchestration while its mutation lifecycle has one explicit owner.
The read model needs an equally explicit owner so facade composition and state ownership are final.

## Proposed change

- Extract one internal query/read-model owner for `getOverview`, `listFiles`, `searchArtifacts` and
  `listArtifactGroups`.
- Keep the existing stateless `query-support.ts` SQL/cursor/DTO helpers and the FI1 mutation owner;
  the facade constructs each owner exactly once and delegates all 11 existing public methods.
- Supply index-completeness through a narrow internal callback/interface so the query owner does not
  duplicate or mutate reconciliation state.
- Extend the architecture contract and module-impact registration to certify final composition,
  public inventory and line gates.

## Scope and non-goals

- Internal ownership cutover and certification only; no public repository, factory, export, IPC or
  caller migration.
- No Prisma schema/row/migration, SQL predicate, cursor, pagination, exclusion, grouping, revision,
  token, event or transaction change.
- No new cache/store or duplicated completeness state.
- No data model, UI, MCP or cross-surface capability change.

## Compatibility

- Preserve every query's validation, ASCII folding, count/page consistency, cursor identity/keyset,
  cross-project search ordering, Artifact grouping and renderer-safe path/version DTO behavior.
- Preserve the mutation owner's authoritative completeness semantics in `getOverview`.
- Preserve Electron/Web/CLI/Task/local-RPC/MCP behavior and Specialist/Permission/Compute asymmetry.
- Keep Prisma fixtures and filesystem paths portable on Windows, macOS and Linux.

## Acceptance criteria and validation

- Exactly one query owner orchestrates all four public read methods, exactly one mutation owner owns
  writes/completeness, and the facade contains composition/delegation only.
- Every production module is <=660 raw lines; final facade/owner/helper counts are reported.
- FI0/FI1 characterization and architecture tests, repository/IPC and session-persistence consumers,
  module-impact validation, Node typecheck, lint/format and independent Standards/Spec pass.
- Exact-head PR Gate, CI Integrity, CodeQL and AI pass before squash merge.

Implementation evidence before final rebase:

- `repository.ts`: 393 -> 105 raw lines; stable constructor/factory/export inventory and all 11
  public methods remain as composition/delegation.
- `query-owner.ts`: 333 raw lines; sole overview/list/search/group orchestrator with only
  `getClient`, `dataRoot` and a narrow completeness read callback.
- Existing mutation owner/projection/query support remain 496/476/530 raw lines, all <=660; mutation
  owner remains the only completeness-state and Prisma-write owner.
- Final module-impact selection: 6 files / 182 tests pass; module-impact validator 7/7, Node
  typecheck, targeted ESLint, Prettier and diff-check pass.
- Independent Standards and Spec reviews completed with 0 findings.

## Review focus

- Confirm query SQL, cursor and DTO behavior is byte-for-byte compatible.
- Confirm `isIndexComplete` still reflects only mutation/reconciliation state with no shadow cache.
- Confirm facade constructor/factory/public/export inventory and all public/data/cross-surface behavior
  are unchanged.
