### PR TITLE
feat(host): add project-scoped frame reads

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -976,7 +976,15 @@ async function hostMcp(server, method, args = undefined, kwargs = undefined) {
   return body.result
 }
 
-const HOST_CAPABILITY_NAMES = ['mcp', 'compute', 'agents', 'skills', 'artifacts', 'lineage']
+const HOST_CAPABILITY_NAMES = [
+  'mcp',
+  'compute',
+  'agents',
+  'skills',
+  'artifacts',
+  'lineage',
+  'frames'
+]
 
 async function hostCapabilities(...args) {
   if (args.length !== 0) throw new TypeError('host.capabilities accepts no arguments')
@@ -1119,6 +1127,219 @@ async function lineageRpc(op, params) {
   const body = await res.json().catch(() => ({}))
   if (!res.ok || body.error) {
     throw new Error(`host.lineage.${op}: ${body.error || 'HTTP ' + res.status}`)
+  }
+  return body.result
+}
+
+const exactObject = (value, requiredKeys, optionalKeys = []) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const keys = Object.keys(value)
+  return (
+    requiredKeys.every((key) => keys.includes(key)) &&
+    keys.every((key) => requiredKeys.includes(key) || optionalKeys.includes(key))
+  )
+}
+
+const hostFrameString = (value) => typeof value === 'string'
+const hostFrameCount = (value) => Number.isSafeInteger(value) && value >= 0
+const hostFrameOptionalString = (value) => value === undefined || hostFrameString(value)
+const frozenProjection = (value, keys) =>
+  Object.freeze(
+    Object.fromEntries(
+      keys.filter((key) => value[key] !== undefined).map((key) => [key, value[key]])
+    )
+  )
+
+const HOST_FRAME_REQUIRED_KEYS = [
+  'frame_id',
+  'session_id',
+  'session_title',
+  'kind',
+  'recorded_frame_status',
+  'session_status',
+  'created_at',
+  'session_updated_at',
+  'message_count',
+  'child_count'
+]
+const HOST_FRAME_OPTIONAL_KEYS = [
+  'parent_frame_id',
+  'origin_message_id',
+  'agent_name',
+  'delegate_name',
+  'linked_review_id',
+  'completed_at',
+  'archived_at'
+]
+const HOST_FRAME_KINDS = ['root', 'reviewer', 'delegate', 'compatibility']
+const HOST_FRAME_STATUSES = ['running', 'completed', 'cancelled', 'error']
+const HOST_SESSION_STATUSES = [
+  'idle',
+  'running',
+  'waiting-for-user',
+  'waiting-permission',
+  'waiting-plan-approval',
+  'error'
+]
+
+const validatedHostFrame = (value) => {
+  if (
+    !exactObject(value, HOST_FRAME_REQUIRED_KEYS, HOST_FRAME_OPTIONAL_KEYS) ||
+    !hostFrameString(value.frame_id) ||
+    !hostFrameString(value.session_id) ||
+    !hostFrameString(value.session_title) ||
+    !HOST_FRAME_KINDS.includes(value.kind) ||
+    !HOST_FRAME_STATUSES.includes(value.recorded_frame_status) ||
+    !HOST_SESSION_STATUSES.includes(value.session_status) ||
+    !hostFrameString(value.created_at) ||
+    !hostFrameString(value.session_updated_at) ||
+    !hostFrameCount(value.message_count) ||
+    !hostFrameCount(value.child_count) ||
+    HOST_FRAME_OPTIONAL_KEYS.some((key) => !hostFrameOptionalString(value[key]))
+  ) {
+    throw new Error('host.frames returned an invalid Frame')
+  }
+  return frozenProjection(value, [...HOST_FRAME_REQUIRED_KEYS, ...HOST_FRAME_OPTIONAL_KEYS])
+}
+
+const validatedHostFrameSession = (value) => {
+  const required = ['session_id', 'session_title', 'session_status', 'created_at', 'updated_at']
+  const optional = ['archived_at']
+  if (
+    !exactObject(value, required, optional) ||
+    !hostFrameString(value.session_id) ||
+    !hostFrameString(value.session_title) ||
+    !HOST_SESSION_STATUSES.includes(value.session_status) ||
+    !hostFrameString(value.created_at) ||
+    !hostFrameString(value.updated_at) ||
+    !hostFrameOptionalString(value.archived_at)
+  ) {
+    throw new Error('host.frames.get returned an invalid Session')
+  }
+  return frozenProjection(value, [...required, ...optional])
+}
+
+const validatedHostFrameBranch = (value) => {
+  const keys = ['branch_id', 'created_at', 'updated_at']
+  if (!exactObject(value, keys) || keys.some((key) => !hostFrameString(value[key]))) {
+    throw new Error('host.frames.get returned an invalid Branch')
+  }
+  return frozenProjection(value, keys)
+}
+
+const validatedHostFrameTurnUsage = (value) => {
+  const required = ['input_tokens', 'cache_tokens', 'output_tokens']
+  const optional = ['cached_read_tokens', 'cached_write_tokens', 'turn_count']
+  if (
+    !exactObject(value, required, optional) ||
+    [...required, ...optional].some(
+      (key) => value[key] !== undefined && !hostFrameCount(value[key])
+    )
+  ) {
+    throw new Error('host.frames.get returned invalid turn usage')
+  }
+  return frozenProjection(value, [...required, ...optional])
+}
+
+const validatedHostFrameAttachment = (value) => {
+  const required = ['kind', 'attachment_id']
+  const optional = ['version_id', 'name', 'mime_type', 'size_bytes']
+  if (
+    !exactObject(value, required, optional) ||
+    !['upload', 'artifact', 'image'].includes(value.kind) ||
+    !hostFrameString(value.attachment_id) ||
+    ['version_id', 'name', 'mime_type'].some((key) => !hostFrameOptionalString(value[key])) ||
+    (value.size_bytes !== undefined && !hostFrameCount(value.size_bytes))
+  ) {
+    throw new Error('host.frames.get returned an invalid attachment')
+  }
+  return frozenProjection(value, [...required, ...optional])
+}
+
+const validatedHostFrameMessage = (value) => {
+  const required = ['message_id', 'role', 'content', 'status', 'created_at', 'updated_at']
+  const optional = [
+    'response_to_message_id',
+    'runtime_segment_id',
+    'completed_at',
+    'failed_at',
+    'turn_usage',
+    'attachments'
+  ]
+  if (
+    !exactObject(value, required, optional) ||
+    !hostFrameString(value.message_id) ||
+    !['user', 'agent'].includes(value.role) ||
+    !hostFrameString(value.content) ||
+    !['complete', 'streaming', 'error'].includes(value.status) ||
+    !hostFrameString(value.created_at) ||
+    !hostFrameString(value.updated_at) ||
+    ['response_to_message_id', 'runtime_segment_id', 'completed_at', 'failed_at'].some(
+      (key) => !hostFrameOptionalString(value[key])
+    ) ||
+    (value.turn_usage !== undefined &&
+      (!value.turn_usage ||
+        typeof value.turn_usage !== 'object' ||
+        Array.isArray(value.turn_usage))) ||
+    (value.attachments !== undefined && !Array.isArray(value.attachments))
+  ) {
+    throw new Error('host.frames.get returned an invalid Message')
+  }
+  return Object.freeze({
+    ...frozenProjection(
+      value,
+      [...required, ...optional].filter((key) => !['turn_usage', 'attachments'].includes(key))
+    ),
+    ...(value.turn_usage ? { turn_usage: validatedHostFrameTurnUsage(value.turn_usage) } : {}),
+    ...(value.attachments
+      ? { attachments: Object.freeze(value.attachments.map(validatedHostFrameAttachment)) }
+      : {})
+  })
+}
+
+const validatedHostFrameTranscript = (value) => {
+  const required = ['messages', 'has_more_before']
+  const optional = ['previous_cursor']
+  if (
+    !exactObject(value, required, optional) ||
+    !Array.isArray(value.messages) ||
+    typeof value.has_more_before !== 'boolean' ||
+    !hostFrameOptionalString(value.previous_cursor) ||
+    value.has_more_before !== (value.previous_cursor !== undefined)
+  ) {
+    throw new Error('host.frames.get returned an invalid transcript')
+  }
+  return Object.freeze({
+    messages: Object.freeze(value.messages.map(validatedHostFrameMessage)),
+    ...(value.previous_cursor !== undefined ? { previous_cursor: value.previous_cursor } : {}),
+    has_more_before: value.has_more_before
+  })
+}
+
+const validatedHostRuntimeSegment = (value) => {
+  const required = ['runtime_segment_id', 'started_at']
+  const optional = ['agent_name', 'ended_at']
+  if (
+    !exactObject(value, required, optional) ||
+    !hostFrameString(value.runtime_segment_id) ||
+    !hostFrameString(value.started_at) ||
+    optional.some((key) => !hostFrameOptionalString(value[key]))
+  ) {
+    throw new Error('host.frames.get returned an invalid runtime segment')
+  }
+  return frozenProjection(value, [...required, ...optional])
+}
+
+async function framesRpc(op, params) {
+  if (!RPC_ENDPOINT) throw new Error(`host.frames.${op} is unavailable: RPC endpoint not set`)
+  const res = await capturedRpcFetch(RPC_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
+    body: JSON.stringify({ method: 'framesCall', params: { op, ...params } })
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok || body.error) {
+    throw new Error(`host.frames.${op}: ${body.error || 'HTTP ' + res.status}`)
   }
   return body.result
 }
@@ -1793,6 +2014,60 @@ async function hostLineageGet(versionId) {
 
 const hostLineage = Object.freeze({ graph: hostLineageGraph, get: hostLineageGet })
 
+async function hostFramesList(options = {}) {
+  if (arguments.length > 1)
+    throw new TypeError('host.frames.list accepts at most one options object')
+  const result = await framesRpc('list', { options })
+  const required = ['project_id', 'frames', 'total_count']
+  const optional = ['next_cursor']
+  if (
+    !exactObject(result, required, optional) ||
+    !hostFrameString(result.project_id) ||
+    !Array.isArray(result.frames) ||
+    !hostFrameCount(result.total_count) ||
+    result.total_count < result.frames.length ||
+    !hostFrameOptionalString(result.next_cursor)
+  ) {
+    throw new Error('host.frames.list returned an invalid result')
+  }
+  return Object.freeze({
+    project_id: result.project_id,
+    frames: Object.freeze(result.frames.map(validatedHostFrame)),
+    total_count: result.total_count,
+    ...(result.next_cursor !== undefined ? { next_cursor: result.next_cursor } : {})
+  })
+}
+
+async function hostFramesGet(frameId, options = {}) {
+  if (arguments.length < 1 || arguments.length > 2) {
+    throw new TypeError('host.frames.get accepts frame_id and at most one options object')
+  }
+  const result = await framesRpc('get', { frame_id: frameId, options })
+  const keys = ['project_id', 'session', 'frame', 'branch', 'transcript', 'runtime_segments']
+  if (
+    !exactObject(result, keys) ||
+    !hostFrameString(result.project_id) ||
+    !Array.isArray(result.runtime_segments)
+  ) {
+    throw new Error('host.frames.get returned an invalid result')
+  }
+  const session = validatedHostFrameSession(result.session)
+  const frame = validatedHostFrame(result.frame)
+  if (frame.frame_id !== frameId || frame.session_id !== session.session_id) {
+    throw new Error('host.frames.get returned an invalid result')
+  }
+  return Object.freeze({
+    project_id: result.project_id,
+    session,
+    frame,
+    branch: validatedHostFrameBranch(result.branch),
+    transcript: validatedHostFrameTranscript(result.transcript),
+    runtime_segments: Object.freeze(result.runtime_segments.map(validatedHostRuntimeSegment))
+  })
+}
+
+const hostFrames = Object.freeze({ list: hostFramesList, get: hostFramesGet })
+
 // host.compute: async remote-compute calls over the SAME app-local RPC endpoint as host.mcp, routed to
 // the main-process ComputeService via {method:'computeCall'}. Like host.mcp, this is only injected in
 // the trusted control plane — the python/r data kernels have no host.compute, so SSH/approval always
@@ -2094,6 +2369,7 @@ const sandbox = {
     artifacts: hostArtifacts,
     artifact_path: hostArtifactPath,
     lineage: hostLineage,
+    frames: hostFrames,
     mcp: hostMcp,
     compute: hostCompute,
     agents: hostAgents,

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-awareness
-description: Inspect Open Science's JavaScript control REPL, discover managed Project files, and safely feature-gate host.* calls with host.capabilities(). Use when an Agent needs to discover available host APIs or locate an Artifact or Upload Version in the current Project.
+description: Inspect Open Science's JavaScript control REPL, discover managed Project files and Agent Frames, and safely feature-gate host.* calls with host.capabilities(). Use when an Agent needs to discover available host APIs, locate an Artifact or Upload Version, or read a Frame transcript in the current Project.
 ---
 
 # Self-awareness
@@ -14,7 +14,7 @@ JavaScript control REPL; Python and R data kernels do not receive it.
 const caps = await host.capabilities()
 ```
 
-The v1 result contains exactly six boolean keys:
+The v1 result contains exactly seven boolean keys:
 
 - `mcp` gates `host.mcp` connector calls.
 - `compute` gates the `host.compute` namespace.
@@ -22,6 +22,7 @@ The v1 result contains exactly six boolean keys:
 - `skills` gates the `host.skills` namespace.
 - `artifacts` gates `host.artifacts` and `host.artifact_path`.
 - `lineage` gates the read-only `host.lineage` namespace.
+- `frames` gates the read-only `host.frames` namespace.
 
 Interpret the result narrowly:
 
@@ -95,6 +96,27 @@ Session scope fields, create extraction work, or return content, messages, full 
 reviews, paths, storage keys, Bearer tokens, or internal routes. Missing or ambiguous identities,
 cross-Project edges, and corrupt evidence fail closed. There is no indexed property, `clear()`,
 client cache, Python/R `host`, or lineage API outside the JavaScript control REPL.
+
+## Discover Agent Frames
+
+When `caps.frames === true`, use `await host.frames.list(options)` for a metadata-only catalog across
+Sessions in the token-owned current Project. It never searches message bodies. Optional snake_case
+fields are `search`, `session_id`, `roots_only` (default `true`), `kind`, `archived`
+(`exclude`/`include`/`only`, default `exclude`), `after`, `before`, `cursor`, and `limit` (default 20,
+maximum 100). Metadata search fuzzily matches Session title, `agent_name`, and `delegate_name`.
+
+Use `await host.frames.get(frameId, options)` with an exact full Frame ID to read one visible
+conversation path. `session_id` may narrow or disambiguate within the current Project. `branch_id`
+selects a specific Branch; without it, the Frame's active Branch is used. The latest 40 messages are
+returned chronologically by default, with a maximum of 100. Pass `before` with the returned
+`previous_cursor` to page backward through older messages.
+
+The result contains frozen Project, Session, Frame, Branch, visible transcript, and sanitized runtime
+segment projections. Messages follow the selected Branch graph rather than stored array order. The
+response never returns private reasoning, tool activities and raw inputs/outputs, terminal output,
+image bytes, local paths, storage and provider identifiers, internal event/stream identifiers, cost,
+or synthesized summaries. Missing, ambiguous, wrong-Session, invalid-Branch, and stale-cursor reads fail
+explicitly without enabling cross-Project discovery.
 
 ## Continue with the owning Skill
 

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -649,7 +649,8 @@ describe('ACP session capability owner', () => {
       'notebook',
       'skill-import',
       'host-agents',
-      'host-skills'
+      'host-skills',
+      'host-frames'
     ])
     expect(primary.descriptor.modelFacingMcpServerNames).toEqual([
       'open_science_artifacts',
@@ -667,7 +668,8 @@ describe('ACP session capability owner', () => {
       'mcpCall',
       'computeCall',
       'agentsCall',
-      'skillsCall'
+      'skillsCall',
+      'framesCall'
     ])
     expect(reviewer.mcpServers).toEqual([])
     expect(reviewer.descriptor.capabilities).toEqual([])
@@ -685,7 +687,7 @@ describe('ACP session capability owner', () => {
     ['codex-response', codexFramework, true, false],
     ['codex-bridge', codexFramework, false, true]
   ] as const)(
-    'publishes host capability and lineage reads through the %s primary control descriptor',
+    'publishes Host Lineage and Frames through the %s primary control descriptor',
     async (_route, framework, nativeMcpEnabled, bridgeMcpAliasesEnabled) => {
       const owner = createOwner()
       const built = await owner.provision({
@@ -700,6 +702,8 @@ describe('ACP session capability owner', () => {
 
       expect(built.descriptor.controlRpcMethods).toContain('capabilitiesCall')
       expect(built.descriptor.controlRpcMethods).toContain('lineageCall')
+      expect(built.descriptor.controlRpcMethods).toContain('framesCall')
+      expect(built.descriptor.capabilities).toContain('host-frames')
     }
   )
 

--- a/src/main/acp/session-capability-owner.ts
+++ b/src/main/acp/session-capability-owner.ts
@@ -42,6 +42,7 @@ const CURRENT_PRIMARY_CAPABILITIES = [
   'plan',
   'host-agents',
   'host-skills',
+  'host-frames',
   'host-message'
 ] as const
 const NOTEBOOK_CONTROL_RPC_METHODS = [
@@ -50,7 +51,8 @@ const NOTEBOOK_CONTROL_RPC_METHODS = [
   'mcpCall',
   'computeCall',
   'agentsCall',
-  'skillsCall'
+  'skillsCall',
+  'framesCall'
 ] as const
 
 export type SessionCapabilityName = (typeof CURRENT_PRIMARY_CAPABILITIES)[number]
@@ -507,6 +509,12 @@ export class AcpSessionCapabilityOwner {
     ) {
       capabilities.push('host-skills')
     }
+    if (
+      capabilities.includes('notebook') &&
+      policyAllowsSessionCapability(request.policy, 'host-frames')
+    ) {
+      capabilities.push('host-frames')
+    }
 
     const descriptor = freezeDescriptor({
       role: request.policy.role,
@@ -516,7 +524,9 @@ export class AcpSessionCapabilityOwner {
       canonicalMcpServerNames,
       modelFacingMcpServerNames,
       controlRpcMethods:
-        capabilities.includes('host-agents') || capabilities.includes('host-skills')
+        capabilities.includes('host-agents') ||
+        capabilities.includes('host-skills') ||
+        capabilities.includes('host-frames')
           ? [...NOTEBOOK_CONTROL_RPC_METHODS]
           : []
     })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -123,6 +123,7 @@ import { createRuntimeSelectionWorkflows } from './notebook/runtime-selection-wo
 import { runtimeRoot } from './notebook/runtime-paths'
 import { HostArtifactsService } from './notebook/host-artifacts-service'
 import { HostLineageService } from './notebook/host-lineage-service'
+import { HostFramesService } from './notebook/host-frames-service'
 import type { NotebookEnvironmentManager } from './notebook/runtime-service'
 import { parseArtifactVersionLocator } from '../shared/artifact-provenance'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../shared/artifacts'
@@ -1286,6 +1287,14 @@ const createApplicationModules = async (
       hostLineage: new HostLineageService({
         catalog: projectFilesRepository,
         provenance: artifactProvenanceRepository
+      }),
+      hostFrames: new HostFramesService({
+        readProject: (projectId) =>
+          sessionRepository.loadProjectWithDiagnostics(projectId, { mode: 'read-only' }),
+        readSession: (projectId, sessionId) =>
+          sessionRepository.loadSessionWithDiagnostics(projectId, sessionId, {
+            mode: 'read-only'
+          })
       }),
       inputRegistry: notebookInputRegistry,
       agentsService,

--- a/src/main/notebook/host-frames-service.test.ts
+++ b/src/main/notebook/host-frames-service.test.ts
@@ -662,6 +662,8 @@ describe('HostFramesService', () => {
       { kind: 'unknown' },
       { archived: 'yes' },
       { after: '2026-02-30' },
+      { after: '2026-02-30T00:00:00Z' },
+      { before: '2025-02-29T12:00:00+08:00' },
       { after: '2026-08-03', before: '2026-08-03' },
       { after: '2026-08-03T10:00:00' },
       { limit: 0 },

--- a/src/main/notebook/host-frames-service.test.ts
+++ b/src/main/notebook/host-frames-service.test.ts
@@ -1,0 +1,688 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createLinearConversationGraph } from '../../shared/conversation-graph'
+import type { PersistedChatMessage, PersistedChatSession } from '../../shared/session-persistence'
+import { HostFramesService, type HostFramesRepository } from './host-frames-service'
+
+const message = (
+  id: string,
+  role: PersistedChatMessage['role'],
+  createdAt: number
+): PersistedChatMessage => ({
+  id,
+  role,
+  content: `${role} ${id}`,
+  status: 'complete',
+  eventIds: [],
+  createdAt,
+  updatedAt: createdAt
+})
+
+const session = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => {
+  const id = overrides.id ?? 'session-1'
+  const messages = overrides.messages ?? [message('message-1', 'user', 100)]
+  const base: PersistedChatSession = {
+    id,
+    projectId: 'project-a',
+    title: 'Literature review',
+    cwd: '/private/workspace',
+    status: 'idle',
+    messages,
+    conversationGraph: createLinearConversationGraph({
+      sessionId: id,
+      messages,
+      frameworkId: 'claude-code',
+      createdAt: 100,
+      updatedAt: 200
+    }),
+    createdAt: 100,
+    updatedAt: 200
+  }
+  return { ...base, ...overrides }
+}
+
+const context = { projectId: 'project-a', sessionId: 'calling-session' }
+
+const renameRootFrame = (target: PersistedChatSession, frameId: string): void => {
+  const graph = target.conversationGraph!
+  graph.rootFrameId = frameId
+  graph.activeFrameId = frameId
+  graph.frames[0].id = frameId
+  for (const branch of graph.branches) branch.agentFrameId = frameId
+  for (const item of graph.messages) item.agentFrameId = frameId
+  for (const segment of graph.runtimeSegments) segment.agentFrameId = frameId
+}
+
+describe('HostFramesService', () => {
+  it('lists the current Project root Frame through the stable metadata projection', async () => {
+    const readProject = vi.fn(async () => ({ sessions: [session()], isComplete: true }))
+    const repository: HostFramesRepository = {
+      readProject,
+      readSession: vi.fn()
+    }
+    const service = new HostFramesService(repository)
+
+    await expect(service.list({}, context)).resolves.toEqual({
+      project_id: 'project-a',
+      total_count: 1,
+      frames: [
+        {
+          frame_id: 'root-frame-session-1',
+          session_id: 'session-1',
+          session_title: 'Literature review',
+          kind: 'root',
+          recorded_frame_status: 'completed',
+          session_status: 'idle',
+          created_at: new Date(100).toISOString(),
+          completed_at: new Date(200).toISOString(),
+          session_updated_at: new Date(200).toISOString(),
+          message_count: 1,
+          child_count: 0
+        }
+      ]
+    })
+    expect(readProject).toHaveBeenCalledWith('project-a')
+  })
+
+  it('excludes archived Sessions by default and orders eligible roots newest-first', async () => {
+    const older = session({ id: 'older', title: 'Older', createdAt: 100, updatedAt: 200 })
+    const newer = session({ id: 'newer', title: 'Newer', createdAt: 300, updatedAt: 400 })
+    const archived = session({
+      id: 'archived',
+      title: 'Archived',
+      archivedAt: 500,
+      createdAt: 500,
+      updatedAt: 600
+    })
+    older.conversationGraph!.frames[0].createdAt = 100
+    newer.conversationGraph!.frames[0].createdAt = 300
+    archived.conversationGraph!.frames[0].createdAt = 500
+    const service = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: [older, archived, newer], isComplete: true })),
+      readSession: vi.fn()
+    })
+
+    const result = (await service.list({}, context)) as { frames: Array<{ frame_id: string }> }
+
+    expect(result.frames.map((frame) => frame.frame_id)).toEqual([
+      'root-frame-newer',
+      'root-frame-older'
+    ])
+    await expect(service.list({ archived: 'only' }, context)).resolves.toMatchObject({
+      total_count: 1,
+      frames: [expect.objectContaining({ frame_id: 'root-frame-archived' })]
+    })
+    await expect(service.list({ archived: 'include' }, context)).resolves.toMatchObject({
+      total_count: 3
+    })
+  })
+
+  it('breaks equal-timestamp catalog ties with locale-independent identity ordering', async () => {
+    const lower = session({ id: 'session-a' })
+    const upper = session({ id: 'session-Z' })
+    lower.conversationGraph!.frames[0].createdAt = 100
+    upper.conversationGraph!.frames[0].createdAt = 100
+    const service = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: [lower, upper], isComplete: true })),
+      readSession: vi.fn()
+    })
+
+    const result = (await service.list({}, context)) as { frames: Array<{ frame_id: string }> }
+
+    expect(result.frames.map((frame) => frame.frame_id)).toEqual([
+      'root-frame-session-Z',
+      'root-frame-session-a'
+    ])
+  })
+
+  it('narrows to one Session and filters Frame metadata without searching message bodies', async () => {
+    const target = session({ title: 'Clinical genomics' })
+    const graph = target.conversationGraph!
+    graph.frames.push({
+      id: 'delegate-frame-exact',
+      parentFrameId: graph.rootFrameId,
+      originMessageId: 'message-1',
+      originBindingState: 'validated',
+      kind: 'delegate',
+      agentName: 'Research Agent',
+      delegateName: 'Meta Analyst',
+      status: 'running',
+      activeBranchId: 'delegate-branch',
+      createdAt: 300
+    })
+    graph.branches.push({
+      id: 'delegate-branch',
+      agentFrameId: 'delegate-frame-exact',
+      headMessageId: 'delegate-message',
+      createdAt: 300,
+      updatedAt: 300
+    })
+    graph.messages.push({
+      ...message('delegate-message', 'agent', 300),
+      content: 'This body must never participate in catalog search: secretneedle',
+      agentFrameId: 'delegate-frame-exact',
+      introducedOnBranchId: 'delegate-branch'
+    })
+    const readSession = vi.fn(async () => ({ status: 'found' as const, session: target }))
+    const readProject = vi.fn(async () => ({ sessions: [target], isComplete: true }))
+    const service = new HostFramesService({ readProject, readSession })
+
+    const result = (await service.list(
+      {
+        session_id: 'session-1',
+        roots_only: false,
+        kind: 'delegate',
+        archived: 'include',
+        search: 'mta',
+        after: '1970-01-01T00:00:00.200Z',
+        before: '1970-01-01T00:00:00.400Z'
+      },
+      context
+    )) as { frames: Array<{ frame_id: string }> }
+
+    expect(result.frames.map((frame) => frame.frame_id)).toEqual(['delegate-frame-exact'])
+    expect(readSession).toHaveBeenCalledWith('project-a', 'session-1')
+    expect(readProject).not.toHaveBeenCalled()
+    await expect(
+      service.list({ roots_only: false, search: 'secretneedle' }, context)
+    ).resolves.toMatchObject({ total_count: 0 })
+  })
+
+  it('paginates a stable catalog with opaque filter-bound cursors and rejects stale snapshots', async () => {
+    const sessions = ['one', 'two', 'three'].map((id, index) => {
+      const item = session({ id, title: id, updatedAt: 300 - index * 100 })
+      item.conversationGraph!.frames[0].createdAt = 300 - index * 100
+      return item
+    })
+    const service = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions, isComplete: true })),
+      readSession: vi.fn()
+    })
+
+    const first = (await service.list({ limit: 2 }, context)) as {
+      total_count: number
+      next_cursor?: string
+      frames: Array<{ frame_id: string }>
+    }
+    expect(first).toMatchObject({ total_count: 3 })
+    expect(first.frames.map((frame) => frame.frame_id)).toEqual([
+      'root-frame-one',
+      'root-frame-two'
+    ])
+    expect(first.next_cursor).toEqual(expect.any(String))
+
+    await expect(service.list({ limit: 2, cursor: first.next_cursor }, context)).resolves.toEqual({
+      project_id: 'project-a',
+      total_count: 3,
+      frames: [expect.objectContaining({ frame_id: 'root-frame-three' })]
+    })
+    await expect(
+      service.list({ roots_only: false, limit: 2, cursor: first.next_cursor }, context)
+    ).rejects.toThrow('cursor does not match')
+
+    sessions[2].updatedAt += 1
+    await expect(service.list({ limit: 2, cursor: first.next_cursor }, context)).rejects.toThrow(
+      'cursor is no longer valid'
+    )
+  })
+
+  it('uses the catalog and transcript default page limits', async () => {
+    const catalogSessions = Array.from({ length: 21 }, (_, index) => {
+      const item = session({ id: `catalog-${index}` })
+      item.conversationGraph!.frames[0].createdAt = index
+      return item
+    })
+    const catalog = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: catalogSessions, isComplete: true })),
+      readSession: vi.fn()
+    })
+    const catalogPage = (await catalog.list({}, context)) as {
+      total_count: number
+      next_cursor?: string
+      frames: unknown[]
+    }
+    expect(catalogPage).toMatchObject({
+      total_count: 21,
+      next_cursor: expect.any(String)
+    })
+    expect(catalogPage.frames).toHaveLength(20)
+
+    const transcriptSession = session({
+      messages: Array.from({ length: 45 }, (_, index) =>
+        message(`message-${index + 1}`, index % 2 ? 'agent' : 'user', index + 1)
+      )
+    })
+    const transcript = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: [transcriptSession], isComplete: true })),
+      readSession: vi.fn()
+    })
+    const result = (await transcript.get(
+      transcriptSession.conversationGraph!.rootFrameId,
+      {},
+      context
+    )) as { transcript: { messages: Array<{ message_id: string }>; previous_cursor?: string } }
+    expect(result.transcript.messages).toHaveLength(40)
+    expect(result.transcript.messages[0].message_id).toBe('message-6')
+    expect(result.transcript.previous_cursor).toEqual(expect.any(String))
+  })
+
+  it('gets an exact Frame on its active Branch with a chronological sanitized transcript', async () => {
+    const messages = [
+      {
+        ...message('prompt', 'user', 100),
+        content: '<think>private user note</think>user prompt'
+      },
+      {
+        ...message('response', 'agent', 200),
+        content: '<think>private chain of thought</think>Visible answer',
+        responseToMessageId: 'prompt',
+        completedAt: 210,
+        turnUsage: { inputTokens: 10, cacheTokens: 2, outputTokens: 5, turnCount: 1 }
+      }
+    ]
+    const target = session({ messages, updatedAt: 220 })
+    const service = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: [target], isComplete: true })),
+      readSession: vi.fn()
+    })
+
+    await expect(service.get('root-frame-session-1', {}, context)).resolves.toEqual({
+      project_id: 'project-a',
+      session: {
+        session_id: 'session-1',
+        session_title: 'Literature review',
+        session_status: 'idle',
+        created_at: new Date(100).toISOString(),
+        updated_at: new Date(220).toISOString()
+      },
+      frame: {
+        frame_id: 'root-frame-session-1',
+        session_id: 'session-1',
+        session_title: 'Literature review',
+        kind: 'root',
+        recorded_frame_status: 'completed',
+        session_status: 'idle',
+        created_at: new Date(100).toISOString(),
+        completed_at: new Date(200).toISOString(),
+        session_updated_at: new Date(220).toISOString(),
+        message_count: 2,
+        child_count: 0
+      },
+      branch: {
+        branch_id: 'message-branch-session-1',
+        created_at: new Date(100).toISOString(),
+        updated_at: new Date(200).toISOString()
+      },
+      transcript: {
+        messages: [
+          {
+            message_id: 'prompt',
+            role: 'user',
+            content: 'user prompt',
+            status: 'complete',
+            runtime_segment_id: 'runtime-segment-session-1',
+            created_at: new Date(100).toISOString(),
+            updated_at: new Date(100).toISOString()
+          },
+          {
+            message_id: 'response',
+            role: 'agent',
+            content: 'Visible answer',
+            status: 'complete',
+            response_to_message_id: 'prompt',
+            runtime_segment_id: 'runtime-segment-session-1',
+            created_at: new Date(200).toISOString(),
+            updated_at: new Date(200).toISOString(),
+            completed_at: new Date(210).toISOString(),
+            turn_usage: {
+              input_tokens: 10,
+              cache_tokens: 2,
+              output_tokens: 5,
+              turn_count: 1
+            }
+          }
+        ],
+        has_more_before: false
+      },
+      runtime_segments: [
+        {
+          runtime_segment_id: 'runtime-segment-session-1',
+          started_at: new Date(100).toISOString()
+        }
+      ]
+    })
+  })
+
+  it('resolves an explicitly selected non-active Branch by parent links instead of array order', async () => {
+    const target = session({
+      messages: [message('shared-prompt', 'user', 100), message('active-response', 'agent', 200)]
+    })
+    const graph = target.conversationGraph!
+    graph.branches.push({
+      id: 'alternative-branch',
+      agentFrameId: graph.rootFrameId,
+      headMessageId: 'alternative-response',
+      createdAt: 150,
+      updatedAt: 250
+    })
+    graph.messages.unshift({
+      ...message('array-order-decoy', 'agent', 240),
+      agentFrameId: graph.rootFrameId,
+      introducedOnBranchId: 'alternative-branch'
+    })
+    graph.messages.push({
+      ...message('alternative-response', 'agent', 250),
+      agentFrameId: graph.rootFrameId,
+      introducedOnBranchId: 'alternative-branch',
+      parentMessageId: 'shared-prompt',
+      runtimeSegmentId: graph.runtimeSegments[0].id
+    })
+    const service = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: [target], isComplete: true })),
+      readSession: vi.fn()
+    })
+
+    const result = (await service.get(
+      graph.rootFrameId,
+      { branch_id: 'alternative-branch' },
+      context
+    )) as { transcript: { messages: Array<{ message_id: string }> } }
+
+    expect(result.transcript.messages.map((item) => item.message_id)).toEqual([
+      'shared-prompt',
+      'alternative-response'
+    ])
+  })
+
+  it('pages backward from the latest Messages and rejects a stale transcript cursor', async () => {
+    const target = session({
+      messages: [1, 2, 3, 4, 5].map((index) =>
+        message(`message-${index}`, index % 2 ? 'user' : 'agent', index * 100)
+      )
+    })
+    const service = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: [target], isComplete: true })),
+      readSession: vi.fn()
+    })
+    const frameId = target.conversationGraph!.rootFrameId
+
+    const first = (await service.get(frameId, { limit: 2 }, context)) as {
+      transcript: {
+        messages: Array<{ message_id: string }>
+        previous_cursor?: string
+        has_more_before: boolean
+      }
+    }
+    expect(first.transcript.messages.map((item) => item.message_id)).toEqual([
+      'message-4',
+      'message-5'
+    ])
+    expect(first.transcript).toMatchObject({
+      previous_cursor: expect.any(String),
+      has_more_before: true
+    })
+
+    const second = (await service.get(
+      frameId,
+      { limit: 2, before: first.transcript.previous_cursor },
+      context
+    )) as typeof first
+    expect(second.transcript.messages.map((item) => item.message_id)).toEqual([
+      'message-2',
+      'message-3'
+    ])
+    expect(second.transcript.has_more_before).toBe(true)
+
+    const third = (await service.get(
+      frameId,
+      { limit: 2, before: second.transcript.previous_cursor },
+      context
+    )) as typeof first
+    expect(third.transcript.messages.map((item) => item.message_id)).toEqual(['message-1'])
+    expect(third.transcript).toMatchObject({ has_more_before: false })
+    expect(third.transcript.previous_cursor).toBeUndefined()
+
+    const graph = target.conversationGraph!
+    graph.frames.push({
+      id: 'other-frame',
+      parentFrameId: graph.rootFrameId,
+      originBindingState: 'legacy-unavailable',
+      kind: 'compatibility',
+      status: 'completed',
+      activeBranchId: 'other-branch',
+      createdAt: 600,
+      completedAt: 600
+    })
+    graph.branches.push({
+      id: 'other-branch',
+      agentFrameId: 'other-frame',
+      createdAt: 600,
+      updatedAt: 600
+    })
+    await expect(
+      service.get('other-frame', { limit: 2, before: first.transcript.previous_cursor }, context)
+    ).rejects.toThrow('cursor does not match')
+    await expect(service.get(frameId, { branch_id: 'other-branch' }, context)).rejects.toThrow(
+      'Branch not found'
+    )
+
+    target.conversationGraph!.messages.find((item) => item.id === 'message-3')!.updatedAt += 1
+    await expect(
+      service.get(frameId, { limit: 2, before: first.transcript.previous_cursor }, context)
+    ).rejects.toThrow('cursor is no longer valid')
+  })
+
+  it('requires full exact ids and uses Session narrowing to disambiguate within the Project', async () => {
+    const first = session({ id: 'session-one', title: 'One' })
+    const second = session({ id: 'session-two', title: 'Two' })
+    renameRootFrame(first, 'shared-frame-exact')
+    renameRootFrame(second, 'shared-frame-exact')
+    const readSession = vi.fn(async (_projectId: string, sessionId: string) =>
+      sessionId === 'session-two'
+        ? { status: 'found' as const, session: second }
+        : { status: 'missing' as const }
+    )
+    const service = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: [first, second], isComplete: true })),
+      readSession
+    })
+
+    await expect(service.get('shared-frame-exact', {}, context)).rejects.toThrow('ambiguous')
+    await expect(
+      service.get('shared-frame-exact', { session_id: 'session-two' }, context)
+    ).resolves.toMatchObject({
+      project_id: 'project-a',
+      session: { session_id: 'session-two' },
+      frame: { frame_id: 'shared-frame-exact' }
+    })
+    expect(readSession).toHaveBeenCalledWith('project-a', 'session-two')
+    await expect(service.get('shared-frame', {}, context)).rejects.toThrow(
+      'not found in the current Project'
+    )
+    await expect(
+      service.get('shared-frame-exact', { session_id: 'wrong-session' }, context)
+    ).rejects.toThrow('not found in the current Project')
+  })
+
+  it('projects safe attachment references without leaking paths, bytes, tools, or runtime internals', async () => {
+    const user = message('prompt', 'user', 100)
+    user.uploads = [
+      {
+        id: 'upload-1',
+        versionId: 'upload-version-1',
+        versionNumber: 1,
+        sessionId: 'session-1',
+        name: 'managed.csv',
+        originalName: '/private/input/source.csv',
+        mimeType: 'text/csv',
+        size: 12,
+        path: '/private/uploads/managed.csv'
+      }
+    ]
+    user.images = [
+      { id: 'image-1', mimeType: 'image/png', data: 'SECRET_IMAGE_BASE64', byteLength: 12 }
+    ]
+    user.parts = [
+      {
+        type: 'artifact',
+        id: 'mention-1',
+        name: 'private.csv',
+        source: 'artifact',
+        path: '/private/mentioned/private.csv'
+      }
+    ]
+    const agent = {
+      ...message('response', 'agent', 200),
+      content: '<think>SECRET_REASONING</think>Safe answer',
+      artifactIds: ['artifact-ref-1'],
+      eventIds: ['SECRET_EVENT_ID'],
+      streamId: 'SECRET_STREAM_ID'
+    }
+    const target = session({
+      cwd: '/private/project/cwd',
+      providerSessionId: 'SECRET_PROVIDER_SESSION',
+      providerContinuityToken: 'SECRET_CONTINUITY_TOKEN',
+      messages: [user, agent],
+      artifacts: [
+        {
+          id: 'artifact-ref-1',
+          artifactId: 'artifact-1',
+          versionId: 'artifact-version-1',
+          versionNumber: 1,
+          kind: 'managed-file',
+          name: '/private/generated/report.pdf',
+          path: '/private/artifacts/report.pdf',
+          mimeType: 'application/pdf',
+          size: 42
+        }
+      ],
+      activities: [
+        {
+          id: 'tool-1',
+          kind: 'tool',
+          title: 'SECRET_TOOL_TITLE',
+          status: 'completed',
+          sortIndex: 1,
+          eventIds: [],
+          rawInput: 'SECRET_RAW_INPUT',
+          rawOutput: 'SECRET_RAW_OUTPUT',
+          terminalOutput: 'SECRET_TERMINAL_OUTPUT',
+          createdAt: 150,
+          updatedAt: 160
+        }
+      ]
+    })
+    target.conversationGraph!.runtimeSegments[0] = {
+      ...target.conversationGraph!.runtimeSegments[0],
+      backendId: 'SECRET_BACKEND_ID',
+      model: 'SECRET_MODEL',
+      agentName: 'Visible Agent'
+    }
+    const service = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: [target], isComplete: true })),
+      readSession: vi.fn()
+    })
+
+    const result = (await service.get(target.conversationGraph!.rootFrameId, {}, context)) as {
+      transcript: { messages: Array<{ message_id: string; attachments?: unknown[] }> }
+    }
+    expect(result.transcript.messages).toEqual([
+      expect.objectContaining({
+        message_id: 'prompt',
+        attachments: [
+          {
+            kind: 'upload',
+            attachment_id: 'upload-1',
+            version_id: 'upload-version-1',
+            name: 'source.csv',
+            mime_type: 'text/csv',
+            size_bytes: 12
+          },
+          {
+            kind: 'image',
+            attachment_id: 'image-1',
+            name: 'Image 1',
+            mime_type: 'image/png'
+          }
+        ]
+      }),
+      expect.objectContaining({
+        message_id: 'response',
+        content: 'Safe answer',
+        attachments: [
+          {
+            kind: 'artifact',
+            attachment_id: 'artifact-ref-1',
+            version_id: 'artifact-version-1',
+            name: 'report.pdf',
+            mime_type: 'application/pdf',
+            size_bytes: 42
+          }
+        ]
+      })
+    ])
+    expect(JSON.stringify(result)).not.toMatch(
+      /SECRET_|\/private|rawInput|rawOutput|terminalOutput|streamId|eventIds|providerSessionId|providerContinuityToken|backendId|model/u
+    )
+  })
+
+  it('fails explicitly for unreadable Session authority while retaining readable list results', async () => {
+    const readable = session()
+    const projectScoped = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: [readable], isComplete: false })),
+      readSession: vi.fn()
+    })
+    await expect(projectScoped.list({}, context)).resolves.toMatchObject({ total_count: 1 })
+    await expect(
+      projectScoped.get(readable.conversationGraph!.rootFrameId, {}, context)
+    ).rejects.toThrow('Session is unreadable')
+
+    const narrowed = new HostFramesService({
+      readProject: vi.fn(),
+      readSession: vi.fn(async () => ({ status: 'unreadable' as const }))
+    })
+    await expect(narrowed.list({ session_id: 'broken' }, context)).rejects.toThrow(
+      'Session is unreadable'
+    )
+    await expect(narrowed.get('unknown-frame', { session_id: 'broken' }, context)).rejects.toThrow(
+      'Session is unreadable'
+    )
+  })
+
+  it('rejects malformed and authority-bearing options at the Module interface', async () => {
+    const target = session()
+    const service = new HostFramesService({
+      readProject: vi.fn(async () => ({ sessions: [target], isComplete: true })),
+      readSession: vi.fn()
+    })
+    for (const options of [
+      null,
+      { project_id: 'other' },
+      { roots_only: 'yes' },
+      { kind: 'unknown' },
+      { archived: 'yes' },
+      { after: '2026-02-30' },
+      { after: '2026-08-03', before: '2026-08-03' },
+      { after: '2026-08-03T10:00:00' },
+      { limit: 0 },
+      { limit: 101 },
+      { cursor: 'not-a-cursor' }
+    ]) {
+      await expect(service.list(options, context)).rejects.toThrow(/host\.frames\.list/u)
+    }
+    await expect(service.get('', {}, context)).rejects.toThrow(/frame_id/u)
+    for (const options of [
+      null,
+      { project_id: 'other' },
+      { session_id: 1 },
+      { branch_id: 1 },
+      { limit: 0 },
+      { limit: 101 },
+      { before: 'not-a-cursor' }
+    ]) {
+      await expect(
+        service.get(target.conversationGraph!.rootFrameId, options, context)
+      ).rejects.toThrow(/host\.frames\.get/u)
+    }
+  })
+})

--- a/src/main/notebook/host-frames-service.ts
+++ b/src/main/notebook/host-frames-service.ts
@@ -121,7 +121,8 @@ const optionalString = (
 }
 
 const parseUtcTime = (value: string, key: 'after' | 'before'): number => {
-  const normalized = /^\d{4}-\d{2}-\d{2}$/u.test(value) ? `${value}T00:00:00.000Z` : value
+  const dateOnly = /^\d{4}-\d{2}-\d{2}$/u.test(value)
+  const normalized = dateOnly ? `${value}T00:00:00.000Z` : value
   if (
     !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/u.test(
       normalized
@@ -129,11 +130,16 @@ const parseUtcTime = (value: string, key: 'after' | 'before'): number => {
   ) {
     throw new Error(`host.frames.list ${key} must be a UTC date or ISO timestamp with an offset.`)
   }
+  const calendarDate = normalized.slice(0, 10)
+  const calendarTime = Date.parse(`${calendarDate}T00:00:00.000Z`)
+  if (
+    !Number.isFinite(calendarTime) ||
+    new Date(calendarTime).toISOString().slice(0, 10) !== calendarDate
+  ) {
+    throw new Error(`host.frames.list ${key} is not a valid ${dateOnly ? 'UTC date' : 'time'}.`)
+  }
   const parsed = Date.parse(normalized)
   if (!Number.isFinite(parsed)) throw new Error(`host.frames.list ${key} is not a valid time.`)
-  if (/^\d{4}-\d{2}-\d{2}$/u.test(value) && new Date(parsed).toISOString().slice(0, 10) !== value) {
-    throw new Error(`host.frames.list ${key} is not a valid UTC date.`)
-  }
   return parsed
 }
 

--- a/src/main/notebook/host-frames-service.ts
+++ b/src/main/notebook/host-frames-service.ts
@@ -1,0 +1,557 @@
+import { createHash } from 'node:crypto'
+
+import {
+  resolveMessageBranchPath,
+  type PersistedAgentFrame,
+  type PersistedConversationGraph,
+  type PersistedMessageNode
+} from '../../shared/conversation-graph'
+import { sanitizeExportMarkdown } from '../../shared/conversation-export'
+import { fuzzyScore } from '../../shared/fuzzy-match'
+import type { PersistedArtifact, PersistedChatSession } from '../../shared/session-persistence'
+
+type HostFrameReadContext = Readonly<{ projectId: string; sessionId: string }>
+
+type HostFramesSessionDiagnostic =
+  | { status: 'found'; session: PersistedChatSession }
+  | { status: 'missing' }
+  | { status: 'unreadable' }
+
+type HostFramesRepository = {
+  readProject(projectId: string): Promise<{
+    sessions: PersistedChatSession[]
+    isComplete: boolean
+  }>
+  readSession(projectId: string, sessionId: string): Promise<HostFramesSessionDiagnostic>
+}
+
+type ArchivedFilter = 'exclude' | 'include' | 'only'
+
+type NormalizedListOptions = {
+  sessionId?: string
+  rootsOnly: boolean
+  kind?: 'root' | 'reviewer' | 'delegate' | 'compatibility'
+  archived: ArchivedFilter
+  search?: string
+  afterMs?: number
+  beforeMs?: number
+  cursor?: string
+  limit: number
+}
+
+type ListCursor = {
+  version: 1
+  queryKey: string
+  snapshotKey: string
+  offset: number
+}
+
+type TranscriptCursor = {
+  version: 1
+  projectId: string
+  sessionId: string
+  frameId: string
+  branchId: string
+  snapshotKey: string
+  end: number
+}
+
+type NormalizedGetOptions = {
+  sessionId?: string
+  branchId?: string
+  before?: string
+  limit: number
+}
+
+type HostFrameProjection = {
+  frame_id: string
+  session_id: string
+  session_title: string
+  parent_frame_id?: string
+  origin_message_id?: string
+  kind: PersistedAgentFrame['kind']
+  agent_name?: string
+  delegate_name?: string
+  linked_review_id?: string
+  recorded_frame_status: PersistedAgentFrame['status']
+  session_status: PersistedChatSession['status']
+  created_at: string
+  completed_at?: string
+  session_updated_at: string
+  archived_at?: string
+  message_count: number
+  child_count: number
+}
+
+const LIST_OPTION_KEYS = new Set([
+  'session_id',
+  'roots_only',
+  'kind',
+  'archived',
+  'search',
+  'after',
+  'before',
+  'limit',
+  'cursor'
+])
+const FRAME_KINDS = new Set(['root', 'reviewer', 'delegate', 'compatibility'])
+const ARCHIVED_FILTERS = new Set<ArchivedFilter>(['exclude', 'include', 'only'])
+const DEFAULT_LIST_LIMIT = 20
+const MAX_LIMIT = 100
+const DEFAULT_GET_LIMIT = 40
+const GET_OPTION_KEYS = new Set(['session_id', 'branch_id', 'before', 'limit'])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const optionalString = (
+  options: Record<string, unknown>,
+  key: string,
+  maxLength = 256,
+  prefix = 'host.frames'
+): string | undefined => {
+  const value = options[key]
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || value.length === 0 || value.length > maxLength) {
+    throw new Error(
+      `${prefix} ${key} must be a non-empty string of at most ${maxLength} characters.`
+    )
+  }
+  return value
+}
+
+const parseUtcTime = (value: string, key: 'after' | 'before'): number => {
+  const normalized = /^\d{4}-\d{2}-\d{2}$/u.test(value) ? `${value}T00:00:00.000Z` : value
+  if (
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/u.test(
+      normalized
+    )
+  ) {
+    throw new Error(`host.frames.list ${key} must be a UTC date or ISO timestamp with an offset.`)
+  }
+  const parsed = Date.parse(normalized)
+  if (!Number.isFinite(parsed)) throw new Error(`host.frames.list ${key} is not a valid time.`)
+  if (/^\d{4}-\d{2}-\d{2}$/u.test(value) && new Date(parsed).toISOString().slice(0, 10) !== value) {
+    throw new Error(`host.frames.list ${key} is not a valid UTC date.`)
+  }
+  return parsed
+}
+
+const normalizeListOptions = (value: unknown): NormalizedListOptions => {
+  if (value === undefined) value = {}
+  if (!isRecord(value)) throw new Error('host.frames.list options must be an object.')
+  const unknown = Object.keys(value).find((key) => !LIST_OPTION_KEYS.has(key))
+  if (unknown) throw new Error(`host.frames.list unknown option: ${unknown}`)
+
+  const sessionId = optionalString(value, 'session_id', 512, 'host.frames.list')
+  const search = optionalString(value, 'search', 256, 'host.frames.list')
+  const after = optionalString(value, 'after', 64, 'host.frames.list')
+  const before = optionalString(value, 'before', 64, 'host.frames.list')
+  const cursor = optionalString(value, 'cursor', 4096, 'host.frames.list')
+  const rootsOnly = value.roots_only === undefined ? true : value.roots_only
+  if (typeof rootsOnly !== 'boolean') {
+    throw new Error('host.frames.list roots_only must be a boolean.')
+  }
+  const kind = value.kind
+  if (kind !== undefined && (typeof kind !== 'string' || !FRAME_KINDS.has(kind))) {
+    throw new Error('host.frames.list kind is invalid.')
+  }
+  const archived = value.archived === undefined ? 'exclude' : value.archived
+  if (typeof archived !== 'string' || !ARCHIVED_FILTERS.has(archived as ArchivedFilter)) {
+    throw new Error('host.frames.list archived must be exclude, include, or only.')
+  }
+  const limit = value.limit === undefined ? DEFAULT_LIST_LIMIT : value.limit
+  if (!Number.isInteger(limit) || (limit as number) < 1 || (limit as number) > MAX_LIMIT) {
+    throw new Error(`host.frames.list limit must be an integer between 1 and ${MAX_LIMIT}.`)
+  }
+  const afterMs = after ? parseUtcTime(after, 'after') : undefined
+  const beforeMs = before ? parseUtcTime(before, 'before') : undefined
+  if (afterMs !== undefined && beforeMs !== undefined && afterMs >= beforeMs) {
+    throw new Error('host.frames.list after must be earlier than before.')
+  }
+  return {
+    sessionId,
+    rootsOnly,
+    kind: kind as NormalizedListOptions['kind'],
+    archived: archived as ArchivedFilter,
+    search,
+    afterMs,
+    beforeMs,
+    cursor,
+    limit: limit as number
+  }
+}
+
+const normalizeGetOptions = (value: unknown): NormalizedGetOptions => {
+  if (value === undefined) value = {}
+  if (!isRecord(value)) throw new Error('host.frames.get options must be an object.')
+  const unknown = Object.keys(value).find((key) => !GET_OPTION_KEYS.has(key))
+  if (unknown) throw new Error(`host.frames.get unknown option: ${unknown}`)
+  const sessionId = optionalString(value, 'session_id', 512, 'host.frames.get')
+  const branchId = optionalString(value, 'branch_id', 512, 'host.frames.get')
+  const before = optionalString(value, 'before', 4096, 'host.frames.get')
+  const limit = value.limit === undefined ? DEFAULT_GET_LIMIT : value.limit
+  if (!Number.isInteger(limit) || (limit as number) < 1 || (limit as number) > MAX_LIMIT) {
+    throw new Error(`host.frames.get limit must be an integer between 1 and ${MAX_LIMIT}.`)
+  }
+  return { sessionId, branchId, before, limit: limit as number }
+}
+
+const toIso = (timestamp: number): string => new Date(timestamp).toISOString()
+
+const encodeCursor = (cursor: ListCursor | TranscriptCursor): string =>
+  Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url')
+
+const decodeListCursor = (value: string, queryKey: string): ListCursor => {
+  let cursor: unknown
+  try {
+    cursor = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as unknown
+  } catch {
+    throw new Error('host.frames.list cursor is invalid.')
+  }
+  if (
+    !isRecord(cursor) ||
+    cursor.version !== 1 ||
+    cursor.queryKey !== queryKey ||
+    typeof cursor.snapshotKey !== 'string' ||
+    !Number.isInteger(cursor.offset) ||
+    (cursor.offset as number) < 0
+  ) {
+    throw new Error('host.frames.list cursor does not match the requested filters.')
+  }
+  return cursor as ListCursor
+}
+
+const decodeTranscriptCursor = (
+  value: string,
+  binding: Pick<TranscriptCursor, 'projectId' | 'sessionId' | 'frameId' | 'branchId'>
+): TranscriptCursor => {
+  let cursor: unknown
+  try {
+    cursor = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as unknown
+  } catch {
+    throw new Error('host.frames.get cursor is invalid.')
+  }
+  if (
+    !isRecord(cursor) ||
+    cursor.version !== 1 ||
+    cursor.projectId !== binding.projectId ||
+    cursor.sessionId !== binding.sessionId ||
+    cursor.frameId !== binding.frameId ||
+    cursor.branchId !== binding.branchId ||
+    typeof cursor.snapshotKey !== 'string' ||
+    !Number.isInteger(cursor.end) ||
+    (cursor.end as number) < 0
+  ) {
+    throw new Error('host.frames.get cursor does not match the requested Frame and Branch.')
+  }
+  return cursor as TranscriptCursor
+}
+
+const fingerprint = (value: unknown): string =>
+  createHash('sha256').update(JSON.stringify(value)).digest('base64url')
+
+const compareOrdinal = (left: string, right: string): number =>
+  left === right ? 0 : left < right ? -1 : 1
+
+const toTurnUsage = (usage: NonNullable<PersistedMessageNode['turnUsage']>): unknown => ({
+  input_tokens: usage.inputTokens,
+  cache_tokens: usage.cacheTokens,
+  ...(usage.cachedReadTokens === undefined ? {} : { cached_read_tokens: usage.cachedReadTokens }),
+  ...(usage.cachedWriteTokens === undefined
+    ? {}
+    : { cached_write_tokens: usage.cachedWriteTokens }),
+  output_tokens: usage.outputTokens,
+  ...(usage.turnCount === undefined ? {} : { turn_count: usage.turnCount })
+})
+
+const displayName = (value: string | undefined): string | undefined =>
+  value?.split(/[\\/]/u).filter(Boolean).at(-1) || undefined
+
+const safeSize = (value: number | undefined): number | undefined =>
+  value !== undefined && Number.isSafeInteger(value) && value >= 0 ? value : undefined
+
+const toAttachments = (
+  message: PersistedMessageNode,
+  artifactsById: ReadonlyMap<string, PersistedArtifact>
+): unknown[] => [
+  ...(message.uploads ?? []).map((upload) => {
+    const name = displayName(upload.originalName) ?? displayName(upload.name)
+    const size = safeSize(upload.size)
+    return {
+      kind: 'upload',
+      attachment_id: upload.id,
+      ...(upload.versionId ? { version_id: upload.versionId } : {}),
+      ...(name ? { name } : {}),
+      ...(upload.mimeType ? { mime_type: upload.mimeType } : {}),
+      ...(size === undefined ? {} : { size_bytes: size })
+    }
+  }),
+  ...(message.artifactIds ?? []).flatMap((artifactId) => {
+    const artifact = artifactsById.get(artifactId)
+    if (!artifact) return []
+    const name = displayName(artifact.name)
+    const size = safeSize(artifact.size)
+    return [
+      {
+        kind: 'artifact',
+        attachment_id: artifact.id,
+        ...(artifact.versionId ? { version_id: artifact.versionId } : {}),
+        ...(name ? { name } : {}),
+        ...(artifact.mimeType ? { mime_type: artifact.mimeType } : {}),
+        ...(size === undefined ? {} : { size_bytes: size })
+      }
+    ]
+  }),
+  ...(message.images ?? []).map((image, index) => ({
+    kind: 'image',
+    attachment_id: image.id,
+    name: `Image ${index + 1}`,
+    mime_type: image.mimeType
+  }))
+]
+
+const toMessage = (
+  message: PersistedMessageNode,
+  artifactsById: ReadonlyMap<string, PersistedArtifact>
+): unknown => {
+  const attachments = toAttachments(message, artifactsById)
+  return {
+    message_id: message.id,
+    role: message.role,
+    content: sanitizeExportMarkdown(message.content),
+    status: message.status,
+    ...(message.responseToMessageId ? { response_to_message_id: message.responseToMessageId } : {}),
+    ...(message.runtimeSegmentId ? { runtime_segment_id: message.runtimeSegmentId } : {}),
+    created_at: toIso(message.createdAt),
+    updated_at: toIso(message.updatedAt),
+    ...(message.completedAt === undefined ? {} : { completed_at: toIso(message.completedAt) }),
+    ...(message.failedAt === undefined ? {} : { failed_at: toIso(message.failedAt) }),
+    ...(message.turnUsage ? { turn_usage: toTurnUsage(message.turnUsage) } : {}),
+    ...(attachments.length > 0 ? { attachments } : {})
+  }
+}
+
+const frameProjection = (
+  session: PersistedChatSession,
+  graph: PersistedConversationGraph,
+  frame: PersistedAgentFrame
+): HostFrameProjection => ({
+  frame_id: frame.id,
+  session_id: session.id,
+  session_title: session.title,
+  ...(frame.parentFrameId ? { parent_frame_id: frame.parentFrameId } : {}),
+  ...(frame.originMessageId ? { origin_message_id: frame.originMessageId } : {}),
+  kind: frame.kind,
+  ...(frame.agentName ? { agent_name: frame.agentName } : {}),
+  ...(frame.delegateName ? { delegate_name: frame.delegateName } : {}),
+  ...(frame.linkedReviewId ? { linked_review_id: frame.linkedReviewId } : {}),
+  recorded_frame_status: frame.status,
+  session_status: session.status,
+  created_at: toIso(frame.createdAt),
+  ...(frame.completedAt === undefined ? {} : { completed_at: toIso(frame.completedAt) }),
+  session_updated_at: toIso(session.updatedAt),
+  ...(session.archivedAt === undefined ? {} : { archived_at: toIso(session.archivedAt) }),
+  message_count: resolveMessageBranchPath(graph, frame.activeBranchId).length,
+  child_count: graph.frames.filter((candidate) => candidate.parentFrameId === frame.id).length
+})
+
+class HostFramesService {
+  constructor(private readonly repository: HostFramesRepository) {}
+
+  async list(options: unknown, context: HostFrameReadContext): Promise<unknown> {
+    const normalized = normalizeListOptions(options)
+    const sessions = normalized.sessionId
+      ? await this.readNarrowedSession(context.projectId, normalized.sessionId)
+      : (await this.repository.readProject(context.projectId)).sessions
+    const frames = sessions.flatMap((session) => {
+      if (
+        (normalized.archived === 'exclude' && session.archivedAt !== undefined) ||
+        (normalized.archived === 'only' && session.archivedAt === undefined)
+      ) {
+        return []
+      }
+      const graph = session.conversationGraph
+      if (!graph) return []
+      return graph.frames
+        .filter((frame) => {
+          if (normalized.rootsOnly && frame.parentFrameId) return false
+          if (normalized.kind && frame.kind !== normalized.kind) return false
+          if (normalized.afterMs !== undefined && frame.createdAt < normalized.afterMs) return false
+          if (normalized.beforeMs !== undefined && frame.createdAt >= normalized.beforeMs)
+            return false
+          if (
+            normalized.search &&
+            ![session.title, frame.agentName, frame.delegateName].some(
+              (value) => value && fuzzyScore(normalized.search!, value)
+            )
+          ) {
+            return false
+          }
+          return true
+        })
+        .map((frame) => frameProjection(session, graph, frame))
+    })
+    frames.sort(
+      (left, right) =>
+        Date.parse(right.created_at) - Date.parse(left.created_at) ||
+        compareOrdinal(left.session_id, right.session_id) ||
+        compareOrdinal(left.frame_id, right.frame_id)
+    )
+    const queryKey = JSON.stringify({
+      projectId: context.projectId,
+      sessionId: normalized.sessionId,
+      rootsOnly: normalized.rootsOnly,
+      kind: normalized.kind,
+      archived: normalized.archived,
+      search: normalized.search,
+      afterMs: normalized.afterMs,
+      beforeMs: normalized.beforeMs
+    })
+    const snapshotKey = fingerprint(frames)
+    const cursor = normalized.cursor ? decodeListCursor(normalized.cursor, queryKey) : undefined
+    if (cursor && cursor.snapshotKey !== snapshotKey) {
+      throw new Error('host.frames.list cursor is no longer valid.')
+    }
+    const offset = cursor?.offset ?? 0
+    if (offset > frames.length) throw new Error('host.frames.list cursor is no longer valid.')
+    const page = frames.slice(offset, offset + normalized.limit)
+    const nextOffset = offset + page.length
+    return {
+      project_id: context.projectId,
+      total_count: frames.length,
+      ...(nextOffset < frames.length
+        ? {
+            next_cursor: encodeCursor({
+              version: 1,
+              queryKey,
+              snapshotKey,
+              offset: nextOffset
+            })
+          }
+        : {}),
+      frames: page
+    }
+  }
+
+  private async readNarrowedSession(
+    projectId: string,
+    sessionId: string
+  ): Promise<PersistedChatSession[]> {
+    const diagnostic = await this.repository.readSession(projectId, sessionId)
+    if (diagnostic.status === 'found') return [diagnostic.session]
+    if (diagnostic.status === 'unreadable') {
+      throw new Error(`Session is unreadable in the current Project: ${sessionId}`)
+    }
+    return []
+  }
+
+  async get(frameId: unknown, options: unknown, context: HostFrameReadContext): Promise<unknown> {
+    if (typeof frameId !== 'string' || frameId.length === 0 || frameId.length > 512) {
+      throw new Error(
+        'host.frames.get frame_id must be a non-empty string of at most 512 characters.'
+      )
+    }
+    const normalized = normalizeGetOptions(options)
+    let sessions: PersistedChatSession[]
+    if (normalized.sessionId) {
+      sessions = await this.readNarrowedSession(context.projectId, normalized.sessionId)
+    } else {
+      const project = await this.repository.readProject(context.projectId)
+      if (!project.isComplete) {
+        throw new Error(
+          'host.frames.get cannot complete because a current Project Session is unreadable.'
+        )
+      }
+      sessions = project.sessions
+    }
+    const matches = sessions.flatMap((session) => {
+      const graph = session.conversationGraph
+      const frame = graph?.frames.find((candidate) => candidate.id === frameId)
+      return graph && frame ? [{ session, graph, frame }] : []
+    })
+    if (matches.length > 1) {
+      throw new Error(`Frame id is ambiguous in the current Project: ${frameId}`)
+    }
+    const match = matches[0]
+    if (!match) throw new Error(`Frame not found in the current Project: ${frameId}`)
+    const branchId = normalized.branchId ?? match.frame.activeBranchId
+    const branch = match.graph.branches.find(
+      (candidate) => candidate.id === branchId && candidate.agentFrameId === match.frame.id
+    )
+    if (!branch) throw new Error(`Frame Branch not found in the current Project: ${branchId}`)
+    const path = resolveMessageBranchPath(match.graph, branch.id)
+    const binding = {
+      projectId: context.projectId,
+      sessionId: match.session.id,
+      frameId: match.frame.id,
+      branchId: branch.id
+    }
+    const snapshotKey = fingerprint({
+      branchUpdatedAt: branch.updatedAt,
+      messages: path.map((message) => [
+        message.id,
+        message.updatedAt,
+        message.status,
+        message.content
+      ])
+    })
+    const cursor = normalized.before
+      ? decodeTranscriptCursor(normalized.before, binding)
+      : undefined
+    if (cursor && cursor.snapshotKey !== snapshotKey) {
+      throw new Error('host.frames.get cursor is no longer valid.')
+    }
+    const end = cursor?.end ?? path.length
+    if (end > path.length) throw new Error('host.frames.get cursor is no longer valid.')
+    const start = Math.max(0, end - normalized.limit)
+    const messages = path.slice(start, end)
+    const artifactsById = new Map(
+      (match.session.artifacts ?? []).map((artifact) => [artifact.id, artifact])
+    )
+    return {
+      project_id: context.projectId,
+      session: {
+        session_id: match.session.id,
+        session_title: match.session.title,
+        session_status: match.session.status,
+        created_at: toIso(match.session.createdAt),
+        updated_at: toIso(match.session.updatedAt),
+        ...(match.session.archivedAt === undefined
+          ? {}
+          : { archived_at: toIso(match.session.archivedAt) })
+      },
+      frame: frameProjection(match.session, match.graph, match.frame),
+      branch: {
+        branch_id: branch.id,
+        created_at: toIso(branch.createdAt),
+        updated_at: toIso(branch.updatedAt)
+      },
+      transcript: {
+        messages: messages.map((message) => toMessage(message, artifactsById)),
+        ...(start > 0
+          ? {
+              previous_cursor: encodeCursor({
+                version: 1,
+                ...binding,
+                snapshotKey,
+                end: start
+              })
+            }
+          : {}),
+        has_more_before: start > 0
+      },
+      runtime_segments: match.graph.runtimeSegments
+        .filter((segment) => segment.agentFrameId === match.frame.id)
+        .map((segment) => ({
+          runtime_segment_id: segment.id,
+          ...(segment.agentName ? { agent_name: segment.agentName } : {}),
+          started_at: toIso(segment.startedAt),
+          ...(segment.endedAt === undefined ? {} : { ended_at: toIso(segment.endedAt) })
+        }))
+    }
+  }
+}
+
+export { HostFramesService }
+export type { HostFrameReadContext, HostFramesRepository, HostFramesSessionDiagnostic }

--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -39,7 +39,8 @@ describe('capabilitiesCall RPC', () => {
       agentsService: {} as never,
       skillsService: {} as never,
       hostArtifacts: {} as never,
-      hostLineage: {} as never
+      hostLineage: {} as never,
+      hostFrames: {} as never
     })
     const connection = await server.issueControlConnection('trusted-session', 'trusted-project')
 
@@ -57,7 +58,8 @@ describe('capabilitiesCall RPC', () => {
         agents: true,
         skills: true,
         artifacts: true,
-        lineage: true
+        lineage: true,
+        frames: true
       }
     })
   })
@@ -77,9 +79,22 @@ describe('capabilitiesCall RPC', () => {
           agents: false,
           skills: false,
           artifacts: false,
-          lineage: false
+          lineage: false,
+          frames: false
         }
       }
+    })
+  })
+
+  it('does not advertise Host Frames to an ordinary non-control Session token', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostFrames: {} as never
+    })
+    const connection = await server.issueSessionConnection('trusted-session', 'trusted-project')
+
+    await expect(callCapabilities(connection)).resolves.toMatchObject({
+      payload: { result: { frames: false } }
     })
   })
 

--- a/src/main/notebook/local-rpc-server.frames.test.ts
+++ b/src/main/notebook/local-rpc-server.frames.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { NotebookLocalRpcServer } from './local-rpc-server'
+
+type RpcConnection = { endpoint: string; token: string; release?: () => void }
+
+const callFrames = async (
+  connection: RpcConnection,
+  token: string,
+  params: Record<string, unknown>
+): Promise<{ response: Response; payload: Record<string, unknown> }> => {
+  const response = await fetch(connection.endpoint, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ method: 'framesCall', params })
+  })
+  return { response, payload: (await response.json()) as Record<string, unknown> }
+}
+
+let server: NotebookLocalRpcServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+describe('framesCall RPC', () => {
+  it('uses only the control token Project and calling Session for list and get operations', async () => {
+    const list = vi.fn(async () => ({ frames: [] }))
+    const get = vi.fn(async () => ({ frame: { frame_id: 'frame-exact' } }))
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostFrames: { list, get }
+    })
+    const control = await server.issueControlConnection('trusted-session', 'trusted-project')
+
+    const listed = await callFrames(control, control.token, {
+      op: 'list',
+      options: { session_id: 'narrow-session' },
+      projectId: 'forged-project',
+      project_id: 'forged-project',
+      sessionId: 'forged-session'
+    })
+    expect(listed).toMatchObject({ response: { status: 200 }, payload: { result: { frames: [] } } })
+    expect(list).toHaveBeenCalledWith(
+      { session_id: 'narrow-session' },
+      { projectId: 'trusted-project', sessionId: 'trusted-session' }
+    )
+
+    await expect(
+      callFrames(control, control.token, {
+        op: 'get',
+        frame_id: 'frame-exact',
+        options: { branch_id: 'branch-exact' },
+        projectId: 'forged-project',
+        sessionId: 'forged-session'
+      })
+    ).resolves.toMatchObject({ response: { status: 200 } })
+    expect(get).toHaveBeenCalledWith(
+      'frame-exact',
+      { branch_id: 'branch-exact' },
+      { projectId: 'trusted-project', sessionId: 'trusted-session' }
+    )
+  })
+
+  it('rejects bootstrap, invalid, ordinary Session, and released control capabilities', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostFrames: { list: vi.fn(), get: vi.fn() }
+    })
+    const bootstrap = await server.ensureStarted()
+    const ordinary = await server.issueSessionConnection('trusted-session', 'trusted-project')
+    const control = await server.issueControlConnection('trusted-session', 'trusted-project')
+    const params = { op: 'list', options: {} }
+
+    await expect(callFrames(control, bootstrap.token, params)).resolves.toMatchObject({
+      response: { status: 401 },
+      payload: { error: 'A session-bound notebook RPC token is required.' }
+    })
+    await expect(callFrames(control, 'invalid-token', params)).resolves.toMatchObject({
+      response: { status: 401 },
+      payload: { error: 'Invalid notebook RPC token.' }
+    })
+    await expect(callFrames(control, ordinary.token, params)).resolves.toMatchObject({
+      response: { status: 403 },
+      payload: { error: 'host.frames requires a control-plane REPL capability.' }
+    })
+
+    control.release()
+    await expect(callFrames(control, control.token, params)).resolves.toMatchObject({
+      response: { status: 401 },
+      payload: { error: 'Invalid notebook RPC token.' }
+    })
+    ordinary.release?.()
+  })
+})

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -149,6 +149,14 @@ type NotebookLocalRpcServerOptions = {
       context: { projectId: string; sessionId: string }
     ): Promise<HostLineageVersion>
   }
+  hostFrames?: {
+    list(options: unknown, context: { projectId: string; sessionId: string }): Promise<unknown>
+    get(
+      frameId: unknown,
+      options: unknown,
+      context: { projectId: string; sessionId: string }
+    ): Promise<unknown>
+  }
   // host.agents control-plane SDK (issue 02): exposes the Specialist/catalog surface to the
   // JavaScript control-plane REPL via the extensible dispatcher. Never routed through host.mcp();
   // carries the trusted calling session identity captured outside the sandbox so switch()
@@ -204,6 +212,7 @@ const CONTROL_RPC_METHODS = new Set([
   'capabilitiesCall',
   'artifactsCall',
   'lineageCall',
+  'framesCall',
   'mcpCall',
   'computeCall',
   'agentsCall',
@@ -254,6 +263,7 @@ class NotebookLocalRpcServer {
   private readonly inputRegistry: NotebookLocalRpcServerOptions['inputRegistry']
   private readonly hostArtifacts: NotebookLocalRpcServerOptions['hostArtifacts']
   private readonly hostLineage: NotebookLocalRpcServerOptions['hostLineage']
+  private readonly hostFrames: NotebookLocalRpcServerOptions['hostFrames']
   private readonly agentsService: NotebookLocalRpcServerOptions['agentsService']
   private readonly skillsService: NotebookLocalRpcServerOptions['skillsService']
   private server: Server | undefined
@@ -292,6 +302,7 @@ class NotebookLocalRpcServer {
     this.inputRegistry = options.inputRegistry
     this.hostArtifacts = options.hostArtifacts
     this.hostLineage = options.hostLineage
+    this.hostFrames = options.hostFrames
     this.agentsService = options.agentsService
     this.skillsService = options.skillsService
   }
@@ -709,7 +720,10 @@ class NotebookLocalRpcServer {
         ? authorization.slice('Bearer '.length)
         : ''
       let hostCapabilities:
-        | Record<'mcp' | 'compute' | 'agents' | 'skills' | 'artifacts' | 'lineage', boolean>
+        | Record<
+            'mcp' | 'compute' | 'agents' | 'skills' | 'artifacts' | 'lineage' | 'frames',
+            boolean
+          >
         | undefined
       if (isArtifactRpcMethod(method)) {
         const acquired = this.acquireArtifactRpcRequest(method, bearerToken, params)
@@ -741,6 +755,9 @@ class NotebookLocalRpcServer {
               throw new Error('host.lineage RPC params are invalid.')
             }
           }
+          if (method === 'framesCall' && !sessionBinding.isControl) {
+            throw new RpcHttpError(403, 'host.frames requires a control-plane REPL capability.')
+          }
           if (
             method === 'agentsCall' &&
             params.op === 'switch' &&
@@ -760,7 +777,11 @@ class NotebookLocalRpcServer {
               agents: allows('agentsCall') && Boolean(this.agentsService),
               skills: allows('skillsCall') && Boolean(this.skillsService),
               artifacts: allows('artifactsCall') && Boolean(this.hostArtifacts),
-              lineage: allows('lineageCall') && Boolean(this.hostLineage)
+              lineage: allows('lineageCall') && Boolean(this.hostLineage),
+              frames:
+                Boolean(sessionBinding.isControl) &&
+                allows('framesCall') &&
+                Boolean(this.hostFrames)
             }
           }
           // The request body is agent-controlled. Owner fields always come from the unforgeable,
@@ -921,6 +942,19 @@ class NotebookLocalRpcServer {
       }
       if (params.op === 'get') return this.hostLineage.get(params.version_id, context)
       throw new Error('Unknown host.lineage operation.')
+    }
+
+    if (method === 'framesCall') {
+      if (!this.hostFrames) throw new Error('Host Frame reads are not configured.')
+      const projectId = typeof params.projectId === 'string' ? params.projectId : ''
+      const sessionId = typeof params.sessionId === 'string' ? params.sessionId : ''
+      if (!projectId || !sessionId) {
+        throw new Error('Host Frame reads require a session-bound Project scope.')
+      }
+      const context = { projectId, sessionId }
+      if (params.op === 'list') return this.hostFrames.list(params.options, context)
+      if (params.op === 'get') return this.hostFrames.get(params.frame_id, params.options, context)
+      throw new Error('Unknown host Frame operation.')
     }
 
     if (method === 'resolveNotebookInput') {

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -107,7 +107,8 @@ describe('repl_loop local RPC transport', () => {
                 agents: true,
                 skills: true,
                 artifacts: true,
-                lineage: true
+                lineage: true,
+                frames: true
               }
             : {
                 mcp: true,
@@ -115,7 +116,8 @@ describe('repl_loop local RPC transport', () => {
                 agents: true,
                 skills: true,
                 artifacts: true,
-                lineage: true
+                lineage: true,
+                frames: true
               }
         response
           .writeHead(200, { 'content-type': 'application/json' })
@@ -146,7 +148,8 @@ describe('repl_loop local RPC transport', () => {
           agents: true,
           skills: true,
           artifacts: true,
-          lineage: true
+          lineage: true,
+          frames: true
         },
         second: {
           mcp: true,
@@ -154,7 +157,8 @@ describe('repl_loop local RPC transport', () => {
           agents: true,
           skills: true,
           artifacts: true,
-          lineage: true
+          lineage: true,
+          frames: true
         },
         frozen: true,
         same: false
@@ -536,6 +540,164 @@ describe('repl_loop local RPC transport', () => {
         },
         { method: 'artifactsCall', params: { op: 'path', version_id: 'upload-version-1' } }
       ])
+    } finally {
+      child.kill()
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  }, 60_000)
+
+  it('validates and freezes host.frames list and get projections', async () => {
+    const requests: Array<{ method?: string; params?: Record<string, unknown> }> = []
+    const frame = {
+      frame_id: 'frame-1',
+      session_id: 'session-a',
+      session_title: 'Research session',
+      kind: 'root',
+      recorded_frame_status: 'completed',
+      session_status: 'idle',
+      created_at: '2026-08-01T00:00:00.000Z',
+      completed_at: '2026-08-01T00:01:00.000Z',
+      session_updated_at: '2026-08-01T00:01:00.000Z',
+      message_count: 2,
+      child_count: 0
+    }
+    const server = createServer((request, response) => {
+      let body = ''
+      request.on('data', (chunk) => (body += chunk))
+      request.on('end', () => {
+        const parsed = JSON.parse(body) as {
+          method?: string
+          params?: Record<string, unknown>
+        }
+        requests.push(parsed)
+        const result =
+          requests.length === 3
+            ? { project_id: 'project-a', total_count: 0, frames: [], cwd: '/private' }
+            : parsed.params?.op === 'get'
+              ? {
+                  project_id: 'project-a',
+                  session: {
+                    session_id: 'session-a',
+                    session_title: 'Research session',
+                    session_status: 'idle',
+                    created_at: '2026-08-01T00:00:00.000Z',
+                    updated_at: '2026-08-01T00:01:00.000Z'
+                  },
+                  frame,
+                  branch: {
+                    branch_id: 'branch-1',
+                    created_at: '2026-08-01T00:00:00.000Z',
+                    updated_at: '2026-08-01T00:01:00.000Z'
+                  },
+                  transcript: {
+                    messages: [
+                      {
+                        message_id: 'message-1',
+                        role: 'agent',
+                        content: 'Visible answer',
+                        status: 'complete',
+                        runtime_segment_id: 'runtime-1',
+                        created_at: '2026-08-01T00:00:30.000Z',
+                        updated_at: '2026-08-01T00:01:00.000Z',
+                        turn_usage: {
+                          input_tokens: 10,
+                          cache_tokens: 2,
+                          output_tokens: 5
+                        },
+                        attachments: [
+                          {
+                            kind: 'artifact',
+                            attachment_id: 'artifact-1',
+                            version_id: 'artifact-version-1',
+                            name: 'report.pdf',
+                            mime_type: 'application/pdf',
+                            size_bytes: 42
+                          }
+                        ]
+                      }
+                    ],
+                    has_more_before: false
+                  },
+                  runtime_segments: [
+                    {
+                      runtime_segment_id: 'runtime-1',
+                      agent_name: 'Research Agent',
+                      started_at: '2026-08-01T00:00:00.000Z',
+                      ended_at: '2026-08-01T00:01:00.000Z'
+                    }
+                  ]
+                }
+              : { project_id: 'project-a', total_count: 1, next_cursor: 'next', frames: [frame] }
+        response
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ result }))
+      })
+    })
+    const connection = await listenForLocalRpc(server, {
+      name: 'repl-loop-frames-test',
+      transport: 'pipe'
+    })
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+      OPEN_SCIENCE_MCP_RPC_SOCKET_PATH: connection.socketPath,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'test-token'
+    })
+
+    try {
+      const projection = await send(
+        "const page = await host.frames.list({ search: 'research' }); " +
+          "const detail = await host.frames.get('frame-1', { branch_id: 'branch-1' }); " +
+          'return JSON.stringify({ page, detail, pageFrozen: Object.isFrozen(page), ' +
+          'framesFrozen: Object.isFrozen(page.frames), frameFrozen: Object.isFrozen(page.frames[0]), ' +
+          'detailFrozen: Object.isFrozen(detail), transcriptFrozen: Object.isFrozen(detail.transcript), ' +
+          'sessionFrozen: Object.isFrozen(detail.session), detailFrameFrozen: Object.isFrozen(detail.frame), ' +
+          'branchFrozen: Object.isFrozen(detail.branch), segmentsFrozen: Object.isFrozen(detail.runtime_segments), ' +
+          'segmentFrozen: Object.isFrozen(detail.runtime_segments[0]), ' +
+          'messagesFrozen: Object.isFrozen(detail.transcript.messages), ' +
+          'messageFrozen: Object.isFrozen(detail.transcript.messages[0]), ' +
+          'usageFrozen: Object.isFrozen(detail.transcript.messages[0].turn_usage), ' +
+          'attachmentsFrozen: Object.isFrozen(detail.transcript.messages[0].attachments), ' +
+          'attachmentFrozen: Object.isFrozen(detail.transcript.messages[0].attachments[0]) })'
+      )
+      expect(projection.error).toBeNull()
+      expect(JSON.parse(projection.result ?? '{}')).toMatchObject({
+        page: { project_id: 'project-a', total_count: 1, next_cursor: 'next' },
+        detail: { project_id: 'project-a', frame: { frame_id: 'frame-1' } },
+        pageFrozen: true,
+        framesFrozen: true,
+        frameFrozen: true,
+        detailFrozen: true,
+        transcriptFrozen: true,
+        sessionFrozen: true,
+        detailFrameFrozen: true,
+        branchFrozen: true,
+        segmentsFrozen: true,
+        segmentFrozen: true,
+        messagesFrozen: true,
+        messageFrozen: true,
+        usageFrozen: true,
+        attachmentsFrozen: true,
+        attachmentFrozen: true
+      })
+      expect(requests).toEqual([
+        {
+          method: 'framesCall',
+          params: { op: 'list', options: { search: 'research' } }
+        },
+        {
+          method: 'framesCall',
+          params: { op: 'get', frame_id: 'frame-1', options: { branch_id: 'branch-1' } }
+        }
+      ])
+
+      const invalid = await send(
+        "try { await host.frames.list(); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(invalid.result).toBe('host.frames.list returned an invalid result')
+      expect(requests).toHaveLength(3)
     } finally {
       child.kill()
       await new Promise<void>((resolve, reject) =>

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -403,6 +403,28 @@ describe('session persistence repository (per-session files)', () => {
     await expect(readdir(projectDir)).resolves.toEqual(['damaged.json'])
   })
 
+  it('keeps direct Project and Session diagnostics strictly read-only', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    const projectDir = join(storageRoot!, 'sessions', 'project-a')
+    const damagedPath = join(projectDir, 'damaged.json')
+    const damagedJson = JSON.stringify({
+      version: 2,
+      session: { id: 'damaged', messages: 'not-an-array' }
+    })
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(damagedPath, damagedJson, 'utf8')
+
+    await expect(
+      repository.loadProjectWithDiagnostics('project-a', { mode: 'read-only' })
+    ).resolves.toEqual({ sessions: [], isComplete: false })
+    await expect(
+      repository.loadSessionWithDiagnostics('project-a', 'damaged', { mode: 'read-only' })
+    ).resolves.toEqual({ status: 'unreadable' })
+
+    await expect(readFile(damagedPath, 'utf8')).resolves.toBe(damagedJson)
+    await expect(readdir(projectDir)).resolves.toEqual(['damaged.json'])
+  })
+
   it('quarantines a structurally corrupt Session instead of normalizing it to empty', async () => {
     const repository = new SessionRepository(await createStorageRoot())
     const projectDir = join(storageRoot!, 'sessions', 'project-a')

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -183,13 +183,15 @@ class SessionRepository {
   // both as undefined could unlink the JSON before Upload cleanup has observed its final authority.
   async loadSessionWithDiagnostics(
     projectId: string,
-    sessionId: string
+    sessionId: string,
+    options: SessionScanOptions = {}
   ): Promise<SessionLoadDiagnostic> {
     const safeProjectId = assertSafeSegment(projectId)
     const safeSessionId = assertSafeSegment(sessionId)
     const read = await this.readSessionFile(
       this.sessionFilePath(safeProjectId, safeSessionId),
-      safeProjectId
+      safeProjectId,
+      { quarantineInvalidFiles: options.mode !== 'read-only' }
     )
     if (!read.isComplete || read.wasQuarantined) return { status: 'unreadable' }
 
@@ -219,9 +221,13 @@ class SessionRepository {
 
   // Project deletion needs a complete view of only its target authority. An unrelated unreadable
   // Project must not block deletion, while any target-directory failure remains fail-closed.
-  async loadProjectWithDiagnostics(projectId: string): Promise<ProjectSessionLoadDiagnostics> {
+  async loadProjectWithDiagnostics(
+    projectId: string,
+    options: SessionScanOptions = {}
+  ): Promise<ProjectSessionLoadDiagnostics> {
     return this.readProjectSessions(assertSafeSegment(projectId), {
-      quarantinedIsIncomplete: true
+      quarantinedIsIncomplete: true,
+      quarantineInvalidFiles: options.mode !== 'read-only'
     })
   }
 

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -602,6 +602,7 @@ describe('Settings backend ownership architecture', () => {
       'capabilitiesCall',
       'artifactsCall',
       'lineageCall',
+      'framesCall',
       'mcpCall',
       'computeCall',
       'agentsCall',

--- a/src/main/skills/self-awareness-skill.test.ts
+++ b/src/main/skills/self-awareness-skill.test.ts
@@ -22,7 +22,7 @@ describe('self-awareness bundled Skill', () => {
     expect(skill?.description).toMatch(/JavaScript control REPL/i)
   })
 
-  it('documents the shipped six-key JavaScript contract and Artifact lineage read limits', async () => {
+  it('documents the shipped seven-key JavaScript contract and read limits', async () => {
     const body = await new SkillRegistry(skillsRoot).body('self-awareness')
 
     for (const phrase of [
@@ -34,11 +34,18 @@ describe('self-awareness bundled Skill', () => {
       '`skills`',
       '`artifacts`',
       '`lineage`',
+      '`frames`',
       'caps.compute === true',
       'caps.artifacts === true',
+      'caps.frames === true',
       'await host.artifacts(options)',
       'await host.artifact_path',
+      'await host.frames.list(options)',
+      'await host.frames.get(frameId, options)',
       'current Project',
+      'exact full Frame ID',
+      'active Branch',
+      'private reasoning',
       'Version ID',
       'collisions',
       'never content',
@@ -56,6 +63,6 @@ describe('self-awareness bundled Skill', () => {
     ]) {
       expect(body).toContain(phrase)
     }
-    expect(body).not.toMatch(/host\.(query|frames|artifact_read)/)
+    expect(body).not.toMatch(/host\.(query|artifact_read)/)
   })
 })


### PR DESCRIPTION
## Summary

- expose authenticated project-scoped host.frames.list and host.frames.get reads in the JavaScript control REPL
- preserve branch-correct transcript traversal and strict allowlisted sanitization
- add read-only Session repository diagnostics, capability routing, framework coverage, and self-awareness documentation

## Validation

- 142 focused Host Frames tests passed
- npm run typecheck passed for node and web
- lint completed with zero errors
- complete suite with timeout headroom: 13,304 passed, 192 skipped, one unrelated existing Prisma runtime-DDL mismatch

## Impact

- no database, migration, persisted relationship, or UI changes
- no Python or R host surface
- project reads remain strictly read-only