### PR TITLE
refactor(settings): extract document codec

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -211,7 +211,11 @@
       "fallbackCapability": "main_runtime"
     },
     "settings_repository": {
-      "ownerPaths": ["src/main/settings/repository.ts", "src/main/settings/record-codec.ts"],
+      "ownerPaths": [
+        "src/main/settings/repository.ts",
+        "src/main/settings/record-codec.ts",
+        "src/main/settings/document-codec.ts"
+      ],
       "interfacePaths": ["src/main/settings/repository.ts"],
       "consumerModules": [
         "settings_provider_accounts",
@@ -221,6 +225,7 @@
       "testFiles": {
         "owner": [
           "src/main/settings/settings-backend.architecture.test.ts",
+          "src/main/settings/document-codec.test.ts",
           "src/main/settings/record-codec.test.ts",
           "src/main/settings/repository.test.ts",
           "src/main/settings/compute-grants.test.ts",

--- a/src/main/settings/document-codec.test.ts
+++ b/src/main/settings/document-codec.test.ts
@@ -1,0 +1,65 @@
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { CODEX_SUBSCRIPTION_PROVIDER_ID, SETTINGS_FILE_VERSION } from '../../shared/settings'
+import { sanitizeSettings } from './document-codec'
+
+describe('settings document codec', () => {
+  it('exposes one pure document boundary', async () => {
+    expect(Object.keys(await import('./document-codec')).sort()).toEqual(['sanitizeSettings'])
+  })
+
+  it('fails closed for corrupt input', () => {
+    expect(sanitizeSettings(null)).toEqual({ version: SETTINGS_FILE_VERSION, providers: [] })
+    expect(sanitizeSettings(['not', 'a', 'document'])).toEqual({
+      version: SETTINGS_FILE_VERSION,
+      providers: []
+    })
+  })
+
+  it('preserves cross-field migrations and durable settings families', () => {
+    const dataRoot = resolve('portable-settings-data')
+    const settings = sanitizeSettings({
+      providers: [
+        {
+          id: 'builtin-codex-shared',
+          type: 'codex-shared',
+          name: 'Legacy Codex',
+          model: 'codex-model',
+          keyRef: 'encrypted:key',
+          keyMask: 'sk-…abcd',
+          apiKey: 'plaintext-must-not-survive'
+        }
+      ],
+      activeProviderId: 'builtin-codex-shared',
+      connectors: { enabledIds: ['pubmed'], autoAllowIds: [] },
+      computeGrants: [{ projectId: 'p1', operation: 'download', providerId: 'c1' }],
+      notebookRuntimes: { python: { source: 'managed' } },
+      defaultPermissionProfile: 'ask',
+      dataRoot,
+      unknown: true
+    })
+
+    expect(settings).toMatchObject({
+      version: SETTINGS_FILE_VERSION,
+      activeProviderId: CODEX_SUBSCRIPTION_PROVIDER_ID,
+      activeModel: 'codex-model',
+      connectors: { enabledIds: ['pubmed'], autoAllowIds: [] },
+      computeGrants: [{ projectId: 'p1', operation: 'download', providerId: 'c1' }],
+      notebookRuntimes: { python: { source: 'managed' } },
+      defaultPermissionProfile: 'ask',
+      dataRoot
+    })
+    expect(settings.providers).toEqual([
+      expect.objectContaining({
+        id: CODEX_SUBSCRIPTION_PROVIDER_ID,
+        type: 'codex-isolated',
+        keyRef: 'encrypted:key',
+        keyMask: 'sk-…abcd'
+      })
+    ])
+    expect(settings.providers[0]).not.toHaveProperty('apiKey')
+    expect(settings).not.toHaveProperty('unknown')
+  })
+})

--- a/src/main/settings/document-codec.ts
+++ b/src/main/settings/document-codec.ts
@@ -1,0 +1,274 @@
+import { isAbsolute, normalize, parse } from 'node:path'
+
+import {
+  CODEX_SUBSCRIPTION_PROVIDER_ID,
+  SETTINGS_FILE_VERSION,
+  codexSubscriptionProviderIdentity,
+  isAppIconVariant,
+  isClaudeSubscriptionProvider,
+  isClaudeSubscriptionProviderId,
+  isCodexSubscriptionProvider,
+  isCodexSubscriptionProviderId,
+  isReasoningEffort
+} from '../../shared/settings'
+import { isPermissionProfileId } from '../../shared/permission-profiles'
+import type { NotebookLanguage } from '../../shared/notebook'
+import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
+import {
+  createEmptySettings,
+  type StoredComputeGrant,
+  type StoredProvider,
+  type StoredSettings
+} from './types'
+import {
+  sanitizeClaudeInfo,
+  sanitizeCodexInfo,
+  sanitizeComputeGrant,
+  sanitizeConnectors,
+  sanitizePackageMirror,
+  sanitizeProvider
+} from './record-codec'
+
+// Checks for plain JSON objects so untrusted settings payloads can be sanitized safely.
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : []
+
+const asBoolean = (value: unknown): boolean | undefined =>
+  typeof value === 'boolean' ? value : undefined
+
+// Rebuilds a record<string,boolean>, dropping any key whose value isn't a boolean. Returns an empty
+// record (never undefined) for a non-record input so callers get a stable, always-mergeable map.
+const asBooleanRecord = (value: unknown): Record<string, boolean> => {
+  if (!isRecord(value)) return {}
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, boolean] => typeof entry[1] === 'boolean'
+  )
+  return Object.fromEntries(entries)
+}
+
+// Validates the per-language manual-interpreter catalog without applying platform-specific rules.
+const sanitizeManualInterpreters = (
+  value: unknown
+): Partial<Record<NotebookLanguage, string[]>> | undefined => {
+  if (!isRecord(value)) return undefined
+  const result: Partial<Record<NotebookLanguage, string[]>> = {}
+  for (const language of ['python', 'r'] as const) {
+    const paths = asStringArray(value[language])
+    const cleaned = [...new Set(paths.map((path) => path.trim()).filter(Boolean))]
+    if (cleaned.length > 0) result[language] = cleaned
+  }
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+// Validates one persisted RuntimeSelection and defaults explicit authority flags to false.
+const sanitizeRuntimeSelection = (value: unknown): RuntimeSelection | undefined => {
+  if (!isRecord(value)) return undefined
+  if (value.source === 'managed') return { source: 'managed' }
+  if (value.source !== 'external') return undefined
+  const interpreterPath = asString(value.interpreterPath)
+  if (!interpreterPath) return undefined
+  const interpreterArgs = asStringArray(value.interpreterArgs)
+  return {
+    source: 'external',
+    interpreterPath,
+    ...(interpreterArgs.length > 0 ? { interpreterArgs } : {}),
+    appOwnedOverlay: value.appOwnedOverlay === true,
+    packageInstallAuthorized: value.packageInstallAuthorized === true
+  }
+}
+
+// Keeps only known languages; R remains managed-only in the current persisted contract.
+const sanitizeNotebookRuntimes = (
+  value: unknown
+): Partial<Record<NotebookLanguage, RuntimeSelection>> | undefined => {
+  if (!isRecord(value)) return undefined
+  const result: Partial<Record<NotebookLanguage, RuntimeSelection>> = {}
+  for (const language of ['python', 'r'] as const) {
+    const selection = sanitizeRuntimeSelection(value[language])
+    if (!selection || (language === 'r' && selection.source === 'external')) continue
+    result[language] = selection
+  }
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+const sanitizeRuntimeEnablementEntry = (value: unknown): RuntimeEnablement => ({
+  enabled: asBooleanRecord(isRecord(value) ? value.enabled : undefined),
+  installAuthorized: asBooleanRecord(isRecord(value) ? value.installAuthorized : undefined)
+})
+
+const sanitizeRuntimeEnablement = (
+  value: unknown
+): Partial<Record<NotebookLanguage, RuntimeEnablement>> | undefined => {
+  if (!isRecord(value)) return undefined
+  const result: Partial<Record<NotebookLanguage, RuntimeEnablement>> = {}
+  for (const language of ['python', 'r'] as const) {
+    const entry = sanitizeRuntimeEnablementEntry(value[language])
+    if (Object.keys(entry.enabled).length || Object.keys(entry.installAuthorized).length) {
+      result[language] = entry
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+// Rebuilds the whole settings document, applying migrations before cross-field selection cleanup.
+const sanitizeSettings = (value: unknown): StoredSettings => {
+  if (!isRecord(value)) return createEmptySettings()
+
+  const sanitizedProviders = Array.isArray(value.providers)
+    ? value.providers
+        .map(sanitizeProvider)
+        .filter((provider): provider is StoredProvider => !!provider)
+    : []
+  const legacyActiveProviderId = asString(value.activeProviderId)
+  const codexProviders = sanitizedProviders.filter((provider) =>
+    isCodexSubscriptionProvider(provider.type)
+  )
+  const selectedCodexProvider =
+    codexProviders.find((provider) => provider.id === legacyActiveProviderId) ?? codexProviders[0]
+  const migratedCodexProvider = selectedCodexProvider
+    ? {
+        ...selectedCodexProvider,
+        id: CODEX_SUBSCRIPTION_PROVIDER_ID,
+        type: 'codex-isolated' as const,
+        codexAuthMode: selectedCodexProvider.codexAuthMode ?? 'isolated',
+        name: codexSubscriptionProviderIdentity().name
+      }
+    : undefined
+
+  // Legacy shared validation describes the global home, not the app-owned isolated profile.
+  if (selectedCodexProvider?.type === 'codex-shared' && migratedCodexProvider) {
+    delete migratedCodexProvider.lastValidatedAt
+    delete migratedCodexProvider.lastValidationFailure
+    delete migratedCodexProvider.expiresAt
+  }
+
+  const providers = [
+    ...sanitizedProviders.filter((provider) => !isCodexSubscriptionProvider(provider.type)),
+    ...(migratedCodexProvider ? [migratedCodexProvider] : [])
+  ]
+  const settings: StoredSettings = { version: SETTINGS_FILE_VERSION, providers }
+  const claudeSubscriptionProviderId = asString(value.claudeSubscriptionProviderId)
+  if (
+    claudeSubscriptionProviderId &&
+    isClaudeSubscriptionProviderId(claudeSubscriptionProviderId) &&
+    providers.some(
+      (provider) =>
+        provider.id === claudeSubscriptionProviderId && isClaudeSubscriptionProvider(provider.type)
+    )
+  ) {
+    settings.claudeSubscriptionProviderId = claudeSubscriptionProviderId
+  }
+
+  const claude = sanitizeClaudeInfo(value.claude)
+  const codex = sanitizeCodexInfo(value.codex)
+  const activeProviderId =
+    legacyActiveProviderId && isCodexSubscriptionProviderId(legacyActiveProviderId)
+      ? CODEX_SUBSCRIPTION_PROVIDER_ID
+      : legacyActiveProviderId
+  if (claude) settings.claude = claude
+  if (codex) settings.codex = codex
+  if (activeProviderId && providers.some((provider) => provider.id === activeProviderId)) {
+    settings.activeProviderId = activeProviderId
+    const activeProvider = providers.find((provider) => provider.id === activeProviderId)
+    const activeModel = asString(value.activeModel) ?? activeProvider?.model
+    if (activeModel) settings.activeModel = activeModel
+  }
+
+  const onboardingCompletedAt = asNumber(value.onboardingCompletedAt)
+  if (onboardingCompletedAt !== undefined) settings.onboardingCompletedAt = onboardingCompletedAt
+
+  const disabledSkillIds = Array.isArray(value.disabledSkillIds)
+    ? [
+        ...new Set(
+          value.disabledSkillIds.filter(
+            (entry): entry is string => typeof entry === 'string' && entry !== ''
+          )
+        )
+      ]
+    : []
+  if (disabledSkillIds.length > 0) settings.disabledSkillIds = disabledSkillIds
+
+  const githubTokenRef = asString(value.githubTokenRef)
+  const githubTokenMask = asString(value.githubTokenMask)
+  if (githubTokenRef) settings.githubTokenRef = githubTokenRef
+  if (githubTokenMask) settings.githubTokenMask = githubTokenMask
+
+  const connectors = sanitizeConnectors(value.connectors)
+  if (connectors) settings.connectors = connectors
+  const packageMirror = sanitizePackageMirror(value.packageMirror)
+  if (packageMirror) settings.packageMirror = packageMirror
+
+  const pathsNormalizedAt = asNumber(value.pathsNormalizedAt)
+  if (pathsNormalizedAt !== undefined) settings.pathsNormalizedAt = pathsNormalizedAt
+  const legacyDataMovePromptDismissedAt = asNumber(value.legacyDataMovePromptDismissedAt)
+  if (legacyDataMovePromptDismissedAt !== undefined) {
+    settings.legacyDataMovePromptDismissedAt = legacyDataMovePromptDismissedAt
+  }
+
+  // Keep absolute paths canonical without stripping a filesystem root on any supported platform.
+  const dataRoot = asString(value.dataRoot)?.trim()
+  if (dataRoot && isAbsolute(dataRoot)) {
+    const normalized = normalize(dataRoot)
+    const { root } = parse(normalized)
+    settings.dataRoot =
+      normalized.length > root.length ? normalized.replace(/[\\/]+$/, '') : normalized
+  }
+
+  const agentFrameworkId = asString(value.agentFrameworkId)
+  if (
+    agentFrameworkId === 'claude-code' ||
+    agentFrameworkId === 'opencode' ||
+    agentFrameworkId === 'codex'
+  ) {
+    settings.agentFrameworkId = agentFrameworkId
+  }
+  const reasoningEffort = asString(value.reasoningEffort)
+  if (isReasoningEffort(reasoningEffort)) settings.reasoningEffort = reasoningEffort
+  const notificationsEnabled = asBoolean(value.notificationsEnabled)
+  if (notificationsEnabled !== undefined) settings.notificationsEnabled = notificationsEnabled
+  const conversationSkillImportEnabled = asBoolean(value.conversationSkillImportEnabled)
+  if (conversationSkillImportEnabled !== undefined) {
+    settings.conversationSkillImportEnabled = conversationSkillImportEnabled
+  }
+  const closePreference = asString(value.closePreference)
+  if (closePreference === 'minimize' || closePreference === 'quit') {
+    settings.closePreference = closePreference
+  }
+  if (isAppIconVariant(value.appIconVariant)) settings.appIconVariant = value.appIconVariant
+  if (isPermissionProfileId(value.defaultPermissionProfile)) {
+    settings.defaultPermissionProfile = value.defaultPermissionProfile
+  }
+
+  const opencodePath = asString(value.opencodePath)
+  if (opencodePath) {
+    settings.opencodePath = opencodePath
+    const opencodeVersion = asString(value.opencodeVersion)
+    if (opencodeVersion) settings.opencodeVersion = opencodeVersion
+  }
+
+  const notebookRuntimes = sanitizeNotebookRuntimes(value.notebookRuntimes)
+  if (notebookRuntimes) settings.notebookRuntimes = notebookRuntimes
+  const notebookRuntimeEnablement = sanitizeRuntimeEnablement(value.notebookRuntimeEnablement)
+  if (notebookRuntimeEnablement) settings.notebookRuntimeEnablement = notebookRuntimeEnablement
+  const notebookManualInterpreters = sanitizeManualInterpreters(value.notebookManualInterpreters)
+  if (notebookManualInterpreters) settings.notebookManualInterpreters = notebookManualInterpreters
+
+  const computeGrants = Array.isArray(value.computeGrants)
+    ? value.computeGrants
+        .map(sanitizeComputeGrant)
+        .filter((grant): grant is StoredComputeGrant => grant !== undefined)
+    : undefined
+  if (computeGrants?.length) settings.computeGrants = computeGrants
+  return settings
+}
+
+export { sanitizeSettings }

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -3,7 +3,8 @@ import { isAbsolute, join, normalize, sep } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { SettingsRepository, sanitizeSettings } from './repository'
+import { sanitizeSettings } from './document-codec'
+import { SettingsRepository } from './repository'
 import type { StoredProvider } from './types'
 
 // Capture the warn calls the repository makes through createLogger. vi.hoisted runs before the
@@ -1052,17 +1053,19 @@ describe('settings repository: v2 official providers & activeModel migration', (
     expect((await repository.getSettings()).notebookRuntimes).toBeUndefined()
   })
 
-  it('rejects a malformed runtime selection (no interpreter path)', async () => {
+  it('rejects malformed runtime selections before applying language constraints', async () => {
     const repository = new SettingsRepository(await createStorageRoot())
 
-    await expect(
-      repository.setRuntimeSelection('python', {
-        source: 'external',
-        interpreterPath: '',
-        appOwnedOverlay: false,
-        packageInstallAuthorized: false
-      })
-    ).rejects.toThrow(/invalid/i)
+    for (const language of ['python', 'r'] as const) {
+      await expect(
+        repository.setRuntimeSelection(language, {
+          source: 'external',
+          interpreterPath: '',
+          appOwnedOverlay: false,
+          packageInstallAuthorized: false
+        })
+      ).rejects.toThrow(/invalid/i)
+    }
   })
 
   it('persists and clears a per-language runtime enablement via setRuntimeEnablement', async () => {

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
-import { isAbsolute, join, normalize, parse } from 'node:path'
+import { join } from 'node:path'
 import { isDeepStrictEqual } from 'node:util'
 
 import type {
@@ -12,18 +12,11 @@ import type {
 import {
   CLAUDE_ISOLATED_PROVIDER_ID,
   CLAUDE_SHARED_PROVIDER_ID,
-  CODEX_SUBSCRIPTION_PROVIDER_ID,
-  SETTINGS_FILE_VERSION,
   claudeIsolatedProviderIdentity,
-  codexSubscriptionProviderIdentity,
-  isAppIconVariant,
   isClaudeSubscriptionProvider,
-  isClaudeSubscriptionProviderId,
-  isCodexSubscriptionProvider,
-  isCodexSubscriptionProviderId,
-  isReasoningEffort
+  isClaudeSubscriptionProviderId
 } from '../../shared/settings'
-import { isPermissionProfileId, type PermissionProfileId } from '../../shared/permission-profiles'
+import type { PermissionProfileId } from '../../shared/permission-profiles'
 import type { PackageMirror } from '../../shared/mirror'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
@@ -38,365 +31,10 @@ import {
   type StoredProvider,
   type StoredSettings
 } from './types'
-import {
-  sanitizeClaudeInfo,
-  sanitizeCodexInfo,
-  sanitizeComputeGrant,
-  sanitizeConnectors,
-  sanitizePackageMirror,
-  sanitizeProvider
-} from './record-codec'
+import { sanitizePackageMirror } from './record-codec'
+import { sanitizeSettings } from './document-codec'
 
 const SETTINGS_FILE = 'settings.json'
-
-// Checks for plain JSON objects so untrusted settings payloads can be sanitized safely.
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value)
-
-const asString = (value: unknown): string | undefined =>
-  typeof value === 'string' ? value : undefined
-
-const asNumber = (value: unknown): number | undefined =>
-  typeof value === 'number' && Number.isFinite(value) ? value : undefined
-
-const asStringArray = (value: unknown): string[] =>
-  Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : []
-
-const asBoolean = (value: unknown): boolean | undefined =>
-  typeof value === 'boolean' ? value : undefined
-
-// Rebuilds a record<string,boolean>, dropping any key whose value isn't a boolean. Returns an empty
-// record (never undefined) for a non-record input so callers get a stable, always-mergeable map.
-const asBooleanRecord = (value: unknown): Record<string, boolean> => {
-  if (!isRecord(value)) return {}
-
-  const entries = Object.entries(value).filter(
-    (entry): entry is [string, boolean] => typeof entry[1] === 'boolean'
-  )
-
-  return Object.fromEntries(entries)
-}
-
-// Rebuilds the whole settings document, keeping activeProviderId only when it points at a provider.
-const sanitizeSettings = (value: unknown): StoredSettings => {
-  if (!isRecord(value)) return createEmptySettings()
-
-  const sanitizedProviders = Array.isArray(value.providers)
-    ? value.providers
-        .map(sanitizeProvider)
-        .filter((provider): provider is StoredProvider => !!provider)
-    : []
-  const legacyActiveProviderId = asString(value.activeProviderId)
-  const codexProviders = sanitizedProviders.filter((provider) =>
-    isCodexSubscriptionProvider(provider.type)
-  )
-  const activeCodexProvider = codexProviders.find(
-    (provider) => provider.id === legacyActiveProviderId
-  )
-  const selectedCodexProvider = activeCodexProvider ?? codexProviders[0]
-  const migratedCodexProvider = selectedCodexProvider
-    ? {
-        ...selectedCodexProvider,
-        id: CODEX_SUBSCRIPTION_PROVIDER_ID,
-        // `codex-shared` is legacy setup input only. Runtime always uses the app-owned
-        // subscription home, so sanitized/newly persisted state has one isolated form.
-        type: 'codex-isolated' as const,
-        // Releases before codexAuthMode normalized both setup choices to the subscription id, so
-        // that shape is ambiguous. Prefer isolated to preserve the established runtime behavior;
-        // legacy shared users can explicitly re-import into the new app-owned profile.
-        codexAuthMode: selectedCodexProvider.codexAuthMode ?? 'isolated',
-        name: codexSubscriptionProviderIdentity().name
-      }
-    : undefined
-
-  // A legacy shared provider's validation describes credentials in the user's global Codex home,
-  // not the isolated home selected above. Do not present that stale state as an app-owned login;
-  // the Settings card will offer a fresh sign-in instead.
-  if (selectedCodexProvider?.type === 'codex-shared' && migratedCodexProvider) {
-    delete migratedCodexProvider.lastValidatedAt
-    delete migratedCodexProvider.lastValidationFailure
-    delete migratedCodexProvider.expiresAt
-  }
-
-  const providers = [
-    ...sanitizedProviders.filter((provider) => !isCodexSubscriptionProvider(provider.type)),
-    ...(migratedCodexProvider ? [migratedCodexProvider] : [])
-  ]
-  const settings: StoredSettings = {
-    version: SETTINGS_FILE_VERSION,
-    providers
-  }
-  const claudeSubscriptionProviderId = asString(value.claudeSubscriptionProviderId)
-
-  if (
-    claudeSubscriptionProviderId &&
-    isClaudeSubscriptionProviderId(claudeSubscriptionProviderId) &&
-    providers.some(
-      (provider) =>
-        provider.id === claudeSubscriptionProviderId && isClaudeSubscriptionProvider(provider.type)
-    )
-  ) {
-    settings.claudeSubscriptionProviderId = claudeSubscriptionProviderId
-  }
-  const claude = sanitizeClaudeInfo(value.claude)
-  const codex = sanitizeCodexInfo(value.codex)
-  const activeProviderId =
-    legacyActiveProviderId && isCodexSubscriptionProviderId(legacyActiveProviderId)
-      ? CODEX_SUBSCRIPTION_PROVIDER_ID
-      : legacyActiveProviderId
-
-  if (claude) settings.claude = claude
-  if (codex) settings.codex = codex
-  if (activeProviderId && providers.some((provider) => provider.id === activeProviderId)) {
-    settings.activeProviderId = activeProviderId
-
-    // activeModel migration: v2 stores it explicitly; a pre-v2 file has none, so backfill from the
-    // active provider's own model (which was the only model it could run).
-    const activeProvider = providers.find((provider) => provider.id === activeProviderId)
-    const activeModel = asString(value.activeModel) ?? activeProvider?.model
-
-    if (activeModel) settings.activeModel = activeModel
-  }
-
-  const onboardingCompletedAt = asNumber(value.onboardingCompletedAt)
-
-  if (onboardingCompletedAt !== undefined) {
-    settings.onboardingCompletedAt = onboardingCompletedAt
-  }
-
-  const disabledSkillIds = Array.isArray(value.disabledSkillIds)
-    ? [
-        ...new Set(
-          value.disabledSkillIds.filter(
-            (entry): entry is string => typeof entry === 'string' && entry !== ''
-          )
-        )
-      ]
-    : []
-
-  if (disabledSkillIds.length > 0) {
-    settings.disabledSkillIds = disabledSkillIds
-  }
-
-  const githubTokenRef = asString(value.githubTokenRef)
-  const githubTokenMask = asString(value.githubTokenMask)
-
-  if (githubTokenRef) settings.githubTokenRef = githubTokenRef
-  if (githubTokenMask) settings.githubTokenMask = githubTokenMask
-
-  const connectors = sanitizeConnectors(value.connectors)
-
-  if (connectors) settings.connectors = connectors
-
-  const packageMirror = sanitizePackageMirror(value.packageMirror)
-
-  if (packageMirror) settings.packageMirror = packageMirror
-
-  const pathsNormalizedAt = asNumber(value.pathsNormalizedAt)
-
-  if (pathsNormalizedAt !== undefined) {
-    settings.pathsNormalizedAt = pathsNormalizedAt
-  }
-
-  const legacyDataMovePromptDismissedAt = asNumber(value.legacyDataMovePromptDismissedAt)
-
-  if (legacyDataMovePromptDismissedAt !== undefined) {
-    settings.legacyDataMovePromptDismissedAt = legacyDataMovePromptDismissedAt
-  }
-
-  // Only accept an absolute, normalized dataRoot. A relative path (corrupt or hand-edited
-  // settings.json) would make the entire data tree resolve against process.cwd(); drop it so
-  // initDataRoot falls back to the default. Mirrors the OPEN_SCIENCE_STORAGE_ROOT absolute contract.
-  const dataRoot = asString(value.dataRoot)?.trim()
-
-  if (dataRoot && isAbsolute(dataRoot)) {
-    // normalize collapses redundant separators; strip any trailing separator so the stored form
-    // matches dataRootForPicked's canonical (no-trailing-slash) output — samePath() compares exact
-    // strings, so a stray trailing slash would wrongly fail the "is default" check. Never strip past a
-    // filesystem root, though: turning "C:\" into "C:" would make an absolute path drive-relative.
-    const normalized = normalize(dataRoot)
-    const { root } = parse(normalized)
-    settings.dataRoot =
-      normalized.length > root.length ? normalized.replace(/[\\/]+$/, '') : normalized
-  }
-
-  // Selected agent backend; only the known ids survive so a bad value can't leak through.
-  const agentFrameworkId = asString(value.agentFrameworkId)
-
-  if (
-    agentFrameworkId === 'claude-code' ||
-    agentFrameworkId === 'opencode' ||
-    agentFrameworkId === 'codex'
-  ) {
-    settings.agentFrameworkId = agentFrameworkId
-  }
-
-  // Reasoning-effort preference; only the known levels survive so a bad value can't leak through.
-  const reasoningEffort = asString(value.reasoningEffort)
-
-  if (isReasoningEffort(reasoningEffort)) {
-    settings.reasoningEffort = reasoningEffort
-  }
-
-  // Desktop-notification preference; only a real boolean survives.
-  const notificationsEnabled = asBoolean(value.notificationsEnabled)
-
-  if (notificationsEnabled !== undefined) {
-    settings.notificationsEnabled = notificationsEnabled
-  }
-
-  // Conversation Skill import preference; only a real boolean survives.
-  const conversationSkillImportEnabled = asBoolean(value.conversationSkillImportEnabled)
-
-  if (conversationSkillImportEnabled !== undefined) {
-    settings.conversationSkillImportEnabled = conversationSkillImportEnabled
-  }
-
-  const closePreference = asString(value.closePreference)
-
-  if (closePreference === 'minimize' || closePreference === 'quit') {
-    settings.closePreference = closePreference
-  }
-
-  // App-icon look; only a known variant survives so a bad value can't leak through.
-  const appIconVariant = value.appIconVariant
-
-  if (isAppIconVariant(appIconVariant)) {
-    settings.appIconVariant = appIconVariant
-  }
-
-  // New-conversation approval default; only known profiles survive hand-edited settings.json.
-  const defaultPermissionProfile = value.defaultPermissionProfile
-
-  if (isPermissionProfileId(defaultPermissionProfile)) {
-    settings.defaultPermissionProfile = defaultPermissionProfile
-  }
-
-  const opencodePath = asString(value.opencodePath)
-
-  if (opencodePath) {
-    settings.opencodePath = opencodePath
-
-    const opencodeVersion = asString(value.opencodeVersion)
-    if (opencodeVersion) settings.opencodeVersion = opencodeVersion
-  }
-
-  const notebookRuntimes = sanitizeNotebookRuntimes(value.notebookRuntimes)
-
-  if (notebookRuntimes) {
-    settings.notebookRuntimes = notebookRuntimes
-  }
-
-  const notebookRuntimeEnablement = sanitizeRuntimeEnablement(value.notebookRuntimeEnablement)
-
-  if (notebookRuntimeEnablement) {
-    settings.notebookRuntimeEnablement = notebookRuntimeEnablement
-  }
-
-  const notebookManualInterpreters = sanitizeManualInterpreters(value.notebookManualInterpreters)
-
-  if (notebookManualInterpreters) {
-    settings.notebookManualInterpreters = notebookManualInterpreters
-  }
-
-  // Persist project-scope compute grants. Unknown/corrupt entries are dropped; well-formed ones
-  // are preserved. Empty array is omitted (same as absent).
-  const computeGrants = Array.isArray(value.computeGrants)
-    ? value.computeGrants
-        .map(sanitizeComputeGrant)
-        .filter((g): g is StoredComputeGrant => g !== undefined)
-    : undefined
-
-  if (computeGrants && computeGrants.length > 0) {
-    settings.computeGrants = computeGrants
-  }
-
-  return settings
-}
-
-// Validates the per-language manual-interpreter catalog: a map of language -> array of non-empty,
-// de-duplicated absolute-ish path strings. Non-string / empty entries are dropped; an empty result for
-// a language is omitted, and an empty overall map returns undefined (so it is not persisted).
-const sanitizeManualInterpreters = (
-  value: unknown
-): Partial<Record<NotebookLanguage, string[]>> | undefined => {
-  if (!isRecord(value)) return undefined
-  const result: Partial<Record<NotebookLanguage, string[]>> = {}
-  for (const language of ['python', 'r'] as const) {
-    const paths = asStringArray(value[language])
-    const cleaned = [...new Set((paths ?? []).map((p) => p.trim()).filter((p) => p.length > 0))]
-    if (cleaned.length > 0) result[language] = cleaned
-  }
-  return Object.keys(result).length > 0 ? result : undefined
-}
-
-// Validates one persisted RuntimeSelection. 'managed' carries no extra fields; 'external' requires a
-// non-empty interpreter path and coerces the two boolean flags (default false — a persisted external
-// env is read-only and not an app overlay unless explicitly recorded). Anything else -> undefined
-// (dropped), so a corrupt entry can never grant unexpected package-write authority.
-const sanitizeRuntimeSelection = (value: unknown): RuntimeSelection | undefined => {
-  if (!isRecord(value)) return undefined
-  if (value.source === 'managed') return { source: 'managed' }
-  if (value.source === 'external') {
-    const interpreterPath = asString(value.interpreterPath)
-    if (!interpreterPath) return undefined
-    const interpreterArgs = asStringArray(value.interpreterArgs)
-    return {
-      source: 'external',
-      interpreterPath,
-      ...(interpreterArgs.length > 0 ? { interpreterArgs } : {}),
-      appOwnedOverlay: value.appOwnedOverlay === true,
-      packageInstallAuthorized: value.packageInstallAuthorized === true
-    }
-  }
-  return undefined
-}
-
-// Per-language runtime selections; only the known languages are kept, invalid entries dropped. Returns
-// undefined when nothing valid is present so the field stays absent (== "use the managed default").
-const sanitizeNotebookRuntimes = (
-  value: unknown
-): Partial<Record<NotebookLanguage, RuntimeSelection>> | undefined => {
-  if (!isRecord(value)) return undefined
-  const result: Partial<Record<NotebookLanguage, RuntimeSelection>> = {}
-  for (const language of ['python', 'r'] as const) {
-    const selection = sanitizeRuntimeSelection(value[language])
-    // R is managed-only in v1 (the external resolver + overlay are Python-specific), so an external R
-    // selection is rejected here rather than reaching a broken code path from a hand-edited file.
-    if (!selection) continue
-    if (language === 'r' && selection.source === 'external') continue
-    result[language] = selection
-  }
-  return Object.keys(result).length > 0 ? result : undefined
-}
-
-// Rebuilds one language's RuntimeEnablement, keeping only string->boolean entries in both maps and
-// dropping any non-object input. A hand-edited or corrupt entry can therefore never grant unexpected
-// enablement or package-write authority (a bad value simply falls back to the provenance default).
-const sanitizeRuntimeEnablementEntry = (value: unknown): RuntimeEnablement => ({
-  enabled: asBooleanRecord(isRecord(value) ? value.enabled : undefined),
-  installAuthorized: asBooleanRecord(isRecord(value) ? value.installAuthorized : undefined)
-})
-
-// Per-language v4 enablement; only the known languages are kept, empty entries dropped. Returns
-// undefined when nothing valid is present so the field stays absent (== "use the provenance default").
-const sanitizeRuntimeEnablement = (
-  value: unknown
-): Partial<Record<NotebookLanguage, RuntimeEnablement>> | undefined => {
-  if (!isRecord(value)) return undefined
-  const result: Partial<Record<NotebookLanguage, RuntimeEnablement>> = {}
-  for (const language of ['python', 'r'] as const) {
-    const entry = sanitizeRuntimeEnablementEntry(value[language])
-    if (
-      Object.keys(entry.enabled).length === 0 &&
-      Object.keys(entry.installAuthorized).length === 0
-    ) {
-      continue
-    }
-    result[language] = entry
-  }
-  return Object.keys(result).length > 0 ? result : undefined
-}
 
 // Owns durable reads/writes of the single settings.json document. Writes are serialized through a
 // queue and made atomic (temp + rename); an unreadable file falls back to empty settings so the app
@@ -743,7 +381,10 @@ class SettingsRepository {
     language: NotebookLanguage,
     selection: RuntimeSelection | null
   ): Promise<StoredSettings> {
-    const sanitized = selection === null ? null : sanitizeRuntimeSelection(selection)
+    const sanitized =
+      selection === null
+        ? null
+        : sanitizeSettings({ notebookRuntimes: { python: selection } }).notebookRuntimes?.python
 
     if (selection !== null && !sanitized) {
       throw new Error('Invalid runtime selection.')
@@ -775,7 +416,8 @@ class SettingsRepository {
     language: NotebookLanguage,
     enablement: RuntimeEnablement
   ): Promise<StoredSettings> {
-    const sanitized = sanitizeRuntimeEnablementEntry(enablement)
+    const sanitized = sanitizeSettings({ notebookRuntimeEnablement: { [language]: enablement } })
+      .notebookRuntimeEnablement?.[language] ?? { enabled: {}, installAuthorized: {} }
     const isEmpty =
       Object.keys(sanitized.enabled).length === 0 &&
       Object.keys(sanitized.installAuthorized).length === 0

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -39,13 +39,13 @@ const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
 const settingsPaths = {
   repository: resolve(settingsRoot, 'repository.ts'),
   recordCodec: resolve(settingsRoot, 'record-codec.ts'),
+  documentCodec: resolve(settingsRoot, 'document-codec.ts'),
   providerAccounts: resolve(settingsRoot, 'provider-accounts.ts'),
   backendResolver: resolve(settingsRoot, 'backend-resolver.ts'),
   responsesBridge: resolve(settingsRoot, 'responses-bridge.ts'),
   service: resolve(settingsRoot, 'service.ts'),
   types: resolve(settingsRoot, 'types.ts')
 } as const
-
 const sourceCache = new Map<string, string>()
 const readSource = (path: string): string => {
   const cached = sourceCache.get(path)
@@ -73,7 +73,6 @@ const sourceFileFor = (path: string): SourceFile => {
   sourceFileCache.set(path, sourceFile)
   return sourceFile
 }
-
 const productionSources = (): string[] => {
   const sources: string[] = []
   const visit = (directory: string): void => {
@@ -92,7 +91,6 @@ const productionSources = (): string[] => {
   visit(resolve(projectRoot, 'packages'))
   return sources.sort()
 }
-
 const importSpecifiersCache = new Map<string, string[]>()
 const importSpecifiersFrom = (sourcePath: string): string[] => {
   const cached = importSpecifiersCache.get(sourcePath)
@@ -124,10 +122,8 @@ const importSpecifiersFrom = (sourcePath: string): string[] => {
   importSpecifiersCache.set(sourcePath, specifiers)
   return specifiers
 }
-
 const resolveImportTarget = (sourcePath: string, specifier: string): string | undefined =>
   specifier.startsWith('.') ? modulePath(resolve(dirname(sourcePath), specifier)) : undefined
-
 const importersOf = (targetPath: string): string[] =>
   productionSourcePaths
     .filter((sourcePath) => readSource(sourcePath).includes(basename(modulePath(targetPath))))
@@ -137,7 +133,6 @@ const importersOf = (targetPath: string): string[] =>
       )
     )
     .map(portableProjectPath)
-
 const constructorSitesFor = (targetPath: string, className: string): string[] =>
   importersOf(targetPath).flatMap((portablePath) => {
     const sourcePath = resolve(projectRoot, portablePath)
@@ -155,7 +150,6 @@ const constructorSitesFor = (targetPath: string, className: string): string[] =>
     visit(sourceFileFor(sourcePath))
     return Array.from({ length: count }, () => portablePath)
   })
-
 const exportInventoryFrom = (path: string): string[] => {
   const names: string[] = []
   const sourceFile = sourceFileFor(path)
@@ -192,7 +186,6 @@ const exportInventoryFrom = (path: string): string[] => {
   }
   return names.sort()
 }
-
 const publicOperationsOf = (path: string, className: string): string[] => {
   const sourceFile = sourceFileFor(path)
   const declaration = sourceFile.statements.find(
@@ -274,8 +267,9 @@ const productionSourcePaths = productionSources()
 
 describe('Settings backend ownership architecture', () => {
   it('holds the current facade ceilings until their owner cutovers', () => {
-    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(1045)
+    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(700)
     expect(rawLineCount(readSource(settingsPaths.recordCodec))).toBeLessThanOrEqual(660)
+    expect(rawLineCount(readSource(settingsPaths.documentCodec))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(1095)
     expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1407)
     expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(950)
@@ -484,7 +478,11 @@ describe('Settings backend ownership architecture', () => {
       'src/main/settings/service.ts',
       'src/main/settings/skill-catalog.ts'
     ])
-    expect(importersOf(settingsPaths.recordCodec)).toEqual(['src/main/settings/repository.ts'])
+    expect(importersOf(settingsPaths.recordCodec)).toEqual([
+      'src/main/settings/document-codec.ts',
+      'src/main/settings/repository.ts'
+    ])
+    expect(importersOf(settingsPaths.documentCodec)).toEqual(['src/main/settings/repository.ts'])
     expect(importersOf(settingsPaths.providerAccounts)).toEqual([
       'src/main/settings/agent-runtime-manager.ts',
       'src/main/settings/backend-resolver.ts',
@@ -602,7 +600,8 @@ describe('Settings backend ownership architecture', () => {
     const manifest = JSON.parse(readSource(manifestPath)) as ModuleImpactManifest
     expect(manifest.modules.settings_repository.ownerPaths).toEqual([
       'src/main/settings/repository.ts',
-      'src/main/settings/record-codec.ts'
+      'src/main/settings/record-codec.ts',
+      'src/main/settings/document-codec.ts'
     ])
     expect(manifest.modules.settings_backend_resolution.ownerPaths).toEqual([
       'src/main/settings/backend-resolver.ts',


### PR DESCRIPTION
## Problem

Top-level Settings version migration, cross-field sanitization, and durable document construction were interleaved with persistence in `SettingsRepository`. That gave `repository.ts` two unrelated responsibilities and made migration ordering difficult to review independently.

## Proposed change

- Extract a pure `document-codec.ts` owner for the top-level Settings document.
- Move provider/subscription migration, active provider/model cleanup, durable field defaults, portable data-root normalization, runtime selection, enablement, and interpreter sanitization behind `sanitizeSettings`.
- Keep semantic mutations, the serialized write queue, and atomic filesystem IO in `SettingsRepository`.
- Preserve the existing `repository.ts` re-export while moving sanitizer characterization to direct codec coverage.
- Register the codec in the Settings repository impact owner and certify its production importer boundary and line ceiling.

## Scope and non-goals

- No Settings version bump or persisted-data shape change.
- No movement of the write queue, temporary-file sequencing, or atomic rename behavior; D3 owns that persistence cutover.
- No provider authentication, model-selection, UI-default, IPC, or public API changes.
- Baseline alignment only: the architecture contract accepts the current 1,003-line `SettingsService` and records the existing `listHostSkills`, `publishHostSkill`, and `withHostSkillRead` methods introduced on `main`; this PR does not modify that service.

## Compatibility

- Preserves corrupt/unreadable fallback, `SETTINGS_FILE_VERSION`, legacy Codex/Claude subscription migration order, active provider/model cleanup, and every durable Settings field.
- Preserves encrypted credential references and masks while continuing to drop unknown/plaintext fields.
- Preserves Specialist, Permission, Compute, connector, skill, runtime-selection, and notebook settings semantics.
- Preserves Electron/Web/CLI/Task/local RPC/MCP capability boundaries and the current cross-surface asymmetry.
- Keeps Windows/macOS/Linux path handling portable by using Node path normalization and by treating interpreter paths as opaque persisted strings.

## Acceptance criteria and validation

- `document-codec.ts`: 274 raw lines (target <=600, hard ceiling <=660).
- `repository.ts`: reduced from 1,045 to 687 raw lines; persistence and semantic mutations remain in place for D3.
- Central architecture certification: 656 raw lines (hard ceiling <=660).
- Settings repository module plan: 16 files, 490 tests passed after the final rebase.
- `npm run typecheck`: passed after the final rebase.
- `npm run lint -- --no-cache`: passed with 17 pre-existing warnings and 0 errors after the final rebase.
- Changed-file Prettier check and diff whitespace check: passed.
- The module-impact owner changed, so exact-head CI remains authoritative for the full portable fallback and AI review before merge.

## Review focus

- Verify legacy subscription migration runs before active provider/model cleanup.
- Verify runtime/interpreter/path sanitizers retain the exact previous fail-closed behavior on all supported platforms.
- Verify `SettingsRepository` still exclusively owns semantic mutations, serialized writes, and atomic IO.
- Verify the codec exposes one cohesive document-policy interface rather than a general utility surface.
