### PR TITLE
refactor(workspace): extract session controller

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -81,6 +81,7 @@
         "src/renderer/src/pages/workspace/WorkspacePage.tsx",
         "src/renderer/src/pages/workspace/workspace-panel-layout.tsx",
         "src/renderer/src/pages/workspace/workspace-composer-controller.ts",
+        "src/renderer/src/pages/workspace/workspace-session-controller.ts",
         "src/renderer/src/pages/workspace/composer-attachment-intake.ts",
         "src/renderer/src/pages/workspace/composer-upload-transfer.ts",
         "src/renderer/src/pages/workspace/composer/composer-history.ts"
@@ -98,12 +99,20 @@
           "src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx",
           "src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx",
           "src/renderer/src/pages/workspace/workspace-composer-controller.test.ts",
+          "src/renderer/src/pages/workspace/workspace-session-controller.test.ts",
           "src/renderer/src/pages/workspace/composer-attachment-intake.test.ts",
           "src/renderer/src/pages/workspace/composer-upload-transfer.test.ts",
           "src/renderer/src/pages/workspace/composer/composer-history.test.ts",
           "src/renderer/src/pages/workspace/workspace-components.test.tsx"
         ],
-        "contract": [],
+        "contract": [
+          "src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx",
+          "src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.interaction.test.tsx",
+          "src/renderer/src/pages/workspace/HandoffLifecycleStatus.integration.test.tsx",
+          "src/renderer/src/pages/workspace/handoff-lifecycle-source.test.ts",
+          "src/renderer/src/pages/workspace/handoff-lifecycle-projection.test.ts",
+          "src/renderer/src/stores/session-store.test.ts"
+        ],
         "consumer": []
       },
       "capabilityOverlays": ["renderer_state"],

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/lib/acp/useWorkspaceElicitation'
 import { usePreviewPersistence } from '@/lib/preview-persistence/preview-persistence'
 import { useNavigationStore } from '@/stores/navigation-store'
-import { useArchiveUndoStore } from '@/stores/archive-undo-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import {
@@ -21,7 +20,6 @@ import {
   PROJECT_FILES_PREVIEW_ID,
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
-import type { ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
@@ -30,11 +28,7 @@ import {
   suppressNextAutoReview,
   clearSuppressNextAutoReview
 } from '@/lib/acp/workspace-events'
-import type { ConversationExportFormat } from '../../../../shared/conversation-export'
-import {
-  resolveEffectiveSpecialistSkills,
-  type CompletionHandoffLifecycleEvent
-} from '../../../../shared/specialist'
+import { resolveEffectiveSpecialistSkills } from '../../../../shared/specialist'
 
 import {
   appendArtifactMention,
@@ -63,6 +57,7 @@ import { useJobAnalysisEffect } from '@/lib/compute/useJobAnalysisEffect'
 import { selectActiveBranchPlan } from './session-plan/active-branch-plan'
 import { WorkspacePanelLayout } from './workspace-panel-layout'
 import { useWorkspaceComposerController } from './workspace-composer-controller'
+import { useWorkspaceSessionController } from './workspace-session-controller'
 
 type WorkspacePageProps = {
   isSessionPersistenceHydrated: boolean
@@ -73,20 +68,6 @@ type WorkspacePageProps = {
 // Converts unknown async failures into composer-visible text.
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
-
-const compareHandoffEventOrder = (
-  left: Pick<CompletionHandoffLifecycleEvent, 'commitOrder' | 'observedAt' | 'sequence' | 'id'>,
-  right: Pick<CompletionHandoffLifecycleEvent, 'commitOrder' | 'observedAt' | 'sequence' | 'id'>
-): number =>
-  (left.commitOrder !== undefined || right.commitOrder !== undefined
-    ? left.commitOrder === undefined
-      ? -1
-      : right.commitOrder === undefined
-        ? 1
-        : left.commitOrder - right.commitOrder
-    : left.observedAt - right.observedAt) ||
-  left.sequence - right.sequence ||
-  left.id.localeCompare(right.id)
 
 // New-conversation drafts are project-scoped so switching projects never leaks unsent intent.
 const newConversationDraftKeyFor = (projectId: string): string => `new:${projectId}`
@@ -132,16 +113,8 @@ const WorkspacePage = ({
   const newConversationDraftKey = newConversationDraftKeyFor(scopedProjectId)
   const currentDraftKey = selectedSessionId ?? newConversationDraftKey
   const clearSelection = useSessionStore((state) => state.clearSelection)
-  const renameSession = useSessionStore((state) => state.renameSession)
-  const togglePinned = useSessionStore((state) => state.togglePinned)
-  const updateSessionArchive = useSessionStore((state) => state.updateSessionArchive)
-  const enqueueSessionArchive = useArchiveUndoStore((state) => state.enqueueSession)
   const setAutoReviewEnabled = useSessionStore((state) => state.setAutoReviewEnabled)
   const setEnabledComputeHosts = useSessionStore((state) => state.setEnabledComputeHosts)
-  const setSessionSpecialistId = useSessionStore((state) => state.setSessionSpecialistId)
-  const markSpecialistSwitchResetRequired = useSessionStore(
-    (state) => state.markSpecialistSwitchResetRequired
-  )
   const setFixLoopActive = useSessionStore((state) => state.setFixLoopActive)
   const setActivePlanProjection = useSessionStore((state) => state.setActivePlanProjection)
   // Only sessions belonging to the active project are shown in this workspace.
@@ -200,70 +173,12 @@ const WorkspacePage = ({
   const [newConversationEnabledComputeHosts, setNewConversationEnabledComputeHosts] = useState<
     string[]
   >([])
-  // Draft specialist selection for a not-yet-created conversation. Stored in memory only (not
-  // persisted across restarts). Reset when clicking New; restored when switching back to the draft.
-  // On first send, the UUID is forwarded to createSession; the main process resolves the latest Profile.
-  const [newConversationSpecialistId, setNewConversationSpecialistId] = useState<
-    string | undefined
-  >(undefined)
-  // Keep availability derived from the current catalog, rather than caching it at click time: a profile
-  // can be disabled or deleted while a new-conversation draft is open.
-  const newConversationSpecialistUnavailable =
-    specialistCatalogLoaded &&
-    newConversationSpecialistId !== undefined &&
-    !specialistItems.some(
-      (item) => item.kind === 'custom' && item.enabled && item.id === newConversationSpecialistId
-    )
-
-  // Per-session pending specialist selection for existing conversations.
-  // Key: sessionId. Value: the pending UUID (or undefined to clear binding).
-  // The pending value is the user's last selection; it takes effect on the next send via reconfigure
-  // barrier. Multiple switches before send only keep the last one (last-write-wins).
-  const [pendingSessionSpecialist, setPendingSessionSpecialist] = useState<
-    Record<string, string | undefined>
-  >({})
-
-  // Latest specialist catalog, mirrored into a ref so the pending-switch broadcast subscription
-  // stays stable (subscribes once on mount) while still reading fresh data when a host.agents.switch()
-  // broadcast arrives. Set in an effect (never during render) to comply with the react-hooks/refs rule.
-  const specialistItemsRef = useRef(specialistItems)
-
-  // Reconfigure failure state: set when a user-initiated pre-send dispose/resume fails.
-  // Approved handoff failures belong solely to their transcript lifecycle row, which owns Retry.
-  // This keeps a single handoff failure from rendering a second composer banner.
-  const [reconfigureError, setReconfigureError] = useState<{
-    sessionId: string
-    specialistName: string
-    message: string
-  } | null>(null)
-  // Per-session set of session IDs currently running the reconfigure barrier (async send in flight).
-  // The Set is reactive (drives canSendMessage) so a second Enter press disables send after the first
-  // barrier starts. The ref mirrors it for synchronous reads inside the event handler itself.
-  const [barrierInFlightSessions, setBarrierInFlightSessions] = useState<ReadonlySet<string>>(
-    new Set()
-  )
-  const barrierInFlightRef = useRef<Set<string>>(new Set())
   // Closes the synchronous gap before the hook's reactive preparation state re-renders this page.
   // A second submit for the same draft key returns without clearing its possibly newer local draft.
   const sendRequestsInFlightRef = useRef(new Set<string>())
-  const [exportError, setExportError] = useState<string | null>(null)
   const [notebookReferences, setNotebookReferences] = useState<
     Record<string, NotebookSessionReference>
   >({})
-  const [sessionToRename, setSessionToRename] = useState<ChatSession | undefined>(undefined)
-  const [renameDraft, setRenameDraft] = useState('')
-  const [sessionToDownloadArtifacts, setSessionToDownloadArtifacts] = useState<
-    ChatSession | undefined
-  >(undefined)
-  const [sessionToDelete, setSessionToDelete] = useState<ChatSession | undefined>(undefined)
-  const [sessionDeletionInProgressIds, setSessionDeletionInProgressIds] = useState<
-    ReadonlySet<string>
-  >(new Set())
-  const [archivingSessionIds, setArchivingSessionIds] = useState<ReadonlySet<string>>(new Set())
-  const [sessionToViewNotebook, setSessionToViewNotebook] = useState<ChatSession | undefined>(
-    undefined
-  )
-  const [jobListModal, setJobListModal] = useState({ open: false, sessionId: '' })
 
   // The selected session is the only conversation rendered in the center panel.
   const activeSession = useMemo(
@@ -277,11 +192,27 @@ const WorkspacePage = ({
         : buildStarterComposerHistory(sessions),
     [activeSession, sessions]
   )
-  const historySpecialistId = activeSession
-    ? Object.hasOwn(pendingSessionSpecialist, activeSession.id)
-      ? pendingSessionSpecialist[activeSession.id]
-      : activeSession.specialistId
-    : newConversationSpecialistId
+  // Composer ports are lazy event-time callbacks. The controller does not invoke them while its hook
+  // initializes, so the composer owner below is established before any archive/delete action can run.
+  const sessionController = useWorkspaceSessionController({
+    activeSession,
+    selectedSessionId,
+    isPersistenceHydrated: isSessionPersistenceHydrated,
+    isPersistenceReady: isSessionPersistenceReady,
+    canDeleteConversations,
+    specialistCatalogLoaded,
+    specialistItems,
+    loadSpecialists,
+    promptInFlightSessionIds,
+    sendPreparationInFlightSessionIds,
+    hasUnfinishedTransfers: (sessionId) => composer.lifecycle.hasUnfinishedTransfers(sessionId),
+    beginSessionDeletion: (sessionId) => composer.lifecycle.beginSessionDeletion(sessionId),
+    settleSessionDeletion: (sessionId, deleted) =>
+      composer.lifecycle.settleSessionDeletion(sessionId, deleted),
+    deleteRuntimeSession
+  })
+  const historySpecialistId = sessionController.view.specialist.historyId
+  const newConversationSpecialistId = sessionController.view.specialist.newConversationId
   const catalogSkillIds = useMemo(
     () => new Set(catalogSkills.map((skill) => skill.id)),
     [catalogSkills]
@@ -338,7 +269,7 @@ const WorkspacePage = ({
     newConversationDraftKey,
     activeProjectId,
     pendingCustomizePrefill,
-    onCustomizePrefillApplied: () => setNewConversationSpecialistId(undefined),
+    onCustomizePrefillApplied: sessionController.actions.resetNewConversationSpecialist,
     historyEntries: composerHistoryEntries,
     hasActiveSession: activeSession !== undefined,
     historyPolicy: composerHistoryPolicy,
@@ -386,21 +317,7 @@ const WorkspacePage = ({
       cancelled = true
     }
   }, [activeSession, setActivePlanProjection])
-  const canArchiveSession = (session: ChatSession): boolean => {
-    return (
-      isSessionPersistenceReady &&
-      !session.isPending &&
-      session.archivedAt === undefined &&
-      !archivingSessionIds.has(session.id) &&
-      !sessionDeletionInProgressIds.has(session.id) &&
-      !promptInFlightSessionIds.includes(session.id) &&
-      !sendPreparationInFlightSessionIds.includes(session.id) &&
-      session.status !== 'running' &&
-      session.status !== 'waiting-permission' &&
-      session.status !== 'waiting-plan-approval' &&
-      !composer.lifecycle.hasUnfinishedTransfers(session.id)
-    )
-  }
+  const canArchiveSession = sessionController.lifecycle.canArchive
   const visiblePermissionRequests = useMemo(
     () => getVisiblePermissionRequests(pendingPermissions, activeSession?.id),
     [activeSession?.id, pendingPermissions]
@@ -491,7 +408,7 @@ const WorkspacePage = ({
     !activeSession?.compacting &&
     // Block while the reconfigure barrier is running (async, between Enter and sendMessage). This
     // prevents a second Enter press from racing the first one through the same pending-switch barrier.
-    !barrierInFlightSessions.has(activeSession?.id ?? '')
+    !sessionController.view.specialist.barrierInFlight
 
   // Make the composer-owned mention capability available to Global Search without exposing its draft.
   // The value is transient and Project-scoped; cleanup prevents a stale Project from accepting an
@@ -545,7 +462,7 @@ const WorkspacePage = ({
     !activeSession?.fixLoopActive &&
     !activeSession?.conversationGraphSyncBlocked &&
     !activeSession?.compacting &&
-    !sessionDeletionInProgressIds.has(activeSession?.id ?? '')
+    !sessionController.view.deletingIds.has(activeSession?.id ?? '')
   const canEditMessageRef = useRef(canEditMessage)
   useLayoutEffect(() => {
     canEditMessageRef.current = canEditMessage
@@ -577,7 +494,8 @@ const WorkspacePage = ({
     : activeSession?.status === 'error'
       ? 'Resolve the current session error before compacting.'
       : 'Wait for the current agent activity to finish.'
-  const visibleActionError = attachmentError ?? exportError ?? (activeSession ? null : actionError)
+  const visibleActionError =
+    attachmentError ?? sessionController.view.exportError ?? (activeSession ? null : actionError)
 
   const compactActiveContext = useCallback((): void => {
     if (!activeSession || !canCompactContext) return
@@ -729,7 +647,7 @@ const WorkspacePage = ({
     setNewConversationAutoReviewEnabled(false)
     setNewConversationEnabledComputeHosts([])
     useNavigationStore.getState().recordUserNavigation()
-    setNewConversationSpecialistId(undefined)
+    sessionController.actions.resetNewConversationSpecialist()
     clearSelection()
   }
 
@@ -820,7 +738,7 @@ const WorkspacePage = ({
     if (branchInNewSession && !activeSession) return
     // Secondary synchronous guard: blocks a second Enter press that arrives before the state update
     // from the first barrier start triggers a re-render and disables canSendMessage.
-    if (activeSession && barrierInFlightRef.current.has(activeSession.id)) return
+    if (activeSession && sessionController.lifecycle.isBarrierInFlight(activeSession.id)) return
     if (
       supportsImageInput !== true &&
       attachments.some((attachment) => attachment.mimeType?.startsWith('image/'))
@@ -828,30 +746,7 @@ const WorkspacePage = ({
       setAttachmentError('The selected model is not configured for image input.')
       return
     }
-    // Block send if the draft specialist is unavailable (disabled/deleted/corrupt).
-    if (!activeSession && newConversationSpecialistUnavailable) {
-      return
-    }
-    // Block send for existing sessions when the bound specialist is unavailable (fail-closed).
-    // Hole A fix: use Object.hasOwn to distinguish "no pending entry" from "pending entry whose
-    // value is None (undefined)" — a falsy check would skip the guard for any pending switch.
-    // Hole B fix: treat an unloaded catalog as blocking (kick off the load so the next attempt
-    // succeeds). Gating on specialistCatalogLoaded=true would skip the guard before catalog
-    // resolves; the submenu only loads on open, so isLoaded is plausibly false on a fresh workspace.
-    if (activeSession?.specialistId !== undefined) {
-      if (!specialistCatalogLoaded) {
-        void loadSpecialists()
-        return
-      }
-      if (
-        !Object.hasOwn(pendingSessionSpecialist, activeSession.id) &&
-        !specialistItems.some(
-          (item) => item.kind === 'custom' && item.enabled && item.id === activeSession.specialistId
-        )
-      ) {
-        return
-      }
-    }
+    if (!sessionController.lifecycle.canStartSend()) return
 
     const sendSnapshot = composer.lifecycle.captureSend()
     const sendRequestKey = sendSnapshot.draftKey
@@ -865,20 +760,8 @@ const WorkspacePage = ({
     const draftEnabledComputeHosts = newConversationEnabledComputeHosts
     // Capture pending specialist for existing sessions (last change wins). `undefined` is a valid
     // pending choice meaning Main Agent, so ownership—not truthiness—distinguishes it from no choice.
-    const hasStoredPendingSpecialist =
-      activeSession !== undefined && Object.hasOwn(pendingSessionSpecialist, activeSession.id)
-    const pendingSpecialistId = activeSession
-      ? pendingSessionSpecialist[activeSession.id]
-      : undefined
-    // Capture the final specialist selection (last change wins before first send).
-    const draftSpecialistId = branchInNewSession
-      ? hasStoredPendingSpecialist
-        ? (pendingSpecialistId ?? null)
-        : activeSession?.specialistId
-      : wasNewConversation
-        ? newConversationSpecialistId
-        : undefined
-    const hasPendingSwitch = !branchInNewSession && hasStoredPendingSpecialist
+    const { draftSpecialistId, hasPendingSwitch, pendingSpecialistId } =
+      sessionController.lifecycle.captureSendIntent(branchInNewSession)
 
     // Dispatches the final send after draft/attachment state has been cleared.
     // Shared by the normal send path and the Retry recovery action so the logic stays in sync.
@@ -932,89 +815,27 @@ const WorkspacePage = ({
           }
           setNewConversationAutoReviewEnabled(false)
           setNewConversationEnabledComputeHosts([])
-          setNewConversationSpecialistId(undefined)
+          sessionController.actions.resetNewConversationSpecialist()
         })
         .finally(() => sendRequestsInFlightRef.current.delete(sendRequestKey))
-    }
-
-    // Runs the reconfigure barrier then dispatches the send on success. Extracted so that both the
-    // initial send path and the Retry recovery action can invoke the same ordered sequence.
-    const runBarrierAndSend = async (
-      sessionId: string,
-      specialistId: string | undefined
-    ): Promise<void> => {
-      // Mark the barrier as in-flight synchronously (ref) and reactively (state). The ref allows
-      // the sendCurrentMessage guard to block a second call before the state re-render fires;
-      // the state drives canSendMessage so the Send button also disables on the next render.
-      barrierInFlightRef.current.add(sessionId)
-      setBarrierInFlightSessions((prev) => new Set(prev).add(sessionId))
-      try {
-        // Apply the pending binding to main process (validates the UUID is still available, then
-        // hot-switches the live agent session). contextReset signals the agent session was replaced
-        // (Claude bakes identity into the session at creation) so history must be replayed below.
-        const switchResult = await window.api?.specialist?.setSessionSpecialist?.({
-          sessionId,
-          specialistId
-        })
-        if (switchResult?.contextReset) {
-          markSpecialistSwitchResetRequired(sessionId)
-        }
-      } catch (err: unknown) {
-        // Reconfigure failed — preserve draft (pendingSessionSpecialist is intentionally left set
-        // so Retry has the specialist to re-attempt), do not send, show the recovery banner.
-        const pendingProfile = specialistItems.find(
-          (item) => item.kind === 'custom' && item.id === specialistId
-        )
-        const name =
-          specialistId === undefined
-            ? 'Main Agent'
-            : pendingProfile?.kind === 'custom'
-              ? pendingProfile.name
-              : 'the selected specialist'
-        setReconfigureError({
-          sessionId,
-          specialistName: name,
-          message: err instanceof Error ? err.message : String(err)
-        })
-        barrierInFlightRef.current.delete(sessionId)
-        setBarrierInFlightSessions((prev) => {
-          const next = new Set(prev)
-          next.delete(sessionId)
-          return next
-        })
-        sendRequestsInFlightRef.current.delete(sendRequestKey)
-        return
-      }
-
-      // Reconfigure succeeded: update the session's persisted specialist binding,
-      // clear the pending state, and proceed to send.
-      // Updating the session store's specialistId here ensures the next sendMessage
-      // call (which reads currentSession.specialistId for resumeSession) uses the
-      // new UUID — triggering the ACP dispose+resume that re-injects the new identity.
-      setSessionSpecialistId(sessionId, specialistId)
-      setPendingSessionSpecialist((prev) => {
-        const next = { ...prev }
-        delete next[sessionId]
-        return next
-      })
-      composer.lifecycle.clearDraft(sessionId)
-      setReconfigureError(null)
-
-      barrierInFlightRef.current.delete(sessionId)
-      setBarrierInFlightSessions((prev) => {
-        const next = new Set(prev)
-        next.delete(sessionId)
-        return next
-      })
-      dispatchSend(sessionId)
     }
 
     // If there is a pending specialist switch for an existing session, run the reconfigure barrier
     // BEFORE appending the user turn. The barrier is strictly ordered: reconfigure must succeed
     // before any message is sent. On failure, the draft is restored, no user turn is created, and
     // the recovery banner is shown.
-    if (hasPendingSwitch) {
-      void runBarrierAndSend(activeSession.id, pendingSpecialistId)
+    if (hasPendingSwitch && activeSession) {
+      const sessionId = activeSession.id
+      void sessionController.lifecycle
+        .prepareSpecialistSend(sessionId, pendingSpecialistId)
+        .then((ready) => {
+          if (!ready) {
+            sendRequestsInFlightRef.current.delete(sendRequestKey)
+            return
+          }
+          composer.lifecycle.clearDraft(sessionId)
+          dispatchSend(sessionId)
+        })
       return
     }
 
@@ -1032,111 +853,9 @@ const WorkspacePage = ({
     sendCurrentMessage(forcedSkillIds, { turnIntent: 'plan-first' })
   }
 
-  // Opens the rename dialog with the current title prefilled.
-  const openRenameDialog = (session: ChatSession): void => {
-    if (!isSessionPersistenceReady) return
-
-    setSessionToRename(session)
-    setRenameDraft(session.title)
-  }
-
-  // Main reloads the durable session and owns both normalization and the native Save As operation.
-  const exportConversation = (session: ChatSession, format: ConversationExportFormat): void => {
-    setExportError(null)
-    void window.api.sessions
-      .exportConversation({
-        projectId: session.projectId,
-        sessionId: session.id,
-        format
-      })
-      .catch((error: unknown) => setExportError(getErrorMessage(error)))
-  }
-
   const openSessionWithoutExportError = (sessionId: string): void => {
-    setExportError(null)
+    sessionController.actions.clearExportError()
     openSession(sessionId)
-  }
-
-  // Resets rename state from either cancel action or Radix open state changes.
-  const closeRenameDialog = (): void => {
-    setSessionToRename(undefined)
-    setRenameDraft('')
-  }
-
-  // Commits a non-empty title change and closes the rename dialog.
-  const confirmRenameSession = (event: React.FormEvent<HTMLFormElement>): void => {
-    event.preventDefault()
-
-    if (!isSessionPersistenceReady || !sessionToRename || renameDraft.trim().length === 0) return
-
-    renameSession(sessionToRename.id, renameDraft)
-    closeRenameDialog()
-  }
-
-  // Explicit deletion is target-validated and may remain available after a partial Session scan, but
-  // main requires Project deletion-journal recovery before either deletion IPC can safely run.
-  const openDeleteDialog = (session: ChatSession): void => {
-    if (!isSessionPersistenceHydrated || !canDeleteConversations) return
-
-    setSessionToDelete(session)
-  }
-
-  const archiveSession = (session: ChatSession): void => {
-    if (!canArchiveSession(session)) return
-
-    setArchivingSessionIds((current) => new Set(current).add(session.id))
-    setExportError(null)
-    void updateSessionArchive({
-      projectId: session.projectId,
-      sessionId: session.id,
-      archived: true,
-      expectedArchivedAt: null
-    })
-      .then((archived) => {
-        enqueueSessionArchive(archived)
-        if (selectedSessionId === session.id) clearSelection()
-      })
-      .catch((error: unknown) => setExportError(getErrorMessage(error)))
-      .finally(() => {
-        setArchivingSessionIds((current) => {
-          const next = new Set(current)
-          next.delete(session.id)
-          return next
-        })
-      })
-  }
-
-  // Deletes the selected session and repairs the chat surface if it was showing that session.
-  const confirmDeleteSession = (): void => {
-    if (!isSessionPersistenceHydrated || !canDeleteConversations || !sessionToDelete) return
-
-    // Cancel deferred notification/deep-link navigation before the asynchronous authoritative
-    // deletion begins. The user's destructive action owns the view even if the target is unrelated.
-    useNavigationStore.getState().recordUserNavigation()
-    const deletedSessionId = sessionToDelete.id
-    if (!composer.lifecycle.beginSessionDeletion(deletedSessionId)) {
-      setSessionToDelete(undefined)
-      return
-    }
-    setSessionDeletionInProgressIds((current) => new Set(current).add(deletedSessionId))
-
-    setSessionToDelete(undefined)
-    // Staged bytes and local draft state are owned by the session until runtime and durable deletion
-    // both succeed. The store's successful deletion updates selection and lets the draft effect load
-    // the fallback session without clearing that replacement draft here.
-    void deleteRuntimeSession(deletedSessionId).then((deleted) => {
-      setSessionDeletionInProgressIds((current) => {
-        const next = new Set(current)
-        next.delete(deletedSessionId)
-        return next
-      })
-      composer.lifecycle.settleSessionDeletion(deletedSessionId, deleted)
-    })
-  }
-
-  // Closes the delete dialog without changing runtime or store state.
-  const closeDeleteDialog = (): void => {
-    setSessionToDelete(undefined)
   }
 
   // Cancels the run for the currently visible session when one is selected. During an active fix
@@ -1261,174 +980,6 @@ const WorkspacePage = ({
     upsertAndActivatePreviewItem(createProjectFilesPreviewItem())
   }
 
-  // Handles specialist selection for the new-conversation draft. Availability is derived from the
-  // catalog above so a later disable/delete is reflected before the next send.
-  const handleNewConversationSpecialistChange = (specialistId: string | undefined): void => {
-    setNewConversationSpecialistId(specialistId)
-  }
-
-  // Handles specialist selection for an existing conversation.
-  // For idle sessions: immediately write the binding via IPC (no reconfigure yet — lazy).
-  // For running sessions: record as pending; the chip appears; binding takes effect next send.
-  const handleExistingSessionSpecialistChange = (specialistId: string | undefined): void => {
-    if (!activeSession) return
-    const sessionId = activeSession.id
-    if (barrierInFlightRef.current.has(sessionId)) return
-    const isRunning =
-      activeSession.status === 'running' || activeSession.status === 'waiting-permission'
-
-    if (isRunning) {
-      // Pending switch: will be applied at next send via reconfigure barrier.
-      setPendingSessionSpecialist((prev) => ({ ...prev, [sessionId]: specialistId }))
-    } else {
-      // Idle: apply immediately (write to main process binding store + persist UUID).
-      const previousSpecialistId = activeSession.specialistId
-      // Optimistically update the session store so the specialist chip reflects the new selection
-      // right away and the persistence bridge writes the new UUID. Reverted on IPC failure so a
-      // rejected switch (e.g. specialist disabled between render and click) leaves the UI consistent.
-      setSessionSpecialistId(sessionId, specialistId)
-      setPendingSessionSpecialist((prev) => {
-        const next = { ...prev }
-        delete next[sessionId]
-        return next
-      })
-      void window.api?.specialist
-        ?.setSessionSpecialist?.({ sessionId, specialistId })
-        ?.then((result) => {
-          // The agent session was replaced on the main side; replay history on the next send so the
-          // new specialist keeps conversation continuity.
-          if (result?.contextReset) markSpecialistSwitchResetRequired(sessionId)
-        })
-        ?.catch((err: unknown) => {
-          setSessionSpecialistId(sessionId, previousSpecialistId)
-          console.warn('setSessionSpecialist failed', err)
-        })
-    }
-    // Clear any prior reconfigure error when the user picks a new specialist.
-    if (reconfigureError?.sessionId === sessionId) {
-      setReconfigureError(null)
-    }
-  }
-
-  // Subscribe to specialist catalog changes so unavailability state stays fresh.
-  useEffect(() => {
-    // Guard: specialist.list is Electron-only and unavailable in the web gateway.
-    if (typeof window.api?.specialist?.list !== 'function') return
-    void loadSpecialists()
-    const remove = window.api.specialist.onCatalogChanged(() => {
-      void loadSpecialists()
-    })
-    return remove
-  }, [loadSpecialists])
-
-  // Keep the latest specialist catalog in a ref so the stable broadcast subscription below reads
-  // fresh data without re-subscribing on every catalog change.
-  useEffect(() => {
-    specialistItemsRef.current = specialistItems
-  }, [specialistItems])
-
-  // Compatibility-only pending-selection subscription. Production approved SDK switches no longer
-  // emit this channel: their durable lifecycle row is read-only and their continuation is owned by
-  // the completion gate, never by a renderer send barrier.
-  useEffect(() => {
-    if (!window.api?.specialist?.onPendingSwitch) return
-    const remove = window.api.specialist.onPendingSwitch((pending) => {
-      // null target => revert to Main Agent. main already persisted the clear BEFORE broadcasting
-      // (host.agents.switch(null) writes the Main binding, then notifies), so the renderer only
-      // mirrors it here — no resolveSessionSpecialist round-trip is needed, unlike the named-target
-      // fallthrough below. The pending entry is set to undefined so the next-send barrier, which keys
-      // on pendingSessionSpecialist ownership, clears the binding. If a target resolves unavailable
-      // between approval and broadcast the pending entry is simply unset and the failure surfaces
-      // fail-closed at the next send; the message never runs under the wrong identity.
-      if (pending.targetName === null) {
-        setPendingSessionSpecialist((prev) => ({ ...prev, [pending.sessionId]: undefined }))
-        return
-      }
-      // Resolve the public name to a UUID against the live catalog (last-write-wins: each broadcast
-      // overwrites the pending entry).
-      const match = specialistItemsRef.current.find(
-        (item) => item.kind === 'custom' && item.name === pending.targetName
-      )
-      if (match && match.kind === 'custom') {
-        setPendingSessionSpecialist((prev) => ({ ...prev, [pending.sessionId]: match.id }))
-        return
-      }
-      // Catalog not yet loaded or the target was renamed/deleted between approval and broadcast:
-      // resolve the durable binding that host.agents.switch already persisted on main. The result is
-      // mirrored as the pending target so the barrier still reconfigures at the next send.
-      const resolver = window.api?.specialist?.resolveSessionSpecialist
-      if (!resolver) return
-      void resolver
-        .call(window.api.specialist, { sessionId: pending.sessionId })
-        .then((resolution) => {
-          if (resolution.kind === 'bound') {
-            setPendingSessionSpecialist((prev) => ({
-              ...prev,
-              [pending.sessionId]: resolution.profile.id
-            }))
-          }
-        })
-        .catch(() => {
-          // Resolution failed: the durable binding still applies on the next session create/resume;
-          // leave the pending state unset so the user can retry explicitly.
-        })
-    })
-    return remove
-  }, [])
-
-  // An approved SDK handoff reconfigures the runtime on main, without using the legacy pending
-  // switch broadcast. Once reconfiguration has succeeded, read the authoritative binding back so
-  // the session store (and therefore the specialist menu) reflects the live identity. A completed
-  // lifecycle replay uses the same path after the renderer reconnects.
-  const syncCompletedHandoffSpecialist = useCallback(
-    (event: CompletionHandoffLifecycleEvent): void => {
-      if (event.phase !== 'continuation-start' && event.phase !== 'continued') return
-      const resolver = window.api?.specialist?.resolveSessionSpecialist
-      if (!resolver) return
-      void resolver
-        .call(window.api.specialist, { sessionId: event.sessionId })
-        .then((resolution) => {
-          if (resolution.kind === 'bound') {
-            setSessionSpecialistId(event.sessionId, resolution.profile.id)
-          } else if (resolution.kind === 'main') {
-            setSessionSpecialistId(event.sessionId, undefined)
-          }
-        })
-        .catch(() => {
-          // The lifecycle projection is observational; a transient readback failure must not affect
-          // the already-authorized runtime handoff or turn into a misleading composer error.
-        })
-    },
-    [setSessionSpecialistId]
-  )
-
-  const applyHandoffLifecycleEvent = useCallback(
-    (event: CompletionHandoffLifecycleEvent): void => {
-      syncCompletedHandoffSpecialist(event)
-    },
-    [syncCompletedHandoffSpecialist]
-  )
-
-  // The renderer is a read-only lifecycle projection. Replay catches failures persisted before a
-  // reload; subscription follows later transitions. Neither route grants execution authority.
-  useEffect(() => {
-    const specialistApi = window.api?.specialist
-    if (!specialistApi?.onHandoffLifecycleEvent) return
-    return specialistApi.onHandoffLifecycleEvent(applyHandoffLifecycleEvent)
-  }, [applyHandoffLifecycleEvent])
-
-  useEffect(() => {
-    const specialistApi = window.api?.specialist
-    if (!activeSessionId || !specialistApi?.getHandoffEvents) return
-    void specialistApi
-      .getHandoffEvents(activeSessionId)
-      .then((events) => {
-        const latest = events.sort(compareHandoffEventOrder).at(-1)
-        if (latest) applyHandoffLifecycleEvent(latest)
-      })
-      .catch(() => undefined)
-  }, [activeSessionId, applyHandoffLifecycleEvent])
-
   return (
     <main className="h-[100dvh] overflow-hidden bg-bg-10 text-[13px] leading-normal text-text-000 md:h-screen md:p-[10px]">
       <WorkspacePanelLayout
@@ -1452,21 +1003,21 @@ const WorkspacePage = ({
             isFilesOpen={activePreviewItemId === PROJECT_FILES_PREVIEW_ID}
             onOpenFiles={openFilesPreview}
             onOpenSession={openSessionWithoutExportError}
-            onRenameSession={openRenameDialog}
+            onRenameSession={sessionController.actions.openRename}
             canDownloadArtifacts={typeof window.api?.saveSessionArtifacts === 'function'}
-            onDownloadArtifacts={setSessionToDownloadArtifacts}
-            onViewNotebook={setSessionToViewNotebook}
+            onDownloadArtifacts={sessionController.actions.openDownloadArtifacts}
+            onViewNotebook={sessionController.actions.openNotebook}
             onExportSession={
               typeof window.api.sessions?.exportConversation === 'function'
-                ? exportConversation
+                ? sessionController.actions.exportConversation
                 : undefined
             }
             onTogglePin={(session) => {
-              if (isSessionPersistenceReady) togglePinned(session.id)
+              sessionController.actions.togglePin(session)
             }}
             canArchiveSession={canArchiveSession}
-            onArchiveSession={archiveSession}
-            onDeleteSession={openDeleteDialog}
+            onArchiveSession={sessionController.actions.archive}
+            onDeleteSession={sessionController.actions.openDelete}
             onOpenSettings={openSettings}
           />
         }
@@ -1497,37 +1048,37 @@ const WorkspacePage = ({
             }}
             onRenameSession={(session) => {
               close()
-              openRenameDialog(session)
+              sessionController.actions.openRename(session)
             }}
             canDownloadArtifacts={typeof window.api?.saveSessionArtifacts === 'function'}
             onDownloadArtifacts={(session) => {
               close()
-              setSessionToDownloadArtifacts(session)
+              sessionController.actions.openDownloadArtifacts(session)
             }}
             onViewNotebook={(session) => {
               close()
-              setSessionToViewNotebook(session)
+              sessionController.actions.openNotebook(session)
             }}
             onExportSession={
               typeof window.api.sessions?.exportConversation === 'function'
                 ? (session, format) => {
                     close()
-                    exportConversation(session, format)
+                    sessionController.actions.exportConversation(session, format)
                   }
                 : undefined
             }
             onTogglePin={(session) => {
               close()
-              if (isSessionPersistenceReady) togglePinned(session.id)
+              sessionController.actions.togglePin(session)
             }}
             canArchiveSession={canArchiveSession}
             onArchiveSession={(session) => {
               close()
-              archiveSession(session)
+              sessionController.actions.archive(session)
             }}
             onDeleteSession={(session) => {
               close()
-              openDeleteDialog(session)
+              sessionController.actions.openDelete(session)
             }}
             onOpenSettings={() => {
               close()
@@ -1595,120 +1146,45 @@ const WorkspacePage = ({
             isRequestReviewDisabled={isRequestReviewDisabled}
             canEditMessage={canEditMessage}
             onSendEditedMessage={sendEditedMessage}
-            onOpenJobList={(sessionId) => setJobListModal({ open: true, sessionId })}
+            onOpenJobList={sessionController.actions.openJobList}
             specialistId={
               // For existing sessions: badge shows the currently-effective specialist (session
               // binding). A pending switch is signalled by the chip, not by overriding the badge.
               activeSession ? activeSession.specialistId : newConversationSpecialistId
             }
-            specialistUnavailable={
-              activeSession
-                ? specialistCatalogLoaded &&
-                  activeSession.specialistId !== undefined &&
-                  // A pending switch overrides: the new selection is checked for availability.
-                  !Object.hasOwn(pendingSessionSpecialist, activeSession.id) &&
-                  !specialistItems.some(
-                    (item) =>
-                      item.kind === 'custom' &&
-                      item.enabled &&
-                      item.id === activeSession.specialistId
-                  )
-                : newConversationSpecialistUnavailable
-            }
-            specialistHasPendingSwitch={
-              activeSession !== undefined &&
-              Object.hasOwn(pendingSessionSpecialist, activeSession.id) &&
-              (activeSession.status === 'running' || activeSession.status === 'waiting-permission')
-            }
-            reconfigureError={
-              reconfigureError?.sessionId === activeSession?.id ? reconfigureError : null
-            }
+            specialistUnavailable={sessionController.view.specialist.unavailable}
+            specialistHasPendingSwitch={sessionController.view.specialist.hasPendingSwitch}
+            reconfigureError={sessionController.view.specialist.reconfigureError}
             onReconfigureRetry={() => {
-              // Re-run the full barrier: clears the banner first, then re-attempts the switch
-              // and, on success, dispatches the send — identical to the original send path.
-              if (!reconfigureError || !activeSession) return
-              if (!Object.hasOwn(pendingSessionSpecialist, reconfigureError.sessionId)) {
-                setReconfigureError(null)
-                return
-              }
-              setReconfigureError(null)
-              sendCurrentMessage(docToSkillIds(draftDoc))
-            }}
-            onReconfigureChooseOther={() => {
-              // Clear the failed pending selection so the picker reflects the currently-effective
-              // specialist. The user can then pick a new one from the menu and send again.
-              // No mechanism exists to programmatically open the picker, so we note it here.
-              if (activeSession && reconfigureError) {
-                setPendingSessionSpecialist((prev) => {
-                  const next = { ...prev }
-                  delete next[activeSession.id]
-                  return next
-                })
-                setReconfigureError(null)
+              if (sessionController.actions.beginReconfigureRetry()) {
+                sendCurrentMessage(docToSkillIds(draftDoc))
               }
             }}
-            onReconfigureUseNone={() => {
-              if (activeSession && reconfigureError) {
-                const sessionId = activeSession.id
-                const specialistApi = window.api?.specialist
-                if (
-                  !specialistApi?.setSessionSpecialist ||
-                  barrierInFlightRef.current.has(sessionId)
-                ) {
-                  return
-                }
-                barrierInFlightRef.current.add(sessionId)
-                setBarrierInFlightSessions((prev) => new Set(prev).add(sessionId))
-                void specialistApi
-                  .setSessionSpecialist({ sessionId, specialistId: undefined })
-                  ?.then((result) => {
-                    if (result?.contextReset) markSpecialistSwitchResetRequired(sessionId)
-                    setSessionSpecialistId(sessionId, undefined)
-                    setPendingSessionSpecialist((prev) => {
-                      const next = { ...prev }
-                      delete next[sessionId]
-                      return next
-                    })
-                    setReconfigureError(null)
-                  })
-                  ?.catch((err: unknown) => console.warn('setSessionSpecialist (none) failed', err))
-                  ?.finally(() => {
-                    barrierInFlightRef.current.delete(sessionId)
-                    setBarrierInFlightSessions((prev) => {
-                      const next = new Set(prev)
-                      next.delete(sessionId)
-                      return next
-                    })
-                  })
-              }
-            }}
-            onSpecialistChange={
-              activeSession
-                ? handleExistingSessionSpecialistChange
-                : handleNewConversationSpecialistChange
-            }
+            onReconfigureChooseOther={sessionController.actions.chooseOtherSpecialist}
+            onReconfigureUseNone={sessionController.actions.useMainAgent}
+            onSpecialistChange={sessionController.actions.selectSpecialist}
           />
         )}
       />
 
       <RenameSessionDialog
-        session={sessionToRename}
-        renameDraft={renameDraft}
-        onRenameDraftChange={setRenameDraft}
-        onCancel={closeRenameDialog}
-        onConfirmRename={confirmRenameSession}
+        session={sessionController.view.dialogs.rename?.session}
+        renameDraft={sessionController.view.dialogs.rename?.draft ?? ''}
+        onRenameDraftChange={sessionController.actions.changeRenameDraft}
+        onCancel={sessionController.actions.closeRename}
+        onConfirmRename={sessionController.actions.confirmRename}
       />
 
       <DeleteSessionDialog
-        session={sessionToDelete}
+        session={sessionController.view.dialogs.delete ?? undefined}
         canDelete={canDeleteConversations}
-        onCancel={closeDeleteDialog}
-        onConfirmDelete={confirmDeleteSession}
+        onCancel={sessionController.actions.closeDelete}
+        onConfirmDelete={sessionController.actions.confirmDelete}
       />
 
       <DownloadSessionArtifactsDialog
-        session={sessionToDownloadArtifacts}
-        onClose={() => setSessionToDownloadArtifacts(undefined)}
+        session={sessionController.view.dialogs.downloadArtifacts ?? undefined}
+        onClose={sessionController.actions.closeDownloadArtifacts}
       />
 
       <FilePreviewDialog
@@ -1717,15 +1193,15 @@ const WorkspacePage = ({
       />
 
       <SessionNotebookDialog
-        session={sessionToViewNotebook}
-        onClose={() => setSessionToViewNotebook(undefined)}
+        session={sessionController.view.dialogs.notebook ?? undefined}
+        onClose={sessionController.actions.closeNotebook}
       />
 
       <JobDetailModal
-        key={jobListModal.sessionId}
-        open={jobListModal.open}
-        sessionId={jobListModal.sessionId}
-        onClose={() => setJobListModal((modal) => ({ ...modal, open: false }))}
+        key={sessionController.view.dialogs.jobList.sessionId}
+        open={sessionController.view.dialogs.jobList.open}
+        sessionId={sessionController.view.dialogs.jobList.sessionId}
+        onClose={sessionController.actions.closeJobList}
       />
     </main>
   )

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SpecialistListItem } from '../../../../shared/specialist'
+import { useArchiveUndoStore } from '@/stores/archive-undo-store'
+import {
+  createInitialSessionState,
+  useSessionStore,
+  type ChatSession
+} from '@/stores/session-store'
+
+import { useWorkspaceSessionController } from './workspace-session-controller'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const session = (overrides: Partial<ChatSession> = {}): ChatSession => ({
+  id: 'session-a',
+  projectId: 'project-a',
+  title: 'Original title',
+  cwd: 'workspace',
+  status: 'idle',
+  messages: [],
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+const specialist = (id: string, name: string): SpecialistListItem =>
+  ({ kind: 'custom', id, name, enabled: true }) as SpecialistListItem
+
+const deferred = <Value>(): {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+} => {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((accept) => {
+    resolve = accept
+  })
+  return { promise, resolve }
+}
+
+type Options = Parameters<typeof useWorkspaceSessionController>[0]
+type ControllerHook = {
+  result: { current: ReturnType<typeof useWorkspaceSessionController> }
+  rerender: (next: ChatSession) => void
+  unmount: () => void
+}
+
+const renderController = (overrides: Partial<Options> = {}): ControllerHook => {
+  let activeSession = overrides.activeSession ?? session()
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const result = {
+    current: undefined as unknown as ReturnType<typeof useWorkspaceSessionController>
+  }
+  const defaults: Options = {
+    activeSession,
+    selectedSessionId: activeSession.id,
+    isPersistenceHydrated: true,
+    isPersistenceReady: true,
+    canDeleteConversations: true,
+    specialistCatalogLoaded: true,
+    specialistItems: [],
+    loadSpecialists: vi.fn().mockResolvedValue(undefined),
+    promptInFlightSessionIds: [],
+    sendPreparationInFlightSessionIds: [],
+    hasUnfinishedTransfers: vi.fn(() => false),
+    beginSessionDeletion: vi.fn(() => true),
+    settleSessionDeletion: vi.fn(),
+    deleteRuntimeSession: vi.fn().mockResolvedValue(true)
+  }
+  const Harness = (): null => {
+    result.current = useWorkspaceSessionController({
+      ...defaults,
+      ...overrides,
+      activeSession
+    })
+    return null
+  }
+  const render = (): void => act(() => root.render(createElement(Harness)))
+  render()
+  return {
+    result,
+    rerender: (next: ChatSession): void => {
+      activeSession = next
+      render()
+    },
+    unmount: (): void => act(() => root.unmount())
+  }
+}
+
+const mounted: Array<ReturnType<typeof renderController>> = []
+const originalApi = window.api
+
+beforeEach(() => {
+  window.api = {} as Window['api']
+  useSessionStore.setState(createInitialSessionState())
+  useArchiveUndoStore.setState({ notices: [], restoringKey: undefined })
+})
+
+afterEach(() => {
+  for (const hook of mounted.splice(0)) hook.unmount()
+  window.api = originalApi
+})
+
+describe('workspace session controller', () => {
+  it('keeps rename whitespace while using trim only as the empty-title gate', () => {
+    const active = session()
+    useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })
+    const renameSession = vi.spyOn(useSessionStore.getState(), 'renameSession')
+    const hook = renderController({ activeSession: active })
+    mounted.push(hook)
+
+    act(() => {
+      hook.result.current.actions.openRename(active)
+      hook.result.current.actions.changeRenameDraft('  Retained title  ')
+    })
+    act(() => hook.result.current.actions.confirmRename({ preventDefault: vi.fn() } as never))
+
+    expect(renameSession).toHaveBeenCalledWith(active.id, '  Retained title  ')
+    expect(hook.result.current.view.dialogs.rename).toBeNull()
+  })
+
+  it('preserves an own pending Main value when capturing a branch intent', () => {
+    const active = session({ status: 'running', specialistId: 'specialist-a' })
+    const hook = renderController({ activeSession: active })
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.selectSpecialist(undefined))
+
+    expect(hook.result.current.lifecycle.captureSendIntent(true)).toEqual({
+      draftSpecialistId: null,
+      hasPendingSwitch: false,
+      pendingSpecialistId: undefined
+    })
+    expect(hook.result.current.view.specialist.hasPendingSwitch).toBe(true)
+  })
+
+  it('archives durably before enqueueing undo and clearing the active selection', async () => {
+    const active = session()
+    const order: string[] = []
+    const updateSessionArchive = vi.fn().mockImplementation(async () => {
+      order.push('archive')
+      return { ...active, archivedAt: 2 }
+    })
+    const clearSelection = vi.fn(() => order.push('clear'))
+    const enqueueSession = vi.fn(() => order.push('undo'))
+    useSessionStore.setState({
+      sessions: [active],
+      selectedSessionId: active.id,
+      updateSessionArchive,
+      clearSelection
+    })
+    useArchiveUndoStore.setState({ enqueueSession })
+    const hook = renderController({ activeSession: active })
+    mounted.push(hook)
+
+    await act(async () => {
+      hook.result.current.actions.archive(active)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(order).toEqual(['archive', 'undo', 'clear'])
+    expect(hook.result.current.lifecycle.canArchive(active)).toBe(true)
+  })
+
+  it('fails closed and retains pending identity when the send barrier rejects', async () => {
+    const active = session({ status: 'running' })
+    useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })
+    const setSessionSpecialist = vi.fn().mockRejectedValue(new Error('switch rejected'))
+    window.api = { specialist: { setSessionSpecialist } } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: active,
+      specialistItems: [specialist('specialist-a', 'Specialist A')]
+    })
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.selectSpecialist('specialist-a'))
+    let ready = true
+    await act(async () => {
+      ready = await hook.result.current.lifecycle.prepareSpecialistSend(active.id, 'specialist-a')
+    })
+
+    expect(ready).toBe(false)
+    expect(hook.result.current.lifecycle.captureSendIntent(false).hasPendingSwitch).toBe(true)
+    expect(hook.result.current.view.specialist.reconfigureError).toMatchObject({
+      specialistName: 'Specialist A',
+      message: 'switch rejected'
+    })
+    expect(hook.result.current.view.specialist.barrierInFlight).toBe(false)
+  })
+
+  it('coordinates duplicate deletion through the composer transaction boundary', async () => {
+    const active = session()
+    const deletion = deferred<boolean>()
+    const beginSessionDeletion = vi.fn().mockReturnValueOnce(true).mockReturnValue(false)
+    const settleSessionDeletion = vi.fn()
+    const deleteRuntimeSession = vi.fn(() => deletion.promise)
+    const hook = renderController({
+      activeSession: active,
+      beginSessionDeletion,
+      settleSessionDeletion,
+      deleteRuntimeSession
+    })
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.openDelete(active))
+    act(() => hook.result.current.actions.confirmDelete())
+    act(() => hook.result.current.actions.openDelete(active))
+    act(() => hook.result.current.actions.confirmDelete())
+    expect(deleteRuntimeSession).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      deletion.resolve(true)
+      await deletion.promise
+    })
+    expect(settleSessionDeletion).toHaveBeenCalledWith(active.id, true)
+    expect(hook.result.current.view.deletingIds.has(active.id)).toBe(false)
+  })
+})

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -1,0 +1,559 @@
+import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
+
+import type { ConversationExportFormat } from '../../../../shared/conversation-export'
+import type {
+  CompletionHandoffLifecycleEvent,
+  SpecialistListItem
+} from '../../../../shared/specialist'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { useArchiveUndoStore } from '@/stores/archive-undo-store'
+import type { ChatSession } from '@/stores/session-store'
+import { useSessionStore } from '@/stores/session-store'
+
+type ReconfigureError = {
+  sessionId: string
+  specialistName: string
+  message: string
+}
+
+type WorkspaceSessionControllerOptions = {
+  activeSession: ChatSession | undefined
+  selectedSessionId: string | undefined
+  isPersistenceHydrated: boolean
+  isPersistenceReady: boolean
+  canDeleteConversations: boolean
+  specialistCatalogLoaded: boolean
+  specialistItems: SpecialistListItem[]
+  loadSpecialists: () => Promise<void>
+  promptInFlightSessionIds: string[]
+  sendPreparationInFlightSessionIds: string[]
+  hasUnfinishedTransfers: (sessionId: string) => boolean
+  beginSessionDeletion: (sessionId: string) => boolean
+  settleSessionDeletion: (sessionId: string, deleted: boolean) => void
+  deleteRuntimeSession: (sessionId: string) => Promise<boolean>
+}
+
+type SpecialistSendIntent = {
+  draftSpecialistId: string | null | undefined
+  hasPendingSwitch: boolean
+  pendingSpecialistId: string | undefined
+}
+
+type WorkspaceSessionController = {
+  view: {
+    dialogs: {
+      rename: { session: ChatSession; draft: string } | null
+      delete: ChatSession | null
+      downloadArtifacts: ChatSession | null
+      notebook: ChatSession | null
+      jobList: { open: boolean; sessionId: string }
+    }
+    exportError: string | null
+    deletingIds: ReadonlySet<string>
+    specialist: {
+      newConversationId: string | undefined
+      historyId: string | undefined
+      unavailable: boolean
+      hasPendingSwitch: boolean
+      barrierInFlight: boolean
+      reconfigureError: ReconfigureError | null
+    }
+  }
+  actions: {
+    clearExportError: () => void
+    openRename: (session: ChatSession) => void
+    closeRename: () => void
+    changeRenameDraft: (draft: string) => void
+    confirmRename: (event: FormEvent<HTMLFormElement>) => void
+    togglePin: (session: ChatSession) => void
+    archive: (session: ChatSession) => void
+    exportConversation: (session: ChatSession, format: ConversationExportFormat) => void
+    openDelete: (session: ChatSession) => void
+    closeDelete: () => void
+    confirmDelete: () => void
+    openDownloadArtifacts: (session: ChatSession | null) => void
+    closeDownloadArtifacts: () => void
+    openNotebook: (session: ChatSession | null) => void
+    closeNotebook: () => void
+    openJobList: (sessionId: string) => void
+    closeJobList: () => void
+    selectSpecialist: (specialistId: string | undefined) => void
+    resetNewConversationSpecialist: () => void
+    beginReconfigureRetry: () => boolean
+    chooseOtherSpecialist: () => void
+    useMainAgent: () => void
+  }
+  lifecycle: {
+    canArchive: (session: ChatSession) => boolean
+    canStartSend: () => boolean
+    captureSendIntent: (branchInNewSession: boolean) => SpecialistSendIntent
+    prepareSpecialistSend: (sessionId: string, specialistId: string | undefined) => Promise<boolean>
+    isBarrierInFlight: (sessionId: string) => boolean
+  }
+}
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const compareHandoffEventOrder = (
+  left: Pick<CompletionHandoffLifecycleEvent, 'commitOrder' | 'observedAt' | 'sequence' | 'id'>,
+  right: Pick<CompletionHandoffLifecycleEvent, 'commitOrder' | 'observedAt' | 'sequence' | 'id'>
+): number =>
+  (left.commitOrder !== undefined || right.commitOrder !== undefined
+    ? left.commitOrder === undefined
+      ? -1
+      : right.commitOrder === undefined
+        ? 1
+        : left.commitOrder - right.commitOrder
+    : left.observedAt - right.observedAt) ||
+  left.sequence - right.sequence ||
+  left.id.localeCompare(right.id)
+
+// Owns Workspace session transactions and Specialist identity without taking over message dispatch.
+const useWorkspaceSessionController = ({
+  activeSession,
+  selectedSessionId,
+  isPersistenceHydrated,
+  isPersistenceReady,
+  canDeleteConversations,
+  specialistCatalogLoaded,
+  specialistItems,
+  loadSpecialists,
+  promptInFlightSessionIds,
+  sendPreparationInFlightSessionIds,
+  hasUnfinishedTransfers,
+  beginSessionDeletion,
+  settleSessionDeletion,
+  deleteRuntimeSession
+}: WorkspaceSessionControllerOptions): WorkspaceSessionController => {
+  const renameSession = useSessionStore((state) => state.renameSession)
+  const togglePinned = useSessionStore((state) => state.togglePinned)
+  const updateSessionArchive = useSessionStore((state) => state.updateSessionArchive)
+  const clearSelection = useSessionStore((state) => state.clearSelection)
+  const setSessionSpecialistId = useSessionStore((state) => state.setSessionSpecialistId)
+  const markSpecialistSwitchResetRequired = useSessionStore(
+    (state) => state.markSpecialistSwitchResetRequired
+  )
+  const enqueueSessionArchive = useArchiveUndoStore((state) => state.enqueueSession)
+
+  const [newConversationSpecialistId, setNewConversationSpecialistId] = useState<
+    string | undefined
+  >(undefined)
+  const [pendingSpecialists, setPendingSpecialists] = useState<Record<string, string | undefined>>(
+    {}
+  )
+  const [reconfigureError, setReconfigureError] = useState<ReconfigureError | null>(null)
+  const [barrierInFlightIds, setBarrierInFlightIds] = useState<ReadonlySet<string>>(new Set())
+  const barrierInFlightRef = useRef(new Set<string>())
+  const specialistItemsRef = useRef(specialistItems)
+
+  const [exportError, setExportError] = useState<string | null>(null)
+  const [renameDialog, setRenameDialog] = useState<{
+    session: ChatSession
+    draft: string
+  } | null>(null)
+  const [deleteDialog, setDeleteDialog] = useState<ChatSession | null>(null)
+  const [downloadArtifactsDialog, setDownloadArtifactsDialog] = useState<ChatSession | null>(null)
+  const [notebookDialog, setNotebookDialog] = useState<ChatSession | null>(null)
+  const [jobListDialog, setJobListDialog] = useState({ open: false, sessionId: '' })
+  const [deletingIds, setDeletingIds] = useState<ReadonlySet<string>>(new Set())
+  const [archivingIds, setArchivingIds] = useState<ReadonlySet<string>>(new Set())
+
+  const activeHasPending = Boolean(
+    activeSession && Object.hasOwn(pendingSpecialists, activeSession.id)
+  )
+  const historySpecialistId = activeSession
+    ? activeHasPending
+      ? pendingSpecialists[activeSession.id]
+      : activeSession.specialistId
+    : newConversationSpecialistId
+  const newConversationSpecialistUnavailable =
+    specialistCatalogLoaded &&
+    newConversationSpecialistId !== undefined &&
+    !specialistItems.some(
+      (item) => item.kind === 'custom' && item.enabled && item.id === newConversationSpecialistId
+    )
+  const activeSpecialistUnavailable = activeSession
+    ? specialistCatalogLoaded &&
+      activeSession.specialistId !== undefined &&
+      !activeHasPending &&
+      !specialistItems.some(
+        (item) => item.kind === 'custom' && item.enabled && item.id === activeSession.specialistId
+      )
+    : newConversationSpecialistUnavailable
+  const activeHasPendingSwitch = Boolean(
+    activeSession &&
+    activeHasPending &&
+    (activeSession.status === 'running' || activeSession.status === 'waiting-permission')
+  )
+
+  const setBarrier = useCallback((sessionId: string, inFlight: boolean): void => {
+    if (inFlight) barrierInFlightRef.current.add(sessionId)
+    else barrierInFlightRef.current.delete(sessionId)
+    setBarrierInFlightIds((current) => {
+      const next = new Set(current)
+      if (inFlight) next.add(sessionId)
+      else next.delete(sessionId)
+      return next
+    })
+  }, [])
+
+  const clearPending = useCallback((sessionId: string): void => {
+    setPendingSpecialists((current) => {
+      const next = { ...current }
+      delete next[sessionId]
+      return next
+    })
+  }, [])
+
+  const canArchive = (session: ChatSession): boolean =>
+    isPersistenceReady &&
+    !session.isPending &&
+    session.archivedAt === undefined &&
+    !archivingIds.has(session.id) &&
+    !deletingIds.has(session.id) &&
+    !promptInFlightSessionIds.includes(session.id) &&
+    !sendPreparationInFlightSessionIds.includes(session.id) &&
+    session.status !== 'running' &&
+    session.status !== 'waiting-permission' &&
+    session.status !== 'waiting-plan-approval' &&
+    !hasUnfinishedTransfers(session.id)
+
+  const openRename = (session: ChatSession): void => {
+    if (isPersistenceReady) setRenameDialog({ session, draft: session.title })
+  }
+
+  const closeRename = (): void => setRenameDialog(null)
+
+  const confirmRename = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault()
+    if (!isPersistenceReady || !renameDialog || renameDialog.draft.trim().length === 0) return
+    renameSession(renameDialog.session.id, renameDialog.draft)
+    closeRename()
+  }
+
+  const exportConversation = (session: ChatSession, format: ConversationExportFormat): void => {
+    const exporter = window.api?.sessions?.exportConversation
+    if (!exporter) return
+    setExportError(null)
+    void exporter({ projectId: session.projectId, sessionId: session.id, format }).catch(
+      (error: unknown) => setExportError(errorMessage(error))
+    )
+  }
+
+  const archive = (session: ChatSession): void => {
+    if (!canArchive(session)) return
+    setArchivingIds((current) => new Set(current).add(session.id))
+    setExportError(null)
+    void updateSessionArchive({
+      projectId: session.projectId,
+      sessionId: session.id,
+      archived: true,
+      expectedArchivedAt: null
+    })
+      .then((archived) => {
+        enqueueSessionArchive(archived)
+        if (selectedSessionId === session.id) clearSelection()
+      })
+      .catch((error: unknown) => setExportError(errorMessage(error)))
+      .finally(() => {
+        setArchivingIds((current) => {
+          const next = new Set(current)
+          next.delete(session.id)
+          return next
+        })
+      })
+  }
+
+  const openDelete = (session: ChatSession): void => {
+    if (isPersistenceHydrated && canDeleteConversations) setDeleteDialog(session)
+  }
+
+  const confirmDelete = (): void => {
+    if (!isPersistenceHydrated || !canDeleteConversations || !deleteDialog) return
+    useNavigationStore.getState().recordUserNavigation()
+    const sessionId = deleteDialog.id
+    if (!beginSessionDeletion(sessionId)) {
+      setDeleteDialog(null)
+      return
+    }
+    setDeletingIds((current) => new Set(current).add(sessionId))
+    setDeleteDialog(null)
+    void deleteRuntimeSession(sessionId).then((deleted) => {
+      setDeletingIds((current) => {
+        const next = new Set(current)
+        next.delete(sessionId)
+        return next
+      })
+      settleSessionDeletion(sessionId, deleted)
+    })
+  }
+
+  const selectSpecialist = (specialistId: string | undefined): void => {
+    if (!activeSession) {
+      setNewConversationSpecialistId(specialistId)
+      return
+    }
+    const sessionId = activeSession.id
+    if (barrierInFlightRef.current.has(sessionId)) return
+    const running =
+      activeSession.status === 'running' || activeSession.status === 'waiting-permission'
+    if (running) {
+      setPendingSpecialists((current) => ({ ...current, [sessionId]: specialistId }))
+    } else {
+      const previousSpecialistId = activeSession.specialistId
+      setSessionSpecialistId(sessionId, specialistId)
+      clearPending(sessionId)
+      void window.api?.specialist
+        ?.setSessionSpecialist?.({ sessionId, specialistId })
+        ?.then((result) => {
+          if (result?.contextReset) markSpecialistSwitchResetRequired(sessionId)
+        })
+        ?.catch((error: unknown) => {
+          setSessionSpecialistId(sessionId, previousSpecialistId)
+          console.warn('setSessionSpecialist failed', error)
+        })
+    }
+    if (reconfigureError?.sessionId === sessionId) setReconfigureError(null)
+  }
+
+  const canStartSend = (): boolean => {
+    if (!activeSession) return !newConversationSpecialistUnavailable
+    if (barrierInFlightRef.current.has(activeSession.id)) return false
+    if (activeSession.specialistId === undefined) return true
+    if (!specialistCatalogLoaded) {
+      void loadSpecialists()
+      return false
+    }
+    return activeHasPending || !activeSpecialistUnavailable
+  }
+
+  const captureSendIntent = (branchInNewSession: boolean): SpecialistSendIntent => {
+    const hasPending = Boolean(activeSession && Object.hasOwn(pendingSpecialists, activeSession.id))
+    const pendingSpecialistId = activeSession ? pendingSpecialists[activeSession.id] : undefined
+    return {
+      draftSpecialistId: branchInNewSession
+        ? hasPending
+          ? (pendingSpecialistId ?? null)
+          : activeSession?.specialistId
+        : !activeSession
+          ? newConversationSpecialistId
+          : undefined,
+      hasPendingSwitch: !branchInNewSession && hasPending,
+      pendingSpecialistId
+    }
+  }
+
+  const prepareSpecialistSend = async (
+    sessionId: string,
+    specialistId: string | undefined
+  ): Promise<boolean> => {
+    if (barrierInFlightRef.current.has(sessionId)) return false
+    setBarrier(sessionId, true)
+    try {
+      const result = await window.api?.specialist?.setSessionSpecialist?.({
+        sessionId,
+        specialistId
+      })
+      if (result?.contextReset) markSpecialistSwitchResetRequired(sessionId)
+    } catch (error: unknown) {
+      const pendingProfile = specialistItems.find(
+        (item) => item.kind === 'custom' && item.id === specialistId
+      )
+      setReconfigureError({
+        sessionId,
+        specialistName:
+          specialistId === undefined
+            ? 'Main Agent'
+            : pendingProfile?.kind === 'custom'
+              ? pendingProfile.name
+              : 'the selected specialist',
+        message: errorMessage(error)
+      })
+      setBarrier(sessionId, false)
+      return false
+    }
+    setSessionSpecialistId(sessionId, specialistId)
+    clearPending(sessionId)
+    setReconfigureError(null)
+    setBarrier(sessionId, false)
+    return true
+  }
+
+  const beginReconfigureRetry = (): boolean => {
+    if (!reconfigureError || !Object.hasOwn(pendingSpecialists, reconfigureError.sessionId)) {
+      setReconfigureError(null)
+      return false
+    }
+    setReconfigureError(null)
+    return true
+  }
+
+  const chooseOtherSpecialist = (): void => {
+    if (!activeSession || !reconfigureError) return
+    clearPending(activeSession.id)
+    setReconfigureError(null)
+  }
+
+  const useMainAgent = (): void => {
+    if (!activeSession || !reconfigureError) return
+    const sessionId = activeSession.id
+    const setter = window.api?.specialist?.setSessionSpecialist
+    if (!setter || barrierInFlightRef.current.has(sessionId)) return
+    setBarrier(sessionId, true)
+    void setter({ sessionId, specialistId: undefined })
+      .then((result) => {
+        if (result?.contextReset) markSpecialistSwitchResetRequired(sessionId)
+        setSessionSpecialistId(sessionId, undefined)
+        clearPending(sessionId)
+        setReconfigureError(null)
+      })
+      .catch((error: unknown) => console.warn('setSessionSpecialist (none) failed', error))
+      .finally(() => setBarrier(sessionId, false))
+  }
+
+  useEffect(() => {
+    if (typeof window.api?.specialist?.list !== 'function') return
+    void loadSpecialists()
+    return window.api.specialist.onCatalogChanged(() => void loadSpecialists())
+  }, [loadSpecialists])
+
+  useEffect(() => {
+    specialistItemsRef.current = specialistItems
+  }, [specialistItems])
+
+  useEffect(() => {
+    const specialistApi = window.api?.specialist
+    if (!specialistApi?.onPendingSwitch) return
+    return specialistApi.onPendingSwitch((pending) => {
+      if (pending.targetName === null) {
+        setPendingSpecialists((current) => ({
+          ...current,
+          [pending.sessionId]: undefined
+        }))
+        return
+      }
+      const match = specialistItemsRef.current.find(
+        (item) => item.kind === 'custom' && item.name === pending.targetName
+      )
+      if (match?.kind === 'custom') {
+        setPendingSpecialists((current) => ({
+          ...current,
+          [pending.sessionId]: match.id
+        }))
+        return
+      }
+      const resolver = specialistApi.resolveSessionSpecialist
+      if (!resolver) return
+      void resolver
+        .call(specialistApi, { sessionId: pending.sessionId })
+        .then((resolution) => {
+          if (resolution.kind === 'bound') {
+            setPendingSpecialists((current) => ({
+              ...current,
+              [pending.sessionId]: resolution.profile.id
+            }))
+          }
+        })
+        .catch(() => undefined)
+    })
+  }, [])
+
+  const applyHandoffLifecycleEvent = useCallback(
+    (event: CompletionHandoffLifecycleEvent): void => {
+      if (event.phase !== 'continuation-start' && event.phase !== 'continued') return
+      const specialistApi = window.api?.specialist
+      const resolver = specialistApi?.resolveSessionSpecialist
+      if (!resolver) return
+      void resolver
+        .call(specialistApi, { sessionId: event.sessionId })
+        .then((resolution) => {
+          if (resolution.kind === 'bound') {
+            setSessionSpecialistId(event.sessionId, resolution.profile.id)
+          } else if (resolution.kind === 'main') {
+            setSessionSpecialistId(event.sessionId, undefined)
+          }
+        })
+        .catch(() => undefined)
+    },
+    [setSessionSpecialistId]
+  )
+
+  useEffect(() => {
+    const specialistApi = window.api?.specialist
+    if (!specialistApi?.onHandoffLifecycleEvent) return
+    return specialistApi.onHandoffLifecycleEvent(applyHandoffLifecycleEvent)
+  }, [applyHandoffLifecycleEvent])
+
+  useEffect(() => {
+    const specialistApi = window.api?.specialist
+    if (!activeSession?.id || !specialistApi?.getHandoffEvents) return
+    void specialistApi
+      .getHandoffEvents(activeSession.id)
+      .then((events) => {
+        const latest = events.sort(compareHandoffEventOrder).at(-1)
+        if (latest) applyHandoffLifecycleEvent(latest)
+      })
+      .catch(() => undefined)
+  }, [activeSession?.id, applyHandoffLifecycleEvent])
+
+  return {
+    view: {
+      dialogs: {
+        rename: renameDialog,
+        delete: deleteDialog,
+        downloadArtifacts: downloadArtifactsDialog,
+        notebook: notebookDialog,
+        jobList: jobListDialog
+      },
+      exportError,
+      deletingIds,
+      specialist: {
+        newConversationId: newConversationSpecialistId,
+        historyId: historySpecialistId,
+        unavailable: activeSpecialistUnavailable,
+        hasPendingSwitch: activeHasPendingSwitch,
+        barrierInFlight: barrierInFlightIds.has(activeSession?.id ?? ''),
+        reconfigureError:
+          reconfigureError?.sessionId === activeSession?.id ? reconfigureError : null
+      }
+    },
+    actions: {
+      clearExportError: () => setExportError(null),
+      openRename,
+      closeRename,
+      changeRenameDraft: (draft: string) =>
+        setRenameDialog((current) => (current ? { ...current, draft } : current)),
+      confirmRename,
+      togglePin: (session: ChatSession) => {
+        if (isPersistenceReady) togglePinned(session.id)
+      },
+      archive,
+      exportConversation,
+      openDelete,
+      closeDelete: () => setDeleteDialog(null),
+      confirmDelete,
+      openDownloadArtifacts: setDownloadArtifactsDialog,
+      closeDownloadArtifacts: () => setDownloadArtifactsDialog(null),
+      openNotebook: setNotebookDialog,
+      closeNotebook: () => setNotebookDialog(null),
+      openJobList: (sessionId: string) => setJobListDialog({ open: true, sessionId }),
+      closeJobList: () => setJobListDialog((current) => ({ ...current, open: false })),
+      selectSpecialist,
+      resetNewConversationSpecialist: () => setNewConversationSpecialistId(undefined),
+      beginReconfigureRetry,
+      chooseOtherSpecialist,
+      useMainAgent
+    },
+    lifecycle: {
+      canArchive,
+      canStartSend,
+      captureSendIntent,
+      prepareSpecialistSend,
+      isBarrierInFlight: (sessionId: string) => barrierInFlightRef.current.has(sessionId)
+    }
+  }
+}
+
+export { useWorkspaceSessionController }
+export type { ReconfigureError, SpecialistSendIntent, WorkspaceSessionController }

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -2820,6 +2820,7 @@ describe('session store public contract', () => {
       'src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.ts',
       'src/renderer/src/pages/workspace/use-project-artifact-files.ts',
       'src/renderer/src/pages/workspace/workspace-conversation-items.ts',
+      'src/renderer/src/pages/workspace/workspace-session-controller.ts',
       'src/renderer/src/pages/workspace/workspace-tool-activity-details.ts',
       'src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts',
       'src/renderer/src/pages/workspace/workspace-tool-activity-style.ts',


### PR DESCRIPTION
## Problem

`WorkspacePage` owned Session dialog transactions and Specialist runtime identity details alongside
rendering and message dispatch. That made the page understand archive/delete ordering, pending switch
ownership, reconfigure recovery and handoff readback, and made those contracts difficult to test as a
single state machine.

## Proposed change

Add `workspace-session-controller.ts` as one deep `view / actions / lifecycle` owner. Move Session
rename/archive/delete/dialog state and Specialist pending/barrier/handoff behavior into it, then adapt
`WorkspacePage` to consume the controller. Add direct transaction tests and update the module-impact
map so module-scoped validation follows the new owner and its contracts.

## Scope and non-goals

- Keep composer capture/rollback and final `sendMessage` dispatch in `WorkspacePage`.
- Reuse the existing handoff lifecycle source and projection modules.
- Do not change Permission, Compute, Review or Notebook hydration ownership.
- Do not add public APIs, IPC channels, persisted fields or new user capabilities.
- Defer the proposed `submit / revise / resume / cancel / delete` Workspace Conversation interface to
  the separately confirmed WC stage.

## Compatibility

- Electron keeps Specialist, download and export capabilities and existing IPC payloads.
- Web keeps capability detection and does not gain Electron-only operations.
- CLI remains outside the renderer and receives no new management API.
- `Object.hasOwn` pending-Main semantics, context-reset markers, handoff replay ordering, archive undo
  ordering and two-phase composer deletion cleanup remain unchanged.
- Tests contain no host-specific filesystem assertions and remain portable across Windows, macOS and
  Linux.

## Acceptance criteria and validation

- Session/Specialist owner remains at or below 660 physical lines: 559 lines.
- Workspace Page decreases from 1,734 to 1,210 physical lines.
- `npm run typecheck:web` -> passed.
- focused ESLint for changed source and test files -> passed.
- `npm run test:module -- workspace_page` -> 20 files / 297 tests passed.
- module-impact manifest tests -> 3 files / 29 tests passed.
- `npm run typecheck` -> passed.
- `npm run lint` -> passed with 0 errors and 17 unrelated baseline warnings.
- `npm test` -> 865 files / 12,623 tests passed; 14 files / 190 tests skipped.
- Exact-head CI/AI -> pending PR.
- Independent Standards review -> 0 hard violations; one non-blocking WP4 line-gate judgment.
- Independent Spec review -> 0 findings.

The listed focused checks ran after the latest material source edit. Full fallback is required because
the ownership manifest changed. No local Windows/macOS/Linux packaging lane is claimed; exact-head CI
is authoritative for platform coverage.

## Review focus

- Reconfigure must complete before a pending Specialist send and must fail closed without clearing the
  draft or pending identity.
- Branching must inherit a pending Main selection as `null` without mutating the source pending state.
- Archive must persist before enqueueing undo and clearing the selected Session.
- Delete must retain composer state until runtime and durable deletion both succeed and reject duplicate
  deletion transactions.
- Optional Electron bridges must remain guarded so Web behavior and current capability asymmetry do not
  change.
