### PR TITLE
refactor(settings): extract responses request adapter

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -276,7 +276,8 @@
     "settings_backend_resolution": {
       "ownerPaths": [
         "src/main/settings/backend-resolver.ts",
-        "src/main/settings/responses-bridge.ts"
+        "src/main/settings/responses-bridge.ts",
+        "src/main/settings/responses-request-adapter.ts"
       ],
       "interfacePaths": [
         "src/main/settings/backend-resolver.ts",
@@ -291,6 +292,8 @@
         "owner": [
           "src/main/settings/settings-backend.architecture.test.ts",
           "src/main/settings/backend-resolver.test.ts",
+          "src/main/settings/responses-request-adapter.architecture.test.ts",
+          "src/main/settings/responses-request-adapter.test.ts",
           "src/main/settings/responses-bridge.test.ts",
           "src/main/settings/responses-bridge.integration.test.ts",
           "src/main/settings/native-responses-compatibility.test.ts",

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -138,6 +138,18 @@ describe('module test impact commands', () => {
       ]
     ],
     [
+      'src/main/settings/responses-request-adapter.ts',
+      [
+        'artifact_provenance',
+        'reviewer_orchestrator',
+        'session_persistence',
+        'settings_backend_resolution',
+        'settings_service_facade',
+        'workspace_page',
+        'workspace_runtime'
+      ]
+    ],
+    [
       'src/main/settings/service.ts',
       ['settings_service_facade', 'workspace_page', 'workspace_runtime']
     ]
@@ -154,7 +166,8 @@ describe('module test impact commands', () => {
         ? 'settings_repository'
         : path === 'src/main/settings/provider-accounts.ts'
           ? 'settings_provider_accounts'
-          : path === 'src/main/settings/responses-bridge.ts'
+          : path === 'src/main/settings/responses-bridge.ts' ||
+              path === 'src/main/settings/responses-request-adapter.ts'
             ? 'settings_backend_resolution'
             : 'settings_service_facade'
     expect(plan.reasonChains).toEqual(

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -3,14 +3,8 @@ import { createConnection } from 'node:net'
 
 import { describe, expect, it, vi } from 'vitest'
 
-import {
-  ResponsesBridge,
-  completionToResponse,
-  inputToMessages,
-  responsesToChatRequest,
-  toolsToChat,
-  upstreamErrorMessage
-} from './responses-bridge'
+import { ResponsesBridge, completionToResponse, upstreamErrorMessage } from './responses-bridge'
+import { inputToMessages, responsesToChatRequest, toolsToChat } from './responses-request-adapter'
 import { selectExplicitConnectorSkills } from './skill-selector-routing'
 
 describe('Responses-compatible bridge conversion', () => {

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -3,12 +3,15 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 
 import { createLogger } from '../logger'
 import { appendChatCompletions } from './base-url'
-import { resolveChatReasoningTransport } from './reasoning-transport'
 import type { OfficialVendorId } from '../../shared/provider-registry'
 import type {
   CustomReasoningEffortTransport,
   ModelReasoningEffort
 } from '../../shared/reasoning-effort'
+import {
+  responsesToChatRequest,
+  type ResponsesBridgeNamespacedTool
+} from './responses-request-adapter'
 import {
   boundedSkillSelectorCatalog,
   renderSkillSelectorCatalog,
@@ -49,14 +52,6 @@ export type ResponsesBridgeModelTarget = Pick<
   'model' | 'vendorId' | 'reasoningEffortTransport' | 'reasoningEffort'
 >
 
-export type ResponsesBridgeNamespacedTool = {
-  namespace: string
-  name: string
-  description?: string
-  parameters: JsonObject
-  strict?: boolean
-}
-
 export type ResponsesBridgeConnection = {
   baseUrl: string
   token: string
@@ -94,20 +89,6 @@ class BridgeHttpError extends Error {
   }
 }
 
-const ALLOWED_INCLUDE_VALUES = new Set(['reasoning.encrypted_content'])
-const ALLOWED_REASONING_KEYS = new Set(['effort', 'summary'])
-const ALLOWED_REASONING_EFFORTS = new Set([
-  'none',
-  'minimal',
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-  'max',
-  'ultra'
-])
-const ALLOWED_REASONING_SUMMARIES = new Set(['auto', 'concise', 'detailed'])
-const ALLOWED_IMAGE_DETAILS = new Set(['auto', 'low', 'high'])
 const UPSTREAM_IMAGE_TYPES = new Set(['image', 'image_url', 'input_image', 'output_image'])
 
 const unsupportedUpstreamImageOutput = (): BridgeHttpError =>
@@ -116,62 +97,6 @@ const unsupportedUpstreamImageOutput = (): BridgeHttpError =>
     502,
     'unsupported_upstream_output'
   )
-
-const UNSUPPORTED_FIELDS = [
-  'previous_response_id',
-  'conversation',
-  'background',
-  'prompt',
-  'context_management'
-] as const
-
-// Codex built-in / auto-generated ResponseItem types that carry no Chat Completions message form and
-// are safe to skip (logged). Anything outside {message, function_call, function_call_output} and this
-// set is unknown history the bridge would silently discard, so it hard-errors instead (see
-// inputToMessages) — that throw happens before response headers, so it surfaces as a clean 400.
-const KNOWN_SKIPPABLE_ITEM_TYPES = new Set([
-  'reasoning',
-  'additional_tools',
-  'tool_search_call',
-  'tool_search_output',
-  'custom_tool_call',
-  'custom_tool_call_output',
-  'web_search_call',
-  'image_generation_call',
-  'compaction',
-  'compaction_trigger',
-  'context_compaction',
-  'local_shell_call',
-  'internal_chat_message_metadata_passthrough'
-])
-
-// A Chat Completions endpoint can only accept `function` tools. These Codex built-in, Responses-native
-// tool declarations (including tool_search, whose deferred-tool discovery only works against the real
-// OpenAI Responses backend) have no Chat Completions representation and are safe to drop (logged). A
-// tool type outside {function} and this set is unknown: the bridge hard-errors rather than silently
-// dropping it, matching the MVP boundary used for unknown history items (throw before headers ⇒ 400).
-const FILTERABLE_TOOL_TYPES = new Set([
-  'namespace',
-  'mcp',
-  'web_search',
-  'web_search_preview',
-  'file_search',
-  'code_interpreter',
-  'computer_use_preview',
-  'image_generation',
-  'local_shell',
-  'custom',
-  'tool_search'
-])
-
-// Codex's MCP resource browser functions enumerate resources exposed by MCP servers attached directly
-// to Codex. Open Science data connectors are reached through host.mcp in the notebook instead, so these
-// names are misleading in bridge mode (e.g. `mcp-pubmed` is a skill, not a Codex MCP server).
-const FILTERABLE_FUNCTION_NAMES = new Set([
-  'list_mcp_resources',
-  'list_mcp_resource_templates',
-  'read_mcp_resource'
-])
 
 const json = (response: ServerResponse, status: number, body: unknown): void => {
   response.writeHead(status, { 'content-type': 'application/json' })
@@ -206,71 +131,6 @@ const upstreamErrorMessage = (body: string, status: number): string => {
   }
 
   return `Chat Completions upstream returned ${status}`
-}
-
-const imageUrlFromPart = (part: JsonObject): JsonObject => {
-  if (part.file_id !== undefined && part.file_id !== null) {
-    throw new Error('Responses image file_id is not supported by this gateway')
-  }
-
-  const imageUrl = part.image_url
-  const url = typeof imageUrl === 'object' && imageUrl !== null ? imageUrl.url : imageUrl
-  const nestedDetail =
-    typeof imageUrl === 'object' && imageUrl !== null ? imageUrl.detail : undefined
-  if (part.detail !== undefined && nestedDetail !== undefined && part.detail !== nestedDetail) {
-    throw new Error('Responses image detail values must not conflict')
-  }
-  const detail = part.detail ?? nestedDetail
-
-  if (typeof url !== 'string' || url.length === 0) {
-    throw new Error('Responses image_url must be a non-empty string')
-  }
-  if (detail !== undefined && !ALLOWED_IMAGE_DETAILS.has(String(detail))) {
-    throw new Error(`Unsupported Responses image detail: ${String(detail)}`)
-  }
-
-  if (url.startsWith('data:')) {
-    const match = /^data:image\/[a-z0-9.+-]+;base64,([a-z0-9+/]+={0,2})$/i.exec(url)
-    if (!match || match[1].length % 4 !== 0) {
-      throw new Error('Responses image data URL must contain valid base64 image data')
-    }
-  } else {
-    let parsed: URL
-    try {
-      parsed = new URL(url)
-    } catch {
-      throw new Error('Responses image_url must be an absolute HTTP(S) or image data URL')
-    }
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      throw new Error('Responses image_url must use HTTP(S) or an image data URL')
-    }
-  }
-
-  return {
-    type: 'image_url',
-    image_url: { url, ...(detail === undefined ? {} : { detail }) }
-  }
-}
-
-const textFromContent = (content: unknown): string | JsonObject[] => {
-  if (typeof content === 'string') return content
-  if (!Array.isArray(content)) return ''
-
-  return content.map((part) => {
-    if (!part || typeof part !== 'object') {
-      throw new Error('Responses content parts must be objects')
-    }
-    if (part.type === 'input_text' || part.type === 'output_text' || part.type === 'text') {
-      if (typeof part.text !== 'string') {
-        throw new Error(`Responses ${String(part.type)} content must contain string text`)
-      }
-      return { type: 'text', text: part.text }
-    }
-    if (part.type === 'input_image' || part.type === 'image_url') {
-      return imageUrlFromPart(part)
-    }
-    throw new Error(`Unsupported Responses content part: ${String(part.type)}`)
-  })
 }
 
 const upstreamTextFromContent = (content: unknown): string => {
@@ -325,352 +185,13 @@ const hasUpstreamImageField = (value: JsonObject): boolean =>
   value.image_url !== undefined ||
   value.output_image !== undefined
 
-const namespacedToolAlias = (
-  tool: Pick<ResponsesBridgeNamespacedTool, 'namespace' | 'name'>
-): string => `${tool.namespace}__${tool.name}`
-
-const namespacedToolByAlias = (
-  tools: readonly ResponsesBridgeNamespacedTool[]
-): Map<string, ResponsesBridgeNamespacedTool> =>
-  new Map(tools.map((tool) => [namespacedToolAlias(tool), tool]))
-
-const chatToolName = (
-  item: JsonObject,
-  tools: readonly ResponsesBridgeNamespacedTool[]
-): string => {
-  if (typeof item.namespace !== 'string' || item.namespace.length === 0) {
-    return String(item.name ?? '')
-  }
-
-  const match = tools.find(
-    (tool) => tool.namespace === item.namespace && tool.name === String(item.name ?? '')
-  )
-  return match ? namespacedToolAlias(match) : `${item.namespace}__${String(item.name ?? '')}`
-}
-
 const responseFunctionIdentity = (
   chatName: unknown,
   tools: readonly ResponsesBridgeNamespacedTool[]
 ): { name: string; namespace?: string } => {
   const name = String(chatName ?? '')
-  const namespaced = namespacedToolByAlias(tools).get(name)
+  const namespaced = tools.find((tool) => `${tool.namespace}__${tool.name}` === name)
   return namespaced ? { name: namespaced.name, namespace: namespaced.namespace } : { name }
-}
-
-// Thinking-mode providers (e.g. DeepSeek reasoner) reject a follow-up request whose assistant
-// tool-call turn omits the reasoning_content the model produced with those calls ("the
-// reasoning_content in the thinking mode must be passed back to the API"). Codex never round-trips
-// that field, so the bridge caches it per tool-call id when a response is produced and re-attaches it
-// here when the same call is replayed in history. Optional so plain (non-thinking) turns and unit
-// tests need not supply it.
-const inputToMessages = (
-  body: JsonObject,
-  reasoningByCallId?: Map<string, string>,
-  namespacedTools: readonly ResponsesBridgeNamespacedTool[] = []
-): JsonObject[] => {
-  const messages: JsonObject[] = []
-  if (typeof body.instructions === 'string' && body.instructions.length > 0) {
-    messages.push({ role: 'system', content: body.instructions })
-  }
-
-  const input =
-    typeof body.input === 'string'
-      ? [{ type: 'message', role: 'user', content: body.input }]
-      : body.input
-  if (!Array.isArray(input)) return messages
-
-  const droppedItemTypes = new Set<string>()
-  // Chat Completions requires an assistant message with tool_calls to be immediately followed by a
-  // tool message per tool_call_id. Codex emits parallel tool calls as consecutive function_call items
-  // (fc_A, fc_B, output_A, output_B), so coalesce a run of function_call items into ONE assistant
-  // message rather than one message each — otherwise assistant[A] is followed by assistant[B] and the
-  // upstream rejects it. Flushed when a message or a tool output ends the run.
-  let pendingToolCalls: JsonObject[] = []
-  let pendingReasoning: string | undefined
-  const flushToolCalls = (): void => {
-    if (pendingToolCalls.length === 0) return
-    messages.push({
-      role: 'assistant',
-      ...(pendingReasoning ? { reasoning_content: pendingReasoning } : {}),
-      tool_calls: pendingToolCalls
-    })
-    pendingToolCalls = []
-    pendingReasoning = undefined
-  }
-
-  for (const item of input) {
-    if (!item || typeof item !== 'object') throw new Error('Responses input items must be objects')
-    if (item.type === 'function_call') {
-      const callId = item.call_id ?? item.id
-      const reasoning = reasoningByCallId?.get(String(callId))
-      if (reasoning && !pendingReasoning) pendingReasoning = reasoning
-      pendingToolCalls.push({
-        id: callId,
-        type: 'function',
-        function: { name: chatToolName(item, namespacedTools), arguments: item.arguments ?? '{}' }
-      })
-    } else if (item.type === 'message') {
-      flushToolCalls()
-      // Responses uses `developer` for higher-priority instructions; Chat Completions vendors such
-      // as DeepSeek generally only accept `system`, so preserve the instruction semantics with the
-      // broadly supported role.
-      const role = item.role === 'developer' ? 'system' : (item.role ?? 'user')
-      if (!['system', 'user', 'assistant'].includes(role)) {
-        throw new Error(`Unsupported Responses message role: ${String(item.role)}`)
-      }
-      messages.push({ role, content: textFromContent(item.content) })
-    } else if (item.type === 'function_call_output') {
-      flushToolCalls()
-      messages.push({
-        role: 'tool',
-        tool_call_id: item.call_id,
-        content: typeof item.output === 'string' ? item.output : JSON.stringify(item.output)
-      })
-    } else if (KNOWN_SKIPPABLE_ITEM_TYPES.has(String(item.type))) {
-      // Known built-in items (reasoning, additional_tools, …) have no Chat Completions message form.
-      // Skip them (logged), but do NOT flush a pending tool-call run — that would split parallel calls
-      // back into separate assistant messages.
-      droppedItemTypes.add(String(item.type))
-    } else {
-      // An unknown item type would silently discard history while still returning a "successful"
-      // answer. Fail the turn instead (before headers ⇒ clean 400) so the boundary stays explicit.
-      throw new Error(`Unsupported Responses input item: ${String(item.type)}`)
-    }
-  }
-  // A run of tool calls at the very end (no trailing output yet) still emits as one assistant message.
-  flushToolCalls()
-
-  if (droppedItemTypes.size > 0) {
-    log.info('bridge dropped non-representable input items', {
-      droppedTypes: [...droppedItemTypes]
-    })
-  }
-
-  const systemMessages = messages.filter((message) => message.role === 'system')
-  if (systemMessages.length <= 1) return messages
-
-  // Some OpenAI-compatible gateways (notably MiniMax) only accept one system message and require
-  // it to be first. Responses can provide both `instructions` and developer message items, so merge
-  // their text while preserving the order of every non-system message.
-  const systemText = systemMessages
-    .map((message) => {
-      if (typeof message.content === 'string') return message.content
-      if (Array.isArray(message.content)) {
-        return message.content
-          .map((part) => (typeof part === 'object' ? String(part.text ?? '') : String(part)))
-          .join('')
-      }
-      return ''
-    })
-    .filter(Boolean)
-    .join('\n\n')
-
-  return [
-    { role: 'system', content: systemText },
-    ...messages.filter((message) => message.role !== 'system')
-  ]
-}
-
-const toolsToChat = (
-  tools: unknown,
-  namespacedTools: readonly ResponsesBridgeNamespacedTool[] = []
-): JsonObject[] | undefined => {
-  if (tools === undefined) return undefined
-  if (!Array.isArray(tools)) throw new Error('Responses tools must be an array')
-
-  const dropped = new Set<string>()
-  const droppedFunctions = new Set<string>()
-  const converted = tools.flatMap((tool) => {
-    if (!tool || typeof tool !== 'object' || typeof tool.type !== 'string') {
-      throw new Error('Responses tools must have a supported type')
-    }
-    const responseTool = tool as JsonObject
-    if (
-      responseTool.type === 'function' &&
-      FILTERABLE_FUNCTION_NAMES.has(String(responseTool.name))
-    ) {
-      droppedFunctions.add(String(responseTool.name))
-      return []
-    }
-    // Known built-in types (tool_search, custom/freeform apply_patch, web_search, namespace, …) have no
-    // Chat Completions equivalent; drop them (logged). tool_search in particular can't work over the
-    // bridge — Codex's deferred-tool discovery is resolved server-side by the OpenAI Responses backend,
-    // so forwarding it just yields tool calls Codex rejects as "unsupported". An unknown type is
-    // rejected so the boundary stays explicit rather than silently discarding a tool the turn needs.
-    if (responseTool.type !== 'function') {
-      if (!FILTERABLE_TOOL_TYPES.has(responseTool.type)) {
-        throw new Error(`Unsupported Responses tool type: ${responseTool.type}`)
-      }
-      dropped.add(responseTool.type)
-      return []
-    }
-    return {
-      type: 'function',
-      function: {
-        name: responseTool.name,
-        description: responseTool.description,
-        parameters: responseTool.parameters,
-        ...(responseTool.strict === undefined ? {} : { strict: responseTool.strict })
-      }
-    }
-  })
-  for (const tool of namespacedTools) {
-    converted.push({
-      type: 'function',
-      function: {
-        name: namespacedToolAlias(tool),
-        description: tool.description,
-        parameters: tool.parameters,
-        ...(tool.strict === undefined ? {} : { strict: tool.strict })
-      }
-    })
-  }
-  if (dropped.size > 0) {
-    log.info('bridge dropped non-function tools', { droppedTypes: [...dropped] })
-  }
-  if (droppedFunctions.size > 0) {
-    log.info('bridge dropped MCP resource browser functions', {
-      droppedNames: [...droppedFunctions]
-    })
-  }
-  return converted
-}
-
-const toolChoiceToChat = (toolChoice: unknown): unknown => {
-  if (toolChoice === undefined || toolChoice === null) return toolChoice
-  if (typeof toolChoice === 'string') {
-    if (!['auto', 'none', 'required'].includes(toolChoice)) {
-      throw new Error(`Unsupported Responses tool_choice: ${toolChoice}`)
-    }
-    return toolChoice
-  }
-  if (
-    toolChoice &&
-    typeof toolChoice === 'object' &&
-    (toolChoice as JsonObject).type === 'function' &&
-    typeof (toolChoice as JsonObject).name === 'string'
-  ) {
-    return { type: 'function', function: { name: (toolChoice as JsonObject).name } }
-  }
-  throw new Error('Only function tool_choice values are supported by the Chat Completions bridge')
-}
-
-export const responsesToChatRequest = (
-  body: JsonObject,
-  upstreamModel?: string,
-  reasoningByCallId?: Map<string, string>,
-  namespacedTools: readonly ResponsesBridgeNamespacedTool[] = [],
-  options?: {
-    reasoningEffortOverride?: ModelReasoningEffort
-    vendorId?: OfficialVendorId
-    reasoningEffortTransport?: CustomReasoningEffortTransport
-  }
-): JsonObject => {
-  for (const field of UNSUPPORTED_FIELDS) {
-    if (body[field] !== undefined && body[field] !== null) {
-      throw new Error(`Responses field "${field}" is not supported by this gateway`)
-    }
-  }
-  if (body.stream !== undefined && typeof body.stream !== 'boolean') {
-    throw new Error('Responses stream must be a boolean')
-  }
-  if (body.include !== undefined && body.include !== null) {
-    if (!Array.isArray(body.include)) throw new Error('Responses include must be an array')
-    for (const value of body.include) {
-      if (typeof value !== 'string' || !ALLOWED_INCLUDE_VALUES.has(value)) {
-        throw new Error(
-          `Responses include value is not supported by this gateway: ${String(value)}`
-        )
-      }
-    }
-    // Codex requests `reasoning.encrypted_content` automatically. Chat Completions has no equivalent,
-    // so the one allowlisted advisory value is intentionally omitted from the upstream request.
-  }
-  if (body.reasoning !== undefined && body.reasoning !== null) {
-    if (typeof body.reasoning !== 'object' || Array.isArray(body.reasoning)) {
-      throw new Error('Responses reasoning must be an object')
-    }
-    for (const key of Object.keys(body.reasoning)) {
-      if (!ALLOWED_REASONING_KEYS.has(key)) {
-        throw new Error(`Responses reasoning field is not supported by this gateway: ${key}`)
-      }
-    }
-    const effort = body.reasoning.effort
-    if (effort !== undefined && effort !== null && !ALLOWED_REASONING_EFFORTS.has(String(effort))) {
-      throw new Error(`Unsupported Responses reasoning effort: ${String(effort)}`)
-    }
-    const summary = body.reasoning.summary
-    if (
-      summary !== undefined &&
-      summary !== null &&
-      !ALLOWED_REASONING_SUMMARIES.has(String(summary))
-    ) {
-      throw new Error(`Unsupported Responses reasoning summary: ${String(summary)}`)
-    }
-    // The summary preference has no portable Chat Completions equivalent and is omitted; the
-    // effort is translated below.
-  }
-  if (body.store !== undefined && body.store !== false && body.store !== null) {
-    throw new Error('Stored Responses are not supported by this gateway')
-  }
-  if (
-    body.prompt_cache_key !== undefined &&
-    body.prompt_cache_key !== null &&
-    typeof body.prompt_cache_key !== 'string'
-  ) {
-    throw new Error('Responses prompt_cache_key must be a string')
-  }
-  if (
-    body.max_output_tokens !== undefined &&
-    body.max_output_tokens !== null &&
-    typeof body.max_output_tokens !== 'number'
-  ) {
-    throw new Error('Responses max_output_tokens must be a number')
-  }
-
-  const tools = toolsToChat(body.tools ?? [], namespacedTools)
-  const hasTools = Boolean(tools && tools.length > 0)
-  const requestedToolChoice =
-    body.tool_choice === undefined ? undefined : toolChoiceToChat(body.tool_choice)
-  const toolChoice = hasTools ? requestedToolChoice : undefined
-  const stream = body.stream !== false
-
-  // The model profile already chose the upstream API value. Never derive it from Codex's request:
-  // Codex runs a catalog transport model and may omit, default, or clamp values that the real model
-  // supports. Undefined intentionally strips Codex's own effort from the Chat request.
-  const chatReasoningEffort = options?.reasoningEffortOverride
-  const reasoningTransport = chatReasoningEffort
-    ? resolveChatReasoningTransport(
-        options?.vendorId,
-        upstreamModel,
-        chatReasoningEffort,
-        options?.reasoningEffortTransport
-      )
-    : undefined
-
-  return {
-    model: upstreamModel ?? body.model,
-    messages: inputToMessages(body, reasoningByCallId, namespacedTools),
-    ...(hasTools ? { tools } : {}),
-    ...(toolChoice === undefined ? {} : { tool_choice: toolChoice }),
-    ...(!hasTools || body.parallel_tool_calls === undefined
-      ? {}
-      : { parallel_tool_calls: body.parallel_tool_calls }),
-    ...(body.temperature === undefined ? {} : { temperature: body.temperature }),
-    ...(body.top_p === undefined ? {} : { top_p: body.top_p }),
-    ...(body.max_output_tokens === undefined || body.max_output_tokens === null
-      ? {}
-      : { max_tokens: body.max_output_tokens }),
-    ...(reasoningTransport?.reasoningEffort
-      ? { reasoning_effort: reasoningTransport.reasoningEffort }
-      : {}),
-    ...(reasoningTransport?.thinking ? { thinking: reasoningTransport.thinking } : {}),
-    ...(reasoningTransport?.reasoning ? { reasoning: reasoningTransport.reasoning } : {}),
-    stream,
-    // Responses stream options are not Chat Completions options. Request final usage explicitly and
-    // do not forward fields such as include_obfuscation that a Chat-compatible gateway may reject.
-    ...(stream ? { stream_options: { include_usage: true } } : {})
-  }
 }
 
 const responseEnvelope = (
@@ -1420,4 +941,10 @@ export class ResponsesBridge {
   }
 }
 
-export { chatUrl, completionToResponse, inputToMessages, toolsToChat, upstreamErrorMessage }
+export { chatUrl, completionToResponse, upstreamErrorMessage }
+export {
+  inputToMessages,
+  responsesToChatRequest,
+  toolsToChat,
+  type ResponsesBridgeNamespacedTool
+} from './responses-request-adapter'

--- a/src/main/settings/responses-request-adapter.architecture.test.ts
+++ b/src/main/settings/responses-request-adapter.architecture.test.ts
@@ -1,0 +1,168 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { basename, dirname, extname, relative, resolve } from 'node:path'
+
+import {
+  canHaveModifiers,
+  createSourceFile,
+  forEachChild,
+  getModifiers,
+  isCallExpression,
+  isClassDeclaration,
+  isEnumDeclaration,
+  isExportDeclaration,
+  isFunctionDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isImportTypeNode,
+  isInterfaceDeclaration,
+  isLiteralTypeNode,
+  isNamedExports,
+  isStringLiteralLike,
+  isTypeAliasDeclaration,
+  isVariableStatement,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  type Node,
+  type SourceFile
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = resolve(__dirname, '../../..')
+const adapterPath = resolve(__dirname, 'responses-request-adapter.ts')
+const bridgePath = resolve(__dirname, 'responses-bridge.ts')
+const readSource = (path: string): string => readFileSync(path, 'utf8')
+const rawLineCount = (source: string): number =>
+  source.split(/\r?\n/).length - Number(source.endsWith('\n'))
+const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
+const portableProjectPath = (path: string): string =>
+  relative(projectRoot, path).replaceAll('\\', '/')
+const sourceFileFor = (path: string): SourceFile =>
+  createSourceFile(
+    path,
+    readSource(path),
+    ScriptTarget.Latest,
+    true,
+    extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
+  )
+
+const productionSources = (): string[] => {
+  const sources: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isDirectory()) visit(path)
+      else if (
+        ['.ts', '.tsx'].includes(extname(path)) &&
+        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
+      ) {
+        sources.push(path)
+      }
+    }
+  }
+  visit(resolve(projectRoot, 'src'))
+  visit(resolve(projectRoot, 'packages'))
+  return sources.sort()
+}
+
+const importSpecifiersFrom = (sourcePath: string): string[] => {
+  const specifiers: string[] = []
+  const visit = (node: Node): void => {
+    if (
+      (isImportDeclaration(node) || isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text)
+    } else if (isImportTypeNode(node)) {
+      if (isLiteralTypeNode(node.argument) && isStringLiteralLike(node.argument.literal)) {
+        specifiers.push(node.argument.literal.text)
+      }
+    } else if (isCallExpression(node)) {
+      const [argument] = node.arguments
+      const requireCall = isIdentifier(node.expression) && node.expression.text === 'require'
+      const dynamicImport = node.expression.kind === SyntaxKind.ImportKeyword
+      if ((requireCall || dynamicImport) && argument && isStringLiteralLike(argument)) {
+        specifiers.push(argument.text)
+      }
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFileFor(sourcePath))
+  return specifiers
+}
+
+const importersOf = (targetPath: string): string[] =>
+  productionSources()
+    .filter((sourcePath) => readSource(sourcePath).includes(basename(modulePath(targetPath))))
+    .filter((sourcePath) =>
+      importSpecifiersFrom(sourcePath).some(
+        (specifier) =>
+          specifier.startsWith('.') &&
+          modulePath(resolve(dirname(sourcePath), specifier)) === modulePath(targetPath)
+      )
+    )
+    .map(portableProjectPath)
+
+const exportInventoryFrom = (path: string): string[] => {
+  const names: string[] = []
+  for (const statement of sourceFileFor(path).statements) {
+    if (isExportDeclaration(statement) && statement.exportClause) {
+      if (isNamedExports(statement.exportClause)) {
+        for (const element of statement.exportClause.elements) {
+          names.push(
+            `${statement.isTypeOnly || element.isTypeOnly ? 'type' : 'value'}:${element.name.text}`
+          )
+        }
+      }
+      continue
+    }
+    const exported =
+      canHaveModifiers(statement) &&
+      getModifiers(statement)?.some((modifier) => modifier.kind === SyntaxKind.ExportKeyword)
+    if (!exported) continue
+    if (isInterfaceDeclaration(statement) || isTypeAliasDeclaration(statement)) {
+      names.push(`type:${statement.name.text}`)
+    } else if (
+      isClassDeclaration(statement) ||
+      isEnumDeclaration(statement) ||
+      isFunctionDeclaration(statement)
+    ) {
+      names.push(`value:${statement.name?.text ?? '<anonymous>'}`)
+    } else if (isVariableStatement(statement)) {
+      names.push(
+        ...statement.declarationList.declarations.flatMap((declaration) =>
+          isIdentifier(declaration.name) ? [`value:${declaration.name.text}`] : []
+        )
+      )
+    }
+  }
+  return names.sort()
+}
+
+describe('Responses request adapter ownership', () => {
+  it('keeps a small, exact conversion interface', () => {
+    expect(rawLineCount(readSource(adapterPath))).toBeLessThanOrEqual(600)
+    expect(exportInventoryFrom(adapterPath)).toEqual([
+      'type:ResponsesBridgeNamespacedTool',
+      'type:ResponsesRequestAdapterOptions',
+      'value:inputToMessages',
+      'value:responsesToChatRequest',
+      'value:toolsToChat'
+    ])
+    expect(importersOf(adapterPath)).toEqual(['src/main/settings/responses-bridge.ts'])
+  })
+
+  it('excludes response projection and HTTP/session lifecycle', () => {
+    const adapter = readSource(adapterPath)
+    const bridge = readSource(bridgePath)
+
+    expect(adapter).not.toMatch(/from ['"]node:(?:crypto|http|net)['"]/)
+    expect(adapter).not.toContain('fetch(')
+    expect(adapter).not.toMatch(/completionToResponse|streamChatToResponses|responseEnvelope/)
+    expect(bridge).toContain('createServer(')
+    expect(bridge).toContain('reviewerSessionKeys')
+    expect(bridge).toContain('reasoningByCallId')
+    expect(bridge).toContain('streamChatToResponses(')
+  })
+})

--- a/src/main/settings/responses-request-adapter.test.ts
+++ b/src/main/settings/responses-request-adapter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import { responsesToChatRequest } from './responses-request-adapter'
+
+describe('Responses request protocol adapter', () => {
+  it('converts replayed namespaced tool calls, images, and configured reasoning without session state', () => {
+    const request = responsesToChatRequest(
+      {
+        model: 'catalog-model',
+        instructions: 'Use the notebook.',
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'Inspect this image.' },
+              {
+                type: 'input_image',
+                image_url: 'https://example.test/image.png',
+                detail: 'high'
+              }
+            ]
+          },
+          {
+            type: 'function_call',
+            call_id: 'call-1',
+            namespace: 'mcp__open_science_notebook',
+            name: 'notebook_execute',
+            arguments: '{"code":"print(1)"}'
+          },
+          { type: 'function_call_output', call_id: 'call-1', output: '1' }
+        ],
+        tools: [],
+        stream: false
+      },
+      'deepseek-v4-pro',
+      new Map([['call-1', 'inspect the notebook first']]),
+      [
+        {
+          namespace: 'mcp__open_science_notebook',
+          name: 'notebook_execute',
+          parameters: { type: 'object' }
+        }
+      ],
+      { reasoningEffortOverride: 'none', vendorId: 'deepseek' }
+    )
+
+    expect(request).toMatchObject({
+      model: 'deepseek-v4-pro',
+      stream: false,
+      thinking: { type: 'disabled' },
+      messages: [
+        { role: 'system', content: 'Use the notebook.' },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Inspect this image.' },
+            {
+              type: 'image_url',
+              image_url: { url: 'https://example.test/image.png', detail: 'high' }
+            }
+          ]
+        },
+        {
+          role: 'assistant',
+          reasoning_content: 'inspect the notebook first',
+          tool_calls: [
+            {
+              id: 'call-1',
+              type: 'function',
+              function: {
+                name: 'mcp__open_science_notebook__notebook_execute',
+                arguments: '{"code":"print(1)"}'
+              }
+            }
+          ]
+        },
+        { role: 'tool', tool_call_id: 'call-1', content: '1' }
+      ],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'mcp__open_science_notebook__notebook_execute',
+            parameters: { type: 'object' }
+          }
+        }
+      ]
+    })
+  })
+})

--- a/src/main/settings/responses-request-adapter.ts
+++ b/src/main/settings/responses-request-adapter.ts
@@ -1,0 +1,448 @@
+import { createLogger } from '../logger'
+import type { OfficialVendorId } from '../../shared/provider-registry'
+import type {
+  CustomReasoningEffortTransport,
+  ModelReasoningEffort
+} from '../../shared/reasoning-effort'
+import { resolveChatReasoningTransport } from './reasoning-transport'
+
+// Responses and Chat Completions payloads are open-ended at this protocol seam. The adapter validates
+// the supported subset before producing an upstream request.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type JsonObject = Record<string, any>
+
+const log = createLogger('acp-bridge')
+
+export type ResponsesBridgeNamespacedTool = {
+  namespace: string
+  name: string
+  description?: string
+  parameters: JsonObject
+  strict?: boolean
+}
+
+export type ResponsesRequestAdapterOptions = {
+  reasoningEffortOverride?: ModelReasoningEffort
+  vendorId?: OfficialVendorId
+  reasoningEffortTransport?: CustomReasoningEffortTransport
+}
+
+const ALLOWED_INCLUDE_VALUES = new Set(['reasoning.encrypted_content'])
+const ALLOWED_REASONING_KEYS = new Set(['effort', 'summary'])
+const ALLOWED_REASONING_EFFORTS = new Set([
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra'
+])
+const ALLOWED_REASONING_SUMMARIES = new Set(['auto', 'concise', 'detailed'])
+const ALLOWED_IMAGE_DETAILS = new Set(['auto', 'low', 'high'])
+
+const UNSUPPORTED_FIELDS = [
+  'previous_response_id',
+  'conversation',
+  'background',
+  'prompt',
+  'context_management'
+] as const
+
+// Known Codex Responses items with no Chat Completions message representation are intentionally
+// skipped. Unknown history is rejected so the adapter never silently loses a turn dependency.
+const KNOWN_SKIPPABLE_ITEM_TYPES = new Set([
+  'reasoning',
+  'additional_tools',
+  'tool_search_call',
+  'tool_search_output',
+  'custom_tool_call',
+  'custom_tool_call_output',
+  'web_search_call',
+  'image_generation_call',
+  'compaction',
+  'compaction_trigger',
+  'context_compaction',
+  'local_shell_call',
+  'internal_chat_message_metadata_passthrough'
+])
+
+// Chat Completions accepts only function tools. These known Responses-native declarations have no
+// equivalent and are dropped; unknown declarations remain hard errors.
+const FILTERABLE_TOOL_TYPES = new Set([
+  'namespace',
+  'mcp',
+  'web_search',
+  'web_search_preview',
+  'file_search',
+  'code_interpreter',
+  'computer_use_preview',
+  'image_generation',
+  'local_shell',
+  'custom',
+  'tool_search'
+])
+
+const FILTERABLE_FUNCTION_NAMES = new Set([
+  'list_mcp_resources',
+  'list_mcp_resource_templates',
+  'read_mcp_resource'
+])
+
+const imageUrlFromPart = (part: JsonObject): JsonObject => {
+  if (part.file_id !== undefined && part.file_id !== null) {
+    throw new Error('Responses image file_id is not supported by this gateway')
+  }
+
+  const imageUrl = part.image_url
+  const url = typeof imageUrl === 'object' && imageUrl !== null ? imageUrl.url : imageUrl
+  const nestedDetail =
+    typeof imageUrl === 'object' && imageUrl !== null ? imageUrl.detail : undefined
+  if (part.detail !== undefined && nestedDetail !== undefined && part.detail !== nestedDetail) {
+    throw new Error('Responses image detail values must not conflict')
+  }
+  const detail = part.detail ?? nestedDetail
+
+  if (typeof url !== 'string' || url.length === 0) {
+    throw new Error('Responses image_url must be a non-empty string')
+  }
+  if (detail !== undefined && !ALLOWED_IMAGE_DETAILS.has(String(detail))) {
+    throw new Error(`Unsupported Responses image detail: ${String(detail)}`)
+  }
+
+  if (url.startsWith('data:')) {
+    const match = /^data:image\/[a-z0-9.+-]+;base64,([a-z0-9+/]+={0,2})$/i.exec(url)
+    if (!match || match[1].length % 4 !== 0) {
+      throw new Error('Responses image data URL must contain valid base64 image data')
+    }
+  } else {
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+    } catch {
+      throw new Error('Responses image_url must be an absolute HTTP(S) or image data URL')
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('Responses image_url must use HTTP(S) or an image data URL')
+    }
+  }
+
+  return {
+    type: 'image_url',
+    image_url: { url, ...(detail === undefined ? {} : { detail }) }
+  }
+}
+
+const textFromContent = (content: unknown): string | JsonObject[] => {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+
+  return content.map((part) => {
+    if (!part || typeof part !== 'object') {
+      throw new Error('Responses content parts must be objects')
+    }
+    if (part.type === 'input_text' || part.type === 'output_text' || part.type === 'text') {
+      if (typeof part.text !== 'string') {
+        throw new Error(`Responses ${String(part.type)} content must contain string text`)
+      }
+      return { type: 'text', text: part.text }
+    }
+    if (part.type === 'input_image' || part.type === 'image_url') {
+      return imageUrlFromPart(part)
+    }
+    throw new Error(`Unsupported Responses content part: ${String(part.type)}`)
+  })
+}
+
+const namespacedToolAlias = (
+  tool: Pick<ResponsesBridgeNamespacedTool, 'namespace' | 'name'>
+): string => `${tool.namespace}__${tool.name}`
+
+const chatToolName = (
+  item: JsonObject,
+  tools: readonly ResponsesBridgeNamespacedTool[]
+): string => {
+  if (typeof item.namespace !== 'string' || item.namespace.length === 0) {
+    return String(item.name ?? '')
+  }
+
+  const match = tools.find(
+    (tool) => tool.namespace === item.namespace && tool.name === String(item.name ?? '')
+  )
+  return match ? namespacedToolAlias(match) : `${item.namespace}__${String(item.name ?? '')}`
+}
+
+export const inputToMessages = (
+  body: JsonObject,
+  reasoningByCallId?: Map<string, string>,
+  namespacedTools: readonly ResponsesBridgeNamespacedTool[] = []
+): JsonObject[] => {
+  const messages: JsonObject[] = []
+  if (typeof body.instructions === 'string' && body.instructions.length > 0) {
+    messages.push({ role: 'system', content: body.instructions })
+  }
+
+  const input =
+    typeof body.input === 'string'
+      ? [{ type: 'message', role: 'user', content: body.input }]
+      : body.input
+  if (!Array.isArray(input)) return messages
+
+  const droppedItemTypes = new Set<string>()
+  let pendingToolCalls: JsonObject[] = []
+  let pendingReasoning: string | undefined
+  const flushToolCalls = (): void => {
+    if (pendingToolCalls.length === 0) return
+    messages.push({
+      role: 'assistant',
+      ...(pendingReasoning ? { reasoning_content: pendingReasoning } : {}),
+      tool_calls: pendingToolCalls
+    })
+    pendingToolCalls = []
+    pendingReasoning = undefined
+  }
+
+  for (const item of input) {
+    if (!item || typeof item !== 'object') throw new Error('Responses input items must be objects')
+    if (item.type === 'function_call') {
+      const callId = item.call_id ?? item.id
+      const reasoning = reasoningByCallId?.get(String(callId))
+      if (reasoning && !pendingReasoning) pendingReasoning = reasoning
+      pendingToolCalls.push({
+        id: callId,
+        type: 'function',
+        function: { name: chatToolName(item, namespacedTools), arguments: item.arguments ?? '{}' }
+      })
+    } else if (item.type === 'message') {
+      flushToolCalls()
+      const role = item.role === 'developer' ? 'system' : (item.role ?? 'user')
+      if (!['system', 'user', 'assistant'].includes(role)) {
+        throw new Error(`Unsupported Responses message role: ${String(item.role)}`)
+      }
+      messages.push({ role, content: textFromContent(item.content) })
+    } else if (item.type === 'function_call_output') {
+      flushToolCalls()
+      messages.push({
+        role: 'tool',
+        tool_call_id: item.call_id,
+        content: typeof item.output === 'string' ? item.output : JSON.stringify(item.output)
+      })
+    } else if (KNOWN_SKIPPABLE_ITEM_TYPES.has(String(item.type))) {
+      droppedItemTypes.add(String(item.type))
+    } else {
+      throw new Error(`Unsupported Responses input item: ${String(item.type)}`)
+    }
+  }
+  flushToolCalls()
+
+  if (droppedItemTypes.size > 0) {
+    log.info('bridge dropped non-representable input items', {
+      droppedTypes: [...droppedItemTypes]
+    })
+  }
+
+  const systemMessages = messages.filter((message) => message.role === 'system')
+  if (systemMessages.length <= 1) return messages
+
+  const systemText = systemMessages
+    .map((message) => {
+      if (typeof message.content === 'string') return message.content
+      if (Array.isArray(message.content)) {
+        return message.content
+          .map((part) => (typeof part === 'object' ? String(part.text ?? '') : String(part)))
+          .join('')
+      }
+      return ''
+    })
+    .filter(Boolean)
+    .join('\n\n')
+
+  return [
+    { role: 'system', content: systemText },
+    ...messages.filter((message) => message.role !== 'system')
+  ]
+}
+
+export const toolsToChat = (
+  tools: unknown,
+  namespacedTools: readonly ResponsesBridgeNamespacedTool[] = []
+): JsonObject[] | undefined => {
+  if (tools === undefined) return undefined
+  if (!Array.isArray(tools)) throw new Error('Responses tools must be an array')
+
+  const dropped = new Set<string>()
+  const droppedFunctions = new Set<string>()
+  const converted = tools.flatMap((tool) => {
+    if (!tool || typeof tool !== 'object' || typeof tool.type !== 'string') {
+      throw new Error('Responses tools must have a supported type')
+    }
+    const responseTool = tool as JsonObject
+    if (
+      responseTool.type === 'function' &&
+      FILTERABLE_FUNCTION_NAMES.has(String(responseTool.name))
+    ) {
+      droppedFunctions.add(String(responseTool.name))
+      return []
+    }
+    if (responseTool.type !== 'function') {
+      if (!FILTERABLE_TOOL_TYPES.has(responseTool.type)) {
+        throw new Error(`Unsupported Responses tool type: ${responseTool.type}`)
+      }
+      dropped.add(responseTool.type)
+      return []
+    }
+    return {
+      type: 'function',
+      function: {
+        name: responseTool.name,
+        description: responseTool.description,
+        parameters: responseTool.parameters,
+        ...(responseTool.strict === undefined ? {} : { strict: responseTool.strict })
+      }
+    }
+  })
+  for (const tool of namespacedTools) {
+    converted.push({
+      type: 'function',
+      function: {
+        name: namespacedToolAlias(tool),
+        description: tool.description,
+        parameters: tool.parameters,
+        ...(tool.strict === undefined ? {} : { strict: tool.strict })
+      }
+    })
+  }
+  if (dropped.size > 0) {
+    log.info('bridge dropped non-function tools', { droppedTypes: [...dropped] })
+  }
+  if (droppedFunctions.size > 0) {
+    log.info('bridge dropped MCP resource browser functions', {
+      droppedNames: [...droppedFunctions]
+    })
+  }
+  return converted
+}
+
+const toolChoiceToChat = (toolChoice: unknown): unknown => {
+  if (toolChoice === undefined || toolChoice === null) return toolChoice
+  if (typeof toolChoice === 'string') {
+    if (!['auto', 'none', 'required'].includes(toolChoice)) {
+      throw new Error(`Unsupported Responses tool_choice: ${toolChoice}`)
+    }
+    return toolChoice
+  }
+  if (
+    toolChoice &&
+    typeof toolChoice === 'object' &&
+    (toolChoice as JsonObject).type === 'function' &&
+    typeof (toolChoice as JsonObject).name === 'string'
+  ) {
+    return { type: 'function', function: { name: (toolChoice as JsonObject).name } }
+  }
+  throw new Error('Only function tool_choice values are supported by the Chat Completions bridge')
+}
+
+export const responsesToChatRequest = (
+  body: JsonObject,
+  upstreamModel?: string,
+  reasoningByCallId?: Map<string, string>,
+  namespacedTools: readonly ResponsesBridgeNamespacedTool[] = [],
+  options?: ResponsesRequestAdapterOptions
+): JsonObject => {
+  for (const field of UNSUPPORTED_FIELDS) {
+    if (body[field] !== undefined && body[field] !== null) {
+      throw new Error(`Responses field "${field}" is not supported by this gateway`)
+    }
+  }
+  if (body.stream !== undefined && typeof body.stream !== 'boolean') {
+    throw new Error('Responses stream must be a boolean')
+  }
+  if (body.include !== undefined && body.include !== null) {
+    if (!Array.isArray(body.include)) throw new Error('Responses include must be an array')
+    for (const value of body.include) {
+      if (typeof value !== 'string' || !ALLOWED_INCLUDE_VALUES.has(value)) {
+        throw new Error(
+          `Responses include value is not supported by this gateway: ${String(value)}`
+        )
+      }
+    }
+  }
+  if (body.reasoning !== undefined && body.reasoning !== null) {
+    if (typeof body.reasoning !== 'object' || Array.isArray(body.reasoning)) {
+      throw new Error('Responses reasoning must be an object')
+    }
+    for (const key of Object.keys(body.reasoning)) {
+      if (!ALLOWED_REASONING_KEYS.has(key)) {
+        throw new Error(`Responses reasoning field is not supported by this gateway: ${key}`)
+      }
+    }
+    const effort = body.reasoning.effort
+    if (effort !== undefined && effort !== null && !ALLOWED_REASONING_EFFORTS.has(String(effort))) {
+      throw new Error(`Unsupported Responses reasoning effort: ${String(effort)}`)
+    }
+    const summary = body.reasoning.summary
+    if (
+      summary !== undefined &&
+      summary !== null &&
+      !ALLOWED_REASONING_SUMMARIES.has(String(summary))
+    ) {
+      throw new Error(`Unsupported Responses reasoning summary: ${String(summary)}`)
+    }
+  }
+  if (body.store !== undefined && body.store !== false && body.store !== null) {
+    throw new Error('Stored Responses are not supported by this gateway')
+  }
+  if (
+    body.prompt_cache_key !== undefined &&
+    body.prompt_cache_key !== null &&
+    typeof body.prompt_cache_key !== 'string'
+  ) {
+    throw new Error('Responses prompt_cache_key must be a string')
+  }
+  if (
+    body.max_output_tokens !== undefined &&
+    body.max_output_tokens !== null &&
+    typeof body.max_output_tokens !== 'number'
+  ) {
+    throw new Error('Responses max_output_tokens must be a number')
+  }
+
+  const tools = toolsToChat(body.tools ?? [], namespacedTools)
+  const hasTools = Boolean(tools && tools.length > 0)
+  const requestedToolChoice =
+    body.tool_choice === undefined ? undefined : toolChoiceToChat(body.tool_choice)
+  const toolChoice = hasTools ? requestedToolChoice : undefined
+  const stream = body.stream !== false
+  const chatReasoningEffort = options?.reasoningEffortOverride
+  const reasoningTransport = chatReasoningEffort
+    ? resolveChatReasoningTransport(
+        options?.vendorId,
+        upstreamModel,
+        chatReasoningEffort,
+        options?.reasoningEffortTransport
+      )
+    : undefined
+
+  return {
+    model: upstreamModel ?? body.model,
+    messages: inputToMessages(body, reasoningByCallId, namespacedTools),
+    ...(hasTools ? { tools } : {}),
+    ...(toolChoice === undefined ? {} : { tool_choice: toolChoice }),
+    ...(!hasTools || body.parallel_tool_calls === undefined
+      ? {}
+      : { parallel_tool_calls: body.parallel_tool_calls }),
+    ...(body.temperature === undefined ? {} : { temperature: body.temperature }),
+    ...(body.top_p === undefined ? {} : { top_p: body.top_p }),
+    ...(body.max_output_tokens === undefined || body.max_output_tokens === null
+      ? {}
+      : { max_tokens: body.max_output_tokens }),
+    ...(reasoningTransport?.reasoningEffort
+      ? { reasoning_effort: reasoningTransport.reasoningEffort }
+      : {}),
+    ...(reasoningTransport?.thinking ? { thinking: reasoningTransport.thinking } : {}),
+    ...(reasoningTransport?.reasoning ? { reasoning: reasoningTransport.reasoning } : {}),
+    stream,
+    ...(stream ? { stream_options: { include_usage: true } } : {})
+  }
+}

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -278,8 +278,8 @@ describe('Settings backend ownership architecture', () => {
     expect(rawLineCount(readSource(settingsPaths.recordCodec))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(1283)
     expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1407)
-    expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(1423)
-    expect(rawLineCount(readSource(settingsPaths.service))).toBeLessThanOrEqual(1000)
+    expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(950)
+    expect(rawLineCount(readSource(settingsPaths.service))).toBeLessThanOrEqual(1003)
   })
 
   it('locks the stable module export inventories', () => {
@@ -442,8 +442,7 @@ describe('Settings backend ownership architecture', () => {
       `
         addCustomServer addManualInterpreter authenticateCustomServer buildCustomServerTemplateExport
         buildSkillExport cancelClaudeIsolatedLogin cancelClaudeLogin cancelCodexLogin
-        cancelCustomServerAuthentication captureActiveAgentBackendSelection
-        captureActiveExplicitAgentBackendTarget checkEnvironment codexSkillCatalog
+        cancelCustomServerAuthentication captureActiveAgentBackendSelection captureActiveExplicitAgentBackendTarget checkEnvironment codexSkillCatalog
         codexSkillDescriptorsForIds createSkill deleteProvider deleteSkill detectClaude detectCodex
         detectOpencode dismissLegacyDataMovePrompt getAppIconVariant getClosePreference
         getComputeBookmarks getConnectorDetail getConnectors getConversationSkillImportEnabled
@@ -451,12 +450,12 @@ describe('Settings backend ownership architecture', () => {
         getPreflight getRuntimeEnablement getRuntimeSelection getSettingsView getSkillDetail
         getStoredSettings importAgentHomeSkills importSkill importSkillArchiveBatch importSkillZip
         importSkillZipBatch installClaude installCodex installOpencode isEncryptionAvailable
-        isNpmAvailable listAgentHomeSkills listConnectors listSkills listSpecialistSkillCatalog
+        isNpmAvailable listAgentHomeSkills listConnectors listHostSkills listSkills listSpecialistSkillCatalog
         loginClaudeShared loginIsolatedClaude loginIsolatedClaudeBrowser loginIsolatedCodex
         logoutClaudeShared logoutIsolatedClaude logoutIsolatedCodex markOnboardingComplete
         markPathsNormalized previewAgentHomeSkill previewCustomServerTemplateExport
         previewCustomServerTemplateImport previewGitHubSkill previewSkillArchive previewSkillZip
-        provisionedConnectorSkillNames refreshProviderModels removeCustomServer removeGitHubToken
+        provisionedConnectorSkillNames publishHostSkill refreshProviderModels removeCustomServer removeGitHubToken
         removeManualInterpreter resolveActiveModelChangeTarget resolveActiveReasoningEffort
         resolveAgentBackend resolveExplicitAgentBackend saveCustomServerOAuthState saveGitHubToken
         scanRepoSkills setActiveProvider setAgentFramework setAppIconVariant setClosePreference
@@ -466,7 +465,7 @@ describe('Settings backend ownership architecture', () => {
         setMaterializedCustomSkillNamesProvider setNcbiCredentials setNotificationsEnabled
         setPackageMirror setReasoningEffort setRuntimeSelection setSkillDeletionGuard setSkillEnabled
         setToolPermission skillNudgeNamesForIds skillsNeedingForceLoad uninstallClaude uninstallCodex
-        uninstallOpencode updateCustomServer updateSkill upsertProvider validateProvider
+        uninstallOpencode updateCustomServer updateSkill upsertProvider validateProvider withHostSkillRead
       `
         .trim()
         .split(/\s+/)
@@ -610,7 +609,8 @@ describe('Settings backend ownership architecture', () => {
     ])
     expect(manifest.modules.settings_backend_resolution.ownerPaths).toEqual([
       'src/main/settings/backend-resolver.ts',
-      'src/main/settings/responses-bridge.ts'
+      'src/main/settings/responses-bridge.ts',
+      'src/main/settings/responses-request-adapter.ts'
     ])
     expect(manifest.modules.settings_service_facade.interfacePaths).toEqual([
       'src/main/settings/service.ts',


### PR DESCRIPTION
## Problem

`responses-bridge.ts` mixed stateless Responses-to-Chat request conversion with response projection,
streaming, HTTP authentication, and trusted-session lifecycle. This made strict request validation,
image conversion, replayed tool calls, tool namespace aliases, and reasoning transport difficult to
review independently.

## Proposed change

- Extract request conversion into a stateless `responses-request-adapter.ts` owner.
- Keep `responsesToChatRequest`, `inputToMessages`, `toolsToChat`, and the namespaced-tool type
  available from `responses-bridge.ts` through compatible re-exports.
- Route the bridge facade through the extracted adapter without changing request ordering or error
  semantics.
- Add focused behavior and architecture contracts, and register the owner in the module-impact graph.

## Scope and non-goals

- This PR changes only the Responses request direction.
- Response/JSON projection and SSE streaming remain in `responses-bridge.ts` for R2.
- HTTP server startup, bearer-token authentication, abort/close handling, trusted Reviewer/tool-less
  session scopes, and the reasoning replay cache remain in the facade.
- No provider route, transport generation, model catalog, IPC, persistent data, UI, or orchestration
  behavior is added or changed.

## Compatibility

- Public imports remain valid through facade re-exports.
- Accepted and rejected Responses fields, image validation, parallel tool-call replay, unsupported
  built-in filtering, tool choice, output limits, provider-native reasoning transport, and Notebook /
  Reviewer namespace aliases retain their existing behavior.
- Electron, Web, CLI, Task, Notebook local RPC, MCP, Specialist, Permission, and Compute capability
  asymmetries are unchanged; the adapter introduces no new cross-surface command.
- The SettingsService ceiling and method inventory are aligned to the already-merged #1001 baseline
  (`listHostSkills`, `publishHostSkill`, and `withHostSkillRead`); this is contract alignment, not an
  R1 behavior change.
- Paths and tests use project-relative or Node portable path operations for Windows, macOS, and Linux.

## Acceptance criteria and validation

- Production raw: new request adapter 448 lines; `responses-bridge.ts` reduced from 1,423 to 950
  lines. Central Settings architecture test remains 660 lines; the new architecture test is 168.
- `npm run test:module -- settings_backend_resolution`: 21 passed / 1 skipped files; 362 passed / 3
  skipped tests.
- Focused validation and impact routing: 3 files and 61 tests passed.
- Final architecture/manifest checks after the last edit: 3 files and 20 tests passed.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors and 17 pre-existing warnings.
- Changed-file Prettier check and `git diff --check`: passed.
- Independent Standards review: 0 findings. Independent Spec review: 0 findings.
- Because this PR updates ownership routing in `module-impact.json`, exact-head CI provides the
  authoritative full fallback and Windows/macOS/Linux coverage before merge.

## Review focus

- Compare request-field acceptance/rejection and conversion ordering against the prior bridge code.
- Check images, parallel/replayed tool calls, namespace aliases, tool filtering, and reasoning
  transport for lossy or permissive changes.
- Confirm response/SSE and HTTP/session state did not move into the stateless adapter.
- Confirm the impact owner and downstream test expansion remain complete.
