### PR TITLE
fix(compute): centralize session enabled host ownership

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -187,10 +187,16 @@
         "src/main/compute/job-dispatcher.ts",
         "src/main/compute/job-poller.ts",
         "src/main/compute/job-repository.ts",
+        "src/main/compute/enabled-hosts-registry.ts",
+        "src/main/compute/session-enabled-hosts-owner.ts",
         "src/main/compute/permission-grant-adapter.ts",
         "src/main/compute/compute-service.ts"
       ],
-      "interfacePaths": ["src/main/compute/compute-service.ts", "src/main/compute/ipc.ts"],
+      "interfacePaths": [
+        "src/main/compute/compute-service.ts",
+        "src/main/compute/ipc.ts",
+        "src/main/compute/electron-ipc-adapter.ts"
+      ],
       "consumerModules": [],
       "testFiles": {
         "owner": [
@@ -200,6 +206,7 @@
           "src/main/compute/compute-host-profile-owner.test.ts",
           "src/main/compute/compute-job-workflow-owner.test.ts",
           "src/main/compute/compute-remote-operation-owner.test.ts",
+          "src/main/compute/session-enabled-hosts-owner.test.ts",
           "src/main/compute/permission-grant-adapter.test.ts",
           "src/main/compute/compute-service.test.ts",
           "src/main/compute/compute-jobs.integration.test.ts",

--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -119,10 +119,10 @@ describe('production application command wiring', () => {
     expect(legacyAdapterBlock).toContain('registerPreviewStateIpcHandlers(previewStateRepository)')
 
     expect(compact(ipcSource)).toContain(
-      'electronAdapters: { beforeCompute: beforeComputeAdapters, compute: computeIpcModule,'
+      'electronAdapters: { beforeCompute: beforeComputeAdapters, compute: { handlers: computeIpcModule.handlers, enabledHosts: sessionEnabledComputeHostsOwner },'
     )
     expect(dependencyBlock).toContain('compute: computeIpcModule.handlers')
-    expect(dependencyBlock).toContain('enabledHosts: hostsRegistry')
+    expect(dependencyBlock).toContain('enabledHosts: sessionEnabledComputeHostsOwner')
   })
 
   it('keeps native-only commands inside the Electron owner adapter and exposes only narrow views', () => {

--- a/src/main/compute/application-commands.test.ts
+++ b/src/main/compute/application-commands.test.ts
@@ -202,7 +202,7 @@ describe('Compute application commands', () => {
     expect(enabledHostsResult).toEqual(session)
     expect(dependencies.events.publish).toHaveBeenCalledWith('session:updated', {
       session,
-      originClientId: 'electron:7'
+      originClientId: 'main:enabled-compute-hosts'
     })
     expect(dependencies.bookmarks.set).toHaveBeenCalledWith('ssh:cluster', ['/work'])
   })

--- a/src/main/compute/application-commands.test.ts
+++ b/src/main/compute/application-commands.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { ComputeHost } from '../../shared/compute'
 import { decodeRemoteFsError } from '../../shared/remote-fs'
 import { RENDERER_CONTRACT_GROUPS } from '../../shared/renderer-contract-catalog'
+import type { PersistedChatSession } from '../../shared/session-persistence'
 import {
   createApplicationCommandRouter,
   type ApplicationCallerLease,
@@ -24,6 +25,18 @@ import {
 } from './application-commands'
 
 const host = { providerId: 'ssh:cluster', displayName: 'Cluster' } as ComputeHost
+const session: PersistedChatSession = {
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [],
+  filesRevision: 1,
+  enabledComputeHosts: ['ssh:cluster'],
+  createdAt: 1,
+  updatedAt: 2
+}
 
 const createDependencies = (): ComputeApplicationCommandDependencies => ({
   compute: {
@@ -52,8 +65,9 @@ const createDependencies = (): ComputeApplicationCommandDependencies => ({
   },
   enabledHosts: {
     get: vi.fn(() => ['ssh:cluster']),
-    set: vi.fn(() => undefined)
-  }
+    set: vi.fn(async () => session)
+  },
+  events: { publish: vi.fn() }
 })
 
 const invocation = <Args extends readonly unknown[]>(
@@ -154,7 +168,7 @@ describe('Compute application commands', () => {
       computeApplicationCommands.enabledHostsGet,
       invocation(['session-1'])
     )
-    await router.dispatcher.invoke(
+    const enabledHostsResult = await router.dispatcher.invoke(
       computeApplicationCommands.enabledHostsSet,
       invocation(['session-1', ['ssh:cluster']])
     )
@@ -185,6 +199,11 @@ describe('Compute application commands', () => {
     expect(dependencies.compute.jobsList).toHaveBeenCalledWith(filter)
     expect(dependencies.compute.jobsMarkConsumed).toHaveBeenCalledWith('session-1', ['job-1'])
     expect(dependencies.enabledHosts.set).toHaveBeenCalledWith('session-1', ['ssh:cluster'])
+    expect(enabledHostsResult).toEqual(session)
+    expect(dependencies.events.publish).toHaveBeenCalledWith('session:updated', {
+      session,
+      originClientId: 'electron:7'
+    })
     expect(dependencies.bookmarks.set).toHaveBeenCalledWith('ssh:cluster', ['/work'])
   })
 

--- a/src/main/compute/application-commands.ts
+++ b/src/main/compute/application-commands.ts
@@ -1,11 +1,14 @@
 import type { ComputeApprovalDecision, DeleteComputeHostRequest } from '../../shared/compute'
+import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
 import { encodeRemoteFsError, type SerializableRemoteFsError } from '../../shared/remote-fs'
+import type { PersistedChatSession } from '../../shared/session-persistence'
 import {
   defineApplicationCommand,
   defineApplicationCommandGroup,
   type ApplicationCommandInstallation,
   type ApplicationCommandRegistrar
 } from '../application-command-router'
+import type { ApplicationEventPublisher } from '../application-events'
 import { canSatisfyHumanApproval, type CallerContext } from '../caller-context'
 import type { ComputeHandlers } from './ipc'
 
@@ -38,7 +41,7 @@ type ComputeBookmarksOwner = Readonly<{
 
 type ComputeEnabledHostsOwner = Readonly<{
   get(sessionId: string): string[]
-  set(sessionId: string, providerIds: string[]): void
+  set(sessionId: string, providerIds: readonly string[]): Promise<PersistedChatSession>
 }>
 
 type OwnerArgs<Owner, Method extends keyof Owner> = Owner[Method] extends (
@@ -195,6 +198,7 @@ type ComputeApplicationCommandDependencies = Readonly<{
   compute: ComputeCommandOwner
   bookmarks: ComputeBookmarksOwner
   enabledHosts: ComputeEnabledHostsOwner
+  events: ApplicationEventPublisher
 }>
 
 const withSerializedRemoteFsError = async <Result>(
@@ -266,7 +270,18 @@ const registerComputeApplicationCommands = (
       'compute:jobs:mark-consumed': ({ args }) =>
         dependencies.compute.jobsMarkConsumed(args[0], args[1]),
       'compute:enabled-hosts:get': ({ args }) => dependencies.enabledHosts.get(args[0]),
-      'compute:enabled-hosts:set': ({ args }) => dependencies.enabledHosts.set(args[0], args[1]),
+      'compute:enabled-hosts:set': async ({ args, callerContext }) => {
+        const session = await dependencies.enabledHosts.set(args[0], args[1])
+        try {
+          dependencies.events.publish(LIFECYCLE_CHANNELS.sessionUpdated, {
+            session,
+            originClientId: callerContext.lifecycleClientId
+          })
+        } catch {
+          // Lifecycle delivery cannot roll back committed Session authority.
+        }
+        return session
+      },
       'compute:bookmarks:get': ({ args }) => dependencies.bookmarks.get(args[0]),
       'compute:bookmarks:set': ({ args }) => dependencies.bookmarks.set(args[0], args[1])
     })

--- a/src/main/compute/application-commands.ts
+++ b/src/main/compute/application-commands.ts
@@ -1,5 +1,8 @@
 import type { ComputeApprovalDecision, DeleteComputeHostRequest } from '../../shared/compute'
-import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
+import {
+  LIFECYCLE_CHANNELS,
+  MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID
+} from '../../shared/lifecycle-events'
 import { encodeRemoteFsError, type SerializableRemoteFsError } from '../../shared/remote-fs'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import {
@@ -270,12 +273,12 @@ const registerComputeApplicationCommands = (
       'compute:jobs:mark-consumed': ({ args }) =>
         dependencies.compute.jobsMarkConsumed(args[0], args[1]),
       'compute:enabled-hosts:get': ({ args }) => dependencies.enabledHosts.get(args[0]),
-      'compute:enabled-hosts:set': async ({ args, callerContext }) => {
+      'compute:enabled-hosts:set': async ({ args }) => {
         const session = await dependencies.enabledHosts.set(args[0], args[1])
         try {
           dependencies.events.publish(LIFECYCLE_CHANNELS.sessionUpdated, {
             session,
-            originClientId: callerContext.lifecycleClientId
+            originClientId: MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID
           })
         } catch {
           // Lifecycle delivery cannot roll back committed Session authority.

--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -43,7 +43,9 @@ const computePaths = {
   concurrencyManager: resolve(mainRoot, 'compute/concurrency-manager.ts'),
   jobDispatcher: resolve(mainRoot, 'compute/job-dispatcher.ts'),
   jobPoller: resolve(mainRoot, 'compute/job-poller.ts'),
+  sessionEnabledHostsOwner: resolve(mainRoot, 'compute/session-enabled-hosts-owner.ts'),
   ipc: resolve(mainRoot, 'compute/ipc.ts'),
+  electronIpcAdapter: resolve(mainRoot, 'compute/electron-ipc-adapter.ts'),
   mainIpc: resolve(mainRoot, 'ipc.ts'),
   applicationCommands: resolve(mainRoot, 'compute/application-commands.ts'),
   jobRuntime: resolve(mainRoot, 'compute/job-runtime.ts'),
@@ -213,6 +215,7 @@ describe('Compute service architecture', () => {
         portableProjectPath(ownerPath)
       ).toBeLessThanOrEqual(660)
     }
+    expect(rawLineCount(readSource(computePaths.sessionEnabledHostsOwner))).toBeLessThanOrEqual(660)
     for (const lifecyclePath of lifecyclePaths) {
       expect(
         rawLineCount(readSource(lifecyclePath)),
@@ -220,6 +223,7 @@ describe('Compute service architecture', () => {
       ).toBeLessThanOrEqual(660)
     }
     expect(rawLineCount(readSource(computePaths.ipc))).toBeLessThanOrEqual(660)
+    expect(rawLineCount(readSource(computePaths.electronIpcAdapter))).toBeLessThanOrEqual(660)
   })
 
   it('keeps lifecycle state ownership behind the narrow intent interface', () => {
@@ -491,18 +495,22 @@ describe('Compute service architecture', () => {
       'src/main/compute/job-dispatcher.ts',
       'src/main/compute/job-poller.ts',
       'src/main/compute/job-repository.ts',
+      'src/main/compute/enabled-hosts-registry.ts',
+      'src/main/compute/session-enabled-hosts-owner.ts',
       'src/main/compute/permission-grant-adapter.ts',
       'src/main/compute/compute-service.ts'
     ])
     expect(computeService.interfacePaths).toEqual([
       'src/main/compute/compute-service.ts',
-      'src/main/compute/ipc.ts'
+      'src/main/compute/ipc.ts',
+      'src/main/compute/electron-ipc-adapter.ts'
     ])
     expect(computeService.testFiles.owner).toEqual(
       expect.arrayContaining([
         architectureTestPath,
         'src/main/compute/compute-job-lifecycle.test.ts',
         'src/main/compute/job-deletion-owner.test.ts',
+        'src/main/compute/session-enabled-hosts-owner.test.ts',
         'src/main/compute/compute-host-profile-owner.test.ts',
         'src/main/compute/compute-job-workflow-owner.test.ts',
         'src/main/compute/compute-remote-operation-owner.test.ts',

--- a/src/main/compute/electron-ipc-adapter.ts
+++ b/src/main/compute/electron-ipc-adapter.ts
@@ -1,0 +1,150 @@
+import type {
+  ComputeApprovalDecision,
+  CreateComputeHostRequest,
+  DeleteComputeHostRequest,
+  DetailsAuthor
+} from '../../shared/compute'
+import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
+import type { DownloadDest, SerializableRemoteFsError } from '../../shared/remote-fs'
+import { encodeRemoteFsError } from '../../shared/remote-fs'
+import {
+  createIpcHandlerInstallationScope,
+  ipcMainHandle,
+  type IpcHandlerInstallation
+} from '../ipc-handler-registry'
+import { broadcastLifecycleEvent, getLifecycleClientId } from '../lifecycle-broadcast'
+import type { ComputeHandlers } from './ipc'
+import type { SessionEnabledComputeHostsOwner } from './session-enabled-hosts-owner'
+
+// IPC channel name for the renderer job feed (Phase 3d, issue 05).
+const COMPUTE_JOBS_LIST_CHANNEL = 'compute:jobs:list'
+
+type ComputeIpcAdapter = {
+  handlers: ComputeHandlers
+  enabledHosts: Pick<SessionEnabledComputeHostsOwner, 'get' | 'set'>
+}
+
+const registerComputeIpcHandlerSet = ({ handlers, enabledHosts }: ComputeIpcAdapter): void => {
+  ipcMainHandle('compute:list', () => handlers.list())
+  ipcMainHandle('compute:get', (_event, providerId: string) => handlers.get(providerId))
+  ipcMainHandle('compute:create', (_event, request: CreateComputeHostRequest) =>
+    handlers.create(request)
+  )
+  ipcMainHandle('compute:delete', async (_event, request: DeleteComputeHostRequest) => {
+    await handlers.delete(request.providerId)
+  })
+  ipcMainHandle('compute:ssh-config-aliases', () => handlers.sshConfigAliases())
+  ipcMainHandle('compute:probe', (_event, providerId: string) => handlers.probe(providerId))
+  ipcMainHandle('compute:details:get', (_event, providerId: string) =>
+    handlers.detailsGet(providerId)
+  )
+  ipcMainHandle(
+    'compute:details:save',
+    (_event, providerId: string, text: string, oldText: string, author: DetailsAuthor) =>
+      handlers.detailsSave(providerId, text, oldText, author)
+  )
+  ipcMainHandle('compute:scratch:set', (_event, providerId: string, path: string) =>
+    handlers.scratchSet(providerId, path)
+  )
+  ipcMainHandle('compute:concurrency:set', (_event, providerId: string, limit: number) =>
+    handlers.concurrencySet(providerId, limit)
+  )
+  // Session-level concurrency control (Phase 3c, issue 04).
+  ipcMainHandle(
+    'compute:session:set-concurrency-limit',
+    (_event, sessionId: string, limit: number) =>
+      handlers.setSessionConcurrencyLimit(sessionId, limit)
+  )
+  ipcMainHandle('compute:session:status', (_event, sessionId: string) =>
+    handlers.getSessionConcurrencyStatus(sessionId)
+  )
+  // Lists a remote directory (browse experience, issue 05).
+  ipcMainHandle('compute:list-dir', async (_event, providerId: string, path: string) => {
+    try {
+      return await handlers.listDir(providerId, path)
+    } catch (err) {
+      const e = err as Error & { remoteFsError?: SerializableRemoteFsError }
+      if (e.remoteFsError) {
+        throw new Error(encodeRemoteFsError(e.message, e.remoteFsError))
+      }
+      throw err
+    }
+  })
+  // Downloads a remote file to OS Downloads or project artifact. No approval gate (issue 03).
+  ipcMainHandle(
+    'compute:download',
+    async (_event, providerId: string, remotePath: string, dest: DownloadDest) => {
+      try {
+        return await handlers.download(providerId, remotePath, dest)
+      } catch (err) {
+        const e = err as Error & { remoteFsError?: SerializableRemoteFsError }
+        if (e.remoteFsError) {
+          throw new Error(encodeRemoteFsError(e.message, e.remoteFsError))
+        }
+        throw err
+      }
+    }
+  )
+  // Reveals a local file path in the OS file manager (Finder / Explorer).
+  ipcMainHandle('compute:reveal-in-folder', (_event, filePath: string) => {
+    handlers.revealInFolder(filePath)
+  })
+  // Renderer responds to an in-flight approval card (issue 04/05). Decision now carries the
+  // chosen scope: 'once' | 'conversation' | 'project' | 'deny'.
+  ipcMainHandle(
+    'compute:approval-respond',
+    (_event, request: { id: string; decision: ComputeApprovalDecision }) => {
+      handlers.approvalRespond(request.id, request.decision)
+    }
+  )
+  ipcMainHandle('compute:approval-replay', (_event, id: unknown) =>
+    typeof id === 'string' ? handlers.approvalReplay(id) : null
+  )
+  // Returns all jobs for a session as JobSummary[], optionally filtered by status (Phase 3d).
+  ipcMainHandle(
+    COMPUTE_JOBS_LIST_CHANNEL,
+    (_event, filter: { sessionId: string; status?: string[] }) => handlers.jobsList(filter)
+  )
+  // Returns jobs pending analysis turn (notifiedAt set, notificationConsumedAt null — issue 05).
+  ipcMainHandle('compute:jobs:pending-notification', (_event, sessionId: string) =>
+    handlers.jobsPendingNotification(sessionId)
+  )
+  // Marks job ids as notification-consumed (analysis turn done — issue 05).
+  ipcMainHandle('compute:jobs:mark-consumed', (_event, sessionId: string, jobIds: string[]) =>
+    handlers.jobsMarkConsumed(sessionId, jobIds)
+  )
+
+  // Per-session enabled Compute Hosts. Main commits Session authority before updating the runtime
+  // projection consulted by list_compute.
+  ipcMainHandle('compute:enabled-hosts:get', (_event, sessionId: string): string[] =>
+    enabledHosts.get(sessionId)
+  )
+  ipcMainHandle(
+    'compute:enabled-hosts:set',
+    async (event, sessionId: string, providerIds: string[]) => {
+      const originClientId = getLifecycleClientId(event)
+      const session = await enabledHosts.set(sessionId, providerIds)
+      try {
+        broadcastLifecycleEvent(LIFECYCLE_CHANNELS.sessionUpdated, { session, originClientId })
+      } catch {
+        // Lifecycle delivery cannot roll back committed Session authority.
+      }
+      return session
+    }
+  )
+}
+
+// Installs only the renderer-callable Electron adapter over an already-constructed Compute module.
+const installComputeIpcHandlers = (adapter: ComputeIpcAdapter): IpcHandlerInstallation => {
+  const scope = createIpcHandlerInstallationScope()
+  try {
+    registerComputeIpcHandlerSet(adapter)
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}
+
+export { COMPUTE_JOBS_LIST_CHANNEL, installComputeIpcHandlers }
+export type { ComputeIpcAdapter }

--- a/src/main/compute/enabled-hosts-registry.ts
+++ b/src/main/compute/enabled-hosts-registry.ts
@@ -1,7 +1,5 @@
-// In-memory registry mapping sessionId → enabled compute providerIds (set semantics, array storage).
-// Populated when the renderer calls the set IPC after loading a session, and updated on each toggle.
-// The registry is the authoritative source for `list_compute` RPC ops — the renderer is the
-// persistent source (session JSON), the main process is the runtime cache.
+// Derived runtime projection mapping Session id → enabled Compute Host provider ids. Durable Session
+// JSON is the authority; this cache only serves synchronous list_compute lookups.
 export class EnabledComputeHostsRegistry {
   private readonly map = new Map<string, Set<string>>()
 
@@ -22,6 +20,21 @@ export class EnabledComputeHostsRegistry {
 
   clear(sessionId: string): void {
     this.map.delete(sessionId)
+  }
+
+  removeProvider(providerId: string): void {
+    for (const [sessionId, providerIds] of this.map) {
+      providerIds.delete(providerId)
+      if (providerIds.size === 0) this.map.delete(sessionId)
+    }
+  }
+
+  reconcile(
+    entries: Iterable<readonly [sessionId: string, providerIds: readonly string[]]>,
+    isComplete: boolean
+  ): void {
+    if (isComplete) this.map.clear()
+    for (const [sessionId, providerIds] of entries) this.set(sessionId, [...providerIds])
   }
 }
 

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -516,6 +516,59 @@ describe('host delete guard', () => {
     expect(pruneSessionEnabledHosts).toHaveBeenCalledWith('ssh:biowulf', expect.any(Function))
   })
 
+  it('preserves provider permission grants when host deletion fails', async () => {
+    const del = vi.fn().mockRejectedValue(new Error('Host delete failed'))
+    const prune = vi.fn().mockResolvedValue([])
+    const permissionGrantRegistry = { prune } as unknown as PermissionGrantRegistry
+    const pruneSessionEnabledHosts = vi.fn(
+      async (_providerId: string, deleteProvider?: () => Promise<void>) => deleteProvider?.()
+    )
+    const handlers = createComputeHandlers(
+      mockRepository({ delete: del }),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      permissionGrantRegistry,
+      undefined,
+      { pruneSessionEnabledHosts }
+    )
+
+    await expect(handlers.delete('ssh:biowulf')).rejects.toThrow('Host delete failed')
+
+    expect(prune).not.toHaveBeenCalled()
+  })
+
+  it('treats permission grant cleanup as repairable after host deletion', async () => {
+    const del = vi.fn().mockResolvedValue(undefined)
+    const prune = vi.fn().mockRejectedValue(new Error('Grant cleanup failed'))
+    const permissionGrantRegistry = { prune } as unknown as PermissionGrantRegistry
+    const handlers = createComputeHandlers(
+      mockRepository({ delete: del }),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      permissionGrantRegistry
+    )
+
+    await expect(handlers.delete('ssh:biowulf')).resolves.toBeUndefined()
+
+    expect(del).toHaveBeenCalledOnce()
+    expect(prune).toHaveBeenCalledOnce()
+    expect(del.mock.invocationCallOrder[0]).toBeLessThan(prune.mock.invocationCallOrder[0])
+  })
+
   it('does not expose a replacement provider id until deletion grant cleanup completes', async () => {
     let releaseDeletePrune: (() => void) | undefined
     let pruneCalls = 0

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -462,6 +462,29 @@ describe('host delete guard', () => {
     expect(del).toHaveBeenCalledWith('ssh:biowulf')
   })
 
+  it('keeps the host when enabled Session reference pruning fails', async () => {
+    const del = vi.fn().mockResolvedValue(undefined)
+    const pruneSessionEnabledHosts = vi.fn().mockRejectedValue(new Error('Session write failed'))
+    const handlers = createComputeHandlers(
+      mockRepository({ delete: del }),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { pruneSessionEnabledHosts }
+    )
+
+    await expect(handlers.delete('ssh:biowulf')).rejects.toThrow('Session write failed')
+    expect(del).not.toHaveBeenCalled()
+  })
+
   it('does not expose a replacement provider id until deletion grant cleanup completes', async () => {
     let releaseDeletePrune: (() => void) | undefined
     let pruneCalls = 0

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../shared/compute'
 import type { DirListing, DownloadDest, LocalFile } from '../../shared/remote-fs'
 import { decodeRemoteFsError } from '../../shared/remote-fs'
+import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { ComputeService } from './compute-service'
 import type { ComputeApprovalBroker } from './compute-approval-broker'
 import {
@@ -24,6 +25,7 @@ import {
   installComputeIpcHandlers,
   toJobSummary
 } from './ipc'
+import type { ComputeIpcAdapter, ComputeIpcModule } from './ipc'
 import type { ComputeJobRepository } from './job-repository'
 import type { ComputeHostRepository } from './repository'
 import { EnabledComputeHostsRegistry } from './enabled-hosts-registry'
@@ -482,6 +484,7 @@ describe('host delete guard', () => {
       completeProviderInvalidation
     } as unknown as ComputeApprovalBroker
     const permissionGrantRegistry = { prune } as unknown as PermissionGrantRegistry
+    const pruneSessionEnabledHosts = vi.fn().mockResolvedValue(undefined)
     const handlers = createComputeHandlers(
       mockRepository({ delete: del, get, create }),
       undefined,
@@ -493,7 +496,9 @@ describe('host delete guard', () => {
       undefined,
       undefined,
       undefined,
-      permissionGrantRegistry
+      permissionGrantRegistry,
+      undefined,
+      { pruneSessionEnabledHosts }
     )
 
     const deleting = handlers.delete('ssh:biowulf')
@@ -513,6 +518,9 @@ describe('host delete guard', () => {
       kind: 'compute_provider',
       providerId: 'ssh:biowulf'
     })
+    expect(pruneSessionEnabledHosts).toHaveBeenCalledTimes(2)
+    expect(pruneSessionEnabledHosts).toHaveBeenNthCalledWith(1, 'ssh:biowulf')
+    expect(pruneSessionEnabledHosts).toHaveBeenNthCalledWith(2, 'ssh:biowulf')
     expect(create).toHaveBeenCalledOnce()
   })
 })
@@ -1286,7 +1294,19 @@ describe('compute handlers — jobsMarkConsumed', () => {
 const invokeHandler = async (channel: string, ...args: unknown[]): Promise<unknown> => {
   const handler = handlers.get(channel)
   if (!handler) throw new Error(`No handler registered for channel "${channel}"`)
-  return handler({} as never, ...args)
+  return handler({ sender: { id: 7 } } as never, ...args)
+}
+
+const installComputeModule = (
+  module: ComputeIpcModule,
+  enabledHosts: ComputeIpcAdapter['enabledHosts'] = {
+    get: (sessionId) => module.enabledComputeHostsRegistry.get(sessionId),
+    set: async () => {
+      throw new Error('Enabled Compute Hosts owner is not configured for this test.')
+    }
+  }
+): void => {
+  installComputeIpcHandlers({ handlers: module.handlers, enabledHosts })
 }
 
 // Calls a handler that is expected to reject and returns the thrown error. Use this when the test
@@ -1316,7 +1336,7 @@ describe('installComputeIpcHandlers', () => {
 
   it('registers every compute:* channel that the renderer can invoke', () => {
     const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
-    installComputeIpcHandlers(module)
+    installComputeModule(module)
 
     const expected = [
       'compute:list',
@@ -1401,41 +1421,56 @@ describe('installComputeIpcHandlers', () => {
 
     expect(handlers.size).toBe(0)
 
-    installComputeIpcHandlers(module)
+    installComputeModule(module)
 
     expect(handlers.has('compute:list')).toBe(true)
     expect(module.computeService).toBeDefined()
   })
 
-  it('round-trips the enabled-hosts registry through get/set IPC channels', async () => {
+  it('routes enabled-hosts IPC through the authoritative owner and publishes its result', async () => {
     const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
-    installComputeIpcHandlers(module)
+    const session: PersistedChatSession = {
+      id: 'sess-fresh',
+      projectId: 'project-1',
+      title: 'Session',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [],
+      filesRevision: 1,
+      enabledComputeHosts: ['ssh:biowulf'],
+      createdAt: 1,
+      updatedAt: 2
+    }
+    const enabledHosts = {
+      get: vi.fn((sessionId: string) => module.enabledComputeHostsRegistry.get(sessionId)),
+      set: vi.fn(async () => {
+        module.enabledComputeHostsRegistry.set(session.id, session.enabledComputeHosts ?? [])
+        return session
+      })
+    }
+    const lifecycle = vi.fn()
+    const removeLifecycle = addRendererBroadcastSink(lifecycle)
+    installComputeModule(module, enabledHosts)
 
-    // Initially empty for an unseen session.
     const initial = await invokeHandler('compute:enabled-hosts:get', 'sess-fresh')
     expect(initial).toEqual([])
 
-    // Setting must persist across subsequent get calls.
-    await invokeHandler('compute:enabled-hosts:set', 'sess-fresh', ['ssh:biowulf', 'ssh:lab-gpu'])
+    const result = await invokeHandler('compute:enabled-hosts:set', 'sess-fresh', ['ssh:biowulf'])
     const afterSet = await invokeHandler('compute:enabled-hosts:get', 'sess-fresh')
-    expect(afterSet).toEqual(['ssh:biowulf', 'ssh:lab-gpu'])
 
-    // Setting again replaces (set semantics), preserving order.
-    await invokeHandler('compute:enabled-hosts:set', 'sess-fresh', ['ssh:biowulf'])
-    const afterReplace = await invokeHandler('compute:enabled-hosts:get', 'sess-fresh')
-    expect(afterReplace).toEqual(['ssh:biowulf'])
-
-    // Different sessions are independent.
-    await invokeHandler('compute:enabled-hosts:set', 'sess-other', ['ssh:lab-gpu'])
-    const other = await invokeHandler('compute:enabled-hosts:get', 'sess-other')
-    expect(other).toEqual(['ssh:lab-gpu'])
-    const firstAgain = await invokeHandler('compute:enabled-hosts:get', 'sess-fresh')
-    expect(firstAgain).toEqual(['ssh:biowulf'])
+    expect(enabledHosts.set).toHaveBeenCalledWith('sess-fresh', ['ssh:biowulf'])
+    expect(result).toEqual(session)
+    expect(afterSet).toEqual(['ssh:biowulf'])
+    expect(lifecycle).toHaveBeenCalledWith('session:updated', {
+      session,
+      originClientId: 'electron:7'
+    })
+    removeLifecycle()
   })
 
   it('returns the production computeService and jobRepository so downstream wiring can use them', () => {
     const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
-    installComputeIpcHandlers(module)
+    installComputeModule(module)
 
     expect(module.computeService).toBeDefined()
     expect(module.jobRepository).toBeDefined()
@@ -1473,7 +1508,7 @@ describe('installComputeIpcHandlers — remoteFsError serialization', () => {
     const service = mockService({ listDir })
 
     const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}), undefined, service)
-    installComputeIpcHandlers(module)
+    installComputeModule(module)
 
     const err = await invokeExpectingError('compute:list-dir', 'ssh:biowulf', '/missing')
 
@@ -1496,7 +1531,7 @@ describe('installComputeIpcHandlers — remoteFsError serialization', () => {
     const service = mockService({ download })
 
     const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}), undefined, service)
-    installComputeIpcHandlers(module)
+    installComputeModule(module)
 
     const dest: DownloadDest = { kind: 'os-downloads' }
     const err = await invokeExpectingError('compute:download', 'ssh:biowulf', '/some/dir', dest)
@@ -1513,7 +1548,7 @@ describe('installComputeIpcHandlers — remoteFsError serialization', () => {
     const service = mockService({ download })
 
     const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}), undefined, service)
-    installComputeIpcHandlers(module)
+    installComputeModule(module)
 
     const dest: DownloadDest = { kind: 'os-downloads' }
     const err = await invokeExpectingError('compute:download', 'ssh:biowulf', '/x', dest)

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -485,6 +485,37 @@ describe('host delete guard', () => {
     expect(del).not.toHaveBeenCalled()
   })
 
+  it('deletes the host inside the enabled Session lifecycle boundary', async () => {
+    const del = vi.fn().mockResolvedValue(undefined)
+    const pruneSessionEnabledHosts = vi.fn(
+      async (_providerId: string, deleteProvider?: () => Promise<void>) => {
+        expect(del).not.toHaveBeenCalled()
+        expect(deleteProvider).toBeDefined()
+        await deleteProvider?.()
+        expect(del).toHaveBeenCalledOnce()
+      }
+    )
+    const handlers = createComputeHandlers(
+      mockRepository({ delete: del }),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { pruneSessionEnabledHosts }
+    )
+
+    await handlers.delete('ssh:biowulf')
+
+    expect(pruneSessionEnabledHosts).toHaveBeenCalledWith('ssh:biowulf', expect.any(Function))
+  })
+
   it('does not expose a replacement provider id until deletion grant cleanup completes', async () => {
     let releaseDeletePrune: (() => void) | undefined
     let pruneCalls = 0
@@ -507,7 +538,9 @@ describe('host delete guard', () => {
       completeProviderInvalidation
     } as unknown as ComputeApprovalBroker
     const permissionGrantRegistry = { prune } as unknown as PermissionGrantRegistry
-    const pruneSessionEnabledHosts = vi.fn().mockResolvedValue(undefined)
+    const pruneSessionEnabledHosts = vi.fn(
+      async (_providerId: string, afterPrune?: () => Promise<void>) => afterPrune?.()
+    )
     const handlers = createComputeHandlers(
       mockRepository({ delete: del, get, create }),
       undefined,
@@ -542,7 +575,7 @@ describe('host delete guard', () => {
       providerId: 'ssh:biowulf'
     })
     expect(pruneSessionEnabledHosts).toHaveBeenCalledTimes(2)
-    expect(pruneSessionEnabledHosts).toHaveBeenNthCalledWith(1, 'ssh:biowulf')
+    expect(pruneSessionEnabledHosts).toHaveBeenNthCalledWith(1, 'ssh:biowulf', expect.any(Function))
     expect(pruneSessionEnabledHosts).toHaveBeenNthCalledWith(2, 'ssh:biowulf')
     expect(create).toHaveBeenCalledOnce()
   })

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -181,7 +181,7 @@ type ComputeHandlers = {
 }
 
 type ComputeHostLifecycle = Readonly<{
-  pruneSessionEnabledHosts(providerId: string): Promise<void>
+  pruneSessionEnabledHosts(providerId: string, afterPrune?: () => Promise<void>): Promise<void>
 }>
 
 // Adapts a repository into thin handlers.
@@ -339,9 +339,15 @@ const createComputeHandlers = (
         }
         await broker.invalidateProvider(providerId)
         try {
-          await hostLifecycle?.pruneSessionEnabledHosts(providerId)
-          await permissionGrantRegistry?.prune({ kind: 'compute_provider', providerId })
-          await repository.delete(providerId)
+          const deleteProvider = async (): Promise<void> => {
+            await permissionGrantRegistry?.prune({ kind: 'compute_provider', providerId })
+            await repository.delete(providerId)
+          }
+          if (hostLifecycle) {
+            await hostLifecycle.pruneSessionEnabledHosts(providerId, deleteProvider)
+          } else {
+            await deleteProvider()
+          }
           try {
             await syncComputeSkillDocument?.()
           } catch (error) {

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -4,12 +4,6 @@ import { join } from 'node:path'
 
 import { BrowserWindow, shell } from 'electron'
 
-import {
-  createIpcHandlerInstallationScope,
-  ipcMainHandle,
-  type IpcHandlerInstallation
-} from '../ipc-handler-registry'
-
 import type {
   ComputeApprovalDecision,
   ComputeHost,
@@ -17,18 +11,11 @@ import type {
   ComputeJob,
   JobSummary,
   CreateComputeHostRequest,
-  DeleteComputeHostRequest,
   DetailsAuthor,
   ProbeResult
 } from '../../shared/compute'
 import { computeProviderId } from '../../shared/compute'
-import type {
-  DirListing,
-  DownloadDest,
-  LocalFile,
-  SerializableRemoteFsError
-} from '../../shared/remote-fs'
-import { encodeRemoteFsError } from '../../shared/remote-fs'
+import type { DirListing, DownloadDest, LocalFile } from '../../shared/remote-fs'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { createLogger, errorLogFields } from '../logger'
 import { resolveDataRoot, resolveStorageRoot } from '../storage-root'
@@ -58,9 +45,6 @@ import {
   type LegacyComputeGrantPort
 } from './permission-grant-adapter'
 import { hasCanonicalComputeSkillDoc, syncComputeSkillDoc } from './skill-doc'
-
-// IPC channel names for the renderer job feed (Phase 3d, issue 05).
-export const COMPUTE_JOBS_LIST_CHANNEL = 'compute:jobs:list'
 export const COMPUTE_JOB_UPDATED_CHANNEL = 'compute:job-updated'
 
 const log = createLogger('compute')
@@ -196,6 +180,10 @@ type ComputeHandlers = {
   jobsMarkConsumed: (sessionId: string, jobIds: string[]) => Promise<void>
 }
 
+type ComputeHostLifecycle = Readonly<{
+  pruneSessionEnabledHosts(providerId: string): Promise<void>
+}>
+
 // Adapts a repository into thin handlers.
 const createComputeHandlers = (
   repository: ComputeHostRepository,
@@ -212,7 +200,8 @@ const createComputeHandlers = (
     'handleComputeApproval' | 'settleAuthorization'
   >,
   permissionGrantRegistry?: PermissionGrantRegistry,
-  syncComputeSkillDocument?: () => Promise<void>
+  syncComputeSkillDocument?: () => Promise<void>,
+  hostLifecycle?: ComputeHostLifecycle
 ): ComputeHandlers => {
   const permissionGrants = permissionGrantRegistry
     ? createComputePermissionGrantAdapter(permissionGrantRegistry, legacyComputeGrants)
@@ -325,11 +314,12 @@ const createComputeHandlers = (
     get: (providerId) => repository.get(providerId),
     create: (request) =>
       runHostLifecycleMutation(async () => {
-        if (permissionGrantRegistry) {
+        if (permissionGrantRegistry || hostLifecycle) {
           const providerId = computeProviderId(request.sshAlias)
           const existing = await repository.get(providerId)
           if (!existing) {
-            await permissionGrantRegistry.prune({ kind: 'compute_provider', providerId })
+            await permissionGrantRegistry?.prune({ kind: 'compute_provider', providerId })
+            await hostLifecycle?.pruneSessionEnabledHosts(providerId)
           }
         }
         const host = await repository.create(request)
@@ -350,6 +340,7 @@ const createComputeHandlers = (
         await broker.invalidateProvider(providerId)
         try {
           await repository.delete(providerId)
+          await hostLifecycle?.pruneSessionEnabledHosts(providerId)
           await permissionGrantRegistry?.prune({ kind: 'compute_provider', providerId })
           await syncComputeSkillDocument?.()
         } finally {
@@ -489,7 +480,8 @@ const createComputeIpcModule = (
     'handleComputeApproval' | 'settleAuthorization'
   >,
   permissionGrantRegistry?: PermissionGrantRegistry,
-  legacyComputeGrants?: LegacyComputeGrantPort
+  legacyComputeGrants?: LegacyComputeGrantPort,
+  hostLifecycle?: ComputeHostLifecycle
 ): ComputeIpcModule => {
   const storageRoot = resolveStorageRoot()
   const dataRoot = resolveDataRoot()
@@ -510,7 +502,8 @@ const createComputeIpcModule = (
     dataRoot,
     taskNotifications,
     permissionGrantRegistry,
-    () => syncCurrentComputeSkillDocuments(storageRoot, repository)
+    () => syncCurrentComputeSkillDocuments(storageRoot, repository),
+    hostLifecycle
   )
   const jobDeletionOwner = createComputeJobDeletionOwner({
     jobRepository,
@@ -529,132 +522,13 @@ const createComputeIpcModule = (
   }
 }
 
-type ComputeIpcAdapter = Pick<ComputeIpcModule, 'handlers' | 'enabledComputeHostsRegistry'>
-
-const registerComputeIpcHandlerSet = ({
-  handlers,
-  enabledComputeHostsRegistry
-}: ComputeIpcAdapter): void => {
-  ipcMainHandle('compute:list', () => handlers.list())
-  ipcMainHandle('compute:get', (_event, providerId: string) => handlers.get(providerId))
-  ipcMainHandle('compute:create', (_event, request: CreateComputeHostRequest) =>
-    handlers.create(request)
-  )
-  ipcMainHandle('compute:delete', async (_event, request: DeleteComputeHostRequest) => {
-    await handlers.delete(request.providerId)
-  })
-  ipcMainHandle('compute:ssh-config-aliases', () => handlers.sshConfigAliases())
-  ipcMainHandle('compute:probe', (_event, providerId: string) => handlers.probe(providerId))
-  ipcMainHandle('compute:details:get', (_event, providerId: string) =>
-    handlers.detailsGet(providerId)
-  )
-  ipcMainHandle(
-    'compute:details:save',
-    (_event, providerId: string, text: string, oldText: string, author: DetailsAuthor) =>
-      handlers.detailsSave(providerId, text, oldText, author)
-  )
-  ipcMainHandle('compute:scratch:set', (_event, providerId: string, path: string) =>
-    handlers.scratchSet(providerId, path)
-  )
-  ipcMainHandle('compute:concurrency:set', (_event, providerId: string, limit: number) =>
-    handlers.concurrencySet(providerId, limit)
-  )
-  // Session-level concurrency control (Phase 3c, issue 04).
-  ipcMainHandle(
-    'compute:session:set-concurrency-limit',
-    (_event, sessionId: string, limit: number) =>
-      handlers.setSessionConcurrencyLimit(sessionId, limit)
-  )
-  ipcMainHandle('compute:session:status', (_event, sessionId: string) =>
-    handlers.getSessionConcurrencyStatus(sessionId)
-  )
-  // Lists a remote directory (browse experience, issue 05).
-  ipcMainHandle('compute:list-dir', async (_event, providerId: string, path: string) => {
-    try {
-      return await handlers.listDir(providerId, path)
-    } catch (err) {
-      const e = err as Error & { remoteFsError?: SerializableRemoteFsError }
-      if (e.remoteFsError) {
-        throw new Error(encodeRemoteFsError(e.message, e.remoteFsError))
-      }
-      throw err
-    }
-  })
-  // Downloads a remote file to OS Downloads or project artifact. No approval gate (issue 03).
-  ipcMainHandle(
-    'compute:download',
-    async (_event, providerId: string, remotePath: string, dest: DownloadDest) => {
-      try {
-        return await handlers.download(providerId, remotePath, dest)
-      } catch (err) {
-        const e = err as Error & { remoteFsError?: SerializableRemoteFsError }
-        if (e.remoteFsError) {
-          throw new Error(encodeRemoteFsError(e.message, e.remoteFsError))
-        }
-        throw err
-      }
-    }
-  )
-  // Reveals a local file path in the OS file manager (Finder / Explorer).
-  ipcMainHandle('compute:reveal-in-folder', (_event, filePath: string) => {
-    handlers.revealInFolder(filePath)
-  })
-  // Renderer responds to an in-flight approval card (issue 04/05). Decision now carries the
-  // chosen scope: 'once' | 'conversation' | 'project' | 'deny'.
-  ipcMainHandle(
-    'compute:approval-respond',
-    (_event, request: { id: string; decision: ComputeApprovalDecision }) => {
-      handlers.approvalRespond(request.id, request.decision)
-    }
-  )
-  ipcMainHandle('compute:approval-replay', (_event, id: unknown) =>
-    typeof id === 'string' ? handlers.approvalReplay(id) : null
-  )
-  // Returns all jobs for a session as JobSummary[], optionally filtered by status (Phase 3d).
-  ipcMainHandle(
-    COMPUTE_JOBS_LIST_CHANNEL,
-    (_event, filter: { sessionId: string; status?: string[] }) => handlers.jobsList(filter)
-  )
-  // Returns jobs pending analysis turn (notifiedAt set, notificationConsumedAt null — issue 05).
-  ipcMainHandle('compute:jobs:pending-notification', (_event, sessionId: string) =>
-    handlers.jobsPendingNotification(sessionId)
-  )
-  // Marks job ids as notification-consumed (analysis turn done — issue 05).
-  ipcMainHandle('compute:jobs:mark-consumed', (_event, sessionId: string, jobIds: string[]) =>
-    handlers.jobsMarkConsumed(sessionId, jobIds)
-  )
-
-  // Per-session enabled compute hosts (issue 06). The renderer owns the durable state (session
-  // JSON); the main-process registry is the runtime cache consulted by list_compute RPC ops.
-  ipcMainHandle('compute:enabled-hosts:get', (_event, sessionId: string): string[] =>
-    enabledComputeHostsRegistry.get(sessionId)
-  )
-  ipcMainHandle(
-    'compute:enabled-hosts:set',
-    (_event, sessionId: string, providerIds: string[]): void => {
-      enabledComputeHostsRegistry.set(sessionId, providerIds)
-    }
-  )
-}
-
-// Installs only the renderer-callable Electron adapter over an already-constructed Compute module.
-const installComputeIpcHandlers = (module: ComputeIpcAdapter): IpcHandlerInstallation => {
-  const scope = createIpcHandlerInstallationScope()
-  try {
-    registerComputeIpcHandlerSet(module)
-    return scope.complete()
-  } catch (error) {
-    scope.rollback()
-    throw error
-  }
-}
-
 export {
   createComputeHandlers,
   createComputeIpcModule,
   createDefaultComputeHostRepository,
   createDefaultComputeJobRepository,
-  installComputeIpcHandlers,
   enabledComputeHostsRegistry
 }
-export type { ComputeHandlers, ComputeIpcModule }
+export { COMPUTE_JOBS_LIST_CHANNEL, installComputeIpcHandlers } from './electron-ipc-adapter'
+export type { ComputeIpcAdapter } from './electron-ipc-adapter'
+export type { ComputeHandlers, ComputeHostLifecycle, ComputeIpcModule }

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -339,10 +339,14 @@ const createComputeHandlers = (
         }
         await broker.invalidateProvider(providerId)
         try {
-          await repository.delete(providerId)
           await hostLifecycle?.pruneSessionEnabledHosts(providerId)
           await permissionGrantRegistry?.prune({ kind: 'compute_provider', providerId })
-          await syncComputeSkillDocument?.()
+          await repository.delete(providerId)
+          try {
+            await syncComputeSkillDocument?.()
+          } catch (error) {
+            log.warn('compute skill sync after host deletion failed', errorLogFields(error))
+          }
         } finally {
           broker.completeProviderInvalidation(providerId)
         }

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -339,14 +339,19 @@ const createComputeHandlers = (
         }
         await broker.invalidateProvider(providerId)
         try {
-          const deleteProvider = async (): Promise<void> => {
-            await permissionGrantRegistry?.prune({ kind: 'compute_provider', providerId })
-            await repository.delete(providerId)
-          }
+          const deleteProvider = (): Promise<void> => repository.delete(providerId)
           if (hostLifecycle) {
             await hostLifecycle.pruneSessionEnabledHosts(providerId, deleteProvider)
           } else {
             await deleteProvider()
+          }
+          try {
+            await permissionGrantRegistry?.prune({ kind: 'compute_provider', providerId })
+          } catch (error) {
+            log.warn(
+              'compute permission grant cleanup after host deletion failed',
+              errorLogFields(error)
+            )
           }
           try {
             await syncComputeSkillDocument?.()

--- a/src/main/compute/session-enabled-hosts-owner.test.ts
+++ b/src/main/compute/session-enabled-hosts-owner.test.ts
@@ -253,7 +253,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
     expect(owner.get('session-1')).toEqual([])
   })
 
-  it('removes a deleted or reusable provider before repairing durable Sessions', async () => {
+  it('removes a deleted or reusable provider only after repairing durable Sessions', async () => {
     const registry = new EnabledComputeHostsRegistry()
     registry.set('session-1', ['ssh:deleted', 'ssh:kept'])
     let finishPrune: ((result: PruneResult) => void) | undefined
@@ -278,7 +278,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
     })
 
     const pruning = owner.pruneProvider('ssh:deleted')
-    expect(owner.get('session-1')).toEqual(['ssh:kept'])
+    expect(owner.get('session-1')).toEqual(['ssh:deleted', 'ssh:kept'])
     await vi.waitFor(() =>
       expect(pruneSessionEnabledComputeHosts).toHaveBeenCalledWith(['ssh:kept'])
     )
@@ -287,6 +287,58 @@ describe('SessionEnabledComputeHostsOwner', () => {
     finishPrune?.(createPruneResult([repaired]))
     await expect(pruning).resolves.toEqual([repaired])
     expect(owner.get('session-1')).toEqual(['ssh:kept'])
+  })
+
+  it('keeps the cache unchanged when durable provider pruning fails', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    registry.set('session-1', ['ssh:deleted', 'ssh:kept'])
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds: async () => ['ssh:deleted', 'ssh:kept'],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts: async () => {
+          throw new Error('Session prune failed')
+        }
+      },
+      withDataRootWrite: passthroughDataRootWrite
+    })
+
+    await expect(owner.pruneProvider('ssh:deleted')).rejects.toThrow('Session prune failed')
+
+    expect(owner.get('session-1')).toEqual(['ssh:deleted', 'ssh:kept'])
+  })
+
+  it('returns loaded Sessions without changing the cache when the Host catalog is unavailable', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    registry.set('cached-session', ['ssh:cached'])
+    const sessions = [createSession({ enabledComputeHosts: ['ssh:cluster'] })]
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds: async () => {
+        throw new Error('Compute database unavailable')
+      },
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        }
+      },
+      withDataRootWrite: passthroughDataRootWrite
+    })
+
+    await expect(owner.reconcile(sessions, true)).resolves.toEqual(sessions)
+
+    expect(owner.get('cached-session')).toEqual(['ssh:cached'])
+    expect(owner.get('session-1')).toEqual([])
   })
 
   it('holds the owner queue through provider deletion before validating a queued enable', async () => {

--- a/src/main/compute/session-enabled-hosts-owner.test.ts
+++ b/src/main/compute/session-enabled-hosts-owner.test.ts
@@ -17,6 +17,9 @@ const createSession = (overrides: Partial<PersistedChatSession> = {}): Persisted
   ...overrides
 })
 
+const passthroughDataRootWrite = <Result>(operation: () => Promise<Result>): Promise<Result> =>
+  operation()
+
 describe('SessionEnabledComputeHostsOwner', () => {
   it('projects only the enabled hosts committed by Session authority', async () => {
     const registry = new EnabledComputeHostsRegistry()
@@ -34,7 +37,8 @@ describe('SessionEnabledComputeHostsOwner', () => {
         sessionProjectId: async () => 'project-1',
         setSessionEnabledComputeHosts,
         pruneSessionEnabledComputeHosts: async () => []
-      }
+      },
+      withDataRootWrite: passthroughDataRootWrite
     })
 
     await expect(owner.set('session-1', ['ssh:new'])).resolves.toEqual(durable)
@@ -43,6 +47,45 @@ describe('SessionEnabledComputeHostsOwner', () => {
       'ssh:new'
     ])
     expect(owner.get('session-1')).toEqual(['ssh:new'])
+  })
+
+  it('runs durable mutations inside the data-root write boundary', async () => {
+    let insideWriteBoundary = false
+    let writeBoundaryCalls = 0
+    const withDataRootWrite = async <Result>(operation: () => Promise<Result>): Promise<Result> => {
+      writeBoundaryCalls += 1
+      insideWriteBoundary = true
+      try {
+        return await operation()
+      } finally {
+        insideWriteBoundary = false
+      }
+    }
+    const durable = createSession({ enabledComputeHosts: ['ssh:cluster'], updatedAt: 3 })
+    const setSessionEnabledComputeHosts = vi.fn(async () => {
+      expect(insideWriteBoundary).toBe(true)
+      return durable
+    })
+    const pruneSessionEnabledComputeHosts = vi.fn(async () => {
+      expect(insideWriteBoundary).toBe(true)
+      return [durable]
+    })
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry: new EnabledComputeHostsRegistry(),
+      hostExists: async () => true,
+      listHostIds: async () => ['ssh:cluster'],
+      sessionAuthority: {
+        sessionProjectId: async () => 'project-1',
+        setSessionEnabledComputeHosts,
+        pruneSessionEnabledComputeHosts
+      },
+      withDataRootWrite
+    })
+
+    await owner.set('session-1', ['ssh:cluster'])
+    await owner.pruneProvider('ssh:deleted')
+
+    expect(writeBoundaryCalls).toBe(2)
   })
 
   it('projects a committed first Session save without accepting another intent', () => {
@@ -57,7 +100,8 @@ describe('SessionEnabledComputeHostsOwner', () => {
           throw new Error('not expected')
         },
         pruneSessionEnabledComputeHosts: async () => []
-      }
+      },
+      withDataRootWrite: passthroughDataRootWrite
     })
 
     owner.project(createSession({ enabledComputeHosts: ['ssh:cluster'] }))
@@ -77,7 +121,8 @@ describe('SessionEnabledComputeHostsOwner', () => {
           throw new Error('not expected')
         },
         pruneSessionEnabledComputeHosts: async () => []
-      }
+      },
+      withDataRootWrite: passthroughDataRootWrite
     })
     const durable = createSession({ enabledComputeHosts: ['ssh:cluster'], updatedAt: 3 })
     const commit = vi.fn(async () => durable)
@@ -112,7 +157,8 @@ describe('SessionEnabledComputeHostsOwner', () => {
           throw new Error('not expected')
         },
         pruneSessionEnabledComputeHosts: async () => []
-      }
+      },
+      withDataRootWrite: passthroughDataRootWrite
     })
 
     await owner.reconcile([createSession({ enabledComputeHosts: ['ssh:cluster'] })], true)
@@ -136,7 +182,8 @@ describe('SessionEnabledComputeHostsOwner', () => {
           throw new Error('not expected')
         },
         pruneSessionEnabledComputeHosts
-      }
+      },
+      withDataRootWrite: passthroughDataRootWrite
     })
 
     await expect(
@@ -165,7 +212,8 @@ describe('SessionEnabledComputeHostsOwner', () => {
           throw new Error('not expected')
         },
         pruneSessionEnabledComputeHosts
-      }
+      },
+      withDataRootWrite: passthroughDataRootWrite
     })
 
     const sessions = [createSession({ enabledComputeHosts: ['ssh:cluster', 'ssh:deleted'] })]
@@ -189,7 +237,8 @@ describe('SessionEnabledComputeHostsOwner', () => {
           throw new Error('not expected')
         },
         pruneSessionEnabledComputeHosts: async () => []
-      }
+      },
+      withDataRootWrite: passthroughDataRootWrite
     })
 
     owner.clear(['session-1'])
@@ -217,7 +266,8 @@ describe('SessionEnabledComputeHostsOwner', () => {
           throw new Error('not expected')
         },
         pruneSessionEnabledComputeHosts
-      }
+      },
+      withDataRootWrite: passthroughDataRootWrite
     })
 
     const pruning = owner.pruneProvider('ssh:deleted')
@@ -230,5 +280,41 @@ describe('SessionEnabledComputeHostsOwner', () => {
     finishPrune?.([repaired])
     await expect(pruning).resolves.toEqual([repaired])
     expect(owner.get('session-1')).toEqual(['ssh:kept'])
+  })
+
+  it('holds the owner queue through provider deletion before validating a queued enable', async () => {
+    let hostExists = true
+    let finishPrune: ((sessions: PersistedChatSession[]) => void) | undefined
+    const pruneSessionEnabledComputeHosts = vi.fn(
+      () =>
+        new Promise<PersistedChatSession[]>((resolve) => {
+          finishPrune = resolve
+        })
+    )
+    const setSessionEnabledComputeHosts = vi.fn(async () => createSession())
+    const deleteProvider = vi.fn(async () => {
+      hostExists = false
+    })
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry: new EnabledComputeHostsRegistry(),
+      hostExists: async () => hostExists,
+      listHostIds: async () => (hostExists ? ['ssh:cluster'] : []),
+      sessionAuthority: {
+        sessionProjectId: async () => 'project-1',
+        setSessionEnabledComputeHosts,
+        pruneSessionEnabledComputeHosts
+      },
+      withDataRootWrite: async (operation) => operation()
+    })
+
+    const deleting = owner.pruneProvider('ssh:cluster', deleteProvider)
+    await vi.waitFor(() => expect(pruneSessionEnabledComputeHosts).toHaveBeenCalledOnce())
+    const enabling = owner.set('session-1', ['ssh:cluster'])
+    finishPrune?.([])
+
+    await expect(deleting).resolves.toEqual([])
+    await expect(enabling).rejects.toThrow('Compute Host not found')
+    expect(deleteProvider).toHaveBeenCalledOnce()
+    expect(setSessionEnabledComputeHosts).not.toHaveBeenCalled()
   })
 })

--- a/src/main/compute/session-enabled-hosts-owner.test.ts
+++ b/src/main/compute/session-enabled-hosts-owner.test.ts
@@ -19,6 +19,13 @@ const createSession = (overrides: Partial<PersistedChatSession> = {}): Persisted
 
 const passthroughDataRootWrite = <Result>(operation: () => Promise<Result>): Promise<Result> =>
   operation()
+const createPruneResult = (
+  sessions: PersistedChatSession[] = []
+): { sessions: PersistedChatSession[]; previousSelections: [] } => ({
+  sessions,
+  previousSelections: []
+})
+type PruneResult = ReturnType<typeof createPruneResult>
 
 describe('SessionEnabledComputeHostsOwner', () => {
   it('projects only the enabled hosts committed by Session authority', async () => {
@@ -36,7 +43,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
       sessionAuthority: {
         sessionProjectId: async () => 'project-1',
         setSessionEnabledComputeHosts,
-        pruneSessionEnabledComputeHosts: async () => []
+        pruneSessionEnabledComputeHosts: async () => createPruneResult()
       },
       withDataRootWrite: passthroughDataRootWrite
     })
@@ -68,7 +75,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
     })
     const pruneSessionEnabledComputeHosts = vi.fn(async () => {
       expect(insideWriteBoundary).toBe(true)
-      return [durable]
+      return createPruneResult([durable])
     })
     const owner = new SessionEnabledComputeHostsOwner({
       registry: new EnabledComputeHostsRegistry(),
@@ -99,7 +106,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
         setSessionEnabledComputeHosts: async () => {
           throw new Error('not expected')
         },
-        pruneSessionEnabledComputeHosts: async () => []
+        pruneSessionEnabledComputeHosts: async () => createPruneResult()
       },
       withDataRootWrite: passthroughDataRootWrite
     })
@@ -120,7 +127,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
         setSessionEnabledComputeHosts: async () => {
           throw new Error('not expected')
         },
-        pruneSessionEnabledComputeHosts: async () => []
+        pruneSessionEnabledComputeHosts: async () => createPruneResult()
       },
       withDataRootWrite: passthroughDataRootWrite
     })
@@ -156,7 +163,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
         setSessionEnabledComputeHosts: async () => {
           throw new Error('not expected')
         },
-        pruneSessionEnabledComputeHosts: async () => []
+        pruneSessionEnabledComputeHosts: async () => createPruneResult()
       },
       withDataRootWrite: passthroughDataRootWrite
     })
@@ -171,7 +178,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
     const registry = new EnabledComputeHostsRegistry()
     registry.set('stale-session', ['ssh:old'])
     const repaired = createSession({ enabledComputeHosts: ['ssh:cluster'], updatedAt: 3 })
-    const pruneSessionEnabledComputeHosts = vi.fn(async () => [repaired])
+    const pruneSessionEnabledComputeHosts = vi.fn(async () => createPruneResult([repaired]))
     const owner = new SessionEnabledComputeHostsOwner({
       registry,
       hostExists: async () => true,
@@ -201,7 +208,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
   it('filters a partial cache without pruning unseen durable Sessions', async () => {
     const registry = new EnabledComputeHostsRegistry()
     registry.set('unseen-session', ['ssh:cluster'])
-    const pruneSessionEnabledComputeHosts = vi.fn(async () => [])
+    const pruneSessionEnabledComputeHosts = vi.fn(async () => createPruneResult())
     const owner = new SessionEnabledComputeHostsOwner({
       registry,
       hostExists: async () => true,
@@ -236,7 +243,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
         setSessionEnabledComputeHosts: async () => {
           throw new Error('not expected')
         },
-        pruneSessionEnabledComputeHosts: async () => []
+        pruneSessionEnabledComputeHosts: async () => createPruneResult()
       },
       withDataRootWrite: passthroughDataRootWrite
     })
@@ -249,10 +256,10 @@ describe('SessionEnabledComputeHostsOwner', () => {
   it('removes a deleted or reusable provider before repairing durable Sessions', async () => {
     const registry = new EnabledComputeHostsRegistry()
     registry.set('session-1', ['ssh:deleted', 'ssh:kept'])
-    let finishPrune: ((sessions: PersistedChatSession[]) => void) | undefined
+    let finishPrune: ((result: PruneResult) => void) | undefined
     const pruneSessionEnabledComputeHosts = vi.fn(
       () =>
-        new Promise<PersistedChatSession[]>((resolve) => {
+        new Promise<PruneResult>((resolve) => {
           finishPrune = resolve
         })
     )
@@ -277,17 +284,17 @@ describe('SessionEnabledComputeHostsOwner', () => {
     )
 
     const repaired = createSession({ enabledComputeHosts: ['ssh:kept'] })
-    finishPrune?.([repaired])
+    finishPrune?.(createPruneResult([repaired]))
     await expect(pruning).resolves.toEqual([repaired])
     expect(owner.get('session-1')).toEqual(['ssh:kept'])
   })
 
   it('holds the owner queue through provider deletion before validating a queued enable', async () => {
     let hostExists = true
-    let finishPrune: ((sessions: PersistedChatSession[]) => void) | undefined
+    let finishPrune: ((result: PruneResult) => void) | undefined
     const pruneSessionEnabledComputeHosts = vi.fn(
       () =>
-        new Promise<PersistedChatSession[]>((resolve) => {
+        new Promise<PruneResult>((resolve) => {
           finishPrune = resolve
         })
     )
@@ -310,11 +317,54 @@ describe('SessionEnabledComputeHostsOwner', () => {
     const deleting = owner.pruneProvider('ssh:cluster', deleteProvider)
     await vi.waitFor(() => expect(pruneSessionEnabledComputeHosts).toHaveBeenCalledOnce())
     const enabling = owner.set('session-1', ['ssh:cluster'])
-    finishPrune?.([])
+    finishPrune?.(createPruneResult())
 
     await expect(deleting).resolves.toEqual([])
     await expect(enabling).rejects.toThrow('Compute Host not found')
     expect(deleteProvider).toHaveBeenCalledOnce()
     expect(setSessionEnabledComputeHosts).not.toHaveBeenCalled()
+  })
+
+  it('restores durable selections and the cache when provider deletion fails', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    registry.set('session-1', ['ssh:cluster', 'ssh:kept'])
+    const repaired = createSession({ enabledComputeHosts: ['ssh:kept'], updatedAt: 3 })
+    const restored = createSession({
+      enabledComputeHosts: ['ssh:cluster', 'ssh:kept'],
+      updatedAt: 4
+    })
+    const setSessionEnabledComputeHosts = vi.fn(async () => restored)
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds: async () => ['ssh:cluster', 'ssh:kept'],
+      sessionAuthority: {
+        sessionProjectId: async () => 'project-1',
+        setSessionEnabledComputeHosts,
+        pruneSessionEnabledComputeHosts: async () => ({
+          sessions: [repaired],
+          previousSelections: [
+            {
+              projectId: 'project-1',
+              sessionId: 'session-1',
+              providerIds: ['ssh:cluster', 'ssh:kept']
+            }
+          ]
+        })
+      },
+      withDataRootWrite: passthroughDataRootWrite
+    })
+
+    await expect(
+      owner.pruneProvider('ssh:cluster', async () => {
+        throw new Error('Host delete failed')
+      })
+    ).rejects.toThrow('Host delete failed')
+
+    expect(setSessionEnabledComputeHosts).toHaveBeenCalledWith('project-1', 'session-1', [
+      'ssh:cluster',
+      'ssh:kept'
+    ])
+    expect(owner.get('session-1')).toEqual(['ssh:cluster', 'ssh:kept'])
   })
 })

--- a/src/main/compute/session-enabled-hosts-owner.test.ts
+++ b/src/main/compute/session-enabled-hosts-owner.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { EnabledComputeHostsRegistry } from './enabled-hosts-registry'
+import { SessionEnabledComputeHostsOwner } from './session-enabled-hosts-owner'
+
+const createSession = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => ({
+  id: 'session-1',
+  projectId: 'project-1',
+  title: 'Session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [],
+  filesRevision: 1,
+  createdAt: 1,
+  updatedAt: 2,
+  ...overrides
+})
+
+describe('SessionEnabledComputeHostsOwner', () => {
+  it('projects only the enabled hosts committed by Session authority', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    registry.set('session-1', ['ssh:old'])
+    const durable = createSession({ enabledComputeHosts: ['ssh:new'], updatedAt: 3 })
+    const setSessionEnabledComputeHosts = vi.fn(async () => {
+      expect(registry.get('session-1')).toEqual(['ssh:old'])
+      return durable
+    })
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async (providerId) => providerId === 'ssh:new',
+      listHostIds: async () => ['ssh:new'],
+      sessionAuthority: {
+        sessionProjectId: async () => 'project-1',
+        setSessionEnabledComputeHosts,
+        pruneSessionEnabledComputeHosts: async () => []
+      }
+    })
+
+    await expect(owner.set('session-1', ['ssh:new'])).resolves.toEqual(durable)
+
+    expect(setSessionEnabledComputeHosts).toHaveBeenCalledWith('project-1', 'session-1', [
+      'ssh:new'
+    ])
+    expect(owner.get('session-1')).toEqual(['ssh:new'])
+  })
+
+  it('projects a committed first Session save without accepting another intent', () => {
+    const registry = new EnabledComputeHostsRegistry()
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds: async () => [],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts: async () => []
+      }
+    })
+
+    owner.project(createSession({ enabledComputeHosts: ['ssh:cluster'] }))
+
+    expect(owner.get('session-1')).toEqual(['ssh:cluster'])
+  })
+
+  it('validates and projects a first Session creation through the owner', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async (providerId) => providerId === 'ssh:cluster',
+      listHostIds: async () => ['ssh:cluster'],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts: async () => []
+      }
+    })
+    const durable = createSession({ enabledComputeHosts: ['ssh:cluster'], updatedAt: 3 })
+    const commit = vi.fn(async () => durable)
+
+    await expect(
+      owner.createSession(
+        createSession({ enabledComputeHosts: ['ssh:cluster', 'ssh:cluster'] }),
+        commit
+      )
+    ).resolves.toEqual(durable)
+    expect(commit).toHaveBeenCalledWith(
+      expect.objectContaining({ enabledComputeHosts: ['ssh:cluster'] })
+    )
+    expect(owner.get('session-1')).toEqual(['ssh:cluster'])
+
+    await expect(
+      owner.createSession(createSession({ enabledComputeHosts: ['ssh:missing'] }), commit)
+    ).rejects.toThrow('Compute Host not found')
+    expect(commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('replaces the derived cache from a complete Session catalog', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    registry.set('stale-session', ['ssh:old'])
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds: async () => ['ssh:cluster'],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts: async () => []
+      }
+    })
+
+    await owner.reconcile([createSession({ enabledComputeHosts: ['ssh:cluster'] })], true)
+
+    expect(owner.get('session-1')).toEqual(['ssh:cluster'])
+    expect(owner.get('stale-session')).toEqual([])
+  })
+
+  it('durably prunes missing hosts before replacing a complete cache', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    registry.set('stale-session', ['ssh:old'])
+    const repaired = createSession({ enabledComputeHosts: ['ssh:cluster'], updatedAt: 3 })
+    const pruneSessionEnabledComputeHosts = vi.fn(async () => [repaired])
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds: async () => ['ssh:cluster'],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts
+      }
+    })
+
+    await expect(
+      owner.reconcile(
+        [createSession({ enabledComputeHosts: ['ssh:cluster', 'ssh:deleted'] })],
+        true
+      )
+    ).resolves.toEqual([repaired])
+
+    expect(pruneSessionEnabledComputeHosts).toHaveBeenCalledWith(['ssh:cluster'])
+    expect(owner.get('session-1')).toEqual(['ssh:cluster'])
+    expect(owner.get('stale-session')).toEqual([])
+  })
+
+  it('filters a partial cache without pruning unseen durable Sessions', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    registry.set('unseen-session', ['ssh:cluster'])
+    const pruneSessionEnabledComputeHosts = vi.fn(async () => [])
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds: async () => ['ssh:cluster'],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts
+      }
+    })
+
+    const sessions = [createSession({ enabledComputeHosts: ['ssh:cluster', 'ssh:deleted'] })]
+    await expect(owner.reconcile(sessions, false)).resolves.toEqual(sessions)
+
+    expect(pruneSessionEnabledComputeHosts).not.toHaveBeenCalled()
+    expect(owner.get('session-1')).toEqual(['ssh:cluster'])
+    expect(owner.get('unseen-session')).toEqual(['ssh:cluster'])
+  })
+
+  it('clears deleted Sessions from the cache', () => {
+    const registry = new EnabledComputeHostsRegistry()
+    registry.set('session-1', ['ssh:cluster'])
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds: async () => ['ssh:cluster'],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts: async () => []
+      }
+    })
+
+    owner.clear(['session-1'])
+
+    expect(owner.get('session-1')).toEqual([])
+  })
+
+  it('removes a deleted or reusable provider before repairing durable Sessions', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    registry.set('session-1', ['ssh:deleted', 'ssh:kept'])
+    let finishPrune: ((sessions: PersistedChatSession[]) => void) | undefined
+    const pruneSessionEnabledComputeHosts = vi.fn(
+      () =>
+        new Promise<PersistedChatSession[]>((resolve) => {
+          finishPrune = resolve
+        })
+    )
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds: async () => ['ssh:kept'],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts
+      }
+    })
+
+    const pruning = owner.pruneProvider('ssh:deleted')
+    expect(owner.get('session-1')).toEqual(['ssh:kept'])
+    await vi.waitFor(() =>
+      expect(pruneSessionEnabledComputeHosts).toHaveBeenCalledWith(['ssh:kept'])
+    )
+
+    const repaired = createSession({ enabledComputeHosts: ['ssh:kept'] })
+    finishPrune?.([repaired])
+    await expect(pruning).resolves.toEqual([repaired])
+    expect(owner.get('session-1')).toEqual(['ssh:kept'])
+  })
+})

--- a/src/main/compute/session-enabled-hosts-owner.test.ts
+++ b/src/main/compute/session-enabled-hosts-owner.test.ts
@@ -210,7 +210,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
     const owner = new SessionEnabledComputeHostsOwner({
       registry,
       hostExists: async () => true,
-      listHostIds: async () => ['ssh:kept'],
+      listHostIds: async () => ['ssh:deleted', 'ssh:kept'],
       sessionAuthority: {
         sessionProjectId: async () => undefined,
         setSessionEnabledComputeHosts: async () => {

--- a/src/main/compute/session-enabled-hosts-owner.test.ts
+++ b/src/main/compute/session-enabled-hosts-owner.test.ts
@@ -231,7 +231,7 @@ describe('SessionEnabledComputeHostsOwner', () => {
     expect(owner.get('unseen-session')).toEqual(['ssh:cluster'])
   })
 
-  it('clears deleted Sessions from the cache', () => {
+  it('clears deleted Sessions from the cache', async () => {
     const registry = new EnabledComputeHostsRegistry()
     registry.set('session-1', ['ssh:cluster'])
     const owner = new SessionEnabledComputeHostsOwner({
@@ -248,7 +248,44 @@ describe('SessionEnabledComputeHostsOwner', () => {
       withDataRootWrite: passthroughDataRootWrite
     })
 
-    owner.clear(['session-1'])
+    await owner.clear(['session-1'])
+
+    expect(owner.get('session-1')).toEqual([])
+  })
+
+  it('serializes Session deletion cache clears after in-flight reconciliation', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    registry.set('session-1', ['ssh:cluster'])
+    let finishHostList: ((providerIds: readonly string[]) => void) | undefined
+    const listHostIds = vi.fn(
+      () =>
+        new Promise<readonly string[]>((resolve) => {
+          finishHostList = resolve
+        })
+    )
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds,
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts: async () => createPruneResult()
+      },
+      withDataRootWrite: passthroughDataRootWrite
+    })
+
+    const reconciling = owner.reconcile(
+      [createSession({ enabledComputeHosts: ['ssh:cluster'] })],
+      true
+    )
+    await vi.waitFor(() => expect(listHostIds).toHaveBeenCalledOnce())
+    const clearing = owner.clear(['session-1'])
+    finishHostList?.(['ssh:cluster'])
+
+    await Promise.all([reconciling, clearing])
 
     expect(owner.get('session-1')).toEqual([])
   })

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -63,7 +63,9 @@ class SessionEnabledComputeHostsOwner {
     this.options.registry.removeProvider(providerId)
     return this.enqueue(async () => {
       this.options.registry.removeProvider(providerId)
-      const validProviderIds = await this.options.listHostIds()
+      const validProviderIds = (await this.options.listHostIds()).filter(
+        (candidate) => candidate !== providerId
+      )
       const sessions =
         await this.options.sessionAuthority.pruneSessionEnabledComputeHosts(validProviderIds)
       this.options.registry.reconcile(

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -8,9 +8,14 @@ type SessionEnabledComputeHostsAuthority = Readonly<{
     sessionId: string,
     providerIds: readonly string[]
   ): Promise<PersistedChatSession>
-  pruneSessionEnabledComputeHosts(
-    validProviderIds: readonly string[]
-  ): Promise<PersistedChatSession[]>
+  pruneSessionEnabledComputeHosts(validProviderIds: readonly string[]): Promise<{
+    sessions: PersistedChatSession[]
+    previousSelections: Array<{
+      projectId: string
+      sessionId: string
+      providerIds: string[]
+    }>
+  }>
 }>
 
 type SessionEnabledComputeHostsOwnerOptions = Readonly<{
@@ -74,14 +79,41 @@ class SessionEnabledComputeHostsOwner {
       const validProviderIds = (await this.options.listHostIds()).filter(
         (candidate) => candidate !== providerId
       )
-      const sessions =
+      const repair =
         await this.options.sessionAuthority.pruneSessionEnabledComputeHosts(validProviderIds)
-      await afterPrune?.()
+      try {
+        await afterPrune?.()
+      } catch (error) {
+        try {
+          const restoredSessions: PersistedChatSession[] = []
+          for (const selection of repair.previousSelections) {
+            restoredSessions.push(
+              await this.options.sessionAuthority.setSessionEnabledComputeHosts(
+                selection.projectId,
+                selection.sessionId,
+                selection.providerIds
+              )
+            )
+          }
+          this.options.registry.reconcile(
+            restoredSessions.map(
+              (session) => [session.id, session.enabledComputeHosts ?? []] as const
+            ),
+            false
+          )
+        } catch (rollbackError) {
+          throw new AggregateError(
+            [error, rollbackError],
+            'Compute Host mutation failed and enabled Session selections could not be restored.'
+          )
+        }
+        throw error
+      }
       this.options.registry.reconcile(
-        sessions.map((session) => [session.id, session.enabledComputeHosts ?? []] as const),
+        repair.sessions.map((session) => [session.id, session.enabledComputeHosts ?? []] as const),
         true
       )
-      return sessions
+      return repair.sessions
     })
   }
 
@@ -97,7 +129,8 @@ class SessionEnabledComputeHostsOwner {
       )
       const authoritativeSessions =
         isComplete && hasMissingHost
-          ? await this.options.sessionAuthority.pruneSessionEnabledComputeHosts(validProviderIds)
+          ? (await this.options.sessionAuthority.pruneSessionEnabledComputeHosts(validProviderIds))
+              .sessions
           : sessions.map((session) => ({
               ...session,
               enabledComputeHosts: session.enabledComputeHosts?.filter((providerId) =>

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -65,8 +65,10 @@ class SessionEnabledComputeHostsOwner {
     this.options.registry.set(session.id, session.enabledComputeHosts ?? [])
   }
 
-  clear(sessionIds: readonly string[]): void {
-    for (const sessionId of sessionIds) this.options.registry.clear(sessionId)
+  clear(sessionIds: readonly string[]): Promise<void> {
+    return this.enqueue(async () => {
+      for (const sessionId of sessionIds) this.options.registry.clear(sessionId)
+    })
   }
 
   pruneProvider(

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -1,0 +1,141 @@
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { EnabledComputeHostsRegistry } from './enabled-hosts-registry'
+
+type SessionEnabledComputeHostsAuthority = Readonly<{
+  sessionProjectId(sessionId: string): Promise<string | undefined>
+  setSessionEnabledComputeHosts(
+    projectId: string,
+    sessionId: string,
+    providerIds: readonly string[]
+  ): Promise<PersistedChatSession>
+  pruneSessionEnabledComputeHosts(
+    validProviderIds: readonly string[]
+  ): Promise<PersistedChatSession[]>
+}>
+
+type SessionEnabledComputeHostsOwnerOptions = Readonly<{
+  registry: EnabledComputeHostsRegistry
+  hostExists(providerId: string): Promise<boolean>
+  listHostIds(): Promise<readonly string[]>
+  sessionAuthority: SessionEnabledComputeHostsAuthority
+}>
+
+class SessionEnabledComputeHostsOwner {
+  private queue: Promise<unknown> = Promise.resolve()
+
+  constructor(private readonly options: SessionEnabledComputeHostsOwnerOptions) {}
+
+  private enqueue<Result>(operation: () => Promise<Result>): Promise<Result> {
+    const result = this.queue.then(operation)
+    this.queue = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
+  }
+
+  private async validate(providerIds: readonly string[]): Promise<string[]> {
+    const normalized = [...new Set(providerIds)]
+    for (const providerId of normalized) {
+      if (!providerId.startsWith('ssh:') || providerId.length <= 4) {
+        throw new Error(`Invalid Compute Host provider id: ${providerId}`)
+      }
+      if (!(await this.options.hostExists(providerId))) {
+        throw new Error(`Compute Host not found: ${providerId}`)
+      }
+    }
+    return normalized
+  }
+
+  get(sessionId: string): string[] {
+    return this.options.registry.get(sessionId)
+  }
+
+  project(session: PersistedChatSession): void {
+    this.options.registry.set(session.id, session.enabledComputeHosts ?? [])
+  }
+
+  clear(sessionIds: readonly string[]): void {
+    for (const sessionId of sessionIds) this.options.registry.clear(sessionId)
+  }
+
+  pruneProvider(providerId: string): Promise<PersistedChatSession[]> {
+    this.options.registry.removeProvider(providerId)
+    return this.enqueue(async () => {
+      this.options.registry.removeProvider(providerId)
+      const validProviderIds = await this.options.listHostIds()
+      const sessions =
+        await this.options.sessionAuthority.pruneSessionEnabledComputeHosts(validProviderIds)
+      this.options.registry.reconcile(
+        sessions.map((session) => [session.id, session.enabledComputeHosts ?? []] as const),
+        true
+      )
+      return sessions
+    })
+  }
+
+  reconcile(
+    sessions: readonly PersistedChatSession[],
+    isComplete: boolean
+  ): Promise<PersistedChatSession[]> {
+    return this.enqueue(async () => {
+      const validProviderIds = await this.options.listHostIds()
+      const validProviderIdSet = new Set(validProviderIds)
+      const hasMissingHost = sessions.some((session) =>
+        session.enabledComputeHosts?.some((providerId) => !validProviderIdSet.has(providerId))
+      )
+      const authoritativeSessions =
+        isComplete && hasMissingHost
+          ? await this.options.sessionAuthority.pruneSessionEnabledComputeHosts(validProviderIds)
+          : sessions.map((session) => ({
+              ...session,
+              enabledComputeHosts: session.enabledComputeHosts?.filter((providerId) =>
+                validProviderIdSet.has(providerId)
+              )
+            }))
+      this.options.registry.reconcile(
+        authoritativeSessions.map(
+          (session) => [session.id, session.enabledComputeHosts ?? []] as const
+        ),
+        isComplete
+      )
+      return isComplete ? authoritativeSessions : [...sessions]
+    })
+  }
+
+  createSession(
+    session: PersistedChatSession,
+    commit: (session: PersistedChatSession) => Promise<PersistedChatSession>
+  ): Promise<PersistedChatSession> {
+    return this.enqueue(async () => {
+      const enabledComputeHosts = await this.validate(session.enabledComputeHosts ?? [])
+      const durableSession = await commit({
+        ...session,
+        ...(session.enabledComputeHosts || enabledComputeHosts.length > 0
+          ? { enabledComputeHosts }
+          : {})
+      })
+      this.project(durableSession)
+      return durableSession
+    })
+  }
+
+  set(sessionId: string, providerIds: readonly string[]): Promise<PersistedChatSession> {
+    return this.enqueue(async () => {
+      const normalized = await this.validate(providerIds)
+      const projectId = await this.options.sessionAuthority.sessionProjectId(sessionId)
+      if (!projectId) throw new Error(`Session not found: ${sessionId}`)
+
+      const session = await this.options.sessionAuthority.setSessionEnabledComputeHosts(
+        projectId,
+        sessionId,
+        normalized
+      )
+      this.project(session)
+      return session
+    })
+  }
+}
+
+export { SessionEnabledComputeHostsOwner }
+export type { SessionEnabledComputeHostsAuthority, SessionEnabledComputeHostsOwnerOptions }

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -18,6 +18,7 @@ type SessionEnabledComputeHostsOwnerOptions = Readonly<{
   hostExists(providerId: string): Promise<boolean>
   listHostIds(): Promise<readonly string[]>
   sessionAuthority: SessionEnabledComputeHostsAuthority
+  withDataRootWrite<Result>(operation: () => Promise<Result>): Promise<Result>
 }>
 
 class SessionEnabledComputeHostsOwner {
@@ -32,6 +33,10 @@ class SessionEnabledComputeHostsOwner {
       () => undefined
     )
     return result
+  }
+
+  private enqueueWrite<Result>(operation: () => Promise<Result>): Promise<Result> {
+    return this.enqueue(() => this.options.withDataRootWrite(operation))
   }
 
   private async validate(providerIds: readonly string[]): Promise<string[]> {
@@ -59,15 +64,19 @@ class SessionEnabledComputeHostsOwner {
     for (const sessionId of sessionIds) this.options.registry.clear(sessionId)
   }
 
-  pruneProvider(providerId: string): Promise<PersistedChatSession[]> {
+  pruneProvider(
+    providerId: string,
+    afterPrune?: () => Promise<void>
+  ): Promise<PersistedChatSession[]> {
     this.options.registry.removeProvider(providerId)
-    return this.enqueue(async () => {
+    return this.enqueueWrite(async () => {
       this.options.registry.removeProvider(providerId)
       const validProviderIds = (await this.options.listHostIds()).filter(
         (candidate) => candidate !== providerId
       )
       const sessions =
         await this.options.sessionAuthority.pruneSessionEnabledComputeHosts(validProviderIds)
+      await afterPrune?.()
       this.options.registry.reconcile(
         sessions.map((session) => [session.id, session.enabledComputeHosts ?? []] as const),
         true
@@ -80,7 +89,7 @@ class SessionEnabledComputeHostsOwner {
     sessions: readonly PersistedChatSession[],
     isComplete: boolean
   ): Promise<PersistedChatSession[]> {
-    return this.enqueue(async () => {
+    return this.enqueueWrite(async () => {
       const validProviderIds = await this.options.listHostIds()
       const validProviderIdSet = new Set(validProviderIds)
       const hasMissingHost = sessions.some((session) =>
@@ -109,7 +118,7 @@ class SessionEnabledComputeHostsOwner {
     session: PersistedChatSession,
     commit: (session: PersistedChatSession) => Promise<PersistedChatSession>
   ): Promise<PersistedChatSession> {
-    return this.enqueue(async () => {
+    return this.enqueueWrite(async () => {
       const enabledComputeHosts = await this.validate(session.enabledComputeHosts ?? [])
       const durableSession = await commit({
         ...session,
@@ -123,7 +132,7 @@ class SessionEnabledComputeHostsOwner {
   }
 
   set(sessionId: string, providerIds: readonly string[]): Promise<PersistedChatSession> {
-    return this.enqueue(async () => {
+    return this.enqueueWrite(async () => {
       const normalized = await this.validate(providerIds)
       const projectId = await this.options.sessionAuthority.sessionProjectId(sessionId)
       if (!projectId) throw new Error(`Session not found: ${sessionId}`)

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -73,14 +73,13 @@ class SessionEnabledComputeHostsOwner {
     providerId: string,
     afterPrune?: () => Promise<void>
   ): Promise<PersistedChatSession[]> {
-    this.options.registry.removeProvider(providerId)
     return this.enqueueWrite(async () => {
-      this.options.registry.removeProvider(providerId)
       const validProviderIds = (await this.options.listHostIds()).filter(
         (candidate) => candidate !== providerId
       )
       const repair =
         await this.options.sessionAuthority.pruneSessionEnabledComputeHosts(validProviderIds)
+      this.options.registry.removeProvider(providerId)
       try {
         await afterPrune?.()
       } catch (error) {
@@ -122,7 +121,12 @@ class SessionEnabledComputeHostsOwner {
     isComplete: boolean
   ): Promise<PersistedChatSession[]> {
     return this.enqueueWrite(async () => {
-      const validProviderIds = await this.options.listHostIds()
+      let validProviderIds: readonly string[]
+      try {
+        validProviderIds = await this.options.listHostIds()
+      } catch {
+        return [...sessions]
+      }
       const validProviderIdSet = new Set(validProviderIds)
       const hasMissingHost = sessions.some((session) =>
         session.enabledComputeHosts?.some((providerId) => !validProviderIdSet.has(providerId))

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1145,11 +1145,14 @@ const createApplicationModules = async (
     permissionGrantRegistry,
     settingsRepository,
     {
-      pruneSessionEnabledHosts: async (providerId) => {
+      pruneSessionEnabledHosts: async (providerId, afterPrune) => {
         if (!sessionEnabledComputeHostsOwnerRef.current) {
           throw new Error('Session enabled Compute Host ownership is not initialized.')
         }
-        const sessions = await sessionEnabledComputeHostsOwnerRef.current.pruneProvider(providerId)
+        const sessions = await sessionEnabledComputeHostsOwnerRef.current.pruneProvider(
+          providerId,
+          afterPrune
+        )
         for (const session of sessions) {
           try {
             applicationEvents.publish('session:updated', {
@@ -1175,7 +1178,8 @@ const createApplicationModules = async (
     registry: hostsRegistry,
     hostExists: async (providerId) => (await hostRepository.get(providerId)) !== null,
     listHostIds: async () => (await hostRepository.list()).map((host) => host.providerId),
-    sessionAuthority: sessionPersistenceCoordinator
+    sessionAuthority: sessionPersistenceCoordinator,
+    withDataRootWrite
   })
   sessionEnabledComputeHostsOwnerRef.current = sessionEnabledComputeHostsOwner
   computeJobDeletionRef.current = jobDeletionOwner

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -720,7 +720,7 @@ const createApplicationModules = async (
     inbox: notificationInbox,
     sessionPersistenceCoordinator,
     onSessionsDeleted: async (sessionIds) => {
-      sessionEnabledComputeHostsOwnerRef.current?.clear(sessionIds)
+      await sessionEnabledComputeHostsOwnerRef.current?.clear(sessionIds)
       await (sideChatOwnerRef.current?.invalidateParents(sessionIds) ?? Promise.resolve())
     }
   })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -51,6 +51,7 @@ import { ArtifactRunRegistry } from './artifacts/run-registry'
 import { createComputeIpcModule } from './compute/ipc'
 import type { ComputeJobOwnerLiveness } from './compute/job-deletion-owner'
 import { attachEnabledComputeHosts } from './compute/enabled-hosts-registry'
+import { SessionEnabledComputeHostsOwner } from './compute/session-enabled-hosts-owner'
 import { createComputeJobRuntime } from './compute/job-runtime'
 import { waitForInitialConnectorRefresh } from './connector-reload'
 import { ApprovalBroker } from './connectors/approval-broker'
@@ -134,6 +135,7 @@ import { parseArtifactVersionLocator } from '../shared/artifact-provenance'
 import { parseUploadVersionReference } from '../shared/uploads'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../shared/artifacts'
 import type { NotebookLanguage } from '../shared/notebook'
+import { MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID } from '../shared/lifecycle-events'
 import { OFFICE_PREVIEW_STATE_CHANNEL } from '../shared/office-preview'
 import { prepareExternalPythonRuntime } from './notebook/venv-overlay'
 import {
@@ -713,11 +715,14 @@ const createApplicationModules = async (
   archiveCoordinator.setMarkReadSessions((sessionIds) =>
     notificationInbox.markSessionsRead(sessionIds)
   )
+  const sessionEnabledComputeHostsOwnerRef: { current?: SessionEnabledComputeHostsOwner } = {}
   bindNotificationInboxDeletionRuntime({
     inbox: notificationInbox,
     sessionPersistenceCoordinator,
-    onSessionsDeleted: (sessionIds) =>
-      sideChatOwnerRef.current?.invalidateParents(sessionIds) ?? Promise.resolve()
+    onSessionsDeleted: async (sessionIds) => {
+      sessionEnabledComputeHostsOwnerRef.current?.clear(sessionIds)
+      await (sideChatOwnerRef.current?.invalidateParents(sessionIds) ?? Promise.resolve())
+    }
   })
   const projectHandlers = createProjectHandlers(projectRepository, projectDeletionCoordinator, {
     updateArchive: (request) => archiveCoordinator.updateProjectArchive(request)
@@ -732,8 +737,22 @@ const createApplicationModules = async (
   // the next message. Shared by persistSessionSpecialist (stash) and saveSession (flush).
   const pendingSpecialistBindings = new PendingSessionSpecialistBindings()
   const sessionPersistenceBackend: SessionPersistenceBackend = {
-    loadAll: () =>
-      loadSessionsAfterProjectRecovery(projectDeletionCoordinator, sessionPersistenceCoordinator),
+    loadAll: async () => {
+      const result = await loadSessionsAfterProjectRecovery(
+        projectDeletionCoordinator,
+        sessionPersistenceCoordinator
+      )
+      if (!sessionEnabledComputeHostsOwnerRef.current) {
+        throw new Error('Session enabled Compute Host ownership is not initialized.')
+      }
+      return {
+        ...result,
+        sessions: await sessionEnabledComputeHostsOwnerRef.current.reconcile(
+          result.sessions,
+          result.diagnostics?.isComplete === true
+        )
+      }
+    },
     loadOne: async ({ projectId, sessionId }) => {
       await projectDeletionCoordinator.recoverPendingDeletions()
       return sessionRepository.loadSession(projectId, sessionId)
@@ -742,7 +761,16 @@ const createApplicationModules = async (
       await projectDeletionCoordinator.recoverPendingDeletions()
       const created =
         (await sessionRepository.loadSession(session.projectId, session.id)) === undefined
-      const durableSession = await sessionPersistenceCoordinator.saveSession(session, options)
+      const durableSession = created
+        ? await (() => {
+            if (!sessionEnabledComputeHostsOwnerRef.current) {
+              throw new Error('Session enabled Compute Host ownership is not initialized.')
+            }
+            return sessionEnabledComputeHostsOwnerRef.current.createSession(session, (candidate) =>
+              sessionPersistenceCoordinator.saveSession(candidate, options)
+            )
+          })()
+        : await sessionPersistenceCoordinator.saveSession(session, options)
       // Flush any approved host.agents.switch binding stashed while this session was not yet durable,
       // so the approved target survives a restart before the next message (the in-memory binding
       // alone does not persist across restart).
@@ -1115,7 +1143,25 @@ const createApplicationModules = async (
     undefined,
     taskNotifications,
     permissionGrantRegistry,
-    settingsRepository
+    settingsRepository,
+    {
+      pruneSessionEnabledHosts: async (providerId) => {
+        if (!sessionEnabledComputeHostsOwnerRef.current) {
+          throw new Error('Session enabled Compute Host ownership is not initialized.')
+        }
+        const sessions = await sessionEnabledComputeHostsOwnerRef.current.pruneProvider(providerId)
+        for (const session of sessions) {
+          try {
+            applicationEvents.publish('session:updated', {
+              session,
+              originClientId: MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID
+            })
+          } catch {
+            // The durable repair and cache projection have committed; lifecycle delivery is best effort.
+          }
+        }
+      }
+    }
   )
   surfaceAdapters = beforeAcpAdapters
   const {
@@ -1125,6 +1171,13 @@ const createApplicationModules = async (
     hostRepository,
     enabledComputeHostsRegistry: hostsRegistry
   } = computeIpcModule
+  const sessionEnabledComputeHostsOwner = new SessionEnabledComputeHostsOwner({
+    registry: hostsRegistry,
+    hostExists: async (providerId) => (await hostRepository.get(providerId)) !== null,
+    listHostIds: async () => (await hostRepository.list()).map((host) => host.providerId),
+    sessionAuthority: sessionPersistenceCoordinator
+  })
+  sessionEnabledComputeHostsOwnerRef.current = sessionEnabledComputeHostsOwner
   computeJobDeletionRef.current = jobDeletionOwner
   await projectDeletionCoordinator.restorePendingDeletionBarriers()
   await jobDeletionOwner.restoreOrphanJobDeletionBarriers(isComputeJobOwnerLive)
@@ -2469,7 +2522,8 @@ const createApplicationModules = async (
         get: (providerId) => settingsService.getComputeBookmarks(providerId),
         set: (providerId, folders) => settingsService.setComputeBookmarks(providerId, folders)
       },
-      enabledHosts: hostsRegistry
+      enabledHosts: sessionEnabledComputeHostsOwner,
+      events: applicationEvents
     },
     permissionGrants: permissionGrantProjection,
     dataContent: {
@@ -2569,7 +2623,10 @@ const createApplicationModules = async (
     prepareForQuit: () => runtime.prepareForQuit(),
     electronAdapters: {
       beforeCompute: beforeComputeAdapters,
-      compute: computeIpcModule,
+      compute: {
+        handlers: computeIpcModule.handlers,
+        enabledHosts: sessionEnabledComputeHostsOwner
+      },
       beforeAcp: beforeAcpAdapters,
       acp: {
         runtime,

--- a/src/main/runtime-electron-wiring.test.ts
+++ b/src/main/runtime-electron-wiring.test.ts
@@ -30,7 +30,7 @@ describe('production Electron runtime wiring', () => {
   })
 
   it('installs the constructed Compute and ACP modules before remaining surfaces', async () => {
-    const compute = { handlers: {}, enabledComputeHostsRegistry: {} } as never
+    const compute = { handlers: {}, enabledHosts: {} } as never
     const runtime = {} as never
     const workflows = {} as never
 
@@ -73,7 +73,7 @@ describe('production Electron runtime wiring', () => {
 
   it('rolls back every installed adapter in reverse order when a later install fails', async () => {
     const rollbackOrder: string[] = []
-    const compute = { handlers: {}, enabledComputeHostsRegistry: {} } as never
+    const compute = { handlers: {}, enabledHosts: {} } as never
     const runtime = {} as never
     const workflows = {} as never
     installComputeIpcHandlers.mockReturnValueOnce({

--- a/src/main/runtime-electron-wiring.ts
+++ b/src/main/runtime-electron-wiring.ts
@@ -1,7 +1,7 @@
 import { installAcpIpcHandlers } from './acp/ipc'
 import type { AcpHandlerWorkflows } from './acp/handler-workflows'
 import type { AcpRuntimeCoordinator } from './acp/runtime-coordinator'
-import { installComputeIpcHandlers, type ComputeIpcModule } from './compute/ipc'
+import { installComputeIpcHandlers, type ComputeIpcAdapter } from './compute/ipc'
 import type { ElicitationResponse } from '../shared/acp'
 
 type Awaitable<T> = T | Promise<T>
@@ -17,7 +17,7 @@ export type NamedElectronSurfaceAdapter = {
 
 export type ElectronRuntimeAdapterInterfaces = {
   readonly beforeCompute: readonly NamedElectronSurfaceAdapter[]
-  readonly compute: Pick<ComputeIpcModule, 'handlers' | 'enabledComputeHostsRegistry'>
+  readonly compute: ComputeIpcAdapter
   readonly beforeAcp: readonly NamedElectronSurfaceAdapter[]
   readonly acp: {
     runtime: AcpRuntimeCoordinator

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -439,6 +439,7 @@ describe('Session persistence coordinator architecture', () => {
         'loadPersistedSideChats',
         'markCommittedProjectSessionsPrepared',
         'patchSessionRuntimeContext',
+        'pruneSessionEnabledComputeHosts',
         'readChildren',
         'readSessionRuntimeContext',
         'recoverInterruptedDelegatedWork',
@@ -451,6 +452,7 @@ describe('Session persistence coordinator architecture', () => {
         'sessionMetadataSnapshot',
         'sessionProjectId',
         'setSessionDeletionHandlers',
+        'setSessionEnabledComputeHosts',
         'settleMessage',
         'startAttemptRuntime',
         'startContinuationAttempt',
@@ -797,13 +799,15 @@ describe('Session persistence coordinator architecture', () => {
         'markMetadataIncomplete',
         'metadataSnapshot',
         'patchRuntimeContext',
+        'pruneEnabledComputeHosts',
         'readRuntimeContext',
         'recordSession',
         'removeProject',
         'removeSession',
         'replaceMetadata',
         'saveSession',
-        'sessionProjectId'
+        'sessionProjectId',
+        'setEnabledComputeHosts'
       ].sort()
     )
     expect(methods(stateOwner, 'private')).toEqual(['loadRuntimeContextSession'])
@@ -873,12 +877,14 @@ describe('Session persistence coordinator architecture', () => {
       loadPersistedSideChats: ['sideChatOwner.loadCatalog'],
       markCommittedProjectSessionsPrepared: ['deletionOwner.markCommittedProjectSessionsPrepared'],
       patchSessionRuntimeContext: ['stateOwner.patchRuntimeContext'],
+      pruneSessionEnabledComputeHosts: ['stateOwner.pruneEnabledComputeHosts'],
       readSessionRuntimeContext: ['stateOwner.readRuntimeContext'],
       saveSession: ['stateOwner.saveSession'],
       saveSessionSpecialistBinding: ['stateOwner.saveSession'],
       saveSideChatProjection: ['sideChatOwner.saveProjection'],
       sessionMetadataSnapshot: ['stateOwner.metadataSnapshot'],
       sessionProjectId: ['stateOwner.sessionProjectId'],
+      setSessionEnabledComputeHosts: ['stateOwner.setEnabledComputeHosts'],
       readChildren: ['delegatedWorkOwner.readChildren'],
       recoverInterruptedDelegatedWork: ['delegatedWorkOwner.recoverInterruptedDelegatedWork'],
       settleMessage: ['delegatedWorkOwner.settleMessage'],

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -1071,9 +1071,16 @@ describe('SessionPersistenceCoordinator', () => {
 
     const result = await coordinator.pruneSessionEnabledComputeHosts(['ssh:kept'])
 
-    expect(result.map((session) => session.enabledComputeHosts)).toEqual([
+    expect(result.sessions.map((session) => session.enabledComputeHosts)).toEqual([
       ['ssh:kept'],
       ['ssh:kept']
+    ])
+    expect(result.previousSelections).toEqual([
+      {
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        providerIds: ['ssh:kept', 'ssh:deleted']
+      }
     ])
     expect(saveSession).toHaveBeenCalledTimes(1)
     expect(saveSession).toHaveBeenCalledWith(

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -1088,6 +1088,41 @@ describe('SessionPersistenceCoordinator', () => {
     )
   })
 
+  it('restores every attempted Session when durable Compute Host pruning fails partway', async () => {
+    const originalSessions = [
+      createSession({ enabledComputeHosts: ['ssh:kept', 'ssh:deleted'] }),
+      createSession({
+        id: 'session-2',
+        enabledComputeHosts: ['ssh:deleted'],
+        updatedAt: 5
+      })
+    ]
+    let sessions = structuredClone(originalSessions)
+    let saveAttempts = 0
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn(async () => ({
+        result: { sessions, manifest: { version: 1 as const } },
+        isComplete: true
+      })),
+      saveSession: vi.fn(async (session) => {
+        saveAttempts += 1
+        sessions = sessions.map((candidate) =>
+          candidate.id === session.id ? structuredClone(session) : candidate
+        )
+        if (saveAttempts === 2) throw new Error('Session write failed')
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(coordinator.pruneSessionEnabledComputeHosts(['ssh:kept'])).rejects.toThrow(
+      'Session write failed'
+    )
+
+    expect(sessions.map((session) => session.enabledComputeHosts)).toEqual(
+      originalSessions.map((session) => session.enabledComputeHosts)
+    )
+  })
+
   it('refuses Compute Host pruning from an incomplete Session catalog', async () => {
     const repository = createSessionRepository({
       loadAllWithDiagnostics: vi.fn(async () => ({

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -980,6 +980,121 @@ describe('SessionPersistenceCoordinator', () => {
     expect(durable).toMatchObject({ title: 'Renderer rename', archivedAt: 10 })
   })
 
+  it('updates enabled Compute Hosts through the durable Session owner', async () => {
+    const previousUpdatedAt = Date.now() + 10_000
+    let durable = createSession({
+      title: 'Authoritative session',
+      enabledComputeHosts: ['ssh:old'],
+      updatedAt: previousUpdatedAt
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    const result = await coordinator.setSessionEnabledComputeHosts('project-1', 'session-1', [
+      'ssh:new'
+    ])
+
+    expect(result).toEqual(durable)
+    expect(durable).toMatchObject({
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Authoritative session',
+      enabledComputeHosts: ['ssh:new']
+    })
+    expect(durable.updatedAt).toBeGreaterThan(previousUpdatedAt)
+  })
+
+  it('preserves enabled Compute Host authority on an ordinary existing-Session save', async () => {
+    const authorityUpdatedAt = Date.now() + 10_000
+    let durable = createSession({
+      title: 'Before rename',
+      enabledComputeHosts: ['ssh:authoritative'],
+      updatedAt: authorityUpdatedAt
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    const result = await coordinator.saveSession(
+      createSession({
+        title: 'Renamed',
+        enabledComputeHosts: ['ssh:stale'],
+        updatedAt: authorityUpdatedAt - 1_000
+      })
+    )
+
+    expect(result).toMatchObject({
+      title: 'Renamed',
+      enabledComputeHosts: ['ssh:authoritative']
+    })
+    expect(durable.enabledComputeHosts).toEqual(['ssh:authoritative'])
+    expect(durable.updatedAt).toBeGreaterThan(authorityUpdatedAt)
+  })
+
+  it('prunes missing Compute Hosts across a complete durable Session catalog', async () => {
+    let sessions = [
+      createSession({ enabledComputeHosts: ['ssh:kept', 'ssh:deleted'] }),
+      createSession({
+        id: 'session-2',
+        enabledComputeHosts: ['ssh:kept'],
+        updatedAt: 5
+      })
+    ]
+    const saveSession = vi.fn(async (session: PersistedChatSession) => {
+      sessions = sessions.map((candidate) =>
+        candidate.id === session.id ? structuredClone(session) : candidate
+      )
+    })
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn(async () => ({
+        result: { sessions, manifest: { version: 1 as const } },
+        isComplete: true
+      })),
+      saveSession
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    const result = await coordinator.pruneSessionEnabledComputeHosts(['ssh:kept'])
+
+    expect(result.map((session) => session.enabledComputeHosts)).toEqual([
+      ['ssh:kept'],
+      ['ssh:kept']
+    ])
+    expect(saveSession).toHaveBeenCalledTimes(1)
+    expect(saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'session-1', enabledComputeHosts: ['ssh:kept'] })
+    )
+  })
+
+  it('refuses Compute Host pruning from an incomplete Session catalog', async () => {
+    const repository = createSessionRepository({
+      loadAllWithDiagnostics: vi.fn(async () => ({
+        result: { sessions: [createSession()], manifest: { version: 1 as const } },
+        isComplete: false
+      }))
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(coordinator.pruneSessionEnabledComputeHosts([])).rejects.toThrow(
+      'complete Session catalog'
+    )
+  })
+
   it('rejects Session archive while the Session is running', async () => {
     const repository = createSessionRepository({
       loadSessionWithDiagnostics: vi.fn(async () => ({

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -672,6 +672,31 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     )
   }
 
+  setSessionEnabledComputeHosts(
+    projectId: string,
+    sessionId: string,
+    providerIds: readonly string[]
+  ): Promise<PersistedChatSession> {
+    return this.enqueue(() =>
+      this.stateOwner.setEnabledComputeHosts(projectId, sessionId, providerIds)
+    )
+  }
+
+  pruneSessionEnabledComputeHosts(
+    validProviderIds: readonly string[]
+  ): Promise<PersistedChatSession[]> {
+    return this.enqueue(async () => {
+      const scan = await this.repository.loadAllWithDiagnostics()
+      if (!scan.isComplete) {
+        throw new Error('Cannot prune Compute Hosts without a complete Session catalog.')
+      }
+      return this.stateOwner.pruneEnabledComputeHosts(
+        scan.result.sessions,
+        new Set(validProviderIds)
+      )
+    })
+  }
+
   // Joins late Session-owned side effects (for example Upload finalization) to the same ordering
   // boundary as JSON save and deletion. The mutation is rejected after a Session/Project tombstone.
   runSessionMutation<Result>(

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -682,18 +682,31 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     )
   }
 
-  pruneSessionEnabledComputeHosts(
-    validProviderIds: readonly string[]
-  ): Promise<PersistedChatSession[]> {
+  pruneSessionEnabledComputeHosts(validProviderIds: readonly string[]): Promise<{
+    sessions: PersistedChatSession[]
+    previousSelections: Array<{
+      projectId: string
+      sessionId: string
+      providerIds: string[]
+    }>
+  }> {
     return this.enqueue(async () => {
       const scan = await this.repository.loadAllWithDiagnostics()
       if (!scan.isComplete) {
         throw new Error('Cannot prune Compute Hosts without a complete Session catalog.')
       }
-      return this.stateOwner.pruneEnabledComputeHosts(
+      const validProviderIdSet = new Set(validProviderIds)
+      const previousSelections = scan.result.sessions.flatMap((session) => {
+        const providerIds = session.enabledComputeHosts ?? []
+        return providerIds.some((providerId) => !validProviderIdSet.has(providerId))
+          ? [{ projectId: session.projectId, sessionId: session.id, providerIds: [...providerIds] }]
+          : []
+      })
+      const sessions = await this.stateOwner.pruneEnabledComputeHosts(
         scan.result.sessions,
-        new Set(validProviderIds)
+        validProviderIdSet
       )
+      return { sessions, previousSelections }
     })
   }
 

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -121,9 +121,7 @@ const rebaseSafeSessionFields = (
         rebased.autoReviewEnabled = submitted.autoReviewEnabled
         break
       case 'enabledComputeHosts':
-        rebased.enabledComputeHosts = submitted.enabledComputeHosts
-          ? [...submitted.enabledComputeHosts]
-          : undefined
+        // Retained in the wire-compatible enum, but this field is now changed only by its command.
         break
       case 'pinned':
         rebased.pinned = submitted.pinned
@@ -259,13 +257,10 @@ class SessionPersistenceStateOwner {
   private readonly validatedBindingTopologies = new Map<string, string>()
   private sessionMetadata = new Map<string, SessionMetadata>()
   private isSessionMetadataComplete = false
-
   constructor(private readonly options: SessionPersistenceStateOwnerOptions) {}
-
   beginHydration(): void {
     this.validatedBindingTopologies.clear()
   }
-
   replaceMetadata(sessions: readonly PersistedChatSession[], isComplete: boolean): void {
     this.sessionMetadata = new Map(
       sessions.map((session) => [
@@ -275,7 +270,6 @@ class SessionPersistenceStateOwner {
     )
     this.isSessionMetadataComplete = isComplete
   }
-
   recordSession(session: PersistedChatSession): void {
     this.sessionMetadata.set(session.id, {
       id: session.id,
@@ -283,38 +277,31 @@ class SessionPersistenceStateOwner {
       title: session.title
     })
   }
-
   markMetadataIncomplete(): void {
     this.isSessionMetadataComplete = false
   }
-
   removeSession(projectId: string, sessionId: string): void {
     this.sessionMetadata.delete(sessionId)
     this.invalidateBindingTopology(projectId, sessionId)
   }
-
   removeProject(projectId: string, sessionIds: readonly string[]): void {
     for (const [sessionId, metadata] of this.sessionMetadata) {
       if (metadata.projectId === projectId) this.sessionMetadata.delete(sessionId)
     }
     for (const sessionId of sessionIds) this.invalidateBindingTopology(projectId, sessionId)
   }
-
   metadataSnapshot(): SessionMetadataSnapshot {
     return {
       sessions: [...this.sessionMetadata.values()],
       isComplete: this.isSessionMetadataComplete
     }
   }
-
   sessionProjectId(sessionId: string): string | undefined {
     return this.sessionMetadata.get(sessionId)?.projectId
   }
-
   invalidateBindingTopology(projectId: string, sessionId: string): void {
     this.validatedBindingTopologies.delete(`${projectId}:${sessionId}`)
   }
-
   async containsMessageOnActiveBranch(
     projectId: string,
     sessionId: string,
@@ -459,6 +446,51 @@ class SessionPersistenceStateOwner {
     return message
   }
 
+  async setEnabledComputeHosts(
+    projectId: string,
+    sessionId: string,
+    providerIds: readonly string[]
+  ): Promise<PersistedChatSession> {
+    this.options.assertMutable(projectId, sessionId, 'mutate')
+    const loaded = await this.options.repository.loadSessionWithDiagnostics(projectId, sessionId)
+    if (loaded.status !== 'found') {
+      throw new Error(`Cannot update enabled Compute Hosts for a ${loaded.status} Session.`)
+    }
+    const durableSession: PersistedChatSession = {
+      ...loaded.session,
+      enabledComputeHosts: [...providerIds],
+      updatedAt: Math.max(loaded.session.updatedAt + 1, Date.now())
+    }
+    await this.options.repository.saveSession(durableSession)
+    this.recordSession(durableSession)
+    return durableSession
+  }
+
+  async pruneEnabledComputeHosts(
+    sessions: readonly PersistedChatSession[],
+    validProviderIds: ReadonlySet<string>
+  ): Promise<PersistedChatSession[]> {
+    const durableSessions: PersistedChatSession[] = []
+    for (const session of sessions) {
+      const current = session.enabledComputeHosts ?? []
+      const enabledComputeHosts = current.filter((providerId) => validProviderIds.has(providerId))
+      if (enabledComputeHosts.length === current.length) {
+        durableSessions.push(session)
+        continue
+      }
+      this.options.assertMutable(session.projectId, session.id, 'mutate')
+      const durableSession: PersistedChatSession = {
+        ...session,
+        enabledComputeHosts,
+        updatedAt: Math.max(session.updatedAt + 1, Date.now())
+      }
+      await this.options.repository.saveSession(durableSession)
+      this.recordSession(durableSession)
+      durableSessions.push(durableSession)
+    }
+    return durableSessions
+  }
+
   async saveSession(
     session: PersistedChatSession,
     options: SaveSessionOptions = {}
@@ -494,9 +526,16 @@ class SessionPersistenceStateOwner {
       messages: mergeMainOwnedRelayMessages(rendererOwnedSession.messages, authority?.messages),
       ...(authority?.runtimeContext ? { runtimeContext: authority.runtimeContext } : {}),
       ...(authority?.archivedAt ? { archivedAt: authority.archivedAt } : {}),
+      ...(authority
+        ? {
+            enabledComputeHosts: authority.enabledComputeHosts
+              ? [...authority.enabledComputeHosts]
+              : undefined
+          }
+        : {}),
       ...(mainOwnedStatus ? { status: mainOwnedStatus } : {}),
       updatedAt:
-        authority?.runtimeContext || mainOwnedStatus
+        authority?.runtimeContext || mainOwnedStatus || authority?.enabledComputeHosts !== undefined
           ? Math.max(rendererOwnedSession.updatedAt, (authority?.updatedAt ?? -1) + 1, Date.now())
           : rendererOwnedSession.updatedAt
     }

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -471,24 +471,45 @@ class SessionPersistenceStateOwner {
     validProviderIds: ReadonlySet<string>
   ): Promise<PersistedChatSession[]> {
     const durableSessions: PersistedChatSession[] = []
-    for (const session of sessions) {
-      const current = session.enabledComputeHosts ?? []
-      const enabledComputeHosts = current.filter((providerId) => validProviderIds.has(providerId))
-      if (enabledComputeHosts.length === current.length) {
-        durableSessions.push(session)
-        continue
+    const attemptedSessions: PersistedChatSession[] = []
+    try {
+      for (const session of sessions) {
+        const current = session.enabledComputeHosts ?? []
+        const enabledComputeHosts = current.filter((providerId) => validProviderIds.has(providerId))
+        if (enabledComputeHosts.length === current.length) {
+          durableSessions.push(session)
+          continue
+        }
+        this.options.assertMutable(session.projectId, session.id, 'mutate')
+        const durableSession: PersistedChatSession = {
+          ...session,
+          enabledComputeHosts,
+          updatedAt: Math.max(session.updatedAt + 1, Date.now())
+        }
+        attemptedSessions.push(session)
+        await this.options.repository.saveSession(durableSession)
+        this.recordSession(durableSession)
+        durableSessions.push(durableSession)
       }
-      this.options.assertMutable(session.projectId, session.id, 'mutate')
-      const durableSession: PersistedChatSession = {
-        ...session,
-        enabledComputeHosts,
-        updatedAt: Math.max(session.updatedAt + 1, Date.now())
+      return durableSessions
+    } catch (error) {
+      const rollbackErrors: unknown[] = []
+      for (const session of attemptedSessions) {
+        try {
+          await this.options.repository.saveSession(session)
+          this.recordSession(session)
+        } catch (rollbackError) {
+          rollbackErrors.push(rollbackError)
+        }
       }
-      await this.options.repository.saveSession(durableSession)
-      this.recordSession(durableSession)
-      durableSessions.push(durableSession)
+      if (rollbackErrors.length > 0) {
+        throw new AggregateError(
+          [error, ...rollbackErrors],
+          'Compute Host pruning failed and affected Sessions could not all be restored.'
+        )
+      }
+      throw error
     }
-    return durableSessions
   }
 
   async saveSession(

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -692,10 +692,9 @@ export interface OpenScienceAPI {
     jobsMarkConsumed(sessionId: string, jobIds: string[]): Promise<void>
     // Fires when a job's status or tail changes (broadcast from the main-process poller).
     onJobUpdated(listener: (job: JobSummary) => void): () => void
-    // Per-session enabled compute hosts (issue 06). The renderer owns the durable state (session JSON);
-    // the main-process registry is the runtime cache for list_compute RPC ops.
+    // Per-session enabled Compute Hosts. Main owns durable Session JSON and projects the runtime cache.
     enabledHostsGet(sessionId: string): Promise<string[]>
-    enabledHostsSet(sessionId: string, providerIds: string[]): Promise<void>
+    enabledHostsSet(sessionId: string, providerIds: string[]): Promise<PersistedChatSession>
   }
   preview: {
     load(request: LoadPreviewStateRequest): Promise<PersistedPreviewState | null>

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID,
+  MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID,
   MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
   type ProjectDeletedEvent,
   type SessionDeletedEvent,
@@ -184,6 +185,31 @@ describe('useLifecycleSync', () => {
 
     expect(useSessionStore.getState().sessions[0]?.title).toBe('Updated session')
     expect(container.querySelector<HTMLButtonElement>('button')?.dataset.noticeSession).toBe('')
+  })
+
+  it('projects enabled Compute Host authority without replacing live chat state', async () => {
+    useSessionStore.getState().hydrateSessions([session])
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().appendUserMessage({
+      sessionId: session.id,
+      content: 'Keep this live prompt'
+    })
+
+    await act(async () => {
+      listeners.sessionUpdated?.({
+        originClientId: MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID,
+        session: {
+          ...toPersistedSession(source),
+          enabledComputeHosts: ['ssh:lab'],
+          updatedAt: source.updatedAt + 1
+        }
+      })
+    })
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      enabledComputeHosts: ['ssh:lab'],
+      messages: [expect.objectContaining({ content: 'Keep this live prompt' })]
+    })
   })
 
   it('merges Main-owned permission authority without replacing live chat state', async () => {

--- a/src/renderer/src/hooks/useLifecycleSync.ts
+++ b/src/renderer/src/hooks/useLifecycleSync.ts
@@ -2,6 +2,7 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 import {
   MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID,
+  MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID,
   MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
   type SessionUpsertEvent
 } from '../../../shared/lifecycle-events'
@@ -139,6 +140,18 @@ const useLifecycleSync = ({
               source,
               session,
               mode: 'permission-authority'
+            })
+          } else {
+            store.upsertPersistedSession(session)
+          }
+        } else if (originClientId === MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID) {
+          const store = useSessionStore.getState()
+          const source = store.sessions.find((candidate) => candidate.id === session.id)
+          if (source) {
+            store.applyDurableSessionProjection({
+              source,
+              session,
+              mode: 'enabled-compute-hosts-authority'
             })
           } else {
             store.upsertPersistedSession(session)

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -479,7 +479,8 @@ const sendIntentKeys = [
   'forcedSkillIds',
   'referencedArtifacts',
   'parts',
-  'specialistId'
+  'specialistId',
+  'enabledComputeHosts'
 ] as const
 const ownerDependencyNames = (path: string): string[] => {
   const targets = new Set(importsFrom(path).map((reference) => reference.target))

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -2420,6 +2420,42 @@ describe('workspace agent message sending', () => {
     await vi.waitFor(() => expect(runtime.sendPrompt).toHaveBeenCalledOnce())
   })
 
+  it('deletes a new runtime Session when enabled Compute Host persistence fails', async () => {
+    vi.stubGlobal('window', {
+      api: {
+        sessions: {
+          saveSession: vi.fn().mockRejectedValue(new Error('Session write failed'))
+        }
+      }
+    })
+    const deleteSession = vi.fn().mockResolvedValue(createSnapshot())
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn().mockResolvedValue({
+        sessionId: 'transport-session-1',
+        cwd: '/workspace/project'
+      }),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      deleteSession,
+      sendPrompt: vi.fn()
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      text: 'Inspect the cluster',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      enabledComputeHosts: ['ssh:cluster']
+    })
+
+    await vi.waitFor(() => expect(deleteSession).toHaveBeenCalledWith('transport-session-1'))
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      status: 'error',
+      error: 'Session write failed'
+    })
+  })
+
   it('retains Plan first while a new Session waits for ACP creation', async () => {
     const created = createDeferred<{ sessionId: string; cwd?: string }>()
     const runtime = {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -3,6 +3,7 @@ import type {
   AcpRuntimeEvent,
   AcpStateSnapshot
 } from '../../../../shared/acp'
+import type { PersistedChatSession } from '../../../../shared/session-persistence'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -2381,6 +2382,42 @@ describe('workspace agent message sending', () => {
       expect.objectContaining({ promptMessageId: expect.any(String) }),
       false
     )
+  })
+
+  it('persists enabled Compute Hosts before dispatching a new Session prompt', async () => {
+    const persisted = createDeferred<PersistedChatSession>()
+    const saveSession = vi.fn((session: PersistedChatSession) => {
+      void session
+      return persisted.promise
+    })
+    vi.stubGlobal('window', { api: { sessions: { saveSession } } })
+    const runtime = {
+      state: createSnapshot(),
+      createSession: vi.fn().mockResolvedValue({
+        sessionId: 'transport-session-1',
+        cwd: '/workspace/project'
+      }),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      text: 'Inspect the cluster',
+      cwd: '/workspace/project',
+      projectId: 'project-1',
+      enabledComputeHosts: ['ssh:cluster']
+    })
+
+    await vi.waitFor(() => expect(saveSession).toHaveBeenCalledOnce())
+    expect(saveSession.mock.calls[0]?.[0]).toMatchObject({
+      id: 'transport-session-1',
+      enabledComputeHosts: ['ssh:cluster']
+    })
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+
+    persisted.resolve(saveSession.mock.calls[0]![0])
+    await vi.waitFor(() => expect(runtime.sendPrompt).toHaveBeenCalledOnce())
   })
 
   it('retains Plan first while a new Session waits for ACP creation', async () => {

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -43,6 +43,7 @@ type SendWorkspaceMessageIntent = {
   referencedArtifacts?: FileReference[]
   parts?: MessagePart[]
   specialistId?: string | null
+  enabledComputeHosts?: string[]
 }
 
 type SendWorkspaceMessageCommand = SendWorkspaceMessageIntent & {
@@ -566,7 +567,8 @@ const sendWorkspaceMessage = async (
     agentFrameworkId: input.agentFrameworkId,
     agentBackendId: input.agentBackendId,
     agentModel: input.agentModel,
-    specialistId: input.specialistId ?? undefined
+    specialistId: input.specialistId ?? undefined,
+    enabledComputeHosts: input.enabledComputeHosts
   })
   if (!pending) return undefined
   startPendingPrompt(runtime, {

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -82,7 +82,8 @@ type ResendEditedWorkspaceMessageOptions = WorkspaceCommandLifecycle & {
 type WorkspaceCommandRuntime = Pick<
   ReturnType<typeof useAcpRuntime>,
   'state' | 'createSession' | 'resumeSession' | 'resetSessionContext' | 'sendPrompt'
->
+> &
+  Partial<Pick<ReturnType<typeof useAcpRuntime>, 'deleteSession'>>
 type HistoryReplayContext = {
   historyPreamble?: string
   historyAttachments?: UploadedAttachment[]
@@ -336,6 +337,17 @@ const startPendingPrompt = (
       try {
         await saveSessionInOrder(toPersistedSession(boundSession))
       } catch (error) {
+        try {
+          const snapshot = await runtime.deleteSession?.(created.sessionId)
+          if (
+            runtime.deleteSession &&
+            (!snapshot || snapshot.sessionIds.includes(created.sessionId))
+          ) {
+            console.warn('Agent Session cleanup after persistence failure did not complete')
+          }
+        } catch (cleanupError) {
+          console.warn('Agent Session cleanup after persistence failure failed', cleanupError)
+        }
         if (ownsPrompt(created.sessionId, bound.messageId)) {
           useSessionStore.getState().failRun(created.sessionId, errorMessage(error))
         }

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -13,8 +13,9 @@ import {
   type UploadedAttachment
 } from '../../../../shared/uploads'
 import { getActiveConversationContext } from '../../../../shared/conversation-graph'
+import { saveSessionInOrder } from '../session-persistence/session-persistence'
 import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
-import { useSessionStore, type ChatMessage } from '../../stores/session-store'
+import { toPersistedSession, useSessionStore, type ChatMessage } from '../../stores/session-store'
 import {
   buildWorkspaceHistoryReplay,
   resolveHistoryReplayTarget,
@@ -327,6 +328,22 @@ const startPendingPrompt = (
       return
     }
     if (!ownsPrompt(created.sessionId, bound.messageId)) return
+
+    const boundSession = useSessionStore
+      .getState()
+      .sessions.find((session) => session.id === created.sessionId)
+    if (boundSession?.enabledComputeHosts?.length) {
+      try {
+        await saveSessionInOrder(toPersistedSession(boundSession))
+      } catch (error) {
+        if (ownsPrompt(created.sessionId, bound.messageId)) {
+          useSessionStore.getState().failRun(created.sessionId, errorMessage(error))
+        }
+        return
+      }
+      if (!ownsPrompt(created.sessionId, bound.messageId)) return
+    }
+
     dispatchPrompt(runtime, {
       sessionId: created.sessionId,
       messageId: bound.messageId,

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -45,7 +45,6 @@ const SESSION_CONFLICT_REBASE_FIELDS = [
   'title',
   'permissionProfile',
   'autoReviewEnabled',
-  'enabledComputeHosts',
   'pinned',
   'specialistId'
 ] as const satisfies readonly SessionConflictRebaseField[]
@@ -55,13 +54,7 @@ const conflictRebaseFieldChanged = (
   next: ChatSession,
   field: SessionConflictRebaseField
 ): boolean => {
-  if (field !== 'enabledComputeHosts') return previous[field] !== next[field]
-  const previousHosts = previous.enabledComputeHosts ?? []
-  const nextHosts = next.enabledComputeHosts ?? []
-  return (
-    previousHosts.length !== nextHosts.length ||
-    previousHosts.some((host, index) => host !== nextHosts[index])
-  )
+  return previous[field] !== next[field]
 }
 
 const mergeSaveSessionOptions = (

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -116,7 +116,6 @@ const WorkspacePage = ({
   const currentDraftKey = selectedSessionId ?? newConversationDraftKey
   const clearSelection = useSessionStore((state) => state.clearSelection)
   const setAutoReviewEnabled = useSessionStore((state) => state.setAutoReviewEnabled)
-  const setEnabledComputeHosts = useSessionStore((state) => state.setEnabledComputeHosts)
   const setFixLoopActive = useSessionStore((state) => state.setFixLoopActive)
   const setActivePlanProjection = useSessionStore((state) => state.setActivePlanProjection)
   // Only sessions belonging to the active project are shown in this workspace.
@@ -463,13 +462,10 @@ const WorkspacePage = ({
     sideChat: canEditDraft && !sideChatDisabledReason ? { start: sideChat.start } : undefined,
     sideChatOpen: sideChat.view !== undefined,
     setAutoReviewEnabled,
-    setEnabledComputeHosts,
     resetNewConversationSettings: () => {
       setNewConversationAutoReviewEnabled(false)
       setNewConversationEnabledComputeHosts([])
     },
-    syncComputeHosts: (sessionId, providerIds) =>
-      window.api.compute.enabledHostsSet(sessionId, providerIds),
     abortFixLoop: (request) => window.api.reviewer.abortFixLoop(request),
     getSession: (sessionId) =>
       useSessionStore.getState().sessions.find((candidate) => candidate.id === sessionId)
@@ -707,21 +703,6 @@ const WorkspacePage = ({
     }
   }, [activeSessionId, activeSessionCwd, activeSessionProjectId])
 
-  // Sync the active session's enabled compute hosts to the main-process registry when switching
-  // sessions. The registry is the runtime source for list_compute RPC ops; the session JSON is the
-  // durable source. Toggle updates also sync directly in handleComputeHostToggle.
-  useEffect(() => {
-    if (!activeSessionId) return
-    // Read from store snapshot to avoid stale closure on activeEnabledComputeHosts.
-    const session = useSessionStore.getState().sessions.find((s) => s.id === activeSessionId)
-    void window.api.compute
-      .enabledHostsSet(activeSessionId, session?.enabledComputeHosts ?? [])
-      .catch((err: unknown) => {
-        console.warn('Failed to sync enabled compute hosts to registry', err)
-      })
-    // Only re-run when the active session changes (session switch). Toggle handler syncs directly.
-  }, [activeSessionId])
-
   // Keeps New as a local draft reset after persistence hydration has selected restored sessions.
   const openNewConversation = useCallback((): void => {
     if (!isSessionPersistenceReady) return
@@ -811,7 +792,7 @@ const WorkspacePage = ({
   // Enables or disables a compute host for the active session (single-select semantics).
   // Enabling one host replaces any existing selection; disabling clears the set.
   // For a not-yet-created conversation, the Conversation submit transaction stamps this draft state
-  // onto the new session. Existing sessions update the store and main-process registry immediately.
+  // onto the new session. Existing sessions update only from the durable command result.
   const handleComputeHostToggle = (providerId: string, enabled: boolean): void => {
     // Single-select: enable one host ↔ clear all others; disabling clears the selection entirely.
     const newEnabledHosts = enabled ? [providerId] : []
@@ -819,13 +800,20 @@ const WorkspacePage = ({
       setNewConversationEnabledComputeHosts(newEnabledHosts)
       return
     }
-    const sessionId = activeSession.id
-    setEnabledComputeHosts(sessionId, newEnabledHosts)
-    // Keep the main-process registry in sync immediately so list_compute() reflects the change
-    // without waiting for the next session-switch effect.
-    void window.api.compute.enabledHostsSet(sessionId, newEnabledHosts).catch((err: unknown) => {
-      console.warn('Failed to sync enabled compute hosts to registry', err)
-    })
+    const source = activeSession
+    setAttachmentError(null)
+    void window.api.compute
+      .enabledHostsSet(source.id, newEnabledHosts)
+      .then((session) => {
+        useSessionStore.getState().applyDurableSessionProjection({
+          source,
+          session,
+          mode: 'enabled-compute-hosts-authority'
+        })
+      })
+      .catch((error: unknown) => {
+        setAttachmentError(error instanceof Error ? error.message : String(error))
+      })
   }
 
   // Manually triggers a review of the last completed turn, bypassing autoReviewEnabled and the

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
@@ -97,9 +97,7 @@ const options = (
     },
     sideChatOpen: false,
     setAutoReviewEnabled: vi.fn(),
-    setEnabledComputeHosts: vi.fn(),
     resetNewConversationSettings: vi.fn(),
-    syncComputeHosts: vi.fn(() => Promise.resolve()),
     abortFixLoop: vi.fn(() => Promise.resolve()),
     getSession: (sessionId) => (sessionId === 'session-a' ? session() : undefined),
     ...overrides
@@ -352,7 +350,7 @@ describe('workspace conversation controller', () => {
     )
   })
 
-  it('stamps new-Session Review and Compute intent only after submit succeeds', async () => {
+  it('includes new-Session Compute intent in creation and stamps Review after submit succeeds', async () => {
     const input = options({
       activeSession: undefined,
       currentDraftKey: 'new:project-a',
@@ -375,8 +373,9 @@ describe('workspace conversation controller', () => {
     await vi.waitFor(() => expect(input.resetNewConversationSettings).toHaveBeenCalled())
 
     expect(input.setAutoReviewEnabled).toHaveBeenCalledWith('pending-session', true)
-    expect(input.setEnabledComputeHosts).toHaveBeenCalledWith('pending-session', ['ssh:lab'])
-    expect(input.syncComputeHosts).toHaveBeenCalledWith('pending-session', ['ssh:lab'])
+    expect(input.runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ enabledComputeHosts: ['ssh:lab'] })
+    )
     expect(input.session.actions.resetNewConversationSpecialist).toHaveBeenCalledOnce()
   })
 

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -76,9 +76,7 @@ type WorkspaceConversationControllerOptions = {
   sideChat?: Readonly<{ start: (text: string) => Promise<boolean> }>
   sideChatOpen: boolean
   setAutoReviewEnabled: (sessionId: string, enabled: boolean) => void
-  setEnabledComputeHosts: (sessionId: string, providerIds: string[]) => void
   resetNewConversationSettings: () => void
-  syncComputeHosts: (sessionId: string, providerIds: string[]) => Promise<unknown>
   abortFixLoop: (request: { projectId: string; appSessionId: string }) => Promise<unknown>
   getSession: (sessionId: string) => ChatSession | undefined
 }
@@ -219,7 +217,10 @@ const useWorkspaceConversationController = (
             permissionProfile: current.permissionProfile,
             forcedSkillIds,
             ...(mode === 'plan-first' ? { turnIntent: 'plan-first' as const } : {}),
-            specialistId: draftSpecialistId
+            specialistId: draftSpecialistId,
+            ...(wasNewConversation && computeHosts.length > 0
+              ? { enabledComputeHosts: computeHosts }
+              : {})
           })
           .catch((error: unknown) => {
             composer.actions.setError(errorMessage(error))
@@ -232,17 +233,6 @@ const useWorkspaceConversationController = (
             }
             if (wasNewConversation && autoReviewEnabled) {
               current.setAutoReviewEnabled(result.sessionId, true)
-            }
-            if (wasNewConversation && computeHosts.length > 0) {
-              current.setEnabledComputeHosts(result.sessionId, computeHosts)
-              void current
-                .syncComputeHosts(result.sessionId, computeHosts)
-                .catch((error: unknown) =>
-                  console.warn(
-                    'Failed to sync draft compute hosts to registry for new session',
-                    error
-                  )
-                )
             }
             current.resetNewConversationSettings()
             session.actions.resetNewConversationSpecialist()

--- a/src/renderer/src/stores/session-store-message-graph-helpers.ts
+++ b/src/renderer/src/stores/session-store-message-graph-helpers.ts
@@ -40,6 +40,7 @@ export type AppendUserMessageInput = {
   agentModel?: string
   isPending?: boolean
   specialistId?: string
+  enabledComputeHosts?: string[]
 }
 
 export type AppendPendingUserMessageInput = Omit<AppendUserMessageInput, 'sessionId' | 'isPending'>

--- a/src/renderer/src/stores/session-store-message-graph-owner.ts
+++ b/src/renderer/src/stores/session-store-message-graph-owner.ts
@@ -174,7 +174,8 @@ export const createSessionMessageGraphOwner = <
     agentBackendId,
     agentModel,
     isPending,
-    specialistId
+    specialistId,
+    enabledComputeHosts
   }) => {
     const trimmedContent = content.trim()
     const normalizedAgentBackendId = agentBackendId?.trim() || undefined
@@ -265,6 +266,7 @@ export const createSessionMessageGraphOwner = <
         agentBackendId: normalizedAgentBackendId,
         agentModel: normalizedAgentModel,
         ...(specialistId ? { specialistId } : {}),
+        ...(enabledComputeHosts?.length ? { enabledComputeHosts: [...enabledComputeHosts] } : {}),
         messages: [userMessage],
         activeRun,
         createdAt: now,
@@ -287,32 +289,10 @@ export const createSessionMessageGraphOwner = <
 
     return { sessionId, messageId: userMessage.id }
   },
-  appendPendingUserMessage: ({
-    content,
-    attachments = [],
-    parts,
-    turnIntent,
-    cwd,
-    projectId,
-    permissionProfile,
-    agentFrameworkId,
-    agentBackendId,
-    agentModel,
-    specialistId
-  }) =>
+  appendPendingUserMessage: (input) =>
     get().appendUserMessage({
+      ...input,
       sessionId: createPendingSessionId(),
-      content,
-      attachments,
-      parts,
-      turnIntent,
-      cwd,
-      projectId,
-      permissionProfile,
-      agentFrameworkId,
-      agentBackendId,
-      agentModel,
-      specialistId,
       isPending: true
     }),
   branchInNewSession: ({

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -111,7 +111,11 @@ export type SessionHydrationSelection = {
 export type ApplyDurableSessionProjectionInput = {
   source: ChatSession
   session: PersistedChatSession
-  mode?: 'merge-upload-identities' | 'replace-persisted-if-current' | 'permission-authority'
+  mode?:
+    | 'merge-upload-identities'
+    | 'replace-persisted-if-current'
+    | 'permission-authority'
+    | 'enabled-compute-hosts-authority'
 }
 
 export type SessionPersistenceActions = {
@@ -484,6 +488,22 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
     set((state) => {
       const current = state.sessions.find((candidate) => candidate.id === session.id)
       if (!current) return state
+
+      if (mode === 'enabled-compute-hosts-authority') {
+        const projected: ChatSession = {
+          ...current,
+          enabledComputeHosts: session.enabledComputeHosts
+            ? [...session.enabledComputeHosts]
+            : undefined,
+          updatedAt: Math.max(current.updatedAt, session.updatedAt)
+        }
+        externallyHydratedSessions.add(projected)
+        return {
+          sessions: state.sessions.map((candidate) =>
+            candidate.id === session.id ? projected : candidate
+          )
+        } as Partial<State>
+      }
 
       if (mode === 'permission-authority') {
         const currentRevision = current.runtimeContext?.revision

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -909,7 +909,6 @@ describe('Session Store architecture', () => {
       'setAutoReviewEnabled',
       'setBranchSwitchBlocked',
       'setContextUsage',
-      'setEnabledComputeHosts',
       'setFixLoopActive',
       'setPermissionProfile',
       'setSessionSpecialistId',

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1726,7 +1726,8 @@ describe('session store', () => {
   it('creates a pending first message before a runtime session id exists', () => {
     const result = useSessionStore.getState().appendPendingUserMessage({
       content: 'Help me inspect this notebook',
-      cwd: '/workspace/project'
+      cwd: '/workspace/project',
+      enabledComputeHosts: ['ssh:lab']
     })
 
     expect(result?.sessionId).toMatch(/^pending-session-/)
@@ -1736,6 +1737,7 @@ describe('session store', () => {
         id: result?.sessionId,
         isPending: true,
         cwd: '/workspace/project',
+        enabledComputeHosts: ['ssh:lab'],
         title: 'Help me inspect this notebook',
         status: 'running',
         activeRun: {
@@ -4359,7 +4361,6 @@ describe('session store public contract', () => {
         'setElicitationDraftAnswers',
         'setElicitationHistoryReplayRequest',
         'setElicitationPending',
-        'setEnabledComputeHosts',
         'setFixLoopActive',
         'setPermissionPending',
         'setPermissionProfile',
@@ -5626,6 +5627,27 @@ describe('truncateSessionFromMessage', () => {
     expect(useSessionStore.getState().sessions[0]).toMatchObject({
       title: 'Acknowledged title',
       elicitationHistoryReplayRequestId: 'choice-retry'
+    })
+  })
+
+  it('projects enabled Compute Host authority without replacing newer local state', () => {
+    seedSession()
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().renameSession('session-1', 'Newer local title')
+
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: {
+        ...toPersistedSession(source),
+        enabledComputeHosts: ['ssh:lab'],
+        updatedAt: source.updatedAt + 1
+      },
+      mode: 'enabled-compute-hosts-authority'
+    })
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      title: 'Newer local title',
+      enabledComputeHosts: ['ssh:lab']
     })
   })
 })

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -52,8 +52,6 @@ type SessionStore = SessionStoreData &
     setPermissionProfile: (sessionId: string, profile: PermissionProfileId) => void
     // Persists the per-session auto-review toggle. true = on; false = off (default).
     setAutoReviewEnabled: (sessionId: string, enabled: boolean) => void
-    // Sets the per-session enabled compute hosts (single-select, stored as array for extensibility).
-    setEnabledComputeHosts: (sessionId: string, providerIds: string[]) => void
     // Updates the persisted specialist UUID for an existing session after reconfigure succeeds.
     // Passing undefined clears the binding (Main Agent). Persistence only stores the UUID.
     setSessionSpecialistId: (sessionId: string, specialistId: string | undefined) => void
@@ -189,20 +187,6 @@ const createSessionStoreInitializer = (): StateCreator<SessionStore> => (set, ge
         )
       }
     })
-  },
-
-  setEnabledComputeHosts: (sessionId, providerIds) => {
-    set((state) => ({
-      sessions: state.sessions.map((session) =>
-        session.id === sessionId
-          ? {
-              ...session,
-              enabledComputeHosts: providerIds.length > 0 ? providerIds : undefined,
-              updatedAt: Date.now()
-            }
-          : session
-      )
-    }))
   },
 
   // Updates the persisted specialist UUID for an existing session (called after reconfigure succeeds).

--- a/src/shared/lifecycle-events.ts
+++ b/src/shared/lifecycle-events.ts
@@ -10,6 +10,7 @@ type SessionUpsertEvent = {
 // but it must merge into the live renderer Session instead of replacing in-flight chat state.
 const MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID = 'main:permission-wait'
 const MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID = 'main:durable-continuation'
+const MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID = 'main:enabled-compute-hosts'
 
 type ProjectDeletedEvent = {
   projectId: string
@@ -33,6 +34,7 @@ const LIFECYCLE_CHANNELS = {
 export {
   LIFECYCLE_CHANNELS,
   MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID,
+  MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID,
   MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID
 }
 export type { Project, ProjectDeletedEvent, SessionDeletedEvent, SessionUpsertEvent }


### PR DESCRIPTION
## Problem

Session enabled Compute Hosts had two writers: renderer Session JSON persistence and a main-process runtime registry. Toggle and Session-switch synchronization was best effort, so failed or reordered IPC could fork durable authority from list_compute, while Host and Session deletion did not prune references through one owner.

Related issue: none; this follows the requested P2 architecture assessment and fix.

## Proposed change

- Add a main-owned SessionEnabledComputeHostsOwner that validates intents, serializes Session authority mutations, and projects committed results into the runtime registry.
- Route the existing compute:enabled-hosts:set Electron and application-command paths through that owner, preserving caller lifecycle origin semantics.
- Treat the registry as a derived cache rebuilt from complete Session hydration; partial hydration filters runtime results without destructive durable pruning.
- Prune deleted or deterministically recreated Host ids through the same owner, and clear deleted Session/Project cache entries after authoritative deletion.
- Carry first-Session enabled-host intent through the pending Session save instead of a second renderer-side registry write.
- Preserve enabled-host authority and monotonic updatedAt across stale ordinary Session saves.

```mermaid
flowchart LR
  R[Renderer intent] --> O[Main enabled-hosts owner]
  O --> S[Session JSON authority]
  S --> C[Derived runtime registry]
  H[Host and Session lifecycle] --> O
```

## Scope and non-goals

- Reuses the existing public compute:enabled-hosts:set contract; no new public channel or database schema is introduced.
- Keeps the synchronous registry for list_compute, but removes it as an authority.
- Does not change ACP protocol translation, provider-specific behavior, dependencies, or UI layout.
- Multi-Session Host pruning is serialized and idempotent, not a cross-file filesystem transaction.

## Acceptance criteria and validation

Evidence mapping, run after the last material edit and the final rebase onto origin/main:

- Main authority commit-before-cache ordering, validation, reconciliation, partial-catalog behavior, and Host pruning: session-enabled-hosts-owner tests plus coordinator tests.
- Electron/application-command routing and caller lifecycle origin: compute IPC and application-command tests.
- First-Session intent, stale-save protection, and narrow lifecycle projection: workspace conversation, Session store, and lifecycle sync tests.
- Composition and module boundaries: Compute and Session architecture tests plus runtime/application wiring tests.

Checks:

- npm test -- --maxWorkers=4 --testTimeout=120000: 943 files; 13,365 passed, 193 skipped, 0 failed.
- Focused cross-impact set: 14 files; 613 passed, 0 failed.
- npm run typecheck:node: passed.
- npm run typecheck:web: passed.
- npm run lint: passed with 0 errors and 17 existing warnings outside this diff.
- CodeGraph sync/status: index up to date.
- Independent Standards and Spec review: 0 unresolved findings after follow-up verification.

Uncovered operational risks: lifecycle publication remains best effort after a durable commit; later hydration repairs missed delivery. A multi-Session prune can stop after a partial write failure, but runtime filtering is immediate and retry/startup reconciliation completes the idempotent durable repair. Incomplete Session catalogs never drive destructive pruning.

## Review focus

- Session JSON authority versus derived registry ordering in the new owner.
- Complete versus partial hydration reconciliation.
- Host delete/recreate pruning and failure recovery.
- First-Session intent and stale renderer-save behavior.
