### PR TITLE
fix(app): keep startup animation during conversation loading

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -784,13 +784,19 @@ describe('App startup routing', () => {
     expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
   })
 
-  it('blocks Home while the initial session snapshot is loading', async () => {
+  it('continues the startup animation while the initial session snapshot loads', async () => {
+    await render()
+
+    const settingsLogo = container.querySelector<HTMLCanvasElement>(
+      '[data-testid="settings-startup-loading"] canvas[data-testid="open-science-logo-loader"]'
+    )
+    expect(settingsLogo).not.toBeNull()
+
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.isHydrated = false
     mocks.sessionPersistence.isLoading = true
     mocks.sessionPersistence.isReady = false
-
-    await render()
+    await act(async () => root.render(<App />))
 
     const shell = container.querySelector('[data-testid="session-persistence-startup-loading"]')
     expect(shell).not.toBeNull()
@@ -798,6 +804,9 @@ describe('App startup routing', () => {
     expect(shell?.classList.contains('h-screen')).toBe(false)
     expect(shell?.classList.contains('text-foreground')).toBe(true)
     expect(shell?.classList.contains('text-muted-foreground')).toBe(false)
+    expect(
+      shell?.querySelector<HTMLCanvasElement>('canvas[data-testid="open-science-logo-loader"]')
+    ).toBe(settingsLogo)
     expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
   })
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -492,7 +492,10 @@ const App = (): React.JSX.Element | null => {
         role="status"
         className="flex min-h-svh items-center justify-center bg-background text-foreground"
       >
-        <span className="text-sm text-muted-foreground">Loading saved conversations…</span>
+        <div className="flex flex-col items-center gap-14">
+          <OpenScienceLogoLoader />
+          <span className="text-sm text-muted-foreground">Loading saved conversations…</span>
+        </div>
       </main>
     )
   }


### PR DESCRIPTION
## Problem

The startup surface showed the animated Open Science logo while loading settings, but replaced it with static text while hydrating saved conversations. This created a visible animation gap during `npm run dev` even though startup was still in progress.

## Proposed change

- Reuse `OpenScienceLogoLoader` during saved-conversation hydration.
- Keep the startup render tree stable across the settings and conversation-loading phases.
- Cover the real phase transition and assert that React preserves the same canvas node, so the animation does not restart.

## Scope and non-goals

- Changes only the Renderer app startup surface and its regression test.
- Does not change logo motion, session persistence, startup ordering, or loading copy.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- Startup animation continuity -> `npm test -- src/renderer/src/App.test.tsx src/renderer/src/components/OpenScienceLogoLoader.test.tsx src/renderer/src/components/open-science-logo-motion.test.ts` -> 44/44 tests passed.
- Node and Web type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings outside this diff.
- Portable suite -> `npm test -- --maxWorkers=4` -> 871 files and 12,713 tests passed; 5 unrelated fixed-timeout tests in 4 files exceeded the 15-second per-test limit under full-suite load.
- Timeout isolation -> `npm test -- src/main/agents/completion-gate.execute-control.integration.test.ts src/main/notebook/mcp-server.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts src/renderer/src/pages/workspace/ProjectFilesView.test.tsx --maxWorkers=1` -> 156/156 tests passed.

The complete local suite is therefore not fully green under concurrent load; exact-head CI remains the final validation authority. No platform lane or packaged Electron boundary was included because the change is a platform-neutral React render-tree correction at the existing `App` seam.

## Review focus

- Confirm that the two startup branches retain matching child structure.
- Confirm that the regression test's canvas identity assertion protects animation continuity rather than only checking visual presence.
