### PR TITLE
feat(workspace): unify plan approval composer

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -528,7 +528,14 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
   handle, not the full hit-area background.
 - Ask-User elicitation uses the same content-bounded bottom resize behavior. While it owns the
   composer lane, hide the Notebook, jobs, and Plan status chrome above it so the resize handle is the
-  panel's single top affordance. Restore that status chrome after the elicitation leaves the lane.
+  panel's single top affordance. Key the resize shell to the elicitation request so a new question
+  starts at its natural height instead of inheriting the previous question's manual height. Restore
+  that status chrome after the elicitation leaves the lane.
+- Plan approval uses the same content-bounded bottom panel shell and single-border embedded surface.
+  Its compact summary normally has no hidden overflow, so the top resize handle cannot stretch it
+  into empty space. The card shows the Plan lifecycle, task summary, confidence, and inline revision
+  field; keep only Open and Approve in its top action group. Open activates the Plan in the right
+  Preview panel, where the complete Plan and the separate Dismiss action remain available.
 - Textarea: `min-h-[36px] max-h-[200px] py-1.5 text-[15px] leading-relaxed text-text-000 placeholder:text-text-100`.
 - Toolbar action buttons are `h-8 w-8`; send uses `bg-primary text-primary-foreground hover:bg-primary/80`, cancel uses `bg-bg-200 text-text-000 hover:bg-bg-300`.
 - Read-only state: apply `opacity-50` to the input content and action area as a whole, but do not shrink the layout.

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -489,6 +489,38 @@ describe('ConversationPanel composer intake', () => {
     expect((elicitationComposer as HTMLElement).style.height).toBe('398px')
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalInnerHeight })
 
+    renderPanel({
+      activeSession: {
+        ...activeSession,
+        activities: [
+          {
+            ...activeSession.activities![0],
+            id: 'tool-ask-2',
+            elicitation: {
+              message: 'Choose the next skill type.',
+              fields,
+              state: 'pending'
+            }
+          }
+        ]
+      },
+      pendingElicitations: [
+        {
+          requestId: 'elicitation-2',
+          sessionId: activeSession.id,
+          toolCallId: 'tool-ask-2',
+          message: 'Choose the next skill type.',
+          fields
+        }
+      ]
+    })
+
+    const nextElicitationComposer = container.querySelector(
+      '[data-testid="elicitation-composer"]'
+    ) as HTMLDivElement
+    expect(nextElicitationComposer).not.toBe(elicitationComposer)
+    expect(nextElicitationComposer.style.height).toBe('')
+
     const surfaceFade = container.querySelector('[data-testid="composer-surface-fade"]')
     expect(surfaceFade?.classList.contains('-top-18')).toBe(true)
     expect(surfaceFade?.classList.contains('h-18')).toBe(true)
@@ -1567,17 +1599,54 @@ describe('ConversationPanel + menu', () => {
     const pendingEditor = container.querySelector('[role="textbox"]')
     expect(pendingEditor?.closest('form')?.classList.contains('hidden')).toBe(true)
     expect(container.textContent).toContain('Plan ready for review')
+    const planComposer = container.querySelector('[data-testid="plan-composer"]') as HTMLDivElement
+    const planScrollSurface = container.querySelector(
+      '[data-testid="plan-composer-scroll"]'
+    ) as HTMLDivElement
+    const planResizeHandle = container.querySelector(
+      '[aria-label="Resize Plan panel"]'
+    ) as HTMLButtonElement
+    expect(planComposer).not.toBeNull()
+    expect(planScrollSurface.classList.contains('overflow-y-auto')).toBe(true)
+    expect(planResizeHandle).not.toBeNull()
+    expect(
+      [...container.querySelectorAll<HTMLButtonElement>('button')].some(
+        (button) => button.textContent === 'Dismiss'
+      )
+    ).toBe(false)
     const pendingPlanCard = [...container.querySelectorAll('article')].find((article) =>
       article.textContent?.includes('Plan ready for review')
     )
-    expect(pendingPlanCard?.classList.contains('relative')).toBe(true)
-    expect(pendingPlanCard?.classList.contains('z-10')).toBe(true)
+    expect(pendingPlanCard?.classList.contains('border-0')).toBe(true)
+    expect(pendingPlanCard?.classList.contains('shadow-none')).toBe(true)
     expect(
       container
         .querySelector('[data-testid="composer-plus-trigger"]')
         ?.closest('form')
         ?.classList.contains('hidden')
     ).toBe(true)
+
+    planComposer.getBoundingClientRect = () => ({ height: 260 }) as DOMRect
+    Object.defineProperties(planScrollSurface, {
+      clientHeight: { configurable: true, value: 228 },
+      scrollHeight: { configurable: true, value: 228 }
+    })
+    act(() => {
+      planResizeHandle.dispatchEvent(
+        new MouseEvent('pointerdown', { bubbles: true, button: 0, clientY: 100 })
+      )
+      planResizeHandle.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 0 }))
+      planResizeHandle.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 0 }))
+    })
+    expect(planComposer.style.height).toBe('260px')
+
+    act(() => {
+      ;[...container.querySelectorAll<HTMLButtonElement>('button')]
+        .find((button) => button.textContent === 'Open')
+        ?.click()
+    })
+    expect(usePreviewWorkbenchStore.getState().panelState).toBe('open')
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('tool:session-plan:plan')
 
     await act(async () => {
       ;[...container.querySelectorAll<HTMLButtonElement>('button')]
@@ -1805,41 +1874,35 @@ describe('ConversationPanel + menu', () => {
     )
   })
 
-  it.each([
-    ['Approve', 'approved'],
-    ['Dismiss', 'rejected']
-  ] as const)(
-    'routes restored Plan %s through the durable decision API',
-    async (label, decision) => {
-      const session: ChatSession = {
-        id: `session-restored-${decision}`,
-        projectId: 'project-a',
-        title: 'Restored pending Plan',
-        cwd: '/workspace',
-        status: 'waiting-plan-approval',
-        messages: planOriginMessages(),
-        createdAt: 1,
-        updatedAt: 2,
-        activePlanProjection: {
-          ...completedPlanProjection,
-          approval: 'pending',
-          lifecycle: 'awaiting_approval'
-        }
+  it('routes restored Plan approval through the durable decision API', async () => {
+    const session: ChatSession = {
+      id: 'session-restored-approved',
+      projectId: 'project-a',
+      title: 'Restored pending Plan',
+      cwd: '/workspace',
+      status: 'waiting-plan-approval',
+      messages: planOriginMessages(),
+      createdAt: 1,
+      updatedAt: 2,
+      activePlanProjection: {
+        ...completedPlanProjection,
+        approval: 'pending',
+        lifecycle: 'awaiting_approval'
       }
-      const onRespondToRestoredPlan = vi.fn().mockResolvedValue(undefined)
-      renderPanel({ activeSession: session, canEditDraft: false, onRespondToRestoredPlan })
-
-      await act(async () => {
-        ;[...container.querySelectorAll<HTMLButtonElement>('button')]
-          .find((button) => button.textContent === label)
-          ?.click()
-        await Promise.resolve()
-      })
-
-      expect(onRespondToRestoredPlan).toHaveBeenCalledWith({ decision })
-      expect(respondToSessionPlanMock).not.toHaveBeenCalled()
     }
-  )
+    const onRespondToRestoredPlan = vi.fn().mockResolvedValue(undefined)
+    renderPanel({ activeSession: session, canEditDraft: false, onRespondToRestoredPlan })
+
+    await act(async () => {
+      ;[...container.querySelectorAll<HTMLButtonElement>('button')]
+        .find((button) => button.textContent === 'Approve')
+        ?.click()
+      await Promise.resolve()
+    })
+
+    expect(onRespondToRestoredPlan).toHaveBeenCalledWith({ decision: 'approved' })
+    expect(respondToSessionPlanMock).not.toHaveBeenCalled()
+  })
 
   it('Attach files item triggers the hidden file input (onStageAttachmentFiles path)', () => {
     // We can only confirm the item exists and is not disabled; the picker click is browser-native.

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -149,6 +149,17 @@ const ResizablePermissionComposer = ({ children }: React.PropsWithChildren): Rea
   </ResizableBottomPanel>
 )
 
+const ResizablePlanComposer = ({ children }: React.PropsWithChildren): React.JSX.Element => (
+  <ResizableBottomPanel
+    ariaLabel="Resize Plan panel"
+    testId="plan-composer"
+    scrollTestId="plan-composer-scroll"
+    constrainGrowthToOverflow
+  >
+    {children}
+  </ResizableBottomPanel>
+)
+
 // Formats the compact size label shown under each composer attachment chip.
 const formatAttachmentSize = (size: number): string => {
   if (size < 1024) return `${size} B`
@@ -814,9 +825,10 @@ const ConversationPanel = ({
                       />
                     </ResizablePermissionComposer>
                   ) : pendingElicitation ? (
-                    <ResizableElicitationComposer>
+                    <ResizableElicitationComposer
+                      key={pendingElicitationRequest?.requestId ?? pendingElicitationActivity?.id}
+                    >
                       <WorkspaceElicitationCard
-                        key={pendingElicitationRequest?.requestId ?? pendingElicitationActivity?.id}
                         elicitation={pendingElicitation}
                         request={pendingElicitationRequest}
                         embedded
@@ -832,14 +844,16 @@ const ConversationPanel = ({
                       />
                     </ResizableElicitationComposer>
                   ) : pendingPlan ? (
-                    <WorkspacePlanCard
-                      className="relative z-10"
-                      projection={pendingPlan}
-                      onOpen={openPendingPlan}
-                      onRespond={(decision) => respondToPendingPlan({ decision })}
-                      onSubmitResponse={(text) => respondToPendingPlan({ feedback: text })}
-                      onResolved={() => setResolvedPlanKey(activePendingPlanKey)}
-                    />
+                    <ResizablePlanComposer key={activePendingPlanKey}>
+                      <WorkspacePlanCard
+                        embedded
+                        projection={pendingPlan}
+                        onOpen={openPendingPlan}
+                        onRespond={(decision) => respondToPendingPlan({ decision })}
+                        onSubmitResponse={(text) => respondToPendingPlan({ feedback: text })}
+                        onResolved={() => setResolvedPlanKey(activePendingPlanKey)}
+                      />
+                    </ResizablePlanComposer>
                   ) : null}
 
                   {/* Composer stays mounted to preserve its draft, but a pending blocking interaction

--- a/src/renderer/src/pages/workspace/MobilePreviewSheet.tsx
+++ b/src/renderer/src/pages/workspace/MobilePreviewSheet.tsx
@@ -2,15 +2,21 @@ import { X } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 
 import { PreviewPanelSurface } from './PreviewPanel'
+import type { RestoredPlanResponder } from './session-plan/SessionPlanSurfaces'
 
 type MobilePreviewSheetProps = {
   open: boolean
   onClose: () => void
+  restoredPlanResponder?: RestoredPlanResponder
 }
 
 // Mobile workbench presentation: generated files, code, and notebooks keep the desktop tab model,
 // but rise from the bottom so the conversation remains the primary screen.
-const MobilePreviewSheet = ({ open, onClose }: MobilePreviewSheetProps): React.JSX.Element => (
+const MobilePreviewSheet = ({
+  open,
+  onClose,
+  restoredPlanResponder
+}: MobilePreviewSheetProps): React.JSX.Element => (
   <Dialog.Root open={open} onOpenChange={(next) => (next ? undefined : onClose())}>
     <Dialog.Portal>
       <Dialog.Overlay className="fixed inset-0 z-50 bg-black/45 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:data-[state=closed]:animate-none motion-reduce:data-[state=open]:animate-none" />
@@ -34,7 +40,10 @@ const MobilePreviewSheet = ({ open, onClose }: MobilePreviewSheetProps): React.J
             </button>
           </Dialog.Close>
         </div>
-        <PreviewPanelSurface className="min-h-0 flex-1" />
+        <PreviewPanelSurface
+          className="min-h-0 flex-1"
+          restoredPlanResponder={restoredPlanResponder}
+        />
       </Dialog.Content>
     </Dialog.Portal>
   </Dialog.Root>

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -16,6 +16,7 @@ import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { PreviewFileSurface } from './PreviewFileSurface'
 import { PreviewFileContent } from './previews/PreviewFileContent'
 import { PreviewToolContent } from './previews/PreviewToolContent'
+import type { RestoredPlanResponder } from './session-plan/SessionPlanSurfaces'
 import { useHorizontalScrollFade } from './use-horizontal-scroll-fade'
 
 type PreviewPanelProps = {
@@ -23,17 +24,21 @@ type PreviewPanelProps = {
   defaultSize: string
   minSize: string
   onResize: (panelSize: PanelSize, previousPanelSize: PanelSize | undefined) => void
+  restoredPlanResponder?: RestoredPlanResponder
 }
 
 type PreviewPanelSurfaceProps = {
   className?: string
+  restoredPlanResponder?: RestoredPlanResponder
 }
 
 // Renders the active tab's content, or an empty state when nothing is previewed yet.
 const PreviewActiveContent = ({
-  item
+  item,
+  restoredPlanResponder
 }: {
   item: PreviewItem | undefined
+  restoredPlanResponder?: RestoredPlanResponder
 }): React.JSX.Element | null => {
   if (!item) {
     return (
@@ -43,7 +48,9 @@ const PreviewActiveContent = ({
     )
   }
 
-  if (item.type === 'tool') return <PreviewToolContent item={item} />
+  if (item.type === 'tool') {
+    return <PreviewToolContent item={item} restoredPlanResponder={restoredPlanResponder} />
+  }
 
   return <PreviewFileContent item={item} />
 }
@@ -412,10 +419,12 @@ const PreviewFilePanel = ({
 // returning a different element from this map position would let React unmount the subtree.
 const PreviewToolPanel = ({
   item,
-  isActive
+  isActive,
+  restoredPlanResponder
 }: {
   item: PreviewToolItem
   isActive: boolean
+  restoredPlanResponder?: RestoredPlanResponder
 }): React.JSX.Element => {
   const isExpanded = usePreviewWorkbenchStore(
     (state) => state.expandedToolItemId === item.id && isActive
@@ -462,7 +471,7 @@ const PreviewToolPanel = ({
             : 'h-full min-h-0 w-full overflow-y-auto'
         }
       >
-        <PreviewActiveContent item={item} />
+        <PreviewActiveContent item={item} restoredPlanResponder={restoredPlanResponder} />
       </section>
     </>
   )
@@ -470,7 +479,10 @@ const PreviewToolPanel = ({
 
 // Shared workbench surface. Desktop wraps it in a resizable panel; mobile presents the exact same
 // tabs and active content inside a bottom sheet.
-const PreviewPanelSurface = ({ className }: PreviewPanelSurfaceProps): React.JSX.Element => {
+const PreviewPanelSurface = ({
+  className,
+  restoredPlanResponder
+}: PreviewPanelSurfaceProps): React.JSX.Element => {
   const items = usePreviewWorkbenchStore((state) => state.items)
   const activeItemId = usePreviewWorkbenchStore((state) => state.activeItemId)
   const panelState = usePreviewWorkbenchStore((state) => state.panelState)
@@ -512,14 +524,27 @@ const PreviewPanelSurface = ({ className }: PreviewPanelSurfaceProps): React.JSX
         </div>
       ) : null}
       <div className={cn('min-h-0 flex-1', activeItem?.type === 'file' && 'pl-2 pr-1')}>
-        {!activeItem ? <PreviewActiveContent key={activeContentKey} item={activeItem} /> : null}
+        {!activeItem ? (
+          <PreviewActiveContent
+            key={activeContentKey}
+            item={activeItem}
+            restoredPlanResponder={restoredPlanResponder}
+          />
+        ) : null}
         {items.map((item) => {
           const isActivePanel = item.id === activeItemId && panelState === 'open'
           // Tool panels render at this map position whether active or not, so React keeps the
           // subtree mounted across tab switches. File panels re-create on activation anyway
           // (contentKey encodes path+mtime), so an inactive one collapses to an empty region.
           if (item.type === 'tool') {
-            return <PreviewToolPanel key={item.id} item={item} isActive={isActivePanel} />
+            return (
+              <PreviewToolPanel
+                key={item.id}
+                item={item}
+                isActive={isActivePanel}
+                restoredPlanResponder={restoredPlanResponder}
+              />
+            )
           }
 
           return isActivePanel ? (
@@ -549,7 +574,8 @@ const PreviewPanel = ({
   panelRef,
   defaultSize,
   minSize,
-  onResize
+  onResize,
+  restoredPlanResponder
 }: PreviewPanelProps): React.JSX.Element => {
   const handleResize = (
     panelSize: PanelSize,
@@ -570,7 +596,7 @@ const PreviewPanel = ({
       collapsedSize="0%"
       onResize={handleResize}
     >
-      <PreviewPanelSurface />
+      <PreviewPanelSurface restoredPlanResponder={restoredPlanResponder} />
     </ResizablePanel>
   )
 }

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -767,6 +767,14 @@ const WorkspacePage = ({
     <main className="h-[100dvh] overflow-hidden bg-bg-10 text-[13px] leading-normal text-text-000 md:h-screen md:p-[10px]">
       <WorkspacePanelLayout
         hasPreviewItems={previewItems.length > 0}
+        restoredPlanResponder={
+          activeSession
+            ? {
+                sessionId: activeSession.id,
+                respond: conversation.actions.submit.restoredPlan
+              }
+            : undefined
+        }
         preview={{
           state: previewPanelState,
           openRequestVersion: previewOpenRequestVersion,

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.plan.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.plan.test.tsx
@@ -57,12 +57,14 @@ const approvedProjection: ActivePlanProjection = {
 }
 
 const respondPlan = vi.fn()
+const respondToRestoredPlan = vi.fn()
 const getPlanProjection = vi.fn()
 const saveBlobFile = vi.fn()
 
 beforeEach(() => {
   sideChatState.parentSessionId = undefined
   respondPlan.mockReset().mockResolvedValue({ projection: approvedProjection, changed: true })
+  respondToRestoredPlan.mockReset().mockResolvedValue(undefined)
   getPlanProjection.mockReset().mockResolvedValue(approvedProjection)
   saveBlobFile.mockReset().mockResolvedValue({ saved: true })
   Object.defineProperty(window, 'api', {
@@ -208,6 +210,54 @@ describe('Plan Preview workbench integration', () => {
     expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull()
     expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull()
     expect(screen.getByText(/original Agent interaction has ended/u)).toBeTruthy()
+  })
+
+  it('routes restored pending Plan decisions through the session-bound responder', async () => {
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-1',
+          status: 'waiting-plan-approval',
+          activePlanProjection: pendingProjection
+        } as never
+      ]
+    })
+
+    const item = {
+      id: 'tool:session-1:plan',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      type: 'tool' as const,
+      toolKind: 'plan' as const,
+      title: 'Session Plan'
+    }
+    const { rerender } = render(
+      <PreviewToolContent
+        item={item}
+        restoredPlanResponder={{
+          sessionId: 'session-2',
+          respond: respondToRestoredPlan
+        }}
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull()
+    rerender(
+      <PreviewToolContent
+        item={item}
+        restoredPlanResponder={{
+          sessionId: 'session-1',
+          respond: respondToRestoredPlan
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    await waitFor(() =>
+      expect(respondToRestoredPlan).toHaveBeenCalledWith({ decision: 'rejected' })
+    )
+    expect(respondPlan).not.toHaveBeenCalled()
   })
 
   it('keeps the parent Plan read-only while its Side chat is open', () => {

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
@@ -8,7 +8,7 @@ import type { NotebookPreviewItem } from '../NotebookPreview'
 import { ProjectFilesView } from '../ProjectFilesView'
 import { SessionReviewerPanel } from '../SessionReviewerPanel'
 import { respondToSessionPlan } from '../session-plan/respond-to-session-plan'
-import { PlanPreviewSurface } from '../session-plan/SessionPlanSurfaces'
+import { PlanPreviewSurface, type RestoredPlanResponder } from '../session-plan/SessionPlanSurfaces'
 import { useIsSideChatOpenForSession } from '../use-side-chat-controller'
 
 const isNotebookPreviewItem = (item: PreviewToolItem): item is NotebookPreviewItem =>
@@ -42,9 +42,11 @@ const SessionReviewerContent = ({
 }
 
 export const PreviewToolContent = ({
-  item
+  item,
+  restoredPlanResponder
 }: {
   item: PreviewToolItem
+  restoredPlanResponder?: RestoredPlanResponder
 }): React.JSX.Element | null => {
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
   const isSideChatOpen = useIsSideChatOpenForSession(item.sessionId)
@@ -65,15 +67,20 @@ export const PreviewToolContent = ({
 
   const respondPlan = async (decision: 'approved' | 'rejected'): Promise<void> => {
     if (!planProjection || !item.projectId) return
-    await respondToSessionPlan(
-      { projectId: item.projectId, sessionId: item.sessionId, projection: planProjection },
-      { decision }
-    )
+    if (planSession?.activeRun) {
+      await respondToSessionPlan(
+        { projectId: item.projectId, sessionId: item.sessionId, projection: planProjection },
+        { decision }
+      )
+      return
+    }
+    if (restoredPlanResponder?.sessionId !== item.sessionId) return
+    await restoredPlanResponder.respond({ decision })
   }
+  const hasPlanResponsePath =
+    planSession?.activeRun !== undefined || restoredPlanResponder?.sessionId === item.sessionId
   const canRespondToPlan =
-    planSession?.status === 'waiting-plan-approval' &&
-    planSession.activeRun !== undefined &&
-    !isSideChatOpen
+    planSession?.status === 'waiting-plan-approval' && hasPlanResponsePath && !isSideChatOpen
 
   // Remount the Files tool per project so its transient dialog cannot outlive the project it opened.
   if (item.toolKind === 'files') {

--- a/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx
@@ -96,8 +96,9 @@ describe('Session Plan renderer surfaces', () => {
 
     expect(screen.getByText('Plan ready for review')).toBeTruthy()
     expect(screen.getByText('Analyze one dataset')).toBeTruthy()
-    expect(screen.getByText('1 phase · 1 delegation · 1 step')).toBeTruthy()
+    expect(screen.queryByText('1 phase · 1 delegation · 1 step')).toBeNull()
     expect(screen.getByText(/high confidence/u)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull()
     expect(screen.getAllByRole('button').every((button) => button.dataset.slot === 'button')).toBe(
       true
     )
@@ -108,19 +109,27 @@ describe('Session Plan renderer surfaces', () => {
     expect(onRespond).toHaveBeenCalledWith('approved')
   })
 
-  it.each([
-    ['Approve', 'approved'],
-    ['Dismiss', 'rejected']
-  ] as const)('removes the card after a successful %s response', async (buttonName, decision) => {
+  it('removes the compact card after a successful approval', async () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
     const view = render(
       <WorkspacePlanCard projection={projection} onOpen={vi.fn()} onRespond={onRespond} />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: buttonName }))
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
 
-    await waitFor(() => expect(onRespond).toHaveBeenCalledWith(decision))
+    await waitFor(() => expect(onRespond).toHaveBeenCalledWith('approved'))
     expect(view.container.querySelector('article')).toBeNull()
+  })
+
+  it('drops nested card chrome when embedded in the shared composer panel', () => {
+    const view = render(
+      <WorkspacePlanCard embedded projection={projection} onOpen={vi.fn()} onRespond={vi.fn()} />
+    )
+
+    const card = view.container.querySelector('article')
+    expect(card?.classList.contains('rounded-none')).toBe(true)
+    expect(card?.classList.contains('border-0')).toBe(true)
+    expect(card?.classList.contains('shadow-none')).toBe(true)
   })
 
   it('submits inline revision feedback as a user Message', async () => {

--- a/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.tsx
@@ -1,5 +1,20 @@
+/*
+ * Hallmark · component: Plan approval card · genre: modern-minimal · theme: existing semantic tokens
+ * pre-emit critique: P5 · H5 · E5 · S5 · R5 · V4
+ * states: default · hover · focus · active · disabled · loading · error · success
+ * contrast: inherited from the shared Button, Textarea, and workspace surface tokens
+ * slop test: pass · component scope, existing workspace chrome and tokens preserved
+ */
 import { useState } from 'react'
-import { Download, Info, ListChecks, Maximize2, Minimize2 } from 'lucide-react'
+import {
+  CornerDownLeft,
+  Download,
+  Info,
+  ListChecks,
+  Maximize2,
+  Minimize2,
+  Pencil
+} from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -13,9 +28,6 @@ import {
 } from '../../../../../shared/session-plan/contract'
 
 type PlanSurfaceProps = Readonly<{ projection: ActivePlanProjection; stale?: boolean }>
-
-const plural = (count: number, singular: string): string =>
-  `${count} ${singular}${count === 1 ? '' : 's'}`
 
 const lifecycleLabel = (projection: ActivePlanProjection): string => {
   switch (projection.lifecycle) {
@@ -62,6 +74,7 @@ const STEP_STATUS_PRESENTATION: Record<
 const WorkspacePlanCard = ({
   projection,
   stale = false,
+  embedded = false,
   className = '',
   onOpen,
   onRespond,
@@ -73,6 +86,7 @@ const WorkspacePlanCard = ({
     onRespond: (decision: 'approved' | 'rejected') => Promise<void>
     onSubmitResponse?: (text: string) => Promise<void>
     onResolved?: () => void
+    embedded?: boolean
     className?: string
   }>): React.JSX.Element => {
   const decisionPending = projection.approval === 'pending' && !stale
@@ -98,53 +112,53 @@ const WorkspacePlanCard = ({
   if (resolvedProjectionKey === projectionKey) return <></>
   return (
     <article
-      className={`overflow-hidden rounded-lg border border-border bg-card shadow-card ${className}`}
+      className={`overflow-hidden bg-card ${
+        embedded
+          ? 'rounded-none border-0 shadow-none'
+          : 'rounded-lg border border-border shadow-card'
+      } ${className}`}
+      aria-busy={decisionBusy}
     >
       {stale ? (
         <div className="border-b border-border bg-muted px-3.5 py-2 text-xs text-muted-foreground">
           ⚠ A newer plan is active. This plan can no longer be approved.
         </div>
       ) : null}
-      <div className="p-4">
-        <div className="flex flex-wrap items-start justify-between gap-4">
+      <div className="p-4 sm:p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-56 flex-1">
-            <div className="text-xs text-muted-foreground">{lifecycleLabel(projection)}</div>
-            <div className="mt-1 text-[17px] font-medium text-foreground">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <ListChecks className="size-3.5" strokeWidth={1.75} aria-hidden="true" />
+              <span>{lifecycleLabel(projection)}</span>
+            </div>
+            <div className="mt-1 min-w-0 break-words text-[17px] font-semibold leading-6 text-foreground">
               {projection.document.task_summary}
             </div>
-            <div className="mt-1 text-xs text-muted-foreground">
-              {plural(projection.counts.phases, 'phase')} ·{' '}
-              {plural(projection.counts.delegations, 'delegation')} ·{' '}
-              {plural(projection.counts.steps, 'step')}
-            </div>
           </div>
-          <div className="flex gap-2">
-            <Button type="button" variant="outline" onClick={onOpen}>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="[@media(pointer:coarse)]:h-11"
+              onClick={onOpen}
+            >
               Open
             </Button>
             {decisionPending ? (
-              <>
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={decisionBusy}
-                  onClick={() => void respond('rejected')}
-                >
-                  Dismiss
-                </Button>
-                <Button
-                  type="button"
-                  disabled={decisionBusy}
-                  onClick={() => void respond('approved')}
-                >
-                  Approve
-                </Button>
-              </>
+              <Button
+                type="button"
+                className="[@media(pointer:coarse)]:h-11"
+                disabled={decisionBusy}
+                onClick={() => void respond('approved')}
+              >
+                Approve
+              </Button>
             ) : null}
           </div>
         </div>
-        <div className="mt-3 inline-flex rounded-full bg-primary/10 px-2 py-1 text-[11px] font-medium text-primary">
-          ● {projection.document.feasibility.confidence} confidence
+        <div className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-bg-200 px-2 py-1 text-[11px] font-medium text-text-100">
+          <span className="size-1.5 rounded-full bg-text-300" aria-hidden="true" />
+          {projection.document.feasibility.confidence} confidence
         </div>
         {decisionPending ? (
           <form
@@ -176,23 +190,42 @@ const WorkspacePlanCard = ({
             <label className="sr-only" htmlFor={`plan-response-${projection.artifactVersionId}`}>
               Respond to Plan
             </label>
-            <div className="flex items-center gap-2">
-              <span aria-hidden="true">✎</span>
+            <div className="flex items-start gap-2">
+              <span
+                className="grid size-9 shrink-0 place-items-center rounded-lg bg-bg-100 text-text-300"
+                aria-hidden="true"
+              >
+                <Pencil className="size-4" strokeWidth={1.75} />
+              </span>
               <Textarea
                 id={`plan-response-${projection.artifactVersionId}`}
                 rows={1}
-                className="min-h-9 flex-1 resize-none border-0 bg-transparent px-0 py-2 shadow-none dark:bg-transparent"
-                placeholder="Describe changes, or type “approve”…"
+                aria-invalid={decisionError ? true : undefined}
+                aria-describedby={
+                  decisionError ? `plan-response-error-${projection.artifactVersionId}` : undefined
+                }
+                className="max-h-40 min-h-9 min-w-0 flex-1 resize-none border-0 bg-transparent px-0 py-1.5 text-[15px] leading-6 shadow-none focus-visible:border-transparent dark:bg-transparent"
+                placeholder="Describe changes to the Plan…"
                 value={responseText}
                 disabled={decisionBusy}
                 onChange={(event) => setResponseText(event.target.value)}
               />
-              <Button type="submit" disabled={decisionBusy || responseText.trim().length === 0}>
-                Send
+              <Button
+                type="submit"
+                variant="outline"
+                size="icon-lg"
+                aria-label="Send Plan feedback"
+                disabled={decisionBusy || responseText.trim().length === 0}
+              >
+                <CornerDownLeft className="size-4" strokeWidth={1.75} aria-hidden="true" />
               </Button>
             </div>
             {decisionError ? (
-              <p role="alert" className="mt-1 text-xs text-destructive">
+              <p
+                id={`plan-response-error-${projection.artifactVersionId}`}
+                role="alert"
+                className="mt-1 pl-11 text-xs text-destructive"
+              >
                 {decisionError}
               </p>
             ) : null}

--- a/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.tsx
@@ -29,6 +29,11 @@ import {
 
 type PlanSurfaceProps = Readonly<{ projection: ActivePlanProjection; stale?: boolean }>
 
+type RestoredPlanResponder = Readonly<{
+  sessionId: string
+  respond: (response: { decision: 'approved' | 'rejected' }) => Promise<void>
+}>
+
 const lifecycleLabel = (projection: ActivePlanProjection): string => {
   switch (projection.lifecycle) {
     case 'awaiting_approval':
@@ -484,3 +489,4 @@ const PlanPreviewSurface = ({
 }
 
 export { PlanPreviewSurface, PlanProgressChip, WorkspacePlanCard }
+export type { RestoredPlanResponder }

--- a/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
+++ b/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
@@ -8,6 +8,7 @@ import { useMediaQuery } from '@/hooks/useMediaQuery'
 
 import { MobilePreviewSheet } from './MobilePreviewSheet'
 import { PreviewPanel } from './PreviewPanel'
+import type { RestoredPlanResponder } from './session-plan/SessionPlanSurfaces'
 
 const PANEL_COLLAPSED_SIZE = 0
 const PANEL_COLLAPSED_SIZE_CSS = `${PANEL_COLLAPSED_SIZE}%`
@@ -391,6 +392,7 @@ const useWorkspacePanelLayout = (previewPort: PreviewPanelLayoutPort): Workspace
 
 type WorkspacePanelLayoutProps = {
   hasPreviewItems: boolean
+  restoredPlanResponder?: RestoredPlanResponder
   preview: PreviewPanelLayoutPort
   desktopSidebar: React.ReactNode
   renderMobileSidebar: (options: { isOpen: boolean; close: () => void }) => React.ReactNode
@@ -404,6 +406,7 @@ type WorkspacePanelLayoutProps = {
 // Adapts the controller to the desktop split view and mobile drawer/sheet without owning page data.
 const WorkspacePanelLayout = ({
   hasPreviewItems,
+  restoredPlanResponder,
   preview: previewPort,
   desktopSidebar,
   renderMobileSidebar,
@@ -482,6 +485,7 @@ const WorkspacePanelLayout = ({
                 defaultSize={preview.defaultSize}
                 minSize={preview.minSize}
                 onResize={preview.onResize}
+                restoredPlanResponder={restoredPlanResponder}
               />
             </>
           ) : null}
@@ -491,7 +495,11 @@ const WorkspacePanelLayout = ({
       </div>
 
       {isMobile ? (
-        <MobilePreviewSheet open={preview.state === 'open'} onClose={preview.collapse} />
+        <MobilePreviewSheet
+          open={preview.state === 'open'}
+          onClose={preview.collapse}
+          restoredPlanResponder={restoredPlanResponder}
+        />
       ) : null}
     </>
   )


### PR DESCRIPTION
## Problem

Plan approval used a standalone card above the conversation composer while Permission and Ask-user used the shared resizable bottom-panel shell. The visual structure was inconsistent, Plan exposed a compact Dismiss action that belongs with the full preview, and Ask-user could retain a manually resized height when a new request replaced the previous one.

## Proposed change

- Render compact Plan approval inside the shared content-bounded ResizableBottomPanel shell.
- Keep the compact Plan surface single-bordered and limited to Open and Approve actions.
- Keep full Plan details and Dismiss in the right-side PreviewPanel; Open activates that preview.
- Key the Ask-user resize shell by request identity so each new elicitation starts at its natural height.
- Align Plan summary, confidence, revision field, icons, responsive behavior, and interaction states with the existing workspace design system.
- Document the shared composer behavior in docs/design.md.

## Scope and non-goals

This change is limited to the workspace conversation composer and Session Plan renderer surfaces. It does not change Plan persistence, approval APIs, Permission behavior, PreviewPanel detail rendering, or global design tokens and dependencies.

## Acceptance criteria and validation

- Ask-user resize state resets between request identities: covered by ConversationPanel.interaction.test.tsx.
- Plan uses the shared resize handle and cannot grow into empty space when no content overflows: covered by ConversationPanel.interaction.test.tsx.
- Compact Plan exposes Open and Approve only, while Open activates the Plan PreviewPanel: covered by ConversationPanel.interaction.test.tsx and SessionPlanSurfaces.test.tsx.
- Embedded Plan surface drops nested border and shadow chrome: covered by SessionPlanSurfaces.test.tsx.
- Full Plan preview retains Dismiss and existing decision behavior: existing SessionPlanSurfaces preview tests remain passing.

Validation run:

- Targeted Vitest: 98 passed.
- Web TypeScript check: passed.
- ESLint: passed with 0 errors and 17 existing warnings outside this change.
- Prettier and git diff check: passed.
- Full Vitest run: 13,131 passed and 190 skipped; 8 unrelated tests hit the default 15-second timeout under full concurrency. Re-running the 7 affected files produced 1,050 passes with only the repository-wide architecture scan timing out; that scan then passed 11 of 11 in isolation with a 60-second timeout.

## Review focus

- Whether content-bounded resizing is the right shared behavior for the compact Plan summary.
- Whether keeping Dismiss exclusively in the full PreviewPanel gives the intended decision hierarchy.
- Whether the Ask-user shell key correctly resets only request-local manual height.