### PR TITLE
test(workspace): certify page ownership

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -99,6 +99,7 @@
           "src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx",
           "src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx",
           "src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx",
+          "src/renderer/src/pages/workspace/workspace-page.architecture.test.ts",
           "src/renderer/src/pages/workspace/workspace-composer-controller.test.ts",
           "src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts",
           "src/renderer/src/pages/workspace/workspace-session-controller.test.ts",

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -151,10 +151,10 @@ const WorkspacePage = ({
     useState<PermissionProfileId>(defaultPermissionProfile)
   // Draft auto-review state for a not-yet-created conversation. Auto-review defaults off, so a new
   // conversation starts disabled; the user can toggle it on before sending. On send it is stamped
-  // onto the created session (see sendCurrentMessage).
+  // onto the created session through the Conversation submit transaction.
   const [newConversationAutoReviewEnabled, setNewConversationAutoReviewEnabled] = useState(false)
   // Draft compute hosts for a not-yet-created conversation. Cleared when a new conversation draft
-  // is started, and stamped onto the session when the first message is sent (see sendCurrentMessage).
+  // is started, and stamped onto the session by the Conversation submit transaction.
   const [newConversationEnabledComputeHosts, setNewConversationEnabledComputeHosts] = useState<
     string[]
   >([])
@@ -655,7 +655,7 @@ const WorkspacePage = ({
   }
 
   // Persists the auto-review toggle for the active session; for a not-yet-created conversation it
-  // updates the draft state, which sendCurrentMessage stamps onto the new session.
+  // updates the draft state, which the Conversation submit transaction stamps onto the new session.
   const changeAutoReviewEnabled = (enabled: boolean): void => {
     if (!activeSession) {
       setNewConversationAutoReviewEnabled(enabled)
@@ -667,8 +667,8 @@ const WorkspacePage = ({
 
   // Enables or disables a compute host for the active session (single-select semantics).
   // Enabling one host replaces any existing selection; disabling clears the set.
-  // For a not-yet-created conversation, updates the draft state; sendCurrentMessage stamps it onto
-  // the new session. For an existing session, updates the session store and main-process registry.
+  // For a not-yet-created conversation, the Conversation submit transaction stamps this draft state
+  // onto the new session. Existing sessions update the store and main-process registry immediately.
   const handleComputeHostToggle = (providerId: string, enabled: boolean): void => {
     // Single-select: enable one host ↔ clear all others; disabling clears the selection entirely.
     const newEnabledHosts = enabled ? [providerId] : []

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -657,5 +657,4 @@ const useWorkspaceComposerController = ({
   }
 }
 
-export { useWorkspaceComposerController }
-export type { WorkspaceComposerController }
+export { useWorkspaceComposerController, type WorkspaceComposerController }

--- a/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
@@ -1,0 +1,198 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { basename, dirname, extname, relative, resolve } from 'node:path'
+import {
+  createSourceFile,
+  forEachChild,
+  isCallExpression,
+  isExportDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isPropertyAccessExpression,
+  isStringLiteralLike,
+  ScriptKind,
+  ScriptTarget,
+  type Node
+} from 'typescript'
+
+import { describe, expect, it } from 'vitest'
+
+const workspaceDirectory = __dirname
+const repositoryRoot = resolve(workspaceDirectory, '../../../../..')
+const rendererRoot = resolve(workspaceDirectory, '../..')
+const manifestPath = resolve(repositoryRoot, 'scripts/ci/module-impact.json')
+const architectureTestPath = 'src/renderer/src/pages/workspace/workspace-page.architecture.test.ts'
+const ownerPaths = {
+  page: resolve(workspaceDirectory, 'WorkspacePage.tsx'),
+  layout: resolve(workspaceDirectory, 'workspace-panel-layout.tsx'),
+  composer: resolve(workspaceDirectory, 'workspace-composer-controller.ts'),
+  conversation: resolve(workspaceDirectory, 'workspace-conversation-controller.ts'),
+  session: resolve(workspaceDirectory, 'workspace-session-controller.ts')
+} as const
+
+const readSource = (path: string): string => readFileSync(path, 'utf8')
+const rawLineCount = (source: string): number => source.trimEnd().split(/\r?\n/).length
+const portableRelativePath = (path: string): string =>
+  relative(rendererRoot, path).replaceAll('\\', '/')
+const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
+const productionSources = (): string[] => {
+  const sources: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isDirectory()) visit(path)
+      else if (
+        ['.ts', '.tsx'].includes(extname(path)) &&
+        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
+      ) {
+        sources.push(path)
+      }
+    }
+  }
+  visit(rendererRoot)
+  return sources.sort()
+}
+const importedTargets = (sourcePath: string): string[] => {
+  const targets: string[] = []
+  const sourceFile = createSourceFile(
+    sourcePath,
+    readSource(sourcePath),
+    ScriptTarget.Latest,
+    true,
+    extname(sourcePath) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
+  )
+  const visit = (node: Node): void => {
+    if (
+      (isImportDeclaration(node) || isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      const specifier = node.moduleSpecifier.text
+      if (specifier.startsWith('@/')) targets.push(resolve(rendererRoot, specifier.slice(2)))
+      else if (specifier.startsWith('.')) targets.push(resolve(dirname(sourcePath), specifier))
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return targets.map(modulePath)
+}
+const productionSourcePaths = productionSources()
+const importedTargetsBySource = new Map(
+  productionSourcePaths.map((path) => [path, importedTargets(path)] as const)
+)
+const importersOf = (targetPath: string): string[] =>
+  productionSourcePaths
+    .filter((path) => importedTargetsBySource.get(path)?.includes(modulePath(targetPath)) === true)
+    .map(portableRelativePath)
+const conversationCommandCalls = (sourcePath: string): string[] => {
+  const commands = new Set([
+    'sendMessage',
+    'resendEditedMessage',
+    'resumeInterruptedSession',
+    'cancelRun',
+    'deleteRuntimeSession'
+  ])
+  const calls: string[] = []
+  const sourceFile = createSourceFile(
+    sourcePath,
+    readSource(sourcePath),
+    ScriptTarget.Latest,
+    true,
+    ScriptKind.TSX
+  )
+  const visit = (node: Node): void => {
+    if (isCallExpression(node)) {
+      const name = isIdentifier(node.expression)
+        ? node.expression.text
+        : isPropertyAccessExpression(node.expression)
+          ? node.expression.name.text
+          : undefined
+      if (name && commands.has(name)) calls.push(name)
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return calls
+}
+
+describe('workspace page architecture', () => {
+  it('keeps the page and extracted owners within their completion gates', () => {
+    expect(rawLineCount(readSource(ownerPaths.page))).toBeLessThanOrEqual(1_200)
+    for (const ownerPath of [
+      ownerPaths.layout,
+      ownerPaths.composer,
+      ownerPaths.conversation,
+      ownerPaths.session
+    ]) {
+      expect(rawLineCount(readSource(ownerPath)), basename(ownerPath)).toBeLessThanOrEqual(660)
+    }
+  })
+
+  it('keeps private controller consumers explicit and bounded', () => {
+    expect(importersOf(ownerPaths.composer)).toEqual([
+      'pages/workspace/WorkspacePage.tsx',
+      'pages/workspace/workspace-conversation-controller.ts'
+    ])
+    expect(importersOf(ownerPaths.session)).toEqual([
+      'pages/workspace/WorkspacePage.tsx',
+      'pages/workspace/workspace-conversation-controller.ts'
+    ])
+    expect(importersOf(ownerPaths.conversation)).toEqual(['pages/workspace/WorkspacePage.tsx'])
+  })
+
+  it('keeps conversation command calls out of the page and behind injected ports', () => {
+    const pageSource = readSource(ownerPaths.page)
+    const conversationSource = readSource(ownerPaths.conversation)
+
+    expect(conversationCommandCalls(ownerPaths.page)).toEqual([])
+    expect(pageSource).toContain('conversation.actions.submit.draft')
+    expect(pageSource).toContain('conversation.actions.submit.restoredPlan')
+    expect(pageSource).toContain('conversation.actions.revise')
+    expect(pageSource).toContain('conversation.actions.resume')
+    expect(pageSource).toContain('conversation.actions.cancel')
+    expect(pageSource).toContain('conversation.actions.delete')
+    for (const directOwner of [
+      'window.api',
+      'useSessionStore',
+      'useReviewStore',
+      'useSettingsStore',
+      'useSpecialistStore'
+    ]) {
+      expect(conversationSource).not.toContain(directOwner)
+    }
+    for (const intent of ['submit:', 'revise:', 'resume:', 'cancel:', 'delete:']) {
+      expect(conversationSource).toContain(intent)
+    }
+  })
+
+  it('keeps Workspace runtime internals behind the public renderer facade', () => {
+    const workspaceSources = productionSourcePaths
+      .filter((path) => !relative(workspaceDirectory, path).startsWith('..'))
+      .map(readSource)
+      .join('\n')
+    const pageSource = readSource(ownerPaths.page)
+    const conversationSource = readSource(ownerPaths.conversation)
+
+    expect(pageSource).toContain("from '@/lib/acp/useWorkspaceAgentRuntime'")
+    expect(pageSource).toContain('const runtime = useWorkspaceAgentRuntime()')
+    expect(conversationSource).toContain(
+      "import type { WorkspaceAgentRuntime } from '@/lib/acp/useWorkspaceAgentRuntime'"
+    )
+    expect(workspaceSources).not.toMatch(
+      /from ['"][^'"]*workspace-runtime-(?:event|prompt|command|session)/
+    )
+  })
+
+  it('registers the complete owner boundary and this certification test', () => {
+    const manifest = JSON.parse(readSource(manifestPath)) as {
+      modules: { workspace_page: { ownerPaths: string[]; testFiles: { owner: string[] } } }
+    }
+    const workspacePage = manifest.modules.workspace_page
+
+    for (const ownerPath of Object.values(ownerPaths)) {
+      expect(workspacePage.ownerPaths).toContain(
+        relative(repositoryRoot, ownerPath).replaceAll('\\', '/')
+      )
+    }
+    expect(workspacePage.testFiles.owner).toContain(architectureTestPath)
+  })
+})


### PR DESCRIPTION
# Problem

The Workspace Page refactor now has stable Layout, Composer, Session and Conversation owners, but the
completion constraints existed only in the local plan. A later change could silently grow an owner past
its approved line gate, add a private-controller consumer, move conversation commands back into the
page, or bypass the public runtime facade.

# Proposed change

- Add a portable architecture certification test for the Workspace Page boundary.
- Register the test in the existing `workspace_page` module Test Impact Set.
- Consolidate the Composer value/type exports so the owner meets the 660-line hard gate.
- Refresh stale Page comments that still name the removed `sendCurrentMessage` helper.

```mermaid
flowchart LR
  Page["WorkspacePage <= 1200"] --> Layout["Layout <= 660"]
  Page --> Composer["Composer <= 660"]
  Page --> Session["Session <= 660"]
  Page --> Conversation["Conversation <= 660"]
  Conversation -. "injected ports" .-> Composer
  Conversation -. "injected ports" .-> Session
  Page --> Facade["public Workspace runtime facade"]
  Conversation -. "runtime port" .-> Facade
```

# Scope and non-goals

This is certification and residual cleanup only. It does not add another controller or hook, change
runtime behavior, complete any capability asymmetry, or refactor the underlying ACP runtime. The latest
Codex MCP permission-broker behavior on `main` remains untouched.

# Compatibility

There is no public API, IPC, persisted-data, data-relationship or user-interaction change. Electron,
Web and CLI retain their current behavior and capability boundaries. The test normalizes paths and uses
Node/TypeScript APIs so its assertions remain portable across Windows, macOS and Linux.

# Acceptance criteria and validation

Final evidence below ran after the last material edit:

- `npm run test:module -- workspace_page` — 22 files / 309 tests passed.
- `npm test -- --run scripts/ci/validate-module-impact.test.ts scripts/ci/module-test-impact.test.ts scripts/ci/module-impact-shadow.test.ts` — 3 files / 29 tests passed.
- `npm run typecheck:web` — passed.
- `npm run lint` — 0 errors; 17 pre-existing repository warnings.
- `git diff --check` — passed.
- Independent Standards review — 0 findings.
- Independent Spec review — 0 findings.

Measured physical lines: Page 972; Layout 468; Composer 660; Conversation 330; Session 559. The only
manifest edit adds `testFiles` to the already-owned `workspace_page` module, so CONTRIBUTING's
testFiles-only exemption applies and no local full fallback is required. Exact-head CI/AI remains the
authoritative cross-platform gate. Uncovered risk: the certification checks structural ownership, not
semantic equivalence of future runtime implementations; the existing focused behavior tests cover the
current user flows.

# Review focus

- Confirm the AST-based consumer and command checks lock architectural boundaries without coupling to
  implementation helper names.
- Confirm the allowed private-controller consumers match the intended Page/Conversation composition.
- Confirm the module-impact registration selects the certification test without widening the owner.
- Confirm the source edits are comment/export-only and preserve all runtime behavior.
