### PR TITLE
docs(contributing): allow module-scoped local tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ Run installation, development, and validation commands from the repository root:
 | Install        | `npm install`                                              |
 | Run            | `npm run dev`                                              |
 | Target test    | `npm test -- <affected-test-path> [-t '<test pattern>']`   |
+| Module tests   | `npm run test:module -- <module-id>`                       |
 | Node typecheck | `npm run typecheck:node`                                   |
 | Web typecheck  | `npm run typecheck:web`                                    |
 | Lint           | `npm run lint`                                             |
@@ -160,12 +161,17 @@ Run `npm run typecheck`, `npm run lint`, and `npm test` when any of these apply:
 
 - the Owner Module, changed Interface, or consumers cannot be established;
 - global validation inputs change, including package metadata, TypeScript/Vitest/build configuration,
-  the PR Gate workflow, or its classifier and manifest;
+  the PR Gate workflow or classifier, or ownership, consumer, capability, or fallback routing in the
+  module-impact manifest;
 - the change crosses several runtime areas without a demonstrated impact map;
 - a release-candidate workflow or maintainer explicitly requests the complete local suite.
 
 Full fallback is a safety mechanism, not an unconditional prerequisite for every pull request.
 Contributors are not expected to reproduce every operating-system CI lane locally.
+
+Changing only `testFiles` within an already-owned Module does not trigger the full fallback. Run the
+manifest validation tests, `npm run test:module -- <module-id>`, the affected process typechecks and
+lint instead; exact-head CI remains authoritative for the complete portable and platform suites.
 
 ### CI authority and evidence
 


### PR DESCRIPTION
## Problem

The verification policy requires the full local fallback for every module-impact manifest edit, even
when a change only registers a test under an already-established Module. That duplicates the complete
portable suite locally without changing ownership or CI routing.

## Proposed change

- Document `npm run test:module -- <module-id>` in the root command table.
- Reserve the full local fallback for ownership, consumer, capability, or fallback-routing changes.
- Allow `testFiles`-only manifest edits to use manifest validation, the Module Test Impact Set,
  affected typechecks and lint.

## Scope and non-goals

- Documentation only.
- No script, classifier, manifest, workflow, or required-check change.
- No weakening of exact-head CI or its fail-closed behavior.

## Compatibility

Runtime, IPC, data, UI, Electron, Web, CLI, Task and platform behavior are unchanged.

## Acceptance criteria and validation

- The documented command matches the existing `test:module` package script.
- Local full-fallback conditions remain explicit for ownership or validation-routing changes.
- Exact-head CI remains authoritative for complete portable and platform suites.
- Markdown formatting and `git diff --check` pass.

## Review focus

Confirm that the exception applies only to `testFiles` updates inside an already-owned Module and
does not allow ownership or CI-routing changes to bypass the full local fallback.
