### PR TITLE
refactor(project-files-view): extract preview owner

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -43,7 +43,10 @@
       "fallbackCapability": "renderer_view"
     },
     "project_files_view": {
-      "ownerPaths": ["src/renderer/src/pages/workspace/ProjectFilesView.tsx"],
+      "ownerPaths": [
+        "src/renderer/src/pages/workspace/ProjectFilesView.tsx",
+        "src/renderer/src/pages/workspace/project-files-preview-owner.ts"
+      ],
       "interfacePaths": ["src/renderer/src/pages/workspace/ProjectFilesView.tsx"],
       "consumerModules": ["workspace_page"],
       "testFiles": {

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -52,20 +52,18 @@ import type {
 
 import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { ArtifactPreview } from './artifact-preview'
-import {
-  ARTIFACT_IMAGE_PREVIEW_BYTES,
-  ARTIFACT_PREVIEW_BYTES,
-  getArtifactPreviewFormat
-} from './artifact-preview-utils'
 import { ManagedFileDownloadButton } from './ManagedFileDownloadButton'
 import { createPreviewFileItem } from './preview-file-item'
 import type { MessageArtifact } from './preview-file-item'
 import { FileBrowserModal } from '../settings/FileBrowserModal'
 import { LocalFileBrowser } from './LocalFileBrowser'
-import { getPreviewThumbnailReadEncoding } from './preview-support'
-import { createKeyedRequestReader } from './project-file-preview-queue'
-import { isUnavailableFileError, FILE_MISSING_TAG } from './previews/preview-errors'
-import { createPreviewRequestScope, getPreviewFileReader } from './previews/preview-file-reader'
+import {
+  createProjectFilePreviewArtifact,
+  useProjectFilePreviewReader,
+  useProjectFilePreviews,
+  type ProjectFilePreviewReader
+} from './project-files-preview-owner'
+import { FILE_MISSING_TAG } from './previews/preview-errors'
 import { useNearViewport } from './previews/useNearViewport'
 import { useUnavailablePreviewProbe } from './previews/useUnavailablePreviewProbe'
 import {
@@ -117,35 +115,9 @@ const getCollapsedSessionOptions = (
   return [...firstOptions.slice(0, COLLAPSED_SESSION_OPTION_COUNT - 1), selectedOption]
 }
 
-type ProjectFilePreviewTarget = {
-  id: string
-  path: string
-  source: 'artifact' | 'upload'
-  artifact: MessageArtifact
-  projectId: string
-  sessionId: string
-  cacheKey: string
-  encoding?: 'utf8' | 'base64'
-}
-
-type ReadableProjectFilePreviewTarget = ProjectFilePreviewTarget & {
-  encoding: 'utf8' | 'base64'
-}
-
-type ProjectFilePreviewEntry = {
-  cacheKey: string
-  preview: ArtifactPreviewResult | undefined
-}
-
-// Each stable file id retains only its current path/version preview entry.
-type ProjectFilePreviewState = Record<string, ProjectFilePreviewEntry | undefined>
-
-type ProjectFilePreviewReadResult = ProjectFilePreviewEntry & { id: string }
 type FilePageLoadMode = 'manual' | 'scroll'
 type ProjectFilesViewMode = 'grid' | 'list'
 
-const PREVIEW_READ_CONCURRENCY = 4
-const MAX_PREVIEW_CACHE_ENTRIES = 96
 // Keeps manual pagination recognizable without the outline competing with the surrounding file tiles.
 const loadMoreButtonClassName = 'bg-bg-200 text-text-100 hover:bg-bg-300 hover:text-text-000'
 // Shares count grammar between the toolbar summary and independently paginated section headers.
@@ -156,218 +128,6 @@ const HOUR_MS = 60 * MINUTE_MS
 const DAY_MS = 24 * HOUR_MS
 const MONTH_MS = 30 * DAY_MS
 const YEAR_MS = 365 * DAY_MS
-
-const createProjectFilePreviewArtifact = (file: ProjectFileItem): MessageArtifact => ({
-  id: file.sourceVersionId ?? file.sourceFileId,
-  artifactId: file.source === 'artifact' ? file.sourceFileId : undefined,
-  versionId: file.sourceVersionId,
-  kind: 'managed-file',
-  path: file.path,
-  name: file.name,
-  mimeType: file.mimeType,
-  size: file.size,
-  mtimeMs: file.mtimeMs
-})
-
-// A moved or rewritten file is a new cache entry even when its stable UI id stays the same.
-const getProjectFilePreviewCacheKey = ({
-  id,
-  path,
-  source,
-  artifact
-}: Pick<ProjectFilePreviewTarget, 'id' | 'path' | 'source' | 'artifact'>): string =>
-  JSON.stringify([source, id, path, artifact.size ?? null, artifact.mtimeMs ?? null])
-
-// Builds the source-neutral capability and source-specific read metadata used by File tiles.
-const createProjectFilePreviewTarget = (
-  target: Pick<
-    ProjectFilePreviewTarget,
-    'id' | 'path' | 'source' | 'artifact' | 'projectId' | 'sessionId'
-  >
-): ProjectFilePreviewTarget => ({
-  ...target,
-  cacheKey: getProjectFilePreviewCacheKey(target),
-  encoding: getPreviewThumbnailReadEncoding(getArtifactPreviewFormat(target.artifact))
-})
-
-// Skips unsupported, cached, and oversized image targets before any IPC reads start.
-const getMissingProjectFilePreviewTargets = (
-  targets: ProjectFilePreviewTarget[],
-  previews: ProjectFilePreviewState
-): ReadableProjectFilePreviewTarget[] =>
-  targets
-    .filter((target): target is ReadableProjectFilePreviewTarget => target.encoding !== undefined)
-    .filter((target) => previews[target.id]?.cacheKey !== target.cacheKey)
-    .filter(
-      (target) =>
-        target.encoding !== 'base64' ||
-        (typeof target.artifact.size === 'number' &&
-          target.artifact.size <= ARTIFACT_IMAGE_PREVIEW_BYTES)
-    )
-
-// Reads one tile through its source-specific IPC while retaining the source-neutral cache identity.
-const readProjectFilePreview = async (
-  target: ReadableProjectFilePreviewTarget
-): Promise<ProjectFilePreviewReadResult> => {
-  const readPreview = getPreviewFileReader(target.source)
-
-  try {
-    const preview = await readPreview({
-      path: target.path,
-      ...createPreviewRequestScope({
-        projectId: target.projectId,
-        sessionId: target.sessionId,
-        source: target.source,
-        path: target.path
-      }),
-      maxBytes:
-        target.encoding === 'base64' ? ARTIFACT_IMAGE_PREVIEW_BYTES : ARTIFACT_PREVIEW_BYTES,
-      encoding: target.encoding
-    })
-
-    return { id: target.id, cacheKey: target.cacheKey, preview }
-  } catch (error) {
-    // Missing or out-of-root files are represented on the tile; only unexpected read failures belong
-    // in the console because unavailable files are a normal state after deletion or data-root changes.
-    if (!isUnavailableFileError(error)) {
-      console.error('Failed to read project file preview', error)
-    }
-    return { id: target.id, cacheKey: target.cacheKey, preview: undefined }
-  }
-}
-
-// Merges one completed read batch without dropping cached entries for other visible files.
-const mergeProjectFilePreviews = (
-  currentPreviews: ProjectFilePreviewState,
-  previews: ProjectFilePreviewReadResult[],
-  protectedIds: ReadonlySet<string>
-): ProjectFilePreviewState => {
-  const nextPreviews = previews.reduce<ProjectFilePreviewState>(
-    (nextPreviews, item) => {
-      // Reinsert completed entries so object insertion order acts as a compact LRU approximation.
-      delete nextPreviews[item.id]
-      nextPreviews[item.id] = { cacheKey: item.cacheKey, preview: item.preview }
-      return nextPreviews
-    },
-    { ...currentPreviews }
-  )
-
-  return trimProjectFilePreviews(nextPreviews, protectedIds)
-}
-
-// Current tiles stay protected; retain at most one compact page pool of hidden previews for return
-// navigation without letting collapsed or previously paged sections grow the cache indefinitely.
-const trimProjectFilePreviews = (
-  currentPreviews: ProjectFilePreviewState,
-  protectedIds: ReadonlySet<string>
-): ProjectFilePreviewState => {
-  const keys = Object.keys(currentPreviews)
-  const hiddenIds = keys.filter((id) => !protectedIds.has(id))
-  if (hiddenIds.length <= MAX_PREVIEW_CACHE_ENTRIES) return currentPreviews
-
-  const nextPreviews = { ...currentPreviews }
-  const removeCount = hiddenIds.length - MAX_PREVIEW_CACHE_ENTRIES
-  for (const id of hiddenIds.slice(0, removeCount)) {
-    delete nextPreviews[id]
-  }
-  return nextPreviews
-}
-
-type ProjectFilePreviewReader = ((
-  target: ReadableProjectFilePreviewTarget
-) => Promise<ProjectFilePreviewReadResult>) & {
-  setActiveKeys?: (keys: ReadonlySet<string>) => void
-}
-
-const getProjectFilePreviewRequestKey = (target: ProjectFilePreviewTarget): string =>
-  `${target.projectId}:${target.cacheKey}`
-
-// Shares one queue across render batches so preview reads remain capped and deduplicated even when
-// pagination, filters, or section expansion update the target list in quick succession.
-const createProjectFilePreviewReader = (
-  read: ProjectFilePreviewReader = readProjectFilePreview,
-  maxConcurrency = PREVIEW_READ_CONCURRENCY
-): ProjectFilePreviewReader =>
-  createKeyedRequestReader(read, getProjectFilePreviewRequestKey, maxConcurrency, {
-    getGenerationKey: (target) => target.projectId,
-    createCanceledResult: (target) => ({
-      id: target.id,
-      cacheKey: target.cacheKey,
-      preview: undefined
-    })
-  })
-
-/**
- * Maintains version-aware tile previews for the currently rendered file targets.
- *
- * Active request keys cancel queued reads for collapsed/filtered files. Attempted keys suppress retry
- * loops for failed reads, but are removed once a target leaves the active set so an evicted preview is
- * eligible for a fresh read when the user returns. Completed batches merge without evicting visible
- * tiles, while hidden entries are bounded separately.
- */
-const useProjectFilePreviews = (
-  previewTargets: ProjectFilePreviewTarget[],
-  previewReader: ProjectFilePreviewReader
-): ProjectFilePreviewState => {
-  const [filePreviews, setFilePreviews] = useState<ProjectFilePreviewState>({})
-  const attemptedCacheKeyByIdRef = useRef(new Map<string, string>())
-
-  useEffect(() => {
-    const activeCacheKeys = new Map(
-      previewTargets.map((target) => [target.id, target.cacheKey] as const)
-    )
-    const protectedIds = new Set(activeCacheKeys.keys())
-    const attemptedCacheKeys = attemptedCacheKeyByIdRef.current
-    let canceled = false
-    previewReader.setActiveKeys?.(new Set(previewTargets.map(getProjectFilePreviewRequestKey)))
-
-    // Attempts only suppress cache-eviction loops for the current render set. Hidden evicted files
-    // must be eligible for a fresh read when the user returns to them.
-    for (const [id, cacheKey] of attemptedCacheKeys) {
-      if (activeCacheKeys.get(id) !== cacheKey) attemptedCacheKeys.delete(id)
-    }
-    void Promise.resolve().then(() => {
-      if (!canceled) {
-        setFilePreviews((current) => trimProjectFilePreviews(current, protectedIds))
-      }
-    })
-
-    const missingTargets = getMissingProjectFilePreviewTargets(previewTargets, filePreviews).filter(
-      (target) => attemptedCacheKeys.get(target.id) !== target.cacheKey
-    )
-    if (missingTargets.length === 0) {
-      return () => {
-        canceled = true
-        previewReader.setActiveKeys?.(new Set())
-      }
-    }
-
-    let completed = false
-    for (const target of missingTargets) {
-      attemptedCacheKeys.set(target.id, target.cacheKey)
-    }
-
-    void Promise.all(missingTargets.map(previewReader)).then((previews) => {
-      completed = true
-      if (canceled) return
-      setFilePreviews((current) => mergeProjectFilePreviews(current, previews, protectedIds))
-    })
-
-    return () => {
-      canceled = true
-      previewReader.setActiveKeys?.(new Set())
-      if (!completed) {
-        for (const target of missingTargets) {
-          if (attemptedCacheKeys.get(target.id) === target.cacheKey) {
-            attemptedCacheKeys.delete(target.id)
-          }
-        }
-      }
-    }
-  }, [filePreviews, previewReader, previewTargets])
-
-  return filePreviews
-}
 
 // Converts one stable sentinel into guarded infinite loading. The root margin starts the next page
 // shortly before it becomes visible; environments without IntersectionObserver fall back to manual UI.
@@ -1512,39 +1272,16 @@ const ProjectFilesViewContent = ({
       visibleArtifactGroups
     ]
   )
-  const previewTargets = useMemo<ProjectFilePreviewTarget[]>(
+  const previewFiles = useMemo<ProjectFileItem[]>(
     // Collapsed sections are intentionally absent: they neither protect cache entries nor enqueue new
     // thumbnail reads. List rows use only the lightweight availability probe and need no thumbnails.
     () =>
       viewMode === 'grid'
-        ? [...(uploadsCollapsed ? [] : visibleUploadFiles), ...visibleArtifactFiles].map((file) =>
-            createProjectFilePreviewTarget({
-              id: file.id,
-              path: file.path,
-              source: file.source,
-              artifact: createProjectFilePreviewArtifact(file),
-              projectId: file.projectId,
-              sessionId: file.sessionId
-            })
-          )
+        ? [...(uploadsCollapsed ? [] : visibleUploadFiles), ...visibleArtifactFiles]
         : [],
     [uploadsCollapsed, viewMode, visibleArtifactFiles, visibleUploadFiles]
   )
-  const filePreviews = useProjectFilePreviews(previewTargets, previewReader)
-  // A previous version may remain cached while the current path loads; never render it as current.
-  const currentFilePreviewById = useMemo(
-    () =>
-      new Map(
-        previewTargets.map((target) => {
-          const entry = filePreviews[target.id]
-          return [
-            target.id,
-            entry?.cacheKey === target.cacheKey ? entry.preview : undefined
-          ] as const
-        })
-      ),
-    [filePreviews, previewTargets]
-  )
+  const currentFilePreviewById = useProjectFilePreviews(previewFiles, previewReader)
 
   const toggleSection = (sectionId: string): void => {
     setCollapsedSectionIds((currentIds) => {
@@ -1972,7 +1709,7 @@ const ProjectFilesViewContent = ({
 
 const ProjectFilesView = (): React.JSX.Element => {
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
-  const [previewReader] = useState<ProjectFilePreviewReader>(() => createProjectFilePreviewReader())
+  const previewReader = useProjectFilePreviewReader()
 
   return (
     <ProjectFilesViewContent

--- a/src/renderer/src/pages/workspace/project-files-preview-owner.ts
+++ b/src/renderer/src/pages/workspace/project-files-preview-owner.ts
@@ -1,0 +1,285 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import type { ArtifactPreviewResult } from '../../../../shared/artifacts'
+import type { ProjectFileItem } from '../../../../shared/project-files'
+
+import {
+  ARTIFACT_IMAGE_PREVIEW_BYTES,
+  ARTIFACT_PREVIEW_BYTES,
+  getArtifactPreviewFormat
+} from './artifact-preview-utils'
+import { createKeyedRequestReader } from './project-file-preview-queue'
+import type { MessageArtifact } from './preview-file-item'
+import { getPreviewThumbnailReadEncoding } from './preview-support'
+import { isUnavailableFileError } from './previews/preview-errors'
+import { createPreviewRequestScope, getPreviewFileReader } from './previews/preview-file-reader'
+
+type ProjectFilePreviewTarget = {
+  id: string
+  path: string
+  source: 'artifact' | 'upload'
+  artifact: MessageArtifact
+  projectId: string
+  sessionId: string
+  cacheKey: string
+  encoding?: 'utf8' | 'base64'
+}
+
+type ReadableProjectFilePreviewTarget = ProjectFilePreviewTarget & {
+  encoding: 'utf8' | 'base64'
+}
+
+type ProjectFilePreviewEntry = {
+  cacheKey: string
+  preview: ArtifactPreviewResult | undefined
+}
+
+// Each stable file id retains only its current path/version preview entry.
+type ProjectFilePreviewState = Record<string, ProjectFilePreviewEntry | undefined>
+type ProjectFilePreviewReadResult = ProjectFilePreviewEntry & { id: string }
+
+type ProjectFilePreviewReader = ((
+  target: ReadableProjectFilePreviewTarget
+) => Promise<ProjectFilePreviewReadResult>) & {
+  setActiveKeys?: (keys: ReadonlySet<string>) => void
+}
+
+const PREVIEW_READ_CONCURRENCY = 4
+const MAX_PREVIEW_CACHE_ENTRIES = 96
+
+const createProjectFilePreviewArtifact = (file: ProjectFileItem): MessageArtifact => ({
+  id: file.sourceVersionId ?? file.sourceFileId,
+  artifactId: file.source === 'artifact' ? file.sourceFileId : undefined,
+  versionId: file.sourceVersionId,
+  kind: 'managed-file',
+  path: file.path,
+  name: file.name,
+  mimeType: file.mimeType,
+  size: file.size,
+  mtimeMs: file.mtimeMs
+})
+
+// A moved or rewritten file is a new cache entry even when its stable UI id stays the same.
+const getProjectFilePreviewCacheKey = ({
+  id,
+  path,
+  source,
+  artifact
+}: Pick<ProjectFilePreviewTarget, 'id' | 'path' | 'source' | 'artifact'>): string =>
+  JSON.stringify([source, id, path, artifact.size ?? null, artifact.mtimeMs ?? null])
+
+// Builds the source-neutral capability and source-specific read metadata used by File tiles.
+const createProjectFilePreviewTarget = (file: ProjectFileItem): ProjectFilePreviewTarget => {
+  const artifact = createProjectFilePreviewArtifact(file)
+  const target = {
+    id: file.id,
+    path: file.path,
+    source: file.source,
+    artifact,
+    projectId: file.projectId,
+    sessionId: file.sessionId
+  }
+
+  return {
+    ...target,
+    cacheKey: getProjectFilePreviewCacheKey(target),
+    encoding: getPreviewThumbnailReadEncoding(getArtifactPreviewFormat(artifact))
+  }
+}
+
+// Skips unsupported, cached, and oversized image targets before any IPC reads start.
+const getMissingProjectFilePreviewTargets = (
+  targets: ProjectFilePreviewTarget[],
+  previews: ProjectFilePreviewState
+): ReadableProjectFilePreviewTarget[] =>
+  targets
+    .filter((target): target is ReadableProjectFilePreviewTarget => target.encoding !== undefined)
+    .filter((target) => previews[target.id]?.cacheKey !== target.cacheKey)
+    .filter(
+      (target) =>
+        target.encoding !== 'base64' ||
+        (typeof target.artifact.size === 'number' &&
+          target.artifact.size <= ARTIFACT_IMAGE_PREVIEW_BYTES)
+    )
+
+// Reads one tile through its source-specific IPC while retaining the source-neutral cache identity.
+const readProjectFilePreview = async (
+  target: ReadableProjectFilePreviewTarget
+): Promise<ProjectFilePreviewReadResult> => {
+  const readPreview = getPreviewFileReader(target.source)
+
+  try {
+    const preview = await readPreview({
+      path: target.path,
+      ...createPreviewRequestScope({
+        projectId: target.projectId,
+        sessionId: target.sessionId,
+        source: target.source,
+        path: target.path
+      }),
+      maxBytes:
+        target.encoding === 'base64' ? ARTIFACT_IMAGE_PREVIEW_BYTES : ARTIFACT_PREVIEW_BYTES,
+      encoding: target.encoding
+    })
+
+    return { id: target.id, cacheKey: target.cacheKey, preview }
+  } catch (error) {
+    // Missing or out-of-root files are represented on the tile; only unexpected read failures belong
+    // in the console because unavailable files are a normal state after deletion or data-root changes.
+    if (!isUnavailableFileError(error)) {
+      console.error('Failed to read project file preview', error)
+    }
+    return { id: target.id, cacheKey: target.cacheKey, preview: undefined }
+  }
+}
+
+// Current tiles stay protected; retain at most one compact page pool of hidden previews for return
+// navigation without letting collapsed or previously paged sections grow the cache indefinitely.
+const trimProjectFilePreviews = (
+  currentPreviews: ProjectFilePreviewState,
+  protectedIds: ReadonlySet<string>
+): ProjectFilePreviewState => {
+  const keys = Object.keys(currentPreviews)
+  const hiddenIds = keys.filter((id) => !protectedIds.has(id))
+  if (hiddenIds.length <= MAX_PREVIEW_CACHE_ENTRIES) return currentPreviews
+
+  const nextPreviews = { ...currentPreviews }
+  const removeCount = hiddenIds.length - MAX_PREVIEW_CACHE_ENTRIES
+  for (const id of hiddenIds.slice(0, removeCount)) {
+    delete nextPreviews[id]
+  }
+  return nextPreviews
+}
+
+// Merges one completed read batch without dropping cached entries for other visible files.
+const mergeProjectFilePreviews = (
+  currentPreviews: ProjectFilePreviewState,
+  previews: ProjectFilePreviewReadResult[],
+  protectedIds: ReadonlySet<string>
+): ProjectFilePreviewState => {
+  const nextPreviews = previews.reduce<ProjectFilePreviewState>(
+    (nextPreviews, item) => {
+      // Reinsert completed entries so object insertion order acts as a compact LRU approximation.
+      delete nextPreviews[item.id]
+      nextPreviews[item.id] = { cacheKey: item.cacheKey, preview: item.preview }
+      return nextPreviews
+    },
+    { ...currentPreviews }
+  )
+
+  return trimProjectFilePreviews(nextPreviews, protectedIds)
+}
+
+const getProjectFilePreviewRequestKey = (target: ProjectFilePreviewTarget): string =>
+  `${target.projectId}:${target.cacheKey}`
+
+// Shares one queue across render batches so preview reads remain capped and deduplicated even when
+// pagination, filters, or section expansion update the target list in quick succession.
+const createProjectFilePreviewReader = (
+  read: ProjectFilePreviewReader = readProjectFilePreview,
+  maxConcurrency = PREVIEW_READ_CONCURRENCY
+): ProjectFilePreviewReader =>
+  createKeyedRequestReader(read, getProjectFilePreviewRequestKey, maxConcurrency, {
+    getGenerationKey: (target) => target.projectId,
+    createCanceledResult: (target) => ({
+      id: target.id,
+      cacheKey: target.cacheKey,
+      preview: undefined
+    })
+  })
+
+// Keeps one queue alive across keyed ProjectFilesViewContent mounts so project changes cancel stale
+// queued work without creating a second concurrency pool.
+const useProjectFilePreviewReader = (): ProjectFilePreviewReader => {
+  const [reader] = useState<ProjectFilePreviewReader>(() => createProjectFilePreviewReader())
+  return reader
+}
+
+/**
+ * Maintains version-aware tile previews for the currently rendered file targets.
+ *
+ * Active request keys cancel queued reads for collapsed/filtered files. Attempted keys suppress retry
+ * loops for failed reads, but are removed once a target leaves the active set so an evicted preview is
+ * eligible for a fresh read when the user returns. Completed batches merge without evicting visible
+ * tiles, while hidden entries are bounded separately.
+ */
+const useProjectFilePreviews = (
+  files: ProjectFileItem[],
+  previewReader: ProjectFilePreviewReader
+): Map<string, ArtifactPreviewResult | undefined> => {
+  const previewTargets = useMemo(() => files.map(createProjectFilePreviewTarget), [files])
+  const [filePreviews, setFilePreviews] = useState<ProjectFilePreviewState>({})
+  const attemptedCacheKeyByIdRef = useRef(new Map<string, string>())
+
+  useEffect(() => {
+    const activeCacheKeys = new Map(
+      previewTargets.map((target) => [target.id, target.cacheKey] as const)
+    )
+    const protectedIds = new Set(activeCacheKeys.keys())
+    const attemptedCacheKeys = attemptedCacheKeyByIdRef.current
+    let canceled = false
+    previewReader.setActiveKeys?.(new Set(previewTargets.map(getProjectFilePreviewRequestKey)))
+
+    // Attempts only suppress cache-eviction loops for the current render set. Hidden evicted files
+    // must be eligible for a fresh read when the user returns to them.
+    for (const [id, cacheKey] of attemptedCacheKeys) {
+      if (activeCacheKeys.get(id) !== cacheKey) attemptedCacheKeys.delete(id)
+    }
+    void Promise.resolve().then(() => {
+      if (!canceled) {
+        setFilePreviews((current) => trimProjectFilePreviews(current, protectedIds))
+      }
+    })
+
+    const missingTargets = getMissingProjectFilePreviewTargets(previewTargets, filePreviews).filter(
+      (target) => attemptedCacheKeys.get(target.id) !== target.cacheKey
+    )
+    if (missingTargets.length === 0) {
+      return () => {
+        canceled = true
+        previewReader.setActiveKeys?.(new Set())
+      }
+    }
+
+    let completed = false
+    for (const target of missingTargets) {
+      attemptedCacheKeys.set(target.id, target.cacheKey)
+    }
+
+    void Promise.all(missingTargets.map(previewReader)).then((previews) => {
+      completed = true
+      if (canceled) return
+      setFilePreviews((current) => mergeProjectFilePreviews(current, previews, protectedIds))
+    })
+
+    return () => {
+      canceled = true
+      previewReader.setActiveKeys?.(new Set())
+      if (!completed) {
+        for (const target of missingTargets) {
+          if (attemptedCacheKeys.get(target.id) === target.cacheKey) {
+            attemptedCacheKeys.delete(target.id)
+          }
+        }
+      }
+    }
+  }, [filePreviews, previewReader, previewTargets])
+
+  // A previous version may remain cached while the current path loads; never render it as current.
+  return useMemo(
+    () =>
+      new Map(
+        previewTargets.map((target) => {
+          const entry = filePreviews[target.id]
+          return [
+            target.id,
+            entry?.cacheKey === target.cacheKey ? entry.preview : undefined
+          ] as const
+        })
+      ),
+    [filePreviews, previewTargets]
+  )
+}
+
+export { createProjectFilePreviewArtifact, useProjectFilePreviewReader, useProjectFilePreviews }
+export type { ProjectFilePreviewReader }


### PR DESCRIPTION
## Problem

After FV0 characterized Project Files filters, pagination, preview behavior and interaction
boundaries, `ProjectFilesView.tsx` still owns preview target construction, source-aware IPC reads,
request concurrency, stale-work suppression and the bounded thumbnail cache alongside layout and
pagination composition. That stateful preview lifecycle needs one explicit owner before the remaining
query/presentation phases can deepen the component safely.

## Proposed change

- Extract `project-files-preview-owner.ts` as the single owner for Project File preview artifacts and
  targets, source-aware readers, the shared four-request queue, attempted-key tracking, stale-result
  suppression and the 96-hidden-entry cache.
- Keep the reader lifetime above the project-keyed content mount so switching projects continues to
  cancel stale queued work without creating a second concurrency pool.
- Return only the current `Map<file id, preview>` to `ProjectFilesView`; the component now selects the
  visible grid files and composes the existing grid/list presentation.
- Register the new internal owner under the existing `project_files_view` module-impact boundary.

## Scope and non-goals

- Internal ownership extraction only; no public component export, preload, IPC, command, shared type,
  persistence or caller migration.
- No layout, keyboard, filter, search, pagination, scroll, 160px prefetch, error/retry, cache-limit,
  concurrency, deduplication, authorization or stale-result semantic change.
- No new cache, Store, dependency or speculative preview abstraction.
- No data model, data relationship, UI copy or user-interaction change.

## Compatibility

- Preserve generated Artifact and Upload request scoping, including Upload Version source-Session
  adoption through `createPreviewRequestScope` and the existing managed IPC readers.
- Preserve the single cross-project reader queue, four-read concurrency, active-key cancellation,
  failed-attempt retry eligibility, current-version matching and 96 hidden-entry retention policy.
- Preserve Electron/local Web behavior and the existing remote Web/CLI/Task boundaries; no surface
  capability or Specialist/Permission/Compute asymmetry changes.
- Continue reading Session state only through the public Session Store interface; the new owner does
  not import or own Session state. No executable filesystem path or platform-specific test fixture was
  added, so Windows, macOS and Linux path behavior is unchanged.

## Acceptance criteria and validation

- One internal module owns all preview target/reader/cache state while `ProjectFilesView` only selects
  currently visible grid files and consumes the resulting preview map.
- The new owner remains below the 600-line target and 660-line hard limit; the facade reduction and
  production raw counts are reported.
- FV0 owner behavior, Preview File Surface contract, direct Preview Tool consumer, module-impact
  manifest, Web typecheck, lint/format and independent review pass.
- Exact-head PR Gate, CI Integrity, CodeQL and AI must pass before squash merge; full portable and
  platform coverage remains authoritative online.

Implementation evidence:

- `ProjectFilesView.tsx`: 1,986 -> 1,723 raw lines; its public `ProjectFilesView` export and keyed
  content boundary are unchanged.
- `project-files-preview-owner.ts`: 285 raw lines; sole target/reader/cache owner, below both limits.
- Combined touched production raw: 1,986 -> 2,008 lines (+22), reflecting ownership naming without
  duplicated preview state.
- Final Module Test Impact Set: `npm run test:module -- project_files_view` passed 2 files / 86 tests;
  manifest, impact-planner and direct `PreviewToolContent` consumer checks passed 3 files / 26 tests.
- Full `npm run typecheck` (Node + Web), `npm run lint`, targeted Prettier and `git diff --check`
  passed after the final material edit; lint reported 0 errors and 17 pre-existing warnings.
- Full local `npm test`: 851 files / 12,459 tests passed, 14 files / 190 tests skipped, and one known
  `src/main/projects/prisma-client.test.ts` failure remained. Clean `main@aaa20043` independently
  reproduces the same `NotificationInboxItem` runtime-DDL/Prisma-column mismatch, and the intervening
  `0a3b7270` change is Notebook-only; FV1 changes no Prisma, database or main-process file.
- Independent boundary review reported 0 FV1 findings and confirmed equivalent reader lifetime,
  four-read concurrency, stale suppression and 96-hidden-entry semantics.

## Review focus

- Confirm the reader remains above the project-keyed content mount and remains one shared concurrency
  pool across project switches.
- Confirm a changed path/version cannot render the previous cached result and collapsed/filtered files
  neither protect cache entries nor retain queued reads.
- Confirm source-specific authorization/scoping, public/API/IPC/data/UI behavior and cross-surface
  capability boundaries are unchanged.
