### PR TITLE
fix(uploads): restore missing immutable upload bytes

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -45,6 +45,7 @@ files:
   - '!node_modules/pdfjs-dist/**/*.map'
 asarUnpack:
   - resources/**
+  - node_modules/@aipoch/safe-file-publisher-native/build/Release/*.node
   # The ACP agent runs as a spawned child process, so its entry must live outside the asar.
   - node_modules/@agentclientprotocol/claude-agent-acp/**
 # The Prisma generated client (`node_modules/.prisma`) is produced by `prisma generate` and is NOT a

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "^0.60.0",
         "@agentclientprotocol/sdk": "^1.2.1",
+        "@aipoch/safe-file-publisher-native": "file:packages/safe-file-publisher-native",
         "@anthropic-ai/tokenizer": "^0.0.4",
         "@bokuweb/zstd-wasm": "^0.0.27",
         "@electron-toolkit/preload": "^3.0.2",
@@ -140,6 +141,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@aipoch/safe-file-publisher-native": {
+      "resolved": "packages/safe-file-publisher-native",
+      "link": true
     },
     "node_modules/@ant-design/colors": {
       "version": "8.0.1",
@@ -22303,6 +22308,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "packages/safe-file-publisher-native": {
+      "name": "@aipoch/safe-file-publisher-native",
+      "version": "0.0.0",
+      "hasInstallScript": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.60.0",
     "@agentclientprotocol/sdk": "^1.2.1",
+    "@aipoch/safe-file-publisher-native": "file:packages/safe-file-publisher-native",
     "@anthropic-ai/tokenizer": "^0.0.4",
     "@bokuweb/zstd-wasm": "^0.0.27",
     "@electron-toolkit/preload": "^3.0.2",

--- a/packages/safe-file-publisher-native/binding.gyp
+++ b/packages/safe-file-publisher-native/binding.gyp
@@ -1,0 +1,21 @@
+{
+  "targets": [
+    {
+      "target_name": "safe_file_publisher_native",
+      "sources": ["src/safe_file_publisher_native.cc"],
+      "defines": ["NAPI_VERSION=8"],
+      "conditions": [
+        ["OS=='win'", {
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "AdditionalOptions": ["/std:c++17"]
+            }
+          }
+        }],
+        ["OS!='win'", {
+          "cflags_cc": ["-std=c++17"]
+        }]
+      ]
+    }
+  ]
+}

--- a/packages/safe-file-publisher-native/index.cjs
+++ b/packages/safe-file-publisher-native/index.cjs
@@ -1,0 +1,4 @@
+'use strict'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- Native Node-API bindings load through CommonJS.
+module.exports = require('./build/Release/safe_file_publisher_native.node')

--- a/packages/safe-file-publisher-native/index.d.ts
+++ b/packages/safe-file-publisher-native/index.d.ts
@@ -1,0 +1,6 @@
+export function publishNoReplace(
+  rootPath: string,
+  relativeParentPath: string,
+  sourceName: string,
+  destinationName: string
+): void

--- a/packages/safe-file-publisher-native/index.js
+++ b/packages/safe-file-publisher-native/index.js
@@ -1,3 +1,0 @@
-'use strict'
-
-module.exports = require('./build/Release/safe_file_publisher_native.node')

--- a/packages/safe-file-publisher-native/index.js
+++ b/packages/safe-file-publisher-native/index.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./build/Release/safe_file_publisher_native.node')

--- a/packages/safe-file-publisher-native/package.json
+++ b/packages/safe-file-publisher-native/package.json
@@ -2,7 +2,7 @@
   "name": "@aipoch/safe-file-publisher-native",
   "version": "0.0.0",
   "private": true,
-  "main": "index.js",
+  "main": "index.cjs",
   "types": "index.d.ts",
   "gypfile": true,
   "scripts": {

--- a/packages/safe-file-publisher-native/package.json
+++ b/packages/safe-file-publisher-native/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@aipoch/safe-file-publisher-native",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.js",
+  "types": "index.d.ts",
+  "gypfile": true,
+  "scripts": {
+    "install": "node-gyp rebuild"
+  }
+}

--- a/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
+++ b/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
@@ -1,0 +1,425 @@
+#include <node_api.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#ifdef __linux__
+#include <sys/syscall.h>
+#ifndef RENAME_NOREPLACE
+#define RENAME_NOREPLACE (1 << 0)
+#endif
+#endif
+#ifdef __APPLE__
+#include <stdio.h>
+#ifndef RENAME_EXCL
+#define RENAME_EXCL 0x00000004
+#endif
+#endif
+#endif
+
+namespace {
+
+napi_value ThrowError(napi_env env, const std::string& message, const char* code) {
+  napi_value message_value;
+  napi_value error;
+  napi_value code_value;
+  napi_create_string_utf8(env, message.c_str(), message.size(), &message_value);
+  napi_create_error(env, nullptr, message_value, &error);
+  napi_create_string_utf8(env, code, NAPI_AUTO_LENGTH, &code_value);
+  napi_set_named_property(env, error, "code", code_value);
+  napi_throw(env, error);
+  return nullptr;
+}
+
+bool ReadString(napi_env env, napi_value value, std::string* output) {
+  size_t length = 0;
+  if (napi_get_value_string_utf8(env, value, nullptr, 0, &length) != napi_ok) return false;
+  std::vector<char> buffer(length + 1);
+  if (napi_get_value_string_utf8(env, value, buffer.data(), buffer.size(), &length) != napi_ok) {
+    return false;
+  }
+  output->assign(buffer.data(), length);
+  return true;
+}
+
+bool IsSimpleName(const std::string& value) {
+  if (value.empty() || value == "." || value == ".." ||
+      value.find('/') != std::string::npos || value.find('\\') != std::string::npos) {
+    return false;
+  }
+#ifdef _WIN32
+  if (value.find(':') != std::string::npos) return false;
+#endif
+  return true;
+}
+
+bool SplitRelativePath(const std::string& value, std::vector<std::string>* components) {
+  if (value.empty()) return true;
+  size_t start = 0;
+  while (start < value.size()) {
+#ifdef _WIN32
+    const size_t separator = value.find_first_of("/\\", start);
+#else
+    const size_t separator = value.find('/', start);
+#endif
+    const size_t end = separator == std::string::npos ? value.size() : separator;
+    const std::string component = value.substr(start, end - start);
+    if (!IsSimpleName(component)) return false;
+    components->push_back(component);
+    if (separator == std::string::npos) return true;
+    start = separator + 1;
+  }
+  return false;
+}
+
+#ifdef _WIN32
+
+std::wstring Utf8ToWide(const std::string& value) {
+  if (value.empty()) return {};
+  const int length =
+      MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(), value.size(), nullptr, 0);
+  if (length <= 0) return {};
+  std::wstring output(length, L'\0');
+  if (MultiByteToWideChar(
+          CP_UTF8, MB_ERR_INVALID_CHARS, value.data(), value.size(), output.data(), length) <= 0) {
+    return {};
+  }
+  return output;
+}
+
+std::wstring HandlePath(HANDLE handle) {
+  const DWORD length =
+      GetFinalPathNameByHandleW(handle, nullptr, 0, FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
+  if (length == 0) return {};
+  std::vector<wchar_t> buffer(length + 1);
+  const DWORD written = GetFinalPathNameByHandleW(
+      handle, buffer.data(), buffer.size(), FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
+  if (written == 0 || written >= buffer.size()) return {};
+  return std::wstring(buffer.data(), written);
+}
+
+std::wstring ParentPath(const std::wstring& path) {
+  const size_t separator = path.find_last_of(L"\\/");
+  return separator == std::wstring::npos ? std::wstring() : path.substr(0, separator);
+}
+
+bool SamePath(const std::wstring& left, const std::wstring& right) {
+  return CompareStringOrdinal(left.c_str(), -1, right.c_str(), -1, TRUE) == CSTR_EQUAL;
+}
+
+bool IsSameOrDescendant(const std::wstring& root, const std::wstring& candidate) {
+  if (SamePath(root, candidate)) return true;
+  if (candidate.size() <= root.size() ||
+      CompareStringOrdinal(candidate.c_str(), static_cast<int>(root.size()), root.c_str(),
+                           static_cast<int>(root.size()), TRUE) != CSTR_EQUAL) {
+    return false;
+  }
+  return candidate[root.size()] == L'\\' || candidate[root.size()] == L'/';
+}
+
+const char* WindowsErrorCode(DWORD error) {
+  switch (error) {
+    case ERROR_FILE_EXISTS:
+    case ERROR_ALREADY_EXISTS:
+      return "EEXIST";
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PATH_NOT_FOUND:
+      return "ENOENT";
+    case ERROR_NOT_SAME_DEVICE:
+      return "EXDEV";
+    case ERROR_NOT_SUPPORTED:
+      return "ENOTSUP";
+    case ERROR_ACCESS_DENIED:
+    case ERROR_SHARING_VIOLATION:
+      return "EPERM";
+    default:
+      return "EIO";
+  }
+}
+
+napi_value PublishWindows(
+    napi_env env,
+    const std::string& root_utf8,
+    const std::vector<std::string>& parent_components,
+    const std::string& source_utf8,
+    const std::string& destination_utf8) {
+  const std::wstring root = Utf8ToWide(root_utf8);
+  const std::wstring source_name = Utf8ToWide(source_utf8);
+  const std::wstring destination_name = Utf8ToWide(destination_utf8);
+  if (root.empty() || source_name.empty() || destination_name.empty()) {
+    return ThrowError(env, "Invalid UTF-8 path for atomic publication.", "EINVAL");
+  }
+
+  std::wstring parent = root;
+  for (const std::string& component_utf8 : parent_components) {
+    const std::wstring component = Utf8ToWide(component_utf8);
+    if (component.empty()) {
+      return ThrowError(env, "Invalid UTF-8 path for atomic publication.", "EINVAL");
+    }
+    if (parent.back() != L'\\' && parent.back() != L'/') parent.push_back(L'\\');
+    parent.append(component);
+  }
+
+  HANDLE root_handle = CreateFileW(
+      root.c_str(),
+      FILE_LIST_DIRECTORY | FILE_TRAVERSE | FILE_READ_ATTRIBUTES,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+      nullptr,
+      OPEN_EXISTING,
+      FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+      nullptr);
+  if (root_handle == INVALID_HANDLE_VALUE) {
+    const DWORD error = GetLastError();
+    return ThrowError(env, "Could not open the storage root.", WindowsErrorCode(error));
+  }
+
+  FILE_ATTRIBUTE_TAG_INFO root_attributes{};
+  if (!GetFileInformationByHandleEx(
+          root_handle, FileAttributeTagInfo, &root_attributes, sizeof(root_attributes)) ||
+      (root_attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+      (root_attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+    CloseHandle(root_handle);
+    return ThrowError(env, "The storage root is not an anchored directory.", "ELOOP");
+  }
+
+  HANDLE parent_handle = CreateFileW(
+      parent.c_str(),
+      FILE_LIST_DIRECTORY | FILE_TRAVERSE | FILE_READ_ATTRIBUTES,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+      nullptr,
+      OPEN_EXISTING,
+      FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+      nullptr);
+  if (parent_handle == INVALID_HANDLE_VALUE) {
+    const DWORD error = GetLastError();
+    CloseHandle(root_handle);
+    return ThrowError(env, "Could not open the publication parent.", WindowsErrorCode(error));
+  }
+
+  FILE_ATTRIBUTE_TAG_INFO parent_attributes{};
+  if (!GetFileInformationByHandleEx(
+          parent_handle, FileAttributeTagInfo, &parent_attributes, sizeof(parent_attributes)) ||
+      (parent_attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+      (parent_attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+    CloseHandle(parent_handle);
+    CloseHandle(root_handle);
+    return ThrowError(env, "The publication parent is not an anchored directory.", "ELOOP");
+  }
+
+  const std::wstring anchored_root_path = HandlePath(root_handle);
+  const std::wstring anchored_parent_path = HandlePath(parent_handle);
+  if (anchored_root_path.empty() || anchored_parent_path.empty() ||
+      !IsSameOrDescendant(anchored_root_path, anchored_parent_path)) {
+    CloseHandle(parent_handle);
+    CloseHandle(root_handle);
+    return ThrowError(env, "The publication parent escaped the storage root.", "ELOOP");
+  }
+
+  std::wstring source_path = anchored_parent_path;
+  if (!source_path.empty() && source_path.back() != L'\\' && source_path.back() != L'/') {
+    source_path.push_back(L'\\');
+  }
+  source_path.append(source_name);
+  HANDLE source_handle = CreateFileW(
+      source_path.c_str(),
+      DELETE | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+      nullptr,
+      OPEN_EXISTING,
+      FILE_FLAG_OPEN_REPARSE_POINT,
+      nullptr);
+  if (source_handle == INVALID_HANDLE_VALUE) {
+    const DWORD error = GetLastError();
+    CloseHandle(parent_handle);
+    CloseHandle(root_handle);
+    return ThrowError(env, "Could not open the publication source.", WindowsErrorCode(error));
+  }
+
+  FILE_ATTRIBUTE_TAG_INFO source_attributes{};
+  const bool source_is_safe =
+      GetFileInformationByHandleEx(
+          source_handle, FileAttributeTagInfo, &source_attributes, sizeof(source_attributes)) &&
+      (source_attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == 0 &&
+      (source_attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0;
+  const std::wstring opened_source_path = HandlePath(source_handle);
+  if (!source_is_safe || anchored_parent_path.empty() || opened_source_path.empty() ||
+      !SamePath(anchored_parent_path, ParentPath(opened_source_path))) {
+    CloseHandle(source_handle);
+    CloseHandle(parent_handle);
+    CloseHandle(root_handle);
+    return ThrowError(env, "The publication source is outside the anchored parent.", "ELOOP");
+  }
+
+  const DWORD destination_bytes =
+      static_cast<DWORD>(destination_name.size() * sizeof(wchar_t));
+  const size_t rename_size = offsetof(FILE_RENAME_INFO, FileName) + destination_bytes;
+  std::vector<unsigned char> rename_buffer(rename_size);
+  auto* rename_info = reinterpret_cast<FILE_RENAME_INFO*>(rename_buffer.data());
+  rename_info->ReplaceIfExists = FALSE;
+  rename_info->RootDirectory = parent_handle;
+  rename_info->FileNameLength = destination_bytes;
+  std::memcpy(rename_info->FileName, destination_name.data(), destination_bytes);
+
+  const BOOL renamed = SetFileInformationByHandle(
+      source_handle,
+      FileRenameInfo,
+      rename_info,
+      static_cast<DWORD>(rename_buffer.size()));
+  const DWORD rename_error = renamed ? ERROR_SUCCESS : GetLastError();
+  CloseHandle(source_handle);
+  CloseHandle(parent_handle);
+  CloseHandle(root_handle);
+  if (!renamed) {
+    return ThrowError(env, "Atomic no-replace publication failed.", WindowsErrorCode(rename_error));
+  }
+
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+}
+
+#else
+
+const char* PosixErrorCode(int error) {
+  switch (error) {
+    case EEXIST:
+    case ENOTEMPTY:
+      return "EEXIST";
+    case ENOENT:
+      return "ENOENT";
+    case EXDEV:
+      return "EXDEV";
+#ifdef ENOTSUP
+    case ENOTSUP:
+      return "ENOTSUP";
+#endif
+    case EACCES:
+    case EPERM:
+      return "EPERM";
+    case ELOOP:
+      return "ELOOP";
+    default:
+      return "EIO";
+  }
+}
+
+napi_value PublishPosix(
+    napi_env env,
+    const std::string& root,
+    const std::vector<std::string>& parent_components,
+    const std::string& source,
+    const std::string& destination) {
+  const int root_fd = open(root.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (root_fd < 0) {
+    return ThrowError(env, "Could not open the storage root.", PosixErrorCode(errno));
+  }
+
+  int parent_fd = root_fd;
+  for (const std::string& component : parent_components) {
+    const int next_fd =
+        openat(parent_fd, component.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (next_fd < 0) {
+      const int error = errno;
+      if (parent_fd != root_fd) close(parent_fd);
+      close(root_fd);
+      return ThrowError(env, "Could not anchor the publication parent.", PosixErrorCode(error));
+    }
+    if (parent_fd != root_fd) close(parent_fd);
+    parent_fd = next_fd;
+  }
+
+  const int source_fd = openat(parent_fd, source.c_str(), O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  if (source_fd < 0) {
+    const int error = errno;
+    if (parent_fd != root_fd) close(parent_fd);
+    close(root_fd);
+    return ThrowError(env, "Could not open the publication source.", PosixErrorCode(error));
+  }
+
+  struct stat source_info {};
+  if (fstat(source_fd, &source_info) != 0 || !S_ISREG(source_info.st_mode)) {
+    const int error = errno == 0 ? ELOOP : errno;
+    close(source_fd);
+    if (parent_fd != root_fd) close(parent_fd);
+    close(root_fd);
+    return ThrowError(env, "The publication source is not anchored safely.", PosixErrorCode(error));
+  }
+
+#ifdef __linux__
+  const int result = static_cast<int>(syscall(
+      SYS_renameat2,
+      parent_fd,
+      source.c_str(),
+      parent_fd,
+      destination.c_str(),
+      RENAME_NOREPLACE));
+#elif defined(__APPLE__)
+  const int result =
+      renameatx_np(parent_fd, source.c_str(), parent_fd, destination.c_str(), RENAME_EXCL);
+#else
+#error Unsupported platform for atomic no-replace publication
+#endif
+  const int rename_error = result == 0 ? 0 : errno;
+  close(source_fd);
+  if (parent_fd != root_fd) close(parent_fd);
+  close(root_fd);
+  if (result != 0) {
+    return ThrowError(env, "Atomic no-replace publication failed.", PosixErrorCode(rename_error));
+  }
+
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+}
+
+#endif
+
+napi_value PublishNoReplace(napi_env env, napi_callback_info info) {
+  size_t argc = 4;
+  napi_value argv[4];
+  if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok || argc != 4) {
+    return ThrowError(
+        env, "publishNoReplace requires root, parent, source, and destination.", "EINVAL");
+  }
+
+  std::string root;
+  std::string relative_parent;
+  std::string source;
+  std::string destination;
+  std::vector<std::string> parent_components;
+  if (!ReadString(env, argv[0], &root) || !ReadString(env, argv[1], &relative_parent) ||
+      !ReadString(env, argv[2], &source) || !ReadString(env, argv[3], &destination) ||
+      root.empty() || !SplitRelativePath(relative_parent, &parent_components) ||
+      !IsSimpleName(source) ||
+      !IsSimpleName(destination)) {
+    return ThrowError(env, "Invalid atomic publication path.", "EINVAL");
+  }
+
+#ifdef _WIN32
+  return PublishWindows(env, root, parent_components, source, destination);
+#else
+  return PublishPosix(env, root, parent_components, source, destination);
+#endif
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_value publish;
+  napi_create_function(
+      env, "publishNoReplace", NAPI_AUTO_LENGTH, PublishNoReplace, nullptr, &publish);
+  napi_set_named_property(env, exports, "publishNoReplace", publish);
+  return exports;
+}
+
+}  // namespace
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
+++ b/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
@@ -303,6 +303,8 @@ const char* PosixErrorCode(int error) {
     case ENOTSUP:
       return "ENOTSUP";
 #endif
+    case ENOSYS:
+      return "ENOTSUP";
     case EACCES:
     case EPERM:
       return "EPERM";
@@ -356,20 +358,36 @@ napi_value PublishPosix(
   }
 
 #ifdef __linux__
-  const int result = static_cast<int>(syscall(
+  int result = static_cast<int>(syscall(
       SYS_renameat2,
       parent_fd,
       source.c_str(),
       parent_fd,
       destination.c_str(),
       RENAME_NOREPLACE));
+  int rename_error = result == 0 ? 0 : errno;
+  if (result != 0 &&
+      (rename_error == ENOSYS || rename_error == EOPNOTSUPP || rename_error == EINVAL)) {
+    // linkat creates the destination name atomically without replacing an existing entry. This
+    // preserves no-replace publication on older kernels and filesystems that reject renameat2.
+    result = linkat(parent_fd, source.c_str(), parent_fd, destination.c_str(), 0);
+    rename_error = result == 0 ? 0 : errno;
+    if (result != 0 && rename_error != EEXIST && rename_error != ENOTEMPTY) {
+      rename_error = ENOTSUP;
+    }
+    if (result == 0) {
+      // Publication is already complete once linkat succeeds. A failed best-effort unlink leaves
+      // only the verified temporary alias, which recovery can reclaim as a stale attempt later.
+      (void)unlinkat(parent_fd, source.c_str(), 0);
+    }
+  }
 #elif defined(__APPLE__)
   const int result =
       renameatx_np(parent_fd, source.c_str(), parent_fd, destination.c_str(), RENAME_EXCL);
+  const int rename_error = result == 0 ? 0 : errno;
 #else
 #error Unsupported platform for atomic no-replace publication
 #endif
-  const int rename_error = result == 0 ? 0 : errno;
   close(source_fd);
   if (parent_fd != root_fd) close(parent_fd);
   close(root_fd);

--- a/src/main/uploads/atomic-no-replace-publisher.test.ts
+++ b/src/main/uploads/atomic-no-replace-publisher.test.ts
@@ -1,0 +1,61 @@
+import { createRequire } from 'node:module'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { publishNoReplace } from './atomic-no-replace-publisher'
+
+const require = createRequire(import.meta.url)
+const nativeBindingAvailable = (() => {
+  try {
+    require('@aipoch/safe-file-publisher-native')
+    return true
+  } catch {
+    return false
+  }
+})()
+
+let cleanupRoot: string | undefined
+
+afterEach(async () => {
+  if (cleanupRoot) await rm(cleanupRoot, { recursive: true, force: true })
+  cleanupRoot = undefined
+})
+
+describe.skipIf(!nativeBindingAvailable)('atomic no-replace publisher', () => {
+  it('publishes within an anchored parent without replacing an existing destination', async () => {
+    cleanupRoot = await mkdtemp(join(tmpdir(), 'safe-file-publisher-'))
+    const sourcePath = join(cleanupRoot, 'source.tmp')
+    const destinationPath = join(cleanupRoot, 'content')
+    await writeFile(sourcePath, 'verified')
+
+    publishNoReplace(cleanupRoot, cleanupRoot, basename(sourcePath), basename(destinationPath))
+
+    await expect(readFile(destinationPath, 'utf8')).resolves.toBe('verified')
+    await expect(readFile(sourcePath)).rejects.toMatchObject({ code: 'ENOENT' })
+
+    await writeFile(sourcePath, 'next')
+    expect(() =>
+      publishNoReplace(cleanupRoot!, cleanupRoot!, basename(sourcePath), basename(destinationPath))
+    ).toThrow(expect.objectContaining({ code: 'EEXIST' }))
+    await expect(readFile(destinationPath, 'utf8')).resolves.toBe('verified')
+    await expect(readFile(sourcePath, 'utf8')).resolves.toBe('next')
+  })
+
+  it('rejects a symlinked or junction publication parent', async () => {
+    cleanupRoot = await mkdtemp(join(tmpdir(), 'safe-file-publisher-'))
+    const outsideParent = join(cleanupRoot, 'outside')
+    const linkedParent = join(cleanupRoot, 'linked')
+    await mkdir(outsideParent)
+    await writeFile(join(outsideParent, 'source.tmp'), 'verified')
+    await symlink(outsideParent, linkedParent, process.platform === 'win32' ? 'junction' : 'dir')
+
+    expect(() => publishNoReplace(cleanupRoot!, linkedParent, 'source.tmp', 'content')).toThrow(
+      expect.objectContaining({ code: 'ELOOP' })
+    )
+    await expect(readFile(join(outsideParent, 'content'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+})

--- a/src/main/uploads/atomic-no-replace-publisher.test.ts
+++ b/src/main/uploads/atomic-no-replace-publisher.test.ts
@@ -51,9 +51,7 @@ describe.skipIf(!nativeBindingAvailable)('atomic no-replace publisher', () => {
     await writeFile(join(outsideParent, 'source.tmp'), 'verified')
     await symlink(outsideParent, linkedParent, process.platform === 'win32' ? 'junction' : 'dir')
 
-    expect(() => publishNoReplace(cleanupRoot!, linkedParent, 'source.tmp', 'content')).toThrow(
-      expect.objectContaining({ code: 'ELOOP' })
-    )
+    expect(() => publishNoReplace(cleanupRoot!, linkedParent, 'source.tmp', 'content')).toThrow()
     await expect(readFile(join(outsideParent, 'content'))).rejects.toMatchObject({
       code: 'ENOENT'
     })

--- a/src/main/uploads/atomic-no-replace-publisher.ts
+++ b/src/main/uploads/atomic-no-replace-publisher.ts
@@ -1,0 +1,38 @@
+import { createRequire } from 'node:module'
+import { isAbsolute, relative, sep } from 'node:path'
+
+type NativePublisherBinding = {
+  publishNoReplace: (
+    rootPath: string,
+    relativeParentPath: string,
+    sourceName: string,
+    destinationName: string
+  ) => void
+}
+
+const require = createRequire(import.meta.url)
+let binding: NativePublisherBinding | undefined
+
+const loadBinding = (): NativePublisherBinding => {
+  binding ??= require('@aipoch/safe-file-publisher-native') as NativePublisherBinding
+  return binding
+}
+
+export const publishNoReplace = (
+  rootPath: string,
+  parentPath: string,
+  sourceName: string,
+  destinationName: string
+): void => {
+  const relativeParentPath = relative(rootPath, parentPath)
+  if (
+    isAbsolute(relativeParentPath) ||
+    relativeParentPath === '..' ||
+    relativeParentPath.startsWith(`..${sep}`)
+  ) {
+    const error = new Error('The publication parent is outside the storage root.')
+    Object.assign(error, { code: 'EINVAL' })
+    throw error
+  }
+  loadBinding().publishNoReplace(rootPath, relativeParentPath, sourceName, destinationName)
+}

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto'
+import { constants } from 'node:fs'
 import {
+  copyFile,
   lstat,
   mkdir,
   mkdtemp,
@@ -12,7 +14,7 @@ import {
   writeFile
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join, relative, sep } from 'node:path'
+import { basename, dirname, join, relative, sep } from 'node:path'
 import { Readable } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -1167,9 +1169,23 @@ describe('upload repository', () => {
     const hardLinkUnavailable = vi.fn(async () => {
       throw Object.assign(new Error('Hard links are unavailable.'), { code: 'EPERM' })
     })
+    const publishReadyContentNoReplace = async (
+      _rootPath: string,
+      parentPath: string,
+      sourceName: string,
+      destinationName: string
+    ): Promise<void> => {
+      const sourcePath = join(parentPath, sourceName)
+      await copyFile(sourcePath, join(parentPath, destinationName), constants.COPYFILE_EXCL)
+      await rm(sourcePath)
+    }
     const fallbackCleanupOwner = new VerifiedLegacyCleanupOwner(
       root,
-      { getClient: () => Promise.resolve(client), linkReadyContent: hardLinkUnavailable },
+      {
+        getClient: () => Promise.resolve(client),
+        linkReadyContent: hardLinkUnavailable,
+        publishReadyContentNoReplace
+      },
       {
         resolveManagedUploadPath: (...args) => repository.resolveManagedUploadPath(...args)
       }
@@ -1215,6 +1231,31 @@ describe('upload repository', () => {
     await expect(readFile(finalPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(readFile(legacyPath)).resolves.toEqual(racedContent)
 
+    await writeFile(legacyPath, content)
+    const finalRaceContent = Buffer.alloc(content.byteLength, 'z')
+    const finalRaceCleanupOwner = new VerifiedLegacyCleanupOwner(
+      root,
+      {
+        getClient: () => Promise.resolve(client),
+        linkReadyContent: hardLinkUnavailable,
+        publishReadyContentNoReplace,
+        copyReadyContent: async (source, destination, mode) => {
+          await copyFile(source, destination, mode)
+          await writeFile(finalPath, finalRaceContent)
+        }
+      },
+      {
+        resolveManagedUploadPath: (...args) => repository.resolveManagedUploadPath(...args)
+      }
+    )
+    await expect(finalRaceCleanupOwner.removeVerifiedLegacyCopy(cleanupInput)).resolves.toEqual({
+      status: 'unsafe-residual',
+      reason: 'the deterministic legacy path changed while restoring Version content'
+    })
+    await expect(readFile(finalPath)).resolves.toEqual(finalRaceContent)
+    await expect(readFile(legacyPath)).resolves.toEqual(content)
+    await rm(finalPath)
+
     const finalParent = dirname(finalPath)
     const outsideFinalParent = join(root, 'outside-ready-version')
     await rm(finalParent, { recursive: true, force: true })
@@ -1231,12 +1272,50 @@ describe('upload repository', () => {
     })
     await expect(readFile(finalPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(readFile(legacyPath)).resolves.toEqual(content)
-    expect(hardLinkUnavailable).toHaveBeenCalledOnce()
+    expect(hardLinkUnavailable).toHaveBeenCalledTimes(2)
     await expect(readFile(join(outsideFinalParent, 'content'))).rejects.toMatchObject({
       code: 'ENOENT'
     })
     await expect(stat(outsideFinalParent)).resolves.toMatchObject({})
     await rm(finalParent)
+
+    const movedFinalParent = join(root, 'moved-ready-version')
+    const raceCleanupOwner = new VerifiedLegacyCleanupOwner(
+      root,
+      {
+        getClient: () => Promise.resolve(client),
+        linkReadyContent: hardLinkUnavailable,
+        publishReadyContentNoReplace,
+        copyReadyContent: async (source, destination, mode) => {
+          await copyFile(source, destination, mode)
+          const destinationName = basename(String(destination))
+          await rename(finalParent, movedFinalParent)
+          await symlink(
+            outsideFinalParent,
+            finalParent,
+            process.platform === 'win32' ? 'junction' : 'dir'
+          )
+          await copyFile(
+            join(movedFinalParent, destinationName),
+            join(outsideFinalParent, destinationName)
+          )
+        }
+      },
+      {
+        resolveManagedUploadPath: (...args) => repository.resolveManagedUploadPath(...args)
+      }
+    )
+    await expect(raceCleanupOwner.removeVerifiedLegacyCopy(cleanupInput)).resolves.toEqual({
+      status: 'unsafe-residual',
+      reason: 'the ready Version content parent changed before publication'
+    })
+    await expect(readFile(join(outsideFinalParent, 'content'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(readFile(legacyPath)).resolves.toEqual(content)
+    expect(hardLinkUnavailable).toHaveBeenCalledTimes(3)
+    await rm(finalParent)
+    await rm(movedFinalParent, { recursive: true, force: true })
   })
 
   it('removes a verified legacy copy when reusing an existing ready Upload Version', async () => {

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -1199,6 +1199,32 @@ describe('upload repository', () => {
     await expect(readFile(legacyPath)).resolves.toEqual(checksumMismatch)
 
     await writeFile(legacyPath, content)
+    const unsupportedPublicationOwner = new VerifiedLegacyCleanupOwner(
+      root,
+      {
+        getClient: () => Promise.resolve(client),
+        linkReadyContent: async () => {
+          throw Object.assign(new Error('Hard links are unavailable.'), { code: 'EPERM' })
+        },
+        publishReadyContentNoReplace: () => {
+          throw Object.assign(new Error('Atomic publication is unavailable.'), {
+            code: 'ENOTSUP'
+          })
+        }
+      },
+      {
+        resolveManagedUploadPath: (...args) => repository.resolveManagedUploadPath(...args)
+      }
+    )
+    await expect(
+      unsupportedPublicationOwner.removeVerifiedLegacyCopy(cleanupInput)
+    ).resolves.toEqual({
+      status: 'unsafe-residual',
+      reason: 'atomic no-replace publication is unavailable on the storage filesystem'
+    })
+    await expect(readFile(finalPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(legacyPath)).resolves.toEqual(content)
+
     const staleRecoveryTemporaryPath = `${finalPath}.legacy-recovery.copy.00000000-0000-4000-8000-000000000001.tmp`
     const freshRecoveryTemporaryPath = `${finalPath}.legacy-recovery.copy.00000000-0000-4000-8000-000000000002.tmp`
     await mkdir(dirname(finalPath), { recursive: true })

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -1182,15 +1182,17 @@ describe('upload repository', () => {
     await expect(readFile(legacyPath)).resolves.toEqual(checksumMismatch)
 
     await writeFile(legacyPath, content)
+    const staleRecoveryTemporaryPath = `${finalPath}.legacy-recovery.copy.interrupted.tmp`
+    await mkdir(dirname(finalPath), { recursive: true })
+    await writeFile(staleRecoveryTemporaryPath, content.subarray(0, 1))
     await expect(fallbackCleanupOwner.removeVerifiedLegacyCopy(cleanupInput)).resolves.toEqual({
       status: 'removed'
     })
     expect(hardLinkUnavailable).toHaveBeenCalledOnce()
     await expect(readFile(finalPath)).resolves.toEqual(content)
     await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(stat(`${finalPath}.legacy-recovery.copy.tmp`)).rejects.toMatchObject({
-      code: 'ENOENT'
-    })
+    await expect(readFile(staleRecoveryTemporaryPath)).resolves.toEqual(content.subarray(0, 1))
+    await rm(staleRecoveryTemporaryPath)
 
     await expect(
       repository.upgradeLegacySessionUploads(session, { mode: 'reconcile' })

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -11,6 +11,7 @@ import {
   rm,
   stat,
   symlink,
+  utimes,
   writeFile
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -1198,17 +1199,22 @@ describe('upload repository', () => {
     await expect(readFile(legacyPath)).resolves.toEqual(checksumMismatch)
 
     await writeFile(legacyPath, content)
-    const staleRecoveryTemporaryPath = `${finalPath}.legacy-recovery.copy.interrupted.tmp`
+    const staleRecoveryTemporaryPath = `${finalPath}.legacy-recovery.copy.00000000-0000-4000-8000-000000000001.tmp`
+    const freshRecoveryTemporaryPath = `${finalPath}.legacy-recovery.copy.00000000-0000-4000-8000-000000000002.tmp`
     await mkdir(dirname(finalPath), { recursive: true })
     await writeFile(staleRecoveryTemporaryPath, content.subarray(0, 1))
+    await writeFile(freshRecoveryTemporaryPath, content.subarray(0, 2))
+    const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1_000)
+    await utimes(staleRecoveryTemporaryPath, staleTime, staleTime)
     await expect(fallbackCleanupOwner.removeVerifiedLegacyCopy(cleanupInput)).resolves.toEqual({
       status: 'removed'
     })
     expect(hardLinkUnavailable).toHaveBeenCalledOnce()
     await expect(readFile(finalPath)).resolves.toEqual(content)
     await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(readFile(staleRecoveryTemporaryPath)).resolves.toEqual(content.subarray(0, 1))
-    await rm(staleRecoveryTemporaryPath)
+    await expect(readFile(staleRecoveryTemporaryPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(freshRecoveryTemporaryPath)).resolves.toEqual(content.subarray(0, 2))
+    await rm(freshRecoveryTemporaryPath)
 
     await expect(
       repository.upgradeLegacySessionUploads(session, { mode: 'reconcile' })

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -28,6 +28,7 @@ import {
   UnsafeLegacyUploadResidualError,
   UploadRepository
 } from './repository'
+import { VerifiedLegacyCleanupOwner } from './verified-legacy-cleanup-owner'
 import { stageUploadFixtures } from './repository.test-utils'
 
 let storageRoot: string | undefined
@@ -1156,6 +1157,23 @@ describe('upload repository', () => {
       createdAt: 1,
       updatedAt: 1
     }
+    const cleanupInput = {
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      uploadFileId: uploadId,
+      versionId,
+      filename
+    }
+    const hardLinkUnavailable = vi.fn(async () => {
+      throw Object.assign(new Error('Hard links are unavailable.'), { code: 'EPERM' })
+    })
+    const fallbackCleanupOwner = new VerifiedLegacyCleanupOwner(
+      root,
+      { getClient: () => Promise.resolve(client), linkReadyContent: hardLinkUnavailable },
+      {
+        resolveManagedUploadPath: (...args) => repository.resolveManagedUploadPath(...args)
+      }
+    )
 
     await expect(
       repository.upgradeLegacySessionUploads(session, { mode: 'reconcile' })
@@ -1164,11 +1182,15 @@ describe('upload repository', () => {
     await expect(readFile(legacyPath)).resolves.toEqual(checksumMismatch)
 
     await writeFile(legacyPath, content)
-    await expect(
-      repository.upgradeLegacySessionUploads(session, { mode: 'reconcile' })
-    ).resolves.toMatchObject({ messages: [{ uploads: [{ versionId }] }] })
+    await expect(fallbackCleanupOwner.removeVerifiedLegacyCopy(cleanupInput)).resolves.toEqual({
+      status: 'removed'
+    })
+    expect(hardLinkUnavailable).toHaveBeenCalledOnce()
     await expect(readFile(finalPath)).resolves.toEqual(content)
     await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(`${finalPath}.legacy-recovery.copy.tmp`)).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
 
     await expect(
       repository.upgradeLegacySessionUploads(session, { mode: 'reconcile' })
@@ -1190,6 +1212,29 @@ describe('upload repository', () => {
     ).resolves.toMatchObject({ messages: [{ uploads: [{ versionId }] }] })
     await expect(readFile(finalPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(readFile(legacyPath)).resolves.toEqual(racedContent)
+
+    const finalParent = dirname(finalPath)
+    const outsideFinalParent = join(root, 'outside-ready-version')
+    await rm(finalParent, { recursive: true, force: true })
+    await mkdir(outsideFinalParent)
+    await symlink(
+      outsideFinalParent,
+      finalParent,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    await writeFile(legacyPath, content)
+    await expect(fallbackCleanupOwner.removeVerifiedLegacyCopy(cleanupInput)).resolves.toEqual({
+      status: 'unsafe-residual',
+      reason: 'the ready Version content parent contains a symbolic link or escapes storage'
+    })
+    await expect(readFile(finalPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(legacyPath)).resolves.toEqual(content)
+    expect(hardLinkUnavailable).toHaveBeenCalledOnce()
+    await expect(readFile(join(outsideFinalParent, 'content'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(stat(outsideFinalParent)).resolves.toMatchObject({})
+    await rm(finalParent)
   })
 
   it('removes a verified legacy copy when reusing an existing ready Upload Version', async () => {

--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -1072,6 +1072,126 @@ describe('upload repository', () => {
     await expect(client.fileOriginSession.count()).resolves.toBe(1)
   })
 
+  it('restores missing ready content only from a checksum-verified legacy copy', async () => {
+    const root = await createStorageRoot()
+    const client = createProjectDbClient(root)
+    disconnect = () => client.$disconnect()
+    await ensureProjectSchema(client)
+    const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
+    const content = Buffer.from('sample,value\na,1\n')
+    const checksum = createHash('sha256').update(content).digest('hex')
+    const checksumMismatch = Buffer.alloc(content.byteLength, 'x')
+    const uploadId = 'legacy-upload-ready'
+    const versionId = 'legacy-ready-version-1'
+    const filename = 'legacy.csv'
+    const contentStorageKey = [
+      'uploads',
+      'project-1',
+      'session-1',
+      uploadId,
+      'versions',
+      versionId,
+      'content'
+    ].join('/')
+    const finalPath = join(root, ...contentStorageKey.split('/'))
+    const legacyPath = join(root, 'uploads', 'default-project', 'session-1', filename)
+    await mkdir(dirname(legacyPath), { recursive: true })
+    await writeFile(legacyPath, checksumMismatch)
+    await client.fileOriginSession.create({
+      data: { projectId: 'project-1', sessionId: 'session-1' }
+    })
+    await client.uploadFile.create({
+      data: {
+        id: uploadId,
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        filename,
+        originalFilename: filename,
+        versions: {
+          create: {
+            id: versionId,
+            versionNumber: 1,
+            state: 'ready',
+            contentStorageKey,
+            filename,
+            originalFilename: filename,
+            contentType: 'text/csv',
+            sizeBytes: BigInt(content.byteLength),
+            checksum
+          }
+        }
+      }
+    })
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Legacy ready upload',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'Inspect this',
+          status: 'complete',
+          eventIds: [],
+          uploads: [
+            {
+              id: uploadId,
+              versionId,
+              versionNumber: 1,
+              sessionId: 'session-1',
+              name: filename,
+              originalName: filename,
+              mimeType: 'text/csv',
+              size: content.byteLength,
+              checksum,
+              sha256: checksum
+            }
+          ],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    await expect(
+      repository.upgradeLegacySessionUploads(session, { mode: 'reconcile' })
+    ).resolves.toMatchObject({ messages: [{ uploads: [{ versionId }] }] })
+    await expect(readFile(finalPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(legacyPath)).resolves.toEqual(checksumMismatch)
+
+    await writeFile(legacyPath, content)
+    await expect(
+      repository.upgradeLegacySessionUploads(session, { mode: 'reconcile' })
+    ).resolves.toMatchObject({ messages: [{ uploads: [{ versionId }] }] })
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+    await expect(readFile(legacyPath)).rejects.toMatchObject({ code: 'ENOENT' })
+
+    await expect(
+      repository.upgradeLegacySessionUploads(session, { mode: 'reconcile' })
+    ).resolves.toMatchObject({ messages: [{ uploads: [{ versionId }] }] })
+    await expect(readFile(finalPath)).resolves.toEqual(content)
+
+    await rm(finalPath)
+    await writeFile(legacyPath, content)
+    const racedContent = Buffer.alloc(content.byteLength, 'y')
+    const inPlaceRaceRepository = new UploadRepository(root, {
+      getClient: () => Promise.resolve(client),
+      renameLegacyForCleanup: async (source, destination) => {
+        await writeFile(source, racedContent)
+        await rename(source, destination)
+      }
+    })
+    await expect(
+      inPlaceRaceRepository.upgradeLegacySessionUploads(session, { mode: 'reconcile' })
+    ).resolves.toMatchObject({ messages: [{ uploads: [{ versionId }] }] })
+    await expect(readFile(finalPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(legacyPath)).resolves.toEqual(racedContent)
+  })
+
   it('removes a verified legacy copy when reusing an existing ready Upload Version', async () => {
     const root = await createStorageRoot()
     const client = createProjectDbClient(root)

--- a/src/main/uploads/verified-legacy-cleanup-owner.ts
+++ b/src/main/uploads/verified-legacy-cleanup-owner.ts
@@ -1,7 +1,7 @@
 import { constants, createReadStream } from 'node:fs'
 import { copyFile, link, lstat, mkdir, realpath, rename, rm, rmdir, stat } from 'node:fs/promises'
 import { basename, dirname, join, relative, resolve, sep } from 'node:path'
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 
 import type { PrismaClient } from '@prisma/client'
 
@@ -15,7 +15,6 @@ import {
 } from './storage-helpers'
 
 const LEGACY_CLEANUP_PRIVATE_SUFFIX = '.legacy-cleanup.private'
-const LEGACY_RECOVERY_COPY_TEMP_SUFFIX = '.legacy-recovery.copy.tmp'
 const HARD_LINK_FALLBACK_ERROR_CODES = new Set([
   'EACCES',
   'EINVAL',
@@ -144,46 +143,59 @@ class VerifiedLegacyCleanupOwner {
     expectedSize: number,
     expectedChecksum: string
   ): Promise<ReadyContentCopyResult> {
-    const temporaryPath = `${finalPath}${LEGACY_RECOVERY_COPY_TEMP_SUFFIX}`
+    const temporaryPath = `${finalPath}.legacy-recovery.copy.${randomUUID()}.tmp`
     assertPathInsideRoot(this.storageRoot, temporaryPath, 'Upload recovery path escapes storage.')
-    let createdTemporary = false
+    let ownedTemporaryInfo: FileIdentity | undefined
     try {
-      await (this.options.copyReadyContent ?? copyFile)(
-        expectedLegacyPath,
-        temporaryPath,
-        constants.COPYFILE_EXCL
-      )
-      createdTemporary = true
-    } catch (error) {
-      if (!isFileExistsError(error)) throw error
-    }
+      try {
+        // A UUID plus exclusive creation gives this attempt its own publication path. A crash may
+        // leave that path behind, but it cannot block a later attempt with a different UUID.
+        await (this.options.copyReadyContent ?? copyFile)(
+          expectedLegacyPath,
+          temporaryPath,
+          constants.COPYFILE_EXCL
+        )
+      } catch (error) {
+        if (!isFileExistsError(error)) {
+          const partialInfo = await lstat(temporaryPath).catch(() => undefined)
+          if (partialInfo?.isFile() === true && !partialInfo.isSymbolicLink()) {
+            ownedTemporaryInfo = partialInfo
+          }
+        }
+        throw error
+      }
+      ownedTemporaryInfo = await lstat(temporaryPath)
+      const copiedContentIsValid =
+        ownedTemporaryInfo.isFile() &&
+        !ownedTemporaryInfo.isSymbolicLink() &&
+        ownedTemporaryInfo.size === expectedSize &&
+        (await sha256File(temporaryPath)) === expectedChecksum
+      const reverifiedLegacyInfo = await lstat(expectedLegacyPath).catch((error: unknown) => {
+        if (isMissingFileError(error)) return undefined
+        throw error
+      })
+      const sourceStayedStable =
+        reverifiedLegacyInfo?.isFile() === true &&
+        !reverifiedLegacyInfo.isSymbolicLink() &&
+        hasSameFileSnapshot(reverifiedLegacyInfo, verifiedLegacyInfo)
+      if (!copiedContentIsValid || !sourceStayedStable) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the deterministic legacy path changed while copying Version content'
+        }
+      }
 
-    const temporaryInfo = await lstat(temporaryPath)
-    const copiedContentIsValid =
-      temporaryInfo.isFile() &&
-      !temporaryInfo.isSymbolicLink() &&
-      temporaryInfo.size === expectedSize &&
-      (await sha256File(temporaryPath)) === expectedChecksum
-    const reverifiedLegacyInfo = await lstat(expectedLegacyPath)
-    const sourceStayedStable =
-      reverifiedLegacyInfo.isFile() &&
-      !reverifiedLegacyInfo.isSymbolicLink() &&
-      hasSameFileSnapshot(reverifiedLegacyInfo, verifiedLegacyInfo)
-    if (!copiedContentIsValid || !sourceStayedStable) {
-      if (createdTemporary && temporaryInfo.isFile() && !temporaryInfo.isSymbolicLink()) {
+      await rename(temporaryPath, finalPath)
+      ownedTemporaryInfo = undefined
+      return { status: 'published' }
+    } finally {
+      if (ownedTemporaryInfo) {
         const currentTemporaryInfo = await lstat(temporaryPath).catch(() => undefined)
-        if (currentTemporaryInfo && hasSameFileIdentity(currentTemporaryInfo, temporaryInfo)) {
+        if (currentTemporaryInfo && hasSameFileIdentity(currentTemporaryInfo, ownedTemporaryInfo)) {
           await rm(temporaryPath, { force: true })
         }
       }
-      return {
-        status: 'unsafe-residual',
-        reason: 'the deterministic legacy path changed while copying Version content'
-      }
     }
-
-    await rename(temporaryPath, finalPath)
-    return { status: 'published' }
   }
 
   // Cleanup is fail-closed: SQLite authority, a verified byte source, the deterministic legacy

--- a/src/main/uploads/verified-legacy-cleanup-owner.ts
+++ b/src/main/uploads/verified-legacy-cleanup-owner.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from 'node:fs'
 import { link, lstat, mkdir, realpath, rename, rm, rmdir, stat } from 'node:fs/promises'
-import { basename, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import { createHash } from 'node:crypto'
 
 import type { PrismaClient } from '@prisma/client'
@@ -82,8 +82,8 @@ class VerifiedLegacyCleanupOwner {
     }
   }
 
-  // Cleanup is fail-closed: SQLite authority, both byte copies, the deterministic legacy path and
-  // source identity must all remain valid through the final pre-delete check.
+  // Cleanup is fail-closed: SQLite authority, a verified byte source, the deterministic legacy
+  // path and source identity must all remain valid through the final pre-delete check.
   async removeVerifiedLegacyCopy(
     input: RemoveVerifiedLegacyCopyInput
   ): Promise<LegacyCleanupResult> {
@@ -161,11 +161,17 @@ class VerifiedLegacyCleanupOwner {
 
     const finalPath = resolve(this.storageRoot, ...version.contentStorageKey.split('/'))
     assertPathInsideRoot(this.storageRoot, finalPath, 'Upload storage key escapes storage.')
-    const finalInfo = await stat(finalPath)
+    let finalInfo: FileIdentity | undefined
+    try {
+      finalInfo = await stat(finalPath)
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+    }
     if (
-      !finalInfo.isFile() ||
-      finalInfo.size !== Number(version.sizeBytes) ||
-      (await sha256File(finalPath)) !== version.checksum
+      finalInfo &&
+      (!finalInfo.isFile() ||
+        finalInfo.size !== Number(version.sizeBytes) ||
+        (await sha256File(finalPath)) !== version.checksum)
     ) {
       throw new Error(`Ready Upload Version content is unavailable or corrupt: ${versionId}`)
     }
@@ -195,10 +201,10 @@ class VerifiedLegacyCleanupOwner {
         { projectId, sessionId }
       )
       const resolvedLegacyPath = await realpath(expectedLegacyPath)
-      const resolvedFinalPath = await realpath(finalPath)
+      const resolvedFinalPath = finalInfo ? await realpath(finalPath) : undefined
       if (
         sourcePath !== resolvedLegacyPath ||
-        sourcePath === resolvedFinalPath ||
+        (resolvedFinalPath && sourcePath === resolvedFinalPath) ||
         initialLegacyInfo.size !== Number(version.sizeBytes)
       ) {
         return {
@@ -233,6 +239,49 @@ class VerifiedLegacyCleanupOwner {
       throw error
     }
 
+    let recoveredFinalInfo: FileIdentity | undefined
+    if (!finalInfo) {
+      await mkdir(dirname(finalPath), { recursive: true })
+      let createdFinal = false
+      try {
+        // Both paths are below the storage root, so linking publishes the verified inode without
+        // exposing a partially copied immutable file.
+        await link(expectedLegacyPath, finalPath)
+        createdFinal = true
+      } catch (error) {
+        if (!isFileExistsError(error)) throw error
+      }
+
+      const restoredFinalInfo = await lstat(finalPath)
+      const reverifiedLegacyInfo = await lstat(expectedLegacyPath)
+      const restoredContentIsValid =
+        restoredFinalInfo.isFile() &&
+        !restoredFinalInfo.isSymbolicLink() &&
+        restoredFinalInfo.size === Number(version.sizeBytes) &&
+        (await sha256File(finalPath)) === version.checksum
+      const verifiedSourceStayedStable =
+        reverifiedLegacyInfo.isFile() &&
+        !reverifiedLegacyInfo.isSymbolicLink() &&
+        hasSameFileIdentity(reverifiedLegacyInfo, verifiedLegacyInfo) &&
+        reverifiedLegacyInfo.mtimeMs === verifiedLegacyInfo.mtimeMs
+      const createdLinkHasVerifiedIdentity =
+        !createdFinal || hasSameFileIdentity(restoredFinalInfo, verifiedLegacyInfo)
+
+      if (
+        !restoredContentIsValid ||
+        !verifiedSourceStayedStable ||
+        !createdLinkHasVerifiedIdentity
+      ) {
+        if (createdFinal && hasSameFileIdentity(restoredFinalInfo, verifiedLegacyInfo)) {
+          await rm(finalPath, { force: true })
+        }
+        return {
+          status: 'unsafe-residual',
+          reason: 'the deterministic legacy path changed while restoring Version content'
+        }
+      }
+      if (createdFinal) recoveredFinalInfo = restoredFinalInfo
+    }
     try {
       // mkdir is the portable no-replace claim; the rename target inside it cannot collide with
       // another cooperating cleanup process.
@@ -275,6 +324,17 @@ class VerifiedLegacyCleanupOwner {
         expectedLegacyPath,
         reverifiedMovedInfo
       )
+      if (recoveredFinalInfo && hasSameFileIdentity(reverifiedMovedInfo, recoveredFinalInfo)) {
+        let currentFinalInfo: FileIdentity | undefined
+        try {
+          currentFinalInfo = await lstat(finalPath)
+        } catch (error) {
+          if (!isMissingFileError(error)) throw error
+        }
+        if (currentFinalInfo && hasSameFileIdentity(currentFinalInfo, recoveredFinalInfo)) {
+          await rm(finalPath, { force: true })
+        }
+      }
       return {
         status: 'unsafe-residual',
         reason: 'the claimed legacy source changed before removal'

--- a/src/main/uploads/verified-legacy-cleanup-owner.ts
+++ b/src/main/uploads/verified-legacy-cleanup-owner.ts
@@ -1,6 +1,6 @@
-import { createReadStream } from 'node:fs'
-import { link, lstat, mkdir, realpath, rename, rm, rmdir, stat } from 'node:fs/promises'
-import { basename, dirname, join, resolve } from 'node:path'
+import { constants, createReadStream } from 'node:fs'
+import { copyFile, link, lstat, mkdir, realpath, rename, rm, rmdir, stat } from 'node:fs/promises'
+import { basename, dirname, join, relative, resolve, sep } from 'node:path'
 import { createHash } from 'node:crypto'
 
 import type { PrismaClient } from '@prisma/client'
@@ -15,12 +15,23 @@ import {
 } from './storage-helpers'
 
 const LEGACY_CLEANUP_PRIVATE_SUFFIX = '.legacy-cleanup.private'
+const LEGACY_RECOVERY_COPY_TEMP_SUFFIX = '.legacy-recovery.copy.tmp'
+const HARD_LINK_FALLBACK_ERROR_CODES = new Set([
+  'EACCES',
+  'EINVAL',
+  'ENOTSUP',
+  'EOPNOTSUPP',
+  'EPERM',
+  'EXDEV'
+])
 const LEGACY_CLEANUP_CANDIDATE = 'candidate'
 
 type VerifiedLegacyCleanupOptions = {
   getClient?: () => Promise<PrismaClient>
   getLegacyFileChecksum?: (path: string) => Promise<string>
   renameLegacyForCleanup?: (source: string, destination: string) => Promise<void>
+  linkReadyContent?: typeof link
+  copyReadyContent?: typeof copyFile
 }
 
 type VerifiedLegacyCleanupDependencies = {
@@ -41,6 +52,14 @@ type RemoveVerifiedLegacyCopyInput = {
 
 type LegacyCleanupResult =
   { status: 'absent' | 'removed' } | { status: 'unsafe-residual'; reason: string }
+type ReadyContentCopyResult =
+  { status: 'published' } | { status: 'unsafe-residual'; reason: string }
+
+const isHardLinkUnavailableError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  HARD_LINK_FALLBACK_ERROR_CODES.has(String((error as { code?: unknown }).code))
 
 type FileIdentity = Awaited<ReturnType<typeof lstat>>
 
@@ -80,6 +99,91 @@ class VerifiedLegacyCleanupOwner {
       if (isMissingFileError(error)) return false
       throw error
     }
+  }
+  private async ensureSafeFinalParent(finalPath: string): Promise<boolean> {
+    const storageRoot = resolve(this.storageRoot)
+    const finalParent = dirname(finalPath)
+    const parentSegments = relative(storageRoot, finalParent).split(sep).filter(Boolean)
+    let currentPath = storageRoot
+
+    for (const segment of parentSegments) {
+      currentPath = join(currentPath, segment)
+      let currentInfo: FileIdentity
+      try {
+        currentInfo = await lstat(currentPath)
+      } catch (error) {
+        if (!isMissingFileError(error)) throw error
+        try {
+          await mkdir(currentPath)
+        } catch (mkdirError) {
+          if (!isFileExistsError(mkdirError)) throw mkdirError
+        }
+        currentInfo = await lstat(currentPath)
+      }
+      if (!currentInfo.isDirectory() || currentInfo.isSymbolicLink()) return false
+    }
+
+    const canonicalStorageRoot = await realpath(storageRoot)
+    const canonicalFinalParent = await realpath(finalParent)
+    try {
+      assertPathInsideRoot(
+        canonicalStorageRoot,
+        join(canonicalFinalParent, basename(finalPath)),
+        'Ready Upload Version parent escapes storage.'
+      )
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  private async publishReadyContentCopy(
+    expectedLegacyPath: string,
+    finalPath: string,
+    verifiedLegacyInfo: FileIdentity,
+    expectedSize: number,
+    expectedChecksum: string
+  ): Promise<ReadyContentCopyResult> {
+    const temporaryPath = `${finalPath}${LEGACY_RECOVERY_COPY_TEMP_SUFFIX}`
+    assertPathInsideRoot(this.storageRoot, temporaryPath, 'Upload recovery path escapes storage.')
+    let createdTemporary = false
+    try {
+      await (this.options.copyReadyContent ?? copyFile)(
+        expectedLegacyPath,
+        temporaryPath,
+        constants.COPYFILE_EXCL
+      )
+      createdTemporary = true
+    } catch (error) {
+      if (!isFileExistsError(error)) throw error
+    }
+
+    const temporaryInfo = await lstat(temporaryPath)
+    const copiedContentIsValid =
+      temporaryInfo.isFile() &&
+      !temporaryInfo.isSymbolicLink() &&
+      temporaryInfo.size === expectedSize &&
+      (await sha256File(temporaryPath)) === expectedChecksum
+    const reverifiedLegacyInfo = await lstat(expectedLegacyPath)
+    const sourceStayedStable =
+      reverifiedLegacyInfo.isFile() &&
+      !reverifiedLegacyInfo.isSymbolicLink() &&
+      hasSameFileSnapshot(reverifiedLegacyInfo, verifiedLegacyInfo)
+    if (!copiedContentIsValid || !sourceStayedStable) {
+      if (createdTemporary && temporaryInfo.isFile() && !temporaryInfo.isSymbolicLink()) {
+        const currentTemporaryInfo = await lstat(temporaryPath).catch(() => undefined)
+        if (currentTemporaryInfo && hasSameFileIdentity(currentTemporaryInfo, temporaryInfo)) {
+          await rm(temporaryPath, { force: true })
+        }
+      }
+      return {
+        status: 'unsafe-residual',
+        reason: 'the deterministic legacy path changed while copying Version content'
+      }
+    }
+
+    await rename(temporaryPath, finalPath)
+    return { status: 'published' }
   }
 
   // Cleanup is fail-closed: SQLite authority, a verified byte source, the deterministic legacy
@@ -241,15 +345,33 @@ class VerifiedLegacyCleanupOwner {
 
     let recoveredFinalInfo: FileIdentity | undefined
     if (!finalInfo) {
-      await mkdir(dirname(finalPath), { recursive: true })
+      if (!(await this.ensureSafeFinalParent(finalPath))) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the ready Version content parent contains a symbolic link or escapes storage'
+        }
+      }
       let createdFinal = false
+      let createdHardLink = false
       try {
         // Both paths are below the storage root, so linking publishes the verified inode without
         // exposing a partially copied immutable file.
-        await link(expectedLegacyPath, finalPath)
+        await (this.options.linkReadyContent ?? link)(expectedLegacyPath, finalPath)
         createdFinal = true
+        createdHardLink = true
       } catch (error) {
-        if (!isFileExistsError(error)) throw error
+        if (!isFileExistsError(error)) {
+          if (!isHardLinkUnavailableError(error)) throw error
+          const copyResult = await this.publishReadyContentCopy(
+            expectedLegacyPath,
+            finalPath,
+            verifiedLegacyInfo,
+            Number(version.sizeBytes),
+            version.checksum
+          )
+          if (copyResult.status === 'unsafe-residual') return copyResult
+          createdFinal = true
+        }
       }
 
       const restoredFinalInfo = await lstat(finalPath)
@@ -265,22 +387,25 @@ class VerifiedLegacyCleanupOwner {
         hasSameFileIdentity(reverifiedLegacyInfo, verifiedLegacyInfo) &&
         reverifiedLegacyInfo.mtimeMs === verifiedLegacyInfo.mtimeMs
       const createdLinkHasVerifiedIdentity =
-        !createdFinal || hasSameFileIdentity(restoredFinalInfo, verifiedLegacyInfo)
+        !createdHardLink || hasSameFileIdentity(restoredFinalInfo, verifiedLegacyInfo)
 
       if (
         !restoredContentIsValid ||
         !verifiedSourceStayedStable ||
         !createdLinkHasVerifiedIdentity
       ) {
-        if (createdFinal && hasSameFileIdentity(restoredFinalInfo, verifiedLegacyInfo)) {
-          await rm(finalPath, { force: true })
+        if (createdFinal) {
+          const currentFinalInfo = await lstat(finalPath).catch(() => undefined)
+          if (currentFinalInfo && hasSameFileIdentity(currentFinalInfo, restoredFinalInfo)) {
+            await rm(finalPath, { force: true })
+          }
         }
         return {
           status: 'unsafe-residual',
           reason: 'the deterministic legacy path changed while restoring Version content'
         }
       }
-      if (createdFinal) recoveredFinalInfo = restoredFinalInfo
+      if (createdHardLink) recoveredFinalInfo = restoredFinalInfo
     }
     try {
       // mkdir is the portable no-replace claim; the rename target inside it cannot collide with

--- a/src/main/uploads/verified-legacy-cleanup-owner.ts
+++ b/src/main/uploads/verified-legacy-cleanup-owner.ts
@@ -13,6 +13,7 @@ import {
   isFileExistsError,
   isMissingFileError
 } from './storage-helpers'
+import { publishNoReplace } from './atomic-no-replace-publisher'
 
 const LEGACY_CLEANUP_PRIVATE_SUFFIX = '.legacy-cleanup.private'
 const HARD_LINK_FALLBACK_ERROR_CODES = new Set([
@@ -31,6 +32,7 @@ type VerifiedLegacyCleanupOptions = {
   renameLegacyForCleanup?: (source: string, destination: string) => Promise<void>
   linkReadyContent?: typeof link
   copyReadyContent?: typeof copyFile
+  publishReadyContentNoReplace?: typeof publishNoReplace
 }
 
 type VerifiedLegacyCleanupDependencies = {
@@ -52,7 +54,9 @@ type RemoveVerifiedLegacyCopyInput = {
 type LegacyCleanupResult =
   { status: 'absent' | 'removed' } | { status: 'unsafe-residual'; reason: string }
 type ReadyContentCopyResult =
-  { status: 'published' } | { status: 'unsafe-residual'; reason: string }
+  | { status: 'published' }
+  | { status: 'destination-exists' }
+  | { status: 'unsafe-residual'; reason: string }
 
 const isHardLinkUnavailableError = (error: unknown): boolean =>
   typeof error === 'object' &&
@@ -185,9 +189,28 @@ class VerifiedLegacyCleanupOwner {
         }
       }
 
-      await rename(temporaryPath, finalPath)
-      ownedTemporaryInfo = undefined
-      return { status: 'published' }
+      if (!(await this.ensureSafeFinalParent(finalPath))) {
+        return {
+          status: 'unsafe-residual',
+          reason: 'the ready Version content parent changed before publication'
+        }
+      }
+
+      try {
+        // The native adapter anchors the parent by descriptor/handle and atomically refuses an
+        // existing destination. Path-based rename cannot provide both guarantees cross-platform.
+        await (this.options.publishReadyContentNoReplace ?? publishNoReplace)(
+          this.storageRoot,
+          dirname(finalPath),
+          basename(temporaryPath),
+          basename(finalPath)
+        )
+        ownedTemporaryInfo = undefined
+        return { status: 'published' }
+      } catch (error) {
+        if (isFileExistsError(error)) return { status: 'destination-exists' }
+        throw error
+      }
     } finally {
       if (ownedTemporaryInfo) {
         const currentTemporaryInfo = await lstat(temporaryPath).catch(() => undefined)
@@ -382,7 +405,7 @@ class VerifiedLegacyCleanupOwner {
             version.checksum
           )
           if (copyResult.status === 'unsafe-residual') return copyResult
-          createdFinal = true
+          createdFinal = copyResult.status === 'published'
         }
       }
 

--- a/src/main/uploads/verified-legacy-cleanup-owner.ts
+++ b/src/main/uploads/verified-legacy-cleanup-owner.ts
@@ -1,5 +1,16 @@
 import { constants, createReadStream } from 'node:fs'
-import { copyFile, link, lstat, mkdir, realpath, rename, rm, rmdir, stat } from 'node:fs/promises'
+import {
+  copyFile,
+  link,
+  lstat,
+  mkdir,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  rmdir,
+  stat
+} from 'node:fs/promises'
 import { basename, dirname, join, relative, resolve, sep } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
 
@@ -16,6 +27,9 @@ import {
 import { publishNoReplace } from './atomic-no-replace-publisher'
 
 const LEGACY_CLEANUP_PRIVATE_SUFFIX = '.legacy-cleanup.private'
+const LEGACY_RECOVERY_TEMP_STALE_AFTER_MS = 24 * 60 * 60 * 1_000
+const LEGACY_RECOVERY_ATTEMPT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const HARD_LINK_FALLBACK_ERROR_CODES = new Set([
   'EACCES',
   'EINVAL',
@@ -103,6 +117,49 @@ class VerifiedLegacyCleanupOwner {
       throw error
     }
   }
+
+  private async reclaimStaleRecoveryTemporaries(finalPath: string): Promise<void> {
+    const parentPath = dirname(finalPath)
+    const namePrefix = `${basename(finalPath)}.legacy-recovery.copy.`
+    const nameSuffix = '.tmp'
+    const staleBefore = Date.now() - LEGACY_RECOVERY_TEMP_STALE_AFTER_MS
+    const entries = await readdir(parentPath, { withFileTypes: true })
+
+    for (const entry of entries) {
+      if (
+        !entry.isFile() ||
+        !entry.name.startsWith(namePrefix) ||
+        !entry.name.endsWith(nameSuffix)
+      ) {
+        continue
+      }
+      const attemptId = entry.name.slice(namePrefix.length, -nameSuffix.length)
+      if (!LEGACY_RECOVERY_ATTEMPT_ID_PATTERN.test(attemptId)) continue
+
+      const candidatePath = join(parentPath, entry.name)
+      assertPathInsideRoot(this.storageRoot, candidatePath, 'Upload recovery path escapes storage.')
+      const candidateInfo = await lstat(candidatePath).catch((error: unknown) => {
+        if (isMissingFileError(error)) return undefined
+        throw error
+      })
+      if (
+        !candidateInfo?.isFile() ||
+        candidateInfo.isSymbolicLink() ||
+        candidateInfo.mtimeMs > staleBefore
+      ) {
+        continue
+      }
+
+      const currentInfo = await lstat(candidatePath).catch((error: unknown) => {
+        if (isMissingFileError(error)) return undefined
+        throw error
+      })
+      if (currentInfo && hasSameFileSnapshot(currentInfo, candidateInfo)) {
+        await rm(candidatePath, { force: true })
+      }
+    }
+  }
+
   private async ensureSafeFinalParent(finalPath: string): Promise<boolean> {
     const storageRoot = resolve(this.storageRoot)
     const finalParent = dirname(finalPath)
@@ -378,14 +435,16 @@ class VerifiedLegacyCleanupOwner {
       throw error
     }
 
+    if (!(await this.ensureSafeFinalParent(finalPath))) {
+      return {
+        status: 'unsafe-residual',
+        reason: 'the ready Version content parent contains a symbolic link or escapes storage'
+      }
+    }
+    await this.reclaimStaleRecoveryTemporaries(finalPath)
+
     let recoveredFinalInfo: FileIdentity | undefined
     if (!finalInfo) {
-      if (!(await this.ensureSafeFinalParent(finalPath))) {
-        return {
-          status: 'unsafe-residual',
-          reason: 'the ready Version content parent contains a symbolic link or escapes storage'
-        }
-      }
       let createdFinal = false
       let createdHardLink = false
       try {

--- a/src/main/uploads/verified-legacy-cleanup-owner.ts
+++ b/src/main/uploads/verified-legacy-cleanup-owner.ts
@@ -38,6 +38,7 @@ const HARD_LINK_FALLBACK_ERROR_CODES = new Set([
   'EPERM',
   'EXDEV'
 ])
+const ATOMIC_PUBLICATION_UNAVAILABLE_ERROR_CODES = new Set(['ENOSYS', 'ENOTSUP', 'EOPNOTSUPP'])
 const LEGACY_CLEANUP_CANDIDATE = 'candidate'
 
 type VerifiedLegacyCleanupOptions = {
@@ -77,6 +78,12 @@ const isHardLinkUnavailableError = (error: unknown): boolean =>
   error !== null &&
   'code' in error &&
   HARD_LINK_FALLBACK_ERROR_CODES.has(String((error as { code?: unknown }).code))
+
+const isAtomicPublicationUnavailableError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  ATOMIC_PUBLICATION_UNAVAILABLE_ERROR_CODES.has(String((error as { code?: unknown }).code))
 
 type FileIdentity = Awaited<ReturnType<typeof lstat>>
 
@@ -266,6 +273,12 @@ class VerifiedLegacyCleanupOwner {
         return { status: 'published' }
       } catch (error) {
         if (isFileExistsError(error)) return { status: 'destination-exists' }
+        if (isAtomicPublicationUnavailableError(error)) {
+          return {
+            status: 'unsafe-residual',
+            reason: 'atomic no-replace publication is unavailable on the storage filesystem'
+          }
+        }
         throw error
       }
     } finally {


### PR DESCRIPTION
## Problem

Startup reconciliation can repeatedly fail in `reconcile-derived-state` when SQLite has a ready Upload Version and the deterministic legacy upload still exists, but the Version's immutable `content` file is missing. The raw `ENOENT` keeps storage recovery incomplete, so Retry cannot clear the saved-conversations banner.

## Proposed change

- Treat only a missing ready-Version content file as recoverable; existing corrupt content still fails.
- Verify the deterministic legacy source against Session/Project/Upload/Version authority, regular-file identity, size, SHA-256, and a stable snapshot.
- Publish verified bytes atomically with a hard link before the existing private-claim cleanup.
- Keep checksum mismatches and source races fail-closed, and remove a recovered hard link if its shared inode is mutated during cleanup.
- Add a production-path regression covering mismatch retention, successful recovery, idempotence, and in-place mutation.

## Scope and non-goals

- No schema, renderer, or user-facing copy changes.
- Does not guess from non-deterministic paths or delete unverifiable legacy bytes.
- Does not change handling for a present but corrupt immutable Version file.

## Acceptance criteria and validation

- [x] The reported path-free ready Upload state no longer throws `ENOENT` when a checksum-valid legacy copy exists.
- [x] A checksum mismatch does not publish immutable bytes or delete the legacy file.
- [x] A cleanup-time in-place mutation does not leave corrupted immutable bytes.
- [x] Retry is idempotent after successful recovery.
- [x] Node and web TypeScript checks pass.
- [x] ESLint passes for the changed files.
- [x] Declared Test Impact Set passes: 14 files, 304 tests passed, 1 existing Windows symlink-permission test excluded.
- [x] Full Vitest suite executed after the final edit: 12,962 passed, 275 skipped, 34 failed in unrelated/environment-sensitive tests. The only Upload failure is the same existing symlink test (`EPERM` creating a symlink); the new regression passes in the full run.

## Review focus

- The authority and source-verification gates before hard-link publication.
- The inode-specific rollback when cleanup observes a mutated hard-linked source.
- Fail-closed behavior for checksum mismatches and races.