### PR TITLE
fix(workspace): preserve thinking elapsed time

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx
@@ -14,14 +14,25 @@ let root: Root
 
 // A running session whose turn started `startedAgoMs` ago, optionally with a latest agent status line.
 const seedRunningSession = (startedAgoMs: number, agentStatus?: string): void => {
+  const startedAt = Date.now() - startedAgoMs
   const session: ChatSession = {
     id: 's1',
     projectId: 'p1',
     title: 's1',
     cwd: '/workspace',
     status: 'running',
-    messages: [],
-    activeRun: { promptMessageId: 'm1', startedAt: Date.now() - startedAgoMs },
+    messages: [
+      {
+        id: 'm1',
+        role: 'user',
+        content: 'Prompt',
+        status: 'complete',
+        eventIds: [],
+        createdAt: startedAt,
+        updatedAt: startedAt
+      }
+    ],
+    activeRun: { promptMessageId: 'm1', startedAt },
     agentStatus,
     createdAt: 0,
     updatedAt: 0
@@ -45,11 +56,11 @@ afterEach(() => {
 })
 
 describe('WorkspaceAgentLoadingRow', () => {
-  it('starts elapsed time when the indicator mounts', () => {
+  it('starts elapsed time from the Session timeline', () => {
     seedRunningSession(5000)
     act(() => root.render(<AgentLoadingIndicator sessionId="s1" phase="thinking" />))
 
-    expect(container.textContent).toContain('0:00')
+    expect(container.textContent).toContain('0:05')
     expect(container.textContent).toContain('Thinking')
     const indicator = container.querySelector('[data-testid="open-science-thinking-indicator"]')
     expect(indicator).not.toBeNull()
@@ -71,18 +82,11 @@ describe('WorkspaceAgentLoadingRow', () => {
     expect(statusRow?.classList.contains('text-text-300')).toBe(false)
   })
 
-  it('adds a "taking longer than usual" hint after the indicator stays visible', () => {
+  it('shows the slow hint when the Session has already been thinking long enough', () => {
     seedRunningSession(45_000)
     act(() => root.render(<AgentLoadingIndicator sessionId="s1" phase="thinking" />))
 
-    expect(container.textContent).toContain('0:00')
-    expect(container.textContent).not.toContain('taking longer than usual')
-
-    act(() => {
-      vi.advanceTimersByTime(21_000)
-    })
-
-    expect(container.textContent).toContain('0:21')
+    expect(container.textContent).toContain('0:45')
     expect(container.textContent).toContain('taking longer than usual')
   })
 
@@ -90,41 +94,39 @@ describe('WorkspaceAgentLoadingRow', () => {
     seedRunningSession(5000)
     act(() => root.render(<AgentLoadingIndicator sessionId="s1" phase="thinking" />))
 
-    expect(container.textContent).toContain('0:00')
+    expect(container.textContent).toContain('0:05')
 
     // The row ticks once a second; advancing the clock should move the label forward.
     act(() => {
       vi.advanceTimersByTime(3000)
     })
 
-    expect(container.textContent).toContain('0:03')
-    expect(container.textContent).not.toContain('0:00')
+    expect(container.textContent).toContain('0:08')
+    expect(container.textContent).not.toContain('0:05')
   })
 
   it('crosses into the "taking longer than usual" hint as time passes the threshold', () => {
-    // The active turn age does not count toward this mount's slow-hint threshold.
     seedRunningSession(18_000)
     act(() => root.render(<AgentLoadingIndicator sessionId="s1" phase="thinking" />))
 
-    expect(container.textContent).toContain('0:00')
+    expect(container.textContent).toContain('0:18')
     expect(container.textContent).not.toContain('taking longer than usual')
 
-    // Advance past 20s: the label keeps ticking and the slow hint appears.
     act(() => {
-      vi.advanceTimersByTime(21_000)
+      vi.advanceTimersByTime(3000)
     })
 
     expect(container.textContent).toContain('0:21')
     expect(container.textContent).toContain('taking longer than usual')
   })
 
-  it('resets elapsed time after the indicator unmounts and mounts again', () => {
+  it('keeps elapsed time after navigating away and returning', () => {
     seedRunningSession(45_000)
     act(() => root.render(<AgentLoadingIndicator sessionId="s1" phase="thinking" />))
     act(() => {
       vi.advanceTimersByTime(8000)
     })
-    expect(container.textContent).toContain('0:08')
+    expect(container.textContent).toContain('0:53')
 
     act(() => root.render(null))
     act(() => {
@@ -132,8 +134,39 @@ describe('WorkspaceAgentLoadingRow', () => {
       root.render(<AgentLoadingIndicator sessionId="s1" phase="thinking" />)
     })
 
-    expect(container.textContent).toContain('0:00')
-    expect(container.textContent).not.toContain('0:13')
+    expect(container.textContent).toContain('0:58')
+    expect(container.textContent).not.toContain('0:00')
+  })
+
+  it('keeps an independent elapsed time when switching Sessions', () => {
+    seedRunningSession(5000)
+    const firstSession = useSessionStore.getState().sessions[0]
+    useSessionStore.setState({
+      sessions: [
+        firstSession,
+        {
+          ...firstSession,
+          id: 's2',
+          title: 's2',
+          activeRun: { promptMessageId: 'm1', startedAt: Date.now() - 10_000 }
+        }
+      ]
+    })
+    act(() => root.render(<AgentLoadingIndicator sessionId="s1" phase="thinking" />))
+
+    expect(container.textContent).toContain('0:05')
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+      root.render(<AgentLoadingIndicator sessionId="s2" phase="thinking" />)
+    })
+    expect(container.textContent).toContain('0:12')
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+      root.render(<AgentLoadingIndicator sessionId="s1" phase="thinking" />)
+    })
+    expect(container.textContent).toContain('0:09')
   })
 
   it('surfaces the latest agent status line when present', () => {
@@ -176,17 +209,44 @@ describe('WorkspaceAgentLoadingRow', () => {
     act(() => {
       vi.advanceTimersByTime(8000)
     })
-    expect(container.textContent).toContain('0:08')
+    expect(container.textContent).toContain('0:53')
 
     act(() => root.render(<AgentLoadingIndicator sessionId="s1" phase="interacting-with-tools" />))
-    expect(container.textContent).not.toContain('0:08')
+    expect(container.textContent).not.toContain('0:53')
 
     act(() => {
       vi.advanceTimersByTime(5000)
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) =>
+          session.id === 's1'
+            ? {
+                ...session,
+                activities: [
+                  {
+                    id: 'tool-1',
+                    kind: 'tool',
+                    title: 'Read files',
+                    status: 'completed',
+                    eventIds: ['tool-event-1'],
+                    sortIndex: 2,
+                    promptMessageId: 'm1',
+                    createdAt: Date.now() - 1000,
+                    updatedAt: Date.now()
+                  }
+                ]
+              }
+            : session
+        )
+      }))
       root.render(<AgentLoadingIndicator sessionId="s1" phase="thinking" />)
     })
 
     expect(container.textContent).toContain('0:00')
-    expect(container.textContent).not.toContain('0:13')
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+
+    expect(container.textContent).toContain('0:03')
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.tsx
@@ -4,7 +4,7 @@ import { OpenScienceThinkingIndicator } from '@/components/OpenScienceThinkingIn
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { cn } from '@/lib/utils'
 import { useSessionStore } from '@/stores/session-store'
-import type { AgentLoadingPhase } from './agent-loading-message'
+import { getAgentThinkingStartedAt, type AgentLoadingPhase } from './agent-loading-message'
 
 type WorkspaceAgentLoadingRowProps = {
   sessionId: string
@@ -27,13 +27,11 @@ const formatElapsed = (ms: number): string => {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`
 }
 
-// Thinking owns only silent model waits. Keeping its timer in this phase-specific child resets the
-// elapsed time whenever tool interaction ends and Thinking mounts again.
 const ThinkingLoadingContent = ({ sessionId }: { sessionId: string }): React.JSX.Element => {
-  const status = useSessionStore(
-    (state) => state.sessions.find((session) => session.id === sessionId)?.agentStatus
+  const session = useSessionStore((state) =>
+    state.sessions.find((candidate) => candidate.id === sessionId)
   )
-  const [startedAt] = useState(() => Date.now())
+  const [mountedAt] = useState(() => Date.now())
   const [now, setNow] = useState(() => Date.now())
 
   // Tick once a second so the elapsed label stays live while the turn runs.
@@ -43,7 +41,7 @@ const ThinkingLoadingContent = ({ sessionId }: { sessionId: string }): React.JSX
     return () => clearInterval(timer)
   }, [])
 
-  const elapsedMs = now - startedAt
+  const elapsedMs = now - (getAgentThinkingStartedAt(session) ?? mountedAt)
   const slow = elapsedMs >= SLOW_HINT_AFTER_MS
 
   return (
@@ -56,9 +54,9 @@ const ThinkingLoadingContent = ({ sessionId }: { sessionId: string }): React.JSX
         </span>
         {slow ? <span aria-hidden="true">· taking longer than usual</span> : null}
       </div>
-      {status ? (
-        <span className="truncate text-[11px] text-text-000/70" title={status}>
-          {status}
+      {session?.agentStatus ? (
+        <span className="truncate text-[11px] text-text-000/70" title={session.agentStatus}>
+          {session.agentStatus}
         </span>
       ) : null}
     </>

--- a/src/renderer/src/pages/workspace/agent-loading-message.ts
+++ b/src/renderer/src/pages/workspace/agent-loading-message.ts
@@ -1,4 +1,4 @@
-import type { ChatSession } from '@/stores/session-store'
+import type { ChatMessage, ChatSession, ToolActivity } from '@/stores/session-store'
 import { isActivityActive } from './workspace-conversation-items'
 
 type TimelinePosition = {
@@ -19,6 +19,37 @@ const findLatest = <T extends TimelinePosition>(items: T[]): T | undefined =>
     undefined
   )
 
+const getCurrentRunTimeline = (
+  session: ChatSession
+): { prompt: ChatMessage | undefined; tools: ToolActivity[] } => {
+  const latestUserPromptId = session.messages.findLast((message) => message.role === 'user')?.id
+  const promptMessageId = session.activeRun?.promptMessageId ?? latestUserPromptId
+  const prompt = promptMessageId
+    ? session.messages.find((message) => message.id === promptMessageId)
+    : undefined
+  const tools = (session.activities ?? []).filter((activity) => {
+    if (!promptMessageId || !prompt) return false
+    return activity.promptMessageId
+      ? activity.promptMessageId === promptMessageId
+      : isLaterThan(activity, prompt)
+  })
+
+  return { prompt, tools }
+}
+
+// Uses timeline-owned timestamps so navigating away from a live Session cannot restart its clock.
+// A terminal tool update begins the next silent thinking span, matching the visible phase change.
+const getAgentThinkingStartedAt = (session: ChatSession | undefined): number | undefined => {
+  if (!session) return undefined
+
+  const { prompt, tools } = getCurrentRunTimeline(session)
+  const latestTool = findLatest(tools)
+  const runStartedAt = session.activeRun?.startedAt ?? prompt?.createdAt
+
+  if (runStartedAt === undefined) return latestTool?.updatedAt
+  return Math.max(runStartedAt, latestTool?.updatedAt ?? runStartedAt)
+}
+
 // The transient row belongs to the active request, not persisted history. Text output owns the
 // transcript, while tool activity and the silent gaps around it use their own indicator phases.
 const getAgentLoadingPhase = (session: ChatSession | undefined): AgentLoadingPhase => {
@@ -29,17 +60,8 @@ const getAgentLoadingPhase = (session: ChatSession | undefined): AgentLoadingPha
     (session.status === 'running' || session.status === 'waiting-permission')
   if (!hasLocalRun && !session.agentPromptInFlight) return 'hidden'
 
-  const latestUserPromptId = session.messages.findLast((message) => message.role === 'user')?.id
-  const promptMessageId = session.activeRun?.promptMessageId ?? latestUserPromptId
-  const prompt = promptMessageId
-    ? session.messages.find((message) => message.id === promptMessageId)
-    : undefined
-  const currentRunTools = (session.activities ?? []).filter((activity) => {
-    if (!promptMessageId || !prompt) return false
-    return activity.promptMessageId
-      ? activity.promptMessageId === promptMessageId
-      : isLaterThan(activity, prompt)
-  })
+  const { prompt, tools: currentRunTools } = getCurrentRunTimeline(session)
+  const promptMessageId = session.activeRun?.promptMessageId ?? prompt?.id
 
   // Any live tool in the current request takes precedence over the surrounding thinking gaps.
   if (currentRunTools.some(isActivityActive)) return 'interacting-with-tools'
@@ -69,5 +91,5 @@ const getAgentLoadingPhase = (session: ChatSession | undefined): AgentLoadingPha
   return latestTool && isLaterThan(latestTool, latestVisibleOutput) ? 'thinking' : 'hidden'
 }
 
-export { getAgentLoadingPhase }
+export { getAgentLoadingPhase, getAgentThinkingStartedAt }
 export type { AgentLoadingPhase }


### PR DESCRIPTION
## Problem

The Thinking indicator owned its elapsed-time origin in component-local React state. Switching Sessions or returning to Home unmounted the row, so an in-progress thinking span restarted at 0:00 when the user returned.

## Proposed change

Derive the Thinking clock origin from Session timeline data that survives view remounts:

- use the active run start for the initial silent wait;
- use the latest current-run tool terminal timestamp when Thinking resumes after tool interaction;
- retain the mount timestamp only as a fallback when no Session timeline timestamp exists.

Regression coverage now exercises navigation away and back, switching between live Sessions, slow-hint timing, and the fresh timer after tool interaction.

## Scope and non-goals

- Renderer-only timing derivation and tests.
- No persistence schema, Session data model, ACP protocol, adapter, launcher, model, or runtime lifecycle changes.
- No change to the existing rule that a new Thinking phase after tool interaction starts a fresh clock.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Thinking clock continuity across remounts and Session switches -> npm test -- src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx src/renderer/src/pages/workspace/agent-loading-message.test.ts -> 2 files passed, 23 tests passed.
- Renderer and shared TypeScript contracts -> npm run typecheck -> passed for Node and Web.
- Repository lint policy -> npm run lint -- --no-cache -> passed with 0 errors; 17 pre-existing warnings outside the changed files.
- Formatting of changed files -> npx prettier --check on the three changed files -> passed.
- Fail-closed Test Impact Set for the unregistered renderer view owner -> npm test -> 867 files passed, 14 skipped; 12,638 tests passed, 190 skipped.

Platform scope: the final suite ran on macOS. No platform-specific path, process, packaging, or OS behavior changed, so additional local platform lanes were excluded. UI E2E was not run because the deterministic renderer tests directly own the timer behavior; PR Gate remains authoritative for required CI lanes.

## Review focus

Please focus on whether the timestamp precedence in getAgentThinkingStartedAt preserves both invariants: navigation cannot reset a live thinking span, and a completed current-run tool begins the next thinking span.