### PR TITLE
test(reviewer): define orchestrator impact boundary

### DIFF
--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -647,6 +647,7 @@ describe('task CLI', () => {
       'compute',
       'notebook',
       'notebook-env',
+      'reviewer',
       'runtime'
     ]) {
       await expect(runCli([command])).rejects.toThrow(`Unknown command: ${command}`)

--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -121,6 +121,48 @@
       "capabilityOverlays": ["renderer_state"],
       "fallbackCapability": "renderer_view"
     },
+    "reviewer_orchestrator": {
+      "ownerPaths": ["src/main/reviewer/orchestrator.ts"],
+      "interfacePaths": [
+        "src/main/reviewer/orchestrator.ts",
+        "src/main/reviewer/ipc.ts",
+        "src/shared/reviewer.ts"
+      ],
+      "consumerModules": [],
+      "testFiles": {
+        "owner": [
+          "src/main/reviewer/orchestrator.test.ts",
+          "src/main/reviewer/orchestrator-drive.test.ts",
+          "src/main/reviewer/log-capture.test.ts",
+          "src/main/reviewer/orchestrator-prompt.test.ts",
+          "src/main/reviewer/orchestrator-prompt-prefix.test.ts",
+          "src/main/reviewer/orchestrator.start-contract.test.ts",
+          "src/main/reviewer/fix-loop.test.ts",
+          "src/main/reviewer/correction.test.ts"
+        ],
+        "contract": [
+          "src/main/reviewer/ipc.test.ts",
+          "src/main/reviewer/lifecycle.test.ts",
+          "src/main/reviewer/mcp-server.test.ts",
+          "src/main/application-command-wiring.test.ts",
+          "src/main/host-application-commands.test.ts",
+          "src/main/application-command-composition.test.ts",
+          "src/main/web-service/application-event-projections.test.ts",
+          "src/shared/renderer-contract-catalog.test.ts",
+          "src/preload/index.test.ts",
+          "src/renderer/web/api-installer.test.ts"
+        ],
+        "consumer": [
+          "packages/open-science/cli.test.ts",
+          "src/main/notebook/local-rpc-notebook-adapter.test.ts",
+          "src/renderer/src/lib/acp/workspace-events.test.ts",
+          "src/renderer/src/stores/review-store.test.ts",
+          "src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx"
+        ]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
     "compute_service": {
       "ownerPaths": [
         "src/main/compute/compute-host-profile-owner.ts",

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -219,6 +219,18 @@ describe('application command composition', () => {
     expect(listProjects).toHaveBeenCalledOnce()
   })
 
+  it('keeps Reviewer commands on local and remote Web but out of Task', () => {
+    const composition = createApplicationCommandComposition(dependencies())
+    const reviewerCommands = ['reviewer:abort-fix-loop', 'reviewer:get-for-session', 'reviewer:run']
+
+    expect(composition.localWeb.commandNames()).toEqual(expect.arrayContaining(reviewerCommands))
+    expect(composition.remoteWeb.commandNames()).toEqual(expect.arrayContaining(reviewerCommands))
+    for (const command of reviewerCommands) {
+      expect(composition.remoteWeb.rejectedCommandNames()).not.toContain(command)
+    }
+    expect(composition.task.commandNames()).not.toEqual(expect.arrayContaining(reviewerCommands))
+  })
+
   it('exposes only the seven Task commands and no transport-wide capability', async () => {
     const composition = createApplicationCommandComposition(dependencies())
 

--- a/src/main/notebook/local-rpc-notebook-adapter.test.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.test.ts
@@ -54,6 +54,7 @@ describe('notebook local RPC adapter', () => {
       'mcpCall',
       'computeCall',
       'agentsCall',
+      'reviewerCall',
       'skillImport',
       'artifactCreateVersion',
       'artifactReplayVersion',
@@ -122,7 +123,7 @@ describe('notebook local RPC adapter', () => {
   it('rejects unknown methods after validating common routing fields', () => {
     const capability = createCapability()
 
-    for (const method of ['unknown', 'listPackages', 'listPackageCounts']) {
+    for (const method of ['unknown', 'listPackages', 'listPackageCounts', 'reviewerCall']) {
       expect(() => resolveNotebookLocalRpcHandler(capability, method, request)).toThrow(
         `Unknown notebook RPC method: ${method}`
       )

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -1,3 +1,6 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ReviewRunRequest } from '../../shared/reviewer'
@@ -5,8 +8,10 @@ import { REVIEWER_IPC } from '../../shared/reviewer'
 import type { AcpRuntime } from '../acp/runtime'
 
 // Distinct roots so a config-vs-data mix-up is unambiguous: artifacts must read from the data root.
-const CONFIG_ROOT = '/tmp/open-science-config-root'
-const DATA_ROOT = '/tmp/open-science-data-root'
+const CONFIG_ROOT = join(tmpdir(), 'open-science-config-root')
+const DATA_ROOT = join(tmpdir(), 'open-science-data-root')
+const INJECTED_CONFIG_ROOT = join(tmpdir(), 'injected-config')
+const INJECTED_DATA_ROOT = join(tmpdir(), 'injected-data')
 
 // Capture every ipcMain.handle registration so handlers can be invoked directly in the test.
 const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
@@ -173,8 +178,8 @@ describe('reviewer IPC handlers', () => {
     getProjectDbClient.mockReset()
     registerReviewerIpcHandlers({
       acpRuntime,
-      storageRoot: '/tmp/injected-config',
-      dataRoot: '/tmp/injected-data'
+      storageRoot: INJECTED_CONFIG_ROOT,
+      dataRoot: INJECTED_DATA_ROOT
     })
 
     const runHandler = handlers.get(REVIEWER_IPC.RUN)
@@ -183,16 +188,16 @@ describe('reviewer IPC handlers', () => {
     await vi.waitFor(() => expect(runReview).toHaveBeenCalledTimes(1))
 
     const passed = runReview.mock.calls[0][0] as { artifactStorageRoot: string }
-    expect(passed.artifactStorageRoot).toBe('/tmp/injected-data')
+    expect(passed.artifactStorageRoot).toBe(INJECTED_DATA_ROOT)
     // ReviewRepository is constructed against the injected config root, not the resolveStorageRoot()
     // default. The repository captures a thunk `() => getProjectDbClient(storageRoot)`; invoke it
     // and assert the captured storageRoot surfaces through the getProjectDbClient spy.
     expect(reviewRepositoryThunks).toHaveLength(1)
     reviewRepositoryThunks[0]?.()
-    expect(getProjectDbClient).toHaveBeenCalledWith('/tmp/injected-config')
+    expect(getProjectDbClient).toHaveBeenCalledWith(INJECTED_CONFIG_ROOT)
     expect(getProjectDbClient).not.toHaveBeenCalledWith(CONFIG_ROOT)
     // SessionRepository takes a plain root string, captured by the mock constructor.
-    expect(sessionRepositoryRoots).toEqual(['/tmp/injected-config'])
+    expect(sessionRepositoryRoots).toEqual([INJECTED_CONFIG_ROOT])
   })
 
   it('forwards scopeTurnMessageId so a re-run audits the scope turn, grouped under turnMessageId', async () => {

--- a/src/main/reviewer/orchestrator.start-contract.test.ts
+++ b/src/main/reviewer/orchestrator.start-contract.test.ts
@@ -1,3 +1,6 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Review, ReviewWithChecks, TurnScope } from '../../shared/reviewer'
@@ -88,7 +91,7 @@ const baseOptions = (
   getSession: () => session,
   reviewRepository,
   acpRuntime,
-  artifactStorageRoot: '/tmp/data-root',
+  artifactStorageRoot: join(tmpdir(), 'reviewer-data-root'),
   onStarted: hooks.onStarted,
   onReviewUpdate: hooks.onReviewUpdate
 })

--- a/src/main/web-service/application-event-projections.test.ts
+++ b/src/main/web-service/application-event-projections.test.ts
@@ -73,6 +73,34 @@ describe('application event projections', () => {
     }
   })
 
+  it('projects Reviewer events to Web while keeping them out of public Task', () => {
+    const events: ApplicationEvent[] = [
+      { channel: 'reviewer:updated', payload: { review: {} as never } },
+      {
+        channel: 'reviewer:suppress-next-auto-review',
+        payload: { projectId: 'project-1', appSessionId: 'session-1' }
+      },
+      {
+        channel: 'reviewer:fix-loop-start',
+        payload: { projectId: 'project-1', appSessionId: 'session-1' }
+      },
+      {
+        channel: 'reviewer:fix-loop-end',
+        payload: { projectId: 'project-1', appSessionId: 'session-1' }
+      }
+    ]
+
+    for (const event of events) {
+      expect(projectWebRendererEvent(event)).toEqual({
+        protocolVersion: 1,
+        channel: event.channel,
+        payload: event.payload
+      })
+      expect(projectPublicTaskEvent(event)).toBeUndefined()
+      expect(projectTaskRuntimeEvent(event)).toBeUndefined()
+    }
+  })
+
   it('keeps public Task events to the existing two-channel allowlist', () => {
     const permission: ApplicationEvent<'acp:permission-request'> = {
       channel: 'acp:permission-request',


### PR DESCRIPTION
# Problem

`src/main/reviewer/orchestrator.ts` is a 1,474-line facade with extensive behavior coverage, but it
had no repository-owned Module entry. CodeGraph traversed shared runtime types and reported 874
affected tests, so the planned owner extractions had no deterministic, explainable Test Impact Set.
The existing cross-surface Reviewer capability and a few POSIX-only path fixtures were also implicit.

# Proposed change

- Add a `reviewer_orchestrator` module-impact entry with the current facade and stable IPC/shared
  Interfaces plus explicit owner, contract and consumer tests.
- Characterize the existing three Reviewer commands as available on local and remote Web but absent
  from Task.
- Characterize the existing four Reviewer events as projected to Web but absent from public Task
  runtime/event projections.
- Include the existing Electron direct/IPC shared-owner arbitration contract in the Module set.
- Replace touched `/tmp/...` Reviewer fixtures with `tmpdir()` and `join()` so the same tests remain
  portable on Windows, macOS and Linux.

# Scope and non-goals

- Test and test-impact registration only; no production source is changed.
- No Review/Session schema, IPC channel, application command, renderer contract, UI state or
  interaction changes.
- No new Reviewer capability for Task, direct CLI or Notebook local RPC.
- No Reviewer owner extraction yet; R1-R3 will perform the serial cutovers.
- No Issue #458 session-tree, child lifecycle, delegation MCP/API or generic OrchestratorService.

# Compatibility

- Electron keeps the legacy Reviewer IPC adapter and the same shared `ReviewerCommandOwner` used by
  Web application commands.
- Local and remote Web keep all three Reviewer commands and four Reviewer events.
- `open-science start` remains the local Web UI path and therefore keeps Reviewer support.
- Task/headless, direct CLI and Notebook local RPC retain their current lack of Reviewer commands;
  the internal Reviewer MCP transport remains private model infrastructure.
- Claude Code, Codex and OpenCode Reviewer behavior, MCP scope, Review persistence, correction loop,
  Specialist/Permission/Compute behavior and user interaction are unchanged.
- Test paths now use Node path APIs; intentional Windows named-pipe fixtures remain unchanged.

# Acceptance criteria and validation

- Focused cross-surface characterization tests: 4 files, 47 tests passed.
- `npm run test:module -- reviewer_orchestrator`: 23 files, 380 tests passed.
- Module-impact validation: 3 files, 30 tests passed.
- `npm run typecheck`: passed (Node and Web).
- `npm run lint -- --no-cache`: passed with 0 errors and 17 pre-existing warnings.
- Full repository fallback passed before the final test-only coverage additions: 874 files passed /
  14 skipped; 12,699 tests passed / 190 skipped. The final-state fallback was also run while another
  worktree's full suite was active; only four unrelated 15-second timeout cases failed. Their three
  files were then rerun sequentially and passed (3 files, 83 tests).
- Prettier and `git diff --check`: passed.
- Exact-head CI, platform lanes, CodeQL and AI review remain required before normal squash merge.

# Review focus

- Verify the Module set covers Reviewer behavior, interfaces and real consumers without selecting
  the entire repository.
- Verify the Web/Task assertions preserve current capability asymmetry rather than adding parity.
- Verify Electron and Web continue to share one Reviewer command owner and that Reviewer stays an
  ephemeral, reviewer-only leaf for Issue #458.
- Verify path fixtures are portable and no intentional Windows transport contract was changed.
