### PR TITLE
fix(session-plan): preserve provenance and pending review state

### DIFF
--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -477,6 +477,7 @@ class AcpPromptTurnWorkflow {
       sessionId: request.sessionId,
       kind: 'prompt',
       promptMessageId: request.provenanceContext?.promptMessageId,
+      provenanceContext: request.provenanceContext,
       turnToken: request.continuation?.originatingTurnToken
     })
   }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4628,6 +4628,101 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('preserves the originating Agent Frame when an app-owned choice continues the turn', async () => {
+    const storageRoot = await createTemporaryRoot()
+    const process = new FakeAgentProcess()
+    const observedProvenance: Array<{
+      rootFrameId: string
+      agentFrameId: string
+      messageBranchId: string
+      messageBranchAncestry: string[]
+      messageAncestry: string[]
+      runtimeSegmentId: string
+      promptMessageId: string
+    }> = []
+    let currentRunFile = ''
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: storageRoot,
+        dataRoot: storageRoot,
+        projectName: 'project-1',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: new ArtifactRepository(storageRoot)
+      }
+    })
+    const fakeAgent = startFakeAgent(process, ['user-choice-frame-session'], {
+      onPrompt: async ({ sessionId, text }) => {
+        const currentRun = JSON.parse(await readFile(currentRunFile, 'utf8')) as {
+          rootFrameId: string
+          agentFrameId: string
+          messageBranchId: string
+          messageBranchAncestry: string[]
+          messageAncestry: string[]
+          runtimeSegmentId: string
+          promptMessageId: string
+        }
+        observedProvenance.push({
+          rootFrameId: currentRun.rootFrameId,
+          agentFrameId: currentRun.agentFrameId,
+          messageBranchId: currentRun.messageBranchId,
+          messageBranchAncestry: currentRun.messageBranchAncestry,
+          messageAncestry: currentRun.messageAncestry,
+          runtimeSegmentId: currentRun.runtimeSegmentId,
+          promptMessageId: currentRun.promptMessageId
+        })
+        if (text === 'begin the framed workflow') {
+          await runtime.requestUserInput({
+            sessionId,
+            questions: [
+              {
+                question: 'Which implementation should I use?',
+                options: [{ label: 'Minimal' }, { label: 'Expanded' }]
+              }
+            ]
+          })
+        }
+      }
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+    currentRunFile = getEnvValue(
+      fakeAgent.newSessions[0].mcpServers[0],
+      'OPEN_SCIENCE_ARTIFACT_CURRENT_RUN_FILE'
+    )
+    const expectedProvenance = {
+      rootFrameId: 'durable-root-frame',
+      agentFrameId: 'originating-agent-frame',
+      messageBranchId: 'durable-root-branch',
+      messageBranchAncestry: ['durable-root-branch'],
+      messageAncestry: ['originating-prompt-message'],
+      runtimeSegmentId: 'durable-runtime-segment',
+      promptMessageId: 'originating-prompt-message'
+    }
+    const originatingProvenance = structuredClone(expectedProvenance)
+    await runtime.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'begin the framed workflow',
+      provenanceContext: originatingProvenance
+    })
+
+    const choice = runtime.getSnapshot().pendingElicitations?.[0]
+    expect(choice).toBeDefined()
+    originatingProvenance.rootFrameId = 'mutated-after-the-originating-turn'
+    originatingProvenance.messageBranchAncestry.push('mutated-branch')
+    originatingProvenance.messageAncestry.push('mutated-message')
+    await runtime.respondToElicitation({
+      requestId: choice!.requestId,
+      action: 'accept',
+      answers: [{ fieldId: 'question_0', value: 'Minimal' }]
+    })
+    await vi.waitFor(() => expect(observedProvenance).toHaveLength(2))
+
+    expect(observedProvenance).toEqual([expectedProvenance, expectedProvenance])
+  })
+
   it('waits for every queued app-owned choice before continuing with all answers', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['queued-user-choice-session'])

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -359,6 +359,13 @@ class AcpRuntime {
   private readonly sessionInteractions: AcpSessionInteractionOwner
   private readonly elicitationOwner: AcpElicitationOwner
   private readonly appContinuations: AcpAppContinuationOwner
+  private readonly userChoiceProvenanceContexts = new Map<
+    string,
+    Readonly<{
+      sessionId: string
+      provenanceContext: NonNullable<AcpPromptRequest['provenanceContext']>
+    }>
+  >()
   private readonly durableContinuationContext: AcpRuntimeSessionOwners['durableContinuationContext']
   private readonly permissionWaitOwner: AcpRuntimeSessionOwners['permissionWaitOwner']
   private durablePermissionContinuations?: Map<
@@ -1342,13 +1349,15 @@ class AcpRuntime {
       }
     }
 
+    const liveProvenance = this.userChoiceProvenanceContexts.get(response.requestId)
     const resolution = this.elicitationOwner.respond(response)
+    this.userChoiceProvenanceContexts.delete(response.requestId)
     if (resolution.detached) {
       const continuation = this.userChoiceContinuation(
         resolution.request,
         resolution.response,
         restoredContinuation?.historyReplay,
-        restoredContinuation?.provenanceContext
+        restoredContinuation?.provenanceContext ?? liveProvenance?.provenanceContext
       )
       if (continuation) {
         this.appContinuations.set(resolution.request.sessionId, {
@@ -1453,6 +1462,12 @@ class AcpRuntime {
     )
 
     if (!pending) return { action: 'cancelled' }
+    if (promptInteraction?.kind === 'prompt' && promptInteraction.provenanceContext) {
+      this.userChoiceProvenanceContexts.set(requestId, {
+        sessionId: request.sessionId,
+        provenanceContext: promptInteraction.provenanceContext
+      })
+    }
     return { action: 'pending' }
   }
 
@@ -1695,6 +1710,14 @@ class AcpRuntime {
 
   private cancelPermissionFlowForSession(sessionId: string): void {
     this.permissionContext.cancelForSession(sessionId)
+    const provenanceContexts = this.userChoiceProvenanceContexts
+    if (provenanceContexts) {
+      for (const [requestId, provenance] of provenanceContexts) {
+        if (provenance.sessionId === sessionId) {
+          provenanceContexts.delete(requestId)
+        }
+      }
+    }
     this.elicitationOwner.cancelForSession(sessionId)
     this.appContinuations.delete(sessionId)
   }

--- a/src/main/acp/session-interaction-owner.ts
+++ b/src/main/acp/session-interaction-owner.ts
@@ -1,6 +1,24 @@
 import { randomUUID } from 'node:crypto'
 
-import type { AcpTurnTokenUsage } from '../../shared/acp'
+import type { AcpPromptRequest, AcpTurnTokenUsage } from '../../shared/acp'
+
+const cloneProvenanceContext = (
+  provenanceContext: AcpPromptRequest['provenanceContext']
+): AcpPromptRequest['provenanceContext'] => {
+  if (!provenanceContext) return undefined
+  const clone: NonNullable<AcpPromptRequest['provenanceContext']> = {
+    ...provenanceContext,
+    ...(provenanceContext.messageBranchAncestry
+      ? { messageBranchAncestry: [...provenanceContext.messageBranchAncestry] }
+      : {}),
+    ...(provenanceContext.messageAncestry
+      ? { messageAncestry: [...provenanceContext.messageAncestry] }
+      : {})
+  }
+  if (clone.messageBranchAncestry) Object.freeze(clone.messageBranchAncestry)
+  if (clone.messageAncestry) Object.freeze(clone.messageAncestry)
+  return Object.freeze(clone)
+}
 
 export type AcpSessionInteractionKind = 'prompt' | 'compaction'
 
@@ -8,6 +26,7 @@ export interface AcpPromptSessionInteractionRequest {
   readonly sessionId: string
   readonly kind: 'prompt'
   readonly promptMessageId?: string
+  readonly provenanceContext?: AcpPromptRequest['provenanceContext']
   readonly turnToken?: string
 }
 
@@ -28,6 +47,7 @@ interface AcpSessionInteractionScopeBase {
 export interface AcpPromptSessionInteractionScope extends AcpSessionInteractionScopeBase {
   readonly kind: 'prompt'
   readonly promptMessageId?: string
+  readonly provenanceContext?: AcpPromptRequest['provenanceContext']
   readonly turnToken: string
 }
 
@@ -312,6 +332,7 @@ export class AcpSessionInteractionOwner {
       sessionId: request.sessionId,
       kind: 'prompt',
       promptMessageId: request.promptMessageId,
+      provenanceContext: cloneProvenanceContext(request.provenanceContext),
       turnToken: request.turnToken ?? randomUUID(),
       sequence: ++this.sequence,
       signal: abortController.signal
@@ -359,6 +380,7 @@ export class AcpSessionInteractionOwner {
             ...base,
             kind: request.kind,
             promptMessageId: request.promptMessageId,
+            provenanceContext: cloneProvenanceContext(request.provenanceContext),
             turnToken: request.turnToken ?? randomUUID()
           }
         : { ...base, kind: request.kind }

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -8,6 +8,7 @@ import {
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile
 } from '../../../../shared/artifacts'
+import type { ActivePlanProjection } from '../../../../shared/session-plan/contract'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -71,6 +72,26 @@ const createArtifactFile = (overrides: Partial<ArtifactFile> = {}): ArtifactFile
   ...overrides
 })
 
+const pendingPlanProjection: ActivePlanProjection = {
+  artifactId: 'plan-1',
+  artifactVersionId: 'plan-version-1',
+  artifactChecksum: 'a'.repeat(64),
+  revision: 1,
+  approval: 'pending',
+  lifecycle: 'awaiting_approval',
+  requiresExplicitContinuation: false,
+  document: {
+    schema_version: 1,
+    task_summary: 'Review the generated plan',
+    phases: [],
+    desired_outputs: [],
+    feasibility: { confidence: 'high', rationale: 'Ready for review.' }
+  },
+  stepStatuses: {},
+  stepStates: {},
+  counts: { phases: 0, delegations: 0, steps: 0, completed: 0, inProgress: 0 }
+}
+
 describe('workspace runtime events', () => {
   // Rebuild the visible session before each adapter assertion.
   beforeEach(() => {
@@ -112,6 +133,21 @@ describe('workspace runtime events', () => {
       streamId: 'assistant-message-1',
       eventIds: ['event-1', 'event-2'],
       status: 'streaming'
+    })
+  })
+
+  it('keeps a pending Plan actionable after the runtime reports a timeout stop', async () => {
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'plan-ready', kind: 'plan', planProjection: pendingPlanProjection })
+    )
+    await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'plan-timeout', kind: 'stop', text: 'end_turn' })
+    )
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-plan-approval',
+      activeRun: undefined,
+      activePlanProjection: { approval: 'pending', lifecycle: 'awaiting_approval' }
     })
   })
 

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ProjectFilesChangedEvent } from '../../../../shared/project-files'
 import type { Project } from '../../../../shared/projects'
 import type { EnvironmentCheckResult } from '../../../../shared/settings'
+import type { ActivePlanProjection } from '../../../../shared/session-plan/contract'
 import { EMPTY_SNAPSHOT, useNotificationInboxStore } from '@/stores/notification-inbox-store'
 import { createInitialProjectState, useProjectStore } from '@/stores/project-store'
 import { useNavigationStore } from '@/stores/navigation-store'
@@ -54,6 +55,26 @@ const session = (
   createdAt: updatedAt,
   updatedAt
 })
+
+const pendingPlan: ActivePlanProjection = {
+  artifactId: 'plan-1',
+  artifactVersionId: 'plan-version-1',
+  artifactChecksum: 'a'.repeat(64),
+  revision: 1,
+  approval: 'pending',
+  lifecycle: 'awaiting_approval',
+  requiresExplicitContinuation: false,
+  document: {
+    schema_version: 1,
+    task_summary: 'Review the generated plan',
+    phases: [],
+    desired_outputs: [],
+    feasibility: { confidence: 'high', rationale: 'Ready for review.' }
+  },
+  stepStatuses: {},
+  stepStates: {},
+  counts: { phases: 0, delegations: 0, steps: 0, completed: 0, inProgress: 0 }
+}
 
 const environment = (checks: EnvironmentCheckResult['checks']): EnvironmentCheckResult => ({
   checkedAt: 1,
@@ -586,6 +607,33 @@ describe('HomePage activity overview', () => {
     expect(
       container.querySelector('[aria-label="Open session Live analysis, needs you"]')
     ).not.toBeNull()
+  })
+
+  it('keeps a timed-out Plan approval visible as needs you', async () => {
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects: [project],
+      isLoaded: true
+    })
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'plan-session',
+      projectId: project.id,
+      cwd: '/workspace/project-1',
+      content: 'Create a research plan'
+    })
+    useSessionStore.getState().setActivePlanProjection('plan-session', pendingPlan)
+    useSessionStore.getState().finishRun('plan-session')
+
+    await act(async () =>
+      root.render(
+        <HomePage canDeleteProjects hasCompleteSessionCatalog onOpenGlobalSearch={vi.fn()} />
+      )
+    )
+
+    expect(
+      container.querySelector('[aria-label="Open session Create a research plan, needs you"]')
+    ).not.toBeNull()
+    expect(container.querySelector('[aria-label="1 waiting on you"]')).not.toBeNull()
   })
 
   it('dismisses every backend completion for a session without opening it', async () => {

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -313,6 +313,42 @@ const mergeDurableUploadProjection = <Message extends PersistedChatMessage>(
   return { messages, changed }
 }
 
+const projectDurablePlanAuthority = (
+  current: ChatSession,
+  durable: PersistedChatSession
+): ChatSession => {
+  const incomingRevision = durable.runtimeContext?.revision
+  const currentRevision = current.runtimeContext?.revision
+  const hasPlanAuthority =
+    durable.runtimeContext?.plan !== undefined || current.runtimeContext?.plan !== undefined
+  if (
+    !hasPlanAuthority ||
+    incomingRevision === undefined ||
+    (currentRevision !== undefined && incomingRevision < currentRevision)
+  ) {
+    return current
+  }
+
+  const status =
+    current.compacting ||
+    current.status === 'waiting-for-user' ||
+    current.status === 'waiting-permission'
+      ? current.status
+      : durable.runtimeContext?.plan?.approval === 'pending'
+        ? 'waiting-plan-approval'
+        : current.status === 'waiting-plan-approval'
+          ? current.activeRun || current.agentPromptInFlight
+            ? 'running'
+            : 'idle'
+          : current.status
+  return {
+    ...current,
+    status,
+    runtimeContext: durable.runtimeContext,
+    updatedAt: Math.max(current.updatedAt, durable.updatedAt)
+  }
+}
+
 export const createSessionPersistenceOwner = <State extends SessionStoreData>(
   set: StoreApi<State>['setState']
 ): SessionPersistenceActions => ({
@@ -469,8 +505,12 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
               session.conversationGraph?.messages ?? session.messages
             )
           : undefined
-        if (!flat.changed && !graph?.changed) return state
-        projected = withTransientSessionState(session, current)
+        const authorityProjected = projectDurablePlanAuthority(current, session)
+        if (!flat.changed && !graph?.changed && authorityProjected === current) return state
+        projected =
+          flat.changed || graph?.changed
+            ? projectDurablePlanAuthority(withTransientSessionState(session, current), session)
+            : authorityProjected
       } else {
         const flat = mergeDurableUploadProjection(
           current.messages,
@@ -484,8 +524,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
               session.conversationGraph?.messages ?? session.messages
             )
           : undefined
-        if (!flat.changed && !graph?.changed) return state
-        projected = {
+        const merged: ChatSession = {
           ...current,
           messages: flat.messages,
           ...(graph?.changed
@@ -497,6 +536,8 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
               }
             : {})
         }
+        projected = projectDurablePlanAuthority(merged, session)
+        if (!flat.changed && !graph?.changed && projected === merged) return state
       }
 
       externallyHydratedSessions.add(projected)

--- a/src/renderer/src/stores/session-store-run-activity-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-activity-helpers.ts
@@ -135,11 +135,7 @@ export const projectActivePlan = (
       session.compacting || session.status === 'waiting-for-user'
         ? session.status
         : projection.lifecycle === 'awaiting_approval'
-          ? session.activeRun ||
-            session.status === 'waiting-plan-approval' ||
-            session.status === 'waiting-permission'
-            ? 'waiting-plan-approval'
-            : 'idle'
+          ? 'waiting-plan-approval'
           : projection.lifecycle === 'rejected'
             ? session.activeRun
               ? 'running'

--- a/src/renderer/src/stores/session-store-run-terminal-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-terminal-helpers.ts
@@ -308,10 +308,13 @@ export const projectFinishedRun = (
       cause
     })
   }
+  const planAwaitingApproval =
+    session.activePlanProjection?.lifecycle === 'awaiting_approval' &&
+    session.activePlanProjection.approval === 'pending'
   return {
     ...session,
     ...CLEARED_AGENT_RUN_STATE,
-    status: keepArtifactError ? 'error' : 'idle',
+    status: keepArtifactError ? 'error' : planAwaitingApproval ? 'waiting-plan-approval' : 'idle',
     error: keepArtifactError ? session.error : undefined,
     errorReportable: keepArtifactError ? session.errorReportable : undefined,
     messages,
@@ -357,12 +360,17 @@ export const projectFailedRun = (
       runError: error
     })
   }
+  const planAwaitingApproval =
+    session.activePlanProjection?.lifecycle === 'awaiting_approval' &&
+    session.activePlanProjection.approval === 'pending'
   return {
     ...session,
     ...CLEARED_AGENT_RUN_STATE,
-    status: 'error',
-    error,
-    errorReportable: reportable ?? isReportableRunFailure(error),
+    status: planAwaitingApproval ? 'waiting-plan-approval' : 'error',
+    error: planAwaitingApproval ? undefined : error,
+    errorReportable: planAwaitingApproval
+      ? undefined
+      : (reportable ?? isReportableRunFailure(error)),
     messages,
     activities,
     activityGroups,
@@ -468,13 +476,16 @@ export const projectInterruptedRun = (
       resumeRecovery
     }
   }
+  const planAwaitingApproval =
+    session.activePlanProjection?.lifecycle === 'awaiting_approval' &&
+    session.activePlanProjection.approval === 'pending'
   return {
     ...session,
     ...CLEARED_AGENT_RUN_STATE,
-    status: 'error',
-    interrupted: true,
-    resumeRecovery,
-    error,
+    status: planAwaitingApproval ? 'waiting-plan-approval' : 'error',
+    interrupted: planAwaitingApproval ? undefined : true,
+    resumeRecovery: planAwaitingApproval ? undefined : resumeRecovery,
+    error: planAwaitingApproval ? undefined : error,
     errorReportable: undefined,
     messages,
     activities,

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -311,6 +311,141 @@ describe('session store', () => {
     expect(toPersistedSession(projection)).not.toHaveProperty('runtimeContext')
   })
 
+  it('converges a newer durable Plan authority when message content is unchanged', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Plan approval',
+        cwd: '/workspace',
+        status: 'idle',
+        messages: [],
+        createdAt: 1,
+        updatedAt: 2
+      }
+    ])
+    const source = useSessionStore.getState().sessions[0]
+    const updatedAt = source.updatedAt + 10
+
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: {
+        ...toPersistedSession(source),
+        status: 'waiting-plan-approval',
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          plan: {
+            artifactId: 'plan-1',
+            artifactVersionId: 'plan-version-1',
+            artifactChecksum: 'a'.repeat(64),
+            approval: 'pending',
+            stepStatuses: {}
+          }
+        },
+        updatedAt
+      }
+    })
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-plan-approval',
+      runtimeContext: { revision: 1, plan: { approval: 'pending' } },
+      updatedAt
+    })
+  })
+
+  it('does not replace newer local conversation state when a durable Plan authority arrives', () => {
+    const prompt = useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      content: 'Create a plan'
+    })
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'session-1',
+      streamId: 'run-1',
+      eventId: 'agent-output-1',
+      promptMessageId: prompt?.messageId,
+      content: 'The plan is ready.'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: {
+        ...toPersistedSession(source),
+        status: 'waiting-plan-approval',
+        runtimeContext: {
+          version: 1,
+          revision: 2,
+          plan: {
+            artifactId: 'plan-1',
+            artifactVersionId: 'plan-version-1',
+            artifactChecksum: 'a'.repeat(64),
+            approval: 'pending',
+            stepStatuses: {}
+          }
+        },
+        updatedAt: source.updatedAt + 10
+      }
+    })
+
+    const projected = useSessionStore.getState().sessions[0]
+    expect(projected.status).toBe('waiting-plan-approval')
+    expect(projected.runtimeContext?.revision).toBe(2)
+    expect(projected.messages.map((message) => message.content)).toEqual([
+      'Create a plan',
+      'The plan is ready.'
+    ])
+    expect(projected.conversationGraph?.messages.map((message) => message.content)).toEqual([
+      'Create a plan',
+      'The plan is ready.'
+    ])
+  })
+
+  it('rejects an older durable Plan authority revision', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Plan approval',
+        cwd: '/workspace',
+        status: 'waiting-plan-approval',
+        runtimeContext: {
+          version: 1,
+          revision: 3,
+          plan: {
+            artifactId: 'plan-1',
+            artifactVersionId: 'plan-version-1',
+            artifactChecksum: 'a'.repeat(64),
+            approval: 'pending',
+            stepStatuses: {}
+          }
+        },
+        messages: [],
+        createdAt: 1,
+        updatedAt: 20
+      }
+    ])
+    const source = useSessionStore.getState().sessions[0]
+
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: {
+        ...toPersistedSession(source),
+        status: 'idle',
+        runtimeContext: { version: 1, revision: 2 },
+        updatedAt: 30
+      }
+    })
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-plan-approval',
+      runtimeContext: { revision: 3, plan: { approval: 'pending' } },
+      updatedAt: 20
+    })
+  })
+
   it('keeps a current Plan projection when a durable Session update echoes back', () => {
     const persistedPlan = {
       artifactId: 'artifact-version-1',
@@ -561,7 +696,7 @@ describe('session store', () => {
     })
   })
 
-  it('keeps a pending Plan idle after its Agent interaction ended without a decision', () => {
+  it('keeps a pending Plan awaiting review after its Agent interaction ended without a decision', () => {
     useSessionStore.getState().hydrateSessions([
       {
         id: 'session-1',
@@ -580,7 +715,7 @@ describe('session store', () => {
       .setActivePlanProjection('session-1', createPlanProjection('version-1'))
 
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
-      status: 'idle',
+      status: 'waiting-plan-approval',
       activePlanProjection: { approval: 'pending' }
     })
   })
@@ -1504,6 +1639,94 @@ describe('session store', () => {
       status: 'waiting-plan-approval',
       activePlanProjection: { lifecycle: 'awaiting_approval' }
     })
+  })
+
+  it('keeps Plan approval waiting when the Agent interaction times out', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Create a plan'
+    })
+    useSessionStore
+      .getState()
+      .setActivePlanProjection('transport-session-1', createPlanProjection('version-1'))
+
+    useSessionStore.getState().finishRun('transport-session-1')
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-plan-approval',
+      activeRun: undefined,
+      activePlanProjection: { lifecycle: 'awaiting_approval', approval: 'pending' }
+    })
+  })
+
+  it('keeps pending Plan approval available when the active run fails', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Create a plan'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'Waiting for Plan approval'
+    })
+    useSessionStore.getState().upsertToolActivity({
+      sessionId: 'transport-session-1',
+      toolCallId: 'generate-plan-call',
+      eventId: 'generate-plan-started',
+      providerToolName: 'generate_plan',
+      status: 'pending'
+    })
+    useSessionStore
+      .getState()
+      .setActivePlanProjection('transport-session-1', createPlanProjection('version-1'))
+
+    useSessionStore
+      .getState()
+      .failRun('transport-session-1', 'timed out awaiting tools/call after 300s')
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session).toMatchObject({
+      status: 'waiting-plan-approval',
+      activeRun: undefined,
+      activePlanProjection: { lifecycle: 'awaiting_approval', approval: 'pending' }
+    })
+    expect(session.error).toBeUndefined()
+    expect(session.errorReportable).toBeUndefined()
+    expect(session.messages[1]).toMatchObject({ status: 'error', failedAt: expect.any(Number) })
+    expect(session.activities[0]).toMatchObject({ status: 'failed' })
+  })
+
+  it('keeps pending Plan approval available when the active run is interrupted', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Create a plan'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'transport-session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'Waiting for Plan approval'
+    })
+    useSessionStore
+      .getState()
+      .setActivePlanProjection('transport-session-1', createPlanProjection('version-1'))
+
+    useSessionStore
+      .getState()
+      .interruptRun('transport-session-1', 'connection-lost', 'Connection lost')
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session).toMatchObject({
+      status: 'waiting-plan-approval',
+      activeRun: undefined,
+      activePlanProjection: { lifecycle: 'awaiting_approval', approval: 'pending' }
+    })
+    expect(session.error).toBeUndefined()
+    expect(session.interrupted).toBeUndefined()
+    expect(session.resumeRecovery).toBeUndefined()
+    expect(session.messages[0]).toMatchObject({ role: 'user', interrupted: true })
+    expect(session.messages[1]).toMatchObject({ status: 'error', failedAt: expect.any(Number) })
   })
 
   it('upserts transient tool activities without duplicating repeated events', () => {

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1694,7 +1694,7 @@ describe('session store', () => {
     expect(session.error).toBeUndefined()
     expect(session.errorReportable).toBeUndefined()
     expect(session.messages[1]).toMatchObject({ status: 'error', failedAt: expect.any(Number) })
-    expect(session.activities[0]).toMatchObject({ status: 'failed' })
+    expect(session.activities?.[0]).toMatchObject({ status: 'failed' })
   })
 
   it('keeps pending Plan approval available when the active run is interrupted', () => {


### PR DESCRIPTION
## Problem

App-owned user-choice continuations kept only `promptMessageId`, so later Plan artifacts could use fallback root/frame identity and fail durable finalization with `root-frame-mismatch`. If `generate_plan` then timed out or stopped while its Plan was pending, renderer terminalization reset the Session to idle and Home no longer showed the review.

## Proposed change

- Carry a cloned, immutable conversation provenance context through live user-choice continuations without exposing it through renderer persistence.
- Keep pending Plan reviews in `waiting-plan-approval` after Agent stop or timeout.
- Converge newer durable Plan authority by runtime-context revision without replacing newer local messages or conversation graph data.
- Add runtime, store, workspace-event, and Home regression coverage.

## Scope and non-goals

- No change to the 300-second MCP timeout policy.
- No relaxation of durable artifact ownership validation.
- No persisted elicitation schema expansion.

## Acceptance criteria and validation

Checks ran after the last material edit.

- User-choice continuation provenance: focused runtime regression passed.
- Pending Plan survives stop/timeout and remains visible on Home: focused renderer suites passed (224 tests).
- Full portable suite: `npm test` passed (917 files passed, 15 skipped; 13,184 tests passed, 203 skipped).
- Node/Web contracts: `npm run typecheck` passed.
- Repository lint: `npm run lint` passed with 0 errors (18 pre-existing warnings in untouched files).
- Formatting and diff hygiene: targeted Prettier check and `git diff --check` passed.

Uncovered risk: the real five-minute provider wait is not exercised; tests inject terminal stop/timeout semantics deterministically. Platform-specific Electron packaging/E2E was not run because this change does not touch packaging or platform integration.

## Review focus

- Main-private provenance lifetime and cancellation cleanup.
- Runtime-context revision ordering in durable Plan authority projection.
- Pending Plan status priority after renderer terminalization.
