### PR TITLE
fix(composer): add auto-review divider

### DIFF
--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx
@@ -826,7 +826,7 @@ describe('ComposerAgentControlsMenu', () => {
     expect(computeSubContents).toHaveLength(1)
     expect(computeSubContents[0]?.textContent).toContain('Manage compute...')
 
-    // Top-level order: permission mode -> session grants -> auto-review -> specialist -> compute.
+    // Top-level order: permission mode -> session grants -> divider -> auto-review -> specialist -> compute.
     const orderAnchor = (needle: string): Element => {
       const match = Array.from(container.querySelectorAll('[data-testid="submenu-trigger"]')).find(
         (el) => el.textContent?.includes(needle)
@@ -848,8 +848,12 @@ describe('ComposerAgentControlsMenu', () => {
 
     const precedes = (a: Element, b: Element): boolean =>
       (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+    const autoReviewDivider = Array.from(container.querySelectorAll('hr')).find(
+      (separator) =>
+        precedes(sessionGrantsHeading as Element, separator) && precedes(separator, autoReviewRow)
+    )
     expect(precedes(permissionTrigger, sessionGrantsHeading as Element)).toBe(true)
-    expect(precedes(sessionGrantsHeading as Element, autoReviewRow)).toBe(true)
+    expect(autoReviewDivider).not.toBeUndefined()
     expect(precedes(autoReviewRow, specialistStub as Element)).toBe(true)
     expect(precedes(specialistStub as Element, computeTrigger)).toBe(true)
   })

--- a/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerAgentControlsMenu.tsx
@@ -416,6 +416,8 @@ const ComposerAgentControlsMenu = ({
                 </div>
               ) : null}
 
+              <DropdownMenuSeparator />
+
               {/* The whole row toggles auto-review; the Switch is a visual indicator only. */}
               <DropdownMenuItem
                 disabled={readOnly || autoReviewDisabled}


### PR DESCRIPTION
## Problem

The agent controls menu flows directly from session grants into Auto-review without a visual boundary, making the sections appear grouped together.

## Proposed change

Add the existing dropdown-menu separator immediately above Auto-review and extend the menu-order regression test to cover its placement.

## Scope and non-goals

This is a presentation-only change. It does not alter auto-review behavior, permission grants, menu interaction, persistence, or platform-specific code.

## Acceptance criteria and validation

- Auto-review is separated from the section above it: npm test -- src/renderer/src/pages/workspace/ComposerAgentControlsMenu.interaction.test.tsx — 27 tests passed
- Renderer types remain valid: npm run typecheck:web — passed
- Lint remains clean of errors: npm run lint — passed with 17 pre-existing warnings
- Patch formatting: git diff --check — passed

All checks ran after the final material edit. Full npm test and platform lanes were excluded because the owner component and targeted test are established, and the change does not affect interfaces, logic, persistence, or platform behavior.

## Review focus

Confirm the separator appears immediately above Auto-review in the primary agent controls menu.