### PR TITLE
test(notebook): use local RPC transport in user input tests

### DIFF
--- a/src/main/notebook/local-rpc-server.user-input.test.ts
+++ b/src/main/notebook/local-rpc-server.user-input.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { fetchLocalRpc } from '../local-rpc-transport'
 import { NotebookLocalRpcServer } from './local-rpc-server'
+
+const fetchRpc = (
+  connection: { endpoint: string; socketPath?: string },
+  init: RequestInit
+): Promise<Response> => fetchLocalRpc(connection, init, 'Notebook user input RPC')
 
 describe('NotebookLocalRpcServer user input bridge', () => {
   let server: NotebookLocalRpcServer | undefined
@@ -18,7 +24,7 @@ describe('NotebookLocalRpcServer user input bridge', () => {
     const connection = await server.issueSessionConnection('pre-session-alias', 'project-1')
     server.registerSessionAlias('pre-session-alias', 'session-1')
 
-    const response = await fetch(connection.endpoint, {
+    const response = await fetchRpc(connection, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${connection.token}`,
@@ -78,7 +84,7 @@ describe('NotebookLocalRpcServer user input bridge', () => {
     })
     const connection = await server.issueSessionConnection('session-1', 'project-1')
 
-    const response = await fetch(connection.endpoint, {
+    const response = await fetchRpc(connection, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${connection.token}`,
@@ -109,7 +115,7 @@ describe('NotebookLocalRpcServer user input bridge', () => {
     })
     const connection = await server.ensureStarted()
 
-    const response = await fetch(connection.endpoint, {
+    const response = await fetchRpc(connection, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${connection.token}`,


### PR DESCRIPTION
## Problem

The Windows full-test run failed all three structured user-input RPC tests. Windows defaults Notebook local RPC to a named pipe, but these tests called the placeholder HTTP endpoint with global fetch, so their requests never used the connection socket path. This produced empty response bodies and an incorrect authorization status in CI.

Failure: https://github.com/aipoch/open-science/actions/runs/31282333266/job/93165556568

## Proposed change

Route the user-input test requests through the existing fetchLocalRpc helper. It selects the connection's named pipe on Windows and retains normal loopback HTTP on macOS and Linux.

## Scope and non-goals

- Changes only src/main/notebook/local-rpc-server.user-input.test.ts.
- Does not change production RPC, ACP, agent-framework, lifecycle, subscription, or user-interface behavior.
- Does not modify the module-impact manifest or unrelated Windows tests.

## Acceptance criteria and validation

All passing checks below ran after the last material edit.

- Session alias routing, pending acknowledgements, and server-token rejection over the Windows named-pipe path -> npm test -- src/main/notebook/local-rpc-server.user-input.test.ts -> 3 passed.
- Regression test plus module-impact manifest validation under CI timeout/worker settings -> npm test -- src/main/notebook/local-rpc-server.user-input.test.ts scripts/ci/validate-module-impact.test.ts --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000 -> 12 passed.
- Main and renderer TypeScript contracts -> npm run typecheck -> passed.
- Repository lint -> npm run lint -> passed with 0 errors and 17 warnings in unchanged files.

The complete portable suite was also attempted after the final edit: 861 files and 12,517 tests passed; 29 unrelated tests failed locally because this Windows environment cannot create required symbolic links or ACLs, cannot execute the Bash workflow fixtures, and hit one existing integration timeout. The changed test passed within that run. Exact-head PR CI remains authoritative for those uncovered environment-specific risks.

No production Interface changed, so no consumer or E2E lanes are required. The affected Windows platform path is covered directly because the focused tests ran on Windows with the default named-pipe transport.

## Review focus

- Confirm the tests use the same platform-aware local RPC transport as production clients.
- Confirm the helper preserves the existing response and capability assertions without broadening the change.
