### PR TITLE
refactor(settings): extract provider runtime projection

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -243,13 +243,18 @@
       "fallbackCapability": "main_runtime"
     },
     "settings_provider_accounts": {
-      "ownerPaths": ["src/main/settings/provider-accounts.ts"],
+      "ownerPaths": [
+        "src/main/settings/provider-accounts.ts",
+        "src/main/settings/provider-runtime-projection.ts"
+      ],
       "interfacePaths": ["src/main/settings/provider-accounts.ts"],
       "consumerModules": ["settings_backend_resolution", "settings_service_facade"],
       "testFiles": {
         "owner": [
           "src/main/settings/settings-backend.architecture.test.ts",
           "src/main/settings/provider-accounts.test.ts",
+          "src/main/settings/provider-runtime-projection.test.ts",
+          "src/main/settings/provider-runtime-projection.architecture.test.ts",
           "src/main/settings/codex-auth.test.ts",
           "src/main/settings/claude-isolated-auth.test.ts",
           "src/main/settings/claude-shared-auth.test.ts",

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -27,32 +27,21 @@ import {
 } from '../../shared/settings'
 import {
   defaultVendorModel,
-  getOfficialVendorModelIds,
   isOfficialVendorId,
-  isVendorModelMultimodal,
   isVendorModelResponsesSupported,
   resolveCustomModelContextWindow,
-  resolveModelContextWindow,
   resolveVendorApiEndpoints,
   resolveVendorBaseUrl,
   resolveVendorModelsUrl,
   resolveVendorOpenAiBaseUrl
 } from '../../shared/provider-registry'
-import {
-  resolveProviderEffectiveModel,
-  resolveProviderReasoningEffortProfile
-} from '../../shared/provider-reasoning-effort'
 import type { ReasoningEffortProfile } from '../../shared/reasoning-effort'
-import { isModelBridgeSupported } from '../../shared/provider-registry'
 import {
   DEFAULT_AGENT_FRAMEWORK_ID,
   getAgentFramework,
   type AgentFrameworkId
 } from '../agent-framework'
-import {
-  codexSubscriptionStorageDir,
-  isOfficialOpenAiResponsesBase
-} from '../agent-framework/codex'
+import { codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { netFetchStandard } from '../skills/net-fetch'
 import {
   clearAppOwnedCodexAuthentication,
@@ -78,6 +67,12 @@ import { encryptKey, isEncryptionAvailable, maskKey, tryDecryptKey } from './cry
 import { classifyStatus, validateProvider as validateProviderTarget } from './validate'
 import { listProviderModels } from './list-models'
 import { getAppClaudeConfigDir, type ResolvedProvider } from './provider-env'
+import {
+  ProviderRuntimeProjectionOwner,
+  requiresNativeResponsesCompatibility,
+  type ProviderRuntimeTarget,
+  type RuntimeProviderModelSelection
+} from './provider-runtime-projection'
 import type { SettingsRepository } from './repository'
 import type { SystemProxyEnvironment } from './system-proxy'
 import type { StoredProvider, StoredSettings } from './types'
@@ -107,38 +102,6 @@ type ProviderAccountsModuleOptions = {
   claudeSharedAuth?: ClaudeSharedAuthControllerPort
 }
 
-export type RuntimeProviderModelSelection =
-  | { kind: 'configured'; requestedModel?: string }
-  | { kind: 'required'; model: string }
-  | { kind: 'provider-default' }
-
-export type ProviderRuntimeTarget = {
-  providerId: string
-  providerType: StoredProvider['type']
-  disconnectedAt?: number
-  effectiveModel?: string
-  apiEndpoints: ChatApiEndpoint[]
-  provider: ResolvedProvider
-  reasoningEffortProfile: ReasoningEffortProfile
-  frameworkCompatible: boolean
-  modelBridgeSupported: boolean
-  needsChatResponsesBridge: boolean
-  needsNativeResponsesCompatibility: boolean
-}
-
-// Native Responses vendors other than OpenAI require the same namespace compatibility proxy during
-// validation and runtime. Export one predicate so both paths prove the same protocol contract.
-const requiresNativeResponsesCompatibility = (
-  provider: ResolvedProvider,
-  framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
-): boolean =>
-  framework.id === 'codex' &&
-  framework.supportedApiTypes.includes('responses') &&
-  providerEndpoints(provider).includes('responses') &&
-  !isCodexSubscriptionProvider(provider.type) &&
-  provider.vendorId !== 'openai' &&
-  !isOfficialOpenAiResponsesBase(provider.openaiBaseUrl ?? provider.baseUrl)
-
 // Owns durable provider records and every provider-specific validation/authentication lifecycle.
 // Executable installation, runtime spawn configuration, live ACP reconnect, and transports remain
 // outside this module.
@@ -147,6 +110,7 @@ class ProviderAccountsModule {
   private readonly codexAuth: CodexAuthControllerPort
   private readonly claudeIsolatedAuth: ClaudeIsolatedAuthControllerPort
   private readonly claudeSharedAuth: ClaudeSharedAuthControllerPort
+  private readonly runtimeProjection = new ProviderRuntimeProjectionOwner()
   private claudeSharedAuthStatusCache: { authenticated: boolean; checkedAt: number } | undefined
   private claudeSharedAuthStatusGeneration = 0
   private claudeSharedAuthStatusPromise:
@@ -927,64 +891,11 @@ class ProviderAccountsModule {
   }
 
   resolveProviderApiEndpoints(provider: StoredProvider, activeModel?: string): ChatApiEndpoint[] {
-    if (provider.type === 'official' && provider.vendorId) {
-      const vendorEndpoints = resolveVendorApiEndpoints(provider.vendorId)
-      const modelToCheck = activeModel ?? defaultVendorModel(provider.vendorId)
-      if (
-        !vendorEndpoints.includes('responses') &&
-        isVendorModelResponsesSupported(provider.vendorId, modelToCheck)
-      ) {
-        return [...vendorEndpoints, 'responses']
-      }
-      return vendorEndpoints
-    }
-
-    return provider.apiEndpoints && provider.apiEndpoints.length > 0
-      ? [...provider.apiEndpoints]
-      : ['anthropic']
+    return this.runtimeProjection.resolveProviderApiEndpoints(provider, activeModel)
   }
 
   toProviderView(provider: StoredProvider, activeModel?: string): ProviderView {
-    const hasKey = Boolean(provider.keyRef)
-    const needsKey = hasKey && tryDecryptKey(provider.keyRef) === undefined
-
-    return {
-      id: provider.id,
-      type: provider.type,
-      codexAuthMode: provider.codexAuthMode,
-      name: provider.name,
-      apiEndpoints: this.resolveProviderApiEndpoints(provider, activeModel),
-      baseUrl: provider.baseUrl,
-      model: provider.model,
-      contextWindow: provider.contextWindow,
-      supportsImageInput: this.providerSupportsImageInput(provider, activeModel),
-      reasoningEffortPreset:
-        provider.type === 'custom' ? provider.reasoningEffortPreset : undefined,
-      reasoningEffortTransport:
-        provider.type === 'custom' ? provider.reasoningEffortTransport : undefined,
-      vendorId: provider.vendorId,
-      region: provider.region,
-      models: this.availableModels(provider),
-      maskedKey: provider.keyMask,
-      hasKey,
-      needsKey,
-      lastValidatedAt: provider.lastValidatedAt,
-      lastValidationFailure: provider.lastValidationFailure,
-      ...(provider.expiresAt !== undefined ? { expiresAt: provider.expiresAt } : {})
-    }
-  }
-
-  private providerSupportsImageInput(provider: StoredProvider, activeModel?: string): boolean {
-    if (isCodexSubscriptionProvider(provider.type)) return true
-    if (isClaudeSubscriptionProvider(provider.type)) return true
-    if (provider.type === 'custom') return provider.supportsImageInput === true
-    if (provider.type === 'official' && provider.vendorId) {
-      return isVendorModelMultimodal(
-        provider.vendorId,
-        activeModel ?? defaultVendorModel(provider.vendorId)
-      )
-    }
-    return false
+    return this.runtimeProjection.toProviderView(provider, activeModel)
   }
 
   private invalidateClaudeSharedAuthStatus(): void {
@@ -1032,24 +943,8 @@ class ProviderAccountsModule {
     return Boolean(provider.keyRef) && tryDecryptKey(provider.keyRef) !== undefined
   }
 
-  private availableModels(provider: StoredProvider): string[] {
-    if (isCodexSubscriptionProvider(provider.type)) {
-      return getOfficialVendorModelIds('openai')
-    }
-    if (provider.type === 'official' && provider.vendorId) {
-      if (provider.fetchedModels && provider.fetchedModels.length > 0) {
-        return provider.fetchedModels
-      }
-      return getOfficialVendorModelIds(provider.vendorId)
-    }
-    return provider.model ? [provider.model] : []
-  }
-
   resolveActiveModel(provider: StoredProvider | undefined, requested?: string): string | undefined {
-    return resolveProviderEffectiveModel(
-      provider ? { ...provider, models: this.availableModels(provider) } : undefined,
-      requested
-    )
+    return this.runtimeProjection.resolveActiveModel(provider, requested)
   }
 
   // Produces the complete ephemeral provider input for one backend generation without mutating the
@@ -1060,111 +955,28 @@ class ProviderAccountsModule {
     selection: RuntimeProviderModelSelection,
     framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
   ): ProviderRuntimeTarget {
-    const availableModels = this.availableModels(storedProvider)
-    if (
-      selection.kind === 'required' &&
-      availableModels.length > 0 &&
-      !availableModels.includes(selection.model)
-    ) {
-      throw new Error(
-        `The requested model "${selection.model}" is not available for provider "${storedProvider.name}".`
-      )
-    }
-
-    const effectiveModel =
-      selection.kind === 'required'
-        ? this.resolveActiveModel(storedProvider, selection.model)
-        : this.resolveActiveModel(
-            storedProvider,
-            selection.kind === 'configured' ? selection.requestedModel : undefined
-          )
-
-    if (selection.kind === 'required' && effectiveModel !== selection.model) {
-      throw new Error(
-        `The requested model "${selection.model}" is not available for provider "${storedProvider.name}".`
-      )
-    }
-
-    const apiEndpoints = this.resolveProviderApiEndpoints(storedProvider, effectiveModel)
-    const provider = this.resolveProvider(storedProvider, effectiveModel)
-
-    return {
-      providerId: storedProvider.id,
-      providerType: storedProvider.type,
-      ...(storedProvider.disconnectedAt === undefined
-        ? {}
-        : { disconnectedAt: storedProvider.disconnectedAt }),
-      effectiveModel,
-      apiEndpoints,
-      provider,
-      reasoningEffortProfile: resolveProviderReasoningEffortProfile(storedProvider, effectiveModel),
-      frameworkCompatible: isProviderUsableByFramework(
-        { apiEndpoints, type: storedProvider.type },
-        framework
-      ),
-      modelBridgeSupported: isModelBridgeSupported(storedProvider, effectiveModel),
-      needsChatResponsesBridge: requiresChatCompletionsBridge(provider, framework),
-      needsNativeResponsesCompatibility: requiresNativeResponsesCompatibility(provider, framework)
-    }
+    return this.runtimeProjection.resolveRuntimeTarget(storedProvider, selection, framework)
   }
 
   resolveRuntimeModelCatalog(
     storedProvider: StoredProvider,
     framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
   ): ProviderRuntimeTarget[] {
-    return this.availableModels(storedProvider).map((model) =>
-      this.resolveRuntimeTarget(storedProvider, { kind: 'required', model }, framework)
-    )
+    return this.runtimeProjection.resolveRuntimeModelCatalog(storedProvider, framework)
   }
 
   resolveRuntimeReasoningEffortProfile(
     storedProvider: StoredProvider,
     requestedModel?: string
   ): ReasoningEffortProfile {
-    return resolveProviderReasoningEffortProfile(
+    return this.runtimeProjection.resolveRuntimeReasoningEffortProfile(
       storedProvider,
-      this.resolveActiveModel(storedProvider, requestedModel)
+      requestedModel
     )
   }
 
   resolveProvider(provider: StoredProvider, modelOverride?: string): ResolvedProvider {
-    const key = provider.keyRef ? tryDecryptKey(provider.keyRef) : undefined
-    if (provider.type === 'official' && provider.vendorId) {
-      const model = modelOverride ?? defaultVendorModel(provider.vendorId)
-      const contextWindow = resolveModelContextWindow(provider.vendorId, model)
-      return {
-        type: 'custom',
-        vendorId: provider.vendorId,
-        baseUrl: resolveVendorBaseUrl(provider.vendorId, provider.region),
-        openaiBaseUrl: resolveVendorOpenAiBaseUrl(provider.vendorId, provider.region),
-        model,
-        ...(contextWindow === undefined ? {} : { contextWindow }),
-        key,
-        apiEndpoints: this.resolveProviderApiEndpoints(provider, model),
-        supportsImageInput: this.providerSupportsImageInput(provider, modelOverride)
-      }
-    }
-
-    const model = modelOverride ?? provider.model
-    const contextWindow =
-      provider.type === 'custom'
-        ? resolveCustomModelContextWindow(provider.contextWindow)
-        : isClaudeSubscriptionProvider(provider.type)
-          ? resolveModelContextWindow('anthropic', model)
-          : undefined
-    return {
-      type: provider.type,
-      ...(provider.codexAuthMode === undefined ? {} : { codexAuthMode: provider.codexAuthMode }),
-      baseUrl: provider.baseUrl,
-      model,
-      ...(contextWindow === undefined ? {} : { contextWindow }),
-      key,
-      apiEndpoints: this.resolveProviderApiEndpoints(provider, model),
-      supportsImageInput: this.providerSupportsImageInput(provider, modelOverride),
-      ...(provider.type === 'custom'
-        ? { reasoningEffortTransport: provider.reasoningEffortTransport }
-        : {})
-    }
+    return this.runtimeProjection.resolveProvider(provider, modelOverride)
   }
 
   private resolveDraft(draft: ProviderDraft): ResolvedProvider {
@@ -1280,4 +1092,4 @@ export {
   ProviderAccountsModule,
   requiresNativeResponsesCompatibility
 }
-export type { ProviderAccountsModuleOptions }
+export type { ProviderAccountsModuleOptions, ProviderRuntimeTarget, RuntimeProviderModelSelection }

--- a/src/main/settings/provider-runtime-projection.architecture.test.ts
+++ b/src/main/settings/provider-runtime-projection.architecture.test.ts
@@ -1,0 +1,146 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { extname, relative, resolve } from 'node:path'
+
+import {
+  canHaveModifiers,
+  createSourceFile,
+  getModifiers,
+  isClassDeclaration,
+  isExportDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isMethodDeclaration,
+  isNamedExports,
+  isPropertyDeclaration,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  type Node,
+  type SourceFile
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = resolve(__dirname, '../../..')
+const ownerPath = resolve(__dirname, 'provider-runtime-projection.ts')
+const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
+const readSource = (path: string): string => readFileSync(path, 'utf8')
+const sourceFileFor = (path: string): SourceFile =>
+  createSourceFile(
+    path,
+    readSource(path),
+    ScriptTarget.Latest,
+    true,
+    extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
+  )
+const portablePath = (path: string): string => relative(projectRoot, path).replaceAll('\\', '/')
+
+const productionSources = (): string[] => {
+  const sources: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isDirectory()) visit(path)
+      else if (
+        ['.ts', '.tsx'].includes(extname(path)) &&
+        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
+      ) {
+        sources.push(path)
+      }
+    }
+  }
+  visit(resolve(projectRoot, 'src'))
+  visit(resolve(projectRoot, 'packages'))
+  return sources
+}
+
+const importsOwner = (path: string): boolean => {
+  let imports = false
+  const sourceFile = sourceFileFor(path)
+  const visit = (node: Node): void => {
+    if (
+      isImportDeclaration(node) &&
+      node.moduleSpecifier.getText(sourceFile).includes('provider-runtime-projection')
+    ) {
+      imports = true
+    }
+    node.forEachChild(visit)
+  }
+  visit(sourceFile)
+  return imports
+}
+
+const publicOperations = (): string[] => {
+  const declaration = sourceFileFor(ownerPath).statements.find(
+    (statement) =>
+      isClassDeclaration(statement) && statement.name?.text === 'ProviderRuntimeProjectionOwner'
+  )
+  if (!declaration || !isClassDeclaration(declaration)) throw new Error('owner class not found')
+  return declaration.members
+    .flatMap((member) => {
+      const hidden =
+        canHaveModifiers(member) &&
+        getModifiers(member)?.some((modifier) => modifier.kind === SyntaxKind.PrivateKeyword)
+      return !hidden &&
+        (isMethodDeclaration(member) || isPropertyDeclaration(member)) &&
+        isIdentifier(member.name)
+        ? [member.name.text]
+        : []
+    })
+    .sort()
+}
+
+describe('Provider runtime projection ownership', () => {
+  it('keeps one focused owner below the production hard limit', () => {
+    const source = readSource(ownerPath)
+    expect(source.split(/\r?\n/).length - Number(source.endsWith('\n'))).toBeLessThanOrEqual(660)
+    expect(source).not.toMatch(/SettingsRepository|setActiveProvider|upsertProvider/)
+  })
+
+  it('locks the owner interface and compatibility exports', () => {
+    expect(publicOperations()).toEqual([
+      'resolveActiveModel',
+      'resolveProvider',
+      'resolveProviderApiEndpoints',
+      'resolveRuntimeModelCatalog',
+      'resolveRuntimeReasoningEffortProfile',
+      'resolveRuntimeTarget',
+      'toProviderView'
+    ])
+
+    const exportDeclaration = sourceFileFor(ownerPath).statements.filter(isExportDeclaration)
+    expect(
+      exportDeclaration.flatMap((statement) =>
+        statement.exportClause && isNamedExports(statement.exportClause)
+          ? statement.exportClause.elements.map(
+              (element) =>
+                `${statement.isTypeOnly || element.isTypeOnly ? 'type' : 'value'}:${element.name.text}`
+            )
+          : []
+      )
+    ).toEqual([
+      'value:ProviderRuntimeProjectionOwner',
+      'value:requiresNativeResponsesCompatibility',
+      'type:ProviderRuntimeTarget',
+      'type:RuntimeProviderModelSelection'
+    ])
+  })
+
+  it('keeps the internal owner behind ProviderAccountsModule and in its impact set', () => {
+    expect(productionSources().filter(importsOwner).map(portablePath)).toEqual([
+      'src/main/settings/provider-accounts.ts'
+    ])
+    const manifest = JSON.parse(readSource(manifestPath)) as {
+      modules: Record<string, { ownerPaths: string[]; testFiles: { owner: string[] } }>
+    }
+    expect(manifest.modules.settings_provider_accounts.ownerPaths).toEqual([
+      'src/main/settings/provider-accounts.ts',
+      'src/main/settings/provider-runtime-projection.ts'
+    ])
+    expect(manifest.modules.settings_provider_accounts.testFiles.owner).toEqual(
+      expect.arrayContaining([
+        'src/main/settings/provider-runtime-projection.test.ts',
+        'src/main/settings/provider-runtime-projection.architecture.test.ts'
+      ])
+    )
+  })
+})

--- a/src/main/settings/provider-runtime-projection.test.ts
+++ b/src/main/settings/provider-runtime-projection.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getAgentFramework } from '../agent-framework'
+import type { StoredProvider } from './types'
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`cipher:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => buffer.toString('utf8').slice('cipher:'.length)
+  }
+}))
+
+const { ProviderRuntimeProjectionOwner } = await import('./provider-runtime-projection')
+const { encryptKey } = await import('./crypto')
+
+describe('ProviderRuntimeProjectionOwner', () => {
+  it('fails closed when a required model is outside the provider catalog', () => {
+    const owner = new ProviderRuntimeProjectionOwner()
+    const provider: StoredProvider = {
+      id: 'provider-1',
+      type: 'custom',
+      name: 'Lab gateway',
+      baseUrl: 'https://lab.example/v1',
+      model: 'lab-model',
+      apiEndpoints: ['openai']
+    }
+
+    expect(() =>
+      owner.resolveRuntimeTarget(
+        provider,
+        { kind: 'required', model: 'unavailable-model' },
+        getAgentFramework('codex')
+      )
+    ).toThrow(
+      'The requested model "unavailable-model" is not available for provider "Lab gateway".'
+    )
+  })
+
+  it('projects a configured target without mutating or exposing the stored credential', () => {
+    const owner = new ProviderRuntimeProjectionOwner()
+    const provider: StoredProvider = {
+      id: 'provider-1',
+      type: 'custom',
+      name: 'Lab gateway',
+      baseUrl: 'https://lab.example/v1',
+      model: 'lab-model',
+      keyRef: encryptKey('secret-key'),
+      keyMask: 'secr…-key',
+      apiEndpoints: ['openai']
+    }
+    const before = structuredClone(provider)
+
+    const target = owner.resolveRuntimeTarget(
+      provider,
+      { kind: 'configured', requestedModel: 'unavailable-model' },
+      getAgentFramework('codex')
+    )
+    const view = owner.toProviderView(provider)
+
+    expect(target).toMatchObject({
+      providerId: 'provider-1',
+      effectiveModel: 'lab-model',
+      provider: { model: 'lab-model', key: 'secret-key' },
+      needsChatResponsesBridge: true
+    })
+    expect(view).toMatchObject({
+      models: ['lab-model'],
+      maskedKey: 'secr…-key',
+      hasKey: true,
+      needsKey: false
+    })
+    expect(JSON.stringify(view)).not.toContain('secret-key')
+    expect(provider).toEqual(before)
+  })
+
+  it('keeps an exact required model when a subscription catalog is unknown', () => {
+    const owner = new ProviderRuntimeProjectionOwner()
+    const provider: StoredProvider = {
+      id: 'builtin-claude-shared',
+      type: 'claude-shared',
+      name: 'Claude shared'
+    }
+
+    const target = owner.resolveRuntimeTarget(
+      provider,
+      { kind: 'required', model: 'account-model' },
+      getAgentFramework('claude-code')
+    )
+
+    expect(target).toMatchObject({
+      effectiveModel: 'account-model',
+      provider: { model: 'account-model' }
+    })
+  })
+
+  it('builds a catalog and reasoning profile through the same effective-model policy', () => {
+    const owner = new ProviderRuntimeProjectionOwner()
+    const provider: StoredProvider = {
+      id: 'provider-1',
+      type: 'custom',
+      name: 'Lab gateway',
+      model: 'lab-model',
+      apiEndpoints: ['anthropic']
+    }
+
+    expect(owner.resolveRuntimeModelCatalog(provider, getAgentFramework('claude-code'))).toEqual([
+      expect.objectContaining({ effectiveModel: 'lab-model', frameworkCompatible: true })
+    ])
+    expect(owner.resolveRuntimeReasoningEffortProfile(provider, 'unavailable-model')).toMatchObject(
+      {
+        supported: true
+      }
+    )
+  })
+})

--- a/src/main/settings/provider-runtime-projection.ts
+++ b/src/main/settings/provider-runtime-projection.ts
@@ -1,0 +1,262 @@
+import type { ChatApiEndpoint, ProviderView } from '../../shared/settings'
+import {
+  isClaudeSubscriptionProvider,
+  isCodexSubscriptionProvider,
+  isProviderUsableByFramework,
+  providerEndpoints,
+  requiresChatCompletionsBridge
+} from '../../shared/settings'
+import {
+  defaultVendorModel,
+  getOfficialVendorModelIds,
+  isModelBridgeSupported,
+  isVendorModelMultimodal,
+  isVendorModelResponsesSupported,
+  resolveCustomModelContextWindow,
+  resolveModelContextWindow,
+  resolveVendorApiEndpoints,
+  resolveVendorBaseUrl,
+  resolveVendorOpenAiBaseUrl
+} from '../../shared/provider-registry'
+import {
+  resolveProviderEffectiveModel,
+  resolveProviderReasoningEffortProfile
+} from '../../shared/provider-reasoning-effort'
+import type { ReasoningEffortProfile } from '../../shared/reasoning-effort'
+import type { AgentFrameworkId } from '../agent-framework'
+import { isOfficialOpenAiResponsesBase } from '../agent-framework/codex'
+import { tryDecryptKey } from './crypto'
+import type { ResolvedProvider } from './provider-env'
+import type { StoredProvider } from './types'
+
+type RuntimeProviderModelSelection =
+  | { kind: 'configured'; requestedModel?: string }
+  | { kind: 'required'; model: string }
+  | { kind: 'provider-default' }
+
+type ProviderRuntimeTarget = {
+  providerId: string
+  providerType: StoredProvider['type']
+  disconnectedAt?: number
+  effectiveModel?: string
+  apiEndpoints: ChatApiEndpoint[]
+  provider: ResolvedProvider
+  reasoningEffortProfile: ReasoningEffortProfile
+  frameworkCompatible: boolean
+  modelBridgeSupported: boolean
+  needsChatResponsesBridge: boolean
+  needsNativeResponsesCompatibility: boolean
+}
+
+// Native Responses vendors other than OpenAI require the same namespace compatibility proxy during
+// validation and runtime. Export one predicate so both paths prove the same protocol contract.
+const requiresNativeResponsesCompatibility = (
+  provider: ResolvedProvider,
+  framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
+): boolean =>
+  framework.id === 'codex' &&
+  framework.supportedApiTypes.includes('responses') &&
+  providerEndpoints(provider).includes('responses') &&
+  !isCodexSubscriptionProvider(provider.type) &&
+  provider.vendorId !== 'openai' &&
+  !isOfficialOpenAiResponsesBase(provider.openaiBaseUrl ?? provider.baseUrl)
+
+// Owns secret-aware provider projection inside main. It derives views, catalogs, effective models,
+// and ephemeral runtime targets without mutating durable selection or entering account lifecycles.
+class ProviderRuntimeProjectionOwner {
+  resolveProviderApiEndpoints(provider: StoredProvider, activeModel?: string): ChatApiEndpoint[] {
+    if (provider.type === 'official' && provider.vendorId) {
+      const vendorEndpoints = resolveVendorApiEndpoints(provider.vendorId)
+      const modelToCheck = activeModel ?? defaultVendorModel(provider.vendorId)
+      if (
+        !vendorEndpoints.includes('responses') &&
+        isVendorModelResponsesSupported(provider.vendorId, modelToCheck)
+      ) {
+        return [...vendorEndpoints, 'responses']
+      }
+      return vendorEndpoints
+    }
+
+    return provider.apiEndpoints && provider.apiEndpoints.length > 0
+      ? [...provider.apiEndpoints]
+      : ['anthropic']
+  }
+
+  toProviderView(provider: StoredProvider, activeModel?: string): ProviderView {
+    const hasKey = Boolean(provider.keyRef)
+    const needsKey = hasKey && tryDecryptKey(provider.keyRef) === undefined
+
+    return {
+      id: provider.id,
+      type: provider.type,
+      codexAuthMode: provider.codexAuthMode,
+      name: provider.name,
+      apiEndpoints: this.resolveProviderApiEndpoints(provider, activeModel),
+      baseUrl: provider.baseUrl,
+      model: provider.model,
+      contextWindow: provider.contextWindow,
+      supportsImageInput: this.providerSupportsImageInput(provider, activeModel),
+      reasoningEffortPreset:
+        provider.type === 'custom' ? provider.reasoningEffortPreset : undefined,
+      reasoningEffortTransport:
+        provider.type === 'custom' ? provider.reasoningEffortTransport : undefined,
+      vendorId: provider.vendorId,
+      region: provider.region,
+      models: this.availableModels(provider),
+      maskedKey: provider.keyMask,
+      hasKey,
+      needsKey,
+      lastValidatedAt: provider.lastValidatedAt,
+      lastValidationFailure: provider.lastValidationFailure,
+      ...(provider.expiresAt !== undefined ? { expiresAt: provider.expiresAt } : {})
+    }
+  }
+
+  resolveActiveModel(provider: StoredProvider | undefined, requested?: string): string | undefined {
+    return resolveProviderEffectiveModel(
+      provider ? { ...provider, models: this.availableModels(provider) } : undefined,
+      requested
+    )
+  }
+
+  resolveRuntimeTarget(
+    storedProvider: StoredProvider,
+    selection: RuntimeProviderModelSelection,
+    framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
+  ): ProviderRuntimeTarget {
+    const availableModels = this.availableModels(storedProvider)
+    if (
+      selection.kind === 'required' &&
+      availableModels.length > 0 &&
+      !availableModels.includes(selection.model)
+    ) {
+      throw new Error(
+        `The requested model "${selection.model}" is not available for provider "${storedProvider.name}".`
+      )
+    }
+
+    const effectiveModel =
+      selection.kind === 'required'
+        ? this.resolveActiveModel(storedProvider, selection.model)
+        : this.resolveActiveModel(
+            storedProvider,
+            selection.kind === 'configured' ? selection.requestedModel : undefined
+          )
+
+    if (selection.kind === 'required' && effectiveModel !== selection.model) {
+      throw new Error(
+        `The requested model "${selection.model}" is not available for provider "${storedProvider.name}".`
+      )
+    }
+
+    const apiEndpoints = this.resolveProviderApiEndpoints(storedProvider, effectiveModel)
+    const provider = this.resolveProvider(storedProvider, effectiveModel)
+
+    return {
+      providerId: storedProvider.id,
+      providerType: storedProvider.type,
+      ...(storedProvider.disconnectedAt === undefined
+        ? {}
+        : { disconnectedAt: storedProvider.disconnectedAt }),
+      effectiveModel,
+      apiEndpoints,
+      provider,
+      reasoningEffortProfile: resolveProviderReasoningEffortProfile(storedProvider, effectiveModel),
+      frameworkCompatible: isProviderUsableByFramework(
+        { apiEndpoints, type: storedProvider.type },
+        framework
+      ),
+      modelBridgeSupported: isModelBridgeSupported(storedProvider, effectiveModel),
+      needsChatResponsesBridge: requiresChatCompletionsBridge(provider, framework),
+      needsNativeResponsesCompatibility: requiresNativeResponsesCompatibility(provider, framework)
+    }
+  }
+
+  resolveRuntimeModelCatalog(
+    storedProvider: StoredProvider,
+    framework: { id: AgentFrameworkId; supportedApiTypes: readonly ChatApiEndpoint[] }
+  ): ProviderRuntimeTarget[] {
+    return this.availableModels(storedProvider).map((model) =>
+      this.resolveRuntimeTarget(storedProvider, { kind: 'required', model }, framework)
+    )
+  }
+
+  resolveRuntimeReasoningEffortProfile(
+    storedProvider: StoredProvider,
+    requestedModel?: string
+  ): ReasoningEffortProfile {
+    return resolveProviderReasoningEffortProfile(
+      storedProvider,
+      this.resolveActiveModel(storedProvider, requestedModel)
+    )
+  }
+
+  resolveProvider(provider: StoredProvider, modelOverride?: string): ResolvedProvider {
+    const key = provider.keyRef ? tryDecryptKey(provider.keyRef) : undefined
+    if (provider.type === 'official' && provider.vendorId) {
+      const model = modelOverride ?? defaultVendorModel(provider.vendorId)
+      const contextWindow = resolveModelContextWindow(provider.vendorId, model)
+      return {
+        type: 'custom',
+        vendorId: provider.vendorId,
+        baseUrl: resolveVendorBaseUrl(provider.vendorId, provider.region),
+        openaiBaseUrl: resolveVendorOpenAiBaseUrl(provider.vendorId, provider.region),
+        model,
+        ...(contextWindow === undefined ? {} : { contextWindow }),
+        key,
+        apiEndpoints: this.resolveProviderApiEndpoints(provider, model),
+        supportsImageInput: this.providerSupportsImageInput(provider, modelOverride)
+      }
+    }
+
+    const model = modelOverride ?? provider.model
+    const contextWindow =
+      provider.type === 'custom'
+        ? resolveCustomModelContextWindow(provider.contextWindow)
+        : isClaudeSubscriptionProvider(provider.type)
+          ? resolveModelContextWindow('anthropic', model)
+          : undefined
+    return {
+      type: provider.type,
+      ...(provider.codexAuthMode === undefined ? {} : { codexAuthMode: provider.codexAuthMode }),
+      baseUrl: provider.baseUrl,
+      model,
+      ...(contextWindow === undefined ? {} : { contextWindow }),
+      key,
+      apiEndpoints: this.resolveProviderApiEndpoints(provider, model),
+      supportsImageInput: this.providerSupportsImageInput(provider, modelOverride),
+      ...(provider.type === 'custom'
+        ? { reasoningEffortTransport: provider.reasoningEffortTransport }
+        : {})
+    }
+  }
+
+  private providerSupportsImageInput(provider: StoredProvider, activeModel?: string): boolean {
+    if (isCodexSubscriptionProvider(provider.type)) return true
+    if (isClaudeSubscriptionProvider(provider.type)) return true
+    if (provider.type === 'custom') return provider.supportsImageInput === true
+    if (provider.type === 'official' && provider.vendorId) {
+      return isVendorModelMultimodal(
+        provider.vendorId,
+        activeModel ?? defaultVendorModel(provider.vendorId)
+      )
+    }
+    return false
+  }
+
+  private availableModels(provider: StoredProvider): string[] {
+    if (isCodexSubscriptionProvider(provider.type)) {
+      return getOfficialVendorModelIds('openai')
+    }
+    if (provider.type === 'official' && provider.vendorId) {
+      if (provider.fetchedModels && provider.fetchedModels.length > 0) {
+        return provider.fetchedModels
+      }
+      return getOfficialVendorModelIds(provider.vendorId)
+    }
+    return provider.model ? [provider.model] : []
+  }
+}
+
+export { ProviderRuntimeProjectionOwner, requiresNativeResponsesCompatibility }
+export type { ProviderRuntimeTarget, RuntimeProviderModelSelection }

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -276,7 +276,7 @@ describe('Settings backend ownership architecture', () => {
   it('holds the current facade ceilings until their owner cutovers', () => {
     expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(1045)
     expect(rawLineCount(readSource(settingsPaths.recordCodec))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(1283)
+    expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(1095)
     expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1407)
     expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(950)
     expect(rawLineCount(readSource(settingsPaths.service))).toBeLessThanOrEqual(1003)
@@ -603,9 +603,6 @@ describe('Settings backend ownership architecture', () => {
     expect(manifest.modules.settings_repository.ownerPaths).toEqual([
       'src/main/settings/repository.ts',
       'src/main/settings/record-codec.ts'
-    ])
-    expect(manifest.modules.settings_provider_accounts.ownerPaths).toEqual([
-      'src/main/settings/provider-accounts.ts'
     ])
     expect(manifest.modules.settings_backend_resolution.ownerPaths).toEqual([
       'src/main/settings/backend-resolver.ts',


### PR DESCRIPTION
## Problem

`provider-accounts.ts` owned provider CRUD, authentication and validation lifecycle state together with pure model catalog, endpoint, reasoning and ephemeral runtime-target projection policy. That mixed credential-sensitive lifecycle work with the secret-aware but mutation-free policy consumed by backend resolution, and left the facade at 1,283 raw lines.

## Proposed change

- Extract `ProviderRuntimeProjectionOwner` as the single owner of provider views, endpoint catalogs, effective-model selection, reasoning profiles, resolved providers and ephemeral runtime targets.
- Keep the existing `ProviderAccountsModule` interface as compatibility-preserving delegation and reduce the facade to 1,095 raw lines.
- Add direct behavioral and architecture contracts for required-model fail-closed behavior, subscription catalog fallback, credential-safe views, mutation-free projection, exact owner operations/importers and the 660-line hard limit.
- Route the new owner and its tests through `settings_provider_accounts` in the module-impact graph.

## Scope and non-goals

- No provider CRUD, authentication controller, validation generation, lifecycle state or persistence ownership moves in this PR.
- No new provider, model, reasoning capability, universal provider abstraction or transport route policy.
- No `SettingsService`, backend resolver, Responses bridge, renderer or IPC production change.

## Compatibility

- Public exports and every `ProviderAccountsModule` method remain unchanged; existing importers continue to use the facade.
- Required-model fail-closed behavior, configured/default fallback, subscription catalogs, endpoint ordering, reasoning normalization and native/chat compatibility predicates are preserved.
- Plaintext credentials remain transient inside main; provider views remain masked and persistent records remain encrypted references.
- Electron, local/remote Web, CLI, Task, Notebook local RPC/MCP and current Specialist/Permission/Compute capability asymmetry are unchanged.
- The central architecture contract also aligns with #1001's already-merged `SettingsService` reality (`<=1003` plus `listHostSkills`, `publishHostSkill` and `withHostSkillRead`). This is baseline alignment only, not a P1 behavior change.

## Acceptance criteria and validation

All listed checks ran after the last material edit and after rebasing onto the final local `origin/main` base:

- Provider projection/facade behavior and direct consumers -> `npm run test:module -- settings_provider_accounts` -> 18 files, 309 tests passed.
- Backend-resolution consumers and cross-surface CLI/Task/Notebook/MCP contracts -> `npm run test:module -- settings_backend_resolution` -> 21 files passed, 1 skipped; 362 tests passed, 3 skipped.
- Settings application facade, IPC, preload, Web renderer and workspace consumers -> `npm run test:module -- settings_service_facade` -> 22 files, 557 tests passed.
- Node and Web compile contracts -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 17 pre-existing warnings outside this diff.
- Formatting and whitespace -> Prettier check plus `git diff --cached --check` -> passed.
- Independent review -> Standards 0 actionable findings; Spec 0 findings.

Because `scripts/ci/module-impact.json` changes, exact-head CI remains authoritative for the full portable fallback and Windows/macOS/Linux lanes. Local validation intentionally used the dependency-aware affected modules. No uncovered behavioral risk is known; platform certification and the published AI `Verdict: mergeable` remain merge gates.

## Review focus

- Confirm projection is mutation-free and CRUD/auth/validation lifecycle ownership remains in the facade.
- Check required versus configured/default model semantics, endpoint/model catalog behavior and reasoning normalization.
- Confirm credentials do not enter views or persistent/public targets and the owner remains internal to `ProviderAccountsModule`.
- Verify module-impact ownership includes the new owner without widening public, IPC or cross-surface capabilities.
