### PR TITLE
feat(projects): add project pinning

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -580,7 +580,8 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Recent sessions: the secondary line is always the owning Project name, never a prompt preview or a
   repeat of the Session title. Once the Session catalog is complete, if the entire Recent sessions
   list is empty, each Project row also shows its artifact count from a complete Project Files index;
-  partial index counts are omitted.
+  partial index counts are omitted. While those counts are visible, Project Files change events
+  refresh the affected Project so index repair and file changes do not leave stale totals.
 - List row: `h-10 rounded-lg px-3 hover:bg-accent hover:text-accent-foreground`.
 - Inline more actions: default `opacity-0`, then `opacity-100` on hover or focus-visible.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -548,8 +548,10 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Projects title: use `GalleryVerticalEnd`; activity counters sit beside each Project name and split
   `running` from `waiting on you` rather than presenting one ambiguous total.
 - Project actions: use the shared Session dropdown styling and size the surface to its content so
-  inline padding stays balanced. The first action is `Settings`, opening `Project Settings` for Name
-  and Description; its edit action is labelled `Save`.
+  inline padding stays balanced. The first action is `Pin project` / `Unpin project`, using an outline
+  / filled star; `Settings` opens `Project Settings` for Name and Description, and its edit action is
+  labelled `Save`. Pinned Projects form the first group while each pinned and unpinned group retains
+  the existing most-recent-activity ordering.
 - Project description: explain that the optional description is shown in the Project list for the
   user's reference and is not included in the agent prompt.
 - Session updates: show a responsive card grid above the Project/Recent columns for
@@ -576,7 +578,9 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
   additional border, so its built-in hairline ring matches the New project button instead of
   stacking into a heavier outline.
 - Recent sessions: the secondary line is always the owning Project name, never a prompt preview or a
-  repeat of the Session title.
+  repeat of the Session title. Once the Session catalog is complete, if the entire Recent sessions
+  list is empty, each Project row also shows its artifact count from a complete Project Files index;
+  partial index counts are omitted.
 - List row: `h-10 rounded-lg px-3 hover:bg-accent hover:text-accent-foreground`.
 - Inline more actions: default `opacity-0`, then `opacity-100` on hover or focus-visible.
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Project {
   name        String
   description String   @default("")
   isExample   Boolean  @default(false)
+  pinned      Boolean  @default(false)
   archivedAt  DateTime?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt

--- a/src/main/projects/prisma-client.test.ts
+++ b/src/main/projects/prisma-client.test.ts
@@ -749,6 +749,10 @@ describe('project prisma client (integration)', () => {
     const renamed = await repository.update({ id: created.id, name: 'Renamed' })
     expect(renamed.name).toBe('Renamed')
 
+    const pinned = await repository.update({ id: created.id, pinned: true })
+    expect(pinned.pinned).toBe(true)
+    expect(pinned.updatedAt).toBe(renamed.updatedAt)
+
     // Any project is deletable — there is no protected default.
     await repository.delete(created.id)
     expect(await repository.get(created.id)).toBeNull()

--- a/src/main/projects/prisma-client.test.ts
+++ b/src/main/projects/prisma-client.test.ts
@@ -53,7 +53,7 @@ describe('project prisma client (integration)', () => {
     }
   })
 
-  it('adds archive visibility to an existing Project table without rewriting its activity time', async () => {
+  it('adds visibility and pin state to an existing Project without rewriting its activity time', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-project-archive-migration-'))
     const client = createProjectDbClient(storageRoot)
     disconnect = () => client.$disconnect()
@@ -76,6 +76,7 @@ describe('project prisma client (integration)', () => {
       client.project.findUniqueOrThrow({ where: { id: 'project-1' } })
     ).resolves.toMatchObject({
       archivedAt: null,
+      pinned: false,
       updatedAt: new Date('2026-08-06T00:00:00.000Z')
     })
   })

--- a/src/main/projects/prisma-client.ts
+++ b/src/main/projects/prisma-client.ts
@@ -22,6 +22,7 @@ const PROJECT_TABLE_DDL = `CREATE TABLE IF NOT EXISTS "Project" (
     "name" TEXT NOT NULL,
     "description" TEXT NOT NULL DEFAULT '',
     "isExample" BOOLEAN NOT NULL DEFAULT false,
+    "pinned" BOOLEAN NOT NULL DEFAULT false,
     "archivedAt" DATETIME,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL
@@ -164,6 +165,7 @@ const PROJECT_DELETION_INTENT_TABLE_DDL = `CREATE TABLE IF NOT EXISTS "ProjectDe
 // Existing installations create their Project table before Archive existed. Keep the migration
 // additive so no stored Project or its activity ordering is rewritten.
 const PROJECT_ADD_ARCHIVED_AT_DDL = `ALTER TABLE "Project" ADD COLUMN "archivedAt" DATETIME`
+const PROJECT_ADD_PINNED_DDL = `ALTER TABLE "Project" ADD COLUMN "pinned" BOOLEAN NOT NULL DEFAULT false`
 
 // ManagedFile is a metadata projection only: storageKey points back into the existing managed roots,
 // while soft-delete fields keep Files queries reversible during durable session/project deletion.
@@ -610,6 +612,7 @@ const addColumnIfMissing = async (
 const ensureProjectSchema = async (client: PrismaClient): Promise<void> => {
   await client.$executeRawUnsafe(PROJECT_TABLE_DDL)
   await addColumnIfMissing(client, 'Project', 'archivedAt', PROJECT_ADD_ARCHIVED_AT_DDL)
+  await addColumnIfMissing(client, 'Project', 'pinned', PROJECT_ADD_PINNED_DDL)
   await client.$executeRawUnsafe(PERMISSION_GRANT_TABLE_DDL)
   for (const ddl of PERMISSION_GRANT_INDEX_DDLS) {
     await client.$executeRawUnsafe(ddl)

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -7,6 +7,7 @@ const createRow = (overrides: Record<string, unknown> = {}): Record<string, unkn
   name: 'Research',
   description: 'A project',
   isExample: false,
+  pinned: false,
   createdAt: new Date(1710000000000),
   updatedAt: new Date(1710000000100),
   ...overrides
@@ -101,6 +102,26 @@ describe('project repository', () => {
     expect(project.update).toHaveBeenCalledWith({
       where: { id: 'project-1' },
       data: { name: 'Renamed' }
+    })
+  })
+
+  it('changes pin placement without rewriting activity time', async () => {
+    const current = createRow()
+    const pinned = createRow({ pinned: true })
+    const { client, project } = createMockClient({
+      findUnique: () => Promise.resolve(current),
+      update: () => Promise.resolve(pinned)
+    })
+    const repository = new ProjectRepository(() => Promise.resolve(client))
+
+    await expect(repository.update({ id: 'project-1', pinned: true })).resolves.toMatchObject({
+      pinned: true,
+      updatedAt: 1710000000100
+    })
+
+    expect(project.update).toHaveBeenCalledWith({
+      where: { id: 'project-1' },
+      data: { pinned: true, updatedAt: new Date(1710000000100) }
     })
   })
 

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -20,6 +20,7 @@ const createMockClient = (
   >
 ): {
   client: ProjectClient
+  executeRaw: ReturnType<typeof vi.fn>
   project: Record<string, ReturnType<typeof vi.fn>>
   projectDeletionIntent: Record<string, ReturnType<typeof vi.fn>>
 } => {
@@ -37,9 +38,11 @@ const createMockClient = (
     deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
     findMany: vi.fn().mockResolvedValue([])
   }
+  const executeRaw = vi.fn().mockResolvedValue(1)
 
   return {
-    client: { project, projectDeletionIntent } as unknown as ProjectClient,
+    client: { $executeRaw: executeRaw, project, projectDeletionIntent } as unknown as ProjectClient,
+    executeRaw,
     project,
     projectDeletionIntent
   }
@@ -105,24 +108,29 @@ describe('project repository', () => {
     })
   })
 
-  it('changes pin placement without rewriting activity time', async () => {
-    const current = createRow()
-    const pinned = createRow({ pinned: true })
-    const { client, project } = createMockClient({
-      findUnique: () => Promise.resolve(current),
-      update: () => Promise.resolve(pinned)
+  it('does not roll back concurrent activity time while changing pin placement', async () => {
+    let persisted = createRow()
+    const concurrentUpdatedAt = new Date(1710000000200)
+    const { client, executeRaw, project } = createMockClient({
+      findUnique: () => Promise.resolve(persisted),
+      update: ({ data }: { data: Record<string, unknown> }) => {
+        persisted = { ...persisted, updatedAt: concurrentUpdatedAt, ...data }
+        return Promise.resolve(persisted)
+      }
+    })
+    executeRaw.mockImplementation(() => {
+      persisted = { ...persisted, pinned: true, updatedAt: concurrentUpdatedAt }
+      return Promise.resolve(1)
     })
     const repository = new ProjectRepository(() => Promise.resolve(client))
 
     await expect(repository.update({ id: 'project-1', pinned: true })).resolves.toMatchObject({
       pinned: true,
-      updatedAt: 1710000000100
+      updatedAt: concurrentUpdatedAt.getTime()
     })
 
-    expect(project.update).toHaveBeenCalledWith({
-      where: { id: 'project-1' },
-      data: { pinned: true, updatedAt: new Date(1710000000100) }
-    })
+    expect(executeRaw).toHaveBeenCalledOnce()
+    expect(project.update).not.toHaveBeenCalled()
   })
 
   it('deletes a project by id', async () => {

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -9,7 +9,7 @@ import type {
 
 // Only the project delegate is needed; typing to this subset keeps the repository unit-testable with a
 // lightweight mock instead of a real (engine-backed) PrismaClient.
-type ProjectClient = Pick<PrismaClient, 'project' | 'projectDeletionIntent'>
+type ProjectClient = Pick<PrismaClient, '$executeRaw' | 'project' | 'projectDeletionIntent'>
 
 // Normalizes Prisma rows into the epoch-ms shape shared with the renderer.
 const toProject = (row: PrismaProject): Project => ({
@@ -66,7 +66,7 @@ class ProjectRepository {
   // Updates editable fields, ignoring undefined values so callers can patch only what changed.
   // Pin-only changes preserve updatedAt because pinning controls placement, not research activity.
   async update(request: UpdateProjectRequest): Promise<Project> {
-    const data: { name?: string; description?: string; pinned?: boolean; updatedAt?: Date } = {}
+    const data: { name?: string; description?: string; pinned?: boolean } = {}
 
     if (request.name !== undefined) {
       const name = request.name.trim()
@@ -84,15 +84,27 @@ class ProjectRepository {
 
     const client = await this.getClient()
 
-    if (request.pinned !== undefined) {
-      data.pinned = request.pinned
+    if (
+      request.pinned !== undefined &&
+      request.name === undefined &&
+      request.description === undefined
+    ) {
+      // Prisma's @updatedAt automation also runs for administrative changes. Updating only the pin
+      // column in SQL avoids both a fake activity bump and a read/write race that could restore an
+      // older timestamp over concurrent Project activity.
+      const updated = await client.$executeRaw`
+        UPDATE "Project"
+        SET "pinned" = ${request.pinned}
+        WHERE "id" = ${request.id}
+      `
+      if (updated !== 1) throw new Error('Project not found.')
 
-      if (request.name === undefined && request.description === undefined) {
-        const current = await client.project.findUnique({ where: { id: request.id } })
-        if (!current) throw new Error('Project not found.')
-        data.updatedAt = current.updatedAt
-      }
+      const row = await client.project.findUnique({ where: { id: request.id } })
+      if (!row) throw new Error('Project not found.')
+      return toProject(row)
     }
+
+    if (request.pinned !== undefined) data.pinned = request.pinned
 
     const row = await client.project.update({ where: { id: request.id }, data })
 

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -17,6 +17,7 @@ const toProject = (row: PrismaProject): Project => ({
   name: row.name,
   description: row.description,
   isExample: row.isExample,
+  ...(row.pinned ? { pinned: true } : {}),
   ...(row.archivedAt ? { archivedAt: row.archivedAt.getTime() } : {}),
   createdAt: row.createdAt.getTime(),
   updatedAt: row.updatedAt.getTime()
@@ -62,9 +63,10 @@ class ProjectRepository {
     return toProject(row)
   }
 
-  // Updates name and/or description, ignoring undefined fields so callers can patch either one.
+  // Updates editable fields, ignoring undefined values so callers can patch only what changed.
+  // Pin-only changes preserve updatedAt because pinning controls placement, not research activity.
   async update(request: UpdateProjectRequest): Promise<Project> {
-    const data: { name?: string; description?: string } = {}
+    const data: { name?: string; description?: string; pinned?: boolean; updatedAt?: Date } = {}
 
     if (request.name !== undefined) {
       const name = request.name.trim()
@@ -81,6 +83,17 @@ class ProjectRepository {
     }
 
     const client = await this.getClient()
+
+    if (request.pinned !== undefined) {
+      data.pinned = request.pinned
+
+      if (request.name === undefined && request.description === undefined) {
+        const current = await client.project.findUnique({ where: { id: request.id } })
+        if (!current) throw new Error('Project not found.')
+        data.updatedAt = current.updatedAt
+      }
+    }
+
     const row = await client.project.update({ where: { id: request.id }, data })
 
     return toProject(row)

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -86,6 +86,20 @@ describe('HomePage persistence recovery', () => {
   let deleteProject: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        projectFiles: {
+          getOverview: vi.fn().mockResolvedValue({
+            totalCount: 0,
+            uploadCount: 0,
+            artifactCount: 0,
+            artifactGroupCount: 0,
+            isIndexComplete: true
+          })
+        }
+      }
+    })
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -96,7 +96,8 @@ describe('HomePage persistence recovery', () => {
             artifactCount: 0,
             artifactGroupCount: 0,
             isIndexComplete: true
-          })
+          }),
+          onChanged: vi.fn(() => vi.fn())
         }
       }
     })

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@/components/UpdateCapsule', () => ({ UpdateCapsule: () => null }))
 
 let container: HTMLDivElement
 let root: Root
+let getProjectFilesOverview: ReturnType<typeof vi.fn>
 
 const project: Project = {
   id: 'project-1',
@@ -63,6 +64,17 @@ const environment = (checks: EnvironmentCheckResult['checks']): EnvironmentCheck
 })
 
 beforeEach(() => {
+  getProjectFilesOverview = vi.fn().mockResolvedValue({
+    totalCount: 0,
+    uploadCount: 0,
+    artifactCount: 0,
+    artifactGroupCount: 0,
+    isIndexComplete: true
+  })
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { projectFiles: { getOverview: getProjectFilesOverview } }
+  })
   useProjectStore.setState(createInitialProjectState())
   useNavigationStore.setState({ pendingProjectCreation: false })
   useSessionStore.setState(createInitialSessionState())
@@ -290,7 +302,12 @@ describe('HomePage activity overview', () => {
     expect(menu?.className).toContain('text-popover-foreground')
     expect(menu?.className).toContain('w-max')
     expect(menu?.className).toContain('min-w-0')
-    expect(items.map((item) => item.textContent?.trim())).toEqual(['Settings', 'Archive', 'Delete'])
+    expect(items.map((item) => item.textContent?.trim())).toEqual([
+      'Pin project',
+      'Settings',
+      'Archive',
+      'Delete'
+    ])
 
     const settingsItem = items.find((item) => item.textContent?.trim() === 'Settings')
     clickRadixMenuItem(settingsItem)
@@ -300,6 +317,116 @@ describe('HomePage activity overview', () => {
     expect(document.body.textContent).toContain('Update this project’s name and description.')
     expect(document.body.textContent).toContain('Save')
     expect(document.body.textContent).not.toContain('Save changes')
+  })
+
+  it('pins and unpins a Project from the first menu action', async () => {
+    const updateProject = vi.fn(async ({ pinned }: { pinned?: boolean }) => {
+      const updated = { ...project, pinned }
+      useProjectStore.setState({ projects: [updated] })
+      return updated
+    })
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects: [project],
+      isLoaded: true,
+      updateProject
+    } as never)
+
+    await act(async () =>
+      root.render(
+        <HomePage canDeleteProjects hasCompleteSessionCatalog onOpenGlobalSearch={vi.fn()} />
+      )
+    )
+
+    openRadixMenu(
+      container.querySelector<HTMLButtonElement>('[aria-label="Open actions for Research project"]')
+    )
+    clickRadixMenuItem(
+      Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+        (item) => item.textContent?.trim() === 'Pin project'
+      )
+    )
+    await act(async () => Promise.resolve())
+
+    expect(updateProject).toHaveBeenCalledWith({ id: project.id, pinned: true })
+    expect(container.textContent).toContain('Pinned project')
+
+    openRadixMenu(
+      container.querySelector<HTMLButtonElement>('[aria-label="Open actions for Research project"]')
+    )
+    const unpinItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find((item) => item.textContent?.trim() === 'Unpin project')
+    expect(unpinItem).toBeDefined()
+    clickRadixMenuItem(unpinItem)
+    await act(async () => Promise.resolve())
+
+    expect(updateProject).toHaveBeenLastCalledWith({ id: project.id, pinned: false })
+  })
+
+  it('groups pinned Projects first while preserving recent activity order inside both groups', async () => {
+    const projects: Project[] = [
+      { ...project, id: 'unpinned-new', name: 'Unpinned new', updatedAt: 400 },
+      { ...project, id: 'pinned-old', name: 'Pinned old', pinned: true, updatedAt: 100 },
+      { ...project, id: 'unpinned-old', name: 'Unpinned old', updatedAt: 300 },
+      { ...project, id: 'pinned-new', name: 'Pinned new', pinned: true, updatedAt: 200 }
+    ]
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects,
+      isLoaded: true
+    })
+
+    await act(async () =>
+      root.render(
+        <HomePage canDeleteProjects hasCompleteSessionCatalog onOpenGlobalSearch={vi.fn()} />
+      )
+    )
+
+    expect(
+      Array.from(container.querySelectorAll<HTMLElement>('[aria-label^="Open actions for "]')).map(
+        (action) => action.getAttribute('aria-label')
+      )
+    ).toEqual([
+      'Open actions for Pinned new',
+      'Open actions for Pinned old',
+      'Open actions for Unpinned new',
+      'Open actions for Unpinned old'
+    ])
+  })
+
+  it('shows complete artifact counts only while the entire Recent sessions list is empty', async () => {
+    getProjectFilesOverview.mockResolvedValue({
+      totalCount: 114,
+      uploadCount: 0,
+      artifactCount: 114,
+      artifactGroupCount: 1,
+      isIndexComplete: true
+    })
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects: [project],
+      isLoaded: true
+    })
+
+    await act(async () =>
+      root.render(
+        <HomePage canDeleteProjects hasCompleteSessionCatalog onOpenGlobalSearch={vi.fn()} />
+      )
+    )
+    await act(async () => Promise.resolve())
+
+    expect(container.textContent).toContain('114 artifacts')
+    expect(getProjectFilesOverview).toHaveBeenCalledWith({ projectId: project.id })
+
+    await act(async () => {
+      useSessionStore.setState({
+        ...createInitialSessionState(),
+        sessions: [session('recent', 'Recent analysis', 'idle', 600_000)]
+      })
+    })
+
+    expect(container.textContent).not.toContain('114 artifacts')
   })
 
   it('opens global search from the header and uses the selected Projects icon', async () => {

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ProjectFilesChangedEvent } from '../../../../shared/project-files'
 import type { Project } from '../../../../shared/projects'
 import type { EnvironmentCheckResult } from '../../../../shared/settings'
 import { EMPTY_SNAPSHOT, useNotificationInboxStore } from '@/stores/notification-inbox-store'
@@ -23,6 +24,8 @@ vi.mock('@/components/UpdateCapsule', () => ({ UpdateCapsule: () => null }))
 let container: HTMLDivElement
 let root: Root
 let getProjectFilesOverview: ReturnType<typeof vi.fn>
+let onProjectFilesChanged: ((event: ProjectFilesChangedEvent) => void) | undefined
+let removeProjectFilesChanged: ReturnType<typeof vi.fn>
 
 const project: Project = {
   id: 'project-1',
@@ -64,6 +67,8 @@ const environment = (checks: EnvironmentCheckResult['checks']): EnvironmentCheck
 })
 
 beforeEach(() => {
+  onProjectFilesChanged = undefined
+  removeProjectFilesChanged = vi.fn()
   getProjectFilesOverview = vi.fn().mockResolvedValue({
     totalCount: 0,
     uploadCount: 0,
@@ -73,7 +78,15 @@ beforeEach(() => {
   })
   Object.defineProperty(window, 'api', {
     configurable: true,
-    value: { projectFiles: { getOverview: getProjectFilesOverview } }
+    value: {
+      projectFiles: {
+        getOverview: getProjectFilesOverview,
+        onChanged: vi.fn((listener: (event: ProjectFilesChangedEvent) => void) => {
+          onProjectFilesChanged = listener
+          return removeProjectFilesChanged
+        })
+      }
+    }
   })
   useProjectStore.setState(createInitialProjectState())
   useNavigationStore.setState({ pendingProjectCreation: false })
@@ -419,6 +432,26 @@ describe('HomePage activity overview', () => {
     expect(container.textContent).toContain('114 artifacts')
     expect(getProjectFilesOverview).toHaveBeenCalledWith({ projectId: project.id })
 
+    getProjectFilesOverview.mockResolvedValue({
+      totalCount: 115,
+      uploadCount: 0,
+      artifactCount: 115,
+      artifactGroupCount: 1,
+      isIndexComplete: true
+    })
+    await act(async () => {
+      onProjectFilesChanged?.({
+        projectId: project.id,
+        sessionId: 'session-1',
+        sources: ['artifact'],
+        kind: 'upsert'
+      })
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).toContain('115 artifacts')
+    expect(getProjectFilesOverview).toHaveBeenCalledTimes(2)
+
     await act(async () => {
       useSessionStore.setState({
         ...createInitialSessionState(),
@@ -427,6 +460,8 @@ describe('HomePage activity overview', () => {
     })
 
     expect(container.textContent).not.toContain('114 artifacts')
+    expect(container.textContent).not.toContain('115 artifacts')
+    expect(removeProjectFilesChanged).toHaveBeenCalledOnce()
   })
 
   it('opens global search from the header and uses the selected Projects icon', async () => {

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -276,29 +276,41 @@ const HomePage = ({
 
   useEffect(() => {
     let cancelled = false
+    const activeProjectIds = new Set(activeProjects.map((project) => project.id))
+    const requestVersions = new Map<string, number>()
 
     if (!showArtifactCounts) return
 
-    void Promise.all(
-      activeProjects.map(async (project) => {
-        try {
-          const overview = await window.api.projectFiles.getOverview({ projectId: project.id })
-          return overview.isIndexComplete
-            ? ([project.id, overview.artifactCount] as const)
-            : undefined
-        } catch {
-          return undefined
-        }
+    const refreshArtifactCount = async (projectId: string): Promise<void> => {
+      const requestVersion = (requestVersions.get(projectId) ?? 0) + 1
+      requestVersions.set(projectId, requestVersion)
+
+      let artifactCount: number | undefined
+      try {
+        const overview = await window.api.projectFiles.getOverview({ projectId })
+        if (overview.isIndexComplete) artifactCount = overview.artifactCount
+      } catch {
+        // An unavailable or incomplete index is not authoritative, so omit its count.
+      }
+
+      if (cancelled || requestVersions.get(projectId) !== requestVersion) return
+      setArtifactCounts((current) => {
+        const next = new Map(current)
+        if (artifactCount === undefined) next.delete(projectId)
+        else next.set(projectId, artifactCount)
+        return next
       })
-    ).then((entries) => {
-      if (cancelled) return
-      setArtifactCounts(
-        new Map(entries.filter((entry): entry is readonly [string, number] => entry !== undefined))
-      )
+    }
+
+    for (const project of activeProjects) void refreshArtifactCount(project.id)
+
+    const removeChangedListener = window.api.projectFiles.onChanged((event) => {
+      if (activeProjectIds.has(event.projectId)) void refreshArtifactCount(event.projectId)
     })
 
     return () => {
       cancelled = true
+      removeChangedListener()
     }
   }, [activeProjects, showArtifactCounts])
 

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -13,6 +13,7 @@ import {
   Plus,
   Search,
   Settings,
+  Star,
   Trash2,
   X
 } from 'lucide-react'
@@ -140,7 +141,9 @@ const HomePage = ({
   const [isDeletingProject, setIsDeletingProject] = useState(false)
   const [deleteProjectError, setDeleteProjectError] = useState<string | undefined>(undefined)
   const [archivingProjectIds, setArchivingProjectIds] = useState<Set<string>>(() => new Set())
-  const [archiveProjectError, setArchiveProjectError] = useState<string | undefined>(undefined)
+  const [pinningProjectIds, setPinningProjectIds] = useState<Set<string>>(() => new Set())
+  const [projectActionError, setProjectActionError] = useState<string | undefined>(undefined)
+  const [artifactCounts, setArtifactCounts] = useState<Map<string, number>>(() => new Map())
   const [markingReadSessionIds, setMarkingReadSessionIds] = useState<Set<string>>(() => new Set())
   const [markReadErrorSessionIds, setMarkReadErrorSessionIds] = useState<Set<string>>(
     () => new Set()
@@ -254,7 +257,11 @@ const HomePage = ({
       }
     })
 
-    return summaries.sort((left, right) => right.lastActivityAt - left.lastActivityAt)
+    return summaries.sort(
+      (left, right) =>
+        Number(Boolean(right.project.pinned)) - Number(Boolean(left.project.pinned)) ||
+        right.lastActivityAt - left.lastActivityAt
+    )
   }, [activeProjects, persistedSessions])
 
   const recentSessions = useMemo(
@@ -264,6 +271,36 @@ const HomePage = ({
         .slice(0, RECENT_SESSION_LIMIT),
     [persistedSessions]
   )
+
+  const showArtifactCounts = hasCompleteSessionCatalog && recentSessions.length === 0
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!showArtifactCounts) return
+
+    void Promise.all(
+      activeProjects.map(async (project) => {
+        try {
+          const overview = await window.api.projectFiles.getOverview({ projectId: project.id })
+          return overview.isIndexComplete
+            ? ([project.id, overview.artifactCount] as const)
+            : undefined
+        } catch {
+          return undefined
+        }
+      })
+    ).then((entries) => {
+      if (cancelled) return
+      setArtifactCounts(
+        new Map(entries.filter((entry): entry is readonly [string, number] => entry !== undefined))
+      )
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeProjects, showArtifactCounts])
 
   const deleteTargetSessionCount = useMemo(
     () =>
@@ -329,13 +366,11 @@ const HomePage = ({
     if (!canArchiveProject(project) || archivingProjectIds.has(project.id)) return
 
     setArchivingProjectIds((current) => new Set(current).add(project.id))
-    setArchiveProjectError(undefined)
+    setProjectActionError(undefined)
     void updateProjectArchive({ id: project.id, archived: true, expectedArchivedAt: null })
       .then((archived) => enqueueProjectArchive(archived))
       .catch((error: unknown) =>
-        setArchiveProjectError(
-          error instanceof Error ? error.message : 'Could not archive project.'
-        )
+        setProjectActionError(error instanceof Error ? error.message : 'Could not archive project.')
       )
       .finally(() => {
         setArchivingProjectIds((current) => {
@@ -366,6 +401,26 @@ const HomePage = ({
         return next
       })
     }
+  }
+
+  const toggleProjectPin = (project: Project): void => {
+    if (pinningProjectIds.has(project.id)) return
+
+    setPinningProjectIds((current) => new Set(current).add(project.id))
+    setProjectActionError(undefined)
+    void updateProject({ id: project.id, pinned: !project.pinned })
+      .catch((error: unknown) =>
+        setProjectActionError(
+          error instanceof Error ? error.message : 'Could not update project pin.'
+        )
+      )
+      .finally(() => {
+        setPinningProjectIds((current) => {
+          const next = new Set(current)
+          next.delete(project.id)
+          return next
+        })
+      })
   }
 
   const closeFormDialog = (): void => {
@@ -655,12 +710,12 @@ const HomePage = ({
               />
               Projects
             </h2>
-            {archiveProjectError ? (
+            {projectActionError ? (
               <div
                 className="mb-3 rounded-2xl border border-danger-000/30 px-4 py-3 text-sm text-danger-000"
                 role="alert"
               >
-                {archiveProjectError}
+                {projectActionError}
               </div>
             ) : null}
             {loadError ? (
@@ -691,6 +746,16 @@ const HomePage = ({
                         <span className="min-w-0 truncate font-semibold text-text-000">
                           {project.name}
                         </span>
+                        {project.pinned ? (
+                          <>
+                            <Star
+                              className="size-4 shrink-0 fill-current text-session-waiting"
+                              strokeWidth={2}
+                              aria-hidden="true"
+                            />
+                            <span className="sr-only">Pinned project</span>
+                          </>
+                        ) : null}
                         {project.isExample ? (
                           <span className="shrink-0 rounded bg-bg-300 px-1.5 py-0.5 text-[10px] font-medium text-text-100">
                             Example
@@ -727,6 +792,12 @@ const HomePage = ({
                           ? `${sessionCount} ${sessionCount === 1 ? 'session' : 'sessions'}`
                           : 'Session count unavailable'}
                       </span>
+                      {showArtifactCounts && artifactCounts.has(project.id) ? (
+                        <span className="hidden shrink-0 tabular-nums text-xs text-text-100 sm:inline">
+                          {artifactCounts.get(project.id)}{' '}
+                          {artifactCounts.get(project.id) === 1 ? 'artifact' : 'artifacts'}
+                        </span>
+                      ) : null}
                       <span className="hidden w-8 shrink-0 text-right text-xs text-text-000 sm:inline">
                         {formatRelativeTime(lastActivityAt)}
                       </span>
@@ -746,6 +817,18 @@ const HomePage = ({
                           align="end"
                           sideOffset={6}
                         >
+                          <DropdownMenuItem
+                            className="gap-2"
+                            disabled={pinningProjectIds.has(project.id)}
+                            onSelect={() => toggleProjectPin(project)}
+                          >
+                            <Star
+                              className={cn('size-4', project.pinned && 'fill-current')}
+                              strokeWidth={2}
+                              aria-hidden="true"
+                            />
+                            {project.pinned ? 'Unpin project' : 'Pin project'}
+                          </DropdownMenuItem>
                           <DropdownMenuItem
                             className="gap-2"
                             onSelect={() => openEditDialog(project)}

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -75,7 +75,7 @@ export const useProjectStore = create<ProjectStore>((set) => ({
     return project
   },
 
-  // Applies a name/description edit and merges the updated row into the cache.
+  // Applies an editable Project patch and merges the updated row into the cache.
   updateProject: async (request) => {
     const project = await window.api.projects.update(request)
 

--- a/src/shared/projects.test.ts
+++ b/src/shared/projects.test.ts
@@ -26,6 +26,9 @@ describe('project application command contracts', () => {
       projectApplicationCommandContracts.update.args.parse([{ id: 'project-1', name: 'Renamed' }])
     ).toEqual([{ id: 'project-1', name: 'Renamed' }])
     expect(
+      projectApplicationCommandContracts.update.args.parse([{ id: 'project-1', pinned: true }])
+    ).toEqual([{ id: 'project-1', pinned: true }])
+    expect(
       projectApplicationCommandContracts.updateArchive.args.parse([
         { id: 'project-1', archived: true, expectedArchivedAt: null }
       ])

--- a/src/shared/projects.ts
+++ b/src/shared/projects.ts
@@ -13,6 +13,8 @@ export const projectSchema = z
     name: z.string(),
     description: z.string(),
     isExample: z.boolean(),
+    // Optional on the wire for compatibility with older persisted payloads; absence means unpinned.
+    pinned: z.boolean().optional(),
     // An absent timestamp keeps the Project on active surfaces. Archive is reversible and does not
     // affect the Project's research activity ordering.
     archivedAt: z.number().finite().optional(),
@@ -32,7 +34,8 @@ export const updateProjectRequestSchema = z
   .object({
     id: z.string(),
     name: z.string().optional(),
-    description: z.string().optional()
+    description: z.string().optional(),
+    pinned: z.boolean().optional()
   })
   .strict()
 


### PR DESCRIPTION
## Problem

Frequently used Projects cannot stay at the top of the Home Project list because every Project follows the same recent-activity ordering. When the entire Recent sessions list is empty, the Project rows also provide no artifact visibility.

## Proposed change

- Persist a per-Project pinned state and expose Pin/Unpin as the first Project menu action with the existing star icon language.
- Group pinned Projects ahead of unpinned Projects while preserving the existing recent-activity order inside both groups.
- Keep pin-only updates from changing `updatedAt`, so pinning does not masquerade as research activity.
- Update only the `pinned` column for pin-only patches, preventing a stale timestamp from overwriting concurrent Project activity.
- Show an authoritative artifact count on each Project row only when the complete Recent sessions catalog is empty and that Project's Files index is complete.
- Document the Home surface behavior in `docs/design.md`.

## Scope and non-goals

- Reuses the existing Project update command and Project Files overview contract; no new dependency or IPC surface.
- Does not change the activity ordering inside pinned or unpinned groups.
- Does not display partial artifact-index counts.
- Subscribes to the existing Project Files change event only while artifact counts are visible, and refetches only the affected Project.

## Acceptance criteria and validation

- Pin state persists through the Project schema and legacy migration: targeted repository, Prisma integration, and shared-contract tests pass.
- Concurrent pin/activity regression: the repository test fails against the original read/write timestamp implementation and passes with the pin-column-only update; the real SQLite round trip also preserves `updatedAt`.
- Pin/Unpin menu behavior, pinned grouping, within-group activity ordering, and empty-Recent artifact visibility: Home render/persistence tests pass.
- Targeted suite: 5 files, 49 tests passed.
- `npm run typecheck:node`: passed.
- `npm run typecheck:web`: passed.
- `npm run lint`: passed with 17 pre-existing warnings and no errors.
- Prisma schema validation: passed.
- Generated web API contract check: passed.
- Web production build: passed.
- Desktop, 390 px mobile, and isolated empty-Recent visual QA: passed with no horizontal overflow.
Checks above were rerun after rebasing onto `688ec334`. Cross-platform behavior remains delegated to CI.

## Review focus

- Pin-only `updatedAt` preservation in `ProjectRepository.update`.
- Pinned-first grouping without disturbing recent-activity ordering inside either group.
- Artifact visibility gating on both an empty complete Session catalog and a complete Project Files index.


