### PR TITLE
fix(compute): guard dispatcher job transitions

### DIFF
--- a/src/main/compute/compute-job-lifecycle.test.ts
+++ b/src/main/compute/compute-job-lifecycle.test.ts
@@ -32,6 +32,17 @@ beforeEach(async () => {
     commandHash: 'hash',
     initialStatus: 'queued'
   })
+  await repository.create({
+    id: 'submitted-job',
+    providerId: 'ssh:test',
+    shape: 'direct_ssh',
+    sessionId: 'session-1',
+    projectId: 'project-1',
+    intent: 'test dispatch',
+    command: 'echo ok',
+    commandHash: 'hash',
+    initialStatus: 'submitted'
+  })
   publish = vi.fn()
   lifecycle = new ComputeJobLifecycle(repository, publish)
 })
@@ -76,5 +87,45 @@ describe('ComputeJobLifecycle', () => {
     const result = await lifecycle.promoteQueued('queued-job')
 
     expect(result.kind).toBe('applied')
+  })
+
+  it('records the running projection and publishes it after dispatch succeeds', async () => {
+    const result = await lifecycle.dispatchRunning('submitted-job', '{"pid":123}')
+
+    expect(result.kind).toBe('applied')
+    if (result.kind !== 'applied') throw new Error('expected an applied transition')
+    expect(result.job.status).toBe('running')
+    expect(result.job.remote_handle).toBe('{"pid":123}')
+    expect(result.job.started_at).toBeGreaterThan(0)
+    expect(publish).toHaveBeenCalledOnce()
+    expect(publish).toHaveBeenCalledWith(result.job)
+  })
+
+  it('records one dispatch error projection with its completion fields', async () => {
+    const result = await lifecycle.dispatchError('submitted-job', {
+      errorCode: 'host_unreachable',
+      stderrTail: 'connection refused'
+    })
+
+    expect(result.kind).toBe('applied')
+    if (result.kind !== 'applied') throw new Error('expected an applied transition')
+    expect(result.job.status).toBe('error')
+    expect(result.job.error_code).toBe('host_unreachable')
+    expect(result.job.stderr_tail).toBe('connection refused')
+    expect(result.job.finished_at).toBeGreaterThan(0)
+    expect(publish).toHaveBeenCalledOnce()
+  })
+
+  it('ignores a late dispatcher result after another writer has made the job terminal', async () => {
+    await repository.update('submitted-job', { status: 'success', finishedAt: new Date() })
+
+    const results = await Promise.all([
+      lifecycle.dispatchError('submitted-job', { errorCode: 'dispatch_failed' }),
+      lifecycle.dispatchRunning('submitted-job', '{"pid":123}')
+    ])
+
+    expect(results).toEqual([{ kind: 'ignored' }, { kind: 'ignored' }])
+    expect((await repository.get('submitted-job'))?.status).toBe('success')
+    expect(publish).not.toHaveBeenCalled()
   })
 })

--- a/src/main/compute/compute-job-lifecycle.ts
+++ b/src/main/compute/compute-job-lifecycle.ts
@@ -1,5 +1,5 @@
-import type { ComputeJob } from '../../shared/compute'
-import type { ComputeJobRepository } from './job-repository'
+import type { ComputeJob, ComputeJobStatus } from '../../shared/compute'
+import type { ComputeJobRepository, UpdateJobRequest } from './job-repository'
 
 export type ComputeJobTransitionResult = { kind: 'applied'; job: ComputeJob } | { kind: 'ignored' }
 
@@ -10,10 +10,38 @@ export class ComputeJobLifecycle {
   ) {}
 
   async promoteQueued(jobId: string): Promise<ComputeJobTransitionResult> {
-    const job = await this.repository.updateIfStatus(jobId, ['queued'], {
+    return this.apply(jobId, ['queued'], {
       status: 'submitted',
       submittedAt: new Date()
     })
+  }
+
+  async dispatchRunning(jobId: string, remoteHandle: string): Promise<ComputeJobTransitionResult> {
+    return this.apply(jobId, ['submitted'], {
+      status: 'running',
+      remoteHandle,
+      startedAt: new Date()
+    })
+  }
+
+  async dispatchError(
+    jobId: string,
+    failure: { errorCode: string; stderrTail?: string }
+  ): Promise<ComputeJobTransitionResult> {
+    return this.apply(jobId, ['submitted'], {
+      status: 'error',
+      errorCode: failure.errorCode,
+      ...(failure.stderrTail === undefined ? {} : { stderrTail: failure.stderrTail }),
+      finishedAt: new Date()
+    })
+  }
+
+  private async apply(
+    jobId: string,
+    expectedStatuses: readonly ComputeJobStatus[],
+    updates: UpdateJobRequest
+  ): Promise<ComputeJobTransitionResult> {
+    const job = await this.repository.updateIfStatus(jobId, expectedStatuses, updates)
     if (!job) return { kind: 'ignored' }
 
     try {

--- a/src/main/compute/compute-job-workflow-owner.test.ts
+++ b/src/main/compute/compute-job-workflow-owner.test.ts
@@ -163,6 +163,32 @@ const makeJobRepo = (
     jobs.set(jobId, updated as import('../../shared/compute').ComputeJob)
     return updated as import('../../shared/compute').ComputeJob
   })
+  const updateIfStatus = vi.fn(
+    async (
+      jobId: string,
+      expectedStatuses: readonly import('../../shared/compute').ComputeJobStatus[],
+      updates: import('./job-repository').UpdateJobRequest
+    ) => {
+      const job = jobs.get(jobId)
+      if (!job || !expectedStatuses.includes(job.status)) return null
+      const updated: import('../../shared/compute').ComputeJob = {
+        ...job,
+        ...(updates.status === undefined ? {} : { status: updates.status }),
+        ...(updates.remoteHandle === undefined ? {} : { remote_handle: updates.remoteHandle }),
+        ...(updates.stderrTail === undefined
+          ? {}
+          : { stderr_tail: updates.stderrTail ?? undefined }),
+        ...(updates.errorCode === undefined ? {} : { error_code: updates.errorCode ?? undefined }),
+        ...(updates.submittedAt === undefined
+          ? {}
+          : { submitted_at: updates.submittedAt.getTime() }),
+        ...(updates.startedAt === undefined ? {} : { started_at: updates.startedAt.getTime() }),
+        ...(updates.finishedAt === undefined ? {} : { finished_at: updates.finishedAt.getTime() })
+      }
+      jobs.set(jobId, updated)
+      return updated
+    }
+  )
   const getCalls = vi.fn(async (jobId: string) => jobs.get(jobId) ?? null)
   const findNonTerminalCalls = vi.fn(async () => Array.from(jobs.values()))
 
@@ -171,6 +197,7 @@ const makeJobRepo = (
       create: createCalls,
       get: getCalls,
       update: updateCalls,
+      updateIfStatus,
       findNonTerminal: findNonTerminalCalls,
       findNonTerminalByProvider: vi.fn(async () => []),
       hasActiveJobsForProvider: vi.fn(async () => false)

--- a/src/main/compute/job-dispatcher.test.ts
+++ b/src/main/compute/job-dispatcher.test.ts
@@ -76,7 +76,7 @@ const makeJob = (overrides: Partial<ComputeJob> = {}): ComputeJob => ({
 })
 
 type HostRepo = Pick<ComputeHostRepository, 'get'>
-type JobRepo = Pick<ComputeJobRepository, 'get' | 'update'>
+type JobRepo = Pick<ComputeJobRepository, 'get' | 'updateIfStatus'>
 
 const makeHostRepo = (host: import('../../shared/compute').ComputeHost | null): HostRepo => ({
   get: vi.fn(() => Promise.resolve(host))
@@ -86,14 +86,14 @@ const makeJobRepo = (
   job: ComputeJob | null
 ): {
   repo: JobRepo
-  update: ReturnType<typeof vi.fn>
+  transition: ReturnType<typeof vi.fn>
   get: ReturnType<typeof vi.fn>
 } => {
-  const update = vi.fn((_id: string, updates: unknown) =>
+  const transition = vi.fn((_id: string, _expectedStatuses: unknown, updates: unknown) =>
     Promise.resolve({ ...job!, ...(updates as object), job_id: _id })
   )
   const get = vi.fn(() => Promise.resolve(job))
-  return { repo: { get, update } as unknown as JobRepo, update, get }
+  return { repo: { get, updateIfStatus: transition } as unknown as JobRepo, transition, get }
 }
 
 const sampleHost = (): import('../../shared/compute').ComputeHost => ({
@@ -308,7 +308,7 @@ describe('dispatchJob', () => {
       truncated: false,
       timedOut: false
     })
-    const { repo, update } = makeJobRepo(job)
+    const { repo, transition } = makeJobRepo(job)
     const onJobUpdated = vi.fn()
 
     await dispatchJob(job.job_id, {
@@ -319,8 +319,12 @@ describe('dispatchJob', () => {
     })
 
     // Should have been called with status=running and a remoteHandle.
-    expect(update).toHaveBeenCalledWith('job-1', expect.objectContaining({ status: 'running' }))
-    const updateCall = update.mock.calls[0]![1]
+    expect(transition).toHaveBeenCalledWith(
+      'job-1',
+      ['submitted'],
+      expect.objectContaining({ status: 'running' })
+    )
+    const updateCall = transition.mock.calls[0]![2]
     expect(updateCall).toHaveProperty('remoteHandle')
     const handle = JSON.parse(updateCall.remoteHandle as string)
     expect(handle.pid).toBe(12345)
@@ -340,13 +344,13 @@ describe('dispatchJob', () => {
     })
     // Observe the tracker state at the moment the terminal update is written — it must still be
     // in-flight then (the finally clears it only after dispatchJobInner returns).
-    const update = vi.fn((_id: string, updates: unknown) => {
+    const updateIfStatus = vi.fn((_id: string, _expectedStatuses: unknown, updates: unknown) => {
       seenInFlightDuringUpdate = tracker.has('job-1')
       return Promise.resolve({ ...job, ...(updates as object), job_id: _id })
     })
     const repo = {
       get: vi.fn(() => Promise.resolve(job)),
-      update
+      updateIfStatus
     } as unknown as ComputeJobRepository
 
     await dispatchJob(job.job_id, {
@@ -413,7 +417,7 @@ describe('dispatchJob', () => {
       truncated: false,
       timedOut: false
     })
-    const { repo, update } = makeJobRepo(job)
+    const { repo, transition } = makeJobRepo(job)
     const onJobUpdated = vi.fn()
 
     await dispatchJob(job.job_id, {
@@ -423,8 +427,9 @@ describe('dispatchJob', () => {
       onJobUpdated
     })
 
-    expect(update).toHaveBeenCalledWith(
+    expect(transition).toHaveBeenCalledWith(
       'job-1',
+      ['submitted'],
       expect.objectContaining({ status: 'error', errorCode: 'host_unreachable' })
     )
   })
@@ -438,7 +443,7 @@ describe('dispatchJob', () => {
       truncated: false,
       timedOut: false
     })
-    const { repo, update } = makeJobRepo(job)
+    const { repo, transition } = makeJobRepo(job)
 
     await dispatchJob(job.job_id, {
       runner,
@@ -446,8 +451,9 @@ describe('dispatchJob', () => {
       jobRepository: repo as unknown as ComputeJobRepository
     })
 
-    expect(update).toHaveBeenCalledWith(
+    expect(transition).toHaveBeenCalledWith(
       'job-1',
+      ['submitted'],
       expect.objectContaining({ status: 'error', errorCode: 'dispatch_failed' })
     )
   })
@@ -602,7 +608,7 @@ describe('dispatchJob — staging integration', () => {
     const scpRunner: ScpRunner = {
       copy: vi.fn(async () => ({ exitCode: 1, stderr: 'no such file', timedOut: false }))
     }
-    const { repo, update } = makeJobRepo(job)
+    const { repo, transition } = makeJobRepo(job)
 
     await dispatchJob(job.job_id, {
       runner,
@@ -611,8 +617,9 @@ describe('dispatchJob — staging integration', () => {
       jobRepository: repo as unknown as ComputeJobRepository
     })
 
-    expect(update).toHaveBeenCalledWith(
+    expect(transition).toHaveBeenCalledWith(
       'job-1',
+      ['submitted'],
       expect.objectContaining({ status: 'error', errorCode: 'dispatch_failed' })
     )
   })

--- a/src/main/compute/job-dispatcher.ts
+++ b/src/main/compute/job-dispatcher.ts
@@ -9,6 +9,7 @@ import type { ScpRunner } from './scp-runner'
 import { SystemScpRunner, runScpUpload } from './scp-runner'
 import { shellSingleQuote } from './scp-runner'
 import { sharedDispatchTracker, type DispatchTracker } from './dispatch-tracker'
+import { ComputeJobLifecycle } from './compute-job-lifecycle'
 
 // Maximum number of bytes for the per-job dispatch SSH command (enough for base64 of large scripts).
 const DISPATCH_MAX_OUTPUT_BYTES = 4 * 1024
@@ -136,18 +137,14 @@ export async function dispatchJob(jobId: string, deps: DispatcherDeps): Promise<
 async function dispatchJobInner(jobId: string, deps: DispatcherDeps): Promise<void> {
   const { runner, hostRepository, jobRepository, onJobUpdated } = deps
   const scpRunner = deps.scpRunner ?? new SystemScpRunner()
+  const lifecycle = new ComputeJobLifecycle(jobRepository, onJobUpdated)
 
   const job = await jobRepository.get(jobId)
   if (!job) return // already gone (unlikely but guard anyway)
 
   const host = await hostRepository.get(job.provider_id)
   if (!host) {
-    const updated = await jobRepository.update(jobId, {
-      status: 'error',
-      errorCode: 'dispatch_failed',
-      finishedAt: new Date()
-    })
-    onJobUpdated?.(updated)
+    await lifecycle.dispatchError(jobId, { errorCode: 'dispatch_failed' })
     return
   }
 
@@ -157,13 +154,10 @@ async function dispatchJobInner(jobId: string, deps: DispatcherDeps): Promise<vo
     target = await resolveSshTarget(host.sshAlias, host.sshOverrides)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    const updated = await jobRepository.update(jobId, {
-      status: 'error',
+    await lifecycle.dispatchError(jobId, {
       errorCode: 'host_unreachable',
-      stderrTail: msg,
-      finishedAt: new Date()
+      stderrTail: msg
     })
-    onJobUpdated?.(updated)
     return
   }
 
@@ -176,13 +170,10 @@ async function dispatchJobInner(jobId: string, deps: DispatcherDeps): Promise<vo
     try {
       entries = JSON.parse(job.input_manifest) as StagedInputEntry[]
     } catch {
-      const updated = await jobRepository.update(jobId, {
-        status: 'error',
+      await lifecycle.dispatchError(jobId, {
         errorCode: 'dispatch_failed',
-        stderrTail: 'Failed to parse inputManifest JSON',
-        finishedAt: new Date()
+        stderrTail: 'Failed to parse inputManifest JSON'
       })
-      onJobUpdated?.(updated)
       return
     }
 
@@ -194,13 +185,10 @@ async function dispatchJobInner(jobId: string, deps: DispatcherDeps): Promise<vo
     })
     if (mkdirResult.exitCode !== 0) {
       const tail = mkdirResult.stderr || `mkdir exit ${mkdirResult.exitCode ?? 'null'}`
-      const updated = await jobRepository.update(jobId, {
-        status: 'error',
+      await lifecycle.dispatchError(jobId, {
         errorCode: 'dispatch_failed',
-        stderrTail: tail,
-        finishedAt: new Date()
+        stderrTail: tail
       })
-      onJobUpdated?.(updated)
       return
     }
 
@@ -208,13 +196,10 @@ async function dispatchJobInner(jobId: string, deps: DispatcherDeps): Promise<vo
       await stageInputs(entries, workdir, runner, target, scpRunner)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      const updated = await jobRepository.update(jobId, {
-        status: 'error',
+      await lifecycle.dispatchError(jobId, {
         errorCode: 'dispatch_failed',
-        stderrTail: `Input staging failed: ${msg}`,
-        finishedAt: new Date()
+        stderrTail: `Input staging failed: ${msg}`
       })
-      onJobUpdated?.(updated)
       return
     }
   }
@@ -254,39 +239,30 @@ async function dispatchJobInner(jobId: string, deps: DispatcherDeps): Promise<vo
   // Connection-level failure.
   if (runResult.timedOut || runResult.exitCode === 255) {
     const tail = runResult.stderr || 'SSH connection failed'
-    const updated = await jobRepository.update(jobId, {
-      status: 'error',
+    await lifecycle.dispatchError(jobId, {
       errorCode: 'host_unreachable',
-      stderrTail: tail,
-      finishedAt: new Date()
+      stderrTail: tail
     })
-    onJobUpdated?.(updated)
     return
   }
 
   // Non-connection failure (mkdir, base64, etc.)
   if (runResult.exitCode !== 0) {
     const tail = runResult.stderr || `exit code ${runResult.exitCode ?? 'null'}`
-    const updated = await jobRepository.update(jobId, {
-      status: 'error',
+    await lifecycle.dispatchError(jobId, {
       errorCode: 'dispatch_failed',
-      stderrTail: tail,
-      finishedAt: new Date()
+      stderrTail: tail
     })
-    onJobUpdated?.(updated)
     return
   }
 
   // Parse pid from stdout (last non-empty line).
   const pid = Number.parseInt(runResult.stdout.trim().split('\n').pop() ?? '', 10)
   if (!Number.isFinite(pid) || pid <= 0) {
-    const updated = await jobRepository.update(jobId, {
-      status: 'error',
+    await lifecycle.dispatchError(jobId, {
       errorCode: 'dispatch_failed',
-      stderrTail: `Could not read pid from dispatch output: ${JSON.stringify(runResult.stdout)}`,
-      finishedAt: new Date()
+      stderrTail: `Could not read pid from dispatch output: ${JSON.stringify(runResult.stdout)}`
     })
-    onJobUpdated?.(updated)
     return
   }
 
@@ -299,10 +275,5 @@ async function dispatchJobInner(jobId: string, deps: DispatcherDeps): Promise<vo
     workdir
   }
 
-  const updated = await jobRepository.update(jobId, {
-    status: 'running',
-    remoteHandle: JSON.stringify(handle),
-    startedAt: new Date()
-  })
-  onJobUpdated?.(updated)
+  await lifecycle.dispatchRunning(jobId, JSON.stringify(handle))
 }


### PR DESCRIPTION
## Problem

Dispatcher owned remote launch work but also wrote `submitted -> running/error` projections directly through unconditional repository updates. A late Dispatcher result could therefore overwrite a status already persisted by another lifecycle writer, and the transition field bundles/publication rule were duplicated across every error path.

## Proposed change

- Add intent-level `dispatchRunning` and `dispatchError` operations to `ComputeJobLifecycle`.
- Guard both operations with the existing repository CAS so only `submitted` jobs transition.
- Keep `remoteHandle`/`startedAt` and `errorCode`/optional `stderrTail`/`finishedAt` in their existing atomic field bundles.
- Route every Dispatcher status-bearing write through the lifecycle owner; stale results return without publication.
- Update Dispatcher and workflow test fixtures to exercise the guarded repository interface.

```mermaid
flowchart LR
  S["submitted"] -->|"dispatchRunning + CAS"| R["running"]
  S -->|"dispatchError + CAS"| E["error"]
  T["success / failed / timeout / error"] -. "late Dispatcher result ignored" .-> T
```

## Scope and non-goals

This PR is CL2 of the staged Compute Job Lifecycle refactor. Dispatcher still owns host resolution, portable path handling, staging, SSH/SCP execution, launch command construction, PID parsing, and remote-handle construction.

It does not cut over Poller writers, serialize Poller ticks, change timeout precedence, add cancellation/retry/scheduler states, or change queue/admission, approval, harvest, notification, or UI behavior.

## Compatibility

- No Prisma schema or persisted status-string change.
- No shared/public API, application-command, IPC, RPC, Electron, Web, or CLI contract change.
- Existing error codes, stderr tails, timestamps, observer callback, tracker ordering, and remote handle representation are preserved.
- Applied transitions still publish once; stale/terminal rows are neither overwritten nor published.
- This stage is independently releasable while Poller remains on its current implementation.

## Acceptance criteria and validation

Final evidence below was collected after the last material edit and after rebasing onto `origin/main@5b44642c`:

- Dispatcher/lifecycle behavior and declared Compute consumers -> `npm run test:module -- compute_service` -> 20 files passed, 1 skipped; 487 tests passed, 5 skipped.
- Main-process contracts -> `npm run typecheck:node` -> passed.
- Changed TypeScript files -> `npx eslint --no-cache <changed files>` -> passed with 0 findings.
- Formatting and whitespace -> Prettier check plus `git diff --check` -> passed.
- Independent review -> Standards P0/P1/P2 = 0/0/0; Spec P0/P1/P2 = 0/0/0.

The first sandboxed module run could not bind Notebook RPC sockets (`EPERM`); the exact same project-owned command was rerun with local socket access and passed as reported above. Exact-head CI/AI remains authoritative for portable and platform lanes.

## Review focus

- Confirm every former Dispatcher status write maps to the same error code/tail or running handle field bundle.
- Confirm CAS expectations are limited to `submitted` and stale results have no observer side effects.
- Confirm remote launch, tracker, and cross-surface contracts remain unchanged.
