### PR TITLE
refactor(reviewer): extract assessment owner

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -124,6 +124,7 @@
     "reviewer_orchestrator": {
       "ownerPaths": [
         "src/main/reviewer/orchestrator.ts",
+        "src/main/reviewer/review-assessment-owner.ts",
         "src/main/reviewer/reviewer-session-driver.ts"
       ],
       "interfacePaths": [
@@ -134,6 +135,7 @@
       "consumerModules": ["workspace_runtime", "workspace_page", "artifact_provenance"],
       "testFiles": {
         "owner": [
+          "src/main/reviewer/review-assessment-owner.test.ts",
           "src/main/reviewer/orchestrator.test.ts",
           "src/main/reviewer/orchestrator-drive.test.ts",
           "src/main/reviewer/log-capture.test.ts",

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -8,36 +8,23 @@
 // Errors are isolated: reviewer failures set lifecycle='error' and do NOT crash the main session.
 
 import { randomUUID } from 'node:crypto'
-import { homedir } from 'node:os'
-
-import type { ActiveSession } from '@agentclientprotocol/sdk'
 
 import { withReviewerRuntimeActivity, type ReviewerAcpRuntime } from './acp-runtime'
-import { createLogger, errorLogFields } from '../logger'
-import type {
-  NewCheck,
-  ReviewCheck,
-  ReviewerLogEntry,
-  ReviewOutcome,
-  ReviewWithChecks,
-  TurnScope
-} from '../../shared/reviewer'
+import { createLogger } from '../logger'
+import type { ReviewCheck, ReviewWithChecks } from '../../shared/reviewer'
 import type { ReviewRepository } from './repository'
-import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
 import {
   materializeSessionConversationGraph,
   type PersistedChatSession
 } from '../../shared/session-persistence'
-import { ReviewerMcpServer } from './mcp-server'
-import { ReviewerHostServer, type ArtifactVersionContentResolver } from './host-sdk'
-import { buildReviewScopeSnapshot } from './scope-snapshot'
-import { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } from './rubric'
+import type { ArtifactVersionContentResolver } from './host-sdk'
 import { injectAuditorMessage } from './correction'
 import { buildHistoryPreamble } from '../../shared/history-preamble'
 import { getActiveConversationContext } from '../../shared/conversation-graph'
-import { driveReviewerToStop } from './reviewer-session-driver'
+import { runReviewAssessment, type ReviewAssessmentResult } from './review-assessment-owner'
 
-export { driveReviewerToStop }
+export { buildReviewerPrompt } from './review-assessment-owner'
+export { driveReviewerToStop } from './reviewer-session-driver'
 
 const log = createLogger('reviewer:orchestrator')
 
@@ -128,68 +115,6 @@ const DEFAULT_REVIEWER_TIMEOUT_MS = 900_000
 const DEFAULT_REVIEWER_MAX_UPDATES = 1000
 const DEFAULT_SESSION_REFRESH_TIMEOUT_MS = 10_000
 const SESSION_REFRESH_POLL_MS = 50
-
-// A review can end without submit_findings for two very different reasons: the reviewer genuinely
-// stalled, or the permission gate rejected its tool calls. The rejection counter cannot tell these
-// apart — it counts every rejected call, including tools the gate is *meant* to block (Bash/network) —
-// so the message reports the count as context without asserting it blocked submit_findings.
-const incompleteReviewMessage = (rejectedToolCalls: number): string =>
-  rejectedToolCalls > 0
-    ? 'Reviewer stopped without calling submit_findings; ' +
-      `${rejectedToolCalls} tool call(s) were also rejected by the permission gate.`
-    : 'Reviewer stopped without calling submit_findings.'
-
-const REVIEWER_BRIDGE_SCOPE_ERROR =
-  'Reviewer request was not constrained to the reviewer-only tool scope.'
-
-type ReviewerCleanupResult = {
-  rejectedToolCalls: number
-  reviewerBridgeScoped: boolean | undefined
-  runtimeCleanupFailed: boolean
-  runtimeCleanupError?: unknown
-}
-
-// Reviewer ACP disposal and MCP shutdown are independent cleanup operations. A throwing ACP adapter
-// must not strand the authenticated MCP server; callers decide whether the disposal error is primary
-// or secondary to an earlier reviewer failure after both cleanup attempts have completed.
-const cleanupReviewerResources = async (
-  acpRuntime: ReviewerAcpRuntime,
-  reviewerSession: ActiveSession | undefined,
-  mcpServer: ReviewerMcpServer | undefined
-): Promise<ReviewerCleanupResult> => {
-  let rejectedToolCalls = 0
-  let reviewerBridgeScoped: boolean | undefined
-  let runtimeCleanupFailed = false
-  let runtimeCleanupError: unknown
-
-  if (reviewerSession) {
-    try {
-      const disposition = acpRuntime.disposeReviewerSession(reviewerSession)
-      rejectedToolCalls = disposition.rejectedToolCalls
-      reviewerBridgeScoped = disposition.reviewerBridgeScoped
-    } catch (error) {
-      runtimeCleanupFailed = true
-      runtimeCleanupError = error
-    }
-  }
-
-  try {
-    await mcpServer?.stop()
-  } catch (error) {
-    // MCP stop was historically best-effort. Keep that contract while reporting the failure; a
-    // runtime cleanup error, when present, remains the cleanup error returned to orchestration.
-    log.error('reviewer MCP server cleanup failed', {
-      error: error instanceof Error ? error.message : String(error)
-    })
-  }
-
-  return {
-    rejectedToolCalls,
-    reviewerBridgeScoped,
-    runtimeCleanupFailed,
-    ...(runtimeCleanupError === undefined ? {} : { runtimeCleanupError })
-  }
-}
 
 // Options for the Phase 3 fix loop.
 type FixLoopOptions = {
@@ -562,8 +487,8 @@ const runFixLoop = async (options: FixLoopOptions): Promise<void> => {
 // Never throws — errors are captured as lifecycle='error'.
 const runScopedReview = async (options: {
   sessionId: string
-  turnMessageId: string // the correction turn's agent message id
-  originalTurnMessageId: string // shared across all Review rows in this fix-loop closure
+  turnMessageId: string
+  originalTurnMessageId: string
   projectId: string
   getSession: SessionProvider
   reviewRepository: ReviewRepository
@@ -578,7 +503,7 @@ const runScopedReview = async (options: {
   reviewerMaxUpdates: number
   trackedChecks: ReviewCheck[]
   sessionSnapshot?: PersistedChatSession
-}): Promise<{ review: ReviewWithChecks; submittedChecks: NewCheck[] }> => {
+}): Promise<ReviewAssessmentResult> => {
   const {
     sessionId,
     turnMessageId,
@@ -599,10 +524,9 @@ const runScopedReview = async (options: {
     sessionSnapshot
   } = options
 
-  // Use the exact durable snapshot that proved the correction message exists. A second independent
-  // read could regress to an older file during concurrent persistence and reintroduce stale auditing.
+  // Keep missing-session handling in the facade: the assessment owner always receives a durable
+  // snapshot and therefore never invents lifecycle rows for absent sessions.
   const session = sessionSnapshot ?? (await getSession(sessionId))
-
   if (!session) {
     log.warn('session not found for scoped re-review', { sessionId })
     const errorReview = await runReviewMutation(runSessionMutation, () =>
@@ -619,217 +543,28 @@ const runScopedReview = async (options: {
     return { review: { ...errorReview, checks: [] }, submittedChecks: [] }
   }
 
-  // Resolve the correction turn's scope, pinning each artifact to a digest of its current bytes.
-  const scope = await resolveTurnScopeWithArtifactDigests(
+  return runReviewAssessment({
+    mode: 'tracked',
     session,
-    turnMessageId,
+    sessionId,
+    scopeTurnMessageId: turnMessageId,
+    turnMessageId: originalTurnMessageId,
+    projectId,
+    reviewRepository,
+    runSessionMutation,
+    acpRuntime,
     artifactStorageRoot,
-    artifactVersionContentResolver
-  )
-
-  // Create a new Review row sharing the originalTurnMessageId (not the correction turn's id),
-  // so all iterations are grouped under the same original turn.
-  const scopeSnapshot = buildReviewScopeSnapshot(session, scope)
-  let review = await runReviewMutation(runSessionMutation, () =>
-    reviewRepository.createReview({
-      projectId,
-      sessionId,
-      turnMessageId: originalTurnMessageId,
-      scope,
-      lifecycle: 'running',
-      model,
-      scopeSnapshot
-    })
-  )
-
-  const initialWithChecks: ReviewWithChecks = { ...review, checks: [] }
-  onReviewUpdate?.(initialWithChecks)
-
-  log.info('scoped re-review created', { reviewId: review.id, blocks: scope.blocks.length })
-
-  // Run the reviewer session (same flow as the initial review).
-  let reviewerSession: ActiveSession | undefined
-  let mcpServer: ReviewerMcpServer | undefined
-  let checksReceived: NewCheck[] = []
-  let checksSubmitted = false
-  let rejectedToolCalls = 0
-  let reviewerBridgeScoped: boolean | undefined
-  let reviewerSessionFailed = false
-  let reviewerSessionError: unknown
-  const capturedLog: ReviewerLogEntry[] = []
-
-  try {
-    const evidence = new ReviewerHostServer(
-      session,
-      scope,
-      artifactStorageRoot,
-      artifactVersionContentResolver,
-      scopeSnapshot
-    )
-
-    mcpServer = new ReviewerMcpServer(
-      scope,
-      async (checks: NewCheck[]) => {
-        checksReceived = checks
-        checksSubmitted = true
-      },
-      evidence,
-      trackedChecks.map((check) => check.id),
-      { command: process.execPath, entryPath: reviewerMcpEntryPath }
-    )
-    await mcpServer.start()
-
-    const reviewerPrompt = buildReviewerPrompt(scope, trackedChecks)
-    const systemPromptAppend = REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
-    const cwd = session.cwd || homedir()
-
-    const built = await acpRuntime.buildReviewerSession({
-      cwd,
-      mcpServers: [mcpServer.toAcpMcpServerConfig()],
-      systemPromptAppend
-    })
-    reviewerSession = built.session
-
-    // opencode has no system-prompt preset, so the rubric rides back as a prompt prefix; Claude gets
-    // it via _meta and returns no prefix. Prepend it so the reviewer rubric reaches either framework.
-    const reviewerPromptText = built.promptPrefix
-      ? `${built.promptPrefix}\n\n${reviewerPrompt}`
-      : reviewerPrompt
-    reviewerSession.prompt([{ type: 'text', text: reviewerPromptText }])
-
-    await driveReviewerToStop(
-      reviewerSession,
-      { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates },
-      { onUpdate: (entry) => capturedLog.push(entry) }
-    )
-  } catch (error) {
-    reviewerSessionFailed = true
-    reviewerSessionError = error
-  } finally {
-    const cleanup = await cleanupReviewerResources(acpRuntime, reviewerSession, mcpServer)
-    rejectedToolCalls = cleanup.rejectedToolCalls
-    reviewerBridgeScoped = cleanup.reviewerBridgeScoped
-    if (cleanup.runtimeCleanupFailed) {
-      if (reviewerSessionFailed) {
-        log.error('scoped re-review session cleanup also failed', {
-          reviewId: review.id,
-          error:
-            cleanup.runtimeCleanupError instanceof Error
-              ? cleanup.runtimeCleanupError.message
-              : String(cleanup.runtimeCleanupError)
-        })
-      } else {
-        reviewerSessionFailed = true
-        reviewerSessionError = cleanup.runtimeCleanupError
-      }
-    }
-  }
-
-  if (reviewerSessionFailed) {
-    const errorMsg =
-      reviewerSessionError instanceof Error
-        ? reviewerSessionError.message
-        : String(reviewerSessionError)
-    log.error('scoped re-review session failed', {
-      reviewId: review.id,
-      ...errorLogFields(reviewerSessionError)
-    })
-
-    review = await runReviewMutation(runSessionMutation, () =>
-      reviewRepository.updateReview(review.id, {
-        lifecycle: 'error',
-        errorMessage: errorMsg,
-        reviewerLog: capturedLog
-      })
-    )
-    const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
-    onReviewUpdate?.(errorWithChecks)
-    return { review: errorWithChecks, submittedChecks: [] }
-  }
-
-  if (reviewerBridgeScoped === false) {
-    log.error('scoped re-review bridge isolation failed', { reviewId: review.id })
-    review = await runReviewMutation(runSessionMutation, () =>
-      reviewRepository.updateReview(review.id, {
-        lifecycle: 'error',
-        errorMessage: REVIEWER_BRIDGE_SCOPE_ERROR,
-        reviewerLog: capturedLog
-      })
-    )
-    const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
-    onReviewUpdate?.(errorWithChecks)
-    return { review: errorWithChecks, submittedChecks: [] }
-  }
-
-  if (!checksSubmitted) {
-    const errorMessage = incompleteReviewMessage(rejectedToolCalls)
-    log.error('scoped re-review protocol incomplete', { reviewId: review.id, error: errorMessage })
-    review = await runReviewMutation(runSessionMutation, () =>
-      reviewRepository.updateReview(review.id, {
-        lifecycle: 'error',
-        errorMessage,
-        reviewerLog: capturedLog
-      })
-    )
-    const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
-    onReviewUpdate?.(errorWithChecks)
-    return { review: errorWithChecks, submittedChecks: [] }
-  }
-
-  // Persist new Findings, tracked dispositions, and Review completion in one transaction.
-  let finalReview: ReviewWithChecks
-  try {
-    const hasWarnOrFailCheck = checksReceived.some(
-      (c) => c.status === 'warn' || c.status === 'fail'
-    )
-    const outcome: ReviewOutcome = hasWarnOrFailCheck ? 'flagged' : 'pass'
-    finalReview = await runReviewMutation(runSessionMutation, () =>
-      reviewRepository.commitScopedSubmission({
-        reviewId: review.id,
-        checks: checksReceived,
-        expectedSourceFindingIds: trackedChecks.map((check) => check.id),
-        outcome,
-        reviewerLog: capturedLog
-      })
-    )
-    review = finalReview
-  } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error)
-    log.error('scoped re-review persistence failed', { reviewId: review.id, error: errorMsg })
-    review = await runReviewMutation(runSessionMutation, () =>
-      reviewRepository.updateReview(review.id, {
-        lifecycle: 'error',
-        errorMessage: errorMsg,
-        reviewerLog: capturedLog
-      })
-    )
-    const errorWithChecks: ReviewWithChecks = { ...review, checks: [] }
-    onReviewUpdate?.(errorWithChecks)
-    return { review: errorWithChecks, submittedChecks: [] }
-  }
-
-  // Tracked dispositions mutate their source Review cards. Push those rows only after the atomic
-  // scoped submission commits, then push the completed assessment Review.
-  const trackedById = new Map(trackedChecks.map((check) => [check.id, check]))
-  const mutatedSourceReviewIds = new Set(
-    checksReceived.flatMap((check) => {
-      const source = check.sourceFindingId ? trackedById.get(check.sourceFindingId) : undefined
-      return source ? [source.reviewId] : []
-    })
-  )
-  if (mutatedSourceReviewIds.size > 0) {
-    const allReviews = await reviewRepository.getReviewsForProjectSession(projectId, sessionId)
-    for (const sourceReview of allReviews) {
-      if (mutatedSourceReviewIds.has(sourceReview.id)) onReviewUpdate?.(sourceReview)
-    }
-  }
-
-  onReviewUpdate?.(finalReview)
-  return { review: finalReview, submittedChecks: checksReceived }
+    artifactVersionContentResolver,
+    reviewerMcpEntryPath,
+    model,
+    onReviewUpdate,
+    reviewerTimeoutMs,
+    reviewerMaxUpdates,
+    trackedChecks
+  })
 }
 
-// Drives one complete auto-review cycle: scope resolution → DB record → reviewer session →
-// submit_findings → lifecycle update. Returns the final review (with checks) for the caller
+// Drives one complete auto-review cycle and returns the final review (with checks) for the caller
 // to broadcast. Never throws — errors are captured as lifecycle='error'.
 const runReviewWithSession = async (
   options: RunReviewOptions,
@@ -862,221 +597,27 @@ const runReviewWithSession = async (
     sessionRefreshTimeoutMs = DEFAULT_SESSION_REFRESH_TIMEOUT_MS
   } = options
 
-  // Audit the scope turn (defaults to the grouping turn) but keep the row grouped under turnMessageId.
-  const scope = await resolveTurnScopeWithArtifactDigests(
+  const assessment = await runReviewAssessment({
+    mode: 'initial',
     session,
-    scopeTurnMessageId ?? turnMessageId,
+    sessionId,
+    scopeTurnMessageId: scopeTurnMessageId ?? turnMessageId,
+    turnMessageId,
+    projectId,
+    reviewRepository,
+    runSessionMutation,
+    acpRuntime,
     artifactStorageRoot,
-    artifactVersionContentResolver
-  )
-
-  // Step 2: create the Review row (lifecycle='running') immediately so the renderer shows a spinner.
-  const scopeSnapshot = buildReviewScopeSnapshot(session, scope)
-  let review = await runReviewMutation(runSessionMutation, () =>
-    reviewRepository.createReview({
-      projectId,
-      sessionId,
-      turnMessageId,
-      scope,
-      lifecycle: 'running',
-      model,
-      scopeSnapshot
-    })
-  )
-
-  const initialWithFindings: ReviewWithChecks = { ...review, checks: [] }
-  onReviewUpdate?.(initialWithFindings)
-  // The running row now exists and has been pushed to the renderer — this is the point a caller can
-  // treat the review as genuinely "started". Anything that failed before here (scope resolution, the
-  // createReview insert) threw instead, so `started` is never reported for a run that never appeared.
-  onStarted?.()
-
-  log.info('review created', { reviewId: review.id, blocks: scope.blocks.length })
-
-  // Step 3: run the reviewer session. All failures inside are caught and set lifecycle='error'.
-  let reviewerSession: ActiveSession | undefined
-  let mcpServer: ReviewerMcpServer | undefined
-  let checksReceived: NewCheck[] = []
-  let checksSubmitted = false
-  let rejectedToolCalls = 0
-  let reviewerBridgeScoped: boolean | undefined
-  let reviewerSessionFailed = false
-  let reviewerSessionError: unknown
-  const capturedLog: ReviewerLogEntry[] = []
-
-  try {
-    // Evidence reads and submission share one authenticated MCP server. The evidence object enforces
-    // turn/artifact scope server-side; no host token or Bash bootstrap is exposed to the model.
-    const evidence = new ReviewerHostServer(
-      session,
-      scope,
-      artifactStorageRoot,
-      artifactVersionContentResolver,
-      scopeSnapshot
-    )
-
-    mcpServer = new ReviewerMcpServer(
-      scope,
-      async (checks: NewCheck[]) => {
-        checksReceived = checks
-        checksSubmitted = true
-        log.info('submit_findings received by MCP handler', { count: checks.length })
-      },
-      evidence,
-      [],
-      { command: process.execPath, entryPath: reviewerMcpEntryPath }
-    )
-    await mcpServer.start()
-
-    const reviewerPrompt = buildReviewerPrompt(scope)
-
-    const systemPromptAppend = REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
-
-    // Spawn the reviewer ACP session (clean context, reviewer-only tools).
-    const cwd = session.cwd || homedir()
-
-    const built = await acpRuntime.buildReviewerSession({
-      cwd,
-      mcpServers: [mcpServer.toAcpMcpServerConfig()],
-      systemPromptAppend
-    })
-    reviewerSession = built.session
-
-    log.info('reviewer session started', { sessionId: reviewerSession.sessionId })
-
-    // Send the prompt and drive the session to completion. A timeout / update cap guards against a
-    // hung or fast-looping reviewer that never stops: on expiry this throws, the catch below sets
-    // lifecycle='error', and the finally disposes the session + MCP server.
-    // opencode gets the rubric via a prompt prefix (Claude via _meta, prefix empty).
-    const reviewerPromptText = built.promptPrefix
-      ? `${built.promptPrefix}\n\n${reviewerPrompt}`
-      : reviewerPrompt
-    reviewerSession.prompt([{ type: 'text', text: reviewerPromptText }])
-
-    const stopReason = await driveReviewerToStop(
-      reviewerSession,
-      {
-        timeoutMs: reviewerTimeoutMs,
-        maxUpdates: reviewerMaxUpdates
-      },
-      {
-        onUpdate: (entry) => capturedLog.push(entry)
-      }
-    )
-    log.info('reviewer session stopped', { reviewId: review.id, stopReason })
-  } catch (error) {
-    reviewerSessionFailed = true
-    reviewerSessionError = error
-  } finally {
-    const cleanup = await cleanupReviewerResources(acpRuntime, reviewerSession, mcpServer)
-    rejectedToolCalls = cleanup.rejectedToolCalls
-    reviewerBridgeScoped = cleanup.reviewerBridgeScoped
-    if (cleanup.runtimeCleanupFailed) {
-      if (reviewerSessionFailed) {
-        log.error('reviewer session cleanup also failed', {
-          reviewId: review.id,
-          error:
-            cleanup.runtimeCleanupError instanceof Error
-              ? cleanup.runtimeCleanupError.message
-              : String(cleanup.runtimeCleanupError)
-        })
-      } else {
-        reviewerSessionFailed = true
-        reviewerSessionError = cleanup.runtimeCleanupError
-      }
-    }
-  }
-
-  if (reviewerSessionFailed) {
-    const errorMsg =
-      reviewerSessionError instanceof Error
-        ? reviewerSessionError.message
-        : String(reviewerSessionError)
-    log.error('reviewer session failed', {
-      reviewId: review.id,
-      ...errorLogFields(reviewerSessionError)
-    })
-
-    review = await runReviewMutation(runSessionMutation, () =>
-      reviewRepository.updateReview(review.id, {
-        lifecycle: 'error',
-        errorMessage: errorMsg,
-        reviewerLog: capturedLog
-      })
-    )
-    const errorWithFindings: ReviewWithChecks = { ...review, checks: [] }
-    onReviewUpdate?.(errorWithFindings)
-
-    return errorWithFindings
-  }
-
-  if (reviewerBridgeScoped === false) {
-    log.error('reviewer bridge isolation failed', { reviewId: review.id })
-    review = await runReviewMutation(runSessionMutation, () =>
-      reviewRepository.updateReview(review.id, {
-        lifecycle: 'error',
-        errorMessage: REVIEWER_BRIDGE_SCOPE_ERROR,
-        reviewerLog: capturedLog
-      })
-    )
-    const errorWithFindings: ReviewWithChecks = { ...review, checks: [] }
-    onReviewUpdate?.(errorWithFindings)
-    return errorWithFindings
-  }
-
-  if (!checksSubmitted) {
-    const errorMessage = incompleteReviewMessage(rejectedToolCalls)
-    log.error('review protocol incomplete', { reviewId: review.id, error: errorMessage })
-    review = await runReviewMutation(runSessionMutation, () =>
-      reviewRepository.updateReview(review.id, {
-        lifecycle: 'error',
-        errorMessage,
-        reviewerLog: capturedLog
-      })
-    )
-    const errorWithFindings: ReviewWithChecks = { ...review, checks: [] }
-    onReviewUpdate?.(errorWithFindings)
-    return errorWithFindings
-  }
-
-  // Step 4: persist checks and set lifecycle='complete'.
-  // outcome = flagged iff at least one check is warn or fail; otherwise pass.
-  let finalReview: ReviewWithChecks
-  try {
-    const hasWarnOrFailCheck = checksReceived.some(
-      (c) => c.status === 'warn' || c.status === 'fail'
-    )
-    const outcome: ReviewOutcome = hasWarnOrFailCheck ? 'flagged' : 'pass'
-    finalReview = await runReviewMutation(runSessionMutation, () =>
-      reviewRepository.commitScopedSubmission({
-        reviewId: review.id,
-        checks: checksReceived,
-        expectedSourceFindingIds: [],
-        outcome,
-        reviewerLog: capturedLog
-      })
-    )
-    review = finalReview
-
-    log.info('review complete', {
-      reviewId: review.id,
-      outcome,
-      checkCount: checksReceived.length
-    })
-  } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error)
-    log.error('review persistence failed', { reviewId: review.id, error: errorMsg })
-
-    review = await runReviewMutation(runSessionMutation, () =>
-      reviewRepository.updateReview(review.id, {
-        lifecycle: 'error',
-        errorMessage: errorMsg
-      })
-    )
-    const errorWithFindings: ReviewWithChecks = { ...review, checks: [] }
-    onReviewUpdate?.(errorWithFindings)
-    return errorWithFindings
-  }
+    artifactVersionContentResolver,
+    reviewerMcpEntryPath,
+    model,
+    onReviewUpdate,
+    onStarted,
+    reviewerTimeoutMs,
+    reviewerMaxUpdates
+  })
+  const finalReview = assessment.review
+  if (finalReview.lifecycle === 'error') return finalReview
 
   // Step 5: Phase 3 fix loop. If there are warn/fail checks and a main session is provided,
   // drive the bounded re-review loop: inject → correction → re-review → resolution → repeat.
@@ -1114,7 +655,7 @@ const runReviewWithSession = async (
 
     // Reload checks after the fix loop so the returned object reflects final resolutions.
     const reloadedReviews = await reviewRepository.getReviewsForProjectSession(projectId, sessionId)
-    const reloadedReview = reloadedReviews.find((r) => r.id === review.id)
+    const reloadedReview = reloadedReviews.find((r) => r.id === finalReview.id)
     if (reloadedReview) {
       onReviewUpdate?.(reloadedReview)
       return reloadedReview
@@ -1181,59 +722,4 @@ export const runReview = async (options: RunReviewOptions): Promise<ReviewWithCh
     },
     (scopedRuntime) => runReviewWithSession({ ...options, acpRuntime: scopedRuntime }, session)
   )
-}
-
-// Builds the prompt sent to the isolated reviewer session. All evidence is available only through the
-// scope-bounded reviewer MCP; no executable bootstrap, filesystem path, or bearer token enters the prompt.
-export const buildReviewerPrompt = (
-  scope: TurnScope,
-  trackedChecks: readonly ReviewCheck[] = []
-): string => {
-  const blockSummary =
-    scope.blocks.length === 0
-      ? 'This turn has no blocks (it may be empty).'
-      : `This turn has ${scope.blocks.length} block(s): ` +
-        scope.blocks
-          .map((b) => `[${b.blockIndex}] ${b.kind}:${b.sourceId}`)
-          .slice(0, 10)
-          .join(', ') +
-        (scope.blocks.length > 10 ? ', ...' : '')
-
-  const artifactSummary =
-    scope.artifactVersionIds.length === 0
-      ? 'No artifacts in this turn.'
-      : `Artifact version ids: ${scope.artifactVersionIds.join(', ')}`
-
-  const trackedSummary =
-    trackedChecks.length === 0
-      ? []
-      : [
-          '',
-          'This is a fix-loop re-review. Disposition every tracked finding exactly once by copying',
-          '`sourceFindingId` unchanged into its check. Use pass if fixed, warn/fail if it remains:',
-          JSON.stringify(
-            trackedChecks.map((check) => ({
-              sourceFindingId: check.id,
-              previousStatus: check.status,
-              claim: check.claim,
-              evidence: check.evidence
-            }))
-          ),
-          'You may report a newly discovered issue without sourceFindingId, but omission of any tracked',
-          'finding or reuse of an unknown/duplicate id is rejected.'
-        ]
-
-  return [
-    `You are reviewing turn: ${scope.turnMessageId}`,
-    '',
-    blockSummary,
-    artifactSummary,
-    ...trackedSummary,
-    '',
-    'Use only the reviewer MCP tools: read_turn, query_execution_log, and read_artifact.',
-    'They expose only this audited scope. Do not use Bash, filesystem, network, or other tools.',
-    '',
-    'After reading the turn data, apply the rubric, then call submit_findings once with your findings.',
-    'Call submit_findings with at least one explicit pass check if you find no issues; an empty array is invalid.'
-  ].join('\n')
 }

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -1,0 +1,312 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AcpRuntime } from '../acp/runtime'
+import type {
+  NewCheck,
+  Review,
+  ReviewCheck,
+  ReviewWithChecks,
+  TurnScope
+} from '../../shared/reviewer'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { ReviewRepository } from './repository'
+
+const harness = vi.hoisted(() => ({
+  events: [] as string[],
+  inMutation: false,
+  submission: undefined as NewCheck[] | undefined,
+  submit: undefined as ((checks: NewCheck[]) => Promise<void>) | undefined,
+  promptError: undefined as Error | undefined,
+  disposeError: undefined as Error | undefined,
+  stopError: undefined as Error | undefined,
+  bridgeScoped: undefined as boolean | undefined
+}))
+
+const outsideMutation = (event: string): void => {
+  if (harness.inMutation) throw new Error(`${event} ran inside the Session mutation`)
+  harness.events.push(event)
+}
+
+const insideMutation = (event: string): void => {
+  if (!harness.inMutation) throw new Error(`${event} ran outside the Session mutation`)
+  harness.events.push(event)
+}
+
+const scope: TurnScope = { turnMessageId: 'turn-scope', blocks: [], artifactVersionIds: [] }
+
+vi.mock('./artifact-digest', () => ({
+  resolveTurnScopeWithArtifactDigests: async () => {
+    outsideMutation('scope')
+    return scope
+  }
+}))
+
+vi.mock('./scope-snapshot', () => ({
+  buildReviewScopeSnapshot: () => {
+    outsideMutation('snapshot')
+    return []
+  }
+}))
+
+vi.mock('./host-sdk', () => ({
+  ReviewerHostServer: class {
+    constructor() {
+      outsideMutation('host')
+    }
+  }
+}))
+
+vi.mock('./mcp-server', () => ({
+  ReviewerMcpServer: class {
+    constructor(
+      _scope: TurnScope,
+      submit: (checks: NewCheck[]) => Promise<void>,
+      _host: unknown,
+      trackedIds: string[]
+    ) {
+      outsideMutation(`mcp:create:${trackedIds.join(',')}`)
+      harness.submit = submit
+    }
+
+    async start(): Promise<void> {
+      outsideMutation('mcp:start')
+      if (harness.submission) await harness.submit?.(harness.submission)
+    }
+
+    async stop(): Promise<void> {
+      outsideMutation('mcp:stop')
+      if (harness.stopError) throw harness.stopError
+    }
+
+    toAcpMcpServerConfig(): Record<string, never> {
+      outsideMutation('mcp:config')
+      return {}
+    }
+  }
+}))
+
+const { runReviewAssessment } = await import('./review-assessment-owner')
+
+type InitialAssessmentOptions = Extract<
+  Parameters<typeof runReviewAssessment>[0],
+  { mode: 'initial' }
+>
+
+const session: PersistedChatSession = {
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Reviewer owner test',
+  cwd: join(tmpdir(), 'reviewer-owner-workspace'),
+  status: 'idle',
+  messages: [],
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const review = (id: string, lifecycle: Review['lifecycle'] = 'running'): Review => ({
+  id,
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  turnMessageId: 'turn-group',
+  scope,
+  lifecycle,
+  outcome: lifecycle === 'complete' ? 'pass' : null,
+  model: 'reviewer-model',
+  reviewerLog: [],
+  createdAt: 1,
+  updatedAt: 1
+})
+
+const trackedCheck: ReviewCheck = {
+  id: 'finding-1',
+  reviewId: 'source-review',
+  status: 'warn',
+  resolution: 'open',
+  claim: 'Source claim',
+  evidence: 'Source evidence',
+  sortIndex: 0,
+  reflagCount: 0,
+  artifactBindingState: 'legacy_unverified'
+}
+
+const makeRepository = (): ReviewRepository =>
+  ({
+    createReview: vi.fn(async () => {
+      insideMutation('write:create')
+      return review('assessment-review')
+    }),
+    updateReview: vi.fn(async (_id: string, patch: Partial<Review>) => {
+      insideMutation(`write:error:${patch.errorMessage}`)
+      return { ...review('assessment-review'), ...patch }
+    }),
+    commitScopedSubmission: vi.fn(async () => {
+      insideMutation('write:commit')
+      return { ...review('assessment-review', 'complete'), checks: [] }
+    }),
+    getReviewsForProjectSession: vi.fn(async () => {
+      outsideMutation('query:reviews')
+      return [{ ...review('source-review', 'complete'), checks: [trackedCheck] }]
+    })
+  }) as unknown as ReviewRepository
+
+const runtime = (): AcpRuntime =>
+  ({
+    buildReviewerSession: async () => {
+      outsideMutation('acp:build')
+      return {
+        session: {
+          sessionId: 'reviewer-session',
+          prompt: () => {
+            outsideMutation('acp:prompt')
+            if (harness.promptError) throw harness.promptError
+          },
+          nextUpdate: async () => ({ kind: 'stop', stopReason: 'end_turn' })
+        }
+      }
+    },
+    disposeReviewerSession: () => {
+      outsideMutation('acp:dispose')
+      if (harness.disposeError) throw harness.disposeError
+      return { rejectedToolCalls: 0, reviewerBridgeScoped: harness.bridgeScoped }
+    }
+  }) as unknown as AcpRuntime
+
+const mutationRunner = async <Result>(mutation: () => Promise<Result>): Promise<Result> => {
+  harness.events.push('mutation:start')
+  harness.inMutation = true
+  try {
+    return await mutation()
+  } finally {
+    harness.inMutation = false
+    harness.events.push('mutation:end')
+  }
+}
+
+const commonOptions = (
+  reviewRepository: ReviewRepository
+): Omit<InitialAssessmentOptions, 'mode' | 'onStarted'> => ({
+  session,
+  sessionId: 'session-1',
+  scopeTurnMessageId: 'turn-scope',
+  turnMessageId: 'turn-group',
+  projectId: 'project-1',
+  reviewRepository,
+  runSessionMutation: mutationRunner,
+  acpRuntime: runtime(),
+  artifactStorageRoot: join(tmpdir(), 'reviewer-owner-artifacts'),
+  model: 'reviewer-model',
+  reviewerTimeoutMs: 1000,
+  reviewerMaxUpdates: 100
+})
+
+describe('review assessment owner', () => {
+  beforeEach(() => {
+    harness.events = []
+    harness.inMutation = false
+    harness.submission = [{ status: 'pass', claim: 'Pass', evidence: 'Verified' }]
+    harness.submit = undefined
+    harness.promptError = undefined
+    harness.disposeError = undefined
+    harness.stopError = undefined
+    harness.bridgeScoped = undefined
+  })
+
+  it('publishes initial running before onStarted and keeps remote work outside mutations', async () => {
+    const reviewRepository = makeRepository()
+    const result = await runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      mode: 'initial',
+      onReviewUpdate: (value: ReviewWithChecks) => outsideMutation(`publish:${value.lifecycle}`),
+      onStarted: () => outsideMutation('started')
+    })
+
+    expect(result.review.lifecycle).toBe('complete')
+    expect(harness.events).toEqual([
+      'scope',
+      'snapshot',
+      'mutation:start',
+      'write:create',
+      'mutation:end',
+      'publish:running',
+      'started',
+      'host',
+      'mcp:create:',
+      'mcp:start',
+      'mcp:config',
+      'acp:build',
+      'acp:prompt',
+      'acp:dispose',
+      'mcp:stop',
+      'mutation:start',
+      'write:commit',
+      'mutation:end'
+    ])
+  })
+
+  it('stops MCP independently and preserves session then bridge error precedence', async () => {
+    const reviewRepository = makeRepository()
+    harness.promptError = new Error('prompt failed')
+    harness.disposeError = new Error('dispose failed')
+    harness.stopError = new Error('stop failed')
+
+    const sessionFailure = await runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      mode: 'initial'
+    })
+    expect(sessionFailure.review.errorMessage).toBe('prompt failed')
+    expect(harness.events).toContain('acp:dispose')
+    expect(harness.events).toContain('mcp:stop')
+
+    harness.events = []
+    harness.submission = undefined
+    harness.promptError = undefined
+    harness.disposeError = undefined
+    harness.stopError = undefined
+    harness.bridgeScoped = false
+    const bridgeFailure = await runReviewAssessment({
+      ...commonOptions(makeRepository()),
+      mode: 'initial'
+    })
+    expect(bridgeFailure.review.errorMessage).toBe(
+      'Reviewer request was not constrained to the reviewer-only tool scope.'
+    )
+  })
+
+  it('commits tracked findings atomically before publishing source then assessment', async () => {
+    harness.submission = [
+      {
+        status: 'pass',
+        claim: 'Fixed',
+        evidence: 'Verified',
+        sourceFindingId: trackedCheck.id
+      }
+    ]
+    const reviewRepository = makeRepository()
+    const result = await runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      mode: 'tracked',
+      trackedChecks: [trackedCheck],
+      onReviewUpdate: (value: ReviewWithChecks) => outsideMutation(`publish:${value.id}`)
+    })
+
+    expect(result.submittedChecks).toEqual(harness.submission)
+    expect(reviewRepository.commitScopedSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedSourceFindingIds: [trackedCheck.id] })
+    )
+    expect(harness.events).toEqual(
+      expect.arrayContaining([
+        'mcp:create:finding-1',
+        'mutation:start',
+        'write:commit',
+        'mutation:end',
+        'query:reviews'
+      ])
+    )
+    expect(harness.events.indexOf('publish:source-review')).toBeLessThan(
+      harness.events.lastIndexOf('publish:assessment-review')
+    )
+  })
+})

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -1,0 +1,414 @@
+// Owns one complete Reviewer assessment from scope resolution through durable submission.
+
+import { homedir } from 'node:os'
+
+import type { ActiveSession } from '@agentclientprotocol/sdk'
+
+import type {
+  NewCheck,
+  ReviewCheck,
+  ReviewerLogEntry,
+  ReviewOutcome,
+  ReviewWithChecks,
+  TurnScope
+} from '../../shared/reviewer'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { createLogger, errorLogFields } from '../logger'
+import type { ReviewerAcpRuntime } from './acp-runtime'
+import { resolveTurnScopeWithArtifactDigests } from './artifact-digest'
+import { ReviewerHostServer, type ArtifactVersionContentResolver } from './host-sdk'
+import { ReviewerMcpServer } from './mcp-server'
+import type { ReviewRepository } from './repository'
+import { driveReviewerToStop } from './reviewer-session-driver'
+import { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } from './rubric'
+import { buildReviewScopeSnapshot } from './scope-snapshot'
+
+const log = createLogger('reviewer:orchestrator')
+
+type ReviewMutationRunner = <Result>(mutation: () => Promise<Result>) => Promise<Result>
+
+type CommonAssessmentOptions = {
+  session: PersistedChatSession
+  sessionId: string
+  scopeTurnMessageId: string
+  turnMessageId: string
+  projectId: string
+  reviewRepository: ReviewRepository
+  runSessionMutation?: ReviewMutationRunner
+  acpRuntime: ReviewerAcpRuntime
+  artifactStorageRoot: string
+  artifactVersionContentResolver?: ArtifactVersionContentResolver
+  reviewerMcpEntryPath?: string
+  model: string
+  onReviewUpdate?: (review: ReviewWithChecks) => void
+  reviewerTimeoutMs: number
+  reviewerMaxUpdates: number
+}
+
+type InitialAssessmentOptions = CommonAssessmentOptions & {
+  mode: 'initial'
+  onStarted?: () => void
+}
+
+type TrackedAssessmentOptions = CommonAssessmentOptions & {
+  mode: 'tracked'
+  trackedChecks: readonly ReviewCheck[]
+}
+
+type ReviewAssessmentOptions = InitialAssessmentOptions | TrackedAssessmentOptions
+
+export type ReviewAssessmentResult = {
+  review: ReviewWithChecks
+  submittedChecks: NewCheck[]
+}
+
+const runReviewMutation = <Result>(
+  runner: ReviewMutationRunner | undefined,
+  mutation: () => Promise<Result>
+): Promise<Result> => (runner ? runner(mutation) : mutation())
+
+const incompleteReviewMessage = (rejectedToolCalls: number): string =>
+  rejectedToolCalls > 0
+    ? 'Reviewer stopped without calling submit_findings; ' +
+      `${rejectedToolCalls} tool call(s) were also rejected by the permission gate.`
+    : 'Reviewer stopped without calling submit_findings.'
+
+const REVIEWER_BRIDGE_SCOPE_ERROR =
+  'Reviewer request was not constrained to the reviewer-only tool scope.'
+
+type ReviewerCleanupResult = {
+  rejectedToolCalls: number
+  reviewerBridgeScoped: boolean | undefined
+  runtimeCleanupFailed: boolean
+  runtimeCleanupError?: unknown
+}
+
+// Disposal and MCP shutdown are independent: a broken ACP adapter must not strand the MCP server.
+const cleanupReviewerResources = async (
+  acpRuntime: ReviewerAcpRuntime,
+  reviewerSession: ActiveSession | undefined,
+  mcpServer: ReviewerMcpServer | undefined
+): Promise<ReviewerCleanupResult> => {
+  let rejectedToolCalls = 0
+  let reviewerBridgeScoped: boolean | undefined
+  let runtimeCleanupFailed = false
+  let runtimeCleanupError: unknown
+
+  if (reviewerSession) {
+    try {
+      const disposition = acpRuntime.disposeReviewerSession(reviewerSession)
+      rejectedToolCalls = disposition.rejectedToolCalls
+      reviewerBridgeScoped = disposition.reviewerBridgeScoped
+    } catch (error) {
+      runtimeCleanupFailed = true
+      runtimeCleanupError = error
+    }
+  }
+
+  try {
+    await mcpServer?.stop()
+  } catch (error) {
+    log.error('reviewer MCP server cleanup failed', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+
+  return {
+    rejectedToolCalls,
+    reviewerBridgeScoped,
+    runtimeCleanupFailed,
+    ...(runtimeCleanupError === undefined ? {} : { runtimeCleanupError })
+  }
+}
+
+// Runs either an initial assessment or a tracked fix-loop assessment. The discriminant changes only
+// the durable grouping/allowlist and publication contract; all remote lifecycle behavior is shared.
+export const runReviewAssessment = async (
+  options: ReviewAssessmentOptions
+): Promise<ReviewAssessmentResult> => {
+  const {
+    session,
+    sessionId,
+    scopeTurnMessageId,
+    turnMessageId,
+    projectId,
+    reviewRepository,
+    runSessionMutation,
+    acpRuntime,
+    artifactStorageRoot,
+    artifactVersionContentResolver,
+    reviewerMcpEntryPath,
+    model,
+    onReviewUpdate,
+    reviewerTimeoutMs,
+    reviewerMaxUpdates
+  } = options
+  const trackedChecks = options.mode === 'tracked' ? options.trackedChecks : []
+
+  const scope = await resolveTurnScopeWithArtifactDigests(
+    session,
+    scopeTurnMessageId,
+    artifactStorageRoot,
+    artifactVersionContentResolver
+  )
+  const scopeSnapshot = buildReviewScopeSnapshot(session, scope)
+  let review = await runReviewMutation(runSessionMutation, () =>
+    reviewRepository.createReview({
+      projectId,
+      sessionId,
+      turnMessageId,
+      scope,
+      lifecycle: 'running',
+      model,
+      scopeSnapshot
+    })
+  )
+
+  const runningReview: ReviewWithChecks = { ...review, checks: [] }
+  onReviewUpdate?.(runningReview)
+  if (options.mode === 'initial') options.onStarted?.()
+
+  log.info(options.mode === 'tracked' ? 'scoped re-review created' : 'review created', {
+    reviewId: review.id,
+    blocks: scope.blocks.length
+  })
+
+  let reviewerSession: ActiveSession | undefined
+  let mcpServer: ReviewerMcpServer | undefined
+  let checksReceived: NewCheck[] = []
+  let checksSubmitted = false
+  let rejectedToolCalls = 0
+  let reviewerBridgeScoped: boolean | undefined
+  let reviewerSessionFailed = false
+  let reviewerSessionError: unknown
+  const capturedLog: ReviewerLogEntry[] = []
+
+  try {
+    const evidence = new ReviewerHostServer(
+      session,
+      scope,
+      artifactStorageRoot,
+      artifactVersionContentResolver,
+      scopeSnapshot
+    )
+    mcpServer = new ReviewerMcpServer(
+      scope,
+      async (checks: NewCheck[]) => {
+        checksReceived = checks
+        checksSubmitted = true
+        if (options.mode === 'initial') {
+          log.info('submit_findings received by MCP handler', { count: checks.length })
+        }
+      },
+      evidence,
+      trackedChecks.map((check) => check.id),
+      { command: process.execPath, entryPath: reviewerMcpEntryPath }
+    )
+    await mcpServer.start()
+
+    const reviewerPrompt = buildReviewerPrompt(scope, trackedChecks)
+    const built = await acpRuntime.buildReviewerSession({
+      cwd: session.cwd || homedir(),
+      mcpServers: [mcpServer.toAcpMcpServerConfig()],
+      systemPromptAppend: REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
+    })
+    reviewerSession = built.session
+    if (options.mode === 'initial') {
+      log.info('reviewer session started', { sessionId: reviewerSession.sessionId })
+    }
+
+    const reviewerPromptText = built.promptPrefix
+      ? `${built.promptPrefix}\n\n${reviewerPrompt}`
+      : reviewerPrompt
+    reviewerSession.prompt([{ type: 'text', text: reviewerPromptText }])
+    const stopReason = await driveReviewerToStop(
+      reviewerSession,
+      { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates },
+      { onUpdate: (entry) => capturedLog.push(entry) }
+    )
+    if (options.mode === 'initial') {
+      log.info('reviewer session stopped', { reviewId: review.id, stopReason })
+    }
+  } catch (error) {
+    reviewerSessionFailed = true
+    reviewerSessionError = error
+  } finally {
+    const cleanup = await cleanupReviewerResources(acpRuntime, reviewerSession, mcpServer)
+    rejectedToolCalls = cleanup.rejectedToolCalls
+    reviewerBridgeScoped = cleanup.reviewerBridgeScoped
+    if (cleanup.runtimeCleanupFailed) {
+      if (reviewerSessionFailed) {
+        log.error(
+          options.mode === 'tracked'
+            ? 'scoped re-review session cleanup also failed'
+            : 'reviewer session cleanup also failed',
+          {
+            reviewId: review.id,
+            error:
+              cleanup.runtimeCleanupError instanceof Error
+                ? cleanup.runtimeCleanupError.message
+                : String(cleanup.runtimeCleanupError)
+          }
+        )
+      } else {
+        reviewerSessionFailed = true
+        reviewerSessionError = cleanup.runtimeCleanupError
+      }
+    }
+  }
+
+  const fail = async (
+    errorMessage: string,
+    includeReviewerLog = true
+  ): Promise<ReviewAssessmentResult> => {
+    review = await runReviewMutation(runSessionMutation, () =>
+      reviewRepository.updateReview(review.id, {
+        lifecycle: 'error',
+        errorMessage,
+        ...(includeReviewerLog ? { reviewerLog: capturedLog } : {})
+      })
+    )
+    const errorReview: ReviewWithChecks = { ...review, checks: [] }
+    onReviewUpdate?.(errorReview)
+    return { review: errorReview, submittedChecks: [] }
+  }
+
+  if (reviewerSessionFailed) {
+    const errorMessage =
+      reviewerSessionError instanceof Error
+        ? reviewerSessionError.message
+        : String(reviewerSessionError)
+    log.error(
+      options.mode === 'tracked' ? 'scoped re-review session failed' : 'reviewer session failed',
+      { reviewId: review.id, ...errorLogFields(reviewerSessionError) }
+    )
+    return fail(errorMessage)
+  }
+
+  if (reviewerBridgeScoped === false) {
+    log.error(
+      options.mode === 'tracked'
+        ? 'scoped re-review bridge isolation failed'
+        : 'reviewer bridge isolation failed',
+      { reviewId: review.id }
+    )
+    return fail(REVIEWER_BRIDGE_SCOPE_ERROR)
+  }
+
+  if (!checksSubmitted) {
+    const errorMessage = incompleteReviewMessage(rejectedToolCalls)
+    log.error(
+      options.mode === 'tracked'
+        ? 'scoped re-review protocol incomplete'
+        : 'review protocol incomplete',
+      { reviewId: review.id, error: errorMessage }
+    )
+    return fail(errorMessage)
+  }
+
+  let finalReview: ReviewWithChecks
+  try {
+    const hasWarnOrFailCheck = checksReceived.some(
+      (check) => check.status === 'warn' || check.status === 'fail'
+    )
+    const outcome: ReviewOutcome = hasWarnOrFailCheck ? 'flagged' : 'pass'
+    finalReview = await runReviewMutation(runSessionMutation, () =>
+      reviewRepository.commitScopedSubmission({
+        reviewId: review.id,
+        checks: checksReceived,
+        expectedSourceFindingIds: trackedChecks.map((check) => check.id),
+        outcome,
+        reviewerLog: capturedLog
+      })
+    )
+    review = finalReview
+    if (options.mode === 'initial') {
+      log.info('review complete', {
+        reviewId: review.id,
+        outcome,
+        checkCount: checksReceived.length
+      })
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    log.error(
+      options.mode === 'tracked'
+        ? 'scoped re-review persistence failed'
+        : 'review persistence failed',
+      { reviewId: review.id, error: errorMessage }
+    )
+    return fail(errorMessage, options.mode === 'tracked')
+  }
+
+  if (options.mode === 'tracked') {
+    const trackedById = new Map(trackedChecks.map((check) => [check.id, check]))
+    const mutatedSourceReviewIds = new Set(
+      checksReceived.flatMap((check) => {
+        const source = check.sourceFindingId ? trackedById.get(check.sourceFindingId) : undefined
+        return source ? [source.reviewId] : []
+      })
+    )
+    if (mutatedSourceReviewIds.size > 0) {
+      const allReviews = await reviewRepository.getReviewsForProjectSession(projectId, sessionId)
+      for (const sourceReview of allReviews) {
+        if (mutatedSourceReviewIds.has(sourceReview.id)) onReviewUpdate?.(sourceReview)
+      }
+    }
+    onReviewUpdate?.(finalReview)
+  }
+
+  return { review: finalReview, submittedChecks: checksReceived }
+}
+
+export const buildReviewerPrompt = (
+  scope: TurnScope,
+  trackedChecks: readonly ReviewCheck[] = []
+): string => {
+  const blockSummary =
+    scope.blocks.length === 0
+      ? 'This turn has no blocks (it may be empty).'
+      : `This turn has ${scope.blocks.length} block(s): ` +
+        scope.blocks
+          .map((block) => `[${block.blockIndex}] ${block.kind}:${block.sourceId}`)
+          .slice(0, 10)
+          .join(', ') +
+        (scope.blocks.length > 10 ? ', ...' : '')
+
+  const artifactSummary =
+    scope.artifactVersionIds.length === 0
+      ? 'No artifacts in this turn.'
+      : `Artifact version ids: ${scope.artifactVersionIds.join(', ')}`
+
+  const trackedSummary =
+    trackedChecks.length === 0
+      ? []
+      : [
+          '',
+          'This is a fix-loop re-review. Disposition every tracked finding exactly once by copying',
+          '`sourceFindingId` unchanged into its check. Use pass if fixed, warn/fail if it remains:',
+          JSON.stringify(
+            trackedChecks.map((check) => ({
+              sourceFindingId: check.id,
+              previousStatus: check.status,
+              claim: check.claim,
+              evidence: check.evidence
+            }))
+          ),
+          'You may report a newly discovered issue without sourceFindingId, but omission of any tracked',
+          'finding or reuse of an unknown/duplicate id is rejected.'
+        ]
+
+  return [
+    `You are reviewing turn: ${scope.turnMessageId}`,
+    '',
+    blockSummary,
+    artifactSummary,
+    ...trackedSummary,
+    '',
+    'Use only the reviewer MCP tools: read_turn, query_execution_log, and read_artifact.',
+    'They expose only this audited scope. Do not use Bash, filesystem, network, or other tools.',
+    '',
+    'After reading the turn data, apply the rubric, then call submit_findings once with your findings.',
+    'Call submit_findings with at least one explicit pass check if you find no issues; an empty array is invalid.'
+  ].join('\n')
+}


### PR DESCRIPTION
## Problem

Initial Reviewer assessments and tracked fix-loop assessments duplicated scope resolution, running-row creation, MCP/ACP execution, cleanup, failure handling, and atomic submission inside `orchestrator.ts`. The two copies made the same lifecycle semantics vulnerable to drift and kept the facade at 1,239 lines after R1.

## Proposed change

Extract one concrete `review-assessment-owner.ts` for both assessment modes. The owner now holds the complete scope-to-submission lifecycle while `orchestrator.ts` delegates initial and tracked execution and retains missing-session handling plus bounded fix-loop coordination.

- assessment owner: 414 lines
- orchestrator facade: 1,239 -> 725 lines
- module impact registration includes the new owner and its focused contract test

## Scope and non-goals

This PR is an internal ownership refactor. It does not extract the bounded correction/fix loop; that remains the next R3 seam. It does not add generic child-agent or delegation primitives for Issue #458, introduce an interface/factory around one implementation, or broaden Reviewer availability.

The existing `reviewer_orchestrator` consumer closure remains `workspace_runtime`, `workspace_page`, and `artifact_provenance`, with transitive `session_persistence` coverage.

## Compatibility

- Public exports remain stable: `buildReviewerPrompt` and `driveReviewerToStop` are still available from `orchestrator.ts`.
- IPC channels, renderer contracts, persisted Review/Check schemas, and UI behavior are unchanged.
- Initial mode preserves `create running -> publish running -> onStarted`, pre-start throws, prompt-prefix delivery, cleanup/error precedence, and delayed final publication around the optional fix loop.
- Tracked mode preserves finding-ID allowlisting, atomic submission, source-Review publication before assessment publication, and the historical commit-failure reviewer-log behavior.
- Electron and local/remote Web Reviewer behavior is unchanged. Task/direct CLI and Notebook local RPC still do not expose Reviewer.
- Test paths use Node path utilities and remain portable across Windows, macOS, and Linux.

## Acceptance criteria and validation

All commands below ran after the final material edit and after rebasing onto `origin/main@3fef0a34`:

- assessment lifecycle, cleanup, prompt, fix-loop integration, IPC and surface contracts -> `npm run test:module -- reviewer_orchestrator` -> 24 files / 384 tests passed
- ownership manifest and downstream selection -> targeted module-impact suite -> 3 files / 32 tests passed
- Node and renderer type surfaces -> `npm run typecheck` -> passed
- linted source/configuration -> `npm run lint -- --quiet` -> passed with 0 errors
- CodeGraph blast-radius check -> 173 broadly affected tests; the deterministic module manifest supplies the narrower owned/contract/surface set above

Per the approved workflow, the complete local `npm test` fallback was not run; exact-head CI remains authoritative for the full portable and platform suites. Independent Standards and Spec reviews both reported 0 findings. The published Codex Review must say `Verdict: mergeable` before squash merge.

## Review focus

- Are remote MCP/ACP work, cleanup, queries, and callbacks kept outside `runSessionMutation`, with only durable writes inside it?
- Are original reviewer-session errors still primary over cleanup errors, and is MCP shutdown attempted independently?
- Do initial and tracked publication/error asymmetries remain exact rather than being accidentally unified?
- Does the facade remain a compatibility boundary while R3 retains the bounded fix-loop state machine?
