### PR TITLE
fix(session-persistence): preserve live permission waits

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -366,7 +366,16 @@ const createApplicationModules = async (
       diagnosticErrorFields(error)
     )
   }
-  const sessionRepository = createDefaultSessionRepository()
+  // Session reads and permission scope validation both need a late-bound view of ACP ownership:
+  // startup runs before the runtime exists, while later reads must preserve live prompt state.
+  const runtimeRef: { current: ReturnType<typeof createAcpRuntime> | undefined } = {
+    current: undefined
+  }
+  const sessionRepository = createDefaultSessionRepository((projectId, sessionId) =>
+    (runtimeRef.current?.getActivePromptSessions() ?? []).some(
+      (session) => session.projectName === projectId && session.sessionId === sessionId
+    )
+  )
   const projectRepository = createDefaultProjectRepository()
   const previewStateRepository = createDefaultPreviewStateRepository()
 
@@ -462,12 +471,6 @@ const createApplicationModules = async (
   })
   const managedPreviewOwners = createManagedPreviewOwnerRegistry(previewResources)
 
-  // Permission scope validation starts before the ACP coordinator is constructed. Keep the late-bound
-  // reference here so a first-turn Session grant can recognize its live owner before the renderer's
-  // asynchronous session persistence finishes.
-  const runtimeRef: { current: ReturnType<typeof createAcpRuntime> | undefined } = {
-    current: undefined
-  }
   const notebookActivityRef: {
     current:
       { getActiveNotebookSessions(): { projectName: string; sessionId: string }[] } | undefined

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -3,6 +3,10 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
+vi.mock('electron', () => ({
+  app: { getPath: () => '/home/user', isPackaged: true }
+}))
+
 import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
 import {
   createLinearConversationGraph,
@@ -33,6 +37,7 @@ import {
   type SessionMutationRepository,
   type SessionProvenancePersistence
 } from './coordinator'
+import { SessionRepository } from './repository'
 
 const createSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
   id: 'session-1',
@@ -1467,6 +1472,61 @@ describe('SessionPersistenceCoordinator', () => {
     )
     expect(fileIndex.syncSession).toHaveBeenCalledWith(session)
     expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([session])
+  })
+
+  it('preserves a live permission wait when another client hydrates in the same process', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-live-permission-hydration-'))
+    const repository = new SessionRepository(root, { hasActiveRuntimePrompt: () => true })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    try {
+      await repository.saveSession(createSession())
+      await coordinator.loadAll()
+
+      await coordinator.saveSession(
+        createSession({
+          status: 'waiting-permission',
+          activeRun: { promptMessageId: 'prompt-1', startedAt: 3 },
+          messages: [
+            {
+              id: 'prompt-1',
+              role: 'user',
+              content: 'Run the notebook cell',
+              status: 'complete',
+              eventIds: [],
+              createdAt: 3,
+              updatedAt: 3
+            }
+          ],
+          activities: [
+            {
+              id: 'notebook-call-1',
+              kind: 'tool',
+              title: 'Notebook cell',
+              status: 'in_progress',
+              sortIndex: 1,
+              eventIds: [],
+              createdAt: 3,
+              updatedAt: 3
+            }
+          ]
+        })
+      )
+
+      const rehydrated = await coordinator.loadAll()
+
+      expect(rehydrated.sessions[0]).toMatchObject({
+        status: 'waiting-permission',
+        activeRun: { promptMessageId: 'prompt-1', startedAt: 3 }
+      })
+      expect(rehydrated.sessions[0].resumeRecovery).toBeUndefined()
+      expect(rehydrated.sessions[0].error).toBeUndefined()
+      expect(rehydrated.sessions[0].messages[0].interrupted).toBeUndefined()
+      expect(rehydrated.sessions[0].activities?.[0].status).toBe('in_progress')
+      expect(rehydrated.sessions[0].conversationGraph?.activities[0]?.status).toBe('in_progress')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   it('records a phased terminal aggregate for complete Session hydration', async () => {

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -127,8 +127,9 @@ const createSessionPersistenceHandlers = (
 }
 
 // Creates the production repository rooted at the (dev-aware) storage root.
-const createDefaultSessionRepository = (): SessionRepository =>
-  new SessionRepository(resolveStorageRoot())
+const createDefaultSessionRepository = (
+  hasActiveRuntimePrompt: (projectId: string, sessionId: string) => boolean = () => false
+): SessionRepository => new SessionRepository(resolveStorageRoot(), { hasActiveRuntimePrompt })
 
 const createDefaultReviewRepository = (): ReviewRepository =>
   new ReviewRepository(() => getProjectDbClient(resolveStorageRoot()))

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -54,6 +54,7 @@ type SessionDirectoryEntry = {
 }
 
 type SessionRepositoryDependencies = {
+  hasActiveRuntimePrompt(projectId: string, sessionId: string): boolean
   remove(path: string, options: { force: boolean; recursive: boolean }): Promise<void>
   readDirectoryEntries(path: string): Promise<SessionDirectoryEntry[]>
   readManifestFile(path: string): Promise<string>
@@ -63,6 +64,7 @@ type SessionRepositoryDependencies = {
 }
 
 const DEFAULT_DEPENDENCIES: SessionRepositoryDependencies = {
+  hasActiveRuntimePrompt: () => false,
   remove: (path, options) => rm(path, options),
   readDirectoryEntries: (path) => readdir(path, { withFileTypes: true }),
   readManifestFile: (path) => readFile(path, 'utf8'),
@@ -119,6 +121,8 @@ class SessionRepository {
     dependencies: Partial<SessionRepositoryDependencies> = {}
   ) {
     this.dependencies = {
+      hasActiveRuntimePrompt:
+        dependencies.hasActiveRuntimePrompt ?? DEFAULT_DEPENDENCIES.hasActiveRuntimePrompt,
       remove: dependencies.remove ?? DEFAULT_DEPENDENCIES.remove,
       readDirectoryEntries:
         dependencies.readDirectoryEntries ?? DEFAULT_DEPENDENCIES.readDirectoryEntries,
@@ -635,7 +639,9 @@ class SessionRepository {
 
     try {
       const session = normalizeSessionFile(JSON.parse(raw) as unknown, {
-        preserveLegacyUploadPaths: true
+        preserveLegacyUploadPaths: true,
+        preserveRuntimeState: (sessionId) =>
+          this.dependencies.hasActiveRuntimePrompt(projectId, sessionId)
       })
       if (!session) {
         const wasQuarantined =

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -1232,7 +1232,7 @@ const sanitizeMessage = (
 
 const sanitizeConversationGraph = (
   value: unknown,
-  options: { preserveLegacyUploadPaths?: boolean } = {}
+  options: { preserveLegacyUploadPaths?: boolean; preserveRuntimeState?: boolean } = {}
 ): PersistedConversationGraph | undefined => {
   if (!isRecord(value) || value.schemaVersion !== 1) return undefined
   const rootFrameId = asString(value.rootFrameId)
@@ -1329,7 +1329,7 @@ const sanitizeConversationGraph = (
         if (!message || !agentFrameId || !introducedOnBranchId) return []
         return [
           {
-            ...normalizeMessageAfterRestore(message),
+            ...(options.preserveRuntimeState ? message : normalizeMessageAfterRestore(message)),
             agentFrameId,
             introducedOnBranchId,
             ...(asString(candidate.parentMessageId)
@@ -1391,7 +1391,9 @@ const sanitizeConversationGraph = (
         return activity && agentFrameId && messageBranchId && promptMessageId && runtimeSegmentId
           ? [
               {
-                ...normalizeActivityAfterRestore(activity),
+                ...(options.preserveRuntimeState
+                  ? activity
+                  : normalizeActivityAfterRestore(activity)),
                 agentFrameId,
                 messageBranchId,
                 promptMessageId,
@@ -1411,7 +1413,9 @@ const sanitizeConversationGraph = (
         return group && agentFrameId && messageBranchId && promptMessageId
           ? [
               {
-                ...normalizeActivityGroupAfterRestore(group),
+                ...(options.preserveRuntimeState
+                  ? group
+                  : normalizeActivityGroupAfterRestore(group)),
                 agentFrameId,
                 messageBranchId,
                 promptMessageId
@@ -1511,7 +1515,7 @@ const sanitizePendingHistoryReplay = (
 // Rebuilds a persisted chat session and normalizes any runtime-only interrupted state.
 const sanitizeSession = (
   session: unknown,
-  options: { preserveLegacyUploadPaths?: boolean } = {}
+  options: { preserveLegacyUploadPaths?: boolean; preserveRuntimeState?: boolean } = {}
 ): PersistedChatSession | undefined => {
   if (!isRecord(session)) return undefined
 
@@ -1526,13 +1530,17 @@ const sanitizeSession = (
     ? session.activities
         .map(sanitizeToolActivity)
         .filter((item): item is PersistedToolActivity => !!item)
-        .map(normalizeActivityAfterRestore)
+        .map((activity) =>
+          options.preserveRuntimeState ? activity : normalizeActivityAfterRestore(activity)
+        )
     : []
   const activityGroups = Array.isArray(session.activityGroups)
     ? session.activityGroups
         .map(sanitizeActivityGroup)
         .filter((item): item is PersistedActivityGroup => !!item)
-        .map(normalizeActivityGroupAfterRestore)
+        .map((group) =>
+          options.preserveRuntimeState ? group : normalizeActivityGroupAfterRestore(group)
+        )
     : []
   let sanitized: PersistedChatSession = {
     id,
@@ -1623,7 +1631,7 @@ const sanitizeSession = (
 
   // Normalize before graph creation so a legacy flat transcript never seeds a streaming message or
   // loses the active prompt identity while activeRun is cleared.
-  sanitized = normalizeSessionAfterRestore(sanitized)
+  if (!options.preserveRuntimeState) sanitized = normalizeSessionAfterRestore(sanitized)
 
   if (session.conversationGraph !== undefined) {
     const graph = sanitizeConversationGraph(session.conversationGraph, options)
@@ -1644,7 +1652,7 @@ const sanitizeSession = (
 
   // Normalize only after resolving the canonical active Branch. Recovery references and the durable
   // interrupted marker must never be inferred from an abandoned Branch.
-  sanitized = normalizeSessionAfterRestore(sanitized)
+  if (!options.preserveRuntimeState) sanitized = normalizeSessionAfterRestore(sanitized)
   const activeUserMessageIds = new Set(
     sanitized.messages.filter((message) => message.role === 'user').map((message) => message.id)
   )
@@ -1697,11 +1705,14 @@ export const createSessionFile = (session: PersistedChatSession): PersistedSessi
   }
 }
 
-// Reads one session-file payload, tolerating either the envelope or a bare session object, and applies
-// the same sanitization + interrupted-run normalization used by the legacy whole-state loader.
+// Reads one session-file payload, tolerating either the envelope or a bare session object. Runtime
+// recovery is skipped only when the main process confirms that the owning prompt is still active.
 export const normalizeSessionFile = (
   value: unknown,
-  options: { preserveLegacyUploadPaths?: boolean } = {}
+  options: {
+    preserveLegacyUploadPaths?: boolean
+    preserveRuntimeState?: boolean | ((sessionId: string) => boolean)
+  } = {}
 ): PersistedChatSession | undefined => {
   if (!isRecord(value)) return undefined
 
@@ -1714,7 +1725,16 @@ export const normalizeSessionFile = (
     return undefined
   }
 
-  return sanitizeSession(rawSession, options)
+  const sessionId = asString(rawSession.id)
+  const preserveRuntimeState =
+    typeof options.preserveRuntimeState === 'function'
+      ? sessionId !== undefined && options.preserveRuntimeState(sessionId)
+      : options.preserveRuntimeState
+
+  return sanitizeSession(rawSession, {
+    preserveLegacyUploadPaths: options.preserveLegacyUploadPaths,
+    preserveRuntimeState
+  })
 }
 
 // Tiny app-level pointer restoring the last-open project + session after a restart.


### PR DESCRIPTION
## Problem

When an ACP prompt waited for user permission, an additional `sessions:load-all` read normalized the persisted `waiting-permission` state as an app-restart interruption. That cleared `activeRun`, marked the Notebook activity as failed, and showed the interrupted-session banner even though the provider request was still alive. Runtime logs confirmed the same request could wait for more than 21 minutes and then continue successfully.

## Proposed change

- Give the Session repository a late-bound view of active ACP prompt ownership.
- Preserve runtime status, messages, activities, activity groups, and conversation-graph state only while the exact owning prompt remains active.
- Keep the existing interrupted-run normalization when no live prompt owns the Session, preserving genuine app-restart recovery.

## Scope and non-goals

- No ACP, MCP, or Notebook execution timeout changes.
- No persistence schema or migration changes.
- No cross-process resurrection of an ACP request after a real app shutdown.
- Authorization decisions and permission profiles are unchanged.

## Acceptance criteria and validation

- Live permission rehydration remains `waiting-permission` with its active Notebook activity: `npm test -- --run src/shared/session-persistence.test.ts src/main/session-persistence/repository.test.ts src/main/session-persistence/coordinator.test.ts src/main/session-persistence/ipc.test.ts` -> 194 passed.
- Genuine restart normalization remains covered by the same persistence set -> passed.
- Main/shared type safety: `npm run typecheck:node` -> passed.
- Lint: `npm run lint` -> passed with 0 errors; 17 existing warnings are outside this diff.
- Complete portable suite: `npm test` -> 12,481 passed, 190 skipped. The final run used the required localhost-capable environment after the restricted sandbox rejected test server binds with `EPERM`.

These checks ran after the last material edit. The changed Session read path and ACP ownership adapter are covered by the repository/coordinator regression plus the complete portable suite. No renderer contract, durable schema, platform-specific implementation, or package/build input changed, so renderer E2E and platform packaging lanes were excluded. A manual Electron multi-client wait was not run; the regression exercises the real repository and coordinator boundary that produced the false interruption.

## Review focus

- The liveness check must match both project and Session identity.
- Runtime-only state must be preserved only for a currently active prompt.
- Sessions without an active prompt must retain existing app-restart recovery behavior.