### PR TITLE
fix(task-api): add explicit run cancellation

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -98,13 +98,17 @@ to poll its state:
 ```bash
 open-science run --project "Systematic review" --prompt-file ./task.md --json
 open-science run status <run-id> --json
+open-science run cancel <run-id> --json
 open-science session status <session-id> --json
 ```
 
 Use `--timeout-ms <milliseconds>` with `--wait` to bound how long the client waits. A timeout stops the
 CLI wait and returns exit code `1`; it does not cancel the run, which can still be inspected with
-`open-science run status <run-id>`. When the `ask` approval profile needs permission, human-readable
-output directs the user to approve the request in Open Science Desktop or the Web UI.
+`open-science run status <run-id>`. Add `--cancel-on-timeout` to explicitly cancel the server run after
+the timeout; the command still reports the original timeout and returns exit code `1`. Explicit
+cancellation waits for provider work and application finalization to drain, and preserves partial
+output and successfully finalized artifacts. When the `ask` approval profile needs permission,
+human-readable output directs the user to approve the request in Open Science Desktop or the Web UI.
 
 Pass an existing session ID to continue a conversation. Approval profiles are `ask`, `auto`, and
 `full`; `--skill` is repeatable:

--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -21,5 +21,13 @@ const result = await client.waitForRun(run.id)
 console.log(result.output)
 ```
 
+To stop a still-running task instead of waiting for it, cancel it explicitly. Cancellation waits for
+provider work and application finalization to drain before returning the terminal Run:
+
+```js
+const cancelled = await client.cancelRun(run.id)
+console.log(cancelled.status) // cancelled
+```
+
 The client discovers the local daemon and reads its authentication token from the Open Science config
 directory. Tokens are sent in request headers and are never included in normal command output.

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -30,6 +30,7 @@ Commands:
   project create <name> [--description <text>]
   run --project <id-or-name> (--prompt <text> | --prompt-file <path>) [--wait]
   run status <run-id>
+  run cancel <run-id>
   session status <session-id>
   artifacts list <session-id>
   artifacts download <artifact-id> --output <path>
@@ -48,6 +49,7 @@ Options:
   --skill <id>           Force-load a skill for this run (repeatable)
   --wait                 Wait for the run to finish
   --timeout-ms <ms>      Stop waiting after this many milliseconds
+  --cancel-on-timeout    Cancel the server run when --timeout-ms expires
   --jsonl                With run --wait, stream one machine-readable event per line
   --output <path>        Artifact download destination
   --yes                  Confirm the offline rollback conversion
@@ -89,7 +91,8 @@ export const parseCliArgs = (argv) => {
   const args = [...argv]
   const command = args.shift()
   const subcommand =
-    GROUP_COMMANDS.has(command) || (command === 'run' && args[0] === 'status')
+    GROUP_COMMANDS.has(command) ||
+    (command === 'run' && (args[0] === 'status' || args[0] === 'cancel'))
       ? args.shift()
       : undefined
   const options = {
@@ -107,6 +110,7 @@ export const parseCliArgs = (argv) => {
     else if (arg === '--yes') options.yes = true
     else if (arg === '--jsonl') options.jsonl = true
     else if (arg === '--wait') options.wait = true
+    else if (arg === '--cancel-on-timeout') options.cancelOnTimeout = true
     else if (arg === '--skill') {
       const value = args.shift()
       if (!value) throw new CliUsageError('--skill requires a value.')
@@ -147,6 +151,9 @@ export const parseCliArgs = (argv) => {
   }
   if (options.timeoutMs !== undefined && (command !== 'run' || subcommand || !options.wait)) {
     throw new CliUsageError('--timeout-ms requires run --wait.')
+  }
+  if (options.cancelOnTimeout && options.timeoutMs === undefined) {
+    throw new CliUsageError('--cancel-on-timeout requires --timeout-ms.')
   }
   if (options.noSandbox && command !== 'start') {
     throw new CliUsageError('--no-sandbox requires start.')
@@ -682,6 +689,12 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
     outputValue(await client.getRun(runId), options, deps)
     return
   }
+  if (command === 'run' && subcommand === 'cancel') {
+    const runId = positionals[0]
+    if (!runId) throw new CliUsageError('Run id is required.')
+    outputValue(await client.cancelRun(runId), options, deps)
+    return
+  }
   if (command === 'run') {
     if (!options.project) throw new CliUsageError('--project is required.')
     const prompt = await readPrompt(options, deps)
@@ -712,11 +725,27 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
           emitRunEvent(event, options, deps)
         }
       }
-      result = options.wait
-        ? options.timeoutMs === undefined
-          ? await client.waitForRun(started.id)
-          : await client.waitForRun(started.id, { timeoutMs: options.timeoutMs })
-        : started
+      try {
+        result = options.wait
+          ? options.timeoutMs === undefined
+            ? await client.waitForRun(started.id)
+            : await client.waitForRun(started.id, { timeoutMs: options.timeoutMs })
+          : started
+      } catch (error) {
+        if (options.cancelOnTimeout && error?.code === 'timeout') {
+          try {
+            await client.cancelRun(started.id)
+          } catch (cancelError) {
+            if (error instanceof Error) {
+              if (error.cause === undefined) error.cause = cancelError
+              const cancelMessage =
+                cancelError instanceof Error ? cancelError.message : String(cancelError)
+              error.message = `${error.message} Server run cancellation also failed: ${cancelMessage}`
+            }
+          }
+        }
+        throw error
+      }
     } finally {
       abortController.abort()
       await eventTask
@@ -724,6 +753,7 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
     if (options.json || options.jsonl) outputValue(result, options, deps)
     else if (result.status === 'completed') deps.log(result.output || `Run completed: ${result.id}`)
     else if (result.status === 'failed') deps.log(`Run failed: ${result.error ?? result.id}`)
+    else if (result.status === 'cancelled') deps.log(`Run cancelled: ${result.id}`)
     else deps.log(`Run started: ${result.id} (session ${result.sessionId})`)
     if (result.status === 'failed') deps.setExitCode(1)
     return

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -45,6 +45,12 @@ describe('task CLI', () => {
       positionals: ['run-1'],
       options: { open: true, json: true, jsonl: false, wait: false }
     })
+    expect(parseCliArgs(['run', 'cancel', 'run-1', '--json'])).toEqual({
+      command: 'run',
+      subcommand: 'cancel',
+      positionals: ['run-1'],
+      options: { open: true, json: true, jsonl: false, wait: false }
+    })
     expect(
       parseCliArgs([
         'run',
@@ -62,6 +68,22 @@ describe('task CLI', () => {
     expect(() => parseCliArgs(['run', '--timeout-ms', '1000'])).toThrow(
       '--timeout-ms requires run --wait.'
     )
+    expect(() => parseCliArgs(['run', '--cancel-on-timeout', '--wait'])).toThrow(
+      '--cancel-on-timeout requires --timeout-ms.'
+    )
+    expect(
+      parseCliArgs([
+        'run',
+        '--project',
+        'project-1',
+        '--prompt',
+        'Research this.',
+        '--wait',
+        '--timeout-ms',
+        '1000',
+        '--cancel-on-timeout'
+      ]).options.cancelOnTimeout
+    ).toBe(true)
     expect(
       parseCliArgs([
         'run',
@@ -193,6 +215,7 @@ describe('task CLI', () => {
       createProject: vi.fn().mockResolvedValue({ id: 'project-2', name: 'Created' }),
       getSession: vi.fn().mockResolvedValue({ id: 'session-1', status: 'idle' }),
       getRun: vi.fn().mockResolvedValue({ id: 'run-1', status: 'completed' }),
+      cancelRun: vi.fn().mockResolvedValue({ id: 'run-1', status: 'cancelled' }),
       listArtifacts: vi.fn().mockResolvedValue([{ id: 'artifact-1', name: 'report.md' }]),
       downloadArtifact: vi.fn().mockResolvedValue(new Response('report'))
     }
@@ -203,6 +226,15 @@ describe('task CLI', () => {
 
     await runTaskCommand(
       { command: 'project', subcommand: 'list', options: { json: true, jsonl: false } },
+      deps
+    )
+    await runTaskCommand(
+      {
+        command: 'run',
+        subcommand: 'cancel',
+        positionals: ['run-1'],
+        options: { json: true, jsonl: false }
+      },
       deps
     )
     await runTaskCommand(
@@ -254,6 +286,7 @@ describe('task CLI', () => {
     expect(client.createProject).toHaveBeenCalledWith({ name: 'Created', description: undefined })
     expect(client.getSession).toHaveBeenCalledWith('session-1')
     expect(client.getRun).toHaveBeenCalledWith('run-1')
+    expect(client.cancelRun).toHaveBeenCalledWith('run-1')
     expect(client.listArtifacts).toHaveBeenCalledWith('session-1')
     expect(client.downloadArtifact).toHaveBeenCalledWith('artifact-1')
     expect(writeDownload).toHaveBeenCalledWith(expect.any(Response), 'report.md')
@@ -413,7 +446,7 @@ describe('task CLI', () => {
     )
   })
 
-  it('stops only the CLI event wait when a timeout occurs', async () => {
+  it('stops only the CLI event wait when a timeout occurs by default', async () => {
     const timeout = Object.assign(new Error('Timed out waiting for run run-1.'), {
       code: 'timeout'
     })
@@ -443,7 +476,8 @@ describe('task CLI', () => {
         sessionId: 'session-1',
         status: 'running'
       }),
-      waitForRun: vi.fn().mockRejectedValue(timeout)
+      waitForRun: vi.fn().mockRejectedValue(timeout),
+      cancelRun: vi.fn()
     }
 
     await expect(
@@ -465,7 +499,86 @@ describe('task CLI', () => {
 
     expect(client.waitForRun).toHaveBeenCalledWith('run-1', { timeoutMs: 25 })
     expect(eventSignal?.aborted).toBe(true)
-    expect(client).not.toHaveProperty('cancelRun')
+    expect(client.cancelRun).not.toHaveBeenCalled()
+  })
+
+  it('explicitly cancels the server run after a wait timeout and preserves the timeout error', async () => {
+    const timeout = Object.assign(new Error('Timed out waiting for run run-1.'), {
+      code: 'timeout'
+    })
+    const client = {
+      startRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: 'session-1',
+        status: 'running'
+      }),
+      waitForRun: vi.fn().mockRejectedValue(timeout),
+      cancelRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: 'session-1',
+        status: 'cancelled'
+      })
+    }
+
+    await expect(
+      runTaskCommand(
+        {
+          command: 'run',
+          options: {
+            project: 'project-1',
+            prompt: 'Research this.',
+            wait: true,
+            timeoutMs: 25,
+            cancelOnTimeout: true,
+            json: true,
+            jsonl: false
+          }
+        },
+        { connect: vi.fn().mockResolvedValue(client), stdinIsTTY: true }
+      )
+    ).rejects.toBe(timeout)
+
+    expect(client.waitForRun).toHaveBeenCalledWith('run-1', { timeoutMs: 25 })
+    expect(client.cancelRun).toHaveBeenCalledWith('run-1')
+  })
+
+  it('reports when cancellation after a wait timeout also fails', async () => {
+    const timeout = Object.assign(new Error('Timed out waiting for run run-1.'), {
+      code: 'timeout'
+    })
+    const cancelError = new Error('daemon disconnected')
+    const client = {
+      startRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: 'session-1',
+        status: 'running'
+      }),
+      waitForRun: vi.fn().mockRejectedValue(timeout),
+      cancelRun: vi.fn().mockRejectedValue(cancelError)
+    }
+
+    await expect(
+      runTaskCommand(
+        {
+          command: 'run',
+          options: {
+            project: 'project-1',
+            prompt: 'Research this.',
+            wait: true,
+            timeoutMs: 25,
+            cancelOnTimeout: true,
+            json: true,
+            jsonl: false
+          }
+        },
+        { connect: vi.fn().mockResolvedValue(client), stdinIsTTY: true }
+      )
+    ).rejects.toMatchObject({
+      code: 'timeout',
+      message:
+        'Timed out waiting for run run-1. Server run cancellation also failed: daemon disconnected',
+      cause: cancelError
+    })
   })
 
   it('keeps capability management surfaces outside the CLI', async () => {

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -31,6 +31,7 @@ describe('OpenScienceClient', () => {
         'getSession',
         'startRun',
         'getRun',
+        'cancelRun',
         'waitForRun',
         'listArtifacts',
         'downloadArtifact',
@@ -154,7 +155,42 @@ describe('OpenScienceClient', () => {
     }
   })
 
-  it('honors caller cancellation before polling without exposing a run-cancel operation', async () => {
+  it('cancels one run through the explicit server operation', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      response(200, {
+        data: {
+          id: 'run/1',
+          sessionId: 'session-1',
+          projectId: 'project-1',
+          status: 'cancelled',
+          startedAt: 1,
+          cancelRequestedAt: 2,
+          cancelledAt: 3,
+          completedAt: 3,
+          artifacts: []
+        }
+      })
+    )
+    const client = new OpenScienceClient({
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'secret-token',
+      fetch
+    })
+
+    await expect(client.cancelRun('run/1')).resolves.toMatchObject({
+      id: 'run/1',
+      status: 'cancelled'
+    })
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:44100/api/v1/runs/run%2F1/cancel',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ authorization: 'Bearer secret-token' })
+      })
+    )
+  })
+
+  it('honors caller cancellation before polling without invoking run cancellation', async () => {
     const fetch = vi.fn()
     const client = new OpenScienceClient({
       baseUrl: 'http://127.0.0.1:44100',
@@ -169,7 +205,7 @@ describe('OpenScienceClient', () => {
       cancellation
     )
     expect(fetch).not.toHaveBeenCalled()
-    expect(client).not.toHaveProperty('cancelRun')
+    expect(client.cancelRun).toEqual(expect.any(Function))
     expect(client).not.toHaveProperty('permissions')
     expect(client).not.toHaveProperty('specialists')
     expect(client).not.toHaveProperty('compute')

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -1,5 +1,5 @@
 export type PermissionProfile = 'ask' | 'auto' | 'full'
-export type RunStatus = 'running' | 'completed' | 'failed'
+export type RunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
 
 export type Project = {
   id: string
@@ -16,6 +16,8 @@ export type Run = {
   projectId: string
   status: RunStatus
   startedAt: number
+  cancelRequestedAt?: number
+  cancelledAt?: number
   completedAt?: number
   output?: string
   error?: string
@@ -74,6 +76,7 @@ export class OpenScienceClient {
     skillIds?: string[]
   }): Promise<Run>
   getRun(runId: string): Promise<Run>
+  cancelRun(runId: string): Promise<Run>
   waitForRun(
     runId: string,
     options?: { pollIntervalMs?: number; signal?: AbortSignal; timeoutMs?: number }

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -66,6 +66,10 @@ export class OpenScienceClient {
     return this.request(`/api/v1/runs/${encodeURIComponent(runId)}`)
   }
 
+  cancelRun(runId) {
+    return this.request(`/api/v1/runs/${encodeURIComponent(runId)}/cancel`, { method: 'POST' })
+  }
+
   async waitForRun(runId, { pollIntervalMs = 250, signal, timeoutMs } = {}) {
     if (timeoutMs !== undefined && (!Number.isFinite(timeoutMs) || timeoutMs <= 0)) {
       throw new TypeError('timeoutMs must be a positive number.')

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -12,6 +12,7 @@ describe('ACP Task Agent port', () => {
       | 'resumeSession'
       | 'setPermissionProfile'
       | 'prompt'
+      | 'cancelPrompt'
     >()
   })
 
@@ -32,7 +33,8 @@ describe('ACP Task Agent port', () => {
         contextReset: true
       })),
       setPermissionProfile: vi.fn(async () => undefined),
-      sendPrompt: vi.fn(async () => undefined)
+      sendPrompt: vi.fn(async () => undefined),
+      cancelPrompt: vi.fn(async () => undefined)
     }
     const withSessionAvailable = vi.fn()
     const port = createAcpTaskAgentPort(runtime, { create }, undefined, {
@@ -81,6 +83,7 @@ describe('ACP Task Agent port', () => {
       contextReset: true,
       resumeFallback: { historyPreamble: 'Fallback conversation.' }
     })
+    await port.cancelPrompt('session-stable')
 
     expect(create).toHaveBeenCalledWith({
       projectName: 'project-1',
@@ -108,6 +111,7 @@ describe('ACP Task Agent port', () => {
       contextReset: true,
       resumeFallback: { historyPreamble: 'Fallback conversation.' }
     })
+    expect(runtime.cancelPrompt).toHaveBeenCalledWith({ sessionId: 'session-stable' })
   })
 
   it('keeps Task prompt notification tracking equivalent on success and failure', async () => {
@@ -126,7 +130,8 @@ describe('ACP Task Agent port', () => {
         getSnapshot: () => ({ sessionIds: [] }),
         resumeSession: vi.fn(),
         setPermissionProfile: vi.fn(),
-        sendPrompt
+        sendPrompt,
+        cancelPrompt: vi.fn()
       },
       { create: vi.fn() },
       { trackPrompt, untrackPrompt }

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -13,6 +13,7 @@ type AcpTaskAgentRuntime = {
   resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
   setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<unknown>
   sendPrompt(request: AcpPromptRequest): Promise<unknown>
+  cancelPrompt(request: { sessionId: string }): Promise<unknown>
 }
 
 type TaskPromptNotifications = Pick<TaskNotificationService, 'trackPrompt' | 'untrackPrompt'>
@@ -73,7 +74,8 @@ const createAcpTaskAgentPort = (
       if (tracked) notifications?.untrackPrompt(acpRequest.sessionId, tracked)
       throw error
     }
-  }
+  },
+  cancelPrompt: (sessionId) => runtime.cancelPrompt({ sessionId }).then(() => undefined)
 })
 
 export { createAcpTaskAgentPort }

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { AcpRuntimeEvent } from '../../shared/acp'
 import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
@@ -49,6 +49,7 @@ const createRunner = (overrides: Partial<TaskRunnerDependencies> = {}): TaskRunn
       createSession: async () => ({ sessionId: 'session-created' }),
       resumeSession: async (request) => ({ sessionId: request.sessionId }),
       setPermissionProfile: async () => undefined,
+      cancelPrompt: async () => undefined,
       prompt: async () => undefined
     },
     artifacts: {
@@ -218,6 +219,7 @@ describe('TaskRunner', () => {
         }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
         prompt: async () => {
           emitEvent?.({
             id: 'event-1',
@@ -301,6 +303,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'unused' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
         prompt: async () => promptGate
       },
       createId: () => ids.shift() ?? 'generated-id'
@@ -347,6 +350,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'unused' }),
         resumeSession,
         setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
         prompt: async () => undefined
       }
     })
@@ -410,6 +414,7 @@ describe('TaskRunner', () => {
           return { sessionId: existing.id, cwd: existing.cwd, contextReset: true }
         },
         setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
         prompt: async (request) => {
           prompts.push(request)
         }
@@ -476,6 +481,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'unused' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
         prompt: async (request) => {
           prompts.push(request)
         }
@@ -522,6 +528,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'session-artifact', cwd: '/workspace/artifact' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
         prompt: async () => {
           emitEvent?.({
             id: 'artifact-event',
@@ -604,6 +611,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'session-save', cwd: '/workspace/save' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
         prompt: async () => {
           emitEvent?.({
             id: 'save-event',
@@ -655,6 +663,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'session-partial', cwd: '/workspace/partial' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
         prompt: async () => {
           emitEvent?.({
             id: 'artifact-first',
@@ -759,6 +768,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'session-tool', cwd: '/workspace/tool' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
         prompt: async () => {
           emitEvent?.({
             id: 'tool-start',
@@ -838,6 +848,347 @@ describe('TaskRunner', () => {
     })
   })
 
+  it('cancels one active run, retains partial output, and returns the Session to idle', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let rejectPrompt: ((error: Error) => void) | undefined
+    const promptGate = new Promise<void>((_resolve, reject) => {
+      rejectPrompt = reject
+    })
+    const savedSessions: PersistedChatSession[] = []
+    const cancelPrompt = vi.fn(async (sessionId: string) => {
+      emitEvent?.({
+        id: 'partial-output',
+        timestamp: 20,
+        kind: 'message',
+        level: 'info',
+        sessionId,
+        role: 'assistant',
+        text: 'Partial result.'
+      })
+      rejectPrompt?.(new Error('provider prompt cancelled'))
+    })
+    let time = 100
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-cancel' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        prompt: async () => promptGate,
+        cancelPrompt
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: (() => {
+        const ids = ['cancel-user', 'cancel-run', 'cancel-agent']
+        return () => ids.shift() ?? 'generated-id'
+      })(),
+      now: () => ++time
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Long research.' })
+    const cancelled = await runner.cancelRun(started.id)
+
+    expect(cancelPrompt).toHaveBeenCalledOnce()
+    expect(cancelPrompt).toHaveBeenCalledWith('session-cancel')
+    expect(cancelled).toMatchObject({
+      status: 'cancelled',
+      output: 'Partial result.',
+      cancelRequestedAt: expect.any(Number),
+      cancelledAt: expect.any(Number),
+      completedAt: expect.any(Number)
+    })
+    expect(cancelled.cancelledAt).toBe(cancelled.completedAt)
+    expect(savedSessions.at(-1)).toMatchObject({
+      id: 'session-cancel',
+      status: 'idle',
+      activeRun: undefined,
+      messages: [
+        expect.objectContaining({ role: 'user', content: 'Long research.' }),
+        expect.objectContaining({ role: 'agent', content: 'Partial result.' })
+      ]
+    })
+  })
+
+  it('deduplicates concurrent cancellation and treats terminal cancellation as a read', async () => {
+    let finishPrompt: (() => void) | undefined
+    let acceptCancellation: (() => void) | undefined
+    const promptGate = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const cancellationGate = new Promise<void>((resolve) => {
+      acceptCancellation = resolve
+    })
+    const cancelPrompt = vi.fn(async () => {
+      await cancellationGate
+      finishPrompt?.()
+    })
+    const runner = createRunner({
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-concurrent-cancel' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        prompt: async () => promptGate,
+        cancelPrompt
+      },
+      createId: (() => {
+        const ids = ['concurrent-user', 'concurrent-run', 'concurrent-agent']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Cancel once.' })
+    const first = runner.cancelRun(started.id)
+    const second = runner.cancelRun(started.id)
+    await vi.waitFor(() => expect(cancelPrompt).toHaveBeenCalledOnce())
+    acceptCancellation?.()
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ status: 'cancelled' }),
+      expect.objectContaining({ status: 'cancelled' })
+    ])
+    await expect(runner.cancelRun(started.id)).resolves.toMatchObject({ status: 'cancelled' })
+    expect(cancelPrompt).toHaveBeenCalledOnce()
+  })
+
+  it('leaves a naturally terminal run unchanged when cancellation arrives late', async () => {
+    const cancelPrompt = vi.fn(async () => undefined)
+    const runner = createRunner({
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-completed' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        prompt: async () => undefined,
+        cancelPrompt
+      },
+      createId: (() => {
+        const ids = ['completed-user', 'completed-run', 'completed-agent']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Finish naturally.' })
+    await runner.waitForRun(started.id)
+
+    await expect(runner.cancelRun(started.id)).resolves.toMatchObject({
+      status: 'completed',
+      cancelRequestedAt: undefined,
+      cancelledAt: undefined
+    })
+    expect(cancelPrompt).not.toHaveBeenCalled()
+  })
+
+  it('observes cancellation accepted while the final Session save is draining', async () => {
+    let finalSaveStarted: (() => void) | undefined
+    let releaseFinalSave: (() => void) | undefined
+    const finalSaveStart = new Promise<void>((resolve) => {
+      finalSaveStarted = resolve
+    })
+    const finalSaveGate = new Promise<void>((resolve) => {
+      releaseFinalSave = resolve
+    })
+    let saveCount = 0
+    const cancelPrompt = vi.fn(async () => undefined)
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async () => {
+          saveCount += 1
+          if (saveCount === 2) {
+            finalSaveStarted?.()
+            await finalSaveGate
+          }
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-cancel-during-save' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        prompt: async () => undefined,
+        cancelPrompt
+      },
+      createId: (() => {
+        const ids = ['save-user', 'save-run', 'save-agent']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Finish and persist.' })
+    await finalSaveStart
+    const cancellation = runner.cancelRun(started.id)
+    await vi.waitFor(() => expect(cancelPrompt).toHaveBeenCalledOnce())
+    releaseFinalSave?.()
+
+    await expect(cancellation).resolves.toMatchObject({ status: 'cancelled' })
+  })
+
+  it('keeps a real Prompt failure when cancellation is requested afterward', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let finalizationStarted: (() => void) | undefined
+    let releaseFinalization: (() => void) | undefined
+    const finalizationStart = new Promise<void>((resolve) => {
+      finalizationStarted = resolve
+    })
+    const finalizationGate = new Promise<void>((resolve) => {
+      releaseFinalization = resolve
+    })
+    const cancelPrompt = vi.fn(async () => undefined)
+    const runner = createRunner({
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-failure-before-cancel' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'failure-artifact',
+            timestamp: 20,
+            kind: 'artifact',
+            level: 'info',
+            sessionId: 'session-failure-before-cancel',
+            artifactClaimId: 'claim-failure-before-cancel',
+            artifacts: []
+          })
+          throw new Error('provider failed before cancellation')
+        },
+        cancelPrompt
+      },
+      artifacts: {
+        finalizeRun: async () => {
+          finalizationStarted?.()
+          await finalizationGate
+          return { ok: true, artifacts: [] }
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: (() => {
+        const ids = ['failure-user', 'failure-run', 'failure-agent']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Fail first.' })
+    await finalizationStart
+    const cancellation = runner.cancelRun(started.id)
+    await vi.waitFor(() => expect(cancelPrompt).toHaveBeenCalledOnce())
+    releaseFinalization?.()
+
+    await expect(cancellation).resolves.toMatchObject({
+      status: 'failed',
+      error: 'provider failed before cancellation'
+    })
+  })
+
+  it('clears a rejected cancellation request while the run remains active', async () => {
+    let finishPrompt: (() => void) | undefined
+    const promptGate = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const cancelPrompt = vi.fn(async () => {
+      throw new Error('cancel dispatch failed')
+    })
+    const runner = createRunner({
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-cancel-failure' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        prompt: async () => promptGate,
+        cancelPrompt
+      },
+      createId: (() => {
+        const ids = ['failure-user', 'failure-run', 'failure-agent']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Keep working.' })
+    await expect(runner.cancelRun(started.id)).rejects.toThrow('cancel dispatch failed')
+    expect(runner.getRun(started.id)).toMatchObject({
+      status: 'running',
+      cancelRequestedAt: undefined
+    })
+
+    finishPrompt?.()
+    await expect(runner.waitForRun(started.id)).resolves.toMatchObject({ status: 'completed' })
+  })
+
+  it('lets Artifact finalization failure win after cancellation is accepted', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let finishPrompt: (() => void) | undefined
+    const promptGate = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const runner = createRunner({
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-cancel-artifact' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'cancel-artifact',
+            timestamp: 20,
+            kind: 'artifact',
+            level: 'info',
+            sessionId: 'session-cancel-artifact',
+            artifactClaimId: 'claim-cancel-artifact',
+            artifacts: []
+          })
+          return promptGate
+        },
+        cancelPrompt: async () => finishPrompt?.()
+      },
+      artifacts: {
+        finalizeRun: async () => {
+          throw new Error('artifact finalization failed')
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: (() => {
+        const ids = ['artifact-user', 'artifact-run', 'artifact-agent']
+        return () => ids.shift() ?? 'generated-id'
+      })()
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Create then cancel.' })
+
+    await expect(runner.cancelRun(started.id)).resolves.toMatchObject({
+      status: 'failed',
+      error: 'artifact finalization failed'
+    })
+  })
+
   it('releases its runtime-event subscription when disposed', () => {
     let unsubscribeCount = 0
     const runner = createRunner({
@@ -864,6 +1215,7 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: `session-${++sessionCounter}` }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
         prompt: async () => undefined
       },
       createId: () => `id-${++idCounter}`,

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -96,6 +96,7 @@ type TaskAgentPort = {
   resumeSession(request: TaskAgentResumeSessionRequest): Promise<TaskAgentSession>
   setPermissionProfile(sessionId: string, profile: PermissionProfileId): Promise<void>
   prompt(request: TaskAgentPromptRequest): Promise<void>
+  cancelPrompt(sessionId: string): Promise<void>
 }
 
 type TaskArtifactPort = {
@@ -120,6 +121,10 @@ type TaskRunnerDependencies = {
 type MutableTaskRun = TaskRun & {
   events: AcpRuntimeEvent[]
   completion: Promise<void>
+  cancellation?: {
+    accepted: boolean
+    dispatch: Promise<void>
+  }
 }
 
 type CompletedTaskSession = {
@@ -146,6 +151,8 @@ const cloneRun = (run: MutableTaskRun): TaskRun => ({
   projectId: run.projectId,
   status: run.status,
   startedAt: run.startedAt,
+  cancelRequestedAt: run.cancelRequestedAt,
+  cancelledAt: run.cancelledAt,
   completedAt: run.completedAt,
   output: run.output,
   error: run.error,
@@ -374,6 +381,42 @@ class TaskRunner {
     return cloneRun(run)
   }
 
+  async cancelRun(runId: string): Promise<TaskRun> {
+    const run = this.runs.get(runId)
+    if (!run) throw new TaskRunnerError('run_not_found', `Run not found: ${runId}`)
+    if (run.status !== 'running') return cloneRun(run)
+
+    const existingCancellation = run.cancellation
+    if (existingCancellation) {
+      await existingCancellation.dispatch
+      await run.completion
+      return cloneRun(run)
+    }
+
+    run.cancelRequestedAt = this.dependencies.now()
+    const cancellation = {
+      accepted: false,
+      dispatch: Promise.resolve()
+    }
+    run.cancellation = cancellation
+    cancellation.dispatch = Promise.resolve()
+      .then(() => this.dependencies.agent.cancelPrompt(run.sessionId))
+      .then(() => {
+        cancellation.accepted = true
+      })
+      .catch((error) => {
+        if (run.status === 'running' && run.cancellation === cancellation) {
+          run.cancellation = undefined
+          run.cancelRequestedAt = undefined
+        }
+        throw error
+      })
+
+    await cancellation.dispatch
+    await run.completion
+    return cloneRun(run)
+  }
+
   private reserveSession(sessionId: string, runId: string): void {
     const activeRunId = this.activeRunBySession.get(sessionId)
     if (activeRunId && activeRunId !== runId) {
@@ -486,6 +529,7 @@ class TaskRunner {
     resumeFallback?: TaskAgentPromptRequest['resumeFallback']
   ): Promise<void> {
     let promptError: unknown
+    let cancellationAtPromptFailure: MutableTaskRun['cancellation'] = undefined
     try {
       await this.dependencies.agent.prompt({
         sessionId: session.id,
@@ -498,6 +542,7 @@ class TaskRunner {
       })
     } catch (error) {
       promptError = error
+      cancellationAtPromptFailure = run.cancellation
     }
 
     let completed: CompletedTaskSession | undefined
@@ -513,7 +558,10 @@ class TaskRunner {
       }
     }
 
-    const failure = completionError ?? promptError
+    const cancellation = run.cancellation
+    if (cancellation) await cancellation.dispatch.catch(() => undefined)
+    const promptFailureWasCancelled = cancellationAtPromptFailure?.accepted === true
+    const failure = completionError ?? (promptFailureWasCancelled ? undefined : promptError)
     if (failure) {
       await this.failRun(run, session, completed, failure)
       return
@@ -525,10 +573,15 @@ class TaskRunner {
       await this.failRun(run, session, completed, error)
       return
     }
-    run.status = 'completed'
+    const terminalCancellation = run.cancellation
+    if (terminalCancellation) await terminalCancellation.dispatch.catch(() => undefined)
+    const terminalCancellationAccepted = terminalCancellation?.accepted === true
+    run.status = terminalCancellationAccepted ? 'cancelled' : 'completed'
     run.output = completed!.output
     run.artifacts = completed!.artifacts
-    run.completedAt = this.dependencies.now()
+    const completedAt = this.dependencies.now()
+    run.completedAt = completedAt
+    if (terminalCancellationAccepted) run.cancelledAt = completedAt
   }
 
   private async failRun(

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -201,6 +201,7 @@ describe('createWebServiceController', () => {
         createSession: vi.fn(async () => ({ sessionId: 'session-created' })),
         resumeSession: vi.fn(async (request) => ({ sessionId: request.sessionId })),
         setPermissionProfile: vi.fn(async () => undefined),
+        cancelPrompt: vi.fn(async () => undefined),
         prompt: vi.fn(async () => undefined)
       }
     })

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -670,6 +670,7 @@ describe('startWebHttpServer', () => {
         artifacts: []
       })),
       getRun: vi.fn(),
+      cancelRun: vi.fn(),
       listArtifacts: vi.fn(),
       acquireArtifact: vi.fn(),
       releaseArtifact: vi.fn()
@@ -744,6 +745,8 @@ describe('startWebHttpServer', () => {
       )
     ).toBe(401)
     expect(tasks.startRun).not.toHaveBeenCalled()
+    expect(await postAfterExpiringAuthorization('/api/v1/runs/run-1/cancel', {}, 3)).toBe(401)
+    expect(tasks.cancelRun).not.toHaveBeenCalled()
     const taskContext = taskContexts[0]
     expect(taskContext).toMatchObject({
       surface: 'task',
@@ -1228,6 +1231,17 @@ describe('startWebHttpServer', () => {
         output: 'Done',
         artifacts: []
       }),
+      cancelRun: vi.fn().mockResolvedValue({
+        id: 'run/1',
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        status: 'cancelled',
+        startedAt: 1,
+        cancelRequestedAt: 2,
+        cancelledAt: 3,
+        completedAt: 3,
+        artifacts: []
+      }),
       listArtifacts: vi.fn().mockResolvedValue([{ id: 'artifact/1', name: 'report.md' }]),
       acquireArtifact: vi.fn(),
       releaseArtifact: vi.fn(),
@@ -1317,6 +1331,28 @@ describe('startWebHttpServer', () => {
     const status = await fetch(`${base}/api/v1/runs/run-1`, { headers })
     expect(await status.json()).toMatchObject({ data: { status: 'completed', output: 'Done' } })
 
+    const cancelled = await fetch(`${base}/api/v1/runs/run%2F1/cancel`, {
+      method: 'POST',
+      headers
+    })
+    expect(cancelled.status).toBe(200)
+    expect(await cancelled.json()).toMatchObject({
+      data: { id: 'run/1', status: 'cancelled', cancelRequestedAt: 2, cancelledAt: 3 }
+    })
+    expect(tasks.cancelRun).toHaveBeenCalledWith('run/1')
+
+    tasks.cancelRun.mockRejectedValueOnce(
+      new TaskApiError('run_not_found', 'Run not found: missing')
+    )
+    const missingRun = await fetch(`${base}/api/v1/runs/missing/cancel`, {
+      method: 'POST',
+      headers
+    })
+    expect(missingRun.status).toBe(404)
+    expect(await missingRun.json()).toEqual({
+      error: { code: 'run_not_found', message: 'Run not found: missing' }
+    })
+
     tasks.startRun.mockRejectedValueOnce(
       new TaskApiError('session_busy', 'Session already has an active run: session-1')
     )
@@ -1390,6 +1426,7 @@ describe('startWebHttpServer', () => {
       getSession: vi.fn(),
       startRun: vi.fn(),
       getRun: vi.fn(),
+      cancelRun: vi.fn(),
       listArtifacts: vi.fn(),
       acquireArtifact: vi.fn().mockResolvedValue({
         resourceId: 'resource-1',
@@ -1456,6 +1493,7 @@ describe('startWebHttpServer', () => {
       getSession: vi.fn(),
       startRun: vi.fn(),
       getRun: vi.fn(),
+      cancelRun: vi.fn(),
       listArtifacts: vi.fn(),
       acquireArtifact: vi.fn().mockResolvedValue({
         resourceId: 'resource-disconnect',

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -76,6 +76,7 @@ type WebServerOptions = {
     | 'getSession'
     | 'startRun'
     | 'getRun'
+    | 'cancelRun'
     | 'listArtifacts'
     | 'acquireArtifact'
     | 'releaseArtifact'
@@ -335,6 +336,15 @@ const handleTaskApiRequest = async (
       if (runMatch && request.method === 'GET') {
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 200, { data: tasks.getRun(decodeURIComponent(runMatch[1])) })
+        return true
+      }
+      const cancelRunMatch = url.pathname.match(/^\/api\/v1\/runs\/([^/]+)\/cancel$/)
+      if (cancelRunMatch && request.method === 'POST') {
+        await readJsonBody(request)
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, {
+          data: await tasks.cancelRun(decodeURIComponent(cancelRunMatch[1]))
+        })
         return true
       }
       const sessionArtifactsMatch = url.pathname.match(/^\/api\/v1\/sessions\/([^/]+)\/artifacts$/)

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -42,6 +42,7 @@ const createAgent = (overrides: Partial<TaskAgentMock> = {}): TaskAgentMock => (
   })),
   setPermissionProfile: vi.fn<TaskAgentPort['setPermissionProfile']>(async () => undefined),
   prompt: vi.fn<TaskAgentPort['prompt']>(async () => undefined),
+  cancelPrompt: vi.fn<TaskAgentPort['cancelPrompt']>(async () => undefined),
   ...overrides
 })
 
@@ -341,5 +342,64 @@ describe('HeadlessTaskApi adapter', () => {
     expect(agent.listAttachedSessionIds).not.toHaveBeenCalled()
     expect(agent.createSession).not.toHaveBeenCalled()
     expect(agent.prompt).not.toHaveBeenCalled()
+  })
+
+  it('forwards run cancellation through the direct Agent port under the request caller context', async () => {
+    let finishPrompt: (() => void) | undefined
+    const promptGate = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
+      if (channel === 'sessions:save-session') return undefined
+      throw new Error(`Unexpected RPC channel: ${channel}`)
+    })
+    const agent = createAgent({
+      createSession: vi.fn(async () => ({ sessionId: 'session-cancel-context' })),
+      prompt: vi.fn(async () => promptGate),
+      cancelPrompt: vi.fn(async () => finishPrompt?.())
+    })
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent })
+    const context = createTaskCallerContext({ location: 'remote' })
+
+    const run = await api.startRun({ project: project.id, prompt: 'Cancel remotely.' })
+    const cancelled = await api.runWithCallerContext(context, () => api.cancelRun(run.id))
+
+    expect(cancelled).toMatchObject({ status: 'cancelled' })
+    expect(agent.cancelPrompt).toHaveBeenCalledWith('session-cancel-context')
+  })
+
+  it('does not enter the direct Agent port for cancellation after authorization expires', async () => {
+    let finishPrompt: (() => void) | undefined
+    const promptGate = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
+      if (channel === 'sessions:save-session') return undefined
+      throw new Error(`Unexpected RPC channel: ${channel}`)
+    })
+    const agent = createAgent({
+      createSession: vi.fn(async () => ({ sessionId: 'session-revoked-cancel' })),
+      prompt: vi.fn(async () => promptGate),
+      cancelPrompt: vi.fn(async () => finishPrompt?.())
+    })
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent })
+    let authorizationCurrent = false
+    const context = createTaskCallerContext({
+      location: 'remote',
+      isAuthorizationCurrent: () => authorizationCurrent
+    })
+    const run = await api.startRun({ project: project.id, prompt: 'Keep running.' })
+
+    await expect(api.runWithCallerContext(context, () => api.cancelRun(run.id))).rejects.toThrow(
+      'Caller authorization is no longer current.'
+    )
+    expect(agent.cancelPrompt).not.toHaveBeenCalled()
+
+    authorizationCurrent = true
+    await api.runWithCallerContext(context, () => api.cancelRun(run.id))
   })
 })

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -80,7 +80,9 @@ class HeadlessTaskApi {
           this.withCurrentCaller(() => this.ports.agent.resumeSession(request)),
         setPermissionProfile: (sessionId, profile) =>
           this.withCurrentCaller(() => this.ports.agent.setPermissionProfile(sessionId, profile)),
-        prompt: (request) => this.withCurrentCaller(() => this.ports.agent.prompt(request))
+        prompt: (request) => this.withCurrentCaller(() => this.ports.agent.prompt(request)),
+        cancelPrompt: (sessionId) =>
+          this.withCurrentCaller(() => this.ports.agent.cancelPrompt(sessionId))
       },
       artifacts: {
         finalizeRun: (request: FinalizeRunArtifactsRequest) =>
@@ -149,6 +151,10 @@ class HeadlessTaskApi {
 
   waitForRun(runId: string): Promise<TaskRun> {
     return this.runner.waitForRun(runId)
+  }
+
+  cancelRun(runId: string): Promise<TaskRun> {
+    return this.runner.cancelRun(runId)
   }
 
   listArtifacts(sessionId: string): Promise<PersistedArtifact[]> {

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -3,7 +3,7 @@ import type { PermissionProfileId } from './permission-profiles'
 import type { Project } from './projects'
 import type { PersistedSessionStatus } from './session-persistence'
 
-export type TaskRunStatus = 'running' | 'completed' | 'failed'
+export type TaskRunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
 
 export type StartTaskRunRequest = {
   project: string
@@ -19,6 +19,8 @@ export type TaskRun = {
   projectId: string
   status: TaskRunStatus
   startedAt: number
+  cancelRequestedAt?: number
+  cancelledAt?: number
   completedAt?: number
   output?: string
   error?: string


### PR DESCRIPTION
## Problem

Headless Task runs had no server-side cancellation operation. Stopping a client-side wait only stopped polling, so the owning ACP Session could remain active and continue provider/tool work as an orphaned task.

## Proposed change

- Add an explicit, idempotent `cancelRun(runId)` lifecycle to `TaskRunner`.
- Route cancellation through the existing ACP Session owner and wait for provider work, Session persistence, and Artifact finalization to drain.
- Add the terminal `cancelled` status plus `cancelRequestedAt` and `cancelledAt` timestamps.
- Expose `POST /api/v1/runs/:runId/cancel`, SDK `cancelRun(runId)`, CLI `run cancel`, and opt-in `--cancel-on-timeout`.
- Preserve partial Assistant output, tool activity, and successfully finalized Artifacts.
- Preserve real provider/finalization failures when they occurred before or independently of cancellation.

```mermaid
flowchart LR
  A["SDK / CLI"] --> B["Task HTTP API"]
  B --> C["HeadlessTaskApi"]
  C --> D["TaskRunner.cancelRun"]
  D --> E["TaskAgentPort.cancelPrompt"]
  E --> F["AcpRuntimeCoordinator"]
  F --> G["Owning ACP runtime"]
```

## Scope and non-goals

- No Prisma or persisted-data schema changes; Run state remains process-local.
- No changes to Specialist handoff, parent/child Agent orchestration, message provenance, or future `host.send_message()` behavior.
- Normal SDK/CLI wait timeout and `AbortSignal` behavior remains wait-only. Server cancellation is explicit.
- This addresses item 2 of #721 only; it does not address first-response latency, tool-call parsing, or durable Artifact proof finalization.

## Acceptance criteria and validation

All focused checks below ran after the last material edit and an independent Standards/Spec review:

- Run cancellation state, HTTP authorization, SDK and CLI behavior -> `npm test -- --run src/main/tasks/task-runner.test.ts src/main/acp/task-agent-port.test.ts src/main/web-service/task-api.test.ts src/main/web-service/http-server.test.ts packages/open-science/client.test.ts packages/open-science/cli.test.ts` -> 6 files / 73 tests passed.
- Shared ACP cancellation lifecycle -> `npm test -- --run src/main/acp/session-interaction-owner.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/runtime.test.ts -t cancel` -> 3 files / 18 tests passed.
- Claude Code, OpenCode, Codex Responses and bridge routing compatibility -> `npm test -- --run src/main/acp/codex-completion-handoff.integration.test.ts src/main/acp/opencode-immediate-handoff.integration.test.ts src/main/agents/claude-code-handoff.test.ts src/main/agent-framework/codex.test.ts` -> 4 files / 59 tests passed.
- Node/Web types -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> 0 errors; 17 pre-existing warnings outside changed files.
- Full fallback -> `npm test -- --maxWorkers=4` -> 841 files / 12,321 tests passed, with one unrelated existing compute recovery-scan test failing under the full run; that exact test passed when rerun in isolation.

CI remains the final authority for the full portable suite and platform lanes.

## Review focus

- Cancellation/error ordering around Prompt rejection and final Session persistence.
- Concurrent cancellation deduplication and dispatch-failure retry semantics.
- Authorization freshness after request-body drain.
- Public consumers handling the additive `cancelled` Run status.

Refs #721
