### PR TITLE
fix(session-persistence): preserve live graph on save echo

### DIFF
--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -9,11 +9,17 @@ import type {
   SessionUpsertEvent
 } from '../../../shared/lifecycle-events'
 import type { Project } from '../../../shared/projects'
+import { getActiveConversationContext } from '../../../shared/conversation-graph'
+import { validateDurableMessageOwnership } from '../../../main/artifacts/provenance-message-finalization'
 import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useArchiveUndoStore } from '@/stores/archive-undo-store'
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
-import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
+import {
+  createInitialSessionState,
+  toPersistedSession,
+  useSessionStore
+} from '@/stores/session-store'
 import { useLifecycleSync } from './useLifecycleSync'
 
 const listeners: {
@@ -172,6 +178,68 @@ describe('useLifecycleSync', () => {
 
     expect(useSessionStore.getState().sessions[0]?.title).toBe('Updated session')
     expect(container.querySelector<HTMLButtonElement>('button')?.dataset.noticeSession).toBe('')
+  })
+
+  it("does not roll back live conversation state from this renderer's save echo", async () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        ...session,
+        agentFrameworkId: 'codex',
+        agentBackendId: 'codex-response',
+        agentModel: 'gpt-5.5',
+        runtimeContext: { version: 1, revision: 1 }
+      }
+    ])
+    const earlierSave = toPersistedSession(useSessionStore.getState().sessions[0])
+    const appended = useSessionStore.getState().appendUserMessage({
+      sessionId: session.id,
+      content: 'Create the report',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex-response',
+      agentModel: 'gpt-5.6-sol'
+    })
+    const live = useSessionStore.getState().sessions[0]
+    const context = getActiveConversationContext(live.conversationGraph!, appended!.messageId)
+    const response = useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: session.id,
+      streamId: 'run-1',
+      eventId: 'agent-message-1',
+      promptMessageId: appended?.messageId,
+      content: 'Saved the report.'
+    })
+    useSessionStore.getState().finishRun(session.id, undefined, appended?.messageId)
+
+    await act(async () => {
+      listeners.sessionUpdated?.({
+        session: { ...earlierSave, updatedAt: live.updatedAt + 1 },
+        originClientId: 'electron:7'
+      })
+    })
+
+    expect(() =>
+      validateDurableMessageOwnership(toPersistedSession(useSessionStore.getState().sessions[0]), {
+        ...context,
+        messageId: response!.messageId
+      })
+    ).not.toThrow()
+  })
+
+  it("keeps archive cleanup for this renderer's update echo", async () => {
+    const removeSessionItems = vi.spyOn(usePreviewWorkbenchStore.getState(), 'removeSessionItems')
+    useSessionStore.getState().hydrateSessions([{ ...session, title: 'Live title', updatedAt: 3 }])
+    useSessionStore.setState({ selectedSessionId: session.id })
+
+    await act(async () => {
+      listeners.sessionUpdated?.({
+        session: { ...session, title: 'Stale title', archivedAt: 2, updatedAt: 4 },
+        originClientId: 'electron:7'
+      })
+    })
+
+    expect(useSessionStore.getState().sessions[0]?.title).toBe('Live title')
+    expect(useSessionStore.getState().sessions[0]?.archivedAt).toBeUndefined()
+    expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
+    expect(removeSessionItems).toHaveBeenCalledWith(session.id)
   })
 
   it('clears a stale notice when its session is archived', async () => {

--- a/src/renderer/src/hooks/useLifecycleSync.ts
+++ b/src/renderer/src/hooks/useLifecycleSync.ts
@@ -108,9 +108,16 @@ const useLifecycleSync = ({
         })
       }
     )
-    const removeSessionUpdated = window.api.sessions.onUpdated(({ session }) => {
+    const removeSessionUpdated = window.api.sessions.onUpdated(({ session, originClientId }) => {
       applyOrQueue(() => {
-        useSessionStore.getState().upsertPersistedSession(session)
+        // The ordered persistence owner already applies this renderer's save result. Its lifecycle
+        // echo may describe an earlier graph with a later main-owned timestamp, so replacing the
+        // live projection here can discard a prompt and the Runtime Segment used by its artifact
+        // claim. Events from other clients remain authoritative synchronization input; same-client
+        // command results return through their direct IPC path.
+        if (originClientId !== lifecycleClientIdRef.current) {
+          useSessionStore.getState().upsertPersistedSession(session)
+        }
         useArchiveUndoStore.getState().reconcileSession(session)
         if (
           session.archivedAt !== undefined &&


### PR DESCRIPTION
## Problem

Issue #993 reports artifacts that are generated successfully but remain stuck in finalization with `runtime-segment-missing`. The attached `main.log` contains 8 artifact runs, 63 finalization attempts, and 48 explicit `runtime-segment-missing` outcomes across one affected session.

The renderer could receive its own `session:updated` lifecycle echo for an earlier save after a newer prompt had already created a Runtime Segment. Main-owned state could give that earlier durable snapshot a later `updatedAt`, so `upsertPersistedSession` replaced the live conversation graph and removed the prompt/segment needed by the artifact claim. Finalization then correctly rejected the now-undurable ownership chain.

Fixes #993. Related: #900 and #776.

## Proposed change

- Do not replace the live Session projection from a `session:updated` event emitted by the same lifecycle client. The ordered persistence path already applies the command's returned durable Session directly.
- Continue applying events from other clients as authoritative synchronization input.
- Preserve lifecycle cleanup for same-client archive echoes, including selection, preview, notice, and undo reconciliation.
- Add a regression that reproduces the earlier-save/newer-runtime-segment race and verifies the final agent message still has durable artifact ownership.

## Scope and non-goals

- This changes the shared renderer lifecycle seam, so it covers claude-code, opencode, codex-response, and codex-bridge without backend-specific behavior.
- It does not synthesize missing prompts or Runtime Segments and does not relax provenance validation; already-corrupt ownership remains fail-closed.
- It does not change the Session schema or migrate stored data.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Same-client save echo preserves the live prompt, Runtime Segment, and artifact message ownership -> `npm test -- --run src/renderer/src/hooks/useLifecycleSync.test.tsx` -> 14/14 passed.
- Lifecycle, ordered renderer persistence, conversation graph, artifact provenance, Session coordinator, recovery, and workspace event consumers -> targeted 8-file Vitest command -> 284/284 passed.
- Affected Node and renderer TypeScript processes -> `npm run typecheck` -> passed.
- Changed source and repository lint rules -> `npm run lint` -> passed with 0 errors; 17 warnings are in unchanged files.
- Portable fallback -> `npm test` -> 12,546 passed and 36 failed in unchanged modules. Every timeout-class failure passed when rerun with one worker and a 60-second timeout (14 selected tests passed). The remaining local failures require unavailable bash or Windows symbolic-link privilege.

Uncovered local risks: bash workflow contracts and symlink-specific filesystem behavior could not run in this Windows environment. Exact-head PR Gate and platform CI remain authoritative for those lanes. Independent review and CI are pending.

## Review focus

- Confirm that same-client command responses remain the sole state-update path while lifecycle echoes retain their cleanup side effects.
- Confirm that external-client Session updates still replace local persisted state.
- Confirm that the regression models the `main.log` ordering failure without weakening durable ownership checks.
