### PR TITLE
fix(session-persistence): preserve restored MCP activity

### DIFF
--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -9,7 +9,7 @@ vi.mock('electron', () => ({
   app: { getPath: () => '/home/user', isPackaged: true }
 }))
 
-import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { PersistedChatSession, PersistedToolActivity } from '../../shared/session-persistence'
 import { DEV_SESSION_DIR_NAME, SessionRepository, getSessionPersistenceDir } from './repository'
 
 let storageRoot: string | undefined
@@ -39,6 +39,18 @@ const createSession = (overrides: Partial<PersistedChatSession> = {}): Persisted
   createdAt: 1710000000000,
   updatedAt: 1710000000100,
   ...overrides
+})
+
+const createPendingMcpToolActivity = (): PersistedToolActivity => ({
+  id: 'tool-1',
+  kind: 'tool',
+  title: 'Run npm test',
+  status: 'in_progress',
+  sortIndex: 1,
+  eventIds: ['tool-1-started'],
+  promptMessageId: 'message-1',
+  createdAt: 1710000000200,
+  updatedAt: 1710000000200
 })
 
 afterEach(async () => {
@@ -652,6 +664,7 @@ describe('session persistence repository (per-session files)', () => {
       createSession({
         status: 'waiting-permission',
         activeRun: { promptMessageId: 'message-1', startedAt: 1710000000200 },
+        activities: [createPendingMcpToolActivity()],
         runtimeContext: {
           version: 1,
           revision: 1,
@@ -662,7 +675,8 @@ describe('session persistence repository (per-session files)', () => {
               sessionId: 'session-1',
               toolCallId: 'tool-1',
               title: 'Run npm test',
-              providerToolName: 'Bash',
+              providerToolName: 'notebook_execute',
+              isMcp: true,
               rawInput: { command: 'npm test' },
               options: [
                 {
@@ -727,6 +741,7 @@ describe('session persistence repository (per-session files)', () => {
       createSession({
         status: 'running',
         activeRun: { promptMessageId: 'message-1', startedAt: 1710000000200 },
+        activities: [createPendingMcpToolActivity()],
         runtimeContext: {
           version: 1,
           revision: 2,
@@ -737,6 +752,7 @@ describe('session persistence repository (per-session files)', () => {
               sessionId: 'session-1',
               toolCallId: 'tool-1',
               title: 'Run npm test',
+              isMcp: true,
               options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }]
             },
             originatingPromptMessageId: 'message-1',

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -11,6 +11,7 @@ import {
   sanitizeToolActivity,
   type PersistedChatSession,
   type PersistedSideChat,
+  type PersistedToolActivity,
   type SessionPermissionRuntimeContext,
   type SessionPlanRuntimeContext
 } from './session-persistence'
@@ -37,6 +38,62 @@ const createSessionWithActivity = (activity: unknown): Record<string, unknown> =
 
 const getRestoredActivities = (session: unknown): PersistedChatSession['activities'] =>
   normalizeSessionFile(session)?.activities
+
+const createOpenToolActivity = (
+  id = 'tool-1',
+  overrides: Partial<PersistedToolActivity> = {}
+): PersistedToolActivity => ({
+  id,
+  kind: 'tool',
+  title: 'Run npm test',
+  status: 'in_progress',
+  sortIndex: 1,
+  eventIds: [`${id}-started`],
+  promptMessageId: 'prompt-1',
+  createdAt: 2,
+  updatedAt: 2,
+  ...overrides
+})
+
+const createContinuingPermissionFile = (
+  activities: PersistedToolActivity[],
+  originatingPromptMessageId = 'prompt-1'
+): ReturnType<typeof createSessionFile> =>
+  createSessionFile({
+    ...(createSessionWithActivity(undefined) as PersistedChatSession),
+    activities,
+    status: 'running',
+    activeRun: { promptMessageId: 'prompt-1', startedAt: 2 },
+    messages: [
+      {
+        id: 'prompt-1',
+        role: 'user',
+        content: 'Run the tests',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ],
+    runtimeContext: {
+      version: 1,
+      revision: 4,
+      permission: {
+        state: 'continuing',
+        request: {
+          requestId: 'permission-1',
+          sessionId: 'session-1',
+          toolCallId: 'tool-1',
+          title: 'Run npm test',
+          isMcp: true,
+          options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }]
+        },
+        originatingPromptMessageId,
+        fingerprint: 'a'.repeat(64),
+        createdAt: 2
+      }
+    }
+  })
 
 const createRuntimePlan = (): SessionPlanRuntimeContext => ({
   artifactId: 'plan-1',
@@ -1080,101 +1137,179 @@ describe('normalizeSessionFile with activities', () => {
     expect(normalizePermission({ ...permission, state: 'unknown' })).toBeUndefined()
   })
 
-  it('rearms a prompt-bound continuing permission after restart', () => {
-    const restored = normalizeSessionFile(
-      createSessionFile({
-        ...(createSessionWithActivity(undefined) as PersistedChatSession),
-        activities: undefined,
-        status: 'running',
-        activeRun: { promptMessageId: 'prompt-1', startedAt: 2 },
-        messages: [
-          {
-            id: 'prompt-1',
-            role: 'user',
-            content: 'Run the tests',
-            status: 'complete',
-            eventIds: [],
-            createdAt: 1,
-            updatedAt: 1
-          }
-        ],
+  it.each(['pending', 'in_progress'] as const)(
+    'rearms a prompt-bound continuing MCP permission without failing its %s tool activity',
+    (status) => {
+      const restored = normalizeSessionFile(
+        createContinuingPermissionFile([
+          createOpenToolActivity('tool-1', { status }),
+          createOpenToolActivity('unrelated-tool', {
+            title: 'Read another file',
+            sortIndex: 2,
+            createdAt: 3,
+            updatedAt: 3
+          })
+        ])
+      )
+
+      expect(restored).toMatchObject({
+        status: 'waiting-permission',
         runtimeContext: {
           version: 1,
           revision: 4,
           permission: {
-            state: 'continuing',
-            request: {
-              requestId: 'permission-1',
-              sessionId: 'session-1',
-              toolCallId: 'tool-1',
-              title: 'Run npm test',
-              options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }]
-            },
-            originatingPromptMessageId: 'prompt-1',
-            fingerprint: 'a'.repeat(64),
-            createdAt: 2
+            state: 'pending',
+            originatingPromptMessageId: 'prompt-1'
           }
         }
       })
+      expect(restored?.activeRun).toBeUndefined()
+      expect(restored?.resumeRecovery).toBeUndefined()
+      expect(restored?.error).toBeUndefined()
+      expect(restored?.messages[0]?.interrupted).toBeUndefined()
+      expect(restored?.activities?.[0]?.status).toBe(status)
+      expect(restored?.conversationGraph?.activities[0]?.status).toBe(status)
+      expect(restored?.activities?.[1]?.status).toBe('failed')
+      expect(restored?.conversationGraph?.activities[1]?.status).toBe('failed')
+    }
+  )
+
+  it('fails a permission tool activity hidden by the active conversation branch', () => {
+    const persisted = createContinuingPermissionFile([createOpenToolActivity()])
+    expect(persisted.session.conversationGraph).toBeDefined()
+    const conversationGraph = forkConversationAfterActivity(
+      persisted.session.conversationGraph!,
+      'prompt-1',
+      'tool-1',
+      'revised-branch',
+      3
     )
 
-    expect(restored).toMatchObject({
-      status: 'waiting-permission',
-      runtimeContext: {
-        version: 1,
-        revision: 4,
-        permission: {
-          state: 'pending',
-          originatingPromptMessageId: 'prompt-1'
-        }
-      }
+    const restored = normalizeSessionFile({
+      ...persisted,
+      session: { ...persisted.session, conversationGraph }
     })
-    expect(restored?.activeRun).toBeUndefined()
-    expect(restored?.resumeRecovery).toBeUndefined()
-    expect(restored?.error).toBeUndefined()
-    expect(restored?.messages[0]?.interrupted).toBeUndefined()
+
+    expect(restored?.status).toBe('error')
+    expect(restored?.runtimeContext?.permission).toBeUndefined()
+    expect(restored?.activities?.[0]?.status).toBe('failed')
+    expect(restored?.conversationGraph?.activities[0]?.status).toBe('failed')
   })
 
-  it('releases an invalid continuing permission before generic restart recovery', () => {
+  it('releases a non-MCP permission instead of preserving its open tool activity', () => {
+    const persisted = createContinuingPermissionFile([createOpenToolActivity()])
+    persisted.session.runtimeContext!.permission!.request.isMcp = false
+
+    const restored = normalizeSessionFile(persisted)
+
+    expect(restored?.status).toBe('error')
+    expect(restored?.runtimeContext?.permission).toBeUndefined()
+    expect(restored?.activities?.[0]?.status).toBe('failed')
+    expect(restored?.conversationGraph?.activities[0]?.status).toBe('failed')
+  })
+
+  it('releases a permission whose exact tool activity is missing', () => {
     const restored = normalizeSessionFile(
-      createSessionFile({
-        ...(createSessionWithActivity(undefined) as PersistedChatSession),
-        activities: undefined,
-        status: 'running',
-        activeRun: { promptMessageId: 'prompt-1', startedAt: 2 },
-        messages: [
-          {
-            id: 'prompt-1',
-            role: 'user',
-            content: 'Run the tests',
-            status: 'complete',
-            eventIds: [],
-            createdAt: 1,
-            updatedAt: 1
-          }
-        ],
-        runtimeContext: {
-          version: 1,
-          revision: 4,
-          permission: {
-            state: 'continuing',
-            request: {
-              requestId: 'permission-1',
-              sessionId: 'session-1',
-              toolCallId: 'tool-1',
-              title: 'Run npm test',
-              options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }]
-            },
-            originatingPromptMessageId: 'missing-prompt',
-            fingerprint: 'a'.repeat(64),
-            createdAt: 2
-          }
-        }
-      })
+      createContinuingPermissionFile([createOpenToolActivity('unrelated-tool')])
     )
 
     expect(restored?.status).toBe('error')
     expect(restored?.runtimeContext?.permission).toBeUndefined()
+    expect(restored?.activities?.[0]?.status).toBe('failed')
+    expect(restored?.conversationGraph?.activities[0]?.status).toBe('failed')
+  })
+
+  it('releases a permission whose exact tool activity is already terminal', () => {
+    const restored = normalizeSessionFile(
+      createContinuingPermissionFile([
+        createOpenToolActivity('tool-1', { status: 'completed', updatedAt: 3 })
+      ])
+    )
+
+    expect(restored?.status).toBe('error')
+    expect(restored?.runtimeContext?.permission).toBeUndefined()
+    expect(restored?.activities?.[0]?.status).toBe('completed')
+    expect(restored?.conversationGraph?.activities[0]?.status).toBe('completed')
+  })
+
+  it('releases pending permission authority attached to a non-waiting Session', () => {
+    const persisted = createContinuingPermissionFile([createOpenToolActivity()])
+    const permission = persisted.session.runtimeContext!.permission!
+    const restored = normalizeSessionFile({
+      ...persisted,
+      session: {
+        ...persisted.session,
+        runtimeContext: {
+          ...persisted.session.runtimeContext!,
+          permission: { ...permission, state: 'pending' }
+        }
+      }
+    })
+
+    expect(restored?.status).toBe('error')
+    expect(restored?.runtimeContext?.permission).toBeUndefined()
+    expect(restored?.activities?.[0]?.status).toBe('failed')
+    expect(restored?.conversationGraph?.activities[0]?.status).toBe('failed')
+  })
+
+  it('releases continuing permission authority attached to a non-running Session', () => {
+    const persisted = createContinuingPermissionFile([createOpenToolActivity()])
+    const restored = normalizeSessionFile({
+      ...persisted,
+      session: { ...persisted.session, status: 'idle' }
+    })
+
+    expect(restored?.status).toBe('error')
+    expect(restored?.runtimeContext?.permission).toBeUndefined()
+    expect(restored?.activities?.[0]?.status).toBe('failed')
+    expect(restored?.conversationGraph?.activities[0]?.status).toBe('failed')
+  })
+
+  it('releases permission authority with duplicated flat tool call correlation', () => {
+    const persisted = createContinuingPermissionFile([createOpenToolActivity()])
+    const activity = persisted.session.activities![0]
+    const restored = normalizeSessionFile({
+      ...persisted,
+      session: {
+        ...persisted.session,
+        activities: [activity, { ...activity, title: 'Duplicate tool projection' }]
+      }
+    })
+
+    expect(restored?.status).toBe('error')
+    expect(restored?.runtimeContext?.permission).toBeUndefined()
+    expect(restored?.activities?.map((candidate) => candidate.status)).toEqual(['failed', 'failed'])
+    expect(restored?.conversationGraph?.activities[0]?.status).toBe('failed')
+  })
+
+  it('fails a mismatched flat permission activity instead of trusting its tool call id', () => {
+    const persisted = createContinuingPermissionFile([createOpenToolActivity()])
+    const restored = normalizeSessionFile({
+      ...persisted,
+      session: {
+        ...persisted.session,
+        activities: persisted.session.activities?.map((activity) => ({
+          ...activity,
+          promptMessageId: 'stale-prompt'
+        }))
+      }
+    })
+
+    expect(restored?.status).toBe('error')
+    expect(restored?.runtimeContext?.permission).toBeUndefined()
+    expect(restored?.activities?.[0]?.status).toBe('failed')
+    expect(restored?.conversationGraph?.activities[0]?.status).toBe('failed')
+  })
+
+  it('releases an invalid continuing permission before generic restart recovery', () => {
+    const restored = normalizeSessionFile(
+      createContinuingPermissionFile([createOpenToolActivity()], 'missing-prompt')
+    )
+
+    expect(restored?.status).toBe('error')
+    expect(restored?.runtimeContext?.permission).toBeUndefined()
+    expect(restored?.activities?.[0]?.status).toBe('failed')
+    expect(restored?.conversationGraph?.activities[0]?.status).toBe('failed')
     expect(restored?.resumeRecovery).toEqual({
       kind: 'resume-required',
       cause: 'app-restart',

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -32,6 +32,7 @@ import {
 import {
   createLinearConversationGraph,
   projectConversationMessage,
+  resolveActiveConversationActivities,
   resolveActiveConversationMessages,
   synchronizeActiveConversationActivities,
   synchronizeActiveConversationMessages,
@@ -1117,14 +1118,52 @@ const isPermissionAuthorityBoundToActivePrompt = (
   )
 }
 
-const hasRestorablePermissionWait = (session: PersistedChatSession): boolean => {
+type RestorablePermissionToolAuthority = Readonly<{
+  permission: SessionPermissionRuntimeContext
+  activity: PersistedBranchActivity
+}>
+
+const resolveRestorablePermissionToolAuthority = (
+  session: PersistedChatSession
+): RestorablePermissionToolAuthority | undefined => {
   const permission = session.runtimeContext?.permission
-  return Boolean(
-    session.status === 'waiting-permission' &&
-    permission?.state === 'pending' &&
-    isPermissionAuthorityBoundToActivePrompt(session, permission)
+  if (
+    !permission ||
+    permission.request.isMcp !== true ||
+    !session.conversationGraph ||
+    !isPermissionAuthorityBoundToActivePrompt(session, permission)
+  ) {
+    return undefined
+  }
+  const activity = session.conversationGraph.activities.find(
+    (candidate) => candidate.id === permission.request.toolCallId
   )
+  const flatActivities =
+    session.activities?.filter((candidate) => candidate.id === permission.request.toolCallId) ?? []
+  const flatActivity = flatActivities.length === 1 ? flatActivities[0] : undefined
+  const visibleActivity = resolveActiveConversationActivities(
+    session.conversationGraph
+  ).activities.find((candidate) => candidate.id === permission.request.toolCallId)
+  if (
+    !activity ||
+    !flatActivity ||
+    !visibleActivity ||
+    activity.promptMessageId !== permission.originatingPromptMessageId ||
+    flatActivity.promptMessageId !== permission.originatingPromptMessageId ||
+    (activity.status !== 'pending' && activity.status !== 'in_progress') ||
+    (flatActivity.status !== 'pending' && flatActivity.status !== 'in_progress')
+  ) {
+    return undefined
+  }
+  return { permission, activity }
 }
+
+const hasRestorablePermissionWait = (session: PersistedChatSession): boolean =>
+  Boolean(
+    session.status === 'waiting-permission' &&
+    session.runtimeContext?.permission?.state === 'pending' &&
+    resolveRestorablePermissionToolAuthority(session)
+  )
 
 // Identifies UI states that cannot survive an app process shutdown. Permission waits are durable
 // only when their main-owned authority and active-branch prompt binding survived with the Session.
@@ -1158,11 +1197,47 @@ const latestUserMessageId = (messages: PersistedChatMessage[]): string | undefin
   [...messages].reverse().find((message) => message.role === 'user')?.id
 
 // Rehydrates durable waits and converts runtime-only work into recoverable states after restart.
-const normalizeSessionAfterRestore = (session: PersistedChatSession): PersistedChatSession => {
+const recoverInterruptedPermissionAfterRestore = (
+  session: PersistedChatSession
+): PersistedChatSession => {
+  const persistedRuntimeContext = session.runtimeContext
+  if (!persistedRuntimeContext) return session
+  const runtimeContext = { ...persistedRuntimeContext }
+  delete runtimeContext.permission
+  const promptMessageId = latestUserMessageId(session.messages)
+  return {
+    ...session,
+    status: 'error',
+    activeRun: undefined,
+    runtimeContext,
+    resumeRecovery: {
+      kind: 'resume-required',
+      cause: 'app-restart',
+      promptMessageId
+    },
+    error: session.error ?? INTERRUPTED_SESSION_ERROR,
+    messages: markInterruptedPrompt(
+      session.messages.map(normalizeMessageAfterRestore),
+      promptMessageId
+    )
+  }
+}
+
+const normalizeSessionAfterRestore = (
+  session: PersistedChatSession,
+  options: { deferPermissionValidation?: boolean } = {}
+): PersistedChatSession => {
   const persistedRuntimeContext = session.runtimeContext
   const continuingPermission = persistedRuntimeContext?.permission
+  if (options.deferPermissionValidation && continuingPermission) {
+    return {
+      ...session,
+      messages: session.messages.map(normalizeMessageAfterRestore)
+    }
+  }
+  const permissionAuthority = resolveRestorablePermissionToolAuthority(session)
   if (persistedRuntimeContext && continuingPermission?.state === 'continuing') {
-    if (isPermissionAuthorityBoundToActivePrompt(session, continuingPermission)) {
+    if (permissionAuthority && session.status === 'running') {
       // The provider continuation died with the process. Re-present its durable request instead
       // of automatically replaying privileged work that may already have partially completed.
       return {
@@ -1182,26 +1257,7 @@ const normalizeSessionAfterRestore = (session: PersistedChatSession): PersistedC
         messages: session.messages.map(normalizeMessageAfterRestore)
       }
     }
-
-    const runtimeContext = { ...persistedRuntimeContext }
-    delete runtimeContext.permission
-    const promptMessageId = latestUserMessageId(session.messages)
-    return {
-      ...session,
-      status: 'error',
-      activeRun: undefined,
-      runtimeContext,
-      resumeRecovery: {
-        kind: 'resume-required',
-        cause: 'app-restart',
-        promptMessageId
-      },
-      error: session.error ?? INTERRUPTED_SESSION_ERROR,
-      messages: markInterruptedPrompt(
-        session.messages.map(normalizeMessageAfterRestore),
-        promptMessageId
-      )
-    }
+    return recoverInterruptedPermissionAfterRestore(session)
   }
   if (hasRestorablePermissionWait(session)) {
     return {
@@ -1214,6 +1270,7 @@ const normalizeSessionAfterRestore = (session: PersistedChatSession): PersistedC
       messages: session.messages.map(normalizeMessageAfterRestore)
     }
   }
+  if (continuingPermission) return recoverInterruptedPermissionAfterRestore(session)
   if (
     session.status === 'waiting-plan-approval' &&
     session.runtimeContext?.plan?.approval === 'pending'
@@ -1553,11 +1610,17 @@ export const sanitizeToolActivity = (activity: unknown): PersistedToolActivity |
   return sanitized
 }
 
-// Runtime activity state cannot resume after a restart, so restore open activities as failed.
-const normalizeActivityAfterRestore = (activity: PersistedToolActivity): PersistedToolActivity => ({
+// Runtime activity state cannot resume after restart unless the exact active-Branch tool call is
+// parked behind durable permission authority. Restore every other open activity as failed.
+const normalizeActivityAfterRestore = (
+  activity: PersistedToolActivity,
+  permissionAuthority?: RestorablePermissionToolAuthority
+): PersistedToolActivity => ({
   ...activity,
   ...((activity.status === 'pending' || activity.status === 'in_progress') &&
-  !activity.elicitation?.durable
+  !activity.elicitation?.durable &&
+  (activity.id !== permissionAuthority?.activity.id ||
+    activity.promptMessageId !== permissionAuthority.permission.originatingPromptMessageId)
     ? { status: 'failed' as const }
     : {}),
   ...(activity.elicitation?.state === 'pending' && !activity.elicitation.durable
@@ -1979,9 +2042,7 @@ const sanitizeConversationGraph = (
         return activity && agentFrameId && messageBranchId && promptMessageId && runtimeSegmentId
           ? [
               {
-                ...(options.preserveRuntimeState
-                  ? activity
-                  : normalizeActivityAfterRestore(activity)),
+                ...activity,
                 agentFrameId,
                 messageBranchId,
                 promptMessageId,
@@ -2118,9 +2179,6 @@ const sanitizeSession = (
     ? session.activities
         .map(sanitizeToolActivity)
         .filter((item): item is PersistedToolActivity => !!item)
-        .map((activity) =>
-          options.preserveRuntimeState ? activity : normalizeActivityAfterRestore(activity)
-        )
     : []
   const activityGroups = Array.isArray(session.activityGroups)
     ? session.activityGroups
@@ -2229,7 +2287,9 @@ const sanitizeSession = (
 
   // Normalize before graph creation so a legacy flat transcript never seeds a streaming message or
   // loses the active prompt identity while activeRun is cleared.
-  if (!options.preserveRuntimeState) sanitized = normalizeSessionAfterRestore(sanitized)
+  if (!options.preserveRuntimeState) {
+    sanitized = normalizeSessionAfterRestore(sanitized, { deferPermissionValidation: true })
+  }
 
   if (session.conversationGraph !== undefined) {
     const graph = sanitizeConversationGraph(session.conversationGraph, options)
@@ -2251,6 +2311,30 @@ const sanitizeSession = (
   // Normalize only after resolving the canonical active Branch. Recovery references and the durable
   // interrupted marker must never be inferred from an abandoned Branch.
   if (!options.preserveRuntimeState) sanitized = normalizeSessionAfterRestore(sanitized)
+  if (!options.preserveRuntimeState) {
+    const permissionAuthority = resolveRestorablePermissionToolAuthority(sanitized)
+    sanitized = {
+      ...sanitized,
+      ...(sanitized.activities
+        ? {
+            activities: sanitized.activities.map((activity) =>
+              normalizeActivityAfterRestore(activity, permissionAuthority)
+            )
+          }
+        : {}),
+      ...(sanitized.conversationGraph
+        ? {
+            conversationGraph: {
+              ...sanitized.conversationGraph,
+              activities: sanitized.conversationGraph.activities.map((activity) => ({
+                ...activity,
+                ...normalizeActivityAfterRestore(activity, permissionAuthority)
+              }))
+            }
+          }
+        : {})
+    }
+  }
   const activeUserMessageIds = new Set(
     sanitized.messages.filter((message) => message.role === 'user').map((message) => message.id)
   )


### PR DESCRIPTION
## Problem

After an app restart, Session hydration converted every open tool activity without durable Elicitation state to `failed`. A durable MCP Permission wait is owned by `runtimeContext.permission`, so its exact parked tool call became a red terminal row before the restored continuation could settle it.

## Proposed change

- Resolve one restorable MCP Permission authority from the durable Session only when Session ID, active Prompt, exact Tool Call ID, active Branch visibility, flat compatibility projection, and open activity status all agree.
- Preserve only that exact `pending` or `in_progress` tool activity during restart normalization.
- Release Permission authority and enter restart recovery for non-MCP, missing, duplicated, mismatched, off-Branch, terminal, or lifecycle-inconsistent correlation.
- Continue marking every unrelated open runtime activity as failed.

## Scope and non-goals

This changes restart hydration behavior only. It does not change the persisted schema, ACP protocol, Permission or Elicitation data model, permission grants, provider replay, or UI structure.

## Acceptance criteria and validation

All listed checks ran after the last material edit and after rebasing onto the latest `origin/main`.

| Behavior | Command | Result |
| --- | --- | --- |
| Exact MCP activity remains open; stale, missing, duplicate, non-MCP, terminal, lifecycle-mismatched, and off-Branch authority fails closed | `npm test -- --run src/shared/session-persistence.test.ts src/main/session-persistence/repository.test.ts` | 107 passed |
| Restored continuation contract across Claude Code, OpenCode, Codex Responses, and Codex Bridge | `npm test -- --run src/main/acp/runtime.test.ts -t builds restored permission replay through` | 4 passed |
| Renderer accepts the restored decision once and does not regress terminal tool activity | `npm test -- --run src/renderer/src/stores/session-store.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx -t does not revive finished sessions or regress terminal tool activity statuses\|reattaches a restored permission wait before sending its main-validated decision\|keeps an accepted restored permission hidden across a newer pending projection` | 3 passed |
| Node and renderer types | `npm run typecheck` | passed |
| Repository lint | `npm run lint` | 0 errors; 17 existing warnings outside this diff |
| Complete portable suite | `npm test` | 917 files passed, 15 skipped; 13,197 tests passed, 192 skipped |

The shared persistence owner, its repository consumer, all four ACP restored-continuation paths, and renderer terminalization behavior are included. The logic is model-independent and contains no OS-specific paths; exact-head CI remains authoritative for platform lanes.

Independent Standards and Spec reviews found no remaining actionable findings.

Uncovered risk: a manual packaged-app restart journey was not run locally; the portable persistence, ACP contract, renderer, and full Vitest suites cover the state transition in isolation.

## Review focus

Please focus on the exact authority predicate in Session hydration, the pre-graph permission-validation deferral, and fail-closed cleanup for inconsistent durable projections.