### PR TITLE
test(settings): certify backend ownership boundaries

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -220,7 +220,10 @@
         "src/main/settings/document-store.ts",
         "src/main/settings/compute-grant-port.ts"
       ],
-      "interfacePaths": ["src/main/settings/repository.ts"],
+      "interfacePaths": [
+        "src/main/settings/repository.ts",
+        "src/main/settings/compute-grant-port.ts"
+      ],
       "consumerModules": [
         "settings_provider_accounts",
         "settings_service_facade",
@@ -380,6 +383,9 @@
           "src/main/application-command-composition.test.ts",
           "src/main/application-command-wiring.test.ts",
           "src/shared/renderer-contract-catalog.test.ts",
+          "src/shared/renderer-surface-inventory.test.ts",
+          "src/shared/renderer-surface-matrix.test.ts",
+          "src/shared/web-rpc-contract.test.ts",
           "src/preload/electron-renderer-contract-adapter.test.ts",
           "src/renderer/web/api-installer.test.ts"
         ],
@@ -388,7 +394,10 @@
           "src/main/acp/backend-generation-owner.test.ts",
           "src/main/acp/runtime-provider-session-composition.test.ts",
           "src/main/acp/task-agent-port.test.ts",
+          "src/main/notebook/local-rpc-notebook-adapter.test.ts",
           "src/main/notebook/local-rpc-server.mcpcall.test.ts",
+          "src/main/notebook/mcp-server.test.ts",
+          "src/main/web-service/http-server.test.ts",
           "src/renderer/src/stores/settings-runtime-slice.test.ts",
           "src/renderer/src/stores/settings-store.test.ts"
         ]

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -113,6 +113,21 @@ describe('module test impact commands', () => {
       ]
     ],
     [
+      'src/main/settings/compute-grant-port.ts',
+      [
+        'artifact_provenance',
+        'compute_service',
+        'reviewer_orchestrator',
+        'session_persistence',
+        'settings_backend_resolution',
+        'settings_provider_accounts',
+        'settings_repository',
+        'settings_service_facade',
+        'workspace_page',
+        'workspace_runtime'
+      ]
+    ],
+    [
       'src/main/settings/provider-accounts.ts',
       [
         'artifact_provenance',
@@ -186,7 +201,8 @@ describe('module test impact commands', () => {
     expect(plan.mode).toBe('selective')
     expect([...plan.modules].sort()).toEqual(expectedModules)
     const rootModule =
-      path === 'src/main/settings/repository.ts'
+      path === 'src/main/settings/repository.ts' ||
+      path === 'src/main/settings/compute-grant-port.ts'
         ? 'settings_repository'
         : path === 'src/main/settings/provider-accounts.ts'
           ? 'settings_provider_accounts'
@@ -208,6 +224,17 @@ describe('module test impact commands', () => {
               `${rootModule} -> settings_service_facade -> workspace_runtime`
             ]
       )
+    )
+    expect(plan.testFiles).toEqual(
+      expect.arrayContaining([
+        'src/shared/renderer-surface-inventory.test.ts',
+        'src/shared/renderer-surface-matrix.test.ts',
+        'src/shared/web-rpc-contract.test.ts',
+        'src/main/notebook/local-rpc-notebook-adapter.test.ts',
+        'src/main/notebook/local-rpc-server.mcpcall.test.ts',
+        'src/main/notebook/mcp-server.test.ts',
+        'src/main/web-service/http-server.test.ts'
+      ])
     )
   })
 

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -144,6 +144,24 @@ describe('notebook MCP server config', () => {
     expect(toolNames).not.toContain('notebook_run_cell')
   })
 
+  it('locks the complete Notebook MCP capability inventory', () => {
+    expect(NOTEBOOK_RPC_TOOLS.map((tool) => tool.name)).toEqual([
+      'ask_user_question',
+      'notebook_execute',
+      'repl_execute',
+      'bash_execute',
+      'notebook_state',
+      'list_notebook_runtimes',
+      'notebook_bind_runtime',
+      'notebook_switch_runtime',
+      'notebook_restart',
+      'notebook_shutdown',
+      'inspect_packages',
+      'manage_packages',
+      'manage_environments'
+    ])
+  })
+
   it('exposes manage_environments and explains named environments are separate namespaces', () => {
     const toolNames = NOTEBOOK_RPC_TOOLS.map((tool) => tool.name)
     expect(toolNames).toContain('manage_environments')

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -6,6 +6,7 @@ import {
   createSourceFile,
   forEachChild,
   getModifiers,
+  isArrayLiteralExpression,
   isCallExpression,
   isClassDeclaration,
   isEnumDeclaration,
@@ -43,13 +44,19 @@ const settingsPaths = {
   documentStore: resolve(settingsRoot, 'document-store.ts'),
   computeGrantPort: resolve(settingsRoot, 'compute-grant-port.ts'),
   providerAccounts: resolve(settingsRoot, 'provider-accounts.ts'),
+  providerAuthLifecycle: resolve(settingsRoot, 'provider-auth-lifecycle.ts'),
+  providerRuntimeProjection: resolve(settingsRoot, 'provider-runtime-projection.ts'),
   backendResolver: resolve(settingsRoot, 'backend-resolver.ts'),
   backendSelection: resolve(settingsRoot, 'backend-selection-owner.ts'),
   backendRoutePlanner: resolve(settingsRoot, 'backend-route-planner.ts'),
   providerTransportOwner: resolve(settingsRoot, 'provider-transport-owner.ts'),
   responsesBridge: resolve(settingsRoot, 'responses-bridge.ts'),
+  responsesProtocolTypes: resolve(settingsRoot, 'responses-protocol-types.ts'),
+  responsesRequestAdapter: resolve(settingsRoot, 'responses-request-adapter.ts'),
+  responsesResponseAdapter: resolve(settingsRoot, 'responses-response-adapter.ts'),
   service: resolve(settingsRoot, 'service.ts'),
-  types: resolve(settingsRoot, 'types.ts')
+  types: resolve(settingsRoot, 'types.ts'),
+  notebookLocalRpcServer: resolve(projectRoot, 'src/main/notebook/local-rpc-server.ts')
 } as const
 const sourceCache = new Map<string, string>()
 const readSource = (path: string): string => {
@@ -237,6 +244,22 @@ const typePropertyNames = (path: string, typeName: string): string[] => {
     .sort()
 }
 
+const stringSetValues = (path: string, variableName: string): string[] => {
+  const declaration = sourceFileFor(path)
+    .statements.filter(isVariableStatement)
+    .flatMap((statement) => [...statement.declarationList.declarations])
+    .find((candidate) => isIdentifier(candidate.name) && candidate.name.text === variableName)
+  const initializer = declaration?.initializer
+  const [values] = initializer && isNewExpression(initializer) ? (initializer.arguments ?? []) : []
+  if (!values || !isArrayLiteralExpression(values)) {
+    throw new Error(`${variableName} is not initialized from an array`)
+  }
+  return values.elements.map((element) => {
+    if (!isStringLiteralLike(element)) throw new Error(`${variableName} contains a non-string`)
+    return element.text
+  })
+}
+
 type ModuleImpactManifest = {
   modules: Record<
     string,
@@ -254,17 +277,28 @@ type ModuleImpactManifest = {
 const productionSourcePaths = productionSources()
 
 describe('Settings backend ownership architecture', () => {
-  it('holds the current facade ceilings until their owner cutovers', () => {
-    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(660)
+  it('locks the final facade ceilings and every internal owner below the hard limit', () => {
+    // D3 explicitly accepted 646 as the non-growing Repository facade baseline under the 660 gate.
+    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(646)
     expect(rawLineCount(readSource(settingsPaths.recordCodec))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.documentCodec))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.documentStore))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.computeGrantPort))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.providerAccounts))).toBeLessThanOrEqual(600)
+    expect(rawLineCount(readSource(settingsPaths.providerAuthLifecycle))).toBeLessThanOrEqual(660)
+    expect(rawLineCount(readSource(settingsPaths.providerRuntimeProjection))).toBeLessThanOrEqual(
+      660
+    )
     expect(rawLineCount(readSource(settingsPaths.backendResolver))).toBeLessThanOrEqual(600)
+    expect(rawLineCount(readSource(settingsPaths.backendSelection))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.backendRoutePlanner))).toBeLessThanOrEqual(500)
     expect(rawLineCount(readSource(settingsPaths.providerTransportOwner))).toBeLessThanOrEqual(600)
     expect(rawLineCount(readSource(settingsPaths.responsesBridge))).toBeLessThanOrEqual(600)
+    expect(rawLineCount(readSource(settingsPaths.responsesProtocolTypes))).toBeLessThanOrEqual(660)
+    expect(rawLineCount(readSource(settingsPaths.responsesRequestAdapter))).toBeLessThanOrEqual(660)
+    expect(rawLineCount(readSource(settingsPaths.responsesResponseAdapter))).toBeLessThanOrEqual(
+      660
+    )
     expect(rawLineCount(readSource(settingsPaths.service))).toBeLessThanOrEqual(1003)
   })
 
@@ -531,6 +565,51 @@ describe('Settings backend ownership architecture', () => {
     ])
   })
 
+  it('keeps Issue #458 coordination code behind application-owned ports', () => {
+    const concreteSettingsOwners = new Set(
+      [
+        settingsPaths.repository,
+        settingsPaths.backendResolver,
+        settingsPaths.providerTransportOwner
+      ].map(modulePath)
+    )
+    const coordinationSources = productionSourcePaths.filter((sourcePath) =>
+      /(?:orchestrat|coordinat|delegat)/i.test(portableProjectPath(sourcePath))
+    )
+
+    expect(coordinationSources.length).toBeGreaterThan(0)
+    expect(
+      coordinationSources
+        .filter((sourcePath) =>
+          importSpecifiersFrom(sourcePath).some((specifier) => {
+            const target = resolveImportTarget(sourcePath, specifier)
+            return target ? concreteSettingsOwners.has(target) : false
+          })
+        )
+        .map(portableProjectPath)
+    ).toEqual([])
+  })
+
+  it('locks the complete Notebook local-RPC capability inventory', () => {
+    expect(stringSetValues(settingsPaths.notebookLocalRpcServer, 'ARTIFACT_RPC_METHODS')).toEqual([
+      'artifactCreateVersion',
+      'artifactReplayVersion'
+    ])
+    expect(stringSetValues(settingsPaths.notebookLocalRpcServer, 'CONTROL_RPC_METHODS')).toEqual([
+      'mcpCall',
+      'computeCall',
+      'agentsCall',
+      'skillsCall',
+      'requestUserInput'
+    ])
+    expect(
+      stringSetValues(settingsPaths.notebookLocalRpcServer, 'SKILL_IMPORT_RPC_METHODS')
+    ).toEqual(['skillImport'])
+    expect(stringSetValues(settingsPaths.notebookLocalRpcServer, 'PLAN_RPC_METHODS')).toEqual([
+      'planCall'
+    ])
+  })
+
   it('locks the durable Settings shape and secret-free explicit target seam', () => {
     expect(typePropertyNames(settingsPaths.types, 'StoredSettings')).toEqual([
       'activeModel',
@@ -617,6 +696,18 @@ describe('Settings backend ownership architecture', () => {
       'src/main/settings/document-store.ts',
       'src/main/settings/compute-grant-port.ts'
     ])
+    expect(manifest.modules.settings_repository.interfacePaths).toEqual([
+      'src/main/settings/repository.ts',
+      'src/main/settings/compute-grant-port.ts'
+    ])
+    expect(manifest.modules.settings_provider_accounts.ownerPaths).toEqual([
+      'src/main/settings/provider-accounts.ts',
+      'src/main/settings/provider-auth-lifecycle.ts',
+      'src/main/settings/provider-runtime-projection.ts'
+    ])
+    expect(manifest.modules.settings_provider_accounts.interfacePaths).toEqual([
+      'src/main/settings/provider-accounts.ts'
+    ])
     expect(manifest.modules.settings_backend_resolution.ownerPaths).toEqual([
       'src/main/settings/backend-resolver.ts',
       'src/main/settings/backend-selection-owner.ts',
@@ -626,6 +717,13 @@ describe('Settings backend ownership architecture', () => {
       'src/main/settings/responses-protocol-types.ts',
       'src/main/settings/responses-request-adapter.ts',
       'src/main/settings/responses-response-adapter.ts'
+    ])
+    expect(manifest.modules.settings_backend_resolution.interfacePaths).toEqual([
+      'src/main/settings/backend-resolver.ts',
+      'src/main/settings/responses-bridge.ts'
+    ])
+    expect(manifest.modules.settings_service_facade.ownerPaths).toEqual([
+      'src/main/settings/service.ts'
     ])
     expect(manifest.modules.settings_service_facade.interfacePaths).toEqual([
       'src/main/settings/service.ts',
@@ -655,15 +753,34 @@ describe('Settings backend ownership architecture', () => {
         'src/main/settings/runtime-application-commands.test.ts',
         'src/main/settings/integration-application-commands.test.ts',
         'src/main/settings/ipc.test.ts',
+        'src/main/settings/capabilities.test.ts',
         'src/shared/renderer-contract-catalog.test.ts',
+        'src/shared/renderer-surface-inventory.test.ts',
+        'src/shared/renderer-surface-matrix.test.ts',
+        'src/shared/web-rpc-contract.test.ts',
         'src/preload/electron-renderer-contract-adapter.test.ts',
         'src/renderer/web/api-installer.test.ts'
+      ])
+    )
+    expect(manifest.modules.settings_service_facade.testFiles.consumer).toEqual(
+      expect.arrayContaining([
+        'packages/open-science/cli.test.ts',
+        'src/main/acp/backend-generation-owner.test.ts',
+        'src/main/acp/runtime-provider-session-composition.test.ts',
+        'src/main/acp/task-agent-port.test.ts',
+        'src/main/notebook/local-rpc-notebook-adapter.test.ts',
+        'src/main/notebook/local-rpc-server.mcpcall.test.ts',
+        'src/main/notebook/mcp-server.test.ts',
+        'src/main/web-service/http-server.test.ts',
+        'src/renderer/src/stores/settings-runtime-slice.test.ts',
+        'src/renderer/src/stores/settings-store.test.ts'
       ])
     )
     expect(manifest.modules.settings_backend_resolution.testFiles.consumer).toEqual(
       expect.arrayContaining([
         'packages/open-science/cli.test.ts',
         'src/main/acp/artifact-code-reconstruction-runner.test.ts',
+        'src/main/acp/backend-generation-owner.test.ts',
         'src/main/acp/task-agent-port.test.ts',
         'src/main/acp/turn-skill-owner.test.ts',
         'src/main/artifacts/code-reconstruction.test.ts',
@@ -671,5 +788,13 @@ describe('Settings backend ownership architecture', () => {
         'src/main/reviewer/mcp-server.test.ts'
       ])
     )
+    expect(
+      [
+        'settings_repository',
+        'settings_provider_accounts',
+        'settings_backend_resolution',
+        'settings_service_facade'
+      ].map((moduleName) => manifest.modules[moduleName].fallbackCapability)
+    ).toEqual(['main_runtime', 'main_runtime', 'main_runtime', 'main_runtime'])
   })
 })

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1479,7 +1479,12 @@ describe('startWebHttpServer', () => {
     for (const path of [
       '/api/v1/permissions/permission-1/approve',
       '/api/v1/specialists',
-      '/api/v1/compute'
+      '/api/v1/compute',
+      '/api/v1/settings',
+      '/api/v1/providers',
+      '/api/v1/runtime',
+      '/api/v1/notebook',
+      '/api/v1/reviewer'
     ]) {
       const absent = await fetch(`${base}${path}`, { method: 'POST', headers })
       expect(absent.status).toBe(404)


### PR DESCRIPTION
## Problem

The Settings backend refactor had completed every production owner cutover, but final certification still lacked a truthful Compute interface edge and complete selective evidence for Electron, Web, CLI, Task, Notebook local-RPC/MCP, and the existing Specialist/Permission/Compute capability asymmetry. The final line, importer, data, secret, and future orchestration boundaries also needed one executable gate.

## Proposed change

- Lock the accepted final facade ceilings, including the explicitly approved D3 `repository.ts` non-growth baseline of 646, every internal owner hard limit, and the 1,003-line `SettingsService` baseline.
- Lock exact Repository, Provider, Backend, Responses, and Service owner/interface paths, importers, exports, durable Settings shape, and secret-free explicit backend targets.
- Mark `compute-grant-port.ts` as a real Settings Repository interface so changes expand through `compute_service`.
- Route Settings changes through complete renderer surface inventory/matrix, Web RPC, Task HTTP, Notebook local-RPC, and Notebook MCP certification suites.
- Pin the complete Notebook MCP tool inventory, Task API management-surface exclusions, and Issue #458 coordination code behind application-owned ports.

## Scope and non-goals

- Test and CI metadata only; production raw change is zero.
- No production refactor, public export, application command, IPC channel, Settings schema, persisted relation, UI flow, or user-facing text change.
- No new Specialist, Permission, Compute, provider, runtime, Task, Notebook, local-RPC, MCP, or orchestration capability.
- `types.ts` remains fail-closed through the existing unknown-path full fallback rather than being assigned an incomplete selective dependency graph.

## Compatibility

- Preserves current Electron/local Web/remote Web/CLI/Task/Notebook/local-RPC/MCP behavior and inventory.
- Preserves Specialist as Electron-only, Permission human authority on Electron/Web but not Task, full local Compute with remote Web download/reveal rejection, and current CLI/local-RPC subsets.
- Preserves Settings JSON shape/version, provider credential masking, executable/path behavior, and Windows/macOS/Linux portable fixtures.
- Preserves Issue #458 as a future application-owned orchestration layer: coordination code cannot import concrete Settings repository, backend resolver, or transport owners.

## Acceptance criteria and validation

- Final production gates: Repository <=646 accepted D3 baseline; Provider/Backend/Responses facades <=600; internal owners <=660; SettingsService <=1,003; no production file changed.
- Focused architecture, impact, renderer surface, Web RPC, Notebook adapter, and Notebook MCP validation: 8 files, 123 tests passed.
- Final architecture/impact subset after the Compute interface and local-RPC inventory updates: 2 files, 29 tests passed.
- Node/Web typecheck, changed-file ESLint, Prettier, and diff whitespace checks passed.
- The focused Task HTTP test reached only the known local sandbox `listen EPERM` boundary; exact-head CI is authoritative for its portable execution.
- Independent final-head Standards review: 0 findings. Independent final-head Spec review: 0 findings.
- Merge only after exact-head PR Gate, CI Integrity, CodeQL, platform checks, and published AI `Verdict: mergeable` are green.

## Review focus

- Verify every manifest interface/consumer/test edge represents a real dependency or compatibility surface.
- Verify the 646 Repository gate records the already approved D3 exception without relaxing the global 660 hard limit or allowing growth.
- Verify the new capability assertions freeze public inventory rather than private implementation details.
- Verify coordination, Task, Notebook, and renderer assertions prevent capability leakage without adding any new surface.
