### PR TITLE
fix(notifications): acknowledge visible session messages

### DIFF
--- a/src/main/notifications/notification-inbox-controller.test.ts
+++ b/src/main/notifications/notification-inbox-controller.test.ts
@@ -110,11 +110,12 @@ describe('createNotificationInboxController', () => {
     expect(onError).toHaveBeenCalledWith(error)
   })
 
-  it('records a focused visible task as read and leaves background tasks unread', async () => {
+  it('records focused visible session notifications as read and leaves background tasks unread', async () => {
     const record = vi
       .fn()
       .mockResolvedValueOnce({ changed: true, unreadCount: 0, latestSequence: 1 })
-      .mockResolvedValueOnce({ changed: true, unreadCount: 1, latestSequence: 2 })
+      .mockResolvedValueOnce({ changed: true, unreadCount: 0, latestSequence: 2 })
+      .mockResolvedValueOnce({ changed: true, unreadCount: 1, latestSequence: 3 })
     const db = repository({ record } as never)
     let focused = true
     const inbox = createNotificationInboxController({
@@ -138,6 +139,16 @@ describe('createNotificationInboxController', () => {
       title: 'Task completed',
       summary: 'Visible task finished.'
     })
+    await inbox.record({
+      dedupeKey: 'authorization:agent-tool:visible',
+      kind: 'authorization.required',
+      source: 'agent-tool',
+      sessionId: 'session-visible',
+      originId: 'visible-approval',
+      title: 'Approval needed',
+      summary: 'A visible task needs approval.',
+      actionState: 'pending'
+    })
     focused = false
     await inbox.record({
       dedupeKey: 'task:background',
@@ -149,7 +160,8 @@ describe('createNotificationInboxController', () => {
     })
 
     expect(record.mock.calls[0]?.[0]).toMatchObject({ readAt: 2000 })
-    expect(record.mock.calls[1]?.[0]).not.toHaveProperty('readAt')
+    expect(record.mock.calls[1]?.[0]).toMatchObject({ actionState: 'pending', readAt: 2000 })
+    expect(record.mock.calls[2]?.[0]).not.toHaveProperty('readAt')
   })
 
   it('uses the snapshot sequence when a client explicitly marks all read', async () => {
@@ -269,7 +281,7 @@ describe('createNotificationInboxController', () => {
     expect(settle).toHaveBeenCalledWith('input:agent-question:choice-1', 'resolved', 4500)
   })
 
-  it('auto-acknowledges only task outcomes when a conversation becomes visible', async () => {
+  it('auto-acknowledges all session notifications when a conversation becomes visible', async () => {
     const db = repository()
     const inbox = createNotificationInboxController({
       headless: false,
@@ -281,7 +293,7 @@ describe('createNotificationInboxController', () => {
 
     await inbox.syncViewState({ visibleSessionId: 'session-1' })
 
-    expect(db.markSessionTaskOutcomesRead).toHaveBeenCalledWith(['session-1'], 5000)
-    expect(db.markSessionsRead).not.toHaveBeenCalled()
+    expect(db.markSessionsRead).toHaveBeenCalledWith(['session-1'], 5000)
+    expect(db.markSessionTaskOutcomesRead).not.toHaveBeenCalled()
   })
 })

--- a/src/main/notifications/notification-inbox-controller.ts
+++ b/src/main/notifications/notification-inbox-controller.ts
@@ -4,7 +4,6 @@ import type {
   NotificationActionState,
   NotificationInboxChanged,
   NotificationInboxSnapshot,
-  NotificationKind,
   NotificationSource,
   UnreadTaskViewState
 } from '../../shared/notifications'
@@ -71,8 +70,6 @@ const authorizationDedupeKey = (source: NotificationSource, originId: string): s
   `authorization:${source}:${originId}`
 
 const agentQuestionDedupeKey = (originId: string): string => `input:agent-question:${originId}`
-
-const isTaskOutcome = (kind: NotificationKind): boolean => kind.startsWith('task.')
 
 export const createNotificationInboxController = (
   dependencies: NotificationInboxControllerDependencies
@@ -169,7 +166,7 @@ export const createNotificationInboxController = (
     if (sessionId && isSessionAvailable && !(await isSessionAvailable(sessionId))) return
 
     let readAt: number | undefined
-    if (sessionId && isTaskOutcome(input.kind) && isAppFocused()) {
+    if (sessionId && isAppFocused()) {
       const visible = await confirmVisibleSession(sessionId)
       if (isAppFocused() && visible) readAt = now()
     }
@@ -225,8 +222,8 @@ export const createNotificationInboxController = (
   const markSessionsRead = (sessionIds: readonly string[]): Promise<void> =>
     mutate(() => dependencies.repository.markSessionsRead(sessionIds, now()))
 
-  const markVisibleSessionTaskOutcomesRead = (sessionIds: readonly string[]): Promise<void> =>
-    mutate(() => dependencies.repository.markSessionTaskOutcomesRead(sessionIds, now()))
+  const markVisibleSessionNotificationsRead = (sessionIds: readonly string[]): Promise<void> =>
+    mutate(() => dependencies.repository.markSessionsRead(sessionIds, now()))
 
   const markSessionCompletionsRead = (sessionIds: readonly string[]): Promise<void> =>
     mutate(() => dependencies.repository.markSessionCompletionsRead(sessionIds, now()))
@@ -245,7 +242,7 @@ export const createNotificationInboxController = (
   const syncViewState = async (state: UnreadTaskViewState): Promise<void> => {
     visibleSessionId = state.visibleSessionId?.trim() || undefined
     if (isAppFocused() && visibleSessionId) {
-      await markVisibleSessionTaskOutcomesRead([visibleSessionId])
+      await markVisibleSessionNotificationsRead([visibleSessionId])
     } else refreshBadge()
   }
 
@@ -256,7 +253,7 @@ export const createNotificationInboxController = (
     }
     const candidate = visibleSessionId
     const visible = await confirmVisibleSession(candidate)
-    if (isAppFocused() && visible) await markVisibleSessionTaskOutcomesRead([candidate])
+    if (isAppFocused() && visible) await markVisibleSessionNotificationsRead([candidate])
     else refreshBadge()
   }
 


### PR DESCRIPTION
## Problem

Session visibility acknowledged only `task.*` inbox items. A pending authorization or other session-scoped message could therefore remain unread—and keep the Bell red dot active—even while the focused user was already viewing that conversation.

## Proposed change

- Mark every session-scoped inbox message read after the backend confirms that its conversation is visible in the focused app.
- Apply the same rule when a new message is recorded while that conversation is already visible.
- Keep authorization action state independent: viewing the conversation leaves `actionState: pending` intact until the user allows or denies it.

## Scope and non-goals

- No notification wire-contract, persistence-schema, renderer-layout, or ACP protocol changes.
- No change to approval resolution or permission routing.
- Background-session messages remain unread.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Session notification generation, focused/visible read projection, repository updates, and Bell red-dot consumption -> `npm test -- src/main/notifications/task-notifications.test.ts src/main/notifications/notification-inbox-controller.test.ts src/main/notifications/notification-inbox-repository.test.ts src/renderer/src/components/NotificationBell.test.tsx` -> 96 passed.
- Node and renderer type safety -> `npm run typecheck` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings outside the changed files.
- Full portable fallback -> `npm test` -> 13,114 passed; 6 unrelated tests failed under full-suite load (five timeouts and one UI timing assertion). Every failed case passed when rerun in isolation; the two architecture scans required `--test-timeout 60000` and completed in about 32 seconds.

Included paths: shared main-process notification read projection and its task/repository/Bell consumers. Excluded paths: ACP framework adapters (`claude-code`, `opencode`, `codex-response`, `codex-bridge`), models, and platform-specific delivery adapters because notification creation/protocol translation and native delivery were unchanged. No UI E2E was run; the Bell's `unreadCount` behavior is covered by its focused component test. Exact-head PR CI remains the final authority for the complete portable and platform suites.

## Review focus

Confirm that read state changes for a visible session while authorization action state remains pending.
