### PR TITLE
refactor(compute): extract host profile owner

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -122,11 +122,15 @@
       "fallbackCapability": "renderer_view"
     },
     "compute_service": {
-      "ownerPaths": ["src/main/compute/compute-service.ts"],
+      "ownerPaths": [
+        "src/main/compute/compute-host-profile-owner.ts",
+        "src/main/compute/compute-service.ts"
+      ],
       "interfacePaths": ["src/main/compute/compute-service.ts"],
       "consumerModules": [],
       "testFiles": {
         "owner": [
+          "src/main/compute/compute-host-profile-owner.test.ts",
           "src/main/compute/compute-service.test.ts",
           "src/main/compute/compute-jobs.integration.test.ts",
           "src/main/compute/concurrency-integration.test.ts"

--- a/src/main/compute/compute-host-profile-owner.test.ts
+++ b/src/main/compute/compute-host-profile-owner.test.ts
@@ -1,0 +1,632 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ComputeHost } from '../../shared/compute'
+import { ComputeHostProfileOwner, parseProbeOutput } from './compute-host-profile-owner'
+import type { ComputeHostRepository } from './repository'
+import type { ResolvedSshTarget, SshRunner } from './ssh-runner'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const sampleHost = (overrides: Partial<ComputeHost> = {}): ComputeHost => ({
+  id: 'host-1',
+  providerId: 'ssh:biowulf',
+  displayName: 'biowulf',
+  shape: 'direct_ssh',
+  sshAlias: 'biowulf',
+  sshOverrides: undefined,
+  scratchRoot: undefined,
+  scratchPinned: false,
+  concurrencyLimit: undefined,
+  probeResult: undefined,
+  detailsDoc: '',
+  detailsUpdatedAt: undefined,
+  detailsUpdatedBy: undefined,
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+// A fake target returned by the real resolveSshTarget helper — tests bypass that step by mocking the
+// entire runner (which already has the target baked in).
+const fakeTarget: ResolvedSshTarget = {
+  sshBinary: '/usr/bin/ssh',
+  host: 'biowulf.nih.gov',
+  extraArgs: ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=10']
+}
+
+// Minimal fake runner — always resolves with a success result by default.
+const makeFakeRunner = (result: Awaited<ReturnType<SshRunner['run']>>): SshRunner => ({
+  run: vi.fn(() => Promise.resolve(result))
+})
+
+// Minimal repository double.
+const makeRepo = (
+  host: ComputeHost | null = sampleHost()
+): {
+  repo: ComputeHostRepository
+  updateProbeResult: ReturnType<typeof vi.fn>
+  updateScratchRoot: ReturnType<typeof vi.fn>
+  updateDetails: ReturnType<typeof vi.fn>
+  updateScratchPinned: ReturnType<typeof vi.fn>
+  updateConcurrencyLimit: ReturnType<typeof vi.fn>
+} => {
+  const updateProbeResult = vi.fn(() => Promise.resolve())
+  const updateScratchRoot = vi.fn(() => Promise.resolve())
+  const updateDetails = vi.fn(() => Promise.resolve())
+  const updateScratchPinned = vi.fn(() => Promise.resolve())
+  const updateConcurrencyLimit = vi.fn(() => Promise.resolve())
+  const repo: ComputeHostRepository = {
+    get: vi.fn(() => Promise.resolve(host)),
+    list: vi.fn(() => Promise.resolve([])),
+    create: vi.fn(),
+    delete: vi.fn(),
+    updateProbeResult,
+    updateScratchRoot,
+    updateDetails,
+    updateScratchPinned,
+    updateConcurrencyLimit
+  } as unknown as ComputeHostRepository
+  return {
+    repo,
+    updateProbeResult,
+    updateScratchRoot,
+    updateDetails,
+    updateScratchPinned,
+    updateConcurrencyLimit
+  }
+}
+
+// A successful probe script output representing a Linux slurm cluster.
+const SLURM_STDOUT = [
+  'os=Linux',
+  'cpus=64',
+  'mem_mib=256000',
+  'gpus=Tesla V100 SXM2 32GB;Tesla V100 SXM2 32GB;',
+  'sbatch=yes',
+  'qsub=no',
+  'bsub=no',
+  'scratch=/gpfs/scratch/user123'
+].join('\n')
+
+// ---------------------------------------------------------------------------
+// parseProbeOutput — pure function tests
+// ---------------------------------------------------------------------------
+
+describe('parseProbeOutput', () => {
+  it('parses a complete slurm linux output', () => {
+    const result = parseProbeOutput(SLURM_STDOUT)
+    expect(result.os).toBe('Linux')
+    expect(result.cpus).toBe(64)
+    expect(result.memMib).toBe(256000)
+    expect(result.gpus).toEqual([{ type: 'Tesla V100 SXM2 32GB', count: 2 }])
+    expect(result.detectedScheduler).toBe('slurm')
+    expect(result.scratchEnv).toBe('/gpfs/scratch/user123')
+  })
+
+  it('detects PBS (qsub) scheduler', () => {
+    const out = 'os=Linux\ncpus=8\nmem_mib=32000\ngpus=\nsbatch=no\nqsub=yes\nbsub=no\nscratch='
+    const result = parseProbeOutput(out)
+    expect(result.detectedScheduler).toBe('pbs')
+  })
+
+  it('detects LSF (bsub) scheduler', () => {
+    const out = 'os=Linux\ncpus=8\nmem_mib=32000\ngpus=\nsbatch=no\nqsub=no\nbsub=yes\nscratch='
+    const result = parseProbeOutput(out)
+    expect(result.detectedScheduler).toBe('lsf')
+  })
+
+  it('returns none when no scheduler is detected', () => {
+    const out = 'os=Darwin\ncpus=16\nmem_mib=65536\ngpus=\nsbatch=no\nqsub=no\nbsub=no\nscratch='
+    const result = parseProbeOutput(out)
+    expect(result.detectedScheduler).toBe('none')
+  })
+
+  it('handles empty GPU list gracefully', () => {
+    const out = 'os=Linux\ncpus=4\nmem_mib=8000\ngpus=\nsbatch=no\nqsub=no\nbsub=no\nscratch='
+    const result = parseProbeOutput(out)
+    expect(result.gpus).toEqual([])
+  })
+
+  it('leaves undefined for missing / non-numeric cpus and mem', () => {
+    const result = parseProbeOutput('os=Linux\ngpus=\nsbatch=no\nqsub=no\nbsub=no\nscratch=')
+    expect(result.cpus).toBeUndefined()
+    expect(result.memMib).toBeUndefined()
+  })
+
+  it('ignores lines without an equals sign', () => {
+    const result = parseProbeOutput('this is garbage\nos=Linux\ncpus=4\n')
+    expect(result.os).toBe('Linux')
+    expect(result.cpus).toBe(4)
+  })
+
+  it('leaves scratchEnv undefined when the env var is empty', () => {
+    const out = 'os=Linux\ncpus=8\nmem_mib=16000\ngpus=\nsbatch=no\nqsub=no\nbsub=no\nscratch='
+    const result = parseProbeOutput(out)
+    expect(result.scratchEnv).toBeUndefined()
+  })
+
+  it('aggregates multiple identical GPU models into one entry', () => {
+    const out = 'gpus=A100 80GB;A100 80GB;A100 80GB;\nsbatch=no\nqsub=no\nbsub=no\nscratch='
+    const result = parseProbeOutput(out)
+    expect(result.gpus).toEqual([{ type: 'A100 80GB', count: 3 }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComputeHostProfileOwner.probe — integration with fake SshRunner
+// ---------------------------------------------------------------------------
+
+// We use vi.mock for resolveSshTarget so the tests don't spawn ssh.
+vi.mock('./ssh-runner', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('./ssh-runner')>()
+  return {
+    ...orig,
+    resolveSshTarget: vi.fn(() => Promise.resolve(fakeTarget))
+  }
+})
+
+describe('ComputeHostProfileOwner.probe', () => {
+  it('returns ok:true and persists probeResult + shape on a successful probe', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: SLURM_STDOUT,
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo, updateProbeResult, updateScratchRoot } = makeRepo()
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    const result = await service.probe('ssh:biowulf')
+
+    expect(result.ok).toBe(true)
+    expect(result.exitCode).toBe(0)
+    expect(result.cpus).toBe(64)
+    expect(result.detectedScheduler).toBe('slurm')
+    expect(updateProbeResult).toHaveBeenCalledWith(
+      'ssh:biowulf',
+      expect.objectContaining({ ok: true, cpus: 64 }),
+      'scheduler_cluster'
+    )
+    // scratchRoot should be set because scratchPinned=false and scratch is provided.
+    expect(updateScratchRoot).toHaveBeenCalledWith('ssh:biowulf', '/gpfs/scratch/user123')
+  })
+
+  it('returns ok:false and maps exit 255 to host_unreachable (connection failure)', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 255,
+      stdout: '',
+      stderr: 'ssh: connect to host biowulf.nih.gov port 22: Connection refused',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo, updateProbeResult, updateScratchRoot } = makeRepo()
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    const result = await service.probe('ssh:biowulf')
+
+    expect(result.ok).toBe(false)
+    expect(result.exitCode).toBe(255)
+    expect(result.errorTail).toContain('Connection refused')
+    expect(updateProbeResult).toHaveBeenCalledWith(
+      'ssh:biowulf',
+      expect.objectContaining({ ok: false }),
+      'direct_ssh'
+    )
+    expect(updateScratchRoot).not.toHaveBeenCalled()
+  })
+
+  it('returns ok:false on timeout and sets timedOut flag', async () => {
+    const runner = makeFakeRunner({
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: true
+    })
+    const { repo, updateProbeResult } = makeRepo()
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    const result = await service.probe('ssh:biowulf')
+
+    expect(result.ok).toBe(false)
+    expect(updateProbeResult).toHaveBeenCalledWith(
+      'ssh:biowulf',
+      expect.objectContaining({ ok: false }),
+      'direct_ssh'
+    )
+  })
+
+  it('probes ok but detectedScheduler=none → shape=direct_ssh', async () => {
+    const stdout = [
+      'os=Darwin',
+      'cpus=16',
+      'mem_mib=32000',
+      'gpus=',
+      'sbatch=no',
+      'qsub=no',
+      'bsub=no',
+      'scratch='
+    ].join('\n')
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout,
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo, updateProbeResult } = makeRepo()
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    const result = await service.probe('ssh:biowulf')
+
+    expect(result.ok).toBe(true)
+    expect(result.detectedScheduler).toBe('none')
+    expect(updateProbeResult).toHaveBeenCalledWith(
+      'ssh:biowulf',
+      expect.objectContaining({ ok: true }),
+      'direct_ssh'
+    )
+  })
+
+  it('does NOT update scratchRoot when scratchPinned=true', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: SLURM_STDOUT,
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const pinnedHost = sampleHost({ scratchPinned: true, scratchRoot: '/my/custom/scratch' })
+    const { repo, updateScratchRoot } = makeRepo(pinnedHost)
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    await service.probe('ssh:biowulf')
+
+    expect(updateScratchRoot).not.toHaveBeenCalled()
+  })
+
+  it('does NOT update scratchRoot when $SCRATCH is empty', async () => {
+    const stdout = 'os=Linux\ncpus=8\nmem_mib=16000\ngpus=\nsbatch=no\nqsub=no\nbsub=no\nscratch='
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout,
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo, updateScratchRoot } = makeRepo()
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    await service.probe('ssh:biowulf')
+
+    expect(updateScratchRoot).not.toHaveBeenCalled()
+  })
+
+  it('does NOT write detailsDoc', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: SLURM_STDOUT,
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo, updateProbeResult } = makeRepo()
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    await service.probe('ssh:biowulf')
+
+    // Verify that probeResult is the only "content" written.
+    const probeCall = updateProbeResult.mock.calls[0]
+    const writtenResult = probeCall?.[1] as Record<string, unknown>
+    expect(Object.keys(writtenResult)).not.toContain('detailsDoc')
+  })
+
+  it('throws when the host does not exist', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo } = makeRepo(null)
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    await expect(service.probe('ssh:nonexistent')).rejects.toThrow(/not found|no compute host/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComputeHostProfileOwner.getDetails — skeleton synthesis and pass-through
+// ---------------------------------------------------------------------------
+
+describe('ComputeHostProfileOwner.getDetails', () => {
+  const fakeRunner = makeFakeRunner({
+    exitCode: 0,
+    stdout: '',
+    stderr: '',
+    truncated: false,
+    timedOut: false
+  })
+
+  it('returns detailsDoc as-is when it is non-empty', async () => {
+    const { repo } = makeRepo(sampleHost({ detailsDoc: '## Resources\ncpus: 8' }))
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    const result = await service.getDetails('ssh:biowulf')
+    expect(result.doc).toBe('## Resources\ncpus: 8')
+    expect(result.isSkeleton).toBe(false)
+  })
+
+  it('returns a skeleton from probeResult when detailsDoc is empty', async () => {
+    const probeResult = {
+      ok: true,
+      probedAt: '2026-01-01T00:00:00Z',
+      exitCode: 0,
+      errorTail: null,
+      cpus: 64,
+      memMib: 256000,
+      gpus: [{ type: 'A100 80GB', count: 2 }],
+      detectedScheduler: 'slurm' as const
+    }
+    const { repo } = makeRepo(sampleHost({ detailsDoc: '', probeResult }))
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    const result = await service.getDetails('ssh:biowulf')
+    expect(result.isSkeleton).toBe(true)
+    expect(result.doc).toContain('## Resources')
+    expect(result.doc).toContain('cpus:')
+    expect(result.doc).toContain('mem:')
+    expect(result.doc).toContain('gpus:')
+    expect(result.doc).toContain('scheduler:')
+  })
+
+  it('returns a skeleton with only available fields when some are missing', async () => {
+    const probeResult = {
+      ok: true,
+      probedAt: '2026-01-01T00:00:00Z',
+      exitCode: 0,
+      errorTail: null,
+      cpus: 8
+    }
+    const { repo } = makeRepo(sampleHost({ detailsDoc: '', probeResult }))
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    const result = await service.getDetails('ssh:biowulf')
+    expect(result.isSkeleton).toBe(true)
+    expect(result.doc).toContain('cpus: 8')
+    expect(result.doc).not.toContain('gpus:')
+    expect(result.doc).not.toContain('mem:')
+  })
+
+  it('returns empty string with isSkeleton=false when no probeResult and detailsDoc is empty', async () => {
+    const { repo } = makeRepo(sampleHost({ detailsDoc: '', probeResult: undefined }))
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    const result = await service.getDetails('ssh:biowulf')
+    expect(result.doc).toBe('')
+    expect(result.isSkeleton).toBe(false)
+  })
+
+  it('throws when the host does not exist', async () => {
+    const { repo } = makeRepo(null)
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await expect(service.getDetails('ssh:nonexistent')).rejects.toThrow(
+      /not found|no compute host/i
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComputeHostProfileOwner.replaceDetails — old_text guard and persistence
+// ---------------------------------------------------------------------------
+
+describe('ComputeHostProfileOwner.replaceDetails', () => {
+  const fakeRunner = makeFakeRunner({
+    exitCode: 0,
+    stdout: '',
+    stderr: '',
+    truncated: false,
+    timedOut: false
+  })
+
+  it('replaces matching text and persists with author=user', async () => {
+    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: 'hello world' }))
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await service.replaceDetails('ssh:biowulf', {
+      text: 'hello friend',
+      oldText: 'hello world',
+      author: 'user'
+    })
+    expect(updateDetails).toHaveBeenCalledWith('ssh:biowulf', 'hello friend', 'user')
+  })
+
+  it('returns error and does not write when oldText does not match', async () => {
+    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: 'hello world' }))
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await expect(
+      service.replaceDetails('ssh:biowulf', {
+        text: 'something',
+        oldText: 'not present',
+        author: 'user'
+      })
+    ).rejects.toThrow(/not found|does not match|old_text/i)
+    expect(updateDetails).not.toHaveBeenCalled()
+  })
+
+  it('rejects when resulting doc exceeds 32768 characters', async () => {
+    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: 'short' }))
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    const bigText = 'x'.repeat(32769)
+    await expect(
+      service.replaceDetails('ssh:biowulf', { text: bigText, oldText: 'short', author: 'user' })
+    ).rejects.toThrow(/32768|too long|limit/i)
+    expect(updateDetails).not.toHaveBeenCalled()
+  })
+
+  it('works with author=agent', async () => {
+    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: 'original text' }))
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await service.replaceDetails('ssh:biowulf', {
+      text: 'new text',
+      oldText: 'original text',
+      author: 'agent'
+    })
+    expect(updateDetails).toHaveBeenCalledWith('ssh:biowulf', 'new text', 'agent')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComputeHostProfileOwner.setScratchRoot — sets scratchPinned=true
+// ---------------------------------------------------------------------------
+
+describe('ComputeHostProfileOwner.setScratchRoot', () => {
+  const fakeRunner = makeFakeRunner({
+    exitCode: 0,
+    stdout: '',
+    stderr: '',
+    truncated: false,
+    timedOut: false
+  })
+
+  it('sets scratch root and marks pinned', async () => {
+    const { repo, updateScratchPinned } = makeRepo()
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await service.setScratchRoot('ssh:biowulf', '/my/scratch')
+    expect(updateScratchPinned).toHaveBeenCalledWith('ssh:biowulf', '/my/scratch')
+  })
+
+  it('throws when the host does not exist', async () => {
+    const { repo } = makeRepo(null)
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await expect(service.setScratchRoot('ssh:nonexistent', '/path')).rejects.toThrow(
+      /not found|no compute host/i
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComputeHostProfileOwner.setConcurrencyLimit — validates 1..500
+// ---------------------------------------------------------------------------
+
+describe('ComputeHostProfileOwner.setConcurrencyLimit', () => {
+  const fakeRunner = makeFakeRunner({
+    exitCode: 0,
+    stdout: '',
+    stderr: '',
+    truncated: false,
+    timedOut: false
+  })
+
+  it('persists a valid concurrency limit', async () => {
+    const { repo, updateConcurrencyLimit } = makeRepo()
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await service.setConcurrencyLimit('ssh:biowulf', 10)
+    expect(updateConcurrencyLimit).toHaveBeenCalledWith('ssh:biowulf', 10)
+  })
+
+  it('rejects 0 (below minimum)', async () => {
+    const { repo } = makeRepo()
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await expect(service.setConcurrencyLimit('ssh:biowulf', 0)).rejects.toThrow(
+      /1.*500|range|invalid/i
+    )
+  })
+
+  it('rejects 501 (above maximum)', async () => {
+    const { repo } = makeRepo()
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await expect(service.setConcurrencyLimit('ssh:biowulf', 501)).rejects.toThrow(
+      /1.*500|range|invalid/i
+    )
+  })
+
+  it('accepts the boundary values 1 and 500', async () => {
+    const { repo, updateConcurrencyLimit } = makeRepo()
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await service.setConcurrencyLimit('ssh:biowulf', 1)
+    await service.setConcurrencyLimit('ssh:biowulf', 500)
+    expect(updateConcurrencyLimit).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws when the host does not exist', async () => {
+    const { repo } = makeRepo(null)
+    const service = new ComputeHostProfileOwner(fakeRunner, repo)
+    await expect(service.setConcurrencyLimit('ssh:nonexistent', 10)).rejects.toThrow(
+      /not found|no compute host/i
+    )
+  })
+})
+// ---------------------------------------------------------------------------
+// ComputeHostProfileOwner.appendDetails — issue 06
+// ---------------------------------------------------------------------------
+
+describe('ComputeHostProfileOwner.appendDetails', () => {
+  it('appends text to an empty doc', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: '' }))
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    await service.appendDetails('ssh:biowulf', { text: '## Note\nhello', author: 'agent' })
+
+    expect(updateDetails).toHaveBeenCalledWith('ssh:biowulf', '## Note\nhello', 'agent')
+  })
+
+  it('appends text with a newline separator when doc is non-empty', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: '## Resources\ncpus: 4' }))
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    await service.appendDetails('ssh:biowulf', { text: '## Note\nhello', author: 'agent' })
+
+    expect(updateDetails).toHaveBeenCalledWith(
+      'ssh:biowulf',
+      '## Resources\ncpus: 4\n## Note\nhello',
+      'agent'
+    )
+  })
+
+  it('throws when the appended doc would exceed 32KB', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const bigDoc = 'x'.repeat(32760)
+    const { repo } = makeRepo(sampleHost({ detailsDoc: bigDoc }))
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    await expect(
+      service.appendDetails('ssh:biowulf', { text: 'overflow', author: 'agent' })
+    ).rejects.toThrow(/32768|characters or fewer/i)
+  })
+
+  it('throws when host is not found', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo } = makeRepo(null)
+    const service = new ComputeHostProfileOwner(runner, repo)
+
+    await expect(
+      service.appendDetails('ssh:ghost', { text: 'hello', author: 'agent' })
+    ).rejects.toThrow(/no compute host found/i)
+  })
+})

--- a/src/main/compute/compute-host-profile-owner.ts
+++ b/src/main/compute/compute-host-profile-owner.ts
@@ -1,0 +1,233 @@
+import type { DetailsAuthor, ProbeResult } from '../../shared/compute'
+import { DETAILS_DOC_MAX_LENGTH } from '../../shared/compute'
+import type { ComputeHostRepository } from './repository'
+import type { SshRunner } from './ssh-runner'
+import { resolveSshTarget } from './ssh-runner'
+
+const PROBE_TIMEOUT_MS = 30_000
+const PROBE_MAX_OUTPUT_BYTES = 4 * 1024
+
+const PROBE_SCRIPT = [
+  'echo "os=$(uname -s 2>/dev/null)"',
+  'echo "cpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo)"',
+  'echo "mem_mib=$(free -m 2>/dev/null | awk \'NR==2{print $2}\' || echo $(( $(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1048576 )))"',
+  "echo \"gpus=$(nvidia-smi -L 2>/dev/null | grep -oP 'GPU \\d+: \\K[^(]+' | tr '\\n' ';' || echo)\"",
+  'echo "sbatch=$(command -v sbatch 2>/dev/null && echo yes || echo no)"',
+  'echo "qsub=$(command -v qsub 2>/dev/null && echo yes || echo no)"',
+  'echo "bsub=$(command -v bsub 2>/dev/null && echo yes || echo no)"',
+  'echo "scratch=$SCRATCH"'
+].join('\n')
+
+export type ProbeScriptOutput = {
+  os?: string
+  cpus?: number
+  memMib?: number
+  gpus?: Array<{ type: string; count: number }>
+  detectedScheduler?: 'slurm' | 'pbs' | 'lsf' | 'none'
+  scratchEnv?: string
+}
+
+const aggregateGpus = (raw: string): Array<{ type: string; count: number }> => {
+  if (!raw.trim()) return []
+  const models = raw
+    .split(';')
+    .map((model) => model.trim())
+    .filter(Boolean)
+  const counts = new Map<string, number>()
+  for (const model of models) counts.set(model, (counts.get(model) ?? 0) + 1)
+  return Array.from(counts.entries()).map(([type, count]) => ({ type, count }))
+}
+
+export const parseProbeOutput = (stdout: string): ProbeScriptOutput => {
+  const values: Record<string, string> = {}
+  for (const line of stdout.split('\n')) {
+    const separator = line.indexOf('=')
+    if (separator === -1) continue
+    values[line.slice(0, separator).trim()] = line.slice(separator + 1).trim()
+  }
+
+  const cpus = Number.parseInt(values['cpus'] ?? '', 10)
+  const memMib = Number.parseInt(values['mem_mib'] ?? '', 10)
+  const detectedScheduler: ProbeScriptOutput['detectedScheduler'] =
+    values['sbatch'] === 'yes'
+      ? 'slurm'
+      : values['qsub'] === 'yes'
+        ? 'pbs'
+        : values['bsub'] === 'yes'
+          ? 'lsf'
+          : 'none'
+
+  return {
+    os: values['os'] || undefined,
+    cpus: Number.isFinite(cpus) && cpus > 0 ? cpus : undefined,
+    memMib: Number.isFinite(memMib) && memMib > 0 ? memMib : undefined,
+    gpus: aggregateGpus(values['gpus'] ?? ''),
+    detectedScheduler,
+    scratchEnv: values['scratch'] || undefined
+  }
+}
+
+const errorTail = (stderr: string, stdout: string, maxLines = 10): string => {
+  const lines = [stderr, stdout]
+    .filter(Boolean)
+    .join('\n')
+    .split('\n')
+    .filter((line) => line.trim())
+  return lines.slice(-maxLines).join('\n')
+}
+
+const buildDetailsSkeleton = (probe: ProbeResult): string => {
+  const lines: string[] = ['## Resources', '']
+  if (probe.cpus != null) lines.push(`cpus: ${probe.cpus}`)
+  if (probe.memMib != null) lines.push(`mem: ${Math.round(probe.memMib / 1024)} GB`)
+  if (probe.gpus && probe.gpus.length > 0) {
+    lines.push(`gpus: ${probe.gpus.map((gpu) => `${gpu.count}x ${gpu.type}`).join(', ')}`)
+  }
+  if (probe.detectedScheduler) lines.push(`scheduler: ${probe.detectedScheduler}`)
+  return lines.join('\n')
+}
+
+const hostNotFound = (providerId: string): Error =>
+  new Error(`No compute host found with provider id "${providerId}".`)
+
+export class ComputeHostProfileOwner {
+  constructor(
+    private readonly runner: SshRunner,
+    private readonly repository: ComputeHostRepository
+  ) {}
+
+  async probe(providerId: string): Promise<ProbeResult> {
+    const host = await this.repository.get(providerId)
+    if (!host) throw hostNotFound(providerId)
+
+    const probedAt = new Date().toISOString()
+    let target
+    try {
+      target = await resolveSshTarget(host.sshAlias, host.sshOverrides)
+    } catch (error) {
+      const result: ProbeResult = {
+        ok: false,
+        probedAt,
+        exitCode: null,
+        errorTail: error instanceof Error ? error.message : String(error)
+      }
+      await this.repository.updateProbeResult(providerId, result, 'direct_ssh')
+      return result
+    }
+
+    let runResult = await this.runner.run(target, PROBE_SCRIPT, {
+      timeoutMs: PROBE_TIMEOUT_MS,
+      loginShell: true,
+      maxOutputBytes: PROBE_MAX_OUTPUT_BYTES
+    })
+    const connectionFailed =
+      runResult.timedOut ||
+      runResult.exitCode === 255 ||
+      (runResult.exitCode === null && runResult.stderr.includes('Connection'))
+
+    if (connectionFailed && !runResult.timedOut) {
+      const errorText = (runResult.stderr + runResult.stdout).toLowerCase()
+      if (errorText.includes('no route to host') || errorText.includes('network is unreachable')) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 3000))
+        runResult = await this.runner.run(target, PROBE_SCRIPT, {
+          timeoutMs: PROBE_TIMEOUT_MS,
+          loginShell: true,
+          maxOutputBytes: PROBE_MAX_OUTPUT_BYTES
+        })
+      }
+    }
+
+    const connectionFailedFinal =
+      runResult.timedOut ||
+      runResult.exitCode === 255 ||
+      (runResult.exitCode === null && runResult.stderr.includes('Connection'))
+    if (connectionFailedFinal) {
+      const result: ProbeResult = {
+        ok: false,
+        probedAt,
+        exitCode: runResult.exitCode,
+        errorTail: errorTail(runResult.stderr, runResult.stdout) || 'Connection failed'
+      }
+      await this.repository.updateProbeResult(providerId, result, 'direct_ssh')
+      return result
+    }
+
+    const parsed = parseProbeOutput(runResult.stdout)
+    const shape =
+      parsed.detectedScheduler && parsed.detectedScheduler !== 'none'
+        ? 'scheduler_cluster'
+        : 'direct_ssh'
+    const result: ProbeResult = {
+      ok: true,
+      probedAt,
+      exitCode: runResult.exitCode,
+      errorTail: null,
+      os: parsed.os,
+      cpus: parsed.cpus,
+      memMib: parsed.memMib,
+      gpus: parsed.gpus && parsed.gpus.length > 0 ? parsed.gpus : undefined,
+      detectedScheduler: parsed.detectedScheduler
+    }
+
+    await this.repository.updateProbeResult(providerId, result, shape)
+    if (!host.scratchPinned && parsed.scratchEnv) {
+      await this.repository.updateScratchRoot(providerId, parsed.scratchEnv)
+    }
+    return result
+  }
+
+  async getDetails(providerId: string): Promise<{ doc: string; isSkeleton: boolean }> {
+    const host = await this.repository.get(providerId)
+    if (!host) throw hostNotFound(providerId)
+    if (host.detailsDoc) return { doc: host.detailsDoc, isSkeleton: false }
+    if (!host.probeResult?.ok) return { doc: '', isSkeleton: false }
+    return { doc: buildDetailsSkeleton(host.probeResult), isSkeleton: true }
+  }
+
+  async replaceDetails(
+    providerId: string,
+    { text, oldText, author }: { text: string; oldText: string; author: DetailsAuthor }
+  ): Promise<void> {
+    const host = await this.repository.get(providerId)
+    if (!host) throw hostNotFound(providerId)
+    if (host.detailsDoc !== oldText) {
+      throw new Error(
+        `replaceDetails: old_text does not match the current details document for "${providerId}".`
+      )
+    }
+    if (text.length > DETAILS_DOC_MAX_LENGTH) {
+      throw new Error(
+        `Details must be ${DETAILS_DOC_MAX_LENGTH} characters or fewer (got ${text.length}).`
+      )
+    }
+    await this.repository.updateDetails(providerId, text, author)
+  }
+
+  async appendDetails(
+    providerId: string,
+    { text, author }: { text: string; author: DetailsAuthor }
+  ): Promise<void> {
+    const host = await this.repository.get(providerId)
+    if (!host) throw hostNotFound(providerId)
+    const newDoc = host.detailsDoc ? `${host.detailsDoc}\n${text}` : text
+    if (newDoc.length > DETAILS_DOC_MAX_LENGTH) {
+      throw new Error(
+        `Details must be ${DETAILS_DOC_MAX_LENGTH} characters or fewer (appended doc would be ${newDoc.length}).`
+      )
+    }
+    await this.repository.updateDetails(providerId, newDoc, author)
+  }
+
+  async setScratchRoot(providerId: string, path: string): Promise<void> {
+    if (!(await this.repository.get(providerId))) throw hostNotFound(providerId)
+    await this.repository.updateScratchPinned(providerId, path)
+  }
+
+  async setConcurrencyLimit(providerId: string, limit: number): Promise<void> {
+    if (!(await this.repository.get(providerId))) throw hostNotFound(providerId)
+    if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+      throw new Error(`Concurrent job limit must be an integer in the range 1..500 (got ${limit}).`)
+    }
+    await this.repository.updateConcurrencyLimit(providerId, limit)
+  }
+}

--- a/src/main/compute/compute-service.test.ts
+++ b/src/main/compute/compute-service.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
 
 import type { ComputeHost } from '../../shared/compute'
 import type { DownloadDest } from '../../shared/remote-fs'
-import { ComputeService, parseProbeOutput, resolveInputs } from './compute-service'
+import { ComputeService, resolveInputs } from './compute-service'
 import type { ComputeApprovalBroker } from './compute-approval-broker'
 import type { ComputeHostRepository } from './repository'
 import type { ResolvedSshTarget, SshRunner } from './ssh-runner'
@@ -86,86 +86,6 @@ const makeRepo = (
   }
 }
 
-// A successful probe script output representing a Linux slurm cluster.
-const SLURM_STDOUT = [
-  'os=Linux',
-  'cpus=64',
-  'mem_mib=256000',
-  'gpus=Tesla V100 SXM2 32GB;Tesla V100 SXM2 32GB;',
-  'sbatch=yes',
-  'qsub=no',
-  'bsub=no',
-  'scratch=/gpfs/scratch/user123'
-].join('\n')
-
-// ---------------------------------------------------------------------------
-// parseProbeOutput — pure function tests
-// ---------------------------------------------------------------------------
-
-describe('parseProbeOutput', () => {
-  it('parses a complete slurm linux output', () => {
-    const result = parseProbeOutput(SLURM_STDOUT)
-    expect(result.os).toBe('Linux')
-    expect(result.cpus).toBe(64)
-    expect(result.memMib).toBe(256000)
-    expect(result.gpus).toEqual([{ type: 'Tesla V100 SXM2 32GB', count: 2 }])
-    expect(result.detectedScheduler).toBe('slurm')
-    expect(result.scratchEnv).toBe('/gpfs/scratch/user123')
-  })
-
-  it('detects PBS (qsub) scheduler', () => {
-    const out = 'os=Linux\ncpus=8\nmem_mib=32000\ngpus=\nsbatch=no\nqsub=yes\nbsub=no\nscratch='
-    const result = parseProbeOutput(out)
-    expect(result.detectedScheduler).toBe('pbs')
-  })
-
-  it('detects LSF (bsub) scheduler', () => {
-    const out = 'os=Linux\ncpus=8\nmem_mib=32000\ngpus=\nsbatch=no\nqsub=no\nbsub=yes\nscratch='
-    const result = parseProbeOutput(out)
-    expect(result.detectedScheduler).toBe('lsf')
-  })
-
-  it('returns none when no scheduler is detected', () => {
-    const out = 'os=Darwin\ncpus=16\nmem_mib=65536\ngpus=\nsbatch=no\nqsub=no\nbsub=no\nscratch='
-    const result = parseProbeOutput(out)
-    expect(result.detectedScheduler).toBe('none')
-  })
-
-  it('handles empty GPU list gracefully', () => {
-    const out = 'os=Linux\ncpus=4\nmem_mib=8000\ngpus=\nsbatch=no\nqsub=no\nbsub=no\nscratch='
-    const result = parseProbeOutput(out)
-    expect(result.gpus).toEqual([])
-  })
-
-  it('leaves undefined for missing / non-numeric cpus and mem', () => {
-    const result = parseProbeOutput('os=Linux\ngpus=\nsbatch=no\nqsub=no\nbsub=no\nscratch=')
-    expect(result.cpus).toBeUndefined()
-    expect(result.memMib).toBeUndefined()
-  })
-
-  it('ignores lines without an equals sign', () => {
-    const result = parseProbeOutput('this is garbage\nos=Linux\ncpus=4\n')
-    expect(result.os).toBe('Linux')
-    expect(result.cpus).toBe(4)
-  })
-
-  it('leaves scratchEnv undefined when the env var is empty', () => {
-    const out = 'os=Linux\ncpus=8\nmem_mib=16000\ngpus=\nsbatch=no\nqsub=no\nbsub=no\nscratch='
-    const result = parseProbeOutput(out)
-    expect(result.scratchEnv).toBeUndefined()
-  })
-
-  it('aggregates multiple identical GPU models into one entry', () => {
-    const out = 'gpus=A100 80GB;A100 80GB;A100 80GB;\nsbatch=no\nqsub=no\nbsub=no\nscratch='
-    const result = parseProbeOutput(out)
-    expect(result.gpus).toEqual([{ type: 'A100 80GB', count: 3 }])
-  })
-})
-
-// ---------------------------------------------------------------------------
-// ComputeService.probe — integration with fake SshRunner
-// ---------------------------------------------------------------------------
-
 // We use vi.mock for resolveSshTarget so the tests don't spawn ssh.
 vi.mock('./ssh-runner', async (importOriginal) => {
   const orig = await importOriginal<typeof import('./ssh-runner')>()
@@ -173,396 +93,6 @@ vi.mock('./ssh-runner', async (importOriginal) => {
     ...orig,
     resolveSshTarget: vi.fn(() => Promise.resolve(fakeTarget))
   }
-})
-
-describe('ComputeService.probe', () => {
-  it('returns ok:true and persists probeResult + shape on a successful probe', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: SLURM_STDOUT,
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo, updateProbeResult, updateScratchRoot } = makeRepo()
-    const service = new ComputeService(runner, repo)
-
-    const result = await service.probe('ssh:biowulf')
-
-    expect(result.ok).toBe(true)
-    expect(result.exitCode).toBe(0)
-    expect(result.cpus).toBe(64)
-    expect(result.detectedScheduler).toBe('slurm')
-    expect(updateProbeResult).toHaveBeenCalledWith(
-      'ssh:biowulf',
-      expect.objectContaining({ ok: true, cpus: 64 }),
-      'scheduler_cluster'
-    )
-    // scratchRoot should be set because scratchPinned=false and scratch is provided.
-    expect(updateScratchRoot).toHaveBeenCalledWith('ssh:biowulf', '/gpfs/scratch/user123')
-  })
-
-  it('returns ok:false and maps exit 255 to host_unreachable (connection failure)', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 255,
-      stdout: '',
-      stderr: 'ssh: connect to host biowulf.nih.gov port 22: Connection refused',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo, updateProbeResult, updateScratchRoot } = makeRepo()
-    const service = new ComputeService(runner, repo)
-
-    const result = await service.probe('ssh:biowulf')
-
-    expect(result.ok).toBe(false)
-    expect(result.exitCode).toBe(255)
-    expect(result.errorTail).toContain('Connection refused')
-    expect(updateProbeResult).toHaveBeenCalledWith(
-      'ssh:biowulf',
-      expect.objectContaining({ ok: false }),
-      'direct_ssh'
-    )
-    expect(updateScratchRoot).not.toHaveBeenCalled()
-  })
-
-  it('returns ok:false on timeout and sets timedOut flag', async () => {
-    const runner = makeFakeRunner({
-      exitCode: null,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: true
-    })
-    const { repo, updateProbeResult } = makeRepo()
-    const service = new ComputeService(runner, repo)
-
-    const result = await service.probe('ssh:biowulf')
-
-    expect(result.ok).toBe(false)
-    expect(updateProbeResult).toHaveBeenCalledWith(
-      'ssh:biowulf',
-      expect.objectContaining({ ok: false }),
-      'direct_ssh'
-    )
-  })
-
-  it('probes ok but detectedScheduler=none → shape=direct_ssh', async () => {
-    const stdout = [
-      'os=Darwin',
-      'cpus=16',
-      'mem_mib=32000',
-      'gpus=',
-      'sbatch=no',
-      'qsub=no',
-      'bsub=no',
-      'scratch='
-    ].join('\n')
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout,
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo, updateProbeResult } = makeRepo()
-    const service = new ComputeService(runner, repo)
-
-    const result = await service.probe('ssh:biowulf')
-
-    expect(result.ok).toBe(true)
-    expect(result.detectedScheduler).toBe('none')
-    expect(updateProbeResult).toHaveBeenCalledWith(
-      'ssh:biowulf',
-      expect.objectContaining({ ok: true }),
-      'direct_ssh'
-    )
-  })
-
-  it('does NOT update scratchRoot when scratchPinned=true', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: SLURM_STDOUT,
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const pinnedHost = sampleHost({ scratchPinned: true, scratchRoot: '/my/custom/scratch' })
-    const { repo, updateScratchRoot } = makeRepo(pinnedHost)
-    const service = new ComputeService(runner, repo)
-
-    await service.probe('ssh:biowulf')
-
-    expect(updateScratchRoot).not.toHaveBeenCalled()
-  })
-
-  it('does NOT update scratchRoot when $SCRATCH is empty', async () => {
-    const stdout = 'os=Linux\ncpus=8\nmem_mib=16000\ngpus=\nsbatch=no\nqsub=no\nbsub=no\nscratch='
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout,
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo, updateScratchRoot } = makeRepo()
-    const service = new ComputeService(runner, repo)
-
-    await service.probe('ssh:biowulf')
-
-    expect(updateScratchRoot).not.toHaveBeenCalled()
-  })
-
-  it('does NOT write detailsDoc', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: SLURM_STDOUT,
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo, updateProbeResult } = makeRepo()
-    const service = new ComputeService(runner, repo)
-
-    await service.probe('ssh:biowulf')
-
-    // Verify that probeResult is the only "content" written.
-    const probeCall = updateProbeResult.mock.calls[0]
-    const writtenResult = probeCall?.[1] as Record<string, unknown>
-    expect(Object.keys(writtenResult)).not.toContain('detailsDoc')
-  })
-
-  it('throws when the host does not exist', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo } = makeRepo(null)
-    const service = new ComputeService(runner, repo)
-
-    await expect(service.probe('ssh:nonexistent')).rejects.toThrow(/not found|no compute host/i)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// ComputeService.getDetails — skeleton synthesis and pass-through
-// ---------------------------------------------------------------------------
-
-describe('ComputeService.getDetails', () => {
-  const fakeRunner = makeFakeRunner({
-    exitCode: 0,
-    stdout: '',
-    stderr: '',
-    truncated: false,
-    timedOut: false
-  })
-
-  it('returns detailsDoc as-is when it is non-empty', async () => {
-    const { repo } = makeRepo(sampleHost({ detailsDoc: '## Resources\ncpus: 8' }))
-    const service = new ComputeService(fakeRunner, repo)
-    const result = await service.getDetails('ssh:biowulf')
-    expect(result.doc).toBe('## Resources\ncpus: 8')
-    expect(result.isSkeleton).toBe(false)
-  })
-
-  it('returns a skeleton from probeResult when detailsDoc is empty', async () => {
-    const probeResult = {
-      ok: true,
-      probedAt: '2026-01-01T00:00:00Z',
-      exitCode: 0,
-      errorTail: null,
-      cpus: 64,
-      memMib: 256000,
-      gpus: [{ type: 'A100 80GB', count: 2 }],
-      detectedScheduler: 'slurm' as const
-    }
-    const { repo } = makeRepo(sampleHost({ detailsDoc: '', probeResult }))
-    const service = new ComputeService(fakeRunner, repo)
-    const result = await service.getDetails('ssh:biowulf')
-    expect(result.isSkeleton).toBe(true)
-    expect(result.doc).toContain('## Resources')
-    expect(result.doc).toContain('cpus:')
-    expect(result.doc).toContain('mem:')
-    expect(result.doc).toContain('gpus:')
-    expect(result.doc).toContain('scheduler:')
-  })
-
-  it('returns a skeleton with only available fields when some are missing', async () => {
-    const probeResult = {
-      ok: true,
-      probedAt: '2026-01-01T00:00:00Z',
-      exitCode: 0,
-      errorTail: null,
-      cpus: 8
-    }
-    const { repo } = makeRepo(sampleHost({ detailsDoc: '', probeResult }))
-    const service = new ComputeService(fakeRunner, repo)
-    const result = await service.getDetails('ssh:biowulf')
-    expect(result.isSkeleton).toBe(true)
-    expect(result.doc).toContain('cpus: 8')
-    expect(result.doc).not.toContain('gpus:')
-    expect(result.doc).not.toContain('mem:')
-  })
-
-  it('returns empty string with isSkeleton=false when no probeResult and detailsDoc is empty', async () => {
-    const { repo } = makeRepo(sampleHost({ detailsDoc: '', probeResult: undefined }))
-    const service = new ComputeService(fakeRunner, repo)
-    const result = await service.getDetails('ssh:biowulf')
-    expect(result.doc).toBe('')
-    expect(result.isSkeleton).toBe(false)
-  })
-
-  it('throws when the host does not exist', async () => {
-    const { repo } = makeRepo(null)
-    const service = new ComputeService(fakeRunner, repo)
-    await expect(service.getDetails('ssh:nonexistent')).rejects.toThrow(
-      /not found|no compute host/i
-    )
-  })
-})
-
-// ---------------------------------------------------------------------------
-// ComputeService.replaceDetails — old_text guard and persistence
-// ---------------------------------------------------------------------------
-
-describe('ComputeService.replaceDetails', () => {
-  const fakeRunner = makeFakeRunner({
-    exitCode: 0,
-    stdout: '',
-    stderr: '',
-    truncated: false,
-    timedOut: false
-  })
-
-  it('replaces matching text and persists with author=user', async () => {
-    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: 'hello world' }))
-    const service = new ComputeService(fakeRunner, repo)
-    await service.replaceDetails('ssh:biowulf', {
-      text: 'hello friend',
-      oldText: 'hello world',
-      author: 'user'
-    })
-    expect(updateDetails).toHaveBeenCalledWith('ssh:biowulf', 'hello friend', 'user')
-  })
-
-  it('returns error and does not write when oldText does not match', async () => {
-    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: 'hello world' }))
-    const service = new ComputeService(fakeRunner, repo)
-    await expect(
-      service.replaceDetails('ssh:biowulf', {
-        text: 'something',
-        oldText: 'not present',
-        author: 'user'
-      })
-    ).rejects.toThrow(/not found|does not match|old_text/i)
-    expect(updateDetails).not.toHaveBeenCalled()
-  })
-
-  it('rejects when resulting doc exceeds 32768 characters', async () => {
-    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: 'short' }))
-    const service = new ComputeService(fakeRunner, repo)
-    const bigText = 'x'.repeat(32769)
-    await expect(
-      service.replaceDetails('ssh:biowulf', { text: bigText, oldText: 'short', author: 'user' })
-    ).rejects.toThrow(/32768|too long|limit/i)
-    expect(updateDetails).not.toHaveBeenCalled()
-  })
-
-  it('works with author=agent', async () => {
-    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: 'original text' }))
-    const service = new ComputeService(fakeRunner, repo)
-    await service.replaceDetails('ssh:biowulf', {
-      text: 'new text',
-      oldText: 'original text',
-      author: 'agent'
-    })
-    expect(updateDetails).toHaveBeenCalledWith('ssh:biowulf', 'new text', 'agent')
-  })
-})
-
-// ---------------------------------------------------------------------------
-// ComputeService.setScratchRoot — sets scratchPinned=true
-// ---------------------------------------------------------------------------
-
-describe('ComputeService.setScratchRoot', () => {
-  const fakeRunner = makeFakeRunner({
-    exitCode: 0,
-    stdout: '',
-    stderr: '',
-    truncated: false,
-    timedOut: false
-  })
-
-  it('sets scratch root and marks pinned', async () => {
-    const { repo, updateScratchPinned } = makeRepo()
-    const service = new ComputeService(fakeRunner, repo)
-    await service.setScratchRoot('ssh:biowulf', '/my/scratch')
-    expect(updateScratchPinned).toHaveBeenCalledWith('ssh:biowulf', '/my/scratch')
-  })
-
-  it('throws when the host does not exist', async () => {
-    const { repo } = makeRepo(null)
-    const service = new ComputeService(fakeRunner, repo)
-    await expect(service.setScratchRoot('ssh:nonexistent', '/path')).rejects.toThrow(
-      /not found|no compute host/i
-    )
-  })
-})
-
-// ---------------------------------------------------------------------------
-// ComputeService.setConcurrencyLimit — validates 1..500
-// ---------------------------------------------------------------------------
-
-describe('ComputeService.setConcurrencyLimit', () => {
-  const fakeRunner = makeFakeRunner({
-    exitCode: 0,
-    stdout: '',
-    stderr: '',
-    truncated: false,
-    timedOut: false
-  })
-
-  it('persists a valid concurrency limit', async () => {
-    const { repo, updateConcurrencyLimit } = makeRepo()
-    const service = new ComputeService(fakeRunner, repo)
-    await service.setConcurrencyLimit('ssh:biowulf', 10)
-    expect(updateConcurrencyLimit).toHaveBeenCalledWith('ssh:biowulf', 10)
-  })
-
-  it('rejects 0 (below minimum)', async () => {
-    const { repo } = makeRepo()
-    const service = new ComputeService(fakeRunner, repo)
-    await expect(service.setConcurrencyLimit('ssh:biowulf', 0)).rejects.toThrow(
-      /1.*500|range|invalid/i
-    )
-  })
-
-  it('rejects 501 (above maximum)', async () => {
-    const { repo } = makeRepo()
-    const service = new ComputeService(fakeRunner, repo)
-    await expect(service.setConcurrencyLimit('ssh:biowulf', 501)).rejects.toThrow(
-      /1.*500|range|invalid/i
-    )
-  })
-
-  it('accepts the boundary values 1 and 500', async () => {
-    const { repo, updateConcurrencyLimit } = makeRepo()
-    const service = new ComputeService(fakeRunner, repo)
-    await service.setConcurrencyLimit('ssh:biowulf', 1)
-    await service.setConcurrencyLimit('ssh:biowulf', 500)
-    expect(updateConcurrencyLimit).toHaveBeenCalledTimes(2)
-  })
-
-  it('throws when the host does not exist', async () => {
-    const { repo } = makeRepo(null)
-    const service = new ComputeService(fakeRunner, repo)
-    await expect(service.setConcurrencyLimit('ssh:nonexistent', 10)).rejects.toThrow(
-      /not found|no compute host/i
-    )
-  })
 })
 
 // ---------------------------------------------------------------------------
@@ -575,6 +105,54 @@ const makeApprovalBroker = (decision: 'once' | 'deny'): ComputeApprovalBroker =>
     request: vi.fn(() => Promise.resolve(decision)),
     respond: vi.fn()
   }) as unknown as ComputeApprovalBroker
+
+describe('ComputeService host profile facade', () => {
+  it('preserves all six host profile operations through the facade', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: 'os=Linux\ncpus=4\nmem_mib=8192\ngpus=\nsbatch=yes\nqsub=no\nbsub=no\nscratch=',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo, updateProbeResult, updateDetails, updateScratchPinned, updateConcurrencyLimit } =
+      makeRepo(sampleHost({ detailsDoc: 'current details' }))
+    const service = new ComputeService(runner, repo)
+
+    await expect(service.probe('ssh:biowulf')).resolves.toMatchObject({
+      ok: true,
+      cpus: 4,
+      detectedScheduler: 'slurm'
+    })
+    await expect(service.getDetails('ssh:biowulf')).resolves.toEqual({
+      doc: 'current details',
+      isSkeleton: false
+    })
+    await service.replaceDetails('ssh:biowulf', {
+      text: 'replacement',
+      oldText: 'current details',
+      author: 'user'
+    })
+    await service.appendDetails('ssh:biowulf', { text: 'appendix', author: 'agent' })
+    await service.setScratchRoot('ssh:biowulf', '/portable/scratch')
+    await service.setConcurrencyLimit('ssh:biowulf', 4)
+
+    expect(updateProbeResult).toHaveBeenCalledWith(
+      'ssh:biowulf',
+      expect.objectContaining({ ok: true, cpus: 4 }),
+      'scheduler_cluster'
+    )
+    expect(updateDetails).toHaveBeenNthCalledWith(1, 'ssh:biowulf', 'replacement', 'user')
+    expect(updateDetails).toHaveBeenNthCalledWith(
+      2,
+      'ssh:biowulf',
+      'current details\nappendix',
+      'agent'
+    )
+    expect(updateScratchPinned).toHaveBeenCalledWith('ssh:biowulf', '/portable/scratch')
+    expect(updateConcurrencyLimit).toHaveBeenCalledWith('ssh:biowulf', 4)
+  })
+})
 
 describe('ComputeService.callCommand', () => {
   it('returns ExecResult on success with correct fields', async () => {
@@ -1119,81 +697,6 @@ describe('ComputeService.list', () => {
     expect(result).toHaveLength(2)
     expect(result[0].providerId).toBe('ssh:biowulf')
     expect(result[1].providerId).toBe('ssh:lab-gpu')
-  })
-})
-
-// ---------------------------------------------------------------------------
-// ComputeService.appendDetails — issue 06
-// ---------------------------------------------------------------------------
-
-describe('ComputeService.appendDetails', () => {
-  it('appends text to an empty doc', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: '' }))
-    const service = new ComputeService(runner, repo)
-
-    await service.appendDetails('ssh:biowulf', { text: '## Note\nhello', author: 'agent' })
-
-    expect(updateDetails).toHaveBeenCalledWith('ssh:biowulf', '## Note\nhello', 'agent')
-  })
-
-  it('appends text with a newline separator when doc is non-empty', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo, updateDetails } = makeRepo(sampleHost({ detailsDoc: '## Resources\ncpus: 4' }))
-    const service = new ComputeService(runner, repo)
-
-    await service.appendDetails('ssh:biowulf', { text: '## Note\nhello', author: 'agent' })
-
-    expect(updateDetails).toHaveBeenCalledWith(
-      'ssh:biowulf',
-      '## Resources\ncpus: 4\n## Note\nhello',
-      'agent'
-    )
-  })
-
-  it('throws when the appended doc would exceed 32KB', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const bigDoc = 'x'.repeat(32760)
-    const { repo } = makeRepo(sampleHost({ detailsDoc: bigDoc }))
-    const service = new ComputeService(runner, repo)
-
-    await expect(
-      service.appendDetails('ssh:biowulf', { text: 'overflow', author: 'agent' })
-    ).rejects.toThrow(/32768|characters or fewer/i)
-  })
-
-  it('throws when host is not found', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo } = makeRepo(null)
-    const service = new ComputeService(runner, repo)
-
-    await expect(
-      service.appendDetails('ssh:ghost', { text: 'hello', author: 'agent' })
-    ).rejects.toThrow(/no compute host found/i)
   })
 })
 

--- a/src/main/compute/compute-service.ts
+++ b/src/main/compute/compute-service.ts
@@ -14,7 +14,6 @@ import type {
   ProbeResult,
   SubmitJobResult
 } from '../../shared/compute'
-import { DETAILS_DOC_MAX_LENGTH } from '../../shared/compute'
 import type { DirListing, DownloadDest, LocalFile, RemoteFsError } from '../../shared/remote-fs'
 import { classifyRemoteError, parseFindListing } from '../../shared/remote-fs'
 import type { ComputeApprovalBroker } from './compute-approval-broker'
@@ -41,13 +40,10 @@ import { getJobHarvestDir } from './harvest-engine'
 import { getNotebookSessionRoot } from '../notebook/repository'
 import type { ConcurrencyManager, SessionStatus } from './concurrency-manager'
 import { workspaceRelativePath } from './workspace-path'
+import { ComputeHostProfileOwner } from './compute-host-profile-owner'
 
-// Probe timeout for the full bundle — individual commands share one connection but each gets this
-// budget. Set generously so slow clusters don't abort, but short enough for a responsive UI (30s).
-const PROBE_TIMEOUT_MS = 30_000
-
-// Maximum output to capture per probe command (4 KB is plenty for nproc / nvidia-smi -L output).
-const PROBE_MAX_OUTPUT_BYTES = 4 * 1024
+export { parseProbeOutput } from './compute-host-profile-owner'
+export type { ProbeScriptOutput } from './compute-host-profile-owner'
 
 // Default timeout for call_command (design.md §5). Callers may pass a longer value but 60s prevents
 // accidental indefinite hangs when the agent forgets to set a timeout.
@@ -71,112 +67,13 @@ const LIST_DIR_TIMEOUT_MS = 30_000
 // Short command preview shown in the approval card when the full command is long.
 const COMMAND_PREVIEW_MAX_LEN = 120
 
-// Shell script run as a single SSH command. We collect all outputs in one round-trip:
-//   - uname -s for OS
-//   - nproc for CPU count
-//   - free -m for memory (Linux only; macOS falls back via sysctl)
-//   - nvidia-smi -L for GPU list (optional; missing command is fine)
-//   - which sbatch / qsub / bsub for scheduler detection
-//   - echo $SCRATCH for scratch root suggestion
-//
-// The output is a simple line-delimited key=value format so the parser is a pure function.
-const PROBE_SCRIPT = [
-  'echo "os=$(uname -s 2>/dev/null)"',
-  'echo "cpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo)"',
-  // Linux: free -m | awk, macOS: sysctl hw.memsize converted to MiB.
-  'echo "mem_mib=$(free -m 2>/dev/null | awk \'NR==2{print $2}\' || echo $(( $(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1048576 )))"',
-  "echo \"gpus=$(nvidia-smi -L 2>/dev/null | grep -oP 'GPU \\d+: \\K[^(]+' | tr '\\n' ';' || echo)\"",
-  'echo "sbatch=$(command -v sbatch 2>/dev/null && echo yes || echo no)"',
-  'echo "qsub=$(command -v qsub 2>/dev/null && echo yes || echo no)"',
-  'echo "bsub=$(command -v bsub 2>/dev/null && echo yes || echo no)"',
-  'echo "scratch=$SCRATCH"'
-].join('\n')
-
-// Parsed output from the probe script — a pure-data structure so parseProbeOutput is unit-testable
-// without SSH.
-export type ProbeScriptOutput = {
-  os?: string
-  cpus?: number
-  memMib?: number
-  gpus?: Array<{ type: string; count: number }>
-  detectedScheduler?: 'slurm' | 'pbs' | 'lsf' | 'none'
-  scratchEnv?: string
-}
-
-// Counts consecutive identical GPU model names to build the [{type, count}] list.
-const aggregateGpus = (raw: string): Array<{ type: string; count: number }> => {
-  if (!raw.trim()) return []
-  const models = raw
-    .split(';')
-    .map((s) => s.trim())
-    .filter(Boolean)
-  const counts: Map<string, number> = new Map()
-  for (const model of models) {
-    counts.set(model, (counts.get(model) ?? 0) + 1)
-  }
-  return Array.from(counts.entries()).map(([type, count]) => ({ type, count }))
-}
-
-// Pure function: parses the line-delimited key=value output of PROBE_SCRIPT into ProbeScriptOutput.
-// Exported so it can be unit-tested independently of SSH.
-export const parseProbeOutput = (stdout: string): ProbeScriptOutput => {
-  const kv: Record<string, string> = {}
-  for (const line of stdout.split('\n')) {
-    const eq = line.indexOf('=')
-    if (eq === -1) continue
-    const key = line.slice(0, eq).trim()
-    const value = line.slice(eq + 1).trim()
-    kv[key] = value
-  }
-
-  const cpusRaw = Number.parseInt(kv['cpus'] ?? '', 10)
-  const memRaw = Number.parseInt(kv['mem_mib'] ?? '', 10)
-
-  const scheduler: ProbeScriptOutput['detectedScheduler'] =
-    kv['sbatch'] === 'yes'
-      ? 'slurm'
-      : kv['qsub'] === 'yes'
-        ? 'pbs'
-        : kv['bsub'] === 'yes'
-          ? 'lsf'
-          : 'none'
-
-  return {
-    os: kv['os'] || undefined,
-    cpus: Number.isFinite(cpusRaw) && cpusRaw > 0 ? cpusRaw : undefined,
-    memMib: Number.isFinite(memRaw) && memRaw > 0 ? memRaw : undefined,
-    gpus: aggregateGpus(kv['gpus'] ?? ''),
-    detectedScheduler: scheduler,
-    scratchEnv: kv['scratch'] || undefined
-  }
-}
-
-// Extracts a short tail from stderr/stdout to surface in the UI probe-failed banner.
 const errorTail = (stderr: string, stdout: string, maxLines = 10): string => {
-  const combined = [stderr, stdout].filter(Boolean).join('\n')
-  const lines = combined.split('\n').filter((l) => l.trim())
+  const lines = [stderr, stdout]
+    .filter(Boolean)
+    .join('\n')
+    .split('\n')
+    .filter((line) => line.trim())
   return lines.slice(-maxLines).join('\n')
-}
-
-// Synthesizes a first-contact skeleton from a successful probeResult. Used by getDetails when
-// detailsDoc is empty — gives agents a structured starting point without requiring a manual edit.
-const buildDetailsSkeleton = (probe: ProbeResult): string => {
-  const lines: string[] = ['## Resources', '']
-  if (probe.cpus != null) {
-    lines.push(`cpus: ${probe.cpus}`)
-  }
-  if (probe.memMib != null) {
-    const gb = Math.round(probe.memMib / 1024)
-    lines.push(`mem: ${gb} GB`)
-  }
-  if (probe.gpus && probe.gpus.length > 0) {
-    const gpuStr = probe.gpus.map((g) => `${g.count}x ${g.type}`).join(', ')
-    lines.push(`gpus: ${gpuStr}`)
-  }
-  if (probe.detectedScheduler) {
-    lines.push(`scheduler: ${probe.detectedScheduler}`)
-  }
-  return lines.join('\n')
 }
 
 // Raw input spec as submitted by the agent (before resolution to local paths).
@@ -288,9 +185,9 @@ const JOB_MAX_TIMEOUT_SECONDS = 7 * 24 * 3600
 // Default timeout when not specified (24 hours).
 const JOB_DEFAULT_TIMEOUT_SECONDS = 24 * 3600
 
-// ComputeService owns probe logic. It is injected with a SshRunner (for testability) and a
-// repository (for persistence). It does NOT write detailsDoc — only probeResult, shape, and
-// scratchRoot (when applicable). See design.md §4 for the probe/Details distinction.
+// ComputeService preserves the public facade while ComputeHostProfileOwner owns probe and host
+// profile mutations. Both share the injected runner and repository. See design.md §4 for the
+// probe/Details distinction.
 // approvalBroker is optional: when omitted, callCommand throws rather than requesting approval
 // (unit tests that don't exercise the approval path omit it).
 // scpRunner is optional: when omitted a SystemScpRunner is used (production default).
@@ -300,6 +197,7 @@ const JOB_DEFAULT_TIMEOUT_SECONDS = 24 * 3600
 // concurrencyManager is optional: when omitted, submitJob will not enforce concurrency limits.
 export class ComputeService {
   private readonly scpRunner: ScpRunner
+  private readonly hostProfiles: ComputeHostProfileOwner
 
   constructor(
     private readonly runner: SshRunner,
@@ -314,216 +212,41 @@ export class ComputeService {
     private readonly concurrencyManager?: ConcurrencyManager
   ) {
     this.scpRunner = scpRunner ?? new SystemScpRunner()
+    this.hostProfiles = new ComputeHostProfileOwner(runner, repository)
   }
 
-  // Runs the probe bundle against the host identified by providerId. Persists the structured
-  // probeResult and (conditionally) scratchRoot. Never touches detailsDoc.
   async probe(providerId: string): Promise<ProbeResult> {
-    const host = await this.repository.get(providerId)
-    if (!host) {
-      throw new Error(`No compute host found with provider id "${providerId}".`)
-    }
-
-    const probedAt = new Date().toISOString()
-
-    // Resolve SSH target (runs ssh -G, applies overrides). On connection failure this itself may
-    // throw — we catch below and treat it as host_unreachable.
-    let target
-    try {
-      target = await resolveSshTarget(host.sshAlias, host.sshOverrides)
-    } catch (err) {
-      const result: ProbeResult = {
-        ok: false,
-        probedAt,
-        exitCode: null,
-        errorTail: err instanceof Error ? err.message : String(err)
-      }
-      await this.repository.updateProbeResult(providerId, result, 'direct_ssh')
-      return result
-    }
-
-    // Run the probe script in a login shell so module/conda PATHs are present.
-    let runResult = await this.runner.run(target, PROBE_SCRIPT, {
-      timeoutMs: PROBE_TIMEOUT_MS,
-      loginShell: true,
-      maxOutputBytes: PROBE_MAX_OUTPUT_BYTES
-    })
-
-    // SSH exit 255 signals a connection-level failure (host unreachable / batch-mode auth failure /
-    // unknown host key). Any non-zero exit from the script itself is still a "probe succeeded at
-    // connection level" — we report it as ok:true with partial data.
-    const connectionFailed =
-      runResult.timedOut ||
-      runResult.exitCode === 255 ||
-      (runResult.exitCode === null && runResult.stderr.includes('Connection'))
-
-    // Retry once on transient routing errors (e.g. "No route to host", "Network is unreachable").
-    // These occur on macOS when a virtual network bridge (multipass vmnet, Docker, VPN) is still
-    // recovering after sleep/wake — the kernel immediately returns EHOSTUNREACH regardless of
-    // ConnectTimeout. A 3-second wait is usually enough for the bridge to restore its routes.
-    if (connectionFailed && !runResult.timedOut) {
-      const errText = (runResult.stderr + runResult.stdout).toLowerCase()
-      const isTransientRouting =
-        errText.includes('no route to host') || errText.includes('network is unreachable')
-      if (isTransientRouting) {
-        await new Promise<void>((resolve) => setTimeout(resolve, 3000))
-        runResult = await this.runner.run(target, PROBE_SCRIPT, {
-          timeoutMs: PROBE_TIMEOUT_MS,
-          loginShell: true,
-          maxOutputBytes: PROBE_MAX_OUTPUT_BYTES
-        })
-      }
-    }
-
-    const connectionFailedFinal =
-      runResult.timedOut ||
-      runResult.exitCode === 255 ||
-      (runResult.exitCode === null && runResult.stderr.includes('Connection'))
-
-    if (connectionFailedFinal) {
-      const tail = errorTail(runResult.stderr, runResult.stdout)
-      const result: ProbeResult = {
-        ok: false,
-        probedAt,
-        exitCode: runResult.exitCode,
-        errorTail: tail || 'Connection failed'
-      }
-      await this.repository.updateProbeResult(providerId, result, 'direct_ssh')
-      return result
-    }
-
-    const parsed = parseProbeOutput(runResult.stdout)
-
-    // Infer shape from detected scheduler (design.md §4).
-    const shape =
-      parsed.detectedScheduler && parsed.detectedScheduler !== 'none'
-        ? 'scheduler_cluster'
-        : 'direct_ssh'
-
-    const result: ProbeResult = {
-      ok: true,
-      probedAt,
-      exitCode: runResult.exitCode,
-      errorTail: null,
-      os: parsed.os,
-      cpus: parsed.cpus,
-      memMib: parsed.memMib,
-      gpus: parsed.gpus && parsed.gpus.length > 0 ? parsed.gpus : undefined,
-      detectedScheduler: parsed.detectedScheduler
-    }
-
-    // Persist probe result and shape. Update scratchRoot only when not pinned and the env var was set.
-    await this.repository.updateProbeResult(providerId, result, shape)
-    if (!host.scratchPinned && parsed.scratchEnv) {
-      await this.repository.updateScratchRoot(providerId, parsed.scratchEnv)
-    }
-
-    return result
+    return this.hostProfiles.probe(providerId)
   }
 
-  // Lists all registered compute hosts, newest-first. Returns a lightweight summary for discovery
-  // (provider_id / display_name / shape / status derived from probeResult.ok).
   async list(): Promise<ComputeHost[]> {
     return this.repository.list()
   }
 
-  // Returns the details document for a host. When detailsDoc is empty and a successful probe
-  // exists, synthesizes a first-contact skeleton from probeResult (## Resources + resource lines).
-  // isSkeleton=true signals the caller this was auto-generated, not user/agent content.
   async getDetails(providerId: string): Promise<{ doc: string; isSkeleton: boolean }> {
-    const host = await this.repository.get(providerId)
-    if (!host) {
-      throw new Error(`No compute host found with provider id "${providerId}".`)
-    }
-
-    if (host.detailsDoc) {
-      return { doc: host.detailsDoc, isSkeleton: false }
-    }
-
-    // No stored doc — synthesize a skeleton from the last probe result if available.
-    const probe = host.probeResult
-    if (!probe || !probe.ok) {
-      return { doc: '', isSkeleton: false }
-    }
-
-    return { doc: buildDetailsSkeleton(probe), isSkeleton: true }
+    return this.hostProfiles.getDetails(providerId)
   }
 
-  // Replaces detailsDoc via exact-match: the full current doc is replaced with `text` only if
-  // `oldText` equals the current detailsDoc. This prevents concurrent edit collisions and is the
-  // mechanism used by both the UI (author='user') and the agent (author='agent', issue 06).
   async replaceDetails(
     providerId: string,
-    { text, oldText, author }: { text: string; oldText: string; author: DetailsAuthor }
+    request: { text: string; oldText: string; author: DetailsAuthor }
   ): Promise<void> {
-    const host = await this.repository.get(providerId)
-    if (!host) {
-      throw new Error(`No compute host found with provider id "${providerId}".`)
-    }
-
-    // Exact-match guard: oldText must equal the current stored doc.
-    if (host.detailsDoc !== oldText) {
-      throw new Error(
-        `replaceDetails: old_text does not match the current details document for "${providerId}".`
-      )
-    }
-
-    if (text.length > DETAILS_DOC_MAX_LENGTH) {
-      throw new Error(
-        `Details must be ${DETAILS_DOC_MAX_LENGTH} characters or fewer (got ${text.length}).`
-      )
-    }
-
-    await this.repository.updateDetails(providerId, text, author)
+    return this.hostProfiles.replaceDetails(providerId, request)
   }
 
-  // Appends text to detailsDoc, respecting the 32KB cap. Used by the agent-facing details channel
-  // (design.md §5). Reads the current doc, validates the combined length, then delegates to the
-  // repository updateDetails — same path as replaceDetails, no duplicated validation logic.
   async appendDetails(
     providerId: string,
-    { text, author }: { text: string; author: DetailsAuthor }
+    request: { text: string; author: DetailsAuthor }
   ): Promise<void> {
-    const host = await this.repository.get(providerId)
-    if (!host) {
-      throw new Error(`No compute host found with provider id "${providerId}".`)
-    }
-
-    const newDoc = host.detailsDoc ? `${host.detailsDoc}\n${text}` : text
-
-    if (newDoc.length > DETAILS_DOC_MAX_LENGTH) {
-      throw new Error(
-        `Details must be ${DETAILS_DOC_MAX_LENGTH} characters or fewer (appended doc would be ${newDoc.length}).`
-      )
-    }
-
-    await this.repository.updateDetails(providerId, newDoc, author)
+    return this.hostProfiles.appendDetails(providerId, request)
   }
 
-  // Sets the scratch root and marks the host as pinned. Pinned hosts are never overwritten by
-  // probe (probe checks scratchPinned before updating scratchRoot — see probe() above).
   async setScratchRoot(providerId: string, path: string): Promise<void> {
-    const host = await this.repository.get(providerId)
-    if (!host) {
-      throw new Error(`No compute host found with provider id "${providerId}".`)
-    }
-
-    await this.repository.updateScratchPinned(providerId, path)
+    return this.hostProfiles.setScratchRoot(providerId, path)
   }
 
-  // Stores the concurrent job limit (1..500). Phase 1 persists it only — no enforcement until
-  // the job runner lands in a later phase.
   async setConcurrencyLimit(providerId: string, limit: number): Promise<void> {
-    const host = await this.repository.get(providerId)
-    if (!host) {
-      throw new Error(`No compute host found with provider id "${providerId}".`)
-    }
-
-    if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
-      throw new Error(`Concurrent job limit must be an integer in the range 1..500 (got ${limit}).`)
-    }
-
-    await this.repository.updateConcurrencyLimit(providerId, limit)
+    return this.hostProfiles.setConcurrencyLimit(providerId, limit)
   }
 
   // Lists the contents of a remote directory using find -printf via the existing exec SshRunner.


### PR DESCRIPTION
# Problem

`ComputeService` mixed host probing and profile mutation with remote execution, file transfer, and job lifecycle. Callers should not need to understand probe retries, scheduler classification, scratch pinning, details skeletons, or compare-and-replace rules.

# Proposed change

- Add a private `ComputeHostProfileOwner` for `probe`, `getDetails`, `replaceDetails`, `appendDetails`, `setScratchRoot`, and `setConcurrencyLimit`.
- Keep `ComputeService` as the stable facade and construct one owner from its existing SSH runner and repository dependencies.
- Move the probe parser and host-profile characterization tests to the owner while preserving the existing `compute-service.ts` parser/type re-exports.
- Register the new owner and its direct tests in the `compute_service` module-impact entry.

# Scope and non-goals

- `list()` remains a direct `ComputeService` repository passthrough.
- Host create/delete/grant cleanup remains outside this owner.
- Remote file, command, download, and job workflow implementations are unchanged.
- This PR does not introduce a public interface, IPC channel, persistence schema, or UI change.

# Compatibility

- Electron, Web, CLI/Task, and Session-bound local RPC retain their current capabilities and facade contracts.
- Probe retry timing, scheduler classification, error strings, scratch pinning, details exact-match/length validation, and concurrency limit validation are preserved.
- `parseProbeOutput` and `ProbeScriptOutput` remain available from `compute-service.ts`.
- Tests use repository-relative paths and do not add OS-specific assumptions.

# Acceptance criteria and validation

- Private owner: 233 physical lines; below the 600 target and 660 hard limit.
- `compute-service.ts` is the only production importer of the private owner.
- `npm run test:module -- compute_service`: 285 passed, 5 skipped.
- Module-impact tests: 30 passed.
- `npm run typecheck`: passed for Node and Web.
- `npm run lint`: 0 errors; 17 pre-existing warnings.
- Full `npm test`: 12,641 passed, 190 skipped; one unrelated Workspace runtime architecture scan hit its fixed 15-second timeout under full-suite load, then passed 10/10 in an isolated rerun.
- `git diff --check`: passed.
- Exact-head CI/AI remains required before squash merge.

# Review focus

- Confirm the owner is a cohesive host-profile boundary rather than a second public service.
- Confirm probe retry/classification, details CAS, scratch pinning, and validation behavior remain compatible.
- Confirm `list()` and all remote/job workflows remain in `ComputeService`.
- Confirm mutable host data still belongs to `ComputeHostRepository` and no cross-surface capability is expanded.
