### PR TITLE
refactor(uploads): extract legacy recovery owners

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -93,16 +93,19 @@
       "ownerPaths": [
         "src/main/uploads/repository.ts",
         "src/main/uploads/active-transfer-owner.ts",
+        "src/main/uploads/legacy-recovery-owner.ts",
         "src/main/uploads/managed-upload-resolver.ts",
         "src/main/uploads/staged-publication-owner.ts",
-        "src/main/uploads/storage-helpers.ts"
+        "src/main/uploads/storage-helpers.ts",
+        "src/main/uploads/verified-legacy-cleanup-owner.ts"
       ],
       "interfacePaths": ["src/main/uploads/repository.ts"],
       "consumerModules": ["session_persistence"],
       "testFiles": {
         "owner": [
           "src/main/uploads/repository.test.ts",
-          "src/main/uploads/repository.characterization.test.ts"
+          "src/main/uploads/repository.characterization.test.ts",
+          "src/main/uploads/repository.architecture.test.ts"
         ],
         "contract": ["src/main/uploads/ipc.test.ts", "src/main/uploads/command-owner.test.ts"],
         "consumer": [

--- a/src/main/uploads/legacy-recovery-owner.ts
+++ b/src/main/uploads/legacy-recovery-owner.ts
@@ -1,0 +1,477 @@
+import { constants, createReadStream } from 'node:fs'
+import { copyFile, lstat, mkdir, readdir, rename, rm, stat } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { createHash } from 'node:crypto'
+
+import type { PrismaClient } from '@prisma/client'
+
+import {
+  PENDING_UPLOAD_SESSION_ID,
+  toPersistedUploadedAttachment,
+  toRuntimeUploadedAttachment,
+  type DeleteUploadRequest,
+  type PersistedUploadedAttachment,
+  type UploadedAttachment
+} from '../../shared/uploads'
+import type { PersistedChatMessage, PersistedChatSession } from '../../shared/session-persistence'
+import {
+  OrphanLegacyUploadAuthorityMissingError,
+  type PublicationOptions,
+  type UploadVersionRecord
+} from './staged-publication-owner'
+import {
+  UPLOADS_DIR,
+  assertPathInsideRoot,
+  assertSafePathSegment,
+  getSessionUploadDir,
+  isMissingFileError
+} from './storage-helpers'
+import type {
+  LegacyCleanupResult,
+  RemoveVerifiedLegacyCopyInput,
+  VerifiedLegacyCleanupOwner
+} from './verified-legacy-cleanup-owner'
+
+const LIVE_COPY_TEMP_SUFFIX = '.live-copy.tmp'
+
+type LegacyRecoveryOptions = {
+  getClient?: () => Promise<PrismaClient>
+}
+
+type LegacyUploadUpgradeOptions = {
+  // Live callers cannot prove that every renderer has applied the returned path-free projection.
+  // Orphan recovery also preserves the source but may only reuse pre-existing durable authority.
+  mode?: 'reconcile' | 'live-save' | 'orphan-recovery' | 'terminal-delete'
+}
+
+type LegacyRecoveryDependencies = {
+  resolveManagedUploadPath: (request: DeleteUploadRequest) => Promise<string>
+  finalizeSessionUploads: (
+    sessionId: string,
+    attachments: UploadedAttachment[],
+    projectId: string,
+    options?: PublicationOptions
+  ) => Promise<UploadedAttachment[]>
+  cleanup: Pick<
+    VerifiedLegacyCleanupOwner,
+    'assertLegacySourceAbsent' | 'hasPrivateClaim' | 'removeVerifiedLegacyCopy'
+  >
+}
+
+const sha256File = async (filePath: string): Promise<string> => {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk)
+  return hash.digest('hex')
+}
+
+// Sibling publication must settle before an orphan-recovery failure escapes, otherwise a late
+// sibling could reactivate ManagedFile rows after its caller has soft-deleted the Project index.
+const settleSiblingOperations = async <Value>(operations: Promise<Value>[]): Promise<Value[]> => {
+  const settled = await Promise.allSettled(operations)
+  const failures = settled.filter(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  )
+  const failure =
+    failures.find(
+      (result) => !(result.reason instanceof OrphanLegacyUploadAuthorityMissingError)
+    ) ?? failures[0]
+  if (failure) throw failure.reason
+  return settled.map((result) => (result as PromiseFulfilledResult<Value>).value)
+}
+
+// Sole owner of legacy Session validation, upgrade, orphan authority and staging crash recovery.
+class LegacyRecoveryOwner {
+  constructor(
+    private readonly storageRoot: string,
+    private readonly options: LegacyRecoveryOptions,
+    private readonly dependencies: LegacyRecoveryDependencies
+  ) {}
+
+  async upgradeLegacySessionUploads(
+    session: PersistedChatSession,
+    options: LegacyUploadUpgradeOptions = {}
+  ): Promise<PersistedChatSession> {
+    this.assertConsistentSessionUploadReferences(session)
+    const isLiveSave = options.mode === 'live-save' || options.mode === 'orphan-recovery'
+    const requireExistingAuthority = options.mode === 'orphan-recovery'
+    const isTerminalDelete = options.mode === 'terminal-delete'
+    const upgrades = new Map<string, Promise<PersistedUploadedAttachment | undefined>>()
+    const reconciliations = new Map<string, Promise<LegacyCleanupResult>>()
+    const upgrade = async (
+      upload: PersistedUploadedAttachment
+    ): Promise<PersistedUploadedAttachment | undefined> => {
+      if (upload.versionId) {
+        const persisted = toPersistedUploadedAttachment(
+          toRuntimeUploadedAttachment(upload, session.projectId)
+        )
+        if (isLiveSave) return persisted
+        const reconciliationKey = `${upload.id}:${upload.versionId}`
+        let reconciliation = reconciliations.get(reconciliationKey)
+        if (!reconciliation) {
+          reconciliation = this.dependencies.cleanup.removeVerifiedLegacyCopy({
+            projectId: session.projectId,
+            sessionId: upload.sessionId,
+            uploadFileId: upload.id,
+            versionId: upload.versionId,
+            filename: upload.name
+          })
+          reconciliations.set(reconciliationKey, reconciliation)
+        }
+        return reconciliation.then(async (cleanup) => {
+          if (isTerminalDelete) {
+            await this.dependencies.cleanup.assertLegacySourceAbsent(
+              upload.sessionId,
+              upload.name,
+              cleanup
+            )
+          }
+          return persisted
+        })
+      }
+
+      const existing = upgrades.get(upload.id)
+      if (existing) return existing
+      const operation = (async () => {
+        if (!upload.path) throw new Error(`Legacy upload has no recoverable path: ${upload.id}`)
+        const [finalized] = await this.dependencies.finalizeSessionUploads(
+          session.id,
+          [toRuntimeUploadedAttachment(upload, session.projectId)],
+          session.projectId,
+          { preserveLegacySource: isLiveSave, requireExistingAuthority }
+        )
+        if (!finalized) return undefined
+        if (isTerminalDelete) {
+          await this.dependencies.cleanup.assertLegacySourceAbsent(upload.sessionId, upload.name, {
+            status: 'absent'
+          })
+        }
+        return toPersistedUploadedAttachment(finalized)
+      })()
+      upgrades.set(upload.id, operation)
+      return operation
+    }
+    const upgradeMessage = async <Message extends PersistedChatMessage>(
+      message: Message
+    ): Promise<Message> => {
+      if (!message.uploads?.length) return message
+      const uploads = (await settleSiblingOperations(message.uploads.map(upgrade))).filter(
+        (upload): upload is PersistedUploadedAttachment => upload !== undefined
+      )
+      return { ...message, uploads } as Message
+    }
+    const messagesOperation = settleSiblingOperations(session.messages.map(upgradeMessage))
+    const graphMessagesOperation = session.conversationGraph
+      ? settleSiblingOperations(session.conversationGraph.messages.map(upgradeMessage))
+      : undefined
+    await settleSiblingOperations<unknown>([
+      messagesOperation,
+      ...(graphMessagesOperation ? [graphMessagesOperation] : [])
+    ])
+    const messages = await messagesOperation
+    const graphMessages = await graphMessagesOperation
+
+    return {
+      ...session,
+      messages,
+      ...(session.conversationGraph
+        ? { conversationGraph: { ...session.conversationGraph, messages: graphMessages! } }
+        : {})
+    }
+  }
+
+  // Operation sharing is safe only after every occurrence across the flat transcript and graph has
+  // proven the same immutable identity, before database or filesystem work begins.
+  private assertConsistentSessionUploadReferences(session: PersistedChatSession): void {
+    const identities = new Map<string, string>()
+    const messages = [...session.messages, ...(session.conversationGraph?.messages ?? [])]
+    for (const upload of messages.flatMap((message) => message.uploads ?? [])) {
+      if (upload.sha256 && upload.checksum && upload.sha256 !== upload.checksum) {
+        throw new Error(`Session Upload reference has conflicting checksums: ${upload.id}`)
+      }
+      const identity = JSON.stringify([
+        upload.sessionId,
+        upload.name,
+        upload.originalName,
+        upload.path === undefined ? null : resolve(upload.path),
+        upload.versionId ?? null,
+        upload.versionNumber ?? null,
+        upload.sha256 ?? upload.checksum ?? null,
+        upload.size,
+        upload.mimeType ?? null,
+        upload.createdAt ?? null
+      ])
+      const existing = identities.get(upload.id)
+      if (existing !== undefined && existing !== identity) {
+        throw new Error(
+          `Session Upload references have conflicting immutable identity: ${upload.id}`
+        )
+      }
+      identities.set(upload.id, identity)
+    }
+  }
+
+  // Completes crash-interrupted staging rows at startup. Every row is attempted so one corrupt
+  // upload cannot hide another recoverable row.
+  async recoverStagingUploads(): Promise<void> {
+    if (!this.options.getClient) return
+    const client = await this.options.getClient()
+    const versions = await client.uploadVersion.findMany({
+      where: { state: 'staging' },
+      include: { uploadFile: true }
+    })
+    const results = await Promise.allSettled(
+      versions.map(async (version) => {
+        const finalPath = resolve(this.storageRoot, ...version.contentStorageKey.split('/'))
+        const sourceCandidates = [
+          finalPath,
+          getSessionUploadDir(this.storageRoot, PENDING_UPLOAD_SESSION_ID),
+          getSessionUploadDir(this.storageRoot, version.uploadFile.sessionId)
+        ].map((path, index) => (index === 0 ? path : join(path, version.filename)))
+        let sourcePath = sourceCandidates[0]
+        for (const candidate of sourceCandidates) {
+          try {
+            if ((await stat(candidate)).isFile()) {
+              sourcePath = candidate
+              break
+            }
+          } catch (error) {
+            if (!isMissingFileError(error)) throw error
+          }
+        }
+        await this.completeStagingUpload(
+          version.uploadFile.projectId,
+          version.uploadFile.sessionId,
+          {
+            id: version.uploadFileId,
+            sessionId: version.uploadFile.sessionId,
+            name: version.filename,
+            originalName: version.originalFilename,
+            path: sourcePath,
+            mimeType: version.contentType ?? undefined,
+            size: Number(version.sizeBytes),
+            versionId: version.id,
+            versionNumber: version.versionNumber,
+            checksum: version.checksum,
+            createdAt: version.createdAt?.toISOString()
+          },
+          version
+        )
+      })
+    )
+    const failures = results.filter((result) => result.status === 'rejected')
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        `Could not recover ${failures.length} staging Upload Version(s).`
+      )
+    }
+  }
+
+  // Missing legacy/private/version candidates are positive evidence that the old deletion tail
+  // consumed the bytes. A mismatched recorded locator remains unknown and is retained fail-closed.
+  async hasOrphanLegacyCandidate(
+    projectId: string,
+    sessionId: string,
+    uploadFileId: string,
+    attachment: UploadedAttachment
+  ): Promise<boolean> {
+    assertSafePathSegment(projectId)
+    assertSafePathSegment(sessionId)
+    assertSafePathSegment(uploadFileId)
+    const legacyRoot = getSessionUploadDir(this.storageRoot, sessionId)
+    const expectedLegacyPath = resolve(legacyRoot, attachment.name)
+    assertPathInsideRoot(legacyRoot, expectedLegacyPath)
+    if (resolve(attachment.path) !== expectedLegacyPath) return true
+    try {
+      await lstat(expectedLegacyPath)
+      return true
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+    }
+    if (await this.dependencies.cleanup.hasPrivateClaim(expectedLegacyPath)) return true
+
+    // Once SQLite authority is gone, scan only this Upload's bounded versions root. Any surviving
+    // entry, including a live-copy temporary, must be retained for manual or retry recovery.
+    const versionsRoot = resolve(
+      this.storageRoot,
+      UPLOADS_DIR,
+      projectId,
+      sessionId,
+      uploadFileId,
+      'versions'
+    )
+    assertPathInsideRoot(this.storageRoot, versionsRoot)
+    let versionsRootInfo
+    try {
+      versionsRootInfo = await lstat(versionsRoot)
+    } catch (error) {
+      if (isMissingFileError(error)) return false
+      throw error
+    }
+    if (!versionsRootInfo.isDirectory() || versionsRootInfo.isSymbolicLink()) return true
+    const versionEntries = await readdir(versionsRoot, { withFileTypes: true })
+    for (const versionEntry of versionEntries) {
+      if (!versionEntry.isDirectory() || versionEntry.isSymbolicLink()) return true
+      const entries = await readdir(join(versionsRoot, versionEntry.name), { withFileTypes: true })
+      if (entries.length > 0) return true
+    }
+    return false
+  }
+
+  async removeVerifiedLegacyCopy(input: RemoveVerifiedLegacyCopyInput): Promise<unknown> {
+    return this.dependencies.cleanup.removeVerifiedLegacyCopy(input)
+  }
+
+  async completeStagingUpload(
+    projectId: string,
+    sessionId: string,
+    attachment: UploadedAttachment,
+    version: UploadVersionRecord,
+    options: { preserveSource?: boolean } = {}
+  ): Promise<UploadedAttachment> {
+    const finalPath = resolve(this.storageRoot, ...version.contentStorageKey.split('/'))
+    assertPathInsideRoot(
+      resolve(this.storageRoot),
+      finalPath,
+      'Upload storage key escapes storage.'
+    )
+    const validateContent = async (path: string): Promise<boolean> => {
+      try {
+        const info = await stat(path)
+        return (
+          info.isFile() &&
+          info.size === Number(version.sizeBytes) &&
+          (await sha256File(path)) === version.checksum
+        )
+      } catch (error) {
+        if (isMissingFileError(error)) return false
+        throw error
+      }
+    }
+
+    let finalValid = await validateContent(finalPath)
+    if (version.state === 'ready' && !finalValid) {
+      throw new Error(`Ready Upload Version content is unavailable or corrupt: ${version.id}`)
+    }
+    if (version.state !== 'staging' && version.state !== 'ready') {
+      throw new Error(`Unsupported Upload Version state: ${version.state}`)
+    }
+    if (!finalValid) {
+      try {
+        await stat(finalPath)
+        throw new Error(`Upload Version final content is corrupt: ${version.id}`)
+      } catch (error) {
+        if (!isMissingFileError(error)) throw error
+      }
+      await mkdir(dirname(finalPath), { recursive: true })
+      const temporaryPath = `${finalPath}${LIVE_COPY_TEMP_SUFFIX}`
+      if (await validateContent(temporaryPath)) {
+        await rename(temporaryPath, finalPath)
+        finalValid = await validateContent(finalPath)
+        if (!finalValid)
+          throw new Error(`Recovered Upload Version content is corrupt: ${version.id}`)
+      } else {
+        await rm(temporaryPath, { force: true })
+      }
+    }
+
+    if (!finalValid) {
+      let sourcePath: string | undefined
+      try {
+        sourcePath = await this.dependencies.resolveManagedUploadPath({ path: attachment.path })
+      } catch (error) {
+        if (!isMissingFileError(error)) throw error
+      }
+      if (!sourcePath || !(await validateContent(sourcePath))) {
+        const client = await this.options.getClient!()
+        await client.$transaction(async (tx) => {
+          await tx.uploadVersion.deleteMany({ where: { id: version.id, state: 'staging' } })
+          await tx.uploadFile.deleteMany({
+            where: { id: version.uploadFileId, versions: { none: {} } }
+          })
+        })
+        throw new Error(`Upload Version staging content is unavailable: ${version.id}`)
+      }
+      if (options.preserveSource) {
+        const temporaryPath = `${finalPath}${LIVE_COPY_TEMP_SUFFIX}`
+        try {
+          await copyFile(sourcePath, temporaryPath, constants.COPYFILE_EXCL)
+          if (!(await validateContent(temporaryPath))) {
+            throw new Error(`Copied Upload Version content is corrupt: ${version.id}`)
+          }
+          await rename(temporaryPath, finalPath)
+        } finally {
+          await rm(temporaryPath, { force: true }).catch(() => undefined)
+        }
+      } else {
+        await rename(sourcePath, finalPath)
+      }
+      finalValid = await validateContent(finalPath)
+      if (!finalValid) throw new Error(`Published Upload Version content is corrupt: ${version.id}`)
+    }
+
+    await rm(`${finalPath}${LIVE_COPY_TEMP_SUFFIX}`, { force: true })
+    const client = await this.options.getClient!()
+    const ready = await client.$transaction(async (tx) => {
+      const updated =
+        version.state === 'ready'
+          ? version
+          : await tx.uploadVersion.update({ where: { id: version.id }, data: { state: 'ready' } })
+      const timestamp = updated.createdAt ?? new Date()
+      await tx.managedFile.upsert({
+        where: {
+          projectId_source_sourceFileId: {
+            projectId,
+            source: 'upload',
+            sourceFileId: version.uploadFileId
+          }
+        },
+        create: {
+          source: 'upload',
+          sourceFileId: version.uploadFileId,
+          sourceVersionId: version.id,
+          checksum: version.checksum,
+          projectId,
+          sessionId,
+          displayName: version.originalFilename || version.filename,
+          storageKey: version.contentStorageKey,
+          mimeType: version.contentType,
+          sizeBytes: version.sizeBytes,
+          mtimeMs: BigInt(timestamp.getTime()),
+          sortAtMs: BigInt(timestamp.getTime())
+        },
+        update: {
+          sourceVersionId: version.id,
+          checksum: version.checksum,
+          sessionId,
+          displayName: version.originalFilename || version.filename,
+          storageKey: version.contentStorageKey,
+          mimeType: version.contentType,
+          sizeBytes: version.sizeBytes,
+          mtimeMs: BigInt(timestamp.getTime()),
+          sortAtMs: BigInt(timestamp.getTime()),
+          deletedAt: null,
+          deleteOperationId: null
+        }
+      })
+      return updated
+    })
+
+    return {
+      id: version.uploadFileId,
+      sessionId,
+      name: version.filename,
+      originalName: version.originalFilename,
+      path: finalPath,
+      mimeType: version.contentType ?? undefined,
+      size: Number(version.sizeBytes),
+      versionId: ready.id,
+      versionNumber: ready.versionNumber,
+      checksum: ready.checksum,
+      createdAt: ready.createdAt?.toISOString()
+    }
+  }
+}
+
+export { LegacyRecoveryOwner }
+export type { LegacyRecoveryDependencies, LegacyUploadUpgradeOptions }

--- a/src/main/uploads/repository.architecture.test.ts
+++ b/src/main/uploads/repository.architecture.test.ts
@@ -1,0 +1,356 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import {
+  canHaveModifiers,
+  createSourceFile,
+  forEachChild,
+  getModifiers,
+  isCallExpression,
+  isClassDeclaration,
+  isConstructorDeclaration,
+  isEnumDeclaration,
+  isExportAssignment,
+  isExportDeclaration,
+  isFunctionDeclaration,
+  isIdentifier,
+  isMethodDeclaration,
+  isNamedExports,
+  isNewExpression,
+  isPropertyDeclaration,
+  isPropertyAccessExpression,
+  isReturnStatement,
+  isVariableStatement,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  type ClassDeclaration,
+  type Node,
+  type SourceFile
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const productionFiles = readdirSync(__dirname, { withFileTypes: true })
+  .filter(
+    (entry) =>
+      entry.isFile() &&
+      entry.name.endsWith('.ts') &&
+      !entry.name.endsWith('.test.ts') &&
+      !entry.name.endsWith('.test-utils.ts')
+  )
+  .map((entry) => entry.name)
+  .sort()
+const sources = new Map(
+  productionFiles.map((file) => [file, readFileSync(resolve(__dirname, file), 'utf8')])
+)
+const sourceFileFor = (file: string): SourceFile =>
+  createSourceFile(file, sources.get(file)!, ScriptTarget.Latest, true, ScriptKind.TS)
+
+const classFrom = (file: string, name: string): ClassDeclaration => {
+  const candidate = sourceFileFor(file).statements.find(
+    (statement) => isClassDeclaration(statement) && statement.name?.text === name
+  )
+  if (!candidate || !isClassDeclaration(candidate)) throw new Error(`${name} class not found`)
+  return candidate
+}
+
+const hasModifier = (node: Node, kind: SyntaxKind): boolean =>
+  canHaveModifiers(node) &&
+  (getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false)
+
+const publicMethods = (declaration: ClassDeclaration): string[] =>
+  declaration.members
+    .filter(isMethodDeclaration)
+    .filter(
+      (member) =>
+        !hasModifier(member, SyntaxKind.PrivateKeyword) &&
+        !hasModifier(member, SyntaxKind.ProtectedKeyword)
+    )
+    .map((member) => (isIdentifier(member.name) ? member.name.text : undefined))
+    .filter((name): name is string => name !== undefined)
+    .sort()
+
+const asyncMethods = (declaration: ClassDeclaration): string[] =>
+  declaration.members
+    .filter(isMethodDeclaration)
+    .filter((member) => hasModifier(member, SyntaxKind.AsyncKeyword))
+    .map((member) => (isIdentifier(member.name) ? member.name.text : undefined))
+    .filter((name): name is string => name !== undefined)
+    .sort()
+
+const fields = (declaration: ClassDeclaration): string[] =>
+  declaration.members
+    .filter(isPropertyDeclaration)
+    .map((member) => (isIdentifier(member.name) ? member.name.text : undefined))
+    .filter((name): name is string => name !== undefined)
+    .sort()
+
+const newExpressionSites = (className: string): string[] => {
+  const sites: string[] = []
+  for (const file of productionFiles) {
+    const sourceFile = sourceFileFor(file)
+    const visit = (node: Node): void => {
+      if (
+        isNewExpression(node) &&
+        isIdentifier(node.expression) &&
+        node.expression.text === className
+      ) {
+        let current: Node | undefined = node.parent
+        while (current && !isConstructorDeclaration(current)) current = current.parent
+        sites.push(`${file}:${current ? 'constructor' : 'outside-constructor'}`)
+      }
+      forEachChild(node, visit)
+    }
+    visit(sourceFile)
+  }
+  return sites
+}
+
+const constructorParameters = (declaration: ClassDeclaration): string[] => {
+  const constructors = declaration.members.filter(isConstructorDeclaration)
+  expect(constructors).toHaveLength(1)
+  return constructors[0].parameters.map((parameter) =>
+    [
+      parameter.name.getText(),
+      parameter.type?.getText() ?? '<untyped>',
+      parameter.initializer ? 'defaulted' : 'required'
+    ].join(':')
+  )
+}
+
+const methodDeclarationSites = (methodName: string): string[] => {
+  const sites: string[] = []
+  for (const file of productionFiles) {
+    const sourceFile = sourceFileFor(file)
+    for (const statement of sourceFile.statements) {
+      if (!isClassDeclaration(statement) || !statement.name) continue
+      for (const member of statement.members) {
+        if (
+          isMethodDeclaration(member) &&
+          isIdentifier(member.name) &&
+          member.name.text === methodName
+        ) {
+          sites.push(`${file}:${statement.name.text}`)
+        }
+      }
+    }
+  }
+  return sites.sort()
+}
+
+const facadeDelegations = (
+  facade: ClassDeclaration,
+  facadeFile: SourceFile
+): Readonly<Record<string, string>> =>
+  Object.fromEntries(
+    facade.members.filter(isMethodDeclaration).map((method) => {
+      if (!isIdentifier(method.name) || !method.body || method.body.statements.length !== 1) {
+        throw new Error('UploadRepository methods must be single-return delegations')
+      }
+      const [statement] = method.body.statements
+      if (
+        !isReturnStatement(statement) ||
+        !statement.expression ||
+        !isCallExpression(statement.expression) ||
+        !isPropertyAccessExpression(statement.expression.expression)
+      ) {
+        throw new Error(`${method.name.text} is not a direct owner delegation`)
+      }
+      return [method.name.text, statement.expression.expression.getText(facadeFile)]
+    })
+  )
+
+const exportedValues = (sourceFile: SourceFile): string[] => {
+  const names: string[] = []
+  for (const statement of sourceFile.statements) {
+    if (isExportAssignment(statement)) {
+      names.push(`default:${statement.expression.getText(sourceFile)}`)
+      continue
+    }
+    if (isExportDeclaration(statement)) {
+      if (statement.isTypeOnly) continue
+      if (!statement.exportClause) {
+        names.push('export-all')
+      } else if (isNamedExports(statement.exportClause)) {
+        names.push(
+          ...statement.exportClause.elements
+            .filter((element) => !element.isTypeOnly)
+            .map((element) => element.name.text)
+        )
+      } else {
+        names.push(`namespace:${statement.exportClause.getText(sourceFile)}`)
+      }
+      continue
+    }
+    if (!hasModifier(statement, SyntaxKind.ExportKeyword)) continue
+    if (
+      isClassDeclaration(statement) ||
+      isFunctionDeclaration(statement) ||
+      isEnumDeclaration(statement)
+    ) {
+      const name = statement.name?.text ?? '<anonymous-export>'
+      names.push(hasModifier(statement, SyntaxKind.DefaultKeyword) ? `default:${name}` : name)
+    } else if (isVariableStatement(statement)) {
+      names.push(
+        ...statement.declarationList.declarations.map((declaration) =>
+          declaration.name.getText(sourceFile)
+        )
+      )
+    }
+  }
+  return names.sort()
+}
+
+describe('Upload repository architecture', () => {
+  const facadeFile = sourceFileFor('repository.ts')
+  const facade = classFrom('repository.ts', 'UploadRepository')
+
+  it('keeps every production module within the completion gate', () => {
+    for (const [file, source] of sources) {
+      const physicalLines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
+      expect(physicalLines, file).toBeLessThanOrEqual(660)
+    }
+  })
+
+  it('keeps the established 15-method public facade and three value exports', () => {
+    const establishedMethods = [
+      'abortTransfer',
+      'appendTransfer',
+      'beginTransfer',
+      'deleteUpload',
+      'finalizePendingSessionUploads',
+      'finishTransfer',
+      'getTransferStatus',
+      'readManagedUploadPreview',
+      'recoverStagingUploads',
+      'resolveManagedUpload',
+      'resolveManagedUploadPath',
+      'resolveSessionUpload',
+      'resolveSessionUploadPath',
+      'stageLocalFile',
+      'upgradeLegacySessionUploads'
+    ].sort()
+    expect(publicMethods(facade)).toEqual(establishedMethods)
+    expect(asyncMethods(facade)).toEqual(establishedMethods)
+    expect(constructorParameters(facade)).toEqual([
+      'storageRoot:string:required',
+      'options:UploadRepositoryOptions:defaulted'
+    ])
+    expect(exportedValues(facadeFile)).toEqual(
+      [
+        'OrphanLegacyUploadAuthorityMissingError',
+        'UnsafeLegacyUploadResidualError',
+        'UploadRepository'
+      ].sort()
+    )
+  })
+
+  it('distinguishes named, default, namespace and assignment value exports', () => {
+    const alternateExports = createSourceFile(
+      'alternate-exports.ts',
+      [
+        'export class Named {}',
+        'export default function Defaulted() {}',
+        "export * as scope from './scope'",
+        'export const extra = 1'
+      ].join('\n'),
+      ScriptTarget.Latest,
+      true,
+      ScriptKind.TS
+    )
+    const assignmentExport = createSourceFile(
+      'assignment-export.ts',
+      'const assigned = 1; export default assigned',
+      ScriptTarget.Latest,
+      true,
+      ScriptKind.TS
+    )
+
+    expect(exportedValues(alternateExports)).toEqual(
+      ['Named', 'default:Defaulted', 'extra', 'namespace:* as scope'].sort()
+    )
+    expect(exportedValues(assignmentExport)).toEqual(['default:assigned'])
+  })
+
+  it('composes each owner exactly once without facade lifecycle state', () => {
+    for (const owner of [
+      'ActiveTransferOwner',
+      'LegacyRecoveryOwner',
+      'ManagedUploadResolver',
+      'StagedPublicationOwner',
+      'VerifiedLegacyCleanupOwner'
+    ]) {
+      expect(newExpressionSites(owner), owner).toEqual(['repository.ts:constructor'])
+    }
+    expect(fields(facade)).toEqual([
+      'legacyRecoveryOwner',
+      'managedUploadResolver',
+      'stagedPublicationOwner',
+      'transferOwner'
+    ])
+  })
+
+  it('keeps every facade method as a direct delegation to its established owner', () => {
+    expect(facadeDelegations(facade, facadeFile)).toEqual({
+      abortTransfer: 'this.transferOwner.abortTransfer',
+      appendTransfer: 'this.transferOwner.appendTransfer',
+      beginTransfer: 'this.transferOwner.beginTransfer',
+      deleteUpload: 'this.managedUploadResolver.deleteUpload',
+      finalizePendingSessionUploads: 'this.stagedPublicationOwner.finalizePendingSessionUploads',
+      finishTransfer: 'this.transferOwner.finishTransfer',
+      getTransferStatus: 'this.transferOwner.getTransferStatus',
+      readManagedUploadPreview: 'this.managedUploadResolver.readManagedUploadPreview',
+      recoverStagingUploads: 'this.legacyRecoveryOwner.recoverStagingUploads',
+      resolveManagedUpload: 'this.managedUploadResolver.resolveManagedUpload',
+      resolveManagedUploadPath: 'this.managedUploadResolver.resolveManagedUploadPath',
+      resolveSessionUpload: 'this.managedUploadResolver.resolveSessionUpload',
+      resolveSessionUploadPath: 'this.managedUploadResolver.resolveSessionUploadPath',
+      stageLocalFile: 'this.transferOwner.stageLocalFile',
+      upgradeLegacySessionUploads: 'this.legacyRecoveryOwner.upgradeLegacySessionUploads'
+    })
+  })
+
+  it('keeps recovery and verified cleanup decisions behind their owners', () => {
+    const facadeSource = sources.get('repository.ts')!
+    const cleanupSource = sources.get('verified-legacy-cleanup-owner.ts')!
+    const recoverySource = sources.get('legacy-recovery-owner.ts')!
+
+    expect(facadeSource).not.toMatch(/from ['"]node:fs\/promises['"]/)
+    expect(facadeSource).not.toContain('LEGACY_CLEANUP_PRIVATE_SUFFIX')
+    expect(facadeSource).not.toContain('settleSiblingOperations')
+    expect(publicMethods(classFrom('legacy-recovery-owner.ts', 'LegacyRecoveryOwner'))).toEqual(
+      [
+        'completeStagingUpload',
+        'hasOrphanLegacyCandidate',
+        'recoverStagingUploads',
+        'removeVerifiedLegacyCopy',
+        'upgradeLegacySessionUploads'
+      ].sort()
+    )
+    expect(
+      publicMethods(classFrom('verified-legacy-cleanup-owner.ts', 'VerifiedLegacyCleanupOwner'))
+    ).toEqual(['assertLegacySourceAbsent', 'hasPrivateClaim', 'removeVerifiedLegacyCopy'].sort())
+    expect(methodDeclarationSites('assertConsistentSessionUploadReferences')).toEqual([
+      'legacy-recovery-owner.ts:LegacyRecoveryOwner'
+    ])
+    expect(methodDeclarationSites('hasOrphanLegacyCandidate')).toEqual([
+      'legacy-recovery-owner.ts:LegacyRecoveryOwner'
+    ])
+    expect(methodDeclarationSites('completeStagingUpload')).toEqual([
+      'legacy-recovery-owner.ts:LegacyRecoveryOwner'
+    ])
+    expect(methodDeclarationSites('restoreLegacyCleanupPrivate')).toEqual([
+      'verified-legacy-cleanup-owner.ts:VerifiedLegacyCleanupOwner'
+    ])
+    expect(methodDeclarationSites('assertLegacySourceAbsent')).toEqual([
+      'verified-legacy-cleanup-owner.ts:VerifiedLegacyCleanupOwner'
+    ])
+    expect(cleanupSource.match(/LEGACY_CLEANUP_PRIVATE_SUFFIX/g)).toHaveLength(4)
+    for (const [file, source] of sources) {
+      if (file !== 'verified-legacy-cleanup-owner.ts') {
+        expect(source, file).not.toContain('LEGACY_CLEANUP_PRIVATE_SUFFIX')
+      }
+    }
+    expect(recoverySource).toContain('cleanup: Pick<')
+  })
+})

--- a/src/main/uploads/repository.ts
+++ b/src/main/uploads/repository.ts
@@ -1,27 +1,10 @@
-import { constants, createReadStream } from 'node:fs'
-import {
-  copyFile,
-  link,
-  lstat,
-  mkdir,
-  readdir,
-  realpath,
-  rename,
-  rm,
-  rmdir,
-  stat
-} from 'node:fs/promises'
-import { basename, dirname, join, resolve } from 'node:path'
-import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
 
 import type { PrismaClient } from '@prisma/client'
 
 import type { ArtifactPreviewResult, ReadArtifactPreviewRequest } from '../../shared/artifacts'
 import {
   DEFAULT_UPLOAD_PROJECT_NAME,
-  PENDING_UPLOAD_SESSION_ID,
-  toPersistedUploadedAttachment,
-  toRuntimeUploadedAttachment,
   type AppendUploadTransferRequest,
   type BeginUploadTransferRequest,
   type DeleteUploadRequest,
@@ -29,29 +12,20 @@ import {
   type UploadTransferProgress,
   type UploadTransferRequest,
   type UploadTransferStatus,
-  type UploadedAttachment,
-  type PersistedUploadedAttachment
+  type UploadedAttachment
 } from '../../shared/uploads'
-import type { PersistedChatMessage, PersistedChatSession } from '../../shared/session-persistence'
+import type { PersistedChatSession } from '../../shared/session-persistence'
 import { ActiveTransferOwner } from './active-transfer-owner'
+import { LegacyRecoveryOwner, type LegacyUploadUpgradeOptions } from './legacy-recovery-owner'
 import { ManagedUploadResolver, type ResolvedManagedUpload } from './managed-upload-resolver'
 import {
   OrphanLegacyUploadAuthorityMissingError,
-  StagedPublicationOwner,
-  type UploadVersionRecord
+  StagedPublicationOwner
 } from './staged-publication-owner'
 import {
-  UPLOADS_DIR,
-  assertPathInsideRoot,
-  assertSafePathSegment,
-  getSessionUploadDir,
-  isFileExistsError,
-  isMissingFileError
-} from './storage-helpers'
-
-const LIVE_COPY_TEMP_SUFFIX = '.live-copy.tmp'
-const LEGACY_CLEANUP_PRIVATE_SUFFIX = '.legacy-cleanup.private'
-const LEGACY_CLEANUP_CANDIDATE = 'candidate'
+  UnsafeLegacyUploadResidualError,
+  VerifiedLegacyCleanupOwner
+} from './verified-legacy-cleanup-owner'
 
 type UploadRepositoryOptions = {
   maxFileBytes?: number
@@ -64,89 +38,41 @@ type UploadRepositoryOptions = {
   ) => ReturnType<typeof createReadStream>
 }
 
-type LegacyUploadUpgradeOptions = {
-  // Live callers cannot prove that every renderer has applied the returned path-free projection.
-  // Preserve the legacy source until a later startup/deletion reconciliation runs without live state.
-  // Orphan recovery also preserves it, but may only reuse authority left by the old deletion tail:
-  // recreating identity after provenance succeeded could claim unrelated residual bytes.
-  mode?: 'reconcile' | 'live-save' | 'orphan-recovery' | 'terminal-delete'
-}
-
-const sha256File = async (filePath: string): Promise<string> => {
-  const hash = createHash('sha256')
-  for await (const chunk of createReadStream(filePath)) hash.update(chunk)
-  return hash.digest('hex')
-}
-
-type FileIdentity = Awaited<ReturnType<typeof lstat>>
-
-const hasSameFileIdentity = (left: FileIdentity, right: FileIdentity): boolean =>
-  left.dev === right.dev && left.ino === right.ino && left.size === right.size
-
-const hasSameFileSnapshot = (left: FileIdentity, right: FileIdentity): boolean =>
-  hasSameFileIdentity(left, right) &&
-  left.mtimeMs === right.mtimeMs &&
-  left.ctimeMs === right.ctimeMs
-
-class LegacyCleanupIncompleteError extends Error {}
-
-// Terminal Project deletion may leave bytes only when reconciliation has positively proved that the
-// deterministic legacy path no longer contains the Version-owned source. Callers must not use this
-// type for missing/corrupt Version authority or transient filesystem/private-claim failures.
-class UnsafeLegacyUploadResidualError extends Error {}
-
-// Orphan adoption may suppress only this positively proven cross-version state: the Upload row is
-// absent while candidate bytes exist or cannot safely be ruled out from the surviving locator.
-// Database/filesystem failures and malformed surviving authority keep their original retry behavior.
-// Promise.all rejects before sibling publication settles. Orphan recovery must not let a late
-// sibling reactivate ManagedFile rows after its caller has already soft-deleted the Project index.
-// Prefer an ordinary failure over the suppressible missing-authority state so DB/FS errors retain
-// their durable intent instead of being accidentally collapsed into orphan-retained.
-const settleSiblingOperations = async <Value>(operations: Promise<Value>[]): Promise<Value[]> => {
-  const settled = await Promise.allSettled(operations)
-  const failures = settled.filter(
-    (result): result is PromiseRejectedResult => result.status === 'rejected'
-  )
-  const failure =
-    failures.find(
-      (result) => !(result.reason instanceof OrphanLegacyUploadAuthorityMissingError)
-    ) ?? failures[0]
-  if (failure) throw failure.reason
-  return settled.map((result) => (result as PromiseFulfilledResult<Value>).value)
-}
-
-type LegacyCleanupResult =
-  { status: 'absent' | 'removed' } | { status: 'unsafe-residual'; reason: string }
-
-// Owns app-managed uploads so renderer paths are always validated in the main process.
+// Public upload seam. Owners are composed once here; all behavior lives behind the existing 15
+// async methods so Electron, Web, CLI, Task, local-RPC and MCP callers retain the same interface.
 class UploadRepository {
   private readonly transferOwner: ActiveTransferOwner
   private readonly managedUploadResolver: ManagedUploadResolver
   private readonly stagedPublicationOwner: StagedPublicationOwner
+  private readonly legacyRecoveryOwner: LegacyRecoveryOwner
 
-  // The storage root is the app persistence root; this class appends uploads/project/session.
-  constructor(
-    private readonly storageRoot: string,
-    private readonly options: UploadRepositoryOptions = {}
-  ) {
+  constructor(storageRoot: string, options: UploadRepositoryOptions = {}) {
     this.transferOwner = new ActiveTransferOwner(storageRoot, options)
     this.managedUploadResolver = new ManagedUploadResolver(storageRoot, options)
+    const cleanupOwner = new VerifiedLegacyCleanupOwner(storageRoot, options, {
+      resolveManagedUploadPath: (...args) =>
+        this.managedUploadResolver.resolveManagedUploadPath(...args)
+    })
     this.stagedPublicationOwner = new StagedPublicationOwner(storageRoot, options, {
       resolver: this.managedUploadResolver,
-      completeStagingUpload: (...args) => this.completeStagingUpload(...args),
-      hasOrphanLegacyCandidate: (...args) => this.hasOrphanLegacyCandidate(...args),
-      removeVerifiedLegacyCopy: (input) => this.removeVerifiedLegacyCopy(input)
+      completeStagingUpload: (...args) => this.legacyRecoveryOwner.completeStagingUpload(...args),
+      hasOrphanLegacyCandidate: (...args) =>
+        this.legacyRecoveryOwner.hasOrphanLegacyCandidate(...args),
+      removeVerifiedLegacyCopy: (input) => this.legacyRecoveryOwner.removeVerifiedLegacyCopy(input)
+    })
+    this.legacyRecoveryOwner = new LegacyRecoveryOwner(storageRoot, options, {
+      resolveManagedUploadPath: (request) =>
+        this.managedUploadResolver.resolveManagedUploadPath(request),
+      finalizeSessionUploads: (...args) =>
+        this.stagedPublicationOwner.finalizeSessionUploads(...args),
+      cleanup: cleanupOwner
     })
   }
 
-  // Allocates an empty temporary file for sources that can only provide bytes (Web, clipboard,
-  // synthetic File objects). Chunks are appended through appendTransfer and committed by finish.
   async beginTransfer(request: BeginUploadTransferRequest): Promise<UploadTransferStatus> {
     return this.transferOwner.beginTransfer(request)
   }
 
-  // Accepts exactly one bounded chunk at the caller's expected offset. This makes retries safe:
-  // callers query status and resume from receivedBytes instead of duplicating data.
   async appendTransfer(request: AppendUploadTransferRequest): Promise<UploadTransferStatus> {
     return this.transferOwner.appendTransfer(request)
   }
@@ -155,19 +81,14 @@ class UploadRepository {
     return this.transferOwner.getTransferStatus(request)
   }
 
-  // Publishes a fully received temporary file into the same pending attachment namespace used by
-  // desktop-path uploads. Incomplete transfers remain resumable until explicitly aborted.
   async finishTransfer(request: UploadTransferRequest): Promise<UploadedAttachment> {
     return this.transferOwner.finishTransfer(request)
   }
 
-  // Cancellation is idempotent so renderer cleanup can safely race a failed transfer.
   async abortTransfer(request: UploadTransferRequest): Promise<void> {
     return this.transferOwner.abortTransfer(request)
   }
 
-  // Streams an existing desktop file into managed staging without routing its bytes through the
-  // renderer or a single IPC message. The temporary file is committed only after all bytes arrive.
   async stageLocalFile(
     request: StageLocalUploadRequest,
     onProgress?: (progress: UploadTransferProgress) => void
@@ -175,7 +96,6 @@ class UploadRepository {
     return this.transferOwner.stageLocalFile(request, onProgress)
   }
 
-  // Moves pending attachments into their durable session directory once the runtime id is known.
   async finalizePendingSessionUploads(
     sessionId: string,
     attachments: UploadedAttachment[],
@@ -188,212 +108,21 @@ class UploadRepository {
     )
   }
 
-  private async finalizeSessionUploads(
-    sessionId: string,
-    attachments: UploadedAttachment[],
-    projectId: string,
-    options: { preserveLegacySource?: boolean; requireExistingAuthority?: boolean } = {}
-  ): Promise<UploadedAttachment[]> {
-    return this.stagedPublicationOwner.finalizeSessionUploads(
-      sessionId,
-      attachments,
-      projectId,
-      options
-    )
-  }
-
-  // Converts path-only Session records from pre-Version releases before the Session repository is
-  // allowed to write its path-free JSON projection, and reconciles historical copies left behind by
-  // older Version-aware releases. Repeated references share one publication or reconciliation.
   async upgradeLegacySessionUploads(
     session: PersistedChatSession,
     options: LegacyUploadUpgradeOptions = {}
   ): Promise<PersistedChatSession> {
-    this.assertConsistentSessionUploadReferences(session)
-    const isLiveSave = options.mode === 'live-save' || options.mode === 'orphan-recovery'
-    const requireExistingAuthority = options.mode === 'orphan-recovery'
-    const isTerminalDelete = options.mode === 'terminal-delete'
-    const upgrades = new Map<string, Promise<PersistedUploadedAttachment | undefined>>()
-    const reconciliations = new Map<string, Promise<LegacyCleanupResult>>()
-    const upgrade = async (
-      upload: PersistedUploadedAttachment
-    ): Promise<PersistedUploadedAttachment | undefined> => {
-      if (upload.versionId) {
-        const persisted = toPersistedUploadedAttachment(
-          toRuntimeUploadedAttachment(upload, session.projectId)
-        )
-        if (isLiveSave) return Promise.resolve(persisted)
-        const reconciliationKey = `${upload.id}:${upload.versionId}`
-        let reconciliation = reconciliations.get(reconciliationKey)
-        if (!reconciliation) {
-          reconciliation = this.removeVerifiedLegacyCopy({
-            projectId: session.projectId,
-            sessionId: upload.sessionId,
-            uploadFileId: upload.id,
-            versionId: upload.versionId,
-            filename: upload.name
-          })
-          reconciliations.set(reconciliationKey, reconciliation)
-        }
-        return reconciliation.then(async (cleanup) => {
-          if (isTerminalDelete) {
-            await this.assertLegacySourceAbsent(upload.sessionId, upload.name, cleanup)
-          }
-          return persisted
-        })
-      }
-
-      const existing = upgrades.get(upload.id)
-      if (existing) return existing
-      const operation = (async () => {
-        if (!upload.path) {
-          throw new Error(`Legacy upload has no recoverable path: ${upload.id}`)
-        }
-        const [finalized] = await this.finalizeSessionUploads(
-          session.id,
-          [toRuntimeUploadedAttachment(upload, session.projectId)],
-          session.projectId,
-          { preserveLegacySource: isLiveSave, requireExistingAuthority }
-        )
-        if (!finalized) return undefined
-        if (isTerminalDelete) {
-          await this.assertLegacySourceAbsent(upload.sessionId, upload.name, { status: 'absent' })
-        }
-        return toPersistedUploadedAttachment(finalized)
-      })()
-      upgrades.set(upload.id, operation)
-      return operation
-    }
-    const upgradeMessage = async <Message extends PersistedChatMessage>(
-      message: Message
-    ): Promise<Message> => {
-      if (!message.uploads?.length) return message
-      const uploads = (await settleSiblingOperations(message.uploads.map(upgrade))).filter(
-        (upload): upload is PersistedUploadedAttachment => upload !== undefined
-      )
-      return { ...message, uploads } as Message
-    }
-    const messagesOperation = settleSiblingOperations(session.messages.map(upgradeMessage))
-    const graphMessagesOperation = session.conversationGraph
-      ? settleSiblingOperations(session.conversationGraph.messages.map(upgradeMessage))
-      : undefined
-    await settleSiblingOperations<unknown>([
-      messagesOperation,
-      ...(graphMessagesOperation ? [graphMessagesOperation] : [])
-    ])
-    const messages = await messagesOperation
-    const graphMessages = await graphMessagesOperation
-
-    return {
-      ...session,
-      messages,
-      ...(session.conversationGraph
-        ? {
-            conversationGraph: {
-              ...session.conversationGraph,
-              messages: graphMessages!
-            }
-          }
-        : {})
-    }
+    return this.legacyRecoveryOwner.upgradeLegacySessionUploads(session, options)
   }
 
-  // Operation sharing is safe only after every occurrence across the flat transcript and graph has
-  // proven the same immutable identity. This synchronous, lexical preflight runs before any DB or
-  // filesystem work starts, so a conflicting historical locator cannot be overwritten or orphaned.
-  private assertConsistentSessionUploadReferences(session: PersistedChatSession): void {
-    const identities = new Map<string, string>()
-    const messages = [...session.messages, ...(session.conversationGraph?.messages ?? [])]
-    for (const upload of messages.flatMap((message) => message.uploads ?? [])) {
-      if (upload.sha256 && upload.checksum && upload.sha256 !== upload.checksum) {
-        throw new Error(`Session Upload reference has conflicting checksums: ${upload.id}`)
-      }
-      const identity = JSON.stringify([
-        upload.sessionId,
-        upload.name,
-        upload.originalName,
-        upload.path === undefined ? null : resolve(upload.path),
-        upload.versionId ?? null,
-        upload.versionNumber ?? null,
-        upload.sha256 ?? upload.checksum ?? null,
-        upload.size,
-        upload.mimeType ?? null,
-        upload.createdAt ?? null
-      ])
-      const existing = identities.get(upload.id)
-      if (existing !== undefined && existing !== identity) {
-        throw new Error(
-          `Session Upload references have conflicting immutable identity: ${upload.id}`
-        )
-      }
-      identities.set(upload.id, identity)
-    }
-  }
-
-  // Completes crash-interrupted staging rows at startup. Both native pending uploads and legacy
-  // session-owned files have deterministic source candidates; a post-rename crash is recovered from
-  // the already-valid final content. Every row is attempted so one corrupt upload cannot hide others.
   async recoverStagingUploads(): Promise<void> {
-    if (!this.options.getClient) return
-    const client = await this.options.getClient()
-    const versions = await client.uploadVersion.findMany({
-      where: { state: 'staging' },
-      include: { uploadFile: true }
-    })
-    const results = await Promise.allSettled(
-      versions.map(async (version) => {
-        const finalPath = resolve(this.storageRoot, ...version.contentStorageKey.split('/'))
-        const sourceCandidates = [
-          finalPath,
-          join(this.getSessionUploadDir(PENDING_UPLOAD_SESSION_ID), version.filename),
-          join(this.getSessionUploadDir(version.uploadFile.sessionId), version.filename)
-        ]
-        let sourcePath = sourceCandidates[0]
-        for (const candidate of sourceCandidates) {
-          try {
-            if ((await stat(candidate)).isFile()) {
-              sourcePath = candidate
-              break
-            }
-          } catch (error) {
-            if (!isMissingFileError(error)) throw error
-          }
-        }
-        await this.completeStagingUpload(
-          version.uploadFile.projectId,
-          version.uploadFile.sessionId,
-          {
-            id: version.uploadFileId,
-            sessionId: version.uploadFile.sessionId,
-            name: version.filename,
-            originalName: version.originalFilename,
-            path: sourcePath,
-            mimeType: version.contentType ?? undefined,
-            size: Number(version.sizeBytes),
-            versionId: version.id,
-            versionNumber: version.versionNumber,
-            checksum: version.checksum,
-            createdAt: version.createdAt?.toISOString()
-          },
-          version
-        )
-      })
-    )
-    const failures = results.filter((result) => result.status === 'rejected')
-    if (failures.length > 0) {
-      throw new AggregateError(
-        failures.map((failure) => failure.reason),
-        `Could not recover ${failures.length} staging Upload Version(s).`
-      )
-    }
+    return this.legacyRecoveryOwner.recoverStagingUploads()
   }
 
-  // Deletes an app-managed upload after resolving the caller path through the trust boundary.
   async deleteUpload(request: DeleteUploadRequest): Promise<void> {
     return this.managedUploadResolver.deleteUpload(request)
   }
 
-  // Resolves a renderer-provided upload path only after root and symlink checks pass.
   async resolveManagedUploadPath(
     request: DeleteUploadRequest,
     scope: { projectId?: string; sessionId?: string } = {}
@@ -401,8 +130,6 @@ class UploadRepository {
     return this.managedUploadResolver.resolveManagedUploadPath(request, scope)
   }
 
-  // Resolves an upload only when it belongs to the named durable session. Agent-facing tools use
-  // this stricter seam so a model cannot point a capability at another conversation's attachment.
   async resolveSessionUploadPath(
     sessionId: string,
     request: DeleteUploadRequest,
@@ -411,9 +138,6 @@ class UploadRepository {
     return this.managedUploadResolver.resolveSessionUploadPath(sessionId, request, projectId)
   }
 
-  // Resolves both immutable bytes and their frozen user-facing name. Native Upload Versions store
-  // bytes in a file named `content`, so consumers must not infer the original extension from the
-  // physical path.
   async resolveSessionUpload(
     sessionId: string,
     request: DeleteUploadRequest,
@@ -429,537 +153,10 @@ class UploadRepository {
     return this.managedUploadResolver.resolveManagedUpload(request, scope)
   }
 
-  // Reads upload previews through the shared bounded reader after upload-specific path validation.
   async readManagedUploadPreview(
     request: ReadArtifactPreviewRequest
   ): Promise<ArtifactPreviewResult> {
     return this.managedUploadResolver.readManagedUploadPreview(request)
-  }
-
-  // Missing legacy and private candidates are positive evidence that the old deletion tail already
-  // consumed the bytes. A mismatched recorded locator remains unknown and is retained fail-closed.
-  private async hasOrphanLegacyCandidate(
-    projectId: string,
-    sessionId: string,
-    uploadFileId: string,
-    attachment: UploadedAttachment
-  ): Promise<boolean> {
-    assertSafePathSegment(projectId)
-    assertSafePathSegment(sessionId)
-    assertSafePathSegment(uploadFileId)
-    const legacyRoot = this.getSessionUploadDir(sessionId)
-    const expectedLegacyPath = resolve(legacyRoot, attachment.name)
-    const privateClaimDir = `${expectedLegacyPath}${LEGACY_CLEANUP_PRIVATE_SUFFIX}`
-    assertPathInsideRoot(legacyRoot, expectedLegacyPath)
-    assertPathInsideRoot(legacyRoot, privateClaimDir)
-    if (resolve(attachment.path) !== expectedLegacyPath) return true
-
-    for (const candidate of [expectedLegacyPath, privateClaimDir]) {
-      try {
-        await lstat(candidate)
-        return true
-      } catch (error) {
-        if (!isMissingFileError(error)) throw error
-      }
-    }
-
-    // A live-save can crash after copying bytes into an authority-derived Version directory. The
-    // Version id is unavailable once SQLite authority is gone, so scan only this Upload's bounded
-    // versions root. Empty directories left by provenance cleanup are harmless; any surviving entry
-    // (including content.live-copy.tmp) is retained for manual/retry recovery.
-    const versionsRoot = resolve(
-      this.storageRoot,
-      UPLOADS_DIR,
-      projectId,
-      sessionId,
-      uploadFileId,
-      'versions'
-    )
-    assertPathInsideRoot(this.storageRoot, versionsRoot)
-    let versionsRootInfo
-    try {
-      versionsRootInfo = await lstat(versionsRoot)
-    } catch (error) {
-      if (isMissingFileError(error)) return false
-      throw error
-    }
-    if (!versionsRootInfo.isDirectory() || versionsRootInfo.isSymbolicLink()) return true
-    const versionEntries = await readdir(versionsRoot, { withFileTypes: true })
-    for (const versionEntry of versionEntries) {
-      if (!versionEntry.isDirectory() || versionEntry.isSymbolicLink()) return true
-      const entries = await readdir(join(versionsRoot, versionEntry.name), {
-        withFileTypes: true
-      })
-      if (entries.length > 0) return true
-    }
-    return false
-  }
-
-  private async completeStagingUpload(
-    projectId: string,
-    sessionId: string,
-    attachment: UploadedAttachment,
-    version: UploadVersionRecord,
-    options: { preserveSource?: boolean } = {}
-  ): Promise<UploadedAttachment> {
-    const finalPath = resolve(this.storageRoot, ...version.contentStorageKey.split('/'))
-    assertPathInsideRoot(
-      resolve(this.storageRoot),
-      finalPath,
-      'Upload storage key escapes storage.'
-    )
-    const validateContent = async (path: string): Promise<boolean> => {
-      try {
-        const info = await stat(path)
-        return (
-          info.isFile() &&
-          info.size === Number(version.sizeBytes) &&
-          (await sha256File(path)) === version.checksum
-        )
-      } catch (error) {
-        if (isMissingFileError(error)) return false
-        throw error
-      }
-    }
-
-    let finalValid = await validateContent(finalPath)
-    if (version.state === 'ready' && !finalValid) {
-      throw new Error(`Ready Upload Version content is unavailable or corrupt: ${version.id}`)
-    }
-    if (version.state !== 'staging' && version.state !== 'ready') {
-      throw new Error(`Unsupported Upload Version state: ${version.state}`)
-    }
-
-    if (!finalValid) {
-      try {
-        await stat(finalPath)
-        throw new Error(`Upload Version final content is corrupt: ${version.id}`)
-      } catch (error) {
-        if (!isMissingFileError(error)) throw error
-      }
-      await mkdir(dirname(finalPath), { recursive: true })
-      const temporaryPath = `${finalPath}${LIVE_COPY_TEMP_SUFFIX}`
-      if (await validateContent(temporaryPath)) {
-        // A prior live save completed its copy but exited before the atomic final rename. The
-        // deterministic path is derived from staging authority, so recovery can safely finish it.
-        await rename(temporaryPath, finalPath)
-        finalValid = await validateContent(finalPath)
-        if (!finalValid) {
-          throw new Error(`Recovered Upload Version content is corrupt: ${version.id}`)
-        }
-      } else {
-        // Remove a partial/corrupt crash residue before retrying from the still-authoritative source.
-        await rm(temporaryPath, { force: true })
-      }
-    }
-
-    if (!finalValid) {
-      let sourcePath: string | undefined
-      try {
-        sourcePath = await this.resolveManagedUploadPath({ path: attachment.path })
-      } catch (error) {
-        if (!isMissingFileError(error)) throw error
-      }
-      if (!sourcePath || !(await validateContent(sourcePath))) {
-        const client = await this.options.getClient!()
-        await client.$transaction(async (tx) => {
-          await tx.uploadVersion.deleteMany({ where: { id: version.id, state: 'staging' } })
-          await tx.uploadFile.deleteMany({
-            where: { id: version.uploadFileId, versions: { none: {} } }
-          })
-        })
-        throw new Error(`Upload Version staging content is unavailable: ${version.id}`)
-      }
-      if (options.preserveSource) {
-        // A live Session may still be rendering the path-only projection. Publish through an atomic
-        // temporary copy, but retain that sole readable path until a later startup/deletion pass can
-        // prove the path-free projection is authoritative without relying on renderer delivery.
-        const temporaryPath = `${finalPath}${LIVE_COPY_TEMP_SUFFIX}`
-        try {
-          await copyFile(sourcePath, temporaryPath, constants.COPYFILE_EXCL)
-          if (!(await validateContent(temporaryPath))) {
-            throw new Error(`Copied Upload Version content is corrupt: ${version.id}`)
-          }
-          await rename(temporaryPath, finalPath)
-        } finally {
-          await rm(temporaryPath, { force: true }).catch(() => undefined)
-        }
-      } else {
-        // The staging row is durable before this atomic move. If the process exits before the row is
-        // marked ready, startup recovery validates the final path and completes publication. If the
-        // Session JSON still contains the legacy path, a retry resolves the same row by uploadFileId.
-        await rename(sourcePath, finalPath)
-      }
-      finalValid = await validateContent(finalPath)
-      if (!finalValid) {
-        throw new Error(`Published Upload Version content is corrupt: ${version.id}`)
-      }
-    }
-
-    // A valid final path supersedes any deterministic crash residue from an earlier staging retry.
-    await rm(`${finalPath}${LIVE_COPY_TEMP_SUFFIX}`, { force: true })
-
-    const client = await this.options.getClient!()
-    const ready = await client.$transaction(async (tx) => {
-      const updated =
-        version.state === 'ready'
-          ? version
-          : await tx.uploadVersion.update({
-              where: { id: version.id },
-              data: { state: 'ready' }
-            })
-      const timestamp = updated.createdAt ?? new Date()
-      await tx.managedFile.upsert({
-        where: {
-          projectId_source_sourceFileId: {
-            projectId,
-            source: 'upload',
-            sourceFileId: version.uploadFileId
-          }
-        },
-        create: {
-          source: 'upload',
-          sourceFileId: version.uploadFileId,
-          sourceVersionId: version.id,
-          checksum: version.checksum,
-          projectId,
-          sessionId,
-          displayName: version.originalFilename || version.filename,
-          storageKey: version.contentStorageKey,
-          mimeType: version.contentType,
-          sizeBytes: version.sizeBytes,
-          mtimeMs: BigInt(timestamp.getTime()),
-          sortAtMs: BigInt(timestamp.getTime())
-        },
-        update: {
-          sourceVersionId: version.id,
-          checksum: version.checksum,
-          sessionId,
-          displayName: version.originalFilename || version.filename,
-          storageKey: version.contentStorageKey,
-          mimeType: version.contentType,
-          sizeBytes: version.sizeBytes,
-          mtimeMs: BigInt(timestamp.getTime()),
-          sortAtMs: BigInt(timestamp.getTime()),
-          deletedAt: null,
-          deleteOperationId: null
-        }
-      })
-      return updated
-    })
-
-    return {
-      id: version.uploadFileId,
-      sessionId,
-      name: version.filename,
-      originalName: version.originalFilename,
-      path: finalPath,
-      mimeType: version.contentType ?? undefined,
-      size: Number(version.sizeBytes),
-      versionId: ready.id,
-      versionNumber: ready.versionNumber,
-      checksum: ready.checksum,
-      createdAt: ready.createdAt?.toISOString()
-    }
-  }
-
-  // Reconciles copies left by releases that published a ready Version without consuming the legacy
-  // source. Cleanup is fail-closed: SQLite authority, both byte copies, the deterministic legacy path,
-  // and the source file identity must all remain valid through the final pre-delete check.
-  private async removeVerifiedLegacyCopy(input: {
-    projectId: string
-    sessionId: string
-    uploadFileId: string
-    versionId: string
-    filename: string
-    legacyPath?: string
-  }): Promise<LegacyCleanupResult> {
-    const projectId = assertSafePathSegment(input.projectId)
-    const sessionId = assertSafePathSegment(input.sessionId)
-    const uploadFileId = assertSafePathSegment(input.uploadFileId)
-    const versionId = assertSafePathSegment(input.versionId)
-    const legacyRoot = this.getSessionUploadDir(sessionId)
-    const expectedLegacyPath = resolve(legacyRoot, input.filename)
-    const cleanupPrivateDir = `${expectedLegacyPath}${LEGACY_CLEANUP_PRIVATE_SUFFIX}`
-    const cleanupPrivatePath = join(cleanupPrivateDir, LEGACY_CLEANUP_CANDIDATE)
-    assertPathInsideRoot(legacyRoot, expectedLegacyPath)
-    assertPathInsideRoot(legacyRoot, cleanupPrivateDir)
-    assertPathInsideRoot(legacyRoot, cleanupPrivatePath)
-
-    let initialLegacyInfo: FileIdentity | undefined
-    let privateDirInfo: FileIdentity | undefined
-    let privateInfo: FileIdentity | undefined
-    try {
-      initialLegacyInfo = await lstat(expectedLegacyPath)
-    } catch (error) {
-      if (!isMissingFileError(error)) throw error
-    }
-    try {
-      privateDirInfo = await lstat(cleanupPrivateDir)
-    } catch (error) {
-      if (!isMissingFileError(error)) throw error
-    }
-    if (privateDirInfo) {
-      if (!privateDirInfo.isDirectory() || privateDirInfo.isSymbolicLink()) {
-        throw new LegacyCleanupIncompleteError(
-          `Legacy upload cleanup found an unsafe private claim: ${input.filename}`
-        )
-      }
-      try {
-        privateInfo = await lstat(cleanupPrivatePath)
-      } catch (error) {
-        if (!isMissingFileError(error)) throw error
-        try {
-          await rmdir(cleanupPrivateDir)
-          privateDirInfo = undefined
-        } catch {
-          throw new LegacyCleanupIncompleteError(
-            `Legacy upload cleanup found an incomplete private claim: ${input.filename}`
-          )
-        }
-      }
-    }
-    if (!initialLegacyInfo && !privateInfo) return { status: 'absent' }
-
-    if (input.legacyPath && resolve(input.legacyPath) !== expectedLegacyPath) {
-      return {
-        status: 'unsafe-residual',
-        reason: 'the recorded legacy path does not match its deterministic Session path'
-      }
-    }
-
-    if (!this.options.getClient) {
-      throw new Error(`Upload Version authority is unavailable for legacy cleanup: ${versionId}`)
-    }
-
-    // The common path-free case has neither candidate, so the lstat checks above avoid a database read
-    // and full immutable-file hash on every subsequent Session save. Database failures after a
-    // candidate is found propagate so reconciliation remains incomplete and retries later.
-    const client = await this.options.getClient()
-    const version = await client.uploadVersion.findFirst({
-      where: {
-        id: versionId,
-        uploadFileId,
-        state: 'ready',
-        uploadFile: { is: { projectId, sessionId } }
-      },
-      select: {
-        contentStorageKey: true,
-        filename: true,
-        sizeBytes: true,
-        checksum: true
-      }
-    })
-    if (!version) {
-      throw new Error(`Ready Upload Version authority is unavailable: ${versionId}`)
-    }
-    if (version.filename !== input.filename) {
-      throw new Error(`Ready Upload Version filename does not match: ${versionId}`)
-    }
-
-    const finalPath = resolve(this.storageRoot, ...version.contentStorageKey.split('/'))
-    assertPathInsideRoot(this.storageRoot, finalPath, 'Upload storage key escapes storage.')
-    const finalInfo = await stat(finalPath)
-    if (
-      !finalInfo.isFile() ||
-      finalInfo.size !== Number(version.sizeBytes) ||
-      (await sha256File(finalPath)) !== version.checksum
-    ) {
-      throw new Error(`Ready Upload Version content is unavailable or corrupt: ${versionId}`)
-    }
-
-    // A pre-existing claim has lost the pre-rename inode witness held by its original process. Never
-    // delete that candidate from checksum alone: restore it without overwrite, release the claim, and
-    // make this invocation prove the legacy path again before acquiring a fresh claim.
-    if (privateInfo) {
-      await this.restoreLegacyCleanupPrivate(
-        cleanupPrivateDir,
-        cleanupPrivatePath,
-        expectedLegacyPath,
-        privateInfo
-      )
-    }
-
-    let verifiedLegacyInfo: FileIdentity
-    try {
-      initialLegacyInfo = await lstat(expectedLegacyPath)
-      if (!initialLegacyInfo.isFile() || initialLegacyInfo.isSymbolicLink()) {
-        return {
-          status: 'unsafe-residual',
-          reason: 'the deterministic legacy path is not a regular owned file'
-        }
-      }
-      const sourcePath = await this.resolveManagedUploadPath(
-        { path: expectedLegacyPath },
-        { projectId, sessionId }
-      )
-      const resolvedLegacyPath = await realpath(expectedLegacyPath)
-      const resolvedFinalPath = await realpath(finalPath)
-      if (
-        sourcePath !== resolvedLegacyPath ||
-        sourcePath === resolvedFinalPath ||
-        initialLegacyInfo.size !== Number(version.sizeBytes)
-      ) {
-        return {
-          status: 'unsafe-residual',
-          reason: 'the deterministic legacy path does not match the Version-owned source'
-        }
-      }
-
-      const legacyChecksum = await (this.options.getLegacyFileChecksum ?? sha256File)(
-        expectedLegacyPath
-      )
-      if (legacyChecksum !== version.checksum) {
-        return {
-          status: 'unsafe-residual',
-          reason: 'the deterministic legacy path contains different content'
-        }
-      }
-
-      verifiedLegacyInfo = await lstat(expectedLegacyPath)
-      const verifiedLegacyPath = await realpath(expectedLegacyPath)
-      if (
-        !verifiedLegacyInfo.isFile() ||
-        verifiedLegacyInfo.isSymbolicLink() ||
-        verifiedLegacyPath !== sourcePath ||
-        !hasSameFileSnapshot(verifiedLegacyInfo, initialLegacyInfo)
-      ) {
-        return {
-          status: 'unsafe-residual',
-          reason: 'the deterministic legacy path changed during ownership verification'
-        }
-      }
-    } catch (error) {
-      if (isMissingFileError(error)) return { status: 'absent' }
-      throw error
-    }
-
-    try {
-      // mkdir is the no-replace claim Node exposes portably. Once this empty directory is ours, the
-      // rename target inside it cannot collide with another cooperating cleanup process.
-      await mkdir(cleanupPrivateDir)
-    } catch (error) {
-      if (isFileExistsError(error)) {
-        throw new LegacyCleanupIncompleteError(
-          `Legacy upload cleanup private claim is already occupied: ${input.filename}`
-        )
-      }
-      throw error
-    }
-
-    try {
-      await (this.options.renameLegacyForCleanup ?? rename)(expectedLegacyPath, cleanupPrivatePath)
-    } catch (error) {
-      if (isMissingFileError(error)) {
-        try {
-          await rmdir(cleanupPrivateDir)
-        } catch {
-          throw new LegacyCleanupIncompleteError(
-            `Legacy upload cleanup could not release its private claim: ${input.filename}`
-          )
-        }
-        return { status: 'absent' }
-      }
-      throw error
-    }
-
-    const movedInfo = await lstat(cleanupPrivatePath)
-    const movedChecksum = await sha256File(cleanupPrivatePath)
-    const reverifiedMovedInfo = await lstat(cleanupPrivatePath)
-    if (
-      !hasSameFileIdentity(movedInfo, verifiedLegacyInfo) ||
-      movedChecksum !== version.checksum ||
-      !hasSameFileSnapshot(reverifiedMovedInfo, movedInfo)
-    ) {
-      await this.restoreLegacyCleanupPrivate(
-        cleanupPrivateDir,
-        cleanupPrivatePath,
-        expectedLegacyPath,
-        reverifiedMovedInfo
-      )
-      return {
-        status: 'unsafe-residual',
-        reason: 'the claimed legacy source changed before removal'
-      }
-    }
-
-    await rm(cleanupPrivatePath, { force: true })
-    await rmdir(cleanupPrivateDir)
-    return { status: 'removed' }
-  }
-
-  private async restoreLegacyCleanupPrivate(
-    cleanupPrivateDir: string,
-    cleanupPrivatePath: string,
-    expectedLegacyPath: string,
-    privateInfo: FileIdentity
-  ): Promise<void> {
-    if (!privateInfo.isFile() || privateInfo.isSymbolicLink()) {
-      throw new LegacyCleanupIncompleteError(
-        `Legacy upload cleanup left an unverifiable private candidate: ${basename(expectedLegacyPath)}`
-      )
-    }
-
-    try {
-      await link(cleanupPrivatePath, expectedLegacyPath)
-    } catch (error) {
-      if (isFileExistsError(error)) {
-        // If a previous restore linked the same inode before crashing, finish removal of the extra
-        // private name. Any different replacement wins EEXIST and remains untouched alongside it.
-        const currentLegacyInfo = await lstat(expectedLegacyPath).catch(() => undefined)
-        if (currentLegacyInfo && hasSameFileIdentity(currentLegacyInfo, privateInfo)) {
-          await rm(cleanupPrivatePath, { force: true })
-          await rmdir(cleanupPrivateDir)
-          return
-        }
-      }
-      throw new LegacyCleanupIncompleteError(
-        `Legacy upload cleanup could not safely restore a private candidate: ${basename(expectedLegacyPath)}`
-      )
-    }
-
-    await rm(cleanupPrivatePath, { force: true })
-    await rmdir(cleanupPrivateDir)
-  }
-
-  // Session/project deletion removes the final JSON authority needed to discover a legacy duplicate.
-  // Refuse that terminal commit while any deterministic candidate remains, including a replacement
-  // file that fail-closed checksum or inode validation deliberately would not delete.
-  private async assertLegacySourceAbsent(
-    sessionId: string,
-    filename: string,
-    cleanup: LegacyCleanupResult
-  ): Promise<void> {
-    const legacyRoot = this.getSessionUploadDir(assertSafePathSegment(sessionId))
-    const legacyPath = resolve(legacyRoot, filename)
-    const cleanupPrivateDir = `${legacyPath}${LEGACY_CLEANUP_PRIVATE_SUFFIX}`
-    assertPathInsideRoot(legacyRoot, legacyPath)
-    assertPathInsideRoot(legacyRoot, cleanupPrivateDir)
-    try {
-      await lstat(cleanupPrivateDir)
-      throw new LegacyCleanupIncompleteError(
-        `Legacy upload cleanup found an incomplete private claim: ${filename}`
-      )
-    } catch (error) {
-      if (!isMissingFileError(error)) throw error
-    }
-    try {
-      await lstat(legacyPath)
-    } catch (error) {
-      if (isMissingFileError(error)) return
-      throw error
-    }
-    if (cleanup.status === 'unsafe-residual') {
-      throw new UnsafeLegacyUploadResidualError(
-        `Legacy upload source is not owned by its ready Version: ${filename}; ${cleanup.reason}.`
-      )
-    }
-    throw new Error(`Legacy upload cleanup is incomplete: ${filename}`)
-  }
-
-  // Returns the staging or durable directory for one upload session.
-  private getSessionUploadDir(sessionId: string): string {
-    return getSessionUploadDir(this.storageRoot, sessionId)
   }
 }
 

--- a/src/main/uploads/verified-legacy-cleanup-owner.ts
+++ b/src/main/uploads/verified-legacy-cleanup-owner.ts
@@ -1,0 +1,357 @@
+import { createReadStream } from 'node:fs'
+import { link, lstat, mkdir, realpath, rename, rm, rmdir, stat } from 'node:fs/promises'
+import { basename, join, resolve } from 'node:path'
+import { createHash } from 'node:crypto'
+
+import type { PrismaClient } from '@prisma/client'
+
+import type { DeleteUploadRequest } from '../../shared/uploads'
+import {
+  assertPathInsideRoot,
+  assertSafePathSegment,
+  getSessionUploadDir,
+  isFileExistsError,
+  isMissingFileError
+} from './storage-helpers'
+
+const LEGACY_CLEANUP_PRIVATE_SUFFIX = '.legacy-cleanup.private'
+const LEGACY_CLEANUP_CANDIDATE = 'candidate'
+
+type VerifiedLegacyCleanupOptions = {
+  getClient?: () => Promise<PrismaClient>
+  getLegacyFileChecksum?: (path: string) => Promise<string>
+  renameLegacyForCleanup?: (source: string, destination: string) => Promise<void>
+}
+
+type VerifiedLegacyCleanupDependencies = {
+  resolveManagedUploadPath: (
+    request: DeleteUploadRequest,
+    scope?: { projectId?: string; sessionId?: string }
+  ) => Promise<string>
+}
+
+type RemoveVerifiedLegacyCopyInput = {
+  projectId: string
+  sessionId: string
+  uploadFileId: string
+  versionId: string
+  filename: string
+  legacyPath?: string
+}
+
+type LegacyCleanupResult =
+  { status: 'absent' | 'removed' } | { status: 'unsafe-residual'; reason: string }
+
+type FileIdentity = Awaited<ReturnType<typeof lstat>>
+
+const sha256File = async (filePath: string): Promise<string> => {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk)
+  return hash.digest('hex')
+}
+
+const hasSameFileIdentity = (left: FileIdentity, right: FileIdentity): boolean =>
+  left.dev === right.dev && left.ino === right.ino && left.size === right.size
+
+const hasSameFileSnapshot = (left: FileIdentity, right: FileIdentity): boolean =>
+  hasSameFileIdentity(left, right) &&
+  left.mtimeMs === right.mtimeMs &&
+  left.ctimeMs === right.ctimeMs
+
+class LegacyCleanupIncompleteError extends Error {}
+
+// Terminal Project deletion may leave bytes only when reconciliation has positively proved that the
+// deterministic legacy path no longer contains the Version-owned source.
+class UnsafeLegacyUploadResidualError extends Error {}
+
+// Sole owner of verified legacy source removal, private-claim restoration and absence proof.
+class VerifiedLegacyCleanupOwner {
+  constructor(
+    private readonly storageRoot: string,
+    private readonly options: VerifiedLegacyCleanupOptions,
+    private readonly dependencies: VerifiedLegacyCleanupDependencies
+  ) {}
+
+  async hasPrivateClaim(legacyPath: string): Promise<boolean> {
+    try {
+      await lstat(`${legacyPath}${LEGACY_CLEANUP_PRIVATE_SUFFIX}`)
+      return true
+    } catch (error) {
+      if (isMissingFileError(error)) return false
+      throw error
+    }
+  }
+
+  // Cleanup is fail-closed: SQLite authority, both byte copies, the deterministic legacy path and
+  // source identity must all remain valid through the final pre-delete check.
+  async removeVerifiedLegacyCopy(
+    input: RemoveVerifiedLegacyCopyInput
+  ): Promise<LegacyCleanupResult> {
+    const projectId = assertSafePathSegment(input.projectId)
+    const sessionId = assertSafePathSegment(input.sessionId)
+    const uploadFileId = assertSafePathSegment(input.uploadFileId)
+    const versionId = assertSafePathSegment(input.versionId)
+    const legacyRoot = getSessionUploadDir(this.storageRoot, sessionId)
+    const expectedLegacyPath = resolve(legacyRoot, input.filename)
+    const cleanupPrivateDir = `${expectedLegacyPath}${LEGACY_CLEANUP_PRIVATE_SUFFIX}`
+    const cleanupPrivatePath = join(cleanupPrivateDir, LEGACY_CLEANUP_CANDIDATE)
+    assertPathInsideRoot(legacyRoot, expectedLegacyPath)
+    assertPathInsideRoot(legacyRoot, cleanupPrivateDir)
+    assertPathInsideRoot(legacyRoot, cleanupPrivatePath)
+
+    let initialLegacyInfo: FileIdentity | undefined
+    let privateDirInfo: FileIdentity | undefined
+    let privateInfo: FileIdentity | undefined
+    try {
+      initialLegacyInfo = await lstat(expectedLegacyPath)
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+    }
+    try {
+      privateDirInfo = await lstat(cleanupPrivateDir)
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+    }
+    if (privateDirInfo) {
+      if (!privateDirInfo.isDirectory() || privateDirInfo.isSymbolicLink()) {
+        throw new LegacyCleanupIncompleteError(
+          `Legacy upload cleanup found an unsafe private claim: ${input.filename}`
+        )
+      }
+      try {
+        privateInfo = await lstat(cleanupPrivatePath)
+      } catch (error) {
+        if (!isMissingFileError(error)) throw error
+        try {
+          await rmdir(cleanupPrivateDir)
+          privateDirInfo = undefined
+        } catch {
+          throw new LegacyCleanupIncompleteError(
+            `Legacy upload cleanup found an incomplete private claim: ${input.filename}`
+          )
+        }
+      }
+    }
+    if (!initialLegacyInfo && !privateInfo) return { status: 'absent' }
+
+    if (input.legacyPath && resolve(input.legacyPath) !== expectedLegacyPath) {
+      return {
+        status: 'unsafe-residual',
+        reason: 'the recorded legacy path does not match its deterministic Session path'
+      }
+    }
+    if (!this.options.getClient) {
+      throw new Error(`Upload Version authority is unavailable for legacy cleanup: ${versionId}`)
+    }
+
+    const client = await this.options.getClient()
+    const version = await client.uploadVersion.findFirst({
+      where: {
+        id: versionId,
+        uploadFileId,
+        state: 'ready',
+        uploadFile: { is: { projectId, sessionId } }
+      },
+      select: { contentStorageKey: true, filename: true, sizeBytes: true, checksum: true }
+    })
+    if (!version) throw new Error(`Ready Upload Version authority is unavailable: ${versionId}`)
+    if (version.filename !== input.filename) {
+      throw new Error(`Ready Upload Version filename does not match: ${versionId}`)
+    }
+
+    const finalPath = resolve(this.storageRoot, ...version.contentStorageKey.split('/'))
+    assertPathInsideRoot(this.storageRoot, finalPath, 'Upload storage key escapes storage.')
+    const finalInfo = await stat(finalPath)
+    if (
+      !finalInfo.isFile() ||
+      finalInfo.size !== Number(version.sizeBytes) ||
+      (await sha256File(finalPath)) !== version.checksum
+    ) {
+      throw new Error(`Ready Upload Version content is unavailable or corrupt: ${versionId}`)
+    }
+
+    // A pre-existing claim has lost its original process's pre-rename inode witness. Restore it
+    // without overwrite and make this invocation prove the legacy path again before reacquiring it.
+    if (privateInfo) {
+      await this.restoreLegacyCleanupPrivate(
+        cleanupPrivateDir,
+        cleanupPrivatePath,
+        expectedLegacyPath,
+        privateInfo
+      )
+    }
+
+    let verifiedLegacyInfo: FileIdentity
+    try {
+      initialLegacyInfo = await lstat(expectedLegacyPath)
+      if (!initialLegacyInfo.isFile() || initialLegacyInfo.isSymbolicLink()) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the deterministic legacy path is not a regular owned file'
+        }
+      }
+      const sourcePath = await this.dependencies.resolveManagedUploadPath(
+        { path: expectedLegacyPath },
+        { projectId, sessionId }
+      )
+      const resolvedLegacyPath = await realpath(expectedLegacyPath)
+      const resolvedFinalPath = await realpath(finalPath)
+      if (
+        sourcePath !== resolvedLegacyPath ||
+        sourcePath === resolvedFinalPath ||
+        initialLegacyInfo.size !== Number(version.sizeBytes)
+      ) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the deterministic legacy path does not match the Version-owned source'
+        }
+      }
+      const legacyChecksum = await (this.options.getLegacyFileChecksum ?? sha256File)(
+        expectedLegacyPath
+      )
+      if (legacyChecksum !== version.checksum) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the deterministic legacy path contains different content'
+        }
+      }
+      verifiedLegacyInfo = await lstat(expectedLegacyPath)
+      const verifiedLegacyPath = await realpath(expectedLegacyPath)
+      if (
+        !verifiedLegacyInfo.isFile() ||
+        verifiedLegacyInfo.isSymbolicLink() ||
+        verifiedLegacyPath !== sourcePath ||
+        !hasSameFileSnapshot(verifiedLegacyInfo, initialLegacyInfo)
+      ) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the deterministic legacy path changed during ownership verification'
+        }
+      }
+    } catch (error) {
+      if (isMissingFileError(error)) return { status: 'absent' }
+      throw error
+    }
+
+    try {
+      // mkdir is the portable no-replace claim; the rename target inside it cannot collide with
+      // another cooperating cleanup process.
+      await mkdir(cleanupPrivateDir)
+    } catch (error) {
+      if (isFileExistsError(error)) {
+        throw new LegacyCleanupIncompleteError(
+          `Legacy upload cleanup private claim is already occupied: ${input.filename}`
+        )
+      }
+      throw error
+    }
+    try {
+      await (this.options.renameLegacyForCleanup ?? rename)(expectedLegacyPath, cleanupPrivatePath)
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        try {
+          await rmdir(cleanupPrivateDir)
+        } catch {
+          throw new LegacyCleanupIncompleteError(
+            `Legacy upload cleanup could not release its private claim: ${input.filename}`
+          )
+        }
+        return { status: 'absent' }
+      }
+      throw error
+    }
+
+    const movedInfo = await lstat(cleanupPrivatePath)
+    const movedChecksum = await sha256File(cleanupPrivatePath)
+    const reverifiedMovedInfo = await lstat(cleanupPrivatePath)
+    if (
+      !hasSameFileIdentity(movedInfo, verifiedLegacyInfo) ||
+      movedChecksum !== version.checksum ||
+      !hasSameFileSnapshot(reverifiedMovedInfo, movedInfo)
+    ) {
+      await this.restoreLegacyCleanupPrivate(
+        cleanupPrivateDir,
+        cleanupPrivatePath,
+        expectedLegacyPath,
+        reverifiedMovedInfo
+      )
+      return {
+        status: 'unsafe-residual',
+        reason: 'the claimed legacy source changed before removal'
+      }
+    }
+
+    await rm(cleanupPrivatePath, { force: true })
+    await rmdir(cleanupPrivateDir)
+    return { status: 'removed' }
+  }
+
+  private async restoreLegacyCleanupPrivate(
+    cleanupPrivateDir: string,
+    cleanupPrivatePath: string,
+    expectedLegacyPath: string,
+    privateInfo: FileIdentity
+  ): Promise<void> {
+    if (!privateInfo.isFile() || privateInfo.isSymbolicLink()) {
+      throw new LegacyCleanupIncompleteError(
+        `Legacy upload cleanup left an unverifiable private candidate: ${basename(expectedLegacyPath)}`
+      )
+    }
+    try {
+      await link(cleanupPrivatePath, expectedLegacyPath)
+    } catch (error) {
+      if (isFileExistsError(error)) {
+        const currentLegacyInfo = await lstat(expectedLegacyPath).catch(() => undefined)
+        if (currentLegacyInfo && hasSameFileIdentity(currentLegacyInfo, privateInfo)) {
+          await rm(cleanupPrivatePath, { force: true })
+          await rmdir(cleanupPrivateDir)
+          return
+        }
+      }
+      throw new LegacyCleanupIncompleteError(
+        `Legacy upload cleanup could not safely restore a private candidate: ${basename(expectedLegacyPath)}`
+      )
+    }
+    await rm(cleanupPrivatePath, { force: true })
+    await rmdir(cleanupPrivateDir)
+  }
+
+  async assertLegacySourceAbsent(
+    sessionId: string,
+    filename: string,
+    cleanup: LegacyCleanupResult
+  ): Promise<void> {
+    const legacyRoot = getSessionUploadDir(this.storageRoot, assertSafePathSegment(sessionId))
+    const legacyPath = resolve(legacyRoot, filename)
+    const cleanupPrivateDir = `${legacyPath}${LEGACY_CLEANUP_PRIVATE_SUFFIX}`
+    assertPathInsideRoot(legacyRoot, legacyPath)
+    assertPathInsideRoot(legacyRoot, cleanupPrivateDir)
+    try {
+      await lstat(cleanupPrivateDir)
+      throw new LegacyCleanupIncompleteError(
+        `Legacy upload cleanup found an incomplete private claim: ${filename}`
+      )
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+    }
+    try {
+      await lstat(legacyPath)
+    } catch (error) {
+      if (isMissingFileError(error)) return
+      throw error
+    }
+    if (cleanup.status === 'unsafe-residual') {
+      throw new UnsafeLegacyUploadResidualError(
+        `Legacy upload source is not owned by its ready Version: ${filename}; ${cleanup.reason}.`
+      )
+    }
+    throw new Error(`Legacy upload cleanup is incomplete: ${filename}`)
+  }
+}
+
+export { UnsafeLegacyUploadResidualError, VerifiedLegacyCleanupOwner }
+export type {
+  LegacyCleanupResult,
+  RemoveVerifiedLegacyCopyInput,
+  VerifiedLegacyCleanupDependencies
+}


### PR DESCRIPTION
## Problem

After UP2, the Upload Repository facade is below the completion gate but still contains the entire
legacy upgrade, staging crash recovery, orphan adoption and verified legacy cleanup lifecycle. This
final stateful/transactional boundary should be explicit and mechanically certified.

## Proposed change

- Extract one internal legacy-recovery owner for Session reference validation, legacy upgrade,
  staging recovery, orphan-candidate authority and completion of staging Upload Versions.
- Extract one internal verified-cleanup owner for live-copy/private-candidate cleanup, compensation,
  source-absence proof and cleanup restoration; the recovery owner composes it through a narrow
  interface.
- Keep all 15 existing async methods on `UploadRepository`; the facade composes transfer,
  publication, resolver and legacy owners exactly once and delegates without changing contracts.
- Add/extend an architecture contract that freezes the final public/export inventory, unique owner
  composition, absence of shadow mutable/cleanup logic and <=660 raw-line gate.

## Scope and non-goals

- Internal ownership extraction and certification only; no caller, preload, IPC, command or shared
  type migration.
- No upload identity, checksum, Session reference, Version row/state, staging/storage layout, atomic
  move, orphan adoption, cleanup/compensation, retry or error semantic change.
- No new cleanup path and no broadening of deletion; durable bytes retain existing policy.
- No data model, UI, MCP or cross-surface capability change.

## Compatibility

- Preserve live-save/reconcile/orphan-recovery/terminal-delete modes and their distinct source
  preservation/cleanup behavior.
- Preserve publication transaction ordering, staging-to-ready recovery, positively-proven orphan
  suppression, sibling-settlement guard and failure retry boundaries.
- Preserve Electron/Web/CLI/Task/local-RPC/MCP behavior and Specialist/Permission/Compute asymmetry.
- Keep all filesystem paths/fixtures portable on Windows, macOS and Linux via `node:path` and
  repository-owned temporary roots.

## Acceptance criteria and validation

- Exactly one legacy-recovery owner decides upgrade/recovery/adoption, and exactly one cleanup owner
  decides verified legacy cleanup/compensation; the facade contains composition/delegation only.
- Every production module is <=660 raw lines and final facade/owner/helper counts are reported.
- UP0-UP2 characterization and final architecture tests, upload command/IPC, Session deletion, ACP
  resolver/prompt/runtime and conversation-import consumers, module-impact validation, Node/Web
  typecheck, lint/format and independent Standards/Spec pass.
- Exact-head PR Gate, CI Integrity, CodeQL and AI pass before squash merge.

Implementation evidence before final rebase:

- `repository.ts`: 970 -> 167 raw lines; stable constructor, 15 async methods and three value
  exports remain as composition/delegation.
- `legacy-recovery-owner.ts`: 477 raw lines; sole upgrade/recovery/orphan/staging-Version owner.
- `verified-legacy-cleanup-owner.ts`: 357 raw lines; sole verified cleanup/restore/source-proof owner.
- All uploads production modules are <=660; production total is 970 -> 1,001 raw lines (+31).
- Final module-impact selection: 9 files / 116 tests; final architecture + manifest checks 22/22;
  ACP runtime 447/447; Node/Web typecheck, changed ESLint, Prettier and diff-check pass.
- Spec initially found the architecture contract did not freeze constructor, all public methods,
  owner construction/delegation and declaration ownership; the strengthened AST contract closed the
  P1 and Spec re-review reached 0 findings.
- Standards re-review found handwritten production-file enumeration and default/namespace export
  parsing could fail open; dynamic production discovery and complete value-export parsing closed the
  findings, with final Standards re-review at 0 findings.

## Review focus

- Confirm no recovery, cleanup or source-removal ordering changed and no new destructive path exists.
- Confirm orphan adoption suppresses only the same positively proven missing-authority state.
- Confirm final facade public/export inventory, path/data/IPC/UI and cross-surface behavior remain
  unchanged.
