### PR TITLE
refactor(artifact-provenance): extract execution evidence

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -145,6 +145,8 @@
     },
     "artifact_provenance": {
       "ownerPaths": [
+        "src/main/artifacts/provenance-canonical.ts",
+        "src/main/artifacts/provenance-execution-evidence.ts",
         "src/main/artifacts/provenance-message-snapshot.ts",
         "src/main/artifacts/provenance-repository.ts",
         "src/main/artifacts/provenance-version-writer.ts"

--- a/src/main/artifacts/provenance-canonical.ts
+++ b/src/main/artifacts/provenance-canonical.ts
@@ -1,0 +1,21 @@
+import { createHash } from 'node:crypto'
+
+type CanonicalJson =
+  null | boolean | number | string | CanonicalJson[] | { [key: string]: CanonicalJson }
+
+const canonicalize = (value: CanonicalJson): CanonicalJson => {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value === null || typeof value !== 'object') return value
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalize(entry)])
+  )
+}
+
+const canonicalJson = (value: CanonicalJson): string => JSON.stringify(canonicalize(value))
+const sha256 = (value: Buffer | string): string => createHash('sha256').update(value).digest('hex')
+
+export { canonicalJson, sha256 }
+export type { CanonicalJson }

--- a/src/main/artifacts/provenance-execution-evidence.ts
+++ b/src/main/artifacts/provenance-execution-evidence.ts
@@ -1,0 +1,441 @@
+import type {
+  ArtifactVersionEnvironmentEvidence,
+  ArtifactVersionInputEvidence,
+  PersistedArtifactExecutionSnapshot,
+  ProvenanceNotebookOutput,
+  ProvenanceNotebookRun
+} from '../../shared/artifact-provenance'
+import type {
+  NotebookEnvironmentManifest,
+  NotebookEnvironmentPackage,
+  NotebookOutput,
+  NotebookRunEnvironmentCapture,
+  NotebookRunInputFile,
+  NotebookRunRecord
+} from '../../shared/notebook'
+import { canonicalJson, sha256, type CanonicalJson } from './provenance-canonical'
+
+const MAX_EXECUTION_SNAPSHOT_BYTES = 4 * 1024 * 1024
+const MAX_EXECUTION_SNAPSHOT_RUNS = 128
+const MAX_EXECUTION_SNAPSHOT_OUTPUTS = 256
+const MAX_EXECUTION_SNAPSHOT_INPUTS = 256
+const MAX_EXECUTION_OUTPUT_BYTES = 64 * 1024
+
+const clipText = (value: string, maxLength = 16_000): string =>
+  value.length <= maxLength ? value : `${value.slice(0, maxLength)}\n…[truncated]`
+
+const provenanceTextOutput = (value: string): ProvenanceNotebookOutput => {
+  const clipped = clipText(value)
+  return {
+    type: 'text',
+    text: clipped,
+    ...(clipped !== value ? { truncated: true } : {})
+  }
+}
+
+const recordValue = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+
+const tableCell = (value: unknown): CanonicalJson => {
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'number' ||
+    typeof value === 'string'
+  ) {
+    return value
+  }
+  const serialized = JSON.stringify(value)
+  return serialized === undefined ? null : clipText(serialized, 2_000)
+}
+
+const tabularJsonOutput = (value: unknown): ProvenanceNotebookOutput | undefined => {
+  if (!Array.isArray(value) || value.length === 0 || value.some((row) => !recordValue(row))) {
+    return undefined
+  }
+  const previewRecords = value.slice(0, 100).map((row) => recordValue(row)!)
+  const columns = [...new Set(previewRecords.flatMap((row) => Object.keys(row)))].slice(0, 50)
+  if (columns.length === 0) return undefined
+  return {
+    type: 'table',
+    columns,
+    rowCount: value.length,
+    previewRows: previewRecords.map((row) => columns.map((column) => tableCell(row[column])))
+  }
+}
+
+const omittedMediaByteLength = (mimeType: string, value: string): number =>
+  mimeType.startsWith('image/') || mimeType === 'application/pdf'
+    ? Buffer.from(value, 'base64').byteLength
+    : Buffer.byteLength(value)
+
+const boundExecutionOutput = (output: ProvenanceNotebookOutput): ProvenanceNotebookOutput =>
+  Buffer.byteLength(JSON.stringify(output), 'utf8') <= MAX_EXECUTION_OUTPUT_BYTES
+    ? output
+    : {
+        type: 'text',
+        text: '[output omitted because it exceeded the execution evidence limit]',
+        truncated: true
+      }
+
+const sanitizeOutput = (output: NotebookOutput): ProvenanceNotebookOutput[] => {
+  if (output.type === 'display') {
+    const entries = Object.entries(output.data)
+    return [
+      ...entries
+        .filter(([mimeType]) => mimeType.startsWith('text/'))
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([, value]) => provenanceTextOutput(value)),
+      ...entries
+        .filter(([mimeType]) => !mimeType.startsWith('text/'))
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map<ProvenanceNotebookOutput>(([mimeType, value]) => ({
+          type: 'omitted-media',
+          mimeType,
+          byteLength: omittedMediaByteLength(mimeType, value)
+        }))
+    ]
+  }
+  if (output.type === 'json') {
+    return [
+      tabularJsonOutput(output.data) ?? provenanceTextOutput(JSON.stringify(output.data) ?? 'null')
+    ]
+  }
+  if (output.type === 'error') {
+    const traceback = clipText(output.traceback)
+    return [
+      {
+        type: 'error',
+        ...(output.name ? { name: output.name } : {}),
+        message: clipText(output.message ?? output.name ?? 'Notebook execution failed.'),
+        ...(traceback ? { traceback: traceback.split('\n') } : {})
+      }
+    ]
+  }
+  return [provenanceTextOutput(output.text)]
+}
+
+const sanitizeRun = (
+  run: NotebookRunRecord,
+  runIndex: number,
+  outputs: ProvenanceNotebookOutput[] = run.outputs.flatMap(sanitizeOutput)
+): ProvenanceNotebookRun => {
+  const script = clipText(run.script)
+  return {
+    runId: run.runId,
+    runIndex,
+    agentFrameId: run.agentFrameId ?? '',
+    messageBranchId: run.messageBranchId ?? '',
+    runtimeSegmentId: run.runtimeSegmentId ?? '',
+    promptMessageId: run.promptMessageId ?? '',
+    kernelKind: run.kernelKind,
+    ...(run.environment ? { environmentName: run.environment } : {}),
+    script,
+    ...(script !== run.script ? { scriptTruncated: true } : {}),
+    status: run.status,
+    ...(run.executionCount !== undefined ? { executionCount: run.executionCount } : {}),
+    startedAt: new Date(run.startedAt).toISOString(),
+    ...(run.endedAt !== undefined ? { completedAt: new Date(run.endedAt).toISOString() } : {}),
+    outputs,
+    inputFileVersionKeys: (run.inputFiles ?? []).map((input) => ({
+      sourceKind: input.sourceKind,
+      inputFileVersionId: input.inputFileVersionId
+    })),
+    ...(run.workingFiles.length > 0 ? { hasOmittedFiles: true } : {})
+  }
+}
+
+const mergeExecutionInputs = (
+  runs: Array<{ run: NotebookRunRecord; runIndex: number }>
+): NotebookRunInputFile[] => {
+  const inputs = new Map<string, NotebookRunInputFile>()
+  for (const { run } of runs) {
+    for (const input of run.inputFiles ?? []) {
+      const key = `${input.sourceKind}\0${input.inputFileVersionId}`
+      const existing = inputs.get(key)
+      inputs.set(key, {
+        ...input,
+        association:
+          existing?.association === 'resolver-accessed' || input.association === 'resolver-accessed'
+            ? 'resolver-accessed'
+            : 'turn-attached'
+      })
+    }
+  }
+  return [...inputs.values()]
+}
+
+const buildBoundedExecutionSnapshot = (
+  base: Omit<PersistedArtifactExecutionSnapshot, 'inputFiles' | 'runs' | 'truncation'>,
+  eligibleRuns: Array<{ run: NotebookRunRecord; runIndex: number }>
+): PersistedArtifactExecutionSnapshot => {
+  let omittedLeadingRunCount = Math.max(0, eligibleRuns.length - MAX_EXECUTION_SNAPSHOT_RUNS)
+  let omittedOutputCount = 0
+  const selectedRuns = eligibleRuns.slice(-MAX_EXECUTION_SNAPSHOT_RUNS)
+  let remainingOutputs = MAX_EXECUTION_SNAPSHOT_OUTPUTS
+  const runs = selectedRuns.map(({ run, runIndex }) => ({
+    run,
+    runIndex,
+    outputs: [] as ProvenanceNotebookOutput[]
+  }))
+  for (let index = runs.length - 1; index >= 0; index -= 1) {
+    const candidate = runs[index]!
+    const outputs = candidate.run.outputs.flatMap(sanitizeOutput).map(boundExecutionOutput)
+    const retainedCount = Math.min(outputs.length, remainingOutputs)
+    candidate.outputs = outputs.slice(0, retainedCount)
+    const omittedForRun = outputs.length - retainedCount
+    omittedOutputCount += omittedForRun
+    remainingOutputs -= retainedCount
+  }
+
+  const allInputs = mergeExecutionInputs(eligibleRuns)
+  let inputFiles = allInputs.slice(0, MAX_EXECUTION_SNAPSHOT_INPUTS)
+  let omittedInputCount = allInputs.length - inputFiles.length
+  const materializedRuns = runs.map(({ run, runIndex, outputs }) => {
+    const materialized = sanitizeRun(run, runIndex, outputs)
+    const omittedForRun = run.outputs.flatMap(sanitizeOutput).length - outputs.length
+    if (omittedForRun > 0) materialized.omittedOutputCount = omittedForRun
+    return materialized
+  })
+
+  const retainedInputKeys = (): Set<string> =>
+    new Set(inputFiles.map((input) => `${input.sourceKind}\0${input.inputFileVersionId}`))
+  const filterRunInputKeys = (): void => {
+    const retained = retainedInputKeys()
+    for (const run of materializedRuns) {
+      const filtered = run.inputFileVersionKeys.filter((input) =>
+        retained.has(`${input.sourceKind}\0${input.inputFileVersionId}`)
+      )
+      if (filtered.length !== run.inputFileVersionKeys.length) run.hasOmittedInputs = true
+      run.inputFileVersionKeys = filtered
+    }
+  }
+  filterRunInputKeys()
+
+  const snapshot = (): PersistedArtifactExecutionSnapshot => ({
+    ...base,
+    inputFiles,
+    runs: materializedRuns,
+    ...(omittedLeadingRunCount > 0 || omittedOutputCount > 0 || omittedInputCount > 0
+      ? {
+          truncation: {
+            reason: 'payload-limit' as const,
+            omittedLeadingRunCount,
+            omittedOutputCount,
+            omittedInputCount
+          }
+        }
+      : {})
+  })
+  const snapshotBytes = (): number =>
+    Buffer.byteLength(canonicalJson(snapshot() as unknown as CanonicalJson), 'utf8')
+
+  while (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES && materializedRuns.length > 1) {
+    materializedRuns.shift()
+    omittedLeadingRunCount += 1
+  }
+  while (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES) {
+    const runWithOutput = materializedRuns.find((run) => run.outputs.length > 0)
+    if (!runWithOutput) break
+    runWithOutput.outputs.pop()
+    runWithOutput.omittedOutputCount = (runWithOutput.omittedOutputCount ?? 0) + 1
+    omittedOutputCount += 1
+  }
+  while (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES && inputFiles.length > 0) {
+    inputFiles = inputFiles.slice(0, Math.floor(inputFiles.length / 2))
+    omittedInputCount = allInputs.length - inputFiles.length
+    filterRunInputKeys()
+  }
+  if (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES) {
+    const producer = materializedRuns.at(-1)
+    if (producer) {
+      producer.script = clipText(producer.script, 1_000)
+      producer.scriptTruncated = true
+    }
+  }
+  if (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES) {
+    throw new Error('Artifact execution evidence exceeds the bounded snapshot limit.')
+  }
+  return snapshot()
+}
+
+const inputEvidence = (
+  input: NotebookRunInputFile,
+  ordinal: number
+): ArtifactVersionInputEvidence => ({
+  ordinal,
+  input_file_version_id: input.inputFileVersionId,
+  source_kind: input.sourceKind,
+  source_file_id: input.sourceFileId,
+  ...(input.sourceVersionNumber !== undefined
+    ? { source_version_number: input.sourceVersionNumber }
+    : {}),
+  ...(input.sourceCreatedAt ? { source_created_at: input.sourceCreatedAt } : {}),
+  source_project_id: input.sourceProjectId,
+  source_session_id: input.sourceSessionId,
+  filename: input.filename,
+  ...(input.contentType ? { content_type: input.contentType } : {}),
+  size_bytes: input.sizeBytes,
+  checksum: input.checksum,
+  storage_key: input.storageKey,
+  strongest_association: input.association
+})
+
+const environmentPackageEvidence = (
+  pkg: NotebookEnvironmentPackage
+): ArtifactVersionEnvironmentEvidence['packages'][number] => ({
+  name: pkg.name,
+  ...(pkg.version ? { version: pkg.version } : {}),
+  version_status: pkg.versionStatus,
+  ecosystem: pkg.ecosystem,
+  evidence_sources: pkg.evidenceSources,
+  loaded_state: pkg.loadedState ?? 'unknown',
+  ...(pkg.libraryRank !== undefined ? { library_rank: pkg.libraryRank } : {}),
+  ...(pkg.libraryScope ? { library_scope: pkg.libraryScope } : {}),
+  ...(pkg.builtForRuntime ? { built_for_runtime: pkg.builtForRuntime } : {}),
+  ...(pkg.priority ? { priority: pkg.priority } : {})
+})
+
+const environmentEvidence = (
+  manifest: NotebookEnvironmentManifest,
+  checksum: string
+): ArtifactVersionEnvironmentEvidence => ({
+  capture_kind: manifest.captureKind,
+  environment_name: manifest.environmentName,
+  kernel_kind: manifest.kernelKind,
+  runtime_source: manifest.runtimeSource,
+  ...(manifest.runtimeVersion ? { runtime_version: manifest.runtimeVersion } : {}),
+  ...(manifest.platform ? { platform: manifest.platform } : {}),
+  ...(manifest.architecture ? { architecture: manifest.architecture } : {}),
+  packages: manifest.packages.map(environmentPackageEvidence),
+  ...(manifest.kernelKind === 'python' && manifest.runtimeVersion
+    ? { python_version: manifest.runtimeVersion }
+    : {}),
+  ...(manifest.kernelKind === 'r' && manifest.runtimeVersion
+    ? { r_version: manifest.runtimeVersion }
+    : {}),
+  inventory_sources: manifest.inventorySources,
+  installed_inventory: {
+    captured_at: manifest.installedInventory.capturedAt,
+    source: manifest.installedInventory.source,
+    validation: manifest.installedInventory.validation
+  },
+  ...(manifest.operationLog
+    ? {
+        op_log: manifest.operationLog.map((operation) => ({
+          operation_id: operation.operationId,
+          timestamp: operation.timestamp,
+          operation: operation.operation,
+          packages: operation.packages,
+          result: operation.result,
+          attempts: (operation.attempts ?? []).map((attempt) => ({
+            group_ordinal: attempt.groupOrdinal,
+            installer: attempt.installer,
+            packages: attempt.packages,
+            status: attempt.status,
+            mutation_risk: attempt.mutationRisk,
+            ...(attempt.reason ? { reason: attempt.reason } : {})
+          })),
+          fallback_used: operation.fallbackUsed ?? false,
+          inventory_refresh: operation.inventoryRefresh ?? 'published',
+          inventory_refresh_attempts: operation.inventoryRefreshAttempts ?? [],
+          ...(operation.packageChanges
+            ? {
+                package_changes: operation.packageChanges.map((change) => ({
+                  name: change.name,
+                  ecosystem: change.ecosystem,
+                  relationship: change.relationship,
+                  change: change.change,
+                  ...(change.beforeVersion ? { before_version: change.beforeVersion } : {}),
+                  ...(change.afterVersion ? { after_version: change.afterVersion } : {}),
+                  ...(change.libraryRank !== undefined ? { library_rank: change.libraryRank } : {}),
+                  ...(change.libraryScope ? { library_scope: change.libraryScope } : {})
+                }))
+              }
+            : {})
+        }))
+      }
+    : {}),
+  ...(manifest.operationLogTruncation
+    ? {
+        op_log_truncation: {
+          omitted_count: manifest.operationLogTruncation.omittedCount,
+          ...(manifest.operationLogTruncation.earliestRetainedAt
+            ? { earliest_retained_at: manifest.operationLogTruncation.earliestRetainedAt }
+            : {})
+        }
+      }
+    : {}),
+  captured_at: manifest.capturedAt,
+  source_manifest_checksum: checksum,
+  complete: manifest.complete,
+  capture_status: manifest.captureStatus,
+  ...(manifest.warnings ? { warnings: manifest.warnings } : {})
+})
+
+const resolveRunEnvironmentCapture = (
+  run: NotebookRunRecord
+): {
+  capture: NotebookRunEnvironmentCapture
+  manifest?: NotebookEnvironmentManifest
+  checksum?: string
+} => {
+  const manifest = run.environmentManifest
+  const checksum = run.environmentManifestChecksum
+  const serialized = manifest ? `${JSON.stringify(manifest, null, 2)}\n` : undefined
+  const manifestState = manifest?.captureStatus === 'complete' ? 'available' : 'partial'
+  const manifestIsValid =
+    serialized !== undefined &&
+    checksum !== undefined &&
+    sha256(serialized) === checksum &&
+    manifest?.captureKind === 'completed-run' &&
+    manifest.kernelKind === run.kernelKind &&
+    manifest.environmentName === run.environment &&
+    manifest.complete === (manifest.captureStatus === 'complete')
+
+  if (run.environmentCapture) {
+    if (run.environmentCapture.state === 'unavailable') {
+      return { capture: { ...run.environmentCapture } }
+    }
+    if (
+      manifestIsValid &&
+      checksum === run.environmentCapture.manifestChecksum &&
+      manifestState === run.environmentCapture.state
+    ) {
+      return {
+        capture: { ...run.environmentCapture },
+        manifest,
+        checksum
+      }
+    }
+    // A malformed available/partial tuple cannot be emitted as trustworthy evidence, but it also
+    // must not invalidate the Artifact bytes. Collapse only this corrupt publication state.
+    return {
+      capture: { state: 'unavailable', reason: 'environment-manifest-publication-failed' }
+    }
+  }
+
+  if (manifestIsValid && manifest && checksum) {
+    return {
+      capture: {
+        state: manifestState,
+        manifestChecksum: checksum,
+        ...(manifest.warnings?.length ? { warnings: [...manifest.warnings] } : {})
+      },
+      manifest,
+      checksum
+    }
+  }
+  return {
+    capture: { state: 'unavailable', reason: 'legacy-environment-reference-unavailable' }
+  }
+}
+
+export {
+  buildBoundedExecutionSnapshot,
+  environmentEvidence,
+  inputEvidence,
+  resolveRunEnvironmentCapture
+}

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto'
 import { mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -10,17 +10,14 @@ import type {
   ArtifactLineageProvenance,
   ArtifactMessageSnapshotFile,
   ArtifactVersionDescriptor,
-  ArtifactVersionEnvironmentEvidence,
   ArtifactVersionEvidence,
   ArtifactVersionFile,
-  ArtifactVersionInputEvidence,
   ArtifactVersionProvenance,
   CreateArtifactVersionRequest,
   FinalizeArtifactVersionsRequest,
   GetArtifactLineageRequest,
   GetArtifactVersionProvenanceRequest,
   PersistedArtifactExecutionSnapshot,
-  ProvenanceNotebookRun,
   ProvenanceNotebookOutput,
   ProvenanceExecutionInputFile,
   ReplayArtifactVersionRequest
@@ -46,14 +43,14 @@ import {
   type StagingArtifactVersionRecord
 } from './provenance-version-writer'
 import { NotebookRunRepository } from '../notebook/repository'
-import type {
-  NotebookEnvironmentManifest,
-  NotebookEnvironmentPackage,
-  NotebookOutput,
-  NotebookRunEnvironmentCapture,
-  NotebookRunInputFile,
-  NotebookRunRecord
-} from '../../shared/notebook'
+import type { NotebookRunInputFile } from '../../shared/notebook'
+import { canonicalJson, sha256, type CanonicalJson } from './provenance-canonical'
+import {
+  buildBoundedExecutionSnapshot,
+  environmentEvidence,
+  inputEvidence,
+  resolveRunEnvironmentCapture
+} from './provenance-execution-evidence'
 import { toCheck, toReview } from '../reviewer/repository'
 import { selectReviewChainForArtifactVersion } from '../reviewer/artifact-version-review'
 import { flagStaleReviews } from '../reviewer/stale-reviews'
@@ -76,11 +73,6 @@ const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 // inserting its staging row. Only rowless directories older than a full hour are proven abandoned.
 const ORPHAN_STAGING_GRACE_MS = 60 * 60 * 1_000
 const SHA256_PATTERN = /^[a-f0-9]{64}$/
-const MAX_EXECUTION_SNAPSHOT_BYTES = 4 * 1024 * 1024
-const MAX_EXECUTION_SNAPSHOT_RUNS = 128
-const MAX_EXECUTION_SNAPSHOT_OUTPUTS = 256
-const MAX_EXECUTION_SNAPSHOT_INPUTS = 256
-const MAX_EXECUTION_OUTPUT_BYTES = 64 * 1024
 
 type ArtifactProvenanceRepositoryOptions = {
   storageRoot: string
@@ -310,30 +302,12 @@ const isArtifactLinkedToDurableMessage = (
   )
 }
 
-type CanonicalJson =
-  null | boolean | number | string | CanonicalJson[] | { [key: string]: CanonicalJson }
-
 const assertSafeSegment = (value: string, label: string): string => {
   if (!SAFE_SEGMENT_PATTERN.test(value)) {
     throw new Error(`Invalid ${label}: ${value}`)
   }
   return value
 }
-
-const canonicalize = (value: CanonicalJson): CanonicalJson => {
-  if (Array.isArray(value)) return value.map(canonicalize)
-  if (value === null || typeof value !== 'object') return value
-
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => [key, canonicalize(entry)])
-  )
-}
-
-const canonicalJson = (value: CanonicalJson): string => JSON.stringify(canonicalize(value))
-
-const sha256 = (value: Buffer | string): string => createHash('sha256').update(value).digest('hex')
 
 const normalizeArtifactFinalizationProofRequest = (
   request: ArtifactFinalizationProofRequest
@@ -543,18 +517,6 @@ const moveDirectoryIfPresent = async (source: string, destination: string): Prom
       return false
     }
     throw error
-  }
-}
-
-const clipText = (value: string, maxLength = 16_000): string =>
-  value.length <= maxLength ? value : `${value.slice(0, maxLength)}\n…[truncated]`
-
-const provenanceTextOutput = (value: string): ProvenanceNotebookOutput => {
-  const clipped = clipText(value)
-  return {
-    type: 'text',
-    text: clipped,
-    ...(clipped !== value ? { truncated: true } : {})
   }
 }
 
@@ -807,401 +769,6 @@ const validRecoveryFilename = (value: string): boolean =>
   value !== '..' &&
   !value.includes('/') &&
   !value.includes('\\')
-
-const tableCell = (value: unknown): CanonicalJson => {
-  if (
-    value === null ||
-    typeof value === 'boolean' ||
-    typeof value === 'number' ||
-    typeof value === 'string'
-  ) {
-    return value
-  }
-  const serialized = JSON.stringify(value)
-  return serialized === undefined ? null : clipText(serialized, 2_000)
-}
-
-const tabularJsonOutput = (value: unknown): ProvenanceNotebookOutput | undefined => {
-  if (!Array.isArray(value) || value.length === 0 || value.some((row) => !recordValue(row))) {
-    return undefined
-  }
-  const previewRecords = value.slice(0, 100).map((row) => recordValue(row)!)
-  const columns = [...new Set(previewRecords.flatMap((row) => Object.keys(row)))].slice(0, 50)
-  if (columns.length === 0) return undefined
-  return {
-    type: 'table',
-    columns,
-    rowCount: value.length,
-    previewRows: previewRecords.map((row) => columns.map((column) => tableCell(row[column])))
-  }
-}
-
-const omittedMediaByteLength = (mimeType: string, value: string): number =>
-  mimeType.startsWith('image/') || mimeType === 'application/pdf'
-    ? Buffer.from(value, 'base64').byteLength
-    : Buffer.byteLength(value)
-
-const boundExecutionOutput = (output: ProvenanceNotebookOutput): ProvenanceNotebookOutput =>
-  Buffer.byteLength(JSON.stringify(output), 'utf8') <= MAX_EXECUTION_OUTPUT_BYTES
-    ? output
-    : {
-        type: 'text',
-        text: '[output omitted because it exceeded the execution evidence limit]',
-        truncated: true
-      }
-
-const sanitizeOutput = (output: NotebookOutput): ProvenanceNotebookOutput[] => {
-  if (output.type === 'display') {
-    const entries = Object.entries(output.data)
-    return [
-      ...entries
-        .filter(([mimeType]) => mimeType.startsWith('text/'))
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([, value]) => provenanceTextOutput(value)),
-      ...entries
-        .filter(([mimeType]) => !mimeType.startsWith('text/'))
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map<ProvenanceNotebookOutput>(([mimeType, value]) => ({
-          type: 'omitted-media',
-          mimeType,
-          byteLength: omittedMediaByteLength(mimeType, value)
-        }))
-    ]
-  }
-  if (output.type === 'json') {
-    return [
-      tabularJsonOutput(output.data) ?? provenanceTextOutput(JSON.stringify(output.data) ?? 'null')
-    ]
-  }
-  if (output.type === 'error') {
-    const traceback = clipText(output.traceback)
-    return [
-      {
-        type: 'error',
-        ...(output.name ? { name: output.name } : {}),
-        message: clipText(output.message ?? output.name ?? 'Notebook execution failed.'),
-        ...(traceback ? { traceback: traceback.split('\n') } : {})
-      }
-    ]
-  }
-  return [provenanceTextOutput(output.text)]
-}
-
-const sanitizeRun = (
-  run: NotebookRunRecord,
-  runIndex: number,
-  outputs: ProvenanceNotebookOutput[] = run.outputs.flatMap(sanitizeOutput)
-): ProvenanceNotebookRun => {
-  const script = clipText(run.script)
-  return {
-    runId: run.runId,
-    runIndex,
-    agentFrameId: run.agentFrameId ?? '',
-    messageBranchId: run.messageBranchId ?? '',
-    runtimeSegmentId: run.runtimeSegmentId ?? '',
-    promptMessageId: run.promptMessageId ?? '',
-    kernelKind: run.kernelKind,
-    ...(run.environment ? { environmentName: run.environment } : {}),
-    script,
-    ...(script !== run.script ? { scriptTruncated: true } : {}),
-    status: run.status,
-    ...(run.executionCount !== undefined ? { executionCount: run.executionCount } : {}),
-    startedAt: new Date(run.startedAt).toISOString(),
-    ...(run.endedAt !== undefined ? { completedAt: new Date(run.endedAt).toISOString() } : {}),
-    outputs,
-    inputFileVersionKeys: (run.inputFiles ?? []).map((input) => ({
-      sourceKind: input.sourceKind,
-      inputFileVersionId: input.inputFileVersionId
-    })),
-    ...(run.workingFiles.length > 0 ? { hasOmittedFiles: true } : {})
-  }
-}
-
-const mergeExecutionInputs = (
-  runs: Array<{ run: NotebookRunRecord; runIndex: number }>
-): NotebookRunInputFile[] => {
-  const inputs = new Map<string, NotebookRunInputFile>()
-  for (const { run } of runs) {
-    for (const input of run.inputFiles ?? []) {
-      const key = `${input.sourceKind}\0${input.inputFileVersionId}`
-      const existing = inputs.get(key)
-      inputs.set(key, {
-        ...input,
-        association:
-          existing?.association === 'resolver-accessed' || input.association === 'resolver-accessed'
-            ? 'resolver-accessed'
-            : 'turn-attached'
-      })
-    }
-  }
-  return [...inputs.values()]
-}
-
-const buildBoundedExecutionSnapshot = (
-  base: Omit<PersistedArtifactExecutionSnapshot, 'inputFiles' | 'runs' | 'truncation'>,
-  eligibleRuns: Array<{ run: NotebookRunRecord; runIndex: number }>
-): PersistedArtifactExecutionSnapshot => {
-  let omittedLeadingRunCount = Math.max(0, eligibleRuns.length - MAX_EXECUTION_SNAPSHOT_RUNS)
-  let omittedOutputCount = 0
-  const selectedRuns = eligibleRuns.slice(-MAX_EXECUTION_SNAPSHOT_RUNS)
-  let remainingOutputs = MAX_EXECUTION_SNAPSHOT_OUTPUTS
-  const runs = selectedRuns.map(({ run, runIndex }) => ({
-    run,
-    runIndex,
-    outputs: [] as ProvenanceNotebookOutput[]
-  }))
-  for (let index = runs.length - 1; index >= 0; index -= 1) {
-    const candidate = runs[index]!
-    const outputs = candidate.run.outputs.flatMap(sanitizeOutput).map(boundExecutionOutput)
-    const retainedCount = Math.min(outputs.length, remainingOutputs)
-    candidate.outputs = outputs.slice(0, retainedCount)
-    const omittedForRun = outputs.length - retainedCount
-    omittedOutputCount += omittedForRun
-    remainingOutputs -= retainedCount
-  }
-
-  const allInputs = mergeExecutionInputs(eligibleRuns)
-  let inputFiles = allInputs.slice(0, MAX_EXECUTION_SNAPSHOT_INPUTS)
-  let omittedInputCount = allInputs.length - inputFiles.length
-  const materializedRuns = runs.map(({ run, runIndex, outputs }) => {
-    const materialized = sanitizeRun(run, runIndex, outputs)
-    const omittedForRun = run.outputs.flatMap(sanitizeOutput).length - outputs.length
-    if (omittedForRun > 0) materialized.omittedOutputCount = omittedForRun
-    return materialized
-  })
-
-  const retainedInputKeys = (): Set<string> =>
-    new Set(inputFiles.map((input) => `${input.sourceKind}\0${input.inputFileVersionId}`))
-  const filterRunInputKeys = (): void => {
-    const retained = retainedInputKeys()
-    for (const run of materializedRuns) {
-      const filtered = run.inputFileVersionKeys.filter((input) =>
-        retained.has(`${input.sourceKind}\0${input.inputFileVersionId}`)
-      )
-      if (filtered.length !== run.inputFileVersionKeys.length) run.hasOmittedInputs = true
-      run.inputFileVersionKeys = filtered
-    }
-  }
-  filterRunInputKeys()
-
-  const snapshot = (): PersistedArtifactExecutionSnapshot => ({
-    ...base,
-    inputFiles,
-    runs: materializedRuns,
-    ...(omittedLeadingRunCount > 0 || omittedOutputCount > 0 || omittedInputCount > 0
-      ? {
-          truncation: {
-            reason: 'payload-limit' as const,
-            omittedLeadingRunCount,
-            omittedOutputCount,
-            omittedInputCount
-          }
-        }
-      : {})
-  })
-  const snapshotBytes = (): number =>
-    Buffer.byteLength(canonicalJson(snapshot() as unknown as CanonicalJson), 'utf8')
-
-  while (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES && materializedRuns.length > 1) {
-    materializedRuns.shift()
-    omittedLeadingRunCount += 1
-  }
-  while (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES) {
-    const runWithOutput = materializedRuns.find((run) => run.outputs.length > 0)
-    if (!runWithOutput) break
-    runWithOutput.outputs.pop()
-    runWithOutput.omittedOutputCount = (runWithOutput.omittedOutputCount ?? 0) + 1
-    omittedOutputCount += 1
-  }
-  while (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES && inputFiles.length > 0) {
-    inputFiles = inputFiles.slice(0, Math.floor(inputFiles.length / 2))
-    omittedInputCount = allInputs.length - inputFiles.length
-    filterRunInputKeys()
-  }
-  if (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES) {
-    const producer = materializedRuns.at(-1)
-    if (producer) {
-      producer.script = clipText(producer.script, 1_000)
-      producer.scriptTruncated = true
-    }
-  }
-  if (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES) {
-    throw new Error('Artifact execution evidence exceeds the bounded snapshot limit.')
-  }
-  return snapshot()
-}
-
-const inputEvidence = (
-  input: NotebookRunInputFile,
-  ordinal: number
-): ArtifactVersionInputEvidence => ({
-  ordinal,
-  input_file_version_id: input.inputFileVersionId,
-  source_kind: input.sourceKind,
-  source_file_id: input.sourceFileId,
-  ...(input.sourceVersionNumber !== undefined
-    ? { source_version_number: input.sourceVersionNumber }
-    : {}),
-  ...(input.sourceCreatedAt ? { source_created_at: input.sourceCreatedAt } : {}),
-  source_project_id: input.sourceProjectId,
-  source_session_id: input.sourceSessionId,
-  filename: input.filename,
-  ...(input.contentType ? { content_type: input.contentType } : {}),
-  size_bytes: input.sizeBytes,
-  checksum: input.checksum,
-  storage_key: input.storageKey,
-  strongest_association: input.association
-})
-
-const environmentPackageEvidence = (
-  pkg: NotebookEnvironmentPackage
-): ArtifactVersionEnvironmentEvidence['packages'][number] => ({
-  name: pkg.name,
-  ...(pkg.version ? { version: pkg.version } : {}),
-  version_status: pkg.versionStatus,
-  ecosystem: pkg.ecosystem,
-  evidence_sources: pkg.evidenceSources,
-  loaded_state: pkg.loadedState ?? 'unknown',
-  ...(pkg.libraryRank !== undefined ? { library_rank: pkg.libraryRank } : {}),
-  ...(pkg.libraryScope ? { library_scope: pkg.libraryScope } : {}),
-  ...(pkg.builtForRuntime ? { built_for_runtime: pkg.builtForRuntime } : {}),
-  ...(pkg.priority ? { priority: pkg.priority } : {})
-})
-
-const environmentEvidence = (
-  manifest: NotebookEnvironmentManifest,
-  checksum: string
-): ArtifactVersionEnvironmentEvidence => ({
-  capture_kind: manifest.captureKind,
-  environment_name: manifest.environmentName,
-  kernel_kind: manifest.kernelKind,
-  runtime_source: manifest.runtimeSource,
-  ...(manifest.runtimeVersion ? { runtime_version: manifest.runtimeVersion } : {}),
-  ...(manifest.platform ? { platform: manifest.platform } : {}),
-  ...(manifest.architecture ? { architecture: manifest.architecture } : {}),
-  packages: manifest.packages.map(environmentPackageEvidence),
-  ...(manifest.kernelKind === 'python' && manifest.runtimeVersion
-    ? { python_version: manifest.runtimeVersion }
-    : {}),
-  ...(manifest.kernelKind === 'r' && manifest.runtimeVersion
-    ? { r_version: manifest.runtimeVersion }
-    : {}),
-  inventory_sources: manifest.inventorySources,
-  installed_inventory: {
-    captured_at: manifest.installedInventory.capturedAt,
-    source: manifest.installedInventory.source,
-    validation: manifest.installedInventory.validation
-  },
-  ...(manifest.operationLog
-    ? {
-        op_log: manifest.operationLog.map((operation) => ({
-          operation_id: operation.operationId,
-          timestamp: operation.timestamp,
-          operation: operation.operation,
-          packages: operation.packages,
-          result: operation.result,
-          attempts: (operation.attempts ?? []).map((attempt) => ({
-            group_ordinal: attempt.groupOrdinal,
-            installer: attempt.installer,
-            packages: attempt.packages,
-            status: attempt.status,
-            mutation_risk: attempt.mutationRisk,
-            ...(attempt.reason ? { reason: attempt.reason } : {})
-          })),
-          fallback_used: operation.fallbackUsed ?? false,
-          inventory_refresh: operation.inventoryRefresh ?? 'published',
-          inventory_refresh_attempts: operation.inventoryRefreshAttempts ?? [],
-          ...(operation.packageChanges
-            ? {
-                package_changes: operation.packageChanges.map((change) => ({
-                  name: change.name,
-                  ecosystem: change.ecosystem,
-                  relationship: change.relationship,
-                  change: change.change,
-                  ...(change.beforeVersion ? { before_version: change.beforeVersion } : {}),
-                  ...(change.afterVersion ? { after_version: change.afterVersion } : {}),
-                  ...(change.libraryRank !== undefined ? { library_rank: change.libraryRank } : {}),
-                  ...(change.libraryScope ? { library_scope: change.libraryScope } : {})
-                }))
-              }
-            : {})
-        }))
-      }
-    : {}),
-  ...(manifest.operationLogTruncation
-    ? {
-        op_log_truncation: {
-          omitted_count: manifest.operationLogTruncation.omittedCount,
-          ...(manifest.operationLogTruncation.earliestRetainedAt
-            ? { earliest_retained_at: manifest.operationLogTruncation.earliestRetainedAt }
-            : {})
-        }
-      }
-    : {}),
-  captured_at: manifest.capturedAt,
-  source_manifest_checksum: checksum,
-  complete: manifest.complete,
-  capture_status: manifest.captureStatus,
-  ...(manifest.warnings ? { warnings: manifest.warnings } : {})
-})
-
-const resolveRunEnvironmentCapture = (
-  run: NotebookRunRecord
-): {
-  capture: NotebookRunEnvironmentCapture
-  manifest?: NotebookEnvironmentManifest
-  checksum?: string
-} => {
-  const manifest = run.environmentManifest
-  const checksum = run.environmentManifestChecksum
-  const serialized = manifest ? `${JSON.stringify(manifest, null, 2)}\n` : undefined
-  const manifestState = manifest?.captureStatus === 'complete' ? 'available' : 'partial'
-  const manifestIsValid =
-    serialized !== undefined &&
-    checksum !== undefined &&
-    sha256(serialized) === checksum &&
-    manifest?.captureKind === 'completed-run' &&
-    manifest.kernelKind === run.kernelKind &&
-    manifest.environmentName === run.environment &&
-    manifest.complete === (manifest.captureStatus === 'complete')
-
-  if (run.environmentCapture) {
-    if (run.environmentCapture.state === 'unavailable') {
-      return { capture: { ...run.environmentCapture } }
-    }
-    if (
-      manifestIsValid &&
-      checksum === run.environmentCapture.manifestChecksum &&
-      manifestState === run.environmentCapture.state
-    ) {
-      return {
-        capture: { ...run.environmentCapture },
-        manifest,
-        checksum
-      }
-    }
-    // A malformed available/partial tuple cannot be emitted as trustworthy evidence, but it also
-    // must not invalidate the Artifact bytes. Collapse only this corrupt publication state.
-    return {
-      capture: { state: 'unavailable', reason: 'environment-manifest-publication-failed' }
-    }
-  }
-
-  if (manifestIsValid && manifest && checksum) {
-    return {
-      capture: {
-        state: manifestState,
-        manifestChecksum: checksum,
-        ...(manifest.warnings?.length ? { warnings: [...manifest.warnings] } : {})
-      },
-      manifest,
-      checksum
-    }
-  }
-  return {
-    capture: { state: 'unavailable', reason: 'legacy-environment-reference-unavailable' }
-  }
-}
 
 class ArtifactProvenanceRepository {
   private readonly compatibilityRepository: ArtifactRepository

--- a/src/main/artifacts/provenance-version-writer.ts
+++ b/src/main/artifacts/provenance-version-writer.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto'
 import { copyFile, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
@@ -16,6 +15,7 @@ import type {
   NotebookRunRecord
 } from '../../shared/notebook'
 import type { ArtifactDurability } from './durability'
+import { sha256 } from './provenance-canonical'
 import type { ArtifactRepository } from './repository'
 
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
@@ -46,7 +46,6 @@ const normalizeArtifactFilename = (filename: string): string =>
     .replace(/\u00df/gu, 'ss')
     .replace(/\u03c2/gu, '\u03c3')
 
-const sha256 = (value: Buffer | string): string => createHash('sha256').update(value).digest('hex')
 const storageKey = (...segments: string[]): string => segments.join('/')
 const isRetryableLineageVersionConflict = (error: unknown): boolean => {
   if (typeof error !== 'object' || error === null || !('code' in error) || error.code !== 'P2002') {


### PR DESCRIPTION
## Problem

After PV1, the Artifact Provenance facade still owns roughly 400 lines of bounded execution
snapshots, Notebook-output sanitization, environment/input evidence and canonical persistence
codecs. Moving these stateless rules together with producer authority would exceed the approved 660
production-raw limit and obscure the stateful ownership boundary.

## Proposed change

- Add an internal `provenance-execution-evidence` module for bounded execution snapshots, run/output
  sanitization, environment capture projection and input/evidence materialization.
- Add a small internal canonical helper for the existing deterministic JSON and SHA-256 behavior
  shared by the facade and PV1 writer.
- Replace the facade implementations with imports of the same pure functions; do not compose a
  stateful producer owner yet.
- Register both files only under the existing `artifact_provenance` owner paths.

## Scope and non-goals

- Stateless extraction only: no Prisma transaction, filesystem lookup, Notebook repository access,
  source attribution, input authority decision or Version lifecycle ownership.
- No public/shared/IPC/MCP/local-RPC/HTTP/CLI type or value export change.
- No schema, data relationship, checksum, canonical JSON, storage key, Message binding, UI or user
  interaction change.
- Do not implement PV2B producer ownership or move PV3-PV5 behavior.

## Compatibility

- Preserve execution snapshot limits, truncation order, producer-run retention, output/media
  clipping, input ordering and environment status exactly.
- Preserve canonical key ordering, JSON bytes and SHA-256 results byte-for-byte.
- Persist storage keys with `/` and retain native `node:path` handling elsewhere, remaining portable
  on Windows, macOS and Linux.
- Preserve Electron/Web/CLI/Task/local-RPC/MCP behavior and Specialist/Permission/Compute asymmetry.

## Acceptance criteria and validation

- The facade public surface, persisted values and PV1 writer callbacks remain unchanged; the new
  modules are internal, stateless and have no runtime dependency cycle.
- `provenance-canonical.ts` is 21 raw lines and `provenance-execution-evidence.ts` is 441 raw lines;
  both remain below the approved 600 target and 660 hard tolerance.
- `provenance-repository.ts` is reduced from 3,544 to 3,111 raw lines; final production diff is
  +472/-444 and module-impact metadata only adds the two files to existing owner paths.
- PV0A/PV0B contracts pass through the facade; the complete `artifact_provenance` module set,
  local-RPC behavior, impact classifier, Node typecheck, changed lint/format and diff-check pass.
- Independent Standards/Spec/purity review and exact-head PR Gate, CI Integrity, CodeQL and AI pass
  before squash merge.

Final local evidence after the last material edit:

- Write/repository contracts: 2 files / 40 tests passed.
- `npm run test:module -- artifact_provenance`: 23 files / 995 tests passed.
- Focused local-RPC socket suite: 25/25 passed after allowing the local socket.
- Impact validator/selector/shadow: 3 files / 29 tests passed.
- Node typecheck, changed ESLint, Prettier and diff-check passed.
- Independent Standards, Spec and purity reviews each found 0 findings.
- The existing `artifact_provenance` owner set supplies repository, lifecycle, ACP/local-RPC and
  portable platform coverage. No interface path changed, so no new consumer identity or UI/E2E lane
  is introduced. Exact-head CI remains authoritative for Windows/macOS/Linux.

## Review focus

- Confirm this is a mechanical, stateless codec extraction rather than a premature producer owner.
- Confirm canonical bytes, bounds and truncation precedence are unchanged.
- Confirm no public/data/path/UI/cross-surface behavior or capability asymmetry changes.
