### PR TITLE
test(skills): lock user Skill repository contracts

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -212,6 +212,36 @@
       "capabilityOverlays": ["windows_sensitive"],
       "fallbackCapability": "main_runtime"
     },
+    "user_skills_repository": {
+      "ownerPaths": [
+        "src/main/skills/user-skill-repository.ts",
+        "src/main/skills/skill-mutation-owner.ts"
+      ],
+      "interfacePaths": ["src/main/skills/user-skill-repository.ts"],
+      "consumerModules": ["settings_service_facade"],
+      "testFiles": {
+        "owner": [
+          "src/main/skills/user-skill-repository.architecture.test.ts",
+          "src/main/skills/user-skill-repository.atomic.test.ts",
+          "src/main/skills/user-skill-repository.test.ts"
+        ],
+        "contract": [
+          "src/main/skills/host-skills-service.test.ts",
+          "src/main/skills/skill-archive-sniffer.test.ts",
+          "src/main/settings/skill-catalog.test.ts"
+        ],
+        "consumer": [
+          "src/main/skills/conversation-import.test.ts",
+          "src/main/skills/specialist-package-adapter.test.ts",
+          "src/main/notebook/local-rpc-server.test.ts",
+          "src/main/settings/service.test.ts",
+          "src/main/specialist/package/release-certification.test.ts",
+          "src/main/specialist/package/service.test.ts"
+        ]
+      },
+      "capabilityOverlays": ["windows_sensitive"],
+      "fallbackCapability": "main_runtime"
+    },
     "settings_repository": {
       "ownerPaths": [
         "src/main/settings/repository.ts",

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -50,6 +50,61 @@ describe('module test impact commands', () => {
     expect(plan.fallbackCapabilities).toEqual(['main_runtime'])
   })
 
+  it('expands User Skill repository changes through Settings and cross-surface consumers', () => {
+    const direct = createModuleTestPlan('user_skills_repository')
+    expect(direct.testFiles).toEqual(
+      expect.arrayContaining([
+        'src/main/skills/user-skill-repository.architecture.test.ts',
+        'src/main/skills/user-skill-repository.atomic.test.ts',
+        'src/main/skills/user-skill-repository.test.ts',
+        'src/main/skills/host-skills-service.test.ts',
+        'src/main/skills/conversation-import.test.ts',
+        'src/main/skills/specialist-package-adapter.test.ts',
+        'src/main/notebook/local-rpc-server.test.ts',
+        'src/main/settings/skill-catalog.test.ts',
+        'src/main/settings/service.test.ts',
+        'src/main/specialist/package/release-certification.test.ts',
+        'src/main/specialist/package/service.test.ts'
+      ])
+    )
+
+    for (const path of [
+      'src/main/skills/user-skill-repository.ts',
+      'src/main/skills/skill-mutation-owner.ts'
+    ]) {
+      const affected = createAffectedTestPlan(
+        [
+          {
+            path,
+            status: 'modified'
+          }
+        ],
+        { status: 'current', testFiles: [] }
+      )
+      expect([...affected.modules].sort()).toEqual([
+        'settings_service_facade',
+        'user_skills_repository',
+        'workspace_page',
+        'workspace_runtime'
+      ])
+      expect(affected.reasonChains).toEqual(
+        expect.arrayContaining([
+          'user_skills_repository -> settings_service_facade',
+          'user_skills_repository -> settings_service_facade -> workspace_runtime',
+          'user_skills_repository -> settings_service_facade -> workspace_runtime -> workspace_page'
+        ])
+      )
+      expect(affected.testFiles).toEqual(
+        expect.arrayContaining([
+          'src/main/settings/ipc.test.ts',
+          'src/shared/renderer-surface-inventory.test.ts',
+          'src/shared/renderer-surface-matrix.test.ts',
+          'src/shared/web-rpc-contract.test.ts'
+        ])
+      )
+    }
+  })
+
   it('expands changed owners through consumer modules and graph candidates', () => {
     const plan = createAffectedTestPlan(
       [{ path: 'src/main/artifacts/repository.ts', status: 'modified' }],

--- a/src/main/skills/user-skill-repository.architecture.test.ts
+++ b/src/main/skills/user-skill-repository.architecture.test.ts
@@ -1,0 +1,253 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { basename, dirname, extname, relative, resolve } from 'node:path'
+
+import {
+  canHaveModifiers,
+  createSourceFile,
+  forEachChild,
+  getModifiers,
+  isCallExpression,
+  isClassDeclaration,
+  isExportDeclaration,
+  isFunctionDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isImportTypeNode,
+  isInterfaceDeclaration,
+  isLiteralTypeNode,
+  isMethodDeclaration,
+  isNamedExports,
+  isStringLiteralLike,
+  isTypeAliasDeclaration,
+  isVariableStatement,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  type Node,
+  type SourceFile
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const projectRoot = resolve(__dirname, '../../..')
+const skillsRoot = resolve(projectRoot, 'src/main/skills')
+const repositoryPath = resolve(skillsRoot, 'user-skill-repository.ts')
+const mutationOwnerPath = resolve(skillsRoot, 'skill-mutation-owner.ts')
+const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
+
+const readSource = (path: string): string => readFileSync(path, 'utf8')
+const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
+const portableProjectPath = (path: string): string =>
+  relative(projectRoot, path).replaceAll('\\', '/')
+const sourceFileFor = (path: string): SourceFile =>
+  createSourceFile(
+    path,
+    readSource(path),
+    ScriptTarget.Latest,
+    true,
+    extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
+  )
+
+const productionSources = (): string[] => {
+  const sources: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isDirectory()) visit(path)
+      else if (
+        ['.ts', '.tsx'].includes(extname(path)) &&
+        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
+      ) {
+        sources.push(path)
+      }
+    }
+  }
+  visit(resolve(projectRoot, 'src'))
+  visit(resolve(projectRoot, 'packages'))
+  return sources.sort()
+}
+
+const importSpecifiersFrom = (path: string): string[] => {
+  const specifiers: string[] = []
+  const visit = (node: Node): void => {
+    if (
+      (isImportDeclaration(node) || isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text)
+    } else if (isImportTypeNode(node)) {
+      const argument = node.argument
+      if (isLiteralTypeNode(argument) && isStringLiteralLike(argument.literal)) {
+        specifiers.push(argument.literal.text)
+      }
+    } else if (isCallExpression(node)) {
+      const [argument] = node.arguments
+      const isRequire = isIdentifier(node.expression) && node.expression.text === 'require'
+      const isDynamicImport = node.expression.kind === SyntaxKind.ImportKeyword
+      if ((isRequire || isDynamicImport) && argument && isStringLiteralLike(argument)) {
+        specifiers.push(argument.text)
+      }
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFileFor(path))
+  return specifiers
+}
+
+const importersOf = (targetPath: string): string[] =>
+  productionSources()
+    .filter((path) => readSource(path).includes(basename(modulePath(targetPath))))
+    .filter((path) =>
+      importSpecifiersFrom(path).some(
+        (specifier) =>
+          specifier.startsWith('.') &&
+          modulePath(resolve(dirname(path), specifier)) === modulePath(targetPath)
+      )
+    )
+    .map(portableProjectPath)
+
+const exportInventory = (): string[] => {
+  const names: string[] = []
+  for (const statement of sourceFileFor(repositoryPath).statements) {
+    if (isExportDeclaration(statement) && statement.exportClause) {
+      if (isNamedExports(statement.exportClause)) {
+        for (const element of statement.exportClause.elements) {
+          names.push(
+            `${statement.isTypeOnly || element.isTypeOnly ? 'type' : 'value'}:${element.name.text}`
+          )
+        }
+      }
+      continue
+    }
+    const exported =
+      canHaveModifiers(statement) &&
+      getModifiers(statement)?.some((modifier) => modifier.kind === SyntaxKind.ExportKeyword)
+    if (!exported) continue
+    if (isInterfaceDeclaration(statement) || isTypeAliasDeclaration(statement)) {
+      names.push(`type:${statement.name.text}`)
+    } else if (isClassDeclaration(statement) || isFunctionDeclaration(statement)) {
+      names.push(`value:${statement.name?.text ?? '<anonymous>'}`)
+    } else if (isVariableStatement(statement)) {
+      names.push(
+        ...statement.declarationList.declarations.flatMap((declaration) =>
+          isIdentifier(declaration.name) ? [`value:${declaration.name.text}`] : []
+        )
+      )
+    }
+  }
+  return names.sort()
+}
+
+const publicOperations = (): string[] => {
+  const declaration = sourceFileFor(repositoryPath).statements.find(
+    (statement) => isClassDeclaration(statement) && statement.name?.text === 'UserSkillRepository'
+  )
+  if (!declaration || !isClassDeclaration(declaration)) throw new Error('facade class not found')
+
+  return declaration.members
+    .flatMap((member) => {
+      const hidden =
+        canHaveModifiers(member) &&
+        getModifiers(member)?.some((modifier) =>
+          [SyntaxKind.PrivateKeyword, SyntaxKind.ProtectedKeyword].includes(modifier.kind)
+        )
+      return !hidden && isMethodDeclaration(member) && isIdentifier(member.name)
+        ? [member.name.text]
+        : []
+    })
+    .sort()
+}
+
+type ModuleImpactManifest = {
+  modules: Record<
+    string,
+    {
+      ownerPaths: string[]
+      interfacePaths: string[]
+      consumerModules: string[]
+      testFiles: { owner: string[]; contract: string[]; consumer: string[] }
+      capabilityOverlays: string[]
+      fallbackCapability: string
+    }
+  >
+}
+
+describe('User Skill repository architecture', () => {
+  it('locks the compatibility export and operation inventories', () => {
+    expect(exportInventory()).toEqual([
+      'type:ImportOutcome',
+      'value:SAFE_SLUG',
+      'value:UserSkillRepository',
+      'value:assertUsableSlug',
+      'value:frontmatterBlock',
+      'value:parseUserSkillId',
+      'value:toSlug'
+    ])
+    expect(publicOperations()).toEqual([
+      'body',
+      'createPersonal',
+      'delete',
+      'importAgentHomeSkill',
+      'importFromGitHub',
+      'importFromZip',
+      'importFromZipBatch',
+      'list',
+      'listAgentHomeSkills',
+      'matchImportedAgentHomeSkills',
+      'previewAgentHomeSkill',
+      'previewGitHubSkill',
+      'previewZip',
+      'publishPersonalDirectory',
+      'scanRepo',
+      'updatePersonal',
+      'withSkillReadLock'
+    ])
+  })
+
+  it('keeps production consumers on the facade and one mutation-owner construction seam', () => {
+    expect(importersOf(repositoryPath)).toEqual([
+      'src/main/settings/service.ts',
+      'src/main/settings/skill-catalog.ts',
+      'src/main/skills/host-skills-service.ts'
+    ])
+    expect(importersOf(mutationOwnerPath)).toEqual([
+      'src/main/skills/specialist-package-adapter.ts',
+      'src/main/skills/user-skill-repository.ts'
+    ])
+    expect(readSource(repositoryPath).match(/skillMutationOwnerFor\(/g)).toHaveLength(1)
+  })
+
+  it('declares complete ownership and downstream test impact', () => {
+    const manifest = JSON.parse(readSource(manifestPath)) as ModuleImpactManifest
+    expect(manifest.modules.user_skills_repository).toEqual({
+      ownerPaths: [
+        'src/main/skills/user-skill-repository.ts',
+        'src/main/skills/skill-mutation-owner.ts'
+      ],
+      interfacePaths: ['src/main/skills/user-skill-repository.ts'],
+      consumerModules: ['settings_service_facade'],
+      testFiles: {
+        owner: [
+          'src/main/skills/user-skill-repository.architecture.test.ts',
+          'src/main/skills/user-skill-repository.atomic.test.ts',
+          'src/main/skills/user-skill-repository.test.ts'
+        ],
+        contract: [
+          'src/main/skills/host-skills-service.test.ts',
+          'src/main/skills/skill-archive-sniffer.test.ts',
+          'src/main/settings/skill-catalog.test.ts'
+        ],
+        consumer: [
+          'src/main/skills/conversation-import.test.ts',
+          'src/main/skills/specialist-package-adapter.test.ts',
+          'src/main/notebook/local-rpc-server.test.ts',
+          'src/main/settings/service.test.ts',
+          'src/main/specialist/package/release-certification.test.ts',
+          'src/main/specialist/package/service.test.ts'
+        ]
+      },
+      capabilityOverlays: ['windows_sensitive'],
+      fallbackCapability: 'main_runtime'
+    })
+  })
+})


### PR DESCRIPTION
## Problem

`UserSkillRepository` owns Personal Skill storage, failure-atomic package replacement, GitHub/ZIP import, and Agent Home identity workflows, but it had no dependency-aware Module declaration. A later owner extraction could therefore miss Settings, Workspace, Specialist, or Notebook consumers in selective test planning.

## Proposed change

- Add a `user_skills_repository` Module with the existing facade and shared mutation owner.
- Declare `settings_service_facade` as the downstream Module and include the repository, atomicity, Host Skills, conversation import, Specialist package, Settings catalog, and Notebook local-RPC suites.
- Add architecture certification for the exact facade export/method inventory, production importer direction, shared mutation-owner registry callers, and manifest declaration.
- Add affected-plan tests proving both current owner paths expand through Settings to Workspace and cross-surface overlays. Each later extraction PR will register its new owner path in the same change that creates the file.

## Scope and non-goals

This PR changes tests and CI metadata only. It adds no production owner stub and does not refactor `UserSkillRepository`, Main IPC, Settings UI, Specialist UI, Notebook, or any runtime implementation.

## Compatibility

No public method/export, IPC or RPC channel, wire payload, filesystem layout, `.source.json` shape, Skill id, UI behavior, error semantic, or capability availability changes. Existing Electron, Web, CLI, Task, Notebook local-RPC/MCP, Host Skills, and Specialist behavior remains unchanged. Test paths normalize separators and remain portable across Windows, macOS, and Linux.

## Acceptance criteria and validation

Final evidence after the last material edit:

- Facade inventory, importer direction, shared-owner callers, and declared impact routing -> `npm test -- scripts/ci/module-test-impact.test.ts src/main/skills/user-skill-repository.architecture.test.ts` -> 2 files / 22 tests passed.
- Complete declared Module plan -> `npm run test:module -- user_skills_repository` -> 12 files selected; 10 files / 449 tests passed locally. Notebook local-RPC 24 tests and Settings bridge 8 tests could not bind loopback/socket listeners in the managed sandbox (`listen EPERM`); exact-head CI is authoritative for those unchanged consumers.
- Node compilation -> `npm run typecheck:node` -> passed.
- Changed TypeScript lint -> `npx eslint scripts/ci/module-test-impact.test.ts src/main/skills/user-skill-repository.architecture.test.ts` -> passed.
- Formatting -> `npx prettier --check scripts/ci/module-impact.json scripts/ci/module-test-impact.test.ts src/main/skills/user-skill-repository.architecture.test.ts` -> passed.
- Patch hygiene -> `git diff --check` -> passed.
- Final affected-plan explanation -> full fallback, because trusted global impact inputs changed.
- Independent Standards review -> P0/P1/P2 = 0.
- Independent Spec review -> P0/P1/P2 = 0 after aligning the impact declaration with repository path-existence validation.

Uncovered local risk: the managed sandbox cannot exercise listener-backed consumers. Require all exact-head PR Gate, CI Integrity, CodeQL, platform, and online AI checks to pass before squash merge.

## Review focus

Please verify that the declared consumer/test set covers Settings, Workspace, Specialist, Host Skills, conversation import, and Notebook local-RPC; that current owner paths satisfy manifest validation; and that the architecture assertions protect compatibility without constraining private implementation details beyond ownership.
