### PR TITLE
refactor(compute): extract job workflow owner

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -124,6 +124,7 @@
     "compute_service": {
       "ownerPaths": [
         "src/main/compute/compute-host-profile-owner.ts",
+        "src/main/compute/compute-job-workflow-owner.ts",
         "src/main/compute/compute-remote-operation-owner.ts",
         "src/main/compute/compute-service.ts"
       ],
@@ -132,12 +133,15 @@
       "testFiles": {
         "owner": [
           "src/main/compute/compute-host-profile-owner.test.ts",
+          "src/main/compute/compute-job-workflow-owner.test.ts",
           "src/main/compute/compute-remote-operation-owner.test.ts",
           "src/main/compute/compute-service.test.ts",
           "src/main/compute/compute-jobs.integration.test.ts",
           "src/main/compute/concurrency-integration.test.ts"
         ],
         "contract": [
+          "src/main/compute/concurrency-manager.test.ts",
+          "src/main/compute/job-dispatcher.test.ts",
           "src/main/compute/scp-runner.test.ts",
           "src/main/compute/ssh-runner.test.ts",
           "src/main/compute/ipc.test.ts",

--- a/src/main/compute/compute-job-workflow-owner.test.ts
+++ b/src/main/compute/compute-job-workflow-owner.test.ts
@@ -1,0 +1,1082 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+
+import type { ComputeHost } from '../../shared/compute'
+import { ComputeJobWorkflowOwner, resolveInputs } from './compute-job-workflow-owner'
+import type { ComputeApprovalBroker } from './compute-approval-broker'
+import type { ComputeHostRepository } from './repository'
+import type { ResolvedSshTarget, SshRunner } from './ssh-runner'
+import type { ScpRunner } from './scp-runner'
+import type { ConcurrencyManager } from './concurrency-manager'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const sampleHost = (overrides: Partial<ComputeHost> = {}): ComputeHost => ({
+  id: 'host-1',
+  providerId: 'ssh:biowulf',
+  displayName: 'biowulf',
+  shape: 'direct_ssh',
+  sshAlias: 'biowulf',
+  sshOverrides: undefined,
+  scratchRoot: undefined,
+  scratchPinned: false,
+  concurrencyLimit: undefined,
+  probeResult: undefined,
+  detailsDoc: '',
+  detailsUpdatedAt: undefined,
+  detailsUpdatedBy: undefined,
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+// A fake target returned by the real resolveSshTarget helper — tests bypass that step by mocking the
+// entire runner (which already has the target baked in).
+const fakeTarget: ResolvedSshTarget = {
+  sshBinary: '/usr/bin/ssh',
+  host: 'biowulf.nih.gov',
+  extraArgs: ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=10']
+}
+
+// Minimal fake runner — always resolves with a success result by default.
+const makeFakeRunner = (result: Awaited<ReturnType<SshRunner['run']>>): SshRunner => ({
+  run: vi.fn(() => Promise.resolve(result))
+})
+
+// Minimal repository double.
+const makeRepo = (
+  host: ComputeHost | null = sampleHost()
+): {
+  repo: ComputeHostRepository
+  updateProbeResult: ReturnType<typeof vi.fn>
+  updateScratchRoot: ReturnType<typeof vi.fn>
+  updateDetails: ReturnType<typeof vi.fn>
+  updateScratchPinned: ReturnType<typeof vi.fn>
+  updateConcurrencyLimit: ReturnType<typeof vi.fn>
+} => {
+  const updateProbeResult = vi.fn(() => Promise.resolve())
+  const updateScratchRoot = vi.fn(() => Promise.resolve())
+  const updateDetails = vi.fn(() => Promise.resolve())
+  const updateScratchPinned = vi.fn(() => Promise.resolve())
+  const updateConcurrencyLimit = vi.fn(() => Promise.resolve())
+  const repo: ComputeHostRepository = {
+    get: vi.fn(() => Promise.resolve(host)),
+    list: vi.fn(() => Promise.resolve([])),
+    create: vi.fn(),
+    delete: vi.fn(),
+    updateProbeResult,
+    updateScratchRoot,
+    updateDetails,
+    updateScratchPinned,
+    updateConcurrencyLimit
+  } as unknown as ComputeHostRepository
+  return {
+    repo,
+    updateProbeResult,
+    updateScratchRoot,
+    updateDetails,
+    updateScratchPinned,
+    updateConcurrencyLimit
+  }
+}
+
+// We use vi.mock for resolveSshTarget so the tests don't spawn ssh.
+vi.mock('./ssh-runner', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('./ssh-runner')>()
+  return {
+    ...orig,
+    resolveSshTarget: vi.fn(() => Promise.resolve(fakeTarget))
+  }
+})
+
+const makeScpRunner = (): ScpRunner => ({ copy: vi.fn() })
+
+const makeOwner = (
+  runner: SshRunner,
+  repository: ComputeHostRepository,
+  approvalBroker?: ComputeApprovalBroker,
+  jobRepository?: import('./job-repository').ComputeJobRepository,
+  publishJobUpdated?: (job: import('../../shared/compute').ComputeJob) => void,
+  artifactResolver?: { resolveArtifactPath(uri: string): Promise<string> },
+  storageRoot?: string,
+  concurrencyManager?: ConcurrencyManager
+): ComputeJobWorkflowOwner =>
+  new ComputeJobWorkflowOwner(
+    runner,
+    repository,
+    approvalBroker,
+    makeScpRunner(),
+    jobRepository,
+    publishJobUpdated,
+    artifactResolver,
+    storageRoot,
+    concurrencyManager
+  )
+
+const makeJobRepo = (
+  jobs: Map<string, import('../../shared/compute').ComputeJob> = new Map()
+): {
+  repo: import('./job-repository').ComputeJobRepository
+  createCalls: ReturnType<typeof vi.fn>
+  updateCalls: ReturnType<typeof vi.fn>
+} => {
+  const createCalls = vi.fn(async (request: import('./job-repository').CreateJobRequest) => {
+    const job: import('../../shared/compute').ComputeJob = {
+      job_id: request.id,
+      provider_id: request.providerId,
+      shape: request.shape,
+      session_id: request.sessionId,
+      project_id: request.projectId,
+      status: 'submitted',
+      intent: request.intent,
+      command: request.command,
+      command_hash: request.commandHash,
+      environment: request.environment,
+      resource_request: request.resourceRequest,
+      input_manifest: request.inputManifest,
+      output_manifest: request.outputManifest,
+      harvest_config: request.harvestConfig,
+      timeout_seconds: request.timeoutSeconds,
+      remote_workdir: request.remoteWorkdir,
+      remote_handle: undefined,
+      exit_code: undefined,
+      stdout_tail: undefined,
+      stderr_tail: undefined,
+      error_code: undefined,
+      created_at: Date.now(),
+      submitted_at: Date.now(),
+      started_at: undefined,
+      finished_at: undefined,
+      harvested_at: undefined
+    }
+    jobs.set(request.id, job)
+    return job
+  })
+  const updateCalls = vi.fn(async (jobId: string, updates: unknown) => {
+    const job = jobs.get(jobId) ?? { job_id: jobId }
+    const updated = { ...job, ...(updates as object) }
+    jobs.set(jobId, updated as import('../../shared/compute').ComputeJob)
+    return updated as import('../../shared/compute').ComputeJob
+  })
+  const getCalls = vi.fn(async (jobId: string) => jobs.get(jobId) ?? null)
+  const findNonTerminalCalls = vi.fn(async () => Array.from(jobs.values()))
+
+  return {
+    repo: {
+      create: createCalls,
+      get: getCalls,
+      update: updateCalls,
+      findNonTerminal: findNonTerminalCalls,
+      findNonTerminalByProvider: vi.fn(async () => []),
+      hasActiveJobsForProvider: vi.fn(async () => false)
+    } as unknown as import('./job-repository').ComputeJobRepository,
+    createCalls,
+    updateCalls
+  }
+}
+
+describe('ComputeJobWorkflowOwner.submitJob', () => {
+  it('returns job_id + remote_workdir immediately (before dispatch)', async () => {
+    // Runner should never be called for submit_job itself (dispatch is background).
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo: jobRepo, createCalls } = makeJobRepo()
+    const { repo } = makeRepo()
+
+    const approveDecision = vi.fn(() => Promise.resolve('once' as const))
+    const broker = {
+      request: approveDecision,
+      requestWithContext: approveDecision,
+      respond: vi.fn()
+    } as unknown as ComputeApprovalBroker
+
+    const service = makeOwner(runner, repo, broker, jobRepo)
+
+    const result = await service.submitJob(
+      'ssh:biowulf',
+      'smoke test',
+      'echo hello',
+      {},
+      { sessionId: 'sess-1', projectId: 'proj-1' }
+    )
+
+    expect(result.status).toBe('submitted')
+    expect(result.provider_id).toBe('ssh:biowulf')
+    expect(result.job_id).toBeDefined()
+    expect(result.remote_workdir).toContain('.openscience/jobs/')
+    expect(createCalls).toHaveBeenCalledOnce()
+  })
+
+  it('throws approval_denied and does NOT create a DB row when approval is denied', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo: jobRepo, createCalls } = makeJobRepo()
+    const { repo } = makeRepo()
+
+    const denyDecision = vi.fn(() => Promise.resolve('deny' as const))
+    const broker = {
+      request: denyDecision,
+      requestWithContext: denyDecision,
+      respond: vi.fn()
+    } as unknown as ComputeApprovalBroker
+
+    const service = makeOwner(runner, repo, broker, jobRepo)
+
+    const err = await service
+      .submitJob('ssh:biowulf', 'test', 'echo hi', {}, { sessionId: 's1', projectId: 'p1' })
+      .catch((e) => e)
+
+    expect(err.computeCallError?.error_code).toBe('approval_denied')
+    // No DB row should have been created.
+    expect(createCalls).not.toHaveBeenCalled()
+  })
+
+  it('uses operation=submit_job for grant memory (not call_command)', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo: jobRepo } = makeJobRepo()
+    const { repo } = makeRepo()
+
+    const requestWithContext = vi.fn(() => Promise.resolve('conversation' as const))
+    const broker = {
+      request: vi.fn(),
+      requestWithContext,
+      respond: vi.fn()
+    } as unknown as ComputeApprovalBroker
+
+    const service = makeOwner(runner, repo, broker, jobRepo)
+
+    await service.submitJob(
+      'ssh:biowulf',
+      'test',
+      'echo hi',
+      {},
+      { sessionId: 's1', projectId: 'p1' }
+    )
+
+    expect(requestWithContext).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ operation: 'submit_job' })
+    )
+  })
+
+  it('rejects timeout_seconds > 7 days', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo: jobRepo } = makeJobRepo()
+    const { repo } = makeRepo()
+    const broker = {
+      request: vi.fn(),
+      requestWithContext: vi.fn(() => Promise.resolve('once' as const)),
+      respond: vi.fn()
+    } as unknown as ComputeApprovalBroker
+
+    const service = makeOwner(runner, repo, broker, jobRepo)
+
+    const err = await service
+      .submitJob(
+        'ssh:biowulf',
+        'test',
+        'echo hi',
+        { timeoutSeconds: 8 * 24 * 3600 },
+        { sessionId: 's1', projectId: 'p1' }
+      )
+      .catch((e) => e)
+
+    expect(err.computeCallError?.error_code).toBe('timeout')
+  })
+
+  it('approval fires before any DB row is created (security contract)', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo: jobRepo, createCalls } = makeJobRepo()
+    const { repo } = makeRepo()
+
+    let approvalCalledAt: number | undefined
+    let createCalledAt: number | undefined
+
+    const requestWithContext = vi.fn(async () => {
+      approvalCalledAt = Date.now()
+      await new Promise((r) => setTimeout(r, 1))
+      return 'once' as const
+    })
+    const broker = {
+      request: vi.fn(),
+      requestWithContext,
+      respond: vi.fn()
+    } as unknown as ComputeApprovalBroker
+
+    createCalls.mockImplementation(async (request: import('./job-repository').CreateJobRequest) => {
+      createCalledAt = Date.now()
+      return {
+        job_id: request.id,
+        provider_id: request.providerId,
+        shape: request.shape,
+        session_id: request.sessionId,
+        project_id: request.projectId,
+        status: 'submitted' as const,
+        intent: request.intent,
+        command: request.command,
+        command_hash: request.commandHash,
+        environment: undefined,
+        resource_request: undefined,
+        input_manifest: undefined,
+        output_manifest: undefined,
+        harvest_config: undefined,
+        timeout_seconds: request.timeoutSeconds,
+        remote_workdir: request.remoteWorkdir,
+        remote_handle: undefined,
+        exit_code: undefined,
+        stdout_tail: undefined,
+        stderr_tail: undefined,
+        error_code: undefined,
+        created_at: Date.now(),
+        submitted_at: Date.now(),
+        started_at: undefined,
+        finished_at: undefined,
+        harvested_at: undefined
+      }
+    })
+
+    const service = makeOwner(runner, repo, broker, jobRepo)
+    await service.submitJob(
+      'ssh:biowulf',
+      'test',
+      'echo hi',
+      {},
+      { sessionId: 's1', projectId: 'p1' }
+    )
+
+    expect(approvalCalledAt).toBeDefined()
+    expect(createCalledAt).toBeDefined()
+    expect(approvalCalledAt!).toBeLessThanOrEqual(createCalledAt!)
+  })
+})
+
+describe('ComputeJobWorkflowOwner.getJobStatus', () => {
+  it('returns status shape from DB without SSH', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const jobs = new Map<string, import('../../shared/compute').ComputeJob>()
+    const job: import('../../shared/compute').ComputeJob = {
+      job_id: 'job-42',
+      provider_id: 'ssh:biowulf',
+      shape: 'direct_ssh',
+      session_id: 'sess-1',
+      project_id: 'proj-1',
+      status: 'success',
+      intent: 'test',
+      command: 'echo hi',
+      command_hash: 'abc',
+      environment: undefined,
+      resource_request: undefined,
+      input_manifest: undefined,
+      output_manifest: undefined,
+      harvest_config: undefined,
+      timeout_seconds: 3600,
+      remote_workdir: '~/.openscience/jobs/job-42',
+      remote_handle: undefined,
+      exit_code: 0,
+      stdout_tail: 'hi\n',
+      stderr_tail: '',
+      error_code: undefined,
+      created_at: 1,
+      submitted_at: 1,
+      started_at: 1,
+      finished_at: 2,
+      harvested_at: undefined
+    }
+    jobs.set('job-42', job)
+    const { repo: jobRepo } = makeJobRepo(jobs)
+    const { repo } = makeRepo()
+
+    const service = makeOwner(runner, repo, undefined, jobRepo)
+
+    const status = await service.getJobStatus('job-42')
+    expect(status.job_id).toBe('job-42')
+    expect(status.status).toBe('success')
+    expect(status.exit_code).toBe(0)
+    expect(status.stdout_tail).toBe('hi\n')
+    expect(status.remote_workdir).toBe('~/.openscience/jobs/job-42')
+
+    // SSH runner should NOT have been called.
+    expect((runner.run as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0)
+  })
+
+  it('throws when job not found', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo: jobRepo } = makeJobRepo()
+    const { repo } = makeRepo()
+
+    const service = makeOwner(runner, repo, undefined, jobRepo)
+
+    await expect(service.getJobStatus('nonexistent')).rejects.toThrow(/No compute job/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveInputs — unit tests for input staging validation/resolution
+// ---------------------------------------------------------------------------
+
+describe('resolveInputs — workspace source', () => {
+  it('resolves a workspace path to an absolute local path', async () => {
+    const { entries, inputsSummary } = await resolveInputs(
+      [{ src: 'data/sample.fa', dst_filename: 'sample.fa' }],
+      '/workspace/root',
+      undefined
+    )
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ kind: 'upload', dstFilename: 'sample.fa' })
+    expect((entries[0] as { localPath: string }).localPath).toBe(
+      resolve('/workspace/root', 'data/sample.fa')
+    )
+    expect(inputsSummary).toBe('1 input: sample.fa')
+  })
+
+  it('rejects a workspace path that escapes the workspace root via ../', async () => {
+    await expect(
+      resolveInputs(
+        [{ src: '../../etc/passwd', dst_filename: 'passwd' }],
+        '/workspace/root',
+        undefined
+      )
+    ).rejects.toThrow(/escape/)
+  })
+
+  it('throws when workspaceCwd is missing for a workspace src', async () => {
+    await expect(
+      resolveInputs([{ src: 'data.csv', dst_filename: 'data.csv' }], undefined, undefined)
+    ).rejects.toThrow(/workspace_cwd/)
+  })
+})
+
+describe('resolveInputs — artifact source', () => {
+  it('resolves an absolute artifact-store path via ArtifactResolver to a local path', async () => {
+    const resolver = {
+      resolveArtifactPath: vi.fn(async () => '/storage/artifacts/sess/run/model.pkl')
+    }
+    const { entries, inputsSummary } = await resolveInputs(
+      [{ src: '/storage/artifacts/sess/run/model.pkl', dst_filename: 'model.pkl' }],
+      undefined,
+      resolver
+    )
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      kind: 'upload',
+      localPath: '/storage/artifacts/sess/run/model.pkl',
+      dstFilename: 'model.pkl'
+    })
+    expect(inputsSummary).toBe('1 input: model.pkl')
+    expect(resolver.resolveArtifactPath).toHaveBeenCalledWith(
+      '/storage/artifacts/sess/run/model.pkl'
+    )
+  })
+
+  it('throws when artifactResolver is missing for an absolute (artifact) src', async () => {
+    await expect(
+      resolveInputs(
+        [{ src: '/storage/artifacts/sess/run/model.pkl', dst_filename: 'model.pkl' }],
+        undefined,
+        undefined
+      )
+    ).rejects.toThrow(/ArtifactResolver/)
+  })
+})
+
+describe('resolveInputs — remote_path source', () => {
+  it('creates a symlink entry for an absolute remote path', async () => {
+    const { entries, inputsSummary } = await resolveInputs(
+      [{ remote_path: '/scratch/ref.fa', dst_filename: 'ref.fa' }],
+      undefined,
+      undefined
+    )
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      kind: 'symlink',
+      remotePath: '/scratch/ref.fa',
+      dstFilename: 'ref.fa'
+    })
+    expect(inputsSummary).toBe('1 input: ref.fa (symlink)')
+  })
+
+  it('infers dst_filename from basename when omitted', async () => {
+    const { entries } = await resolveInputs(
+      [{ remote_path: '/scratch/genome.fa' }],
+      undefined,
+      undefined
+    )
+    expect(entries[0]).toMatchObject({ kind: 'symlink', dstFilename: 'genome.fa' })
+  })
+
+  it('rejects a relative remote_path', async () => {
+    await expect(
+      resolveInputs([{ remote_path: 'relative/path' }], undefined, undefined)
+    ).rejects.toThrow(/absolute/)
+  })
+
+  it('rejects a remote_path with glob characters', async () => {
+    await expect(
+      resolveInputs([{ remote_path: '/scratch/*.fa' }], undefined, undefined)
+    ).rejects.toThrow(/glob/)
+  })
+
+  it('rejects a remote_path with shell-unsafe characters', async () => {
+    await expect(
+      resolveInputs([{ remote_path: '/scratch/$(id)' }], undefined, undefined)
+    ).rejects.toThrow(/shell-unsafe/)
+  })
+})
+
+describe('resolveInputs — dst_filename validation', () => {
+  it('rejects a dst_filename containing /', async () => {
+    await expect(
+      resolveInputs([{ src: 'data.csv', dst_filename: 'sub/data.csv' }], '/workspace', undefined)
+    ).rejects.toThrow(/bare filename/)
+  })
+
+  it('rejects an empty dst_filename', async () => {
+    await expect(
+      resolveInputs([{ src: 'data.csv', dst_filename: '' }], '/workspace', undefined)
+    ).rejects.toThrow(/bare filename/)
+  })
+})
+
+describe('resolveInputs — mixed inputs summary', () => {
+  it('builds summary for multiple inputs of different kinds', async () => {
+    const resolver = {
+      resolveArtifactPath: vi.fn(async () => '/storage/model.pkl')
+    }
+    const { entries, inputsSummary } = await resolveInputs(
+      [
+        { src: 'data.csv', dst_filename: 'data.csv' },
+        { src: '/storage/artifacts/s/r/model.pkl', dst_filename: 'model.pkl' },
+        { remote_path: '/scratch/ref.fa', dst_filename: 'ref.fa' }
+      ],
+      '/workspace',
+      resolver
+    )
+    expect(entries).toHaveLength(3)
+    expect(inputsSummary).toBe('3 inputs: data.csv, model.pkl, ref.fa (symlink)')
+  })
+
+  it('returns empty summary when no inputs', async () => {
+    const { entries, inputsSummary } = await resolveInputs([], '/workspace', undefined)
+    expect(entries).toHaveLength(0)
+    expect(inputsSummary).toBe('')
+  })
+})
+
+describe('ComputeJobWorkflowOwner.submitJob — inputs_summary in approval', () => {
+  it('passes inputs_summary to the approval request when inputs are provided', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo: jobRepo } = makeJobRepo()
+    const { repo } = makeRepo()
+
+    const requestWithContext = vi.fn(() => Promise.resolve('once' as const))
+    const broker = {
+      request: requestWithContext,
+      requestWithContext,
+      respond: vi.fn()
+    } as unknown as ComputeApprovalBroker
+
+    const service = makeOwner(runner, repo, broker, jobRepo)
+
+    await service.submitJob(
+      'ssh:biowulf',
+      'test',
+      'echo hi',
+      {
+        inputs: [{ remote_path: '/scratch/ref.fa', dst_filename: 'ref.fa' }]
+      },
+      { sessionId: 's1', projectId: 'p1' }
+    )
+
+    const callArg = (requestWithContext as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
+      inputs_summary?: string
+    }
+    expect(callArg.inputs_summary).toBe('1 input: ref.fa (symlink)')
+  })
+
+  it('stores resolved inputManifest in the DB row', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo: jobRepo, createCalls } = makeJobRepo()
+    const { repo } = makeRepo()
+
+    const broker = {
+      request: vi.fn(() => Promise.resolve('once' as const)),
+      requestWithContext: vi.fn(() => Promise.resolve('once' as const)),
+      respond: vi.fn()
+    } as unknown as ComputeApprovalBroker
+
+    const service = makeOwner(runner, repo, broker, jobRepo)
+
+    await service.submitJob(
+      'ssh:biowulf',
+      'test',
+      'echo hi',
+      {
+        inputs: [{ remote_path: '/scratch/ref.fa', dst_filename: 'ref.fa' }]
+      },
+      { sessionId: 's1', projectId: 'p1' }
+    )
+
+    const createArg = (createCalls as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
+      inputManifest?: string
+    }
+    expect(createArg.inputManifest).toBeDefined()
+    const manifest = JSON.parse(createArg.inputManifest!) as Array<{
+      kind: string
+      remotePath: string
+      dstFilename: string
+    }>
+    expect(manifest).toHaveLength(1)
+    expect(manifest[0]).toMatchObject({
+      kind: 'symlink',
+      remotePath: '/scratch/ref.fa',
+      dstFilename: 'ref.fa'
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ComputeJobWorkflowOwner.getJobResult — four-timing semantics (design §9, issue 04)
+// ---------------------------------------------------------------------------
+
+describe('ComputeJobWorkflowOwner.getJobResult', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'job-result-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  const makeServiceWithStorageRoot = (
+    job: import('../../shared/compute').ComputeJob,
+    storageRoot: string
+  ): ComputeJobWorkflowOwner => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const jobs = new Map([[job.job_id, job]])
+    const { repo: jobRepo } = makeJobRepo(jobs)
+    const { repo } = makeRepo()
+    return makeOwner(runner, repo, undefined, jobRepo, undefined, undefined, storageRoot)
+  }
+
+  const baseJob = (
+    overrides: Partial<import('../../shared/compute').ComputeJob> = {}
+  ): import('../../shared/compute').ComputeJob => ({
+    job_id: 'job-result-1',
+    provider_id: 'ssh:biowulf',
+    shape: 'direct_ssh',
+    session_id: 'sess-1',
+    project_id: 'proj-1',
+    status: 'success',
+    intent: 'test',
+    command: 'echo hi',
+    command_hash: 'abc',
+    environment: undefined,
+    resource_request: undefined,
+    input_manifest: undefined,
+    output_manifest: undefined,
+    harvest_config: undefined,
+    timeout_seconds: 3600,
+    remote_workdir: '~/.openscience/jobs/job-result-1',
+    remote_handle: undefined,
+    exit_code: 0,
+    stdout_tail: 'hi\n',
+    stderr_tail: '',
+    error_code: undefined,
+    created_at: 1,
+    submitted_at: 1,
+    started_at: 1,
+    finished_at: 2,
+    harvested_at: undefined,
+    ...overrides
+  })
+
+  it('non-terminal status: returns empty file lists without error', async () => {
+    const job = baseJob({ status: 'running', harvested_at: undefined })
+    const service = makeServiceWithStorageRoot(job, tmpDir)
+    const result = await service.getJobResult('job-result-1')
+    expect(result.status).toBe('running')
+    expect(result.featured_files).toEqual([])
+    expect(result.hidden_files).toEqual([])
+    expect(result.output_files).toEqual([])
+    expect(result.left_on_remote).toEqual([])
+  })
+
+  it('terminal but harvest not done: returns empty file lists without error', async () => {
+    const job = baseJob({ status: 'success', harvested_at: undefined })
+    const service = makeServiceWithStorageRoot(job, tmpDir)
+    const result = await service.getJobResult('job-result-1')
+    expect(result.status).toBe('success')
+    expect(result.featured_files).toEqual([])
+    expect(result.output_files).toEqual([])
+  })
+
+  it('clean harvest: returns full file lists with workspace-relative paths', async () => {
+    const harvestDir = join(tmpDir, 'notebooks', 'proj-1', 'sess-1', 'hpc', 'job-result-1')
+    await mkdir(join(harvestDir, 'featured'), { recursive: true })
+    await mkdir(join(harvestDir, 'hidden'), { recursive: true })
+    await writeFile(join(harvestDir, 'featured', 'out.result'), 'result data')
+    await writeFile(join(harvestDir, 'hidden', 'debug.log'), 'log data')
+
+    const job = baseJob({ harvested_at: Date.now(), harvest_error: undefined })
+    const service = makeServiceWithStorageRoot(job, tmpDir)
+    const result = await service.getJobResult('job-result-1')
+
+    expect(result.status).toBe('success')
+    expect(result.exit_code).toBe(0)
+    expect(result.featured_files).toContain('hpc/job-result-1/featured/out.result')
+    expect(result.hidden_files).toContain('hpc/job-result-1/hidden/debug.log')
+    expect(result.output_files).toContain('hpc/job-result-1/featured/out.result')
+    expect(result.output_files).toContain('hpc/job-result-1/hidden/debug.log')
+    // featured entries come before hidden in output_files
+    const featIdx = result.output_files.indexOf('hpc/job-result-1/featured/out.result')
+    const hidIdx = result.output_files.indexOf('hpc/job-result-1/hidden/debug.log')
+    expect(featIdx).toBeLessThan(hidIdx)
+  })
+
+  it('reads attach_job results from the data-root workspace when config and data roots differ', async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), 'job-result-config-root-'))
+    const dataRoot = await mkdtemp(join(tmpdir(), 'job-result-data-root-'))
+    const dataHarvestDir = join(dataRoot, 'notebooks', 'proj-1', 'sess-1', 'hpc', 'job-result-1')
+    const configHarvestDir = join(
+      configRoot,
+      'notebooks',
+      'proj-1',
+      'sess-1',
+      'hpc',
+      'job-result-1'
+    )
+    await mkdir(join(dataHarvestDir, 'featured'), { recursive: true })
+    await mkdir(join(configHarvestDir, 'featured'), { recursive: true })
+    await writeFile(join(dataHarvestDir, 'featured', 'data-root.result'), 'readable by notebook')
+    await writeFile(
+      join(configHarvestDir, 'featured', 'stale-config.result'),
+      'must not be returned'
+    )
+
+    try {
+      const service = makeServiceWithStorageRoot(baseJob({ harvested_at: Date.now() }), dataRoot)
+      const result = await service.getJobResult('job-result-1')
+      expect(result.featured_files).toEqual(['hpc/job-result-1/featured/data-root.result'])
+      expect(result.output_files).toEqual(['hpc/job-result-1/featured/data-root.result'])
+    } finally {
+      await rm(configRoot, { recursive: true, force: true })
+      await rm(dataRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('harvest_failed: partial files returned, remote_workdir preserved', async () => {
+    const harvestDir = join(tmpDir, 'notebooks', 'proj-1', 'sess-1', 'hpc', 'job-result-1')
+    await mkdir(join(harvestDir, 'featured'), { recursive: true })
+    await writeFile(join(harvestDir, 'featured', 'partial.result'), 'partial')
+
+    const leftOnRemote = JSON.stringify([
+      { uri: 'ssh://biowulf/tmp/big.bin', size_mb: 150, reason: 'exceeds_max_file_mb' }
+    ])
+    const job = baseJob({
+      harvested_at: Date.now(),
+      harvest_error: 'scp failed: connection reset',
+      left_on_remote: leftOnRemote,
+      remote_workdir: '~/.openscience/jobs/job-result-1'
+    })
+    const service = makeServiceWithStorageRoot(job, tmpDir)
+    const result = await service.getJobResult('job-result-1')
+
+    expect(result.status).toBe('success')
+    expect(result.featured_files).toContain('hpc/job-result-1/featured/partial.result')
+    expect(result.remote_workdir).toBe('~/.openscience/jobs/job-result-1')
+    expect(result.left_on_remote).toHaveLength(1)
+    expect(result.left_on_remote[0].uri).toBe('ssh://biowulf/tmp/big.bin')
+  })
+
+  it('throws when job not found', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo: jobRepo } = makeJobRepo()
+    const { repo } = makeRepo()
+    const service = makeOwner(runner, repo, undefined, jobRepo, undefined, undefined, tmpDir)
+    await expect(service.getJobResult('no-such-job')).rejects.toThrow(/No compute job/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session concurrency control (Phase 3c, issue 04)
+// ---------------------------------------------------------------------------
+
+describe('setSessionConcurrencyLimit', () => {
+  it('delegates to concurrency manager', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo } = makeRepo()
+    const setSessionLimit = vi.fn()
+    const concurrencyManager = {
+      setSessionLimit,
+      getStatus: vi.fn(),
+      enqueue: vi.fn(),
+      onJobCompleted: vi.fn()
+    }
+    const service = makeOwner(
+      runner,
+      repo,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      concurrencyManager as unknown as ConcurrencyManager
+    )
+
+    await service.setSessionConcurrencyLimit('session-123', 10)
+    expect(setSessionLimit).toHaveBeenCalledWith('session-123', 10)
+  })
+
+  it('throws when concurrency manager not initialized', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo } = makeRepo()
+    const service = makeOwner(runner, repo)
+
+    await expect(service.setSessionConcurrencyLimit('session-123', 10)).rejects.toThrow(
+      /ConcurrencyManager is required/
+    )
+  })
+
+  it('validates limit is positive integer', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo } = makeRepo()
+    const concurrencyManager = {
+      setSessionLimit: vi.fn(),
+      getStatus: vi.fn(),
+      enqueue: vi.fn(),
+      onJobCompleted: vi.fn()
+    }
+    const service = makeOwner(
+      runner,
+      repo,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      concurrencyManager as unknown as ConcurrencyManager
+    )
+
+    await expect(service.setSessionConcurrencyLimit('session-123', 0)).rejects.toThrow(
+      /integer in the range 1\.\.500/
+    )
+    await expect(service.setSessionConcurrencyLimit('session-123', -5)).rejects.toThrow(
+      /integer in the range 1\.\.500/
+    )
+    await expect(service.setSessionConcurrencyLimit('session-123', 3.5)).rejects.toThrow(
+      /integer in the range 1\.\.500/
+    )
+  })
+})
+
+describe('getSessionConcurrencyStatus', () => {
+  it('delegates to concurrency manager and enriches with all host ceilings', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const hostA = sampleHost({ providerId: 'ssh:host-a', concurrencyLimit: 20 })
+    const hostB = sampleHost({ providerId: 'ssh:host-b', concurrencyLimit: undefined })
+    const hostC = sampleHost({ providerId: 'ssh:host-c', concurrencyLimit: 50 })
+    const list = vi.fn(() => Promise.resolve([hostA, hostB, hostC]))
+    const { repo } = makeRepo()
+    repo.list = list
+
+    const managerStatus = {
+      session_limit: 10,
+      active_count: 3,
+      queued_count: 2,
+      provider_ceilings: { 'ssh:host-a': 20 } // Only one host has jobs in this session
+    }
+    const getStatus = vi.fn(() => Promise.resolve(managerStatus))
+    const concurrencyManager = {
+      setSessionLimit: vi.fn(),
+      getStatus,
+      enqueue: vi.fn(),
+      onJobCompleted: vi.fn()
+    }
+    const service = makeOwner(
+      runner,
+      repo,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      concurrencyManager as unknown as ConcurrencyManager
+    )
+
+    const result = await service.getSessionConcurrencyStatus('session-123')
+    expect(getStatus).toHaveBeenCalledWith('session-123')
+    expect(result.session_limit).toBe(10)
+    expect(result.active_count).toBe(3)
+    expect(result.queued_count).toBe(2)
+    // All registered hosts appear in provider_ceilings
+    expect(result.provider_ceilings['ssh:host-a']).toBe(20) // from jobs
+    expect(result.provider_ceilings['ssh:host-b']).toBe(10) // added (null -> 10)
+    expect(result.provider_ceilings['ssh:host-c']).toBe(50) // added
+  })
+
+  it('throws when concurrency manager not initialized', async () => {
+    const runner = makeFakeRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const { repo } = makeRepo()
+    const service = makeOwner(runner, repo)
+
+    await expect(service.getSessionConcurrencyStatus('session-123')).rejects.toThrow(
+      /ConcurrencyManager is required/
+    )
+  })
+})
+
+describe('ComputeJobWorkflowOwner.handleJobUpdated', () => {
+  const job = { job_id: 'job-1', status: 'running' } as import('../../shared/compute').ComputeJob
+
+  it('publishes only through the concurrency manager when configured', () => {
+    const managerPublish = vi.fn()
+    const fallbackPublish = vi.fn()
+    const { repo } = makeRepo()
+    const owner = makeOwner(
+      makeFakeRunner({
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        truncated: false,
+        timedOut: false
+      }),
+      repo,
+      undefined,
+      undefined,
+      fallbackPublish,
+      undefined,
+      undefined,
+      { handleJobUpdated: managerPublish } as unknown as ConcurrencyManager
+    )
+
+    owner.handleJobUpdated(job)
+
+    expect(managerPublish).toHaveBeenCalledOnce()
+    expect(managerPublish).toHaveBeenCalledWith(job)
+    expect(fallbackPublish).not.toHaveBeenCalled()
+  })
+
+  it('publishes only through the fallback when no concurrency manager is configured', () => {
+    const fallbackPublish = vi.fn()
+    const { repo } = makeRepo()
+    const owner = makeOwner(
+      makeFakeRunner({
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        truncated: false,
+        timedOut: false
+      }),
+      repo,
+      undefined,
+      undefined,
+      fallbackPublish
+    )
+
+    owner.handleJobUpdated(job)
+
+    expect(fallbackPublish).toHaveBeenCalledOnce()
+    expect(fallbackPublish).toHaveBeenCalledWith(job)
+  })
+})

--- a/src/main/compute/compute-job-workflow-owner.ts
+++ b/src/main/compute/compute-job-workflow-owner.ts
@@ -1,0 +1,449 @@
+import { randomUUID } from 'node:crypto'
+import { readdir } from 'node:fs/promises'
+import { basename, isAbsolute, join, relative, resolve } from 'node:path'
+
+import type {
+  ComputeCallError,
+  ComputeJob,
+  JobResult,
+  JobStatusResult,
+  SubmitJobResult
+} from '../../shared/compute'
+import { getNotebookSessionRoot } from '../notebook/repository'
+import type { ComputeApprovalBroker } from './compute-approval-broker'
+import type { ConcurrencyManager, SessionStatus } from './concurrency-manager'
+import { computeRemoteWorkdir, dispatchJob, hashCommand } from './job-dispatcher'
+import type { StagedInputEntry } from './job-dispatcher'
+import type { ComputeJobRepository } from './job-repository'
+import { getJobHarvestDir } from './harvest-engine'
+import type { ComputeHostRepository } from './repository'
+import type { ScpRunner } from './scp-runner'
+import { GLOB_CHARS, SHELL_UNSAFE_CHARS } from './scp-runner'
+import type { SshRunner } from './ssh-runner'
+import { workspaceRelativePath } from './workspace-path'
+
+const COMMAND_PREVIEW_MAX_LEN = 120
+const JOB_MAX_TIMEOUT_SECONDS = 7 * 24 * 3600
+const JOB_DEFAULT_TIMEOUT_SECONDS = 24 * 3600
+const TERMINAL_JOB_STATUSES: ReadonlySet<ComputeJob['status']> = new Set([
+  'success',
+  'failed',
+  'timeout',
+  'error'
+])
+
+export type RawInputSpec =
+  { src: string; dst_filename: string } | { remote_path: string; dst_filename?: string }
+
+export interface ArtifactResolver {
+  resolveArtifactPath(path: string): Promise<string>
+}
+
+const assertBareName = (name: string, label: string): void => {
+  if (!name || name.includes('/') || name.includes('\\') || name === '.' || name === '..') {
+    throw new Error(
+      `dst_filename must be a bare filename with no path separators (got "${name}" for ${label})`
+    )
+  }
+}
+
+const resolveWorkspacePath = (workspaceCwd: string, srcPath: string): string => {
+  const resolved = resolve(workspaceCwd, srcPath)
+  const rel = relative(resolve(workspaceCwd), resolved)
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(`workspace path "${srcPath}" would escape the workspace root "${workspaceCwd}"`)
+  }
+  return resolved
+}
+
+export const resolveInputs = async (
+  rawInputs: RawInputSpec[],
+  workspaceCwd: string | undefined,
+  artifactResolver: ArtifactResolver | undefined
+): Promise<{ entries: StagedInputEntry[]; inputsSummary: string }> => {
+  const entries: StagedInputEntry[] = []
+  const summaryParts: string[] = []
+
+  for (const raw of rawInputs) {
+    if ('remote_path' in raw) {
+      const remotePath = raw.remote_path
+      if (!remotePath.startsWith('/')) {
+        throw new Error(`remote_path must be an absolute path (got "${remotePath}")`)
+      }
+      if (GLOB_CHARS.test(remotePath)) {
+        throw new Error(`remote_path must not contain glob characters (got "${remotePath}")`)
+      }
+      if (SHELL_UNSAFE_CHARS.test(remotePath)) {
+        throw new Error(
+          `remote_path must not contain shell-unsafe characters (got "${remotePath}")`
+        )
+      }
+      const dstFilename = raw.dst_filename ?? basename(remotePath)
+      assertBareName(dstFilename, `remote_path "${remotePath}"`)
+      entries.push({
+        kind: 'symlink',
+        remotePath,
+        dstFilename,
+        label: remotePath
+      })
+      summaryParts.push(`${dstFilename} (symlink)`)
+      continue
+    }
+
+    const { src, dst_filename: dstFilename } = raw
+    assertBareName(dstFilename, `src "${src}"`)
+    if (isAbsolute(src)) {
+      if (!artifactResolver) {
+        throw new Error(`Cannot resolve artifact "${src}": ArtifactResolver is not available`)
+      }
+      const localPath = await artifactResolver.resolveArtifactPath(src)
+      entries.push({ kind: 'upload', localPath, dstFilename, label: src })
+    } else {
+      if (!workspaceCwd) {
+        throw new Error(`Cannot resolve workspace path "${src}": workspace_cwd is not available`)
+      }
+      const localPath = resolveWorkspacePath(workspaceCwd, src)
+      entries.push({ kind: 'upload', localPath, dstFilename, label: src })
+    }
+    summaryParts.push(dstFilename)
+  }
+
+  return {
+    entries,
+    inputsSummary:
+      entries.length === 0
+        ? ''
+        : `${entries.length} input${entries.length === 1 ? '' : 's'}: ${summaryParts.join(', ')}`
+  }
+}
+
+const queueFullError = (): Error & { computeCallError: ComputeCallError } => {
+  const message =
+    'Job queue is full (100 queued jobs). Wait for queued jobs to start running before submitting more.'
+  const error = new Error(message) as Error & { computeCallError: ComputeCallError }
+  error.computeCallError = {
+    error_code: 'queue_full',
+    message,
+    retry_after_user_action: false
+  }
+  return error
+}
+
+export class ComputeJobWorkflowOwner {
+  constructor(
+    private readonly runner: SshRunner,
+    private readonly hostRepository: ComputeHostRepository,
+    private readonly approvalBroker: ComputeApprovalBroker | undefined,
+    private readonly scpRunner: ScpRunner,
+    private readonly jobRepository: ComputeJobRepository | undefined,
+    private readonly publishJobUpdated: ((job: ComputeJob) => void) | undefined,
+    private readonly artifactResolver: ArtifactResolver | undefined,
+    private readonly storageRoot: string | undefined,
+    private readonly concurrencyManager: ConcurrencyManager | undefined
+  ) {}
+
+  async submitJob(
+    providerId: string,
+    intent: string,
+    command: string,
+    options: {
+      environment?: string
+      resourceRequest?: string
+      inputs?: RawInputSpec[]
+      outputManifest?: string
+      harvestConfig?: string
+      timeoutSeconds?: number
+      workspaceCwd?: string
+    },
+    context: { sessionId: string; projectId: string }
+  ): Promise<SubmitJobResult> {
+    if (!this.jobRepository) {
+      throw new Error('ComputeJobRepository is required to call submitJob.')
+    }
+
+    const host = await this.hostRepository.get(providerId)
+    if (!host) {
+      throw new Error(`No compute host found with provider id "${providerId}".`)
+    }
+
+    const rawTimeout = options.timeoutSeconds
+    if (rawTimeout !== undefined) {
+      if (!Number.isFinite(rawTimeout)) {
+        const error = new Error(
+          `timeout_seconds must be a finite number (got ${rawTimeout}).`
+        ) as Error & { computeCallError: ComputeCallError }
+        error.computeCallError = {
+          error_code: 'timeout',
+          message: 'timeout_seconds must be a finite number.',
+          retry_after_user_action: false
+        }
+        throw error
+      }
+      if (!Number.isInteger(rawTimeout) || rawTimeout <= 0) {
+        const error = new Error(
+          `timeout_seconds must be a positive integer (got ${rawTimeout}).`
+        ) as Error & { computeCallError: ComputeCallError }
+        error.computeCallError = {
+          error_code: 'timeout',
+          message: 'timeout_seconds must be a positive integer.',
+          retry_after_user_action: false
+        }
+        throw error
+      }
+      if (rawTimeout > JOB_MAX_TIMEOUT_SECONDS) {
+        const error = new Error(
+          `timeout_seconds ${rawTimeout} exceeds the 7-day maximum. Use a scheduler driver for multi-day jobs.`
+        ) as Error & { computeCallError: ComputeCallError }
+        error.computeCallError = {
+          error_code: 'timeout',
+          message: `timeout_seconds exceeds the 7-day (${JOB_MAX_TIMEOUT_SECONDS}s) maximum.`,
+          retry_after_user_action: false
+        }
+        throw error
+      }
+    }
+    const timeoutSeconds = rawTimeout ?? JOB_DEFAULT_TIMEOUT_SECONDS
+
+    let stagedEntries: StagedInputEntry[] = []
+    let inputsSummary = ''
+    if (options.inputs && options.inputs.length > 0) {
+      const resolved = await resolveInputs(
+        options.inputs,
+        options.workspaceCwd,
+        this.artifactResolver
+      )
+      stagedEntries = resolved.entries
+      inputsSummary = resolved.inputsSummary
+    }
+
+    const jobId = randomUUID()
+    const remoteWorkdir = computeRemoteWorkdir(host.scratchRoot, jobId)
+    if (this.concurrencyManager) {
+      const preview = await this.concurrencyManager.enqueue({
+        jobId,
+        sessionId: context.sessionId,
+        providerId
+      })
+      if (preview === 'queue_full') throw queueFullError()
+    }
+
+    if (!this.approvalBroker) {
+      throw new Error('ComputeApprovalBroker is required to call submitJob.')
+    }
+    const commandPreview =
+      command.length > COMMAND_PREVIEW_MAX_LEN
+        ? `${command.slice(0, COMMAND_PREVIEW_MAX_LEN)}…`
+        : command
+    const decision = await this.approvalBroker.requestWithContext(
+      {
+        provider_id: host.providerId,
+        provider_name: host.displayName,
+        shape: host.shape,
+        intent,
+        command_preview: commandPreview,
+        command_full: command,
+        inputs_summary: inputsSummary || undefined,
+        timeout_seconds: timeoutSeconds,
+        remote_workdir: remoteWorkdir
+      },
+      {
+        sessionId: context.sessionId,
+        projectId: context.projectId,
+        operation: 'submit_job',
+        ownerId: host.id
+      }
+    )
+
+    if (decision === 'deny') {
+      const error = new Error(
+        `Job submission approval was denied for host "${host.displayName}".`
+      ) as Error & { computeCallError: ComputeCallError }
+      error.computeCallError = {
+        error_code: 'approval_denied',
+        message: `Approval denied for submit_job on ${host.displayName}.`,
+        retry_after_user_action: false
+      }
+      throw error
+    }
+
+    const commandHash = hashCommand(command)
+    const inputManifest = stagedEntries.length > 0 ? JSON.stringify(stagedEntries) : undefined
+    const jobRepository = this.jobRepository
+    const createRow = async (initialStatus: 'submitted' | 'queued'): Promise<void> => {
+      await jobRepository.create({
+        id: jobId,
+        providerId: host.providerId,
+        shape: host.shape,
+        sessionId: context.sessionId,
+        projectId: context.projectId,
+        intent,
+        command,
+        commandHash,
+        environment: options.environment,
+        resourceRequest: options.resourceRequest,
+        inputManifest,
+        outputManifest: options.outputManifest,
+        harvestConfig: options.harvestConfig,
+        timeoutSeconds,
+        remoteWorkdir,
+        initialStatus
+      })
+    }
+
+    let initialStatus: 'submitted' | 'queued' = 'submitted'
+    if (this.concurrencyManager) {
+      const admitted = await this.concurrencyManager.admit(
+        { sessionId: context.sessionId, providerId },
+        createRow
+      )
+      if (admitted === 'queue_full') throw queueFullError()
+      initialStatus = admitted
+    } else {
+      await createRow('submitted')
+    }
+
+    if (initialStatus === 'submitted') {
+      void dispatchJob(jobId, {
+        runner: this.runner,
+        scpRunner: this.scpRunner,
+        hostRepository: this.hostRepository,
+        jobRepository: this.jobRepository,
+        onJobUpdated: this.handleJobUpdated
+      })
+    }
+
+    return {
+      job_id: jobId,
+      provider_id: host.providerId,
+      status: initialStatus,
+      remote_workdir: remoteWorkdir
+    }
+  }
+
+  async getJobStatus(jobId: string): Promise<JobStatusResult> {
+    if (!this.jobRepository) {
+      throw new Error('ComputeJobRepository is required to call getJobStatus.')
+    }
+    const job = await this.jobRepository.get(jobId)
+    if (!job) throw new Error(`No compute job found with id "${jobId}".`)
+    return {
+      job_id: job.job_id,
+      status: job.status,
+      exit_code: job.exit_code,
+      stdout_tail: job.stdout_tail,
+      stderr_tail: job.stderr_tail,
+      remote_workdir: job.remote_workdir
+    }
+  }
+
+  async getJobResult(jobId: string): Promise<JobResult> {
+    if (!this.jobRepository) {
+      throw new Error('ComputeJobRepository is required to call getJobResult.')
+    }
+    const job = await this.jobRepository.get(jobId)
+    if (!job) throw new Error(`No compute job found with id "${jobId}".`)
+
+    let leftOnRemote: Array<{ uri: string; size_mb: number; reason: string }> = []
+    if (job.left_on_remote) {
+      try {
+        leftOnRemote = JSON.parse(job.left_on_remote) as typeof leftOnRemote
+      } catch {
+        // Preserve the existing projection for malformed persisted JSON.
+      }
+    }
+
+    if (!TERMINAL_JOB_STATUSES.has(job.status) || !job.harvested_at) {
+      return jobResultWithFiles(job, [], [], [])
+    }
+    if (!this.storageRoot) {
+      return jobResultWithFiles(job, [], [], leftOnRemote)
+    }
+
+    const harvestDir = getJobHarvestDir(
+      this.storageRoot,
+      job.project_id,
+      job.session_id,
+      job.job_id
+    )
+    const workspaceCwd = getNotebookSessionRoot(this.storageRoot, job.project_id, job.session_id)
+    const featuredFiles = await scanDirRelative(join(harvestDir, 'featured'), workspaceCwd)
+    const hiddenFiles = await scanDirRelative(join(harvestDir, 'hidden'), workspaceCwd)
+    return jobResultWithFiles(job, featuredFiles, hiddenFiles, leftOnRemote)
+  }
+
+  async setSessionConcurrencyLimit(sessionId: string, limit: number): Promise<void> {
+    if (!this.concurrencyManager) {
+      throw new Error('ConcurrencyManager is required to set session concurrency limit.')
+    }
+    if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+      throw new Error(
+        `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
+      )
+    }
+    this.concurrencyManager.setSessionLimit(sessionId, limit)
+  }
+
+  async getSessionConcurrencyStatus(sessionId: string): Promise<SessionStatus> {
+    if (!this.concurrencyManager) {
+      throw new Error('ConcurrencyManager is required to get session concurrency status.')
+    }
+    const status = await this.concurrencyManager.getStatus(sessionId)
+    for (const host of await this.hostRepository.list()) {
+      if (!(host.providerId in status.provider_ceilings)) {
+        status.provider_ceilings[host.providerId] = host.concurrencyLimit ?? 10
+      }
+    }
+    return status
+  }
+
+  handleJobUpdated = (job: ComputeJob): void => {
+    if (this.concurrencyManager) this.concurrencyManager.handleJobUpdated(job)
+    else this.publishJobUpdated?.(job)
+  }
+}
+
+const jobResultWithFiles = (
+  job: ComputeJob,
+  featuredFiles: string[],
+  hiddenFiles: string[],
+  leftOnRemote: Array<{ uri: string; size_mb: number; reason: string }>
+): JobResult => ({
+  job_id: job.job_id,
+  status: job.status,
+  exit_code: job.exit_code,
+  featured_files: featuredFiles,
+  hidden_files: hiddenFiles,
+  output_files: [...featuredFiles, ...hiddenFiles],
+  left_on_remote: leftOnRemote,
+  remote_workdir: job.remote_workdir,
+  stdout_tail: job.stdout_tail,
+  stderr_tail: job.stderr_tail
+})
+
+async function scanDirRelative(dir: string, workspaceCwd: string): Promise<string[]> {
+  const results: string[] = []
+  try {
+    await collectFiles(dir, workspaceCwd, results)
+  } catch {
+    // Missing or unreadable harvest directories project as empty file lists.
+  }
+  return results
+}
+
+async function collectFiles(
+  currentDir: string,
+  workspaceCwd: string,
+  results: string[]
+): Promise<void> {
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = await readdir(currentDir, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    const fullPath = join(currentDir, entry.name)
+    if (entry.isDirectory()) await collectFiles(fullPath, workspaceCwd, results)
+    else if (entry.isFile()) results.push(workspaceRelativePath(workspaceCwd, fullPath))
+  }
+}

--- a/src/main/compute/compute-service.test.ts
+++ b/src/main/compute/compute-service.test.ts
@@ -1,20 +1,17 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 
-import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import type { ComputeHost } from '../../shared/compute'
-import { ComputeService, resolveInputs } from './compute-service'
+import type { ComputeHost, ComputeJob } from '../../shared/compute'
 import type { ComputeApprovalBroker } from './compute-approval-broker'
-import type { ComputeHostRepository } from './repository'
-import type { ResolvedSshTarget, SshRunner } from './ssh-runner'
-import type { ScpRunner } from './scp-runner'
+import { ComputeService } from './compute-service'
 import type { ConcurrencyManager } from './concurrency-manager'
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+import type { CreateJobRequest, ComputeJobRepository } from './job-repository'
+import type { ComputeHostRepository } from './repository'
+import type { ScpRunner } from './scp-runner'
+import type { ResolvedSshTarget, SshRunner } from './ssh-runner'
 
 const sampleHost = (overrides: Partial<ComputeHost> = {}): ComputeHost => ({
   id: 'host-1',
@@ -35,32 +32,26 @@ const sampleHost = (overrides: Partial<ComputeHost> = {}): ComputeHost => ({
   ...overrides
 })
 
-// A fake target returned by the real resolveSshTarget helper — tests bypass that step by mocking the
-// entire runner (which already has the target baked in).
 const fakeTarget: ResolvedSshTarget = {
   sshBinary: '/usr/bin/ssh',
   host: 'biowulf.nih.gov',
   extraArgs: ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=10']
 }
 
-// Minimal fake runner — always resolves with a success result by default.
 const makeFakeRunner = (result: Awaited<ReturnType<SshRunner['run']>>): SshRunner => ({
   run: vi.fn(() => Promise.resolve(result))
 })
 
-// Minimal repository double.
 const makeRepo = (
   host: ComputeHost | null = sampleHost()
 ): {
   repo: ComputeHostRepository
   updateProbeResult: ReturnType<typeof vi.fn>
-  updateScratchRoot: ReturnType<typeof vi.fn>
   updateDetails: ReturnType<typeof vi.fn>
   updateScratchPinned: ReturnType<typeof vi.fn>
   updateConcurrencyLimit: ReturnType<typeof vi.fn>
 } => {
   const updateProbeResult = vi.fn(() => Promise.resolve())
-  const updateScratchRoot = vi.fn(() => Promise.resolve())
   const updateDetails = vi.fn(() => Promise.resolve())
   const updateScratchPinned = vi.fn(() => Promise.resolve())
   const updateConcurrencyLimit = vi.fn(() => Promise.resolve())
@@ -70,38 +61,26 @@ const makeRepo = (
     create: vi.fn(),
     delete: vi.fn(),
     updateProbeResult,
-    updateScratchRoot,
+    updateScratchRoot: vi.fn(() => Promise.resolve()),
     updateDetails,
     updateScratchPinned,
     updateConcurrencyLimit
   } as unknown as ComputeHostRepository
-  return {
-    repo,
-    updateProbeResult,
-    updateScratchRoot,
-    updateDetails,
-    updateScratchPinned,
-    updateConcurrencyLimit
-  }
+  return { repo, updateProbeResult, updateDetails, updateScratchPinned, updateConcurrencyLimit }
 }
 
-// We use vi.mock for resolveSshTarget so the tests don't spawn ssh.
 vi.mock('./ssh-runner', async (importOriginal) => {
-  const orig = await importOriginal<typeof import('./ssh-runner')>()
+  const original = await importOriginal<typeof import('./ssh-runner')>()
   return {
-    ...orig,
+    ...original,
     resolveSshTarget: vi.fn(() => Promise.resolve(fakeTarget))
   }
 })
 
-// ---------------------------------------------------------------------------
-// ComputeService.callCommand — fake SshRunner + fake approval broker
-// ---------------------------------------------------------------------------
-
-// A minimal fake approval broker that resolves instantly.
 const makeApprovalBroker = (decision: 'once' | 'deny'): ComputeApprovalBroker =>
   ({
     request: vi.fn(() => Promise.resolve(decision)),
+    requestWithContext: vi.fn(() => Promise.resolve(decision)),
     respond: vi.fn()
   }) as unknown as ComputeApprovalBroker
 
@@ -217,10 +196,6 @@ describe('ComputeService remote operation facade', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// ComputeService.list — issue 06
-// ---------------------------------------------------------------------------
-
 describe('ComputeService.list', () => {
   it('returns all hosts from the repository', async () => {
     const hosts = [
@@ -245,786 +220,8 @@ describe('ComputeService.list', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// ComputeService.submitJob — unit tests with injected fakes
-// ---------------------------------------------------------------------------
-
-const makeJobRepo = (
-  jobs: Map<string, import('../../shared/compute').ComputeJob> = new Map()
-): {
-  repo: import('./job-repository').ComputeJobRepository
-  createCalls: ReturnType<typeof vi.fn>
-  updateCalls: ReturnType<typeof vi.fn>
-} => {
-  const createCalls = vi.fn(async (request: import('./job-repository').CreateJobRequest) => {
-    const job: import('../../shared/compute').ComputeJob = {
-      job_id: request.id,
-      provider_id: request.providerId,
-      shape: request.shape,
-      session_id: request.sessionId,
-      project_id: request.projectId,
-      status: 'submitted',
-      intent: request.intent,
-      command: request.command,
-      command_hash: request.commandHash,
-      environment: request.environment,
-      resource_request: request.resourceRequest,
-      input_manifest: request.inputManifest,
-      output_manifest: request.outputManifest,
-      harvest_config: request.harvestConfig,
-      timeout_seconds: request.timeoutSeconds,
-      remote_workdir: request.remoteWorkdir,
-      remote_handle: undefined,
-      exit_code: undefined,
-      stdout_tail: undefined,
-      stderr_tail: undefined,
-      error_code: undefined,
-      created_at: Date.now(),
-      submitted_at: Date.now(),
-      started_at: undefined,
-      finished_at: undefined,
-      harvested_at: undefined
-    }
-    jobs.set(request.id, job)
-    return job
-  })
-  const updateCalls = vi.fn(async (jobId: string, updates: unknown) => {
-    const job = jobs.get(jobId) ?? { job_id: jobId }
-    const updated = { ...job, ...(updates as object) }
-    jobs.set(jobId, updated as import('../../shared/compute').ComputeJob)
-    return updated as import('../../shared/compute').ComputeJob
-  })
-  const getCalls = vi.fn(async (jobId: string) => jobs.get(jobId) ?? null)
-  const findNonTerminalCalls = vi.fn(async () => Array.from(jobs.values()))
-
-  return {
-    repo: {
-      create: createCalls,
-      get: getCalls,
-      update: updateCalls,
-      findNonTerminal: findNonTerminalCalls,
-      findNonTerminalByProvider: vi.fn(async () => []),
-      hasActiveJobsForProvider: vi.fn(async () => false)
-    } as unknown as import('./job-repository').ComputeJobRepository,
-    createCalls,
-    updateCalls
-  }
-}
-
-describe('ComputeService.submitJob', () => {
-  it('returns job_id + remote_workdir immediately (before dispatch)', async () => {
-    // Runner should never be called for submit_job itself (dispatch is background).
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo: jobRepo, createCalls } = makeJobRepo()
-    const { repo } = makeRepo()
-
-    const approveDecision = vi.fn(() => Promise.resolve('once' as const))
-    const broker = {
-      request: approveDecision,
-      requestWithContext: approveDecision,
-      respond: vi.fn()
-    } as unknown as ComputeApprovalBroker
-
-    const service = new ComputeService(runner, repo, broker, undefined, undefined, jobRepo)
-
-    const result = await service.submitJob(
-      'ssh:biowulf',
-      'smoke test',
-      'echo hello',
-      {},
-      { sessionId: 'sess-1', projectId: 'proj-1' }
-    )
-
-    expect(result.status).toBe('submitted')
-    expect(result.provider_id).toBe('ssh:biowulf')
-    expect(result.job_id).toBeDefined()
-    expect(result.remote_workdir).toContain('.openscience/jobs/')
-    expect(createCalls).toHaveBeenCalledOnce()
-  })
-
-  it('throws approval_denied and does NOT create a DB row when approval is denied', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo: jobRepo, createCalls } = makeJobRepo()
-    const { repo } = makeRepo()
-
-    const denyDecision = vi.fn(() => Promise.resolve('deny' as const))
-    const broker = {
-      request: denyDecision,
-      requestWithContext: denyDecision,
-      respond: vi.fn()
-    } as unknown as ComputeApprovalBroker
-
-    const service = new ComputeService(runner, repo, broker, undefined, undefined, jobRepo)
-
-    const err = await service
-      .submitJob('ssh:biowulf', 'test', 'echo hi', {}, { sessionId: 's1', projectId: 'p1' })
-      .catch((e) => e)
-
-    expect(err.computeCallError?.error_code).toBe('approval_denied')
-    // No DB row should have been created.
-    expect(createCalls).not.toHaveBeenCalled()
-  })
-
-  it('uses operation=submit_job for grant memory (not call_command)', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo: jobRepo } = makeJobRepo()
-    const { repo } = makeRepo()
-
-    const requestWithContext = vi.fn(() => Promise.resolve('conversation' as const))
-    const broker = {
-      request: vi.fn(),
-      requestWithContext,
-      respond: vi.fn()
-    } as unknown as ComputeApprovalBroker
-
-    const service = new ComputeService(runner, repo, broker, undefined, undefined, jobRepo)
-
-    await service.submitJob(
-      'ssh:biowulf',
-      'test',
-      'echo hi',
-      {},
-      { sessionId: 's1', projectId: 'p1' }
-    )
-
-    expect(requestWithContext).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ operation: 'submit_job' })
-    )
-  })
-
-  it('rejects timeout_seconds > 7 days', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo: jobRepo } = makeJobRepo()
-    const { repo } = makeRepo()
-    const broker = {
-      request: vi.fn(),
-      requestWithContext: vi.fn(() => Promise.resolve('once' as const)),
-      respond: vi.fn()
-    } as unknown as ComputeApprovalBroker
-
-    const service = new ComputeService(runner, repo, broker, undefined, undefined, jobRepo)
-
-    const err = await service
-      .submitJob(
-        'ssh:biowulf',
-        'test',
-        'echo hi',
-        { timeoutSeconds: 8 * 24 * 3600 },
-        { sessionId: 's1', projectId: 'p1' }
-      )
-      .catch((e) => e)
-
-    expect(err.computeCallError?.error_code).toBe('timeout')
-  })
-
-  it('approval fires before any DB row is created (security contract)', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo: jobRepo, createCalls } = makeJobRepo()
-    const { repo } = makeRepo()
-
-    let approvalCalledAt: number | undefined
-    let createCalledAt: number | undefined
-
-    const requestWithContext = vi.fn(async () => {
-      approvalCalledAt = Date.now()
-      await new Promise((r) => setTimeout(r, 1))
-      return 'once' as const
-    })
-    const broker = {
-      request: vi.fn(),
-      requestWithContext,
-      respond: vi.fn()
-    } as unknown as ComputeApprovalBroker
-
-    createCalls.mockImplementation(async (request: import('./job-repository').CreateJobRequest) => {
-      createCalledAt = Date.now()
-      return {
-        job_id: request.id,
-        provider_id: request.providerId,
-        shape: request.shape,
-        session_id: request.sessionId,
-        project_id: request.projectId,
-        status: 'submitted' as const,
-        intent: request.intent,
-        command: request.command,
-        command_hash: request.commandHash,
-        environment: undefined,
-        resource_request: undefined,
-        input_manifest: undefined,
-        output_manifest: undefined,
-        harvest_config: undefined,
-        timeout_seconds: request.timeoutSeconds,
-        remote_workdir: request.remoteWorkdir,
-        remote_handle: undefined,
-        exit_code: undefined,
-        stdout_tail: undefined,
-        stderr_tail: undefined,
-        error_code: undefined,
-        created_at: Date.now(),
-        submitted_at: Date.now(),
-        started_at: undefined,
-        finished_at: undefined,
-        harvested_at: undefined
-      }
-    })
-
-    const service = new ComputeService(runner, repo, broker, undefined, undefined, jobRepo)
-    await service.submitJob(
-      'ssh:biowulf',
-      'test',
-      'echo hi',
-      {},
-      { sessionId: 's1', projectId: 'p1' }
-    )
-
-    expect(approvalCalledAt).toBeDefined()
-    expect(createCalledAt).toBeDefined()
-    expect(approvalCalledAt!).toBeLessThanOrEqual(createCalledAt!)
-  })
-})
-
-describe('ComputeService.getJobStatus', () => {
-  it('returns status shape from DB without SSH', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const jobs = new Map<string, import('../../shared/compute').ComputeJob>()
-    const job: import('../../shared/compute').ComputeJob = {
-      job_id: 'job-42',
-      provider_id: 'ssh:biowulf',
-      shape: 'direct_ssh',
-      session_id: 'sess-1',
-      project_id: 'proj-1',
-      status: 'success',
-      intent: 'test',
-      command: 'echo hi',
-      command_hash: 'abc',
-      environment: undefined,
-      resource_request: undefined,
-      input_manifest: undefined,
-      output_manifest: undefined,
-      harvest_config: undefined,
-      timeout_seconds: 3600,
-      remote_workdir: '~/.openscience/jobs/job-42',
-      remote_handle: undefined,
-      exit_code: 0,
-      stdout_tail: 'hi\n',
-      stderr_tail: '',
-      error_code: undefined,
-      created_at: 1,
-      submitted_at: 1,
-      started_at: 1,
-      finished_at: 2,
-      harvested_at: undefined
-    }
-    jobs.set('job-42', job)
-    const { repo: jobRepo } = makeJobRepo(jobs)
-    const { repo } = makeRepo()
-
-    const service = new ComputeService(runner, repo, undefined, undefined, undefined, jobRepo)
-
-    const status = await service.getJobStatus('job-42')
-    expect(status.job_id).toBe('job-42')
-    expect(status.status).toBe('success')
-    expect(status.exit_code).toBe(0)
-    expect(status.stdout_tail).toBe('hi\n')
-    expect(status.remote_workdir).toBe('~/.openscience/jobs/job-42')
-
-    // SSH runner should NOT have been called.
-    expect((runner.run as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0)
-  })
-
-  it('throws when job not found', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo: jobRepo } = makeJobRepo()
-    const { repo } = makeRepo()
-
-    const service = new ComputeService(runner, repo, undefined, undefined, undefined, jobRepo)
-
-    await expect(service.getJobStatus('nonexistent')).rejects.toThrow(/No compute job/)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// resolveInputs — unit tests for input staging validation/resolution
-// ---------------------------------------------------------------------------
-
-describe('resolveInputs — workspace source', () => {
-  it('resolves a workspace path to an absolute local path', async () => {
-    const { entries, inputsSummary } = await resolveInputs(
-      [{ src: 'data/sample.fa', dst_filename: 'sample.fa' }],
-      '/workspace/root',
-      undefined
-    )
-    expect(entries).toHaveLength(1)
-    expect(entries[0]).toMatchObject({ kind: 'upload', dstFilename: 'sample.fa' })
-    expect((entries[0] as { localPath: string }).localPath).toBe(
-      resolve('/workspace/root', 'data/sample.fa')
-    )
-    expect(inputsSummary).toBe('1 input: sample.fa')
-  })
-
-  it('rejects a workspace path that escapes the workspace root via ../', async () => {
-    await expect(
-      resolveInputs(
-        [{ src: '../../etc/passwd', dst_filename: 'passwd' }],
-        '/workspace/root',
-        undefined
-      )
-    ).rejects.toThrow(/escape/)
-  })
-
-  it('throws when workspaceCwd is missing for a workspace src', async () => {
-    await expect(
-      resolveInputs([{ src: 'data.csv', dst_filename: 'data.csv' }], undefined, undefined)
-    ).rejects.toThrow(/workspace_cwd/)
-  })
-})
-
-describe('resolveInputs — artifact source', () => {
-  it('resolves an absolute artifact-store path via ArtifactResolver to a local path', async () => {
-    const resolver = {
-      resolveArtifactPath: vi.fn(async () => '/storage/artifacts/sess/run/model.pkl')
-    }
-    const { entries, inputsSummary } = await resolveInputs(
-      [{ src: '/storage/artifacts/sess/run/model.pkl', dst_filename: 'model.pkl' }],
-      undefined,
-      resolver
-    )
-    expect(entries).toHaveLength(1)
-    expect(entries[0]).toMatchObject({
-      kind: 'upload',
-      localPath: '/storage/artifacts/sess/run/model.pkl',
-      dstFilename: 'model.pkl'
-    })
-    expect(inputsSummary).toBe('1 input: model.pkl')
-    expect(resolver.resolveArtifactPath).toHaveBeenCalledWith(
-      '/storage/artifacts/sess/run/model.pkl'
-    )
-  })
-
-  it('throws when artifactResolver is missing for an absolute (artifact) src', async () => {
-    await expect(
-      resolveInputs(
-        [{ src: '/storage/artifacts/sess/run/model.pkl', dst_filename: 'model.pkl' }],
-        undefined,
-        undefined
-      )
-    ).rejects.toThrow(/ArtifactResolver/)
-  })
-})
-
-describe('resolveInputs — remote_path source', () => {
-  it('creates a symlink entry for an absolute remote path', async () => {
-    const { entries, inputsSummary } = await resolveInputs(
-      [{ remote_path: '/scratch/ref.fa', dst_filename: 'ref.fa' }],
-      undefined,
-      undefined
-    )
-    expect(entries).toHaveLength(1)
-    expect(entries[0]).toMatchObject({
-      kind: 'symlink',
-      remotePath: '/scratch/ref.fa',
-      dstFilename: 'ref.fa'
-    })
-    expect(inputsSummary).toBe('1 input: ref.fa (symlink)')
-  })
-
-  it('infers dst_filename from basename when omitted', async () => {
-    const { entries } = await resolveInputs(
-      [{ remote_path: '/scratch/genome.fa' }],
-      undefined,
-      undefined
-    )
-    expect(entries[0]).toMatchObject({ kind: 'symlink', dstFilename: 'genome.fa' })
-  })
-
-  it('rejects a relative remote_path', async () => {
-    await expect(
-      resolveInputs([{ remote_path: 'relative/path' }], undefined, undefined)
-    ).rejects.toThrow(/absolute/)
-  })
-
-  it('rejects a remote_path with glob characters', async () => {
-    await expect(
-      resolveInputs([{ remote_path: '/scratch/*.fa' }], undefined, undefined)
-    ).rejects.toThrow(/glob/)
-  })
-
-  it('rejects a remote_path with shell-unsafe characters', async () => {
-    await expect(
-      resolveInputs([{ remote_path: '/scratch/$(id)' }], undefined, undefined)
-    ).rejects.toThrow(/shell-unsafe/)
-  })
-})
-
-describe('resolveInputs — dst_filename validation', () => {
-  it('rejects a dst_filename containing /', async () => {
-    await expect(
-      resolveInputs([{ src: 'data.csv', dst_filename: 'sub/data.csv' }], '/workspace', undefined)
-    ).rejects.toThrow(/bare filename/)
-  })
-
-  it('rejects an empty dst_filename', async () => {
-    await expect(
-      resolveInputs([{ src: 'data.csv', dst_filename: '' }], '/workspace', undefined)
-    ).rejects.toThrow(/bare filename/)
-  })
-})
-
-describe('resolveInputs — mixed inputs summary', () => {
-  it('builds summary for multiple inputs of different kinds', async () => {
-    const resolver = {
-      resolveArtifactPath: vi.fn(async () => '/storage/model.pkl')
-    }
-    const { entries, inputsSummary } = await resolveInputs(
-      [
-        { src: 'data.csv', dst_filename: 'data.csv' },
-        { src: '/storage/artifacts/s/r/model.pkl', dst_filename: 'model.pkl' },
-        { remote_path: '/scratch/ref.fa', dst_filename: 'ref.fa' }
-      ],
-      '/workspace',
-      resolver
-    )
-    expect(entries).toHaveLength(3)
-    expect(inputsSummary).toBe('3 inputs: data.csv, model.pkl, ref.fa (symlink)')
-  })
-
-  it('returns empty summary when no inputs', async () => {
-    const { entries, inputsSummary } = await resolveInputs([], '/workspace', undefined)
-    expect(entries).toHaveLength(0)
-    expect(inputsSummary).toBe('')
-  })
-})
-
-describe('ComputeService.submitJob — inputs_summary in approval', () => {
-  it('passes inputs_summary to the approval request when inputs are provided', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo: jobRepo } = makeJobRepo()
-    const { repo } = makeRepo()
-
-    const requestWithContext = vi.fn(() => Promise.resolve('once' as const))
-    const broker = {
-      request: requestWithContext,
-      requestWithContext,
-      respond: vi.fn()
-    } as unknown as ComputeApprovalBroker
-
-    const service = new ComputeService(runner, repo, broker, undefined, undefined, jobRepo)
-
-    await service.submitJob(
-      'ssh:biowulf',
-      'test',
-      'echo hi',
-      {
-        inputs: [{ remote_path: '/scratch/ref.fa', dst_filename: 'ref.fa' }]
-      },
-      { sessionId: 's1', projectId: 'p1' }
-    )
-
-    const callArg = (requestWithContext as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
-      inputs_summary?: string
-    }
-    expect(callArg.inputs_summary).toBe('1 input: ref.fa (symlink)')
-  })
-
-  it('stores resolved inputManifest in the DB row', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo: jobRepo, createCalls } = makeJobRepo()
-    const { repo } = makeRepo()
-
-    const broker = {
-      request: vi.fn(() => Promise.resolve('once' as const)),
-      requestWithContext: vi.fn(() => Promise.resolve('once' as const)),
-      respond: vi.fn()
-    } as unknown as ComputeApprovalBroker
-
-    const service = new ComputeService(runner, repo, broker, undefined, undefined, jobRepo)
-
-    await service.submitJob(
-      'ssh:biowulf',
-      'test',
-      'echo hi',
-      {
-        inputs: [{ remote_path: '/scratch/ref.fa', dst_filename: 'ref.fa' }]
-      },
-      { sessionId: 's1', projectId: 'p1' }
-    )
-
-    const createArg = (createCalls as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
-      inputManifest?: string
-    }
-    expect(createArg.inputManifest).toBeDefined()
-    const manifest = JSON.parse(createArg.inputManifest!) as Array<{
-      kind: string
-      remotePath: string
-      dstFilename: string
-    }>
-    expect(manifest).toHaveLength(1)
-    expect(manifest[0]).toMatchObject({
-      kind: 'symlink',
-      remotePath: '/scratch/ref.fa',
-      dstFilename: 'ref.fa'
-    })
-  })
-})
-
-// ---------------------------------------------------------------------------
-// ComputeService.getJobResult — four-timing semantics (design §9, issue 04)
-// ---------------------------------------------------------------------------
-
-describe('ComputeService.getJobResult', () => {
-  let tmpDir: string
-
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(join(tmpdir(), 'job-result-test-'))
-  })
-
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
-  })
-
-  const makeServiceWithStorageRoot = (
-    job: import('../../shared/compute').ComputeJob,
-    storageRoot: string
-  ): ComputeService => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const jobs = new Map([[job.job_id, job]])
-    const { repo: jobRepo } = makeJobRepo(jobs)
-    const { repo } = makeRepo()
-    return new ComputeService(
-      runner,
-      repo,
-      undefined,
-      undefined,
-      undefined,
-      jobRepo,
-      undefined,
-      undefined,
-      storageRoot
-    )
-  }
-
-  const baseJob = (
-    overrides: Partial<import('../../shared/compute').ComputeJob> = {}
-  ): import('../../shared/compute').ComputeJob => ({
-    job_id: 'job-result-1',
-    provider_id: 'ssh:biowulf',
-    shape: 'direct_ssh',
-    session_id: 'sess-1',
-    project_id: 'proj-1',
-    status: 'success',
-    intent: 'test',
-    command: 'echo hi',
-    command_hash: 'abc',
-    environment: undefined,
-    resource_request: undefined,
-    input_manifest: undefined,
-    output_manifest: undefined,
-    harvest_config: undefined,
-    timeout_seconds: 3600,
-    remote_workdir: '~/.openscience/jobs/job-result-1',
-    remote_handle: undefined,
-    exit_code: 0,
-    stdout_tail: 'hi\n',
-    stderr_tail: '',
-    error_code: undefined,
-    created_at: 1,
-    submitted_at: 1,
-    started_at: 1,
-    finished_at: 2,
-    harvested_at: undefined,
-    ...overrides
-  })
-
-  it('non-terminal status: returns empty file lists without error', async () => {
-    const job = baseJob({ status: 'running', harvested_at: undefined })
-    const service = makeServiceWithStorageRoot(job, tmpDir)
-    const result = await service.getJobResult('job-result-1')
-    expect(result.status).toBe('running')
-    expect(result.featured_files).toEqual([])
-    expect(result.hidden_files).toEqual([])
-    expect(result.output_files).toEqual([])
-    expect(result.left_on_remote).toEqual([])
-  })
-
-  it('terminal but harvest not done: returns empty file lists without error', async () => {
-    const job = baseJob({ status: 'success', harvested_at: undefined })
-    const service = makeServiceWithStorageRoot(job, tmpDir)
-    const result = await service.getJobResult('job-result-1')
-    expect(result.status).toBe('success')
-    expect(result.featured_files).toEqual([])
-    expect(result.output_files).toEqual([])
-  })
-
-  it('clean harvest: returns full file lists with workspace-relative paths', async () => {
-    const harvestDir = join(tmpDir, 'notebooks', 'proj-1', 'sess-1', 'hpc', 'job-result-1')
-    await mkdir(join(harvestDir, 'featured'), { recursive: true })
-    await mkdir(join(harvestDir, 'hidden'), { recursive: true })
-    await writeFile(join(harvestDir, 'featured', 'out.result'), 'result data')
-    await writeFile(join(harvestDir, 'hidden', 'debug.log'), 'log data')
-
-    const job = baseJob({ harvested_at: Date.now(), harvest_error: undefined })
-    const service = makeServiceWithStorageRoot(job, tmpDir)
-    const result = await service.getJobResult('job-result-1')
-
-    expect(result.status).toBe('success')
-    expect(result.exit_code).toBe(0)
-    expect(result.featured_files).toContain('hpc/job-result-1/featured/out.result')
-    expect(result.hidden_files).toContain('hpc/job-result-1/hidden/debug.log')
-    expect(result.output_files).toContain('hpc/job-result-1/featured/out.result')
-    expect(result.output_files).toContain('hpc/job-result-1/hidden/debug.log')
-    // featured entries come before hidden in output_files
-    const featIdx = result.output_files.indexOf('hpc/job-result-1/featured/out.result')
-    const hidIdx = result.output_files.indexOf('hpc/job-result-1/hidden/debug.log')
-    expect(featIdx).toBeLessThan(hidIdx)
-  })
-
-  it('reads attach_job results from the data-root workspace when config and data roots differ', async () => {
-    const configRoot = await mkdtemp(join(tmpdir(), 'job-result-config-root-'))
-    const dataRoot = await mkdtemp(join(tmpdir(), 'job-result-data-root-'))
-    const dataHarvestDir = join(dataRoot, 'notebooks', 'proj-1', 'sess-1', 'hpc', 'job-result-1')
-    const configHarvestDir = join(
-      configRoot,
-      'notebooks',
-      'proj-1',
-      'sess-1',
-      'hpc',
-      'job-result-1'
-    )
-    await mkdir(join(dataHarvestDir, 'featured'), { recursive: true })
-    await mkdir(join(configHarvestDir, 'featured'), { recursive: true })
-    await writeFile(join(dataHarvestDir, 'featured', 'data-root.result'), 'readable by notebook')
-    await writeFile(
-      join(configHarvestDir, 'featured', 'stale-config.result'),
-      'must not be returned'
-    )
-
-    try {
-      const service = makeServiceWithStorageRoot(baseJob({ harvested_at: Date.now() }), dataRoot)
-      const result = await service.getJobResult('job-result-1')
-      expect(result.featured_files).toEqual(['hpc/job-result-1/featured/data-root.result'])
-      expect(result.output_files).toEqual(['hpc/job-result-1/featured/data-root.result'])
-    } finally {
-      await rm(configRoot, { recursive: true, force: true })
-      await rm(dataRoot, { recursive: true, force: true })
-    }
-  })
-
-  it('harvest_failed: partial files returned, remote_workdir preserved', async () => {
-    const harvestDir = join(tmpDir, 'notebooks', 'proj-1', 'sess-1', 'hpc', 'job-result-1')
-    await mkdir(join(harvestDir, 'featured'), { recursive: true })
-    await writeFile(join(harvestDir, 'featured', 'partial.result'), 'partial')
-
-    const leftOnRemote = JSON.stringify([
-      { uri: 'ssh://biowulf/tmp/big.bin', size_mb: 150, reason: 'exceeds_max_file_mb' }
-    ])
-    const job = baseJob({
-      harvested_at: Date.now(),
-      harvest_error: 'scp failed: connection reset',
-      left_on_remote: leftOnRemote,
-      remote_workdir: '~/.openscience/jobs/job-result-1'
-    })
-    const service = makeServiceWithStorageRoot(job, tmpDir)
-    const result = await service.getJobResult('job-result-1')
-
-    expect(result.status).toBe('success')
-    expect(result.featured_files).toContain('hpc/job-result-1/featured/partial.result')
-    expect(result.remote_workdir).toBe('~/.openscience/jobs/job-result-1')
-    expect(result.left_on_remote).toHaveLength(1)
-    expect(result.left_on_remote[0].uri).toBe('ssh://biowulf/tmp/big.bin')
-  })
-
-  it('throws when job not found', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo: jobRepo } = makeJobRepo()
-    const { repo } = makeRepo()
-    const service = new ComputeService(
-      runner,
-      repo,
-      undefined,
-      undefined,
-      undefined,
-      jobRepo,
-      undefined,
-      undefined,
-      tmpDir
-    )
-    await expect(service.getJobResult('no-such-job')).rejects.toThrow(/No compute job/)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// Session concurrency control (Phase 3c, issue 04)
-// ---------------------------------------------------------------------------
-
-describe('setSessionConcurrencyLimit', () => {
-  it('delegates to concurrency manager', async () => {
+describe('ComputeService job workflow facade', () => {
+  it('preserves all job workflow operations and the stable update sink', async () => {
     const runner = makeFakeRunner({
       exitCode: 0,
       stdout: '',
@@ -1033,152 +230,94 @@ describe('setSessionConcurrencyLimit', () => {
       timedOut: false
     })
     const { repo } = makeRepo()
+    let storedJob: ComputeJob | undefined
+    const jobRepository = {
+      create: vi.fn(async (request: CreateJobRequest) => {
+        storedJob = {
+          job_id: request.id,
+          provider_id: request.providerId,
+          shape: request.shape,
+          session_id: request.sessionId,
+          project_id: request.projectId,
+          status: request.initialStatus ?? 'submitted',
+          intent: request.intent,
+          command: request.command,
+          command_hash: request.commandHash,
+          environment: request.environment,
+          resource_request: request.resourceRequest,
+          input_manifest: request.inputManifest,
+          output_manifest: request.outputManifest,
+          harvest_config: request.harvestConfig,
+          timeout_seconds: request.timeoutSeconds,
+          remote_workdir: request.remoteWorkdir,
+          remote_handle: undefined,
+          exit_code: undefined,
+          stdout_tail: undefined,
+          stderr_tail: undefined,
+          error_code: undefined,
+          created_at: 1,
+          submitted_at: 1,
+          started_at: undefined,
+          finished_at: undefined,
+          harvested_at: undefined
+        }
+        return storedJob
+      }),
+      get: vi.fn(async () => storedJob ?? null)
+    } as unknown as ComputeJobRepository
     const setSessionLimit = vi.fn()
+    const handleJobUpdated = vi.fn()
     const concurrencyManager = {
+      enqueue: vi.fn(async () => 'should_queue'),
+      admit: vi.fn(
+        async (
+          _params: { sessionId: string; providerId: string },
+          commit: (status: 'submitted' | 'queued') => Promise<void>
+        ) => {
+          await commit('queued')
+          return 'queued'
+        }
+      ),
       setSessionLimit,
-      getStatus: vi.fn(),
-      enqueue: vi.fn(),
-      onJobCompleted: vi.fn()
-    }
+      getStatus: vi.fn(async () => ({
+        session_limit: 7,
+        active_count: 0,
+        queued_count: 1,
+        provider_ceilings: {}
+      })),
+      handleJobUpdated
+    } as unknown as ConcurrencyManager
     const service = new ComputeService(
       runner,
       repo,
+      makeApprovalBroker('once'),
+      { copy: vi.fn() },
+      undefined,
+      jobRepository,
       undefined,
       undefined,
       undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      concurrencyManager as unknown as ConcurrencyManager
+      concurrencyManager
     )
 
-    await service.setSessionConcurrencyLimit('session-123', 10)
-    expect(setSessionLimit).toHaveBeenCalledWith('session-123', 10)
-  })
-
-  it('throws when concurrency manager not initialized', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo } = makeRepo()
-    const service = new ComputeService(runner, repo)
-
-    await expect(service.setSessionConcurrencyLimit('session-123', 10)).rejects.toThrow(
-      /ConcurrencyManager is required/
+    const submitted = await service.submitJob(
+      'ssh:biowulf',
+      'facade seam',
+      'echo ok',
+      {},
+      { sessionId: 'session-1', projectId: 'project-1' }
     )
-  })
+    const status = await service.getJobStatus(submitted.job_id)
+    const result = await service.getJobResult(submitted.job_id)
+    await service.setSessionConcurrencyLimit('session-1', 7)
+    const concurrency = await service.getSessionConcurrencyStatus('session-1')
+    service.handleJobUpdated(storedJob!)
 
-  it('validates limit is positive integer', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo } = makeRepo()
-    const concurrencyManager = {
-      setSessionLimit: vi.fn(),
-      getStatus: vi.fn(),
-      enqueue: vi.fn(),
-      onJobCompleted: vi.fn()
-    }
-    const service = new ComputeService(
-      runner,
-      repo,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      concurrencyManager as unknown as ConcurrencyManager
-    )
-
-    await expect(service.setSessionConcurrencyLimit('session-123', 0)).rejects.toThrow(
-      /integer in the range 1\.\.500/
-    )
-    await expect(service.setSessionConcurrencyLimit('session-123', -5)).rejects.toThrow(
-      /integer in the range 1\.\.500/
-    )
-    await expect(service.setSessionConcurrencyLimit('session-123', 3.5)).rejects.toThrow(
-      /integer in the range 1\.\.500/
-    )
-  })
-})
-
-describe('getSessionConcurrencyStatus', () => {
-  it('delegates to concurrency manager and enriches with all host ceilings', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const hostA = sampleHost({ providerId: 'ssh:host-a', concurrencyLimit: 20 })
-    const hostB = sampleHost({ providerId: 'ssh:host-b', concurrencyLimit: undefined })
-    const hostC = sampleHost({ providerId: 'ssh:host-c', concurrencyLimit: 50 })
-    const list = vi.fn(() => Promise.resolve([hostA, hostB, hostC]))
-    const { repo } = makeRepo()
-    repo.list = list
-
-    const managerStatus = {
-      session_limit: 10,
-      active_count: 3,
-      queued_count: 2,
-      provider_ceilings: { 'ssh:host-a': 20 } // Only one host has jobs in this session
-    }
-    const getStatus = vi.fn(() => Promise.resolve(managerStatus))
-    const concurrencyManager = {
-      setSessionLimit: vi.fn(),
-      getStatus,
-      enqueue: vi.fn(),
-      onJobCompleted: vi.fn()
-    }
-    const service = new ComputeService(
-      runner,
-      repo,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      concurrencyManager as unknown as ConcurrencyManager
-    )
-
-    const result = await service.getSessionConcurrencyStatus('session-123')
-    expect(getStatus).toHaveBeenCalledWith('session-123')
-    expect(result.session_limit).toBe(10)
-    expect(result.active_count).toBe(3)
-    expect(result.queued_count).toBe(2)
-    // All registered hosts appear in provider_ceilings
-    expect(result.provider_ceilings['ssh:host-a']).toBe(20) // from jobs
-    expect(result.provider_ceilings['ssh:host-b']).toBe(10) // added (null -> 10)
-    expect(result.provider_ceilings['ssh:host-c']).toBe(50) // added
-  })
-
-  it('throws when concurrency manager not initialized', async () => {
-    const runner = makeFakeRunner({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
-      truncated: false,
-      timedOut: false
-    })
-    const { repo } = makeRepo()
-    const service = new ComputeService(runner, repo)
-
-    await expect(service.getSessionConcurrencyStatus('session-123')).rejects.toThrow(
-      /ConcurrencyManager is required/
-    )
+    expect(submitted.status).toBe('queued')
+    expect(status).toMatchObject({ job_id: submitted.job_id, status: 'queued' })
+    expect(result).toMatchObject({ job_id: submitted.job_id, output_files: [] })
+    expect(setSessionLimit).toHaveBeenCalledWith('session-1', 7)
+    expect(concurrency).toMatchObject({ session_limit: 7, queued_count: 1 })
+    expect(handleJobUpdated).toHaveBeenCalledWith(storedJob)
   })
 })

--- a/src/main/compute/compute-service.ts
+++ b/src/main/compute/compute-service.ts
@@ -1,9 +1,4 @@
-import { readdir } from 'node:fs/promises'
-import { basename, isAbsolute, join, relative, resolve } from 'node:path'
-import { randomUUID } from 'node:crypto'
-
 import type {
-  ComputeCallError,
   ComputeHost,
   ComputeJob,
   DetailsAuthor,
@@ -14,160 +9,62 @@ import type {
 } from '../../shared/compute'
 import type { DirListing, DownloadDest, LocalFile } from '../../shared/remote-fs'
 import type { ComputeApprovalBroker } from './compute-approval-broker'
-import type { ComputeHostRepository } from './repository'
-import type { SshRunner } from './ssh-runner'
-import type { ScpRunner } from './scp-runner'
-import { GLOB_CHARS, SHELL_UNSAFE_CHARS, SystemScpRunner } from './scp-runner'
-import type { ComputeJobRepository } from './job-repository'
-import { computeRemoteWorkdir, dispatchJob, hashCommand } from './job-dispatcher'
-import type { StagedInputEntry } from './job-dispatcher'
-import { getJobHarvestDir } from './harvest-engine'
-import { getNotebookSessionRoot } from '../notebook/repository'
-import type { ConcurrencyManager, SessionStatus } from './concurrency-manager'
-import { workspaceRelativePath } from './workspace-path'
 import { ComputeHostProfileOwner } from './compute-host-profile-owner'
+import {
+  ComputeJobWorkflowOwner,
+  type ArtifactResolver,
+  type RawInputSpec
+} from './compute-job-workflow-owner'
 import { ComputeRemoteOperationOwner } from './compute-remote-operation-owner'
+import type { ConcurrencyManager, SessionStatus } from './concurrency-manager'
+import type { ComputeJobRepository } from './job-repository'
+import type { ComputeHostRepository } from './repository'
+import type { ScpRunner } from './scp-runner'
+import { SystemScpRunner } from './scp-runner'
+import type { SshRunner } from './ssh-runner'
 
 export { parseProbeOutput } from './compute-host-profile-owner'
 export type { ProbeScriptOutput } from './compute-host-profile-owner'
-
-const COMMAND_PREVIEW_MAX_LEN = 120
-
-// Raw input spec as submitted by the agent (before resolution to local paths).
-// Three kinds:
-//   workspace: {src:"relative/path.csv", dst_filename:"name.csv"}        — relative to session cwd
-//   artifact:  {src:"/storage/artifacts/.../name.csv", dst_filename:...} — absolute artifact-store path
-//   remote:    {remote_path:"/abs/path", dst_filename?:"name.csv"}       — symlinked, not uploaded
-export type RawInputSpec =
-  | { src: string; dst_filename: string } // workspace (relative) or artifact (absolute) — see resolveInputs
-  | { remote_path: string; dst_filename?: string }
-
-// Validates a dst_filename: must be a bare filename with no path separators.
-const assertBareName = (name: string, label: string): void => {
-  if (!name || name.includes('/') || name.includes('\\') || name === '.' || name === '..') {
-    throw new Error(
-      `dst_filename must be a bare filename with no path separators (got "${name}" for ${label})`
-    )
-  }
-}
-
-// Checks a workspace path doesn't escape the workspace root.
-// Returns the resolved absolute path on success, throws on escape.
-const resolveWorkspacePath = (workspaceCwd: string, srcPath: string): string => {
-  const resolved = resolve(workspaceCwd, srcPath)
-  const rel = relative(resolve(workspaceCwd), resolved)
-  if (rel.startsWith('..') || isAbsolute(rel)) {
-    throw new Error(`workspace path "${srcPath}" would escape the workspace root "${workspaceCwd}"`)
-  }
-  return resolved
-}
-
-// Resolves an artifact-store path to a validated local absolute path. Backed in production by
-// ArtifactRepository.resolveManagedFilePath, which enforces that the path stays inside the artifact
-// store root (security boundary) and follows symlinks safely. This product addresses artifacts by
-// path (the ArtifactFile.path an agent already holds), not by an opaque id — see design note below.
-export interface ArtifactResolver {
-  resolveArtifactPath(path: string): Promise<string>
-}
-
-// Validates and resolves raw input specs into staged manifest entries.
-//   relative src   → resolveWorkspacePath  → StagedInputEntry{kind:'upload', localPath}
-//   absolute src   → artifactResolver       → StagedInputEntry{kind:'upload', localPath}
-//   remote_path    → validate absolute + no unsafe/glob chars → StagedInputEntry{kind:'symlink'}
-// An absolute `src` is an artifact-store path (validated to stay inside the store by the resolver);
-// a relative `src` is resolved against the session workspace cwd. remote_path inputs use their own
-// key, so within the src branch absolute-vs-relative is an unambiguous discriminator. Returns
-// [entries, inputs_summary].
-export const resolveInputs = async (
-  rawInputs: RawInputSpec[],
-  workspaceCwd: string | undefined,
-  artifactResolver: ArtifactResolver | undefined
-): Promise<{ entries: StagedInputEntry[]; inputsSummary: string }> => {
-  const entries: StagedInputEntry[] = []
-  const summaryParts: string[] = []
-
-  for (const raw of rawInputs) {
-    if ('remote_path' in raw) {
-      // Remote symlink: validate absolute + no unsafe/glob chars.
-      const rp = raw.remote_path
-      if (!rp.startsWith('/')) {
-        throw new Error(`remote_path must be an absolute path (got "${rp}")`)
-      }
-      if (GLOB_CHARS.test(rp)) {
-        throw new Error(`remote_path must not contain glob characters (got "${rp}")`)
-      }
-      if (SHELL_UNSAFE_CHARS.test(rp)) {
-        throw new Error(`remote_path must not contain shell-unsafe characters (got "${rp}")`)
-      }
-      const dstFilename = raw.dst_filename ?? basename(rp)
-      assertBareName(dstFilename, `remote_path "${rp}"`)
-      entries.push({ kind: 'symlink', remotePath: rp, dstFilename, label: rp })
-      summaryParts.push(`${dstFilename} (symlink)`)
-    } else {
-      // src-based input: absolute → artifact store, relative → workspace.
-      const { src, dst_filename: dstFilename } = raw
-      assertBareName(dstFilename, `src "${src}"`)
-
-      if (isAbsolute(src)) {
-        // Artifact-store path. The resolver enforces it stays inside the artifact store root.
-        if (!artifactResolver) {
-          throw new Error(`Cannot resolve artifact "${src}": ArtifactResolver is not available`)
-        }
-        const localPath = await artifactResolver.resolveArtifactPath(src)
-        entries.push({ kind: 'upload', localPath, dstFilename, label: src })
-        summaryParts.push(dstFilename)
-      } else {
-        // Workspace-relative path.
-        if (!workspaceCwd) {
-          throw new Error(`Cannot resolve workspace path "${src}": workspace_cwd is not available`)
-        }
-        const localPath = resolveWorkspacePath(workspaceCwd, src)
-        entries.push({ kind: 'upload', localPath, dstFilename, label: src })
-        summaryParts.push(dstFilename)
-      }
-    }
-  }
-
-  const inputsSummary =
-    entries.length === 0
-      ? ''
-      : `${entries.length} input${entries.length === 1 ? '' : 's'}: ${summaryParts.join(', ')}`
-
-  return { entries, inputsSummary }
-}
-
-// Maximum timeout seconds allowed for a job (7 days). Commands above this are rejected.
-const JOB_MAX_TIMEOUT_SECONDS = 7 * 24 * 3600
-
-// Default timeout when not specified (24 hours).
-const JOB_DEFAULT_TIMEOUT_SECONDS = 24 * 3600
+export { resolveInputs } from './compute-job-workflow-owner'
+export type { ArtifactResolver, RawInputSpec } from './compute-job-workflow-owner'
 
 // Stable facade composed from private host-profile, remote-operation and job workflows.
 export class ComputeService {
-  private readonly scpRunner: ScpRunner
   private readonly hostProfiles: ComputeHostProfileOwner
   private readonly remoteOperations: ComputeRemoteOperationOwner
+  private readonly jobWorkflow: ComputeJobWorkflowOwner
 
   constructor(
-    private readonly runner: SshRunner,
+    runner: SshRunner,
     private readonly repository: ComputeHostRepository,
-    private readonly approvalBroker?: ComputeApprovalBroker,
+    approvalBroker?: ComputeApprovalBroker,
     scpRunner?: ScpRunner,
     overrideDownloadsDir?: string,
-    private readonly jobRepository?: ComputeJobRepository,
-    private readonly onJobUpdated?: (job: import('../../shared/compute').ComputeJob) => void,
-    private readonly artifactResolver?: ArtifactResolver,
-    private readonly storageRoot?: string,
-    private readonly concurrencyManager?: ConcurrencyManager
+    jobRepository?: ComputeJobRepository,
+    onJobUpdated?: (job: ComputeJob) => void,
+    artifactResolver?: ArtifactResolver,
+    storageRoot?: string,
+    concurrencyManager?: ConcurrencyManager
   ) {
-    this.scpRunner = scpRunner ?? new SystemScpRunner()
+    const effectiveScpRunner = scpRunner ?? new SystemScpRunner()
     this.hostProfiles = new ComputeHostProfileOwner(runner, repository)
     this.remoteOperations = new ComputeRemoteOperationOwner(
       runner,
       repository,
       approvalBroker,
-      this.scpRunner,
+      effectiveScpRunner,
       overrideDownloadsDir
+    )
+    this.jobWorkflow = new ComputeJobWorkflowOwner(
+      runner,
+      repository,
+      approvalBroker,
+      effectiveScpRunner,
+      jobRepository,
+      onJobUpdated,
+      artifactResolver,
+      storageRoot,
+      concurrencyManager
     )
   }
 
@@ -236,18 +133,6 @@ export class ComputeService {
     return this.remoteOperations.download(providerId, remotePath, dest, context)
   }
 
-  // Submits a remote compute job asynchronously (design.md §4, §5).
-  //
-  // Flow:
-  //   1. Validate host exists and timeout is within bounds.
-  //   2. Resolve and validate inputs (workspace/artifact/remote_path).
-  //   3. Pre-generate a job_id (not yet in DB).
-  //   4. Check concurrency limits (if ConcurrencyManager is present).
-  //   5. Fire approval gate (before any DB write or SSH).
-  //   6. On approval: write ComputeJob row (status=queued or submitted) + trigger background dispatch if submitted.
-  //   7. Return { job_id, provider_id, status, remote_workdir } immediately.
-  //
-  // The background dispatcher transitions the job to running (or error) without blocking this call.
   async submitJob(
     providerId: string,
     intent: string,
@@ -263,394 +148,26 @@ export class ComputeService {
     },
     context: { sessionId: string; projectId: string }
   ): Promise<SubmitJobResult> {
-    if (!this.jobRepository) {
-      throw new Error('ComputeJobRepository is required to call submitJob.')
-    }
-
-    const host = await this.repository.get(providerId)
-    if (!host) {
-      throw new Error(`No compute host found with provider id "${providerId}".`)
-    }
-
-    // Validate timeout bounds.
-    const rawTimeout = options.timeoutSeconds
-    if (rawTimeout !== undefined) {
-      if (!Number.isFinite(rawTimeout)) {
-        const err = new Error(
-          `timeout_seconds must be a finite number (got ${rawTimeout}).`
-        ) as Error & { computeCallError: ComputeCallError }
-        err.computeCallError = {
-          error_code: 'timeout',
-          message: `timeout_seconds must be a finite number.`,
-          retry_after_user_action: false
-        }
-        throw err
-      }
-      if (!Number.isInteger(rawTimeout) || rawTimeout <= 0) {
-        const err = new Error(
-          `timeout_seconds must be a positive integer (got ${rawTimeout}).`
-        ) as Error & { computeCallError: ComputeCallError }
-        err.computeCallError = {
-          error_code: 'timeout',
-          message: `timeout_seconds must be a positive integer.`,
-          retry_after_user_action: false
-        }
-        throw err
-      }
-      if (rawTimeout > JOB_MAX_TIMEOUT_SECONDS) {
-        const err = new Error(
-          `timeout_seconds ${rawTimeout} exceeds the 7-day maximum. Use a scheduler driver for multi-day jobs.`
-        ) as Error & { computeCallError: ComputeCallError }
-        err.computeCallError = {
-          error_code: 'timeout',
-          message: `timeout_seconds exceeds the 7-day (${JOB_MAX_TIMEOUT_SECONDS}s) maximum.`,
-          retry_after_user_action: false
-        }
-        throw err
-      }
-    }
-    const timeoutSeconds = rawTimeout ?? JOB_DEFAULT_TIMEOUT_SECONDS
-
-    // ── RESOLVE INPUTS (validation in main process — security boundary) ───────────
-    let stagedEntries: StagedInputEntry[] = []
-    let inputsSummary = ''
-    if (options.inputs && options.inputs.length > 0) {
-      const resolved = await resolveInputs(
-        options.inputs,
-        options.workspaceCwd,
-        this.artifactResolver
-      )
-      stagedEntries = resolved.entries
-      inputsSummary = resolved.inputsSummary
-    }
-
-    // Pre-generate job_id for the approval card's remote_workdir preview.
-    const jobId = randomUUID()
-    const remoteWorkdir = computeRemoteWorkdir(host.scratchRoot, jobId)
-
-    // ── EARLY QUEUE-FULL CHECK (before approval gate) ─────────────────────────────
-    // Advisory only: reject obviously-unacceptable jobs before prompting the user. The
-    // authoritative decision (and slot reservation) happens atomically in admit() below, after
-    // approval, so two concurrent submissions cannot both pass the same slot.
-    const queueFullError = (): Error & { computeCallError: ComputeCallError } => {
-      const message =
-        'Job queue is full (100 queued jobs). Wait for queued jobs to start running before submitting more.'
-      const err = new Error(message) as Error & { computeCallError: ComputeCallError }
-      err.computeCallError = { error_code: 'queue_full', message, retry_after_user_action: false }
-      return err
-    }
-    if (this.concurrencyManager) {
-      const preview = await this.concurrencyManager.enqueue({
-        jobId,
-        sessionId: context.sessionId,
-        providerId
-      })
-      if (preview === 'queue_full') throw queueFullError()
-    }
-
-    // ── APPROVAL GATE (must fire before any DB write or SSH) ──────────────────────
-    if (!this.approvalBroker) {
-      throw new Error('ComputeApprovalBroker is required to call submitJob.')
-    }
-
-    const commandPreview =
-      command.length > COMMAND_PREVIEW_MAX_LEN
-        ? `${command.slice(0, COMMAND_PREVIEW_MAX_LEN)}…`
-        : command
-
-    const approvalInfo = {
-      provider_id: host.providerId,
-      provider_name: host.displayName,
-      shape: host.shape,
-      intent,
-      command_preview: commandPreview,
-      command_full: command,
-      inputs_summary: inputsSummary || undefined,
-      timeout_seconds: timeoutSeconds,
-      remote_workdir: remoteWorkdir
-    }
-
-    const decision = await this.approvalBroker.requestWithContext(approvalInfo, {
-      sessionId: context.sessionId,
-      projectId: context.projectId,
-      operation: 'submit_job',
-      ownerId: host.id
-    })
-
-    if (decision === 'deny') {
-      const err = new Error(
-        `Job submission approval was denied for host "${host.displayName}".`
-      ) as Error & { computeCallError: ComputeCallError }
-      err.computeCallError = {
-        error_code: 'approval_denied',
-        message: `Approval denied for submit_job on ${host.displayName}.`,
-        retry_after_user_action: false
-      }
-      throw err
-    }
-
-    // ── WRITE JOB ROW ──────────────────────────────────────────────────────────────
-    const commandHash = hashCommand(command)
-    const inputManifest = stagedEntries.length > 0 ? JSON.stringify(stagedEntries) : undefined
-    const jobRepository = this.jobRepository
-    const createRow = async (initialStatus: 'submitted' | 'queued'): Promise<void> => {
-      await jobRepository.create({
-        id: jobId,
-        providerId: host.providerId,
-        shape: host.shape,
-        sessionId: context.sessionId,
-        projectId: context.projectId,
-        intent,
-        command,
-        commandHash,
-        environment: options.environment,
-        resourceRequest: options.resourceRequest,
-        inputManifest,
-        outputManifest: options.outputManifest,
-        harvestConfig: options.harvestConfig,
-        timeoutSeconds,
-        remoteWorkdir,
-        initialStatus
-      })
-    }
-
-    // With a ConcurrencyManager, decide the status and commit the row atomically so concurrent
-    // submissions cannot both pass one slot. Without one, submit immediately (tests / no-limit mode).
-    let initialStatus: 'submitted' | 'queued' = 'submitted'
-    if (this.concurrencyManager) {
-      const admitted = await this.concurrencyManager.admit(
-        { sessionId: context.sessionId, providerId },
-        createRow
-      )
-      if (admitted === 'queue_full') throw queueFullError()
-      initialStatus = admitted
-    } else {
-      await createRow('submitted')
-    }
-
-    // ── BACKGROUND DISPATCH (non-blocking, only for submitted jobs) ────────────────
-    // Fire-and-forget. Errors are persisted to the job row by the dispatcher.
-    // Queued jobs are NOT dispatched here — they wait for ConcurrencyManager.tryDispatchNext().
-    if (initialStatus === 'submitted') {
-      void dispatchJob(jobId, {
-        runner: this.runner,
-        scpRunner: this.scpRunner,
-        hostRepository: this.repository,
-        jobRepository: this.jobRepository,
-        onJobUpdated: this.handleJobUpdated
-      })
-    }
-
-    return {
-      job_id: jobId,
-      provider_id: host.providerId,
-      status: initialStatus,
-      remote_workdir: remoteWorkdir
-    }
+    return this.jobWorkflow.submitJob(providerId, intent, command, options, context)
   }
 
-  // Returns the lightweight status shape for a job. Does not make any SSH call.
   async getJobStatus(jobId: string): Promise<import('../../shared/compute').JobStatusResult> {
-    if (!this.jobRepository) {
-      throw new Error('ComputeJobRepository is required to call getJobStatus.')
-    }
-
-    const job = await this.jobRepository.get(jobId)
-    if (!job) {
-      throw new Error(`No compute job found with id "${jobId}".`)
-    }
-
-    return {
-      job_id: job.job_id,
-      status: job.status,
-      exit_code: job.exit_code,
-      stdout_tail: job.stdout_tail,
-      stderr_tail: job.stderr_tail,
-      remote_workdir: job.remote_workdir
-    }
+    return this.jobWorkflow.getJobStatus(jobId)
   }
 
-  // Returns the full job result (spec §11.4, design §9). Non-blocking: reads DB row + scans
-  // the local harvest directory. Does not make any SSH call or trigger harvest.
-  //
-  // Four-timing semantics:
-  //  1. Non-terminal (submitted/running): empty file lists, no error.
-  //  2. Terminal but harvest not done (harvestedAt null): same.
-  //  3. Clean harvest (harvestedAt set, harvestError null): full file lists.
-  //  4. harvest_failed (harvestedAt set, harvestError non-null): partial files + remote_workdir.
-  //
-  // File paths are workspace-relative (e.g. "hpc/<jobId>/featured/out.result") so the agent's
-  // data kernel can directly open() them relative to the workspace cwd (design §4).
   async getJobResult(jobId: string): Promise<JobResult> {
-    if (!this.jobRepository) {
-      throw new Error('ComputeJobRepository is required to call getJobResult.')
-    }
-
-    const job = await this.jobRepository.get(jobId)
-    if (!job) {
-      throw new Error(`No compute job found with id "${jobId}".`)
-    }
-
-    // Terminal states that can have harvest output.
-    const terminalStates = new Set(['success', 'failed', 'timeout', 'error'])
-    const isTerminal = terminalStates.has(job.status)
-
-    // Parse left_on_remote JSON from the job row (may be undefined before harvest).
-    let leftOnRemote: Array<{ uri: string; size_mb: number; reason: string }> = []
-    if (job.left_on_remote) {
-      try {
-        leftOnRemote = JSON.parse(job.left_on_remote) as typeof leftOnRemote
-      } catch {
-        // Malformed JSON — treat as empty (same guard as harvest-engine and job-notifier).
-      }
-    }
-
-    // Return empty file lists for non-terminal or pre-harvest states (design §9 rules 1 & 2).
-    if (!isTerminal || !job.harvested_at) {
-      return {
-        job_id: job.job_id,
-        status: job.status,
-        exit_code: job.exit_code,
-        featured_files: [],
-        hidden_files: [],
-        output_files: [],
-        left_on_remote: [],
-        remote_workdir: job.remote_workdir,
-        stdout_tail: job.stdout_tail,
-        stderr_tail: job.stderr_tail
-      }
-    }
-
-    // Harvest is done (rules 3 & 4): scan the local harvest directory for actual files.
-    // storageRoot is required to locate the harvest directory.
-    const effectiveStorageRoot = this.storageRoot
-    if (!effectiveStorageRoot) {
-      // Fall back to empty file lists if storageRoot was not wired (should not happen in prod).
-      return {
-        job_id: job.job_id,
-        status: job.status,
-        exit_code: job.exit_code,
-        featured_files: [],
-        hidden_files: [],
-        output_files: [],
-        left_on_remote: leftOnRemote,
-        remote_workdir: job.remote_workdir,
-        stdout_tail: job.stdout_tail,
-        stderr_tail: job.stderr_tail
-      }
-    }
-
-    const harvestDir = getJobHarvestDir(
-      effectiveStorageRoot,
-      job.project_id,
-      job.session_id,
-      job.job_id
-    )
-    // Workspace root: one level up from hpc/<jobId>/ — the session workspace cwd.
-    const workspaceCwd = getNotebookSessionRoot(
-      effectiveStorageRoot,
-      job.project_id,
-      job.session_id
-    )
-
-    const featuredFiles = await scanDirRelative(join(harvestDir, 'featured'), workspaceCwd)
-    const hiddenFiles = await scanDirRelative(join(harvestDir, 'hidden'), workspaceCwd)
-
-    return {
-      job_id: job.job_id,
-      status: job.status,
-      exit_code: job.exit_code,
-      featured_files: featuredFiles,
-      hidden_files: hiddenFiles,
-      // featured first, then hidden (design §9).
-      output_files: [...featuredFiles, ...hiddenFiles],
-      left_on_remote: leftOnRemote,
-      remote_workdir: job.remote_workdir,
-      stdout_tail: job.stdout_tail,
-      stderr_tail: job.stderr_tail
-    }
+    return this.jobWorkflow.getJobResult(jobId)
   }
 
-  // Sets the session-level concurrency limit. Delegates to ConcurrencyManager.
   async setSessionConcurrencyLimit(sessionId: string, limit: number): Promise<void> {
-    if (!this.concurrencyManager) {
-      throw new Error('ConcurrencyManager is required to set session concurrency limit.')
-    }
-
-    if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
-      throw new Error(
-        `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
-      )
-    }
-
-    this.concurrencyManager.setSessionLimit(sessionId, limit)
+    return this.jobWorkflow.setSessionConcurrencyLimit(sessionId, limit)
   }
 
-  // Returns the session concurrency status (session limit, active/queued counts, provider ceilings).
-  // Enriches with all registered compute hosts' concurrency limits.
   async getSessionConcurrencyStatus(sessionId: string): Promise<SessionStatus> {
-    if (!this.concurrencyManager) {
-      throw new Error('ConcurrencyManager is required to get session concurrency status.')
-    }
-
-    const status = await this.concurrencyManager.getStatus(sessionId)
-
-    // Enrich with ALL registered compute hosts (not just those with jobs in this session).
-    const allHosts = await this.repository.list()
-    for (const host of allHosts) {
-      // Only set if not already present from jobs.
-      if (!(host.providerId in status.provider_ceilings)) {
-        status.provider_ceilings[host.providerId] = host.concurrencyLimit ?? 10
-      }
-    }
-
-    return status
+    return this.jobWorkflow.getSessionConcurrencyStatus(sessionId)
   }
 
-  // Stable producer-facing sink for every persisted job update, regardless of whether the dispatcher
-  // or poller observed it. ConcurrencyManager owns the combined broadcast-and-drain policy when
-  // queueing is enabled; otherwise this preserves the observer-only behavior used by lightweight
-  // service configurations.
   handleJobUpdated = (job: ComputeJob): void => {
-    if (this.concurrencyManager) this.concurrencyManager.handleJobUpdated(job)
-    else this.onJobUpdated?.(job)
-  }
-}
-
-// ---------------------------------------------------------------------------
-// scanDirRelative: recursively list files under a directory, returning paths
-// relative to workspaceCwd. Returns [] if the directory does not exist.
-// ---------------------------------------------------------------------------
-
-async function scanDirRelative(dir: string, workspaceCwd: string): Promise<string[]> {
-  const results: string[] = []
-  try {
-    await collectFiles(dir, dir, workspaceCwd, results)
-  } catch {
-    // Directory absent (harvest not created yet, or was deleted) — return empty.
-  }
-  return results
-}
-
-async function collectFiles(
-  baseDir: string,
-  currentDir: string,
-  workspaceCwd: string,
-  results: string[]
-): Promise<void> {
-  let entries: import('node:fs').Dirent[]
-  try {
-    entries = await readdir(currentDir, { withFileTypes: true })
-  } catch {
-    return
-  }
-  for (const entry of entries) {
-    const fullPath = join(currentDir, entry.name)
-    if (entry.isDirectory()) {
-      await collectFiles(baseDir, fullPath, workspaceCwd, results)
-    } else if (entry.isFile()) {
-      // Use workspace-relative path so agent can open() directly (design §4).
-      results.push(workspaceRelativePath(workspaceCwd, fullPath))
-    }
+    this.jobWorkflow.handleJobUpdated(job)
   }
 }


### PR DESCRIPTION
# Problem

`ComputeService` still coordinated remote job input resolution, approval, atomic queue admission,
background dispatch, status/result projection, Session concurrency, and job-update publication. That
workflow forced the public facade to own queue and harvest implementation details even though the
repository, `ConcurrencyManager`, dispatcher, and harvest components already provide deep behavior.

# Proposed change

- Add a private `ComputeJobWorkflowOwner` for `submitJob`, `getJobStatus`, `getJobResult`,
  `setSessionConcurrencyLimit`, `getSessionConcurrencyStatus`, and the stable `handleJobUpdated` sink.
- Move input validation/resolution, approval and admission composition, asynchronous dispatch, harvest
  projection, and concurrency publication behind the owner.
- Keep `ComputeService` as the only production importer and existing public facade; preserve the
  `ArtifactResolver`, `RawInputSpec`, and `resolveInputs` export path.
- Move 34 existing job workflow behavior cases to the owner test, add two direct update-sink tests,
  and retain one real facade seam covering all five async intents plus the stable sink.
- Register the owner, concurrency-manager contract, and dispatcher contract in the `compute_service`
  module-impact mapping.

# Scope and non-goals

- No queue-limit, timeout, database-row, command-hash, dispatcher/poller, harvest-layout,
  notification-timing, or fire-and-forget behavior change.
- No scheduler-driver feature, Issue #458 orchestration state, or changes to job repository,
  `ConcurrencyManager`, `JobDispatcher`, or harvest algorithms.
- No IPC/application-command/local-RPC surface, persistence schema, renderer, or UI change.

# Compatibility

- `ComputeService` constructor order, method signatures, error shapes, and exports are unchanged.
- Submission preserves validation, advisory queue preview, approval, hash/input manifest, atomic
  admission/row commit, then submitted-only non-blocking dispatch.
- `ConcurrencyManager` remains the sole atomic admission and publish-and-drain owner.
- Electron/Web capabilities are unchanged; remote Web receives no new job surface.
- Session-bound local RPC retains `submit_job`, `job_status`, `job_result`,
  `set_concurrency_limit`, and `concurrency_status` payloads and trusted context behavior.
- CLI/Task receives no direct Compute management API.
- Harvest paths continue using portable Node path APIs and workspace-relative projection across
  Windows, macOS, and Linux; remote paths remain POSIX protocol values.
- The branch was rebased onto `origin/main@fb923c4b`; the newly merged permission-default seeding does
  not alter Compute composition or approval ordering.

# Acceptance criteria and validation

- Job workflow owner: 449 physical lines (target <=600, hard limit <=660).
- Compute facade: 173 physical lines (completion gate <=600).
- Only `ComputeService` imports the private owner in production.
- `npm run test:module -- compute_service`: 456 passed, 5 skipped.
- Module-impact validation: 30 passed.
- `npm run typecheck`: passed.
- `npm run lint -- --no-cache`: passed with 0 errors and 17 pre-existing warnings.
- `npm test`: 12,666 passed, 190 skipped.
- Prettier and `git diff --check`: passed.
- Exact-head CI, platform lanes, CodeQL, and AI review remain required before squash merge.

# Review focus

- Verify approval still occurs before any job row or SSH, while atomic admission remains after
  approval and contains only the row commit.
- Verify only `submitted` jobs dispatch asynchronously and queued jobs wait for manager drain.
- Verify `handleJobUpdated` delegates only to the manager when configured, otherwise only to the
  fallback publisher.
- Verify non-terminal, pre-harvest, complete, and partial result projections remain identical.
- Verify the facade and public export path remain the only external seam.
