### PR TITLE
fix(workspace): persist choices only after next

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
@@ -236,9 +236,7 @@ describe('WorkspaceElicitationCard choice question', () => {
     })
 
     expect(onRespond).not.toHaveBeenCalled()
-    expect(onDraftChange).toHaveBeenLastCalledWith([
-      { fieldId: 'question_0', value: 'multi-omics' }
-    ])
+    expect(onDraftChange).not.toHaveBeenCalled()
     expect(container.querySelector('h3')?.textContent).toBe(
       'What should this skill primarily cover?'
     )
@@ -250,6 +248,10 @@ describe('WorkspaceElicitationCard choice question', () => {
     expect(advance?.querySelector('svg.lucide-chevron-right')).not.toBeNull()
     await act(async () => advance?.click())
 
+    expect(onDraftChange).toHaveBeenCalledOnce()
+    expect(onDraftChange).toHaveBeenLastCalledWith([
+      { fieldId: 'question_0', value: 'multi-omics' }
+    ])
     expect(container.querySelector('h3')?.textContent).toBe('Which language should the skill use?')
     expect(
       container.querySelector('[data-testid="elicitation-question-progress"]')?.textContent
@@ -273,9 +275,9 @@ describe('WorkspaceElicitationCard choice question', () => {
     })
 
     expect(onRespond).not.toHaveBeenCalled()
+    expect(onDraftChange).toHaveBeenCalledOnce()
     expect(onDraftChange).toHaveBeenLastCalledWith([
-      { fieldId: 'question_0', value: 'multi-omics' },
-      { fieldId: 'question_1', value: 'chinese' }
+      { fieldId: 'question_0', value: 'multi-omics' }
     ])
     const finish = Array.from(container.querySelectorAll('button')).find(
       (button) => button.textContent?.trim() === 'Finish'

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
@@ -305,6 +305,10 @@ describe('WorkspaceElicitationCard choice question', () => {
     )
     expect(next?.querySelector('svg.lucide-chevron-right')).not.toBeNull()
     await act(async () => next?.click())
+    expect(onDraftChange).toHaveBeenCalledTimes(2)
+    expect(onDraftChange).toHaveBeenLastCalledWith([
+      { fieldId: 'question_0', value: 'multi-omics' }
+    ])
     expect(
       container.querySelector('[data-testid="elicitation-question-progress"]')?.textContent
     ).toBe('2 of 2')

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
@@ -153,6 +153,7 @@ const WorkspaceElicitationCard = ({
   const [values, setValues] = useState<Record<string, ElicitationValue | undefined>>(
     () => restoredValues
   )
+  const [confirmedValues, setConfirmedValues] = useState(() => restoredValues)
   const [activeChoiceIndex, setActiveChoiceIndex] = useState(() =>
     choiceQuestions ? firstUnansweredQuestionIndex(choiceQuestions, restoredValues) : 0
   )
@@ -242,7 +243,13 @@ const WorkspaceElicitationCard = ({
     if (!request || !choiceQuestions || !choiceQuestion || !currentChoiceAnswer) return
 
     if (!isFinalChoiceQuestion) {
-      onDraftChange?.(completedChoiceAnswers)
+      const nextConfirmedValues = {
+        ...confirmedValues,
+        [choiceQuestion.choiceField.id]: values[choiceQuestion.choiceField.id],
+        [choiceQuestion.customField.id]: values[choiceQuestion.customField.id]
+      }
+      setConfirmedValues(nextConfirmedValues)
+      onDraftChange?.(choiceAnswers(choiceQuestions, nextConfirmedValues))
       setActiveChoiceIndex((index) => index + 1)
       setError(undefined)
       return

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
@@ -283,7 +283,6 @@ const WorkspaceElicitationCard = ({
       }
       setValues(nextValues)
       setError(undefined)
-      onDraftChange?.(choiceAnswers(choiceQuestions, nextValues))
       return
     }
 
@@ -293,11 +292,8 @@ const WorkspaceElicitationCard = ({
       [choiceQuestion.customField.id]: undefined,
       [answer.fieldId]: answer.value
     }
-    const nextAnswers = choiceAnswers(choiceQuestions, nextValues)
     setValues(nextValues)
     setError(undefined)
-
-    onDraftChange?.(nextAnswers)
   }
 
   return (


### PR DESCRIPTION
## Problem

Selecting an option in a multi-question Ask User card persisted that answer immediately. Draft restoration treats persisted answers as completed steps, so a projection refresh could advance to the next question before the user clicked Next.

## Proposed change

Keep the current question answer local while the user selects or edits it. Persist completed choice answers only through the existing Next submit path.

## Scope and non-goals

This changes only the Ask User choice confirmation boundary and its interaction regression test. It does not change card styling, final submission, or restored draft behavior.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- WorkspaceElicitationCard interaction tests: 14 passed.
- ConversationPanel interaction tests: 77 passed.
- Web and Node typechecks: passed.
- Lint: passed with 0 errors and 17 pre-existing warnings.
- Full portable Vitest: 13,282 passed and 193 skipped. Seven resource-contention timeouts passed when rerun at low concurrency. One unrelated existing failure remains in project prisma client: PermissionGrantSeed runtime DDL is missing id and appliedAt.

Uncovered risk: the complete local suite is not fully green because of that existing Prisma schema baseline failure; exact-head CI remains authoritative.

## Review focus

Confirm that option clicks no longer invoke the draft completion callback and that Next remains the only non-final action that persists and advances a question.