### PR TITLE
refactor(settings): extract backend route planner

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -296,6 +296,7 @@
       "ownerPaths": [
         "src/main/settings/backend-resolver.ts",
         "src/main/settings/backend-selection-owner.ts",
+        "src/main/settings/backend-route-planner.ts",
         "src/main/settings/responses-bridge.ts",
         "src/main/settings/responses-protocol-types.ts",
         "src/main/settings/responses-request-adapter.ts",
@@ -316,6 +317,8 @@
           "src/main/settings/backend-resolver.test.ts",
           "src/main/settings/backend-selection-owner.test.ts",
           "src/main/settings/backend-selection-owner.architecture.test.ts",
+          "src/main/settings/backend-route-planner.test.ts",
+          "src/main/settings/backend-route-planner.architecture.test.ts",
           "src/main/settings/responses-request-adapter.architecture.test.ts",
           "src/main/settings/responses-request-adapter.test.ts",
           "src/main/settings/responses-response-adapter.architecture.test.ts",

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -1063,6 +1063,49 @@ describe('AgentBackendResolver runtime delegation', () => {
     expect(harness.resolveRuntimeTarget).not.toHaveBeenCalled()
   })
 
+  it.each(['opencode', 'codex'] as const)(
+    'preserves %s executable error priority over route catalog projection',
+    async (frameworkId) => {
+      const harness = makeHarness()
+      const executableError = new Error(`${frameworkId} executable is unavailable`)
+      harness.resolveRuntimeModelCatalog.mockImplementation(() => {
+        throw new Error('catalog projection failed')
+      })
+      if (frameworkId === 'codex') {
+        harness.runtime.resolveCodexExecutable.mockRejectedValueOnce(executableError)
+      } else {
+        harness.runtime.resolveOpencodeExecutable.mockRejectedValueOnce(executableError)
+      }
+
+      await expect(
+        harness.resolver.resolveExplicitTarget({
+          frameworkId,
+          providerId: 'provider-a',
+          model: { kind: 'provider-default' },
+          reasoningEffort: 'high'
+        })
+      ).rejects.toBe(executableError)
+    }
+  )
+
+  it('preserves Codex native probe error priority over route catalog projection', async () => {
+    const harness = makeHarness()
+    const probeError = new Error('Codex native probe failed')
+    harness.resolveRuntimeModelCatalog.mockImplementation(() => {
+      throw new Error('catalog projection failed')
+    })
+    harness.runtime.probeCodexNativeVersion.mockRejectedValueOnce(probeError)
+
+    await expect(
+      harness.resolver.resolveExplicitTarget({
+        frameworkId: 'codex',
+        providerId: 'provider-a',
+        model: { kind: 'provider-default' },
+        reasoningEffort: 'high'
+      })
+    ).rejects.toBe(probeError)
+  })
+
   it.each([
     { frameworkId: 'claude-code' as const, executableMethod: 'resolveClaudeExecutable' as const },
     { frameworkId: 'opencode' as const, executableMethod: 'resolveOpencodeExecutable' as const },

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -1,11 +1,8 @@
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 
-import { z } from 'zod'
-
 import type { ReasoningEffort } from '../../shared/settings'
 import {
-  CODEX_ISOLATED_PROVIDER_ID,
   DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
   DEFAULT_REASONING_EFFORT,
   isCodexSubscriptionProvider
@@ -15,36 +12,21 @@ import {
   CODEX_BRIDGE_UNSUPPORTED_MESSAGE,
   NO_ACTIVE_PROVIDER_MESSAGE
 } from '../../shared/run-error-classification'
-import {
-  resolveReasoningEffortValue,
-  type ModelReasoningEffort,
-  type ResolvedReasoningEffort
-} from '../../shared/reasoning-effort'
+import type { ModelReasoningEffort, ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import {
   getAgentFramework,
   type AgentModelCatalogEntry,
   type AgentModelChangeTarget,
-  type AgentModelRoute,
   type AgentFrameworkId,
   type ResolvedAgentBackend
 } from '../agent-framework'
 import { opencodeConfigDir, opencodeTransportProviderId } from '../agent-framework/opencode'
 import {
-  CODEX_BRIDGE_MODEL,
   codexStorageDir,
   codexSubscriptionStorageDir,
   normalizeResponsesBaseUrl
 } from '../agent-framework/codex'
 import { renderConnectorInstructions } from '../connectors/skill-doc'
-import { NOTEBOOK_MCP_SERVER_NAME, NOTEBOOK_RPC_TOOLS } from '../notebook/mcp-server'
-import { ARTIFACT_MCP_SERVER_NAME, writeArtifactFileToolSchema } from '../artifacts/mcp-server'
-import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
-import { requestSkillImportToolSchema } from '../skills/mcp-server'
-import {
-  REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
-  REQUEST_SKILL_IMPORT_TOOL_NAME,
-  SKILL_IMPORT_MCP_SERVER_NAME
-} from '../../shared/skill-import'
 import {
   normalizeAnthropicBaseUrl,
   openAiChatCompletionsUrl,
@@ -84,6 +66,7 @@ import {
   type BackendSelectionResolution,
   type ExplicitAgentBackendTarget
 } from './backend-selection-owner'
+import { BackendRoutePlanner, type BackendTransportPlan } from './backend-route-planner'
 
 export type { AgentBackendSelection, ExplicitAgentBackendTarget } from './backend-selection-owner'
 
@@ -171,41 +154,6 @@ type NativeCodexProviderTransport = Readonly<{
   lease: NonNullable<ResolvedAgentBackend['providerTransportLease']>
 }>
 
-const modelRouteFor = (
-  frameworkId: AgentFrameworkId,
-  target: ProviderRuntimeTarget
-): AgentModelRoute => {
-  if (frameworkId === 'claude-code') return 'claude-anthropic'
-  if (frameworkId === 'opencode') {
-    return target.apiEndpoints.includes('openai') ? 'opencode-openai' : 'opencode-anthropic'
-  }
-  if (target.needsChatResponsesBridge) return 'codex-bridge'
-  if (target.needsNativeResponsesCompatibility) return 'codex-responses-compatibility'
-  return 'codex-responses'
-}
-
-const resolvedModelEffort = (
-  intent: ReasoningEffort,
-  target: ProviderRuntimeTarget
-): ResolvedReasoningEffort =>
-  intent === DEFAULT_REASONING_EFFORT
-    ? DEFAULT_REASONING_EFFORT
-    : resolveReasoningEffortValue(intent, target.reasoningEffortProfile)
-
-const claudeBridgeTargetId = (providerId: string, model: string): string =>
-  JSON.stringify([providerId, model])
-
-const providerTransportTargetId = (
-  frameworkId: AgentFrameworkId,
-  providerId: string,
-  model: string
-): string => JSON.stringify([frameworkId, providerId, model])
-
-type ClaudeBridgeCatalog = Readonly<{
-  targets: readonly AnthropicProviderBridgeTarget[]
-  initialTargetId: string
-}>
-
 export type AgentBackendResolverOptions = {
   readSettings: () => Promise<StoredSettings>
   providers: AgentBackendProviderPort
@@ -228,55 +176,6 @@ export type AgentBackendResolverOptions = {
   nextGenerationId?: () => string
 }
 
-// Codex exposes local MCP tools as namespaced Responses functions. Chat Completions has no namespace
-// field, so the bridge receives the app-owned notebook schemas and aliases them for the upstream.
-const CODEX_NOTEBOOK_TOOL_NAMESPACE = `mcp__${NOTEBOOK_MCP_SERVER_NAME.replace(
-  /[^a-zA-Z0-9_]/g,
-  '_'
-)}`
-const CODEX_BRIDGE_NOTEBOOK_TOOLS: ResponsesBridgeNamespacedTool[] = NOTEBOOK_RPC_TOOLS.map(
-  (tool) => ({
-    namespace: CODEX_NOTEBOOK_TOOL_NAMESPACE,
-    name: tool.name,
-    description:
-      tool.name === 'notebook_execute'
-        ? `${tool.description} For Open Science data connectors, the Python code MUST call host.mcp(server, method, arguments). Never use requests, urllib, httpx, curl, or a raw upstream API for connector data; those bypass app permissions, credentials, and rate limits. Codex MCP resource-list tools are not connector discovery.`
-        : tool.description,
-    parameters: z.toJSONSchema(z.object(tool.inputSchema), {
-      target: 'draft-7'
-    }) as ResponsesBridgeNamespacedTool['parameters']
-  })
-)
-const CODEX_ARTIFACT_TOOL_NAMESPACE = `mcp__${ARTIFACT_MCP_SERVER_NAME.replace(
-  /[^a-zA-Z0-9_]/g,
-  '_'
-)}`
-const CODEX_BRIDGE_ARTIFACT_TOOLS: ResponsesBridgeNamespacedTool[] = [
-  {
-    namespace: CODEX_ARTIFACT_TOOL_NAMESPACE,
-    name: 'write_artifact_file',
-    description:
-      'Attach a generated image, chart, report, data export, or archive to the current Open Science response. The file must already exist before using a localPath source.',
-    parameters: z.toJSONSchema(z.object(writeArtifactFileToolSchema), {
-      target: 'draft-7'
-    }) as ResponsesBridgeNamespacedTool['parameters']
-  }
-]
-const CODEX_SKILL_IMPORT_TOOL_NAMESPACE = `mcp__${SKILL_IMPORT_MCP_SERVER_NAME.replace(
-  /[^a-zA-Z0-9_]/g,
-  '_'
-)}`
-const CODEX_BRIDGE_SKILL_IMPORT_TOOLS: ResponsesBridgeNamespacedTool[] = [
-  {
-    namespace: CODEX_SKILL_IMPORT_TOOL_NAMESPACE,
-    name: REQUEST_SKILL_IMPORT_TOOL_NAME,
-    description: REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
-    parameters: z.toJSONSchema(z.object(requestSkillImportToolSchema), {
-      target: 'draft-7'
-    }) as ResponsesBridgeNamespacedTool['parameters']
-  }
-]
-
 // Owns backend resolution decisions and every live bridge/proxy generation created for them. The
 // constructor is intentionally side-effect free; runtime resources start only inside resolve calls.
 export class AgentBackendResolver {
@@ -287,6 +186,7 @@ export class AgentBackendResolver {
   private readonly storageRoot: string
   private readonly userClaudeDir: string
   private readonly selection: BackendSelectionOwner
+  private readonly planner: BackendRoutePlanner
   private readonly createResponsesBridge: (target: ResponsesBridgeTarget) => ResponsesBridgePort
   private readonly createNativeResponsesProxy: (
     target: NativeResponsesProxyTarget
@@ -321,6 +221,7 @@ export class AgentBackendResolver {
       resolveRuntimeReasoningEffortProfile: (provider, model) =>
         this.providers.resolveRuntimeReasoningEffortProfile(provider, model)
     })
+    this.planner = new BackendRoutePlanner({ providers: this.providers })
     this.createResponsesBridge =
       options.createResponsesBridge ?? ((target) => new ResponsesBridge(target))
     this.createNativeResponsesProxy =
@@ -344,11 +245,23 @@ export class AgentBackendResolver {
     const settings = await this.readSettings()
     const executablePath = await this.runtime.resolveClaudeExecutable(settings.claude?.resolvedPath)
     const target = this.resolveConfiguredProviderTarget(settings, getAgentFramework('claude-code'))
+    if (target.providerType === 'claude-shared' && target.disconnectedAt !== undefined) {
+      throw new Error(CLAUDE_SHARED_DISCONNECTED_MESSAGE)
+    }
+    const plan = this.planner.planBackend({
+      settings,
+      frameworkId: 'claude-code',
+      target,
+      effortIntent: settings.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+      conversationSkillImportEnabled:
+        settings.conversationSkillImportEnabled ?? DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED
+    })
     return this.resolveClaudeSpawnConfig(
       settings,
       target,
       new Set(context.forcedSkillIds ?? []),
-      executablePath
+      executablePath,
+      plan.claudeModelConfig
     )
   }
 
@@ -370,65 +283,11 @@ export class AgentBackendResolver {
     if (!target.frameworkCompatible || (frameworkId === 'codex' && !target.modelBridgeSupported)) {
       return undefined
     }
-
-    const model = target.effectiveModel ?? target.provider.model
-    if (!model) return undefined
-    const route = modelRouteFor(frameworkId, target)
-    const openCodeTransportTargets =
-      frameworkId === 'opencode' ? this.resolveOpenCodeApiTargets(settings, target, route) : []
-    const hasOpenCodeProviderTransport =
-      new Set(openCodeTransportTargets.map((candidate) => candidate.providerId)).size >= 2
-    const codexTransportTargets =
-      frameworkId === 'codex' ? this.resolveCodexApiTargets(settings, target, route) : []
-    const hasCodexProviderTransport =
-      new Set(codexTransportTargets.map((candidate) => candidate.providerId)).size >= 2
-    const hasClaudeProviderTransport =
-      frameworkId === 'claude-code' &&
-      this.resolveClaudeBridgeCatalog(settings, target) !== undefined
-    const backendProviderId =
-      frameworkId === 'codex' && isCodexSubscriptionProvider(target.provider.type)
-        ? CODEX_ISOLATED_PROVIDER_ID
-        : target.providerId
-
-    return Object.freeze({
+    return this.planner.projectModelChange({
+      settings,
       frameworkId,
-      backendId: `${frameworkId}:${backendProviderId}`,
-      route,
-      model,
-      sessionModel:
-        route === 'codex-bridge'
-          ? CODEX_BRIDGE_MODEL
-          : hasOpenCodeProviderTransport
-            ? `${opencodeTransportProviderId(target.providerId, model)}/${model}`
-            : model,
-      sessionModelRequired:
-        frameworkId === 'codex' && isCodexSubscriptionProvider(target.provider.type),
-      supportsImageInput: target.provider.supportsImageInput === true,
-      reasoningEffort: resolvedModelEffort(reasoningEffort, target),
-      ...(hasClaudeProviderTransport
-        ? { anthropicBridgeTargetId: claudeBridgeTargetId(target.providerId, model) }
-        : {}),
-      ...(hasOpenCodeProviderTransport || hasCodexProviderTransport
-        ? {
-            providerTransportTargetId: providerTransportTargetId(
-              frameworkId,
-              target.providerId,
-              model
-            )
-          }
-        : {}),
-      ...(target.provider.contextWindow ? { contextWindow: target.provider.contextWindow } : {}),
-      ...(route === 'codex-bridge' || route === 'codex-responses-compatibility'
-        ? {
-            bridge: Object.freeze({
-              model,
-              ...(target.provider.vendorId ? { vendorId: target.provider.vendorId } : {}),
-              ...(target.provider.reasoningEffortTransport
-                ? { reasoningEffortTransport: target.provider.reasoningEffortTransport }
-                : {})
-            })
-          }
-        : {})
+      target,
+      effortIntent: reasoningEffort
     })
   }
 
@@ -508,36 +367,68 @@ export class AgentBackendResolver {
     if (framework.id === 'codex' && !target.modelBridgeSupported) {
       throw new Error(CODEX_BRIDGE_UNSUPPORTED_MESSAGE)
     }
-
-    const configuredModelRoute = modelRouteFor(frameworkId, target)
     const forceNativeResponsesCompatibility =
       context.forceCodexNativeResponsesCompatibility === true &&
       framework.id === 'codex' &&
-      configuredModelRoute === 'codex-responses'
+      !target.needsChatResponsesBridge &&
+      !target.needsNativeResponsesCompatibility
     if (forceNativeResponsesCompatibility && isCodexSubscriptionProvider(target.provider.type)) {
       throw new Error(
         'Artifact code reconstruction is unavailable with Codex subscription authentication.'
       )
     }
-    const modelRoute = forceNativeResponsesCompatibility
-      ? 'codex-responses-compatibility'
-      : configuredModelRoute
-    const resolvedEffort = resolvedModelEffort(effortIntent, target)
-    const sessionEffort: ModelReasoningEffort | undefined =
-      resolvedEffort === 'default' ? undefined : resolvedEffort
-    const supportedReasoningEfforts = target.reasoningEffortProfile.supported
-      ? [...new Set(target.reasoningEffortProfile.slots)]
-      : undefined
     const forcedSkillIds = new Set(context.forcedSkillIds ?? [])
     const connectorSkillNames =
       framework.id === 'claude-code'
         ? await this.connectors.provisionedConnectorSkillNames()
         : this.connectors.enabledConnectorIds(settings.connectors).map((id) => `mcp-${id}`)
     const connectorInstructions = renderConnectorInstructions(connectorSkillNames)
+    const executablePath =
+      framework.id === 'claude-code'
+        ? await this.runtime.resolveClaudeExecutable(settings.claude?.resolvedPath)
+        : framework.id === 'codex'
+          ? await this.runtime.resolveCodexExecutable(
+              settings.codex?.resolvedPath,
+              settings.codex?.nativePath
+            )
+          : await this.runtime.resolveOpencodeExecutable(settings.opencodePath)
+    const codexNativeVersion =
+      framework.id === 'codex'
+        ? await this.runtime.probeCodexNativeVersion(settings.codex?.nativePath)
+        : undefined
+    if (
+      framework.id === 'claude-code' &&
+      target.providerType === 'claude-shared' &&
+      target.disconnectedAt !== undefined
+    ) {
+      throw new Error(CLAUDE_SHARED_DISCONNECTED_MESSAGE)
+    }
+    const plan = this.planner.planBackend({
+      settings,
+      frameworkId,
+      target,
+      effortIntent,
+      conversationSkillImportEnabled:
+        settings.conversationSkillImportEnabled ?? DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
+      forceNativeResponsesCompatibility
+    })
+    const modelRoute = plan.modelRoute
+    const sessionEffort = plan.sessionEffort
+    const supportedReasoningEfforts = plan.supportedReasoningEfforts
     if (framework.id === 'claude-code') {
-      const { envOverrides, executablePath, sessionOptions, contextWindow } =
-        await this.resolveClaudeSpawnConfig(settings, target, forcedSkillIds)
-      const bridgeCatalog = this.resolveClaudeBridgeCatalog(settings, target)
+      const {
+        envOverrides,
+        executablePath: claudeExecutablePath,
+        sessionOptions,
+        contextWindow
+      } = await this.resolveClaudeSpawnConfig(
+        settings,
+        target,
+        forcedSkillIds,
+        executablePath,
+        plan.claudeModelConfig
+      )
+      const bridgeCatalog = plan.transport.kind === 'claude-anthropic' ? plan.transport : undefined
       let bridge: AnthropicProviderBridgePort | undefined
       try {
         const bridgeConnection = bridgeCatalog
@@ -557,7 +448,7 @@ export class AgentBackendResolver {
           framework,
           backendId: `${framework.id}:${target.providerId}`,
           modelRoute,
-          executablePath,
+          executablePath: claudeExecutablePath,
           env: {
             ...envOverrides,
             ...(bridgeConnection
@@ -583,49 +474,12 @@ export class AgentBackendResolver {
       }
     }
 
-    const executablePath =
-      framework.id === 'codex'
-        ? await this.runtime.resolveCodexExecutable(
-            settings.codex?.resolvedPath,
-            settings.codex?.nativePath
-          )
-        : await this.runtime.resolveOpencodeExecutable(settings.opencodePath)
-    const codexNativeVersion =
-      framework.id === 'codex'
-        ? await this.runtime.probeCodexNativeVersion(settings.codex?.nativePath)
-        : undefined
     let provider = target.provider
-    const codexProviderTargets =
-      framework.id === 'codex' ? this.resolveCodexApiTargets(settings, target, modelRoute) : []
-    const hasCodexProviderTransport =
-      new Set(codexProviderTargets.map((candidate) => candidate.providerId)).size >= 2
-    const catalogTargets = hasCodexProviderTransport
-      ? codexProviderTargets
-      : this.providers.resolveRuntimeModelCatalog(storedProvider, framework)
-    let providerModelCatalog: readonly AgentModelCatalogEntry[] = catalogTargets
-      .filter(
-        (candidate) =>
-          candidate.frameworkCompatible &&
-          (framework.id !== 'codex' || candidate.modelBridgeSupported) &&
-          modelRouteFor(framework.id, candidate) === modelRoute
-      )
-      .map((candidate) => {
-        const candidateEffort = resolvedModelEffort(effortIntent, candidate)
-        return Object.freeze({
-          provider: candidate.provider,
-          ...(candidateEffort === 'default' ? {} : { reasoningEffort: candidateEffort }),
-          ...(candidate.reasoningEffortProfile.supported
-            ? { reasoningEfforts: [...new Set(candidate.reasoningEffortProfile.slots)] }
-            : {})
-        })
-      })
+    let providerModelCatalog: readonly AgentModelCatalogEntry[] = plan.providerModelCatalog
     if (framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)) {
       await this.ensureCodexSubscriptionHome()
     }
-    const backendProviderId =
-      framework.id === 'codex' && isCodexSubscriptionProvider(provider.type)
-        ? CODEX_ISOLATED_PROVIDER_ID
-        : target.providerId
+    const backendProviderId = plan.backendProviderId
     const skillsRoot =
       framework.id === 'codex'
         ? isCodexSubscriptionProvider(provider.type)
@@ -636,15 +490,15 @@ export class AgentBackendResolver {
 
     const openCodeProviderTransport =
       framework.id === 'opencode'
-        ? await this.ensureOpenCodeProviderTransports(settings, target, modelRoute, effortIntent)
+        ? await this.ensureOpenCodeProviderTransports(target, plan.transport)
         : undefined
     if (openCodeProviderTransport) {
       provider = openCodeProviderTransport.provider
       providerModelCatalog = openCodeProviderTransport.providerModelCatalog
     }
     const nativeCodexProviderTransport =
-      framework.id === 'codex' && modelRoute === 'codex-responses' && hasCodexProviderTransport
-        ? await this.ensureNativeCodexProviderTransport(target, codexProviderTargets)
+      framework.id === 'codex' && plan.transport.kind === 'codex-native-responses'
+        ? await this.ensureNativeCodexProviderTransport(target, plan.transport)
         : undefined
     if (nativeCodexProviderTransport) provider = nativeCodexProviderTransport.provider
 
@@ -652,14 +506,16 @@ export class AgentBackendResolver {
       ? await this.ensureResponsesBridge(
           target,
           sessionEffort,
-          settings.conversationSkillImportEnabled ?? DEFAULT_CONVERSATION_SKILL_IMPORT_ENABLED,
-          hasCodexProviderTransport ? codexProviderTargets : undefined,
-          effortIntent
+          plan.transport,
+          plan.codexBridgeTools ?? [],
+          plan.reviewerBridgeTools ?? []
         )
-      : target.needsNativeResponsesCompatibility || forceNativeResponsesCompatibility
+      : target.needsNativeResponsesCompatibility ||
+          plan.modelRoute === 'codex-responses-compatibility'
         ? await this.ensureNativeResponsesCompatibility(
             target,
-            hasCodexProviderTransport ? codexProviderTargets : undefined
+            plan.transport,
+            plan.reviewerBridgeTools ?? []
           )
         : undefined
     const persistentSystemPromptAppends = [
@@ -766,7 +622,8 @@ export class AgentBackendResolver {
     settings: StoredSettings,
     target: ProviderRuntimeTarget,
     forcedSkillIds: ReadonlySet<string>,
-    resolvedExecutablePath?: string
+    resolvedExecutablePath?: string,
+    modelConfig?: ClaudeRuntimeModelConfig
   ): Promise<AgentSpawnConfig> {
     const executablePath =
       resolvedExecutablePath ??
@@ -775,7 +632,6 @@ export class AgentBackendResolver {
       throw new Error(CLAUDE_SHARED_DISCONNECTED_MESSAGE)
     }
     const provider = target.provider
-    const modelConfig = this.resolveClaudeModelConfig(settings, target)
     const appConfigDir = await this.runtime.provisionClaudeRuntimeConfig(
       settings,
       forcedSkillIds,
@@ -810,220 +666,14 @@ export class AgentBackendResolver {
     }
   }
 
-  private resolveClaudeModelConfig(
-    settings: StoredSettings,
-    target: ProviderRuntimeTarget
-  ): ClaudeRuntimeModelConfig | undefined {
-    if (target.provider.type !== 'custom') return undefined
-    const registered = [
-      ...new Set(
-        this.resolveClaudeApiTargets(settings, target).map(
-          (candidate) => candidate.effectiveModel ?? candidate.provider.model
-        )
-      )
-    ].filter((model): model is string => Boolean(model))
-    if (registered.length < 2) return undefined
-
-    return Object.freeze({
-      availableModels: Object.freeze([...registered]),
-      modelOverrides: Object.freeze(
-        // Identity overrides deliberately register opaque third-party ids with Claude's SDK. A real
-        // adapter spike verifies that this has no three-alias ceiling and setModel accepts every row.
-        Object.fromEntries(registered.map((model) => [model, model]))
-      )
-    })
-  }
-
-  private resolveClaudeBridgeCatalog(
-    settings: StoredSettings,
-    target: ProviderRuntimeTarget
-  ): ClaudeBridgeCatalog | undefined {
-    if (target.provider.type !== 'custom') return undefined
-    const apiTargets = this.resolveClaudeApiTargets(settings, target)
-    if (new Set(apiTargets.map((candidate) => candidate.providerId)).size < 2) return undefined
-    const targets = apiTargets.flatMap((candidate): AnthropicProviderBridgeTarget[] => {
-      const model = candidate.effectiveModel ?? candidate.provider.model
-      const baseUrl = normalizeAnthropicBaseUrl(candidate.provider.baseUrl ?? '')
-      if (!model || !baseUrl) return []
-      return [
-        Object.freeze({
-          id: claudeBridgeTargetId(candidate.providerId, model),
-          baseUrl,
-          ...(candidate.provider.key ? { key: candidate.provider.key } : {}),
-          model
-        })
-      ]
-    })
-    const initialModel = target.effectiveModel ?? target.provider.model
-    if (!initialModel) return undefined
-    const initialTargetId = claudeBridgeTargetId(target.providerId, initialModel)
-    if (!targets.some((candidate) => candidate.id === initialTargetId)) return undefined
-
-    return Object.freeze({ targets: Object.freeze(targets), initialTargetId })
-  }
-
-  private resolveClaudeApiTargets(
-    settings: StoredSettings,
-    activeTarget: ProviderRuntimeTarget
-  ): ProviderRuntimeTarget[] {
-    const framework = getAgentFramework('claude-code')
-    const candidates: ProviderRuntimeTarget[] = [activeTarget]
-
-    for (const storedProvider of settings.providers) {
-      try {
-        const configured =
-          storedProvider.id === activeTarget.providerId
-            ? activeTarget
-            : this.providers.resolveRuntimeTarget(
-                storedProvider,
-                { kind: 'configured', requestedModel: storedProvider.model },
-                framework
-              )
-        candidates.push(configured)
-        candidates.push(...this.providers.resolveRuntimeModelCatalog(storedProvider, framework))
-      } catch {
-        // Another configured provider may have stale/missing credentials. It must not prevent the
-        // active backend from starting; selecting it later falls back to reconnect and validation.
-      }
-    }
-
-    const seen = new Set<string>()
-    return candidates.filter((candidate) => {
-      const model = candidate.effectiveModel ?? candidate.provider.model
-      if (
-        !candidate.frameworkCompatible ||
-        candidate.provider.type !== 'custom' ||
-        !candidate.apiEndpoints.includes('anthropic') ||
-        !model ||
-        !candidate.provider.baseUrl ||
-        !candidate.provider.key
-      ) {
-        return false
-      }
-      const id = claudeBridgeTargetId(candidate.providerId, model)
-      if (seen.has(id)) return false
-      seen.add(id)
-      return true
-    })
-  }
-
-  private resolveOpenCodeApiTargets(
-    settings: StoredSettings,
-    activeTarget: ProviderRuntimeTarget,
-    route: AgentModelRoute
-  ): ProviderRuntimeTarget[] {
-    if (route !== 'opencode-anthropic' && route !== 'opencode-openai') return []
-    const framework = getAgentFramework('opencode')
-    const candidates: ProviderRuntimeTarget[] = [activeTarget]
-
-    for (const storedProvider of settings.providers) {
-      try {
-        const configured =
-          storedProvider.id === activeTarget.providerId
-            ? activeTarget
-            : this.providers.resolveRuntimeTarget(
-                storedProvider,
-                { kind: 'configured', requestedModel: storedProvider.model },
-                framework
-              )
-        candidates.push(configured)
-        candidates.push(...this.providers.resolveRuntimeModelCatalog(storedProvider, framework))
-      } catch {
-        // A stale provider must not stop the active generation. If selected later it reconnects.
-      }
-    }
-
-    const seen = new Set<string>()
-    return candidates.filter((candidate) => {
-      const model = candidate.effectiveModel ?? candidate.provider.model
-      const endpoint =
-        route === 'opencode-openai'
-          ? openAiChatCompletionsUrl(candidate.provider)
-          : normalizeAnthropicBaseUrl(candidate.provider.baseUrl ?? '')
-      const id = model
-        ? providerTransportTargetId('opencode', candidate.providerId, model)
-        : undefined
-      if (
-        !candidate.frameworkCompatible ||
-        modelRouteFor('opencode', candidate) !== route ||
-        !model ||
-        !endpoint ||
-        !id ||
-        seen.has(id)
-      ) {
-        return false
-      }
-      seen.add(id)
-      return true
-    })
-  }
-
-  private resolveCodexApiTargets(
-    settings: StoredSettings,
-    activeTarget: ProviderRuntimeTarget,
-    route: AgentModelRoute
-  ): ProviderRuntimeTarget[] {
-    if (
-      route !== 'codex-bridge' &&
-      route !== 'codex-responses-compatibility' &&
-      route !== 'codex-responses'
-    ) {
-      return []
-    }
-    const framework = getAgentFramework('codex')
-    const candidates: ProviderRuntimeTarget[] = [activeTarget]
-
-    for (const storedProvider of settings.providers) {
-      try {
-        const configured =
-          storedProvider.id === activeTarget.providerId
-            ? activeTarget
-            : this.providers.resolveRuntimeTarget(
-                storedProvider,
-                { kind: 'configured', requestedModel: storedProvider.model },
-                framework
-              )
-        candidates.push(configured)
-        candidates.push(...this.providers.resolveRuntimeModelCatalog(storedProvider, framework))
-      } catch {
-        // A stale provider remains a reconnect-only target until it resolves successfully.
-      }
-    }
-
-    const seen = new Set<string>()
-    return candidates.filter((candidate) => {
-      const model = candidate.effectiveModel ?? candidate.provider.model
-      const baseUrl =
-        route === 'codex-bridge'
-          ? openAiCompletionsBase(candidate.provider)
-          : normalizeResponsesBaseUrl(
-              candidate.provider.openaiBaseUrl ?? candidate.provider.baseUrl
-            )
-      const id = model ? providerTransportTargetId('codex', candidate.providerId, model) : undefined
-      if (
-        !candidate.frameworkCompatible ||
-        !candidate.modelBridgeSupported ||
-        modelRouteFor('codex', candidate) !== route ||
-        !model ||
-        !baseUrl ||
-        !id ||
-        seen.has(id)
-      ) {
-        return false
-      }
-      seen.add(id)
-      return true
-    })
-  }
-
   private async ensureOpenCodeProviderTransports(
-    settings: StoredSettings,
     activeTarget: ProviderRuntimeTarget,
-    route: AgentModelRoute,
-    effortIntent: ReasoningEffort
+    transport: BackendTransportPlan
   ): Promise<OpenCodeProviderTransport | undefined> {
-    const candidates = this.resolveOpenCodeApiTargets(settings, activeTarget, route)
-    if (new Set(candidates.map((candidate) => candidate.providerId)).size < 2) return undefined
+    if (transport.kind !== 'opencode-openai' && transport.kind !== 'opencode-anthropic') {
+      return undefined
+    }
+    const route = transport.kind
 
     const bridges: Array<AnthropicProviderBridgePort | OpenAiProviderBridgePort> = []
     const targetIds = new Set<string>()
@@ -1031,10 +681,11 @@ export class AgentBackendResolver {
     let activeProvider: ProviderRuntimeTarget['provider'] | undefined
 
     try {
-      for (const candidate of candidates) {
+      for (const planned of transport.targets) {
+        const candidate = planned.target
         const model = candidate.effectiveModel ?? candidate.provider.model
         if (!model) continue
-        const targetId = providerTransportTargetId('opencode', candidate.providerId, model)
+        const targetId = planned.id
         const bridge =
           route === 'opencode-openai'
             ? this.createOpenAiProviderBridge(
@@ -1076,14 +727,11 @@ export class AgentBackendResolver {
           key: connection.token,
           apiEndpoints
         })
-        const effort = resolvedModelEffort(effortIntent, candidate)
         catalog.push(
           Object.freeze({
             provider: localProvider,
-            ...(effort === 'default' ? {} : { reasoningEffort: effort }),
-            ...(candidate.reasoningEffortProfile.supported
-              ? { reasoningEfforts: [...new Set(candidate.reasoningEffortProfile.slots)] }
-              : {})
+            ...(planned.reasoningEffort ? { reasoningEffort: planned.reasoningEffort } : {}),
+            ...(planned.reasoningEfforts ? { reasoningEfforts: planned.reasoningEfforts } : {})
           })
         )
         targetIds.add(targetId)
@@ -1118,16 +766,17 @@ export class AgentBackendResolver {
 
   private async ensureNativeCodexProviderTransport(
     activeTarget: ProviderRuntimeTarget,
-    candidates: readonly ProviderRuntimeTarget[]
+    transport: Extract<BackendTransportPlan, { targets: readonly unknown[] }>
   ): Promise<NativeCodexProviderTransport> {
-    const targets = candidates.map((candidate): OpenAiProviderBridgeTarget => {
+    const targets = transport.targets.map((planned): OpenAiProviderBridgeTarget => {
+      const candidate = planned.target
       const model = candidate.effectiveModel ?? candidate.provider.model
       const baseUrl = normalizeResponsesBaseUrl(
         candidate.provider.openaiBaseUrl ?? candidate.provider.baseUrl
       )
       if (!model || !baseUrl) throw new Error('The native Responses provider target is incomplete.')
       return Object.freeze({
-        id: providerTransportTargetId('codex', candidate.providerId, model),
+        id: planned.id,
         wire: 'responses',
         endpoint: `${baseUrl}/responses`,
         ...(candidate.provider.key ? { key: candidate.provider.key } : {}),
@@ -1136,7 +785,8 @@ export class AgentBackendResolver {
     })
     const activeModel = activeTarget.effectiveModel ?? activeTarget.provider.model
     if (!activeModel) throw new Error('The active native Responses model is unavailable.')
-    const initialTargetId = providerTransportTargetId('codex', activeTarget.providerId, activeModel)
+    const initialTargetId = transport.initialTargetId
+    if (!initialTargetId) throw new Error('The active native Responses model is unavailable.')
     const bridge = this.createOpenAiProviderBridge(targets, initialTargetId)
 
     try {
@@ -1169,9 +819,9 @@ export class AgentBackendResolver {
   private async ensureResponsesBridge(
     activeTarget: ProviderRuntimeTarget,
     reasoningEffort: ModelReasoningEffort | undefined,
-    conversationSkillImportEnabled: boolean,
-    providerTargets?: readonly ProviderRuntimeTarget[],
-    effortIntent: ReasoningEffort = DEFAULT_REASONING_EFFORT
+    transport: BackendTransportPlan,
+    namespacedTools: readonly ResponsesBridgeNamespacedTool[],
+    reviewerTools: readonly ResponsesBridgeNamespacedTool[]
   ): Promise<LeasedResponsesBridgeConnection> {
     const createTarget = (
       candidate: ProviderRuntimeTarget,
@@ -1186,27 +836,25 @@ export class AgentBackendResolver {
         reasoningEffortTransport: candidate.provider.reasoningEffortTransport,
         model: candidate.effectiveModel ?? candidate.provider.model,
         reasoningEffort: effort,
-        namespacedTools: [
-          ...CODEX_BRIDGE_NOTEBOOK_TOOLS,
-          ...CODEX_BRIDGE_ARTIFACT_TOOLS,
-          ...(conversationSkillImportEnabled ? CODEX_BRIDGE_SKILL_IMPORT_TOOLS : [])
-        ],
-        reviewerScope: { namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS }
+        namespacedTools: [...namespacedTools],
+        reviewerScope: { namespacedTools: [...reviewerTools] }
       }
     }
     const targets = new Map<string, ResponsesBridgeTarget>()
-    for (const candidate of providerTargets ?? []) {
+    const plannedTargets = transport.kind === 'codex-chat' ? transport.targets : []
+    for (const planned of plannedTargets) {
+      const candidate = planned.target
       const model = candidate.effectiveModel ?? candidate.provider.model
       if (!model) continue
-      const resolvedEffort = resolvedModelEffort(effortIntent, candidate)
-      targets.set(
-        providerTransportTargetId('codex', candidate.providerId, model),
-        createTarget(candidate, resolvedEffort === 'default' ? undefined : resolvedEffort)
-      )
+      targets.set(planned.id, createTarget(candidate, planned.reasoningEffort))
     }
     const activeModel = activeTarget.effectiveModel ?? activeTarget.provider.model
     const initialTargetId = activeModel
-      ? providerTransportTargetId('codex', activeTarget.providerId, activeModel)
+      ? plannedTargets.find(
+          ({ target }) =>
+            target.providerId === activeTarget.providerId &&
+            (target.effectiveModel ?? target.provider.model) === activeModel
+        )?.id
       : undefined
     const target =
       (initialTargetId ? targets.get(initialTargetId) : undefined) ??
@@ -1269,7 +917,8 @@ export class AgentBackendResolver {
 
   private async ensureNativeResponsesCompatibility(
     activeTarget: ProviderRuntimeTarget,
-    providerTargets?: readonly ProviderRuntimeTarget[]
+    transport: BackendTransportPlan,
+    reviewerTools: readonly ResponsesBridgeNamespacedTool[]
   ): Promise<LeasedResponsesBridgeConnection> {
     const createTarget = (candidate: ProviderRuntimeTarget): NativeResponsesProxyTarget => {
       const targetBaseUrl = normalizeResponsesBaseUrl(
@@ -1280,21 +929,25 @@ export class AgentBackendResolver {
         baseUrl: targetBaseUrl,
         key: candidate.provider.key,
         model: candidate.effectiveModel ?? candidate.provider.model,
-        reviewerScope: { namespacedTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS }
+        reviewerScope: { namespacedTools: [...reviewerTools] }
       }
     }
     const targets = new Map<string, NativeResponsesProxyTarget>()
-    for (const candidate of providerTargets ?? []) {
+    const plannedTargets =
+      transport.kind === 'codex-responses-compatibility' ? transport.targets : []
+    for (const planned of plannedTargets) {
+      const candidate = planned.target
       const model = candidate.effectiveModel ?? candidate.provider.model
       if (!model) continue
-      targets.set(
-        providerTransportTargetId('codex', candidate.providerId, model),
-        createTarget(candidate)
-      )
+      targets.set(planned.id, createTarget(candidate))
     }
     const activeModel = activeTarget.effectiveModel ?? activeTarget.provider.model
     const initialTargetId = activeModel
-      ? providerTransportTargetId('codex', activeTarget.providerId, activeModel)
+      ? plannedTargets.find(
+          ({ target }) =>
+            target.providerId === activeTarget.providerId &&
+            (target.effectiveModel ?? target.provider.model) === activeModel
+        )?.id
       : undefined
     const proxyId = this.nextGenerationId()
     const proxy = this.createNativeResponsesProxy(

--- a/src/main/settings/backend-route-planner.architecture.test.ts
+++ b/src/main/settings/backend-route-planner.architecture.test.ts
@@ -1,0 +1,138 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { extname, relative, resolve } from 'node:path'
+
+import {
+  canHaveModifiers,
+  createSourceFile,
+  getModifiers,
+  isClassDeclaration,
+  isExportDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isMethodDeclaration,
+  isNamedExports,
+  isPropertyDeclaration,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  type Node,
+  type SourceFile
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = resolve(__dirname, '../../..')
+const plannerPath = resolve(__dirname, 'backend-route-planner.ts')
+const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
+const readSource = (path: string): string => readFileSync(path, 'utf8')
+const sourceFileFor = (path: string): SourceFile =>
+  createSourceFile(
+    path,
+    readSource(path),
+    ScriptTarget.Latest,
+    true,
+    extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
+  )
+const portablePath = (path: string): string => relative(projectRoot, path).replaceAll('\\', '/')
+
+const productionSources = (): string[] => {
+  const sources: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isDirectory()) visit(path)
+      else if (
+        ['.ts', '.tsx'].includes(extname(path)) &&
+        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
+      ) {
+        sources.push(path)
+      }
+    }
+  }
+  visit(resolve(projectRoot, 'src'))
+  visit(resolve(projectRoot, 'packages'))
+  return sources
+}
+
+const importsPlanner = (path: string): boolean => {
+  let imports = false
+  const sourceFile = sourceFileFor(path)
+  const visit = (node: Node): void => {
+    if (
+      isImportDeclaration(node) &&
+      node.moduleSpecifier.getText(sourceFile).includes('backend-route-planner')
+    ) {
+      imports = true
+    }
+    node.forEachChild(visit)
+  }
+  visit(sourceFile)
+  return imports
+}
+
+const publicOperations = (): string[] => {
+  const declaration = sourceFileFor(plannerPath).statements.find(
+    (statement) => isClassDeclaration(statement) && statement.name?.text === 'BackendRoutePlanner'
+  )
+  if (!declaration || !isClassDeclaration(declaration)) throw new Error('planner class not found')
+  return declaration.members
+    .flatMap((member) => {
+      const hidden =
+        canHaveModifiers(member) &&
+        getModifiers(member)?.some((modifier) => modifier.kind === SyntaxKind.PrivateKeyword)
+      return !hidden &&
+        (isMethodDeclaration(member) || isPropertyDeclaration(member)) &&
+        isIdentifier(member.name)
+        ? [member.name.text]
+        : []
+    })
+    .sort()
+}
+
+describe('Backend route planning ownership', () => {
+  it('keeps the pure planner within forecast and free of live resource ownership', () => {
+    const source = readSource(plannerPath)
+    const lines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
+    expect(lines).toBeLessThanOrEqual(500)
+    expect(lines).toBeLessThanOrEqual(660)
+    expect(source).not.toMatch(
+      /new\s+(?:ResponsesBridge|NativeResponsesCompatibilityProxy|AnthropicProviderBridge|OpenAiProviderBridge)|\.start\(|\.close\(|\blease\b|nextGenerationId|randomUUID|new\s+Map|responsesBridges|nativeResponsesCompatibilityProxies/
+    )
+    expect(source).not.toMatch(/console\.|JSON\.stringify\([^\n]*(?:key|token|credential)/i)
+  })
+
+  it('locks the planner to two deep operations and an internal export inventory', () => {
+    expect(publicOperations()).toEqual(['planBackend', 'projectModelChange'])
+    const exports = sourceFileFor(plannerPath).statements.filter(isExportDeclaration)
+    expect(
+      exports.flatMap((statement) =>
+        statement.exportClause && isNamedExports(statement.exportClause)
+          ? statement.exportClause.elements.map(
+              (element) =>
+                `${statement.isTypeOnly || element.isTypeOnly ? 'type' : 'value'}:${element.name.text}`
+            )
+          : []
+      )
+    ).toEqual([
+      'value:BackendRoutePlanner',
+      'type:BackendRouteProviderPort',
+      'type:BackendTransportPlan'
+    ])
+  })
+
+  it('keeps the planner behind the resolver and inside dependency-aware impact routing', () => {
+    expect(productionSources().filter(importsPlanner).map(portablePath)).toEqual([
+      'src/main/settings/backend-resolver.ts'
+    ])
+    const manifest = JSON.parse(readSource(manifestPath)) as {
+      modules: Record<string, { ownerPaths: string[]; testFiles: { owner: string[] } }>
+    }
+    const module = manifest.modules.settings_backend_resolution
+    expect(module.ownerPaths).toContain('src/main/settings/backend-route-planner.ts')
+    expect(module.testFiles.owner).toEqual(
+      expect.arrayContaining([
+        'src/main/settings/backend-route-planner.test.ts',
+        'src/main/settings/backend-route-planner.architecture.test.ts'
+      ])
+    )
+  })
+})

--- a/src/main/settings/backend-route-planner.test.ts
+++ b/src/main/settings/backend-route-planner.test.ts
@@ -1,0 +1,591 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { SETTINGS_FILE_VERSION } from '../../shared/settings'
+import type { AgentFrameworkId } from '../agent-framework'
+import type { ProviderRuntimeTarget } from './provider-accounts'
+import type { ResolvedProvider } from './provider-env'
+import type { StoredProvider, StoredSettings } from './types'
+import { BackendRoutePlanner, type BackendRouteProviderPort } from './backend-route-planner'
+
+const makeStoredProvider = (overrides: Partial<StoredProvider> = {}): StoredProvider => ({
+  id: 'provider-a',
+  type: 'custom',
+  name: 'Provider A',
+  apiEndpoints: ['anthropic', 'openai', 'responses'],
+  baseUrl: 'https://provider-a.example/v1',
+  model: 'model-a',
+  keyRef: 'provider-a-key-ref',
+  ...overrides
+})
+
+const makeSettings = (provider = makeStoredProvider()): StoredSettings => ({
+  version: SETTINGS_FILE_VERSION,
+  providers: [provider],
+  activeProviderId: provider.id,
+  activeModel: provider.model,
+  agentFrameworkId: 'codex',
+  reasoningEffort: 'high'
+})
+
+const makeTarget = (
+  provider: StoredProvider,
+  overrides: Omit<Partial<ProviderRuntimeTarget>, 'provider'> & {
+    provider?: Partial<ResolvedProvider>
+  } = {}
+): ProviderRuntimeTarget => {
+  const { provider: providerOverrides, ...targetOverrides } = overrides
+  return {
+    providerId: provider.id,
+    providerType: provider.type,
+    effectiveModel: provider.model,
+    apiEndpoints: provider.apiEndpoints ?? ['anthropic'],
+    provider: {
+      type: provider.type,
+      baseUrl: provider.baseUrl,
+      openaiBaseUrl: provider.baseUrl,
+      model: provider.model,
+      key: 'plain-provider-key',
+      apiEndpoints: provider.apiEndpoints,
+      ...providerOverrides
+    },
+    reasoningEffortProfile: {
+      supported: true,
+      slots: ['low', 'medium', 'high', 'xhigh', 'max']
+    },
+    frameworkCompatible: true,
+    modelBridgeSupported: true,
+    needsChatResponsesBridge: false,
+    needsNativeResponsesCompatibility: false,
+    ...targetOverrides
+  }
+}
+
+const makePlanner = (): BackendRoutePlanner => {
+  const providers: BackendRouteProviderPort = {
+    resolveRuntimeTarget: vi.fn(),
+    resolveRuntimeModelCatalog: vi.fn(() => [])
+  }
+  return new BackendRoutePlanner({ providers })
+}
+
+describe('BackendRoutePlanner route matrix', () => {
+  it.each<{
+    name: string
+    frameworkId: AgentFrameworkId
+    target: Omit<Partial<ProviderRuntimeTarget>, 'provider'> & {
+      provider?: Partial<ResolvedProvider>
+    }
+    forceCompatibility?: boolean
+    route: string
+  }>([
+    { name: 'Claude', frameworkId: 'claude-code', target: {}, route: 'claude-anthropic' },
+    {
+      name: 'OpenCode OpenAI',
+      frameworkId: 'opencode',
+      target: { apiEndpoints: ['openai'] },
+      route: 'opencode-openai'
+    },
+    {
+      name: 'OpenCode Anthropic',
+      frameworkId: 'opencode',
+      target: { apiEndpoints: ['anthropic'] },
+      route: 'opencode-anthropic'
+    },
+    {
+      name: 'Codex Chat bridge',
+      frameworkId: 'codex',
+      target: { needsChatResponsesBridge: true },
+      route: 'codex-bridge'
+    },
+    {
+      name: 'Codex native compatibility',
+      frameworkId: 'codex',
+      target: { needsNativeResponsesCompatibility: true },
+      route: 'codex-responses-compatibility'
+    },
+    { name: 'Codex direct Responses', frameworkId: 'codex', target: {}, route: 'codex-responses' },
+    {
+      name: 'forced Codex compatibility',
+      frameworkId: 'codex',
+      target: {},
+      forceCompatibility: true,
+      route: 'codex-responses-compatibility'
+    }
+  ])('plans $name without starting a live resource', (testCase) => {
+    const provider = makeStoredProvider()
+    const target = makeTarget(provider, testCase.target)
+
+    const plan = makePlanner().planBackend({
+      settings: makeSettings(provider),
+      frameworkId: testCase.frameworkId,
+      target,
+      effortIntent: 'high',
+      conversationSkillImportEnabled: true,
+      forceNativeResponsesCompatibility: testCase.forceCompatibility
+    })
+
+    expect(plan.modelRoute).toBe(testCase.route)
+  })
+
+  it('rejects forced native compatibility for Codex subscription before planning resources', () => {
+    const provider = makeStoredProvider({
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      codexAuthMode: 'isolated',
+      keyRef: undefined
+    })
+
+    expect(() =>
+      makePlanner().planBackend({
+        settings: makeSettings(provider),
+        frameworkId: 'codex',
+        target: makeTarget(provider),
+        effortIntent: 'high',
+        conversationSkillImportEnabled: true,
+        forceNativeResponsesCompatibility: true
+      })
+    ).toThrow('unavailable with Codex subscription authentication')
+  })
+})
+
+describe('BackendRoutePlanner provider candidates', () => {
+  it('deduplicates valid Claude bridge targets and ignores stale sibling providers', () => {
+    const providerA = makeStoredProvider({ id: 'provider-a', model: 'model-a' })
+    const providerB = makeStoredProvider({
+      id: 'provider-b',
+      model: 'model-b',
+      baseUrl: 'https://provider-b.example/anthropic'
+    })
+    const stale = makeStoredProvider({ id: 'stale', model: 'stale-model' })
+    const targetA = makeTarget(providerA, {
+      apiEndpoints: ['anthropic'],
+      provider: { apiEndpoints: ['anthropic'] }
+    })
+    const targetB = makeTarget(providerB, {
+      apiEndpoints: ['anthropic'],
+      provider: { apiEndpoints: ['anthropic'] }
+    })
+    const providers: BackendRouteProviderPort = {
+      resolveRuntimeTarget: vi.fn((provider) => {
+        if (provider.id === stale.id) throw new Error('stale credential')
+        return provider.id === providerA.id ? targetA : targetB
+      }),
+      resolveRuntimeModelCatalog: vi.fn((provider) =>
+        provider.id === providerB.id ? [targetB, targetB] : []
+      )
+    }
+    const settings = makeSettings(providerA)
+    settings.providers = [providerA, providerB, stale]
+
+    const plan = new BackendRoutePlanner({ providers }).planBackend({
+      settings,
+      frameworkId: 'claude-code',
+      target: targetA,
+      effortIntent: 'high',
+      conversationSkillImportEnabled: true
+    })
+
+    expect(plan.transport).toEqual({
+      kind: 'claude-anthropic',
+      targets: [
+        {
+          id: JSON.stringify(['provider-a', 'model-a']),
+          baseUrl: 'https://provider-a.example',
+          key: 'plain-provider-key',
+          model: 'model-a'
+        },
+        {
+          id: JSON.stringify(['provider-b', 'model-b']),
+          baseUrl: 'https://provider-b.example/anthropic',
+          key: 'plain-provider-key',
+          model: 'model-b'
+        }
+      ],
+      initialTargetId: JSON.stringify(['provider-a', 'model-a'])
+    })
+    expect(providers.resolveRuntimeTarget).toHaveBeenCalledWith(
+      stale,
+      { kind: 'configured', requestedModel: stale.model },
+      expect.objectContaining({ id: 'claude-code' })
+    )
+  })
+
+  it('filters model catalogs by route and preserves deduplicated effort slots', () => {
+    const provider = makeStoredProvider()
+    const active = makeTarget(provider, {
+      apiEndpoints: ['openai'],
+      provider: { apiEndpoints: ['openai'] }
+    })
+    const catalogTarget = makeTarget(provider, {
+      effectiveModel: 'catalog-model',
+      apiEndpoints: ['openai'],
+      provider: { model: 'catalog-model', apiEndpoints: ['openai'] },
+      reasoningEffortProfile: {
+        supported: true,
+        slots: ['low', 'high', 'high', 'xhigh', 'max']
+      }
+    })
+    const wrongRoute = makeTarget(provider, {
+      effectiveModel: 'anthropic-model',
+      apiEndpoints: ['anthropic'],
+      provider: { model: 'anthropic-model', apiEndpoints: ['anthropic'] }
+    })
+    const providers: BackendRouteProviderPort = {
+      resolveRuntimeTarget: vi.fn(() => active),
+      resolveRuntimeModelCatalog: vi.fn(() => [catalogTarget, wrongRoute])
+    }
+
+    const plan = new BackendRoutePlanner({ providers }).planBackend({
+      settings: makeSettings(provider),
+      frameworkId: 'opencode',
+      target: active,
+      effortIntent: 'max',
+      conversationSkillImportEnabled: true
+    })
+
+    expect(plan.providerModelCatalog).toEqual([
+      {
+        provider: catalogTarget.provider,
+        reasoningEffort: 'max',
+        reasoningEfforts: ['low', 'high', 'xhigh', 'max']
+      }
+    ])
+  })
+
+  it('registers opaque third-party Claude model ids through identity overrides', () => {
+    const provider = makeStoredProvider({ model: 'third-party/model-a' })
+    const targetA = makeTarget(provider, {
+      effectiveModel: 'third-party/model-a',
+      apiEndpoints: ['anthropic'],
+      provider: { model: 'third-party/model-a', apiEndpoints: ['anthropic'] }
+    })
+    const targetB = makeTarget(provider, {
+      effectiveModel: 'third-party/model-b',
+      apiEndpoints: ['anthropic'],
+      provider: { model: 'third-party/model-b', apiEndpoints: ['anthropic'] }
+    })
+    const providers: BackendRouteProviderPort = {
+      resolveRuntimeTarget: vi.fn(() => targetA),
+      resolveRuntimeModelCatalog: vi.fn(() => [targetA, targetB, targetB])
+    }
+
+    const plan = new BackendRoutePlanner({ providers }).planBackend({
+      settings: makeSettings(provider),
+      frameworkId: 'claude-code',
+      target: targetA,
+      effortIntent: 'high',
+      conversationSkillImportEnabled: true
+    })
+
+    expect(plan.claudeModelConfig).toEqual({
+      availableModels: ['third-party/model-a', 'third-party/model-b'],
+      modelOverrides: {
+        'third-party/model-a': 'third-party/model-a',
+        'third-party/model-b': 'third-party/model-b'
+      }
+    })
+    expect(JSON.stringify(plan.claudeModelConfig)).not.toContain('plain-provider-key')
+  })
+
+  it('keeps OpenAI-only and incomplete providers out of the Claude model configuration', () => {
+    const providersById = [
+      makeStoredProvider({ id: 'provider-a', model: 'model-a' }),
+      makeStoredProvider({ id: 'provider-b', model: 'model-b' }),
+      makeStoredProvider({ id: 'openai-only', model: 'openai-model' }),
+      makeStoredProvider({ id: 'missing-key', model: 'missing-key-model' }),
+      makeStoredProvider({ id: 'missing-base', model: 'missing-base-model' })
+    ]
+    const targets = new Map(
+      providersById.map((provider) => {
+        const invalidOverrides: Parameters<typeof makeTarget>[1] =
+          provider.id === 'openai-only'
+            ? { apiEndpoints: ['openai'], provider: { apiEndpoints: ['openai'] } }
+            : provider.id === 'missing-key'
+              ? { provider: { key: undefined } }
+              : provider.id === 'missing-base'
+                ? { provider: { baseUrl: undefined } }
+                : {}
+        return [provider.id, makeTarget(provider, invalidOverrides)] as const
+      })
+    )
+    const settings = makeSettings(providersById[0])
+    settings.providers = providersById
+    const planner = new BackendRoutePlanner({
+      providers: {
+        resolveRuntimeTarget: vi.fn((provider) => targets.get(provider.id)!),
+        resolveRuntimeModelCatalog: vi.fn(() => [])
+      }
+    })
+
+    const plan = planner.planBackend({
+      settings,
+      frameworkId: 'claude-code',
+      target: targets.get('provider-a')!,
+      effortIntent: 'high',
+      conversationSkillImportEnabled: true
+    })
+
+    expect(plan.claudeModelConfig).toEqual({
+      availableModels: ['model-a', 'model-b'],
+      modelOverrides: { 'model-a': 'model-a', 'model-b': 'model-b' }
+    })
+  })
+
+  it.each(['claude-shared', 'claude-isolated'] as const)(
+    'does not expose custom sibling model overrides to an active %s subscription',
+    (subscriptionType) => {
+      const subscription = makeStoredProvider({
+        id: `builtin-${subscriptionType}`,
+        type: subscriptionType,
+        apiEndpoints: [],
+        baseUrl: undefined,
+        model: 'subscription-model',
+        keyRef: undefined
+      })
+      const customA = makeStoredProvider({ id: 'custom-a', model: 'custom-model-a' })
+      const customB = makeStoredProvider({ id: 'custom-b', model: 'custom-model-b' })
+      const targets = new Map([
+        [
+          subscription.id,
+          makeTarget(subscription, {
+            apiEndpoints: [],
+            provider: { apiEndpoints: [], baseUrl: undefined, key: undefined }
+          })
+        ],
+        [customA.id, makeTarget(customA)],
+        [customB.id, makeTarget(customB)]
+      ])
+      const settings = makeSettings(subscription)
+      settings.providers = [subscription, customA, customB]
+      const planner = new BackendRoutePlanner({
+        providers: {
+          resolveRuntimeTarget: vi.fn((provider) => targets.get(provider.id)!),
+          resolveRuntimeModelCatalog: vi.fn(() => [])
+        }
+      })
+
+      const plan = planner.planBackend({
+        settings,
+        frameworkId: 'claude-code',
+        target: targets.get(subscription.id)!,
+        effortIntent: 'high',
+        conversationSkillImportEnabled: true
+      })
+
+      expect(plan.claudeModelConfig).toBeUndefined()
+      expect(plan.transport).toEqual({ kind: 'direct' })
+    }
+  )
+
+  it('keeps a configured sibling when its model catalog projection fails', () => {
+    const providerA = makeStoredProvider({ id: 'provider-a', model: 'model-a' })
+    const providerB = makeStoredProvider({ id: 'provider-b', model: 'model-b' })
+    const targetA = makeTarget(providerA, {
+      apiEndpoints: ['openai'],
+      provider: { apiEndpoints: ['openai'] }
+    })
+    const targetB = makeTarget(providerB, {
+      apiEndpoints: ['openai'],
+      provider: { apiEndpoints: ['openai'] }
+    })
+    const settings = makeSettings(providerA)
+    settings.providers = [providerA, providerB]
+    const planner = new BackendRoutePlanner({
+      providers: {
+        resolveRuntimeTarget: vi.fn((provider) =>
+          provider.id === providerA.id ? targetA : targetB
+        ),
+        resolveRuntimeModelCatalog: vi.fn((provider) => {
+          if (provider.id === providerB.id) throw new Error('catalog projection failed')
+          return []
+        })
+      }
+    })
+
+    const plan = planner.planBackend({
+      settings,
+      frameworkId: 'opencode',
+      target: targetA,
+      effortIntent: 'high',
+      conversationSkillImportEnabled: true
+    })
+
+    expect(plan.transport).toMatchObject({
+      kind: 'opencode-openai',
+      targets: [{ target: { providerId: providerA.id } }, { target: { providerId: providerB.id } }]
+    })
+  })
+
+  it('plans deduplicated OpenCode targets within the active endpoint route', () => {
+    const providerA = makeStoredProvider({ id: 'provider-a', model: 'model-a' })
+    const providerB = makeStoredProvider({ id: 'provider-b', model: 'model-b' })
+    const providerC = makeStoredProvider({ id: 'provider-c', model: 'model-c' })
+    const targetA = makeTarget(providerA, {
+      apiEndpoints: ['openai'],
+      provider: { apiEndpoints: ['openai'] }
+    })
+    const targetB = makeTarget(providerB, {
+      apiEndpoints: ['openai'],
+      provider: { apiEndpoints: ['openai'] }
+    })
+    const targetC = makeTarget(providerC, {
+      apiEndpoints: ['anthropic'],
+      provider: { apiEndpoints: ['anthropic'] }
+    })
+    const targets = new Map([
+      [providerA.id, targetA],
+      [providerB.id, targetB],
+      [providerC.id, targetC]
+    ])
+    const providers: BackendRouteProviderPort = {
+      resolveRuntimeTarget: vi.fn((provider) => targets.get(provider.id)!),
+      resolveRuntimeModelCatalog: vi.fn((provider) =>
+        provider.id === providerB.id ? [targetB, targetB] : []
+      )
+    }
+    const settings = makeSettings(providerA)
+    settings.providers = [providerA, providerB, providerC]
+
+    const plan = new BackendRoutePlanner({ providers }).planBackend({
+      settings,
+      frameworkId: 'opencode',
+      target: targetA,
+      effortIntent: 'max',
+      conversationSkillImportEnabled: true
+    })
+
+    expect(plan.transport).toMatchObject({
+      kind: 'opencode-openai',
+      targets: [
+        {
+          id: JSON.stringify(['opencode', 'provider-a', 'model-a']),
+          target: { providerId: 'provider-a', effectiveModel: 'model-a' }
+        },
+        {
+          id: JSON.stringify(['opencode', 'provider-b', 'model-b']),
+          target: { providerId: 'provider-b', effectiveModel: 'model-b' }
+        }
+      ]
+    })
+    expect((plan.transport as { targets: readonly unknown[] }).targets).toHaveLength(2)
+  })
+
+  it('declares canonical Codex Chat tools and keeps Reviewer tools scoped to reviewers', () => {
+    const providerA = makeStoredProvider({ id: 'provider-a', model: 'model-a' })
+    const providerB = makeStoredProvider({ id: 'provider-b', model: 'model-b' })
+    const targetA = makeTarget(providerA, {
+      apiEndpoints: ['openai'],
+      needsChatResponsesBridge: true,
+      provider: { apiEndpoints: ['openai'] }
+    })
+    const targetB = makeTarget(providerB, {
+      apiEndpoints: ['openai'],
+      needsChatResponsesBridge: true,
+      provider: { apiEndpoints: ['openai'] }
+    })
+    const providers: BackendRouteProviderPort = {
+      resolveRuntimeTarget: vi.fn((provider) => (provider.id === providerA.id ? targetA : targetB)),
+      resolveRuntimeModelCatalog: vi.fn(() => [])
+    }
+    const settings = makeSettings(providerA)
+    settings.providers = [providerA, providerB]
+
+    const plan = new BackendRoutePlanner({ providers }).planBackend({
+      settings,
+      frameworkId: 'codex',
+      target: targetA,
+      effortIntent: 'max',
+      conversationSkillImportEnabled: true
+    })
+    const transport = plan.transport as {
+      kind: string
+      targets: { id: string }[]
+    }
+
+    expect(transport.kind).toBe('codex-chat')
+    expect(transport.targets.map(({ id }) => id)).toEqual([
+      JSON.stringify(['codex', 'provider-a', 'model-a']),
+      JSON.stringify(['codex', 'provider-b', 'model-b'])
+    ])
+    expect(plan.codexBridgeTools?.map(({ namespace, name }) => `${namespace}/${name}`)).toEqual(
+      expect.arrayContaining([
+        'mcp__open_science_notebook/notebook_execute',
+        'mcp__open_science_artifacts/write_artifact_file',
+        'mcp__open_science_skills/request_skill_import'
+      ])
+    )
+    expect(plan.reviewerBridgeTools?.map(({ namespace, name }) => `${namespace}/${name}`)).toEqual(
+      expect.arrayContaining([
+        'mcp__open_science_reviewer/read_turn',
+        'mcp__open_science_reviewer/submit_findings'
+      ])
+    )
+    expect(plan.codexBridgeTools).not.toEqual(
+      expect.arrayContaining([...(plan.reviewerBridgeTools ?? [])])
+    )
+    const withoutSkillImport = new BackendRoutePlanner({ providers }).planBackend({
+      settings,
+      frameworkId: 'codex',
+      target: targetA,
+      effortIntent: 'max',
+      conversationSkillImportEnabled: false
+    })
+    expect(withoutSkillImport.codexBridgeTools?.map(({ name }) => name)).not.toContain(
+      'request_skill_import'
+    )
+  })
+})
+
+describe('BackendRoutePlanner model-change projection', () => {
+  it('projects a secret-free retargetable Codex model identity', () => {
+    const providerA = makeStoredProvider({ id: 'provider-a', model: 'model-a' })
+    const providerB = makeStoredProvider({ id: 'provider-b', model: 'model-b' })
+    const targetA = makeTarget(providerA, {
+      apiEndpoints: ['openai'],
+      needsChatResponsesBridge: true,
+      provider: {
+        apiEndpoints: ['openai'],
+        vendorId: 'deepseek',
+        contextWindow: 128_000,
+        reasoningEffortTransport: 'deepseek'
+      }
+    })
+    const targetB = makeTarget(providerB, {
+      apiEndpoints: ['openai'],
+      needsChatResponsesBridge: true,
+      provider: { apiEndpoints: ['openai'] }
+    })
+    const providers: BackendRouteProviderPort = {
+      resolveRuntimeTarget: vi.fn((provider) => (provider.id === providerA.id ? targetA : targetB)),
+      resolveRuntimeModelCatalog: vi.fn(() => [])
+    }
+    const settings = makeSettings(providerA)
+    settings.providers = [providerA, providerB]
+
+    const target = new BackendRoutePlanner({ providers }).projectModelChange({
+      settings,
+      frameworkId: 'codex',
+      target: targetA,
+      effortIntent: 'max'
+    })
+
+    expect(target).toEqual({
+      frameworkId: 'codex',
+      backendId: 'codex:provider-a',
+      route: 'codex-bridge',
+      model: 'model-a',
+      sessionModel: 'gpt-5.4',
+      sessionModelRequired: false,
+      supportsImageInput: false,
+      reasoningEffort: 'max',
+      contextWindow: 128_000,
+      providerTransportTargetId: JSON.stringify(['codex', 'provider-a', 'model-a']),
+      bridge: {
+        model: 'model-a',
+        vendorId: 'deepseek',
+        reasoningEffortTransport: 'deepseek'
+      }
+    })
+    expect(JSON.stringify(target)).not.toContain('plain-provider-key')
+  })
+})

--- a/src/main/settings/backend-route-planner.ts
+++ b/src/main/settings/backend-route-planner.ts
@@ -1,0 +1,500 @@
+import { z } from 'zod'
+
+import {
+  CODEX_ISOLATED_PROVIDER_ID,
+  DEFAULT_REASONING_EFFORT,
+  isCodexSubscriptionProvider,
+  type ReasoningEffort
+} from '../../shared/settings'
+import {
+  resolveReasoningEffortValue,
+  type ModelReasoningEffort,
+  type ResolvedReasoningEffort
+} from '../../shared/reasoning-effort'
+import {
+  REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
+  REQUEST_SKILL_IMPORT_TOOL_NAME,
+  SKILL_IMPORT_MCP_SERVER_NAME
+} from '../../shared/skill-import'
+import { ARTIFACT_MCP_SERVER_NAME, writeArtifactFileToolSchema } from '../artifacts/mcp-server'
+import {
+  getAgentFramework,
+  type AgentFrameworkId,
+  type AgentModelCatalogEntry,
+  type AgentModelChangeTarget,
+  type AgentModelRoute
+} from '../agent-framework'
+import { CODEX_BRIDGE_MODEL, normalizeResponsesBaseUrl } from '../agent-framework/codex'
+import { opencodeTransportProviderId } from '../agent-framework/opencode'
+import { NOTEBOOK_MCP_SERVER_NAME, NOTEBOOK_RPC_TOOLS } from '../notebook/mcp-server'
+import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
+import { requestSkillImportToolSchema } from '../skills/mcp-server'
+import type { AnthropicProviderBridgeTarget } from './anthropic-provider-bridge'
+import {
+  normalizeAnthropicBaseUrl,
+  openAiChatCompletionsUrl,
+  openAiCompletionsBase
+} from './base-url'
+import type { ClaudeRuntimeModelConfig } from './claude-config-provision'
+import type { ProviderAccountsModule, ProviderRuntimeTarget } from './provider-accounts'
+import type { ResponsesBridgeNamespacedTool } from './responses-bridge'
+import type { StoredSettings } from './types'
+type BackendRouteProviderPort = Pick<
+  ProviderAccountsModule,
+  'resolveRuntimeTarget' | 'resolveRuntimeModelCatalog'
+>
+type BackendRoutePlanInput = Readonly<{
+  settings: StoredSettings
+  frameworkId: AgentFrameworkId
+  target: ProviderRuntimeTarget
+  effortIntent: ReasoningEffort
+  conversationSkillImportEnabled: boolean
+  forceNativeResponsesCompatibility?: boolean
+}>
+type BackendModelChangePlanInput = Omit<
+  BackendRoutePlanInput,
+  'conversationSkillImportEnabled' | 'forceNativeResponsesCompatibility'
+>
+type PlannedProviderTarget = Readonly<{
+  id: string
+  target: ProviderRuntimeTarget
+  reasoningEffort?: ModelReasoningEffort
+  reasoningEfforts?: readonly ModelReasoningEffort[]
+}>
+type BackendTransportPlan =
+  | Readonly<{ kind: 'direct' }>
+  | Readonly<{
+      kind: 'claude-anthropic'
+      targets: readonly AnthropicProviderBridgeTarget[]
+      initialTargetId: string
+    }>
+  | Readonly<{
+      kind:
+        | 'opencode-anthropic'
+        | 'opencode-openai'
+        | 'codex-chat'
+        | 'codex-responses-compatibility'
+        | 'codex-native-responses'
+      targets: readonly PlannedProviderTarget[]
+      initialTargetId?: string
+    }>
+type BackendRoutePlan = Readonly<{
+  modelRoute: AgentModelRoute
+  backendProviderId: string
+  sessionEffort?: ModelReasoningEffort
+  supportedReasoningEfforts?: readonly ModelReasoningEffort[]
+  providerModelCatalog: readonly AgentModelCatalogEntry[]
+  transport: BackendTransportPlan
+  claudeModelConfig?: ClaudeRuntimeModelConfig
+  codexBridgeTools?: readonly ResponsesBridgeNamespacedTool[]
+  reviewerBridgeTools?: readonly ResponsesBridgeNamespacedTool[]
+}>
+const modelRouteFor = (
+  frameworkId: AgentFrameworkId,
+  target: ProviderRuntimeTarget
+): AgentModelRoute => {
+  if (frameworkId === 'claude-code') return 'claude-anthropic'
+  if (frameworkId === 'opencode') {
+    return target.apiEndpoints.includes('openai') ? 'opencode-openai' : 'opencode-anthropic'
+  }
+  if (target.needsChatResponsesBridge) return 'codex-bridge'
+  if (target.needsNativeResponsesCompatibility) return 'codex-responses-compatibility'
+  return 'codex-responses'
+}
+const modelEffort = (
+  intent: ReasoningEffort,
+  target: ProviderRuntimeTarget
+): ResolvedReasoningEffort =>
+  intent === DEFAULT_REASONING_EFFORT
+    ? DEFAULT_REASONING_EFFORT
+    : resolveReasoningEffortValue(intent, target.reasoningEffortProfile)
+const claudeTargetId = (providerId: string, model: string): string =>
+  JSON.stringify([providerId, model])
+const transportTargetId = (
+  frameworkId: AgentFrameworkId,
+  providerId: string,
+  model: string
+): string => JSON.stringify([frameworkId, providerId, model])
+const namespaceFor = (serverName: string): string =>
+  `mcp__${serverName.replace(/[^a-zA-Z0-9_]/g, '_')}`
+const NOTEBOOK_TOOLS: ResponsesBridgeNamespacedTool[] = NOTEBOOK_RPC_TOOLS.map((tool) => ({
+  namespace: namespaceFor(NOTEBOOK_MCP_SERVER_NAME),
+  name: tool.name,
+  description:
+    tool.name === 'notebook_execute'
+      ? `${tool.description} For Open Science data connectors, the Python code MUST call host.mcp(server, method, arguments). Never use requests, urllib, httpx, curl, or a raw upstream API for connector data; those bypass app permissions, credentials, and rate limits. Codex MCP resource-list tools are not connector discovery.`
+      : tool.description,
+  parameters: z.toJSONSchema(z.object(tool.inputSchema), {
+    target: 'draft-7'
+  }) as ResponsesBridgeNamespacedTool['parameters']
+}))
+const ARTIFACT_TOOLS: ResponsesBridgeNamespacedTool[] = [
+  {
+    namespace: namespaceFor(ARTIFACT_MCP_SERVER_NAME),
+    name: 'write_artifact_file',
+    description:
+      'Attach a generated image, chart, report, data export, or archive to the current Open Science response. The file must already exist before using a localPath source.',
+    parameters: z.toJSONSchema(z.object(writeArtifactFileToolSchema), {
+      target: 'draft-7'
+    }) as ResponsesBridgeNamespacedTool['parameters']
+  }
+]
+const SKILL_IMPORT_TOOLS: ResponsesBridgeNamespacedTool[] = [
+  {
+    namespace: namespaceFor(SKILL_IMPORT_MCP_SERVER_NAME),
+    name: REQUEST_SKILL_IMPORT_TOOL_NAME,
+    description: REQUEST_SKILL_IMPORT_TOOL_DESCRIPTION,
+    parameters: z.toJSONSchema(z.object(requestSkillImportToolSchema), {
+      target: 'draft-7'
+    }) as ResponsesBridgeNamespacedTool['parameters']
+  }
+]
+class BackendRoutePlanner {
+  private readonly providers: BackendRouteProviderPort
+  constructor({ providers }: { providers: BackendRouteProviderPort }) {
+    this.providers = providers
+  }
+  planBackend(input: BackendRoutePlanInput): BackendRoutePlan {
+    const configuredRoute = modelRouteFor(input.frameworkId, input.target)
+    const forcedCompatibility =
+      input.forceNativeResponsesCompatibility === true &&
+      input.frameworkId === 'codex' &&
+      configuredRoute === 'codex-responses'
+    if (forcedCompatibility && isCodexSubscriptionProvider(input.target.provider.type)) {
+      throw new Error(
+        'Artifact code reconstruction is unavailable with Codex subscription authentication.'
+      )
+    }
+    const modelRoute = forcedCompatibility ? 'codex-responses-compatibility' : configuredRoute
+    const resolvedEffort = modelEffort(input.effortIntent, input.target)
+    const sessionEffort = resolvedEffort === 'default' ? undefined : resolvedEffort
+    const supportedReasoningEfforts = input.target.reasoningEffortProfile.supported
+      ? [...new Set(input.target.reasoningEffortProfile.slots)]
+      : undefined
+    const routeCandidates = this.routeCandidates(
+      input.settings,
+      input.target,
+      input.frameworkId,
+      modelRoute
+    )
+    const retargetable = new Set(routeCandidates.map(({ providerId }) => providerId)).size >= 2
+    const activeProvider = input.settings.providers.find(({ id }) => id === input.target.providerId)
+    const catalogSource =
+      input.frameworkId === 'codex' && retargetable
+        ? routeCandidates
+        : input.frameworkId === 'claude-code'
+          ? []
+          : activeProvider
+            ? this.providers.resolveRuntimeModelCatalog(
+                activeProvider,
+                getAgentFramework(input.frameworkId)
+              )
+            : []
+    const providerModelCatalog = this.modelCatalog(
+      catalogSource,
+      input.frameworkId,
+      modelRoute,
+      input.effortIntent
+    )
+    const backendProviderId =
+      input.frameworkId === 'codex' && isCodexSubscriptionProvider(input.target.provider.type)
+        ? CODEX_ISOLATED_PROVIDER_ID
+        : input.target.providerId
+    const transport = this.transportPlan(
+      input.target,
+      input.frameworkId,
+      modelRoute,
+      routeCandidates,
+      retargetable,
+      input.effortIntent
+    )
+    const claudeModelConfig =
+      input.frameworkId === 'claude-code' && input.target.provider.type === 'custom'
+        ? this.claudeModelConfig(routeCandidates)
+        : undefined
+    return Object.freeze({
+      modelRoute,
+      backendProviderId,
+      ...(sessionEffort ? { sessionEffort } : {}),
+      ...(supportedReasoningEfforts ? { supportedReasoningEfforts } : {}),
+      providerModelCatalog: Object.freeze(providerModelCatalog),
+      transport,
+      ...(claudeModelConfig ? { claudeModelConfig } : {}),
+      ...(modelRoute === 'codex-bridge'
+        ? {
+            codexBridgeTools: Object.freeze([
+              ...NOTEBOOK_TOOLS,
+              ...ARTIFACT_TOOLS,
+              ...(input.conversationSkillImportEnabled ? SKILL_IMPORT_TOOLS : [])
+            ]),
+            reviewerBridgeTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS
+          }
+        : modelRoute === 'codex-responses-compatibility'
+          ? { reviewerBridgeTools: REVIEWER_BRIDGE_NAMESPACED_TOOLS }
+          : {})
+    })
+  }
+  projectModelChange(input: BackendModelChangePlanInput): AgentModelChangeTarget | undefined {
+    const model = input.target.effectiveModel ?? input.target.provider.model
+    if (!model) return undefined
+    const route = modelRouteFor(input.frameworkId, input.target)
+    const candidates = this.routeCandidates(input.settings, input.target, input.frameworkId, route)
+    const retargetable = new Set(candidates.map(({ providerId }) => providerId)).size >= 2
+    const hasClaudeTransport =
+      input.frameworkId === 'claude-code' && retargetable && candidates.includes(input.target)
+    const backendProviderId =
+      input.frameworkId === 'codex' && isCodexSubscriptionProvider(input.target.provider.type)
+        ? CODEX_ISOLATED_PROVIDER_ID
+        : input.target.providerId
+    return Object.freeze({
+      frameworkId: input.frameworkId,
+      backendId: `${input.frameworkId}:${backendProviderId}`,
+      route,
+      model,
+      sessionModel:
+        route === 'codex-bridge'
+          ? CODEX_BRIDGE_MODEL
+          : input.frameworkId === 'opencode' && retargetable
+            ? `${opencodeTransportProviderId(input.target.providerId, model)}/${model}`
+            : model,
+      sessionModelRequired:
+        input.frameworkId === 'codex' && isCodexSubscriptionProvider(input.target.provider.type),
+      supportsImageInput: input.target.provider.supportsImageInput === true,
+      reasoningEffort: modelEffort(input.effortIntent, input.target),
+      ...(hasClaudeTransport
+        ? { anthropicBridgeTargetId: claudeTargetId(input.target.providerId, model) }
+        : {}),
+      ...((input.frameworkId === 'opencode' || input.frameworkId === 'codex') && retargetable
+        ? {
+            providerTransportTargetId: transportTargetId(
+              input.frameworkId,
+              input.target.providerId,
+              model
+            )
+          }
+        : {}),
+      ...(input.target.provider.contextWindow
+        ? { contextWindow: input.target.provider.contextWindow }
+        : {}),
+      ...(route === 'codex-bridge' || route === 'codex-responses-compatibility'
+        ? {
+            bridge: Object.freeze({
+              model,
+              ...(input.target.provider.vendorId
+                ? { vendorId: input.target.provider.vendorId }
+                : {}),
+              ...(input.target.provider.reasoningEffortTransport
+                ? { reasoningEffortTransport: input.target.provider.reasoningEffortTransport }
+                : {})
+            })
+          }
+        : {})
+    })
+  }
+  private transportPlan(
+    active: ProviderRuntimeTarget,
+    frameworkId: AgentFrameworkId,
+    route: AgentModelRoute,
+    candidates: readonly ProviderRuntimeTarget[],
+    retargetable: boolean,
+    effortIntent: ReasoningEffort
+  ): BackendTransportPlan {
+    if (frameworkId === 'claude-code') {
+      if (!retargetable || active.provider.type !== 'custom')
+        return Object.freeze({ kind: 'direct' })
+      const targets = candidates.flatMap((candidate): AnthropicProviderBridgeTarget[] => {
+        const model = candidate.effectiveModel ?? candidate.provider.model
+        const baseUrl = normalizeAnthropicBaseUrl(candidate.provider.baseUrl ?? '')
+        return !model || !baseUrl
+          ? []
+          : [
+              Object.freeze({
+                id: claudeTargetId(candidate.providerId, model),
+                baseUrl,
+                ...(candidate.provider.key ? { key: candidate.provider.key } : {}),
+                model
+              })
+            ]
+      })
+      const model = active.effectiveModel ?? active.provider.model
+      if (!model) return Object.freeze({ kind: 'direct' })
+      const initialTargetId = claudeTargetId(active.providerId, model)
+      return targets.some(({ id }) => id === initialTargetId)
+        ? Object.freeze({
+            kind: 'claude-anthropic',
+            targets: Object.freeze(targets),
+            initialTargetId
+          })
+        : Object.freeze({ kind: 'direct' })
+    }
+    if (frameworkId === 'opencode') {
+      return retargetable
+        ? Object.freeze({
+            kind: route as 'opencode-anthropic' | 'opencode-openai',
+            targets: this.plannedTargets(candidates, frameworkId, effortIntent)
+          })
+        : Object.freeze({ kind: 'direct' })
+    }
+    if (route === 'codex-bridge' || route === 'codex-responses-compatibility') {
+      return Object.freeze({
+        kind: route === 'codex-bridge' ? 'codex-chat' : 'codex-responses-compatibility',
+        targets: retargetable
+          ? this.plannedTargets(candidates, frameworkId, effortIntent)
+          : Object.freeze([])
+      })
+    }
+    const model = active.effectiveModel ?? active.provider.model
+    return retargetable && model
+      ? Object.freeze({
+          kind: 'codex-native-responses',
+          targets: this.plannedTargets(candidates, frameworkId, effortIntent),
+          initialTargetId: transportTargetId(frameworkId, active.providerId, model)
+        })
+      : Object.freeze({ kind: 'direct' })
+  }
+  private plannedTargets(
+    candidates: readonly ProviderRuntimeTarget[],
+    frameworkId: AgentFrameworkId,
+    effortIntent: ReasoningEffort
+  ): readonly PlannedProviderTarget[] {
+    return Object.freeze(
+      candidates.flatMap((target): PlannedProviderTarget[] => {
+        const model = target.effectiveModel ?? target.provider.model
+        const effort = modelEffort(effortIntent, target)
+        return model
+          ? [
+              Object.freeze({
+                id: transportTargetId(frameworkId, target.providerId, model),
+                target,
+                ...(effort === 'default' ? {} : { reasoningEffort: effort }),
+                ...(target.reasoningEffortProfile.supported
+                  ? { reasoningEfforts: [...new Set(target.reasoningEffortProfile.slots)] }
+                  : {})
+              })
+            ]
+          : []
+      })
+    )
+  }
+
+  private routeCandidates(
+    settings: StoredSettings,
+    active: ProviderRuntimeTarget,
+    frameworkId: AgentFrameworkId,
+    route: AgentModelRoute
+  ): ProviderRuntimeTarget[] {
+    const seen = new Set<string>()
+    return this.enumerateCandidates(settings, active, frameworkId).filter((candidate) => {
+      const model = candidate.effectiveModel ?? candidate.provider.model
+      const endpoint =
+        frameworkId === 'claude-code'
+          ? normalizeAnthropicBaseUrl(candidate.provider.baseUrl ?? '')
+          : frameworkId === 'opencode'
+            ? route === 'opencode-openai'
+              ? openAiChatCompletionsUrl(candidate.provider)
+              : normalizeAnthropicBaseUrl(candidate.provider.baseUrl ?? '')
+            : route === 'codex-bridge'
+              ? openAiCompletionsBase(candidate.provider)
+              : normalizeResponsesBaseUrl(
+                  candidate.provider.openaiBaseUrl ?? candidate.provider.baseUrl
+                )
+      const id = model
+        ? frameworkId === 'claude-code'
+          ? claudeTargetId(candidate.providerId, model)
+          : transportTargetId(frameworkId, candidate.providerId, model)
+        : undefined
+      if (
+        !candidate.frameworkCompatible ||
+        (frameworkId === 'claude-code' &&
+          (candidate.provider.type !== 'custom' ||
+            !candidate.apiEndpoints.includes('anthropic') ||
+            !candidate.provider.key)) ||
+        (frameworkId === 'codex' && !candidate.modelBridgeSupported) ||
+        modelRouteFor(frameworkId, candidate) !== route ||
+        !model ||
+        !endpoint ||
+        !id ||
+        seen.has(id)
+      )
+        return false
+      seen.add(id)
+      return true
+    })
+  }
+
+  private enumerateCandidates(
+    settings: StoredSettings,
+    active: ProviderRuntimeTarget,
+    frameworkId: AgentFrameworkId
+  ): ProviderRuntimeTarget[] {
+    const framework = getAgentFramework(frameworkId)
+    const candidates = [active]
+    for (const provider of settings.providers) {
+      let configured: ProviderRuntimeTarget
+      try {
+        configured =
+          provider.id === active.providerId
+            ? active
+            : this.providers.resolveRuntimeTarget(
+                provider,
+                { kind: 'configured', requestedModel: provider.model },
+                framework
+              )
+      } catch {
+        // Stale sibling providers stay reconnect-only and cannot block the active generation.
+        continue
+      }
+      candidates.push(configured)
+      try {
+        candidates.push(...this.providers.resolveRuntimeModelCatalog(provider, framework))
+      } catch {
+        // A stale model catalog cannot discard the provider's configured target.
+      }
+    }
+    return candidates
+  }
+
+  private modelCatalog(
+    candidates: readonly ProviderRuntimeTarget[],
+    frameworkId: AgentFrameworkId,
+    route: AgentModelRoute,
+    effortIntent: ReasoningEffort
+  ): AgentModelCatalogEntry[] {
+    return candidates
+      .filter(
+        (candidate) =>
+          candidate.frameworkCompatible &&
+          (frameworkId !== 'codex' || candidate.modelBridgeSupported) &&
+          modelRouteFor(frameworkId, candidate) === route
+      )
+      .map((candidate) => {
+        const effort = modelEffort(effortIntent, candidate)
+        return Object.freeze({
+          provider: candidate.provider,
+          ...(effort === 'default' ? {} : { reasoningEffort: effort }),
+          ...(candidate.reasoningEffortProfile.supported
+            ? { reasoningEfforts: [...new Set(candidate.reasoningEffortProfile.slots)] }
+            : {})
+        })
+      })
+  }
+
+  private claudeModelConfig(
+    candidates: readonly ProviderRuntimeTarget[]
+  ): ClaudeRuntimeModelConfig | undefined {
+    const models = [
+      ...new Set(
+        candidates.map((candidate) => candidate.effectiveModel ?? candidate.provider.model)
+      )
+    ].filter((model): model is string => Boolean(model))
+    return models.length < 2
+      ? undefined
+      : Object.freeze({
+          availableModels: Object.freeze(models),
+          modelOverrides: Object.freeze(Object.fromEntries(models.map((model) => [model, model])))
+        })
+  }
+}
+
+export { BackendRoutePlanner }
+export type { BackendRouteProviderPort, BackendTransportPlan }

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -45,6 +45,7 @@ const settingsPaths = {
   providerAccounts: resolve(settingsRoot, 'provider-accounts.ts'),
   backendResolver: resolve(settingsRoot, 'backend-resolver.ts'),
   backendSelection: resolve(settingsRoot, 'backend-selection-owner.ts'),
+  backendRoutePlanner: resolve(settingsRoot, 'backend-route-planner.ts'),
   responsesBridge: resolve(settingsRoot, 'responses-bridge.ts'),
   service: resolve(settingsRoot, 'service.ts'),
   types: resolve(settingsRoot, 'types.ts')
@@ -259,7 +260,8 @@ describe('Settings backend ownership architecture', () => {
     expect(rawLineCount(readSource(settingsPaths.documentStore))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.computeGrantPort))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(600)
-    expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1357)
+    expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(1010)
+    expect(rawLineCount(readSource(settingsPaths.backendRoutePlanner))).toBeLessThanOrEqual(500)
     expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(600)
     expect(rawLineCount(readSource(settingsPaths.service))).toBeLessThanOrEqual(1003)
   })
@@ -482,6 +484,7 @@ describe('Settings backend ownership architecture', () => {
     expect(importersOf(settingsPaths.providerAccounts)).toEqual([
       'src/main/settings/agent-runtime-manager.ts',
       'src/main/settings/backend-resolver.ts',
+      'src/main/settings/backend-route-planner.ts',
       'src/main/settings/backend-selection-owner.ts',
       'src/main/settings/service.ts'
     ])
@@ -490,11 +493,15 @@ describe('Settings backend ownership architecture', () => {
       'src/main/artifacts/code-reconstruction.ts',
       'src/main/settings/service.ts'
     ])
+    expect(importersOf(settingsPaths.backendRoutePlanner)).toEqual([
+      'src/main/settings/backend-resolver.ts'
+    ])
     expect(importersOf(settingsPaths.responsesBridge)).toEqual([
       'src/main/acp/turn-skill-owner.ts',
       'src/main/agent-framework/types.ts',
       'src/main/reviewer/bridge-tools.ts',
       'src/main/settings/backend-resolver.ts',
+      'src/main/settings/backend-route-planner.ts',
       'src/main/settings/native-responses-compatibility.ts',
       'src/main/settings/validate.ts'
     ])
@@ -599,6 +606,7 @@ describe('Settings backend ownership architecture', () => {
     expect(manifest.modules.settings_backend_resolution.ownerPaths).toEqual([
       'src/main/settings/backend-resolver.ts',
       'src/main/settings/backend-selection-owner.ts',
+      'src/main/settings/backend-route-planner.ts',
       'src/main/settings/responses-bridge.ts',
       'src/main/settings/responses-protocol-types.ts',
       'src/main/settings/responses-request-adapter.ts',


### PR DESCRIPTION
## Problem

`AgentBackendResolver` owned both pure backend route decisions and live transport lifecycle. That mixed provider/model projection, candidate/catalog construction, and Codex tool declarations with bridge startup, retargeting, generation maps, cleanup, and leases, making the Settings backend seam harder to reason about and certify.

## Proposed change

- Add a pure `BackendRoutePlanner` with two operations: full backend planning and secret-free model-change projection.
- Move the Claude/OpenCode/Codex route matrix, target IDs, candidate filtering/deduplication, route-scoped catalogs/reasoning, and Codex Notebook/Artifact/Skill/Reviewer declarations behind that interface.
- Keep concrete bridge/proxy construction, startup, retargeting, cleanup, generation maps, and leases in `AgentBackendResolver` for the subsequent lifecycle cutover.
- Register the planner and its direct/architecture tests in the Settings backend-resolution impact owner.
- Reduce `backend-resolver.ts` from 1,357 to 1,010 raw lines; the new planner is 500 raw lines (500 target, 660 hard limit).

```mermaid
flowchart LR
  C["Settings and runtime consumers"] --> R["AgentBackendResolver"]
  R --> P["BackendRoutePlanner: pure route, candidates, catalog, tools, model projection"]
  R --> L["Live transports: bridges, proxies, generations, cleanup, leases"]
  P --> R
```

## Scope and non-goals

- Internal Settings-main-process refactor only; no public API, IPC, persisted data, or user-interface change.
- No change to Electron, Web, CLI, Task, Notebook, localRPC, or MCP capability behavior.
- No change to existing Specialist, Permission, Compute, or Reviewer asymmetry; Reviewer remains a leaf capability.
- No Issue #458 orchestration model or public orchestration interface is introduced.
- Live transport ownership remains in the resolver and is reserved for B3.

## Compatibility

- Preserves Claude subscription/custom routing and Anthropic bridge selection.
- Preserves OpenCode Anthropic/OpenAI routing, target identities, multi-provider behavior, and local-provider catalog semantics.
- Preserves Codex subscription, Chat bridge, native Responses, third-party compatibility, forced artifact-compatibility rejection, and tool namespace behavior.
- Preserves candidate ordering, stale-provider failure isolation, route-scoped deduplication, opaque third-party model identities, error priority, and secret-free model-change projection.
- Tests use repository-relative paths and do not add OS-specific path assumptions.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- Route matrix, candidates, catalogs, target IDs, tool declarations, error priority, and lifecycle integration -> `npm run test:module -- settings_backend_resolution` -> 27 files passed, 1 skipped; 399 tests passed, 3 skipped.
- Settings facade and Electron/Web/CLI/runtime consumers -> `npm run test:module -- settings_service_facade` -> 22 files and 557 tests passed.
- Impact routing integrity -> `npm test -- --run scripts/ci/validate-module-impact.test.ts scripts/ci/module-test-impact.test.ts` -> 2 files and 26 tests passed.
- Node and Web type safety -> `npm run typecheck` -> passed.
- Changed TypeScript lint -> targeted `eslint --no-cache` over the six changed TypeScript files -> passed.
- Formatting and whitespace -> targeted Prettier check plus `git diff --check` -> passed.
- Independent Standards review -> 0 findings.
- Independent Spec review -> 0 findings.

The final impact set includes both the owning Settings backend-resolution module and the Settings facade consumer slice. Per the approved workflow for this refactor, local validation is selective; exact-head CI is authoritative for the complete portable and platform suites. Uncovered local risk is limited to full cross-platform execution, which CI will exercise. No administrative CI/AI exception is requested.

## Review focus

- Verify that the planner is declarative and side-effect free, with only `planBackend` and `projectModelChange` public.
- Verify exact routing and error-priority parity for Claude, OpenCode, Codex subscription/Chat/native Responses, and third-party compatibility.
- Verify live bridge/proxy state, start/close/retarget, generation, cleanup, and lease ownership did not move out of the resolver.
- Verify module-impact routing selects direct planner, architecture, resolver integration, and downstream facade coverage.
