### PR TITLE
fix(permissions): align conversation scope wording

### DIFF
--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
@@ -37,17 +37,17 @@ afterEach(() => {
 })
 
 describe('PermissionApprovalControls interactions', () => {
-  it('default Allow button uses the Session scope so a repeated tool does not re-prompt', () => {
+  it('default Allow button labels the session scope as this conversation', () => {
     // The easiest click approves for the logical Session; narrowing to a one-time
     // approval is an explicit choice via the scope menu.
     act(() => {
       root.render(<PermissionApprovalControls requests={[baseRequest]} onRespond={vi.fn()} />)
     })
-    expect(container.textContent).toContain('this session')
+    expect(container.textContent).toContain('this conversation')
     expect(container.textContent).not.toContain('this call only')
   })
 
-  it('uses option scope metadata and labels session access accurately', () => {
+  it('uses option scope metadata and labels session access as this conversation', () => {
     const scopedRequest: AcpPermissionRequest = {
       ...baseRequest,
       options: [
@@ -63,15 +63,15 @@ describe('PermissionApprovalControls interactions', () => {
 
     expect(
       (container.querySelector('[data-testid="allow-primary"]') as HTMLButtonElement).textContent
-    ).toBe('Allow for this session')
+    ).toBe('Allow for this conversation')
 
     const chevron = container.querySelector('[data-testid="scope-chevron"]') as HTMLButtonElement
     act(() => chevron.click())
 
     const sessionItem = Array.from(container.querySelectorAll('[role="menuitemradio"]')).find(
-      (item) => item.textContent?.includes('This session')
+      (item) => item.textContent?.includes('This conversation')
     )
-    expect(sessionItem?.textContent).toContain('Across restarts for this session')
+    expect(sessionItem?.textContent).toContain('Until this chat ends')
     expect(container.textContent).not.toContain('Agent session')
   })
 
@@ -166,7 +166,7 @@ describe('PermissionApprovalControls interactions', () => {
     const chevron = container.querySelector('[data-testid="scope-chevron"]') as HTMLButtonElement
     act(() => chevron.click())
     const onceItem = Array.from(container.querySelectorAll('[role="menuitemradio"]')).find(
-      (el) => el.textContent?.includes('Once') && !el.textContent?.includes('session')
+      (el) => el.textContent?.includes('Once') && !el.textContent?.includes('conversation')
     ) as HTMLElement
     act(() => onceItem.click())
     expect(container.textContent).toContain('Allow once')
@@ -175,7 +175,7 @@ describe('PermissionApprovalControls interactions', () => {
     expect(onRespond).toHaveBeenCalledWith('req-1', 'opt-once')
   })
 
-  it('selecting This session sends the session option from the primary button', () => {
+  it('selecting This conversation sends the session option from the primary button', () => {
     const onRespond = vi.fn()
     act(() => {
       root.render(<PermissionApprovalControls requests={[baseRequest]} onRespond={onRespond} />)
@@ -185,7 +185,7 @@ describe('PermissionApprovalControls interactions', () => {
     act(() => chevron.click())
     const sessionItem = Array.from(
       container.querySelectorAll<HTMLElement>('[role="menuitemradio"]')
-    ).find((item) => item.textContent?.includes('This session'))
+    ).find((item) => item.textContent?.includes('This conversation'))
 
     expect(sessionItem).toBeDefined()
     act(() => sessionItem?.click())
@@ -193,7 +193,7 @@ describe('PermissionApprovalControls interactions', () => {
     const allowButton = container.querySelector(
       '[data-testid="allow-primary"]'
     ) as HTMLButtonElement
-    expect(allowButton.textContent).toBe('Allow for this session')
+    expect(allowButton.textContent).toBe('Allow for this conversation')
     act(() => allowButton.click())
 
     expect(onRespond).toHaveBeenCalledWith('req-1', 'opt-always')
@@ -234,9 +234,19 @@ describe('PermissionApprovalControls interactions', () => {
     act(() =>
       (container.querySelector('[data-testid="scope-chevron"]') as HTMLButtonElement).click()
     )
-    const project = Array.from(
+    const scopeItems = Array.from(
       container.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')
-    ).find((item) => item.textContent?.includes('This project'))
+    )
+    expect(
+      scopeItems.find((item) => item.textContent?.includes('This conversation'))?.textContent
+    ).toContain('Until this chat ends')
+    expect(
+      scopeItems.find((item) => item.textContent?.includes('This project'))?.textContent
+    ).toContain('Remembered for this project')
+    expect(scopeItems.find((item) => item.textContent?.includes('Global'))?.textContent).toContain(
+      'Remembered across all projects'
+    )
+    const project = scopeItems.find((item) => item.textContent?.includes('This project'))
     expect(project).toBeDefined()
     act(() => project?.click())
     expect(container.querySelector('[data-testid="allow-primary"]')?.textContent).toBe(
@@ -463,7 +473,7 @@ describe('PermissionApprovalControls interactions', () => {
       root.render(<PermissionApprovalControls requests={[alwaysOnly]} onRespond={onRespond} />)
     })
     // Defaults to the available session scope.
-    expect(container.textContent).toContain('Allow for this session')
+    expect(container.textContent).toContain('Allow for this conversation')
     expect(container.querySelector('[data-testid="scope-chevron"]')).toBeNull()
     expect(container.querySelector('[role="menu"]')).toBeNull()
     // Allowing sends the session option, never a mislabeled once grant.
@@ -714,7 +724,7 @@ describe('PermissionApprovalControls interactions', () => {
     const chevron = container.querySelector('[data-testid="scope-chevron"]') as HTMLButtonElement
     act(() => chevron.click())
     const onceItem = Array.from(container.querySelectorAll('[role="menuitemradio"]')).find(
-      (el) => el.textContent?.includes('Once') && !el.textContent?.includes('session')
+      (el) => el.textContent?.includes('Once') && !el.textContent?.includes('conversation')
     ) as HTMLElement
     act(() => onceItem.click())
     // Collapse the code card so we can prove it re-expands for the next request.
@@ -736,7 +746,7 @@ describe('PermissionApprovalControls interactions', () => {
       root.render(<PermissionApprovalControls requests={[nextRequest]} onRespond={vi.fn()} />)
     })
     // Scope reset to the default Session, menu closed, card re-expanded.
-    expect(container.textContent).toContain('this session')
+    expect(container.textContent).toContain('this conversation')
     expect(container.textContent).not.toContain('this call only')
     expect(container.querySelector('[role="menuitemradio"]')).toBeNull()
     const nextToggle = container.querySelector(

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
@@ -71,7 +71,7 @@ describe('PermissionApprovalControls interactions', () => {
     const sessionItem = Array.from(container.querySelectorAll('[role="menuitemradio"]')).find(
       (item) => item.textContent?.includes('This conversation')
     )
-    expect(sessionItem?.textContent).toContain('Until this chat ends')
+    expect(sessionItem?.textContent).toContain('Remembered for this conversation')
     expect(container.textContent).not.toContain('Agent session')
   })
 
@@ -239,7 +239,7 @@ describe('PermissionApprovalControls interactions', () => {
     )
     expect(
       scopeItems.find((item) => item.textContent?.includes('This conversation'))?.textContent
-    ).toContain('Until this chat ends')
+    ).toContain('Remembered for this conversation')
     expect(
       scopeItems.find((item) => item.textContent?.includes('This project'))?.textContent
     ).toContain('Remembered for this project')

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -137,9 +137,9 @@ const secondPermissionRequest: AcpPermissionRequest = {
 }
 
 describe('PermissionApprovalControls', () => {
-  it('renders the Allow button with the Session scope by default', () => {
+  it('renders the Allow button with the conversation copy for the session scope by default', () => {
     const html = renderControls()
-    expect(html).toContain('for this session')
+    expect(html).toContain('for this conversation')
     expect(html).not.toContain('for this call only')
     expect(html).toContain('data-testid="allow-primary"')
     expect(html).toContain('data-testid="deny-button"')

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -47,9 +47,9 @@ type ScopeOption = { scope: PermissionScope; label: string; subtitle: string }
 
 const SCOPE_OPTIONS: ScopeOption[] = [
   { scope: 'once', label: 'Once', subtitle: 'This call only' },
-  { scope: 'session', label: 'This session', subtitle: 'Across restarts for this session' },
-  { scope: 'project', label: 'This project', subtitle: 'Across sessions in this project' },
-  { scope: 'global', label: 'Global', subtitle: 'Across all projects' }
+  { scope: 'session', label: 'This conversation', subtitle: 'Until this chat ends' },
+  { scope: 'project', label: 'This project', subtitle: 'Remembered for this project' },
+  { scope: 'global', label: 'Global', subtitle: 'Remembered across all projects' }
 ]
 const PERMISSION_SCOPES = SCOPE_OPTIONS.map(({ scope }) => scope)
 
@@ -597,7 +597,7 @@ const PermissionApprovalControls = ({
   const denyOptionId = getDenyOptionId(request.options)
   const scopeLabel: Record<PermissionScope, string> = {
     once: 'once',
-    session: 'for this session',
+    session: 'for this conversation',
     project: 'for this project',
     global: 'globally'
   }
@@ -616,8 +616,8 @@ const PermissionApprovalControls = ({
         : effectiveScope === 'global'
           ? 'Approval applies to matching calls in every project.'
           : presentation.notebookRuntime
-            ? `Approval covers later ${notebookRuntimeLabel[presentation.notebookRuntime]} calls in this session.`
-            : 'Approval remains attached to this session across restarts.'
+            ? `Approval covers later ${notebookRuntimeLabel[presentation.notebookRuntime]} calls in this conversation.`
+            : 'Approval applies to matching calls until this conversation ends.'
   const hasScopePicker = availableScopes.size > 1
   const isSubmitting = submittingRequestId === request.requestId
   const respondOnce = (optionId?: string, broadScopeConfirmed = false): void => {

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -47,7 +47,7 @@ type ScopeOption = { scope: PermissionScope; label: string; subtitle: string }
 
 const SCOPE_OPTIONS: ScopeOption[] = [
   { scope: 'once', label: 'Once', subtitle: 'This call only' },
-  { scope: 'session', label: 'This conversation', subtitle: 'Until this chat ends' },
+  { scope: 'session', label: 'This conversation', subtitle: 'Remembered for this conversation' },
   { scope: 'project', label: 'This project', subtitle: 'Remembered for this project' },
   { scope: 'global', label: 'Global', subtitle: 'Remembered across all projects' }
 ]
@@ -616,8 +616,8 @@ const PermissionApprovalControls = ({
         : effectiveScope === 'global'
           ? 'Approval applies to matching calls in every project.'
           : presentation.notebookRuntime
-            ? `Approval covers later ${notebookRuntimeLabel[presentation.notebookRuntime]} calls in this conversation.`
-            : 'Approval applies to matching calls until this conversation ends.'
+            ? `Approval covers later ${notebookRuntimeLabel[presentation.notebookRuntime]} calls in this conversation, including across restarts.`
+            : 'Approval remains attached to this conversation across restarts.'
   const hasScopePicker = availableScopes.size > 1
   const isSubmitting = submittingRequestId === request.requestId
   const respondOnce = (optionId?: string, broadScopeConfirmed = false): void => {


### PR DESCRIPTION
## Problem

The runtime permission picker uses session-oriented wording that does not match the conversation terminology shown elsewhere in the product.

## Proposed change

- Present the internal session scope as "This conversation".
- Align the scope subtitles with the approved copy for conversation, project, and global grants.
- Use conversation wording in the primary Allow action and permission impact text.
- Update the focused renderer tests for the canonical UI copy.

## Scope and non-goals

- No permission scope, persistence, or ACP protocol behavior changes.
- No changes to the Settings → Permissions panel description.
- No changes to provider-supplied option names or internal session identifiers.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Runtime permission scope copy → `npm test -- src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx` → passed (2 files, 62 tests).
- Renderer types for the changed component and consumers → `npm run typecheck:web` → passed.
- Source formatting and lint rules → `npm run lint` → passed with 0 errors; 17 pre-existing warnings remain in unrelated files.
- Patch integrity → `git diff --check` → passed.

Consumer and platform lanes are excluded because this is renderer-only copy with no interface, state, protocol, persistence, path, or platform-dependent behavior change. Full `npm test` is not included because the owner and affected tests are explicit.

No uncovered functional risks are known. Visual placement was not re-baselined because layout and styling are unchanged.

## Review focus

Confirm the permission picker and primary Allow action use conversation terminology while Settings → Permissions remains unchanged.
