### PR TITLE
feat(permissions): seed global customize grants

### DIFF
--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -10,6 +10,7 @@ import {
   createPermissionGrantRegistry,
   type PermissionGrantRegistry
 } from '../permission-grants/registry'
+import { seedDefaultPermissionGrants } from '../permission-grants/defaults'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import { AcpPermissionBroker, projectRegistrySessionGrants } from './permission-broker'
 import { withTrustedMcpToolIdentity } from './permission-policy'
@@ -736,6 +737,25 @@ describe('ACP permission broker with durable grants', () => {
         'exec:local/bash'
       ].sort()
     )
+  })
+
+  it('uses a default Global customization grant without prompting', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-default-grant-'))
+    client = createProjectDbClient(storageRoot)
+    await ensureProjectSchema(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
+    const registry = await createPermissionGrantRegistry({ getClient: async () => client! })
+    await seedDefaultPermissionGrants(registry, client)
+    const emitted: Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0][] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request), undefined, registry)
+
+    await expect(
+      broker.requestPermission(registeredToolRequest('agent_create'), {
+        profile: 'ask',
+        projectId: 'project-1'
+      })
+    ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'provider-allow-once' } })
+    expect(emitted).toEqual([])
   })
 
   it('reuses one app MCP grant across Claude Code, Codex, OpenCode, and runtime-trusted sparse requests', async () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -147,6 +147,7 @@ import { createProjectFilesHandlers, registerProjectFilesIpcHandlers } from './p
 import { createManagedFileIndexRepository } from './project-files/repository'
 import { ProjectDeletionCoordinator } from './projects/deletion-coordinator'
 import { getProjectDbClient } from './projects/prisma-client'
+import { seedDefaultPermissionGrants } from './permission-grants/defaults'
 import { createPermissionGrantRegistry } from './permission-grants/registry'
 import { isPermissionGrantScopeLive } from './permission-grants/scope-liveness'
 import { registerPermissionGrantIpcAdapter } from './permission-grants/ipc'
@@ -496,6 +497,7 @@ const createApplicationModules = async (
           runtimeRef.current?.hasLiveSession(projectId, sessionId) ?? false
       })
   })
+  await seedDefaultPermissionGrants(permissionGrantRegistry, await getProjectDbClient(configRoot))
   const projectFilesRepository = createManagedFileIndexRepository(
     getProjectDbClient,
     configRoot,

--- a/src/main/permission-grants/defaults.test.ts
+++ b/src/main/permission-grants/defaults.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { DEFAULT_GLOBAL_CUSTOMIZE_PERMISSION_KEYS, seedDefaultPermissionGrants } from './defaults'
+import { PRE_REGISTERED_PERMISSION_IDENTITIES } from './identity-catalog'
+import { createPermissionGrantRegistry, type PermissionGrantRegistry } from './registry'
+
+let storageRoot: string | undefined
+let client: PrismaClient | undefined
+
+afterEach(async () => {
+  await client?.$disconnect()
+  client = undefined
+  if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
+  storageRoot = undefined
+})
+
+const setup = async (): Promise<{ client: PrismaClient; registry: PermissionGrantRegistry }> => {
+  storageRoot = await mkdtemp(join(tmpdir(), 'open-science-permission-defaults-'))
+  client = createProjectDbClient(storageRoot)
+  await ensureProjectSchema(client)
+  const registry = await createPermissionGrantRegistry({ getClient: async () => client! })
+  return { client, registry }
+}
+
+describe('default permission grants', () => {
+  it('seeds the registered customization permissions globally', async () => {
+    const fixture = await setup()
+
+    await seedDefaultPermissionGrants(fixture.registry, fixture.client)
+
+    expect(DEFAULT_GLOBAL_CUSTOMIZE_PERMISSION_KEYS).toEqual(
+      PRE_REGISTERED_PERMISSION_IDENTITIES.customize_mutation
+    )
+    const grants = await fixture.registry.list()
+    expect(grants.map((grant) => grant.capability.key)).toEqual(
+      [...DEFAULT_GLOBAL_CUSTOMIZE_PERMISSION_KEYS].sort()
+    )
+    expect(grants).toEqual(
+      expect.arrayContaining(
+        DEFAULT_GLOBAL_CUSTOMIZE_PERMISSION_KEYS.map((key) =>
+          expect.objectContaining({
+            capability: { kind: 'customize_mutation', key },
+            scope: { kind: 'global' }
+          })
+        )
+      )
+    )
+  })
+
+  it('does not recreate a revoked default on a later startup', async () => {
+    const fixture = await setup()
+    await seedDefaultPermissionGrants(fixture.registry, fixture.client)
+    const [revoked] = await fixture.registry.list()
+    await fixture.registry.revoke({ grants: [{ id: revoked!.id, revision: revoked!.revision }] })
+
+    const reopenedRegistry = await createPermissionGrantRegistry({
+      getClient: async () => fixture.client
+    })
+    await seedDefaultPermissionGrants(reopenedRegistry, fixture.client)
+
+    await expect(reopenedRegistry.list()).resolves.toHaveLength(
+      DEFAULT_GLOBAL_CUSTOMIZE_PERMISSION_KEYS.length - 1
+    )
+  })
+})

--- a/src/main/permission-grants/defaults.ts
+++ b/src/main/permission-grants/defaults.ts
@@ -1,0 +1,47 @@
+import type { PrismaClient } from '@prisma/client'
+
+import type { PermissionCapability } from '../../shared/permission-grants'
+import type { PermissionGrantRegistry } from './registry'
+
+const DEFAULT_PERMISSION_GRANT_SEED_ID = 'global-customize-v1'
+
+const DEFAULT_GLOBAL_CUSTOMIZE_PERMISSION_KEYS = [
+  'customize:agent_create',
+  'customize:agent_update',
+  'customize:skill_publish',
+  'customize:skill_edit',
+  'customize:agent_attach_skill',
+  'customize:agent_detach_skill',
+  'customize:agent_attach_connector',
+  'customize:agent_detach_connector'
+] as const
+
+const PERMISSION_GRANT_SEED_TABLE_DDL = `CREATE TABLE IF NOT EXISTS "PermissionGrantSeed" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "appliedAt" DATETIME NOT NULL
+);`
+
+const seedDefaultPermissionGrants = async (
+  registry: PermissionGrantRegistry,
+  client: PrismaClient
+): Promise<void> => {
+  await client.$executeRawUnsafe(PERMISSION_GRANT_SEED_TABLE_DDL)
+  const applied = await client.$queryRawUnsafe<Array<{ id: string }>>(
+    'SELECT "id" FROM "PermissionGrantSeed" WHERE "id" = ? LIMIT 1',
+    DEFAULT_PERMISSION_GRANT_SEED_ID
+  )
+  if (applied.length > 0) return
+
+  for (const key of DEFAULT_GLOBAL_CUSTOMIZE_PERMISSION_KEYS) {
+    const capability: PermissionCapability = { kind: 'customize_mutation', key }
+    await registry.remember({ capability, scope: { kind: 'global' } })
+  }
+
+  await client.$executeRawUnsafe(
+    'INSERT OR IGNORE INTO "PermissionGrantSeed" ("id", "appliedAt") VALUES (?, ?)',
+    DEFAULT_PERMISSION_GRANT_SEED_ID,
+    new Date()
+  )
+}
+
+export { DEFAULT_GLOBAL_CUSTOMIZE_PERMISSION_KEYS, seedDefaultPermissionGrants }


### PR DESCRIPTION
## Problem

Fresh application databases do not currently grant the built-in customization mutations, so operations such as creating or updating agents and publishing or editing skills can prompt even though the Permission panel is intended to start with these capabilities allowed globally.

## Proposed change

- Seed the eight registered `customize_mutation` capabilities as Global grants during application composition.
- Record a versioned seed marker only after all defaults are present, so interrupted startup can retry safely.
- Preserve user intent after startup: once a default grant is revoked, later launches do not recreate it.
- Reuse the existing permission registry and broker resolution path; no provider-specific permission behavior is introduced.

## Scope and non-goals

- Includes only the existing eight customization capabilities: agent create/update, skill publish/edit, skill attach/detach, and connector attach/detach.
- Does not add Project or Conversation default grants.
- Does not change permission wire formats, provider adapters, or Permission panel rendering.

## Acceptance criteria and validation

- [x] A fresh database contains exactly the eight registered customization grants with Global scope.
- [x] A revoked seeded grant remains revoked after reopening the registry and rerunning startup seeding.
- [x] A seeded Global customization grant resolves through the shared ACP broker without emitting a permission prompt.
- [x] `npm run typecheck`
- [x] `npm run lint` (passes with 17 existing warnings outside the changed files)
- [x] `npm test` (868 files passed, 14 skipped; 12,641 tests passed, 190 skipped)
- [x] `git diff --check`

## ACP and platform impact

The change initializes the shared `PermissionGrantRegistry` before the shared `AcpPermissionBroker` is consumed. Claude Code, OpenCode, Codex Responses, and Codex Bridge therefore use the same grant lookup path; no launcher-, model-, protocol-, or provider-specific branch changed. The broker regression suite exercises default auto-approval and retains its existing cross-framework identity coverage.

The persistence path uses the existing Prisma/SQLite project database and registry contract. Local validation ran on macOS; packaged Windows and Linux behavior remains covered by CI because no platform-specific paths or process behavior changed.

## Review focus

- Confirm the one-time seed marker correctly balances first-run defaults with durable user revocation.
- Confirm startup ordering seeds before permission consumers are composed.
- Confirm the explicit list remains aligned with the registered customization identity catalog.
