### PR TITLE
fix(workspace): preserve pending interaction priority

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -4,6 +4,7 @@
     "session_renderer": {
       "ownerPaths": [
         "src/renderer/src/stores/session-store.ts",
+        "src/renderer/src/stores/session-store-interaction-state.ts",
         "src/renderer/src/stores/session-store-persistence-owner.ts",
         "src/renderer/src/stores/session-store-message-graph-owner.ts",
         "src/renderer/src/stores/session-store-message-graph-helpers.ts",

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -967,6 +967,56 @@ describe('workspace durable elicitation', () => {
     expect(useSessionStore.getState().sessions[0].status).toBe('waiting-for-user')
   })
 
+  it('does not rearm an answered durable question when Permission becomes pending', () => {
+    const request = {
+      requestId: 'choice-1',
+      sessionId: 'session-choice-1',
+      toolCallId: 'tool-choice-1',
+      message: 'Choose an approach',
+      fields: [{ id: 'question_0', label: 'Approach', kind: 'text' as const }],
+      durable: { kind: 'agent-user-choice' as const, requestId: 'choice-1' }
+    }
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === request.sessionId
+          ? {
+              ...session,
+              status: 'waiting-for-user',
+              activities: [
+                {
+                  id: request.toolCallId,
+                  kind: 'tool',
+                  title: 'Waiting for an answer',
+                  status: 'in_progress',
+                  sortIndex: 1,
+                  eventIds: [],
+                  elicitation: {
+                    message: request.message,
+                    fields: request.fields,
+                    state: 'pending',
+                    durable: request.durable
+                  },
+                  createdAt: Date.now(),
+                  updatedAt: Date.now()
+                }
+              ]
+            }
+          : session
+      )
+    }))
+
+    syncWorkspaceElicitationState([request])
+    useSessionStore.getState().setElicitationPending(request.sessionId, false)
+    useSessionStore.getState().setPermissionPending(request.sessionId)
+    syncWorkspaceElicitationState([])
+    useSessionStore.getState().clearPermissionPending(request.sessionId)
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'idle',
+      interactionState: { permission: false, elicitation: false }
+    })
+  })
+
   it('reattaches a restored session before submitting its durable answer', async () => {
     const resumeSession = vi.fn().mockResolvedValue({
       sessionId: 'session-choice-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1,4 +1,8 @@
-import type { AcpRuntimeEvent, AcpStateSnapshot } from '../../../../shared/acp'
+import type {
+  AcpPermissionRequest,
+  AcpRuntimeEvent,
+  AcpStateSnapshot
+} from '../../../../shared/acp'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -29,7 +33,8 @@ import {
 import { respondToWorkspaceElicitation } from './workspace-elicitation-runtime'
 import {
   resetWorkspaceRuntimeEventOwnerForTests,
-  syncWorkspaceElicitationState
+  syncWorkspaceElicitationState,
+  syncWorkspacePermissionState
 } from './workspace-runtime-event-owner'
 import {
   cancelWorkspaceRun,
@@ -708,6 +713,122 @@ describe('workspace durable elicitation', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('keeps another session waiting on a restored permission after answering a durable question', async () => {
+    const permissionRequest: AcpPermissionRequest = {
+      requestId: 'permission-restored',
+      sessionId: 'session-permission-1',
+      toolCallId: 'tool-permission-1',
+      title: 'Run npm test',
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }],
+      durable: true
+    }
+    useSessionStore.getState().appendUserMessage({
+      sessionId: permissionRequest.sessionId,
+      content: 'Run the verification',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+    useSessionStore.getState().finishRun(permissionRequest.sessionId)
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === permissionRequest.sessionId
+          ? {
+              ...session,
+              status: 'waiting-permission',
+              runtimeContext: {
+                version: 1,
+                revision: 1,
+                permission: {
+                  state: 'pending',
+                  request: permissionRequest,
+                  originatingPromptMessageId: session.messages[0].id,
+                  fingerprint: 'a'.repeat(64),
+                  createdAt: 1
+                }
+              }
+            }
+          : session
+      )
+    }))
+    syncWorkspacePermissionState([permissionRequest])
+    useSessionStore.getState().setElicitationPending('session-choice-1', true)
+
+    await respondToWorkspaceElicitation(
+      {
+        state: createSnapshot(['session-choice-1']),
+        resumeSession: vi.fn(),
+        respondToElicitation: vi.fn().mockResolvedValue(createSnapshot(['session-choice-1']))
+      },
+      {
+        requestId: 'choice-1',
+        action: 'accept',
+        answers: [{ fieldId: 'question_0', value: 'Minimal' }],
+        request: {
+          requestId: 'choice-1',
+          sessionId: 'session-choice-1',
+          toolCallId: 'tool-choice-1',
+          message: 'Choose an approach',
+          fields: [{ id: 'question_0', label: 'Approach', kind: 'text' }],
+          durable: { kind: 'agent-user-choice', requestId: 'choice-1' }
+        }
+      }
+    )
+
+    expect(
+      useSessionStore
+        .getState()
+        .sessions.find((session) => session.id === permissionRequest.sessionId)
+    ).toMatchObject({
+      status: 'waiting-permission',
+      runtimeContext: { permission: { state: 'pending', request: permissionRequest } }
+    })
+  })
+
+  it('falls back to a pending permission in the same session after answering a durable question', async () => {
+    const permissionRequest: AcpPermissionRequest = {
+      requestId: 'permission-live',
+      sessionId: 'session-choice-1',
+      toolCallId: 'tool-permission-live',
+      title: 'Run npm test',
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    const elicitationRequest = {
+      requestId: 'choice-1',
+      sessionId: 'session-choice-1',
+      toolCallId: 'tool-choice-1',
+      message: 'Choose an approach',
+      fields: [{ id: 'question_0', label: 'Approach', kind: 'text' as const }],
+      durable: { kind: 'agent-user-choice' as const, requestId: 'choice-1' }
+    }
+    syncWorkspacePermissionState([permissionRequest])
+    syncWorkspaceElicitationState([elicitationRequest])
+    const continued = {
+      ...createSnapshot(['session-choice-1']),
+      pendingPermissions: [permissionRequest],
+      pendingElicitations: []
+    }
+
+    await respondToWorkspaceElicitation(
+      {
+        state: {
+          ...createSnapshot(['session-choice-1']),
+          pendingPermissions: [permissionRequest],
+          pendingElicitations: [elicitationRequest]
+        },
+        resumeSession: vi.fn(),
+        respondToElicitation: vi.fn().mockResolvedValue(continued)
+      },
+      {
+        requestId: elicitationRequest.requestId,
+        action: 'accept',
+        answers: [{ fieldId: 'question_0', value: 'Minimal' }],
+        request: elicitationRequest
+      }
+    )
+
+    expect(useSessionStore.getState().sessions[0].status).toBe('waiting-permission')
   })
 
   it('returns to running when no actionable user choice remains', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -277,8 +277,8 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   }, [agentPromptInFlightSessionIds, runtime.state])
 
   useEffect(() => {
-    syncWorkspacePermissionState(pendingPermissions)
     syncWorkspaceElicitationState(runtime.state.pendingElicitations ?? [])
+    syncWorkspacePermissionState(pendingPermissions)
   }, [pendingPermissions, runtime.state.pendingElicitations])
 
   useEffect(() => {

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -285,6 +285,11 @@ const syncWorkspaceAgentFirstOutputState = (sessionIds: string[]): void => {
 const syncWorkspacePermissionState = (requests: AcpPermissionRequest[]): void => {
   const nextSessionIds = new Set(requests.map((request) => request.sessionId))
   const store = useSessionStore.getState()
+  for (const session of store.sessions) {
+    if (session.runtimeContext?.permission?.state === 'pending') {
+      nextSessionIds.add(session.id)
+    }
+  }
 
   for (const sessionId of nextSessionIds) {
     store.setPermissionPending(sessionId)
@@ -309,7 +314,7 @@ const syncWorkspaceElicitationState = (requests: PendingElicitationRequest[]): v
   )
   for (const session of store.sessions) {
     if (
-      session.status === 'waiting-for-user' &&
+      (session.status === 'waiting-for-user' || session.status === 'waiting-permission') &&
       session.activities?.some(
         (activity) =>
           activity.elicitation?.state === 'pending' &&
@@ -339,8 +344,8 @@ const syncWorkspaceInteractionState = (
   >
 ): void => {
   syncWorkspaceAgentFirstOutputState(snapshot.agentPromptInFlightSessionIds ?? [])
-  syncWorkspacePermissionState(snapshot.pendingPermissions)
   syncWorkspaceElicitationState(snapshot.pendingElicitations ?? [])
+  syncWorkspacePermissionState(snapshot.pendingPermissions)
 }
 
 const resetWorkspaceRuntimeEventOwnerForTests = (): void => {

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -315,6 +315,7 @@ const syncWorkspaceElicitationState = (requests: PendingElicitationRequest[]): v
   for (const session of store.sessions) {
     if (
       (session.status === 'waiting-for-user' || session.status === 'waiting-permission') &&
+      session.interactionState?.elicitation !== false &&
       session.activities?.some(
         (activity) =>
           activity.elicitation?.state === 'pending' &&

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -1119,6 +1119,31 @@ describe('ConversationPanel composer intake', () => {
     }
   )
 
+  it('keeps Side chat disabled while the main Session is waiting-plan-approval', () => {
+    const onStartSideChat = vi.fn()
+    renderPanel({
+      activeSession: {
+        id: 'session-plan-waiting',
+        projectId: 'project-a',
+        title: 'Waiting Plan',
+        cwd: '/workspace',
+        status: 'waiting-plan-approval',
+        messages: planOriginMessages(),
+        createdAt: 1,
+        updatedAt: 2
+      },
+      canSendMessage: false,
+      canEditDraft: true,
+      draftDoc: { nodes: [{ type: 'text', text: 'Ask on the side' }] },
+      onStartSideChat
+    })
+
+    const item = container.querySelector('[data-testid="menu-side-chat"]') as HTMLButtonElement
+    expect(item.disabled).toBe(true)
+    act(() => item.click())
+    expect(onStartSideChat).not.toHaveBeenCalled()
+  })
+
   it('explains why strict Side chat is unavailable for an unsupported backend', () => {
     const reason = 'Strict tool isolation is unavailable.'
     renderPanel({
@@ -1311,20 +1336,24 @@ describe('ConversationPanel composer intake', () => {
   })
 
   it('keeps main approval and ask-user surfaces waiting while Side chat is open', () => {
+    const activeSession: ChatSession = {
+      id: 'session-existing',
+      projectId: 'project-a',
+      title: 'Existing session',
+      cwd: '/workspace',
+      status: 'waiting-permission',
+      interrupted: true,
+      messages: planOriginMessages(),
+      createdAt: 1,
+      updatedAt: 2
+    }
+    const pendingPermissions = [{} as never]
+    const pendingElicitations = [{} as never]
+
     renderPanel({
-      activeSession: {
-        id: 'session-existing',
-        projectId: 'project-a',
-        title: 'Existing session',
-        cwd: '/workspace',
-        status: 'waiting-permission',
-        interrupted: true,
-        messages: planOriginMessages(),
-        createdAt: 1,
-        updatedAt: 2
-      },
-      pendingPermissions: [{} as never],
-      pendingElicitations: [{} as never],
+      activeSession,
+      pendingPermissions,
+      pendingElicitations,
       sideChat: {
         generation: 1,
         parentSessionId: 'session-existing',
@@ -1346,6 +1375,55 @@ describe('ConversationPanel composer intake', () => {
       container.querySelector('[data-testid="scroller-pending-elicitations"]')?.textContent
     ).toBe('0')
     expect(getComposerForm().hidden).toBe(true)
+
+    renderPanel({ activeSession, pendingPermissions, pendingElicitations })
+
+    expect(container.querySelector('[data-testid="permission-approval-controls"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="elicitation-composer"]')).toBeNull()
+    expect(
+      container.querySelector('[data-testid="scroller-pending-elicitations"]')?.textContent
+    ).toBe('1')
+  })
+
+  it('reveals a waiting Plan immediately after Side chat closes', () => {
+    const activeSession: ChatSession = {
+      id: 'session-plan-under-side-chat',
+      projectId: 'project-a',
+      title: 'Plan under Side chat',
+      cwd: '/workspace',
+      status: 'waiting-plan-approval',
+      messages: planOriginMessages(),
+      activePlanProjection: {
+        ...completedPlanProjection,
+        approval: 'pending',
+        lifecycle: 'awaiting_approval'
+      },
+      createdAt: 1,
+      updatedAt: 2
+    }
+
+    renderPanel({
+      activeSession,
+      sideChat: {
+        generation: 1,
+        parentSessionId: activeSession.id,
+        projectId: activeSession.projectId,
+        sideSessionId: 'side-plan',
+        draft: '',
+        running: false,
+        entries: []
+      },
+      onSendSideChat: vi.fn(async () => true),
+      onSideChatDraftChange: vi.fn(),
+      onCancelSideChat: vi.fn(),
+      onCloseSideChat: vi.fn()
+    })
+
+    expect(container.querySelector('[data-testid="plan-composer"]')).toBeNull()
+
+    renderPanel({ activeSession })
+
+    expect(container.querySelector('[data-testid="plan-composer"]')).not.toBeNull()
   })
 
   it('disables Plan first for an attachment-only draft', () => {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -502,6 +502,7 @@ const ConversationPanel = ({
     hasMainConversation(activeSession) &&
     activeSession?.status !== 'waiting-for-user' &&
     activeSession?.status !== 'waiting-permission' &&
+    activeSession?.status !== 'waiting-plan-approval' &&
     canEditDraft &&
     hasTextDraft &&
     attachments.length === 0 &&

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
@@ -186,7 +186,7 @@ describe('workspace conversation controller', () => {
     expect(input.composer.lifecycle.clearDraft).not.toHaveBeenCalled()
   })
 
-  it.each(['waiting-for-user', 'waiting-permission'] as const)(
+  it.each(['waiting-for-user', 'waiting-permission', 'waiting-plan-approval'] as const)(
     'does not start Side chat while the main Session is %s',
     (status) => {
       const input = options({

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -156,6 +156,7 @@ const canStartSideChat = (options: WorkspaceConversationControllerOptions): bool
     options.isPersistenceReady &&
     options.activeSession.status !== 'waiting-for-user' &&
     options.activeSession.status !== 'waiting-permission' &&
+    options.activeSession.status !== 'waiting-plan-approval' &&
     options.composer.view.transfers.length === 0 &&
     options.composer.view.attachments.length === 0 &&
     docToText(options.composer.view.doc).trim()

--- a/src/renderer/src/stores/session-store-interaction-state.ts
+++ b/src/renderer/src/stores/session-store-interaction-state.ts
@@ -1,0 +1,62 @@
+import type { ChatSession, SessionStatus } from './session-store-persistence-owner'
+
+export type SessionInteractionState = Readonly<{
+  permission: boolean
+  elicitation: boolean
+  plan: boolean
+}>
+
+const isWaitingStatus = (status: SessionStatus): boolean =>
+  status === 'waiting-permission' ||
+  status === 'waiting-for-user' ||
+  status === 'waiting-plan-approval'
+
+const hasPendingDurableElicitation = (session: ChatSession): boolean =>
+  (session.status === 'waiting-for-user' || session.status === 'waiting-permission') &&
+  session.activities?.some(
+    (activity) =>
+      activity.elicitation?.state === 'pending' &&
+      activity.elicitation.durable?.kind === 'agent-user-choice'
+  ) === true
+
+export const inferSessionInteractionState = (session: ChatSession): SessionInteractionState =>
+  session.interactionState ?? {
+    permission:
+      session.runtimeContext?.permission?.state === 'pending' ||
+      session.status === 'waiting-permission',
+    elicitation: session.status === 'waiting-for-user' || hasPendingDurableElicitation(session),
+    plan:
+      session.status === 'waiting-plan-approval' ||
+      ((session.status === 'waiting-permission' || session.status === 'waiting-for-user') &&
+        session.runtimeContext?.plan?.approval === 'pending')
+  }
+
+export const resolveSessionInteractionStatus = (
+  session: ChatSession,
+  interactionState: SessionInteractionState = inferSessionInteractionState(session)
+): SessionStatus => {
+  if (interactionState.permission) return 'waiting-permission'
+  if (interactionState.elicitation) return 'waiting-for-user'
+  if (interactionState.plan) return 'waiting-plan-approval'
+  if (!isWaitingStatus(session.status)) return session.status
+  return session.activeRun || session.agentPromptInFlight ? 'running' : 'idle'
+}
+
+export const projectSessionInteractionState = (
+  session: ChatSession,
+  patch: Partial<SessionInteractionState>
+): ChatSession => {
+  const current = inferSessionInteractionState(session)
+  const interactionState = { ...current, ...patch }
+  const status = resolveSessionInteractionStatus(session, interactionState)
+  if (
+    current.permission === interactionState.permission &&
+    current.elicitation === interactionState.elicitation &&
+    current.plan === interactionState.plan &&
+    session.interactionState &&
+    status === session.status
+  ) {
+    return session
+  }
+  return { ...session, interactionState, status, updatedAt: Date.now() }
+}

--- a/src/renderer/src/stores/session-store-interaction-state.ts
+++ b/src/renderer/src/stores/session-store-interaction-state.ts
@@ -20,16 +20,18 @@ const hasPendingDurableElicitation = (session: ChatSession): boolean =>
   ) === true
 
 export const inferSessionInteractionState = (session: ChatSession): SessionInteractionState =>
-  session.interactionState ?? {
-    permission:
-      session.runtimeContext?.permission?.state === 'pending' ||
-      session.status === 'waiting-permission',
-    elicitation: session.status === 'waiting-for-user' || hasPendingDurableElicitation(session),
-    plan:
-      session.status === 'waiting-plan-approval' ||
-      ((session.status === 'waiting-permission' || session.status === 'waiting-for-user') &&
-        session.runtimeContext?.plan?.approval === 'pending')
-  }
+  session.interactionState && isWaitingStatus(session.status)
+    ? session.interactionState
+    : {
+        permission:
+          session.runtimeContext?.permission?.state === 'pending' ||
+          session.status === 'waiting-permission',
+        elicitation: session.status === 'waiting-for-user' || hasPendingDurableElicitation(session),
+        plan:
+          session.status === 'waiting-plan-approval' ||
+          ((session.status === 'waiting-permission' || session.status === 'waiting-for-user') &&
+            session.runtimeContext?.plan?.approval === 'pending')
+      }
 
 export const resolveSessionInteractionStatus = (
   session: ChatSession,

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -343,21 +343,20 @@ const projectDurablePlanAuthority = (
     return current
   }
 
-  const status =
-    current.compacting ||
-    current.status === 'waiting-for-user' ||
-    current.status === 'waiting-permission'
-      ? current.status
-      : durable.runtimeContext?.plan?.approval === 'pending'
-        ? 'waiting-plan-approval'
-        : current.status === 'waiting-plan-approval'
-          ? current.activeRun || current.agentPromptInFlight
-            ? 'running'
-            : 'idle'
-          : current.status
+  const interactionState = {
+    ...inferSessionInteractionState(current),
+    plan: durable.runtimeContext?.plan?.approval === 'pending'
+  }
+  const status = current.compacting
+    ? current.status
+    : resolveSessionInteractionStatus(
+        { ...current, runtimeContext: durable.runtimeContext },
+        interactionState
+      )
   return {
     ...current,
     status,
+    interactionState,
     runtimeContext: durable.runtimeContext,
     updatedAt: Math.max(current.updatedAt, durable.updatedAt)
   }

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -29,6 +29,11 @@ import {
   type PersistedToolActivity,
   type PersistedUploadedAttachment
 } from '../../../shared/session-persistence'
+import {
+  inferSessionInteractionState,
+  resolveSessionInteractionStatus,
+  type SessionInteractionState
+} from './session-store-interaction-state'
 
 export type SessionStatus = PersistedSessionStatus
 export type ChatMessageRole = PersistedMessageRole
@@ -85,6 +90,9 @@ export type ChatSession = Omit<
   branchSwitchBlocked?: boolean
   conversationGraphSyncBlocked?: boolean
   pendingContextReplayMessageId?: string
+  // Transient independent facts for the blocking lane. Plan remains owned by its durable
+  // projection, while Side chat remains an overlay that never settles these facts.
+  interactionState?: SessionInteractionState
 }
 
 export type SessionStoreData = {
@@ -153,6 +161,7 @@ export const toPersistedSession = (session: ChatSession): PersistedChatSession =
     branchSwitchBlocked,
     conversationGraphSyncBlocked,
     pendingContextReplayMessageId,
+    interactionState,
     activePlanProjection,
     planHistoryProjections,
     runtimeContext,
@@ -174,6 +183,7 @@ export const toPersistedSession = (session: ChatSession): PersistedChatSession =
   void branchSwitchBlocked
   void conversationGraphSyncBlocked
   void pendingContextReplayMessageId
+  void interactionState
   void activePlanProjection
   void runtimeContext
 
@@ -207,16 +217,19 @@ export const hydrateToolActivity = (activity: PersistedToolActivity): ToolActivi
 })
 
 // Maps a persisted session (with bounded activities) back into the in-memory chat session shape.
-export const hydrateSession = (session: PersistedChatSession): ChatSession => ({
-  ...session,
-  permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
-  activities: session.activities?.map(hydrateToolActivity),
-  interrupted:
-    session.resumeRecovery?.kind === 'resume-required' ||
-    session.error === INTERRUPTED_SESSION_ERROR
-      ? true
-      : undefined
-})
+export const hydrateSession = (session: PersistedChatSession): ChatSession => {
+  const hydrated: ChatSession = {
+    ...session,
+    permissionProfile: session.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+    activities: session.activities?.map(hydrateToolActivity),
+    interrupted:
+      session.resumeRecovery?.kind === 'resume-required' ||
+      session.error === INTERRUPTED_SESSION_ERROR
+        ? true
+        : undefined
+  }
+  return { ...hydrated, interactionState: inferSessionInteractionState(hydrated) }
+}
 
 const matchesPersistedPlanProjection = (
   projection: ActivePlanProjection | undefined,
@@ -260,7 +273,8 @@ const withTransientSessionState = (
     elicitationHistoryReplayRequestId: source.elicitationHistoryReplayRequestId,
     branchSwitchBlocked: source.branchSwitchBlocked,
     conversationGraphSyncBlocked: source.conversationGraphSyncBlocked,
-    pendingContextReplayMessageId: source.pendingContextReplayMessageId
+    pendingContextReplayMessageId: source.pendingContextReplayMessageId,
+    interactionState: source.interactionState
   }
 }
 
@@ -466,18 +480,18 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
         }
 
         const permissionPending = session.runtimeContext?.permission?.state === 'pending'
-        const status = permissionPending
-          ? current.status === 'waiting-for-user' || current.status === 'waiting-plan-approval'
-            ? current.status
-            : 'waiting-permission'
-          : current.status === 'waiting-permission'
-            ? current.activeRun || current.agentPromptInFlight
-              ? 'running'
-              : 'idle'
-            : current.status
+        const interactionState = {
+          ...inferSessionInteractionState(current),
+          permission: permissionPending
+        }
+        const status = resolveSessionInteractionStatus(
+          { ...current, runtimeContext: session.runtimeContext },
+          interactionState
+        )
         const projected: ChatSession = {
           ...current,
           status,
+          interactionState,
           runtimeContext: session.runtimeContext,
           updatedAt: Math.max(current.updatedAt, session.updatedAt)
         }

--- a/src/renderer/src/stores/session-store-run-activity-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-activity-helpers.ts
@@ -5,6 +5,7 @@ import { sanitizeActivityGroupTitle } from '../../../shared/activity-groups'
 import type { ActivePlanProjection } from '../../../shared/session-plan/contract'
 import type { PersistedActivityGroup } from '../../../shared/session-persistence'
 import { createSortIndex } from './session-store-message-graph-owner'
+import { inferSessionInteractionState } from './session-store-interaction-state'
 import type {
   ChatSession,
   SessionStatus,
@@ -127,30 +128,41 @@ export const projectActivePlan = (
           previous
         ]
       : session.planHistoryProjections
+  const interactionState = inferSessionInteractionState(session)
+  const planWaiting = projection.lifecycle === 'awaiting_approval'
+  const interactionStatus = interactionState.permission
+    ? 'waiting-permission'
+    : interactionState.elicitation
+      ? 'waiting-for-user'
+      : planWaiting
+        ? 'waiting-plan-approval'
+        : undefined
   return {
     ...session,
     ...(replaced ? { planHistoryProjections: replaced } : {}),
     activePlanProjection: projection,
-    status:
-      session.compacting || session.status === 'waiting-for-user'
-        ? session.status
-        : projection.lifecycle === 'awaiting_approval'
-          ? 'waiting-plan-approval'
-          : projection.lifecycle === 'rejected'
-            ? session.activeRun
-              ? 'running'
-              : 'idle'
-            : projection.lifecycle === 'blocked'
-              ? 'idle'
-              : projection.lifecycle === 'completed'
+    interactionState: {
+      ...interactionState,
+      plan: planWaiting
+    },
+    status: session.compacting
+      ? session.status
+      : (interactionStatus ??
+        (projection.lifecycle === 'rejected'
+          ? session.activeRun
+            ? 'running'
+            : 'idle'
+          : projection.lifecycle === 'blocked'
+            ? 'idle'
+            : projection.lifecycle === 'completed'
+              ? session.activeRun
+                ? 'running'
+                : 'idle'
+              : projection.approval === 'approved'
                 ? session.activeRun
                   ? 'running'
                   : 'idle'
-                : projection.approval === 'approved'
-                  ? session.activeRun
-                    ? 'running'
-                    : 'idle'
-                  : session.status,
+                : session.status)),
     updatedAt: Date.now()
   }
 }

--- a/src/renderer/src/stores/session-store-run-terminal-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-terminal-helpers.ts
@@ -15,6 +15,7 @@ import {
   completeOpenActivityGroups,
   failOpenActivities
 } from './session-store-run-activity-helpers'
+import { projectSessionInteractionState } from './session-store-interaction-state'
 import type { ChatMessage, ChatSession, ToolActivity } from './session-store-persistence-owner'
 
 const ARTIFACT_ERROR_PREFIX = 'Generated file finalization failed'
@@ -29,7 +30,8 @@ const CLEARED_AGENT_RUN_STATE = {
   agentStatus: undefined,
   awaitingFirstAgentOutput: undefined,
   agentPromptInFlight: undefined,
-  compacting: undefined
+  compacting: undefined,
+  interactionState: undefined
 } satisfies Pick<
   ChatSession,
   | 'activeRun'
@@ -38,6 +40,7 @@ const CLEARED_AGENT_RUN_STATE = {
   | 'awaitingFirstAgentOutput'
   | 'agentPromptInFlight'
   | 'compacting'
+  | 'interactionState'
 >
 
 const settleConversationGraphSyncFailure = (
@@ -186,21 +189,7 @@ export const projectAgentPromptInFlight = (
 }
 
 export const projectElicitationPending = (session: ChatSession, pending: boolean): ChatSession => {
-  if (pending) {
-    if (session.status === 'waiting-for-user') return session
-    return { ...session, status: 'waiting-for-user', updatedAt: Date.now() }
-  }
-  if (session.status !== 'waiting-for-user') return session
-  return {
-    ...session,
-    status:
-      session.activePlanProjection?.lifecycle === 'awaiting_approval'
-        ? 'waiting-plan-approval'
-        : session.activeRun || session.agentPromptInFlight
-          ? 'running'
-          : 'idle',
-    updatedAt: Date.now()
-  }
+  return projectSessionInteractionState(session, { elicitation: pending })
 }
 
 export const projectPermissionPending = (
@@ -214,12 +203,12 @@ export const projectPermissionPending = (
   if (rearmAuthority && runtimeContext && permission) {
     nextRuntimeContext = { ...runtimeContext, permission: { ...permission, state: 'pending' } }
   }
-  const status =
-    session.status === 'waiting-for-user' || session.status === 'waiting-plan-approval'
-      ? session.status
-      : 'waiting-permission'
-  if (nextRuntimeContext === runtimeContext && status === session.status) return session
-  return { ...session, runtimeContext: nextRuntimeContext, status, updatedAt: Date.now() }
+  return projectSessionInteractionState(
+    nextRuntimeContext === runtimeContext
+      ? session
+      : { ...session, runtimeContext: nextRuntimeContext },
+    { permission: true }
+  )
 }
 
 export const projectPermissionCleared = (
@@ -245,14 +234,12 @@ export const projectPermissionCleared = (
     delete settledRuntimeContext.permission
     nextRuntimeContext = settledRuntimeContext
   }
-  const status =
-    session.status === 'waiting-permission'
-      ? session.activeRun || session.agentPromptInFlight
-        ? 'running'
-        : 'idle'
-      : session.status
-  if (nextRuntimeContext === runtimeContext && status === session.status) return session
-  return { ...session, runtimeContext: nextRuntimeContext, status, updatedAt: Date.now() }
+  return projectSessionInteractionState(
+    nextRuntimeContext === runtimeContext
+      ? session
+      : { ...session, runtimeContext: nextRuntimeContext },
+    { permission: false }
+  )
 }
 
 export const projectArtifactError = (session: ChatSession, error: string): ChatSession => ({

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -89,6 +89,7 @@ const resolveImportTarget = (sourcePath: string, specifier: string): string | un
 }
 
 const ownerNames = [
+  'session-store-interaction-state',
   'session-store-message-graph-helpers',
   'session-store-message-graph-owner',
   'session-store-persistence-owner',
@@ -996,6 +997,7 @@ describe('Session Store architecture', () => {
     expect(manifest.modules.session_renderer).toMatchObject({
       ownerPaths: [
         'src/renderer/src/stores/session-store.ts',
+        'src/renderer/src/stores/session-store-interaction-state.ts',
         'src/renderer/src/stores/session-store-persistence-owner.ts',
         'src/renderer/src/stores/session-store-message-graph-owner.ts',
         'src/renderer/src/stores/session-store-message-graph-helpers.ts',

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -716,8 +716,16 @@ describe('session store', () => {
 
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       status: 'waiting-plan-approval',
-      activePlanProjection: { approval: 'pending' }
+      activePlanProjection: { approval: 'pending' },
+      interactionState: { plan: true }
     })
+
+    useSessionStore.getState().setPermissionPending('session-1')
+    expect(useSessionStore.getState().sessions[0].status).toBe('waiting-permission')
+
+    useSessionStore.getState().clearPermissionPending('session-1')
+
+    expect(useSessionStore.getState().sessions[0].status).toBe('waiting-plan-approval')
   })
 
   it('returns a settled blocked Plan session to idle', () => {
@@ -1597,7 +1605,7 @@ describe('session store', () => {
     expect(useSessionStore.getState().sessions[0].status).toBe('idle')
   })
 
-  it('keeps user input and Plan approval ahead of a simultaneous permission wait', () => {
+  it('projects simultaneous blocking interactions in Permission, Ask, then Plan order', () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',
       content: 'Run the workflow'
@@ -1605,17 +1613,107 @@ describe('session store', () => {
     useSessionStore.getState().setElicitationPending('transport-session-1', true)
     useSessionStore.getState().setPermissionPending('transport-session-1')
 
-    expect(useSessionStore.getState().sessions[0].status).toBe('waiting-for-user')
+    expect(useSessionStore.getState().sessions[0].status).toBe('waiting-permission')
 
     useSessionStore
       .getState()
       .setActivePlanProjection('transport-session-1', createPlanProjection('version-1'))
+    expect(useSessionStore.getState().sessions[0].status).toBe('waiting-permission')
+
+    useSessionStore.getState().clearPermissionPending('transport-session-1')
     expect(useSessionStore.getState().sessions[0].status).toBe('waiting-for-user')
 
     useSessionStore.getState().setElicitationPending('transport-session-1', false)
-    useSessionStore.getState().setPermissionPending('transport-session-1')
-
     expect(useSessionStore.getState().sessions[0].status).toBe('waiting-plan-approval')
+  })
+
+  it('restores simultaneous durable Permission, Ask, and Plan state without persisting the transient index', () => {
+    const restored: PersistedChatSession = {
+      id: 'session-restored-interactions',
+      projectId: 'project-1',
+      title: 'Restored interactions',
+      cwd: '/workspace',
+      status: 'waiting-permission',
+      runtimeContext: {
+        version: 1,
+        revision: 1,
+        permission: {
+          state: 'pending',
+          request: {
+            requestId: 'permission-restored',
+            sessionId: 'session-restored-interactions',
+            toolCallId: 'permission-tool',
+            title: 'Run npm test',
+            options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+          },
+          originatingPromptMessageId: 'prompt-1',
+          fingerprint: 'a'.repeat(64),
+          createdAt: 1
+        },
+        plan: {
+          artifactId: 'plan-artifact',
+          artifactVersionId: 'plan-version',
+          artifactChecksum: 'b'.repeat(64),
+          approval: 'pending',
+          stepStatuses: {}
+        }
+      },
+      messages: [
+        {
+          id: 'prompt-1',
+          role: 'user',
+          content: 'Run the workflow',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      activities: [
+        {
+          id: 'ask-tool',
+          kind: 'tool',
+          title: 'Choose an approach',
+          status: 'in_progress',
+          eventIds: [],
+          sortIndex: 1,
+          elicitation: {
+            message: 'Choose an approach',
+            fields: [{ id: 'question_0', label: 'Approach', kind: 'text' }],
+            state: 'pending',
+            durable: { kind: 'agent-user-choice', requestId: 'choice-restored' }
+          },
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 2
+    }
+
+    useSessionStore.getState().hydrateSessions([restored])
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-permission',
+      interactionState: { permission: true, elicitation: true, plan: true }
+    })
+    expect(toPersistedSession(useSessionStore.getState().sessions[0])).not.toHaveProperty(
+      'interactionState'
+    )
+
+    useSessionStore.getState().clearPermissionPending('session-restored-interactions', {
+      authority: 'settled'
+    })
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-for-user',
+      interactionState: { permission: false, elicitation: true, plan: true }
+    })
+
+    useSessionStore.getState().setElicitationPending('session-restored-interactions', false)
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-plan-approval',
+      interactionState: { permission: false, elicitation: false, plan: true }
+    })
   })
 
   it('keeps Plan approval waiting sticky across late generate_plan activity updates', () => {

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -354,6 +354,107 @@ describe('session store', () => {
     })
   })
 
+  it('reconciles a pending durable Plan while Permission is waiting', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Plan approval',
+        cwd: '/workspace',
+        status: 'idle',
+        messages: [],
+        createdAt: 1,
+        updatedAt: 2
+      }
+    ])
+    useSessionStore.getState().setPermissionPending('session-1')
+    const source = useSessionStore.getState().sessions[0]
+
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: {
+        ...toPersistedSession(source),
+        status: 'waiting-plan-approval',
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          plan: {
+            artifactId: 'plan-1',
+            artifactVersionId: 'plan-version-1',
+            artifactChecksum: 'a'.repeat(64),
+            approval: 'pending',
+            stepStatuses: {}
+          }
+        },
+        updatedAt: source.updatedAt + 10
+      }
+    })
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-permission',
+      interactionState: { permission: true, plan: true }
+    })
+
+    useSessionStore.getState().clearPermissionPending('session-1')
+    expect(useSessionStore.getState().sessions[0].status).toBe('waiting-plan-approval')
+  })
+
+  it('drops a settled durable Plan while Permission is waiting', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Plan approval',
+        cwd: '/workspace',
+        status: 'waiting-plan-approval',
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          plan: {
+            artifactId: 'plan-1',
+            artifactVersionId: 'plan-version-1',
+            artifactChecksum: 'a'.repeat(64),
+            approval: 'pending',
+            stepStatuses: {}
+          }
+        },
+        messages: [],
+        createdAt: 1,
+        updatedAt: 2
+      }
+    ])
+    useSessionStore.getState().setPermissionPending('session-1')
+    const source = useSessionStore.getState().sessions[0]
+
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: {
+        ...toPersistedSession(source),
+        status: 'idle',
+        runtimeContext: {
+          version: 1,
+          revision: 2,
+          plan: {
+            artifactId: 'plan-1',
+            artifactVersionId: 'plan-version-1',
+            artifactChecksum: 'a'.repeat(64),
+            approval: 'approved',
+            stepStatuses: {}
+          }
+        },
+        updatedAt: source.updatedAt + 10
+      }
+    })
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'waiting-permission',
+      interactionState: { permission: true, plan: false }
+    })
+
+    useSessionStore.getState().clearPermissionPending('session-1')
+    expect(useSessionStore.getState().sessions[0].status).toBe('idle')
+  })
+
   it('does not replace newer local conversation state when a durable Plan authority arrives', () => {
     const prompt = useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1627,6 +1627,65 @@ describe('session store', () => {
     expect(useSessionStore.getState().sessions[0].status).toBe('waiting-plan-approval')
   })
 
+  it('does not restore obsolete Ask and Plan waits after a new turn starts', () => {
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: 'session-restored-interactions',
+          projectId: 'project-1',
+          title: 'Restored interactions',
+          cwd: '/workspace',
+          status: 'waiting-for-user',
+          interactionState: { permission: false, elicitation: true, plan: true },
+          messages: [],
+          createdAt: 1,
+          updatedAt: 2
+        }
+      ],
+      selectedSessionId: 'session-restored-interactions'
+    })
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-restored-interactions',
+      content: 'Continue with the selected choices'
+    })
+    useSessionStore.getState().setPermissionPending('session-restored-interactions')
+    useSessionStore.getState().clearPermissionPending('session-restored-interactions')
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'running',
+      interactionState: { permission: false, elicitation: false, plan: false }
+    })
+  })
+
+  it('does not restore obsolete Ask and Plan waits after a Session resumes', () => {
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: 'session-restored-interactions',
+          projectId: 'project-1',
+          title: 'Restored interactions',
+          cwd: '/workspace',
+          status: 'waiting-for-user',
+          interactionState: { permission: false, elicitation: true, plan: true },
+          messages: [],
+          createdAt: 1,
+          updatedAt: 2
+        }
+      ],
+      selectedSessionId: 'session-restored-interactions'
+    })
+
+    useSessionStore.getState().markResumed('session-restored-interactions')
+    useSessionStore.getState().setPermissionPending('session-restored-interactions')
+    useSessionStore.getState().clearPermissionPending('session-restored-interactions')
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'idle',
+      interactionState: { permission: false, elicitation: false, plan: false }
+    })
+  })
+
   it('restores simultaneous durable Permission, Ask, and Plan state without persisting the transient index', () => {
     const restored: PersistedChatSession = {
       id: 'session-restored-interactions',


### PR DESCRIPTION
## Problem

After restart, answering a durable Ask card could synchronize a live-only runtime snapshot that omitted another restored Permission. The shared Session status was then reset even though durable Permission authority still existed, so the sidebar lost Waiting for you and the Session showed an MCP tool without actionable controls.

Permission, Ask, and Plan also wrote the same status independently. Settling one interaction could therefore hide another interaction in the same Session. Side chat had a separate overlay, but Plan approval did not block starting a new Side chat.

## Proposed change

- Track Permission, Ask, and Plan waits as independent transient Session facts and derive the visible status in one priority order: Permission, Ask, then Plan.
- Preserve durable restored Permission authority when a live snapshot does not contain that request.
- Rebuild simultaneous interaction facts during hydration without persisting the transient index.
- Keep an already-open Side chat above the blocking lane; closing it immediately reveals the highest-priority pending card.
- Prevent starting a new Side chat while Plan approval is waiting.

```mermaid
flowchart TD
  A{Side chat already open?} -->|yes| S[Show Side chat and retain underlying waits]
  A -->|no| P{Permission pending?}
  P -->|yes| PC[Show Permission]
  P -->|no| Q{Ask pending?}
  Q -->|yes| QC[Show Ask]
  Q -->|no| L{Plan waiting?}
  L -->|yes| LC[Show Plan]
  L -->|no| C[Show normal composer]
```

## Scope and non-goals

This changes renderer Session projection, workspace runtime synchronization, and Side chat admission. It does not change ACP wire protocols, framework adapters, persisted Session schemas, database DDL, or platform-specific behavior.

## Acceptance criteria and validation

The checks below ran after the final material edit.

- Restart hydration, cross-Session isolation, same-Session Permission > Ask > Plan fallback, and persistence boundaries -> `npm run test:module -- session_renderer` -> 4 files, 337 tests passed.
- Workspace runtime synchronization and framework-facing renderer consumers -> `npm run test:module -- workspace_runtime` -> 6 files, 275 tests passed.
- Side chat admission, overlay retention, close-to-reveal behavior, and workspace consumers -> `npm run test:module -- workspace_page` -> 23 files, 347 tests passed.
- Node and renderer types -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> 0 errors; 17 pre-existing warnings outside this diff.
- Full portable fallback -> `npm test` -> 916 files passed, 15 skipped; 13,222 tests passed, 192 skipped. One unrelated existing test failed: `src/main/projects/prisma-client.test.ts` reports missing `PermissionGrantSeed.id` and `PermissionGrantSeed.appliedAt` runtime DDL columns. The same isolated failure reproduces on unmodified main.

Included frameworks: claude-code, opencode, codex-response, and codex-bridge through the final full fallback and workspace runtime characterization coverage. Platform lanes are excluded locally because the diff contains no platform-specific code; exact-head CI remains authoritative.

Uncovered risk: a packaged-app manual restart journey was not run. Durable hydration, runtime resynchronization, and card rendering are covered at their project-owned boundaries. Independent PR review is still required before marking the change verified.

## Review focus

- Whether restored Permission authority should remain additive to live runtime requests until Main settles it.
- Whether the transient Plan fact correctly distinguishes an active approval wait from an idle, read-only pending Plan projection.
- Whether the Side chat overlay preserves every underlying blocking interaction without settling it.