### PR TITLE
fix(workspace): hide status chrome for blocking composers

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -526,9 +526,9 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
   height, remaining content scrolls inside the panel while the title banner and Allow/Deny action bar
   stay pinned to the panel top and bottom. Pressing the resize hit area changes only the visible
   handle, not the full hit-area background.
-- Ask-User elicitation uses the same content-bounded bottom resize behavior. While it owns the
-  composer lane, hide the Notebook, jobs, and Plan status chrome above it so the resize handle is the
-  panel's single top affordance. Restore that status chrome after the elicitation leaves the lane.
+- Ask-User elicitation uses the same content-bounded bottom resize behavior. While Permission
+  approval, Ask-User elicitation, or Plan approval owns the composer lane, hide the Notebook, jobs,
+  and Plan status chrome above it. Restore that status chrome only with the ordinary composer.
 - Textarea: `min-h-[36px] max-h-[200px] py-1.5 text-[15px] leading-relaxed text-text-000 placeholder:text-text-100`.
 - Toolbar action buttons are `h-8 w-8`; send uses `bg-primary text-primary-foreground hover:bg-primary/80`, cancel uses `bg-bg-200 text-text-000 hover:bg-bg-300`.
 - Read-only state: apply `opacity-50` to the input content and action area as a whole, but do not shrink the layout.

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -529,7 +529,28 @@ describe('ConversationPanel composer intake', () => {
   })
 
   it('puts permission approval ahead of Ask-User in a content-bounded composer lane', () => {
+    const activeSession: ChatSession = {
+      id: 'session-existing',
+      projectId: 'project-a',
+      title: 'Permission request',
+      cwd: '/workspace',
+      status: 'waiting-permission',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    mockAllJobs = [{ job_id: 'job-1', status: 'done', created_at: 1 }]
     renderPanel({
+      activeSession,
+      notebookReference: {
+        sessionId: activeSession.id,
+        projectName: activeSession.projectId,
+        workspaceCwd: '/workspace',
+        notebookSessionRoot: '/notebook',
+        dataRoot: '/data',
+        runtimeRoot: '/runtime',
+        runJsonPath: '/notebook/run.json'
+      },
       pendingPermissions: [{ requestId: 'permission-1' } as never],
       pendingElicitations: [
         {
@@ -565,6 +586,8 @@ describe('ConversationPanel composer intake', () => {
     expect(resizeHandle.classList.contains('active:bg-bg-200')).toBe(false)
     expect(container.querySelector('[data-testid="permission-approval-controls"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="elicitation-composer"]')).toBeNull()
+    expect(container.querySelector('[aria-label="Open notebook"]')).toBeNull()
+    expect(container.querySelector('[data-testid="remote-job-badge"]')).toBeNull()
     expect(getComposerForm().hidden).toBe(true)
     expect(
       container
@@ -1562,11 +1585,26 @@ describe('ConversationPanel + menu', () => {
         lifecycle: 'awaiting_approval'
       }
     }
-    renderPanel({ activeSession: session, canEditDraft: false })
+    mockAllJobs = [{ job_id: 'job-1', status: 'done', created_at: 1 }]
+    renderPanel({
+      activeSession: session,
+      canEditDraft: false,
+      notebookReference: {
+        sessionId: session.id,
+        projectName: session.projectId,
+        workspaceCwd: '/workspace',
+        notebookSessionRoot: '/notebook',
+        dataRoot: '/data',
+        runtimeRoot: '/runtime',
+        runJsonPath: '/notebook/run.json'
+      }
+    })
 
     const pendingEditor = container.querySelector('[role="textbox"]')
     expect(pendingEditor?.closest('form')?.classList.contains('hidden')).toBe(true)
     expect(container.textContent).toContain('Plan ready for review')
+    expect(container.querySelector('[aria-label="Open notebook"]')).toBeNull()
+    expect(container.querySelector('[data-testid="remote-job-badge"]')).toBeNull()
     const pendingPlanCard = [...container.querySelectorAll('article')].find((article) =>
       article.textContent?.includes('Plan ready for review')
     )
@@ -1590,6 +1628,8 @@ describe('ConversationPanel + menu', () => {
     expect(
       container.querySelector('[role="textbox"]')?.closest('form')?.classList.contains('hidden')
     ).toBe(false)
+    expect(container.querySelector('[aria-label="Open notebook"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="remote-job-badge"]')).not.toBeNull()
 
     renderPanel({
       activeSession: {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -648,7 +648,9 @@ const ConversationPanel = ({
                 {/* Switching between a compact job bar and Notebook chrome remounts this layer so a
                     Notebook that becomes available after jobs still receives its entrance animation. */}
                 {!sideChat &&
-                (!pendingElicitation || hasPendingPermission) &&
+                !hasPendingPermission &&
+                !pendingElicitation &&
+                !pendingPlan &&
                 (notebookReference ||
                   hasAnyJobs ||
                   (activeBranchPlan ? isPlanProgressVisible(activeBranchPlan) : false)) ? (


### PR DESCRIPTION
## Problem

The Notebook, jobs, and Plan status chrome could remain visible above Permission approval and Plan approval, even though those blocking interactions replace the ordinary user composer.

## Proposed change

Gate the shared status chrome on the ordinary composer lane being available. Permission approval, Ask-User elicitation, Plan approval, and Side Chat now keep that chrome hidden; it returns when the ordinary composer returns. The Renderer design specification and existing ConversationPanel interaction coverage are updated with the same rule.

## Scope and non-goals

This is Renderer presentation logic only. It does not change ACP request/response shapes, permission decisions or grants, notebook/job state, Plan state, persistence, models, launchers, or platform behavior.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Blocking composer chrome visibility -> npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx -> 1 file passed, 78 tests passed.
- Workspace page consumers -> npm run test:module -- workspace_page -> 23 files passed, 345 tests passed.
- Node and Web types -> npm run typecheck -> passed.
- Source lint -> npm run lint -> passed with 0 errors and 17 pre-existing warnings outside the changed files.
- Full portable suite -> npm test -> 13,000 tests passed and 190 skipped; 5 unrelated tests timed out under full-suite resource pressure and 6 workers failed to start. Re-running all 11 affected files in isolation passed: 11 files, 202 tests.

Framework, launcher, model, and platform matrices are excluded because this diff changes only a React visibility condition and does not touch ACP protocol or runtime behavior. E2E and visual lanes were not run locally; the changed DOM behavior is asserted directly, and required CI remains authoritative.

## Review focus

Please verify that the status chrome is present only with the ordinary composer and returns immediately after a blocking interaction resolves.