### PR TITLE
fix(workspace): capture custom-answer value before state updater

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
@@ -595,13 +595,14 @@ const WorkspaceElicitationCard = ({
                 MAX_ELICITATION_MESSAGE_CHARS
               )}
               className="max-h-40 min-h-9 min-w-0 flex-1 resize-none overflow-y-auto rounded-none border-0 bg-transparent px-0 py-1.5 shadow-none focus-visible:border-transparent focus-visible:ring-0"
-              onChange={(event) =>
+              onChange={(event) => {
+                const value = event.currentTarget.value
                 setValues((current) => ({
                   ...current,
                   [choiceQuestion.choiceField.id]: undefined,
-                  [choiceQuestion.customField.id]: event.currentTarget.value
+                  [choiceQuestion.customField.id]: value
                 }))
-              }
+              }}
             />
             <Button
               className="mt-0.5"


### PR DESCRIPTION
## Problem

When the agent calls `ask_user_question` and the user types into the "Or type your own answer" textarea of the choice card, the workspace whitescreens. Renderer log:

```
[renderer] renderer javascript failure
  source: 'window-error', surface: 'workspace', errorCategory: 'type', fingerprint: '5aec8bf4'
```

DevTools:

```
Uncaught TypeError: Cannot read properties of null (reading 'value')
    at WorkspaceElicitationCard.tsx:602:72
    at basicStateReducer ... (useState)
```

Root cause: the textarea's `onChange` read `event.currentTarget.value` **inside** the `setValues` functional updater. Functional updaters run on the deferred render pass, after React nulls the synthetic event's `currentTarget` — so the read hit `null.value` and, with no error boundary in this tree, unmounted the whole workspace.

## Proposed change

Read `event.currentTarget.value` into a local in the synchronous handler, then let the updater close over the local. Mirrors the number field's existing pattern in the same file.

## Scope and non-goals

- In scope: the single `currentTarget`-in-updater site (`WorkspaceElicitationCard.tsx:602`), verified to be the only such site in the renderer.
- Non-goals: `event.target`-in-updater sites elsewhere (`SpecialistEditor`, `NetworkPanel`) share the smell but do not crash — native `target` is not nulled post-callback — so they are left for a separate cleanup.

## Acceptance criteria and validation

Manual: in `npm run dev` / `dev:web`, trigger `ask_user_question`, type a custom answer → no whitescreen, value submits correctly.

Evidence mapping (all ran after the last material edit, in the `.worktree/fix-ask-user-question-feedback` checkout off `origin/main`):

| behavior | command | result |
| --- | --- | --- |
| custom-answer input + Finish/Skip/agent-decide | `vitest run src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx` | 14/14 pass |
| ConversationPanel composer integration (durable + structured input) | `vitest run src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` | 78/78 pass |
| renderer types | `npm run typecheck:web` | pass |
| changed file lint | `eslint src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx` | clean |

Uncovered risk: jsdom cannot reproduce this (under `act()` the updater flushes synchronously, before `currentTarget` is nulled), so regression guard is the functional tests + manual verification. An e2e guard was deferred per request.

## Review focus

- Correctness of the behavior change (semantics unchanged: clear choice field, set custom value).
- Whether to also clean up the `event.target`-in-updater sites now or defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)