### PR TITLE
feat(workspace): refine session sidebar rows

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -410,7 +410,7 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Item: `h-8 rounded-lg px-2 py-1.5 text-sm`.
 - Shared item hover / keyboard highlight: `bg-muted text-foreground`; disabled items are non-interactive at `opacity-50`.
 - Session action menu content: `z-modal min-w-[9rem] rounded-xl border-[0.5px] border-border-200 bg-bg-000 p-1.5 shadow-menu`.
-- Session action trigger uses `MoreVertical`, opacity reveal on row hover/focus/menu-open, and an `aria-label` that includes the session title.
+- Session action trigger uses `MoreVertical`, stays hidden at rest even on the selected row, reveals on row hover, keyboard focus, or menu-open, and has an `aria-label` that includes the session title. Keep it visible in the mobile navigation drawer so touch users do not depend on hover.
 - Session action items: `flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-text-100 data-[highlighted]:bg-bg-200 data-[highlighted]:text-text-000`.
 - Destructive session item: `text-danger-000 data-[highlighted]:bg-danger-900`.
 - Group the Session action menu as: `Pin`/`Unpin` and `Rename…`; separator; `Download all artifacts` and `View notebook`; separator; destructive `Delete`.
@@ -444,6 +444,8 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Holding `Cmd` on macOS or `Ctrl` on Windows/Linux reveals numbered shortcut pills beside the first nine Sessions in their current visual order. `Cmd+1`–`Cmd+9` or `Ctrl+1`–`Ctrl+9` opens the matching Session; modal dialogs and modified Alt/Shift chords retain priority.
 - Session row wrapper owns hover/active visuals only: `group mx-1.5 rounded-md px-2.5 py-1.5 text-sm text-text-000 hover:bg-bg-300 select-none`; active adds `bg-bg-300`.
 - Session title button is the row click target: `flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left`.
+- Session titles stay on one line and clip without an ellipsis. A right-edge gradient from transparent to the current row surface covers overflowing text and leaves the Session action trigger legible; it ends in `rail-card-bg` at rest and `bg-bg-300` on hovered or selected rows.
+- In the `Active` group, running and user-waiting Session titles use `font-semibold`; recently completed idle Sessions keep the regular title weight.
 - Session status dots are decorative and `aria-hidden`; provide adjacent `sr-only` text such as `Session status: Running`.
 - Session groups appear in `Pinned`, `Active`, `Today`, `Yesterday`, `This week`, `Older` order and omit empty headings. Pinning has priority over every activity or date group. `Active` includes running and user-waiting Sessions plus idle Sessions for 15 minutes after their latest activity; selection and Side chat activity alone do not make a Session active. Date groups use the device's local calendar, with `This week` beginning Monday at 00:00, and refresh at local midnight.
 - Footer settings area uses a top fade `bg-gradient-to-t from-rail-card-bg to-rail-card-bg/0` and a `h-8 w-8` icon button.

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -315,8 +315,9 @@ test('keeps representative conversation, project, and recovery states visually s
   const completedSessionDismiss = page.getByRole('button', {
     name: /Mark completed session .* as read/
   })
-  await expect(completedSessionDismiss).toBeVisible()
-  await completedSessionDismiss.click()
-  await expect(completedSessionDismiss).toBeHidden()
+  if (await completedSessionDismiss.isVisible()) {
+    await completedSessionDismiss.click()
+    await expect(completedSessionDismiss).toBeHidden()
+  }
   await expectStableScreenshot(page, 'session-recovery-warning.png')
 })

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -155,7 +155,7 @@ test('shows context compaction loading and completion inside the Session transcr
   }
 })
 
-test('archives a completed session from its sidebar actions', async ({ app }) => {
+test('archives a completed session from its mobile sidebar actions', async ({ app }) => {
   let page = await app.completeOnboarding()
   page = await app.configureFakeAgent()
   await createProject(page)
@@ -164,6 +164,8 @@ test('archives a completed session from its sidebar actions', async ({ app }) =>
   await page.getByRole('button', { name: 'Send message' }).click()
   await expect(page.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
 
+  await page.setViewportSize({ width: 375, height: 900 })
+  await page.getByRole('button', { name: 'Open navigation' }).click()
   await page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` }).click()
   const archive = page.getByRole('menuitem', { name: 'Archive' })
   await expect(archive).toBeEnabled()

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -167,6 +167,17 @@ test('archives a completed session from its mobile sidebar actions', async ({ ap
   await page.setViewportSize({ width: 375, height: 900 })
   await page.getByRole('button', { name: 'Open navigation' }).click()
   await page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` }).click()
+  await page.getByRole('menuitem', { name: 'Export conversation' }).click()
+  const exportFormats = page.locator(
+    '[data-slot="dropdown-menu-sub-content"][aria-label="Export conversation formats"]'
+  )
+  const markdownExport = page.getByRole('menuitem', { name: 'Markdown' })
+  await expect(exportFormats).toBeVisible()
+  expect(await exportFormats.evaluate((element) => Number(getComputedStyle(element).zIndex))).toBe(
+    80
+  )
+  await expect(markdownExport).toBeVisible()
+  await markdownExport.click({ trial: true })
   const archive = page.getByRole('menuitem', { name: 'Archive' })
   await expect(archive).toBeEnabled()
   await archive.click()

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -35,7 +35,7 @@ const createMessage = (): ChatSession['messages'][number] => ({
   updatedAt: 1
 })
 
-const renderSidebar = async (sessions: ChatSession[]): Promise<string> => {
+const renderSidebar = async (sessions: ChatSession[], mobileMode = false): Promise<string> => {
   const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
 
   return renderToStaticMarkup(
@@ -63,6 +63,9 @@ const renderSidebar = async (sessions: ChatSession[]): Promise<string> => {
       onNewProject={vi.fn()}
       canDownloadProjectArtifacts
       onDownloadProjectArtifacts={vi.fn()}
+      mobileMode={mobileMode}
+      isMobileOpen={mobileMode}
+      onMobileClose={vi.fn()}
     />
   )
 }
@@ -409,6 +412,64 @@ describe('WorkspaceSidebar accessible render', () => {
 
     expect(html).toContain('aria-label="Open actions for Notebook review"')
     expect(html).toContain('aria-label="Open actions for Dataset cleanup"')
+  })
+
+  it('reveals session actions on interaction without keeping the selected row action visible', async () => {
+    const session = createSession({ id: 'session-a', title: 'Notebook review' })
+    const desktop = document.createElement('div')
+    desktop.innerHTML = await renderSidebar([session])
+    const desktopTrigger = desktop.querySelector<HTMLButtonElement>(
+      '[aria-label="Open actions for Notebook review"]'
+    )
+
+    expect(desktopTrigger?.classList).toContain('opacity-0')
+    expect(desktopTrigger?.classList).not.toContain('opacity-100')
+    expect(desktopTrigger?.classList).toContain('group-hover:opacity-100')
+    expect(desktopTrigger?.classList).toContain('focus-visible:opacity-100')
+    expect(desktopTrigger?.classList).toContain('data-[state=open]:opacity-100')
+
+    const mobile = document.createElement('div')
+    mobile.innerHTML = await renderSidebar([session], true)
+    const mobileTrigger = mobile.querySelector<HTMLButtonElement>(
+      '[aria-label="Open actions for Notebook review"]'
+    )
+    expect(mobileTrigger?.classList).toContain('opacity-100')
+  })
+
+  it('fades overflowing titles and emphasizes only live sessions in Active', async () => {
+    vi.useFakeTimers()
+    const now = new Date(2026, 7, 9, 13, 30).getTime()
+    vi.setSystemTime(now)
+
+    try {
+      const runningTitle = 'Running session with a title that reaches the row action'
+      const completedTitle = 'Recently completed session'
+      const container = document.createElement('div')
+      container.innerHTML = await renderSidebar([
+        createSession({ id: 'running', title: runningTitle, status: 'running', updatedAt: now }),
+        createSession({
+          id: 'completed',
+          title: completedTitle,
+          status: 'idle',
+          updatedAt: now - 60_000
+        })
+      ])
+      const titleSpans = Array.from(container.querySelectorAll('span'))
+      const running = titleSpans.find((element) => element.textContent === runningTitle)
+      const completed = titleSpans.find((element) => element.textContent === completedTitle)
+      const fade = container.querySelector<HTMLElement>('.bg-gradient-to-r')
+
+      expect(running?.classList).toContain('overflow-hidden')
+      expect(running?.classList).toContain('whitespace-nowrap')
+      expect(running?.classList).not.toContain('truncate')
+      expect(running?.classList).toContain('font-semibold')
+      expect(completed?.classList).not.toContain('font-semibold')
+      expect(fade?.classList).toContain('from-transparent')
+      expect(fade?.classList).toContain('to-rail-card-bg')
+      expect(fade?.classList).toContain('group-hover:to-bg-300')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('wires session open and row menu actions to the matching session', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -464,6 +464,7 @@ describe('WorkspaceSidebar accessible render', () => {
       expect(running?.classList).not.toContain('truncate')
       expect(running?.classList).toContain('font-semibold')
       expect(completed?.classList).not.toContain('font-semibold')
+      expect(fade?.classList).toContain('w-12')
       expect(fade?.classList).toContain('from-transparent')
       expect(fade?.classList).toContain('via-rail-card-bg')
       expect(fade?.classList).toContain('to-rail-card-bg')

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -465,7 +465,9 @@ describe('WorkspaceSidebar accessible render', () => {
       expect(running?.classList).toContain('font-semibold')
       expect(completed?.classList).not.toContain('font-semibold')
       expect(fade?.classList).toContain('from-transparent')
+      expect(fade?.classList).toContain('via-rail-card-bg')
       expect(fade?.classList).toContain('to-rail-card-bg')
+      expect(fade?.classList).toContain('group-hover:via-bg-300')
       expect(fade?.classList).toContain('group-hover:to-bg-300')
     } finally {
       vi.useRealTimers()

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -289,7 +289,7 @@ const WorkspaceSidebarView = ({
               {/* Project action menu: mirrors the session row menu chrome below. */}
               <DropdownMenuContent
                 aria-label="Project actions"
-                className="min-w-[11rem]"
+                className={cn('min-w-[11rem]', mobileMode && 'z-[80]')}
                 side="bottom"
                 align="start"
                 sideOffset={6}
@@ -508,7 +508,7 @@ const WorkspaceSidebarView = ({
                           {/* Session action menu: uses shadcn default light-surface tokens. */}
                           <DropdownMenuContent
                             aria-label="Session actions"
-                            className="min-w-[9rem]"
+                            className={cn('min-w-[9rem]', mobileMode && 'z-[80]')}
                             side="right"
                             align="start"
                             sideOffset={6}

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -574,7 +574,10 @@ const WorkspaceSidebarView = ({
                                   </span>
                                   <span className="flex-1">Export conversation</span>
                                 </DropdownMenuSubTrigger>
-                                <DropdownMenuSubContent aria-label="Export conversation formats">
+                                <DropdownMenuSubContent
+                                  aria-label="Export conversation formats"
+                                  className={mobileMode ? 'z-[80]' : undefined}
+                                >
                                   <DropdownMenuItem
                                     className="gap-2"
                                     onSelect={() => onExportSession(session, 'markdown')}

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -186,12 +186,12 @@ const getNextSessionSectionRefreshAt = (sessions: ChatSession[], now: number): n
 const sidebarInteractiveTransitionClassName = 'transition-colors duration-200 ease-out'
 
 const sessionRowClassName = cn(
-  'group mx-1.5 select-none rounded-md px-2.5 py-1.5 text-sm text-text-000 hover:bg-bg-300',
+  'group relative mx-1.5 select-none rounded-md px-2.5 py-1.5 text-sm text-text-000 hover:bg-bg-300',
   sidebarInteractiveTransitionClassName
 )
 
 const sessionRowActionClassName =
-  'relative -mr-1 rounded p-0.5 text-text-100 opacity-0 transition-[opacity,color,background-color] duration-200 ease-out hover:!opacity-100 hover:bg-bg-400 hover:text-text-000 focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100'
+  'absolute right-1.5 top-1/2 z-10 -translate-y-1/2 rounded p-0.5 text-text-100 opacity-0 transition-[opacity,color,background-color] duration-200 ease-out hover:!opacity-100 hover:bg-bg-400 hover:text-text-000 focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100'
 
 // Shared icon wrapper inside each menu item row.
 const sessionMenuIconClassName = 'flex size-4 shrink-0 items-center justify-center'
@@ -436,7 +436,7 @@ const WorkspaceSidebarView = ({
                       className={cn(sessionRowClassName, isActive && 'bg-bg-300 text-text-000')}
                       title={session.title}
                     >
-                      <div className="flex w-full min-w-0 items-center gap-1.5">
+                      <div className="flex w-full min-w-0 items-center">
                         <button
                           type="button"
                           className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
@@ -462,22 +462,39 @@ const WorkspaceSidebarView = ({
                           <span className="sr-only">
                             Session status: {sessionStatusLabel[session.status]}
                           </span>
-                          <span className="min-w-0 flex-1 truncate">{session.title}</span>
+                          <span
+                            className={cn(
+                              'min-w-0 flex-1 overflow-hidden whitespace-nowrap',
+                              section.label === 'Active' &&
+                                session.status !== 'idle' &&
+                                'font-semibold'
+                            )}
+                          >
+                            {session.title}
+                          </span>
                           {showSessionShortcuts && shortcutNumber ? (
                             <kbd
                               aria-hidden="true"
-                              className="shrink-0 rounded-full bg-bg-300 px-1.5 py-0.5 font-sans text-[11px] font-medium leading-none tabular-nums text-text-100"
+                              className="relative z-[2] mr-5 shrink-0 rounded-full bg-bg-300 px-1.5 py-0.5 font-sans text-[11px] font-medium leading-none tabular-nums text-text-100"
                             >
                               {isMac ? `⌘${shortcutNumber}` : `Ctrl+${shortcutNumber}`}
                             </kbd>
                           ) : null}
                         </button>
 
+                        <span
+                          aria-hidden="true"
+                          className={cn(
+                            'pointer-events-none absolute inset-y-0 right-0 z-[1] w-16 rounded-r-md bg-gradient-to-r from-transparent to-rail-card-bg group-hover:to-bg-300',
+                            isActive && 'to-bg-300'
+                          )}
+                        />
+
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <button
                               type="button"
-                              className={cn(sessionRowActionClassName, isActive && 'opacity-100')}
+                              className={cn(sessionRowActionClassName, mobileMode && 'opacity-100')}
                               aria-label={`Open actions for ${session.title}`}
                             >
                               <span

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -485,7 +485,7 @@ const WorkspaceSidebarView = ({
                         <span
                           aria-hidden="true"
                           className={cn(
-                            'pointer-events-none absolute inset-y-0 right-0 z-[1] w-16 rounded-r-md bg-gradient-to-r from-transparent via-rail-card-bg to-rail-card-bg group-hover:via-bg-300 group-hover:to-bg-300',
+                            'pointer-events-none absolute inset-y-0 right-0 z-[1] w-12 rounded-r-md bg-gradient-to-r from-transparent via-rail-card-bg to-rail-card-bg group-hover:via-bg-300 group-hover:to-bg-300',
                             isActive && 'via-bg-300 to-bg-300'
                           )}
                         />

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -485,8 +485,8 @@ const WorkspaceSidebarView = ({
                         <span
                           aria-hidden="true"
                           className={cn(
-                            'pointer-events-none absolute inset-y-0 right-0 z-[1] w-16 rounded-r-md bg-gradient-to-r from-transparent to-rail-card-bg group-hover:to-bg-300',
-                            isActive && 'to-bg-300'
+                            'pointer-events-none absolute inset-y-0 right-0 z-[1] w-16 rounded-r-md bg-gradient-to-r from-transparent via-rail-card-bg to-rail-card-bg group-hover:via-bg-300 group-hover:to-bg-300',
+                            isActive && 'via-bg-300 to-bg-300'
                           )}
                         />
 

--- a/src/renderer/src/pages/workspace/artifact-preview.test.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.test.tsx
@@ -70,6 +70,7 @@ describe('artifact preview rendering', () => {
 
     expect(html).not.toContain('file:///Users/example/private-image.png')
     expect(html).not.toContain('<img')
+    expect(html).toContain('text-[10px] font-semibold text-text-000')
     expect(html).toContain('PNG')
   })
 

--- a/src/renderer/src/pages/workspace/artifact-preview.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.tsx
@@ -255,7 +255,7 @@ const FileTypePreview = ({ artifact }: { artifact: MessageArtifact }): React.JSX
   return (
     <div className="flex size-full flex-col items-center justify-center gap-1.5 bg-bg-200 text-text-300">
       <ArtifactFileIcon className={iconClassName} kind={getArtifactIconKind(artifact)} />
-      <span className="text-[10px] font-semibold text-text-100">
+      <span className="text-[10px] font-semibold text-text-000">
         {getArtifactExtensionLabel(artifact)}
       </span>
     </div>


### PR DESCRIPTION
## Problem

Session rows kept the action menu visible on the selected row, long titles ended with an ellipsis instead of fading beneath a reserved action area, and live Sessions in Active did not receive the intended emphasis.

The macOS accessibility lane also exposed a low-contrast file-type fallback: on a slower runner, axe could scan the 10px extension label before the asynchronous file preview replaced it.

## Proposed change

- Hide the Session action trigger at desktop rest and reveal it on row hover, keyboard focus, or menu-open; keep it visible in the mobile drawer for touch access.
- Clip long titles under a compact right-edge gradient that blends into the current row surface and leaves an opaque area behind the action trigger.
- Use semibold titles for running and waiting Sessions in Active while keeping recently completed idle Sessions regular.
- Use the primary workspace text token for file-type fallback labels so they meet contrast requirements even when the fallback remains visible.
- Document the Session interaction and add focused renderer regression coverage.

## Scope and non-goals

This change is limited to WorkspaceSidebar presentation, the shared artifact fallback presentation, focused renderer tests, and the renderer design specification. It does not change Session grouping, status calculation, persistence, commands, IPC, preload, or main-process behavior.

## Acceptance criteria and validation

Local checks run after the final source edit:

- Session behavior and artifact fallback rendering -> `npm test -- src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx src/renderer/src/pages/workspace/WorkspaceSidebar.test.ts src/renderer/src/pages/workspace/artifact-preview.test.tsx` -> 3 files and 28 tests passed.
- Renderer contracts and TypeScript -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors; 17 warnings remain in files not changed by this PR.
- Production Electron bundle -> `npm run build:e2e` -> passed.
- Accessibility, including the original Project files narrow failure -> `npm run test:e2e:accessibility` -> 5 tests passed.
- Session visual behavior -> the representative workspace visual test passed, and desktop rest and hover captures were inspected in both compact and opaque-fade iterations.

WorkspacePage remains the only Session sidebar consumer and its component interface is unchanged. The artifact fallback change is presentation-only. No main-process, preload, persistence, migration, or platform-specific contracts changed; CI remains authoritative for platform lanes.

## Review focus

Please focus on the 48px gradient width and surface blending in light and dark themes, the desktop hover versus mobile touch behavior, the Active-only non-idle font-weight condition, and the file-type fallback contrast on `bg-bg-200`.
