### PR TITLE
refactor(workspace-runtime): hide recovery policy from send interface

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -457,6 +457,22 @@ const hookKeys = [
   'setPermissionProfile',
   'revokePermissionGrant'
 ] as const
+const sendIntentKeys = [
+  'sessionId',
+  'branchSourceSessionId',
+  'text',
+  'turnIntent',
+  'planContinuation',
+  'attachments',
+  'cwd',
+  'projectId',
+  'projectName',
+  'permissionProfile',
+  'forcedSkillIds',
+  'referencedArtifacts',
+  'parts',
+  'specialistId'
+] as const
 const ownerDependencyNames = (path: string): string[] => {
   const targets = new Set(importsFrom(path).map((reference) => reference.target))
   return ownerNames.filter((name) => targets.has(ownerTargets.get(name)!))
@@ -508,6 +524,23 @@ describe('workspace runtime architecture', () => {
     expect(owner.type?.getText()).toBe('WorkspaceAgentRuntime')
     expect(consumer.type?.getText()).toBe('WorkspaceAgentRuntime')
     expectSameNames(propertyNames(directReturnObject(owner)), hookKeys)
+  })
+  it('keeps replay and recovery mechanics behind the public send intent', () => {
+    const commandOwnerFile = sourceFileFor(
+      `${ownerTargets.get('workspace-runtime-command-owner')}.ts`
+    )
+    const sendIntent = typeLiteralAlias(commandOwnerFile, 'SendWorkspaceMessageIntent')
+    const declaredKeys = sendIntent.members.map((member) => {
+      if (!member.name) throw new Error('expected named send intent property')
+      return member.name.getText()
+    })
+    const runtimeType = typeLiteralAlias(facadeFile, 'WorkspaceAgentRuntime')
+    const sendMessage = runtimeType.members.find(
+      (member) => member.name?.getText() === 'sendMessage'
+    )
+
+    expectSameNames(declaredKeys, sendIntentKeys)
+    expect(sendMessage?.getText()).toContain('SendWorkspaceMessageIntent')
   })
   it('keeps React composition in the facade and lifecycle state in its owner', () => {
     const calls = callCounts(facadeFile)

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -45,7 +45,7 @@ import {
   resendEditedWorkspaceMessage,
   sendWorkspaceMessage,
   type ResendEditedMessageInput,
-  type SendWorkspaceMessageInput,
+  type SendWorkspaceMessageIntent,
   type SendWorkspaceMessageResult
 } from './workspace-runtime-command-owner'
 import { createWorkspaceRuntimeSessionLifecycleOwner } from './workspace-runtime-session-lifecycle-owner'
@@ -87,7 +87,9 @@ type WorkspaceAgentRuntime = {
   sendPreparationInFlightSessionIds: string[]
   nativeContextCompactionSessionIds: string[]
   compactContext: (sessionId: string) => Promise<boolean>
-  sendMessage: (input: SendWorkspaceMessageInput) => Promise<SendWorkspaceMessageResult | undefined>
+  sendMessage: (
+    input: SendWorkspaceMessageIntent
+  ) => Promise<SendWorkspaceMessageResult | undefined>
   resendEditedMessage: (
     sessionId: string,
     messageId: string,
@@ -198,7 +200,7 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   }, [runtime.state.status, runtime.state.sessionConnectionStatuses])
 
   const sendMessage = useCallback(
-    (input: SendWorkspaceMessageInput): Promise<SendWorkspaceMessageResult | undefined> => {
+    (input: SendWorkspaceMessageIntent): Promise<SendWorkspaceMessageResult | undefined> => {
       lifecycleOwner.recordPromptPlanAuthority(input)
       return sendWorkspaceMessage(
         runtime,

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -26,7 +26,7 @@ import {
 } from './workspace-runtime-prompt-preparation-owner'
 import type { useAcpRuntime } from './useAcpRuntime'
 
-type SendWorkspaceMessageInput = {
+type SendWorkspaceMessageIntent = {
   sessionId?: string
   branchSourceSessionId?: string
   text: string
@@ -39,19 +39,22 @@ type SendWorkspaceMessageInput = {
   projectId?: string
   projectName?: string
   permissionProfile?: PermissionProfileId
+  forcedSkillIds?: string[]
+  referencedArtifacts?: FileReference[]
+  parts?: MessagePart[]
+  specialistId?: string | null
+}
+
+type SendWorkspaceMessageCommand = SendWorkspaceMessageIntent & {
   agentFrameworkId?: AgentFrameworkId
   agentBackendId?: string
   agentModel?: string
   historyReplayDescriptor?: HistoryReplayDescriptor
-  forcedSkillIds?: string[]
-  referencedArtifacts?: FileReference[]
-  parts?: MessagePart[]
   forceHistoryReplay?: boolean
   supportsImageInput?: boolean
   truncateFromMessageId?: string
   allowCompactionRecovery?: boolean
   requireExistingSession?: boolean
-  specialistId?: string | null
 }
 
 type SendWorkspaceMessageResult = { sessionId: string; messageId: string }
@@ -187,7 +190,7 @@ const reconcileBranchedAttachments = async (
 
 const replayHistory = (
   messages: ChatMessage[],
-  input: SendWorkspaceMessageInput,
+  input: SendWorkspaceMessageCommand,
   projectId?: string
 ): HistoryReplayContext | undefined =>
   buildWorkspaceHistoryReplay(
@@ -224,7 +227,7 @@ type PromptDispatch = {
     contextReset?: boolean
   }
   continuation?: Parameters<WorkspaceCommandRuntime['sendPrompt']>[11]
-  turnIntent?: SendWorkspaceMessageInput['turnIntent']
+  turnIntent?: SendWorkspaceMessageIntent['turnIntent']
   accepted?: () => void
 }
 
@@ -256,7 +259,7 @@ const dispatchPrompt = (runtime: WorkspaceCommandRuntime, request: PromptDispatc
     })
 }
 
-type PendingPromptRequest = SendWorkspaceMessageInput & {
+type PendingPromptRequest = SendWorkspaceMessageCommand & {
   pending: SendWorkspaceMessageResult
   content: string
   attachments: UploadedAttachment[]
@@ -340,7 +343,7 @@ const startPendingPrompt = (
 
 const sendWorkspaceMessage = async (
   runtime: WorkspaceCommandRuntime,
-  input: SendWorkspaceMessageInput,
+  input: SendWorkspaceMessageCommand,
   lifecycle: WorkspaceCommandLifecycle = {}
 ): Promise<SendWorkspaceMessageResult | undefined> => {
   const content = input.text.trim()
@@ -622,4 +625,4 @@ const resendEditedWorkspaceMessage = async (
 }
 
 export { resendEditedWorkspaceMessage, sendWorkspaceMessage }
-export type { ResendEditedMessageInput, SendWorkspaceMessageInput, SendWorkspaceMessageResult }
+export type { ResendEditedMessageInput, SendWorkspaceMessageIntent, SendWorkspaceMessageResult }

--- a/src/renderer/src/lib/acp/workspace-runtime-session-lifecycle-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-session-lifecycle-owner.ts
@@ -10,7 +10,7 @@ import { resolveHistoryReplayTarget, type HistoryReplayDescriptor } from './hist
 import { getResumeFailureMessage } from './workspace-runtime-prompt-preparation-owner'
 import {
   sendWorkspaceMessage,
-  type SendWorkspaceMessageInput
+  type SendWorkspaceMessageIntent
 } from './workspace-runtime-command-owner'
 
 type RuntimeEventDrain = (sessionId?: string) => Promise<void>
@@ -303,7 +303,7 @@ const recoverContextOverflowWorkspaceSession = async (
   supportsImageInput?: boolean,
   cancelledSessionIds?: Set<string>,
   historyReplayDescriptor?: HistoryReplayDescriptor,
-  planContinuation?: SendWorkspaceMessageInput['planContinuation']
+  planContinuation?: SendWorkspaceMessageIntent['planContinuation']
 ): Promise<boolean> => {
   const session = useSessionStore.getState().sessions.find((item) => item.id === sessionId)
 
@@ -546,12 +546,12 @@ const createWorkspaceRuntimeSessionLifecycleOwner = () => {
   const cancelledOverflowRecoverySessionIds = new Set<string>()
   const planContinuationBySessionId = new Map<
     string,
-    NonNullable<SendWorkspaceMessageInput['planContinuation']>
+    NonNullable<SendWorkspaceMessageIntent['planContinuation']>
   >()
 
   return {
     recordPromptPlanAuthority(
-      input: Pick<SendWorkspaceMessageInput, 'sessionId' | 'planContinuation'>
+      input: Pick<SendWorkspaceMessageIntent, 'sessionId' | 'planContinuation'>
     ): void {
       if (input.sessionId && input.planContinuation) {
         planContinuationBySessionId.set(input.sessionId, input.planContinuation)


### PR DESCRIPTION
## Problem

The Workspace conversation controller forms a useful seam, but its injected runtime reused the internal `SendWorkspaceMessageInput`. That exposed provider selection and replay/recovery controls—such as `historyReplayDescriptor`, `forceHistoryReplay`, `allowCompactionRecovery`, and `truncateFromMessageId`—to ordinary Workspace callers.

## Proposed change

- Split the caller-facing `SendWorkspaceMessageIntent` from the private `SendWorkspaceMessageCommand`.
- Keep provider/model selection and replay/recovery policy inside the Workspace runtime implementation.
- Make `WorkspaceAgentRuntime.sendMessage` accept only the 14 business-intent fields.
- Add an architecture contract test that locks the public intent shape.

## Scope and non-goals

- Type/interface refactor only; prompt dispatch, persistence, replay, recovery, and lifecycle behavior are unchanged.
- No changes to ACP wire contracts, Electron/preload contracts, Web RPC, CLI/Task ports, or provider-specific protocol translation.
- The shared implementation therefore remains compatible with `claude-code`, `opencode`, `codex-response`, and `codex-bridge`.

## Acceptance criteria and validation

Checks ran after the last material edit.

- Public send interface excludes runtime-owned mechanism fields -> `npm test -- src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts` -> 11/11 passed.
- Workspace runtime owner, contract, and consumer behavior -> explicit six-file module-impact Vitest command -> 254/254 passed.
- Web and CLI/Task compatibility -> focused six-file Web/Task Vitest command -> 62/62 passed.
- Renderer type integration -> `npm run typecheck:web` -> passed.
- CLI/Main type integration -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> 0 errors; 17 existing warnings in unchanged files.

`npm run test:module -- workspace_runtime` produced the correct six-file plan but could not spawn `npm.cmd` on this Windows host (`EINVAL`), so the listed files were run directly.

The full `npm test` run was not green: 12,767 tests across 894 files passed, while 32 tests across 6 unrelated files failed because the host could not create symlinks/set ACLs or launch bash-dependent subprocesses, plus Notebook provisioning timeouts. None of the failures were in Workspace runtime, Web, or CLI/Task coverage.

## Review focus

- Whether the 14-field public intent captures only caller-owned decisions.
- Whether all replay/recovery controls remain private to the command/lifecycle owners.
- Whether the architecture contract is sufficiently strict without coupling tests to implementation behavior.