### PR TITLE
refactor(transport): deepen application renderer contracts

### DIFF
--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -21,6 +21,7 @@ vi.mock('./application-command-router', async (importOriginal) => {
 })
 
 import { RENDERER_CONTRACT_CATALOG } from '../shared/renderer-contract-catalog'
+import type { Project } from '../shared/projects'
 import {
   createApplicationCommandComposition,
   type ApplicationCommandCompositionDependencies
@@ -34,6 +35,14 @@ import {
 import { createCallerContext } from './caller-context'
 
 const EMPTY_OWNER = Object.freeze({})
+const project = (id: string): Project => ({
+  id,
+  name: 'Project',
+  description: '',
+  isExample: false,
+  createdAt: 1,
+  updatedAt: 1
+})
 
 const dependencies = (): ApplicationCommandCompositionDependencies =>
   ({
@@ -165,6 +174,19 @@ const invocation = (
 }
 
 describe('application command composition', () => {
+  it('joins the six runtime-validated Project contracts into the Electron view', () => {
+    const composition = createApplicationCommandComposition(dependencies())
+
+    expect(composition.electron.commandNames()).toEqual([
+      'projects:create',
+      'projects:delete',
+      'projects:get',
+      'projects:list',
+      'projects:update',
+      'projects:update-archive'
+    ])
+  })
+
   it('certifies the complete group inventory behind the local Web view', () => {
     const composition = createApplicationCommandComposition(dependencies())
 
@@ -173,7 +195,7 @@ describe('application command composition', () => {
   })
 
   it('partitions remote Web dispatch from fail-closed pre-dispatch rejections', async () => {
-    const listProjects = vi.fn().mockResolvedValue([{ id: 'project-1' }])
+    const listProjects = vi.fn().mockResolvedValue([project('project-1')])
     const onDiagnostic = vi.fn()
     const composition = createApplicationCommandComposition(
       {
@@ -193,7 +215,7 @@ describe('application command composition', () => {
     expect(onDiagnostic).not.toHaveBeenCalled()
     await expect(
       composition.remoteWeb.invoke('projects:list', invocation('remote'))
-    ).resolves.toEqual([{ id: 'project-1' }])
+    ).resolves.toEqual([project('project-1')])
     expect(listProjects).toHaveBeenCalledOnce()
   })
 
@@ -219,7 +241,7 @@ describe('application command composition', () => {
     )
     expect(composition).not.toHaveProperty('registrar')
     expect(composition).not.toHaveProperty('dispatcher')
-    expect(composition).not.toHaveProperty('electron')
+    expect(composition.electron.commandNames()).toHaveLength(6)
     expect(composition).not.toHaveProperty('cli')
     expect(composition).not.toHaveProperty('localRpc')
     expect(composition).not.toHaveProperty('specialist')
@@ -454,18 +476,18 @@ describe('application command composition', () => {
   it('routes different narrow views through one shared command owner', async () => {
     const listProjects = vi
       .fn()
-      .mockResolvedValueOnce([{ id: 'from-local-web' }])
-      .mockResolvedValueOnce([{ id: 'from-task' }])
+      .mockResolvedValueOnce([project('from-local-web')])
+      .mockResolvedValueOnce([project('from-task')])
     const composition = createApplicationCommandComposition({
       ...dependencies(),
       dataContent: { projects: { list: listProjects } } as never
     })
 
     await expect(composition.localWeb.invoke('projects:list', invocation())).resolves.toEqual([
-      { id: 'from-local-web' }
+      project('from-local-web')
     ])
     await expect(composition.task.invoke('projects:list', invocation())).resolves.toEqual([
-      { id: 'from-task' }
+      project('from-task')
     ])
     expect(listProjects).toHaveBeenCalledTimes(2)
   })

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -1,4 +1,8 @@
-import { RENDERER_CONTRACT_CATALOG } from '../shared/renderer-contract-catalog'
+import { ApplicationCommandError } from '../shared/application-command-contract'
+import {
+  ELECTRON_APPLICATION_COMMAND_CHANNELS,
+  RENDERER_CONTRACT_CATALOG
+} from '../shared/renderer-contract-catalog'
 import {
   acpApplicationCommands,
   registerAcpCommands,
@@ -95,6 +99,7 @@ type ApplicationCommandCompositionDependencies = Readonly<{
 }>
 
 type ApplicationCommandComposition = Readonly<{
+  electron: ApplicationCommandByNameDispatcher
   localWeb: ApplicationCommandByNameDispatcher
   remoteWeb: RemoteWebApplicationCommandDispatcher
   task: ApplicationCommandByNameDispatcher
@@ -108,6 +113,7 @@ const LOCAL_WEB_COMMAND_COUNT = 233
 const REMOTE_WEB_COMMAND_COUNT = 171
 const REMOTE_REJECTED_COMMAND_COUNT = 62
 const TASK_COMMAND_COUNT = 7
+const VALIDATED_ELECTRON_COMMAND_COUNT = 6
 
 const ELECTRON_NATIVE_COMMAND_NAMES = Object.freeze([
   'sessions:export-conversation',
@@ -193,6 +199,7 @@ const createRemoteAccessSlot = (): Readonly<{
 
 const certifyInventory = (): Readonly<{
   commands: ReadonlyMap<string, AnyApplicationCommand>
+  electronNames: readonly string[]
   localWebNames: readonly string[]
   remoteWebNames: readonly string[]
   remoteRejectedNames: readonly string[]
@@ -216,11 +223,13 @@ const certifyInventory = (): Readonly<{
   }
 
   const localWebNames = collectCatalogCommands(({ localWeb }) => localWeb === 'web-rpc')
+  const electronNames = ELECTRON_APPLICATION_COMMAND_CHANNELS
   const remoteWebNames = collectCatalogCommands(({ remoteWeb }) => remoteWeb === 'web-rpc')
   const remoteRejectedNames = collectCatalogCommands(
     ({ localWeb, remoteWeb }) => localWeb === 'web-rpc' && remoteWeb === 'rejecting-stub'
   )
   const expectedCounts = [
+    [electronNames, VALIDATED_ELECTRON_COMMAND_COUNT, 'validated Electron commands'],
     [localWebNames, LOCAL_WEB_COMMAND_COUNT, 'local Web commands'],
     [remoteWebNames, REMOTE_WEB_COMMAND_COUNT, 'remote Web commands'],
     [remoteRejectedNames, REMOTE_REJECTED_COMMAND_COUNT, 'remote Web rejections'],
@@ -232,6 +241,11 @@ const certifyInventory = (): Readonly<{
     if (new Set(names).size !== names.length) failInventory(`${label} contains duplicate names`)
     for (const name of names) {
       if (!commands.has(name)) failInventory(`${label} contains unknown command ${name}`)
+    }
+  }
+  for (const name of electronNames) {
+    if (!commands.get(name)?.contract) {
+      failInventory(`validated Electron command has no runtime codec: ${name}`)
     }
   }
 
@@ -247,7 +261,13 @@ const certifyInventory = (): Readonly<{
     failInventory('remote dispatch and rejection inventories do not partition local Web')
   }
 
-  return Object.freeze({ commands, localWebNames, remoteWebNames, remoteRejectedNames })
+  return Object.freeze({
+    commands,
+    electronNames,
+    localWebNames,
+    remoteWebNames,
+    remoteRejectedNames
+  })
 }
 
 const createApplicationCommandComposition = (
@@ -322,12 +342,18 @@ const createApplicationCommandComposition = (
       invoke: (commandName, invocation): Promise<unknown> => {
         if (rejected.has(commandName)) {
           return Promise.reject(
-            new Error(`Application command is rejected before dispatch: ${commandName}`)
+            new ApplicationCommandError(
+              'command-unavailable',
+              `Application command is rejected before dispatch: ${commandName}`
+            )
           )
         }
         if (!allowed.has(commandName)) {
           return Promise.reject(
-            new Error(`Application command is unavailable in this view: ${commandName}`)
+            new ApplicationCommandError(
+              'command-unavailable',
+              `Application command is unavailable in this view: ${commandName}`
+            )
           )
         }
         return router.dispatcher.invoke(certified.commands.get(commandName)!, invocation)
@@ -335,6 +361,7 @@ const createApplicationCommandComposition = (
     })
   }
 
+  const electron = view(certified.electronNames)
   const localWeb = view(certified.localWebNames)
   const remoteDispatcher = view(certified.remoteWebNames, certified.remoteRejectedNames)
   const remoteWeb = Object.freeze({
@@ -344,6 +371,7 @@ const createApplicationCommandComposition = (
   const task = view(TASK_COMMAND_NAMES)
 
   return Object.freeze({
+    electron,
     localWeb,
     remoteWeb,
     task,

--- a/src/main/application-command-electron-adapter.test.ts
+++ b/src/main/application-command-electron-adapter.test.ts
@@ -1,0 +1,106 @@
+import type { IpcMainInvokeEvent } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ApplicationCommandError } from '../shared/application-command-contract'
+import type { ApplicationCommandByNameDispatcher } from './application-command-composition'
+import type { ApplicationCallerLease } from './application-command-router'
+import { bindCallerLeaseToEvent } from './caller-lifecycle'
+
+const { handlers, warn } = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  warn: vi.fn()
+}))
+
+vi.mock('./ipc-handler-registry', () => ({
+  ipcMainHandle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+    handlers.set(channel, handler)
+  }
+}))
+import { registerApplicationCommandElectronAdapter } from './application-command-electron-adapter'
+
+const projectChannels = [
+  'projects:create',
+  'projects:delete',
+  'projects:get',
+  'projects:list',
+  'projects:update',
+  'projects:update-archive'
+] as const
+
+const eventWithLease = (): IpcMainInvokeEvent => {
+  const event = { sender: { id: 7 } } as unknown as IpcMainInvokeEvent
+  const lease: ApplicationCallerLease = Object.freeze({
+    leaseId: 'electron:7',
+    generation: 1,
+    signal: new AbortController().signal,
+    isCurrent: () => true
+  })
+  bindCallerLeaseToEvent(event, lease)
+  return event
+}
+
+const dispatcher = (
+  invoke: ApplicationCommandByNameDispatcher['invoke']
+): ApplicationCommandByNameDispatcher => ({
+  commandNames: () => projectChannels,
+  invoke
+})
+
+beforeEach(() => {
+  handlers.clear()
+  warn.mockClear()
+})
+
+describe('Electron Application Command adapter', () => {
+  it('installs the catalog-selected Project slice with caller context and lease', async () => {
+    const result = [{ id: 'project-1' }]
+    const invoke = vi.fn().mockResolvedValue(result)
+    registerApplicationCommandElectronAdapter(dispatcher(invoke), { warn })
+    const event = eventWithLease()
+
+    await expect(handlers.get('projects:list')?.(event)).resolves.toEqual({ ok: true, result })
+    expect([...handlers.keys()]).toEqual(projectChannels)
+    expect(invoke).toHaveBeenCalledWith(
+      'projects:list',
+      expect.objectContaining({
+        args: [],
+        callerContext: expect.objectContaining({
+          clientId: '7',
+          surface: 'electron',
+          location: 'local'
+        }),
+        callerLease: expect.objectContaining({ leaseId: 'electron:7' })
+      })
+    )
+  })
+
+  it('returns the public error envelope after recording rejection diagnostics', async () => {
+    const invoke = vi
+      .fn()
+      .mockRejectedValue(
+        new ApplicationCommandError('invalid-command-arguments', 'Invalid project request.')
+      )
+    registerApplicationCommandElectronAdapter(dispatcher(invoke), { warn })
+
+    await expect(
+      handlers.get('projects:create')?.(eventWithLease(), { name: 42 })
+    ).resolves.toEqual({
+      ok: false,
+      error: { code: 'invalid-command-arguments', message: 'Invalid project request.' }
+    })
+    expect(warn).toHaveBeenCalledWith(
+      'ipc handler rejected',
+      expect.objectContaining({ channel: 'projects:create', surface: 'electron' })
+    )
+  })
+
+  it('fails before registration when dispatcher and catalog inventories diverge', () => {
+    expect(() =>
+      registerApplicationCommandElectronAdapter({
+        commandNames: () => ['projects:list'],
+        invoke: vi.fn()
+      })
+    ).toThrow('Electron Application Command adapter inventory mismatch.')
+    expect(handlers).toEqual(new Map())
+  })
+})

--- a/src/main/application-command-electron-adapter.ts
+++ b/src/main/application-command-electron-adapter.ts
@@ -1,0 +1,51 @@
+import type { IpcMainInvokeEvent } from 'electron'
+
+import {
+  toApplicationCommandErrorEnvelope,
+  type ApplicationCommandOutcome
+} from '../shared/application-command-contract'
+import { ELECTRON_APPLICATION_COMMAND_CHANNELS } from '../shared/renderer-contract-catalog'
+import type { ApplicationCommandByNameDispatcher } from './application-command-composition'
+import type { ApplicationInvocation } from './application-command-router'
+import { callerContextForEvent } from './caller-context'
+import { callerLeaseForEvent } from './caller-lifecycle'
+import {
+  invokeWithIpcRejectionDiagnostics,
+  type IpcRejectionLogger
+} from './diagnostics/ipc-rejection'
+import { ipcMainHandle } from './ipc-handler-registry'
+import { createLogger } from './logger'
+
+const registerApplicationCommandElectronAdapter = (
+  dispatcher: ApplicationCommandByNameDispatcher,
+  log: IpcRejectionLogger = createLogger('ipc')
+): void => {
+  const channels = ELECTRON_APPLICATION_COMMAND_CHANNELS
+  if (channels.join('\n') !== [...dispatcher.commandNames()].sort().join('\n')) {
+    throw new Error('Electron Application Command adapter inventory mismatch.')
+  }
+  for (const channel of channels) {
+    ipcMainHandle(channel, async (event, ...args): Promise<ApplicationCommandOutcome<unknown>> => {
+      const ipcEvent = event as IpcMainInvokeEvent
+      const callerContext = callerContextForEvent(ipcEvent)
+      const invocation: ApplicationInvocation<readonly unknown[]> = Object.freeze({
+        callerContext,
+        callerLease: callerLeaseForEvent(ipcEvent),
+        args: Object.freeze([...args])
+      })
+      try {
+        const result = await invokeWithIpcRejectionDiagnostics({
+          channel,
+          callerContext,
+          invoke: () => dispatcher.invoke(channel, invocation),
+          log
+        })
+        return Object.freeze({ ok: true, result })
+      } catch (error) {
+        return Object.freeze({ ok: false, error: toApplicationCommandErrorEnvelope(error) })
+      }
+    })
+  }
+}
+
+export { registerApplicationCommandElectronAdapter }

--- a/src/main/application-command-router.test.ts
+++ b/src/main/application-command-router.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 
+import { ApplicationCommandError } from '../shared/application-command-contract'
 import { createCallerContext, type CallerContext } from './caller-context'
 import {
   createApplicationCommandRouter,
@@ -352,4 +353,74 @@ describe('application command router', () => {
     expect(JSON.stringify(diagnostics)).not.toContain('lease-1')
     expect(JSON.stringify(diagnostics)).not.toContain('private handler detail')
   })
+
+  it('validates contracted arguments and results at the command interface', async () => {
+    const args = ['project-1'] as const
+    const result = { id: 'project-1' }
+    const argsCodec = { parse: vi.fn((value: unknown) => value as typeof args) }
+    const resultCodec = { parse: vi.fn((value: unknown) => value as typeof result) }
+    const command = defineApplicationCommand<'projects:get', readonly [id: string], typeof result>(
+      'projects:get',
+      { args: argsCodec, result: resultCodec }
+    )
+    const handler = vi.fn(() => result)
+    const router = createApplicationCommandRouter()
+    const scope = router.registrar.createScope()
+    scope.registerGroup(defineApplicationCommandGroup('projects', [command] as const), {
+      'projects:get': handler
+    })
+
+    await expect(router.dispatcher.invoke(command, invocation(args))).resolves.toBe(result)
+    expect(argsCodec.parse).toHaveBeenCalledWith(args)
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ args }))
+    expect(resultCodec.parse).toHaveBeenCalledWith(result)
+    expect(Object.isFrozen(command.contract)).toBe(true)
+  })
+
+  it.each([
+    {
+      failure: 'arguments',
+      expectedCode: 'invalid-command-arguments',
+      argsCodec: {
+        parse: (): readonly [string] => {
+          throw new Error('private argument detail')
+        }
+      },
+      resultCodec: { parse: (value: unknown) => value as string }
+    },
+    {
+      failure: 'result',
+      expectedCode: 'invalid-command-result',
+      argsCodec: { parse: (value: unknown) => value as readonly [string] },
+      resultCodec: {
+        parse: (): string => {
+          throw new Error('private result detail')
+        }
+      }
+    }
+  ] as const)(
+    'rejects invalid contracted $failure without leaking codec details',
+    async ({ expectedCode, argsCodec, resultCodec }) => {
+      const diagnostics: unknown[] = []
+      const handler = vi.fn(() => 'value')
+      const command = defineApplicationCommand<'projects:get', readonly [string], string>(
+        'projects:get',
+        { args: argsCodec, result: resultCodec }
+      )
+      const router = createApplicationCommandRouter((diagnostic) => diagnostics.push(diagnostic))
+      const scope = router.registrar.createScope()
+      scope.registerGroup(defineApplicationCommandGroup('projects', [command] as const), {
+        'projects:get': handler
+      })
+
+      const dispatched = router.dispatcher.invoke(command, invocation(['project-1'] as const))
+
+      const error = await dispatched.catch((error) => error)
+      expect(error).toBeInstanceOf(ApplicationCommandError)
+      expect(error).toMatchObject({ code: expectedCode })
+      expect(JSON.stringify(error)).not.toContain('private')
+      expect(diagnostics).toEqual([{ code: expectedCode, commandName: 'projects:get' }])
+      expect(handler).toHaveBeenCalledTimes(expectedCode === 'invalid-command-result' ? 1 : 0)
+    }
+  )
 })

--- a/src/main/application-command-router.ts
+++ b/src/main/application-command-router.ts
@@ -1,10 +1,17 @@
+import {
+  ApplicationCommandError,
+  type ApplicationCommandContract
+} from '../shared/application-command-contract'
 import type { CallerContext } from './caller-context'
 
 declare const applicationCommandTypes: unique symbol
 
 type Awaitable<Value> = Value | PromiseLike<Value>
 
-type AnyApplicationCommand = Readonly<{ name: string }>
+type AnyApplicationCommand = Readonly<{
+  name: string
+  contract?: ApplicationCommandContract<readonly unknown[], unknown>
+}>
 
 export type ApplicationCommand<
   Name extends string,
@@ -12,6 +19,7 @@ export type ApplicationCommand<
   Result
 > = Readonly<{
   name: Name
+  contract?: ApplicationCommandContract<Args, Result>
   [applicationCommandTypes]?: Readonly<{ args: Args; result: Result }>
 }>
 
@@ -86,6 +94,8 @@ export type ApplicationCommandDiagnosticCode =
   | 'authorization-stale'
   | 'lease-mismatch'
   | 'lease-stale'
+  | 'invalid-command-arguments'
+  | 'invalid-command-result'
   | 'handler-rejected'
   | 'router-disposed'
 
@@ -123,9 +133,12 @@ export const defineApplicationCommand = <
   Args extends readonly unknown[],
   Result
 >(
-  name: Name
+  name: Name,
+  contract?: ApplicationCommandContract<Args, Result>
 ): ApplicationCommand<Name, Args, Result> =>
-  Object.freeze({ name }) as ApplicationCommand<Name, Args, Result>
+  Object.freeze(
+    contract ? { name, contract: Object.freeze({ ...contract }) } : { name }
+  ) as ApplicationCommand<Name, Args, Result>
 
 export const defineApplicationCommandGroup = <
   const Name extends string,
@@ -249,12 +262,42 @@ export const createApplicationCommandRouter = (
       throw new Error('Caller lease is no longer current.')
     }
 
+    let handlerInvocation = invocation as ApplicationInvocation<readonly unknown[]>
+    if (registered.command.contract) {
+      try {
+        handlerInvocation = Object.freeze({
+          ...invocation,
+          args: registered.command.contract.args.parse(invocation.args)
+        })
+      } catch {
+        report('invalid-command-arguments', command.name)
+        throw new ApplicationCommandError(
+          'invalid-command-arguments',
+          `Invalid arguments for application command: ${command.name}`
+        )
+      }
+    }
+
+    let result: unknown
     try {
-      return (await registered.handler(invocation)) as CommandResult<typeof command>
+      result = await registered.handler(handlerInvocation)
     } catch (error) {
       report('handler-rejected', command.name)
       throw error
     }
+
+    if (registered.command.contract) {
+      try {
+        return registered.command.contract.result.parse(result) as CommandResult<typeof command>
+      } catch {
+        report('invalid-command-result', command.name)
+        throw new ApplicationCommandError(
+          'invalid-command-result',
+          `Invalid result for application command: ${command.name}`
+        )
+      }
+    }
+    return result as CommandResult<typeof command>
   }
 
   return Object.freeze({

--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -49,17 +49,12 @@ const dependencyBlock = compact(
 )
 
 describe('production application command wiring', () => {
-  it('injects each stateful owner into both legacy Electron and command composition', () => {
+  it('injects each stateful owner into its Electron adapter and command composition', () => {
     const sharedOwners = [
       [
         'managedPreviewOwners',
         'installManagedPreviewElectronAdapter(previewResources, undefined, managedPreviewOwners)',
         'managedPreview: managedPreviewOwners'
-      ],
-      [
-        'projectHandlers',
-        'projectDeletionCoordinator, projectHandlers )',
-        'projects: projectHandlers'
       ],
       [
         'projectFilesHandlers',
@@ -115,6 +110,13 @@ describe('production application command wiring', () => {
         compositionUse
       )
     }
+
+    expect(dependencyBlock).toContain('projects: projectHandlers')
+    expect(compact(ipcSource)).toContain(
+      "declareElectronAdapter('application-projects', () => registerApplicationCommandElectronAdapter(applicationCommandComposition.electron) )"
+    )
+    expect(ipcSource).not.toContain('registerProjectIpcHandlers')
+    expect(legacyAdapterBlock).toContain('registerPreviewStateIpcHandlers(previewStateRepository)')
 
     expect(compact(ipcSource)).toContain(
       'electronAdapters: { beforeCompute: beforeComputeAdapters, compute: computeIpcModule,'

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -421,7 +421,7 @@ describe('Data and content application commands', () => {
       { key: 'projectList', args: [], owner: deps.projects.list },
       {
         key: 'projectUpdateArchive',
-        args: [request('project-update-archive')],
+        args: [{ id: 'project-1', archived: true, expectedArchivedAt: null }],
         owner: deps.projects.updateArchive
       },
       {

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -13,12 +13,13 @@ import type { ProjectHandlers } from './projects/ipc'
 import type { SessionPersistenceHandlers } from './session-persistence/ipc'
 import type { ManagedPreviewOwnerRegistry } from './managed-preview-ipc'
 
+import type { ApplicationCommandContract } from '../shared/application-command-contract'
 import * as Artifacts from '../shared/artifacts'
 import type * as ConversationExport from '../shared/conversation-export'
 import { LIFECYCLE_CHANNELS } from '../shared/lifecycle-events'
 import type * as PreviewResources from '../shared/preview-resources'
 import type * as PreviewState from '../shared/preview-state'
-import type * as Projects from '../shared/projects'
+import * as Projects from '../shared/projects'
 import type * as SessionPersistence from '../shared/session-persistence'
 import * as Uploads from '../shared/uploads'
 
@@ -36,10 +37,15 @@ type OwnerResult<Owner, Method extends keyof Owner> = Owner[Method] extends (
 
 const commandFor =
   <Owner>() =>
-  <const Name extends string, Method extends keyof Owner>(name: Name, method: Method) => {
+  <const Name extends string, Method extends keyof Owner>(
+    name: Name,
+    method: Method,
+    contract?: ApplicationCommandContract<OwnerArgs<Owner, Method>, OwnerResult<Owner, Method>>
+  ) => {
     void method
     return defineApplicationCommand<Name, OwnerArgs<Owner, Method>, OwnerResult<Owner, Method>>(
-      name
+      name,
+      contract
     )
   }
 
@@ -208,16 +214,36 @@ const dataContentApplicationCommands = Object.freeze({
     'project-files:search-artifacts',
     'searchArtifacts'
   ),
-  projectCreate: projectCommand('projects:create', 'create'),
-  projectUpdateArchive: projectCommand('projects:update-archive', 'updateArchive'),
+  projectCreate: projectCommand(
+    'projects:create',
+    'create',
+    Projects.projectApplicationCommandContracts.create
+  ),
+  projectUpdateArchive: projectCommand(
+    'projects:update-archive',
+    'updateArchive',
+    Projects.projectApplicationCommandContracts.updateArchive
+  ),
   projectDelete: defineApplicationCommand<
     'projects:delete',
     readonly [request: Projects.DeleteProjectRequest],
     void
-  >('projects:delete'),
-  projectGet: projectCommand('projects:get', 'get'),
-  projectList: projectCommand('projects:list', 'list'),
-  projectUpdate: projectCommand('projects:update', 'update'),
+  >('projects:delete', Projects.projectApplicationCommandContracts.delete),
+  projectGet: projectCommand(
+    'projects:get',
+    'get',
+    Projects.projectApplicationCommandContracts.get
+  ),
+  projectList: projectCommand(
+    'projects:list',
+    'list',
+    Projects.projectApplicationCommandContracts.list
+  ),
+  projectUpdate: projectCommand(
+    'projects:update',
+    'update',
+    Projects.projectApplicationCommandContracts.update
+  ),
   sessionDelete: sessionCommand('sessions:delete-session', 'deleteSession'),
   sessionExportConversation: electronCommand(
     'sessions:export-conversation',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -26,6 +26,7 @@ import {
   type ApplicationCommandComposition,
   type ApplicationCommandCompositionDependencies
 } from './application-command-composition'
+import { registerApplicationCommandElectronAdapter } from './application-command-electron-adapter'
 import type { ApplicationInvocation } from './application-command-router'
 import { createApplicationEventModule, type ApplicationEventSource } from './application-events'
 
@@ -126,7 +127,7 @@ import {
   createDefaultPreviewStateRepository,
   createDefaultProjectRepository,
   createProjectHandlers,
-  registerProjectIpcHandlers
+  registerPreviewStateIpcHandlers
 } from './projects/ipc'
 import { createReviewerCommandOwner, registerReviewerIpcHandlers } from './reviewer/ipc'
 import {
@@ -1779,13 +1780,8 @@ const createApplicationModules = async (
   )
   // Backs the "This computer" browser; shares localFsService with the managed-preview resolver.
   declareElectronAdapter('local-fs', () => registerLocalFsIpcHandlers(localFsService))
-  declareElectronAdapter('projects', () =>
-    registerProjectIpcHandlers(
-      projectRepository,
-      previewStateRepository,
-      projectDeletionCoordinator,
-      projectHandlers
-    )
+  declareElectronAdapter('preview-state', () =>
+    registerPreviewStateIpcHandlers(previewStateRepository)
   )
   declareElectronAdapter('lifecycle', () => registerLifecycleIpcHandlers())
   // Compute IPC handlers are registered earlier (before the notebook RPC server) so computeService
@@ -1928,6 +1924,9 @@ const createApplicationModules = async (
         dispose: () => composition.dispose()
       }
     }
+  )
+  declareElectronAdapter('application-projects', () =>
+    registerApplicationCommandElectronAdapter(applicationCommandComposition.electron)
   )
 
   return {

--- a/src/main/projects/ipc.test.ts
+++ b/src/main/projects/ipc.test.ts
@@ -1,34 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { PreviewStateRepository } from './preview-repository'
-import type { ProjectRepository } from './repository'
 
-const { broadcastLifecycleEvent, ipcHandlers, registrationFailure } = vi.hoisted(() => ({
-  broadcastLifecycleEvent: vi.fn(),
-  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>(),
-  registrationFailure: {
-    channel: undefined as string | undefined,
-    error: undefined as Error | undefined
-  }
+const { ipcHandlers } = vi.hoisted(() => ({
+  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>()
 }))
 
 vi.mock('electron', () => ({
   ipcMain: {
     handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
-      if (registrationFailure.channel === channel) throw registrationFailure.error
       ipcHandlers.set(channel, handler)
     }
   }
 }))
-vi.mock('../lifecycle-broadcast', () => ({ broadcastLifecycleEvent }))
 
-import { createProjectHandlers, registerProjectIpcHandlers, type ProjectHandlers } from './ipc'
+import { createProjectHandlers, registerPreviewStateIpcHandlers } from './ipc'
 
 beforeEach(() => {
   ipcHandlers.clear()
-  broadcastLifecycleEvent.mockClear()
-  registrationFailure.channel = undefined
-  registrationFailure.error = undefined
 })
 
 describe('createProjectHandlers', () => {
@@ -104,48 +93,18 @@ describe('createProjectHandlers', () => {
     expect(order).toEqual(['recover', 'get', 'recover', 'create', 'recover', 'update'])
   })
 
-  it('registers project and preview channels with exact request forwarding', async () => {
-    const repository = {
-      list: vi.fn().mockResolvedValue([project]),
-      get: vi.fn().mockResolvedValue(project),
-      create: vi.fn().mockResolvedValue(project),
-      update: vi.fn().mockResolvedValue(project),
-      updateArchive: vi.fn().mockResolvedValue({ ...project, archivedAt: 3 })
-    } as unknown as ProjectRepository
+  it('leaves only preview state on the capability-specific Electron adapter', async () => {
     const previewRepository = {
       get: vi.fn().mockResolvedValue(null),
       save: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined)
     } as unknown as PreviewStateRepository
-    const deletionCoordinator = {
-      deleteProject: vi.fn().mockResolvedValue(undefined),
-      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined)
-    }
-    registerProjectIpcHandlers(repository, previewRepository, deletionCoordinator)
+    registerPreviewStateIpcHandlers(previewRepository)
 
-    expect([...ipcHandlers.keys()]).toEqual([
-      'projects:list',
-      'projects:get',
-      'projects:create',
-      'projects:update',
-      'projects:update-archive',
-      'projects:delete',
-      'preview:load',
-      'preview:save',
-      'preview:delete'
-    ])
+    expect([...ipcHandlers.keys()]).toEqual(['preview:load', 'preview:save', 'preview:delete'])
 
-    const createRequest = { name: 'Project' }
-    const updateRequest = { id: 'project-1', name: 'Renamed' }
-    const archiveRequest = { id: 'project-1', archived: true, expectedArchivedAt: null }
     const previewState = { openTabs: [], activeTabId: null }
 
-    await ipcHandlers.get('projects:list')?.()
-    await ipcHandlers.get('projects:get')?.(undefined, 'project-1')
-    await ipcHandlers.get('projects:create')?.(undefined, createRequest)
-    await ipcHandlers.get('projects:update')?.(undefined, updateRequest)
-    await ipcHandlers.get('projects:update-archive')?.(undefined, archiveRequest)
-    await ipcHandlers.get('projects:delete')?.(undefined, { id: 'project-1' })
     await ipcHandlers.get('preview:load')?.(undefined, { projectId: 'project-1' })
     await ipcHandlers.get('preview:save')?.(undefined, {
       projectId: 'project-1',
@@ -153,86 +112,9 @@ describe('createProjectHandlers', () => {
     })
     await ipcHandlers.get('preview:delete')?.(undefined, { projectId: 'project-1' })
 
-    expect(repository.get).toHaveBeenCalledWith('project-1')
-    expect(repository.create).toHaveBeenCalledWith(createRequest)
-    expect(repository.update).toHaveBeenCalledWith(updateRequest)
-    expect(repository.updateArchive).toHaveBeenCalledWith(archiveRequest, expect.any(Number))
-    expect(deletionCoordinator.deleteProject).toHaveBeenCalledWith('project-1')
-    expect(broadcastLifecycleEvent).toHaveBeenCalledWith('project:created', project)
-    expect(broadcastLifecycleEvent).toHaveBeenCalledWith('project:updated', project)
-    expect(broadcastLifecycleEvent).toHaveBeenCalledWith('project:updated', {
-      ...project,
-      archivedAt: 3
-    })
-    expect(broadcastLifecycleEvent).toHaveBeenCalledWith('project:deleted', {
-      projectId: 'project-1'
-    })
     expect(previewRepository.get).toHaveBeenCalledWith('project-1')
     expect(previewRepository.save).toHaveBeenCalledWith('project-1', previewState)
     expect(previewRepository.delete).toHaveBeenCalledWith('project-1')
-  })
-
-  it('dispatches project commands through the injected application handler identity', async () => {
-    const repository = {
-      list: vi.fn(),
-      get: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn()
-    } as unknown as ProjectRepository
-    const previewRepository = {
-      get: vi.fn(),
-      save: vi.fn(),
-      delete: vi.fn()
-    } as unknown as PreviewStateRepository
-    const deletionCoordinator = {
-      deleteProject: vi.fn(),
-      recoverPendingDeletions: vi.fn()
-    }
-    const injected: ProjectHandlers = {
-      list: vi.fn().mockResolvedValue([project]),
-      get: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      updateArchive: vi.fn(),
-      delete: vi.fn()
-    }
-
-    registerProjectIpcHandlers(repository, previewRepository, deletionCoordinator, injected)
-
-    await expect(ipcHandlers.get('projects:list')?.()).resolves.toEqual([project])
-    expect(injected.list).toHaveBeenCalledOnce()
-    expect(repository.list).not.toHaveBeenCalled()
-    expect(deletionCoordinator.recoverPendingDeletions).not.toHaveBeenCalled()
-  })
-
-  it('preserves an injected project handler identity when registration fails', async () => {
-    const failure = new Error('registration failed')
-    const repository = {} as ProjectRepository
-    const previewRepository = {} as PreviewStateRepository
-    const deletionCoordinator = {
-      deleteProject: vi.fn(),
-      recoverPendingDeletions: vi.fn()
-    }
-    const injected: ProjectHandlers = {
-      list: vi.fn().mockResolvedValue([]),
-      get: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      updateArchive: vi.fn(),
-      delete: vi.fn()
-    }
-    registrationFailure.channel = 'projects:list'
-    registrationFailure.error = failure
-
-    expect(() =>
-      registerProjectIpcHandlers(repository, previewRepository, deletionCoordinator, injected)
-    ).toThrow(failure)
-
-    registrationFailure.channel = undefined
-    registrationFailure.error = undefined
-    registerProjectIpcHandlers(repository, previewRepository, deletionCoordinator, injected)
-    await ipcHandlers.get('projects:list')?.()
-    expect(injected.list).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/main/projects/ipc.ts
+++ b/src/main/projects/ipc.ts
@@ -8,13 +8,10 @@ import type {
 } from '../../shared/preview-state'
 import type {
   CreateProjectRequest,
-  DeleteProjectRequest,
   Project,
   UpdateProjectArchiveRequest,
   UpdateProjectRequest
 } from '../../shared/projects'
-import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
-import { broadcastLifecycleEvent } from '../lifecycle-broadcast'
 import type { ProjectDeletionCoordinator } from './deletion-coordinator'
 import { PreviewStateRepository } from './preview-repository'
 import { getProjectDbClient } from './prisma-client'
@@ -85,35 +82,7 @@ const createProjectHandlers = (
   }
 })
 
-// Registers the renderer-callable project + per-project preview-state commands.
-const registerProjectIpcHandlers = (
-  repository: ProjectRepository,
-  previewRepository: PreviewStateRepository,
-  deletionCoordinator: ProjectDeleteHandler,
-  handlers: ProjectHandlers = createProjectHandlers(repository, deletionCoordinator)
-): void => {
-  ipcMainHandle('projects:list', () => handlers.list())
-  ipcMainHandle('projects:get', (_event, id: string) => handlers.get(id))
-  ipcMainHandle('projects:create', async (_event, request: CreateProjectRequest) => {
-    const project = await handlers.create(request)
-    broadcastLifecycleEvent(LIFECYCLE_CHANNELS.projectCreated, project)
-    return project
-  })
-  ipcMainHandle('projects:update', async (_event, request: UpdateProjectRequest) => {
-    const project = await handlers.update(request)
-    broadcastLifecycleEvent(LIFECYCLE_CHANNELS.projectUpdated, project)
-    return project
-  })
-  ipcMainHandle('projects:update-archive', async (_event, request: UpdateProjectArchiveRequest) => {
-    const project = await handlers.updateArchive(request)
-    broadcastLifecycleEvent(LIFECYCLE_CHANNELS.projectUpdated, project)
-    return project
-  })
-  ipcMainHandle('projects:delete', async (_event, request: DeleteProjectRequest) => {
-    await handlers.delete(request.id)
-    broadcastLifecycleEvent(LIFECYCLE_CHANNELS.projectDeleted, { projectId: request.id })
-  })
-
+const registerPreviewStateIpcHandlers = (previewRepository: PreviewStateRepository): void => {
   ipcMainHandle(
     'preview:load',
     (_event, request: LoadPreviewStateRequest): Promise<PersistedPreviewState | null> =>
@@ -131,6 +100,6 @@ export {
   createDefaultPreviewStateRepository,
   createDefaultProjectRepository,
   createProjectHandlers,
-  registerProjectIpcHandlers
+  registerPreviewStateIpcHandlers
 }
 export type { ProjectHandlers }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -13,6 +13,7 @@ vi.mock('electron', () => ({
 }))
 
 import { WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
+import { ApplicationCommandError } from '../../shared/application-command-contract'
 import { isWebRpcChannel, WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
 import { ApplicationEventHub } from '../application-events'
 import type { CallerContext } from '../caller-context'
@@ -160,6 +161,25 @@ describe('startWebHttpServer', () => {
       })
     )
     expect(unusedFallbackInvoke).not.toHaveBeenCalled()
+
+    directInvoke.mockRejectedValueOnce(
+      new ApplicationCommandError('invalid-command-arguments', 'Invalid project request.')
+    )
+    const invalidResponse = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+        'x-open-science-client': 'direct-client'
+      },
+      body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+    })
+    expect(invalidResponse.status).toBe(500)
+    expect(await invalidResponse.json()).toEqual({
+      protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+      ok: false,
+      error: { code: 'invalid-command-arguments', message: 'Invalid project request.' }
+    })
 
     const directSignal = directInvoke.mock.calls[0]?.[1].callerLease.signal
     firstSocket.close()

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -10,6 +10,8 @@ import { gzip } from 'node:zlib'
 import { net } from 'electron'
 import { WebSocket, WebSocketServer } from 'ws'
 
+import { toApplicationCommandErrorEnvelope } from '../../shared/application-command-contract'
+import type { WebRpcErrorCode } from '../../shared/web-rpc-contract'
 import {
   ClientLeaseRegistry,
   createTaskCallerContext,
@@ -154,7 +156,7 @@ const json = (response: ServerResponse, status: number, value: unknown): void =>
 const webRpcError = (
   response: ServerResponse,
   status: number,
-  code: 'invalid_request' | 'method_not_found' | 'handler_error',
+  code: WebRpcErrorCode,
   message: string
 ): void => {
   json(response, status, {
@@ -613,12 +615,8 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
             webRpcError(response, 401, 'invalid_request', error.message)
             return
           }
-          webRpcError(
-            response,
-            500,
-            'handler_error',
-            error instanceof Error ? error.message : String(error)
-          )
+          const publicError = toApplicationCommandErrorEnvelope(error)
+          webRpcError(response, 500, publicError.code, publicError.message)
         }
         return
       }

--- a/src/preload/electron-renderer-contract-adapter.test.ts
+++ b/src/preload/electron-renderer-contract-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, type Mock } from 'vitest'
 
+import { ApplicationCommandError } from '../shared/application-command-contract'
 import { createElectronRendererContractAdapter } from './electron-renderer-contract-adapter'
 
 type MockPort = Readonly<{
@@ -124,6 +125,28 @@ describe('electron renderer contract adapter', () => {
     const adapter = createElectronRendererContractAdapter(port)
 
     await expect(adapter.invoke('preview.load', { projectId: 'project-1' })).rejects.toBe(failure)
+  })
+
+  it('unwraps runtime-validated Project outcomes and reconstructs public failures', async () => {
+    const project = { id: 'project-1' }
+    const port = createPort()
+    const adapter = createElectronRendererContractAdapter(port)
+    port.invoke.mockResolvedValueOnce({ ok: true, result: project }).mockResolvedValueOnce({
+      ok: false,
+      error: {
+        code: 'invalid-command-arguments',
+        message: 'Invalid arguments for application command: projects:create'
+      }
+    })
+
+    await expect(adapter.invoke('projects.get', 'project-1')).resolves.toBe(project)
+    await expect(adapter.invoke('projects.create', { name: 42 })).rejects.toEqual(
+      expect.objectContaining<ApplicationCommandError>({
+        name: 'ApplicationCommandError',
+        code: 'invalid-command-arguments',
+        message: 'Invalid arguments for application command: projects:create'
+      })
+    )
   })
 
   it('rejects surface-native methods from the IPC request path', async () => {

--- a/src/preload/electron-renderer-contract-adapter.ts
+++ b/src/preload/electron-renderer-contract-adapter.ts
@@ -1,4 +1,5 @@
 import { RENDERER_CONTRACT_CATALOG } from '../shared/renderer-contract-catalog'
+import { unwrapApplicationCommandOutcome } from '../shared/application-command-contract'
 import type {
   RendererContractDescriptor,
   RendererParameterCodec
@@ -134,7 +135,10 @@ export const createElectronRendererContractAdapter = (
       port.getPathForFile
     )
     if (encodedArgs === null) return null as Result
-    return (await port.invoke(channel, ...encodedArgs)) as Result
+    const result = await port.invoke(channel, ...encodedArgs)
+    return contract.applicationCommand === 'runtime-validated'
+      ? unwrapApplicationCommandOutcome<Result>(result)
+      : (result as Result)
   },
   send: (publicPath: string, ...args: unknown[]): void => {
     port.send(requireSendContract(publicPath), ...args)

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -10,7 +10,10 @@
 
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
-import { RENDERER_CONTRACT_GROUPS } from '../shared/renderer-contract-catalog'
+import {
+  ELECTRON_APPLICATION_COMMAND_CHANNELS,
+  RENDERER_CONTRACT_GROUPS
+} from '../shared/renderer-contract-catalog'
 
 const { invokeMock, sendMock, exposeMock, getPathForFileMock, onMock, removeListenerMock } =
   vi.hoisted(() => ({
@@ -167,7 +170,9 @@ const collectFunctionPaths = (value: unknown, prefix = ''): string[] => {
 beforeAll(async () => {
   // Take the contextBridge branch of the preload's expose logic (production path with context isolation).
   Object.defineProperty(process, 'contextIsolated', { value: true, configurable: true })
-  invokeMock.mockResolvedValue(undefined)
+  invokeMock.mockImplementation(async (channel: string) =>
+    validatedApplicationCommandChannels.has(channel) ? { ok: true, result: undefined } : undefined
+  )
 
   await import('./index')
 
@@ -205,6 +210,7 @@ const coreContractGroups = RENDERER_CONTRACT_GROUPS.filter(
   ({ capability }) => !runtimeContractCapabilities.has(capability)
 )
 const coreContracts = coreContractGroups.flatMap(({ contracts }) => contracts)
+const validatedApplicationCommandChannels = new Set(ELECTRON_APPLICATION_COMMAND_CHANNELS)
 
 const getApiCallable = (publicPath: string): ((...args: unknown[]) => unknown) => {
   const callable = publicPath

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -41,6 +41,7 @@ class FakeWebSocket {
 
 type WebApi = {
   projects: {
+    create: (request: unknown) => Promise<unknown>
     onCreated: (listener: (payload: unknown) => void) => () => void
   }
 }
@@ -86,6 +87,41 @@ afterEach(() => {
 })
 
 describe('Web bootstrap event connection', () => {
+  it('reconstructs Application Command errors returned by Web RPC', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === '/api/bootstrap') {
+          return new Response(
+            JSON.stringify({ ...bootstrapPayload, rpcChannels: ['projects:create'] }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        }
+        if (String(input) === '/rpc/projects%3Acreate') {
+          return new Response(
+            JSON.stringify({
+              protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+              ok: false,
+              error: {
+                code: 'invalid-command-arguments',
+                message: 'Invalid project request.'
+              }
+            }),
+            { status: 500, headers: { 'content-type': 'application/json' } }
+          )
+        }
+        throw new Error(`Unexpected fetch: ${String(input)}`)
+      })
+    )
+
+    const api = await loadBootstrap()
+    await expect(api.projects.create({ name: 42 })).rejects.toMatchObject({
+      name: 'ApplicationCommandError',
+      code: 'invalid-command-arguments',
+      message: 'Invalid project request.'
+    })
+  })
+
   it('opens the initial event socket with the stable Web client id', async () => {
     await loadBootstrap()
 

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -1,4 +1,8 @@
 import {
+  ApplicationCommandError,
+  isApplicationCommandErrorCode
+} from '../../shared/application-command-contract'
+import {
   WEB_RPC_PROTOCOL_VERSION,
   webRpcBootstrapSchema,
   webRpcEventSchema,
@@ -157,18 +161,22 @@ const invoke = async (channel: string, args: unknown[]): Promise<unknown> => {
     body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args }, encodeBinary)
   })
   const body = await response.text()
-  if (!response.ok) {
-    throw responseError(response, body, `RPC ${channel} failed`)
-  }
   let payload
   try {
     payload = webRpcResponseSchema.parse(JSON.parse(body, reviveBinary))
   } catch {
+    if (!response.ok) throw responseError(response, body, `RPC ${channel} failed`)
     throw new Error(
       'Open Science returned an invalid response. Try reconnecting to the remote computer.'
     )
   }
-  if (!payload.ok) throw new Error(payload.error.message)
+  if (!payload.ok) {
+    if (isApplicationCommandErrorCode(payload.error.code)) {
+      throw new ApplicationCommandError(payload.error.code, payload.error.message)
+    }
+    throw responseError(response, body, payload.error.message)
+  }
+  if (!response.ok) throw responseError(response, body, `RPC ${channel} failed`)
   return rewritePreviewUrls(payload.result)
 }
 

--- a/src/shared/application-command-contract.test.ts
+++ b/src/shared/application-command-contract.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ApplicationCommandError,
+  toApplicationCommandErrorEnvelope,
+  unwrapApplicationCommandOutcome
+} from './application-command-contract'
+
+describe('application command contract', () => {
+  it('preserves only public application command error codes', () => {
+    expect(
+      toApplicationCommandErrorEnvelope(
+        new ApplicationCommandError('invalid-command-arguments', 'Invalid project request.')
+      )
+    ).toEqual({
+      code: 'invalid-command-arguments',
+      message: 'Invalid project request.'
+    })
+    expect(
+      toApplicationCommandErrorEnvelope(
+        Object.assign(new Error('Database unavailable.'), { code: 'SQLITE_BUSY' })
+      )
+    ).toEqual({ code: 'command-failed', message: 'Database unavailable.' })
+  })
+
+  it('unwraps results and reconstructs typed failures', () => {
+    const result = { id: 'project-1' }
+
+    expect(unwrapApplicationCommandOutcome({ ok: true, result })).toBe(result)
+    expect(() =>
+      unwrapApplicationCommandOutcome({
+        ok: false,
+        error: { code: 'command-unavailable', message: 'Projects are unavailable.' }
+      })
+    ).toThrow(
+      expect.objectContaining({
+        name: 'ApplicationCommandError',
+        code: 'command-unavailable',
+        message: 'Projects are unavailable.'
+      })
+    )
+  })
+
+  it('fails closed on malformed outcomes', () => {
+    expect(() => unwrapApplicationCommandOutcome({ ok: true })).toThrow(
+      expect.objectContaining({ code: 'invalid-command-result' })
+    )
+    expect(() =>
+      unwrapApplicationCommandOutcome({
+        ok: false,
+        error: { code: 'SQLITE_BUSY', message: 'private detail' }
+      })
+    ).toThrow(expect.objectContaining({ code: 'invalid-command-result' }))
+  })
+})

--- a/src/shared/application-command-contract.ts
+++ b/src/shared/application-command-contract.ts
@@ -1,0 +1,86 @@
+export const APPLICATION_COMMAND_ERROR_CODES = [
+  'invalid-command-arguments',
+  'invalid-command-result',
+  'command-unavailable',
+  'command-failed'
+] as const
+
+export type ApplicationCommandErrorCode = (typeof APPLICATION_COMMAND_ERROR_CODES)[number]
+
+export type RuntimeCodec<Value> = Readonly<{
+  parse: (value: unknown) => Value
+}>
+
+export const validationCodec = <Value>(codec: RuntimeCodec<Value>): RuntimeCodec<Value> =>
+  Object.freeze({
+    parse: (value): Value => {
+      codec.parse(value)
+      return value as Value
+    }
+  })
+
+export type ApplicationCommandContract<Args extends readonly unknown[], Result> = Readonly<{
+  args: RuntimeCodec<Args>
+  result: RuntimeCodec<Result>
+}>
+
+export type ApplicationCommandErrorEnvelope = Readonly<{
+  code: ApplicationCommandErrorCode
+  message: string
+}>
+
+export type ApplicationCommandOutcome<Result> =
+  | Readonly<{ ok: true; result: Result }>
+  | Readonly<{ ok: false; error: ApplicationCommandErrorEnvelope }>
+
+const errorCodes = new Set<string>(APPLICATION_COMMAND_ERROR_CODES)
+
+export const isApplicationCommandErrorCode = (
+  value: unknown
+): value is ApplicationCommandErrorCode => typeof value === 'string' && errorCodes.has(value)
+
+export class ApplicationCommandError extends Error {
+  constructor(
+    readonly code: ApplicationCommandErrorCode,
+    message: string
+  ) {
+    super(message)
+    this.name = 'ApplicationCommandError'
+  }
+}
+
+export const toApplicationCommandErrorEnvelope = (
+  error: unknown
+): ApplicationCommandErrorEnvelope =>
+  Object.freeze(
+    error instanceof ApplicationCommandError
+      ? { code: error.code, message: error.message }
+      : {
+          code: 'command-failed' as const,
+          message: error instanceof Error ? error.message : String(error)
+        }
+  )
+
+const invalidOutcome = (): ApplicationCommandError =>
+  new ApplicationCommandError(
+    'invalid-command-result',
+    'Application command returned an invalid response.'
+  )
+
+export const unwrapApplicationCommandOutcome = <Result>(value: unknown): Result => {
+  if (!value || typeof value !== 'object' || !('ok' in value)) throw invalidOutcome()
+  if (value.ok === true && 'result' in value) return value.result as Result
+  if (
+    value.ok === false &&
+    'error' in value &&
+    value.error != null &&
+    typeof value.error === 'object' &&
+    'code' in value.error &&
+    isApplicationCommandErrorCode(value.error.code) &&
+    'message' in value.error &&
+    typeof value.error.message === 'string'
+  ) {
+    throw new ApplicationCommandError(value.error.code, value.error.message)
+  }
+  throw invalidOutcome()
+}

--- a/src/shared/projects.test.ts
+++ b/src/shared/projects.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { projectApplicationCommandContracts } from './projects'
+
+const project = {
+  id: 'project-1',
+  name: 'Project',
+  description: '',
+  isExample: false,
+  createdAt: 1,
+  updatedAt: 2
+}
+
+describe('project application command contracts', () => {
+  it('decodes the six Project command argument and result shapes', () => {
+    const listArgs: [] = []
+    const listResult = [project]
+    expect(projectApplicationCommandContracts.list.args.parse(listArgs)).toBe(listArgs)
+    expect(projectApplicationCommandContracts.list.result.parse(listResult)).toBe(listResult)
+    expect(projectApplicationCommandContracts.get.args.parse(['project-1'])).toEqual(['project-1'])
+    expect(projectApplicationCommandContracts.get.result.parse(null)).toBeNull()
+    expect(projectApplicationCommandContracts.create.args.parse([{ name: 'Project' }])).toEqual([
+      { name: 'Project' }
+    ])
+    expect(
+      projectApplicationCommandContracts.update.args.parse([{ id: 'project-1', name: 'Renamed' }])
+    ).toEqual([{ id: 'project-1', name: 'Renamed' }])
+    expect(
+      projectApplicationCommandContracts.updateArchive.args.parse([
+        { id: 'project-1', archived: true, expectedArchivedAt: null }
+      ])
+    ).toEqual([{ id: 'project-1', archived: true, expectedArchivedAt: null }])
+    expect(projectApplicationCommandContracts.delete.args.parse([{ id: 'project-1' }])).toEqual([
+      { id: 'project-1' }
+    ])
+    expect(projectApplicationCommandContracts.delete.result.parse(undefined)).toBeUndefined()
+  })
+
+  it('rejects malformed and surplus public fields', () => {
+    expect(() => projectApplicationCommandContracts.create.args.parse([{ name: 42 }])).toThrow()
+    expect(() =>
+      projectApplicationCommandContracts.delete.args.parse([
+        { id: 'project-1', databasePath: '/private/research.db' }
+      ])
+    ).toThrow()
+    expect(() =>
+      projectApplicationCommandContracts.list.result.parse([{ ...project, createdAt: 'today' }])
+    ).toThrow()
+  })
+})

--- a/src/shared/projects.ts
+++ b/src/shared/projects.ts
@@ -1,39 +1,81 @@
+import { z } from 'zod'
+
+import { validationCodec, type ApplicationCommandContract } from './application-command-contract'
+
 // Shared project types crossing the main <-> renderer IPC boundary.
 //
 // The SQLite/Prisma layer owns Project rows (see src/main/projects). Timestamps are normalized to
 // epoch milliseconds at the repository boundary so the renderer treats them like session timestamps.
 
-export type Project = {
-  id: string
-  name: string
-  description: string
-  isExample: boolean
-  // An absent timestamp keeps the Project on active surfaces. Archive is reversible and does not
-  // affect the Project's research activity ordering.
-  archivedAt?: number
-  createdAt: number
-  updatedAt: number
-}
+export const projectSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    isExample: z.boolean(),
+    // An absent timestamp keeps the Project on active surfaces. Archive is reversible and does not
+    // affect the Project's research activity ordering.
+    archivedAt: z.number().finite().optional(),
+    createdAt: z.number().finite(),
+    updatedAt: z.number().finite()
+  })
+  .strict()
 
-export type CreateProjectRequest = {
-  name: string
-  description?: string
-}
+export const createProjectRequestSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional()
+  })
+  .strict()
 
-export type UpdateProjectRequest = {
-  id: string
-  name?: string
-  description?: string
-}
+export const updateProjectRequestSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    description: z.string().optional()
+  })
+  .strict()
 
-export type DeleteProjectRequest = {
-  id: string
-}
+export const deleteProjectRequestSchema = z.object({ id: z.string() }).strict()
 
-export type UpdateProjectArchiveRequest = {
-  id: string
-  archived: boolean
-  // The last authoritative archive value prevents a stale renderer from restoring or archiving a
-  // Project after another window has already changed it.
-  expectedArchivedAt: number | null
-}
+export const updateProjectArchiveRequestSchema = z
+  .object({
+    id: z.string(),
+    archived: z.boolean(),
+    // The last authoritative archive value prevents a stale renderer from restoring or archiving a
+    // Project after another window has already changed it.
+    expectedArchivedAt: z.number().finite().nullable()
+  })
+  .strict()
+
+export type Project = z.infer<typeof projectSchema>
+export type CreateProjectRequest = z.infer<typeof createProjectRequestSchema>
+export type UpdateProjectRequest = z.infer<typeof updateProjectRequestSchema>
+export type DeleteProjectRequest = z.infer<typeof deleteProjectRequestSchema>
+export type UpdateProjectArchiveRequest = z.infer<typeof updateProjectArchiveRequestSchema>
+
+const contract = <Args extends readonly unknown[], Result>(
+  args: ApplicationCommandContract<Args, Result>['args'],
+  result: ApplicationCommandContract<Args, Result>['result']
+): ApplicationCommandContract<Args, Result> => Object.freeze({ args, result })
+
+export const projectApplicationCommandContracts = Object.freeze({
+  list: contract(validationCodec(z.tuple([])), validationCodec(z.array(projectSchema))),
+  get: contract(validationCodec(z.tuple([z.string()])), validationCodec(projectSchema.nullable())),
+  create: contract(
+    validationCodec(z.tuple([createProjectRequestSchema])),
+    validationCodec(projectSchema)
+  ),
+  update: contract(
+    validationCodec(z.tuple([updateProjectRequestSchema])),
+    validationCodec(projectSchema)
+  ),
+  updateArchive: contract(
+    validationCodec(z.tuple([updateProjectArchiveRequestSchema])),
+    validationCodec(projectSchema)
+  ),
+  delete: contract(
+    validationCodec(z.tuple([deleteProjectRequestSchema])),
+    validationCodec(z.undefined())
+  )
+})

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
-import { RENDERER_CONTRACT_CATALOG, RENDERER_CONTRACT_GROUPS } from './renderer-contract-catalog'
+import {
+  ELECTRON_APPLICATION_COMMAND_CHANNELS,
+  RENDERER_CONTRACT_CATALOG,
+  RENDERER_CONTRACT_GROUPS
+} from './renderer-contract-catalog'
 import { projectRendererContractMaps } from './renderer-contract'
 
 const paths = (
@@ -202,5 +206,24 @@ describe('renderer contract catalog', () => {
       deactivateChannel: 'shortcut:window-find-unready',
       deactivate: 'on-dispose'
     })
+  })
+
+  it('marks only the runtime-validated Project command slice', () => {
+    expect(paths(({ applicationCommand }) => applicationCommand === 'runtime-validated')).toEqual([
+      'projects.create',
+      'projects.delete',
+      'projects.get',
+      'projects.list',
+      'projects.update',
+      'projects.updateArchive'
+    ])
+    expect(ELECTRON_APPLICATION_COMMAND_CHANNELS).toEqual([
+      'projects:create',
+      'projects:delete',
+      'projects:get',
+      'projects:list',
+      'projects:update',
+      'projects:update-archive'
+    ])
   })
 })

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -36,12 +36,13 @@ const RUNTIME_INTERPRETER = 'runtime-interpreter-path-object'
 const NATIVE_FILE_UPLOAD = 'native-file-upload-request'
 const SESSION_SAVE = 'session-save-optional-argument'
 const SESSION_SAVE_JSON = 'session-save-json-undefined'
+const RUNTIME_VALIDATED = 'runtime-validated'
 
 // prettier-ignore
 type ContractProfile = typeof WEB | typeof LOCAL | typeof EVENT | typeof DORMANT_EVENT | typeof CLOSE_PANE_EVENT | typeof ELECTRON | typeof MAPPED_ELECTRON | typeof SEND | typeof WINDOW_FIND_READY | typeof ELECTRON_EVENT | typeof NATIVE | typeof MAPPED_NATIVE | typeof DELEGATED_NATIVE
 
 // prettier-ignore
-type ContractEntry = readonly [member: string, channel: string | null, profile?: ContractProfile, electronCodec?: RendererParameterCodec, webCodec?: RendererParameterCodec]
+type ContractEntry = readonly [member: string, channel: string | null, profile?: ContractProfile, electronCodec?: RendererParameterCodec, webCodec?: RendererParameterCodec, applicationCommand?: typeof RUNTIME_VALIDATED]
 
 // prettier-ignore
 const CLOSE_PANE_LIFECYCLE = { activateChannel: 'shortcut:close-active-pane-ready', activate: 'after-subscribe', deactivateChannel: 'shortcut:close-active-pane-unready', deactivate: 'after-unsubscribe' } as const
@@ -56,7 +57,7 @@ const surface = <Value>(
 
 const expandEntry = (
   publicRoot: string,
-  [member, channel, profile = WEB, electronCodec, webCodec]: ContractEntry
+  [member, channel, profile = WEB, electronCodec, webCodec, applicationCommand]: ContractEntry
 ): RendererContractSeed => {
   const isWebRequest = profile === WEB || profile === LOCAL
   const isDormantEvent = profile === DORMANT_EVENT || profile === CLOSE_PANE_EVENT
@@ -132,6 +133,7 @@ const expandEntry = (
       isWebRequest || profile === DELEGATED_NATIVE ? 'caller-context' : 'none',
       profile === WEB || profile === DELEGATED_NATIVE ? 'caller-context' : 'none'
     ),
+    applicationCommand,
     lifecycleDispatch:
       profile === CLOSE_PANE_EVENT
         ? CLOSE_PANE_LIFECYCLE
@@ -160,7 +162,8 @@ const group = (
     entries.map((entry) => expandEntry(publicRoot, entry))
   )
 
-// Compact tuple manifest: [member, channel, surface profile?, Electron codec?, Web codec?].
+// Compact tuple manifest:
+// [member, channel, surface profile?, Electron codec?, Web codec?, Application command?].
 // prettier-ignore
 export const RENDERER_CONTRACT_GROUPS = Object.freeze([
   group('acp', 'acp', [
@@ -252,8 +255,8 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['listFiles', 'project-files:list-files'], ['repairIndex', 'project-files:repair-index'], ['searchArtifacts', 'project-files:search-artifacts'],
   ]),
   group('projects', 'projects', [
-    ['onCreated', 'project:created', EVENT], ['onDeleted', 'project:deleted', EVENT], ['onUpdated', 'project:updated', EVENT], ['create', 'projects:create'],
-    ['delete', 'projects:delete'], ['get', 'projects:get'], ['list', 'projects:list'], ['updateArchive', 'projects:update-archive'], ['update', 'projects:update'],
+    ['onCreated', 'project:created', EVENT], ['onDeleted', 'project:deleted', EVENT], ['onUpdated', 'project:updated', EVENT], ['create', 'projects:create', WEB, undefined, undefined, RUNTIME_VALIDATED],
+    ['delete', 'projects:delete', WEB, undefined, undefined, RUNTIME_VALIDATED], ['get', 'projects:get', WEB, undefined, undefined, RUNTIME_VALIDATED], ['list', 'projects:list', WEB, undefined, undefined, RUNTIME_VALIDATED], ['updateArchive', 'projects:update-archive', WEB, undefined, undefined, RUNTIME_VALIDATED], ['update', 'projects:update', WEB, undefined, undefined, RUNTIME_VALIDATED],
   ]),
   group('remote-access', 'remoteAccess', [
     ['onChanged', 'remote-access:changed', EVENT], ['approve', 'remote-access:approve'], ['detect', 'remote-access:detect'],
@@ -378,3 +381,16 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
 ])
 
 export const RENDERER_CONTRACT_CATALOG = composeRendererContractCatalog(RENDERER_CONTRACT_GROUPS)
+
+export const ELECTRON_APPLICATION_COMMAND_CHANNELS: readonly string[] = Object.freeze(
+  RENDERER_CONTRACT_CATALOG.flatMap(
+    ({ applicationCommand, channel, dispatchPolicy, kind, surfaceInstallation }) =>
+      applicationCommand === 'runtime-validated' &&
+      channel !== null &&
+      kind === 'method' &&
+      surfaceInstallation.electron === 'preload' &&
+      dispatchPolicy.electron === 'electron-ipc-request'
+        ? [channel]
+        : []
+  ).sort()
+)

--- a/src/shared/renderer-contract.ts
+++ b/src/shared/renderer-contract.ts
@@ -14,6 +14,7 @@ export type RendererEventDeliverability =
 
 export type RendererAuthorityFlow = 'electron-sender' | 'caller-context' | 'none'
 export type RendererMapProjection = 'invoke' | 'event' | 'none'
+export type RendererApplicationCommand = 'runtime-validated'
 
 // prettier-ignore
 export type RendererLifecycleDispatch = Readonly<{ activateChannel: string; activate: 'after-subscribe' | 'on-call'; deactivateChannel: string; deactivate: 'after-unsubscribe' | 'on-dispose' }>
@@ -38,6 +39,7 @@ export type RendererContractSeed = Readonly<{
   dispatchPolicy: RendererSurfaceProfile<RendererDispatchPolicy>
   eventDeliverability: RendererSurfaceProfile<RendererEventDeliverability>
   authorityFlow: RendererSurfaceProfile<RendererAuthorityFlow>
+  applicationCommand?: RendererApplicationCommand
   lifecycleDispatch?: RendererLifecycleDispatch
   mapProjection: RendererMapProjection
 }>

--- a/src/shared/web-rpc-contract.test.ts
+++ b/src/shared/web-rpc-contract.test.ts
@@ -162,5 +162,15 @@ describe('Web RPC contract', () => {
         error: { code: 'invalid_request', message: 'Invalid request.' }
       }).success
     ).toBe(true)
+    expect(
+      webRpcResponseSchema.safeParse({
+        protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+        ok: false,
+        error: {
+          code: 'invalid-command-arguments',
+          message: 'Invalid project request.'
+        }
+      }).success
+    ).toBe(true)
   })
 })

--- a/src/shared/web-rpc-contract.ts
+++ b/src/shared/web-rpc-contract.ts
@@ -1,8 +1,19 @@
 import { z } from 'zod'
 
+import { APPLICATION_COMMAND_ERROR_CODES } from './application-command-contract'
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
 
 export const WEB_RPC_PROTOCOL_VERSION = 1 as const
+export const WEB_RPC_TRANSPORT_ERROR_CODES = [
+  'invalid_request',
+  'method_not_found',
+  'handler_error'
+] as const
+export const WEB_RPC_ERROR_CODES = [
+  ...WEB_RPC_TRANSPORT_ERROR_CODES,
+  ...APPLICATION_COMMAND_ERROR_CODES
+] as const
+export type WebRpcErrorCode = (typeof WEB_RPC_ERROR_CODES)[number]
 
 // The preload interface is the positive source for browser-callable methods. These Electron-only
 // methods have browser adapters or require native WebContents/filesystem capabilities and therefore
@@ -72,7 +83,7 @@ export const webRpcResponseSchema = z.discriminatedUnion('ok', [
       ok: z.literal(false),
       error: z
         .object({
-          code: z.enum(['invalid_request', 'method_not_found', 'handler_error']),
+          code: z.enum(WEB_RPC_ERROR_CODES),
           message: z.string()
         })
         .strict()


### PR DESCRIPTION
## Problem

Application Commands carry runtime names and TypeScript phantom types, while runtime validation, Electron registration, Web RPC errors, and renderer adaptation remain separate concerns. Extending a command can therefore require several manually synchronized edits, and malformed values can cross process boundaries unchecked.

## Proposed change

- Add shared runtime codec and stable Application Command error primitives.
- Define strict Zod request and result contracts for the six Project commands.
- Attach those contracts to the command router and validate before and after handler execution.
- Mark the pilot slice in the renderer catalog and derive the Electron Application Command inventory from that catalog.
- Replace the six handwritten Project IPC handlers with one catalog-driven Electron adapter while retaining preview-state ownership.
- Preserve public Application Command error codes across Electron preload and Web RPC adapters.

## Scope and non-goals

This is an incremental vertical slice covering Project create, delete, get, list, update, and updateArchive. It does not migrate the remaining Application Commands, generate the full OpenScienceAPI declaration, introduce a new dependency, or change UI components and interaction flows.

## Acceptance criteria and validation

The checks below ran after the last material edit:

- Runtime argument and result validation -> targeted router and Project contract tests -> passed.
- Catalog-selected Electron registration, caller context, lease, diagnostics, and error reconstruction -> targeted main and preload adapter tests -> passed.
- Web RPC error-code preservation -> shared contract, HTTP server, and Web bootstrap tests -> passed.
- Generated Web API map remains stable -> npm run check:web-api-map -> passed.
- Node and renderer type surfaces -> npm run typecheck -> passed.
- Repository lint -> npm run lint -> passed with 0 errors and 17 pre-existing warnings in unchanged files.
- Full fallback -> npm test -> 12,493 passed and 190 skipped across 873 test files.
- Whitespace and staged diff integrity -> git diff --check -> passed.

## Review focus

- Whether strict Project schemas match the intended public transport contract.
- Whether the catalog marker and derived Electron inventory provide a suitable migration seam for later command groups.
- Whether the stable error envelope keeps enough public detail without exposing implementation-specific codes.

## Uncovered risks

For mutating Project commands, lifecycle publication occurs inside the handler and result validation occurs when the handler returns. If a repository mutation commits but returns a schema-invalid Project, listeners may receive the event while the caller receives an invalid-command-result error. Current repository normalization makes this unlikely, but the ordering deserves review before expanding the pattern.

No manual UI or packaged Electron smoke test was run because no UI component or public API signature changed. The evidence mapping has not received an independent reviewer pass, so this change is not marked independently verified.