### PR TITLE
feat(notebook): add host capability introspection

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -976,6 +976,35 @@ async function hostMcp(server, method, args = undefined, kwargs = undefined) {
   return body.result
 }
 
+const HOST_CAPABILITY_NAMES = ['mcp', 'compute', 'agents', 'skills']
+
+async function hostCapabilities(...args) {
+  if (args.length !== 0) throw new TypeError('host.capabilities accepts no arguments')
+  if (!RPC_ENDPOINT) throw new Error('host.capabilities is unavailable: RPC endpoint not set')
+  const res = await capturedRpcFetch(RPC_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
+    body: JSON.stringify({ method: 'capabilitiesCall', params: {} })
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok || body.error) {
+    throw new Error(body.error || 'host.capabilities HTTP ' + res.status)
+  }
+  const result = body.result
+  if (
+    !result ||
+    typeof result !== 'object' ||
+    Array.isArray(result) ||
+    Object.keys(result).length !== HOST_CAPABILITY_NAMES.length ||
+    HOST_CAPABILITY_NAMES.some((name) => typeof result[name] !== 'boolean')
+  ) {
+    throw new Error('host.capabilities returned an invalid capability projection')
+  }
+  return Object.freeze(
+    Object.fromEntries(HOST_CAPABILITY_NAMES.map((name) => [name, result[name]]))
+  )
+}
+
 // host.compute: async remote-compute calls over the SAME app-local RPC endpoint as host.mcp, routed to
 // the main-process ComputeService via {method:'computeCall'}. Like host.mcp, this is only injected in
 // the trusted control plane — the python/r data kernels have no host.compute, so SSH/approval always
@@ -1272,7 +1301,13 @@ const hostCompute = {
 
 // Persistent sandbox: user-declared globals persist across requests (assign to `globalThis`/bare).
 const sandbox = {
-  host: { mcp: hostMcp, compute: hostCompute, agents: hostAgents, skills: hostSkills },
+  host: {
+    capabilities: hostCapabilities,
+    mcp: hostMcp,
+    compute: hostCompute,
+    agents: hostAgents,
+    skills: hostSkills
+  },
   console,
   process,
   require,

--- a/resources/skills/manifest.json
+++ b/resources/skills/manifest.json
@@ -116,6 +116,13 @@
       "updatedAt": "2026-07-31T00:00:00.000Z"
     },
     {
+      "id": "self-awareness",
+      "name": "Self-awareness",
+      "source": "featured",
+      "exposure": "internal",
+      "updatedAt": "2026-08-10T00:00:00.000Z"
+    },
+    {
       "id": "skill-creator",
       "name": "Skill Creator",
       "source": "featured",

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: self-awareness
+description: Inspect Open Science's JavaScript control REPL and safely feature-gate host.* calls with host.capabilities(). Use when an Agent needs to discover which host namespaces are available, decide whether an optional host operation may be called, or understand where host APIs run.
+---
+
+# Self-awareness
+
+Use `repl_execute` for every `host.*` call. The `host` object exists only in the persistent
+JavaScript control REPL; Python and R data kernels do not receive it.
+
+## Inspect available capabilities
+
+```javascript
+const caps = await host.capabilities()
+```
+
+The v1 result contains exactly four boolean keys:
+
+- `mcp` gates `host.mcp` connector calls.
+- `compute` gates the `host.compute` namespace.
+- `agents` gates the `host.agents` namespace.
+- `skills` gates the `host.skills` namespace.
+
+Interpret the result narrowly:
+
+- `true` means the current session capability authorizes the namespace and the application has its
+  handler configured. It does not mean a resource exists, approval is unnecessary, or a call will
+  succeed.
+- `false` means the capability name is known but unavailable to this caller.
+- A missing key means this runtime does not know that capability. Test with `=== true`.
+
+```javascript
+const caps = await host.capabilities()
+if (caps.compute === true) {
+  const availableHosts = await host.compute.list()
+}
+```
+
+Do not infer capabilities by reflecting over `host`, and do not treat this result as a resource,
+credential, permission, or readiness inventory. Call it again when current availability matters; each
+call returns a fresh frozen projection.
+
+## Continue with the owning Skill
+
+- Load the matching `mcp-*` Skill before using a connector through `host.mcp`.
+- Load `remote-compute-ssh` for the `host.compute` API and workflow.
+- Load `customize` for Specialist and Skill authoring workflows.
+
+## Maintain this contract
+
+When a new host introspection surface ships, add its public capability key and update this Skill in
+the same feature change. Document only behavior that has shipped; do not predeclare future APIs as
+`false`.

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -662,6 +662,7 @@ describe('ACP session capability owner', () => {
       'open-science-skills'
     ])
     expect(primary.descriptor.controlRpcMethods).toEqual([
+      'capabilitiesCall',
       'mcpCall',
       'computeCall',
       'agentsCall',
@@ -676,6 +677,29 @@ describe('ACP session capability owner', () => {
       policyAllowsSessionCapability(CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY, 'future-delegation')
     ).toBe(false)
   })
+
+  it.each([
+    ['claude-code', claudeCodeFramework, true, false],
+    ['opencode', opencodeFramework, true, false],
+    ['codex-response', codexFramework, true, false],
+    ['codex-bridge', codexFramework, false, true]
+  ] as const)(
+    'publishes capabilitiesCall through the %s primary control descriptor',
+    async (_route, framework, nativeMcpEnabled, bridgeMcpAliasesEnabled) => {
+      const owner = createOwner()
+      const built = await owner.provision({
+        stableAppSessionId: 'session-1',
+        framework,
+        nativeMcpEnabled,
+        bridgeMcpAliasesEnabled,
+        policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+        sessionCwd: '/workspace',
+        projectName: 'project'
+      })
+
+      expect(built.descriptor.controlRpcMethods).toContain('capabilitiesCall')
+    }
+  )
 
   it('returns an immutable, credential-free descriptor', async () => {
     const owner = createOwner()

--- a/src/main/acp/session-capability-owner.ts
+++ b/src/main/acp/session-capability-owner.ts
@@ -44,7 +44,13 @@ const CURRENT_PRIMARY_CAPABILITIES = [
   'host-skills',
   'host-message'
 ] as const
-const NOTEBOOK_CONTROL_RPC_METHODS = ['mcpCall', 'computeCall', 'agentsCall', 'skillsCall'] as const
+const NOTEBOOK_CONTROL_RPC_METHODS = [
+  'capabilitiesCall',
+  'mcpCall',
+  'computeCall',
+  'agentsCall',
+  'skillsCall'
+] as const
 
 export type SessionCapabilityName = (typeof CURRENT_PRIMARY_CAPABILITIES)[number]
 

--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { NotebookLocalRpcServer } from './local-rpc-server'
+
+type RpcConnection = {
+  endpoint: string
+  token: string
+}
+
+const callCapabilities = async (
+  connection: RpcConnection,
+  token = connection.token,
+  params: Record<string, unknown> = {}
+): Promise<{ response: Response; payload: Record<string, unknown> }> => {
+  const response = await fetch(connection.endpoint, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ method: 'capabilitiesCall', params })
+  })
+  return {
+    response,
+    payload: (await response.json()) as Record<string, unknown>
+  }
+}
+
+let server: NotebookLocalRpcServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+describe('capabilitiesCall RPC', () => {
+  it('projects the exact configured host namespace bitmap from a control capability', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      connectorService: {} as never,
+      computeService: {} as never,
+      agentsService: {} as never,
+      skillsService: {} as never
+    })
+    const connection = await server.issueControlConnection('trusted-session', 'trusted-project')
+
+    const { response, payload } = await callCapabilities(connection, connection.token, {
+      sessionId: 'forged-session',
+      projectId: 'forged-project',
+      mcp: false
+    })
+
+    expect(response.status).toBe(200)
+    expect(payload).toEqual({
+      result: { mcp: true, compute: true, agents: true, skills: true }
+    })
+  })
+
+  it('returns false for known namespaces whose server handler is not configured', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      connectorService: {} as never
+    })
+    const connection = await server.issueControlConnection('trusted-session', 'trusted-project')
+
+    await expect(callCapabilities(connection)).resolves.toMatchObject({
+      payload: {
+        result: { mcp: true, compute: false, agents: false, skills: false }
+      }
+    })
+  })
+
+  it('rejects bootstrap, invalid, and released tokens instead of returning an all-false bitmap', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp'
+    })
+    const bootstrap = await server.ensureStarted()
+    const control = await server.issueControlConnection('trusted-session', 'trusted-project')
+
+    const bootstrapAttempt = await callCapabilities(control, bootstrap.token)
+    expect(bootstrapAttempt.response.status).toBe(401)
+    expect(bootstrapAttempt.payload).toEqual({
+      error: 'A session-bound notebook RPC token is required.'
+    })
+
+    const invalidAttempt = await callCapabilities(control, 'invalid-token')
+    expect(invalidAttempt.response.status).toBe(401)
+    expect(invalidAttempt.payload).toEqual({ error: 'Invalid notebook RPC token.' })
+
+    control.release()
+    const releasedAttempt = await callCapabilities(control)
+    expect(releasedAttempt.response.status).toBe(401)
+    expect(releasedAttempt.payload).toEqual({ error: 'Invalid notebook RPC token.' })
+  })
+})

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -181,6 +181,7 @@ const ARTIFACT_RPC_METHODS = new Set<ArtifactRpcMethod>([
 // it must comfortably exceed long notebook executions that remain inside one active turn.
 const DEFAULT_ARTIFACT_RPC_CAPABILITY_TTL_MS = 2 * 60 * 60 * 1_000
 const CONTROL_RPC_METHODS = new Set([
+  'capabilitiesCall',
   'mcpCall',
   'computeCall',
   'agentsCall',
@@ -680,6 +681,7 @@ class NotebookLocalRpcServer {
       const bearerToken = authorization?.startsWith('Bearer ')
         ? authorization.slice('Bearer '.length)
         : ''
+      let hostCapabilities: Record<'mcp' | 'compute' | 'agents' | 'skills', boolean> | undefined
       if (isArtifactRpcMethod(method)) {
         const acquired = this.acquireArtifactRpcRequest(method, bearerToken, params)
         params = acquired.params
@@ -699,6 +701,16 @@ class NotebookLocalRpcServer {
               403,
               'host.agents.switch requires an active trusted control invocation.'
             )
+          }
+          if (method === 'capabilitiesCall') {
+            const allows = (rpcMethod: string): boolean =>
+              !sessionBinding.allowedMethods || sessionBinding.allowedMethods.has(rpcMethod)
+            hostCapabilities = {
+              mcp: allows('mcpCall') && Boolean(this.connectorService),
+              compute: allows('computeCall') && Boolean(this.computeService),
+              agents: allows('agentsCall') && Boolean(this.agentsService),
+              skills: allows('skillsCall') && Boolean(this.skillsService)
+            }
           }
           // The request body is agent-controlled. Owner fields always come from the unforgeable,
           // per-session capability issued while building this session's Notebook environment.
@@ -730,7 +742,8 @@ class NotebookLocalRpcServer {
         }
       }
       // Resolve pre-session aliases before the runtime service looks up persistent state.
-      const result = await this.dispatch(method, this.resolveSessionAlias(params))
+      const result =
+        hostCapabilities ?? (await this.dispatch(method, this.resolveSessionAlias(params)))
 
       writeJson(response, 200, { result })
     } catch (error) {

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -341,6 +341,9 @@ describe('repl_execute tool', () => {
 
   it('describes the control-plane repl (host.mcp + handoff) distinctly from notebook_execute', () => {
     expect(tool?.description).toBe(REPL_EXECUTE_DOC)
+    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('host.capabilities')
+    expect(tool?.description).toContain('host.capabilities')
+    expect(tool?.description).toContain('self-awareness')
     expect(tool?.description).toContain('host.mcp')
     // host.compute (remote compute) is only reachable here too, same as host.mcp.
     expect(tool?.description).toContain('host.compute')

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -23,7 +23,7 @@ const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
   'Notebook tool instructions (only applies when using open-science-notebook tools).',
   'In Default mode, use `ask_user_question` as the first tool call when a request has materially different interpretations; do not inspect or use other tools first, and never print a textual choice list. Put all 1-3 known questions in one call with 2-4 real options each. Infer minor reversible details and omit Other; the UI adds custom, agent-decide, and Skip. It shows questions one at a time, then continues the task after Finish. A pending result ends the turn normally.',
   'Notebook preview is only for code and execution results; keep chat, explanation, and diagnosis in the chat area.',
-  'Use `notebook_execute` for one persistent Python/R cell per call; reuse `cellId` to rerun it. Python/R data kernels cannot call connectors; use `repl_execute` for `host.mcp`/`host.compute`/`host.agents`/`host.skills`. For large cross-kernel data, write under `process.env.OPEN_SCIENCE_HANDOFF_DIR` in the REPL and read that path from Python/R.',
+  'Use `notebook_execute` for one persistent Python/R cell per call; reuse `cellId` to rerun it. Python/R data kernels cannot call connectors; use `repl_execute` for `host.capabilities`/`host.mcp`/`host.compute`/`host.agents`/`host.skills`. For large cross-kernel data, write under `process.env.OPEN_SCIENCE_HANDOFF_DIR` in the REPL and read that path from Python/R.',
   'Each runtime is a separate persistent namespace. Create named runtimes with `manage_environments`, select them with the bind/switch tools, and use files to move data across runtimes. Memory is lost on restart or app reopen; run history and files survive.',
   'The notebook already runs inside a writable session workspace. The cwd is already the session data dir; use plain relative paths for normal inputs and outputs. The connector handoff directory is outside that cwd and must be resolved from `OPEN_SCIENCE_HANDOFF_DIR`. Never copy a saved file onto the same path. Do not modify original user files.',
   'Use `inspect_packages` for version checks and `manage_packages` for installs. Never install inside a cell or shell. App-managed runtime contents belong under `$OPEN_SCIENCE_RUNTIME_DIR`, never the project, workspace, system Python, or a user global environment.',
@@ -166,6 +166,7 @@ const SWITCH_RUNTIME_DOC = [
 // Control-plane REPL contract, embedded as the repl_execute description so the agent always sees it.
 const REPL_EXECUTE_DOC = [
   'Run JavaScript in the persistent control-plane REPL, separate from notebook_execute Python/R data kernels.',
+  'Use `await host.capabilities()` to feature-gate optional host namespaces; load the `self-awareness` Skill for its boolean contract and current capability map.',
   'Only this kernel can call connectors (`await host.mcp(server, method, args)`), remote compute (`host.compute`; load its skill for the API), Specialist management (`host.agents`), and Skill authoring (`host.skills`).',
   'Globals persist and a trailing expression is returned. Return results directly when they are for Agent inspection. To hand off large data from the REPL to Python/R, write it under process.env.OPEN_SCIENCE_HANDOFF_DIR; Python/R reads the same OPEN_SCIENCE_HANDOFF_DIR path. Use notebook_execute for analysis code.'
 ].join('\n')

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -92,6 +92,73 @@ describe('repl_loop local RPC transport', () => {
     }
   }, 60_000)
 
+  it('validates, freezes, and refreshes host.capabilities projections', async () => {
+    const requests: Array<{ method?: string; params?: Record<string, unknown> }> = []
+    const server = createServer((request, response) => {
+      let body = ''
+      request.on('data', (chunk) => (body += chunk))
+      request.on('end', () => {
+        requests.push(JSON.parse(body))
+        const result =
+          requests.length === 3
+            ? { mcp: 'yes', compute: true, agents: true, skills: true }
+            : { mcp: true, compute: true, agents: true, skills: true }
+        response
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ result }))
+      })
+    })
+    const connection = await listenForLocalRpc(server, {
+      name: 'repl-loop-capabilities-test',
+      transport: 'pipe'
+    })
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+      OPEN_SCIENCE_MCP_RPC_SOCKET_PATH: connection.socketPath,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'test-token'
+    })
+
+    try {
+      const projection = await send(
+        'const first = await host.capabilities(); first.mcp = false; ' +
+          'const second = await host.capabilities(); ' +
+          'return JSON.stringify({ first, second, frozen: Object.isFrozen(first), same: first === second })'
+      )
+      expect(projection.error).toBeNull()
+      expect(JSON.parse(projection.result ?? '{}')).toEqual({
+        first: { mcp: true, compute: true, agents: true, skills: true },
+        second: { mcp: true, compute: true, agents: true, skills: true },
+        frozen: true,
+        same: false
+      })
+      expect(requests).toEqual([
+        { method: 'capabilitiesCall', params: {} },
+        { method: 'capabilitiesCall', params: {} }
+      ])
+
+      const extraArgument = await send(
+        "try { await host.capabilities('unexpected'); return 'no error' } " +
+          "catch (error) { return error.name + ': ' + error.message }"
+      )
+      expect(extraArgument.result).toBe('TypeError: host.capabilities accepts no arguments')
+      expect(requests).toHaveLength(2)
+
+      const invalidProjection = await send(
+        "try { await host.capabilities(); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(invalidProjection.result).toBe(
+        'host.capabilities returned an invalid capability projection'
+      )
+      expect(requests).toHaveLength(3)
+    } finally {
+      child.kill()
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  }, 60_000)
+
   it('routes host.skills through its native skillsCall method', async () => {
     let received: { method?: string; params?: Record<string, unknown> } = {}
     const server = createServer((request, response) => {

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -599,6 +599,7 @@ describe('Settings backend ownership architecture', () => {
       'artifactReplayVersion'
     ])
     expect(stringSetValues(settingsPaths.notebookLocalRpcServer, 'CONTROL_RPC_METHODS')).toEqual([
+      'capabilitiesCall',
       'mcpCall',
       'computeCall',
       'agentsCall',

--- a/src/main/skills/self-awareness-skill.test.ts
+++ b/src/main/skills/self-awareness-skill.test.ts
@@ -1,0 +1,43 @@
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { SkillRegistry } from './registry'
+
+const skillsRoot = join(__dirname, '..', '..', '..', 'resources', 'skills')
+
+describe('self-awareness bundled Skill', () => {
+  it('is an internal runtime Skill with host.capabilities trigger metadata', async () => {
+    const skill = (await new SkillRegistry(skillsRoot).list()).find(
+      (entry) => entry.id === 'self-awareness'
+    )
+
+    expect(skill).toMatchObject({
+      id: 'self-awareness',
+      name: 'Self-awareness',
+      source: 'featured',
+      exposure: 'internal'
+    })
+    expect(skill?.description).toContain('host.capabilities()')
+    expect(skill?.description).toMatch(/JavaScript control REPL/i)
+  })
+
+  it('documents only the shipped four-key JavaScript contract and its maintenance rule', async () => {
+    const body = await new SkillRegistry(skillsRoot).body('self-awareness')
+
+    for (const phrase of [
+      'repl_execute',
+      'await host.capabilities()',
+      '`mcp`',
+      '`compute`',
+      '`agents`',
+      '`skills`',
+      'caps.compute === true',
+      'fresh frozen projection',
+      'same feature change'
+    ]) {
+      expect(body).toContain(phrase)
+    }
+    expect(body).not.toMatch(/host\.(query|frames|artifacts)/)
+  })
+})


### PR DESCRIPTION
## Problem

The JavaScript control REPL exposes optional `host.*` namespaces, but an Agent has no authoritative session-scoped way to determine which namespaces may be called.

## Proposed change

- Add authenticated `await host.capabilities()` introspection for `mcp`, `compute`, `agents`, and `skills`.
- Derive each boolean from the current session token method allowance and the configured server handler.
- Return a fresh frozen projection and reject malformed server results.
- Add the bundled internal `self-awareness` Skill for the shipped JavaScript contract.
- Publish `capabilitiesCall` through all current primary session capability routes.

```mermaid
flowchart LR
  A["JavaScript control REPL"] -->|"host.capabilities()"| B["capabilitiesCall"]
  B --> C["Session token allowed methods"]
  B --> D["Configured host handlers"]
  C --> E["Exact four-key boolean projection"]
  D --> E
```

## Scope and non-goals

- JavaScript control REPL only; Python and R kernels remain unchanged.
- No database tables, persisted data model, migrations, or UI changes.
- No speculative future capability keys.
- Invalid, bootstrap, and released tokens continue to fail authorization instead of receiving an all-false projection.

## Acceptance criteria and validation

The listed checks ran after the final material edit.

- Server authorization and projection semantics -> `npm test -- src/main/notebook/local-rpc-server.capabilities.test.ts src/main/notebook/repl-loop.integration.test.ts src/main/acp/session-capability-owner.test.ts src/main/settings/settings-backend.architecture.test.ts src/main/skills/self-awareness-skill.test.ts src/main/skills/skill-nudge-identity.test.ts` -> 6 files passed; 48 tests passed; 30 existing kernel-gated tests skipped.
- REPL tool contract description -> `npm test -- src/main/notebook/mcp-server.test.ts -t "describes the control-plane repl"` -> 1 passed; 51 filtered tests skipped.
- Main-process types -> `npm run typecheck:node` -> passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed with 17 pre-existing warnings and no errors.
- Full portable fallback -> `npm test -- --maxWorkers=2` -> 910 files and 13,144 tests passed; 5 unrelated files had six 15-second timeout or timeout-following cleanup failures. The affected files were `permission-broker-registry.test.ts`, `kernel-executor.test.ts`, `artifact-finalization-recovery.integration.test.ts`, `provenance-migration-validation.test.ts`, and `RuntimesPanel.render.test.tsx`. None exercises the changed capability path; exact-head CI remains authoritative.

Uncovered risk: the complete local portable suite was not fully green because of the unrelated timeout failures listed above. The capability impact set itself is green. Independent reviewer confirmation of the final evidence mapping is still pending.

## Review focus

- Whether the bitmap meaning is narrow enough: current session authorization plus configured handler, not resource readiness.
- Whether `capabilitiesCall` remains session-bound and body parameters cannot forge ownership.
- Whether the exact four-key v1 contract and internal Skill provide a sufficient extension point for future host capabilities.
