### PR TITLE
refactor(settings): extract backend selection owner

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -289,6 +289,7 @@
     "settings_backend_resolution": {
       "ownerPaths": [
         "src/main/settings/backend-resolver.ts",
+        "src/main/settings/backend-selection-owner.ts",
         "src/main/settings/responses-bridge.ts",
         "src/main/settings/responses-protocol-types.ts",
         "src/main/settings/responses-request-adapter.ts",
@@ -307,6 +308,8 @@
         "owner": [
           "src/main/settings/settings-backend.architecture.test.ts",
           "src/main/settings/backend-resolver.test.ts",
+          "src/main/settings/backend-selection-owner.test.ts",
+          "src/main/settings/backend-selection-owner.architecture.test.ts",
           "src/main/settings/responses-request-adapter.architecture.test.ts",
           "src/main/settings/responses-request-adapter.test.ts",
           "src/main/settings/responses-response-adapter.architecture.test.ts",

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -21,7 +21,6 @@ import {
   type ResolvedReasoningEffort
 } from '../../shared/reasoning-effort'
 import {
-  DEFAULT_AGENT_FRAMEWORK_ID,
   getAgentFramework,
   type AgentModelCatalogEntry,
   type AgentModelChangeTarget,
@@ -79,23 +78,20 @@ import { ensureCodexAuthHome } from './codex-auth'
 import { loopbackProxyBypassEnvironment } from './system-proxy'
 import type { StoredSettings } from './types'
 import type { ClaudeRuntimeModelConfig } from './claude-config-provision'
+import {
+  BackendSelectionOwner,
+  type AgentBackendSelection,
+  type BackendSelectionResolution,
+  type ExplicitAgentBackendTarget
+} from './backend-selection-owner'
 
-export type AgentBackendSelection = Readonly<{
-  frameworkId: AgentFrameworkId
-}>
+export type { AgentBackendSelection, ExplicitAgentBackendTarget } from './backend-selection-owner'
 
 export type AgentBackendResolutionContext = {
   forcedSkillIds?: string[]
   systemPromptAppends?: string[]
   forceCodexNativeResponsesCompatibility?: boolean
 }
-
-export type ExplicitAgentBackendTarget = Readonly<{
-  frameworkId: AgentFrameworkId
-  providerId: string
-  model: Readonly<{ kind: 'required'; id: string }> | Readonly<{ kind: 'provider-default' }>
-  reasoningEffort: ReasoningEffort
-}>
 
 export type AgentSpawnConfig = {
   envOverrides: Record<string, string>
@@ -290,7 +286,7 @@ export class AgentBackendResolver {
   private readonly connectors: AgentBackendConnectorPort
   private readonly storageRoot: string
   private readonly userClaudeDir: string
-  private readonly readFrameworkOverride: () => string | undefined
+  private readonly selection: BackendSelectionOwner
   private readonly createResponsesBridge: (target: ResponsesBridgeTarget) => ResponsesBridgePort
   private readonly createNativeResponsesProxy: (
     target: NativeResponsesProxyTarget
@@ -318,8 +314,13 @@ export class AgentBackendResolver {
     this.connectors = options.connectors
     this.storageRoot = options.storageRoot
     this.userClaudeDir = options.userClaudeDir
-    this.readFrameworkOverride =
-      options.readFrameworkOverride ?? (() => process.env.OPEN_SCIENCE_AGENT_FRAMEWORK)
+    this.selection = new BackendSelectionOwner({
+      readSettings: this.readSettings,
+      readFrameworkOverride:
+        options.readFrameworkOverride ?? (() => process.env.OPEN_SCIENCE_AGENT_FRAMEWORK),
+      resolveRuntimeReasoningEffortProfile: (provider, model) =>
+        this.providers.resolveRuntimeReasoningEffortProfile(provider, model)
+    })
     this.createResponsesBridge =
       options.createResponsesBridge ?? ((target) => new ResponsesBridge(target))
     this.createNativeResponsesProxy =
@@ -354,32 +355,18 @@ export class AgentBackendResolver {
   async resolveActiveBackend(
     context: AgentBackendResolutionContext = {}
   ): Promise<ResolvedAgentBackend> {
-    const settings = await this.readSettings()
-    const frameworkId = this.resolveConfiguredFrameworkId(settings)
-    return this.resolveBackendFromSettings(
-      settings,
-      frameworkId,
-      settings.activeProviderId,
-      { kind: 'configured', requestedModel: settings.activeModel },
-      settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
-      context
-    )
+    return this.resolveBackendSelection(await this.selection.resolveActiveSelection(), context)
   }
 
   async resolveActiveModelChangeTarget(): Promise<AgentModelChangeTarget | undefined> {
-    const settings = await this.readSettings()
-    const frameworkId = this.resolveConfiguredFrameworkId(settings)
+    const selection = await this.selection.resolveActiveModelChangeSelection()
+    if (!selection) return undefined
+    const { settings, frameworkId, providerId, modelSelection, reasoningEffort } = selection
     const framework = getAgentFramework(frameworkId)
-    const storedProvider = settings.activeProviderId
-      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
-      : undefined
+    const storedProvider = settings.providers.find((provider) => provider.id === providerId)
     if (!storedProvider) return undefined
 
-    const target = this.providers.resolveRuntimeTarget(
-      storedProvider,
-      { kind: 'configured', requestedModel: settings.activeModel },
-      framework
-    )
+    const target = this.providers.resolveRuntimeTarget(storedProvider, modelSelection, framework)
     if (!target.frameworkCompatible || (frameworkId === 'codex' && !target.modelBridgeSupported)) {
       return undefined
     }
@@ -417,10 +404,7 @@ export class AgentBackendResolver {
       sessionModelRequired:
         frameworkId === 'codex' && isCodexSubscriptionProvider(target.provider.type),
       supportsImageInput: target.provider.supportsImageInput === true,
-      reasoningEffort: resolvedModelEffort(
-        settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
-        target
-      ),
+      reasoningEffort: resolvedModelEffort(reasoningEffort, target),
       ...(hasClaudeProviderTransport
         ? { anthropicBridgeTargetId: claudeBridgeTargetId(target.providerId, model) }
         : {}),
@@ -449,77 +433,43 @@ export class AgentBackendResolver {
   }
 
   async captureConfiguredSelection(): Promise<AgentBackendSelection> {
-    const settings = await this.readSettings()
-    return { frameworkId: this.resolveConfiguredFrameworkId(settings) }
+    return this.selection.captureConfiguredSelection()
   }
 
   async captureExplicitTarget(): Promise<ExplicitAgentBackendTarget> {
-    const settings = await this.readSettings()
-    if (!settings.activeProviderId) throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
-    return Object.freeze({
-      frameworkId: this.resolveConfiguredFrameworkId(settings),
-      providerId: settings.activeProviderId,
-      model: settings.activeModel
-        ? Object.freeze({ kind: 'required' as const, id: settings.activeModel })
-        : Object.freeze({ kind: 'provider-default' as const }),
-      reasoningEffort: settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT
-    })
+    return this.selection.captureExplicitTarget()
   }
 
   async resolveSelection(
     selection: AgentBackendSelection,
     context: AgentBackendResolutionContext = {}
   ): Promise<ResolvedAgentBackend> {
-    const settings = await this.readSettings()
-    return this.resolveBackendFromSettings(
-      settings,
-      selection.frameworkId,
-      settings.activeProviderId,
-      { kind: 'configured', requestedModel: settings.activeModel },
-      settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
-      context
-    )
+    return this.resolveBackendSelection(await this.selection.resolveSelection(selection), context)
   }
 
   async resolveExplicitTarget(
     target: ExplicitAgentBackendTarget,
     context: AgentBackendResolutionContext = {}
   ): Promise<ResolvedAgentBackend> {
-    const settings = await this.readSettings()
-    const modelSelection: RuntimeProviderModelSelection =
-      target.model.kind === 'required'
-        ? { kind: 'required', model: target.model.id }
-        : { kind: 'provider-default' }
-    return this.resolveBackendFromSettings(
-      settings,
-      target.frameworkId,
-      target.providerId,
-      modelSelection,
-      target.reasoningEffort,
-      context
-    )
+    return this.resolveBackendSelection(await this.selection.resolveExplicitTarget(target), context)
   }
 
   async resolveActiveReasoningEffort(intent: ReasoningEffort): Promise<ResolvedReasoningEffort> {
-    const settings = await this.readSettings()
-    if (intent === DEFAULT_REASONING_EFFORT) return DEFAULT_REASONING_EFFORT
-    const activeProvider = settings.activeProviderId
-      ? settings.providers.find((candidate) => candidate.id === settings.activeProviderId)
-      : undefined
-    if (!activeProvider) return DEFAULT_REASONING_EFFORT
-
-    const profile = this.providers.resolveRuntimeReasoningEffortProfile(
-      activeProvider,
-      settings.activeModel
-    )
-    return resolveReasoningEffortValue(intent, profile)
+    return this.selection.resolveActiveReasoningEffort(intent)
   }
 
-  private resolveConfiguredFrameworkId(settings: StoredSettings): AgentFrameworkId {
-    const forced = this.readFrameworkOverride()
-    return forced === 'opencode' || forced === 'claude-code' || forced === 'codex'
-      ? forced
-      : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
+  private resolveBackendSelection(
+    selection: BackendSelectionResolution,
+    context: AgentBackendResolutionContext
+  ): Promise<ResolvedAgentBackend> {
+    return this.resolveBackendFromSettings(
+      selection.settings,
+      selection.frameworkId,
+      selection.providerId,
+      selection.modelSelection,
+      selection.reasoningEffort,
+      context
+    )
   }
 
   private resolveConfiguredProviderTarget(

--- a/src/main/settings/backend-selection-owner.architecture.test.ts
+++ b/src/main/settings/backend-selection-owner.architecture.test.ts
@@ -1,0 +1,147 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { extname, relative, resolve } from 'node:path'
+
+import {
+  canHaveModifiers,
+  createSourceFile,
+  getModifiers,
+  isClassDeclaration,
+  isExportDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isMethodDeclaration,
+  isNamedExports,
+  isPropertyDeclaration,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  type Node,
+  type SourceFile
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = resolve(__dirname, '../../..')
+const ownerPath = resolve(__dirname, 'backend-selection-owner.ts')
+const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
+const readSource = (path: string): string => readFileSync(path, 'utf8')
+const sourceFileFor = (path: string): SourceFile =>
+  createSourceFile(
+    path,
+    readSource(path),
+    ScriptTarget.Latest,
+    true,
+    extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
+  )
+const portablePath = (path: string): string => relative(projectRoot, path).replaceAll('\\', '/')
+
+const productionSources = (): string[] => {
+  const sources: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isDirectory()) visit(path)
+      else if (
+        ['.ts', '.tsx'].includes(extname(path)) &&
+        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
+      ) {
+        sources.push(path)
+      }
+    }
+  }
+  visit(resolve(projectRoot, 'src'))
+  visit(resolve(projectRoot, 'packages'))
+  return sources
+}
+
+const importsOwner = (path: string): boolean => {
+  let imports = false
+  const sourceFile = sourceFileFor(path)
+  const visit = (node: Node): void => {
+    if (
+      isImportDeclaration(node) &&
+      node.moduleSpecifier.getText(sourceFile).includes('backend-selection-owner')
+    ) {
+      imports = true
+    }
+    node.forEachChild(visit)
+  }
+  visit(sourceFile)
+  return imports
+}
+
+const publicOperations = (): string[] => {
+  const declaration = sourceFileFor(ownerPath).statements.find(
+    (statement) => isClassDeclaration(statement) && statement.name?.text === 'BackendSelectionOwner'
+  )
+  if (!declaration || !isClassDeclaration(declaration)) throw new Error('owner class not found')
+  return declaration.members
+    .flatMap((member) => {
+      const hidden =
+        canHaveModifiers(member) &&
+        getModifiers(member)?.some((modifier) => modifier.kind === SyntaxKind.PrivateKeyword)
+      return !hidden &&
+        (isMethodDeclaration(member) || isPropertyDeclaration(member)) &&
+        isIdentifier(member.name)
+        ? [member.name.text]
+        : []
+    })
+    .sort()
+}
+
+describe('Backend selection ownership', () => {
+  it('keeps pure selection policy below the production hard limit', () => {
+    const source = readSource(ownerPath)
+    expect(source.split(/\r?\n/).length - Number(source.endsWith('\n'))).toBeLessThanOrEqual(660)
+    expect(source).not.toMatch(
+      /ResponsesBridge|NativeResponses|create.*Bridge|start\(|close\(|keyRef|credential|lease|generation|orchestration/i
+    )
+  })
+
+  it('locks the owner interface and compatibility exports', () => {
+    expect(publicOperations()).toEqual([
+      'captureConfiguredSelection',
+      'captureExplicitTarget',
+      'resolveActiveModelChangeSelection',
+      'resolveActiveReasoningEffort',
+      'resolveActiveSelection',
+      'resolveExplicitTarget',
+      'resolveSelection'
+    ])
+
+    const exportDeclaration = sourceFileFor(ownerPath).statements.filter(isExportDeclaration)
+    expect(
+      exportDeclaration.flatMap((statement) =>
+        statement.exportClause && isNamedExports(statement.exportClause)
+          ? statement.exportClause.elements.map(
+              (element) =>
+                `${statement.isTypeOnly || element.isTypeOnly ? 'type' : 'value'}:${element.name.text}`
+            )
+          : []
+      )
+    ).toEqual([
+      'value:BackendSelectionOwner',
+      'type:AgentBackendSelection',
+      'type:BackendSelectionResolution',
+      'type:BackendSelectionOwnerOptions',
+      'type:ExplicitAgentBackendTarget'
+    ])
+  })
+
+  it('keeps the owner internal to the resolver and inside dependency-aware impact routing', () => {
+    expect(productionSources().filter(importsOwner).map(portablePath)).toEqual([
+      'src/main/settings/backend-resolver.ts'
+    ])
+    const manifest = JSON.parse(readSource(manifestPath)) as {
+      modules: Record<string, { ownerPaths: string[]; testFiles: { owner: string[] } }>
+    }
+    expect(manifest.modules.settings_backend_resolution.ownerPaths).toContain(
+      'src/main/settings/backend-selection-owner.ts'
+    )
+    expect(manifest.modules.settings_backend_resolution.testFiles.owner).toEqual(
+      expect.arrayContaining([
+        'src/main/settings/backend-selection-owner.test.ts',
+        'src/main/settings/backend-selection-owner.architecture.test.ts'
+      ])
+    )
+  })
+})

--- a/src/main/settings/backend-selection-owner.test.ts
+++ b/src/main/settings/backend-selection-owner.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { SETTINGS_FILE_VERSION } from '../../shared/settings'
+import { NO_ACTIVE_PROVIDER_MESSAGE } from '../../shared/run-error-classification'
+import { BackendSelectionOwner } from './backend-selection-owner'
+import type { StoredSettings } from './types'
+
+const settings = (overrides: Partial<StoredSettings> = {}): StoredSettings => ({
+  version: SETTINGS_FILE_VERSION,
+  providers: [
+    {
+      id: 'provider-a',
+      type: 'custom',
+      name: 'Provider A',
+      model: 'model-a',
+      keyRef: 'enc:credential'
+    }
+  ],
+  activeProviderId: 'provider-a',
+  activeModel: 'model-a',
+  agentFrameworkId: 'codex',
+  reasoningEffort: 'high',
+  ...overrides
+})
+
+describe('BackendSelectionOwner', () => {
+  it('captures only the configured framework without credentials or runtime state', async () => {
+    const owner = new BackendSelectionOwner({
+      readSettings: vi.fn(async () => settings()),
+      readFrameworkOverride: vi.fn(() => undefined),
+      resolveRuntimeReasoningEffortProfile: vi.fn()
+    })
+
+    const selection = await owner.captureConfiguredSelection()
+
+    expect(selection).toEqual({ frameworkId: 'codex' })
+    expect(Object.keys(selection)).toEqual(['frameworkId'])
+    expect(JSON.stringify(selection)).not.toMatch(/credential|provider|model|reasoning|lease/i)
+  })
+
+  it('freezes the explicit provider, model, framework, and reasoning intent without secrets', async () => {
+    const owner = new BackendSelectionOwner({
+      readSettings: vi.fn(async () => settings()),
+      readFrameworkOverride: vi.fn(() => undefined),
+      resolveRuntimeReasoningEffortProfile: vi.fn()
+    })
+
+    const target = await owner.captureExplicitTarget()
+
+    expect(target).toEqual({
+      frameworkId: 'codex',
+      providerId: 'provider-a',
+      model: { kind: 'required', id: 'model-a' },
+      reasoningEffort: 'high'
+    })
+    expect(Object.isFrozen(target)).toBe(true)
+    expect(Object.isFrozen(target.model)).toBe(true)
+    expect(JSON.stringify(target)).not.toMatch(/credential|key|connection|lease|orchestration/i)
+  })
+
+  it('late-binds configured provider/model/reasoning while keeping an explicit target fixed', async () => {
+    let current = settings()
+    const owner = new BackendSelectionOwner({
+      readSettings: vi.fn(async () => current),
+      readFrameworkOverride: vi.fn(() => undefined),
+      resolveRuntimeReasoningEffortProfile: vi.fn()
+    })
+    const configured = await owner.captureConfiguredSelection()
+    const explicit = await owner.captureExplicitTarget()
+    current = settings({
+      providers: [
+        ...current.providers,
+        { id: 'provider-b', type: 'custom', name: 'Provider B', model: 'model-b' }
+      ],
+      activeProviderId: 'provider-b',
+      activeModel: 'model-b-current',
+      agentFrameworkId: 'claude-code',
+      reasoningEffort: 'low'
+    })
+
+    await expect(owner.resolveSelection(configured)).resolves.toMatchObject({
+      settings: current,
+      frameworkId: 'codex',
+      providerId: 'provider-b',
+      modelSelection: { kind: 'configured', requestedModel: 'model-b-current' },
+      reasoningEffort: 'low'
+    })
+    await expect(owner.resolveExplicitTarget(explicit)).resolves.toMatchObject({
+      settings: current,
+      frameworkId: 'codex',
+      providerId: 'provider-a',
+      modelSelection: { kind: 'required', model: 'model-a' },
+      reasoningEffort: 'high'
+    })
+  })
+
+  it('rejects a missing configured provider at selection resolution', async () => {
+    let current = settings()
+    const owner = new BackendSelectionOwner({
+      readSettings: vi.fn(async () => current),
+      readFrameworkOverride: vi.fn(() => undefined),
+      resolveRuntimeReasoningEffortProfile: vi.fn()
+    })
+    const selection = await owner.captureConfiguredSelection()
+    current = settings({ providers: [], activeProviderId: undefined, activeModel: undefined })
+
+    await expect(owner.resolveSelection(selection)).rejects.toThrow(NO_ACTIVE_PROVIDER_MESSAGE)
+  })
+
+  it('resolves the current model-change selection or returns undefined without a provider', async () => {
+    let current = settings()
+    const readFrameworkOverride = vi.fn(() => 'opencode')
+    const owner = new BackendSelectionOwner({
+      readSettings: vi.fn(async () => current),
+      readFrameworkOverride,
+      resolveRuntimeReasoningEffortProfile: vi.fn()
+    })
+
+    await expect(owner.resolveActiveModelChangeSelection()).resolves.toMatchObject({
+      settings: current,
+      frameworkId: 'opencode',
+      providerId: 'provider-a',
+      modelSelection: { kind: 'configured', requestedModel: 'model-a' },
+      reasoningEffort: 'high'
+    })
+
+    current = settings({ providers: [], activeProviderId: undefined, activeModel: undefined })
+    await expect(owner.resolveActiveModelChangeSelection()).resolves.toBeUndefined()
+    expect(readFrameworkOverride).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves reasoning intent from the current provider without resolving a runtime target', async () => {
+    const resolveRuntimeReasoningEffortProfile = vi.fn(() => ({
+      supported: true as const,
+      slots: ['low', 'medium', 'high', 'xhigh', 'max'] as const
+    }))
+    const owner = new BackendSelectionOwner({
+      readSettings: vi.fn(async () => settings()),
+      readFrameworkOverride: vi.fn(() => undefined),
+      resolveRuntimeReasoningEffortProfile
+    })
+
+    await expect(owner.resolveActiveReasoningEffort('max')).resolves.toBe('max')
+    expect(resolveRuntimeReasoningEffortProfile).toHaveBeenCalledWith(
+      settings().providers[0],
+      'model-a'
+    )
+  })
+
+  it('resolves the active configured selection from one settings snapshot', async () => {
+    const readSettings = vi.fn(async () => settings())
+    const owner = new BackendSelectionOwner({
+      readSettings,
+      readFrameworkOverride: vi.fn(() => 'claude-code'),
+      resolveRuntimeReasoningEffortProfile: vi.fn()
+    })
+
+    await expect(owner.resolveActiveSelection()).resolves.toMatchObject({
+      frameworkId: 'claude-code',
+      providerId: 'provider-a',
+      modelSelection: { kind: 'configured', requestedModel: 'model-a' },
+      reasoningEffort: 'high'
+    })
+    expect(readSettings).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/settings/backend-selection-owner.ts
+++ b/src/main/settings/backend-selection-owner.ts
@@ -1,0 +1,157 @@
+import { DEFAULT_REASONING_EFFORT, type ReasoningEffort } from '../../shared/settings'
+import { NO_ACTIVE_PROVIDER_MESSAGE } from '../../shared/run-error-classification'
+import {
+  resolveReasoningEffortValue,
+  type ResolvedReasoningEffort
+} from '../../shared/reasoning-effort'
+import { DEFAULT_AGENT_FRAMEWORK_ID, type AgentFrameworkId } from '../agent-framework'
+import type { StoredSettings } from './types'
+import type { ProviderAccountsModule, RuntimeProviderModelSelection } from './provider-accounts'
+
+type AgentBackendSelection = Readonly<{
+  frameworkId: AgentFrameworkId
+}>
+
+type ExplicitAgentBackendTarget = Readonly<{
+  frameworkId: AgentFrameworkId
+  providerId: string
+  model: Readonly<{ kind: 'required'; id: string }> | Readonly<{ kind: 'provider-default' }>
+  reasoningEffort: ReasoningEffort
+}>
+
+type BackendSelectionResolution = Readonly<{
+  settings: StoredSettings
+  frameworkId: AgentFrameworkId
+  providerId: string
+  modelSelection: RuntimeProviderModelSelection
+  reasoningEffort: ReasoningEffort
+}>
+
+type BackendSelectionOwnerOptions = {
+  readSettings: () => Promise<StoredSettings>
+  readFrameworkOverride: () => string | undefined
+  resolveRuntimeReasoningEffortProfile: ProviderAccountsModule['resolveRuntimeReasoningEffortProfile']
+}
+
+class BackendSelectionOwner {
+  constructor(private readonly options: BackendSelectionOwnerOptions) {}
+
+  async captureConfiguredSelection(): Promise<AgentBackendSelection> {
+    const settings = await this.options.readSettings()
+    return { frameworkId: this.resolveConfiguredFrameworkId(settings) }
+  }
+
+  async captureExplicitTarget(): Promise<ExplicitAgentBackendTarget> {
+    const settings = await this.options.readSettings()
+    if (!settings.activeProviderId) throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
+    return Object.freeze({
+      frameworkId: this.resolveConfiguredFrameworkId(settings),
+      providerId: settings.activeProviderId,
+      model: settings.activeModel
+        ? Object.freeze({ kind: 'required' as const, id: settings.activeModel })
+        : Object.freeze({ kind: 'provider-default' as const }),
+      reasoningEffort: settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT
+    })
+  }
+
+  async resolveSelection(selection: AgentBackendSelection): Promise<BackendSelectionResolution> {
+    const settings = await this.options.readSettings()
+    return Object.freeze({
+      settings,
+      frameworkId: selection.frameworkId,
+      providerId: this.requireProviderId(settings, settings.activeProviderId),
+      modelSelection: {
+        kind: 'configured' as const,
+        requestedModel: settings.activeModel
+      },
+      reasoningEffort: settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT
+    })
+  }
+
+  async resolveActiveSelection(): Promise<BackendSelectionResolution> {
+    const settings = await this.options.readSettings()
+    return Object.freeze({
+      settings,
+      frameworkId: this.resolveConfiguredFrameworkId(settings),
+      providerId: this.requireProviderId(settings, settings.activeProviderId),
+      modelSelection: {
+        kind: 'configured' as const,
+        requestedModel: settings.activeModel
+      },
+      reasoningEffort: settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT
+    })
+  }
+
+  async resolveExplicitTarget(
+    target: ExplicitAgentBackendTarget
+  ): Promise<BackendSelectionResolution> {
+    const settings = await this.options.readSettings()
+    const modelSelection: RuntimeProviderModelSelection =
+      target.model.kind === 'required'
+        ? { kind: 'required', model: target.model.id }
+        : { kind: 'provider-default' }
+    return Object.freeze({
+      settings,
+      frameworkId: target.frameworkId,
+      providerId: this.requireProviderId(settings, target.providerId),
+      modelSelection,
+      reasoningEffort: target.reasoningEffort
+    })
+  }
+
+  async resolveActiveModelChangeSelection(): Promise<BackendSelectionResolution | undefined> {
+    const settings = await this.options.readSettings()
+    const frameworkId = this.resolveConfiguredFrameworkId(settings)
+    const providerId = settings.activeProviderId
+    if (!providerId || !settings.providers.some((provider) => provider.id === providerId)) {
+      return undefined
+    }
+    return Object.freeze({
+      settings,
+      frameworkId,
+      providerId,
+      modelSelection: {
+        kind: 'configured' as const,
+        requestedModel: settings.activeModel
+      },
+      reasoningEffort: settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT
+    })
+  }
+
+  async resolveActiveReasoningEffort(intent: ReasoningEffort): Promise<ResolvedReasoningEffort> {
+    const settings = await this.options.readSettings()
+    if (intent === DEFAULT_REASONING_EFFORT) return DEFAULT_REASONING_EFFORT
+    const activeProvider = settings.activeProviderId
+      ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
+      : undefined
+    if (!activeProvider) return DEFAULT_REASONING_EFFORT
+
+    const profile = this.options.resolveRuntimeReasoningEffortProfile(
+      activeProvider,
+      settings.activeModel
+    )
+    return resolveReasoningEffortValue(intent, profile)
+  }
+
+  private resolveConfiguredFrameworkId(settings: StoredSettings): AgentFrameworkId {
+    const forced = this.options.readFrameworkOverride()
+    return forced === 'opencode' || forced === 'claude-code' || forced === 'codex'
+      ? forced
+      : (settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
+  }
+
+  private requireProviderId(settings: StoredSettings, providerId: string | undefined): string {
+    if (!providerId || !settings.providers.some((provider) => provider.id === providerId)) {
+      throw new Error(NO_ACTIVE_PROVIDER_MESSAGE)
+    }
+    return providerId
+  }
+}
+
+export { BackendSelectionOwner }
+export type {
+  AgentBackendSelection,
+  BackendSelectionResolution,
+  BackendSelectionOwnerOptions,
+  ExplicitAgentBackendTarget
+}

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -42,6 +42,7 @@ const settingsPaths = {
   documentCodec: resolve(settingsRoot, 'document-codec.ts'),
   providerAccounts: resolve(settingsRoot, 'provider-accounts.ts'),
   backendResolver: resolve(settingsRoot, 'backend-resolver.ts'),
+  backendSelection: resolve(settingsRoot, 'backend-selection-owner.ts'),
   responsesBridge: resolve(settingsRoot, 'responses-bridge.ts'),
   service: resolve(settingsRoot, 'service.ts'),
   types: resolve(settingsRoot, 'types.ts')
@@ -271,7 +272,7 @@ describe('Settings backend ownership architecture', () => {
     expect(rawLineCount(readSource(settingsPaths.recordCodec))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.documentCodec))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(600)
-    expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1407)
+    expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1357)
     expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(600)
     expect(rawLineCount(readSource(settingsPaths.service))).toBeLessThanOrEqual(1003)
   })
@@ -485,6 +486,7 @@ describe('Settings backend ownership architecture', () => {
     expect(importersOf(settingsPaths.providerAccounts)).toEqual([
       'src/main/settings/agent-runtime-manager.ts',
       'src/main/settings/backend-resolver.ts',
+      'src/main/settings/backend-selection-owner.ts',
       'src/main/settings/service.ts'
     ])
     expect(importersOf(settingsPaths.backendResolver)).toEqual([
@@ -567,12 +569,9 @@ describe('Settings backend ownership architecture', () => {
       'type',
       'vendorId'
     ])
-    expect(typePropertyNames(settingsPaths.backendResolver, 'ExplicitAgentBackendTarget')).toEqual([
-      'frameworkId',
-      'model',
-      'providerId',
-      'reasoningEffort'
-    ])
+    expect(typePropertyNames(settingsPaths.backendSelection, 'ExplicitAgentBackendTarget')).toEqual(
+      ['frameworkId', 'model', 'providerId', 'reasoningEffort']
+    )
   })
 
   it('characterizes the same-root, independently queued repository composition before D3', () => {
@@ -604,6 +603,7 @@ describe('Settings backend ownership architecture', () => {
     ])
     expect(manifest.modules.settings_backend_resolution.ownerPaths).toEqual([
       'src/main/settings/backend-resolver.ts',
+      'src/main/settings/backend-selection-owner.ts',
       'src/main/settings/responses-bridge.ts',
       'src/main/settings/responses-protocol-types.ts',
       'src/main/settings/responses-request-adapter.ts',


### PR DESCRIPTION
## Problem

After provider projection, persistence and authentication ownership moved out, `backend-resolver.ts` still captured configured/explicit backend selections and resolved model-change/reasoning intent inline with route, catalog, credential and live-bridge concerns. That left a pure selection policy seam embedded in a 1,407-line facade and made its snapshot timing and freeze/late-bind semantics harder to certify independently.

## Proposed change

- Extract `BackendSelectionOwner` as the single pure owner of configured and explicit selection capture plus active model-change/reasoning selection resolution.
- Keep the resolver as the compatibility facade; its public methods and exported selection types delegate/re-export without consumer changes.
- Preserve configured late binding, explicit-target freezing, one-snapshot resolution and the existing missing-provider/framework-override ordering.
- Add direct behavioral tests, an architecture/importer budget lock and module-impact coverage for the new owner.
- Reduce `backend-resolver.ts` from 1,407 to 1,357 raw lines; keep the deliberately narrow owner at 157 raw lines rather than pulling B2/B3 route or transport policy forward.

```mermaid
flowchart LR
  Consumers["Runtime / settings consumers"] --> Resolver["AgentBackendResolver compatibility facade"]
  Resolver --> Selection["BackendSelectionOwner"]
  Selection --> Snapshot["Secret-free selection + reasoning intent"]
  Resolver --> Remaining["Route / catalog / runtime target / live bridge"]
```

## Scope and non-goals

- No provider route, catalog, runtime generation, credential resolution, transport target or live bridge/proxy ownership move; those remain B2/B3 work.
- No public IPC, persisted data model, provider record, UI, error/result or user-interaction change.
- No Issue #458 orchestration data or public interface.
- No generic policy framework and no artificial code added to meet the original 400-550 line forecast.
- R2/P2/D2 ownership and impact gates merged in the baseline remain intact.

## Compatibility

- `AgentBackendSelection` and `ExplicitAgentBackendTarget` remain importable from `backend-resolver.ts`; existing consumers continue to call the same resolver surface.
- Configured targets continue to bind to current settings at resolve time; explicit targets continue to freeze their captured provider/model selection.
- Model-change and reasoning-effort behavior, missing-provider messages and observable framework-override ordering are preserved.
- Captured public selection/target values remain secret-free; credential lookup and plaintext handling remain outside the new owner.
- Electron, local/remote Web, CLI, Task, Notebook local RPC/MCP and current Specialist/Permission/Compute capability asymmetry are unchanged.
- There is no data-model, data-relationship or user-interaction change; this is an internal state-ownership seam only.

## Acceptance criteria and validation

All listed checks ran after the last material edit on `origin/main=688ec334` (`HEAD=14401f4a`):

- Backend selection/resolver/provider behavior and architecture -> `npm run test:module -- settings_backend_resolution` -> 25 files passed, 1 skipped; 375 tests passed, 3 skipped.
- Settings facade and downstream settings compatibility -> `npm run test:module -- settings_service_facade` -> 22 files, 557 tests passed.
- Module-impact portability, ownership and selection -> `npm test -- --run scripts/ci/validate-module-impact.test.ts scripts/ci/module-test-impact.test.ts` -> 2 files, 26 tests passed.
- Node and Web compile contracts -> `npm run typecheck` -> passed.
- Changed TypeScript lint -> `npm exec eslint -- --no-cache <changed TypeScript files>` -> 0 errors and 0 warnings.
- Formatting and whitespace -> `git diff --check origin/main...HEAD` -> passed.
- Independent exact-base review -> Standards: 0 findings; Spec: 0 findings.

The user explicitly authorized local selective validation with exact-head CI as the full-suite authority. Because `scripts/ci/module-impact.json` adds an `ownerPaths` entry, this is a documented exception to CONTRIBUTING's default local full-fallback rule: exact-head CI must pass the complete portable plan and Windows/macOS/Linux lanes before merge. No admin exception is authorized.

## Review focus

- Confirm configured selection remains late-bound while explicit selection remains frozen.
- Verify the owner reads one settings snapshot and preserves missing-provider/framework-override ordering.
- Check public type re-exports and resolver method signatures remain compatible.
- Confirm route/catalog/runtime generation/credential/live-bridge policy remains in the resolver for B2/B3.
- Verify secret boundaries, R2/P2/D2 gates and cross-surface behavior remain unchanged.
