### PR TITLE
fix(permissions): persist authorization waits across restarts

### DIFF
--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -106,7 +106,34 @@ const seedHomeActivitySessions = async (page: Page, cwd: string): Promise<void> 
           title: 'Review a long session result on iPhone',
           cwd: sessionCwd,
           status: 'waiting-permission',
-          messages: [],
+          messages: [
+            {
+              id: 'mobile-needs-you-prompt',
+              role: 'user',
+              content: 'Run the mobile verification.',
+              status: 'complete',
+              eventIds: [],
+              createdAt: now - 2_000,
+              updatedAt: now - 2_000
+            }
+          ],
+          runtimeContext: {
+            version: 1,
+            revision: 1,
+            permission: {
+              state: 'pending',
+              request: {
+                requestId: 'mobile-needs-you-permission',
+                sessionId: 'mobile-needs-you-session',
+                toolCallId: 'mobile-needs-you-tool',
+                title: 'Run mobile verification',
+                options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+              },
+              originatingPromptMessageId: 'mobile-needs-you-prompt',
+              fingerprint: 'a'.repeat(64),
+              createdAt: now - 1_000
+            }
+          },
           createdAt: now - 2_000,
           updatedAt: now - 1_000
         },

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -105,35 +105,8 @@ const seedHomeActivitySessions = async (page: Page, cwd: string): Promise<void> 
           projectId: project.id,
           title: 'Review a long session result on iPhone',
           cwd: sessionCwd,
-          status: 'waiting-permission',
-          messages: [
-            {
-              id: 'mobile-needs-you-prompt',
-              role: 'user',
-              content: 'Run the mobile verification.',
-              status: 'complete',
-              eventIds: [],
-              createdAt: now - 2_000,
-              updatedAt: now - 2_000
-            }
-          ],
-          runtimeContext: {
-            version: 1,
-            revision: 1,
-            permission: {
-              state: 'pending',
-              request: {
-                requestId: 'mobile-needs-you-permission',
-                sessionId: 'mobile-needs-you-session',
-                toolCallId: 'mobile-needs-you-tool',
-                title: 'Run mobile verification',
-                options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
-              },
-              originatingPromptMessageId: 'mobile-needs-you-prompt',
-              fingerprint: 'a'.repeat(64),
-              createdAt: now - 1_000
-            }
-          },
+          status: 'waiting-for-user',
+          messages: [],
           createdAt: now - 2_000,
           updatedAt: now - 1_000
         },

--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -171,6 +171,7 @@ describe('ACP permission broker with durable grants', () => {
 
       await broker.prepareRestoredDecision(
         {
+          state: 'pending',
           request: {
             requestId: 'permission-1',
             sessionId: 'session-1',

--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -142,6 +142,58 @@ const controlledEmptyGrantRegistry = (): {
 }
 
 describe('ACP permission broker with durable grants', () => {
+  it.each([
+    ['session', { kind: 'session', projectId: 'project-1', sessionId: 'session-1' }],
+    ['project', { kind: 'project', projectId: 'project-1' }],
+    ['global', { kind: 'global' }]
+  ] as const)(
+    'commits a restored %s selection through the durable grant registry',
+    async (scope, expectedScope) => {
+      const registry = {
+        resolve: vi.fn().mockResolvedValue(undefined),
+        remember: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn().mockResolvedValue([]),
+        listCached: vi.fn().mockReturnValue([]),
+        revoke: vi.fn(),
+        extendUndo: vi.fn(),
+        restore: vi.fn(),
+        prune: vi.fn(),
+        finalizeOwnerDeletion: vi.fn(),
+        subscribe: vi.fn().mockReturnValue(() => undefined)
+      } satisfies PermissionGrantRegistry
+      const broker = new AcpPermissionBroker(() => undefined, undefined, registry)
+      const option = {
+        optionId: `allow-${scope}`,
+        name: `Allow for ${scope}`,
+        kind: 'allow_always',
+        scope
+      } as const
+
+      await broker.prepareRestoredDecision(
+        {
+          request: {
+            requestId: 'permission-1',
+            sessionId: 'session-1',
+            toolCallId: 'tool-1',
+            title: 'Inspect repository status',
+            options: [option]
+          },
+          originatingPromptMessageId: 'prompt-1',
+          fingerprint: 'a'.repeat(64),
+          capability: { kind: 'execution', key: 'shell:git-status' },
+          createdAt: 1
+        },
+        option,
+        'project-1'
+      )
+
+      expect(registry.remember).toHaveBeenCalledWith({
+        capability: { kind: 'execution', key: 'shell:git-status' },
+        scope: expectedScope
+      })
+    }
+  )
+
   it('cancels a request while its durable grant lookup is still pending', async () => {
     let finishResolve: (() => void) | undefined
     const registry = {

--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -348,6 +348,100 @@ describe('ACP permission broker with durable grants', () => {
     await expect(providerResponse).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
   })
 
+  it('settles durable Session authority before committing a persistent grant', async () => {
+    const journal: string[] = []
+    const registry = {
+      resolve: vi.fn().mockResolvedValue(undefined),
+      remember: vi.fn(async () => {
+        journal.push('grant')
+        return undefined as never
+      }),
+      list: vi.fn().mockResolvedValue([]),
+      listCached: vi.fn().mockReturnValue([]),
+      revoke: vi.fn(),
+      extendUndo: vi.fn(),
+      restore: vi.fn(),
+      prune: vi.fn(),
+      finalizeOwnerDeletion: vi.fn(),
+      subscribe: vi.fn().mockReturnValue(() => undefined)
+    } satisfies PermissionGrantRegistry
+    const emitted: Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0][] = []
+    const broker = new AcpPermissionBroker(
+      (request) => emitted.push(request),
+      undefined,
+      registry,
+      undefined,
+      {
+        persist: vi.fn(async () => true),
+        settleLive: vi.fn(async () => {
+          journal.push('authority')
+        })
+      }
+    )
+    const providerResponse = broker.requestPermission(shellRequest('session-1'), {
+      profile: 'ask',
+      projectId: 'project-1',
+      promptMessageId: 'prompt-1'
+    })
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    const projectOption = emitted[0].options.find((option) => option.scope === 'project')
+    await broker.respond({
+      requestId: emitted[0].requestId,
+      optionId: projectOption?.optionId
+    })
+
+    expect(journal).toEqual(['authority', 'grant'])
+    await expect(providerResponse).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'provider-allow-once' }
+    })
+  })
+
+  it('does not commit a persistent grant when durable Session settlement fails', async () => {
+    const registry = {
+      resolve: vi.fn().mockResolvedValue(undefined),
+      remember: vi.fn(),
+      list: vi.fn().mockResolvedValue([]),
+      listCached: vi.fn().mockReturnValue([]),
+      revoke: vi.fn(),
+      extendUndo: vi.fn(),
+      restore: vi.fn(),
+      prune: vi.fn(),
+      finalizeOwnerDeletion: vi.fn(),
+      subscribe: vi.fn().mockReturnValue(() => undefined)
+    } satisfies PermissionGrantRegistry
+    const emitted: Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0][] = []
+    const broker = new AcpPermissionBroker(
+      (request) => emitted.push(request),
+      undefined,
+      registry,
+      undefined,
+      {
+        persist: vi.fn(async () => true),
+        settleLive: vi.fn(async () => {
+          throw new Error('Session write failed')
+        })
+      }
+    )
+    const providerResponse = broker.requestPermission(shellRequest('session-1'), {
+      profile: 'ask',
+      projectId: 'project-1',
+      promptMessageId: 'prompt-1'
+    })
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    const projectOption = emitted[0].options.find((option) => option.scope === 'project')
+    await expect(
+      broker.respond({
+        requestId: emitted[0].requestId,
+        optionId: projectOption?.optionId
+      })
+    ).rejects.toThrow('Permission approval could not be saved')
+
+    expect(registry.remember).not.toHaveBeenCalled()
+    await expect(providerResponse).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+  })
+
   it('commits a Global grant before returning only the provider one-call decision', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-broker-registry-'))
     client = createProjectDbClient(storageRoot)

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -1,7 +1,11 @@
 import type { RequestPermissionRequest } from '@agentclientprotocol/sdk'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { AcpPermissionBroker, ConversationPermissionGrantStore } from './permission-broker'
+import {
+  AcpPermissionBroker,
+  ConversationPermissionGrantStore,
+  permissionRequestFingerprint
+} from './permission-broker'
 import { withTrustedNativeToolIdentity } from './permission-policy'
 
 type EmittedPermissionRequest = Parameters<ConstructorParameters<typeof AcpPermissionBroker>[0]>[0]
@@ -127,6 +131,140 @@ const createCodexMcpPermissionRequest = (sessionId = 'session-1'): RequestPermis
 })
 
 describe('ACP permission broker', () => {
+  it('persists a prompt-bound request before publishing it and clears authority before release', async () => {
+    const emitted: EmittedPermissionRequest[] = []
+    let finishPersist!: (persisted: boolean) => void
+    const persist = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishPersist = resolve
+        })
+    )
+    const settleLive = vi.fn(async () => undefined)
+    const broker = new AcpPermissionBroker(
+      (request) => emitted.push(request),
+      undefined,
+      undefined,
+      undefined,
+      { persist, settleLive }
+    )
+    const providerResponse = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'python verify.py',
+        providerToolName: 'Bash',
+        kind: 'execute',
+        rawInput: { command: 'python verify.py' }
+      }),
+      {
+        profile: 'ask',
+        cwd: '/workspace',
+        projectId: 'project-1',
+        promptMessageId: 'prompt-1'
+      }
+    )
+
+    expect(persist).toHaveBeenCalledOnce()
+    expect(emitted).toEqual([])
+    expect(broker.hasDurablePendingForSession('session-1')).toBe(false)
+
+    finishPersist(true)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0].durable).toBe(true)
+    expect(broker.hasDurablePendingForSession('session-1')).toBe(true)
+    const reject = emitted[0].options.find((option) => option.kind === 'reject_once')
+    await broker.respond({ requestId: emitted[0].requestId, optionId: reject?.optionId })
+
+    expect(settleLive).toHaveBeenCalledOnce()
+    await expect(providerResponse).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'reject-once' }
+    })
+  })
+
+  it('abandons a durable provider RPC during teardown without settling its restored card', async () => {
+    const emitted: EmittedPermissionRequest[] = []
+    const settleLive = vi.fn(async () => undefined)
+    const onSettled = vi.fn()
+    const broker = new AcpPermissionBroker(
+      (request) => emitted.push(request),
+      undefined,
+      undefined,
+      onSettled,
+      { persist: vi.fn(async () => true), settleLive }
+    )
+    const providerResponse = broker.requestPermission(createPermissionRequest(), {
+      profile: 'ask',
+      cwd: '/workspace',
+      projectId: 'project-1',
+      promptMessageId: 'prompt-1'
+    })
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    broker.abandonAllPending()
+
+    await expect(providerResponse).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+    expect(settleLive).not.toHaveBeenCalled()
+    expect(onSettled).not.toHaveBeenCalled()
+    expect(broker.getPendingRequests()).toEqual([])
+  })
+
+  it('releases a restored allow-once only for the exact parked tool fingerprint', async () => {
+    const emitted: EmittedPermissionRequest[] = []
+    const broker = new AcpPermissionBroker((request) => emitted.push(request))
+    const originalProviderResponse = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'python verify.py',
+        providerToolName: 'Bash',
+        kind: 'execute',
+        rawInput: { command: 'python verify.py' }
+      }),
+      { profile: 'ask', cwd: '/workspace' }
+    )
+    const original = emitted[0]
+    const fingerprint = permissionRequestFingerprint(original)
+    expect(fingerprint).toMatch(/^[a-f0-9]{64}$/)
+    broker.cancelAllPending()
+    await expect(originalProviderResponse).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+    await broker.prepareRestoredDecision(
+      {
+        request: original,
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: fingerprint!,
+        createdAt: 1
+      },
+      original.options.find((option) => option.scope === 'once'),
+      'project-1'
+    )
+
+    const mismatch = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'python verify.py',
+        providerToolName: 'Bash',
+        kind: 'execute',
+        rawInput: { command: 'python different.py' }
+      }),
+      { profile: 'ask', cwd: '/workspace' }
+    )
+    expect(emitted).toHaveLength(2)
+    await broker.respond({ requestId: emitted[1].requestId, cancelled: true })
+    await expect(mismatch).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+
+    const exact = broker.requestPermission(
+      createToolPermissionRequest({
+        title: 'python verify.py',
+        providerToolName: 'Bash',
+        kind: 'execute',
+        rawInput: { command: 'python verify.py' }
+      }),
+      { profile: 'ask', cwd: '/workspace' }
+    )
+    await expect(exact).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+    expect(emitted).toHaveLength(2)
+  })
+
   it('projects legacy command-group grants as readable shell grants', () => {
     const store = new ConversationPermissionGrantStore()
     const categoryKey = `shell-group:argv-prefix:sha256:v1:${'a'.repeat(64)}`

--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -228,6 +228,7 @@ describe('ACP permission broker', () => {
     await expect(originalProviderResponse).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
     await broker.prepareRestoredDecision(
       {
+        state: 'pending',
         request: original,
         originatingPromptMessageId: 'prompt-1',
         fingerprint: fingerprint!,

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -1216,9 +1216,9 @@ class AcpPermissionBroker {
                 sessionId: pending.request.sessionId
               }
       try {
-        await this.permissionGrantRegistry.remember({ capability: pending.capability, scope })
         const persistence = this.persistLiveSettlement(pending)
         if (persistence) await persistence
+        await this.permissionGrantRegistry.remember({ capability: pending.capability, scope })
         this.settlePending(
           pending,
           { outcome: { outcome: 'selected', optionId: providerOptionId } },

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -1,5 +1,5 @@
 import type { RequestPermissionRequest, RequestPermissionResponse } from '@agentclientprotocol/sdk'
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 
 import type {
   AcpPermissionGrant,
@@ -13,6 +13,7 @@ import type {
   PermissionGrantRecord,
   PermissionGrantScope
 } from '../../shared/permission-grants'
+import type { SessionPermissionRuntimeContext } from '../../shared/session-persistence'
 import type { CommandShellDialect } from '../agent-framework/types'
 import { extractProviderToolName } from './runtime-events'
 import {
@@ -43,10 +44,29 @@ type PendingPermission = {
   capability?: PermissionCapability
   projectId?: string
   providerAllowOnceOptionId?: string
+  durableCandidate?: DurablePermissionWaitCandidate
+  durablePersisted?: boolean
+  durableReady?: Promise<void>
+  durablePersistenceSettled?: boolean
+  settled?: boolean
   resolve: (response: RequestPermissionResponse) => void
 }
 
 type EmitPermissionRequest = (request: AcpPermissionRequest) => void
+
+type DurablePermissionWaitCandidate = Readonly<{
+  request: AcpPermissionRequest
+  projectId?: string
+  promptMessageId?: string
+  fingerprint: string
+  categoryKey?: string
+  capability?: PermissionCapability
+}>
+
+type PermissionWaitHooks = Readonly<{
+  persist: (candidate: DurablePermissionWaitCandidate) => Promise<boolean>
+  settleLive: (candidate: DurablePermissionWaitCandidate) => Promise<void>
+}>
 
 class ConversationPermissionGrantStore {
   private readonly categoriesBySession = new Map<string, Set<string>>()
@@ -109,6 +129,38 @@ const metadataRecord = (value: unknown): Record<string, unknown> | undefined =>
   value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined
+
+const canonicalPermissionValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(canonicalPermissionValue)
+  if (!value || typeof value !== 'object') return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalPermissionValue(entry)])
+  )
+}
+
+const permissionRequestFingerprint = (request: AcpPermissionRequest): string | undefined => {
+  try {
+    const canonical = JSON.stringify(
+      canonicalPermissionValue({
+        title: request.title,
+        providerToolName: request.providerToolName,
+        isMcp: request.isMcp,
+        mcpIdentity: request.mcpIdentity,
+        toolKind: request.toolKind,
+        toolLocations: request.toolLocations,
+        commandPrefix: request.commandPrefix,
+        rawInput: request.rawInput
+      })
+    )
+    return canonical === undefined
+      ? undefined
+      : createHash('sha256').update(canonical).digest('hex')
+  } catch {
+    return undefined
+  }
+}
 
 type CodexCommandGroup = { categoryKey: string; commandPrefix: string[] }
 type CodexCommandGroupMatch = { kind: 'group'; group: CodexCommandGroup } | { kind: 'unsafe' }
@@ -671,6 +723,7 @@ const projectRegistrySessionGrants = (
 // Tracks permission requests until the renderer chooses an outcome.
 class AcpPermissionBroker {
   private pendingRequests = new Map<string, PendingPermission>()
+  private readonly restoredAllowOnceBySession = new Map<string, string>()
   private cancellationGeneration = 0
   private readonly sessionCancellationGenerations = new Map<string, number>()
   private readonly livePermissionProfiles = new Map<
@@ -690,7 +743,8 @@ class AcpPermissionBroker {
     private readonly onPermissionSettled?: (
       requestId: string,
       state: AcpPermissionSettlementState
-    ) => void
+    ) => void,
+    private readonly permissionWaitHooks?: PermissionWaitHooks
   ) {}
 
   // Returns serializable pending requests for runtime snapshots.
@@ -701,6 +755,13 @@ class AcpPermissionBroker {
   hasPendingForSession(sessionId: string): boolean {
     return Array.from(this.pendingRequests.values()).some(
       ({ request }) => request.sessionId === sessionId
+    )
+  }
+
+  hasDurablePendingForSession(sessionId: string): boolean {
+    return Array.from(this.pendingRequests.values()).some(
+      ({ request, durablePersisted }) =>
+        request.sessionId === sessionId && durablePersisted === true
     )
   }
 
@@ -925,6 +986,27 @@ class AcpPermissionBroker {
       rawInput: params.toolCall.rawInput,
       options: permissionOptions
     }
+    const fingerprint = permissionRequestFingerprint(request)
+    const durableCandidate: DurablePermissionWaitCandidate | undefined = fingerprint
+      ? {
+          request,
+          projectId: policyContext?.projectId,
+          promptMessageId: policyContext?.promptMessageId,
+          fingerprint,
+          categoryKey,
+          capability
+        }
+      : undefined
+
+    if (
+      durableCandidate &&
+      this.restoredAllowOnceBySession.get(request.sessionId) === durableCandidate.fingerprint
+    ) {
+      this.restoredAllowOnceBySession.delete(request.sessionId)
+      return Promise.resolve({
+        outcome: { outcome: 'selected', optionId: providerAllowOnceOption.optionId }
+      })
+    }
 
     // A model-independent fallback auto-reviews only structured, workspace-contained low-risk tools.
     // Resolve against the projected options so a stripped policy amendment can never be an automatic
@@ -968,7 +1050,8 @@ class AcpPermissionBroker {
             categoryKey,
             capability,
             projectId: policyContext?.projectId,
-            providerAllowOnceOptionId: providerAllowOnceOption?.optionId
+            providerAllowOnceOptionId: providerAllowOnceOption?.optionId,
+            durableCandidate
           })
         })
     }
@@ -991,7 +1074,8 @@ class AcpPermissionBroker {
       automaticRequest,
       policyContext,
       categoryKey,
-      providerAllowOnceOptionId: providerAllowOnceOption?.optionId
+      providerAllowOnceOptionId: providerAllowOnceOption?.optionId,
+      durableCandidate
     })
   }
 
@@ -1029,14 +1113,46 @@ class AcpPermissionBroker {
   private enqueuePermissionRequest(
     pending: Omit<PendingPermission, 'resolve'> & { requestId: string }
   ): Promise<RequestPermissionResponse> {
-    return new Promise((resolve) => {
-      const { requestId, ...entry } = pending
-      this.pendingRequests.set(requestId, {
-        ...entry,
-        resolve
-      })
-      this.emitPermissionRequest(entry.request)
+    let resolveResponse!: (response: RequestPermissionResponse) => void
+    const response = new Promise<RequestPermissionResponse>((resolve) => {
+      resolveResponse = resolve
     })
+    const { requestId, ...entry } = pending
+    const stored: PendingPermission = {
+      ...entry,
+      resolve: resolveResponse
+    }
+    this.pendingRequests.set(requestId, stored)
+
+    if (!stored.durableCandidate || !this.permissionWaitHooks) {
+      this.emitPermissionRequest(entry.request)
+      return response
+    }
+
+    stored.durableReady = this.permissionWaitHooks.persist(stored.durableCandidate).then(
+      (persisted) => {
+        stored.durablePersisted = persisted
+        stored.durablePersistenceSettled = true
+        if (persisted) stored.request = { ...stored.request, durable: true }
+      },
+      (error: unknown) => {
+        stored.durablePersistenceSettled = true
+        throw error
+      }
+    )
+    return stored.durableReady.then(
+      () => {
+        if (this.pendingRequests.get(requestId) === stored) {
+          this.emitPermissionRequest(stored.request)
+        }
+        return response
+      },
+      (error: unknown) => {
+        this.pendingRequests.delete(requestId)
+        this.settlePending(stored, { outcome: { outcome: 'cancelled' } }, 'cancelled')
+        throw error
+      }
+    )
   }
 
   // Resolves one pending request and reports whether it was found.
@@ -1050,6 +1166,8 @@ class AcpPermissionBroker {
     this.pendingRequests.delete(response.requestId)
 
     if (response.cancelled || !response.optionId) {
+      const persistence = this.persistLiveSettlement(pending)
+      if (persistence) await persistence
       this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
       return true
     }
@@ -1057,6 +1175,8 @@ class AcpPermissionBroker {
     // Only options projected to the renderer are valid responses. This keeps provider-specific
     // persistent policy actions hidden at the protocol boundary as well as in the UI.
     if (!pending.request.options.some((option) => option.optionId === response.optionId)) {
+      const persistence = this.persistLiveSettlement(pending)
+      if (persistence) await persistence
       this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
       return true
     }
@@ -1072,6 +1192,8 @@ class AcpPermissionBroker {
     const providerOptionId = rememberedScope ? pending.providerAllowOnceOptionId : response.optionId
 
     if (!providerOptionId) {
+      const persistence = this.persistLiveSettlement(pending)
+      if (persistence) await persistence
       this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
       return true
     }
@@ -1095,6 +1217,8 @@ class AcpPermissionBroker {
               }
       try {
         await this.permissionGrantRegistry.remember({ capability: pending.capability, scope })
+        const persistence = this.persistLiveSettlement(pending)
+        if (persistence) await persistence
         this.settlePending(
           pending,
           { outcome: { outcome: 'selected', optionId: providerOptionId } },
@@ -1114,6 +1238,9 @@ class AcpPermissionBroker {
       this.rememberSessionGrant(pending.request, pending.categoryKey, response.optionId)
     }
 
+    const persistence = this.persistLiveSettlement(pending)
+    if (persistence) await persistence
+
     this.settlePending(
       pending,
       {
@@ -1128,11 +1255,34 @@ class AcpPermissionBroker {
     return true
   }
 
+  private persistLiveSettlement(pending: PendingPermission): Promise<void> | undefined {
+    const candidate = pending.durableCandidate
+    const hooks = this.permissionWaitHooks
+    if (!candidate || !hooks) return undefined
+    return (async () => {
+      try {
+        await pending.durableReady
+        if (!pending.durablePersisted) return
+        await hooks.settleLive(candidate)
+      } catch (error) {
+        this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
+        throw new Error(
+          'Permission decision could not be persisted; the tool call was cancelled.',
+          {
+            cause: error
+          }
+        )
+      }
+    })()
+  }
+
   private settlePending(
     pending: PendingPermission,
     response: RequestPermissionResponse,
     state: AcpPermissionSettlementState
   ): void {
+    if (pending.settled) return
+    pending.settled = true
     pending.resolve(response)
     try {
       this.onPermissionSettled?.(pending.request.requestId, state)
@@ -1166,14 +1316,78 @@ class AcpPermissionBroker {
     this.conversationGrants.remember(request.sessionId, categoryKey)
   }
 
+  async prepareRestoredDecision(
+    permission: SessionPermissionRuntimeContext,
+    option: AcpPermissionRequest['options'][number] | undefined,
+    projectId: string
+  ): Promise<void> {
+    if (!option || option.kind.toLowerCase().startsWith('reject_')) return
+    if (!option.kind.toLowerCase().startsWith('allow_')) {
+      throw new Error('The restored permission option cannot be replayed safely.')
+    }
+
+    if (option.scope === 'once' || option.kind.toLowerCase() === ALLOW_ONCE_OPTION_KIND) {
+      this.restoredAllowOnceBySession.set(permission.request.sessionId, permission.fingerprint)
+      return
+    }
+
+    if (
+      (option.scope === 'session' || option.scope === 'project' || option.scope === 'global') &&
+      permission.capability &&
+      this.permissionGrantRegistry
+    ) {
+      const scope: PermissionGrantScope =
+        option.scope === 'global'
+          ? { kind: 'global' }
+          : option.scope === 'project'
+            ? { kind: 'project', projectId }
+            : { kind: 'session', projectId, sessionId: permission.request.sessionId }
+      await this.permissionGrantRegistry.remember({ capability: permission.capability, scope })
+      return
+    }
+
+    if (option.scope === 'session' && permission.categoryKey) {
+      this.conversationGrants.remember(permission.request.sessionId, permission.categoryKey)
+      return
+    }
+    throw new Error('The restored permission scope cannot be granted safely.')
+  }
+
+  clearRestoredDecision(sessionId: string): void {
+    this.restoredAllowOnceBySession.delete(sessionId)
+  }
+
+  // Process/connection teardown must release the dead provider RPC without erasing the durable
+  // human decision. No settlement callback fires because the restored card remains pending.
+  abandonAllPending(): void {
+    this.cancellationGeneration += 1
+    this.livePermissionProfiles.clear()
+    this.restoredAllowOnceBySession.clear()
+    const pending = Array.from(this.pendingRequests.values())
+    this.pendingRequests.clear()
+    for (const request of pending) {
+      if (request.settled) continue
+      if (
+        request.durablePersisted ||
+        (request.durableReady && !request.durablePersistenceSettled)
+      ) {
+        request.settled = true
+        request.resolve({ outcome: { outcome: 'cancelled' } })
+      } else {
+        this.settlePending(request, { outcome: { outcome: 'cancelled' } }, 'cancelled')
+      }
+    }
+  }
+
   // Cancels every pending request while preserving conversation grants across Agent reconnects.
   cancelAllPending(): void {
     this.cancellationGeneration += 1
     this.livePermissionProfiles.clear()
+    this.restoredAllowOnceBySession.clear()
     const pendingRequests = Array.from(this.pendingRequests.keys())
 
     for (const requestId of pendingRequests) {
-      this.respond({ requestId, cancelled: true })
+      void this.respond({ requestId, cancelled: true }).catch(() => undefined)
     }
   }
 
@@ -1183,11 +1397,12 @@ class AcpPermissionBroker {
       sessionId,
       (this.sessionCancellationGenerations.get(sessionId) ?? 0) + 1
     )
+    this.restoredAllowOnceBySession.delete(sessionId)
     const pendingRequests = Array.from(this.pendingRequests.values())
 
     for (const { request } of pendingRequests) {
       if (request.sessionId === sessionId) {
-        this.respond({ requestId: request.requestId, cancelled: true })
+        void this.respond({ requestId: request.requestId, cancelled: true }).catch(() => undefined)
       }
     }
   }
@@ -1204,6 +1419,8 @@ export {
   AcpPermissionBroker,
   ConversationPermissionGrantStore,
   projectRegistrySessionGrants,
+  permissionRequestFingerprint,
   resolveCategoryKey,
   resolveNotebookPermissionContext
 }
+export type { DurablePermissionWaitCandidate, PermissionWaitHooks }

--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -15,12 +15,14 @@ import type { SessionPermissionProfileState } from '../../shared/permission-prof
 import type { AgentFrameworkId } from '../../shared/settings'
 import { getAgentFramework, type AgentFramework } from '../agent-framework'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
+import type { SessionPermissionRuntimeContext } from '../../shared/session-persistence'
 import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
 import { createLogger } from '../logger'
 import {
   AcpPermissionBroker,
   ConversationPermissionGrantStore,
-  resolveNotebookPermissionContext
+  resolveNotebookPermissionContext,
+  type PermissionWaitHooks
 } from './permission-broker'
 import type { PermissionPolicyContext } from './permission-policy'
 import {
@@ -94,6 +96,7 @@ type AcpPermissionContextOptions = {
     capturePrompt: (sessionId: string) =>
       | {
           sequence: number
+          promptMessageId?: string
           isCancellationAccepted: () => boolean
         }
       | undefined
@@ -121,6 +124,7 @@ type AcpPermissionContextOptions = {
     waitMs: number
   }) => void
   onPermissionSettled?: (requestId: string, state: AcpPermissionSettlementState) => void
+  permissionWaitHooks?: PermissionWaitHooks
 }
 
 type PermissionContextSessionSnapshot = {
@@ -291,7 +295,8 @@ class AcpPermissionContext {
       },
       options.conversationGrants,
       options.permissionGrantRegistry,
-      options.onPermissionSettled
+      options.onPermissionSettled,
+      options.permissionWaitHooks
     )
     this.setTimer = options.setTimer ?? setTimeout
     this.clearTimer = options.clearTimer ?? clearTimeout
@@ -372,7 +377,8 @@ class AcpPermissionContext {
           autoReviewStrategy: profileState?.autoReviewStrategy,
           cwd: aggregateSnapshot?.cwd,
           mcpServerNames,
-          projectId: routing.resolveProjectId(appSessionId)
+          projectId: routing.resolveProjectId(appSessionId),
+          promptMessageId: promptInteraction?.promptMessageId
         }
       )
     } catch (error) {
@@ -406,6 +412,22 @@ class AcpPermissionContext {
 
   getPendingRequests(): AcpPermissionRequest[] {
     return this.broker.getPendingRequests()
+  }
+
+  hasDurablePendingForSession(sessionId: string): boolean {
+    return this.broker.hasDurablePendingForSession(sessionId)
+  }
+
+  prepareRestoredDecision(
+    permission: SessionPermissionRuntimeContext,
+    option: AcpPermissionRequest['options'][number] | undefined,
+    projectId: string
+  ): Promise<void> {
+    return this.broker.prepareRestoredDecision(permission, option, projectId)
+  }
+
+  clearRestoredDecision(sessionId: string): void {
+    this.broker.clearRestoredDecision(sessionId)
   }
 
   async applyPermissionProfile(
@@ -724,7 +746,8 @@ class AcpPermissionContext {
   }
 
   dispose(): void {
-    this.cancelAllPending()
+    this.broker.abandonAllPending()
+    this.humanOnlyRequestIds.clear()
     const sessionIds = new Set([
       ...this.codexMcpToolIdentities.keys(),
       ...this.claudeCodeMcpToolInputs.keys(),

--- a/src/main/acp/permission-policy.ts
+++ b/src/main/acp/permission-policy.ts
@@ -27,6 +27,8 @@ type PermissionPolicyContext = {
   cwd?: string
   // Canonical MCP server names, so framework-visible tools can resolve to stable policy identities.
   mcpServerNames?: readonly string[]
+  // Main-owned identity of the user Message whose provider turn is parked on this request.
+  promptMessageId?: string
 }
 
 const TRUSTED_MCP_TOOL_IDENTITY = Symbol('trusted-mcp-tool-identity')

--- a/src/main/acp/permission-wait-owner.test.ts
+++ b/src/main/acp/permission-wait-owner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { SessionRuntimeContext } from '../../shared/session-persistence'
+import type { PersistedChatSession, SessionRuntimeContext } from '../../shared/session-persistence'
 import type { DurablePermissionWaitCandidate } from './permission-broker'
 import { AcpPermissionWaitOwner, type PermissionWaitSessions } from './permission-wait-owner'
 
@@ -40,11 +40,32 @@ const createSessions = (
     }
     return structuredClone(context)
   })
+  const session: PersistedChatSession = {
+    id: 'session-1',
+    projectId: 'project-1',
+    title: 'Permission wait',
+    cwd: '/workspace',
+    status: 'waiting-permission',
+    messages: [
+      {
+        id: 'prompt-1',
+        role: 'user',
+        content: 'Run npm test',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ],
+    createdAt: 1,
+    updatedAt: 1
+  }
   return {
     sessions: {
       readSessionRuntimeContext: vi.fn(async () => structuredClone(context)),
       patchSessionRuntimeContext: patches,
-      containsMessageOnActiveBranch: vi.fn(async () => containsMessage)
+      containsMessageOnActiveBranch: vi.fn(async () => containsMessage),
+      loadSessionForPermissionReplay: vi.fn(async () => structuredClone(session))
     },
     context: () => context,
     patches

--- a/src/main/acp/permission-wait-owner.test.ts
+++ b/src/main/acp/permission-wait-owner.test.ts
@@ -145,6 +145,26 @@ describe('ACP durable permission wait owner', () => {
     expect(fixture.patches).not.toHaveBeenCalled()
   })
 
+  it('cancels matching pending and continuing authority idempotently', async () => {
+    const fixture = createSessions()
+    const owner = new AcpPermissionWaitOwner(fixture.sessions)
+    const candidate = createCandidate()
+
+    await owner.persist(candidate)
+    await owner.cancelContinuation('project-1', 'session-1', 'permission-1')
+    expect(fixture.context().permission).toBeUndefined()
+
+    await owner.persist(candidate)
+    await owner.beginContinuation('project-1', 'session-1', 'permission-1')
+    await owner.cancelContinuation('project-1', 'session-1', 'permission-1')
+    await owner.cancelContinuation('project-1', 'session-1', 'permission-1')
+
+    expect(fixture.context().permission).toBeUndefined()
+    expect(fixture.patches).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionStatus: 'idle', patch: { permission: undefined } })
+    )
+  })
+
   it('rejects a restored locator that does not match the durable Session', async () => {
     const fixture = createSessions()
     const owner = new AcpPermissionWaitOwner(fixture.sessions)

--- a/src/main/acp/permission-wait-owner.test.ts
+++ b/src/main/acp/permission-wait-owner.test.ts
@@ -32,20 +32,12 @@ const createSessions = (
   patches: ReturnType<typeof vi.fn>
 } => {
   let context: SessionRuntimeContext = { version: 1, revision: 0 }
-  const patches = vi.fn(async (command) => {
-    context = {
-      ...context,
-      ...command.patch,
-      revision: context.revision + 1
-    }
-    return structuredClone(context)
-  })
   const session: PersistedChatSession = {
     id: 'session-1',
     projectId: 'project-1',
     title: 'Permission wait',
     cwd: '/workspace',
-    status: 'waiting-permission',
+    status: 'idle',
     messages: [
       {
         id: 'prompt-1',
@@ -60,6 +52,17 @@ const createSessions = (
     createdAt: 1,
     updatedAt: 1
   }
+  const patches = vi.fn(async (command) => {
+    context = {
+      ...context,
+      ...command.patch,
+      revision: context.revision + 1
+    }
+    session.runtimeContext = structuredClone(context)
+    session.status = command.sessionStatus
+    session.updatedAt += 1
+    return structuredClone(context)
+  })
   return {
     sessions: {
       readSessionRuntimeContext: vi.fn(async () => structuredClone(context)),
@@ -73,6 +76,39 @@ const createSessions = (
 }
 
 describe('ACP durable permission wait owner', () => {
+  it('publishes the authoritative Session after permission authority is durable', async () => {
+    const fixture = createSessions()
+    const publishSessionUpdated = vi.fn()
+    const owner = new AcpPermissionWaitOwner(fixture.sessions, publishSessionUpdated)
+
+    await expect(owner.persist(createCandidate())).resolves.toBe(true)
+
+    expect(publishSessionUpdated).toHaveBeenCalledOnce()
+    expect(publishSessionUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'session-1',
+        status: 'waiting-permission',
+        runtimeContext: expect.objectContaining({
+          permission: expect.objectContaining({
+            state: 'pending',
+            request: expect.objectContaining({ requestId: 'permission-1' })
+          })
+        })
+      })
+    )
+
+    await owner.clearLive(createCandidate())
+
+    expect(publishSessionUpdated).toHaveBeenCalledTimes(2)
+    expect(publishSessionUpdated).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: 'session-1',
+        status: 'running',
+        runtimeContext: expect.not.objectContaining({ permission: expect.anything() })
+      })
+    )
+  })
+
   it('persists, revalidates, and clears one prompt-bound permission authority', async () => {
     const fixture = createSessions()
     const owner = new AcpPermissionWaitOwner(fixture.sessions)

--- a/src/main/acp/permission-wait-owner.test.ts
+++ b/src/main/acp/permission-wait-owner.test.ts
@@ -66,6 +66,7 @@ describe('ACP durable permission wait owner', () => {
         sessionStatus: 'waiting-permission',
         patch: {
           permission: expect.objectContaining({
+            state: 'pending',
             request: expect.objectContaining({ requestId: 'permission-1' }),
             originatingPromptMessageId: 'prompt-1',
             fingerprint: 'a'.repeat(64)
@@ -90,6 +91,24 @@ describe('ACP durable permission wait owner', () => {
       permission: { originatingPromptMessageId: 'prompt-1' }
     })
 
+    await owner.beginContinuation('project-1', 'session-1', 'permission-1')
+    expect(fixture.context().permission).toMatchObject({ state: 'continuing' })
+    await expect(
+      owner.resolveRestored(
+        {
+          requestId: 'permission-1',
+          optionId: 'allow-once',
+          restored: { sessionId: 'session-1', projectId: 'project-1' }
+        },
+        'project-1',
+        'session-1'
+      )
+    ).rejects.toThrow('stale or no longer pending')
+
+    await owner.rearmContinuation('project-1', 'session-1', 'permission-1')
+    expect(fixture.context().permission).toMatchObject({ state: 'pending' })
+
+    await owner.beginContinuation('project-1', 'session-1', 'permission-1')
     await owner.clearAfterContinuation('project-1', 'session-1', 'permission-1')
     expect(fixture.context().permission).toBeUndefined()
     expect(fixture.patches).toHaveBeenLastCalledWith(

--- a/src/main/acp/permission-wait-owner.test.ts
+++ b/src/main/acp/permission-wait-owner.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SessionRuntimeContext } from '../../shared/session-persistence'
+import type { DurablePermissionWaitCandidate } from './permission-broker'
+import { AcpPermissionWaitOwner, type PermissionWaitSessions } from './permission-wait-owner'
+
+const createCandidate = (): DurablePermissionWaitCandidate => ({
+  request: {
+    requestId: 'permission-1',
+    sessionId: 'session-1',
+    toolCallId: 'tool-1',
+    title: 'Run npm test',
+    providerToolName: 'Bash',
+    rawInput: { command: 'npm test' },
+    options: [
+      { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once', scope: 'once' },
+      { optionId: 'deny', name: 'Deny', kind: 'reject_once' }
+    ]
+  },
+  projectId: 'project-1',
+  promptMessageId: 'prompt-1',
+  fingerprint: 'a'.repeat(64),
+  categoryKey: 'shell:npm-test',
+  capability: { kind: 'execution', key: 'shell:npm-test' }
+})
+
+const createSessions = (
+  containsMessage = true
+): {
+  sessions: PermissionWaitSessions
+  context: () => SessionRuntimeContext
+  patches: ReturnType<typeof vi.fn>
+} => {
+  let context: SessionRuntimeContext = { version: 1, revision: 0 }
+  const patches = vi.fn(async (command) => {
+    context = {
+      ...context,
+      ...command.patch,
+      revision: context.revision + 1
+    }
+    return structuredClone(context)
+  })
+  return {
+    sessions: {
+      readSessionRuntimeContext: vi.fn(async () => structuredClone(context)),
+      patchSessionRuntimeContext: patches,
+      containsMessageOnActiveBranch: vi.fn(async () => containsMessage)
+    },
+    context: () => context,
+    patches
+  }
+}
+
+describe('ACP durable permission wait owner', () => {
+  it('persists, revalidates, and clears one prompt-bound permission authority', async () => {
+    const fixture = createSessions()
+    const owner = new AcpPermissionWaitOwner(fixture.sessions)
+    const candidate = createCandidate()
+
+    await expect(owner.persist(candidate)).resolves.toBe(true)
+    expect(fixture.patches).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        expectedRevision: 0,
+        sessionStatus: 'waiting-permission',
+        patch: {
+          permission: expect.objectContaining({
+            request: expect.objectContaining({ requestId: 'permission-1' }),
+            originatingPromptMessageId: 'prompt-1',
+            fingerprint: 'a'.repeat(64)
+          })
+        }
+      })
+    )
+
+    await expect(
+      owner.resolveRestored(
+        {
+          requestId: 'permission-1',
+          optionId: 'allow-once',
+          restored: { sessionId: 'session-1', projectId: 'project-1' }
+        },
+        'project-1',
+        'session-1'
+      )
+    ).resolves.toMatchObject({
+      denied: false,
+      option: { optionId: 'allow-once' },
+      permission: { originatingPromptMessageId: 'prompt-1' }
+    })
+
+    await owner.clearAfterContinuation('project-1', 'session-1', 'permission-1')
+    expect(fixture.context().permission).toBeUndefined()
+    expect(fixture.patches).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionStatus: 'idle', patch: { permission: undefined } })
+    )
+  })
+
+  it('does not persist authority for a prompt outside the active Message Branch', async () => {
+    const fixture = createSessions(false)
+    const owner = new AcpPermissionWaitOwner(fixture.sessions)
+
+    await expect(owner.persist(createCandidate())).resolves.toBe(false)
+    expect(fixture.patches).not.toHaveBeenCalled()
+  })
+
+  it('rejects a restored locator that does not match the durable Session', async () => {
+    const fixture = createSessions()
+    const owner = new AcpPermissionWaitOwner(fixture.sessions)
+    await owner.persist(createCandidate())
+
+    await expect(
+      owner.resolveRestored(
+        {
+          requestId: 'permission-1',
+          optionId: 'allow-once',
+          restored: { sessionId: 'session-1', projectId: 'other-project' }
+        },
+        'project-1',
+        'session-1'
+      )
+    ).rejects.toThrow('does not match the active Session')
+  })
+})

--- a/src/main/acp/permission-wait-owner.test.ts
+++ b/src/main/acp/permission-wait-owner.test.ts
@@ -181,6 +181,30 @@ describe('ACP durable permission wait owner', () => {
     expect(fixture.patches).not.toHaveBeenCalled()
   })
 
+  it('does not let a new durable wait replace an active continuation', async () => {
+    const fixture = createSessions()
+    const owner = new AcpPermissionWaitOwner(fixture.sessions)
+    const candidate = createCandidate()
+
+    await owner.persist(candidate)
+    await owner.beginContinuation('project-1', 'session-1', 'permission-1')
+
+    await expect(
+      owner.persist({
+        ...candidate,
+        request: {
+          ...candidate.request,
+          requestId: 'permission-2',
+          toolCallId: 'tool-2'
+        }
+      })
+    ).rejects.toThrow('Another durable permission request already owns this Session.')
+    expect(fixture.context().permission).toMatchObject({
+      state: 'continuing',
+      request: { requestId: 'permission-1' }
+    })
+  })
+
   it('cancels matching pending and continuing authority idempotently', async () => {
     const fixture = createSessions()
     const owner = new AcpPermissionWaitOwner(fixture.sessions)

--- a/src/main/acp/permission-wait-owner.ts
+++ b/src/main/acp/permission-wait-owner.ts
@@ -40,6 +40,7 @@ class AcpPermissionWaitOwner {
     }
 
     const permission = sanitizeSessionPermissionRuntimeContext({
+      state: 'pending',
       request: candidate.request,
       originatingPromptMessageId: candidate.promptMessageId,
       fingerprint: candidate.fingerprint,
@@ -55,6 +56,7 @@ class AcpPermissionWaitOwner {
       (context) => {
         if (
           context.permission &&
+          context.permission.state === 'pending' &&
           context.permission.request.requestId !== permission.request.requestId
         ) {
           throw new Error('Another durable permission request already owns this Session.')
@@ -82,7 +84,41 @@ class AcpPermissionWaitOwner {
     requestId: string
   ): Promise<void> {
     if (!this.sessions) return
-    await this.clear(projectId, sessionId, requestId, 'idle')
+    await this.patch(
+      projectId,
+      sessionId,
+      (context) => {
+        const permission = context.permission
+        if (!permission || permission.request.requestId !== requestId) return permission
+        if (permission.state !== 'continuing') {
+          throw new Error('The restored permission continuation is no longer active.')
+        }
+        return undefined
+      },
+      'idle'
+    )
+  }
+
+  async beginContinuation(projectId: string, sessionId: string, requestId: string): Promise<void> {
+    await this.transitionContinuation(
+      projectId,
+      sessionId,
+      requestId,
+      'pending',
+      'continuing',
+      'running'
+    )
+  }
+
+  async rearmContinuation(projectId: string, sessionId: string, requestId: string): Promise<void> {
+    await this.transitionContinuation(
+      projectId,
+      sessionId,
+      requestId,
+      'continuing',
+      'pending',
+      'waiting-permission'
+    )
   }
 
   async resolveRestored(
@@ -101,6 +137,7 @@ class AcpPermissionWaitOwner {
     const permission = context.permission
     if (
       !permission ||
+      permission.state !== 'pending' ||
       permission.request.requestId !== response.requestId ||
       permission.request.sessionId !== sessionId
     ) {
@@ -146,6 +183,33 @@ class AcpPermissionWaitOwner {
       sessionId,
       (context) =>
         context.permission?.request.requestId === requestId ? undefined : context.permission,
+      sessionStatus
+    )
+  }
+
+  private async transitionContinuation(
+    projectId: string,
+    sessionId: string,
+    requestId: string,
+    expectedState: SessionPermissionRuntimeContext['state'],
+    state: SessionPermissionRuntimeContext['state'],
+    sessionStatus: 'waiting-permission' | 'running'
+  ): Promise<void> {
+    if (!this.sessions) return
+    await this.patch(
+      projectId,
+      sessionId,
+      (context) => {
+        const permission = context.permission
+        if (
+          !permission ||
+          permission.request.requestId !== requestId ||
+          permission.state !== expectedState
+        ) {
+          throw new Error('The restored permission request is stale or no longer pending.')
+        }
+        return { ...permission, state }
+      },
       sessionStatus
     )
   }

--- a/src/main/acp/permission-wait-owner.ts
+++ b/src/main/acp/permission-wait-owner.ts
@@ -1,4 +1,9 @@
 import type { AcpPermissionResponse } from '../../shared/acp'
+import type { HistoryReplayDescriptor } from '../../shared/history-preamble'
+import {
+  buildSessionHistoryReplay,
+  type SessionHistoryReplay
+} from '../../shared/session-history-replay'
 import {
   sanitizeSessionPermissionRuntimeContext,
   type SessionPermissionRuntimeContext,
@@ -9,7 +14,10 @@ import type { DurablePermissionWaitCandidate } from './permission-broker'
 
 type PermissionWaitSessions = Pick<
   SessionPersistenceCoordinator,
-  'readSessionRuntimeContext' | 'patchSessionRuntimeContext' | 'containsMessageOnActiveBranch'
+  | 'readSessionRuntimeContext'
+  | 'patchSessionRuntimeContext'
+  | 'containsMessageOnActiveBranch'
+  | 'loadSessionForPermissionReplay'
 >
 
 type RestoredPermissionDecision = Readonly<{
@@ -118,6 +126,34 @@ class AcpPermissionWaitOwner {
       'continuing',
       'pending',
       'waiting-permission'
+    )
+  }
+
+  async buildRestoredContinuationReplay(
+    projectId: string,
+    sessionId: string,
+    permission: SessionPermissionRuntimeContext,
+    descriptor: HistoryReplayDescriptor,
+    supportsImageInput: boolean
+  ): Promise<SessionHistoryReplay | undefined> {
+    if (!this.sessions) {
+      throw new Error('Permission replay Session authority is not available.')
+    }
+    const session = await this.sessions.loadSessionForPermissionReplay(projectId, sessionId)
+    if (
+      session.id !== sessionId ||
+      session.projectId !== projectId ||
+      !session.messages.some(
+        (message) => message.id === permission.originatingPromptMessageId && message.role === 'user'
+      )
+    ) {
+      throw new Error('Permission replay no longer matches the active Message Branch.')
+    }
+    return buildSessionHistoryReplay(
+      session.messages,
+      descriptor,
+      session.projectId,
+      supportsImageInput
     )
   }
 

--- a/src/main/acp/permission-wait-owner.ts
+++ b/src/main/acp/permission-wait-owner.ts
@@ -19,7 +19,8 @@ type PermissionWaitSessions = Pick<
   | 'patchSessionRuntimeContext'
   | 'containsMessageOnActiveBranch'
   | 'loadSessionForPermissionReplay'
->
+> &
+  Partial<Pick<SessionPersistenceCoordinator, 'sessionProjectId'>>
 
 type RestoredPermissionDecision = Readonly<{
   permission: SessionPermissionRuntimeContext
@@ -123,6 +124,28 @@ class AcpPermissionWaitOwner {
         if (!permission) return undefined
         if (permission.request.requestId !== requestId) {
           throw new Error('A different permission request now owns this Session.')
+        }
+        return undefined
+      },
+      'idle'
+    )
+  }
+
+  async cancelPendingSession(sessionId: string): Promise<boolean> {
+    if (!this.sessions?.sessionProjectId) return false
+    const projectId = await this.sessions.sessionProjectId(sessionId)
+    if (!projectId) return false
+    return this.patch(
+      projectId,
+      sessionId,
+      (context) => {
+        const permission = context.permission
+        if (
+          !permission ||
+          permission.state !== 'pending' ||
+          permission.request.sessionId !== sessionId
+        ) {
+          return permission
         }
         return undefined
       },
@@ -278,12 +301,12 @@ class AcpPermissionWaitOwner {
     sessionId: string,
     update: (context: SessionRuntimeContext) => SessionPermissionRuntimeContext | undefined,
     sessionStatus: 'waiting-permission' | 'running' | 'idle'
-  ): Promise<void> {
-    if (!this.sessions) return
+  ): Promise<boolean> {
+    if (!this.sessions) return false
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const context = await this.sessions.readSessionRuntimeContext(projectId, sessionId)
       const permission = update(context)
-      if (permission === context.permission) return
+      if (permission === context.permission) return false
       try {
         await this.sessions.patchSessionRuntimeContext({
           projectId,
@@ -296,11 +319,12 @@ class AcpPermissionWaitOwner {
           const session = await this.sessions.loadSessionForPermissionReplay(projectId, sessionId)
           await this.publishSessionUpdated(session)
         }
-        return
+        return true
       } catch (error) {
         if (!isRevisionConflict(error) || attempt === 2) throw error
       }
     }
+    return false
   }
 }
 

--- a/src/main/acp/permission-wait-owner.ts
+++ b/src/main/acp/permission-wait-owner.ts
@@ -69,11 +69,14 @@ class AcpPermissionWaitOwner {
       candidate.projectId,
       candidate.request.sessionId,
       (context) => {
-        if (
-          context.permission &&
-          context.permission.state === 'pending' &&
-          context.permission.request.requestId !== permission.request.requestId
-        ) {
+        const currentPermission = context.permission
+        if (currentPermission) {
+          if (
+            currentPermission.state === 'pending' &&
+            currentPermission.request.requestId === permission.request.requestId
+          ) {
+            return currentPermission
+          }
           throw new Error('Another durable permission request already owns this Session.')
         }
         return permission
@@ -97,9 +100,9 @@ class AcpPermissionWaitOwner {
     projectId: string,
     sessionId: string,
     requestId: string
-  ): Promise<void> {
-    if (!this.sessions) return
-    await this.patch(
+  ): Promise<boolean> {
+    if (!this.sessions) return false
+    return this.patch(
       projectId,
       sessionId,
       (context) => {

--- a/src/main/acp/permission-wait-owner.ts
+++ b/src/main/acp/permission-wait-owner.ts
@@ -6,6 +6,7 @@ import {
 } from '../../shared/session-history-replay'
 import {
   sanitizeSessionPermissionRuntimeContext,
+  type PersistedChatSession,
   type SessionPermissionRuntimeContext,
   type SessionRuntimeContext
 } from '../../shared/session-persistence'
@@ -26,6 +27,8 @@ type RestoredPermissionDecision = Readonly<{
   denied: boolean
 }>
 
+type PublishPermissionWaitSession = (session: PersistedChatSession) => Promise<void> | void
+
 const isRevisionConflict = (error: unknown): boolean =>
   typeof error === 'object' &&
   error !== null &&
@@ -33,7 +36,10 @@ const isRevisionConflict = (error: unknown): boolean =>
   error.code === 'revision-conflict'
 
 class AcpPermissionWaitOwner {
-  constructor(private readonly sessions?: PermissionWaitSessions) {}
+  constructor(
+    private readonly sessions?: PermissionWaitSessions,
+    private readonly publishSessionUpdated?: PublishPermissionWaitSession
+  ) {}
 
   async persist(candidate: DurablePermissionWaitCandidate): Promise<boolean> {
     if (!this.sessions || !candidate.projectId || !candidate.promptMessageId) return false
@@ -286,6 +292,10 @@ class AcpPermissionWaitOwner {
           patch: { permission },
           sessionStatus
         })
+        if (this.publishSessionUpdated) {
+          const session = await this.sessions.loadSessionForPermissionReplay(projectId, sessionId)
+          await this.publishSessionUpdated(session)
+        }
         return
       } catch (error) {
         if (!isRevisionConflict(error) || attempt === 2) throw error
@@ -295,4 +305,4 @@ class AcpPermissionWaitOwner {
 }
 
 export { AcpPermissionWaitOwner }
-export type { PermissionWaitSessions, RestoredPermissionDecision }
+export type { PermissionWaitSessions, PublishPermissionWaitSession, RestoredPermissionDecision }

--- a/src/main/acp/permission-wait-owner.ts
+++ b/src/main/acp/permission-wait-owner.ts
@@ -1,0 +1,181 @@
+import type { AcpPermissionResponse } from '../../shared/acp'
+import {
+  sanitizeSessionPermissionRuntimeContext,
+  type SessionPermissionRuntimeContext,
+  type SessionRuntimeContext
+} from '../../shared/session-persistence'
+import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import type { DurablePermissionWaitCandidate } from './permission-broker'
+
+type PermissionWaitSessions = Pick<
+  SessionPersistenceCoordinator,
+  'readSessionRuntimeContext' | 'patchSessionRuntimeContext' | 'containsMessageOnActiveBranch'
+>
+
+type RestoredPermissionDecision = Readonly<{
+  permission: SessionPermissionRuntimeContext
+  option?: SessionPermissionRuntimeContext['request']['options'][number]
+  denied: boolean
+}>
+
+const isRevisionConflict = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  error.code === 'revision-conflict'
+
+class AcpPermissionWaitOwner {
+  constructor(private readonly sessions?: PermissionWaitSessions) {}
+
+  async persist(candidate: DurablePermissionWaitCandidate): Promise<boolean> {
+    if (!this.sessions || !candidate.projectId || !candidate.promptMessageId) return false
+    if (
+      !(await this.sessions.containsMessageOnActiveBranch(
+        candidate.projectId,
+        candidate.request.sessionId,
+        candidate.promptMessageId
+      ))
+    ) {
+      return false
+    }
+
+    const permission = sanitizeSessionPermissionRuntimeContext({
+      request: candidate.request,
+      originatingPromptMessageId: candidate.promptMessageId,
+      fingerprint: candidate.fingerprint,
+      categoryKey: candidate.categoryKey,
+      capability: candidate.capability,
+      createdAt: Date.now()
+    })
+    if (!permission) throw new Error('Permission request could not be persisted safely.')
+
+    await this.patch(
+      candidate.projectId,
+      candidate.request.sessionId,
+      (context) => {
+        if (
+          context.permission &&
+          context.permission.request.requestId !== permission.request.requestId
+        ) {
+          throw new Error('Another durable permission request already owns this Session.')
+        }
+        return permission
+      },
+      'waiting-permission'
+    )
+    return true
+  }
+
+  async clearLive(candidate: DurablePermissionWaitCandidate): Promise<void> {
+    if (!this.sessions || !candidate.projectId || !candidate.promptMessageId) return
+    await this.clear(
+      candidate.projectId,
+      candidate.request.sessionId,
+      candidate.request.requestId,
+      'running'
+    )
+  }
+
+  async clearAfterContinuation(
+    projectId: string,
+    sessionId: string,
+    requestId: string
+  ): Promise<void> {
+    if (!this.sessions) return
+    await this.clear(projectId, sessionId, requestId, 'idle')
+  }
+
+  async resolveRestored(
+    response: AcpPermissionResponse,
+    projectId: string,
+    sessionId: string
+  ): Promise<RestoredPermissionDecision> {
+    if (!this.sessions || !response.restored) {
+      throw new Error('The restored permission request is no longer available.')
+    }
+    if (response.restored.sessionId !== sessionId || response.restored.projectId !== projectId) {
+      throw new Error('Restored permission Session context does not match the active Session.')
+    }
+
+    const context = await this.sessions.readSessionRuntimeContext(projectId, sessionId)
+    const permission = context.permission
+    if (
+      !permission ||
+      permission.request.requestId !== response.requestId ||
+      permission.request.sessionId !== sessionId
+    ) {
+      throw new Error('The restored permission request is stale or no longer pending.')
+    }
+    if (
+      !(await this.sessions.containsMessageOnActiveBranch(
+        projectId,
+        sessionId,
+        permission.originatingPromptMessageId
+      ))
+    ) {
+      throw new Error('The restored permission request is not on the active Message Branch.')
+    }
+
+    if (response.cancelled || !response.optionId) {
+      return { permission, denied: true }
+    }
+    const option = permission.request.options.find(
+      (candidate) => candidate.optionId === response.optionId
+    )
+    if (!option) throw new Error('The restored permission option is no longer available.')
+    const kind = option.kind.toLowerCase()
+    if (
+      kind !== 'allow_once' &&
+      kind !== 'allow_always' &&
+      kind !== 'reject_once' &&
+      kind !== 'reject_always'
+    ) {
+      throw new Error('The restored permission option cannot be replayed safely.')
+    }
+    return { permission, option, denied: kind.startsWith('reject_') }
+  }
+
+  private async clear(
+    projectId: string,
+    sessionId: string,
+    requestId: string,
+    sessionStatus: 'running' | 'idle'
+  ): Promise<void> {
+    await this.patch(
+      projectId,
+      sessionId,
+      (context) =>
+        context.permission?.request.requestId === requestId ? undefined : context.permission,
+      sessionStatus
+    )
+  }
+
+  private async patch(
+    projectId: string,
+    sessionId: string,
+    update: (context: SessionRuntimeContext) => SessionPermissionRuntimeContext | undefined,
+    sessionStatus: 'waiting-permission' | 'running' | 'idle'
+  ): Promise<void> {
+    if (!this.sessions) return
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const context = await this.sessions.readSessionRuntimeContext(projectId, sessionId)
+      const permission = update(context)
+      if (permission === context.permission) return
+      try {
+        await this.sessions.patchSessionRuntimeContext({
+          projectId,
+          sessionId,
+          expectedRevision: context.revision,
+          patch: { permission },
+          sessionStatus
+        })
+        return
+      } catch (error) {
+        if (!isRevisionConflict(error) || attempt === 2) throw error
+      }
+    }
+  }
+}
+
+export { AcpPermissionWaitOwner }
+export type { PermissionWaitSessions, RestoredPermissionDecision }

--- a/src/main/acp/permission-wait-owner.ts
+++ b/src/main/acp/permission-wait-owner.ts
@@ -107,6 +107,23 @@ class AcpPermissionWaitOwner {
     )
   }
 
+  async cancelContinuation(projectId: string, sessionId: string, requestId: string): Promise<void> {
+    if (!this.sessions) return
+    await this.patch(
+      projectId,
+      sessionId,
+      (context) => {
+        const permission = context.permission
+        if (!permission) return undefined
+        if (permission.request.requestId !== requestId) {
+          throw new Error('A different permission request now owns this Session.')
+        }
+        return undefined
+      },
+      'idle'
+    )
+  }
+
   async beginContinuation(projectId: string, sessionId: string, requestId: string): Promise<void> {
     await this.transitionContinuation(
       projectId,

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -4,6 +4,7 @@ import { app } from 'electron'
 
 import type { AcpPermissionRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
+import { MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID } from '../../shared/lifecycle-events'
 import {
   filterSpecialistConnectorSkills,
   resolveEffectiveSpecialistSkills
@@ -208,7 +209,22 @@ const createAcpRuntime = ({
           authorizeReferencedUploads: authorizeSkillImportReferencedUploads
         },
         ...(sessionPersistenceCoordinator
-          ? { permissionWait: { sessions: sessionPersistenceCoordinator } }
+          ? {
+              permissionWait: {
+                sessions: sessionPersistenceCoordinator,
+                onSessionUpdated: (session) => {
+                  try {
+                    broadcastToRenderers('session:updated', {
+                      session,
+                      originClientId: MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID
+                    })
+                  } catch (error) {
+                    // The durable commit remains authoritative when a renderer projection is gone.
+                    log.warn('permission wait Session publication failed', errorLogFields(error))
+                  }
+                }
+              }
+            }
           : {}),
         ...(sessionPersistenceCoordinator
           ? {

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -88,6 +88,7 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
     | 'appendUserMessageToInteraction'
     | 'containsMessageOnActiveBranch'
     | 'loadSessionForPermissionReplay'
+    | 'sessionProjectId'
   >
 }
 

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -86,6 +86,7 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
     | 'patchSessionRuntimeContext'
     | 'appendUserMessageToInteraction'
     | 'containsMessageOnActiveBranch'
+    | 'loadSessionForPermissionReplay'
   >
 }
 

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -207,6 +207,9 @@ const createAcpRuntime = ({
           authorizeReferencedUploads: authorizeSkillImportReferencedUploads
         },
         ...(sessionPersistenceCoordinator
+          ? { permissionWait: { sessions: sessionPersistenceCoordinator } }
+          : {}),
+        ...(sessionPersistenceCoordinator
           ? {
               plan: {
                 mcpEntryPath,

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -49,6 +49,7 @@ const createFakeRuntime = (options: {
   beforeResume?: () => Promise<void>
   afterResumeAttached?: () => Promise<void>
   eligibleAttachmentUri?: string
+  quitBlockingSessions?: { projectName: string; sessionId: string }[]
   prompt?: (sessionId: string) => Promise<unknown>
 }): {
   runtime: AcpRuntime
@@ -184,6 +185,7 @@ const createFakeRuntime = (options: {
   const runtime = {
     getSnapshot: () => snapshot,
     getActivePromptSessions: () => [],
+    getQuitBlockingPromptSessions: () => options.quitBlockingSessions ?? [],
     hasLiveSession: (projectId: string, sessionId: string) =>
       snapshot.sessionIds.includes(sessionId) && sessionProjects.get(sessionId) === projectId,
     liveSessionProjectId: (sessionId: string) => sessionProjects.get(sessionId),
@@ -270,6 +272,23 @@ const createFakeRuntime = (options: {
 }
 
 describe('AcpRuntimeCoordinator', () => {
+  it('combines only the quit-blocking prompts reported by each runtime generation', async () => {
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks,
+          quitBlockingSessions: [{ projectName: 'project-1', sessionId: 'session-running' }]
+        }).runtime
+    )
+    await coordinator.connect()
+
+    expect(coordinator.getQuitBlockingPromptSessions()).toEqual([
+      { projectName: 'project-1', sessionId: 'session-running' }
+    ])
+  })
+
   it.each([
     ['Claude Code', 'claude-code'],
     ['OpenCode', 'opencode'],

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -49,6 +49,7 @@ const createFakeRuntime = (options: {
   beforeResume?: () => Promise<void>
   afterResumeAttached?: () => Promise<void>
   eligibleAttachmentUri?: string
+  activePromptSessions?: { projectName: string; sessionId: string }[]
   quitBlockingSessions?: { projectName: string; sessionId: string }[]
   prompt?: (sessionId: string) => Promise<unknown>
 }): {
@@ -184,7 +185,7 @@ const createFakeRuntime = (options: {
   const sendAppContinuation = vi.fn(runPrompt)
   const runtime = {
     getSnapshot: () => snapshot,
-    getActivePromptSessions: () => [],
+    getActivePromptSessions: () => options.activePromptSessions ?? [],
     getQuitBlockingPromptSessions: () => options.quitBlockingSessions ?? [],
     hasLiveSession: (projectId: string, sessionId: string) =>
       snapshot.sessionIds.includes(sessionId) && sessionProjects.get(sessionId) === projectId,
@@ -781,6 +782,34 @@ describe('AcpRuntimeCoordinator', () => {
     await running
     await preparing
     expect(prepared).toBe(true)
+  })
+
+  it('preserves a durable permission wait during quit preparation', async () => {
+    const prompt = createDeferred<unknown>()
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: ['session-1'],
+        callbacks,
+        prompt: () => prompt.promise,
+        activePromptSessions: [{ projectName: 'project-1', sessionId: 'session-1' }],
+        quitBlockingSessions: []
+      })
+      return created.runtime
+    })
+    const session = await coordinator.createSession({
+      cwd: '/workspace',
+      projectName: 'project-1'
+    })
+    const running = coordinator.sendPrompt({ sessionId: session.sessionId, text: 'wait for me' })
+    await Promise.resolve()
+
+    await expect(coordinator.prepareForQuit(1_000)).resolves.toBe('completed')
+    expect(created.cancelPrompt).not.toHaveBeenCalled()
+
+    prompt.resolve({ stopReason: 'cancelled' })
+    await running
   })
 
   it('bounds quit preparation when an agent never returns a terminal response', async () => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -347,13 +347,22 @@ class AcpRuntimeCoordinator {
     timeoutMs = QUIT_PREPARATION_TIMEOUT_MS
   ): Promise<Extract<ShutdownStepOutcome, 'completed' | 'timeout' | 'failed'>> {
     this.promptAdmissionClosedForQuit = true
+    const activePromptSessionIds = new Set(
+      this.getActivePromptSessions().map(({ sessionId }) => sessionId)
+    )
+    const quitBlockingSessionIds = new Set(
+      this.getQuitBlockingPromptSessions().map(({ sessionId }) => sessionId)
+    )
+    const durablePermissionWaitSessionIds = new Set(
+      [...activePromptSessionIds].filter((sessionId) => !quitBlockingSessionIds.has(sessionId))
+    )
     const sessionIds = Array.from(
       new Set([
         ...this.activePromptRequests.keys(),
         ...this.pendingPromptStarts.keys(),
         ...this.getSnapshot().promptInFlightSessionIds
       ])
-    )
+    ).filter((sessionId) => !durablePermissionWaitSessionIds.has(sessionId))
     if (sessionIds.length === 0) return 'completed'
 
     const cancelAndDrain = async (): Promise<void> => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -268,6 +268,10 @@ class AcpRuntimeCoordinator {
     return Array.from(this.runtimes).flatMap((runtime) => runtime.getActivePromptSessions())
   }
 
+  getQuitBlockingPromptSessions(): { projectName: string; sessionId: string }[] {
+    return Array.from(this.runtimes).flatMap((runtime) => runtime.getQuitBlockingPromptSessions())
+  }
+
   hasLiveSession(projectId: string, sessionId: string): boolean {
     const runtime = this.sessionRuntimes.get(sessionId)
     return runtime?.hasLiveSession(projectId, sessionId) ?? false
@@ -737,6 +741,7 @@ class AcpRuntimeCoordinator {
           .getSnapshot()
           .pendingPermissions.some((request) => request.requestId === response.requestId)
       ) ??
+      (response.restored ? this.sessionRuntimes.get(response.restored.sessionId) : undefined) ??
       this.getActiveRuntime()
     try {
       await runtime.respondToPermission(response)

--- a/src/main/acp/runtime-session-composition.ts
+++ b/src/main/acp/runtime-session-composition.ts
@@ -5,6 +5,7 @@ import { AcpAppContinuationOwner } from './app-continuation-owner'
 import { AcpContextUsagePolicy } from './context-usage-policy'
 import { AcpElicitationOwner } from './elicitation-owner'
 import { AcpPermissionContext } from './permission-context'
+import { AcpPermissionWaitOwner } from './permission-wait-owner'
 import { ReviewerSessionOwner } from './reviewer-session-owner'
 import type { AcpRuntimeOptions } from './runtime'
 import type { AcpRuntimeBaseOwners } from './runtime-base-composition'
@@ -130,6 +131,7 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     systemPromptAppends: () => sessionEnvironment.systemPromptAppends(),
     tooling: () => sessionEnvironment.toolingAvailability()
   })
+  const permissionWaitOwner = new AcpPermissionWaitOwner(options.permissionWait?.sessions)
   const permissionContext = new AcpPermissionContext({
     emitPermissionRequest: (request) => publication.publishPermissionRequest(request),
     routing: {
@@ -151,6 +153,7 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
         return scope?.kind === 'prompt'
           ? {
               sequence: scope.sequence,
+              promptMessageId: scope.promptMessageId,
               isCancellationAccepted: () => base.sessionInteractions.isCancellationAccepted(scope)
             }
           : undefined
@@ -165,6 +168,10 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     },
     conversationGrants: options.permissionGrantStore,
     permissionGrantRegistry: options.permissionGrantRegistry,
+    permissionWaitHooks: {
+      persist: (candidate) => permissionWaitOwner.persist(candidate),
+      settleLive: (candidate) => permissionWaitOwner.clearLive(candidate)
+    },
     setTimer: base.setTimer,
     clearTimer: base.clearTimer,
     onPermissionSettled: callbacks.onPermissionSettled,
@@ -226,6 +233,7 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     publication,
     appContinuations,
     elicitationOwner,
+    permissionWaitOwner,
     permissionContext,
     reviewerSessions,
     sessionUpdateProjector

--- a/src/main/acp/runtime-session-composition.ts
+++ b/src/main/acp/runtime-session-composition.ts
@@ -131,7 +131,10 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     systemPromptAppends: () => sessionEnvironment.systemPromptAppends(),
     tooling: () => sessionEnvironment.toolingAvailability()
   })
-  const permissionWaitOwner = new AcpPermissionWaitOwner(options.permissionWait?.sessions)
+  const permissionWaitOwner = new AcpPermissionWaitOwner(
+    options.permissionWait?.sessions,
+    options.permissionWait?.onSessionUpdated
+  )
   const permissionContext = new AcpPermissionContext({
     emitPermissionRequest: (request) => publication.publishPermissionRequest(request),
     routing: {

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -153,7 +153,10 @@ const createRuntimeHarness = (options: {
       lookup: () => ({ attachment: { session: { sessionId: 'provider-session-1' } } })
     },
     sessionPlanWorkflow,
-    appContinuations: { delete: vi.fn(() => false) },
+    appContinuations: {
+      get: vi.fn(() => undefined),
+      delete: vi.fn(() => false)
+    },
     artifactTurns: {
       promptMessageIdFor: () => 'interaction-1'
     },

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -60,6 +60,7 @@ import { UploadRepository } from '../uploads/repository'
 import { stageUploadFixtures } from '../uploads/repository.test-utils'
 import { MAX_INLINE_IMAGE_TOTAL_BASE64_BYTES } from '../uploads/attachment-media'
 import { ConversationSkillImporter, SkillImportApprovalBroker } from '../skills/conversation-import'
+import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
 import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
 import { NotebookRuntimeService } from '../notebook/runtime-service'
@@ -1841,6 +1842,96 @@ describe('ACP runtime restored permission continuation', () => {
     expect(fakeAgent.prompts[0]?.text).toContain('approved the pending tool permission')
   })
 
+  it('marks restored authority continuing before committing a persistent grant', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['restored-session'])
+    const journal: string[] = []
+    let runtimeContext: SessionRuntimeContext = {
+      version: 1,
+      revision: 1,
+      permission: {
+        state: 'pending',
+        request: {
+          requestId: 'permission-restored',
+          sessionId: 'restored-session',
+          toolCallId: 'tool-restored',
+          title: 'Run npm test',
+          providerToolName: 'Bash',
+          rawInput: { command: 'npm test' },
+          options: [
+            {
+              optionId: 'allow-project',
+              name: 'Allow for project',
+              kind: 'allow_always',
+              scope: 'project'
+            }
+          ]
+        },
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: 'a'.repeat(64),
+        capability: { kind: 'execution', key: 'exec:agent/shell' },
+        createdAt: 1
+      }
+    }
+    const patchSessionRuntimeContext = vi.fn(
+      async (command: { patch: { permission?: SessionRuntimeContext['permission'] } }) => {
+        if (command.patch.permission?.state === 'continuing') journal.push('authority')
+        runtimeContext = {
+          ...runtimeContext,
+          ...command.patch,
+          revision: runtimeContext.revision + 1
+        }
+        return structuredClone(runtimeContext)
+      }
+    )
+    const permissionGrantRegistry = {
+      resolve: vi.fn(),
+      remember: vi.fn(async () => {
+        journal.push('grant')
+        return undefined as never
+      }),
+      list: vi.fn().mockResolvedValue([]),
+      listCached: vi.fn().mockReturnValue([]),
+      revoke: vi.fn(),
+      extendUndo: vi.fn(),
+      restore: vi.fn(),
+      prune: vi.fn(),
+      finalizeOwnerDeletion: vi.fn(),
+      subscribe: vi.fn().mockReturnValue(() => undefined)
+    } satisfies PermissionGrantRegistry
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      permissionGrantRegistry,
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+          patchSessionRuntimeContext,
+          containsMessageOnActiveBranch: vi.fn(async () => true),
+          loadSessionForPermissionReplay: vi.fn(async () => {
+            throw new Error('Unexpected permission replay load')
+          })
+        }
+      },
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        backendId: 'claude-code:provider-a',
+        modelRoute: 'claude-anthropic',
+        executablePath: '/bin/agent',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+
+    await runtime.respondToPermission({
+      requestId: 'permission-restored',
+      optionId: 'allow-project',
+      restored: { sessionId: 'restored-session', projectId: 'project-1' }
+    })
+
+    expect(journal.slice(0, 2)).toEqual(['authority', 'grant'])
+  })
+
   it('releases the restored decision lock after a failed continuation so the card can retry', async () => {
     const process = new FakeAgentProcess()
     let continuationAttempts = 0
@@ -2025,6 +2116,92 @@ describe('ACP runtime restored permission continuation', () => {
       ).toBe(true)
     )
     expect(runtimeContext.permission).toMatchObject({ state: 'continuing' })
+  })
+
+  it('clears durable restored authority when its active continuation is cancelled', async () => {
+    const process = new FakeAgentProcess()
+    const continuationGate = createDeferred()
+    const fakeAgent = startFakeAgent(process, ['restored-session'], {
+      onPrompt: async () => {
+        await continuationGate.promise
+      }
+    })
+    let runtimeContext: SessionRuntimeContext = {
+      version: 1,
+      revision: 1,
+      permission: {
+        state: 'pending',
+        request: {
+          requestId: 'permission-restored',
+          sessionId: 'restored-session',
+          toolCallId: 'tool-restored',
+          title: 'Run npm test',
+          providerToolName: 'Bash',
+          rawInput: { command: 'npm test' },
+          options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+        },
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: 'a'.repeat(64),
+        createdAt: 1
+      }
+    }
+    const patchSessionRuntimeContext = vi.fn(
+      async (command: { patch: { permission?: SessionRuntimeContext['permission'] } }) => {
+        runtimeContext = {
+          ...runtimeContext,
+          ...command.patch,
+          revision: runtimeContext.revision + 1
+        }
+        return structuredClone(runtimeContext)
+      }
+    )
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+          patchSessionRuntimeContext,
+          containsMessageOnActiveBranch: vi.fn(async () => true),
+          loadSessionForPermissionReplay: vi.fn(async () => {
+            throw new Error('Unexpected permission replay load')
+          })
+        }
+      },
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        backendId: 'claude-code:provider-a',
+        modelRoute: 'claude-anthropic',
+        executablePath: '/bin/agent',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+    await runtime.respondToPermission({
+      requestId: 'permission-restored',
+      optionId: 'allow-once',
+      restored: { sessionId: 'restored-session', projectId: 'project-1' }
+    })
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+
+    await runtime.cancelPrompt({ sessionId: 'restored-session' })
+
+    expect(runtimeContext.permission).toBeUndefined()
+    continuationGate.resolve()
+    await vi.waitFor(() =>
+      expect(runtime.getSnapshot().promptInFlightSessionIds).not.toContain('restored-session')
+    )
+    expect(runtimeContext.permission).toBeUndefined()
+    expect(runtime.getSnapshot().events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'permission',
+          sessionId: 'restored-session',
+          title: 'Restored permission continuation settled',
+          text: 'cancelled'
+        })
+      ])
+    )
   })
 })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1596,6 +1596,59 @@ describe('ACP runtime provider prompt acceptance', () => {
 })
 
 describe('ACP runtime restored permission continuation', () => {
+  it('cancels restored pending authority without a live ACP interaction', async () => {
+    let runtimeContext: SessionRuntimeContext = {
+      version: 1,
+      revision: 1,
+      permission: {
+        state: 'pending',
+        request: {
+          requestId: 'permission-restored',
+          sessionId: 'restored-session',
+          toolCallId: 'tool-restored',
+          title: 'Run npm test',
+          options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+        },
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: 'a'.repeat(64),
+        createdAt: 1
+      }
+    }
+    const patchSessionRuntimeContext = vi.fn(async (command) => {
+      runtimeContext = {
+        ...runtimeContext,
+        ...command.patch,
+        revision: runtimeContext.revision + 1
+      }
+      return structuredClone(runtimeContext)
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+          patchSessionRuntimeContext,
+          containsMessageOnActiveBranch: vi.fn(async () => true),
+          loadSessionForPermissionReplay: vi.fn(),
+          sessionProjectId: vi.fn(async () => 'project-1')
+        }
+      }
+    })
+
+    await runtime.cancelPrompt({ sessionId: 'restored-session' })
+
+    expect(runtimeContext.permission).toBeUndefined()
+    expect(patchSessionRuntimeContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        sessionId: 'restored-session',
+        patch: { permission: undefined },
+        sessionStatus: 'idle'
+      })
+    )
+  })
+
   it.each([
     ['Claude Code', claudeCodeFramework, 'claude-anthropic', 'claude-code:provider-a'],
     ['OpenCode', opencodeFramework, 'opencode-openai', 'opencode:provider-a'],

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1614,6 +1614,7 @@ describe('ACP runtime restored permission continuation', () => {
         version: 1,
         revision: 1,
         permission: {
+          state: 'pending',
           request: {
             requestId: 'permission-restored',
             sessionId: 'restored-session',
@@ -1710,6 +1711,7 @@ describe('ACP runtime restored permission continuation', () => {
       version: 1,
       revision: 1,
       permission: {
+        state: 'pending',
         request: {
           requestId: 'permission-restored',
           sessionId: 'restored-session',
@@ -1790,6 +1792,90 @@ describe('ACP runtime restored permission continuation', () => {
     expect(patchSessionRuntimeContext).toHaveBeenCalledWith(
       expect.objectContaining({ sessionStatus: 'idle', patch: { permission: undefined } })
     )
+  })
+
+  it('keeps a successful continuation non-replayable when clearing its authority fails', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['restored-session'])
+    let runtimeContext: SessionRuntimeContext = {
+      version: 1,
+      revision: 1,
+      permission: {
+        state: 'pending',
+        request: {
+          requestId: 'permission-restored',
+          sessionId: 'restored-session',
+          toolCallId: 'tool-restored',
+          title: 'Run npm test',
+          providerToolName: 'Bash',
+          rawInput: { command: 'npm test' },
+          options: [
+            {
+              optionId: 'allow-once',
+              name: 'Allow once',
+              kind: 'allow_once',
+              scope: 'once'
+            }
+          ]
+        },
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: 'a'.repeat(64),
+        createdAt: 1
+      }
+    }
+    const patchSessionRuntimeContext = vi.fn(
+      async (command: {
+        expectedRevision: number
+        patch: { permission?: SessionRuntimeContext['permission'] }
+      }) => {
+        if (command.patch.permission === undefined) throw new Error('disk unavailable')
+        runtimeContext = {
+          ...runtimeContext,
+          ...command.patch,
+          revision: runtimeContext.revision + 1
+        }
+        return structuredClone(runtimeContext)
+      }
+    )
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+          patchSessionRuntimeContext,
+          containsMessageOnActiveBranch: vi.fn(async () => true)
+        }
+      },
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        backendId: 'claude-code:provider-a',
+        modelRoute: 'claude-anthropic',
+        executablePath: '/bin/agent',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+
+    await runtime.respondToPermission({
+      requestId: 'permission-restored',
+      optionId: 'allow-once',
+      restored: { sessionId: 'restored-session', projectId: 'project-1' }
+    })
+
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    await vi.waitFor(() =>
+      expect(
+        runtime
+          .getSnapshot()
+          .events.some(
+            (event) =>
+              event.kind === 'permission' &&
+              event.title === 'Permission continuation completed but its wait could not be cleared'
+          )
+      ).toBe(true)
+    )
+    expect(runtimeContext.permission).toMatchObject({ state: 'continuing' })
   })
 })
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -53,7 +53,7 @@ import { createArtifactVersionLocator } from '../../shared/artifact-provenance'
 import { BEGIN_ACTIVITY_GROUP_TOOL_NAME } from '../../shared/activity-groups'
 import type { UploadedAttachment } from '../../shared/uploads'
 import { projectConversationMessage } from '../../shared/conversation-graph'
-import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { PersistedChatSession, SessionRuntimeContext } from '../../shared/session-persistence'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
 import { UploadRepository } from '../uploads/repository'
 import { stageUploadFixtures } from '../uploads/repository.test-utils'
@@ -1589,6 +1589,111 @@ describe('ACP runtime provider prompt acceptance', () => {
 
       expect(onProviderPromptAccepted).toHaveBeenCalledOnce()
       expect(onProviderPromptAccepted).toHaveBeenCalledWith(session.sessionId, undefined)
+    }
+  )
+})
+
+describe('ACP runtime restored permission continuation', () => {
+  it.each([
+    ['Claude Code', claudeCodeFramework, 'claude-anthropic', 'claude-code:provider-a'],
+    ['OpenCode', opencodeFramework, 'opencode-openai', 'opencode:provider-a'],
+    ['Codex Responses', codexFramework, 'codex-responses', 'codex:provider-a'],
+    ['Codex Bridge', codexFramework, 'codex-bridge', 'codex:provider-a']
+  ] as const)(
+    'continues an approved restored wait through %s and then clears its authority',
+    async (_name, framework, modelRoute, backendId) => {
+      const process = new FakeAgentProcess()
+      const fakeAgent = startFakeAgent(process, ['restored-session'], {
+        ...(framework.id === 'codex'
+          ? { modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent') }
+          : {})
+      })
+      const bridgeLease =
+        modelRoute === 'codex-bridge' ? createBackendLeaseHarness().lease : undefined
+      let runtimeContext: SessionRuntimeContext = {
+        version: 1,
+        revision: 1,
+        permission: {
+          request: {
+            requestId: 'permission-restored',
+            sessionId: 'restored-session',
+            toolCallId: 'tool-restored',
+            title: 'Run npm test',
+            providerToolName: 'Bash',
+            rawInput: { command: 'npm test' },
+            options: [
+              {
+                optionId: 'allow-once',
+                name: 'Allow once',
+                kind: 'allow_once',
+                scope: 'once'
+              },
+              { optionId: 'deny', name: 'Deny', kind: 'reject_once' }
+            ]
+          },
+          originatingPromptMessageId: 'prompt-1',
+          fingerprint: 'a'.repeat(64),
+          createdAt: 1
+        }
+      }
+      const patchSessionRuntimeContext = vi.fn(
+        async (command: {
+          expectedRevision: number
+          patch: { permission?: SessionRuntimeContext['permission'] }
+        }) => {
+          expect(command.expectedRevision).toBe(runtimeContext.revision)
+          runtimeContext = {
+            ...runtimeContext,
+            ...command.patch,
+            revision: runtimeContext.revision + 1
+          }
+          return structuredClone(runtimeContext)
+        }
+      )
+      const onPermissionSettled = vi.fn()
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        callbacks: { onPermissionSettled },
+        permissionWait: {
+          sessions: {
+            readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+            patchSessionRuntimeContext,
+            containsMessageOnActiveBranch: vi.fn(async () => true)
+          }
+        },
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          backendId,
+          modelRoute,
+          executablePath: '/bin/agent',
+          env: {},
+          ...(bridgeLease ? { responsesBridgeLease: bridgeLease } : {})
+        })
+      })
+      await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+
+      await runtime.respondToPermission({
+        requestId: 'permission-restored',
+        optionId: 'allow-once',
+        restored: {
+          sessionId: 'restored-session',
+          projectId: 'project-1',
+          historyReplay: { historyPreamble: 'Previous conversation context.' }
+        }
+      })
+
+      await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+      expect(fakeAgent.prompts[0]?.text).toContain('Previous conversation context.')
+      expect(fakeAgent.prompts[0]?.text).toContain('approved the pending tool permission')
+      await vi.waitFor(() => expect(runtimeContext.permission).toBeUndefined())
+      expect(patchSessionRuntimeContext).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sessionStatus: 'idle',
+          patch: { permission: undefined }
+        })
+      )
+      expect(onPermissionSettled).toHaveBeenCalledWith('permission-restored', 'resolved')
     }
   )
 })
@@ -7448,6 +7553,64 @@ describe('ACP runtime session management', () => {
     expect(emittedUnknownPermission).toBe(false)
     expect(permissionError).toBeDefined()
     expect(runtime.getSnapshot().pendingPermissions).toEqual([])
+  })
+
+  it('keeps a durable permission wait active for Session safety but excludes it from quit warnings', async () => {
+    const process = new FakeAgentProcess()
+    const permissionSeen = createDeferred<AcpPermissionRequest>()
+    startPermissionProbeAgent(process, {
+      newSessionId: 'durable-permission-session',
+      toolCallId: 'durable-permission-tool',
+      toolTitle: 'Run command',
+      modes: createModes(['default', 'bypassPermissions'])
+    })
+    let runtimeContext: SessionRuntimeContext = { version: 1, revision: 0 }
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      callbacks: { onPermissionRequest: (request) => permissionSeen.resolve(request) },
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+          patchSessionRuntimeContext: vi.fn(
+            async (command: {
+              patch: { permission?: SessionRuntimeContext['permission'] }
+              expectedRevision: number
+            }) => {
+              expect(command.expectedRevision).toBe(runtimeContext.revision)
+              runtimeContext = {
+                ...runtimeContext,
+                ...command.patch,
+                revision: runtimeContext.revision + 1
+              }
+              return structuredClone(runtimeContext)
+            }
+          ),
+          containsMessageOnActiveBranch: vi.fn(async () => true)
+        }
+      }
+    })
+    const session = await runtime.createSession({
+      cwd: '/workspace',
+      projectName: 'project-1',
+      permissionProfile: 'ask'
+    })
+    const prompting = runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'run a command',
+      provenanceContext: { promptMessageId: 'prompt-1' }
+    })
+    const permission = await permissionSeen.promise
+
+    expect(permission.durable).toBe(true)
+    expect(runtime.getActivePromptSessions()).toEqual([
+      { projectName: 'project-1', sessionId: session.sessionId }
+    ])
+    expect(runtime.getQuitBlockingPromptSessions()).toEqual([])
+
+    await runtime.respondToPermission({ requestId: permission.requestId, cancelled: true })
+    await expect(prompting).resolves.toMatchObject({ stopReason: 'end_turn' })
   })
 
   it('changes permission profile while a prompt is waiting and releases the eligible request', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1696,6 +1696,101 @@ describe('ACP runtime restored permission continuation', () => {
       expect(onPermissionSettled).toHaveBeenCalledWith('permission-restored', 'resolved')
     }
   )
+
+  it('releases the restored decision lock after a failed continuation so the card can retry', async () => {
+    const process = new FakeAgentProcess()
+    let continuationAttempts = 0
+    const fakeAgent = startFakeAgent(process, ['restored-session'], {
+      onPrompt: () => {
+        continuationAttempts += 1
+        if (continuationAttempts === 1) throw new Error('continuation unavailable')
+      }
+    })
+    let runtimeContext: SessionRuntimeContext = {
+      version: 1,
+      revision: 1,
+      permission: {
+        request: {
+          requestId: 'permission-restored',
+          sessionId: 'restored-session',
+          toolCallId: 'tool-restored',
+          title: 'Run npm test',
+          providerToolName: 'Bash',
+          rawInput: { command: 'npm test' },
+          options: [
+            {
+              optionId: 'allow-once',
+              name: 'Allow once',
+              kind: 'allow_once',
+              scope: 'once'
+            },
+            { optionId: 'deny', name: 'Deny', kind: 'reject_once' }
+          ]
+        },
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: 'a'.repeat(64),
+        createdAt: 1
+      }
+    }
+    const patchSessionRuntimeContext = vi.fn(
+      async (command: {
+        expectedRevision: number
+        patch: { permission?: SessionRuntimeContext['permission'] }
+      }) => {
+        runtimeContext = {
+          ...runtimeContext,
+          ...command.patch,
+          revision: runtimeContext.revision + 1
+        }
+        return structuredClone(runtimeContext)
+      }
+    )
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+          patchSessionRuntimeContext,
+          containsMessageOnActiveBranch: vi.fn(async () => true)
+        }
+      },
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        backendId: 'claude-code:provider-a',
+        modelRoute: 'claude-anthropic',
+        executablePath: '/bin/agent',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+    const response = {
+      requestId: 'permission-restored',
+      optionId: 'allow-once',
+      restored: { sessionId: 'restored-session', projectId: 'project-1' }
+    }
+
+    await runtime.respondToPermission(response)
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    await vi.waitFor(() =>
+      expect(
+        runtime
+          .getSnapshot()
+          .events.some(
+            (event) => event.kind === 'error' && event.title === 'Could not continue the Agent task'
+          )
+      ).toBe(true)
+    )
+    expect(runtimeContext.permission).toBeDefined()
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    await expect(runtime.respondToPermission(response)).resolves.toBeDefined()
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(2))
+    await vi.waitFor(() => expect(runtimeContext.permission).toBeUndefined())
+    expect(patchSessionRuntimeContext).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionStatus: 'idle', patch: { permission: undefined } })
+    )
+  })
 })
 
 describe('ACP runtime session management', () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1780,6 +1780,109 @@ describe('ACP runtime restored permission continuation', () => {
     }
   )
 
+  it('does not publish stale settlement when permission authority changed during continuation', async () => {
+    const process = new FakeAgentProcess()
+    let runtimeContext: SessionRuntimeContext = {
+      version: 1,
+      revision: 1,
+      permission: {
+        state: 'pending',
+        request: {
+          requestId: 'permission-restored',
+          sessionId: 'restored-session',
+          toolCallId: 'tool-restored',
+          title: 'Run npm test',
+          providerToolName: 'Bash',
+          rawInput: { command: 'npm test' },
+          options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+        },
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: 'a'.repeat(64),
+        createdAt: 1
+      }
+    }
+    const replacementPermission: NonNullable<SessionRuntimeContext['permission']> = {
+      ...runtimeContext.permission!,
+      state: 'pending',
+      request: {
+        ...runtimeContext.permission!.request,
+        requestId: 'permission-newer',
+        toolCallId: 'tool-newer'
+      },
+      fingerprint: 'b'.repeat(64),
+      createdAt: 2
+    }
+    const fakeAgent = startFakeAgent(process, ['restored-session'], {
+      onPrompt: () => {
+        runtimeContext = {
+          ...runtimeContext,
+          revision: runtimeContext.revision + 1,
+          permission: replacementPermission
+        }
+      }
+    })
+    const patchSessionRuntimeContext = vi.fn(
+      async (command: {
+        expectedRevision: number
+        patch: { permission?: SessionRuntimeContext['permission'] }
+      }) => {
+        expect(command.expectedRevision).toBe(runtimeContext.revision)
+        runtimeContext = {
+          ...runtimeContext,
+          ...command.patch,
+          revision: runtimeContext.revision + 1
+        }
+        return structuredClone(runtimeContext)
+      }
+    )
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+          patchSessionRuntimeContext,
+          containsMessageOnActiveBranch: vi.fn(async () => true),
+          loadSessionForPermissionReplay: vi.fn(async () => {
+            throw new Error('Unexpected permission replay load')
+          })
+        }
+      },
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        backendId: 'claude-code:provider-a',
+        modelRoute: 'claude-anthropic',
+        executablePath: '/bin/agent',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+
+    await runtime.respondToPermission({
+      requestId: 'permission-restored',
+      optionId: 'allow-once',
+      restored: { sessionId: 'restored-session', projectId: 'project-1' }
+    })
+
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    await vi.waitFor(() =>
+      expect(runtime.getSnapshot().promptInFlightSessionIds).not.toContain('restored-session')
+    )
+    expect(runtimeContext.permission).toMatchObject({
+      state: 'pending',
+      request: { requestId: 'permission-newer' }
+    })
+    expect(runtime.getSnapshot().events).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'permission',
+          sessionId: 'restored-session',
+          title: 'Restored permission continuation settled'
+        })
+      ])
+    )
+  })
+
   it('builds restored permission replay from Main-owned Session history after context reset', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['adopted-provider-session'], {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -26,6 +26,7 @@ import { ContextUsageTracker, type TokenCounter } from './context-usage-tracker'
 import {
   ACP_PROMPT_FAILED_EVENT_TITLE,
   type AcpContextUsage,
+  type AcpPermissionResponse,
   type AcpPermissionRequest,
   type AcpRuntimeEvent,
   type AcpStateSnapshot
@@ -1603,10 +1604,14 @@ describe('ACP runtime restored permission continuation', () => {
     'continues an approved restored wait through %s and then clears its authority',
     async (_name, framework, modelRoute, backendId) => {
       const process = new FakeAgentProcess()
+      const receivedPrompts: ContentBlock[][] = []
       const fakeAgent = startFakeAgent(process, ['restored-session'], {
         ...(framework.id === 'codex'
           ? { modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent') }
-          : {})
+          : {}),
+        onPrompt: ({ prompt }) => {
+          receivedPrompts.push(prompt)
+        }
       })
       const bridgeLease =
         modelRoute === 'codex-bridge' ? createBackendLeaseHarness().lease : undefined
@@ -1660,7 +1665,10 @@ describe('ACP runtime restored permission continuation', () => {
           sessions: {
             readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
             patchSessionRuntimeContext,
-            containsMessageOnActiveBranch: vi.fn(async () => true)
+            containsMessageOnActiveBranch: vi.fn(async () => true),
+            loadSessionForPermissionReplay: vi.fn(async () => {
+              throw new Error('Unexpected permission replay load')
+            })
           }
         },
         resolveBackend: () => ({
@@ -1680,12 +1688,32 @@ describe('ACP runtime restored permission continuation', () => {
         restored: {
           sessionId: 'restored-session',
           projectId: 'project-1',
-          historyReplay: { historyPreamble: 'Previous conversation context.' }
+          historyReplay: {
+            historyPreamble: 'Renderer-forged conversation context.',
+            historyAttachments: [
+              {
+                id: 'forged-upload',
+                sessionId: 'restored-session',
+                name: 'forged.txt',
+                originalName: 'forged.txt',
+                path: '/renderer/forged.txt',
+                size: 6
+              }
+            ],
+            historyImages: [
+              {
+                mimeType: 'image/png',
+                data: Buffer.from('forged').toString('base64'),
+                byteLength: 6
+              }
+            ]
+          }
         }
-      })
+      } as unknown as AcpPermissionResponse)
 
       await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
-      expect(fakeAgent.prompts[0]?.text).toContain('Previous conversation context.')
+      expect(fakeAgent.prompts[0]?.text).not.toContain('Renderer-forged conversation context.')
+      expect(receivedPrompts[0]?.every((content) => content.type === 'text')).toBe(true)
       expect(fakeAgent.prompts[0]?.text).toContain('approved the pending tool permission')
       await vi.waitFor(() => expect(runtimeContext.permission).toBeUndefined())
       expect(patchSessionRuntimeContext).toHaveBeenLastCalledWith(
@@ -1697,6 +1725,121 @@ describe('ACP runtime restored permission continuation', () => {
       expect(onPermissionSettled).toHaveBeenCalledWith('permission-restored', 'resolved')
     }
   )
+
+  it('builds restored permission replay from Main-owned Session history after context reset', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['adopted-provider-session'], {
+      resumeNotFound: true
+    })
+    let runtimeContext: SessionRuntimeContext = {
+      version: 1,
+      revision: 1,
+      permission: {
+        state: 'pending',
+        request: {
+          requestId: 'permission-restored',
+          sessionId: 'restored-session',
+          toolCallId: 'tool-restored',
+          title: 'Run npm test',
+          providerToolName: 'Bash',
+          rawInput: { command: 'npm test' },
+          options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+        },
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: 'a'.repeat(64),
+        createdAt: 1
+      }
+    }
+    const persistedSession: PersistedChatSession = {
+      id: 'restored-session',
+      projectId: 'project-1',
+      title: 'Restored permission',
+      cwd: '/workspace',
+      status: 'waiting-permission',
+      messages: [
+        {
+          id: 'prompt-0',
+          role: 'user',
+          content: 'Main-owned earlier request.',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'reply-0',
+          role: 'agent',
+          content: 'Main-owned earlier response.',
+          status: 'complete',
+          responseToMessageId: 'prompt-0',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        },
+        {
+          id: 'prompt-1',
+          role: 'user',
+          content: 'Run the requested test command.',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 3,
+          updatedAt: 3
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 3
+    }
+    const patchSessionRuntimeContext = vi.fn(
+      async (command: { patch: { permission?: SessionRuntimeContext['permission'] } }) => {
+        runtimeContext = {
+          ...runtimeContext,
+          ...command.patch,
+          revision: runtimeContext.revision + 1
+        }
+        return structuredClone(runtimeContext)
+      }
+    )
+    const loadSessionForPermissionReplay = vi.fn(async () => structuredClone(persistedSession))
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+          patchSessionRuntimeContext,
+          containsMessageOnActiveBranch: vi.fn(async () => true),
+          loadSessionForPermissionReplay
+        }
+      },
+      resolveBackend: () => ({
+        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
+        backendId: 'claude-code:provider-a',
+        modelRoute: 'claude-anthropic',
+        executablePath: '/bin/agent',
+        env: {},
+        contextWindow: 200_000,
+        supportsImageInput: true
+      })
+    })
+
+    await expect(
+      runtime.resumeSession({
+        sessionId: 'restored-session',
+        cwd: '/workspace',
+        projectName: 'project-1'
+      })
+    ).resolves.toMatchObject({ sessionId: 'restored-session', contextReset: true })
+    await runtime.respondToPermission({
+      requestId: 'permission-restored',
+      optionId: 'allow-once',
+      restored: { sessionId: 'restored-session', projectId: 'project-1' }
+    })
+
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    expect(loadSessionForPermissionReplay).toHaveBeenCalledWith('project-1', 'restored-session')
+    expect(fakeAgent.prompts[0]?.text).toContain('Main-owned earlier request.')
+    expect(fakeAgent.prompts[0]?.text).toContain('approved the pending tool permission')
+  })
 
   it('releases the restored decision lock after a failed continuation so the card can retry', async () => {
     const process = new FakeAgentProcess()
@@ -1754,7 +1897,10 @@ describe('ACP runtime restored permission continuation', () => {
         sessions: {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
-          containsMessageOnActiveBranch: vi.fn(async () => true)
+          containsMessageOnActiveBranch: vi.fn(async () => true),
+          loadSessionForPermissionReplay: vi.fn(async () => {
+            throw new Error('Unexpected permission replay load')
+          })
         }
       },
       resolveBackend: () => ({
@@ -1844,7 +1990,10 @@ describe('ACP runtime restored permission continuation', () => {
         sessions: {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
-          containsMessageOnActiveBranch: vi.fn(async () => true)
+          containsMessageOnActiveBranch: vi.fn(async () => true),
+          loadSessionForPermissionReplay: vi.fn(async () => {
+            throw new Error('Unexpected permission replay load')
+          })
         }
       },
       resolveBackend: () => ({
@@ -7768,7 +7917,10 @@ describe('ACP runtime session management', () => {
               return structuredClone(runtimeContext)
             }
           ),
-          containsMessageOnActiveBranch: vi.fn(async () => true)
+          containsMessageOnActiveBranch: vi.fn(async () => true),
+          loadSessionForPermissionReplay: vi.fn(async () => {
+            throw new Error('Unexpected permission replay load')
+          })
         }
       }
     })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -9,23 +9,27 @@ import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 
-import type {
-  AcpCancelPromptRequest,
-  AcpCompactSessionRequest,
-  AcpConnectRequest,
-  AcpCreateSessionRequest,
-  AcpCreateSessionResponse,
-  AcpRuntimeEvent,
-  AcpDeleteSessionRequest,
-  AcpPermissionRequest,
-  AcpPermissionResponse,
-  AcpPermissionSettlementState,
-  ElicitationResponse,
-  AcpPromptRequest,
-  AcpResumeSessionRequest,
-  AcpRevokePermissionGrantRequest,
-  AcpSetPermissionProfileRequest,
-  AcpStateSnapshot
+import {
+  ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+  type AcpCancelPromptRequest,
+  type AcpCompactSessionRequest,
+  type AcpConnectRequest,
+  type AcpCreateSessionRequest,
+  type AcpCreateSessionResponse,
+  type AcpRuntimeEvent,
+  type AcpDeleteSessionRequest,
+  type AcpPermissionRequest,
+  type AcpPermissionResponse,
+  type AcpPermissionSettlementState,
+  type ElicitationResponse,
+  type AcpPromptRequest,
+  type AcpResumeSessionRequest,
+  type AcpRevokePermissionGrantRequest,
+  type AcpSetPermissionProfileRequest,
+  type AcpStateSnapshot
 } from '../../shared/acp'
 import { type AgentFrameworkId } from '../../shared/settings'
 import {
@@ -333,7 +337,10 @@ class AcpRuntime {
   private readonly elicitationOwner: AcpElicitationOwner
   private readonly appContinuations: AcpAppContinuationOwner
   private readonly permissionWaitOwner: AcpRuntimeSessionOwners['permissionWaitOwner']
-  private durablePermissionContinuations?: Map<string, { projectId: string; requestId: string }>
+  private durablePermissionContinuations?: Map<
+    string,
+    { projectId: string; requestId: string; cancellationRequested?: boolean }
+  >
   private restoredPermissionContextResetSessionIds?: Set<string>
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
@@ -982,13 +989,18 @@ class AcpRuntime {
       request.sessionId
     )
     const interactionInFlight = this.sessionInteractions.current(request.sessionId) !== undefined
-    const cancelledPendingContinuation = this.appContinuations.delete(request.sessionId)
+    const durablePermission = this.durablePermissionContinuations?.get(request.sessionId)
+    if (durablePermission) durablePermission.cancellationRequested = true
+    const continuationWasPending = this.appContinuations.get(request.sessionId) !== undefined
+    const cancelledContinuation = this.appContinuations.delete(request.sessionId)
 
-    if (cancelledPendingContinuation && !interactionInFlight) {
+    if (continuationWasPending && cancelledContinuation && !interactionInFlight) {
+      await this.settleCancelledDurablePermissionContinuation(request.sessionId)
       this.emitState()
       return this.getSnapshot()
     }
 
+    let cancellationAccepted = false
     if (connection && activeSession) {
       await this.sessionInteractions.cancelPrompt({
         sessionId: request.sessionId,
@@ -997,6 +1009,7 @@ class AcpRuntime {
             sessionId: activeSession.sessionId
           }),
         onAccepted: () => {
+          cancellationAccepted = true
           cancelPlanInteraction()
           this.cancelPermissionFlowForSession(request.sessionId)
           this.pushEvent({
@@ -1018,6 +1031,10 @@ class AcpRuntime {
           void this.disconnect()
         }
       })
+    }
+    if (cancellationAccepted) {
+      await this.settleCancelledDurablePermissionContinuation(request.sessionId)
+      this.emitState()
     }
 
     return this.getSnapshot()
@@ -1124,7 +1141,7 @@ class AcpRuntime {
       : undefined
     const durablePermissionContinuations =
       this.durablePermissionContinuations ??
-      new Map<string, { projectId: string; requestId: string }>()
+      new Map<string, { projectId: string; requestId: string; cancellationRequested?: boolean }>()
     this.durablePermissionContinuations = durablePermissionContinuations
     if (durablePermissionContinuations.has(restored.sessionId)) {
       throw new Error('The restored permission request is already being continued.')
@@ -1133,21 +1150,47 @@ class AcpRuntime {
       projectId,
       requestId: response.requestId
     })
+    let continuationBegan = false
     try {
-      await this.permissionContext.prepareRestoredDecision(
-        decision.permission,
-        decision.option,
-        projectId
-      )
       // Persist the consumed/non-replayable marker before starting provider work. A process loss or
-      // later clear failure must never restore the accepted approval as an actionable card.
+      // grant failure must never leave a reusable approval without consuming its authority first.
       await this.permissionWaitOwner.beginContinuation(
         projectId,
         restored.sessionId,
         response.requestId
       )
+      continuationBegan = true
+      await this.permissionContext.prepareRestoredDecision(
+        decision.permission,
+        decision.option,
+        projectId
+      )
     } catch (error) {
       this.permissionContext.clearRestoredDecision(restored.sessionId)
+      if (continuationBegan) {
+        try {
+          await this.permissionWaitOwner.rearmContinuation(
+            projectId,
+            restored.sessionId,
+            response.requestId
+          )
+          this.pushEvent({
+            kind: 'permission',
+            level: 'info',
+            sessionId: restored.sessionId,
+            title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
+          })
+        } catch (rearmError) {
+          this.pushEvent({
+            kind: 'permission',
+            level: 'error',
+            sessionId: restored.sessionId,
+            title: ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
+            text: errorMessage(rearmError)
+          })
+        }
+        this.emitState()
+      }
       durablePermissionContinuations.delete(restored.sessionId)
       throw error
     }
@@ -1418,7 +1461,9 @@ class AcpRuntime {
     } finally {
       const durablePermission = this.durablePermissionContinuations?.get(sessionId)
       this.permissionContext.clearRestoredDecision(sessionId)
-      if (completed && durablePermission) {
+      if (durablePermission?.cancellationRequested) {
+        await this.settleCancelledDurablePermissionContinuation(sessionId)
+      } else if (completed && durablePermission) {
         this.restoredPermissionContextResetSessionIds?.delete(sessionId)
         try {
           await this.permissionWaitOwner.clearAfterContinuation(
@@ -1426,12 +1471,19 @@ class AcpRuntime {
             sessionId,
             durablePermission.requestId
           )
+          this.pushEvent({
+            kind: 'permission',
+            level: 'info',
+            sessionId,
+            title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+            text: 'completed'
+          })
         } catch (error) {
           this.pushEvent({
             kind: 'permission',
             level: 'error',
             sessionId,
-            title: 'Permission continuation completed but its wait could not be cleared',
+            title: ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
             text: errorMessage(error)
           })
         } finally {
@@ -1446,12 +1498,18 @@ class AcpRuntime {
             sessionId,
             durablePermission.requestId
           )
+          this.pushEvent({
+            kind: 'permission',
+            level: 'info',
+            sessionId,
+            title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
+          })
         } catch (error) {
           this.pushEvent({
             kind: 'permission',
             level: 'error',
             sessionId,
-            title: 'Permission continuation failed and its wait could not be restored',
+            title: ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
             text: errorMessage(error)
           })
         } finally {
@@ -1599,8 +1657,38 @@ class AcpRuntime {
     this.permissionContext.cancelForSession(sessionId)
     this.elicitationOwner.cancelForSession(sessionId)
     this.appContinuations.delete(sessionId)
-    this.durablePermissionContinuations?.delete(sessionId)
+  }
+
+  private async settleCancelledDurablePermissionContinuation(sessionId: string): Promise<void> {
+    const durablePermission = this.durablePermissionContinuations?.get(sessionId)
+    if (!durablePermission) return
+    try {
+      await this.permissionWaitOwner.cancelContinuation(
+        durablePermission.projectId,
+        sessionId,
+        durablePermission.requestId
+      )
+    } catch (error) {
+      this.pushEvent({
+        kind: 'permission',
+        level: 'error',
+        sessionId,
+        title: ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
+        text: errorMessage(error)
+      })
+      return
+    }
+    if (this.durablePermissionContinuations?.get(sessionId) !== durablePermission) return
+    this.durablePermissionContinuations.delete(sessionId)
     this.restoredPermissionContextResetSessionIds?.delete(sessionId)
+    this.permissionContext.clearRestoredDecision(sessionId)
+    this.pushEvent({
+      kind: 'permission',
+      level: 'info',
+      sessionId,
+      title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+      text: 'cancelled'
+    })
   }
 
   private restoredPermissionHistoryReplayDescriptor(): HistoryReplayDescriptor {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -159,6 +159,12 @@ type AcpRuntimeOptions = {
   skillImport?: AcpRuntimeSkillImportOptions
   skills?: AcpTurnSkillHooks
   plan?: AcpRuntimePlanOptions
+  permissionWait?: {
+    sessions: Pick<
+      SessionPersistenceCoordinator,
+      'readSessionRuntimeContext' | 'patchSessionRuntimeContext' | 'containsMessageOnActiveBranch'
+    >
+  }
   // The agent backend to drive. Defaults to Claude Code; selecting another (opencode) swaps only the
   // framework-coupled behavior (spawn, session meta, permission-mode mapping) via AgentFramework.
   framework?: AgentFramework
@@ -322,6 +328,8 @@ class AcpRuntime {
   private readonly sessionInteractions: AcpSessionInteractionOwner
   private readonly elicitationOwner: AcpElicitationOwner
   private readonly appContinuations: AcpAppContinuationOwner
+  private readonly permissionWaitOwner: AcpRuntimeSessionOwners['permissionWaitOwner']
+  private durablePermissionContinuations?: Map<string, { projectId: string; requestId: string }>
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
   private readonly turnSkills: AcpTurnSkillOwner
@@ -376,6 +384,7 @@ class AcpRuntime {
     this.publication = session.publication
     this.permissionContext = session.permissionContext
     this.elicitationOwner = session.elicitationOwner
+    this.permissionWaitOwner = session.permissionWaitOwner
     this.appContinuations = session.appContinuations
     this.reviewerSessions = session.reviewerSessions
     this.sessionUpdateProjector = session.sessionUpdateProjector
@@ -482,6 +491,17 @@ class AcpRuntime {
       projectName: this.resolveSessionProjectName(sessionId),
       sessionId
     }))
+  }
+
+  // A permission-blocked prompt whose authority reached durable storage is quiescent for app quit:
+  // teardown loses only the dead provider RPC, while the card remains actionable after restart.
+  getQuitBlockingPromptSessions(): { projectName: string; sessionId: string }[] {
+    return this.getInFlightSessionIds()
+      .filter((sessionId) => !this.permissionContext.hasDurablePendingForSession(sessionId))
+      .map((sessionId) => ({
+        projectName: this.resolveSessionProjectName(sessionId),
+        sessionId
+      }))
   }
 
   hasLiveSession(projectId: string, sessionId: string): boolean {
@@ -999,6 +1019,9 @@ class AcpRuntime {
     const permissionRequest = this.permissionContext
       .getPendingRequests()
       .find((request) => request.requestId === response.requestId)
+    if (!permissionRequest && response.restored) {
+      return this.respondToRestoredPermission(response)
+    }
     const selectedOption = permissionRequest?.options.find(
       (option) => option.optionId === response.optionId
     )
@@ -1060,6 +1083,84 @@ class AcpRuntime {
     }
     this.emitState()
 
+    return this.getSnapshot()
+  }
+
+  private async respondToRestoredPermission(
+    response: AcpPermissionResponse
+  ): Promise<AcpStateSnapshot> {
+    const restored = response.restored!
+    const activeSession = this.activeSessionFor(restored.sessionId)
+    if (!activeSession) throw new Error(`ACP session not found: ${restored.sessionId}`)
+    const projectId = this.sessionEnvironment.projectName(restored.sessionId)
+    const decision = await this.permissionWaitOwner.resolveRestored(
+      response,
+      projectId,
+      restored.sessionId
+    )
+    const durablePermissionContinuations =
+      this.durablePermissionContinuations ??
+      new Map<string, { projectId: string; requestId: string }>()
+    this.durablePermissionContinuations = durablePermissionContinuations
+    if (durablePermissionContinuations.has(restored.sessionId)) {
+      throw new Error('The restored permission request is already being continued.')
+    }
+    durablePermissionContinuations.set(restored.sessionId, {
+      projectId,
+      requestId: response.requestId
+    })
+    try {
+      await this.permissionContext.prepareRestoredDecision(
+        decision.permission,
+        decision.option,
+        projectId
+      )
+    } catch (error) {
+      durablePermissionContinuations.delete(restored.sessionId)
+      throw error
+    }
+
+    const scope = decision.option?.scope
+    const text = decision.denied
+      ? 'The user denied the pending tool permission. Continue the current task without that tool ' +
+        'call. Use an alternative that does not require the denied permission, or explain what ' +
+        'cannot be completed. Do not request the same permission again unless the user explicitly asks.'
+      : `The user approved the pending tool permission${scope ? ` for ${scope}` : ''}. Retry only ` +
+        'the exact parked tool call and continue the current task. Do not broaden or reinterpret the approval.'
+    this.appContinuations.set(restored.sessionId, {
+      condition: 'always',
+      request: {
+        sessionId: restored.sessionId,
+        text,
+        suppressUserMessage: true,
+        provenanceContext: {
+          promptMessageId: decision.permission.originatingPromptMessageId
+        },
+        ...(restored.historyReplay?.historyPreamble
+          ? { historyPreamble: restored.historyReplay.historyPreamble }
+          : {}),
+        ...(restored.historyReplay?.historyAttachments?.length
+          ? { historyAttachments: restored.historyReplay.historyAttachments }
+          : {}),
+        ...(restored.historyReplay?.historyImages?.length
+          ? { historyImages: restored.historyReplay.historyImages }
+          : {})
+      }
+    })
+    this.schedulePendingAppContinuation(restored.sessionId)
+    this.options.callbacks?.onPermissionSettled?.(
+      response.requestId,
+      response.cancelled ? 'cancelled' : decision.denied ? 'rejected' : 'resolved'
+    )
+    this.pushEvent({
+      kind: 'permission',
+      level: 'info',
+      sessionId: restored.sessionId,
+      promptMessageId: decision.permission.originatingPromptMessageId,
+      title: 'Restored permission response accepted',
+      text: response.cancelled ? 'cancelled' : response.optionId
+    })
+    this.emitState()
     return this.getSnapshot()
   }
 
@@ -1268,8 +1369,10 @@ class AcpRuntime {
     if (!pending || this.sessionInteractions.current(sessionId)) return
     const continuation = this.appContinuations.takeAndActivate(sessionId)
     if (!continuation) return
+    let completed = false
     try {
       await this.sendAppContinuation(continuation.request)
+      completed = true
     } catch (error) {
       this.pushEvent({
         kind: 'error',
@@ -1281,6 +1384,26 @@ class AcpRuntime {
       })
       this.emitState()
     } finally {
+      const durablePermission = this.durablePermissionContinuations?.get(sessionId)
+      this.permissionContext.clearRestoredDecision(sessionId)
+      if (completed && durablePermission) {
+        try {
+          await this.permissionWaitOwner.clearAfterContinuation(
+            durablePermission.projectId,
+            sessionId,
+            durablePermission.requestId
+          )
+          this.durablePermissionContinuations?.delete(sessionId)
+        } catch (error) {
+          this.pushEvent({
+            kind: 'permission',
+            level: 'error',
+            sessionId,
+            title: 'Permission continuation completed but its wait could not be cleared',
+            text: errorMessage(error)
+          })
+        }
+      }
       this.appContinuations.complete(sessionId)
       this.emitState()
     }
@@ -1422,6 +1545,7 @@ class AcpRuntime {
     this.permissionContext.cancelForSession(sessionId)
     this.elicitationOwner.cancelForSession(sessionId)
     this.appContinuations.delete(sessionId)
+    this.durablePermissionContinuations?.delete(sessionId)
   }
 
   private processEventDisposition(

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -172,6 +172,7 @@ type AcpRuntimeOptions = {
       | 'containsMessageOnActiveBranch'
       | 'loadSessionForPermissionReplay'
     >
+    onSessionUpdated?: import('./permission-wait-owner').PublishPermissionWaitSession
   }
   // The agent backend to drive. Defaults to Claude Code; selecting another (opencode) swaps only the
   // framework-coupled behavior (spawn, session meta, permission-mode mapping) via AgentFramework.

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -63,6 +63,7 @@ import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, FileReference } from '../../shared/artifacts'
 import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
+import type { HistoryReplayDescriptor } from '../../shared/history-preamble'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
 import type { AcpAppContinuationOwner } from './app-continuation-owner'
 import type { ContextUsageTracker } from './context-usage-tracker'
@@ -162,7 +163,10 @@ type AcpRuntimeOptions = {
   permissionWait?: {
     sessions: Pick<
       SessionPersistenceCoordinator,
-      'readSessionRuntimeContext' | 'patchSessionRuntimeContext' | 'containsMessageOnActiveBranch'
+      | 'readSessionRuntimeContext'
+      | 'patchSessionRuntimeContext'
+      | 'containsMessageOnActiveBranch'
+      | 'loadSessionForPermissionReplay'
     >
   }
   // The agent backend to drive. Defaults to Claude Code; selecting another (opencode) swaps only the
@@ -330,6 +334,7 @@ class AcpRuntime {
   private readonly appContinuations: AcpAppContinuationOwner
   private readonly permissionWaitOwner: AcpRuntimeSessionOwners['permissionWaitOwner']
   private durablePermissionContinuations?: Map<string, { projectId: string; requestId: string }>
+  private restoredPermissionContextResetSessionIds?: Set<string>
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
   private readonly turnSkills: AcpTurnSkillOwner
@@ -600,7 +605,17 @@ class AcpRuntime {
 
   // Reattaches a persisted protocol session after an app restart so later prompts can stream.
   async resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
-    return this.withOperationLease(() => this.providerSessionResumer.resume(request))
+    return this.withOperationLease(async () => {
+      this.restoredPermissionContextResetSessionIds?.delete(request.sessionId)
+      const resumed = await this.providerSessionResumer.resume(request)
+      if (resumed.contextReset) {
+        const contextResetSessionIds =
+          this.restoredPermissionContextResetSessionIds ?? new Set<string>()
+        this.restoredPermissionContextResetSessionIds = contextResetSessionIds
+        contextResetSessionIds.add(request.sessionId)
+      }
+      return resumed
+    })
   }
 
   // Forcibly drops the agent-side context for a session whose accumulated history can no longer be sent
@@ -1098,6 +1113,15 @@ class AcpRuntime {
       projectId,
       restored.sessionId
     )
+    const historyReplay = this.restoredPermissionContextResetSessionIds?.has(restored.sessionId)
+      ? await this.permissionWaitOwner.buildRestoredContinuationReplay(
+          projectId,
+          restored.sessionId,
+          decision.permission,
+          this.restoredPermissionHistoryReplayDescriptor(),
+          this.backendGeneration.current.context.supportsImageInput
+        )
+      : undefined
     const durablePermissionContinuations =
       this.durablePermissionContinuations ??
       new Map<string, { projectId: string; requestId: string }>()
@@ -1144,14 +1168,14 @@ class AcpRuntime {
         provenanceContext: {
           promptMessageId: decision.permission.originatingPromptMessageId
         },
-        ...(restored.historyReplay?.historyPreamble
-          ? { historyPreamble: restored.historyReplay.historyPreamble }
+        ...(historyReplay?.historyPreamble
+          ? { historyPreamble: historyReplay.historyPreamble }
           : {}),
-        ...(restored.historyReplay?.historyAttachments?.length
-          ? { historyAttachments: restored.historyReplay.historyAttachments }
+        ...(historyReplay?.historyAttachments.length
+          ? { historyAttachments: historyReplay.historyAttachments }
           : {}),
-        ...(restored.historyReplay?.historyImages?.length
-          ? { historyImages: restored.historyReplay.historyImages }
+        ...(historyReplay?.historyImages.length
+          ? { historyImages: historyReplay.historyImages }
           : {})
       }
     })
@@ -1395,6 +1419,7 @@ class AcpRuntime {
       const durablePermission = this.durablePermissionContinuations?.get(sessionId)
       this.permissionContext.clearRestoredDecision(sessionId)
       if (completed && durablePermission) {
+        this.restoredPermissionContextResetSessionIds?.delete(sessionId)
         try {
           await this.permissionWaitOwner.clearAfterContinuation(
             durablePermission.projectId,
@@ -1575,6 +1600,23 @@ class AcpRuntime {
     this.elicitationOwner.cancelForSession(sessionId)
     this.appContinuations.delete(sessionId)
     this.durablePermissionContinuations?.delete(sessionId)
+    this.restoredPermissionContextResetSessionIds?.delete(sessionId)
+  }
+
+  private restoredPermissionHistoryReplayDescriptor(): HistoryReplayDescriptor {
+    const backend = this.backendGeneration.current
+    const target =
+      backend.framework.id === 'opencode'
+        ? 'opencode'
+        : backend.framework.id === 'codex'
+          ? backend.modelRoute === 'codex-bridge'
+            ? 'codex-bridge'
+            : 'codex-response'
+          : 'claude-code'
+    return {
+      target,
+      ...(backend.context.window ? { contextWindow: backend.context.window } : {})
+    }
   }
 
   private processEventDisposition(

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -171,7 +171,8 @@ type AcpRuntimeOptions = {
       | 'patchSessionRuntimeContext'
       | 'containsMessageOnActiveBranch'
       | 'loadSessionForPermissionReplay'
-    >
+    > &
+      Partial<Pick<SessionPersistenceCoordinator, 'sessionProjectId'>>
     onSessionUpdated?: import('./permission-wait-owner').PublishPermissionWaitSession
   }
   // The agent backend to drive. Defaults to Claude Code; selecting another (opencode) swaps only the
@@ -999,6 +1000,34 @@ class AcpRuntime {
       await this.settleCancelledDurablePermissionContinuation(request.sessionId)
       this.emitState()
       return this.getSnapshot()
+    }
+
+    if (!interactionInFlight && !durablePermission) {
+      try {
+        if (await this.permissionWaitOwner.cancelPendingSession(request.sessionId)) {
+          this.restoredPermissionContextResetSessionIds?.delete(request.sessionId)
+          this.permissionContext.clearRestoredDecision(request.sessionId)
+          this.pushEvent({
+            kind: 'permission',
+            level: 'info',
+            sessionId: request.sessionId,
+            title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+            text: 'cancelled'
+          })
+          this.emitState()
+          return this.getSnapshot()
+        }
+      } catch (error) {
+        this.pushEvent({
+          kind: 'permission',
+          level: 'error',
+          sessionId: request.sessionId,
+          title: ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
+          text: errorMessage(error)
+        })
+        this.emitState()
+        return this.getSnapshot()
+      }
     }
 
     let cancellationAccepted = false

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1403,6 +1403,10 @@ class AcpRuntime {
             text: errorMessage(error)
           })
         }
+      } else if (durablePermission) {
+        // The durable authority remains the retry token after a failed provider continuation. Release
+        // only the process-local dedup reservation so the restored card can submit another attempt.
+        this.durablePermissionContinuations?.delete(sessionId)
       }
       this.appContinuations.complete(sessionId)
       this.emitState()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1115,7 +1115,15 @@ class AcpRuntime {
         decision.option,
         projectId
       )
+      // Persist the consumed/non-replayable marker before starting provider work. A process loss or
+      // later clear failure must never restore the accepted approval as an actionable card.
+      await this.permissionWaitOwner.beginContinuation(
+        projectId,
+        restored.sessionId,
+        response.requestId
+      )
     } catch (error) {
+      this.permissionContext.clearRestoredDecision(restored.sessionId)
       durablePermissionContinuations.delete(restored.sessionId)
       throw error
     }
@@ -1393,7 +1401,6 @@ class AcpRuntime {
             sessionId,
             durablePermission.requestId
           )
-          this.durablePermissionContinuations?.delete(sessionId)
         } catch (error) {
           this.pushEvent({
             kind: 'permission',
@@ -1402,11 +1409,29 @@ class AcpRuntime {
             title: 'Permission continuation completed but its wait could not be cleared',
             text: errorMessage(error)
           })
+        } finally {
+          this.durablePermissionContinuations?.delete(sessionId)
         }
       } else if (durablePermission) {
-        // The durable authority remains the retry token after a failed provider continuation. Release
-        // only the process-local dedup reservation so the restored card can submit another attempt.
-        this.durablePermissionContinuations?.delete(sessionId)
+        try {
+          // A retry is safe only after durable authority returns from consumed to pending. If this
+          // write fails, retain `continuing` as a fail-closed tombstone and do not expose the card.
+          await this.permissionWaitOwner.rearmContinuation(
+            durablePermission.projectId,
+            sessionId,
+            durablePermission.requestId
+          )
+        } catch (error) {
+          this.pushEvent({
+            kind: 'permission',
+            level: 'error',
+            sessionId,
+            title: 'Permission continuation failed and its wait could not be restored',
+            text: errorMessage(error)
+          })
+        } finally {
+          this.durablePermissionContinuations?.delete(sessionId)
+        }
       }
       this.appContinuations.complete(sessionId)
       this.emitState()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1496,18 +1496,20 @@ class AcpRuntime {
       } else if (completed && durablePermission) {
         this.restoredPermissionContextResetSessionIds?.delete(sessionId)
         try {
-          await this.permissionWaitOwner.clearAfterContinuation(
+          const cleared = await this.permissionWaitOwner.clearAfterContinuation(
             durablePermission.projectId,
             sessionId,
             durablePermission.requestId
           )
-          this.pushEvent({
-            kind: 'permission',
-            level: 'info',
-            sessionId,
-            title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
-            text: 'completed'
-          })
+          if (cleared) {
+            this.pushEvent({
+              kind: 'permission',
+              level: 'info',
+              sessionId,
+              title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+              text: 'completed'
+            })
+          }
         } catch (error) {
           this.pushEvent({
             kind: 'permission',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1996,7 +1996,11 @@ const createApplicationModules = async (
     taskAgent,
     sessionDeletionCapability: sessionPersistenceCoordinator,
     archiveCapability: archiveCoordinator,
-    detectActiveSessions: () => detectActiveSessions({ runtime, notebook: notebookService }),
+    detectActiveSessions: () =>
+      detectActiveSessions({
+        runtime: { getActivePromptSessions: () => runtime.getQuitBlockingPromptSessions() },
+        notebook: notebookService
+      }),
     prepareForQuit: () => runtime.prepareForQuit(),
     electronAdapters: {
       beforeCompute: beforeComputeAdapters,

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -399,6 +399,7 @@ describe('Session persistence coordinator architecture', () => {
         'listLegacyProjectSessionTombstones',
         'loadAll',
         'loadAllReadOnly',
+        'loadSessionForPermissionReplay',
         'markCommittedProjectSessionsPrepared',
         'patchSessionRuntimeContext',
         'readSessionRuntimeContext',

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -65,6 +65,7 @@ const createRuntimePlan = (
 })
 
 const createRuntimePermission = (): SessionPermissionRuntimeContext => ({
+  state: 'pending',
   request: {
     requestId: 'permission-1',
     sessionId: 'session-1',
@@ -537,6 +538,38 @@ describe('SessionPersistenceCoordinator', () => {
       runtimeContext: { version: 1, revision: 4 }
     })
     expect(durable.runtimeContext?.permission).toBeUndefined()
+  })
+
+  it('does not let a stale renderer save revive a consumed permission continuation', async () => {
+    const continuingPermission = { ...createRuntimePermission(), state: 'continuing' as const }
+    let durable = createSession({
+      status: 'running',
+      runtimeContext: { version: 1, revision: 4, permission: continuingPermission }
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.saveSession(
+        createSession({
+          status: 'waiting-permission',
+          runtimeContext: { version: 1, revision: 3, permission: createRuntimePermission() }
+        })
+      )
+    ).resolves.toMatchObject({
+      status: 'running',
+      runtimeContext: { version: 1, revision: 4, permission: continuingPermission }
+    })
+    expect(durable.status).toBe('running')
+    expect(durable.runtimeContext?.permission).toEqual(continuingPermission)
   })
 
   it('preserves main-owned archive state on a stale whole-session save', async () => {

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -18,6 +18,7 @@ import {
   type PersistedArtifact,
   type PersistedChatMessage,
   type PersistedChatSession,
+  type SessionPermissionRuntimeContext,
   type SessionPlanRuntimeContext
 } from '../../shared/session-persistence'
 import type { ArtifactProjectReconciliationSnapshot } from '../artifacts/provenance-repository'
@@ -61,6 +62,19 @@ const createRuntimePlan = (
   approval: 'pending',
   stepStatuses: {},
   ...overrides
+})
+
+const createRuntimePermission = (): SessionPermissionRuntimeContext => ({
+  request: {
+    requestId: 'permission-1',
+    sessionId: 'session-1',
+    toolCallId: 'tool-1',
+    title: 'Run npm test',
+    options: [{ optionId: 'deny', name: 'Deny', kind: 'reject_once' }]
+  },
+  originatingPromptMessageId: 'prompt-1',
+  fingerprint: 'a'.repeat(64),
+  createdAt: 1
 })
 
 const createLegacyUploadSession = (sessionId: string): PersistedChatSession =>
@@ -463,6 +477,66 @@ describe('SessionPersistenceCoordinator', () => {
       plan: createRuntimePlan()
     })
     expect(durable.updatedAt).toBeGreaterThan(previousUpdatedAt)
+  })
+
+  it('preserves authoritative permission context and waiting status on a stale renderer save', async () => {
+    let durable = createSession({
+      status: 'waiting-permission',
+      runtimeContext: { version: 1, revision: 3, permission: createRuntimePermission() }
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.saveSession(createSession({ status: 'idle', runtimeContext: undefined }))
+    ).resolves.toMatchObject({
+      status: 'waiting-permission',
+      runtimeContext: {
+        version: 1,
+        revision: 3,
+        permission: { request: { requestId: 'permission-1' } }
+      }
+    })
+    expect(durable.status).toBe('waiting-permission')
+    expect(durable.runtimeContext?.permission).toEqual(createRuntimePermission())
+  })
+
+  it('does not let a stale renderer save revive a permission wait after main clears it', async () => {
+    let durable = createSession({
+      status: 'running',
+      runtimeContext: { version: 1, revision: 4 }
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.saveSession(
+        createSession({
+          status: 'waiting-permission',
+          runtimeContext: { version: 1, revision: 3, permission: createRuntimePermission() }
+        })
+      )
+    ).resolves.toMatchObject({
+      status: 'running',
+      runtimeContext: { version: 1, revision: 4 }
+    })
+    expect(durable.runtimeContext?.permission).toBeUndefined()
   })
 
   it('preserves main-owned archive state on a stale whole-session save', async () => {
@@ -1474,7 +1548,7 @@ describe('SessionPersistenceCoordinator', () => {
     expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([session])
   })
 
-  it('preserves a live permission wait when another client hydrates in the same process', async () => {
+  it('preserves a main-owned permission wait when another client hydrates in the same process', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-live-permission-hydration-'))
     const repository = new SessionRepository(root, { hasActiveRuntimePrompt: () => true })
     const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
@@ -1485,7 +1559,7 @@ describe('SessionPersistenceCoordinator', () => {
 
       await coordinator.saveSession(
         createSession({
-          status: 'waiting-permission',
+          status: 'running',
           activeRun: { promptMessageId: 'prompt-1', startedAt: 3 },
           messages: [
             {
@@ -1512,6 +1586,13 @@ describe('SessionPersistenceCoordinator', () => {
           ]
         })
       )
+      await coordinator.patchSessionRuntimeContext({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        expectedRevision: 0,
+        patch: { permission: createRuntimePermission() },
+        sessionStatus: 'waiting-permission'
+      })
 
       const rehydrated = await coordinator.loadAll()
 

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -261,6 +261,48 @@ describe('SessionPersistenceCoordinator', () => {
     }
   )
 
+  it('loads an isolated durable Session snapshot for permission replay', async () => {
+    const durable = createSession({
+      messages: [
+        {
+          id: 'prompt-1',
+          role: 'user',
+          content: 'Run the command',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      }))
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    const loaded = await coordinator.loadSessionForPermissionReplay('project-1', 'session-1')
+    loaded.messages[0].content = 'mutated snapshot'
+
+    expect(durable.messages[0].content).toBe('Run the command')
+  })
+
+  it.each(['missing', 'unreadable'] as const)(
+    'refuses permission replay when the durable Session is %s',
+    async (status) => {
+      const repository = createSessionRepository({
+        loadSessionWithDiagnostics: vi.fn(async () => ({ status }))
+      })
+      const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+      await expect(
+        coordinator.loadSessionForPermissionReplay('project-1', 'session-1')
+      ).rejects.toThrow(`Cannot build permission replay for a ${status} Session.`)
+    }
+  )
+
   it('persists blocked Plan feedback as a standard user Message without changing Plan authority', async () => {
     let durable = createSession({
       status: 'waiting-plan-approval',

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -186,6 +186,19 @@ class SessionPersistenceCoordinator {
     )
   }
 
+  loadSessionForPermissionReplay(
+    projectId: string,
+    sessionId: string
+  ): Promise<PersistedChatSession> {
+    return this.enqueue(async () => {
+      const loaded = await this.repository.loadSessionWithDiagnostics(projectId, sessionId)
+      if (loaded.status !== 'found') {
+        throw new Error(`Cannot build permission replay for a ${loaded.status} Session.`)
+      }
+      return structuredClone(loaded.session)
+    })
+  }
+
   // Binds unread cleanup to authoritative Session mutations. Reconciliation is called only with a
   // complete live Session catalog, while commit runs only after deletion succeeds.
   setSessionDeletionHandlers(handlers: SessionDeletionHandlers): void {

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -721,7 +721,7 @@ describe('session persistence repository (per-session files)', () => {
     expect(sessions[0].messages[0].interrupted).toBe(true)
   })
 
-  it('fails a permission continuation closed instead of restoring an actionable card', async () => {
+  it('rearms a prompt-bound permission continuation as actionable after restart', async () => {
     const repository = new SessionRepository(await createStorageRoot())
     await repository.saveSession(
       createSession({
@@ -750,16 +750,20 @@ describe('session persistence repository (per-session files)', () => {
     const { sessions } = await repository.loadAll()
 
     expect(sessions[0]).toMatchObject({
-      status: 'error',
-      runtimeContext: { version: 1, revision: 2 },
-      resumeRecovery: {
-        kind: 'resume-required',
-        cause: 'app-restart',
-        promptMessageId: 'message-1'
+      status: 'waiting-permission',
+      runtimeContext: {
+        version: 1,
+        revision: 2,
+        permission: {
+          state: 'pending',
+          originatingPromptMessageId: 'message-1'
+        }
       }
     })
-    expect(sessions[0].runtimeContext?.permission).toMatchObject({ state: 'continuing' })
-    expect(sessions[0].messages[0].interrupted).toBe(true)
+    expect(sessions[0].activeRun).toBeUndefined()
+    expect(sessions[0].resumeRecovery).toBeUndefined()
+    expect(sessions[0].error).toBeUndefined()
+    expect(sessions[0].messages[0].interrupted).toBeUndefined()
   })
 
   it('fails a permission wait closed when its persisted fingerprint is invalid', async () => {

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -643,38 +643,67 @@ describe('session persistence repository (per-session files)', () => {
     })
   })
 
-  it('normalizes interrupted runs and open activities on load', async () => {
+  it('restores permission waits without interrupting the active turn', async () => {
     const repository = new SessionRepository(await createStorageRoot())
 
-    // saveSession writes verbatim, so this simulates an app that closed mid-run.
+    // saveSession writes verbatim, so this simulates an app that closed after the main process made
+    // the permission request durable but before the user responded.
     await repository.saveSession(
       createSession({
         status: 'waiting-permission',
         activeRun: { promptMessageId: 'message-1', startedAt: 1710000000200 },
-        messages: [
-          {
-            id: 'message-2',
-            role: 'agent',
-            content: 'Partial',
-            status: 'streaming',
-            streamId: 'assistant-message-1',
-            eventIds: ['event-1'],
-            createdAt: 1,
-            updatedAt: 1
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            request: {
+              requestId: 'permission-1',
+              sessionId: 'session-1',
+              toolCallId: 'tool-1',
+              title: 'Run npm test',
+              providerToolName: 'Bash',
+              rawInput: { command: 'npm test' },
+              options: [
+                {
+                  optionId: 'allow-once',
+                  name: 'Allow once',
+                  kind: 'allow_once',
+                  scope: 'once'
+                },
+                { optionId: 'deny', name: 'Deny', kind: 'reject_once' }
+              ]
+            },
+            originatingPromptMessageId: 'message-1',
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1710000000200
           }
-        ],
-        activities: [
-          {
-            id: 'activity-open',
-            kind: 'tool',
-            title: 'downloading',
-            status: 'in_progress',
-            sortIndex: 1,
-            eventIds: [],
-            createdAt: 1,
-            updatedAt: 1
-          }
-        ]
+        }
+      })
+    )
+
+    const { sessions } = await repository.loadAll()
+
+    expect(sessions[0]).toMatchObject({
+      status: 'waiting-permission',
+      runtimeContext: {
+        permission: {
+          request: { requestId: 'permission-1' },
+          originatingPromptMessageId: 'message-1'
+        }
+      }
+    })
+    expect(sessions[0].activeRun).toBeUndefined()
+    expect(sessions[0].resumeRecovery).toBeUndefined()
+    expect(sessions[0].error).toBeUndefined()
+    expect(sessions[0].messages[0].interrupted).toBeUndefined()
+  })
+
+  it('fails a legacy permission wait closed when no durable request authority exists', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    await repository.saveSession(
+      createSession({
+        status: 'waiting-permission',
+        activeRun: { promptMessageId: 'message-1', startedAt: 1710000000200 }
       })
     )
 
@@ -682,11 +711,45 @@ describe('session persistence repository (per-session files)', () => {
 
     expect(sessions[0]).toMatchObject({
       status: 'error',
-      error: 'Session was interrupted before the app closed.'
+      resumeRecovery: {
+        kind: 'resume-required',
+        cause: 'app-restart',
+        promptMessageId: 'message-1'
+      }
     })
-    expect(sessions[0].activeRun).toBeUndefined()
-    expect(sessions[0].messages[0].status).toBe('error')
-    expect(sessions[0].activities?.[0].status).toBe('failed')
+    expect(sessions[0].messages[0].interrupted).toBe(true)
+  })
+
+  it('fails a permission wait closed when its persisted fingerprint is invalid', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    await repository.saveSession(
+      createSession({
+        status: 'waiting-permission',
+        activeRun: { promptMessageId: 'message-1', startedAt: 1710000000200 },
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            request: {
+              requestId: 'permission-1',
+              sessionId: 'session-1',
+              toolCallId: 'tool-1',
+              title: 'Run npm test',
+              options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }]
+            },
+            originatingPromptMessageId: 'message-1',
+            fingerprint: 'not-a-valid-fingerprint',
+            createdAt: 1710000000200
+          }
+        }
+      })
+    )
+
+    const { sessions } = await repository.loadAll()
+
+    expect(sessions[0].status).toBe('error')
+    expect(sessions[0].runtimeContext).toBeUndefined()
+    expect(sessions[0].messages[0].interrupted).toBe(true)
   })
 
   it('deletes a single session file and a whole project directory', async () => {

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -656,6 +656,7 @@ describe('session persistence repository (per-session files)', () => {
           version: 1,
           revision: 1,
           permission: {
+            state: 'pending',
             request: {
               requestId: 'permission-1',
               sessionId: 'session-1',
@@ -720,6 +721,47 @@ describe('session persistence repository (per-session files)', () => {
     expect(sessions[0].messages[0].interrupted).toBe(true)
   })
 
+  it('fails a permission continuation closed instead of restoring an actionable card', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    await repository.saveSession(
+      createSession({
+        status: 'running',
+        activeRun: { promptMessageId: 'message-1', startedAt: 1710000000200 },
+        runtimeContext: {
+          version: 1,
+          revision: 2,
+          permission: {
+            state: 'continuing',
+            request: {
+              requestId: 'permission-1',
+              sessionId: 'session-1',
+              toolCallId: 'tool-1',
+              title: 'Run npm test',
+              options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }]
+            },
+            originatingPromptMessageId: 'message-1',
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1710000000200
+          }
+        }
+      })
+    )
+
+    const { sessions } = await repository.loadAll()
+
+    expect(sessions[0]).toMatchObject({
+      status: 'error',
+      runtimeContext: { version: 1, revision: 2 },
+      resumeRecovery: {
+        kind: 'resume-required',
+        cause: 'app-restart',
+        promptMessageId: 'message-1'
+      }
+    })
+    expect(sessions[0].runtimeContext?.permission).toMatchObject({ state: 'continuing' })
+    expect(sessions[0].messages[0].interrupted).toBe(true)
+  })
+
   it('fails a permission wait closed when its persisted fingerprint is invalid', async () => {
     const repository = new SessionRepository(await createStorageRoot())
     await repository.saveSession(
@@ -730,6 +772,7 @@ describe('session persistence repository (per-session files)', () => {
           version: 1,
           revision: 1,
           permission: {
+            state: 'pending',
             request: {
               requestId: 'permission-1',
               sessionId: 'session-1',

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -367,11 +367,12 @@ class SessionPersistenceStateOwner {
     delete rendererOwnedSession.runtimeContext
     delete rendererOwnedSession.archivedAt
     const authority = authoritative.status === 'found' ? authoritative.session : undefined
-    const permissionOwnedStatus = authority?.runtimeContext?.permission
-      ? 'waiting-permission'
-      : rendererOwnedSession.status === 'waiting-permission'
-        ? (authority?.status ?? 'idle')
-        : undefined
+    const permissionOwnedStatus =
+      authority?.runtimeContext?.permission?.state === 'pending'
+        ? 'waiting-permission'
+        : rendererOwnedSession.status === 'waiting-permission'
+          ? (authority?.status ?? 'idle')
+          : undefined
     const mainOwnedStatus = permissionOwnedStatus
       ? permissionOwnedStatus
       : authority?.status === 'waiting-plan-approval' ||

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -290,7 +290,7 @@ class SessionPersistenceStateOwner {
     if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 0) {
       throw new Error('Session runtime context expected revision must be a non-negative integer.')
     }
-    if (Object.keys(patch).some((owner) => owner !== 'plan')) {
+    if (Object.keys(patch).some((owner) => owner !== 'plan' && owner !== 'permission')) {
       throw new Error('Session runtime context patch contains an unknown authority owner.')
     }
 
@@ -367,9 +367,15 @@ class SessionPersistenceStateOwner {
     delete rendererOwnedSession.runtimeContext
     delete rendererOwnedSession.archivedAt
     const authority = authoritative.status === 'found' ? authoritative.session : undefined
-    const mainOwnedStatus =
-      authority?.status === 'waiting-plan-approval' ||
-      rendererOwnedSession.status === 'waiting-plan-approval'
+    const permissionOwnedStatus = authority?.runtimeContext?.permission
+      ? 'waiting-permission'
+      : rendererOwnedSession.status === 'waiting-permission'
+        ? (authority?.status ?? 'idle')
+        : undefined
+    const mainOwnedStatus = permissionOwnedStatus
+      ? permissionOwnedStatus
+      : authority?.status === 'waiting-plan-approval' ||
+          rendererOwnedSession.status === 'waiting-plan-approval'
         ? (authority?.status ?? 'idle')
         : undefined
     const mergedSession: PersistedChatSession = {

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -3,10 +3,11 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type {
-  ProjectDeletedEvent,
-  SessionDeletedEvent,
-  SessionUpsertEvent
+import {
+  MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
+  type ProjectDeletedEvent,
+  type SessionDeletedEvent,
+  type SessionUpsertEvent
 } from '../../../shared/lifecycle-events'
 import type { Project } from '../../../shared/projects'
 import { getActiveConversationContext } from '../../../shared/conversation-graph'
@@ -178,6 +179,79 @@ describe('useLifecycleSync', () => {
 
     expect(useSessionStore.getState().sessions[0]?.title).toBe('Updated session')
     expect(container.querySelector<HTMLButtonElement>('button')?.dataset.noticeSession).toBe('')
+  })
+
+  it('merges Main-owned permission authority without replacing live chat state', async () => {
+    useSessionStore.getState().hydrateSessions([session])
+    const prompt = useSessionStore.getState().appendUserMessage({
+      sessionId: session.id,
+      content: 'Run the verification'
+    })
+    const durableBeforeOutput = toPersistedSession(useSessionStore.getState().sessions[0])
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: session.id,
+      streamId: 'run-1',
+      eventId: 'agent-message-1',
+      promptMessageId: prompt?.messageId,
+      content: 'Preparing the command.'
+    })
+
+    await act(async () => {
+      listeners.sessionUpdated?.({
+        originClientId: MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
+        session: {
+          ...durableBeforeOutput,
+          status: 'waiting-permission',
+          updatedAt: durableBeforeOutput.updatedAt + 1,
+          runtimeContext: {
+            version: 1,
+            revision: 1,
+            permission: {
+              state: 'pending',
+              request: {
+                requestId: 'permission-1',
+                sessionId: session.id,
+                toolCallId: 'tool-1',
+                title: 'Run npm test',
+                options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+              },
+              originatingPromptMessageId: prompt!.messageId,
+              fingerprint: 'a'.repeat(64),
+              createdAt: 1
+            }
+          }
+        }
+      })
+    })
+
+    const projected = useSessionStore.getState().sessions[0]
+    expect(projected.status).toBe('waiting-permission')
+    expect(projected.runtimeContext?.permission?.request.requestId).toBe('permission-1')
+    expect(projected.messages.map((message) => message.content)).toEqual([
+      'Run the verification',
+      'Preparing the command.'
+    ])
+    expect(projected.activeRun?.promptMessageId).toBe(prompt?.messageId)
+
+    await act(async () => {
+      listeners.sessionUpdated?.({
+        originClientId: MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
+        session: {
+          ...durableBeforeOutput,
+          status: 'running',
+          updatedAt: durableBeforeOutput.updatedAt + 2,
+          runtimeContext: { version: 1, revision: 2 }
+        }
+      })
+    })
+
+    const settled = useSessionStore.getState().sessions[0]
+    expect(settled.status).toBe('running')
+    expect(settled.runtimeContext?.permission).toBeUndefined()
+    expect(settled.messages.map((message) => message.content)).toEqual([
+      'Run the verification',
+      'Preparing the command.'
+    ])
   })
 
   it("does not roll back live conversation state from this renderer's save echo", async () => {

--- a/src/renderer/src/hooks/useLifecycleSync.ts
+++ b/src/renderer/src/hooks/useLifecycleSync.ts
@@ -1,6 +1,9 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
-import type { SessionUpsertEvent } from '../../../shared/lifecycle-events'
+import {
+  MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
+  type SessionUpsertEvent
+} from '../../../shared/lifecycle-events'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useArchiveUndoStore } from '@/stores/archive-undo-store'
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
@@ -115,7 +118,19 @@ const useLifecycleSync = ({
         // live projection here can discard a prompt and the Runtime Segment used by its artifact
         // claim. Events from other clients remain authoritative synchronization input; same-client
         // command results return through their direct IPC path.
-        if (originClientId !== lifecycleClientIdRef.current) {
+        if (originClientId === MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID) {
+          const store = useSessionStore.getState()
+          const source = store.sessions.find((candidate) => candidate.id === session.id)
+          if (source) {
+            store.applyDurableSessionProjection({
+              source,
+              session,
+              mode: 'permission-authority'
+            })
+          } else {
+            store.upsertPersistedSession(session)
+          }
+        } else if (originClientId !== lifecycleClientIdRef.current) {
           useSessionStore.getState().upsertPersistedSession(session)
         }
         useArchiveUndoStore.getState().reconcileSession(session)

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -91,7 +91,11 @@ const useAcpRuntime = (): {
     planContinuation?: AcpPromptRequest['planContinuation'],
     turnIntent?: AcpPromptRequest['turnIntent']
   ) => Promise<AcpStateSnapshot>
-  respondToPermission: (requestId: string, optionId?: string) => Promise<AcpStateSnapshot>
+  respondToPermission: (
+    requestId: string,
+    optionId?: string,
+    restored?: AcpPermissionResponse['restored']
+  ) => Promise<AcpStateSnapshot>
   respondToElicitation: (response: ElicitationResponse) => Promise<AcpStateSnapshot>
   setPermissionProfile: (
     sessionId: string,
@@ -345,11 +349,16 @@ const useAcpRuntime = (): {
 
   // Converts a UI permission click into the response shape expected by IPC.
   const respondToPermission = useCallback(
-    async (requestId: string, optionId?: string): Promise<AcpStateSnapshot> => {
+    async (
+      requestId: string,
+      optionId?: string,
+      restored?: AcpPermissionResponse['restored']
+    ): Promise<AcpStateSnapshot> => {
       const response: AcpPermissionResponse = {
         requestId,
         optionId,
-        cancelled: !optionId
+        cancelled: !optionId,
+        ...(restored ? { restored } : {})
       }
       setActionError(null)
       try {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -527,6 +527,7 @@ describe('workspace runtime architecture', () => {
     })
     expect(Object.fromEntries(propertyCallCounts(facadeFile, 'runtime'))).toEqual({
       setPermissionProfile: 1,
+      resumeSession: 1,
       respondToPermission: 1,
       revokePermissionGrant: 1
     })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -329,6 +329,7 @@ describe('workspace Agent Runtime hook contract', () => {
           version: 1,
           revision: 1,
           permission: {
+            state: 'pending',
             request,
             originatingPromptMessageId: session.messages[0].id,
             fingerprint: 'a'.repeat(64),
@@ -395,6 +396,7 @@ describe('workspace Agent Runtime hook contract', () => {
           version: 1,
           revision: 1,
           permission: {
+            state: 'pending',
             request,
             originatingPromptMessageId: session.messages[0].id,
             fingerprint: 'a'.repeat(64),

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -422,7 +422,7 @@ describe('workspace Agent Runtime hook contract', () => {
     })
   })
 
-  it('refreshes a re-armed restored permission card after an asynchronous continuation failure', async () => {
+  it('mirrors restored continuation settlement before re-arming an asynchronous failure', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',
       content: 'Run the verification',
@@ -463,11 +463,18 @@ describe('workspace Agent Runtime hook contract', () => {
       await latest.respondToPermission('permission-restored', 'allow-once')
     })
     expect(latest.pendingPermissions).toEqual([])
+    expect(useSessionStore.getState().sessions[0].runtimeContext?.permission?.state).toBe(
+      'continuing'
+    )
 
-    act(() => useSessionStore.getState().failRun('session-1', 'Continuation failed'))
+    act(() => useSessionStore.getState().failRun('session-1', 'Unrelated later failure'))
     await act(async () => Promise.resolve())
+    expect(latest.pendingPermissions).toEqual([])
 
-    // Re-projecting the durable pending authority moves the Session back to its actionable wait.
+    act(() =>
+      useSessionStore.getState().setPermissionPending('session-1', { rearmAuthority: true })
+    )
+    await act(async () => Promise.resolve())
     expect(useSessionStore.getState().sessions[0].status).toBe('waiting-permission')
     expect(latest.pendingPermissions).toEqual([request])
   })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -6,7 +6,11 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 
 import type { AcpCreateSessionResponse, AcpStateSnapshot } from '../../../../shared/acp'
-import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
+import {
+  createInitialSessionState,
+  toPersistedSession,
+  useSessionStore
+} from '../../stores/session-store'
 import { createInitialSettingsState, useSettingsStore } from '../../stores/settings-store'
 import { resetDeferredArtifactEventsForTests } from './workspace-events'
 import { resetWorkspaceRuntimeEventOwnerForTests } from './workspace-runtime-event-owner'
@@ -420,6 +424,65 @@ describe('workspace Agent Runtime hook contract', () => {
       sessionId: 'session-1',
       projectId: 'project-1'
     })
+  })
+
+  it('keeps a newly persisted permission card when its provider disconnects in-process', async () => {
+    const prompt = useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Run the verification',
+      cwd: workspacePath,
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code'
+    })
+    const request = {
+      requestId: 'permission-live',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Run npm test',
+      durable: true as const,
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    const runtime = createRuntime(
+      createSnapshot({ sessionIds: ['session-1'], pendingPermissions: [request] })
+    )
+    runtimeMock.current = runtime
+    await render()
+
+    const source = useSessionStore.getState().sessions[0]
+    act(() =>
+      useSessionStore.getState().applyDurableSessionProjection({
+        source,
+        session: {
+          ...toPersistedSession(source),
+          status: 'waiting-permission',
+          runtimeContext: {
+            version: 1,
+            revision: 1,
+            permission: {
+              state: 'pending',
+              request,
+              originatingPromptMessageId: prompt!.messageId,
+              fingerprint: 'a'.repeat(64),
+              createdAt: 1
+            }
+          }
+        },
+        mode: 'permission-authority'
+      })
+    )
+
+    runtime.state = createSnapshot({
+      status: 'closed',
+      sessionConnectionStatuses: { 'session-1': 'closed' }
+    })
+    await render()
+
+    expect(latest.pendingPermissions).toEqual([request])
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-permission',
+      runtimeContext: { permission: { state: 'pending' } }
+    })
+    expect(useSessionStore.getState().sessions[0].interrupted).toBeUndefined()
   })
 
   it('mirrors restored continuation settlement before re-arming an asynchronous failure', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -370,4 +370,53 @@ describe('workspace Agent Runtime hook contract', () => {
     })
     expect(useSessionStore.getState().sessions[0].status).toBe('idle')
   })
+
+  it('keeps a restored permission card actionable when its response fails', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Run the verification',
+      cwd: workspacePath,
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code'
+    })
+    const request = {
+      requestId: 'permission-restored',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Run npm test',
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'waiting-permission',
+        activeRun: undefined,
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            request,
+            originatingPromptMessageId: session.messages[0].id,
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1
+          }
+        }
+      }))
+    }))
+    const runtime = createRuntime(createSnapshot({ sessionIds: ['session-1'] }))
+    runtime.respondToPermission.mockRejectedValue(new Error('Permission continuation unavailable'))
+    runtimeMock.current = runtime
+    await render()
+
+    await act(async () => {
+      await latest.respondToPermission('permission-restored', 'allow-once')
+    })
+
+    expect(useSessionStore.getState().sessions[0].status).toBe('waiting-permission')
+    expect(latest.pendingPermissions).toEqual([request])
+    expect(runtime.respondToPermission).toHaveBeenCalledWith('permission-restored', 'allow-once', {
+      sessionId: 'session-1',
+      projectId: 'project-1'
+    })
+  })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -295,9 +295,79 @@ describe('workspace Agent Runtime hook contract', () => {
       await latest.revokePermissionGrant('session-1', 'shell:git')
     })
 
-    expect(runtime.respondToPermission).toHaveBeenCalledWith('permission-1', 'allow-once')
+    expect(runtime.respondToPermission).toHaveBeenCalledWith(
+      'permission-1',
+      'allow-once',
+      undefined
+    )
     expect(runtime.setPermissionProfile).toHaveBeenCalledWith('session-1', 'full')
     expect(runtime.revokePermissionGrant).toHaveBeenCalledWith('session-1', 'shell:git')
     expect(useSessionStore.getState().sessions[0]?.permissionProfile).toBe('auto')
+  })
+
+  it('reattaches a restored permission wait before sending its main-validated decision', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Run the verification',
+      cwd: workspacePath,
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code'
+    })
+    const request = {
+      requestId: 'permission-restored',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Run npm test',
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'waiting-permission',
+        activeRun: undefined,
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            request,
+            originatingPromptMessageId: session.messages[0].id,
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1
+          }
+        }
+      }))
+    }))
+    const runtime = createRuntime(createSnapshot())
+    runtime.resumeSession.mockResolvedValue({
+      sessionId: 'session-1',
+      cwd: workspacePath,
+      frameworkId: 'claude-code',
+      backendId: 'claude-code:anthropic',
+      contextReset: false
+    })
+    runtimeMock.current = runtime
+    await render()
+
+    expect(latest.pendingPermissions).toEqual([request])
+    await act(async () => {
+      await latest.respondToPermission('permission-restored', 'allow-once')
+    })
+
+    expect(runtime.resumeSession).toHaveBeenCalledWith(
+      'session-1',
+      workspacePath,
+      'project-1',
+      'ask',
+      'claude-code',
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    )
+    expect(runtime.respondToPermission).toHaveBeenCalledWith('permission-restored', 'allow-once', {
+      sessionId: 'session-1',
+      projectId: 'project-1'
+    })
+    expect(useSessionStore.getState().sessions[0].status).toBe('idle')
   })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -421,4 +421,54 @@ describe('workspace Agent Runtime hook contract', () => {
       projectId: 'project-1'
     })
   })
+
+  it('refreshes a re-armed restored permission card after an asynchronous continuation failure', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Run the verification',
+      cwd: workspacePath,
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code'
+    })
+    const request = {
+      requestId: 'permission-restored',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Run npm test',
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'waiting-permission',
+        activeRun: undefined,
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            state: 'pending',
+            request,
+            originatingPromptMessageId: session.messages[0].id,
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1
+          }
+        }
+      }))
+    }))
+    const runtime = createRuntime(createSnapshot({ sessionIds: ['session-1'] }))
+    runtimeMock.current = runtime
+    await render()
+
+    await act(async () => {
+      await latest.respondToPermission('permission-restored', 'allow-once')
+    })
+    expect(latest.pendingPermissions).toEqual([])
+
+    act(() => useSessionStore.getState().failRun('session-1', 'Continuation failed'))
+    await act(async () => Promise.resolve())
+
+    // Re-projecting the durable pending authority moves the Session back to its actionable wait.
+    expect(useSessionStore.getState().sessions[0].status).toBe('waiting-permission')
+    expect(latest.pendingPermissions).toEqual([request])
+  })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -17,6 +17,7 @@ import {
   createWorkspaceRuntimeEventProcessor,
   getResumeFailureMessage,
   markRunningSessionsDisconnectedOnDrop,
+  pendingWorkspacePermissions,
   processVisibleWorkspaceRuntimeEvents,
   setWorkspacePermissionProfile,
   syncWorkspaceContextUsage
@@ -90,6 +91,50 @@ const flushRuntimeTasks = async (): Promise<void> => {
   await Promise.resolve()
   await Promise.resolve()
 }
+
+describe('workspace permission wait recovery', () => {
+  it('projects a restored main-owned request and prefers a matching live request', () => {
+    useSessionStore.setState(createInitialSessionState())
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Run the verification',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+    const durableRequest = {
+      requestId: 'permission-1',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Run npm test',
+      options: [{ optionId: 'deny', name: 'Deny', kind: 'reject_once' }]
+    }
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'waiting-permission',
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            request: durableRequest,
+            originatingPromptMessageId: session.messages[0].id,
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1
+          }
+        }
+      }))
+    }))
+
+    expect(pendingWorkspacePermissions(useSessionStore.getState().sessions, [])).toEqual([
+      durableRequest
+    ])
+
+    const liveRequest = { ...durableRequest, title: 'Live runtime title' }
+    expect(pendingWorkspacePermissions(useSessionStore.getState().sessions, [liveRequest])).toEqual(
+      [liveRequest]
+    )
+  })
+})
 
 describe('workspace permission profile persistence', () => {
   it('persists the profile committed by the runtime instead of a superseded request', async () => {
@@ -3746,6 +3791,37 @@ describe('resuming an interrupted session on demand', () => {
     const session = useSessionStore.getState().sessions[0]
     expect(session.status).toBe('waiting-for-user')
     expect(session.interrupted).toBeUndefined()
+  })
+
+  it('keeps a durable permission wait actionable when the connection drops', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Run the verification',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().setPermissionPending('session-1')
+
+    markRunningSessionsDisconnectedOnDrop('connected', 'closed', {}, {}, new Set(['session-1']))
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session.status).toBe('waiting-permission')
+    expect(session.interrupted).toBeUndefined()
+  })
+
+  it('interrupts a non-durable permission wait when the connection drops', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Approve an in-memory action',
+      cwd: '/workspace/project'
+    })
+    useSessionStore.getState().setPermissionPending('session-1')
+
+    markRunningSessionsDisconnectedOnDrop('connected', 'closed')
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      interrupted: true
+    })
   })
 
   it('reconnects and continues the interrupted turn without duplicating its user message', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -133,6 +133,17 @@ describe('workspace permission wait recovery', () => {
     expect(pendingWorkspacePermissions(useSessionStore.getState().sessions, [liveRequest])).toEqual(
       [liveRequest]
     )
+
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === 'session-1'
+          ? { ...session, status: 'error', error: 'Continuation failed' }
+          : session
+      )
+    }))
+    expect(pendingWorkspacePermissions(useSessionStore.getState().sessions, [])).toEqual([
+      durableRequest
+    ])
   })
 })
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -116,6 +116,7 @@ describe('workspace permission wait recovery', () => {
           version: 1,
           revision: 1,
           permission: {
+            state: 'pending',
             request: durableRequest,
             originatingPromptMessageId: session.messages[0].id,
             fingerprint: 'a'.repeat(64),
@@ -144,6 +145,19 @@ describe('workspace permission wait recovery', () => {
     expect(pendingWorkspacePermissions(useSessionStore.getState().sessions, [])).toEqual([
       durableRequest
     ])
+
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        runtimeContext: session.runtimeContext?.permission
+          ? {
+              ...session.runtimeContext,
+              permission: { ...session.runtimeContext.permission, state: 'continuing' }
+            }
+          : session.runtimeContext
+      }))
+    }))
+    expect(pendingWorkspacePermissions(useSessionStore.getState().sessions, [])).toEqual([])
   })
 })
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -27,7 +27,6 @@ import { useSessionStore, type ChatSession } from '../../stores/session-store'
 import { useSettingsStore } from '../../stores/settings-store'
 import { useAcpRuntime } from './useAcpRuntime'
 import {
-  buildWorkspaceHistoryReplay,
   resolveHistoryReplayTarget,
   resolveSessionHistoryReplayDescriptor,
   type HistoryReplayDescriptor
@@ -133,8 +132,15 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     JSON.stringify(
       state.sessions.flatMap((session) => {
         const permission = session.runtimeContext?.permission
-        return session.status === 'waiting-permission' && permission?.state === 'pending'
-          ? [[session.id, session.runtimeContext?.revision, permission.request.requestId]]
+        return permission?.state === 'pending'
+          ? [
+              [
+                session.id,
+                session.runtimeContext?.revision,
+                permission.request.requestId,
+                session.status
+              ]
+            ]
           : []
       })
     )
@@ -180,13 +186,6 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     },
     [agentFrameworks, providers]
   )
-  const getSessionSupportsImageInput = useCallback(
-    (session: ChatSession): boolean =>
-      providers.find(
-        (candidate) => session.agentBackendId === `${session.agentFrameworkId}:${candidate.id}`
-      )?.supportsImageInput ?? false,
-    [providers]
-  )
   const [lifecycleOwner] = useState(createWorkspaceRuntimeSessionLifecycleOwner)
   const pendingPermissions = useMemo(
     () => pendingWorkspacePermissions(restoredPermissionSessions, runtime.state.pendingPermissions),
@@ -216,7 +215,11 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
           .filter((request) => request.durable)
           .map((request) => request.sessionId),
         ...restoredPermissionSessions
-          .filter((session) => session.runtimeContext?.permission?.state === 'pending')
+          .filter(
+            (session) =>
+              (session.status === 'waiting-permission' || session.status === 'error') &&
+              session.runtimeContext?.permission?.state === 'pending'
+          )
           .map((session) => session.id)
       ])
     ).sort()
@@ -366,7 +369,6 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
             .getState()
             .sessions.find((candidate) => candidate.id === request.sessionId)
           if (!session) throw new Error(`Session not found: ${request.sessionId}`)
-          let contextReset = false
           if (!runtime.state.sessionIds.includes(request.sessionId)) {
             const cwd = session.cwd || runtime.state.cwd
             if (!cwd) throw new Error('Choose a workspace folder before resuming this Session.')
@@ -396,32 +398,14 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
             // until the restored decision is accepted so a retryable response failure cannot make
             // the card disappear from the renderer projection.
             useSessionStore.getState().setPermissionPending(session.id)
-            contextReset = resumed?.contextReset === true
             session = useSessionStore
               .getState()
               .sessions.find((candidate) => candidate.id === request.sessionId)
             if (!session) throw new Error(`Session not found: ${request.sessionId}`)
           }
-          const replay = contextReset
-            ? buildWorkspaceHistoryReplay(
-                session.messages,
-                getSessionHistoryReplayDescriptor(session.id),
-                session.projectId,
-                getSessionSupportsImageInput(session)
-              )
-            : undefined
           restored = {
             sessionId: session.id,
-            projectId: session.projectId,
-            ...(replay
-              ? {
-                  historyReplay: {
-                    historyPreamble: replay.historyPreamble,
-                    historyAttachments: replay.historyAttachments,
-                    historyImages: replay.historyImages
-                  }
-                }
-              : {})
+            projectId: session.projectId
           }
         }
         await runtime.respondToPermission(requestId, optionId, restored)
@@ -438,7 +422,7 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
         }
       }
     },
-    [getSessionHistoryReplayDescriptor, getSessionSupportsImageInput, pendingPermissions, runtime]
+    [pendingPermissions, runtime]
   )
   const setPermissionProfile = useCallback(
     (sessionId: string, profile: PermissionProfileId): Promise<boolean> =>

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -70,9 +70,11 @@ const pendingWorkspacePermissions = (
   const liveRequestIds = new Set(liveRequests.map((request) => request.requestId))
   const restoredRequests: AcpPermissionRequest[] = []
   for (const session of sessions) {
-    const request = session.runtimeContext?.permission?.request
+    const permission = session.runtimeContext?.permission
+    const request = permission?.request
     if (
       (session.status === 'waiting-permission' || session.status === 'error') &&
+      permission?.state === 'pending' &&
       request?.sessionId === session.id &&
       !liveRequestIds.has(request.requestId)
     ) {
@@ -131,7 +133,7 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     JSON.stringify(
       state.sessions.flatMap((session) => {
         const permission = session.runtimeContext?.permission
-        return session.status === 'waiting-permission' && permission
+        return session.status === 'waiting-permission' && permission?.state === 'pending'
           ? [[session.id, session.runtimeContext?.revision, permission.request.requestId]]
           : []
       })
@@ -214,7 +216,7 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
           .filter((request) => request.durable)
           .map((request) => request.sessionId),
         ...restoredPermissionSessions
-          .filter((session) => session.runtimeContext?.permission)
+          .filter((session) => session.runtimeContext?.permission?.state === 'pending')
           .map((session) => session.id)
       ])
     ).sort()

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -72,7 +72,7 @@ const pendingWorkspacePermissions = (
   for (const session of sessions) {
     const request = session.runtimeContext?.permission?.request
     if (
-      session.status === 'waiting-permission' &&
+      (session.status === 'waiting-permission' || session.status === 'error') &&
       request?.sessionId === session.id &&
       !liveRequestIds.has(request.requestId)
     ) {
@@ -353,10 +353,13 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const respondToPermission = useCallback(
     async (requestId: string, optionId?: string): Promise<void> => {
       const request = pendingPermissions.find((item) => item.requestId === requestId)
+      const isRestoredRequest = Boolean(
+        request &&
+        !runtime.state.pendingPermissions.some((item) => item.requestId === request.requestId)
+      )
       try {
-        const live = runtime.state.pendingPermissions.some((item) => item.requestId === requestId)
         let restored: AcpPermissionResponse['restored']
-        if (request && !live) {
+        if (request && isRestoredRequest) {
           let session = useSessionStore
             .getState()
             .sessions.find((candidate) => candidate.id === request.sessionId)
@@ -424,7 +427,13 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
           useSessionStore.getState().clearPermissionPending(request.sessionId)
         }
       } catch (error) {
-        if (request) useSessionStore.getState().failRun(request.sessionId, getErrorMessage(error))
+        if (request && isRestoredRequest) {
+          // The main-owned authority is still valid. Keep the card actionable; useAcpRuntime retains
+          // the transient action error separately for the active Session to display.
+          useSessionStore.getState().setPermissionPending(request.sessionId)
+        } else if (request) {
+          useSessionStore.getState().failRun(request.sessionId, getErrorMessage(error))
+        }
       }
     },
     [getSessionHistoryReplayDescriptor, getSessionSupportsImageInput, pendingPermissions, runtime]

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -410,13 +410,22 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
         }
         await runtime.respondToPermission(requestId, optionId, restored)
         if (request && restored) {
-          useSessionStore.getState().clearPermissionPending(request.sessionId)
+          useSessionStore.getState().clearPermissionPending(request.sessionId, {
+            authority: 'continuing',
+            requestId
+          })
         }
       } catch (error) {
         if (request && isRestoredRequest) {
           // The main-owned authority is still valid. Keep the card actionable; useAcpRuntime retains
           // the transient action error separately for the active Session to display.
-          useSessionStore.getState().setPermissionPending(request.sessionId)
+          const permission = useSessionStore
+            .getState()
+            .sessions.find((session) => session.id === request.sessionId)
+            ?.runtimeContext?.permission
+          if (permission?.state === 'pending') {
+            useSessionStore.getState().setPermissionPending(request.sessionId)
+          }
         } else if (request) {
           useSessionStore.getState().failRun(request.sessionId, getErrorMessage(error))
         }

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -14,17 +14,20 @@ import {
 import type {
   AcpContextUsage,
   AcpPermissionGrant,
-  AcpPermissionRequest
+  AcpPermissionRequest,
+  AcpPermissionResponse
 } from '../../../../shared/acp'
 import {
+  DEFAULT_PERMISSION_PROFILE,
   type PermissionProfileId,
   type SessionPermissionProfileState
 } from '../../../../shared/permission-profiles'
 import { resolveModelContextWindow } from '../../../../shared/provider-registry'
-import { useSessionStore } from '../../stores/session-store'
+import { useSessionStore, type ChatSession } from '../../stores/session-store'
 import { useSettingsStore } from '../../stores/settings-store'
 import { useAcpRuntime } from './useAcpRuntime'
 import {
+  buildWorkspaceHistoryReplay,
   resolveHistoryReplayTarget,
   resolveSessionHistoryReplayDescriptor,
   type HistoryReplayDescriptor
@@ -59,6 +62,25 @@ type WorkspacePermissionProfileRuntime = Pick<
 const EMPTY_AGENT_PROMPT_IN_FLIGHT_SESSION_IDS: string[] = []
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
+
+const pendingWorkspacePermissions = (
+  sessions: ChatSession[],
+  liveRequests: AcpPermissionRequest[]
+): AcpPermissionRequest[] => {
+  const liveRequestIds = new Set(liveRequests.map((request) => request.requestId))
+  const restoredRequests: AcpPermissionRequest[] = []
+  for (const session of sessions) {
+    const request = session.runtimeContext?.permission?.request
+    if (
+      session.status === 'waiting-permission' &&
+      request?.sessionId === session.id &&
+      !liveRequestIds.has(request.requestId)
+    ) {
+      restoredRequests.push(request)
+    }
+  }
+  return restoredRequests.length > 0 ? [...liveRequests, ...restoredRequests] : liveRequests
+}
 
 const setWorkspacePermissionProfile = async (
   runtime: WorkspacePermissionProfileRuntime,
@@ -105,6 +127,21 @@ const WorkspaceAgentRuntimeContext = createContext<WorkspaceAgentRuntime | null>
 
 const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const runtime = useAcpRuntime()
+  const restoredPermissionProjectionKey = useSessionStore((state) =>
+    JSON.stringify(
+      state.sessions.flatMap((session) => {
+        const permission = session.runtimeContext?.permission
+        return session.status === 'waiting-permission' && permission
+          ? [[session.id, session.runtimeContext?.revision, permission.request.requestId]]
+          : []
+      })
+    )
+  )
+  const restoredPermissionSessions = useMemo(() => {
+    // The primitive projection key intentionally controls when this store snapshot is refreshed.
+    void restoredPermissionProjectionKey
+    return useSessionStore.getState().sessions
+  }, [restoredPermissionProjectionKey])
   const activeProvider = useSettingsStore((state) =>
     state.providers.find((candidate) => candidate.id === state.activeProviderId)
   )
@@ -141,7 +178,18 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     },
     [agentFrameworks, providers]
   )
+  const getSessionSupportsImageInput = useCallback(
+    (session: ChatSession): boolean =>
+      providers.find(
+        (candidate) => session.agentBackendId === `${session.agentFrameworkId}:${candidate.id}`
+      )?.supportsImageInput ?? false,
+    [providers]
+  )
   const [lifecycleOwner] = useState(createWorkspaceRuntimeSessionLifecycleOwner)
+  const pendingPermissions = useMemo(
+    () => pendingWorkspacePermissions(restoredPermissionSessions, runtime.state.pendingPermissions),
+    [restoredPermissionSessions, runtime.state.pendingPermissions]
+  )
   const [sendPreparationInFlightSessionIds, setSendPreparationInFlightSessionIds] = useState<
     string[]
   >([])
@@ -158,6 +206,23 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const drainRuntimeEvents = drainWorkspaceRuntimeEventsForPersistence
   const previousStatusRef = useRef(runtime.state.status)
   const previousSessionStatusesRef = useRef(runtime.state.sessionConnectionStatuses)
+  const previousDurablePermissionSessionIdsRef = useRef<ReadonlySet<string>>(new Set())
+  const durablePermissionSessionIdsKey = JSON.stringify(
+    Array.from(
+      new Set([
+        ...runtime.state.pendingPermissions
+          .filter((request) => request.durable)
+          .map((request) => request.sessionId),
+        ...restoredPermissionSessions
+          .filter((session) => session.runtimeContext?.permission)
+          .map((session) => session.id)
+      ])
+    ).sort()
+  )
+  const durablePermissionSessionIds = useMemo<ReadonlySet<string>>(
+    () => new Set(JSON.parse(durablePermissionSessionIdsKey) as string[]),
+    [durablePermissionSessionIdsKey]
+  )
 
   // Recover overflow before the event projection can surface its raw error or clear the neutral lock.
   useEffect(() => {
@@ -176,9 +241,9 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   }, [agentPromptInFlightSessionIds, runtime.state.events])
 
   useEffect(() => {
-    syncWorkspacePermissionState(runtime.state.pendingPermissions)
+    syncWorkspacePermissionState(pendingPermissions)
     syncWorkspaceElicitationState(runtime.state.pendingElicitations ?? [])
-  }, [runtime.state.pendingElicitations, runtime.state.pendingPermissions])
+  }, [pendingPermissions, runtime.state.pendingElicitations])
 
   useEffect(() => {
     syncWorkspaceContextUsage(runtime.state.sessionIds, runtime.state.contextUsageBySession)
@@ -187,15 +252,18 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   useEffect(() => {
     const previousStatus = previousStatusRef.current
     const previousSessionStatuses = previousSessionStatusesRef.current
+    const previousDurablePermissionSessionIds = previousDurablePermissionSessionIdsRef.current
     previousStatusRef.current = runtime.state.status
     previousSessionStatusesRef.current = runtime.state.sessionConnectionStatuses
+    previousDurablePermissionSessionIdsRef.current = durablePermissionSessionIds
     markRunningSessionsDisconnectedOnDrop(
       previousStatus,
       runtime.state.status,
       previousSessionStatuses,
-      runtime.state.sessionConnectionStatuses
+      runtime.state.sessionConnectionStatuses,
+      new Set([...previousDurablePermissionSessionIds, ...durablePermissionSessionIds])
     )
-  }, [runtime.state.status, runtime.state.sessionConnectionStatuses])
+  }, [durablePermissionSessionIds, runtime.state.status, runtime.state.sessionConnectionStatuses])
 
   const sendMessage = useCallback(
     (input: SendWorkspaceMessageInput): Promise<SendWorkspaceMessageResult | undefined> => {
@@ -284,14 +352,82 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   )
   const respondToPermission = useCallback(
     async (requestId: string, optionId?: string): Promise<void> => {
-      const request = runtime.state.pendingPermissions.find((item) => item.requestId === requestId)
+      const request = pendingPermissions.find((item) => item.requestId === requestId)
       try {
-        await runtime.respondToPermission(requestId, optionId)
+        const live = runtime.state.pendingPermissions.some((item) => item.requestId === requestId)
+        let restored: AcpPermissionResponse['restored']
+        if (request && !live) {
+          let session = useSessionStore
+            .getState()
+            .sessions.find((candidate) => candidate.id === request.sessionId)
+          if (!session) throw new Error(`Session not found: ${request.sessionId}`)
+          let contextReset = false
+          if (!runtime.state.sessionIds.includes(request.sessionId)) {
+            const cwd = session.cwd || runtime.state.cwd
+            if (!cwd) throw new Error('Choose a workspace folder before resuming this Session.')
+            const resumed = await runtime.resumeSession(
+              session.id,
+              cwd,
+              session.projectId,
+              session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+              session.agentFrameworkId,
+              session.agentBackendId,
+              session.specialistId,
+              session.providerSessionId,
+              session.providerContinuityToken
+            )
+            useSessionStore.getState().markResumed(
+              session.id,
+              resumed
+                ? {
+                    agentFrameworkId: resumed.frameworkId,
+                    agentBackendId: resumed.backendId,
+                    providerSessionId: resumed.providerSessionId,
+                    providerContinuityToken: resumed.providerContinuityToken
+                  }
+                : undefined
+            )
+            // markResumed clears generic interrupted state to idle. Re-arm this main-owned wait
+            // until the restored decision is accepted so a retryable response failure cannot make
+            // the card disappear from the renderer projection.
+            useSessionStore.getState().setPermissionPending(session.id)
+            contextReset = resumed?.contextReset === true
+            session = useSessionStore
+              .getState()
+              .sessions.find((candidate) => candidate.id === request.sessionId)
+            if (!session) throw new Error(`Session not found: ${request.sessionId}`)
+          }
+          const replay = contextReset
+            ? buildWorkspaceHistoryReplay(
+                session.messages,
+                getSessionHistoryReplayDescriptor(session.id),
+                session.projectId,
+                getSessionSupportsImageInput(session)
+              )
+            : undefined
+          restored = {
+            sessionId: session.id,
+            projectId: session.projectId,
+            ...(replay
+              ? {
+                  historyReplay: {
+                    historyPreamble: replay.historyPreamble,
+                    historyAttachments: replay.historyAttachments,
+                    historyImages: replay.historyImages
+                  }
+                }
+              : {})
+          }
+        }
+        await runtime.respondToPermission(requestId, optionId, restored)
+        if (request && restored) {
+          useSessionStore.getState().clearPermissionPending(request.sessionId)
+        }
       } catch (error) {
         if (request) useSessionStore.getState().failRun(request.sessionId, getErrorMessage(error))
       }
     },
-    [runtime]
+    [getSessionHistoryReplayDescriptor, getSessionSupportsImageInput, pendingPermissions, runtime]
   )
   const setPermissionProfile = useCallback(
     (sessionId: string, profile: PermissionProfileId): Promise<boolean> =>
@@ -309,7 +445,7 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   return {
     actionError: runtime.actionError,
     isConnecting: runtime.isConnecting,
-    pendingPermissions: runtime.state.pendingPermissions,
+    pendingPermissions,
     permissionProfiles: runtime.state.permissionProfiles,
     permissionGrants: runtime.state.permissionGrants,
     contextUsageBySession: runtime.state.contextUsageBySession,
@@ -351,6 +487,7 @@ export {
   markRunningSessionsDisconnectedOnDrop,
   processVisibleWorkspaceRuntimeEvents,
   setWorkspacePermissionProfile,
+  pendingWorkspacePermissions,
   syncWorkspaceContextUsage,
   syncWorkspaceInteractionState,
   useWorkspaceAgentRuntime

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -1,4 +1,9 @@
-import type { AcpRuntimeEvent, AcpPermissionRequest } from '../../../../shared/acp'
+import {
+  ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+  type AcpRuntimeEvent,
+  type AcpPermissionRequest
+} from '../../../../shared/acp'
 import {
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile
@@ -805,6 +810,48 @@ describe('workspace runtime events', () => {
     syncWorkspacePermissionState([])
 
     expect(useSessionStore.getState().sessions[0].status).toBe('running')
+  })
+
+  it('mirrors restored permission rearm and clear events into the local authority projection', async () => {
+    const request = createPermissionRequest()
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'idle',
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            state: 'continuing',
+            request,
+            originatingPromptMessageId: session.messages[0].id,
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1
+          }
+        }
+      }))
+    }))
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'permission-rearmed',
+        kind: 'permission',
+        title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
+      })
+    )
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-permission',
+      runtimeContext: { permission: { state: 'pending' } }
+    })
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'permission-settled',
+        kind: 'permission',
+        title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE
+      })
+    )
+    expect(useSessionStore.getState().sessions[0].runtimeContext?.permission).toBeUndefined()
   })
 
   it('syncs first-output waiting only for known foreground workspace sessions', () => {

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -1,5 +1,9 @@
 import {
   ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME,
+  ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
   type AcpRuntimeEvent,
   type AcpTurnTokenUsage
 } from '../../../../shared/acp'
@@ -479,6 +483,21 @@ const applyWorkspaceRuntimeEvent = async (
   dependencies: WorkspaceRuntimeEventDependencies = {}
 ): Promise<boolean> => {
   const store = useSessionStore.getState()
+
+  if (event.kind === 'permission' && event.sessionId) {
+    if (event.title === ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE) {
+      store.setPermissionPending(event.sessionId, { rearmAuthority: true })
+      return true
+    }
+    if (
+      event.title === ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE ||
+      event.title === ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE ||
+      event.title === ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE
+    ) {
+      store.clearPermissionPending(event.sessionId, { authority: 'settled' })
+      return true
+    }
+  }
 
   // A routed user Message is persisted by main before broadcast. Project that same Message locally
   // without treating it as a fresh prompt or starting another run.

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -303,24 +303,26 @@ const processWorkspaceRuntimeEvents = (
   return liveWorkspaceRuntimeEventProcessor.process(events)
 }
 
-// Flags sessions with an active prompt or native compaction as disconnected on a transition into a
-// dropped connection state.
+// Flags sessions with a live Agent operation as disconnected on a transition into a dropped
+// connection state. Durable permission waits are intentionally quiescent: their provider RPC can
+// disappear while the persisted card remains actionable after a later resume.
 const markRunningSessionsDisconnectedOnDrop = (
   previousStatus: AcpConnectionStatus,
   currentStatus: AcpConnectionStatus,
   previousSessionStatuses: Partial<Record<string, AcpConnectionStatus>> = {},
-  currentSessionStatuses: Partial<Record<string, AcpConnectionStatus>> = {}
+  currentSessionStatuses: Partial<Record<string, AcpConnectionStatus>> = {},
+  durablePermissionSessionIds: ReadonlySet<string> = new Set()
 ): void => {
   const { sessions, markDisconnected } = useSessionStore.getState()
 
   for (const session of sessions) {
-    if (
-      session.status !== 'running' &&
-      session.status !== 'waiting-permission' &&
-      !session.compacting
-    ) {
+    const isPermissionWait = session.status === 'waiting-permission'
+    const isDurablePermissionWait = isPermissionWait && durablePermissionSessionIds.has(session.id)
+    if (session.status !== 'running' && !isPermissionWait && !session.compacting) {
       continue
     }
+
+    if (isDurablePermissionWait) continue
 
     const previousOwnedStatus = previousSessionStatuses[session.id]
     const currentOwnedStatus = currentSessionStatuses[session.id]

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -26,6 +26,7 @@ import { type ComposerDoc } from './composer/composer-doc'
 
 // Capture the ConversationPanel props the page computes, notably canSendMessage and the draft callback.
 let conversationProps: {
+  actionError: string | null
   draftDoc: ComposerDoc
   canEditDraft: boolean
   canSendMessage: boolean
@@ -42,6 +43,7 @@ let conversationProps: {
 }
 
 const runtime = vi.hoisted(() => ({
+  actionError: null as string | null,
   promptInFlightSessionIds: [] as string[],
   sendPreparationInFlightSessionIds: [] as string[],
   nativeContextCompactionSessionIds: ['sess-a'] as string[],
@@ -64,7 +66,7 @@ vi.mock('@/components/ui/resizable', () => ({
 
 vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
   useWorkspaceAgentRuntime: () => ({
-    actionError: null,
+    actionError: runtime.actionError,
     pendingPermissions: [],
     promptInFlightSessionIds: runtime.promptInFlightSessionIds,
     sendPreparationInFlightSessionIds: runtime.sendPreparationInFlightSessionIds,
@@ -175,6 +177,7 @@ describe('WorkspacePage send gate while compacting', () => {
       selectedSessionId: 'sess-a'
     })
     vi.clearAllMocks()
+    runtime.actionError = null
     runtime.promptInFlightSessionIds = []
     runtime.sendPreparationInFlightSessionIds = []
     runtime.nativeContextCompactionSessionIds = ['sess-a']
@@ -599,5 +602,42 @@ describe('WorkspacePage send gate while compacting', () => {
     expect(conversationProps.compactContextDisabledReason).toBe(
       'Resolve the current session error before compacting.'
     )
+  })
+
+  it('surfaces restored permission retry errors without replacing the authorization card', async () => {
+    runtime.actionError = 'Permission response failed'
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'waiting-permission',
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            request: {
+              requestId: 'permission-restored',
+              sessionId: session.id,
+              toolCallId: 'tool-1',
+              title: 'Run npm test',
+              options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+            },
+            originatingPromptMessageId: 'prompt-1',
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1
+          }
+        }
+      }))
+    }))
+    await renderPage()
+
+    expect(conversationProps.actionError).toBe('Permission response failed')
+
+    runtime.actionError = null
+    await act(async () => {
+      useSessionStore.getState().failRun('sess-a', 'Continuation failed')
+      useSessionStore.getState().setPermissionPending('sess-a')
+    })
+
+    expect(conversationProps.actionError).toBe('Continuation failed')
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -614,6 +614,7 @@ describe('WorkspacePage send gate while compacting', () => {
           version: 1,
           revision: 1,
           permission: {
+            state: 'pending',
             request: {
               requestId: 'permission-restored',
               sessionId: session.id,

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -469,8 +469,14 @@ const WorkspacePage = ({
     : activeSession?.status === 'error'
       ? 'Resolve the current session error before compacting.'
       : 'Wait for the current agent activity to finish.'
+  const durablePermissionError =
+    activeSession?.status === 'waiting-permission' && activeSession.runtimeContext?.permission
+      ? (activeSession.error ?? actionError)
+      : null
   const visibleActionError =
-    attachmentError ?? sessionController.view.exportError ?? (activeSession ? null : actionError)
+    attachmentError ??
+    sessionController.view.exportError ??
+    (activeSession ? durablePermissionError : actionError)
 
   const compactActiveContext = useCallback((): void => {
     if (!activeSession || !canCompactContext) return

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -470,7 +470,8 @@ const WorkspacePage = ({
       ? 'Resolve the current session error before compacting.'
       : 'Wait for the current agent activity to finish.'
   const durablePermissionError =
-    activeSession?.status === 'waiting-permission' && activeSession.runtimeContext?.permission
+    activeSession?.status === 'waiting-permission' &&
+    activeSession.runtimeContext?.permission?.state === 'pending'
       ? (activeSession.error ?? actionError)
       : null
   const visibleActionError =

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -99,7 +99,7 @@ export type SessionHydrationSelection = {
 export type ApplyDurableSessionProjectionInput = {
   source: ChatSession
   session: PersistedChatSession
-  mode?: 'merge-upload-identities' | 'replace-persisted-if-current'
+  mode?: 'merge-upload-identities' | 'replace-persisted-if-current' | 'permission-authority'
 }
 
 export type SessionPersistenceActions = {
@@ -417,6 +417,31 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
     set((state) => {
       const current = state.sessions.find((candidate) => candidate.id === session.id)
       if (!current) return state
+
+      if (mode === 'permission-authority') {
+        const permissionPending = session.runtimeContext?.permission?.state === 'pending'
+        const status = permissionPending
+          ? current.status === 'waiting-for-user' || current.status === 'waiting-plan-approval'
+            ? current.status
+            : 'waiting-permission'
+          : current.status === 'waiting-permission'
+            ? current.activeRun || current.agentPromptInFlight
+              ? 'running'
+              : 'idle'
+            : current.status
+        const projected: ChatSession = {
+          ...current,
+          status,
+          runtimeContext: session.runtimeContext,
+          updatedAt: Math.max(current.updatedAt, session.updatedAt)
+        }
+        externallyHydratedSessions.add(projected)
+        return {
+          sessions: state.sessions.map((candidate) =>
+            candidate.id === session.id ? projected : candidate
+          )
+        } as Partial<State>
+      }
 
       let projected: ChatSession
       if (current === source && mode === 'replace-persisted-if-current') {

--- a/src/renderer/src/stores/session-store-run-projection-owner.ts
+++ b/src/renderer/src/stores/session-store-run-projection-owner.ts
@@ -42,7 +42,9 @@ import {
   projectElicitationPending,
   projectFailedRun,
   projectFinishedRun,
-  projectInterruptedRun
+  projectInterruptedRun,
+  projectPermissionCleared,
+  projectPermissionPending
 } from './session-store-run-terminal-helpers'
 import type { ChatSession, SessionStoreData } from './session-store-persistence-owner'
 
@@ -53,6 +55,11 @@ export type SessionRunProjectionActions = {
   setAwaitingFirstAgentOutput: (sessionId: string, waiting: boolean) => void
   setAgentPromptInFlight: (sessionId: string, inFlight: boolean) => void
   setElicitationPending: (sessionId: string, pending: boolean) => void
+  setPermissionPending: (sessionId: string, options?: { rearmAuthority?: boolean }) => void
+  clearPermissionPending: (
+    sessionId: string,
+    options?: { authority?: 'continuing' | 'settled'; requestId?: string }
+  ) => void
   attachRunArtifacts: (input: AttachRunArtifactsInput) => AppendMessageResult | undefined
   replaceMessageArtifacts: (input: ReplaceMessageArtifactsInput) => void
   replaceMessageUploads: (input: ReplaceMessageUploadsInput) => void
@@ -162,6 +169,22 @@ export const createSessionRunProjectionOwner = <
       setSessionState((state) => ({
         sessions: projectSession(state.sessions, sessionId, (session) =>
           projectElicitationPending(session, pending)
+        )
+      }))
+    },
+
+    setPermissionPending: (sessionId, options) => {
+      setSessionState((state) => ({
+        sessions: projectSession(state.sessions, sessionId, (session) =>
+          projectPermissionPending(session, options?.rearmAuthority)
+        )
+      }))
+    },
+
+    clearPermissionPending: (sessionId, options) => {
+      setSessionState((state) => ({
+        sessions: projectSession(state.sessions, sessionId, (session) =>
+          projectPermissionCleared(session, options?.authority, options?.requestId)
         )
       }))
     },

--- a/src/renderer/src/stores/session-store-run-terminal-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-terminal-helpers.ts
@@ -163,6 +163,58 @@ export const projectElicitationPending = (session: ChatSession, pending: boolean
   }
 }
 
+export const projectPermissionPending = (
+  session: ChatSession,
+  rearmAuthority = false
+): ChatSession => {
+  const runtimeContext = session.runtimeContext
+  const permission = runtimeContext?.permission
+  if (rearmAuthority && (!runtimeContext || permission?.state !== 'continuing')) return session
+  let nextRuntimeContext = runtimeContext
+  if (rearmAuthority && runtimeContext && permission) {
+    nextRuntimeContext = { ...runtimeContext, permission: { ...permission, state: 'pending' } }
+  }
+  const status =
+    session.status === 'waiting-for-user' || session.status === 'waiting-plan-approval'
+      ? session.status
+      : 'waiting-permission'
+  if (nextRuntimeContext === runtimeContext && status === session.status) return session
+  return { ...session, runtimeContext: nextRuntimeContext, status, updatedAt: Date.now() }
+}
+
+export const projectPermissionCleared = (
+  session: ChatSession,
+  authority?: 'continuing' | 'settled',
+  requestId?: string
+): ChatSession => {
+  const runtimeContext = session.runtimeContext
+  const permission = runtimeContext?.permission
+  if (
+    authority === 'continuing' &&
+    (!runtimeContext ||
+      permission?.state !== 'pending' ||
+      permission.request.requestId !== requestId)
+  ) {
+    return session
+  }
+  let nextRuntimeContext = runtimeContext
+  if (authority === 'continuing' && runtimeContext && permission) {
+    nextRuntimeContext = { ...runtimeContext, permission: { ...permission, state: 'continuing' } }
+  } else if (authority === 'settled' && runtimeContext && permission) {
+    const settledRuntimeContext = { ...runtimeContext }
+    delete settledRuntimeContext.permission
+    nextRuntimeContext = settledRuntimeContext
+  }
+  const status =
+    session.status === 'waiting-permission'
+      ? session.activeRun || session.agentPromptInFlight
+        ? 'running'
+        : 'idle'
+      : session.status
+  if (nextRuntimeContext === runtimeContext && status === session.status) return session
+  return { ...session, runtimeContext: nextRuntimeContext, status, updatedAt: Date.now() }
+}
+
 export const projectArtifactError = (session: ChatSession, error: string): ChatSession => ({
   ...session,
   status: 'error',

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -896,7 +896,6 @@ describe('Session Store architecture', () => {
     ])
     expect(facadeActionNames(facadeSource)).toEqual([
       'clearBranchContextReset',
-      'clearPermissionPending',
       'clearSelection',
       'clearSpecialistSwitchResetRequired',
       'deleteSession',
@@ -910,7 +909,6 @@ describe('Session Store architecture', () => {
       'setContextUsage',
       'setEnabledComputeHosts',
       'setFixLoopActive',
-      'setPermissionPending',
       'setPermissionProfile',
       'setSessionSpecialistId',
       'togglePinned',
@@ -947,6 +945,7 @@ describe('Session Store architecture', () => {
       'beginCompaction',
       'clearArtifactError',
       'clearPendingHistoryReplay',
+      'clearPermissionPending',
       'completeActivityGroup',
       'completeInterruptedTurnResume',
       'failCompaction',
@@ -965,6 +964,7 @@ describe('Session Store architecture', () => {
       'setAwaitingFirstAgentOutput',
       'setElicitationDraftAnswers',
       'setElicitationPending',
+      'setPermissionPending',
       'upsertToolActivity'
     ])
   })

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1361,6 +1361,58 @@ describe('session store', () => {
     expect(useSessionStore.getState().sessions[0].status).toBe('running')
   })
 
+  it('mirrors restored permission authority through continuing, rearm, and settlement', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Run npm test'
+    })
+    useSessionStore.getState().finishRun('transport-session-1')
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'waiting-permission',
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            state: 'pending',
+            request: {
+              requestId: 'permission-restored',
+              sessionId: session.id,
+              toolCallId: 'tool-1',
+              title: 'Run npm test',
+              options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+            },
+            originatingPromptMessageId: session.messages[0].id,
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1
+          }
+        }
+      }))
+    }))
+
+    useSessionStore.getState().clearPermissionPending('transport-session-1', {
+      authority: 'continuing',
+      requestId: 'permission-restored'
+    })
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'idle',
+      runtimeContext: { permission: { state: 'continuing' } }
+    })
+
+    useSessionStore.getState().setPermissionPending('transport-session-1', { rearmAuthority: true })
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-permission',
+      runtimeContext: { permission: { state: 'pending' } }
+    })
+
+    useSessionStore
+      .getState()
+      .clearPermissionPending('transport-session-1', { authority: 'settled' })
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({ status: 'idle' })
+    expect(useSessionStore.getState().sessions[0].runtimeContext?.permission).toBeUndefined()
+  })
+
   it('tracks user-input waiting and resumes a runtime-owned continuation immediately', () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -47,8 +47,6 @@ type SessionStore = SessionStoreData &
     clearBranchContextReset: (sessionId: string) => void
     markSpecialistSwitchResetRequired: (sessionId: string) => void
     clearSpecialistSwitchResetRequired: (sessionId: string) => void
-    setPermissionPending: (sessionId: string) => void
-    clearPermissionPending: (sessionId: string) => void
     setContextUsage: (sessionId: string, contextUsage: AcpContextUsage | undefined) => void
     setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => void
     // Persists the per-session auto-review toggle. true = on; false = off (default).
@@ -142,39 +140,6 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       sessions: state.sessions.map((session) =>
         session.id === sessionId
           ? { ...session, specialistSwitchResetRequired: undefined }
-          : session
-      )
-    }))
-  },
-
-  // Marks a session as blocked on a user permission decision.
-  setPermissionPending: (sessionId) => {
-    set((state) => ({
-      sessions: state.sessions.map((session) =>
-        session.id === sessionId &&
-        session.status !== 'waiting-permission' &&
-        session.status !== 'waiting-for-user' &&
-        session.status !== 'waiting-plan-approval'
-          ? {
-              ...session,
-              status: 'waiting-permission',
-              updatedAt: Date.now()
-            }
-          : session
-      )
-    }))
-  },
-
-  // Restores a permission-blocked session to running or idle state.
-  clearPermissionPending: (sessionId) => {
-    set((state) => ({
-      sessions: state.sessions.map((session) =>
-        session.id === sessionId && session.status === 'waiting-permission'
-          ? {
-              ...session,
-              status: session.activeRun || session.agentPromptInFlight ? 'running' : 'idle',
-              updatedAt: Date.now()
-            }
           : session
       )
     }))

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -133,6 +133,17 @@ export type AcpHandoffFailure = {
 // both sides at once.
 export const ACP_PROMPT_FAILED_EVENT_TITLE = 'Prompt failed'
 
+// Main owns restored permission authority. These lifecycle events let renderer projections follow
+// durable settlement without making the renderer part of the persistence protocol.
+export const ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE =
+  'Restored permission continuation re-armed'
+export const ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE =
+  'Restored permission continuation settled'
+export const ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE =
+  'Permission continuation completed but its wait could not be cleared'
+export const ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE =
+  'Permission continuation failed and its wait could not be restored'
+
 // Marks a prompt failure the app can auto-recover from without user action. 'context-overflow' means
 // the conversation outgrew the provider's request-size limit; the renderer tries framework-native
 // compaction first, then falls back to a fresh context plus text replay. Absent on ordinary events.

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -649,11 +649,6 @@ export type AcpPermissionResponse = {
   restored?: {
     sessionId: string
     projectId: string
-    historyReplay?: {
-      historyPreamble?: AcpPromptRequest['historyPreamble']
-      historyAttachments?: AcpPromptRequest['historyAttachments']
-      historyImages?: AcpPromptRequest['historyImages']
-    }
   }
 }
 

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -443,6 +443,9 @@ export type AcpPermissionRequest = {
   sessionId: string
   toolCallId: string
   title: string
+  // Renderer lifecycle hint only. Main sets this after the request authority reaches Session
+  // storage; restored authority is still reloaded and validated independently before use.
+  durable?: true
   status?: string
   providerToolName?: string
   // Set by the permission broker after framework-aware classification so the renderer never has to
@@ -640,6 +643,18 @@ export type AcpPermissionResponse = {
   requestId: string
   optionId?: string
   cancelled?: boolean
+  // Present only when the renderer is answering main-owned permission authority restored from the
+  // Session record. Main reloads and validates that authority; this locator and replay projection do
+  // not themselves grant permission.
+  restored?: {
+    sessionId: string
+    projectId: string
+    historyReplay?: {
+      historyPreamble?: AcpPromptRequest['historyPreamble']
+      historyAttachments?: AcpPromptRequest['historyAttachments']
+      historyImages?: AcpPromptRequest['historyImages']
+    }
+  }
 }
 
 export type AcpPermissionSettlementState = 'resolved' | 'rejected' | 'cancelled'

--- a/src/shared/lifecycle-events.ts
+++ b/src/shared/lifecycle-events.ts
@@ -6,6 +6,10 @@ type SessionUpsertEvent = {
   originClientId: string
 }
 
+// Main-owned permission authority is projected through the existing Session lifecycle channel,
+// but it must merge into the live renderer Session instead of replacing in-flight chat state.
+const MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID = 'main:permission-wait'
+
 type ProjectDeletedEvent = {
   projectId: string
 }
@@ -25,5 +29,5 @@ const LIFECYCLE_CHANNELS = {
   sessionDeleted: 'session:deleted'
 } as const
 
-export { LIFECYCLE_CHANNELS }
+export { LIFECYCLE_CHANNELS, MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID }
 export type { Project, ProjectDeletedEvent, SessionDeletedEvent, SessionUpsertEvent }

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -9,7 +9,8 @@ import {
   sanitizeMessageImages,
   sanitizeToolActivity,
   type PersistedChatSession,
-  type SessionPlanRuntimeContext
+  type SessionPlanRuntimeContext,
+  type SessionPermissionRuntimeContext
 } from './session-persistence'
 import {
   activateConversationBranch,
@@ -922,6 +923,36 @@ describe('normalizeSessionFile with activities', () => {
       }
     })
     expect(restored?.error).toBeUndefined()
+  })
+
+  it('normalizes legacy permission authority to pending and accepts only known lifecycle states', () => {
+    const permission = {
+      request: {
+        requestId: 'permission-1',
+        sessionId: 'session-1',
+        toolCallId: 'tool-1',
+        title: 'Run npm test',
+        options: [{ optionId: 'deny', name: 'Deny', kind: 'reject_once' }]
+      },
+      originatingPromptMessageId: 'prompt-1',
+      fingerprint: 'a'.repeat(64),
+      createdAt: 1
+    }
+    const normalizePermission = (
+      candidate: Record<string, unknown>
+    ): SessionPermissionRuntimeContext | undefined =>
+      normalizeSessionFile(
+        {
+          ...createSessionWithActivity(undefined),
+          activities: undefined,
+          runtimeContext: { version: 1, revision: 1, permission: candidate }
+        },
+        { preserveRuntimeState: true }
+      )?.runtimeContext?.permission
+
+    expect(normalizePermission(permission)?.state).toBe('pending')
+    expect(normalizePermission({ ...permission, state: 'continuing' })?.state).toBe('continuing')
+    expect(normalizePermission({ ...permission, state: 'unknown' })).toBeUndefined()
   })
 
   it('round-trips special Plan step titles without changing object prototypes', () => {

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -955,6 +955,108 @@ describe('normalizeSessionFile with activities', () => {
     expect(normalizePermission({ ...permission, state: 'unknown' })).toBeUndefined()
   })
 
+  it('rearms a prompt-bound continuing permission after restart', () => {
+    const restored = normalizeSessionFile(
+      createSessionFile({
+        ...(createSessionWithActivity(undefined) as PersistedChatSession),
+        activities: undefined,
+        status: 'running',
+        activeRun: { promptMessageId: 'prompt-1', startedAt: 2 },
+        messages: [
+          {
+            id: 'prompt-1',
+            role: 'user',
+            content: 'Run the tests',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        runtimeContext: {
+          version: 1,
+          revision: 4,
+          permission: {
+            state: 'continuing',
+            request: {
+              requestId: 'permission-1',
+              sessionId: 'session-1',
+              toolCallId: 'tool-1',
+              title: 'Run npm test',
+              options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }]
+            },
+            originatingPromptMessageId: 'prompt-1',
+            fingerprint: 'a'.repeat(64),
+            createdAt: 2
+          }
+        }
+      })
+    )
+
+    expect(restored).toMatchObject({
+      status: 'waiting-permission',
+      runtimeContext: {
+        version: 1,
+        revision: 4,
+        permission: {
+          state: 'pending',
+          originatingPromptMessageId: 'prompt-1'
+        }
+      }
+    })
+    expect(restored?.activeRun).toBeUndefined()
+    expect(restored?.resumeRecovery).toBeUndefined()
+    expect(restored?.error).toBeUndefined()
+    expect(restored?.messages[0]?.interrupted).toBeUndefined()
+  })
+
+  it('releases an invalid continuing permission before generic restart recovery', () => {
+    const restored = normalizeSessionFile(
+      createSessionFile({
+        ...(createSessionWithActivity(undefined) as PersistedChatSession),
+        activities: undefined,
+        status: 'running',
+        activeRun: { promptMessageId: 'prompt-1', startedAt: 2 },
+        messages: [
+          {
+            id: 'prompt-1',
+            role: 'user',
+            content: 'Run the tests',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        runtimeContext: {
+          version: 1,
+          revision: 4,
+          permission: {
+            state: 'continuing',
+            request: {
+              requestId: 'permission-1',
+              sessionId: 'session-1',
+              toolCallId: 'tool-1',
+              title: 'Run npm test',
+              options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }]
+            },
+            originatingPromptMessageId: 'missing-prompt',
+            fingerprint: 'a'.repeat(64),
+            createdAt: 2
+          }
+        }
+      })
+    )
+
+    expect(restored?.status).toBe('error')
+    expect(restored?.runtimeContext?.permission).toBeUndefined()
+    expect(restored?.resumeRecovery).toEqual({
+      kind: 'resume-required',
+      cause: 'app-restart',
+      promptMessageId: 'prompt-1'
+    })
+  })
+
   it('round-trips special Plan step titles without changing object prototypes', () => {
     const specialStatuses = JSON.parse(
       '{"toString":{"status":"completed","updatedAt":1},"constructor":{"status":"skipped","updatedAt":2},"__proto__":{"status":"blocked","updatedAt":3}}'

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -860,18 +860,27 @@ const asArtifactKind = (value: unknown): PersistedArtifactKind | undefined => {
   return kind && ARTIFACT_KINDS.has(kind) ? kind : undefined
 }
 
-const hasRestorablePermissionWait = (session: PersistedChatSession): boolean => {
-  const permission = session.runtimeContext?.permission
+const isPermissionAuthorityBoundToActivePrompt = (
+  session: PersistedChatSession,
+  permission: SessionPermissionRuntimeContext
+): boolean => {
   const activeMessages = session.conversationGraph
     ? resolveActiveConversationMessages(session.conversationGraph)
     : session.messages
   return Boolean(
-    session.status === 'waiting-permission' &&
-    permission?.state === 'pending' &&
-    permission?.request.sessionId === session.id &&
+    permission.request.sessionId === session.id &&
     activeMessages.some(
       (message) => message.id === permission.originatingPromptMessageId && message.role === 'user'
     )
+  )
+}
+
+const hasRestorablePermissionWait = (session: PersistedChatSession): boolean => {
+  const permission = session.runtimeContext?.permission
+  return Boolean(
+    session.status === 'waiting-permission' &&
+    permission?.state === 'pending' &&
+    isPermissionAuthorityBoundToActivePrompt(session, permission)
   )
 }
 
@@ -906,15 +915,40 @@ const markInterruptedPrompt = (
 const latestUserMessageId = (messages: PersistedChatMessage[]): string | undefined =>
   [...messages].reverse().find((message) => message.role === 'user')?.id
 
-// Restores interrupted sessions as retryable errors because runtime state is gone.
+// Rehydrates durable waits and converts runtime-only work into recoverable states after restart.
 const normalizeSessionAfterRestore = (session: PersistedChatSession): PersistedChatSession => {
-  const continuingPermission = session.runtimeContext?.permission
-  if (continuingPermission?.state === 'continuing') {
-    const promptMessageId = continuingPermission.originatingPromptMessageId
+  const persistedRuntimeContext = session.runtimeContext
+  const continuingPermission = persistedRuntimeContext?.permission
+  if (persistedRuntimeContext && continuingPermission?.state === 'continuing') {
+    if (isPermissionAuthorityBoundToActivePrompt(session, continuingPermission)) {
+      // The provider continuation died with the process. Re-present its durable request instead
+      // of automatically replaying privileged work that may already have partially completed.
+      return {
+        ...session,
+        status: 'waiting-permission',
+        activeRun: undefined,
+        runtimeContext: {
+          ...persistedRuntimeContext,
+          permission: {
+            ...continuingPermission,
+            state: 'pending'
+          }
+        },
+        resumeRecovery: undefined,
+        error: undefined,
+        errorReportable: undefined,
+        messages: session.messages.map(normalizeMessageAfterRestore)
+      }
+    }
+
+    const runtimeContext = { ...persistedRuntimeContext }
+    delete runtimeContext.permission
+    const promptMessageId = latestUserMessageId(session.messages)
     return {
       ...session,
       status: 'error',
       activeRun: undefined,
+      runtimeContext,
       resumeRecovery: {
         kind: 'resume-required',
         cause: 'app-restart',

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -92,6 +92,7 @@ export type SessionPlanRuntimeContext = Readonly<{
 }>
 
 export type SessionPermissionRuntimeContext = Readonly<{
+  state: 'pending' | 'continuing'
   request: AcpPermissionRequest
   originatingPromptMessageId: string
   fingerprint: string
@@ -684,6 +685,7 @@ export const sanitizeSessionPermissionRuntimeContext = (
       (field) =>
         ![
           'request',
+          'state',
           'originatingPromptMessageId',
           'fingerprint',
           'categoryKey',
@@ -695,6 +697,7 @@ export const sanitizeSessionPermissionRuntimeContext = (
     return undefined
   }
   const request = sanitizePermissionRequest(value.request)
+  const state = value.state === undefined ? 'pending' : asString(value.state)
   const originatingPromptMessageId = boundedPermissionString(value.originatingPromptMessageId)
   const fingerprint = asString(value.fingerprint)
   const categoryKey = boundedPermissionString(value.categoryKey)
@@ -702,6 +705,7 @@ export const sanitizeSessionPermissionRuntimeContext = (
   const createdAt = asNumber(value.createdAt)
   if (
     !request ||
+    (state !== 'pending' && state !== 'continuing') ||
     !originatingPromptMessageId ||
     !fingerprint ||
     !PERMISSION_FINGERPRINT_PATTERN.test(fingerprint) ||
@@ -713,6 +717,7 @@ export const sanitizeSessionPermissionRuntimeContext = (
     return undefined
   }
   return {
+    state,
     request,
     originatingPromptMessageId,
     fingerprint,
@@ -862,6 +867,7 @@ const hasRestorablePermissionWait = (session: PersistedChatSession): boolean => 
     : session.messages
   return Boolean(
     session.status === 'waiting-permission' &&
+    permission?.state === 'pending' &&
     permission?.request.sessionId === session.id &&
     activeMessages.some(
       (message) => message.id === permission.originatingPromptMessageId && message.role === 'user'
@@ -902,6 +908,25 @@ const latestUserMessageId = (messages: PersistedChatMessage[]): string | undefin
 
 // Restores interrupted sessions as retryable errors because runtime state is gone.
 const normalizeSessionAfterRestore = (session: PersistedChatSession): PersistedChatSession => {
+  const continuingPermission = session.runtimeContext?.permission
+  if (continuingPermission?.state === 'continuing') {
+    const promptMessageId = continuingPermission.originatingPromptMessageId
+    return {
+      ...session,
+      status: 'error',
+      activeRun: undefined,
+      resumeRecovery: {
+        kind: 'resume-required',
+        cause: 'app-restart',
+        promptMessageId
+      },
+      error: session.error ?? INTERRUPTED_SESSION_ERROR,
+      messages: markInterruptedPrompt(
+        session.messages.map(normalizeMessageAfterRestore),
+        promptMessageId
+      )
+    }
+  }
   if (hasRestorablePermissionWait(session)) {
     return {
       ...session,

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -7,6 +7,7 @@ import {
   sanitizeAcpContextUsage,
   sanitizeAcpMessageImage,
   sanitizeAcpTurnTokenUsage,
+  type AcpPermissionRequest,
   type AcpContextUsage,
   type AcpMessageImage,
   type AcpTurnTokenUsage
@@ -41,6 +42,11 @@ import {
   type PersistedMessageNode,
   type PersistedRuntimeSegment
 } from './conversation-graph'
+import {
+  EXACT_PERMISSION_QUALIFIER_PATTERN,
+  PERMISSION_CAPABILITY_KINDS,
+  type PermissionCapability
+} from './permission-grants'
 
 // One JSON file per session (sessions/<projectId>/<sessionId>.json) carries this envelope version.
 export const SESSION_FILE_VERSION = 2
@@ -62,7 +68,7 @@ export type SessionRuntimeContextValue =
   | SessionRuntimeContextValue[]
   | { [key: string]: SessionRuntimeContextValue }
 
-export type SessionRuntimeContextOwner = 'plan'
+export type SessionRuntimeContextOwner = 'plan' | 'permission'
 
 export type SessionPlanApproval = 'pending' | 'approved' | 'rejected'
 export type SessionPlanStepStatus = 'in_progress' | 'completed' | 'blocked' | 'skipped'
@@ -85,6 +91,15 @@ export type SessionPlanRuntimeContext = Readonly<{
   >
 }>
 
+export type SessionPermissionRuntimeContext = Readonly<{
+  request: AcpPermissionRequest
+  originatingPromptMessageId: string
+  fingerprint: string
+  categoryKey?: string
+  capability?: PermissionCapability
+  createdAt: number
+}>
+
 // Main-owned mutable authority embedded in the Session record. Owner modules use top-level keys
 // (for example `plan`); renderer consumers receive this only as a read projection. Versioning lets a
 // future incompatible envelope fail closed instead of reviving authority under unknown semantics.
@@ -92,11 +107,13 @@ export type SessionRuntimeContext = Readonly<{
   version: 1
   revision: number
   plan?: SessionPlanRuntimeContext
+  permission?: SessionPermissionRuntimeContext
 }>
 
-export type SessionRuntimeContextPatch = Readonly<
-  Partial<Record<SessionRuntimeContextOwner, SessionPlanRuntimeContext | undefined>>
->
+export type SessionRuntimeContextPatch = Readonly<{
+  plan?: SessionPlanRuntimeContext | undefined
+  permission?: SessionPermissionRuntimeContext | undefined
+}>
 
 // Stores artifact references only; file bytes stay on disk under the managed artifact root.
 export type PersistedArtifact = {
@@ -502,6 +519,209 @@ const sanitizeSessionPlanRuntimeContext = (
   }
 }
 
+const PERMISSION_FINGERPRINT_PATTERN = /^[a-f0-9]{64}$/
+const PERMISSION_SCOPES = new Set(['once', 'session', 'project', 'global'])
+const PERMISSION_OPTION_KINDS = new Set([
+  'allow_once',
+  'allow_always',
+  'reject_once',
+  'reject_always'
+])
+const PERMISSION_CAPABILITY_KIND_SET = new Set<string>(PERMISSION_CAPABILITY_KINDS)
+const MAX_PERMISSION_CONTEXT_STRING_CHARS = 16_000
+const MAX_PERMISSION_CONTEXT_RAW_CHARS = 8_000
+
+const boundedPermissionString = (value: unknown): string | undefined => {
+  const text = asString(value)
+  return text && text.length <= MAX_PERMISSION_CONTEXT_STRING_CHARS ? text : undefined
+}
+
+const sanitizePermissionRawInput = (value: unknown): unknown | undefined => {
+  if (value === undefined) return undefined
+  try {
+    const serialized = JSON.stringify(value)
+    if (serialized === undefined || serialized.length > MAX_PERMISSION_CONTEXT_RAW_CHARS) {
+      return undefined
+    }
+    return JSON.parse(serialized) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+const sanitizePermissionCapability = (value: unknown): PermissionCapability | undefined => {
+  if (!isRecord(value)) return undefined
+  const kind = asString(value.kind)
+  const key = boundedPermissionString(value.key)?.trim()
+  if (!kind || !PERMISSION_CAPABILITY_KIND_SET.has(kind) || !key) return undefined
+
+  if (value.qualifier === undefined) {
+    return { kind: kind as PermissionCapability['kind'], key }
+  }
+  if (!isRecord(value.qualifier)) return undefined
+  const mode = asString(value.qualifier.mode)
+  if (mode === 'any') {
+    return { kind: kind as PermissionCapability['kind'], key, qualifier: { mode } }
+  }
+  const qualifierValue = boundedPermissionString(value.qualifier.value)?.trim()
+  if (
+    (mode !== 'category' && mode !== 'exact') ||
+    !qualifierValue ||
+    (mode === 'exact' && !EXACT_PERMISSION_QUALIFIER_PATTERN.test(qualifierValue))
+  ) {
+    return undefined
+  }
+  return {
+    kind: kind as PermissionCapability['kind'],
+    key,
+    qualifier: { mode, value: qualifierValue }
+  }
+}
+
+const sanitizePermissionRequest = (value: unknown): AcpPermissionRequest | undefined => {
+  if (!isRecord(value)) return undefined
+  const requestId = boundedPermissionString(value.requestId)
+  const sessionId = boundedPermissionString(value.sessionId)
+  const toolCallId = boundedPermissionString(value.toolCallId)
+  const title = boundedPermissionString(value.title)
+  if (!requestId || !sessionId || !toolCallId || !title || !Array.isArray(value.options)) {
+    return undefined
+  }
+
+  const optionIds = new Set<string>()
+  const options = value.options.flatMap((candidate) => {
+    if (!isRecord(candidate)) return []
+    const optionId = boundedPermissionString(candidate.optionId)
+    const name = boundedPermissionString(candidate.name)
+    const kind = boundedPermissionString(candidate.kind)
+    const scope = asString(candidate.scope)
+    const normalizedKind = kind?.toLowerCase()
+    if (
+      !optionId ||
+      !name ||
+      !kind ||
+      !normalizedKind ||
+      !PERMISSION_OPTION_KINDS.has(normalizedKind) ||
+      optionIds.has(optionId) ||
+      (scope !== undefined && !PERMISSION_SCOPES.has(scope)) ||
+      (scope === 'once' && normalizedKind !== 'allow_once') ||
+      ((scope === 'session' || scope === 'project' || scope === 'global') &&
+        normalizedKind !== 'allow_always')
+    ) {
+      return []
+    }
+    optionIds.add(optionId)
+    return [
+      {
+        optionId,
+        name,
+        kind,
+        ...(scope
+          ? { scope: scope as NonNullable<AcpPermissionRequest['options'][number]['scope']> }
+          : {})
+      }
+    ]
+  })
+  if (options.length === 0 || options.length !== value.options.length || options.length > 32) {
+    return undefined
+  }
+
+  const request: AcpPermissionRequest = { requestId, sessionId, toolCallId, title, options }
+  const status = boundedPermissionString(value.status)
+  const providerToolName = boundedPermissionString(value.providerToolName)
+  const mcpIdentity = boundedPermissionString(value.mcpIdentity)
+  const toolKind = boundedPermissionString(value.toolKind)
+  const commandPrefix = Array.isArray(value.commandPrefix)
+    ? value.commandPrefix.map(boundedPermissionString).filter((item): item is string => !!item)
+    : undefined
+  const toolLocations = Array.isArray(value.toolLocations)
+    ? value.toolLocations.flatMap((candidate) => {
+        if (!isRecord(candidate)) return []
+        const path = boundedPermissionString(candidate.path)
+        const line = asNumber(candidate.line)
+        if (!path || (line !== undefined && (!Number.isSafeInteger(line) || line < 0))) return []
+        return [{ path, ...(line === undefined ? {} : { line }) }]
+      })
+    : undefined
+  const rawInput = sanitizePermissionRawInput(value.rawInput)
+  if (value.rawInput !== undefined && rawInput === undefined) return undefined
+  if (
+    value.toolLocations !== undefined &&
+    (!Array.isArray(value.toolLocations) ||
+      toolLocations?.length !== value.toolLocations.length ||
+      toolLocations.length > 100)
+  ) {
+    return undefined
+  }
+  if (
+    value.commandPrefix !== undefined &&
+    (!Array.isArray(value.commandPrefix) ||
+      commandPrefix?.length !== value.commandPrefix.length ||
+      commandPrefix.length > 32)
+  ) {
+    return undefined
+  }
+
+  if (status) request.status = status
+  if (providerToolName) request.providerToolName = providerToolName
+  if (typeof value.isMcp === 'boolean') request.isMcp = value.isMcp
+  if (mcpIdentity) request.mcpIdentity = mcpIdentity
+  if (toolKind) request.toolKind = toolKind as AcpPermissionRequest['toolKind']
+  if (toolLocations) {
+    request.toolLocations = toolLocations as AcpPermissionRequest['toolLocations']
+  }
+  if (commandPrefix) request.commandPrefix = commandPrefix
+  if (rawInput !== undefined) request.rawInput = rawInput
+  return request
+}
+
+export const sanitizeSessionPermissionRuntimeContext = (
+  value: unknown
+): SessionPermissionRuntimeContext | undefined => {
+  if (!isRecord(value)) return undefined
+  if (
+    Object.keys(value).some(
+      (field) =>
+        ![
+          'request',
+          'originatingPromptMessageId',
+          'fingerprint',
+          'categoryKey',
+          'capability',
+          'createdAt'
+        ].includes(field)
+    )
+  ) {
+    return undefined
+  }
+  const request = sanitizePermissionRequest(value.request)
+  const originatingPromptMessageId = boundedPermissionString(value.originatingPromptMessageId)
+  const fingerprint = asString(value.fingerprint)
+  const categoryKey = boundedPermissionString(value.categoryKey)
+  const capability = sanitizePermissionCapability(value.capability)
+  const createdAt = asNumber(value.createdAt)
+  if (
+    !request ||
+    !originatingPromptMessageId ||
+    !fingerprint ||
+    !PERMISSION_FINGERPRINT_PATTERN.test(fingerprint) ||
+    createdAt === undefined ||
+    !Number.isSafeInteger(createdAt) ||
+    createdAt < 0 ||
+    (value.capability !== undefined && !capability)
+  ) {
+    return undefined
+  }
+  return {
+    request,
+    originatingPromptMessageId,
+    fingerprint,
+    ...(categoryKey ? { categoryKey } : {}),
+    ...(capability ? { capability } : {}),
+    createdAt
+  }
+}
+
 export const sanitizeSessionRuntimeContext = (
   value: unknown
 ): SessionRuntimeContext | undefined => {
@@ -509,19 +729,30 @@ export const sanitizeSessionRuntimeContext = (
   const revision = asNumber(value.revision)
   if (revision === undefined || !Number.isSafeInteger(revision) || revision < 0) return undefined
 
-  const result: { version: 1; revision: number; plan?: SessionPlanRuntimeContext } = {
+  const result: {
+    version: 1
+    revision: number
+    plan?: SessionPlanRuntimeContext
+    permission?: SessionPermissionRuntimeContext
+  } = {
     version: 1,
     revision
   }
   const budget = { remaining: 2_000 }
   for (const [owner, ownerValue] of Object.entries(value)) {
     if (owner === 'version' || owner === 'revision') continue
-    if (owner !== 'plan') return undefined
+    if (owner !== 'plan' && owner !== 'permission') return undefined
     const sanitizedJson = sanitizeRuntimeContextValue(ownerValue, budget)
     if (sanitizedJson === undefined) return undefined
-    const plan = sanitizeSessionPlanRuntimeContext(sanitizedJson)
-    if (!plan) return undefined
-    result.plan = plan
+    if (owner === 'plan') {
+      const plan = sanitizeSessionPlanRuntimeContext(sanitizedJson)
+      if (!plan) return undefined
+      result.plan = plan
+      continue
+    }
+    const permission = sanitizeSessionPermissionRuntimeContext(sanitizedJson)
+    if (!permission) return undefined
+    result.permission = permission
   }
   return result
 }
@@ -624,9 +855,25 @@ const asArtifactKind = (value: unknown): PersistedArtifactKind | undefined => {
   return kind && ARTIFACT_KINDS.has(kind) ? kind : undefined
 }
 
-// Identifies UI states that cannot survive an app process shutdown.
-const isSessionInterrupted = (status: PersistedSessionStatus): boolean =>
-  status === 'running' || status === 'waiting-permission'
+const hasRestorablePermissionWait = (session: PersistedChatSession): boolean => {
+  const permission = session.runtimeContext?.permission
+  const activeMessages = session.conversationGraph
+    ? resolveActiveConversationMessages(session.conversationGraph)
+    : session.messages
+  return Boolean(
+    session.status === 'waiting-permission' &&
+    permission?.request.sessionId === session.id &&
+    activeMessages.some(
+      (message) => message.id === permission.originatingPromptMessageId && message.role === 'user'
+    )
+  )
+}
+
+// Identifies UI states that cannot survive an app process shutdown. Permission waits are durable
+// only when their main-owned authority and active-branch prompt binding survived with the Session.
+const isSessionInterrupted = (session: PersistedChatSession): boolean =>
+  session.status === 'running' ||
+  (session.status === 'waiting-permission' && !hasRestorablePermissionWait(session))
 
 // Converts partial streamed assistant messages into visible errors after restart.
 const normalizeMessageAfterRestore = (message: PersistedChatMessage): PersistedChatMessage =>
@@ -655,6 +902,17 @@ const latestUserMessageId = (messages: PersistedChatMessage[]): string | undefin
 
 // Restores interrupted sessions as retryable errors because runtime state is gone.
 const normalizeSessionAfterRestore = (session: PersistedChatSession): PersistedChatSession => {
+  if (hasRestorablePermissionWait(session)) {
+    return {
+      ...session,
+      status: 'waiting-permission',
+      activeRun: undefined,
+      resumeRecovery: undefined,
+      error: undefined,
+      errorReportable: undefined,
+      messages: session.messages.map(normalizeMessageAfterRestore)
+    }
+  }
   if (
     session.status === 'waiting-plan-approval' &&
     session.runtimeContext?.plan?.approval === 'pending'
@@ -665,7 +923,7 @@ const normalizeSessionAfterRestore = (session: PersistedChatSession): PersistedC
       messages: session.messages.map(normalizeMessageAfterRestore)
     }
   }
-  if (!isSessionInterrupted(session.status)) {
+  if (!isSessionInterrupted(session)) {
     const legacyInterrupted =
       session.resumeRecovery === undefined && session.error === INTERRUPTED_SESSION_ERROR
     const promptMessageId =


### PR DESCRIPTION
## Problem

Permission cards were backed only by the live ACP broker promise. Closing the app therefore treated a permission-blocked turn as active work, disposed the request, and restored the Session as interrupted instead of preserving the user's pending decision.

## Proposed change

- Persist a main-owned permission authority, including a sanitized request, active-branch prompt binding, exact tool-call fingerprint, and grant capability, before publishing the card.
- Restore durable permission cards after restart, resume the original Session/backend, and continue the parked turn after applying the selected one-shot or persistent Session/Project/Global grant.
- Keep durable permission waits active for archive and storage safety, while excluding only those quiescent waits from the app-quit running-task warning.
- Fail closed for legacy or invalid permission waits that do not have valid durable authority.

## Scope and non-goals

This change covers `waiting-permission` recovery across the shared persistence contract, main ACP runtime, and renderer projection. It does not attempt to preserve the dead provider RPC or make generic running turns restartable; restart creates a suppressed app-owned continuation bound to the original user Message.

## Acceptance criteria and validation

The final Test Impact Set ran after the last material edit.

| Behavior | Project-owned check | Final result |
| --- | --- | --- |
| Main-owned authority, stale renderer merge, valid restore, and legacy fail-closed recovery | `npm test -- src/main/session-persistence/repository.test.ts src/main/session-persistence/coordinator.test.ts src/main/session-persistence/coordinator-contract.test.ts` (included in the 17-file affected set) | Passed |
| Broker persistence ordering, exact one-shot matching, persistent scope grants, four backend continuation routes, and quit classification | `npm test --` the 17 explicit affected files | 17 files, 1,074 tests passed |
| Renderer restored-card projection, detached resume, history replay, and durable drop handling | `npm test -- src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx src/renderer/src/lib/acp/useWorkspaceAgentRuntime.first-output.render.test.tsx` | 4 files, 163 tests passed |
| Main and renderer TypeScript interfaces | `npm run typecheck` | Passed |
| Lint and API surface | `npm run lint`; `npm run check:web-api-map` | Passed; lint reports 17 pre-existing warnings and 0 errors |
| Patch integrity | `git diff --check` | Passed |

An earlier complete `npm test` run reached 12,692 passing tests and reported unrelated existing/environment failures in Windows symlink/ACL cases, bash workflow spawning, notebook timing/abort cases, and static architecture budgets. The explicit final impact set covering every changed owner, interface, and renderer consumer passes.

Uncovered risk: a physical packaged-app close/reopen interaction was not automated locally. CI remains authoritative for portable and platform lanes.

## Review focus

- Confirm the persisted permission request and capability sanitizers remain fail-closed.
- Confirm authority is cleared only after a live decision is persisted or a restored continuation completes.
- Confirm quit filtering does not weaken archive or storage active-session checks.
