### PR TITLE
feat(workspace): add scroll edge fades

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1,3 +1,4 @@
+/* Hallmark · pre-emit critique: P5 H4 E5 S5 R5 V4 */
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import './agent-markdown.css';
@@ -258,6 +259,36 @@
 }
 
 @layer components {
+  /* Theme-independent edge treatment for compact horizontal navigation and chip rails. */
+  .scroll-fade-x {
+    -webkit-mask-image: var(--scroll-fade-x-mask, none);
+    mask-image: var(--scroll-fade-x-mask, none);
+    mask-repeat: no-repeat;
+    mask-size: 100% 100%;
+  }
+
+  .scroll-fade-x[data-scroll-fade='left'] {
+    --scroll-fade-x-mask: linear-gradient(to right, transparent, hsl(var(--always-black)) 2.5rem);
+  }
+
+  .scroll-fade-x[data-scroll-fade='right'] {
+    --scroll-fade-x-mask: linear-gradient(
+      to right,
+      hsl(var(--always-black)) calc(100% - 2.5rem),
+      transparent
+    );
+  }
+
+  .scroll-fade-x[data-scroll-fade='both'] {
+    --scroll-fade-x-mask: linear-gradient(
+      to right,
+      transparent,
+      hsl(var(--always-black)) 2.5rem,
+      hsl(var(--always-black)) calc(100% - 2.5rem),
+      transparent
+    );
+  }
+
   /*
    * Radix ScrollArea wraps content in display:table / min-width:100%, which lets
    * long unbroken strings expand past the resizable panel. Force a normal block.

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -47,6 +47,7 @@ import { WorkspaceElicitationCard } from './WorkspaceElicitationCard'
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
 import { createConversationItems } from './workspace-conversation-items'
 import { groupConversationItems } from './workspace-tool-activity-groups'
+import { useHorizontalScrollFade } from './use-horizontal-scroll-fade'
 
 type ProvenanceTab = 'code' | 'execution' | 'messages' | 'environment' | 'review'
 type DeferredProvenanceTab = Extract<ProvenanceTab, 'execution' | 'messages' | 'review'>
@@ -443,6 +444,7 @@ const ArtifactProvenancePanel = ({
   onClose,
   onVersionChange
 }: ArtifactProvenancePanelProps): React.JSX.Element => {
+  const tabScrollFadeRef = useHorizontalScrollFade<HTMLDivElement>()
   const lineageKey = `${projectId}:${item.sessionId}:${item.artifactId ?? ''}`
   const lineageRequestKey = `${lineageKey}:${item.selectedVersionId ?? ''}`
   const [lineageResult, setLineageResult] = useState<{
@@ -996,8 +998,9 @@ const ArtifactProvenancePanel = ({
       </div>
 
       <div
+        ref={tabScrollFadeRef}
         role="tablist"
-        className="flex shrink-0 gap-1 overflow-x-auto border-b border-border-300/60 px-2 py-1"
+        className="scroll-fade-x flex shrink-0 gap-1 overflow-x-auto border-b border-border-300/60 px-2 py-1"
       >
         {tabs.map((tab) => (
           <button

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -271,6 +271,9 @@ describe('ConversationPanel header spacing', () => {
     )
     expect(messageButton).not.toBeNull()
     expect(messageButton?.className.split(' ')).toContain('md:hidden')
+    const surfaceFade = container.querySelector('[data-testid="composer-surface-fade"]')
+    expect(surfaceFade?.classList.contains('-top-12')).toBe(true)
+    expect(surfaceFade?.classList.contains('h-12')).toBe(true)
   })
 })
 
@@ -431,8 +434,8 @@ describe('ConversationPanel composer intake', () => {
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight })
 
     const surfaceFade = container.querySelector('[data-testid="composer-surface-fade"]')
-    expect(surfaceFade?.classList.contains('-top-12')).toBe(true)
-    expect(surfaceFade?.classList.contains('h-12')).toBe(true)
+    expect(surfaceFade?.classList.contains('-top-18')).toBe(true)
+    expect(surfaceFade?.classList.contains('h-18')).toBe(true)
     expect(surfaceFade?.classList.contains('bg-gradient-to-t')).toBe(true)
     expect(surfaceFade?.classList.contains('from-bg-10')).toBe(true)
     expect(surfaceFade?.classList.contains('to-bg-10/0')).toBe(true)

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -642,7 +642,7 @@ const ConversationPanel = ({
             data-testid="composer-surface-fade"
             className={cn(
               'pointer-events-none absolute inset-x-0 bg-gradient-to-t from-bg-10 to-bg-10/0',
-              pendingElicitation ? '-top-12 h-12' : '-top-6 h-6'
+              pendingElicitation ? '-top-18 h-18' : '-top-12 h-12'
             )}
           />
 

--- a/src/renderer/src/pages/workspace/NotebookInputDataStrip.tsx
+++ b/src/renderer/src/pages/workspace/NotebookInputDataStrip.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../../shared/notebook'
 import { previewIdForNotebookInput } from './notebook-input-preview'
 import { createPreviewFileItem } from './preview-file-item'
+import { useHorizontalScrollFade } from './use-horizontal-scroll-fade'
 
 type NotebookInputDataStripProps = {
   inputFiles: readonly (NotebookRunInputFile | NotebookInputFileSummary)[]
@@ -43,11 +44,13 @@ const NotebookInputDataStrip = ({
 }: NotebookInputDataStripProps): React.JSX.Element | null => {
   const inputs = collectInputs(inputFiles)
   const openPreview = usePreviewWorkbenchStore((state) => state.upsertAndActivateItem)
+  const scrollFadeRef = useHorizontalScrollFade<HTMLElement>()
   if (inputs.length === 0) return null
 
   return (
     <section
-      className={cn('flex items-center gap-2 overflow-x-auto', className)}
+      ref={scrollFadeRef}
+      className={cn('scroll-fade-x flex items-center gap-2 overflow-x-auto', className)}
       aria-label={label}
       data-testid="notebook-input-data"
     >

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -18,6 +18,7 @@ import { notebookGated } from './provisioning-view'
 import { NotebookCodeBlock } from './notebook-code'
 import { NotebookRunOutputs } from './NotebookRunOutputs'
 import { NotebookInputDataStrip } from './NotebookInputDataStrip'
+import { useHorizontalScrollFade } from './use-horizontal-scroll-fade'
 import {
   resolveRunErrorLine,
   environmentLabel,
@@ -203,6 +204,8 @@ const TerminalInput = ({
 
 // Renders the notebook preview and keeps it synchronized with main-process runtime events.
 const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
+  const kernelScrollFadeRef = useHorizontalScrollFade<HTMLDivElement>()
+  const environmentScrollFadeRef = useHorizontalScrollFade<HTMLDivElement>()
   const [notebookState, setNotebookState] = useState<NotebookSessionState | undefined>()
   const [terminalCode, setTerminalCode] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -394,7 +397,10 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
         className="flex shrink-0 items-center border-b border-border-100 px-2 py-1.5"
         data-testid="kernel-switcher"
       >
-        <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+        <div
+          ref={kernelScrollFadeRef}
+          className="scroll-fade-x flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
+        >
           {visibleKinds.map((kind) =>
             kind === 'r' ? (
               // R additionally kicks off lazy provisioning on first selection (D6 — see lazy-r.ts).
@@ -437,7 +443,8 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
 
       {showEnvSelector ? (
         <div
-          className="flex shrink-0 items-center gap-1 border-b border-border-100 px-2 py-1"
+          ref={environmentScrollFadeRef}
+          className="scroll-fade-x flex min-w-0 shrink-0 items-center gap-1 overflow-x-auto border-b border-border-100 px-2 py-1"
           data-testid="env-selector"
         >
           {envNames.map((envName) => (

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -16,6 +16,7 @@ import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { PreviewFileSurface } from './PreviewFileSurface'
 import { PreviewFileContent } from './previews/PreviewFileContent'
 import { PreviewToolContent } from './previews/PreviewToolContent'
+import { useHorizontalScrollFade } from './use-horizontal-scroll-fade'
 
 type PreviewPanelProps = {
   panelRef: React.Ref<PanelImperativeHandle>
@@ -162,7 +163,7 @@ const PreviewTabBar = ({
   onActivate: (id: string) => void
   onClose: (id: string) => void
 }): React.JSX.Element => {
-  const tabListRef = useRef<HTMLDivElement | null>(null)
+  const tabListRef = useHorizontalScrollFade<HTMLDivElement>()
   const tabContainerRefs = useRef<Array<HTMLDivElement | null>>([])
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
 
@@ -175,7 +176,7 @@ const PreviewTabBar = ({
       const activeTab = activeIndex === -1 ? null : tabContainerRefs.current[activeIndex]
       if (activeTab) scrollPreviewTabIntoView(tabList, activeTab, behavior)
     },
-    [activeItemId, tabs]
+    [activeItemId, tabListRef, tabs]
   )
 
   // External activation keeps the selected tab visible without moving keyboard focus.
@@ -200,7 +201,7 @@ const PreviewTabBar = ({
     observer.observe(tabList)
 
     return () => observer.disconnect()
-  }, [scrollActiveTabIntoView])
+  }, [scrollActiveTabIntoView, tabListRef])
 
   const moveToTab = (index: number): void => {
     const tab = tabs[index]
@@ -241,7 +242,7 @@ const PreviewTabBar = ({
       role="tablist"
       aria-label="Open previews"
       aria-orientation="horizontal"
-      className="flex min-w-0 flex-1 basis-0 shrink-0 items-center gap-1 overflow-x-auto pb-2"
+      className="scroll-fade-x flex min-w-0 flex-1 basis-0 shrink-0 items-center gap-1 overflow-x-auto pb-2"
     >
       {tabs.map((tab, index) => (
         <PreviewTab

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -94,6 +94,13 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(html).toContain('aria-label="Messages, no unread messages"')
   })
 
+  it('softens the session list behind the footer controls', async () => {
+    const html = await renderSidebar([createSession({ id: 'session-a' })])
+
+    expect(html).toContain('-top-12 h-12 bg-gradient-to-t from-rail-card-bg')
+    expect(html).not.toContain('-top-6 h-6 bg-gradient-to-t from-rail-card-bg')
+  })
+
   it('reserves header padding for the external panel toggle without spacer markup', async () => {
     const html = await renderSidebar([createSession({ id: 'session-a' })])
 

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -417,7 +417,7 @@ const WorkspaceSidebar = ({
           <div className="relative flex shrink-0 items-center gap-1 p-2">
             <div
               aria-hidden="true"
-              className="pointer-events-none absolute inset-x-0 -top-6 h-6 bg-gradient-to-t from-rail-card-bg to-rail-card-bg/0"
+              className="pointer-events-none absolute inset-x-0 -top-12 h-12 bg-gradient-to-t from-rail-card-bg to-rail-card-bg/0"
             />
             <NotificationBell
               side="top"

--- a/src/renderer/src/pages/workspace/use-horizontal-scroll-fade.test.tsx
+++ b/src/renderer/src/pages/workspace/use-horizontal-scroll-fade.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { useHorizontalScrollFade } from './use-horizontal-scroll-fade'
+
+const TestStrip = (): React.JSX.Element => {
+  const ref = useHorizontalScrollFade<HTMLDivElement>()
+  return <div ref={ref} data-testid="strip" />
+}
+
+const setScrollGeometry = (
+  element: HTMLElement,
+  geometry: { clientWidth: number; scrollWidth: number; scrollLeft: number }
+): void => {
+  Object.defineProperties(element, {
+    clientWidth: { configurable: true, value: geometry.clientWidth },
+    scrollWidth: { configurable: true, value: geometry.scrollWidth },
+    scrollLeft: { configurable: true, writable: true, value: geometry.scrollLeft }
+  })
+}
+
+afterEach(cleanup)
+
+describe('useHorizontalScrollFade', () => {
+  it('shows only the edge that still has hidden content', () => {
+    render(<TestStrip />)
+    const strip = screen.getByTestId('strip')
+
+    setScrollGeometry(strip, { clientWidth: 100, scrollWidth: 300, scrollLeft: 0 })
+    fireEvent.scroll(strip)
+    expect(strip.dataset.scrollFade).toBe('right')
+
+    strip.scrollLeft = 100
+    fireEvent.scroll(strip)
+    expect(strip.dataset.scrollFade).toBe('both')
+
+    strip.scrollLeft = 200
+    fireEvent.scroll(strip)
+    expect(strip.dataset.scrollFade).toBe('left')
+  })
+
+  it('keeps all content fully visible when the strip does not overflow', () => {
+    render(<TestStrip />)
+    const strip = screen.getByTestId('strip')
+
+    setScrollGeometry(strip, { clientWidth: 300, scrollWidth: 300, scrollLeft: 0 })
+    fireEvent.scroll(strip)
+
+    expect(strip.dataset.scrollFade).toBe('none')
+  })
+})

--- a/src/renderer/src/pages/workspace/use-horizontal-scroll-fade.ts
+++ b/src/renderer/src/pages/workspace/use-horizontal-scroll-fade.ts
@@ -1,0 +1,41 @@
+import { useLayoutEffect, useRef, type RefObject } from 'react'
+
+type HorizontalScrollFade = 'none' | 'left' | 'right' | 'both'
+
+const EDGE_THRESHOLD_PX = 1
+
+const updateHorizontalScrollFade = (element: HTMLElement): void => {
+  const maxScrollLeft = Math.max(0, element.scrollWidth - element.clientWidth)
+  let fade: HorizontalScrollFade
+
+  if (maxScrollLeft <= EDGE_THRESHOLD_PX) fade = 'none'
+  else if (element.scrollLeft <= EDGE_THRESHOLD_PX) fade = 'right'
+  else if (element.scrollLeft >= maxScrollLeft - EDGE_THRESHOLD_PX) fade = 'left'
+  else fade = 'both'
+
+  if (element.dataset.scrollFade !== fade) element.dataset.scrollFade = fade
+}
+
+export const useHorizontalScrollFade = <T extends HTMLElement>(): RefObject<T | null> => {
+  const ref = useRef<T>(null)
+
+  useLayoutEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const update = (): void => updateHorizontalScrollFade(element)
+    update()
+    element.addEventListener('scroll', update, { passive: true })
+
+    const observer =
+      typeof ResizeObserver === 'undefined' ? undefined : new ResizeObserver(() => update())
+    observer?.observe(element)
+
+    return () => {
+      element.removeEventListener('scroll', update)
+      observer?.disconnect()
+    }
+  })
+
+  return ref
+}

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -216,6 +216,22 @@ describe('workspace page component boundaries', () => {
     expect(mainCssSource).toContain('--always-black:')
   })
 
+  it('uses one theme-aware fade treatment for horizontal workspace scrollers', () => {
+    const mainCssSource = readFileSync(resolve(__dirname, '../../assets/main.css'), 'utf8')
+    const horizontalScrollerSources = [
+      'PreviewPanel.tsx',
+      'NotebookPreview.tsx',
+      'NotebookInputDataStrip.tsx',
+      'ArtifactProvenancePanel.tsx'
+    ].map((fileName) => readFileSync(resolve(__dirname, fileName), 'utf8'))
+
+    expect(mainCssSource).toContain('.scroll-fade-x')
+    expect(mainCssSource).toContain(".scroll-fade-x[data-scroll-fade='both']")
+    expect(mainCssSource).toContain('-webkit-mask-image: var(--scroll-fade-x-mask, none)')
+    expect(mainCssSource).toContain('hsl(var(--always-black))')
+    for (const source of horizontalScrollerSources) expect(source).toContain('scroll-fade-x')
+  })
+
   it('registers the semantic chart tokens used by the response Usage breakdown', () => {
     const mainCssSource = readFileSync(resolve(__dirname, '../../assets/main.css'), 'utf8')
     const messageItemSource = readFileSync(workspaceMessageItemPath, 'utf8')


### PR DESCRIPTION
## Problem
Horizontally scrollable workspace controls do not communicate clipped content at their edges, and the existing session/composer fades are too shallow to soften overlapping content consistently.

## Proposed change
- Add one theme-aware horizontal mask treatment driven by actual overflow and scroll position.
- Apply it to preview tabs, notebook kernel/environment switchers, notebook input data, and Artifact provenance tabs.
- Increase the session footer and normal composer fades from 24 px to 48 px.
- Increase the elicitation composer fade from 48 px to 72 px.
- Add focused behavior and source-boundary coverage for the new treatment.

## Scope and non-goals
- No new dependencies, design tokens, or animations.
- Code blocks, tables, and the home carousel remain unchanged.
- The mask reveals the existing semantic surface, so light and dark themes share the same treatment.

## Acceptance criteria and validation
- Edge fades only appear where content remains hidden — `npm test -- src/renderer/src/pages/workspace/use-horizontal-scroll-fade.test.tsx ...` — 176 tests passed.
- Renderer types remain valid — `npm run typecheck:web` — passed.
- Production Web bundle builds — `npm run build:web` — passed.
- Electron bundle builds — `npm run build:e2e` — passed.
- Desktop and compact visual baselines remain stable — `npm run test:e2e:visual` — 3 tests passed.
- Full regression suite remains green — `npm test` — 12,677 tests passed, 190 skipped.
- Lint remains error-free — `npm run lint` — 0 errors; 17 pre-existing warnings outside this change.

## Review focus
- The 40 px mask ramp and `data-scroll-fade` edge-state behavior.
- The 48 px normal footer/composer fades and 72 px elicitation fade.
- Consistency across the five horizontal workspace scrollers.