### PR TITLE
fix(workspace): keep question progress visible

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
@@ -146,6 +146,27 @@ describe('WorkspaceElicitationCard choice question', () => {
     expect(
       container.querySelector('[data-testid="elicitation-question-progress"]')?.textContent
     ).toBe('1 of 2')
+    expect(
+      container
+        .querySelector('[data-testid="elicitation-question-progress"]')
+        ?.getAttribute('aria-label')
+    ).toBe('Question 1 of 2')
+    expect(
+      container
+        .querySelector('[data-testid="elicitation-question-progress"]')
+        ?.parentElement?.classList.contains('sticky')
+    ).toBe(true)
+    expect(
+      container
+        .querySelector('[data-testid="elicitation-question-progress"]')
+        ?.parentElement?.classList.contains('top-3')
+    ).toBe(true)
+    expect(container.querySelector('h3')?.classList.contains('pr-36')).toBe(true)
+    expect(
+      Array.from(
+        container.querySelectorAll('[data-testid="elicitation-question-progress-segment"]')
+      ).map((segment) => segment.getAttribute('data-state'))
+    ).toEqual(['current', 'upcoming'])
     expect(container.textContent).not.toContain('Which language should the skill use?')
 
     await act(async () => {
@@ -209,6 +230,16 @@ describe('WorkspaceElicitationCard choice question', () => {
     expect(
       container.querySelector('[data-testid="elicitation-question-progress"]')?.textContent
     ).toBe('2 of 2')
+    expect(
+      container
+        .querySelector('[data-testid="elicitation-question-progress"]')
+        ?.getAttribute('aria-label')
+    ).toBe('Question 2 of 2')
+    expect(
+      Array.from(
+        container.querySelectorAll('[data-testid="elicitation-question-progress-segment"]')
+      ).map((segment) => segment.getAttribute('data-state'))
+    ).toEqual(['upcoming', 'current'])
     expect(container.textContent).not.toContain('Finish')
 
     await act(async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
@@ -104,6 +104,19 @@ const multiQuestionRequest = {
   message: 'Please answer the following questions.'
 }
 
+const maximumQuestionFields = Array.from({ length: 8 }, (_, index) => [
+  {
+    ...fields[0],
+    id: `question_${index}`,
+    label: `Question ${index + 1}`,
+    description: `Prompt ${index + 1}`
+  },
+  {
+    ...fields[1],
+    id: `question_${index}_custom`
+  }
+]).flat()
+
 const mixedChoiceFields = [
   { ...multiQuestionFields[0], kind: 'multi-select' as const },
   ...multiQuestionFields.slice(1)
@@ -296,6 +309,31 @@ describe('WorkspaceElicitationCard choice question', () => {
         { fieldId: 'question_1', value: 'chinese' }
       ]
     })
+  })
+
+  it('keeps progress segments width-bounded at the maximum accepted question count', async () => {
+    await act(async () => {
+      root.render(
+        <WorkspaceElicitationCard
+          elicitation={{
+            message: multiQuestionRequest.message,
+            fields: maximumQuestionFields,
+            state: 'pending'
+          }}
+          request={{ ...multiQuestionRequest, fields: maximumQuestionFields }}
+        />
+      )
+    })
+
+    const segments = Array.from(
+      container.querySelectorAll('[data-testid="elicitation-question-progress-segment"]')
+    )
+    expect(segments).toHaveLength(8)
+    expect(segments[0]?.parentElement?.classList.contains('w-16')).toBe(true)
+    expect(segments.every((segment) => segment.classList.contains('flex-1'))).toBe(true)
+    expect(
+      container.querySelector('[data-testid="elicitation-question-progress"]')?.textContent
+    ).toBe('1 of 8')
   })
 
   it('resumes a pending multi-question choice at the first unanswered step', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
@@ -334,14 +334,14 @@ const WorkspaceElicitationCard = ({
             aria-label={`Question ${activeChoiceIndex + 1} of ${choiceQuestions.length}`}
             className="inline-flex shrink-0 items-center gap-3 bg-bg-000 pl-3 text-xs leading-5 text-text-300 tabular-nums"
           >
-            <span aria-hidden="true" className="flex items-center gap-1.5">
+            <span aria-hidden="true" className="flex w-16 items-center gap-0.5">
               {choiceQuestions.map((question, index) => (
                 <span
                   key={question.choiceField.id}
                   data-testid="elicitation-question-progress-segment"
                   data-state={index === activeChoiceIndex ? 'current' : 'upcoming'}
                   className={cn(
-                    'h-1 w-7 rounded-full',
+                    'h-1 min-w-0 flex-1 rounded-full',
                     index === activeChoiceIndex ? 'bg-text-000' : 'bg-bg-400'
                   )}
                 />

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
@@ -202,6 +202,12 @@ const WorkspaceElicitationCard = ({
     (elicitation.state === 'pending' || isReviewingChoice || choiceQuestions?.length === 1)
       ? choiceQuestion.choiceField.description || choiceQuestion.choiceField.label
       : undefined
+  const showChoiceProgress = Boolean(
+    choiceQuestions &&
+    choiceQuestions.length > 1 &&
+    !isPendingPlaceholder &&
+    (elicitation.state === 'pending' || isReviewingChoice)
+  )
 
   const respond = async (response: ElicitationResponse): Promise<boolean> => {
     if (!onRespond || isSubmitting) return false
@@ -320,21 +326,43 @@ const WorkspaceElicitationCard = ({
         </div>
       ) : null}
 
-      <div className="flex items-start justify-between gap-3">
-        <h3 className="min-w-0 flex-1 whitespace-pre-wrap break-words text-base font-semibold leading-6">
-          {choiceTitle ?? elicitation.message}
-        </h3>
-        {choiceQuestions &&
-        choiceQuestions.length > 1 &&
-        !isPendingPlaceholder &&
-        (elicitation.state === 'pending' || isReviewingChoice) ? (
+      {showChoiceProgress && choiceQuestions ? (
+        <div className="pointer-events-none sticky top-3 z-10 -mb-5 flex h-5 justify-end sm:top-4">
           <span
             data-testid="elicitation-question-progress"
-            className="shrink-0 pt-0.5 text-xs leading-5 text-text-300"
+            role="status"
+            aria-label={`Question ${activeChoiceIndex + 1} of ${choiceQuestions.length}`}
+            className="inline-flex shrink-0 items-center gap-3 bg-bg-000 pl-3 text-xs leading-5 text-text-300 tabular-nums"
           >
-            {activeChoiceIndex + 1} of {choiceQuestions.length}
+            <span aria-hidden="true" className="flex items-center gap-1.5">
+              {choiceQuestions.map((question, index) => (
+                <span
+                  key={question.choiceField.id}
+                  data-testid="elicitation-question-progress-segment"
+                  data-state={index === activeChoiceIndex ? 'current' : 'upcoming'}
+                  className={cn(
+                    'h-1 w-7 rounded-full',
+                    index === activeChoiceIndex ? 'bg-text-000' : 'bg-bg-400'
+                  )}
+                />
+              ))}
+            </span>
+            <span aria-hidden="true">
+              {activeChoiceIndex + 1} of {choiceQuestions.length}
+            </span>
           </span>
-        ) : null}
+        </div>
+      ) : null}
+
+      <div className="flex items-start">
+        <h3
+          className={cn(
+            'min-w-0 flex-1 whitespace-pre-wrap break-words text-base font-semibold leading-6',
+            showChoiceProgress && 'pr-36'
+          )}
+        >
+          {choiceTitle ?? elicitation.message}
+        </h3>
       </div>
 
       {isPendingPlaceholder ? (


### PR DESCRIPTION
## Problem

The multi-question Ask User card only showed numeric progress. On long questions, the progress cue could scroll out of view with the rest of the content.

## Proposed change

- Render one equal segment per question and highlight the current question.
- Constrain the segment row so every accepted question pair shares the available width without overflowing the header.
- Keep the upper-right progress indicator sticky inside the question composer's scroll surface while the question content scrolls.
- Preserve an accessible status label for the current question and total count.

## Scope and non-goals

- Changes are limited to the shared renderer component and its interaction tests.
- No ACP protocol, persistence, preload, main-process, or dependency changes.
- No changes to question navigation or answer state behavior.

## Acceptance criteria and validation

- Segmented progress identifies the current question and updates after navigation: covered by `WorkspaceElicitationCard.interaction.test.tsx`.
- Progress remains sticky while the composer content scrolls: covered by component structure assertions and the existing `ConversationPanel` interaction suite.
- Targeted tests: 2 files passed, 92 tests passed, including the maximum accepted 16-field / 8-question shape.
- `npm run typecheck`: passed for node and web.
- Full `npm test`: 13,133 tests passed and 8 unrelated tests hit default timeouts under concurrent load. All six affected files passed on focused reruns; the two persistently slow files passed 11/11 and 491/491 with a command-only `--testTimeout 120000` override.
- `npm run lint`: 0 errors; 17 pre-existing warnings in untouched files.
- `git diff --check`: passed.

All validation was run after the final material edit.

## Affected and excluded consumers

- Included: pending and answer-review states of `WorkspaceElicitationCard` in the `ConversationPanel` scroll surface.
- Excluded: ACP framework adapters, protocol state, persistence, main/preload processes, and platform-specific code.

## Uncovered risk

No live Electron visual regression snapshot was captured. Sticky positioning, reserved header width, accessibility text, and progress transitions are covered structurally and through interaction tests.

## Review focus

- Sticky positioning inside the existing scroll container.
- Progress width and title clearance across the resolver's accepted 2–8 question range.
