### PR TITLE
feat(task-api): expose run progress liveness

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -133,6 +133,12 @@ The default approval profile is `ask`. Unattended workflows must explicitly use
 Use `--json` to emit one result. `--jsonl` requires `run --wait` and emits progress events followed by
 the final run object, one JSON value per line:
 
+The event stream includes `run.progress` phase changes and ten-second liveness heartbeats before the
+first visible provider output. Each progress payload includes `runId`, `sessionId`, `projectId`,
+`phase`, `timestamp`, `elapsedMs`, and `heartbeat`. Its timer starts after Task has prepared the
+Session and registered its Run; Session creation or resume time before registration is outside this
+stream.
+
 ```bash
 open-science run \
   --project "Systematic review" \

--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -21,6 +21,35 @@ const result = await client.waitForRun(run.id)
 console.log(result.output)
 ```
 
+For live automation feedback, subscribe before starting the Run. `run.progress` reports ordered
+provider-neutral phases and emits a heartbeat every ten seconds until the first visible provider
+output. The timer starts after Task has prepared the Session and registered its Run; Session
+creation or resume time before registration is outside this event stream:
+
+```js
+const abortController = new AbortController()
+const events = client.events({ signal: abortController.signal })
+await events.ready
+
+const progress = (async () => {
+  for await (const event of events) {
+    if (event.type === 'run.progress') {
+      console.log(event.data.phase, event.data.elapsedMs, event.data.heartbeat)
+    }
+  }
+})()
+
+const observedRun = await client.startRun({
+  project: 'systematic-review',
+  prompt: 'Summarize the evidence.',
+  permissionProfile: 'auto'
+})
+const observedResult = await client.waitForRun(observedRun.id)
+abortController.abort()
+await progress
+console.log(observedResult.output)
+```
+
 To stop a still-running task instead of waiting for it, cancel it explicitly. Cancellation waits for
 provider work and application finalization to drain before returning the terminal Run:
 

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -614,6 +614,22 @@ const readPrompt = async (options, deps) => {
 const emitRunEvent = (event, options, deps) => {
   if (options.jsonl) {
     deps.log(JSON.stringify(event))
+  } else if (event.type === 'run.progress') {
+    if (event.data?.heartbeat) {
+      const seconds = Math.max(1, Math.round((event.data.elapsedMs ?? 0) / 1_000))
+      const subject =
+        event.data.phase === 'provider-accepted' ? 'the first provider output' : 'the provider'
+      deps.log(`Still waiting for ${subject} (${seconds}s elapsed).`)
+      return
+    }
+    const message = {
+      accepted: 'Run accepted.',
+      'session-ready': 'Session ready.',
+      'prompt-dispatched': 'Prompt dispatched to the agent.',
+      'provider-accepted': 'Provider accepted the prompt.',
+      'first-visible-output': 'First provider output received.'
+    }[event.data?.phase]
+    if (message) deps.log(message)
   } else if (event.type === 'permission.requested') {
     deps.warn(
       'Run is waiting for approval. Approve the request in Open Science Desktop or the Web UI.'

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -446,6 +446,65 @@ describe('task CLI', () => {
     )
   })
 
+  it('prints provider-neutral Run progress and liveness heartbeats while waiting', async () => {
+    const events = async function* (): AsyncGenerator<{
+      type: string
+      data: Record<string, unknown>
+    }> {
+      yield {
+        type: 'run.progress',
+        data: {
+          runId: 'run-1',
+          sessionId: 'session-1',
+          projectId: 'project-1',
+          phase: 'prompt-dispatched',
+          timestamp: 1,
+          elapsedMs: 0,
+          heartbeat: false
+        }
+      }
+      yield {
+        type: 'run.progress',
+        data: {
+          runId: 'run-1',
+          sessionId: 'session-1',
+          projectId: 'project-1',
+          phase: 'prompt-dispatched',
+          timestamp: 10_001,
+          elapsedMs: 10_000,
+          heartbeat: true
+        }
+      }
+    }
+    const client = {
+      events,
+      startRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: 'session-1',
+        status: 'running'
+      }),
+      waitForRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: 'session-1',
+        status: 'completed',
+        output: 'Done',
+        artifacts: []
+      })
+    }
+    const log = vi.fn()
+
+    await runTaskCommand(
+      parseCliArgs(['run', '--project', 'project-1', '--prompt', 'Research this.', '--wait']),
+      { connect: vi.fn().mockResolvedValue(client), stdinIsTTY: true, log }
+    )
+
+    expect(log.mock.calls.map(([line]) => line)).toEqual([
+      'Prompt dispatched to the agent.',
+      'Still waiting for the provider (10s elapsed).',
+      'Done'
+    ])
+  })
+
   it('stops only the CLI event wait when a timeout occurs by default', async () => {
     const timeout = Object.assign(new Error('Timed out waiting for run run-1.'), {
       code: 'timeout'

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -320,6 +320,21 @@ describe('OpenScienceClient', () => {
         data: { sessionId: 'session-1', requestId: 'permission-1' }
       })
     })
+    const third = events.next()
+    FakeWebSocket.instance.emit('message', {
+      data: JSON.stringify({
+        type: 'run.progress',
+        data: {
+          runId: 'run-1',
+          sessionId: 'session-1',
+          projectId: 'project-1',
+          phase: 'provider-accepted',
+          timestamp: 250,
+          elapsedMs: 249,
+          heartbeat: false
+        }
+      })
+    })
 
     await expect(first).resolves.toEqual({
       value: PUBLIC_TERMINAL_FIXTURE,
@@ -329,6 +344,21 @@ describe('OpenScienceClient', () => {
       value: {
         type: 'permission.requested',
         data: { sessionId: 'session-1', requestId: 'permission-1' }
+      },
+      done: false
+    })
+    await expect(third).resolves.toEqual({
+      value: {
+        type: 'run.progress',
+        data: {
+          runId: 'run-1',
+          sessionId: 'session-1',
+          projectId: 'project-1',
+          phase: 'provider-accepted',
+          timestamp: 250,
+          elapsedMs: 249,
+          heartbeat: false
+        }
       },
       done: false
     })

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -1,5 +1,24 @@
 export type PermissionProfile = 'ask' | 'auto' | 'full'
 export type RunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
+export type RunProgressPhase =
+  | 'accepted'
+  | 'session-ready'
+  | 'prompt-dispatched'
+  | 'provider-accepted'
+  | 'first-visible-output'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+
+export type RunProgress = {
+  runId: string
+  sessionId: string
+  projectId: string
+  phase: RunProgressPhase
+  timestamp: number
+  elapsedMs: number
+  heartbeat: boolean
+}
 
 export type Project = {
   id: string
@@ -86,10 +105,10 @@ export class OpenScienceClient {
   events(options?: {
     signal?: AbortSignal
     WebSocket?: typeof globalThis.WebSocket
-  }): AsyncIterable<{
-    type: 'run.event' | 'permission.requested'
-    data: unknown
-  }> & { ready: Promise<void> }
+  }): AsyncIterable<
+    | { type: 'run.progress'; data: RunProgress }
+    | { type: 'run.event' | 'permission.requested'; data: unknown }
+  > & { ready: Promise<void> }
 }
 
 export function connectToOpenScience(options?: {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -34,7 +34,7 @@ const runtimeEventId = (runtimeSequence: number, eventId: string): RegExp =>
   new RegExp(`^runtime-${runtimeSequence}-[0-9a-f-]{36}:${eventId}$`, 'u')
 
 const createFakeRuntime = (options: {
-  frameworkId: 'claude-code' | 'codex'
+  frameworkId: 'claude-code' | 'opencode' | 'codex'
   sessionIds: string[]
   callbacks: AcpRuntimeCallbacks
   permissionGrantStore?: ConversationPermissionGrantStore
@@ -255,6 +255,54 @@ const createFakeRuntime = (options: {
 }
 
 describe('AcpRuntimeCoordinator', () => {
+  it.each([
+    ['Claude Code', 'claude-code'],
+    ['OpenCode', 'opencode'],
+    ['Codex shared runtime', 'codex']
+  ] as const)(
+    'observes provider acceptance through %s without changing completion',
+    async (_route, frameworkId) => {
+      const coordinator = new AcpRuntimeCoordinator(
+        (callbacks) =>
+          createFakeRuntime({ frameworkId, sessionIds: ['session-1'], callbacks }).runtime
+      )
+      const session = await coordinator.createSession()
+      const onProviderPromptAccepted = vi.fn()
+
+      await coordinator.sendPromptObserved(
+        { sessionId: session.sessionId, text: 'Research this.' },
+        onProviderPromptAccepted
+      )
+
+      expect(onProviderPromptAccepted).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('does not report provider acceptance when dispatch fails before acceptance', async () => {
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({
+          frameworkId: 'codex',
+          sessionIds: ['session-1'],
+          callbacks,
+          beforeProviderPromptAccepted: async () => {
+            throw new Error('provider rejected before acceptance')
+          }
+        }).runtime
+    )
+    const session = await coordinator.createSession()
+    const onProviderPromptAccepted = vi.fn()
+
+    await expect(
+      coordinator.sendPromptObserved(
+        { sessionId: session.sessionId, text: 'Research this.' },
+        onProviderPromptAccepted
+      )
+    ).rejects.toThrow('provider rejected before acceptance')
+
+    expect(onProviderPromptAccepted).not.toHaveBeenCalled()
+  })
+
   it('retains a sanitized app-visible Specialist handoff failure until session deletion', async () => {
     const forwardedEvents: AcpRuntimeEvent[] = []
     const created: ReturnType<typeof createFakeRuntime>[] = []

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -71,10 +71,26 @@ type ActivePromptRequest = {
 }
 
 type PromptAcceptance = {
-  promise: Promise<void>
   resolve: () => void
   reject: (error: unknown) => void
   settled: boolean
+}
+
+const observePromptAcceptance = (onAccepted: () => void): PromptAcceptance => {
+  const acceptance: PromptAcceptance = {
+    resolve: () => undefined,
+    reject: () => undefined,
+    settled: false
+  }
+  acceptance.resolve = () => {
+    if (acceptance.settled) return
+    acceptance.settled = true
+    onAccepted()
+  }
+  acceptance.reject = () => {
+    acceptance.settled = true
+  }
+  return acceptance
 }
 
 type PendingSessionDrain = {
@@ -552,10 +568,24 @@ class AcpRuntimeCoordinator {
   }
 
   sendPrompt(request: AcpPromptRequest): ReturnType<AcpRuntime['sendPrompt']> {
+    return this.sendObservedPrompt(request)
+  }
+
+  sendPromptObserved(
+    request: AcpPromptRequest,
+    onProviderPromptAccepted: () => void
+  ): ReturnType<AcpRuntime['sendPrompt']> {
+    return this.sendObservedPrompt(request, observePromptAcceptance(onProviderPromptAccepted))
+  }
+
+  private sendObservedPrompt(
+    request: AcpPromptRequest,
+    acceptance?: PromptAcceptance
+  ): ReturnType<AcpRuntime['sendPrompt']> {
     if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
-    if (!this.promptAdmissionGuard) return this.dispatchPrompt(request, undefined, 'sendPrompt')
+    if (!this.promptAdmissionGuard) return this.dispatchPrompt(request, acceptance, 'sendPrompt')
     return this.promptAdmissionGuard(request.sessionId).then(() =>
-      this.dispatchPrompt(request, undefined, 'sendPrompt')
+      this.dispatchPrompt(request, acceptance, 'sendPrompt')
     )
   }
 
@@ -568,11 +598,11 @@ class AcpRuntimeCoordinator {
   startContinuation(request: AcpPromptRequest): Promise<void> {
     let resolve!: () => void
     let reject!: (error: unknown) => void
+    const accepted = new Promise<void>((promiseResolve, promiseReject) => {
+      resolve = promiseResolve
+      reject = promiseReject
+    })
     const acceptance: PromptAcceptance = {
-      promise: new Promise<void>((promiseResolve, promiseReject) => {
-        resolve = promiseResolve
-        reject = promiseReject
-      }),
       resolve: () => undefined,
       reject: () => undefined,
       settled: false
@@ -591,7 +621,7 @@ class AcpRuntimeCoordinator {
     void this.dispatchPrompt(request, acceptance, 'sendAppContinuation').catch((error) =>
       acceptance.reject(error)
     )
-    return acceptance.promise
+    return accepted
   }
 
   private dispatchPrompt(

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1494,6 +1494,47 @@ describe('ACP runtime migration write-gate', () => {
   })
 })
 
+describe('ACP runtime provider prompt acceptance', () => {
+  it.each([
+    ['Claude Code', claudeCodeFramework, 'claude-anthropic', 'claude-code:provider-a'],
+    ['OpenCode', opencodeFramework, 'opencode-openai', 'opencode:provider-a'],
+    ['Codex Responses', codexFramework, 'codex-responses', 'codex:provider-a'],
+    ['Codex Bridge', codexFramework, 'codex-bridge', 'codex:provider-a']
+  ] as const)(
+    'reports provider acceptance after the first %s update',
+    async (_name, framework, modelRoute, backendId) => {
+      const process = new FakeAgentProcess()
+      startFakeAgent(process, ['acceptance-session'], {
+        ...(framework.id === 'codex'
+          ? { modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent') }
+          : {})
+      })
+      const onProviderPromptAccepted = vi.fn()
+      const bridgeLease =
+        modelRoute === 'codex-bridge' ? createBackendLeaseHarness().lease : undefined
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        callbacks: { onProviderPromptAccepted },
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          backendId,
+          modelRoute,
+          executablePath: '/bin/agent',
+          env: {},
+          ...(bridgeLease ? { responsesBridgeLease: bridgeLease } : {})
+        })
+      })
+
+      const session = await runtime.createSession({ cwd: '/workspace' })
+      await runtime.sendPrompt({ sessionId: session.sessionId, text: 'Research this.' })
+
+      expect(onProviderPromptAccepted).toHaveBeenCalledOnce()
+      expect(onProviderPromptAccepted).toHaveBeenCalledWith(session.sessionId, undefined)
+    }
+  )
+})
+
 describe('ACP runtime session management', () => {
   it('keeps the current primary capability set separate from reviewer-only authority', async () => {
     const root = await createTemporaryRoot()

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -34,6 +34,7 @@ describe('ACP Task Agent port', () => {
       })),
       setPermissionProfile: vi.fn(async () => undefined),
       sendPrompt: vi.fn(async () => undefined),
+      sendPromptObserved: vi.fn(async () => undefined),
       cancelPrompt: vi.fn(async () => undefined)
     }
     const withSessionAvailable = vi.fn()
@@ -131,6 +132,7 @@ describe('ACP Task Agent port', () => {
         resumeSession: vi.fn(),
         setPermissionProfile: vi.fn(),
         sendPrompt,
+        sendPromptObserved: sendPrompt,
         cancelPrompt: vi.fn()
       },
       { create: vi.fn() },
@@ -151,5 +153,34 @@ describe('ACP Task Agent port', () => {
     sendPrompt.mockRejectedValueOnce(failure)
     await expect(port.prompt(prompt)).rejects.toBe(failure)
     expect(untrackPrompt).toHaveBeenCalledWith('session-1', trackedPrompt)
+  })
+
+  it('forwards provider acceptance through the provider-neutral Task prompt observer', async () => {
+    const onProviderPromptAccepted = vi.fn()
+    const sendPrompt = vi.fn(async (_request, onAccepted?: () => void) => {
+      onAccepted?.()
+    })
+    const port = createAcpTaskAgentPort(
+      {
+        getSnapshot: () => ({ sessionIds: [] }),
+        resumeSession: vi.fn(),
+        setPermissionProfile: vi.fn(),
+        sendPrompt,
+        sendPromptObserved: sendPrompt,
+        cancelPrompt: vi.fn()
+      },
+      { create: vi.fn() }
+    )
+
+    await port.prompt(
+      {
+        sessionId: 'session-1',
+        promptMessageId: 'prompt-1',
+        text: 'Research this.'
+      },
+      { onProviderPromptAccepted }
+    )
+
+    expect(onProviderPromptAccepted).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -13,6 +13,10 @@ type AcpTaskAgentRuntime = {
   resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
   setPermissionProfile(request: AcpSetPermissionProfileRequest): Promise<unknown>
   sendPrompt(request: AcpPromptRequest): Promise<unknown>
+  sendPromptObserved(
+    request: AcpPromptRequest,
+    onProviderPromptAccepted: () => void
+  ): Promise<unknown>
   cancelPrompt(request: { sessionId: string }): Promise<unknown>
 }
 
@@ -65,11 +69,15 @@ const createAcpTaskAgentPort = (
     }),
   setPermissionProfile: (sessionId, profile) =>
     runtime.setPermissionProfile({ sessionId, profile }).then(() => undefined),
-  prompt: async (request) => {
+  prompt: async (request, observer) => {
     const acpRequest = toAcpPromptRequest(request)
     const tracked = notifications?.trackPrompt(acpRequest)
     try {
-      await runtime.sendPrompt(acpRequest)
+      if (observer?.onProviderPromptAccepted) {
+        await runtime.sendPromptObserved(acpRequest, observer.onProviderPromptAccepted)
+      } else {
+        await runtime.sendPrompt(acpRequest)
+      }
     } catch (error) {
       if (tracked) notifications?.untrackPrompt(acpRequest.sessionId, tracked)
       throw error

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -284,6 +284,213 @@ describe('TaskRunner', () => {
     })
   })
 
+  it('publishes ordered Run progress from acceptance through completion', async () => {
+    const runner = createRunner()
+    const progress: Array<{ phase: string; heartbeat: boolean }> = []
+    const unsubscribe = runner.subscribeProgress((event) => {
+      progress.push({ phase: event.phase, heartbeat: event.heartbeat })
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Research this.' })
+    await runner.waitForRun(started.id)
+
+    expect(progress).toEqual([
+      { phase: 'accepted', heartbeat: false },
+      { phase: 'session-ready', heartbeat: false },
+      { phase: 'prompt-dispatched', heartbeat: false },
+      { phase: 'completed', heartbeat: false }
+    ])
+
+    unsubscribe()
+    runner.dispose()
+  })
+
+  it('marks provider acceptance before the first visible provider event', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    const phases: string[] = []
+    const runner = createRunner({
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-1' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async (request, observer) => {
+          observer?.onProviderPromptAccepted?.()
+          emitEvent?.({
+            id: 'assistant-1',
+            timestamp: 2,
+            sessionId: request.sessionId,
+            promptMessageId: request.promptMessageId,
+            kind: 'message',
+            role: 'assistant',
+            level: 'info',
+            text: 'Working on it.'
+          })
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => {
+            emitEvent = undefined
+          }
+        }
+      }
+    })
+    runner.subscribeProgress((event) => phases.push(event.phase))
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Research this.' })
+    await runner.waitForRun(started.id)
+
+    expect(phases).toEqual([
+      'accepted',
+      'session-ready',
+      'prompt-dispatched',
+      'provider-accepted',
+      'first-visible-output',
+      'completed'
+    ])
+    runner.dispose()
+  })
+
+  it('emits liveness heartbeats until the first visible provider event', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    let finishPrompt: (() => void) | undefined
+    const prompt = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const progress: Array<{ phase: string; heartbeat: boolean; elapsedMs: number }> = []
+    const runner = createRunner({
+      now: Date.now,
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-1' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => prompt
+      }
+    })
+    runner.subscribeProgress((event) => {
+      progress.push({ phase: event.phase, heartbeat: event.heartbeat, elapsedMs: event.elapsedMs })
+    })
+
+    try {
+      const started = await runner.startRun({ project: project.id, prompt: 'Research this.' })
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      expect(progress.at(-1)).toEqual({
+        phase: 'prompt-dispatched',
+        heartbeat: true,
+        elapsedMs: 10_000
+      })
+
+      finishPrompt?.()
+      await runner.waitForRun(started.id)
+      const countAfterCompletion = progress.length
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(progress).toHaveLength(countAfterCompletion)
+    } finally {
+      runner.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps Run execution independent from progress subscriber failures', async () => {
+    const runner = createRunner()
+    runner.subscribeProgress(() => {
+      throw new Error('subscriber failed')
+    })
+
+    const started = await runner.startRun({ project: project.id, prompt: 'Research this.' })
+
+    await expect(runner.waitForRun(started.id)).resolves.toMatchObject({ status: 'completed' })
+    runner.dispose()
+  })
+
+  it('stops liveness heartbeats after the first visible provider event', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let acceptProvider: (() => void) | undefined
+    let finishPrompt: (() => void) | undefined
+    const prompt = new Promise<void>((resolve) => {
+      finishPrompt = resolve
+    })
+    const progress: Array<{ phase: string; heartbeat: boolean }> = []
+    const runner = createRunner({
+      now: Date.now,
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-1' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async (_request, observer) => {
+          acceptProvider = observer?.onProviderPromptAccepted
+          return prompt
+        }
+      },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => {
+            emitEvent = undefined
+          }
+        }
+      }
+    })
+    runner.subscribeProgress((event) => {
+      progress.push({ phase: event.phase, heartbeat: event.heartbeat })
+    })
+
+    try {
+      const started = await runner.startRun({ project: project.id, prompt: 'Research this.' })
+      acceptProvider?.()
+      emitEvent?.({
+        id: 'other-prompt-assistant',
+        timestamp: 2,
+        sessionId: 'session-1',
+        promptMessageId: 'other-prompt',
+        kind: 'message',
+        role: 'assistant',
+        level: 'info',
+        text: 'Unrelated side-chat output.'
+      })
+      expect(progress.at(-1)).toEqual({ phase: 'provider-accepted', heartbeat: false })
+      emitEvent?.({
+        id: 'assistant-1',
+        timestamp: 3,
+        sessionId: 'session-1',
+        promptMessageId: 'generated-id',
+        kind: 'message',
+        role: 'assistant',
+        level: 'info',
+        text: 'Working on it.'
+      })
+      const countAfterFirstOutput = progress.length
+
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(progress).toHaveLength(countAfterFirstOutput)
+      expect(progress.slice(-2)).toEqual([
+        { phase: 'provider-accepted', heartbeat: false },
+        { phase: 'first-visible-output', heartbeat: false }
+      ])
+
+      finishPrompt?.()
+      const completed = await runner.waitForRun(started.id)
+      expect(completed.output).toBe('Working on it.')
+    } finally {
+      runner.dispose()
+      vi.useRealTimers()
+    }
+  })
+
   it('rejects overlapping runs for the same durable session', async () => {
     let finishPrompt: (() => void) | undefined
     const promptGate = new Promise<void>((resolve) => {
@@ -597,6 +804,7 @@ describe('TaskRunner', () => {
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
     let saveCount = 0
     const ids = ['save-user', 'save-run', 'save-agent']
+    const progressPhases: string[] = []
     const runner = createRunner({
       sessions: {
         list: async () => [],
@@ -633,6 +841,7 @@ describe('TaskRunner', () => {
       createId: () => ids.shift() ?? 'generated-id',
       now: () => 100
     })
+    runner.subscribeProgress((event) => progressPhases.push(event.phase))
 
     const started = await runner.startRun({ project: project.id, prompt: 'Produce an answer.' })
 
@@ -643,6 +852,7 @@ describe('TaskRunner', () => {
       completedAt: 100
     })
     expect(saveCount).toBe(3)
+    expect(progressPhases.at(-1)).toBe('failed')
   })
 
   it('preserves finalized artifacts when a later claim fails after an ownership retry', async () => {
@@ -868,6 +1078,7 @@ describe('TaskRunner', () => {
       rejectPrompt?.(new Error('provider prompt cancelled'))
     })
     let time = 100
+    const progressPhases: string[] = []
     const runner = createRunner({
       sessions: {
         list: async () => [],
@@ -896,6 +1107,7 @@ describe('TaskRunner', () => {
       })(),
       now: () => ++time
     })
+    runner.subscribeProgress((event) => progressPhases.push(event.phase))
 
     const started = await runner.startRun({ project: project.id, prompt: 'Long research.' })
     const cancelled = await runner.cancelRun(started.id)
@@ -910,6 +1122,7 @@ describe('TaskRunner', () => {
       completedAt: expect.any(Number)
     })
     expect(cancelled.cancelledAt).toBe(cancelled.completedAt)
+    expect(progressPhases.at(-1)).toBe('cancelled')
     expect(savedSessions.at(-1)).toMatchObject({
       id: 'session-cancel',
       status: 'idle',

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -464,8 +464,28 @@ describe('TaskRunner', () => {
       })
       expect(progress.at(-1)).toEqual({ phase: 'provider-accepted', heartbeat: false })
       emitEvent?.({
-        id: 'assistant-1',
+        id: 'provider-warning',
         timestamp: 3,
+        sessionId: 'session-1',
+        promptMessageId: 'generated-id',
+        kind: 'system',
+        level: 'warning',
+        text: 'Provider is retrying.'
+      })
+      emitEvent?.({
+        id: 'terminal-stop',
+        timestamp: 4,
+        sessionId: 'session-1',
+        promptMessageId: 'generated-id',
+        kind: 'stop',
+        level: 'info',
+        title: 'Prompt stopped',
+        text: 'end_turn'
+      })
+      expect(progress.at(-1)).toEqual({ phase: 'provider-accepted', heartbeat: false })
+      emitEvent?.({
+        id: 'assistant-1',
+        timestamp: 5,
         sessionId: 'session-1',
         promptMessageId: 'generated-id',
         kind: 'message',

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -26,6 +26,8 @@ import type {
   StartTaskRunRequest,
   TaskApiErrorCode,
   TaskRun,
+  TaskRunProgressEvent,
+  TaskRunProgressPhase,
   TaskSessionSummary
 } from '../../shared/task-api'
 
@@ -85,6 +87,10 @@ type TaskAgentPromptRequest = {
   resumeFallback?: { historyPreamble?: string }
 }
 
+type TaskAgentPromptObserver = {
+  onProviderPromptAccepted?: () => void
+}
+
 type TaskAgentPort = {
   withSessionAvailable<Result>(
     projectId: string,
@@ -95,7 +101,7 @@ type TaskAgentPort = {
   createSession(request: TaskAgentCreateSessionRequest): Promise<TaskAgentSession>
   resumeSession(request: TaskAgentResumeSessionRequest): Promise<TaskAgentSession>
   setPermissionProfile(sessionId: string, profile: PermissionProfileId): Promise<void>
-  prompt(request: TaskAgentPromptRequest): Promise<void>
+  prompt(request: TaskAgentPromptRequest, observer?: TaskAgentPromptObserver): Promise<void>
   cancelPrompt(sessionId: string): Promise<void>
 }
 
@@ -121,6 +127,11 @@ type TaskRunnerDependencies = {
 type MutableTaskRun = TaskRun & {
   events: AcpRuntimeEvent[]
   completion: Promise<void>
+  promptMessageId: string
+  progressPhase: TaskRunProgressPhase
+  providerAccepted: boolean
+  firstVisibleOutput: boolean
+  heartbeatTimer?: ReturnType<typeof setTimeout>
   cancellation?: {
     accepted: boolean
     dispatch: Promise<void>
@@ -144,6 +155,12 @@ class PartialTaskCompletionError extends Error {
 }
 
 const MAX_RETAINED_RUNS = 200
+const TASK_RUN_HEARTBEAT_INTERVAL_MS = 10_000
+
+const isVisibleProviderEvent = (event: AcpRuntimeEvent): boolean =>
+  event.role !== 'user' &&
+  event.kind !== 'raw' &&
+  Boolean(event.text?.trim() || event.title?.trim() || getAcpRuntimeEventImage(event))
 
 const cloneRun = (run: MutableTaskRun): TaskRun => ({
   id: run.id,
@@ -220,6 +237,7 @@ class TaskRunnerError extends Error {
 class TaskRunner {
   private readonly runs = new Map<string, MutableTaskRun>()
   private readonly activeRunBySession = new Map<string, string>()
+  private readonly progressListeners = new Set<(event: TaskRunProgressEvent) => void>()
   private readonly unsubscribeEvents: () => void
 
   constructor(private readonly dependencies: TaskRunnerDependencies) {
@@ -230,6 +248,13 @@ class TaskRunner {
 
   dispose(): void {
     this.unsubscribeEvents()
+    for (const run of this.runs.values()) this.stopHeartbeat(run)
+    this.progressListeners.clear()
+  }
+
+  subscribeProgress(listener: (event: TaskRunProgressEvent) => void): () => void {
+    this.progressListeners.add(listener)
+    return () => this.progressListeners.delete(listener)
   }
 
   listProjects(): Promise<Project[]> {
@@ -351,11 +376,18 @@ class TaskRunner {
       startedAt: this.dependencies.now(),
       artifacts: [],
       events: [],
+      promptMessageId: session.activeRun!.promptMessageId,
+      progressPhase: 'accepted' as const,
+      providerAccepted: false,
+      firstVisibleOutput: false,
       completion: Promise.resolve()
     } satisfies MutableTaskRun
 
     this.pruneRuns()
     this.runs.set(runId, run)
+    this.publishProgress(run, 'accepted')
+    this.publishProgress(run, 'session-ready')
+    this.scheduleHeartbeat(run)
     run.completion = this.executeRun(
       run,
       session,
@@ -531,15 +563,25 @@ class TaskRunner {
     let promptError: unknown
     let cancellationAtPromptFailure: MutableTaskRun['cancellation'] = undefined
     try {
-      await this.dependencies.agent.prompt({
-        sessionId: session.id,
-        promptMessageId: session.activeRun!.promptMessageId,
-        text: prompt,
-        ...(request.skillIds?.length ? { skillIds: request.skillIds } : {}),
-        ...(historyPreamble ? { historyPreamble } : {}),
-        ...(contextReset ? { contextReset: true } : {}),
-        ...(resumeFallback ? { resumeFallback } : {})
-      })
+      this.publishProgress(run, 'prompt-dispatched')
+      await this.dependencies.agent.prompt(
+        {
+          sessionId: session.id,
+          promptMessageId: session.activeRun!.promptMessageId,
+          text: prompt,
+          ...(request.skillIds?.length ? { skillIds: request.skillIds } : {}),
+          ...(historyPreamble ? { historyPreamble } : {}),
+          ...(contextReset ? { contextReset: true } : {}),
+          ...(resumeFallback ? { resumeFallback } : {})
+        },
+        {
+          onProviderPromptAccepted: () => {
+            if (run.status !== 'running' || run.providerAccepted) return
+            run.providerAccepted = true
+            this.publishProgress(run, 'provider-accepted')
+          }
+        }
+      )
     } catch (error) {
       promptError = error
       cancellationAtPromptFailure = run.cancellation
@@ -582,6 +624,8 @@ class TaskRunner {
     const completedAt = this.dependencies.now()
     run.completedAt = completedAt
     if (terminalCancellationAccepted) run.cancelledAt = completedAt
+    this.stopHeartbeat(run)
+    this.publishProgress(run, terminalCancellationAccepted ? 'cancelled' : 'completed')
   }
 
   private async failRun(
@@ -608,6 +652,8 @@ class TaskRunner {
     run.output = completed?.output
     run.artifacts = completed?.artifacts ?? []
     run.completedAt = this.dependencies.now()
+    this.stopHeartbeat(run)
+    this.publishProgress(run, 'failed')
     await this.dependencies.sessions.save(failed).catch(() => undefined)
   }
 
@@ -755,7 +801,63 @@ class TaskRunner {
   private captureEvent(event: AcpRuntimeEvent): void {
     if (!event.sessionId) return
     for (const run of this.runs.values()) {
-      if (run.status === 'running' && run.sessionId === event.sessionId) run.events.push(event)
+      if (run.status !== 'running' || run.sessionId !== event.sessionId) continue
+      if (event.promptMessageId !== undefined && event.promptMessageId !== run.promptMessageId) {
+        continue
+      }
+      run.events.push(event)
+      if (
+        run.providerAccepted &&
+        !run.firstVisibleOutput &&
+        event.promptMessageId === run.promptMessageId &&
+        isVisibleProviderEvent(event)
+      ) {
+        run.firstVisibleOutput = true
+        this.stopHeartbeat(run)
+        this.publishProgress(run, 'first-visible-output')
+      }
+    }
+  }
+
+  private scheduleHeartbeat(run: MutableTaskRun): void {
+    this.stopHeartbeat(run)
+    run.heartbeatTimer = setTimeout(() => {
+      run.heartbeatTimer = undefined
+      if (run.status !== 'running' || run.firstVisibleOutput) return
+      this.publishProgress(run, run.progressPhase, true)
+      this.scheduleHeartbeat(run)
+    }, TASK_RUN_HEARTBEAT_INTERVAL_MS)
+    run.heartbeatTimer.unref?.()
+  }
+
+  private stopHeartbeat(run: MutableTaskRun): void {
+    if (!run.heartbeatTimer) return
+    clearTimeout(run.heartbeatTimer)
+    run.heartbeatTimer = undefined
+  }
+
+  private publishProgress(
+    run: MutableTaskRun,
+    phase: TaskRunProgressPhase,
+    heartbeat = false
+  ): void {
+    const timestamp = this.dependencies.now()
+    if (!heartbeat) run.progressPhase = phase
+    const event: TaskRunProgressEvent = Object.freeze({
+      runId: run.id,
+      sessionId: run.sessionId,
+      projectId: run.projectId,
+      phase,
+      timestamp,
+      elapsedMs: Math.max(0, timestamp - run.startedAt),
+      heartbeat
+    })
+    for (const listener of this.progressListeners) {
+      try {
+        listener(event)
+      } catch {
+        // Public observability is best-effort and must never change Run execution or terminalization.
+      }
     }
   }
 
@@ -798,6 +900,7 @@ export type {
   CreateTaskProjectRequest,
   TaskAgentCreateSessionRequest,
   TaskAgentPort,
+  TaskAgentPromptObserver,
   TaskAgentPromptRequest,
   TaskAgentResumeSessionRequest,
   TaskAgentSession,

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -156,10 +156,17 @@ class PartialTaskCompletionError extends Error {
 
 const MAX_RETAINED_RUNS = 200
 const TASK_RUN_HEARTBEAT_INTERVAL_MS = 10_000
+const VISIBLE_PROVIDER_EVENT_KINDS = new Set<AcpRuntimeEvent['kind']>([
+  'message',
+  'thought',
+  'tool',
+  'plan',
+  'artifact'
+])
 
 const isVisibleProviderEvent = (event: AcpRuntimeEvent): boolean =>
   event.role !== 'user' &&
-  event.kind !== 'raw' &&
+  VISIBLE_PROVIDER_EVENT_KINDS.has(event.kind) &&
   Boolean(event.text?.trim() || event.title?.trim() || getAcpRuntimeEventImage(event))
 
 const cloneRun = (run: MutableTaskRun): TaskRun => ({

--- a/src/main/web-service/application-event-projections.test.ts
+++ b/src/main/web-service/application-event-projections.test.ts
@@ -1,14 +1,33 @@
 import { describe, expect, it } from 'vitest'
 
 import type { AcpRuntimeEvent } from '../../shared/acp'
+import type { TaskRunProgressEvent } from '../../shared/task-api'
 import type { ApplicationEvent } from '../application-events'
 import {
   projectPublicTaskEvent,
+  projectPublicTaskProgressEvent,
   projectTaskRuntimeEvent,
   projectWebRendererEvent
 } from './application-event-projections'
 
 describe('application event projections', () => {
+  it('projects Task-owned progress without routing it through renderer events', () => {
+    const progress: TaskRunProgressEvent = {
+      runId: 'run-1',
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      phase: 'provider-accepted',
+      timestamp: 1_700_000_000_000,
+      elapsedMs: 250,
+      heartbeat: false
+    }
+
+    expect(projectPublicTaskProgressEvent(progress)).toEqual({
+      type: 'run.progress',
+      data: progress
+    })
+  })
+
   it('passes terminal usage metadata through every eligible surface without recomputation', () => {
     const payload: AcpRuntimeEvent = {
       id: 'event-1',

--- a/src/main/web-service/application-event-projections.ts
+++ b/src/main/web-service/application-event-projections.ts
@@ -1,4 +1,5 @@
 import { WEB_RPC_PROTOCOL_VERSION, isWebRpcEventChannel } from '../../shared/web-rpc-contract'
+import type { TaskRunProgressEvent } from '../../shared/task-api'
 import type { ApplicationEvent } from '../application-events'
 
 type WebRendererEvent = {
@@ -13,6 +14,7 @@ type PublicTaskEvent =
       type: 'permission.requested'
       data: Extract<ApplicationEvent, { channel: 'acp:permission-request' }>['payload']
     }
+  | { type: 'run.progress'; data: TaskRunProgressEvent }
 
 const projectWebRendererEvent = (event: ApplicationEvent): WebRendererEvent | undefined =>
   isWebRpcEventChannel(event.channel)
@@ -31,10 +33,20 @@ const projectPublicTaskEvent = (event: ApplicationEvent): PublicTaskEvent | unde
   return undefined
 }
 
+const projectPublicTaskProgressEvent = (event: TaskRunProgressEvent): PublicTaskEvent => ({
+  type: 'run.progress',
+  data: event
+})
+
 const projectTaskRuntimeEvent = (
   event: ApplicationEvent
 ): Extract<ApplicationEvent, { channel: 'acp:event' }>['payload'] | undefined =>
   event.channel === 'acp:event' ? event.payload : undefined
 
-export { projectPublicTaskEvent, projectTaskRuntimeEvent, projectWebRendererEvent }
+export {
+  projectPublicTaskEvent,
+  projectPublicTaskProgressEvent,
+  projectTaskRuntimeEvent,
+  projectWebRendererEvent
+}
 export type { PublicTaskEvent, WebRendererEvent }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -173,11 +173,27 @@ describe('startWebHttpServer', () => {
   it('releases its application-event subscription when listening fails', async () => {
     const unsubscribe = vi.fn()
     const subscribe = vi.fn(() => unsubscribe)
+    const unsubscribeProgress = vi.fn()
+    const subscribeProgress = vi.fn(() => unsubscribeProgress)
     const options = {
       host: '127.0.0.1',
       token: 'test-token',
       staticRoot: '/unused',
       applicationEvents: { subscribe },
+      tasks: {
+        runWithCallerContext,
+        subscribeProgress,
+        listProjects: vi.fn(),
+        createProject: vi.fn(),
+        listSessions: vi.fn(),
+        getSession: vi.fn(),
+        startRun: vi.fn(),
+        getRun: vi.fn(),
+        cancelRun: vi.fn(),
+        listArtifacts: vi.fn(),
+        acquireArtifact: vi.fn(),
+        releaseArtifact: vi.fn()
+      },
       rpc: {
         channels: () => [],
         invoke: vi.fn(async () => undefined),
@@ -201,12 +217,17 @@ describe('startWebHttpServer', () => {
 
     expect(subscribe).toHaveBeenCalledOnce()
     expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(subscribeProgress).toHaveBeenCalledOnce()
+    expect(unsubscribeProgress).toHaveBeenCalledOnce()
 
     const retry = await startWebHttpServer({ ...options, port: 0 })
     expect(subscribe).toHaveBeenCalledTimes(2)
     expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(subscribeProgress).toHaveBeenCalledTimes(2)
+    expect(unsubscribeProgress).toHaveBeenCalledOnce()
     await retry.close()
     expect(unsubscribe).toHaveBeenCalledTimes(2)
+    expect(unsubscribeProgress).toHaveBeenCalledTimes(2)
   })
 
   it('authenticates, invokes direct commands, and delivers projected events once in order', async () => {
@@ -657,6 +678,7 @@ describe('startWebHttpServer', () => {
     }
     const tasks = {
       runWithCallerContext: runWithCapturedCallerContext,
+      subscribeProgress: () => () => undefined,
       listProjects: vi.fn(),
       createProject: vi.fn(),
       listSessions: vi.fn(),
@@ -1207,8 +1229,16 @@ describe('startWebHttpServer', () => {
       taskContexts.push(context)
       return operation()
     }
+    let publishProgress:
+      ((event: import('../../shared/task-api').TaskRunProgressEvent) => void) | undefined
     const tasks = {
       runWithCallerContext: runWithCapturedCallerContext,
+      subscribeProgress: vi.fn((listener) => {
+        publishProgress = listener
+        return () => {
+          publishProgress = undefined
+        }
+      }),
       listProjects: vi.fn().mockResolvedValue([{ id: 'project-1', name: 'Research' }]),
       createProject: vi.fn().mockResolvedValue({ id: 'project-2', name: 'Created' }),
       listSessions: vi.fn().mockResolvedValue([{ id: 'session/1', title: 'Review' }]),
@@ -1270,6 +1300,36 @@ describe('startWebHttpServer', () => {
     servers.push(server)
     const base = `http://127.0.0.1:${server.port}`
     const headers = { authorization: 'Bearer test-token' }
+
+    const progressSocket = new WebSocket(
+      `${base.replace('http:', 'ws:')}/api/v1/events?token=test-token`
+    )
+    await new Promise<void>((resolve) => progressSocket.once('open', resolve))
+    const progressMessage = new Promise<unknown>((resolve) =>
+      progressSocket.once('message', (data) => resolve(JSON.parse(data.toString())))
+    )
+    publishProgress?.({
+      runId: 'run-1',
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      phase: 'provider-accepted',
+      timestamp: 250,
+      elapsedMs: 249,
+      heartbeat: false
+    })
+    await expect(progressMessage).resolves.toEqual({
+      type: 'run.progress',
+      data: {
+        runId: 'run-1',
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        phase: 'provider-accepted',
+        timestamp: 250,
+        elapsedMs: 249,
+        heartbeat: false
+      }
+    })
+    progressSocket.close()
 
     const projects = await fetch(`${base}/api/v1/projects`, { headers })
     expect(projects.status).toBe(200)
@@ -1420,6 +1480,7 @@ describe('startWebHttpServer', () => {
     )
     const tasks = {
       runWithCallerContext,
+      subscribeProgress: () => () => undefined,
       listProjects: vi.fn(),
       createProject: vi.fn(),
       listSessions: vi.fn(),
@@ -1487,6 +1548,7 @@ describe('startWebHttpServer', () => {
     )
     const tasks = {
       runWithCallerContext,
+      subscribeProgress: () => () => undefined,
       listProjects: vi.fn(),
       createProject: vi.fn(),
       listSessions: vi.fn(),

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -25,7 +25,11 @@ import {
   webRpcRequestSchema
 } from '../../shared/web-rpc-contract'
 import { RENDERER_CONTRACT_CATALOG } from '../../shared/renderer-contract-catalog'
-import { projectPublicTaskEvent, projectWebRendererEvent } from './application-event-projections'
+import {
+  projectPublicTaskEvent,
+  projectPublicTaskProgressEvent,
+  projectWebRendererEvent
+} from './application-event-projections'
 import { authenticateRequest, persistAuthCookie } from './auth'
 import type { StartTaskRunRequest } from '../../shared/task-api'
 import { TaskApiError, type HeadlessTaskApi } from './task-api'
@@ -77,6 +81,7 @@ type WebServerOptions = {
     | 'startRun'
     | 'getRun'
     | 'cancelRun'
+    | 'subscribeProgress'
     | 'listArtifacts'
     | 'acquireArtifact'
     | 'releaseArtifact'
@@ -697,6 +702,12 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       }
     }
   })
+  const removeTaskProgressSink = options.tasks?.subscribeProgress((event) => {
+    const message = JSON.stringify(projectPublicTaskProgressEvent(event))
+    for (const socket of publicEventSockets) {
+      if (socket.readyState === WebSocket.OPEN) socket.send(message)
+    }
+  })
 
   try {
     await new Promise<void>((resolveListening, reject) => {
@@ -708,6 +719,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     })
   } catch (error) {
     removeBroadcastSink()
+    removeTaskProgressSink?.()
     try {
       clientLeases.dispose()
     } finally {
@@ -730,6 +742,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     },
     close: async () => {
       removeBroadcastSink()
+      removeTaskProgressSink?.()
       for (const socket of sockets) socket.close()
       wsServer.close()
       await new Promise<void>((resolveClose) => server.close(() => resolveClose()))

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -75,6 +75,29 @@ describe('HeadlessTaskApi adapter', () => {
     )
   })
 
+  it('exposes Task Run progress through one subscription seam', async () => {
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
+      if (channel === 'sessions:save-session') return undefined
+      throw new Error(`Unexpected Task command: ${channel}`)
+    })
+    const ids = ['message-1', 'run-1', 'assistant-1']
+    const api = new HeadlessTaskApi(
+      { commands: commandsFrom(invoke), agent: createAgent() },
+      { createId: () => ids.shift() ?? 'generated-id', now: () => 1 }
+    )
+    const phases: string[] = []
+    const unsubscribe = api.subscribeProgress((event) => phases.push(event.phase))
+
+    const run = await api.startRun({ project: project.id, prompt: 'Research this.' })
+    await api.waitForRun(run.id)
+
+    expect(phases).toEqual(['accepted', 'session-ready', 'prompt-dispatched', 'completed'])
+    unsubscribe()
+    api.dispose()
+  })
+
   it('maps public query and artifact commands to the compatibility façade', async () => {
     const session: PersistedChatSession = {
       id: 'session-query',

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -83,8 +83,13 @@ describe('HeadlessTaskApi adapter', () => {
       throw new Error(`Unexpected Task command: ${channel}`)
     })
     const ids = ['message-1', 'run-1', 'assistant-1']
+    const agent = createAgent({
+      prompt: vi.fn(async (_request, observer) => {
+        observer?.onProviderPromptAccepted?.()
+      })
+    })
     const api = new HeadlessTaskApi(
-      { commands: commandsFrom(invoke), agent: createAgent() },
+      { commands: commandsFrom(invoke), agent },
       { createId: () => ids.shift() ?? 'generated-id', now: () => 1 }
     )
     const phases: string[] = []
@@ -93,7 +98,13 @@ describe('HeadlessTaskApi adapter', () => {
     const run = await api.startRun({ project: project.id, prompt: 'Research this.' })
     await api.waitForRun(run.id)
 
-    expect(phases).toEqual(['accepted', 'session-ready', 'prompt-dispatched', 'completed'])
+    expect(phases).toEqual([
+      'accepted',
+      'session-ready',
+      'prompt-dispatched',
+      'provider-accepted',
+      'completed'
+    ])
     unsubscribe()
     api.dispose()
   })
@@ -224,11 +235,14 @@ describe('HeadlessTaskApi adapter', () => {
 
     expect(agent.listAttachedSessionIds).toHaveBeenCalledOnce()
     expect(agent.setPermissionProfile).toHaveBeenCalledWith(existing.id, 'auto')
-    expect(agent.prompt).toHaveBeenCalledWith({
-      sessionId: existing.id,
-      promptMessageId: 'attached-user',
-      text: 'Continue research.'
-    })
+    expect(agent.prompt).toHaveBeenCalledWith(
+      {
+        sessionId: existing.id,
+        promptMessageId: 'attached-user',
+        text: 'Continue research.'
+      },
+      { onProviderPromptAccepted: expect.any(Function) }
+    )
     expect(invoke.mock.calls.every(([channel]) => !String(channel).startsWith('acp:'))).toBe(true)
     expect(invoke).toHaveBeenCalledWith('artifacts:finalize-run', taskCallerContext(), [
       { claimId: 'artifact-claim', messageId: 'attached-agent' }
@@ -324,11 +338,14 @@ describe('HeadlessTaskApi adapter', () => {
       projectId: project.id,
       permissionProfile: 'ask'
     })
-    expect(agent.prompt).toHaveBeenCalledWith({
-      sessionId: 'session-context',
-      promptMessageId: expect.any(String),
-      text: 'Research with remote context.'
-    })
+    expect(agent.prompt).toHaveBeenCalledWith(
+      {
+        sessionId: 'session-context',
+        promptMessageId: expect.any(String),
+        text: 'Research with remote context.'
+      },
+      { onProviderPromptAccepted: expect.any(Function) }
+    )
     expect(context.isAuthorizationCurrent()).toBe(false)
 
     await api.runWithCallerContext(context, () => api.releaseArtifact('resource-context'))

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -81,7 +81,8 @@ class HeadlessTaskApi {
           this.withCurrentCaller(() => this.ports.agent.resumeSession(request)),
         setPermissionProfile: (sessionId, profile) =>
           this.withCurrentCaller(() => this.ports.agent.setPermissionProfile(sessionId, profile)),
-        prompt: (request) => this.withCurrentCaller(() => this.ports.agent.prompt(request)),
+        prompt: (request, observer) =>
+          this.withCurrentCaller(() => this.ports.agent.prompt(request, observer)),
         cancelPrompt: (sessionId) =>
           this.withCurrentCaller(() => this.ports.agent.cancelPrompt(sessionId))
       },

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -12,6 +12,7 @@ import type {
   AcquiredTaskArtifact,
   StartTaskRunRequest,
   TaskRun,
+  TaskRunProgressEvent,
   TaskSessionSummary
 } from '../../shared/task-api'
 import { createApplicationCommandClient } from '../application-command-client'
@@ -155,6 +156,10 @@ class HeadlessTaskApi {
 
   cancelRun(runId: string): Promise<TaskRun> {
     return this.runner.cancelRun(runId)
+  }
+
+  subscribeProgress(listener: (event: TaskRunProgressEvent) => void): () => void {
+    return this.runner.subscribeProgress(listener)
   }
 
   listArtifacts(sessionId: string): Promise<PersistedArtifact[]> {

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -5,6 +5,26 @@ import type { PersistedSessionStatus } from './session-persistence'
 
 export type TaskRunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
 
+export type TaskRunProgressPhase =
+  | 'accepted'
+  | 'session-ready'
+  | 'prompt-dispatched'
+  | 'provider-accepted'
+  | 'first-visible-output'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+
+export type TaskRunProgressEvent = {
+  runId: string
+  sessionId: string
+  projectId: string
+  phase: TaskRunProgressPhase
+  timestamp: number
+  elapsedMs: number
+  heartbeat: boolean
+}
+
 export type StartTaskRunRequest = {
   project: string
   prompt: string


### PR DESCRIPTION
## Problem

Task API callers have no provider-neutral signal between starting a Run and receiving the first visible ACP output. A live but slow provider therefore looks indistinguishable from a stalled request.

Refs #721.

## Proposed change

- Add an additive `run.progress` contract with ordered lifecycle phases and elapsed time.
- Emit a ten-second heartbeat until the first visible provider output or terminal Run state.
- Observe provider acceptance through the shared ACP prompt lifecycle for Claude Code, OpenCode, Codex Responses, and Codex Bridge.
- Correlate visible output by `sessionId` and `promptMessageId`, so same-Session side chats or future `host.send_message()` prompts do not stop or contaminate another Run.
- Stream progress only through the public Task WebSocket and expose it in the SDK, human CLI output, and `--jsonl`.

```mermaid
flowchart LR
  ACP["Shared ACP prompt lifecycle"] -->|provider accepted| TaskRunner
  TaskRunner -->|run.progress| TaskAPI["Headless Task API"]
  TaskAPI --> PublicWS["/api/v1/events"]
  PublicWS --> SDK
  PublicWS --> CLI
```

## Scope and non-goals

- No database fields or persisted data-model changes.
- No changes to Session messages, Artifact provenance, or Run HTTP representations.
- No Electron/renderer event or Desktop chat interaction changes.
- No progress entries in `main.log`; this is a public Task API event stream.
- Elapsed time begins after Session preparation and Run registration; earlier Session create/resume time is outside this stream.
- Specialist continuations that retain the Task prompt provenance remain part of the Run. Child-agent Sessions and different-prompt side chats remain isolated.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Progress ordering, heartbeat stop, exact prompt correlation, and completed/failed/cancelled terminal phases → `npm test -- --run src/main/tasks/task-runner.test.ts` → passed.
- Task-to-ACP acceptance seam and failure-before-acceptance behavior → `npm test -- --run src/main/acp/runtime-coordinator.test.ts src/main/acp/task-agent-port.test.ts` → passed.
- Claude Code, OpenCode, Codex Responses, and Codex Bridge provider paths → `npm test -- --run src/main/acp/runtime.test.ts -t "ACP runtime provider prompt acceptance"` → 4 passed.
- Public projection, WebSocket delivery, listen-failure cleanup, and close cleanup → `npm test -- --run src/main/web-service/http-server.test.ts` → 17 passed.
- SDK and CLI event handling → `npm test -- --run packages/open-science/client.test.ts packages/open-science/cli.test.ts` → passed.
- Node and Web type contracts → `npm run typecheck` → passed.
- Repository lint → `npm run lint` → 0 errors; 17 pre-existing warnings in files outside this diff.
- Full portable regression suite → `npm test` → 843 files passed, 12,346 tests passed, 14 files and 184 tests skipped.

The change crosses ACP, Task, transport, SDK, and CLI ownership, so the full fallback was used. Platform-specific packaging and Windows certification remain covered by required CI. Independent Standards and Spec reviews reported no findings against the final commit.

## Review focus

- Whether provider acceptance remains exactly-once and cannot replace prompt completion behavior.
- Whether `promptMessageId` scoping correctly isolates future same-Session message sources.
- Whether progress subscription cleanup remains best-effort and cannot affect Run terminalization.
- Whether the additive SDK event union preserves existing consumers.
