### PR TITLE
feat(host): add artifact lineage access

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -976,7 +976,7 @@ async function hostMcp(server, method, args = undefined, kwargs = undefined) {
   return body.result
 }
 
-const HOST_CAPABILITY_NAMES = ['mcp', 'compute', 'agents', 'skills', 'artifacts']
+const HOST_CAPABILITY_NAMES = ['mcp', 'compute', 'agents', 'skills', 'artifacts', 'lineage']
 
 async function hostCapabilities(...args) {
   if (args.length !== 0) throw new TypeError('host.capabilities accepts no arguments')
@@ -1108,6 +1108,690 @@ async function hostArtifactPath(versionId) {
   }
   return result
 }
+
+async function lineageRpc(op, params) {
+  if (!RPC_ENDPOINT) throw new Error('host.lineage is unavailable: RPC endpoint not set')
+  const res = await capturedRpcFetch(RPC_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
+    body: JSON.stringify({ method: 'lineageCall', params: { op, ...params } })
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok || body.error) {
+    throw new Error(`host.lineage.${op}: ${body.error || 'HTTP ' + res.status}`)
+  }
+  return body.result
+}
+
+const isHostLineageRecord = (value) =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+const hasHostLineageKeys = (value, required, optional = []) => {
+  if (!isHostLineageRecord(value)) return false
+  const allowed = new Set([...required, ...optional])
+  const keys = Object.keys(value)
+  return required.every((key) => keys.includes(key)) && keys.every((key) => allowed.has(key))
+}
+
+const validatedHostLineageNode = (value) => {
+  const required = [
+    'file_id',
+    'version_id',
+    'filename',
+    'version_number',
+    'session_id',
+    'root_frame_id',
+    'agent_frame_id',
+    'created_at',
+    'size_bytes',
+    'checksum',
+    'is_user_upload'
+  ]
+  if (
+    !hasHostLineageKeys(value, required, ['content_type']) ||
+    ![
+      value.file_id,
+      value.version_id,
+      value.filename,
+      value.session_id,
+      value.created_at,
+      value.checksum
+    ].every((entry) => typeof entry === 'string' && entry.length > 0) ||
+    !Number.isSafeInteger(value.version_number) ||
+    value.version_number < 1 ||
+    !Number.isSafeInteger(value.size_bytes) ||
+    value.size_bytes < 0 ||
+    (value.root_frame_id !== null && typeof value.root_frame_id !== 'string') ||
+    (value.agent_frame_id !== null && typeof value.agent_frame_id !== 'string') ||
+    (value.content_type !== undefined && typeof value.content_type !== 'string') ||
+    typeof value.is_user_upload !== 'boolean'
+  ) {
+    throw new Error('host.lineage.graph returned an invalid node')
+  }
+  return Object.freeze(
+    Object.fromEntries(
+      [...required, 'content_type']
+        .filter((key) => value[key] !== undefined)
+        .map((key) => [key, value[key]])
+    )
+  )
+}
+
+const validatedHostLineageEdge = (value) => {
+  const required = [
+    'version_id',
+    'depends_on_version_id',
+    'ordinal',
+    'source_kind',
+    'input_filename',
+    'association'
+  ]
+  if (
+    !hasHostLineageKeys(value, required) ||
+    ![value.version_id, value.depends_on_version_id, value.input_filename].every(
+      (entry) => typeof entry === 'string' && entry.length > 0
+    ) ||
+    !Number.isSafeInteger(value.ordinal) ||
+    value.ordinal < 0 ||
+    !['artifact-version', 'upload-version'].includes(value.source_kind) ||
+    !['turn-attached', 'resolver-accessed'].includes(value.association)
+  ) {
+    throw new Error('host.lineage.graph returned an invalid edge')
+  }
+  return Object.freeze(Object.fromEntries(required.map((key) => [key, value[key]])))
+}
+
+const validatedHostLineageGraph = (value) => {
+  const required = ['project_id', 'root_version_id', 'direction', 'truncated', 'nodes', 'edges']
+  const optional = ['truncation_reason', 'frontier_version_ids']
+  if (
+    !hasHostLineageKeys(value, required, optional) ||
+    typeof value.project_id !== 'string' ||
+    typeof value.root_version_id !== 'string' ||
+    !['up', 'down'].includes(value.direction) ||
+    typeof value.truncated !== 'boolean' ||
+    !Array.isArray(value.nodes) ||
+    !Array.isArray(value.edges) ||
+    (value.truncated
+      ? !['max_depth', 'max_nodes'].includes(value.truncation_reason) ||
+        !Array.isArray(value.frontier_version_ids) ||
+        value.frontier_version_ids.length === 0 ||
+        value.frontier_version_ids.some((entry) => typeof entry !== 'string' || !entry)
+      : value.truncation_reason !== undefined || value.frontier_version_ids !== undefined)
+  ) {
+    throw new Error('host.lineage.graph returned an invalid result')
+  }
+  const nodes = Object.freeze(value.nodes.map(validatedHostLineageNode))
+  const edges = Object.freeze(value.edges.map(validatedHostLineageEdge))
+  const frontier = value.frontier_version_ids
+    ? Object.freeze([...value.frontier_version_ids])
+    : undefined
+  return Object.freeze({
+    project_id: value.project_id,
+    root_version_id: value.root_version_id,
+    direction: value.direction,
+    truncated: value.truncated,
+    ...(value.truncation_reason ? { truncation_reason: value.truncation_reason } : {}),
+    ...(frontier ? { frontier_version_ids: frontier } : {}),
+    nodes,
+    edges
+  })
+}
+
+const HOST_LINEAGE_UNAVAILABLE_REASONS = [
+  'producer-not-supplied',
+  'producer-source-unverifiable',
+  'environment-not-supported',
+  'environment-capture-failed',
+  'environment-manifest-publication-failed',
+  'legacy-environment-reference-unavailable'
+]
+const HOST_LINEAGE_ATTEMPT_REASONS = [
+  'package-not-found',
+  'solver-failed',
+  'installer-unavailable',
+  'permission',
+  'network',
+  'authentication',
+  'tls-policy',
+  'validation',
+  'cancelled',
+  'process-unconfirmed',
+  'recovery-blocked',
+  'unknown'
+]
+
+const validatedHostLineageAvailability = (value) => {
+  if (
+    !isHostLineageRecord(value) ||
+    (value.state === 'unavailable'
+      ? !hasHostLineageKeys(value, ['state', 'reason']) ||
+        !HOST_LINEAGE_UNAVAILABLE_REASONS.includes(value.reason)
+      : !hasHostLineageKeys(value, ['state']) || !['available', 'partial'].includes(value.state))
+  ) {
+    throw new Error('host.lineage.get returned an invalid availability projection')
+  }
+  return Object.freeze(
+    value.state === 'unavailable'
+      ? { state: value.state, reason: value.reason }
+      : { state: value.state }
+  )
+}
+
+const validatedHostLineageProducer = (value) => {
+  if (value?.state === 'unavailable') {
+    if (
+      !hasHostLineageKeys(value, ['state', 'reason']) ||
+      !['producer-not-supplied', 'producer-source-unverifiable'].includes(value.reason)
+    ) {
+      throw new Error('host.lineage.get returned an invalid producer projection')
+    }
+    return Object.freeze({ state: value.state, reason: value.reason })
+  }
+  const required = [
+    'state',
+    'notebook_session_id',
+    'producer_run_id',
+    'run_index',
+    'kernel_kind',
+    'association_method'
+  ]
+  if (
+    !hasHostLineageKeys(value, required, ['environment_manifest_checksum']) ||
+    value.state !== 'available' ||
+    typeof value.notebook_session_id !== 'string' ||
+    typeof value.producer_run_id !== 'string' ||
+    !Number.isSafeInteger(value.run_index) ||
+    value.run_index < 0 ||
+    !['python', 'r', 'repl', 'bash'].includes(value.kernel_kind) ||
+    !['agent-declared-and-session-validated', 'server-inferred-file-observation'].includes(
+      value.association_method
+    ) ||
+    (value.environment_manifest_checksum !== undefined &&
+      typeof value.environment_manifest_checksum !== 'string')
+  ) {
+    throw new Error('host.lineage.get returned an invalid producer projection')
+  }
+  return Object.freeze(
+    Object.fromEntries(
+      [...required, 'environment_manifest_checksum']
+        .filter((key) => value[key] !== undefined)
+        .map((key) => [key, value[key]])
+    )
+  )
+}
+
+const validatedHostLineageEnvironment = (value) => {
+  const required = [
+    'capture_kind',
+    'environment_name',
+    'kernel_kind',
+    'runtime_source',
+    'packages',
+    'inventory_sources',
+    'installed_inventory',
+    'captured_at',
+    'source_manifest_checksum',
+    'complete',
+    'capture_status'
+  ]
+  const optional = [
+    'runtime_version',
+    'platform',
+    'architecture',
+    'python_version',
+    'r_version',
+    'op_log',
+    'op_log_truncation',
+    'warnings'
+  ]
+  const optionalStrings = [
+    'runtime_version',
+    'platform',
+    'architecture',
+    'python_version',
+    'r_version'
+  ]
+  if (
+    !hasHostLineageKeys(value, required, optional) ||
+    value.capture_kind !== 'completed-run' ||
+    typeof value.environment_name !== 'string' ||
+    !['python', 'r'].includes(value.kernel_kind) ||
+    !['managed', 'external'].includes(value.runtime_source) ||
+    optionalStrings.some((key) => value[key] !== undefined && typeof value[key] !== 'string') ||
+    !Array.isArray(value.packages) ||
+    !Array.isArray(value.inventory_sources) ||
+    value.inventory_sources.some(
+      (entry) => !['kernel-native', 'interpreter-native', 'operation-log'].includes(entry)
+    ) ||
+    !hasHostLineageKeys(value.installed_inventory, ['captured_at', 'source', 'validation']) ||
+    typeof value.installed_inventory.captured_at !== 'string' ||
+    !['full-scan', 'cache-reused'].includes(value.installed_inventory.source) ||
+    !['full-scan', 'best-effort'].includes(value.installed_inventory.validation) ||
+    typeof value.captured_at !== 'string' ||
+    typeof value.source_manifest_checksum !== 'string' ||
+    typeof value.complete !== 'boolean' ||
+    !['complete', 'partial'].includes(value.capture_status) ||
+    (value.warnings !== undefined &&
+      (!Array.isArray(value.warnings) || value.warnings.some((entry) => typeof entry !== 'string')))
+  ) {
+    throw new Error('host.lineage.get returned an invalid environment projection')
+  }
+  const packages = Object.freeze(
+    value.packages.map((entry) => {
+      const packageRequired = [
+        'name',
+        'version_status',
+        'ecosystem',
+        'evidence_sources',
+        'loaded_state'
+      ]
+      const packageOptional = [
+        'version',
+        'library_rank',
+        'library_scope',
+        'built_for_runtime',
+        'priority'
+      ]
+      if (
+        !hasHostLineageKeys(entry, packageRequired, packageOptional) ||
+        typeof entry.name !== 'string' ||
+        (entry.version !== undefined && typeof entry.version !== 'string') ||
+        !['known', 'unavailable'].includes(entry.version_status) ||
+        !['python', 'r', 'native', 'unknown'].includes(entry.ecosystem) ||
+        !Array.isArray(entry.evidence_sources) ||
+        entry.evidence_sources.some(
+          (source) =>
+            ![
+              'python-importlib-metadata',
+              'python-kernel-modules',
+              'r-installed-packages',
+              'r-session-info'
+            ].includes(source)
+        ) ||
+        !['attached', 'loaded', 'installed-only', 'unknown'].includes(entry.loaded_state) ||
+        (entry.library_rank !== undefined && !Number.isSafeInteger(entry.library_rank)) ||
+        (entry.library_scope !== undefined &&
+          !['environment', 'user', 'system', 'unknown'].includes(entry.library_scope)) ||
+        (entry.built_for_runtime !== undefined && typeof entry.built_for_runtime !== 'string') ||
+        (entry.priority !== undefined && !['base', 'recommended', 'other'].includes(entry.priority))
+      ) {
+        throw new Error('host.lineage.get returned an invalid environment package')
+      }
+      return Object.freeze({
+        name: entry.name,
+        ...(entry.version !== undefined ? { version: entry.version } : {}),
+        version_status: entry.version_status,
+        ecosystem: entry.ecosystem,
+        evidence_sources: Object.freeze([...entry.evidence_sources]),
+        loaded_state: entry.loaded_state,
+        ...(entry.library_rank !== undefined ? { library_rank: entry.library_rank } : {}),
+        ...(entry.library_scope !== undefined ? { library_scope: entry.library_scope } : {}),
+        ...(entry.built_for_runtime !== undefined
+          ? { built_for_runtime: entry.built_for_runtime }
+          : {}),
+        ...(entry.priority !== undefined ? { priority: entry.priority } : {})
+      })
+    })
+  )
+  if (value.op_log !== undefined && !Array.isArray(value.op_log)) {
+    throw new Error('host.lineage.get returned an invalid environment operation log')
+  }
+  const opLog = value.op_log
+    ? Object.freeze(
+        value.op_log.map((entry) => {
+          const operationRequired = [
+            'operation_id',
+            'timestamp',
+            'operation',
+            'packages',
+            'result',
+            'attempts',
+            'fallback_used',
+            'inventory_refresh',
+            'inventory_refresh_attempts'
+          ]
+          if (
+            !hasHostLineageKeys(entry, operationRequired, ['package_changes']) ||
+            typeof entry.operation_id !== 'string' ||
+            typeof entry.timestamp !== 'string' ||
+            !['create', 'install', 'uninstall', 'update'].includes(entry.operation) ||
+            !Array.isArray(entry.packages) ||
+            entry.packages.some((item) => typeof item !== 'string') ||
+            !['success', 'failure'].includes(entry.result) ||
+            !Array.isArray(entry.attempts) ||
+            typeof entry.fallback_used !== 'boolean' ||
+            !['published', 'unchanged', 'failed'].includes(entry.inventory_refresh) ||
+            !Array.isArray(entry.inventory_refresh_attempts) ||
+            (entry.package_changes !== undefined && !Array.isArray(entry.package_changes))
+          ) {
+            throw new Error('host.lineage.get returned an invalid environment operation')
+          }
+          const attempts = Object.freeze(
+            entry.attempts.map((attempt) => {
+              const attemptRequired = [
+                'group_ordinal',
+                'installer',
+                'packages',
+                'status',
+                'mutation_risk'
+              ]
+              if (
+                !hasHostLineageKeys(attempt, attemptRequired, ['reason']) ||
+                !Number.isSafeInteger(attempt.group_ordinal) ||
+                ![
+                  'conda',
+                  'pip',
+                  'uv',
+                  'poetry',
+                  'r-install-packages',
+                  'renv',
+                  'pak',
+                  'biocmanager',
+                  'unknown'
+                ].includes(attempt.installer) ||
+                !Array.isArray(attempt.packages) ||
+                attempt.packages.some((item) => typeof item !== 'string') ||
+                !['succeeded', 'failed', 'skipped'].includes(attempt.status) ||
+                !['none', 'possible', 'confirmed', 'unknown'].includes(attempt.mutation_risk) ||
+                (attempt.reason !== undefined &&
+                  !HOST_LINEAGE_ATTEMPT_REASONS.includes(attempt.reason))
+              ) {
+                throw new Error('host.lineage.get returned an invalid environment attempt')
+              }
+              return Object.freeze({
+                group_ordinal: attempt.group_ordinal,
+                installer: attempt.installer,
+                packages: Object.freeze([...attempt.packages]),
+                status: attempt.status,
+                mutation_risk: attempt.mutation_risk,
+                ...(attempt.reason !== undefined ? { reason: attempt.reason } : {})
+              })
+            })
+          )
+          const refreshAttempts = Object.freeze(
+            entry.inventory_refresh_attempts.map((attempt) => {
+              if (
+                !hasHostLineageKeys(
+                  attempt,
+                  ['attempt', 'trigger', 'timestamp', 'result'],
+                  ['error']
+                ) ||
+                !Number.isSafeInteger(attempt.attempt) ||
+                !['terminal', 'recovery'].includes(attempt.trigger) ||
+                typeof attempt.timestamp !== 'string' ||
+                !['published', 'unchanged', 'failed'].includes(attempt.result) ||
+                (attempt.error !== undefined && typeof attempt.error !== 'string')
+              ) {
+                throw new Error('host.lineage.get returned an invalid inventory refresh attempt')
+              }
+              return Object.freeze({
+                attempt: attempt.attempt,
+                trigger: attempt.trigger,
+                timestamp: attempt.timestamp,
+                result: attempt.result,
+                ...(attempt.error !== undefined ? { error: attempt.error } : {})
+              })
+            })
+          )
+          const packageChanges = entry.package_changes
+            ? Object.freeze(
+                entry.package_changes.map((change) => {
+                  const changeRequired = ['name', 'ecosystem', 'relationship', 'change']
+                  const changeOptional = [
+                    'before_version',
+                    'after_version',
+                    'library_rank',
+                    'library_scope'
+                  ]
+                  if (
+                    !hasHostLineageKeys(change, changeRequired, changeOptional) ||
+                    typeof change.name !== 'string' ||
+                    !['python', 'r', 'native', 'unknown'].includes(change.ecosystem) ||
+                    !['requested', 'dependency', 'unattributed'].includes(change.relationship) ||
+                    !['installed', 'updated', 'removed', 'unchanged', 'observed'].includes(
+                      change.change
+                    ) ||
+                    (change.before_version !== undefined &&
+                      typeof change.before_version !== 'string') ||
+                    (change.after_version !== undefined &&
+                      typeof change.after_version !== 'string') ||
+                    (change.library_rank !== undefined &&
+                      !Number.isSafeInteger(change.library_rank)) ||
+                    (change.library_scope !== undefined &&
+                      !['environment', 'user', 'system', 'unknown'].includes(change.library_scope))
+                  ) {
+                    throw new Error('host.lineage.get returned an invalid package change')
+                  }
+                  return Object.freeze(
+                    Object.fromEntries(
+                      [...changeRequired, ...changeOptional]
+                        .filter((key) => change[key] !== undefined)
+                        .map((key) => [key, change[key]])
+                    )
+                  )
+                })
+              )
+            : undefined
+          return Object.freeze({
+            operation_id: entry.operation_id,
+            timestamp: entry.timestamp,
+            operation: entry.operation,
+            packages: Object.freeze([...entry.packages]),
+            result: entry.result,
+            attempts,
+            fallback_used: entry.fallback_used,
+            inventory_refresh: entry.inventory_refresh,
+            inventory_refresh_attempts: refreshAttempts,
+            ...(packageChanges ? { package_changes: packageChanges } : {})
+          })
+        })
+      )
+    : undefined
+  let opLogTruncation
+  if (value.op_log_truncation !== undefined) {
+    if (
+      !hasHostLineageKeys(value.op_log_truncation, ['omitted_count'], ['earliest_retained_at']) ||
+      !Number.isSafeInteger(value.op_log_truncation.omitted_count) ||
+      value.op_log_truncation.omitted_count <= 0 ||
+      (value.op_log_truncation.earliest_retained_at !== undefined &&
+        typeof value.op_log_truncation.earliest_retained_at !== 'string')
+    ) {
+      throw new Error('host.lineage.get returned an invalid operation-log truncation')
+    }
+    opLogTruncation = Object.freeze({
+      omitted_count: value.op_log_truncation.omitted_count,
+      ...(value.op_log_truncation.earliest_retained_at
+        ? { earliest_retained_at: value.op_log_truncation.earliest_retained_at }
+        : {})
+    })
+  }
+  return Object.freeze({
+    capture_kind: value.capture_kind,
+    environment_name: value.environment_name,
+    kernel_kind: value.kernel_kind,
+    runtime_source: value.runtime_source,
+    ...Object.fromEntries(
+      optionalStrings.filter((key) => value[key] !== undefined).map((key) => [key, value[key]])
+    ),
+    packages,
+    inventory_sources: Object.freeze([...value.inventory_sources]),
+    installed_inventory: Object.freeze({
+      captured_at: value.installed_inventory.captured_at,
+      source: value.installed_inventory.source,
+      validation: value.installed_inventory.validation
+    }),
+    ...(opLog ? { op_log: opLog } : {}),
+    ...(opLogTruncation ? { op_log_truncation: opLogTruncation } : {}),
+    captured_at: value.captured_at,
+    source_manifest_checksum: value.source_manifest_checksum,
+    complete: value.complete,
+    capture_status: value.capture_status,
+    ...(value.warnings ? { warnings: Object.freeze([...value.warnings]) } : {})
+  })
+}
+
+const validatedHostLineageInput = (value) => {
+  const required = [
+    'ordinal',
+    'version_id',
+    'file_id',
+    'source_kind',
+    'session_id',
+    'filename',
+    'size_bytes',
+    'checksum',
+    'association'
+  ]
+  const optional = ['version_number', 'created_at', 'content_type']
+  if (
+    !hasHostLineageKeys(value, required, optional) ||
+    !Number.isSafeInteger(value.ordinal) ||
+    value.ordinal < 0 ||
+    ![value.version_id, value.file_id, value.session_id, value.filename, value.checksum].every(
+      (entry) => typeof entry === 'string' && entry.length > 0
+    ) ||
+    !['artifact-version', 'upload-version'].includes(value.source_kind) ||
+    !Number.isSafeInteger(value.size_bytes) ||
+    value.size_bytes < 0 ||
+    !['turn-attached', 'resolver-accessed'].includes(value.association) ||
+    (value.version_number !== undefined &&
+      (!Number.isSafeInteger(value.version_number) || value.version_number < 1)) ||
+    (value.created_at !== undefined && typeof value.created_at !== 'string') ||
+    (value.content_type !== undefined && typeof value.content_type !== 'string')
+  ) {
+    throw new Error('host.lineage.get returned an invalid input')
+  }
+  return Object.freeze(
+    Object.fromEntries(
+      [...required, ...optional]
+        .filter((key) => value[key] !== undefined)
+        .map((key) => [key, value[key]])
+    )
+  )
+}
+
+const validatedHostLineageVersion = (value) => {
+  const required = [
+    'project_id',
+    'artifact_id',
+    'version_id',
+    'filename',
+    'version_number',
+    'session_id',
+    'root_frame_id',
+    'agent_frame_id',
+    'message_branch_id',
+    'runtime_segment_id',
+    'prompt_message_id',
+    'created_at',
+    'size_bytes',
+    'checksum',
+    'content_status',
+    'execution_status',
+    'producer',
+    'environment_status',
+    'inputs'
+  ]
+  const optional = ['content_type', 'agent_name', 'reproduction_code', 'environment']
+  const stringKeys = [
+    'project_id',
+    'artifact_id',
+    'version_id',
+    'filename',
+    'session_id',
+    'root_frame_id',
+    'agent_frame_id',
+    'message_branch_id',
+    'runtime_segment_id',
+    'prompt_message_id',
+    'created_at',
+    'checksum'
+  ]
+  if (
+    !hasHostLineageKeys(value, required, optional) ||
+    stringKeys.some((key) => typeof value[key] !== 'string' || !value[key]) ||
+    !Number.isSafeInteger(value.version_number) ||
+    value.version_number < 1 ||
+    !Number.isSafeInteger(value.size_bytes) ||
+    value.size_bytes < 0 ||
+    ['content_type', 'agent_name', 'reproduction_code'].some(
+      (key) => value[key] !== undefined && typeof value[key] !== 'string'
+    ) ||
+    !Array.isArray(value.inputs)
+  ) {
+    throw new Error('host.lineage.get returned an invalid result')
+  }
+  let contentStatus
+  if (
+    value.content_status?.state === 'available' &&
+    hasHostLineageKeys(value.content_status, ['state'])
+  ) {
+    contentStatus = Object.freeze({ state: 'available' })
+  } else if (
+    value.content_status?.state === 'unavailable' &&
+    hasHostLineageKeys(value.content_status, ['state', 'reason']) &&
+    ['missing', 'checksum-mismatch'].includes(value.content_status.reason)
+  ) {
+    contentStatus = Object.freeze({
+      state: 'unavailable',
+      reason: value.content_status.reason
+    })
+  } else {
+    throw new Error('host.lineage.get returned an invalid content status')
+  }
+  const inputs = Object.freeze(value.inputs.map(validatedHostLineageInput))
+  const environment = value.environment
+    ? validatedHostLineageEnvironment(value.environment)
+    : undefined
+  return Object.freeze({
+    ...Object.fromEntries(
+      [
+        'project_id',
+        'artifact_id',
+        'version_id',
+        'filename',
+        'version_number',
+        'session_id',
+        'root_frame_id',
+        'agent_frame_id',
+        'message_branch_id',
+        'runtime_segment_id',
+        'prompt_message_id',
+        'created_at',
+        'content_type',
+        'size_bytes',
+        'checksum',
+        'agent_name'
+      ]
+        .filter((key) => value[key] !== undefined)
+        .map((key) => [key, value[key]])
+    ),
+    content_status: contentStatus,
+    ...(value.reproduction_code !== undefined
+      ? { reproduction_code: value.reproduction_code }
+      : {}),
+    execution_status: validatedHostLineageAvailability(value.execution_status),
+    producer: validatedHostLineageProducer(value.producer),
+    environment_status: validatedHostLineageAvailability(value.environment_status),
+    ...(environment ? { environment } : {}),
+    inputs
+  })
+}
+
+async function hostLineageGraph(versionId, options = {}) {
+  if (arguments.length < 1 || arguments.length > 2) {
+    throw new TypeError('host.lineage.graph accepts version_id and at most one options object')
+  }
+  return validatedHostLineageGraph(await lineageRpc('graph', { version_id: versionId, options }))
+}
+
+async function hostLineageGet(versionId) {
+  if (arguments.length !== 1) throw new TypeError('host.lineage.get accepts one version_id')
+  return validatedHostLineageVersion(await lineageRpc('get', { version_id: versionId }))
+}
+
+const hostLineage = Object.freeze({ graph: hostLineageGraph, get: hostLineageGet })
 
 // host.compute: async remote-compute calls over the SAME app-local RPC endpoint as host.mcp, routed to
 // the main-process ComputeService via {method:'computeCall'}. Like host.mcp, this is only injected in
@@ -1409,6 +2093,7 @@ const sandbox = {
     capabilities: hostCapabilities,
     artifacts: hostArtifacts,
     artifact_path: hostArtifactPath,
+    lineage: hostLineage,
     mcp: hostMcp,
     compute: hostCompute,
     agents: hostAgents,

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -14,13 +14,14 @@ JavaScript control REPL; Python and R data kernels do not receive it.
 const caps = await host.capabilities()
 ```
 
-The v1 result contains exactly five boolean keys:
+The v1 result contains exactly six boolean keys:
 
 - `mcp` gates `host.mcp` connector calls.
 - `compute` gates the `host.compute` namespace.
 - `agents` gates the `host.agents` namespace.
 - `skills` gates the `host.skills` namespace.
 - `artifacts` gates `host.artifacts` and `host.artifact_path`.
+- `lineage` gates the read-only `host.lineage` namespace.
 
 Interpret the result narrowly:
 
@@ -63,7 +64,37 @@ generated Artifact Version or Upload Version, then use the existing file workflo
 collisions, missing Versions, cross-Project ownership, and checksum mismatches fail closed.
 
 The public result is a fresh frozen projection. It does not expose fuzzy scores, storage keys,
-lineage, provenance, markers, or a content-read API.
+markers, or a content-read API.
+
+## Read immutable Version lineage
+
+When `caps.lineage === true`, start with
+`await host.lineage.graph(versionId, options)` to inspect the dependency graph without reading
+Artifact content. `options` accepts only `direction` (`'up'` by default or `'down'`), `max_depth`
+(default 5, maximum 20), and `max_nodes` (default 100, maximum 500). Graphs use stable BFS order;
+an Upload is an upstream leaf and may be a downstream root. A truncated result includes a reason
+and `frontier_version_ids` for a narrower follow-up query.
+
+```javascript
+const caps = await host.capabilities()
+if (caps.lineage === true) {
+  const graph = await host.lineage.graph(versionId)
+  const generated = graph.nodes.find((node) => !node.is_user_upload)
+  const provenance = generated ? await host.lineage.get(generated.version_id) : undefined
+}
+```
+
+Use `await host.lineage.get(versionId)` only for a generated Artifact Version after graph discovery.
+It returns the existing immutable core provenance projection: reproduction code when available,
+producer and environment status/evidence, and typed input Version evidence. Upload Versions are
+rejected by `get`; obtain their metadata with `host.artifacts({ version_id: versionId })`.
+
+Both calls are fresh, frozen reads scoped only by the session-bound control token to the current
+Project, including Versions created in another Session of that Project. They never accept Project or
+Session scope fields, create extraction work, or return content, messages, full execution outputs,
+reviews, paths, storage keys, Bearer tokens, or internal routes. Missing or ambiguous identities,
+cross-Project edges, and corrupt evidence fail closed. There is no indexed property, `clear()`,
+client cache, Python/R `host`, or lineage API outside the JavaScript control REPL.
 
 ## Continue with the owning Skill
 

--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -540,6 +540,8 @@
     "artifact_provenance": {
       "ownerPaths": [
         "src/main/artifacts/provenance-canonical.ts",
+        "src/main/artifacts/provenance-core-evidence.ts",
+        "src/main/artifacts/provenance-dependency-reader.ts",
         "src/main/artifacts/provenance-execution-evidence.ts",
         "src/main/artifacts/provenance-finalization-recovery.ts",
         "src/main/artifacts/provenance-message-finalization.ts",
@@ -559,6 +561,7 @@
       "consumerModules": ["session_persistence"],
       "testFiles": {
         "owner": [
+          "src/main/artifacts/provenance-dependency-read.test.ts",
           "src/main/artifacts/provenance-lifecycle-contract.test.ts",
           "src/main/artifacts/provenance-message-snapshot.test.ts",
           "src/main/artifacts/provenance-repository.architecture.test.ts",

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -663,6 +663,7 @@ describe('ACP session capability owner', () => {
     ])
     expect(primary.descriptor.controlRpcMethods).toEqual([
       'capabilitiesCall',
+      'lineageCall',
       'mcpCall',
       'computeCall',
       'agentsCall',
@@ -684,7 +685,7 @@ describe('ACP session capability owner', () => {
     ['codex-response', codexFramework, true, false],
     ['codex-bridge', codexFramework, false, true]
   ] as const)(
-    'publishes capabilitiesCall through the %s primary control descriptor',
+    'publishes host capability and lineage reads through the %s primary control descriptor',
     async (_route, framework, nativeMcpEnabled, bridgeMcpAliasesEnabled) => {
       const owner = createOwner()
       const built = await owner.provision({
@@ -698,6 +699,7 @@ describe('ACP session capability owner', () => {
       })
 
       expect(built.descriptor.controlRpcMethods).toContain('capabilitiesCall')
+      expect(built.descriptor.controlRpcMethods).toContain('lineageCall')
     }
   )
 

--- a/src/main/acp/session-capability-owner.ts
+++ b/src/main/acp/session-capability-owner.ts
@@ -46,6 +46,7 @@ const CURRENT_PRIMARY_CAPABILITIES = [
 ] as const
 const NOTEBOOK_CONTROL_RPC_METHODS = [
   'capabilitiesCall',
+  'lineageCall',
   'mcpCall',
   'computeCall',
   'agentsCall',

--- a/src/main/artifacts/provenance-core-evidence.ts
+++ b/src/main/artifacts/provenance-core-evidence.ts
@@ -1,0 +1,109 @@
+import type { Prisma } from '@prisma/client'
+
+import type { ArtifactVersionEvidence } from '../../shared/artifact-provenance'
+
+type CoreEvidenceVersion = Prisma.ArtifactVersionGetPayload<{
+  include: { artifact: true; inputs: true }
+}>
+
+const ENVIRONMENT_UNAVAILABLE_REASONS = new Set([
+  'environment-not-supported',
+  'environment-capture-failed',
+  'environment-manifest-publication-failed',
+  'legacy-environment-reference-unavailable'
+])
+
+const inputMatches = (
+  evidence: ArtifactVersionEvidence['inputs'][number],
+  row: CoreEvidenceVersion['inputs'][number],
+  ordinal: number
+): boolean =>
+  evidence.ordinal === ordinal &&
+  row.ordinal === ordinal &&
+  evidence.input_file_version_id === row.inputFileVersionId &&
+  evidence.source_kind === row.sourceKind &&
+  evidence.source_file_id === row.sourceFileId &&
+  evidence.source_version_number === (row.sourceVersionNumber ?? undefined) &&
+  evidence.source_created_at === row.sourceCreatedAt?.toISOString() &&
+  evidence.source_project_id === row.sourceProjectId &&
+  evidence.source_session_id === row.sourceSessionId &&
+  evidence.filename === row.filename &&
+  evidence.content_type === (row.contentType ?? undefined) &&
+  Number.isSafeInteger(evidence.size_bytes) &&
+  evidence.size_bytes === Number(row.sizeBytes) &&
+  evidence.checksum === row.checksum &&
+  evidence.storage_key === row.storageKey &&
+  evidence.strongest_association === row.strongestAssociation
+
+const validateArtifactCoreEvidence = (
+  evidence: ArtifactVersionEvidence,
+  version: CoreEvidenceVersion
+): void => {
+  const producer = evidence.producer
+  const producerValid =
+    version.producerRunId === null
+      ? version.notebookSessionId === null &&
+        version.producerRunIndex === null &&
+        version.executionSnapshotChecksum === null &&
+        evidence.execution_snapshot_checksum === undefined &&
+        evidence.reproduction_code === undefined &&
+        producer.state === 'unavailable' &&
+        evidence.execution_status.state === 'unavailable' &&
+        evidence.execution_status.reason === producer.reason &&
+        evidence.inputs.length === 0
+      : producer.state === 'available' &&
+        producer.notebook_session_id === version.notebookSessionId &&
+        producer.producer_run_id === version.producerRunId &&
+        producer.run_index === version.producerRunIndex &&
+        evidence.execution_status.state === 'available' &&
+        evidence.execution_snapshot_checksum === version.executionSnapshotChecksum &&
+        typeof evidence.reproduction_code === 'string'
+  const environmentValid = evidence.environment
+    ? producer.state === 'available' &&
+      producer.environment_manifest_checksum === evidence.environment.source_manifest_checksum &&
+      evidence.environment_status.state ===
+        (evidence.environment.capture_status === 'complete' ? 'available' : 'partial') &&
+      evidence.environment.complete === (evidence.environment.capture_status === 'complete')
+    : evidence.environment_status.state === 'unavailable' &&
+      (producer.state === 'unavailable'
+        ? evidence.environment_status.reason === producer.reason
+        : producer.environment_manifest_checksum === undefined &&
+          ENVIRONMENT_UNAVAILABLE_REASONS.has(evidence.environment_status.reason))
+  const inputsValid =
+    evidence.inputs.length === version.inputs.length &&
+    evidence.inputs.every((input, ordinal) => {
+      const row = version.inputs[ordinal]
+      return row !== undefined && inputMatches(input, row, ordinal)
+    })
+  const sizeBytes = Number(version.sizeBytes)
+
+  if (
+    evidence.schema_version !== 1 ||
+    evidence.project_id !== version.artifact.projectId ||
+    evidence.app_session_id !== version.artifact.sessionId ||
+    evidence.artifact_id !== version.artifactId ||
+    evidence.version_id !== version.id ||
+    evidence.version_number !== version.versionNumber ||
+    evidence.filename !== version.filename ||
+    evidence.content_type !== (version.contentType ?? undefined) ||
+    !Number.isSafeInteger(sizeBytes) ||
+    evidence.size_bytes !== sizeBytes ||
+    evidence.checksum !== version.checksum ||
+    evidence.created_at !== version.createdAt.toISOString() ||
+    evidence.conversation.root_frame_id !== version.rootFrameId ||
+    evidence.conversation.agent_frame_id !== version.agentFrameId ||
+    evidence.conversation.message_branch_id !== version.messageBranchId ||
+    evidence.conversation.runtime_segment_id !== version.runtimeSegmentId ||
+    evidence.conversation.prompt_message_id !== version.promptMessageId ||
+    evidence.is_user_upload !== false ||
+    (evidence.agent_name !== undefined && typeof evidence.agent_name !== 'string') ||
+    !producerValid ||
+    !environmentValid ||
+    !inputsValid
+  ) {
+    throw new Error(`Artifact Version core evidence metadata mismatch: ${version.id}`)
+  }
+}
+
+export { validateArtifactCoreEvidence }
+export type { CoreEvidenceVersion }

--- a/src/main/artifacts/provenance-dependency-read.test.ts
+++ b/src/main/artifacts/provenance-dependency-read.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  createArtifactVersionRequest,
+  createProvenanceTestFixture
+} from './provenance-test-fixtures'
+
+type Fixture = Awaited<ReturnType<typeof createProvenanceTestFixture>>
+const fixtures: Fixture[] = []
+
+afterEach(async () => {
+  await Promise.all(fixtures.splice(0).map((fixture) => fixture.dispose()))
+})
+
+describe('Artifact Provenance dependency reads', () => {
+  it('projects the same typed input relation upstream and downstream', async () => {
+    const fixture = await createProvenanceTestFixture()
+    fixtures.push(fixture)
+    await fixture.stagePng('upstream', 'input.png')
+    const upstream = await fixture.repository.createVersion(
+      createArtifactVersionRequest({
+        filename: 'input.png',
+        writeOperationId: 'write-upstream',
+        writeRequestChecksum: 'b'.repeat(64)
+      })
+    )
+    await fixture.stagePng('downstream', 'output.png')
+    const downstream = await fixture.repository.createVersion(
+      createArtifactVersionRequest({
+        filename: 'output.png',
+        writeOperationId: 'write-downstream',
+        writeRequestChecksum: 'c'.repeat(64)
+      })
+    )
+    const source = await fixture.client.artifactVersion.findUniqueOrThrow({
+      where: { id: upstream.versionId }
+    })
+    await fixture.client.artifactVersionInput.create({
+      data: {
+        id: 'input-relation-1',
+        artifactVersionId: downstream.versionId,
+        ordinal: 0,
+        inputFileVersionId: upstream.versionId,
+        sourceKind: 'artifact-version',
+        sourceFileId: upstream.artifactId,
+        sourceArtifactVersionId: upstream.versionId,
+        sourceVersionNumber: upstream.versionNumber,
+        sourceCreatedAt: new Date(upstream.createdAt),
+        sourceProjectId: 'project-1',
+        sourceSessionId: 'session-1',
+        filename: 'input.png',
+        contentType: 'image/png',
+        sizeBytes: BigInt(upstream.size),
+        checksum: upstream.checksum,
+        storageKey: source.contentStorageKey,
+        strongestAssociation: 'resolver-accessed'
+      }
+    })
+
+    const expected = [
+      {
+        versionId: downstream.versionId,
+        dependsOnVersionId: upstream.versionId,
+        ordinal: 0,
+        sourceKind: 'artifact-version',
+        inputFilename: 'input.png',
+        association: 'resolver-accessed'
+      }
+    ]
+    await expect(
+      fixture.repository.readDependencyRelations({
+        projectId: 'project-1',
+        versionId: downstream.versionId,
+        direction: 'up'
+      })
+    ).resolves.toEqual(expected)
+    await expect(
+      fixture.repository.readDependencyRelations({
+        projectId: 'project-1',
+        versionId: upstream.versionId,
+        direction: 'down'
+      })
+    ).resolves.toEqual(expected)
+
+    await fixture.client.uploadFile.create({
+      data: {
+        id: 'upload-file-1',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        filename: 'source.csv',
+        originalFilename: 'source.csv',
+        versions: {
+          create: {
+            id: 'upload-version-1',
+            versionNumber: 1,
+            state: 'ready',
+            contentStorageKey: 'uploads/project-1/session-1/upload-version-1/content',
+            filename: 'source.csv',
+            originalFilename: 'source.csv',
+            contentType: 'text/csv',
+            sizeBytes: 7n,
+            checksum: 'd'.repeat(64),
+            createdAt: new Date('2026-08-02T00:00:00.000Z')
+          }
+        }
+      }
+    })
+    await fixture.client.artifactVersionInput.create({
+      data: {
+        id: 'input-relation-upload',
+        artifactVersionId: downstream.versionId,
+        ordinal: 1,
+        inputFileVersionId: 'upload-version-1',
+        sourceKind: 'upload-version',
+        sourceFileId: 'upload-file-1',
+        sourceUploadVersionId: 'upload-version-1',
+        sourceVersionNumber: 1,
+        sourceCreatedAt: new Date('2026-08-02T00:00:00.000Z'),
+        sourceProjectId: 'project-1',
+        sourceSessionId: 'session-1',
+        filename: 'source.csv',
+        contentType: 'text/csv',
+        sizeBytes: 7n,
+        checksum: 'd'.repeat(64),
+        storageKey: 'uploads/project-1/session-1/upload-version-1/content',
+        strongestAssociation: 'turn-attached'
+      }
+    })
+    await expect(
+      fixture.repository.readDependencyRelations({
+        projectId: 'project-1',
+        versionId: 'upload-version-1',
+        direction: 'down'
+      })
+    ).resolves.toEqual([
+      {
+        versionId: downstream.versionId,
+        dependsOnVersionId: 'upload-version-1',
+        ordinal: 1,
+        sourceKind: 'upload-version',
+        inputFilename: 'source.csv',
+        association: 'turn-attached'
+      }
+    ])
+
+    await fixture.client.fileOriginSession.create({
+      data: { projectId: 'project-2', sessionId: 'session-1' }
+    })
+    await fixture.client.artifactVersionInput.update({
+      where: { id: 'input-relation-1' },
+      data: { sourceProjectId: 'project-2' }
+    })
+    await expect(
+      fixture.repository.readDependencyRelations({
+        projectId: 'project-1',
+        versionId: downstream.versionId,
+        direction: 'up'
+      })
+    ).rejects.toThrow('Artifact dependency relation is corrupt')
+
+    await fixture.client.artifactVersionInput.update({
+      where: { id: 'input-relation-1' },
+      data: { sourceProjectId: 'project-1' }
+    })
+    await fixture.client.$executeRawUnsafe('PRAGMA foreign_keys = OFF')
+    await fixture.client.artifactVersionInput.update({
+      where: { id: 'input-relation-1' },
+      data: {
+        inputFileVersionId: 'missing-version',
+        sourceArtifactVersionId: 'missing-version'
+      }
+    })
+    await fixture.client.$executeRawUnsafe('PRAGMA foreign_keys = ON')
+    await expect(
+      fixture.repository.readDependencyRelations({
+        projectId: 'project-1',
+        versionId: downstream.versionId,
+        direction: 'up'
+      })
+    ).rejects.toThrow('Artifact dependency relation is corrupt')
+  })
+})

--- a/src/main/artifacts/provenance-dependency-reader.ts
+++ b/src/main/artifacts/provenance-dependency-reader.ts
@@ -1,0 +1,118 @@
+import type { PrismaClient } from '@prisma/client'
+
+import type { HostLineageDependencyRelation, HostLineageDirection } from '../../shared/host-lineage'
+
+type ReadDependencyRelationsRequest = {
+  projectId: string
+  versionId: string
+  direction: HostLineageDirection
+}
+
+const compareText = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0
+
+const sameDate = (left: Date | null, right: Date | null): boolean =>
+  left?.getTime() === right?.getTime()
+
+class ArtifactProvenanceDependencyReader {
+  constructor(private readonly getClient: () => Promise<PrismaClient>) {}
+
+  async readDependencyRelations(
+    request: ReadDependencyRelationsRequest
+  ): Promise<HostLineageDependencyRelation[]> {
+    const client = await this.getClient()
+    const rows = await client.artifactVersionInput.findMany({
+      where:
+        request.direction === 'up'
+          ? { artifactVersionId: request.versionId }
+          : {
+              OR: [
+                { sourceArtifactVersionId: request.versionId },
+                { sourceUploadVersionId: request.versionId }
+              ]
+            },
+      include: {
+        artifactVersion: { include: { artifact: true } },
+        sourceArtifactVersion: { include: { artifact: true } },
+        sourceUploadVersion: { include: { uploadFile: true } }
+      }
+    })
+
+    return rows
+      .map((row) => {
+        const output = row.artifactVersion
+        const commonValid =
+          output.artifact.projectId === request.projectId &&
+          (output.state === 'pending' || output.state === 'finalized') &&
+          row.sourceProjectId === request.projectId &&
+          Number.isSafeInteger(row.ordinal) &&
+          row.ordinal >= 0 &&
+          (row.strongestAssociation === 'turn-attached' ||
+            row.strongestAssociation === 'resolver-accessed') &&
+          (request.direction === 'up'
+            ? output.id === request.versionId
+            : row.sourceArtifactVersionId === request.versionId ||
+              row.sourceUploadVersionId === request.versionId)
+        const artifactSource = row.sourceArtifactVersion
+        const uploadSource = row.sourceUploadVersion
+        const artifactValid =
+          row.sourceKind === 'artifact-version' &&
+          artifactSource !== null &&
+          uploadSource === null &&
+          row.sourceArtifactVersionId === row.inputFileVersionId &&
+          row.sourceUploadVersionId === null &&
+          artifactSource.id === row.inputFileVersionId &&
+          artifactSource.artifact.projectId === request.projectId &&
+          (artifactSource.state === 'pending' || artifactSource.state === 'finalized') &&
+          row.sourceFileId === artifactSource.artifactId &&
+          row.sourceSessionId === artifactSource.artifact.sessionId &&
+          row.sourceVersionNumber === artifactSource.versionNumber &&
+          sameDate(row.sourceCreatedAt, artifactSource.createdAt) &&
+          row.filename === artifactSource.filename &&
+          row.contentType === artifactSource.contentType &&
+          row.sizeBytes === artifactSource.sizeBytes &&
+          row.checksum === artifactSource.checksum &&
+          row.storageKey === artifactSource.contentStorageKey
+        const uploadValid =
+          row.sourceKind === 'upload-version' &&
+          uploadSource !== null &&
+          artifactSource === null &&
+          row.sourceUploadVersionId === row.inputFileVersionId &&
+          row.sourceArtifactVersionId === null &&
+          uploadSource.id === row.inputFileVersionId &&
+          uploadSource.uploadFile.projectId === request.projectId &&
+          uploadSource.state === 'ready' &&
+          row.sourceFileId === uploadSource.uploadFileId &&
+          row.sourceSessionId === uploadSource.uploadFile.sessionId &&
+          row.sourceVersionNumber === uploadSource.versionNumber &&
+          sameDate(row.sourceCreatedAt, uploadSource.createdAt) &&
+          row.filename === (uploadSource.originalFilename || uploadSource.filename) &&
+          row.contentType === uploadSource.contentType &&
+          row.sizeBytes === uploadSource.sizeBytes &&
+          row.checksum === uploadSource.checksum &&
+          row.storageKey === uploadSource.contentStorageKey
+
+        if (!commonValid || (!artifactValid && !uploadValid)) {
+          throw new Error(`Artifact dependency relation is corrupt: ${row.id}`)
+        }
+        return {
+          versionId: output.id,
+          dependsOnVersionId: row.inputFileVersionId,
+          ordinal: row.ordinal,
+          sourceKind: row.sourceKind as 'artifact-version' | 'upload-version',
+          inputFilename: row.filename,
+          association: row.strongestAssociation as 'turn-attached' | 'resolver-accessed'
+        }
+      })
+      .sort(
+        (left, right) =>
+          compareText(left.versionId, right.versionId) ||
+          left.ordinal - right.ordinal ||
+          compareText(left.sourceKind, right.sourceKind) ||
+          compareText(left.dependsOnVersionId, right.dependsOnVersionId)
+      )
+  }
+}
+
+export { ArtifactProvenanceDependencyReader }
+export type { ReadDependencyRelationsRequest }

--- a/src/main/artifacts/provenance-lifecycle-contract.test.ts
+++ b/src/main/artifacts/provenance-lifecycle-contract.test.ts
@@ -4,6 +4,7 @@ import { basename, join, sep } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import type {
+  ArtifactVersionEvidence,
   CreateArtifactVersionRequest,
   FinalizeArtifactVersionsRequest
 } from '../../shared/artifact-provenance'
@@ -16,6 +17,7 @@ import {
   ArtifactOwnershipPersistenceRaceError,
   ArtifactProvenanceRepository
 } from './provenance-repository'
+import { canonicalJson, sha256, type CanonicalJson } from './provenance-canonical'
 import { ProvenanceMessageSnapshotRepository } from './provenance-message-snapshot'
 import {
   createArtifactVersionRequest,
@@ -271,5 +273,128 @@ describe('artifact provenance durable lifecycle contract', () => {
     await expect(repository.getVersionMessages(firstIdentity)).resolves.toEqual({
       messages: { state: 'unavailable', reason: 'message-snapshot-corrupt' }
     })
+
+    const coreRow = await value.client.artifactVersion.findUniqueOrThrow({
+      where: { id: first.versionId }
+    })
+    const corruptEvidence = JSON.parse(coreRow.evidenceJson) as ArtifactVersionEvidence
+    const persistCorruptEvidence = async (): Promise<void> => {
+      const corruptEvidenceJson = canonicalJson(corruptEvidence as unknown as CanonicalJson)
+      await value.client.artifactVersion.update({
+        where: { id: first.versionId },
+        data: {
+          evidenceJson: corruptEvidenceJson,
+          evidenceChecksum: sha256(corruptEvidenceJson)
+        }
+      })
+      await writeFile(
+        join(value.storageRoot, ...coreRow.evidenceStorageKey.split('/')),
+        corruptEvidenceJson,
+        'utf8'
+      )
+    }
+
+    if (corruptEvidence.producer.state !== 'unavailable') {
+      throw new Error('Expected the lifecycle fixture producer to be unavailable.')
+    }
+    corruptEvidence.environment_status = {
+      state: 'unavailable',
+      reason: 'environment-capture-failed'
+    }
+    await persistCorruptEvidence()
+    await expect(repository.getVersionCore(firstIdentity)).rejects.toThrow(
+      'Artifact Version core evidence metadata mismatch'
+    )
+
+    corruptEvidence.environment_status = {
+      state: 'unavailable',
+      reason: corruptEvidence.producer.reason
+    }
+    corruptEvidence.conversation.message_branch_id = 'self-consistent-but-wrong-branch'
+    await persistCorruptEvidence()
+    await expect(repository.getVersionCore(firstIdentity)).rejects.toThrow(
+      'Artifact Version core evidence metadata mismatch'
+    )
+  })
+
+  it('rejects a self-consistent checksum when an available producer uses a producer-only environment reason', async () => {
+    const value = await fixture()
+    const session = durableSession(value.storageRoot)
+    const request = versionRequest(session)
+    await value.notebookRepository.loadOrCreate({
+      projectName: 'project-1',
+      sessionId: 'session-1',
+      workspaceCwd: join(value.storageRoot, 'workspace')
+    })
+    await value.notebookRepository.appendRun({
+      projectName: 'project-1',
+      sessionId: 'session-1',
+      run: {
+        runId: 'producer-run-1',
+        cellId: 'cell-1',
+        source: 'agent',
+        kernelKind: 'python',
+        status: 'completed',
+        startedAt: 1,
+        endedAt: 2,
+        script: 'save_plot()',
+        text: { stdout: '', stderr: '', traceback: '', plain: [] },
+        outputs: [],
+        artifacts: [],
+        workingFiles: [],
+        inputFiles: [],
+        environmentCapture: {
+          state: 'unavailable',
+          reason: 'environment-capture-failed'
+        },
+        rootFrameId: request.rootFrameId,
+        agentFrameId: request.agentFrameId,
+        messageBranchId: request.messageBranchId,
+        runtimeSegmentId: request.runtimeSegmentId,
+        promptMessageId: request.promptMessageId
+      }
+    })
+    await value.stagePng('producer bytes')
+    const version = await value.repository.createVersion({
+      ...request,
+      notebookSessionId: 'session-1',
+      producerRunId: 'producer-run-1',
+      sourceKind: 'inline'
+    })
+    const identity = {
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactId: version.artifactId,
+      versionId: version.versionId
+    }
+    const row = await value.client.artifactVersion.findUniqueOrThrow({
+      where: { id: version.versionId }
+    })
+    const corruptEvidence = JSON.parse(row.evidenceJson) as ArtifactVersionEvidence
+    expect(corruptEvidence).toMatchObject({
+      producer: { state: 'available' },
+      environment_status: { state: 'unavailable', reason: 'environment-capture-failed' }
+    })
+    corruptEvidence.environment_status = {
+      state: 'unavailable',
+      reason: 'producer-not-supplied'
+    }
+    const corruptEvidenceJson = canonicalJson(corruptEvidence as unknown as CanonicalJson)
+    await value.client.artifactVersion.update({
+      where: { id: version.versionId },
+      data: {
+        evidenceJson: corruptEvidenceJson,
+        evidenceChecksum: sha256(corruptEvidenceJson)
+      }
+    })
+    await writeFile(
+      join(value.storageRoot, ...row.evidenceStorageKey.split('/')),
+      corruptEvidenceJson,
+      'utf8'
+    )
+
+    await expect(value.repository.getVersionCore(identity)).rejects.toThrow(
+      'Artifact Version core evidence metadata mismatch'
+    )
   })
 })

--- a/src/main/artifacts/provenance-read-model.ts
+++ b/src/main/artifacts/provenance-read-model.ts
@@ -33,6 +33,7 @@ import {
   validateArtifactExecutionSnapshot
 } from './provenance-execution-evidence'
 import { sha256 } from './provenance-canonical'
+import { validateArtifactCoreEvidence } from './provenance-core-evidence'
 import { readOptionalFile, resolveStorageKey } from './provenance-storage'
 import type { PersistedVersionFileRecord } from './provenance-version-writer'
 
@@ -248,6 +249,7 @@ class ArtifactProvenanceReadModel {
       `Artifact Version evidence is corrupt: ${versionId}`
     )
     const evidence = JSON.parse(evidenceMirror) as ArtifactVersionEvidence
+    validateArtifactCoreEvidence(evidence, version)
     const contentPath = resolveStorageKey(this.options.storageRoot, version.contentStorageKey)
     const contentStatus: ArtifactVersionProvenance['contentStatus'] = await readFile(contentPath)
       .then((content) =>

--- a/src/main/artifacts/provenance-repository.architecture.test.ts
+++ b/src/main/artifacts/provenance-repository.architecture.test.ts
@@ -28,6 +28,8 @@ import { describe, expect, it } from 'vitest'
 
 const productionFiles = [
   'provenance-canonical.ts',
+  'provenance-core-evidence.ts',
+  'provenance-dependency-reader.ts',
   'provenance-execution-evidence.ts',
   'provenance-finalization-recovery.ts',
   'provenance-message-finalization.ts',
@@ -228,6 +230,7 @@ describe('Artifact Provenance repository architecture', () => {
         'finalizeRun',
         'getLineage',
         'getVersionCore',
+        'readDependencyRelations',
         'getVersionExecution',
         'getVersionMessages',
         'getVersionProvenance',
@@ -251,6 +254,7 @@ describe('Artifact Provenance repository architecture', () => {
 
   it('composes each state owner exactly once without mutable facade fields', () => {
     for (const owner of [
+      'ArtifactProvenanceDependencyReader',
       'ArtifactProvenanceFinalizationRecovery',
       'ArtifactProvenanceMessageFinalizer',
       'ArtifactProvenanceProducerCapture',
@@ -266,6 +270,7 @@ describe('Artifact Provenance repository architecture', () => {
         'compatibilityRepository',
         'createId',
         'durability',
+        'dependencyReader',
         'finalizationRecovery',
         'messageFinalizer',
         'now',
@@ -296,6 +301,7 @@ describe('Artifact Provenance repository architecture', () => {
           'finalizeRun',
           'getLineage',
           'getVersionCore',
+          'readDependencyRelations',
           'getVersionExecution',
           'getVersionMessages',
           'getVersionProvenance',
@@ -310,6 +316,7 @@ describe('Artifact Provenance repository architecture', () => {
       finalizeRun: 'this.messageFinalizer.finalizeRun',
       getLineage: 'this.readModel.getLineage',
       getVersionCore: 'this.readModel.getVersionCore',
+      readDependencyRelations: 'this.dependencyReader.readDependencyRelations',
       getVersionExecution: 'this.readModel.getVersionExecution',
       getVersionMessages: 'this.readModel.getVersionMessages',
       getVersionProvenance: 'this.readModel.getVersionProvenance',
@@ -352,6 +359,7 @@ describe('Artifact Provenance repository architecture', () => {
     expect(module.testFiles.owner).toEqual(
       [
         'src/main/artifacts/provenance-lifecycle-contract.test.ts',
+        'src/main/artifacts/provenance-dependency-read.test.ts',
         'src/main/artifacts/provenance-message-snapshot.test.ts',
         'src/main/artifacts/provenance-repository.architecture.test.ts',
         'src/main/artifacts/provenance-repository.test.ts',

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -46,6 +46,8 @@ import { ArtifactProvenanceUnindexedRecovery } from './provenance-unindexed-reco
 import { resolveStorageKey, storageKey } from './provenance-storage'
 import { ArtifactProvenanceReadModel } from './provenance-read-model'
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import { ArtifactProvenanceDependencyReader } from './provenance-dependency-reader'
+import type { HostLineageDependencyRelation, HostLineageDirection } from '../../shared/host-lineage'
 
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 
@@ -114,6 +116,7 @@ class ArtifactProvenanceRepository {
   private readonly createId: () => string
   private readonly now: () => Date
   private readonly durability: ArtifactDurability
+  private readonly dependencyReader: ArtifactProvenanceDependencyReader
   private readonly finalizationRecovery: ArtifactProvenanceFinalizationRecovery
   private readonly messageFinalizer: ArtifactProvenanceMessageFinalizer
   private readonly producerCapture: ArtifactProvenanceProducerCapture
@@ -136,6 +139,7 @@ class ArtifactProvenanceRepository {
         storageRoot: options.storageRoot,
         getClient: options.getClient
       })
+    this.dependencyReader = new ArtifactProvenanceDependencyReader(options.getClient)
     this.readModel = new ArtifactProvenanceReadModel({
       storageRoot: options.storageRoot,
       getClient: options.getClient,
@@ -472,6 +476,14 @@ class ArtifactProvenanceRepository {
     request: GetArtifactVersionProvenanceRequest
   ): Promise<ArtifactVersionProvenance> {
     return this.readModel.getVersionCore(request)
+  }
+
+  async readDependencyRelations(request: {
+    projectId: string
+    versionId: string
+    direction: HostLineageDirection
+  }): Promise<HostLineageDependencyRelation[]> {
+    return this.dependencyReader.readDependencyRelations(request)
   }
 
   async getVersionExecution(

--- a/src/main/artifacts/provenance-write-contract.test.ts
+++ b/src/main/artifacts/provenance-write-contract.test.ts
@@ -53,6 +53,7 @@ const PUBLIC_METHODS = [
   'getVersionProvenance',
   'resolveVersionDescriptors',
   'getVersionCore',
+  'readDependencyRelations',
   'getVersionExecution',
   'getVersionMessages',
   'getVersionReview',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -122,6 +122,7 @@ import { createProductionMicromambaRunner } from './notebook/windows-micromamba-
 import { createRuntimeSelectionWorkflows } from './notebook/runtime-selection-workflows'
 import { runtimeRoot } from './notebook/runtime-paths'
 import { HostArtifactsService } from './notebook/host-artifacts-service'
+import { HostLineageService } from './notebook/host-lineage-service'
 import type { NotebookEnvironmentManager } from './notebook/runtime-service'
 import { parseArtifactVersionLocator } from '../shared/artifact-provenance'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../shared/artifacts'
@@ -1275,6 +1276,10 @@ const createApplicationModules = async (
       hostArtifacts: new HostArtifactsService(projectFilesRepository, {
         artifact: artifactProvenanceRepository,
         upload: uploadRepository
+      }),
+      hostLineage: new HostLineageService({
+        catalog: projectFilesRepository,
+        provenance: artifactProvenanceRepository
       }),
       inputRegistry: notebookInputRegistry,
       agentsService,

--- a/src/main/notebook/host-lineage-service.test.ts
+++ b/src/main/notebook/host-lineage-service.test.ts
@@ -20,6 +20,7 @@ const artifact = (
   sizeBytes: 12,
   sortAtMs: Date.parse('2026-08-01T00:00:00.000Z'),
   createdAt: '2026-08-01T00:00:00.000Z',
+  sourceCreatedAt: '2026-08-01T00:00:00.000Z',
   rootFrameId: 'root-a',
   agentFrameId: 'agent-a',
   ...overrides
@@ -41,6 +42,7 @@ const upload = (
   sizeBytes: 24,
   sortAtMs: Date.parse('2026-08-02T00:00:00.000Z'),
   createdAt: '2026-08-02T00:00:00.000Z',
+  sourceCreatedAt: '2026-08-02T00:00:00.000Z',
   rootFrameId: null,
   agentFrameId: null,
   ...overrides
@@ -561,6 +563,7 @@ describe('HostLineageService', () => {
       review: { state: 'available', value: { secret: 'review' } },
       path: '/private/artifact/path'
     } as unknown as ArtifactVersionCoreProvenance
+    let inputSourceCreatedAt: string | undefined = '2026-08-02T00:00:00.000Z'
     const service = new HostLineageService({
       catalog: {
         readHostArtifactCatalog: async ({ versionId }) =>
@@ -573,7 +576,8 @@ describe('HostLineageService', () => {
                   versionNumber: 1,
                   sizeBytes: 42,
                   checksum: 'f'.repeat(64),
-                  createdAt: '2026-08-02T00:00:00.000Z'
+                  createdAt: '2026-08-02T00:00:00.000Z',
+                  sourceCreatedAt: inputSourceCreatedAt
                 })
               ]
             : [item]
@@ -643,6 +647,15 @@ describe('HostLineageService', () => {
         }
       ]
     })
+
+    const inputEvidence = core.evidence.inputs[0] as { source_created_at?: string }
+    delete inputEvidence.source_created_at
+    inputSourceCreatedAt = undefined
+    const nullableUploadResult = await service.get('artifact-v1', {
+      projectId: 'project-a',
+      sessionId: 'session-current'
+    })
+    expect(nullableUploadResult.inputs[0]).not.toHaveProperty('created_at')
 
     environment.op_log[0].attempts[0].reason = 'secret-reason' as 'unknown'
     await expect(

--- a/src/main/notebook/host-lineage-service.test.ts
+++ b/src/main/notebook/host-lineage-service.test.ts
@@ -1,0 +1,753 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ArtifactVersionCoreProvenance } from '../../shared/artifact-provenance'
+import type { HostArtifactCatalogItem } from '../../shared/project-files'
+import { HostLineageService } from './host-lineage-service'
+
+const artifact = (
+  versionId: string,
+  overrides: Partial<HostArtifactCatalogItem> = {}
+): HostArtifactCatalogItem => ({
+  source: 'artifact',
+  sourceFileId: `file-${versionId}`,
+  versionId,
+  versionNumber: 1,
+  checksum: 'a'.repeat(64),
+  projectId: 'project-a',
+  sessionId: 'session-a',
+  filename: `${versionId}.csv`,
+  contentType: 'text/csv',
+  sizeBytes: 12,
+  sortAtMs: Date.parse('2026-08-01T00:00:00.000Z'),
+  createdAt: '2026-08-01T00:00:00.000Z',
+  rootFrameId: 'root-a',
+  agentFrameId: 'agent-a',
+  ...overrides
+})
+
+const upload = (
+  versionId: string,
+  overrides: Partial<HostArtifactCatalogItem> = {}
+): HostArtifactCatalogItem => ({
+  source: 'upload',
+  sourceFileId: `file-${versionId}`,
+  versionId,
+  versionNumber: 1,
+  checksum: 'b'.repeat(64),
+  projectId: 'project-a',
+  sessionId: 'session-b',
+  filename: `${versionId}.csv`,
+  contentType: 'text/csv',
+  sizeBytes: 24,
+  sortAtMs: Date.parse('2026-08-02T00:00:00.000Z'),
+  createdAt: '2026-08-02T00:00:00.000Z',
+  rootFrameId: null,
+  agentFrameId: null,
+  ...overrides
+})
+
+describe('HostLineageService', () => {
+  it('returns an upstream root-first graph with direct Upload inputs by default', async () => {
+    const items = new Map([
+      ['artifact-v1', artifact('artifact-v1')],
+      ['upload-v1', upload('upload-v1')]
+    ])
+    const service = new HostLineageService({
+      catalog: {
+        readHostArtifactCatalog: async ({ projectId, versionId }) => {
+          const item = versionId ? items.get(versionId) : undefined
+          return item?.projectId === projectId ? [item] : []
+        }
+      },
+      provenance: {
+        readDependencyRelations: async ({ versionId, direction }) =>
+          versionId === 'artifact-v1' && direction === 'up'
+            ? [
+                {
+                  versionId: 'artifact-v1',
+                  dependsOnVersionId: 'upload-v1',
+                  ordinal: 0,
+                  sourceKind: 'upload-version' as const,
+                  inputFilename: 'upload-v1.csv',
+                  association: 'turn-attached' as const
+                }
+              ]
+            : [],
+        getVersionCore: async () => ({}) as ArtifactVersionCoreProvenance
+      }
+    })
+
+    await expect(
+      service.graph('artifact-v1', undefined, {
+        projectId: 'project-a',
+        sessionId: 'session-current'
+      })
+    ).resolves.toEqual({
+      project_id: 'project-a',
+      root_version_id: 'artifact-v1',
+      direction: 'up',
+      truncated: false,
+      nodes: [
+        {
+          file_id: 'file-artifact-v1',
+          version_id: 'artifact-v1',
+          filename: 'artifact-v1.csv',
+          version_number: 1,
+          session_id: 'session-a',
+          root_frame_id: 'root-a',
+          agent_frame_id: 'agent-a',
+          created_at: '2026-08-01T00:00:00.000Z',
+          content_type: 'text/csv',
+          size_bytes: 12,
+          checksum: 'a'.repeat(64),
+          is_user_upload: false
+        },
+        {
+          file_id: 'file-upload-v1',
+          version_id: 'upload-v1',
+          filename: 'upload-v1.csv',
+          version_number: 1,
+          session_id: 'session-b',
+          root_frame_id: null,
+          agent_frame_id: null,
+          created_at: '2026-08-02T00:00:00.000Z',
+          content_type: 'text/csv',
+          size_bytes: 24,
+          checksum: 'b'.repeat(64),
+          is_user_upload: true
+        }
+      ],
+      edges: [
+        {
+          version_id: 'artifact-v1',
+          depends_on_version_id: 'upload-v1',
+          ordinal: 0,
+          source_kind: 'upload-version',
+          input_filename: 'upload-v1.csv',
+          association: 'turn-attached'
+        }
+      ]
+    })
+  })
+
+  it('rejects unknown graph options and invalid option types or ranges', async () => {
+    const service = new HostLineageService({
+      catalog: { readHostArtifactCatalog: async () => [artifact('artifact-v1')] },
+      provenance: {
+        readDependencyRelations: async () => [],
+        getVersionCore: async () => ({}) as ArtifactVersionCoreProvenance
+      }
+    })
+    const context = { projectId: 'project-a', sessionId: 'session-current' }
+
+    await expect(service.graph('artifact-v1', null, context)).rejects.toThrow(
+      'host.lineage.graph options must be an object.'
+    )
+    await expect(
+      service.graph('artifact-v1', { project_id: 'forged-project' }, context)
+    ).rejects.toThrow('host.lineage.graph unknown option: project_id')
+    await expect(service.graph('artifact-v1', { direction: 'sideways' }, context)).rejects.toThrow(
+      "host.lineage.graph direction must be 'up' or 'down'."
+    )
+    await expect(service.graph('artifact-v1', { max_depth: 1.5 }, context)).rejects.toThrow(
+      'host.lineage.graph max_depth must be an integer between 0 and 20.'
+    )
+    await expect(service.graph('artifact-v1', { max_depth: 21 }, context)).rejects.toThrow(
+      'host.lineage.graph max_depth must be an integer between 0 and 20.'
+    )
+    await expect(service.graph('artifact-v1', { max_nodes: 0 }, context)).rejects.toThrow(
+      'host.lineage.graph max_nodes must be an integer between 1 and 500.'
+    )
+    await expect(service.graph('artifact-v1', { max_nodes: 501 }, context)).rejects.toThrow(
+      'host.lineage.graph max_nodes must be an integer between 1 and 500.'
+    )
+  })
+
+  it('traverses down from an Upload in stable BFS order and terminates an anomalous cycle', async () => {
+    const items = new Map([
+      ['upload-v1', upload('upload-v1')],
+      ['artifact-a', artifact('artifact-a', { sessionId: 'session-a' })],
+      ['artifact-b', artifact('artifact-b', { sessionId: 'session-b' })],
+      ['artifact-c', artifact('artifact-c', { sessionId: 'session-c' })]
+    ])
+    const relations = new Map<
+      string,
+      Array<{
+        versionId: string
+        dependsOnVersionId: string
+        ordinal: number
+        sourceKind: 'artifact-version' | 'upload-version'
+        inputFilename: string
+        association: 'turn-attached' | 'resolver-accessed'
+      }>
+    >([
+      [
+        'upload-v1',
+        [
+          {
+            versionId: 'artifact-b',
+            dependsOnVersionId: 'upload-v1',
+            ordinal: 0,
+            sourceKind: 'upload-version',
+            inputFilename: 'upload-v1.csv',
+            association: 'turn-attached'
+          },
+          {
+            versionId: 'artifact-a',
+            dependsOnVersionId: 'upload-v1',
+            ordinal: 1,
+            sourceKind: 'upload-version',
+            inputFilename: 'upload-v1.csv',
+            association: 'resolver-accessed'
+          }
+        ]
+      ],
+      [
+        'artifact-a',
+        [
+          {
+            versionId: 'artifact-c',
+            dependsOnVersionId: 'artifact-a',
+            ordinal: 1,
+            sourceKind: 'artifact-version',
+            inputFilename: 'artifact-a.csv',
+            association: 'turn-attached'
+          }
+        ]
+      ],
+      [
+        'artifact-b',
+        [
+          {
+            versionId: 'artifact-c',
+            dependsOnVersionId: 'artifact-b',
+            ordinal: 0,
+            sourceKind: 'artifact-version',
+            inputFilename: 'artifact-b.csv',
+            association: 'turn-attached'
+          }
+        ]
+      ],
+      [
+        'artifact-c',
+        [
+          {
+            versionId: 'artifact-a',
+            dependsOnVersionId: 'artifact-c',
+            ordinal: 2,
+            sourceKind: 'artifact-version',
+            inputFilename: 'artifact-c.csv',
+            association: 'turn-attached'
+          }
+        ]
+      ]
+    ])
+    const service = new HostLineageService({
+      catalog: {
+        readHostArtifactCatalog: async ({ projectId, versionId }) => {
+          const item = versionId ? items.get(versionId) : undefined
+          return item?.projectId === projectId ? [item] : []
+        }
+      },
+      provenance: {
+        readDependencyRelations: async ({ versionId }) => relations.get(versionId) ?? [],
+        getVersionCore: async () => ({}) as ArtifactVersionCoreProvenance
+      }
+    })
+
+    const graph = await service.graph(
+      'upload-v1',
+      { direction: 'down' },
+      {
+        projectId: 'project-a',
+        sessionId: 'session-current'
+      }
+    )
+
+    expect(graph.nodes.map((node) => node.version_id)).toEqual([
+      'upload-v1',
+      'artifact-a',
+      'artifact-b',
+      'artifact-c'
+    ])
+    expect(graph.edges.map((edge) => [edge.version_id, edge.depends_on_version_id])).toEqual([
+      ['artifact-a', 'upload-v1'],
+      ['artifact-b', 'upload-v1'],
+      ['artifact-c', 'artifact-a'],
+      ['artifact-c', 'artifact-b'],
+      ['artifact-a', 'artifact-c']
+    ])
+    expect(graph).toMatchObject({ direction: 'down', truncated: false })
+  })
+
+  it('reports only real max_depth truncation with included boundary nodes as the frontier', async () => {
+    const items = new Map([
+      ['artifact-a', artifact('artifact-a')],
+      ['artifact-b', artifact('artifact-b')],
+      ['artifact-c', artifact('artifact-c')]
+    ])
+    const dependencies = new Map([
+      [
+        'artifact-a',
+        [
+          {
+            versionId: 'artifact-a',
+            dependsOnVersionId: 'artifact-b',
+            ordinal: 0,
+            sourceKind: 'artifact-version' as const,
+            inputFilename: 'artifact-b.csv',
+            association: 'turn-attached' as const
+          }
+        ]
+      ],
+      [
+        'artifact-b',
+        [
+          {
+            versionId: 'artifact-b',
+            dependsOnVersionId: 'artifact-c',
+            ordinal: 0,
+            sourceKind: 'artifact-version' as const,
+            inputFilename: 'artifact-c.csv',
+            association: 'turn-attached' as const
+          }
+        ]
+      ]
+    ])
+    const service = new HostLineageService({
+      catalog: {
+        readHostArtifactCatalog: async ({ versionId }) => {
+          const item = versionId ? items.get(versionId) : undefined
+          return item ? [item] : []
+        }
+      },
+      provenance: {
+        readDependencyRelations: async ({ versionId }) => dependencies.get(versionId) ?? [],
+        getVersionCore: async () => ({}) as ArtifactVersionCoreProvenance
+      }
+    })
+    const context = { projectId: 'project-a', sessionId: 'session-current' }
+
+    await expect(service.graph('artifact-a', { max_depth: 0 }, context)).resolves.toMatchObject({
+      truncated: true,
+      truncation_reason: 'max_depth',
+      frontier_version_ids: ['artifact-a'],
+      nodes: [{ version_id: 'artifact-a' }],
+      edges: []
+    })
+    await expect(service.graph('artifact-a', { max_depth: 1 }, context)).resolves.toMatchObject({
+      truncated: true,
+      truncation_reason: 'max_depth',
+      frontier_version_ids: ['artifact-b'],
+      nodes: [{ version_id: 'artifact-a' }, { version_id: 'artifact-b' }],
+      edges: [{ version_id: 'artifact-a', depends_on_version_id: 'artifact-b' }]
+    })
+  })
+
+  it('limits nodes including root and returns resumable max_nodes frontier ids', async () => {
+    const items = new Map(
+      ['artifact-a', 'artifact-b', 'artifact-c', 'artifact-d'].map((versionId) => [
+        versionId,
+        artifact(versionId)
+      ])
+    )
+    const service = new HostLineageService({
+      catalog: {
+        readHostArtifactCatalog: async ({ versionId }) => {
+          const item = versionId ? items.get(versionId) : undefined
+          return item ? [item] : []
+        }
+      },
+      provenance: {
+        readDependencyRelations: async ({ versionId }) =>
+          versionId === 'artifact-a'
+            ? ['artifact-d', 'artifact-b', 'artifact-c'].map((dependsOnVersionId) => ({
+                versionId: 'artifact-a',
+                dependsOnVersionId,
+                ordinal: dependsOnVersionId.charCodeAt(dependsOnVersionId.length - 1),
+                sourceKind: 'artifact-version' as const,
+                inputFilename: `${dependsOnVersionId}.csv`,
+                association: 'turn-attached' as const
+              }))
+            : [],
+        getVersionCore: async () => ({}) as ArtifactVersionCoreProvenance
+      }
+    })
+
+    const graph = await service.graph(
+      'artifact-a',
+      { max_nodes: 2 },
+      {
+        projectId: 'project-a',
+        sessionId: 'session-current'
+      }
+    )
+
+    expect(graph).toMatchObject({
+      truncated: true,
+      truncation_reason: 'max_nodes',
+      frontier_version_ids: ['artifact-b', 'artifact-c', 'artifact-d']
+    })
+    expect(graph.nodes.map((node) => node.version_id)).toEqual(['artifact-a', 'artifact-b'])
+    expect(graph.edges.map((edge) => [edge.version_id, edge.depends_on_version_id])).toEqual([
+      ['artifact-a', 'artifact-b']
+    ])
+  })
+
+  it('projects immutable core provenance without storage or unrelated evidence', async () => {
+    const item = artifact('artifact-v1', {
+      sourceFileId: 'artifact-file-1',
+      sessionId: 'session-other',
+      filename: 'result.csv',
+      versionNumber: 3,
+      sizeBytes: 99,
+      checksum: 'c'.repeat(64),
+      createdAt: '2026-08-03T00:00:00.000Z',
+      rootFrameId: 'root-1',
+      agentFrameId: 'agent-1'
+    })
+    const environment = {
+      capture_kind: 'completed-run' as const,
+      environment_name: 'science',
+      kernel_kind: 'python' as const,
+      runtime_source: 'managed' as const,
+      runtime_version: '3.13.5',
+      platform: 'darwin',
+      architecture: 'arm64',
+      packages: [
+        {
+          name: 'numpy',
+          version: '2.0.0',
+          version_status: 'known' as const,
+          ecosystem: 'python' as const,
+          evidence_sources: ['python-importlib-metadata' as const],
+          loaded_state: 'loaded' as const,
+          library_rank: 0,
+          library_scope: 'environment' as const,
+          built_for_runtime: '3.13',
+          priority: 'other' as const
+        }
+      ],
+      python_version: '3.13.5',
+      inventory_sources: ['kernel-native' as const, 'operation-log' as const],
+      installed_inventory: {
+        captured_at: '2026-08-03T00:00:00.000Z',
+        source: 'full-scan' as const,
+        validation: 'full-scan' as const
+      },
+      op_log: [
+        {
+          operation_id: 'operation-1',
+          timestamp: '2026-08-03T00:00:00.000Z',
+          operation: 'install' as const,
+          packages: ['numpy'],
+          result: 'success' as const,
+          attempts: [
+            {
+              group_ordinal: 0,
+              installer: 'pip' as const,
+              packages: ['numpy'],
+              status: 'succeeded' as const,
+              mutation_risk: 'confirmed' as const,
+              reason: 'unknown' as const
+            }
+          ],
+          fallback_used: false,
+          inventory_refresh: 'published' as const,
+          inventory_refresh_attempts: [
+            {
+              attempt: 1,
+              trigger: 'terminal' as const,
+              timestamp: '2026-08-03T00:00:01.000Z',
+              result: 'published' as const
+            }
+          ],
+          package_changes: [
+            {
+              name: 'numpy',
+              ecosystem: 'python' as const,
+              relationship: 'requested' as const,
+              change: 'installed' as const,
+              after_version: '2.0.0',
+              library_rank: 0,
+              library_scope: 'environment' as const
+            }
+          ]
+        }
+      ],
+      op_log_truncation: {
+        omitted_count: 2,
+        earliest_retained_at: '2026-08-02T23:59:00.000Z'
+      },
+      captured_at: '2026-08-03T00:00:00.000Z',
+      source_manifest_checksum: 'd'.repeat(64),
+      complete: true,
+      capture_status: 'complete' as const,
+      warnings: ['environment capture warning']
+    }
+    const core = {
+      descriptor: {
+        id: 'artifact-v1',
+        artifactId: 'artifact-file-1',
+        versionId: 'artifact-v1',
+        versionNumber: 3,
+        checksum: 'c'.repeat(64),
+        createdAt: '2026-08-03T00:00:00.000Z',
+        projectName: 'project-a',
+        sessionId: 'session-other',
+        runId: 'artifact-run-internal',
+        name: 'result.csv',
+        mimeType: 'text/csv',
+        size: 99,
+        mtimeMs: 123,
+        state: 'finalized' as const
+      },
+      contentStatus: { state: 'available' as const },
+      evidence: {
+        schema_version: 1 as const,
+        project_id: 'project-a',
+        app_session_id: 'session-other',
+        artifact_id: 'artifact-file-1',
+        version_id: 'artifact-v1',
+        version_number: 3,
+        filename: 'result.csv',
+        content_type: 'text/csv',
+        size_bytes: 99,
+        checksum: 'c'.repeat(64),
+        created_at: '2026-08-03T00:00:00.000Z',
+        agent_name: 'Codex',
+        conversation: {
+          root_frame_id: 'root-1',
+          agent_frame_id: 'agent-1',
+          message_branch_id: 'branch-1',
+          runtime_segment_id: 'runtime-1',
+          prompt_message_id: 'prompt-1'
+        },
+        is_user_upload: false as const,
+        reproduction_code: 'print("hello")',
+        execution_snapshot_checksum: 'e'.repeat(64),
+        execution_status: { state: 'available' as const },
+        producer: {
+          state: 'available' as const,
+          notebook_session_id: 'notebook-1',
+          producer_run_id: 'run-1',
+          run_index: 4,
+          kernel_kind: 'python' as const,
+          association_method: 'agent-declared-and-session-validated' as const,
+          environment_manifest_checksum: 'd'.repeat(64)
+        },
+        environment_status: { state: 'available' as const },
+        environment,
+        inputs: [
+          {
+            ordinal: 0,
+            input_file_version_id: 'upload-v1',
+            source_kind: 'upload-version' as const,
+            source_file_id: 'upload-file-1',
+            source_version_number: 1,
+            source_created_at: '2026-08-02T00:00:00.000Z',
+            source_project_id: 'project-a',
+            source_session_id: 'session-input',
+            filename: 'input.csv',
+            content_type: 'text/csv',
+            size_bytes: 42,
+            checksum: 'f'.repeat(64),
+            storage_key: 'uploads/project-a/private/content',
+            strongest_association: 'resolver-accessed' as const
+          }
+        ]
+      },
+      messages: { state: 'available', items: [{ secret: 'message' }] },
+      review: { state: 'available', value: { secret: 'review' } },
+      path: '/private/artifact/path'
+    } as unknown as ArtifactVersionCoreProvenance
+    const service = new HostLineageService({
+      catalog: {
+        readHostArtifactCatalog: async ({ versionId }) =>
+          versionId === 'upload-v1'
+            ? [
+                upload('upload-v1', {
+                  sourceFileId: 'upload-file-1',
+                  sessionId: 'session-input',
+                  filename: 'input.csv',
+                  versionNumber: 1,
+                  sizeBytes: 42,
+                  checksum: 'f'.repeat(64),
+                  createdAt: '2026-08-02T00:00:00.000Z'
+                })
+              ]
+            : [item]
+      },
+      provenance: {
+        readDependencyRelations: async () => [
+          {
+            versionId: 'artifact-v1',
+            dependsOnVersionId: 'upload-v1',
+            ordinal: 0,
+            sourceKind: 'upload-version',
+            inputFilename: 'input.csv',
+            association: 'resolver-accessed'
+          }
+        ],
+        getVersionCore: async () => core
+      }
+    })
+
+    await expect(
+      service.get('artifact-v1', { projectId: 'project-a', sessionId: 'session-current' })
+    ).resolves.toEqual({
+      project_id: 'project-a',
+      artifact_id: 'artifact-file-1',
+      version_id: 'artifact-v1',
+      filename: 'result.csv',
+      version_number: 3,
+      session_id: 'session-other',
+      root_frame_id: 'root-1',
+      agent_frame_id: 'agent-1',
+      message_branch_id: 'branch-1',
+      runtime_segment_id: 'runtime-1',
+      prompt_message_id: 'prompt-1',
+      created_at: '2026-08-03T00:00:00.000Z',
+      content_type: 'text/csv',
+      size_bytes: 99,
+      checksum: 'c'.repeat(64),
+      agent_name: 'Codex',
+      content_status: { state: 'available' },
+      reproduction_code: 'print("hello")',
+      execution_status: { state: 'available' },
+      producer: {
+        state: 'available',
+        notebook_session_id: 'notebook-1',
+        producer_run_id: 'run-1',
+        run_index: 4,
+        kernel_kind: 'python',
+        association_method: 'agent-declared-and-session-validated',
+        environment_manifest_checksum: 'd'.repeat(64)
+      },
+      environment_status: { state: 'available' },
+      environment,
+      inputs: [
+        {
+          ordinal: 0,
+          version_id: 'upload-v1',
+          file_id: 'upload-file-1',
+          source_kind: 'upload-version',
+          version_number: 1,
+          created_at: '2026-08-02T00:00:00.000Z',
+          session_id: 'session-input',
+          filename: 'input.csv',
+          content_type: 'text/csv',
+          size_bytes: 42,
+          checksum: 'f'.repeat(64),
+          association: 'resolver-accessed'
+        }
+      ]
+    })
+
+    environment.op_log[0].attempts[0].reason = 'secret-reason' as 'unknown'
+    await expect(
+      service.get('artifact-v1', { projectId: 'project-a', sessionId: 'session-current' })
+    ).rejects.toThrow('Artifact Version environment evidence is corrupt.')
+    environment.op_log[0].attempts[0].reason = 'unknown'
+    environment.op_log_truncation.omitted_count = 0
+    await expect(
+      service.get('artifact-v1', { projectId: 'project-a', sessionId: 'session-current' })
+    ).rejects.toThrow('Artifact Version environment evidence is corrupt.')
+  })
+
+  it('returns a root-only graph and rejects Upload get or corrupt cross-Project identities', async () => {
+    const service = new HostLineageService({
+      catalog: {
+        readHostArtifactCatalog: async ({ versionId }) =>
+          versionId === 'upload-v1'
+            ? [upload('upload-v1')]
+            : versionId === 'cross-project-v1'
+              ? [artifact('cross-project-v1', { projectId: 'project-b' })]
+              : [artifact('artifact-v1')]
+      },
+      provenance: {
+        readDependencyRelations: async () => [],
+        getVersionCore: async () => ({}) as ArtifactVersionCoreProvenance
+      }
+    })
+    const context = { projectId: 'project-a', sessionId: 'session-current' }
+
+    await expect(service.graph('artifact-v1', {}, context)).resolves.toMatchObject({
+      truncated: false,
+      nodes: [{ version_id: 'artifact-v1' }],
+      edges: []
+    })
+    await expect(service.get('upload-v1', context)).rejects.toThrow(
+      'Upload has no generated lineage.'
+    )
+    await expect(service.graph('cross-project-v1', {}, context)).rejects.toThrow(
+      'Artifact Version identity is corrupt'
+    )
+  })
+
+  it('fails closed when a dependency reader returns a relation outside the current traversal', async () => {
+    const service = new HostLineageService({
+      catalog: { readHostArtifactCatalog: async () => [artifact('artifact-v1')] },
+      provenance: {
+        readDependencyRelations: async () => [
+          {
+            versionId: 'other-project-version',
+            dependsOnVersionId: 'artifact-v1',
+            ordinal: 0,
+            sourceKind: 'artifact-version',
+            inputFilename: 'artifact-v1.csv',
+            association: 'turn-attached'
+          }
+        ],
+        getVersionCore: async () => ({}) as ArtifactVersionCoreProvenance
+      }
+    })
+
+    await expect(
+      service.graph(
+        'artifact-v1',
+        { direction: 'up' },
+        {
+          projectId: 'project-a',
+          sessionId: 'session-current'
+        }
+      )
+    ).rejects.toThrow('Artifact dependency relation is corrupt')
+  })
+
+  it('uses locale-independent code-point ordering for stable BFS traversal', async () => {
+    const versionIds = ['artifact_a', 'artifact-a', 'artifact-Z']
+    const service = new HostLineageService({
+      catalog: {
+        readHostArtifactCatalog: async ({ versionId }) =>
+          versionId === 'upload-v1' ? [upload('upload-v1')] : [artifact(String(versionId))]
+      },
+      provenance: {
+        readDependencyRelations: async ({ versionId }) =>
+          versionId === 'upload-v1'
+            ? versionIds.map((outputVersionId) => ({
+                versionId: outputVersionId,
+                dependsOnVersionId: 'upload-v1',
+                ordinal: 0,
+                sourceKind: 'upload-version' as const,
+                inputFilename: 'upload-v1.csv',
+                association: 'turn-attached' as const
+              }))
+            : [],
+        getVersionCore: async () => ({}) as ArtifactVersionCoreProvenance
+      }
+    })
+
+    const graph = await service.graph(
+      'upload-v1',
+      { direction: 'down' },
+      { projectId: 'project-a', sessionId: 'session-current' }
+    )
+    expect(graph.nodes.map((node) => node.version_id)).toEqual([
+      'upload-v1',
+      'artifact-Z',
+      'artifact-a',
+      'artifact_a'
+    ])
+  })
+})

--- a/src/main/notebook/host-lineage-service.ts
+++ b/src/main/notebook/host-lineage-service.ts
@@ -323,7 +323,7 @@ class HostLineageService {
         source.sourceFileId !== input.source_file_id ||
         source.source !== (input.source_kind === 'artifact-version' ? 'artifact' : 'upload') ||
         source.versionNumber !== input.source_version_number ||
-        source.createdAt !== input.source_created_at ||
+        source.sourceCreatedAt !== input.source_created_at ||
         source.sessionId !== input.source_session_id ||
         source.filename !== input.filename ||
         source.contentType !== input.content_type ||

--- a/src/main/notebook/host-lineage-service.ts
+++ b/src/main/notebook/host-lineage-service.ts
@@ -1,0 +1,495 @@
+import type {
+  ArtifactVersionCoreProvenance,
+  ArtifactVersionEnvironmentEvidence,
+  GetArtifactVersionProvenanceRequest
+} from '../../shared/artifact-provenance'
+import type {
+  HostLineageDependencyRelation,
+  HostLineageDirection,
+  HostLineageEdge,
+  HostLineageGraph,
+  HostLineageNode,
+  HostLineageVersion
+} from '../../shared/host-lineage'
+import type { HostArtifactCatalogItem } from '../../shared/project-files'
+
+type HostLineageReadContext = { projectId: string; sessionId: string }
+
+type HostLineageServiceOptions = {
+  catalog: {
+    readHostArtifactCatalog(request: {
+      projectId: string
+      versionId?: string
+    }): Promise<HostArtifactCatalogItem[]>
+  }
+  provenance: {
+    readDependencyRelations(request: {
+      projectId: string
+      versionId: string
+      direction: HostLineageDirection
+    }): Promise<HostLineageDependencyRelation[]>
+    getVersionCore(
+      request: GetArtifactVersionProvenanceRequest
+    ): Promise<ArtifactVersionCoreProvenance>
+  }
+}
+
+const GRAPH_OPTION_KEYS = new Set(['direction', 'max_depth', 'max_nodes'])
+const ENVIRONMENT_ATTEMPT_REASONS = new Set([
+  'package-not-found',
+  'solver-failed',
+  'installer-unavailable',
+  'permission',
+  'network',
+  'authentication',
+  'tls-policy',
+  'validation',
+  'cancelled',
+  'process-unconfirmed',
+  'recovery-blocked',
+  'unknown'
+])
+const compareText = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const normalizeGraphOptions = (
+  value: unknown
+): { direction: HostLineageDirection; maxDepth: number; maxNodes: number } => {
+  if (value === undefined) value = {}
+  if (!isRecord(value)) throw new Error('host.lineage.graph options must be an object.')
+  const unknown = Object.keys(value).find((key) => !GRAPH_OPTION_KEYS.has(key))
+  if (unknown) throw new Error(`host.lineage.graph unknown option: ${unknown}`)
+
+  const direction = value.direction ?? 'up'
+  if (direction !== 'up' && direction !== 'down') {
+    throw new Error("host.lineage.graph direction must be 'up' or 'down'.")
+  }
+  const maxDepth = value.max_depth ?? 5
+  if (!Number.isInteger(maxDepth) || (maxDepth as number) < 0 || (maxDepth as number) > 20) {
+    throw new Error('host.lineage.graph max_depth must be an integer between 0 and 20.')
+  }
+  const maxNodes = value.max_nodes ?? 100
+  if (!Number.isInteger(maxNodes) || (maxNodes as number) < 1 || (maxNodes as number) > 500) {
+    throw new Error('host.lineage.graph max_nodes must be an integer between 1 and 500.')
+  }
+  return { direction, maxDepth: maxDepth as number, maxNodes: maxNodes as number }
+}
+
+const toNode = (item: HostArtifactCatalogItem): HostLineageNode => {
+  if (
+    !Number.isSafeInteger(item.versionNumber) ||
+    !item.createdAt ||
+    !item.checksum ||
+    item.agentFrameId === undefined
+  ) {
+    throw new Error(`Artifact Version metadata is incomplete: ${item.versionId}`)
+  }
+  return {
+    file_id: item.sourceFileId,
+    version_id: item.versionId,
+    filename: item.filename,
+    version_number: item.versionNumber!,
+    session_id: item.sessionId,
+    root_frame_id: item.rootFrameId,
+    agent_frame_id: item.agentFrameId,
+    created_at: item.createdAt,
+    ...(item.contentType ? { content_type: item.contentType } : {}),
+    size_bytes: item.sizeBytes,
+    checksum: item.checksum,
+    is_user_upload: item.source === 'upload'
+  }
+}
+
+const toEdge = (relation: HostLineageDependencyRelation): HostLineageEdge => ({
+  version_id: relation.versionId,
+  depends_on_version_id: relation.dependsOnVersionId,
+  ordinal: relation.ordinal,
+  source_kind: relation.sourceKind,
+  input_filename: relation.inputFilename,
+  association: relation.association
+})
+
+const projectAvailability = (
+  value: ArtifactVersionCoreProvenance['evidence']['execution_status']
+): HostLineageVersion['execution_status'] =>
+  value.state === 'unavailable'
+    ? { state: value.state, reason: value.reason }
+    : { state: value.state }
+
+const projectProducer = (
+  value: ArtifactVersionCoreProvenance['evidence']['producer']
+): HostLineageVersion['producer'] =>
+  value.state === 'unavailable'
+    ? { state: value.state, reason: value.reason }
+    : {
+        state: value.state,
+        notebook_session_id: value.notebook_session_id,
+        producer_run_id: value.producer_run_id,
+        run_index: value.run_index,
+        kernel_kind: value.kernel_kind,
+        association_method: value.association_method,
+        ...(value.environment_manifest_checksum
+          ? { environment_manifest_checksum: value.environment_manifest_checksum }
+          : {})
+      }
+
+const projectEnvironment = (
+  value: ArtifactVersionEnvironmentEvidence
+): ArtifactVersionEnvironmentEvidence => {
+  if (
+    value.op_log?.some((entry) =>
+      entry.attempts.some(
+        (attempt) =>
+          attempt.reason !== undefined && !ENVIRONMENT_ATTEMPT_REASONS.has(attempt.reason)
+      )
+    ) ||
+    (value.op_log_truncation !== undefined &&
+      (!Number.isSafeInteger(value.op_log_truncation.omitted_count) ||
+        value.op_log_truncation.omitted_count <= 0))
+  ) {
+    throw new Error('Artifact Version environment evidence is corrupt.')
+  }
+
+  return {
+    capture_kind: value.capture_kind,
+    environment_name: value.environment_name,
+    kernel_kind: value.kernel_kind,
+    runtime_source: value.runtime_source,
+    ...(value.runtime_version ? { runtime_version: value.runtime_version } : {}),
+    ...(value.platform ? { platform: value.platform } : {}),
+    ...(value.architecture ? { architecture: value.architecture } : {}),
+    packages: value.packages.map((entry) => ({
+      name: entry.name,
+      ...(entry.version ? { version: entry.version } : {}),
+      version_status: entry.version_status,
+      ecosystem: entry.ecosystem,
+      evidence_sources: [...entry.evidence_sources],
+      loaded_state: entry.loaded_state,
+      ...(entry.library_rank !== undefined ? { library_rank: entry.library_rank } : {}),
+      ...(entry.library_scope ? { library_scope: entry.library_scope } : {}),
+      ...(entry.built_for_runtime ? { built_for_runtime: entry.built_for_runtime } : {}),
+      ...(entry.priority ? { priority: entry.priority } : {})
+    })),
+    ...(value.python_version ? { python_version: value.python_version } : {}),
+    ...(value.r_version ? { r_version: value.r_version } : {}),
+    inventory_sources: [...value.inventory_sources],
+    installed_inventory: {
+      captured_at: value.installed_inventory.captured_at,
+      source: value.installed_inventory.source,
+      validation: value.installed_inventory.validation
+    },
+    ...(value.op_log
+      ? {
+          op_log: value.op_log.map((entry) => ({
+            operation_id: entry.operation_id,
+            timestamp: entry.timestamp,
+            operation: entry.operation,
+            packages: [...entry.packages],
+            result: entry.result,
+            attempts: entry.attempts.map((attempt) => ({
+              group_ordinal: attempt.group_ordinal,
+              installer: attempt.installer,
+              packages: [...attempt.packages],
+              status: attempt.status,
+              mutation_risk: attempt.mutation_risk,
+              ...(attempt.reason !== undefined ? { reason: attempt.reason } : {})
+            })),
+            fallback_used: entry.fallback_used,
+            inventory_refresh: entry.inventory_refresh,
+            inventory_refresh_attempts: entry.inventory_refresh_attempts.map((attempt) => ({
+              attempt: attempt.attempt,
+              trigger: attempt.trigger,
+              timestamp: attempt.timestamp,
+              result: attempt.result,
+              ...(attempt.error ? { error: attempt.error } : {})
+            })),
+            ...(entry.package_changes
+              ? {
+                  package_changes: entry.package_changes.map((change) => ({
+                    name: change.name,
+                    ecosystem: change.ecosystem,
+                    relationship: change.relationship,
+                    change: change.change,
+                    ...(change.before_version ? { before_version: change.before_version } : {}),
+                    ...(change.after_version ? { after_version: change.after_version } : {}),
+                    ...(change.library_rank !== undefined
+                      ? { library_rank: change.library_rank }
+                      : {}),
+                    ...(change.library_scope ? { library_scope: change.library_scope } : {})
+                  }))
+                }
+              : {})
+          }))
+        }
+      : {}),
+    ...(value.op_log_truncation
+      ? {
+          op_log_truncation: {
+            omitted_count: value.op_log_truncation.omitted_count,
+            ...(value.op_log_truncation.earliest_retained_at
+              ? { earliest_retained_at: value.op_log_truncation.earliest_retained_at }
+              : {})
+          }
+        }
+      : {}),
+    captured_at: value.captured_at,
+    source_manifest_checksum: value.source_manifest_checksum,
+    complete: value.complete,
+    capture_status: value.capture_status,
+    ...(value.warnings ? { warnings: [...value.warnings] } : {})
+  }
+}
+
+class HostLineageService {
+  constructor(private readonly options: HostLineageServiceOptions) {}
+
+  async get(versionIdValue: unknown, context: HostLineageReadContext): Promise<HostLineageVersion> {
+    if (typeof versionIdValue !== 'string' || !versionIdValue) {
+      throw new Error('host.lineage.get version_id must be a non-empty string.')
+    }
+    const items = await this.options.catalog.readHostArtifactCatalog({
+      projectId: context.projectId,
+      versionId: versionIdValue
+    })
+    if (items.length !== 1) {
+      throw new Error(`Artifact Version not found in the current Project: ${versionIdValue}`)
+    }
+    const item = items[0]
+    if (item.projectId !== context.projectId || item.versionId !== versionIdValue) {
+      throw new Error(`Artifact Version identity is corrupt: ${versionIdValue}`)
+    }
+    if (item.source === 'upload') throw new Error('Upload has no generated lineage.')
+    const core = await this.options.provenance.getVersionCore({
+      projectId: context.projectId,
+      appSessionId: item.sessionId,
+      artifactId: item.sourceFileId,
+      versionId: item.versionId
+    })
+    const { descriptor, evidence } = core
+    if (
+      descriptor.artifactId !== item.sourceFileId ||
+      descriptor.versionId !== item.versionId ||
+      descriptor.versionNumber !== item.versionNumber ||
+      descriptor.name !== item.filename ||
+      descriptor.sessionId !== item.sessionId ||
+      descriptor.createdAt !== item.createdAt ||
+      descriptor.size !== item.sizeBytes ||
+      descriptor.checksum !== item.checksum ||
+      descriptor.mimeType !== item.contentType ||
+      evidence.project_id !== context.projectId ||
+      evidence.app_session_id !== item.sessionId ||
+      evidence.artifact_id !== item.sourceFileId ||
+      evidence.version_id !== item.versionId ||
+      evidence.version_number !== item.versionNumber ||
+      evidence.filename !== item.filename ||
+      evidence.created_at !== item.createdAt ||
+      evidence.size_bytes !== item.sizeBytes ||
+      evidence.checksum !== item.checksum ||
+      evidence.content_type !== item.contentType ||
+      evidence.conversation.root_frame_id !== item.rootFrameId ||
+      evidence.conversation.agent_frame_id !== item.agentFrameId ||
+      evidence.is_user_upload !== false ||
+      evidence.inputs.some(
+        (input, ordinal) =>
+          input.ordinal !== ordinal || input.source_project_id !== context.projectId
+      )
+    ) {
+      throw new Error(`Artifact Version core provenance is corrupt: ${versionIdValue}`)
+    }
+    const relations = await this.options.provenance.readDependencyRelations({
+      projectId: context.projectId,
+      versionId: item.versionId,
+      direction: 'up'
+    })
+    relations.sort((left, right) => left.ordinal - right.ordinal)
+    if (relations.length !== evidence.inputs.length) {
+      throw new Error(`Artifact Version core provenance is corrupt: ${versionIdValue}`)
+    }
+    for (const [ordinal, input] of evidence.inputs.entries()) {
+      const relation = relations[ordinal]
+      const sourceItems = await this.options.catalog.readHostArtifactCatalog({
+        projectId: context.projectId,
+        versionId: input.input_file_version_id
+      })
+      const source = sourceItems[0]
+      if (
+        sourceItems.length !== 1 ||
+        !source ||
+        source.projectId !== context.projectId ||
+        source.versionId !== input.input_file_version_id ||
+        source.sourceFileId !== input.source_file_id ||
+        source.source !== (input.source_kind === 'artifact-version' ? 'artifact' : 'upload') ||
+        source.versionNumber !== input.source_version_number ||
+        source.createdAt !== input.source_created_at ||
+        source.sessionId !== input.source_session_id ||
+        source.filename !== input.filename ||
+        source.contentType !== input.content_type ||
+        source.sizeBytes !== input.size_bytes ||
+        source.checksum !== input.checksum ||
+        relation?.versionId !== item.versionId ||
+        relation.dependsOnVersionId !== input.input_file_version_id ||
+        relation.ordinal !== ordinal ||
+        relation.sourceKind !== input.source_kind ||
+        relation.inputFilename !== input.filename ||
+        relation.association !== input.strongest_association
+      ) {
+        throw new Error(`Artifact Version core provenance is corrupt: ${versionIdValue}`)
+      }
+    }
+
+    return {
+      project_id: evidence.project_id,
+      artifact_id: evidence.artifact_id,
+      version_id: evidence.version_id,
+      filename: evidence.filename,
+      version_number: evidence.version_number,
+      session_id: evidence.app_session_id,
+      root_frame_id: evidence.conversation.root_frame_id,
+      agent_frame_id: evidence.conversation.agent_frame_id,
+      message_branch_id: evidence.conversation.message_branch_id,
+      runtime_segment_id: evidence.conversation.runtime_segment_id,
+      prompt_message_id: evidence.conversation.prompt_message_id,
+      created_at: evidence.created_at,
+      ...(evidence.content_type ? { content_type: evidence.content_type } : {}),
+      size_bytes: evidence.size_bytes,
+      checksum: evidence.checksum,
+      ...(evidence.agent_name ? { agent_name: evidence.agent_name } : {}),
+      content_status:
+        core.contentStatus.state === 'available'
+          ? { state: core.contentStatus.state }
+          : { state: core.contentStatus.state, reason: core.contentStatus.reason },
+      ...(evidence.reproduction_code ? { reproduction_code: evidence.reproduction_code } : {}),
+      execution_status: projectAvailability(evidence.execution_status),
+      producer: projectProducer(evidence.producer),
+      environment_status: projectAvailability(evidence.environment_status),
+      ...(evidence.environment ? { environment: projectEnvironment(evidence.environment) } : {}),
+      inputs: evidence.inputs.map((input) => ({
+        ordinal: input.ordinal,
+        version_id: input.input_file_version_id,
+        file_id: input.source_file_id,
+        source_kind: input.source_kind,
+        ...(input.source_version_number !== undefined
+          ? { version_number: input.source_version_number }
+          : {}),
+        ...(input.source_created_at ? { created_at: input.source_created_at } : {}),
+        session_id: input.source_session_id,
+        filename: input.filename,
+        ...(input.content_type ? { content_type: input.content_type } : {}),
+        size_bytes: input.size_bytes,
+        checksum: input.checksum,
+        association: input.strongest_association
+      }))
+    }
+  }
+
+  async graph(
+    versionIdValue: unknown,
+    optionsValue: unknown,
+    context: HostLineageReadContext
+  ): Promise<HostLineageGraph> {
+    if (typeof versionIdValue !== 'string' || !versionIdValue) {
+      throw new Error('host.lineage.graph version_id must be a non-empty string.')
+    }
+    const { direction, maxDepth, maxNodes } = normalizeGraphOptions(optionsValue)
+    const resolveNode = async (versionId: string): Promise<HostLineageNode> => {
+      const items = await this.options.catalog.readHostArtifactCatalog({
+        projectId: context.projectId,
+        versionId
+      })
+      if (items.length !== 1) {
+        throw new Error(`Artifact Version not found in the current Project: ${versionId}`)
+      }
+      const item = items[0]
+      if (item.projectId !== context.projectId || item.versionId !== versionId) {
+        throw new Error(`Artifact Version identity is corrupt: ${versionId}`)
+      }
+      return toNode(item)
+    }
+
+    const nodes = [await resolveNode(versionIdValue)]
+    const edges: HostLineageEdge[] = []
+    const maxDepthFrontier: string[] = []
+    const omittedNodeFrontier: string[] = []
+    let pendingNodeFrontier: string[] = []
+    let maxNodesTruncated = false
+    const visited = new Set([versionIdValue])
+    const queue = [{ versionId: versionIdValue, depth: 0 }]
+
+    while (queue.length > 0) {
+      const current = queue.shift()!
+      if (maxNodesTruncated) {
+        pendingNodeFrontier = [current.versionId, ...queue.map((entry) => entry.versionId)]
+        break
+      }
+      const relations = await this.options.provenance.readDependencyRelations({
+        projectId: context.projectId,
+        versionId: current.versionId,
+        direction
+      })
+      relations.sort((left, right) =>
+        direction === 'up'
+          ? left.ordinal - right.ordinal ||
+            compareText(left.sourceKind, right.sourceKind) ||
+            compareText(left.dependsOnVersionId, right.dependsOnVersionId)
+          : compareText(left.versionId, right.versionId) || left.ordinal - right.ordinal
+      )
+      const neighbors = relations.map((relation) => {
+        if (
+          (direction === 'up' && relation.versionId !== current.versionId) ||
+          (direction === 'down' && relation.dependsOnVersionId !== current.versionId)
+        ) {
+          throw new Error(`Artifact dependency relation is corrupt: ${current.versionId}`)
+        }
+        return direction === 'up' ? relation.dependsOnVersionId : relation.versionId
+      })
+      if (current.depth >= maxDepth) {
+        if (neighbors.some((versionId) => !visited.has(versionId))) {
+          maxDepthFrontier.push(current.versionId)
+        }
+        continue
+      }
+      for (const relation of relations) {
+        const neighborVersionId =
+          direction === 'up' ? relation.dependsOnVersionId : relation.versionId
+        if (visited.has(neighborVersionId)) {
+          edges.push(toEdge(relation))
+          continue
+        }
+        if (nodes.length >= maxNodes) {
+          maxNodesTruncated = true
+          omittedNodeFrontier.push(neighborVersionId)
+          continue
+        }
+        edges.push(toEdge(relation))
+        visited.add(neighborVersionId)
+        nodes.push(await resolveNode(neighborVersionId))
+        queue.push({ versionId: neighborVersionId, depth: current.depth + 1 })
+      }
+    }
+
+    const maxNodesFrontier = [...new Set([...pendingNodeFrontier, ...omittedNodeFrontier])]
+    const truncated = maxNodesFrontier.length > 0 || maxDepthFrontier.length > 0
+    const truncation =
+      maxNodesFrontier.length > 0
+        ? { truncation_reason: 'max_nodes' as const, frontier_version_ids: maxNodesFrontier }
+        : maxDepthFrontier.length > 0
+          ? { truncation_reason: 'max_depth' as const, frontier_version_ids: maxDepthFrontier }
+          : {}
+
+    return {
+      project_id: context.projectId,
+      root_version_id: versionIdValue,
+      direction,
+      truncated,
+      ...truncation,
+      nodes,
+      edges
+    }
+  }
+}
+
+export { HostLineageService }
+export type { HostLineageReadContext, HostLineageServiceOptions }

--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -38,7 +38,8 @@ describe('capabilitiesCall RPC', () => {
       computeService: {} as never,
       agentsService: {} as never,
       skillsService: {} as never,
-      hostArtifacts: {} as never
+      hostArtifacts: {} as never,
+      hostLineage: {} as never
     })
     const connection = await server.issueControlConnection('trusted-session', 'trusted-project')
 
@@ -50,7 +51,14 @@ describe('capabilitiesCall RPC', () => {
 
     expect(response.status).toBe(200)
     expect(payload).toEqual({
-      result: { mcp: true, compute: true, agents: true, skills: true, artifacts: true }
+      result: {
+        mcp: true,
+        compute: true,
+        agents: true,
+        skills: true,
+        artifacts: true,
+        lineage: true
+      }
     })
   })
 
@@ -63,7 +71,14 @@ describe('capabilitiesCall RPC', () => {
 
     await expect(callCapabilities(connection)).resolves.toMatchObject({
       payload: {
-        result: { mcp: true, compute: false, agents: false, skills: false, artifacts: false }
+        result: {
+          mcp: true,
+          compute: false,
+          agents: false,
+          skills: false,
+          artifacts: false,
+          lineage: false
+        }
       }
     })
   })

--- a/src/main/notebook/local-rpc-server.lineage.test.ts
+++ b/src/main/notebook/local-rpc-server.lineage.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { NotebookLocalRpcServer } from './local-rpc-server'
+
+type RpcConnection = { endpoint: string; token: string; release?: () => void }
+
+const callLineage = async (
+  connection: RpcConnection,
+  token: string,
+  params: Record<string, unknown>
+): Promise<{ response: Response; payload: Record<string, unknown> }> => {
+  const response = await fetch(connection.endpoint, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ method: 'lineageCall', params })
+  })
+  return { response, payload: (await response.json()) as Record<string, unknown> }
+}
+
+let server: NotebookLocalRpcServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+describe('lineageCall RPC', () => {
+  it('dispatches graph and get with only the control token Project scope', async () => {
+    const graph = vi.fn(async () => ({ root_version_id: 'version-1' }))
+    const get = vi.fn(async () => ({ version_id: 'version-1' }))
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostLineage: { graph, get } as never
+    })
+    const control = await server.issueControlConnection('trusted-session', 'trusted-project')
+
+    const graphed = await callLineage(control, control.token, {
+      op: 'graph',
+      version_id: 'version-1',
+      options: { direction: 'down', max_depth: 2 }
+    })
+    expect(graphed).toMatchObject({
+      response: { status: 200 },
+      payload: { result: { root_version_id: 'version-1' } }
+    })
+    expect(graph).toHaveBeenCalledWith(
+      'version-1',
+      { direction: 'down', max_depth: 2 },
+      { projectId: 'trusted-project', sessionId: 'trusted-session' }
+    )
+
+    const read = await callLineage(control, control.token, {
+      op: 'get',
+      version_id: 'version-1'
+    })
+    expect(read.payload).toEqual({ result: { version_id: 'version-1' } })
+    expect(get).toHaveBeenCalledWith('version-1', {
+      projectId: 'trusted-project',
+      sessionId: 'trusted-session'
+    })
+  })
+
+  it('rejects request-body scope fields, unknown fields, and unsupported operations', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostLineage: { graph: vi.fn(), get: vi.fn() }
+    })
+    const control = await server.issueControlConnection('trusted-session', 'trusted-project')
+
+    for (const forged of [
+      { projectId: 'forged-project' },
+      { sessionId: 'forged-session' },
+      { project_id: 'forged-project' },
+      { session_id: 'forged-session' },
+      { include_all_projects: true }
+    ]) {
+      const attempt = await callLineage(control, control.token, {
+        op: 'graph',
+        version_id: 'version-1',
+        options: {},
+        ...forged
+      })
+      expect(attempt.response.status).toBe(500)
+      expect(attempt.payload).toEqual({ error: 'host.lineage RPC params are invalid.' })
+    }
+
+    await expect(
+      callLineage(control, control.token, { op: 'clear', version_id: 'version-1' })
+    ).resolves.toMatchObject({
+      response: { status: 500 },
+      payload: { error: 'Unknown host.lineage operation.' }
+    })
+  })
+
+  it('rejects bootstrap, invalid, ordinary Session, and released control capabilities', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostLineage: { graph: vi.fn(), get: vi.fn() }
+    })
+    const bootstrap = await server.ensureStarted()
+    const ordinary = await server.issueSessionConnection('trusted-session', 'trusted-project')
+    const control = await server.issueControlConnection('trusted-session', 'trusted-project')
+    const params = { op: 'graph', version_id: 'version-1', options: {} }
+
+    await expect(callLineage(control, bootstrap.token, params)).resolves.toMatchObject({
+      response: { status: 401 },
+      payload: { error: 'A session-bound notebook RPC token is required.' }
+    })
+    await expect(callLineage(control, 'invalid-token', params)).resolves.toMatchObject({
+      response: { status: 401 },
+      payload: { error: 'Invalid notebook RPC token.' }
+    })
+    await expect(callLineage(control, ordinary.token, params)).resolves.toMatchObject({
+      response: { status: 403 },
+      payload: { error: 'host.lineage requires a control-plane REPL capability.' }
+    })
+
+    control.release()
+    await expect(callLineage(control, control.token, params)).resolves.toMatchObject({
+      response: { status: 401 },
+      payload: { error: 'Invalid notebook RPC token.' }
+    })
+    ordinary.release?.()
+  })
+})

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 
 import type { NotebookRunProvenanceContext } from '../../shared/notebook'
+import type { HostLineageGraph, HostLineageVersion } from '../../shared/host-lineage'
 import type { NotebookRpcConnection } from './mcp-server'
 import { NotebookControlCompletionCapturedError } from './execution-owner'
 import {
@@ -137,6 +138,17 @@ type NotebookLocalRpcServerOptions = {
       context: { projectId: string; sessionId: string }
     ): Promise<string>
   }
+  hostLineage?: {
+    graph(
+      versionId: unknown,
+      options: unknown,
+      context: { projectId: string; sessionId: string }
+    ): Promise<HostLineageGraph>
+    get(
+      versionId: unknown,
+      context: { projectId: string; sessionId: string }
+    ): Promise<HostLineageVersion>
+  }
   // host.agents control-plane SDK (issue 02): exposes the Specialist/catalog surface to the
   // JavaScript control-plane REPL via the extensible dispatcher. Never routed through host.mcp();
   // carries the trusted calling session identity captured outside the sandbox so switch()
@@ -191,6 +203,7 @@ const DEFAULT_ARTIFACT_RPC_CAPABILITY_TTL_MS = 2 * 60 * 60 * 1_000
 const CONTROL_RPC_METHODS = new Set([
   'capabilitiesCall',
   'artifactsCall',
+  'lineageCall',
   'mcpCall',
   'computeCall',
   'agentsCall',
@@ -240,6 +253,7 @@ class NotebookLocalRpcServer {
   private readonly artifactProvenance: NotebookLocalRpcServerOptions['artifactProvenance']
   private readonly inputRegistry: NotebookLocalRpcServerOptions['inputRegistry']
   private readonly hostArtifacts: NotebookLocalRpcServerOptions['hostArtifacts']
+  private readonly hostLineage: NotebookLocalRpcServerOptions['hostLineage']
   private readonly agentsService: NotebookLocalRpcServerOptions['agentsService']
   private readonly skillsService: NotebookLocalRpcServerOptions['skillsService']
   private server: Server | undefined
@@ -277,6 +291,7 @@ class NotebookLocalRpcServer {
     this.artifactProvenance = options.artifactProvenance
     this.inputRegistry = options.inputRegistry
     this.hostArtifacts = options.hostArtifacts
+    this.hostLineage = options.hostLineage
     this.agentsService = options.agentsService
     this.skillsService = options.skillsService
   }
@@ -694,7 +709,8 @@ class NotebookLocalRpcServer {
         ? authorization.slice('Bearer '.length)
         : ''
       let hostCapabilities:
-        Record<'mcp' | 'compute' | 'agents' | 'skills' | 'artifacts', boolean> | undefined
+        | Record<'mcp' | 'compute' | 'agents' | 'skills' | 'artifacts' | 'lineage', boolean>
+        | undefined
       if (isArtifactRpcMethod(method)) {
         const acquired = this.acquireArtifactRpcRequest(method, bearerToken, params)
         params = acquired.params
@@ -705,8 +721,25 @@ class NotebookLocalRpcServer {
           if (sessionBinding.allowedMethods && !sessionBinding.allowedMethods.has(method)) {
             throw new RpcHttpError(403, `Notebook RPC capability does not allow ${method}.`)
           }
-          if (method === 'artifactsCall' && !sessionBinding.isControl) {
-            throw new RpcHttpError(403, 'host.artifacts requires a control-plane REPL capability.')
+          if (
+            (method === 'artifactsCall' || method === 'lineageCall') &&
+            !sessionBinding.isControl
+          ) {
+            throw new RpcHttpError(
+              403,
+              method === 'lineageCall'
+                ? 'host.lineage requires a control-plane REPL capability.'
+                : 'host.artifacts requires a control-plane REPL capability.'
+            )
+          }
+          if (method === 'lineageCall') {
+            const allowedKeys =
+              params.op === 'graph'
+                ? new Set(['op', 'version_id', 'options'])
+                : new Set(['op', 'version_id'])
+            if (Object.keys(params).some((key) => !allowedKeys.has(key))) {
+              throw new Error('host.lineage RPC params are invalid.')
+            }
           }
           if (
             method === 'agentsCall' &&
@@ -726,7 +759,8 @@ class NotebookLocalRpcServer {
               compute: allows('computeCall') && Boolean(this.computeService),
               agents: allows('agentsCall') && Boolean(this.agentsService),
               skills: allows('skillsCall') && Boolean(this.skillsService),
-              artifacts: allows('artifactsCall') && Boolean(this.hostArtifacts)
+              artifacts: allows('artifactsCall') && Boolean(this.hostArtifacts),
+              lineage: allows('lineageCall') && Boolean(this.hostLineage)
             }
           }
           // The request body is agent-controlled. Owner fields always come from the unforgeable,
@@ -872,6 +906,21 @@ class NotebookLocalRpcServer {
         return this.hostArtifacts.resolvePath(params.version_id, context)
       }
       throw new Error('Unknown host Artifact operation.')
+    }
+
+    if (method === 'lineageCall') {
+      if (!this.hostLineage) throw new Error('Host Lineage reads are not configured.')
+      const projectId = typeof params.projectId === 'string' ? params.projectId : ''
+      const sessionId = typeof params.sessionId === 'string' ? params.sessionId : ''
+      if (!projectId || !sessionId) {
+        throw new Error('Host Lineage reads require a session-bound Project scope.')
+      }
+      const context = { projectId, sessionId }
+      if (params.op === 'graph') {
+        return this.hostLineage.graph(params.version_id, params.options, context)
+      }
+      if (params.op === 'get') return this.hostLineage.get(params.version_id, context)
+      throw new Error('Unknown host.lineage operation.')
     }
 
     if (method === 'resolveNotebookInput') {

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -101,8 +101,22 @@ describe('repl_loop local RPC transport', () => {
         requests.push(JSON.parse(body))
         const result =
           requests.length === 3
-            ? { mcp: 'yes', compute: true, agents: true, skills: true, artifacts: true }
-            : { mcp: true, compute: true, agents: true, skills: true, artifacts: true }
+            ? {
+                mcp: 'yes',
+                compute: true,
+                agents: true,
+                skills: true,
+                artifacts: true,
+                lineage: true
+              }
+            : {
+                mcp: true,
+                compute: true,
+                agents: true,
+                skills: true,
+                artifacts: true,
+                lineage: true
+              }
         response
           .writeHead(200, { 'content-type': 'application/json' })
           .end(JSON.stringify({ result }))
@@ -126,8 +140,22 @@ describe('repl_loop local RPC transport', () => {
       )
       expect(projection.error).toBeNull()
       expect(JSON.parse(projection.result ?? '{}')).toEqual({
-        first: { mcp: true, compute: true, agents: true, skills: true, artifacts: true },
-        second: { mcp: true, compute: true, agents: true, skills: true, artifacts: true },
+        first: {
+          mcp: true,
+          compute: true,
+          agents: true,
+          skills: true,
+          artifacts: true,
+          lineage: true
+        },
+        second: {
+          mcp: true,
+          compute: true,
+          agents: true,
+          skills: true,
+          artifacts: true,
+          lineage: true
+        },
         frozen: true,
         same: false
       })
@@ -151,6 +179,274 @@ describe('repl_loop local RPC transport', () => {
         'host.capabilities returned an invalid capability projection'
       )
       expect(requests).toHaveLength(3)
+    } finally {
+      child.kill()
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  }, 60_000)
+
+  it('validates, freezes, and freshly reads host.lineage graph and core provenance', async () => {
+    const requests: Array<{ method?: string; params?: Record<string, unknown> }> = []
+    const graphResult = (versionId: string): Record<string, unknown> => ({
+      project_id: 'project-a',
+      root_version_id: versionId,
+      direction: 'up',
+      truncated: false,
+      nodes: [
+        {
+          file_id: 'artifact-1',
+          version_id: versionId,
+          filename: 'result.csv',
+          version_number: 1,
+          session_id: 'session-other',
+          root_frame_id: 'root-1',
+          agent_frame_id: 'agent-1',
+          created_at: '2026-08-01T00:00:00.000Z',
+          content_type: 'text/csv',
+          size_bytes: 12,
+          checksum: 'a'.repeat(64),
+          is_user_upload: false
+        }
+      ],
+      edges: []
+    })
+    const server = createServer((request, response) => {
+      let body = ''
+      request.on('data', (chunk) => (body += chunk))
+      request.on('end', () => {
+        const parsed = JSON.parse(body) as {
+          method?: string
+          params?: Record<string, unknown>
+        }
+        requests.push(parsed)
+        const versionId = String(parsed.params?.version_id)
+        let result: Record<string, unknown>
+        if (parsed.params?.op === 'get') {
+          const environment = {
+            capture_kind: 'completed-run',
+            environment_name: 'science',
+            kernel_kind: 'python',
+            runtime_source: 'managed',
+            runtime_version: '3.13.5',
+            platform: 'darwin',
+            architecture: 'arm64',
+            packages: [
+              {
+                name: 'numpy',
+                version: '2.0.0',
+                version_status: 'known',
+                ecosystem: 'python',
+                evidence_sources: ['python-importlib-metadata'],
+                loaded_state: 'loaded',
+                library_rank: 0,
+                library_scope: 'environment',
+                built_for_runtime: '3.13',
+                priority: 'other'
+              }
+            ],
+            python_version: '3.13.5',
+            inventory_sources: ['kernel-native', 'operation-log'],
+            installed_inventory: {
+              captured_at: '2026-08-01T00:00:00.000Z',
+              source: 'full-scan',
+              validation: 'full-scan'
+            },
+            op_log: [
+              {
+                operation_id: 'operation-1',
+                timestamp: '2026-08-01T00:00:00.000Z',
+                operation: 'install',
+                packages: ['numpy'],
+                result: 'success',
+                attempts: [
+                  {
+                    group_ordinal: 0,
+                    installer: 'pip',
+                    packages: ['numpy'],
+                    status: 'succeeded',
+                    mutation_risk: 'confirmed',
+                    reason: 'unknown'
+                  }
+                ],
+                fallback_used: false,
+                inventory_refresh: 'published',
+                inventory_refresh_attempts: [
+                  {
+                    attempt: 1,
+                    trigger: 'terminal',
+                    timestamp: '2026-08-01T00:00:01.000Z',
+                    result: 'published'
+                  }
+                ],
+                package_changes: [
+                  {
+                    name: 'numpy',
+                    ecosystem: 'python',
+                    relationship: 'requested',
+                    change: 'installed',
+                    after_version: '2.0.0',
+                    library_rank: 0,
+                    library_scope: 'environment'
+                  }
+                ]
+              }
+            ],
+            op_log_truncation: {
+              omitted_count: 2,
+              earliest_retained_at: '2026-07-31T23:59:00.000Z'
+            },
+            captured_at: '2026-08-01T00:00:00.000Z',
+            source_manifest_checksum: 'b'.repeat(64),
+            complete: true,
+            capture_status: 'complete',
+            warnings: ['capture warning']
+          }
+          if (versionId === 'invalid-environment-reason') {
+            environment.op_log[0].attempts[0].reason = 'secret-reason'
+          }
+          if (versionId === 'unknown-environment-key') {
+            Object.assign(environment.packages[0], { storage_key: 'secret' })
+          }
+          if (versionId === 'invalid-environment-truncation') {
+            environment.op_log_truncation.omitted_count = 0
+          }
+          result = {
+            project_id: 'project-a',
+            artifact_id: 'artifact-1',
+            version_id: versionId,
+            filename: 'result.csv',
+            version_number: 1,
+            session_id: 'session-other',
+            root_frame_id: 'root-1',
+            agent_frame_id: 'agent-1',
+            message_branch_id: 'branch-1',
+            runtime_segment_id: 'runtime-1',
+            prompt_message_id: 'prompt-1',
+            created_at: '2026-08-01T00:00:00.000Z',
+            content_type: 'text/csv',
+            size_bytes: 12,
+            checksum: 'a'.repeat(64),
+            content_status: { state: 'available' },
+            reproduction_code: 'print(1)',
+            execution_status: { state: 'available' },
+            producer: {
+              state: 'available',
+              notebook_session_id: 'notebook-1',
+              producer_run_id: 'run-1',
+              run_index: 0,
+              kernel_kind: 'python',
+              association_method: 'agent-declared-and-session-validated',
+              environment_manifest_checksum: 'b'.repeat(64)
+            },
+            environment_status: { state: 'available' },
+            environment,
+            inputs: []
+          }
+        } else {
+          result = graphResult(versionId)
+          if (versionId === 'invalid-v1') {
+            result.nodes = [{ ...(result.nodes as object[])[0], storage_key: 'secret' }]
+          }
+        }
+        response
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ result }))
+      })
+    })
+    const connection = await listenForLocalRpc(server, {
+      name: 'repl-loop-lineage-test',
+      transport: 'pipe'
+    })
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+      OPEN_SCIENCE_MCP_RPC_SOCKET_PATH: connection.socketPath,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'test-token'
+    })
+
+    try {
+      const projection = await send(
+        "const first = await host.lineage.graph('artifact-v1', { max_depth: 0 }); " +
+          "const second = await host.lineage.graph('artifact-v1', { max_depth: 0 }); " +
+          "const core = await host.lineage.get('artifact-v1'); " +
+          'return JSON.stringify({ firstFrozen: Object.isFrozen(first), ' +
+          'nodesFrozen: Object.isFrozen(first.nodes), nodeFrozen: Object.isFrozen(first.nodes[0]), ' +
+          'fresh: first !== second, coreFrozen: Object.isFrozen(core), ' +
+          'inputsFrozen: Object.isFrozen(core.inputs), producerFrozen: Object.isFrozen(core.producer), ' +
+          'environmentFrozen: Object.isFrozen(core.environment), ' +
+          'packagesFrozen: Object.isFrozen(core.environment.packages), ' +
+          'packageFrozen: Object.isFrozen(core.environment.packages[0]), ' +
+          'opLogFrozen: Object.isFrozen(core.environment.op_log), ' +
+          'attemptFrozen: Object.isFrozen(core.environment.op_log[0].attempts[0]) })'
+      )
+      expect(projection.error).toBeNull()
+      expect(JSON.parse(projection.result ?? '{}')).toEqual({
+        firstFrozen: true,
+        nodesFrozen: true,
+        nodeFrozen: true,
+        fresh: true,
+        coreFrozen: true,
+        inputsFrozen: true,
+        producerFrozen: true,
+        environmentFrozen: true,
+        packagesFrozen: true,
+        packageFrozen: true,
+        opLogFrozen: true,
+        attemptFrozen: true
+      })
+      expect(requests).toEqual([
+        {
+          method: 'lineageCall',
+          params: { op: 'graph', version_id: 'artifact-v1', options: { max_depth: 0 } }
+        },
+        {
+          method: 'lineageCall',
+          params: { op: 'graph', version_id: 'artifact-v1', options: { max_depth: 0 } }
+        },
+        { method: 'lineageCall', params: { op: 'get', version_id: 'artifact-v1' } }
+      ])
+
+      const extraArgument = await send(
+        "try { await host.lineage.get('artifact-v1', {}); return 'no error' } " +
+          "catch (error) { return error.name + ': ' + error.message }"
+      )
+      expect(extraArgument.result).toBe('TypeError: host.lineage.get accepts one version_id')
+      expect(requests).toHaveLength(3)
+
+      const invalidProjection = await send(
+        "try { await host.lineage.graph('invalid-v1'); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(invalidProjection.result).toBe('host.lineage.graph returned an invalid node')
+      expect(requests).toHaveLength(4)
+
+      const invalidEnvironmentReason = await send(
+        "try { await host.lineage.get('invalid-environment-reason'); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(invalidEnvironmentReason.result).toBe(
+        'host.lineage.get returned an invalid environment attempt'
+      )
+      expect(requests).toHaveLength(5)
+
+      const unknownEnvironmentKey = await send(
+        "try { await host.lineage.get('unknown-environment-key'); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(unknownEnvironmentKey.result).toBe(
+        'host.lineage.get returned an invalid environment package'
+      )
+      expect(requests).toHaveLength(6)
+
+      const invalidEnvironmentTruncation = await send(
+        "try { await host.lineage.get('invalid-environment-truncation'); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(invalidEnvironmentTruncation.result).toBe(
+        'host.lineage.get returned an invalid operation-log truncation'
+      )
+      expect(requests).toHaveLength(7)
     } finally {
       child.kill()
       await new Promise<void>((resolve, reject) =>

--- a/src/main/project-files/host-artifact-catalog.test.ts
+++ b/src/main/project-files/host-artifact-catalog.test.ts
@@ -189,7 +189,10 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
       expect.objectContaining({
         sourceFileId: 'artifact-a',
         versionId: 'history-v1',
-        rootFrameId: 'root-history-v1'
+        versionNumber: 1,
+        createdAt: '2026-08-01T00:00:00.000Z',
+        rootFrameId: 'root-history-v1',
+        agentFrameId: 'agent-frame'
       })
     ])
     await expect(

--- a/src/main/project-files/host-artifact-catalog.test.ts
+++ b/src/main/project-files/host-artifact-catalog.test.ts
@@ -89,7 +89,8 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
     projectId: string,
     sessionId: string,
     uploadId: string,
-    versionId: string
+    versionId: string,
+    createdAt: Date | null = new Date('2026-08-03T00:00:00.000Z')
   ): Promise<void> => {
     await client.uploadFile.create({
       data: {
@@ -109,7 +110,8 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
             contentType: 'application/pdf',
             sizeBytes: 12n,
             checksum: checksum(versionId),
-            createdAt: new Date('2026-08-03T00:00:00.000Z')
+            createdAt,
+            registeredAt: new Date('2026-08-04T00:00:00.000Z')
           }
         }
       }
@@ -191,6 +193,7 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
         versionId: 'history-v1',
         versionNumber: 1,
         createdAt: '2026-08-01T00:00:00.000Z',
+        sourceCreatedAt: '2026-08-01T00:00:00.000Z',
         rootFrameId: 'root-history-v1',
         agentFrameId: 'agent-frame'
       })
@@ -198,6 +201,25 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
     await expect(
       repository.readHostArtifactCatalog({ projectId: 'project-a', versionId: 'other-project-v1' })
     ).resolves.toEqual([])
+
+    await createUploadVersion(
+      'project-a',
+      'session-b',
+      'upload-null-created-at',
+      'upload-null-created-at-v1',
+      null
+    )
+    const nullableUpload = await repository.readHostArtifactCatalog({
+      projectId: 'project-a',
+      versionId: 'upload-null-created-at-v1'
+    })
+    expect(nullableUpload).toEqual([
+      expect.objectContaining({
+        versionId: 'upload-null-created-at-v1',
+        createdAt: '2026-08-04T00:00:00.000Z'
+      })
+    ])
+    expect(nullableUpload[0]).not.toHaveProperty('sourceCreatedAt')
 
     await createArtifactVersion('project-a', 'session-a', 'collision-artifact', 'collision')
     await createUploadVersion('project-a', 'session-b', 'collision-upload', 'collision')

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -296,6 +296,7 @@ class ProjectFilesQueryOwner {
             source: 'artifact',
             sourceFileId: artifactVersion.artifactId,
             versionId: artifactVersion.id,
+            versionNumber: artifactVersion.versionNumber,
             checksum: artifactVersion.checksum,
             projectId: artifactVersion.artifact.projectId,
             sessionId: artifactVersion.artifact.sessionId,
@@ -303,7 +304,9 @@ class ProjectFilesQueryOwner {
             contentType: artifactVersion.contentType ?? undefined,
             sizeBytes: toSafeCount(artifactVersion.sizeBytes, 'host Artifact size'),
             sortAtMs: artifactVersion.createdAt.getTime(),
-            rootFrameId: artifactVersion.rootFrameId
+            createdAt: artifactVersion.createdAt.toISOString(),
+            rootFrameId: artifactVersion.rootFrameId,
+            agentFrameId: artifactVersion.agentFrameId
           }
         ]
       }
@@ -315,6 +318,7 @@ class ProjectFilesQueryOwner {
               source: 'upload',
               sourceFileId: uploadVersion.uploadFileId,
               versionId: uploadVersion.id,
+              versionNumber: uploadVersion.versionNumber,
               checksum: uploadVersion.checksum,
               projectId: uploadVersion.uploadFile.projectId,
               sessionId: uploadVersion.uploadFile.sessionId,
@@ -322,7 +326,9 @@ class ProjectFilesQueryOwner {
               contentType: uploadVersion.contentType ?? undefined,
               sizeBytes: toSafeCount(uploadVersion.sizeBytes, 'host Upload size'),
               sortAtMs: uploadTime.getTime(),
-              rootFrameId: null
+              createdAt: uploadTime.toISOString(),
+              rootFrameId: null,
+              agentFrameId: null
             }
           ]
         : []

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -305,6 +305,7 @@ class ProjectFilesQueryOwner {
             sizeBytes: toSafeCount(artifactVersion.sizeBytes, 'host Artifact size'),
             sortAtMs: artifactVersion.createdAt.getTime(),
             createdAt: artifactVersion.createdAt.toISOString(),
+            sourceCreatedAt: artifactVersion.createdAt.toISOString(),
             rootFrameId: artifactVersion.rootFrameId,
             agentFrameId: artifactVersion.agentFrameId
           }
@@ -327,6 +328,9 @@ class ProjectFilesQueryOwner {
               sizeBytes: toSafeCount(uploadVersion.sizeBytes, 'host Upload size'),
               sortAtMs: uploadTime.getTime(),
               createdAt: uploadTime.toISOString(),
+              ...(uploadVersion.createdAt
+                ? { sourceCreatedAt: uploadVersion.createdAt.toISOString() }
+                : {}),
               rootFrameId: null,
               agentFrameId: null
             }

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -601,6 +601,7 @@ describe('Settings backend ownership architecture', () => {
     expect(stringSetValues(settingsPaths.notebookLocalRpcServer, 'CONTROL_RPC_METHODS')).toEqual([
       'capabilitiesCall',
       'artifactsCall',
+      'lineageCall',
       'mcpCall',
       'computeCall',
       'agentsCall',

--- a/src/main/skills/self-awareness-skill.test.ts
+++ b/src/main/skills/self-awareness-skill.test.ts
@@ -22,7 +22,7 @@ describe('self-awareness bundled Skill', () => {
     expect(skill?.description).toMatch(/JavaScript control REPL/i)
   })
 
-  it('documents the shipped five-key JavaScript contract and Artifact read limits', async () => {
+  it('documents the shipped six-key JavaScript contract and Artifact lineage read limits', async () => {
     const body = await new SkillRegistry(skillsRoot).body('self-awareness')
 
     for (const phrase of [
@@ -33,6 +33,7 @@ describe('self-awareness bundled Skill', () => {
       '`agents`',
       '`skills`',
       '`artifacts`',
+      '`lineage`',
       'caps.compute === true',
       'caps.artifacts === true',
       'await host.artifacts(options)',
@@ -42,6 +43,15 @@ describe('self-awareness bundled Skill', () => {
       'collisions',
       'never content',
       'fresh frozen projection',
+      'caps.lineage === true',
+      'await host.lineage.graph(versionId)',
+      'await host.lineage.get(versionId)',
+      'graph discovery',
+      'session-bound control token',
+      'another Session',
+      'cross-Project edges',
+      'storage keys',
+      'Python/R `host`',
       'same feature change'
     ]) {
       expect(body).toContain(phrase)

--- a/src/shared/host-lineage.ts
+++ b/src/shared/host-lineage.ts
@@ -1,0 +1,105 @@
+import type {
+  ArtifactVersionAvailability,
+  ArtifactVersionEnvironmentEvidence
+} from './artifact-provenance'
+import type { NotebookInputAssociation } from './notebook'
+
+export type HostLineageDirection = 'up' | 'down'
+
+export type HostLineageNode = {
+  file_id: string
+  version_id: string
+  filename: string
+  version_number: number
+  session_id: string
+  root_frame_id: string | null
+  agent_frame_id: string | null
+  created_at: string
+  content_type?: string
+  size_bytes: number
+  checksum: string
+  is_user_upload: boolean
+}
+
+export type HostLineageEdge = {
+  version_id: string
+  depends_on_version_id: string
+  ordinal: number
+  source_kind: 'artifact-version' | 'upload-version'
+  input_filename: string
+  association: NotebookInputAssociation
+}
+
+export type HostLineageGraph = {
+  project_id: string
+  root_version_id: string
+  direction: HostLineageDirection
+  truncated: boolean
+  truncation_reason?: 'max_depth' | 'max_nodes'
+  frontier_version_ids?: string[]
+  nodes: HostLineageNode[]
+  edges: HostLineageEdge[]
+}
+
+export type HostLineageVersion = {
+  project_id: string
+  artifact_id: string
+  version_id: string
+  filename: string
+  version_number: number
+  session_id: string
+  root_frame_id: string
+  agent_frame_id: string
+  message_branch_id: string
+  runtime_segment_id: string
+  prompt_message_id: string
+  created_at: string
+  content_type?: string
+  size_bytes: number
+  checksum: string
+  agent_name?: string
+  content_status:
+    { state: 'available' } | { state: 'unavailable'; reason: 'missing' | 'checksum-mismatch' }
+  reproduction_code?: string
+  execution_status: ArtifactVersionAvailability
+  producer:
+    | {
+        state: 'available'
+        notebook_session_id: string
+        producer_run_id: string
+        run_index: number
+        kernel_kind: 'python' | 'r' | 'repl' | 'bash'
+        association_method:
+          'agent-declared-and-session-validated' | 'server-inferred-file-observation'
+        environment_manifest_checksum?: string
+      }
+    | {
+        state: 'unavailable'
+        reason: 'producer-not-supplied' | 'producer-source-unverifiable'
+      }
+  environment_status: ArtifactVersionAvailability
+  environment?: ArtifactVersionEnvironmentEvidence
+  inputs: Array<{
+    ordinal: number
+    version_id: string
+    file_id: string
+    source_kind: 'artifact-version' | 'upload-version'
+    version_number?: number
+    created_at?: string
+    session_id: string
+    filename: string
+    content_type?: string
+    size_bytes: number
+    checksum: string
+    association: NotebookInputAssociation
+  }>
+}
+
+export type HostLineageDependencyRelation = {
+  versionId: string
+  dependsOnVersionId: string
+  ordinal: number
+  sourceKind: 'artifact-version' | 'upload-version'
+  inputFilename: string
+  association: NotebookInputAssociation
+}

--- a/src/shared/project-files.ts
+++ b/src/shared/project-files.ts
@@ -119,6 +119,7 @@ export type HostArtifactCatalogItem = {
   source: ProjectFileSource
   sourceFileId: string
   versionId: string
+  versionNumber?: number
   checksum?: string
   projectId: string
   sessionId: string
@@ -126,7 +127,9 @@ export type HostArtifactCatalogItem = {
   contentType?: string
   sizeBytes: number
   sortAtMs: number
+  createdAt?: string
   rootFrameId: string | null
+  agentFrameId?: string | null
 }
 
 export type HostArtifact = {

--- a/src/shared/project-files.ts
+++ b/src/shared/project-files.ts
@@ -128,6 +128,7 @@ export type HostArtifactCatalogItem = {
   sizeBytes: number
   sortAtMs: number
   createdAt?: string
+  sourceCreatedAt?: string
   rootFrameId: string | null
   agentFrameId?: string | null
 }


### PR DESCRIPTION
## Summary
- add project-scoped host.lineage.graph and host.lineage.get to the JavaScript control REPL
- expose lineage atomically through host capabilities and all four framework routes
- add fail-closed catalog, dependency graph, and immutable provenance evidence validation
- document graph-first lineage access in the bundled internal self-awareness skill

## Validation
- affected lineage/provenance tests: 83 passed, 30 skipped
- Node and Web TypeScript checks passed
- lint passed with 0 errors (17 pre-existing warnings)
- Standards and Spec independent reviews passed with no remaining findings
- full npm test was executed; unrelated parallel timeout/flaky cases passed when rerun serially, while the shared parent @prisma/client remains mismatched with this branch schema (PermissionGrantSeed)