### PR TITLE
refactor(settings): extract provider auth lifecycle

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -250,6 +250,7 @@
     "settings_provider_accounts": {
       "ownerPaths": [
         "src/main/settings/provider-accounts.ts",
+        "src/main/settings/provider-auth-lifecycle.ts",
         "src/main/settings/provider-runtime-projection.ts"
       ],
       "interfacePaths": ["src/main/settings/provider-accounts.ts"],
@@ -258,6 +259,8 @@
         "owner": [
           "src/main/settings/settings-backend.architecture.test.ts",
           "src/main/settings/provider-accounts.test.ts",
+          "src/main/settings/provider-auth-lifecycle.test.ts",
+          "src/main/settings/provider-auth-lifecycle.architecture.test.ts",
           "src/main/settings/provider-runtime-projection.test.ts",
           "src/main/settings/provider-runtime-projection.architecture.test.ts",
           "src/main/settings/codex-auth.test.ts",

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -1,5 +1,3 @@
-import { isDeepStrictEqual } from 'node:util'
-
 import type {
   ChatApiEndpoint,
   ProviderDraft,
@@ -17,12 +15,9 @@ import {
   claudeSharedProviderIdentity,
   codexSubscriptionProviderIdentity,
   isClaudeSubscriptionProvider,
-  isClaudeSubscriptionProviderId,
   isCodexSubscriptionProvider,
-  isCodexSubscriptionProviderId,
   isProviderUsableByFramework,
   providerEndpoints,
-  resolveCodexSubscriptionType,
   requiresChatCompletionsBridge
 } from '../../shared/settings'
 import {
@@ -41,32 +36,18 @@ import {
   getAgentFramework,
   type AgentFrameworkId
 } from '../agent-framework'
-import { codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { netFetchStandard } from '../skills/net-fetch'
-import {
-  clearAppOwnedCodexAuthentication,
-  clearImportedCodexProviderRoute,
-  CodexAuthController,
-  ensureCodexAuthHome,
-  importCodexAuthentication,
-  openCodexAuthSession,
-  type CodexAuthControllerPort,
-  type CodexAuthStatus
-} from './codex-auth'
-import {
-  ClaudeIsolatedAuthController,
-  type ClaudeIsolatedAuthControllerPort,
-  type ClaudeIsolatedAuthStatus
-} from './claude-isolated-auth'
-import {
-  ClaudeSharedAuthController,
-  type ClaudeSharedAuthControllerPort,
-  type ClaudeSharedAuthStatus
-} from './claude-shared-auth'
-import { encryptKey, isEncryptionAvailable, maskKey, tryDecryptKey } from './crypto'
+import { type CodexAuthControllerPort } from './codex-auth'
+import { type ClaudeIsolatedAuthControllerPort } from './claude-isolated-auth'
+import { type ClaudeSharedAuthControllerPort } from './claude-shared-auth'
+import { encryptKey, maskKey, tryDecryptKey } from './crypto'
 import { classifyStatus, validateProvider as validateProviderTarget } from './validate'
 import { listProviderModels } from './list-models'
-import { getAppClaudeConfigDir, type ResolvedProvider } from './provider-env'
+import type { ResolvedProvider } from './provider-env'
+import {
+  CLAUDE_SHARED_DISCONNECTED_MESSAGE,
+  ProviderAuthLifecycleOwner
+} from './provider-auth-lifecycle'
 import {
   ProviderRuntimeProjectionOwner,
   requiresNativeResponsesCompatibility,
@@ -76,11 +57,6 @@ import {
 import type { SettingsRepository } from './repository'
 import type { SystemProxyEnvironment } from './system-proxy'
 import type { StoredProvider, StoredSettings } from './types'
-
-const SETUP_TOKEN_LIFETIME_MS = 365 * 24 * 60 * 60 * 1000
-const CLAUDE_SHARED_AUTH_STATUS_TTL_MS = 5_000
-const CLAUDE_SHARED_DISCONNECTED_MESSAGE =
-  'Claude is disconnected from Open Science. Sign in again to use your shared Claude profile.'
 
 type ProviderAccountsModuleOptions = {
   repository: SettingsRepository
@@ -107,83 +83,15 @@ type ProviderAccountsModuleOptions = {
 // outside this module.
 class ProviderAccountsModule {
   private readonly repository: SettingsRepository
-  private readonly codexAuth: CodexAuthControllerPort
-  private readonly claudeIsolatedAuth: ClaudeIsolatedAuthControllerPort
-  private readonly claudeSharedAuth: ClaudeSharedAuthControllerPort
   private readonly runtimeProjection = new ProviderRuntimeProjectionOwner()
-  private claudeSharedAuthStatusCache: { authenticated: boolean; checkedAt: number } | undefined
-  private claudeSharedAuthStatusGeneration = 0
-  private claudeSharedAuthStatusPromise:
-    { generation: number; promise: Promise<boolean> } | undefined
+  private readonly auth: ProviderAuthLifecycleOwner
   private readonly providerValidationGenerations = new Map<string, number>()
 
   constructor(private readonly options: ProviderAccountsModuleOptions) {
     this.repository = options.repository
-    this.codexAuth =
-      options.codexAuth ??
-      new CodexAuthController({
-        openSession: async (mode) => {
-          const settings = await this.repository.getSettings()
-          return openCodexAuthSession({
-            adapterPath: await options.resolveCodexExecutable(
-              settings.codex?.resolvedPath,
-              settings.codex?.nativePath
-            ),
-            nativePath: settings.codex?.nativePath,
-            mode,
-            storageRoot: options.storageRoot,
-            proxyEnv: await options.resolveCodexProxyEnvironment()
-          })
-        }
-      })
-    this.claudeIsolatedAuth =
-      options.claudeIsolatedAuth ??
-      new ClaudeIsolatedAuthController({
-        store: {
-          loadToken: () => this.loadClaudeIsolatedToken(),
-          saveToken: (token) => this.saveClaudeIsolatedToken(token),
-          clearToken: () => this.clearClaudeIsolatedToken(),
-          isEncryptionAvailable: () => isEncryptionAvailable()
-        },
-        claudePath: async () => {
-          const settings = await this.repository.getSettings()
-          return settings.claude?.resolvedPath ?? 'claude'
-        },
-        configDir: getAppClaudeConfigDir(options.storageRoot)
-      })
-    this.claudeSharedAuth =
-      options.claudeSharedAuth ??
-      new ClaudeSharedAuthController({
-        claudePath: async () => {
-          const settings = await this.repository.getSettings()
-          return settings.claude?.resolvedPath ?? 'claude'
-        },
-        configDir: options.userClaudeDir
-      })
-  }
-
-  private async loadClaudeIsolatedToken(): Promise<string | undefined> {
-    const settings = await this.repository.getSettings()
-    const provider = settings.providers.find(
-      (candidate) => candidate.id === CLAUDE_ISOLATED_PROVIDER_ID
-    )
-
-    return provider?.keyRef ? tryDecryptKey(provider.keyRef) : undefined
-  }
-
-  private async saveClaudeIsolatedToken(token: string): Promise<void> {
-    const applied = await this.repository.updateClaudeIsolatedCredentialsIfExists({
-      keyRef: encryptKey(token),
-      keyMask: maskKey(token)
-    })
-
-    if (!applied) throw new Error('The Claude provider was removed before sign-in completed.')
-  }
-
-  private async clearClaudeIsolatedToken(): Promise<void> {
-    await this.repository.updateClaudeIsolatedCredentialsIfExists({
-      keyRef: undefined,
-      keyMask: undefined
+    this.auth = new ProviderAuthLifecycleOwner({
+      ...options,
+      resolveProvider: (provider, model) => this.runtimeProjection.resolveProvider(provider, model)
     })
   }
 
@@ -217,30 +125,11 @@ class ProviderAccountsModule {
 
     const reimportCodexAuthentication =
       request.type === 'codex-shared' && request.reimportCodexAuthentication === true
-    if (
-      request.type === 'codex-shared' &&
-      (existing?.codexAuthMode !== 'imported' || reimportCodexAuthentication)
-    ) {
-      await this.codexAuth.cancelLogin()
-      await importCodexAuthentication(
-        this.options.userCodexDir,
-        codexSubscriptionStorageDir(this.options.storageRoot)
-      )
+    await this.auth.prepareCodexProviderUpsert(request, existing, () => {
       if (reimportCodexAuthentication && requestedId) {
         this.advanceProviderValidationGeneration(requestedId)
       }
-    } else if (request.type === 'codex-isolated' && existing?.codexAuthMode !== 'isolated') {
-      if (existing) await this.codexAuth.cancelLogin()
-      const codexHome = codexSubscriptionStorageDir(this.options.storageRoot)
-      await clearImportedCodexProviderRoute(codexHome)
-      await clearAppOwnedCodexAuthentication(codexHome)
-    }
-    if (isCodexSubscriptionProvider(request.type)) {
-      await ensureCodexAuthHome(
-        request.type === 'codex-shared' ? 'shared' : 'isolated',
-        this.options.storageRoot
-      )
-    }
+    })
 
     const provider: StoredProvider = {
       id: subscriptionIdentity?.id ?? existing?.id ?? this.createProviderId(),
@@ -360,372 +249,56 @@ class ProviderAccountsModule {
   }
 
   async deleteProvider(id: string): Promise<void> {
-    if (isCodexSubscriptionProviderId(id)) {
-      await this.codexAuth.cancelLogin()
-      const codexHome = codexSubscriptionStorageDir(this.options.storageRoot)
-      await clearImportedCodexProviderRoute(codexHome)
-      await clearAppOwnedCodexAuthentication(codexHome)
-    }
-    if (isClaudeSubscriptionProviderId(id)) {
-      this.claudeIsolatedAuth.cancelLogin()
-      this.claudeSharedAuth.cancelLogin()
-    }
+    await this.auth.cleanupProviderBeforeDelete(id)
     await this.repository.deleteProvider(id)
   }
 
   cancelCodexLogin(): void {
-    void this.codexAuth.cancelLogin()
+    this.auth.cancelCodexLogin()
   }
 
   cancelClaudeLogin(): void {
-    this.claudeSharedAuth.cancelLogin()
+    this.auth.cancelClaudeLogin()
   }
 
   async loginIsolatedCodex(): Promise<ValidateProviderResult> {
-    const result = this.codexAuthValidationResult(await this.codexAuth.loginIsolated())
-    const settings = await this.repository.getSettings()
-    const provider = settings.providers.find(
-      (candidate) => candidate.id === codexSubscriptionProviderIdentity().id
-    )
-    if (provider?.type !== 'codex-isolated' || provider.codexAuthMode !== 'isolated') {
-      return { ...result, applied: false }
-    }
-
-    await this.repository.upsertProvider(
-      result.ok
-        ? {
-            ...provider,
-            lastValidatedAt: Date.now(),
-            lastValidationFailure: undefined
-          }
-        : {
-            ...provider,
-            lastValidatedAt: undefined,
-            lastValidationFailure: {
-              at: Date.now(),
-              category: result.category,
-              status: result.status,
-              message: result.message
-            }
-          }
-    )
-
-    return { ...result, applied: true }
+    return this.auth.loginIsolatedCodex()
   }
 
   async logoutIsolatedCodex(): Promise<ValidateProviderResult> {
-    const settings = await this.repository.getSettings()
-    const provider = settings.providers.find(
-      (candidate) => candidate.id === codexSubscriptionProviderIdentity().id
-    )
-    if (provider?.type !== 'codex-isolated' || provider.codexAuthMode !== 'isolated') {
-      return {
-        ok: false,
-        category: 'unknown',
-        message: 'No isolated Open Science Codex login is configured.'
-      }
-    }
-
-    await this.codexAuth.cancelLogin()
-    try {
-      await ensureCodexAuthHome('isolated', this.options.storageRoot)
-      await clearAppOwnedCodexAuthentication(codexSubscriptionStorageDir(this.options.storageRoot))
-    } catch {
-      return {
-        ok: false,
-        category: 'unknown',
-        message: 'The Open Science Codex login could not be removed.'
-      }
-    }
-
-    await this.repository.upsertProvider({
-      ...provider,
-      lastValidatedAt: undefined,
-      lastValidationFailure: undefined
-    })
-
-    return { ok: true, category: 'ok' }
+    return this.auth.logoutIsolatedCodex()
   }
 
   async loginIsolatedClaude(token: string): Promise<ValidateProviderResult> {
-    return this.finalizeClaudeIsolatedLogin(
-      this.claudeIsolatedAuthValidationResult(await this.claudeIsolatedAuth.loginIsolated(token))
-    )
+    return this.auth.loginIsolatedClaude(token)
   }
 
   async loginIsolatedClaudeBrowser(): Promise<ValidateProviderResult> {
-    const authStatus = await this.claudeIsolatedAuth.loginIsolatedBrowser()
-    if (authStatus.cancelled) {
-      return {
-        ok: false,
-        category: 'unknown',
-        message: authStatus.message,
-        applied: false,
-        cancelled: true
-      }
-    }
-
-    return this.finalizeClaudeIsolatedLogin(this.claudeIsolatedAuthValidationResult(authStatus))
+    return this.auth.loginIsolatedClaudeBrowser()
   }
 
   async cancelClaudeIsolatedLogin(): Promise<void> {
-    this.claudeIsolatedAuth.cancelLogin()
-  }
-
-  private async finalizeClaudeIsolatedLogin(
-    initialResult: ValidateProviderResult
-  ): Promise<ValidateProviderResult> {
-    let result = initialResult
-    const settings = await this.repository.getSettings()
-    const provider = settings.providers.find(
-      (candidate) => candidate.id === CLAUDE_ISOLATED_PROVIDER_ID
-    )
-    if (!provider) return { ...result, applied: false }
-
-    if (result.ok) {
-      result = await this.options.runClaudeSubscriptionProbe(
-        this.resolveProvider(
-          provider,
-          settings.activeProviderId === provider.id ? settings.activeModel : undefined
-        ),
-        settings
-      )
-      const applied = await this.repository.updateClaudeIsolatedValidationIfKeyMatches(
-        provider.keyRef,
-        result.ok
-          ? {
-              expiresAt: Date.now() + SETUP_TOKEN_LIFETIME_MS,
-              lastValidatedAt: Date.now(),
-              lastValidationFailure: undefined
-            }
-          : {
-              expiresAt: undefined,
-              lastValidatedAt: undefined,
-              lastValidationFailure: {
-                at: Date.now(),
-                category: result.category,
-                status: result.status,
-                message: result.message
-              }
-            }
-      )
-      return { ...result, applied }
-    }
-
-    const applied = await this.repository.updateClaudeIsolatedValidationIfKeyMatches(
-      provider.keyRef,
-      {
-        expiresAt: undefined,
-        lastValidatedAt: undefined,
-        lastValidationFailure: {
-          at: Date.now(),
-          category: result.category,
-          status: result.status,
-          message: result.message
-        }
-      }
-    )
-    return { ...result, applied }
+    return this.auth.cancelClaudeIsolatedLogin()
   }
 
   async logoutIsolatedClaude(): Promise<ValidateProviderResult> {
-    const status = await this.claudeIsolatedAuth.logoutIsolated()
-    if (status.message) {
-      return {
-        ok: false,
-        category: status.message.toLowerCase().includes('timed out') ? 'timeout' : 'unknown',
-        message: status.message
-      }
-    }
-
-    const settings = await this.repository.getSettings()
-    const provider = settings.providers.find(
-      (candidate) => candidate.id === CLAUDE_ISOLATED_PROVIDER_ID
-    )
-    if (provider && status.authenticated === false) {
-      await this.repository.upsertProvider({
-        ...provider,
-        expiresAt: undefined,
-        lastValidatedAt: undefined,
-        lastValidationFailure: undefined
-      })
-    }
-
-    return { ok: true, category: 'ok' }
+    return this.auth.logoutIsolatedClaude()
   }
 
   async loginClaudeShared(): Promise<ValidateProviderResult> {
-    const loginTarget = await this.repository.getSettings()
-    const targetProvider = loginTarget.providers.find(
-      (candidate) => candidate.id === CLAUDE_SHARED_PROVIDER_ID
-    )
-    this.invalidateClaudeSharedAuthStatus()
-    const authStatus = await this.claudeSharedAuth.loginShared()
-    this.invalidateClaudeSharedAuthStatus()
-    let result = this.claudeSharedAuthValidationResult(authStatus)
-
-    if (authStatus.cancelled) return { ...result, applied: false, cancelled: true }
-    if (targetProvider?.type !== 'claude-shared') return { ...result, applied: false }
-
-    const settings = await this.repository.getSettings()
-    const currentProvider = settings.providers.find(
-      (candidate) => candidate.id === CLAUDE_SHARED_PROVIDER_ID
-    )
-    if (
-      settings.claudeSubscriptionProviderId !== loginTarget.claudeSubscriptionProviderId ||
-      !isDeepStrictEqual(currentProvider, targetProvider)
-    ) {
-      return { ...result, applied: false }
-    }
-
-    const resolvedTarget = this.resolveProvider(
-      targetProvider,
-      settings.activeProviderId === targetProvider.id ? settings.activeModel : undefined
-    )
-    if (result.ok) {
-      result = await this.options.runClaudeSubscriptionProbe(resolvedTarget, settings)
-    }
-    const applied = await this.repository.updateClaudeSharedValidationIfUnchanged(
-      targetProvider,
-      loginTarget.claudeSubscriptionProviderId,
-      resolvedTarget.model,
-      result.ok
-        ? {
-            disconnectedAt: undefined,
-            lastValidatedAt: Date.now(),
-            lastValidationFailure: undefined
-          }
-        : {
-            disconnectedAt: authStatus.authenticated ? undefined : targetProvider.disconnectedAt,
-            lastValidatedAt: undefined,
-            lastValidationFailure: {
-              at: Date.now(),
-              category: result.category,
-              status: result.status,
-              message: result.message
-            }
-          }
-    )
-
-    return { ...result, applied }
+    return this.auth.loginClaudeShared()
   }
 
   async logoutClaudeShared(): Promise<ValidateProviderResult> {
-    this.invalidateClaudeSharedAuthStatus()
-    const settings = await this.repository.getSettings()
-    const provider = settings.providers.find(
-      (candidate) => candidate.id === CLAUDE_SHARED_PROVIDER_ID
-    )
-    if (provider) {
-      const disconnectedAt = Date.now()
-      await this.repository.upsertProvider({
-        ...provider,
-        disconnectedAt,
-        lastValidatedAt: undefined,
-        lastValidationFailure: {
-          at: disconnectedAt,
-          category: 'auth',
-          message: CLAUDE_SHARED_DISCONNECTED_MESSAGE
-        }
-      })
-    }
-
-    return { ok: true, category: 'ok' }
+    return this.auth.logoutClaudeShared()
   }
 
   async getClaudeSharedStatus(): Promise<ValidateProviderResult> {
-    const settings = await this.repository.getSettings()
-    const provider = settings.providers.find(
-      (candidate) => candidate.id === CLAUDE_SHARED_PROVIDER_ID
-    )
-    if (provider?.type !== 'claude-shared') {
-      return {
-        ok: false,
-        category: 'unknown',
-        message: 'Claude subscription provider is not configured.'
-      }
-    }
-
-    return this.validateClaudeSharedProvider(
-      this.resolveProvider(
-        provider,
-        settings.activeProviderId === provider.id ? settings.activeModel : undefined
-      ),
-      settings,
-      provider
-    )
-  }
-
-  private async validateClaudeSharedProvider(
-    provider: ResolvedProvider,
-    settings: StoredSettings,
-    storedProvider?: StoredProvider
-  ): Promise<ValidateProviderResult> {
-    if (storedProvider?.disconnectedAt !== undefined) {
-      return { ok: false, category: 'auth', message: CLAUDE_SHARED_DISCONNECTED_MESSAGE }
-    }
-
-    const status = await this.claudeSharedAuth.getStatus()
-    this.claudeSharedAuthStatusCache = {
-      authenticated: status.authenticated,
-      checkedAt: Date.now()
-    }
-    if (!status.authenticated) {
-      return this.claudeSharedAuthValidationResult(
-        status,
-        'Not signed in. Sign in via browser OAuth in the Settings card to connect your Claude subscription.'
-      )
-    }
-
-    return this.options.runClaudeSubscriptionProbe(provider, settings)
-  }
-
-  private claudeSharedAuthValidationResult(
-    status: ClaudeSharedAuthStatus,
-    notSignedInMessage?: string
-  ): ValidateProviderResult {
-    if (status.authenticated) return { ok: true, category: 'ok' }
-
-    return { ok: false, category: 'unknown', message: status.message ?? notSignedInMessage }
+    return this.auth.getClaudeSharedStatus()
   }
 
   async getClaudeIsolatedStatus(): Promise<ValidateProviderResult> {
-    const status = await this.claudeIsolatedAuth.getStatus()
-    if (!status.authenticated) {
-      return this.claudeIsolatedAuthValidationResult(
-        status,
-        'Not signed in. Run `claude setup-token` and paste the token to connect your Claude subscription.'
-      )
-    }
-
-    const settings = await this.repository.getSettings()
-    const provider = settings.providers.find(
-      (candidate) => candidate.id === CLAUDE_ISOLATED_PROVIDER_ID
-    )
-    if (!provider) {
-      return {
-        ok: false,
-        category: 'unknown',
-        message: 'Claude subscription provider is not configured.'
-      }
-    }
-
-    return this.options.runClaudeSubscriptionProbe(
-      this.resolveProvider(
-        provider,
-        settings.activeProviderId === provider.id ? settings.activeModel : undefined
-      ),
-      settings
-    )
-  }
-
-  private claudeIsolatedAuthValidationResult(
-    status: ClaudeIsolatedAuthStatus,
-    notSignedInMessage?: string
-  ): ValidateProviderResult {
-    if (status.authenticated) return { ok: true, category: 'ok' }
-
-    return { ok: false, category: 'unknown', message: status.message ?? notSignedInMessage }
+    return this.auth.getClaudeIsolatedStatus()
   }
 
   async setActiveProvider(id: string, model?: string): Promise<void> {
@@ -754,37 +327,21 @@ class ProviderAccountsModule {
         ? undefined
         : this.frameworkIncompatibilityResult(resolved.provider, framework)
 
+    const authResult = incompatibility
+      ? undefined
+      : await this.auth.validateProviderAuth(resolved.provider, settings, storedValidationTarget)
     const result =
       incompatibility ??
-      (isCodexSubscriptionProvider(resolved.provider.type)
-        ? this.codexAuthValidationResult(
-            await this.codexAuth.getStatus(
-              resolveCodexSubscriptionType(resolved.provider) === 'codex-shared'
-                ? 'shared'
-                : 'isolated'
-            ),
-            'Not signed in. Use Sign in to connect your ChatGPT account.'
-          )
-        : resolved.provider.type === 'claude-shared'
-          ? await this.validateClaudeSharedProvider(
-              resolved.provider,
-              settings,
-              resolved.storedId
-                ? settings.providers.find((provider) => provider.id === resolved.storedId)
-                : undefined
-            )
-          : resolved.provider.type === 'claude-isolated'
-            ? await this.getClaudeIsolatedStatus()
-            : await validateProviderTarget(resolved.provider, {
-                fetchImpl: netFetchStandard,
-                requireBridgeToolCall: requiresChatCompletionsBridge(resolved.provider, framework),
-                requireNativeResponsesCompatibility: requiresNativeResponsesCompatibility(
-                  resolved.provider,
-                  framework
-                ),
-                frameworkEndpoints:
-                  framework.id === 'codex' ? undefined : framework.supportedApiTypes
-              }))
+      authResult ??
+      (await validateProviderTarget(resolved.provider, {
+        fetchImpl: netFetchStandard,
+        requireBridgeToolCall: requiresChatCompletionsBridge(resolved.provider, framework),
+        requireNativeResponsesCompatibility: requiresNativeResponsesCompatibility(
+          resolved.provider,
+          framework
+        ),
+        frameworkEndpoints: framework.id === 'codex' ? undefined : framework.supportedApiTypes
+      }))
 
     if (!resolved.storedId) return result
     if (this.providerValidationGenerations.get(resolved.storedId) !== validationGeneration) {
@@ -834,27 +391,6 @@ class ProviderAccountsModule {
     return { ...result, applied: true }
   }
 
-  private codexAuthValidationResult(
-    status: CodexAuthStatus,
-    isolatedFallback = 'Codex sign-in did not complete.'
-  ): ValidateProviderResult {
-    if (status.authenticated) return { ok: true, category: 'ok' }
-
-    return {
-      ok: false,
-      category: status.message?.toLowerCase().includes('timed out')
-        ? 'timeout'
-        : status.supported
-          ? 'auth'
-          : 'unknown',
-      message:
-        status.message ??
-        (status.mode === 'shared'
-          ? 'No existing Codex login was found. Run `codex login` or use the isolated Open Science login.'
-          : isolatedFallback)
-    }
-  }
-
   async refreshProviderModels(
     request: RefreshProviderModelsRequest
   ): Promise<RefreshProviderModelsResult> {
@@ -898,49 +434,8 @@ class ProviderAccountsModule {
     return this.runtimeProjection.toProviderView(provider, activeModel)
   }
 
-  private invalidateClaudeSharedAuthStatus(): void {
-    this.claudeSharedAuthStatusCache = undefined
-    this.claudeSharedAuthStatusGeneration += 1
-  }
-
-  private async getClaudeSharedAuthStatus(): Promise<boolean> {
-    const cached = this.claudeSharedAuthStatusCache
-    if (cached && Date.now() - cached.checkedAt < CLAUDE_SHARED_AUTH_STATUS_TTL_MS) {
-      return cached.authenticated
-    }
-    const generation = this.claudeSharedAuthStatusGeneration
-    const pending = this.claudeSharedAuthStatusPromise
-    if (pending?.generation === generation) return pending.promise
-
-    const promise = this.claudeSharedAuth
-      .getStatus()
-      .then((status) => {
-        if (this.claudeSharedAuthStatusGeneration === generation) {
-          this.claudeSharedAuthStatusCache = {
-            authenticated: status.authenticated,
-            checkedAt: Date.now()
-          }
-        }
-        return status.authenticated
-      })
-      .finally(() => {
-        if (this.claudeSharedAuthStatusPromise?.promise === promise) {
-          this.claudeSharedAuthStatusPromise = undefined
-        }
-      })
-
-    this.claudeSharedAuthStatusPromise = { generation, promise }
-    return promise
-  }
-
   async isProviderKeyUsable(provider: StoredProvider): Promise<boolean> {
-    if (isCodexSubscriptionProvider(provider.type)) return true
-    if (provider.type === 'claude-shared') {
-      if (provider.disconnectedAt !== undefined) return false
-      return this.getClaudeSharedAuthStatus()
-    }
-
-    return Boolean(provider.keyRef) && tryDecryptKey(provider.keyRef) !== undefined
+    return this.auth.isProviderKeyUsable(provider)
   }
 
   resolveActiveModel(provider: StoredProvider | undefined, requested?: string): string | undefined {

--- a/src/main/settings/provider-auth-lifecycle.architecture.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.architecture.test.ts
@@ -21,7 +21,7 @@ import {
 import { describe, expect, it } from 'vitest'
 
 const projectRoot = resolve(__dirname, '../../..')
-const ownerPath = resolve(__dirname, 'provider-runtime-projection.ts')
+const ownerPath = resolve(__dirname, 'provider-auth-lifecycle.ts')
 const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
 const readSource = (path: string): string => readFileSync(path, 'utf8')
 const sourceFileFor = (path: string): SourceFile =>
@@ -59,7 +59,7 @@ const importsOwner = (path: string): boolean => {
   const visit = (node: Node): void => {
     if (
       isImportDeclaration(node) &&
-      node.moduleSpecifier.getText(sourceFile).includes('provider-runtime-projection')
+      node.moduleSpecifier.getText(sourceFile).includes('provider-auth-lifecycle')
     ) {
       imports = true
     }
@@ -72,7 +72,7 @@ const importsOwner = (path: string): boolean => {
 const publicOperations = (): string[] => {
   const declaration = sourceFileFor(ownerPath).statements.find(
     (statement) =>
-      isClassDeclaration(statement) && statement.name?.text === 'ProviderRuntimeProjectionOwner'
+      isClassDeclaration(statement) && statement.name?.text === 'ProviderAuthLifecycleOwner'
   )
   if (!declaration || !isClassDeclaration(declaration)) throw new Error('owner class not found')
   return declaration.members
@@ -89,22 +89,33 @@ const publicOperations = (): string[] => {
     .sort()
 }
 
-describe('Provider runtime projection ownership', () => {
+describe('Provider authentication lifecycle ownership', () => {
   it('keeps one focused owner below the production hard limit', () => {
     const source = readSource(ownerPath)
     expect(source.split(/\r?\n/).length - Number(source.endsWith('\n'))).toBeLessThanOrEqual(660)
-    expect(source).not.toMatch(/SettingsRepository|setActiveProvider|upsertProvider/)
+    expect(source).not.toMatch(/ipcMain|contextBridge|window\.api/)
+    expect(source).toContain('keyRef: encryptKey(token)')
+    expect(source).not.toMatch(/keyRef:\s*token\b/)
   })
 
   it('locks the owner interface and compatibility exports', () => {
     expect(publicOperations()).toEqual([
-      'resolveActiveModel',
-      'resolveProvider',
-      'resolveProviderApiEndpoints',
-      'resolveRuntimeModelCatalog',
-      'resolveRuntimeReasoningEffortProfile',
-      'resolveRuntimeTarget',
-      'toProviderView'
+      'cancelClaudeIsolatedLogin',
+      'cancelClaudeLogin',
+      'cancelCodexLogin',
+      'cleanupProviderBeforeDelete',
+      'getClaudeIsolatedStatus',
+      'getClaudeSharedStatus',
+      'isProviderKeyUsable',
+      'loginClaudeShared',
+      'loginIsolatedClaude',
+      'loginIsolatedClaudeBrowser',
+      'loginIsolatedCodex',
+      'logoutClaudeShared',
+      'logoutIsolatedClaude',
+      'logoutIsolatedCodex',
+      'prepareCodexProviderUpsert',
+      'validateProviderAuth'
     ])
 
     const exportDeclaration = sourceFileFor(ownerPath).statements.filter(isExportDeclaration)
@@ -118,10 +129,9 @@ describe('Provider runtime projection ownership', () => {
           : []
       )
     ).toEqual([
-      'value:ProviderRuntimeProjectionOwner',
-      'value:requiresNativeResponsesCompatibility',
-      'type:ProviderRuntimeTarget',
-      'type:RuntimeProviderModelSelection'
+      'value:CLAUDE_SHARED_DISCONNECTED_MESSAGE',
+      'value:ProviderAuthLifecycleOwner',
+      'type:ProviderAuthLifecycleOwnerOptions'
     ])
   })
 
@@ -132,15 +142,13 @@ describe('Provider runtime projection ownership', () => {
     const manifest = JSON.parse(readSource(manifestPath)) as {
       modules: Record<string, { ownerPaths: string[]; testFiles: { owner: string[] } }>
     }
-    expect(manifest.modules.settings_provider_accounts.ownerPaths).toEqual([
-      'src/main/settings/provider-accounts.ts',
-      'src/main/settings/provider-auth-lifecycle.ts',
-      'src/main/settings/provider-runtime-projection.ts'
-    ])
+    expect(manifest.modules.settings_provider_accounts.ownerPaths).toContain(
+      'src/main/settings/provider-auth-lifecycle.ts'
+    )
     expect(manifest.modules.settings_provider_accounts.testFiles.owner).toEqual(
       expect.arrayContaining([
-        'src/main/settings/provider-runtime-projection.test.ts',
-        'src/main/settings/provider-runtime-projection.architecture.test.ts'
+        'src/main/settings/provider-auth-lifecycle.test.ts',
+        'src/main/settings/provider-auth-lifecycle.architecture.test.ts'
       ])
     )
   })

--- a/src/main/settings/provider-auth-lifecycle.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.test.ts
@@ -1,0 +1,287 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  CLAUDE_ISOLATED_PROVIDER_ID,
+  CLAUDE_SHARED_PROVIDER_ID,
+  CODEX_SUBSCRIPTION_PROVIDER_ID
+} from '../../shared/settings'
+import type { CodexAuthControllerPort, CodexAuthStatus } from './codex-auth'
+import type { ClaudeIsolatedAuthControllerPort } from './claude-isolated-auth'
+import type { ClaudeSharedAuthControllerPort, ClaudeSharedAuthStatus } from './claude-shared-auth'
+import type { ProviderAuthLifecycleOwnerOptions } from './provider-auth-lifecycle'
+import { ProviderRuntimeProjectionOwner } from './provider-runtime-projection'
+import type { ValidateProviderResult } from '../../shared/settings'
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`cipher:${plaintext}`, 'utf8'),
+    decryptString: (buffer: Buffer) => buffer.toString('utf8').slice('cipher:'.length)
+  },
+  app: { getPath: () => '/home', getAppPath: () => '/home/no-such-app-root', isPackaged: false }
+}))
+
+const codexFiles = vi.hoisted(() => ({
+  ensureAuthHome: vi.fn(async () => undefined),
+  importAuthentication: vi.fn(async () => undefined)
+}))
+
+vi.mock('./codex-auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./codex-auth')>()
+  return {
+    ...actual,
+    ensureCodexAuthHome: codexFiles.ensureAuthHome,
+    importCodexAuthentication: codexFiles.importAuthentication
+  }
+})
+
+const { ProviderAuthLifecycleOwner } = await import('./provider-auth-lifecycle')
+const { SettingsRepository } = await import('./repository')
+
+const deferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason: unknown) => void
+} => {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+describe('ProviderAuthLifecycleOwner', () => {
+  let dir: string
+  let repository: InstanceType<typeof SettingsRepository>
+  let codexAuth: CodexAuthControllerPort
+  let claudeIsolatedAuth: ClaudeIsolatedAuthControllerPort
+  let claudeSharedAuth: ClaudeSharedAuthControllerPort
+  let runClaudeSubscriptionProbe: ProviderAuthLifecycleOwnerOptions['runClaudeSubscriptionProbe']
+  let owner: InstanceType<typeof ProviderAuthLifecycleOwner>
+
+  beforeEach(async () => {
+    vi.useRealTimers()
+    codexFiles.ensureAuthHome.mockReset().mockResolvedValue(undefined)
+    codexFiles.importAuthentication.mockReset().mockResolvedValue(undefined)
+    dir = await mkdtemp(join(tmpdir(), 'osci-provider-auth-'))
+    repository = new SettingsRepository(dir)
+    await repository.upsertProvider({
+      id: CLAUDE_SHARED_PROVIDER_ID,
+      type: 'claude-shared',
+      name: 'Claude shared',
+      apiEndpoints: ['anthropic']
+    })
+    codexAuth = {
+      getStatus: vi.fn(async (mode: CodexAuthStatus['mode'] = 'isolated') => ({
+        mode,
+        supported: true,
+        authenticated: true
+      })),
+      loginIsolated: vi.fn(async (): Promise<CodexAuthStatus> => ({
+        mode: 'isolated',
+        supported: true,
+        authenticated: true
+      })),
+      cancelLogin: vi.fn(async () => undefined),
+      logoutIsolated: vi.fn(async (): Promise<CodexAuthStatus> => ({
+        mode: 'isolated',
+        supported: true,
+        authenticated: false
+      }))
+    }
+    claudeIsolatedAuth = {
+      getStatus: vi.fn(async () => ({ supported: true, authenticated: false })),
+      loginIsolatedBrowser: vi.fn(async () => ({ supported: true, authenticated: false })),
+      loginIsolated: vi.fn(async () => ({ supported: true, authenticated: false })),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn(async () => ({ supported: true, authenticated: false }))
+    }
+    claudeSharedAuth = {
+      getStatus: vi.fn(async () => ({ supported: true, authenticated: true })),
+      loginShared: vi.fn(async () => ({ supported: true, authenticated: true })),
+      cancelLogin: vi.fn()
+    }
+    runClaudeSubscriptionProbe = vi.fn(async () => ({ ok: true, category: 'ok' as const }))
+    const projection = new ProviderRuntimeProjectionOwner()
+    owner = new ProviderAuthLifecycleOwner({
+      repository,
+      storageRoot: dir,
+      userClaudeDir: join(dir, 'user-claude'),
+      userCodexDir: join(dir, 'user-codex'),
+      resolveCodexExecutable: vi.fn(async () => '/codex-acp'),
+      resolveCodexProxyEnvironment: vi.fn(async () => undefined),
+      runClaudeSubscriptionProbe,
+      resolveProvider: (provider, model) => projection.resolveProvider(provider, model),
+      codexAuth,
+      claudeIsolatedAuth,
+      claudeSharedAuth
+    })
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('coalesces shared status reads and invalidates them across logout and login', async () => {
+    const stored = (await repository.getSettings()).providers[0]
+    const firstStatus = deferred<ClaudeSharedAuthStatus>()
+    vi.mocked(claudeSharedAuth.getStatus).mockImplementationOnce(() => firstStatus.promise)
+
+    const first = owner.isProviderKeyUsable(stored)
+    const second = owner.isProviderKeyUsable(stored)
+    expect(claudeSharedAuth.getStatus).toHaveBeenCalledOnce()
+    firstStatus.resolve({ supported: true, authenticated: true })
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true])
+
+    await owner.logoutClaudeShared()
+    const disconnected = (await repository.getSettings()).providers[0]
+    await expect(owner.isProviderKeyUsable(disconnected)).resolves.toBe(false)
+    expect(claudeSharedAuth.getStatus).toHaveBeenCalledOnce()
+
+    await owner.loginClaudeShared()
+    const reconnected = (await repository.getSettings()).providers[0]
+    await expect(owner.isProviderKeyUsable(reconnected)).resolves.toBe(true)
+    expect(claudeSharedAuth.getStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancels the matching authentication owners before cleanup completes', async () => {
+    await owner.cleanupProviderBeforeDelete('builtin-codex-subscription')
+    expect(codexAuth.cancelLogin).toHaveBeenCalledOnce()
+    expect(claudeIsolatedAuth.cancelLogin).not.toHaveBeenCalled()
+    expect(claudeSharedAuth.cancelLogin).not.toHaveBeenCalled()
+
+    await owner.cleanupProviderBeforeDelete(CLAUDE_SHARED_PROVIDER_ID)
+    expect(claudeIsolatedAuth.cancelLogin).toHaveBeenCalledOnce()
+    expect(claudeSharedAuth.cancelLogin).toHaveBeenCalledOnce()
+  })
+
+  it('does not apply a shared login result after its provider target changes', async () => {
+    const login = deferred<ClaudeSharedAuthStatus>()
+    vi.mocked(claudeSharedAuth.loginShared).mockImplementationOnce(() => login.promise)
+
+    const result = owner.loginClaudeShared()
+    await vi.waitFor(() => expect(claudeSharedAuth.loginShared).toHaveBeenCalledOnce())
+    const stored = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({ ...stored, name: 'Changed while signing in' })
+    login.resolve({ supported: true, authenticated: true })
+
+    await expect(result).resolves.toMatchObject({ ok: true, applied: false })
+    expect((await repository.getSettings()).providers[0].name).toBe('Changed while signing in')
+  })
+
+  it('invalidates reimported Codex validation before auth-home finalization can fail', async () => {
+    const ensure = deferred<undefined>()
+    codexFiles.ensureAuthHome.mockImplementationOnce(() => ensure.promise)
+    const invalidated = vi.fn()
+    const prepared = owner.prepareCodexProviderUpsert(
+      { type: 'codex-shared', reimportCodexAuthentication: true },
+      undefined,
+      invalidated
+    )
+    const failed = expect(prepared).rejects.toThrow('auth home failed')
+
+    await vi.waitFor(() => expect(codexFiles.importAuthentication).toHaveBeenCalledOnce())
+    expect(invalidated).toHaveBeenCalledOnce()
+    ensure.reject(new Error('auth home failed'))
+    await failed
+  })
+
+  it('applies an isolated Codex login result to the current provider', async () => {
+    await repository.deleteProvider(CLAUDE_SHARED_PROVIDER_ID)
+    await repository.upsertProvider({
+      id: CODEX_SUBSCRIPTION_PROVIDER_ID,
+      type: 'codex-isolated',
+      codexAuthMode: 'isolated',
+      name: 'Open Science Codex login',
+      apiEndpoints: ['responses']
+    })
+
+    await expect(owner.loginIsolatedCodex()).resolves.toMatchObject({
+      ok: true,
+      category: 'ok',
+      applied: true
+    })
+    expect((await repository.getSettings()).providers[0].lastValidatedAt).toBeTypeOf('number')
+  })
+
+  it('does not apply an isolated Claude probe after its credential changes', async () => {
+    await repository.deleteProvider(CLAUDE_SHARED_PROVIDER_ID)
+    await repository.upsertProvider({
+      id: CLAUDE_ISOLATED_PROVIDER_ID,
+      type: 'claude-isolated',
+      name: 'Open Science Claude login',
+      apiEndpoints: ['anthropic'],
+      keyRef: 'plain:old-token'
+    })
+    vi.mocked(claudeIsolatedAuth.loginIsolated).mockResolvedValueOnce({
+      supported: true,
+      authenticated: true
+    })
+    const probe = deferred<ValidateProviderResult>()
+    vi.mocked(runClaudeSubscriptionProbe).mockImplementationOnce(() => probe.promise)
+
+    const result = owner.loginIsolatedClaude('old-token')
+    await vi.waitFor(() => expect(runClaudeSubscriptionProbe).toHaveBeenCalledOnce())
+    const stored = (await repository.getSettings()).providers[0]
+    await repository.upsertProvider({ ...stored, keyRef: 'plain:new-token' })
+    probe.resolve({ ok: true, category: 'ok' })
+
+    await expect(result).resolves.toMatchObject({ ok: true, applied: false })
+    expect((await repository.getSettings()).providers[0].keyRef).toBe('plain:new-token')
+  })
+
+  it('reports isolated Claude logout failure and clears validation only on logout truth', async () => {
+    await repository.deleteProvider(CLAUDE_SHARED_PROVIDER_ID)
+    await repository.upsertProvider({
+      id: CLAUDE_ISOLATED_PROVIDER_ID,
+      type: 'claude-isolated',
+      name: 'Open Science Claude login',
+      apiEndpoints: ['anthropic'],
+      expiresAt: 123,
+      lastValidatedAt: 456
+    })
+    vi.mocked(claudeIsolatedAuth.logoutIsolated).mockResolvedValueOnce({
+      supported: true,
+      authenticated: true,
+      message: 'Logout timed out.'
+    })
+
+    await expect(owner.logoutIsolatedClaude()).resolves.toMatchObject({
+      ok: false,
+      category: 'timeout',
+      message: 'Logout timed out.'
+    })
+    expect((await repository.getSettings()).providers[0]).toMatchObject({
+      expiresAt: 123,
+      lastValidatedAt: 456
+    })
+
+    vi.mocked(claudeIsolatedAuth.logoutIsolated).mockResolvedValueOnce({
+      supported: true,
+      authenticated: false
+    })
+    await expect(owner.logoutIsolatedClaude()).resolves.toMatchObject({ ok: true, category: 'ok' })
+    expect((await repository.getSettings()).providers[0]).not.toHaveProperty('expiresAt')
+    expect((await repository.getSettings()).providers[0]).not.toHaveProperty('lastValidatedAt')
+  })
+
+  it('refreshes the shared Claude status after its cache TTL', async () => {
+    vi.useFakeTimers()
+    const stored = (await repository.getSettings()).providers[0]
+
+    await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(true)
+    await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(true)
+    expect(claudeSharedAuth.getStatus).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(5_001)
+    await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(true)
+    expect(claudeSharedAuth.getStatus).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/settings/provider-auth-lifecycle.ts
+++ b/src/main/settings/provider-auth-lifecycle.ts
@@ -1,0 +1,600 @@
+import { isDeepStrictEqual } from 'node:util'
+
+import type { UpsertProviderRequest, ValidateProviderResult } from '../../shared/settings'
+import {
+  CLAUDE_ISOLATED_PROVIDER_ID,
+  CLAUDE_SHARED_PROVIDER_ID,
+  codexSubscriptionProviderIdentity,
+  isClaudeSubscriptionProviderId,
+  isCodexSubscriptionProvider,
+  isCodexSubscriptionProviderId,
+  resolveCodexSubscriptionType
+} from '../../shared/settings'
+import { codexSubscriptionStorageDir } from '../agent-framework/codex'
+import {
+  clearAppOwnedCodexAuthentication,
+  clearImportedCodexProviderRoute,
+  CodexAuthController,
+  ensureCodexAuthHome,
+  importCodexAuthentication,
+  openCodexAuthSession,
+  type CodexAuthControllerPort,
+  type CodexAuthStatus
+} from './codex-auth'
+import {
+  ClaudeIsolatedAuthController,
+  type ClaudeIsolatedAuthControllerPort,
+  type ClaudeIsolatedAuthStatus
+} from './claude-isolated-auth'
+import {
+  ClaudeSharedAuthController,
+  type ClaudeSharedAuthControllerPort,
+  type ClaudeSharedAuthStatus
+} from './claude-shared-auth'
+import { encryptKey, isEncryptionAvailable, maskKey, tryDecryptKey } from './crypto'
+import { getAppClaudeConfigDir, type ResolvedProvider } from './provider-env'
+import type { SettingsRepository } from './repository'
+import type { SystemProxyEnvironment } from './system-proxy'
+import type { StoredProvider, StoredSettings } from './types'
+
+const CLAUDE_SHARED_AUTH_STATUS_TTL_MS = 5_000
+const SETUP_TOKEN_LIFETIME_MS = 365 * 24 * 60 * 60 * 1000
+const CLAUDE_SHARED_DISCONNECTED_MESSAGE =
+  'Claude is disconnected from Open Science. Sign in again to use your shared Claude profile.'
+
+type ProviderAuthLifecycleOwnerOptions = {
+  repository: SettingsRepository
+  storageRoot: string
+  userClaudeDir: string
+  userCodexDir: string
+  resolveCodexExecutable: (
+    adapterPath: string | undefined,
+    nativePath: string | undefined
+  ) => Promise<string>
+  resolveCodexProxyEnvironment: () => Promise<SystemProxyEnvironment | undefined>
+  runClaudeSubscriptionProbe: (
+    provider: ResolvedProvider,
+    settings: StoredSettings
+  ) => Promise<ValidateProviderResult>
+  resolveProvider: (provider: StoredProvider, modelOverride?: string) => ResolvedProvider
+  codexAuth?: CodexAuthControllerPort
+  claudeIsolatedAuth?: ClaudeIsolatedAuthControllerPort
+  claudeSharedAuth?: ClaudeSharedAuthControllerPort
+}
+
+class ProviderAuthLifecycleOwner {
+  private readonly repository: SettingsRepository
+  private readonly codexAuth: CodexAuthControllerPort
+  private readonly claudeIsolatedAuth: ClaudeIsolatedAuthControllerPort
+  private readonly claudeSharedAuth: ClaudeSharedAuthControllerPort
+  private claudeSharedAuthStatusCache: { authenticated: boolean; checkedAt: number } | undefined
+  private claudeSharedAuthStatusGeneration = 0
+  private claudeSharedAuthStatusPromise:
+    { generation: number; promise: Promise<boolean> } | undefined
+
+  constructor(private readonly options: ProviderAuthLifecycleOwnerOptions) {
+    this.repository = options.repository
+    this.codexAuth =
+      options.codexAuth ??
+      new CodexAuthController({
+        openSession: async (mode) => {
+          const settings = await this.repository.getSettings()
+          return openCodexAuthSession({
+            adapterPath: await options.resolveCodexExecutable(
+              settings.codex?.resolvedPath,
+              settings.codex?.nativePath
+            ),
+            nativePath: settings.codex?.nativePath,
+            mode,
+            storageRoot: options.storageRoot,
+            proxyEnv: await options.resolveCodexProxyEnvironment()
+          })
+        }
+      })
+    this.claudeIsolatedAuth =
+      options.claudeIsolatedAuth ??
+      new ClaudeIsolatedAuthController({
+        store: {
+          loadToken: () => this.loadClaudeIsolatedToken(),
+          saveToken: (token) => this.saveClaudeIsolatedToken(token),
+          clearToken: () => this.clearClaudeIsolatedToken(),
+          isEncryptionAvailable: () => isEncryptionAvailable()
+        },
+        claudePath: async () => {
+          const settings = await this.repository.getSettings()
+          return settings.claude?.resolvedPath ?? 'claude'
+        },
+        configDir: getAppClaudeConfigDir(options.storageRoot)
+      })
+    this.claudeSharedAuth =
+      options.claudeSharedAuth ??
+      new ClaudeSharedAuthController({
+        claudePath: async () => {
+          const settings = await this.repository.getSettings()
+          return settings.claude?.resolvedPath ?? 'claude'
+        },
+        configDir: options.userClaudeDir
+      })
+  }
+
+  private async loadClaudeIsolatedToken(): Promise<string | undefined> {
+    const settings = await this.repository.getSettings()
+    const provider = settings.providers.find(
+      (candidate) => candidate.id === CLAUDE_ISOLATED_PROVIDER_ID
+    )
+    return provider?.keyRef ? tryDecryptKey(provider.keyRef) : undefined
+  }
+
+  private async saveClaudeIsolatedToken(token: string): Promise<void> {
+    const applied = await this.repository.updateClaudeIsolatedCredentialsIfExists({
+      keyRef: encryptKey(token),
+      keyMask: maskKey(token)
+    })
+    if (!applied) throw new Error('The Claude provider was removed before sign-in completed.')
+  }
+
+  private async clearClaudeIsolatedToken(): Promise<void> {
+    await this.repository.updateClaudeIsolatedCredentialsIfExists({
+      keyRef: undefined,
+      keyMask: undefined
+    })
+  }
+
+  async prepareCodexProviderUpsert(
+    request: UpsertProviderRequest,
+    existing: StoredProvider | undefined,
+    onAuthenticationReimported: () => void
+  ): Promise<void> {
+    const reimport = request.type === 'codex-shared' && request.reimportCodexAuthentication === true
+    if (request.type === 'codex-shared' && (existing?.codexAuthMode !== 'imported' || reimport)) {
+      await this.codexAuth.cancelLogin()
+      await importCodexAuthentication(
+        this.options.userCodexDir,
+        codexSubscriptionStorageDir(this.options.storageRoot)
+      )
+      if (reimport) onAuthenticationReimported()
+    } else if (request.type === 'codex-isolated' && existing?.codexAuthMode !== 'isolated') {
+      if (existing) await this.codexAuth.cancelLogin()
+      const codexHome = codexSubscriptionStorageDir(this.options.storageRoot)
+      await clearImportedCodexProviderRoute(codexHome)
+      await clearAppOwnedCodexAuthentication(codexHome)
+    }
+    if (isCodexSubscriptionProvider(request.type)) {
+      await ensureCodexAuthHome(
+        request.type === 'codex-shared' ? 'shared' : 'isolated',
+        this.options.storageRoot
+      )
+    }
+  }
+
+  async cleanupProviderBeforeDelete(id: string): Promise<void> {
+    if (isCodexSubscriptionProviderId(id)) {
+      await this.codexAuth.cancelLogin()
+      const codexHome = codexSubscriptionStorageDir(this.options.storageRoot)
+      await clearImportedCodexProviderRoute(codexHome)
+      await clearAppOwnedCodexAuthentication(codexHome)
+    }
+    if (isClaudeSubscriptionProviderId(id)) {
+      this.claudeIsolatedAuth.cancelLogin()
+      this.claudeSharedAuth.cancelLogin()
+    }
+  }
+
+  cancelCodexLogin(): void {
+    void this.codexAuth.cancelLogin()
+  }
+
+  cancelClaudeLogin(): void {
+    this.claudeSharedAuth.cancelLogin()
+  }
+
+  async loginIsolatedCodex(): Promise<ValidateProviderResult> {
+    const result = this.codexAuthValidationResult(await this.codexAuth.loginIsolated())
+    const settings = await this.repository.getSettings()
+    const provider = settings.providers.find(
+      (candidate) => candidate.id === codexSubscriptionProviderIdentity().id
+    )
+    if (provider?.type !== 'codex-isolated' || provider.codexAuthMode !== 'isolated') {
+      return { ...result, applied: false }
+    }
+
+    await this.repository.upsertProvider(
+      result.ok
+        ? { ...provider, lastValidatedAt: Date.now(), lastValidationFailure: undefined }
+        : {
+            ...provider,
+            lastValidatedAt: undefined,
+            lastValidationFailure: {
+              at: Date.now(),
+              category: result.category,
+              status: result.status,
+              message: result.message
+            }
+          }
+    )
+    return { ...result, applied: true }
+  }
+
+  async logoutIsolatedCodex(): Promise<ValidateProviderResult> {
+    const settings = await this.repository.getSettings()
+    const provider = settings.providers.find(
+      (candidate) => candidate.id === codexSubscriptionProviderIdentity().id
+    )
+    if (provider?.type !== 'codex-isolated' || provider.codexAuthMode !== 'isolated') {
+      return {
+        ok: false,
+        category: 'unknown',
+        message: 'No isolated Open Science Codex login is configured.'
+      }
+    }
+
+    await this.codexAuth.cancelLogin()
+    try {
+      await ensureCodexAuthHome('isolated', this.options.storageRoot)
+      await clearAppOwnedCodexAuthentication(codexSubscriptionStorageDir(this.options.storageRoot))
+    } catch {
+      return {
+        ok: false,
+        category: 'unknown',
+        message: 'The Open Science Codex login could not be removed.'
+      }
+    }
+
+    await this.repository.upsertProvider({
+      ...provider,
+      lastValidatedAt: undefined,
+      lastValidationFailure: undefined
+    })
+    return { ok: true, category: 'ok' }
+  }
+
+  async loginIsolatedClaude(token: string): Promise<ValidateProviderResult> {
+    return this.finalizeClaudeIsolatedLogin(
+      this.claudeIsolatedAuthValidationResult(await this.claudeIsolatedAuth.loginIsolated(token))
+    )
+  }
+
+  async loginIsolatedClaudeBrowser(): Promise<ValidateProviderResult> {
+    const authStatus = await this.claudeIsolatedAuth.loginIsolatedBrowser()
+    if (authStatus.cancelled) {
+      return {
+        ok: false,
+        category: 'unknown',
+        message: authStatus.message,
+        applied: false,
+        cancelled: true
+      }
+    }
+    return this.finalizeClaudeIsolatedLogin(this.claudeIsolatedAuthValidationResult(authStatus))
+  }
+
+  async cancelClaudeIsolatedLogin(): Promise<void> {
+    this.claudeIsolatedAuth.cancelLogin()
+  }
+
+  private async finalizeClaudeIsolatedLogin(
+    initialResult: ValidateProviderResult
+  ): Promise<ValidateProviderResult> {
+    let result = initialResult
+    const settings = await this.repository.getSettings()
+    const provider = settings.providers.find(
+      (candidate) => candidate.id === CLAUDE_ISOLATED_PROVIDER_ID
+    )
+    if (!provider) return { ...result, applied: false }
+
+    if (result.ok) {
+      result = await this.options.runClaudeSubscriptionProbe(
+        this.options.resolveProvider(
+          provider,
+          settings.activeProviderId === provider.id ? settings.activeModel : undefined
+        ),
+        settings
+      )
+    }
+    const applied = await this.repository.updateClaudeIsolatedValidationIfKeyMatches(
+      provider.keyRef,
+      result.ok
+        ? {
+            expiresAt: Date.now() + SETUP_TOKEN_LIFETIME_MS,
+            lastValidatedAt: Date.now(),
+            lastValidationFailure: undefined
+          }
+        : {
+            expiresAt: undefined,
+            lastValidatedAt: undefined,
+            lastValidationFailure: {
+              at: Date.now(),
+              category: result.category,
+              status: result.status,
+              message: result.message
+            }
+          }
+    )
+    return { ...result, applied }
+  }
+
+  async logoutIsolatedClaude(): Promise<ValidateProviderResult> {
+    const status = await this.claudeIsolatedAuth.logoutIsolated()
+    if (status.message) {
+      return {
+        ok: false,
+        category: status.message.toLowerCase().includes('timed out') ? 'timeout' : 'unknown',
+        message: status.message
+      }
+    }
+
+    const settings = await this.repository.getSettings()
+    const provider = settings.providers.find(
+      (candidate) => candidate.id === CLAUDE_ISOLATED_PROVIDER_ID
+    )
+    if (provider && status.authenticated === false) {
+      await this.repository.upsertProvider({
+        ...provider,
+        expiresAt: undefined,
+        lastValidatedAt: undefined,
+        lastValidationFailure: undefined
+      })
+    }
+    return { ok: true, category: 'ok' }
+  }
+
+  async loginClaudeShared(): Promise<ValidateProviderResult> {
+    const loginTarget = await this.repository.getSettings()
+    const targetProvider = loginTarget.providers.find(
+      (candidate) => candidate.id === CLAUDE_SHARED_PROVIDER_ID
+    )
+    this.invalidateClaudeSharedAuthStatus()
+    const authStatus = await this.claudeSharedAuth.loginShared()
+    this.invalidateClaudeSharedAuthStatus()
+    let result = this.claudeSharedAuthValidationResult(authStatus)
+
+    if (authStatus.cancelled) return { ...result, applied: false, cancelled: true }
+    if (targetProvider?.type !== 'claude-shared') return { ...result, applied: false }
+
+    const settings = await this.repository.getSettings()
+    const currentProvider = settings.providers.find(
+      (candidate) => candidate.id === CLAUDE_SHARED_PROVIDER_ID
+    )
+    if (
+      settings.claudeSubscriptionProviderId !== loginTarget.claudeSubscriptionProviderId ||
+      !isDeepStrictEqual(currentProvider, targetProvider)
+    ) {
+      return { ...result, applied: false }
+    }
+
+    const resolvedTarget = this.options.resolveProvider(
+      targetProvider,
+      settings.activeProviderId === targetProvider.id ? settings.activeModel : undefined
+    )
+    if (result.ok) {
+      result = await this.options.runClaudeSubscriptionProbe(resolvedTarget, settings)
+    }
+    const applied = await this.repository.updateClaudeSharedValidationIfUnchanged(
+      targetProvider,
+      loginTarget.claudeSubscriptionProviderId,
+      resolvedTarget.model,
+      result.ok
+        ? {
+            disconnectedAt: undefined,
+            lastValidatedAt: Date.now(),
+            lastValidationFailure: undefined
+          }
+        : {
+            disconnectedAt: authStatus.authenticated ? undefined : targetProvider.disconnectedAt,
+            lastValidatedAt: undefined,
+            lastValidationFailure: {
+              at: Date.now(),
+              category: result.category,
+              status: result.status,
+              message: result.message
+            }
+          }
+    )
+
+    return { ...result, applied }
+  }
+
+  async logoutClaudeShared(): Promise<ValidateProviderResult> {
+    this.invalidateClaudeSharedAuthStatus()
+    const settings = await this.repository.getSettings()
+    const provider = settings.providers.find(
+      (candidate) => candidate.id === CLAUDE_SHARED_PROVIDER_ID
+    )
+    if (provider) {
+      const disconnectedAt = Date.now()
+      await this.repository.upsertProvider({
+        ...provider,
+        disconnectedAt,
+        lastValidatedAt: undefined,
+        lastValidationFailure: {
+          at: disconnectedAt,
+          category: 'auth',
+          message: CLAUDE_SHARED_DISCONNECTED_MESSAGE
+        }
+      })
+    }
+
+    return { ok: true, category: 'ok' }
+  }
+
+  async getClaudeSharedStatus(): Promise<ValidateProviderResult> {
+    const settings = await this.repository.getSettings()
+    const provider = settings.providers.find(
+      (candidate) => candidate.id === CLAUDE_SHARED_PROVIDER_ID
+    )
+    if (provider?.type !== 'claude-shared') {
+      return {
+        ok: false,
+        category: 'unknown',
+        message: 'Claude subscription provider is not configured.'
+      }
+    }
+
+    return this.validateClaudeSharedProvider(
+      this.options.resolveProvider(
+        provider,
+        settings.activeProviderId === provider.id ? settings.activeModel : undefined
+      ),
+      settings,
+      provider
+    )
+  }
+
+  async getClaudeIsolatedStatus(): Promise<ValidateProviderResult> {
+    const status = await this.claudeIsolatedAuth.getStatus()
+    if (!status.authenticated) {
+      return this.claudeIsolatedAuthValidationResult(
+        status,
+        'Not signed in. Run `claude setup-token` and paste the token to connect your Claude subscription.'
+      )
+    }
+
+    const settings = await this.repository.getSettings()
+    const provider = settings.providers.find(
+      (candidate) => candidate.id === CLAUDE_ISOLATED_PROVIDER_ID
+    )
+    if (!provider) {
+      return {
+        ok: false,
+        category: 'unknown',
+        message: 'Claude subscription provider is not configured.'
+      }
+    }
+
+    return this.options.runClaudeSubscriptionProbe(
+      this.options.resolveProvider(
+        provider,
+        settings.activeProviderId === provider.id ? settings.activeModel : undefined
+      ),
+      settings
+    )
+  }
+
+  async validateProviderAuth(
+    provider: ResolvedProvider,
+    settings: StoredSettings,
+    storedProvider?: StoredProvider
+  ): Promise<ValidateProviderResult | undefined> {
+    if (isCodexSubscriptionProvider(provider.type)) {
+      return this.codexAuthValidationResult(
+        await this.codexAuth.getStatus(
+          resolveCodexSubscriptionType(provider) === 'codex-shared' ? 'shared' : 'isolated'
+        ),
+        'Not signed in. Use Sign in to connect your ChatGPT account.'
+      )
+    }
+    if (provider.type === 'claude-shared') {
+      return this.validateClaudeSharedProvider(provider, settings, storedProvider)
+    }
+    if (provider.type === 'claude-isolated') return this.getClaudeIsolatedStatus()
+    return undefined
+  }
+
+  async isProviderKeyUsable(provider: StoredProvider): Promise<boolean> {
+    if (isCodexSubscriptionProvider(provider.type)) return true
+    if (provider.type === 'claude-shared') {
+      if (provider.disconnectedAt !== undefined) return false
+      return this.getClaudeSharedAuthStatus()
+    }
+
+    return Boolean(provider.keyRef) && tryDecryptKey(provider.keyRef) !== undefined
+  }
+
+  private invalidateClaudeSharedAuthStatus(): void {
+    this.claudeSharedAuthStatusCache = undefined
+    this.claudeSharedAuthStatusGeneration += 1
+  }
+
+  private async getClaudeSharedAuthStatus(): Promise<boolean> {
+    const cached = this.claudeSharedAuthStatusCache
+    if (cached && Date.now() - cached.checkedAt < CLAUDE_SHARED_AUTH_STATUS_TTL_MS) {
+      return cached.authenticated
+    }
+    const generation = this.claudeSharedAuthStatusGeneration
+    const pending = this.claudeSharedAuthStatusPromise
+    if (pending?.generation === generation) return pending.promise
+
+    const promise = this.claudeSharedAuth
+      .getStatus()
+      .then((status) => {
+        if (this.claudeSharedAuthStatusGeneration === generation) {
+          this.claudeSharedAuthStatusCache = {
+            authenticated: status.authenticated,
+            checkedAt: Date.now()
+          }
+        }
+        return status.authenticated
+      })
+      .finally(() => {
+        if (this.claudeSharedAuthStatusPromise?.promise === promise) {
+          this.claudeSharedAuthStatusPromise = undefined
+        }
+      })
+
+    this.claudeSharedAuthStatusPromise = { generation, promise }
+    return promise
+  }
+
+  private claudeSharedAuthValidationResult(
+    status: ClaudeSharedAuthStatus,
+    notSignedInMessage?: string
+  ): ValidateProviderResult {
+    if (status.authenticated) return { ok: true, category: 'ok' }
+
+    return { ok: false, category: 'unknown', message: status.message ?? notSignedInMessage }
+  }
+
+  private async validateClaudeSharedProvider(
+    provider: ResolvedProvider,
+    settings: StoredSettings,
+    storedProvider?: StoredProvider
+  ): Promise<ValidateProviderResult> {
+    if (storedProvider?.disconnectedAt !== undefined) {
+      return { ok: false, category: 'auth', message: CLAUDE_SHARED_DISCONNECTED_MESSAGE }
+    }
+
+    const status = await this.claudeSharedAuth.getStatus()
+    this.claudeSharedAuthStatusCache = {
+      authenticated: status.authenticated,
+      checkedAt: Date.now()
+    }
+    if (!status.authenticated) {
+      return this.claudeSharedAuthValidationResult(
+        status,
+        'Not signed in. Sign in via browser OAuth in the Settings card to connect your Claude subscription.'
+      )
+    }
+    return this.options.runClaudeSubscriptionProbe(provider, settings)
+  }
+
+  private claudeIsolatedAuthValidationResult(
+    status: ClaudeIsolatedAuthStatus,
+    notSignedInMessage?: string
+  ): ValidateProviderResult {
+    if (status.authenticated) return { ok: true, category: 'ok' }
+    return { ok: false, category: 'unknown', message: status.message ?? notSignedInMessage }
+  }
+
+  private codexAuthValidationResult(
+    status: CodexAuthStatus,
+    isolatedFallback = 'Codex sign-in did not complete.'
+  ): ValidateProviderResult {
+    if (status.authenticated) return { ok: true, category: 'ok' }
+    return {
+      ok: false,
+      category: status.message?.toLowerCase().includes('timed out')
+        ? 'timeout'
+        : status.supported
+          ? 'auth'
+          : 'unknown',
+      message:
+        status.message ??
+        (status.mode === 'shared'
+          ? 'No existing Codex login was found. Run `codex login` or use the isolated Open Science login.'
+          : isolatedFallback)
+    }
+  }
+}
+
+export { CLAUDE_SHARED_DISCONNECTED_MESSAGE, ProviderAuthLifecycleOwner }
+export type { ProviderAuthLifecycleOwnerOptions }

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -270,7 +270,7 @@ describe('Settings backend ownership architecture', () => {
     expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(700)
     expect(rawLineCount(readSource(settingsPaths.recordCodec))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.documentCodec))).toBeLessThanOrEqual(660)
-    expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(1095)
+    expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(600)
     expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1407)
     expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(600)
     expect(rawLineCount(readSource(settingsPaths.service))).toBeLessThanOrEqual(1003)
@@ -473,6 +473,7 @@ describe('Settings backend ownership architecture', () => {
       'src/main/settings/notebook-runtime-settings.ts',
       'src/main/settings/preferences.ts',
       'src/main/settings/provider-accounts.ts',
+      'src/main/settings/provider-auth-lifecycle.ts',
       'src/main/settings/service.ts',
       'src/main/settings/skill-catalog.ts'
     ])


### PR DESCRIPTION
## Problem

After runtime projection moved out, `provider-accounts.ts` still owned provider CRUD and latest-wins validation together with Codex/Claude login, logout, cancellation, credential cleanup and shared-Claude status caching. That kept credential-sensitive lifecycle state in the facade and left it at 1,095 raw lines.

## Proposed change

- Extract `ProviderAuthLifecycleOwner` as the single owner of Codex and Claude authentication sessions, credential persistence/cleanup, deletion pre-cleanup and shared-Claude cache generation/coalescing/invalidation.
- Keep CRUD, active selection and latest-wins validation generation/CAS in `ProviderAccountsModule`; reduce the facade to 590 raw lines while keeping the owner at 600.
- Preserve the original Codex reimport ordering: invalidate in-flight validation immediately after a successful import and before auth-home finalization.
- Add direct owner tests for authentication results, cancellation, stale completions, logout truth/error behavior and cache TTL/coalescing/invalidation.
- Add architecture, secret-handling and module-impact locks for the new internal owner.

```mermaid
flowchart LR
  Consumers["SettingsService / backend consumers"] --> Facade["ProviderAccountsModule facade"]
  Facade --> Crud["CRUD + latest-wins validation commit"]
  Facade --> Auth["ProviderAuthLifecycleOwner"]
  Auth --> Controllers["Codex / Claude auth controllers"]
  Auth --> Repo["Credential-safe repository CAS"]
```

## Scope and non-goals

- No public method, IPC contract, provider record shape, migration order, credential encoding or user-facing error/result rewrite.
- No generic authentication framework and no separate validation owner in this PR.
- No renderer, preload, Web transport, CLI, Task, Notebook local RPC/MCP or runtime protocol production change.
- R2/D2 ownership and impact gates merged in the latest main are retained unchanged.

## Compatibility

- Public exports and every `ProviderAccountsModule` operation remain stable; its existing consumers continue to use the facade.
- Cancellation-before-delete, logout truth, cache TTL/coalescing/invalidation, generation/CAS ordering and stale-result rejection are preserved and directly certified.
- Plaintext credentials remain transient in main; stored credentials remain encrypted references and public views remain masked.
- Electron, local/remote Web, CLI, Task, Notebook local RPC/MCP and current Specialist/Permission/Compute capability asymmetry are unchanged.
- There is no data-model, data-relationship or user-interaction change; the architecture change is internal state ownership only.

## Acceptance criteria and validation

All listed checks ran after the last material edit and after rebasing onto final local `origin/main=9574fe88` (`HEAD=3010b997`):

- Provider auth owner/facade behavior, auth controllers, validation, backend consumers and renderer auth slice -> `npm test -- --run --maxWorkers=1 <20 settings-provider test files>` -> 20 files, 320 tests passed.
- Module-impact portability, ownership and selection -> `npm test -- --run scripts/ci/validate-module-impact.test.ts scripts/ci/module-test-impact.test.ts` -> 2 files, 26 tests passed.
- Node and Web compile contracts -> `npm run typecheck` -> passed.
- Changed TypeScript lint -> `npm exec eslint -- --no-cache <changed TypeScript files>` -> 0 errors and 0 warnings.
- Formatting and whitespace -> Prettier on changed files plus `git diff --check origin/main...HEAD` -> passed.
- Independent exact-base review -> Standards: 0 code/architecture findings; Spec: 0 findings.

The user explicitly authorized local selective validation with exact-head CI as the full-suite authority. Because `scripts/ci/module-impact.json` adds an `ownerPaths` entry, this is a documented exception to CONTRIBUTING's default local full-fallback rule: exact-head CI must pass the complete portable plan and Windows/macOS/Linux lanes before merge. No uncovered behavioral risk is known.

## Review focus

- Confirm the owner contains authentication lifecycle state while CRUD and latest-wins validation commits remain in the facade.
- Verify Codex reimport advances validation generation after import but before fallible auth-home finalization.
- Check isolated/shared Claude stale-result CAS, logout truth and shared cache invalidation/coalescing semantics.
- Confirm secrets remain main-only/encrypted at rest and public/IPC/cross-surface compatibility is unchanged.
- Verify R2/D2 architecture and module-impact ownership remain intact.
