### PR TITLE
refactor(workspace-runtime): extract runtime event owner

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -26,13 +26,18 @@
       "fallbackCapability": "renderer_view"
     },
     "workspace_runtime": {
-      "ownerPaths": ["src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts"],
+      "ownerPaths": [
+        "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts",
+        "src/renderer/src/lib/acp/workspace-events.ts",
+        "src/renderer/src/lib/acp/workspace-runtime-event-owner.ts"
+      ],
       "interfacePaths": ["src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts"],
       "consumerModules": ["workspace_page"],
       "testFiles": {
         "owner": [
           "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts",
-          "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx"
+          "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx",
+          "src/renderer/src/lib/acp/workspace-events.test.ts"
         ],
         "contract": [
           "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.first-output.render.test.tsx"

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -9,6 +9,7 @@ import type { AcpCreateSessionResponse, AcpStateSnapshot } from '../../../../sha
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
 import { createInitialSettingsState, useSettingsStore } from '../../stores/settings-store'
 import { resetDeferredArtifactEventsForTests } from './workspace-events'
+import { resetWorkspaceRuntimeEventOwnerForTests } from './workspace-runtime-event-owner'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -96,6 +97,7 @@ describe('workspace Agent Runtime hook contract', () => {
 
   beforeEach(() => {
     resetDeferredArtifactEventsForTests()
+    resetWorkspaceRuntimeEventOwnerForTests()
     useSessionStore.setState(createInitialSessionState())
     useSettingsStore.setState(createInitialSettingsState())
     runtimeMock.current = createRuntime(createSnapshot())

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.first-output.render.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.first-output.render.test.tsx
@@ -8,6 +8,7 @@ import type { AcpStateSnapshot } from '../../../../shared/acp'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
 import { getAgentLoadingPhase } from '../../pages/workspace/agent-loading-message'
 import { resetDeferredArtifactEventsForTests } from './workspace-events'
+import { resetWorkspaceRuntimeEventOwnerForTests } from './workspace-runtime-event-owner'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -67,6 +68,7 @@ describe('workspace Agent first-output runtime sync', () => {
 
   beforeEach(() => {
     resetDeferredArtifactEventsForTests()
+    resetWorkspaceRuntimeEventOwnerForTests()
     useSessionStore.setState(createInitialSessionState())
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type {
-  AcpConnectionStatus,
   AcpCreateSessionResponse,
   AcpPermissionGrant,
   AcpPermissionRequest,
@@ -46,10 +45,14 @@ import {
   type HistoryReplayDescriptor
 } from './history-preamble'
 import {
-  applyWorkspaceRuntimeEvent,
-  syncWorkspaceAgentFirstOutputState,
+  createWorkspaceRuntimeEventProcessor,
+  drainWorkspaceRuntimeEventsForPersistence,
+  markRunningSessionsDisconnectedOnDrop,
+  processVisibleWorkspaceRuntimeEvents,
+  processWorkspaceRuntimeEvents,
+  syncWorkspaceContextUsage,
   syncWorkspacePermissionState
-} from './workspace-events'
+} from './workspace-runtime-event-owner'
 
 type SendWorkspaceMessageInput = {
   sessionId?: string
@@ -186,13 +189,6 @@ type WorkspacePermissionProfileRuntime = Pick<
   'state' | 'setPermissionProfile'
 >
 type PersistSessionDeletion = (request: { projectId: string; sessionId: string }) => Promise<void>
-
-type RuntimeEventApplier = (event: AcpRuntimeEvent) => Promise<boolean>
-
-type WorkspaceRuntimeEventProcessor = {
-  process: (events: AcpRuntimeEvent[]) => Promise<void>
-  drain: (sessionId?: string) => Promise<void>
-}
 
 // Runtime adoption and Branch reset intentionally complete before appendUserMessage creates the next
 // run. Keep duplicate preparations closed during that idle-looking interval without exposing a
@@ -450,197 +446,6 @@ const shutdownNotebookForBranchChange = async (
   if (typeof window === 'undefined' || !window.api?.notebook?.shutdown) return
   await window.api.notebook.shutdown({ sessionId, workspaceCwd, projectName })
 }
-
-const processVisibleWorkspaceRuntimeEvents = async (
-  events: AcpRuntimeEvent[],
-  processedEventIds: Set<string>,
-  applyEvent: RuntimeEventApplier = applyWorkspaceRuntimeEvent,
-  processingEventIds = new Set<string>()
-): Promise<void> => {
-  // Runtime snapshots are bounded, so forget ids that can no longer be replayed from the source list.
-  const visibleEventIds = new Set(events.map((event) => event.id))
-
-  for (const eventId of processedEventIds) {
-    if (!visibleEventIds.has(eventId)) {
-      processedEventIds.delete(eventId)
-    }
-  }
-
-  for (const eventId of processingEventIds) {
-    if (!visibleEventIds.has(eventId)) {
-      processingEventIds.delete(eventId)
-    }
-  }
-
-  for (const event of events) {
-    if (processedEventIds.has(event.id) || processingEventIds.has(event.id)) continue
-
-    processingEventIds.add(event.id)
-    try {
-      // Apply visible events sequentially so message chunks and artifact finalization stay ordered.
-      await applyEvent(event)
-      processedEventIds.add(event.id)
-    } catch {
-      // Artifact finalization errors are recorded by the adapter before throwing.
-      // Keeping this id unprocessed lets the same visible runtime event retry.
-      continue
-    } finally {
-      processingEventIds.delete(event.id)
-    }
-  }
-}
-
-const createWorkspaceRuntimeEventProcessor = (
-  applyEvent: RuntimeEventApplier = applyWorkspaceRuntimeEvent
-): WorkspaceRuntimeEventProcessor => {
-  type EventLane = {
-    acceptedEvents: Map<string, AcpRuntimeEvent>
-    failedEventIds: Set<string>
-    processedEventIds: Set<string>
-    processingEventIds: Set<string>
-    drainInFlight?: Promise<void>
-    drainAgain: boolean
-  }
-
-  const unscopedEventLane = Symbol('unscoped-workspace-runtime-events')
-  const eventLanes = new Map<string | symbol, EventLane>()
-  let latestEvents: AcpRuntimeEvent[] = []
-  let acceptedEventVersion = 0
-
-  const getEventLaneKey = (event: AcpRuntimeEvent): string | symbol =>
-    event.sessionId ?? unscopedEventLane
-
-  const getEventLane = (laneKey: string | symbol): EventLane => {
-    let lane = eventLanes.get(laneKey)
-    if (!lane) {
-      lane = {
-        acceptedEvents: new Map<string, AcpRuntimeEvent>(),
-        failedEventIds: new Set<string>(),
-        processedEventIds: new Set<string>(),
-        processingEventIds: new Set<string>(),
-        drainAgain: false
-      }
-      eventLanes.set(laneKey, lane)
-    }
-
-    return lane
-  }
-
-  const cleanEventLane = (laneKey: string | symbol, lane: EventLane): void => {
-    const visibleEventIds = new Set(
-      latestEvents.filter((event) => getEventLaneKey(event) === laneKey).map((event) => event.id)
-    )
-
-    for (const eventId of lane.acceptedEvents.keys()) {
-      if (!visibleEventIds.has(eventId) && lane.processedEventIds.has(eventId)) {
-        lane.acceptedEvents.delete(eventId)
-        lane.failedEventIds.delete(eventId)
-        lane.processedEventIds.delete(eventId)
-        lane.processingEventIds.delete(eventId)
-      }
-    }
-
-    if (lane.acceptedEvents.size === 0 && !lane.drainInFlight) {
-      eventLanes.delete(laneKey)
-    }
-  }
-
-  const drainLane = async (laneKey: string | symbol): Promise<void> => {
-    const lane = getEventLane(laneKey)
-
-    if (lane.drainInFlight) {
-      lane.drainAgain = true
-      return lane.drainInFlight
-    }
-
-    lane.drainInFlight = (async () => {
-      do {
-        lane.drainAgain = false
-        await processVisibleWorkspaceRuntimeEvents(
-          [...lane.acceptedEvents.values()],
-          lane.processedEventIds,
-          async (event) => {
-            const hadFailed = lane.failedEventIds.has(event.id)
-            try {
-              const applied = await applyEvent(event)
-              lane.failedEventIds.delete(event.id)
-              return applied
-            } catch (error) {
-              const isVisible = latestEvents.some(
-                (candidate) => candidate.id === event.id && getEventLaneKey(candidate) === laneKey
-              )
-              if (hadFailed && !isVisible) {
-                lane.acceptedEvents.delete(event.id)
-                lane.failedEventIds.delete(event.id)
-              } else {
-                lane.failedEventIds.add(event.id)
-              }
-              throw error
-            }
-          },
-          lane.processingEventIds
-        )
-      } while (lane.drainAgain)
-    })()
-
-    try {
-      await lane.drainInFlight
-    } finally {
-      lane.drainInFlight = undefined
-      cleanEventLane(laneKey, lane)
-    }
-  }
-
-  return {
-    process: (events) => {
-      latestEvents = events
-      const visibleLaneKeys = new Set<string | symbol>()
-
-      for (const event of events) {
-        const laneKey = getEventLaneKey(event)
-        const lane = getEventLane(laneKey)
-        visibleLaneKeys.add(laneKey)
-
-        if (
-          !lane.processedEventIds.has(event.id) &&
-          !lane.processingEventIds.has(event.id) &&
-          !lane.acceptedEvents.has(event.id)
-        ) {
-          // A bounded source snapshot may evict this event before a slow predecessor finishes.
-          lane.acceptedEvents.set(event.id, event)
-          acceptedEventVersion += 1
-        }
-      }
-
-      for (const [laneKey, lane] of eventLanes) {
-        cleanEventLane(laneKey, lane)
-      }
-
-      const drains = [...visibleLaneKeys].map((laneKey) => drainLane(laneKey))
-      for (const [laneKey, lane] of eventLanes) {
-        if (!visibleLaneKeys.has(laneKey) && lane.acceptedEvents.size > 0) {
-          void drainLane(laneKey)
-        }
-      }
-
-      return Promise.all(drains).then(() => undefined)
-    },
-    drain: async (sessionId) => {
-      if (sessionId !== undefined) {
-        if (eventLanes.has(sessionId)) await drainLane(sessionId)
-        return
-      }
-
-      let drainedVersion: number
-      do {
-        drainedVersion = acceptedEventVersion
-        await Promise.all([...eventLanes.keys()].map((laneKey) => drainLane(laneKey)))
-      } while (drainedVersion !== acceptedEventVersion)
-    }
-  }
-}
-
-const liveWorkspaceRuntimeEventProcessor = createWorkspaceRuntimeEventProcessor()
 
 const sessionOwnsActivePrompt = (sessionId: string, messageId: string): boolean => {
   const session = useSessionStore
@@ -1920,64 +1725,6 @@ const processContextOverflowRecovery = (
   }
 }
 
-// Flags sessions with an active prompt or native compaction as disconnected on a TRANSITION into a
-// dropped connection state. Abnormal drops (agent crash / gateway drop) go through main's
-// handleConnectionClosed → status 'closed'; deliberate mid-prompt disconnects use disconnect(false)
-// (no 'closed' emit) and idle provider/skills reconnects have no active interaction, so neither reaches
-// markDisconnected here.
-const markRunningSessionsDisconnectedOnDrop = (
-  previousStatus: AcpConnectionStatus,
-  currentStatus: AcpConnectionStatus,
-  previousSessionStatuses: Partial<Record<string, AcpConnectionStatus>> = {},
-  currentSessionStatuses: Partial<Record<string, AcpConnectionStatus>> = {}
-): void => {
-  const { sessions, markDisconnected } = useSessionStore.getState()
-
-  for (const session of sessions) {
-    if (
-      session.status !== 'running' &&
-      session.status !== 'waiting-permission' &&
-      !session.compacting
-    ) {
-      continue
-    }
-
-    const previousOwnedStatus = previousSessionStatuses[session.id]
-    const currentOwnedStatus = currentSessionStatuses[session.id]
-    const hasOwningRuntimeStatus =
-      previousOwnedStatus !== undefined || currentOwnedStatus !== undefined
-    const previous = hasOwningRuntimeStatus
-      ? (previousOwnedStatus ?? currentOwnedStatus ?? previousStatus)
-      : previousStatus
-    const current = hasOwningRuntimeStatus
-      ? (currentOwnedStatus ?? previousOwnedStatus ?? currentStatus)
-      : currentStatus
-    const droppedNow =
-      (current === 'closed' || current === 'error') && previous !== 'closed' && previous !== 'error'
-
-    if (droppedNow) markDisconnected(session.id)
-  }
-}
-
-// Copies live context usage into the durable Session. Missing usage clears only attached sessions,
-// preserving the last snapshot for detached sessions while invalidating replaced runtime contexts.
-const syncWorkspaceContextUsage = (
-  sessionIds: readonly string[],
-  contextUsageBySession: Record<string, AcpContextUsage>
-): void => {
-  const { setContextUsage } = useSessionStore.getState()
-  for (const sessionId of sessionIds) {
-    setContextUsage(sessionId, contextUsageBySession[sessionId])
-  }
-}
-
-const drainWorkspaceRuntimeEventsForPersistence = async (sessionId?: string): Promise<void> => {
-  const snapshot = await window.api.acp.getState()
-  void liveWorkspaceRuntimeEventProcessor.process(snapshot.events)
-  await liveWorkspaceRuntimeEventProcessor.drain(sessionId)
-  syncWorkspaceContextUsage(snapshot.sessionIds, snapshot.contextUsageBySession)
-}
-
 // Deletes in three ordered ownership layers: agent runtime, durable JSON/DB coordinator, then renderer
 // state. A failure in either authoritative layer leaves the session visible with an actionable error.
 const deleteWorkspaceSession = async (
@@ -2133,8 +1880,7 @@ const useWorkspaceAgentRuntime = (): {
   // Publish ownership before processing the same snapshot's events. A first visible chunk then clears
   // the wait monotonically instead of a later effect rearming it from that snapshot.
   useEffect(() => {
-    syncWorkspaceAgentFirstOutputState(agentPromptInFlightSessionIds)
-    void liveWorkspaceRuntimeEventProcessor.process(runtime.state.events)
+    void processWorkspaceRuntimeEvents(runtime.state.events, agentPromptInFlightSessionIds)
   }, [agentPromptInFlightSessionIds, runtime.state.events])
 
   // Mirrors pending permission requests into per-session store status.

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -18,13 +18,16 @@ import { saveSessionInOrder } from '../session-persistence/session-persistence'
 import {
   applyWorkspaceRuntimeEvent,
   assembleReviewRunRequest,
-  syncWorkspaceAgentFirstOutputState,
-  syncWorkspacePermissionState,
   suppressAutoReviewsForQuit,
   suppressNextAutoReview,
   clearSuppressNextAutoReview,
   resetDeferredArtifactEventsForTests
 } from './workspace-events'
+import {
+  resetWorkspaceRuntimeEventOwnerForTests,
+  syncWorkspaceAgentFirstOutputState,
+  syncWorkspacePermissionState
+} from './workspace-runtime-event-owner'
 
 // Creates a runtime event with stable defaults for store adapter tests.
 const createEvent = (overrides: Partial<AcpRuntimeEvent>): AcpRuntimeEvent => ({
@@ -68,6 +71,7 @@ describe('workspace runtime events', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-07-04T08:00:00.000Z'))
     resetDeferredArtifactEventsForTests()
+    resetWorkspaceRuntimeEventOwnerForTests()
     useSessionStore.setState(createInitialSessionState())
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     useSessionStore.getState().appendUserMessage({

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -1,8 +1,4 @@
-import type {
-  AcpRuntimeEvent,
-  AcpPermissionRequest,
-  AcpTurnTokenUsage
-} from '../../../../shared/acp'
+import type { AcpRuntimeEvent, AcpTurnTokenUsage } from '../../../../shared/acp'
 import {
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile,
@@ -37,12 +33,6 @@ import {
   isRuntimeChatMessageEvent
 } from './chat-events'
 
-// Remembers which sessions were marked as waiting during the previous permission sync.
-const pendingPermissionSessionIds = new Set<string>()
-// Tracks runtime prompt-ownership entry edges. A first visible chunk clears the store flag without
-// removing this id, so repeated snapshots for the same prompt cannot re-arm the indicator.
-const firstOutputWaitingSessionIds = new Set<string>()
-
 // Sessions whose next triggerAutoReview call should be skipped exactly once.
 // Used to suppress the re-review that would otherwise be triggered by the [Auditor] correction turn:
 // the main process broadcasts reviewer:suppress-next-auto-review before sending the correction prompt;
@@ -76,7 +66,6 @@ const AUTO_REVIEW_ARTIFACT_SETTLE_DELAY_MS = 100
 const resetDeferredArtifactEventsForTests = (): void => {
   deferredArtifactEventsBySession.clear()
   pendingArtifactTurnUsageBySession.clear()
-  firstOutputWaitingSessionIds.clear()
   for (const timer of scheduledAutoReviewsBySession.values()) clearTimeout(timer)
   scheduledAutoReviewsBySession.clear()
   autoReviewsSuppressedForQuit = false
@@ -745,60 +734,9 @@ const applyWorkspaceRuntimeEvent = async (
   return false
 }
 
-// Keeps store permission state aligned with the runtime's current pending request set.
-const syncWorkspacePermissionState = (requests: AcpPermissionRequest[]): void => {
-  const nextSessionIds = new Set(requests.map((request) => request.sessionId))
-  const store = useSessionStore.getState()
-
-  // New pending sessions enter the waiting-permission status.
-  for (const sessionId of nextSessionIds) {
-    if (!pendingPermissionSessionIds.has(sessionId)) {
-      store.setPermissionPending(sessionId)
-    }
-  }
-
-  // Sessions with no pending request return to their prior run-derived status.
-  for (const sessionId of pendingPermissionSessionIds) {
-    if (!nextSessionIds.has(sessionId)) {
-      store.clearPermissionPending(sessionId)
-    }
-  }
-
-  pendingPermissionSessionIds.clear()
-
-  // Remember the current set for the next sync pass.
-  for (const sessionId of nextSessionIds) {
-    pendingPermissionSessionIds.add(sessionId)
-  }
-}
-
-// Projects runtime foreground ownership and its initial silent gap into renderer-only state. Unknown
-// ids belong to background/runtime-only sessions; repeated snapshots must not restart the gap timer.
-const syncWorkspaceAgentFirstOutputState = (sessionIds: string[]): void => {
-  const nextSessionIds = new Set(sessionIds)
-  const store = useSessionStore.getState()
-  const workspaceSessionIds = new Set(store.sessions.map((session) => session.id))
-
-  for (const sessionId of nextSessionIds) {
-    if (!workspaceSessionIds.has(sessionId) || firstOutputWaitingSessionIds.has(sessionId)) continue
-    store.setAgentPromptInFlight(sessionId, true)
-    store.setAwaitingFirstAgentOutput(sessionId, true)
-    firstOutputWaitingSessionIds.add(sessionId)
-  }
-
-  for (const sessionId of firstOutputWaitingSessionIds) {
-    if (nextSessionIds.has(sessionId)) continue
-    store.setAgentPromptInFlight(sessionId, false)
-    store.setAwaitingFirstAgentOutput(sessionId, false)
-    firstOutputWaitingSessionIds.delete(sessionId)
-  }
-}
-
 export {
   applyWorkspaceRuntimeEvent,
   assembleReviewRunRequest,
-  syncWorkspaceAgentFirstOutputState,
-  syncWorkspacePermissionState,
   suppressAutoReviewsForQuit,
   suppressNextAutoReview,
   clearSuppressNextAutoReview,

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -1,0 +1,318 @@
+import type {
+  AcpConnectionStatus,
+  AcpContextUsage,
+  AcpPermissionRequest,
+  AcpRuntimeEvent
+} from '../../../../shared/acp'
+import { useSessionStore } from '../../stores/session-store'
+import { applyWorkspaceRuntimeEvent } from './workspace-events'
+
+// Snapshot projections retain only transition edges; durable chat facts remain in Session Store.
+const pendingPermissionSessionIds = new Set<string>()
+const firstOutputWaitingSessionIds = new Set<string>()
+
+type RuntimeEventApplier = (event: AcpRuntimeEvent) => Promise<boolean>
+
+type WorkspaceRuntimeEventProcessor = {
+  process: (events: AcpRuntimeEvent[]) => Promise<void>
+  drain: (sessionId?: string) => Promise<void>
+}
+
+const processVisibleWorkspaceRuntimeEvents = async (
+  events: AcpRuntimeEvent[],
+  processedEventIds: Set<string>,
+  applyEvent: RuntimeEventApplier = applyWorkspaceRuntimeEvent,
+  processingEventIds = new Set<string>()
+): Promise<void> => {
+  // Runtime snapshots are bounded, so forget ids that can no longer be replayed from the source list.
+  const visibleEventIds = new Set(events.map((event) => event.id))
+
+  for (const eventId of processedEventIds) {
+    if (!visibleEventIds.has(eventId)) processedEventIds.delete(eventId)
+  }
+
+  for (const eventId of processingEventIds) {
+    if (!visibleEventIds.has(eventId)) processingEventIds.delete(eventId)
+  }
+
+  for (const event of events) {
+    if (processedEventIds.has(event.id) || processingEventIds.has(event.id)) continue
+
+    processingEventIds.add(event.id)
+    try {
+      // Apply visible events sequentially so message chunks and artifact finalization stay ordered.
+      await applyEvent(event)
+      processedEventIds.add(event.id)
+    } catch {
+      // Artifact finalization errors are recorded by the adapter before throwing.
+      // Keeping this id unprocessed lets the same visible runtime event retry.
+      continue
+    } finally {
+      processingEventIds.delete(event.id)
+    }
+  }
+}
+
+const createWorkspaceRuntimeEventProcessor = (
+  applyEvent: RuntimeEventApplier = applyWorkspaceRuntimeEvent
+): WorkspaceRuntimeEventProcessor => {
+  type EventLane = {
+    acceptedEvents: Map<string, AcpRuntimeEvent>
+    failedEventIds: Set<string>
+    processedEventIds: Set<string>
+    processingEventIds: Set<string>
+    drainInFlight?: Promise<void>
+    drainAgain: boolean
+  }
+
+  const unscopedEventLane = Symbol('unscoped-workspace-runtime-events')
+  const eventLanes = new Map<string | symbol, EventLane>()
+  let latestEvents: AcpRuntimeEvent[] = []
+  let acceptedEventVersion = 0
+
+  const getEventLaneKey = (event: AcpRuntimeEvent): string | symbol =>
+    event.sessionId ?? unscopedEventLane
+
+  const getEventLane = (laneKey: string | symbol): EventLane => {
+    let lane = eventLanes.get(laneKey)
+    if (!lane) {
+      lane = {
+        acceptedEvents: new Map<string, AcpRuntimeEvent>(),
+        failedEventIds: new Set<string>(),
+        processedEventIds: new Set<string>(),
+        processingEventIds: new Set<string>(),
+        drainAgain: false
+      }
+      eventLanes.set(laneKey, lane)
+    }
+
+    return lane
+  }
+
+  const cleanEventLane = (laneKey: string | symbol, lane: EventLane): void => {
+    const visibleEventIds = new Set(
+      latestEvents.filter((event) => getEventLaneKey(event) === laneKey).map((event) => event.id)
+    )
+
+    for (const eventId of lane.acceptedEvents.keys()) {
+      if (!visibleEventIds.has(eventId) && lane.processedEventIds.has(eventId)) {
+        lane.acceptedEvents.delete(eventId)
+        lane.failedEventIds.delete(eventId)
+        lane.processedEventIds.delete(eventId)
+        lane.processingEventIds.delete(eventId)
+      }
+    }
+
+    if (lane.acceptedEvents.size === 0 && !lane.drainInFlight) eventLanes.delete(laneKey)
+  }
+
+  const drainLane = async (laneKey: string | symbol): Promise<void> => {
+    const lane = getEventLane(laneKey)
+
+    if (lane.drainInFlight) {
+      lane.drainAgain = true
+      return lane.drainInFlight
+    }
+
+    lane.drainInFlight = (async () => {
+      do {
+        lane.drainAgain = false
+        await processVisibleWorkspaceRuntimeEvents(
+          [...lane.acceptedEvents.values()],
+          lane.processedEventIds,
+          async (event) => {
+            const hadFailed = lane.failedEventIds.has(event.id)
+            try {
+              const applied = await applyEvent(event)
+              lane.failedEventIds.delete(event.id)
+              return applied
+            } catch (error) {
+              const isVisible = latestEvents.some(
+                (candidate) => candidate.id === event.id && getEventLaneKey(candidate) === laneKey
+              )
+              if (hadFailed && !isVisible) {
+                lane.acceptedEvents.delete(event.id)
+                lane.failedEventIds.delete(event.id)
+              } else {
+                lane.failedEventIds.add(event.id)
+              }
+              throw error
+            }
+          },
+          lane.processingEventIds
+        )
+      } while (lane.drainAgain)
+    })()
+
+    try {
+      await lane.drainInFlight
+    } finally {
+      lane.drainInFlight = undefined
+      cleanEventLane(laneKey, lane)
+    }
+  }
+
+  return {
+    process: (events) => {
+      latestEvents = events
+      const visibleLaneKeys = new Set<string | symbol>()
+
+      for (const event of events) {
+        const laneKey = getEventLaneKey(event)
+        const lane = getEventLane(laneKey)
+        visibleLaneKeys.add(laneKey)
+
+        if (
+          !lane.processedEventIds.has(event.id) &&
+          !lane.processingEventIds.has(event.id) &&
+          !lane.acceptedEvents.has(event.id)
+        ) {
+          // A bounded source snapshot may evict this event before a slow predecessor finishes.
+          lane.acceptedEvents.set(event.id, event)
+          acceptedEventVersion += 1
+        }
+      }
+
+      for (const [laneKey, lane] of eventLanes) cleanEventLane(laneKey, lane)
+
+      const drains = [...visibleLaneKeys].map((laneKey) => drainLane(laneKey))
+      for (const [laneKey, lane] of eventLanes) {
+        if (!visibleLaneKeys.has(laneKey) && lane.acceptedEvents.size > 0) void drainLane(laneKey)
+      }
+
+      return Promise.all(drains).then(() => undefined)
+    },
+    drain: async (sessionId) => {
+      if (sessionId !== undefined) {
+        if (eventLanes.has(sessionId)) await drainLane(sessionId)
+        return
+      }
+
+      let drainedVersion: number
+      do {
+        drainedVersion = acceptedEventVersion
+        await Promise.all([...eventLanes.keys()].map((laneKey) => drainLane(laneKey)))
+      } while (drainedVersion !== acceptedEventVersion)
+    }
+  }
+}
+
+const liveWorkspaceRuntimeEventProcessor = createWorkspaceRuntimeEventProcessor()
+
+// Projects runtime foreground ownership and its initial silent gap into renderer-only state. Unknown
+// ids belong to background/runtime-only sessions; repeated snapshots must not restart the gap timer.
+const syncWorkspaceAgentFirstOutputState = (sessionIds: string[]): void => {
+  const nextSessionIds = new Set(sessionIds)
+  const store = useSessionStore.getState()
+  const workspaceSessionIds = new Set(store.sessions.map((session) => session.id))
+
+  for (const sessionId of nextSessionIds) {
+    if (!workspaceSessionIds.has(sessionId) || firstOutputWaitingSessionIds.has(sessionId)) continue
+    store.setAgentPromptInFlight(sessionId, true)
+    store.setAwaitingFirstAgentOutput(sessionId, true)
+    firstOutputWaitingSessionIds.add(sessionId)
+  }
+
+  for (const sessionId of firstOutputWaitingSessionIds) {
+    if (nextSessionIds.has(sessionId)) continue
+    store.setAgentPromptInFlight(sessionId, false)
+    store.setAwaitingFirstAgentOutput(sessionId, false)
+    firstOutputWaitingSessionIds.delete(sessionId)
+  }
+}
+
+// Keeps store permission state aligned with the runtime's current pending request set.
+const syncWorkspacePermissionState = (requests: AcpPermissionRequest[]): void => {
+  const nextSessionIds = new Set(requests.map((request) => request.sessionId))
+  const store = useSessionStore.getState()
+
+  for (const sessionId of nextSessionIds) {
+    if (!pendingPermissionSessionIds.has(sessionId)) store.setPermissionPending(sessionId)
+  }
+
+  for (const sessionId of pendingPermissionSessionIds) {
+    if (!nextSessionIds.has(sessionId)) store.clearPermissionPending(sessionId)
+  }
+
+  pendingPermissionSessionIds.clear()
+  for (const sessionId of nextSessionIds) pendingPermissionSessionIds.add(sessionId)
+}
+
+const resetWorkspaceRuntimeEventOwnerForTests = (): void => {
+  pendingPermissionSessionIds.clear()
+  firstOutputWaitingSessionIds.clear()
+}
+
+// Publishes prompt ownership before applying the same snapshot's events so first output can only
+// clear, never re-arm, the renderer waiting state.
+const processWorkspaceRuntimeEvents = (
+  events: AcpRuntimeEvent[],
+  agentPromptInFlightSessionIds: string[]
+): Promise<void> => {
+  syncWorkspaceAgentFirstOutputState(agentPromptInFlightSessionIds)
+  return liveWorkspaceRuntimeEventProcessor.process(events)
+}
+
+// Flags sessions with an active prompt or native compaction as disconnected on a transition into a
+// dropped connection state.
+const markRunningSessionsDisconnectedOnDrop = (
+  previousStatus: AcpConnectionStatus,
+  currentStatus: AcpConnectionStatus,
+  previousSessionStatuses: Partial<Record<string, AcpConnectionStatus>> = {},
+  currentSessionStatuses: Partial<Record<string, AcpConnectionStatus>> = {}
+): void => {
+  const { sessions, markDisconnected } = useSessionStore.getState()
+
+  for (const session of sessions) {
+    if (
+      session.status !== 'running' &&
+      session.status !== 'waiting-permission' &&
+      !session.compacting
+    ) {
+      continue
+    }
+
+    const previousOwnedStatus = previousSessionStatuses[session.id]
+    const currentOwnedStatus = currentSessionStatuses[session.id]
+    const hasOwningRuntimeStatus =
+      previousOwnedStatus !== undefined || currentOwnedStatus !== undefined
+    const previous = hasOwningRuntimeStatus
+      ? (previousOwnedStatus ?? currentOwnedStatus ?? previousStatus)
+      : previousStatus
+    const current = hasOwningRuntimeStatus
+      ? (currentOwnedStatus ?? previousOwnedStatus ?? currentStatus)
+      : currentStatus
+    const droppedNow =
+      (current === 'closed' || current === 'error') && previous !== 'closed' && previous !== 'error'
+
+    if (droppedNow) markDisconnected(session.id)
+  }
+}
+
+// Copies live context usage into the durable Session. Missing usage clears only attached sessions.
+const syncWorkspaceContextUsage = (
+  sessionIds: readonly string[],
+  contextUsageBySession: Record<string, AcpContextUsage>
+): void => {
+  const { setContextUsage } = useSessionStore.getState()
+  for (const sessionId of sessionIds) setContextUsage(sessionId, contextUsageBySession[sessionId])
+}
+
+const drainWorkspaceRuntimeEventsForPersistence = async (sessionId?: string): Promise<void> => {
+  const snapshot = await window.api.acp.getState()
+  void liveWorkspaceRuntimeEventProcessor.process(snapshot.events)
+  await liveWorkspaceRuntimeEventProcessor.drain(sessionId)
+  syncWorkspaceContextUsage(snapshot.sessionIds, snapshot.contextUsageBySession)
+}
+
+export {
+  createWorkspaceRuntimeEventProcessor,
+  drainWorkspaceRuntimeEventsForPersistence,
+  markRunningSessionsDisconnectedOnDrop,
+  processVisibleWorkspaceRuntimeEvents,
+  processWorkspaceRuntimeEvents,
+  resetWorkspaceRuntimeEventOwnerForTests,
+  syncWorkspaceAgentFirstOutputState,
+  syncWorkspaceContextUsage,
+  syncWorkspacePermissionState
+}

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -2773,6 +2773,7 @@ describe('session store public contract', () => {
       'src/renderer/src/lib/acp/history-preamble.ts',
       'src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts',
       'src/renderer/src/lib/acp/workspace-events.ts',
+      'src/renderer/src/lib/acp/workspace-runtime-event-owner.ts',
       'src/renderer/src/lib/active-session-display.ts',
       'src/renderer/src/lib/compute/useJobAnalysisEffect.ts',
       'src/renderer/src/lib/deep-link.ts',


### PR DESCRIPTION
# refactor(workspace-runtime): extract runtime event owner

## Problem

`useWorkspaceAgentRuntime.ts` still owned bounded runtime-event scheduling together with Session Store
snapshot projections. That mixed same-session ordering, cross-session concurrency, persistence drains,
first-output timing, permission waiting, context usage and disconnect transitions into the command
hook, leaving no single internal owner for the event-to-renderer boundary.

## Proposed change

- Add `workspace-runtime-event-owner.ts` as the sole owner of visible event lanes and runtime snapshot
  projections into Session Store.
- Preserve sequential processing within a Session, parallel processing across Sessions, bounded-window
  retention, failed-event retry and explicit Session/all-lane persistence drains.
- Move first-output and permission transition Sets out of the single-event adapter; keep
  `workspace-events.ts` responsible only for applying one accepted runtime event.
- Keep the current hook exports as compatibility re-exports and register the new owner and its existing
  behavioral tests under `workspace_runtime` module impact.

## Scope and non-goals

- WR1 ownership extraction only; send/resend, resume, compaction, overflow recovery, cancellation,
  deletion and permission commands remain in their current owners for later WR phases.
- No public hook shape, shared contract, preload/API, IPC payload, persisted data, data relationship,
  UI copy or interaction change.
- No new Store, dependency, generic event bus or speculative abstraction.

## Compatibility

- Preserve the exact 18-key `useWorkspaceAgentRuntime` surface and the existing event replay,
  first-output, terminal usage, Plan, Permission, Specialist, Compute and Artifact semantics.
- Preserve interrupted-turn hidden continuation, pending history replay, Provider identity/continuity
  adoption and the Session-scoped drain barrier introduced on the `aaa20043` baseline.
- The overflow recovery effect remains before event processing; first-output ownership is still
  projected before events from the same runtime snapshot are applied.
- Electron, Web, CLI and Task capability asymmetry is unchanged; no IPC/data/UI boundary moves.
- No executable filesystem path or platform-specific fixture was added, so Windows, macOS and Linux
  behavior remains unchanged.

## Acceptance criteria and validation

- `workspace-runtime-event-owner.ts`: 318 raw lines, below the 600-line target and 660-line hard limit.
- Baseline: `origin/main 0a3b7270`; includes the interrupted-turn continuation fix and the latest
  unrelated Notebook captured-output change.
- `useWorkspaceAgentRuntime.ts`: 2,335 -> 2,081 raw lines; `workspace-events.ts`: 806 -> 744 raw lines.
- Touched production raw diff: +327/-325; public hook and compatibility export paths remain unchanged.
- `npm run test:module -- workspace_runtime`: 5 files / 223 tests passed.
- Module-impact validation/planner/shadow set: 3 files / 29 tests passed.
- Session Store public-facade architecture guard: 1 file / 110 tests passed after registering the new
  internal owner as an expected public-store consumer.
- Full `npm run typecheck` (Node + Web), `npm run lint` (0 errors; 17 pre-existing warnings), targeted
  Prettier and `git diff --check` passed.
- Full local `npm test`: 850 files / 12,458 tests passed, 14 files / 190 tests skipped. The known
  `src/main/projects/prisma-client.test.ts` runtime-DDL failure remained, and one unrelated
  `job-poller.test.ts` assertion flaked under full concurrency before passing its isolated 28-test
  rerun. Clean `main@aaa20043` independently reproduces the Prisma mismatch, and the intervening
  `0a3b7270` change is Notebook-only; WR1 changes no Prisma, database, Compute or main-process file.

## Review focus

- Confirm snapshot-level first-output and permission transition state has one module-singleton owner,
  while `workspace-events.ts` retains only single-event adapter state.
- Confirm no accepted event can be reordered within a Session, dropped when a bounded snapshot evicts
  it, duplicated during overlapping snapshots or made to block an unrelated Session lane.
- Confirm overflow recovery ordering, persistence drains, hook surface and Electron/Web/CLI/Task
  compatibility remain unchanged.
