### PR TITLE
fix(acp): keep unsupported binary files out of provider prompts

### DIFF
--- a/src/main/acp/attachment-content.test.ts
+++ b/src/main/acp/attachment-content.test.ts
@@ -4,6 +4,7 @@ import {
   MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
   buildDatasetAttachmentNotice,
   buildDeferredMediaNotice,
+  buildLocalFileAttachmentNotice,
   buildOversizedAttachmentNotice,
   formatBytes,
   imageAttachmentMimeType,
@@ -173,6 +174,18 @@ describe('binary dataset attachments', () => {
     expect(notice).toContain('sample')
     expect(notice).toContain('notebook')
     expect(notice).toContain('Do not load the whole file')
+  })
+})
+
+describe('generic binary attachments', () => {
+  it('keeps unsupported provider file formats available through local tooling', () => {
+    const notice = buildLocalFileAttachmentNotice({ name: 'report.docx', size: 24_576 })
+
+    expect(notice).toContain('report.docx')
+    expect(notice).toContain('24.0 KB')
+    expect(notice).toContain('available on disk')
+    expect(notice).toContain('appropriate local tooling')
+    expect(notice).toContain('do not send the binary file directly to the model')
   })
 })
 

--- a/src/main/acp/attachment-content.ts
+++ b/src/main/acp/attachment-content.ts
@@ -216,6 +216,15 @@ export const buildDatasetAttachmentNotice = (input: { name: string; size: number
     'Do not load the whole file into the conversation. Inspect its schema and a small sample first, then use the notebook or a streaming/query tool to compute over the full dataset.]'
   ].join('\n')
 
+// Provider file inputs accept only a narrow media set, and ACP agents translate resource links
+// differently. Keep every remaining binary format provider-neutral while still giving the agent a
+// trusted local path it can inspect with an appropriate tool.
+export const buildLocalFileAttachmentNotice = (input: { name: string; size: number }): string =>
+  [
+    `[Attached file "${input.name}" (${formatBytes(input.size)}) is available on disk via the local file reference below.`,
+    'Use appropriate local tooling to inspect only the content needed for this task; do not send the binary file directly to the model.]'
+  ].join('\n')
+
 export const buildDeferredMediaNotice = (input: {
   name: string
   size: number

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -29,6 +29,7 @@ import {
   MAX_EMBEDDED_TEXT_UPLOAD_BYTES,
   buildDatasetAttachmentNotice,
   buildDeferredMediaNotice,
+  buildLocalFileAttachmentNotice,
   buildOversizedAttachmentNotice,
   isDatasetAttachment,
   isTabularAttachment,
@@ -346,10 +347,27 @@ class AcpPromptContentOwner {
       ].join('\n')
     })
 
+    const normalizedName = name.toLowerCase()
+    const normalizedMimeType = mimeEssence(mimeType)
+    const isArchive =
+      normalizedName.endsWith('.zip') ||
+      normalizedName.endsWith('.skill') ||
+      normalizedMimeType === 'application/zip' ||
+      normalizedMimeType === 'application/x-zip-compressed'
+    const imageMimeType = imageAttachmentMimeType(name, mimeType)
+
     // A replayed raster may still be required by the selected conversational turn. Every other
-    // historical file is a descriptor only: do not re-import archives or re-embed text/PDF bytes.
-    if (isHistoryUpload && !imageAttachmentMimeType(name, mimeType)) {
-      return [{ type: 'resource_link', uri, name, title: name, mimeType, size }]
+    // historical file remains a descriptor: formats that downstream agents can safely represent
+    // keep their resource link, while binary formats become provider-neutral local-file text.
+    if (isHistoryUpload && !imageMimeType) {
+      if (this.isPdfFile(name, mimeType) || isTextLikeAttachment(name, mimeType)) {
+        return [{ type: 'resource_link', uri, name, title: name, mimeType, size }]
+      }
+      if (isArchive) return [attachmentTextReference('attached_local_archive', false)]
+      const notice = isDatasetAttachment(name, mimeType)
+        ? buildDatasetAttachmentNotice({ name, size })
+        : buildLocalFileAttachmentNotice({ name, size })
+      return [localFileTextReference(notice)]
     }
 
     if (
@@ -368,18 +386,10 @@ class AcpPromptContentOwner {
       }
     }
 
-    const normalizedName = name.toLowerCase()
-    const normalizedMimeType = mimeEssence(mimeType)
-    if (
-      normalizedName.endsWith('.zip') ||
-      normalizedName.endsWith('.skill') ||
-      normalizedMimeType === 'application/zip' ||
-      normalizedMimeType === 'application/x-zip-compressed'
-    ) {
+    if (isArchive) {
       return [attachmentTextReference('attached_local_archive', false)]
     }
 
-    const imageMimeType = imageAttachmentMimeType(name, mimeType)
     if (imageMimeType) {
       if (size > MAX_AUTO_PROCESS_IMAGE_BYTES) {
         return [
@@ -445,7 +455,7 @@ class AcpPromptContentOwner {
       return [localFileTextReference(buildDatasetAttachmentNotice({ name, size }))]
     }
 
-    return [{ type: 'resource_link', uri, name, title: name, mimeType, size }]
+    return [localFileTextReference(buildLocalFileAttachmentNotice({ name, size }))]
   }
 
   private async admitTextResource(

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4467,6 +4467,85 @@ describe('ACP runtime session management', () => {
     expect(JSON.stringify(prompt)).not.toContain('SENTINEL_PAST_PREVIEW_WINDOW')
   })
 
+  it('does not send DOCX attachments as unsupported provider file parts', async () => {
+    const root = await createTemporaryRoot()
+    const uploadRepository = new UploadRepository(root)
+    const [document, historyPending] = await stageUploadFixtures(uploadRepository, {
+      files: [
+        {
+          name: 'report.docx',
+          mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          content: Buffer.from('document-bytes').toString('base64')
+        },
+        {
+          name: 'history-report.docx',
+          mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          content: Buffer.from('history-document-bytes').toString('base64')
+        }
+      ]
+    })
+    const [historyDocument] = await uploadRepository.finalizePendingSessionUploads(
+      'source-session',
+      [historyPending]
+    )
+    const process = new FakeAgentProcess()
+    const receivedPrompts: ContentBlock[][] = []
+    startFakeAgent(process, ['remote-session-1'], {
+      onPrompt: ({ prompt }) => {
+        receivedPrompts.push(prompt)
+        const unsupportedDocument = prompt.find(
+          (block) =>
+            block.type === 'resource_link' &&
+            block.mimeType ===
+              'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        )
+        if (unsupportedDocument) {
+          throw new Error(
+            "'file part media typeapplication/vnd.openxmlformats-officedocument.wordprocessingml.document' functionality not supported"
+          )
+        }
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      uploads: { repository: uploadRepository }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+
+    await expect(
+      runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'summarize this document',
+        attachments: [document]
+      })
+    ).resolves.toMatchObject({ stopReason: 'end_turn' })
+
+    await expect(
+      runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'summarize the earlier document',
+        historyAttachments: [historyDocument]
+      })
+    ).resolves.toMatchObject({ stopReason: 'end_turn' })
+
+    expect(receivedPrompts).toHaveLength(2)
+    for (const prompt of receivedPrompts) {
+      expect(prompt.some((block) => block.type === 'resource_link')).toBe(false)
+      const descriptor = prompt.find(
+        (block) => block.type === 'text' && block.text.includes('<attached_local_file>')
+      )
+      expect(descriptor).toMatchObject({ type: 'text' })
+      if (descriptor?.type !== 'text') throw new Error('Expected a local file text descriptor.')
+      expect(descriptor.text).toContain(
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+      )
+      expect(descriptor.text).toContain('do not send the binary file directly to the model')
+    }
+  })
+
   it('adopts a fresh agent session under the same app id on a context reset', async () => {
     const root = await createTemporaryRoot()
     const connectorCall = vi.fn(async () => ({ ok: true }))
@@ -5749,14 +5828,14 @@ describe('ACP runtime session management', () => {
       data: createPngBytes('runtime referenced image').toString('base64'),
       uri: expect.stringContaining('chart.png')
     })
-    // Referenced binary artifact -> resource link.
-    expect(receivedPrompts[0][3]).toMatchObject({
-      type: 'resource_link',
-      name: 'data.bin',
-      title: 'data.bin',
-      mimeType: 'application/octet-stream',
-      uri: expect.stringContaining('data.bin')
-    })
+    // Referenced binary artifact -> provider-neutral local file descriptor.
+    expect(receivedPrompts[0][3]).toMatchObject({ type: 'text' })
+    const binaryDescriptor = receivedPrompts[0][3]
+    if (binaryDescriptor.type !== 'text') throw new Error('Expected a local file text descriptor.')
+    expect(binaryDescriptor.text).toContain('data.bin')
+    expect(binaryDescriptor.text).toContain('application/octet-stream')
+    expect(binaryDescriptor.text).toContain('<attached_local_file>')
+    expect(binaryDescriptor.text).toContain('do not send the binary file directly to the model')
     // Artifact-backed Skill package -> provider-safe ordinary archive reference, never the
     // current-session import wrapper.
     expect(receivedPrompts[0][4]).toMatchObject({


### PR DESCRIPTION
## Problem

Attaching a DOCX or another unclassified binary currently emits an ACP `resource_link`. OpenCode converts file-backed resource links into provider file parts, and the provider rejects the DOCX MIME before the turn starts:

`application/vnd.openxmlformats-officedocument.wordprocessingml.document functionality not supported`

The supplied field log confirms the failing framework is OpenCode. It also shows that after the first rejected DOCX turn, later text-only prompts on the same provider session repeat the error, while a newly created session succeeds.

## Proposed change

- Represent remaining binary attachments as provider-neutral text descriptors containing the trusted local file URI, name, MIME, and size.
- Apply the same contract to current uploads, replayed history attachments, and referenced artifacts.
- Preserve the existing rich paths for images, PDFs, text, datasets, Skill packages, and ordinary archives.
- Add runtime coverage for both current and historical DOCX attachments and update the generic binary artifact contract.

## Scope / non-goals

- DOCX contents are not eagerly parsed or uploaded as provider file parts; agents inspect the local file on demand with appropriate tooling.
- The implementation is framework-neutral and does not branch on OpenCode.
- Provider sessions already poisoned by an older build are not mutated in place. Creating a new session or resetting context adopts a fresh provider session; this change prevents new sessions from being poisoned.

## Acceptance criteria

- A current DOCX attachment reaches ACP as an `attached_local_file` text descriptor, not a `resource_link`.
- A replayed DOCX attachment follows the same provider-safe path.
- Generic binary artifact references use the same contract.
- Existing image, PDF, text, dataset, and archive behavior remains covered.

## Review focus

- Provider-neutral behavior across claude-code, opencode, codex-response, and codex-bridge.
- History replay semantics and archive/Skill import ordering.
- Whether the local descriptor gives enough information for tool-driven inspection without sending binary bytes to the model.

## Test evidence

- `npm test -- src/main/acp/attachment-content.test.ts src/main/acp/prompt-content-owner.test.ts` — 31 passed.
- Targeted ACP runtime regression tests — 2 passed.
- Full `src/main/acp/runtime.test.ts` — 471 passed.
- `npm run typecheck:node` — passed.
- `npm run lint` — 0 errors; warnings are outside the changed files.
- Full `npm test` was executed: 12,748 tests passed. The remaining failures were in Windows ACL/symlink, timing-sensitive, and workflow-fixture groups; the one affected ACP expectation was updated and the complete ACP runtime file subsequently passed.