### PR TITLE
refactor(artifact-provenance): extract finalization recovery

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -147,6 +147,7 @@
       "ownerPaths": [
         "src/main/artifacts/provenance-canonical.ts",
         "src/main/artifacts/provenance-execution-evidence.ts",
+        "src/main/artifacts/provenance-finalization-recovery.ts",
         "src/main/artifacts/provenance-message-finalization.ts",
         "src/main/artifacts/provenance-message-snapshot.ts",
         "src/main/artifacts/provenance-producer-capture.ts",

--- a/src/main/artifacts/provenance-finalization-recovery.ts
+++ b/src/main/artifacts/provenance-finalization-recovery.ts
@@ -1,0 +1,297 @@
+import type { PrismaClient } from '@prisma/client'
+
+import type {
+  ArtifactVersionFile,
+  FinalizeArtifactVersionsRequest
+} from '../../shared/artifact-provenance'
+import { resolveMessageBranchPath } from '../../shared/conversation-graph'
+import {
+  materializeSessionConversationGraph,
+  type PersistedChatSession
+} from '../../shared/session-persistence'
+import {
+  ArtifactFinalizationProofError,
+  ArtifactProvenanceMessageFinalizer,
+  validateDurableMessageOwnership
+} from './provenance-message-finalization'
+import type { ArtifactRepository, PendingArtifactRunPublication } from './repository'
+
+type ArtifactProjectReconciliationState = {
+  readonly projectId: string
+  readonly unfinishedCompatibilityPublications: readonly PendingArtifactRunPublication[]
+}
+
+const artifactProjectReconciliationState = Symbol('artifactProjectReconciliationState')
+
+// Opaque outside this module: callers may route a Project-scoped snapshot but cannot inspect or
+// construct its publication state. This keeps compatibility layout knowledge inside Provenance.
+type ArtifactProjectReconciliationSnapshot = {
+  readonly [artifactProjectReconciliationState]: ArtifactProjectReconciliationState
+}
+
+type PreparedArtifactFinalizationContext = Pick<
+  FinalizeArtifactVersionsRequest,
+  'rootFrameId' | 'agentFrameId' | 'messageBranchId' | 'runtimeSegmentId' | 'promptMessageId'
+>
+
+type ArtifactFinalizationRecoveryResult = {
+  recoveredVersionIds: string[]
+  recoveredMessageArtifacts: Array<{ messageId: string; artifacts: ArtifactVersionFile[] }>
+}
+
+type ArtifactProvenanceFinalizationRecoveryOptions = {
+  getClient: () => Promise<PrismaClient>
+  compatibilityRepository?: Pick<
+    ArtifactRepository,
+    'listPendingRunPublications' | 'findRunFinalizationMarker' | 'finalizeRunArtifacts'
+  >
+  messageFinalizer: Pick<ArtifactProvenanceMessageFinalizer, 'finalizeRunWithDurableSession'>
+}
+
+// Resolves the one agent message produced by the prepared prompt turn. It deliberately considers
+// only messages before the next user prompt on the declared Branch and Runtime Segment; choosing a
+// latest message (or accepting multiple candidates) could attach a crashed run to a later turn.
+const inferDurableFinalizationMessageId = (
+  session: PersistedChatSession,
+  context: PreparedArtifactFinalizationContext
+): string | undefined => {
+  const graph = materializeSessionConversationGraph(session).conversationGraph!
+  if (graph.rootFrameId !== context.rootFrameId) return undefined
+  const frame = graph.frames.find((candidate) => candidate.id === context.agentFrameId)
+  const branch = graph.branches.find((candidate) => candidate.id === context.messageBranchId)
+  const segment = graph.runtimeSegments.find(
+    (candidate) =>
+      candidate.id === context.runtimeSegmentId && candidate.agentFrameId === context.agentFrameId
+  )
+  if (!frame || !branch || branch.agentFrameId !== frame.id || !segment) return undefined
+
+  const path = resolveMessageBranchPath(graph, context.messageBranchId)
+  const promptIndex = path.findIndex((message) => message.id === context.promptMessageId)
+  if (promptIndex < 0) return undefined
+  const followingUserOffset = path
+    .slice(promptIndex + 1)
+    .findIndex((message) => message.role === 'user')
+  const turnEnd = followingUserOffset < 0 ? path.length : promptIndex + 1 + followingUserOffset
+  const candidates = path
+    .slice(promptIndex + 1, turnEnd)
+    .filter(
+      (message) =>
+        message.role === 'agent' &&
+        message.agentFrameId === context.agentFrameId &&
+        message.introducedOnBranchId === context.messageBranchId &&
+        message.runtimeSegmentId === context.runtimeSegmentId
+    )
+  if (candidates.length !== 1) return undefined
+
+  validateDurableMessageOwnership(session, { ...context, messageId: candidates[0].id })
+  return candidates[0].id
+}
+
+// Require Session metadata and every persisted owner projection to carry ArtifactFile.id.
+const isArtifactLinkedToDurableMessage = (
+  session: PersistedChatSession,
+  messageId: string,
+  versionId: string
+): boolean => {
+  const owners = [
+    session.messages.find((message) => message.id === messageId),
+    session.conversationGraph?.messages.find((message) => message.id === messageId)
+  ].filter((message): message is NonNullable<typeof message> => !!message)
+
+  return (
+    owners.length > 0 &&
+    owners.every((message) => message.artifactIds?.includes(versionId)) &&
+    !!session.artifacts?.some((artifact) => artifact.id === versionId)
+  )
+}
+
+class ArtifactProvenanceFinalizationRecovery {
+  constructor(private readonly options: ArtifactProvenanceFinalizationRecoveryOptions) {}
+
+  async prepareProjectReconciliation(
+    projectId: string
+  ): Promise<ArtifactProjectReconciliationSnapshot> {
+    const unfinishedCompatibilityPublications = this.options.compatibilityRepository
+      ? await this.options.compatibilityRepository.listPendingRunPublications(projectId)
+      : []
+    return {
+      [artifactProjectReconciliationState]: {
+        projectId,
+        unfinishedCompatibilityPublications
+      }
+    }
+  }
+
+  validateProjectReconciliation(
+    projectId: string,
+    snapshot?: ArtifactProjectReconciliationSnapshot
+  ): void {
+    const prepared = snapshot?.[artifactProjectReconciliationState]
+    if (snapshot && !prepared) {
+      throw new Error('Artifact Project reconciliation snapshot is invalid.')
+    }
+    if (prepared && prepared.projectId !== projectId) {
+      throw new Error('Artifact Project reconciliation snapshot belongs to another Project.')
+    }
+  }
+
+  async reconcileSession(
+    projectId: string,
+    appSessionId: string,
+    durableSession?: PersistedChatSession,
+    snapshot?: ArtifactProjectReconciliationSnapshot
+  ): Promise<ArtifactFinalizationRecoveryResult> {
+    this.validateProjectReconciliation(projectId, snapshot)
+    const result: ArtifactFinalizationRecoveryResult = {
+      recoveredVersionIds: [],
+      recoveredMessageArtifacts: []
+    }
+    const compatibilityRepository = this.options.compatibilityRepository
+    if (
+      !durableSession ||
+      durableSession.projectId !== projectId ||
+      durableSession.id !== appSessionId ||
+      !compatibilityRepository
+    ) {
+      return result
+    }
+
+    const client = await this.options.getClient()
+    const allFinalizationVersions = await client.artifactVersion.findMany({
+      where: {
+        state: { in: ['pending', 'finalized'] },
+        artifact: { is: { projectId, sessionId: appSessionId } }
+      }
+    })
+    const candidateVersions = allFinalizationVersions.filter(
+      (version) =>
+        version.state === 'pending' ||
+        (version.messageId !== null &&
+          !isArtifactLinkedToDurableMessage(durableSession, version.messageId, version.id))
+    )
+    // Native Session linkage proves only that immutable Provenance content is attached. A single
+    // project scan adds the much narrower set whose compatibility publication is physically
+    // unfinished, without replaying every historical finalized run or rescanning Sessions per run.
+    // Direct callers deliberately get a fresh scan. Startup supplies one opaque Project snapshot
+    // to every Session, avoiding repeated scans without persisting stale repository state.
+    const prepared = snapshot?.[artifactProjectReconciliationState]
+    const unfinishedCompatibilityPublications =
+      prepared?.unfinishedCompatibilityPublications ??
+      (await compatibilityRepository.listPendingRunPublications(projectId))
+    const publicationByRunId = new Map(
+      unfinishedCompatibilityPublications.map((publication) => [publication.runId, publication])
+    )
+    const runIds = [
+      ...new Set([
+        ...candidateVersions.map((version) => version.artifactRunId),
+        ...unfinishedCompatibilityPublications.map((publication) => publication.runId)
+      ])
+    ]
+    for (const artifactRunId of runIds) {
+      const unfinishedPublication = publicationByRunId.get(artifactRunId)
+      const marker = unfinishedPublication
+        ? unfinishedPublication.marker
+          ? {
+              ...unfinishedPublication.marker,
+              sourceSessionId: unfinishedPublication.sourceSessionId
+            }
+          : undefined
+        : await compatibilityRepository.findRunFinalizationMarker(projectId, artifactRunId)
+      const markerContext = marker?.provenanceContext
+      if (!marker || marker.sessionId !== appSessionId || !markerContext) continue
+      // Exact-set proof covers the whole pending/finalized run, including Versions already linked
+      // to Session JSON. The candidate subset decides whether recovery is needed, not what the run
+      // owns; otherwise a partially linked run would look like it contained unexpected Versions.
+      const runVersions = allFinalizationVersions.filter(
+        (version) => version.artifactRunId === artifactRunId
+      )
+      if (
+        runVersions.length === 0 ||
+        runVersions.some(
+          (version) =>
+            version.rootFrameId !== markerContext.rootFrameId ||
+            version.agentFrameId !== markerContext.agentFrameId ||
+            version.messageBranchId !== markerContext.messageBranchId ||
+            version.runtimeSegmentId !== markerContext.runtimeSegmentId ||
+            version.promptMessageId !== markerContext.promptMessageId
+        )
+      ) {
+        continue
+      }
+      let proof: { messageId: string } | undefined
+      try {
+        const messageId =
+          marker.messageId ?? inferDurableFinalizationMessageId(durableSession, markerContext)
+        if (messageId) {
+          validateDurableMessageOwnership(durableSession, {
+            ...markerContext,
+            messageId
+          })
+          proof = { messageId }
+        }
+      } catch {
+        // Leave the pending Version visible and retryable; an unproven marker is never guessed.
+      }
+      if (!proof) continue
+
+      const pendingVersionIds = new Set(
+        runVersions.filter((version) => version.state === 'pending').map((version) => version.id)
+      )
+      // Markers created before exact-set publication shipped have no frozen ids. Preserve that
+      // on-disk compatibility by deriving the whole run once; every new marker carries ids and is
+      // consumed verbatim, so recovery can never widen or narrow a modern runtime claim.
+      const markerVersionIds = marker.artifactVersionIds ?? runVersions.map((version) => version.id)
+      const finalizationRequest: FinalizeArtifactVersionsRequest = {
+        projectId,
+        appSessionId,
+        artifactRunId,
+        ...markerContext,
+        messageId: proof.messageId,
+        artifactVersionIds: markerVersionIds
+      }
+      let finalized: ArtifactVersionFile[]
+      try {
+        // Commit complete ownership and execution proof before the irreversible compatibility move.
+        // A crash or I/O failure after this point leaves a finalized-but-unlinked Version, which the
+        // candidate selector above deliberately retries on the next startup.
+        finalized = await this.options.messageFinalizer.finalizeRunWithDurableSession(
+          finalizationRequest,
+          durableSession
+        )
+      } catch (error) {
+        if (error instanceof ArtifactFinalizationProofError) continue
+        throw error
+      }
+      // Replay unconditionally after the durable Version commit: a bound marker may have survived a
+      // crash before pending bytes moved. Operational compatibility failures escape and keep startup
+      // incomplete without exposing the not-yet-attached Version in Session JSON.
+      await compatibilityRepository.finalizeRunArtifacts({
+        projectName: projectId,
+        sourceSessionId: marker.sourceSessionId,
+        sessionId: appSessionId,
+        runId: artifactRunId,
+        messageId: proof.messageId,
+        artifactVersionIds: markerVersionIds,
+        provenanceContext: markerContext
+      })
+      result.recoveredVersionIds.push(
+        ...finalized
+          .filter((version) => pendingVersionIds.has(version.versionId!))
+          .map((version) => version.versionId!)
+      )
+      if (finalized.length > 0) {
+        result.recoveredMessageArtifacts.push({
+          messageId: proof.messageId,
+          artifacts: finalized
+        })
+      }
+    }
+    return result
+  }
+}
+
+export {
+  ArtifactProvenanceFinalizationRecovery,
+  type ArtifactFinalizationRecoveryResult,
+  type ArtifactProjectReconciliationSnapshot
+}

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -25,11 +25,7 @@ import {
   MAX_ARTIFACT_VERSION_DESCRIPTOR_IDS,
   type ResolveArtifactVersionDescriptorsRequest
 } from '../../shared/artifacts'
-import {
-  ArtifactCompatibilityScanIncompleteError,
-  ArtifactRepository,
-  type PendingArtifactRunPublication
-} from './repository'
+import { ArtifactCompatibilityScanIncompleteError, ArtifactRepository } from './repository'
 import { defaultArtifactDurability, type ArtifactDurability } from './durability'
 import {
   ArtifactProvenanceVersionWriter,
@@ -48,9 +44,12 @@ import {
   ArtifactFinalizationProofError,
   ArtifactOwnershipPersistenceRaceError,
   ArtifactProvenanceMessageFinalizer,
-  validateDurableMessageOwnership,
   type ArtifactFinalizationProofReason
 } from './provenance-message-finalization'
+import {
+  ArtifactProvenanceFinalizationRecovery,
+  type ArtifactProjectReconciliationSnapshot
+} from './provenance-finalization-recovery'
 import { ArtifactProvenanceStagingRecovery } from './provenance-staging-recovery'
 import { readOptionalFile, resolveStorageKey, storageKey } from './provenance-storage'
 import { toCheck, toReview } from '../reviewer/repository'
@@ -63,12 +62,7 @@ import type {
   ReviewWithProvenanceEvidence
 } from '../../shared/reviewer'
 import type { PersistedChatSession } from '../../shared/session-persistence'
-import {
-  materializeSessionConversationGraph,
-  sanitizeActivityGroup,
-  sanitizeToolActivity
-} from '../../shared/session-persistence'
-import { resolveMessageBranchPath } from '../../shared/conversation-graph'
+import { sanitizeActivityGroup, sanitizeToolActivity } from '../../shared/session-persistence'
 
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 const SHA256_PATTERN = /^[a-f0-9]{64}$/
@@ -108,81 +102,6 @@ type ArtifactStorageReconciliationResult = {
   recoveredVersionIds: string[]
   quarantinedVersionIds: string[]
   recoveredMessageArtifacts: Array<{ messageId: string; artifacts: ArtifactVersionFile[] }>
-}
-
-type ArtifactProjectReconciliationState = {
-  readonly projectId: string
-  readonly unfinishedCompatibilityPublications: readonly PendingArtifactRunPublication[]
-}
-
-const artifactProjectReconciliationState = Symbol('artifactProjectReconciliationState')
-
-// Opaque outside this module: callers may route a Project-scoped snapshot but cannot inspect or
-// construct its publication state. This keeps compatibility layout knowledge inside Provenance.
-export type ArtifactProjectReconciliationSnapshot = {
-  readonly [artifactProjectReconciliationState]: ArtifactProjectReconciliationState
-}
-
-type PreparedArtifactFinalizationContext = Pick<
-  FinalizeArtifactVersionsRequest,
-  'rootFrameId' | 'agentFrameId' | 'messageBranchId' | 'runtimeSegmentId' | 'promptMessageId'
->
-
-// Resolves the one agent message produced by the prepared prompt turn. It deliberately considers only
-// messages before the next user prompt on the declared Branch and Runtime Segment; choosing a latest
-// message (or accepting multiple candidates) could attach a crashed run to a later turn.
-const inferDurableFinalizationMessageId = (
-  session: PersistedChatSession,
-  context: PreparedArtifactFinalizationContext
-): string | undefined => {
-  const graph = materializeSessionConversationGraph(session).conversationGraph!
-  if (graph.rootFrameId !== context.rootFrameId) return undefined
-  const frame = graph.frames.find((candidate) => candidate.id === context.agentFrameId)
-  const branch = graph.branches.find((candidate) => candidate.id === context.messageBranchId)
-  const segment = graph.runtimeSegments.find(
-    (candidate) =>
-      candidate.id === context.runtimeSegmentId && candidate.agentFrameId === context.agentFrameId
-  )
-  if (!frame || !branch || branch.agentFrameId !== frame.id || !segment) return undefined
-
-  const path = resolveMessageBranchPath(graph, context.messageBranchId)
-  const promptIndex = path.findIndex((message) => message.id === context.promptMessageId)
-  if (promptIndex < 0) return undefined
-  const followingUserOffset = path
-    .slice(promptIndex + 1)
-    .findIndex((message) => message.role === 'user')
-  const turnEnd = followingUserOffset < 0 ? path.length : promptIndex + 1 + followingUserOffset
-  const candidates = path
-    .slice(promptIndex + 1, turnEnd)
-    .filter(
-      (message) =>
-        message.role === 'agent' &&
-        message.agentFrameId === context.agentFrameId &&
-        message.introducedOnBranchId === context.messageBranchId &&
-        message.runtimeSegmentId === context.runtimeSegmentId
-    )
-  if (candidates.length !== 1) return undefined
-
-  validateDurableMessageOwnership(session, { ...context, messageId: candidates[0].id })
-  return candidates[0].id
-}
-
-// Require Session metadata and every persisted owner projection to carry ArtifactFile.id.
-const isArtifactLinkedToDurableMessage = (
-  session: PersistedChatSession,
-  messageId: string,
-  versionId: string
-): boolean => {
-  const owners = [
-    session.messages.find((message) => message.id === messageId),
-    session.conversationGraph?.messages.find((message) => message.id === messageId)
-  ].filter((message): message is NonNullable<typeof message> => !!message)
-
-  return (
-    owners.length > 0 &&
-    owners.every((message) => message.artifactIds?.includes(versionId)) &&
-    !!session.artifacts?.some((artifact) => artifact.id === versionId)
-  )
 }
 
 const assertSafeSegment = (value: string, label: string): string => {
@@ -301,6 +220,7 @@ class ArtifactProvenanceRepository {
   private readonly createId: () => string
   private readonly now: () => Date
   private readonly durability: ArtifactDurability
+  private readonly finalizationRecovery: ArtifactProvenanceFinalizationRecovery
   private readonly messageFinalizer: ArtifactProvenanceMessageFinalizer
   private readonly producerCapture: ArtifactProvenanceProducerCapture
   private readonly stagingRecovery: ArtifactProvenanceStagingRecovery
@@ -324,6 +244,11 @@ class ArtifactProvenanceRepository {
       loadSession: options.loadSession,
       projectVersionFile: (version, projectId, appSessionId) =>
         this.toArtifactVersionFile(version, projectId, appSessionId)
+    })
+    this.finalizationRecovery = new ArtifactProvenanceFinalizationRecovery({
+      getClient: options.getClient,
+      compatibilityRepository: options.compatibilityRepository,
+      messageFinalizer: this.messageFinalizer
     })
     this.stagingRecovery = new ArtifactProvenanceStagingRecovery({
       storageRoot: options.storageRoot,
@@ -547,15 +472,7 @@ class ArtifactProvenanceRepository {
     projectIdInput: string
   ): Promise<ArtifactProjectReconciliationSnapshot> {
     const projectId = assertSafeSegment(projectIdInput, 'project id')
-    const unfinishedCompatibilityPublications = this.options.compatibilityRepository
-      ? await this.options.compatibilityRepository.listPendingRunPublications(projectId)
-      : []
-    return {
-      [artifactProjectReconciliationState]: {
-        projectId,
-        unfinishedCompatibilityPublications
-      }
-    }
+    return this.finalizationRecovery.prepareProjectReconciliation(projectId)
   }
 
   async reconcileSession(
@@ -569,15 +486,10 @@ class ArtifactProvenanceRepository {
   ): Promise<ArtifactStorageReconciliationResult> {
     const projectId = assertSafeSegment(projectIdInput, 'project id')
     const appSessionId = assertSafeSegment(appSessionIdInput, 'app session id')
-    const preparedProjectReconciliation = options?.projectReconciliation
-      ? options.projectReconciliation[artifactProjectReconciliationState]
-      : undefined
-    if (options?.projectReconciliation && !preparedProjectReconciliation) {
-      throw new Error('Artifact Project reconciliation snapshot is invalid.')
-    }
-    if (preparedProjectReconciliation && preparedProjectReconciliation.projectId !== projectId) {
-      throw new Error('Artifact Project reconciliation snapshot belongs to another Project.')
-    }
+    this.finalizationRecovery.validateProjectReconciliation(
+      projectId,
+      options?.projectReconciliation
+    )
     const provenanceRoot = resolveStorageKey(
       this.options.storageRoot,
       storageKey('artifacts', projectId, appSessionId, '.provenance')
@@ -608,151 +520,14 @@ class ArtifactProvenanceRepository {
     result.recoveredVersionIds.push(...stagingResult.recoveredVersionIds)
     result.quarantinedVersionIds.push(...stagingResult.quarantinedVersionIds)
     const client = await this.options.getClient()
-
-    // Runtime publication first records a durable intent, then renderer finalization upgrades it with
-    // the terminal message before moving compatibility bytes. Recover either crash window only when
-    // the marker context and durable graph independently prove the same Branch/message ownership.
-    if (
-      durableSession &&
-      durableSession.projectId === projectId &&
-      durableSession.id === appSessionId &&
-      this.options.compatibilityRepository
-    ) {
-      const allFinalizationVersions = await client.artifactVersion.findMany({
-        where: {
-          state: { in: ['pending', 'finalized'] },
-          artifact: { is: { projectId, sessionId: appSessionId } }
-        }
-      })
-      const candidateVersions = allFinalizationVersions.filter(
-        (version) =>
-          version.state === 'pending' ||
-          (version.messageId !== null &&
-            !isArtifactLinkedToDurableMessage(durableSession, version.messageId, version.id))
-      )
-      // Native Session linkage proves only that immutable Provenance content is attached. A single
-      // project scan adds the much narrower set whose compatibility publication is physically
-      // unfinished, without replaying every historical finalized run or rescanning Sessions per run.
-      // Direct callers deliberately get a fresh scan. Startup supplies one opaque Project snapshot
-      // to every Session, avoiding repeated scans without persisting stale repository state.
-      const unfinishedCompatibilityPublications =
-        preparedProjectReconciliation?.unfinishedCompatibilityPublications ??
-        (await this.options.compatibilityRepository.listPendingRunPublications(projectId))
-      const publicationByRunId = new Map(
-        unfinishedCompatibilityPublications.map((publication) => [publication.runId, publication])
-      )
-      const runIds = [
-        ...new Set([
-          ...candidateVersions.map((version) => version.artifactRunId),
-          ...unfinishedCompatibilityPublications.map((publication) => publication.runId)
-        ])
-      ]
-      for (const artifactRunId of runIds) {
-        const unfinishedPublication = publicationByRunId.get(artifactRunId)
-        const marker = unfinishedPublication
-          ? unfinishedPublication.marker
-            ? {
-                ...unfinishedPublication.marker,
-                sourceSessionId: unfinishedPublication.sourceSessionId
-              }
-            : undefined
-          : await this.options.compatibilityRepository.findRunFinalizationMarker(
-              projectId,
-              artifactRunId
-            )
-        const markerContext = marker?.provenanceContext
-        if (!marker || marker.sessionId !== appSessionId || !markerContext) continue
-        // Exact-set proof covers the whole pending/finalized run, including Versions already linked
-        // to Session JSON. The candidate subset decides whether recovery is needed, not what the run
-        // owns; otherwise a partially linked run would look like it contained unexpected Versions.
-        const runVersions = allFinalizationVersions.filter(
-          (version) => version.artifactRunId === artifactRunId
-        )
-        if (
-          runVersions.length === 0 ||
-          runVersions.some(
-            (version) =>
-              version.rootFrameId !== markerContext.rootFrameId ||
-              version.agentFrameId !== markerContext.agentFrameId ||
-              version.messageBranchId !== markerContext.messageBranchId ||
-              version.runtimeSegmentId !== markerContext.runtimeSegmentId ||
-              version.promptMessageId !== markerContext.promptMessageId
-          )
-        ) {
-          continue
-        }
-        let proof: { messageId: string } | undefined
-        try {
-          const messageId =
-            marker.messageId ?? inferDurableFinalizationMessageId(durableSession, markerContext)
-          if (messageId) {
-            validateDurableMessageOwnership(durableSession, {
-              ...markerContext,
-              messageId
-            })
-            proof = {
-              messageId
-            }
-          }
-        } catch {
-          // Leave the pending Version visible and retryable; an unproven marker is never guessed.
-        }
-        if (!proof) continue
-
-        const pendingVersionIds = new Set(
-          runVersions.filter((version) => version.state === 'pending').map((version) => version.id)
-        )
-        // Markers created before exact-set publication shipped have no frozen ids. Preserve that
-        // on-disk compatibility by deriving the whole run once; every new marker carries ids and is
-        // consumed verbatim, so recovery can never widen or narrow a modern runtime claim.
-        const markerVersionIds =
-          marker.artifactVersionIds ?? runVersions.map((version) => version.id)
-        const finalizationRequest: FinalizeArtifactVersionsRequest = {
-          projectId,
-          appSessionId,
-          artifactRunId,
-          ...markerContext,
-          messageId: proof.messageId,
-          artifactVersionIds: markerVersionIds
-        }
-        let finalized: ArtifactVersionFile[]
-        try {
-          // Commit complete ownership and execution proof before the irreversible compatibility move.
-          // A crash or I/O failure after this point leaves a finalized-but-unlinked Version, which the
-          // candidate selector above deliberately retries on the next startup.
-          finalized = await this.messageFinalizer.finalizeRunWithDurableSession(
-            finalizationRequest,
-            durableSession
-          )
-        } catch (error) {
-          if (error instanceof ArtifactFinalizationProofError) continue
-          throw error
-        }
-        // Replay unconditionally after the durable Version commit: a bound marker may have survived a
-        // crash before pending bytes moved. Operational compatibility failures escape and keep startup
-        // incomplete without exposing the not-yet-attached Version in Session JSON.
-        await this.options.compatibilityRepository.finalizeRunArtifacts({
-          projectName: projectId,
-          sourceSessionId: marker.sourceSessionId,
-          sessionId: appSessionId,
-          runId: artifactRunId,
-          messageId: proof.messageId,
-          artifactVersionIds: markerVersionIds,
-          provenanceContext: markerContext
-        })
-        result.recoveredVersionIds.push(
-          ...finalized
-            .filter((version) => pendingVersionIds.has(version.versionId!))
-            .map((version) => version.versionId!)
-        )
-        if (finalized.length > 0) {
-          result.recoveredMessageArtifacts.push({
-            messageId: proof.messageId,
-            artifacts: finalized
-          })
-        }
-      }
-    }
+    const finalizationResult = await this.finalizationRecovery.reconcileSession(
+      projectId,
+      appSessionId,
+      durableSession,
+      options?.projectReconciliation
+    )
+    result.recoveredVersionIds.push(...finalizationResult.recoveredVersionIds)
+    result.recoveredMessageArtifacts.push(...finalizationResult.recoveredMessageArtifacts)
 
     for (const lineageEntry of lineageEntries) {
       if (
@@ -1838,3 +1613,4 @@ export {
   ArtifactProvenanceRepository
 }
 export type { ArtifactFinalizationProofReason, ArtifactProvenanceRepositoryOptions }
+export type { ArtifactProjectReconciliationSnapshot }


### PR DESCRIPTION
## Problem

`ArtifactProvenanceRepository` still owns durable finalization-marker recovery inside its session
reconciliation loop. That code combines Project-scoped compatibility scans, exact run selection,
durable Message inference, Version finalization, and post-transaction compatibility replay with the
facade's remaining unindexed-Version recovery.

## Proposed change

- Extract `ArtifactProvenanceFinalizationRecovery` as the owner of prepared/bound marker recovery.
- Move the opaque Project reconciliation snapshot and its validation into that owner.
- Move exact run candidate selection, durable Message inference, finalization proof handling, and
  compatibility replay behind one narrow internal interface.
- Keep `ArtifactProvenanceRepository` as the composition boundary and merge the owner's result into
  the unchanged reconciliation result.
- Register the new owner in the existing `artifact_provenance` module-impact closure.

```mermaid
sequenceDiagram
  participant F as Repository facade
  participant R as Finalization recovery
  participant S as Durable Session
  participant D as Provenance SQLite
  participant C as Compatibility storage
  F->>R: reconcileSession(project, session, snapshot)
  R->>C: select unfinished run markers
  R->>S: prove exact Branch and Message owner
  R->>D: finalize immutable Version ownership
  R->>C: replay pending compatibility publication
  R-->>F: recovered Version ids and Message artifacts
```

## Scope and non-goals

This PR is PV4B only. It does not alter PV4A staging lifecycle recovery, extract PV4C unindexed
immutable Version recovery, change PV5 read models/caches, or perform PV6 certification. It adds no
public runtime surface and does not change Artifact, Version, Lineage, Message, producer, run, or
source data models.

## Compatibility and data flow

The owner preserves the existing Project-snapshot validation messages, direct-call fresh scan,
prepared-marker Message inference, exact run-wide context proof, legacy marker id derivation,
`ArtifactFinalizationProofError` retry behavior, durable SQLite-before-filesystem ordering, and
unconditional compatibility replay after finalization. Public, IPC, data, UI, Electron, Web, CLI,
Task, local RPC, and MCP behavior remains unchanged, including Specialist, Permission, and Compute
capability asymmetries. No persisted key or native path representation changes.

## Acceptance criteria and validation

- Production diff: +323/-250 raw lines; total diff: +324/-250.
- Owner size: finalization recovery 297 lines; repository facade 1,840 → 1,616 physical lines. Every
  production owner remains below the 660-line hard limit.
- `npm run typecheck:node` — passed after the last material edit.
- Changed-file ESLint, Prettier, and `git diff --check` — passed after the last material edit.
- Module-impact validation — 2 files / 16 tests passed after the last material edit.
- `npm run test:module -- artifact_provenance` — 23 files / 1,010 tests passed after the last
  material edit.
- CodeGraph depth-two impact analysis — 88 dependents traversed and 42 affected tests identified.
- Exact-head PR Gate, CI Integrity, CodeQL, cross-platform checks, and AI review remain required
  before squash merge. Exact-head CI is the authoritative full fallback.

## Review focus

Review snapshot opacity and lifetime, the one-message inference boundary, exact run/version context
matching, legacy marker id compatibility, and the ordering of durable Version ownership before the
irreversible compatibility move. Verify that proof failures remain retryable, operational failures
still escape, and PV4C's unindexed-Version loop remains in the facade unchanged.
