### PR TITLE
refactor(settings): extract atomic document store

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -176,9 +176,10 @@
         "src/main/compute/compute-host-profile-owner.ts",
         "src/main/compute/compute-job-workflow-owner.ts",
         "src/main/compute/compute-remote-operation-owner.ts",
+        "src/main/compute/permission-grant-adapter.ts",
         "src/main/compute/compute-service.ts"
       ],
-      "interfacePaths": ["src/main/compute/compute-service.ts"],
+      "interfacePaths": ["src/main/compute/compute-service.ts", "src/main/compute/ipc.ts"],
       "consumerModules": [],
       "testFiles": {
         "owner": [
@@ -186,6 +187,7 @@
           "src/main/compute/compute-host-profile-owner.test.ts",
           "src/main/compute/compute-job-workflow-owner.test.ts",
           "src/main/compute/compute-remote-operation-owner.test.ts",
+          "src/main/compute/permission-grant-adapter.test.ts",
           "src/main/compute/compute-service.test.ts",
           "src/main/compute/compute-jobs.integration.test.ts",
           "src/main/compute/concurrency-integration.test.ts"
@@ -214,7 +216,9 @@
       "ownerPaths": [
         "src/main/settings/repository.ts",
         "src/main/settings/record-codec.ts",
-        "src/main/settings/document-codec.ts"
+        "src/main/settings/document-codec.ts",
+        "src/main/settings/document-store.ts",
+        "src/main/settings/compute-grant-port.ts"
       ],
       "interfacePaths": ["src/main/settings/repository.ts"],
       "consumerModules": [
@@ -225,6 +229,7 @@
       "testFiles": {
         "owner": [
           "src/main/settings/settings-backend.architecture.test.ts",
+          "src/main/settings/document-store.test.ts",
           "src/main/settings/document-codec.test.ts",
           "src/main/settings/record-codec.test.ts",
           "src/main/settings/repository.test.ts",
@@ -237,6 +242,7 @@
         "consumer": [
           "src/main/settings/service.test.ts",
           "src/main/compute/ipc.test.ts",
+          "src/main/compute/permission-grant-adapter.test.ts",
           "src/main/settings/agent-runtime-manager.test.ts",
           "src/main/settings/connector-settings.test.ts",
           "src/main/settings/notebook-runtime-settings.test.ts",

--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -353,15 +353,20 @@ describe('Compute service architecture', () => {
       'src/main/compute/compute-host-profile-owner.ts',
       'src/main/compute/compute-job-workflow-owner.ts',
       'src/main/compute/compute-remote-operation-owner.ts',
+      'src/main/compute/permission-grant-adapter.ts',
       'src/main/compute/compute-service.ts'
     ])
-    expect(computeService.interfacePaths).toEqual(['src/main/compute/compute-service.ts'])
+    expect(computeService.interfacePaths).toEqual([
+      'src/main/compute/compute-service.ts',
+      'src/main/compute/ipc.ts'
+    ])
     expect(computeService.testFiles.owner).toEqual(
       expect.arrayContaining([
         architectureTestPath,
         'src/main/compute/compute-host-profile-owner.test.ts',
         'src/main/compute/compute-job-workflow-owner.test.ts',
         'src/main/compute/compute-remote-operation-owner.test.ts',
+        'src/main/compute/permission-grant-adapter.test.ts',
         'src/main/compute/compute-service.test.ts'
       ])
     )

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -1,10 +1,15 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ComputeHost, ComputeJob, CreateComputeHostRequest } from '../../shared/compute'
+import type {
+  ComputeApprovalRequest,
+  ComputeHost,
+  ComputeJob,
+  CreateComputeHostRequest
+} from '../../shared/compute'
 import type { DirListing, DownloadDest, LocalFile } from '../../shared/remote-fs'
 import { decodeRemoteFsError } from '../../shared/remote-fs'
 import type { ComputeService } from './compute-service'
@@ -81,6 +86,13 @@ const mockService = (impl: Partial<ComputeService>): ComputeService => impl as C
 const mockJobRepo = (impl: Partial<ComputeJobRepository>): ComputeJobRepository =>
   impl as ComputeJobRepository
 
+const approvalBrokerFrom = (service: ComputeService): ComputeApprovalBroker =>
+  (
+    service as unknown as {
+      remoteOperations: { approvalBroker: ComputeApprovalBroker }
+    }
+  ).remoteOperations.approvalBroker
+
 describe('compute handlers', () => {
   it('list delegates to the repository', async () => {
     const list = vi.fn(() => Promise.resolve([sampleHost()]))
@@ -117,6 +129,70 @@ describe('compute handlers', () => {
     const handlers = createComputeHandlers(mockRepository({ create }))
 
     await expect(handlers.create({ sshAlias: 'biowulf' })).rejects.toThrow(/already registered/i)
+  })
+
+  it('persists project grants through the legacy port when no Registry is available', async () => {
+    let remembered = false
+    let pendingRequest: ComputeApprovalRequest | undefined
+    const hasComputeGrant = vi.fn(() => Promise.resolve(remembered))
+    const addComputeGrant = vi.fn(() => {
+      remembered = true
+      return Promise.resolve({})
+    })
+    const legacyComputeGrants = {
+      listComputeGrants: vi.fn(() => Promise.resolve([])),
+      clearComputeGrants: vi.fn(() => Promise.resolve()),
+      hasComputeGrant,
+      addComputeGrant
+    }
+    const handleComputeApproval = vi.fn((request: ComputeApprovalRequest) => {
+      pendingRequest = request
+      return Promise.resolve()
+    })
+    const computeHandlers = createComputeHandlers(
+      mockRepository({ get: vi.fn(() => Promise.resolve(sampleHost())) }),
+      undefined,
+      undefined,
+      undefined,
+      legacyComputeGrants,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        handleComputeApproval,
+        settleAuthorization: vi.fn(() => Promise.resolve())
+      }
+    )
+    const broker = approvalBrokerFrom(computeHandlers.computeService)
+    const request = {
+      provider_id: 'ssh:biowulf',
+      provider_name: 'biowulf',
+      shape: 'direct_ssh' as const,
+      intent: 'Check module availability',
+      command_preview: 'module avail',
+      command_full: 'module avail'
+    }
+    const context = {
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      operation: 'call_command',
+      ownerId: 'host-1'
+    }
+
+    const firstDecision = broker.requestWithContext(request, context)
+    await vi.waitFor(() => expect(pendingRequest).toBeDefined())
+    computeHandlers.approvalRespond(pendingRequest!.id, 'project')
+
+    await expect(firstDecision).resolves.toBe('project')
+    expect(addComputeGrant).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      operation: 'call_command',
+      providerId: 'ssh:biowulf'
+    })
+    await expect(broker.requestWithContext(request, context)).resolves.toBe('project')
+    expect(hasComputeGrant).toHaveBeenCalledTimes(2)
+    expect(handleComputeApproval).toHaveBeenCalledOnce()
   })
 
   it('delete passes the provider id through', async () => {
@@ -1208,6 +1284,56 @@ describe('installComputeIpcHandlers', () => {
     for (const channel of expected) {
       expect(handlers.has(channel)).toBe(true)
     }
+  })
+
+  it('keeps the default no-Registry factory backed by persistent project grants', async () => {
+    let pendingRequest: ComputeApprovalRequest | undefined
+    const handleComputeApproval = vi.fn((request: ComputeApprovalRequest) => {
+      pendingRequest = request
+      return Promise.resolve()
+    })
+    const repository = mockRepository({ get: vi.fn(() => Promise.resolve(sampleHost())) })
+    const module = createComputeIpcModule(repository, mockJobRepo({}), undefined, undefined, {
+      handleComputeApproval,
+      settleAuthorization: vi.fn(() => Promise.resolve())
+    })
+    const request = {
+      provider_id: 'ssh:biowulf',
+      provider_name: 'biowulf',
+      shape: 'direct_ssh' as const,
+      intent: 'Check module availability',
+      command_preview: 'module avail',
+      command_full: 'module avail'
+    }
+    const context = {
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      operation: 'call_command',
+      ownerId: 'host-1'
+    }
+
+    const firstDecision = approvalBrokerFrom(module.computeService).requestWithContext(
+      request,
+      context
+    )
+    await vi.waitFor(() => expect(pendingRequest).toBeDefined())
+    module.handlers.approvalRespond(pendingRequest!.id, 'project')
+    await expect(firstDecision).resolves.toBe('project')
+
+    const persisted = JSON.parse(await readFile(join(storageRoot, 'settings.json'), 'utf8')) as {
+      computeGrants?: unknown[]
+    }
+    expect(persisted.computeGrants).toHaveLength(1)
+
+    const reloadedNotifications = vi.fn(() => Promise.resolve())
+    const reloaded = createComputeIpcModule(repository, mockJobRepo({}), undefined, undefined, {
+      handleComputeApproval: reloadedNotifications,
+      settleAuthorization: vi.fn(() => Promise.resolve())
+    })
+    await expect(
+      approvalBrokerFrom(reloaded.computeService).requestWithContext(request, context)
+    ).resolves.toBe('project')
+    expect(reloadedNotifications).not.toHaveBeenCalled()
   })
 
   it('keeps Compute construction separate from Electron adapter installation', () => {

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -32,8 +32,8 @@ import { encodeRemoteFsError } from '../../shared/remote-fs'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { createLogger, errorLogFields } from '../logger'
 import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
-import { SettingsRepository } from '../settings/repository'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
+import { createSettingsComputeGrantPort } from '../settings/compute-grant-port'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { opencodeConfigDir } from '../agent-framework/opencode'
 import { broadcastToRenderers } from '../renderer-broadcast'
@@ -52,7 +52,10 @@ import { EnabledComputeHostsRegistry, enabledComputeHostsRegistry } from './enab
 import { getJobHarvestDir } from './harvest-engine'
 import { workspaceRelativePath } from './workspace-path'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
-import { createComputePermissionGrantAdapter } from './permission-grant-adapter'
+import {
+  createComputePermissionGrantAdapter,
+  type LegacyComputeGrantPort
+} from './permission-grant-adapter'
 import { hasCanonicalComputeSkillDoc, syncComputeSkillDoc } from './skill-doc'
 
 // IPC channel names for the renderer job feed (Phase 3d, issue 05).
@@ -198,7 +201,7 @@ const createComputeHandlers = (
   listSshAliases: () => Promise<string[]> = readSshConfigHostAliases,
   injectedService?: ComputeService,
   injectedBroker?: ComputeApprovalBroker,
-  settingsRepository?: SettingsRepository,
+  legacyComputeGrants?: LegacyComputeGrantPort,
   jobRepository?: ComputeJobRepository,
   onJobUpdated?: (job: ComputeJob) => void,
   artifactResolver?: ArtifactResolver,
@@ -211,7 +214,7 @@ const createComputeHandlers = (
   syncComputeSkillDocument?: () => Promise<void>
 ): ComputeHandlers => {
   const permissionGrants = permissionGrantRegistry
-    ? createComputePermissionGrantAdapter(permissionGrantRegistry, settingsRepository)
+    ? createComputePermissionGrantAdapter(permissionGrantRegistry, legacyComputeGrants)
     : undefined
   if (permissionGrants) {
     void permissionGrants
@@ -241,14 +244,14 @@ const createComputeHandlers = (
       onSettled: taskNotifications
         ? (id, state) => void taskNotifications.settleAuthorization('compute', id, state)
         : undefined,
-      // Isolated legacy callers retain their old hooks. Production uses only the Registry adapter.
+      // Isolated/no-Registry callers retain the former settings-backed Project grant behavior.
       checkProjectGrant:
-        settingsRepository && !permissionGrantRegistry
-          ? (grant) => settingsRepository.hasComputeGrant(grant)
+        legacyComputeGrants && !permissionGrantRegistry
+          ? (grant) => legacyComputeGrants.hasComputeGrant(grant)
           : undefined,
       saveProjectGrant:
-        settingsRepository && !permissionGrantRegistry
-          ? (grant) => settingsRepository.addComputeGrant(grant).then(() => undefined)
+        legacyComputeGrants && !permissionGrantRegistry
+          ? (grant) => legacyComputeGrants.addComputeGrant(grant).then(() => undefined)
           : undefined,
       isProviderCurrent: async ({ providerId, ownerId }) => {
         const current = await repository.get(providerId)
@@ -482,14 +485,13 @@ const createComputeIpcModule = (
     TaskNotificationService,
     'handleComputeApproval' | 'settleAuthorization'
   >,
-  permissionGrantRegistry?: PermissionGrantRegistry
+  permissionGrantRegistry?: PermissionGrantRegistry,
+  legacyComputeGrants?: LegacyComputeGrantPort
 ): ComputeIpcModule => {
   const storageRoot = resolveStorageRoot()
   const dataRoot = resolveDataRoot()
-
-  // Read the legacy settings repository only for lazy one-way Project grant import. New remembered
-  // approvals are written exclusively through the SQLite PermissionGrant Registry.
-  const settingsRepo = new SettingsRepository(storageRoot)
+  const effectiveLegacyComputeGrants =
+    legacyComputeGrants ?? createSettingsComputeGrantPort(storageRoot)
 
   // Broadcast dispatcher status transitions to the renderer, same hook shape as the JobPoller uses.
   const onJobUpdated = createJobUpdatedBroadcaster(repository, dataRoot)
@@ -499,7 +501,7 @@ const createComputeIpcModule = (
     undefined,
     injectedService,
     undefined,
-    settingsRepo,
+    effectiveLegacyComputeGrants,
     jobRepository,
     onJobUpdated,
     artifactResolver,

--- a/src/main/compute/permission-grant-adapter.ts
+++ b/src/main/compute/permission-grant-adapter.ts
@@ -5,10 +5,19 @@ import {
   type PermissionGrantRegistry
 } from '../permission-grants/registry'
 
-type LegacyComputeGrantRepository = {
-  listComputeGrants(): Promise<Array<{ projectId: string; operation: string; providerId: string }>>
+type LegacyComputeGrant = { projectId: string; operation: string; providerId: string }
+
+type LegacyComputeGrantPort = {
+  listComputeGrants(): Promise<LegacyComputeGrant[]>
   clearComputeGrants(): Promise<void>
+  hasComputeGrant(grant: LegacyComputeGrant): Promise<boolean>
+  addComputeGrant(grant: LegacyComputeGrant): Promise<unknown>
 }
+
+type LegacyComputeGrantMigrationPort = Pick<
+  LegacyComputeGrantPort,
+  'listComputeGrants' | 'clearComputeGrants'
+>
 
 type ComputeGrantContext = {
   projectId: string
@@ -54,7 +63,7 @@ const computeScope = (
 
 const createComputePermissionGrantAdapter = (
   registry: PermissionGrantRegistry,
-  legacy?: LegacyComputeGrantRepository
+  legacy?: LegacyComputeGrantMigrationPort
 ): ComputePermissionGrantAdapter => {
   let migration: Promise<void> | undefined
   const migrateLegacy = (): Promise<void> => {
@@ -131,4 +140,4 @@ const createComputePermissionGrantAdapter = (
 }
 
 export { createComputePermissionGrantAdapter }
-export type { ComputeGrantContext, ComputePermissionGrantAdapter, LegacyComputeGrantRepository }
+export type { ComputeGrantContext, ComputePermissionGrantAdapter, LegacyComputeGrantPort }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -161,7 +161,8 @@ import { SETTINGS_INSTALL_LOG_CHANNEL, registerSettingsIpcHandlers } from './set
 import { registerLocalFsIpcHandlers } from './local-fs/ipc'
 import { LocalFsService } from './local-fs/service'
 import { getAppClaudeConfigDir } from './settings/provider-env'
-import { createDefaultSettingsService } from './settings/service'
+import { SettingsService } from './settings/service'
+import { SettingsRepository } from './settings/repository'
 import type { NotebookRuntimeSettings } from './settings/capabilities'
 import type { WindowSettingsCapabilities } from './settings/service-capabilities'
 import { createSettingsWorkflows } from './settings/workflows'
@@ -336,8 +337,9 @@ const createApplicationModules = async (
     createApplicationEventModule
   )
   // One settings service backs both the settings IPC and the ACP spawn config (single source of truth).
+  const settingsRepository = new SettingsRepository(resolveStorageRoot())
   const settingsService = await modules.add(undefined, () => ({
-    capability: createDefaultSettingsService()
+    capability: new SettingsService({ repository: settingsRepository })
   }))
   const storedSettings = await settingsService.getStoredSettings()
   const storageLog = createLogger('storage')
@@ -960,7 +962,8 @@ const createApplicationModules = async (
     computeArtifactResolver,
     undefined,
     taskNotifications,
-    permissionGrantRegistry
+    permissionGrantRegistry,
+    settingsRepository
   )
   surfaceAdapters = beforeAcpAdapters
   const {

--- a/src/main/settings/compute-grant-port.ts
+++ b/src/main/settings/compute-grant-port.ts
@@ -1,0 +1,23 @@
+import { SettingsRepository } from './repository'
+import type { StoredComputeGrant } from './types'
+
+type SettingsComputeGrantPort = {
+  listComputeGrants(): Promise<StoredComputeGrant[]>
+  clearComputeGrants(): Promise<void>
+  hasComputeGrant(grant: StoredComputeGrant): Promise<boolean>
+  addComputeGrant(grant: StoredComputeGrant): Promise<unknown>
+}
+
+// Compatibility factory for isolated Compute module construction. Production passes its shared
+// repository explicitly, so this fallback never creates a second production arbitration owner.
+const createSettingsComputeGrantPort = (storageRoot: string): SettingsComputeGrantPort => {
+  const repository = new SettingsRepository(storageRoot)
+  return {
+    listComputeGrants: () => repository.listComputeGrants(),
+    clearComputeGrants: () => repository.clearComputeGrants(),
+    hasComputeGrant: (grant) => repository.hasComputeGrant(grant),
+    addComputeGrant: (grant) => repository.addComputeGrant(grant)
+  }
+}
+
+export { createSettingsComputeGrantPort }

--- a/src/main/settings/compute-grants.test.ts
+++ b/src/main/settings/compute-grants.test.ts
@@ -5,10 +5,12 @@ import { join } from 'node:path'
 import { SettingsRepository } from './repository'
 
 describe('SettingsRepository compute grant persistence', () => {
-  const withRepo = async (fn: (repo: SettingsRepository) => Promise<void>): Promise<void> => {
+  const withRepo = async (
+    fn: (repo: SettingsRepository, storageDir: string) => Promise<void>
+  ): Promise<void> => {
     const dir = await mkdtemp(join(tmpdir(), 'osci-compute-grants-'))
     try {
-      await fn(new SettingsRepository(dir))
+      await fn(new SettingsRepository(dir), dir)
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
@@ -90,16 +92,13 @@ describe('SettingsRepository compute grant persistence', () => {
   })
 
   it('persists grants to disk and survives a fresh repository read', async () => {
-    await withRepo(async (repo) => {
+    await withRepo(async (repo, storageDir) => {
       await repo.addComputeGrant({
         projectId: 'proj-1',
         operation: 'call_command',
         providerId: 'ssh:biowulf'
       })
-      const raw = await readFile(
-        join((repo as unknown as { storageDir: string }).storageDir, 'settings.json'),
-        'utf8'
-      )
+      const raw = await readFile(join(storageDir, 'settings.json'), 'utf8')
       const parsed = JSON.parse(raw) as { computeGrants?: unknown[] }
       expect(Array.isArray(parsed.computeGrants)).toBe(true)
       expect((parsed.computeGrants ?? []).length).toBeGreaterThan(0)

--- a/src/main/settings/connectors-settings.test.ts
+++ b/src/main/settings/connectors-settings.test.ts
@@ -31,10 +31,12 @@ describe('sanitizeConnectors', () => {
 })
 
 describe('SettingsRepository connector mutators', () => {
-  const withRepo = async (fn: (repo: SettingsRepository) => Promise<void>): Promise<void> => {
+  const withRepo = async (
+    fn: (repo: SettingsRepository, storageDir: string) => Promise<void>
+  ): Promise<void> => {
     const dir = await mkdtemp(join(tmpdir(), 'osci-connectors-'))
     try {
-      await fn(new SettingsRepository(dir))
+      await fn(new SettingsRepository(dir), dir)
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
@@ -84,12 +86,9 @@ describe('SettingsRepository connector mutators', () => {
   })
 
   it('persists mutations to disk', async () => {
-    await withRepo(async (repo) => {
+    await withRepo(async (repo, storageDir) => {
       await repo.setConnectorDisabled('rna', true)
-      const raw = await readFile(
-        join((repo as unknown as { storageDir: string }).storageDir, 'settings.json'),
-        'utf8'
-      )
+      const raw = await readFile(join(storageDir, 'settings.json'), 'utf8')
       expect(JSON.parse(raw).connectors.disabledConnectorIds).toEqual(['rna'])
     })
   })

--- a/src/main/settings/document-store.test.ts
+++ b/src/main/settings/document-store.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const faults = vi.hoisted(() => ({ failRenameOnce: false }))
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    rename: vi.fn(async (source: string, destination: string) => {
+      if (faults.failRenameOnce) {
+        faults.failRenameOnce = false
+        throw Object.assign(new Error('EPERM: settings file is temporarily locked'), {
+          code: 'EPERM'
+        })
+      }
+      await actual.rename(source, destination)
+    })
+  }
+})
+
+import { SettingsDocumentStore } from './document-store'
+
+let storageRoot: string | undefined
+
+afterEach(async () => {
+  faults.failRenameOnce = false
+  if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
+  storageRoot = undefined
+})
+
+describe('settings document store', () => {
+  it('exposes one atomic document owner', async () => {
+    expect(Object.keys(await import('./document-store')).sort()).toEqual(['SettingsDocumentStore'])
+  })
+
+  it('recovers its mutation queue after an atomic rename failure', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
+    const store = new SettingsDocumentStore(storageRoot)
+    faults.failRenameOnce = true
+
+    await expect(
+      store.mutate((settings) => ({ ...settings, notificationsEnabled: true }))
+    ).rejects.toThrow('temporarily locked')
+    await expect(
+      store.mutate((settings) => ({ ...settings, conversationSkillImportEnabled: true }))
+    ).resolves.toMatchObject({ conversationSkillImportEnabled: true })
+    await expect(store.read()).resolves.toMatchObject({ conversationSkillImportEnabled: true })
+  })
+})

--- a/src/main/settings/document-store.ts
+++ b/src/main/settings/document-store.ts
@@ -1,0 +1,50 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { sanitizeSettings } from './document-codec'
+import { createEmptySettings, type StoredSettings } from './types'
+
+const SETTINGS_FILE = 'settings.json'
+
+// Owns the complete settings.json transaction: fresh read, serialized mutation, atomic publish and
+// queue recovery. Callers sharing this instance cannot overwrite one another with stale snapshots.
+class SettingsDocumentStore {
+  private mutationTail: Promise<void> = Promise.resolve()
+  private writeSequence = 0
+
+  constructor(private readonly storageDir: string) {}
+
+  private get path(): string {
+    return join(this.storageDir, SETTINGS_FILE)
+  }
+
+  async read(): Promise<StoredSettings> {
+    try {
+      return sanitizeSettings(JSON.parse(await readFile(this.path, 'utf8')) as unknown)
+    } catch {
+      return createEmptySettings()
+    }
+  }
+
+  mutate(update: (settings: StoredSettings) => StoredSettings): Promise<StoredSettings> {
+    const result = this.mutationTail.then(async () => {
+      const next = update(await this.read())
+      await this.write(next)
+      return next
+    })
+    this.mutationTail = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
+  }
+
+  private async write(settings: StoredSettings): Promise<void> {
+    await mkdir(this.storageDir, { recursive: true })
+    const temporaryPath = `${this.path}.${Date.now()}-${++this.writeSequence}.tmp`
+    await writeFile(temporaryPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
+    await rename(temporaryPath, this.path)
+  }
+}
+
+export { SettingsDocumentStore }

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { sanitizeSettings } from './document-codec'
+import { SettingsDocumentStore } from './document-store'
 import { SettingsRepository } from './repository'
 import type { StoredProvider } from './types'
 
@@ -661,6 +662,28 @@ describe('settings repository', () => {
 
     const settings = await repository.getSettings()
     expect(settings.providers.map((item) => item.id).sort()).toEqual(['p1', 'p2', 'p3'])
+  })
+
+  it('preserves concurrent mutations from Settings and legacy Compute callers', async () => {
+    const store = new SettingsDocumentStore(await createStorageRoot())
+    const settings = new SettingsRepository(store)
+    const legacyCompute = new SettingsRepository(store)
+
+    await Promise.all([
+      settings.upsertProvider(provider({ id: 'p-settings' })),
+      legacyCompute.addComputeGrant({
+        projectId: 'project-1',
+        operation: 'submit_job',
+        providerId: 'ssh:cluster'
+      })
+    ])
+
+    await expect(settings.getSettings()).resolves.toMatchObject({
+      providers: [expect.objectContaining({ id: 'p-settings' })],
+      computeGrants: [
+        { projectId: 'project-1', operation: 'submit_job', providerId: 'ssh:cluster' }
+      ]
+    })
   })
 
   it('stamps onboardingCompletedAt once and is idempotent', async () => {

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -1,5 +1,3 @@
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import { isDeepStrictEqual } from 'node:util'
 
 import type {
@@ -23,7 +21,6 @@ import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-
 import type { CloseActionPreference } from '../../shared/window-controls'
 import { customConnectorSlug } from '../../shared/custom-connector'
 import {
-  createEmptySettings,
   type StoredComputeGrant,
   type StoredConnectors,
   type StoredCodexInfo,
@@ -33,32 +30,20 @@ import {
 } from './types'
 import { sanitizePackageMirror } from './record-codec'
 import { sanitizeSettings } from './document-codec'
+import { SettingsDocumentStore } from './document-store'
 
-const SETTINGS_FILE = 'settings.json'
-
-// Owns durable reads/writes of the single settings.json document. Writes are serialized through a
-// queue and made atomic (temp + rename); an unreadable file falls back to empty settings so the app
-// still boots into onboarding. All secret handling lives above this layer (crypto.ts / service.ts);
-// the repository only persists whatever records it is given.
+// Stable semantic mutation facade. The injected document store owns arbitration and atomic IO; all
+// secret handling remains above this layer in crypto.ts and service.ts.
 class SettingsRepository {
-  private saveQueue: Promise<void> = Promise.resolve()
-  private writeSequence = 0
+  private readonly store: SettingsDocumentStore
 
-  constructor(private readonly storageDir: string) {}
-
-  private get settingsPath(): string {
-    return join(this.storageDir, SETTINGS_FILE)
+  constructor(storage: string | SettingsDocumentStore) {
+    this.store = typeof storage === 'string' ? new SettingsDocumentStore(storage) : storage
   }
 
   // Reads and sanitizes the settings document, returning empty settings when nothing is stored yet.
   async getSettings(): Promise<StoredSettings> {
-    try {
-      const raw = await readFile(this.settingsPath, 'utf8')
-
-      return sanitizeSettings(JSON.parse(raw) as unknown)
-    } catch {
-      return createEmptySettings()
-    }
+    return this.store.read()
   }
 
   // Inserts or replaces a provider by id, then returns the persisted document. An existing provider is
@@ -653,33 +638,7 @@ class SettingsRepository {
 
   // Serializes a read-modify-write cycle so concurrent callers cannot clobber each other.
   private mutate(update: (settings: StoredSettings) => StoredSettings): Promise<StoredSettings> {
-    const run = this.saveQueue.then(async () => {
-      const current = await this.getSettings()
-      const next = update(current)
-
-      await this.writeSettings(next)
-
-      return next
-    })
-
-    // Keep the queue chained even when a write rejects so later mutations still run.
-    this.saveQueue = run.then(
-      () => undefined,
-      () => undefined
-    )
-
-    return run
-  }
-
-  // Writes through a unique temp file, then atomically replaces settings.json.
-  private async writeSettings(settings: StoredSettings): Promise<void> {
-    await mkdir(this.storageDir, { recursive: true })
-
-    this.writeSequence += 1
-    const temporaryPath = `${this.settingsPath}.${Date.now()}-${this.writeSequence}.tmp`
-
-    await writeFile(temporaryPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
-    await rename(temporaryPath, this.settingsPath)
+    return this.store.mutate(update)
   }
 }
 

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -40,6 +40,8 @@ const settingsPaths = {
   repository: resolve(settingsRoot, 'repository.ts'),
   recordCodec: resolve(settingsRoot, 'record-codec.ts'),
   documentCodec: resolve(settingsRoot, 'document-codec.ts'),
+  documentStore: resolve(settingsRoot, 'document-store.ts'),
+  computeGrantPort: resolve(settingsRoot, 'compute-grant-port.ts'),
   providerAccounts: resolve(settingsRoot, 'provider-accounts.ts'),
   backendResolver: resolve(settingsRoot, 'backend-resolver.ts'),
   backendSelection: resolve(settingsRoot, 'backend-selection-owner.ts'),
@@ -213,23 +215,6 @@ const publicOperationsOf = (path: string, className: string): string[] => {
     .sort()
 }
 
-const privatePropertiesOf = (path: string, className: string): string[] => {
-  const sourceFile = sourceFileFor(path)
-  const declaration = sourceFile.statements.find(
-    (statement) => isClassDeclaration(statement) && statement.name?.text === className
-  )
-  if (!declaration || !isClassDeclaration(declaration)) throw new Error(`${className} not found`)
-
-  return declaration.members
-    .flatMap((member) => {
-      const isPrivate =
-        isPropertyDeclaration(member) &&
-        getModifiers(member)?.some((modifier) => modifier.kind === SyntaxKind.PrivateKeyword)
-      return isPrivate && isIdentifier(member.name) ? [member.name.text] : []
-    })
-    .sort()
-}
-
 const typePropertyNames = (path: string, typeName: string): string[] => {
   const sourceFile = sourceFileFor(path)
   const declaration = sourceFile.statements.find(
@@ -268,9 +253,11 @@ const productionSourcePaths = productionSources()
 
 describe('Settings backend ownership architecture', () => {
   it('holds the current facade ceilings until their owner cutovers', () => {
-    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(700)
+    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.recordCodec))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.documentCodec))).toBeLessThanOrEqual(660)
+    expect(rawLineCount(readSource(settingsPaths.documentStore))).toBeLessThanOrEqual(660)
+    expect(rawLineCount(readSource(settingsPaths.computeGrantPort))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(600)
     expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1357)
     expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(600)
@@ -284,6 +271,9 @@ describe('Settings backend ownership architecture', () => {
       'value:sanitizeCustomMcpServer',
       'value:sanitizePackageMirror',
       'value:sanitizeSettings'
+    ])
+    expect(exportInventoryFrom(settingsPaths.computeGrantPort)).toEqual([
+      'value:createSettingsComputeGrantPort'
     ])
     expect(exportInventoryFrom(settingsPaths.providerAccounts)).toEqual([
       'type:ProviderAccountsModuleOptions',
@@ -468,8 +458,9 @@ describe('Settings backend ownership architecture', () => {
 
   it('locks the current production importer graph at the public seams', () => {
     expect(importersOf(settingsPaths.repository)).toEqual([
-      'src/main/compute/ipc.ts',
+      'src/main/ipc.ts',
       'src/main/settings/agent-runtime-manager.ts',
+      'src/main/settings/compute-grant-port.ts',
       'src/main/settings/connector-settings.ts',
       'src/main/settings/notebook-runtime-settings.ts',
       'src/main/settings/preferences.ts',
@@ -482,7 +473,12 @@ describe('Settings backend ownership architecture', () => {
       'src/main/settings/document-codec.ts',
       'src/main/settings/repository.ts'
     ])
-    expect(importersOf(settingsPaths.documentCodec)).toEqual(['src/main/settings/repository.ts'])
+    expect(importersOf(settingsPaths.documentCodec)).toEqual([
+      'src/main/settings/document-store.ts',
+      'src/main/settings/repository.ts'
+    ])
+    expect(importersOf(settingsPaths.documentStore)).toEqual(['src/main/settings/repository.ts'])
+    expect(importersOf(settingsPaths.computeGrantPort)).toEqual(['src/main/compute/ipc.ts'])
     expect(importersOf(settingsPaths.providerAccounts)).toEqual([
       'src/main/settings/agent-runtime-manager.ts',
       'src/main/settings/backend-resolver.ts',
@@ -574,24 +570,21 @@ describe('Settings backend ownership architecture', () => {
     )
   })
 
-  it('characterizes the same-root, independently queued repository composition before D3', () => {
+  it('locks one production Settings arbitration owner and the narrow Compute legacy port', () => {
     expect(constructorSitesFor(settingsPaths.repository, 'SettingsRepository')).toEqual([
-      'src/main/compute/ipc.ts',
+      'src/main/ipc.ts',
+      'src/main/settings/compute-grant-port.ts',
       'src/main/settings/service.ts'
     ])
-    expect(privatePropertiesOf(settingsPaths.repository, 'SettingsRepository')).toEqual(
-      expect.arrayContaining(['saveQueue', 'writeSequence'])
-    )
-    expect(readSource(resolve(projectRoot, 'src/main/compute/ipc.ts'))).toContain(
-      'const storageRoot = resolveStorageRoot()'
-    )
-    expect(readSource(resolve(projectRoot, 'src/main/compute/ipc.ts'))).toContain(
-      'new SettingsRepository(storageRoot)'
-    )
-    expect(readSource(settingsPaths.service)).toContain(
-      'this.storageRoot = options.storageRoot ?? resolveStorageRoot()'
-    )
-    expect(readSource(settingsPaths.service)).toContain('new SettingsRepository(this.storageRoot)')
+    const computeIpc = readSource(resolve(projectRoot, 'src/main/compute/ipc.ts'))
+    expect(computeIpc).not.toContain("from '../settings/repository'")
+    expect(computeIpc).toContain('legacyComputeGrants?: LegacyComputeGrantPort')
+    expect(computeIpc).toContain('legacyComputeGrants && !permissionGrantRegistry')
+    expect(computeIpc).toContain('legacyComputeGrants.hasComputeGrant(grant)')
+    expect(computeIpc).toContain('legacyComputeGrants.addComputeGrant(grant)')
+    const mainIpc = readSource(resolve(projectRoot, 'src/main/ipc.ts'))
+    expect(mainIpc).toContain('new SettingsService({ repository: settingsRepository })')
+    expect(mainIpc).toContain('permissionGrantRegistry,\n    settingsRepository')
   })
 
   it('locks dependency-aware impact owners and cross-surface evidence', () => {
@@ -599,7 +592,9 @@ describe('Settings backend ownership architecture', () => {
     expect(manifest.modules.settings_repository.ownerPaths).toEqual([
       'src/main/settings/repository.ts',
       'src/main/settings/record-codec.ts',
-      'src/main/settings/document-codec.ts'
+      'src/main/settings/document-codec.ts',
+      'src/main/settings/document-store.ts',
+      'src/main/settings/compute-grant-port.ts'
     ])
     expect(manifest.modules.settings_backend_resolution.ownerPaths).toEqual([
       'src/main/settings/backend-resolver.ts',


### PR DESCRIPTION
## Problem

Settings and Compute each constructed a `SettingsRepository` for the same `settings.json` path. Each repository owned an independent mutation queue, so concurrent read-modify-write operations could publish stale snapshots and lose unrelated settings updates.

## Proposed change

- Extract `SettingsDocumentStore` as the single owner of fresh reads, serialized mutation arbitration, atomic temp-file publication, and queue recovery after a failed write.
- Keep `SettingsRepository` as the semantic settings facade and inject the shared document store through the application composition root.
- Share the production repository between `SettingsService` and Compute's four-method legacy grant port; the Registry adapter narrows it to `list/clear`, and new remembered grants remain owned by the Permission Grant Registry.
- Preserve ordinary no-Registry `createComputeIpcModule` callers through a Settings-owned four-method compatibility port factory; production bypasses this fallback by passing its shared repository.
- Route the new owner and Compute interface through `module-impact.json`, with architecture gates for the production composition and hard line ceilings.

```mermaid
flowchart LR
  S["SettingsService"] --> R["SettingsRepository semantic facade"]
  C["Compute legacy grant migration"] --> P["LegacyComputeGrantPort"]
  P --> R
  R --> D["SettingsDocumentStore read / mutate"]
  D --> F["settings.json atomic rename"]
  C --> G["PermissionGrantRegistry new writes"]
```

## Scope and non-goals

- This is D3 of the Settings backend refactor and is limited to settings-document arbitration and Compute's legacy migration dependency.
- It does not introduce a singleton, service locator, generic storage framework, new orchestration data, or a new public interface.
- It does not redesign Settings semantics, provider records, permission policy, Compute operations, or Specialist behavior.
- `repository.ts` is 646 lines, `compute/ipc.ts` is 651 lines (both within the approved 660 hard gate), `document-store.ts` is 50 lines, and the compatibility port is 23 lines. Production raw change is approximately 190 lines.

## Compatibility

- No settings schema, serialized field, IPC channel, `window.api` contract, CLI contract, UI flow, or user-facing text changes.
- Electron, local Web, remote Web, and CLI retain their current capability boundaries; remote Web Compute download/reveal restrictions are unchanged.
- Permission Grant Registry remains the only owner of new remembered grants. Existing Settings grants are still imported lazily and cleared only after successful registry writes.
- Isolated callers without a Registry retain the previous Settings-backed project-grant lookup/save behavior, including persistence across a freshly constructed Compute module.
- Paths use Node `join`, `tmpdir`, and opaque storage roots; tests do not assume POSIX separators and remain portable across Windows, macOS, and Linux.
- The only intentional behavior correction is preventing concurrent Settings/legacy-Compute mutations from overwriting one another.

## Acceptance criteria and validation

All listed checks ran against the final material state (`68623a49`) rebased on `origin/main` at `9f880e50`:

- Concurrent lost-update prevention and write-failure queue recovery -> focused repository/document-store tests -> passed.
- Explicit-port and default-factory persistence/reload, owner, architecture and impact routing -> focused validation -> 9 files, 187 tests passed.
- Settings owner and consumers -> `npm run test:module -- settings_repository` -> 18 files, 501 tests passed.
- Compute owner/interface consumers -> `npm run test:module -- compute_service` -> 19 files passed, 1 skipped; 480 tests passed, 5 skipped by existing conditions.
- Node and Web contracts -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint -- --no-cache` -> 0 errors; 17 pre-existing warnings outside this diff.
- Formatting/patch integrity -> Prettier on changed files and `git diff --check` -> passed.
- Independent Standards review -> 0 findings. Independent Spec review -> 0 findings.

Because ownership/interface routing changed, exact-head PR Gate and CI are authoritative for the complete portable/platform fallback. A local full `npm test` and OS packaging/E2E lanes were not run under the approved selective-local/online-full policy.

## Review focus

- Verify every production Settings mutation reaches the same `SettingsDocumentStore` arbitration owner.
- Verify Compute depends only on the narrow legacy migration port and continues to write new grants exclusively through `PermissionGrantRegistry`.
- Verify ordinary no-Registry factory callers retain Settings-backed project lookup/save without creating a second repository in the production composition.
- Verify failed atomic publication does not poison later mutations and concurrent semantic facades cannot lose unrelated fields.
- Verify module-impact owner/interface routing selects both Settings and Compute certification suites plus the Windows-sensitive overlay.
