### PR TITLE
refactor(artifact-provenance): extract persisted execution proof

### DIFF
--- a/src/main/artifacts/provenance-execution-evidence.ts
+++ b/src/main/artifacts/provenance-execution-evidence.ts
@@ -1,5 +1,6 @@
 import type {
   ArtifactVersionEnvironmentEvidence,
+  ArtifactVersionEvidence,
   ArtifactVersionInputEvidence,
   PersistedArtifactExecutionSnapshot,
   ProvenanceNotebookOutput,
@@ -37,6 +38,12 @@ const recordValue = (value: unknown): Record<string, unknown> | undefined =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined
+
+const stringValue = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined
+
+const numberValue = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined
 
 const tableCell = (value: unknown): CanonicalJson => {
   if (
@@ -433,9 +440,157 @@ const resolveRunEnvironmentCapture = (
   }
 }
 
+const normalizeStoredProvenanceOutput = (value: unknown): ProvenanceNotebookOutput[] => {
+  const output = recordValue(value)
+  if (output?.type === 'text' && typeof output.text === 'string') {
+    return [
+      {
+        type: 'text',
+        text: output.text,
+        ...(output.truncated === true ? { truncated: true } : {})
+      }
+    ]
+  }
+  if (output?.type === 'error') {
+    const name = stringValue(output.name)
+    const message = stringValue(output.message) ?? name ?? 'Notebook execution failed.'
+    const traceback = Array.isArray(output.traceback)
+      ? output.traceback.filter((line): line is string => typeof line === 'string')
+      : typeof output.traceback === 'string' && output.traceback
+        ? output.traceback.split('\n')
+        : undefined
+    return [
+      { type: 'error', ...(name ? { name } : {}), message, ...(traceback ? { traceback } : {}) }
+    ]
+  }
+  if (output?.type === 'table') {
+    const columns = Array.isArray(output.columns)
+      ? output.columns.filter((column): column is string => typeof column === 'string')
+      : []
+    const previewRows = Array.isArray(output.previewRows)
+      ? output.previewRows.filter((row): row is unknown[] => Array.isArray(row))
+      : []
+    const rowCount = numberValue(output.rowCount)
+    return columns.length > 0 && rowCount !== undefined
+      ? [{ type: 'table', columns, rowCount, previewRows }]
+      : []
+  }
+  if (output?.type === 'omitted-media') {
+    const mimeTypes =
+      typeof output.mimeType === 'string'
+        ? [output.mimeType]
+        : Array.isArray(output.mime_types)
+          ? output.mime_types.filter((mimeType): mimeType is string => typeof mimeType === 'string')
+          : []
+    return mimeTypes.map((mimeType) => ({
+      type: 'omitted-media',
+      mimeType,
+      ...(typeof output.byteLength === 'number' ? { byteLength: output.byteLength } : {})
+    }))
+  }
+  return []
+}
+
+const parseArtifactExecutionSnapshot = (value: string): PersistedArtifactExecutionSnapshot => {
+  const parsed = JSON.parse(value) as unknown
+  const snapshot = recordValue(parsed)
+  const truncation = recordValue(snapshot?.truncation)
+  if (
+    snapshot?.schemaVersion !== 2 ||
+    typeof snapshot.rootFrameId !== 'string' ||
+    typeof snapshot.agentFrameId !== 'string' ||
+    typeof snapshot.messageBranchId !== 'string' ||
+    typeof snapshot.terminalPromptMessageId !== 'string' ||
+    typeof snapshot.producerRunId !== 'string' ||
+    typeof snapshot.producerRunIndex !== 'number' ||
+    !Number.isSafeInteger(snapshot.producerRunIndex) ||
+    typeof snapshot.createdAt !== 'string' ||
+    !Array.isArray(snapshot.inputFiles) ||
+    !Array.isArray(snapshot.runs) ||
+    (snapshot.truncation !== undefined &&
+      (!truncation ||
+        truncation.reason !== 'payload-limit' ||
+        !Number.isSafeInteger(truncation.omittedLeadingRunCount) ||
+        Number(truncation.omittedLeadingRunCount) < 0 ||
+        !Number.isSafeInteger(truncation.omittedOutputCount) ||
+        Number(truncation.omittedOutputCount) < 0 ||
+        !Number.isSafeInteger(truncation.omittedInputCount) ||
+        Number(truncation.omittedInputCount) < 0)) ||
+    snapshot.runs.some((run) => {
+      const candidate = recordValue(run)
+      return (
+        !candidate ||
+        typeof candidate.runId !== 'string' ||
+        typeof candidate.runIndex !== 'number' ||
+        !Number.isSafeInteger(candidate.runIndex) ||
+        typeof candidate.kernelKind !== 'string' ||
+        typeof candidate.script !== 'string' ||
+        typeof candidate.status !== 'string' ||
+        typeof candidate.startedAt !== 'string' ||
+        !Array.isArray(candidate.outputs) ||
+        !Array.isArray(candidate.inputFileVersionKeys)
+      )
+    })
+  ) {
+    throw new Error('Artifact Version execution snapshot schema is invalid.')
+  }
+  const normalized = parsed as PersistedArtifactExecutionSnapshot
+  return {
+    ...normalized,
+    runs: normalized.runs.map((run) => ({
+      ...run,
+      outputs: (run.outputs as unknown[]).flatMap(normalizeStoredProvenanceOutput)
+    }))
+  }
+}
+
+const validateArtifactExecutionSnapshot = (
+  snapshot: PersistedArtifactExecutionSnapshot,
+  expected: {
+    rootFrameId: string
+    agentFrameId: string
+    messageBranchId: string
+    promptMessageId: string
+    producerRunId: string | null
+    producerRunIndex: number | null
+    executionSnapshotChecksum: string
+    evidence: ArtifactVersionEvidence
+  }
+): void => {
+  const producer = expected.evidence.producer
+  const runIndexes = snapshot.runs.map((run) => run.runIndex)
+  const indexesAreStrictlyIncreasing = runIndexes.every(
+    (runIndex, index) => index === 0 || runIndex > runIndexes[index - 1]!
+  )
+  const terminalRun = snapshot.runs.at(-1)
+  if (
+    snapshot.rootFrameId !== expected.rootFrameId ||
+    snapshot.agentFrameId !== expected.agentFrameId ||
+    snapshot.messageBranchId !== expected.messageBranchId ||
+    snapshot.terminalPromptMessageId !== expected.promptMessageId ||
+    expected.producerRunId === null ||
+    expected.producerRunIndex === null ||
+    snapshot.producerRunId !== expected.producerRunId ||
+    snapshot.producerRunIndex !== expected.producerRunIndex ||
+    expected.evidence.execution_snapshot_checksum !== expected.executionSnapshotChecksum ||
+    producer.state !== 'available' ||
+    producer.producer_run_id !== expected.producerRunId ||
+    producer.run_index !== expected.producerRunIndex ||
+    snapshot.runs.length === 0 ||
+    !indexesAreStrictlyIncreasing ||
+    runIndexes.some((runIndex) => runIndex > expected.producerRunIndex!) ||
+    terminalRun?.runId !== expected.producerRunId ||
+    terminalRun.runIndex !== expected.producerRunIndex
+  ) {
+    throw new Error('Artifact Version execution snapshot metadata mismatch.')
+  }
+}
+
 export {
   buildBoundedExecutionSnapshot,
   environmentEvidence,
   inputEvidence,
-  resolveRunEnvironmentCapture
+  parseArtifactExecutionSnapshot,
+  resolveRunEnvironmentCapture,
+  validateArtifactExecutionSnapshot
 }

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -18,7 +18,6 @@ import type {
   GetArtifactLineageRequest,
   GetArtifactVersionProvenanceRequest,
   PersistedArtifactExecutionSnapshot,
-  ProvenanceNotebookOutput,
   ProvenanceExecutionInputFile,
   ReplayArtifactVersionRequest
 } from '../../shared/artifact-provenance'
@@ -44,6 +43,10 @@ import { NotebookRunRepository } from '../notebook/repository'
 import type { NotebookRunInputFile } from '../../shared/notebook'
 import { canonicalJson, sha256, type CanonicalJson } from './provenance-canonical'
 import { ArtifactProvenanceProducerCapture } from './provenance-producer-capture'
+import {
+  parseArtifactExecutionSnapshot,
+  validateArtifactExecutionSnapshot
+} from './provenance-execution-evidence'
 import { toCheck, toReview } from '../reviewer/repository'
 import { selectReviewChainForArtifactVersion } from '../reviewer/artifact-version-review'
 import { flagStaleReviews } from '../reviewer/stale-reviews'
@@ -576,152 +579,6 @@ const stringValue = (value: unknown): string | undefined =>
 
 const numberValue = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isFinite(value) ? value : undefined
-
-const normalizeStoredProvenanceOutput = (value: unknown): ProvenanceNotebookOutput[] => {
-  const output = recordValue(value)
-  if (output?.type === 'text' && typeof output.text === 'string') {
-    return [
-      {
-        type: 'text',
-        text: output.text,
-        ...(output.truncated === true ? { truncated: true } : {})
-      }
-    ]
-  }
-  if (output?.type === 'error') {
-    const name = stringValue(output.name)
-    const message = stringValue(output.message) ?? name ?? 'Notebook execution failed.'
-    const traceback = Array.isArray(output.traceback)
-      ? output.traceback.filter((line): line is string => typeof line === 'string')
-      : typeof output.traceback === 'string' && output.traceback
-        ? output.traceback.split('\n')
-        : undefined
-    return [
-      { type: 'error', ...(name ? { name } : {}), message, ...(traceback ? { traceback } : {}) }
-    ]
-  }
-  if (output?.type === 'table') {
-    const columns = Array.isArray(output.columns)
-      ? output.columns.filter((column): column is string => typeof column === 'string')
-      : []
-    const previewRows = Array.isArray(output.previewRows)
-      ? output.previewRows.filter((row): row is unknown[] => Array.isArray(row))
-      : []
-    const rowCount = numberValue(output.rowCount)
-    return columns.length > 0 && rowCount !== undefined
-      ? [{ type: 'table', columns, rowCount, previewRows }]
-      : []
-  }
-  if (output?.type === 'omitted-media') {
-    const mimeTypes =
-      typeof output.mimeType === 'string'
-        ? [output.mimeType]
-        : Array.isArray(output.mime_types)
-          ? output.mime_types.filter((mimeType): mimeType is string => typeof mimeType === 'string')
-          : []
-    return mimeTypes.map((mimeType) => ({
-      type: 'omitted-media',
-      mimeType,
-      ...(typeof output.byteLength === 'number' ? { byteLength: output.byteLength } : {})
-    }))
-  }
-  return []
-}
-
-const parseArtifactExecutionSnapshot = (value: string): PersistedArtifactExecutionSnapshot => {
-  const parsed = JSON.parse(value) as unknown
-  const snapshot = recordValue(parsed)
-  const truncation = recordValue(snapshot?.truncation)
-  if (
-    snapshot?.schemaVersion !== 2 ||
-    typeof snapshot.rootFrameId !== 'string' ||
-    typeof snapshot.agentFrameId !== 'string' ||
-    typeof snapshot.messageBranchId !== 'string' ||
-    typeof snapshot.terminalPromptMessageId !== 'string' ||
-    typeof snapshot.producerRunId !== 'string' ||
-    typeof snapshot.producerRunIndex !== 'number' ||
-    !Number.isSafeInteger(snapshot.producerRunIndex) ||
-    typeof snapshot.createdAt !== 'string' ||
-    !Array.isArray(snapshot.inputFiles) ||
-    !Array.isArray(snapshot.runs) ||
-    (snapshot.truncation !== undefined &&
-      (!truncation ||
-        truncation.reason !== 'payload-limit' ||
-        !Number.isSafeInteger(truncation.omittedLeadingRunCount) ||
-        Number(truncation.omittedLeadingRunCount) < 0 ||
-        !Number.isSafeInteger(truncation.omittedOutputCount) ||
-        Number(truncation.omittedOutputCount) < 0 ||
-        !Number.isSafeInteger(truncation.omittedInputCount) ||
-        Number(truncation.omittedInputCount) < 0)) ||
-    snapshot.runs.some((run) => {
-      const candidate = recordValue(run)
-      return (
-        !candidate ||
-        typeof candidate.runId !== 'string' ||
-        typeof candidate.runIndex !== 'number' ||
-        !Number.isSafeInteger(candidate.runIndex) ||
-        typeof candidate.kernelKind !== 'string' ||
-        typeof candidate.script !== 'string' ||
-        typeof candidate.status !== 'string' ||
-        typeof candidate.startedAt !== 'string' ||
-        !Array.isArray(candidate.outputs) ||
-        !Array.isArray(candidate.inputFileVersionKeys)
-      )
-    })
-  ) {
-    throw new Error('Artifact Version execution snapshot schema is invalid.')
-  }
-  const normalized = parsed as PersistedArtifactExecutionSnapshot
-  return {
-    ...normalized,
-    runs: normalized.runs.map((run) => ({
-      ...run,
-      outputs: (run.outputs as unknown[]).flatMap(normalizeStoredProvenanceOutput)
-    }))
-  }
-}
-
-const validateArtifactExecutionSnapshot = (
-  snapshot: PersistedArtifactExecutionSnapshot,
-  expected: {
-    rootFrameId: string
-    agentFrameId: string
-    messageBranchId: string
-    promptMessageId: string
-    producerRunId: string | null
-    producerRunIndex: number | null
-    executionSnapshotChecksum: string
-    evidence: ArtifactVersionEvidence
-  }
-): void => {
-  const producer = expected.evidence.producer
-  const runIndexes = snapshot.runs.map((run) => run.runIndex)
-  const indexesAreStrictlyIncreasing = runIndexes.every(
-    (runIndex, index) => index === 0 || runIndex > runIndexes[index - 1]!
-  )
-  const terminalRun = snapshot.runs.at(-1)
-  if (
-    snapshot.rootFrameId !== expected.rootFrameId ||
-    snapshot.agentFrameId !== expected.agentFrameId ||
-    snapshot.messageBranchId !== expected.messageBranchId ||
-    snapshot.terminalPromptMessageId !== expected.promptMessageId ||
-    expected.producerRunId === null ||
-    expected.producerRunIndex === null ||
-    snapshot.producerRunId !== expected.producerRunId ||
-    snapshot.producerRunIndex !== expected.producerRunIndex ||
-    expected.evidence.execution_snapshot_checksum !== expected.executionSnapshotChecksum ||
-    producer.state !== 'available' ||
-    producer.producer_run_id !== expected.producerRunId ||
-    producer.run_index !== expected.producerRunIndex ||
-    snapshot.runs.length === 0 ||
-    !indexesAreStrictlyIncreasing ||
-    runIndexes.some((runIndex) => runIndex > expected.producerRunIndex!) ||
-    terminalRun?.runId !== expected.producerRunId ||
-    terminalRun.runIndex !== expected.producerRunIndex
-  ) {
-    throw new Error('Artifact Version execution snapshot metadata mismatch.')
-  }
-}
 
 type PersistedExecutionInputRow = {
   ordinal: number


### PR DESCRIPTION
## Problem

The Artifact Provenance facade still owns persisted execution snapshot parsing, legacy output
normalization and immutable metadata validation. Durable Message finalization and provenance reads
both depend on these rules, so extracting the finalizer directly would either create a dependency
cycle or leave proof ownership split across the facade and the new owner.

## Proposed change

- Move persisted execution snapshot parsing and legacy stored-output normalization into the existing
  stateless `provenance-execution-evidence` codec.
- Move immutable execution metadata validation into the same codec.
- Import those functions from the repository facade for both durable finalization proof and
  provenance read projection.
- Keep SQLite input-row relationship validation in the facade for the later PV5 read-model split.

## Scope and non-goals

- This is a mechanical internal extraction and the serial prerequisite for PV3B Message
  finalization ownership.
- No durable Message graph, exact Version-set, transaction, recovery or read-cache ownership moves in
  this PR.
- No public/shared/IPC/MCP/local-RPC/HTTP/CLI type or value export changes.
- No Prisma/schema/data relationship, persisted bytes, checksum, storage key, path, UI or user
  interaction changes.

## Compatibility

- Preserve schema-version checks, payload-limit truncation fields, legacy traceback and
  `mime_types` normalization, run ordering and producer-terminal metadata validation exactly.
- Preserve #934's finalization proof reason codes, runtime error-class identity, privacy-safe
  diagnostics and persistence-race-only retry policy.
- Preserve Electron/Web/CLI/Task/local-RPC/MCP behavior and the current
  Specialist/Permission/Compute capability asymmetry.
- The moved codec has no filesystem logic; existing `/` storage keys and native `node:path` handling
  remain unchanged on Windows, macOS and Linux.

## Acceptance criteria and validation

- Final production diff is +160/-148; `provenance-execution-evidence.ts` is 596 raw lines, below the
  approved 600 target, and `provenance-repository.ts` is reduced from 2,674 to 2,531 raw lines.
- Worktree-local CodeGraph confirms the two functions are owned by the execution-evidence codec and
  are called by both finalization proof and provenance reads, with no reverse dependency.
- Repository and lifecycle contracts: 2 files / 37 tests passed.
- `npm run test:module -- artifact_provenance`: 23 files / 1,010 tests passed after allowing the
  project-owned local RPC/HTTP tests to listen on loopback and a temporary Unix socket.
- `npm run typecheck:node`, changed-file ESLint, Prettier and `git diff --check` passed.
- All listed checks ran after the last material edit. Exact-head PR Gate, CI Integrity, CodeQL and AI
  review must pass before squash merge.

## Review focus

- Confirm the move is behavior-preserving and does not broaden the internal codec into a stateful
  owner.
- Confirm finalization and read projection now share one persisted execution proof implementation.
- Confirm input-row validation remains with PV5 and PV3B remains the sole future Message
  finalization owner.
- Confirm no public/data/path/UI/cross-surface behavior or capability asymmetry changes.
