### PR TITLE
fix(notebook): seed selected offline package cache

### DIFF
--- a/src/main/notebook/bundle-local.ts
+++ b/src/main/notebook/bundle-local.ts
@@ -110,7 +110,7 @@ export const createLocalBundleAdapter =
         if (pathBudget) {
           writeFileSync(join(packDir, PACK_PATH_BUDGET_FILE), `${JSON.stringify(pathBudget)}\n`)
         }
-        return { lockPath, pathBudget }
+        return { lockPath, pathBudget, packageSourceDir: packDir }
       } catch {
         // A malformed or stale local bundle is not authoritative. Let the next adapter (CDN) try
         // the same pack instead of turning a local residue into the final provisioning error.

--- a/src/main/notebook/language-pack-fetch.ts
+++ b/src/main/notebook/language-pack-fetch.ts
@@ -316,7 +316,7 @@ export const createFetchBundleAdapter = (
               'utf8'
             )
           }
-          return { lockPath: winnerLockPath, pathBudget }
+          return { lockPath: winnerLockPath, pathBudget, packageSourceDir: finalDir }
         } catch {
           // Only remove a directory that is demonstrably not a complete pack, then retry the
           // rename. This handles a process interrupted before its final commit.
@@ -324,7 +324,11 @@ export const createFetchBundleAdapter = (
           await rename(unpackedDir, finalDir)
         }
       }
-      return { lockPath: join(finalDir, `${fetched.id}.lock`), pathBudget }
+      return {
+        lockPath: join(finalDir, `${fetched.id}.lock`),
+        pathBudget,
+        packageSourceDir: finalDir
+      }
     } catch (error) {
       const message = `Managed runtime pack unavailable: ${error instanceof Error ? error.message : String(error)}`
       onProgress({

--- a/src/main/notebook/pack-content.ts
+++ b/src/main/notebook/pack-content.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 
 import { pkgsCache } from './runtime-paths'
 import { md5File } from './provisioner-runtime'
-import { micromambaCacheLockKey } from './micromamba-cache'
+import { micromambaCacheLockKey, type MicromambaCache } from './micromamba-cache'
 import { withExclusiveCacheLock } from './pkgs-cache-lock'
 
 export type LockPackage = { file: string; md5: string }
@@ -30,18 +30,17 @@ export const lockPackages = (lockText: string): LockPackage[] => {
   return packages
 }
 
-export const validateAndSeedPack = async (
-  root: string,
+export const validateAndSeedPackIntoCache = async (
   packDir: string,
   lockPath: string,
+  cache: MicromambaCache,
   onProgress?: (completed: number, total: number) => void
 ): Promise<LockPackage[]> => {
   const entries = lockPackages(await readFile(lockPath, 'utf8'))
   const present = new Set(await readdir(packDir))
-  const cache = pkgsCache(root)
-  await mkdir(cache, { recursive: true })
+  await mkdir(cache.path, { recursive: true })
 
-  await withExclusiveCacheLock(micromambaCacheLockKey(cache), async () => {
+  await withExclusiveCacheLock(cache.lockKey, async () => {
     for (const [index, entry] of entries.entries()) {
       if (!present.has(entry.file)) {
         throw new Error(`runtime pack is missing lock tarball ${entry.file}`)
@@ -55,7 +54,7 @@ export const validateAndSeedPack = async (
         throw new Error(`runtime pack tarball failed md5 verification: ${entry.file}`)
       }
 
-      const destination = join(cache, entry.file)
+      const destination = join(cache.path, entry.file)
       let destinationValid = false
       try {
         const destinationStat = await stat(destination)
@@ -70,4 +69,19 @@ export const validateAndSeedPack = async (
     }
   })
   return entries
+}
+
+export const validateAndSeedPack = async (
+  root: string,
+  packDir: string,
+  lockPath: string,
+  onProgress?: (completed: number, total: number) => void
+): Promise<LockPackage[]> => {
+  const path = pkgsCache(root)
+  return validateAndSeedPackIntoCache(
+    packDir,
+    lockPath,
+    { path, lockKey: micromambaCacheLockKey(path) },
+    onProgress
+  )
 }

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -36,6 +36,7 @@ import { CHILD_UNCONFIRMED } from './provisioner-runtime'
 import { envsLockDir } from './runtime-relocation'
 import { serializeProvisioner } from './environment-operation-foundation'
 import { withExclusiveCacheLock, withSharedCacheLock } from './pkgs-cache-lock'
+import { validateAndSeedPack } from './pack-content'
 import { micromambaCacheLockKey, selectMicromambaCache } from './micromamba-cache'
 import {
   operationJournalPath,
@@ -191,6 +192,60 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     await new DefaultRuntimeProvisioner(deps).provisionPython(() => {})
     expect(argvs[0]).toContain('--offline')
     expect(argvs[0]).toContain(lockPath)
+  })
+
+  it('seeds verified pack tarballs into the selected Windows cache before offline create', async () => {
+    const root = makeRoot()
+    const packDir = join(root, 'packs', '1', 'win-64', 'python-3.12')
+    const lockPath = join(packDir, 'python-3.12.lock')
+    const packageFile = 'nomkl-1.0-h5ca1d4c_0.tar.bz2'
+    const selectedCache = join(root, 'short-pkgs')
+    const fetchBundle = vi.fn(async (): Promise<FetchedBundle> => {
+      mkdirSync(packDir, { recursive: true })
+      writeFileSync(
+        lockPath,
+        `@EXPLICIT\nhttps://conda.anaconda.org/conda-forge/noarch/${packageFile}#0cc175b9c0f1b6a831c399e269772661\n`
+      )
+      writeFileSync(join(packDir, packageFile), 'a')
+      await validateAndSeedPack(root, packDir, lockPath)
+      return {
+        lockPath,
+        pathBudget: { maxCacheRelativePath: 1, maxEnvRelativePath: 1 },
+        packageSourceDir: packDir
+      }
+    })
+    const runArgvImpl: ProvisionerDeps['runArgv'] = async (
+      argv,
+      _signal,
+      _onChild,
+      _onBeforeSpawn,
+      cache
+    ) => {
+      expect(argv).toContain('--offline')
+      expect(cache?.path).toBe(selectedCache)
+      if (!existsSync(join(selectedCache, packageFile))) {
+        throw new Error(
+          `critical libmamba Download error (28) Timeout was reached ` +
+            `[https://conda.anaconda.org/conda-forge/noarch/${packageFile}]`
+        )
+      }
+      const prefix = argv[argv.indexOf('-p') + 1]
+      const bin = pythonBin(prefix)
+      mkdirSync(dirname(bin), { recursive: true })
+      writeFileSync(bin, 'x')
+    }
+    const runArgv = vi.fn(runArgvImpl)
+    const provisioner = new DefaultRuntimeProvisioner(
+      makeDeps(root, {
+        platform: 'win32',
+        cache: { path: selectedCache, lockKey: selectedCache },
+        fetchBundle,
+        runArgv
+      })
+    )
+
+    await expect(provisioner.provisionPython(() => {})).resolves.toBeUndefined()
+    expect(runArgv).toHaveBeenCalledOnce()
   })
 
   it('enforces fetched pack cache and environment budgets before micromamba runs', async () => {

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -27,6 +27,7 @@ import { chainFetchBundle, createLocalBundleAdapter, resolveBundleDir } from './
 import { createFetchBundleAdapter } from './language-pack-fetch'
 import { DEFAULT_MAX_ENV_RELATIVE_PATH, type PackPathBudget } from './bundle-manifest'
 import { withExclusiveCacheLocks, withSharedCacheLocks } from './pkgs-cache-lock'
+import { validateAndSeedPackIntoCache } from './pack-content'
 import {
   recoverWindowsMaxPathPackage,
   removeOverBudgetUrlPackages,
@@ -85,8 +86,13 @@ import {
 // both main and renderer); re-export here so IPC-adjacent code can import them from the provisioner.
 export type { ProvisionProgress, ProvisionStatus }
 
-// A resolved bundle on disk: the local @EXPLICIT lock whose tarballs are already in the pkgs cache.
-export type FetchedBundle = { lockPath: string; pathBudget?: PackPathBudget }
+// A resolved bundle on disk. Production adapters retain the verified tarballs in packageSourceDir so
+// Windows can seed the short cache selected from the pack's path budget before offline materialization.
+export type FetchedBundle = {
+  lockPath: string
+  pathBudget?: PackPathBudget
+  packageSourceDir?: string
+}
 
 // One default environment specification (A-internal). `version` is the curated interpreter version
 // (e.g. "3.12" / "4.4") — it identifies the staged offline pack via packId(language, version) (see
@@ -320,6 +326,19 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       cache.lockKey,
       micromambaCacheLockKey(pkgsCache(this.deps.root), { platform: this.deps.platform })
     ]
+  }
+
+  private async seedBundleCache(bundle: FetchedBundle, cache: MicromambaCache): Promise<void> {
+    if (!bundle.packageSourceDir) return
+    const legacyCache = pkgsCache(this.deps.root)
+    const legacyLockKey = micromambaCacheLockKey(legacyCache, {
+      platform: this.deps.platform
+    })
+    const selectedLockKey = micromambaCacheLockKey(cache.path, {
+      platform: this.deps.platform
+    })
+    if (legacyLockKey === selectedLockKey) return
+    await validateAndSeedPackIntoCache(bundle.packageSourceDir, bundle.lockPath, cache)
   }
 
   private cacheForBundle(
@@ -1206,6 +1225,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // must not delete an incomplete extraction mid-upgrade, and a Windows path-limit failure is retried
     // once after a short cache recovery.
     const selected = this.cacheForBundle(spec, bundle)
+    await this.seedBundleCache(bundle, selected.cache)
     await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
     await this.withJournaledPrefixWrite(
       'upgrade',
@@ -1301,6 +1321,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // Select the cache scoped to this bundle (Windows budget) and clear any legacy over-budget URL
     // packages before the create, so a Windows path-limit blocker doesn't fail the first attempt.
     const selected = this.cacheForBundle(spec, bundle)
+    await this.seedBundleCache(bundle, selected.cache)
     await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
     // Journal the create (child PID + prefix) so a process death mid-materialize is reconciled at next
     // startup: the recorded child is killed if it survived and, if liveness is unconfirmed, the prefix
@@ -1393,6 +1414,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           )
           if (!reseeded) throw error
           const retrySelected = this.cacheForBundle(spec, reseeded)
+          await this.seedBundleCache(reseeded, retrySelected.cache)
           await runCreate(reseeded.lockPath, retrySelected.cache, retrySelected.budget)
         }
       }


### PR DESCRIPTION
## Problem

On Windows, runtime pack tarballs were verified into the runtime-root package cache while micromamba was configured through CONDA_PKGS_DIRS to consume a separate short-path cache. When the selected cache lacked a package such as nomkl, compatibility micromamba attempted conda-forge despite the offline create flow and failed whenever that route was unavailable.

## Proposed change

- Retain the verified package source directory in production runtime bundles.
- Seed the actual selected micromamba cache before create, upgrade, and retry operations.
- Keep the existing runtime-root cache helper as a backward-compatible wrapper.
- Add a regression test that reproduces the nomkl offline timeout when the selected Windows cache is empty.

## Scope and non-goals

This change is limited to notebook runtime pack cache placement. It does not change proxy or VPN configuration, online fallback policy, runtime lock contents, or micromamba version selection. It also does not address the separate access-violation failure observed from the packaged primary micromamba binary.

## Acceptance criteria and validation

Final Test Impact Set, run after the last material edit:

- Relevant notebook suite: 5 files and 121 tests passed.
- Provisioner suite in isolation: 88 tests passed.
- npm run typecheck:node passed.
- npm run lint passed with 17 pre-existing warnings outside the changed files.
- git diff --check passed.

The full npm test fallback completed with 903 of 924 files and 12961 of 13271 tests passing. Its 35 failures were Windows symlink or ACL permission failures, workflow-fixture failures, and full-concurrency timeouts. The five provisioner timeouts from that run all passed when the provisioner suite was rerun in isolation.

Uncovered risk: no end-to-end provision was run on the originally affected Windows installation. CI and independent review remain authoritative before this change is considered fully verified.

## Review focus

Please focus on whether every production bundle path retains a verified package source, whether seeding occurs before every micromamba create or upgrade attempt, and whether the physical cache lock comparison safely avoids redundant reseeding.