### PR TITLE
fix(acp): aggregate ask-user turn usage

### DIFF
--- a/src/main/acp/prompt-outcome-finalizer.ts
+++ b/src/main/acp/prompt-outcome-finalizer.ts
@@ -1,6 +1,10 @@
 import type { PromptResponse } from '@agentclientprotocol/sdk'
 
-import { ACP_PROMPT_FAILED_EVENT_TITLE, type AcpRuntimeEvent } from '../../shared/acp'
+import {
+  ACP_PROMPT_FAILED_EVENT_TITLE,
+  type AcpRuntimeEvent,
+  type AcpTurnTokenUsage
+} from '../../shared/acp'
 import { isMediaOverflowError } from '../../shared/media-overflow'
 import { createLogger, errorLogFields } from '../logger'
 import type { ContextUsageTurnHandle } from './context-usage-tracker'
@@ -47,7 +51,83 @@ type ObservedPromptStop = Readonly<{
   turnUsage?: Extract<ProviderPromptOutcome, { kind: 'stopped' }>['facts']['turnUsage']
   modelTurnCount?: number
 }>
+
+type LogicalTurnUsage = Readonly<{
+  turnUsage?: AcpTurnTokenUsage
+  unavailable?: true
+}>
+
+const MAX_LOGICAL_TURN_USAGE_ENTRIES = 500
+
+const sumTurnUsage = (
+  left: AcpTurnTokenUsage,
+  right: AcpTurnTokenUsage
+): AcpTurnTokenUsage | undefined => {
+  const inputTokens = left.inputTokens + right.inputTokens
+  const cacheTokens = left.cacheTokens + right.cacheTokens
+  const outputTokens = left.outputTokens + right.outputTokens
+  const hasCacheBreakdown =
+    left.cachedReadTokens !== undefined &&
+    left.cachedWriteTokens !== undefined &&
+    right.cachedReadTokens !== undefined &&
+    right.cachedWriteTokens !== undefined
+  const cachedReadTokens = (left.cachedReadTokens ?? 0) + (right.cachedReadTokens ?? 0)
+  const cachedWriteTokens = (left.cachedWriteTokens ?? 0) + (right.cachedWriteTokens ?? 0)
+  const hasTurnCount = left.turnCount !== undefined && right.turnCount !== undefined
+  const turnCount = (left.turnCount ?? 0) + (right.turnCount ?? 0)
+
+  if (
+    !Number.isSafeInteger(inputTokens) ||
+    !Number.isSafeInteger(cacheTokens) ||
+    !Number.isSafeInteger(outputTokens) ||
+    !Number.isSafeInteger(cachedReadTokens) ||
+    !Number.isSafeInteger(cachedWriteTokens) ||
+    !Number.isSafeInteger(turnCount)
+  ) {
+    return undefined
+  }
+
+  return {
+    inputTokens,
+    cacheTokens,
+    ...(hasCacheBreakdown ? { cachedReadTokens, cachedWriteTokens } : {}),
+    outputTokens,
+    ...(hasTurnCount ? { turnCount } : {})
+  }
+}
+
 export class AcpPromptOutcomeFinalizer {
+  // Detached ask-user replies resume as new provider prompts but keep the original Message identity.
+  // Retain a bounded running total so every later stop describes that complete visible user turn.
+  private readonly logicalTurnUsage = new Map<string, LogicalTurnUsage>()
+
+  private accumulateTurnUsage(
+    sessionId: string,
+    promptMessageId: string | undefined,
+    turnUsage: AcpTurnTokenUsage | undefined
+  ): AcpTurnTokenUsage | undefined {
+    if (!promptMessageId) return turnUsage
+
+    const key = `${sessionId.length}:${sessionId}${promptMessageId}`
+    const previous = this.logicalTurnUsage.get(key)
+    const accumulated =
+      !turnUsage || previous?.unavailable
+        ? undefined
+        : previous?.turnUsage
+          ? sumTurnUsage(previous.turnUsage, turnUsage)
+          : turnUsage
+    const next: LogicalTurnUsage = accumulated ? { turnUsage: accumulated } : { unavailable: true }
+
+    // Refresh insertion order so an active continuation is never the oldest retained entry.
+    this.logicalTurnUsage.delete(key)
+    this.logicalTurnUsage.set(key, next)
+    if (this.logicalTurnUsage.size > MAX_LOGICAL_TURN_USAGE_ENTRIES) {
+      const oldestKey = this.logicalTurnUsage.keys().next().value
+      if (oldestKey) this.logicalTurnUsage.delete(oldestKey)
+    }
+    return accumulated
+  }
+
   async finalize(
     handles: AcpPromptFinalizationHandles,
     outcome: AcpPromptFinalizationOutcome
@@ -99,6 +179,11 @@ export class AcpPromptOutcomeFinalizer {
           : { modelTurnCount: observedStop.modelTurnCount })
       })
       if (!terminal) return false
+      const turnUsage = this.accumulateTurnUsage(
+        sessionId,
+        handles.promptMessageId,
+        terminal.turnUsage
+      )
       handles.pushEvent({
         kind: 'stop',
         level: 'info',
@@ -107,7 +192,7 @@ export class AcpPromptOutcomeFinalizer {
         timestamp: terminal.timestamp,
         title: 'Prompt stopped',
         text: observedStop.response.stopReason,
-        turnUsage: terminal.turnUsage,
+        turnUsage,
         raw: observedStop.response
       })
       return true

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3337,6 +3337,109 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.prompts[0].text).toContain('Report')
   })
 
+  it('aggregates usage across repeated app-owned choices for the originating user turn', async () => {
+    const process = new FakeAgentProcess()
+    const usageForText = (text: string): NonNullable<PromptResponse['usage']> =>
+      text === 'begin the workflow'
+        ? {
+            totalTokens: 17,
+            inputTokens: 10,
+            cachedReadTokens: 2,
+            cachedWriteTokens: 1,
+            outputTokens: 4
+          }
+        : text.includes('Answer: Minimal')
+          ? {
+              totalTokens: 31,
+              inputTokens: 20,
+              cachedReadTokens: 4,
+              cachedWriteTokens: 1,
+              outputTokens: 6
+            }
+          : {
+              totalTokens: 45,
+              inputTokens: 30,
+              cachedReadTokens: 5,
+              cachedWriteTokens: 2,
+              outputTokens: 8
+            }
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const fakeAgent = startFakeAgent(process, ['repeated-user-choice-session'], {
+      onPrompt: async ({ sessionId, text }) => {
+        if (text === 'begin the workflow') {
+          await runtime.requestUserInput({
+            sessionId,
+            questions: [
+              {
+                question: 'Which implementation should I use?',
+                options: [{ label: 'Minimal' }, { label: 'Expanded' }]
+              }
+            ]
+          })
+        } else if (text.includes('Answer: Minimal')) {
+          await runtime.requestUserInput({
+            sessionId,
+            questions: [
+              {
+                question: 'Which output should I produce?',
+                options: [{ label: 'Report' }, { label: 'Notebook' }]
+              }
+            ]
+          })
+        }
+        return { stopReason: 'end_turn', usage: usageForText(text) }
+      },
+      claudeTurnCountForPrompt: (text) =>
+        text === 'begin the workflow' ? 1 : text.includes('Answer: Minimal') ? 2 : 3
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    const promptMessageId = 'originating-user-message'
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'begin the workflow',
+      provenanceContext: { promptMessageId }
+    })
+
+    const firstChoice = runtime.getSnapshot().pendingElicitations?.[0]
+    expect(firstChoice).toBeDefined()
+    runtime.respondToElicitation({
+      requestId: firstChoice!.requestId,
+      action: 'accept',
+      answers: [{ fieldId: 'question_0', value: 'Minimal' }]
+    })
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(2))
+    await vi.waitFor(() => expect(runtime.getSnapshot().pendingElicitations).toHaveLength(1))
+
+    const secondChoice = runtime.getSnapshot().pendingElicitations?.[0]
+    runtime.respondToElicitation({
+      requestId: secondChoice!.requestId,
+      action: 'accept',
+      answers: [{ fieldId: 'question_0', value: 'Report' }]
+    })
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(3))
+    await vi.waitFor(() =>
+      expect(runtime.getSnapshot().promptInFlightSessionIds).not.toContain(session.sessionId)
+    )
+
+    const stops = runtime
+      .getSnapshot()
+      .events.filter((event) => event.kind === 'stop' && event.promptMessageId === promptMessageId)
+    expect(stops).toHaveLength(3)
+    expect(stops.at(-1)?.turnUsage).toEqual({
+      inputTokens: 60,
+      cacheTokens: 15,
+      cachedReadTokens: 11,
+      cachedWriteTokens: 4,
+      outputTokens: 18,
+      turnCount: 6
+    })
+  })
+
   it('publishes one multi-question choice and continues only after every answer', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['batched-user-choice-session'])

--- a/src/renderer/src/stores/session-store-run-terminal-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-terminal-helpers.ts
@@ -72,22 +72,26 @@ const completeStreamingMessages = (
   turnUsage: AcpTurnTokenUsage | undefined,
   now: number
 ): ChatMessage[] => {
-  const usageFooterMessageId = promptMessageId
-    ? [...messages]
-        .reverse()
-        .find(
-          (message) => message.role === 'agent' && message.responseToMessageId === promptMessageId
-        )?.id
-    : undefined
+  const promptResponses = promptMessageId
+    ? messages.filter(
+        (message) => message.role === 'agent' && message.responseToMessageId === promptMessageId
+      )
+    : []
+  const usageFooterMessageId = promptResponses.at(-1)?.id
   return messages.map((message) => {
     const completesStream = message.status === 'streaming'
     const ownsTurnUsageFooter = message.id === usageFooterMessageId
-    if (!completesStream && !ownsTurnUsageFooter) return message
+    const belongsToPrompt =
+      promptMessageId !== undefined &&
+      message.role === 'agent' &&
+      message.responseToMessageId === promptMessageId
+    if (!completesStream && !belongsToPrompt) return message
     const recordsCompletion =
       completesStream ||
       (ownsTurnUsageFooter && message.status === 'complete' && message.completedAt === undefined)
     return {
       ...message,
+      ...(belongsToPrompt ? { turnUsage: undefined, turnUsageUnavailable: undefined } : {}),
       ...(completesStream ? { status: 'complete' as const } : {}),
       ...(recordsCompletion ? { completedAt: now } : {}),
       ...(ownsTurnUsageFooter

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -963,6 +963,128 @@ describe('session store', () => {
     })
   })
 
+  it('moves cumulative ask-user continuation usage to the final agent message', () => {
+    const prompt = useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Build the requested workflow'
+    })
+    expect(prompt).toBeDefined()
+
+    const segments = [
+      {
+        streamId: 'assistant-before-first-question',
+        eventId: 'event-before-first-question',
+        content: 'I need the first detail.',
+        usage: {
+          inputTokens: 10,
+          cacheTokens: 3,
+          cachedReadTokens: 2,
+          cachedWriteTokens: 1,
+          outputTokens: 4,
+          turnCount: 1
+        }
+      },
+      {
+        streamId: 'assistant-before-second-question',
+        eventId: 'event-before-second-question',
+        content: 'I need one more detail.',
+        usage: {
+          inputTokens: 30,
+          cacheTokens: 8,
+          cachedReadTokens: 6,
+          cachedWriteTokens: 2,
+          outputTokens: 10,
+          turnCount: 3
+        }
+      },
+      {
+        streamId: 'assistant-after-answers',
+        eventId: 'event-after-answers',
+        content: 'The workflow is complete.',
+        usage: {
+          inputTokens: 60,
+          cacheTokens: 15,
+          cachedReadTokens: 11,
+          cachedWriteTokens: 4,
+          outputTokens: 18,
+          turnCount: 6
+        }
+      }
+    ]
+
+    for (const segment of segments) {
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: segment.streamId,
+        eventId: segment.eventId,
+        promptMessageId: prompt!.messageId,
+        content: segment.content
+      })
+      useSessionStore.getState().finishRun('transport-session-1', segment.usage, prompt!.messageId)
+    }
+
+    const session = useSessionStore.getState().sessions[0]
+    const agentMessages = session.messages.filter((message) => message.role === 'agent')
+    expect(agentMessages).toHaveLength(3)
+    expect(agentMessages[0].turnUsage).toBeUndefined()
+    expect(agentMessages[1].turnUsage).toBeUndefined()
+    expect(agentMessages[2].turnUsage).toEqual({
+      inputTokens: 60,
+      cacheTokens: 15,
+      cachedReadTokens: 11,
+      cachedWriteTokens: 4,
+      outputTokens: 18,
+      turnCount: 6
+    })
+    expect(
+      session.conversationGraph?.messages.find((message) => message.id === agentMessages[2].id)
+        ?.turnUsage
+    ).toEqual(agentMessages[2].turnUsage)
+    expect(toPersistedSession(session).messages.at(-1)?.turnUsage).toEqual(
+      agentMessages[2].turnUsage
+    )
+  })
+
+  it('marks aggregate ask-user continuation usage unavailable when any segment is unavailable', () => {
+    const prompt = useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Build the requested workflow'
+    })
+    expect(prompt).toBeDefined()
+
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'assistant-before-question',
+      eventId: 'event-before-question',
+      promptMessageId: prompt!.messageId,
+      content: 'I need one detail.'
+    })
+    useSessionStore
+      .getState()
+      .finishRun(
+        'transport-session-1',
+        { inputTokens: 10, cacheTokens: 3, outputTokens: 4, turnCount: 1 },
+        prompt!.messageId
+      )
+
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'assistant-after-answer',
+      eventId: 'event-after-answer',
+      promptMessageId: prompt!.messageId,
+      content: 'The workflow is complete.'
+    })
+    useSessionStore.getState().finishRun('transport-session-1', undefined, prompt!.messageId)
+
+    const agentMessages = useSessionStore
+      .getState()
+      .sessions[0].messages.filter((message) => message.role === 'agent')
+    expect(agentMessages[0].turnUsage).toBeUndefined()
+    expect(agentMessages[0].turnUsageUnavailable).toBeUndefined()
+    expect(agentMessages[1].turnUsage).toBeUndefined()
+    expect(agentMessages[1].turnUsageUnavailable).toBe(true)
+  })
+
   it('marks only the final agent message when whole-turn usage is unavailable', () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',


### PR DESCRIPTION
## Problem

App-owned ask-user interactions resume the same visible user turn through new ACP provider prompts. Terminal token usage and model-turn counts were scoped to each provider prompt, so the final message showed only the segment after the last ask-user response.

## Proposed change

- Accumulate provider-normalized usage for terminal prompt segments sharing the same session and originating prompt message.
- Preserve cache breakdowns and model-turn counts only when every segment reports them, and fail closed when any segment is unavailable or totals overflow.
- Move the cumulative usage footer to the final agent response for the originating user message.

## Scope and non-goals

- No provider-adapter behavior changes; Claude Code, OpenCode, Codex managed, and Codex bridge continue using their existing normalization paths.
- No persistence schema or IPC contract changes.
- The accumulator is bounded to the runtime event-retention size.

## Acceptance criteria and validation

All impact checks below ran after the last material production edit.

- Repeated app-owned ask-user continuations aggregate three prompt segments into one user-turn total -> npm test -- --run src/main/acp/runtime.test.ts -> 467 passed.
- Finalizer publication remains correctly ordered and settled -> npm test -- --run src/main/acp/prompt-outcome-finalizer.test.ts -> 10 passed.
- Only the final response retains the cumulative usage footer and the conversation graph persists it -> npm test -- --run src/renderer/src/stores/session-store.test.ts src/renderer/src/lib/acp/workspace-events.test.ts -> 197 passed.
- Main and renderer contracts -> npm run typecheck:node and npm run typecheck:web -> passed.
- Lint -> npm run lint -> passed with 0 errors and 17 pre-existing warnings.

An additional full npm test run completed with 868 test files passing and 7 unrelated files failing in the restricted Windows environment. The 33 failures were limited to unavailable bash execution, denied symlink or ACL creation, and timing-sensitive notebook, settings, and office-package tests; all ACP and renderer impact tests above passed.

Independent review is requested through this PR; the local handoff was not marked fully verified before that review.

## Review focus

- Confirm that promptMessageId is the correct visible-turn identity across repeated ask-user continuations.
- Confirm conservative handling when a provider omits one segment's usage.
- Confirm earlier agent responses no longer retain stale per-segment footers.