### PR TITLE
fix(settings): fail closed on settings read errors

### DIFF
--- a/src/main/settings/document-store.test.ts
+++ b/src/main/settings/document-store.test.ts
@@ -1,14 +1,25 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const faults = vi.hoisted(() => ({ failRenameOnce: false }))
+const faults = vi.hoisted(() => ({
+  failReadOnceWith: undefined as Error | undefined,
+  failRenameOnce: false
+}))
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
   return {
     ...actual,
+    readFile: vi.fn(async (...args: Parameters<typeof actual.readFile>) => {
+      if (faults.failReadOnceWith) {
+        const error = faults.failReadOnceWith
+        faults.failReadOnceWith = undefined
+        throw error
+      }
+      return actual.readFile(...args)
+    }),
     rename: vi.fn(async (source: string, destination: string) => {
       if (faults.failRenameOnce) {
         faults.failRenameOnce = false
@@ -26,6 +37,7 @@ import { SettingsDocumentStore } from './document-store'
 let storageRoot: string | undefined
 
 afterEach(async () => {
+  faults.failReadOnceWith = undefined
   faults.failRenameOnce = false
   if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
   storageRoot = undefined
@@ -34,6 +46,59 @@ afterEach(async () => {
 describe('settings document store', () => {
   it('exposes one atomic document owner', async () => {
     expect(Object.keys(await import('./document-store')).sort()).toEqual(['SettingsDocumentStore'])
+  })
+
+  it('treats a missing settings document as an uninitialized store', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
+    const store = new SettingsDocumentStore(storageRoot)
+
+    await expect(store.read()).resolves.toEqual({ version: 2, providers: [] })
+    await expect(
+      store.mutate((settings) => ({ ...settings, notificationsEnabled: false }))
+    ).resolves.toMatchObject({ providers: [], notificationsEnabled: false })
+  })
+
+  it('rejects corrupt JSON and prevents a mutation from publishing over it', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
+    const settingsPath = join(storageRoot, 'settings.json')
+    const corruptContents = '{"providers":['
+    await writeFile(settingsPath, corruptContents, 'utf8')
+    const store = new SettingsDocumentStore(storageRoot)
+    const update = vi.fn((settings) => ({ ...settings, notificationsEnabled: false }))
+
+    await expect(store.read()).rejects.toBeInstanceOf(SyntaxError)
+    await expect(store.mutate(update)).rejects.toBeInstanceOf(SyntaxError)
+
+    expect(update).not.toHaveBeenCalled()
+    await expect(readFile(settingsPath, 'utf8')).resolves.toBe(corruptContents)
+  })
+
+  it('propagates a read I/O failure without publishing and recovers its mutation queue', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
+    const settingsPath = join(storageRoot, 'settings.json')
+    const originalContents = `${JSON.stringify({
+      version: 2,
+      providers: [],
+      conversationSkillImportEnabled: false
+    })}\n`
+    await writeFile(settingsPath, originalContents, 'utf8')
+    const store = new SettingsDocumentStore(storageRoot)
+    const update = vi.fn((settings) => ({ ...settings, notificationsEnabled: false }))
+    const readFailure = Object.assign(new Error('EACCES: settings file is unreadable'), {
+      code: 'EACCES'
+    })
+    faults.failReadOnceWith = readFailure
+
+    await expect(store.mutate(update)).rejects.toBe(readFailure)
+    expect(update).not.toHaveBeenCalled()
+    await expect(readFile(settingsPath, 'utf8')).resolves.toBe(originalContents)
+
+    await expect(
+      store.mutate((settings) => ({ ...settings, notificationsEnabled: false }))
+    ).resolves.toMatchObject({
+      conversationSkillImportEnabled: false,
+      notificationsEnabled: false
+    })
   })
 
   it('recovers its mutation queue after an atomic rename failure', async () => {

--- a/src/main/settings/document-store.ts
+++ b/src/main/settings/document-store.ts
@@ -19,11 +19,23 @@ class SettingsDocumentStore {
   }
 
   async read(): Promise<StoredSettings> {
+    let contents: string
+
     try {
-      return sanitizeSettings(JSON.parse(await readFile(this.path, 'utf8')) as unknown)
-    } catch {
-      return createEmptySettings()
+      contents = await readFile(this.path, 'utf8')
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        error.code === 'ENOENT'
+      ) {
+        return createEmptySettings()
+      }
+      throw error
     }
+
+    return sanitizeSettings(JSON.parse(contents) as unknown)
   }
 
   mutate(update: (settings: StoredSettings) => StoredSettings): Promise<StoredSettings> {


### PR DESCRIPTION
## Problem

`SettingsDocumentStore.read()` treated every read or parse failure as an uninitialized store. A later mutation could therefore publish an empty settings document over an existing corrupt or temporarily unreadable file, losing unrelated providers, Connectors, runtime selections, and grants.

## Proposed change

Treat only a `readFile` failure with code `ENOENT` as an uninitialized settings store. Propagate malformed JSON and every other filesystem error before the updater or atomic publisher can run.

Add owner-level regression coverage for:

- missing-file initialization;
- malformed JSON preserving the original bytes;
- `EACCES` propagation without publication;
- mutation-queue recovery after read and rename failures.

## Scope and non-goals

- No settings fields, schema version, migration, data model, IPC contract, or renderer interaction changes.
- No corrupt-file backup or automatic recovery in this minimal fix.
- Existing renderer startup and write-error surfaces continue to display propagated failures.

## Acceptance criteria and validation

The checks below ran after the last material edit.

- Missing settings file remains a valid first run; corrupt and unreadable files fail closed; failed reads do not run the updater or publisher; the queue recovers after a transient failure.
  - `npm test -- src/main/settings/document-store.test.ts`
  - **Passed:** 1 file, 5 tests.
- Settings repository owner, contract, and declared consumer coverage.
  - `npm test -- <18 files emitted by npm run test:module -- settings_repository>`
  - **Partial local result:** 17/18 files passed; 501 tests passed. Seven unrelated `SettingsService: importAgentHomeSkills realpath containment` tests could not create symlinks on this Windows host and failed in fixture setup with `EPERM`.
  - The module dispatcher itself could not launch its nested `npm.cmd` on this host (`spawnSync npm.cmd EINVAL`), so its exact emitted file plan was run directly.
- Node and renderer type safety.
  - `npm run typecheck`
  - **Passed.**
- Lint.
  - `npm run lint`
  - **Passed with 0 errors;** 17 pre-existing warnings outside the changed files.

The final diff changes only the `settings_repository` owner implementation and owner test; no Interface path changed, so no additional renderer or E2E consumer lane was selected locally. The module plan's Windows-sensitive coverage was attempted as described above. CI remains authoritative for the seven symlink tests unavailable on this host.

Independent Standards and Spec reviews found no hard or spec findings. Standards noted one low judgement call about repeated two-line test setup; it remains explicit for local readability.

## Review focus

Please focus on the `readFile`-only `ENOENT` classification boundary and the regression assertions that no updater or publish occurs after a failed read.