### PR TITLE
ci(pr-gate): reduce cross-platform runner contention

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -504,7 +504,9 @@ jobs:
         # the unit bundle without unit_macos. Merge once so thresholds see the complete suite.
         if: ${{ needs.unit_shard.result != 'skipped' }}
         continue-on-error: true
-        run: npx vitest run --merge-reports=vitest-reports --coverage
+        # macOS blob reports retain their source test paths. Ubuntu can merge their results and
+        # coverage, but local discovery finds no tests; keep coverage thresholds authoritative.
+        run: npx vitest run --merge-reports=vitest-reports --coverage --passWithNoTests
       - name: Upload Module coverage report
         if: ${{ always() && (steps.unit_macos_related.outcome != 'skipped' || steps.unit_macos_full.outcome != 'skipped') }}
         continue-on-error: true

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -7,6 +7,15 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Focused no-side-effect validation plan
+        required: false
+        default: classified
+        type: choice
+        options:
+          - classified
+          - unit-coverage
 
 permissions:
   contents: read
@@ -103,11 +112,30 @@ jobs:
         id: classify
         env:
           BASE_SHA: ${{ steps.revisions.outputs.base }}
+          DRY_RUN_MODE: ${{ inputs.dry_run || 'classified' }}
+          EVENT_NAME: ${{ github.event_name }}
           HEAD_SHA: ${{ steps.revisions.outputs.head }}
           TRUSTED_CLASSIFIER_DIR: ${{ steps.trusted_classifier.outputs.dir }}
           TRUSTED_CLASSIFIER_SOURCE: ${{ steps.trusted_classifier.outputs.source }}
         run: |
           set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$DRY_RUN_MODE" == "unit-coverage" ]]; then
+            plan='{"schemaVersion":1,"mode":"full","roots":["manual:unit-coverage"],"lanes":["policy","unit_macos"],"bundles":["policy","unit"],"reasonChains":["workflow_dispatch unit-coverage -> focused dry-run"]}'
+            echo "plan=$plan" >> "$GITHUB_OUTPUT"
+            echo 'lanes=["policy","unit_macos"]' >> "$GITHUB_OUTPUT"
+            printf '%s\n' \
+              '## PR Gate preflight' \
+              '' \
+              '- Mode: **full (focused dry-run)**' \
+              '- Selected lanes: policy, unit_macos' \
+              '- Execution bundles: policy, unit' \
+              '' \
+              '### Reason chains' \
+              '' \
+              '- `workflow_dispatch unit-coverage -> focused dry-run`' \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           if [[ "$TRUSTED_CLASSIFIER_SOURCE" == "base" ]]; then
             node "$TRUSTED_CLASSIFIER_DIR/classify-pr-changes.mjs" --base "$BASE_SHA" --head "$HEAD_SHA"
             exit 0
@@ -434,10 +462,12 @@ jobs:
           exit "$failed"
 
   unit:
-    name: Module tests (macOS)
+    name: Module tests and coverage
     needs: [preflight, unit_shard]
     if: ${{ always() && needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit') }}
-    runs-on: macos-14
+    # Full plans merge macOS shard reports on Ubuntu so coverage enforcement does not wait for a
+    # scarce fifth macOS slot. Selective plans still execute affected Modules on real macOS.
+    runs-on: ${{ needs.unit_shard.result != 'skipped' && 'ubuntu-latest' || 'macos-14' }}
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
   windows_full_test:
-    name: Windows full test (${{ matrix.shard }}/4)
+    name: Windows full test (${{ matrix.shard }}/3)
     needs: plan
     if: needs.plan.outputs.should_test == 'true'
     runs-on: windows-latest
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -74,4 +74,4 @@ jobs:
         # every available core, and hosted-runner disk latency occasionally exceeds the default
         # per-test/hook budgets. Keep files serial and use bounded 60-second budgets; the 25-minute
         # job timeout remains the backstop for a real hang.
-        run: npm test -- --shard=${{ matrix.shard }}/4 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000
+        run: npm test -- --shard=${{ matrix.shard }}/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -1,35 +1,61 @@
 name: Windows Full Test
 
 # Preserve complete real-Windows coverage after merge without adding its runtime to ordinary PRs or
-# blocking a stable release.
+# blocking a stable release. Batch busy main periods into one latest-head run per hour so advisory
+# coverage does not compete with every PR Gate for hosted-runner capacity.
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
+  schedule:
+    - cron: '47 * * * *'
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
-# A newer main push supersedes stale advisory coverage.
+# A newer batch or manual run on the same ref supersedes stale advisory coverage.
 concurrency:
   group: windows-full-test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  plan:
+    name: Check for untested main changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_test: ${{ steps.decide.outputs.should_test }}
+    steps:
+      - name: Check for untested main changes
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch always runs the selected ref."
+            exit 0
+          fi
+
+          last_successful_sha="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/windows-full-test.yml/runs?branch=main&status=success&per_page=1" --jq '.workflow_runs[0].head_sha // ""' 2>/dev/null || true)"
+          if [[ "$last_successful_sha" == "$GITHUB_SHA" ]]; then
+            echo "should_test=false" >> "$GITHUB_OUTPUT"
+            echo "Windows full coverage already passed for $GITHUB_SHA."
+          else
+            echo "should_test=true" >> "$GITHUB_OUTPUT"
+            echo "Latest successful Windows full coverage is ${last_successful_sha:-unavailable}; testing $GITHUB_SHA."
+          fi
+
   windows_full_test:
-    name: Windows full test (${{ matrix.shard }}/3)
+    name: Windows full test (${{ matrix.shard }}/4)
+    needs: plan
+    if: needs.plan.outputs.should_test == 'true'
     runs-on: windows-latest
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -48,4 +74,4 @@ jobs:
         # every available core, and hosted-runner disk latency occasionally exceeds the default
         # per-test/hook budgets. Keep files serial and use bounded 60-second budgets; the 25-minute
         # job timeout remains the backstop for a real hang.
-        run: npm test -- --shard=${{ matrix.shard }}/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000
+        run: npm test -- --shard=${{ matrix.shard }}/4 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -373,7 +373,7 @@ describe('PR Gate workflow', () => {
       id: 'unit_macos_full',
       'continue-on-error': true,
       if: "${{ needs.unit_shard.result != 'skipped' }}",
-      run: 'npx vitest run --merge-reports=vitest-reports --coverage'
+      run: 'npx vitest run --merge-reports=vitest-reports --coverage --passWithNoTests'
     })
     expect(unit.steps?.some(({ name }) => name === 'Test Renderer (blocking)')).toBe(false)
     expect(unit.steps?.filter(({ run }) => run === 'npm run test:coverage')).toHaveLength(0)
@@ -504,7 +504,7 @@ describe('PR Gate workflow', () => {
     )
     expect(portable).toMatchObject({
       'continue-on-error': true,
-      run: 'npx vitest run --merge-reports=vitest-reports --coverage'
+      run: 'npx vitest run --merge-reports=vitest-reports --coverage --passWithNoTests'
     })
 
     expect(workflow.jobs.windows_core).toMatchObject({

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -90,7 +90,17 @@ describe('PR Gate workflow', () => {
     })
     expect(workflow.on?.pull_request?.['paths-ignore']).toBeUndefined()
     expect(workflow.on?.merge_group).toEqual({ types: ['checks_requested'] })
-    expect(workflow.on).toHaveProperty('workflow_dispatch')
+    expect(workflow.on?.workflow_dispatch).toEqual({
+      inputs: {
+        dry_run: {
+          description: 'Focused no-side-effect validation plan',
+          required: false,
+          default: 'classified',
+          type: 'choice',
+          options: ['classified', 'unit-coverage']
+        }
+      }
+    })
     expect(workflow.permissions).toEqual({ contents: 'read', 'pull-requests': 'read' })
     expect(workflow.concurrency).toEqual({
       group:
@@ -135,9 +145,16 @@ describe('PR Gate workflow', () => {
     expect(prepare?.run).toContain('git show "${BASE_SHA}:${file}"')
     expect(prepare?.run).toContain('source=bootstrap')
     expect(classify?.env).toMatchObject({
+      DRY_RUN_MODE: "${{ inputs.dry_run || 'classified' }}",
+      EVENT_NAME: '${{ github.event_name }}',
       TRUSTED_CLASSIFIER_DIR: '${{ steps.trusted_classifier.outputs.dir }}',
       TRUSTED_CLASSIFIER_SOURCE: '${{ steps.trusted_classifier.outputs.source }}'
     })
+    expect(classify?.run).toContain(
+      '[[ "$EVENT_NAME" == "workflow_dispatch" && "$DRY_RUN_MODE" == "unit-coverage" ]]'
+    )
+    expect(classify?.run).toContain('"lanes":["policy","unit_macos"]')
+    expect(classify?.run).toContain('"bundles":["policy","unit"]')
     expect(classify?.run).toContain(
       'node "$TRUSTED_CLASSIFIER_DIR/classify-pr-changes.mjs" --base "$BASE_SHA" --head "$HEAD_SHA"'
     )
@@ -303,9 +320,9 @@ describe('PR Gate workflow', () => {
     )
     expect(legacyCoverage.steps?.filter(({ run }) => run === 'npm ci')).toHaveLength(1)
     expect(unit).toMatchObject({
-      name: 'Module tests (macOS)',
+      name: 'Module tests and coverage',
       needs: ['preflight', 'unit_shard'],
-      'runs-on': 'macos-14'
+      'runs-on': "${{ needs.unit_shard.result != 'skipped' && 'ubuntu-latest' || 'macos-14' }}"
     })
     expect(unit.if).toContain('always()')
     expect(unit.env?.VITEST_DEFER_COVERAGE_THRESHOLDS).toBeUndefined()

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -19,6 +19,7 @@ type Job = {
   env?: Record<string, string>
   if?: string
   needs?: string | string[]
+  outputs?: Record<string, string>
   'runs-on'?: string
   steps?: Step[]
   strategy?: { matrix?: { shard?: number[] } }
@@ -43,13 +44,31 @@ const step = (job: Job, name: string): Step => {
 }
 
 describe('release and scheduled workflow topology', () => {
-  it('runs three serial Windows full-suite shards', () => {
-    const job = workflow('windows-full-test.yml').jobs.windows_full_test
+  it('batches latest-main Windows coverage hourly across four serial shards', () => {
+    const windows = workflow('windows-full-test.yml')
+    const schedule = windows.on?.schedule as Array<{ cron: string }>
+    const plan = windows.jobs.plan
+    const job = windows.jobs.windows_full_test
     const test = step(job, 'Test complete suite shard')
 
-    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3])
-    expect(test.run).toContain('--shard=${{ matrix.shard }}/3')
+    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3, 4])
+    expect(test.run).toContain('--shard=${{ matrix.shard }}/4')
     expect(test.run).toContain('--maxWorkers=1')
+    expect(windows.on).not.toHaveProperty('push')
+    expect(schedule).toEqual([{ cron: '47 * * * *' }])
+    expect(windows.on).toHaveProperty('workflow_dispatch')
+    expect(windows.permissions).toEqual({ actions: 'read', contents: 'read' })
+    expect(plan).toMatchObject({
+      'runs-on': 'ubuntu-latest',
+      outputs: { should_test: '${{ steps.decide.outputs.should_test }}' }
+    })
+    expect(step(plan, 'Check for untested main changes').run).toContain(
+      'actions/workflows/windows-full-test.yml/runs?branch=main&status=success&per_page=1'
+    )
+    expect(job).toMatchObject({
+      needs: 'plan',
+      if: "needs.plan.outputs.should_test == 'true'"
+    })
   })
 
   it('runs reusable verification beside native builds while callers remain fail closed', () => {

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -44,15 +44,15 @@ const step = (job: Job, name: string): Step => {
 }
 
 describe('release and scheduled workflow topology', () => {
-  it('batches latest-main Windows coverage hourly across four serial shards', () => {
+  it('batches latest-main Windows coverage hourly across three serial shards', () => {
     const windows = workflow('windows-full-test.yml')
     const schedule = windows.on?.schedule as Array<{ cron: string }>
     const plan = windows.jobs.plan
     const job = windows.jobs.windows_full_test
     const test = step(job, 'Test complete suite shard')
 
-    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3, 4])
-    expect(test.run).toContain('--shard=${{ matrix.shard }}/4')
+    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3])
+    expect(test.run).toContain('--shard=${{ matrix.shard }}/3')
     expect(test.run).toContain('--maxWorkers=1')
     expect(windows.on).not.toHaveProperty('push')
     expect(schedule).toEqual([{ cron: '47 * * * *' }])

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -34,6 +34,7 @@ type Workflow = {
   jobs: Record<string, WorkflowJob>
   on?: {
     push?: { branches?: string[]; tags?: string[] }
+    schedule?: Array<{ cron: string }>
     workflow_call?: unknown
     workflow_dispatch?: unknown
   }
@@ -59,21 +60,27 @@ describe('post-merge Windows validation', () => {
     expect(stage.run).toContain('"$compatibility_path" --version')
   })
 
-  it('runs the complete Windows suite independently after changes land on main', () => {
+  it('batches complete Windows coverage independently against the latest main head', () => {
     const build = readWorkflow('build.yml')
     const workflow = readWorkflow('windows-full-test.yml')
+    const plan = workflow.jobs.plan
     const job = workflow.jobs.windows_full_test
 
     expect(build.jobs.windows_full_test).toBeUndefined()
-    expect(workflow.on?.push).toMatchObject({ branches: ['main'] })
+    expect(workflow.on?.push).toBeUndefined()
+    expect(workflow.on?.schedule).toEqual([{ cron: '47 * * * *' }])
+    expect(workflow.on).toHaveProperty('workflow_dispatch')
     expect(workflow.on).not.toHaveProperty('workflow_call')
+    expect(findStep(plan, 'Check for untested main changes').run).toContain('status=success')
     expect(job).toMatchObject({
+      needs: 'plan',
+      if: "needs.plan.outputs.should_test == 'true'",
       'runs-on': 'windows-latest'
     })
     expect(job['continue-on-error']).toBeUndefined()
-    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3])
+    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3, 4])
     expect(findStep(job, 'Test complete suite shard').run).toBe(
-      'npm test -- --shard=${{ matrix.shard }}/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000'
+      'npm test -- --shard=${{ matrix.shard }}/4 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000'
     )
   })
 

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -78,9 +78,9 @@ describe('post-merge Windows validation', () => {
       'runs-on': 'windows-latest'
     })
     expect(job['continue-on-error']).toBeUndefined()
-    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3, 4])
+    expect(job.strategy?.matrix?.shard).toEqual([1, 2, 3])
     expect(findStep(job, 'Test complete suite shard').run).toBe(
-      'npm test -- --shard=${{ matrix.shard }}/4 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000'
+      'npm test -- --shard=${{ matrix.shard }}/3 --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000'
     )
   })
 


### PR DESCRIPTION
## Problem

CI wall time is dominated by scarce hosted-runner capacity rather than a lack of macOS shards. Recent full PR samples showed macOS coverage merge work waiting behind the five-runner macOS cap, while the advisory Windows full-suite workflow ran after every main push and frequently overlapped newer work.

## Proposed change

- add a focused, no-side-effect `unit-coverage` dispatch mode to PR Gate for validating the real macOS shard and coverage topology
- keep the two full macOS test shards, but move full report download, merge, coverage upload, and threshold enforcement to Ubuntu
- make the cross-platform Vitest blob merge tolerate the absence of locally discoverable Ubuntu test paths while preserving coverage threshold failures
- batch Windows full-suite coverage hourly at minute 47
- skip an hourly Windows run when the latest successful workflow already covered the current main SHA; manual dispatches always run
- retain the existing three Windows shards after a four-shard experiment showed no material wall-clock improvement

## Scope and non-goals

- Changes are limited to two GitHub Actions workflows and their topology tests.
- No product source code or runtime behavior changes.
- No third macOS shard is added because observed macOS capacity serialized existing shards.
- No Windows test failures are suppressed; the workflow remains advisory and fail-closed when it runs.
- The known atomic publisher `EIO` failure is not fixed here.

## Acceptance criteria and validation

- Focused PR Gate dry-run: [run 31383567512](https://github.com/aipoch/open-science/actions/runs/31383567512) passed on commit `597b6137`.
  - macOS shards passed in 5m34s and 3m43s.
  - Ubuntu `Module tests and coverage` passed in 1m24s, including artifact download, cross-platform merge, coverage thresholds, upload, and final deterministic gate.
  - The run observed the two macOS shards execute serially because of runner availability, confirming that another macOS shard would add queue pressure.
- Windows four-shard experiment: [run 31384719168](https://github.com/aipoch/open-science/actions/runs/31384719168).
  - job times were 15.47m, 10.03m, 10.60m, and 9.60m; test-step times were 11.62m, 6.42m, 6.85m, and 6.18m.
  - the 3/4 shard hit the pre-existing atomic publisher `EIO`.
  - the 15.47m long tail did not improve on the historical three-shard baseline, so the final workflow retains three shards.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors and 17 warnings in unchanged files.
- Affected workflow tests: 5 files and 77 tests passed.
- Prettier and `git diff --check`: passed.
- Full local `npm test` was attempted: 903 files passed and 15 failed (41 failed tests), with Windows-local symlink/ACL/file-lock failures and load-related timeouts in untouched suites. Exact-head GitHub Actions remains the authoritative full validation.

## Review focus

- Verify that full plans use Ubuntu only for report merge and threshold enforcement, while selective affected-module tests remain on macOS.
- Verify that the focused dispatch cannot select release or platform E2E bundles.
- Verify that the hourly Windows planner fails open on API lookup errors, skips only an already-successful main SHA, and never skips manual dispatches.
- Verify that the final matrix and command remain three-way sharded.
## Merge prerequisite

- CI Integrity intentionally rejects changes to the protected PR Gate control plane. An explicit maintainer ruleset bypass is required before merge; this PR does not weaken or bypass that guard.
