### PR TITLE
feat(workspace): add session keyboard shortcuts

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -439,7 +439,9 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Workspace sidebar outer slot: `z-10 flex h-full w-[220px] min-w-0 shrink-0 flex-col`.
 - Workspace rail card: `m-2 mr-0 flex min-h-0 flex-1 flex-col rounded-lg bg-rail-card-bg shadow-card`.
 - Workspace brand title uses `text-text-000`; beta and section labels use `text-text-100`.
+- `Cmd+B` on macOS and `Ctrl+B` on Windows/Linux toggle the Workspace sidebar. At mobile widths, the same shortcut toggles the navigation drawer.
 - Sessions nav uses `aria-label="Sessions"` and a scroll body `min-h-0 flex-1 overflow-y-auto py-1`.
+- Holding `Cmd` on macOS or `Ctrl` on Windows/Linux reveals numbered shortcut pills beside the first nine Sessions in their current visual order. `Cmd+1`–`Cmd+9` or `Ctrl+1`–`Ctrl+9` opens the matching Session; modal dialogs and modified Alt/Shift chords retain priority.
 - Session row wrapper owns hover/active visuals only: `group mx-1.5 rounded-md px-2.5 py-1.5 text-sm text-text-000 hover:bg-bg-300 select-none`; active adds `bg-bg-300`.
 - Session title button is the row click target: `flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left`.
 - Session status dots are decorative and `aria-hidden`; provide adjacent `sr-only` text such as `Session status: Running`.

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -278,6 +278,7 @@ describe('WorkspacePage preview panel resize sync', () => {
       dispatchEvent: vi.fn()
     }))
     window.api = {
+      platform: 'linux',
       notebook: {
         onAvailable: vi.fn(() => vi.fn()),
         getReference: vi.fn(() => Promise.resolve(null))
@@ -354,6 +355,7 @@ describe('WorkspacePage preview panel resize sync', () => {
 
     expect(toggleButton.getAttribute('aria-expanded')).toBe('true')
     expect(toggleButton.getAttribute('aria-controls')).toBe('left-panel')
+    expect(toggleButton.getAttribute('aria-keyshortcuts')).toBe('Control+B')
     expect(sidebarPanel?.contains(toggleButton)).toBe(false)
     expect(toggleButton.className).toContain('absolute')
     expect(toggleButton.className.split(' ')).toContain('top-0')
@@ -365,6 +367,85 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(toggleButton.className).not.toContain('bg-primary/20')
     expect(toggleButton.style.left).not.toBe('0px')
     expect(resizeHandle?.className).toContain('transition-opacity')
+  })
+
+  it.each([
+    { platform: 'darwin', modifier: { metaKey: true }, wrongModifier: { ctrlKey: true } },
+    { platform: 'win32', modifier: { ctrlKey: true }, wrongModifier: { metaKey: true } },
+    { platform: 'linux', modifier: { ctrlKey: true }, wrongModifier: { metaKey: true } }
+  ])(
+    'toggles the desktop sidebar with the platform shortcut on $platform',
+    async ({ platform, modifier, wrongModifier }) => {
+      window.api.platform = platform
+      await renderPage()
+
+      const toggleButton = getSidebarToggle()
+      expect(toggleButton.getAttribute('aria-keyshortcuts')).toBe(
+        platform === 'darwin' ? 'Meta+B' : 'Control+B'
+      )
+
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+
+      await act(async () => {
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'b',
+            ...wrongModifier,
+            bubbles: true,
+            cancelable: true
+          })
+        )
+      })
+      expect(toggleButton.getAttribute('aria-expanded')).toBe('true')
+
+      const collapseEvent = new KeyboardEvent('keydown', {
+        key: 'b',
+        ...modifier,
+        bubbles: true,
+        cancelable: true
+      })
+      await act(async () => window.dispatchEvent(collapseEvent))
+      expect(collapseEvent.defaultPrevented).toBe(true)
+      expect(toggleButton.getAttribute('aria-expanded')).toBe('false')
+
+      await act(async () => {
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'b',
+            ...modifier,
+            bubbles: true,
+            cancelable: true
+          })
+        )
+      })
+      expect(toggleButton.getAttribute('aria-expanded')).toBe('true')
+      input.remove()
+    }
+  )
+
+  it('leaves the sidebar unchanged while a modal dialog is open', async () => {
+    await renderPage()
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    document.body.appendChild(dialog)
+
+    try {
+      await act(async () => {
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'b',
+            ctrlKey: true,
+            bubbles: true,
+            cancelable: true
+          })
+        )
+      })
+      expect(getSidebarToggle().getAttribute('aria-expanded')).toBe('true')
+    } finally {
+      dialog.remove()
+    }
   })
 
   // Right preview edge keeps the always-on divider from main; left stays tick-on-hover only.
@@ -585,6 +666,30 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(
       container.querySelector('[data-testid="mobile-preview-sheet"]')?.getAttribute('data-open')
     ).toBe('true')
+  })
+
+  it('toggles the mobile navigation drawer with Ctrl+B', async () => {
+    workspacePageHarness.isMobile = true
+    await renderPage()
+
+    const toggleFromKeyboard = async (): Promise<void> => {
+      await act(async () => {
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'b',
+            ctrlKey: true,
+            bubbles: true,
+            cancelable: true
+          })
+        )
+      })
+    }
+
+    expect(container.querySelector('aside')?.getAttribute('data-mobile-open')).toBe('false')
+    await toggleFromKeyboard()
+    expect(container.querySelector('aside')?.getAttribute('data-mobile-open')).toBe('true')
+    await toggleFromKeyboard()
+    expect(container.querySelector('aside')?.getAttribute('data-mobile-open')).toBe('false')
   })
 
   it('closes the mobile navigation drawer from Escape and the overlay', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -467,6 +467,126 @@ describe('WorkspaceSidebar accessible render', () => {
     }
   })
 
+  it.each([
+    {
+      platform: 'darwin',
+      modifierKey: 'Meta',
+      modifier: { metaKey: true },
+      hint: '⌘1',
+      ariaShortcut: 'Meta+1'
+    },
+    {
+      platform: 'win32',
+      modifierKey: 'Control',
+      modifier: { ctrlKey: true },
+      hint: 'Ctrl+1',
+      ariaShortcut: 'Control+1'
+    },
+    {
+      platform: 'linux',
+      modifierKey: 'Control',
+      modifier: { ctrlKey: true },
+      hint: 'Ctrl+1',
+      ariaShortcut: 'Control+1'
+    }
+  ])(
+    'shows and handles the first nine session shortcuts on $platform',
+    async ({ platform, modifierKey, modifier, hint, ariaShortcut }) => {
+      const originalApi = window.api
+      window.api = { ...originalApi, platform } as never
+      const sessions = [
+        createSession({ id: 'active-first', title: 'Active first' }),
+        createSession({ id: 'pinned-target', title: 'Pinned target', pinned: true }),
+        ...Array.from({ length: 8 }, (_, index) =>
+          createSession({ id: `active-${index + 2}`, title: `Active ${index + 2}` })
+        )
+      ]
+      const onOpenSession = vi.fn()
+      const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+      const container = document.createElement('div')
+      const root = createRoot(container)
+      let dialog: HTMLDivElement | undefined
+
+      try {
+        await act(async () => {
+          root.render(
+            <WorkspaceSidebar
+              projectName="Example project"
+              sessions={sessions}
+              activeSessionId={undefined}
+              canCreateConversation
+              canMutateConversations
+              canDeleteConversations
+              onGoHome={vi.fn()}
+              onNewConversation={vi.fn()}
+              isFilesOpen={false}
+              onOpenFiles={vi.fn()}
+              onOpenSession={onOpenSession}
+              onRenameSession={vi.fn()}
+              canDownloadArtifacts
+              onDownloadArtifacts={vi.fn()}
+              onViewNotebook={vi.fn()}
+              onExportSession={vi.fn()}
+              onTogglePin={vi.fn()}
+              onDeleteSession={vi.fn()}
+              onOpenSettings={vi.fn()}
+            />
+          )
+        })
+
+        const shortcutButtons = container.querySelectorAll<HTMLButtonElement>(
+          'button[aria-keyshortcuts]'
+        )
+        expect(shortcutButtons).toHaveLength(9)
+        expect(shortcutButtons[0]?.textContent).toContain('Pinned target')
+        expect(shortcutButtons[0]?.getAttribute('aria-keyshortcuts')).toBe(ariaShortcut)
+
+        await act(async () => {
+          window.dispatchEvent(
+            new KeyboardEvent('keydown', { key: modifierKey, ...modifier, bubbles: true })
+          )
+        })
+        expect(container.querySelectorAll('kbd')).toHaveLength(9)
+        expect(container.textContent).toContain(hint)
+
+        const openEvent = new KeyboardEvent('keydown', {
+          key: '1',
+          ...modifier,
+          bubbles: true,
+          cancelable: true
+        })
+        await act(async () => window.dispatchEvent(openEvent))
+        expect(openEvent.defaultPrevented).toBe(true)
+        expect(onOpenSession).toHaveBeenCalledWith('pinned-target')
+
+        await act(async () => {
+          window.dispatchEvent(new KeyboardEvent('keyup', { key: modifierKey, bubbles: true }))
+        })
+        expect(container.querySelector('kbd')).toBeNull()
+
+        onOpenSession.mockClear()
+        dialog = document.createElement('div')
+        dialog.setAttribute('role', 'dialog')
+        document.body.appendChild(dialog)
+        await act(async () => {
+          window.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: '2',
+              ...modifier,
+              bubbles: true,
+              cancelable: true
+            })
+          )
+        })
+        expect(onOpenSession).not.toHaveBeenCalled()
+      } finally {
+        dialog?.remove()
+        act(() => root.unmount())
+        window.api = originalApi
+      }
+    }
+  )
+
   it('shows Pin for an unpinned session and Unpin for a pinned one, wired to the session', async () => {
     const { WorkspaceSidebarView } = await import('./WorkspaceSidebar')
     const sessions = [

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -65,6 +65,7 @@ type WorkspaceSidebarProps = {
 
 type WorkspaceSidebarViewProps = WorkspaceSidebarProps & {
   now: number
+  showSessionShortcuts?: boolean
 }
 
 // Maps each session status to the left-side indicator dot using emitted theme colors.
@@ -87,6 +88,8 @@ const sessionStatusLabel: Record<SessionStatus, string> = {
 }
 
 const ACTIVE_SESSION_GRACE_MS = 15 * 60_000
+const OPEN_DIALOG_SELECTOR =
+  '[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"])'
 
 const isLiveSessionStatus = (status: SessionStatus): boolean =>
   status === 'running' ||
@@ -201,9 +204,17 @@ const WorkspaceSidebarView = ({
   mobileMode = false,
   isMobileOpen = false,
   onMobileClose,
-  now
+  now,
+  showSessionShortcuts = false
 }: WorkspaceSidebarViewProps): React.JSX.Element => {
   const sections = getSessionSections(sessions, now)
+  const shortcutNumberBySessionId = new Map(
+    sections
+      .flatMap((section) => section.items)
+      .slice(0, 9)
+      .map((session, index) => [session.id, index + 1])
+  )
+  const isMac = window.api?.platform === 'darwin'
 
   return (
     <aside
@@ -325,6 +336,7 @@ const WorkspaceSidebarView = ({
                 </div>
                 {section.items.map((session) => {
                   const isActive = session.id === activeSessionId
+                  const shortcutNumber = shortcutNumberBySessionId.get(session.id)
                   const isExportDisabled =
                     session.messages.length === 0 ||
                     session.status === 'running' ||
@@ -342,6 +354,11 @@ const WorkspaceSidebarView = ({
                           type="button"
                           className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
                           aria-current={isActive ? 'page' : undefined}
+                          aria-keyshortcuts={
+                            shortcutNumber
+                              ? `${isMac ? 'Meta' : 'Control'}+${shortcutNumber}`
+                              : undefined
+                          }
                           onClick={() => onOpenSession(session.id)}
                         >
                           <span
@@ -359,6 +376,14 @@ const WorkspaceSidebarView = ({
                             Session status: {sessionStatusLabel[session.status]}
                           </span>
                           <span className="min-w-0 flex-1 truncate">{session.title}</span>
+                          {showSessionShortcuts && shortcutNumber ? (
+                            <kbd
+                              aria-hidden="true"
+                              className="shrink-0 rounded-full bg-bg-300 px-1.5 py-0.5 font-sans text-[11px] font-medium leading-none tabular-nums text-text-100"
+                            >
+                              {isMac ? `⌘${shortcutNumber}` : `Ctrl+${shortcutNumber}`}
+                            </kbd>
+                          ) : null}
                         </button>
 
                         <DropdownMenu>
@@ -540,8 +565,11 @@ const WorkspaceSidebarView = ({
 }
 
 const WorkspaceSidebar = (props: WorkspaceSidebarProps): React.JSX.Element => {
+  const { onOpenSession, sessions } = props
   const [now, setNow] = useState(Date.now)
-  const nextSectionRefreshAt = getNextSessionSectionRefreshAt(props.sessions, now)
+  const [showSessionShortcuts, setShowSessionShortcuts] = useState(false)
+  const nextSectionRefreshAt = getNextSessionSectionRefreshAt(sessions, now)
+  const isMac = window.api?.platform === 'darwin'
 
   // Reclassify recent completions at 15 minutes and date groups at local midnight without waiting
   // for unrelated Session activity to trigger a render.
@@ -553,7 +581,58 @@ const WorkspaceSidebar = (props: WorkspaceSidebarProps): React.JSX.Element => {
     return () => window.clearTimeout(timeoutId)
   }, [nextSectionRefreshAt])
 
-  return <WorkspaceSidebarView {...props} now={now} />
+  useEffect(() => {
+    const primaryModifierKey = isMac ? 'Meta' : 'Control'
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === primaryModifierKey) {
+        if (!event.repeat && document.querySelector(OPEN_DIALOG_SELECTOR) === null) {
+          setShowSessionShortcuts(true)
+        }
+        return
+      }
+
+      if (
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.repeat ||
+        event.altKey ||
+        event.shiftKey ||
+        !(isMac ? event.metaKey : event.ctrlKey) ||
+        document.querySelector(OPEN_DIALOG_SELECTOR) !== null
+      ) {
+        return
+      }
+
+      const shortcutNumber = Number(event.key)
+      if (!Number.isInteger(shortcutNumber) || shortcutNumber < 1 || shortcutNumber > 9) return
+
+      const session = getSessionSections(sessions, now)
+        .flatMap((section) => section.items)
+        .at(shortcutNumber - 1)
+      if (!session) return
+
+      event.preventDefault()
+      onOpenSession(session.id)
+    }
+
+    const handleKeyUp = (event: KeyboardEvent): void => {
+      if (event.key === primaryModifierKey) setShowSessionShortcuts(false)
+    }
+
+    const hideSessionShortcuts = (): void => setShowSessionShortcuts(false)
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+    window.addEventListener('blur', hideSessionShortcuts)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', hideSessionShortcuts)
+    }
+  }, [isMac, now, onOpenSession, sessions])
+
+  return <WorkspaceSidebarView {...props} now={now} showSessionShortcuts={showSessionShortcuts} />
 }
 
 export { WorkspaceSidebar }

--- a/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
+++ b/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
@@ -21,6 +21,8 @@ const SIDEBAR_TOGGLE_RIGHT_INSET = 38
 const PREVIEW_PANEL_DEFAULT_SIZE = 40
 const PREVIEW_PANEL_DEFAULT_SIZE_CSS = `${PREVIEW_PANEL_DEFAULT_SIZE}%`
 const PREVIEW_PANEL_MIN_OPEN_SIZE = 30
+const OPEN_DIALOG_SELECTOR =
+  '[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"])'
 
 const panelAnimation = {
   duration: 0.22,
@@ -252,6 +254,10 @@ const useWorkspacePanelLayout = (previewPort: PreviewPanelLayoutPort): Workspace
 
   const openMobileSidebar = useCallback((): void => setIsMobileSidebarOpen(true), [])
   const closeMobileSidebar = useCallback((): void => setIsMobileSidebarOpen(false), [])
+  const toggleMobileSidebar = useCallback(
+    (): void => setIsMobileSidebarOpen((isOpen) => !isOpen),
+    []
+  )
   const toggleSidebar = useCallback(
     (): void => setSidebarState((state) => (state === 'collapsed' ? 'open' : 'collapsed')),
     []
@@ -292,6 +298,31 @@ const useWorkspacePanelLayout = (previewPort: PreviewPanelLayoutPort): Workspace
     return () => window.removeEventListener('keydown', closeOnEscape)
   }, [closeMobileSidebar, isMobile, isMobileSidebarOpen])
 
+  useEffect(() => {
+    const toggleSidebarFromShortcut = (event: KeyboardEvent): void => {
+      const isMac = window.api?.platform === 'darwin'
+      if (
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.repeat ||
+        event.key.toLowerCase() !== 'b' ||
+        !(isMac ? event.metaKey : event.ctrlKey) ||
+        event.altKey ||
+        event.shiftKey ||
+        document.querySelector(OPEN_DIALOG_SELECTOR) !== null
+      ) {
+        return
+      }
+
+      event.preventDefault()
+      if (isMobile) toggleMobileSidebar()
+      else toggleSidebar()
+    }
+
+    window.addEventListener('keydown', toggleSidebarFromShortcut)
+    return () => window.removeEventListener('keydown', toggleSidebarFromShortcut)
+  }, [isMobile, toggleMobileSidebar, toggleSidebar])
+
   return {
     isMobile,
     mobileSidebar: {
@@ -317,6 +348,7 @@ const useWorkspacePanelLayout = (previewPort: PreviewPanelLayoutPort): Workspace
           }
           aria-expanded={sidebarState !== 'collapsed'}
           aria-controls="left-panel"
+          aria-keyshortcuts={window.api?.platform === 'darwin' ? 'Meta+B' : 'Control+B'}
           title={sidebarState === 'collapsed' ? 'Expand sidebar panel' : 'Collapse sidebar panel'}
           onClick={toggleSidebar}
         >


### PR DESCRIPTION
## Problem

The Workspace session sidebar could only be expanded, collapsed, and navigated with pointer controls. Frequent session switching required moving away from the keyboard, and the available session shortcuts were not discoverable.

## Proposed change

- Toggle the existing desktop sidebar with Cmd+B on macOS and Ctrl+B on Windows/Linux, preserving its current animation and last open width.
- Toggle the mobile navigation drawer with the same platform shortcut.
- Reveal numbered pills for the first nine Sessions while the platform modifier is held.
- Open Sessions 1–9 in their current visual order with Cmd+1–9 or Ctrl+1–9.
- Expose the shortcuts through aria-keyshortcuts and defer to modal dialogs, IME composition, repeated events, and Alt/Shift chords.

## Scope and non-goals

- Renderer-only Workspace interaction; no persistence, data model, ACP, or main-process behavior changes.
- No new dependency or shortcut configuration surface.
- Session numbering intentionally follows the existing Pinned, Active, Today, Yesterday, This week, and Older visual order and is limited to nine entries.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Sidebar toggle, mobile drawer toggle, modifier hints, visual-order mapping, modal priority, accessibility metadata, and macOS/Windows/Linux modifier behavior -> `npm run test:module -- workspace_page` -> 23 files and 345 tests passed.
- Cross-process TypeScript compatibility -> `npm run typecheck` -> Node and Web typechecks passed.
- Source and test linting -> `npm run lint` -> passed with 0 errors; 17 pre-existing warnings remain in untouched files.
- Portable regression suite -> `npm test -- --maxWorkers=4` -> 911 files and 13,106 tests passed; 14 files and 190 tests skipped by repository configuration.

The complete fallback was selected because WorkspaceSidebar.tsx is not directly mapped as an owner path in the module-impact manifest and the shared CodeGraph index does not match this independent worktree. No consumer or runtime path was excluded from the portable suite. Native macOS, Windows, and Linux UI lanes were not run locally; platform-specific keyboard events are covered in unit tests, and CI remains authoritative for native packaging lanes.

## Review focus

- Confirm that shortcut numbering matches the rendered Session order across groups.
- Confirm that keyboard handling stays global in the composer while yielding to modal and IME interactions.
- Confirm that the shortcut reuses the existing sidebar state owner rather than introducing a second layout state.
