### PR TITLE
refactor(settings): extract record codec

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -211,7 +211,7 @@
       "fallbackCapability": "main_runtime"
     },
     "settings_repository": {
-      "ownerPaths": ["src/main/settings/repository.ts"],
+      "ownerPaths": ["src/main/settings/repository.ts", "src/main/settings/record-codec.ts"],
       "interfacePaths": ["src/main/settings/repository.ts"],
       "consumerModules": [
         "settings_provider_accounts",
@@ -221,6 +221,7 @@
       "testFiles": {
         "owner": [
           "src/main/settings/settings-backend.architecture.test.ts",
+          "src/main/settings/record-codec.test.ts",
           "src/main/settings/repository.test.ts",
           "src/main/settings/compute-grants.test.ts",
           "src/main/settings/connectors-settings.test.ts",

--- a/src/main/settings/record-codec.test.ts
+++ b/src/main/settings/record-codec.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  sanitizeClaudeInfo,
+  sanitizeCodexInfo,
+  sanitizeComputeGrant,
+  sanitizeProvider
+} from './record-codec'
+
+describe('settings record codec', () => {
+  it('keeps the private owner interface explicit', async () => {
+    expect(Object.keys(await import('./record-codec')).sort()).toEqual([
+      'sanitizeClaudeInfo',
+      'sanitizeCodexInfo',
+      'sanitizeComputeGrant',
+      'sanitizeConnectors',
+      'sanitizeCustomMcpServer',
+      'sanitizePackageMirror',
+      'sanitizeProvider'
+    ])
+  })
+
+  it('rebuilds provider records from known fields without exposing plaintext credentials', () => {
+    expect(
+      sanitizeProvider({
+        id: 'provider-1',
+        type: 'custom',
+        name: 'Gateway',
+        baseUrl: 'https://example.test/v1',
+        model: 'model-1',
+        apiEndpoints: ['responses', 'responses', 'unknown'],
+        contextWindow: 128_000,
+        keyRef: 'encrypted:key',
+        keyMask: 'sk-…abcd',
+        apiKey: 'plaintext-must-not-survive',
+        unknown: true
+      })
+    ).toEqual({
+      id: 'provider-1',
+      type: 'custom',
+      name: 'Gateway',
+      baseUrl: 'https://example.test/v1',
+      model: 'model-1',
+      apiEndpoints: ['responses'],
+      contextWindow: 128_000,
+      keyRef: 'encrypted:key',
+      keyMask: 'sk-…abcd'
+    })
+  })
+
+  it('rejects unusable provider identities and invalid compute grants', () => {
+    expect(sanitizeProvider({ id: 'official', type: 'official', name: 'Unknown' })).toBeUndefined()
+    expect(sanitizeProvider({ id: 'provider-1', type: 'removed', name: 'Old' })).toBeUndefined()
+    expect(
+      sanitizeComputeGrant({ projectId: 'p1', operation: 'download', providerId: 'c1' })
+    ).toEqual({
+      projectId: 'p1',
+      operation: 'download',
+      providerId: 'c1'
+    })
+    expect(
+      sanitizeComputeGrant({ projectId: 'p1', operation: 42, providerId: 'c1' })
+    ).toBeUndefined()
+  })
+
+  it('keeps only recognized Claude and Codex metadata fields', () => {
+    expect(
+      sanitizeClaudeInfo({ resolvedPath: 'claude-bin', version: '1.0.0', ignored: true })
+    ).toEqual({ resolvedPath: 'claude-bin', version: '1.0.0' })
+    expect(
+      sanitizeCodexInfo({
+        resolvedPath: 'codex-bin',
+        version: '2.0.0',
+        nativePath: 'native-codex-bin',
+        nativeVersion: '2.0.1',
+        ignored: true
+      })
+    ).toEqual({
+      resolvedPath: 'codex-bin',
+      version: '2.0.0',
+      nativePath: 'native-codex-bin',
+      nativeVersion: '2.0.1'
+    })
+  })
+})

--- a/src/main/settings/record-codec.ts
+++ b/src/main/settings/record-codec.ts
@@ -1,0 +1,325 @@
+import type {
+  ChatApiEndpoint,
+  ClaudeInfo,
+  ProviderType,
+  ProviderValidationFailure,
+  ValidationCategory
+} from '../../shared/settings'
+import { isCodexSubscriptionProvider } from '../../shared/settings'
+import { isCustomConnectorSlug } from '../../shared/custom-connector'
+import type { PackageMirror } from '../../shared/mirror'
+import { isOfficialVendorId } from '../../shared/provider-registry'
+import {
+  isCustomReasoningEffortTransport,
+  isReasoningEffortPresetSetting
+} from '../../shared/reasoning-effort'
+import { createLogger } from '../logger'
+import type {
+  StoredComputeGrant,
+  StoredConnectors,
+  StoredCodexInfo,
+  StoredCustomMcpServer,
+  StoredProvider
+} from './types'
+
+const log = createLogger('settings.repository')
+
+const PROVIDER_TYPES = new Set<ProviderType>([
+  'custom',
+  'claude-shared',
+  'claude-isolated',
+  'official',
+  'codex-shared',
+  'codex-isolated'
+])
+
+const VALIDATION_CATEGORIES = new Set<ValidationCategory>([
+  'ok',
+  'network',
+  'auth',
+  'model-not-found',
+  'bad-url',
+  'timeout',
+  'incompatible',
+  'server-error',
+  'unknown'
+])
+
+const CUSTOM_MCP_TRANSPORTS = new Set<StoredCustomMcpServer['transport']>([
+  'stdio',
+  'streamable_http',
+  'sse'
+])
+
+// Treat only plain JSON objects as records before rebuilding durable values.
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+
+const asBoolean = (value: unknown): boolean | undefined =>
+  typeof value === 'boolean' ? value : undefined
+
+// Drop non-string values so environment and header maps cannot retain untrusted shapes.
+const asStringRecord = (value: unknown): Record<string, string> | undefined => {
+  if (!isRecord(value)) return undefined
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string'
+  )
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined
+}
+
+// Rebuild runtime metadata from allowed fields only.
+export const sanitizeClaudeInfo = (value: unknown): ClaudeInfo | undefined => {
+  if (!isRecord(value)) return undefined
+  const info: ClaudeInfo = {}
+  const resolvedPath = asString(value.resolvedPath)
+  const version = asString(value.version)
+  if (resolvedPath) info.resolvedPath = resolvedPath
+  if (version) info.version = version
+  return Object.keys(info).length > 0 ? info : undefined
+}
+
+// Rebuild runtime metadata from allowed fields only.
+export const sanitizeCodexInfo = (value: unknown): StoredCodexInfo | undefined => {
+  if (!isRecord(value)) return undefined
+  const info: StoredCodexInfo = {}
+  const resolvedPath = asString(value.resolvedPath)
+  const version = asString(value.version)
+  const nativePath = asString(value.nativePath)
+  const nativeVersion = asString(value.nativeVersion)
+  if (resolvedPath) info.resolvedPath = resolvedPath
+  if (version) info.version = version
+  if (nativePath) info.nativePath = nativePath
+  if (nativeVersion) info.nativeVersion = nativeVersion
+  return Object.keys(info).length > 0 ? info : undefined
+}
+
+// A recorded failure is valid only with a timestamp and known category.
+const sanitizeValidationFailure = (value: unknown): ProviderValidationFailure | undefined => {
+  if (!isRecord(value)) return undefined
+  const at = asNumber(value.at)
+  const category = asString(value.category) as ValidationCategory | undefined
+  if (at === undefined || !category || !VALIDATION_CATEGORIES.has(category)) return undefined
+  const failure: ProviderValidationFailure = { at, category }
+  const status = asNumber(value.status)
+  const message = asString(value.message)
+  if (status !== undefined) failure.status = status
+  if (message) failure.message = message
+  return failure
+}
+
+// Rebuild one provider from known fields and durable credential references only.
+export const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
+  if (!isRecord(value)) return undefined
+  const id = asString(value.id)
+  const type = asString(value.type) as ProviderType | undefined
+  const name = asString(value.name)
+  if (!id || !type || name === undefined) return undefined
+  if (!PROVIDER_TYPES.has(type)) {
+    log.warn('dropping stored provider with unknown type', { id, type })
+    return undefined
+  }
+  // Official providers require a known catalog owner and cannot run without one.
+  const vendorId = isOfficialVendorId(value.vendorId) ? value.vendorId : undefined
+  if (type === 'official' && !vendorId) return undefined
+
+  const provider: StoredProvider = { id, type, name }
+  const baseUrl = asString(value.baseUrl)
+  const model = asString(value.model)
+  const rawContextWindow = asNumber(value.contextWindow)
+  const contextWindow =
+    rawContextWindow !== undefined && Number.isSafeInteger(rawContextWindow) && rawContextWindow > 0
+      ? rawContextWindow
+      : undefined
+  const supportsImageInput = asBoolean(value.supportsImageInput)
+  const reasoningEffortPreset = isReasoningEffortPresetSetting(value.reasoningEffortPreset)
+    ? value.reasoningEffortPreset
+    : undefined
+  const reasoningEffortTransport = isCustomReasoningEffortTransport(value.reasoningEffortTransport)
+    ? value.reasoningEffortTransport
+    : undefined
+  const region = asString(value.region)
+  const keyRef = asString(value.keyRef)
+  const keyMask = asString(value.keyMask)
+  const lastValidatedAt = asNumber(value.lastValidatedAt)
+  const lastValidationFailure = sanitizeValidationFailure(value.lastValidationFailure)
+  const expiresAt = asNumber(value.expiresAt)
+  const disconnectedAt = asNumber(value.disconnectedAt)
+  const codexAuthMode = asString(value.codexAuthMode)
+  // Keep only non-empty model ids from persisted discovery results.
+  const fetchedModels = Array.isArray(value.fetchedModels)
+    ? value.fetchedModels.filter(
+        (entry): entry is string => typeof entry === 'string' && entry !== ''
+      )
+    : undefined
+
+  // Migrate the removed scalar apiType to the explicit endpoint array.
+  const rawEndpoints = Array.isArray(value.apiEndpoints) ? value.apiEndpoints : []
+  const knownEndpoints = rawEndpoints.filter(
+    (entry): entry is ChatApiEndpoint =>
+      entry === 'anthropic' || entry === 'openai' || entry === 'responses'
+  )
+  const legacyApiType = asString(value.apiType)
+  const apiEndpoints: ChatApiEndpoint[] =
+    knownEndpoints.length > 0
+      ? [...new Set(knownEndpoints)]
+      : legacyApiType === 'both'
+        ? ['anthropic', 'openai']
+        : legacyApiType === 'anthropic' ||
+            legacyApiType === 'openai' ||
+            legacyApiType === 'responses'
+          ? [legacyApiType]
+          : []
+
+  if (baseUrl) provider.baseUrl = baseUrl
+  if (model) provider.model = model
+  if (contextWindow !== undefined) provider.contextWindow = contextWindow
+  if (supportsImageInput !== undefined) provider.supportsImageInput = supportsImageInput
+  if (reasoningEffortPreset !== undefined && type === 'custom') {
+    provider.reasoningEffortPreset = reasoningEffortPreset
+  }
+  if (reasoningEffortTransport !== undefined && type === 'custom') {
+    provider.reasoningEffortTransport = reasoningEffortTransport
+  }
+  if (apiEndpoints.length > 0) provider.apiEndpoints = apiEndpoints
+  if (vendorId) provider.vendorId = vendorId
+  if (region) provider.region = region
+  if (fetchedModels && fetchedModels.length > 0) provider.fetchedModels = fetchedModels
+  if (keyRef) provider.keyRef = keyRef
+  if (keyMask) provider.keyMask = keyMask
+  if (lastValidatedAt !== undefined) provider.lastValidatedAt = lastValidatedAt
+  if (lastValidationFailure) provider.lastValidationFailure = lastValidationFailure
+  if (expiresAt !== undefined) provider.expiresAt = expiresAt
+  if (disconnectedAt !== undefined && type === 'claude-shared') {
+    provider.disconnectedAt = disconnectedAt
+  }
+  if (
+    isCodexSubscriptionProvider(type) &&
+    (codexAuthMode === 'imported' || codexAuthMode === 'isolated')
+  ) {
+    provider.codexAuthMode = codexAuthMode
+  }
+  return provider
+}
+
+// Rebuild one custom MCP server, enforcing the transport-specific command/url requirement.
+export const sanitizeCustomMcpServer = (value: unknown): StoredCustomMcpServer | undefined => {
+  if (!isRecord(value)) return undefined
+  const id = asString(value.id)
+  const name = asString(value.name)
+  const transport = asString(value.transport) as StoredCustomMcpServer['transport'] | undefined
+  const enabled = asBoolean(value.enabled)
+  if (
+    !id ||
+    !name ||
+    !transport ||
+    !CUSTOM_MCP_TRANSPORTS.has(transport) ||
+    enabled === undefined
+  ) {
+    return undefined
+  }
+  const command = asString(value.command)
+  const url = asString(value.url)
+  if (transport === 'stdio' && !command) return undefined
+  if ((transport === 'streamable_http' || transport === 'sse') && !url) return undefined
+
+  const storedSlug = asString(value.slug)
+  const server: StoredCustomMcpServer = { id, name, transport, enabled }
+  if (storedSlug && isCustomConnectorSlug(storedSlug)) server.slug = storedSlug
+  if (command) server.command = command
+  const args = asStringArray(value.args)
+  if (args.length) server.args = args
+  const env = asStringRecord(value.env)
+  if (env) server.env = env
+  const envRefs = asStringRecord(value.envRefs)
+  if (envRefs) server.envRefs = envRefs
+  if (url) server.url = url
+  const headers = asStringRecord(value.headers)
+  if (headers) server.headers = headers
+  const headerRefs = asStringRecord(value.headerRefs)
+  if (headerRefs) server.headerRefs = headerRefs
+  if (transport !== 'stdio' && isRecord(value.oauth)) {
+    const oauth: NonNullable<StoredCustomMcpServer['oauth']> = {}
+    const clientMetadataUrl = asString(value.oauth.clientMetadataUrl)
+    const authorizationServerUrl = asString(value.oauth.authorizationServerUrl)
+    const scopes = asStringArray(value.oauth.scopes)
+      .map((scope) => scope.trim())
+      .filter(Boolean)
+    if (clientMetadataUrl) oauth.clientMetadataUrl = clientMetadataUrl
+    if (authorizationServerUrl) oauth.authorizationServerUrl = authorizationServerUrl
+    if (scopes.length) oauth.scopes = [...new Set(scopes)]
+    server.oauth = oauth
+  }
+  const oauthRef = asString(value.oauthRef)
+  if (server.oauth) {
+    delete server.headers
+    delete server.headerRefs
+    if (oauthRef) server.oauthRef = oauthRef
+  }
+  const trustedAt = asNumber(value.trustedAt)
+  if (trustedAt !== undefined) server.trustedAt = trustedAt
+  const description = asString(value.description)
+  if (description) server.description = description
+  return server
+}
+
+// Drop compute grants without all three identity fields.
+export const sanitizeComputeGrant = (value: unknown): StoredComputeGrant | undefined => {
+  if (!isRecord(value)) return undefined
+  const projectId = asString(value.projectId)
+  const operation = asString(value.operation)
+  const providerId = asString(value.providerId)
+  if (!projectId || !operation || !providerId) return undefined
+  return { projectId, operation, providerId }
+}
+
+// Rebuild the connector policy block and its nested custom MCP records.
+export const sanitizeConnectors = (value: unknown): StoredConnectors | undefined => {
+  if (!isRecord(value)) return undefined
+  const connectors: StoredConnectors = {
+    enabledIds: asStringArray(value.enabledIds),
+    autoAllowIds: asStringArray(value.autoAllowIds)
+  }
+  const contactEmail = asString(value.contactEmail)
+  const ncbiApiKeyRef = asString(value.ncbiApiKeyRef)
+  if (contactEmail) connectors.contactEmail = contactEmail
+  if (ncbiApiKeyRef) connectors.ncbiApiKeyRef = ncbiApiKeyRef
+  const blockedToolIds = asStringArray(value.blockedToolIds)
+  if (blockedToolIds.length) connectors.blockedToolIds = blockedToolIds
+  const askToolIds = asStringArray(value.askToolIds)
+  if (askToolIds.length) connectors.askToolIds = askToolIds
+  const disabledConnectorIds = asStringArray(value.disabledConnectorIds)
+  if (disabledConnectorIds.length) {
+    connectors.disabledConnectorIds = [...new Set(disabledConnectorIds)]
+  }
+  const customMcpServers = Array.isArray(value.customMcpServers)
+    ? value.customMcpServers
+        .map(sanitizeCustomMcpServer)
+        .filter((server): server is StoredCustomMcpServer => !!server)
+    : []
+  if (customMcpServers.length) connectors.customMcpServers = customMcpServers
+  return connectors
+}
+
+// An absent or empty mirror means the public-host defaults remain active.
+export const sanitizePackageMirror = (value: unknown): PackageMirror | undefined => {
+  if (!isRecord(value)) return undefined
+  const condaChannel = asString(value.condaChannel)
+  const pypiIndex = asString(value.pypiIndex)
+  const cranMirror = asString(value.cranMirror)
+  const caBundle = asString(value.caBundle)
+  const result: PackageMirror = {}
+  if (condaChannel) result.condaChannel = condaChannel
+  if (pypiIndex) result.pypiIndex = pypiIndex
+  if (cranMirror) result.cranMirror = cranMirror
+  if (caBundle) result.caBundle = caBundle
+  return Object.keys(result).length > 0 ? result : undefined
+}

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -5,13 +5,9 @@ import { isDeepStrictEqual } from 'node:util'
 import type {
   AgentFrameworkId,
   AppIconVariant,
-  ChatApiEndpoint,
   ClaudeSubscriptionProviderId,
   ClaudeInfo,
-  ProviderType,
-  ProviderValidationFailure,
-  ReasoningEffort,
-  ValidationCategory
+  ReasoningEffort
 } from '../../shared/settings'
 import {
   CLAUDE_ISOLATED_PROVIDER_ID,
@@ -27,18 +23,12 @@ import {
   isCodexSubscriptionProviderId,
   isReasoningEffort
 } from '../../shared/settings'
-import { isOfficialVendorId } from '../../shared/provider-registry'
 import { isPermissionProfileId, type PermissionProfileId } from '../../shared/permission-profiles'
-import {
-  isCustomReasoningEffortTransport,
-  isReasoningEffortPresetSetting
-} from '../../shared/reasoning-effort'
 import type { PackageMirror } from '../../shared/mirror'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
 import type { CloseActionPreference } from '../../shared/window-controls'
-import { customConnectorSlug, isCustomConnectorSlug } from '../../shared/custom-connector'
-import { createLogger } from '../logger'
+import { customConnectorSlug } from '../../shared/custom-connector'
 import {
   createEmptySettings,
   type StoredComputeGrant,
@@ -48,31 +38,16 @@ import {
   type StoredProvider,
   type StoredSettings
 } from './types'
+import {
+  sanitizeClaudeInfo,
+  sanitizeCodexInfo,
+  sanitizeComputeGrant,
+  sanitizeConnectors,
+  sanitizePackageMirror,
+  sanitizeProvider
+} from './record-codec'
 
 const SETTINGS_FILE = 'settings.json'
-
-const log = createLogger('settings.repository')
-
-const PROVIDER_TYPES = new Set<ProviderType>([
-  'custom',
-  'claude-shared',
-  'claude-isolated',
-  'official',
-  'codex-shared',
-  'codex-isolated'
-])
-
-const VALIDATION_CATEGORIES = new Set<ValidationCategory>([
-  'ok',
-  'network',
-  'auth',
-  'model-not-found',
-  'bad-url',
-  'timeout',
-  'incompatible',
-  'server-error',
-  'unknown'
-])
 
 // Checks for plain JSON objects so untrusted settings payloads can be sanitized safely.
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -90,18 +65,6 @@ const asStringArray = (value: unknown): string[] =>
 const asBoolean = (value: unknown): boolean | undefined =>
   typeof value === 'boolean' ? value : undefined
 
-// Rebuilds a record<string,string>, dropping any key whose value isn't a string. Returns undefined
-// for a non-record input or when nothing survives.
-const asStringRecord = (value: unknown): Record<string, string> | undefined => {
-  if (!isRecord(value)) return undefined
-
-  const entries = Object.entries(value).filter(
-    (entry): entry is [string, string] => typeof entry[1] === 'string'
-  )
-
-  return entries.length > 0 ? Object.fromEntries(entries) : undefined
-}
-
 // Rebuilds a record<string,boolean>, dropping any key whose value isn't a boolean. Returns an empty
 // record (never undefined) for a non-record input so callers get a stable, always-mergeable map.
 const asBooleanRecord = (value: unknown): Record<string, boolean> => {
@@ -112,293 +75,6 @@ const asBooleanRecord = (value: unknown): Record<string, boolean> => {
   )
 
   return Object.fromEntries(entries)
-}
-
-const CUSTOM_MCP_TRANSPORTS = new Set<StoredCustomMcpServer['transport']>([
-  'stdio',
-  'streamable_http',
-  'sse'
-])
-
-// Rebuilds claude metadata from allowed fields only.
-const sanitizeClaudeInfo = (value: unknown): ClaudeInfo | undefined => {
-  if (!isRecord(value)) return undefined
-
-  const info: ClaudeInfo = {}
-  const resolvedPath = asString(value.resolvedPath)
-  const version = asString(value.version)
-
-  if (resolvedPath) info.resolvedPath = resolvedPath
-  if (version) info.version = version
-
-  return Object.keys(info).length > 0 ? info : undefined
-}
-
-const sanitizeCodexInfo = (value: unknown): StoredCodexInfo | undefined => {
-  if (!isRecord(value)) return undefined
-
-  const info: StoredCodexInfo = {}
-  const resolvedPath = asString(value.resolvedPath)
-  const version = asString(value.version)
-  const nativePath = asString(value.nativePath)
-  const nativeVersion = asString(value.nativeVersion)
-
-  if (resolvedPath) info.resolvedPath = resolvedPath
-  if (version) info.version = version
-  if (nativePath) info.nativePath = nativePath
-  if (nativeVersion) info.nativeVersion = nativeVersion
-
-  return Object.keys(info).length > 0 ? info : undefined
-}
-
-// Rebuilds a recorded validation failure, dropping it unless it has a numeric timestamp and a known
-// category (status/message are optional). Without this the field would be stripped on every read.
-const sanitizeValidationFailure = (value: unknown): ProviderValidationFailure | undefined => {
-  if (!isRecord(value)) return undefined
-
-  const at = asNumber(value.at)
-  const category = asString(value.category) as ValidationCategory | undefined
-
-  if (at === undefined || !category || !VALIDATION_CATEGORIES.has(category)) return undefined
-
-  const failure: ProviderValidationFailure = { at, category }
-  const status = asNumber(value.status)
-  const message = asString(value.message)
-
-  if (status !== undefined) failure.status = status
-  if (message) failure.message = message
-
-  return failure
-}
-
-// Rebuilds one provider record, dropping unknown fields and records missing required identity.
-// An unknown `type` is dropped at load time and logged at WARN — usually a stale provider kind from a
-// prior version (e.g. the removed 'claude-default'). A bad value must never reach the active snapshot.
-const sanitizeProvider = (value: unknown): StoredProvider | undefined => {
-  if (!isRecord(value)) return undefined
-
-  const id = asString(value.id)
-  const type = asString(value.type) as ProviderType | undefined
-  const name = asString(value.name)
-
-  if (!id || !type || name === undefined) return undefined
-
-  if (!PROVIDER_TYPES.has(type)) {
-    log.warn('dropping stored provider with unknown type', { id, type })
-
-    return undefined
-  }
-
-  // An official provider without a recognizable vendor is unusable (no base URL/catalog to resolve),
-  // so drop the corrupt record rather than keep a provider that can never spawn or validate.
-  const vendorId = isOfficialVendorId(value.vendorId) ? value.vendorId : undefined
-
-  if (type === 'official' && !vendorId) return undefined
-
-  const provider: StoredProvider = { id, type, name }
-  const baseUrl = asString(value.baseUrl)
-  const model = asString(value.model)
-  const rawContextWindow = asNumber(value.contextWindow)
-  const contextWindow =
-    rawContextWindow !== undefined && Number.isSafeInteger(rawContextWindow) && rawContextWindow > 0
-      ? rawContextWindow
-      : undefined
-  const supportsImageInput = asBoolean(value.supportsImageInput)
-  const reasoningEffortPreset = isReasoningEffortPresetSetting(value.reasoningEffortPreset)
-    ? value.reasoningEffortPreset
-    : undefined
-  const reasoningEffortTransport = isCustomReasoningEffortTransport(value.reasoningEffortTransport)
-    ? value.reasoningEffortTransport
-    : undefined
-  const region = asString(value.region)
-  const keyRef = asString(value.keyRef)
-  const keyMask = asString(value.keyMask)
-  const lastValidatedAt = asNumber(value.lastValidatedAt)
-  const lastValidationFailure = sanitizeValidationFailure(value.lastValidationFailure)
-  const expiresAt = asNumber(value.expiresAt)
-  const disconnectedAt = asNumber(value.disconnectedAt)
-  const codexAuthMode = asString(value.codexAuthMode)
-  // Keep only a clean list of non-empty string model ids.
-  const fetchedModels = Array.isArray(value.fetchedModels)
-    ? value.fetchedModels.filter(
-        (entry): entry is string => typeof entry === 'string' && entry !== ''
-      )
-    : undefined
-
-  // Resolve the provider's chat endpoints, migrating the removed scalar `apiType` on legacy records
-  // ('both' meant anthropic+openai) to the explicit array. Only known endpoint values survive.
-  const rawEndpoints = Array.isArray(value.apiEndpoints) ? value.apiEndpoints : []
-  const knownEndpoints = rawEndpoints.filter(
-    (entry): entry is ChatApiEndpoint =>
-      entry === 'anthropic' || entry === 'openai' || entry === 'responses'
-  )
-  const legacyApiType = asString(value.apiType)
-  const apiEndpoints: ChatApiEndpoint[] =
-    knownEndpoints.length > 0
-      ? [...new Set(knownEndpoints)]
-      : legacyApiType === 'both'
-        ? ['anthropic', 'openai']
-        : legacyApiType === 'anthropic' ||
-            legacyApiType === 'openai' ||
-            legacyApiType === 'responses'
-          ? [legacyApiType]
-          : []
-
-  if (baseUrl) provider.baseUrl = baseUrl
-  if (model) provider.model = model
-  if (contextWindow !== undefined) provider.contextWindow = contextWindow
-  if (supportsImageInput !== undefined) provider.supportsImageInput = supportsImageInput
-  if (reasoningEffortPreset !== undefined && type === 'custom') {
-    provider.reasoningEffortPreset = reasoningEffortPreset
-  }
-  if (reasoningEffortTransport !== undefined && type === 'custom') {
-    provider.reasoningEffortTransport = reasoningEffortTransport
-  }
-  if (apiEndpoints.length > 0) provider.apiEndpoints = apiEndpoints
-  if (vendorId) provider.vendorId = vendorId
-  if (region) provider.region = region
-  if (fetchedModels && fetchedModels.length > 0) provider.fetchedModels = fetchedModels
-  if (keyRef) provider.keyRef = keyRef
-  if (keyMask) provider.keyMask = keyMask
-  if (lastValidatedAt !== undefined) provider.lastValidatedAt = lastValidatedAt
-  if (lastValidationFailure) provider.lastValidationFailure = lastValidationFailure
-  if (expiresAt !== undefined) provider.expiresAt = expiresAt
-  if (disconnectedAt !== undefined && type === 'claude-shared') {
-    provider.disconnectedAt = disconnectedAt
-  }
-  if (
-    isCodexSubscriptionProvider(type) &&
-    (codexAuthMode === 'imported' || codexAuthMode === 'isolated')
-  ) {
-    provider.codexAuthMode = codexAuthMode
-  }
-
-  return provider
-}
-
-// Rebuilds one custom MCP server, dropping unknown fields and records missing required identity.
-// Phase 1 only wires up the stdio transport end-to-end, so stdio additionally requires a non-empty
-// `command`; `url` is accepted (for the remote transports) but not yet validated further.
-export const sanitizeCustomMcpServer = (value: unknown): StoredCustomMcpServer | undefined => {
-  if (!isRecord(value)) return undefined
-
-  const id = asString(value.id)
-  const name = asString(value.name)
-  const transport = asString(value.transport) as StoredCustomMcpServer['transport'] | undefined
-  const enabled = asBoolean(value.enabled)
-
-  if (
-    !id ||
-    !name ||
-    !transport ||
-    !CUSTOM_MCP_TRANSPORTS.has(transport) ||
-    enabled === undefined
-  ) {
-    return undefined
-  }
-
-  const command = asString(value.command)
-  const url = asString(value.url)
-
-  if (transport === 'stdio' && !command) return undefined
-  if ((transport === 'streamable_http' || transport === 'sse') && !url) return undefined
-
-  const storedSlug = asString(value.slug)
-  const server: StoredCustomMcpServer = { id, name, transport, enabled }
-  if (storedSlug && isCustomConnectorSlug(storedSlug)) server.slug = storedSlug
-
-  if (command) server.command = command
-  const args = asStringArray(value.args)
-  if (args.length) server.args = args
-  const env = asStringRecord(value.env)
-  if (env) server.env = env
-  const envRefs = asStringRecord(value.envRefs)
-  if (envRefs) server.envRefs = envRefs
-  if (url) server.url = url
-  const headers = asStringRecord(value.headers)
-  if (headers) server.headers = headers
-  const headerRefs = asStringRecord(value.headerRefs)
-  if (headerRefs) server.headerRefs = headerRefs
-  if (transport !== 'stdio' && isRecord(value.oauth)) {
-    const oauth: NonNullable<StoredCustomMcpServer['oauth']> = {}
-    const clientMetadataUrl = asString(value.oauth.clientMetadataUrl)
-    const authorizationServerUrl = asString(value.oauth.authorizationServerUrl)
-    const scopes = asStringArray(value.oauth.scopes)
-      .map((scope) => scope.trim())
-      .filter(Boolean)
-    if (clientMetadataUrl) oauth.clientMetadataUrl = clientMetadataUrl
-    if (authorizationServerUrl) oauth.authorizationServerUrl = authorizationServerUrl
-    if (scopes.length) oauth.scopes = [...new Set(scopes)]
-    server.oauth = oauth
-  }
-  const oauthRef = asString(value.oauthRef)
-  if (server.oauth) {
-    delete server.headers
-    delete server.headerRefs
-    if (oauthRef) server.oauthRef = oauthRef
-  }
-  const trustedAt = asNumber(value.trustedAt)
-  if (trustedAt !== undefined) server.trustedAt = trustedAt
-  const description = asString(value.description)
-  if (description) server.description = description
-
-  return server
-}
-
-// Rebuilds one compute grant, dropping records with missing required string fields.
-const sanitizeComputeGrant = (value: unknown): StoredComputeGrant | undefined => {
-  if (!isRecord(value)) return undefined
-  const projectId = asString(value.projectId)
-  const operation = asString(value.operation)
-  const providerId = asString(value.providerId)
-  if (!projectId || !operation || !providerId) return undefined
-  return { projectId, operation, providerId }
-}
-
-// Rebuilds the connectors block from allowed fields only.
-export const sanitizeConnectors = (value: unknown): StoredConnectors | undefined => {
-  if (!isRecord(value)) return undefined
-  const connectors: StoredConnectors = {
-    enabledIds: asStringArray(value.enabledIds),
-    autoAllowIds: asStringArray(value.autoAllowIds)
-  }
-  const contactEmail = asString(value.contactEmail)
-  const ncbiApiKeyRef = asString(value.ncbiApiKeyRef)
-  if (contactEmail) connectors.contactEmail = contactEmail
-  if (ncbiApiKeyRef) connectors.ncbiApiKeyRef = ncbiApiKeyRef
-  const blockedToolIds = asStringArray(value.blockedToolIds)
-  if (blockedToolIds.length) connectors.blockedToolIds = blockedToolIds
-  const askToolIds = asStringArray(value.askToolIds)
-  if (askToolIds.length) connectors.askToolIds = askToolIds
-  const disabledConnectorIds = asStringArray(value.disabledConnectorIds)
-  if (disabledConnectorIds.length)
-    connectors.disabledConnectorIds = [...new Set(disabledConnectorIds)]
-  const customMcpServers = Array.isArray(value.customMcpServers)
-    ? value.customMcpServers
-        .map(sanitizeCustomMcpServer)
-        .filter((server): server is StoredCustomMcpServer => !!server)
-    : []
-  if (customMcpServers.length) connectors.customMcpServers = customMcpServers
-  return connectors
-}
-
-// Rebuilds a PackageMirror from untrusted JSON, keeping only string url/path fields. Returns
-// undefined when nothing valid remains (absent == public hosts default).
-export const sanitizePackageMirror = (value: unknown): PackageMirror | undefined => {
-  if (!isRecord(value)) return undefined
-
-  const condaChannel = asString(value.condaChannel)
-  const pypiIndex = asString(value.pypiIndex)
-  const cranMirror = asString(value.cranMirror)
-  const caBundle = asString(value.caBundle)
-  const result: PackageMirror = {}
-
-  if (condaChannel) result.condaChannel = condaChannel
-  if (pypiIndex) result.pypiIndex = pypiIndex
-  if (cranMirror) result.cranMirror = cranMirror
-  if (caBundle) result.caBundle = caBundle
-
-  return Object.keys(result).length > 0 ? result : undefined
 }
 
 // Rebuilds the whole settings document, keeping activeProviderId only when it points at a provider.
@@ -1366,3 +1042,4 @@ class SettingsRepository {
 }
 
 export { SettingsRepository, sanitizeSettings }
+export { sanitizeConnectors, sanitizeCustomMcpServer, sanitizePackageMirror } from './record-codec'

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -38,6 +38,7 @@ const settingsRoot = resolve(projectRoot, 'src/main/settings')
 const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
 const settingsPaths = {
   repository: resolve(settingsRoot, 'repository.ts'),
+  recordCodec: resolve(settingsRoot, 'record-codec.ts'),
   providerAccounts: resolve(settingsRoot, 'provider-accounts.ts'),
   backendResolver: resolve(settingsRoot, 'backend-resolver.ts'),
   responsesBridge: resolve(settingsRoot, 'responses-bridge.ts'),
@@ -273,7 +274,8 @@ const productionSourcePaths = productionSources()
 
 describe('Settings backend ownership architecture', () => {
   it('holds the current facade ceilings until their owner cutovers', () => {
-    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(1368)
+    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(1045)
+    expect(rawLineCount(readSource(settingsPaths.recordCodec))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(1283)
     expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1407)
     expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(1423)
@@ -483,6 +485,7 @@ describe('Settings backend ownership architecture', () => {
       'src/main/settings/service.ts',
       'src/main/settings/skill-catalog.ts'
     ])
+    expect(importersOf(settingsPaths.recordCodec)).toEqual(['src/main/settings/repository.ts'])
     expect(importersOf(settingsPaths.providerAccounts)).toEqual([
       'src/main/settings/agent-runtime-manager.ts',
       'src/main/settings/backend-resolver.ts',
@@ -599,7 +602,8 @@ describe('Settings backend ownership architecture', () => {
   it('locks dependency-aware impact owners and cross-surface evidence', () => {
     const manifest = JSON.parse(readSource(manifestPath)) as ModuleImpactManifest
     expect(manifest.modules.settings_repository.ownerPaths).toEqual([
-      'src/main/settings/repository.ts'
+      'src/main/settings/repository.ts',
+      'src/main/settings/record-codec.ts'
     ])
     expect(manifest.modules.settings_provider_accounts.ownerPaths).toEqual([
       'src/main/settings/provider-accounts.ts'


### PR DESCRIPTION
## Problem

`repository.ts` owns provider, connector, custom MCP, Compute grant, and package-mirror record sanitization in addition to top-level Settings migrations, semantic mutations, and persistence. That makes the durable record policy difficult to review independently and keeps the repository facade at 1,368 raw lines.

## Proposed change

- Extract the existing nested-record sanitizers into the private `record-codec.ts` owner.
- Keep `sanitizeSettings` as the top-level document coordinator and cut it over to the new owner.
- Preserve the existing `repository.ts` exports for `sanitizeConnectors`, `sanitizeCustomMcpServer`, and `sanitizePackageMirror` through direct re-exports.
- Add direct codec characterization and lock the new owner, sole production importer, facade ceiling, and selective test routing.

## Scope and non-goals

This is a pure D1 policy extraction. It does not move or alter top-level document migrations, provider ordering/active-pointer cleanup, semantic repository mutations, the per-instance write queue, atomic file replacement, persistence composition, provider validation, or authentication. D2 owns the top-level document codec; D3 owns the unified atomic store and lost-update correction.

## Compatibility

Accepted and emitted record shapes are field-for-field unchanged, including unknown-field removal, legacy `apiType` endpoint migration, official-provider validation, context/reasoning fields, key references/masks, auth metadata, MCP transport/OAuth/env/header rules, connector policy, Compute grants, and package mirrors. The public/IPC/data/UI contract and Electron/Web/CLI/Task/Notebook/local-RPC/MCP behavior remain unchanged. No plaintext credential field is retained. Tests contain no platform-specific filesystem paths.

## Acceptance criteria and validation

- Production raw additions: 336; new owner: 325 raw lines, below the 600 target and 660 hard limit.
- `repository.ts`: 1,368 -> 1,045 raw lines; architecture contract remains exactly 660 lines.
- Red phase failed on the absent owner/import/impact route; green focused phase passed 4 files/35 tests.
- Final `settings_repository` plan passed 15 files/486 tests, including Repository, Service, Compute IPC, Agent runtime, Connectors, Notebook runtime, Preferences, Skill catalog, shared Settings, and architecture contracts.
- Rebase-to-latest verification passed 4 files/36 tests on exact head `187f4e9f`.
- Typecheck passed. Lint passed with 0 errors and 17 pre-existing warnings. Prettier and diff checks passed.
- Independent Standards review: 0 findings. Independent Spec/compatibility review: 0 findings.
- Per the approved local-selective/online-full workflow, exact-head PR Gate must run the ownership-change full fallback; all CI/CodeQL/cross-platform checks and published AI `Verdict: mergeable` are required before normal squash merge.

## Review focus

Please compare each sanitizer's accepted/defaulted/dropped fields against the former inline implementation; verify that `repository.ts` remains the only production importer of the private owner and its public helper re-exports retain identity; confirm the impact graph selects all repository consumers; and reject any accidental D2/D3 migration or persistence behavior change.
