### PR TITLE
fix(compute): guard poller job transitions

### DIFF
--- a/src/main/compute/compute-job-lifecycle.test.ts
+++ b/src/main/compute/compute-job-lifecycle.test.ts
@@ -43,6 +43,17 @@ beforeEach(async () => {
     commandHash: 'hash',
     initialStatus: 'submitted'
   })
+  await repository.create({
+    id: 'running-job',
+    providerId: 'ssh:test',
+    shape: 'direct_ssh',
+    sessionId: 'session-1',
+    projectId: 'project-1',
+    intent: 'test polling',
+    command: 'echo ok',
+    commandHash: 'hash',
+    initialStatus: 'running'
+  })
   publish = vi.fn()
   lifecycle = new ComputeJobLifecycle(repository, publish)
 })
@@ -127,5 +138,71 @@ describe('ComputeJobLifecycle', () => {
     expect(results).toEqual([{ kind: 'ignored' }, { kind: 'ignored' }])
     expect((await repository.get('submitted-job'))?.status).toBe('success')
     expect(publish).not.toHaveBeenCalled()
+  })
+
+  it('lets only one overlapping terminal poll observation apply and publish', async () => {
+    const results = await Promise.all([
+      lifecycle.finishPolled('running-job', {
+        status: 'success',
+        exitCode: 0,
+        stdoutTail: 'done',
+        stderrTail: null,
+        errorCode: null
+      }),
+      lifecycle.finishPolled('running-job', {
+        status: 'timeout',
+        exitCode: 124,
+        stdoutTail: 'late',
+        stderrTail: null,
+        errorCode: 'timeout'
+      })
+    ])
+
+    expect(results.map(({ kind }) => kind).sort()).toEqual(['applied', 'ignored'])
+    expect(publish).toHaveBeenCalledOnce()
+    expect(['success', 'timeout']).toContain((await repository.get('running-job'))?.status)
+  })
+
+  it('updates active polling projections only while the observed status is current', async () => {
+    const result = await lifecycle.observeRunning('running-job', 'running', {
+      stdoutTail: 'progress',
+      stderrTail: null
+    })
+
+    expect(result.kind).toBe('applied')
+    if (result.kind !== 'applied') throw new Error('expected an applied transition')
+    expect(result.job.status).toBe('running')
+    expect(result.job.stdout_tail).toBe('progress')
+    expect(result.job.last_poll_error).toBeUndefined()
+    expect(publish).toHaveBeenCalledOnce()
+  })
+
+  it('does not attach a late poll error or active projection to a terminal row', async () => {
+    await repository.update('running-job', { status: 'failed', finishedAt: new Date() })
+
+    const results = await Promise.all([
+      lifecycle.recordPollError('running-job', 'running', 'connection lost'),
+      lifecycle.observeRunning('running-job', 'running', {
+        stdoutTail: 'late output',
+        stderrTail: null
+      })
+    ])
+
+    expect(results).toEqual([{ kind: 'ignored' }, { kind: 'ignored' }])
+    expect((await repository.get('running-job'))?.last_poll_error).toBeUndefined()
+    expect((await repository.get('running-job'))?.stdout_tail).toBeUndefined()
+    expect(publish).not.toHaveBeenCalled()
+  })
+
+  it('records the interrupted-dispatch recovery bundle once', async () => {
+    const result = await lifecycle.recoverInterruptedDispatch('submitted-job')
+
+    expect(result.kind).toBe('applied')
+    if (result.kind !== 'applied') throw new Error('expected an applied transition')
+    expect(result.job.status).toBe('error')
+    expect(result.job.error_code).toBe('dispatch_failed')
+    expect(result.job.stderr_tail).toBe('dispatch interrupted by restart')
+    expect(result.job.finished_at).toBeGreaterThan(0)
+    expect(publish).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/compute/compute-job-lifecycle.ts
+++ b/src/main/compute/compute-job-lifecycle.ts
@@ -3,6 +3,14 @@ import type { ComputeJobRepository, UpdateJobRequest } from './job-repository'
 
 export type ComputeJobTransitionResult = { kind: 'applied'; job: ComputeJob } | { kind: 'ignored' }
 
+type ActiveJobStatus = Extract<ComputeJobStatus, 'submitted' | 'running'>
+type PollTails = { stdoutTail: string | null; stderrTail: string | null }
+type PolledJobFinish = PollTails & {
+  status: Extract<ComputeJobStatus, 'success' | 'failed' | 'timeout'>
+  exitCode?: number
+  errorCode: string | null
+}
+
 export class ComputeJobLifecycle {
   constructor(
     private readonly repository: ComputeJobRepository,
@@ -36,6 +44,49 @@ export class ComputeJobLifecycle {
     })
   }
 
+  async recoverInterruptedDispatch(jobId: string): Promise<ComputeJobTransitionResult> {
+    return this.apply(jobId, ['submitted'], {
+      status: 'error',
+      errorCode: 'dispatch_failed',
+      stderrTail: 'dispatch interrupted by restart',
+      finishedAt: new Date()
+    })
+  }
+
+  async finishPolled(jobId: string, result: PolledJobFinish): Promise<ComputeJobTransitionResult> {
+    return this.apply(jobId, ['submitted', 'running'], {
+      status: result.status,
+      ...(result.exitCode === undefined ? {} : { exitCode: result.exitCode }),
+      stdoutTail: result.stdoutTail,
+      stderrTail: result.stderrTail,
+      errorCode: result.errorCode,
+      finishedAt: new Date()
+    })
+  }
+
+  async observeRunning(
+    jobId: string,
+    observedStatus: ActiveJobStatus,
+    tails: PollTails
+  ): Promise<ComputeJobTransitionResult> {
+    return this.apply(jobId, [observedStatus], {
+      ...(observedStatus === 'submitted' ? { status: 'running' as const } : {}),
+      ...tails,
+      lastPollError: null
+    })
+  }
+
+  async recordPollError(
+    jobId: string,
+    observedStatus: ActiveJobStatus,
+    message: string
+  ): Promise<ComputeJobTransitionResult> {
+    return this.apply(jobId, [observedStatus], {
+      lastPollError: message,
+      retryAfterUserAction: true
+    })
+  }
+
   private async apply(
     jobId: string,
     expectedStatuses: readonly ComputeJobStatus[],
@@ -43,7 +94,6 @@ export class ComputeJobLifecycle {
   ): Promise<ComputeJobTransitionResult> {
     const job = await this.repository.updateIfStatus(jobId, expectedStatuses, updates)
     if (!job) return { kind: 'ignored' }
-
     try {
       this.onApplied(job)
     } catch {

--- a/src/main/compute/job-poller.test.ts
+++ b/src/main/compute/job-poller.test.ts
@@ -1,3 +1,6 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ComputeJob } from '../../shared/compute'
@@ -40,6 +43,13 @@ const withNonce = (lines: string[]): string =>
 const makeSshRunner = (result: Awaited<ReturnType<SshRunner['run']>>): SshRunner => ({
   run: vi.fn(() => Promise.resolve(result))
 })
+
+const guardStatusUpdate = (
+  update: (jobId: string, updates: unknown) => unknown
+): ReturnType<typeof vi.fn> =>
+  vi.fn((jobId: string, _expectedStatuses: unknown, updates: unknown) => update(jobId, updates))
+
+const testStorageRoot = (): string => join(tmpdir(), 'open-science-poller-test-storage')
 
 const makeJob = (overrides: Partial<ComputeJob> = {}): ComputeJob => ({
   job_id: 'job-1',
@@ -106,7 +116,8 @@ describe('JobPoller', () => {
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
       get: vi.fn(() => Promise.resolve(job)),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -149,6 +160,49 @@ describe('JobPoller', () => {
     expect(onJobUpdated).toHaveBeenCalled()
   })
 
+  it('does not publish or harvest a terminal observation that loses the lifecycle race', async () => {
+    const job = makeJob()
+    const updateIfStatus = vi.fn(() => Promise.resolve(null))
+    const jobRepo = {
+      findNonTerminal: vi.fn(() => Promise.resolve([job])),
+      findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
+      updateIfStatus
+    } as unknown as ComputeJobRepository
+    const hostRepo = {
+      get: vi.fn(() => Promise.resolve(sampleHost()))
+    } as unknown as ComputeHostRepository
+    const runner = makeSshRunner({
+      exitCode: 0,
+      stdout: withNonce([
+        'JOB_START:job-1',
+        'alive:0',
+        '0',
+        'done',
+        'STDOUT_END:job-1',
+        '',
+        'STDERR_END:job-1'
+      ]),
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const onJobUpdated = vi.fn()
+    const harvestFn: HarvestFn = vi.fn(() => Promise.resolve())
+
+    await new JobPoller({
+      runner,
+      hostRepository: hostRepo,
+      jobRepository: jobRepo,
+      onJobUpdated,
+      makeNonce: () => NONCE,
+      harvestFn
+    }).tick()
+
+    expect(updateIfStatus).toHaveBeenCalledOnce()
+    expect(onJobUpdated).not.toHaveBeenCalled()
+    expect(harvestFn).not.toHaveBeenCalled()
+  })
+
   it('clears a stale lastPollError on a successful poll of a still-running job', async () => {
     // A running job that previously recorded a transient SSH error must have that error cleared once
     // a poll succeeds again (schema.prisma: "Cleared on the next successful poll"). Regression for
@@ -158,7 +212,8 @@ describe('JobPoller', () => {
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
       get: vi.fn(() => Promise.resolve(job)),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -199,7 +254,8 @@ describe('JobPoller', () => {
     const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -242,7 +298,8 @@ describe('JobPoller', () => {
     const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -285,7 +342,8 @@ describe('JobPoller', () => {
     const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -343,7 +401,8 @@ describe('JobPoller', () => {
     const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -394,7 +453,8 @@ describe('JobPoller', () => {
     const update = vi.fn()
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -423,7 +483,8 @@ describe('JobPoller', () => {
     const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -464,9 +525,12 @@ describe('JobPoller', () => {
       started_at: now - timeoutSecs * 1000 // exactly at the boundary
     })
     const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
+    const updateIfStatus = guardStatusUpdate(update)
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      get: vi.fn(() => Promise.resolve(job)),
+      update,
+      updateIfStatus
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -515,7 +579,8 @@ describe('JobPoller', () => {
     const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -565,9 +630,12 @@ describe('JobPoller', () => {
       started_at: now - graceMs
     })
     const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
+    const updateIfStatus = guardStatusUpdate(update)
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      get: vi.fn(() => Promise.resolve(job)),
+      update,
+      updateIfStatus
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -601,11 +669,13 @@ describe('JobPoller', () => {
       timedOut: false
     })
     const runner: SshRunner = { run: runFn }
+    const onJobUpdated = vi.fn()
 
     const poller = new JobPoller({
       runner,
       hostRepository: hostRepo,
       jobRepository: jobRepo,
+      onJobUpdated,
       makeNonce: () => NONCE
     })
     await poller.tick()
@@ -620,6 +690,130 @@ describe('JobPoller', () => {
     const killCall = runFn.mock.calls[1]
     expect(killCall[1]).toContain('kill')
     expect(killCall[1]).toContain('1234') // pid from makeJob
+    expect(runFn.mock.invocationCallOrder[1]).toBeLessThan(
+      updateIfStatus.mock.invocationCallOrder[0]
+    )
+    expect(updateIfStatus.mock.invocationCallOrder[0]).toBeLessThan(
+      onJobUpdated.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('serializes overlapping results so a late fallback timeout cannot kill after success', async () => {
+    const job = makeJob({ timeout_seconds: 10, started_at: Date.now() - 71_000 })
+    let current = job
+    const updateIfStatus = vi.fn(
+      async (
+        _jobId: string,
+        expectedStatuses: readonly ComputeJob['status'][],
+        updates: { status?: ComputeJob['status'] }
+      ) => {
+        if (!expectedStatuses.includes(current.status)) return null
+        current = {
+          ...current,
+          ...(updates.status === undefined ? {} : { status: updates.status })
+        }
+        return current
+      }
+    )
+    const jobRepo = {
+      findNonTerminal: vi.fn(() => Promise.resolve([job])),
+      findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
+      get: vi.fn(() => Promise.resolve(current)),
+      updateIfStatus
+    } as unknown as ComputeJobRepository
+    const successfulOutput = withNonce([
+      'JOB_START:job-1',
+      'alive:0',
+      '0',
+      'done',
+      'STDOUT_END:job-1',
+      '',
+      'STDERR_END:job-1'
+    ])
+    const timeoutOutput = withNonce([
+      'JOB_START:job-1',
+      'alive:1',
+      '',
+      '',
+      'STDOUT_END:job-1',
+      '',
+      'STDERR_END:job-1'
+    ])
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: successfulOutput,
+        stderr: '',
+        truncated: false,
+        timedOut: false
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: timeoutOutput,
+        stderr: '',
+        truncated: false,
+        timedOut: false
+      })
+    const runner: SshRunner = { run }
+    const onJobUpdated = vi.fn()
+    const harvestFn: HarvestFn = vi.fn(() => Promise.resolve())
+    const poller = new JobPoller({
+      runner,
+      hostRepository: {
+        get: vi.fn(() => Promise.resolve(sampleHost()))
+      } as unknown as ComputeHostRepository,
+      jobRepository: jobRepo,
+      onJobUpdated,
+      makeNonce: () => NONCE,
+      harvestFn
+    })
+
+    await Promise.all([poller.tick(), poller.tick()])
+
+    expect(current.status).toBe('success')
+    expect(updateIfStatus).toHaveBeenCalledOnce()
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(run.mock.calls.some(([, command]) => String(command).includes('kill 1234'))).toBe(false)
+    expect(onJobUpdated).toHaveBeenCalledOnce()
+    expect(harvestFn).toHaveBeenCalledOnce()
+  })
+
+  it('does not kill when a fresh state check sees an already-terminal row', async () => {
+    const job = makeJob({ timeout_seconds: 10, started_at: Date.now() - 71_000 })
+    const updateIfStatus = vi.fn()
+    const jobRepo = {
+      findNonTerminal: vi.fn(() => Promise.resolve([job])),
+      get: vi.fn(() => Promise.resolve({ ...job, status: 'success' as const })),
+      updateIfStatus
+    } as unknown as ComputeJobRepository
+    const runner = makeSshRunner({
+      exitCode: 0,
+      stdout: withNonce([
+        'JOB_START:job-1',
+        'alive:1',
+        '',
+        '',
+        'STDOUT_END:job-1',
+        '',
+        'STDERR_END:job-1'
+      ]),
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+
+    await new JobPoller({
+      runner,
+      hostRepository: {
+        get: vi.fn(() => Promise.resolve(sampleHost()))
+      } as unknown as ComputeHostRepository,
+      jobRepository: jobRepo,
+      makeNonce: () => NONCE
+    }).tick()
+
+    expect(updateIfStatus).not.toHaveBeenCalled()
+    expect(runner.run).toHaveBeenCalledOnce()
   })
 
   it('marks submitted job without pid as error/dispatch_failed on restart', async () => {
@@ -629,7 +823,8 @@ describe('JobPoller', () => {
     const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -670,7 +865,8 @@ describe('JobPoller', () => {
     const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -790,7 +986,8 @@ describe('JobPoller — harvest wiring', () => {
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -833,7 +1030,8 @@ describe('JobPoller — harvest wiring', () => {
       const jobRepo = {
         findNonTerminal: vi.fn(() => Promise.resolve([job])),
         findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
-        update
+        update,
+        updateIfStatus: guardStatusUpdate(update)
       } as unknown as ComputeJobRepository
       const hostRepo = {
         get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -867,7 +1065,8 @@ describe('JobPoller — harvest wiring', () => {
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -911,7 +1110,8 @@ describe('JobPoller — harvest wiring', () => {
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -971,7 +1171,8 @@ describe('JobPoller — harvest wiring', () => {
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve(jobs)),
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -1021,7 +1222,8 @@ describe('JobPoller — harvest wiring', () => {
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -1152,7 +1354,8 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
       findErrorUnnotified: vi.fn(() => Promise.resolve([])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
 
     const hostRepo = {
@@ -1175,12 +1378,11 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
       jobRepository: jobRepo,
       dispatchTracker: new DispatchTracker(), // empty = post-restart, triggers dispatch_failed
       broadcast,
-      storageRoot: '/tmp/test-storage'
+      storageRoot: testStorageRoot()
     })
 
     await poller.tick()
-    // Wait for the async notification to settle
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await vi.waitFor(() => expect(broadcast).toHaveBeenCalledOnce())
 
     // Status update was called with error/dispatch_failed
     expect(update).toHaveBeenCalledWith(
@@ -1195,12 +1397,42 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
     )
 
     // Broadcast was called with the notification summary
-    expect(broadcast).toHaveBeenCalledOnce()
     const summary = broadcast.mock.calls[0][0]
     expect(summary.status).toBe('error')
     expect(summary.notified_at).toBeDefined()
     expect(summary.featured_files).toEqual([])
     expect(summary.featured_file_count).toBe(0)
+  })
+
+  it('does not notify when interrupted-dispatch recovery loses the lifecycle race', async () => {
+    const job = makeJob({ status: 'submitted', remote_handle: undefined })
+    const updateIfStatus = vi.fn(() => Promise.resolve(null))
+    const jobRepo = {
+      findNonTerminal: vi.fn(() => Promise.resolve([job])),
+      findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
+      findErrorUnnotified: vi.fn(() => Promise.resolve([])),
+      updateIfStatus
+    } as unknown as ComputeJobRepository
+    const runner = makeSshRunner({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    })
+    const broadcast = vi.fn()
+
+    await new JobPoller({
+      runner,
+      hostRepository: { get: vi.fn() } as unknown as ComputeHostRepository,
+      jobRepository: jobRepo,
+      dispatchTracker: new DispatchTracker(),
+      broadcast,
+      storageRoot: testStorageRoot()
+    }).tick()
+
+    expect(updateIfStatus).toHaveBeenCalledOnce()
+    expect(broadcast).not.toHaveBeenCalled()
   })
 
   it('does NOT emit notification if broadcast is not wired', async () => {
@@ -1210,7 +1442,8 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
     const jobRepo = {
       findNonTerminal: vi.fn(() => Promise.resolve([job])),
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = { get: vi.fn() } as unknown as ComputeHostRepository
 
@@ -1257,7 +1490,8 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
       findNonTerminal: vi.fn(() => Promise.resolve([])),
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
       findErrorUnnotified: vi.fn(() => Promise.resolve([errorJob])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -1276,7 +1510,7 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
       hostRepository: hostRepo,
       jobRepository: jobRepo,
       broadcast,
-      storageRoot: '/tmp/test-storage'
+      storageRoot: testStorageRoot()
     })
 
     await poller.tick()
@@ -1318,7 +1552,8 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
       // Both ticks see the row as still unnotified (write is gated).
       findErrorUnnotified: vi.fn(() => Promise.resolve([errorJob])),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))
@@ -1337,7 +1572,7 @@ describe('compute_done notification on dispatch_failed (error) jobs', () => {
       hostRepository: hostRepo,
       jobRepository: jobRepo,
       broadcast,
-      storageRoot: '/tmp/test-storage'
+      storageRoot: testStorageRoot()
     })
 
     // Fire two overlapping ticks, then release the gated write.
@@ -1378,7 +1613,8 @@ describe('JobPoller sub-batching (per-job output budget)', () => {
       findNonTerminal: vi.fn(() => Promise.resolve(jobs)),
       findTerminalUnharvested: vi.fn(() => Promise.resolve([])),
       get: vi.fn((id: string) => Promise.resolve(makeJob({ job_id: id }))),
-      update
+      update,
+      updateIfStatus: guardStatusUpdate(update)
     } as unknown as ComputeJobRepository
     const hostRepo = {
       get: vi.fn(() => Promise.resolve(sampleHost()))

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -8,6 +8,7 @@ import { resolveSshTarget } from './ssh-runner'
 import { quoteRemotePath, type RemoteHandle } from './job-dispatcher'
 import { sharedDispatchTracker, type DispatchTracker } from './dispatch-tracker'
 import { emitJobNotification } from './job-notifier'
+import { ComputeJobLifecycle } from './compute-job-lifecycle'
 
 // Polling interval: 15 seconds (design.md §8).
 export const POLL_INTERVAL_MS = 15_000
@@ -89,6 +90,7 @@ type VanishState = { ticks: number }
 export class JobPoller {
   private handle: ReturnType<typeof setInterval> | undefined
   private readonly vanishCounters = new Map<string, VanishState>()
+  private readonly pollResultChains = new Map<string, Promise<void>>()
 
   // Injectable timers (tests override to control ticks synchronously).
   private readonly setIntervalFn: (fn: () => void, ms: number) => ReturnType<typeof setInterval>
@@ -99,6 +101,7 @@ export class JobPoller {
   private readonly dispatchTracker: DispatchTracker
   // Optional injectable harvest function (design §3).
   private readonly harvestFn: HarvestFn | undefined
+  private readonly lifecycle: ComputeJobLifecycle
 
   // Harvest concurrency state (design §3):
   //   inFlightHarvests: jobIds whose harvest is currently running — prevents duplicate dispatches
@@ -117,6 +120,7 @@ export class JobPoller {
     this.makeNonceFn = deps.makeNonce ?? (() => randomBytes(12).toString('hex') + '_')
     this.dispatchTracker = deps.dispatchTracker ?? sharedDispatchTracker
     this.harvestFn = deps.harvestFn
+    this.lifecycle = new ComputeJobLifecycle(deps.jobRepository, deps.onJobUpdated)
   }
 
   // Starts the poller. Polls once immediately (picks up jobs that were running before restart),
@@ -262,13 +266,9 @@ export class JobPoller {
     }
 
     for (const job of noHandle) {
-      const updated = await this.deps.jobRepository.update(job.job_id, {
-        status: 'error',
-        errorCode: 'dispatch_failed',
-        stderrTail: 'dispatch interrupted by restart',
-        finishedAt: new Date()
-      })
-      this.deps.onJobUpdated?.(updated)
+      const transition = await this.lifecycle.recoverInterruptedDispatch(job.job_id)
+      if (transition.kind === 'ignored') continue
+      const updated = transition.job
       // Emit compute_done notification for execution-error jobs (design §8: error is a final
       // resting state). Fire-and-forget: notification failure must not break the poller tick.
       if (this.deps.broadcast && this.deps.storageRoot) {
@@ -391,11 +391,8 @@ export class JobPoller {
   // Implements design.md §8 boundary 2: "host unreachable ≠ job failed".
   private async _recordPollError(jobs: ComputeJob[], message: string): Promise<void> {
     for (const job of jobs) {
-      const updated = await this.deps.jobRepository.update(job.job_id, {
-        lastPollError: message,
-        retryAfterUserAction: true
-      })
-      this.deps.onJobUpdated?.(updated)
+      if (job.status !== 'submitted' && job.status !== 'running') continue
+      await this.lifecycle.recordPollError(job.job_id, job.status, message)
     }
   }
 
@@ -471,6 +468,32 @@ export class JobPoller {
     },
     target: import('./ssh-runner').ResolvedSshTarget
   ): Promise<void> {
+    const previous = this.pollResultChains.get(job.job_id) ?? Promise.resolve()
+    const current = previous
+      .catch(() => undefined)
+      .then(() => this._applyPollResultExclusive(job, result, target))
+    this.pollResultChains.set(job.job_id, current)
+
+    try {
+      await current
+    } finally {
+      if (this.pollResultChains.get(job.job_id) === current) {
+        this.pollResultChains.delete(job.job_id)
+      }
+    }
+  }
+
+  private async _applyPollResultExclusive(
+    job: ComputeJob,
+    result: {
+      alive: boolean
+      exitCode: number | null
+      hasExitCode: boolean
+      stdoutTail: string
+      stderrTail: string
+    },
+    target: import('./ssh-runner').ResolvedSshTarget
+  ): Promise<void> {
     const { alive, exitCode, hasExitCode, stdoutTail, stderrTail } = result
 
     // Terminal: exit_code file exists — this is authoritative.
@@ -503,18 +526,17 @@ export class JobPoller {
         errorCode = 'job_failed'
       }
 
-      const updated = await this.deps.jobRepository.update(job.job_id, {
+      const transition = await this.lifecycle.finishPolled(job.job_id, {
         status,
         exitCode,
         stdoutTail: stdoutTail || null,
         stderrTail: stderrTail || null,
-        errorCode: errorCode ?? null,
-        finishedAt: new Date()
+        errorCode: errorCode ?? null
       })
-      this.deps.onJobUpdated?.(updated)
+      if (transition.kind === 'ignored') return
       // Async-dispatch harvest for success/failed/timeout (design §3). Not awaited — must not
       // block the tick loop. 'error' status is never reached here (only in the noHandle path).
-      this._dispatchHarvest(updated)
+      this._dispatchHarvest(transition.job)
       return
     }
 
@@ -526,16 +548,14 @@ export class JobPoller {
 
       if (state.ticks >= PROCESS_VANISHED_TICKS) {
         this.vanishCounters.delete(job.job_id)
-        const updated = await this.deps.jobRepository.update(job.job_id, {
+        const transition = await this.lifecycle.finishPolled(job.job_id, {
           status: 'failed',
           errorCode: 'process_vanished',
           stdoutTail: stdoutTail || null,
-          stderrTail: stderrTail || null,
-          finishedAt: new Date()
+          stderrTail: stderrTail || null
         })
-        this.deps.onJobUpdated?.(updated)
         // process_vanished is a terminal state — dispatch harvest (design §3).
-        this._dispatchHarvest(updated)
+        if (transition.kind === 'applied') this._dispatchHarvest(transition.job)
       }
       // else: keep running, check again next tick
       return
@@ -551,7 +571,12 @@ export class JobPoller {
     if (startedAt) {
       const elapsedSecs = (Date.now() - startedAt) / 1000
       if (elapsedSecs >= timeoutSecs + POLLER_KILL_GRACE_SECONDS) {
-        const handle = this._parseHandle(job.remote_handle)
+        // Same-job poll results are serialized. Re-read after acquiring that chain so an earlier
+        // terminal result can suppress this stale destructive observation before any remote kill.
+        const current = await this.deps.jobRepository.get(job.job_id)
+        if (!current || (current.status !== 'submitted' && current.status !== 'running')) return
+
+        const handle = this._parseHandle(current.remote_handle)
         if (handle) {
           // Best-effort kill; ignore errors (process may have already exited).
           try {
@@ -568,40 +593,25 @@ export class JobPoller {
             // Ignore kill errors — the job is marked terminal regardless.
           }
         }
-        const updated = await this.deps.jobRepository.update(job.job_id, {
+        const transition = await this.lifecycle.finishPolled(job.job_id, {
           status: 'timeout',
           errorCode: 'timeout',
           stdoutTail: stdoutTail || null,
-          stderrTail: stderrTail || null,
-          finishedAt: new Date()
+          stderrTail: stderrTail || null
         })
-        this.deps.onJobUpdated?.(updated)
+        if (transition.kind === 'ignored') return
         // Poller-fallback timeout is a terminal state — dispatch harvest (design §3).
-        this._dispatchHarvest(updated)
+        this._dispatchHarvest(transition.job)
         return
       }
     }
 
-    if (job.status !== 'running') {
-      // Transition to running if still in submitted (shouldn't happen but guard).
-      // Clear any stale lastPollError: a successful poll proves connectivity is healthy again
-      // (schema.prisma: "Cleared on the next successful poll").
-      const updated = await this.deps.jobRepository.update(job.job_id, {
-        status: 'running',
-        stdoutTail: stdoutTail || null,
-        stderrTail: stderrTail || null,
-        lastPollError: null
-      })
-      this.deps.onJobUpdated?.(updated)
-    } else {
-      // Just update tails. Also clear any stale lastPollError now that this poll succeeded, so a
-      // transient SSH blip's error banner does not stick to a healthy running job forever.
-      const updated = await this.deps.jobRepository.update(job.job_id, {
-        stdoutTail: stdoutTail || null,
-        stderrTail: stderrTail || null,
-        lastPollError: null
-      })
-      this.deps.onJobUpdated?.(updated)
-    }
+    if (job.status !== 'submitted' && job.status !== 'running') return
+    // Transition a submitted-with-handle recovery to running, or refresh an existing running row.
+    // A successful poll also clears any stale connectivity projection.
+    await this.lifecycle.observeRunning(job.job_id, job.status, {
+      stdoutTail: stdoutTail || null,
+      stderrTail: stderrTail || null
+    })
   }
 }


### PR DESCRIPTION
## Problem

`JobPoller` persisted lifecycle status and active polling projections directly. Overlapping ticks could therefore race terminal observations, overwrite an already accepted terminal result, or run terminal side effects more than once. Fallback timeout handling also needs to retain the existing remote-kill ordering without allowing a stale observation to kill a process after another terminal result wins.

## Proposed change

- Add Poller-specific intents to `ComputeJobLifecycle` for interrupted dispatch recovery, terminal completion, active observations, and poll errors.
- Guard each write with the current expected active status and publish only an applied transition.
- Serialize only same-job poll-result application, then re-read fallback candidates before preserving the existing `kill -> CAS/publish -> harvest` order.
- Run harvesting and immediate error notification only after an applied lifecycle result.

```mermaid
sequenceDiagram
  participant Tick as Poll tick
  participant Chain as Same-job result chain
  participant Remote as Remote process
  participant Life as ComputeJobLifecycle
  participant Repo as JobRepository

  Tick->>Chain: enqueue observed result by job id
  Chain->>Repo: fresh-read current job
  alt current row is terminal
    Chain-->>Tick: ignore stale result
  else fallback timeout while active
    Chain->>Remote: best-effort kill
    Chain->>Life: finishPolled(timeout)
    Life->>Repo: CAS active -> timeout
    Repo-->>Life: applied or ignored
    Life-->>Tick: publish and harvest only if applied
  end
```

## Scope and non-goals

In scope: Poller status transitions, guarded active/error projections, same-job result ordering, and their focused tests.

Not in scope: Prisma schema or persisted status changes; cancellation/retry/scheduler states; queue/admission rules; SSH/SCP commands; timeout classification; polling interval/provider parallelism; harvest or notification payload redesign; generic arbitrary lifecycle APIs.

## Compatibility

- Keeps `ComputeService`, application-command, IPC, local-RPC, Electron, Web, and CLI interfaces unchanged.
- Keeps current status strings, field bundles, error codes, timestamps, tail handling, vanish thresholds, restart behavior, tracker behavior, and fallback command unchanged.
- Different jobs, providers, batches, SSH polls, and timer ticks remain concurrent; only result application for the same job is ordered.
- Production raw lines remain within the approved ceiling: lifecycle 104, Poller 617 (both <=660). Added lines: 453 (<=600).
- Test paths use `tmpdir()` and `join()` for Win/macOS/Linux portability.

## Acceptance criteria and validation

- [x] Every Poller status-bearing write routes through `ComputeJobLifecycle`.
- [x] Terminal rows reject late terminal, active, and poll-error projections without publication or side effects.
- [x] Fallback timeout preserves `fresh check -> kill -> CAS/publish -> harvest`.
- [x] Focused lifecycle/Poller tests: 2 files, 42 tests passed.
- [x] Compute Test Impact Set: 20 files passed, 1 skipped; 491 tests passed, 5 skipped.
- [x] `npm run typecheck:node` passed.
- [x] Full lint passed with 0 errors and 17 pre-existing warnings; changed files have no warnings.
- [x] Prettier and `git diff --check` passed.
- [x] Independent Standards and Spec reviews: P0/P1/P2 = 0/0/0.
- [ ] Exact-head CI/AI and CodeQL pass before squash merge.

## Review focus

- Confirm same-job serialization is narrow and cannot reduce cross-job/provider polling concurrency.
- Confirm stale terminal observations cannot kill, publish, harvest, or notify.
- Confirm fallback timeout retains the pre-refactor kill-before-persistence crash-recovery and capacity-release semantics.
- Confirm the lifecycle remains a state/atomic-write owner and does not absorb SSH or Poller orchestration behavior.
