### PR TITLE
fix(reviewer): validate persisted review data

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -109,6 +109,7 @@ model NotificationInboxItem {
 // as JSON array of ReviewerLogEntry). submit_findings no longer accepts `reasoning`.
 model Review {
   id            String    @id @default(cuid())
+  codecVersion  Int       @default(0)
   projectId     String
   sessionId     String
   turnMessageId String

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -16,6 +16,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0003_granted_local_roots',
     checksum: '3bc5e32cdf7f793771d22fe3027f082c1ba8e3a5e4decab37bd0c92c7928bfc7'
+  },
+  {
+    id: '0004_review_codec_version',
+    checksum: '55c571e13247a3cfdb5bda7b7469fb688aad787214732271581cad2fa1fd7298'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -497,6 +497,15 @@ describe('Provenance Message snapshots', () => {
       outcome: 'pass',
       scopeSnapshot: []
     })
+    const corrupt = await client.review.create({
+      data: {
+        id: 'corrupt-review',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        turnMessageId: 'corrupt-turn',
+        scope: JSON.stringify({ artifactVersionIds: [version.versionId] })
+      }
+    })
     const unrelatedSnapshot = await client.reviewScopeSnapshot.findUniqueOrThrow({
       where: { reviewId: unrelated.id }
     })
@@ -539,6 +548,7 @@ describe('Provenance Message snapshots', () => {
     expect(new Set(retained.map((review) => review.id))).toEqual(
       new Set([direct.id, correction.id])
     )
+    await expect(client.review.findUnique({ where: { id: corrupt.id } })).resolves.toBeNull()
     await expect(
       client.reviewFindingDisposition.count({
         where: { sourceFindingId: directWithCheck.checks[0]!.id }

--- a/src/main/artifacts/provenance-message-snapshot.ts
+++ b/src/main/artifacts/provenance-message-snapshot.ts
@@ -19,6 +19,7 @@ import type {
   ProvenanceMessage,
   ProvenanceMessagePart
 } from '../../shared/artifact-provenance'
+import { reviewPersistenceCodec } from '../reviewer/persistence-codec'
 
 type ProvenanceMessageSnapshotOptions = {
   storageRoot: string
@@ -267,16 +268,11 @@ class ProvenanceMessageSnapshotRepository {
     )
     const seedTurnIds = new Set(
       sessionReviews.flatMap((review) => {
-        let scopeVersionIds: unknown = []
-        try {
-          scopeVersionIds = (JSON.parse(review.scope) as { artifactVersionIds?: unknown })
-            .artifactVersionIds
-        } catch {
-          // A corrupt scope cannot prove a direct binding; the independently scoped message fallback
-          // below remains available for legacy rows.
-        }
+        const scope = reviewPersistenceCodec.decodeReviewScope(review)
         const directlyBound =
-          Array.isArray(scopeVersionIds) && scopeVersionIds.some((id) => versionIds.has(String(id)))
+          scope?.artifactVersionIds.some((artifactVersionId) =>
+            versionIds.has(artifactVersionId)
+          ) ?? false
         return directlyBound || versionMessageIds.has(review.turnMessageId)
           ? [review.turnMessageId]
           : []

--- a/src/main/artifacts/provenance-read-model.ts
+++ b/src/main/artifacts/provenance-read-model.ts
@@ -21,7 +21,8 @@ import { sanitizeActivityGroup, sanitizeToolActivity } from '../../shared/sessio
 import type { ReviewScopeSnapshotBlock, ReviewWithProvenanceEvidence } from '../../shared/reviewer'
 import { flagStaleReviews } from '../reviewer/stale-reviews'
 import { selectReviewChainForArtifactVersion } from '../reviewer/artifact-version-review'
-import { toCheck, toFindingDisposition, toReview } from '../reviewer/repository'
+import { reviewPersistenceCodec } from '../reviewer/persistence-codec'
+import { toCheck, toReview } from '../reviewer/repository'
 import type { ArtifactDurability } from './durability'
 import {
   parseArtifactExecutionSnapshot,
@@ -467,10 +468,7 @@ class ArtifactProvenanceReadModel {
           selectedVersionId: versionId,
           versionMessageId: version.messageId ?? undefined,
           reviews: resolvedReviews,
-          dispositions: dispositionRows.flatMap((disposition) => {
-            const decoded = toFindingDisposition(disposition)
-            return decoded ? [decoded] : []
-          })
+          dispositions: reviewPersistenceCodec.decodeDispositions(dispositionRows)
         })
         if (projection) review = { state: 'available', value: projection }
       }

--- a/src/main/artifacts/provenance-read-model.ts
+++ b/src/main/artifacts/provenance-read-model.ts
@@ -18,15 +18,10 @@ import type {
 import type { NotebookRunInputFile } from '../../shared/notebook'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { sanitizeActivityGroup, sanitizeToolActivity } from '../../shared/session-persistence'
-import type {
-  ReviewFindingDispositionOutcome,
-  ReviewFindingDispositionTrigger,
-  ReviewScopeSnapshotBlock,
-  ReviewWithProvenanceEvidence
-} from '../../shared/reviewer'
+import type { ReviewScopeSnapshotBlock, ReviewWithProvenanceEvidence } from '../../shared/reviewer'
 import { flagStaleReviews } from '../reviewer/stale-reviews'
 import { selectReviewChainForArtifactVersion } from '../reviewer/artifact-version-review'
-import { toCheck, toReview } from '../reviewer/repository'
+import { toCheck, toFindingDisposition, toReview } from '../reviewer/repository'
 import type { ArtifactDurability } from './durability'
 import {
   parseArtifactExecutionSnapshot,
@@ -421,7 +416,7 @@ class ArtifactProvenanceReadModel {
           }
           return {
             ...toReview(reviewRow),
-            checks: checkRows.map(toCheck),
+            checks: checkRows.map((checkRow) => toCheck(checkRow, reviewRow.codecVersion)),
             scopeSnapshot
           }
         })
@@ -472,17 +467,10 @@ class ArtifactProvenanceReadModel {
           selectedVersionId: versionId,
           versionMessageId: version.messageId ?? undefined,
           reviews: resolvedReviews,
-          dispositions: dispositionRows.map((disposition) => ({
-            id: disposition.id,
-            sourceFindingId: disposition.sourceFindingId,
-            causeReviewId: disposition.causeReviewId ?? undefined,
-            sequence: disposition.sequence,
-            trigger: disposition.trigger as ReviewFindingDispositionTrigger,
-            outcome: disposition.outcome as ReviewFindingDispositionOutcome,
-            note: disposition.note ?? undefined,
-            assessedArtifactVersionId: disposition.assessedArtifactVersionId ?? undefined,
-            createdAt: disposition.createdAt.getTime()
-          }))
+          dispositions: dispositionRows.flatMap((disposition) => {
+            const decoded = toFindingDisposition(disposition)
+            return decoded ? [decoded] : []
+          })
         })
         if (projection) review = { state: 'available', value: projection }
       }

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -1638,6 +1638,18 @@ describe('artifact provenance repository', () => {
           reviewerLog: '[]',
           createdAt: new Date('2026-07-27T10:01:00Z'),
           updatedAt: new Date('2026-07-27T10:01:00Z')
+        },
+        {
+          id: 'review-corrupt-json',
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          turnMessageId: 'prompt-1',
+          scope: 'null',
+          lifecycle: 'complete',
+          outcome: 'pass',
+          reviewerLog: '42',
+          createdAt: new Date('2026-07-27T10:02:00Z'),
+          updatedAt: new Date('2026-07-27T10:02:00Z')
         }
       ]
     })
@@ -1648,6 +1660,18 @@ describe('artifact provenance repository', () => {
         status: 'pass',
         claim: 'Artifact values match the execution output.',
         evidence: 'Recomputed from the immutable Artifact Version.',
+        artifactVersionId: version.versionId,
+        artifactBindingState: 'scope_validated'
+      }
+    })
+    await client.finding.create({
+      data: {
+        id: 'finding-corrupt-locator',
+        reviewId: 'review-corrupt-json',
+        status: 'fail',
+        claim: 'Persisted locator is corrupt.',
+        evidence: 'The containing Review must not break the Provenance read.',
+        locator: 'null',
         artifactVersionId: version.versionId,
         artifactBindingState: 'scope_validated'
       }
@@ -1668,7 +1692,7 @@ describe('artifact provenance repository', () => {
         value: {
           binding: 'version',
           currentDirectAssessment: { id: 'review-direct-pass', outcome: 'pass' },
-          latestChainReview: { id: 'review-direct-pass', outcome: 'pass' },
+          latestChainReview: { id: 'review-corrupt-json', lifecycle: 'error', outcome: null },
           selectedVersionChecks: [{ artifactBindingState: 'scope_validated' }]
         }
       }

--- a/src/main/compute/job-repository.test.ts
+++ b/src/main/compute/job-repository.test.ts
@@ -182,7 +182,8 @@ describe('ComputeJob schema migration (integration)', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
     // Idempotent second run.
@@ -258,7 +259,8 @@ describe('ComputeJob schema migration (integration)', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
     // Idempotent second run.

--- a/src/main/compute/prisma-client.test.ts
+++ b/src/main/compute/prisma-client.test.ts
@@ -121,7 +121,8 @@ describe('compute host prisma client (integration)', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
     // Idempotent second run.

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -100,7 +100,8 @@ describe('database startup logging', () => {
             applied: [
               '0001_runtime_schema_baseline',
               '0002_project_agent_context',
-              '0003_granted_local_roots'
+              '0003_granted_local_roots',
+              '0004_review_codec_version'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -64,6 +64,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
 );`,
   `CREATE TABLE IF NOT EXISTS "Review" (
     "id" TEXT NOT NULL PRIMARY KEY,
+    "codecVersion" INTEGER NOT NULL DEFAULT 0,
     "projectId" TEXT NOT NULL,
     "sessionId" TEXT NOT NULL,
     "turnMessageId" TEXT NOT NULL,

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -11,6 +11,7 @@ import {
   BASELINE_CHECKSUM,
   MIGRATION_MANIFEST,
   PROJECT_AGENT_CONTEXT_CHECKSUM,
+  REVIEW_CODEC_VERSION_CHECKSUM,
   checksumMigrationPayload,
   classifyDatabaseFailure,
   migrateApplicationDatabase,
@@ -19,7 +20,7 @@ import {
 } from './migration-service'
 
 const futureTestMigration = (): MigrationManifestEntry => {
-  const id = '0004_test_suffix'
+  const id = '0005_test_suffix'
   const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
   const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
@@ -140,6 +141,9 @@ describe('application database migrations', () => {
     expect(PROJECT_AGENT_CONTEXT_CHECKSUM).toBe(
       'f3b29cf4543d1739a0cd211ddea172dcfd18aa9d7c8f94d520913ab88cb977c6'
     )
+    expect(REVIEW_CODEC_VERSION_CHECKSUM).toBe(
+      '55c571e13247a3cfdb5bda7b7469fb688aad787214732271581cad2fa1fd7298'
+    )
     const verifier = [{ kind: 'table-exists', version: 1, table: 'probe' }] as const
     expect(checksumMigrationPayload('0001_test', ['one\r\ntwo'], verifier)).toBe(
       checksumMigrationPayload('0001_test', ['one\ntwo'], verifier)
@@ -173,10 +177,11 @@ describe('application database migrations', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ],
       from: null,
-      to: '0003_granted_local_roots'
+      to: '0004_review_codec_version'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -189,8 +194,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0003_granted_local_roots',
-      to: '0003_granted_local_roots'
+      from: '0004_review_codec_version',
+      to: '0004_review_codec_version'
     })
   })
 
@@ -234,7 +239,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0003_granted_local_roots'
+      migrationId: '0004_review_codec_version'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -250,9 +255,9 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0004_test_suffix'],
-      from: '0003_granted_local_roots',
-      to: '0004_test_suffix'
+      applied: ['0005_test_suffix'],
+      from: '0004_review_codec_version',
+      to: '0005_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ id: string }>>`
@@ -262,7 +267,8 @@ describe('application database migrations', () => {
       { id: '0001_runtime_schema_baseline' },
       { id: '0002_project_agent_context' },
       { id: '0003_granted_local_roots' },
-      { id: '0004_test_suffix' }
+      { id: '0004_review_codec_version' },
+      { id: '0005_test_suffix' }
     ])
   })
 
@@ -285,10 +291,11 @@ describe('application database migrations', () => {
     expect(backupEvents).toEqual([])
   })
 
-  it('retains a recovery snapshot before adding Agent Context to a ledger database', async () => {
+  it('backs up each pending schema migration and preserves legacy Review codec semantics', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-agent-context-backup-'))
     const databasePath = join(storageRoot, 'open-science.db')
-    const backupPath = `${databasePath}.before-0002_project_agent_context.backup`
+    const agentContextBackupPath = `${databasePath}.before-0002_project_agent_context.backup`
+    const reviewCodecBackupPath = `${databasePath}.before-0004_review_codec_version.backup`
     const backupEvents: unknown[] = []
     client = createProjectDbClient(storageRoot)
     for (const statement of MIGRATION_MANIFEST[0]!.statements) {
@@ -307,6 +314,10 @@ describe('application database migrations', () => {
       INSERT INTO "Project" ("id", "name", "updatedAt")
       VALUES (${'project-1'}, ${'Preserved'}, ${new Date('2026-01-02T03:04:05Z')})
     `
+    await client.$executeRaw`
+      INSERT INTO "Review" ("id", "projectId", "sessionId", "turnMessageId", "updatedAt")
+      VALUES (${'review-1'}, ${'project-1'}, ${'session-1'}, ${'message-1'}, ${new Date('2026-01-02T03:04:05Z')})
+    `
 
     await expect(
       migrateApplicationDatabase(client, {
@@ -315,28 +326,43 @@ describe('application database migrations', () => {
       })
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0002_project_agent_context', '0003_granted_local_roots'],
+      applied: [
+        '0002_project_agent_context',
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
+      ],
       from: '0001_runtime_schema_baseline',
-      to: '0003_granted_local_roots'
+      to: '0004_review_codec_version'
     })
     expect(backupEvents).toEqual([
       {
         migrationId: '0002_project_agent_context',
-        path: backupPath,
+        path: agentContextBackupPath,
         reused: false
       },
       {
         migrationId: '0003_granted_local_roots',
         path: `${databasePath}.before-0003_granted_local_roots.backup`,
         reused: false
+      },
+      {
+        migrationId: '0004_review_codec_version',
+        path: reviewCodecBackupPath,
+        reused: false
       }
     ])
-    await expect(access(backupPath)).resolves.toBeUndefined()
+    await expect(access(agentContextBackupPath)).resolves.toBeUndefined()
+    await expect(access(reviewCodecBackupPath)).resolves.toBeUndefined()
     await expect(
       client.$queryRaw<Array<{ agentContext: string; name: string }>>`
         SELECT "agentContext", "name" FROM "Project" WHERE "id" = 'project-1'
       `
     ).resolves.toEqual([{ agentContext: '', name: 'Preserved' }])
+    await expect(
+      client.$queryRaw<Array<{ codecVersion: number }>>`
+        SELECT "codecVersion" FROM "Review" WHERE "id" = 'review-1'
+      `
+    ).resolves.toEqual([{ codecVersion: 0 }])
   })
 
   it('rolls back a future migration and its ledger row when verification fails', async () => {
@@ -361,7 +387,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0004_test_suffix'
+      migrationId: '0005_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -376,7 +402,8 @@ describe('application database migrations', () => {
     ).resolves.toEqual([
       { id: '0001_runtime_schema_baseline' },
       { id: '0002_project_agent_context' },
-      { id: '0003_granted_local_roots' }
+      { id: '0003_granted_local_roots' },
+      { id: '0004_review_codec_version' }
     ])
   })
 
@@ -398,7 +425,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0004_test_suffix'
+      migrationId: '0005_test_suffix'
     })
   })
 
@@ -427,9 +454,10 @@ describe('application database migrations', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_test_suffix'
+        '0004_review_codec_version',
+        '0005_test_suffix'
       ],
-      to: '0004_test_suffix'
+      to: '0005_test_suffix'
     })
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
@@ -443,7 +471,7 @@ describe('application database migrations', () => {
     await client.project.create({ data: { id: 'project-1', name: 'Preserved' } })
     await client.$executeRaw`
       INSERT INTO "_open_science_migrations" ("id", "checksum")
-      VALUES (${'0004_future_schema'}, ${'f'.repeat(64)})
+      VALUES (${'0005_future_schema'}, ${'f'.repeat(64)})
     `
 
     await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
@@ -514,7 +542,8 @@ describe('application database migrations', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
     await expect(
@@ -553,7 +582,8 @@ describe('application database migrations', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -605,7 +635,8 @@ describe('application database migrations', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
     await expect(
@@ -660,7 +691,8 @@ describe('application database migrations', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
     await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
@@ -749,7 +781,8 @@ describe('application database migrations', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
     await expect(
@@ -763,6 +796,7 @@ describe('application database migrations', () => {
     const databasePath = join(storageRoot, 'open-science.db')
     const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
     const agentContextBackupPath = `${databasePath}.before-0002_project_agent_context.backup`
+    const reviewCodecBackupPath = `${databasePath}.before-0004_review_codec_version.backup`
     const backupEvents: unknown[] = []
     client = createProjectDbClient(storageRoot)
     await client.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -791,7 +825,8 @@ describe('application database migrations', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
     expect(backupEvents).toEqual([
@@ -809,9 +844,15 @@ describe('application database migrations', () => {
         migrationId: '0003_granted_local_roots',
         path: `${databasePath}.before-0003_granted_local_roots.backup`,
         reused: false
+      },
+      {
+        migrationId: '0004_review_codec_version',
+        path: reviewCodecBackupPath,
+        reused: false
       }
     ])
     await expect(access(agentContextBackupPath)).resolves.toBeUndefined()
+    await expect(access(reviewCodecBackupPath)).resolves.toBeUndefined()
     await expect(client.project.count()).resolves.toBe(1)
 
     const backupClient = new PrismaClient({
@@ -1149,6 +1190,7 @@ describe('application database migrations', () => {
     const databasePath = join(storageRoot, 'open-science.db')
     const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
     const agentContextBackupPath = `${databasePath}.before-0002_project_agent_context.backup`
+    const reviewCodecBackupPath = `${databasePath}.before-0004_review_codec_version.backup`
     client = createProjectDbClient(storageRoot)
     await client.$executeRawUnsafe(`CREATE TABLE "Project" (
       "id" TEXT NOT NULL PRIMARY KEY,
@@ -1191,6 +1233,11 @@ describe('application database migrations', () => {
         migrationId: '0003_granted_local_roots',
         path: `${databasePath}.before-0003_granted_local_roots.backup`,
         reused: false
+      }),
+      expect.objectContaining({
+        migrationId: '0004_review_codec_version',
+        path: reviewCodecBackupPath,
+        reused: false
       })
     ])
     expect(retired).toEqual([
@@ -1199,10 +1246,12 @@ describe('application database migrations', () => {
       {
         migrationId: '0003_granted_local_roots',
         path: `${databasePath}.before-0003_granted_local_roots.backup`
-      }
+      },
+      { migrationId: '0004_review_codec_version', path: reviewCodecBackupPath }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(agentContextBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(access(reviewCodecBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(
       client.$queryRaw<Array<{ id: string; name: string }>>`SELECT "id", "name" FROM "Project"`
     ).resolves.toEqual([{ id: 'legacy-project', name: 'Preserved' }])

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -16,6 +16,7 @@ import { migrationSqlExecutor } from './migration-sql-executor'
 import { runtimeSchemaBaselineMigration } from './migrations/0001-runtime-schema-baseline'
 import { projectAgentContextMigration } from './migrations/0002-project-agent-context'
 import { grantedLocalRootsMigration } from './migrations/0003-granted-local-roots'
+import { reviewCodecVersionMigration } from './migrations/0004-review-codec-version'
 
 type MigrationVerifierDescriptor =
   | {
@@ -95,6 +96,11 @@ const GRANTED_LOCAL_ROOTS_CHECKSUM = checksumMigrationPayload(
   grantedLocalRootsMigration.statements,
   grantedLocalRootsMigration.verifiers
 )
+const REVIEW_CODEC_VERSION_CHECKSUM = checksumMigrationPayload(
+  reviewCodecVersionMigration.id,
+  reviewCodecVersionMigration.statements,
+  reviewCodecVersionMigration.verifiers
+)
 const MIGRATION_MANIFEST = [
   {
     ...runtimeSchemaBaselineMigration,
@@ -113,6 +119,13 @@ const MIGRATION_MANIFEST = [
     checksum: GRANTED_LOCAL_ROOTS_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
+  },
+  {
+    ...reviewCodecVersionMigration,
+    checksum: REVIEW_CODEC_VERSION_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain',
+    legacyAdoption: 'accept-current-schema'
   }
 ] as const satisfies readonly MigrationManifestEntry[]
 // schema-locality: begin frozen-0001-repairs
@@ -187,6 +200,7 @@ type MigrationManifestEntry = {
   verifiers: MigrationVerifiers
   backupOnApply: 'required' | 'none'
   backupRetention: 'retain' | 'delete-after-success'
+  legacyAdoption?: 'accept-current-schema'
 }
 
 const runMigrationVerifiers = async (
@@ -646,11 +660,21 @@ const applyBaselineMigration = async (
 
 const applyManifestMigration = async (
   client: PrismaClient,
-  migration: MigrationManifestEntry
+  migration: MigrationManifestEntry,
+  adoptedLegacy: boolean
 ): Promise<void> => {
   try {
     await client.$transaction(async (transaction) => {
       const transactionClient = transaction as unknown as PrismaClient
+      if (adoptedLegacy && migration.legacyAdoption === 'accept-current-schema') {
+        try {
+          await verifyCurrentRuntimeSchema(transactionClient)
+          await insertLedgerRow(transactionClient, migration)
+          return
+        } catch (error) {
+          if (!(error instanceof DatabaseValidationError)) throw error
+        }
+      }
       for (const statement of migration.statements) {
         await migrationSqlExecutor.execute(transaction, statement)
       }
@@ -776,7 +800,7 @@ const migrateApplicationDatabaseWithManifest = async (
   for (const migration of manifest.slice(nextIndex)) {
     options.onProgress?.({ phase: 'migrating', migrationId: migration.id })
     await backupBeforeMigration(migration)
-    await applyManifestMigration(client, migration)
+    await applyManifestMigration(client, migration, adoptedLegacy)
     applied.push(migration.id)
   }
 
@@ -792,6 +816,7 @@ const migrateApplicationDatabase = (
 export {
   BASELINE_CHECKSUM,
   PROJECT_AGENT_CONTEXT_CHECKSUM,
+  REVIEW_CODEC_VERSION_CHECKSUM,
   DatabaseMigrationError,
   checksumMigrationPayload,
   classifyDatabaseFailure,

--- a/src/main/database/migrations/0004-review-codec-version.ts
+++ b/src/main/database/migrations/0004-review-codec-version.ts
@@ -1,0 +1,20 @@
+/* Immutable 0004 migration snapshot. Do not regenerate after release. */
+
+// Existing Review rows predate the persistence codec. Version 0 selects the legacy decoder while
+// new and rewritten rows are stamped with the current codec version by ReviewRepository.
+const reviewCodecVersionMigration = {
+  id: '0004_review_codec_version',
+  statements: [
+    `ALTER TABLE "Review" ADD COLUMN "codecVersion" INTEGER NOT NULL DEFAULT 0`
+  ] as const,
+  verifiers: [
+    {
+      kind: 'column-exists',
+      version: 1,
+      table: 'Review',
+      column: 'codecVersion'
+    }
+  ] as const
+}
+
+export { reviewCodecVersionMigration }

--- a/src/main/projects/prisma-client.test.ts
+++ b/src/main/projects/prisma-client.test.ts
@@ -104,7 +104,8 @@ describe('project prisma client (integration)', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
 
@@ -935,6 +936,9 @@ describe('project prisma client (integration)', () => {
       turnMessageId: 'm1',
       scope: { turnMessageId: 'm1', blocks: [], artifactVersionIds: [] }
     })
+    await expect(
+      client.review.findUniqueOrThrow({ where: { id: review.id } })
+    ).resolves.toMatchObject({ codecVersion: 1 })
 
     await reviewRepo.addChecks(review.id, [
       { status: 'fail', claim: 'test claim', evidence: 'test evidence', sortIndex: 0 }
@@ -1002,16 +1006,20 @@ describe('project prisma client (integration)', () => {
       applied: [
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
-        '0003_granted_local_roots'
+        '0003_granted_local_roots',
+        '0004_review_codec_version'
       ]
     })
 
-    // Running it again is idempotent (guard catches duplicate-column error).
+    // Running the versioned migration chain again is idempotent.
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
 
     // The old row reads back with reflagCount = 0 (the column default).
     const reviewRepo = new ReviewRepository(() => Promise.resolve(client))
     const [stored] = await reviewRepo.getReviewsForSession('s1')
     expect(stored.checks[0]!.reflagCount).toBe(0)
+    await expect(client.review.findUniqueOrThrow({ where: { id: 'r1' } })).resolves.toMatchObject({
+      codecVersion: 0
+    })
   })
 })

--- a/src/main/reviewer/log-capture.test.ts
+++ b/src/main/reviewer/log-capture.test.ts
@@ -523,13 +523,12 @@ describe('ReviewRepository — reviewerLog round-trip', () => {
     await client.$disconnect()
   })
 
-  it('tolerates legacy/unknown entry kinds in the persisted JSON without throwing', async () => {
+  it('migrates legacy tool entries and isolates unknown persisted log kinds', async () => {
     const client = createProjectDbClient(temporaryRoot!)
     await migrateApplicationDatabase(client)
     const repository = new ReviewRepository(() => Promise.resolve(client))
 
     // Simulate a legacy log that still uses the old tool_call/tool_result split (or unknown kind).
-    // The repository parses defensively; unknown kinds should be returned as-is (no crash).
     const legacyLog = [
       { kind: 'thought', text: 'old thought' },
       { kind: 'tool_call', toolName: 'read_turn', title: 'read_turn()' }, // legacy
@@ -551,11 +550,18 @@ describe('ReviewRepository — reviewerLog round-trip', () => {
       }
     })
 
-    // Must not throw on reload.
     const reviews = await repository.getReviewsForSession('session-legacy')
     expect(reviews).toHaveLength(1)
-    // The legacy entries are returned as-is (parseJson just returns the raw array).
-    expect(reviews[0]?.reviewerLog).toHaveLength(4)
+    expect(reviews[0]?.reviewerLog).toEqual([
+      { kind: 'thought', text: 'old thought' },
+      {
+        kind: 'tool',
+        toolName: 'read_turn',
+        title: 'read_turn()',
+        rawOutput: '[...]',
+        status: 'ok'
+      }
+    ])
 
     await client.$disconnect()
   })

--- a/src/main/reviewer/persistence-codec.test.ts
+++ b/src/main/reviewer/persistence-codec.test.ts
@@ -88,6 +88,10 @@ describe('review persistence codec', () => {
       lifecycle: 'running',
       outcome: null
     })
+    expect(reviewPersistenceCodec.encodeReviewPatch({ lifecycle: 'complete' })).toMatchObject({
+      codecVersion: 1,
+      lifecycle: 'complete'
+    })
     expect(() =>
       reviewPersistenceCodec.encodeReview({
         ...createInput(),
@@ -150,6 +154,9 @@ describe('review persistence codec', () => {
           { kind: 'thought', text: 'old thought' },
           { kind: 'tool_call', toolName: 'read_turn', title: 'read_turn()' },
           { kind: 'tool_result', status: 'ok', rawOutput: '[block-0]' },
+          { kind: 'tool_call', toolName: 42 },
+          { kind: 'tool_result', rawOutput: 'must be discarded with the invalid call' },
+          { kind: 'tool_result', rawOutput: 'orphan result without a tool identity' },
           { kind: 'unknown_future_kind', data: 'discard me' },
           { kind: 'message', text: 'done' }
         ])
@@ -226,5 +233,11 @@ describe('review persistence codec', () => {
     expect(
       reviewPersistenceCodec.decodeDisposition(dispositionRow({ outcome: 'future-outcome' }))
     ).toBeUndefined()
+    expect(
+      reviewPersistenceCodec.decodeDispositions([
+        dispositionRow(),
+        dispositionRow({ id: 'invalid-disposition', trigger: 'future-trigger' })
+      ])
+    ).toHaveLength(1)
   })
 })

--- a/src/main/reviewer/persistence-codec.test.ts
+++ b/src/main/reviewer/persistence-codec.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  Finding as PrismaFinding,
+  Review as PrismaReview,
+  ReviewFindingDisposition as PrismaReviewFindingDisposition
+} from '@prisma/client'
+
+import type { CreateReviewInput, ReviewerLogEntry, TurnScope } from '../../shared/reviewer'
+import { reviewPersistenceCodec } from './persistence-codec'
+
+const scope = (turnMessageId = 'turn-1'): TurnScope => ({
+  turnMessageId,
+  blocks: [
+    {
+      id: `message:${turnMessageId}`,
+      kind: 'message' as const,
+      sourceId: turnMessageId,
+      blockIndex: 0,
+      contentHash: 'hash-1'
+    }
+  ],
+  artifactVersionIds: ['artifact-1']
+})
+
+const reviewRow = (patch: Partial<PrismaReview> = {}): PrismaReview => ({
+  id: 'review-1',
+  codecVersion: 1,
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  turnMessageId: 'turn-1',
+  scope: JSON.stringify(scope()),
+  lifecycle: 'complete',
+  outcome: 'pass',
+  errorMessage: null,
+  model: 'model-1',
+  reviewerLog: '[]',
+  createdAt: new Date('2026-08-10T00:00:00.000Z'),
+  updatedAt: new Date('2026-08-10T00:00:01.000Z'),
+  ...patch
+})
+
+const findingRow = (patch: Partial<PrismaFinding> = {}): PrismaFinding => ({
+  id: 'finding-1',
+  reviewId: 'review-1',
+  status: 'fail',
+  resolution: 'open',
+  claim: 'claim',
+  evidence: 'evidence',
+  locator: JSON.stringify({
+    blockRef: { messageId: 'turn-1', blockIndex: 0 },
+    contentHash: 'hash-1'
+  }),
+  artifactVersionId: null,
+  artifactBindingState: 'legacy_unverified',
+  sortIndex: 0,
+  reflagCount: 0,
+  ...patch
+})
+
+const dispositionRow = (
+  patch: Partial<PrismaReviewFindingDisposition> = {}
+): PrismaReviewFindingDisposition => ({
+  id: 'disposition-1',
+  sourceFindingId: 'finding-1',
+  causeReviewId: null,
+  sequence: 1,
+  trigger: 'review_submission',
+  outcome: 'resolved',
+  note: null,
+  assessedArtifactVersionId: null,
+  createdAt: new Date('2026-08-10T00:00:02.000Z'),
+  ...patch
+})
+
+const createInput = (reviewerLog: ReviewerLogEntry[] = []): CreateReviewInput => ({
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  turnMessageId: 'turn-1',
+  scope: scope(),
+  reviewerLog
+})
+
+describe('review persistence codec', () => {
+  it('writes the current version and rejects invalid in-memory JSON shapes', () => {
+    expect(reviewPersistenceCodec.encodeReview(createInput())).toMatchObject({
+      codecVersion: 1,
+      lifecycle: 'running',
+      outcome: null
+    })
+    expect(() =>
+      reviewPersistenceCodec.encodeReview({
+        ...createInput(),
+        scope: null as never
+      })
+    ).toThrow('Review scope is invalid')
+    expect(() =>
+      reviewPersistenceCodec.encodeReview(
+        createInput([{ kind: 'message', text: 42 } as unknown as ReviewerLogEntry])
+      )
+    ).toThrow('Reviewer log is invalid')
+    expect(() =>
+      reviewPersistenceCodec.encodeReview({
+        ...createInput(),
+        lifecycle: 'future-lifecycle' as never
+      })
+    ).toThrow('Review lifecycle is invalid')
+    expect(() =>
+      reviewPersistenceCodec.encodeFinding(
+        {
+          status: 'fail',
+          claim: 'claim',
+          evidence: 'evidence',
+          locator: null as never
+        },
+        0
+      )
+    ).toThrow('Finding locator is invalid')
+    expect(() =>
+      reviewPersistenceCodec.encodeFinding(
+        { status: 'future-status' as never, claim: 'claim', evidence: 'evidence' },
+        0
+      )
+    ).toThrow('Finding status is invalid')
+  })
+
+  it('fails closed when critical Review fields have valid JSON with invalid shapes', () => {
+    const row = reviewRow({
+      scope: 'null',
+      reviewerLog: '42',
+      lifecycle: 'complete',
+      outcome: 'pass'
+    })
+    const decoded = reviewPersistenceCodec.decodeReview(row)
+
+    expect(decoded).toMatchObject({
+      scope: { turnMessageId: 'turn-1', blocks: [], artifactVersionIds: [] },
+      lifecycle: 'error',
+      outcome: null,
+      reviewerLog: [],
+      errorMessage: 'Stored Review scope is invalid.'
+    })
+    expect(reviewPersistenceCodec.decodeReviewScope(row)).toBeUndefined()
+  })
+
+  it('migrates legacy split tool entries and isolates unknown log entries', () => {
+    const decoded = reviewPersistenceCodec.decodeReview(
+      reviewRow({
+        reviewerLog: JSON.stringify([
+          { kind: 'thought', text: 'old thought' },
+          { kind: 'tool_call', toolName: 'read_turn', title: 'read_turn()' },
+          { kind: 'tool_result', status: 'ok', rawOutput: '[block-0]' },
+          { kind: 'unknown_future_kind', data: 'discard me' },
+          { kind: 'message', text: 'done' }
+        ])
+      })
+    )
+
+    expect(decoded.reviewerLog).toEqual([
+      { kind: 'thought', text: 'old thought' },
+      {
+        kind: 'tool',
+        toolName: 'read_turn',
+        title: 'read_turn()',
+        rawOutput: '[block-0]',
+        status: 'ok'
+      },
+      { kind: 'message', text: 'done' }
+    ])
+  })
+
+  it.each([
+    ['claude-code', { kind: 'tool', toolName: 'Bash', rawInput: 'python -V' }],
+    ['opencode', { kind: 'tool', toolName: 'read_turn', title: 'Read turn' }],
+    ['codex-response', { kind: 'thought', text: 'Inspect the evidence.' }],
+    [
+      'codex-bridge',
+      {
+        kind: 'tool',
+        toolName: 'mcp__open-science-reviewer__submit_findings',
+        status: 'ok'
+      }
+    ]
+  ] as const)('round-trips normalized %s reviewer log entries', (_route, entry) => {
+    const encoded = reviewPersistenceCodec.encodeReview(createInput([entry as ReviewerLogEntry]))
+    const decoded = reviewPersistenceCodec.decodeReview(
+      reviewRow({ codecVersion: encoded.codecVersion, reviewerLog: encoded.reviewerLog })
+    )
+    expect(decoded.reviewerLog).toEqual([entry])
+  })
+
+  it('preserves a finding while degrading its malformed locator and unknown enums', () => {
+    const decoded = reviewPersistenceCodec.decodeFinding(
+      findingRow({
+        locator: 'null',
+        status: 'future-status',
+        resolution: 'future-resolution',
+        artifactBindingState: 'future-binding'
+      }),
+      1
+    )
+
+    expect(decoded).toMatchObject({
+      id: 'finding-1',
+      status: 'warn',
+      resolution: 'open',
+      artifactBindingState: 'legacy_unverified'
+    })
+    expect(decoded.locator).toBeUndefined()
+  })
+
+  it('isolates dispositions with unknown audit enums', () => {
+    expect(() =>
+      reviewPersistenceCodec.encodeDisposition('future-trigger' as never, 'resolved')
+    ).toThrow('Finding disposition trigger is invalid')
+    expect(() =>
+      reviewPersistenceCodec.encodeDisposition('review_submission', 'future-outcome' as never)
+    ).toThrow('Finding disposition outcome is invalid')
+    expect(reviewPersistenceCodec.decodeDisposition(dispositionRow())).toMatchObject({
+      trigger: 'review_submission',
+      outcome: 'resolved'
+    })
+    expect(
+      reviewPersistenceCodec.decodeDisposition(dispositionRow({ trigger: 'future-trigger' }))
+    ).toBeUndefined()
+    expect(
+      reviewPersistenceCodec.decodeDisposition(dispositionRow({ outcome: 'future-outcome' }))
+    ).toBeUndefined()
+  })
+})

--- a/src/main/reviewer/persistence-codec.ts
+++ b/src/main/reviewer/persistence-codec.ts
@@ -69,6 +69,7 @@ type ReviewPersistenceCodec = {
   decodeReview(row: VersionedPrismaReview): Review
   decodeFinding(row: PrismaFinding, codecVersion?: number): ReviewCheck
   decodeDisposition(row: PrismaReviewFindingDisposition): ReviewFindingDisposition | undefined
+  decodeDispositions(rows: readonly PrismaReviewFindingDisposition[]): ReviewFindingDisposition[]
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -172,21 +173,34 @@ const decodeLocatorValue = (value: unknown): FindingLocator | undefined => {
 }
 
 const decodeToolFields = (
-  value: Record<string, unknown>,
-  fallbackToolName?: string
-): ReviewerLogEntry & { kind: 'tool' } => {
+  value: Record<string, unknown>
+): (ReviewerLogEntry & { kind: 'tool' }) | undefined => {
+  const toolName = asString(value.toolName)
+  const title = asOptionalString(value.title)
+  const rawInput = asOptionalString(value.rawInput)
+  const rawOutput = asOptionalString(value.rawOutput)
   const exitCode =
     value.exitCode === null
       ? null
       : asFiniteNumber(value.exitCode) !== undefined && Number.isSafeInteger(value.exitCode)
         ? (value.exitCode as number)
         : undefined
+  if (
+    toolName === undefined ||
+    (value.title !== undefined && title === undefined) ||
+    (value.rawInput !== undefined && rawInput === undefined) ||
+    (value.rawOutput !== undefined && rawOutput === undefined) ||
+    (value.status !== undefined && value.status !== 'ok' && value.status !== 'error') ||
+    (value.exitCode !== undefined && exitCode === undefined)
+  ) {
+    return undefined
+  }
   return {
     kind: 'tool',
-    toolName: asString(value.toolName) ?? fallbackToolName ?? 'tool',
-    ...(asString(value.title) !== undefined ? { title: value.title as string } : {}),
-    ...(asString(value.rawInput) !== undefined ? { rawInput: value.rawInput as string } : {}),
-    ...(asString(value.rawOutput) !== undefined ? { rawOutput: value.rawOutput as string } : {}),
+    toolName,
+    ...(title !== undefined ? { title } : {}),
+    ...(rawInput !== undefined ? { rawInput } : {}),
+    ...(rawOutput !== undefined ? { rawOutput } : {}),
     ...(value.status === 'ok' || value.status === 'error' ? { status: value.status } : {}),
     ...(exitCode !== undefined ? { exitCode } : {})
   }
@@ -198,21 +212,7 @@ const decodeCurrentLogEntry = (value: unknown): ReviewerLogEntry | undefined => 
     const text = asString(value.text)
     return text === undefined ? undefined : { kind: value.kind, text }
   }
-  if (
-    value.kind === 'tool' &&
-    typeof value.toolName === 'string' &&
-    (value.title === undefined || typeof value.title === 'string') &&
-    (value.rawInput === undefined || typeof value.rawInput === 'string') &&
-    (value.rawOutput === undefined || typeof value.rawOutput === 'string') &&
-    (value.status === undefined || value.status === 'ok' || value.status === 'error') &&
-    (value.exitCode === undefined ||
-      value.exitCode === null ||
-      (typeof value.exitCode === 'number' &&
-        Number.isFinite(value.exitCode) &&
-        Number.isSafeInteger(value.exitCode)))
-  ) {
-    return decodeToolFields(value)
-  }
+  if (value.kind === 'tool') return decodeToolFields(value)
   return undefined
 }
 
@@ -231,14 +231,24 @@ const decodeReviewerLogValue = (
     }
     if (isRecord(current) && current.kind === 'tool_call') {
       const next = value[index + 1]
-      const merged =
-        isRecord(next) && next.kind === 'tool_result' ? { ...current, ...next } : current
-      entries.push(decodeToolFields(merged))
-      if (merged !== current) index++
+      const decodedCall = decodeToolFields(current)
+      if (isRecord(next) && next.kind === 'tool_result') {
+        const merged = decodeToolFields({ ...current, ...next, toolName: current.toolName })
+        if (merged) entries.push(merged)
+        else if (decodedCall) entries.push(decodedCall)
+        if (!merged) discarded = true
+        index++
+      } else if (decodedCall) {
+        entries.push(decodedCall)
+      } else {
+        discarded = true
+      }
       continue
     }
     if (isRecord(current) && current.kind === 'tool_result') {
-      entries.push(decodeToolFields(current))
+      const decodedResult = decodeToolFields(current)
+      if (decodedResult) entries.push(decodedResult)
+      else discarded = true
       continue
     }
     discarded = true
@@ -334,6 +344,7 @@ const encodeReviewPatch = (patch: UpdateReviewPatch): Record<string, unknown> =>
     throw new Error('Review outcome is invalid.')
   }
   return {
+    codecVersion: CURRENT_REVIEW_CODEC_VERSION,
     ...(patch.scope !== undefined ? { scope: encodeScope(patch.scope) } : {}),
     ...(patch.lifecycle !== undefined ? { lifecycle: patch.lifecycle } : {}),
     ...(patch.outcome !== undefined ? { outcome: patch.outcome } : {}),
@@ -499,6 +510,14 @@ const decodeDisposition = (
   }
 }
 
+const decodeDispositions = (
+  rows: readonly PrismaReviewFindingDisposition[]
+): ReviewFindingDisposition[] =>
+  rows.flatMap((row) => {
+    const decoded = decodeDisposition(row)
+    return decoded ? [decoded] : []
+  })
+
 const reviewPersistenceCodec: ReviewPersistenceCodec = {
   currentVersion: CURRENT_REVIEW_CODEC_VERSION,
   encodeReview,
@@ -508,7 +527,8 @@ const reviewPersistenceCodec: ReviewPersistenceCodec = {
   decodeReviewScope,
   decodeReview,
   decodeFinding,
-  decodeDisposition
+  decodeDisposition,
+  decodeDispositions
 }
 
 export { reviewPersistenceCodec }

--- a/src/main/reviewer/persistence-codec.ts
+++ b/src/main/reviewer/persistence-codec.ts
@@ -1,0 +1,515 @@
+import type {
+  Finding as PrismaFinding,
+  Review as PrismaReview,
+  ReviewFindingDisposition as PrismaReviewFindingDisposition
+} from '@prisma/client'
+
+import type {
+  CheckStatus,
+  CreateReviewInput,
+  FindingLocator,
+  FindingResolution,
+  NewCheck,
+  Review,
+  ReviewCheck,
+  ReviewFindingDisposition,
+  ReviewFindingDispositionOutcome,
+  ReviewFindingDispositionTrigger,
+  ReviewerLogEntry,
+  ReviewLifecycle,
+  ReviewOutcome,
+  ScopeBlock,
+  TurnScope,
+  UpdateReviewPatch
+} from '../../shared/reviewer'
+import { createLogger } from '../logger'
+
+const CURRENT_REVIEW_CODEC_VERSION = 1
+const LEGACY_REVIEW_CODEC_VERSION = 0
+const INVALID_SCOPE_MESSAGE = 'Stored Review scope is invalid.'
+
+const log = createLogger('reviewer:persistence-codec')
+
+type VersionedPrismaReview = PrismaReview & { codecVersion?: number }
+type ReviewScopeRow = Pick<PrismaReview, 'id' | 'scope' | 'turnMessageId'> & {
+  codecVersion?: number
+}
+
+type EncodedReview = {
+  codecVersion: number
+  scope: string
+  lifecycle: ReviewLifecycle
+  outcome: ReviewOutcome | null
+  errorMessage: string | null
+  model: string
+  reviewerLog: string
+}
+
+type EncodedFinding = {
+  status: CheckStatus
+  resolution: FindingResolution
+  claim: string
+  evidence: string
+  locator: string
+  artifactVersionId: string | null
+  artifactBindingState: 'scope_validated' | 'legacy_unverified'
+  sortIndex: number
+}
+
+type ReviewPersistenceCodec = {
+  readonly currentVersion: number
+  encodeReview(input: CreateReviewInput): EncodedReview
+  encodeReviewPatch(patch: UpdateReviewPatch): Record<string, unknown>
+  encodeFinding(check: NewCheck, sortIndex: number): EncodedFinding
+  encodeDisposition(
+    trigger: ReviewFindingDispositionTrigger,
+    outcome: ReviewFindingDispositionOutcome
+  ): { trigger: ReviewFindingDispositionTrigger; outcome: ReviewFindingDispositionOutcome }
+  decodeReviewScope(row: ReviewScopeRow): TurnScope | undefined
+  decodeReview(row: VersionedPrismaReview): Review
+  decodeFinding(row: PrismaFinding, codecVersion?: number): ReviewCheck
+  decodeDisposition(row: PrismaReviewFindingDisposition): ReviewFindingDisposition | undefined
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined
+
+const asOptionalString = (value: unknown): string | undefined =>
+  value === undefined ? undefined : asString(value)
+
+const asFiniteNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined
+
+const parseJson = (value: string): { valid: true; value: unknown } | { valid: false } => {
+  try {
+    return { valid: true, value: JSON.parse(value) as unknown }
+  } catch {
+    return { valid: false }
+  }
+}
+
+const emptyScope = (turnMessageId: string): TurnScope => ({
+  turnMessageId,
+  blocks: [],
+  artifactVersionIds: []
+})
+
+const decodeScopeBlock = (value: unknown): ScopeBlock | undefined => {
+  if (!isRecord(value)) return undefined
+  const id = asString(value.id)
+  const sourceId = asString(value.sourceId)
+  const contentHash = asString(value.contentHash)
+  const blockIndex = asFiniteNumber(value.blockIndex)
+  if (
+    id === undefined ||
+    (value.kind !== 'message' && value.kind !== 'activity') ||
+    sourceId === undefined ||
+    blockIndex === undefined ||
+    !Number.isSafeInteger(blockIndex) ||
+    blockIndex < 0 ||
+    contentHash === undefined
+  ) {
+    return undefined
+  }
+  return { id, kind: value.kind, sourceId, blockIndex, contentHash }
+}
+
+const decodeScopeValue = (value: unknown): TurnScope | undefined => {
+  if (!isRecord(value)) return undefined
+  const turnMessageId = asString(value.turnMessageId)
+  if (!turnMessageId || !Array.isArray(value.blocks) || !Array.isArray(value.artifactVersionIds)) {
+    return undefined
+  }
+  const blocks = value.blocks.map(decodeScopeBlock)
+  if (blocks.some((block) => block === undefined)) return undefined
+  if (!value.artifactVersionIds.every((id): id is string => typeof id === 'string')) {
+    return undefined
+  }
+  const agentFrameId = asOptionalString(value.agentFrameId)
+  const messageBranchId = asOptionalString(value.messageBranchId)
+  if (
+    (value.agentFrameId !== undefined && agentFrameId === undefined) ||
+    (value.messageBranchId !== undefined && messageBranchId === undefined)
+  ) {
+    return undefined
+  }
+  return {
+    turnMessageId,
+    ...(agentFrameId ? { agentFrameId } : {}),
+    ...(messageBranchId ? { messageBranchId } : {}),
+    blocks: blocks as ScopeBlock[],
+    artifactVersionIds: value.artifactVersionIds
+  }
+}
+
+const decodeLocatorValue = (value: unknown): FindingLocator | undefined => {
+  if (!isRecord(value) || !isRecord(value.blockRef)) return undefined
+  const blockIndex = asFiniteNumber(value.blockRef.blockIndex)
+  const messageId = asOptionalString(value.blockRef.messageId)
+  const activityId = asOptionalString(value.blockRef.activityId)
+  const contentHash = asString(value.contentHash)
+  if (
+    blockIndex === undefined ||
+    !Number.isSafeInteger(blockIndex) ||
+    blockIndex < 0 ||
+    contentHash === undefined ||
+    (value.blockRef.messageId !== undefined && messageId === undefined) ||
+    (value.blockRef.activityId !== undefined && activityId === undefined)
+  ) {
+    return undefined
+  }
+  return {
+    blockRef: {
+      ...(messageId ? { messageId } : {}),
+      ...(activityId ? { activityId } : {}),
+      blockIndex
+    },
+    contentHash
+  }
+}
+
+const decodeToolFields = (
+  value: Record<string, unknown>,
+  fallbackToolName?: string
+): ReviewerLogEntry & { kind: 'tool' } => {
+  const exitCode =
+    value.exitCode === null
+      ? null
+      : asFiniteNumber(value.exitCode) !== undefined && Number.isSafeInteger(value.exitCode)
+        ? (value.exitCode as number)
+        : undefined
+  return {
+    kind: 'tool',
+    toolName: asString(value.toolName) ?? fallbackToolName ?? 'tool',
+    ...(asString(value.title) !== undefined ? { title: value.title as string } : {}),
+    ...(asString(value.rawInput) !== undefined ? { rawInput: value.rawInput as string } : {}),
+    ...(asString(value.rawOutput) !== undefined ? { rawOutput: value.rawOutput as string } : {}),
+    ...(value.status === 'ok' || value.status === 'error' ? { status: value.status } : {}),
+    ...(exitCode !== undefined ? { exitCode } : {})
+  }
+}
+
+const decodeCurrentLogEntry = (value: unknown): ReviewerLogEntry | undefined => {
+  if (!isRecord(value)) return undefined
+  if (value.kind === 'thought' || value.kind === 'message') {
+    const text = asString(value.text)
+    return text === undefined ? undefined : { kind: value.kind, text }
+  }
+  if (
+    value.kind === 'tool' &&
+    typeof value.toolName === 'string' &&
+    (value.title === undefined || typeof value.title === 'string') &&
+    (value.rawInput === undefined || typeof value.rawInput === 'string') &&
+    (value.rawOutput === undefined || typeof value.rawOutput === 'string') &&
+    (value.status === undefined || value.status === 'ok' || value.status === 'error') &&
+    (value.exitCode === undefined ||
+      value.exitCode === null ||
+      (typeof value.exitCode === 'number' &&
+        Number.isFinite(value.exitCode) &&
+        Number.isSafeInteger(value.exitCode)))
+  ) {
+    return decodeToolFields(value)
+  }
+  return undefined
+}
+
+const decodeReviewerLogValue = (
+  value: unknown
+): { entries: ReviewerLogEntry[]; discarded: boolean } => {
+  if (!Array.isArray(value)) return { entries: [], discarded: true }
+  const entries: ReviewerLogEntry[] = []
+  let discarded = false
+  for (let index = 0; index < value.length; index++) {
+    const current = value[index]
+    const decoded = decodeCurrentLogEntry(current)
+    if (decoded) {
+      entries.push(decoded)
+      continue
+    }
+    if (isRecord(current) && current.kind === 'tool_call') {
+      const next = value[index + 1]
+      const merged =
+        isRecord(next) && next.kind === 'tool_result' ? { ...current, ...next } : current
+      entries.push(decodeToolFields(merged))
+      if (merged !== current) index++
+      continue
+    }
+    if (isRecord(current) && current.kind === 'tool_result') {
+      entries.push(decodeToolFields(current))
+      continue
+    }
+    discarded = true
+  }
+  return { entries, discarded }
+}
+
+const encodeScope = (scope: TurnScope): string => {
+  const decoded = decodeScopeValue(scope)
+  if (!decoded) throw new Error('Review scope is invalid.')
+  return JSON.stringify(decoded)
+}
+
+const encodeReviewerLog = (reviewerLog: ReviewerLogEntry[]): string => {
+  const decoded = decodeReviewerLogValue(reviewerLog)
+  if (decoded.discarded || decoded.entries.length !== reviewerLog.length) {
+    throw new Error('Reviewer log is invalid.')
+  }
+  return JSON.stringify(decoded.entries)
+}
+
+const encodeLocator = (locator: FindingLocator | undefined): string => {
+  if (locator === undefined) return '{}'
+  const decoded = decodeLocatorValue(locator)
+  if (!decoded) throw new Error('Finding locator is invalid.')
+  return JSON.stringify(decoded)
+}
+
+const codecVersionOf = (row: { codecVersion?: number }): number => {
+  const value = row.codecVersion
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : LEGACY_REVIEW_CODEC_VERSION
+}
+
+const warnDecodeIssue = (
+  rowKind: 'Review' | 'Finding' | 'ReviewFindingDisposition',
+  rowId: string,
+  field: string,
+  codecVersion: number
+): void => {
+  log.warn('degraded invalid persisted reviewer data', { rowKind, rowId, field, codecVersion })
+}
+
+const decodeLifecycle = (value: string): ReviewLifecycle =>
+  value === 'running' || value === 'complete' || value === 'error' ? value : 'error'
+
+const decodeOutcome = (value: string | null): ReviewOutcome | null =>
+  value === 'pass' || value === 'flagged' ? value : null
+
+const decodeStatus = (value: string): CheckStatus =>
+  value === 'pass' || value === 'warn' || value === 'fail' ? value : 'warn'
+
+const decodeResolution = (value: string): FindingResolution =>
+  value === 'resolved' || value === 'unaddressed' ? value : 'open'
+
+const assertReviewEnums = (lifecycle: ReviewLifecycle, outcome: ReviewOutcome | null): void => {
+  if (decodeLifecycle(lifecycle) !== lifecycle) throw new Error('Review lifecycle is invalid.')
+  if (outcome !== null && decodeOutcome(outcome) !== outcome) {
+    throw new Error('Review outcome is invalid.')
+  }
+}
+
+const assertFindingEnums = (status: CheckStatus, resolution: FindingResolution): void => {
+  if (decodeStatus(status) !== status) throw new Error('Finding status is invalid.')
+  if (decodeResolution(resolution) !== resolution) throw new Error('Finding resolution is invalid.')
+}
+
+const encodeReview = (input: CreateReviewInput): EncodedReview => {
+  const lifecycle = input.lifecycle ?? 'running'
+  const outcome = input.outcome ?? null
+  assertReviewEnums(lifecycle, outcome)
+  return {
+    codecVersion: CURRENT_REVIEW_CODEC_VERSION,
+    scope: encodeScope(input.scope),
+    lifecycle,
+    outcome,
+    errorMessage: input.errorMessage ?? null,
+    model: input.model ?? '',
+    reviewerLog: encodeReviewerLog(input.reviewerLog ?? [])
+  }
+}
+
+const encodeReviewPatch = (patch: UpdateReviewPatch): Record<string, unknown> => {
+  if (patch.lifecycle !== undefined && decodeLifecycle(patch.lifecycle) !== patch.lifecycle) {
+    throw new Error('Review lifecycle is invalid.')
+  }
+  if (
+    patch.outcome !== undefined &&
+    patch.outcome !== null &&
+    decodeOutcome(patch.outcome) !== patch.outcome
+  ) {
+    throw new Error('Review outcome is invalid.')
+  }
+  return {
+    ...(patch.scope !== undefined ? { scope: encodeScope(patch.scope) } : {}),
+    ...(patch.lifecycle !== undefined ? { lifecycle: patch.lifecycle } : {}),
+    ...(patch.outcome !== undefined ? { outcome: patch.outcome } : {}),
+    ...(patch.errorMessage !== undefined ? { errorMessage: patch.errorMessage } : {}),
+    ...(patch.model !== undefined ? { model: patch.model } : {}),
+    ...(patch.reviewerLog !== undefined
+      ? { reviewerLog: encodeReviewerLog(patch.reviewerLog) }
+      : {})
+  }
+}
+
+const encodeFinding = (check: NewCheck, sortIndex: number): EncodedFinding => {
+  const resolution = check.resolution ?? 'open'
+  assertFindingEnums(check.status, resolution)
+  return {
+    status: check.status,
+    resolution,
+    claim: check.claim,
+    evidence: check.evidence,
+    locator: encodeLocator(check.locator),
+    artifactVersionId: check.artifactVersionId ?? null,
+    artifactBindingState: check.artifactVersionId ? 'scope_validated' : 'legacy_unverified',
+    sortIndex: check.sortIndex ?? sortIndex
+  }
+}
+
+const decodeReviewScope = (row: ReviewScopeRow): TurnScope | undefined => {
+  const parsedScope = parseJson(row.scope)
+  const scope = parsedScope.valid ? decodeScopeValue(parsedScope.value) : undefined
+  if (scope === undefined) {
+    warnDecodeIssue('Review', row.id, 'scope', codecVersionOf(row))
+  }
+  return scope
+}
+
+const decodeReview = (row: VersionedPrismaReview): Review => {
+  const codecVersion = codecVersionOf(row)
+  const scope = decodeReviewScope(row)
+  const parsedLog = parseJson(row.reviewerLog)
+  const reviewerLog = parsedLog.valid
+    ? decodeReviewerLogValue(parsedLog.value)
+    : { entries: [], discarded: true }
+  const storedLifecycle = decodeLifecycle(row.lifecycle)
+  const storedOutcome = decodeOutcome(row.outcome)
+  const invalidScope = scope === undefined
+  const invalidLifecycle = storedLifecycle !== row.lifecycle
+  const invalidOutcome = row.outcome !== null && storedOutcome === null
+
+  if (reviewerLog.discarded) warnDecodeIssue('Review', row.id, 'reviewerLog', codecVersion)
+  if (invalidLifecycle) warnDecodeIssue('Review', row.id, 'lifecycle', codecVersion)
+  if (invalidOutcome) warnDecodeIssue('Review', row.id, 'outcome', codecVersion)
+  if (codecVersion > CURRENT_REVIEW_CODEC_VERSION) {
+    warnDecodeIssue('Review', row.id, 'codecVersion', codecVersion)
+  }
+
+  const failClosed = invalidScope || invalidLifecycle || invalidOutcome
+  const existingError = row.errorMessage ?? undefined
+  const errorMessage = invalidScope
+    ? [existingError, INVALID_SCOPE_MESSAGE].filter(Boolean).join(' ')
+    : existingError
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    sessionId: row.sessionId,
+    turnMessageId: row.turnMessageId,
+    scope: scope ?? emptyScope(row.turnMessageId),
+    lifecycle: failClosed ? 'error' : storedLifecycle,
+    outcome: failClosed ? null : storedOutcome,
+    ...(errorMessage ? { errorMessage } : {}),
+    model: row.model,
+    reviewerLog: reviewerLog.entries,
+    createdAt: row.createdAt.getTime(),
+    updatedAt: row.updatedAt.getTime()
+  }
+}
+
+const decodeFinding = (
+  row: PrismaFinding,
+  codecVersion = LEGACY_REVIEW_CODEC_VERSION
+): ReviewCheck => {
+  const parsedLocator = parseJson(row.locator)
+  const emptyLocator =
+    parsedLocator.valid &&
+    isRecord(parsedLocator.value) &&
+    Object.keys(parsedLocator.value).length === 0
+  const locator = parsedLocator.valid ? decodeLocatorValue(parsedLocator.value) : undefined
+  if (!emptyLocator && locator === undefined) {
+    warnDecodeIssue('Finding', row.id, 'locator', codecVersion)
+  }
+  const status = decodeStatus(row.status)
+  if (status !== row.status) warnDecodeIssue('Finding', row.id, 'status', codecVersion)
+  const resolution = decodeResolution(row.resolution)
+  if (resolution !== row.resolution) warnDecodeIssue('Finding', row.id, 'resolution', codecVersion)
+  const artifactBindingState =
+    row.artifactBindingState === 'scope_validated' ? 'scope_validated' : 'legacy_unverified'
+  if (
+    row.artifactBindingState !== 'scope_validated' &&
+    row.artifactBindingState !== 'legacy_unverified'
+  ) {
+    warnDecodeIssue('Finding', row.id, 'artifactBindingState', codecVersion)
+  }
+  return {
+    id: row.id,
+    reviewId: row.reviewId,
+    status,
+    resolution,
+    claim: row.claim,
+    evidence: row.evidence,
+    ...(locator ? { locator } : {}),
+    ...(row.artifactVersionId ? { artifactVersionId: row.artifactVersionId } : {}),
+    artifactBindingState,
+    sortIndex: row.sortIndex,
+    reflagCount: row.reflagCount ?? 0
+  }
+}
+
+const DISPOSITION_TRIGGERS = new Set<ReviewFindingDispositionTrigger>([
+  'review_submission',
+  'loop_terminated',
+  'correction_failed',
+  'aborted'
+])
+const DISPOSITION_OUTCOMES = new Set<ReviewFindingDispositionOutcome>([
+  'still_open',
+  'resolved',
+  'unaddressed'
+])
+
+const encodeDisposition = (
+  trigger: ReviewFindingDispositionTrigger,
+  outcome: ReviewFindingDispositionOutcome
+): { trigger: ReviewFindingDispositionTrigger; outcome: ReviewFindingDispositionOutcome } => {
+  if (!DISPOSITION_TRIGGERS.has(trigger)) throw new Error('Finding disposition trigger is invalid.')
+  if (!DISPOSITION_OUTCOMES.has(outcome)) throw new Error('Finding disposition outcome is invalid.')
+  return { trigger, outcome }
+}
+
+const decodeDisposition = (
+  row: PrismaReviewFindingDisposition
+): ReviewFindingDisposition | undefined => {
+  const trigger = row.trigger as ReviewFindingDispositionTrigger
+  const outcome = row.outcome as ReviewFindingDispositionOutcome
+  if (!DISPOSITION_TRIGGERS.has(trigger)) {
+    warnDecodeIssue('ReviewFindingDisposition', row.id, 'trigger', LEGACY_REVIEW_CODEC_VERSION)
+    return undefined
+  }
+  if (!DISPOSITION_OUTCOMES.has(outcome)) {
+    warnDecodeIssue('ReviewFindingDisposition', row.id, 'outcome', LEGACY_REVIEW_CODEC_VERSION)
+    return undefined
+  }
+  return {
+    id: row.id,
+    sourceFindingId: row.sourceFindingId,
+    ...(row.causeReviewId ? { causeReviewId: row.causeReviewId } : {}),
+    sequence: row.sequence,
+    trigger,
+    outcome,
+    ...(row.note ? { note: row.note } : {}),
+    ...(row.assessedArtifactVersionId
+      ? { assessedArtifactVersionId: row.assessedArtifactVersionId }
+      : {}),
+    createdAt: row.createdAt.getTime()
+  }
+}
+
+const reviewPersistenceCodec: ReviewPersistenceCodec = {
+  currentVersion: CURRENT_REVIEW_CODEC_VERSION,
+  encodeReview,
+  encodeReviewPatch,
+  encodeFinding,
+  encodeDisposition,
+  decodeReviewScope,
+  decodeReview,
+  decodeFinding,
+  decodeDisposition
+}
+
+export { reviewPersistenceCodec }
+export type { ReviewPersistenceCodec }

--- a/src/main/reviewer/repository.test.ts
+++ b/src/main/reviewer/repository.test.ts
@@ -128,6 +128,55 @@ describe('review repository (integration)', () => {
     expect(stored.checks[2]!.locator).toBeUndefined()
   })
 
+  it('isolates shape-invalid persisted JSON without breaking healthy reviews', async () => {
+    const repository = await createRepository()
+    const healthy = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'healthy-turn',
+      scope: scope('healthy-turn'),
+      lifecycle: 'complete',
+      outcome: 'pass'
+    })
+    const corrupt = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'corrupt-turn',
+      scope: scope('corrupt-turn'),
+      lifecycle: 'complete',
+      outcome: 'flagged',
+      reviewerLog: [{ kind: 'message', text: 'valid before corruption' }]
+    })
+    await repository.addChecks(corrupt.id, [checks()[0]!])
+    const corruptFinding = await client!.finding.findFirstOrThrow({
+      where: { reviewId: corrupt.id }
+    })
+
+    await client!.review.update({
+      where: { id: corrupt.id },
+      data: { scope: 'null', reviewerLog: '42' }
+    })
+    await client!.finding.update({
+      where: { id: corruptFinding.id },
+      data: { locator: 'null' }
+    })
+
+    const stored = await repository.getReviewsForSession('session-1')
+    expect(stored.find((review) => review.id === healthy.id)).toMatchObject({
+      lifecycle: 'complete',
+      outcome: 'pass',
+      scope: scope('healthy-turn')
+    })
+    expect(stored.find((review) => review.id === corrupt.id)).toMatchObject({
+      lifecycle: 'error',
+      outcome: null,
+      scope: { turnMessageId: 'corrupt-turn', blocks: [], artifactVersionIds: [] },
+      reviewerLog: [],
+      checks: [{ id: corruptFinding.id, status: 'fail' }]
+    })
+    expect(stored.find((review) => review.id === corrupt.id)?.checks[0]?.locator).toBeUndefined()
+  })
+
   it('retains an error Review row when its frozen scope snapshot cannot be published', async () => {
     await createRepository()
     const invalidSnapshotRoot = join(storageRoot!, 'not-a-directory')
@@ -572,6 +621,17 @@ describe('review repository (integration)', () => {
         {
           ...input,
           eventId: 'disposition-event-2',
+          causeReviewId: outsideScope.id
+        }
+      ])
+    ).rejects.toThrow(/outside Review scope/u)
+
+    await client!.review.update({ where: { id: outsideScope.id }, data: { scope: 'null' } })
+    await expect(
+      repository.commitFindingDispositions([
+        {
+          ...input,
+          eventId: 'disposition-event-corrupt-scope',
           causeReviewId: outsideScope.id
         }
       ])

--- a/src/main/reviewer/repository.test.ts
+++ b/src/main/reviewer/repository.test.ts
@@ -646,6 +646,10 @@ describe('review repository (integration)', () => {
       turnMessageId: 'a1',
       scope: scope('a1')
     })
+    await client!.review.update({
+      where: { id: review.id },
+      data: { codecVersion: 0 }
+    })
 
     const updated = await repository.updateReview(review.id, {
       lifecycle: 'complete',
@@ -661,6 +665,9 @@ describe('review repository (integration)', () => {
     expect(stored.outcome).toBe('flagged')
     expect(stored.reviewerLog).toHaveLength(1)
     expect(stored.reviewerLog[0]?.kind).toBe('thought')
+    await expect(
+      client!.review.findUniqueOrThrow({ where: { id: review.id } })
+    ).resolves.toMatchObject({ codecVersion: 1 })
   })
 
   it("deletes a session's reviews and their checks, leaving other sessions untouched", async () => {

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -2,12 +2,16 @@ import { createHash, randomUUID } from 'node:crypto'
 import { mkdir, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, relative, resolve, sep } from 'node:path'
 
-import type { Finding as PrismaFinding, PrismaClient, Review as PrismaReview } from '@prisma/client'
+import type {
+  Finding as PrismaFinding,
+  PrismaClient,
+  Review as PrismaReview,
+  ReviewFindingDisposition as PrismaReviewFindingDisposition
+} from '@prisma/client'
 
 import type {
   CheckStatus,
   CreateReviewInput,
-  FindingLocator,
   FindingResolution,
   NewCheck,
   Review,
@@ -16,12 +20,11 @@ import type {
   ReviewFindingDispositionOutcome,
   ReviewFindingDispositionTrigger,
   ReviewerLogEntry,
-  ReviewLifecycle,
   ReviewOutcome,
   ReviewWithChecks,
-  TurnScope,
   UpdateReviewPatch
 } from '../../shared/reviewer'
+import { reviewPersistenceCodec } from './persistence-codec'
 
 // Legacy alias for callers still using FindingSeverity (now CheckStatus).
 type FindingSeverity = CheckStatus
@@ -91,100 +94,14 @@ const touchReview = async (tx: Pick<PrismaClient, 'review'>, reviewId: string): 
   await tx.review.update({ where: { id: reviewId }, data: { updatedAt: new Date() } })
 }
 
-// JSON columns are parsed defensively: a corrupt value degrades to the given fallback rather than
-// throwing, so one bad row cannot break loading a whole session's reviews.
-const parseJson = <T>(value: string, fallback: T): T => {
-  try {
-    return JSON.parse(value) as T
-  } catch {
-    return fallback
-  }
-}
+const toReview = (row: PrismaReview): Review => reviewPersistenceCodec.decodeReview(row)
 
-const EMPTY_SCOPE = (turnMessageId: string): TurnScope => ({
-  turnMessageId,
-  blocks: [],
-  artifactVersionIds: []
-})
+const toCheck = (row: PrismaFinding, codecVersion?: number): ReviewCheck =>
+  reviewPersistenceCodec.decodeFinding(row, codecVersion)
 
-// Narrows the free-text lifecycle column back to the domain union, defaulting unknown values to 'error'
-// so a corrupt row surfaces as a failed review rather than a phantom running one.
-const asLifecycle = (value: string): ReviewLifecycle =>
-  value === 'running' || value === 'complete' ? value : 'error'
-
-const asOutcome = (value: string | null): ReviewOutcome | null =>
-  value === 'pass' || value === 'flagged' ? value : null
-
-// Maps a Prisma review row (JSON strings + DateTime) into the epoch-ms domain shape shared with the renderer.
-// v2: Review no longer has summary/checks columns; those are gone.
-// v3: reasoning replaced by reviewerLog (captured action stream).
-const toReview = (row: PrismaReview): Review => ({
-  id: row.id,
-  projectId: row.projectId,
-  sessionId: row.sessionId,
-  turnMessageId: row.turnMessageId,
-  scope: parseJson<TurnScope>(row.scope, EMPTY_SCOPE(row.turnMessageId)),
-  lifecycle: asLifecycle(row.lifecycle),
-  outcome: asOutcome(row.outcome),
-  errorMessage: row.errorMessage ?? undefined,
-  model: row.model,
-  reviewerLog: parseJson<ReviewerLogEntry[]>(row.reviewerLog, []),
-  createdAt: row.createdAt.getTime(),
-  updatedAt: row.updatedAt.getTime()
-})
-
-// Maps a Prisma Finding row to the unified ReviewCheck domain type.
-// v2: `status` replaces `severity`; locator is optional (pass checks may have empty JSON = {}).
-const asCheckStatus = (value: string): CheckStatus => {
-  if (value === 'fail' || value === 'warn' || value === 'pass') return value
-  // Legacy migration: old 'severity' values were only warn/fail, default to 'warn' if unknown.
-  if (value === 'inconclusive') return 'warn'
-  return 'warn'
-}
-
-const toCheck = (row: PrismaFinding): ReviewCheck => {
-  const locatorRaw = parseJson<FindingLocator | Record<string, never>>(row.locator, {})
-  // A locator is meaningful only when it has a blockRef (pass checks may store '{}').
-  const hasLocator = 'blockRef' in locatorRaw && locatorRaw.blockRef !== undefined
-  return {
-    id: row.id,
-    reviewId: row.reviewId,
-    status: asCheckStatus(row.status),
-    resolution:
-      row.resolution === 'resolved' || row.resolution === 'unaddressed' ? row.resolution : 'open',
-    claim: row.claim,
-    evidence: row.evidence,
-    locator: hasLocator ? (locatorRaw as FindingLocator) : undefined,
-    artifactVersionId: row.artifactVersionId ?? undefined,
-    artifactBindingState:
-      row.artifactBindingState === 'scope_validated' ? 'scope_validated' : 'legacy_unverified',
-    sortIndex: row.sortIndex,
-    // Default to 0 for rows written before the reflagCount column was added (issue 15 migration guard).
-    reflagCount: row.reflagCount ?? 0
-  }
-}
-
-const toFindingDisposition = (row: {
-  id: string
-  sourceFindingId: string
-  causeReviewId: string | null
-  sequence: number
-  trigger: string
-  outcome: string
-  note: string | null
-  assessedArtifactVersionId: string | null
-  createdAt: Date
-}): ReviewFindingDisposition => ({
-  id: row.id,
-  sourceFindingId: row.sourceFindingId,
-  causeReviewId: row.causeReviewId ?? undefined,
-  sequence: row.sequence,
-  trigger: row.trigger as ReviewFindingDispositionTrigger,
-  outcome: row.outcome as ReviewFindingDispositionOutcome,
-  note: row.note ?? undefined,
-  assessedArtifactVersionId: row.assessedArtifactVersionId ?? undefined,
-  createdAt: row.createdAt.getTime()
-})
+const toFindingDisposition = (
+  row: PrismaReviewFindingDisposition
+): ReviewFindingDisposition | undefined => reviewPersistenceCodec.decodeDisposition(row)
 
 // Owns Review/check reads/writes. The client is resolved lazily per call so schema-ensure failures can
 // recover (see projects/repository.ts). Reviews live in SQLite while the transcript stays in session JSON;
@@ -198,17 +115,13 @@ class ReviewRepository {
   // Inserts a new review, defaulting a fresh audit to the 'running' lifecycle with no outcome yet.
   async createReview(input: CreateReviewInput): Promise<Review> {
     const client = await this.getClient()
+    const encoded = reviewPersistenceCodec.encodeReview(input)
     const row = await client.review.create({
       data: {
         projectId: input.projectId,
         sessionId: input.sessionId,
         turnMessageId: input.turnMessageId,
-        scope: JSON.stringify(input.scope),
-        lifecycle: input.lifecycle ?? 'running',
-        outcome: input.outcome ?? null,
-        errorMessage: input.errorMessage ?? null,
-        model: input.model ?? '',
-        reviewerLog: JSON.stringify(input.reviewerLog ?? [])
+        ...encoded
       }
     })
 
@@ -219,11 +132,11 @@ class ReviewRepository {
         await client.review
           .update({
             where: { id: row.id },
-            data: {
+            data: reviewPersistenceCodec.encodeReviewPatch({
               lifecycle: 'error',
               outcome: null,
               errorMessage: error instanceof Error ? error.message : String(error)
-            }
+            })
           })
           .catch(() => undefined)
         throw error
@@ -302,17 +215,11 @@ class ReviewRepository {
 
   // Patches only the provided fields so a caller can flip lifecycle/outcome without resupplying the rest.
   async updateReview(id: string, patch: UpdateReviewPatch): Promise<Review> {
-    const data: Record<string, unknown> = {}
-
-    if (patch.scope !== undefined) data.scope = JSON.stringify(patch.scope)
-    if (patch.lifecycle !== undefined) data.lifecycle = patch.lifecycle
-    if (patch.outcome !== undefined) data.outcome = patch.outcome
-    if (patch.errorMessage !== undefined) data.errorMessage = patch.errorMessage
-    if (patch.model !== undefined) data.model = patch.model
-    if (patch.reviewerLog !== undefined) data.reviewerLog = JSON.stringify(patch.reviewerLog)
-
     const client = await this.getClient()
-    const row = await client.review.update({ where: { id }, data })
+    const row = await client.review.update({
+      where: { id },
+      data: reviewPersistenceCodec.encodeReviewPatch(patch)
+    })
 
     return toReview(row)
   }
@@ -326,7 +233,7 @@ class ReviewRepository {
     await client.$transaction(async (tx) => {
       const review = await tx.review.findUnique({ where: { id: reviewId } })
       if (!review) throw new Error(`Review not found: ${reviewId}`)
-      const scope = parseJson<TurnScope>(review.scope, EMPTY_SCOPE(review.turnMessageId))
+      const scope = reviewPersistenceCodec.decodeReview(review).scope
       for (const check of checks) {
         if (
           check.artifactVersionId &&
@@ -340,14 +247,7 @@ class ReviewRepository {
       await tx.finding.createMany({
         data: checks.map((check, index) => ({
           reviewId,
-          status: check.status,
-          resolution: check.resolution ?? 'open',
-          claim: check.claim,
-          evidence: check.evidence,
-          locator: JSON.stringify(check.locator ?? {}),
-          artifactVersionId: check.artifactVersionId ?? null,
-          artifactBindingState: check.artifactVersionId ? 'scope_validated' : 'legacy_unverified',
-          sortIndex: check.sortIndex ?? index
+          ...reviewPersistenceCodec.encodeFinding(check, index)
         }))
       })
       await touchReview(tx, reviewId)
@@ -394,10 +294,7 @@ class ReviewRepository {
       if (assessmentReview.lifecycle !== 'running') {
         throw new Error(`Review submission is already terminal: ${input.reviewId}`)
       }
-      const assessmentScope = parseJson<TurnScope>(
-        assessmentReview.scope,
-        EMPTY_SCOPE(assessmentReview.turnMessageId)
-      )
+      const assessmentScope = reviewPersistenceCodec.decodeReview(assessmentReview).scope
       for (const check of input.checks) {
         if (
           check.artifactVersionId &&
@@ -414,14 +311,7 @@ class ReviewRepository {
         await tx.finding.createMany({
           data: newChecks.map((check, index) => ({
             reviewId: input.reviewId,
-            status: check.status,
-            resolution: check.resolution ?? 'open',
-            claim: check.claim,
-            evidence: check.evidence,
-            locator: JSON.stringify(check.locator ?? {}),
-            artifactVersionId: check.artifactVersionId ?? null,
-            artifactBindingState: check.artifactVersionId ? 'scope_validated' : 'legacy_unverified',
-            sortIndex: check.sortIndex ?? index
+            ...reviewPersistenceCodec.encodeFinding(check, index)
           }))
         })
       }
@@ -486,8 +376,7 @@ class ReviewRepository {
             sourceFindingId: finding.id,
             causeReviewId: assessmentReview.id,
             sequence: (latest?.sequence ?? 0) + 1,
-            trigger: 'review_submission',
-            outcome: dispositionOutcome,
+            ...reviewPersistenceCodec.encodeDisposition('review_submission', dispositionOutcome),
             assessedArtifactVersionId: check.artifactVersionId ?? null
           }
         })
@@ -499,12 +388,12 @@ class ReviewRepository {
       }
       await tx.review.update({
         where: { id: assessmentReview.id },
-        data: {
+        data: reviewPersistenceCodec.encodeReviewPatch({
           lifecycle: 'complete',
           outcome: input.outcome,
           errorMessage: null,
-          reviewerLog: JSON.stringify(input.reviewerLog ?? [])
-        }
+          reviewerLog: input.reviewerLog ?? []
+        })
       })
       return { projectId: assessmentReview.projectId, sessionId: assessmentReview.sessionId }
     })
@@ -552,7 +441,7 @@ class ReviewRepository {
           orderBy: { sortIndex: 'asc' }
         })
 
-        const checks = checkRows.map(toCheck)
+        const checks = checkRows.map((checkRow) => toCheck(checkRow, row.codecVersion))
         return {
           ...toReview(row),
           checks,
@@ -640,6 +529,10 @@ class ReviewRepository {
     note?: string
     assessedArtifactVersionId?: string
   }): Promise<ReviewFindingDisposition> {
+    const encodedDisposition = reviewPersistenceCodec.encodeDisposition(
+      input.trigger,
+      input.outcome
+    )
     const client = await this.getClient()
     const row = await client.$transaction(async (tx) => {
       const existing = await tx.reviewFindingDisposition.findUnique({
@@ -671,24 +564,15 @@ class ReviewRepository {
           sourceFindingId: input.sourceFindingId,
           causeReviewId: input.causeReviewId ?? null,
           sequence: (latest?.sequence ?? 0) + 1,
-          trigger: input.trigger,
-          outcome: input.outcome,
+          ...encodedDisposition,
           note: input.note ?? null,
           assessedArtifactVersionId: input.assessedArtifactVersionId ?? null
         }
       })
     })
-    return {
-      id: row.id,
-      sourceFindingId: row.sourceFindingId,
-      causeReviewId: row.causeReviewId ?? undefined,
-      sequence: row.sequence,
-      trigger: row.trigger as ReviewFindingDispositionTrigger,
-      outcome: row.outcome as ReviewFindingDispositionOutcome,
-      note: row.note ?? undefined,
-      assessedArtifactVersionId: row.assessedArtifactVersionId ?? undefined,
-      createdAt: row.createdAt.getTime()
-    }
+    const decoded = reviewPersistenceCodec.decodeDisposition(row)
+    if (!decoded) throw new Error(`Stored Finding disposition is invalid: ${row.id}`)
+    return decoded
   }
 
   // Applies the fix-loop materialized state and appends its immutable audit event in one SQLite
@@ -720,9 +604,13 @@ class ReviewRepository {
 
     const client = await this.getClient()
     const rows = await client.$transaction(async (tx) => {
-      const dispositions: Array<Parameters<typeof toFindingDisposition>[0]> = []
+      const dispositions: PrismaReviewFindingDisposition[] = []
       const reviewIds = new Set<string>()
       for (const input of inputs) {
+        const encodedDisposition = reviewPersistenceCodec.encodeDisposition(
+          input.trigger,
+          input.outcome
+        )
         const finding = await tx.finding.findFirst({
           where: { id: input.sourceFindingId, reviewId: input.reviewId }
         })
@@ -744,10 +632,7 @@ class ReviewRepository {
           throw new Error('Finding disposition Review belongs to another Project or Session.')
         }
         if (input.assessedArtifactVersionId) {
-          const assessmentScope = parseJson<TurnScope>(
-            assessmentReview.scope,
-            EMPTY_SCOPE(assessmentReview.turnMessageId)
-          )
+          const assessmentScope = reviewPersistenceCodec.decodeReview(assessmentReview).scope
           if (!assessmentScope.artifactVersionIds.includes(input.assessedArtifactVersionId)) {
             throw new Error(
               `Assessed Artifact Version is outside Review scope: ${input.assessedArtifactVersionId}`
@@ -800,8 +685,7 @@ class ReviewRepository {
               sourceFindingId: finding.id,
               causeReviewId: input.causeReviewId ?? null,
               sequence: (latest?.sequence ?? 0) + 1,
-              trigger: input.trigger,
-              outcome: input.outcome,
+              ...encodedDisposition,
               note: input.note ?? null,
               assessedArtifactVersionId: input.assessedArtifactVersionId ?? null
             }
@@ -812,7 +696,10 @@ class ReviewRepository {
       for (const reviewId of reviewIds) await touchReview(tx, reviewId)
       return dispositions
     })
-    return rows.map(toFindingDisposition)
+    return rows.flatMap((row) => {
+      const decoded = toFindingDisposition(row)
+      return decoded ? [decoded] : []
+    })
   }
 
   async getFindingDispositions(sourceFindingId: string): Promise<ReviewFindingDisposition[]> {
@@ -821,7 +708,10 @@ class ReviewRepository {
       where: { sourceFindingId },
       orderBy: { sequence: 'asc' }
     })
-    return rows.map(toFindingDisposition)
+    return rows.flatMap((row) => {
+      const decoded = toFindingDisposition(row)
+      return decoded ? [decoded] : []
+    })
   }
 
   // Test/diagnostic helper: total check rows, used to assert no orphans survive a cascade delete.
@@ -848,7 +738,7 @@ class ReviewRepository {
   }
 }
 
-export { ReviewRepository, toCheck, toReview }
+export { ReviewRepository, toCheck, toFindingDisposition, toReview }
 export type { ReviewClient, ReviewClientProvider, ReviewRepositoryOptions, FindingSeverity }
 
 // Legacy exports kept for callers that still reference toFinding.

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -696,10 +696,7 @@ class ReviewRepository {
       for (const reviewId of reviewIds) await touchReview(tx, reviewId)
       return dispositions
     })
-    return rows.flatMap((row) => {
-      const decoded = toFindingDisposition(row)
-      return decoded ? [decoded] : []
-    })
+    return reviewPersistenceCodec.decodeDispositions(rows)
   }
 
   async getFindingDispositions(sourceFindingId: string): Promise<ReviewFindingDisposition[]> {
@@ -708,10 +705,7 @@ class ReviewRepository {
       where: { sourceFindingId },
       orderBy: { sequence: 'asc' }
     })
-    return rows.flatMap((row) => {
-      const decoded = toFindingDisposition(row)
-      return decoded ? [decoded] : []
-    })
+    return reviewPersistenceCodec.decodeDispositions(rows)
   }
 
   // Test/diagnostic helper: total check rows, used to assert no orphans survive a cascade delete.

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -99,10 +99,6 @@ const toReview = (row: PrismaReview): Review => reviewPersistenceCodec.decodeRev
 const toCheck = (row: PrismaFinding, codecVersion?: number): ReviewCheck =>
   reviewPersistenceCodec.decodeFinding(row, codecVersion)
 
-const toFindingDisposition = (
-  row: PrismaReviewFindingDisposition
-): ReviewFindingDisposition | undefined => reviewPersistenceCodec.decodeDisposition(row)
-
 // Owns Review/check reads/writes. The client is resolved lazily per call so schema-ensure failures can
 // recover (see projects/repository.ts). Reviews live in SQLite while the transcript stays in session JSON;
 // cross-store cleanup is done here by deleting review rows (and their checks) by session/project id.
@@ -732,7 +728,7 @@ class ReviewRepository {
   }
 }
 
-export { ReviewRepository, toCheck, toFindingDisposition, toReview }
+export { ReviewRepository, toCheck, toReview }
 export type { ReviewClient, ReviewClientProvider, ReviewRepositoryOptions, FindingSeverity }
 
 // Legacy exports kept for callers that still reference toFinding.

--- a/src/main/reviewer/reviewer-orchestrator.architecture.test.ts
+++ b/src/main/reviewer/reviewer-orchestrator.architecture.test.ts
@@ -319,6 +319,7 @@ describe('Reviewer orchestrator architecture', () => {
   it('keeps orchestration metadata out of the Reviewer persistence leaf', () => {
     expect(prismaModelFields('Review')).toEqual([
       'id String @id @default(cuid())',
+      'codecVersion Int @default(0)',
       'projectId String',
       'sessionId String',
       'turnMessageId String',

--- a/src/main/storage/provenance-migration-validation.test.ts
+++ b/src/main/storage/provenance-migration-validation.test.ts
@@ -431,7 +431,9 @@ describe('validateProvenanceMigrationState', () => {
     const scope = {
       turnMessageId: 'message-1',
       agentFrameId: 'agent-1',
-      messageBranchId: 'branch-1'
+      messageBranchId: 'branch-1',
+      blocks: [],
+      artifactVersionIds: []
     }
     await client.review.create({
       data: {
@@ -479,6 +481,16 @@ describe('validateProvenanceMigrationState', () => {
 
     await expect(validateProvenanceMigrationState(dataRoot, authorityRoot)).rejects.toThrow(
       /Review snapshot ownership is invalid/i
+    )
+
+    const reopened = createProjectDbClient(authorityRoot)
+    await reopened.review.update({
+      where: { id: 'review-1' },
+      data: { scope: JSON.stringify({ artifactVersionIds: [] }) }
+    })
+    await reopened.$disconnect()
+    await expect(validateProvenanceMigrationState(dataRoot, authorityRoot)).rejects.toThrow(
+      /Review scope is invalid/i
     )
   })
 

--- a/src/main/storage/provenance-migration-validation.ts
+++ b/src/main/storage/provenance-migration-validation.ts
@@ -8,6 +8,7 @@ import { NOTEBOOK_RUN_FILE } from '../../shared/notebook'
 import { normalizeSessionFile } from '../../shared/session-persistence'
 import { operationJournalPath, RuntimeOperationJournal } from '../notebook/operation-journal'
 import { createProjectDbClient } from '../projects/prisma-client'
+import { reviewPersistenceCodec } from '../reviewer/persistence-codec'
 
 const SHA256_PATTERN = /^[a-f0-9]{64}$/
 const storageKey = (...segments: string[]): string => segments.join('/')
@@ -453,7 +454,10 @@ const validateSqliteStore = async (dataRoot: string, authorityRoot: string): Pro
         }
         const payload = recordValue(JSON.parse(serialized))
         const payloadScope = recordValue(payload?.scope)
-        const reviewScope = recordValue(JSON.parse(snapshot.review.scope))
+        const reviewScope = reviewPersistenceCodec.decodeReviewScope(snapshot.review)
+        if (!reviewScope) {
+          throw new Error(`Review scope is invalid: ${snapshot.reviewId}`)
+        }
         if (
           !payload ||
           payload.schemaVersion !== snapshot.schemaVersion ||


### PR DESCRIPTION
## Summary

- add a versioned Review persistence codec that structurally validates Review scope/logs, Finding locators, and persisted enums
- migrate recognized legacy reviewer-log entries while isolating malformed rows and unknown audit dispositions
- route Review repository, Provenance/read-model, deletion-closure, and migration-validation consumers through the same codec
- add the additive SQLite/Prisma `codecVersion` guard and focused regression coverage

## Root cause

The repository parsed SQLite JSON and immediately asserted the requested TypeScript type. Syntactically valid values such as `null`, numbers, or partial objects therefore escaped into callers that assumed the full shape; for example, a malformed Finding locator reached `'blockRef' in locatorRaw` and could abort a whole Review/Provenance read.

## Impact

Persisted reads are now total and fail closed at one locality. A bad Review scope becomes an error Review with an empty scope; malformed log entries and dispositions are isolated; a malformed locator no longer removes its Finding. New and rewritten Review rows carry codec version 1, while existing rows start at legacy version 0.

The persistence seam remains ACP-neutral. Claude Code, OpenCode, Codex Responses, and Codex Bridge converge through the existing reviewer session/log normalization before persistence; no provider subscription or lifecycle behavior changes.

## Verification

The final impact classifier selected the full fallback because `prisma/schema.prisma` is an unknown owner.

- codec/repository/provenance/deletion/migration behavior -> focused 8-file Vitest run -> **135/135 passed** after the last cleanup
- Node and renderer contracts -> `npm run typecheck` -> **passed**
- repository lint -> `npm run lint -- --no-cache` -> **0 errors** (17 pre-existing warnings outside this diff)
- Prisma compatibility -> `prisma validate --schema prisma/schema.prisma` with a process-local SQLite URL -> **passed**
- Standards + Spec independent review -> two-axis review and post-fix re-review -> **no remaining findings**
- complete portable suite -> `npm test` -> **13,189 passed; 22 failed; 277 skipped** across 937 files

The complete-suite failures were local Windows environment/contention failures: symlink creation returned `EPERM`, one cleanup returned `EBUSY`, and unrelated long-running tests exceeded the default 15-second budget under full parallel load. One affected Provenance test also timed out only in the full parallel run and passed in the focused run. Exact-head CI remains authoritative for the complete portable/platform lanes.

All listed focused checks and static checks ran after the last material edit.