### PR TITLE
fix(acp): preserve restored continuation provenance

### DIFF
--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -50,7 +50,7 @@ const createDependencies = (): AcpApplicationCommandDependencies => ({
     cancelPrompt: vi.fn(async () => snapshot),
     deleteSession: vi.fn(async () => snapshot),
     respondToPermission: vi.fn(async () => snapshot),
-    respondToElicitation: vi.fn(() => snapshot),
+    respondToElicitation: vi.fn(async () => snapshot),
     getSessionPlanProjection: vi.fn(async () => null),
     respondSessionPlan: vi.fn(async () => ({ projection: {} as never, changed: true })),
     setPermissionProfile: vi.fn(async () => snapshot),

--- a/src/main/acp/client-interaction-owner.test.ts
+++ b/src/main/acp/client-interaction-owner.test.ts
@@ -1,0 +1,184 @@
+import type {
+  CreateElicitationRequest,
+  CreateElicitationResponse,
+  RequestPermissionRequest,
+  RequestPermissionResponse
+} from '@agentclientprotocol/sdk'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AgentFrameworkId } from '../../shared/settings'
+import { AcpClientInteractionOwner } from './client-interaction-owner'
+
+const elicitationRequest = (): CreateElicitationRequest => ({
+  mode: 'form',
+  sessionId: 'provider-session',
+  toolCallId: 'ask-1',
+  message: 'Choose an approach',
+  requestedSchema: {
+    type: 'object',
+    properties: {
+      question_0: { type: 'string', enum: ['minimal', 'expanded'] }
+    }
+  }
+})
+
+const permissionRequest = (): RequestPermissionRequest => ({
+  sessionId: 'provider-session',
+  toolCall: {
+    toolCallId: 'tool-1',
+    title: 'Run command',
+    kind: 'execute',
+    status: 'pending'
+  },
+  options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+})
+
+const codexApprovalRequest = (): CreateElicitationRequest => ({
+  ...elicitationRequest(),
+  toolCallId: 'mcp-tool-1',
+  message: 'Allow this MCP tool?',
+  _meta: { codex_approval_kind: 'mcp_tool_call' }
+})
+
+const createOwner = (
+  options: {
+    frameworkId?: AgentFrameworkId
+    hasTrustedCodexMcpToolCall?: boolean
+    consumeTrustedCodexMcpToolCall?: boolean
+  } = {}
+): {
+  owner: AcpClientInteractionOwner
+  requestElicitation: ReturnType<typeof vi.fn>
+  requestPermission: ReturnType<typeof vi.fn>
+  consumeTrustedCodexMcpToolCall: ReturnType<typeof vi.fn>
+  hasTrustedCodexMcpToolCall: ReturnType<typeof vi.fn>
+} => {
+  const requestElicitation = vi
+    .fn<(request: CreateElicitationRequest) => Promise<CreateElicitationResponse>>()
+    .mockResolvedValue({ action: 'accept', content: { question_0: 'minimal' } })
+  const requestPermission = vi
+    .fn<(request: RequestPermissionRequest) => Promise<RequestPermissionResponse>>()
+    .mockImplementation(async (request) => ({
+      outcome: { outcome: 'selected', optionId: request.options[0].optionId }
+    }))
+  const consumeTrustedCodexMcpToolCall = vi.fn(
+    () => options.consumeTrustedCodexMcpToolCall ?? false
+  )
+  const hasTrustedCodexMcpToolCall = vi.fn(() => options.hasTrustedCodexMcpToolCall ?? false)
+  const owner = new AcpClientInteractionOwner({
+    routing: {
+      resolveAppSessionId: () => 'app-session',
+      isActiveSession: () => true,
+      frameworkForSession: () => options.frameworkId ?? 'claude-code',
+      promptMessageIdForSession: () => 'prompt-1'
+    },
+    elicitation: { request: requestElicitation },
+    permission: {
+      handleProviderRequest: requestPermission,
+      consumeTrustedCodexMcpToolCall,
+      hasTrustedCodexMcpToolCall
+    }
+  })
+
+  return {
+    owner,
+    requestElicitation,
+    requestPermission,
+    consumeTrustedCodexMcpToolCall,
+    hasTrustedCodexMcpToolCall
+  }
+}
+
+describe('ACP client interaction owner', () => {
+  it.each<AgentFrameworkId>(['claude-code', 'opencode', 'codex'])(
+    'routes an ordinary %s elicitation to structured user input',
+    async (frameworkId) => {
+      const { owner, requestElicitation, requestPermission } = createOwner({ frameworkId })
+      const request = elicitationRequest()
+
+      await expect(owner.createElicitation(request)).resolves.toEqual({
+        action: 'accept',
+        content: { question_0: 'minimal' }
+      })
+
+      expect(requestElicitation).toHaveBeenCalledWith(
+        request,
+        { sessionId: 'app-session' },
+        { promptMessageId: 'prompt-1' }
+      )
+      expect(requestPermission).not.toHaveBeenCalled()
+    }
+  )
+
+  it('silently accepts the trusted Codex user-choice tool approval', async () => {
+    const { owner, requestElicitation, requestPermission } = createOwner({
+      frameworkId: 'codex',
+      consumeTrustedCodexMcpToolCall: true
+    })
+    const request = codexApprovalRequest()
+
+    await expect(owner.createElicitation(request)).resolves.toEqual({ action: 'accept' })
+
+    expect(requestElicitation).not.toHaveBeenCalled()
+    expect(requestPermission).not.toHaveBeenCalled()
+  })
+
+  it('routes a provider permission request to authorization', async () => {
+    const { owner, requestElicitation, requestPermission } = createOwner()
+    const request = permissionRequest()
+
+    await expect(owner.requestPermission(request)).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow-once' }
+    })
+
+    expect(requestPermission).toHaveBeenCalledWith(request)
+    expect(requestElicitation).not.toHaveBeenCalled()
+  })
+
+  it('routes a trusted Codex MCP approval elicitation to authorization', async () => {
+    const { owner, requestElicitation, requestPermission } = createOwner({
+      frameworkId: 'codex',
+      hasTrustedCodexMcpToolCall: true
+    })
+
+    await expect(owner.createElicitation(codexApprovalRequest())).resolves.toEqual({
+      action: 'accept'
+    })
+
+    expect(requestPermission).toHaveBeenCalledWith({
+      sessionId: 'provider-session',
+      toolCall: { toolCallId: 'mcp-tool-1', kind: 'execute', status: 'pending' },
+      options: [
+        {
+          optionId: 'codex-elicitation-allow-once',
+          name: 'Allow once',
+          kind: 'allow_once'
+        },
+        {
+          optionId: 'codex-elicitation-reject-once',
+          name: 'Deny',
+          kind: 'reject_once'
+        }
+      ],
+      _meta: { is_mcp_tool_approval: true }
+    })
+    expect(requestElicitation).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['an untrusted Codex approval', 'codex' as const, false],
+    ['Codex approval metadata from another framework', 'claude-code' as const, true]
+  ])('fails closed for %s', async (_case, frameworkId, hasTrustedCodexMcpToolCall) => {
+    const { owner, requestElicitation, requestPermission } = createOwner({
+      frameworkId,
+      hasTrustedCodexMcpToolCall
+    })
+
+    await expect(owner.createElicitation(codexApprovalRequest())).resolves.toEqual({
+      action: 'cancel'
+    })
+
+    expect(requestElicitation).not.toHaveBeenCalled()
+    expect(requestPermission).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/acp/client-interaction-owner.ts
+++ b/src/main/acp/client-interaction-owner.ts
@@ -1,0 +1,114 @@
+import type {
+  CreateElicitationRequest,
+  CreateElicitationResponse,
+  RequestPermissionRequest,
+  RequestPermissionResponse
+} from '@agentclientprotocol/sdk'
+
+import type { AgentFrameworkId } from '../../shared/settings'
+import type { AcpElicitationOwner } from './elicitation-owner'
+import type { AcpPermissionContext } from './permission-context'
+
+type AcpClientInteractionOwnerOptions = {
+  routing: {
+    resolveAppSessionId: (providerSessionId: string) => string
+    isActiveSession: (appSessionId: string) => boolean
+    frameworkForSession: (appSessionId: string) => AgentFrameworkId | undefined
+    promptMessageIdForSession: (appSessionId: string) => string | undefined
+  }
+  elicitation: Pick<AcpElicitationOwner, 'request'>
+  permission: Pick<
+    AcpPermissionContext,
+    'consumeTrustedCodexMcpToolCall' | 'handleProviderRequest' | 'hasTrustedCodexMcpToolCall'
+  >
+}
+
+type ElicitationIntent =
+  { kind: 'authorization'; toolCallId: string } | { kind: 'user-input' } | { kind: 'reject' }
+
+const classifyElicitation = (
+  frameworkId: AgentFrameworkId | undefined,
+  params: CreateElicitationRequest
+): ElicitationIntent => {
+  const meta = params._meta
+  const isCodexMcpApproval =
+    typeof meta === 'object' && meta !== null && meta.codex_approval_kind === 'mcp_tool_call'
+  if (!isCodexMcpApproval) return { kind: 'user-input' }
+  if (frameworkId !== 'codex') return { kind: 'reject' }
+
+  const toolCallId = 'toolCallId' in params ? params.toolCallId : undefined
+  return typeof toolCallId === 'string' ? { kind: 'authorization', toolCallId } : { kind: 'reject' }
+}
+
+// Keeps provider transport quirks at one seam so authorization can never be projected as user input.
+class AcpClientInteractionOwner {
+  constructor(private readonly options: AcpClientInteractionOwnerOptions) {}
+
+  createElicitation(params: CreateElicitationRequest): Promise<CreateElicitationResponse> {
+    if (!('sessionId' in params) || typeof params.sessionId !== 'string') {
+      return Promise.resolve({ action: 'cancel' })
+    }
+
+    const sessionId = this.options.routing.resolveAppSessionId(params.sessionId)
+    if (!this.options.routing.isActiveSession(sessionId)) {
+      return Promise.resolve({ action: 'cancel' })
+    }
+
+    const intent = classifyElicitation(this.options.routing.frameworkForSession(sessionId), params)
+    if (intent.kind === 'reject') return Promise.resolve({ action: 'cancel' })
+    if (intent.kind === 'authorization') {
+      return this.requestCodexMcpAuthorization(params.sessionId, sessionId, intent.toolCallId)
+    }
+
+    const promptMessageId = this.options.routing.promptMessageIdForSession(sessionId)
+    return this.options.elicitation.request(
+      params,
+      { sessionId },
+      promptMessageId ? { promptMessageId } : undefined
+    )
+  }
+
+  requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
+    return this.options.permission.handleProviderRequest(params)
+  }
+
+  private async requestCodexMcpAuthorization(
+    providerSessionId: string,
+    appSessionId: string,
+    toolCallId: string
+  ): Promise<CreateElicitationResponse> {
+    if (
+      this.options.permission.consumeTrustedCodexMcpToolCall(
+        appSessionId,
+        toolCallId,
+        'open-science-notebook/ask_user_question'
+      )
+    ) {
+      return { action: 'accept' }
+    }
+    if (!this.options.permission.hasTrustedCodexMcpToolCall(appSessionId, toolCallId)) {
+      return { action: 'cancel' }
+    }
+
+    const allowOnceOptionId = 'codex-elicitation-allow-once'
+    const response = await this.options.permission.handleProviderRequest({
+      sessionId: providerSessionId,
+      toolCall: { toolCallId, kind: 'execute', status: 'pending' },
+      options: [
+        { optionId: allowOnceOptionId, name: 'Allow once', kind: 'allow_once' },
+        {
+          optionId: 'codex-elicitation-reject-once',
+          name: 'Deny',
+          kind: 'reject_once'
+        }
+      ],
+      _meta: { is_mcp_tool_approval: true }
+    })
+    if (response.outcome.outcome === 'cancelled') return { action: 'cancel' }
+    return response.outcome.optionId === allowOnceOptionId
+      ? { action: 'accept' }
+      : { action: 'decline' }
+  }
+}
+
+export { AcpClientInteractionOwner }

--- a/src/main/acp/durable-continuation-context-owner.test.ts
+++ b/src/main/acp/durable-continuation-context-owner.test.ts
@@ -236,9 +236,33 @@ describe('AcpDurableContinuationContextOwner', () => {
     )
     durable.activities = []
     durable.status = 'idle'
+    const revisionInput = {
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      requestId: 'choice-1',
+      toolCallId: 'renderer-forged-revision-tool',
+      action: 'accept' as const,
+      answers: [{ fieldId: 'question_0', value: 'Expanded' }],
+      replacePreviousAnswer: true
+    }
+    const invalidActivityOwner = structuredClone(durable)
+    invalidActivityOwner.conversationGraph!.activities.find(
+      (activity) => activity.id === 'tool-choice-1'
+    )!.messageBranchId = 'message-branch-revision'
+    await expect(
+      createOwner(invalidActivityOwner).prepareElicitation(revisionInput)
+    ).rejects.toThrow('active Session Branch')
+
     const appendUserMessageToInteraction = async (
       command: Parameters<SessionPersistenceCoordinator['appendUserMessageToInteraction']>[0]
     ): Promise<PersistedChatMessage> => {
+      const staleAuthority = structuredClone(durable)
+      staleAuthority.conversationGraph!.activities.find(
+        (activity) => activity.id === 'tool-choice-1'
+      )!.elicitation!.fields[0].label = 'Changed concurrently'
+      expect(() => command.beforePersist?.(staleAuthority)).toThrow(
+        'revision authority changed before commit'
+      )
       command.beforePersist?.(structuredClone(durable))
       const revisedPrompt: PersistedChatMessage = {
         id: 'prompt-revision',
@@ -267,15 +291,7 @@ describe('AcpDurableContinuationContextOwner', () => {
       appendUserMessageToInteraction: vi.fn(appendUserMessageToInteraction)
     })
 
-    const prepared = await owner.prepareElicitation({
-      projectId: 'project-1',
-      sessionId: 'session-1',
-      requestId: 'choice-1',
-      toolCallId: 'renderer-forged-revision-tool',
-      action: 'accept',
-      answers: [{ fieldId: 'question_0', value: 'Expanded' }],
-      replacePreviousAnswer: true
-    })
+    const prepared = await owner.prepareElicitation(revisionInput)
 
     expect(prepared.request).toMatchObject({
       requestId: 'choice-1',

--- a/src/main/acp/durable-continuation-context-owner.test.ts
+++ b/src/main/acp/durable-continuation-context-owner.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { createLinearConversationGraph } from '../../shared/conversation-graph'
-import type { PersistedChatMessage, PersistedChatSession } from '../../shared/session-persistence'
+import type {
+  PersistedChatMessage,
+  PersistedChatSession,
+  PersistedToolActivity
+} from '../../shared/session-persistence'
 import { AcpDurableContinuationContextOwner } from './durable-continuation-context-owner'
 
 const message = (id: string, content: string): PersistedChatMessage => ({
@@ -14,30 +18,60 @@ const message = (id: string, content: string): PersistedChatMessage => ({
   updatedAt: 1
 })
 
+const createSession = (
+  messages: PersistedChatMessage[],
+  graphMessages = messages
+): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Restored task',
+  cwd: '/workspace',
+  status: 'waiting-for-user',
+  messages,
+  conversationGraph: createLinearConversationGraph({
+    sessionId: 'pending-session',
+    messages: graphMessages,
+    frameworkId: 'claude-code',
+    createdAt: 1,
+    updatedAt: 1
+  }),
+  createdAt: 1,
+  updatedAt: 1
+})
+
+const pendingChoice = (overrides: Partial<PersistedToolActivity> = {}): PersistedToolActivity => ({
+  id: 'tool-choice-1',
+  kind: 'tool',
+  title: 'Choose an approach',
+  status: 'in_progress',
+  sortIndex: 0,
+  eventIds: [],
+  promptMessageId: 'prompt-active',
+  elicitation: {
+    message: 'Choose an approach',
+    fields: [{ id: 'question_0', label: 'Approach', kind: 'text' }],
+    state: 'pending',
+    durable: {
+      kind: 'agent-user-choice',
+      requestId: 'choice-1',
+      promptMessageId: 'prompt-active'
+    }
+  },
+  createdAt: 2,
+  updatedAt: 2,
+  ...overrides
+})
+
+const createOwner = (session: PersistedChatSession): AcpDurableContinuationContextOwner =>
+  new AcpDurableContinuationContextOwner({
+    loadSessionForContinuation: vi.fn(async () => structuredClone(session))
+  })
+
 describe('AcpDurableContinuationContextOwner', () => {
   it('rejects an originating prompt that is no longer on the active Message Branch', async () => {
     const inactivePrompt = message('prompt-inactive', 'Use the abandoned approach.')
     const activePrompt = message('prompt-active', 'Use the revised approach.')
-    const session: PersistedChatSession = {
-      id: 'session-1',
-      projectId: 'project-1',
-      title: 'Branched task',
-      cwd: '/workspace',
-      status: 'waiting-permission',
-      messages: [inactivePrompt, activePrompt],
-      conversationGraph: createLinearConversationGraph({
-        sessionId: 'pending-session',
-        messages: [activePrompt],
-        frameworkId: 'claude-code',
-        createdAt: 1,
-        updatedAt: 1
-      }),
-      createdAt: 1,
-      updatedAt: 1
-    }
-    const owner = new AcpDurableContinuationContextOwner({
-      loadSessionForContinuation: vi.fn(async () => structuredClone(session))
-    })
+    const owner = createOwner(createSession([inactivePrompt, activePrompt], [activePrompt]))
 
     await expect(
       owner.prepare({
@@ -46,5 +80,91 @@ describe('AcpDurableContinuationContextOwner', () => {
         promptMessageId: 'prompt-inactive'
       })
     ).rejects.toThrow('active Message Branch')
+  })
+
+  it('rejects an inherited prompt that was introduced on an ancestor Branch', async () => {
+    const prompt = message('prompt-active', 'Choose an approach.')
+    const session = createSession([prompt])
+    const graph = session.conversationGraph!
+    const frame = graph.frames[0]
+    const parentBranch = graph.branches[0]
+    graph.branches.push({
+      id: 'message-branch-revised-choice',
+      agentFrameId: frame.id,
+      parentBranchId: parentBranch.id,
+      forkMessageId: prompt.id,
+      headMessageId: prompt.id,
+      createdAt: 2,
+      updatedAt: 2
+    })
+    frame.activeBranchId = 'message-branch-revised-choice'
+
+    await expect(
+      createOwner(session).prepare({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        promptMessageId: prompt.id
+      })
+    ).rejects.toThrow('active Message Branch')
+  })
+
+  it('restores an elicitation from the canonical pending Session activity', async () => {
+    const session = createSession([message('prompt-active', 'Choose an approach.')])
+    session.activities = [pendingChoice()]
+
+    await expect(
+      createOwner(session).prepareElicitation({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        requestId: 'choice-1',
+        toolCallId: 'tool-choice-1'
+      })
+    ).resolves.toMatchObject({
+      request: {
+        requestId: 'choice-1',
+        sessionId: 'session-1',
+        toolCallId: 'tool-choice-1',
+        message: 'Choose an approach',
+        fields: [{ id: 'question_0', label: 'Approach', kind: 'text' }],
+        durable: { promptMessageId: 'prompt-active' }
+      },
+      provenanceContext: {
+        rootFrameId: 'root-frame-pending-session',
+        messageBranchId: 'message-branch-pending-session',
+        promptMessageId: 'prompt-active'
+      }
+    })
+  })
+
+  it.each([
+    ['missing', []],
+    [
+      'stale',
+      [
+        pendingChoice({
+          elicitation: {
+            ...pendingChoice().elicitation!,
+            durable: {
+              kind: 'agent-user-choice',
+              requestId: 'choice-newer',
+              promptMessageId: 'prompt-active'
+            }
+          }
+        })
+      ]
+    ],
+    ['duplicated', [pendingChoice(), pendingChoice()]]
+  ] as const)('rejects a %s durable elicitation correlation', async (_case, activities) => {
+    const session = createSession([message('prompt-active', 'Choose an approach.')])
+    session.activities = structuredClone([...activities])
+
+    await expect(
+      createOwner(session).prepareElicitation({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        requestId: 'choice-1',
+        toolCallId: 'tool-choice-1'
+      })
+    ).rejects.toThrow('pending Session activity')
   })
 })

--- a/src/main/acp/durable-continuation-context-owner.test.ts
+++ b/src/main/acp/durable-continuation-context-owner.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createLinearConversationGraph } from '../../shared/conversation-graph'
+import {
+  createLinearConversationGraph,
+  forkConversationAfterActivity,
+  synchronizeActiveConversationActivities,
+  synchronizeActiveConversationMessages
+} from '../../shared/conversation-graph'
 import type {
   PersistedChatMessage,
   PersistedChatSession,
   PersistedToolActivity
 } from '../../shared/session-persistence'
+import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
 import { AcpDurableContinuationContextOwner } from './durable-continuation-context-owner'
 
 const message = (id: string, content: string): PersistedChatMessage => ({
@@ -67,6 +73,16 @@ const createOwner = (session: PersistedChatSession): AcpDurableContinuationConte
     loadSessionForContinuation: vi.fn(async () => structuredClone(session))
   })
 
+const setActivities = (
+  session: PersistedChatSession,
+  activities: PersistedToolActivity[]
+): void => {
+  session.activities = activities
+  session.conversationGraph = structuredClone(
+    synchronizeActiveConversationActivities(session.conversationGraph!, activities, [])
+  )
+}
+
 describe('AcpDurableContinuationContextOwner', () => {
   it('rejects an originating prompt that is no longer on the active Message Branch', async () => {
     const inactivePrompt = message('prompt-inactive', 'Use the abandoned approach.')
@@ -110,14 +126,16 @@ describe('AcpDurableContinuationContextOwner', () => {
 
   it('restores an elicitation from the canonical pending Session activity', async () => {
     const session = createSession([message('prompt-active', 'Choose an approach.')])
-    session.activities = [pendingChoice()]
+    setActivities(session, [pendingChoice()])
 
     await expect(
       createOwner(session).prepareElicitation({
         projectId: 'project-1',
         sessionId: 'session-1',
         requestId: 'choice-1',
-        toolCallId: 'tool-choice-1'
+        toolCallId: 'tool-choice-1',
+        action: 'accept',
+        answers: [{ fieldId: 'question_0', value: 'Expanded' }]
       })
     ).resolves.toMatchObject({
       request: {
@@ -153,18 +171,127 @@ describe('AcpDurableContinuationContextOwner', () => {
         })
       ]
     ],
-    ['duplicated', [pendingChoice(), pendingChoice()]]
+    ['duplicated', [pendingChoice(), pendingChoice({ id: 'tool-choice-2' })]]
   ] as const)('rejects a %s durable elicitation correlation', async (_case, activities) => {
     const session = createSession([message('prompt-active', 'Choose an approach.')])
-    session.activities = structuredClone([...activities])
+    setActivities(session, structuredClone([...activities]))
 
     await expect(
       createOwner(session).prepareElicitation({
         projectId: 'project-1',
         sessionId: 'session-1',
         requestId: 'choice-1',
-        toolCallId: 'tool-choice-1'
+        toolCallId: 'tool-choice-1',
+        action: 'accept',
+        answers: [{ fieldId: 'question_0', value: 'Expanded' }]
       })
     ).rejects.toThrow('pending Session activity')
+  })
+
+  it('rejects a flat elicitation projection that disagrees with the active graph', async () => {
+    const session = createSession([message('prompt-active', 'Choose an approach.')])
+    setActivities(session, [pendingChoice()])
+    session.activities![0].elicitation!.message = 'Stale renderer projection'
+
+    await expect(
+      createOwner(session).prepareElicitation({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        requestId: 'choice-1',
+        toolCallId: 'tool-choice-1',
+        action: 'accept',
+        answers: [{ fieldId: 'question_0', value: 'Expanded' }]
+      })
+    ).rejects.toThrow('pending Session activity')
+  })
+
+  it('validates a revision fork and creates Main-owned prompt and tool-call identities', async () => {
+    const prompt = message('prompt-active', 'Choose an approach.')
+    const preamble: PersistedChatMessage = {
+      id: 'agent-question-preamble',
+      role: 'agent',
+      content: 'Please choose one option.',
+      status: 'complete',
+      responseToMessageId: prompt.id,
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    let durable = createSession([prompt, preamble])
+    const answeredChoice = pendingChoice({
+      status: 'completed',
+      elicitation: {
+        ...pendingChoice().elicitation!,
+        state: 'answered',
+        answers: [{ fieldId: 'question_0', value: 'Minimal' }]
+      }
+    })
+    setActivities(durable, [answeredChoice])
+    durable.conversationGraph = forkConversationAfterActivity(
+      durable.conversationGraph!,
+      preamble.id,
+      answeredChoice.id,
+      'message-branch-revision',
+      3
+    )
+    durable.activities = []
+    durable.status = 'idle'
+    const appendUserMessageToInteraction = async (
+      command: Parameters<SessionPersistenceCoordinator['appendUserMessageToInteraction']>[0]
+    ): Promise<PersistedChatMessage> => {
+      command.beforePersist?.(structuredClone(durable))
+      const revisedPrompt: PersistedChatMessage = {
+        id: 'prompt-revision',
+        role: 'user',
+        content: command.content,
+        status: 'complete',
+        responseToMessageId: command.interactionId,
+        eventIds: [],
+        createdAt: 4,
+        updatedAt: 4
+      }
+      durable = {
+        ...durable,
+        messages: [...durable.messages, revisedPrompt],
+        conversationGraph: synchronizeActiveConversationMessages(
+          durable.conversationGraph!,
+          [...durable.messages, revisedPrompt],
+          4
+        ),
+        updatedAt: 4
+      }
+      return structuredClone(revisedPrompt)
+    }
+    const owner = new AcpDurableContinuationContextOwner({
+      loadSessionForContinuation: vi.fn(async () => structuredClone(durable)),
+      appendUserMessageToInteraction: vi.fn(appendUserMessageToInteraction)
+    })
+
+    const prepared = await owner.prepareElicitation({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      requestId: 'choice-1',
+      toolCallId: 'renderer-forged-revision-tool',
+      action: 'accept',
+      answers: [{ fieldId: 'question_0', value: 'Expanded' }],
+      replacePreviousAnswer: true
+    })
+
+    expect(prepared.request).toMatchObject({
+      requestId: 'choice-1',
+      sessionId: 'session-1',
+      toolCallId: expect.stringMatching(/^ask-user-question-revision-/),
+      durable: { promptMessageId: 'prompt-revision' }
+    })
+    expect(prepared.request.toolCallId).not.toBe('renderer-forged-revision-tool')
+    expect(prepared.provenanceContext).toMatchObject({
+      messageBranchId: 'message-branch-revision',
+      promptMessageId: 'prompt-revision'
+    })
+    expect(durable.messages.at(-1)).toMatchObject({
+      id: 'prompt-revision',
+      responseToMessageId: 'agent-question-preamble',
+      content: expect.stringContaining('Approach: Expanded')
+    })
   })
 })

--- a/src/main/acp/durable-continuation-context-owner.test.ts
+++ b/src/main/acp/durable-continuation-context-owner.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createLinearConversationGraph } from '../../shared/conversation-graph'
+import type { PersistedChatMessage, PersistedChatSession } from '../../shared/session-persistence'
+import { AcpDurableContinuationContextOwner } from './durable-continuation-context-owner'
+
+const message = (id: string, content: string): PersistedChatMessage => ({
+  id,
+  role: 'user',
+  content,
+  status: 'complete',
+  eventIds: [],
+  createdAt: 1,
+  updatedAt: 1
+})
+
+describe('AcpDurableContinuationContextOwner', () => {
+  it('rejects an originating prompt that is no longer on the active Message Branch', async () => {
+    const inactivePrompt = message('prompt-inactive', 'Use the abandoned approach.')
+    const activePrompt = message('prompt-active', 'Use the revised approach.')
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Branched task',
+      cwd: '/workspace',
+      status: 'waiting-permission',
+      messages: [inactivePrompt, activePrompt],
+      conversationGraph: createLinearConversationGraph({
+        sessionId: 'pending-session',
+        messages: [activePrompt],
+        frameworkId: 'claude-code',
+        createdAt: 1,
+        updatedAt: 1
+      }),
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const owner = new AcpDurableContinuationContextOwner({
+      loadSessionForContinuation: vi.fn(async () => structuredClone(session))
+    })
+
+    await expect(
+      owner.prepare({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        promptMessageId: 'prompt-inactive'
+      })
+    ).rejects.toThrow('active Message Branch')
+  })
+})

--- a/src/main/acp/durable-continuation-context-owner.test.ts
+++ b/src/main/acp/durable-continuation-context-owner.test.ts
@@ -205,7 +205,7 @@ describe('AcpDurableContinuationContextOwner', () => {
     ).rejects.toThrow('pending Session activity')
   })
 
-  it('validates a revision fork and creates Main-owned prompt and tool-call identities', async () => {
+  it('validates an inherited revision fork and creates Main-owned identities', async () => {
     const prompt = message('prompt-active', 'Choose an approach.')
     const preamble: PersistedChatMessage = {
       id: 'agent-question-preamble',
@@ -227,12 +227,25 @@ describe('AcpDurableContinuationContextOwner', () => {
       }
     })
     setActivities(durable, [answeredChoice])
+    const graph = durable.conversationGraph!
+    const frame = graph.frames[0]
+    const rootBranch = graph.branches[0]
+    graph.branches.push({
+      id: 'message-branch-intermediate',
+      agentFrameId: frame.id,
+      parentBranchId: rootBranch.id,
+      forkMessageId: preamble.id,
+      headMessageId: preamble.id,
+      createdAt: 3,
+      updatedAt: 3
+    })
+    frame.activeBranchId = 'message-branch-intermediate'
     durable.conversationGraph = forkConversationAfterActivity(
-      durable.conversationGraph!,
+      graph,
       preamble.id,
       answeredChoice.id,
       'message-branch-revision',
-      3
+      4
     )
     durable.activities = []
     durable.status = 'idle'

--- a/src/main/acp/durable-continuation-context-owner.ts
+++ b/src/main/acp/durable-continuation-context-owner.ts
@@ -1,26 +1,38 @@
+import { randomUUID } from 'node:crypto'
+import { isDeepStrictEqual } from 'node:util'
+
 import type { AcpPromptRequest } from '../../shared/acp'
 import {
   getActiveConversationContext,
+  resolveActiveConversationActivities,
   resolveMessageBranchPath
 } from '../../shared/conversation-graph'
+import type { ElicitationAnswer, PendingElicitationRequest } from '../../shared/elicitation'
 import type { HistoryReplayDescriptor } from '../../shared/history-preamble'
 import {
   buildSessionHistoryReplay,
   type SessionHistoryReplay
 } from '../../shared/session-history-replay'
-import type { PendingElicitationRequest } from '../../shared/elicitation'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import { validateElicitationAnswers } from './elicitation-owner'
 
-type DurableContinuationSessions = Pick<SessionPersistenceCoordinator, 'loadSessionForContinuation'>
+type DurableContinuationSessions = Pick<
+  SessionPersistenceCoordinator,
+  'loadSessionForContinuation'
+> &
+  Partial<Pick<SessionPersistenceCoordinator, 'appendUserMessageToInteraction'>>
 
 type DurableContinuationPreparation = Readonly<{
   provenanceContext: NonNullable<AcpPromptRequest['provenanceContext']>
   historyReplay?: SessionHistoryReplay
 }>
 
-type DurableElicitationContinuationPreparation = DurableContinuationPreparation &
-  Readonly<{ request: PendingElicitationRequest }>
+type DurableElicitationContinuationPreparation = Readonly<{
+  request: PendingElicitationRequest
+  provenanceContext?: DurableContinuationPreparation['provenanceContext']
+  historyReplay?: SessionHistoryReplay
+}>
 
 type DurableContinuationReplay = {
   descriptor: HistoryReplayDescriptor
@@ -45,43 +57,205 @@ class AcpDurableContinuationContextOwner {
     sessionId: string
     requestId: string
     toolCallId: string
+    action: 'accept' | 'decline' | 'cancel'
+    answers?: ElicitationAnswer[]
+    replacePreviousAnswer?: boolean
     replay?: DurableContinuationReplay
   }): Promise<DurableElicitationContinuationPreparation> {
     const session = await this.loadSession(input.projectId, input.sessionId)
-    const matches = (session.activities ?? []).filter(
+    if (input.replacePreviousAnswer) {
+      return this.prepareElicitationRevision(session, input)
+    }
+    const authority = this.resolvePendingElicitation(session, input)
+    const continuation = this.prepareFromSession(session, authority.promptMessageId, input.replay)
+    return {
+      ...continuation,
+      request: this.canonicalRequest(session.id, authority)
+    }
+  }
+
+  private resolvePendingElicitation(
+    session: PersistedChatSession,
+    input: Pick<
+      Parameters<AcpDurableContinuationContextOwner['prepareElicitation']>[0],
+      'requestId' | 'toolCallId'
+    >
+  ): {
+    activityId: string
+    message: string
+    fields: PendingElicitationRequest['fields']
+    durable: NonNullable<PendingElicitationRequest['durable']>
+    promptMessageId: string
+  } {
+    const graph = session.conversationGraph
+    if (!graph || session.status !== 'waiting-for-user') {
+      throw new Error('Durable elicitation no longer matches the pending Session activity.')
+    }
+    const visible = resolveActiveConversationActivities(graph).activities.filter(
       (activity) =>
-        activity.id === input.toolCallId &&
         activity.elicitation?.state === 'pending' &&
         activity.elicitation.durable?.kind === 'agent-user-choice' &&
         activity.elicitation.durable.requestId === input.requestId
     )
-    if (matches.length !== 1) {
+    const activity =
+      visible.length === 1 && visible[0].id === input.toolCallId ? visible[0] : undefined
+    const graphActivity = activity
+      ? graph.activities.find((candidate) => candidate.id === activity.id)
+      : undefined
+    const flatMatches = activity
+      ? (session.activities ?? []).filter((candidate) => candidate.id === activity.id)
+      : []
+    const flatActivity = flatMatches.length === 1 ? flatMatches[0] : undefined
+    if (
+      !activity ||
+      !graphActivity ||
+      !flatActivity ||
+      !isDeepStrictEqual(flatActivity.elicitation, activity.elicitation) ||
+      (flatActivity.promptMessageId !== undefined &&
+        flatActivity.promptMessageId !== graphActivity.promptMessageId) ||
+      flatActivity.title !== activity.title ||
+      flatActivity.status !== activity.status ||
+      flatActivity.sortIndex !== activity.sortIndex
+    ) {
       throw new Error('Durable elicitation no longer matches the pending Session activity.')
     }
-    const activity = matches[0]
-    const projection = activity.elicitation!
+    const projection = graphActivity.elicitation!
     const durable = projection.durable!
-    const promptMessageId = activity.promptMessageId ?? durable.promptMessageId
-    if (
-      !promptMessageId ||
-      (activity.promptMessageId !== undefined &&
-        durable.promptMessageId !== undefined &&
-        activity.promptMessageId !== durable.promptMessageId)
-    ) {
+    const promptMessageId = graphActivity.promptMessageId
+    if (durable.promptMessageId && durable.promptMessageId !== promptMessageId) {
       throw new Error('Durable elicitation has inconsistent prompt authority.')
     }
-    const continuation = this.prepareFromSession(session, promptMessageId, input.replay)
+    return {
+      activityId: graphActivity.id,
+      message: projection.message,
+      fields: projection.fields,
+      durable,
+      promptMessageId
+    }
+  }
+
+  private async prepareElicitationRevision(
+    session: PersistedChatSession,
+    input: Parameters<AcpDurableContinuationContextOwner['prepareElicitation']>[0]
+  ): Promise<DurableElicitationContinuationPreparation> {
+    const authority = this.resolveElicitationRevision(session, input.requestId)
+    const toolCallId = `ask-user-question-revision-${randomUUID()}`
+    const originalRequest = this.canonicalRequest(session.id, {
+      ...authority,
+      activityId: toolCallId
+    })
+    if (input.action === 'cancel') return { request: originalRequest }
+    const answers =
+      input.action === 'accept'
+        ? validateElicitationAnswers(originalRequest, input.answers)
+        : undefined
+    if (!this.sessions?.appendUserMessageToInteraction) {
+      throw new Error('Durable elicitation revision authority is not available.')
+    }
+    const message = await this.sessions.appendUserMessageToInteraction({
+      projectId: input.projectId,
+      sessionId: input.sessionId,
+      interactionId: authority.interactionId,
+      content: this.revisionPromptContent(originalRequest, input.action, answers),
+      beforePersist: (latest) => {
+        const current = this.resolveElicitationRevision(latest, input.requestId)
+        if (
+          current.branchId !== authority.branchId ||
+          current.interactionId !== authority.interactionId
+        ) {
+          throw new Error('Durable elicitation revision authority changed before commit.')
+        }
+      }
+    })
+    const continuedSession = await this.loadSession(input.projectId, input.sessionId)
+    const continuation = this.prepareFromSession(continuedSession, message.id, input.replay)
     return {
       ...continuation,
       request: {
-        requestId: durable.requestId,
-        sessionId: session.id,
-        toolCallId: activity.id,
-        message: projection.message,
-        fields: structuredClone(projection.fields),
-        durable: structuredClone(durable)
+        ...originalRequest,
+        durable: { ...originalRequest.durable!, promptMessageId: message.id }
       }
     }
+  }
+
+  private resolveElicitationRevision(
+    session: PersistedChatSession,
+    requestId: string
+  ): {
+    activityId: string
+    branchId: string
+    interactionId: string
+    message: string
+    fields: PendingElicitationRequest['fields']
+    durable: NonNullable<PendingElicitationRequest['durable']>
+    promptMessageId: string
+  } {
+    const graph = session.conversationGraph
+    const frame = graph?.frames.find((candidate) => candidate.id === graph.activeFrameId)
+    const branch = graph?.branches.find((candidate) => candidate.id === frame?.activeBranchId)
+    const activity = branch?.forkActivityId
+      ? graph?.activities.find((candidate) => candidate.id === branch.forkActivityId)
+      : undefined
+    const projection = activity?.elicitation
+    const durable = projection?.durable
+    if (
+      !graph ||
+      session.status !== 'idle' ||
+      !branch?.forkActivityId ||
+      !branch.forkMessageId ||
+      branch.headMessageId !== branch.forkMessageId ||
+      !activity ||
+      projection?.state !== 'answered' ||
+      durable?.kind !== 'agent-user-choice' ||
+      durable.requestId !== requestId ||
+      (session.activities ?? []).some((candidate) => candidate.id === activity.id)
+    ) {
+      throw new Error('Durable elicitation revision no longer matches the active Session Branch.')
+    }
+    return {
+      activityId: activity.id,
+      branchId: branch.id,
+      interactionId: branch.forkMessageId,
+      message: projection.message,
+      fields: projection.fields,
+      durable,
+      promptMessageId: activity.promptMessageId
+    }
+  }
+
+  private canonicalRequest(
+    sessionId: string,
+    authority: {
+      activityId: string
+      message: string
+      fields: PendingElicitationRequest['fields']
+      durable: NonNullable<PendingElicitationRequest['durable']>
+      promptMessageId: string
+    }
+  ): PendingElicitationRequest {
+    return {
+      requestId: authority.durable.requestId,
+      sessionId,
+      toolCallId: authority.activityId,
+      message: authority.message,
+      fields: structuredClone(authority.fields),
+      durable: { ...structuredClone(authority.durable), promptMessageId: authority.promptMessageId }
+    }
+  }
+
+  private revisionPromptContent(
+    request: PendingElicitationRequest,
+    action: 'accept' | 'decline',
+    answers?: ElicitationAnswer[]
+  ): string {
+    if (action === 'decline')
+      return 'The user revised the previous structured answer by declining it.'
+    const fields = new Map(request.fields.map((field) => [field.id, field]))
+    const lines = (answers ?? []).map((answer) => {
+      const value = Array.isArray(answer.value) ? answer.value.join(', ') : String(answer.value)
+      return `${fields.get(answer.fieldId)?.label ?? answer.fieldId}: ${value}`
+    })
+    return ['The user revised the previous structured answer:', ...lines].join('\n')
   }
 
   private async loadSession(projectId: string, sessionId: string): Promise<PersistedChatSession> {

--- a/src/main/acp/durable-continuation-context-owner.ts
+++ b/src/main/acp/durable-continuation-context-owner.ts
@@ -1,0 +1,72 @@
+import type { AcpPromptRequest } from '../../shared/acp'
+import {
+  getActiveConversationContext,
+  resolveMessageBranchPath
+} from '../../shared/conversation-graph'
+import type { HistoryReplayDescriptor } from '../../shared/history-preamble'
+import {
+  buildSessionHistoryReplay,
+  type SessionHistoryReplay
+} from '../../shared/session-history-replay'
+import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+
+type DurableContinuationSessions = Pick<
+  SessionPersistenceCoordinator,
+  'loadSessionForContinuation'
+>
+
+type DurableContinuationPreparation = Readonly<{
+  provenanceContext: NonNullable<AcpPromptRequest['provenanceContext']>
+  historyReplay?: SessionHistoryReplay
+}>
+
+class AcpDurableContinuationContextOwner {
+  constructor(private readonly sessions?: DurableContinuationSessions) {}
+
+  async prepare(input: {
+    projectId: string
+    sessionId: string
+    promptMessageId: string
+    replay?: { descriptor: HistoryReplayDescriptor; supportsImageInput: boolean }
+  }): Promise<DurableContinuationPreparation> {
+    if (!this.sessions) throw new Error('Durable continuation Session authority is not available.')
+
+    const session = await this.sessions.loadSessionForContinuation(
+      input.projectId,
+      input.sessionId
+    )
+    const prompt = session.messages.find((message) => message.id === input.promptMessageId)
+    const graph = session.conversationGraph
+    const activeFrame = graph?.frames.find((frame) => frame.id === graph.activeFrameId)
+    const activeMessageIds =
+      graph && activeFrame
+        ? new Set(resolveMessageBranchPath(graph, activeFrame.activeBranchId).map(({ id }) => id))
+        : undefined
+    if (
+      session.id !== input.sessionId ||
+      session.projectId !== input.projectId ||
+      prompt?.role !== 'user' ||
+      !graph ||
+      !activeMessageIds?.has(input.promptMessageId)
+    ) {
+      throw new Error('Durable continuation no longer matches the active Message Branch.')
+    }
+
+    return {
+      provenanceContext: getActiveConversationContext(graph, input.promptMessageId),
+      ...(input.replay
+        ? {
+            historyReplay: buildSessionHistoryReplay(
+              session.messages,
+              input.replay.descriptor,
+              session.projectId,
+              input.replay.supportsImageInput
+            )
+          }
+        : {})
+    }
+  }
+}
+
+export { AcpDurableContinuationContextOwner }
+export type { DurableContinuationPreparation, DurableContinuationSessions }

--- a/src/main/acp/durable-continuation-context-owner.ts
+++ b/src/main/acp/durable-continuation-context-owner.ts
@@ -39,8 +39,13 @@ type DurableContinuationReplay = {
   supportsImageInput: boolean
 }
 
+type PublishDurableContinuationSession = (session: PersistedChatSession) => Promise<void> | void
+
 class AcpDurableContinuationContextOwner {
-  constructor(private readonly sessions?: DurableContinuationSessions) {}
+  constructor(
+    private readonly sessions?: DurableContinuationSessions,
+    private readonly publishSessionUpdated?: PublishDurableContinuationSession
+  ) {}
 
   async prepare(input: {
     projectId: string
@@ -159,16 +164,14 @@ class AcpDurableContinuationContextOwner {
       content: this.revisionPromptContent(originalRequest, input.action, answers),
       beforePersist: (latest) => {
         const current = this.resolveElicitationRevision(latest, input.requestId)
-        if (
-          current.branchId !== authority.branchId ||
-          current.interactionId !== authority.interactionId
-        ) {
+        if (!isDeepStrictEqual(current, authority)) {
           throw new Error('Durable elicitation revision authority changed before commit.')
         }
       }
     })
     const continuedSession = await this.loadSession(input.projectId, input.sessionId)
     const continuation = this.prepareFromSession(continuedSession, message.id, input.replay)
+    await this.publishSessionUpdated?.(structuredClone(continuedSession))
     return {
       ...continuation,
       request: {
@@ -193,21 +196,44 @@ class AcpDurableContinuationContextOwner {
     const graph = session.conversationGraph
     const frame = graph?.frames.find((candidate) => candidate.id === graph.activeFrameId)
     const branch = graph?.branches.find((candidate) => candidate.id === frame?.activeBranchId)
+    const parentBranch = graph?.branches.find(
+      (candidate) => candidate.id === branch?.parentBranchId
+    )
     const activity = branch?.forkActivityId
       ? graph?.activities.find((candidate) => candidate.id === branch.forkActivityId)
       : undefined
     const projection = activity?.elicitation
     const durable = projection?.durable
+    const parentPath = graph && parentBranch ? resolveMessageBranchPath(graph, parentBranch.id) : []
+    const prompt = activity
+      ? parentPath.find((candidate) => candidate.id === activity.promptMessageId)
+      : undefined
+    const runtimeSegment = activity
+      ? graph?.runtimeSegments.find((candidate) => candidate.id === activity.runtimeSegmentId)
+      : undefined
     if (
       !graph ||
       session.status !== 'idle' ||
+      !frame ||
       !branch?.forkActivityId ||
       !branch.forkMessageId ||
       branch.headMessageId !== branch.forkMessageId ||
+      !parentBranch ||
+      parentBranch.agentFrameId !== frame.id ||
       !activity ||
+      activity.agentFrameId !== frame.id ||
+      activity.messageBranchId !== parentBranch.id ||
+      !prompt ||
+      prompt.role !== 'user' ||
+      prompt.status !== 'complete' ||
+      prompt.agentFrameId !== frame.id ||
+      prompt.runtimeSegmentId !== activity.runtimeSegmentId ||
+      !runtimeSegment ||
+      runtimeSegment.agentFrameId !== frame.id ||
       projection?.state !== 'answered' ||
       durable?.kind !== 'agent-user-choice' ||
       durable.requestId !== requestId ||
+      durable.promptMessageId !== activity.promptMessageId ||
       (session.activities ?? []).some((candidate) => candidate.id === activity.id)
     ) {
       throw new Error('Durable elicitation revision no longer matches the active Session Branch.')

--- a/src/main/acp/durable-continuation-context-owner.ts
+++ b/src/main/acp/durable-continuation-context-owner.ts
@@ -4,6 +4,7 @@ import { isDeepStrictEqual } from 'node:util'
 import type { AcpPromptRequest } from '../../shared/acp'
 import {
   getActiveConversationContext,
+  type PersistedConversationGraph,
   resolveActiveConversationActivities,
   resolveMessageBranchPath
 } from '../../shared/conversation-graph'
@@ -40,6 +41,26 @@ type DurableContinuationReplay = {
 }
 
 type PublishDurableContinuationSession = (session: PersistedChatSession) => Promise<void> | void
+
+const isActivityVisibleOnBranch = (
+  graph: PersistedConversationGraph,
+  frameId: string,
+  branchId: string,
+  activityId: string
+): boolean => {
+  const candidate = structuredClone(graph)
+  const frame = candidate.frames.find((item) => item.id === frameId)
+  if (!frame) return false
+  candidate.activeFrameId = frame.id
+  frame.activeBranchId = branchId
+  try {
+    return resolveActiveConversationActivities(candidate).activities.some(
+      (activity) => activity.id === activityId
+    )
+  } catch {
+    return false
+  }
+}
 
 class AcpDurableContinuationContextOwner {
   constructor(
@@ -211,6 +232,10 @@ class AcpDurableContinuationContextOwner {
     const runtimeSegment = activity
       ? graph?.runtimeSegments.find((candidate) => candidate.id === activity.runtimeSegmentId)
       : undefined
+    const activityVisibleOnParent =
+      graph && frame && parentBranch && activity
+        ? isActivityVisibleOnBranch(graph, frame.id, parentBranch.id, activity.id)
+        : false
     if (
       !graph ||
       session.status !== 'idle' ||
@@ -222,7 +247,7 @@ class AcpDurableContinuationContextOwner {
       parentBranch.agentFrameId !== frame.id ||
       !activity ||
       activity.agentFrameId !== frame.id ||
-      activity.messageBranchId !== parentBranch.id ||
+      !activityVisibleOnParent ||
       !prompt ||
       prompt.role !== 'user' ||
       prompt.status !== 'complete' ||

--- a/src/main/acp/durable-continuation-context-owner.ts
+++ b/src/main/acp/durable-continuation-context-owner.ts
@@ -8,17 +8,24 @@ import {
   buildSessionHistoryReplay,
   type SessionHistoryReplay
 } from '../../shared/session-history-replay'
+import type { PendingElicitationRequest } from '../../shared/elicitation'
+import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
 
-type DurableContinuationSessions = Pick<
-  SessionPersistenceCoordinator,
-  'loadSessionForContinuation'
->
+type DurableContinuationSessions = Pick<SessionPersistenceCoordinator, 'loadSessionForContinuation'>
 
 type DurableContinuationPreparation = Readonly<{
   provenanceContext: NonNullable<AcpPromptRequest['provenanceContext']>
   historyReplay?: SessionHistoryReplay
 }>
+
+type DurableElicitationContinuationPreparation = DurableContinuationPreparation &
+  Readonly<{ request: PendingElicitationRequest }>
+
+type DurableContinuationReplay = {
+  descriptor: HistoryReplayDescriptor
+  supportsImageInput: boolean
+}
 
 class AcpDurableContinuationContextOwner {
   constructor(private readonly sessions?: DurableContinuationSessions) {}
@@ -27,40 +34,101 @@ class AcpDurableContinuationContextOwner {
     projectId: string
     sessionId: string
     promptMessageId: string
-    replay?: { descriptor: HistoryReplayDescriptor; supportsImageInput: boolean }
+    replay?: DurableContinuationReplay
   }): Promise<DurableContinuationPreparation> {
-    if (!this.sessions) throw new Error('Durable continuation Session authority is not available.')
+    const session = await this.loadSession(input.projectId, input.sessionId)
+    return this.prepareFromSession(session, input.promptMessageId, input.replay)
+  }
 
-    const session = await this.sessions.loadSessionForContinuation(
-      input.projectId,
-      input.sessionId
+  async prepareElicitation(input: {
+    projectId: string
+    sessionId: string
+    requestId: string
+    toolCallId: string
+    replay?: DurableContinuationReplay
+  }): Promise<DurableElicitationContinuationPreparation> {
+    const session = await this.loadSession(input.projectId, input.sessionId)
+    const matches = (session.activities ?? []).filter(
+      (activity) =>
+        activity.id === input.toolCallId &&
+        activity.elicitation?.state === 'pending' &&
+        activity.elicitation.durable?.kind === 'agent-user-choice' &&
+        activity.elicitation.durable.requestId === input.requestId
     )
-    const prompt = session.messages.find((message) => message.id === input.promptMessageId)
+    if (matches.length !== 1) {
+      throw new Error('Durable elicitation no longer matches the pending Session activity.')
+    }
+    const activity = matches[0]
+    const projection = activity.elicitation!
+    const durable = projection.durable!
+    const promptMessageId = activity.promptMessageId ?? durable.promptMessageId
+    if (
+      !promptMessageId ||
+      (activity.promptMessageId !== undefined &&
+        durable.promptMessageId !== undefined &&
+        activity.promptMessageId !== durable.promptMessageId)
+    ) {
+      throw new Error('Durable elicitation has inconsistent prompt authority.')
+    }
+    const continuation = this.prepareFromSession(session, promptMessageId, input.replay)
+    return {
+      ...continuation,
+      request: {
+        requestId: durable.requestId,
+        sessionId: session.id,
+        toolCallId: activity.id,
+        message: projection.message,
+        fields: structuredClone(projection.fields),
+        durable: structuredClone(durable)
+      }
+    }
+  }
+
+  private async loadSession(projectId: string, sessionId: string): Promise<PersistedChatSession> {
+    if (!this.sessions) throw new Error('Durable continuation Session authority is not available.')
+    const session = await this.sessions.loadSessionForContinuation(projectId, sessionId)
+    if (session.id !== sessionId || session.projectId !== projectId) {
+      throw new Error('Durable continuation Session identity does not match its authority.')
+    }
+    return session
+  }
+
+  private prepareFromSession(
+    session: PersistedChatSession,
+    promptMessageId: string,
+    replay?: DurableContinuationReplay
+  ): DurableContinuationPreparation {
     const graph = session.conversationGraph
     const activeFrame = graph?.frames.find((frame) => frame.id === graph.activeFrameId)
-    const activeMessageIds =
+    const activeBranch = graph?.branches.find((branch) => branch.id === activeFrame?.activeBranchId)
+    const prompt =
       graph && activeFrame
-        ? new Set(resolveMessageBranchPath(graph, activeFrame.activeBranchId).map(({ id }) => id))
+        ? resolveMessageBranchPath(graph, activeFrame.activeBranchId).find(
+            (message) => message.id === promptMessageId
+          )
         : undefined
     if (
-      session.id !== input.sessionId ||
-      session.projectId !== input.projectId ||
-      prompt?.role !== 'user' ||
       !graph ||
-      !activeMessageIds?.has(input.promptMessageId)
+      !activeFrame ||
+      !activeBranch ||
+      prompt?.role !== 'user' ||
+      prompt.status !== 'complete' ||
+      prompt.agentFrameId !== activeFrame.id ||
+      prompt.introducedOnBranchId !== activeBranch.id ||
+      !prompt.runtimeSegmentId
     ) {
       throw new Error('Durable continuation no longer matches the active Message Branch.')
     }
 
     return {
-      provenanceContext: getActiveConversationContext(graph, input.promptMessageId),
-      ...(input.replay
+      provenanceContext: getActiveConversationContext(graph, promptMessageId),
+      ...(replay
         ? {
             historyReplay: buildSessionHistoryReplay(
               session.messages,
-              input.replay.descriptor,
+              replay.descriptor,
               session.projectId,
-              input.replay.supportsImageInput
+              replay.supportsImageInput
             )
           }
         : {})
@@ -69,4 +137,8 @@ class AcpDurableContinuationContextOwner {
 }
 
 export { AcpDurableContinuationContextOwner }
-export type { DurableContinuationPreparation, DurableContinuationSessions }
+export type {
+  DurableContinuationPreparation,
+  DurableContinuationSessions,
+  DurableElicitationContinuationPreparation
+}

--- a/src/main/acp/elicitation-owner.ts
+++ b/src/main/acp/elicitation-owner.ts
@@ -314,7 +314,7 @@ const validateAnswerValue = (field: ElicitationField, value: ElicitationValue): 
   return value.every((item) => allowed.has(item))
 }
 
-const validateAnswers = (
+export const validateElicitationAnswers = (
   request: PendingElicitationRequest,
   answers: ElicitationAnswer[] | undefined
 ): ElicitationAnswer[] => {
@@ -505,7 +505,7 @@ export class AcpElicitationOwner {
     let state: ElicitationProjection['state']
 
     if (response.action === 'accept') {
-      answers = validateAnswers(pending.request, response.answers)
+      answers = validateElicitationAnswers(pending.request, response.answers)
       protocolResponse = {
         action: 'accept',
         content: Object.fromEntries(answers.map((answer) => [answer.fieldId, answer.value]))

--- a/src/main/acp/permission-wait-owner.test.ts
+++ b/src/main/acp/permission-wait-owner.test.ts
@@ -68,7 +68,7 @@ const createSessions = (
       readSessionRuntimeContext: vi.fn(async () => structuredClone(context)),
       patchSessionRuntimeContext: patches,
       containsMessageOnActiveBranch: vi.fn(async () => containsMessage),
-      loadSessionForPermissionReplay: vi.fn(async () => structuredClone(session))
+      loadSessionForContinuation: vi.fn(async () => structuredClone(session))
     },
     context: () => context,
     patches

--- a/src/main/acp/permission-wait-owner.ts
+++ b/src/main/acp/permission-wait-owner.ts
@@ -1,9 +1,4 @@
 import type { AcpPermissionResponse } from '../../shared/acp'
-import type { HistoryReplayDescriptor } from '../../shared/history-preamble'
-import {
-  buildSessionHistoryReplay,
-  type SessionHistoryReplay
-} from '../../shared/session-history-replay'
 import {
   sanitizeSessionPermissionRuntimeContext,
   type PersistedChatSession,
@@ -18,7 +13,7 @@ type PermissionWaitSessions = Pick<
   | 'readSessionRuntimeContext'
   | 'patchSessionRuntimeContext'
   | 'containsMessageOnActiveBranch'
-  | 'loadSessionForPermissionReplay'
+  | 'loadSessionForContinuation'
 > &
   Partial<Pick<SessionPersistenceCoordinator, 'sessionProjectId'>>
 
@@ -178,34 +173,6 @@ class AcpPermissionWaitOwner {
     )
   }
 
-  async buildRestoredContinuationReplay(
-    projectId: string,
-    sessionId: string,
-    permission: SessionPermissionRuntimeContext,
-    descriptor: HistoryReplayDescriptor,
-    supportsImageInput: boolean
-  ): Promise<SessionHistoryReplay | undefined> {
-    if (!this.sessions) {
-      throw new Error('Permission replay Session authority is not available.')
-    }
-    const session = await this.sessions.loadSessionForPermissionReplay(projectId, sessionId)
-    if (
-      session.id !== sessionId ||
-      session.projectId !== projectId ||
-      !session.messages.some(
-        (message) => message.id === permission.originatingPromptMessageId && message.role === 'user'
-      )
-    ) {
-      throw new Error('Permission replay no longer matches the active Message Branch.')
-    }
-    return buildSessionHistoryReplay(
-      session.messages,
-      descriptor,
-      session.projectId,
-      supportsImageInput
-    )
-  }
-
   async resolveRestored(
     response: AcpPermissionResponse,
     projectId: string,
@@ -319,7 +286,7 @@ class AcpPermissionWaitOwner {
           sessionStatus
         })
         if (this.publishSessionUpdated) {
-          const session = await this.sessions.loadSessionForPermissionReplay(projectId, sessionId)
+          const session = await this.sessions.loadSessionForContinuation(projectId, sessionId)
           await this.publishSessionUpdated(session)
         }
         return true

--- a/src/main/acp/permission-wait-owner.ts
+++ b/src/main/acp/permission-wait-owner.ts
@@ -129,11 +129,12 @@ class AcpPermissionWaitOwner {
     )
   }
 
-  async cancelPendingSession(sessionId: string): Promise<boolean> {
-    if (!this.sessions?.sessionProjectId) return false
+  async cancelPendingSession(sessionId: string): Promise<string | undefined> {
+    if (!this.sessions?.sessionProjectId) return undefined
     const projectId = await this.sessions.sessionProjectId(sessionId)
-    if (!projectId) return false
-    return this.patch(
+    if (!projectId) return undefined
+    let cancelledRequestId: string | undefined
+    const cleared = await this.patch(
       projectId,
       sessionId,
       (context) => {
@@ -145,10 +146,12 @@ class AcpPermissionWaitOwner {
         ) {
           return permission
         }
+        cancelledRequestId = permission.request.requestId
         return undefined
       },
       'idle'
     )
+    return cleared ? cancelledRequestId : undefined
   }
 
   async beginContinuation(projectId: string, sessionId: string, requestId: string): Promise<void> {

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -4,7 +4,10 @@ import { app } from 'electron'
 
 import type { AcpPermissionRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../../shared/artifacts'
-import { MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID } from '../../shared/lifecycle-events'
+import {
+  MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID,
+  MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID
+} from '../../shared/lifecycle-events'
 import {
   filterSpecialistConnectorSkills,
   resolveEffectiveSpecialistSkills
@@ -224,6 +227,19 @@ const createAcpRuntime = ({
                   } catch (error) {
                     // The durable commit remains authoritative when a renderer projection is gone.
                     log.warn('permission wait Session publication failed', errorLogFields(error))
+                  }
+                },
+                onContinuationSessionUpdated: (session) => {
+                  try {
+                    broadcastToRenderers('session:updated', {
+                      session,
+                      originClientId: MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID
+                    })
+                  } catch (error) {
+                    log.warn(
+                      'durable continuation Session publication failed',
+                      errorLogFields(error)
+                    )
                   }
                 }
               }

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -87,7 +87,7 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
     | 'patchSessionRuntimeContext'
     | 'appendUserMessageToInteraction'
     | 'containsMessageOnActiveBranch'
-    | 'loadSessionForPermissionReplay'
+    | 'loadSessionForContinuation'
     | 'sessionProjectId'
   >
   sideChatRelays?: AcpRuntimeOptions['sideChatRelays']

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -14,12 +14,15 @@ import type { AgentModelChangeTarget } from '../agent-framework'
 const createDeferred = <Value = void>(): {
   promise: Promise<Value>
   resolve: (value: Value) => void
+  reject: (error: unknown) => void
 } => {
   let resolve!: (value: Value) => void
-  const promise = new Promise<Value>((promiseResolve) => {
+  let reject!: (error: unknown) => void
+  const promise = new Promise<Value>((promiseResolve, promiseReject) => {
     resolve = promiseResolve
+    reject = promiseReject
   })
-  return { promise, resolve }
+  return { promise, resolve, reject }
 }
 
 const emptySnapshot = (): AcpStateSnapshot => ({
@@ -808,8 +811,8 @@ describe('AcpRuntimeCoordinator', () => {
     await expect(coordinator.prepareForQuit(1_000)).resolves.toBe('completed')
     expect(created.cancelPrompt).not.toHaveBeenCalled()
 
-    prompt.resolve({ stopReason: 'cancelled' })
-    await running
+    prompt.reject(new Error('provider connection closed during quit'))
+    await expect(running).resolves.toMatchObject({ stopReason: 'cancelled' })
   })
 
   it('bounds quit preparation when an agent never returns a terminal response', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -811,8 +811,35 @@ describe('AcpRuntimeCoordinator', () => {
     await expect(coordinator.prepareForQuit(1_000)).resolves.toBe('completed')
     expect(created.cancelPrompt).not.toHaveBeenCalled()
 
+    await expect(coordinator.shutdownForQuit()).resolves.toEqual({ reaped: true })
     prompt.reject(new Error('provider connection closed during quit'))
     await expect(running).resolves.toMatchObject({ stopReason: 'cancelled' })
+  })
+
+  it('preserves an unexpected durable prompt failure before provider quit teardown', async () => {
+    const prompt = createDeferred<unknown>()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks,
+          prompt: () => prompt.promise,
+          activePromptSessions: [{ projectName: 'project-1', sessionId: 'session-1' }],
+          quitBlockingSessions: []
+        }).runtime
+    )
+    const session = await coordinator.createSession({
+      cwd: '/workspace',
+      projectName: 'project-1'
+    })
+    const running = coordinator.sendPrompt({ sessionId: session.sessionId, text: 'wait for me' })
+    await Promise.resolve()
+
+    await expect(coordinator.prepareForQuit(1_000)).resolves.toBe('completed')
+    prompt.reject(new Error('unexpected persistence failure'))
+
+    await expect(running).rejects.toThrow('unexpected persistence failure')
   })
 
   it('bounds quit preparation when an agent never returns a terminal response', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -276,6 +276,20 @@ const createFakeRuntime = (options: {
 }
 
 describe('AcpRuntimeCoordinator', () => {
+  it('publishes snapshots with a coordinator-wide monotonic revision', () => {
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks
+        }).runtime
+    )
+
+    expect(coordinator.getSnapshot().revision).toBe(1)
+    expect(coordinator.getSnapshot().revision).toBe(2)
+  })
+
   it('combines only the quit-blocking prompts reported by each runtime generation', async () => {
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) =>

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -113,6 +113,7 @@ class AcpRuntimeCoordinator {
   private readonly runtimeIds = new WeakMap<AcpRuntime, string>()
   private readonly publishedRuntimeEventIds = new WeakMap<AcpRuntime, Set<string>>()
   private readonly applicationEvents: AcpRuntimeEvent[] = []
+  private readonly durableQuitDetachedSessionIds = new Set<string>()
   private readonly permissionGrantStore = new ConversationPermissionGrantStore()
   // Runtime events are persisted on Message nodes. A process-local sequence alone restarts at one
   // after every app launch and can collide with a historical Session's event ids.
@@ -356,6 +357,9 @@ class AcpRuntimeCoordinator {
     const durablePermissionWaitSessionIds = new Set(
       [...activePromptSessionIds].filter((sessionId) => !quitBlockingSessionIds.has(sessionId))
     )
+    for (const sessionId of durablePermissionWaitSessionIds) {
+      this.durableQuitDetachedSessionIds.add(sessionId)
+    }
     const sessionIds = Array.from(
       new Set([
         ...this.activePromptRequests.keys(),
@@ -686,12 +690,24 @@ class AcpRuntimeCoordinator {
     }
     this.activePromptRequests.set(request.sessionId, activePrompt)
     if (retainAsLatestUserPrompt) this.latestPromptRequests.set(request.sessionId, taskRequest)
-    return runtime[operation](taskRequest, attempt.id).finally(() => {
-      this.removePendingPromptStart(request.sessionId, attempt)
-      if (this.activePromptRequests.get(request.sessionId) === activePrompt) {
-        this.activePromptRequests.delete(request.sessionId)
-      }
-    })
+    return runtime[operation](taskRequest, attempt.id)
+      .catch((error: unknown) => {
+        if (
+          operation === 'sendPrompt' &&
+          this.promptAdmissionClosedForQuit &&
+          this.durableQuitDetachedSessionIds.has(request.sessionId)
+        ) {
+          return { stopReason: 'cancelled' as const }
+        }
+        throw error
+      })
+      .finally(() => {
+        this.durableQuitDetachedSessionIds.delete(request.sessionId)
+        this.removePendingPromptStart(request.sessionId, attempt)
+        if (this.activePromptRequests.get(request.sessionId) === activePrompt) {
+          this.activePromptRequests.delete(request.sessionId)
+        }
+      })
   }
 
   async cancelPrompt(request: AcpCancelPromptRequest): Promise<AcpStateSnapshot> {
@@ -760,7 +776,7 @@ class AcpRuntimeCoordinator {
     return this.getSnapshot()
   }
 
-  respondToElicitation(response: ElicitationResponse): AcpStateSnapshot {
+  async respondToElicitation(response: ElicitationResponse): Promise<AcpStateSnapshot> {
     const runtime =
       Array.from(this.runtimes).find((candidate) =>
         candidate
@@ -769,7 +785,7 @@ class AcpRuntimeCoordinator {
       ) ??
       (response.request ? this.findRuntimeForSession(response.request.sessionId) : undefined) ??
       this.getActiveRuntime()
-    runtime.respondToElicitation(response)
+    await runtime.respondToElicitation(response)
     return this.getSnapshot()
   }
 

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -119,6 +119,7 @@ class AcpRuntimeCoordinator {
   // after every app launch and can collide with a historical Session's event ids.
   private readonly eventNamespace = randomUUID()
   private runtimeSequence = 0
+  private snapshotRevision = 0
   private initializationGeneration = 0
   private globalCancellationGeneration = 0
   private promptAttemptSequence = 0
@@ -154,6 +155,7 @@ class AcpRuntimeCoordinator {
   }
 
   getSnapshot(): AcpStateSnapshot {
+    this.snapshotRevision += 1
     const snapshots = Array.from(this.runtimes, (runtime) => ({
       runtime,
       snapshot: runtime.getSnapshot()
@@ -219,6 +221,7 @@ class AcpRuntimeCoordinator {
     )
 
     return {
+      revision: this.snapshotRevision,
       status: primary?.status ?? 'idle',
       sessionConnectionStatuses: Object.fromEntries(this.sessionConnectionStatuses),
       cwd: primary?.cwd ?? this.defaultCwd,

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -129,6 +129,7 @@ class AcpRuntimeCoordinator {
   private readonly interactionReleaseWaiters = new Map<string, Set<() => void>>()
   private promptAdmissionGuard?: (sessionId: string) => Promise<void>
   private promptAdmissionClosedForQuit = false
+  private providerShutdownStartedForQuit = false
   private readonly pendingSessionAdoptions = new Map<string, AcpRuntime>()
   private readonly pendingSessionDrains = new Map<string, PendingSessionDrain>()
   // The latest user-originated prompt is retained only long enough to construct an app-owned
@@ -336,6 +337,7 @@ class AcpRuntimeCoordinator {
   }
 
   async shutdownForQuit(): Promise<{ reaped: boolean }> {
+    this.providerShutdownStartedForQuit = true
     this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()
     return this.shutdownAll((runtime) => runtime.shutdownForQuit())
@@ -695,6 +697,7 @@ class AcpRuntimeCoordinator {
         if (
           operation === 'sendPrompt' &&
           this.promptAdmissionClosedForQuit &&
+          this.providerShutdownStartedForQuit &&
           this.durableQuitDetachedSessionIds.has(request.sessionId)
         ) {
           return { stopReason: 'cancelled' as const }

--- a/src/main/acp/runtime-session-composition.ts
+++ b/src/main/acp/runtime-session-composition.ts
@@ -3,6 +3,7 @@ import { SESSION_PLAN_SYSTEM_PROMPT_APPEND } from '../session-plan/guidance'
 import { createLogger } from '../logger'
 import { AcpAppContinuationOwner } from './app-continuation-owner'
 import { AcpContextUsagePolicy } from './context-usage-policy'
+import { AcpDurableContinuationContextOwner } from './durable-continuation-context-owner'
 import { AcpElicitationOwner } from './elicitation-owner'
 import { AcpPermissionContext } from './permission-context'
 import { AcpPermissionWaitOwner } from './permission-wait-owner'
@@ -134,6 +135,9 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     systemPromptAppends: () => sessionEnvironment.systemPromptAppends(),
     tooling: () => sessionEnvironment.toolingAvailability()
   })
+  const durableContinuationContext = new AcpDurableContinuationContextOwner(
+    options.permissionWait?.sessions
+  )
   const permissionWaitOwner = new AcpPermissionWaitOwner(
     options.permissionWait?.sessions,
     options.permissionWait?.onSessionUpdated
@@ -239,6 +243,7 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     publication,
     appContinuations,
     elicitationOwner,
+    durableContinuationContext,
     permissionWaitOwner,
     permissionContext,
     reviewerSessions,

--- a/src/main/acp/runtime-session-composition.ts
+++ b/src/main/acp/runtime-session-composition.ts
@@ -136,7 +136,8 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     tooling: () => sessionEnvironment.toolingAvailability()
   })
   const durableContinuationContext = new AcpDurableContinuationContextOwner(
-    options.permissionWait?.sessions
+    options.permissionWait?.sessions,
+    options.permissionWait?.onContinuationSessionUpdated
   )
   const permissionWaitOwner = new AcpPermissionWaitOwner(
     options.permissionWait?.sessions,

--- a/src/main/acp/runtime-session-composition.ts
+++ b/src/main/acp/runtime-session-composition.ts
@@ -2,6 +2,7 @@ import type { SessionPermissionProfileState } from '../../shared/permission-prof
 import { SESSION_PLAN_SYSTEM_PROMPT_APPEND } from '../session-plan/guidance'
 import { createLogger } from '../logger'
 import { AcpAppContinuationOwner } from './app-continuation-owner'
+import { AcpClientInteractionOwner } from './client-interaction-owner'
 import { AcpContextUsagePolicy } from './context-usage-policy'
 import { AcpDurableContinuationContextOwner } from './durable-continuation-context-owner'
 import { AcpElicitationOwner } from './elicitation-owner'
@@ -215,6 +216,20 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     unregisterBridgeSession: (sessionId) =>
       base.connectionResources.unregisterBridgeReviewerSession(sessionId)
   })
+  const clientInteractions = new AcpClientInteractionOwner({
+    routing: {
+      resolveAppSessionId: (sessionId) => sessionRegistry.resolveAppSessionId(sessionId),
+      isActiveSession: (sessionId) => sessionRegistry.lookup(sessionId)?.attachment !== undefined,
+      frameworkForSession: (sessionId) =>
+        sessionRegistry.lookup(sessionId)?.aggregate.snapshot().frameworkId,
+      promptMessageIdForSession: (sessionId) => {
+        const interaction = base.sessionInteractions.current(sessionId)
+        return interaction?.kind === 'prompt' ? interaction.promptMessageId : undefined
+      }
+    },
+    elicitation: elicitationOwner,
+    permission: permissionContext
+  })
   const sessionUpdateProjector = new AcpSessionUpdateProjector({
     registry: sessionRegistry,
     contextUsage: base.contextUsageTracker,
@@ -247,6 +262,7 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     durableContinuationContext,
     permissionWaitOwner,
     permissionContext,
+    clientInteractions,
     reviewerSessions,
     sessionUpdateProjector
   })

--- a/src/main/acp/runtime-snapshot-owner.ts
+++ b/src/main/acp/runtime-snapshot-owner.ts
@@ -79,6 +79,9 @@ class AcpRuntimeSnapshotOwner {
       providerError: event.providerError,
       turnUsage: event.turnUsage,
       terminalContextWindow: event.terminalContextWindow,
+      ...(event.permissionRequestId !== undefined
+        ? { permissionRequestId: event.permissionRequestId }
+        : {}),
       sessionId: event.sessionId,
       messageId: event.messageId,
       role: event.role,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -57,10 +57,13 @@ import { BEGIN_ACTIVITY_GROUP_TOOL_NAME } from '../../shared/activity-groups'
 import type { UploadedAttachment } from '../../shared/uploads'
 import {
   createLinearConversationGraph,
+  forkConversationAfterActivity,
   projectConversationMessage,
+  synchronizeActiveConversationActivities,
   synchronizeActiveConversationMessages
 } from '../../shared/conversation-graph'
 import type { PersistedChatSession, SessionRuntimeContext } from '../../shared/session-persistence'
+import type { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
 import { UploadRepository } from '../uploads/repository'
 import { stageUploadFixtures } from '../uploads/repository.test-utils'
@@ -1669,7 +1672,87 @@ const addPendingRestoredChoice = (
       updatedAt: 2
     }
   ]
+  if (session.conversationGraph) {
+    session.conversationGraph = synchronizeActiveConversationActivities(
+      session.conversationGraph,
+      session.activities,
+      []
+    )
+  }
   return session
+}
+
+const createRestoredChoiceRevisionSession = (): PersistedChatSession => {
+  const messages: PersistedChatSession['messages'] = [
+    {
+      id: 'prompt-restored-1',
+      role: 'user',
+      content: 'Choose an approach.',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    },
+    {
+      id: 'agent-question-preamble',
+      role: 'agent',
+      content: 'Please choose one option.',
+      status: 'complete',
+      responseToMessageId: 'prompt-restored-1',
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    }
+  ]
+  const activity: NonNullable<PersistedChatSession['activities']>[number] = {
+    id: 'tool-choice-restored-1',
+    kind: 'tool',
+    title: 'Choose an approach',
+    status: 'completed',
+    sortIndex: 0,
+    eventIds: [],
+    promptMessageId: 'prompt-restored-1',
+    elicitation: {
+      message: 'Choose an approach',
+      fields: [{ id: 'question_0', label: 'Approach', kind: 'text' }],
+      state: 'answered',
+      durable: {
+        kind: 'agent-user-choice',
+        requestId: 'choice-restored-1',
+        promptMessageId: 'prompt-restored-1'
+      },
+      answers: [{ fieldId: 'question_0', value: 'Minimal' }]
+    },
+    createdAt: 2,
+    updatedAt: 2
+  }
+  let graph = createLinearConversationGraph({
+    sessionId: 'pending-session',
+    messages,
+    frameworkId: 'claude-code',
+    createdAt: 1,
+    updatedAt: 2
+  })
+  graph = synchronizeActiveConversationActivities(graph, [activity], [])
+  graph = forkConversationAfterActivity(
+    graph,
+    'agent-question-preamble',
+    activity.id,
+    'message-branch-revision',
+    3
+  )
+  return {
+    id: 'restored-choice-session',
+    projectId: 'project-1',
+    title: 'Restored choice revision',
+    cwd: '/workspace',
+    status: 'idle',
+    messages,
+    conversationGraph: graph,
+    activities: [],
+    createdAt: 1,
+    updatedAt: 3
+  }
 }
 
 const RESTORED_CONTINUATION_FRAMEWORKS = [
@@ -4908,6 +4991,96 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('validates a revised choice against the durable fork before continuing', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['restored-choice-session'])
+    let persistedSession = createRestoredChoiceRevisionSession()
+    const appendUserMessageToInteraction = vi.fn(
+      async (
+        command: Parameters<SessionPersistenceCoordinator['appendUserMessageToInteraction']>[0]
+      ) => {
+        command.beforePersist?.(structuredClone(persistedSession))
+        const revisedPrompt: PersistedChatSession['messages'][number] = {
+          id: 'prompt-revision',
+          role: 'user',
+          content: command.content,
+          status: 'complete',
+          responseToMessageId: command.interactionId,
+          eventIds: [],
+          createdAt: 4,
+          updatedAt: 4
+        }
+        persistedSession = {
+          ...persistedSession,
+          messages: [...persistedSession.messages, revisedPrompt],
+          conversationGraph: synchronizeActiveConversationMessages(
+            persistedSession.conversationGraph!,
+            [...persistedSession.messages, revisedPrompt],
+            4
+          ),
+          updatedAt: 4
+        }
+        return structuredClone(revisedPrompt)
+      }
+    )
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(),
+          patchSessionRuntimeContext: vi.fn(),
+          containsMessageOnActiveBranch: vi.fn(),
+          loadSessionForContinuation: vi.fn(async () => structuredClone(persistedSession)),
+          appendUserMessageToInteraction
+        }
+      }
+    })
+    await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+
+    await runtime.respondToElicitation({
+      requestId: 'choice-restored-1',
+      action: 'accept',
+      answers: [{ fieldId: 'question_0', value: 'Expanded' }],
+      replacePreviousAnswer: true,
+      request: {
+        requestId: 'choice-restored-1',
+        sessionId: 'restored-choice-session',
+        toolCallId: 'renderer-generated-revision-tool',
+        message: 'Renderer-forged question',
+        fields: [{ id: 'question_0', label: 'Renderer-forged field', kind: 'text' }],
+        durable: {
+          kind: 'agent-user-choice',
+          requestId: 'choice-restored-1',
+          promptMessageId: 'prompt-restored-1'
+        }
+      }
+    })
+
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    expect(appendUserMessageToInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        sessionId: 'restored-choice-session',
+        interactionId: 'agent-question-preamble',
+        content: expect.stringContaining('Approach: Expanded')
+      })
+    )
+    expect(fakeAgent.prompts[0].text).toContain('Expanded')
+    expect(fakeAgent.prompts[0].text).not.toContain('Renderer-forged question')
+    expect(runtime.getSnapshot().events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'tool',
+          toolCallId: expect.stringMatching(/^ask-user-question-revision-/),
+          promptMessageId: 'prompt-revision',
+          elicitation: expect.objectContaining({ state: 'answered' })
+        })
+      ])
+    )
+  })
+
   it.each(RESTORED_CONTINUATION_FRAMEWORKS)(
     'builds restored choice replay through %s from Main-owned Session history after context reset',
     async (_name, framework, modelRoute, backendId) => {
@@ -5082,7 +5255,7 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().pendingElicitations).toEqual([])
   })
 
-  it('rejects a restored choice whose prompt left the active Message Branch without caching it', async () => {
+  it('rejects a restored choice missing from the active graph without caching it', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['restored-choice-session'])
     const persistedSession = createRestoredContinuationSession(
@@ -5132,7 +5305,7 @@ describe('ACP runtime session management', () => {
           }
         }
       })
-    ).rejects.toThrow('active Message Branch')
+    ).rejects.toThrow('pending Session activity')
     expect(runtime.getSnapshot().pendingElicitations).toEqual([])
     await expect(
       runtime.respondToElicitation({

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4993,7 +4993,12 @@ describe('ACP runtime session management', () => {
 
   it('validates a revised choice against the durable fork before continuing', async () => {
     const process = new FakeAgentProcess()
-    const fakeAgent = startFakeAgent(process, ['restored-choice-session'])
+    const journal: string[] = []
+    const fakeAgent = startFakeAgent(process, ['restored-choice-session'], {
+      onPrompt: () => {
+        journal.push('provider-prompt')
+      }
+    })
     let persistedSession = createRestoredChoiceRevisionSession()
     const appendUserMessageToInteraction = vi.fn(
       async (
@@ -5034,6 +5039,10 @@ describe('ACP runtime session management', () => {
           containsMessageOnActiveBranch: vi.fn(),
           loadSessionForContinuation: vi.fn(async () => structuredClone(persistedSession)),
           appendUserMessageToInteraction
+        },
+        onContinuationSessionUpdated: (session) => {
+          expect(session.messages.at(-1)).toMatchObject({ id: 'prompt-revision' })
+          journal.push('session-published')
         }
       }
     })
@@ -5059,6 +5068,7 @@ describe('ACP runtime session management', () => {
     })
 
     await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    expect(journal).toEqual(['session-published', 'provider-prompt'])
     expect(appendUserMessageToInteraction).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: 'project-1',

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -47,6 +47,7 @@ import { CODEX_BRIDGE_MODEL } from '../agent-framework/codex'
 import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
+import { validateDurableMessageOwnership } from '../artifacts/provenance-message-finalization'
 import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
 import type { ArtifactRunClaim } from '../artifacts/run-registry'
 import { createPngBytes, createPngInlineSource } from '../artifacts/artifact-test-fixtures'
@@ -56,7 +57,8 @@ import { BEGIN_ACTIVITY_GROUP_TOOL_NAME } from '../../shared/activity-groups'
 import type { UploadedAttachment } from '../../shared/uploads'
 import {
   createLinearConversationGraph,
-  projectConversationMessage
+  projectConversationMessage,
+  synchronizeActiveConversationMessages
 } from '../../shared/conversation-graph'
 import type { PersistedChatSession, SessionRuntimeContext } from '../../shared/session-persistence'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
@@ -1634,6 +1636,49 @@ const createRestoredContinuationSession = (
   }
 }
 
+const addPendingRestoredChoice = (
+  session: PersistedChatSession,
+  input: {
+    requestId?: string
+    toolCallId?: string
+    promptMessageId?: string
+    message?: string
+  } = {}
+): PersistedChatSession => {
+  const requestId = input.requestId ?? 'choice-restored-1'
+  const toolCallId = input.toolCallId ?? 'tool-choice-restored-1'
+  const promptMessageId = input.promptMessageId ?? 'prompt-restored-1'
+  const message = input.message ?? 'Choose an approach'
+  session.status = 'waiting-for-user'
+  session.activities = [
+    {
+      id: toolCallId,
+      kind: 'tool',
+      title: message,
+      status: 'in_progress',
+      sortIndex: 0,
+      eventIds: [],
+      promptMessageId,
+      elicitation: {
+        message,
+        fields: [{ id: 'question_0', label: 'Approach', kind: 'text' }],
+        state: 'pending',
+        durable: { kind: 'agent-user-choice', requestId, promptMessageId }
+      },
+      createdAt: 2,
+      updatedAt: 2
+    }
+  ]
+  return session
+}
+
+const RESTORED_CONTINUATION_FRAMEWORKS = [
+  ['Claude Code', claudeCodeFramework, 'claude-anthropic', 'claude-code:provider-a'],
+  ['OpenCode', opencodeFramework, 'opencode-openai', 'opencode:provider-a'],
+  ['Codex Responses', codexFramework, 'codex-responses', 'codex:provider-a'],
+  ['Codex Bridge', codexFramework, 'codex-bridge', 'codex:provider-a']
+] as const
+
 describe('ACP runtime restored permission continuation', () => {
   it('cancels restored pending authority without a live ACP interaction', async () => {
     let runtimeContext: SessionRuntimeContext = {
@@ -1688,12 +1733,7 @@ describe('ACP runtime restored permission continuation', () => {
     )
   })
 
-  it.each([
-    ['Claude Code', claudeCodeFramework, 'claude-anthropic', 'claude-code:provider-a'],
-    ['OpenCode', opencodeFramework, 'opencode-openai', 'opencode:provider-a'],
-    ['Codex Responses', codexFramework, 'codex-responses', 'codex:provider-a'],
-    ['Codex Bridge', codexFramework, 'codex-bridge', 'codex:provider-a']
-  ] as const)(
+  it.each(RESTORED_CONTINUATION_FRAMEWORKS)(
     'continues an approved restored wait through %s and then clears its authority',
     async (_name, framework, modelRoute, backendId) => {
       const root = await createTemporaryRoot()
@@ -1864,6 +1904,34 @@ describe('ACP runtime restored permission continuation', () => {
         runtimeSegmentId: 'runtime-segment-pending-session',
         promptMessageId: 'prompt-1'
       })
+      const finalMessage: PersistedChatSession['messages'][number] = {
+        id: 'agent-final',
+        role: 'agent',
+        content: 'The requested command completed.',
+        status: 'complete',
+        responseToMessageId: 'prompt-1',
+        eventIds: [],
+        createdAt: 4,
+        updatedAt: 4
+      }
+      const finalizationSession = structuredClone(persistedSession)
+      finalizationSession.messages.push(finalMessage)
+      finalizationSession.conversationGraph = synchronizeActiveConversationMessages(
+        finalizationSession.conversationGraph!,
+        finalizationSession.messages,
+        4,
+        artifactContext!.runtimeSegmentId as string
+      )
+      expect(() =>
+        validateDurableMessageOwnership(finalizationSession, {
+          rootFrameId: artifactContext!.rootFrameId as string,
+          agentFrameId: artifactContext!.agentFrameId as string,
+          messageBranchId: artifactContext!.messageBranchId as string,
+          runtimeSegmentId: artifactContext!.runtimeSegmentId as string,
+          promptMessageId: artifactContext!.promptMessageId as string,
+          messageId: finalMessage.id
+        })
+      ).not.toThrow()
       expect(fakeAgent.prompts[0]?.text).not.toContain('Renderer-forged conversation context.')
       expect(receivedPrompts[0]?.every((content) => content.type === 'text')).toBe(true)
       expect(fakeAgent.prompts[0]?.text).toContain('approved the pending tool permission')
@@ -1941,9 +2009,7 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForContinuation: vi.fn(async () =>
-            createRestoredContinuationSession()
-          )
+          loadSessionForContinuation: vi.fn(async () => createRestoredContinuationSession())
         }
       },
       resolveBackend: () => ({
@@ -1981,127 +2047,152 @@ describe('ACP runtime restored permission continuation', () => {
     )
   })
 
-  it('builds restored permission replay from Main-owned Session history after context reset', async () => {
-    const process = new FakeAgentProcess()
-    const fakeAgent = startFakeAgent(process, ['adopted-provider-session'], {
-      resumeNotFound: true
-    })
-    let runtimeContext: SessionRuntimeContext = {
-      version: 1,
-      revision: 1,
-      permission: {
-        state: 'pending',
-        request: {
-          requestId: 'permission-restored',
-          sessionId: 'restored-session',
-          toolCallId: 'tool-restored',
-          title: 'Run npm test',
-          providerToolName: 'Bash',
-          rawInput: { command: 'npm test' },
-          options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
-        },
-        originatingPromptMessageId: 'prompt-1',
-        fingerprint: 'a'.repeat(64),
-        createdAt: 1
-      }
-    }
-    const persistedSession: PersistedChatSession = {
-      id: 'restored-session',
-      projectId: 'project-1',
-      title: 'Restored permission',
-      cwd: '/workspace',
-      status: 'waiting-permission',
-      messages: [
-        {
-          id: 'prompt-0',
-          role: 'user',
-          content: 'Main-owned earlier request.',
-          status: 'complete',
-          eventIds: [],
-          createdAt: 1,
-          updatedAt: 1
-        },
-        {
-          id: 'reply-0',
-          role: 'agent',
-          content: 'Main-owned earlier response.',
-          status: 'complete',
-          responseToMessageId: 'prompt-0',
-          eventIds: [],
-          createdAt: 2,
-          updatedAt: 2
-        },
-        {
-          id: 'prompt-1',
-          role: 'user',
-          content: 'Run the requested test command.',
-          status: 'complete',
-          eventIds: [],
-          createdAt: 3,
-          updatedAt: 3
+  it.each(RESTORED_CONTINUATION_FRAMEWORKS)(
+    'builds restored permission replay through %s from Main-owned Session history after context reset',
+    async (_name, framework, modelRoute, backendId) => {
+      const process = new FakeAgentProcess()
+      const receivedPrompts: ContentBlock[][] = []
+      const fakeAgent = startFakeAgent(process, ['adopted-provider-session'], {
+        resumeNotFound: true,
+        ...(framework.id === 'codex'
+          ? { modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent') }
+          : {}),
+        onPrompt: ({ prompt }) => {
+          receivedPrompts.push(prompt)
         }
-      ],
-      createdAt: 1,
-      updatedAt: 3
-    }
-    persistedSession.conversationGraph = createLinearConversationGraph({
-      sessionId: 'pending-session',
-      messages: persistedSession.messages,
-      frameworkId: 'claude-code',
-      createdAt: 1,
-      updatedAt: 3
-    })
-    const patchSessionRuntimeContext = vi.fn(
-      async (command: { patch: { permission?: SessionRuntimeContext['permission'] } }) => {
-        runtimeContext = {
-          ...runtimeContext,
-          ...command.patch,
-          revision: runtimeContext.revision + 1
-        }
-        return structuredClone(runtimeContext)
-      }
-    )
-    const loadSessionForContinuation = vi.fn(async () => structuredClone(persistedSession))
-    const runtime = new AcpRuntime({
-      appVersion: '0.1.0',
-      defaultCwd: '/workspace',
-      permissionWait: {
-        sessions: {
-          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
-          patchSessionRuntimeContext,
-          containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForContinuation
-        }
-      },
-      resolveBackend: () => ({
-        framework: { ...claudeCodeFramework, spawn: () => asAgentProcess(process) },
-        backendId: 'claude-code:provider-a',
-        modelRoute: 'claude-anthropic',
-        executablePath: '/bin/agent',
-        env: {},
-        contextWindow: 200_000,
-        supportsImageInput: true
       })
-    })
-
-    await expect(
-      runtime.resumeSession({
-        sessionId: 'restored-session',
+      const bridgeLease =
+        modelRoute === 'codex-bridge' ? createBackendLeaseHarness().lease : undefined
+      let runtimeContext: SessionRuntimeContext = {
+        version: 1,
+        revision: 1,
+        permission: {
+          state: 'pending',
+          request: {
+            requestId: 'permission-restored',
+            sessionId: 'restored-session',
+            toolCallId: 'tool-restored',
+            title: 'Run npm test',
+            providerToolName: 'Bash',
+            rawInput: { command: 'npm test' },
+            options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+          },
+          originatingPromptMessageId: 'prompt-1',
+          fingerprint: 'a'.repeat(64),
+          createdAt: 1
+        }
+      }
+      const persistedSession: PersistedChatSession = {
+        id: 'restored-session',
+        projectId: 'project-1',
+        title: 'Restored permission',
         cwd: '/workspace',
-        projectName: 'project-1'
+        status: 'waiting-permission',
+        messages: [
+          {
+            id: 'prompt-0',
+            role: 'user',
+            content: 'Main-owned earlier request.',
+            status: 'complete',
+            images: [
+              {
+                id: 'permission-replay-image',
+                mimeType: 'image/png',
+                data: createPngBytes('permission-replay').toString('base64'),
+                byteLength: createPngBytes('permission-replay').byteLength
+              }
+            ],
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 1
+          },
+          {
+            id: 'reply-0',
+            role: 'agent',
+            content: 'Main-owned earlier response.',
+            status: 'complete',
+            responseToMessageId: 'prompt-0',
+            eventIds: [],
+            createdAt: 2,
+            updatedAt: 2
+          },
+          {
+            id: 'prompt-1',
+            role: 'user',
+            content: 'Run the requested test command.',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 3,
+            updatedAt: 3
+          }
+        ],
+        createdAt: 1,
+        updatedAt: 3
+      }
+      persistedSession.conversationGraph = createLinearConversationGraph({
+        sessionId: 'pending-session',
+        messages: persistedSession.messages,
+        frameworkId: framework.id,
+        backendId,
+        createdAt: 1,
+        updatedAt: 3
       })
-    ).resolves.toMatchObject({ sessionId: 'restored-session', contextReset: true })
-    await runtime.respondToPermission({
-      requestId: 'permission-restored',
-      optionId: 'allow-once',
-      restored: { sessionId: 'restored-session', projectId: 'project-1' }
-    })
+      const patchSessionRuntimeContext = vi.fn(
+        async (command: { patch: { permission?: SessionRuntimeContext['permission'] } }) => {
+          runtimeContext = {
+            ...runtimeContext,
+            ...command.patch,
+            revision: runtimeContext.revision + 1
+          }
+          return structuredClone(runtimeContext)
+        }
+      )
+      const loadSessionForContinuation = vi.fn(async () => structuredClone(persistedSession))
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        permissionWait: {
+          sessions: {
+            readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+            patchSessionRuntimeContext,
+            containsMessageOnActiveBranch: vi.fn(async () => true),
+            loadSessionForContinuation
+          }
+        },
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          backendId,
+          modelRoute,
+          executablePath: '/bin/agent',
+          env: {},
+          contextWindow: 200_000,
+          supportsImageInput: true,
+          ...(bridgeLease ? { responsesBridgeLease: bridgeLease } : {})
+        })
+      })
 
-    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
-    expect(loadSessionForContinuation).toHaveBeenCalledWith('project-1', 'restored-session')
-    expect(fakeAgent.prompts[0]?.text).toContain('Main-owned earlier request.')
-    expect(fakeAgent.prompts[0]?.text).toContain('approved the pending tool permission')
-  })
+      await expect(
+        runtime.resumeSession({
+          sessionId: 'restored-session',
+          cwd: '/workspace',
+          projectName: 'project-1'
+        })
+      ).resolves.toMatchObject({ sessionId: 'restored-session', contextReset: true })
+      await runtime.respondToPermission({
+        requestId: 'permission-restored',
+        optionId: 'allow-once',
+        restored: { sessionId: 'restored-session', projectId: 'project-1' }
+      })
+
+      await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+      expect(loadSessionForContinuation).toHaveBeenCalledWith('project-1', 'restored-session')
+      expect(fakeAgent.prompts[0]?.text).toContain('Main-owned earlier request.')
+      expect(fakeAgent.prompts[0]?.text).toContain('approved the pending tool permission')
+      expect(receivedPrompts[0]).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'image' })])
+      )
+    }
+  )
 
   it('marks restored authority continuing before committing a persistent grant', async () => {
     const process = new FakeAgentProcess()
@@ -2169,9 +2260,7 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForContinuation: vi.fn(async () =>
-            createRestoredContinuationSession()
-          )
+          loadSessionForContinuation: vi.fn(async () => createRestoredContinuationSession())
         }
       },
       resolveBackend: () => ({
@@ -2250,9 +2339,7 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForContinuation: vi.fn(async () =>
-            createRestoredContinuationSession()
-          )
+          loadSessionForContinuation: vi.fn(async () => createRestoredContinuationSession())
         }
       },
       resolveBackend: () => ({
@@ -2343,9 +2430,7 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForContinuation: vi.fn(async () =>
-            createRestoredContinuationSession()
-          )
+          loadSessionForContinuation: vi.fn(async () => createRestoredContinuationSession())
         }
       },
       resolveBackend: () => ({
@@ -2424,9 +2509,7 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForContinuation: vi.fn(async () =>
-            createRestoredContinuationSession()
-          )
+          loadSessionForContinuation: vi.fn(async () => createRestoredContinuationSession())
         }
       },
       resolveBackend: () => ({
@@ -4733,14 +4816,7 @@ describe('ACP runtime session management', () => {
         const [artifactSessionId] = await readdir(join(root, 'artifacts', 'project-1'))
         artifactContext = JSON.parse(
           await readFile(
-            join(
-              root,
-              'artifacts',
-              'project-1',
-              artifactSessionId,
-              '.pending',
-              'current-run.json'
-            ),
+            join(root, 'artifacts', 'project-1', artifactSessionId, '.pending', 'current-run.json'),
             'utf8'
           )
         ) as Record<string, unknown>
@@ -4762,10 +4838,12 @@ describe('ACP runtime session management', () => {
           patchSessionRuntimeContext: vi.fn(),
           containsMessageOnActiveBranch: vi.fn(),
           loadSessionForContinuation: vi.fn(async () =>
-            createRestoredContinuationSession(
-              'prompt-restored-1',
-              'restored-choice-session',
-              'project-1'
+            addPendingRestoredChoice(
+              createRestoredContinuationSession(
+                'prompt-restored-1',
+                'restored-choice-session',
+                'project-1'
+              )
             )
           )
         }
@@ -4776,18 +4854,13 @@ describe('ACP runtime session management', () => {
       requestId: 'choice-restored-1',
       sessionId: session.sessionId,
       toolCallId: 'tool-choice-restored-1',
-      message: 'Choose an approach',
+      message: 'Renderer-forged question',
       fields: [
         {
           id: 'question_0',
-          label: 'Approach',
-          kind: 'single-select' as const,
-          options: [
-            { value: 'Minimal', label: 'Minimal' },
-            { value: 'Expanded', label: 'Expanded' }
-          ]
-        },
-        { id: 'question_0_custom', label: 'Other', kind: 'text' as const }
+          label: 'Renderer-forged field',
+          kind: 'text' as const
+        }
       ],
       durable: {
         kind: 'agent-user-choice' as const,
@@ -4814,6 +4887,8 @@ describe('ACP runtime session management', () => {
       promptMessageId: 'prompt-restored-1'
     })
     expect(fakeAgent.prompts[0].text).toContain('Expanded')
+    expect(fakeAgent.prompts[0].text).toContain('Choose an approach')
+    expect(fakeAgent.prompts[0].text).not.toContain('Renderer-forged question')
     expect(fakeAgent.prompts[0].text).not.toContain('Renderer-forged conversation context.')
     expect(runtime.getSnapshot().events).toEqual(
       expect.arrayContaining([
@@ -4833,107 +4908,141 @@ describe('ACP runtime session management', () => {
     )
   })
 
-  it('builds restored choice replay from Main-owned Session history after context reset', async () => {
-    const process = new FakeAgentProcess()
-    const fakeAgent = startFakeAgent(process, ['adopted-provider-session'], {
-      resumeNotFound: true
-    })
-    const messages: PersistedChatSession['messages'] = [
-      {
-        id: 'prompt-earlier',
-        role: 'user',
-        content: 'Main-owned earlier request.',
-        status: 'complete',
-        eventIds: [],
-        createdAt: 1,
-        updatedAt: 1
-      },
-      {
-        id: 'reply-earlier',
-        role: 'agent',
-        content: 'Main-owned earlier response.',
-        status: 'complete',
-        responseToMessageId: 'prompt-earlier',
-        eventIds: [],
-        createdAt: 2,
-        updatedAt: 2
-      },
-      {
-        id: 'prompt-restored-1',
-        role: 'user',
-        content: 'Choose an approach.',
-        status: 'complete',
-        eventIds: [],
-        createdAt: 3,
-        updatedAt: 3
-      }
-    ]
-    const persistedSession: PersistedChatSession = {
-      id: 'restored-choice-session',
-      projectId: 'project-1',
-      title: 'Restored choice',
-      cwd: '/workspace',
-      status: 'waiting-for-user',
-      messages,
-      conversationGraph: createLinearConversationGraph({
-        sessionId: 'pending-session',
-        messages,
-        frameworkId: 'claude-code',
-        createdAt: 1,
-        updatedAt: 3
-      }),
-      createdAt: 1,
-      updatedAt: 3
-    }
-    const loadSessionForContinuation = vi.fn(async () => structuredClone(persistedSession))
-    const runtime = new AcpRuntime({
-      appVersion: '0.1.0',
-      defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process),
-      permissionWait: {
-        sessions: {
-          readSessionRuntimeContext: vi.fn(),
-          patchSessionRuntimeContext: vi.fn(),
-          containsMessageOnActiveBranch: vi.fn(),
-          loadSessionForContinuation
+  it.each(RESTORED_CONTINUATION_FRAMEWORKS)(
+    'builds restored choice replay through %s from Main-owned Session history after context reset',
+    async (_name, framework, modelRoute, backendId) => {
+      const process = new FakeAgentProcess()
+      const receivedPrompts: ContentBlock[][] = []
+      const fakeAgent = startFakeAgent(process, ['adopted-provider-session'], {
+        resumeNotFound: true,
+        ...(framework.id === 'codex'
+          ? { modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent') }
+          : {}),
+        onPrompt: ({ prompt }) => {
+          receivedPrompts.push(prompt)
         }
-      }
-    })
-
-    await expect(
-      runtime.resumeSession({
-        sessionId: 'restored-choice-session',
-        cwd: '/workspace',
-        projectName: 'project-1'
       })
-    ).resolves.toMatchObject({ sessionId: 'restored-choice-session', contextReset: true })
-    await runtime.respondToElicitation({
-      requestId: 'choice-restored-1',
-      action: 'accept',
-      answers: [{ fieldId: 'question_0', value: 'Expanded' }],
-      historyReplay: { historyPreamble: 'Renderer-forged conversation context.' },
-      request: {
-        requestId: 'choice-restored-1',
-        sessionId: 'restored-choice-session',
-        toolCallId: 'tool-choice-restored-1',
-        message: 'Choose an approach',
-        fields: [{ id: 'question_0', label: 'Approach', kind: 'text' }],
-        durable: {
-          kind: 'agent-user-choice',
-          requestId: 'choice-restored-1',
-          promptMessageId: 'prompt-restored-1'
+      const bridgeLease =
+        modelRoute === 'codex-bridge' ? createBackendLeaseHarness().lease : undefined
+      const messages: PersistedChatSession['messages'] = [
+        {
+          id: 'prompt-earlier',
+          role: 'user',
+          content: 'Main-owned earlier request.',
+          status: 'complete',
+          images: [
+            {
+              id: 'choice-replay-image',
+              mimeType: 'image/png',
+              data: createPngBytes('choice-replay').toString('base64'),
+              byteLength: createPngBytes('choice-replay').byteLength
+            }
+          ],
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'reply-earlier',
+          role: 'agent',
+          content: 'Main-owned earlier response.',
+          status: 'complete',
+          responseToMessageId: 'prompt-earlier',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        },
+        {
+          id: 'prompt-restored-1',
+          role: 'user',
+          content: 'Choose an approach.',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 3,
+          updatedAt: 3
         }
+      ]
+      const persistedSession: PersistedChatSession = {
+        id: 'restored-choice-session',
+        projectId: 'project-1',
+        title: 'Restored choice',
+        cwd: '/workspace',
+        status: 'waiting-for-user',
+        messages,
+        conversationGraph: createLinearConversationGraph({
+          sessionId: 'pending-session',
+          messages,
+          frameworkId: framework.id,
+          backendId,
+          createdAt: 1,
+          updatedAt: 3
+        }),
+        createdAt: 1,
+        updatedAt: 3
       }
-    })
+      addPendingRestoredChoice(persistedSession)
+      const loadSessionForContinuation = vi.fn(async () => structuredClone(persistedSession))
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        permissionWait: {
+          sessions: {
+            readSessionRuntimeContext: vi.fn(),
+            patchSessionRuntimeContext: vi.fn(),
+            containsMessageOnActiveBranch: vi.fn(),
+            loadSessionForContinuation
+          }
+        },
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          backendId,
+          modelRoute,
+          executablePath: '/bin/agent',
+          env: {},
+          contextWindow: 200_000,
+          supportsImageInput: true,
+          ...(bridgeLease ? { responsesBridgeLease: bridgeLease } : {})
+        })
+      })
 
-    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
-    expect(loadSessionForContinuation).toHaveBeenCalledWith(
-      'project-1',
-      'restored-choice-session'
-    )
-    expect(fakeAgent.prompts[0].text).toContain('Main-owned earlier request.')
-    expect(fakeAgent.prompts[0].text).not.toContain('Renderer-forged conversation context.')
-  })
+      await expect(
+        runtime.resumeSession({
+          sessionId: 'restored-choice-session',
+          cwd: '/workspace',
+          projectName: 'project-1'
+        })
+      ).resolves.toMatchObject({ sessionId: 'restored-choice-session', contextReset: true })
+      await runtime.respondToElicitation({
+        requestId: 'choice-restored-1',
+        action: 'accept',
+        answers: [{ fieldId: 'question_0', value: 'Expanded' }],
+        historyReplay: { historyPreamble: 'Renderer-forged conversation context.' },
+        request: {
+          requestId: 'choice-restored-1',
+          sessionId: 'restored-choice-session',
+          toolCallId: 'tool-choice-restored-1',
+          message: 'Choose an approach',
+          fields: [{ id: 'question_0', label: 'Approach', kind: 'text' }],
+          durable: {
+            kind: 'agent-user-choice',
+            requestId: 'choice-restored-1',
+            promptMessageId: 'prompt-restored-1'
+          }
+        }
+      })
+
+      await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+      expect(loadSessionForContinuation).toHaveBeenCalledWith(
+        'project-1',
+        'restored-choice-session'
+      )
+      expect(fakeAgent.prompts[0].text).toContain('Main-owned earlier request.')
+      expect(fakeAgent.prompts[0].text).not.toContain('Renderer-forged conversation context.')
+      expect(receivedPrompts[0]).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'image' })])
+      )
+    }
+  )
 
   it('rejects a mismatched restored choice without leaving a pending request', async () => {
     const process = new FakeAgentProcess()
@@ -4989,6 +5098,7 @@ describe('ACP runtime session management', () => {
       createdAt: 2,
       updatedAt: 2
     })
+    addPendingRestoredChoice(persistedSession, { promptMessageId: 'prompt-inactive' })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -54,7 +54,10 @@ import { writeArtifactFileForCurrentRun } from '../artifacts/mcp-server'
 import { createArtifactVersionLocator } from '../../shared/artifact-provenance'
 import { BEGIN_ACTIVITY_GROUP_TOOL_NAME } from '../../shared/activity-groups'
 import type { UploadedAttachment } from '../../shared/uploads'
-import { projectConversationMessage } from '../../shared/conversation-graph'
+import {
+  createLinearConversationGraph,
+  projectConversationMessage
+} from '../../shared/conversation-graph'
 import type { PersistedChatSession, SessionRuntimeContext } from '../../shared/session-persistence'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
 import { UploadRepository } from '../uploads/repository'
@@ -1596,6 +1599,41 @@ describe('ACP runtime provider prompt acceptance', () => {
   )
 })
 
+const createRestoredContinuationSession = (
+  promptMessageId = 'prompt-1',
+  sessionId = 'restored-session',
+  projectId = 'project-1'
+): PersistedChatSession => {
+  const messages: PersistedChatSession['messages'] = [
+    {
+      id: promptMessageId,
+      role: 'user',
+      content: 'Continue the restored task.',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+  ]
+  return {
+    id: sessionId,
+    projectId,
+    title: 'Restored task',
+    cwd: '/workspace',
+    status: 'waiting-permission',
+    messages,
+    conversationGraph: createLinearConversationGraph({
+      sessionId: 'pending-session',
+      messages,
+      frameworkId: 'claude-code',
+      createdAt: 1,
+      updatedAt: 1
+    }),
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
 describe('ACP runtime restored permission continuation', () => {
   it('cancels restored pending authority without a live ACP interaction', async () => {
     let runtimeContext: SessionRuntimeContext = {
@@ -1631,7 +1669,7 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForPermissionReplay: vi.fn(),
+          loadSessionForContinuation: vi.fn(),
           sessionProjectId: vi.fn(async () => 'project-1')
         }
       }
@@ -1658,14 +1696,30 @@ describe('ACP runtime restored permission continuation', () => {
   ] as const)(
     'continues an approved restored wait through %s and then clears its authority',
     async (_name, framework, modelRoute, backendId) => {
+      const root = await createTemporaryRoot()
       const process = new FakeAgentProcess()
       const receivedPrompts: ContentBlock[][] = []
+      let artifactContext: Record<string, unknown> | undefined
       const fakeAgent = startFakeAgent(process, ['restored-session'], {
         ...(framework.id === 'codex'
           ? { modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent') }
           : {}),
-        onPrompt: ({ prompt }) => {
+        onPrompt: async ({ prompt }) => {
           receivedPrompts.push(prompt)
+          const [artifactSessionId] = await readdir(join(root, 'artifacts', 'project-1'))
+          artifactContext = JSON.parse(
+            await readFile(
+              join(
+                root,
+                'artifacts',
+                'project-1',
+                artifactSessionId,
+                '.pending',
+                'current-run.json'
+              ),
+              'utf8'
+            )
+          ) as Record<string, unknown>
         }
       })
       const bridgeLease =
@@ -1712,18 +1766,51 @@ describe('ACP runtime restored permission continuation', () => {
         }
       )
       const onPermissionSettled = vi.fn()
+      const messages: PersistedChatSession['messages'] = [
+        {
+          id: 'prompt-1',
+          role: 'user',
+          content: 'Run the requested test command.',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+      const persistedSession: PersistedChatSession = {
+        id: 'restored-session',
+        projectId: 'project-1',
+        title: 'Restored permission',
+        cwd: '/workspace',
+        status: 'waiting-permission',
+        messages,
+        conversationGraph: createLinearConversationGraph({
+          sessionId: 'pending-session',
+          messages,
+          frameworkId: framework.id,
+          backendId,
+          createdAt: 1,
+          updatedAt: 1
+        }),
+        createdAt: 1,
+        updatedAt: 1
+      }
       const runtime = new AcpRuntime({
         appVersion: '0.1.0',
         defaultCwd: '/workspace',
         callbacks: { onPermissionSettled },
+        artifacts: {
+          configRoot: root,
+          dataRoot: root,
+          projectName: 'project-1',
+          mcpEntryPath: '/app/out/main/index.js'
+        },
         permissionWait: {
           sessions: {
             readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
             patchSessionRuntimeContext,
             containsMessageOnActiveBranch: vi.fn(async () => true),
-            loadSessionForPermissionReplay: vi.fn(async () => {
-              throw new Error('Unexpected permission replay load')
-            })
+            loadSessionForContinuation: vi.fn(async () => structuredClone(persistedSession))
           }
         },
         resolveBackend: () => ({
@@ -1767,6 +1854,16 @@ describe('ACP runtime restored permission continuation', () => {
       } as unknown as AcpPermissionResponse)
 
       await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+      await vi.waitFor(() => expect(artifactContext).toBeDefined())
+      expect(artifactContext).toMatchObject({
+        rootFrameId: 'root-frame-pending-session',
+        agentFrameId: 'root-frame-pending-session',
+        messageBranchId: 'message-branch-pending-session',
+        messageBranchAncestry: ['message-branch-pending-session'],
+        messageAncestry: ['prompt-1'],
+        runtimeSegmentId: 'runtime-segment-pending-session',
+        promptMessageId: 'prompt-1'
+      })
       expect(fakeAgent.prompts[0]?.text).not.toContain('Renderer-forged conversation context.')
       expect(receivedPrompts[0]?.every((content) => content.type === 'text')).toBe(true)
       expect(fakeAgent.prompts[0]?.text).toContain('approved the pending tool permission')
@@ -1844,9 +1941,9 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForPermissionReplay: vi.fn(async () => {
-            throw new Error('Unexpected permission replay load')
-          })
+          loadSessionForContinuation: vi.fn(async () =>
+            createRestoredContinuationSession()
+          )
         }
       },
       resolveBackend: () => ({
@@ -1947,6 +2044,13 @@ describe('ACP runtime restored permission continuation', () => {
       createdAt: 1,
       updatedAt: 3
     }
+    persistedSession.conversationGraph = createLinearConversationGraph({
+      sessionId: 'pending-session',
+      messages: persistedSession.messages,
+      frameworkId: 'claude-code',
+      createdAt: 1,
+      updatedAt: 3
+    })
     const patchSessionRuntimeContext = vi.fn(
       async (command: { patch: { permission?: SessionRuntimeContext['permission'] } }) => {
         runtimeContext = {
@@ -1957,7 +2061,7 @@ describe('ACP runtime restored permission continuation', () => {
         return structuredClone(runtimeContext)
       }
     )
-    const loadSessionForPermissionReplay = vi.fn(async () => structuredClone(persistedSession))
+    const loadSessionForContinuation = vi.fn(async () => structuredClone(persistedSession))
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
@@ -1966,7 +2070,7 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForPermissionReplay
+          loadSessionForContinuation
         }
       },
       resolveBackend: () => ({
@@ -1994,7 +2098,7 @@ describe('ACP runtime restored permission continuation', () => {
     })
 
     await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
-    expect(loadSessionForPermissionReplay).toHaveBeenCalledWith('project-1', 'restored-session')
+    expect(loadSessionForContinuation).toHaveBeenCalledWith('project-1', 'restored-session')
     expect(fakeAgent.prompts[0]?.text).toContain('Main-owned earlier request.')
     expect(fakeAgent.prompts[0]?.text).toContain('approved the pending tool permission')
   })
@@ -2065,9 +2169,9 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForPermissionReplay: vi.fn(async () => {
-            throw new Error('Unexpected permission replay load')
-          })
+          loadSessionForContinuation: vi.fn(async () =>
+            createRestoredContinuationSession()
+          )
         }
       },
       resolveBackend: () => ({
@@ -2146,9 +2250,9 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForPermissionReplay: vi.fn(async () => {
-            throw new Error('Unexpected permission replay load')
-          })
+          loadSessionForContinuation: vi.fn(async () =>
+            createRestoredContinuationSession()
+          )
         }
       },
       resolveBackend: () => ({
@@ -2239,9 +2343,9 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForPermissionReplay: vi.fn(async () => {
-            throw new Error('Unexpected permission replay load')
-          })
+          loadSessionForContinuation: vi.fn(async () =>
+            createRestoredContinuationSession()
+          )
         }
       },
       resolveBackend: () => ({
@@ -2320,9 +2424,9 @@ describe('ACP runtime restored permission continuation', () => {
           readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
           patchSessionRuntimeContext,
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForPermissionReplay: vi.fn(async () => {
-            throw new Error('Unexpected permission replay load')
-          })
+          loadSessionForContinuation: vi.fn(async () =>
+            createRestoredContinuationSession()
+          )
         }
       },
       resolveBackend: () => ({
@@ -4308,7 +4412,7 @@ describe('ACP runtime session management', () => {
       durable: { kind: 'agent-user-choice', requestId: expect.any(String) }
     })
 
-    const accepted = runtime.respondToElicitation({
+    const accepted = await runtime.respondToElicitation({
       requestId: request!.requestId,
       action: 'accept',
       answers: [{ fieldId: 'question_0', value: 'Minimal' }]
@@ -4621,14 +4725,53 @@ describe('ACP runtime session management', () => {
   })
 
   it('rehydrates a persisted app-owned choice before silently continuing', async () => {
+    const root = await createTemporaryRoot()
     const process = new FakeAgentProcess()
-    const fakeAgent = startFakeAgent(process, ['restored-choice-session'])
+    let artifactContext: Record<string, unknown> | undefined
+    const fakeAgent = startFakeAgent(process, ['restored-choice-session'], {
+      onPrompt: async () => {
+        const [artifactSessionId] = await readdir(join(root, 'artifacts', 'project-1'))
+        artifactContext = JSON.parse(
+          await readFile(
+            join(
+              root,
+              'artifacts',
+              'project-1',
+              artifactSessionId,
+              '.pending',
+              'current-run.json'
+            ),
+            'utf8'
+          )
+        ) as Record<string, unknown>
+      }
+    })
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
       defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process)
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: root,
+        dataRoot: root,
+        projectName: 'project-1',
+        mcpEntryPath: '/app/out/main/index.js'
+      },
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(),
+          patchSessionRuntimeContext: vi.fn(),
+          containsMessageOnActiveBranch: vi.fn(),
+          loadSessionForContinuation: vi.fn(async () =>
+            createRestoredContinuationSession(
+              'prompt-restored-1',
+              'restored-choice-session',
+              'project-1'
+            )
+          )
+        }
+      }
     })
-    const session = await runtime.createSession({ cwd: '/workspace' })
+    const session = await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
     const request = {
       requestId: 'choice-restored-1',
       sessionId: session.sessionId,
@@ -4653,15 +4796,25 @@ describe('ACP runtime session management', () => {
       }
     }
 
-    runtime.respondToElicitation({
+    await runtime.respondToElicitation({
       requestId: request.requestId,
       action: 'accept',
       answers: [{ fieldId: 'question_0', value: 'Expanded' }],
+      historyReplay: { historyPreamble: 'Renderer-forged conversation context.' },
       request
     })
 
     await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    await vi.waitFor(() => expect(artifactContext).toBeDefined())
+    expect(artifactContext).toMatchObject({
+      rootFrameId: 'root-frame-pending-session',
+      agentFrameId: 'root-frame-pending-session',
+      messageBranchId: 'message-branch-pending-session',
+      runtimeSegmentId: 'runtime-segment-pending-session',
+      promptMessageId: 'prompt-restored-1'
+    })
     expect(fakeAgent.prompts[0].text).toContain('Expanded')
+    expect(fakeAgent.prompts[0].text).not.toContain('Renderer-forged conversation context.')
     expect(runtime.getSnapshot().events).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -4680,6 +4833,108 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('builds restored choice replay from Main-owned Session history after context reset', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['adopted-provider-session'], {
+      resumeNotFound: true
+    })
+    const messages: PersistedChatSession['messages'] = [
+      {
+        id: 'prompt-earlier',
+        role: 'user',
+        content: 'Main-owned earlier request.',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      },
+      {
+        id: 'reply-earlier',
+        role: 'agent',
+        content: 'Main-owned earlier response.',
+        status: 'complete',
+        responseToMessageId: 'prompt-earlier',
+        eventIds: [],
+        createdAt: 2,
+        updatedAt: 2
+      },
+      {
+        id: 'prompt-restored-1',
+        role: 'user',
+        content: 'Choose an approach.',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 3,
+        updatedAt: 3
+      }
+    ]
+    const persistedSession: PersistedChatSession = {
+      id: 'restored-choice-session',
+      projectId: 'project-1',
+      title: 'Restored choice',
+      cwd: '/workspace',
+      status: 'waiting-for-user',
+      messages,
+      conversationGraph: createLinearConversationGraph({
+        sessionId: 'pending-session',
+        messages,
+        frameworkId: 'claude-code',
+        createdAt: 1,
+        updatedAt: 3
+      }),
+      createdAt: 1,
+      updatedAt: 3
+    }
+    const loadSessionForContinuation = vi.fn(async () => structuredClone(persistedSession))
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(),
+          patchSessionRuntimeContext: vi.fn(),
+          containsMessageOnActiveBranch: vi.fn(),
+          loadSessionForContinuation
+        }
+      }
+    })
+
+    await expect(
+      runtime.resumeSession({
+        sessionId: 'restored-choice-session',
+        cwd: '/workspace',
+        projectName: 'project-1'
+      })
+    ).resolves.toMatchObject({ sessionId: 'restored-choice-session', contextReset: true })
+    await runtime.respondToElicitation({
+      requestId: 'choice-restored-1',
+      action: 'accept',
+      answers: [{ fieldId: 'question_0', value: 'Expanded' }],
+      historyReplay: { historyPreamble: 'Renderer-forged conversation context.' },
+      request: {
+        requestId: 'choice-restored-1',
+        sessionId: 'restored-choice-session',
+        toolCallId: 'tool-choice-restored-1',
+        message: 'Choose an approach',
+        fields: [{ id: 'question_0', label: 'Approach', kind: 'text' }],
+        durable: {
+          kind: 'agent-user-choice',
+          requestId: 'choice-restored-1',
+          promptMessageId: 'prompt-restored-1'
+        }
+      }
+    })
+
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    expect(loadSessionForContinuation).toHaveBeenCalledWith(
+      'project-1',
+      'restored-choice-session'
+    )
+    expect(fakeAgent.prompts[0].text).toContain('Main-owned earlier request.')
+    expect(fakeAgent.prompts[0].text).not.toContain('Renderer-forged conversation context.')
+  })
+
   it('rejects a mismatched restored choice without leaving a pending request', async () => {
     const process = new FakeAgentProcess()
     startFakeAgent(process, ['mismatched-choice-session'])
@@ -4690,7 +4945,7 @@ describe('ACP runtime session management', () => {
     })
     const session = await runtime.createSession({ cwd: '/workspace' })
 
-    expect(() =>
+    await expect(
       runtime.respondToElicitation({
         requestId: 'outer-choice-id',
         action: 'accept',
@@ -4714,8 +4969,68 @@ describe('ACP runtime session management', () => {
           durable: { kind: 'agent-user-choice', requestId: 'inner-choice-id' }
         }
       })
-    ).toThrow('Restored structured input request id does not match the response')
+    ).rejects.toThrow('Restored structured input request id does not match the response')
     expect(runtime.getSnapshot().pendingElicitations).toEqual([])
+  })
+
+  it('rejects a restored choice whose prompt left the active Message Branch without caching it', async () => {
+    const process = new FakeAgentProcess()
+    startFakeAgent(process, ['restored-choice-session'])
+    const persistedSession = createRestoredContinuationSession(
+      'prompt-active',
+      'restored-choice-session'
+    )
+    persistedSession.messages.push({
+      id: 'prompt-inactive',
+      role: 'user',
+      content: 'Use the abandoned approach.',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(),
+          patchSessionRuntimeContext: vi.fn(),
+          containsMessageOnActiveBranch: vi.fn(),
+          loadSessionForContinuation: vi.fn(async () => structuredClone(persistedSession))
+        }
+      }
+    })
+    await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+
+    await expect(
+      runtime.respondToElicitation({
+        requestId: 'choice-restored-1',
+        action: 'accept',
+        answers: [{ fieldId: 'question_0', value: 'Expanded' }],
+        request: {
+          requestId: 'choice-restored-1',
+          sessionId: 'restored-choice-session',
+          toolCallId: 'tool-choice-restored-1',
+          message: 'Choose an approach',
+          fields: [{ id: 'question_0', label: 'Approach', kind: 'text' }],
+          durable: {
+            kind: 'agent-user-choice',
+            requestId: 'choice-restored-1',
+            promptMessageId: 'prompt-inactive'
+          }
+        }
+      })
+    ).rejects.toThrow('active Message Branch')
+    expect(runtime.getSnapshot().pendingElicitations).toEqual([])
+    await expect(
+      runtime.respondToElicitation({
+        requestId: 'choice-restored-1',
+        action: 'accept',
+        answers: [{ fieldId: 'question_0', value: 'Expanded' }]
+      })
+    ).rejects.toThrow('Unknown structured input request')
   })
 
   it('waits for the asking turn to stop before silently continuing with the answer', async () => {
@@ -8489,7 +8804,7 @@ describe('ACP runtime session management', () => {
             }
           ),
           containsMessageOnActiveBranch: vi.fn(async () => true),
-          loadSessionForPermissionReplay: vi.fn(async () => {
+          loadSessionForContinuation: vi.fn(async () => {
             throw new Error('Unexpected permission replay load')
           })
         }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2026,6 +2026,15 @@ describe('ACP runtime restored permission continuation', () => {
         })
       )
       expect(onPermissionSettled).toHaveBeenCalledWith('permission-restored', 'resolved')
+      expect(runtime.getSnapshot().events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'permission',
+            title: 'Restored permission continuation settled',
+            permissionRequestId: 'permission-restored'
+          })
+        ])
+      )
     }
   )
 
@@ -2452,6 +2461,15 @@ describe('ACP runtime restored permission continuation', () => {
       ).toBe(true)
     )
     expect(runtimeContext.permission).toBeDefined()
+    expect(runtime.getSnapshot().events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'permission',
+          title: 'Restored permission continuation re-armed',
+          permissionRequestId: 'permission-restored'
+        })
+      ])
+    )
 
     await new Promise<void>((resolve) => setImmediate(resolve))
     await expect(runtime.respondToPermission(response)).resolves.toBeDefined()
@@ -2540,7 +2558,9 @@ describe('ACP runtime restored permission continuation', () => {
           .events.some(
             (event) =>
               event.kind === 'permission' &&
-              event.title === 'Permission continuation completed but its wait could not be cleared'
+              event.title ===
+                'Permission continuation completed but its wait could not be cleared' &&
+              event.permissionRequestId === 'permission-restored'
           )
       ).toBe(true)
     )
@@ -2625,6 +2645,7 @@ describe('ACP runtime restored permission continuation', () => {
           kind: 'permission',
           sessionId: 'restored-session',
           title: 'Restored permission continuation settled',
+          permissionRequestId: 'permission-restored',
           text: 'cancelled'
         })
       ])

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1029,13 +1029,17 @@ class AcpRuntime {
 
     if (!interactionInFlight && !durablePermission) {
       try {
-        if (await this.permissionWaitOwner.cancelPendingSession(request.sessionId)) {
+        const permissionRequestId = await this.permissionWaitOwner.cancelPendingSession(
+          request.sessionId
+        )
+        if (permissionRequestId) {
           this.restoredContinuationContextResetSessionIds?.delete(request.sessionId)
           this.permissionContext.clearRestoredDecision(request.sessionId)
           this.pushEvent({
             kind: 'permission',
             level: 'info',
             sessionId: request.sessionId,
+            permissionRequestId,
             title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
             text: 'cancelled'
           })
@@ -1237,6 +1241,7 @@ class AcpRuntime {
             kind: 'permission',
             level: 'info',
             sessionId: restored.sessionId,
+            permissionRequestId: response.requestId,
             title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
           })
         } catch (rearmError) {
@@ -1244,6 +1249,7 @@ class AcpRuntime {
             kind: 'permission',
             level: 'error',
             sessionId: restored.sessionId,
+            permissionRequestId: response.requestId,
             title: ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
             text: errorMessage(rearmError)
           })
@@ -1568,6 +1574,7 @@ class AcpRuntime {
               kind: 'permission',
               level: 'info',
               sessionId,
+              permissionRequestId: durablePermission.requestId,
               title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
               text: 'completed'
             })
@@ -1577,6 +1584,7 @@ class AcpRuntime {
             kind: 'permission',
             level: 'error',
             sessionId,
+            permissionRequestId: durablePermission.requestId,
             title: ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
             text: errorMessage(error)
           })
@@ -1596,6 +1604,7 @@ class AcpRuntime {
             kind: 'permission',
             level: 'info',
             sessionId,
+            permissionRequestId: durablePermission.requestId,
             title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
           })
         } catch (error) {
@@ -1603,6 +1612,7 @@ class AcpRuntime {
             kind: 'permission',
             level: 'error',
             sessionId,
+            permissionRequestId: durablePermission.requestId,
             title: ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
             text: errorMessage(error)
           })
@@ -1703,6 +1713,7 @@ class AcpRuntime {
         kind: 'permission',
         level: 'error',
         sessionId,
+        permissionRequestId: durablePermission.requestId,
         title: ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
         text: errorMessage(error)
       })
@@ -1716,6 +1727,7 @@ class AcpRuntime {
       kind: 'permission',
       level: 'info',
       sessionId,
+      permissionRequestId: durablePermission.requestId,
       title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
       text: 'cancelled'
     })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -371,6 +371,7 @@ class AcpRuntime {
   private readonly turnSkills: AcpTurnSkillOwner
   private readonly handoffContinuity: AcpHandoffContinuityOwner
   private readonly permissionContext: AcpPermissionContext
+  private readonly clientInteractions: AcpRuntimeSessionOwners['clientInteractions']
   private readonly publication: AcpRuntimePublicationOwner
   private readonly sessionEnvironment: AcpSessionEnvironmentPolicy
   private readonly spawnAgent: (() => ChildProcessWithoutNullStreams) | undefined
@@ -419,6 +420,7 @@ class AcpRuntime {
     this.sessionEnvironment = session.sessionEnvironment
     this.publication = session.publication
     this.permissionContext = session.permissionContext
+    this.clientInteractions = session.clientInteractions
     this.elicitationOwner = session.elicitationOwner
     this.durableContinuationContext = session.durableContinuationContext
     this.permissionWaitOwner = session.permissionWaitOwner
@@ -885,8 +887,8 @@ class AcpRuntime {
     onFrameworkResolved: (framework: AgentFramework['id']) => void
   ): Promise<AcpAgentConnectionCandidate> {
     const hooks: AcpAgentConnectionHooks = {
-      createElicitation: (params) => this.handleElicitationRequest(params),
-      requestPermission: (params) => this.permissionContext.handleProviderRequest(params),
+      createElicitation: (params) => this.clientInteractions.createElicitation(params),
+      requestPermission: (params) => this.clientInteractions.requestPermission(params),
       observeSessionUpdate: (notification) =>
         this.permissionContext.observeProviderUpdate(notification),
       observeClaudeSdkMessage: (params) => this.observeClaudeSdkMessage(params),
@@ -1679,70 +1681,6 @@ class AcpRuntime {
       throw new Error('No active assistant turn to attach a generated file to.')
     }
     return this.artifactTurns.writeForActiveTurn(sessionId, input)
-  }
-
-  private handleElicitationRequest(
-    params: acp.CreateElicitationRequest
-  ): Promise<acp.CreateElicitationResponse> {
-    if (!('sessionId' in params) || typeof params.sessionId !== 'string') {
-      return Promise.resolve({ action: 'cancel' })
-    }
-
-    const sessionId = this.sessionRegistry.resolveAppSessionId(params.sessionId)
-    if (!this.activeSessionFor(sessionId)) return Promise.resolve({ action: 'cancel' })
-
-    const meta = params._meta
-    const isCodexMcpToolApproval =
-      typeof meta === 'object' && meta !== null && meta.codex_approval_kind === 'mcp_tool_call'
-    const toolCallId = 'toolCallId' in params ? params.toolCallId : undefined
-    const frameworkId = this.getSessionFramework(sessionId)
-    // Codex ACP can surface an MCP approval through elicitation/create instead of
-    // session/request_permission. Keep that provider detail behind the existing permission owner so
-    // the renderer never mistakes an authorization prompt for structured user input.
-    if (frameworkId === 'codex' && isCodexMcpToolApproval) {
-      if (typeof toolCallId !== 'string') return Promise.resolve({ action: 'cancel' })
-      if (
-        this.permissionContext.consumeTrustedCodexMcpToolCall(
-          sessionId,
-          toolCallId,
-          'open-science-notebook/ask_user_question'
-        )
-      ) {
-        return Promise.resolve({ action: 'accept' })
-      }
-      if (!this.permissionContext.hasTrustedCodexMcpToolCall(sessionId, toolCallId)) {
-        return Promise.resolve({ action: 'cancel' })
-      }
-
-      const allowOnceOptionId = 'codex-elicitation-allow-once'
-      return this.permissionContext
-        .handleProviderRequest({
-          sessionId: params.sessionId,
-          toolCall: { toolCallId, kind: 'execute', status: 'pending' },
-          options: [
-            { optionId: allowOnceOptionId, name: 'Allow once', kind: 'allow_once' },
-            {
-              optionId: 'codex-elicitation-reject-once',
-              name: 'Deny',
-              kind: 'reject_once'
-            }
-          ],
-          _meta: { is_mcp_tool_approval: true }
-        })
-        .then((response) => {
-          if (response.outcome.outcome === 'cancelled') return { action: 'cancel' as const }
-          return response.outcome.optionId === allowOnceOptionId
-            ? { action: 'accept' as const }
-            : { action: 'decline' as const }
-        })
-    }
-
-    const promptInteraction = this.sessionInteractions.current(sessionId)
-    const durableChoiceContext =
-      promptInteraction?.kind === 'prompt' && promptInteraction.promptMessageId
-        ? { promptMessageId: promptInteraction.promptMessageId }
-        : undefined
-    return this.elicitationOwner.request(params, { sessionId }, durableChoiceContext)
   }
 
   private cancelPermissionFlowForSession(sessionId: string): void {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -178,6 +178,7 @@ type AcpRuntimeOptions = {
         Pick<SessionPersistenceCoordinator, 'appendUserMessageToInteraction' | 'sessionProjectId'>
       >
     onSessionUpdated?: import('./permission-wait-owner').PublishPermissionWaitSession
+    onContinuationSessionUpdated?: import('./permission-wait-owner').PublishPermissionWaitSession
   }
   sideChat?: Readonly<{
     sendMessage: (
@@ -1472,7 +1473,14 @@ class AcpRuntime {
               ? selectedAnswer.join(', ')
               : undefined
       return answer
-        ? [{ question: field.description ?? field.label ?? request.message, answer }]
+        ? [
+            {
+              question:
+                field.description ??
+                (request.fields.length === 1 ? request.message : (field.label ?? request.message)),
+              answer
+            }
+          ]
         : []
     })
     const text = (() => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -174,7 +174,9 @@ type AcpRuntimeOptions = {
       | 'containsMessageOnActiveBranch'
       | 'loadSessionForContinuation'
     > &
-      Partial<Pick<SessionPersistenceCoordinator, 'sessionProjectId'>>
+      Partial<
+        Pick<SessionPersistenceCoordinator, 'appendUserMessageToInteraction' | 'sessionProjectId'>
+      >
     onSessionUpdated?: import('./permission-wait-owner').PublishPermissionWaitSession
   }
   sideChat?: Readonly<{
@@ -1314,6 +1316,9 @@ class AcpRuntime {
         sessionId: response.request.sessionId,
         requestId: response.request.requestId,
         toolCallId: response.request.toolCallId,
+        action: response.action,
+        answers: response.answers,
+        replacePreviousAnswer: response.replacePreviousAnswer,
         ...(this.restoredContinuationContextResetSessionIds?.has(response.request.sessionId)
           ? {
               replay: {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -1296,7 +1296,9 @@ class AcpRuntime {
       throw new Error('Restored structured input request id does not match the response')
     }
     let restoredContinuation:
-      | Awaited<ReturnType<AcpRuntimeSessionOwners['durableContinuationContext']['prepare']>>
+      | Awaited<
+          ReturnType<AcpRuntimeSessionOwners['durableContinuationContext']['prepareElicitation']>
+        >
       | undefined
     if (
       !this.elicitationOwner
@@ -1307,14 +1309,11 @@ class AcpRuntime {
       if (!this.activeSessionFor(response.request.sessionId)) {
         throw new Error(`ACP session not found: ${response.request.sessionId}`)
       }
-      const promptMessageId = response.request.durable?.promptMessageId
-      if (!promptMessageId) {
-        throw new Error('Restored structured input request has no durable prompt authority')
-      }
-      restoredContinuation = await this.durableContinuationContext.prepare({
+      restoredContinuation = await this.durableContinuationContext.prepareElicitation({
         projectId: this.sessionEnvironment.projectName(response.request.sessionId),
         sessionId: response.request.sessionId,
-        promptMessageId,
+        requestId: response.request.requestId,
+        toolCallId: response.request.toolCallId,
         ...(this.restoredContinuationContextResetSessionIds?.has(response.request.sessionId)
           ? {
               replay: {
@@ -1324,7 +1323,7 @@ class AcpRuntime {
             }
           : {})
       })
-      if (!this.elicitationOwner.restoreDetached(response.request)) {
+      if (!this.elicitationOwner.restoreDetached(restoredContinuation.request)) {
         throw new Error('Invalid restored structured input request')
       }
     }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -172,7 +172,7 @@ type AcpRuntimeOptions = {
       | 'readSessionRuntimeContext'
       | 'patchSessionRuntimeContext'
       | 'containsMessageOnActiveBranch'
-      | 'loadSessionForPermissionReplay'
+      | 'loadSessionForContinuation'
     > &
       Partial<Pick<SessionPersistenceCoordinator, 'sessionProjectId'>>
     onSessionUpdated?: import('./permission-wait-owner').PublishPermissionWaitSession
@@ -356,12 +356,13 @@ class AcpRuntime {
   private readonly sessionInteractions: AcpSessionInteractionOwner
   private readonly elicitationOwner: AcpElicitationOwner
   private readonly appContinuations: AcpAppContinuationOwner
+  private readonly durableContinuationContext: AcpRuntimeSessionOwners['durableContinuationContext']
   private readonly permissionWaitOwner: AcpRuntimeSessionOwners['permissionWaitOwner']
   private durablePermissionContinuations?: Map<
     string,
     { projectId: string; requestId: string; cancellationRequested?: boolean }
   >
-  private restoredPermissionContextResetSessionIds?: Set<string>
+  private restoredContinuationContextResetSessionIds?: Set<string>
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
   private readonly reviewerSessions: ReviewerSessionOwner
   private readonly turnSkills: AcpTurnSkillOwner
@@ -416,6 +417,7 @@ class AcpRuntime {
     this.publication = session.publication
     this.permissionContext = session.permissionContext
     this.elicitationOwner = session.elicitationOwner
+    this.durableContinuationContext = session.durableContinuationContext
     this.permissionWaitOwner = session.permissionWaitOwner
     this.appContinuations = session.appContinuations
     this.reviewerSessions = session.reviewerSessions
@@ -633,12 +635,12 @@ class AcpRuntime {
   // Reattaches a persisted protocol session after an app restart so later prompts can stream.
   async resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
     return this.withOperationLease(async () => {
-      this.restoredPermissionContextResetSessionIds?.delete(request.sessionId)
+      this.restoredContinuationContextResetSessionIds?.delete(request.sessionId)
       const resumed = await this.providerSessionResumer.resume(request)
       if (resumed.contextReset) {
         const contextResetSessionIds =
-          this.restoredPermissionContextResetSessionIds ?? new Set<string>()
-        this.restoredPermissionContextResetSessionIds = contextResetSessionIds
+          this.restoredContinuationContextResetSessionIds ?? new Set<string>()
+        this.restoredContinuationContextResetSessionIds = contextResetSessionIds
         contextResetSessionIds.add(request.sessionId)
       }
       return resumed
@@ -1023,7 +1025,7 @@ class AcpRuntime {
     if (!interactionInFlight && !durablePermission) {
       try {
         if (await this.permissionWaitOwner.cancelPendingSession(request.sessionId)) {
-          this.restoredPermissionContextResetSessionIds?.delete(request.sessionId)
+          this.restoredContinuationContextResetSessionIds?.delete(request.sessionId)
           this.permissionContext.clearRestoredDecision(request.sessionId)
           this.pushEvent({
             kind: 'permission',
@@ -1178,15 +1180,19 @@ class AcpRuntime {
       projectId,
       restored.sessionId
     )
-    const historyReplay = this.restoredPermissionContextResetSessionIds?.has(restored.sessionId)
-      ? await this.permissionWaitOwner.buildRestoredContinuationReplay(
-          projectId,
-          restored.sessionId,
-          decision.permission,
-          this.restoredPermissionHistoryReplayDescriptor(),
-          this.backendGeneration.current.context.supportsImageInput
-        )
-      : undefined
+    const continuation = await this.durableContinuationContext.prepare({
+      projectId,
+      sessionId: restored.sessionId,
+      promptMessageId: decision.permission.originatingPromptMessageId,
+      ...(this.restoredContinuationContextResetSessionIds?.has(restored.sessionId)
+        ? {
+            replay: {
+              descriptor: this.durableContinuationHistoryReplayDescriptor(),
+              supportsImageInput: this.backendGeneration.current.context.supportsImageInput
+            }
+          }
+        : {})
+    })
     const durablePermissionContinuations =
       this.durablePermissionContinuations ??
       new Map<string, { projectId: string; requestId: string; cancellationRequested?: boolean }>()
@@ -1256,17 +1262,15 @@ class AcpRuntime {
         sessionId: restored.sessionId,
         text,
         suppressUserMessage: true,
-        provenanceContext: {
-          promptMessageId: decision.permission.originatingPromptMessageId
-        },
-        ...(historyReplay?.historyPreamble
-          ? { historyPreamble: historyReplay.historyPreamble }
+        provenanceContext: continuation.provenanceContext,
+        ...(continuation.historyReplay?.historyPreamble
+          ? { historyPreamble: continuation.historyReplay.historyPreamble }
           : {}),
-        ...(historyReplay?.historyAttachments.length
-          ? { historyAttachments: historyReplay.historyAttachments }
+        ...(continuation.historyReplay?.historyAttachments.length
+          ? { historyAttachments: continuation.historyReplay.historyAttachments }
           : {}),
-        ...(historyReplay?.historyImages.length
-          ? { historyImages: historyReplay.historyImages }
+        ...(continuation.historyReplay?.historyImages.length
+          ? { historyImages: continuation.historyReplay.historyImages }
           : {})
       }
     })
@@ -1287,10 +1291,13 @@ class AcpRuntime {
     return this.getSnapshot()
   }
 
-  respondToElicitation(response: ElicitationResponse): AcpStateSnapshot {
+  async respondToElicitation(response: ElicitationResponse): Promise<AcpStateSnapshot> {
     if (response.request && response.request.requestId !== response.requestId) {
       throw new Error('Restored structured input request id does not match the response')
     }
+    let restoredContinuation:
+      | Awaited<ReturnType<AcpRuntimeSessionOwners['durableContinuationContext']['prepare']>>
+      | undefined
     if (
       !this.elicitationOwner
         .getPendingRequests()
@@ -1300,6 +1307,23 @@ class AcpRuntime {
       if (!this.activeSessionFor(response.request.sessionId)) {
         throw new Error(`ACP session not found: ${response.request.sessionId}`)
       }
+      const promptMessageId = response.request.durable?.promptMessageId
+      if (!promptMessageId) {
+        throw new Error('Restored structured input request has no durable prompt authority')
+      }
+      restoredContinuation = await this.durableContinuationContext.prepare({
+        projectId: this.sessionEnvironment.projectName(response.request.sessionId),
+        sessionId: response.request.sessionId,
+        promptMessageId,
+        ...(this.restoredContinuationContextResetSessionIds?.has(response.request.sessionId)
+          ? {
+              replay: {
+                descriptor: this.durableContinuationHistoryReplayDescriptor(),
+                supportsImageInput: this.backendGeneration.current.context.supportsImageInput
+              }
+            }
+          : {})
+      })
       if (!this.elicitationOwner.restoreDetached(response.request)) {
         throw new Error('Invalid restored structured input request')
       }
@@ -1310,7 +1334,8 @@ class AcpRuntime {
       const continuation = this.userChoiceContinuation(
         resolution.request,
         resolution.response,
-        response.historyReplay
+        restoredContinuation?.historyReplay,
+        restoredContinuation?.provenanceContext
       )
       if (continuation) {
         this.appContinuations.set(resolution.request.sessionId, {
@@ -1319,6 +1344,7 @@ class AcpRuntime {
         })
         this.schedulePendingAppContinuation(resolution.request.sessionId)
       }
+      this.restoredContinuationContextResetSessionIds?.delete(resolution.request.sessionId)
     }
     return this.getSnapshot()
   }
@@ -1420,7 +1446,8 @@ class AcpRuntime {
   private userChoiceContinuation(
     request: PendingElicitationRequest,
     response: CreateElicitationResponse,
-    historyReplay?: ElicitationResponse['historyReplay']
+    historyReplay?: ElicitationResponse['historyReplay'],
+    provenanceContext?: AcpPromptRequest['provenanceContext']
   ): AcpPromptRequest | undefined {
     if (response.action === 'cancel') return undefined
     const content =
@@ -1457,13 +1484,16 @@ class AcpRuntime {
         .join('\n\n')
       return `The user answered the pending questions:\n${answers}\nContinue the current task using these answers without asking the same questions again.`
     })()
+    const continuationProvenance =
+      provenanceContext ??
+      (request.durable?.promptMessageId
+        ? { promptMessageId: request.durable.promptMessageId }
+        : undefined)
     return {
       sessionId: request.sessionId,
       text,
       suppressUserMessage: true,
-      ...(request.durable?.promptMessageId
-        ? { provenanceContext: { promptMessageId: request.durable.promptMessageId } }
-        : {}),
+      ...(continuationProvenance ? { provenanceContext: continuationProvenance } : {}),
       ...(historyReplay?.historyPreamble ? { historyPreamble: historyReplay.historyPreamble } : {}),
       ...(historyReplay?.historyAttachments?.length
         ? { historyAttachments: historyReplay.historyAttachments }
@@ -1512,7 +1542,7 @@ class AcpRuntime {
       if (durablePermission?.cancellationRequested) {
         await this.settleCancelledDurablePermissionContinuation(sessionId)
       } else if (completed && durablePermission) {
-        this.restoredPermissionContextResetSessionIds?.delete(sessionId)
+        this.restoredContinuationContextResetSessionIds?.delete(sessionId)
         try {
           const cleared = await this.permissionWaitOwner.clearAfterContinuation(
             durablePermission.projectId,
@@ -1730,7 +1760,7 @@ class AcpRuntime {
     }
     if (this.durablePermissionContinuations?.get(sessionId) !== durablePermission) return
     this.durablePermissionContinuations.delete(sessionId)
-    this.restoredPermissionContextResetSessionIds?.delete(sessionId)
+    this.restoredContinuationContextResetSessionIds?.delete(sessionId)
     this.permissionContext.clearRestoredDecision(sessionId)
     this.pushEvent({
       kind: 'permission',
@@ -1741,7 +1771,7 @@ class AcpRuntime {
     })
   }
 
-  private restoredPermissionHistoryReplayDescriptor(): HistoryReplayDescriptor {
+  private durableContinuationHistoryReplayDescriptor(): HistoryReplayDescriptor {
     const backend = this.backendGeneration.current
     const target =
       backend.framework.id === 'opencode'

--- a/src/main/runtime-state-ownership.architecture.test.ts
+++ b/src/main/runtime-state-ownership.architecture.test.ts
@@ -423,16 +423,28 @@ describe('runtime state ownership architecture', () => {
     expect(composition).not.toMatch(/AcpRuntime\.prototype|from ['"]electron['"]/)
   })
 
-  it('keeps provider permission routing and reviewer preparation behind their owners', () => {
-    const source = readSource('src/main/acp/runtime.ts')
+  it('keeps provider interactions and reviewer preparation behind their owners', () => {
+    const runtime = readSource('src/main/acp/runtime.ts')
+    const interactions = readSource('src/main/acp/client-interaction-owner.ts')
+    const composition = readSource('src/main/acp/runtime-session-composition.ts')
 
-    expect(source).not.toContain('private async handlePermissionRequest')
-    expect(source).not.toContain('private observePermissionToolContext')
-    expect(source).not.toContain('reviewerSessions.create(request, async')
-    expect(source).toContain('this.permissionContext.handleProviderRequest(params)')
-    expect(source).toContain('this.permissionContext.observeProviderUpdate(notification)')
-    expect(source).toContain('this.reviewerSessions.create(request, {')
-    expect(source).toContain('ensureConnected: (cwd) => this.ensureConnected(cwd)')
+    expect(runtime).not.toContain('private async handlePermissionRequest')
+    expect(runtime).not.toContain('private handleElicitationRequest')
+    expect(runtime).not.toContain('private observePermissionToolContext')
+    expect(runtime).not.toContain('reviewerSessions.create(request, async')
+    expect(runtime).not.toContain('codex_approval_kind')
+    expect(runtime).toContain('this.clientInteractions.createElicitation(params)')
+    expect(runtime).toContain('this.clientInteractions.requestPermission(params)')
+    expect(runtime).toContain('this.permissionContext.observeProviderUpdate(notification)')
+    expect(runtime).toContain('this.reviewerSessions.create(request, {')
+    expect(runtime).toContain('ensureConnected: (cwd) => this.ensureConnected(cwd)')
+
+    expect(interactions).toContain("meta.codex_approval_kind === 'mcp_tool_call'")
+    expect(interactions).toContain('this.options.elicitation.request(')
+    expect(interactions).toContain('this.options.permission.handleProviderRequest(params)')
+    expect(composition.match(/new AcpClientInteractionOwner\(/g)).toHaveLength(1)
+    expect(composition).toContain('elicitation: elicitationOwner')
+    expect(composition).toContain('permission: permissionContext')
   })
 
   it('keeps provider selection and Context routing behind their prompt owners', () => {

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -404,7 +404,7 @@ describe('Session persistence coordinator architecture', () => {
         'listLegacyProjectSessionTombstones',
         'loadAll',
         'loadAllReadOnly',
-        'loadSessionForPermissionReplay',
+        'loadSessionForContinuation',
         'loadPersistedSideChats',
         'markCommittedProjectSessionsPrepared',
         'patchSessionRuntimeContext',

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -280,7 +280,7 @@ describe('SessionPersistenceCoordinator', () => {
     }
   )
 
-  it('loads an isolated durable Session snapshot for permission replay', async () => {
+  it('loads an isolated durable Session snapshot for a continuation', async () => {
     const durable = createSession({
       messages: [
         {
@@ -302,14 +302,14 @@ describe('SessionPersistenceCoordinator', () => {
     })
     const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
 
-    const loaded = await coordinator.loadSessionForPermissionReplay('project-1', 'session-1')
+    const loaded = await coordinator.loadSessionForContinuation('project-1', 'session-1')
     loaded.messages[0].content = 'mutated snapshot'
 
     expect(durable.messages[0].content).toBe('Run the command')
   })
 
   it.each(['missing', 'unreadable'] as const)(
-    'refuses permission replay when the durable Session is %s',
+    'refuses a durable continuation when the Session is %s',
     async (status) => {
       const repository = createSessionRepository({
         loadSessionWithDiagnostics: vi.fn(async () => ({ status }))
@@ -317,8 +317,8 @@ describe('SessionPersistenceCoordinator', () => {
       const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
 
       await expect(
-        coordinator.loadSessionForPermissionReplay('project-1', 'session-1')
-      ).rejects.toThrow(`Cannot build permission replay for a ${status} Session.`)
+        coordinator.loadSessionForContinuation('project-1', 'session-1')
+      ).rejects.toThrow(`Cannot prepare a durable continuation for a ${status} Session.`)
     }
   )
 

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -337,14 +337,19 @@ describe('SessionPersistenceCoordinator', () => {
       })
     })
     const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+    const beforePersist = vi.fn()
 
     await coordinator.appendUserMessageToInteraction({
       projectId: 'project-1',
       sessionId: 'session-1',
       interactionId: 'interaction-1',
-      content: 'Split the analysis by cohort.'
+      content: 'Split the analysis by cohort.',
+      beforePersist
     })
 
+    expect(beforePersist).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'session-1', messages: [] })
+    )
     expect(durable.messages).toContainEqual(
       expect.objectContaining({
         role: 'user',

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -206,14 +206,14 @@ class SessionPersistenceCoordinator {
     )
   }
 
-  loadSessionForPermissionReplay(
+  loadSessionForContinuation(
     projectId: string,
     sessionId: string
   ): Promise<PersistedChatSession> {
     return this.enqueue(async () => {
       const loaded = await this.repository.loadSessionWithDiagnostics(projectId, sessionId)
       if (loaded.status !== 'found') {
-        throw new Error(`Cannot build permission replay for a ${loaded.status} Session.`)
+        throw new Error(`Cannot prepare a durable continuation for a ${loaded.status} Session.`)
       }
       return structuredClone(loaded.session)
     })

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -206,10 +206,7 @@ class SessionPersistenceCoordinator {
     )
   }
 
-  loadSessionForContinuation(
-    projectId: string,
-    sessionId: string
-  ): Promise<PersistedChatSession> {
+  loadSessionForContinuation(projectId: string, sessionId: string): Promise<PersistedChatSession> {
     return this.enqueue(async () => {
       const loaded = await this.repository.loadSessionWithDiagnostics(projectId, sessionId)
       if (loaded.status !== 'found') {

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -36,7 +36,7 @@ type AppendUserMessageToInteractionCommand = Readonly<{
   sessionId: string
   interactionId: string
   content: string
-  beforePersist?: () => void
+  beforePersist?: (session: PersistedChatSession) => void
 }>
 
 type SessionStateRepository = {
@@ -341,7 +341,7 @@ class SessionPersistenceStateOwner {
     if (!content) throw new Error('User Message content must be non-empty.')
     this.options.assertMutable(projectId, sessionId, 'mutate')
     const session = await this.loadRuntimeContextSession(projectId, sessionId, 'patch')
-    command.beforePersist?.()
+    command.beforePersist?.(session)
     const timestamp = Math.max(session.updatedAt + 1, Date.now())
     const message: PersistedChatMessage = {
       id: `message-${randomUUID()}`,

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -4,13 +4,18 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID,
   MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
   type ProjectDeletedEvent,
   type SessionDeletedEvent,
   type SessionUpsertEvent
 } from '../../../shared/lifecycle-events'
 import type { Project } from '../../../shared/projects'
-import { getActiveConversationContext } from '../../../shared/conversation-graph'
+import {
+  createLinearConversationGraph,
+  getActiveConversationContext,
+  synchronizeActiveConversationMessages
+} from '../../../shared/conversation-graph'
 import { validateDurableMessageOwnership } from '../../../main/artifacts/provenance-message-finalization'
 import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
 import { useNavigationStore } from '@/stores/navigation-store'
@@ -252,6 +257,99 @@ describe('useLifecycleSync', () => {
       'Run the verification',
       'Preparing the command.'
     ])
+  })
+
+  it('applies a Main-owned continuation prompt before projecting later artifact events', async () => {
+    const prompt = {
+      id: 'prompt-original',
+      role: 'user' as const,
+      content: 'Choose an approach.',
+      status: 'complete' as const,
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const preamble = {
+      id: 'agent-question-preamble',
+      role: 'agent' as const,
+      content: 'Please choose one option.',
+      status: 'complete' as const,
+      responseToMessageId: prompt.id,
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const base = {
+      ...session,
+      messages: [prompt, preamble],
+      conversationGraph: createLinearConversationGraph({
+        sessionId: session.id,
+        messages: [prompt, preamble],
+        frameworkId: 'claude-code',
+        createdAt: 1,
+        updatedAt: 2
+      }),
+      updatedAt: 2
+    }
+    useSessionStore.getState().hydrateSessions([base])
+    const revisionPrompt = {
+      id: 'prompt-revision',
+      role: 'user' as const,
+      content: 'The user revised the previous structured answer: Approach: Expanded',
+      status: 'complete' as const,
+      responseToMessageId: preamble.id,
+      eventIds: [],
+      createdAt: 3,
+      updatedAt: 3
+    }
+    const durable = {
+      ...base,
+      messages: [...base.messages, revisionPrompt],
+      conversationGraph: synchronizeActiveConversationMessages(
+        base.conversationGraph,
+        [...base.messages, revisionPrompt],
+        3
+      ),
+      updatedAt: 3
+    }
+
+    await act(async () => {
+      listeners.sessionUpdated?.({
+        session: durable,
+        originClientId: MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID
+      })
+    })
+
+    const projected = toPersistedSession(useSessionStore.getState().sessions[0])
+    expect(projected.messages.at(-1)).toMatchObject({ id: revisionPrompt.id })
+    expect(projected.conversationGraph?.messages.at(-1)).toMatchObject({
+      id: revisionPrompt.id,
+      introducedOnBranchId: `message-branch-${session.id}`
+    })
+    const context = getActiveConversationContext(projected.conversationGraph!, revisionPrompt.id)
+    const finalMessage = {
+      id: 'agent-final',
+      role: 'agent' as const,
+      content: 'Created the revised artifact.',
+      status: 'complete' as const,
+      responseToMessageId: revisionPrompt.id,
+      eventIds: [],
+      createdAt: 4,
+      updatedAt: 4
+    }
+    projected.messages.push(finalMessage)
+    projected.conversationGraph = synchronizeActiveConversationMessages(
+      projected.conversationGraph!,
+      projected.messages,
+      4,
+      context.runtimeSegmentId
+    )
+    expect(() =>
+      validateDurableMessageOwnership(projected, {
+        ...context,
+        messageId: finalMessage.id
+      })
+    ).not.toThrow()
   })
 
   it("does not roll back live conversation state from this renderer's save echo", async () => {

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -201,31 +201,33 @@ describe('useLifecycleSync', () => {
       content: 'Preparing the command.'
     })
 
+    const pendingAuthoritySession = {
+      ...durableBeforeOutput,
+      status: 'waiting-permission' as const,
+      updatedAt: durableBeforeOutput.updatedAt + 1,
+      runtimeContext: {
+        version: 1 as const,
+        revision: 1,
+        permission: {
+          state: 'pending' as const,
+          request: {
+            requestId: 'permission-1',
+            sessionId: session.id,
+            toolCallId: 'tool-1',
+            title: 'Run npm test',
+            options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' as const }]
+          },
+          originatingPromptMessageId: prompt!.messageId,
+          fingerprint: 'a'.repeat(64),
+          createdAt: 1
+        }
+      }
+    }
+
     await act(async () => {
       listeners.sessionUpdated?.({
         originClientId: MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
-        session: {
-          ...durableBeforeOutput,
-          status: 'waiting-permission',
-          updatedAt: durableBeforeOutput.updatedAt + 1,
-          runtimeContext: {
-            version: 1,
-            revision: 1,
-            permission: {
-              state: 'pending',
-              request: {
-                requestId: 'permission-1',
-                sessionId: session.id,
-                toolCallId: 'tool-1',
-                title: 'Run npm test',
-                options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
-              },
-              originatingPromptMessageId: prompt!.messageId,
-              fingerprint: 'a'.repeat(64),
-              createdAt: 1
-            }
-          }
-        }
+        session: pendingAuthoritySession
       })
     })
 
@@ -254,6 +256,25 @@ describe('useLifecycleSync', () => {
     expect(settled.status).toBe('running')
     expect(settled.runtimeContext?.permission).toBeUndefined()
     expect(settled.messages.map((message) => message.content)).toEqual([
+      'Run the verification',
+      'Preparing the command.'
+    ])
+
+    await act(async () => {
+      listeners.sessionUpdated?.({
+        originClientId: MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
+        session: {
+          ...pendingAuthoritySession,
+          updatedAt: durableBeforeOutput.updatedAt + 3
+        }
+      })
+    })
+
+    const afterStalePendingReplay = useSessionStore.getState().sessions[0]
+    expect(afterStalePendingReplay.status).toBe('running')
+    expect(afterStalePendingReplay.runtimeContext?.revision).toBe(2)
+    expect(afterStalePendingReplay.runtimeContext?.permission).toBeUndefined()
+    expect(afterStalePendingReplay.messages.map((message) => message.content)).toEqual([
       'Run the verification',
       'Preparing the command.'
     ])

--- a/src/renderer/src/hooks/useLifecycleSync.ts
+++ b/src/renderer/src/hooks/useLifecycleSync.ts
@@ -1,6 +1,7 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 import {
+  MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID,
   MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
   type SessionUpsertEvent
 } from '../../../shared/lifecycle-events'
@@ -118,7 +119,19 @@ const useLifecycleSync = ({
         // live projection here can discard a prompt and the Runtime Segment used by its artifact
         // claim. Events from other clients remain authoritative synchronization input; same-client
         // command results return through their direct IPC path.
-        if (originClientId === MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID) {
+        if (originClientId === MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID) {
+          const store = useSessionStore.getState()
+          const source = store.sessions.find((candidate) => candidate.id === session.id)
+          if (source) {
+            store.applyDurableSessionProjection({
+              source,
+              session,
+              mode: 'replace-persisted-if-current'
+            })
+          } else {
+            store.upsertPersistedSession(session)
+          }
+        } else if (originClientId === MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID) {
           const store = useSessionStore.getState()
           const source = store.sessions.find((candidate) => candidate.id === session.id)
           if (source) {

--- a/src/renderer/src/lib/acp/runtime-snapshot-revision-owner.ts
+++ b/src/renderer/src/lib/acp/runtime-snapshot-revision-owner.ts
@@ -1,0 +1,21 @@
+import type { AcpStateSnapshot } from '../../../../shared/acp'
+
+let latestRevision: number | undefined
+
+// Reserves Main snapshot order synchronously at every renderer ingress. Multiple consumers may
+// observe the same revision, but no consumer may admit authority older than the shared watermark.
+const acceptAcpRuntimeSnapshotRevision = (
+  snapshot: Pick<AcpStateSnapshot, 'revision'>
+): boolean => {
+  const revision = snapshot.revision
+  if (revision === undefined) return latestRevision === undefined
+  if (latestRevision !== undefined && revision < latestRevision) return false
+  latestRevision = revision
+  return true
+}
+
+const resetAcpRuntimeSnapshotRevisionForTests = (): void => {
+  latestRevision = undefined
+}
+
+export { acceptAcpRuntimeSnapshotRevision, resetAcpRuntimeSnapshotRevisionForTests }

--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -5,6 +5,10 @@ import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAcpRuntime } from './useAcpRuntime'
+import {
+  acceptAcpRuntimeSnapshotRevision,
+  resetAcpRuntimeSnapshotRevisionForTests
+} from './runtime-snapshot-revision-owner'
 
 // React's act() refuses to run unless the environment opts in to act-aware scheduling.
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -100,6 +104,7 @@ const mountRuntime = async (): Promise<{
 }
 
 beforeEach(() => {
+  resetAcpRuntimeSnapshotRevisionForTests()
   capturedStateListener = undefined
   removeStateListener = vi.fn()
   acpApi = {
@@ -435,6 +440,50 @@ describe('useAcpRuntime state subscription', () => {
     unmount()
 
     expect(removeStateListener).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not let an older initial snapshot overwrite a newer pushed lifecycle event', async () => {
+    const initial = createDeferred<AcpStateSnapshot>()
+    acpApi.getState.mockReturnValueOnce(initial.promise)
+    const { result } = await mountRuntime()
+    const terminal = createSnapshot({
+      revision: 2,
+      events: [
+        {
+          id: 'permission-settled',
+          timestamp: 2,
+          kind: 'permission',
+          level: 'info',
+          permissionRequestId: 'permission-restored',
+          title: 'Restored permission settled'
+        }
+      ]
+    })
+
+    act(() => {
+      capturedStateListener?.(terminal)
+    })
+    expect(acceptAcpRuntimeSnapshotRevision({ revision: 1 })).toBe(false)
+    await act(async () => {
+      initial.resolve(
+        createSnapshot({
+          revision: 1,
+          events: [
+            {
+              id: 'permission-rearmed',
+              timestamp: 1,
+              kind: 'permission',
+              level: 'info',
+              permissionRequestId: 'permission-restored',
+              title: 'Restored permission rearmed'
+            }
+          ]
+        })
+      )
+      await initial.promise
+    })
+
+    expect(result.current.state).toEqual(terminal)
   })
 })
 

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../../../shared/acp'
 import type { PermissionProfileId } from '../../../../shared/permission-profiles'
 import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react'
+import { acceptAcpRuntimeSnapshotRevision } from './runtime-snapshot-revision-owner'
 
 // Provides a stable renderer fallback before the first main-process snapshot arrives.
 const emptyAcpState: AcpStateSnapshot = {
@@ -111,21 +112,28 @@ const useAcpRuntime = (): {
   const [isConnecting, setIsConnecting] = useState(false)
   const [isDisconnecting, setIsDisconnecting] = useState(false)
 
+  const applySnapshot = useCallback((snapshot: AcpStateSnapshot): void => {
+    if (!acceptAcpRuntimeSnapshotRevision(snapshot)) return
+    setState(snapshot)
+  }, [])
+
   // Loads the initial snapshot and keeps state fresh through runtime broadcasts.
   useEffect(() => {
     let isMounted = true
+    let hasPushedSnapshot = false
 
     // Avoids setting React state after the component using the hook unmounts.
-    const applySnapshot = (snapshot: AcpStateSnapshot): void => {
-      if (isMounted) {
-        setState(snapshot)
-      }
+    const applyMountedSnapshot = (snapshot: AcpStateSnapshot): void => {
+      if (isMounted) applySnapshot(snapshot)
     }
 
     // Pulls current runtime state before any broadcast has arrived.
     const loadInitialState = async (): Promise<void> => {
       try {
-        applySnapshot(await window.api.acp.getState())
+        const snapshot = await window.api.acp.getState()
+        // Older Main versions do not publish revisions. In that compatibility case, a pushed
+        // snapshot received after subscription is the only safe authority over the initial pull.
+        if (!hasPushedSnapshot || snapshot.revision !== undefined) applyMountedSnapshot(snapshot)
       } catch (error) {
         if (isMounted) {
           setActionError(getErrorMessage(error))
@@ -133,7 +141,10 @@ const useAcpRuntime = (): {
       }
     }
 
-    const removeStateListener = window.api.acp.onState(applySnapshot)
+    const removeStateListener = window.api.acp.onState((snapshot) => {
+      hasPushedSnapshot = true
+      applyMountedSnapshot(snapshot)
+    })
 
     void loadInitialState()
 
@@ -141,7 +152,7 @@ const useAcpRuntime = (): {
       isMounted = false
       removeStateListener()
     }
-  }, [])
+  }, [applySnapshot])
 
   // Runs an IPC action that returns a full runtime snapshot.
   const runSnapshotAction = useCallback(
@@ -154,7 +165,7 @@ const useAcpRuntime = (): {
 
       try {
         const snapshot = await action()
-        setState(snapshot)
+        applySnapshot(snapshot)
         return snapshot
       } catch (error) {
         setActionError(getErrorMessage(error))
@@ -163,7 +174,7 @@ const useAcpRuntime = (): {
         setPending?.(false)
       }
     },
-    []
+    [applySnapshot]
   )
 
   // Runs an IPC action that returns a non-snapshot value such as a new session id.
@@ -202,10 +213,10 @@ const useAcpRuntime = (): {
       // Apply state-sync side-effect before returning, matching runSnapshotAction's contract.
       // Without this, callers that do `void runtime.sendPrompt(...)` would discard the snapshot
       // and the UI would show stale state until the next async IPC event fires.
-      setState(snapshot)
+      applySnapshot(snapshot)
       return snapshot
     },
-    []
+    [applySnapshot]
   )
 
   // Keep all renderer ACP IPC calls in one hook so the future conversation UI can reuse it.
@@ -363,14 +374,14 @@ const useAcpRuntime = (): {
       setActionError(null)
       try {
         const snapshot = await window.api.acp.respondToPermission(response)
-        setState(snapshot)
+        applySnapshot(snapshot)
         return snapshot
       } catch (error) {
         setActionError(getErrorMessage(error))
         throw error
       }
     },
-    []
+    [applySnapshot]
   )
 
   const respondToElicitation = useCallback(
@@ -378,14 +389,14 @@ const useAcpRuntime = (): {
       setActionError(null)
       try {
         const snapshot = await window.api.acp.respondToElicitation(response)
-        setState(snapshot)
+        applySnapshot(snapshot)
         return snapshot
       } catch (error) {
         setActionError(getErrorMessage(error))
         throw error
       }
     },
-    []
+    [applySnapshot]
   )
 
   const setPermissionProfile = useCallback(

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -5,7 +5,15 @@ import { act, type JSX } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 
-import type { AcpCreateSessionResponse, AcpStateSnapshot } from '../../../../shared/acp'
+import {
+  ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+  type AcpCreateSessionResponse,
+  type AcpPermissionRequest,
+  type AcpStateSnapshot
+} from '../../../../shared/acp'
 import {
   createInitialSessionState,
   toPersistedSession,
@@ -13,7 +21,11 @@ import {
 } from '../../stores/session-store'
 import { createInitialSettingsState, useSettingsStore } from '../../stores/settings-store'
 import { resetDeferredArtifactEventsForTests } from './workspace-events'
-import { resetWorkspaceRuntimeEventOwnerForTests } from './workspace-runtime-event-owner'
+import { acceptAcpRuntimeSnapshotRevision } from './runtime-snapshot-revision-owner'
+import {
+  drainWorkspaceRuntimeEventsForPersistence,
+  resetWorkspaceRuntimeEventOwnerForTests
+} from './workspace-runtime-event-owner'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -107,6 +119,56 @@ describe('workspace Agent Runtime hook contract', () => {
         </WorkspaceAgentRuntimeProvider>
       )
     )
+  }
+
+  const projectRestoredPermissionPending = (request: AcpPermissionRequest): void => {
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === request.sessionId
+          ? {
+              ...session,
+              status: 'waiting-permission',
+              activeRun: undefined,
+              runtimeContext: {
+                ...session.runtimeContext,
+                version: 1,
+                revision: (session.runtimeContext?.revision ?? 0) + 1,
+                permission: {
+                  state: 'pending',
+                  request,
+                  originatingPromptMessageId: session.messages[0].id,
+                  fingerprint: 'a'.repeat(64),
+                  createdAt: 1
+                }
+              }
+            }
+          : session
+      )
+    }))
+  }
+
+  const arrangeRestoredPermission = (): {
+    request: AcpPermissionRequest
+    runtime: RuntimeMock
+  } => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Run the verification',
+      cwd: workspacePath,
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code'
+    })
+    const request: AcpPermissionRequest = {
+      requestId: 'permission-restored',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Run npm test',
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    projectRestoredPermissionPending(request)
+    const runtime = createRuntime(createSnapshot({ sessionIds: ['session-1'] }))
+    runtimeMock.current = runtime
+    return { request, runtime }
   }
 
   beforeEach(() => {
@@ -579,72 +641,324 @@ describe('workspace Agent Runtime hook contract', () => {
     expect(useSessionStore.getState().sessions[0].interrupted).toBeUndefined()
   })
 
-  it('preserves a Main rearm that arrives before the restored response settles', async () => {
-    useSessionStore.getState().appendUserMessage({
-      sessionId: 'session-1',
-      content: 'Run the verification',
-      cwd: workspacePath,
-      projectId: 'project-1',
-      agentFrameworkId: 'claude-code'
-    })
-    const request = {
-      requestId: 'permission-restored',
-      sessionId: 'session-1',
-      toolCallId: 'tool-1',
-      title: 'Run npm test',
-      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
-    }
-    useSessionStore.setState((state) => ({
-      sessions: state.sessions.map((session) => ({
-        ...session,
-        status: 'waiting-permission',
-        activeRun: undefined,
-        runtimeContext: {
-          version: 1,
-          revision: 1,
-          permission: {
-            state: 'pending',
-            request,
-            originatingPromptMessageId: session.messages[0].id,
-            fingerprint: 'a'.repeat(64),
-            createdAt: 1
-          }
-        }
-      }))
-    }))
+  it('keeps an accepted restored permission hidden across a newer pending projection', async () => {
+    const { request, runtime } = arrangeRestoredPermission()
     const deferred = createDeferred<AcpStateSnapshot>()
-    const runtime = createRuntime(createSnapshot({ sessionIds: ['session-1'] }))
     runtime.respondToPermission.mockReturnValue(deferred.promise)
-    runtimeMock.current = runtime
     await render()
 
     let first!: Promise<void>
     act(() => {
       first = latest.respondToPermission('permission-restored', 'allow-once')
     })
-    act(() => {
-      useSessionStore.setState((state) => ({
-        sessions: state.sessions.map((session) =>
-          session.id === 'session-1'
-            ? {
-                ...session,
-                status: 'waiting-permission',
-                runtimeContext: { ...session.runtimeContext!, revision: 3 }
-              }
-            : session
-        )
-      }))
-    })
     deferred.resolve(createSnapshot({ sessionIds: ['session-1'] }))
     await act(async () => first)
-    expect(useSessionStore.getState().sessions[0].status).toBe('waiting-permission')
-    expect(useSessionStore.getState().sessions[0].runtimeContext).toMatchObject({
-      revision: 3,
-      permission: { state: 'pending' }
-    })
-    expect(latest.pendingPermissions).toEqual([request])
+    act(() => projectRestoredPermissionPending(request))
+    expect(latest.pendingPermissions).toEqual([])
     expect(runtime.respondToPermission).toHaveBeenCalledOnce()
     await act(async () => latest.respondToPermission('permission-restored', 'allow-once'))
+    expect(runtime.respondToPermission).toHaveBeenCalledOnce()
+  })
+
+  it('preserves an explicit Main rearm that arrives before the restored response settles', async () => {
+    const { request, runtime } = arrangeRestoredPermission()
+    const deferred = createDeferred<AcpStateSnapshot>()
+    runtime.respondToPermission.mockReturnValue(deferred.promise)
+    await render()
+
+    let first!: Promise<void>
+    act(() => {
+      first = latest.respondToPermission('permission-restored', 'allow-once')
+      useSessionStore.getState().clearPermissionPending('session-1', {
+        authority: 'continuing',
+        requestId: request.requestId
+      })
+    })
+    runtime.state = createSnapshot({
+      sessionIds: ['session-1'],
+      events: [
+        {
+          id: 'permission-rearmed',
+          timestamp: 3,
+          kind: 'permission',
+          level: 'info',
+          sessionId: 'session-1',
+          permissionRequestId: request.requestId,
+          title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
+        }
+      ]
+    })
+    await render()
+
+    deferred.resolve(createSnapshot({ sessionIds: ['session-1'] }))
+    await act(async () => first)
+    expect(latest.pendingPermissions).toEqual([request])
+    expect(runtime.respondToPermission).toHaveBeenCalledOnce()
+
+    await act(async () => latest.respondToPermission('permission-restored', 'allow-once'))
+    expect(runtime.respondToPermission).toHaveBeenCalledTimes(2)
+
+    runtime.state = createSnapshot({ sessionIds: ['session-1'], events: [] })
+    await render()
+    runtime.state = createSnapshot({
+      sessionIds: ['session-1'],
+      events: [
+        {
+          id: 'permission-rearmed',
+          timestamp: 3,
+          kind: 'permission',
+          level: 'info',
+          sessionId: 'session-1',
+          permissionRequestId: request.requestId,
+          title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
+        }
+      ]
+    })
+    await render()
+
+    expect(useSessionStore.getState().sessions[0].runtimeContext?.permission?.state).toBe(
+      'continuing'
+    )
+    await act(async () => latest.respondToPermission('permission-restored', 'allow-once'))
+    expect(runtime.respondToPermission).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps a terminal request hidden when an earlier rearm replays without a local attempt', async () => {
+    const { request, runtime } = arrangeRestoredPermission()
+    runtime.state = createSnapshot({
+      sessionIds: ['session-1'],
+      events: [
+        {
+          id: 'permission-rearmed-before-attempt',
+          timestamp: 1,
+          kind: 'permission',
+          level: 'info',
+          sessionId: request.sessionId,
+          permissionRequestId: request.requestId,
+          title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
+        }
+      ]
+    })
+    await render()
+
+    runtime.state = createSnapshot({
+      sessionIds: ['session-1'],
+      events: [
+        {
+          id: 'permission-settled-without-attempt',
+          timestamp: 2,
+          kind: 'permission',
+          level: 'info',
+          sessionId: request.sessionId,
+          permissionRequestId: request.requestId,
+          title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE
+        }
+      ]
+    })
+    await render()
+    runtime.state = createSnapshot({ sessionIds: ['session-1'], events: [] })
+    await render()
+    runtime.state = createSnapshot({
+      sessionIds: ['session-1'],
+      events: [
+        {
+          id: 'permission-rearmed-before-attempt',
+          timestamp: 1,
+          kind: 'permission',
+          level: 'info',
+          sessionId: request.sessionId,
+          permissionRequestId: request.requestId,
+          title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
+        }
+      ]
+    })
+    await render()
+    act(() => projectRestoredPermissionPending(request))
+
+    expect(latest.pendingPermissions).toEqual([])
+    await act(async () => latest.respondToPermission(request.requestId, 'allow-once'))
+    expect(runtime.respondToPermission).not.toHaveBeenCalled()
+  })
+
+  it('rejects an older quit-drain rearm that resolves after a newer terminal snapshot', async () => {
+    const { request, runtime } = arrangeRestoredPermission()
+    const olderPull = createDeferred<AcpStateSnapshot>()
+    window.api = { acp: { getState: vi.fn().mockReturnValue(olderPull.promise) } } as never
+    await render()
+    await act(async () => latest.respondToPermission(request.requestId, 'allow-once'))
+
+    const drain = drainWorkspaceRuntimeEventsForPersistence(request.sessionId)
+    // The subscription reserves revision 2 synchronously before React commits its state/effects.
+    expect(acceptAcpRuntimeSnapshotRevision({ revision: 2 })).toBe(true)
+    await act(async () => {
+      olderPull.resolve(
+        createSnapshot({
+          revision: 1,
+          sessionIds: [request.sessionId],
+          events: [
+            {
+              id: 'permission-rearmed-older-unseen',
+              timestamp: 1,
+              kind: 'permission',
+              level: 'info',
+              sessionId: request.sessionId,
+              permissionRequestId: request.requestId,
+              title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
+            }
+          ]
+        })
+      )
+      await drain
+    })
+    expect(useSessionStore.getState().sessions[0].runtimeContext?.permission?.state).toBe(
+      'continuing'
+    )
+
+    runtime.state = createSnapshot({
+      revision: 2,
+      sessionIds: [request.sessionId],
+      events: [
+        {
+          id: 'permission-settled-newer',
+          timestamp: 2,
+          kind: 'permission',
+          level: 'info',
+          sessionId: request.sessionId,
+          permissionRequestId: request.requestId,
+          title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE
+        }
+      ]
+    })
+    await render()
+
+    expect(useSessionStore.getState().sessions[0].runtimeContext?.permission?.state).not.toBe(
+      'pending'
+    )
+    expect(latest.pendingPermissions).toEqual([])
+    await act(async () => latest.respondToPermission(request.requestId, 'allow-once'))
+    expect(runtime.respondToPermission).toHaveBeenCalledOnce()
+  })
+
+  it('cleans an accepted tombstone when its continuing Session is deleted', async () => {
+    const { request, runtime } = arrangeRestoredPermission()
+    await render()
+    await act(async () => latest.respondToPermission(request.requestId, 'allow-once'))
+    expect(useSessionStore.getState().sessions[0].runtimeContext?.permission?.state).toBe(
+      'continuing'
+    )
+
+    const deletedSession = structuredClone(useSessionStore.getState().sessions[0])
+    act(() => useSessionStore.setState({ sessions: [] }))
+    await render()
+    act(() => useSessionStore.setState({ sessions: [deletedSession] }))
+    act(() => projectRestoredPermissionPending(request))
+    await render()
+
+    expect(latest.pendingPermissions).toEqual([request])
+    await act(async () => latest.respondToPermission(request.requestId, 'allow-once'))
+    expect(runtime.respondToPermission).toHaveBeenCalledTimes(2)
+  })
+
+  it('releases an accepted response only for a matching Main rearm', async () => {
+    const { request, runtime } = arrangeRestoredPermission()
+    await render()
+
+    await act(async () => latest.respondToPermission(request.requestId, 'allow-once'))
+    runtime.state = createSnapshot({
+      sessionIds: ['session-1'],
+      events: [
+        {
+          id: 'permission-rearmed-mismatch',
+          timestamp: 3,
+          kind: 'permission',
+          level: 'info',
+          sessionId: 'session-1',
+          permissionRequestId: 'permission-other',
+          title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
+        }
+      ]
+    })
+    await render()
+
+    expect(latest.pendingPermissions).toEqual([])
+    await act(async () => latest.respondToPermission(request.requestId, 'allow-once'))
+    expect(runtime.respondToPermission).toHaveBeenCalledOnce()
+
+    runtime.state = createSnapshot({
+      sessionIds: ['session-1'],
+      events: [
+        {
+          id: 'permission-settled',
+          timestamp: 4,
+          kind: 'permission',
+          level: 'info',
+          sessionId: 'session-1',
+          permissionRequestId: request.requestId,
+          title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE
+        }
+      ]
+    })
+    await render()
+    act(() => projectRestoredPermissionPending(request))
+    expect(latest.pendingPermissions).toEqual([])
+    await act(async () => latest.respondToPermission(request.requestId, 'allow-once'))
+    expect(runtime.respondToPermission).toHaveBeenCalledOnce()
+
+    runtime.state = createSnapshot({
+      sessionIds: ['session-1'],
+      events: [
+        {
+          id: 'permission-rearm-failed',
+          timestamp: 5,
+          kind: 'permission',
+          level: 'error',
+          sessionId: 'session-1',
+          permissionRequestId: request.requestId,
+          title: ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE
+        }
+      ]
+    })
+    await render()
+    act(() => projectRestoredPermissionPending(request))
+    expect(latest.pendingPermissions).toEqual([])
+    await act(async () => latest.respondToPermission(request.requestId, 'allow-once'))
+    expect(runtime.respondToPermission).toHaveBeenCalledOnce()
+
+    const deletedSession = structuredClone(useSessionStore.getState().sessions[0])
+    act(() => useSessionStore.setState({ sessions: [] }))
+    await render()
+    act(() => useSessionStore.setState({ sessions: [deletedSession] }))
+    await render()
+
+    expect(latest.pendingPermissions).toEqual([request])
+    const secondResponse = createDeferred<AcpStateSnapshot>()
+    runtime.respondToPermission.mockReturnValueOnce(secondResponse.promise)
+    let second!: Promise<void>
+    act(() => {
+      second = latest.respondToPermission(request.requestId, 'allow-once')
+    })
+    runtime.state = createSnapshot({
+      sessionIds: ['session-1'],
+      events: [
+        {
+          id: 'permission-clear-failed-before-acceptance',
+          timestamp: 6,
+          kind: 'permission',
+          level: 'error',
+          sessionId: 'session-1',
+          permissionRequestId: request.requestId,
+          title: ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE
+        }
+      ]
+    })
+    await render()
+    secondResponse.resolve(createSnapshot({ sessionIds: ['session-1'] }))
+    await act(async () => second)
+
+    expect(runtime.respondToPermission).toHaveBeenCalledTimes(2)
+    act(() => projectRestoredPermissionPending(request))
+    expect(latest.pendingPermissions).toEqual([])
+    await act(async () => latest.respondToPermission(request.requestId, 'allow-once'))
     expect(runtime.respondToPermission).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -309,6 +309,41 @@ describe('workspace Agent Runtime hook contract', () => {
     expect(useSessionStore.getState().sessions[0]?.permissionProfile).toBe('auto')
   })
 
+  it('hides a live permission immediately while its response is pending', async () => {
+    const request = {
+      requestId: 'permission-live',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Allow command?',
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    const deferred = createDeferred<AcpStateSnapshot>()
+    const runtime = createRuntime(
+      createSnapshot({ sessionIds: ['session-1'], pendingPermissions: [request] })
+    )
+    runtime.respondToPermission.mockImplementation(async () => {
+      const snapshot = await deferred.promise
+      runtime.state = snapshot
+      return snapshot
+    })
+    runtimeMock.current = runtime
+    await render()
+
+    expect(latest.pendingPermissions).toEqual([request])
+
+    let response!: Promise<void>
+    act(() => {
+      response = latest.respondToPermission('permission-live', 'allow-once')
+    })
+
+    expect(runtime.respondToPermission).toHaveBeenCalledOnce()
+    expect(latest.pendingPermissions).toEqual([])
+
+    deferred.resolve(createSnapshot({ sessionIds: ['session-1'] }))
+    await act(async () => response)
+    expect(latest.pendingPermissions).toEqual([])
+  })
+
   it('reattaches a restored permission wait before sending its main-validated decision', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -352,6 +352,7 @@ describe('workspace Agent Runtime hook contract', () => {
     })
     runtimeMock.current = runtime
     await render()
+    const staleResponder = latest.respondToPermission
 
     expect(latest.pendingPermissions).toEqual([request])
     await act(async () => {
@@ -374,6 +375,8 @@ describe('workspace Agent Runtime hook contract', () => {
       projectId: 'project-1'
     })
     expect(useSessionStore.getState().sessions[0].status).toBe('idle')
+    await act(async () => staleResponder('permission-restored', 'allow-once'))
+    expect(runtime.respondToPermission).toHaveBeenCalledOnce()
   })
 
   it('keeps a restored permission card actionable when its response fails', async () => {
@@ -541,7 +544,7 @@ describe('workspace Agent Runtime hook contract', () => {
     expect(useSessionStore.getState().sessions[0].interrupted).toBeUndefined()
   })
 
-  it('mirrors restored continuation settlement before re-arming an asynchronous failure', async () => {
+  it('preserves a Main rearm that arrives before the restored response settles', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',
       content: 'Run the verification',
@@ -574,27 +577,39 @@ describe('workspace Agent Runtime hook contract', () => {
         }
       }))
     }))
+    const deferred = createDeferred<AcpStateSnapshot>()
     const runtime = createRuntime(createSnapshot({ sessionIds: ['session-1'] }))
+    runtime.respondToPermission.mockReturnValue(deferred.promise)
     runtimeMock.current = runtime
     await render()
 
-    await act(async () => {
-      await latest.respondToPermission('permission-restored', 'allow-once')
+    let first!: Promise<void>
+    act(() => {
+      first = latest.respondToPermission('permission-restored', 'allow-once')
     })
-    expect(latest.pendingPermissions).toEqual([])
-    expect(useSessionStore.getState().sessions[0].runtimeContext?.permission?.state).toBe(
-      'continuing'
-    )
-
-    act(() => useSessionStore.getState().failRun('session-1', 'Unrelated later failure'))
-    await act(async () => Promise.resolve())
-    expect(latest.pendingPermissions).toEqual([])
-
-    act(() =>
-      useSessionStore.getState().setPermissionPending('session-1', { rearmAuthority: true })
-    )
-    await act(async () => Promise.resolve())
+    act(() => {
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) =>
+          session.id === 'session-1'
+            ? {
+                ...session,
+                status: 'waiting-permission',
+                runtimeContext: { ...session.runtimeContext!, revision: 3 }
+              }
+            : session
+        )
+      }))
+    })
+    deferred.resolve(createSnapshot({ sessionIds: ['session-1'] }))
+    await act(async () => first)
     expect(useSessionStore.getState().sessions[0].status).toBe('waiting-permission')
+    expect(useSessionStore.getState().sessions[0].runtimeContext).toMatchObject({
+      revision: 3,
+      permission: { state: 'pending' }
+    })
     expect(latest.pendingPermissions).toEqual([request])
+    expect(runtime.respondToPermission).toHaveBeenCalledOnce()
+    await act(async () => latest.respondToPermission('permission-restored', 'allow-once'))
+    expect(runtime.respondToPermission).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -424,6 +424,62 @@ describe('workspace Agent Runtime hook contract', () => {
       sessionId: 'session-1',
       projectId: 'project-1'
     })
+
+    await act(async () => {
+      await latest.respondToPermission('permission-restored', 'allow-once')
+    })
+    expect(runtime.respondToPermission).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces concurrent responses for the same restored permission request', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Run the verification',
+      cwd: workspacePath,
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code'
+    })
+    const request = {
+      requestId: 'permission-restored',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Run npm test',
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'waiting-permission',
+        activeRun: undefined,
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            state: 'pending',
+            request,
+            originatingPromptMessageId: session.messages[0].id,
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1
+          }
+        }
+      }))
+    }))
+    const deferred = createDeferred<AcpStateSnapshot>()
+    const runtime = createRuntime(createSnapshot({ sessionIds: ['session-1'] }))
+    runtime.respondToPermission.mockReturnValue(deferred.promise)
+    runtimeMock.current = runtime
+    await render()
+
+    let first!: Promise<void>
+    let duplicate!: Promise<void>
+    act(() => {
+      first = latest.respondToPermission('permission-restored', 'allow-once')
+      duplicate = latest.respondToPermission('permission-restored', 'allow-once')
+    })
+
+    expect(runtime.respondToPermission).toHaveBeenCalledOnce()
+    deferred.resolve(createSnapshot({ sessionIds: ['session-1'] }))
+    await act(async () => Promise.all([first, duplicate]))
   })
 
   it('keeps a newly persisted permission card when its provider disconnects in-process', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1109,6 +1109,8 @@ describe('workspace durable elicitation', () => {
     })
     const respondToElicitation = vi.fn().mockResolvedValue(createSnapshot([session.id]))
     const onSendPreparationStateChange = vi.fn()
+    const persistedRevision = createDeferred<void>()
+    const flushPersistence = vi.fn(() => persistedRevision.promise)
     const response = {
       requestId: 'choice-revision',
       action: 'accept' as const,
@@ -1151,7 +1153,8 @@ describe('workspace durable elicitation', () => {
         agentFrameworkId: 'codex',
         agentBackendId: 'codex:provider-2',
         agentModel: 'new-model',
-        onSendPreparationStateChange
+        onSendPreparationStateChange,
+        flushPersistence
       }
     )
     const competingSendPrompt = vi.fn()
@@ -1173,6 +1176,9 @@ describe('workspace durable elicitation', () => {
     )
     expect(competing).toBeUndefined()
     expect(competingSendPrompt).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(flushPersistence).toHaveBeenCalledOnce())
+    expect(respondToElicitation).not.toHaveBeenCalled()
+    persistedRevision.resolve(undefined)
     await revision
 
     expect(resumeSession.mock.invocationCallOrder[0]).toBeLessThan(
@@ -1182,6 +1188,9 @@ describe('workspace durable elicitation', () => {
       resetSessionContext.mock.invocationCallOrder[0]
     )
     expect(resetSessionContext.mock.invocationCallOrder[0]).toBeLessThan(
+      flushPersistence.mock.invocationCallOrder[0]
+    )
+    expect(flushPersistence.mock.invocationCallOrder[0]).toBeLessThan(
       respondToElicitation.mock.invocationCallOrder[0]
     )
     expect(resumeSession).toHaveBeenCalledWith(

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -13,15 +13,10 @@ import {
 } from 'react'
 
 import {
-  ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
-  ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
-  ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
-  ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
   type AcpContextUsage,
   type AcpPermissionGrant,
   type AcpPermissionRequest,
-  type AcpPermissionResponse,
-  type AcpRuntimeEvent
+  type AcpPermissionResponse
 } from '../../../../shared/acp'
 import {
   DEFAULT_PERMISSION_PROFILE,
@@ -58,183 +53,9 @@ import {
   type SendWorkspaceMessageResult
 } from './workspace-runtime-command-owner'
 import { createWorkspaceRuntimeSessionLifecycleOwner } from './workspace-runtime-session-lifecycle-owner'
+import { createPermissionResponseAttemptOwner } from './workspace-permission-response-attempt-owner'
 
 type SendPreparationStateChange = (sessionId: string, inFlight: boolean) => void
-type PermissionResponseAttempt = {
-  accepted: boolean
-  rearmed: boolean
-  settled: boolean
-  authorityRemoved: boolean
-  restored: boolean
-  sessionId?: string
-  promise: Promise<void>
-}
-type ObservedPermissionLifecycleEvents = { sessionId?: string; eventIds: Set<string> }
-type RetiredPermissionResponse = ObservedPermissionLifecycleEvents & { promise: Promise<void> }
-type PermissionLifecycleEvent = AcpRuntimeEvent & { permissionRequestId: string }
-type PermissionResponseAttemptOwner = {
-  subscribe: (listener: () => void) => () => void
-  getSnapshot: () => readonly string[]
-  getPromise: (requestId: string) => Promise<void> | undefined
-  begin: (requestId: string) => PermissionResponseAttempt
-  accept: (requestId: string, attempt: PermissionResponseAttempt) => void
-  fail: (requestId: string, attempt: PermissionResponseAttempt) => void
-  shouldApplyLifecycle: (event: PermissionLifecycleEvent) => boolean
-  observeLifecycle: (event: PermissionLifecycleEvent) => void
-  cleanSessions: (sessions: ChatSession[]) => void
-  cleanLive: (requests: AcpPermissionRequest[]) => void
-}
-
-const createPermissionResponseAttemptOwner = (): PermissionResponseAttemptOwner => {
-  const attempts = new Map<string, PermissionResponseAttempt>()
-  const observedLifecycleEvents = new Map<string, ObservedPermissionLifecycleEvents>()
-  const retiredResponses = new Map<string, RetiredPermissionResponse>()
-  const listeners = new Set<() => void>()
-  let hiddenRequestIds: readonly string[] = []
-
-  const publish = (): void => {
-    hiddenRequestIds = [...new Set([...attempts.keys(), ...retiredResponses.keys()])]
-    for (const listener of listeners) listener()
-  }
-  const release = (requestId: string, attempt?: PermissionResponseAttempt): void => {
-    if (attempt && attempts.get(requestId) !== attempt) return
-    const activeChanged = attempts.delete(requestId)
-    const retiredChanged = retiredResponses.delete(requestId)
-    if (activeChanged || retiredChanged) publish()
-  }
-  const retire = (requestId: string, attempt?: PermissionResponseAttempt): void => {
-    if (attempt && attempts.get(requestId) !== attempt) return
-    const observed = observedLifecycleEvents.get(requestId)
-    const retired = retiredResponses.get(requestId)
-    const sessionId = attempt?.sessionId ?? observed?.sessionId ?? retired?.sessionId
-    attempts.delete(requestId)
-    observedLifecycleEvents.delete(requestId)
-    retiredResponses.set(requestId, {
-      sessionId,
-      eventIds: new Set([...(retired?.eventIds ?? []), ...(observed?.eventIds ?? [])]),
-      promise: attempt?.promise ?? retired?.promise ?? Promise.resolve()
-    })
-    publish()
-  }
-
-  return {
-    subscribe: (listener: () => void): (() => void) => {
-      listeners.add(listener)
-      return () => listeners.delete(listener)
-    },
-    getSnapshot: (): readonly string[] => hiddenRequestIds,
-    getPromise: (requestId: string): Promise<void> | undefined =>
-      attempts.get(requestId)?.promise ?? retiredResponses.get(requestId)?.promise,
-    begin: (requestId: string): PermissionResponseAttempt => {
-      const attempt: PermissionResponseAttempt = {
-        accepted: false,
-        rearmed: false,
-        settled: false,
-        authorityRemoved: false,
-        restored: false,
-        promise: Promise.resolve()
-      }
-      attempts.set(requestId, attempt)
-      publish()
-      return attempt
-    },
-    accept: (requestId: string, attempt: PermissionResponseAttempt): void => {
-      attempt.accepted = true
-      if (attempt.rearmed) release(requestId, attempt)
-      else if (attempt.settled || attempt.authorityRemoved) retire(requestId, attempt)
-    },
-    fail: (requestId: string, attempt: PermissionResponseAttempt): void => {
-      if (attempt.settled || attempt.authorityRemoved) retire(requestId, attempt)
-      else if (!attempt.accepted) release(requestId, attempt)
-    },
-    shouldApplyLifecycle: (event: PermissionLifecycleEvent): boolean =>
-      event.title !== ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE ||
-      !(
-        observedLifecycleEvents.get(event.permissionRequestId)?.eventIds.has(event.id) ||
-        retiredResponses.get(event.permissionRequestId)?.eventIds.has(event.id)
-      ),
-    observeLifecycle: (event: PermissionLifecycleEvent): void => {
-      const attempt = attempts.get(event.permissionRequestId)
-      const settled =
-        event.title === ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE ||
-        event.title === ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE ||
-        event.title === ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE
-      if (event.title === ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE) {
-        const retired = retiredResponses.get(event.permissionRequestId)
-        if (retired?.eventIds.has(event.id)) return
-        const observed = observedLifecycleEvents.get(event.permissionRequestId) ?? {
-          sessionId: event.sessionId,
-          eventIds: new Set(retired?.eventIds)
-        }
-        if (observed.eventIds.has(event.id)) return
-        observed.eventIds.add(event.id)
-        observedLifecycleEvents.set(event.permissionRequestId, observed)
-        if (retired) release(event.permissionRequestId)
-        if (attempt) {
-          attempt.rearmed = true
-          if (attempt.accepted) release(event.permissionRequestId, attempt)
-        }
-      } else if (settled) {
-        if (attempt) {
-          attempt.settled = true
-          if (attempt.accepted) retire(event.permissionRequestId, attempt)
-        } else {
-          const observed = observedLifecycleEvents.get(event.permissionRequestId)
-          observedLifecycleEvents.set(event.permissionRequestId, {
-            sessionId: event.sessionId ?? observed?.sessionId,
-            eventIds: new Set([
-              ...(retiredResponses.get(event.permissionRequestId)?.eventIds ?? []),
-              ...(observed?.eventIds ?? [])
-            ])
-          })
-          retire(event.permissionRequestId)
-        }
-      }
-    },
-    cleanSessions: (sessions: ChatSession[]): void => {
-      const sessionsById = new Map(sessions.map((session) => [session.id, session]))
-      for (const [requestId, attempt] of attempts) {
-        if (!attempt.sessionId) continue
-        const session = sessionsById.get(attempt.sessionId)
-        if (session) {
-          const currentRequestId = session.runtimeContext?.permission?.request.requestId
-          if (currentRequestId === requestId || !attempt.restored) continue
-          attempt.authorityRemoved = true
-          if (attempt.accepted) retire(requestId, attempt)
-          continue
-        }
-        observedLifecycleEvents.delete(requestId)
-        release(requestId, attempt)
-      }
-      for (const [requestId, observed] of observedLifecycleEvents) {
-        if (!observed.sessionId) continue
-        const session = sessionsById.get(observed.sessionId)
-        if (session) {
-          const currentRequestId = session.runtimeContext?.permission?.request.requestId
-          if (currentRequestId === requestId) continue
-          retire(requestId)
-          continue
-        }
-        observedLifecycleEvents.delete(requestId)
-      }
-      for (const [requestId, retired] of retiredResponses) {
-        if (retired.sessionId && !sessionsById.has(retired.sessionId)) {
-          retiredResponses.delete(requestId)
-          publish()
-        }
-      }
-    },
-    cleanLive: (requests: AcpPermissionRequest[]): void => {
-      const liveRequestIds = new Set(requests.map((request) => request.requestId))
-      for (const [requestId, attempt] of attempts) {
-        if (attempt.accepted && !attempt.restored && !liveRequestIds.has(requestId)) {
-          observedLifecycleEvents.delete(requestId)
-          release(requestId, attempt)
-        }
-      }
-    }
-  }
-}
 type WorkspacePermissionProfileRuntime = Pick<
   ReturnType<typeof useAcpRuntime>,
   'state' | 'setPermissionProfile'

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -7,15 +7,21 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type PropsWithChildren,
   type ReactElement
 } from 'react'
 
-import type {
-  AcpContextUsage,
-  AcpPermissionGrant,
-  AcpPermissionRequest,
-  AcpPermissionResponse
+import {
+  ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+  type AcpContextUsage,
+  type AcpPermissionGrant,
+  type AcpPermissionRequest,
+  type AcpPermissionResponse,
+  type AcpRuntimeEvent
 } from '../../../../shared/acp'
 import {
   DEFAULT_PERMISSION_PROFILE,
@@ -37,6 +43,7 @@ import {
   markRunningSessionsDisconnectedOnDrop,
   processVisibleWorkspaceRuntimeEvents,
   processWorkspaceRuntimeEvents,
+  subscribeWorkspacePermissionLifecycle,
   syncWorkspaceContextUsage,
   syncWorkspaceElicitationState,
   syncWorkspaceInteractionState,
@@ -53,7 +60,181 @@ import {
 import { createWorkspaceRuntimeSessionLifecycleOwner } from './workspace-runtime-session-lifecycle-owner'
 
 type SendPreparationStateChange = (sessionId: string, inFlight: boolean) => void
-type PermissionResponseAttempt = { accepted: boolean; promise: Promise<void> }
+type PermissionResponseAttempt = {
+  accepted: boolean
+  rearmed: boolean
+  settled: boolean
+  authorityRemoved: boolean
+  restored: boolean
+  sessionId?: string
+  promise: Promise<void>
+}
+type ObservedPermissionLifecycleEvents = { sessionId?: string; eventIds: Set<string> }
+type RetiredPermissionResponse = ObservedPermissionLifecycleEvents & { promise: Promise<void> }
+type PermissionLifecycleEvent = AcpRuntimeEvent & { permissionRequestId: string }
+type PermissionResponseAttemptOwner = {
+  subscribe: (listener: () => void) => () => void
+  getSnapshot: () => readonly string[]
+  getPromise: (requestId: string) => Promise<void> | undefined
+  begin: (requestId: string) => PermissionResponseAttempt
+  accept: (requestId: string, attempt: PermissionResponseAttempt) => void
+  fail: (requestId: string, attempt: PermissionResponseAttempt) => void
+  shouldApplyLifecycle: (event: PermissionLifecycleEvent) => boolean
+  observeLifecycle: (event: PermissionLifecycleEvent) => void
+  cleanSessions: (sessions: ChatSession[]) => void
+  cleanLive: (requests: AcpPermissionRequest[]) => void
+}
+
+const createPermissionResponseAttemptOwner = (): PermissionResponseAttemptOwner => {
+  const attempts = new Map<string, PermissionResponseAttempt>()
+  const observedLifecycleEvents = new Map<string, ObservedPermissionLifecycleEvents>()
+  const retiredResponses = new Map<string, RetiredPermissionResponse>()
+  const listeners = new Set<() => void>()
+  let hiddenRequestIds: readonly string[] = []
+
+  const publish = (): void => {
+    hiddenRequestIds = [...new Set([...attempts.keys(), ...retiredResponses.keys()])]
+    for (const listener of listeners) listener()
+  }
+  const release = (requestId: string, attempt?: PermissionResponseAttempt): void => {
+    if (attempt && attempts.get(requestId) !== attempt) return
+    const activeChanged = attempts.delete(requestId)
+    const retiredChanged = retiredResponses.delete(requestId)
+    if (activeChanged || retiredChanged) publish()
+  }
+  const retire = (requestId: string, attempt?: PermissionResponseAttempt): void => {
+    if (attempt && attempts.get(requestId) !== attempt) return
+    const observed = observedLifecycleEvents.get(requestId)
+    const retired = retiredResponses.get(requestId)
+    const sessionId = attempt?.sessionId ?? observed?.sessionId ?? retired?.sessionId
+    attempts.delete(requestId)
+    observedLifecycleEvents.delete(requestId)
+    retiredResponses.set(requestId, {
+      sessionId,
+      eventIds: new Set([...(retired?.eventIds ?? []), ...(observed?.eventIds ?? [])]),
+      promise: attempt?.promise ?? retired?.promise ?? Promise.resolve()
+    })
+    publish()
+  }
+
+  return {
+    subscribe: (listener: () => void): (() => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    getSnapshot: (): readonly string[] => hiddenRequestIds,
+    getPromise: (requestId: string): Promise<void> | undefined =>
+      attempts.get(requestId)?.promise ?? retiredResponses.get(requestId)?.promise,
+    begin: (requestId: string): PermissionResponseAttempt => {
+      const attempt: PermissionResponseAttempt = {
+        accepted: false,
+        rearmed: false,
+        settled: false,
+        authorityRemoved: false,
+        restored: false,
+        promise: Promise.resolve()
+      }
+      attempts.set(requestId, attempt)
+      publish()
+      return attempt
+    },
+    accept: (requestId: string, attempt: PermissionResponseAttempt): void => {
+      attempt.accepted = true
+      if (attempt.rearmed) release(requestId, attempt)
+      else if (attempt.settled || attempt.authorityRemoved) retire(requestId, attempt)
+    },
+    fail: (requestId: string, attempt: PermissionResponseAttempt): void => {
+      if (attempt.settled || attempt.authorityRemoved) retire(requestId, attempt)
+      else if (!attempt.accepted) release(requestId, attempt)
+    },
+    shouldApplyLifecycle: (event: PermissionLifecycleEvent): boolean =>
+      event.title !== ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE ||
+      !(
+        observedLifecycleEvents.get(event.permissionRequestId)?.eventIds.has(event.id) ||
+        retiredResponses.get(event.permissionRequestId)?.eventIds.has(event.id)
+      ),
+    observeLifecycle: (event: PermissionLifecycleEvent): void => {
+      const attempt = attempts.get(event.permissionRequestId)
+      const settled =
+        event.title === ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE ||
+        event.title === ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE ||
+        event.title === ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE
+      if (event.title === ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE) {
+        const retired = retiredResponses.get(event.permissionRequestId)
+        if (retired?.eventIds.has(event.id)) return
+        const observed = observedLifecycleEvents.get(event.permissionRequestId) ?? {
+          sessionId: event.sessionId,
+          eventIds: new Set(retired?.eventIds)
+        }
+        if (observed.eventIds.has(event.id)) return
+        observed.eventIds.add(event.id)
+        observedLifecycleEvents.set(event.permissionRequestId, observed)
+        if (retired) release(event.permissionRequestId)
+        if (attempt) {
+          attempt.rearmed = true
+          if (attempt.accepted) release(event.permissionRequestId, attempt)
+        }
+      } else if (settled) {
+        if (attempt) {
+          attempt.settled = true
+          if (attempt.accepted) retire(event.permissionRequestId, attempt)
+        } else {
+          const observed = observedLifecycleEvents.get(event.permissionRequestId)
+          observedLifecycleEvents.set(event.permissionRequestId, {
+            sessionId: event.sessionId ?? observed?.sessionId,
+            eventIds: new Set([
+              ...(retiredResponses.get(event.permissionRequestId)?.eventIds ?? []),
+              ...(observed?.eventIds ?? [])
+            ])
+          })
+          retire(event.permissionRequestId)
+        }
+      }
+    },
+    cleanSessions: (sessions: ChatSession[]): void => {
+      const sessionsById = new Map(sessions.map((session) => [session.id, session]))
+      for (const [requestId, attempt] of attempts) {
+        if (!attempt.sessionId) continue
+        const session = sessionsById.get(attempt.sessionId)
+        if (session) {
+          const currentRequestId = session.runtimeContext?.permission?.request.requestId
+          if (currentRequestId === requestId || !attempt.restored) continue
+          attempt.authorityRemoved = true
+          if (attempt.accepted) retire(requestId, attempt)
+          continue
+        }
+        observedLifecycleEvents.delete(requestId)
+        release(requestId, attempt)
+      }
+      for (const [requestId, observed] of observedLifecycleEvents) {
+        if (!observed.sessionId) continue
+        const session = sessionsById.get(observed.sessionId)
+        if (session) {
+          const currentRequestId = session.runtimeContext?.permission?.request.requestId
+          if (currentRequestId === requestId) continue
+          retire(requestId)
+          continue
+        }
+        observedLifecycleEvents.delete(requestId)
+      }
+      for (const [requestId, retired] of retiredResponses) {
+        if (retired.sessionId && !sessionsById.has(retired.sessionId)) {
+          retiredResponses.delete(requestId)
+          publish()
+        }
+      }
+    },
+    cleanLive: (requests: AcpPermissionRequest[]): void => {
+      const liveRequestIds = new Set(requests.map((request) => request.requestId))
+      for (const [requestId, attempt] of attempts) {
+        if (attempt.accepted && !attempt.restored && !liveRequestIds.has(requestId)) {
+          observedLifecycleEvents.delete(requestId)
+          release(requestId, attempt)
+        }
+      }
+    }
+  }
+}
 type WorkspacePermissionProfileRuntime = Pick<
   ReturnType<typeof useAcpRuntime>,
   'state' | 'setPermissionProfile'
@@ -133,18 +314,14 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const runtime = useAcpRuntime()
   const restoredPermissionProjectionKey = useSessionStore((state) =>
     JSON.stringify(
-      state.sessions.flatMap((session) => {
+      state.sessions.map((session) => {
         const permission = session.runtimeContext?.permission
-        return permission?.state === 'pending'
-          ? [
-              [
-                session.id,
-                session.runtimeContext?.revision,
-                permission.request.requestId,
-                session.status
-              ]
-            ]
-          : []
+        return [
+          session.id,
+          permission?.state === 'pending'
+            ? [session.runtimeContext?.revision, permission.request.requestId, session.status]
+            : null
+        ]
       })
     )
   )
@@ -194,15 +371,18 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     () => pendingWorkspacePermissions(restoredPermissionSessions, runtime.state.pendingPermissions),
     [restoredPermissionSessions, runtime.state.pendingPermissions]
   )
-  const [respondingPermissionRequestIds, setRespondingPermissionRequestIds] = useState<string[]>([])
+  const [permissionResponseAttemptOwner] = useState(createPermissionResponseAttemptOwner)
+  const hiddenPermissionRequestIds = useSyncExternalStore(
+    permissionResponseAttemptOwner.subscribe,
+    permissionResponseAttemptOwner.getSnapshot,
+    permissionResponseAttemptOwner.getSnapshot
+  )
   const visiblePendingPermissions = useMemo(
     () =>
-      respondingPermissionRequestIds.length === 0
-        ? pendingPermissions
-        : pendingPermissions.filter(
-            (request) => !respondingPermissionRequestIds.includes(request.requestId)
-          ),
-    [pendingPermissions, respondingPermissionRequestIds]
+      pendingPermissions.filter(
+        (request) => !hiddenPermissionRequestIds.includes(request.requestId)
+      ),
+    [hiddenPermissionRequestIds, pendingPermissions]
   )
   const [sendPreparationInFlightSessionIds, setSendPreparationInFlightSessionIds] = useState<
     string[]
@@ -221,7 +401,6 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const previousStatusRef = useRef(runtime.state.status)
   const previousSessionStatusesRef = useRef(runtime.state.sessionConnectionStatuses)
   const previousDurablePermissionSessionIdsRef = useRef<ReadonlySet<string>>(new Set())
-  const permissionResponseAttemptsRef = useRef(new Map<string, PermissionResponseAttempt>())
   const durablePermissionSessionIdsKey = JSON.stringify(
     Array.from(
       new Set([
@@ -255,9 +434,26 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const agentPromptInFlightSessionIds =
     runtime.state.agentPromptInFlightSessionIds ?? EMPTY_AGENT_PROMPT_IN_FLIGHT_SESSION_IDS
 
+  useEffect(
+    () =>
+      subscribeWorkspacePermissionLifecycle({
+        shouldApply: permissionResponseAttemptOwner.shouldApplyLifecycle,
+        onApplied: permissionResponseAttemptOwner.observeLifecycle
+      }),
+    [permissionResponseAttemptOwner]
+  )
+
   useEffect(() => {
-    void processWorkspaceRuntimeEvents(runtime.state.events, agentPromptInFlightSessionIds)
-  }, [agentPromptInFlightSessionIds, runtime.state.events])
+    permissionResponseAttemptOwner.cleanSessions(restoredPermissionSessions)
+  }, [permissionResponseAttemptOwner, restoredPermissionSessions])
+
+  useEffect(() => {
+    permissionResponseAttemptOwner.cleanLive(runtime.state.pendingPermissions)
+  }, [permissionResponseAttemptOwner, runtime.state.pendingPermissions])
+
+  useEffect(() => {
+    void processWorkspaceRuntimeEvents(runtime.state)
+  }, [agentPromptInFlightSessionIds, runtime.state])
 
   useEffect(() => {
     syncWorkspacePermissionState(pendingPermissions)
@@ -371,32 +567,18 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   )
   const respondToPermission = useCallback(
     (requestId: string, optionId?: string): Promise<void> => {
-      const existing = permissionResponseAttemptsRef.current.get(requestId)
-      if (existing) {
-        const rearmed =
-          existing.accepted &&
-          useSessionStore
-            .getState()
-            .sessions.some(
-              (session) =>
-                session.runtimeContext?.permission?.state === 'pending' &&
-                session.runtimeContext.permission.request.requestId === requestId
-            )
-        if (!rearmed) return existing.promise
-        permissionResponseAttemptsRef.current.delete(requestId)
-      }
+      const existing = permissionResponseAttemptOwner.getPromise(requestId)
+      if (existing) return existing
 
-      const attempt: PermissionResponseAttempt = { accepted: false, promise: Promise.resolve() }
-      setRespondingPermissionRequestIds((current) =>
-        current.includes(requestId) ? current : [...current, requestId]
-      )
+      const attempt = permissionResponseAttemptOwner.begin(requestId)
       const response = (async (): Promise<void> => {
         const request = pendingPermissions.find((item) => item.requestId === requestId)
         const isRestoredRequest = Boolean(
           request &&
           !runtime.state.pendingPermissions.some((item) => item.requestId === request.requestId)
         )
-        let restoredAuthorityRevision: number | undefined
+        attempt.restored = isRestoredRequest
+        attempt.sessionId = request?.sessionId
         try {
           let restored: AcpPermissionResponse['restored']
           if (request && isRestoredRequest) {
@@ -442,20 +624,21 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
               sessionId: session.id,
               projectId: session.projectId
             }
-            restoredAuthorityRevision = session.runtimeContext?.revision
           }
           await runtime.respondToPermission(requestId, optionId, restored)
-          attempt.accepted = true
+          permissionResponseAttemptOwner.accept(requestId, attempt)
+          if (attempt.rearmed || attempt.settled) return
           const currentSession = request
             ? useSessionStore
                 .getState()
                 .sessions.find((session) => session.id === request.sessionId)
             : undefined
+          const currentPermission = currentSession?.runtimeContext?.permission
           if (
             request &&
             restored &&
-            restoredAuthorityRevision !== undefined &&
-            currentSession?.runtimeContext?.revision === restoredAuthorityRevision
+            currentPermission?.state === 'pending' &&
+            currentPermission.request.requestId === requestId
           ) {
             useSessionStore.getState().clearPermissionPending(request.sessionId, {
               authority: 'continuing',
@@ -479,20 +662,14 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
         }
       })()
       const tracked = response.finally(() => {
-        setRespondingPermissionRequestIds((current) =>
-          current.includes(requestId) ? current.filter((id) => id !== requestId) : current
-        )
         // A permission request id is one-shot authority. Keep successful responses coalesced for
         // stale renders, releasing it only when Main explicitly re-arms the durable request.
-        if (!attempt.accepted && permissionResponseAttemptsRef.current.get(requestId) === attempt) {
-          permissionResponseAttemptsRef.current.delete(requestId)
-        }
+        permissionResponseAttemptOwner.fail(requestId, attempt)
       })
       attempt.promise = tracked
-      permissionResponseAttemptsRef.current.set(requestId, attempt)
       return tracked
     },
-    [pendingPermissions, runtime]
+    [pendingPermissions, permissionResponseAttemptOwner, runtime]
   )
   const setPermissionProfile = useCallback(
     (sessionId: string, profile: PermissionProfileId): Promise<boolean> =>

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -194,6 +194,16 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     () => pendingWorkspacePermissions(restoredPermissionSessions, runtime.state.pendingPermissions),
     [restoredPermissionSessions, runtime.state.pendingPermissions]
   )
+  const [respondingPermissionRequestIds, setRespondingPermissionRequestIds] = useState<string[]>([])
+  const visiblePendingPermissions = useMemo(
+    () =>
+      respondingPermissionRequestIds.length === 0
+        ? pendingPermissions
+        : pendingPermissions.filter(
+            (request) => !respondingPermissionRequestIds.includes(request.requestId)
+          ),
+    [pendingPermissions, respondingPermissionRequestIds]
+  )
   const [sendPreparationInFlightSessionIds, setSendPreparationInFlightSessionIds] = useState<
     string[]
   >([])
@@ -377,6 +387,9 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
       }
 
       const attempt: PermissionResponseAttempt = { accepted: false, promise: Promise.resolve() }
+      setRespondingPermissionRequestIds((current) =>
+        current.includes(requestId) ? current : [...current, requestId]
+      )
       const response = (async (): Promise<void> => {
         const request = pendingPermissions.find((item) => item.requestId === requestId)
         const isRestoredRequest = Boolean(
@@ -466,6 +479,9 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
         }
       })()
       const tracked = response.finally(() => {
+        setRespondingPermissionRequestIds((current) =>
+          current.includes(requestId) ? current.filter((id) => id !== requestId) : current
+        )
         // A permission request id is one-shot authority. Keep successful responses coalesced for
         // stale renders, releasing it only when Main explicitly re-arms the durable request.
         if (!attempt.accepted && permissionResponseAttemptsRef.current.get(requestId) === attempt) {
@@ -494,7 +510,7 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   return {
     actionError: runtime.actionError,
     isConnecting: runtime.isConnecting,
-    pendingPermissions,
+    pendingPermissions: visiblePendingPermissions,
     permissionProfiles: runtime.state.permissionProfiles,
     permissionGrants: runtime.state.permissionGrants,
     contextUsageBySession: runtime.state.contextUsageBySession,

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -210,6 +210,7 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const previousStatusRef = useRef(runtime.state.status)
   const previousSessionStatusesRef = useRef(runtime.state.sessionConnectionStatuses)
   const previousDurablePermissionSessionIdsRef = useRef<ReadonlySet<string>>(new Set())
+  const permissionResponsesInFlightRef = useRef(new Map<string, Promise<void>>())
   const durablePermissionSessionIdsKey = JSON.stringify(
     Array.from(
       new Set([
@@ -358,80 +359,92 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     [lifecycleOwner, runtime]
   )
   const respondToPermission = useCallback(
-    async (requestId: string, optionId?: string): Promise<void> => {
-      const request = pendingPermissions.find((item) => item.requestId === requestId)
-      const isRestoredRequest = Boolean(
-        request &&
-        !runtime.state.pendingPermissions.some((item) => item.requestId === request.requestId)
-      )
-      try {
-        let restored: AcpPermissionResponse['restored']
-        if (request && isRestoredRequest) {
-          let session = useSessionStore
-            .getState()
-            .sessions.find((candidate) => candidate.id === request.sessionId)
-          if (!session) throw new Error(`Session not found: ${request.sessionId}`)
-          if (!runtime.state.sessionIds.includes(request.sessionId)) {
-            const cwd = session.cwd || runtime.state.cwd
-            if (!cwd) throw new Error('Choose a workspace folder before resuming this Session.')
-            const resumed = await runtime.resumeSession(
-              session.id,
-              cwd,
-              session.projectId,
-              session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
-              session.agentFrameworkId,
-              session.agentBackendId,
-              session.specialistId,
-              session.providerSessionId,
-              session.providerContinuityToken
-            )
-            useSessionStore.getState().markResumed(
-              session.id,
-              resumed
-                ? {
-                    agentFrameworkId: resumed.frameworkId,
-                    agentBackendId: resumed.backendId,
-                    providerSessionId: resumed.providerSessionId,
-                    providerContinuityToken: resumed.providerContinuityToken
-                  }
-                : undefined
-            )
-            // markResumed clears generic interrupted state to idle. Re-arm this main-owned wait
-            // until the restored decision is accepted so a retryable response failure cannot make
-            // the card disappear from the renderer projection.
-            useSessionStore.getState().setPermissionPending(session.id)
-            session = useSessionStore
+    (requestId: string, optionId?: string): Promise<void> => {
+      const existing = permissionResponsesInFlightRef.current.get(requestId)
+      if (existing) return existing
+
+      const response = (async (): Promise<void> => {
+        const request = pendingPermissions.find((item) => item.requestId === requestId)
+        const isRestoredRequest = Boolean(
+          request &&
+          !runtime.state.pendingPermissions.some((item) => item.requestId === request.requestId)
+        )
+        try {
+          let restored: AcpPermissionResponse['restored']
+          if (request && isRestoredRequest) {
+            let session = useSessionStore
               .getState()
               .sessions.find((candidate) => candidate.id === request.sessionId)
             if (!session) throw new Error(`Session not found: ${request.sessionId}`)
+            if (!runtime.state.sessionIds.includes(request.sessionId)) {
+              const cwd = session.cwd || runtime.state.cwd
+              if (!cwd) throw new Error('Choose a workspace folder before resuming this Session.')
+              const resumed = await runtime.resumeSession(
+                session.id,
+                cwd,
+                session.projectId,
+                session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+                session.agentFrameworkId,
+                session.agentBackendId,
+                session.specialistId,
+                session.providerSessionId,
+                session.providerContinuityToken
+              )
+              useSessionStore.getState().markResumed(
+                session.id,
+                resumed
+                  ? {
+                      agentFrameworkId: resumed.frameworkId,
+                      agentBackendId: resumed.backendId,
+                      providerSessionId: resumed.providerSessionId,
+                      providerContinuityToken: resumed.providerContinuityToken
+                    }
+                  : undefined
+              )
+              // markResumed clears generic interrupted state to idle. Re-arm this main-owned wait
+              // until the restored decision is accepted so a retryable response failure cannot make
+              // the card disappear from the renderer projection.
+              useSessionStore.getState().setPermissionPending(session.id)
+              session = useSessionStore
+                .getState()
+                .sessions.find((candidate) => candidate.id === request.sessionId)
+              if (!session) throw new Error(`Session not found: ${request.sessionId}`)
+            }
+            restored = {
+              sessionId: session.id,
+              projectId: session.projectId
+            }
           }
-          restored = {
-            sessionId: session.id,
-            projectId: session.projectId
+          await runtime.respondToPermission(requestId, optionId, restored)
+          if (request && restored) {
+            useSessionStore.getState().clearPermissionPending(request.sessionId, {
+              authority: 'continuing',
+              requestId
+            })
+          }
+        } catch (error) {
+          if (request && isRestoredRequest) {
+            // The main-owned authority is still valid. Keep the card actionable; useAcpRuntime retains
+            // the transient action error separately for the active Session to display.
+            const permission = useSessionStore
+              .getState()
+              .sessions.find((session) => session.id === request.sessionId)
+              ?.runtimeContext?.permission
+            if (permission?.state === 'pending') {
+              useSessionStore.getState().setPermissionPending(request.sessionId)
+            }
+          } else if (request) {
+            useSessionStore.getState().failRun(request.sessionId, getErrorMessage(error))
           }
         }
-        await runtime.respondToPermission(requestId, optionId, restored)
-        if (request && restored) {
-          useSessionStore.getState().clearPermissionPending(request.sessionId, {
-            authority: 'continuing',
-            requestId
-          })
+      })()
+      const tracked = response.finally(() => {
+        if (permissionResponsesInFlightRef.current.get(requestId) === tracked) {
+          permissionResponsesInFlightRef.current.delete(requestId)
         }
-      } catch (error) {
-        if (request && isRestoredRequest) {
-          // The main-owned authority is still valid. Keep the card actionable; useAcpRuntime retains
-          // the transient action error separately for the active Session to display.
-          const permission = useSessionStore
-            .getState()
-            .sessions.find((session) => session.id === request.sessionId)
-            ?.runtimeContext?.permission
-          if (permission?.state === 'pending') {
-            useSessionStore.getState().setPermissionPending(request.sessionId)
-          }
-        } else if (request) {
-          useSessionStore.getState().failRun(request.sessionId, getErrorMessage(error))
-        }
-      }
+      })
+      permissionResponsesInFlightRef.current.set(requestId, tracked)
+      return tracked
     },
     [pendingPermissions, runtime]
   )

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -53,6 +53,7 @@ import {
 import { createWorkspaceRuntimeSessionLifecycleOwner } from './workspace-runtime-session-lifecycle-owner'
 
 type SendPreparationStateChange = (sessionId: string, inFlight: boolean) => void
+type PermissionResponseAttempt = { accepted: boolean; promise: Promise<void> }
 type WorkspacePermissionProfileRuntime = Pick<
   ReturnType<typeof useAcpRuntime>,
   'state' | 'setPermissionProfile'
@@ -210,7 +211,7 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const previousStatusRef = useRef(runtime.state.status)
   const previousSessionStatusesRef = useRef(runtime.state.sessionConnectionStatuses)
   const previousDurablePermissionSessionIdsRef = useRef<ReadonlySet<string>>(new Set())
-  const permissionResponsesInFlightRef = useRef(new Map<string, Promise<void>>())
+  const permissionResponseAttemptsRef = useRef(new Map<string, PermissionResponseAttempt>())
   const durablePermissionSessionIdsKey = JSON.stringify(
     Array.from(
       new Set([
@@ -360,15 +361,29 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   )
   const respondToPermission = useCallback(
     (requestId: string, optionId?: string): Promise<void> => {
-      const existing = permissionResponsesInFlightRef.current.get(requestId)
-      if (existing) return existing
+      const existing = permissionResponseAttemptsRef.current.get(requestId)
+      if (existing) {
+        const rearmed =
+          existing.accepted &&
+          useSessionStore
+            .getState()
+            .sessions.some(
+              (session) =>
+                session.runtimeContext?.permission?.state === 'pending' &&
+                session.runtimeContext.permission.request.requestId === requestId
+            )
+        if (!rearmed) return existing.promise
+        permissionResponseAttemptsRef.current.delete(requestId)
+      }
 
+      const attempt: PermissionResponseAttempt = { accepted: false, promise: Promise.resolve() }
       const response = (async (): Promise<void> => {
         const request = pendingPermissions.find((item) => item.requestId === requestId)
         const isRestoredRequest = Boolean(
           request &&
           !runtime.state.pendingPermissions.some((item) => item.requestId === request.requestId)
         )
+        let restoredAuthorityRevision: number | undefined
         try {
           let restored: AcpPermissionResponse['restored']
           if (request && isRestoredRequest) {
@@ -414,9 +429,21 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
               sessionId: session.id,
               projectId: session.projectId
             }
+            restoredAuthorityRevision = session.runtimeContext?.revision
           }
           await runtime.respondToPermission(requestId, optionId, restored)
-          if (request && restored) {
+          attempt.accepted = true
+          const currentSession = request
+            ? useSessionStore
+                .getState()
+                .sessions.find((session) => session.id === request.sessionId)
+            : undefined
+          if (
+            request &&
+            restored &&
+            restoredAuthorityRevision !== undefined &&
+            currentSession?.runtimeContext?.revision === restoredAuthorityRevision
+          ) {
             useSessionStore.getState().clearPermissionPending(request.sessionId, {
               authority: 'continuing',
               requestId
@@ -439,11 +466,14 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
         }
       })()
       const tracked = response.finally(() => {
-        if (permissionResponsesInFlightRef.current.get(requestId) === tracked) {
-          permissionResponsesInFlightRef.current.delete(requestId)
+        // A permission request id is one-shot authority. Keep successful responses coalesced for
+        // stale renders, releasing it only when Main explicitly re-arms the durable request.
+        if (!attempt.accepted && permissionResponseAttemptsRef.current.get(requestId) === attempt) {
+          permissionResponseAttemptsRef.current.delete(requestId)
         }
       })
-      permissionResponsesInFlightRef.current.set(requestId, tracked)
+      attempt.promise = tracked
+      permissionResponseAttemptsRef.current.set(requestId, attempt)
       return tracked
     },
     [pendingPermissions, runtime]

--- a/src/renderer/src/lib/acp/workspace-elicitation-runtime.ts
+++ b/src/renderer/src/lib/acp/workspace-elicitation-runtime.ts
@@ -2,6 +2,7 @@ import { isDurableAgentUserChoiceRequest, type ElicitationResponse } from '../..
 import { DEFAULT_PERMISSION_PROFILE } from '../../../../shared/permission-profiles'
 import { RESUME_WORKSPACE_MISSING_MESSAGE } from '../../../../shared/run-error-classification'
 import type { AgentFrameworkId } from '../../../../shared/settings'
+import { flushSessionPersistence } from '../session-persistence/session-persistence'
 import { useSessionStore, type ChatMessage, type ChatSession } from '../../stores/session-store'
 import type { useAcpRuntime } from './useAcpRuntime'
 import {
@@ -26,6 +27,7 @@ type WorkspaceElicitationOptions = {
   historyReplayDescriptor?: HistoryReplayDescriptor
   onSendPreparationStateChange?: (sessionId: string, inFlight: boolean) => void
   drainRuntimeEvents?: (sessionId?: string) => Promise<void>
+  flushPersistence?: () => Promise<void>
 }
 
 const buildElicitationReplay = (
@@ -246,6 +248,7 @@ const reviseWorkspaceElicitation = async (
     if (!useSessionStore.getState().reviseSessionFromElicitation(session.id, activity.id)) {
       throw new Error('The conversation could not rewind to this question.')
     }
+    await (options.flushPersistence ?? flushSessionPersistence)()
     const snapshot = await runtime.respondToElicitation(responseToSend)
     syncWorkspaceInteractionState(snapshot)
     if (

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -915,7 +915,7 @@ describe('workspace runtime events', () => {
     expect(useSessionStore.getState().sessions[0].status).toBe('running')
   })
 
-  it('mirrors restored permission rearm and clear events into the local authority projection', async () => {
+  it('mirrors only request-correlated restored permission lifecycle events', async () => {
     const request = createPermissionRequest()
     useSessionStore.setState((state) => ({
       sessions: state.sessions.map((session) => ({
@@ -937,9 +937,48 @@ describe('workspace runtime events', () => {
 
     await applyWorkspaceRuntimeEvent(
       createEvent({
-        id: 'permission-rearmed',
+        id: 'permission-rearmed-uncorrelated',
         kind: 'permission',
         title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE
+      })
+    )
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'idle',
+      runtimeContext: { permission: { state: 'continuing' } }
+    })
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'permission-rearmed-mismatch',
+        kind: 'permission',
+        title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
+        permissionRequestId: 'permission-other'
+      })
+    )
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'idle',
+      runtimeContext: { permission: { state: 'continuing' } }
+    })
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'permission-rearmed',
+        kind: 'permission',
+        title: ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
+        permissionRequestId: request.requestId
+      })
+    )
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-permission',
+      runtimeContext: { permission: { state: 'pending' } }
+    })
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'permission-settled-mismatch',
+        kind: 'permission',
+        title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+        permissionRequestId: 'permission-other'
       })
     )
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
@@ -951,7 +990,8 @@ describe('workspace runtime events', () => {
       createEvent({
         id: 'permission-settled',
         kind: 'permission',
-        title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE
+        title: ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+        permissionRequestId: request.requestId
       })
     )
     expect(useSessionStore.getState().sessions[0].runtimeContext?.permission).toBeUndefined()

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -497,6 +497,14 @@ const applyWorkspaceRuntimeEvent = async (
   const store = useSessionStore.getState()
 
   if (event.kind === 'permission' && event.sessionId) {
+    const permission = store.sessions.find((session) => session.id === event.sessionId)
+      ?.runtimeContext?.permission
+    if (
+      !event.permissionRequestId ||
+      (permission && permission.request.requestId !== event.permissionRequestId)
+    ) {
+      return false
+    }
     if (event.title === ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE) {
       store.setPermissionPending(event.sessionId, { rearmAuthority: true })
       return true
@@ -506,7 +514,10 @@ const applyWorkspaceRuntimeEvent = async (
       event.title === ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE ||
       event.title === ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE
     ) {
-      store.clearPermissionPending(event.sessionId, { authority: 'settled' })
+      store.clearPermissionPending(event.sessionId, {
+        authority: 'settled',
+        requestId: event.permissionRequestId
+      })
       return true
     }
   }

--- a/src/renderer/src/lib/acp/workspace-permission-response-attempt-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-permission-response-attempt-owner.ts
@@ -1,0 +1,187 @@
+import {
+  ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+  type AcpPermissionRequest,
+  type AcpRuntimeEvent
+} from '../../../../shared/acp'
+import type { ChatSession } from '../../stores/session-store'
+
+type PermissionResponseAttempt = {
+  accepted: boolean
+  rearmed: boolean
+  settled: boolean
+  authorityRemoved: boolean
+  restored: boolean
+  sessionId?: string
+  promise: Promise<void>
+}
+type ObservedPermissionLifecycleEvents = { sessionId?: string; eventIds: Set<string> }
+type RetiredPermissionResponse = ObservedPermissionLifecycleEvents & { promise: Promise<void> }
+type PermissionLifecycleEvent = AcpRuntimeEvent & { permissionRequestId: string }
+type PermissionResponseAttemptOwner = {
+  subscribe: (listener: () => void) => () => void
+  getSnapshot: () => readonly string[]
+  getPromise: (requestId: string) => Promise<void> | undefined
+  begin: (requestId: string) => PermissionResponseAttempt
+  accept: (requestId: string, attempt: PermissionResponseAttempt) => void
+  fail: (requestId: string, attempt: PermissionResponseAttempt) => void
+  shouldApplyLifecycle: (event: PermissionLifecycleEvent) => boolean
+  observeLifecycle: (event: PermissionLifecycleEvent) => void
+  cleanSessions: (sessions: ChatSession[]) => void
+  cleanLive: (requests: AcpPermissionRequest[]) => void
+}
+
+const createPermissionResponseAttemptOwner = (): PermissionResponseAttemptOwner => {
+  const attempts = new Map<string, PermissionResponseAttempt>()
+  const observedLifecycleEvents = new Map<string, ObservedPermissionLifecycleEvents>()
+  const retiredResponses = new Map<string, RetiredPermissionResponse>()
+  const listeners = new Set<() => void>()
+  let hiddenRequestIds: readonly string[] = []
+
+  const publish = (): void => {
+    hiddenRequestIds = [...new Set([...attempts.keys(), ...retiredResponses.keys()])]
+    for (const listener of listeners) listener()
+  }
+  const release = (requestId: string, attempt?: PermissionResponseAttempt): void => {
+    if (attempt && attempts.get(requestId) !== attempt) return
+    const activeChanged = attempts.delete(requestId)
+    const retiredChanged = retiredResponses.delete(requestId)
+    if (activeChanged || retiredChanged) publish()
+  }
+  const retire = (requestId: string, attempt?: PermissionResponseAttempt): void => {
+    if (attempt && attempts.get(requestId) !== attempt) return
+    const observed = observedLifecycleEvents.get(requestId)
+    const retired = retiredResponses.get(requestId)
+    const sessionId = attempt?.sessionId ?? observed?.sessionId ?? retired?.sessionId
+    attempts.delete(requestId)
+    observedLifecycleEvents.delete(requestId)
+    retiredResponses.set(requestId, {
+      sessionId,
+      eventIds: new Set([...(retired?.eventIds ?? []), ...(observed?.eventIds ?? [])]),
+      promise: attempt?.promise ?? retired?.promise ?? Promise.resolve()
+    })
+    publish()
+  }
+
+  return {
+    subscribe: (listener: () => void): (() => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    getSnapshot: (): readonly string[] => hiddenRequestIds,
+    getPromise: (requestId: string): Promise<void> | undefined =>
+      attempts.get(requestId)?.promise ?? retiredResponses.get(requestId)?.promise,
+    begin: (requestId: string): PermissionResponseAttempt => {
+      const attempt: PermissionResponseAttempt = {
+        accepted: false,
+        rearmed: false,
+        settled: false,
+        authorityRemoved: false,
+        restored: false,
+        promise: Promise.resolve()
+      }
+      attempts.set(requestId, attempt)
+      publish()
+      return attempt
+    },
+    accept: (requestId: string, attempt: PermissionResponseAttempt): void => {
+      attempt.accepted = true
+      if (attempt.rearmed) release(requestId, attempt)
+      else if (attempt.settled || attempt.authorityRemoved) retire(requestId, attempt)
+    },
+    fail: (requestId: string, attempt: PermissionResponseAttempt): void => {
+      if (attempt.settled || attempt.authorityRemoved) retire(requestId, attempt)
+      else if (!attempt.accepted) release(requestId, attempt)
+    },
+    shouldApplyLifecycle: (event: PermissionLifecycleEvent): boolean =>
+      event.title !== ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE ||
+      !(
+        observedLifecycleEvents.get(event.permissionRequestId)?.eventIds.has(event.id) ||
+        retiredResponses.get(event.permissionRequestId)?.eventIds.has(event.id)
+      ),
+    observeLifecycle: (event: PermissionLifecycleEvent): void => {
+      const attempt = attempts.get(event.permissionRequestId)
+      const settled =
+        event.title === ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE ||
+        event.title === ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE ||
+        event.title === ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE
+      if (event.title === ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE) {
+        const retired = retiredResponses.get(event.permissionRequestId)
+        if (retired?.eventIds.has(event.id)) return
+        const observed = observedLifecycleEvents.get(event.permissionRequestId) ?? {
+          sessionId: event.sessionId,
+          eventIds: new Set(retired?.eventIds)
+        }
+        if (observed.eventIds.has(event.id)) return
+        observed.eventIds.add(event.id)
+        observedLifecycleEvents.set(event.permissionRequestId, observed)
+        if (retired) release(event.permissionRequestId)
+        if (attempt) {
+          attempt.rearmed = true
+          if (attempt.accepted) release(event.permissionRequestId, attempt)
+        }
+      } else if (settled) {
+        if (attempt) {
+          attempt.settled = true
+          if (attempt.accepted) retire(event.permissionRequestId, attempt)
+        } else {
+          const observed = observedLifecycleEvents.get(event.permissionRequestId)
+          observedLifecycleEvents.set(event.permissionRequestId, {
+            sessionId: event.sessionId ?? observed?.sessionId,
+            eventIds: new Set([
+              ...(retiredResponses.get(event.permissionRequestId)?.eventIds ?? []),
+              ...(observed?.eventIds ?? [])
+            ])
+          })
+          retire(event.permissionRequestId)
+        }
+      }
+    },
+    cleanSessions: (sessions: ChatSession[]): void => {
+      const sessionsById = new Map(sessions.map((session) => [session.id, session]))
+      for (const [requestId, attempt] of attempts) {
+        if (!attempt.sessionId) continue
+        const session = sessionsById.get(attempt.sessionId)
+        if (session) {
+          const currentRequestId = session.runtimeContext?.permission?.request.requestId
+          if (currentRequestId === requestId || !attempt.restored) continue
+          attempt.authorityRemoved = true
+          if (attempt.accepted) retire(requestId, attempt)
+          continue
+        }
+        observedLifecycleEvents.delete(requestId)
+        release(requestId, attempt)
+      }
+      for (const [requestId, observed] of observedLifecycleEvents) {
+        if (!observed.sessionId) continue
+        const session = sessionsById.get(observed.sessionId)
+        if (session) {
+          const currentRequestId = session.runtimeContext?.permission?.request.requestId
+          if (currentRequestId === requestId) continue
+          retire(requestId)
+          continue
+        }
+        observedLifecycleEvents.delete(requestId)
+      }
+      for (const [requestId, retired] of retiredResponses) {
+        if (retired.sessionId && !sessionsById.has(retired.sessionId)) {
+          retiredResponses.delete(requestId)
+          publish()
+        }
+      }
+    },
+    cleanLive: (requests: AcpPermissionRequest[]): void => {
+      const liveRequestIds = new Set(requests.map((request) => request.requestId))
+      for (const [requestId, attempt] of attempts) {
+        if (attempt.accepted && !attempt.restored && !liveRequestIds.has(requestId)) {
+          observedLifecycleEvents.delete(requestId)
+          release(requestId, attempt)
+        }
+      }
+    }
+  }
+}
+
+export { createPermissionResponseAttemptOwner }

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -1,4 +1,8 @@
 import {
+  ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
   isDurableAgentUserChoiceRequest,
   type AcpConnectionStatus,
   type AcpContextUsage,
@@ -8,6 +12,10 @@ import {
   type PendingElicitationRequest
 } from '../../../../shared/acp'
 import { useSessionStore } from '../../stores/session-store'
+import {
+  acceptAcpRuntimeSnapshotRevision,
+  resetAcpRuntimeSnapshotRevisionForTests
+} from './runtime-snapshot-revision-owner'
 import { applyWorkspaceRuntimeEvent } from './workspace-events'
 
 // Snapshot projections retain only transition edges; durable chat facts remain in Session Store.
@@ -16,11 +24,20 @@ const pendingElicitationSessionIds = new Set<string>()
 const firstOutputWaitingSessionIds = new Set<string>()
 
 type RuntimeEventApplier = (event: AcpRuntimeEvent) => Promise<boolean>
+type WorkspacePermissionLifecycleEvent = AcpRuntimeEvent & { permissionRequestId: string }
+type WorkspacePermissionLifecycleObserver = {
+  shouldApply: (event: WorkspacePermissionLifecycleEvent) => boolean
+  onApplied: (event: WorkspacePermissionLifecycleEvent) => void
+}
 
 type WorkspaceRuntimeEventProcessor = {
   process: (events: AcpRuntimeEvent[]) => Promise<void>
   drain: (sessionId?: string) => Promise<void>
 }
+type WorkspaceRuntimeEventSnapshot = Pick<
+  AcpStateSnapshot,
+  'agentPromptInFlightSessionIds' | 'events' | 'revision'
+>
 
 const processVisibleWorkspaceRuntimeEvents = async (
   events: AcpRuntimeEvent[],
@@ -201,7 +218,46 @@ const createWorkspaceRuntimeEventProcessor = (
   }
 }
 
-const liveWorkspaceRuntimeEventProcessor = createWorkspaceRuntimeEventProcessor()
+const permissionLifecycleEventTitles = new Set([
+  ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_CLEAR_FAILED_EVENT_TITLE,
+  ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE
+])
+const permissionLifecycleObservers = new Set<WorkspacePermissionLifecycleObserver>()
+
+const isWorkspacePermissionLifecycleEvent = (
+  event: AcpRuntimeEvent
+): event is AcpRuntimeEvent & { permissionRequestId: string } =>
+  event.kind === 'permission' &&
+  typeof event.permissionRequestId === 'string' &&
+  permissionLifecycleEventTitles.has(event.title ?? '')
+
+const subscribeWorkspacePermissionLifecycle = (
+  observer: WorkspacePermissionLifecycleObserver
+): (() => void) => {
+  permissionLifecycleObservers.add(observer)
+  return () => permissionLifecycleObservers.delete(observer)
+}
+
+const liveWorkspaceRuntimeEventProcessor = createWorkspaceRuntimeEventProcessor(async (event) => {
+  const permissionLifecycleEvent = isWorkspacePermissionLifecycleEvent(event) ? event : undefined
+  if (
+    permissionLifecycleEvent &&
+    [...permissionLifecycleObservers].some(
+      (observer) => !observer.shouldApply(permissionLifecycleEvent)
+    )
+  ) {
+    return true
+  }
+  const applied = await applyWorkspaceRuntimeEvent(event)
+  if (applied && permissionLifecycleEvent) {
+    for (const observer of permissionLifecycleObservers) {
+      observer.onApplied(permissionLifecycleEvent)
+    }
+  }
+  return applied
+})
 
 // Projects runtime foreground ownership and its initial silent gap into renderer-only state. Unknown
 // ids belong to background/runtime-only sessions; repeated snapshots must not restart the gap timer.
@@ -291,17 +347,31 @@ const resetWorkspaceRuntimeEventOwnerForTests = (): void => {
   pendingPermissionSessionIds.clear()
   pendingElicitationSessionIds.clear()
   firstOutputWaitingSessionIds.clear()
+  resetAcpRuntimeSnapshotRevisionForTests()
+}
+
+// Accepts Main snapshots once in construction order. This gate is shared by React subscription and
+// quit-persistence pulls so a delayed older snapshot cannot replay stale lifecycle authority.
+const acceptWorkspaceRuntimeSnapshot = (snapshot: Pick<AcpStateSnapshot, 'revision'>): boolean => {
+  return acceptAcpRuntimeSnapshotRevision(snapshot)
+}
+
+const ingestWorkspaceRuntimeSnapshot = async (
+  snapshot: WorkspaceRuntimeEventSnapshot,
+  syncFirstOutput: boolean
+): Promise<boolean> => {
+  if (!acceptWorkspaceRuntimeSnapshot(snapshot)) return false
+  if (syncFirstOutput) {
+    syncWorkspaceAgentFirstOutputState(snapshot.agentPromptInFlightSessionIds ?? [])
+  }
+  await liveWorkspaceRuntimeEventProcessor.process(snapshot.events)
+  return true
 }
 
 // Publishes prompt ownership before applying the same snapshot's events so first output can only
 // clear, never re-arm, the renderer waiting state.
-const processWorkspaceRuntimeEvents = (
-  events: AcpRuntimeEvent[],
-  agentPromptInFlightSessionIds: string[]
-): Promise<void> => {
-  syncWorkspaceAgentFirstOutputState(agentPromptInFlightSessionIds)
-  return liveWorkspaceRuntimeEventProcessor.process(events)
-}
+const processWorkspaceRuntimeEvents = (snapshot: WorkspaceRuntimeEventSnapshot): Promise<boolean> =>
+  ingestWorkspaceRuntimeSnapshot(snapshot, true)
 
 // Flags sessions with a live Agent operation as disconnected on a transition into a dropped
 // connection state. Durable permission waits are intentionally quiescent: their provider RPC can
@@ -352,9 +422,9 @@ const syncWorkspaceContextUsage = (
 
 const drainWorkspaceRuntimeEventsForPersistence = async (sessionId?: string): Promise<void> => {
   const snapshot = await window.api.acp.getState()
-  void liveWorkspaceRuntimeEventProcessor.process(snapshot.events)
+  const accepted = await ingestWorkspaceRuntimeSnapshot(snapshot, false)
   await liveWorkspaceRuntimeEventProcessor.drain(sessionId)
-  syncWorkspaceContextUsage(snapshot.sessionIds, snapshot.contextUsageBySession)
+  if (accepted) syncWorkspaceContextUsage(snapshot.sessionIds, snapshot.contextUsageBySession)
 }
 
 export {
@@ -364,6 +434,7 @@ export {
   processVisibleWorkspaceRuntimeEvents,
   processWorkspaceRuntimeEvents,
   resetWorkspaceRuntimeEventOwnerForTests,
+  subscribeWorkspacePermissionLifecycle,
   syncWorkspaceAgentFirstOutputState,
   syncWorkspaceContextUsage,
   syncWorkspaceElicitationState,

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -419,6 +419,16 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
       if (!current) return state
 
       if (mode === 'permission-authority') {
+        const currentRevision = current.runtimeContext?.revision
+        const incomingRevision = session.runtimeContext?.revision
+        if (
+          currentRevision !== undefined &&
+          incomingRevision !== undefined &&
+          incomingRevision < currentRevision
+        ) {
+          return state
+        }
+
         const permissionPending = session.runtimeContext?.permission?.state === 'pending'
         const status = permissionPending
           ? current.status === 'waiting-for-user' || current.status === 'waiting-plan-approval'

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -3023,6 +3023,7 @@ describe('session store public contract', () => {
       'src/renderer/src/lib/acp/useWorkspaceElicitation.ts',
       'src/renderer/src/lib/acp/workspace-elicitation-runtime.ts',
       'src/renderer/src/lib/acp/workspace-events.ts',
+      'src/renderer/src/lib/acp/workspace-permission-response-attempt-owner.ts',
       'src/renderer/src/lib/acp/workspace-runtime-command-owner.ts',
       'src/renderer/src/lib/acp/workspace-runtime-event-owner.ts',
       'src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts',

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -451,6 +451,8 @@ export type AcpRuntimeEvent = {
   timestamp: number
   kind: AcpRuntimeEventKind
   level: AcpRuntimeEventLevel
+  // Correlates transient restored-permission lifecycle events without extending durable Session data.
+  permissionRequestId?: string
   // Present only on a usage_update-derived event; the runtime records it per session and does not push
   // the event into the visible conversation.
   contextUsage?: AcpContextUsage
@@ -581,6 +583,9 @@ export type AcpPermissionGrant = {
 }
 
 export type AcpStateSnapshot = {
+  // Main-owned construction order lets the renderer reject delayed older IPC snapshots. It is
+  // transient runtime state and is not persisted with Session data.
+  revision?: number
   status: AcpConnectionStatus
   // A coordinator may keep multiple framework generations alive. Callers handling one session should
   // prefer its owning runtime status over the active generation's top-level compatibility status.

--- a/src/shared/lifecycle-events.ts
+++ b/src/shared/lifecycle-events.ts
@@ -9,6 +9,7 @@ type SessionUpsertEvent = {
 // Main-owned permission authority is projected through the existing Session lifecycle channel,
 // but it must merge into the live renderer Session instead of replacing in-flight chat state.
 const MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID = 'main:permission-wait'
+const MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID = 'main:durable-continuation'
 
 type ProjectDeletedEvent = {
   projectId: string
@@ -29,5 +30,9 @@ const LIFECYCLE_CHANNELS = {
   sessionDeleted: 'session:deleted'
 } as const
 
-export { LIFECYCLE_CHANNELS, MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID }
+export {
+  LIFECYCLE_CHANNELS,
+  MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID,
+  MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID
+}
 export type { Project, ProjectDeletedEvent, SessionDeletedEvent, SessionUpsertEvent }


### PR DESCRIPTION
## Problem

After an app restart, persisted permission and elicitation continuations could resume with only the originating prompt id. The resumed ACP runtime then synthesized Frame, Branch, and Runtime Segment identities from the provider session instead of the durable Session graph. Artifact writes could therefore complete under a current-run root that the strict finalizer correctly rejected as unrelated to the durable Session graph.

An out-of-order Main permission lifecycle event could also project an older pending runtime-context revision over a newer settled revision. The permission was accepted, but the old card remained visible; clicking it again then correctly reached Main as a stale restored request. Independently, a stale renderer callback could resubmit an already accepted restored permission after the first IPC call settled.

## Proposed change

- Restore permission and elicitation continuations through a Main-owned context owner that loads the durable Session and derives the complete provenance context and history replay.
- Validate pending and revised elicitation authority against the active Frame, visible Branch ancestry, prompt, Runtime Segment, durable request identity, and flat projection.
- Persist and publish Main-owned revision prompts before resuming the provider so later renderer artifact events extend the same Session graph.
- Keep strict Artifact finalization unchanged and validate restored ownership against the captured current-run context.
- Coalesce concurrent and stale permission responses after success, while releasing failed attempts and explicit Main re-arms of the same request id.
- Guard the renderer fallback projection by runtime-context revision so an IPC result cannot overwrite a newer Main-owned rearm.
- Reject Main permission-authority projections whose runtime-context revision is older than the renderer's current revision, so a late pending snapshot cannot resurrect a settled card.
- Preserve the quit boundary: only durable waits detached by actual shutdown are converted to cancellation.

```mermaid
sequenceDiagram
  participant R as Renderer
  participant M as Main ACP runtime
  participant S as Durable Session
  participant P as Provider
  R->>M: restored permission or elicitation response
  M->>S: load and validate graph authority
  M->>S: persist continuing or revision prompt
  M-->>R: publish authoritative Session revision
  M->>P: continue with durable provenance
  P-->>M: complete or fail
  M->>S: settle or rearm pending authority
  M-->>R: publish newer durable revision
  Note over R,M: older permission revisions are ignored
```

## Scope and non-goals

- The Artifact finalizer remains fail-closed; this does not weaken graph ownership checks.
- Existing artifact runs already persisted with mismatched provenance are not silently rewritten.
- This does not reinterpret or accept invalid `write_artifact_file` arguments. Provider tool calls that fail the `source` schema remain separate input-validation failures.
- No provider protocol or permission-grant semantics are changed.

## Acceptance criteria and validation

Checks against the final HEAD:

- Restored permission lifecycle and response-race coverage, including a settled revision followed by a stale pending replay -> 175 targeted tests passed.
- Full Vitest run -> 13,093 tests passed; 8 unrelated tests timed out under full parallel load. All 5 affected files were rerun with one worker and passed 594/594.
- Main, preload, shared, and renderer type contracts -> `npm run typecheck` -> passed.
- Repository source and test standards -> `npm run lint` -> passed with 0 errors (17 pre-existing warnings).
- Formatting and patch integrity -> Prettier on changed files and `git diff --check` -> passed.
- Independent Spec and Standards reviews of the final HEAD -> clean, with no actionable findings.

The Test Impact classifier selected full fallback because an ACP test path has no known module owner. Packaged/manual restart behavior remains an external verification risk; deterministic restart, stale-projection, and response-race paths are covered at the runtime and renderer seams.

## Review focus

- Durable Session graph authority versus provider-session identity during restored continuations.
- Ordering of Main-owned revision publication before hidden provider continuation.
- Permission response attempt lifetime: stale-success suppression, direct-failure retry, explicit rearm retry, and revision protection against a fast Main rearm.
- Monotonic permission-authority projection: an older pending revision must not replace a newer settled revision.
