### PR TITLE
feat(workspace): group sidebar sessions by activity

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -443,6 +443,7 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Session row wrapper owns hover/active visuals only: `group mx-1.5 rounded-md px-2.5 py-1.5 text-sm text-text-000 hover:bg-bg-300 select-none`; active adds `bg-bg-300`.
 - Session title button is the row click target: `flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left`.
 - Session status dots are decorative and `aria-hidden`; provide adjacent `sr-only` text such as `Session status: Running`.
+- Session groups appear in `Pinned`, `Active`, `Today`, `Yesterday`, `This week`, `Older` order and omit empty headings. Pinning has priority over every activity or date group. `Active` includes running and user-waiting Sessions plus idle Sessions for 15 minutes after their latest activity; selection and Side chat activity alone do not make a Session active. Date groups use the device's local calendar, with `This week` beginning Monday at 00:00, and refresh at local midnight.
 - Footer settings area uses a top fade `bg-gradient-to-t from-rail-card-bg to-rail-card-bg/0` and a `h-8 w-8` icon button.
 
 ### Message Center

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -1,7 +1,12 @@
+// @vitest-environment jsdom
+
 import { renderToStaticMarkup } from 'react-dom/server'
-import { Children, isValidElement, type ReactElement, type ReactNode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { act, Children, isValidElement, type ReactElement, type ReactNode } from 'react'
 import type { ChatSession } from '@/stores/session-store'
 import { describe, expect, it, vi } from 'vitest'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
 vi.mock('@/lib/utils', () => ({
   cn: (...values: Array<string | false | undefined>) => values.filter(Boolean).join(' ')
@@ -133,7 +138,7 @@ describe('WorkspaceSidebar accessible render', () => {
   })
 
   it('wires session open and row menu actions to the matching session', async () => {
-    const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+    const { WorkspaceSidebarView } = await import('./WorkspaceSidebar')
     const sessions = [
       createSession({ id: 'session-a', title: 'Notebook review' }),
       createSession({ id: 'session-b', title: 'Dataset cleanup' })
@@ -144,7 +149,8 @@ describe('WorkspaceSidebar accessible render', () => {
     const onDeleteSession = vi.fn()
     const onExportSession = vi.fn()
     const onArchiveSession = vi.fn()
-    const tree = WorkspaceSidebar({
+    const tree = WorkspaceSidebarView({
+      now: Date.now(),
       projectName: 'Example project',
       sessions,
       activeSessionId: sessions[0].id,
@@ -215,9 +221,10 @@ describe('WorkspaceSidebar accessible render', () => {
   })
 
   it('renders Files directly after New and wires it to the preview opener', async () => {
-    const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+    const { WorkspaceSidebarView } = await import('./WorkspaceSidebar')
     const onOpenFiles = vi.fn()
-    const tree = WorkspaceSidebar({
+    const tree = WorkspaceSidebarView({
+      now: Date.now(),
       projectName: 'Example project',
       sessions: [createSession({ id: 'session-a', title: 'Notebook review' })],
       activeSessionId: 'session-a',
@@ -253,13 +260,14 @@ describe('WorkspaceSidebar accessible render', () => {
   })
 
   it('wires the View notebook menu item to the matching session', async () => {
-    const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+    const { WorkspaceSidebarView } = await import('./WorkspaceSidebar')
     const sessions = [
       createSession({ id: 'session-a', title: 'Notebook review' }),
       createSession({ id: 'session-b', title: 'Dataset cleanup' })
     ]
     const onViewNotebook = vi.fn()
-    const tree = WorkspaceSidebar({
+    const tree = WorkspaceSidebarView({
+      now: Date.now(),
       projectName: 'Example project',
       sessions,
       activeSessionId: sessions[0].id,
@@ -303,14 +311,162 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(withPin.indexOf('>Pinned<')).toBeLessThan(withPin.indexOf('>Active<'))
   })
 
-  it('shows Pin for an unpinned session and Unpin for a pinned one, wired to the session', async () => {
+  it('groups unpinned sessions by live activity, recent completion, and local date', async () => {
+    vi.useFakeTimers()
+    const now = new Date(2026, 7, 9, 13, 30).getTime()
+    vi.setSystemTime(now)
+
+    try {
+      const html = await renderSidebar([
+        createSession({
+          id: 'older-session',
+          title: 'Older conversation',
+          status: 'idle',
+          updatedAt: new Date(2026, 7, 2, 12).getTime()
+        }),
+        createSession({
+          id: 'today-session',
+          title: 'Earlier today',
+          status: 'idle',
+          updatedAt: now - 16 * 60_000
+        }),
+        createSession({
+          id: 'failed-session',
+          title: 'Failed today',
+          status: 'error',
+          updatedAt: now
+        }),
+        createSession({
+          id: 'week-session',
+          title: 'Earlier this week',
+          status: 'idle',
+          updatedAt: new Date(2026, 7, 4, 12).getTime()
+        }),
+        createSession({
+          id: 'yesterday-session',
+          title: 'Yesterday conversation',
+          status: 'idle',
+          updatedAt: new Date(2026, 7, 8, 12).getTime()
+        }),
+        createSession({
+          id: 'recent-session',
+          title: 'Just completed',
+          status: 'idle',
+          updatedAt: now - 14 * 60_000
+        }),
+        createSession({
+          id: 'waiting-session',
+          title: 'Waiting for approval',
+          status: 'waiting-permission',
+          updatedAt: new Date(2026, 7, 1, 12).getTime()
+        }),
+        createSession({
+          id: 'waiting-user-session',
+          title: 'Waiting for an answer',
+          status: 'waiting-for-user',
+          updatedAt: new Date(2026, 7, 1, 12).getTime()
+        }),
+        createSession({
+          id: 'waiting-plan-session',
+          title: 'Waiting for plan approval',
+          status: 'waiting-plan-approval',
+          updatedAt: new Date(2026, 7, 1, 12).getTime()
+        }),
+        createSession({
+          id: 'pinned-session',
+          title: 'Pinned running session',
+          status: 'running',
+          pinned: true,
+          updatedAt: now
+        })
+      ])
+
+      const headings = ['Pinned', 'Active', 'Today', 'Yesterday', 'This week', 'Older']
+      headings.reduce((previousIndex, heading) => {
+        const index = html.indexOf(`>${heading}<`)
+        expect(index).toBeGreaterThan(previousIndex)
+        return index
+      }, -1)
+
+      expect(html.indexOf('Pinned running session')).toBeLessThan(html.indexOf('>Active<'))
+      expect(html.indexOf('Waiting for approval')).toBeLessThan(html.indexOf('>Today<'))
+      expect(html.indexOf('Waiting for an answer')).toBeLessThan(html.indexOf('>Today<'))
+      expect(html.indexOf('Waiting for plan approval')).toBeLessThan(html.indexOf('>Today<'))
+      expect(html.indexOf('Just completed')).toBeLessThan(html.indexOf('>Today<'))
+      expect(html.indexOf('Earlier today')).toBeGreaterThan(html.indexOf('>Today<'))
+      expect(html.indexOf('Failed today')).toBeGreaterThan(html.indexOf('>Today<'))
+      expect(html.indexOf('Older conversation')).toBeGreaterThan(html.indexOf('>Older<'))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('moves a recently completed idle session to Today when its Active grace period expires', async () => {
+    vi.useFakeTimers()
+    const now = new Date(2026, 7, 9, 13, 30).getTime()
+    vi.setSystemTime(now)
+    const session = createSession({
+      id: 'recent-session',
+      title: 'Just completed',
+      status: 'idle',
+      updatedAt: now - 14 * 60_000
+    })
     const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkspaceSidebar
+            projectName="Example project"
+            sessions={[session]}
+            activeSessionId={undefined}
+            canCreateConversation
+            canMutateConversations
+            canDeleteConversations
+            onGoHome={vi.fn()}
+            onNewConversation={vi.fn()}
+            isFilesOpen={false}
+            onOpenFiles={vi.fn()}
+            onOpenSession={vi.fn()}
+            onRenameSession={vi.fn()}
+            canDownloadArtifacts
+            onDownloadArtifacts={vi.fn()}
+            onViewNotebook={vi.fn()}
+            onExportSession={vi.fn()}
+            onTogglePin={vi.fn()}
+            onDeleteSession={vi.fn()}
+            onOpenSettings={vi.fn()}
+          />
+        )
+      })
+
+      expect(container.textContent).toContain('Active')
+      expect(container.textContent).not.toContain('Today')
+
+      await act(async () => {
+        vi.advanceTimersByTime(60_001)
+      })
+
+      expect(container.textContent).not.toContain('Active')
+      expect(container.textContent).toContain('Today')
+      expect(container.textContent).toContain('Just completed')
+    } finally {
+      act(() => root.unmount())
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows Pin for an unpinned session and Unpin for a pinned one, wired to the session', async () => {
+    const { WorkspaceSidebarView } = await import('./WorkspaceSidebar')
     const sessions = [
       createSession({ id: 'session-a', title: 'Unpinned one' }),
       createSession({ id: 'session-b', title: 'Pinned one', pinned: true })
     ]
     const onTogglePin = vi.fn()
-    const tree = WorkspaceSidebar({
+    const tree = WorkspaceSidebarView({
+      now: Date.now(),
       projectName: 'Example project',
       sessions,
       activeSessionId: sessions[0].id,
@@ -347,9 +503,10 @@ describe('WorkspaceSidebar accessible render', () => {
   })
 
   it('keeps target-validated deletion available while other mutations are recovering', async () => {
-    const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+    const { WorkspaceSidebarView } = await import('./WorkspaceSidebar')
     const session = createSession({ id: 'session-a', title: 'Notebook review' })
-    const tree = WorkspaceSidebar({
+    const tree = WorkspaceSidebarView({
+      now: Date.now(),
       projectName: 'Example project',
       sessions: [session],
       activeSessionId: session.id,
@@ -380,8 +537,9 @@ describe('WorkspaceSidebar accessible render', () => {
   })
 
   it('disables conversation export for active, waiting, or empty sessions', async () => {
-    const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
-    const tree = WorkspaceSidebar({
+    const { WorkspaceSidebarView } = await import('./WorkspaceSidebar')
+    const tree = WorkspaceSidebarView({
+      now: Date.now(),
       projectName: 'Example project',
       sessions: [
         createSession({ id: 'running', status: 'running', messages: [createMessage()] }),
@@ -431,8 +589,9 @@ describe('WorkspaceSidebar accessible render', () => {
   })
 
   it('hides conversation export when the runtime does not expose that capability', async () => {
-    const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
-    const tree = WorkspaceSidebar({
+    const { WorkspaceSidebarView } = await import('./WorkspaceSidebar')
+    const tree = WorkspaceSidebarView({
+      now: Date.now(),
       projectName: 'Example project',
       sessions: [createSession({ status: 'idle', messages: [createMessage()] })],
       activeSessionId: 'session-1',
@@ -457,9 +616,10 @@ describe('WorkspaceSidebar accessible render', () => {
   })
 
   it('hides artifact downloads when the runtime does not provide the desktop save capability', async () => {
-    const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+    const { WorkspaceSidebarView } = await import('./WorkspaceSidebar')
     const session = createSession({ id: 'session-a', title: 'Notebook review' })
-    const tree = WorkspaceSidebar({
+    const tree = WorkspaceSidebarView({
+      now: Date.now(),
       projectName: 'Example project',
       sessions: [session],
       activeSessionId: session.id,

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -15,6 +15,7 @@ import {
   Trash2,
   X
 } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -61,6 +62,10 @@ type WorkspaceSidebarProps = {
   onMobileClose?: () => void
 }
 
+type WorkspaceSidebarViewProps = WorkspaceSidebarProps & {
+  now: number
+}
+
 // Maps each session status to the left-side indicator dot using emitted theme colors.
 const sessionStatusDotClassName: Record<SessionStatus, string> = {
   idle: 'border border-text-100 bg-transparent',
@@ -80,6 +85,82 @@ const sessionStatusLabel: Record<SessionStatus, string> = {
   error: 'Error'
 }
 
+const ACTIVE_SESSION_GRACE_MS = 15 * 60_000
+
+const isLiveSessionStatus = (status: SessionStatus): boolean =>
+  status === 'running' ||
+  status === 'waiting-for-user' ||
+  status === 'waiting-permission' ||
+  status === 'waiting-plan-approval'
+
+type SidebarSessionSection = {
+  label: 'Pinned' | 'Active' | 'Today' | 'Yesterday' | 'This week' | 'Older'
+  items: ChatSession[]
+}
+
+const startOfLocalDay = (timestamp: number): number => {
+  const date = new Date(timestamp)
+  date.setHours(0, 0, 0, 0)
+  return date.getTime()
+}
+
+const getSessionSections = (sessions: ChatSession[], now: number): SidebarSessionSection[] => {
+  const todayStartedAt = startOfLocalDay(now)
+  const yesterday = new Date(todayStartedAt)
+  yesterday.setDate(yesterday.getDate() - 1)
+  const yesterdayStartedAt = yesterday.getTime()
+  const week = new Date(todayStartedAt)
+  week.setDate(week.getDate() - ((week.getDay() + 6) % 7))
+  const weekStartedAt = week.getTime()
+
+  const pinned: ChatSession[] = []
+  const active: ChatSession[] = []
+  const today: ChatSession[] = []
+  const yesterdaySessions: ChatSession[] = []
+  const thisWeek: ChatSession[] = []
+  const older: ChatSession[] = []
+
+  sessions.forEach((session) => {
+    if (session.pinned) {
+      pinned.push(session)
+    } else if (
+      isLiveSessionStatus(session.status) ||
+      (session.status === 'idle' && now - session.updatedAt < ACTIVE_SESSION_GRACE_MS)
+    ) {
+      active.push(session)
+    } else if (session.updatedAt >= todayStartedAt) {
+      today.push(session)
+    } else if (session.updatedAt >= yesterdayStartedAt) {
+      yesterdaySessions.push(session)
+    } else if (session.updatedAt >= weekStartedAt) {
+      thisWeek.push(session)
+    } else {
+      older.push(session)
+    }
+  })
+
+  const sections: SidebarSessionSection[] = [
+    { label: 'Pinned', items: pinned },
+    { label: 'Active', items: active },
+    { label: 'Today', items: today },
+    { label: 'Yesterday', items: yesterdaySessions },
+    { label: 'This week', items: thisWeek },
+    { label: 'Older', items: older }
+  ]
+  return sections.filter((section) => section.items.length > 0)
+}
+
+const getNextSessionSectionRefreshAt = (sessions: ChatSession[], now: number): number => {
+  const tomorrow = new Date(now)
+  tomorrow.setHours(24, 0, 0, 0)
+
+  return sessions.reduce((nextRefreshAt, session) => {
+    if (session.pinned || session.status !== 'idle') return nextRefreshAt
+    const activeUntil = session.updatedAt + ACTIVE_SESSION_GRACE_MS
+    return activeUntil > now ? Math.min(nextRefreshAt, activeUntil) : nextRefreshAt
+  }, tomorrow.getTime())
+}
+
 const sidebarInteractiveTransitionClassName = 'transition-colors duration-200 ease-out'
 
 const sessionRowClassName = cn(
@@ -94,7 +175,7 @@ const sessionRowActionClassName =
 const sessionMenuIconClassName = 'flex size-4 shrink-0 items-center justify-center'
 
 // Left navigation owns session selection, creation entry, and workspace settings.
-const WorkspaceSidebar = ({
+const WorkspaceSidebarView = ({
   projectName,
   sessions,
   activeSessionId,
@@ -118,17 +199,10 @@ const WorkspaceSidebar = ({
   onOpenSettings,
   mobileMode = false,
   isMobileOpen = false,
-  onMobileClose
-}: WorkspaceSidebarProps): React.JSX.Element => {
-  // Partition sessions into pinned and unpinned groups; each group preserves the incoming order.
-  const pinnedSessions = sessions.filter((s) => s.pinned)
-  const activeSessions = sessions.filter((s) => !s.pinned)
-
-  // Build section descriptors so the list renders with a labelled header per group.
-  const sections: Array<{ label: string; items: typeof sessions }> = []
-
-  if (pinnedSessions.length > 0) sections.push({ label: 'Pinned', items: pinnedSessions })
-  sections.push({ label: 'Active', items: activeSessions })
+  onMobileClose,
+  now
+}: WorkspaceSidebarViewProps): React.JSX.Element => {
+  const sections = getSessionSections(sessions, now)
 
   return (
     <aside
@@ -446,4 +520,22 @@ const WorkspaceSidebar = ({
   )
 }
 
+const WorkspaceSidebar = (props: WorkspaceSidebarProps): React.JSX.Element => {
+  const [now, setNow] = useState(Date.now)
+  const nextSectionRefreshAt = getNextSessionSectionRefreshAt(props.sessions, now)
+
+  // Reclassify recent completions at 15 minutes and date groups at local midnight without waiting
+  // for unrelated Session activity to trigger a render.
+  useEffect(() => {
+    const timeoutId = window.setTimeout(
+      () => setNow(Date.now()),
+      Math.max(1, nextSectionRefreshAt - Date.now() + 1)
+    )
+    return () => window.clearTimeout(timeoutId)
+  }, [nextSectionRefreshAt])
+
+  return <WorkspaceSidebarView {...props} now={now} />
+}
+
 export { WorkspaceSidebar }
+export { WorkspaceSidebarView }


### PR DESCRIPTION
## Problem

The workspace sidebar currently labels every unpinned session as Active. It does not distinguish live work from completed sessions, does not preserve recently completed conversations for a short grace period, and has no calendar buckets for the remaining history.

## Proposed change

- Keep pinned sessions first and exclude them from Active.
- Treat running, waiting-for-user, waiting-permission, and waiting-plan-approval sessions as live.
- Keep an idle session in Active for 15 minutes after its latest activity, then place it in a local-date bucket.
- Add Today, Yesterday, This week, and Older buckets; This week begins Monday at 00:00 local time.
- Refresh the grouping at the next idle-grace expiry or local midnight, without waiting for unrelated React updates.
- Preserve session order within each group and omit empty headings.
- Keep Side chat-only activity from activating its parent session by deriving the group from the parent session state only.

## Scope and non-goals

This is a renderer-only sidebar change. It does not change persisted session schemas, runtime status transitions, ACP protocol handling, or Side chat state management.

## Acceptance criteria and validation

- Group priority, live-status mapping, pin precedence, selected-session behavior, local date boundaries, and the 15-minute grace period: `npm test -- src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx` — 16 tests passed.
- Workspace page owner and contract coverage: `npm run test:module -- workspace_page` — 22 files and 317 tests passed.
- Renderer type safety: `npm run typecheck:web` — passed.
- Lint: `npm run lint` — passed with 17 pre-existing warnings in unrelated files and no errors.
- Formatting: `npx prettier --check docs/design.md src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx src/renderer/src/pages/workspace/WorkspaceSidebar.tsx` — passed.
- Patch integrity: `git diff --check` — passed.

The impact set includes the workspace sidebar owner and its architectural/session-store contracts. Main, preload, persistence, ACP, and OS-specific suites are excluded because this change does not cross those interfaces. Packaged UI/E2E behavior is not covered; deterministic render and fake-timer tests cover the changed interaction.

## Review focus

- Whether the 15-minute idle grace matches the intended Active semantics.
- Local calendar boundary handling, especially Monday 00:00.
- Timer scheduling and cleanup when session data changes.
