### PR TITLE
test(settings): define backend ownership contracts

### DIFF
--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -648,7 +648,8 @@ describe('task CLI', () => {
       'notebook',
       'notebook-env',
       'reviewer',
-      'runtime'
+      'runtime',
+      'settings'
     ]) {
       await expect(runCli([command])).rejects.toThrow(`Unknown command: ${command}`)
     }

--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -210,6 +210,156 @@
       "capabilityOverlays": ["windows_sensitive"],
       "fallbackCapability": "main_runtime"
     },
+    "settings_repository": {
+      "ownerPaths": ["src/main/settings/repository.ts"],
+      "interfacePaths": ["src/main/settings/repository.ts"],
+      "consumerModules": [
+        "settings_provider_accounts",
+        "settings_service_facade",
+        "compute_service"
+      ],
+      "testFiles": {
+        "owner": [
+          "src/main/settings/settings-backend.architecture.test.ts",
+          "src/main/settings/repository.test.ts",
+          "src/main/settings/compute-grants.test.ts",
+          "src/main/settings/connectors-settings.test.ts",
+          "src/main/settings/custom-mcp-settings.test.ts",
+          "src/main/settings/mirror-settings.test.ts"
+        ],
+        "contract": ["src/shared/settings.test.ts"],
+        "consumer": [
+          "src/main/settings/service.test.ts",
+          "src/main/compute/ipc.test.ts",
+          "src/main/settings/agent-runtime-manager.test.ts",
+          "src/main/settings/connector-settings.test.ts",
+          "src/main/settings/notebook-runtime-settings.test.ts",
+          "src/main/settings/preferences.test.ts",
+          "src/main/settings/skill-catalog.test.ts"
+        ]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
+    "settings_provider_accounts": {
+      "ownerPaths": ["src/main/settings/provider-accounts.ts"],
+      "interfacePaths": ["src/main/settings/provider-accounts.ts"],
+      "consumerModules": ["settings_backend_resolution", "settings_service_facade"],
+      "testFiles": {
+        "owner": [
+          "src/main/settings/settings-backend.architecture.test.ts",
+          "src/main/settings/provider-accounts.test.ts",
+          "src/main/settings/codex-auth.test.ts",
+          "src/main/settings/claude-isolated-auth.test.ts",
+          "src/main/settings/claude-shared-auth.test.ts",
+          "src/main/settings/validate.test.ts",
+          "src/main/settings/list-models.test.ts",
+          "src/main/settings/crypto.test.ts",
+          "src/main/settings/provider-env.test.ts"
+        ],
+        "contract": [
+          "src/main/settings/service.providers.test.ts",
+          "src/main/settings/runtime-application-commands.test.ts",
+          "src/shared/provider-registry.test.ts",
+          "src/shared/provider-reasoning-effort.test.ts"
+        ],
+        "consumer": [
+          "src/main/settings/agent-runtime-manager.test.ts",
+          "src/main/settings/backend-resolver.test.ts",
+          "src/renderer/src/stores/settings-provider-auth-slice.test.ts"
+        ]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
+    "settings_backend_resolution": {
+      "ownerPaths": [
+        "src/main/settings/backend-resolver.ts",
+        "src/main/settings/responses-bridge.ts"
+      ],
+      "interfacePaths": [
+        "src/main/settings/backend-resolver.ts",
+        "src/main/settings/responses-bridge.ts"
+      ],
+      "consumerModules": [
+        "settings_service_facade",
+        "reviewer_orchestrator",
+        "artifact_provenance"
+      ],
+      "testFiles": {
+        "owner": [
+          "src/main/settings/settings-backend.architecture.test.ts",
+          "src/main/settings/backend-resolver.test.ts",
+          "src/main/settings/responses-bridge.test.ts",
+          "src/main/settings/responses-bridge.integration.test.ts",
+          "src/main/settings/native-responses-compatibility.test.ts",
+          "src/main/settings/anthropic-provider-bridge.test.ts",
+          "src/main/settings/openai-provider-bridge.test.ts",
+          "src/main/settings/system-proxy.test.ts"
+        ],
+        "contract": [
+          "src/main/agent-framework/codex.test.ts",
+          "src/main/agent-framework/opencode.test.ts",
+          "src/main/agent-framework/registry.test.ts"
+        ],
+        "consumer": [
+          "packages/open-science/cli.test.ts",
+          "src/main/acp/artifact-code-reconstruction-runner.test.ts",
+          "src/main/acp/backend-generation-owner.test.ts",
+          "src/main/acp/provider-prompt-executor.test.ts",
+          "src/main/acp/task-agent-port.test.ts",
+          "src/main/acp/turn-skill-owner.test.ts",
+          "src/main/artifacts/code-reconstruction.test.ts",
+          "src/main/notebook/local-rpc-server.mcpcall.test.ts",
+          "src/main/reviewer/mcp-server.test.ts"
+        ]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
+    "settings_service_facade": {
+      "ownerPaths": ["src/main/settings/service.ts"],
+      "interfacePaths": [
+        "src/main/settings/service.ts",
+        "src/main/settings/application-commands.ts",
+        "src/main/settings/runtime-application-commands.ts",
+        "src/main/settings/integration-application-commands.ts",
+        "src/main/settings/ipc.ts"
+      ],
+      "consumerModules": ["workspace_runtime"],
+      "testFiles": {
+        "owner": [
+          "src/main/settings/settings-backend.architecture.test.ts",
+          "src/main/settings/service.test.ts",
+          "src/main/settings/service.providers.test.ts",
+          "src/main/settings/service.connectors.test.ts"
+        ],
+        "contract": [
+          "src/main/settings/application-commands.test.ts",
+          "src/main/settings/runtime-application-commands.test.ts",
+          "src/main/settings/integration-application-commands.test.ts",
+          "src/main/settings/ipc.test.ts",
+          "src/main/settings/capabilities.test.ts",
+          "src/main/settings/workflows.test.ts",
+          "src/main/application-command-composition.test.ts",
+          "src/main/application-command-wiring.test.ts",
+          "src/shared/renderer-contract-catalog.test.ts",
+          "src/preload/electron-renderer-contract-adapter.test.ts",
+          "src/renderer/web/api-installer.test.ts"
+        ],
+        "consumer": [
+          "packages/open-science/cli.test.ts",
+          "src/main/acp/backend-generation-owner.test.ts",
+          "src/main/acp/runtime-provider-session-composition.test.ts",
+          "src/main/acp/task-agent-port.test.ts",
+          "src/main/notebook/local-rpc-server.mcpcall.test.ts",
+          "src/renderer/src/stores/settings-runtime-slice.test.ts",
+          "src/renderer/src/stores/settings-store.test.ts"
+        ]
+      },
+      "capabilityOverlays": ["settings_ipc", "renderer_settings", "windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
     "artifact_storage": {
       "ownerPaths": [
         "src/main/artifacts/compatibility-owner.ts",

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -96,6 +96,82 @@ describe('module test impact commands', () => {
     }
   )
 
+  it.each([
+    [
+      'src/main/settings/repository.ts',
+      [
+        'artifact_provenance',
+        'compute_service',
+        'reviewer_orchestrator',
+        'session_persistence',
+        'settings_backend_resolution',
+        'settings_provider_accounts',
+        'settings_repository',
+        'settings_service_facade',
+        'workspace_page',
+        'workspace_runtime'
+      ]
+    ],
+    [
+      'src/main/settings/provider-accounts.ts',
+      [
+        'artifact_provenance',
+        'reviewer_orchestrator',
+        'session_persistence',
+        'settings_backend_resolution',
+        'settings_provider_accounts',
+        'settings_service_facade',
+        'workspace_page',
+        'workspace_runtime'
+      ]
+    ],
+    [
+      'src/main/settings/responses-bridge.ts',
+      [
+        'artifact_provenance',
+        'reviewer_orchestrator',
+        'session_persistence',
+        'settings_backend_resolution',
+        'settings_service_facade',
+        'workspace_page',
+        'workspace_runtime'
+      ]
+    ],
+    [
+      'src/main/settings/service.ts',
+      ['settings_service_facade', 'workspace_page', 'workspace_runtime']
+    ]
+  ])('expands Settings ownership through real consumers for %s', (path, expectedModules) => {
+    const plan = createAffectedTestPlan([{ path, status: 'modified' }], {
+      status: 'current',
+      testFiles: []
+    })
+
+    expect(plan.mode).toBe('selective')
+    expect([...plan.modules].sort()).toEqual(expectedModules)
+    const rootModule =
+      path === 'src/main/settings/repository.ts'
+        ? 'settings_repository'
+        : path === 'src/main/settings/provider-accounts.ts'
+          ? 'settings_provider_accounts'
+          : path === 'src/main/settings/responses-bridge.ts'
+            ? 'settings_backend_resolution'
+            : 'settings_service_facade'
+    expect(plan.reasonChains).toEqual(
+      expect.arrayContaining(
+        rootModule === 'settings_service_facade'
+          ? [
+              'settings_service_facade -> workspace_runtime',
+              'settings_service_facade -> workspace_runtime -> workspace_page'
+            ]
+          : [
+              `${rootModule}${rootModule === 'settings_repository' ? ' -> settings_provider_accounts' : ''}${rootModule === 'settings_backend_resolution' ? '' : ' -> settings_backend_resolution'} -> reviewer_orchestrator`,
+              `${rootModule} -> settings_service_facade -> workspace_runtime`
+            ]
+      )
+    )
+  })
+
   it('fails closed for unknown and destructive changes', () => {
     expect(
       createAffectedTestPlan([{ path: 'src/main/unknown-owner.ts', status: 'added' }], {

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -18,6 +18,23 @@ afterEach(async () => {
 })
 
 describe('mcpCall RPC', () => {
+  it('keeps Settings management outside the Notebook local RPC surface', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp'
+    })
+    const { endpoint, token } = await sessionConnection(server)
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ method: 'settingsCall', params: { workspaceCwd: process.cwd() } })
+    })
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Unknown notebook RPC method: settingsCall'
+    })
+  })
+
   it('rejects privileged calls made with the server-wide bootstrap token', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -1,0 +1,656 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { basename, dirname, extname, relative, resolve } from 'node:path'
+
+import {
+  canHaveModifiers,
+  createSourceFile,
+  forEachChild,
+  getModifiers,
+  isCallExpression,
+  isClassDeclaration,
+  isEnumDeclaration,
+  isExportDeclaration,
+  isFunctionDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isImportTypeNode,
+  isInterfaceDeclaration,
+  isLiteralTypeNode,
+  isMethodDeclaration,
+  isNamedExports,
+  isNewExpression,
+  isPropertyDeclaration,
+  isStringLiteralLike,
+  isTypeAliasDeclaration,
+  isTypeLiteralNode,
+  isTypeReferenceNode,
+  isVariableStatement,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  type Node,
+  type SourceFile
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = resolve(__dirname, '../../..')
+const settingsRoot = resolve(projectRoot, 'src/main/settings')
+const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
+const settingsPaths = {
+  repository: resolve(settingsRoot, 'repository.ts'),
+  providerAccounts: resolve(settingsRoot, 'provider-accounts.ts'),
+  backendResolver: resolve(settingsRoot, 'backend-resolver.ts'),
+  responsesBridge: resolve(settingsRoot, 'responses-bridge.ts'),
+  service: resolve(settingsRoot, 'service.ts'),
+  types: resolve(settingsRoot, 'types.ts')
+} as const
+
+const sourceCache = new Map<string, string>()
+const readSource = (path: string): string => {
+  const cached = sourceCache.get(path)
+  if (cached) return cached
+  const source = readFileSync(path, 'utf8')
+  sourceCache.set(path, source)
+  return source
+}
+const rawLineCount = (source: string): number =>
+  source.split(/\r?\n/).length - Number(source.endsWith('\n'))
+const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
+const portableProjectPath = (path: string): string =>
+  relative(projectRoot, path).replaceAll('\\', '/')
+const sourceFileCache = new Map<string, SourceFile>()
+const sourceFileFor = (path: string): SourceFile => {
+  const cached = sourceFileCache.get(path)
+  if (cached) return cached
+  const sourceFile = createSourceFile(
+    path,
+    readSource(path),
+    ScriptTarget.Latest,
+    true,
+    extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
+  )
+  sourceFileCache.set(path, sourceFile)
+  return sourceFile
+}
+
+const productionSources = (): string[] => {
+  const sources: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isDirectory()) visit(path)
+      else if (
+        ['.ts', '.tsx'].includes(extname(path)) &&
+        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
+      ) {
+        sources.push(path)
+      }
+    }
+  }
+  visit(resolve(projectRoot, 'src'))
+  visit(resolve(projectRoot, 'packages'))
+  return sources.sort()
+}
+
+const importSpecifiersCache = new Map<string, string[]>()
+const importSpecifiersFrom = (sourcePath: string): string[] => {
+  const cached = importSpecifiersCache.get(sourcePath)
+  if (cached) return cached
+  const specifiers: string[] = []
+  const visit = (node: Node): void => {
+    if (
+      (isImportDeclaration(node) || isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text)
+    } else if (isImportTypeNode(node)) {
+      const argument = node.argument
+      if (isLiteralTypeNode(argument) && isStringLiteralLike(argument.literal)) {
+        specifiers.push(argument.literal.text)
+      }
+    } else if (isCallExpression(node)) {
+      const [argument] = node.arguments
+      const isRequire = isIdentifier(node.expression) && node.expression.text === 'require'
+      const isDynamicImport = node.expression.kind === SyntaxKind.ImportKeyword
+      if ((isRequire || isDynamicImport) && argument && isStringLiteralLike(argument)) {
+        specifiers.push(argument.text)
+      }
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFileFor(sourcePath))
+  importSpecifiersCache.set(sourcePath, specifiers)
+  return specifiers
+}
+
+const resolveImportTarget = (sourcePath: string, specifier: string): string | undefined =>
+  specifier.startsWith('.') ? modulePath(resolve(dirname(sourcePath), specifier)) : undefined
+
+const importersOf = (targetPath: string): string[] =>
+  productionSourcePaths
+    .filter((sourcePath) => readSource(sourcePath).includes(basename(modulePath(targetPath))))
+    .filter((sourcePath) =>
+      importSpecifiersFrom(sourcePath).some(
+        (specifier) => resolveImportTarget(sourcePath, specifier) === modulePath(targetPath)
+      )
+    )
+    .map(portableProjectPath)
+
+const constructorSitesFor = (targetPath: string, className: string): string[] =>
+  importersOf(targetPath).flatMap((portablePath) => {
+    const sourcePath = resolve(projectRoot, portablePath)
+    let count = 0
+    const visit = (node: Node): void => {
+      if (
+        isNewExpression(node) &&
+        isIdentifier(node.expression) &&
+        node.expression.text === className
+      ) {
+        count += 1
+      }
+      forEachChild(node, visit)
+    }
+    visit(sourceFileFor(sourcePath))
+    return Array.from({ length: count }, () => portablePath)
+  })
+
+const exportInventoryFrom = (path: string): string[] => {
+  const names: string[] = []
+  const sourceFile = sourceFileFor(path)
+  for (const statement of sourceFile.statements) {
+    if (isExportDeclaration(statement) && statement.exportClause) {
+      if (isNamedExports(statement.exportClause)) {
+        for (const element of statement.exportClause.elements) {
+          names.push(
+            `${statement.isTypeOnly || element.isTypeOnly ? 'type' : 'value'}:${element.name.text}`
+          )
+        }
+      }
+      continue
+    }
+    const exported =
+      canHaveModifiers(statement) &&
+      getModifiers(statement)?.some((modifier) => modifier.kind === SyntaxKind.ExportKeyword)
+    if (!exported) continue
+    if (isInterfaceDeclaration(statement) || isTypeAliasDeclaration(statement)) {
+      names.push(`type:${statement.name.text}`)
+    } else if (
+      isClassDeclaration(statement) ||
+      isEnumDeclaration(statement) ||
+      isFunctionDeclaration(statement)
+    ) {
+      names.push(`value:${statement.name?.text ?? '<anonymous>'}`)
+    } else if (isVariableStatement(statement)) {
+      names.push(
+        ...statement.declarationList.declarations.flatMap((declaration) =>
+          isIdentifier(declaration.name) ? [`value:${declaration.name.text}`] : []
+        )
+      )
+    }
+  }
+  return names.sort()
+}
+
+const publicOperationsOf = (path: string, className: string): string[] => {
+  const sourceFile = sourceFileFor(path)
+  const declaration = sourceFile.statements.find(
+    (statement) => isClassDeclaration(statement) && statement.name?.text === className
+  )
+  if (!declaration || !isClassDeclaration(declaration)) throw new Error(`${className} not found`)
+
+  return declaration.members
+    .flatMap((member) => {
+      const hidden =
+        canHaveModifiers(member) &&
+        getModifiers(member)?.some((modifier) =>
+          [SyntaxKind.PrivateKeyword, SyntaxKind.ProtectedKeyword].includes(modifier.kind)
+        )
+      if (
+        hidden ||
+        (!isMethodDeclaration(member) && !isPropertyDeclaration(member)) ||
+        !isIdentifier(member.name)
+      ) {
+        return []
+      }
+      return [member.name.text]
+    })
+    .sort()
+}
+
+const privatePropertiesOf = (path: string, className: string): string[] => {
+  const sourceFile = sourceFileFor(path)
+  const declaration = sourceFile.statements.find(
+    (statement) => isClassDeclaration(statement) && statement.name?.text === className
+  )
+  if (!declaration || !isClassDeclaration(declaration)) throw new Error(`${className} not found`)
+
+  return declaration.members
+    .flatMap((member) => {
+      const isPrivate =
+        isPropertyDeclaration(member) &&
+        getModifiers(member)?.some((modifier) => modifier.kind === SyntaxKind.PrivateKeyword)
+      return isPrivate && isIdentifier(member.name) ? [member.name.text] : []
+    })
+    .sort()
+}
+
+const typePropertyNames = (path: string, typeName: string): string[] => {
+  const sourceFile = sourceFileFor(path)
+  const declaration = sourceFile.statements.find(
+    (statement) => isTypeAliasDeclaration(statement) && statement.name.text === typeName
+  )
+  if (!declaration || !isTypeAliasDeclaration(declaration)) {
+    throw new Error(`${typeName} is not an object type`)
+  }
+  const typeNode =
+    isTypeReferenceNode(declaration.type) && declaration.type.typeArguments?.[0]
+      ? declaration.type.typeArguments[0]
+      : declaration.type
+  if (!isTypeLiteralNode(typeNode)) {
+    throw new Error(`${typeName} is not an object type`)
+  }
+  return typeNode.members
+    .flatMap((member) => (member.name ? [member.name.getText(sourceFile)] : []))
+    .sort()
+}
+
+type ModuleImpactManifest = {
+  modules: Record<
+    string,
+    {
+      ownerPaths: string[]
+      interfacePaths: string[]
+      consumerModules: string[]
+      testFiles: { owner: string[]; contract: string[]; consumer: string[] }
+      capabilityOverlays: string[]
+      fallbackCapability: string
+    }
+  >
+}
+
+const productionSourcePaths = productionSources()
+
+describe('Settings backend ownership architecture', () => {
+  it('holds the current facade ceilings until their owner cutovers', () => {
+    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(1368)
+    expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(1283)
+    expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1407)
+    expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(1423)
+    expect(rawLineCount(readSource(settingsPaths.service))).toBeLessThanOrEqual(1000)
+  })
+
+  it('locks the stable module export inventories', () => {
+    expect(exportInventoryFrom(settingsPaths.repository)).toEqual([
+      'value:SettingsRepository',
+      'value:sanitizeConnectors',
+      'value:sanitizeCustomMcpServer',
+      'value:sanitizePackageMirror',
+      'value:sanitizeSettings'
+    ])
+    expect(exportInventoryFrom(settingsPaths.providerAccounts)).toEqual([
+      'type:ProviderAccountsModuleOptions',
+      'type:ProviderRuntimeTarget',
+      'type:RuntimeProviderModelSelection',
+      'value:CLAUDE_SHARED_DISCONNECTED_MESSAGE',
+      'value:ProviderAccountsModule',
+      'value:requiresNativeResponsesCompatibility'
+    ])
+    expect(exportInventoryFrom(settingsPaths.backendResolver)).toEqual([
+      'type:AgentBackendConnectorPort',
+      'type:AgentBackendProviderPort',
+      'type:AgentBackendResolutionContext',
+      'type:AgentBackendResolverOptions',
+      'type:AgentBackendRuntimePort',
+      'type:AgentBackendSelection',
+      'type:AgentSpawnConfig',
+      'type:ExplicitAgentBackendTarget',
+      'value:AgentBackendResolver'
+    ])
+    expect(exportInventoryFrom(settingsPaths.responsesBridge)).toEqual([
+      'type:ResponsesBridgeConnection',
+      'type:ResponsesBridgeModelTarget',
+      'type:ResponsesBridgeNamespacedTool',
+      'type:ResponsesBridgeSkillCandidate',
+      'type:ResponsesBridgeSkillInput',
+      'type:ResponsesBridgeTarget',
+      'value:ResponsesBridge',
+      'value:chatUrl',
+      'value:completionToResponse',
+      'value:inputToMessages',
+      'value:responsesToChatRequest',
+      'value:toolsToChat',
+      'value:upstreamErrorMessage'
+    ])
+    expect(exportInventoryFrom(settingsPaths.service)).toEqual([
+      'type:AgentBackendResolutionContext',
+      'type:AgentBackendSelection',
+      'type:CustomServerSecurityChangeGuard',
+      'type:SettingsServiceOptions',
+      'type:UninstallResult',
+      'value:SettingsService',
+      'value:createDefaultSettingsService'
+    ])
+  })
+
+  it('locks repository and provider account facade operations', () => {
+    expect(publicOperationsOf(settingsPaths.repository, 'SettingsRepository')).toEqual([
+      'addComputeGrant',
+      'addCustomServer',
+      'clearCodexInfo',
+      'clearComputeGrants',
+      'clearOpencodeInfo',
+      'deleteProvider',
+      'getSettings',
+      'hasComputeGrant',
+      'listComputeGrants',
+      'markLegacyDataMovePromptDismissed',
+      'markOnboardingComplete',
+      'markPathsNormalized',
+      'removeCustomServer',
+      'setActiveProvider',
+      'setAgentFramework',
+      'setAppIconVariant',
+      'setClaudeInfo',
+      'setClosePreference',
+      'setCodexInfo',
+      'setComputeBookmarks',
+      'setConnectorAutoAllow',
+      'setConnectorDisabled',
+      'setConversationSkillImportEnabled',
+      'setCustomServerEnabled',
+      'setDataRoot',
+      'setDefaultPermissionProfile',
+      'setGitHubToken',
+      'setManualInterpreters',
+      'setNcbiCredentials',
+      'setNotificationsEnabled',
+      'setOpencodeInfo',
+      'setPackageMirror',
+      'setReasoningEffort',
+      'setRuntimeEnablement',
+      'setRuntimeSelection',
+      'setSkillEnabled',
+      'setToolBlocked',
+      'setToolPolicy',
+      'updateClaudeIsolatedCredentialsIfExists',
+      'updateClaudeIsolatedValidationIfKeyMatches',
+      'updateClaudeSharedValidationIfUnchanged',
+      'updateCustomServer',
+      'upsertClaudeIsolatedProvider',
+      'upsertProvider'
+    ])
+    expect(publicOperationsOf(settingsPaths.providerAccounts, 'ProviderAccountsModule')).toEqual([
+      'cancelClaudeIsolatedLogin',
+      'cancelClaudeLogin',
+      'cancelCodexLogin',
+      'deleteProvider',
+      'getClaudeIsolatedStatus',
+      'getClaudeSharedStatus',
+      'isProviderKeyUsable',
+      'loginClaudeShared',
+      'loginIsolatedClaude',
+      'loginIsolatedClaudeBrowser',
+      'loginIsolatedCodex',
+      'logoutClaudeShared',
+      'logoutIsolatedClaude',
+      'logoutIsolatedCodex',
+      'migrateLegacyKeyRefs',
+      'refreshProviderModels',
+      'resolveActiveModel',
+      'resolveProvider',
+      'resolveProviderApiEndpoints',
+      'resolveRuntimeModelCatalog',
+      'resolveRuntimeReasoningEffortProfile',
+      'resolveRuntimeTarget',
+      'setActiveProvider',
+      'toProviderView',
+      'upsertProvider',
+      'validateProvider'
+    ])
+  })
+
+  it('locks backend resolver and Responses bridge facade operations', () => {
+    expect(publicOperationsOf(settingsPaths.backendResolver, 'AgentBackendResolver')).toEqual([
+      'captureConfiguredSelection',
+      'captureExplicitTarget',
+      'resolveActiveBackend',
+      'resolveActiveModelChangeTarget',
+      'resolveActiveReasoningEffort',
+      'resolveActiveSpawnConfig',
+      'resolveExplicitTarget',
+      'resolveSelection'
+    ])
+    expect(publicOperationsOf(settingsPaths.responsesBridge, 'ResponsesBridge')).toEqual([
+      'close',
+      'registerReviewerSession',
+      'registerToolLessSession',
+      'selectSkills',
+      'setModelTarget',
+      'setReasoningEffort',
+      'setTarget',
+      'start',
+      'unregisterReviewerSession',
+      'unregisterToolLessSession'
+    ])
+  })
+
+  it('locks the SettingsService application interface', () => {
+    expect(publicOperationsOf(settingsPaths.service, 'SettingsService')).toEqual(
+      `
+        addCustomServer addManualInterpreter authenticateCustomServer buildCustomServerTemplateExport
+        buildSkillExport cancelClaudeIsolatedLogin cancelClaudeLogin cancelCodexLogin
+        cancelCustomServerAuthentication captureActiveAgentBackendSelection
+        captureActiveExplicitAgentBackendTarget checkEnvironment codexSkillCatalog
+        codexSkillDescriptorsForIds createSkill deleteProvider deleteSkill detectClaude detectCodex
+        detectOpencode dismissLegacyDataMovePrompt getAppIconVariant getClosePreference
+        getComputeBookmarks getConnectorDetail getConnectors getConversationSkillImportEnabled
+        getGitHubTokenStatus getManualInterpreters getNotificationsEnabled getPackageMirror
+        getPreflight getRuntimeEnablement getRuntimeSelection getSettingsView getSkillDetail
+        getStoredSettings importAgentHomeSkills importSkill importSkillArchiveBatch importSkillZip
+        importSkillZipBatch installClaude installCodex installOpencode isEncryptionAvailable
+        isNpmAvailable listAgentHomeSkills listConnectors listSkills listSpecialistSkillCatalog
+        loginClaudeShared loginIsolatedClaude loginIsolatedClaudeBrowser loginIsolatedCodex
+        logoutClaudeShared logoutIsolatedClaude logoutIsolatedCodex markOnboardingComplete
+        markPathsNormalized previewAgentHomeSkill previewCustomServerTemplateExport
+        previewCustomServerTemplateImport previewGitHubSkill previewSkillArchive previewSkillZip
+        provisionedConnectorSkillNames refreshProviderModels removeCustomServer removeGitHubToken
+        removeManualInterpreter resolveActiveModelChangeTarget resolveActiveReasoningEffort
+        resolveAgentBackend resolveExplicitAgentBackend saveCustomServerOAuthState saveGitHubToken
+        scanRepoSkills setActiveProvider setAgentFramework setAppIconVariant setClosePreference
+        setComputeBookmarks setConnectorAutoAllow setConnectorEnabled
+        setConversationSkillImportEnabled setCustomServerAuthenticator setCustomServerEnabled
+        setDataRoot setDefaultPermissionProfile setEnvironmentEnabled setInstallAuthorized
+        setMaterializedCustomSkillNamesProvider setNcbiCredentials setNotificationsEnabled
+        setPackageMirror setReasoningEffort setRuntimeSelection setSkillDeletionGuard setSkillEnabled
+        setToolPermission skillNudgeNamesForIds skillsNeedingForceLoad uninstallClaude uninstallCodex
+        uninstallOpencode updateCustomServer updateSkill upsertProvider validateProvider
+      `
+        .trim()
+        .split(/\s+/)
+        .sort()
+    )
+  })
+
+  it('locks the current production importer graph at the public seams', () => {
+    expect(importersOf(settingsPaths.repository)).toEqual([
+      'src/main/compute/ipc.ts',
+      'src/main/settings/agent-runtime-manager.ts',
+      'src/main/settings/connector-settings.ts',
+      'src/main/settings/notebook-runtime-settings.ts',
+      'src/main/settings/preferences.ts',
+      'src/main/settings/provider-accounts.ts',
+      'src/main/settings/service.ts',
+      'src/main/settings/skill-catalog.ts'
+    ])
+    expect(importersOf(settingsPaths.providerAccounts)).toEqual([
+      'src/main/settings/agent-runtime-manager.ts',
+      'src/main/settings/backend-resolver.ts',
+      'src/main/settings/service.ts'
+    ])
+    expect(importersOf(settingsPaths.backendResolver)).toEqual([
+      'src/main/acp/artifact-code-reconstruction-runner.ts',
+      'src/main/artifacts/code-reconstruction.ts',
+      'src/main/settings/service.ts'
+    ])
+    expect(importersOf(settingsPaths.responsesBridge)).toEqual([
+      'src/main/acp/turn-skill-owner.ts',
+      'src/main/agent-framework/types.ts',
+      'src/main/reviewer/bridge-tools.ts',
+      'src/main/settings/backend-resolver.ts',
+      'src/main/settings/native-responses-compatibility.ts',
+      'src/main/settings/validate.ts'
+    ])
+    expect(importersOf(settingsPaths.service)).toEqual([
+      'src/main/ipc.ts',
+      'src/main/settings/application-commands.ts',
+      'src/main/settings/ipc.ts',
+      'src/main/settings/service-capabilities.ts',
+      'src/main/settings/workflows/appearance.ts',
+      'src/main/settings/workflows/connectors.ts',
+      'src/main/settings/workflows/runtime.ts',
+      'src/main/settings/workflows/skills.ts'
+    ])
+  })
+
+  it('locks the durable Settings shape and secret-free explicit target seam', () => {
+    expect(typePropertyNames(settingsPaths.types, 'StoredSettings')).toEqual([
+      'activeModel',
+      'activeProviderId',
+      'agentFrameworkId',
+      'appIconVariant',
+      'claude',
+      'claudeSubscriptionProviderId',
+      'closePreference',
+      'codex',
+      'computeBookmarks',
+      'computeGrants',
+      'connectors',
+      'conversationSkillImportEnabled',
+      'dataRoot',
+      'defaultPermissionProfile',
+      'disabledSkillIds',
+      'githubTokenMask',
+      'githubTokenRef',
+      'legacyDataMovePromptDismissedAt',
+      'notebookManualInterpreters',
+      'notebookRuntimeEnablement',
+      'notebookRuntimes',
+      'notificationsEnabled',
+      'onboardingCompletedAt',
+      'opencodePath',
+      'opencodeVersion',
+      'packageMirror',
+      'pathsNormalizedAt',
+      'providers',
+      'reasoningEffort',
+      'version'
+    ])
+    expect(typePropertyNames(settingsPaths.types, 'StoredProvider')).toEqual([
+      'apiEndpoints',
+      'baseUrl',
+      'codexAuthMode',
+      'contextWindow',
+      'disconnectedAt',
+      'expiresAt',
+      'fetchedModels',
+      'id',
+      'keyMask',
+      'keyRef',
+      'lastValidatedAt',
+      'lastValidationFailure',
+      'model',
+      'name',
+      'reasoningEffortPreset',
+      'reasoningEffortTransport',
+      'region',
+      'supportsImageInput',
+      'type',
+      'vendorId'
+    ])
+    expect(typePropertyNames(settingsPaths.backendResolver, 'ExplicitAgentBackendTarget')).toEqual([
+      'frameworkId',
+      'model',
+      'providerId',
+      'reasoningEffort'
+    ])
+  })
+
+  it('characterizes the same-root, independently queued repository composition before D3', () => {
+    expect(constructorSitesFor(settingsPaths.repository, 'SettingsRepository')).toEqual([
+      'src/main/compute/ipc.ts',
+      'src/main/settings/service.ts'
+    ])
+    expect(privatePropertiesOf(settingsPaths.repository, 'SettingsRepository')).toEqual(
+      expect.arrayContaining(['saveQueue', 'writeSequence'])
+    )
+    expect(readSource(resolve(projectRoot, 'src/main/compute/ipc.ts'))).toContain(
+      'const storageRoot = resolveStorageRoot()'
+    )
+    expect(readSource(resolve(projectRoot, 'src/main/compute/ipc.ts'))).toContain(
+      'new SettingsRepository(storageRoot)'
+    )
+    expect(readSource(settingsPaths.service)).toContain(
+      'this.storageRoot = options.storageRoot ?? resolveStorageRoot()'
+    )
+    expect(readSource(settingsPaths.service)).toContain('new SettingsRepository(this.storageRoot)')
+  })
+
+  it('locks dependency-aware impact owners and cross-surface evidence', () => {
+    const manifest = JSON.parse(readSource(manifestPath)) as ModuleImpactManifest
+    expect(manifest.modules.settings_repository.ownerPaths).toEqual([
+      'src/main/settings/repository.ts'
+    ])
+    expect(manifest.modules.settings_provider_accounts.ownerPaths).toEqual([
+      'src/main/settings/provider-accounts.ts'
+    ])
+    expect(manifest.modules.settings_backend_resolution.ownerPaths).toEqual([
+      'src/main/settings/backend-resolver.ts',
+      'src/main/settings/responses-bridge.ts'
+    ])
+    expect(manifest.modules.settings_service_facade.interfacePaths).toEqual([
+      'src/main/settings/service.ts',
+      'src/main/settings/application-commands.ts',
+      'src/main/settings/runtime-application-commands.ts',
+      'src/main/settings/integration-application-commands.ts',
+      'src/main/settings/ipc.ts'
+    ])
+    expect(manifest.modules.settings_repository.consumerModules).toEqual([
+      'settings_provider_accounts',
+      'settings_service_facade',
+      'compute_service'
+    ])
+    expect(manifest.modules.settings_provider_accounts.consumerModules).toEqual([
+      'settings_backend_resolution',
+      'settings_service_facade'
+    ])
+    expect(manifest.modules.settings_backend_resolution.consumerModules).toEqual([
+      'settings_service_facade',
+      'reviewer_orchestrator',
+      'artifact_provenance'
+    ])
+    expect(manifest.modules.settings_service_facade.consumerModules).toEqual(['workspace_runtime'])
+    expect(manifest.modules.settings_service_facade.testFiles.contract).toEqual(
+      expect.arrayContaining([
+        'src/main/settings/application-commands.test.ts',
+        'src/main/settings/runtime-application-commands.test.ts',
+        'src/main/settings/integration-application-commands.test.ts',
+        'src/main/settings/ipc.test.ts',
+        'src/shared/renderer-contract-catalog.test.ts',
+        'src/preload/electron-renderer-contract-adapter.test.ts',
+        'src/renderer/web/api-installer.test.ts'
+      ])
+    )
+    expect(manifest.modules.settings_backend_resolution.testFiles.consumer).toEqual(
+      expect.arrayContaining([
+        'packages/open-science/cli.test.ts',
+        'src/main/acp/artifact-code-reconstruction-runner.test.ts',
+        'src/main/acp/task-agent-port.test.ts',
+        'src/main/acp/turn-skill-owner.test.ts',
+        'src/main/artifacts/code-reconstruction.test.ts',
+        'src/main/notebook/local-rpc-server.mcpcall.test.ts',
+        'src/main/reviewer/mcp-server.test.ts'
+      ])
+    )
+  })
+})


### PR DESCRIPTION
## Problem

Settings persistence, provider-account management, backend resolution, and the Settings service facade currently live in large modules without explicit ownership or downstream test-routing contracts. Changes to these seams can therefore fall back to the full suite or omit consumers whose compatibility depends on them.

## Proposed change

- Define four Settings modules in `scripts/ci/module-impact.json`: repository, provider accounts, backend resolution, and service facade.
- Route each module through its direct consumers, including Compute, Reviewer, artifact reconstruction/provenance, Workspace runtime, CLI, Task, Notebook RPC, preload, Web, and renderer Settings surfaces.
- Add an architecture contract that locks current exports, importers, public operations, `SettingsService` methods, persisted field shapes, credential-free explicit backend targets, and the current same-root/per-instance repository write-queue baseline.
- Add explicit CLI and Notebook local-RPC negative contracts for Settings capabilities those surfaces do not currently expose.

## Scope and non-goals

This is the S0 characterization and impact-routing baseline only. It changes zero production lines and does not move owners, alter persistence, resolve the repository write race, add cross-surface capabilities, or change public/IPC/data/UI behavior. Subsequent D/P/R extraction PRs will build on these contracts.

## Compatibility

The contracts preserve the existing Electron/Web/CLI/Task/local-RPC/MCP capability boundaries and the current Specialist/Permission/Compute asymmetry. They lock stable exports and import relationships, the durable `StoredSettings`/`StoredProvider` shapes, masked credential behavior, and the credential-free explicit backend target. Test paths use repository-relative paths or `process.cwd()` and remain portable across Windows, macOS, and Linux.

## Acceptance criteria and validation

- Production raw change: 0 lines; new architecture contract: 656 lines, within the approved 660 ceiling.
- Focused contract/impact tests: 4 files, 45 tests passed.
- Notebook local-RPC contract: 1 file, 23 tests passed.
- Selective module plans passed: repository 14 files/482 tests; provider accounts 16/302; backend resolution 19 passed + 1 skipped files/359 passed + 3 skipped tests; service facade 22/557.
- Typecheck passed; lint passed with 17 pre-existing warnings; Prettier and `git diff --check` passed.
- Independent Standards review: 0 findings. Independent Spec review: 0 findings.
- Local default-concurrency full fallback passed 872 files/12,737 tests and exposed 11 failures dominated by the shared 15-second timeout budget. A low-concurrency rerun reduced those to four timeouts; the remaining three unchanged files then passed with one worker and a command-only timeout override (3 files/134 tests). No unrelated timeout budgets were changed.
- Exact-head GitHub CI and published AI review must be green/mergeable before squash merge.

## Review focus

Please focus on whether dependency edges match actual production consumers, whether the architecture contract protects stable seams instead of implementation detail, whether Electron/Web/CLI/Task/Notebook compatibility boundaries are represented accurately, and whether any path or test assumption is platform-specific.
