### PR TITLE
refactor(inputs): unify immutable input authority

### DIFF
--- a/src/main/artifacts/provenance-producer-capture.ts
+++ b/src/main/artifacts/provenance-producer-capture.ts
@@ -1,7 +1,7 @@
 import { readFile, realpath, stat } from 'node:fs/promises'
 import { isAbsolute, relative, resolve, sep } from 'node:path'
 
-import type { Prisma, PrismaClient } from '@prisma/client'
+import type { Prisma } from '@prisma/client'
 
 import type {
   ArtifactProducerUnavailableReason,
@@ -14,6 +14,7 @@ import type {
   NotebookRunInputFile,
   NotebookRunRecord
 } from '../../shared/notebook'
+import type { ImmutableInputAuthority } from '../immutable-input-authority'
 import { NotebookRunRepository } from '../notebook/repository'
 import { canonicalJson, sha256, type CanonicalJson } from './provenance-canonical'
 import {
@@ -57,7 +58,7 @@ type PreparedArtifactVersionPersistence = {
 }
 
 type ArtifactProvenanceProducerCaptureOptions = {
-  getClient: () => Promise<PrismaClient>
+  inputAuthority: Pick<ImmutableInputAuthority, 'validateVersion'>
   notebookRepository: Pick<NotebookRunRepository, 'findExisting'>
   createId: () => string
 }
@@ -495,48 +496,14 @@ class ArtifactProvenanceProducerCapture {
     projectId: string,
     inputs: NotebookRunInputFile[]
   ): Promise<void> {
-    const client = await this.options.getClient()
     for (const input of inputs) {
-      if (input.sourceProjectId !== projectId) {
+      const validation = await this.options.inputAuthority.validateVersion(projectId, input)
+      if (validation.state === 'project-mismatch') {
         throw new Error(`Notebook input belongs to another Project: ${input.inputFileVersionId}`)
       }
-      if (input.sourceKind === 'upload-version') {
-        const version = await client.uploadVersion.findUnique({
-          where: { id: input.inputFileVersionId },
-          include: { uploadFile: true }
-        })
-        if (
-          !version ||
-          version.state !== 'ready' ||
-          version.uploadFileId !== input.sourceFileId ||
-          version.uploadFile.projectId !== input.sourceProjectId ||
-          version.uploadFile.sessionId !== input.sourceSessionId ||
-          version.versionNumber !== input.sourceVersionNumber ||
-          version.contentStorageKey !== input.storageKey ||
-          version.checksum !== input.checksum ||
-          Number(version.sizeBytes) !== input.sizeBytes
-        ) {
-          throw new Error(`Notebook Upload input identity is corrupt: ${input.inputFileVersionId}`)
-        }
-        continue
-      }
-
-      const version = await client.artifactVersion.findUnique({
-        where: { id: input.inputFileVersionId },
-        include: { artifact: true }
-      })
-      if (
-        !version ||
-        version.state !== 'finalized' ||
-        version.artifactId !== input.sourceFileId ||
-        version.artifact.projectId !== input.sourceProjectId ||
-        version.artifact.sessionId !== input.sourceSessionId ||
-        version.versionNumber !== input.sourceVersionNumber ||
-        version.contentStorageKey !== input.storageKey ||
-        version.checksum !== input.checksum ||
-        Number(version.sizeBytes) !== input.sizeBytes
-      ) {
-        throw new Error(`Notebook Artifact input identity is corrupt: ${input.inputFileVersionId}`)
+      if (validation.state !== 'available') {
+        const label = input.sourceKind === 'upload-version' ? 'Upload' : 'Artifact'
+        throw new Error(`Notebook ${label} input identity is corrupt: ${input.inputFileVersionId}`)
       }
     }
   }

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -21,6 +21,7 @@ import {
   type ResolveArtifactVersionDescriptorsRequest
 } from '../../shared/artifacts'
 import { ArtifactRepository } from './repository'
+import { ImmutableInputAuthority } from '../immutable-input-authority'
 import { defaultArtifactDurability, type ArtifactDurability } from './durability'
 import {
   ArtifactProvenanceVersionWriter,
@@ -51,6 +52,7 @@ const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 type ArtifactProvenanceRepositoryOptions = {
   storageRoot: string
   getClient: () => Promise<PrismaClient>
+  inputAuthority?: Pick<ImmutableInputAuthority, 'validateVersion'>
   compatibilityRepository?: ArtifactRepository
   notebookRepository?: Pick<NotebookRunRepository, 'findExisting'>
   loadSession?: (
@@ -128,6 +130,12 @@ class ArtifactProvenanceRepository {
     this.createId = options.createId ?? randomUUID
     this.now = options.now ?? (() => new Date())
     this.durability = options.durability ?? defaultArtifactDurability
+    const inputAuthority =
+      options.inputAuthority ??
+      new ImmutableInputAuthority({
+        storageRoot: options.storageRoot,
+        getClient: options.getClient
+      })
     this.readModel = new ArtifactProvenanceReadModel({
       storageRoot: options.storageRoot,
       getClient: options.getClient,
@@ -142,7 +150,7 @@ class ArtifactProvenanceRepository {
         this.resolveVersionDerivedPath(request, filename)
     })
     this.producerCapture = new ArtifactProvenanceProducerCapture({
-      getClient: options.getClient,
+      inputAuthority,
       notebookRepository,
       createId: this.createId
     })

--- a/src/main/artifacts/provenance-write-contract.test.ts
+++ b/src/main/artifacts/provenance-write-contract.test.ts
@@ -5,6 +5,7 @@ import { mkdir, readFile, realpath, stat, writeFile } from 'node:fs/promises'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import type { NotebookRunInputFile } from '../../shared/notebook'
+import { ImmutableInputAuthority } from '../immutable-input-authority'
 import { createPngBytes } from './artifact-test-fixtures'
 import * as provenanceModule from './provenance-repository'
 import { ArtifactProvenanceRepository } from './provenance-repository'
@@ -233,6 +234,66 @@ const appendNotebookRun = async (
     path: await realpath(sourcePath),
     sizeBytes: sourceStat.size,
     mtimeMs: sourceStat.mtimeMs
+  }
+}
+
+const createReadyUploadInput = async (
+  value: Fixture
+): Promise<{ input: NotebookRunInputFile; inputPath: string }> => {
+  const content = 'source-A'
+  const storageKey =
+    'uploads/project-1/source-session-1/upload-file-1/versions/upload-version-1/content'
+  const inputPath = join(value.storageRoot, ...storageKey.split('/'))
+  const createdAt = new Date('2026-08-08T08:00:00.000Z')
+  await mkdir(dirname(inputPath), { recursive: true })
+  await writeFile(inputPath, content)
+  await value.client.fileOriginSession.upsert({
+    where: {
+      projectId_sessionId: { projectId: 'project-1', sessionId: 'source-session-1' }
+    },
+    create: { projectId: 'project-1', sessionId: 'source-session-1' },
+    update: {}
+  })
+  await value.client.uploadFile.create({
+    data: {
+      id: 'upload-file-1',
+      projectId: 'project-1',
+      sessionId: 'source-session-1',
+      filename: 'input.csv',
+      originalFilename: 'input.csv',
+      versions: {
+        create: {
+          id: 'upload-version-1',
+          versionNumber: 1,
+          state: 'ready',
+          contentStorageKey: storageKey,
+          filename: 'input.csv',
+          originalFilename: 'input.csv',
+          contentType: 'text/csv',
+          sizeBytes: BigInt(Buffer.byteLength(content)),
+          checksum: sha256(content),
+          createdAt
+        }
+      }
+    }
+  })
+  return {
+    inputPath,
+    input: {
+      inputFileVersionId: 'upload-version-1',
+      sourceKind: 'upload-version',
+      sourceFileId: 'upload-file-1',
+      sourceVersionNumber: 1,
+      sourceCreatedAt: createdAt.toISOString(),
+      sourceProjectId: 'project-1',
+      sourceSessionId: 'source-session-1',
+      filename: 'input.csv',
+      contentType: 'text/csv',
+      sizeBytes: Buffer.byteLength(content),
+      checksum: sha256(content),
+      storageKey,
+      association: 'resolver-accessed'
+    }
   }
 }
 
@@ -468,6 +529,73 @@ describe('artifact provenance input authority', () => {
         })
       )
     ).rejects.toThrow(error)
+    await expect(value.client.artifactVersion.count()).resolves.toBe(0)
+  })
+
+  it('rejects corrupt immutable input bytes at Provenance commit time', async () => {
+    const value = await fixture()
+    const { input, inputPath } = await createReadyUploadInput(value)
+    const inputAuthority = new ImmutableInputAuthority({
+      storageRoot: value.storageRoot,
+      getClient: () => Promise.resolve(value.client)
+    })
+    await inputAuthority.resolveVersion({
+      projectId: 'project-1',
+      sourceKind: input.sourceKind,
+      inputFileVersionId: input.inputFileVersionId,
+      expectedSourceFileId: input.sourceFileId
+    })
+    const repository = new ArtifactProvenanceRepository({
+      ...value.repositoryOptions,
+      inputAuthority
+    })
+    const observation = await appendNotebookRun(value, {
+      runId: 'corrupt-input-run',
+      filename: 'plot.png',
+      payload: 'derived bytes',
+      ownsSource: true,
+      inputFiles: [input]
+    })
+    await writeFile(inputPath, 'source-B')
+    await value.stagePng('derived bytes')
+
+    await expect(
+      repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'corrupt-input-operation',
+          notebookSessionId: 'session-1',
+          producerRunId: 'corrupt-input-run',
+          sourceKind: 'localPath',
+          sourceFileObservation: observation
+        })
+      )
+    ).rejects.toThrow(/input content checksum/i)
+    await expect(value.client.artifactVersion.count()).resolves.toBe(0)
+  })
+
+  it('rejects immutable input metadata drift at Provenance commit time', async () => {
+    const value = await fixture()
+    const { input } = await createReadyUploadInput(value)
+    const observation = await appendNotebookRun(value, {
+      runId: 'metadata-drift-run',
+      filename: 'plot.png',
+      payload: 'derived bytes',
+      ownsSource: true,
+      inputFiles: [{ ...input, sourceVersionNumber: 2 }]
+    })
+    await value.stagePng('derived bytes')
+
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'metadata-drift-operation',
+          notebookSessionId: 'session-1',
+          producerRunId: 'metadata-drift-run',
+          sourceKind: 'localPath',
+          sourceFileObservation: observation
+        })
+      )
+    ).rejects.toThrow(`Notebook Upload input identity is corrupt: ${input.inputFileVersionId}`)
     await expect(value.client.artifactVersion.count()).resolves.toBe(0)
   })
 

--- a/src/main/immutable-input-authority.ts
+++ b/src/main/immutable-input-authority.ts
@@ -1,0 +1,209 @@
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { realpath, stat } from 'node:fs/promises'
+import { isAbsolute, resolve, sep } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+
+import type { NotebookRunInputFile } from '../shared/notebook'
+
+type ResolveImmutableInputVersionRequest = {
+  projectId: string
+  sourceKind: NotebookRunInputFile['sourceKind']
+  inputFileVersionId: string
+  expectedSourceFileId?: string
+}
+
+type ImmutableInputAuthorityOptions = {
+  storageRoot: string
+  getClient: () => Promise<PrismaClient>
+}
+
+type ImmutableInputVersionValidation =
+  | { state: 'available'; input: NotebookRunInputFile }
+  | { state: 'project-mismatch' | 'unavailable' | 'identity-mismatch' }
+
+type VerifiedContent = {
+  fingerprint: string
+  checksum: string
+}
+
+const fileFingerprint = (file: Awaited<ReturnType<typeof stat>>): string =>
+  [file.dev, file.ino, file.size, file.mtimeMs, file.ctimeMs].join(':')
+
+const matchesVersionIdentity = (
+  current: NotebookRunInputFile,
+  expected: NotebookRunInputFile
+): boolean =>
+  current.sourceFileId === expected.sourceFileId &&
+  current.sourceProjectId === expected.sourceProjectId &&
+  current.sourceSessionId === expected.sourceSessionId &&
+  current.sourceVersionNumber === expected.sourceVersionNumber &&
+  current.storageKey === expected.storageKey &&
+  current.checksum === expected.checksum &&
+  current.sizeBytes === expected.sizeBytes
+
+class ImmutableInputAuthority {
+  private readonly verifiedContent = new Map<string, VerifiedContent>()
+
+  constructor(private readonly options: ImmutableInputAuthorityOptions) {}
+
+  async resolveVersion(
+    request: ResolveImmutableInputVersionRequest
+  ): Promise<NotebookRunInputFile | undefined> {
+    const input = await this.loadVersion(request)
+    if (!input) return undefined
+    await this.resolveContent(input)
+    return input
+  }
+
+  async validateVersion(
+    projectId: string,
+    input: NotebookRunInputFile
+  ): Promise<ImmutableInputVersionValidation> {
+    if (input.sourceProjectId !== projectId) {
+      return { state: 'project-mismatch' }
+    }
+    const current = await this.loadVersion({
+      projectId,
+      sourceKind: input.sourceKind,
+      inputFileVersionId: input.inputFileVersionId,
+      expectedSourceFileId: input.sourceFileId
+    })
+    if (!current) return { state: 'unavailable' }
+    if (!matchesVersionIdentity(current, input)) return { state: 'identity-mismatch' }
+    await this.resolveContent(current)
+    return { state: 'available', input: current }
+  }
+
+  async resolveContent(input: NotebookRunInputFile): Promise<string> {
+    const storageRoot = resolve(this.options.storageRoot)
+    const segments = input.storageKey.split('/')
+    if (
+      !input.storageKey ||
+      isAbsolute(input.storageKey) ||
+      input.storageKey.includes('\\') ||
+      segments.some((segment) => !segment || segment === '.' || segment === '..')
+    ) {
+      throw new Error('Invalid Notebook input storage key.')
+    }
+    const absolutePath = resolve(storageRoot, ...segments)
+    const storageRelativePath = absolutePath.slice(storageRoot.length)
+    if (
+      absolutePath === storageRoot ||
+      (!storageRelativePath.startsWith(sep) && storageRelativePath !== '')
+    ) {
+      throw new Error('Notebook input storage key escapes managed storage.')
+    }
+
+    const [resolvedRoot, resolvedPath] = await Promise.all([
+      realpath(storageRoot),
+      realpath(absolutePath)
+    ])
+    const resolvedRelativePath = resolvedPath.slice(resolvedRoot.length)
+    if (
+      resolvedPath === resolvedRoot ||
+      (!resolvedRelativePath.startsWith(sep) && resolvedRelativePath !== '')
+    ) {
+      throw new Error('Notebook input content escapes managed storage.')
+    }
+
+    const file = await stat(resolvedPath)
+    if (!file.isFile() || file.size !== input.sizeBytes) {
+      throw new Error(
+        'Notebook input content is missing or no longer matches its immutable metadata.'
+      )
+    }
+    const fingerprint = fileFingerprint(file)
+    const cached = this.verifiedContent.get(input.storageKey)
+    if (cached?.fingerprint === fingerprint && cached.checksum === input.checksum) {
+      return resolvedPath
+    }
+
+    const hash = createHash('sha256')
+    for await (const chunk of createReadStream(resolvedPath)) hash.update(chunk)
+    if (hash.digest('hex') !== input.checksum) {
+      throw new Error('Notebook input content checksum does not match its immutable metadata.')
+    }
+    const afterRead = await stat(resolvedPath)
+    if (fileFingerprint(afterRead) !== fingerprint) {
+      throw new Error('Notebook input content changed while its checksum was being validated.')
+    }
+    this.verifiedContent.set(input.storageKey, { fingerprint, checksum: input.checksum })
+    return resolvedPath
+  }
+
+  private async loadVersion(
+    request: ResolveImmutableInputVersionRequest
+  ): Promise<NotebookRunInputFile | undefined> {
+    const client = await this.options.getClient()
+    if (request.sourceKind === 'upload-version') {
+      const version = await client.uploadVersion.findFirst({
+        where: {
+          id: request.inputFileVersionId,
+          state: 'ready',
+          uploadFile: { is: { projectId: request.projectId } }
+        },
+        include: { uploadFile: true }
+      })
+      if (
+        !version ||
+        (request.expectedSourceFileId && version.uploadFileId !== request.expectedSourceFileId)
+      ) {
+        return undefined
+      }
+      return {
+        inputFileVersionId: version.id,
+        sourceKind: request.sourceKind,
+        sourceFileId: version.uploadFileId,
+        sourceVersionNumber: version.versionNumber,
+        ...(version.createdAt ? { sourceCreatedAt: version.createdAt.toISOString() } : {}),
+        sourceProjectId: version.uploadFile.projectId,
+        sourceSessionId: version.uploadFile.sessionId,
+        filename: version.originalFilename || version.filename,
+        ...(version.contentType ? { contentType: version.contentType } : {}),
+        sizeBytes: Number(version.sizeBytes),
+        checksum: version.checksum,
+        storageKey: version.contentStorageKey,
+        association: 'turn-attached'
+      }
+    }
+
+    const version = await client.artifactVersion.findFirst({
+      where: {
+        id: request.inputFileVersionId,
+        state: 'finalized',
+        artifact: { is: { projectId: request.projectId } }
+      },
+      include: { artifact: true }
+    })
+    if (
+      !version ||
+      (request.expectedSourceFileId && version.artifactId !== request.expectedSourceFileId)
+    ) {
+      return undefined
+    }
+    return {
+      inputFileVersionId: version.id,
+      sourceKind: request.sourceKind,
+      sourceFileId: version.artifactId,
+      sourceVersionNumber: version.versionNumber,
+      sourceCreatedAt: version.createdAt.toISOString(),
+      sourceProjectId: version.artifact.projectId,
+      sourceSessionId: version.artifact.sessionId,
+      filename: version.artifact.filename,
+      ...(version.contentType ? { contentType: version.contentType } : {}),
+      sizeBytes: Number(version.sizeBytes),
+      checksum: version.checksum,
+      storageKey: version.contentStorageKey,
+      association: 'turn-attached'
+    }
+  }
+}
+
+export { ImmutableInputAuthority }
+export type {
+  ImmutableInputAuthorityOptions,
+  ImmutableInputVersionValidation,
+  ResolveImmutableInputVersionRequest
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -56,6 +56,7 @@ import { ALL_CONNECTOR_IDS } from './connectors/registry'
 import { ConnectorRuntimeSettingsProjection } from './connectors/runtime-settings-projection'
 import { ConnectorService } from './connectors/service'
 import { registerFileSaveHandlers } from './file-save'
+import { ImmutableInputAuthority } from './immutable-input-authority'
 import { createSessionArtifactFileResolver } from './session-artifact-file-resolver'
 import { createCliCommandOwner, registerCliInstallIpcHandlers } from './cli-install/ipc'
 import { createGithubCommandOwner, registerGithubIpcHandlers } from './github-ipc'
@@ -398,9 +399,14 @@ const createApplicationModules = async (
 
   // Share one repository and registry so runtime artifact claims and renderer finalization meet.
   const artifactRepository = createDefaultArtifactRepository()
+  const immutableInputAuthority = new ImmutableInputAuthority({
+    storageRoot: resolveDataRoot(),
+    getClient: () => getProjectDbClient(resolveStorageRoot())
+  })
   const artifactProvenanceRepository = new ArtifactProvenanceRepository({
     storageRoot: resolveDataRoot(),
     getClient: () => getProjectDbClient(resolveStorageRoot()),
+    inputAuthority: immutableInputAuthority,
     compatibilityRepository: artifactRepository,
     loadSession: (projectId, appSessionId) => sessionRepository.loadSession(projectId, appSessionId)
   })
@@ -412,8 +418,7 @@ const createApplicationModules = async (
   // The upload repository above is shared so staging recovery, Session upgrade, prompt finalization,
   // and previews all observe one durable Version authority.
   const notebookInputRegistry = new NotebookInputRegistry({
-    storageRoot: resolveDataRoot(),
-    getClient: () => getProjectDbClient(resolveStorageRoot())
+    inputAuthority: immutableInputAuthority
   })
   // Shared local-fs service backs both the "This computer" browser IPC and the managed-preview
   // resolver below, so path validation stays identical across both entry points.

--- a/src/main/notebook/input-registry.test.ts
+++ b/src/main/notebook/input-registry.test.ts
@@ -7,6 +7,7 @@ import type { PrismaClient } from '@prisma/client'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { ImmutableInputAuthority } from '../immutable-input-authority'
 import { NotebookInputRegistry } from './input-registry'
 import { createNotebookInputPreviewKey } from '../../shared/notebook'
 
@@ -128,7 +129,12 @@ const setup = async (): Promise<NotebookInputRegistry> => {
   storageRoot = await mkdtemp(join(tmpdir(), 'open-science-input-registry-'))
   client = createProjectDbClient(storageRoot)
   await ensureProjectSchema(client)
-  return new NotebookInputRegistry({ storageRoot, getClient: () => Promise.resolve(client!) })
+  return new NotebookInputRegistry({
+    inputAuthority: new ImmutableInputAuthority({
+      storageRoot,
+      getClient: () => Promise.resolve(client!)
+    })
+  })
 }
 
 describe('NotebookInputRegistry', () => {
@@ -307,7 +313,58 @@ describe('NotebookInputRegistry', () => {
     expect(() => lease.getRunInputFiles()).toThrow(/closed/i)
   })
 
-  it('rejects same-size input corruption before returning a managed path', async () => {
+  it('rechecks Version state and immutable metadata before a run', async () => {
+    const registry = await setup()
+    await createUpload({
+      projectId: 'project-1',
+      sessionId: 'source-session-1',
+      uploadFileId: 'upload-1',
+      versionId: 'upload-version-1',
+      filename: 'groups.csv',
+      content: 'group\nA\n'
+    })
+    const attachment = {
+      id: 'upload-1',
+      versionId: 'upload-version-1',
+      versionNumber: 1,
+      sessionId: 'source-session-1',
+      name: 'groups.csv',
+      originalName: 'groups.csv',
+      path: '/ignored',
+      size: 8
+    }
+    await client!.uploadVersion.update({
+      where: { id: 'upload-version-1' },
+      data: { state: 'staging' }
+    })
+    await expect(
+      registry.registerTurn({
+        projectId: 'project-1',
+        appSessionId: 'active-session',
+        promptMessageId: 'prompt-staging',
+        uploads: [attachment],
+        references: []
+      })
+    ).rejects.toThrow(/unavailable in this Project/)
+
+    await client!.uploadVersion.update({
+      where: { id: 'upload-version-1' },
+      data: { state: 'ready' }
+    })
+    const turn = {
+      projectId: 'project-1',
+      appSessionId: 'active-session',
+      promptMessageId: 'prompt-ready'
+    }
+    await registry.registerTurn({ ...turn, uploads: [attachment], references: [] })
+    await client!.uploadVersion.update({
+      where: { id: 'upload-version-1' },
+      data: { versionNumber: 2 }
+    })
+    await expect(registry.openRun(turn)).rejects.toThrow(/registration no longer matches/i)
+  })
+
+  it('rejects same-size input corruption during turn registration', async () => {
     const registry = await setup()
     const storageKey = await createUpload({
       projectId: 'project-1',
@@ -320,10 +377,23 @@ describe('NotebookInputRegistry', () => {
     await writeManagedContent(storageKey, 'group\nB\n')
 
     await expect(
-      registry.resolvePreview({
+      registry.registerTurn({
         projectId: 'project-1',
-        sourceKind: 'upload-version',
-        inputFileVersionId: 'upload-version-1'
+        appSessionId: 'active-session',
+        promptMessageId: 'prompt-1',
+        uploads: [
+          {
+            id: 'upload-1',
+            versionId: 'upload-version-1',
+            versionNumber: 1,
+            sessionId: 'source-session-1',
+            name: 'groups.csv',
+            originalName: 'groups.csv',
+            path: '/ignored',
+            size: 8
+          }
+        ],
+        references: []
       })
     ).rejects.toThrow(/checksum/i)
   })

--- a/src/main/notebook/input-registry.ts
+++ b/src/main/notebook/input-registry.ts
@@ -1,14 +1,8 @@
-import { createHash } from 'node:crypto'
-import { createReadStream } from 'node:fs'
-import { realpath, stat } from 'node:fs/promises'
-import { isAbsolute, resolve, sep } from 'node:path'
-
-import type { PrismaClient } from '@prisma/client'
-
 import type { FileReference } from '../../shared/artifacts'
 import type { ArtifactPreviewResult, ReadArtifactPreviewRequest } from '../../shared/artifacts'
 import { parseNotebookInputPreviewKey, type NotebookRunInputFile } from '../../shared/notebook'
 import type { UploadedAttachment } from '../../shared/uploads'
+import type { ImmutableInputAuthority } from '../immutable-input-authority'
 import { readBoundedManagedFilePreview } from '../managed-file-preview'
 
 type RegisterNotebookTurnInputsRequest = {
@@ -48,8 +42,10 @@ type NotebookInputPreviewTarget = {
 }
 
 type NotebookInputRegistryOptions = {
-  storageRoot: string
-  getClient: () => Promise<PrismaClient>
+  inputAuthority: Pick<
+    ImmutableInputAuthority,
+    'resolveContent' | 'resolveVersion' | 'validateVersion'
+  >
 }
 
 type RegisteredTurn = {
@@ -57,83 +53,11 @@ type RegisteredTurn = {
   inputs: NotebookRunInputFile[]
 }
 
-type VerifiedContent = {
-  fingerprint: string
-  checksum: string
-}
-
 const turnKey = (request: GetNotebookTurnInputsRequest): string =>
   JSON.stringify([request.projectId, request.appSessionId, request.promptMessageId])
 
 const versionKey = (input: NotebookRunInputFile): string =>
   `${input.sourceKind}\0${input.inputFileVersionId}`
-
-const resolveStorageKey = (storageRoot: string, key: string): string => {
-  if (!key || isAbsolute(key) || key.includes('\\')) {
-    throw new Error('Invalid Notebook input storage key.')
-  }
-  const absolutePath = resolve(storageRoot, ...key.split('/'))
-  const relativePath = absolutePath.slice(resolve(storageRoot).length)
-  if (
-    absolutePath === resolve(storageRoot) ||
-    (!relativePath.startsWith(sep) && relativePath !== '') ||
-    key.split('/').some((segment) => segment === '' || segment === '.' || segment === '..')
-  ) {
-    throw new Error('Notebook input storage key escapes managed storage.')
-  }
-  return absolutePath
-}
-
-const assertAvailableContent = async (
-  storageRoot: string,
-  storageKey: string,
-  expectedSize: number,
-  expectedChecksum: string,
-  verifiedContent: Map<string, VerifiedContent>
-): Promise<string> => {
-  const absolutePath = resolveStorageKey(storageRoot, storageKey)
-  const [resolvedRoot, resolvedPath] = await Promise.all([
-    realpath(storageRoot),
-    realpath(absolutePath)
-  ])
-  const resolvedRelativePath = resolvedPath.slice(resolvedRoot.length)
-  if (
-    resolvedPath === resolvedRoot ||
-    (!resolvedRelativePath.startsWith(sep) && resolvedRelativePath !== '')
-  ) {
-    throw new Error('Notebook input content escapes managed storage.')
-  }
-  const file = await stat(resolvedPath)
-  if (!file.isFile() || file.size !== expectedSize) {
-    throw new Error(
-      'Notebook input content is missing or no longer matches its immutable metadata.'
-    )
-  }
-  const fingerprint = [file.dev, file.ino, file.size, file.mtimeMs, file.ctimeMs].join(':')
-  const cached = verifiedContent.get(storageKey)
-  if (cached?.fingerprint === fingerprint && cached.checksum === expectedChecksum) {
-    return resolvedPath
-  }
-
-  const hash = createHash('sha256')
-  for await (const chunk of createReadStream(resolvedPath)) hash.update(chunk)
-  if (hash.digest('hex') !== expectedChecksum) {
-    throw new Error('Notebook input content checksum does not match its immutable metadata.')
-  }
-  const afterRead = await stat(resolvedPath)
-  const afterReadFingerprint = [
-    afterRead.dev,
-    afterRead.ino,
-    afterRead.size,
-    afterRead.mtimeMs,
-    afterRead.ctimeMs
-  ].join(':')
-  if (afterReadFingerprint !== fingerprint) {
-    throw new Error('Notebook input content changed while its checksum was being validated.')
-  }
-  verifiedContent.set(storageKey, { fingerprint, checksum: expectedChecksum })
-  return resolvedPath
-}
 
 // One execution-scoped capability. It never resolves arbitrary paths: callers must name an exact
 // registered Version key, and only that live record is upgraded to resolver-accessed.
@@ -176,7 +100,6 @@ class NotebookInputRunLease {
 
 class NotebookInputRegistry {
   private readonly turns = new Map<string, RegisteredTurn>()
-  private readonly verifiedContent = new Map<string, VerifiedContent>()
 
   constructor(private readonly options: NotebookInputRegistryOptions) {}
 
@@ -187,7 +110,12 @@ class NotebookInputRegistry {
         throw new Error(`Upload input has no immutable Version identity: ${upload.originalName}`)
       }
       inputs.push(
-        await this.resolveVersion(request.projectId, 'upload-version', upload.versionId, upload.id)
+        await this.resolveVersion({
+          projectId: request.projectId,
+          sourceKind: 'upload-version',
+          inputFileVersionId: upload.versionId,
+          expectedSourceFileId: upload.id
+        })
       )
     }
 
@@ -199,11 +127,11 @@ class NotebookInputRegistry {
         continue
       }
       inputs.push(
-        await this.resolveVersion(
-          request.projectId,
-          reference.source === 'upload' ? 'upload-version' : 'artifact-version',
-          reference.versionId
-        )
+        await this.resolveVersion({
+          projectId: request.projectId,
+          sourceKind: reference.source === 'upload' ? 'upload-version' : 'artifact-version',
+          inputFileVersionId: reference.versionId
+        })
       )
     }
 
@@ -227,34 +155,20 @@ class NotebookInputRegistry {
     const registered = this.turns.get(turnKey(request))?.inputs ?? []
     const inputs = await Promise.all(
       registered.map(async (input) => {
-        const current = await this.resolveVersion(
+        const validation = await this.options.inputAuthority.validateVersion(
           request.projectId,
-          input.sourceKind,
-          input.inputFileVersionId,
-          input.sourceFileId
+          input
         )
-        if (
-          current.storageKey !== input.storageKey ||
-          current.checksum !== input.checksum ||
-          current.sizeBytes !== input.sizeBytes ||
-          current.sourceSessionId !== input.sourceSessionId ||
-          current.sourceVersionNumber !== input.sourceVersionNumber
-        ) {
+        if (validation.state !== 'available') {
           throw new Error(
             `Notebook input registration no longer matches its immutable Version: ${input.inputFileVersionId}`
           )
         }
-        return { ...current, association: 'turn-attached' as const }
+        return { ...validation.input, association: 'turn-attached' as const }
       })
     )
     return new NotebookInputRunLease(inputs, (input) =>
-      assertAvailableContent(
-        this.options.storageRoot,
-        input.storageKey,
-        input.sizeBytes,
-        input.checksum,
-        this.verifiedContent
-      )
+      this.options.inputAuthority.resolveContent(input)
     )
   }
 
@@ -268,18 +182,8 @@ class NotebookInputRegistry {
   async resolvePreview(
     request: ResolveNotebookInputPreviewRequest
   ): Promise<NotebookInputPreviewTarget> {
-    const input = await this.resolveVersion(
-      request.projectId,
-      request.sourceKind,
-      request.inputFileVersionId
-    )
-    const absolutePath = await assertAvailableContent(
-      this.options.storageRoot,
-      input.storageKey,
-      input.sizeBytes,
-      input.checksum,
-      this.verifiedContent
-    )
+    const input = await this.resolveVersion(request)
+    const absolutePath = await this.options.inputAuthority.resolveContent(input)
     return {
       sourceKind: input.sourceKind,
       inputFileVersionId: input.inputFileVersionId,
@@ -305,83 +209,14 @@ class NotebookInputRegistry {
   }
 
   private async resolveVersion(
-    projectId: string,
-    sourceKind: NotebookRunInputFile['sourceKind'],
-    inputFileVersionId: string,
-    expectedSourceFileId?: string
+    request: Parameters<ImmutableInputAuthority['resolveVersion']>[0]
   ): Promise<NotebookRunInputFile> {
-    const client = await this.options.getClient()
-    if (sourceKind === 'upload-version') {
-      const version = await client.uploadVersion.findFirst({
-        where: {
-          id: inputFileVersionId,
-          state: 'ready',
-          uploadFile: { is: { projectId } }
-        },
-        include: { uploadFile: true }
-      })
-      if (!version || (expectedSourceFileId && version.uploadFileId !== expectedSourceFileId)) {
-        throw new Error(`Upload Version is unavailable in this Project: ${inputFileVersionId}`)
-      }
-      const sizeBytes = Number(version.sizeBytes)
-      await assertAvailableContent(
-        this.options.storageRoot,
-        version.contentStorageKey,
-        sizeBytes,
-        version.checksum,
-        this.verifiedContent
-      )
-      return {
-        inputFileVersionId: version.id,
-        sourceKind,
-        sourceFileId: version.uploadFileId,
-        sourceVersionNumber: version.versionNumber,
-        ...(version.createdAt ? { sourceCreatedAt: version.createdAt.toISOString() } : {}),
-        sourceProjectId: version.uploadFile.projectId,
-        sourceSessionId: version.uploadFile.sessionId,
-        filename: version.originalFilename || version.filename,
-        ...(version.contentType ? { contentType: version.contentType } : {}),
-        sizeBytes,
-        checksum: version.checksum,
-        storageKey: version.contentStorageKey,
-        association: 'turn-attached'
-      }
-    }
-
-    const version = await client.artifactVersion.findFirst({
-      where: {
-        id: inputFileVersionId,
-        state: 'finalized',
-        artifact: { is: { projectId } }
-      },
-      include: { artifact: true }
-    })
-    if (!version || (expectedSourceFileId && version.artifactId !== expectedSourceFileId)) {
-      throw new Error(`Artifact Version is unavailable in this Project: ${inputFileVersionId}`)
-    }
-    const sizeBytes = Number(version.sizeBytes)
-    await assertAvailableContent(
-      this.options.storageRoot,
-      version.contentStorageKey,
-      sizeBytes,
-      version.checksum,
-      this.verifiedContent
+    const input = await this.options.inputAuthority.resolveVersion(request)
+    if (input) return input
+    const label = request.sourceKind === 'upload-version' ? 'Upload' : 'Artifact'
+    throw new Error(
+      `${label} Version is unavailable in this Project: ${request.inputFileVersionId}`
     )
-    return {
-      inputFileVersionId: version.id,
-      sourceKind,
-      sourceFileId: version.artifactId,
-      sourceVersionNumber: version.versionNumber,
-      sourceCreatedAt: version.createdAt.toISOString(),
-      sourceProjectId: version.artifact.projectId,
-      sourceSessionId: version.artifact.sessionId,
-      filename: version.artifact.filename,
-      ...(version.contentType ? { contentType: version.contentType } : {}),
-      sizeBytes,
-      checksum: version.checksum,
-      storageKey: version.contentStorageKey,
-      association: 'turn-attached'
-    }
   }
 }
 


### PR DESCRIPTION
## Problem

Notebook input registration and Artifact Provenance commit independently validated immutable Upload Version and Artifact Version state, Project ownership, identity metadata, checksum, and stored bytes. The duplicated implementations could drift; in particular, the Provenance path did not re-read content bytes.

## Proposed change

- Add a shared `ImmutableInputAuthority` that resolves canonical immutable input metadata and validates state, Project ownership, identity, checksum, and bytes.
- Inject one production authority into Notebook registration/open-run and Artifact Provenance capture.
- Preserve both validation points so stale or corrupted inputs are rejected when a Notebook run opens and when Provenance commits.
- Keep caller-specific error semantics at the Notebook and Provenance boundaries.

## Scope and non-goals

- No Prisma schema, table, field, relationship, or migration changes.
- No persistence-format, IPC contract, or dependency changes.
- No change to the existing path-containment and byte-verification semantics.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Notebook registration/open-run state, metadata, Project, checksum, and byte validation -> `npm test -- src/main/notebook/input-registry.test.ts` -> 6 passed.
- Provenance commit state, metadata, Project, checksum, and byte validation, including mutation after authority caching -> `npm test -- src/main/artifacts/provenance-write-contract.test.ts` -> 14 passed.
- Main and renderer TypeScript consumers -> `npm run typecheck` -> passed.
- Linted source -> `npm run lint` -> passed with 0 errors; 17 existing warnings remain in untouched files.
- Complete portable suite -> `npm test` -> 856 files passed, 14 skipped; 12,483 tests passed, 190 skipped.
- Independent specification and standards reviews -> clean.

The production composition change is covered by typechecking and the complete portable suite. The existing filesystem verification algorithm was moved without semantic change, so no additional platform lane was required locally; exact-head CI remains authoritative for platform-specific coverage.

## Review focus

- Whether the authority contract cleanly separates shared immutable-input rules from caller-specific errors.
- Whether cache revalidation still detects same-size content changes.
- Whether the Notebook and Provenance validation timing remains intact.
