### PR TITLE
chore(release): bump to v0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Open Science currently includes 18 featured research skills and 24 built-in scientific connectors, with its strongest coverage in bioinformatics, computational biology, biomedical research, genomics, structural biology, and computational drug discovery—and an extensible architecture designed to support more scientific disciplines over time.
 
-> 💡 **[Open Science v0.12.0 released](https://github.com/aipoch/open-science/releases/latest)** _(last updated August 8, 2026)_. Highlights include a cross-surface notification message center, a structured agent clarification workflow, authenticated GitHub skill imports, live session status on the Home dashboard, session-resume continuation for interrupted turns, and notebook output-artifact separation. See the [latest release notes](https://github.com/aipoch/open-science/releases/latest) for the full changelog.
+> 💡 **[Open Science v0.12.1 released](https://github.com/aipoch/open-science/releases/latest)** _(last updated August 9, 2026)_. Highlights include workspace sidebar sessions grouped by live activity and calendar buckets, visible context compaction activity in the transcript, keyboard-driven search navigation, and pre-approved customization grants, alongside Windows notebook runner fallback and Codex approval fixes. See the [latest release notes](https://github.com/aipoch/open-science/releases/latest) for the full changelog.
 
 <p align="center">
  <img width="1920" height="1140" alt="Open Science open-source AI research workbench desktop app workspace showing an agent session with generated artifacts" src="https://github.com/user-attachments/assets/df59db19-98d7-4071-81f2-c682fbecdf86" />
@@ -236,6 +236,7 @@ Open Science is available as a released desktop application and is actively deve
 - **v0.11.1** adds on-demand artifact code reconstruction, live permission profile changes during a running turn, project and session archiving with undo, MCP connector OAuth and portable configuration import/export, tool-activity elapsed time in the transcript, persistent plan call records, and branded loading indicators, while hardening Windows runtime recovery, session-plan turn completion, and cross-platform release certification.
 - **v0.11.2** adds kernel image-output previews for R and Python notebooks, an offline detection indicator with a Network status panel, Task API run-progress liveness and explicit run cancellation, isolated unavailable custom MCP server discovery, artifact finalization proof-failure diagnostics, and Windows updater certification stabilization.
 - **v0.12.0** adds a cross-surface notification message center with durable read state, a structured agent clarification workflow, authenticated GitHub skill imports, live session status on the Home dashboard, session-resume continuation for interrupted turns, and notebook output-artifact separation.
+- **v0.12.1** adds workspace sidebar sessions grouped by live activity and calendar buckets, visible context compaction activity in the transcript, and keyboard-driven search navigation, while fixing Codex MCP approvals, ask-user question presentation, thinking elapsed time, artifact finalization stalls, and Windows notebook runner crashes.
 
 Deterministic reconstruction, portable environment restoration, and full-fidelity session replay remain on the roadmap.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-science",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-science",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "open-science",
   "productName": "Open Science",
   "desktopName": "open-science.desktop",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Open Science — an open-source, model-agnostic AI workbench for scientific discovery.",
   "main": "./out/main/index.js",
   "author": "aipoch",


### PR DESCRIPTION
## Problem

Prepare the v0.12.1 patch release.

## Proposed change

Bumps the single source of truth (`package.json` + `package-lock.json`) from `0.12.0` to `0.12.1` and updates the README release banner and recent-versions list for what landed since v0.12.0.

This is a **patch** release: no breaking changes and no Roadmap phase status changes. It groups workspace sidebar sessions by live activity and calendar buckets, surfaces context compaction as a visible transcript activity, adds keyboard-driven search navigation and pre-approved customization grants, and fixes Codex MCP approval routing, ask-user question presentation, thinking elapsed time, artifact finalization stalls, and Windows notebook runner crashes.

### Since v0.12.0 (headline)

- **Sidebar sessions grouped by live activity and date** — live work is distinguished from completed sessions, with Today / Yesterday / This week / Older calendar buckets. (#1006)
- **Context compaction activity in the transcript** — automatic compaction is visible with loading, completed, cancelled, and failed states across all supported frameworks. (#1003)
- **Keyboard-driven search navigation** — Tab selection for composer mentions and platform search shortcuts for Settings filters. (#1001)
- **Pre-approved customization grants** — common personalization actions are seeded as global allow grants on first run. (#991)
- **Codex MCP approvals routed through permission broker** — MCP tool authorization delivered as elicitation is now handled correctly. (#982)
- **Windows notebook runner preflight and fallback** — a crashing bundled runner is detected and a compatible alternative is used. (#994)
- **Artifact finalization stalls eliminated** — stale session save echoes no longer clobber the live conversation graph. (#997)

## Scope and non-goals

- Version bump in `package.json` and `package-lock.json` (project version only; no dependency version changes).
- README release banner and recent-versions list updated.
- ROADMAP is unchanged — no phase status changes in a patch release.

## Acceptance criteria and validation

- CI passes on the bump commit.
- `package-lock.json` shows `"version": "0.12.1"` at both the root and the root project entry, with no other version changes.