### PR TITLE
fix(connectors): expose custom skills across agents

### DIFF
--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -3,7 +3,11 @@ import { mkdir, mkdtemp, readdir, readFile, stat, writeFile } from 'node:fs/prom
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { renderCustomSkillDoc } from './skill-doc'
-import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './provision'
+import {
+  syncConnectorSkillDocs,
+  syncCustomServerSkillDocs,
+  syncMaterializedCustomServerSkillDocs
+} from './provision'
 import type { StoredCustomMcpServer } from '../settings/types'
 
 const FAKE_TOOLS = [
@@ -216,5 +220,69 @@ describe('bundled and custom skill-doc sync coexist', () => {
     await syncCustomServerSkillDocs(dir, [], listTools)
     entries = (await readdir(dir)).sort()
     expect(entries).toEqual(['mcp-chemistry'])
+  })
+})
+
+describe('syncMaterializedCustomServerSkillDocs', () => {
+  it('copies only valid projected docs and cleans stale custom docs without touching other owners', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'custom-skill-copy-'))
+    const source = join(root, 'source')
+    const target = join(root, 'target')
+    await Promise.all([
+      mkdir(join(source, 'mcp-xt'), { recursive: true }),
+      mkdir(join(source, 'mcp-malformed'), { recursive: true }),
+      mkdir(join(target, 'mcp-stale'), { recursive: true }),
+      mkdir(join(target, 'mcp-pubmed'), { recursive: true }),
+      mkdir(join(target, 'user-skill'), { recursive: true })
+    ])
+    const xtDoc =
+      '---\nname: mcp-xt\ndescription: Use XT records.\nsource: connector\n---\n\n# XT\n'
+    await Promise.all([
+      writeFile(join(source, 'mcp-xt', 'SKILL.md'), xtDoc),
+      writeFile(join(source, 'mcp-malformed', 'SKILL.md'), '# missing frontmatter'),
+      writeFile(join(target, 'mcp-stale', 'SKILL.md'), 'stale'),
+      writeFile(join(target, 'mcp-pubmed', 'SKILL.md'), 'bundled'),
+      writeFile(join(target, 'user-skill', 'SKILL.md'), 'user')
+    ])
+
+    const result = await syncMaterializedCustomServerSkillDocs(source, target, [
+      'mcp-xt',
+      'mcp-xt',
+      'mcp-malformed',
+      'mcp-missing',
+      'mcp-pubmed',
+      'mcp-../../escape'
+    ])
+
+    expect(result.materializedSkillNames).toEqual(['mcp-xt'])
+    expect(result.failures.map(({ skillName }) => skillName)).toEqual([
+      'mcp-malformed',
+      'mcp-missing'
+    ])
+    expect((await readdir(target)).sort()).toEqual(['mcp-pubmed', 'mcp-xt', 'user-skill'])
+    expect(await readFile(join(target, 'mcp-xt', 'SKILL.md'), 'utf8')).toBe(xtDoc)
+    expect(await readFile(join(target, 'mcp-pubmed', 'SKILL.md'), 'utf8')).toBe('bundled')
+  })
+
+  it('canonicalizes a stale case-variant without deleting the copied doc', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'custom-skill-copy-case-'))
+    const source = join(root, 'source')
+    const target = join(root, 'target')
+    await Promise.all([
+      mkdir(join(source, 'mcp-xt'), { recursive: true }),
+      mkdir(join(target, 'mcp-XT'), { recursive: true })
+    ])
+    const xtDoc =
+      '---\nname: mcp-xt\ndescription: Use XT records.\nsource: connector\n---\n\n# XT\n'
+    await Promise.all([
+      writeFile(join(source, 'mcp-xt', 'SKILL.md'), xtDoc),
+      writeFile(join(target, 'mcp-XT', 'SKILL.md'), 'stale')
+    ])
+
+    await syncMaterializedCustomServerSkillDocs(source, target, ['mcp-xt'])
+
+    expect(await readFile(join(target, 'mcp-xt', 'SKILL.md'), 'utf8')).toBe(xtDoc)
+    const entries = await readdir(target)
+    expect(new Set(entries.map((entry) => entry.toLowerCase())).size).toBe(entries.length)
   })
 })

--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -233,6 +233,8 @@ describe('syncMaterializedCustomServerSkillDocs', () => {
       mkdir(join(source, 'mcp-malformed'), { recursive: true }),
       mkdir(join(target, 'mcp-stale'), { recursive: true }),
       mkdir(join(target, 'mcp-pubmed'), { recursive: true }),
+      mkdir(join(target, 'mcp-MySkill'), { recursive: true }),
+      mkdir(join(target, 'mcp-custom.v2'), { recursive: true }),
       mkdir(join(target, 'user-skill'), { recursive: true })
     ])
     const xtDoc =
@@ -242,6 +244,8 @@ describe('syncMaterializedCustomServerSkillDocs', () => {
       writeFile(join(source, 'mcp-malformed', 'SKILL.md'), '# missing frontmatter'),
       writeFile(join(target, 'mcp-stale', 'SKILL.md'), 'stale'),
       writeFile(join(target, 'mcp-pubmed', 'SKILL.md'), 'bundled'),
+      writeFile(join(target, 'mcp-MySkill', 'SKILL.md'), 'user uppercase'),
+      writeFile(join(target, 'mcp-custom.v2', 'SKILL.md'), 'user punctuation'),
       writeFile(join(target, 'user-skill', 'SKILL.md'), 'user')
     ])
 
@@ -259,12 +263,18 @@ describe('syncMaterializedCustomServerSkillDocs', () => {
       'mcp-malformed',
       'mcp-missing'
     ])
-    expect((await readdir(target)).sort()).toEqual(['mcp-pubmed', 'mcp-xt', 'user-skill'])
+    expect((await readdir(target)).sort()).toEqual([
+      'mcp-MySkill',
+      'mcp-custom.v2',
+      'mcp-pubmed',
+      'mcp-xt',
+      'user-skill'
+    ])
     expect(await readFile(join(target, 'mcp-xt', 'SKILL.md'), 'utf8')).toBe(xtDoc)
     expect(await readFile(join(target, 'mcp-pubmed', 'SKILL.md'), 'utf8')).toBe('bundled')
   })
 
-  it('canonicalizes a stale case-variant without deleting the copied doc', async () => {
+  it('does not delete an unowned case-variant while publishing the canonical doc', async () => {
     const root = await mkdtemp(join(tmpdir(), 'custom-skill-copy-case-'))
     const source = join(root, 'source')
     const target = join(root, 'target')
@@ -282,7 +292,6 @@ describe('syncMaterializedCustomServerSkillDocs', () => {
     await syncMaterializedCustomServerSkillDocs(source, target, ['mcp-xt'])
 
     expect(await readFile(join(target, 'mcp-xt', 'SKILL.md'), 'utf8')).toBe(xtDoc)
-    const entries = await readdir(target)
-    expect(new Set(entries.map((entry) => entry.toLowerCase())).size).toBe(entries.length)
+    expect(await readdir(target)).toContain('mcp-XT')
   })
 })

--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -186,6 +186,26 @@ describe('syncCustomServerSkillDocs', () => {
     expect(new Set(folded).size).toBe(entries.length)
     expect(folded).toEqual(['mcp-chemistry'])
   })
+
+  it('fails closed without overwriting an unowned case-variant custom directory', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'custom-skill-case-conflict-'))
+    await mkdir(join(dir, 'mcp-XT'), { recursive: true })
+    await writeFile(join(dir, 'mcp-XT', 'SKILL.md'), 'unowned uppercase content')
+
+    const result = await syncCustomServerSkillDocs(
+      dir,
+      [makeServer({ slug: 'xt', name: 'XT' })],
+      async () => FAKE_TOOLS
+    )
+
+    expect(result.materializedSlugs).toEqual([])
+    expect(result.failures).toHaveLength(1)
+    const entries = await readdir(dir)
+    expect(entries).toEqual(['mcp-XT'])
+    expect(await readFile(join(dir, entries[0], 'SKILL.md'), 'utf8')).toBe(
+      'unowned uppercase content'
+    )
+  })
 })
 
 describe('bundled and custom skill-doc sync coexist', () => {
@@ -274,7 +294,7 @@ describe('syncMaterializedCustomServerSkillDocs', () => {
     expect(await readFile(join(target, 'mcp-pubmed', 'SKILL.md'), 'utf8')).toBe('bundled')
   })
 
-  it('does not delete an unowned case-variant while publishing the canonical doc', async () => {
+  it('fails closed without overwriting an unowned case-variant target directory', async () => {
     const root = await mkdtemp(join(tmpdir(), 'custom-skill-copy-case-'))
     const source = join(root, 'source')
     const target = join(root, 'target')
@@ -289,9 +309,12 @@ describe('syncMaterializedCustomServerSkillDocs', () => {
       writeFile(join(target, 'mcp-XT', 'SKILL.md'), 'stale')
     ])
 
-    await syncMaterializedCustomServerSkillDocs(source, target, ['mcp-xt'])
+    const result = await syncMaterializedCustomServerSkillDocs(source, target, ['mcp-xt'])
 
-    expect(await readFile(join(target, 'mcp-xt', 'SKILL.md'), 'utf8')).toBe(xtDoc)
-    expect(await readdir(target)).toContain('mcp-XT')
+    expect(result.materializedSkillNames).toEqual([])
+    expect(result.failures.map(({ skillName }) => skillName)).toEqual(['mcp-xt'])
+    const entries = await readdir(target)
+    expect(entries).toEqual(['mcp-XT'])
+    expect(await readFile(join(target, entries[0], 'SKILL.md'), 'utf8')).toBe('stale')
   })
 })

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -1,10 +1,15 @@
-import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { ALL_CONNECTOR_IDS } from './registry'
 import { renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
 import type { CustomSkillDocTool } from './skill-doc'
 import type { StoredCustomMcpServer } from '../settings/types'
-import { customConnectorSlug } from '../../shared/custom-connector'
+import {
+  customConnectorSkillName,
+  customConnectorSlug,
+  customConnectorSlugFromSkillName
+} from '../../shared/custom-connector'
+import { parseFrontmatter } from '../skills/frontmatter'
 
 // Whether an `mcp-<x>` directory's suffix names a bundled connector — CASE-INSENSITIVELY. This
 // matters for cleanup ownership: an older version could have left a case-variant dir like
@@ -67,6 +72,11 @@ export type CustomServerSkillSyncResult = {
   failures: Array<{ server: StoredCustomMcpServer; error: unknown }>
 }
 
+export type MaterializedCustomSkillDocSyncResult = {
+  materializedSkillNames: string[]
+  failures: Array<{ skillName: string; error: unknown }>
+}
+
 const isSafeCustomServerSlug = (slug: string): boolean =>
   /^[a-z0-9-]+$/.test(slug) && !ALL_CONNECTOR_IDS.includes(slug)
 
@@ -113,4 +123,88 @@ export async function syncCustomServerSkillDocs(
     }
   }
   return { materializedSlugs, failures }
+}
+
+// Copies only successfully generated custom Connector docs from the canonical app-owned Claude
+// Skill root into an isolated ACP runtime root. The projection-provided names are the authorization
+// boundary: stale custom dirs are removed, while bundled Connector dirs remain owned by
+// syncConnectorSkillDocs. Reading and writing the exact SKILL.md avoids copying arbitrary trees.
+export async function syncMaterializedCustomServerSkillDocs(
+  sourceSkillsDir: string,
+  targetSkillsDir: string,
+  skillNames: readonly string[]
+): Promise<MaterializedCustomSkillDocSyncResult> {
+  await mkdir(targetSkillsDir, { recursive: true })
+  const requested = [
+    ...new Set(
+      skillNames.filter((skillName) => {
+        const slug = customConnectorSlugFromSkillName(skillName)
+        return slug !== undefined && !namesBundledConnector(slug)
+      })
+    )
+  ]
+  const materializedSkillNames: string[] = []
+  const failures: MaterializedCustomSkillDocSyncResult['failures'] = []
+
+  for (const skillName of requested) {
+    const sourceFile = join(sourceSkillsDir, skillName, 'SKILL.md')
+    const targetDir = join(targetSkillsDir, skillName)
+    try {
+      const sourceMetadata = await lstat(sourceFile)
+      if (!sourceMetadata.isFile() || sourceMetadata.isSymbolicLink()) {
+        throw new Error('canonical custom Connector Skill doc is not a regular file')
+      }
+      const contents = await readFile(sourceFile, 'utf8')
+      const { fields } = parseFrontmatter(contents)
+      if (
+        fields.name !== skillName ||
+        fields.source !== 'connector' ||
+        !fields.description?.trim()
+      ) {
+        throw new Error('canonical custom Connector Skill doc has invalid frontmatter')
+      }
+
+      // Never write through a target symlink or a non-directory left by external modification.
+      const targetMetadata = await lstat(targetDir).catch(() => undefined)
+      if (targetMetadata && (!targetMetadata.isDirectory() || targetMetadata.isSymbolicLink())) {
+        await rm(targetDir, { recursive: true, force: true })
+      }
+      await mkdir(targetDir, { recursive: true })
+      const targetFile = join(targetDir, 'SKILL.md')
+      const targetFileMetadata = await lstat(targetFile).catch(() => undefined)
+      if (
+        targetFileMetadata &&
+        (!targetFileMetadata.isFile() || targetFileMetadata.isSymbolicLink())
+      ) {
+        await rm(targetFile, { recursive: true, force: true })
+      }
+      await writeFile(targetFile, contents, 'utf8')
+      materializedSkillNames.push(skillName)
+    } catch (error) {
+      failures.push({ skillName, error })
+      await rm(targetDir, { recursive: true, force: true })
+    }
+  }
+
+  const materialized = new Set(materializedSkillNames)
+  for (const entry of await readdir(targetSkillsDir).catch(() => [] as string[])) {
+    const match = /^mcp-(.+)$/.exec(entry)
+    if (!match || namesBundledConnector(match[1])) continue
+    const canonicalSkillName = customConnectorSkillName(match[1].toLowerCase())
+    if (!materialized.has(canonicalSkillName)) {
+      await rm(join(targetSkillsDir, entry), { recursive: true, force: true })
+      continue
+    }
+    if (entry !== canonicalSkillName) {
+      const [canonical, variant] = await Promise.all([
+        stat(join(targetSkillsDir, canonicalSkillName)).catch(() => null),
+        stat(join(targetSkillsDir, entry)).catch(() => null)
+      ])
+      const distinct =
+        canonical && variant && (canonical.dev !== variant.dev || canonical.ino !== variant.ino)
+      if (distinct) await rm(join(targetSkillsDir, entry), { recursive: true, force: true })
+    }
+  }
+
+  return { materializedSkillNames, failures }
 }

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -5,7 +5,6 @@ import { renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
 import type { CustomSkillDocTool } from './skill-doc'
 import type { StoredCustomMcpServer } from '../settings/types'
 import {
-  customConnectorSkillName,
   customConnectorSlug,
   customConnectorSlugFromSkillName
 } from '../../shared/custom-connector'
@@ -188,21 +187,10 @@ export async function syncMaterializedCustomServerSkillDocs(
 
   const materialized = new Set(materializedSkillNames)
   for (const entry of await readdir(targetSkillsDir).catch(() => [] as string[])) {
-    const match = /^mcp-(.+)$/.exec(entry)
-    if (!match || namesBundledConnector(match[1])) continue
-    const canonicalSkillName = customConnectorSkillName(match[1].toLowerCase())
-    if (!materialized.has(canonicalSkillName)) {
+    const slug = customConnectorSlugFromSkillName(entry)
+    if (!slug || namesBundledConnector(slug)) continue
+    if (!materialized.has(entry)) {
       await rm(join(targetSkillsDir, entry), { recursive: true, force: true })
-      continue
-    }
-    if (entry !== canonicalSkillName) {
-      const [canonical, variant] = await Promise.all([
-        stat(join(targetSkillsDir, canonicalSkillName)).catch(() => null),
-        stat(join(targetSkillsDir, entry)).catch(() => null)
-      ])
-      const distinct =
-        canonical && variant && (canonical.dev !== variant.dev || canonical.ino !== variant.ino)
-      if (distinct) await rm(join(targetSkillsDir, entry), { recursive: true, force: true })
     }
   }
 

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -19,6 +19,20 @@ import { parseFrontmatter } from '../skills/frontmatter'
 const namesBundledConnector = (dirId: string): boolean =>
   ALL_CONNECTOR_IDS.includes(dirId.toLowerCase())
 
+// Skill identities are lowercase ASCII, but APFS and NTFS commonly resolve paths without regard
+// to case. If an externally-owned case variant already exists, writing the canonical name would
+// overwrite that same directory on those filesystems. Detect the alias from the directory listing
+// so every platform preserves the same ownership boundary.
+const findCaseFoldedAlias = async (
+  parentDir: string,
+  canonicalName: string
+): Promise<string | undefined> => {
+  const foldedCanonicalName = canonicalName.toLowerCase()
+  return (await readdir(parentDir).catch(() => [] as string[])).find(
+    (entry) => entry !== canonicalName && entry.toLowerCase() === foldedCanonicalName
+  )
+}
+
 // Writes skills/mcp-<connector>/SKILL.md for enabled connectors; removes the directory for
 // disabled ones. Claude Code discovers skills as `<name>/SKILL.md` directories, not flat files.
 // Custom-server directories (see syncCustomServerSkillDocs below) live in the same skills dir;
@@ -95,7 +109,18 @@ export async function syncCustomServerSkillDocs(
   const materializedSlugs: string[] = []
   const failures: CustomServerSkillSyncResult['failures'] = []
   for (const { server, slug } of safeServers) {
-    const dir = join(skillsDir, `mcp-${slug}`)
+    const skillName = `mcp-${slug}`
+    const dir = join(skillsDir, skillName)
+    const caseFoldedAlias = await findCaseFoldedAlias(skillsDir, skillName)
+    if (caseFoldedAlias) {
+      failures.push({
+        server,
+        error: new Error(
+          `custom Connector Skill ${skillName} conflicts with existing case-variant ${caseFoldedAlias}`
+        )
+      })
+      continue
+    }
     let tools: CustomSkillDocTool[]
     try {
       tools = await listTools(server)
@@ -113,11 +138,12 @@ export async function syncCustomServerSkillDocs(
   const enabledSlugs = new Set(materializedSlugs)
   const existing = await readdir(skillsDir).catch(() => [] as string[])
   for (const entry of existing) {
-    const m = /^mcp-(.+)$/.exec(entry)
+    const slug = customConnectorSlugFromSkillName(entry)
     // A bundled-connector dir (case-insensitive) belongs to syncConnectorSkillDocs — never delete it
     // here, even a case-variant like mcp-Chemistry that the built-in sync has written its doc into.
-    if (!m || namesBundledConnector(m[1])) continue
-    if (!enabledSlugs.has(m[1])) {
+    // Invalid/non-canonical names are also unowned and must be preserved.
+    if (!slug || namesBundledConnector(slug)) continue
+    if (!enabledSlugs.has(slug)) {
       await rm(join(skillsDir, entry), { recursive: true, force: true })
     }
   }
@@ -148,6 +174,16 @@ export async function syncMaterializedCustomServerSkillDocs(
   for (const skillName of requested) {
     const sourceFile = join(sourceSkillsDir, skillName, 'SKILL.md')
     const targetDir = join(targetSkillsDir, skillName)
+    const caseFoldedAlias = await findCaseFoldedAlias(targetSkillsDir, skillName)
+    if (caseFoldedAlias) {
+      failures.push({
+        skillName,
+        error: new Error(
+          `custom Connector Skill ${skillName} conflicts with existing case-variant ${caseFoldedAlias}`
+        )
+      })
+      continue
+    }
     try {
       const sourceMetadata = await lstat(sourceFile)
       if (!sourceMetadata.isFile() || sourceMetadata.isSymbolicLink()) {

--- a/src/main/connectors/runtime-settings-projection.ts
+++ b/src/main/connectors/runtime-settings-projection.ts
@@ -6,7 +6,7 @@ import {
 } from './custom-mcp-bootstrap'
 import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './provision'
 import { ALL_CONNECTOR_IDS } from './registry'
-import { customConnectorSlug } from '../../shared/custom-connector'
+import { customConnectorSkillName, customConnectorSlug } from '../../shared/custom-connector'
 import type { McpClientManager } from './mcp-client-manager'
 import type { StoredConnectors } from '../settings/types'
 
@@ -99,7 +99,7 @@ class ConnectorRuntimeSettingsProjection {
         customServers,
         (server) => this.options.mcpClientManager.listTools(toCustomMcpConfig(server))
       )
-      this.materializedCustomSkills = customSync.materializedSlugs.map((slug) => `mcp-${slug}`)
+      this.materializedCustomSkills = customSync.materializedSlugs.map(customConnectorSkillName)
       this.discoveryAvailabilities = new Map(
         customSync.failures.map(({ server, error }) => [server.id, classifyCustomMcpFailure(error)])
       )

--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -98,7 +98,8 @@ describe('AgentRuntimeManager', () => {
     } as unknown as SkillCatalogModule
     const connectors = {
       getConnectors: vi.fn().mockResolvedValue(undefined),
-      enabledConnectorIds: vi.fn().mockReturnValue([])
+      enabledConnectorIds: vi.fn().mockReturnValue([]),
+      materializedCustomSkillNames: vi.fn().mockReturnValue([])
     } as unknown as ConnectorSettingsModule
 
     return new AgentRuntimeManager({
@@ -441,6 +442,33 @@ describe('AgentRuntimeManager', () => {
     expect(syncComputeSkillDocument).toHaveBeenCalledWith(
       join(getAppClaudeConfigDir(storageRoot), 'skills')
     )
+  })
+
+  it('synchronizes provisioned custom Connector docs into isolated agent Skill roots', async () => {
+    const customSkillName = 'mcp-xt'
+    const sourceDir = join(getAppClaudeConfigDir(storageRoot), 'skills', customSkillName)
+    await mkdir(sourceDir, { recursive: true })
+    await writeFile(
+      join(sourceDir, 'SKILL.md'),
+      '---\nname: mcp-xt\ndescription: Use XT records.\nsource: connector\n---\n\n# XT\n',
+      'utf8'
+    )
+    let materialized = [customSkillName]
+    const connectors = {
+      getConnectors: vi.fn().mockResolvedValue(undefined),
+      enabledConnectorIds: vi.fn().mockReturnValue([]),
+      materializedCustomSkillNames: vi.fn(() => materialized)
+    } as unknown as ConnectorSettingsModule
+    manager = createManager({ connectors })
+    const agentRoot = join(storageRoot, 'isolated-agent')
+    const targetFile = join(agentRoot, 'skills', customSkillName, 'SKILL.md')
+
+    await manager.materializeAgentSkills(await repository.getSettings(), agentRoot, new Set())
+    await expect(readFile(targetFile, 'utf8')).resolves.toContain('Use XT records.')
+
+    materialized = []
+    await manager.materializeAgentSkills(await repository.getSettings(), agentRoot, new Set())
+    await expect(readFile(targetFile, 'utf8')).rejects.toThrow()
   })
 
   it.each([

--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -463,11 +463,15 @@ describe('AgentRuntimeManager', () => {
     const agentRoot = join(storageRoot, 'isolated-agent')
     const targetFile = join(agentRoot, 'skills', customSkillName, 'SKILL.md')
 
-    await manager.materializeAgentSkills(await repository.getSettings(), agentRoot, new Set())
+    await expect(
+      manager.materializeAgentSkills(await repository.getSettings(), agentRoot, new Set())
+    ).resolves.toEqual([customSkillName])
     await expect(readFile(targetFile, 'utf8')).resolves.toContain('Use XT records.')
 
     materialized = []
-    await manager.materializeAgentSkills(await repository.getSettings(), agentRoot, new Set())
+    await expect(
+      manager.materializeAgentSkills(await repository.getSettings(), agentRoot, new Set())
+    ).resolves.toEqual([])
     await expect(readFile(targetFile, 'utf8')).rejects.toThrow()
   })
 

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -26,8 +26,12 @@ import {
   type AgentFrameworkId
 } from '../agent-framework'
 import type { AgentConfigFile } from '../agent-framework/types'
-import { syncConnectorSkillDocs } from '../connectors/provision'
+import {
+  syncConnectorSkillDocs,
+  syncMaterializedCustomServerSkillDocs
+} from '../connectors/provision'
 import { ComputeHostRepository } from '../compute/repository'
+import { createLogger } from '../logger'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { hasCanonicalComputeSkillDoc, syncComputeSkillDoc } from '../compute/skill-doc'
 import { writeAgentConfigFiles } from './agent-config-files'
@@ -84,6 +88,7 @@ import type { ConnectorSettingsModule } from './connector-settings'
 import type { StoredCodexInfo, StoredSettings } from './types'
 
 const execFileAsync = promisify(execFile)
+const log = createLogger('agent-runtime-manager')
 const CLAUDE_PROBE_TIMEOUT_MS = 20_000
 const CODEX_INSTALL_TARGET: InstallTarget = {
   npmPackage: '@agentclientprotocol/codex-acp',
@@ -611,6 +616,14 @@ export class AgentRuntimeManager {
       join(configRoot, 'skills'),
       this.connectors.enabledConnectorIds(connectors)
     )
+    const customSkillSync = await syncMaterializedCustomServerSkillDocs(
+      join(getAppClaudeConfigDir(this.storageRoot), 'skills'),
+      join(configRoot, 'skills'),
+      this.connectors.materializedCustomSkillNames()
+    )
+    for (const failure of customSkillSync.failures) {
+      log.warn('Failed to materialize custom Connector Skill doc', failure)
+    }
     await this.syncComputeSkillDocument(join(configRoot, 'skills'))
   }
 

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -609,13 +609,10 @@ export class AgentRuntimeManager {
     settings: StoredSettings,
     configRoot: string,
     forcedSkillIds: ReadonlySet<string>
-  ): Promise<void> {
+  ): Promise<string[]> {
     await this.skills.materializeSkills(configRoot, settings.disabledSkillIds ?? [], forcedSkillIds)
-    const connectors = await this.connectors.getConnectors()
-    await syncConnectorSkillDocs(
-      join(configRoot, 'skills'),
-      this.connectors.enabledConnectorIds(connectors)
-    )
+    const bundledIds = this.connectors.enabledConnectorIds(settings.connectors)
+    await syncConnectorSkillDocs(join(configRoot, 'skills'), bundledIds)
     const customSkillSync = await syncMaterializedCustomServerSkillDocs(
       join(getAppClaudeConfigDir(this.storageRoot), 'skills'),
       join(configRoot, 'skills'),
@@ -625,6 +622,7 @@ export class AgentRuntimeManager {
       log.warn('Failed to materialize custom Connector Skill doc', failure)
     }
     await this.syncComputeSkillDocument(join(configRoot, 'skills'))
+    return [...bundledIds.map((id) => `mcp-${id}`), ...customSkillSync.materializedSkillNames]
   }
 
   async materializeAgentConfigFiles(files: AgentConfigFile[] | undefined): Promise<void> {

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -244,8 +244,9 @@ const makeHarness = (options: HarnessOptions = {}) => {
     resolveCodexProxyEnvironment: vi.fn(async () => undefined)
   } satisfies AgentBackendRuntimePort
   const connectors = {
-    enabledConnectorIds: vi.fn(() => options.connectorIds ?? []),
-    provisionedConnectorSkillNames: vi.fn(async () => options.connectorSkillNames ?? [])
+    connectorSkillNames: vi.fn(
+      () => options.connectorSkillNames ?? (options.connectorIds ?? []).map((id) => `mcp-${id}`)
+    )
   } satisfies AgentBackendConnectorPort
 
   const responsesBridges: ResponsesBridgeDouble[] = []
@@ -344,8 +345,7 @@ describe('AgentBackendResolver construction and selection', () => {
     expect(harness.readFrameworkOverride).not.toHaveBeenCalled()
     expect(harness.resolveRuntimeTarget).not.toHaveBeenCalled()
     expect(harness.resolveRuntimeReasoningEffortProfile).not.toHaveBeenCalled()
-    expect(harness.connectors.enabledConnectorIds).not.toHaveBeenCalled()
-    expect(harness.connectors.provisionedConnectorSkillNames).not.toHaveBeenCalled()
+    expect(harness.connectors.connectorSkillNames).not.toHaveBeenCalled()
     expect(harness.createResponsesBridge).not.toHaveBeenCalled()
     expect(harness.createNativeResponsesProxy).not.toHaveBeenCalled()
     expect(harness.createAnthropicProviderBridge).not.toHaveBeenCalled()
@@ -1190,14 +1190,10 @@ describe('AgentBackendResolver bridge predicates', () => {
         : backend.persistentSystemPrompt
 
     expect(instructions).toContain(
-      testCase.frameworkId === 'claude-code'
-        ? 'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`, `mcp-custom-chemistry`.'
-        : 'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`.'
+      'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`, `mcp-custom-chemistry`.'
     )
     expect(instructions).toContain('Allowed Specialist Skills for this session')
-    if (testCase.frameworkId !== 'claude-code') {
-      expect(instructions).not.toContain('`mcp-custom-chemistry`')
-    }
+    expect(instructions).not.toContain('host.mcp("custom-chemistry"')
     expect(instructions).not.toContain('`mcp-openalex`')
     await backend.anthropicBridgeLease?.release()
     await backend.responsesBridgeLease?.release()

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -148,6 +148,7 @@ type HarnessOptions = {
   frameworkOverride?: string
   connectorIds?: string[]
   connectorSkillNames?: string[]
+  materializedConnectorSkillNames?: string[]
   rejectRequiredModels?: ReadonlySet<string>
   targetOverride?: (
     provider: StoredProvider,
@@ -236,7 +237,12 @@ const makeHarness = (options: HarnessOptions = {}) => {
     resolveCodexExecutable: vi.fn(async () => '/runtime/codex-acp'),
     probeCodexNativeVersion: vi.fn(async () => '0.144.6'),
     provisionClaudeRuntimeConfig: vi.fn(async () => '/storage/claude-config'),
-    materializeAgentSkills: vi.fn(async () => undefined),
+    materializeAgentSkills: vi.fn(
+      async () =>
+        options.materializedConnectorSkillNames ??
+        options.connectorSkillNames ??
+        (options.connectorIds ?? []).map((id) => `mcp-${id}`)
+    ),
     materializeAgentConfigFiles: vi.fn(async (files?: AgentConfigFile[]) => {
       void files
     }),
@@ -1199,6 +1205,45 @@ describe('AgentBackendResolver bridge predicates', () => {
     await backend.responsesBridgeLease?.release()
     await backend.providerTransportLease?.release()
   })
+
+  it.each([
+    { name: 'OpenCode', frameworkId: 'opencode' as const, target: {} },
+    {
+      name: 'Codex Responses',
+      frameworkId: 'codex' as const,
+      target: { provider: { apiEndpoints: ['responses'] as const } }
+    },
+    {
+      name: 'Codex bridge',
+      frameworkId: 'codex' as const,
+      target: {
+        needsChatResponsesBridge: true,
+        provider: { apiEndpoints: ['openai'] as const }
+      }
+    }
+  ])(
+    'does not advertise a custom Skill whose doc failed to materialize for $name',
+    async (testCase) => {
+      const harness = makeHarness({
+        connectorSkillNames: ['mcp-pubmed', 'mcp-xt'],
+        materializedConnectorSkillNames: ['mcp-pubmed'],
+        targetOverride: () => testCase.target
+      })
+
+      const backend = await harness.resolver.resolveExplicitTarget({
+        frameworkId: testCase.frameworkId,
+        providerId: 'provider-a',
+        model: { kind: 'provider-default' },
+        reasoningEffort: 'high'
+      })
+
+      expect(backend.persistentSystemPrompt).toContain('`mcp-pubmed`')
+      expect(backend.persistentSystemPrompt).not.toContain('`mcp-xt`')
+      await backend.anthropicBridgeLease?.release()
+      await backend.responsesBridgeLease?.release()
+      await backend.providerTransportLease?.release()
+    }
+  )
 
   it.each([
     { name: 'direct Responses', chat: false, native: false, apiEndpoints: ['responses'] as const },

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -79,10 +79,7 @@ export type AgentBackendProviderPort = Pick<
   'resolveRuntimeTarget' | 'resolveRuntimeModelCatalog' | 'resolveRuntimeReasoningEffortProfile'
 >
 
-export type AgentBackendConnectorPort = Pick<
-  ConnectorSettingsModule,
-  'enabledConnectorIds' | 'provisionedConnectorSkillNames'
->
+export type AgentBackendConnectorPort = Pick<ConnectorSettingsModule, 'connectorSkillNames'>
 
 export type AgentBackendResolverOptions = ProviderTransportOwnerOptions & {
   readSettings: () => Promise<StoredSettings>
@@ -269,10 +266,7 @@ export class AgentBackendResolver {
       )
     }
     const forcedSkillIds = new Set(context.forcedSkillIds ?? [])
-    const connectorSkillNames =
-      framework.id === 'claude-code'
-        ? await this.connectors.provisionedConnectorSkillNames()
-        : this.connectors.enabledConnectorIds(settings.connectors).map((id) => `mcp-${id}`)
+    const connectorSkillNames = this.connectors.connectorSkillNames(settings.connectors)
     const connectorInstructions = renderConnectorInstructions(connectorSkillNames)
     const executablePath =
       framework.id === 'claude-code'

--- a/src/main/settings/backend-resolver.ts
+++ b/src/main/settings/backend-resolver.ts
@@ -266,8 +266,10 @@ export class AgentBackendResolver {
       )
     }
     const forcedSkillIds = new Set(context.forcedSkillIds ?? [])
-    const connectorSkillNames = this.connectors.connectorSkillNames(settings.connectors)
-    const connectorInstructions = renderConnectorInstructions(connectorSkillNames)
+    let connectorInstructions =
+      framework.id === 'claude-code'
+        ? renderConnectorInstructions(this.connectors.connectorSkillNames(settings.connectors))
+        : ''
     const executablePath =
       framework.id === 'claude-code'
         ? await this.runtime.resolveClaudeExecutable(settings.claude?.resolvedPath)
@@ -342,7 +344,12 @@ export class AgentBackendResolver {
           ? codexSubscriptionStorageDir(this.storageRoot)
           : codexStorageDir(this.storageRoot)
         : opencodeConfigDir(this.storageRoot)
-    await this.runtime.materializeAgentSkills(settings, skillsRoot, forcedSkillIds)
+    const materializedConnectorSkillNames = await this.runtime.materializeAgentSkills(
+      settings,
+      skillsRoot,
+      forcedSkillIds
+    )
+    connectorInstructions = renderConnectorInstructions(materializedConnectorSkillNames)
 
     const transport = await this.transports.acquire({ activeTarget: target, plan })
     const provider = transport.provider ?? target.provider

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -169,7 +169,7 @@ describe('ConnectorSettingsModule', () => {
     expect(afterRemoval?.askToolIds ?? []).not.toContain(`${added.slug}/lookup`)
   })
 
-  it('advertises custom Connector Skills only from the successful materialization projection', async () => {
+  it('advertises only safe custom Connector Skills from the successful materialization projection', async () => {
     await service.addCustomServer({
       name: 'custom-catalog',
       transport: 'stdio',
@@ -179,12 +179,36 @@ describe('ConnectorSettingsModule', () => {
     expect(await service.provisionedConnectorSkillNames()).not.toContain('mcp-custom-catalog')
 
     service.setCustomServerRuntimeProjectionProvider({
-      materializedSkillNames: () => ['mcp-custom-catalog'],
+      materializedSkillNames: () => [
+        'mcp-custom-catalog',
+        'mcp-custom-catalog',
+        'mcp-second',
+        'mcp-pubmed',
+        'mcp-../../escape',
+        'mcp-UPPER'
+      ],
       availability: () => undefined,
       isRefreshing: () => false
     })
 
     expect(await service.provisionedConnectorSkillNames()).toContain('mcp-custom-catalog')
+    expect(
+      service.connectorSkillNames({
+        enabledIds: [],
+        autoAllowIds: [],
+        disabledConnectorIds: [...ALL_CONNECTOR_IDS]
+      })
+    ).toEqual(['mcp-custom-catalog', 'mcp-second'])
+    expect(
+      service.connectorSkillCatalogEntries({
+        enabledIds: [],
+        autoAllowIds: [],
+        disabledConnectorIds: [...ALL_CONNECTOR_IDS]
+      })
+    ).toEqual([
+      { directory: 'mcp-custom-catalog', name: 'mcp-custom-catalog', source: 'connector' },
+      { directory: 'mcp-second', name: 'mcp-second', source: 'connector' }
+    ])
   })
 
   it('projects runtime availability separately from logical enablement', async () => {

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -23,6 +23,7 @@ import {
   customConnectorAliasKey,
   customConnectorAliases,
   customConnectorSlug,
+  customConnectorSlugFromSkillName,
   isCustomConnectorSlug,
   toCustomConnectorSlug
 } from '../../shared/custom-connector'
@@ -80,6 +81,46 @@ class ConnectorSettingsModule {
     return CONNECTOR_CATALOG.map((meta) => meta.id).filter((id) => !disabled.has(id))
   }
 
+  materializedCustomSkillNames(): string[] {
+    const bundled = new Set(CONNECTOR_CATALOG.map((connector) => connector.id))
+    return [
+      ...new Set(
+        this.customServerRuntimeProjectionProvider.materializedSkillNames().filter((skillName) => {
+          const slug = customConnectorSlugFromSkillName(skillName)
+          return slug !== undefined && !bundled.has(slug)
+        })
+      )
+    ]
+  }
+
+  connectorSkillNames(connectors: StoredConnectors | undefined): string[] {
+    const bundled = this.enabledConnectorIds(connectors).map((id) => `mcp-${id}`)
+    return [...new Set([...bundled, ...this.materializedCustomSkillNames()])]
+  }
+
+  connectorSkillCatalogEntries(connectors: StoredConnectors | undefined): Array<{
+    directory: string
+    name: string
+    description?: string
+    source: 'connector'
+  }> {
+    const bundled = this.enabledConnectorIds(connectors).map((id) => {
+      const connector = CONNECTOR_CATALOG.find((candidate) => candidate.id === id)!
+      return {
+        directory: `mcp-${id}`,
+        name: `mcp-${id}`,
+        description: connector.useWhen,
+        source: 'connector' as const
+      }
+    })
+    const custom = this.materializedCustomSkillNames().map((name) => ({
+      directory: name,
+      name,
+      source: 'connector' as const
+    }))
+    return [...bundled, ...custom]
+  }
+
   // Called from SettingsService's existing whole-settings migration path so the trigger timing and
   // provider-before-Connector ordering stay unchanged while Connector migration has one owner.
   async migrateLegacyNcbiKeyRef(connectors: StoredConnectors | undefined): Promise<boolean> {
@@ -130,10 +171,7 @@ class ConnectorSettingsModule {
 
   async provisionedConnectorSkillNames(): Promise<string[]> {
     const connectors = await this.getConnectors()
-    const bundled = this.enabledConnectorIds(connectors).map((id) => `mcp-${id}`)
-    return Array.from(
-      new Set([...bundled, ...this.customServerRuntimeProjectionProvider.materializedSkillNames()])
-    )
+    return this.connectorSkillNames(connectors)
   }
 
   async listConnectors(): Promise<ConnectorsSnapshot> {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1173,6 +1173,20 @@ describe('SettingsService: providers', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
 
+    const customSkillName = 'mcp-xt'
+    const customSkillSource = join(getAppClaudeConfigDir(storageRoot), 'skills', customSkillName)
+    await mkdir(customSkillSource, { recursive: true })
+    await writeFile(
+      join(customSkillSource, 'SKILL.md'),
+      '---\nname: mcp-xt\ndescription: "Use XT records."\nsource: connector\n---\n\n# XT\n',
+      'utf8'
+    )
+    service.setCustomServerRuntimeProjectionProvider({
+      materializedSkillNames: () => [customSkillName],
+      availability: () => undefined,
+      isRefreshing: () => false
+    })
+
     const backend = await resolveActiveBackend(service, {
       systemPromptAppends: ['Stable Open Science app guidance.']
     })
@@ -1192,6 +1206,9 @@ describe('SettingsService: providers', () => {
     expect(baseline).toContain('mcp-*')
     expect(baseline).toContain('Load the matching `mcp-*` skill before the first `host.mcp` call')
     expect(baseline).toContain('Never guess a connector server or method name')
+    expect(baseline).toContain('`mcp-xt`')
+    expect(baseline).not.toContain('Use XT records.')
+    expect(baseline).not.toContain('host.mcp("xt"')
     expect(baseline).not.toContain('pubchem_get_compounds')
     expect(baseline).not.toContain('search_articles')
     expect(baseline).not.toContain('```json')
@@ -1204,6 +1221,12 @@ describe('SettingsService: providers', () => {
     expect(chemistrySkill).toContain('pubchem_get_compounds')
     expect(chemistrySkill).toContain('**Input:**')
     expect(chemistrySkill).not.toContain('```json')
+    await expect(
+      readFile(
+        join(storageRoot, 'opencode', 'config', 'opencode', 'skills', customSkillName, 'SKILL.md'),
+        'utf8'
+      )
+    ).resolves.toContain('Use XT records.')
   })
 
   it('rejects an invalid custom context window when IPC bypasses the form', async () => {
@@ -3881,6 +3904,20 @@ describe('SettingsService: skills', () => {
     ).providers[0]
     await service.setActiveProvider(provider.id)
 
+    const customSkillName = 'mcp-xt'
+    const customSkillSource = join(getAppClaudeConfigDir(storageRoot), 'skills', customSkillName)
+    await mkdir(customSkillSource, { recursive: true })
+    await writeFile(
+      join(customSkillSource, 'SKILL.md'),
+      '---\nname: mcp-xt\ndescription: "Use XT records."\nsource: connector\n---\n\n# XT\n',
+      'utf8'
+    )
+    service.setCustomServerRuntimeProjectionProvider({
+      materializedSkillNames: () => [customSkillName],
+      availability: () => undefined,
+      isRefreshing: () => false
+    })
+
     await resolveActiveBackend(service)
 
     const materializedDir = join(storageRoot, 'codex', 'skills', 'os-demo')
@@ -3890,10 +3927,19 @@ describe('SettingsService: skills', () => {
       await expect(
         service.codexSkillDescriptorsForIds(['demo', 'missing'], join(storageRoot, 'codex'))
       ).resolves.toEqual([{ name: 'demo', path: materializedFile }])
+      await expect(
+        readFile(join(storageRoot, 'codex', 'skills', customSkillName, 'SKILL.md'), 'utf8')
+      ).resolves.toContain('Use XT records.')
       const selectorCatalog = await service.codexSkillCatalog(join(storageRoot, 'codex'))
       expect(selectorCatalog).toEqual(
         expect.arrayContaining([
           { name: 'demo', description: 'A demo skill.', path: materializedFile },
+          {
+            name: customSkillName,
+            description: 'Use XT records.',
+            path: join(storageRoot, 'codex', 'skills', customSkillName, 'SKILL.md'),
+            source: 'connector'
+          },
           expect.objectContaining({
             name: 'mcp-pubmed',
             description: expect.stringContaining('biomedical literature'),
@@ -3956,7 +4002,7 @@ describe('SettingsService: skills', () => {
     expect(getSettings).toHaveBeenCalledTimes(1)
   })
 
-  it('migrates legacy shared Codex skills into the app-owned subscription home only', async () => {
+  it('materializes ordinary and custom Connector Skills into the subscription home only', async () => {
     const adapterPath = join(storageRoot, 'bin', 'codex-acp')
     await mkdir(dirname(adapterPath), { recursive: true })
     await writeFile(adapterPath, MANAGED_CODEX_ADAPTER_FIXTURE, 'utf8')
@@ -3984,6 +4030,19 @@ describe('SettingsService: skills', () => {
       nativeVersion: '0.144.6'
     })
     await repository.setAgentFramework('codex')
+    const customSkillName = 'mcp-xt'
+    const customSkillSource = join(getAppClaudeConfigDir(storageRoot), 'skills', customSkillName)
+    await mkdir(customSkillSource, { recursive: true })
+    await writeFile(
+      join(customSkillSource, 'SKILL.md'),
+      '---\nname: mcp-xt\ndescription: Use XT records.\nsource: connector\n---\n\n# XT\n',
+      'utf8'
+    )
+    service.setCustomServerRuntimeProjectionProvider({
+      materializedSkillNames: () => [customSkillName],
+      availability: () => undefined,
+      isRefreshing: () => false
+    })
     await repository.upsertProvider({
       id: CODEX_SHARED_PROVIDER_ID,
       type: 'codex-shared',
@@ -4002,7 +4061,16 @@ describe('SettingsService: skills', () => {
       )
     ).toContain('demo body')
     await expect(
+      readFile(
+        join(storageRoot, 'codex-subscription', 'skills', customSkillName, 'SKILL.md'),
+        'utf8'
+      )
+    ).resolves.toContain('Use XT records.')
+    await expect(
       readFile(join(storageRoot, 'workspace', '.agents', 'skills', 'os-demo', 'SKILL.md'), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(
+      readFile(join(storageRoot, 'codex', 'skills', customSkillName, 'SKILL.md'), 'utf8')
     ).rejects.toMatchObject({ code: 'ENOENT' })
     await chmod(join(storageRoot, 'codex-subscription', 'skills', 'os-demo', 'SKILL.md'), 0o644)
     await chmod(join(storageRoot, 'codex-subscription', 'skills', 'os-demo'), 0o755)

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -92,7 +92,6 @@ import {
   type AgentBackendSelection,
   type ExplicitAgentBackendTarget
 } from './backend-resolver'
-import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
 import { UserSkillRepository } from '../skills/user-skill-repository'
 import type { SkillExportArchive } from '../skills/export'
@@ -546,21 +545,9 @@ class SettingsService {
   async codexSkillCatalog(
     codexHome: string | undefined
   ): Promise<Array<{ name: string; description: string; path: string; source?: 'connector' }>> {
-    return this.skills.codexSkillCatalog(codexHome, (settings) => {
-      return this.connectors.enabledConnectorIds(settings.connectors).flatMap((id) => {
-        const connector = CONNECTOR_CATALOG.find((candidate) => candidate.id === id)
-        return connector
-          ? [
-              {
-                directory: `mcp-${id}`,
-                name: `mcp-${id}`,
-                description: connector.useWhen,
-                source: 'connector' as const
-              }
-            ]
-          : []
-      })
-    })
+    return this.skills.codexSkillCatalog(codexHome, (settings) =>
+      this.connectors.connectorSkillCatalogEntries(settings.connectors)
+    )
   }
 
   // Returns one skill's view plus its SKILL.md body for the detail view (any source).

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -272,6 +272,54 @@ describe('SkillCatalogModule', () => {
     ).toEqual(['demo'])
   })
 
+  it('reads authorized Connector descriptions from generated frontmatter and rejects invalid docs', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'settings-connector-catalog-'))
+    const bundleRoot = await mkdtemp(join(tmpdir(), 'settings-connector-bundle-'))
+    roots.push(storageRoot, bundleRoot)
+    await writeFile(join(bundleRoot, 'manifest.json'), JSON.stringify({ version: 1, skills: [] }))
+    const skillsRoot = join(storageRoot, 'codex', 'skills')
+    const docs = new Map([
+      [
+        'mcp-xt',
+        '---\nname: mcp-xt\ndescription: Use XT records.\nsource: connector\n---\n\n# XT\n'
+      ],
+      [
+        'mcp-wrong-name',
+        '---\nname: mcp-another\ndescription: Wrong identity.\nsource: connector\n---\n'
+      ],
+      ['mcp-missing-description', '---\nname: mcp-missing-description\nsource: connector\n---\n'],
+      [
+        'mcp-wrong-source',
+        '---\nname: mcp-wrong-source\ndescription: Wrong source.\nsource: featured\n---\n'
+      ]
+    ])
+    await Promise.all(
+      [...docs].map(async ([name, contents]) => {
+        await mkdir(join(skillsRoot, name), { recursive: true })
+        await writeFile(join(skillsRoot, name, 'SKILL.md'), contents)
+      })
+    )
+    const catalog = new SkillCatalogModule({
+      repository: new SettingsRepository(storageRoot),
+      storageRoot,
+      skillRegistry: new SkillRegistry(bundleRoot)
+    })
+
+    await expect(
+      catalog.codexSkillCatalog(
+        join(storageRoot, 'codex'),
+        [...docs.keys()].map((name) => ({ directory: name, name, source: 'connector' as const }))
+      )
+    ).resolves.toEqual([
+      {
+        name: 'mcp-xt',
+        description: 'Use XT records.',
+        path: join(skillsRoot, 'mcp-xt', 'SKILL.md'),
+        source: 'connector'
+      }
+    ])
+  })
+
   it('exports a personal Skill as a portable ZIP archive', async () => {
     const catalog = await createCatalog()
     await catalog.createSkill({

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -1,6 +1,6 @@
 import { readdir, realpath } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type {
   AgentHomeSkillRef,
@@ -60,7 +60,10 @@ type SkillCatalogEntry = {
   path: string
   source?: 'connector'
 }
-type AdditionalSkillCatalogEntry = Omit<SkillCatalogEntry, 'path'> & { directory: string }
+type AdditionalSkillCatalogEntry = Omit<SkillCatalogEntry, 'path' | 'description'> & {
+  directory: string
+  description?: string
+}
 type AdditionalSkillCatalogEntries =
   | readonly AdditionalSkillCatalogEntry[]
   | ((
@@ -287,9 +290,22 @@ class SkillCatalogModule {
       const filePath = join(skillsRoot, item.directory, 'SKILL.md')
       const realFile = await realpath(filePath).catch(() => undefined)
       if (!realFile || !realFile.startsWith(rootWithSep)) continue
+      let description = item.description?.trim()
+      if (!description) {
+        const parsed = await readSkillFile(dirname(realFile)).catch(() => undefined)
+        if (
+          !parsed ||
+          parsed.fields.name !== item.name ||
+          (item.source !== undefined && parsed.fields.source !== item.source)
+        ) {
+          continue
+        }
+        description = parsed.fields.description?.trim()
+      }
+      if (!description) continue
       result.push({
         name: item.name,
-        description: item.description,
+        description,
         path: filePath,
         ...(item.source ? { source: item.source } : {})
       })

--- a/src/shared/custom-connector.ts
+++ b/src/shared/custom-connector.ts
@@ -11,6 +11,14 @@ export const toCustomConnectorSlug = (name: string): string =>
 export const isCustomConnectorSlug = (value: string): boolean =>
   value.length <= CUSTOM_CONNECTOR_SLUG_MAX_LENGTH && CUSTOM_CONNECTOR_SLUG_PATTERN.test(value)
 
+export const customConnectorSkillName = (slug: string): string => `mcp-${slug}`
+
+export const customConnectorSlugFromSkillName = (name: string): string | undefined => {
+  if (!name.startsWith('mcp-')) return undefined
+  const slug = name.slice('mcp-'.length)
+  return isCustomConnectorSlug(slug) ? slug : undefined
+}
+
 export const customConnectorSlug = (server: { name: string; slug?: string }): string =>
   server.slug && isCustomConnectorSlug(server.slug)
     ? server.slug


### PR DESCRIPTION
## Problem

Custom connector `SKILL.md` files were generated only in the app-owned Claude Code skills root. OpenCode and Codex runtimes use isolated skills roots, so they could receive generic connector instructions without being able to read the generated custom connector documentation. Codex Bridge also built its selector catalog from bundled connectors only.

This made OAuth-backed and other custom connectors appear configured while their generated tool contract was absent from Codex/OpenCode context. OAuth itself was not the root cause: successful authentication and `listTools()` already gate generation of the canonical document.

## Proposed change

- Treat the successfully generated app-owned custom connector document as the canonical source.
- Copy only projection-authorized, validated `SKILL.md` files into non-Claude isolated runtime roots.
- Render non-Claude connector guidance from the set that was actually copied, so missing, malformed, symlinked, or conflicting documents fail closed.
- Add successfully materialized custom connector entries to the Codex Bridge catalog using their validated frontmatter descriptions.
- Remove stale canonical custom connector documents while preserving bundled, ordinary, invalid/unowned, symlinked, and case-folded alias directories.
- Share custom connector skill-name parsing between projection, materialization, and catalog code.

| ACP/runtime path | Custom connector context behavior |
| --- | --- |
| Claude Code | Reads the canonical generated document from the app-owned Claude skills root. |
| OpenCode | Receives the validated document in its isolated OpenCode skills root. |
| Codex Responses | Receives the validated document in the selected standard or subscription `CODEX_HOME`. |
| Codex Bridge | Receives the document in the isolated root and exposes a selector catalog entry from validated frontmatter. |

## Scope and non-goals

- No ACP wire-format, persistence, OAuth, or Settings UI changes.
- No second MCP connection during agent spawn.
- No connector-specific `host.mcp("xt", ...)` call is added to baseline instructions; the generated connector skill remains the source of the concrete tool contract.
- No change to bundled connector documentation ownership.

## Acceptance criteria and validation

All checks below ran after the last material edit and after rebasing onto the latest `origin/main`.

- Full fallback: `npm test -- --maxWorkers=4` — 927 files passed, 15 skipped; 13,359 tests passed, 193 skipped; 0 failed.
- Connector/ACP impact set: 8 files passed; 373 tests passed. This covers generation lifecycle, isolated-root copy/cleanup, OpenCode, Codex Responses, Codex Bridge, subscription roots, catalog frontmatter, fail-closed behavior, and case-folded path conflicts.
- Type contracts: `npm run typecheck` — node and web passed.
- Changed-file standards: ESLint on all modified TypeScript files — passed; `git diff --check` — passed.
- Independent review: Standards and Spec reviews completed; two fail-closed/ownership findings and one cross-platform case-folding finding were fixed, and both final re-reviews reported no remaining findings.

Uncovered risk: tests use deterministic connector/tool-discovery fakes rather than a live OAuth provider. The production OAuth and `listTools()` gate is unchanged; failures intentionally omit the document and catalog/instruction entry.

## Review focus

- Whether the projection-provided materialized names are the correct authorization boundary for copying generated custom connector docs.
- Whether non-Claude guidance and the Codex catalog consistently use only documents that were actually copied and validated.
- Whether stale cleanup and case-folded alias handling preserve directories owned by bundled connectors, ordinary skills, or external/user state.
