### PR TITLE
fix(skills): improve GitHub import empty state

### DIFF
--- a/src/renderer/src/pages/settings/SkillImportView.tsx
+++ b/src/renderer/src/pages/settings/SkillImportView.tsx
@@ -1,7 +1,15 @@
 /* Hallmark · macrostructure: Workbench · tone: utilitarian · palette: existing warm paper + teal */
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
 import { useRef, useState } from 'react'
-import { AlertTriangle, ChevronDown, ChevronUp, LoaderCircle, SearchX, Star } from 'lucide-react'
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp,
+  LoaderCircle,
+  ScrollText,
+  SearchX,
+  Star
+} from 'lucide-react'
 
 import type {
   GitHubRepositorySearchView,
@@ -433,23 +441,36 @@ const SkillImportView = ({ onImported }: SkillImportViewProps): React.JSX.Elemen
         ) : null}
       </div>
 
-      <h3 className="mt-8 border-t border-border pt-5 text-sm font-semibold text-foreground">
-        Imported skills
-      </h3>
-      {imported.length > 0 ? (
-        <ul className="mt-2 flex flex-col divide-y divide-border">
-          {imported.map((skill) => (
-            <li key={skill.id} className="flex items-center gap-2 py-2.5">
-              <span className="min-w-0 flex-1 truncate text-sm text-foreground">{skill.name}</span>
-              <span className="shrink-0 text-xs text-muted-foreground">{skill.id}</span>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="mt-2 py-2 text-xs text-muted-foreground">
-          No imported skills yet. Repos you import from will appear here.
-        </p>
-      )}
+      <section aria-labelledby="imported-skills-heading">
+        <h3
+          id="imported-skills-heading"
+          className="mt-8 border-t border-border pt-5 text-sm font-semibold text-foreground"
+        >
+          Imported skills
+        </h3>
+        {imported.length > 0 ? (
+          <ul className="mt-2 flex flex-col divide-y divide-border">
+            {imported.map((skill) => (
+              <li key={skill.id} className="flex items-center gap-2 py-2.5">
+                <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                  {skill.name}
+                </span>
+                <span className="shrink-0 text-xs text-muted-foreground">{skill.id}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="flex min-h-64 flex-col items-center justify-center px-4 py-8 text-center">
+            <span className="inline-flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+              <ScrollText className="size-5" aria-hidden="true" />
+            </span>
+            <p className="mt-3 text-sm font-medium text-foreground">No imported skills yet</p>
+            <p className="mt-1 max-w-sm text-xs leading-5 text-muted-foreground">
+              Repos you import from will appear here.
+            </p>
+          </div>
+        )}
+      </section>
 
       <SkillImportCandidatePreview {...candidatePreview.previewProps} />
     </div>

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -770,6 +770,11 @@ describe('SkillsPanel (sub-views)', () => {
       (heading) => heading.textContent?.trim() === 'Imported skills'
     )
     expect(importedHeading?.className).toContain('border-t')
+    const importedSection = importedHeading?.closest('section')
+    expect(importedSection?.textContent).toContain('No imported skills yet')
+    expect(importedSection?.textContent).toContain('Repos you import from will appear here.')
+    expect(importedSection?.querySelector('svg')).not.toBeNull()
+    expect(importedHeading?.nextElementSibling?.className).toContain('items-center')
   })
 
   it('shows row-level scan progress, then collapses repository results after scanning', async () => {


### PR DESCRIPTION
## Problem

The GitHub Skill import page rendered its empty imported-skills state as a single inline sentence. That made the section feel unfinished and gave the empty state little visual hierarchy.

## Proposed change

- Present the empty state as a centered icon, title, and supporting description using existing semantic tokens and Lucide assets.
- Mark the imported-skills region as a labeled section without changing the populated list behavior.
- Extend the settings render test to cover the empty-state structure and centered composition.

## Scope and non-goals

- No changes to GitHub search, token, import, or removal behavior.
- No changes to the populated imported-skills list.
- No new dependencies, design tokens, or global styles.

## Acceptance criteria and validation

- GitHub import empty-state hierarchy: `npm test -- src/renderer/src/pages/settings/SkillsPanel.render.test.tsx` — 41/41 passed.
- Full regression suite selected by the impact check: `npm test` — 871 files passed, 12,666 tests passed (14 files and 190 tests skipped).
- Renderer and main-process types: `npm run typecheck` — passed.
- Source lint: `npm run lint` — 0 errors; 17 pre-existing warnings outside this change.
- Production web bundle: `npm run build:web` — passed.
- Visual QA: checked at 320, 375, 414, and 768 px content widths with no horizontal or text overflow.

All validation above was run after the last material edit.

## Review focus

- Empty-state hierarchy and spacing relative to the supplied reference.
- Accessible section labeling and decorative-icon treatment.
- Preservation of the existing imported-skills list path.

## Risks

- The available local profile already contained an imported skill, so the clean-profile empty state was covered by the render test and visually inspected by isolating that production markup in the browser rather than by mutating local profile data.
- Independent review and CI remain the final integration authority.
