### PR TITLE
fix(session-resume): recover legacy provider sessions

### DIFF
--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { AcpCreateSessionResponse, AcpResumeSessionRequest } from '../../shared/acp'
 import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
-import { claudeCodeFramework } from '../agent-framework'
+import { claudeCodeFramework, codexFramework } from '../agent-framework'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
 import { AcpProviderSessionResumer } from './provider-session-resumer'
 import {
@@ -31,6 +31,13 @@ const backend: AcpBackendGenerationView = {
   adapter: { nativeMcpEnabled: true, bridgeMcpAliasesEnabled: false }
 }
 
+const codexResponsesBackend: AcpBackendGenerationView = {
+  ...backend,
+  framework: codexFramework,
+  backendId: 'codex:builtin-codex-subscription',
+  modelRoute: 'codex-responses'
+}
+
 type HarnessOptions = {
   attached?: boolean
   attachError?: Error
@@ -39,6 +46,7 @@ type HarnessOptions = {
   configureError?: Error
   ensureConnected?: () => Promise<ClientConnection>
   foreignIdentityCollision?: (sessionIds: readonly string[]) => Error | undefined
+  initialBackend?: AcpBackendGenerationView
   invalidateDuringResume?: boolean
   observerError?: Error
   resumeError?: unknown
@@ -72,7 +80,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
   const order: string[] = []
   let timerCallback: (() => void) | undefined
   let identityClaimedAtAdoption = false
-  let currentBackend = backend
+  let currentBackend = options.initialBackend ?? backend
   const providerSession = {
     sessionId: 'provider-session',
     dispose: vi.fn(() => order.push('session dispose'))
@@ -475,6 +483,25 @@ describe('AcpProviderSessionResumer', () => {
     expect(harness.order.indexOf('capability release')).toBeLessThan(
       harness.order.indexOf('adopt fresh')
     )
+    expect(harness.adopt).toHaveBeenCalledOnce()
+  })
+
+  it('fresh-adopts a legacy Codex Responses Session after its adapter returns Unknown error', async () => {
+    const harness = createHarness({
+      initialBackend: codexResponsesBackend,
+      resumeError: { code: -32603, message: 'Unknown error' }
+    })
+
+    await expect(
+      harness.resume({
+        sessionId: '019fb8c8-6c66-7f22-9653-17b5b287dbbb',
+        previousFrameworkId: 'codex',
+        previousBackendId: codexResponsesBackend.backendId
+      })
+    ).resolves.toMatchObject({ contextReset: true })
+
+    expect(harness.request).toHaveBeenCalledOnce()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
     expect(harness.adopt).toHaveBeenCalledOnce()
   })
 

--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { AcpCreateSessionResponse, AcpResumeSessionRequest } from '../../shared/acp'
 import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
-import { claudeCodeFramework, codexFramework } from '../agent-framework'
+import { claudeCodeFramework, codexFramework, opencodeFramework } from '../agent-framework'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
 import { AcpProviderSessionResumer } from './provider-session-resumer'
 import {
@@ -36,6 +36,13 @@ const codexResponsesBackend: AcpBackendGenerationView = {
   framework: codexFramework,
   backendId: 'codex:builtin-codex-subscription',
   modelRoute: 'codex-responses'
+}
+
+const opencodeBackend: AcpBackendGenerationView = {
+  ...backend,
+  framework: opencodeFramework,
+  backendId: 'opencode:provider-a',
+  modelRoute: 'opencode-openai'
 }
 
 type HarnessOptions = {
@@ -497,6 +504,25 @@ describe('AcpProviderSessionResumer', () => {
         sessionId: '019fb8c8-6c66-7f22-9653-17b5b287dbbb',
         previousFrameworkId: 'codex',
         previousBackendId: codexResponsesBackend.backendId
+      })
+    ).resolves.toMatchObject({ contextReset: true })
+
+    expect(harness.request).toHaveBeenCalledOnce()
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.adopt).toHaveBeenCalledOnce()
+  })
+
+  it('fresh-adopts a legacy OpenCode Session after its adapter returns Unknown error', async () => {
+    const harness = createHarness({
+      initialBackend: opencodeBackend,
+      resumeError: { code: -32603, message: 'Unknown error' }
+    })
+
+    await expect(
+      harness.resume({
+        sessionId: 'ses_03fed93d1ffe1uw7XFraUNPhun',
+        previousFrameworkId: 'opencode',
+        previousBackendId: opencodeBackend.backendId
       })
     ).resolves.toMatchObject({ contextReset: true })
 

--- a/src/main/acp/provider-session-resumer.ts
+++ b/src/main/acp/provider-session-resumer.ts
@@ -179,11 +179,11 @@ export class AcpProviderSessionResumer {
     identity.renew()
 
     const affinity = this.deps.registry.lookup(request.sessionId)?.aggregate.snapshot()
+    const persistedProviderSessionId = affinity?.providerSessionId ?? request.providerSessionId
     const backend = this.deps.currentBackend()
     const decision = this.policy.decide({
       appSessionId: request.sessionId,
-      providerSessionId:
-        affinity?.providerSessionId ?? request.providerSessionId ?? request.sessionId,
+      providerSessionId: persistedProviderSessionId ?? request.sessionId,
       previousFrameworkId: affinity?.frameworkId ?? request.previousFrameworkId,
       currentFrameworkId: backend.framework.id,
       previousBackendId: affinity?.backendId ?? request.previousBackendId,
@@ -208,7 +208,8 @@ export class AcpProviderSessionResumer {
       cwd,
       projectName,
       identity,
-      decision.providerSessionId
+      decision.providerSessionId,
+      persistedProviderSessionId !== undefined
     )
   }
 
@@ -218,7 +219,8 @@ export class AcpProviderSessionResumer {
     cwd: string,
     projectName: string,
     identity: AcpPrimarySessionIdentityReservation,
-    providerSessionId: string
+    providerSessionId: string,
+    providerSessionIdPersisted: boolean
   ): Promise<AcpCreateSessionResponse> {
     let capability: SessionCapabilityProvision | undefined
     let provisionalSession: ActiveSession | undefined
@@ -257,7 +259,12 @@ export class AcpProviderSessionResumer {
           ...setup.metaArg
         })
       } catch (error) {
-        if (this.policy.classifyFailure(error).disposition !== 'adoptable') throw error
+        const failure = this.policy.classifyFailure(error, {
+          currentFrameworkId: backend.framework.id,
+          currentModelRoute: backend.modelRoute,
+          providerSessionIdPersisted
+        })
+        if (failure.disposition !== 'adoptable') throw error
         try {
           identity.assertCurrent()
         } catch (supersededError) {

--- a/src/main/acp/session-resume-policy.test.ts
+++ b/src/main/acp/session-resume-policy.test.ts
@@ -244,10 +244,29 @@ describe('ACP Session resume policy', () => {
       })
     }
   )
+  it.each(['opencode-anthropic', 'opencode-openai'] as const)(
+    'classifies a legacy %s Unknown error as adoptable',
+    (currentModelRoute) => {
+      const policy = new AcpSessionResumePolicy()
+
+      expect(
+        policy.classifyFailure(
+          { code: -32603, message: 'Unknown error' },
+          {
+            currentFrameworkId: 'opencode',
+            currentModelRoute,
+            providerSessionIdPersisted: false
+          }
+        )
+      ).toEqual({
+        disposition: 'adoptable',
+        reason: 'legacy-opencode-session-unavailable'
+      })
+    }
+  )
 
   it.each([
     ['Claude Code', 'claude-code', undefined],
-    ['OpenCode', 'opencode', 'opencode-openai'],
     ['Codex Bridge', 'codex', 'codex-bridge']
   ] as const)(
     'keeps an Unknown error authoritative for legacy %s Sessions',
@@ -275,6 +294,24 @@ describe('ACP Session resume policy', () => {
         {
           currentFrameworkId: 'codex',
           currentModelRoute: 'codex-responses',
+          providerSessionIdPersisted: true
+        }
+      )
+    ).toEqual({
+      disposition: 'authoritative',
+      reason: 'non-internal-error'
+    })
+  })
+
+  it('keeps an Unknown error authoritative for a persisted OpenCode identity', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.classifyFailure(
+        { code: -32603, message: 'Unknown error' },
+        {
+          currentFrameworkId: 'opencode',
+          currentModelRoute: 'opencode-openai',
           providerSessionIdPersisted: true
         }
       )

--- a/src/main/acp/session-resume-policy.test.ts
+++ b/src/main/acp/session-resume-policy.test.ts
@@ -266,6 +266,46 @@ describe('ACP Session resume policy', () => {
   )
 
   it.each([
+    [
+      'non-internal Codex',
+      { code: -32001, message: 'Unknown error' },
+      {
+        currentFrameworkId: 'codex',
+        currentModelRoute: 'codex-responses',
+        providerSessionIdPersisted: false
+      },
+      'non-internal-error'
+    ],
+    [
+      'missing-code OpenCode',
+      { message: 'Unknown error' },
+      {
+        currentFrameworkId: 'opencode',
+        currentModelRoute: 'opencode-openai',
+        providerSessionIdPersisted: false
+      },
+      'non-internal-error'
+    ],
+    [
+      'non-session OpenCode service',
+      { code: -32603, message: 'Unknown error', data: { service: 'transport' } },
+      {
+        currentFrameworkId: 'opencode',
+        currentModelRoute: 'opencode-anthropic',
+        providerSessionIdPersisted: false
+      },
+      'non-session-service-failure'
+    ]
+  ] as const)('keeps a %s Unknown error authoritative', (_label, error, context, reason) => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(policy.classifyFailure(error, context)).toEqual({
+      disposition: 'authoritative',
+      reason
+    })
+  })
+
+  it.each([
     ['Claude Code', 'claude-code', undefined],
     ['Codex Bridge', 'codex', 'codex-bridge']
   ] as const)(

--- a/src/main/acp/session-resume-policy.test.ts
+++ b/src/main/acp/session-resume-policy.test.ts
@@ -224,6 +224,66 @@ describe('ACP Session resume policy', () => {
     })
   })
 
+  it.each(['codex-responses', 'codex-responses-compatibility'] as const)(
+    'classifies a legacy %s Unknown error as adoptable',
+    (currentModelRoute) => {
+      const policy = new AcpSessionResumePolicy()
+
+      expect(
+        policy.classifyFailure(
+          { code: -32603, message: 'Unknown error' },
+          {
+            currentFrameworkId: 'codex',
+            currentModelRoute,
+            providerSessionIdPersisted: false
+          }
+        )
+      ).toEqual({
+        disposition: 'adoptable',
+        reason: 'legacy-codex-session-unavailable'
+      })
+    }
+  )
+
+  it.each([
+    ['Claude Code', 'claude-code', undefined],
+    ['OpenCode', 'opencode', 'opencode-openai'],
+    ['Codex Bridge', 'codex', 'codex-bridge']
+  ] as const)(
+    'keeps an Unknown error authoritative for legacy %s Sessions',
+    (_label, currentFrameworkId, currentModelRoute) => {
+      const policy = new AcpSessionResumePolicy()
+
+      expect(
+        policy.classifyFailure(
+          { code: -32603, message: 'Unknown error' },
+          { currentFrameworkId, currentModelRoute, providerSessionIdPersisted: false }
+        )
+      ).toEqual({
+        disposition: 'authoritative',
+        reason: 'non-internal-error'
+      })
+    }
+  )
+
+  it('keeps an Unknown error authoritative for a persisted Codex Responses identity', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.classifyFailure(
+        { code: -32603, message: 'Unknown error' },
+        {
+          currentFrameworkId: 'codex',
+          currentModelRoute: 'codex-responses',
+          providerSessionIdPersisted: true
+        }
+      )
+    ).toEqual({
+      disposition: 'authoritative',
+      reason: 'non-internal-error'
+    })
+  })
+
   it('treats the provider session-service marker as an adoptable failure', () => {
     const policy = new AcpSessionResumePolicy()
 

--- a/src/main/acp/session-resume-policy.ts
+++ b/src/main/acp/session-resume-policy.ts
@@ -57,6 +57,7 @@ type AcpSessionResumeAdoptableFailureReason =
   | 'unresumable-error-kind'
   | 'legacy-unresumable-details'
   | 'legacy-codex-session-unavailable'
+  | 'legacy-opencode-session-unavailable'
 
 type AcpSessionResumeAuthoritativeFailureReason =
   | 'unrecognized-error'
@@ -255,14 +256,24 @@ class AcpSessionResumePolicy {
     }
 
     if (
-      context?.currentFrameworkId === 'codex' &&
-      context.providerSessionIdPersisted === false &&
-      (context.currentModelRoute === 'codex-responses' ||
-        context.currentModelRoute === 'codex-responses-compatibility') &&
+      context?.providerSessionIdPersisted === false &&
       typeof message.value === 'string' &&
       /^unknown error\.?$/i.test(message.value.trim())
     ) {
-      return adoptableFailure('legacy-codex-session-unavailable')
+      if (
+        context.currentFrameworkId === 'codex' &&
+        (context.currentModelRoute === 'codex-responses' ||
+          context.currentModelRoute === 'codex-responses-compatibility')
+      ) {
+        return adoptableFailure('legacy-codex-session-unavailable')
+      }
+      if (
+        context.currentFrameworkId === 'opencode' &&
+        (context.currentModelRoute === 'opencode-anthropic' ||
+          context.currentModelRoute === 'opencode-openai')
+      ) {
+        return adoptableFailure('legacy-opencode-session-unavailable')
+      }
     }
 
     if (code.value !== -32603) {

--- a/src/main/acp/session-resume-policy.ts
+++ b/src/main/acp/session-resume-policy.ts
@@ -255,6 +255,20 @@ class AcpSessionResumePolicy {
       return adoptableFailure('session-not-found-message')
     }
 
+    if (code.value !== -32603) {
+      return code.value !== undefined || message.value !== undefined
+        ? authoritativeFailure('non-internal-error')
+        : authoritativeFailure('unrecognized-error')
+    }
+
+    const data = readProperty(error, 'data')
+    if (!data.readable) return authoritativeFailure('uninspectable-error')
+
+    const service = readProperty(data.value, 'service')
+    if (!service.readable) return authoritativeFailure('uninspectable-error')
+    if (service.value === 'session') return adoptableFailure('session-service-failure')
+    if (service.value !== undefined) return authoritativeFailure('non-session-service-failure')
+
     if (
       context?.providerSessionIdPersisted === false &&
       typeof message.value === 'string' &&
@@ -275,20 +289,6 @@ class AcpSessionResumePolicy {
         return adoptableFailure('legacy-opencode-session-unavailable')
       }
     }
-
-    if (code.value !== -32603) {
-      return code.value !== undefined || message.value !== undefined
-        ? authoritativeFailure('non-internal-error')
-        : authoritativeFailure('unrecognized-error')
-    }
-
-    const data = readProperty(error, 'data')
-    if (!data.readable) return authoritativeFailure('uninspectable-error')
-
-    const service = readProperty(data.value, 'service')
-    if (!service.readable) return authoritativeFailure('uninspectable-error')
-    if (service.value === 'session') return adoptableFailure('session-service-failure')
-    if (service.value !== undefined) return authoritativeFailure('non-session-service-failure')
 
     if (typeof message.value !== 'string' || !/^internal error\.?$/i.test(message.value.trim())) {
       return authoritativeFailure('non-internal-error')

--- a/src/main/acp/session-resume-policy.ts
+++ b/src/main/acp/session-resume-policy.ts
@@ -14,6 +14,12 @@ type AcpSessionResumePolicyInput = Readonly<{
   resumeCapabilityAdvertised: boolean
 }>
 
+type AcpSessionResumeFailureContext = Readonly<{
+  currentFrameworkId: AgentFrameworkId
+  currentModelRoute?: AgentModelRoute
+  providerSessionIdPersisted: boolean
+}>
+
 type AcpSessionResumeAdoptionReason =
   | 'framework-changed'
   | 'backend-changed'
@@ -50,6 +56,7 @@ type AcpSessionResumeAdoptableFailureReason =
   | 'session-service-failure'
   | 'unresumable-error-kind'
   | 'legacy-unresumable-details'
+  | 'legacy-codex-session-unavailable'
 
 type AcpSessionResumeAuthoritativeFailureReason =
   | 'unrecognized-error'
@@ -230,7 +237,10 @@ class AcpSessionResumePolicy {
     })
   }
 
-  classifyFailure(error: unknown): AcpSessionResumeFailureClassification {
+  classifyFailure(
+    error: unknown,
+    context?: AcpSessionResumeFailureContext
+  ): AcpSessionResumeFailureClassification {
     const code = readProperty(error, 'code')
     if (!code.readable) return authoritativeFailure('uninspectable-error')
     if (code.value === -32002) return adoptableFailure('resource-not-found-code')
@@ -242,6 +252,17 @@ class AcpSessionResumePolicy {
       /resource not found|session not found|no rollout found for thread id/i.test(message.value)
     ) {
       return adoptableFailure('session-not-found-message')
+    }
+
+    if (
+      context?.currentFrameworkId === 'codex' &&
+      context.providerSessionIdPersisted === false &&
+      (context.currentModelRoute === 'codex-responses' ||
+        context.currentModelRoute === 'codex-responses-compatibility') &&
+      typeof message.value === 'string' &&
+      /^unknown error\.?$/i.test(message.value.trim())
+    ) {
+      return adoptableFailure('legacy-codex-session-unavailable')
     }
 
     if (code.value !== -32603) {
@@ -280,6 +301,7 @@ class AcpSessionResumePolicy {
 
 export { AcpSessionResumePolicy }
 export type {
+  AcpSessionResumeFailureContext,
   AcpSessionResumeAdoptionReason,
   AcpSessionResumeAdoptableFailureReason,
   AcpSessionResumeAuthoritativeFailureReason,


### PR DESCRIPTION
## Problem

Open Science v0.12.1 can fail to reopen legacy provider sessions with RPC `-32603 Unknown error`. Older session records may not contain a persisted provider session ID, and older Codex Responses or OpenCode adapters can reduce an unavailable provider session to that generic error. The error was classified as authoritative and surfaced as “Agent session resume failed”.

## Proposed change

- Pass the current ACP framework/model route and provider-session persistence state into resume-failure classification.
- Fresh-adopt only when all of these signals match: no persisted provider session ID, the exact generic `Unknown error`, internal RPC code `-32603`, no explicit non-session service marker, and either a Codex Responses/Responses Compatibility route or an OpenCode Anthropic/OpenAI route.
- Keep authoritative failure behavior for Claude Code, Codex Bridge, persisted Codex/OpenCode provider identities, non-internal or missing RPC codes, and explicit non-session service failures.
- Preserve existing handling for explicit session-not-found messages and OpenCode `data.service = session` failures.
- Add policy and resumer regression coverage for both Codex and OpenCode.

This retains the local conversation and lets the next turn replay into a fresh provider session. Hidden provider-side context is reset once for the affected legacy session.

## Scope and non-goals

This is limited to the main-process ACP session-resume path. It does not change IPC/shared contracts, provider authentication, model selection, or the general handling of RPC `-32603` outside the guarded legacy routes.

## Acceptance criteria and validation

- Legacy Codex Responses/Compatibility session without a provider ID + exact `-32603 Unknown error` → fresh adoption.
- Legacy OpenCode Anthropic/OpenAI session without a provider ID + exact `-32603 Unknown error` → fresh adoption.
- Other frameworks/routes, persisted Codex/OpenCode identities, non-internal or missing codes, and non-session services → error remains authoritative.
- `npm test -- src/main/acp/provider-session-resumer.test.ts src/main/acp/session-resume-policy.test.ts` → 64/64 passed.
- `npm run typecheck:node` → passed.
- `npm run lint` → 0 errors; 17 unrelated existing warnings.
- `git diff --check` → passed.

The full `npm test` run did not complete green in this Windows environment: 907/927 test files passed, with 13 skipped and 7 failed (13046 tests passed, 275 skipped, 21 failed). The failures are outside the changed files and are dominated by Windows symlink/ACL/file-lock errors and existing timeout failures under suite contention.

## Review focus

Please focus on the narrowness and ordering of the RPC code/service/framework/route/provider-identity guard and whether fresh adoption is the correct boundary for legacy Codex Responses and OpenCode sessions. Packaged adapter end-to-end behavior remains uncovered; deterministic main-process policy/resumer tests cover both reported decision paths and the authoritative-error boundaries.