### PR TITLE
fix(composer): move session grants above auto-review

### DIFF
--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
@@ -795,12 +795,15 @@ describe('ComposerAgentControlsMenu', () => {
   it('folds Compute into a hover submenu that holds the SSH hosts and Manage compute', () => {
     // Regression guard (#545 flattened Compute into the primary panel): Compute must be a
     // single hover-expandable row whose content holds the host list, and the top-level order
-    // stays permission mode -> auto-review -> specialist -> compute.
+    // stays permission mode -> session grants -> auto-review -> specialist -> compute.
     act(() => {
       root.render(
         <ComposerAgentControlsMenu
           profile="ask"
           autoReviewEnabled={false}
+          grants={[
+            { categoryKey: 'shell:git', label: 'git status', kind: 'shell', scope: 'session' }
+          ]}
           enabledComputeHosts={[]}
           showSpecialist
           onProfileChange={vi.fn()}
@@ -823,7 +826,7 @@ describe('ComposerAgentControlsMenu', () => {
     expect(computeSubContents).toHaveLength(1)
     expect(computeSubContents[0]?.textContent).toContain('Manage compute...')
 
-    // Top-level order: permission mode -> auto-review -> specialist -> compute.
+    // Top-level order: permission mode -> session grants -> auto-review -> specialist -> compute.
     const orderAnchor = (needle: string): Element => {
       const match = Array.from(container.querySelectorAll('[data-testid="submenu-trigger"]')).find(
         (el) => el.textContent?.includes(needle)
@@ -836,12 +839,17 @@ describe('ComposerAgentControlsMenu', () => {
     const autoReviewRow = findButton(
       'Auto-reviewA reviewer agent checks every change before it lands.'
     )
+    const sessionGrantsHeading = Array.from(container.querySelectorAll('span')).find(
+      (element) => element.textContent === 'Allowed this session'
+    )
     const specialistStub = container.querySelector('[data-testid="specialist-submenu-stub"]')
+    expect(sessionGrantsHeading).not.toBeUndefined()
     expect(specialistStub).not.toBeNull()
 
     const precedes = (a: Element, b: Element): boolean =>
       (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
-    expect(precedes(permissionTrigger, autoReviewRow)).toBe(true)
+    expect(precedes(permissionTrigger, sessionGrantsHeading as Element)).toBe(true)
+    expect(precedes(sessionGrantsHeading as Element, autoReviewRow)).toBe(true)
     expect(precedes(autoReviewRow, specialistStub as Element)).toBe(true)
     expect(precedes(specialistStub as Element, computeTrigger)).toBe(true)
   })

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
@@ -365,35 +365,6 @@ const ComposerAgentControlsMenu = ({
                 </DropdownMenuSub>
               )}
 
-              {/* The whole row toggles auto-review; the Switch is a visual indicator only. */}
-              <DropdownMenuItem
-                disabled={readOnly || autoReviewDisabled}
-                className="items-center gap-2 px-2 py-1.5"
-                onSelect={(event) => {
-                  event.preventDefault()
-                  onAutoReviewChange(!autoReviewEnabled)
-                }}
-              >
-                <ScanEye
-                  className="size-4 shrink-0 text-text-200"
-                  strokeWidth={2}
-                  aria-hidden="true"
-                />
-                <span className="min-w-0 flex-1">
-                  <span className="block text-[13px] font-medium leading-5">Auto-review</span>
-                  <span className="block text-[11px] leading-4 text-text-300">
-                    A reviewer agent checks every change before it lands.
-                  </span>
-                </span>
-                <Switch
-                  size="sm"
-                  checked={autoReviewEnabled}
-                  tabIndex={-1}
-                  aria-hidden="true"
-                  className="pointer-events-none"
-                />
-              </DropdownMenuItem>
-
               {hasGrants ? (
                 <div className="mt-1 border-t border-border-200 pt-1">
                   <div className="flex items-center justify-between px-2 pb-0.5">
@@ -444,6 +415,35 @@ const ComposerAgentControlsMenu = ({
                   </div>
                 </div>
               ) : null}
+
+              {/* The whole row toggles auto-review; the Switch is a visual indicator only. */}
+              <DropdownMenuItem
+                disabled={readOnly || autoReviewDisabled}
+                className="items-center gap-2 px-2 py-1.5"
+                onSelect={(event) => {
+                  event.preventDefault()
+                  onAutoReviewChange(!autoReviewEnabled)
+                }}
+              >
+                <ScanEye
+                  className="size-4 shrink-0 text-text-200"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[13px] font-medium leading-5">Auto-review</span>
+                  <span className="block text-[11px] leading-4 text-text-300">
+                    A reviewer agent checks every change before it lands.
+                  </span>
+                </span>
+                <Switch
+                  size="sm"
+                  checked={autoReviewEnabled}
+                  tabIndex={-1}
+                  aria-hidden="true"
+                  className="pointer-events-none"
+                />
+              </DropdownMenuItem>
 
               {/* Specialist + Compute are one resource-selection group: a single divider leads
                   the group (above Specialist when present, above Compute otherwise), so the two


### PR DESCRIPTION
## Problem

Session-scoped permission grants were displayed below Auto-review, separating them from the Permission mode they qualify.

## Proposed change

- Move the existing Allowed this session block directly below Permission mode.
- Move the unchanged Auto-review row below session grants.
- Extend the ordering regression test to cover Permission mode -> Allowed this session -> Auto-review -> Specialist -> Compute.

## Scope and non-goals

- No changes to permission, grant revocation, clear-all, auto-review, specialist, or compute behavior.
- No copy, styling, token, or dependency changes.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Menu order -> npm test -- src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx -> pass, 27 tests.
- Renderer and shared type contracts -> npm run typecheck -> pass.
- Source lint -> npm run lint -> pass, 0 errors; 17 existing warnings outside the changed files.
- Formatting -> Prettier check on both changed files -> pass.
- Fail-closed portable suite -> npm test -> pass, 910 files and 13,082 tests; 14 files and 190 tests skipped.
- Final diff -> independent Codex review -> no actionable findings.

The module-impact manifest does not explicitly own ComposerAgentControlsMenu.interaction.test.tsx, so the impact selector correctly chose the complete portable Vitest suite.

## Review focus

Please verify the top-level menu order when at least one session grant exists. UI E2E and platform-specific lanes were excluded because the change only reorders existing DOM nodes and the focused interaction test asserts the exact cross-platform order; no uncovered behavioral risk is known.