### PR TITLE
fix(workspace): require next to advance questions

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
@@ -239,6 +239,17 @@ describe('WorkspaceElicitationCard choice question', () => {
     expect(onDraftChange).toHaveBeenLastCalledWith([
       { fieldId: 'question_0', value: 'multi-omics' }
     ])
+    expect(container.querySelector('h3')?.textContent).toBe(
+      'What should this skill primarily cover?'
+    )
+
+    const advance = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Next'
+    )
+    expect(advance?.disabled).toBe(false)
+    expect(advance?.querySelector('svg.lucide-chevron-right')).not.toBeNull()
+    await act(async () => advance?.click())
+
     expect(container.querySelector('h3')?.textContent).toBe('Which language should the skill use?')
     expect(
       container.querySelector('[data-testid="elicitation-question-progress"]')?.textContent

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
@@ -298,7 +298,6 @@ const WorkspaceElicitationCard = ({
     setError(undefined)
 
     onDraftChange?.(nextAnswers)
-    if (!isFinalChoiceQuestion) setActiveChoiceIndex((index) => index + 1)
   }
 
   return (


### PR DESCRIPTION
## Problem

Selecting an answer on a non-final Ask User single-choice question immediately advances to the next question. The selected state disappears too quickly for users to confirm their answer.

## Proposed change

Keep the current question visible after an answer is selected. Reuse the existing Next action as the only way to advance to the next question. The final question continues to use Finish.

## Scope and non-goals

- Changes only WorkspaceElicitationCard choice navigation and its interaction regression test.
- Preserves draft answer updates, Back navigation, multi-select behavior, custom answers, Skip, and final submission.
- Does not change ACP contracts, persisted data, shared types, or visual tokens.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Manual non-final advancement -> npm test -- src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx -> passed, 14 tests.
- Node and Renderer types -> npm run typecheck -> passed.
- Source lint -> npm run lint -> passed with 17 pre-existing warnings outside the changed files.
- Complete portable suite -> npm test -> 13,286 passed and 192 skipped; one unrelated failure remains in src/main/projects/prisma-client.test.ts because PermissionGrantSeed runtime DDL is missing Prisma columns id and appliedAt.

The complete-suite failure is outside this diff: this branch changes only the Ask User Renderer component and its interaction test. CI remains authoritative for the clean environment.

## Review focus

Please confirm that selecting an option keeps the current question visible and that clicking Next advances exactly once without changing Back or Finish behavior.
