### PR TITLE
fix(compute): certify job lifecycle ownership

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -179,6 +179,10 @@
         "src/main/compute/compute-job-lifecycle.ts",
         "src/main/compute/compute-job-workflow-owner.ts",
         "src/main/compute/compute-remote-operation-owner.ts",
+        "src/main/compute/concurrency-manager.ts",
+        "src/main/compute/job-dispatcher.ts",
+        "src/main/compute/job-poller.ts",
+        "src/main/compute/job-repository.ts",
         "src/main/compute/permission-grant-adapter.ts",
         "src/main/compute/compute-service.ts"
       ],
@@ -200,6 +204,7 @@
           "src/main/application-command-composition.test.ts",
           "src/main/compute/concurrency-manager.test.ts",
           "src/main/compute/job-dispatcher.test.ts",
+          "src/main/compute/job-poller.test.ts",
           "src/main/compute/scp-runner.test.ts",
           "src/main/compute/ssh-runner.test.ts",
           "src/main/compute/ipc.test.ts",

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -63,6 +63,35 @@ describe('module test impact commands', () => {
     )
   })
 
+  it.each([
+    'src/main/compute/compute-job-lifecycle.ts',
+    'src/main/compute/job-repository.ts',
+    'src/main/compute/concurrency-manager.ts',
+    'src/main/compute/job-dispatcher.ts',
+    'src/main/compute/job-poller.ts'
+  ])('routes Compute lifecycle changes through its complete certification set for %s', (path) => {
+    const affected = createAffectedTestPlan([{ path, status: 'modified' }], {
+      status: 'current',
+      testFiles: []
+    })
+
+    expect(affected.mode).toBe('selective')
+    expect(affected.modules).toEqual(['compute_service'])
+    expect(affected.testFiles).toEqual(
+      expect.arrayContaining([
+        'src/main/compute/compute-service.architecture.test.ts',
+        'src/main/compute/compute-job-lifecycle.test.ts',
+        'src/main/compute/concurrency-manager.test.ts',
+        'src/main/compute/job-dispatcher.test.ts',
+        'src/main/compute/job-poller.test.ts',
+        'src/main/compute/compute-jobs.integration.test.ts',
+        'src/main/compute/ipc.test.ts',
+        'src/main/compute/application-commands.test.ts',
+        'src/main/notebook/local-rpc-server.test.ts'
+      ])
+    )
+  })
+
   it('expands User Skill repository changes through Settings and cross-surface consumers', () => {
     const direct = createModuleTestPlan('user_skills_repository')
     expect(direct.testFiles).toEqual(

--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -38,6 +38,10 @@ const computePaths = {
   remoteOwner: resolve(mainRoot, 'compute/compute-remote-operation-owner.ts'),
   jobOwner: resolve(mainRoot, 'compute/compute-job-workflow-owner.ts'),
   jobLifecycle: resolve(mainRoot, 'compute/compute-job-lifecycle.ts'),
+  jobRepository: resolve(mainRoot, 'compute/job-repository.ts'),
+  concurrencyManager: resolve(mainRoot, 'compute/concurrency-manager.ts'),
+  jobDispatcher: resolve(mainRoot, 'compute/job-dispatcher.ts'),
+  jobPoller: resolve(mainRoot, 'compute/job-poller.ts'),
   ipc: resolve(mainRoot, 'compute/ipc.ts'),
   applicationCommands: resolve(mainRoot, 'compute/application-commands.ts'),
   jobRuntime: resolve(mainRoot, 'compute/job-runtime.ts'),
@@ -188,6 +192,13 @@ const privateOwnerPaths = [
   computePaths.remoteOwner,
   computePaths.jobOwner
 ] as const
+const lifecyclePaths = [
+  computePaths.jobLifecycle,
+  computePaths.jobRepository,
+  computePaths.concurrencyManager,
+  computePaths.jobDispatcher,
+  computePaths.jobPoller
+] as const
 const productionSourcePaths = productionSources()
 
 describe('Compute service architecture', () => {
@@ -199,8 +210,72 @@ describe('Compute service architecture', () => {
         portableProjectPath(ownerPath)
       ).toBeLessThanOrEqual(660)
     }
-    expect(rawLineCount(readSource(computePaths.jobLifecycle))).toBeLessThanOrEqual(660)
+    for (const lifecyclePath of lifecyclePaths) {
+      expect(
+        rawLineCount(readSource(lifecyclePath)),
+        portableProjectPath(lifecyclePath)
+      ).toBeLessThanOrEqual(660)
+    }
     expect(rawLineCount(readSource(computePaths.ipc))).toBeLessThanOrEqual(660)
+  })
+
+  it('keeps lifecycle state ownership behind the narrow intent interface', () => {
+    const lifecycle = sourceFileFor(computePaths.jobLifecycle).statements.find(
+      (statement) => isClassDeclaration(statement) && statement.name?.text === 'ComputeJobLifecycle'
+    )
+    expect(lifecycle && isClassDeclaration(lifecycle)).toBe(true)
+    if (!lifecycle || !isClassDeclaration(lifecycle)) return
+
+    const publicMethods = lifecycle.members
+      .flatMap((member) => {
+        if (
+          !isMethodDeclaration(member) ||
+          !isIdentifier(member.name) ||
+          getModifiers(member)?.some((modifier) => modifier.kind === SyntaxKind.PrivateKeyword) ===
+            true
+        ) {
+          return []
+        }
+        return [member.name.text]
+      })
+      .sort()
+    expect(publicMethods).toEqual(
+      [
+        'dispatchError',
+        'dispatchRunning',
+        'finishPolled',
+        'observeRunning',
+        'promoteQueued',
+        'recordPollError',
+        'recoverInterruptedDispatch'
+      ].sort()
+    )
+    expect(calledMembersOn(computePaths.jobLifecycle, ['this', 'repository'])).toEqual([
+      'updateIfStatus'
+    ])
+
+    const lifecycleTarget = modulePath(computePaths.jobLifecycle)
+    const importers = productionSourcePaths.flatMap((sourcePath) =>
+      importSpecifiersFrom(sourcePath).some(
+        (specifier) => resolveImportTarget(sourcePath, specifier) === lifecycleTarget
+      )
+        ? [portableProjectPath(sourcePath)]
+        : []
+    )
+    expect(importers).toEqual([
+      'src/main/compute/concurrency-manager.ts',
+      'src/main/compute/job-dispatcher.ts',
+      'src/main/compute/job-poller.ts'
+    ])
+
+    for (const calls of [
+      calledMembersOn(computePaths.concurrencyManager, ['this', 'jobRepository']),
+      calledMembersOn(computePaths.jobDispatcher, ['jobRepository']),
+      calledMembersOn(computePaths.jobPoller, ['this', 'deps', 'jobRepository'])
+    ]) {
+      expect(calls).not.toContain('update')
+      expect(calls).not.toContain('updateIfStatus')
+    }
   })
 
   it('keeps every private owner behind the public facade', () => {
@@ -356,6 +431,10 @@ describe('Compute service architecture', () => {
       'src/main/compute/compute-job-lifecycle.ts',
       'src/main/compute/compute-job-workflow-owner.ts',
       'src/main/compute/compute-remote-operation-owner.ts',
+      'src/main/compute/concurrency-manager.ts',
+      'src/main/compute/job-dispatcher.ts',
+      'src/main/compute/job-poller.ts',
+      'src/main/compute/job-repository.ts',
       'src/main/compute/permission-grant-adapter.ts',
       'src/main/compute/compute-service.ts'
     ])
@@ -378,7 +457,10 @@ describe('Compute service architecture', () => {
       expect.arrayContaining([
         'src/main/application-command-composition.test.ts',
         'src/main/compute/application-commands.test.ts',
+        'src/main/compute/concurrency-manager.test.ts',
         'src/main/compute/ipc.test.ts',
+        'src/main/compute/job-dispatcher.test.ts',
+        'src/main/compute/job-poller.test.ts',
         'src/main/notebook/local-rpc-server.mcpcall.test.ts',
         'src/main/notebook/local-rpc-server.test.ts'
       ])

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -519,6 +519,41 @@ describe('ConcurrencyManager', () => {
   })
 
   describe('onJobCompleted - dispatch error handling', () => {
+    it('does not overwrite a terminal job when a promoted dispatch fails late', async () => {
+      const queuedJob = {
+        job_id: 'job-1',
+        session_id: 'session-1',
+        provider_id: 'ssh:cluster-a',
+        created_at: 1000,
+        status: 'queued'
+      } as ComputeJob
+      const submittedJob = { ...queuedJob, status: 'submitted' as const }
+
+      vi.mocked(jobRepo.findQueuedJobs).mockResolvedValue([queuedJob])
+      vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(0)
+      vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(0)
+      vi.mocked(hostRepo.get).mockResolvedValue({ concurrencyLimit: 10 } as ComputeHost)
+      vi.mocked(jobRepo.updateIfStatus)
+        .mockResolvedValueOnce(submittedJob)
+        .mockResolvedValueOnce(null)
+      vi.mocked(jobRepo.update).mockResolvedValue({
+        ...submittedJob,
+        status: 'error'
+      } as ComputeJob)
+      vi.mocked(dispatchJob).mockRejectedValueOnce(new Error('late dispatch failure'))
+
+      await manager.onJobCompleted()
+
+      expect(jobRepo.updateIfStatus).toHaveBeenLastCalledWith(
+        'job-1',
+        ['submitted'],
+        expect.objectContaining({ status: 'error', errorCode: 'dispatch_failed' })
+      )
+      expect(jobRepo.update).not.toHaveBeenCalled()
+      expect(onJobUpdated).toHaveBeenCalledTimes(1)
+      expect(onJobUpdated).toHaveBeenCalledWith(submittedJob)
+    })
+
     it('marks job as error when dispatchJob throws', async () => {
       const queuedJobs: ComputeJob[] = [
         {
@@ -537,7 +572,9 @@ describe('ConcurrencyManager', () => {
         concurrencyLimit: 10
       } as ComputeHost)
       const failedJob = { ...queuedJobs[0], status: 'error' as const }
-      vi.mocked(jobRepo.update).mockResolvedValueOnce(failedJob)
+      vi.mocked(jobRepo.updateIfStatus)
+        .mockResolvedValueOnce({ ...queuedJobs[0], status: 'submitted' })
+        .mockResolvedValueOnce(failedJob)
 
       // Simulate dispatchJob failure
       vi.mocked(dispatchJob).mockRejectedValueOnce(new Error('SSH connection failed'))
@@ -545,7 +582,7 @@ describe('ConcurrencyManager', () => {
       await manager.onJobCompleted()
 
       // Then mark as error after dispatch fails
-      expect(jobRepo.update).toHaveBeenCalledWith('job-1', {
+      expect(jobRepo.updateIfStatus).toHaveBeenLastCalledWith('job-1', ['submitted'], {
         status: 'error',
         errorCode: 'dispatch_failed',
         finishedAt: expect.any(Date)
@@ -577,7 +614,6 @@ describe('ConcurrencyManager', () => {
       vi.mocked(hostRepo.get).mockResolvedValue({
         concurrencyLimit: 10
       } as ComputeHost)
-      vi.mocked(jobRepo.update).mockResolvedValue({} as ComputeJob)
 
       // First job fails, second succeeds
       vi.mocked(dispatchJob)
@@ -587,7 +623,7 @@ describe('ConcurrencyManager', () => {
       await manager.onJobCompleted()
 
       // First job should be marked as error
-      expect(jobRepo.update).toHaveBeenCalledWith('job-1', {
+      expect(jobRepo.updateIfStatus).toHaveBeenCalledWith('job-1', ['submitted'], {
         status: 'error',
         errorCode: 'dispatch_failed',
         finishedAt: expect.any(Date)

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -215,12 +215,7 @@ export class ConcurrencyManager {
           await this.dispatchJob(job.job_id, this.handleJobUpdated)
         } catch {
           // If dispatch fails, mark job as error and continue to next queued job.
-          const updated = await this.jobRepository.update(job.job_id, {
-            status: 'error',
-            errorCode: 'dispatch_failed',
-            finishedAt: new Date()
-          })
-          this.handleJobUpdated(updated)
+          await this.lifecycle.dispatchError(job.job_id, { errorCode: 'dispatch_failed' })
         }
       }
     } finally {


### PR DESCRIPTION
## Problem

The staged Compute lifecycle cutover was behaviorally complete in Dispatcher and Poller, but two certification gaps remained:

- `ConcurrencyManager` still handled an unexpected dispatch rejection with an unconditional repository `error` write, so a late failure could overwrite an already accepted terminal result.
- Lifecycle participants and `job-poller.test.ts` were incomplete in the module-impact manifest, so changes to Repository, ConcurrencyManager, Dispatcher, or Poller fell back to an unknown-owner plan and the declared Compute module set omitted Poller coverage.

## Proposed change

- Route ConcurrencyManager's existing dispatch-failure fallback through `ComputeJobLifecycle.dispatchError`, preserving the same `dispatch_failed` field bundle while adding the established `submitted -> error` CAS.
- Certify the seven lifecycle intents, the three legal production importers, and the absence of direct lifecycle writes in ConcurrencyManager, Dispatcher, and Poller.
- Register Repository plus all lifecycle participants as Compute owners, add Poller tests, and prove each participant selects the complete Compute certification set.
- Extend the existing raw-line completion gate across the lifecycle cluster.

```mermaid
flowchart LR
  CM["ConcurrencyManager<br/>queue/admission"] --> L["ComputeJobLifecycle<br/>guarded transition + publish"]
  JD["JobDispatcher<br/>remote launch"] --> L
  JP["JobPoller<br/>remote observation"] --> L
  L --> R["JobRepository<br/>atomic expected-status write"]
  IPC["Electron / local Web / remote Web"] --> F["ComputeService facade"]
  RPC["Session local RPC"] --> F
```

## Scope and non-goals

In scope: the last ConcurrencyManager status-write cutover, lifecycle ownership/interface certification, impact routing, Poller test registration, and raw-line gates.

Not in scope: new lifecycle intents or statuses; Prisma/schema/data changes; queue/admission rules; SSH/SCP or polling behavior; harvest/notification behavior; public/shared interfaces; renderer/UI; IPC/RPC payloads; Electron/Web/CLI capability changes; CodeGraph configuration.

## Compatibility

- Preserves the current ConcurrencyManager, Dispatcher, Poller, Repository, and ComputeService interfaces.
- Preserves the existing `dispatch_failed` status, error code, timestamp, continuation to the next queued job, and applied-transition publication behavior.
- A stale late dispatch failure now becomes an ignored CAS instead of overwriting a terminal winner; this is the invariant established by CL1–CL3.
- Existing Electron/local-Web/remote-Web capability assertions and Session local-RPC facade operation inventory remain unchanged. CLI still has no direct Compute management interface.
- No schema, shared types, preload, renderer, IPC channel, RPC operation, or persisted status change.
- Raw production lines: Lifecycle 104, Repository 362, ConcurrencyManager 225, Dispatcher 279, Poller 617, facade 173, IPC 658; all are <=660.
- Paths use repository-relative forward slashes plus `resolve`/`relative`, preserving Win/macOS/Linux portability.

## Acceptance criteria and validation

- [x] Late dispatch failure cannot overwrite an already terminal job and does not publish twice.
- [x] Lifecycle interface remains seven intent methods and has exactly three production importers.
- [x] ConcurrencyManager, Dispatcher, and Poller do not call repository `update` or `updateIfStatus` for lifecycle state.
- [x] Lifecycle, Repository, ConcurrencyManager, Dispatcher, and Poller changes select `compute_service` and its complete certification set.
- [x] Focused architecture/impact/concurrency tests: 3 files, 64 tests passed.
- [x] Final Compute Test Impact Set: 21 files passed, 1 skipped; 525 tests passed, 5 skipped.
- [x] `npm run typecheck:node` passed after the last material edit.
- [x] `npm run lint` passed with 0 errors; 17 warnings are pre-existing on `main` and none are in changed files.
- [x] Changed-file Prettier and `git diff --check` passed after the last material edit.
- [x] Independent Standards and Spec reviews: P0/P1/P2 = 0/0/0.
- [ ] Exact-head full-fallback PR Gate, CI Integrity, CodeQL, platform lane, and AI review pass before squash merge.

Evidence mapping:

- late dispatch-failure CAS and continued queue processing -> `src/main/compute/concurrency-manager.test.ts` -> passed;
- ownership/interface/line/cross-surface contracts -> `src/main/compute/compute-service.architecture.test.ts` -> passed;
- deterministic impact routing -> `scripts/ci/module-test-impact.test.ts` -> passed;
- complete declared Compute behavior/contract/consumer set -> `npm run test:module -- compute_service` -> passed;
- affected Node process types -> `npm run typecheck:node` -> passed.

The complete portable suite and platform lanes were not duplicated locally. Because `ownerPaths` changes are a global validation input, the trusted exact-head PR Gate must select the full fallback and is authoritative for that remaining risk.

## Review focus

- Confirm the ConcurrencyManager fallback keeps its prior observable behavior while rejecting stale terminal overwrite.
- Confirm lifecycle remains a deep internal module for transition invariants and does not absorb queue, SSH, or polling orchestration.
- Confirm impact ownership includes every lifecycle participant and declared tests now include Poller coverage.
- Confirm the architecture contracts protect useful ownership/interface facts without binding private method counts or implementation layout.
- Confirm no Electron/Web/CLI, IPC/RPC, schema/data, or user-interaction boundary changed.
