### PR TITLE
ci(pipelines): optimize nightly and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,9 @@ on:
         type: boolean
         default: false
 jobs:
-  # Gate every packaged build on the quality suite so nightly (push to main) and release (tag) can
-  # never publish installers that were never tested. Runs once on Apple Silicon to match the
-  # release/verification environment (see pr-check.yml for why macOS). The build matrix `needs` this.
+  # Run the quality suite once on Apple Silicon beside the native package matrix. The reusable
+  # workflow still fails when this job fails, so every caller's publish boundary remains fail closed
+  # without putting the full verification duration on the matrix's critical path.
   verify:
     name: Verify (lint + typecheck + test + package)
     # Skipped by the notarization dry-run (skip_verify), which only needs a signed mac build.
@@ -100,10 +100,10 @@ jobs:
 
   build:
     name: Build ${{ matrix.name }}
-    needs: [verify, setup]
-    # Run once the matrix is resolved. Tolerate a skipped verify (skip_verify dry-run) but still
-    # block on a real verify failure — matching the fail-closed behavior when verify runs.
-    if: ${{ always() && needs.setup.result == 'success' && (needs.verify.result == 'success' || needs.verify.result == 'skipped') }}
+    needs: setup
+    # Start as soon as the matrix is resolved. The sibling verify job remains part of this reusable
+    # workflow's result, so release/nightly callers cannot reach publish if verification fails.
+    if: ${{ needs.setup.result == 'success' }}
     runs-on: ${{ matrix.os }}
     strategy:
       # Don't let one platform's failure cancel the others.

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -38,13 +38,43 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          published=$(gh api "repos/$GITHUB_REPOSITORY/commits/nightly" --jq .sha 2>/dev/null || true)
-          if [ "$published" != "$SOURCE_SHA" ]; then
+          error_file="$RUNNER_TEMP/nightly-published-error.log"
+          if ! published=$(gh api "repos/$GITHUB_REPOSITORY/commits/nightly" --jq .sha 2>"$error_file"); then
+            if grep -Eq 'HTTP (404|422)' "$error_file"; then
+              published=
+            else
+              cat "$error_file" >&2
+              exit 1
+            fi
+          fi
+          if [ -z "$published" ]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
-          else
+            exit 0
+          fi
+          if [ "$published" = "$SOURCE_SHA" ]; then
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             echo "Nightly already points at $SOURCE_SHA; skipping duplicate publication."
+            exit 0
           fi
+
+          # This check runs after the workflow-level publication lock is acquired. GitHub does not
+          # guarantee concurrency queue ordering, so an older workflow may run after a newer one.
+          # Only move the rolling tag forward along the same history; never let that older run
+          # overwrite a newer publication.
+          status=$(gh api "repos/$GITHUB_REPOSITORY/compare/$published...$SOURCE_SHA" --jq .status)
+          case "$status" in
+            ahead)
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            identical|behind)
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              echo "Nightly at $published is not older than $SOURCE_SHA; skipping stale publication."
+              ;;
+            *)
+              echo "::error::Cannot safely advance nightly from $published to $SOURCE_SHA (comparison: $status)."
+              exit 1
+              ;;
+          esac
 
   publish:
     needs: plan

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -1,24 +1,15 @@
 name: Nightly Publish
 
-# Scheduled Nightly completion enters the real, cross-run publish path. workflow_call is the same-run
-# dry-run path used by a manual Nightly so artifact preparation can be tested without side effects.
+# Publish only after a successful scheduled Nightly on main. The low-privilege triggering workflow
+# prepares all metadata; this privileged workflow never checks out or executes triggering-run code.
 on:
-  workflow_call:
-    inputs:
-      dry_run:
-        type: boolean
-        required: true
-      source_run_id:
-        type: string
-        required: true
-      source_sha:
-        type: string
-        required: true
   workflow_run:
     workflows:
       - Nightly
     types:
       - completed
+    branches:
+      - main
 
 permissions:
   actions: read
@@ -33,17 +24,14 @@ concurrency:
 jobs:
   plan:
     if: >-
-      inputs.dry_run ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'schedule' &&
-       github.event.workflow_run.head_branch == 'main')
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'schedule' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     outputs:
       should_publish: ${{ steps.decide.outputs.should_publish }}
     env:
-      DRY_RUN: ${{ inputs.dry_run || false }}
-      SOURCE_SHA: ${{ inputs.source_sha || github.event.workflow_run.head_sha }}
+      SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
       - name: Check for an unpublished build
         id: decide
@@ -51,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           published=$(gh api "repos/$GITHUB_REPOSITORY/commits/nightly" --jq .sha 2>/dev/null || true)
-          if [ "$DRY_RUN" = "true" ] || [ "$published" != "$SOURCE_SHA" ]; then
+          if [ "$published" != "$SOURCE_SHA" ]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
@@ -63,16 +51,10 @@ jobs:
     if: needs.plan.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     env:
-      DRY_RUN: ${{ inputs.dry_run || false }}
-      SOURCE_RUN_ID: ${{ inputs.source_run_id || github.event.workflow_run.id }}
-      SOURCE_SHA: ${{ inputs.source_sha || github.event.workflow_run.head_sha }}
+      SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+      SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
-      - name: Checkout source revision
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ env.SOURCE_SHA }}
-
-      - name: Download all build artifacts
+      - name: Download prepared nightly artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -80,42 +62,17 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Aggregate release certification evidence
-        run: >-
-          node scripts/ci/release-certification-evidence.mjs aggregate
-          --directory artifacts
-          --output artifacts/RELEASE-CERTIFICATION.json
-          --expected-sha "$SOURCE_SHA"
-
-      - name: Generate checksums
-        working-directory: artifacts
+      - name: Verify prepared nightly metadata
         run: |
-          shopt -s nullglob
-          files=(*.dmg *.zip *.exe *.AppImage *.deb)
-          if [ ${#files[@]} -gt 0 ]; then
-            sha256sum "${files[@]}" > SHA256SUMS.txt
-            cat SHA256SUMS.txt
-          fi
-
-      - name: Upload prepared nightly dry-run
-        if: env.DRY_RUN == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: nightly-publish-dry-run
-          retention-days: 1
-          path: |
-            artifacts/SHA256SUMS.txt
-            artifacts/RELEASE-CERTIFICATION.json
-          if-no-files-found: error
+          test -s artifacts/SHA256SUMS.txt
+          test -s artifacts/RELEASE-CERTIFICATION.json
 
       - name: Reset nightly release
-        if: env.DRY_RUN != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release delete nightly --cleanup-tag --yes || true
 
       - name: Publish nightly pre-release
-        if: env.DRY_RUN != 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: nightly

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -1,0 +1,137 @@
+name: Nightly Publish
+
+# Scheduled Nightly completion enters the real, cross-run publish path. workflow_call is the same-run
+# dry-run path used by a manual Nightly so artifact preparation can be tested without side effects.
+on:
+  workflow_call:
+    inputs:
+      dry_run:
+        type: boolean
+        required: true
+      source_run_id:
+        type: string
+        required: true
+      source_sha:
+        type: string
+        required: true
+  workflow_run:
+    workflows:
+      - Nightly
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+
+# Publication is a short serialized phase. Never cancel it between deleting and recreating the
+# rolling release; a newer successful build waits its turn instead.
+concurrency:
+  group: nightly-publish
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    if: >-
+      inputs.dry_run ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'schedule' &&
+       github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.decide.outputs.should_publish }}
+    env:
+      DRY_RUN: ${{ inputs.dry_run || false }}
+      SOURCE_SHA: ${{ inputs.source_sha || github.event.workflow_run.head_sha }}
+    steps:
+      - name: Check for an unpublished build
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          published=$(gh api "repos/$GITHUB_REPOSITORY/commits/nightly" --jq .sha 2>/dev/null || true)
+          if [ "$DRY_RUN" = "true" ] || [ "$published" != "$SOURCE_SHA" ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "Nightly already points at $SOURCE_SHA; skipping duplicate publication."
+          fi
+
+  publish:
+    needs: plan
+    if: needs.plan.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    env:
+      DRY_RUN: ${{ inputs.dry_run || false }}
+      SOURCE_RUN_ID: ${{ inputs.source_run_id || github.event.workflow_run.id }}
+      SOURCE_SHA: ${{ inputs.source_sha || github.event.workflow_run.head_sha }}
+    steps:
+      - name: Checkout source revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ env.SOURCE_RUN_ID }}
+          path: artifacts
+          merge-multiple: true
+
+      - name: Aggregate release certification evidence
+        run: >-
+          node scripts/ci/release-certification-evidence.mjs aggregate
+          --directory artifacts
+          --output artifacts/RELEASE-CERTIFICATION.json
+          --expected-sha "$SOURCE_SHA"
+
+      - name: Generate checksums
+        working-directory: artifacts
+        run: |
+          shopt -s nullglob
+          files=(*.dmg *.zip *.exe *.AppImage *.deb)
+          if [ ${#files[@]} -gt 0 ]; then
+            sha256sum "${files[@]}" > SHA256SUMS.txt
+            cat SHA256SUMS.txt
+          fi
+
+      - name: Upload prepared nightly dry-run
+        if: env.DRY_RUN == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: nightly-publish-dry-run
+          retention-days: 1
+          path: |
+            artifacts/SHA256SUMS.txt
+            artifacts/RELEASE-CERTIFICATION.json
+          if-no-files-found: error
+
+      - name: Reset nightly release
+        if: env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release delete nightly --cleanup-tag --yes || true
+
+      - name: Publish nightly pre-release
+        if: env.DRY_RUN != 'true'
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        with:
+          tag_name: nightly
+          target_commitish: ${{ env.SOURCE_SHA }}
+          name: Nightly (latest main)
+          prerelease: true
+          body: |
+            Automated build of the latest `main` (${{ env.SOURCE_SHA }}).
+
+            Warning: unstable pre-release. macOS builds are ad-hoc signed (not notarized): on first
+            launch, right-click -> Open, or run `xattr -dr com.apple.quarantine "<app>"`.
+          files: |
+            artifacts/*.dmg
+            artifacts/*.zip
+            artifacts/*.exe
+            artifacts/*.AppImage
+            artifacts/*.deb
+            artifacts/SHA256SUMS.txt
+            artifacts/RELEASE-CERTIFICATION.json

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,11 +7,11 @@ on:
     - cron: '17 * * * *'
   workflow_dispatch:
 
-# The manual path calls the real publish workflow in dry-run mode. Reusable workflows cannot elevate
-# permissions above their caller, so contents:write is declared even though that path never publishes.
+# Build and publication preparation run without write access. Only the separate workflow_run
+# publisher receives contents:write, and it never checks out or executes the triggering revision.
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 concurrency:
   group: nightly-build
@@ -45,14 +45,47 @@ jobs:
     with:
       nightly: true
 
-  # A manual Nightly is the focused, no-side-effect validation path: it uses the exact build and
-  # publish preparation jobs, but stops before changing the rolling tag or GitHub Release.
-  publish-dry-run:
+  # Aggregate and checksum on the low-privilege build run. A manual Nightly stops here, making this
+  # the focused no-side-effect dry-run; a successful schedule hands these prepared files to the
+  # separate publisher as artifacts, never as executable code.
+  prepare:
+    name: Prepare nightly publish artifact
     needs: [plan, build]
-    if: github.event_name == 'workflow_dispatch' && needs.build.result == 'success'
-    uses: ./.github/workflows/nightly-publish.yml
-    secrets: inherit
-    with:
-      dry_run: true
-      source_run_id: ${{ github.run_id }}
-      source_sha: ${{ github.sha }}
+    if: needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Aggregate release certification evidence
+        run: >-
+          node scripts/ci/release-certification-evidence.mjs aggregate
+          --directory artifacts
+          --output artifacts/RELEASE-CERTIFICATION.json
+          --expected-sha "$GITHUB_SHA"
+
+      - name: Generate checksums
+        working-directory: artifacts
+        run: |
+          shopt -s nullglob
+          files=(*.dmg *.zip *.exe *.AppImage *.deb)
+          if [ ${#files[@]} -gt 0 ]; then
+            sha256sum "${files[@]}" > SHA256SUMS.txt
+            cat SHA256SUMS.txt
+          fi
+
+      - name: Upload prepared nightly metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: nightly-ready
+          retention-days: 1
+          path: |
+            artifacts/SHA256SUMS.txt
+            artifacts/RELEASE-CERTIFICATION.json
+          if-no-files-found: error

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,90 +1,58 @@
 name: Nightly
 
-# Rolling nightly build: every push to main rebuilds all platforms and refreshes a single
-# pre-release tagged `nightly`, so testers always have the latest main installers. This never
-# touches stable releases (see release.yml). Also runnable manually.
+# Batch main into one build per hour. A newer scheduled build may supersede an older build, while
+# publication is delegated to nightly-publish.yml and is never cancelled once it starts.
 on:
-  push:
-    branches:
-      - main
-    # Docs-only pushes don't change the app, so skip the 4-platform build+publish for them.
-    # workflow_dispatch below still forces a nightly regardless of what changed.
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
+  schedule:
+    - cron: '17 * * * *'
   workflow_dispatch:
 
+# The manual path calls the real publish workflow in dry-run mode. Reusable workflows cannot elevate
+# permissions above their caller, so contents:write is declared even though that path never publishes.
 permissions:
+  actions: read
   contents: write
 
-# A newer push supersedes an in-flight nightly — no point finishing a stale one.
 concurrency:
-  group: nightly
+  group: nightly-build
   cancel-in-progress: true
 
 jobs:
+  plan:
+    name: Check for unpublished main changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
+    steps:
+      - name: Compare main with the rolling nightly tag
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          published=$(gh api "repos/$GITHUB_REPOSITORY/commits/nightly" --jq .sha 2>/dev/null || true)
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$published" != "$GITHUB_SHA" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "Nightly already points at $GITHUB_SHA; there is no new batch to build."
+          fi
+
   build:
+    needs: plan
+    if: needs.plan.outputs.should_build == 'true'
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
       nightly: true
 
-  publish:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Download all build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Aggregate release certification evidence
-        run: >-
-          node scripts/ci/release-certification-evidence.mjs aggregate
-          --directory artifacts
-          --output artifacts/RELEASE-CERTIFICATION.json
-          --expected-sha "$GITHUB_SHA"
-
-      - name: Generate checksums
-        working-directory: artifacts
-        run: |
-          shopt -s nullglob
-          files=(*.dmg *.zip *.exe *.AppImage *.deb)
-          if [ ${#files[@]} -gt 0 ]; then
-            sha256sum "${files[@]}" > SHA256SUMS.txt
-            cat SHA256SUMS.txt
-          fi
-
-      # Delete the previous nightly release and its tag so the new one is a clean rolling snapshot
-      # pointing at the current commit (otherwise the tag would lag behind main).
-      - name: Reset nightly release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release delete nightly --cleanup-tag --yes || true
-
-      - name: Publish nightly pre-release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          tag_name: nightly
-          target_commitish: ${{ github.sha }}
-          name: Nightly (latest main)
-          prerelease: true
-          body: |
-            Automated build of the latest `main` (${{ github.sha }}).
-
-            ⚠️ Unstable pre-release. macOS builds are ad-hoc signed (not notarized): on first launch
-            right-click → Open, or run `xattr -dr com.apple.quarantine "<app>"`.
-          files: |
-            artifacts/*.dmg
-            artifacts/*.zip
-            artifacts/*.exe
-            artifacts/*.AppImage
-            artifacts/*.deb
-            artifacts/SHA256SUMS.txt
-            artifacts/RELEASE-CERTIFICATION.json
+  # A manual Nightly is the focused, no-side-effect validation path: it uses the exact build and
+  # publish preparation jobs, but stops before changing the rolling tag or GitHub Release.
+  publish-dry-run:
+    needs: [plan, build]
+    if: github.event_name == 'workflow_dispatch' && needs.build.result == 'success'
+    uses: ./.github/workflows/nightly-publish.yml
+    secrets: inherit
+    with:
+      dry_run: true
+      source_run_id: ${{ github.run_id }}
+      source_sha: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,129 +60,6 @@ jobs:
     uses: ./.github/workflows/notarize-mac.yml
     secrets: inherit
 
-  # The reusable build already hard-gates a fresh NSIS install/start/uninstall. On stable tags, also
-  # install the latest published stable version, prove electron-updater uses a differential Range
-  # download, upgrade over a live process, roll back, and restart current. Runs beside notarization.
-  windows-upgrade-smoke:
-    needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    runs-on: windows-latest
-    # Windows packages are intentionally unsigned until a certificate is provisioned. This historical
-    # upgrade drill is timing-sensitive on hosted runners, so keep its failure visible without blocking
-    # the independently certified packages and macOS notarization from being published.
-    continue-on-error: true
-    timeout-minutes: 40
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 22
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts --no-audit --no-fund
-
-      - name: Download current Windows installer
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: windows-x64
-          path: current
-
-      - name: Download previous stable Windows installer
-        id: previous
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CURRENT_TAG: ${{ github.ref_name }}
-        run: |
-          New-Item -ItemType Directory -Force previous | Out-Null
-          $releases = gh release list --exclude-drafts --exclude-pre-releases --limit 20 --json tagName
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $tag = ($releases | ConvertFrom-Json | Where-Object { $_.tagName -like 'v*' -and $_.tagName -ne $env:CURRENT_TAG } | Select-Object -First 1).tagName
-          if ([string]::IsNullOrWhiteSpace($tag)) {
-            "available=false" >> $env:GITHUB_OUTPUT
-            "reason=no-previous-stable-release" >> $env:GITHUB_OUTPUT
-            Write-Host "No previous stable release is available; fresh-install smoke already passed."
-            exit 0
-          }
-          gh release download $tag --pattern '*-win-x64-setup.exe' --pattern '*-win-x64-setup.exe.blockmap' --dir previous
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          "available=true" >> $env:GITHUB_OUTPUT
-          "tag=$tag" >> $env:GITHUB_OUTPUT
-
-      - name: Certify Windows electron-updater differential update
-        id: updater
-        if: steps.previous.outputs.available == 'true'
-        continue-on-error: true
-        shell: pwsh
-        run: |
-          node scripts/windows-updater-certification.mjs `
-            --current-dir current `
-            --previous-dir previous `
-            --output windows-updater-observation.json 2>&1 |
-            Tee-Object -FilePath windows-updater-certification.log
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Drill Windows silent upgrade, process lock, rollback, and restart
-        id: installer
-        if: always() && steps.previous.outputs.available == 'true'
-        continue-on-error: true
-        shell: pwsh
-        run: |
-          node scripts/windows-installer-smoke.mjs `
-            --installer-dir current `
-            --previous-installer-dir previous 2>&1 |
-            Tee-Object -FilePath windows-installer-certification.log
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Record Windows update-drill evidence
-        if: always()
-        shell: pwsh
-        run: |
-          $available = '${{ steps.previous.outputs.available }}' -eq 'true'
-          $passed = '${{ steps.updater.outcome }}' -eq 'success' -and '${{ steps.installer.outcome }}' -eq 'success'
-          $status = if (-not $available) { 'not-applicable' } elseif ($passed) { 'passed' } else { 'failed' }
-          $arguments = @(
-            'scripts/ci/release-certification-evidence.mjs', 'write-windows-update',
-            '--output', 'certification-windows-update.json',
-            '--current-tag', '${{ github.ref_name }}',
-            '--status', $status
-          )
-          if ($available) {
-            $arguments += @('--previous-tag', '${{ steps.previous.outputs.tag }}')
-            if (Test-Path 'windows-updater-observation.json') {
-              $arguments += @('--updater-observation', 'windows-updater-observation.json')
-            }
-            if (-not $passed) {
-              $arguments += @('--reason', 'updater=${{ steps.updater.outcome }},installer=${{ steps.installer.outcome }}')
-            }
-          } else {
-            $arguments += @('--reason', '${{ steps.previous.outputs.reason }}')
-          }
-          & node @arguments
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Upload Windows update-drill evidence
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: windows-update-certification
-          retention-days: 1
-          path: |
-            certification-windows-update.json
-            windows-*-certification.log
-          if-no-files-found: error
-
-      - name: Report Windows update-drill outcome
-        if: >-
-          always() && steps.previous.outputs.available == 'true' &&
-          (steps.updater.outcome != 'success' || steps.installer.outcome != 'success')
-        run: exit 1
-
   # Collect every platform's artifacts and publish them to the tag's Release in one shot (a single
   # publish job avoids the race of multiple build jobs writing the same Release). Depends on
   # notarize-mac so the mac dmg/zip it downloads are the stapled versions.
@@ -273,3 +150,14 @@ jobs:
             artifacts/latest-linux.yml
             artifacts/*-mac.yml
             artifacts/*.blockmap
+
+      # The historical upgrade drill consumes the published installer and reports independently.
+      # Dispatch failure is advisory too: it must not invalidate assets already certified above.
+      - name: Dispatch advisory Windows upgrade smoke
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          gh api --method POST "repos/$GITHUB_REPOSITORY/dispatches"
+          --field event_type=windows-upgrade-smoke
+          --field "client_payload[tag]=$GITHUB_REF_NAME"

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -23,13 +23,13 @@ concurrency:
 
 jobs:
   windows_full_test:
-    name: Windows full test (${{ matrix.shard }}/2)
+    name: Windows full test (${{ matrix.shard }}/3)
     runs-on: windows-latest
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -48,4 +48,4 @@ jobs:
         # every available core, and hosted-runner disk latency occasionally exceeds the default
         # per-test/hook budgets. Keep files serial and use bounded 60-second budgets; the 25-minute
         # job timeout remains the backstop for a real hang.
-        run: npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000
+        run: npm test -- --shard=${{ matrix.shard }}/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000

--- a/.github/workflows/windows-upgrade-smoke.yml
+++ b/.github/workflows/windows-upgrade-smoke.yml
@@ -1,0 +1,148 @@
+name: Windows Upgrade Smoke
+
+# Advisory post-release validation. It consumes published assets, so it cannot extend or block the
+# stable Release workflow. A failure is intentionally red here and can be rerun for the same tag.
+on:
+  repository_dispatch:
+    types:
+      - windows-upgrade-smoke
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Published stable tag to validate
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-upgrade-smoke-${{ github.event.client_payload.tag || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  windows-upgrade-smoke:
+    runs-on: windows-latest
+    timeout-minutes: 40
+    env:
+      CURRENT_TAG: ${{ github.event.client_payload.tag || inputs.tag }}
+    steps:
+      - name: Checkout released revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CURRENT_TAG }}
+
+      - name: Resolve released revision
+        id: current
+        shell: pwsh
+        run: "'sha=' + (git rev-parse HEAD) >> $env:GITHUB_OUTPUT"
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Download current Windows installer
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          New-Item -ItemType Directory -Force current | Out-Null
+          gh release download $env:CURRENT_TAG --pattern '*-win-x64-setup.exe' --pattern '*-win-x64-setup.exe.blockmap' --dir current
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Download previous stable Windows installer
+        id: previous
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          New-Item -ItemType Directory -Force previous | Out-Null
+          $releases = gh release list --exclude-drafts --exclude-pre-releases --limit 20 --json tagName
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $tag = ($releases | ConvertFrom-Json | Where-Object { $_.tagName -like 'v*' -and $_.tagName -ne $env:CURRENT_TAG } | Select-Object -First 1).tagName
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            "available=false" >> $env:GITHUB_OUTPUT
+            "reason=no-previous-stable-release" >> $env:GITHUB_OUTPUT
+            Write-Host "No previous stable release is available; fresh-install smoke already passed."
+            exit 0
+          }
+          gh release download $tag --pattern '*-win-x64-setup.exe' --pattern '*-win-x64-setup.exe.blockmap' --dir previous
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "available=true" >> $env:GITHUB_OUTPUT
+          "tag=$tag" >> $env:GITHUB_OUTPUT
+
+      - name: Certify Windows electron-updater differential update
+        id: updater
+        if: steps.previous.outputs.available == 'true'
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          node scripts/windows-updater-certification.mjs `
+            --current-dir current `
+            --previous-dir previous `
+            --output windows-updater-observation.json 2>&1 |
+            Tee-Object -FilePath windows-updater-certification.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Drill Windows silent upgrade, process lock, rollback, and restart
+        id: installer
+        if: always() && steps.previous.outputs.available == 'true'
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          node scripts/windows-installer-smoke.mjs `
+            --installer-dir current `
+            --previous-installer-dir previous 2>&1 |
+            Tee-Object -FilePath windows-installer-certification.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Record Windows update-drill evidence
+        if: always()
+        shell: pwsh
+        env:
+          GITHUB_SHA: ${{ steps.current.outputs.sha }}
+        run: |
+          $available = '${{ steps.previous.outputs.available }}' -eq 'true'
+          $passed = '${{ steps.updater.outcome }}' -eq 'success' -and '${{ steps.installer.outcome }}' -eq 'success'
+          $status = if (-not $available) { 'not-applicable' } elseif ($passed) { 'passed' } else { 'failed' }
+          $arguments = @(
+            'scripts/ci/release-certification-evidence.mjs', 'write-windows-update',
+            '--output', 'certification-windows-update.json',
+            '--current-tag', $env:CURRENT_TAG,
+            '--status', $status
+          )
+          if ($available) {
+            $arguments += @('--previous-tag', '${{ steps.previous.outputs.tag }}')
+            if (Test-Path 'windows-updater-observation.json') {
+              $arguments += @('--updater-observation', 'windows-updater-observation.json')
+            }
+            if (-not $passed) {
+              $arguments += @('--reason', 'updater=${{ steps.updater.outcome }},installer=${{ steps.installer.outcome }}')
+            }
+          } else {
+            $arguments += @('--reason', '${{ steps.previous.outputs.reason }}')
+          }
+          & node @arguments
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload Windows update-drill evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: windows-update-certification-${{ env.CURRENT_TAG }}
+          retention-days: 7
+          path: |
+            certification-windows-update.json
+            windows-*-certification.log
+          if-no-files-found: error
+
+      - name: Report Windows update-drill outcome
+        if: >-
+          always() && steps.previous.outputs.available == 'true' &&
+          (steps.updater.outcome != 'success' || steps.installer.outcome != 'success')
+        run: exit 1

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -129,9 +129,15 @@ describe('release and scheduled workflow topology', () => {
     expect(plan.if).toContain("github.event.workflow_run.conclusion == 'success'")
     expect(plan.if).toContain("github.event.workflow_run.event == 'schedule'")
     expect(plan.if).toContain("github.event.workflow_run.head_branch == 'main'")
-    expect(step(plan, 'Check for an unpublished build').run).toContain(
-      'repos/$GITHUB_REPOSITORY/commits/nightly'
-    )
+    const publicationPlan = step(plan, 'Check for an unpublished build').run
+    expect(publicationPlan).toContain('repos/$GITHUB_REPOSITORY/commits/nightly')
+    expect(publicationPlan).toContain('repos/$GITHUB_REPOSITORY/compare/$published...$SOURCE_SHA')
+    expect(publicationPlan).toContain("grep -Eq 'HTTP (404|422)'")
+    expect(publicationPlan).toContain('cat "$error_file" >&2')
+    expect(publicationPlan).toContain('ahead)')
+    expect(publicationPlan).toContain('identical|behind)')
+    expect(publicationPlan).toContain('skipping stale publication')
+    expect(publicationPlan).toContain('Cannot safely advance nightly')
     expect(publish).toMatchObject({
       needs: 'plan',
       if: "needs.plan.outputs.should_publish == 'true'"

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -1,0 +1,187 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { load } from 'js-yaml'
+import { describe, expect, it } from 'vitest'
+
+type Step = {
+  'continue-on-error'?: boolean
+  env?: Record<string, string>
+  if?: string
+  name?: string
+  run?: string
+  uses?: string
+  with?: Record<string, unknown>
+}
+
+type Job = {
+  'continue-on-error'?: boolean
+  env?: Record<string, string>
+  if?: string
+  needs?: string | string[]
+  steps?: Step[]
+  strategy?: { matrix?: { shard?: number[] } }
+  uses?: string
+  with?: Record<string, unknown>
+}
+
+type Workflow = {
+  concurrency?: { 'cancel-in-progress'?: boolean; group?: string }
+  jobs: Record<string, Job>
+  on?: Record<string, unknown>
+}
+
+const workflow = (name: string): Workflow =>
+  load(readFileSync(join(process.cwd(), '.github/workflows', name), 'utf8')) as Workflow
+
+const step = (job: Job, name: string): Step => {
+  const result = job.steps?.find((candidate) => candidate.name === name)
+  if (!result) throw new Error(`Missing step: ${name}`)
+  return result
+}
+
+describe('release and scheduled workflow topology', () => {
+  it('runs three serial Windows full-suite shards', () => {
+    const job = workflow('windows-full-test.yml').jobs.windows_full_test
+    const test = step(job, 'Test complete suite shard')
+
+    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3])
+    expect(test.run).toContain('--shard=${{ matrix.shard }}/3')
+    expect(test.run).toContain('--maxWorkers=1')
+  })
+
+  it('runs reusable verification beside native builds while callers remain fail closed', () => {
+    const build = workflow('build.yml').jobs.build
+    const nightly = workflow('nightly.yml')
+    const release = workflow('release.yml')
+
+    expect(build.needs).toBe('setup')
+    expect(build.if).toBe("${{ needs.setup.result == 'success' }}")
+    expect(nightly.jobs['publish-dry-run'].needs).toEqual(['plan', 'build'])
+    expect(release.jobs.publish.needs).toEqual(['build', 'notarize-mac'])
+    expect(release.jobs['notarize-mac'].needs).toBe('build')
+  })
+
+  it('batches Nightly hourly and limits manual runs to the real publish dry-run', () => {
+    const nightly = workflow('nightly.yml')
+    const schedule = nightly.on?.schedule as Array<{ cron: string }>
+
+    expect(nightly.on).not.toHaveProperty('push')
+    expect(schedule).toEqual([{ cron: '17 * * * *' }])
+    expect(nightly.on).toHaveProperty('workflow_dispatch')
+    expect(nightly.concurrency).toEqual({
+      group: 'nightly-build',
+      'cancel-in-progress': true
+    })
+    expect(nightly.jobs.build).toMatchObject({
+      needs: 'plan',
+      if: "needs.plan.outputs.should_build == 'true'",
+      uses: './.github/workflows/build.yml',
+      with: { nightly: true }
+    })
+    expect(step(nightly.jobs.plan, 'Compare main with the rolling nightly tag').run).toContain(
+      'repos/$GITHUB_REPOSITORY/commits/nightly'
+    )
+    expect(nightly.jobs['publish-dry-run']).toMatchObject({
+      needs: ['plan', 'build'],
+      if: "github.event_name == 'workflow_dispatch' && needs.build.result == 'success'",
+      uses: './.github/workflows/nightly-publish.yml',
+      with: {
+        dry_run: true,
+        source_run_id: '${{ github.run_id }}',
+        source_sha: '${{ github.sha }}'
+      }
+    })
+  })
+
+  it('serializes successful scheduled Nightly publication without cancellation', () => {
+    const publishWorkflow = workflow('nightly-publish.yml')
+    const plan = publishWorkflow.jobs.plan
+    const publish = publishWorkflow.jobs.publish
+    const download = step(publish, 'Download all build artifacts')
+    const reset = step(publish, 'Reset nightly release')
+    const release = step(publish, 'Publish nightly pre-release')
+    const dryRun = step(publish, 'Upload prepared nightly dry-run')
+    const workflowRun = publishWorkflow.on?.workflow_run as {
+      types: string[]
+      workflows: string[]
+    }
+
+    expect(workflowRun).toEqual({ workflows: ['Nightly'], types: ['completed'] })
+    expect(publishWorkflow.on).toHaveProperty('workflow_call')
+    expect(publishWorkflow.concurrency).toEqual({
+      group: 'nightly-publish',
+      'cancel-in-progress': false
+    })
+    expect(plan.if).toContain("github.event.workflow_run.conclusion == 'success'")
+    expect(plan.if).toContain("github.event.workflow_run.event == 'schedule'")
+    expect(plan.if).toContain("github.event.workflow_run.head_branch == 'main'")
+    expect(step(plan, 'Check for an unpublished build').run).toContain(
+      'repos/$GITHUB_REPOSITORY/commits/nightly'
+    )
+    expect(publish).toMatchObject({
+      needs: 'plan',
+      if: "needs.plan.outputs.should_publish == 'true'"
+    })
+    expect(download.with).toMatchObject({
+      'github-token': '${{ secrets.GITHUB_TOKEN }}',
+      'run-id': '${{ env.SOURCE_RUN_ID }}',
+      'merge-multiple': true
+    })
+    expect(dryRun.if).toBe("env.DRY_RUN == 'true'")
+    expect(reset.if).toBe("env.DRY_RUN != 'true'")
+    expect(release.if).toBe("env.DRY_RUN != 'true'")
+  })
+
+  it('dispatches the advisory Windows upgrade drill only after stable publication', () => {
+    const releaseWorkflow = workflow('release.yml')
+    const publishSteps = releaseWorkflow.jobs.publish.steps ?? []
+    const publishIndex = publishSteps.findIndex(({ name }) => name === 'Publish GitHub Release')
+    const dispatchIndex = publishSteps.findIndex(
+      ({ name }) => name === 'Dispatch advisory Windows upgrade smoke'
+    )
+
+    expect(releaseWorkflow.jobs).not.toHaveProperty('windows-upgrade-smoke')
+    expect(dispatchIndex).toBeGreaterThan(publishIndex)
+    expect(publishSteps[dispatchIndex]).toMatchObject({
+      'continue-on-error': true,
+      env: { GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
+    })
+    expect(publishSteps[dispatchIndex].run).toContain('event_type=windows-upgrade-smoke')
+    expect(publishSteps[dispatchIndex].run).toContain('client_payload[tag]=$GITHUB_REF_NAME')
+  })
+
+  it('runs Windows upgrade smoke independently against published release assets', () => {
+    const smokeWorkflow = workflow('windows-upgrade-smoke.yml')
+    const smoke = smokeWorkflow.jobs['windows-upgrade-smoke']
+    const dispatch = smokeWorkflow.on?.repository_dispatch as { types: string[] }
+
+    expect(dispatch.types).toEqual(['windows-upgrade-smoke'])
+    expect(smokeWorkflow.on).toHaveProperty('workflow_dispatch')
+    expect(smokeWorkflow.concurrency?.['cancel-in-progress']).toBe(false)
+    expect(smoke['continue-on-error']).toBeUndefined()
+    expect(step(smoke, 'Download current Windows installer').run).toContain(
+      'gh release download $env:CURRENT_TAG'
+    )
+    expect(step(smoke, 'Upload Windows update-drill evidence').if).toBe('always()')
+    expect(step(smoke, 'Report Windows update-drill outcome').run).toBe('exit 1')
+  })
+
+  it('pins third-party actions in every changed workflow', () => {
+    for (const name of [
+      'build.yml',
+      'nightly.yml',
+      'nightly-publish.yml',
+      'release.yml',
+      'windows-full-test.yml',
+      'windows-upgrade-smoke.yml'
+    ]) {
+      for (const job of Object.values(workflow(name).jobs)) {
+        for (const candidate of job.steps ?? []) {
+          if (!candidate.uses || candidate.uses.startsWith('./')) continue
+          expect(candidate.uses, `${name}: ${candidate.name}`).toMatch(/^[^@]+@[0-9a-f]{40}$/)
+        }
+      }
+    }
+  })
+})

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -19,6 +19,7 @@ type Job = {
   env?: Record<string, string>
   if?: string
   needs?: string | string[]
+  'runs-on'?: string
   steps?: Step[]
   strategy?: { matrix?: { shard?: number[] } }
   uses?: string
@@ -29,6 +30,7 @@ type Workflow = {
   concurrency?: { 'cancel-in-progress'?: boolean; group?: string }
   jobs: Record<string, Job>
   on?: Record<string, unknown>
+  permissions?: Record<string, string>
 }
 
 const workflow = (name: string): Workflow =>
@@ -57,18 +59,20 @@ describe('release and scheduled workflow topology', () => {
 
     expect(build.needs).toBe('setup')
     expect(build.if).toBe("${{ needs.setup.result == 'success' }}")
-    expect(nightly.jobs['publish-dry-run'].needs).toEqual(['plan', 'build'])
+    expect(nightly.jobs.prepare.needs).toEqual(['plan', 'build'])
     expect(release.jobs.publish.needs).toEqual(['build', 'notarize-mac'])
     expect(release.jobs['notarize-mac'].needs).toBe('build')
   })
 
-  it('batches Nightly hourly and limits manual runs to the real publish dry-run', () => {
+  it('batches Nightly hourly and prepares publication without write access', () => {
     const nightly = workflow('nightly.yml')
     const schedule = nightly.on?.schedule as Array<{ cron: string }>
+    const prepare = nightly.jobs.prepare
 
     expect(nightly.on).not.toHaveProperty('push')
     expect(schedule).toEqual([{ cron: '17 * * * *' }])
     expect(nightly.on).toHaveProperty('workflow_dispatch')
+    expect(nightly.permissions).toEqual({ actions: 'read', contents: 'read' })
     expect(nightly.concurrency).toEqual({
       group: 'nightly-build',
       'cancel-in-progress': true
@@ -82,33 +86,42 @@ describe('release and scheduled workflow topology', () => {
     expect(step(nightly.jobs.plan, 'Compare main with the rolling nightly tag').run).toContain(
       'repos/$GITHUB_REPOSITORY/commits/nightly'
     )
-    expect(nightly.jobs['publish-dry-run']).toMatchObject({
+    expect(nightly.jobs).not.toHaveProperty('publish-dry-run')
+    expect(prepare).toMatchObject({
       needs: ['plan', 'build'],
-      if: "github.event_name == 'workflow_dispatch' && needs.build.result == 'success'",
-      uses: './.github/workflows/nightly-publish.yml',
-      with: {
-        dry_run: true,
-        source_run_id: '${{ github.run_id }}',
-        source_sha: '${{ github.sha }}'
-      }
+      if: "needs.build.result == 'success'",
+      'runs-on': 'ubuntu-latest'
+    })
+    expect(step(prepare, 'Aggregate release certification evidence').run).toContain(
+      '--expected-sha "$GITHUB_SHA"'
+    )
+    expect(step(prepare, 'Generate checksums').run).toContain('sha256sum')
+    expect(step(prepare, 'Upload prepared nightly metadata').with).toMatchObject({
+      name: 'nightly-ready',
+      'retention-days': 1,
+      'if-no-files-found': 'error'
     })
   })
 
-  it('serializes successful scheduled Nightly publication without cancellation', () => {
+  it('publishes prepared scheduled artifacts without executing triggering-run code', () => {
     const publishWorkflow = workflow('nightly-publish.yml')
     const plan = publishWorkflow.jobs.plan
     const publish = publishWorkflow.jobs.publish
-    const download = step(publish, 'Download all build artifacts')
+    const download = step(publish, 'Download prepared nightly artifacts')
     const reset = step(publish, 'Reset nightly release')
     const release = step(publish, 'Publish nightly pre-release')
-    const dryRun = step(publish, 'Upload prepared nightly dry-run')
     const workflowRun = publishWorkflow.on?.workflow_run as {
+      branches: string[]
       types: string[]
       workflows: string[]
     }
 
-    expect(workflowRun).toEqual({ workflows: ['Nightly'], types: ['completed'] })
-    expect(publishWorkflow.on).toHaveProperty('workflow_call')
+    expect(workflowRun).toEqual({
+      workflows: ['Nightly'],
+      types: ['completed'],
+      branches: ['main']
+    })
+    expect(publishWorkflow.on).not.toHaveProperty('workflow_call')
     expect(publishWorkflow.concurrency).toEqual({
       group: 'nightly-publish',
       'cancel-in-progress': false
@@ -128,9 +141,15 @@ describe('release and scheduled workflow topology', () => {
       'run-id': '${{ env.SOURCE_RUN_ID }}',
       'merge-multiple': true
     })
-    expect(dryRun.if).toBe("env.DRY_RUN == 'true'")
-    expect(reset.if).toBe("env.DRY_RUN != 'true'")
-    expect(release.if).toBe("env.DRY_RUN != 'true'")
+    expect(step(publish, 'Verify prepared nightly metadata').run).toContain(
+      'test -s artifacts/RELEASE-CERTIFICATION.json'
+    )
+    expect(publish.steps?.some(({ uses }) => uses?.startsWith('actions/checkout@'))).toBe(false)
+    expect(
+      publish.steps?.some(({ run }) => run?.includes('release-certification-evidence.mjs'))
+    ).toBe(false)
+    expect(reset.if).toBeUndefined()
+    expect(release.if).toBeUndefined()
   })
 
   it('dispatches the advisory Windows upgrade drill only after stable publication', () => {

--- a/scripts/verify-runtime-bundle.mjs
+++ b/scripts/verify-runtime-bundle.mjs
@@ -2,10 +2,15 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
 import { pathToFileURL } from 'node:url'
+import { setTimeout as sleep } from 'node:timers/promises'
 
 import { VERSIONS, packArchiveFile, packId, readDefaultEnvVersion } from './stage-default-envs.mjs'
 
 export const DEFAULT_CDN_BASE = 'https://statics.aipoch.com/open-science'
+export const DEFAULT_MAX_ATTEMPTS = 3
+export const DEFAULT_RETRY_DELAY_MS = 1000
+
+const TRANSIENT_HTTP_STATUSES = new Set([403, 408, 425, 429, 500, 502, 503, 504])
 
 export const runtimeManifestUrl = (cdnBase, envVersion, subdir) =>
   `${cdnBase.replace(/\/+$/, '')}/runtime-bundle/${envVersion}/${subdir}/manifest.json`
@@ -41,11 +46,44 @@ export const validatePublishedManifest = (manifest, envVersion, subdir) => {
   }
 }
 
-export const verifyRuntimeBundle = async (cdnBase, envVersion, subdirs, fetchImpl = fetch) => {
+export const verifyRuntimeBundle = async (
+  cdnBase,
+  envVersion,
+  subdirs,
+  {
+    fetchImpl = fetch,
+    sleepImpl = sleep,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS
+  } = {}
+) => {
   for (const subdir of subdirs) {
     const url = runtimeManifestUrl(cdnBase, envVersion, subdir)
-    const response = await fetchImpl(url, { cache: 'no-store' })
-    if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`)
+    let response
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        response = await fetchImpl(url, { cache: 'no-store' })
+      } catch (error) {
+        if (attempt === maxAttempts) {
+          throw new Error(
+            `${url} request failed after ${attempt} attempts: ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+        console.warn(`[runtime-bundle] ${url} request failed; retrying (${attempt}/${maxAttempts})`)
+        await sleepImpl(retryDelayMs * attempt)
+        continue
+      }
+
+      if (response.ok) break
+      if (!TRANSIENT_HTTP_STATUSES.has(response.status) || attempt === maxAttempts) {
+        throw new Error(`${url} returned HTTP ${response.status} after ${attempt} attempt(s)`)
+      }
+      console.warn(
+        `[runtime-bundle] ${url} returned HTTP ${response.status}; retrying (${attempt}/${maxAttempts})`
+      )
+      await sleepImpl(retryDelayMs * attempt)
+    }
+
     const manifest = await response.json()
     validatePublishedManifest(manifest, envVersion, subdir)
     console.log(`[runtime-bundle] verified ${url}`)

--- a/scripts/verify-runtime-bundle.test.ts
+++ b/scripts/verify-runtime-bundle.test.ts
@@ -50,7 +50,37 @@ describe('runtime bundle release preflight', () => {
   it('fails closed on an unavailable manifest', async () => {
     const fetchImpl = vi.fn(async () => ({ ok: false, status: 404 }))
     await expect(
-      verifyRuntimeBundle('https://cdn.example', 1, ['linux-64'], fetchImpl)
+      verifyRuntimeBundle('https://cdn.example', 1, ['linux-64'], { fetchImpl })
     ).rejects.toThrow(/HTTP 404/)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a transient HTTP 403 with bounded backoff', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 403 })
+      .mockResolvedValueOnce({ ok: false, status: 403 })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => manifest('linux-64') })
+    const sleepImpl = vi.fn(async () => undefined)
+
+    await verifyRuntimeBundle('https://cdn.example', 1, ['linux-64'], {
+      fetchImpl,
+      sleepImpl
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+    expect(sleepImpl).toHaveBeenNthCalledWith(1, 1000)
+    expect(sleepImpl).toHaveBeenNthCalledWith(2, 2000)
+  })
+
+  it('fails closed after the transient retry budget is exhausted', async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 403 }))
+    const sleepImpl = vi.fn(async () => undefined)
+
+    await expect(
+      verifyRuntimeBundle('https://cdn.example', 1, ['win-64'], { fetchImpl, sleepImpl })
+    ).rejects.toThrow(/HTTP 403 after 3 attempt/)
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+    expect(sleepImpl).toHaveBeenCalledTimes(2)
   })
 })

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -61,9 +61,9 @@ describe('post-merge Windows validation', () => {
       'runs-on': 'windows-latest'
     })
     expect(job['continue-on-error']).toBeUndefined()
-    expect(job.strategy?.matrix?.shard).toEqual([1, 2])
+    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3])
     expect(findStep(job, 'Test complete suite shard').run).toBe(
-      'npm test -- --shard=${{ matrix.shard }}/2 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000'
+      'npm test -- --shard=${{ matrix.shard }}/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000'
     )
   })
 
@@ -250,11 +250,11 @@ describe('post-merge Windows validation', () => {
 
   it('records unsigned Windows update diagnostics without blocking publishing', () => {
     const release = readWorkflow('release.yml')
-    const upgrade = release.jobs['windows-upgrade-smoke']
+    const upgrade = readWorkflow('windows-upgrade-smoke.yml').jobs['windows-upgrade-smoke']
 
     expect(upgrade['runs-on']).toBe('windows-latest')
-    expect(upgrade.needs).toBe('build')
-    expect(upgrade['continue-on-error']).toBe(true)
+    expect(upgrade.needs).toBeUndefined()
+    expect(upgrade['continue-on-error']).toBeUndefined()
     expect(upgrade['timeout-minutes']).toBe(40)
     expect(findStep(upgrade, 'Setup Node')).toMatchObject({
       uses: 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020',
@@ -263,11 +263,10 @@ describe('post-merge Windows validation', () => {
     expect(findStep(upgrade, 'Install dependencies').run).toBe(
       'npm ci --ignore-scripts --no-audit --no-fund'
     )
-    expect(findStep(upgrade, 'Download current Windows installer').uses).toBe(
-      'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c'
+    expect(findStep(upgrade, 'Download current Windows installer').run).toContain(
+      'gh release download $env:CURRENT_TAG'
     )
     const previous = findStep(upgrade, 'Download previous stable Windows installer')
-    expect(previous.env?.CURRENT_TAG).toBe('${{ github.ref_name }}')
     expect(previous.run).toContain('gh release download')
     expect(previous.run).toContain('*-win-x64-setup.exe.blockmap')
     expect(previous.run).not.toContain('Get-AuthenticodeSignature')
@@ -288,6 +287,7 @@ describe('post-merge Windows validation', () => {
       findStep(upgrade, 'Drill Windows silent upgrade, process lock, rollback, and restart')
     ).toMatchObject({ id: 'installer', 'continue-on-error': true })
     expect(release.jobs['windows-full-test']).toBeUndefined()
+    expect(release.jobs['windows-upgrade-smoke']).toBeUndefined()
     expect(release.jobs.publish.needs).toEqual(['build', 'notarize-mac'])
     expect(
       findStep(release.jobs.publish, 'Aggregate release certification evidence').run
@@ -314,6 +314,12 @@ describe('post-merge Windows validation', () => {
       })
     })
     expect(findStep(upgrade, 'Report Windows update-drill outcome').run).toBe('exit 1')
+    expect(findStep(release.jobs.publish, 'Dispatch advisory Windows upgrade smoke')).toMatchObject(
+      {
+        'continue-on-error': true,
+        run: expect.stringContaining('event_type=windows-upgrade-smoke')
+      }
+    )
     expect(release.jobs.mirror).toBeUndefined()
   })
 
@@ -343,7 +349,7 @@ describe('post-merge Windows validation', () => {
     expect(release.jobs.build.needs).toBe('release-preflight')
     expect(release.jobs.build.with?.require_windows_signing).toBeUndefined()
     expect(release.jobs['notarize-mac'].if).toBe(stableTagCondition)
-    expect(release.jobs['windows-upgrade-smoke'].if).toBe(stableTagCondition)
+    expect(release.jobs['windows-upgrade-smoke']).toBeUndefined()
     expect(release.jobs.publish.if).toBe(stableTagCondition)
   })
 
@@ -396,7 +402,11 @@ describe('post-merge Windows validation', () => {
   })
 
   it('pins external actions in every changed release workflow', () => {
-    for (const workflowName of ['release.yml', 'mirror-to-website.yml']) {
+    for (const workflowName of [
+      'release.yml',
+      'mirror-to-website.yml',
+      'windows-upgrade-smoke.yml'
+    ]) {
       const workflow = readWorkflow(workflowName)
       const references = Object.values(workflow.jobs).flatMap((job) =>
         (job.steps ?? []).flatMap(({ uses }) => (uses?.startsWith('./') || !uses ? [] : [uses]))


### PR DESCRIPTION
## Problem

Nightly rebuilt and republished on every `main` push, so frequent pushes cancelled expensive native
builds and wasted hosted runners. The reusable release build also serialized verification before the
platform matrix, Windows full coverage had two long serial shards, and the advisory historical
Windows upgrade drill kept stable Release runs open while waiting for a Windows runner. Transient CDN
403 responses could also fail an otherwise healthy package build immediately.

## Proposed change

- Batch Nightly at minute 17 of every hour and skip a batch when the rolling `nightly` tag already
  points at the current `main` commit.
- Prepare Nightly certification metadata and checksums in the read-only build workflow. Move real
  publication into a serialized `workflow_run` workflow with `cancel-in-progress: false`; the
  privileged publisher never checks out or executes triggering-run code, while manual Nightly runs
  stop after producing the no-side-effect `nightly-ready` artifact.
- Run reusable-workflow verification beside the platform matrix while retaining fail-closed publish
  dependencies at every caller.
- Split Windows Full Test from two to three shards while retaining `maxWorkers=1`.
- Retry transient runtime-bundle CDN failures three times with bounded 1s/2s backoff.
- Dispatch the historical Windows upgrade drill after stable assets publish, and run it as an
  independent advisory workflow against those published assets.

## Scope and non-goals

- Stable Release asset certification, macOS notarization, and publish dependencies remain blocking.
- The advisory Windows upgrade drill does not become a stable-release gate.
- Runner images, application code, signing policy, package contents, and release artifact retention
  are unchanged.
- Manual Nightly runs validate publication preparation but cannot overwrite the rolling release.

## Acceptance criteria and validation

Final Test Impact Set mapping (all listed focused checks ran after the final material edit):

- Workflow topology, trigger guards, concurrency, artifact handoff, action pinning, and advisory
  isolation -> `vitest run scripts/ci scripts/verify-runtime-bundle.test.ts scripts/windows-release-workflows.test.ts`
  -> 14 files, 176 tests passed after rebasing onto current `main`.
- TypeScript consumers -> `npm run typecheck` -> passed.
- Linted workflow tests/runtime script -> `npm run lint` -> passed with 17 pre-existing warnings and
  no errors.
- Formatting -> Prettier check for all changed files -> passed.
- Full Nightly build plus read-only publish preparation -> Actions run 31223910062 -> passed; all
  four platform builds, Verify, evidence aggregation, checksums, and the `nightly-ready` artifact
  succeeded without changing a Release.
- Privileged workflow security boundary -> CodeQL check 93014242278 -> passed with no new alerts and
  zero annotations after removing the `workflow_run` source checkout.
- Complete Windows portable suite -> Actions run 31221519591 -> all three serial shards passed in
  10.1-11.4 minutes.
- Local `npm test` exercised 12,571 tests: 12,266 passed before the three intentionally stale workflow
  assertions were updated. The remaining local failures require unavailable Windows symlink/ACL or
  subprocess capabilities, or were full-suite timing failures. Both target-runner suites above passed.

Uncovered pre-merge risks: GitHub only enables the new `workflow_run` and `repository_dispatch`
entrypoints from the default branch, so the real rolling Release mutation and post-release advisory
dispatch cannot be exercised before merge without side effects. Their event and side-effect guards
are covered by contract tests; the manual Nightly path exercises the complete read-only preparation
and the privileged publisher consumes artifacts without executing them.

## Review focus

- Confirm the `Nightly` completion guard admits only successful scheduled `main` runs and that the
  tag comparison safely suppresses empty hourly batches and duplicate publication.
- Confirm every real publish operation is excluded from the manual dry-run path.
- Confirm stable Release dispatch happens only after asset publication and remains advisory.
- Confirm the reusable build still reports verification failure to callers even though native jobs
  no longer depend directly on `verify`.
