### PR TITLE
test(session-store): normalize architecture diagnostic paths

### DIFF
--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -508,6 +508,7 @@ const importsFrom = (path: string, source = readSource(path)): readonly ImportRe
 
 const importBoundaryViolations = (path: string, source = readSource(path)): readonly string[] => {
   const sourceTarget = modulePath(path)
+  const relativePath = normalizePathSeparators(relative(rendererRoot, path))
   const violations: string[] = []
   for (const reference of importsFrom(path, source)) {
     if (
@@ -515,7 +516,7 @@ const importBoundaryViolations = (path: string, source = readSource(path)): read
       !reference.literal &&
       sessionModuleTargets.has(sourceTarget)
     ) {
-      violations.push(`${relative(rendererRoot, path)} uses unresolved ${reference.kind}`)
+      violations.push(`${relativePath} uses unresolved ${reference.kind}`)
       continue
     }
     if (
@@ -523,7 +524,7 @@ const importBoundaryViolations = (path: string, source = readSource(path)): read
       privateOwnerTargets.has(reference.target) &&
       !sessionModuleTargets.has(sourceTarget)
     ) {
-      violations.push(`${relative(rendererRoot, path)} imports a private Session Store owner`)
+      violations.push(`${relativePath} imports a private Session Store owner`)
     }
     if (
       sourceTarget !== publicStoreTarget &&
@@ -532,7 +533,7 @@ const importBoundaryViolations = (path: string, source = readSource(path)): read
         !reference.names ||
         reference.names.some((name) => !publicBindings.has(name)))
     ) {
-      violations.push(`${relative(rendererRoot, path)} bypasses the public Session Store surface`)
+      violations.push(`${relativePath} bypasses the public Session Store surface`)
     }
   }
   return violations


### PR DESCRIPTION
## Problem

The Windows full-test shard in [Actions run 31238631609](https://github.com/aipoch/open-science/actions/runs/31238631609/job/93055674915) failed because the Session Store architecture guard emitted a native Windows path (`pages\workspace\...`) while the diagnostic contract expects stable forward slashes.

## Proposed change

Normalize the renderer-relative path once inside `importBoundaryViolations()` and reuse it for all three architecture violation messages.

## Scope and non-goals

- Changes only the test-owned architecture diagnostic formatting.
- Does not change Session Store production behavior, public interfaces, or consumer behavior.
- Does not modify CI workflow configuration.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Windows regression: `npm test -- src/renderer/src/stores/session-store.architecture.test.ts -t 'rejects dynamic owner access without banning unrelated lazy imports'` -> passed (1/1).
- Session Store architecture behavior: `npm test -- src/renderer/src/stores/session-store.architecture.test.ts` -> passed (12/12).
- Renderer type safety: `npm run typecheck:web` -> passed.
- Lint: `npm run lint` -> passed with 0 errors and 17 pre-existing warnings outside the changed file.
- Full portable suite: `npm test` -> did not pass locally (35 failures across 9 unrelated files); observed causes included Windows symlink/ACL permission failures, timeout-sensitive tests, and unrelated AI review workflow assertions. The changed architecture test passed in that run.

No production Interface or consumers changed, so no consumer lane is required. Windows is the affected platform and the exact regression was reproduced red then verified green locally. macOS/Linux-specific behavior is unchanged; PR Gate remains the authority for cross-platform validation.

Uncovered risk: the complete local suite could not provide a green signal because of the unrelated failures above. Independent review and PR checks are pending.

## Review focus

Confirm that architecture diagnostics should remain host-independent and use forward slashes consistently.