### PR TITLE
test(windows): stabilize slow CI tests

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -90,6 +90,12 @@ vi.mock('../logger', async (importOriginal) => {
   }
 })
 
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
+  getDocument: () => {
+    throw new Error('invalid test PDF')
+  }
+}))
+
 // The real process-tree killer is exercised in process-tree.test.ts. Its Windows path early-returns
 // without calling child.kill() when child.pid is undefined (as it is for FakeAgentProcess), which the
 // POSIX path does not — so the shutdown orchestration tests here would flip on POSIX but not Windows.
@@ -5161,9 +5167,7 @@ describe('ACP runtime session management', () => {
     const serialized = JSON.stringify(receivedPrompts[0])
     expect(serialized).not.toContain(rawBase64)
     expect(receivedPrompts[0].some((block) => block.type === 'image')).toBe(false)
-    // Headroom for the one-time dynamic import of the large pdfjs-dist bundle, whose ESM resolution
-    // is markedly slower on a cold Windows CI runner and can exceed the 5s default there.
-  }, 30000)
+  })
 
   it('attributes app-side artifact writes to the calling session while another turn is in flight', async () => {
     const root = await createTemporaryRoot()

--- a/src/main/notifications/notification-inbox-repository.test.ts
+++ b/src/main/notifications/notification-inbox-repository.test.ts
@@ -202,9 +202,18 @@ describe('NotificationInboxDbRepository', () => {
 
   it('retains only the newest one thousand messages', async () => {
     const repository = await createRepository()
-    for (let index = 0; index <= MAX_NOTIFICATION_INBOX_ITEMS; index += 1) {
-      await record(repository, String(index))
-    }
+    await client!.notificationInboxItem.createMany({
+      data: Array.from({ length: MAX_NOTIFICATION_INBOX_ITEMS }, (_, index) => ({
+        id: `item-${index}`,
+        dedupeKey: `task:${index}`,
+        kind: 'task.completed',
+        sessionId: `session-${index}`,
+        originId: String(index),
+        title: 'Task completed',
+        summary: `Task ${index} finished.`
+      }))
+    })
+    await record(repository, String(MAX_NOTIFICATION_INBOX_ITEMS))
 
     const snapshot = await repository.snapshot(MAX_NOTIFICATION_INBOX_ITEMS)
     await expect(client!.notificationInboxItem.count()).resolves.toBe(MAX_NOTIFICATION_INBOX_ITEMS)


### PR DESCRIPTION
## Problem

The Windows full-test shards in [job 93118857286](https://github.com/aipoch/open-science/actions/runs/31263907788/job/93118857286) and [job 93118857305](https://github.com/aipoch/open-science/actions/runs/31263907788/job/93118857305) timed out in tests whose setup cost obscured the behavior under test.

## Proposed change

- Mock the PDF parser failure at the ACP runtime fallback seam so the test still verifies a `text/plain` resource and never inlines PDF bytes without loading the real `pdfjs-dist` bundle.
- Batch-seed the retained notification history, then use one real repository write to trigger and verify the 1,000-item retention boundary.

## Scope and non-goals

This is test-only. It does not change production behavior, interfaces, persistence formats, or dependencies.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- PDF fallback stays a text resource and excludes base64 -> `npm test -- src/main/acp/runtime.test.ts -t 'sends PDFs as extracted text, never as an inlined base64 file' --testTimeout=500` -> passed (1 test; 59 ms).
- Notification retention removes only the oldest overflow item -> `npm test -- src/main/notifications/notification-inbox-repository.test.ts -t 'retains only the newest one thousand messages' --testTimeout=500` -> passed (1 test; 62 ms; the pre-fix form timed out at 500 ms).
- Both changed test files -> `npm test -- src/main/acp/runtime.test.ts src/main/notifications/notification-inbox-repository.test.ts` -> passed (473 tests).
- Node and Web typing -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors and 17 existing warnings outside the changed files.
- Complete portable suite -> `npm test` -> passed (863 files, 12,614 tests; 14 files and 190 tests skipped).
- Exact-head Windows target shards -> [Windows Full Test run 31265751153](https://github.com/aipoch/open-science/actions/runs/31265751153) -> 1/3 passed in 11m43s and 3/3 passed in 10m46s.

The notification test is not registered in the module-impact manifest, so validation failed closed to the complete portable suite. No production interface changed, so no additional consumer or E2E lane is required. The manually dispatched workflow's unrelated 2/3 shard reproduced the pre-existing `local-rpc-server.user-input.test.ts` failure already present in [the base commit's main run](https://github.com/aipoch/open-science/actions/runs/31265070764); that file is outside this PR diff.

## Review focus

Please verify that the direct Prisma seed preserves the retention boundary semantics and that mocking `getDocument()` keeps the ACP test focused on its fallback contract.
