### PR TITLE
feat(acp): show context compaction activity

### DIFF
--- a/.hallmark/preflight.json
+++ b/.hallmark/preflight.json
@@ -1,0 +1,16 @@
+{
+  "scannedAt": "2026-08-09",
+  "scope": "component",
+  "framework": "Electron, React 19, TypeScript, Tailwind CSS 4",
+  "fontStack": "Inter, ui-sans-serif, system-ui",
+  "palette": "Theme tokens in src/renderer/src/assets/main.css",
+  "motion": "Existing spinner motion with reduced-motion support",
+  "spacing": "Existing Tailwind spacing scale",
+  "designSystem": "docs/design.md",
+  "preserve": [
+    "light and dark color tokens",
+    "message-scroller content gutter",
+    "activity-row geometry",
+    "existing status icon semantics"
+  ]
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -483,6 +483,11 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Agent loading surface is transparent and keeps `px-3 py-2` for stable transcript geometry; elapsed and status text use `text-text-000/70`, while the brand indicator uses `text-text-300`. A silent foreground prompt shows `[indicator] · thinking` with elapsed time and the existing slow-response hint. Active tools and permission waits show `[indicator] · interacting with tools` without a timer. Visible assistant text or images hide the indicator; when the current tool transitions to a terminal state, Thinking returns with a fresh timer until the next visible output. Runtime stop, failure, disconnect, and compaction clear the transient indicator state. Historical, duplicate, and late tool events must not revive it or reorder the activity timeline.
 - User Message copy and edit actions sit immediately left of the bubble and use the standard inline-action opacity transition on row hover or keyboard focus. When editing creates multiple Branches, keep the Branch navigation persistently visible at the right end of the metadata footer below the bubble, after the sent time, with previous/next controls around a Branch icon and the current/total count. Let the footer wrap on narrow surfaces so the navigation remains the final bottom row without colliding with the sent time.
 - Tool row: `h-8 rounded-lg px-2 text-[13px] hover:bg-foreground/[0.04]`.
+- Context compaction is a standalone, non-interactive activity row rather than a generic Tool group.
+  Keep the existing Tool-row geometry inside a quiet `bg-bg-200/70` surface. Show a spinner with
+  `Compacting context` while active, a check with `Context compacted` when complete, the standard
+  failure icon on error, and a neutral cancelled state. Persist the row on its originating Message
+  Branch and do not let duplicate, replayed, or late lifecycle events reopen a terminal row.
 - Tool row metadata: `text-[12.5px] text-muted-foreground tabular-nums`.
 - Link: `text-primary underline-offset-4 hover:underline`.
 - Inline code / resource reference: `rounded-md bg-accent/50 px-1.5 py-0.5 font-mono text-sm text-primary`.

--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -10,8 +10,11 @@ const PERMISSION_PROMPT = 'Request fixture permission.'
 const PROVIDER_BRIDGE_PROMPT = 'Verify the provider bridge.'
 const NOTEBOOK_LIFECYCLE_PROMPT = 'Verify the notebook lifecycle.'
 const ARTIFACT_PROVENANCE_PROMPT = 'Create a provenance artifact.'
+const CONTEXT_COMPACTION_PROMPT = 'Preview context compaction.'
 
 const sessionRoutes = new Map()
+
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))
 
 const stringEnvironment = (overrides = []) => {
   const environment = Object.fromEntries(
@@ -194,7 +197,31 @@ if (process.argv.includes('--version')) {
 
       let reply = 'Deterministic reply: Summarize the deterministic fixture.'
       try {
-        if (prompt.includes(PROVIDER_BRIDGE_PROMPT)) {
+        if (prompt.includes(CONTEXT_COMPACTION_PROMPT)) {
+          await context.client.notify(acp.methods.client.session.update, {
+            sessionId: context.params.sessionId,
+            update: {
+              sessionUpdate: 'tool_call',
+              toolCallId: 'e2e-context-compaction',
+              title: 'Context compacting',
+              kind: 'other',
+              status: 'in_progress',
+              _meta: { contextCompaction: true }
+            }
+          })
+          await delay(1_500)
+          await context.client.notify(acp.methods.client.session.update, {
+            sessionId: context.params.sessionId,
+            update: {
+              sessionUpdate: 'tool_call_update',
+              toolCallId: 'e2e-context-compaction',
+              title: 'Context compacted',
+              status: 'completed',
+              _meta: { contextCompaction: true }
+            }
+          })
+          reply = 'Compaction preview complete.'
+        } else if (prompt.includes(PROVIDER_BRIDGE_PROMPT)) {
           reply = verifyProviderBridge()
         } else if (prompt.includes(NOTEBOOK_LIFECYCLE_PROMPT)) {
           reply = await verifyNotebookLifecycle(context.params.sessionId)

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -7,6 +7,7 @@ const USER_MESSAGE = 'Summarize the deterministic fixture.'
 const EDITED_USER_MESSAGE = 'Summarize the revised deterministic fixture.'
 const AGENT_REPLY = `Deterministic reply: ${USER_MESSAGE}`
 const PERMISSION_PROMPT = 'Request fixture permission.'
+const CONTEXT_COMPACTION_PROMPT = 'Preview context compaction.'
 
 const createProject = async (page: Page): Promise<void> => {
   await page.getByRole('button', { name: 'New project' }).click()
@@ -97,6 +98,31 @@ test('resolves Agent permission requests through both Allow and Deny decisions',
   await expect(page.getByText('Write fixture output', { exact: true })).toBeVisible()
   await page.getByRole('button', { name: 'Deny', exact: true }).click()
   await expect(page.getByText('Fixture permission denied.', { exact: true })).toBeVisible()
+})
+
+test('shows context compaction loading and completion inside the Session transcript', async ({
+  app
+}) => {
+  let page = await app.completeOnboarding()
+  page = await app.configureFakeAgent()
+  await createProject(page)
+
+  await page.getByRole('textbox', { name: 'Ask anything' }).fill(CONTEXT_COMPACTION_PROMPT)
+  await page.getByRole('button', { name: 'Send message' }).click()
+
+  const conversation = page.getByRole('region', { name: 'Conversation' })
+  const compaction = conversation.getByTestId('context-compaction-activity')
+  await expect(compaction).toContainText('Compacting context')
+  await expect(compaction).toContainText('Context compacted')
+  await expect(compaction.getByTestId('tool-chip')).not.toHaveAttribute('role', 'status')
+
+  for (const width of [320, 375, 414, 768]) {
+    await page.setViewportSize({ width, height: 900 })
+    await expect(compaction).toBeVisible()
+    expect(await compaction.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
+      true
+    )
+  }
 })
 
 test('archives a completed session from its sidebar actions', async ({ app }) => {

--- a/src/main/acp/context-compaction-workflow.test.ts
+++ b/src/main/acp/context-compaction-workflow.test.ts
@@ -153,6 +153,8 @@ describe('AcpContextCompactionWorkflow', () => {
       { kind: 'compaction', status: 'in_progress', compactionReason: 'manual' },
       { kind: 'compaction', status: 'completed', compactionReason: 'manual' }
     ])
+    expect(harness.events[0].toolCallId).toMatch(/^context-compaction:/u)
+    expect(harness.events[1].toolCallId).toBe(harness.events[0].toolCallId)
     expect(harness.emitState).toHaveBeenCalledTimes(2)
     expect(harness.interactions.current('app-session')).toBeUndefined()
   })

--- a/src/main/acp/context-compaction-workflow.ts
+++ b/src/main/acp/context-compaction-workflow.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type { ActiveSession, PromptResponse, SessionNotification } from '@agentclientprotocol/sdk'
 
 import type { AcpCompactSessionRequest, AcpRuntimeEvent } from '../../shared/acp'
@@ -105,13 +106,15 @@ class AcpContextCompactionWorkflow {
     }
     const checkpoint = this.options.context.checkpointSession(sessionId)
     const restoreContext = (): void => this.options.context.restoreSession(sessionId, checkpoint)
+    const toolCallId = `context-compaction:${randomUUID()}`
     this.publishEvent({
       kind: 'compaction',
       compactionReason: reason,
       level: 'info',
       sessionId,
       status: 'in_progress',
-      title: 'Compacting context'
+      title: 'Compacting context',
+      toolCallId
     })
 
     try {
@@ -130,7 +133,8 @@ class AcpContextCompactionWorkflow {
               level: 'info',
               sessionId,
               status: 'cancelled',
-              title: 'Context compaction cancelled'
+              title: 'Context compaction cancelled',
+              toolCallId
             })
             return message.response
           }
@@ -153,7 +157,8 @@ class AcpContextCompactionWorkflow {
             level: 'info',
             sessionId,
             status: 'completed',
-            title: 'Context compacted'
+            title: 'Context compacted',
+            toolCallId
           })
           return message.response
         }
@@ -179,7 +184,8 @@ class AcpContextCompactionWorkflow {
         sessionId,
         status: 'failed',
         title: 'Context compaction failed',
-        text: this.options.errorMessage(error)
+        text: this.options.errorMessage(error),
+        toolCallId
       })
       throw error
     }

--- a/src/main/acp/runtime-events.test.ts
+++ b/src/main/acp/runtime-events.test.ts
@@ -152,6 +152,55 @@ describe('ACP runtime event normalization', () => {
     expect(event).not.toHaveProperty('previewToolKind')
   })
 
+  it('maps Codex context-compaction tool calls into the shared compaction lifecycle', () => {
+    const notification: SessionNotification = {
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'compact-1',
+        title: 'Context compacting',
+        kind: 'other',
+        status: 'in_progress',
+        _meta: { contextCompaction: true }
+      }
+    }
+
+    expect(toAcpRuntimeEvent(notification, 'event-compact-start', 1710000000002)).toMatchObject({
+      id: 'event-compact-start',
+      timestamp: 1710000000002,
+      kind: 'compaction',
+      sessionId: 'session-1',
+      toolCallId: 'compact-1',
+      title: 'Compacting context',
+      status: 'in_progress'
+    })
+  })
+
+  it.each(['tool_call', 'tool_call_update'] as const)(
+    'maps Codex %s completion events for live updates and history replay',
+    (sessionUpdate) => {
+      const notification: SessionNotification = {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate,
+          toolCallId: 'compact-1',
+          title: 'Context compacted',
+          kind: 'other',
+          status: 'completed',
+          _meta: { contextCompaction: true }
+        }
+      }
+
+      expect(toAcpRuntimeEvent(notification, `event-${sessionUpdate}`)).toMatchObject({
+        kind: 'compaction',
+        sessionId: 'session-1',
+        toolCallId: 'compact-1',
+        title: 'Context compacted',
+        status: 'completed'
+      })
+    }
+  )
+
   it('maps tool call updates without preview metadata', () => {
     const notification: SessionNotification = {
       sessionId: 'session-1',

--- a/src/main/acp/runtime-events.ts
+++ b/src/main/acp/runtime-events.ts
@@ -179,6 +179,35 @@ type ToolCallUpdate = Extract<
   { sessionUpdate: 'tool_call' | 'tool_call_update' }
 >
 
+// codex-acp represents native automatic and manual context compaction as a tool lifecycle with a
+// structural metadata marker. Normalize it before generic tool projection so every framework reaches
+// the renderer through the same compaction interface.
+const isContextCompactionUpdate = (update: ToolCallUpdate): boolean => {
+  const meta = update._meta
+
+  return isRecord(meta) && meta.contextCompaction === true
+}
+
+const projectContextCompactionUpdate = (
+  update: ToolCallUpdate
+): Pick<AcpRuntimeEvent, 'kind' | 'status' | 'title' | 'toolCallId'> => {
+  const status =
+    update.status ?? (update.sessionUpdate === 'tool_call_update' ? 'completed' : 'in_progress')
+  const title =
+    status === 'completed'
+      ? 'Context compacted'
+      : status === 'failed'
+        ? 'Context compaction failed'
+        : 'Compacting context'
+
+  return {
+    kind: 'compaction',
+    status,
+    title,
+    toolCallId: update.toolCallId
+  }
+}
+
 // Native Skill calls return their instruction document as a tool result. It is agent context, not
 // user-facing output, so do not send it through the activity, IPC, or persistence pipelines.
 const isNativeSkillToolUpdate = (update: ToolCallUpdate): boolean => {
@@ -288,6 +317,13 @@ const toAcpRuntimeEvent = (
         text: contentToText(update.content)
       }
     case 'tool_call':
+      if (isContextCompactionUpdate(update)) {
+        return {
+          ...base,
+          raw: undefined,
+          ...projectContextCompactionUpdate(update)
+        }
+      }
       // Tool events expose only the bounded fields consumed by the UI. Do not retain the original
       // notification because it duplicates the unbounded arguments and results inside `raw`.
       return {
@@ -302,6 +338,13 @@ const toAcpRuntimeEvent = (
         status: update.status
       }
     case 'tool_call_update':
+      if (isContextCompactionUpdate(update)) {
+        return {
+          ...base,
+          raw: undefined,
+          ...projectContextCompactionUpdate(update)
+        }
+      }
       // Tool updates stay compact and do not expose future preview metadata assumptions.
       return {
         ...base,

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -455,6 +455,43 @@ describe('AcpSessionUpdateProjector', () => {
     ])
   })
 
+  it('projects the legacy Codex completion notice as a completed compaction lifecycle', () => {
+    const projector = createProjector()
+    const notice = "*Context compacted to fit the model's context window.*\n\n"
+    const effects = projector.route(
+      {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: notice }
+        }
+      },
+      {
+        framework: 'codex',
+        eventId: 'event-legacy-compaction',
+        visible: true,
+        reconnectPending: false,
+        mcpServerNames: []
+      }
+    )
+
+    expect(effects).toMatchObject([
+      { kind: 'context-observation' },
+      { kind: 'context-refresh' },
+      {
+        kind: 'visible-event',
+        event: {
+          kind: 'compaction',
+          sessionId: 'session-1',
+          status: 'completed',
+          title: 'Context compacted',
+          toolCallId: 'context-compaction:event-legacy-compaction'
+        }
+      }
+    ])
+    expect(effects.at(-1)).not.toHaveProperty('event.text')
+  })
+
   it('projects usage to context state without a visible event and suppresses stale reconnect usage', () => {
     const projector = createProjector()
     const notification: SessionNotification = {

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -18,6 +18,7 @@ import type { AcpSessionRegistry } from './session-registry'
 
 const CODEX_COMPACTION_WARNING =
   'Warning: Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted.'
+const CODEX_LEGACY_COMPACTION_NOTICE = "*Context compacted to fit the model's context window.*"
 const AGENT_USER_CHOICE_TOOL = 'open-science-notebook/ask_user_question'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -199,7 +200,24 @@ class AcpSessionUpdateProjector {
         routing.framework === 'claude-code'
       )
     )
-    const event = deepFreeze(projection.event)
+    const projectedEvent = projection.event
+    const event = deepFreeze(
+      routing.framework === 'codex' &&
+        projectedEvent.kind === 'message' &&
+        projectedEvent.messageId === undefined &&
+        projectedEvent.text?.trim() === CODEX_LEGACY_COMPACTION_NOTICE
+        ? {
+            id: projectedEvent.id,
+            timestamp: projectedEvent.timestamp,
+            level: projectedEvent.level,
+            kind: 'compaction' as const,
+            sessionId: projectedEvent.sessionId,
+            status: 'completed',
+            title: 'Context compacted',
+            toolCallId: `context-compaction:${routing.eventId}`
+          }
+        : projectedEvent
+    )
     // codex-acp 1.1.4 flattens Codex's post-compaction warning into an unscoped assistant chunk.
     // Keep the separate compaction notice, but do not attribute this adapter-authored warning to the model.
     if (

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -411,53 +411,145 @@ describe('workspace runtime events', () => {
 
   it('tracks native context compaction without adding chat messages', async () => {
     useSessionStore.getState().finishRun('transport-session-1')
-    const messageCount = useSessionStore.getState().sessions[0].messages.length
+    const sessionBefore = useSessionStore.getState().sessions[0]
+    const messageCount = sessionBefore.messages.length
+    const promptMessageId = sessionBefore.messages[0].id
 
     await applyWorkspaceRuntimeEvent(
-      createEvent({ id: 'compact-start', kind: 'compaction', status: 'in_progress' })
+      createEvent({
+        id: 'compact-start',
+        kind: 'compaction',
+        promptMessageId,
+        status: 'in_progress',
+        title: 'Compacting context',
+        toolCallId: 'context-compaction:1'
+      })
     )
 
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       status: 'idle',
-      compacting: true
+      compacting: true,
+      activities: [
+        expect.objectContaining({
+          id: 'context-compaction:1',
+          promptMessageId,
+          providerToolName: 'ContextCompaction',
+          status: 'in_progress',
+          title: 'Compacting context'
+        })
+      ]
     })
 
     await applyWorkspaceRuntimeEvent(
-      createEvent({ id: 'compact-done', kind: 'compaction', status: 'completed' })
+      createEvent({
+        id: 'compact-done',
+        kind: 'compaction',
+        promptMessageId,
+        status: 'completed',
+        title: 'Context compacted',
+        toolCallId: 'context-compaction:1'
+      })
     )
 
     const session = useSessionStore.getState().sessions[0]
     expect(session.compacting).toBeUndefined()
     expect(session.status).toBe('idle')
     expect(session.messages).toHaveLength(messageCount)
-  })
+    expect(session.activities).toEqual([
+      expect.objectContaining({
+        id: 'context-compaction:1',
+        eventIds: ['compact-start', 'compact-done'],
+        promptMessageId,
+        providerToolName: 'ContextCompaction',
+        status: 'completed',
+        title: 'Context compacted'
+      })
+    ])
+    expect(toPersistedSession(session).conversationGraph?.activities).toEqual([
+      expect.objectContaining({
+        id: 'context-compaction:1',
+        promptMessageId,
+        providerToolName: 'ContextCompaction',
+        status: 'completed'
+      })
+    ])
 
-  it('settles cancelled native compaction without surfacing a session error', async () => {
-    useSessionStore.getState().finishRun('transport-session-1')
     await applyWorkspaceRuntimeEvent(
-      createEvent({ id: 'compact-start', kind: 'compaction', status: 'in_progress' })
-    )
-    await applyWorkspaceRuntimeEvent(
-      createEvent({ id: 'compact-cancelled', kind: 'compaction', status: 'cancelled' })
+      createEvent({
+        id: 'compact-late-start',
+        kind: 'compaction',
+        promptMessageId,
+        status: 'in_progress',
+        title: 'Compacting context',
+        toolCallId: 'context-compaction:1'
+      })
     )
 
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       status: 'idle',
       compacting: undefined,
-      error: undefined
+      activities: [
+        expect.objectContaining({
+          eventIds: ['compact-start', 'compact-done'],
+          status: 'completed',
+          title: 'Context compacted'
+        })
+      ]
+    })
+  })
+
+  it('settles cancelled native compaction without surfacing a session error', async () => {
+    useSessionStore.getState().finishRun('transport-session-1')
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'compact-start',
+        kind: 'compaction',
+        status: 'in_progress',
+        title: 'Compacting context',
+        toolCallId: 'context-compaction:cancelled'
+      })
+    )
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'compact-cancelled',
+        kind: 'compaction',
+        status: 'cancelled',
+        title: 'Context compaction cancelled',
+        toolCallId: 'context-compaction:cancelled'
+      })
+    )
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'idle',
+      compacting: undefined,
+      error: undefined,
+      activities: [
+        expect.objectContaining({
+          status: 'completed',
+          title: 'Context compaction cancelled'
+        })
+      ]
     })
   })
 
   it('surfaces native compaction failures as non-reportable session errors', async () => {
     useSessionStore.getState().finishRun('transport-session-1')
     await applyWorkspaceRuntimeEvent(
-      createEvent({ id: 'compact-start', kind: 'compaction', status: 'in_progress' })
+      createEvent({
+        id: 'compact-start',
+        kind: 'compaction',
+        status: 'in_progress',
+        title: 'Compacting context',
+        toolCallId: 'context-compaction:failed'
+      })
     )
     await applyWorkspaceRuntimeEvent(
       createEvent({
         id: 'compact-failed',
         kind: 'compaction',
         status: 'failed',
+        title: 'Context compaction failed',
+        toolCallId: 'context-compaction:failed',
         text: 'Agent rejected /compact'
       })
     )
@@ -466,7 +558,10 @@ describe('workspace runtime events', () => {
       status: 'error',
       compacting: undefined,
       error: 'Agent rejected /compact',
-      errorReportable: false
+      errorReportable: false,
+      activities: [
+        expect.objectContaining({ status: 'failed', title: 'Context compaction failed' })
+      ]
     })
   })
 

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -1,4 +1,8 @@
-import type { AcpRuntimeEvent, AcpTurnTokenUsage } from '../../../../shared/acp'
+import {
+  ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME,
+  type AcpRuntimeEvent,
+  type AcpTurnTokenUsage
+} from '../../../../shared/acp'
 import {
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile,
@@ -669,19 +673,52 @@ const applyWorkspaceRuntimeEvent = async (
     return true
   }
 
-  // Native compaction is a framework control turn, not a chat turn. Reflect its lifecycle in the
-  // existing neutral compacting state while keeping command/status output out of the transcript.
+  // Native compaction is a framework control turn, not a chat Message. Persist one branch-scoped,
+  // non-interactive activity row while retaining the existing neutral Session compacting state.
   if (event.kind === 'compaction' && event.sessionId) {
+    const sessionBeforeCompaction = store.sessions.find(
+      (candidate) => candidate.id === event.sessionId
+    )
+    const existingActivity = event.toolCallId
+      ? sessionBeforeCompaction?.activities?.find((activity) => activity.id === event.toolCallId)
+      : undefined
+    if (
+      existingActivity?.providerToolName === ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME &&
+      isTerminalToolActivity(existingActivity)
+    ) {
+      return true
+    }
+
     if (event.status === 'in_progress') {
       store.beginCompaction(event.sessionId)
-    } else if (event.compactionReason === 'overflow-recovery') {
-      // The recovery flow owns the terminal transition: keep the composer gated until its retry
-      // replaces compacting with a new active run, or its fallback reports a concrete failure.
-      return true
-    } else if (event.status === 'completed' || event.status === 'cancelled') {
-      store.finishCompaction(event.sessionId)
-    } else if (event.status === 'failed') {
-      store.failCompaction(event.sessionId, getEventErrorText(event))
+    } else if (event.compactionReason !== 'overflow-recovery') {
+      if (event.status === 'completed' || event.status === 'cancelled') {
+        store.finishCompaction(event.sessionId)
+      } else if (event.status === 'failed') {
+        store.failCompaction(event.sessionId, getEventErrorText(event))
+      }
+    }
+    // For overflow recovery, the recovery flow owns the terminal Session transition: the activity row
+    // still settles below, while the composer stays gated until a retry or fallback takes over.
+
+    const session = useSessionStore
+      .getState()
+      .sessions.find((candidate) => candidate.id === event.sessionId)
+    const promptMessageId =
+      event.promptMessageId ?? (session ? getCurrentPromptMessageId(session) : undefined)
+    if (event.toolCallId && promptMessageId) {
+      store.completeActivityGroup(event.sessionId, promptMessageId)
+      store.upsertToolActivity({
+        sessionId: event.sessionId,
+        toolCallId: event.toolCallId,
+        eventId: event.id,
+        timestamp: event.timestamp,
+        promptMessageId,
+        title: event.title,
+        status: event.status === 'cancelled' ? 'completed' : event.status,
+        providerToolName: ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME,
+        toolKind: 'other'
+      })
     }
 
     return true

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -42,6 +42,7 @@ import { NotebookInputDataStrip } from './NotebookInputDataStrip'
 import { NotebookCodeBlock } from './notebook-code'
 import { NotebookDialogCell } from './SessionNotebookDialog'
 import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
+import { WorkspaceContextCompactionActivityRow } from './WorkspaceContextCompactionActivityRow'
 import { WorkspacePlanActivityRecord } from './WorkspacePlanActivityRecord'
 import { WorkspaceElicitationCard } from './WorkspaceElicitationCard'
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
@@ -383,6 +384,16 @@ const ProvenanceMessagesTimeline = ({
                 if (conversationItem.type === 'plan-activity') {
                   return (
                     <WorkspacePlanActivityRecord
+                      key={conversationItem.id}
+                      activity={conversationItem.activity}
+                      contentPaddingClassName="px-0 md:px-0"
+                    />
+                  )
+                }
+
+                if (conversationItem.type === 'compaction-activity') {
+                  return (
+                    <WorkspaceContextCompactionActivityRow
                       key={conversationItem.id}
                       activity={conversationItem.activity}
                       contentPaddingClassName="px-0 md:px-0"

--- a/src/renderer/src/pages/workspace/WorkspaceActivityIcon.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceActivityIcon.tsx
@@ -3,6 +3,7 @@ import type { ToolActivity } from '@/stores/session-store'
 import {
   Check,
   CircleAlert,
+  CircleMinus,
   FilePen,
   FileText,
   Globe2,
@@ -13,7 +14,7 @@ import {
   Wrench
 } from 'lucide-react'
 
-import { isActivityActive } from './workspace-conversation-items'
+import { isActivityActive, isContextCompactionActivity } from './workspace-conversation-items'
 
 type WorkspaceActivityIconProps = {
   activity: ToolActivity
@@ -32,6 +33,9 @@ const WorkspaceActivityIcon = ({ activity }: WorkspaceActivityIconProps): React.
   // Status takes precedence over tool kind so terminal or active states are unmistakable.
   if (isActive) return <LoaderCircle {...iconProps} />
   if (activity.status === 'failed') return <CircleAlert {...iconProps} />
+  if (isContextCompactionActivity(activity) && activity.title === 'Context compaction cancelled') {
+    return <CircleMinus {...iconProps} />
+  }
   if (activity.status === 'completed') return <Check {...iconProps} />
 
   // Otherwise the tool kind hints at what the call did.

--- a/src/renderer/src/pages/workspace/WorkspaceContextCompactionActivityRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceContextCompactionActivityRow.tsx
@@ -1,0 +1,30 @@
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
+import { MessageScrollerItem } from '@/components/ui/message-scroller'
+import { cn } from '@/lib/utils'
+
+import { WorkspaceToolActivityRow } from './WorkspaceToolActivityRow'
+
+type WorkspaceContextCompactionActivityRowProps = React.ComponentProps<
+  typeof WorkspaceToolActivityRow
+> & {
+  contentPaddingClassName?: string
+}
+
+// Context compaction is a control lifecycle, so it gets a quiet status block without tool controls.
+const WorkspaceContextCompactionActivityRow = ({
+  activity,
+  contentPaddingClassName
+}: WorkspaceContextCompactionActivityRowProps): React.JSX.Element => (
+  <MessageScrollerItem messageId={`compaction-activity-${activity.id}`} className="min-w-0">
+    <div className={cn('px-4 pb-0.5 pt-2.5 md:px-6', contentPaddingClassName)}>
+      <div
+        className="w-full overflow-hidden rounded-[14px] bg-bg-200/70 px-1.5 py-1"
+        data-testid="context-compaction-activity"
+      >
+        <WorkspaceToolActivityRow activity={activity} />
+      </div>
+    </div>
+  </MessageScrollerItem>
+)
+
+export { WorkspaceContextCompactionActivityRow }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -29,6 +29,7 @@ import { extractJobIdFromActivity } from '@/components/job-binding-utils'
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { ReviewerCard } from '@/components/ReviewerCard'
 import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
+import { WorkspaceContextCompactionActivityRow } from './WorkspaceContextCompactionActivityRow'
 import { WorkspacePlanActivityRecord } from './WorkspacePlanActivityRecord'
 import { WorkspaceAgentLoadingRow } from './WorkspaceAgentLoadingRow'
 import { WorkspaceMessageItem } from './WorkspaceMessageItem'
@@ -870,6 +871,15 @@ const WorkspaceMessageScrollerImpl = ({
 
                   if (item.type === 'plan-activity') {
                     return <WorkspacePlanActivityRecord key={item.id} activity={item.activity} />
+                  }
+
+                  if (item.type === 'compaction-activity') {
+                    return (
+                      <WorkspaceContextCompactionActivityRow
+                        key={item.id}
+                        activity={item.activity}
+                      />
+                    )
                   }
 
                   if (item.type === 'activity') {

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ChatSession, ToolActivity } from '@/stores/session-store'
+import { ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME } from '../../../../shared/acp'
 import type { HandoffLifecycleEvent } from '../../../../shared/handoff-lifecycle'
 import {
   createConversationItems,
@@ -44,6 +45,25 @@ describe('workspace conversation items', () => {
     expect(
       formatActivityTitle(createActivity({ title: 'Loading skill: mcp-pubmed', status: 'failed' }))
     ).toBe('Skill failed: mcp-pubmed')
+  })
+
+  it('projects context compaction as a standalone status item with trusted lifecycle copy', () => {
+    const activity = createActivity({
+      id: 'context-compaction:1',
+      providerToolName: ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME,
+      status: 'in_progress',
+      title: 'Compacting context'
+    })
+    const session: ChatSession = { ...baseSession, activities: [activity] }
+
+    expect(formatActivityTitle(activity)).toBe('Compacting context')
+    expect(createConversationItems(session)).toEqual([
+      expect.objectContaining({
+        id: 'compaction-activity-context-compaction:1',
+        type: 'compaction-activity',
+        activity
+      })
+    ])
   })
 
   it('orders messages and activities by stable runtime sort index when timestamps match', () => {

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage, ChatSession, ToolActivity } from '@/stores/session-store'
+import { ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME } from '../../../../shared/acp'
 import type { HandoffLifecycleEvent } from '../../../../shared/handoff-lifecycle'
 
 import {
@@ -15,7 +16,9 @@ type ConversationMessageItem = {
   message: ChatMessage
 }
 
-type ConversationActivityItemBase<ItemType extends 'activity' | 'plan-activity'> = {
+type ConversationActivityItemBase<
+  ItemType extends 'activity' | 'plan-activity' | 'compaction-activity'
+> = {
   id: string
   type: ItemType
   createdAt: number
@@ -25,6 +28,7 @@ type ConversationActivityItemBase<ItemType extends 'activity' | 'plan-activity'>
 
 type ConversationActivityItem = ConversationActivityItemBase<'activity'>
 type ConversationPlanActivityItem = ConversationActivityItemBase<'plan-activity'>
+type ConversationCompactionActivityItem = ConversationActivityItemBase<'compaction-activity'>
 
 // A lifecycle row is a read-only annotation on its originating user turn. It is not another user
 // message and cannot own a separate continuation identity.
@@ -38,6 +42,7 @@ type ConversationItem =
   | ConversationMessageItem
   | ConversationActivityItem
   | ConversationPlanActivityItem
+  | ConversationCompactionActivityItem
   | ConversationHandoffItem
 
 const KNOWN_TITLE_TOOL_NAMES = new Set(['ToolSearch'])
@@ -90,6 +95,9 @@ const formatNotebookToolName = (toolName: string): string | undefined => {
 const isActivityActive = (activity: ToolActivity): boolean =>
   activity.status === 'pending' || activity.status === 'in_progress'
 
+const isContextCompactionActivity = (activity: ToolActivity): boolean =>
+  activity.providerToolName === ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME
+
 // Normalizes optional labels so empty strings can fall back to tool-kind names.
 const trimDetail = (value: string | null | undefined): string | undefined => {
   const trimmedValue = value?.trim()
@@ -133,6 +141,15 @@ const formatActivityToolName = (activity: ToolActivity): string => {
 
 // Builds the status-sensitive text for non-search activity chips.
 const formatActivityTitle = (activity: ToolActivity): string => {
+  if (isContextCompactionActivity(activity)) {
+    const title = trimDetail(activity.title)
+
+    if (title) return title
+    if (activity.status === 'failed') return 'Context compaction failed'
+    if (activity.status === 'completed') return 'Context compacted'
+    return 'Compacting context'
+  }
+
   if (isSkillActivity(activity)) {
     const skillName = getLoadedSkillName(activity)
 
@@ -168,13 +185,19 @@ const createConversationItems = (
     session?.activities?.flatMap((activity): ConversationItem[] => {
       const planToolKind = getPlanToolKind(activity)
       if (planToolKind === 'update_step_status') return []
+      const isCompaction = isContextCompactionActivity(activity)
       return [
         {
-          id:
-            planToolKind === 'generate_plan'
+          id: isCompaction
+            ? `compaction-activity-${activity.id}`
+            : planToolKind === 'generate_plan'
               ? `plan-activity-${activity.id}`
               : `activity-${activity.id}`,
-          type: planToolKind === 'generate_plan' ? 'plan-activity' : 'activity',
+          type: isCompaction
+            ? 'compaction-activity'
+            : planToolKind === 'generate_plan'
+              ? 'plan-activity'
+              : 'activity',
           createdAt: activity.createdAt,
           sortIndex: activity.sortIndex,
           activity
@@ -203,6 +226,7 @@ export {
   formatActivityTitle,
   formatNotebookToolName,
   getNotebookToolSuffix,
-  isActivityActive
+  isActivityActive,
+  isContextCompactionActivity
 }
 export type { ConversationItem }

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
@@ -60,6 +60,14 @@ const planActivityItem = (activity: ToolActivity): ConversationItem => ({
   activity
 })
 
+const compactionActivityItem = (activity: ToolActivity): ConversationItem => ({
+  id: `compaction-activity-${activity.id}`,
+  type: 'compaction-activity',
+  createdAt: activity.createdAt,
+  sortIndex: activity.sortIndex,
+  activity
+})
+
 // The ToolSearch wrapper row that can precede concrete search entries.
 const toolSearchWrapper = (overrides: Partial<ToolActivity> = {}): ToolActivity =>
   createActivity({ id: 'tool-search-wrapper', title: 'ToolSearch', ...overrides })
@@ -187,6 +195,21 @@ describe('groupConversationItems', () => {
         .filter((item) => item.type === 'activity-group')
         .map((item) => formatStepCount(item.activities))
     ).toEqual(['1 step', '1 step'])
+  })
+
+  it('keeps context compaction standalone between adjacent tool groups', () => {
+    const compaction = createActivity({ id: 'context-compaction:1', sortIndex: 2 })
+    const grouped = groupConversationItems([
+      activityItem(createActivity({ id: 'read-1', sortIndex: 1 })),
+      compactionActivityItem(compaction),
+      activityItem(createActivity({ id: 'read-2', sortIndex: 3 }))
+    ])
+
+    expect(grouped.map((item) => item.type)).toEqual([
+      'activity-group',
+      'compaction-activity',
+      'activity-group'
+    ])
   })
 })
 

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
@@ -43,6 +43,7 @@ const groupConversationItems = (
       item.type === 'message' ||
       item.type === 'handoff' ||
       item.type === 'plan-activity' ||
+      item.type === 'compaction-activity' ||
       (item.type === 'activity' && item.activity.elicitation)
     ) {
       groupedItems.push(item)

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -113,6 +113,11 @@ export type AcpRuntimeEventKind =
   | 'stop'
   | 'raw'
 
+// Durable renderer marker for compaction lifecycle rows stored through the existing tool-activity
+// projection. The runtime event remains `kind: 'compaction'`; this value only identifies its transcript
+// activity after persistence and replay.
+export const ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME = 'ContextCompaction'
+
 export type AcpRuntimeEventLevel = 'info' | 'warning' | 'error'
 
 export type AcpHandoffFailure = {


### PR DESCRIPTION
## Problem

Automatic context compaction was invisible in the Session transcript. Claude Code and OpenCode use the app-owned `/compact` workflow, while Codex emits its own structured tool lifecycle (and older adapters emit only a completion notice), so the renderer had no provider-compatible activity contract to display.

## Proposed change

- Give app-owned compaction lifecycles one correlated id across loading, completion, cancellation, and failure.
- Normalize Codex `_meta.contextCompaction` tool events, history replay, and the legacy completion notice into the same ACP runtime event.
- Persist the lifecycle as a branch-scoped, non-interactive Session activity that remains standalone from ordinary Tool groups.
- Render spinner, completed, failed, and cancelled states using the existing activity-row tokens and icon semantics.
- Add unit coverage across runtime normalization, replay, persistence, grouping, and late-event handling, plus a real Electron E2E lifecycle fixture.

```mermaid
flowchart LR
  A["Claude Code / OpenCode host workflow"] --> C["Unified compaction runtime event"]
  B["Codex Responses / Bridge structured or legacy event"] --> C
  C --> D["Branch-scoped persisted activity"]
  D --> E["Standalone Session status row"]
```

## Scope and non-goals

- Supports Claude Code, OpenCode, Codex Responses, and Codex Bridge without changing their compaction thresholds or commands.
- Does not add a persistence schema or migration; it reuses the existing ToolActivity conversation graph.
- Codex does not identify whether a native compaction was automatic or manual, so every recognized Codex compaction lifecycle is displayed.
- Does not change generic Tool activity rendering.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- ACP normalization, lifecycle correlation, replay, renderer persistence, grouping, and all portable consumers -> `npm run test:affected -- --base main --head HEAD` -> full fallback selected; 875 files passed, 12,713 tests passed (14 files / 190 tests skipped).
- Main-process contracts -> `npm run typecheck:node` -> passed.
- Renderer contracts -> `npm run typecheck:web` -> passed.
- Source/style rules -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings.
- Production Electron bundle -> `npm run build:e2e` -> passed.
- Loading-to-completed Session lifecycle -> `npm run test:e2e -- e2e/workspace-conversation.spec.ts --grep "shows context compaction"` -> 1 passed.
- Responsive status row at 320, 375, 414, and 768 CSS px -> covered by the same Electron E2E -> passed without row overflow.
- Patch integrity -> `git diff --check` -> passed.

Uncovered risks: third-party ACP binaries may introduce new compaction event shapes after this change, and cross-platform Electron packaging remains authoritative in CI. The currently observed structured and legacy Codex shapes are covered locally.

## Review focus

- Confirm compaction normalization remains ahead of generic Tool projection without retaining raw tool payloads.
- Confirm terminal duplicate and late events cannot reopen a completed activity.
- Confirm the persisted activity stays attached to the originating Message Branch and does not join ordinary Tool groups.
