### PR TITLE
test(user-skills): certify repository ownership

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -239,9 +239,14 @@
           "src/main/skills/conversation-import.test.ts",
           "src/main/skills/specialist-package-adapter.test.ts",
           "src/main/notebook/local-rpc-server.test.ts",
+          "src/main/notebook/local-rpc-server.skill-import.test.ts",
+          "src/main/notebook/local-rpc-server.skills.test.ts",
           "src/main/settings/service.test.ts",
           "src/main/specialist/package/release-certification.test.ts",
-          "src/main/specialist/package/service.test.ts"
+          "src/main/specialist/package/service.test.ts",
+          "src/preload/index.test.ts",
+          "src/renderer/src/pages/settings/SkillsPanel.render.test.tsx",
+          "src/renderer/src/stores/settings-skills-slice.test.ts"
         ]
       },
       "capabilityOverlays": ["windows_sensitive"],

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -61,10 +61,15 @@ describe('module test impact commands', () => {
         'src/main/skills/conversation-import.test.ts',
         'src/main/skills/specialist-package-adapter.test.ts',
         'src/main/notebook/local-rpc-server.test.ts',
+        'src/main/notebook/local-rpc-server.skill-import.test.ts',
+        'src/main/notebook/local-rpc-server.skills.test.ts',
         'src/main/settings/skill-catalog.test.ts',
         'src/main/settings/service.test.ts',
         'src/main/specialist/package/release-certification.test.ts',
-        'src/main/specialist/package/service.test.ts'
+        'src/main/specialist/package/service.test.ts',
+        'src/preload/index.test.ts',
+        'src/renderer/src/pages/settings/SkillsPanel.render.test.tsx',
+        'src/renderer/src/stores/settings-skills-slice.test.ts'
       ])
     )
 
@@ -96,7 +101,21 @@ describe('module test impact commands', () => {
       )
       expect(affected.testFiles).toEqual(
         expect.arrayContaining([
+          'packages/open-science/cli.test.ts',
+          'src/main/acp/task-agent-port.test.ts',
+          'src/main/notebook/local-rpc-notebook-adapter.test.ts',
+          'src/main/notebook/local-rpc-server.mcpcall.test.ts',
+          'src/main/notebook/local-rpc-server.skill-import.test.ts',
+          'src/main/notebook/local-rpc-server.skills.test.ts',
+          'src/main/notebook/mcp-server.test.ts',
           'src/main/settings/ipc.test.ts',
+          'src/main/web-service/http-server.test.ts',
+          'src/preload/electron-renderer-contract-adapter.test.ts',
+          'src/preload/index.test.ts',
+          'src/renderer/src/pages/settings/SkillsPanel.render.test.tsx',
+          'src/renderer/src/stores/settings-skills-slice.test.ts',
+          'src/renderer/src/stores/settings-store.test.ts',
+          'src/renderer/web/api-installer.test.ts',
           'src/shared/renderer-surface-inventory.test.ts',
           'src/shared/renderer-surface-matrix.test.ts',
           'src/shared/web-rpc-contract.test.ts'

--- a/src/main/skills/user-skill-repository.architecture.test.ts
+++ b/src/main/skills/user-skill-repository.architecture.test.ts
@@ -179,6 +179,10 @@ type ModuleImpactManifest = {
 }
 
 describe('User Skill repository architecture', () => {
+  it('keeps the public facade within the production file budget', () => {
+    expect(rawLineCount(readSource(repositoryPath))).toBeLessThanOrEqual(660)
+  })
+
   it('keeps the catalog and Personal Skill owner within the production file budget', () => {
     expect(rawLineCount(readSource(storePath))).toBeLessThanOrEqual(660)
   })
@@ -189,6 +193,11 @@ describe('User Skill repository architecture', () => {
 
   it('keeps the Agent Home import owner within the production file budget', () => {
     expect(rawLineCount(readSource(agentHomeOwnerPath))).toBeLessThanOrEqual(660)
+  })
+
+  it('keeps the mutation and transaction owners within the production file budget', () => {
+    expect(rawLineCount(readSource(mutationOwnerPath))).toBeLessThanOrEqual(660)
+    expect(rawLineCount(readSource(transactionOwnerPath))).toBeLessThanOrEqual(660)
   })
 
   it('locks the compatibility export and operation inventories', () => {
@@ -299,9 +308,14 @@ describe('User Skill repository architecture', () => {
           'src/main/skills/conversation-import.test.ts',
           'src/main/skills/specialist-package-adapter.test.ts',
           'src/main/notebook/local-rpc-server.test.ts',
+          'src/main/notebook/local-rpc-server.skill-import.test.ts',
+          'src/main/notebook/local-rpc-server.skills.test.ts',
           'src/main/settings/service.test.ts',
           'src/main/specialist/package/release-certification.test.ts',
-          'src/main/specialist/package/service.test.ts'
+          'src/main/specialist/package/service.test.ts',
+          'src/preload/index.test.ts',
+          'src/renderer/src/pages/settings/SkillsPanel.render.test.tsx',
+          'src/renderer/src/stores/settings-skills-slice.test.ts'
         ]
       },
       capabilityOverlays: ['windows_sensitive'],


### PR DESCRIPTION
## Problem

The User Skill Repository owner cutovers are complete, but the final completion gates did not yet enforce the facade and transaction-owner line budgets or directly route every skill-specific Notebook, preload, Settings store, and Settings UI consumer.

## Proposed change

Finalize the User Skill Repository architecture contract with line gates for the facade, mutation owner, and transaction owner. Expand user_skills_repository test impact routing to the existing skill-specific Notebook, preload, Settings store, and SkillsPanel tests. Strengthen the impact regression to prove downstream Electron, Web, CLI, Task, Notebook, local-RPC, MCP, UI, and Specialist expansion.

## Scope and non-goals

This PR changes tests and CI impact metadata only. It does not modify production code, public APIs, IPC, data models, persisted layout, runtime behavior, UI behavior, or capability availability. It does not add a duplicate certification suite or remove existing tests.

## Compatibility

The public facade export inventory and all 17 operations remain locked. Electron, Web, CLI, Task, Notebook/local-RPC/MCP, Settings UI, Host Skills, and Specialist coverage is selected without changing their current capability asymmetry. Repository-relative forward-slash test paths remain portable across Windows, macOS, and Linux.

## Acceptance criteria and validation

- Production diff is zero.
- Facade and all private owners remain at or below 660 raw lines.
- Architecture and module impact contracts pass: 40 tests.
- User Skill module impact suite passes: 17 files, 618 tests.
- Node and Web typechecks pass.
- Changed-file ESLint, Prettier check, and git diff check pass.
- Independent Standards and Spec reviews report zero P0, P1, or P2 findings.
- Exact-head CI, CodeQL, and online AI must pass before merge.

## Review focus

Review whether the added direct consumers close real routing gaps without duplication, whether downstream expansion covers every supported surface, whether the line gates remain implementation-agnostic, and whether the diff is strictly test and CI metadata with no public, data, wire, or UI behavior change.