### PR TITLE
fix(acp): route Codex reviewer approvals through elicitation

### DIFF
--- a/src/main/acp/client-interaction-owner.test.ts
+++ b/src/main/acp/client-interaction-owner.test.ts
@@ -43,6 +43,8 @@ const codexApprovalRequest = (): CreateElicitationRequest => ({
 const createOwner = (
   options: {
     frameworkId?: AgentFrameworkId
+    activeSession?: boolean
+    reviewerFrameworkId?: AgentFrameworkId
     hasTrustedCodexMcpToolCall?: boolean
     consumeTrustedCodexMcpToolCall?: boolean
   } = {}
@@ -68,8 +70,9 @@ const createOwner = (
   const owner = new AcpClientInteractionOwner({
     routing: {
       resolveAppSessionId: () => 'app-session',
-      isActiveSession: () => true,
+      isActiveSession: () => options.activeSession ?? true,
       frameworkForSession: () => options.frameworkId ?? 'claude-code',
+      reviewerFrameworkForSession: () => options.reviewerFrameworkId,
       promptMessageIdForSession: () => 'prompt-1'
     },
     elicitation: { request: requestElicitation },
@@ -162,6 +165,35 @@ describe('ACP client interaction owner', () => {
       ],
       _meta: { is_mcp_tool_approval: true }
     })
+    expect(requestElicitation).not.toHaveBeenCalled()
+  })
+
+  it('routes a trusted Codex reviewer MCP approval elicitation to authorization', async () => {
+    const { owner, requestElicitation, requestPermission } = createOwner({
+      activeSession: false,
+      reviewerFrameworkId: 'codex',
+      hasTrustedCodexMcpToolCall: true
+    })
+
+    await expect(owner.createElicitation(codexApprovalRequest())).resolves.toEqual({
+      action: 'accept'
+    })
+
+    expect(requestPermission).toHaveBeenCalledOnce()
+    expect(requestElicitation).not.toHaveBeenCalled()
+  })
+
+  it('fails closed for ordinary reviewer elicitation', async () => {
+    const { owner, requestElicitation, requestPermission } = createOwner({
+      activeSession: false,
+      reviewerFrameworkId: 'codex'
+    })
+
+    await expect(owner.createElicitation(elicitationRequest())).resolves.toEqual({
+      action: 'cancel'
+    })
+
+    expect(requestPermission).not.toHaveBeenCalled()
     expect(requestElicitation).not.toHaveBeenCalled()
   })
 

--- a/src/main/acp/client-interaction-owner.ts
+++ b/src/main/acp/client-interaction-owner.ts
@@ -14,6 +14,7 @@ type AcpClientInteractionOwnerOptions = {
     resolveAppSessionId: (providerSessionId: string) => string
     isActiveSession: (appSessionId: string) => boolean
     frameworkForSession: (appSessionId: string) => AgentFrameworkId | undefined
+    reviewerFrameworkForSession: (providerSessionId: string) => AgentFrameworkId | undefined
     promptMessageIdForSession: (appSessionId: string) => string | undefined
   }
   elicitation: Pick<AcpElicitationOwner, 'request'>
@@ -50,15 +51,21 @@ class AcpClientInteractionOwner {
     }
 
     const sessionId = this.options.routing.resolveAppSessionId(params.sessionId)
-    if (!this.options.routing.isActiveSession(sessionId)) {
+    const isActiveSession = this.options.routing.isActiveSession(sessionId)
+    const reviewerFramework = this.options.routing.reviewerFrameworkForSession(params.sessionId)
+    if (!isActiveSession && reviewerFramework === undefined) {
       return Promise.resolve({ action: 'cancel' })
     }
 
-    const intent = classifyElicitation(this.options.routing.frameworkForSession(sessionId), params)
+    const intent = classifyElicitation(
+      reviewerFramework ?? this.options.routing.frameworkForSession(sessionId),
+      params
+    )
     if (intent.kind === 'reject') return Promise.resolve({ action: 'cancel' })
     if (intent.kind === 'authorization') {
       return this.requestCodexMcpAuthorization(params.sessionId, sessionId, intent.toolCallId)
     }
+    if (reviewerFramework !== undefined) return Promise.resolve({ action: 'cancel' })
 
     const promptMessageId = this.options.routing.promptMessageIdForSession(sessionId)
     return this.options.elicitation.request(

--- a/src/main/acp/runtime-session-composition.ts
+++ b/src/main/acp/runtime-session-composition.ts
@@ -222,6 +222,8 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
       isActiveSession: (sessionId) => sessionRegistry.lookup(sessionId)?.attachment !== undefined,
       frameworkForSession: (sessionId) =>
         sessionRegistry.lookup(sessionId)?.aggregate.snapshot().frameworkId,
+      reviewerFrameworkForSession: (sessionId) =>
+        reviewerSessions.contextFor(sessionId)?.frameworkId,
       promptMessageIdForSession: (sessionId) => {
         const interaction = base.sessionInteractions.current(sessionId)
         return interaction?.kind === 'prompt' ? interaction.promptMessageId : undefined

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -726,6 +726,7 @@ const startPermissionProbeAgent = (
     }
     codexMcpMarker?: boolean
     codexMcpTitle?: string
+    codexMcpApprovalViaElicitation?: boolean
     announceToolCall?: boolean
     sparseCodexMcpApproval?: boolean
     modes?: SessionModeState
@@ -817,6 +818,19 @@ const startPermissionProbeAgent = (
 
       // opencode renames MCP tools <server>_<tool>; classification must come from the session's
       // recorded MCP server names, so this exercises the sessionMcpServerNames map end to end.
+      if (options.codexMcpApprovalViaElicitation) {
+        const response = await ctx.client.request(acp.methods.client.elicitation.create, {
+          mode: 'form',
+          sessionId: ctx.params.sessionId,
+          toolCallId: options.toolCallId,
+          message: 'Allow this MCP tool?',
+          requestedSchema: { type: 'object', properties: {} },
+          _meta: { codex_approval_kind: 'mcp_tool_call' }
+        })
+        options.onPermissionResponse?.(response)
+        return { stopReason: 'end_turn' }
+      }
+
       const response = await ctx.client.request(acp.methods.client.session.requestPermission, {
         sessionId: ctx.params.sessionId,
         toolCall: {
@@ -11160,6 +11174,57 @@ describe('ACP runtime session management', () => {
       expect(permissionResponse).toEqual({
         outcome: { outcome: 'selected', optionId: expectedOptionId }
       })
+      runtime.disposeReviewerSession(session)
+    }
+  )
+
+  it.each([
+    { tool: 'read_turn', expectedResponse: { action: 'accept' } },
+    { tool: 'query_execution_log', expectedResponse: { action: 'accept' } },
+    { tool: 'read_artifact', expectedResponse: { action: 'accept' } },
+    { tool: 'submit_findings', expectedResponse: { action: 'accept' } },
+    { tool: 'run_shell', expectedResponse: { action: 'decline' } }
+  ])(
+    'handles Codex reviewer MCP tool $tool requested through elicitation/create',
+    async ({ tool, expectedResponse }) => {
+      const process = new FakeAgentProcess()
+      let elicitationResponse: unknown
+      startPermissionProbeAgent(process, {
+        newSessionId: 'codex-reviewer-elicitation-session',
+        toolCallId: `codex-reviewer-elicitation-${tool}`,
+        toolTitle: 'unused by Codex approval elicitation',
+        codexMcpIdentity: {
+          server: 'open-science-reviewer',
+          tool,
+          arguments: { checks: [] }
+        },
+        codexMcpApprovalViaElicitation: true,
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+        onPermissionResponse: (response) => {
+          elicitationResponse = response
+        }
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        framework: codexFramework
+      })
+
+      const { session } = await runtime.buildReviewerSession({
+        cwd: '/workspace',
+        mcpServers: [
+          {
+            type: 'http',
+            name: 'open-science-reviewer',
+            url: 'http://127.0.0.1:1/mcp',
+            headers: []
+          }
+        ]
+      })
+      await session.prompt([{ type: 'text', text: 'submit the reviewer findings' }])
+
+      expect(elicitationResponse).toEqual(expectedResponse)
       runtime.disposeReviewerSession(session)
     }
   )


### PR DESCRIPTION
## Problem

Codex ACP can deliver MCP approval requests through `elicitation/create`. Background Reviewer sessions are owned outside the primary Session registry, but the elicitation ingress only treated primary Session attachments as active. Codex Reviewer approvals were therefore cancelled before trusted MCP identity restoration and the strict Reviewer allowlist, causing every Reviewer MCP call to be declined and leaving the orchestrator to report that `submit_findings` was never called.

## Proposed change

- Resolve the framework for active Reviewer sessions at the client-interaction boundary.
- Route only trusted Codex MCP approval elicitations through the existing permission owner and strict Reviewer allowlist.
- Keep ordinary Reviewer elicitations fail-closed so background review cannot open user-input UI.
- Add deterministic runtime coverage for the current Codex `tool_call` followed by `elicitation/create` wire shape.

## Scope and non-goals

- This does not move Reviewer execution to elicitation or change `session/request_permission`; both ACP approval ingress paths remain supported.
- Claude Code and OpenCode permission routing is unchanged.
- The Reviewer MCP allowlist, Responses bridges, model selection, and Windows named-pipe transport are unchanged.
- No dependency, persistence, schema, or renderer changes are included.

## Acceptance criteria and validation

All checks below ran after the last material edit.

| Behavior | Framework / path | Command | Result |
| --- | --- | --- | --- |
| Reviewer tools `read_turn`, `query_execution_log`, `read_artifact`, and `submit_findings` are allowed; unknown `run_shell` is declined | Codex / `tool_call` -> `elicitation/create` -> permission owner | `npm test -- --run src/main/acp/runtime.test.ts -t 'handles Codex reviewer MCP tool'` | 5 passed |
| Trusted Reviewer approval is routed while ordinary Reviewer elicitation remains fail-closed | Shared client-interaction owner | `npm test -- --run src/main/acp/client-interaction-owner.test.ts` | 10 passed |
| Main and renderer TypeScript contracts remain valid | Node + Web | `npm run typecheck` | passed |
| Source lint remains clean | Repository | `npm run lint` | 0 errors; 17 existing warnings outside this diff |
| Portable regression suite | All declared Vitest paths, including existing Claude Code, OpenCode, Codex `session/request_permission`, bridge, and Reviewer lifecycle coverage | `npm test` | 917 files / 13,195 tests passed; 15 files / 192 tests skipped by repository configuration |

The module-impact planner selected the full fallback because the changed ACP owner files are not yet explicitly owned in `scripts/ci/module-impact.json`. The first sandboxed full-suite attempt failed on prohibited `127.0.0.1` listeners; the identical command passed when rerun with loopback binding enabled.

Model-specific live runs are excluded because the defect is in deterministic ACP request routing and the report reproduces across models. A packaged Windows run is not available locally; the change is platform-neutral and does not touch the Windows Reviewer transport, so exact-head CI remains the platform authority.

## Review focus

- Active Reviewer identity is consulted only for authorization-classified Codex elicitations.
- Ordinary Reviewer elicitation remains cancelled.
- Existing trusted identity restoration and strict Reviewer allow/deny decisions remain the sole authorization authority.

Closes #1070
