### PR TITLE
test(compute): define service impact boundary

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -121,6 +121,31 @@
       "capabilityOverlays": ["renderer_state"],
       "fallbackCapability": "renderer_view"
     },
+    "compute_service": {
+      "ownerPaths": ["src/main/compute/compute-service.ts"],
+      "interfacePaths": ["src/main/compute/compute-service.ts"],
+      "consumerModules": [],
+      "testFiles": {
+        "owner": [
+          "src/main/compute/compute-service.test.ts",
+          "src/main/compute/compute-jobs.integration.test.ts",
+          "src/main/compute/concurrency-integration.test.ts"
+        ],
+        "contract": [
+          "src/main/compute/ssh-runner.test.ts",
+          "src/main/compute/ipc.test.ts",
+          "src/main/compute/application-commands.test.ts",
+          "src/main/notebook/local-rpc-server.mcpcall.test.ts",
+          "src/main/notebook/local-rpc-server.test.ts"
+        ],
+        "consumer": [
+          "src/main/compute/job-runtime.test.ts",
+          "src/main/compute/enabled-hosts-registry.test.ts"
+        ]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
     "artifact_storage": {
       "ownerPaths": [
         "src/main/artifacts/compatibility-owner.ts",

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -35,6 +35,21 @@ describe('module test impact commands', () => {
     expect(() => createModuleTestPlan('unknown_module')).toThrow('Unknown module: unknown_module')
   })
 
+  it('builds the Compute service contract and fallback plan', () => {
+    const plan = createModuleTestPlan('compute_service')
+
+    expect(plan.testFiles).toEqual(
+      expect.arrayContaining([
+        'src/main/compute/compute-service.test.ts',
+        'src/main/compute/ssh-runner.test.ts',
+        'src/main/compute/ipc.test.ts',
+        'src/main/notebook/local-rpc-server.mcpcall.test.ts'
+      ])
+    )
+    expect(plan.capabilityOverlays).toEqual(['windows_sensitive'])
+    expect(plan.fallbackCapabilities).toEqual(['main_runtime'])
+  })
+
   it('expands changed owners through consumer modules and graph candidates', () => {
     const plan = createAffectedTestPlan(
       [{ path: 'src/main/artifacts/repository.ts', status: 'modified' }],

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -553,6 +553,126 @@ describe('computeCall RPC', () => {
     expect(body.error).toMatch(/unknown details mode/i)
   })
 
+  it('routes computeCall op=submit_job with canonical arguments and trusted context', async () => {
+    const captured: unknown[] = []
+    const fakeJob = { job_id: 'job-42', status: 'queued' }
+    const fakeCompute = {
+      submitJob: async (...args: unknown[]) => {
+        captured.push(...args)
+        return fakeJob
+      }
+    }
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      computeService: fakeCompute as never
+    })
+    const { endpoint, token } = await sessionConnection(server)
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        method: 'computeCall',
+        params: {
+          op: 'submit_job',
+          provider_id: 'ssh:biowulf',
+          intent: 'analyze data',
+          command: 'python analyze.py',
+          environment: 'module load python',
+          resources: { cpus: 4, memory_gb: 16 },
+          inputs: ['data/input.csv'],
+          outputs: [{ path: 'results.csv', featured: true }],
+          harvest: { mode: 'manifest' },
+          timeout_seconds: 600,
+          workspace_cwd: 'workspace/project',
+          session_id: 'forged-session',
+          project_id: 'forged-project'
+        }
+      })
+    })
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ result: fakeJob })
+    expect(captured).toEqual([
+      'ssh:biowulf',
+      'analyze data',
+      'python analyze.py',
+      {
+        environment: 'module load python',
+        resourceRequest: JSON.stringify({ cpus: 4, memory_gb: 16 }),
+        inputs: ['data/input.csv'],
+        outputManifest: JSON.stringify([{ path: 'results.csv', featured: true }]),
+        harvestConfig: JSON.stringify({ mode: 'manifest' }),
+        timeoutSeconds: 600,
+        workspaceCwd: 'workspace/project'
+      },
+      { sessionId: 's-42', projectId: 'project-1' }
+    ])
+  })
+
+  it('serializes submit_job compute call errors', async () => {
+    const submitErr = new Error('approval denied') as Error & { computeCallError: unknown }
+    submitErr.computeCallError = {
+      error_code: 'approval_denied',
+      message: 'Approval denied.',
+      retry_after_user_action: false
+    }
+    const fakeCompute = {
+      submitJob: async () => {
+        throw submitErr
+      }
+    }
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      computeService: fakeCompute as never
+    })
+    const { endpoint, token } = await sessionConnection(server)
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        method: 'computeCall',
+        params: {
+          op: 'submit_job',
+          provider_id: 'ssh:biowulf',
+          intent: 'analyze data',
+          command: 'python analyze.py'
+        }
+      })
+    })
+
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { error: string }
+    expect(JSON.parse(body.error)).toEqual(submitErr.computeCallError)
+  })
+
+  it('routes computeCall op=job_status to the compute service', async () => {
+    const fakeStatus = { job_id: 'job-42', status: 'running' }
+    const seenJobIds: string[] = []
+    const fakeCompute = {
+      getJobStatus: async (jobId: string) => {
+        seenJobIds.push(jobId)
+        return fakeStatus
+      }
+    }
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      computeService: fakeCompute as never
+    })
+    const { endpoint, token } = await sessionConnection(server)
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        method: 'computeCall',
+        params: { op: 'job_status', job_id: 'job-42' }
+      })
+    })
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ result: fakeStatus })
+    expect(seenJobIds).toEqual(['job-42'])
+  })
+
   it('routes computeCall op=job_result to getJobResult', async () => {
     const fakeResult = {
       job_id: 'job-42',


### PR DESCRIPTION
# Problem

`ComputeService` has broad behavior coverage but was not represented in the repository module-impact
manifest. Refactoring it without an explicit owner, contract, consumer, platform overlay and fallback
set would make focused local validation incomplete whenever CodeGraph is unavailable or stale.

# Proposed change

- Register `compute_service` with `compute-service.ts` as the current owner and interface.
- Declare the existing service, SSH probe, IPC/application-command, Notebook local-RPC and job-runtime
  tests as its focused Test Impact Set.
- Add an explicit plan assertion for the `windows_sensitive` overlay and `main_runtime` fallback.
- Characterize the previously uncovered Session-bound `submit_job` and `job_status` RPC operations,
  including canonical argument projection, trusted session/project context and structured submit
  errors.

# Scope and non-goals

This PR changes only test and CI-impact configuration. It does not change production code, extract an
owner, alter a schema, add a capability or begin the C1 host-profile cutover. It also does not broaden
the CLI/Task surface.

# Compatibility

Public types, persisted data, IPC channel names and payloads, UI behavior and application commands are
unchanged. Electron/local Web retain the current Compute surface; remote Web continues to reject
download and reveal-in-folder; Session-bound local RPC retains its current operations and trusted
context binding; CLI/Task receives no new direct management API. Test paths are repository-relative
and portable across Windows, macOS and Linux.

# Acceptance criteria and validation

- `npm run test:module -- compute_service`: 9 files passed, 1 platform-skipped; 284 tests passed, 5
  skipped.
- Manifest validation/shadow/plan tests: 3 files and 30 tests passed.
- `npm run typecheck`: passed for Node and Web.
- `npm run lint`: 0 errors; 17 pre-existing repository warnings.
- Prettier and `git diff --check`: passed.
- Full `npm test`: 12,639 tests passed and 190 skipped; two unrelated fixed-15-second tests timed out
  only under full local concurrency. Their exact files passed in isolation (2 files, 32 tests).
- Standards re-review: 0 findings. Spec re-review: 0 findings.
- Exact-head online CI and AI review remain authoritative before squash merge.

# Review focus

- Does the declared set cover the stable Compute facade and every current adapter without selecting
  the entire Compute directory?
- Are `windows_sensitive` and `main_runtime` the correct conservative overlay/fallback?
- Do the new local-RPC cases lock existing behavior without introducing production behavior?
- Did the PR remain production-neutral and preserve all cross-surface capability asymmetries?
