### PR TITLE
fix(workspace): avoid premature Plan projection reads

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -268,6 +268,20 @@ describe('WorkspacePage send gate while compacting', () => {
     }
   )
 
+  it('does not query Plan authority before a newly bound Session is persisted', async () => {
+    useSessionStore.setState({
+      sessions: [createSession({ status: 'running' })],
+      selectedSessionId: 'sess-a'
+    })
+    vi.mocked(window.api.acp.getPlanProjection).mockRejectedValueOnce(
+      new Error('Cannot read runtime context for a missing Session.')
+    )
+
+    await renderPage()
+
+    expect(window.api.acp.getPlanProjection).not.toHaveBeenCalled()
+  })
+
   it('blocks overlapping actions while the Session is waiting for a user answer', async () => {
     useSessionStore.setState({
       sessions: [createSession({ status: 'waiting-for-user' })],

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -292,7 +292,14 @@ const WorkspacePage = ({
 
   useEffect(() => {
     const getPlanProjection = window.api.acp?.getPlanProjection
-    if (!activeSession || activeSession.activePlanProjection || !getPlanProjection) return
+    if (
+      !activeSession ||
+      activeSession.activePlanProjection ||
+      !getPlanProjection ||
+      (activeSession.status !== 'waiting-plan-approval' && !activeSession.runtimeContext?.plan)
+    ) {
+      return
+    }
     let cancelled = false
     void getPlanProjection(activeSession.projectId, activeSession.id)
       .then((projection) => {


### PR DESCRIPTION
## Problem

After ACP creates a new Session, the renderer binds and selects it before the first asynchronous persistence write completes. The Workspace Plan recovery effect queried every selected Session without an active projection, so a normal first send could invoke `acp:get-plan-projection` while the Session file was still missing. The renderer swallowed the rejection, but the main process emitted repeated missing-Session errors.

## Proposed change

- Query Plan projection recovery only when the Session is waiting for Plan approval or its durable runtime context already contains Plan authority.
- Add a regression test proving that a newly bound, running Session does not issue the premature query.

## Scope and non-goals

- This is limited to the renderer Workspace Plan recovery gate.
- It does not change ACP protocol contracts, main-process adapters, persistence formats, Session creation ordering, or framework-specific behavior.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Newly bound Session avoids the missing-Session Plan read -> `npm test -- src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx -t 'does not query Plan authority before a newly bound Session is persisted'` -> passed.
- Workspace Plan recovery and renderer consumers remain intact -> `npm run test:module -- workspace_page` -> 23 files and 337 tests passed.
- Renderer types remain valid -> `npm run typecheck:web` -> passed.
- Source lint remains clean -> `npm run lint` -> passed with 0 errors; 17 pre-existing warnings were outside the changed files.

Framework, launcher, model, and platform-specific ACP paths are excluded because the wire contract and main-process runtime are unchanged. Local E2E was not included because the deterministic Workspace owner test exercises the exact query gate; PR Gate remains authoritative for selected platform lanes.

## Review focus

Confirm that the recovery guard still queries Sessions with durable Plan authority and Sessions stuck in `waiting-plan-approval`, while excluding ordinary newly bound Sessions before their first persistence write.
