### PR TITLE
fix(artifacts): classify finalization proof failures

### DIFF
--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -249,6 +249,7 @@ describe('artifact IPC handlers', () => {
         .fn()
         .mockRejectedValue(
           new ArtifactFinalizationProofError(
+            'execution-snapshot-corrupt',
             'corrupt Artifact Version proof for /Users/private/result.txt: secret artifact contents'
           )
         )
@@ -283,11 +284,13 @@ describe('artifact IPC handlers', () => {
       expect.objectContaining({
         stage: 'durable-finalization',
         failureKind: 'invalid-proof',
+        proofFailureReason: 'execution-snapshot-corrupt',
         durableFinalizationCompleted: false,
         compatibilityPublicationCompleted: false,
         claimId,
         artifactRunId: 'run-1',
         artifactVersionIds: ['version-1'],
+        artifactVersionCount: 1,
         messageId: 'message-forged',
         messageBranchId: 'branch-1'
       })
@@ -301,6 +304,7 @@ describe('artifact IPC handlers', () => {
     const repository = {
       finalizeRunArtifacts: vi.fn()
     } as unknown as ArtifactRepository
+    const diagnosticLogger = { error: vi.fn() }
     const provenance = { finalizeRun: vi.fn() }
     const registry = new ArtifactRunRegistry()
     const claimId = registry.register({
@@ -315,7 +319,8 @@ describe('artifact IPC handlers', () => {
       runtimeSegmentId: 'runtime-1'
     })
     const handlers = createArtifactHandlers(repository, registry, {
-      provenance: provenance as never
+      provenance: provenance as never,
+      logger: diagnosticLogger
     })
 
     await expect(
@@ -323,6 +328,52 @@ describe('artifact IPC handlers', () => {
     ).rejects.toThrow(/complete provenance context/i)
     expect(provenance.finalizeRun).not.toHaveBeenCalled()
     expect(repository.finalizeRunArtifacts).not.toHaveBeenCalled()
+    expect(diagnosticLogger.error).toHaveBeenCalledWith(
+      'artifact finalization attempt failed',
+      expect.objectContaining({
+        failureKind: 'invalid-proof',
+        proofFailureReason: 'claim-context-missing',
+        artifactVersionCount: 1
+      })
+    )
+  })
+
+  it('reports an empty claimed Version set without invoking provenance', async () => {
+    const repository = {
+      finalizeRunArtifacts: vi.fn()
+    } as unknown as ArtifactRepository
+    const diagnosticLogger = { error: vi.fn() }
+    const provenance = { finalizeRun: vi.fn() }
+    const registry = new ArtifactRunRegistry()
+    const claimId = registry.register({
+      projectName: 'default-project',
+      artifactSessionId: 'artifact-session-1',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-1',
+      promptMessageId: 'prompt-1'
+    })
+    const handlers = createArtifactHandlers(repository, registry, {
+      provenance: provenance as never,
+      logger: diagnosticLogger
+    })
+
+    await expect(
+      handlers.finalizeRunArtifacts({ claimId, messageId: 'message-1' })
+    ).rejects.toMatchObject({ reasonCode: 'claim-version-ids-missing' })
+    expect(provenance.finalizeRun).not.toHaveBeenCalled()
+    expect(repository.finalizeRunArtifacts).not.toHaveBeenCalled()
+    expect(diagnosticLogger.error).toHaveBeenCalledWith(
+      'artifact finalization attempt failed',
+      expect.objectContaining({
+        failureKind: 'invalid-proof',
+        proofFailureReason: 'claim-version-ids-missing',
+        artifactVersionCount: 0
+      })
+    )
   })
 
   it('keeps pending bytes in place when normal IPC encounters a corrupt provenance proof', async () => {
@@ -425,7 +476,11 @@ describe('artifact IPC handlers', () => {
 
       await expect(
         handlers.finalizeRunArtifacts({ claimId, messageId: message.id })
-      ).rejects.toThrow(/execution snapshot is corrupt/i)
+      ).rejects.toMatchObject({
+        name: 'ArtifactFinalizationProofError',
+        reasonCode: 'execution-snapshot-corrupt',
+        message: expect.stringMatching(/execution snapshot is corrupt/i)
+      })
       await expect(
         compatibility.listPendingRunFiles({
           projectName: 'project-1',
@@ -498,10 +553,12 @@ describe('artifact IPC handlers', () => {
         claimId,
         artifactRunId: 'run-1',
         artifactVersionIds: ['version-1'],
+        artifactVersionCount: 1,
         messageId: 'message-1',
         messageBranchId: 'branch-1'
       })
     )
+    expect(diagnosticLogger.error.mock.calls[0]?.[1]).not.toHaveProperty('proofFailureReason')
     const diagnostic = JSON.stringify(diagnosticLogger.error.mock.calls[0])
     expect(diagnostic).not.toContain('secret artifact contents')
     expect(diagnostic).not.toContain('/Users/private')
@@ -1039,6 +1096,7 @@ describe('artifact IPC handler registration', () => {
 
   it('returns only the ownership persistence race as a stable IPC failure result', async () => {
     const repository = { finalizeRunArtifacts: vi.fn() } as unknown as ArtifactRepository
+    const diagnosticLogger = { error: vi.fn() }
     const provenance = {
       finalizeRun: vi
         .fn()
@@ -1061,7 +1119,18 @@ describe('artifact IPC handler registration', () => {
       promptMessageId: 'prompt-1',
       artifactVersionIds: ['version-1']
     })
-    registerArtifactIpcHandlers(repository, runRegistry, undefined, provenance as never)
+    const handlers = createArtifactHandlers(repository, runRegistry, {
+      provenance: provenance as never,
+      logger: diagnosticLogger
+    })
+    registerArtifactIpcHandlers(
+      repository,
+      runRegistry,
+      undefined,
+      provenance as never,
+      undefined,
+      handlers
+    )
 
     await expect(
       ipcHandlers.get('artifacts:finalize-run')?.({}, { claimId, messageId: 'message-1' })
@@ -1072,6 +1141,14 @@ describe('artifact IPC handler registration', () => {
     })
     expect(repository.finalizeRunArtifacts).not.toHaveBeenCalled()
     expect(runRegistry.resolve(claimId).finalizedMessageId).toBeUndefined()
+    expect(diagnosticLogger.error).toHaveBeenCalledWith(
+      'artifact finalization attempt failed',
+      expect.objectContaining({
+        failureKind: ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
+        proofFailureReason: 'message-not-durable',
+        artifactVersionCount: 1
+      })
+    )
   })
 
   it('resolves native Version preview locators through Provenance instead of filesystem paths', async () => {

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -280,11 +280,13 @@ const finalizeRunArtifacts = async (
         !claim.promptMessageId
       ) {
         throw new ArtifactFinalizationProofError(
+          'claim-context-missing',
           'Artifact run claim is missing complete provenance context.'
         )
       }
       if (!claim.artifactVersionIds || claim.artifactVersionIds.length === 0) {
         throw new ArtifactFinalizationProofError(
+          'claim-version-ids-missing',
           'Artifact run claim is missing exact Artifact Version ids.'
         )
       }
@@ -347,11 +349,15 @@ const finalizeRunArtifacts = async (
     logger.error('artifact finalization attempt failed', {
       stage,
       failureKind,
+      ...(error instanceof ArtifactFinalizationProofError
+        ? { proofFailureReason: error.reasonCode }
+        : {}),
       durableFinalizationCompleted,
       compatibilityPublicationCompleted,
       claimId: request.claimId,
       artifactRunId: claim.runId,
       messageId: request.messageId,
+      artifactVersionCount: claim.artifactVersionIds?.length ?? 0,
       ...(claim.artifactVersionIds ? { artifactVersionIds: [...claim.artifactVersionIds] } : {}),
       ...(claim.rootFrameId ? { rootFrameId: claim.rootFrameId } : {}),
       ...(claim.agentFrameId ? { agentFrameId: claim.agentFrameId } : {}),

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -2291,18 +2291,44 @@ describe('artifact provenance repository', () => {
       filename: 'sin.png'
     })
 
+    const ownershipRequest = {
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactRunId: 'artifact-run-1',
+      artifactVersionIds: [version.versionId],
+      ...context,
+      messageId: assistant.id
+    }
+    await expect(
+      repository.validateFinalizationOwnership({
+        ...ownershipRequest,
+        rootFrameId: 'root-frame-forged'
+      })
+    ).rejects.toMatchObject({ reasonCode: 'root-frame-mismatch' })
+    await expect(
+      repository.validateFinalizationOwnership({
+        ...ownershipRequest,
+        agentFrameId: 'agent-frame-forged'
+      })
+    ).rejects.toMatchObject({ reasonCode: 'branch-frame-mismatch' })
+    await expect(
+      repository.validateFinalizationOwnership({
+        ...ownershipRequest,
+        runtimeSegmentId: 'runtime-segment-forged'
+      })
+    ).rejects.toMatchObject({ reasonCode: 'runtime-segment-missing' })
+
     await expect(
       repository.finalizeRun({
-        projectId: 'project-1',
-        appSessionId: 'session-1',
-        artifactRunId: 'artifact-run-1',
-        artifactVersionIds: [version.versionId],
-        ...context,
+        ...ownershipRequest,
         messageId: 'message-forged',
         messageBranchAncestry: [branch.id],
         messageAncestry: [prompt.id, 'message-forged']
       })
-    ).rejects.toBeInstanceOf(ArtifactOwnershipPersistenceRaceError)
+    ).rejects.toMatchObject({
+      name: 'ArtifactOwnershipPersistenceRaceError',
+      reasonCode: 'message-not-durable'
+    })
 
     const durablePrompt = conversationGraph.messages.find((message) => message.id === prompt.id)!
     durablePrompt.status = 'streaming'
@@ -2315,7 +2341,10 @@ describe('artifact provenance repository', () => {
         ...context,
         messageId: assistant.id
       })
-    ).rejects.toMatchObject({ name: 'ArtifactFinalizationProofError' })
+    ).rejects.toMatchObject({
+      name: 'ArtifactFinalizationProofError',
+      reasonCode: 'prompt-ownership-mismatch'
+    })
 
     durablePrompt.status = 'complete'
     const durableAssistant = conversationGraph.messages.find(
@@ -2331,7 +2360,10 @@ describe('artifact provenance repository', () => {
         ...context,
         messageId: assistant.id
       })
-    ).rejects.toMatchObject({ name: 'ArtifactFinalizationProofError' })
+    ).rejects.toMatchObject({
+      name: 'ArtifactFinalizationProofError',
+      reasonCode: 'message-ownership-mismatch'
+    })
 
     durableAssistant.role = 'agent'
     durableAssistant.status = 'streaming'
@@ -2453,22 +2485,116 @@ describe('artifact provenance repository', () => {
     }
     await expect(
       repository.finalizeRun({ ...finalizeRequest, artifactVersionIds: [] })
-    ).rejects.toThrow(/Artifact Version ids/i)
+    ).rejects.toMatchObject({
+      reasonCode: 'version-ids-missing',
+      message: expect.stringMatching(/Artifact Version ids/i)
+    })
+    await expect(
+      repository.finalizeRun({
+        ...finalizeRequest,
+        artifactVersionIds: [
+          finalizeRequest.artifactVersionIds[0],
+          finalizeRequest.artifactVersionIds[0]
+        ]
+      })
+    ).rejects.toMatchObject({ reasonCode: 'version-ids-duplicate' })
     await expect(
       repository.finalizeRun({
         ...finalizeRequest,
         artifactVersionIds: [finalizeRequest.artifactVersionIds[0]]
       })
-    ).rejects.toThrow(/omitted from the finalization claim/i)
+    ).rejects.toMatchObject({
+      reasonCode: 'version-omitted-from-claim',
+      message: expect.stringMatching(/omitted from the finalization claim/i)
+    })
     await expect(
       repository.finalizeRun({
         ...finalizeRequest,
         artifactVersionIds: [...finalizeRequest.artifactVersionIds, 'version-not-in-run']
       })
-    ).rejects.toThrow(/no longer eligible/i)
+    ).rejects.toMatchObject({
+      reasonCode: 'version-not-eligible',
+      message: expect.stringMatching(/no longer eligible/i)
+    })
     const ancestryProbe = await client.artifactVersion.findFirstOrThrow({
       where: { artifactRunId: common.artifactRunId, versionNumber: 1 }
     })
+    await client.artifactVersion.update({
+      where: { id: ancestryProbe.id },
+      data: { state: 'finalized', messageId: 'message-other' }
+    })
+    await expect(repository.finalizeRun(finalizeRequest)).rejects.toMatchObject({
+      reasonCode: 'version-message-conflict'
+    })
+    await client.artifactVersion.update({
+      where: { id: ancestryProbe.id },
+      data: { state: ancestryProbe.state, messageId: ancestryProbe.messageId }
+    })
+
+    const invalidEvidence = '{}'
+    await client.artifactVersion.update({
+      where: { id: ancestryProbe.id },
+      data: {
+        evidenceJson: invalidEvidence,
+        evidenceChecksum: createHash('sha256').update(invalidEvidence).digest('hex')
+      }
+    })
+    await expect(repository.finalizeRun(finalizeRequest)).rejects.toMatchObject({
+      reasonCode: 'version-evidence-invalid'
+    })
+    await client.artifactVersion.update({
+      where: { id: ancestryProbe.id },
+      data: {
+        evidenceJson: ancestryProbe.evidenceJson,
+        evidenceChecksum: ancestryProbe.evidenceChecksum
+      }
+    })
+
+    await client.artifactVersion.update({
+      where: { id: ancestryProbe.id },
+      data: {
+        producerRunIndex: 0,
+        executionSnapshotJson: null,
+        executionSnapshotChecksum: null,
+        executionSnapshotStorageKey: null,
+        executionSnapshotSchemaVersion: null
+      }
+    })
+    await expect(repository.finalizeRun(finalizeRequest)).rejects.toMatchObject({
+      reasonCode: 'execution-snapshot-missing'
+    })
+    await client.artifactVersion.update({
+      where: { id: ancestryProbe.id },
+      data: {
+        producerRunIndex: ancestryProbe.producerRunIndex,
+        executionSnapshotJson: ancestryProbe.executionSnapshotJson,
+        executionSnapshotChecksum: ancestryProbe.executionSnapshotChecksum,
+        executionSnapshotStorageKey: ancestryProbe.executionSnapshotStorageKey,
+        executionSnapshotSchemaVersion: ancestryProbe.executionSnapshotSchemaVersion
+      }
+    })
+
+    const invalidExecution = '{}'
+    await client.artifactVersion.update({
+      where: { id: ancestryProbe.id },
+      data: {
+        executionSnapshotJson: invalidExecution,
+        executionSnapshotChecksum: createHash('sha256').update(invalidExecution).digest('hex'),
+        executionSnapshotSchemaVersion: 2
+      }
+    })
+    await expect(repository.finalizeRun(finalizeRequest)).rejects.toMatchObject({
+      reasonCode: 'execution-snapshot-invalid'
+    })
+    await client.artifactVersion.update({
+      where: { id: ancestryProbe.id },
+      data: {
+        executionSnapshotJson: ancestryProbe.executionSnapshotJson,
+        executionSnapshotChecksum: ancestryProbe.executionSnapshotChecksum,
+        executionSnapshotSchemaVersion: ancestryProbe.executionSnapshotSchemaVersion
+      }
+    })
+
     const forgedExecution = JSON.stringify({
       schemaVersion: 2,
       rootFrameId: common.rootFrameId,
@@ -2517,9 +2643,10 @@ describe('artifact provenance repository', () => {
         evidenceChecksum: createHash('sha256').update(forgedEvidence).digest('hex')
       }
     })
-    await expect(repository.finalizeRun(finalizeRequest)).rejects.toThrow(
-      /durable Branch ancestry/i
-    )
+    await expect(repository.finalizeRun(finalizeRequest)).rejects.toMatchObject({
+      reasonCode: 'execution-outside-ancestry',
+      message: expect.stringMatching(/durable Branch ancestry/i)
+    })
     await client.artifactVersion.update({
       where: { id: ancestryProbe.id },
       data: {

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -136,8 +136,32 @@ type ArtifactFinalizationContext = Pick<
 
 type PreparedArtifactFinalizationContext = Omit<ArtifactFinalizationContext, 'messageId'>
 
+export type ArtifactFinalizationProofReason =
+  | 'claim-context-missing'
+  | 'claim-version-ids-missing'
+  | 'root-frame-mismatch'
+  | 'branch-frame-mismatch'
+  | 'runtime-segment-missing'
+  | 'prompt-ownership-mismatch'
+  | 'message-not-durable'
+  | 'message-ownership-mismatch'
+  | 'version-ids-missing'
+  | 'version-ids-duplicate'
+  | 'version-not-eligible'
+  | 'version-omitted-from-claim'
+  | 'version-message-conflict'
+  | 'version-evidence-invalid'
+  | 'execution-snapshot-missing'
+  | 'execution-snapshot-corrupt'
+  | 'execution-outside-ancestry'
+  | 'execution-snapshot-invalid'
+
 export class ArtifactFinalizationProofError extends Error {
-  constructor(message: string, cause?: unknown) {
+  constructor(
+    readonly reasonCode: ArtifactFinalizationProofReason,
+    message: string,
+    cause?: unknown
+  ) {
     super(message, cause === undefined ? undefined : { cause })
     this.name = 'ArtifactFinalizationProofError'
   }
@@ -145,7 +169,7 @@ export class ArtifactFinalizationProofError extends Error {
 
 export class ArtifactOwnershipPersistenceRaceError extends ArtifactFinalizationProofError {
   constructor(message = 'Artifact finalization ownership is not durable yet.') {
-    super(message)
+    super('message-not-durable', message)
     this.name = 'ArtifactOwnershipPersistenceRaceError'
   }
 }
@@ -175,6 +199,7 @@ const validateDurableMessageOwnership = (
   const graph = materializeSessionConversationGraph(session).conversationGraph!
   if (graph.rootFrameId !== context.rootFrameId) {
     throw new ArtifactFinalizationProofError(
+      'root-frame-mismatch',
       'Artifact finalization root Frame does not match the durable Session graph.'
     )
   }
@@ -182,6 +207,7 @@ const validateDurableMessageOwnership = (
   const branch = graph.branches.find((candidate) => candidate.id === context.messageBranchId)
   if (!frame || !branch || branch.agentFrameId !== frame.id) {
     throw new ArtifactFinalizationProofError(
+      'branch-frame-mismatch',
       'Artifact finalization Branch does not belong to the declared Agent Frame.'
     )
   }
@@ -191,6 +217,7 @@ const validateDurableMessageOwnership = (
   )
   if (!segment) {
     throw new ArtifactFinalizationProofError(
+      'runtime-segment-missing',
       'Artifact finalization Runtime Segment is not durable.'
     )
   }
@@ -213,6 +240,7 @@ const validateDurableMessageOwnership = (
     promptMessage.runtimeSegmentId !== context.runtimeSegmentId
   ) {
     throw new ArtifactFinalizationProofError(
+      'prompt-ownership-mismatch',
       'Artifact finalization prompt does not match the declared durable ownership.'
     )
   }
@@ -229,6 +257,7 @@ const validateDurableMessageOwnership = (
     finalMessage.runtimeSegmentId !== context.runtimeSegmentId
   ) {
     throw new ArtifactFinalizationProofError(
+      'message-ownership-mismatch',
       'Artifact finalization message does not match the declared durable ownership.'
     )
   }
@@ -313,13 +342,19 @@ const normalizeArtifactFinalizationProofRequest = (
   request: ArtifactFinalizationProofRequest
 ): ArtifactFinalizationProofRequest => {
   if (!Array.isArray(request.artifactVersionIds) || request.artifactVersionIds.length === 0) {
-    throw new ArtifactFinalizationProofError('Artifact Version ids are required for finalization.')
+    throw new ArtifactFinalizationProofError(
+      'version-ids-missing',
+      'Artifact Version ids are required for finalization.'
+    )
   }
   const artifactVersionIds = request.artifactVersionIds.map((versionId) =>
     assertSafeSegment(versionId, 'artifact version id')
   )
   if (new Set(artifactVersionIds).size !== artifactVersionIds.length) {
-    throw new ArtifactFinalizationProofError('Artifact Version ids must be unique.')
+    throw new ArtifactFinalizationProofError(
+      'version-ids-duplicate',
+      'Artifact Version ids must be unique.'
+    )
   }
 
   return {
@@ -367,12 +402,14 @@ const validateArtifactFinalizationProof = (
   )
   if (missingExpectedVersionId) {
     throw new ArtifactFinalizationProofError(
+      'version-not-eligible',
       `Artifact Version is no longer eligible for finalization: ${missingExpectedVersionId}`
     )
   }
   const unexpectedMatchingVersion = matching.find((version) => !expectedIds.has(version.id))
   if (unexpectedMatchingVersion) {
     throw new ArtifactFinalizationProofError(
+      'version-omitted-from-claim',
       `Artifact Version was omitted from the finalization claim: ${unexpectedMatchingVersion.id}`
     )
   }
@@ -382,6 +419,7 @@ const validateArtifactFinalizationProof = (
   )
   if (conflicting) {
     throw new ArtifactFinalizationProofError(
+      'version-message-conflict',
       `Artifact Version ${conflicting.id} is already finalized to a different message.`
     )
   }
@@ -400,6 +438,7 @@ const validateArtifactFinalizationProof = (
           parsedEvidence.producer?.state !== 'unavailable')
       ) {
         throw new ArtifactFinalizationProofError(
+          'version-evidence-invalid',
           `Artifact Version evidence is invalid: ${version.id}`
         )
       }
@@ -422,6 +461,7 @@ const validateArtifactFinalizationProof = (
           evidence.reproduction_code === undefined
         if (hasProducerOrExecutionFields || !isProvenUnavailableWithoutExecution) {
           throw new ArtifactFinalizationProofError(
+            'execution-snapshot-missing',
             `Artifact Version execution snapshot is missing: ${version.id}`
           )
         }
@@ -433,6 +473,7 @@ const validateArtifactFinalizationProof = (
         sha256(version.executionSnapshotJson) !== version.executionSnapshotChecksum
       ) {
         throw new ArtifactFinalizationProofError(
+          'execution-snapshot-corrupt',
           `Artifact Version execution snapshot is corrupt: ${version.id}`
         )
       }
@@ -456,12 +497,14 @@ const validateArtifactFinalizationProof = (
       )
       if (outsideDurableAncestry) {
         throw new ArtifactFinalizationProofError(
+          'execution-outside-ancestry',
           `Artifact Version execution snapshot is outside the durable Branch ancestry: ${version.id}`
         )
       }
     } catch (error) {
       if (error instanceof ArtifactFinalizationProofError) throw error
       throw new ArtifactFinalizationProofError(
+        'execution-snapshot-invalid',
         error instanceof Error
           ? error.message
           : `Artifact Version execution snapshot is invalid: ${version.id}`,


### PR DESCRIPTION
## Problem

A normal agent turn can reach `end_turn` and still fail Artifact finalization with `failureKind=invalid-proof`. The existing diagnostic identifies the broad failure class but not the proof guard that rejected the claim, so issue #721 cannot be localized from production logs without reproducing the run.

## Proposed change

- Add a stable internal reason code to every Artifact finalization proof rejection.
- Log `proofFailureReason` and `artifactVersionCount` alongside the existing stage and safe ownership identifiers.
- Preserve error-message redaction so paths, Artifact contents, and other exception text are not copied into the diagnostic record.
- Cover all reason mappings and the invalid-proof, ownership-persistence-race, and operational-failure logging paths.

## Scope and non-goals

- No change to fail-closed proof validation or ownership-persistence-race retry behavior.
- No recovery or retry policy for invalid proofs in this phase.
- No Prisma/schema fields, persisted data-model relationships, renderer/shared IPC contracts, architecture, or UI interaction changes.

## Acceptance criteria and validation

Checks ran after the last material edit:

- Proof reason mapping and finalization logging -> `npm test -- src/main/artifacts/ipc.test.ts src/main/artifacts/provenance-repository.test.ts src/main/artifacts/provenance-lifecycle-contract.test.ts src/main/artifacts/provenance-write-contract.test.ts` -> 4 files and 76 tests passed.
- Main-process type safety -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> 0 errors; 17 warnings were reported only in files outside this diff.
- Independent Standards and Phase 1 Spec reviews -> passed with no remaining findings.

The complete portable test suite was not run because the final diff remains within the main-process Artifact owner and its direct contracts. Required CI remains the final authority.

## Review focus

- Whether each reason code describes a stable proof boundary rather than transient error prose.
- Whether structured logs remain content-safe.
- Whether invalid proofs remain fail-closed and only ownership persistence races remain renderer-retryable.

Relates to #721.
