### PR TITLE
fix(acp): route Codex MCP approvals through permission broker

### DIFF
--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -669,6 +669,10 @@ class AcpPermissionContext {
     return true
   }
 
+  hasTrustedCodexMcpToolCall(sessionId: string, toolCallId: string): boolean {
+    return this.codexMcpToolIdentities.get(sessionId)?.has(toolCallId) ?? false
+  }
+
   cancelAllPending(): void {
     this.broker.cancelAllPending()
     this.humanOnlyRequestIds.clear()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3065,7 +3065,98 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.elicitationResponses).toEqual([{ action: 'accept' }])
   })
 
-  it('does not reuse a consumed Codex MCP approval correlation', async () => {
+  it.each([
+    {
+      decision: 'allows',
+      optionKind: 'allow_once',
+      expectedResponse: { action: 'accept' as const }
+    },
+    {
+      decision: 'denies',
+      optionKind: 'reject_once',
+      expectedResponse: { action: 'decline' as const }
+    }
+  ])(
+    'routes Codex MCP approval elicitations through permission controls when the user $decision',
+    async ({ optionKind, expectedResponse }) => {
+      const process = new FakeAgentProcess()
+      const fakeAgent = startFakeAgent(process, ['codex-notebook-approval-session'], {
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only'),
+        codexMcpToolCallBeforeElicitation: {
+          toolCallId: 'call-notebook-state',
+          server: 'open-science-notebook',
+          tool: 'notebook_state'
+        },
+        elicitationForPrompt: ({ sessionId }) => ({
+          mode: 'form',
+          sessionId,
+          toolCallId: 'call-notebook-state',
+          message: 'Allow the open-science-notebook MCP server to run notebook_state?',
+          requestedSchema: {
+            type: 'object',
+            properties: {
+              persist: {
+                type: 'string',
+                title: 'Approval scope',
+                oneOf: [
+                  { const: 'once', title: 'Allow once' },
+                  { const: 'session', title: 'Allow for this session' },
+                  { const: 'always', title: "Allow and don't ask again" }
+                ]
+              }
+            },
+            required: ['persist']
+          },
+          _meta: { codex_approval_kind: 'mcp_tool_call', persist: ['session', 'always'] }
+        })
+      })
+      const permissionRequests: AcpPermissionRequest[] = []
+      let publishedElicitationCount = 0
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        framework: codexFramework,
+        notebook: {
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' })
+        },
+        callbacks: {
+          onPermissionRequest: (request) => {
+            permissionRequests.push(request)
+            const selectedOption = request.options.find((option) => option.kind === optionKind)
+            if (!selectedOption) throw new Error(`Missing ${optionKind} permission option`)
+            void runtime.respondToPermission({
+              requestId: request.requestId,
+              optionId: selectedOption.optionId
+            })
+          },
+          onStateChanged: (snapshot) => {
+            const request = snapshot.pendingElicitations?.[0]
+            if (!request) return
+            publishedElicitationCount += 1
+            runtime.respondToElicitation({ requestId: request.requestId, action: 'decline' })
+          }
+        }
+      })
+
+      const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+      await runtime.sendPrompt({ sessionId: session.sessionId, text: 'inspect the notebook' })
+
+      expect(publishedElicitationCount).toBe(0)
+      expect(permissionRequests).toHaveLength(1)
+      expect(permissionRequests[0]).toMatchObject({
+        sessionId: session.sessionId,
+        toolCallId: 'call-notebook-state',
+        providerToolName: 'notebook_state',
+        isMcp: true
+      })
+      expect(fakeAgent.elicitationResponses).toEqual([expectedResponse])
+    }
+  )
+
+  it('declines a repeated Codex MCP approval after its correlation is consumed', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['codex-choice-replay-session'], {
       modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only'),
@@ -3122,11 +3213,8 @@ describe('ACP runtime session management', () => {
     const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'replay approval' })
 
-    expect(publishedApprovalCount).toBe(1)
-    expect(fakeAgent.elicitationResponses).toEqual([
-      { action: 'accept' },
-      { action: 'accept', content: { persist: 'once' } }
-    ])
+    expect(publishedApprovalCount).toBe(0)
+    expect(fakeAgent.elicitationResponses).toEqual([{ action: 'accept' }, { action: 'decline' }])
   })
 
   it('acknowledges an app-owned MCP choice and silently continues after the user answers', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1369,17 +1369,44 @@ class AcpRuntime {
       typeof meta === 'object' && meta !== null && meta.codex_approval_kind === 'mcp_tool_call'
     const toolCallId = 'toolCallId' in params ? params.toolCallId : undefined
     const frameworkId = this.getSessionFramework(sessionId)
-    if (
-      frameworkId === 'codex' &&
-      isCodexMcpToolApproval &&
-      typeof toolCallId === 'string' &&
-      this.permissionContext.consumeTrustedCodexMcpToolCall(
-        sessionId,
-        toolCallId,
-        'open-science-notebook/ask_user_question'
-      )
-    ) {
-      return Promise.resolve({ action: 'accept' })
+    // Codex ACP can surface an MCP approval through elicitation/create instead of
+    // session/request_permission. Keep that provider detail behind the existing permission owner so
+    // the renderer never mistakes an authorization prompt for structured user input.
+    if (frameworkId === 'codex' && isCodexMcpToolApproval) {
+      if (typeof toolCallId !== 'string') return Promise.resolve({ action: 'decline' })
+      if (
+        this.permissionContext.consumeTrustedCodexMcpToolCall(
+          sessionId,
+          toolCallId,
+          'open-science-notebook/ask_user_question'
+        )
+      ) {
+        return Promise.resolve({ action: 'accept' })
+      }
+      if (!this.permissionContext.hasTrustedCodexMcpToolCall(sessionId, toolCallId)) {
+        return Promise.resolve({ action: 'decline' })
+      }
+
+      const allowOnceOptionId = 'codex-elicitation-allow-once'
+      return this.permissionContext
+        .handleProviderRequest({
+          sessionId: params.sessionId,
+          toolCall: { toolCallId, kind: 'execute', status: 'pending' },
+          options: [
+            { optionId: allowOnceOptionId, name: 'Allow once', kind: 'allow_once' },
+            {
+              optionId: 'codex-elicitation-reject-once',
+              name: 'Deny',
+              kind: 'reject_once'
+            }
+          ],
+          _meta: { is_mcp_tool_approval: true }
+        })
+        .then((response) =>
+          response.outcome.outcome === 'selected' && response.outcome.optionId === allowOnceOptionId
+            ? { action: 'accept' as const }
+            : { action: 'decline' as const }
+        )
     }
 
     const promptInteraction = this.sessionInteractions.current(sessionId)


### PR DESCRIPTION
## Problem

On Codex ACP, ordinary MCP authorization can arrive as elicitation/create with codex_approval_kind=mcp_tool_call instead of session/request_permission. The runtime treated non-ask_user_question requests as structured elicitation, so Windows could show a non-actionable ask-user card and leave authorization waiting.

## Proposed change

- Route trusted Codex MCP approval elicitations through the existing permission broker.
- Preserve the silent approval bootstrap for the trusted open-science-notebook/ask_user_question tool so the subsequent real question remains an elicitation.
- Decline approval-shaped elicitations when their trusted tool-call correlation is absent or already consumed.
- Cover both user allow and deny outcomes with runtime regression tests.

## Scope and non-goals

The changed runtime seam is shared by codex-response and codex-bridge. Claude Code and OpenCode permission flows remain unchanged because they already use session/request_permission and are gated by their framework identifiers. This change does not alter renderer UI, IPC contracts, permission persistence, or provider configuration.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- Codex approval routing -> npm test -- src/main/acp/runtime.test.ts -t Codex MCP approval -> 4 passed
- Cross-framework and ask-user compatibility -> npm test -- src/main/acp/runtime.test.ts -t advertises form elicitation|restores Codex MCP identity|restores OpenCode MCP inputs|auto-allows a Claude Code Artifact -> 4 passed
- ACP runtime suite -> npm test -- src/main/acp/runtime.test.ts -> 466 passed
- Affected process types -> npm run typecheck -> passed
- Source lint -> npm run lint -> 0 errors; 17 pre-existing unrelated warnings
- Full fallback -> npm test -> 865 files passed, 14 skipped; 12,625 tests passed, 190 skipped

The module-impact manifest does not own the changed runtime seam, so the full fallback was included. No Windows desktop E2E was available locally; exact-head CI remains authoritative for platform lanes.

## Review focus

Please verify the trusted Codex tool-call correlation boundary, the mapping from app-owned permission scopes back to provider allow_once, and the fail-closed behavior for stale approval elicitations.