### PR TITLE
ci(windows): include updater metadata in upgrade smoke

### DIFF
--- a/.github/workflows/windows-upgrade-smoke.yml
+++ b/.github/workflows/windows-upgrade-smoke.yml
@@ -52,7 +52,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           New-Item -ItemType Directory -Force current | Out-Null
-          gh release download $env:CURRENT_TAG --pattern '*-win-x64-setup.exe' --pattern '*-win-x64-setup.exe.blockmap' --dir current
+          gh release download $env:CURRENT_TAG --pattern '*-win-x64-setup.exe' --pattern '*-win-x64-setup.exe.blockmap' --pattern 'latest.yml' --dir current
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Download previous stable Windows installer

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -263,9 +263,9 @@ describe('post-merge Windows validation', () => {
     expect(findStep(upgrade, 'Install dependencies').run).toBe(
       'npm ci --ignore-scripts --no-audit --no-fund'
     )
-    expect(findStep(upgrade, 'Download current Windows installer').run).toContain(
-      'gh release download $env:CURRENT_TAG'
-    )
+    const current = findStep(upgrade, 'Download current Windows installer')
+    expect(current.run).toContain('gh release download $env:CURRENT_TAG')
+    expect(current.run).toContain("--pattern 'latest.yml'")
     const previous = findStep(upgrade, 'Download previous stable Windows installer')
     expect(previous.run).toContain('gh release download')
     expect(previous.run).toContain('*-win-x64-setup.exe.blockmap')


### PR DESCRIPTION
## Problem

The advisory Windows upgrade smoke downloaded the installer and blockmap but omitted latest.yml. The updater certification requires the published feed and failed before exercising the differential update path.

## Proposed change

- Download latest.yml with the current Windows release assets.
- Add a workflow contract assertion for the required updater feed.

## Scope and non-goals

This only corrects the inputs consumed by the advisory post-release smoke. It does not change release publishing, application update behavior, architecture, data, or user interaction.

## Acceptance criteria and validation

Final checks ran after the last material edit:

- Workflow asset contract -> focused Vitest run -> 10/10 passed.
- Published v0.11.2 differential updater and installer drill -> Windows Upgrade Smoke run 31228538789 -> passed.

The Windows hosted-runner lane was included because the production certification requires NSIS installation and electron-updater behavior. No additional application consumers are affected. A future release that omits latest.yml will continue to fail closed, as intended; transient release-download failures remain observable and rerunnable.

## Review focus

Confirm that the current release download includes every input required by windows-updater-certification.mjs while the previous release remains limited to the installer and blockmap.