### PR TITLE
test(project-files): honor workflow hook timeout

### DIFF
--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -44,12 +44,12 @@ describe('ManagedFileIndexRepository', () => {
     client = createProjectDbClient(storageRoot)
     await ensureProjectSchema(client)
     repository = new ManagedFileIndexRepository(() => Promise.resolve(client), storageRoot)
-  }, 30_000)
+  })
 
   afterEach(async () => {
     await client.$disconnect()
     await rm(storageRoot, { recursive: true, force: true })
-  }, 30_000)
+  })
 
   it('indexes uploads and all finalized managed artifacts without requiring a message link', async () => {
     const uploadPath = join(storageRoot, 'uploads', 'default-project', SESSION_ID, 'input.csv')

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { coverageThresholdsEnabled, VITEST_EXCLUDE_PATTERNS } from './vitest.config'
+import vitestConfig, { coverageThresholdsEnabled, VITEST_EXCLUDE_PATTERNS } from './vitest.config'
 
 describe('Vitest discovery boundaries', () => {
   it.each(['**/.pnpm-store/**', '**/tmp/**', '**/.worktrees/**', '**/.worktree/**'])(
@@ -15,4 +15,8 @@ it('defers coverage thresholds only for explicit shard collection', () => {
   expect(coverageThresholdsEnabled({})).toBe(true)
   expect(coverageThresholdsEnabled({ VITEST_DEFER_COVERAGE_THRESHOLDS: '1' })).toBe(false)
   expect(coverageThresholdsEnabled({ VITEST_DEFER_COVERAGE_THRESHOLDS: '0' })).toBe(true)
+})
+
+it('keeps a safe default timeout for schema-backed hooks', () => {
+  expect(vitestConfig.test?.hookTimeout).toBe(30_000)
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -59,6 +59,9 @@ export default defineConfig({
     // shared CI runner, so a fast fully-mocked test can still be CPU-starved past 5s and time out
     // spuriously. 15s absorbs that contention without masking a genuine hang (real work is far slower).
     testTimeout: 15000,
+    // Schema-backed hooks can exceed Vitest's 10s default on loaded runners. Keep a safe repository
+    // default while allowing slower platform workflows to raise it explicitly from the CLI.
+    hookTimeout: 30000,
     coverage: {
       provider: 'v8',
       // text for the CI log, lcov for upload/tooling, html for local inspection.


### PR DESCRIPTION
## Problem

The Windows full-test workflow passes `--hookTimeout=60000`, but `src/main/project-files/repository.test.ts` hard-coded 30-second timeouts for its setup and cleanup hooks. On the referenced hosted runner, Prisma schema setup spiked to 30.787 seconds and was terminated at the file-level override before the inactive-branch assertion ran.

Failing run: https://github.com/aipoch/open-science/actions/runs/31314437059/job/93247289164

## Proposed change

- Remove the repository test's per-hook timeout overrides so workflow CLI policy can take precedence.
- Set a 30-second repository-wide default hook timeout in `vitest.config.ts`, preserving the previous safety margin for ordinary and macOS suites that do not pass a CLI override.
- Add a config regression assertion for the 30-second default.

This yields a 30-second default and PR Gate timeout, while Windows full-test can raise the effective timeout to 60 seconds.

## Scope and non-goals

- Test infrastructure only; production behavior, schemas, workflows, and user interactions are unchanged.
- The inactive Message Branch coverage and repository behavior are unchanged.
- This does not address unrelated local Windows permission, subprocess, or timing failures in the full portable suite.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Default timeout contract plus project-files repository under Windows workflow settings -> `npm test -- vitest.config.test.ts src/main/project-files/repository.test.ts --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000` -> passed (44 tests; 1 skipped).
- CLI timeout precedence -> the target test with `--hookTimeout=1` deterministically timed out in its setup and cleanup hooks, proving the CLI value overrides the 30-second config default.
- Main and renderer types -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings outside this change.
- Full portable suite -> `npm test` -> not fully passed on this host: 887 files / 12,730 tests passed; 9 files / 35 tests failed due unavailable bash subprocesses, Windows symlink/ACL permissions, and unrelated load-sensitive tests. The changed config test and project-files suite were not among the failures.

Because `vitest.config.ts` is a global validation input, the full fallback was used. E2E and packaging were not run locally because this change affects only Vitest timeout ownership; PR Gate remains authoritative for platform lanes.

Uncovered risk: the exact hosted Windows full-test shard is not directly dispatchable as a focused dry-run; PR Gate's Windows lanes provide the available hosted Windows evidence.

## Review focus

Confirm that the repository-level 30-second default preserves ordinary/macOS behavior while the removed file-level override lets Windows full-test's 60-second CLI policy govern slow Prisma schema setup.
