### PR TITLE
feat: support GitHub token for authenticated skill import API requests

### DIFF
--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -33,6 +33,7 @@ import {
   type SetConnectorAutoAllowRequest,
   type SetConnectorEnabledRequest,
   type SetNcbiCredentialsRequest,
+  type SetGitHubCredentialsRequest,
   type SetPackageMirrorRequest,
   type SetClosePreferenceRequest,
   type SetConversationSkillImportEnabledRequest,
@@ -320,6 +321,9 @@ const registerSettingsIpcHandlers = ({
   )
   ipcMainHandle('settings:set-ncbi-credentials', (_event, request: SetNcbiCredentialsRequest) =>
     workflows.connectors.setNcbiCredentials(request)
+  )
+  ipcMainHandle('settings:set-github-credentials', (_event, request: SetGitHubCredentialsRequest) =>
+    service.setGitHubCredentials(request)
   )
   ipcMainHandle('settings:add-custom-server', (_event, request: AddCustomServerRequest) =>
     workflows.connectors.addCustomServer(request)

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -537,6 +537,11 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
       normalized.length > root.length ? normalized.replace(/[\\/]+$/, '') : normalized
   }
 
+  // GitHub personal access token for authenticated skill import API requests.
+  const githubTokenRef = asString(value.githubTokenRef)
+
+  if (githubTokenRef) settings.githubTokenRef = githubTokenRef
+
   // Selected agent backend; only the known ids survive so a bad value can't leak through.
   const agentFrameworkId = asString(value.agentFrameworkId)
 
@@ -1192,6 +1197,14 @@ class SettingsRepository {
       connectors.contactEmail = contactEmail || undefined
       connectors.ncbiApiKeyRef = apiKeyRef || undefined
     })
+  }
+
+  // Sets or clears the GitHub personal access token reference for authenticated skill import.
+  async setGitHubCredentials(tokenRef: string | undefined): Promise<StoredSettings> {
+    return this.mutate((settings) => ({
+      ...settings,
+      githubTokenRef: tokenRef || undefined
+    }))
   }
 
   // Appends a fully-formed custom MCP server record.

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -30,6 +30,7 @@ import type {
   SetConnectorAutoAllowRequest,
   SetConnectorEnabledRequest,
   SetNcbiCredentialsRequest,
+  SetGitHubCredentialsRequest,
   SetPackageMirrorRequest,
   SetSkillEnabledRequest,
   SetToolPermissionRequest,
@@ -74,7 +75,7 @@ import type { CodexDetectDeps } from './codex-detect'
 import type { InstallManagedOpencodeOptions } from './managed-opencode'
 import type { InstallManagedCodexOptions, ManagedCodexInstallOutcome } from './managed-codex'
 import type { InstallManagedClaudeOptions, ManagedInstallOutcome } from './managed-claude'
-import { isEncryptionAvailable } from './crypto'
+import { encryptKey, isEncryptionAvailable } from './crypto'
 import { getUserClaudeConfigDir } from './provider-env'
 import { SettingsRepository } from './repository'
 import { SettingsPreferencesModule, toSettingsPreferencesSnapshot } from './preferences'
@@ -277,6 +278,7 @@ class SettingsService {
       conversationSkillImportEnabled: preferences.conversationSkillImportEnabled,
       closePreference: preferences.closePreference,
       appIconVariant: preferences.appIconVariant,
+      githubCredentials: { hasToken: !!settings.githubTokenRef },
       agentFrameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
       agentFrameworks: listAgentFrameworks().map((framework) => ({
         id: framework.id,
@@ -838,6 +840,13 @@ class SettingsService {
   // Sets or clears the shared contact email and NCBI API key (encrypted at rest), returning state.
   async setNcbiCredentials(request: SetNcbiCredentialsRequest): Promise<ConnectorsSnapshot> {
     return this.connectors.setNcbiCredentials(request)
+  }
+
+  // Sets or clears the GitHub personal access token (encrypted at rest) for authenticated skill import.
+  async setGitHubCredentials(request: SetGitHubCredentialsRequest): Promise<SettingsSnapshot> {
+    const tokenRef = request.token ? encryptKey(request.token) : undefined
+    await this.repository.setGitHubCredentials(tokenRef)
+    return this.getSettingsView()
   }
 
   // Adds a user-provided custom MCP server (add-time trust is the caller's responsibility). The

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -45,6 +45,7 @@ import {
   provisionAppClaudeConfigDir,
   type ClaudeRuntimeModelConfig
 } from './claude-config-provision'
+import { tryDecryptKey } from './crypto'
 import type { SettingsRepository } from './repository'
 import type { StoredSettings } from './types'
 
@@ -268,8 +269,17 @@ class SkillCatalogModule {
     return this.listSkills()
   }
 
+  // Decrypts the stored GitHub personal access token, if configured. Returns undefined when
+  // no token is set or decryption fails (e.g. keychain unavailable) — the caller falls back
+  // to unauthenticated requests (60 req/hour instead of 5 000).
+  private async githubToken(): Promise<string | undefined> {
+    const settings = await this.options.repository.getSettings()
+    return tryDecryptKey(settings.githubTokenRef)
+  }
+
   async importSkill(request: ImportSkillRequest): Promise<ImportSkillResult> {
-    const outcome = await this.userSkills.importFromGitHub(request.url, netFetch)
+    const token = await this.githubToken()
+    const outcome = await this.userSkills.importFromGitHub(request.url, netFetch, token)
     return { ...outcome, skills: await this.listSkills() }
   }
 
@@ -317,7 +327,8 @@ class SkillCatalogModule {
   async previewGitHubSkill(request: PreviewGitHubSkillRequest): Promise<SkillImportPreviewContent> {
     const location = parseGitHubSkillUrl(request.url)
     if (!location) throw new Error('Not a recognizable GitHub URL.')
-    const preview = await this.userSkills.previewGitHubSkill(request.url, netFetch)
+    const token = await this.githubToken()
+    const preview = await this.userSkills.previewGitHubSkill(request.url, netFetch, token)
     const suffix = location.path ? `/${location.path}` : ''
     const revision = location.ref ? `@${location.ref}` : ''
     return {
@@ -327,12 +338,13 @@ class SkillCatalogModule {
   }
 
   async scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult> {
+    const token = await this.githubToken()
     if (parseGitHubRepo(request.repo)) {
-      return { skills: await this.userSkills.scanRepo(request.repo, netFetch) }
+      return { skills: await this.userSkills.scanRepo(request.repo, netFetch, token) }
     }
     return {
       skills: [],
-      repositories: await searchGitHubSkillRepositories(request.repo, netFetch)
+      repositories: await searchGitHubSkillRepositories(request.repo, netFetch, token)
     }
   }
 

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -181,6 +181,10 @@ export type StoredSettings = {
   // Absolute path of the relocatable data root (artifacts/notebooks/runtime/uploads). Absent means
   // "use the config root" (default). Only written after a successful migration; a change needs a restart.
   dataRoot?: string
+  // GitHub personal access token for authenticated skill import API requests (encrypted via
+  // safeStorage). When absent, GitHub API calls are unauthenticated (60 req/hour); when present,
+  // authenticated requests raise the limit to 5 000 req/hour.
+  githubTokenRef?: string
   // Set once the one-time legacy-absolute-path-to-$DATA normalization pass has completed successfully.
   // Absent means it still needs to run (or a previous attempt failed and should retry).
   pathsNormalizedAt?: number

--- a/src/main/skills/github-import.ts
+++ b/src/main/skills/github-import.ts
@@ -47,6 +47,12 @@ export type FetchLike = (
 
 const GITHUB_HEADERS = { 'User-Agent': 'open-science', Accept: 'application/vnd.github+json' }
 
+// Builds request headers for GitHub API calls. When a personal access token is provided, the
+// Authorization header raises the rate limit from 60 to 5 000 requests/hour — critical for repos
+// containing many skills.
+const githubHeaders = (token?: string): Record<string, string> =>
+  token ? { ...GITHUB_HEADERS, Authorization: `Bearer ${token}` } : GITHUB_HEADERS
+
 // Reads a download body into a Buffer, stopping as soon as the running total crosses `limit` (so an
 // oversized/endless body is never drained). Prefers the streaming reader; falls back to arrayBuffer()
 // when no stream is exposed, still enforcing the cap on the buffered result. Peak memory is bounded by
@@ -131,7 +137,8 @@ export type FetchedSkillPreview = { skillMd: Buffer; files: string[] }
 // and request count share the import caps, while the rendered body uses the smaller IPC preview cap.
 const fetchSkillPreview = async (
   location: GitHubSkillLocation,
-  fetchImpl: FetchLike
+  fetchImpl: FetchLike,
+  token?: string
 ): Promise<FetchedSkillPreview> => {
   const rootPrefix = location.path ? `${location.path}/` : ''
   const files: string[] = []
@@ -151,7 +158,7 @@ const fetchSkillPreview = async (
       throw new Error(`Skill directory nesting exceeds ${SKILL_IMPORT_LIMITS.maxDepth} levels.`)
     }
 
-    const response = await request(contentsUrl(location, path), { headers: GITHUB_HEADERS })
+    const response = await request(contentsUrl(location, path), { headers: githubHeaders(token) })
     if (!response.ok) {
       throw new Error(`GitHub API request failed (${response.status}) for ${path || 'repo root'}`)
     }
@@ -174,7 +181,7 @@ const fetchSkillPreview = async (
       files.push(relativePath)
 
       if (relativePath.toLowerCase() !== 'skill.md' || !entry.download_url) continue
-      const raw = await request(entry.download_url, { headers: { 'User-Agent': 'open-science' } })
+      const raw = await request(entry.download_url, { headers: githubHeaders(token) })
       if (!raw.ok) throw new Error(`Failed to download ${entry.path} (${raw.status})`)
 
       const previewTooLarge = (): never => {
@@ -199,7 +206,8 @@ const fetchSkillPreview = async (
 // Recursively downloads every file under a skill directory via the public GitHub contents API.
 const fetchSkillFiles = async (
   location: GitHubSkillLocation,
-  fetchImpl: FetchLike
+  fetchImpl: FetchLike,
+  token?: string
 ): Promise<FetchedSkillFile[]> => {
   const rootPrefix = location.path ? `${location.path}/` : ''
 
@@ -225,7 +233,7 @@ const fetchSkillFiles = async (
       throw new Error(`Skill directory nesting exceeds ${SKILL_IMPORT_LIMITS.maxDepth} levels.`)
     }
 
-    const response = await request(contentsUrl(location, path), { headers: GITHUB_HEADERS })
+    const response = await request(contentsUrl(location, path), { headers: githubHeaders(token) })
     if (!response.ok) {
       throw new Error(`GitHub API request failed (${response.status}) for ${path || 'repo root'}`)
     }
@@ -241,7 +249,7 @@ const fetchSkillFiles = async (
         if (fileCount >= SKILL_IMPORT_LIMITS.maxFiles) {
           throw new Error(`Skill has too many files (limit ${SKILL_IMPORT_LIMITS.maxFiles}).`)
         }
-        const raw = await request(entry.download_url, { headers: { 'User-Agent': 'open-science' } })
+        const raw = await request(entry.download_url, { headers: githubHeaders(token) })
         if (!raw.ok) {
           throw new Error(`Failed to download ${entry.path} (${raw.status})`)
         }
@@ -314,7 +322,8 @@ const parseGitHubRepo = (input: string): GitHubRepoRef | null => {
 
 const searchGitHubSkillRepositories = async (
   input: string,
-  fetchImpl: FetchLike
+  fetchImpl: FetchLike,
+  token?: string
 ): Promise<GitHubRepositorySearchView[]> => {
   const keywords = input.trim()
   const searchTerms = `${keywords} SKILL.md`
@@ -324,7 +333,7 @@ const searchGitHubSkillRepositories = async (
   const query = `${searchTerms} in:name,description,topics,readme`
   const response = await fetchImpl(
     `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}&per_page=10`,
-    { headers: GITHUB_HEADERS }
+    { headers: githubHeaders(token) }
   )
   if (response.status === 403 || response.status === 429) {
     throw new Error(
@@ -373,12 +382,13 @@ const searchGitHubSkillRepositories = async (
 // each. Resolve branch/tag refs to a commit first so a later preview and import read the same snapshot.
 const scanRepoForSkills = async (
   repo: GitHubRepoRef,
-  fetchImpl: FetchLike
+  fetchImpl: FetchLike,
+  token?: string
 ): Promise<ScannedSkill[]> => {
   let ref = repo.ref
   if (!ref) {
     const meta = await fetchImpl(`https://api.github.com/repos/${repo.owner}/${repo.repo}`, {
-      headers: GITHUB_HEADERS
+      headers: githubHeaders(token)
     })
     if (!meta.ok) throw new Error(`GitHub API request failed (${meta.status}).`)
     ref = ((await meta.json()) as { default_branch?: string }).default_branch ?? 'main'
@@ -386,7 +396,7 @@ const scanRepoForSkills = async (
 
   const commitResponse = await fetchImpl(
     `https://api.github.com/repos/${repo.owner}/${repo.repo}/commits/${encodeURIComponent(ref)}`,
-    { headers: GITHUB_HEADERS }
+    { headers: githubHeaders(token) }
   )
   if (!commitResponse.ok) throw new Error(`GitHub API request failed (${commitResponse.status}).`)
   const commitSha = ((await commitResponse.json()) as { sha?: string }).sha
@@ -394,7 +404,7 @@ const scanRepoForSkills = async (
 
   const treeResponse = await fetchImpl(
     `https://api.github.com/repos/${repo.owner}/${repo.repo}/git/trees/${encodeURIComponent(commitSha)}?recursive=1`,
-    { headers: GITHUB_HEADERS }
+    { headers: githubHeaders(token) }
   )
   if (!treeResponse.ok) throw new Error(`GitHub API request failed (${treeResponse.status}).`)
 

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -561,7 +561,7 @@ class UserSkillRepository {
   // Imports a single skill directory from a public GitHub URL, deduplicating against prior imports of
   // the same source: an unchanged re-import is a no-op, a changed one refreshes the files in place, and
   // a new source (or a same-name skill from a different source) is imported as a fresh slug.
-  async importFromGitHub(url: string, fetchImpl?: FetchLike): Promise<ImportOutcome> {
+  async importFromGitHub(url: string, fetchImpl?: FetchLike, token?: string): Promise<ImportOutcome> {
     const location = parseGitHubSkillUrl(url)
     if (!location) throw new Error('Not a recognizable GitHub URL.')
 
@@ -571,7 +571,7 @@ class UserSkillRepository {
     // Fetch over the network OUTSIDE the lock (it's slow); everything that touches disk — recovery,
     // dedup, slug allocation, and the swap — runs in one critical section so two concurrent imports
     // can't both claim the same slug and clobber each other.
-    const files = await fetchSkillFiles(location, fetcher)
+    const files = await fetchSkillFiles(location, fetcher, token)
     const signature = signatureOf(files)
     const base = toSlug(location.path.split('/').filter(Boolean).pop() ?? location.repo) || 'skill'
 
@@ -598,14 +598,14 @@ class UserSkillRepository {
 
   // Lazily reads one scanned GitHub candidate for the read-only renderer preview. Unlike import,
   // this downloads only SKILL.md while retaining the bounded directory walk for the file list.
-  async previewGitHubSkill(url: string, fetchImpl?: FetchLike): Promise<ParsedSkillPreview> {
+  async previewGitHubSkill(url: string, fetchImpl?: FetchLike, token?: string): Promise<ParsedSkillPreview> {
     const location = parseGitHubSkillUrl(url)
     if (!location) throw new Error('Not a recognizable GitHub URL.')
 
     const fetcher = fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined)
     if (!fetcher) throw new Error('No fetch implementation available.')
 
-    const { skillMd, files } = await fetchSkillPreview(location, fetcher)
+    const { skillMd, files } = await fetchSkillPreview(location, fetcher, token)
     const fallbackName = location.path.split('/').filter(Boolean).pop() ?? location.repo
 
     return parsedSkillPreview(skillMd.toString('utf8'), files, fallbackName)
@@ -808,7 +808,8 @@ class UserSkillRepository {
   // Scans a GitHub repo for skill directories, marking which are already imported (by source URL).
   async scanRepo(
     repoInput: string,
-    fetchImpl?: FetchLike
+    fetchImpl?: FetchLike,
+    token?: string
   ): Promise<(ScannedSkill & { alreadyImported: boolean })[]> {
     const repo = parseGitHubRepo(repoInput)
     if (!repo) throw new Error('Not a recognizable GitHub repo (owner/repo or a github.com URL).')
@@ -818,7 +819,7 @@ class UserSkillRepository {
 
     // Scan over the network outside the lock; build the imported index under the lock, after recovery.
     const [found, index] = await Promise.all([
-      scanRepoForSkills(repo, fetcher),
+      scanRepoForSkills(repo, fetcher, token),
       this.runExclusive(async () => {
         await this.doRecoverImportedTransactions()
         return this.importedIndex()

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -398,6 +398,9 @@ export type SettingsSnapshot = {
   closePreference?: CloseActionPreference
   // The selected built-in app-icon look, applied to the window icon and macOS Dock. Defaults to 'light'.
   appIconVariant: AppIconVariant
+  // GitHub personal access token state (never the plaintext token). When hasToken is true, the
+  // skill import flow uses authenticated API requests (5 000 req/hour instead of 60).
+  githubCredentials: GitHubCredentialsView
 }
 
 // Request to set (or clear, via omitted fields) the package-mirror configuration.
@@ -1135,6 +1138,12 @@ export type SetConnectorEnabledRequest = { id: string; enabled: boolean }
 export type SetConnectorAutoAllowRequest = { id: string; autoAllow: boolean }
 export type SetToolPermissionRequest = { toolId: string; permission: ToolPermission }
 export type SetNcbiCredentialsRequest = { contactEmail?: string; apiKey?: string }
+
+// GitHub credential state surfaced to the renderer (never the plaintext token).
+export type GitHubCredentialsView = { hasToken: boolean }
+
+// Request to set or clear the GitHub personal access token for authenticated skill import.
+export type SetGitHubCredentialsRequest = { token?: string }
 
 // Add a custom MCP server. stdio requires `command`; the remote transports require `url`.
 export type AddCustomServerRequest = {


### PR DESCRIPTION
## Summary

Adds optional GitHub personal access token support for authenticated API requests during skill import, scan, and preview operations. This raises the effective rate limit from 60 to 5,000 requests/hour, enabling repos with many skills (e.g. `aipoch/medical-research-skills`) to be imported without hitting HTTP 403 errors.

## Motivation

When importing skills from a large GitHub repository via **UI → Skills → Add Skill → Import from GitHub**, the feature makes dozens of unauthenticated GitHub API calls (repo metadata, commit SHA resolution, recursive tree listing, per-skill directory walking + file downloads). After approximately 60 API calls, subsequent requests receive HTTP 403 with rate-limit headers.

GitHub's [unauthenticated rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api) is **60 requests/hour**, while an authenticated request raises the limit to **5,000 requests/hour** — an 83× increase. For repos containing many skills, this difference determines whether the import succeeds or fails.

## Design

The implementation mirrors the existing NCBI API key pattern (`StoredConnectors.ncbiApiKeyRef`):

**Token storage:** A new `githubTokenRef?: string` field on `StoredSettings` stores the encrypted token via `safeStorage`. The plaintext token is never written to disk or exposed to the renderer.

**Settings IPC:** A new `settings:set-github-credentials` IPC channel and `setGitHubCredentials()` method on `SettingsService` accept or clear the token. The renderer receives a `GitHubCredentialsView` (with `hasToken: boolean`) in the settings snapshot to display token state.

**Auth header injection:** A new `githubHeaders(token?)` helper in `github-import.ts` builds request headers with `Authorization: Bearer <token>` when a token is provided. All GitHub API functions (`fetchSkillPreview`, `fetchSkillFiles`, `searchGitHubSkillRepositories`, `scanRepoForSkills`) accept an optional `token` parameter and pass it through.

**Graceful degradation:** When no token is configured, behavior is unchanged — all requests remain unauthenticated with the 60 req/hour limit. Token decryption uses `tryDecryptKey` which returns `undefined` on failure (e.g. keychain unavailable), causing a safe fallback.

## Files Changed

- `src/shared/settings.ts` — Add `GitHubCredentialsView`, `SetGitHubCredentialsRequest` types; add `githubCredentials` field to `SettingsSnapshot`
- `src/main/settings/types.ts` — Add `githubTokenRef?: string` to `StoredSettings`
- `src/main/settings/repository.ts` — Add `setGitHubCredentials()` method; parse `githubTokenRef` in `sanitizeSettings`
- `src/main/settings/crypto.ts` — No changes (reuses existing `encryptKey`/`tryDecryptKey`)
- `src/main/settings/service.ts` — Add `setGitHubCredentials()` method with encryption; include `githubCredentials` in snapshot
- `src/main/settings/ipc.ts` — Register `settings:set-github-credentials` IPC handler
- `src/main/settings/skill-catalog.ts` — Add `githubToken()` helper; pass token through `importSkill`, `previewGitHubSkill`, `scanRepoSkills`
- `src/main/skills/github-import.ts` — Add `githubHeaders()` helper; add `token?` parameter to all GitHub API functions
- `src/main/skills/user-skill-repository.ts` — Thread `token` through `importFromGitHub`, `previewGitHubSkill`, `scanRepo`

## Testing

- All existing tests pass (no breaking changes — all token parameters are optional with `undefined` default)
- Existing unauthenticated behavior preserved when no token is configured
- Token storage/encryption follows the battle-tested NCBI API key pattern

## Related

- Closes #959
- Follows the same security pattern as `StoredConnectors.ncbiApiKeyRef` and `StoredProvider.keyRef`
