### PR TITLE
test(acp): relax notebook static context budget

### DIFF
--- a/src/main/acp/context-usage-static-context.test.ts
+++ b/src/main/acp/context-usage-static-context.test.ts
@@ -48,7 +48,7 @@ describe('contextUsageMcpSections', () => {
     // Baseline before deduplication was about 5.2k cl100k tokens (3.6k schema + 1.6k prompt).
     expect(
       tokenizer.encode(`${NOTEBOOK_SYSTEM_PROMPT_APPEND}\n${schema}`).length
-    ).toBeLessThanOrEqual(3_200)
+    ).toBeLessThanOrEqual(3_300)
   })
 
   it('uses bridge aliases for Codex MCP tools delivered through a compatibility proxy', () => {

--- a/src/main/acp/context-usage-static-context.test.ts
+++ b/src/main/acp/context-usage-static-context.test.ts
@@ -48,7 +48,7 @@ describe('contextUsageMcpSections', () => {
     // Baseline before deduplication was about 5.2k cl100k tokens (3.6k schema + 1.6k prompt).
     expect(
       tokenizer.encode(`${NOTEBOOK_SYSTEM_PROMPT_APPEND}\n${schema}`).length
-    ).toBeLessThanOrEqual(3_300)
+    ).toBeLessThanOrEqual(3_500)
   })
 
   it('uses bridge aliases for Codex MCP tools delivered through a compatibility proxy', () => {


### PR DESCRIPTION
## Problem

Windows Full Test run [31367328897](https://github.com/aipoch/open-science/actions/runs/31367328897/job/93388445578) failed because the Notebook prompt plus serialized MCP schema measured 3,229 cl100k tokens, while the static-context regression guard still allowed only 3,200.

The increase was introduced by the `host.capabilities` and `self-awareness` guidance added in #1064. The later ACP commit shown by the linked run did not cause the increase; it only triggered the same main-branch check again.

## Proposed change

Relax the Notebook static-context budget from 3,200 to 3,500 tokens. This preserves a regression guard while allowing 271 tokens of headroom above the current 3,229-token baseline for future capability guidance. This direction follows the repository owner's explicit decision to retain future headroom rather than compress the current capability contract.

## Scope and non-goals

- Change only the static-context budget assertion.
- Do not change the Notebook prompt, MCP schemas, runtime behavior, or user-facing behavior.
- Do not alter CI workflow configuration.

## Acceptance criteria and validation

The final Test Impact Set below ran after the last material edit.

- Notebook static-context budget and adjacent prompt contract -> `npm test -- src/main/acp/context-usage-static-context.test.ts src/main/notebook/mcp-server.test.ts` -> 2 files passed; 59 tests passed.
- Exact failed Windows shard -> `npm test -- --shard=3/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000` -> 305 files passed; 4,007 tests passed; 5 files and 51 tests skipped.
- Main-process types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings.
- Hosted Windows Full Test -> [run 31371889883](https://github.com/aipoch/open-science/actions/runs/31371889883) at `f2e9b361` -> shards 1/3, 2/3, and 3/3 passed.
- PR checks -> PR Gate, both macOS full-module shards, macOS build/E2E, Windows core/E2E, CI Integrity, CodeQL, static checks, and PR policy passed.

An additional full `npm test` attempt was made before the final headroom increase. The target budget test passed, but the suite was not fully green locally: 911 files passed, 13 skipped, and 7 files had 22 unrelated failures caused by Windows symlink/ACL restrictions and default 15-second timeouts. The exact Windows CI shard above passed on the final commit with the workflow's real timeout and worker settings.

No production interface or consumer changed, so no renderer or cross-runtime consumer lane is required. The Windows platform lane is included because it reproduces the linked failure.

Independent Codex review reported one policy disagreement: it recommends retaining the 3,200 ceiling and compressing payload text. That recommendation conflicts with the repository owner's explicit direction to raise the ceiling to 3,500 for future growth; no correctness defect or failing validation was identified.

## Review focus

- Whether the owner's 3,500-token ceiling is the desired long-term policy above the current 3,229-token baseline.
- Whether the documented 271-token headroom is sufficient for future capability guidance.
