### PR TITLE
fix(compute): make queued job promotion atomic

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -176,6 +176,7 @@
     "compute_service": {
       "ownerPaths": [
         "src/main/compute/compute-host-profile-owner.ts",
+        "src/main/compute/compute-job-lifecycle.ts",
         "src/main/compute/compute-job-workflow-owner.ts",
         "src/main/compute/compute-remote-operation-owner.ts",
         "src/main/compute/permission-grant-adapter.ts",
@@ -185,6 +186,7 @@
       "consumerModules": [],
       "testFiles": {
         "owner": [
+          "src/main/compute/compute-job-lifecycle.test.ts",
           "src/main/compute/compute-service.architecture.test.ts",
           "src/main/compute/compute-host-profile-owner.test.ts",
           "src/main/compute/compute-job-workflow-owner.test.ts",

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -40,6 +40,7 @@ describe('module test impact commands', () => {
 
     expect(plan.testFiles).toEqual(
       expect.arrayContaining([
+        'src/main/compute/compute-job-lifecycle.test.ts',
         'src/main/compute/compute-service.test.ts',
         'src/main/compute/ssh-runner.test.ts',
         'src/main/compute/ipc.test.ts',
@@ -48,6 +49,18 @@ describe('module test impact commands', () => {
     )
     expect(plan.capabilityOverlays).toEqual(['windows_sensitive'])
     expect(plan.fallbackCapabilities).toEqual(['main_runtime'])
+
+    const affected = createAffectedTestPlan(
+      [{ path: 'src/main/compute/compute-job-lifecycle.ts', status: 'added' }],
+      { status: 'current', testFiles: [] }
+    )
+    expect(affected.modules).toEqual(['compute_service'])
+    expect(affected.testFiles).toEqual(
+      expect.arrayContaining([
+        'src/main/compute/compute-job-lifecycle.test.ts',
+        'src/main/compute/concurrency-integration.test.ts'
+      ])
+    )
   })
 
   it('expands User Skill repository changes through Settings and cross-surface consumers', () => {

--- a/src/main/compute/compute-job-lifecycle.test.ts
+++ b/src/main/compute/compute-job-lifecycle.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+import { createProjectDbClient, ensureProjectSchema } from '../projects/prisma-client'
+import { ComputeJobLifecycle } from './compute-job-lifecycle'
+import { ComputeJobRepository } from './job-repository'
+
+let storageRoot: string | undefined
+let disconnect: (() => Promise<void>) | undefined
+let repository: ComputeJobRepository
+let lifecycle: ComputeJobLifecycle
+let publish: Mock
+
+beforeEach(async () => {
+  storageRoot = await mkdtemp(join(tmpdir(), 'open-science-job-lifecycle-'))
+  const client = createProjectDbClient(storageRoot)
+  disconnect = () => client.$disconnect()
+  await ensureProjectSchema(client)
+
+  repository = new ComputeJobRepository(() => Promise.resolve(client))
+  await repository.create({
+    id: 'queued-job',
+    providerId: 'ssh:test',
+    shape: 'direct_ssh',
+    sessionId: 'session-1',
+    projectId: 'project-1',
+    intent: 'test promotion',
+    command: 'echo ok',
+    commandHash: 'hash',
+    initialStatus: 'queued'
+  })
+  publish = vi.fn()
+  lifecycle = new ComputeJobLifecycle(repository, publish)
+})
+
+afterEach(async () => {
+  await disconnect?.()
+  disconnect = undefined
+
+  if (storageRoot) {
+    await rm(storageRoot, { recursive: true, force: true })
+    storageRoot = undefined
+  }
+})
+
+describe('ComputeJobLifecycle', () => {
+  it('promotes a queued job with its submission time and publishes the applied projection once', async () => {
+    const result = await lifecycle.promoteQueued('queued-job')
+
+    expect(result.kind).toBe('applied')
+    if (result.kind !== 'applied') throw new Error('expected an applied transition')
+    expect(result.job.status).toBe('submitted')
+    expect(result.job.submitted_at).toBeGreaterThan(0)
+    expect(publish).toHaveBeenCalledOnce()
+    expect(publish).toHaveBeenCalledWith(result.job)
+  })
+
+  it('lets only one concurrent promotion apply and publish', async () => {
+    const results = await Promise.all([
+      lifecycle.promoteQueued('queued-job'),
+      lifecycle.promoteQueued('queued-job')
+    ])
+
+    expect(results.map(({ kind }) => kind).sort()).toEqual(['applied', 'ignored'])
+    expect(publish).toHaveBeenCalledOnce()
+  })
+
+  it('keeps an applied promotion successful when its observer throws', async () => {
+    publish.mockImplementation(() => {
+      throw new Error('observer failed')
+    })
+
+    const result = await lifecycle.promoteQueued('queued-job')
+
+    expect(result.kind).toBe('applied')
+  })
+})

--- a/src/main/compute/compute-job-lifecycle.ts
+++ b/src/main/compute/compute-job-lifecycle.ts
@@ -1,0 +1,26 @@
+import type { ComputeJob } from '../../shared/compute'
+import type { ComputeJobRepository } from './job-repository'
+
+export type ComputeJobTransitionResult = { kind: 'applied'; job: ComputeJob } | { kind: 'ignored' }
+
+export class ComputeJobLifecycle {
+  constructor(
+    private readonly repository: ComputeJobRepository,
+    private readonly onApplied: (job: ComputeJob) => void = () => undefined
+  ) {}
+
+  async promoteQueued(jobId: string): Promise<ComputeJobTransitionResult> {
+    const job = await this.repository.updateIfStatus(jobId, ['queued'], {
+      status: 'submitted',
+      submittedAt: new Date()
+    })
+    if (!job) return { kind: 'ignored' }
+
+    try {
+      this.onApplied(job)
+    } catch {
+      // The persisted transition is authoritative; an observer cannot roll it back or block dispatch.
+    }
+    return { kind: 'applied', job }
+  }
+}

--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -37,6 +37,7 @@ const computePaths = {
   hostOwner: resolve(mainRoot, 'compute/compute-host-profile-owner.ts'),
   remoteOwner: resolve(mainRoot, 'compute/compute-remote-operation-owner.ts'),
   jobOwner: resolve(mainRoot, 'compute/compute-job-workflow-owner.ts'),
+  jobLifecycle: resolve(mainRoot, 'compute/compute-job-lifecycle.ts'),
   ipc: resolve(mainRoot, 'compute/ipc.ts'),
   applicationCommands: resolve(mainRoot, 'compute/application-commands.ts'),
   jobRuntime: resolve(mainRoot, 'compute/job-runtime.ts'),
@@ -198,6 +199,7 @@ describe('Compute service architecture', () => {
         portableProjectPath(ownerPath)
       ).toBeLessThanOrEqual(660)
     }
+    expect(rawLineCount(readSource(computePaths.jobLifecycle))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(computePaths.ipc))).toBeLessThanOrEqual(660)
   })
 
@@ -351,6 +353,7 @@ describe('Compute service architecture', () => {
 
     expect(computeService.ownerPaths).toEqual([
       'src/main/compute/compute-host-profile-owner.ts',
+      'src/main/compute/compute-job-lifecycle.ts',
       'src/main/compute/compute-job-workflow-owner.ts',
       'src/main/compute/compute-remote-operation-owner.ts',
       'src/main/compute/permission-grant-adapter.ts',
@@ -363,6 +366,7 @@ describe('Compute service architecture', () => {
     expect(computeService.testFiles.owner).toEqual(
       expect.arrayContaining([
         architectureTestPath,
+        'src/main/compute/compute-job-lifecycle.test.ts',
         'src/main/compute/compute-host-profile-owner.test.ts',
         'src/main/compute/compute-job-workflow-owner.test.ts',
         'src/main/compute/compute-remote-operation-owner.test.ts',

--- a/src/main/compute/concurrency-integration.test.ts
+++ b/src/main/compute/concurrency-integration.test.ts
@@ -76,11 +76,7 @@ describe('ConcurrencyManager integration with ComputeService', () => {
     })
 
     // Mock dispatch function for ConcurrencyManager
-    const mockDispatch = vi.fn(async (jobId: string) => {
-      // Simulate dispatch by updating job to 'submitted' then 'running'
-      await jobRepo.update(jobId, { status: 'submitted', submittedAt: new Date() })
-      // Don't immediately transition to running in the mock - let the test control this
-    })
+    const mockDispatch = vi.fn(async () => undefined)
 
     onJobUpdatedSpy = vi.fn()
     concurrencyManager = new ConcurrencyManager(jobRepo, hostRepo, mockDispatch, onJobUpdatedSpy)
@@ -272,6 +268,8 @@ describe('ConcurrencyManager integration with ComputeService', () => {
     // Second job should now be submitted
     const job2Updated = await jobRepo.get(result2.job_id)
     expect(job2Updated?.status).toBe('submitted')
+    expect(job2Updated?.submitted_at).toBeGreaterThan(0)
+    expect(onJobUpdatedSpy).toHaveBeenCalledWith(job2Updated)
   })
 
   it('should dispatch queued jobs in FIFO order', async () => {

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -14,6 +14,7 @@ const createMockJobRepo = (): ComputeJobRepository =>
     countQueuedJobs: vi.fn(),
     findQueuedJobs: vi.fn(),
     update: vi.fn(),
+    updateIfStatus: vi.fn(),
     create: vi.fn(),
     get: vi.fn(),
     findNonTerminal: vi.fn(),
@@ -50,6 +51,14 @@ describe('ConcurrencyManager', () => {
     hostRepo = createMockHostRepo()
     dispatchJob = createMockDispatchJob()
     onJobUpdated = vi.fn()
+    vi.mocked(jobRepo.updateIfStatus).mockImplementation(
+      async (jobId, _expected, updates) =>
+        ({
+          job_id: jobId,
+          status: updates.status ?? 'queued',
+          submitted_at: updates.submittedAt?.getTime()
+        }) as ComputeJob
+    )
     manager = new ConcurrencyManager(jobRepo, hostRepo, dispatchJob, onJobUpdated)
   })
 
@@ -261,12 +270,9 @@ describe('ConcurrencyManager', () => {
       vi.mocked(hostRepo.get).mockResolvedValue({
         concurrencyLimit: 10
       } as ComputeHost)
-      vi.mocked(jobRepo.update).mockResolvedValue({} as ComputeJob)
-
       await manager.onJobCompleted()
 
       // Should dispatch job-1 first (earlier createdAt)
-      expect(jobRepo.update).toHaveBeenCalledWith('job-1', { status: 'submitted' })
       expect(dispatchJob).toHaveBeenCalledWith('job-1', expect.any(Function))
     })
 
@@ -288,13 +294,10 @@ describe('ConcurrencyManager', () => {
       vi.mocked(hostRepo.get).mockResolvedValue({
         concurrencyLimit: 10
       } as ComputeHost)
-      vi.mocked(jobRepo.update).mockResolvedValue({} as ComputeJob)
-
       await manager.onJobCompleted()
 
       expect(jobRepo.countActiveBySession).toHaveBeenCalledWith('session-1')
       expect(jobRepo.countActiveByProvider).toHaveBeenCalledWith('ssh:cluster-a')
-      expect(jobRepo.update).toHaveBeenCalledWith('job-1', { status: 'submitted' })
       expect(dispatchJob).toHaveBeenCalledWith('job-1', expect.any(Function))
     })
 
@@ -319,7 +322,7 @@ describe('ConcurrencyManager', () => {
 
       await manager.onJobCompleted()
 
-      expect(jobRepo.update).not.toHaveBeenCalled()
+      expect(jobRepo.updateIfStatus).not.toHaveBeenCalled()
       expect(dispatchJob).not.toHaveBeenCalled()
     })
 
@@ -343,7 +346,7 @@ describe('ConcurrencyManager', () => {
 
       await manager.onJobCompleted()
 
-      expect(jobRepo.update).not.toHaveBeenCalled()
+      expect(jobRepo.updateIfStatus).not.toHaveBeenCalled()
       expect(dispatchJob).not.toHaveBeenCalled()
     })
 
@@ -372,14 +375,33 @@ describe('ConcurrencyManager', () => {
       vi.mocked(hostRepo.get).mockResolvedValue({
         concurrencyLimit: 10
       } as ComputeHost)
-      vi.mocked(jobRepo.update).mockResolvedValue({} as ComputeJob)
-
       await manager.onJobCompleted()
 
-      expect(jobRepo.update).toHaveBeenCalledTimes(2)
+      expect(jobRepo.updateIfStatus).toHaveBeenCalledTimes(2)
       expect(dispatchJob).toHaveBeenCalledTimes(2)
       expect(dispatchJob).toHaveBeenNthCalledWith(1, 'job-1', expect.any(Function))
       expect(dispatchJob).toHaveBeenNthCalledWith(2, 'job-2', expect.any(Function))
+    })
+
+    it('does not dispatch a queued projection after another writer changes its status', async () => {
+      vi.mocked(jobRepo.findQueuedJobs).mockResolvedValue([
+        {
+          job_id: 'job-1',
+          session_id: 'session-1',
+          provider_id: 'ssh:cluster-a',
+          created_at: 1000,
+          status: 'queued'
+        } as ComputeJob
+      ])
+      vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(0)
+      vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(0)
+      vi.mocked(hostRepo.get).mockResolvedValue({ concurrencyLimit: 10 } as ComputeHost)
+      vi.mocked(jobRepo.updateIfStatus).mockResolvedValue(null)
+
+      await manager.onJobCompleted()
+
+      expect(dispatchJob).not.toHaveBeenCalled()
+      expect(onJobUpdated).not.toHaveBeenCalled()
     })
   })
 
@@ -515,17 +537,13 @@ describe('ConcurrencyManager', () => {
         concurrencyLimit: 10
       } as ComputeHost)
       const failedJob = { ...queuedJobs[0], status: 'error' as const }
-      vi.mocked(jobRepo.update)
-        .mockResolvedValueOnce({ ...queuedJobs[0], status: 'submitted' } as ComputeJob)
-        .mockResolvedValueOnce(failedJob)
+      vi.mocked(jobRepo.update).mockResolvedValueOnce(failedJob)
 
       // Simulate dispatchJob failure
       vi.mocked(dispatchJob).mockRejectedValueOnce(new Error('SSH connection failed'))
 
       await manager.onJobCompleted()
 
-      // Should mark job as submitted first
-      expect(jobRepo.update).toHaveBeenCalledWith('job-1', { status: 'submitted' })
       // Then mark as error after dispatch fails
       expect(jobRepo.update).toHaveBeenCalledWith('job-1', {
         status: 'error',
@@ -576,7 +594,6 @@ describe('ConcurrencyManager', () => {
       })
 
       // Second job should still be dispatched
-      expect(jobRepo.update).toHaveBeenCalledWith('job-2', { status: 'submitted' })
       expect(dispatchJob).toHaveBeenCalledWith('job-2', expect.any(Function))
     })
 
@@ -707,9 +724,13 @@ describe('ConcurrencyManager', () => {
         } as ComputeJob
       ])
       // The promotion's reserve commit (status → 'submitted') bumps the active counter.
-      vi.mocked(jobRepo.update).mockImplementation(async (_id, u) => {
-        if ((u as { status?: string }).status === 'submitted') active++
-        return {} as ComputeJob
+      vi.mocked(jobRepo.updateIfStatus).mockImplementation(async (jobId, _expected, updates) => {
+        if (updates.status === 'submitted') active++
+        return {
+          job_id: jobId,
+          status: updates.status ?? 'queued',
+          submitted_at: updates.submittedAt?.getTime()
+        } as ComputeJob
       })
       vi.mocked(dispatchJob).mockResolvedValue(undefined)
 
@@ -726,8 +747,8 @@ describe('ConcurrencyManager', () => {
       // Exactly one of the two paths won the single slot; active never exceeded the ceiling.
       expect(active).toBe(providerCeiling)
       const promotionSubmits = vi
-        .mocked(jobRepo.update)
-        .mock.calls.filter(([, u]) => (u as { status?: string }).status === 'submitted').length
+        .mocked(jobRepo.updateIfStatus)
+        .mock.calls.filter(([, , updates]) => updates.status === 'submitted').length
       const admitSubmits = admitResult === 'submitted' ? 1 : 0
       expect(promotionSubmits + admitSubmits).toBe(1)
     })

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -1,6 +1,7 @@
 import type { ComputeJobRepository } from './job-repository'
 import type { ComputeHostRepository } from './repository'
 import type { ComputeJob } from '../../shared/compute'
+import { ComputeJobLifecycle } from './compute-job-lifecycle'
 
 export type SessionStatus = {
   session_limit: number | null
@@ -39,13 +40,17 @@ export class ConcurrencyManager {
   // JS is single-threaded, so chaining commit work onto this promise fully serializes the critical
   // section — the row written by one admit is visible to the DB counts read by the next.
   private admitLock: Promise<unknown> = Promise.resolve()
+  private readonly lifecycle: ComputeJobLifecycle
 
   constructor(
     private readonly jobRepository: ComputeJobRepository,
     private readonly hostRepository: ComputeHostRepository,
     private readonly dispatchJob: DispatchQueuedJob,
-    private readonly publishJobUpdated: (job: ComputeJob) => void = () => undefined
-  ) {}
+    private readonly publishJobUpdated: (job: ComputeJob) => void = () => undefined,
+    lifecycle?: ComputeJobLifecycle
+  ) {
+    this.lifecycle = lifecycle ?? new ComputeJobLifecycle(jobRepository, this.handleJobUpdated)
+  }
 
   // Owns the complete update policy used by ComputeService: publish every persisted projection, then
   // free and refill queue capacity for terminal states. Dispatcher and poller both receive this bound
@@ -201,8 +206,8 @@ export class ConcurrencyManager {
         // across SSH work would serialize every submission behind network latency.
         const reserved = await this.runExclusive(async () => {
           if (await this.overActiveLimits(job.session_id, job.provider_id)) return false
-          await this.jobRepository.update(job.job_id, { status: 'submitted' })
-          return true
+          const promotion = await this.lifecycle.promoteQueued(job.job_id)
+          return promotion.kind === 'applied'
         })
         if (!reserved) continue // limits hit — leave queued for a future completion
 

--- a/src/main/compute/job-repository.ts
+++ b/src/main/compute/job-repository.ts
@@ -1,8 +1,8 @@
 import type { ComputeJob as PrismaComputeJob, PrismaClient } from '@prisma/client'
 import type { ComputeJob, ComputeJobStatus } from '../../shared/compute'
 
-// Only the computeJob delegate is needed.
-type ComputeJobClient = Pick<PrismaClient, 'computeJob'>
+// Only ComputeJob persistence and a transaction wrapper are needed.
+type ComputeJobClient = Pick<PrismaClient, '$transaction' | 'computeJob'>
 type ComputeJobClientProvider = () => Promise<ComputeJobClient>
 
 const asStatus = (value: string): ComputeJobStatus => {
@@ -97,6 +97,31 @@ export type UpdateJobRequest = {
   notificationConsumedAt?: Date | null
 }
 
+type ComputeJobUpdateData = Parameters<ComputeJobClient['computeJob']['update']>[0]['data']
+
+const toUpdateData = (updates: UpdateJobRequest): ComputeJobUpdateData => {
+  const data: ComputeJobUpdateData = {}
+
+  if (updates.status !== undefined) data.status = updates.status
+  if (updates.remoteHandle !== undefined) data.remoteHandle = updates.remoteHandle
+  if ('exitCode' in updates) data.exitCode = updates.exitCode
+  if ('stdoutTail' in updates) data.stdoutTail = updates.stdoutTail
+  if ('stderrTail' in updates) data.stderrTail = updates.stderrTail
+  if ('errorCode' in updates) data.errorCode = updates.errorCode
+  if ('lastPollError' in updates) data.lastPollError = updates.lastPollError
+  if (updates.submittedAt !== undefined) data.submittedAt = updates.submittedAt
+  if (updates.startedAt !== undefined) data.startedAt = updates.startedAt
+  if (updates.finishedAt !== undefined) data.finishedAt = updates.finishedAt
+  if (updates.harvestedAt !== undefined) data.harvestedAt = updates.harvestedAt
+  if ('harvestError' in updates) data.harvestError = updates.harvestError
+  if ('leftOnRemote' in updates) data.leftOnRemote = updates.leftOnRemote
+  if ('notifiedAt' in updates) data.notifiedAt = updates.notifiedAt
+  if ('notificationConsumedAt' in updates)
+    data.notificationConsumedAt = updates.notificationConsumedAt
+
+  return data
+}
+
 // Owns ComputeJob reads/writes. Follows the same lazy-provider pattern as ComputeHostRepository.
 export class ComputeJobRepository {
   constructor(private readonly getClient: ComputeJobClientProvider) {}
@@ -187,28 +212,29 @@ export class ComputeJobRepository {
 
   async update(jobId: string, updates: UpdateJobRequest): Promise<ComputeJob> {
     const client = await this.getClient()
-    const data: Parameters<typeof client.computeJob.update>[0]['data'] = {}
-
-    if (updates.status !== undefined) data.status = updates.status
-    if (updates.remoteHandle !== undefined) data.remoteHandle = updates.remoteHandle
-    if ('exitCode' in updates) data.exitCode = updates.exitCode
-    if ('stdoutTail' in updates) data.stdoutTail = updates.stdoutTail
-    if ('stderrTail' in updates) data.stderrTail = updates.stderrTail
-    if ('errorCode' in updates) data.errorCode = updates.errorCode
-    if ('lastPollError' in updates) data.lastPollError = updates.lastPollError
-    if (updates.submittedAt !== undefined) data.submittedAt = updates.submittedAt
-    if (updates.startedAt !== undefined) data.startedAt = updates.startedAt
-    if (updates.finishedAt !== undefined) data.finishedAt = updates.finishedAt
-    // Phase 3b harvest fields
-    if (updates.harvestedAt !== undefined) data.harvestedAt = updates.harvestedAt
-    if ('harvestError' in updates) data.harvestError = updates.harvestError
-    if ('leftOnRemote' in updates) data.leftOnRemote = updates.leftOnRemote
-    if ('notifiedAt' in updates) data.notifiedAt = updates.notifiedAt
-    if ('notificationConsumedAt' in updates)
-      data.notificationConsumedAt = updates.notificationConsumedAt
-
-    const row = await client.computeJob.update({ where: { id: jobId }, data })
+    const row = await client.computeJob.update({
+      where: { id: jobId },
+      data: toUpdateData(updates)
+    })
     return toJob(row)
+  }
+
+  async updateIfStatus(
+    jobId: string,
+    expectedStatuses: readonly ComputeJobStatus[],
+    updates: UpdateJobRequest
+  ): Promise<ComputeJob | null> {
+    const client = await this.getClient()
+    return client.$transaction(async (transaction) => {
+      const applied = await transaction.computeJob.updateMany({
+        where: { id: jobId, status: { in: [...expectedStatuses] } },
+        data: toUpdateData(updates)
+      })
+      if (applied.count === 0) return null
+
+      const row = await transaction.computeJob.findUnique({ where: { id: jobId } })
+      return row ? toJob(row) : null
+    })
   }
 
   // Returns all jobs for a session, newest-first. Optionally filtered by status values.


### PR DESCRIPTION
# Problem

Compute Job persistence is centralized in `ComputeJobRepository`, but lifecycle invariants are not.
Queue promotion currently writes only `status: submitted`, omitting `submittedAt` and the persisted
JobUpdated projection. The unconditional write also lets a stale queued projection claim a slot after
another writer has changed the row.

# Proposed change

- Add a private `ComputeJobLifecycle` seam for guarded lifecycle transitions.
- Add a transactional repository CAS that updates only when the row still has an expected status.
- Route `ConcurrencyManager` queue promotion through `promoteQueued`.
- Persist `submitted` and `submittedAt` in the same guarded write.
- Publish only an applied promotion and dispatch only after the CAS succeeds.
- Preserve the applied result if the projection observer throws, so an observer cannot strand a
  committed reservation before dispatch.
- Register the lifecycle owner and its portable SQLite contract test in the `compute_service` impact
  set.

# Scope and non-goals

- This is CL1 only: queued-to-submitted promotion and the reusable atomic persistence seam.
- Dispatcher and Poller state writers remain unchanged; their serial cutovers are CL2 and CL3.
- No Prisma schema, migration, status value, retry/cancel/scheduler state, or Issue #458 orchestration
  model.
- No change to approval, admission limits, FIFO selection, SSH dispatch, polling cadence, harvesting,
  notifications, or result projection.
- No public `ComputeService`, application-command, IPC, local-RPC, renderer, or Task/CLI interface.

# Compatibility

- Each existing Electron, local Web, remote Web, Session-bound local RPC, and indirect Task/CLI
  capability remains unchanged.
- Existing jobs remain readable because the Prisma schema and persisted status strings are unchanged.
- The first successfully guarded promotion wins; a stale promotion is ignored without publication or
  dispatch.
- Queue promotion now emits the persisted `submitted` projection with `submittedAt`, fixing the
  previously missing update without adding a new event shape.
- Tests use `tmpdir()` and Node path helpers, so paths remain portable across Windows, macOS, and
  Linux.

# Acceptance criteria and validation

- Atomic promotion and observer semantics ->
  `npm test -- src/main/compute/compute-job-lifecycle.test.ts src/main/compute/concurrency-manager.test.ts src/main/compute/concurrency-integration.test.ts`
  -> 3 files, 43 tests passed.
- Final Compute owner/contract/consumer impact set -> `npm run test:module -- compute_service` ->
  20 files passed, 1 skipped; 484 tests passed, 5 skipped.
- Node and Web contracts -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> 0 errors and 17 pre-existing warnings.
- Changed-file Prettier and `git diff --check` -> passed.
- Full portable fallback was exercised on the final tree: 907 files passed, 14 skipped; 5 tests in
  unrelated ACP/Reviewer/Workspace/Agent architecture suites hit their existing 15/30-second local
  timeout budgets. Serial retry cleared Completion Gate and Reviewer; ACP oversized-permission and
  Workspace full-tree AST scans remained local timeout-only. None is in the Compute impact graph;
  exact-head CI remains authoritative for those suites.
- Independent final Standards review: P0/P1/P2 = 0/0/0.
- Independent final Spec review: P0/P1/P2 = 0/0/0.
- Exact-head PR Gate, CI Integrity, platform lanes, CodeQL, and AI review remain required before
  squash merge.

# Review focus

- Verify the CAS predicate contains both job id and the expected `queued` status in the same database
  transaction as `status` and `submittedAt`.
- Verify an ignored promotion cannot publish or dispatch, while an applied promotion publishes once
  and continues to dispatch even if the observer throws.
- Verify `ConcurrencyManager` remains the admission/queue owner and the lifecycle module owns only
  transition rules and atomic persistence.
- Verify no public/data/cross-surface contract changed and the module-impact route selects the new
  lifecycle test plus existing Compute certification suites.
