### PR TITLE
fix(database): accept equivalent legacy check constraints

### DIFF
--- a/src/main/database/legacy-baseline-adapter.ts
+++ b/src/main/database/legacy-baseline-adapter.ts
@@ -132,6 +132,38 @@ const splitSqlDefinitions = (ddl: string): string[] => {
 const readQuotedIdentifiers = (value: string): string[] =>
   [...value.matchAll(/"((?:[^"]|"")+)"/g)].map((match) => match[1]!.replaceAll('""', '"'))
 
+const hasRedundantOuterParentheses = (value: string): boolean => {
+  if (value[0] !== '(' || value.at(-1) !== ')') return false
+
+  let depth = 0
+  let quote: '"' | "'" | undefined
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]!
+    if (quote) {
+      if (char !== quote) continue
+      if (value[index + 1] === quote) index += 1
+      else quote = undefined
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+    if (char === '(') depth += 1
+    else if (char === ')') depth -= 1
+
+    if (depth === 0 && index < value.length - 1) return false
+    if (depth < 0) return false
+  }
+  return depth === 0 && quote === undefined
+}
+
+const stripRedundantOuterParentheses = (value: string): string => {
+  let normalized = value
+  while (hasRedundantOuterParentheses(normalized)) normalized = normalized.slice(1, -1).trim()
+  return normalized
+}
+
 const normalizeSqlFragment = (value: string | null): string | null => {
   if (value === null) return null
   const literals: string[] = []
@@ -145,10 +177,55 @@ const normalizeSqlFragment = (value: string | null): string | null => {
     .replaceAll(/\s+/g, ' ')
     .replaceAll(/\s*([(),=<>])\s*/g, '$1')
     .toLowerCase()
+  normalized = stripRedundantOuterParentheses(normalized)
   literals.forEach((literal, index) => {
     normalized = normalized.replace(`__open_science_sql_literal_${index}__`, literal)
   })
   return normalized
+}
+
+type KnownEquivalentCheckExpression = {
+  actual: string
+  expected: string
+}
+
+// Pre-ledger runtime DDL sometimes emitted an equivalent boolean expression in a different order.
+// Pair each accepted legacy form with the exact frozen target so a future contract change still fails
+// closed instead of inheriting this compatibility allowance.
+const KNOWN_EQUIVALENT_CHECK_EXPRESSIONS: ReadonlyMap<
+  string,
+  readonly KnownEquivalentCheckExpression[]
+> = new Map([
+  [
+    'ArtifactVersionInput.ArtifactVersionInput_sourceIdentity_check',
+    [
+      {
+        actual: normalizeSqlFragment(`
+          ("sourceKind" = 'artifact-version' AND "sourceArtifactVersionId" IS NOT NULL AND "sourceUploadVersionId" IS NULL AND "inputFileVersionId" = "sourceArtifactVersionId") OR
+          ("sourceKind" = 'upload-version' AND "sourceUploadVersionId" IS NOT NULL AND "sourceArtifactVersionId" IS NULL AND "inputFileVersionId" = "sourceUploadVersionId")
+        `)!,
+        expected: normalizeSqlFragment(`
+          (("sourceKind" = 'artifact-version' AND "sourceArtifactVersionId" IS NOT NULL AND "sourceUploadVersionId" IS NULL AND "inputFileVersionId" = "sourceArtifactVersionId") OR
+          ("sourceKind" = 'upload-version' AND "sourceArtifactVersionId" IS NULL AND "sourceUploadVersionId" IS NOT NULL AND "inputFileVersionId" = "sourceUploadVersionId"))
+        `)!
+      }
+    ]
+  ]
+])
+
+const checkExpressionsMatch = (
+  tableName: string,
+  constraintName: string,
+  actual: string | undefined,
+  expected: string
+): boolean => {
+  if (actual === expected) return true
+  return Boolean(
+    actual &&
+    KNOWN_EQUIVALENT_CHECK_EXPRESSIONS.get(`${tableName}.${constraintName}`)?.some(
+      (equivalent) => equivalent.actual === actual && equivalent.expected === expected
+    )
+  )
 }
 
 const parseTargetTable = (ddl: string): readonly [string, TargetTable] | undefined => {
@@ -525,7 +602,8 @@ const verifyRuntimeSchemaTarget = async (
     }
     if (
       [...expectedTable.checks.entries()].some(
-        ([name, expression]) => actualTable.checks.get(name) !== expression
+        ([name, expression]) =>
+          !checkExpressionsMatch(tableName, name, actualTable.checks.get(name), expression)
       ) ||
       actualTable.checks.size !== expectedTable.checks.size
     ) {

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -31,6 +31,63 @@ const futureTestMigration = (): MigrationManifestEntry => {
   }
 }
 
+const LEGACY_PERMISSION_GRANT_TABLE_DDL = `CREATE TABLE "PermissionGrant" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "capabilityKind" TEXT NOT NULL,
+    "capabilityKey" TEXT NOT NULL,
+    "qualifierMode" TEXT NOT NULL DEFAULT 'none',
+    "qualifierValue" TEXT,
+    "scopeKind" TEXT NOT NULL,
+    "projectId" TEXT,
+    "sessionId" TEXT,
+    "fingerprint" TEXT NOT NULL,
+    "revision" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" DATETIME,
+    CONSTRAINT "PermissionGrant_capabilityKind_check" CHECK ("capabilityKind" IN ('customize_mutation', 'mcp_tool', 'execution', 'file_operation', 'skill_operation', 'builtin_tool')),
+    CONSTRAINT "PermissionGrant_capabilityKey_check" CHECK (length(trim("capabilityKey")) > 0),
+    CONSTRAINT "PermissionGrant_qualifier_check" CHECK (
+      ("qualifierMode" IN ('none', 'any') AND "qualifierValue" IS NULL) OR
+      ("qualifierMode" IN ('category', 'exact') AND "qualifierValue" IS NOT NULL AND length(trim("qualifierValue")) > 0)
+    ),
+    CONSTRAINT "PermissionGrant_scope_check" CHECK (
+      ("scopeKind" = 'global' AND "projectId" IS NULL AND "sessionId" IS NULL) OR
+      ("scopeKind" = 'project' AND "projectId" IS NOT NULL AND "sessionId" IS NULL) OR
+      ("scopeKind" = 'session' AND "projectId" IS NOT NULL AND "sessionId" IS NOT NULL)
+    ),
+    CONSTRAINT "PermissionGrant_revision_check" CHECK ("revision" >= 1),
+    CONSTRAINT "PermissionGrant_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);`
+
+const LEGACY_ARTIFACT_VERSION_INPUT_TABLE_DDL = `CREATE TABLE "ArtifactVersionInput" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "artifactVersionId" TEXT NOT NULL,
+    "ordinal" INTEGER NOT NULL,
+    "inputFileVersionId" TEXT NOT NULL,
+    "sourceKind" TEXT NOT NULL,
+    "sourceFileId" TEXT NOT NULL,
+    "sourceArtifactVersionId" TEXT,
+    "sourceUploadVersionId" TEXT,
+    "sourceVersionNumber" INTEGER,
+    "sourceCreatedAt" DATETIME,
+    "sourceProjectId" TEXT NOT NULL,
+    "sourceSessionId" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "contentType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "strongestAssociation" TEXT NOT NULL,
+    CONSTRAINT "ArtifactVersionInput_sourceKind_check" CHECK ("sourceKind" IN ('artifact-version', 'upload-version')),
+    CONSTRAINT "ArtifactVersionInput_sourceIdentity_check" CHECK (
+      ("sourceKind" = 'artifact-version' AND "sourceArtifactVersionId" IS NOT NULL AND "sourceUploadVersionId" IS NULL AND "inputFileVersionId" = "sourceArtifactVersionId") OR
+      ("sourceKind" = 'upload-version' AND "sourceUploadVersionId" IS NOT NULL AND "sourceArtifactVersionId" IS NULL AND "inputFileVersionId" = "sourceUploadVersionId")
+    ),
+    CONSTRAINT "ArtifactVersionInput_artifactVersionId_fkey" FOREIGN KEY ("artifactVersionId") REFERENCES "ArtifactVersion" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceArtifactVersionId_fkey" FOREIGN KEY ("sourceArtifactVersionId") REFERENCES "ArtifactVersion" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceUploadVersionId_fkey" FOREIGN KEY ("sourceUploadVersionId") REFERENCES "UploadVersion" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceProjectId_sourceSessionId_fkey" FOREIGN KEY ("sourceProjectId", "sourceSessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE
+);`
+
 describe('application database migrations', () => {
   let storageRoot: string | undefined
   let client: PrismaClient | undefined
@@ -286,6 +343,91 @@ describe('application database migrations', () => {
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
     ).resolves.toMatchObject({ name: 'Preserved', archivedAt: null })
+  })
+
+  it('adopts the pre-ledger permission grant table emitted by v0.9 through v0.10', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-legacy-permissions-'))
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "Project" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "name" TEXT NOT NULL,
+      "description" TEXT NOT NULL DEFAULT '',
+      "isExample" BOOLEAN NOT NULL DEFAULT false,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL
+    )`)
+    await client.$executeRawUnsafe(LEGACY_PERMISSION_GRANT_TABLE_DDL)
+    await client.$executeRaw`
+      INSERT INTO "Project" ("id", "name", "updatedAt")
+      VALUES (${'legacy-project'}, ${'Preserved'}, ${new Date('2026-01-02T03:04:05Z')})
+    `
+    await client.$executeRaw`
+      INSERT INTO "PermissionGrant" (
+        "id", "capabilityKind", "capabilityKey", "scopeKind", "projectId", "fingerprint"
+      ) VALUES (
+        ${'legacy-grant'}, ${'execution'}, ${'exec:agent/shell'}, ${'project'},
+        ${'legacy-project'}, ${'legacy-fingerprint'}
+      )
+    `
+
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
+      adoptedLegacy: true,
+      applied: ['0001_runtime_schema_baseline']
+    })
+    await expect(
+      client.permissionGrant.findUniqueOrThrow({ where: { id: 'legacy-grant' } })
+    ).resolves.toMatchObject({
+      capabilityKind: 'execution',
+      capabilityKey: 'exec:agent/shell',
+      projectId: 'legacy-project'
+    })
+    await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
+  })
+
+  it('rejects a grouped legacy permission constraint with different semantics', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-invalid-permissions-'))
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(
+      LEGACY_PERMISSION_GRANT_TABLE_DDL.replace(
+        '"qualifierValue" IS NULL) OR',
+        '"qualifierValue" IS NOT NULL) OR'
+      )
+    )
+
+    await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
+      code: 'database_validation_failed',
+      migrationId: '0001_runtime_schema_baseline'
+    })
+    await expect(
+      client.$queryRaw<Array<{ name: string }>>`
+        SELECT "name" FROM "sqlite_schema"
+        WHERE "name" = '_open_science_migrations'
+      `
+    ).resolves.toEqual([])
+  })
+
+  it('adopts the legacy artifact input identity check with equivalent conjunct order', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-legacy-input-check-'))
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(LEGACY_ARTIFACT_VERSION_INPUT_TABLE_DDL)
+
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
+      adoptedLegacy: true,
+      applied: ['0001_runtime_schema_baseline']
+    })
+    await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
+    await expect(
+      client.$queryRaw<Array<{ sql: string }>>`
+        SELECT "sql" FROM "sqlite_schema"
+        WHERE "type" = 'table' AND "name" = 'ArtifactVersionInput'
+      `
+    ).resolves.toEqual([
+      {
+        sql: expect.stringContaining(
+          '"sourceUploadVersionId" IS NOT NULL AND "sourceArtifactVersionId" IS NULL'
+        )
+      }
+    ])
   })
 
   it('adopts the pre-ledger permission seed table from the final baseline', async () => {


### PR DESCRIPTION
## Problem

Databases initialized by v0.9 through v0.10 contain semantically equivalent SQLite `CHECK` constraints whose SQL text differs from the frozen `0001_runtime_schema_baseline` target:

- `PermissionGrant` uses fewer redundant outer parentheses.
- `ArtifactVersionInput_sourceIdentity_check` orders two `AND` conjuncts differently.

The baseline verifier compared normalized SQL text literally, so these valid pre-ledger databases failed startup with `database_validation_failed` even when their stored rows satisfied the required contract.

## Proposed change

- Strip only balanced parentheses that wrap an entire normalized SQL expression.
- Admit the exact known legacy-to-frozen expression pair for `ArtifactVersionInput_sourceIdentity_check`.
- Require both the legacy expression and the expected frozen expression to match the compatibility pair, preserving fail-closed behavior if the target contract changes later.
- Add migration regression coverage for legacy permission grants, legacy artifact input constraints, row preservation, and rejection of a genuinely different constraint.

## Scope and non-goals

- Does not change the Prisma schema, generated runtime schema, frozen migration SQL, migration checksum, or verifier contract.
- Does not rebuild `PermissionGrant` or rewrite permission rows.
- Does not generally reorder or simplify boolean SQL expressions.
- Does not weaken validation for unknown or semantically different constraints.

## Acceptance criteria and validation

The repository impact tool selected the full fallback because `src/main/database/legacy-baseline-adapter.ts` currently has no known module owner:

- Impact selection -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> full fallback selected.
- Legacy adoption and fail-closed regression behavior -> `npm test -- --maxWorkers=4` -> 927 files passed, 15 skipped; 13,343 tests passed, 204 skipped.
- Node and renderer type safety -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors; 17 existing warnings are outside this diff.

These final checks ran after the last material edit. The default Vitest worker count initially caused three unrelated 15-second timeouts; all three passed when rerun directly, and the complete suite passed with `--maxWorkers=4`.

Exact-head CI remains authoritative for platform lanes. Independent review is still pending, so this PR does not claim final verification yet.

## Review focus

- Confirm the outer-parenthesis scanner handles quoted SQL safely and removes only a wrapper spanning the complete expression.
- Confirm the `ArtifactVersionInput` compatibility entry is narrow enough to reject future contract changes and true semantic drift.
- Confirm the regression fixtures accurately reproduce the pre-ledger v0.9-v0.10 DDL.
