### PR TITLE
fix(workspace): align ask-user composer layout

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -526,6 +526,9 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
   height, remaining content scrolls inside the panel while the title banner and Allow/Deny action bar
   stay pinned to the panel top and bottom. Pressing the resize hit area changes only the visible
   handle, not the full hit-area background.
+- Ask-User elicitation uses the same content-bounded bottom resize behavior. While it owns the
+  composer lane, hide the Notebook, jobs, and Plan status chrome above it so the resize handle is the
+  panel's single top affordance. Restore that status chrome after the elicitation leaves the lane.
 - Textarea: `min-h-[36px] max-h-[200px] py-1.5 text-[15px] leading-relaxed text-text-000 placeholder:text-text-100`.
 - Toolbar action buttons are `h-8 w-8`; send uses `bg-primary text-primary-foreground hover:bg-primary/80`, cancel uses `bg-bg-200 text-text-000 hover:bg-bg-300`.
 - Read-only state: apply `opacity-50` to the input content and action area as a whole, but do not shrink the layout.

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -344,7 +344,7 @@ describe('ConversationPanel composer intake', () => {
     window.api = previousApi
   })
 
-  it('hides the ordinary composer while structured input is pending', () => {
+  it('shows structured input in a content-bounded lane without notebook chrome', () => {
     const fields = [
       {
         id: 'question_0',
@@ -389,8 +389,18 @@ describe('ConversationPanel composer intake', () => {
       updatedAt: 1
     }
 
+    mockAllJobs = [{ job_id: 'job-1', status: 'done', created_at: 1 }]
     renderPanel({
       activeSession,
+      notebookReference: {
+        sessionId: activeSession.id,
+        projectName: activeSession.projectId,
+        workspaceCwd: '/workspace',
+        notebookSessionRoot: '/notebook',
+        dataRoot: '/data',
+        runtimeRoot: '/runtime',
+        runJsonPath: '/notebook/run.json'
+      },
       pendingElicitations: [
         {
           requestId: 'elicitation-1',
@@ -422,6 +432,8 @@ describe('ConversationPanel composer intake', () => {
     expect(scrollSurface.classList.contains('border-border-200')).toBe(true)
     expect(scrollSurface.classList.contains('shadow-sm')).toBe(true)
     expect(scrollSurface.classList.contains('shadow-card-opaque')).toBe(false)
+    expect(container.querySelector('[aria-label="Open notebook"]')).toBeNull()
+    expect(container.querySelector('[data-testid="remote-job-badge"]')).toBeNull()
 
     const optionRows = container.querySelectorAll<HTMLElement>(
       '[data-elicitation-option-row="true"]'
@@ -449,11 +461,24 @@ describe('ConversationPanel composer intake', () => {
     act(() => {
       resizeHandle.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowUp' }))
     })
+    expect((elicitationComposer as HTMLElement).style.height).toBe('288px')
+
+    Object.defineProperties(scrollSurface, {
+      clientHeight: { configurable: true, value: 256 },
+      scrollHeight: { configurable: true, value: 400 }
+    })
+    act(() => {
+      resizeHandle.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowUp' }))
+    })
     expect((elicitationComposer as HTMLElement).style.height).toBe('320px')
 
     const originalInnerHeight = window.innerHeight
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 568 })
     ;(elicitationComposer as HTMLElement).getBoundingClientRect = () => ({ height: 300 }) as DOMRect
+    Object.defineProperties(scrollSurface, {
+      clientHeight: { configurable: true, value: 250 },
+      scrollHeight: { configurable: true, value: 500 }
+    })
     act(() => {
       resizeHandle.dispatchEvent(
         new MouseEvent('pointerdown', { bubbles: true, button: 0, clientY: 100 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -130,6 +130,7 @@ const ResizableElicitationComposer = ({ children }: React.PropsWithChildren): Re
     ariaLabel="Resize question panel"
     testId="elicitation-composer"
     scrollTestId="elicitation-composer-scroll"
+    constrainGrowthToOverflow
     minimumContentSelector='[data-elicitation-option-row="true"]'
     minimumContentIndex={1}
   >
@@ -647,6 +648,7 @@ const ConversationPanel = ({
                 {/* Switching between a compact job bar and Notebook chrome remounts this layer so a
                     Notebook that becomes available after jobs still receives its entrance animation. */}
                 {!sideChat &&
+                (!pendingElicitation || hasPendingPermission) &&
                 (notebookReference ||
                   hasAnyJobs ||
                   (activeBranchPlan ? isPlanProgressVisible(activeBranchPlan) : false)) ? (


### PR DESCRIPTION
## Problem

Ask-User owns the blocking composer lane, but the Notebook, jobs, or Plan status chrome can remain above it. The Ask-User panel can also grow to the viewport cap when its content already fits, creating empty space.

## Proposed change

- Hide the Notebook, jobs, and Plan status chrome only while Ask-User is the visible blocking interaction.
- Reuse the permission panel's existing content-overflow resize bound for Ask-User.
- Document the shared behavior and cover both chrome visibility and resize bounds in the composer interaction test.

## Scope and non-goals

- Renderer-only behavior; no ACP protocol, persistence, data model, or backend changes.
- Permission approval keeps precedence over a queued Ask-User request and retains its current layout.
- Side Chat and Plan interaction behavior are unchanged.
- Electron and Web use the same renderer path. No framework-, launcher-, model-, or platform-specific protocol path is affected.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Ask-User hides Notebook and jobs chrome while owning the lane -> `npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` -> 78/78 passed.
- Ask-User cannot grow without hidden overflow and can grow when overflow exists -> same targeted command -> 78/78 passed.
- Renderer and shared types -> `npm run typecheck` -> passed.
- Source lint -> `npm run lint` -> 0 errors; 17 existing warnings outside the changed files.
- Changed-file formatting -> `npm exec -- prettier --check docs/design.md src/renderer/src/pages/workspace/ConversationPanel.tsx src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` -> passed.
- Portable suite -> `npm test` -> 13,134 passed, 190 skipped, and 6 unrelated tests timed out under full parallel load. The four timed-out files were rerun with `--maxWorkers=1` -> 608/608 passed.
- Test-impact explanation -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> full mode because `docs/design.md` has no module owner; the full fallback above was executed.

No manual pixel-level Electron visual run was performed; CI remains authoritative for build, accessibility, workspace E2E, visual, and platform lanes.

## Review focus

- Confirm the status chrome is suppressed only when Ask-User is actually visible; a pending Permission request still wins the blocking lane.
- Confirm the existing overflow-based bound matches the intended Ask-User drag behavior without changing the shared resize implementation.
