### PR TITLE
refactor(artifact-provenance): extract producer capture

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -148,6 +148,7 @@
         "src/main/artifacts/provenance-canonical.ts",
         "src/main/artifacts/provenance-execution-evidence.ts",
         "src/main/artifacts/provenance-message-snapshot.ts",
+        "src/main/artifacts/provenance-producer-capture.ts",
         "src/main/artifacts/provenance-repository.ts",
         "src/main/artifacts/provenance-version-writer.ts"
       ],

--- a/src/main/artifacts/provenance-producer-capture.ts
+++ b/src/main/artifacts/provenance-producer-capture.ts
@@ -1,0 +1,546 @@
+import { readFile, realpath, stat } from 'node:fs/promises'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+
+import type { Prisma, PrismaClient } from '@prisma/client'
+
+import type {
+  ArtifactProducerUnavailableReason,
+  ArtifactVersionEvidence,
+  CreateArtifactVersionRequest
+} from '../../shared/artifact-provenance'
+import type {
+  NotebookEnvironmentManifest,
+  NotebookRunEnvironmentCapture,
+  NotebookRunInputFile,
+  NotebookRunRecord
+} from '../../shared/notebook'
+import { NotebookRunRepository } from '../notebook/repository'
+import { canonicalJson, sha256, type CanonicalJson } from './provenance-canonical'
+import {
+  buildBoundedExecutionSnapshot,
+  environmentEvidence,
+  inputEvidence,
+  resolveRunEnvironmentCapture
+} from './provenance-execution-evidence'
+
+type ArtifactVersionProducerCapture =
+  | {
+      state: 'unavailable'
+      reason: ArtifactProducerUnavailableReason
+    }
+  | {
+      state: 'available'
+      notebookSessionId: string
+      producerRunId: string
+      producerRunIndex: number
+      associationMethod: 'agent-declared-and-session-validated' | 'server-inferred-file-observation'
+      kernelKind: NotebookRunRecord['kernelKind']
+      environmentName?: string
+      reproductionCode: string
+      executionJson: string
+      executionChecksum: string
+      inputFiles: NotebookRunInputFile[]
+      environmentCapture: NotebookRunEnvironmentCapture
+      environmentManifest?: NotebookEnvironmentManifest
+      environmentManifestChecksum?: string
+    }
+
+type PreparedArtifactVersionPersistence = {
+  notebookSessionId?: string
+  producerRunId?: string
+  producerRunIndex?: number
+  evidenceJson: string
+  evidenceChecksum: string
+  executionSnapshotJson?: string
+  executionSnapshotChecksum?: string
+  inputs?: Prisma.ArtifactVersionUncheckedCreateInput['inputs']
+}
+
+type ArtifactProvenanceProducerCaptureOptions = {
+  getClient: () => Promise<PrismaClient>
+  notebookRepository: Pick<NotebookRunRepository, 'findExisting'>
+  createId: () => string
+}
+
+type PrepareVersionPersistenceInput = {
+  request: CreateArtifactVersionRequest
+  producer: ArtifactVersionProducerCapture
+  artifactId: string
+  versionId: string
+  versionNumber: number
+  checksum: string
+  sizeBytes: number
+  createdAt: Date
+}
+
+type ProducerScope = {
+  rootFrameId: string
+  agentFrameId: string
+  messageBranchId: string
+  runtimeSegmentId: string
+  promptMessageId: string
+}
+
+class ArtifactProvenanceProducerCapture {
+  constructor(private readonly options: ArtifactProvenanceProducerCaptureOptions) {}
+
+  async captureProducer(
+    request: CreateArtifactVersionRequest,
+    createdAt: Date,
+    artifactChecksum: string
+  ): Promise<ArtifactVersionProducerCapture> {
+    // Local files require an app-side observation before an Agent-declared run may become evidence.
+    // Inline bytes have no file observation, so they retain the declared run only after the durable
+    // Notebook Session and graph-scope checks below succeed.
+    if (
+      request.producerRunId &&
+      !request.sourceFileObservation &&
+      request.sourceKind !== 'inline'
+    ) {
+      return { state: 'unavailable', reason: 'producer-source-unverifiable' }
+    }
+    if (request.producerRunId && !request.notebookSessionId) {
+      throw new Error('producerRunId requires notebookSessionId in the active Artifact run.')
+    }
+    if (!request.notebookSessionId) {
+      return { state: 'unavailable', reason: 'producer-not-supplied' }
+    }
+    if (!request.producerRunId && !request.sourceFileObservation) {
+      return { state: 'unavailable', reason: 'producer-not-supplied' }
+    }
+
+    const document = await this.options.notebookRepository.findExisting(
+      request.projectId,
+      request.notebookSessionId
+    )
+    const sourceFileObservation = request.sourceFileObservation
+      ? await this.verifySourceFileObservation(
+          document,
+          request.sourceFileObservation,
+          artifactChecksum
+        )
+      : undefined
+    if (request.sourceFileObservation && !sourceFileObservation) {
+      return { state: 'unavailable', reason: 'producer-source-unverifiable' }
+    }
+    const expected = {
+      rootFrameId: request.rootFrameId,
+      agentFrameId: request.agentFrameId,
+      messageBranchId: request.messageBranchId,
+      runtimeSegmentId: request.runtimeSegmentId,
+      promptMessageId: request.promptMessageId
+    }
+    const inferredProducerRunId = request.producerRunId
+      ? undefined
+      : await this.inferProducerRunId(document, sourceFileObservation, expected)
+    const producerRunId = request.producerRunId ?? inferredProducerRunId
+    if (!producerRunId) {
+      return {
+        state: 'unavailable',
+        reason: request.sourceFileObservation
+          ? 'producer-source-unverifiable'
+          : 'producer-not-supplied'
+      }
+    }
+    const producerRunIndex = document?.runs.findIndex((run) => run.runId === producerRunId) ?? -1
+    const producerRun = document?.runs[producerRunIndex]
+
+    if (!document || !producerRun || producerRunIndex < 0) {
+      throw new Error(`Notebook producer run not found: ${producerRunId}`)
+    }
+    for (const [field, value] of Object.entries(expected)) {
+      if (producerRun[field as keyof typeof expected] !== value) {
+        throw new Error(
+          `Notebook producer run does not belong to the active Artifact ${field}: ${producerRunId}`
+        )
+      }
+    }
+    if (request.producerRunId && sourceFileObservation) {
+      const observedOwners = await this.findObservedWorkingFileRunIds(
+        document,
+        sourceFileObservation,
+        expected
+      )
+      if (observedOwners.length > 0 && !observedOwners.includes(request.producerRunId)) {
+        throw new Error(
+          `Declared producer source belongs to another Notebook run: ${observedOwners.join(', ')}`
+        )
+      }
+      if (observedOwners.length !== 1) {
+        return { state: 'unavailable', reason: 'producer-source-unverifiable' }
+      }
+    }
+
+    const eligibleBranchIds = new Set(
+      request.messageBranchAncestry?.length
+        ? request.messageBranchAncestry
+        : [request.messageBranchId]
+    )
+    if (!eligibleBranchIds.has(request.messageBranchId)) {
+      throw new Error('Artifact Branch ancestry does not contain the active Branch.')
+    }
+    const eligibleMessageIds = request.messageAncestry?.length
+      ? new Set(request.messageAncestry)
+      : undefined
+    if (eligibleMessageIds && !eligibleMessageIds.has(request.promptMessageId)) {
+      throw new Error('Artifact Message ancestry does not contain the producer prompt.')
+    }
+    const eligibleRuns = document.runs
+      .slice(0, producerRunIndex + 1)
+      .map((run, runIndex) => ({ run, runIndex }))
+      .filter(
+        ({ run }) =>
+          run.agentFrameId === request.agentFrameId &&
+          !!run.messageBranchId &&
+          eligibleBranchIds.has(run.messageBranchId) &&
+          (eligibleMessageIds
+            ? run.promptMessageId
+              ? eligibleMessageIds.has(run.promptMessageId)
+              : run.messageBranchId === request.messageBranchId
+            : true)
+      )
+    const executionSnapshot = buildBoundedExecutionSnapshot(
+      {
+        schemaVersion: 2,
+        rootFrameId: request.rootFrameId,
+        agentFrameId: request.agentFrameId,
+        messageBranchId: request.messageBranchId,
+        terminalPromptMessageId: request.promptMessageId,
+        producerRunId,
+        producerRunIndex,
+        createdAt: createdAt.toISOString()
+      },
+      eligibleRuns
+    )
+    const inputFiles = executionSnapshot.inputFiles
+    await this.validateInputReferences(request.projectId, inputFiles)
+    const executionJson = canonicalJson(executionSnapshot as unknown as CanonicalJson)
+    const environment = resolveRunEnvironmentCapture(producerRun)
+
+    return {
+      state: 'available',
+      notebookSessionId: request.notebookSessionId,
+      producerRunId,
+      producerRunIndex,
+      associationMethod: request.producerRunId
+        ? 'agent-declared-and-session-validated'
+        : 'server-inferred-file-observation',
+      kernelKind: producerRun.kernelKind,
+      environmentName: producerRun.environment,
+      reproductionCode: producerRun.script,
+      executionJson,
+      executionChecksum: sha256(executionJson),
+      inputFiles,
+      environmentCapture: environment.capture,
+      ...(environment.manifest && environment.checksum
+        ? {
+            environmentManifest: environment.manifest,
+            environmentManifestChecksum: environment.checksum
+          }
+        : {})
+    }
+  }
+
+  prepareVersionPersistence({
+    request,
+    producer,
+    artifactId,
+    versionId,
+    versionNumber,
+    checksum,
+    sizeBytes,
+    createdAt
+  }: PrepareVersionPersistenceInput): PreparedArtifactVersionPersistence {
+    const evidence: ArtifactVersionEvidence = {
+      app_session_id: request.appSessionId,
+      artifact_id: artifactId,
+      checksum,
+      ...(request.contentType ? { content_type: request.contentType } : {}),
+      conversation: {
+        agent_frame_id: request.agentFrameId,
+        message_branch_id: request.messageBranchId,
+        prompt_message_id: request.promptMessageId,
+        root_frame_id: request.rootFrameId,
+        runtime_segment_id: request.runtimeSegmentId
+      },
+      created_at: createdAt.toISOString(),
+      environment_status:
+        producer.state !== 'available'
+          ? { reason: producer.reason, state: 'unavailable' }
+          : producer.environmentCapture.state === 'unavailable'
+            ? { reason: producer.environmentCapture.reason, state: 'unavailable' }
+            : { state: producer.environmentCapture.state },
+      ...(producer.state === 'available' &&
+      producer.environmentManifest &&
+      producer.environmentManifestChecksum
+        ? {
+            environment: environmentEvidence(
+              producer.environmentManifest,
+              producer.environmentManifestChecksum
+            )
+          }
+        : {}),
+      execution_status:
+        producer.state === 'available'
+          ? { state: 'available' }
+          : { reason: producer.reason, state: 'unavailable' },
+      ...(producer.state === 'available'
+        ? {
+            execution_snapshot_checksum: producer.executionChecksum,
+            reproduction_code: producer.reproductionCode
+          }
+        : {}),
+      filename: request.filename,
+      inputs:
+        producer.state === 'available'
+          ? producer.inputFiles.map((input, ordinal) => inputEvidence(input, ordinal))
+          : [],
+      is_user_upload: false,
+      ...(request.agentName ? { agent_name: request.agentName } : {}),
+      producer:
+        producer.state === 'available'
+          ? {
+              association_method: producer.associationMethod,
+              kernel_kind: producer.kernelKind,
+              notebook_session_id: producer.notebookSessionId,
+              producer_run_id: producer.producerRunId,
+              run_index: producer.producerRunIndex,
+              ...(producer.environmentCapture.state !== 'unavailable'
+                ? {
+                    environment_manifest_checksum: producer.environmentCapture.manifestChecksum
+                  }
+                : {}),
+              state: 'available'
+            }
+          : { reason: producer.reason, state: 'unavailable' },
+      project_id: request.projectId,
+      schema_version: 1,
+      size_bytes: sizeBytes,
+      version_id: versionId,
+      version_number: versionNumber
+    }
+    const evidenceJson = canonicalJson(evidence as unknown as CanonicalJson)
+    return {
+      notebookSessionId: producer.state === 'available' ? producer.notebookSessionId : undefined,
+      producerRunId: producer.state === 'available' ? producer.producerRunId : undefined,
+      producerRunIndex: producer.state === 'available' ? producer.producerRunIndex : undefined,
+      evidenceJson,
+      evidenceChecksum: sha256(evidenceJson),
+      executionSnapshotJson: producer.state === 'available' ? producer.executionJson : undefined,
+      executionSnapshotChecksum:
+        producer.state === 'available' ? producer.executionChecksum : undefined,
+      ...(producer.state === 'available' && producer.inputFiles.length > 0
+        ? {
+            inputs: {
+              create: producer.inputFiles.map((input, ordinal) => ({
+                id: this.options.createId(),
+                ordinal,
+                inputFileVersionId: input.inputFileVersionId,
+                sourceKind: input.sourceKind,
+                sourceFileId: input.sourceFileId,
+                ...(input.sourceKind === 'artifact-version'
+                  ? { sourceArtifactVersionId: input.inputFileVersionId }
+                  : { sourceUploadVersionId: input.inputFileVersionId }),
+                sourceVersionNumber: input.sourceVersionNumber,
+                sourceCreatedAt: input.sourceCreatedAt
+                  ? new Date(input.sourceCreatedAt)
+                  : undefined,
+                sourceProjectId: input.sourceProjectId,
+                sourceSessionId: input.sourceSessionId,
+                filename: input.filename,
+                contentType: input.contentType,
+                sizeBytes: BigInt(input.sizeBytes),
+                checksum: input.checksum,
+                storageKey: input.storageKey,
+                strongestAssociation: input.association
+              }))
+            }
+          }
+        : {})
+    }
+  }
+
+  private async inferProducerRunId(
+    document: Awaited<ReturnType<NotebookRunRepository['findExisting']>>,
+    observation: CreateArtifactVersionRequest['sourceFileObservation'],
+    expected: ProducerScope
+  ): Promise<string | undefined> {
+    if (!document || !observation) return undefined
+    const matches = await this.findObservedWorkingFileRunIds(document, observation, expected)
+    return matches.length === 1 ? matches[0] : undefined
+  }
+
+  // Treat the RPC observation as an untrusted path hint. Main re-observes the source under the
+  // Notebook's durable roots and proves that its bytes are exactly the immutable Artifact content
+  // before the hint may participate in producer attribution.
+  private async verifySourceFileObservation(
+    document: Awaited<ReturnType<NotebookRunRepository['findExisting']>>,
+    observation: NonNullable<CreateArtifactVersionRequest['sourceFileObservation']>,
+    artifactChecksum: string
+  ): Promise<NonNullable<CreateArtifactVersionRequest['sourceFileObservation']> | undefined> {
+    if (
+      !document ||
+      !Number.isFinite(observation.sizeBytes) ||
+      observation.sizeBytes < 0 ||
+      !Number.isFinite(observation.mtimeMs) ||
+      observation.mtimeMs < 0
+    ) {
+      return undefined
+    }
+
+    const observedPath = await realpath(resolve(observation.path)).catch(() => undefined)
+    if (!observedPath) return undefined
+    const roots = await Promise.all(
+      [document.notebookSessionRoot, document.workspaceCwd].map((root) =>
+        realpath(resolve(root)).catch(() => resolve(root))
+      )
+    )
+    if (
+      !roots.some((root) => {
+        const relativePath = relative(root, observedPath)
+        return (
+          relativePath !== '' &&
+          relativePath !== '..' &&
+          !relativePath.startsWith(`..${sep}`) &&
+          !isAbsolute(relativePath)
+        )
+      })
+    ) {
+      return undefined
+    }
+
+    const before = await stat(observedPath).catch(() => undefined)
+    if (
+      !before?.isFile() ||
+      before.size !== observation.sizeBytes ||
+      before.mtimeMs !== observation.mtimeMs
+    ) {
+      return undefined
+    }
+    const bytes = await readFile(observedPath).catch(() => undefined)
+    const after = await stat(observedPath).catch(() => undefined)
+    if (
+      !bytes ||
+      !after?.isFile() ||
+      after.size !== before.size ||
+      after.mtimeMs !== before.mtimeMs ||
+      sha256(bytes) !== artifactChecksum
+    ) {
+      return undefined
+    }
+
+    return { path: observedPath, sizeBytes: after.size, mtimeMs: after.mtimeMs }
+  }
+
+  private async findObservedWorkingFileRunIds(
+    document: NonNullable<Awaited<ReturnType<NotebookRunRepository['findExisting']>>>,
+    observation: NonNullable<CreateArtifactVersionRequest['sourceFileObservation']>,
+    expected: ProducerScope
+  ): Promise<string[]> {
+    if (
+      !Number.isFinite(observation.sizeBytes) ||
+      observation.sizeBytes < 0 ||
+      !Number.isFinite(observation.mtimeMs) ||
+      observation.mtimeMs < 0
+    ) {
+      return []
+    }
+
+    const canonicalPath = async (path: string): Promise<string> =>
+      realpath(resolve(path)).catch(() => resolve(path))
+    const observedPath = await canonicalPath(observation.path)
+    const documentRoots = await Promise.all(
+      [document.notebookSessionRoot, document.workspaceCwd].map(canonicalPath)
+    )
+    const isInsideDocumentRoot = documentRoots.some((root) => {
+      const relativePath = relative(root, observedPath)
+      return (
+        relativePath !== '' &&
+        relativePath !== '..' &&
+        !relativePath.startsWith(`..${sep}`) &&
+        !isAbsolute(relativePath)
+      )
+    })
+    if (!isInsideDocumentRoot) return []
+
+    const candidates = document.runs.filter((run) =>
+      Object.entries(expected).every(
+        ([field, value]) => run[field as keyof typeof expected] === value
+      )
+    )
+    const workingFileMatches = (
+      await Promise.all(
+        candidates.map(async (run) => {
+          for (const file of run.workingFiles) {
+            if (
+              (await canonicalPath(file.path)) === observedPath &&
+              file.createdByRunId === run.runId &&
+              file.size === observation.sizeBytes &&
+              file.mtimeMs === observation.mtimeMs
+            ) {
+              return run.runId
+            }
+          }
+          return undefined
+        })
+      )
+    ).filter((runId): runId is string => runId !== undefined)
+
+    // mtime is diagnostic context, not a causal execution receipt. Only a WorkingFile observation
+    // attributed to one run may promote an omitted declaration to available producer evidence.
+    return [...new Set(workingFileMatches)]
+  }
+
+  private async validateInputReferences(
+    projectId: string,
+    inputs: NotebookRunInputFile[]
+  ): Promise<void> {
+    const client = await this.options.getClient()
+    for (const input of inputs) {
+      if (input.sourceProjectId !== projectId) {
+        throw new Error(`Notebook input belongs to another Project: ${input.inputFileVersionId}`)
+      }
+      if (input.sourceKind === 'upload-version') {
+        const version = await client.uploadVersion.findUnique({
+          where: { id: input.inputFileVersionId },
+          include: { uploadFile: true }
+        })
+        if (
+          !version ||
+          version.state !== 'ready' ||
+          version.uploadFileId !== input.sourceFileId ||
+          version.uploadFile.projectId !== input.sourceProjectId ||
+          version.uploadFile.sessionId !== input.sourceSessionId ||
+          version.versionNumber !== input.sourceVersionNumber ||
+          version.contentStorageKey !== input.storageKey ||
+          version.checksum !== input.checksum ||
+          Number(version.sizeBytes) !== input.sizeBytes
+        ) {
+          throw new Error(`Notebook Upload input identity is corrupt: ${input.inputFileVersionId}`)
+        }
+        continue
+      }
+
+      const version = await client.artifactVersion.findUnique({
+        where: { id: input.inputFileVersionId },
+        include: { artifact: true }
+      })
+      if (
+        !version ||
+        version.state !== 'finalized' ||
+        version.artifactId !== input.sourceFileId ||
+        version.artifact.projectId !== input.sourceProjectId ||
+        version.artifact.sessionId !== input.sourceSessionId ||
+        version.versionNumber !== input.sourceVersionNumber ||
+        version.contentStorageKey !== input.storageKey ||
+        version.checksum !== input.checksum ||
+        Number(version.sizeBytes) !== input.sizeBytes
+      ) {
+        throw new Error(`Notebook Artifact input identity is corrupt: ${input.inputFileVersionId}`)
+      }
+    }
+  }
+}
+
+export { ArtifactProvenanceProducerCapture }
+export type { ArtifactVersionProducerCapture, PreparedArtifactVersionPersistence }

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -35,22 +35,15 @@ import { defaultArtifactDurability, type ArtifactDurability } from './durability
 import {
   ArtifactProvenanceVersionWriter,
   normalizeArtifactFilename as normalizeFilename,
-  type ArtifactVersionProducerCapture as ProducerCapture,
   type CompatibilityRoutingPublicationOptions,
   type PersistedVersionFileRecord,
-  type PreparedArtifactVersionPersistence,
   type PublishCompatibilityRouting,
   type StagingArtifactVersionRecord
 } from './provenance-version-writer'
 import { NotebookRunRepository } from '../notebook/repository'
 import type { NotebookRunInputFile } from '../../shared/notebook'
 import { canonicalJson, sha256, type CanonicalJson } from './provenance-canonical'
-import {
-  buildBoundedExecutionSnapshot,
-  environmentEvidence,
-  inputEvidence,
-  resolveRunEnvironmentCapture
-} from './provenance-execution-evidence'
+import { ArtifactProvenanceProducerCapture } from './provenance-producer-capture'
 import { toCheck, toReview } from '../reviewer/repository'
 import { selectReviewChainForArtifactVersion } from '../reviewer/artifact-version-review'
 import { flagStaleReviews } from '../reviewer/stale-reviews'
@@ -772,20 +765,25 @@ const validRecoveryFilename = (value: string): boolean =>
 
 class ArtifactProvenanceRepository {
   private readonly compatibilityRepository: ArtifactRepository
-  private readonly notebookRepository: Pick<NotebookRunRepository, 'findExisting'>
   private readonly createId: () => string
   private readonly now: () => Date
   private readonly durability: ArtifactDurability
+  private readonly producerCapture: ArtifactProvenanceProducerCapture
   private readonly versionWriter: ArtifactProvenanceVersionWriter
 
   constructor(private readonly options: ArtifactProvenanceRepositoryOptions) {
     this.compatibilityRepository =
       options.compatibilityRepository ?? new ArtifactRepository(options.storageRoot)
-    this.notebookRepository =
+    const notebookRepository =
       options.notebookRepository ?? new NotebookRunRepository(options.storageRoot)
     this.createId = options.createId ?? randomUUID
     this.now = options.now ?? (() => new Date())
     this.durability = options.durability ?? defaultArtifactDurability
+    this.producerCapture = new ArtifactProvenanceProducerCapture({
+      getClient: options.getClient,
+      notebookRepository,
+      createId: this.createId
+    })
     this.versionWriter = new ArtifactProvenanceVersionWriter({
       storageRoot: options.storageRoot,
       getClient: options.getClient,
@@ -794,8 +792,8 @@ class ArtifactProvenanceRepository {
       now: this.now,
       durability: this.durability,
       captureProducer: (request, createdAt, checksum) =>
-        this.captureProducer(request, createdAt, checksum),
-      prepareVersionPersistence: (input) => this.prepareVersionPersistence(input),
+        this.producerCapture.captureProducer(request, createdAt, checksum),
+      prepareVersionPersistence: (input) => this.producerCapture.prepareVersionPersistence(input),
       recoverStagingVersion: (version, projectId, appSessionId, filename, publish) =>
         this.recoverStagingVersion(version, projectId, appSessionId, filename, publish),
       projectVersionFile: (version, projectId, appSessionId) =>
@@ -981,134 +979,6 @@ class ArtifactProvenanceRepository {
     return this.toArtifactVersionFile(existing, projectId, appSessionId)
   }
 
-  private prepareVersionPersistence({
-    request,
-    producer,
-    artifactId,
-    versionId,
-    versionNumber,
-    checksum,
-    sizeBytes,
-    createdAt
-  }: {
-    request: CreateArtifactVersionRequest
-    producer: ProducerCapture
-    artifactId: string
-    versionId: string
-    versionNumber: number
-    checksum: string
-    sizeBytes: number
-    createdAt: Date
-  }): PreparedArtifactVersionPersistence {
-    const evidence: ArtifactVersionEvidence = {
-      app_session_id: request.appSessionId,
-      artifact_id: artifactId,
-      checksum,
-      ...(request.contentType ? { content_type: request.contentType } : {}),
-      conversation: {
-        agent_frame_id: request.agentFrameId,
-        message_branch_id: request.messageBranchId,
-        prompt_message_id: request.promptMessageId,
-        root_frame_id: request.rootFrameId,
-        runtime_segment_id: request.runtimeSegmentId
-      },
-      created_at: createdAt.toISOString(),
-      environment_status:
-        producer.state !== 'available'
-          ? { reason: producer.reason, state: 'unavailable' }
-          : producer.environmentCapture.state === 'unavailable'
-            ? { reason: producer.environmentCapture.reason, state: 'unavailable' }
-            : { state: producer.environmentCapture.state },
-      ...(producer.state === 'available' &&
-      producer.environmentManifest &&
-      producer.environmentManifestChecksum
-        ? {
-            environment: environmentEvidence(
-              producer.environmentManifest,
-              producer.environmentManifestChecksum
-            )
-          }
-        : {}),
-      execution_status:
-        producer.state === 'available'
-          ? { state: 'available' }
-          : { reason: producer.reason, state: 'unavailable' },
-      ...(producer.state === 'available'
-        ? {
-            execution_snapshot_checksum: producer.executionChecksum,
-            reproduction_code: producer.reproductionCode
-          }
-        : {}),
-      filename: request.filename,
-      inputs:
-        producer.state === 'available'
-          ? producer.inputFiles.map((input, ordinal) => inputEvidence(input, ordinal))
-          : [],
-      is_user_upload: false,
-      ...(request.agentName ? { agent_name: request.agentName } : {}),
-      producer:
-        producer.state === 'available'
-          ? {
-              association_method: producer.associationMethod,
-              kernel_kind: producer.kernelKind,
-              notebook_session_id: producer.notebookSessionId,
-              producer_run_id: producer.producerRunId,
-              run_index: producer.producerRunIndex,
-              ...(producer.environmentCapture.state !== 'unavailable'
-                ? {
-                    environment_manifest_checksum: producer.environmentCapture.manifestChecksum
-                  }
-                : {}),
-              state: 'available'
-            }
-          : { reason: producer.reason, state: 'unavailable' },
-      project_id: request.projectId,
-      schema_version: 1,
-      size_bytes: sizeBytes,
-      version_id: versionId,
-      version_number: versionNumber
-    }
-    const evidenceJson = canonicalJson(evidence as unknown as CanonicalJson)
-    return {
-      notebookSessionId: producer.state === 'available' ? producer.notebookSessionId : undefined,
-      producerRunId: producer.state === 'available' ? producer.producerRunId : undefined,
-      producerRunIndex: producer.state === 'available' ? producer.producerRunIndex : undefined,
-      evidenceJson,
-      evidenceChecksum: sha256(evidenceJson),
-      executionSnapshotJson: producer.state === 'available' ? producer.executionJson : undefined,
-      executionSnapshotChecksum:
-        producer.state === 'available' ? producer.executionChecksum : undefined,
-      ...(producer.state === 'available' && producer.inputFiles.length > 0
-        ? {
-            inputs: {
-              create: producer.inputFiles.map((input, ordinal) => ({
-                id: this.createId(),
-                ordinal,
-                inputFileVersionId: input.inputFileVersionId,
-                sourceKind: input.sourceKind,
-                sourceFileId: input.sourceFileId,
-                ...(input.sourceKind === 'artifact-version'
-                  ? { sourceArtifactVersionId: input.inputFileVersionId }
-                  : { sourceUploadVersionId: input.inputFileVersionId }),
-                sourceVersionNumber: input.sourceVersionNumber,
-                sourceCreatedAt: input.sourceCreatedAt
-                  ? new Date(input.sourceCreatedAt)
-                  : undefined,
-                sourceProjectId: input.sourceProjectId,
-                sourceSessionId: input.sourceSessionId,
-                filename: input.filename,
-                contentType: input.contentType,
-                sizeBytes: BigInt(input.sizeBytes),
-                checksum: input.checksum,
-                storageKey: input.storageKey,
-                strongestAssociation: input.association
-              }))
-            }
-          }
-        : {})
-    }
-  }
-
   private async recoverStagingVersion(
     version: StagingArtifactVersionRecord,
     projectId: string,
@@ -1263,356 +1133,6 @@ class ArtifactProvenanceRepository {
     const value = bytes.toString('utf8')
     if (value !== canonical || sha256(bytes) !== checksum) throw new Error(corruptMessage)
     return value
-  }
-
-  private async captureProducer(
-    request: CreateArtifactVersionRequest,
-    createdAt: Date,
-    artifactChecksum: string
-  ): Promise<ProducerCapture> {
-    // Local files require an app-side observation before an Agent-declared run may become evidence.
-    // Inline bytes have no file observation, so they retain the declared run only after the durable
-    // Notebook Session and graph-scope checks below succeed.
-    if (
-      request.producerRunId &&
-      !request.sourceFileObservation &&
-      request.sourceKind !== 'inline'
-    ) {
-      return { state: 'unavailable', reason: 'producer-source-unverifiable' }
-    }
-    if (request.producerRunId && !request.notebookSessionId) {
-      throw new Error('producerRunId requires notebookSessionId in the active Artifact run.')
-    }
-    if (!request.notebookSessionId) {
-      return { state: 'unavailable', reason: 'producer-not-supplied' }
-    }
-    if (!request.producerRunId && !request.sourceFileObservation) {
-      return { state: 'unavailable', reason: 'producer-not-supplied' }
-    }
-
-    const document = await this.notebookRepository.findExisting(
-      request.projectId,
-      request.notebookSessionId
-    )
-    const sourceFileObservation = request.sourceFileObservation
-      ? await this.verifySourceFileObservation(
-          document,
-          request.sourceFileObservation,
-          artifactChecksum
-        )
-      : undefined
-    if (request.sourceFileObservation && !sourceFileObservation) {
-      return { state: 'unavailable', reason: 'producer-source-unverifiable' }
-    }
-    const expected = {
-      rootFrameId: request.rootFrameId,
-      agentFrameId: request.agentFrameId,
-      messageBranchId: request.messageBranchId,
-      runtimeSegmentId: request.runtimeSegmentId,
-      promptMessageId: request.promptMessageId
-    }
-    const inferredProducerRunId = request.producerRunId
-      ? undefined
-      : await this.inferProducerRunId(document, sourceFileObservation, expected)
-    const producerRunId = request.producerRunId ?? inferredProducerRunId
-    if (!producerRunId) {
-      return {
-        state: 'unavailable',
-        reason: request.sourceFileObservation
-          ? 'producer-source-unverifiable'
-          : 'producer-not-supplied'
-      }
-    }
-    const producerRunIndex = document?.runs.findIndex((run) => run.runId === producerRunId) ?? -1
-    const producerRun = document?.runs[producerRunIndex]
-
-    if (!document || !producerRun || producerRunIndex < 0) {
-      throw new Error(`Notebook producer run not found: ${producerRunId}`)
-    }
-    for (const [field, value] of Object.entries(expected)) {
-      if (producerRun[field as keyof typeof expected] !== value) {
-        throw new Error(
-          `Notebook producer run does not belong to the active Artifact ${field}: ${producerRunId}`
-        )
-      }
-    }
-    if (request.producerRunId && sourceFileObservation) {
-      const observedOwners = await this.findObservedWorkingFileRunIds(
-        document,
-        sourceFileObservation,
-        expected
-      )
-      if (observedOwners.length > 0 && !observedOwners.includes(request.producerRunId)) {
-        throw new Error(
-          `Declared producer source belongs to another Notebook run: ${observedOwners.join(', ')}`
-        )
-      }
-      if (observedOwners.length !== 1) {
-        return { state: 'unavailable', reason: 'producer-source-unverifiable' }
-      }
-    }
-
-    const eligibleBranchIds = new Set(
-      request.messageBranchAncestry?.length
-        ? request.messageBranchAncestry
-        : [request.messageBranchId]
-    )
-    if (!eligibleBranchIds.has(request.messageBranchId)) {
-      throw new Error('Artifact Branch ancestry does not contain the active Branch.')
-    }
-    const eligibleMessageIds = request.messageAncestry?.length
-      ? new Set(request.messageAncestry)
-      : undefined
-    if (eligibleMessageIds && !eligibleMessageIds.has(request.promptMessageId)) {
-      throw new Error('Artifact Message ancestry does not contain the producer prompt.')
-    }
-    const eligibleRuns = document.runs
-      .slice(0, producerRunIndex + 1)
-      .map((run, runIndex) => ({ run, runIndex }))
-      .filter(
-        ({ run }) =>
-          run.agentFrameId === request.agentFrameId &&
-          !!run.messageBranchId &&
-          eligibleBranchIds.has(run.messageBranchId) &&
-          (eligibleMessageIds
-            ? run.promptMessageId
-              ? eligibleMessageIds.has(run.promptMessageId)
-              : run.messageBranchId === request.messageBranchId
-            : true)
-      )
-    const executionSnapshot = buildBoundedExecutionSnapshot(
-      {
-        schemaVersion: 2,
-        rootFrameId: request.rootFrameId,
-        agentFrameId: request.agentFrameId,
-        messageBranchId: request.messageBranchId,
-        terminalPromptMessageId: request.promptMessageId,
-        producerRunId,
-        producerRunIndex,
-        createdAt: createdAt.toISOString()
-      },
-      eligibleRuns
-    )
-    const inputFiles = executionSnapshot.inputFiles
-    await this.validateInputReferences(request.projectId, inputFiles)
-    const executionJson = canonicalJson(executionSnapshot as unknown as CanonicalJson)
-    const environment = resolveRunEnvironmentCapture(producerRun)
-
-    return {
-      state: 'available',
-      notebookSessionId: request.notebookSessionId,
-      producerRunId,
-      producerRunIndex,
-      associationMethod: request.producerRunId
-        ? 'agent-declared-and-session-validated'
-        : 'server-inferred-file-observation',
-      kernelKind: producerRun.kernelKind,
-      environmentName: producerRun.environment,
-      reproductionCode: producerRun.script,
-      executionJson,
-      executionChecksum: sha256(executionJson),
-      inputFiles,
-      environmentCapture: environment.capture,
-      ...(environment.manifest && environment.checksum
-        ? {
-            environmentManifest: environment.manifest,
-            environmentManifestChecksum: environment.checksum
-          }
-        : {})
-    }
-  }
-
-  private async inferProducerRunId(
-    document: Awaited<ReturnType<NotebookRunRepository['findExisting']>>,
-    observation: CreateArtifactVersionRequest['sourceFileObservation'],
-    expected: {
-      rootFrameId: string
-      agentFrameId: string
-      messageBranchId: string
-      runtimeSegmentId: string
-      promptMessageId: string
-    }
-  ): Promise<string | undefined> {
-    if (!document || !observation) return undefined
-    const matches = await this.findObservedWorkingFileRunIds(document, observation, expected)
-    return matches.length === 1 ? matches[0] : undefined
-  }
-
-  // Treat the RPC observation as an untrusted path hint. Main re-observes the source under the
-  // Notebook's durable roots and proves that its bytes are exactly the immutable Artifact content
-  // before the hint may participate in producer attribution.
-  private async verifySourceFileObservation(
-    document: Awaited<ReturnType<NotebookRunRepository['findExisting']>>,
-    observation: NonNullable<CreateArtifactVersionRequest['sourceFileObservation']>,
-    artifactChecksum: string
-  ): Promise<NonNullable<CreateArtifactVersionRequest['sourceFileObservation']> | undefined> {
-    if (
-      !document ||
-      !Number.isFinite(observation.sizeBytes) ||
-      observation.sizeBytes < 0 ||
-      !Number.isFinite(observation.mtimeMs) ||
-      observation.mtimeMs < 0
-    ) {
-      return undefined
-    }
-
-    const observedPath = await realpath(resolve(observation.path)).catch(() => undefined)
-    if (!observedPath) return undefined
-    const roots = await Promise.all(
-      [document.notebookSessionRoot, document.workspaceCwd].map((root) =>
-        realpath(resolve(root)).catch(() => resolve(root))
-      )
-    )
-    if (
-      !roots.some((root) => {
-        const relativePath = relative(root, observedPath)
-        return (
-          relativePath !== '' &&
-          relativePath !== '..' &&
-          !relativePath.startsWith(`..${sep}`) &&
-          !isAbsolute(relativePath)
-        )
-      })
-    ) {
-      return undefined
-    }
-
-    const before = await stat(observedPath).catch(() => undefined)
-    if (
-      !before?.isFile() ||
-      before.size !== observation.sizeBytes ||
-      before.mtimeMs !== observation.mtimeMs
-    ) {
-      return undefined
-    }
-    const bytes = await readFile(observedPath).catch(() => undefined)
-    const after = await stat(observedPath).catch(() => undefined)
-    if (
-      !bytes ||
-      !after?.isFile() ||
-      after.size !== before.size ||
-      after.mtimeMs !== before.mtimeMs ||
-      sha256(bytes) !== artifactChecksum
-    ) {
-      return undefined
-    }
-
-    return { path: observedPath, sizeBytes: after.size, mtimeMs: after.mtimeMs }
-  }
-
-  private async findObservedWorkingFileRunIds(
-    document: NonNullable<Awaited<ReturnType<NotebookRunRepository['findExisting']>>>,
-    observation: NonNullable<CreateArtifactVersionRequest['sourceFileObservation']>,
-    expected: {
-      rootFrameId: string
-      agentFrameId: string
-      messageBranchId: string
-      runtimeSegmentId: string
-      promptMessageId: string
-    }
-  ): Promise<string[]> {
-    if (
-      !Number.isFinite(observation.sizeBytes) ||
-      observation.sizeBytes < 0 ||
-      !Number.isFinite(observation.mtimeMs) ||
-      observation.mtimeMs < 0
-    ) {
-      return []
-    }
-
-    const canonicalPath = async (path: string): Promise<string> =>
-      realpath(resolve(path)).catch(() => resolve(path))
-    const observedPath = await canonicalPath(observation.path)
-    const documentRoots = await Promise.all(
-      [document.notebookSessionRoot, document.workspaceCwd].map(canonicalPath)
-    )
-    const isInsideDocumentRoot = documentRoots.some((root) => {
-      const relativePath = relative(root, observedPath)
-      return (
-        relativePath !== '' &&
-        relativePath !== '..' &&
-        !relativePath.startsWith(`..${sep}`) &&
-        !isAbsolute(relativePath)
-      )
-    })
-    if (!isInsideDocumentRoot) return []
-
-    const candidates = document.runs.filter((run) =>
-      Object.entries(expected).every(
-        ([field, value]) => run[field as keyof typeof expected] === value
-      )
-    )
-    const workingFileMatches = (
-      await Promise.all(
-        candidates.map(async (run) => {
-          for (const file of run.workingFiles) {
-            if (
-              (await canonicalPath(file.path)) === observedPath &&
-              file.createdByRunId === run.runId &&
-              file.size === observation.sizeBytes &&
-              file.mtimeMs === observation.mtimeMs
-            ) {
-              return run.runId
-            }
-          }
-          return undefined
-        })
-      )
-    ).filter((runId): runId is string => runId !== undefined)
-
-    // mtime is diagnostic context, not a causal execution receipt. Only a WorkingFile observation
-    // attributed to one run may promote an omitted declaration to available producer evidence.
-    return [...new Set(workingFileMatches)]
-  }
-
-  private async validateInputReferences(
-    projectId: string,
-    inputs: NotebookRunInputFile[]
-  ): Promise<void> {
-    const client = await this.options.getClient()
-    for (const input of inputs) {
-      if (input.sourceProjectId !== projectId) {
-        throw new Error(`Notebook input belongs to another Project: ${input.inputFileVersionId}`)
-      }
-      if (input.sourceKind === 'upload-version') {
-        const version = await client.uploadVersion.findUnique({
-          where: { id: input.inputFileVersionId },
-          include: { uploadFile: true }
-        })
-        if (
-          !version ||
-          version.state !== 'ready' ||
-          version.uploadFileId !== input.sourceFileId ||
-          version.uploadFile.projectId !== input.sourceProjectId ||
-          version.uploadFile.sessionId !== input.sourceSessionId ||
-          version.versionNumber !== input.sourceVersionNumber ||
-          version.contentStorageKey !== input.storageKey ||
-          version.checksum !== input.checksum ||
-          Number(version.sizeBytes) !== input.sizeBytes
-        ) {
-          throw new Error(`Notebook Upload input identity is corrupt: ${input.inputFileVersionId}`)
-        }
-        continue
-      }
-
-      const version = await client.artifactVersion.findUnique({
-        where: { id: input.inputFileVersionId },
-        include: { artifact: true }
-      })
-      if (
-        !version ||
-        version.state !== 'finalized' ||
-        version.artifactId !== input.sourceFileId ||
-        version.artifact.projectId !== input.sourceProjectId ||
-        version.artifact.sessionId !== input.sourceSessionId ||
-        version.versionNumber !== input.sourceVersionNumber ||
-        version.contentStorageKey !== input.storageKey ||
-        version.checksum !== input.checksum ||
-        Number(version.sizeBytes) !== input.sizeBytes
-      ) {
-        throw new Error(`Notebook Artifact input identity is corrupt: ${input.inputFileVersionId}`)
-      }
-    }
   }
 
   private async projectExecutionInput(

--- a/src/main/artifacts/provenance-version-writer.ts
+++ b/src/main/artifacts/provenance-version-writer.ts
@@ -1,21 +1,18 @@
 import { copyFile, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
-import type { Prisma, PrismaClient } from '@prisma/client'
+import type { PrismaClient } from '@prisma/client'
 
 import type {
-  ArtifactProducerUnavailableReason,
   ArtifactVersionFile,
   CreateArtifactVersionRequest
 } from '../../shared/artifact-provenance'
-import type {
-  NotebookEnvironmentManifest,
-  NotebookRunEnvironmentCapture,
-  NotebookRunInputFile,
-  NotebookRunRecord
-} from '../../shared/notebook'
 import type { ArtifactDurability } from './durability'
 import { sha256 } from './provenance-canonical'
+import type {
+  ArtifactVersionProducerCapture,
+  PreparedArtifactVersionPersistence
+} from './provenance-producer-capture'
 import type { ArtifactRepository } from './repository'
 
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
@@ -103,39 +100,6 @@ type StagingArtifactVersionRecord = PersistedVersionFileRecord & {
   executionSnapshotStorageKey: string | null
   artifact: { id: string; filename: string }
 }
-type ArtifactVersionProducerCapture =
-  | {
-      state: 'unavailable'
-      reason: ArtifactProducerUnavailableReason
-    }
-  | {
-      state: 'available'
-      notebookSessionId: string
-      producerRunId: string
-      producerRunIndex: number
-      associationMethod: 'agent-declared-and-session-validated' | 'server-inferred-file-observation'
-      kernelKind: NotebookRunRecord['kernelKind']
-      environmentName?: string
-      reproductionCode: string
-      executionJson: string
-      executionChecksum: string
-      inputFiles: NotebookRunInputFile[]
-      environmentCapture: NotebookRunEnvironmentCapture
-      environmentManifest?: NotebookEnvironmentManifest
-      environmentManifestChecksum?: string
-    }
-
-type PreparedArtifactVersionPersistence = {
-  notebookSessionId?: string
-  producerRunId?: string
-  producerRunIndex?: number
-  evidenceJson: string
-  evidenceChecksum: string
-  executionSnapshotJson?: string
-  executionSnapshotChecksum?: string
-  inputs?: Prisma.ArtifactVersionUncheckedCreateInput['inputs']
-}
-
 type PublishCompatibilityRouting = (
   version: PersistedVersionFileRecord,
   options?: CompatibilityRoutingPublicationOptions
@@ -489,10 +453,8 @@ class ArtifactProvenanceVersionWriter {
 
 export { ArtifactProvenanceVersionWriter, normalizeArtifactFilename }
 export type {
-  ArtifactVersionProducerCapture,
   CompatibilityRoutingPublicationOptions,
   PersistedVersionFileRecord,
-  PreparedArtifactVersionPersistence,
   PublishCompatibilityRouting,
   StagingArtifactVersionRecord
 }

--- a/src/main/artifacts/provenance-write-contract.test.ts
+++ b/src/main/artifacts/provenance-write-contract.test.ts
@@ -4,6 +4,7 @@ import { mkdir, readFile, realpath, stat, writeFile } from 'node:fs/promises'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
+import type { NotebookRunInputFile } from '../../shared/notebook'
 import { createPngBytes } from './artifact-test-fixtures'
 import * as provenanceModule from './provenance-repository'
 import { ArtifactProvenanceRepository } from './provenance-repository'
@@ -180,7 +181,13 @@ describe('artifact provenance allocation and write identity', () => {
 
 const appendNotebookRun = async (
   value: Fixture,
-  input: { runId: string; filename: string; payload: string; ownsSource: boolean }
+  input: {
+    runId: string
+    filename: string
+    payload: string
+    ownsSource: boolean
+    inputFiles?: NotebookRunInputFile[]
+  }
 ): Promise<{ path: string; sizeBytes: number; mtimeMs: number }> => {
   const document = await value.notebookRepository.loadOrCreate({
     projectName: 'project-1',
@@ -206,7 +213,7 @@ const appendNotebookRun = async (
       text: { stdout: '', stderr: '', traceback: '', plain: [] },
       outputs: [],
       artifacts: [],
-      inputFiles: [],
+      inputFiles: input.inputFiles ?? [],
       workingFiles: input.ownsSource
         ? [
             {
@@ -356,5 +363,163 @@ describe('artifact provenance producer and source validation', () => {
     expect(JSON.parse(row.evidenceJson)).toMatchObject({
       producer: { state: 'unavailable', reason: 'producer-source-unverifiable' }
     })
+  })
+
+  it('requires a Notebook Session for an inline declared producer', async () => {
+    const value = await fixture()
+    await value.stagePng('inline producer bytes')
+
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'producer-without-session-operation',
+          producerRunId: 'producer-run',
+          sourceKind: 'inline'
+        })
+      )
+    ).rejects.toThrow('producerRunId requires notebookSessionId in the active Artifact run.')
+  })
+
+  it('rejects an observed source outside both durable Notebook roots', async () => {
+    const value = await fixture()
+    await appendNotebookRun(value, {
+      runId: 'outside-root-run',
+      filename: 'plot.png',
+      payload: 'outside root bytes',
+      ownsSource: true
+    })
+    const outsidePath = join(value.storageRoot, 'outside-notebook-roots', 'plot.png')
+    await mkdir(dirname(outsidePath), { recursive: true })
+    await writeFile(outsidePath, createPngBytes('outside root bytes'))
+    const outsideStat = await stat(outsidePath)
+    await value.stagePng('outside root bytes')
+
+    const version = await value.repository.createVersion(
+      createArtifactVersionRequest({
+        writeOperationId: 'outside-root-observation-operation',
+        notebookSessionId: 'session-1',
+        producerRunId: 'outside-root-run',
+        sourceKind: 'localPath',
+        sourceFileObservation: {
+          path: await realpath(outsidePath),
+          sizeBytes: outsideStat.size,
+          mtimeMs: outsideStat.mtimeMs
+        }
+      })
+    )
+    const row = await value.client.artifactVersion.findUniqueOrThrow({
+      where: { id: version.versionId }
+    })
+
+    expect(row).toMatchObject({ producerRunId: null, producerRunIndex: null })
+    expect(JSON.parse(row.evidenceJson)).toMatchObject({
+      producer: { state: 'unavailable', reason: 'producer-source-unverifiable' },
+      execution_status: { state: 'unavailable', reason: 'producer-source-unverifiable' }
+    })
+  })
+})
+
+describe('artifact provenance input authority', () => {
+  const baseUploadInput = {
+    inputFileVersionId: 'missing-upload-version',
+    sourceKind: 'upload-version',
+    sourceFileId: 'upload-file-1',
+    sourceVersionNumber: 1,
+    sourceProjectId: 'project-1',
+    sourceSessionId: 'source-session-1',
+    filename: 'input.csv',
+    contentType: 'text/csv',
+    sizeBytes: 4,
+    checksum: 'b'.repeat(64),
+    storageKey: 'uploads/project-1/source-session-1/upload-file-1/input.csv',
+    association: 'resolver-accessed'
+  } as const satisfies NotebookRunInputFile
+
+  it.each([
+    {
+      name: 'cross-project input',
+      input: { ...baseUploadInput, sourceProjectId: 'other-project' },
+      error: 'Notebook input belongs to another Project: missing-upload-version'
+    },
+    {
+      name: 'corrupt Upload identity',
+      input: baseUploadInput,
+      error: 'Notebook Upload input identity is corrupt: missing-upload-version'
+    }
+  ])('rejects a $name', async ({ input, error }) => {
+    const value = await fixture()
+    const observation = await appendNotebookRun(value, {
+      runId: 'input-authority-run',
+      filename: 'plot.png',
+      payload: 'input authority bytes',
+      ownsSource: true,
+      inputFiles: [input]
+    })
+    await value.stagePng('input authority bytes')
+
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: `invalid-${input.sourceProjectId}-input-operation`,
+          notebookSessionId: 'session-1',
+          producerRunId: 'input-authority-run',
+          sourceKind: 'localPath',
+          sourceFileObservation: observation
+        })
+      )
+    ).rejects.toThrow(error)
+    await expect(value.client.artifactVersion.count()).resolves.toBe(0)
+  })
+
+  it('rejects an Artifact input whose durable Version is not finalized', async () => {
+    const value = await fixture()
+    await value.stagePng('upstream bytes', 'upstream.png')
+    const upstream = await value.repository.createVersion(
+      createArtifactVersionRequest({
+        filename: 'upstream.png',
+        writeOperationId: 'pending-upstream-operation'
+      })
+    )
+    const upstreamRow = await value.client.artifactVersion.findUniqueOrThrow({
+      where: { id: upstream.versionId }
+    })
+    expect(upstreamRow.state).toBe('pending')
+    const observation = await appendNotebookRun(value, {
+      runId: 'pending-artifact-input-run',
+      filename: 'plot.png',
+      payload: 'derived bytes',
+      ownsSource: true,
+      inputFiles: [
+        {
+          inputFileVersionId: upstream.versionId,
+          sourceKind: 'artifact-version',
+          sourceFileId: upstream.artifactId,
+          sourceVersionNumber: upstream.versionNumber,
+          sourceCreatedAt: upstreamRow.createdAt.toISOString(),
+          sourceProjectId: 'project-1',
+          sourceSessionId: 'session-1',
+          filename: upstreamRow.filename,
+          contentType: upstreamRow.contentType ?? undefined,
+          sizeBytes: Number(upstreamRow.sizeBytes),
+          checksum: upstreamRow.checksum,
+          storageKey: upstreamRow.contentStorageKey,
+          association: 'resolver-accessed'
+        }
+      ]
+    })
+    await value.stagePng('derived bytes')
+
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'pending-artifact-input-operation',
+          notebookSessionId: 'session-1',
+          producerRunId: 'pending-artifact-input-run',
+          sourceKind: 'localPath',
+          sourceFileObservation: observation
+        })
+      )
+    ).rejects.toThrow(`Notebook Artifact input identity is corrupt: ${upstream.versionId}`)
+    await expect(value.client.artifactVersion.count()).resolves.toBe(1)
   })
 })


### PR DESCRIPTION
## Problem

PV2A isolates the pure execution/evidence codecs, but the Artifact Provenance facade still decides
Notebook producer attribution, declared versus inferred source ownership, run/graph authority and
input reference validity. These decisions form one stateful producer-capture owner and keep the
facade large.

## Proposed change

- Add one internal `ArtifactProvenanceProducerCapture` owner for Notebook run lookup,
  declared/inferred producer selection, source observation verification, graph/run scope validation,
  input authority and environment/execution capture.
- Let that owner use PV2A's pure codec to return captured producer evidence and the prepared
  persistence material needed by the PV1 writer.
- Compose the owner exactly once in the facade and route the writer's existing capture/preparation
  callbacks to it; keep every public repository method and caller unchanged.
- Register the owner only under the existing `artifact_provenance` owner paths.

## Scope and non-goals

- No Version allocation/write ownership change beyond replacing PV1's internal callbacks.
- Do not move durable Message finalization (PV3), staging/unindexed recovery (PV4) or read/cache
  projections (PV5).
- No public/shared/IPC/MCP/local-RPC/HTTP/CLI payload, Prisma/schema/data relationship, storage
  format, UI or user interaction change.
- Do not add Electron/Web/CLI/Task capabilities or change Specialist/Permission/Compute asymmetry.

## Compatibility

- Preserve exact declared producer validation, server inference, observed-owner conflict rejection,
  prompt ancestry, run prefix, input identity/authority and fail-closed unavailable/error reasons.
- Preserve capability-sanitized graph, Notebook Session and run fields supplied by local-RPC; never
  trust a renderer/agent body over the active turn capability.
- Preserve source mtime non-inference, corrupt/missing observation behavior, execution/environment
  bounds and canonical persistence bytes.
- Retain native `node:path` containment checks and `/` storage keys on Windows, macOS and Linux.

## Acceptance criteria and validation

- `provenance-producer-capture.ts` is 546 raw lines; final production diff is +562/-534, within the
  approved 600 target and 660 hard tolerance.
- `provenance-repository.ts` is reduced from 3,111 to 2,631 raw lines; the PV1 writer is reduced from
  498 to 460 raw lines.
- The owner is composed once and is the single producer/source/input authority. Worktree-local
  CodeGraph confirms the acyclic runtime path
  `repository -> producer-capture -> execution-evidence -> canonical`; the writer dependency is
  type-only.
- Producer/source/input and repository contracts: 2 files / 45 tests passed.
- `npm run test:module -- artifact_provenance`: 23 files / 1,009 tests passed, including TaskRunner,
  ACP, MCP, local-RPC, Electron/preload, renderer consumers and the Windows-sensitive overlay.
- MCP/Web/CLI/client/surface supplement: 5 files / 43 tests passed after allowing the local socket.
- Impact validator/selector/shadow: 3 files / 29 tests passed.
- Node typecheck, changed ESLint, Prettier and diff-check passed.
- New portable negative contracts pin missing Notebook Session, source observation outside both
  trusted roots, cross-Project/corrupt Upload input and non-finalized Artifact input behavior.
- All listed checks ran after the last material edit. Independent Standards, Spec and Architecture
  reviews each found 0 findings. Exact-head PR Gate, CI Integrity, CodeQL and AI must pass before
  squash merge.

## Review focus

- Confirm producer authority moved as one cohesive owner and PV1/PV3-PV5 boundaries remain intact.
- Confirm capture remains before the writer transaction while persistence preparation remains inside
  the Version allocation transaction.
- Confirm trusted capability fields, fail-closed source/input validation and error strings are
  unchanged.
- Confirm no schema/data/path/UI/cross-surface behavior or capability asymmetry changes.
