### PR TITLE
test(side-chat): make cwd assertions platform-aware

### DIFF
--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -895,7 +895,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     expect(resumeSession).toHaveBeenCalledWith({
       sessionId: 'side-chat-restored',
       providerSessionId: 'provider-restored',
-      cwd: expect.stringContaining('/side-chat-restored/cwd'),
+      cwd: join(temporaryRoot, 'runtime-support', 'side-chat', 'side-chat-restored', 'cwd'),
       projectName: 'project-1',
       previousFrameworkId: 'claude-code',
       previousBackendId: 'claude-code:provider-a'
@@ -1449,7 +1449,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     expect(resumeSession).toHaveBeenLastCalledWith({
       sessionId: 'side-session-reconfigure',
       providerSessionId: 'side-session-reconfigure',
-      cwd: expect.stringContaining('/cwd'),
+      cwd: join(temporaryRoot, 'runtime-support', 'side-chat', started.sideSessionId, 'cwd'),
       projectName: 'project-1',
       previousFrameworkId: 'claude-code',
       previousBackendId: 'claude-code:provider-a'


### PR DESCRIPTION
## Problem

[Windows Full Test run 31342387867](https://github.com/aipoch/open-science/actions/runs/31342387867) failed in shard 3/3 because two Side chat tests expected POSIX-only `/` separators while `SideChatRuntimeOwner` correctly supplied native Windows working-directory paths.

## Proposed change

Replace both suffix matchers with exact expected paths built through Node's existing `join(...)` helper. This keeps the assertions strict while making them portable across Windows, macOS, and Linux.

## Scope and non-goals

- Changes only `src/main/side-chat/runtime-owner.test.ts`.
- Does not change production behavior, persisted data, interfaces, or user interactions.
- Does not change ACP lifecycle or framework-specific behavior. The cwd is built before framework dispatch, so the shared `claude-code`, `opencode`, `codex-response`, and `codex-bridge` paths remain untouched.
- No consumer tests or additional platform lanes are required by an interface change; the Windows lane is the authoritative platform check for the original failure.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Dormant Side chat resume and incompatible reconnect cwd contracts -> `npm test -- src/main/side-chat/runtime-owner.test.ts` -> passed, 33/33 tests.
- Node and renderer type safety -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors; 17 pre-existing warnings remain in untouched files.
- Original Windows job command -> `npm test -- --shard=3/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000` -> the changed Side chat tests passed locally; 302 files / 3961 tests passed and 5 files / 51 tests skipped. The only local failure was the unrelated `scripts/ai-review-workflows.test.ts`, because this host lacks the GitHub runner's `jq` tool.
- Full fallback -> `npm test` -> attempted; the changed file passed, while unrelated tests requiring Windows symlink/ACL privileges, bash/jq, or stable high-concurrency timing failed on this local host.
- Hosted Windows full suite -> [workflow run 31344232049](https://github.com/aipoch/open-science/actions/runs/31344232049) -> passed all three shards; the original failing shard 3/3 passed in 12m10s.

## Review focus

Confirm the two expected cwd values mirror `SideChatRuntimeOwner`'s existing `join(configRoot, 'runtime-support', 'side-chat', sideSessionId, 'cwd')` construction without weakening either assertion.

