### PR TITLE
ci(pr-gate): parallelize full coverage checks

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -289,17 +289,48 @@ jobs:
         id: lint
         if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'lint') }}
         continue-on-error: true
-        run: npm run lint
-      - name: Typecheck node
-        id: typecheck_node
-        if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'typecheck_node') }}
+        run: npm run lint -- --concurrency auto
+      - name: Typecheck node and web
+        id: typechecks
+        if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'typecheck_node') || contains(fromJSON(needs.preflight.outputs.plan).lanes, 'typecheck_web') }}
         continue-on-error: true
-        run: npm run typecheck:node
-      - name: Typecheck web
-        id: typecheck_web
-        if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'typecheck_web') }}
-        continue-on-error: true
-        run: npm run typecheck:web
+        shell: bash
+        env:
+          RUN_TYPECHECK_NODE: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'typecheck_node') }}
+          RUN_TYPECHECK_WEB: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'typecheck_web') }}
+        run: |
+          set -uo pipefail
+          failed=0
+          node_outcome=skipped
+          web_outcome=skipped
+          node_log="$RUNNER_TEMP/typecheck-node.log"
+          web_log="$RUNNER_TEMP/typecheck-web.log"
+
+          if [[ "$RUN_TYPECHECK_NODE" == "true" ]]; then
+            npm run typecheck:node >"$node_log" 2>&1 &
+            node_pid=$!
+          fi
+          if [[ "$RUN_TYPECHECK_WEB" == "true" ]]; then
+            npm run typecheck:web >"$web_log" 2>&1 &
+            web_pid=$!
+          fi
+
+          if [[ "$RUN_TYPECHECK_NODE" == "true" ]]; then
+            if wait "$node_pid"; then node_outcome=success; else node_outcome=failure; failed=1; fi
+            echo "::group::Typecheck node"
+            cat "$node_log"
+            echo "::endgroup::"
+          fi
+          if [[ "$RUN_TYPECHECK_WEB" == "true" ]]; then
+            if wait "$web_pid"; then web_outcome=success; else web_outcome=failure; failed=1; fi
+            echo "::group::Typecheck web"
+            cat "$web_log"
+            echo "::endgroup::"
+          fi
+
+          echo "node=$node_outcome" >> "$GITHUB_OUTPUT"
+          echo "web=$web_outcome" >> "$GITHUB_OUTPUT"
+          exit "$failed"
       - name: Check interface contract baseline (shadow)
         id: interface_contracts
         if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'interface_contracts') }}
@@ -330,8 +361,9 @@ jobs:
           FORMAT_OUTCOME: ${{ steps.format.outcome }}
           INTERFACE_CONTRACTS_OUTCOME: ${{ steps.interface_contracts.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
-          TYPECHECK_NODE_OUTCOME: ${{ steps.typecheck_node.outcome }}
-          TYPECHECK_WEB_OUTCOME: ${{ steps.typecheck_web.outcome }}
+          TYPECHECK_NODE_OUTCOME: ${{ steps.typechecks.outputs.node }}
+          TYPECHECKS_OUTCOME: ${{ steps.typechecks.outcome }}
+          TYPECHECK_WEB_OUTCOME: ${{ steps.typechecks.outputs.web }}
         run: |
           set -euo pipefail
           failed=0
@@ -346,14 +378,65 @@ jobs:
           check lint "$LINT_OUTCOME"
           check typecheck_node "$TYPECHECK_NODE_OUTCOME"
           check typecheck_web "$TYPECHECK_WEB_OUTCOME"
+          check typechecks "$TYPECHECKS_OUTCOME"
           check interface_contracts "$INTERFACE_CONTRACTS_OUTCOME"
           check cli_sdk "$CLI_SDK_OUTCOME"
           exit "$failed"
 
+  unit_shard:
+    name: Full Module tests (macOS, shard ${{ matrix.shard }}/2)
+    needs: preflight
+    if: ${{ needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit') && (fromJSON(needs.preflight.outputs.plan).mode == 'full' || !contains(fromJSON(needs.preflight.outputs.plan).lanes, 'unit_macos')) }}
+    runs-on: macos-14
+    env:
+      VITEST_DEFER_COVERAGE_THRESHOLDS: '1'
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Test complete suite shard
+        id: unit_macos_shard
+        continue-on-error: true
+        run: npx vitest run --coverage --coverage.reporter=text-summary --shard=${{ matrix.shard }}/2 --reporter=blob --outputFile=vitest-reports/blob-${{ matrix.shard }}.json
+      - name: Upload full-suite blob report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: unit-macos-blob-${{ matrix.shard }}
+          path: vitest-reports/
+          retention-days: 1
+          if-no-files-found: error
+      - name: Enforce full-suite shard
+        if: ${{ always() }}
+        shell: bash
+        env:
+          UNIT_MACOS_SHARD_OUTCOME: ${{ steps.unit_macos_shard.outcome }}
+        run: |
+          set -euo pipefail
+          failed=0
+          if [[ "$UNIT_MACOS_SHARD_OUTCOME" != "success" ]]; then
+            echo "unit_macos_shard ended with $UNIT_MACOS_SHARD_OUTCOME" >&2
+            failed=1
+          fi
+          exit "$failed"
+
   unit:
     name: Module tests (macOS)
-    needs: preflight
-    if: ${{ needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit') }}
+    needs: [preflight, unit_shard]
+    if: ${{ always() && needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit') }}
     runs-on: macos-14
     timeout-minutes: 15
     steps:
@@ -378,13 +461,20 @@ jobs:
         # Vitest coverage.changed inherits --changed, so this enforces thresholds only for the
         # affected source boundary while using the same test execution.
         run: npx vitest run --coverage --changed "$BASE_SHA"
-      - name: Test complete suite fallback
+      - name: Download full-suite blob reports
+        if: ${{ needs.unit_shard.result != 'skipped' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: unit-macos-blob-*
+          path: vitest-reports
+          merge-multiple: true
+      - name: Merge full-suite reports and coverage
         id: unit_macos_full
-        # A trusted pre-migration selective plan can select the unit bundle through legacy
-        # unit_linux/unit_renderer lanes. Route that migration case through one full coverage run.
-        if: ${{ fromJSON(needs.preflight.outputs.plan).mode == 'full' || (contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit') && !contains(fromJSON(needs.preflight.outputs.plan).lanes, 'unit_macos')) }}
+        # The shard job covers both full plans and trusted pre-migration selective plans that select
+        # the unit bundle without unit_macos. Merge once so thresholds see the complete suite.
+        if: ${{ needs.unit_shard.result != 'skipped' }}
         continue-on-error: true
-        run: npm run test:coverage
+        run: npx vitest run --merge-reports=vitest-reports --coverage
       - name: Upload Module coverage report
         if: ${{ always() && (steps.unit_macos_related.outcome != 'skipped' || steps.unit_macos_full.outcome != 'skipped') }}
         continue-on-error: true
@@ -400,6 +490,7 @@ jobs:
         env:
           UNIT_MACOS_FULL_OUTCOME: ${{ steps.unit_macos_full.outcome }}
           UNIT_MACOS_RELATED_OUTCOME: ${{ steps.unit_macos_related.outcome }}
+          UNIT_MACOS_SHARDS_RESULT: ${{ needs.unit_shard.result }}
         run: |
           set -euo pipefail
           failed=0
@@ -411,6 +502,7 @@ jobs:
           }
           check unit_macos_related "$UNIT_MACOS_RELATED_OUTCOME"
           check unit_macos_full "$UNIT_MACOS_FULL_OUTCOME"
+          check unit_macos_shards "$UNIT_MACOS_SHARDS_RESULT"
           if [[ "$UNIT_MACOS_RELATED_OUTCOME" == "skipped" && "$UNIT_MACOS_FULL_OUTCOME" == "skipped" ]]; then
             echo "Selected unit bundle did not execute a Module-test path" >&2
             failed=1

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -22,6 +22,10 @@ type Job = {
   needs?: string | string[]
   outputs?: Record<string, string>
   'runs-on'?: string
+  strategy?: {
+    'fail-fast'?: boolean
+    matrix?: { shard?: number[] }
+  }
   steps?: Step[]
   'timeout-minutes'?: number
 }
@@ -105,7 +109,11 @@ describe('PR Gate workflow', () => {
 
     for (const bundle of manifest.bundleOrder) {
       expect(workflow.jobs[bundle], `missing job for ${bundle}`).toBeDefined()
-      expect(workflow.jobs[bundle].needs).toBe('preflight')
+      expect(
+        Array.isArray(workflow.jobs[bundle].needs)
+          ? workflow.jobs[bundle].needs
+          : [workflow.jobs[bundle].needs]
+      ).toContain('preflight')
       expect(workflow.jobs[bundle].if).toContain("needs.preflight.result == 'success'")
       expect(workflow.jobs[bundle].if).toContain(`'${bundle}'`)
     }
@@ -226,12 +234,50 @@ describe('PR Gate workflow', () => {
     }
   })
 
-  it('runs one dependency-aware macOS Module-test job without duplicate full suites', () => {
+  it('uses runner-local concurrency while preserving separate static outcomes', () => {
+    const lint = workflow.jobs.static.steps?.find(({ name }) => name === 'Lint')
+    const typechecks = workflow.jobs.static.steps?.find(
+      ({ name }) => name === 'Typecheck node and web'
+    )
+    const enforce = workflow.jobs.static.steps?.find(
+      ({ name }) => name === 'Enforce selected static checks'
+    )
+
+    expect(lint?.run).toBe('npm run lint -- --concurrency auto')
+    expect(typechecks).toMatchObject({
+      id: 'typechecks',
+      'continue-on-error': true,
+      env: {
+        RUN_TYPECHECK_NODE:
+          "${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'typecheck_node') }}",
+        RUN_TYPECHECK_WEB:
+          "${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'typecheck_web') }}"
+      }
+    })
+    expect(typechecks?.if).toContain("'typecheck_node'")
+    expect(typechecks?.if).toContain("'typecheck_web'")
+    expect(typechecks?.run).toContain('npm run typecheck:node >"$node_log" 2>&1 &')
+    expect(typechecks?.run).toContain('npm run typecheck:web >"$web_log" 2>&1 &')
+    expect(typechecks?.run).toContain('echo "node=$node_outcome" >> "$GITHUB_OUTPUT"')
+    expect(typechecks?.run).toContain('echo "web=$web_outcome" >> "$GITHUB_OUTPUT"')
+    expect(enforce?.env).toMatchObject({
+      TYPECHECK_NODE_OUTCOME: '${{ steps.typechecks.outputs.node }}',
+      TYPECHECK_WEB_OUTCOME: '${{ steps.typechecks.outputs.web }}',
+      TYPECHECKS_OUTCOME: '${{ steps.typechecks.outcome }}'
+    })
+    expect(enforce?.run).toContain('check typechecks "$TYPECHECKS_OUTCOME"')
+  })
+
+  it('shards only full macOS Module tests and merges coverage into the stable unit bundle', () => {
     const unit = workflow.jobs.unit
+    const shards = workflow.jobs.unit_shard
     const checkout = unit.steps?.find(({ name }) => name === 'Checkout')
     const related = unit.steps?.find(({ name }) => name === 'Test affected Modules')
-    const fallback = unit.steps?.find(({ name }) => name === 'Test complete suite fallback')
+    const download = unit.steps?.find(({ name }) => name === 'Download full-suite blob reports')
+    const merge = unit.steps?.find(({ name }) => name === 'Merge full-suite reports and coverage')
     const coverageUpload = unit.steps?.find(({ name }) => name === 'Upload Module coverage report')
+    const shardRun = shards.steps?.find(({ name }) => name === 'Test complete suite shard')
+    const shardUpload = shards.steps?.find(({ name }) => name === 'Upload full-suite blob report')
 
     const legacyCoverage = workflow.jobs.coverage_macos
     const coverageOnly = legacyCoverage.steps?.find(
@@ -258,7 +304,37 @@ describe('PR Gate workflow', () => {
     expect(legacyCoverage.steps?.filter(({ run }) => run === 'npm ci')).toHaveLength(1)
     expect(unit).toMatchObject({
       name: 'Module tests (macOS)',
+      needs: ['preflight', 'unit_shard'],
       'runs-on': 'macos-14'
+    })
+    expect(unit.if).toContain('always()')
+    expect(unit.env?.VITEST_DEFER_COVERAGE_THRESHOLDS).toBeUndefined()
+    expect(shards).toMatchObject({
+      env: { VITEST_DEFER_COVERAGE_THRESHOLDS: '1' },
+      name: 'Full Module tests (macOS, shard ${{ matrix.shard }}/2)',
+      needs: 'preflight',
+      'runs-on': 'macos-14',
+      strategy: {
+        'fail-fast': false,
+        matrix: { shard: [1, 2] }
+      }
+    })
+    expect(shards.if).toContain("fromJSON(needs.preflight.outputs.plan).mode == 'full'")
+    expect(shards.if).toContain(
+      "!contains(fromJSON(needs.preflight.outputs.plan).lanes, 'unit_macos')"
+    )
+    expect(shardRun).toMatchObject({
+      'continue-on-error': true,
+      run: 'npx vitest run --coverage --coverage.reporter=text-summary --shard=${{ matrix.shard }}/2 --reporter=blob --outputFile=vitest-reports/blob-${{ matrix.shard }}.json'
+    })
+    expect(shardUpload).toMatchObject({
+      if: '${{ always() }}',
+      with: {
+        name: 'unit-macos-blob-${{ matrix.shard }}',
+        path: 'vitest-reports/',
+        'retention-days': 1,
+        'if-no-files-found': 'error'
+      }
     })
     expect(checkout?.with).toMatchObject({ 'fetch-depth': 0 })
     expect(related).toMatchObject({
@@ -268,20 +344,22 @@ describe('PR Gate workflow', () => {
       run: 'npx vitest run --coverage --changed "$BASE_SHA"'
     })
     expect(related?.if).toContain("fromJSON(needs.preflight.outputs.plan).mode == 'selective'")
-    expect(fallback).toMatchObject({
+    expect(download).toMatchObject({
+      if: "${{ needs.unit_shard.result != 'skipped' }}",
+      with: {
+        pattern: 'unit-macos-blob-*',
+        path: 'vitest-reports',
+        'merge-multiple': true
+      }
+    })
+    expect(merge).toMatchObject({
       id: 'unit_macos_full',
       'continue-on-error': true,
-      run: 'npm run test:coverage'
+      if: "${{ needs.unit_shard.result != 'skipped' }}",
+      run: 'npx vitest run --merge-reports=vitest-reports --coverage'
     })
-    expect(fallback?.if).toContain("fromJSON(needs.preflight.outputs.plan).mode == 'full'")
-    expect(fallback?.if).toContain(
-      "contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit')"
-    )
-    expect(fallback?.if).toContain(
-      "!contains(fromJSON(needs.preflight.outputs.plan).lanes, 'unit_macos')"
-    )
     expect(unit.steps?.some(({ name }) => name === 'Test Renderer (blocking)')).toBe(false)
-    expect(unit.steps?.filter(({ run }) => run === 'npm run test:coverage')).toHaveLength(1)
+    expect(unit.steps?.filter(({ run }) => run === 'npm run test:coverage')).toHaveLength(0)
     expect(coverageUpload).toMatchObject({
       if: "${{ always() && (steps.unit_macos_related.outcome != 'skipped' || steps.unit_macos_full.outcome != 'skipped') }}",
       'continue-on-error': true,
@@ -295,7 +373,14 @@ describe('PR Gate workflow', () => {
   })
 
   it('shares dependency installation and Electron builds inside platform bundles', () => {
-    for (const bundle of ['static', 'unit', 'windows_core', 'macos_e2e', 'windows_e2e']) {
+    for (const bundle of [
+      'static',
+      'unit',
+      'unit_shard',
+      'windows_core',
+      'macos_e2e',
+      'windows_e2e'
+    ]) {
       expect(
         workflow.jobs[bundle].steps?.filter(({ run }) => run === 'npm ci'),
         `${bundle} must install dependencies exactly once`
@@ -348,7 +433,14 @@ describe('PR Gate workflow', () => {
   })
 
   it('collects independent bundle failures before failing the shared runner', () => {
-    for (const bundle of ['static', 'unit', 'windows_core', 'macos_e2e', 'windows_e2e']) {
+    for (const bundle of [
+      'static',
+      'unit',
+      'unit_shard',
+      'windows_core',
+      'macos_e2e',
+      'windows_e2e'
+    ]) {
       const enforce = workflow.jobs[bundle].steps?.find(({ name }) => name?.startsWith('Enforce'))
       expect(enforce, `${bundle} must enforce collected step outcomes`).toMatchObject({
         if: '${{ always() }}'
@@ -368,7 +460,7 @@ describe('PR Gate workflow', () => {
 
     const related = workflow.jobs.unit.steps?.find(({ name }) => name === 'Test affected Modules')
     const full = workflow.jobs.unit.steps?.find(
-      ({ name }) => name === 'Test complete suite fallback'
+      ({ name }) => name === 'Merge full-suite reports and coverage'
     )
     const enforceUnit = workflow.jobs.unit.steps?.find(
       ({ name }) => name === 'Enforce selected unit checks'
@@ -377,10 +469,12 @@ describe('PR Gate workflow', () => {
     expect(full?.['continue-on-error']).toBe(true)
     expect(enforceUnit?.env).toEqual({
       UNIT_MACOS_FULL_OUTCOME: '${{ steps.unit_macos_full.outcome }}',
-      UNIT_MACOS_RELATED_OUTCOME: '${{ steps.unit_macos_related.outcome }}'
+      UNIT_MACOS_RELATED_OUTCOME: '${{ steps.unit_macos_related.outcome }}',
+      UNIT_MACOS_SHARDS_RESULT: '${{ needs.unit_shard.result }}'
     })
     expect(enforceUnit?.run).toContain('check unit_macos_related "$UNIT_MACOS_RELATED_OUTCOME"')
     expect(enforceUnit?.run).toContain('check unit_macos_full "$UNIT_MACOS_FULL_OUTCOME"')
+    expect(enforceUnit?.run).toContain('check unit_macos_shards "$UNIT_MACOS_SHARDS_RESULT"')
     expect(enforceUnit?.run).toContain(
       '[[ "$UNIT_MACOS_RELATED_OUTCOME" == "skipped" && "$UNIT_MACOS_FULL_OUTCOME" == "skipped" ]]'
     )
@@ -389,11 +483,11 @@ describe('PR Gate workflow', () => {
 
   it('preserves the complete portable suite and hard Windows contracts', () => {
     const portable = workflow.jobs.unit.steps?.find(
-      ({ name }) => name === 'Test complete suite fallback'
+      ({ name }) => name === 'Merge full-suite reports and coverage'
     )
     expect(portable).toMatchObject({
       'continue-on-error': true,
-      run: 'npm run test:coverage'
+      run: 'npx vitest run --merge-reports=vitest-reports --coverage'
     })
 
     expect(workflow.jobs.windows_core).toMatchObject({

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { VITEST_EXCLUDE_PATTERNS } from './vitest.config'
+import { coverageThresholdsEnabled, VITEST_EXCLUDE_PATTERNS } from './vitest.config'
 
 describe('Vitest discovery boundaries', () => {
   it.each(['**/.pnpm-store/**', '**/tmp/**', '**/.worktrees/**', '**/.worktree/**'])(
@@ -9,4 +9,10 @@ describe('Vitest discovery boundaries', () => {
       expect(VITEST_EXCLUDE_PATTERNS).toContain(pattern)
     }
   )
+})
+
+it('defers coverage thresholds only for explicit shard collection', () => {
+  expect(coverageThresholdsEnabled({})).toBe(true)
+  expect(coverageThresholdsEnabled({ VITEST_DEFER_COVERAGE_THRESHOLDS: '1' })).toBe(false)
+  expect(coverageThresholdsEnabled({ VITEST_DEFER_COVERAGE_THRESHOLDS: '0' })).toBe(true)
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,11 @@ const VITEST_EXCLUDE_PATTERNS = [
   '**/.worktrees/**',
   '**/.worktree/**'
 ]
+// Full-suite shards collect partial coverage maps. Only the merged report may enforce thresholds.
+
+function coverageThresholdsEnabled(env: NodeJS.ProcessEnv): boolean {
+  return env.VITEST_DEFER_COVERAGE_THRESHOLDS !== '1'
+}
 
 // Mirrors the renderer alias from electron.vite.config.ts so tests that mount real component
 // trees (instead of mocking every aliased import) can resolve '@/...' without a build step.
@@ -72,28 +77,30 @@ export default defineConfig({
       // Baseline thresholds: fail CI when global coverage drops below these. Set ~5pts under the
       // current measured baseline (lines 71 / statements 70 / functions 68 / branches 62) so the gate
       // catches regressions while absorbing minor cross-environment variance. Raise over time.
-      thresholds: {
-        lines: 66,
-        functions: 62,
-        branches: 57,
-        statements: 64,
-        // Keep the now-covered update wiring from being masked by the global aggregate.
-        'src/main/update/**': {
-          lines: 85,
-          functions: 75,
-          branches: 70,
-          statements: 80
-        },
-        // CSV is a user-facing renderer with bounded-data and fallback behavior worth protecting.
-        'src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx': {
-          lines: 95,
-          functions: 95,
-          branches: 80,
-          statements: 95
-        }
-      }
+      thresholds: coverageThresholdsEnabled(process.env)
+        ? {
+            lines: 66,
+            functions: 62,
+            branches: 57,
+            statements: 64,
+            // Keep the now-covered update wiring from being masked by the global aggregate.
+            'src/main/update/**': {
+              lines: 85,
+              functions: 75,
+              branches: 70,
+              statements: 80
+            },
+            // CSV is a user-facing renderer with bounded-data and fallback behavior worth protecting.
+            'src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx': {
+              lines: 95,
+              functions: 95,
+              branches: 80,
+              statements: 95
+            }
+          }
+        : undefined
     }
   }
 })
 
-export { VITEST_EXCLUDE_PATTERNS }
+export { coverageThresholdsEnabled, VITEST_EXCLUDE_PATTERNS }


### PR DESCRIPTION
## Problem

Full pull-request plans spend most of their critical path in one macOS coverage job, while static checks leave runner-local CPU capacity unused. Representative full coverage runs took about 5.5–6 minutes, with a slower sample at 7m44s.

## Proposed change

- Run ESLint with its built-in automatic concurrency.
- Run the node and web TypeScript checks concurrently while preserving separate outcomes and fail-closed aggregation.
- Split only full/legacy-fallback macOS Module tests into two isolated Vitest shards.
- Upload deterministic blob reports and merge them in the stable `unit` bundle before producing coverage artifacts.
- Defer coverage thresholds only during partial shard collection; enforce the unchanged global and path-specific thresholds on the merged report.

## Scope and non-goals

- Selective affected-Module coverage remains a single macOS job.
- Required check names and trusted-base gate evaluation remain unchanged.
- macOS stays on `macos-14`; this PR does not change runner images.
- Playwright remains at one worker, and Windows/E2E topology is unchanged.
- Build/Nightly overlap and Windows Full Test shard scaling remain follow-up work.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Static concurrency contract -> `npm test -- scripts/ci/pr-gate-workflow.test.ts vitest.config.test.ts scripts/ci/check-ci-integrity.test.ts scripts/ci/ci-integrity-workflow.test.ts` -> 64 passed.
- TypeScript consumers -> `npm run typecheck` -> passed.
- Existing lint behavior -> `npm run lint` -> passed with 17 pre-existing warnings and no errors.
- New ESLint invocation -> `npm run lint -- --concurrency auto` -> passed with the same warnings.
- Formatting/YAML parsing/diff hygiene -> Prettier, workflow contract parsing, and `git diff --check` -> passed.
- Full macOS shard/merge path -> [manual PR Gate dry-run](https://github.com/aipoch/open-science/actions/runs/31188598344) -> passed, including both shard uploads, merged coverage thresholds, and stable `PR Gate`.

Dry-run timings:

- shard 1 test execution: 2m33s; job: 3m48s
- shard 2 test execution: 2m54s; job: 4m14s
- merge/coverage job: 1m03s
- static job: 3m05s; ESLint: 1m18s; concurrent typechecks: 36s
- complete PR Gate: about 6m15s, with Windows E2E as the final critical path

The local Windows full `npm test` fallback completed 12,230 tests successfully and reported 33 failures. Failure analysis:

- 14 AI-review shell tests consistently require `bash`, which is unavailable in this PowerShell environment.
- 9 filesystem tests consistently fail because Windows symlink creation is denied with `EPERM`.
- 10 timeout/timing failures all passed when rerun in isolation, identifying whole-suite resource contention rather than deterministic regressions.
- The authoritative macOS full-suite/coverage dry-run passed with the same final commit.

## Review focus

- Verify that only full or legacy-fallback plans start the two shard jobs.
- Verify that `VITEST_DEFER_COVERAGE_THRESHOLDS` is present only on shard collection and absent from the merge job.
- Verify that shard, merge, and static failures remain visible through the stable fail-closed bundle outcomes.
- CI Integrity intentionally protects this control-plane workflow; this PR may require the documented maintainer ruleset approval/bypass.