### PR TITLE
fix(database): preserve pre-migration recovery

### DIFF
--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -1,0 +1,174 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { formatLine, type Logger } from '../logger'
+import { createProjectDbClient } from '../projects/prisma-client'
+import { createDatabaseStartupLogging } from './database-startup-logging'
+import { DatabaseValidationError } from './database-validation-error'
+import { DatabaseMigrationError, migrateApplicationDatabase } from './migration-service'
+
+describe('database startup logging', () => {
+  let storageRoot: string | undefined
+  let client: PrismaClient | undefined
+
+  afterEach(async () => {
+    await client?.$disconnect()
+    if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
+  })
+
+  const createLog = (): {
+    log: Logger
+    records: Array<{ level: string; message: string; data?: unknown }>
+  } => {
+    const records: Array<{ level: string; message: string; data?: unknown }> = []
+    const write =
+      (level: string) =>
+      (message: string, data?: unknown): void => {
+        records.push({ level, message, data })
+      }
+    return {
+      log: {
+        debug: write('debug'),
+        info: write('info'),
+        warn: write('warn'),
+        error: write('error')
+      },
+      records
+    }
+  }
+
+  it('records the migration lifecycle through the production logging adapter', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-startup-log-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "Project" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "name" TEXT NOT NULL,
+      "description" TEXT NOT NULL DEFAULT '',
+      "isExample" BOOLEAN NOT NULL DEFAULT false,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL
+    )`)
+    const { log, records } = createLog()
+    const progress = vi.fn()
+
+    await migrateApplicationDatabase(client, {
+      ...createDatabaseStartupLogging(log, '0.13.0').migrationOptions(progress),
+      databasePath
+    })
+
+    expect(progress).toHaveBeenCalledWith({ phase: 'checking' })
+    expect(progress).toHaveBeenCalledWith({
+      phase: 'migrating',
+      migrationId: '0001_runtime_schema_baseline'
+    })
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ level: 'info', message: 'database migration checking' }),
+        expect.objectContaining({
+          level: 'info',
+          message: 'database migration started',
+          data: { migrationId: '0001_runtime_schema_baseline' }
+        }),
+        expect.objectContaining({
+          level: 'info',
+          message: 'database pre-migration backup ready',
+          data: expect.objectContaining({ migrationId: '0001_runtime_schema_baseline' })
+        }),
+        expect.objectContaining({
+          level: 'info',
+          message: 'database migration completed',
+          data: expect.objectContaining({
+            applied: ['0001_runtime_schema_baseline'],
+            adoptedLegacy: true
+          })
+        })
+      ])
+    )
+  })
+
+  it('records structured validation details through the mandatory redactor', () => {
+    const sensitiveValue = 'customer-secret-value'
+    const cause = new DatabaseValidationError('Schema mismatch.', {
+      kind: 'test-mismatch',
+      table: 'Project',
+      actual: { password: sensitiveValue },
+      expected: { type: 'TEXT' }
+    })
+    const error = new DatabaseMigrationError(
+      'database_validation_failed',
+      'The existing database does not satisfy the required schema contract.',
+      false,
+      '0001_runtime_schema_baseline',
+      { cause }
+    )
+    const { log, records } = createLog()
+
+    createDatabaseStartupLogging(log, '0.13.0').reportBlocked(error)
+
+    const record = records[0]!
+    const line = formatLine('error', 'main', record.message, record.data)
+    expect(line).not.toContain(sensitiveValue)
+    expect(JSON.parse(line)).toMatchObject({
+      level: 'error',
+      msg: 'database startup blocked',
+      data: {
+        appVersion: '0.13.0',
+        code: 'database_validation_failed',
+        details: {
+          cause: {
+            data: {
+              kind: 'test-mismatch',
+              actual: { password: '[redacted]' }
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it('records non-blocking backup retirement failures', () => {
+    const { log, records } = createLog()
+    const options = createDatabaseStartupLogging(log, '0.13.0').migrationOptions(vi.fn())
+    options.onBackupRetirementFailed?.({
+      migrationId: '0001_runtime_schema_baseline',
+      path: '/data/open-science.db.before-0001_runtime_schema_baseline.backup',
+      error: Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    })
+
+    expect(records).toEqual([
+      expect.objectContaining({
+        level: 'warn',
+        message: 'database migration backup retirement failed',
+        data: expect.objectContaining({
+          migrationId: '0001_runtime_schema_baseline',
+          code: 'EACCES',
+          error: 'permission denied'
+        })
+      })
+    ])
+  })
+
+  it('records successful backup retirement', () => {
+    const { log, records } = createLog()
+    const options = createDatabaseStartupLogging(log, '0.13.0').migrationOptions(vi.fn())
+    const path = '/data/open-science.db.before-0001_runtime_schema_baseline.backup'
+
+    options.onBackupRetired?.({ migrationId: '0001_runtime_schema_baseline', path })
+
+    expect(records).toEqual([
+      {
+        level: 'info',
+        message: 'database migration backup retired',
+        data: {
+          migrationId: '0001_runtime_schema_baseline',
+          backupPath: path
+        }
+      }
+    ])
+  })
+})

--- a/src/main/database/database-startup-logging.ts
+++ b/src/main/database/database-startup-logging.ts
@@ -1,0 +1,62 @@
+import { errorLogFields, type Logger } from '../logger'
+import {
+  type DatabaseMigrationError,
+  type SchemaMigrationOptions,
+  type SchemaMigrationProgress
+} from './migration-service'
+
+type DatabaseStartupLogging = {
+  reportBlocked: (error: DatabaseMigrationError) => void
+  migrationOptions: (
+    forwardProgress: (progress: SchemaMigrationProgress) => void
+  ) => SchemaMigrationOptions
+}
+
+const createDatabaseStartupLogging = (log: Logger, appVersion: string): DatabaseStartupLogging => ({
+  reportBlocked: (error) => {
+    log.error('database startup blocked', {
+      appVersion,
+      code: error.code,
+      migrationId: error.migrationId ?? null,
+      retryable: error.retryable,
+      details: errorLogFields(error)
+    })
+  },
+  migrationOptions: (forwardProgress) => ({
+    onProgress: (progress) => {
+      log.info(
+        progress.phase === 'checking'
+          ? 'database migration checking'
+          : 'database migration started',
+        progress.phase === 'migrating' ? { migrationId: progress.migrationId } : undefined
+      )
+      forwardProgress(progress)
+    },
+    onCompatibilityVerified: ({ sqliteVersion }) => {
+      log.info(`database runtime verified: sqlite_version=${sqliteVersion}`)
+    },
+    onBackupReady: ({ migrationId, path, reused }) => {
+      log.info('database pre-migration backup ready', {
+        migrationId,
+        backupPath: path,
+        reused
+      })
+    },
+    onBackupRetired: ({ migrationId, path }) => {
+      log.info('database migration backup retired', { migrationId, backupPath: path })
+    },
+    onBackupRetirementFailed: ({ migrationId, path, error }) => {
+      log.warn('database migration backup retirement failed', {
+        migrationId,
+        backupPath: path ?? null,
+        ...errorLogFields(error)
+      })
+    },
+    onCompleted: ({ from, to, applied, adoptedLegacy }) => {
+      log.info('database migration completed', { from, to, applied, adoptedLegacy })
+    }
+  })
+})
+
+export { createDatabaseStartupLogging }
+export type { DatabaseStartupLogging }

--- a/src/main/database/database-validation-error.ts
+++ b/src/main/database/database-validation-error.ts
@@ -1,0 +1,35 @@
+import { createHash } from 'node:crypto'
+
+type DatabaseValidationDiagnostic = {
+  kind: string
+  table?: string
+  column?: string
+  constraint?: string
+  expected?: unknown
+  actual?: unknown
+}
+
+type DatabaseValueSummary = { type: 'null' } | { type: 'string'; length: number; sha256: string }
+
+const summarizeDatabaseValue = (value: string | null): DatabaseValueSummary =>
+  value === null
+    ? { type: 'null' }
+    : {
+        type: 'string',
+        length: value.length,
+        sha256: createHash('sha256').update(value, 'utf8').digest('hex')
+      }
+
+class DatabaseValidationError extends Error {
+  readonly name = 'DatabaseValidationError'
+
+  constructor(
+    message: string,
+    readonly data: DatabaseValidationDiagnostic
+  ) {
+    super(message)
+  }
+}
+
+export { DatabaseValidationError, summarizeDatabaseValue }
+export type { DatabaseValidationDiagnostic, DatabaseValueSummary }

--- a/src/main/database/legacy-baseline-adapter.ts
+++ b/src/main/database/legacy-baseline-adapter.ts
@@ -18,6 +18,7 @@ import {
   findPendingSqliteCheckConstraints,
   type SqliteCheckConstraintMigration
 } from './sqlite-schema-migrations'
+import { DatabaseValidationError } from './database-validation-error'
 import { migrationSqlExecutor } from './migration-sql-executor'
 
 // schema-locality: begin frozen-0001-repairs
@@ -427,8 +428,9 @@ const classifyLegacySchema = async (client: PrismaClient): Promise<void> => {
      ORDER BY "type", "name"`
   )
   if (unsupportedObjects.length > 0) {
-    throw new Error(
-      `Legacy database classification blocked: unsupported schema objects ${unsupportedObjects.map(({ type, name }) => `${type} ${name}`).join(', ')}.`
+    throw new DatabaseValidationError(
+      `Legacy database classification blocked by unsupported schema objects.`,
+      { kind: 'unsupported-schema-objects', actual: unsupportedObjects }
     )
   }
 
@@ -444,9 +446,10 @@ const classifyLegacySchema = async (client: PrismaClient): Promise<void> => {
     .map((table) => table.name)
     .filter((tableName) => !CURRENT_TABLE_COLUMNS.has(tableName))
   if (unknownTables.length > 0) {
-    throw new Error(
-      `Legacy database classification blocked: unknown tables ${unknownTables.join(', ')}.`
-    )
+    throw new DatabaseValidationError(`Legacy database classification found unknown tables.`, {
+      kind: 'unknown-tables',
+      actual: unknownTables
+    })
   }
 
   for (const { name: tableName } of tables) {
@@ -463,8 +466,9 @@ const classifyLegacySchema = async (client: PrismaClient): Promise<void> => {
       .map((column) => column.name)
       .filter((columnName) => !allowedColumns.has(columnName))
     if (unknownColumns.length > 0) {
-      throw new Error(
-        `Legacy database classification blocked: ${tableName} contains unknown columns ${unknownColumns.join(', ')}.`
+      throw new DatabaseValidationError(
+        `Legacy database classification found unknown columns in ${tableName}.`,
+        { kind: 'unknown-columns', table: tableName, actual: unknownColumns }
       )
     }
   }
@@ -479,11 +483,27 @@ const classifyLegacySchema = async (client: PrismaClient): Promise<void> => {
     .map((index) => index.name)
     .filter((indexName) => !TARGET_INDEX_NAMES.has(indexName))
   if (unknownIndexes.length > 0) {
-    throw new Error(
-      `Legacy database classification blocked: unknown indexes ${unknownIndexes.join(', ')}.`
-    )
+    throw new DatabaseValidationError(`Legacy database classification found unknown indexes.`, {
+      kind: 'unknown-indexes',
+      actual: unknownIndexes
+    })
   }
 }
+
+const columnDiagnostic = (column: SqliteTableColumn): Record<string, unknown> => ({
+  type: column.type.toUpperCase(),
+  notNull: Boolean(Number(column.notnull)),
+  defaultValue: normalizeSqlFragment(column.dflt_value),
+  primaryKeyOrder: Number(column.pk)
+})
+
+const targetColumnDiagnostic = (column: TargetColumn): Record<string, unknown> => ({
+  type: column.type,
+  notNull: column.notNull,
+  defaultValue: column.defaultValue,
+  primaryKeyOrder: column.primaryKeyOrder,
+  autoIncrement: column.autoIncrement
+})
 
 const prepareRuntimeSchemaBaseline = async (
   client: PrismaClient
@@ -513,17 +533,19 @@ const verifyRuntimeSchemaTarget = async (
   const expectedTables = new Set(target.tableNames)
   const missingTables = target.tableNames.filter((tableName) => !actualTables.has(tableName))
   if (missingTables.length > 0) {
-    throw new Error(
-      `Database baseline verification found missing tables ${missingTables.join(', ')}.`
-    )
+    throw new DatabaseValidationError(`Database baseline verification found missing tables.`, {
+      kind: 'missing-tables',
+      expected: missingTables
+    })
   }
   const unexpectedTables = exact
     ? [...actualTables].filter((tableName) => !expectedTables.has(tableName))
     : []
   if (unexpectedTables.length > 0) {
-    throw new Error(
-      `Database baseline verification found unexpected tables ${unexpectedTables.join(', ')}.`
-    )
+    throw new DatabaseValidationError(`Database baseline verification found unexpected tables.`, {
+      kind: 'unexpected-tables',
+      actual: unexpectedTables
+    })
   }
 
   const foreignKeyKey = (foreignKey: TargetForeignKey): string =>
@@ -546,16 +568,21 @@ const verifyRuntimeSchemaTarget = async (
       (columnName) => !actualColumns.has(columnName)
     )
     if (missingColumns.length > 0) {
-      throw new Error(
-        `Database baseline verification found missing columns ${tableName}.${missingColumns.join(`, ${tableName}.`)}.`
+      throw new DatabaseValidationError(
+        `Database baseline verification found missing columns in ${tableName}.`,
+        { kind: 'missing-columns', table: tableName, expected: missingColumns }
       )
     }
+    const retiredColumns = new Set(RETIRED_LEGACY_COLUMNS[tableName] ?? [])
     const unexpectedColumns = exact
-      ? [...actualColumns.keys()].filter((columnName) => !expectedTable.columns.has(columnName))
+      ? [...actualColumns.keys()].filter(
+          (columnName) => !expectedTable.columns.has(columnName) && !retiredColumns.has(columnName)
+        )
       : []
     if (unexpectedColumns.length > 0) {
-      throw new Error(
-        `Database baseline verification found unexpected columns ${tableName}.${unexpectedColumns.join(`, ${tableName}.`)}.`
+      throw new DatabaseValidationError(
+        `Database baseline verification found unexpected columns in ${tableName}.`,
+        { kind: 'unexpected-columns', table: tableName, actual: unexpectedColumns }
       )
     }
 
@@ -568,8 +595,15 @@ const verifyRuntimeSchemaTarget = async (
         actualDefault !== expected.defaultValue ||
         Number(actual.pk) !== expected.primaryKeyOrder
       ) {
-        throw new Error(
-          `Database baseline verification found an incompatible column definition for ${tableName}.${columnName}.`
+        throw new DatabaseValidationError(
+          `Database baseline verification found an incompatible column definition for ${tableName}.${columnName}.`,
+          {
+            kind: 'column-definition-mismatch',
+            table: tableName,
+            column: columnName,
+            expected: targetColumnDiagnostic(expected),
+            actual: columnDiagnostic(actual)
+          }
         )
       }
     }
@@ -581,41 +615,77 @@ const verifyRuntimeSchemaTarget = async (
     )
     const actualTable = rows[0]?.sql ? parseTargetTable(rows[0].sql)?.[1] : undefined
     if (!actualTable) {
-      throw new Error(
-        `Database baseline verification could not inspect constraints for ${tableName}.`
+      throw new DatabaseValidationError(
+        `Database baseline verification could not inspect constraints for ${tableName}.`,
+        { kind: 'constraint-inspection-failed', table: tableName }
       )
     }
     if (actualTable.unsupportedDefinitions.length > 0) {
-      throw new Error(
-        `Database baseline verification found unsupported constraints for ${tableName}.`
+      throw new DatabaseValidationError(
+        `Database baseline verification found unsupported constraints for ${tableName}.`,
+        {
+          kind: 'unsupported-constraints',
+          table: tableName,
+          actual: { count: actualTable.unsupportedDefinitions.length }
+        }
       )
     }
-    if (
-      [...expectedTable.columns].some(
-        ([columnName, expected]) =>
-          actualTable.columns.get(columnName)?.autoIncrement !== expected.autoIncrement
-      )
-    ) {
-      throw new Error(
-        `Database baseline verification found incompatible AUTOINCREMENT constraints for ${tableName}.`
+    const incompatibleAutoIncrement = [...expectedTable.columns].find(
+      ([columnName, expected]) =>
+        actualTable.columns.get(columnName)?.autoIncrement !== expected.autoIncrement
+    )
+    if (incompatibleAutoIncrement) {
+      const [columnName, expected] = incompatibleAutoIncrement
+      throw new DatabaseValidationError(
+        `Database baseline verification found an incompatible AUTOINCREMENT constraint for ${tableName}.${columnName}.`,
+        {
+          kind: 'autoincrement-mismatch',
+          table: tableName,
+          column: columnName,
+          expected: expected.autoIncrement,
+          actual: actualTable.columns.get(columnName)?.autoIncrement ?? null
+        }
       )
     }
-    if (
-      [...expectedTable.checks.entries()].some(
-        ([name, expression]) =>
-          !checkExpressionsMatch(tableName, name, actualTable.checks.get(name), expression)
-      ) ||
-      actualTable.checks.size !== expectedTable.checks.size
-    ) {
-      throw new Error(
-        `Database baseline verification found incompatible CHECK constraints for ${tableName}.`
+    const incompatibleCheck = [...expectedTable.checks.entries()].find(
+      ([name, expression]) =>
+        !checkExpressionsMatch(tableName, name, actualTable.checks.get(name), expression)
+    )
+    if (incompatibleCheck) {
+      const [constraint, expected] = incompatibleCheck
+      throw new DatabaseValidationError(
+        `Database baseline verification found an incompatible CHECK constraint for ${tableName}.${constraint}.`,
+        {
+          kind: 'check-constraint-mismatch',
+          table: tableName,
+          constraint,
+          expected,
+          actual: actualTable.checks.get(constraint) ?? null
+        }
+      )
+    }
+    if (actualTable.checks.size !== expectedTable.checks.size) {
+      throw new DatabaseValidationError(
+        `Database baseline verification found an incompatible CHECK constraint set for ${tableName}.`,
+        {
+          kind: 'check-constraint-set-mismatch',
+          table: tableName,
+          expected: [...expectedTable.checks.keys()],
+          actual: [...actualTable.checks.keys()]
+        }
       )
     }
     const expectedForeignKeys = expectedTable.foreignKeys.map(foreignKeyKey).sort()
     const parsedForeignKeys = actualTable.foreignKeys.map(foreignKeyKey).sort()
     if (parsedForeignKeys.join('\n') !== expectedForeignKeys.join('\n')) {
-      throw new Error(
-        `Database baseline verification found incompatible foreign-key definitions for ${tableName}.`
+      throw new DatabaseValidationError(
+        `Database baseline verification found incompatible foreign-key definitions for ${tableName}.`,
+        {
+          kind: 'foreign-key-definition-mismatch',
+          table: tableName,
+          expected: expectedForeignKeys,
+          actual: parsedForeignKeys
+        }
       )
     }
 
@@ -638,8 +708,14 @@ const verifyRuntimeSchemaTarget = async (
       )
       .sort()
     if (pragmaForeignKeys.join('\n') !== targetPragmaForeignKeys.join('\n')) {
-      throw new Error(
-        `Database baseline verification found incompatible foreign-key metadata for ${tableName}.`
+      throw new DatabaseValidationError(
+        `Database baseline verification found incompatible foreign-key metadata for ${tableName}.`,
+        {
+          kind: 'foreign-key-metadata-mismatch',
+          table: tableName,
+          expected: targetPragmaForeignKeys,
+          actual: pragmaForeignKeys
+        }
       )
     }
   }
@@ -651,8 +727,15 @@ const verifyRuntimeSchemaTarget = async (
     )
     const actualIndex = indexes.find((index) => index.name === expected.name)
     if (!actualIndex || Number(actualIndex.unique) !== Number(expected.unique)) {
-      throw new Error(
-        `Database baseline verification found an incompatible index definition for ${expected.name}.`
+      throw new DatabaseValidationError(
+        `Database baseline verification found an incompatible index definition for ${expected.name}.`,
+        {
+          kind: 'index-definition-mismatch',
+          table: expected.tableName,
+          constraint: expected.name,
+          expected: { unique: expected.unique, columns: expected.columns },
+          actual: actualIndex ? { unique: Boolean(Number(actualIndex.unique)) } : null
+        }
       )
     }
     const indexColumns = await migrationSqlExecutor.query<SqliteIndexColumnRow[]>(
@@ -663,8 +746,15 @@ const verifyRuntimeSchemaTarget = async (
       .sort((left, right) => Number(left.seqno) - Number(right.seqno))
       .map((column) => column.name)
     if (actualColumnNames.join('\n') !== expected.columns.join('\n')) {
-      throw new Error(
-        `Database baseline verification found an incompatible index definition for ${expected.name}.`
+      throw new DatabaseValidationError(
+        `Database baseline verification found incompatible index columns for ${expected.name}.`,
+        {
+          kind: 'index-column-mismatch',
+          table: expected.tableName,
+          constraint: expected.name,
+          expected: expected.columns,
+          actual: actualColumnNames
+        }
       )
     }
   }
@@ -680,8 +770,12 @@ const verifyRuntimeSchemaTarget = async (
       .map((index) => index.name)
       .filter((indexName) => !expectedIndexes.has(indexName))
     if (unexpectedIndexes.length > 0) {
-      throw new Error(
-        `Database baseline verification found unexpected indexes ${unexpectedIndexes.join(', ')}.`
+      throw new DatabaseValidationError(
+        `Database baseline verification found unexpected indexes.`,
+        {
+          kind: 'unexpected-indexes',
+          actual: unexpectedIndexes
+        }
       )
     }
   }
@@ -691,7 +785,10 @@ const verifyRuntimeSchemaTarget = async (
     'PRAGMA integrity_check'
   )
   if (integrityRows.length !== 1 || integrityRows[0]?.integrity_check !== 'ok') {
-    throw new Error('Database baseline verification failed SQLite integrity_check.')
+    throw new DatabaseValidationError(
+      'Database baseline verification failed SQLite integrity_check.',
+      { kind: 'integrity-check-failed', actual: integrityRows }
+    )
   }
 }
 

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { access, copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import type { PrismaClient } from '@prisma/client'
+import { PrismaClient } from '@prisma/client'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { createProjectDbClient } from '../projects/prisma-client'
@@ -19,15 +19,15 @@ import {
 
 const futureTestMigration = (): MigrationManifestEntry => {
   const id = '0002_test_suffix'
-  const statements = [
-    `CREATE TABLE "MigrationSuffixProbe" ("id" TEXT NOT NULL PRIMARY KEY)`
-  ] as const
-  const verifiers = [{ kind: 'table-exists', version: 1, table: 'MigrationSuffixProbe' }] as const
+  const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
+  const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
     id,
     statements,
     verifiers,
-    checksum: checksumMigrationPayload(id, statements, verifiers)
+    checksum: checksumMigrationPayload(id, statements, verifiers),
+    backupOnApply: 'none',
+    backupRetention: 'retain'
   }
 }
 
@@ -204,6 +204,34 @@ describe('application database migrations', () => {
     await expect(verifyCurrentRuntimeSchema(client)).rejects.toThrow(/unexpected tables/)
   })
 
+  it('keeps a recovery snapshot when final verification rejects current schema drift', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-final-verification-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client, { databasePath })
+    await client.$executeRawUnsafe('VACUUM INTO ?', backupPath)
+    await client.$executeRawUnsafe('CREATE TABLE "UnversionedDrift" ("id" TEXT PRIMARY KEY)')
+    const retiredManifest = MIGRATION_MANIFEST.map((migration) => ({
+      ...migration,
+      backupOnApply: 'none' as const,
+      backupRetention: 'delete-after-success' as const
+    }))
+    const retired: unknown[] = []
+
+    await expect(
+      migrateApplicationDatabaseWithManifest(client, retiredManifest, {
+        databasePath,
+        onBackupRetired: (event) => retired.push(event)
+      })
+    ).rejects.toMatchObject({
+      code: 'database_validation_failed',
+      migrationId: '0001_runtime_schema_baseline'
+    })
+    expect(retired).toEqual([])
+    await expect(access(backupPath)).resolves.toBeUndefined()
+  })
+
   it('applies a pending manifest suffix after the recorded baseline', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-suffix-'))
     client = createProjectDbClient(storageRoot)
@@ -225,18 +253,41 @@ describe('application database migrations', () => {
     ).resolves.toEqual([{ id: '0001_runtime_schema_baseline' }, { id: '0002_test_suffix' }])
   })
 
+  it('does not back up a migration that does not request a backup', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-no-backup-suffix-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupEvents: unknown[] = []
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client, { databasePath })
+
+    await migrateApplicationDatabaseWithManifest(
+      client,
+      [...MIGRATION_MANIFEST, futureTestMigration()],
+      {
+        databasePath,
+        onBackupReady: (event) => backupEvents.push(event)
+      }
+    )
+
+    expect(backupEvents).toEqual([])
+  })
+
   it('rolls back a future migration and its ledger row when verification fails', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-suffix-rollback-'))
     client = createProjectDbClient(storageRoot)
     await migrateApplicationDatabase(client)
     const futureBase = futureTestMigration()
+    const statements = [
+      `CREATE TABLE "MigrationSuffixProbe" ("id" TEXT NOT NULL PRIMARY KEY)`
+    ] as const
     const verifiers = [
       { kind: 'table-exists', version: 1, table: 'MissingMigrationSuffixProbe' }
     ] as const
     const future = {
       ...futureBase,
+      statements,
       verifiers,
-      checksum: checksumMigrationPayload(futureBase.id, futureBase.statements, verifiers)
+      checksum: checksumMigrationPayload(futureBase.id, statements, verifiers)
     }
 
     await expect(
@@ -320,6 +371,30 @@ describe('application database migrations', () => {
     })
   })
 
+  it('blocks a required legacy backup when the database path is unavailable', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-missing-backup-path-'))
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "Project" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "name" TEXT NOT NULL,
+      "description" TEXT NOT NULL DEFAULT '',
+      "isExample" BOOLEAN NOT NULL DEFAULT false,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL
+    )`)
+
+    await expect(migrateApplicationDatabase(client, { databasePath: '' })).rejects.toMatchObject({
+      code: 'database_migration_failed',
+      migrationId: '0001_runtime_schema_baseline'
+    })
+    await expect(
+      client.$queryRaw<Array<{ name: string }>>`
+        SELECT "name" FROM "sqlite_schema"
+        WHERE "type" = 'table' AND "name" = '_open_science_migrations'
+      `
+    ).resolves.toEqual([])
+  })
+
   it('adopts a pre-ledger database without losing existing projects', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-legacy-'))
     client = createProjectDbClient(storageRoot)
@@ -343,6 +418,54 @@ describe('application database migrations', () => {
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
     ).resolves.toMatchObject({ name: 'Preserved', archivedAt: null })
+  })
+
+  it('keeps explicitly retired Review and Finding columns after final verification', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-retired-columns-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'legacy-project', name: 'Preserved' } })
+    await client.$executeRawUnsafe('ALTER TABLE "Review" ADD COLUMN "summary" TEXT')
+    await client.$executeRawUnsafe('ALTER TABLE "Review" ADD COLUMN "checks" TEXT')
+    await client.$executeRawUnsafe('ALTER TABLE "Review" ADD COLUMN "reasoning" TEXT')
+    await client.$executeRawUnsafe('ALTER TABLE "Finding" ADD COLUMN "severity" TEXT')
+    await client.$executeRaw`
+      INSERT INTO "Review" (
+        "id", "projectId", "sessionId", "turnMessageId", "updatedAt",
+        "summary", "checks", "reasoning"
+      ) VALUES (
+        ${'legacy-review'}, ${'legacy-project'}, ${'legacy-session'}, ${'legacy-message'},
+        ${new Date('2026-01-02T03:04:05Z')}, ${'retained summary'}, ${'retained checks'},
+        ${'retained reasoning'}
+      )
+    `
+    await client.$executeRaw`
+      INSERT INTO "Finding" ("id", "reviewId", "severity")
+      VALUES (${'legacy-finding'}, ${'legacy-review'}, ${'retained severity'})
+    `
+    await client.$executeRawUnsafe('DROP TABLE "_open_science_migrations"')
+
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
+      adoptedLegacy: true,
+      applied: ['0001_runtime_schema_baseline']
+    })
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
+    await expect(
+      client.$queryRaw<
+        Array<{ summary: string; checks: string; reasoning: string; severity: string }>
+      >`
+        SELECT "Review"."summary", "Review"."checks", "Review"."reasoning", "Finding"."severity"
+        FROM "Review" JOIN "Finding" ON "Finding"."reviewId" = "Review"."id"
+        WHERE "Review"."id" = 'legacy-review'
+      `
+    ).resolves.toEqual([
+      {
+        summary: 'retained summary',
+        checks: 'retained checks',
+        reasoning: 'retained reasoning',
+        severity: 'retained severity'
+      }
+    ])
   })
 
   it('adopts the pre-ledger permission grant table emitted by v0.9 through v0.10', async () => {
@@ -396,7 +519,17 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0001_runtime_schema_baseline'
+      migrationId: '0001_runtime_schema_baseline',
+      cause: {
+        name: 'DatabaseValidationError',
+        data: {
+          kind: 'check-constraint-mismatch',
+          table: 'PermissionGrant',
+          constraint: 'PermissionGrant_qualifier_check',
+          expected: expect.any(String),
+          actual: expect.any(String)
+        }
+      }
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -430,6 +563,59 @@ describe('application database migrations', () => {
     ])
   })
 
+  it('describes an invalid legacy value without exposing its raw content', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-invalid-value-'))
+    client = createProjectDbClient(storageRoot)
+    const sensitiveValue = 'Bearer customer-secret-value'
+    await client.$executeRawUnsafe(`CREATE TABLE "FileOriginSession" (
+      "projectId" TEXT NOT NULL,
+      "sessionId" TEXT NOT NULL,
+      "titleSnapshot" TEXT,
+      "state" TEXT NOT NULL DEFAULT 'active',
+      "deletedAt" DATETIME,
+      "deletionOperationId" TEXT,
+      "retainedReviewIdsJson" TEXT,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL,
+      PRIMARY KEY ("projectId", "sessionId")
+    )`)
+    await client.$executeRaw`
+      INSERT INTO "FileOriginSession" (
+        "projectId", "sessionId", "state", "updatedAt"
+      ) VALUES (${'project-1'}, ${'session-1'}, ${sensitiveValue}, ${new Date('2026-01-02T03:04:05Z')})
+    `
+
+    let failure: unknown
+    try {
+      await migrateApplicationDatabase(client)
+    } catch (error) {
+      failure = error
+    }
+    expect(failure).toMatchObject({
+      code: 'database_validation_failed',
+      cause: {
+        name: 'DatabaseValidationError',
+        data: {
+          kind: 'unsupported-value',
+          table: 'FileOriginSession',
+          column: 'state',
+          expected: ['active', 'deleting', 'deleted'],
+          actual: {
+            type: 'string',
+            length: sensitiveValue.length,
+            sha256: expect.stringMatching(/^[0-9a-f]{64}$/)
+          }
+        }
+      }
+    })
+    expect(String((failure as Error & { cause?: Error }).cause?.message)).not.toContain(
+      sensitiveValue
+    )
+    expect(
+      JSON.stringify((failure as Error & { cause?: { data?: unknown } }).cause?.data)
+    ).not.toContain(sensitiveValue)
+  })
+
   it('adopts the pre-ledger permission seed table from the final baseline', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-permission-seed-'))
     client = createProjectDbClient(storageRoot)
@@ -451,6 +637,63 @@ describe('application database migrations', () => {
       client.permissionGrantSeed.findUniqueOrThrow({ where: { id: 'global-customize-v1' } })
     ).resolves.toEqual({ id: 'global-customize-v1', appliedAt })
     await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
+  })
+
+  it('creates a restorable snapshot before adopting a legacy database', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-backup-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    const backupEvents: unknown[] = []
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "Project" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "name" TEXT NOT NULL,
+      "description" TEXT NOT NULL DEFAULT '',
+      "isExample" BOOLEAN NOT NULL DEFAULT false,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL
+    )`)
+    await client.$executeRaw`
+      INSERT INTO "Project" ("id", "name", "updatedAt")
+      VALUES (${'legacy-project'}, ${'Preserved'}, ${new Date('2026-01-02T03:04:05Z')})
+    `
+
+    await expect(
+      migrateApplicationDatabase(client, {
+        databasePath,
+        onBackupReady: (event) => {
+          backupEvents.push(event)
+          throw new Error('simulated backup diagnostic failure')
+        }
+      })
+    ).resolves.toMatchObject({ adoptedLegacy: true, applied: ['0001_runtime_schema_baseline'] })
+    expect(backupEvents).toEqual([
+      {
+        migrationId: '0001_runtime_schema_baseline',
+        path: backupPath,
+        reused: false
+      }
+    ])
+    await expect(client.project.count()).resolves.toBe(1)
+
+    const backupClient = new PrismaClient({
+      datasources: { db: { url: `file:${backupPath.replaceAll('\\', '/')}` } }
+    })
+    try {
+      await expect(
+        backupClient.$queryRaw<Array<{ id: string; name: string }>>`
+          SELECT "id", "name" FROM "Project" WHERE "id" = 'legacy-project'
+        `
+      ).resolves.toEqual([{ id: 'legacy-project', name: 'Preserved' }])
+      await expect(
+        backupClient.$queryRaw<Array<{ name: string }>>`
+          SELECT "name" FROM "sqlite_schema"
+          WHERE "type" = 'table' AND "name" = '_open_science_migrations'
+        `
+      ).resolves.toEqual([])
+    } finally {
+      await backupClient.$disconnect()
+    }
   })
 
   it('rejects an unknown pre-ledger table without changing it', async () => {
@@ -477,6 +720,389 @@ describe('application database migrations', () => {
         `SELECT "name" FROM "sqlite_schema" WHERE "name" = '_open_science_migrations'`
       )
     ).resolves.toEqual([])
+  })
+
+  it('reuses the original backup when a failed legacy migration is retried', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-backup-retry-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupEvents: Array<{ reused: boolean }> = []
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(
+      'CREATE TABLE "FutureApplicationTable" ("id" TEXT NOT NULL PRIMARY KEY)'
+    )
+    const options = {
+      databasePath,
+      onBackupReady: (event: { reused: boolean }): void => {
+        backupEvents.push(event)
+      }
+    }
+
+    await expect(migrateApplicationDatabase(client, options)).rejects.toMatchObject({
+      code: 'database_validation_failed'
+    })
+    await expect(migrateApplicationDatabase(client, options)).rejects.toMatchObject({
+      code: 'database_validation_failed'
+    })
+    expect(backupEvents).toEqual([
+      expect.objectContaining({ reused: false }),
+      expect.objectContaining({ reused: true })
+    ])
+  })
+
+  it('blocks migration when an existing backup is not a valid SQLite database', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-invalid-backup-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(
+      'CREATE TABLE "FutureApplicationTable" ("id" TEXT NOT NULL PRIMARY KEY)'
+    )
+    await writeFile(backupPath, 'not a SQLite database', 'utf8')
+
+    await expect(migrateApplicationDatabase(client, { databasePath })).rejects.toMatchObject({
+      code: 'database_migration_failed',
+      migrationId: '0001_runtime_schema_baseline'
+    })
+    await expect(
+      client.$queryRaw<Array<{ name: string }>>`
+        SELECT "name" FROM "sqlite_schema"
+        WHERE "name" = '_open_science_migrations'
+      `
+    ).resolves.toEqual([])
+  })
+
+  it('rejects a backup whose index contents fail SQLite integrity_check', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-corrupt-index-backup-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "FutureApplicationTable" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "leftValue" TEXT NOT NULL,
+      "rightValue" TEXT NOT NULL
+    )`)
+    await client.$executeRawUnsafe(
+      'CREATE INDEX "FutureApplicationTable_left_idx" ON "FutureApplicationTable"("leftValue")'
+    )
+    await client.$executeRawUnsafe(
+      'CREATE INDEX "FutureApplicationTable_right_idx" ON "FutureApplicationTable"("rightValue")'
+    )
+    await client.$executeRaw`
+      INSERT INTO "FutureApplicationTable" ("id", "leftValue", "rightValue")
+      VALUES (${'one'}, ${'alpha'}, ${'zulu'}), (${'two'}, ${'beta'}, ${'yankee'})
+    `
+    await client.$executeRawUnsafe('VACUUM INTO ?', backupPath)
+
+    const backupWriter = new PrismaClient({
+      datasources: { db: { url: `file:${backupPath.replaceAll('\\', '/')}` } }
+    })
+    try {
+      const roots = await backupWriter.$queryRawUnsafe<Array<{ name: string; rootpage: bigint }>>(`
+        SELECT "name", "rootpage" FROM "sqlite_schema"
+        WHERE "name" IN (
+          'FutureApplicationTable_left_idx',
+          'FutureApplicationTable_right_idx'
+        )
+      `)
+      const leftRoot = roots.find(
+        ({ name }) => name === 'FutureApplicationTable_left_idx'
+      )!.rootpage
+      const rightRoot = roots.find(
+        ({ name }) => name === 'FutureApplicationTable_right_idx'
+      )!.rootpage
+      await backupWriter.$executeRawUnsafe('PRAGMA writable_schema = ON')
+      await backupWriter.$executeRawUnsafe(
+        `UPDATE "sqlite_schema"
+         SET "rootpage" = CASE "name"
+           WHEN 'FutureApplicationTable_left_idx' THEN ?
+           ELSE ?
+         END
+         WHERE "name" IN (
+           'FutureApplicationTable_left_idx',
+           'FutureApplicationTable_right_idx'
+         )`,
+        rightRoot,
+        leftRoot
+      )
+      await backupWriter.$executeRawUnsafe('PRAGMA writable_schema = OFF')
+    } finally {
+      await backupWriter.$disconnect()
+    }
+
+    const backupReader = new PrismaClient({
+      datasources: { db: { url: `file:${backupPath.replaceAll('\\', '/')}` } }
+    })
+    try {
+      await expect(
+        backupReader.$queryRawUnsafe<Array<{ quick_check: string }>>('PRAGMA quick_check')
+      ).resolves.toEqual([{ quick_check: 'ok' }])
+      const integrity =
+        await backupReader.$queryRawUnsafe<Array<{ integrity_check: string }>>(
+          'PRAGMA integrity_check'
+        )
+      expect(integrity).not.toEqual([{ integrity_check: 'ok' }])
+    } finally {
+      await backupReader.$disconnect()
+    }
+
+    const ready: unknown[] = []
+    let failure: unknown
+    try {
+      await migrateApplicationDatabase(client, {
+        databasePath,
+        onBackupReady: (event) => ready.push(event)
+      })
+    } catch (error) {
+      failure = error
+    }
+    expect(failure).toMatchObject({
+      code: 'database_migration_failed',
+      migrationId: '0001_runtime_schema_baseline'
+    })
+    expect((failure as Error).cause).toMatchObject({
+      name: 'DatabaseValidationError',
+      data: { kind: 'backup-integrity-check-failed' }
+    })
+    expect(ready).toEqual([])
+  })
+
+  it('compares backup contents with duplicate-row multiplicity', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-duplicate-backup-row-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "FutureApplicationTable" (
+      "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      "value" TEXT NOT NULL
+    )`)
+    await client.$executeRaw`
+      INSERT INTO "FutureApplicationTable" ("value") VALUES (${'preserved'})
+    `
+    await client.$executeRawUnsafe('VACUUM INTO ?', backupPath)
+    await client.$executeRawUnsafe(`
+      INSERT INTO "sqlite_sequence" ("name", "seq")
+      SELECT "name", "seq" FROM "sqlite_sequence"
+      WHERE "name" = 'FutureApplicationTable'
+      LIMIT 1
+    `)
+
+    const ready: unknown[] = []
+    let failure: unknown
+    try {
+      await migrateApplicationDatabase(client, {
+        databasePath,
+        onBackupReady: (event) => ready.push(event)
+      })
+    } catch (error) {
+      failure = error
+    }
+    expect(failure).toMatchObject({
+      code: 'database_migration_failed',
+      migrationId: '0001_runtime_schema_baseline'
+    })
+    expect((failure as Error).cause).toMatchObject({
+      name: 'DatabaseValidationError',
+      data: { kind: 'backup-content-mismatch', table: 'sqlite_sequence' }
+    })
+    expect(ready).toEqual([])
+  })
+
+  it('blocks migration when an existing backup belongs to another database', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-foreign-backup-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "Project" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "name" TEXT NOT NULL,
+      "description" TEXT NOT NULL DEFAULT '',
+      "isExample" BOOLEAN NOT NULL DEFAULT false,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL
+    )`)
+    await client.$executeRaw`
+      INSERT INTO "Project" ("id", "name", "updatedAt")
+      VALUES (${'source-project'}, ${'Source'}, ${new Date('2026-01-02T03:04:05Z')})
+    `
+
+    await client.$disconnect()
+    client = undefined
+    await copyFile(databasePath, backupPath)
+    const foreignClient = new PrismaClient({
+      datasources: { db: { url: `file:${backupPath.replaceAll('\\', '/')}` } }
+    })
+    try {
+      await foreignClient.$executeRaw`
+        UPDATE "Project" SET "id" = ${'foreign-project'}, "name" = ${'Foreign'}
+        WHERE "id" = ${'source-project'}
+      `
+    } finally {
+      await foreignClient.$disconnect()
+    }
+    client = createProjectDbClient(storageRoot)
+
+    let failure: unknown
+    try {
+      await migrateApplicationDatabase(client, { databasePath })
+    } catch (error) {
+      failure = error
+    }
+    expect(failure).toMatchObject({
+      code: 'database_migration_failed',
+      migrationId: '0001_runtime_schema_baseline'
+    })
+    expect((failure as Error).cause).toMatchObject({
+      name: 'DatabaseValidationError',
+      data: { kind: 'backup-content-mismatch', table: 'Project' }
+    })
+    await expect(
+      client.$queryRaw<Array<{ id: string; name: string }>>`
+        SELECT "id", "name" FROM "Project"
+      `
+    ).resolves.toEqual([{ id: 'source-project', name: 'Source' }])
+    await expect(
+      client.$queryRaw<Array<{ name: string }>>`
+        SELECT "name" FROM "sqlite_schema"
+        WHERE "name" = '_open_science_migrations'
+      `
+    ).resolves.toEqual([])
+  })
+
+  it('leaves legacy data and the ledger untouched when backup creation fails', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-backup-failure-'))
+    const unavailableDatabasePath = join(storageRoot, 'missing', 'open-science.db')
+    const temporaryBackupPath = `${unavailableDatabasePath}.before-0001_runtime_schema_baseline.backup.tmp`
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "Project" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "name" TEXT NOT NULL,
+      "description" TEXT NOT NULL DEFAULT '',
+      "isExample" BOOLEAN NOT NULL DEFAULT false,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL
+    )`)
+    await client.$executeRaw`
+      INSERT INTO "Project" ("id", "name", "updatedAt")
+      VALUES (${'legacy-project'}, ${'Preserved'}, ${new Date('2026-01-02T03:04:05Z')})
+    `
+
+    await expect(
+      migrateApplicationDatabase(client, { databasePath: unavailableDatabasePath })
+    ).rejects.toMatchObject({
+      code: 'database_migration_failed',
+      migrationId: '0001_runtime_schema_baseline'
+    })
+    await expect(
+      client.$queryRaw<Array<{ id: string; name: string }>>`
+        SELECT "id", "name" FROM "Project"
+      `
+    ).resolves.toEqual([{ id: 'legacy-project', name: 'Preserved' }])
+    await expect(
+      client.$queryRaw<Array<{ name: string }>>`
+        SELECT "name" FROM "sqlite_schema"
+        WHERE "name" = '_open_science_migrations'
+      `
+    ).resolves.toEqual([])
+    await expect(access(temporaryBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('backs up a legacy database before deleting the snapshot after a successful migration', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-retired-backup-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "Project" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "name" TEXT NOT NULL,
+      "description" TEXT NOT NULL DEFAULT '',
+      "isExample" BOOLEAN NOT NULL DEFAULT false,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL
+    )`)
+    await client.$executeRaw`
+      INSERT INTO "Project" ("id", "name", "updatedAt")
+      VALUES (${'legacy-project'}, ${'Preserved'}, ${new Date('2026-01-02T03:04:05Z')})
+    `
+    const retiredManifest = MIGRATION_MANIFEST.map((migration) => ({
+      ...migration,
+      backupOnApply: 'required' as const,
+      backupRetention: 'delete-after-success' as const
+    }))
+    const ready: unknown[] = []
+    const retired: unknown[] = []
+
+    await migrateApplicationDatabaseWithManifest(client, retiredManifest, {
+      databasePath,
+      onBackupReady: (event) => ready.push(event),
+      onBackupRetired: (event) => retired.push(event)
+    })
+
+    expect(ready).toEqual([
+      expect.objectContaining({
+        migrationId: '0001_runtime_schema_baseline',
+        path: backupPath,
+        reused: false
+      })
+    ])
+    expect(retired).toEqual([{ migrationId: '0001_runtime_schema_baseline', path: backupPath }])
+    await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(
+      client.$queryRaw<Array<{ id: string; name: string }>>`SELECT "id", "name" FROM "Project"`
+    ).resolves.toEqual([{ id: 'legacy-project', name: 'Preserved' }])
+  })
+
+  it('does not report backup retirement when no backup exists', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-no-retired-backup-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client, { databasePath })
+    const retiredManifest = MIGRATION_MANIFEST.map((migration) => ({
+      ...migration,
+      backupOnApply: 'none' as const,
+      backupRetention: 'delete-after-success' as const
+    }))
+    const retired: unknown[] = []
+
+    await expect(
+      migrateApplicationDatabaseWithManifest(client, retiredManifest, {
+        databasePath,
+        onBackupRetired: (event) => retired.push(event)
+      })
+    ).resolves.toMatchObject({ applied: [] })
+    expect(retired).toEqual([])
+    await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('reports backup retirement failure without blocking a valid database', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-retirement-failure-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client, { databasePath })
+    await mkdir(backupPath)
+    await writeFile(join(backupPath, 'keep'), 'occupied', 'utf8')
+    const retiredManifest = MIGRATION_MANIFEST.map((migration) => ({
+      ...migration,
+      backupOnApply: 'none' as const,
+      backupRetention: 'delete-after-success' as const
+    }))
+    const failures: unknown[] = []
+
+    await expect(
+      migrateApplicationDatabaseWithManifest(client, retiredManifest, {
+        databasePath,
+        onBackupRetirementFailed: (event) => failures.push(event)
+      })
+    ).resolves.toMatchObject({ applied: [] })
+    expect(failures).toEqual([
+      expect.objectContaining({
+        migrationId: '0001_runtime_schema_baseline',
+        path: backupPath,
+        error: expect.any(Error)
+      })
+    ])
+    await expect(access(backupPath)).resolves.toBeUndefined()
   })
 
   it.each([

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import { access, rename, rm } from 'node:fs/promises'
 
 import type { PrismaClient } from '@prisma/client'
 import type { DatabaseStartupErrorCode } from '../../shared/database-startup'
@@ -7,8 +8,10 @@ import {
   RUNTIME_SCHEMA_BASELINE_CONTRACT,
   applyRuntimeSchemaBaseline,
   prepareRuntimeSchemaBaseline,
+  verifyCurrentRuntimeSchema,
   verifyRuntimeSchemaBaseline
 } from './legacy-baseline-adapter'
+import { DatabaseValidationError } from './database-validation-error'
 import { migrationSqlExecutor } from './migration-sql-executor'
 import { runtimeSchemaBaselineMigration } from './migrations/0001-runtime-schema-baseline'
 
@@ -73,7 +76,12 @@ const BASELINE_CHECKSUM = checksumMigrationPayload(
   runtimeSchemaBaselineMigration.verifiers
 )
 const MIGRATION_MANIFEST = [
-  { ...runtimeSchemaBaselineMigration, checksum: BASELINE_CHECKSUM }
+  {
+    ...runtimeSchemaBaselineMigration,
+    checksum: BASELINE_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  }
 ] as const satisfies readonly MigrationManifestEntry[]
 // schema-locality: begin frozen-0001-repairs
 const LEDGER_TABLE_DDL = `CREATE TABLE IF NOT EXISTS "_open_science_migrations" (
@@ -87,6 +95,10 @@ const LEDGER_TABLE_DDL = `CREATE TABLE IF NOT EXISTS "_open_science_migrations" 
 
 type LedgerRow = { id: string; checksum: string }
 type SqliteForeignKeyStateRow = { foreign_keys: bigint | number }
+type SqliteDatabaseListRow = { name: string; file: string }
+type SqliteIntegrityCheckRow = { integrity_check: string }
+type SqliteSchemaObjectRow = { type: string; name: string; tableName: string; sql: string | null }
+type SqliteDifferenceRow = { different: bigint | number }
 type DatabaseMigrationErrorCode = DatabaseStartupErrorCode
 
 class DatabaseMigrationError extends Error {
@@ -114,9 +126,26 @@ type SchemaMigrationProgress = { phase: 'checking' } | { phase: 'migrating'; mig
 
 type DatabaseCompatibility = { sqliteVersion: string }
 
+type DatabaseMigrationBackup = {
+  migrationId: string
+  path: string
+  reused: boolean
+}
+
+type DatabaseMigrationBackupRetirement = {
+  migrationId: string
+  path?: string
+  error?: unknown
+}
+
 type SchemaMigrationOptions = {
+  databasePath?: string
   onProgress?: (progress: SchemaMigrationProgress) => void
   onCompatibilityVerified?: (compatibility: DatabaseCompatibility) => void
+  onBackupReady?: (backup: DatabaseMigrationBackup) => void
+  onBackupRetired?: (backup: DatabaseMigrationBackupRetirement) => void
+  onBackupRetirementFailed?: (backup: DatabaseMigrationBackupRetirement) => void
+  onCompleted?: (result: SchemaMigrationResult) => void
 }
 
 type MigrationManifestEntry = {
@@ -124,6 +153,8 @@ type MigrationManifestEntry = {
   checksum: string
   statements: readonly string[]
   verifiers: MigrationVerifiers
+  backupOnApply: 'required' | 'none'
+  backupRetention: 'retain' | 'delete-after-success'
 }
 
 const runMigrationVerifiers = async (
@@ -175,6 +206,201 @@ const hasApplicationTables = async (client: PrismaClient): Promise<boolean> => {
     LIMIT 1
   `
   return rows.length > 0
+}
+
+const readMainDatabasePath = async (client: PrismaClient): Promise<string | undefined> => {
+  const databases = await migrationSqlExecutor.query<SqliteDatabaseListRow[]>(
+    client,
+    'PRAGMA database_list'
+  )
+  const path = databases.find((database) => database.name === 'main')?.file.trim()
+  return path || undefined
+}
+
+const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const quoteSqliteIdentifier = (value: string): string => `"${value.replaceAll('"', '""')}"`
+
+const readSnapshotTableNames = (
+  client: PrismaClient,
+  schema: 'main' | '_open_science_backup'
+): Promise<Array<{ name: string }>> =>
+  migrationSqlExecutor.query(
+    client,
+    `SELECT "name" FROM "${schema}"."sqlite_schema"
+     WHERE "type" = 'table'
+       AND ("name" NOT LIKE 'sqlite_%' OR "name" = 'sqlite_sequence')
+     ORDER BY "name"`
+  )
+
+const readSnapshotSchema = (
+  client: PrismaClient,
+  schema: 'main' | '_open_science_backup'
+): Promise<SqliteSchemaObjectRow[]> =>
+  migrationSqlExecutor.query(
+    client,
+    `SELECT "type", "name", "tbl_name" AS "tableName", "sql"
+     FROM "${schema}"."sqlite_schema"
+     WHERE "name" NOT LIKE 'sqlite_%' OR "name" = 'sqlite_sequence'
+     ORDER BY "type", "name"`
+  )
+
+const snapshotTableDiffers = async (client: PrismaClient, tableName: string): Promise<boolean> => {
+  const table = quoteSqliteIdentifier(tableName)
+  const columns = await migrationSqlExecutor.query<Array<{ name: string }>>(
+    client,
+    `PRAGMA "main".table_xinfo(${table})`
+  )
+  if (columns.length === 0) return true
+  const projection = columns.map(({ name }) => quoteSqliteIdentifier(name)).join(', ')
+  const rows = await migrationSqlExecutor.query<SqliteDifferenceRow[]>(
+    client,
+    `WITH "current_rows" AS (
+       SELECT ${projection}, COUNT(*) FROM "main".${table} GROUP BY ${projection}
+     ), "backup_rows" AS (
+       SELECT ${projection}, COUNT(*) FROM "_open_science_backup".${table} GROUP BY ${projection}
+     )
+     SELECT (
+       EXISTS(SELECT * FROM "current_rows" EXCEPT SELECT * FROM "backup_rows")
+       OR EXISTS(SELECT * FROM "backup_rows" EXCEPT SELECT * FROM "current_rows")
+     ) AS "different"`
+  )
+  return Number(rows[0]?.different ?? 1) !== 0
+}
+
+const verifyDatabaseMigrationBackup = async (client: PrismaClient, path: string): Promise<void> => {
+  let attached = false
+  let failure: unknown
+  try {
+    await migrationSqlExecutor.execute(client, 'ATTACH DATABASE ? AS "_open_science_backup"', path)
+    attached = true
+    const [integrity, currentTables, backupTables, currentSchema, backupSchema] = await Promise.all(
+      [
+        migrationSqlExecutor.query<SqliteIntegrityCheckRow[]>(
+          client,
+          'PRAGMA "_open_science_backup".integrity_check'
+        ),
+        readSnapshotTableNames(client, 'main'),
+        readSnapshotTableNames(client, '_open_science_backup'),
+        readSnapshotSchema(client, 'main'),
+        readSnapshotSchema(client, '_open_science_backup')
+      ]
+    )
+    if (integrity.length !== 1 || integrity[0]?.integrity_check !== 'ok') {
+      throw new DatabaseValidationError(
+        'The existing database migration backup failed SQLite integrity_check.',
+        { kind: 'backup-integrity-check-failed', actual: integrity }
+      )
+    }
+    if (JSON.stringify(currentSchema) !== JSON.stringify(backupSchema)) {
+      throw new DatabaseValidationError(
+        'The existing database migration backup does not match the current schema.',
+        { kind: 'backup-schema-mismatch', expected: currentSchema, actual: backupSchema }
+      )
+    }
+    if (
+      currentTables.map(({ name }) => name).join('\n') !==
+      backupTables.map(({ name }) => name).join('\n')
+    ) {
+      throw new DatabaseValidationError(
+        'The existing database migration backup does not contain the current tables.',
+        { kind: 'backup-table-set-mismatch', expected: currentTables, actual: backupTables }
+      )
+    }
+    for (const { name } of currentTables) {
+      if (await snapshotTableDiffers(client, name)) {
+        throw new DatabaseValidationError(
+          `The existing database migration backup does not match the current contents of ${name}.`,
+          { kind: 'backup-content-mismatch', table: name }
+        )
+      }
+    }
+  } catch (error) {
+    failure = error
+  }
+  if (attached) {
+    try {
+      await migrationSqlExecutor.execute(client, 'DETACH DATABASE "_open_science_backup"')
+    } catch (error) {
+      failure ??= error
+    }
+  }
+  if (failure) throw failure
+}
+
+const createDatabaseMigrationBackup = async (
+  client: PrismaClient,
+  databasePath: string,
+  migrationId: string
+): Promise<DatabaseMigrationBackup> => {
+  const path = `${databasePath}.before-${migrationId}.backup`
+  if (await pathExists(path)) {
+    await verifyDatabaseMigrationBackup(client, path)
+    return { migrationId, path, reused: true }
+  }
+
+  const temporaryPath = `${path}.tmp`
+  await rm(temporaryPath, { force: true })
+  try {
+    // SQLite owns the snapshot so WAL contents are included; rename publishes only a complete backup.
+    await migrationSqlExecutor.execute(client, 'VACUUM INTO ?', temporaryPath)
+    await rename(temporaryPath, path)
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined)
+    throw error
+  }
+  return { migrationId, path, reused: false }
+}
+
+const retireDatabaseMigrationBackups = async (
+  client: PrismaClient,
+  manifest: readonly MigrationManifestEntry[],
+  options: SchemaMigrationOptions
+): Promise<void> => {
+  const retired = manifest.filter(
+    (migration) => migration.backupRetention === 'delete-after-success'
+  )
+  if (retired.length === 0) return
+  let databasePath: string | undefined
+  try {
+    databasePath = options.databasePath ?? (await readMainDatabasePath(client))
+    if (!databasePath) throw new Error('The database backup retention path is unavailable.')
+  } catch (error) {
+    for (const migration of retired) {
+      try {
+        options.onBackupRetirementFailed?.({ migrationId: migration.id, error })
+      } catch {
+        // A diagnostic sink failure must not block an otherwise valid database.
+      }
+    }
+    return
+  }
+  for (const migration of retired) {
+    const path = `${databasePath}.before-${migration.id}.backup`
+    try {
+      await rm(path)
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') continue
+      try {
+        options.onBackupRetirementFailed?.({ migrationId: migration.id, path, error })
+      } catch {
+        // A diagnostic sink failure must not block an otherwise valid database.
+      }
+      continue
+    }
+    try {
+      options.onBackupRetired?.({ migrationId: migration.id, path })
+    } catch {
+      // A diagnostic sink failure must not invalidate completed backup retirement.
+    }
+  }
 }
 
 const validateLedger = (
@@ -443,22 +669,60 @@ const migrateApplicationDatabaseWithManifest = async (
   const appliedCount = validateLedger(ledger, manifest)
   const latest = manifest.at(-1)!
   const from = ledger.at(-1)?.id ?? null
-  if (appliedCount === manifest.length) {
+  const complete = async (result: SchemaMigrationResult): Promise<SchemaMigrationResult> => {
+    try {
+      await verifyCurrentRuntimeSchema(client)
+    } catch (error) {
+      throw classifyDatabaseFailure(error, 'validation', latest.id)
+    }
     await reportDatabaseCompatibility(client, options)
-    return { adoptedLegacy: false, applied: [], from, to: latest.id }
+    await retireDatabaseMigrationBackups(client, manifest, options)
+    try {
+      options.onCompleted?.(result)
+    } catch {
+      // A diagnostic sink failure must not invalidate a completed migration.
+    }
+    return result
+  }
+  if (appliedCount === manifest.length) {
+    return complete({ adoptedLegacy: false, applied: [], from, to: latest.id })
+  }
+
+  let hadApplicationTablesAtStart: boolean
+  try {
+    hadApplicationTablesAtStart = await hasApplicationTables(client)
+  } catch (error) {
+    throw classifyDatabaseFailure(error, 'open')
+  }
+
+  const backupBeforeMigration = async (migration: MigrationManifestEntry): Promise<void> => {
+    if (migration.backupOnApply !== 'required') return
+    const migrationId = migration.id
+    if (!hadApplicationTablesAtStart) return
+    let backup: DatabaseMigrationBackup
+    try {
+      const databasePath = options.databasePath ?? (await readMainDatabasePath(client))
+      if (!databasePath) {
+        throw new Error('A database path is required before this migration can create its backup.')
+      }
+      backup = await createDatabaseMigrationBackup(client, databasePath, migrationId)
+    } catch (error) {
+      throw classifyDatabaseFailure(error, 'migration', migrationId)
+    }
+    try {
+      options.onBackupReady?.(backup)
+    } catch {
+      // A diagnostic sink failure must not invalidate a durable database backup.
+    }
   }
 
   const applied: string[] = []
-  let adoptedLegacy = false
+  const adoptedLegacy = appliedCount === 0 && hadApplicationTablesAtStart
   let nextIndex = appliedCount
   if (nextIndex === 0) {
     const baseline = manifest[0]!
     options.onProgress?.({ phase: 'migrating', migrationId: baseline.id })
-    try {
-      adoptedLegacy = await hasApplicationTables(client)
-    } catch (error) {
-      throw classifyDatabaseFailure(error, 'open')
-    }
+    await backupBeforeMigration(baseline)
     await applyBaselineMigration(client, baseline)
     applied.push(baseline.id)
     nextIndex = 1
@@ -466,12 +730,12 @@ const migrateApplicationDatabaseWithManifest = async (
 
   for (const migration of manifest.slice(nextIndex)) {
     options.onProgress?.({ phase: 'migrating', migrationId: migration.id })
+    await backupBeforeMigration(migration)
     await applyManifestMigration(client, migration)
     applied.push(migration.id)
   }
 
-  await reportDatabaseCompatibility(client, options)
-  return { adoptedLegacy, applied, from, to: latest.id }
+  return complete({ adoptedLegacy, applied, from, to: latest.id })
 }
 
 const migrateApplicationDatabase = (
@@ -491,6 +755,8 @@ export {
 }
 export type {
   DatabaseCompatibility,
+  DatabaseMigrationBackup,
+  DatabaseMigrationBackupRetirement,
   DatabaseMigrationErrorCode,
   MigrationManifestEntry,
   MigrationVerifierDescriptor,

--- a/src/main/database/sqlite-schema-migrations.ts
+++ b/src/main/database/sqlite-schema-migrations.ts
@@ -2,6 +2,7 @@ import {
   migrationSqlExecutor,
   type MigrationSqlClient as SqliteExecutor
 } from './migration-sql-executor'
+import { DatabaseValidationError, summarizeDatabaseValue } from './database-validation-error'
 
 type SqliteTableInfoRow = { name: string }
 type SqliteTableSqlRow = { sql: string | null }
@@ -54,8 +55,15 @@ const validateExistingValues = async (
   const invalidValue = invalidRows[0]?.value
   if (invalidRows.length === 0) return
 
-  throw new Error(
-    `SQLite schema migration blocked: ${migration.tableName}.${migration.columnName} contains unsupported value ${JSON.stringify(invalidValue)}.`
+  throw new DatabaseValidationError(
+    `SQLite schema migration blocked: ${migration.tableName}.${migration.columnName} contains an unsupported value.`,
+    {
+      kind: 'unsupported-value',
+      table: migration.tableName,
+      column: migration.columnName,
+      expected: migration.allowedValues,
+      actual: summarizeDatabaseValue(invalidValue ?? null)
+    }
   )
 }
 
@@ -99,14 +107,21 @@ const rebuildTable = async (
   const targetColumnSet = new Set(targetColumns)
   const unknownSourceColumns = [...sourceColumns].filter((column) => !targetColumnSet.has(column))
   if (unknownSourceColumns.length > 0) {
-    throw new Error(
-      `SQLite schema migration blocked: ${migration.tableName} contains unknown columns ${unknownSourceColumns.join(', ')}.`
+    throw new DatabaseValidationError(
+      `SQLite schema migration blocked by unknown columns in ${migration.tableName}.`,
+      { kind: 'unknown-columns', table: migration.tableName, actual: unknownSourceColumns }
     )
   }
   const copyColumns = targetColumns.filter((column) => sourceColumns.has(column))
   if (copyColumns.length === 0) {
-    throw new Error(
-      `SQLite schema migration found no compatible columns for ${migration.tableName}.`
+    throw new DatabaseValidationError(
+      `SQLite schema migration found no compatible columns for ${migration.tableName}.`,
+      {
+        kind: 'no-compatible-columns',
+        table: migration.tableName,
+        expected: targetColumns,
+        actual: [...sourceColumns]
+      }
     )
   }
 
@@ -118,8 +133,14 @@ const rebuildTable = async (
   )
   const replacementRowCount = await countRows(client, replacementTableName)
   if (replacementRowCount !== sourceRowCount) {
-    throw new Error(
-      `SQLite schema migration row-count mismatch for ${migration.tableName}: expected ${sourceRowCount}, copied ${replacementRowCount}.`
+    throw new DatabaseValidationError(
+      `SQLite schema migration found a row-count mismatch for ${migration.tableName}.`,
+      {
+        kind: 'row-count-mismatch',
+        table: migration.tableName,
+        expected: sourceRowCount,
+        actual: replacementRowCount
+      }
     )
   }
 
@@ -162,8 +183,15 @@ const applySqliteCheckConstraints = async (
   )
   if (violations.length > 0) {
     const violation = violations[0]!
-    throw new Error(
-      `SQLite schema migration introduced a foreign-key violation in ${violation.table} row ${String(violation.rowid)} referencing ${violation.parent}.`
+    throw new DatabaseValidationError(
+      `SQLite schema migration introduced a foreign-key violation in ${violation.table}.`,
+      {
+        kind: 'foreign-key-violation',
+        table: violation.table,
+        constraint: String(violation.fkid),
+        expected: { parent: violation.parent },
+        actual: { rowid: violation.rowid }
+      }
     )
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -229,6 +229,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { createDesktopBadgeAdapter, createWindowsBadgeBitmap },
         { wireNotificationInboxController },
         { registerUnreadTaskIpc },
+        { createDatabaseStartupLogging },
         { createDatabaseStartupOwner },
         { installDatabaseStartupQuitGuard, registerDatabaseStartupIpc },
         { getProjectDbClient },
@@ -253,6 +254,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./notifications/desktop-badge'),
         import('./notifications/notification-inbox-controller'),
         import('./notifications/unread-task-ipc'),
+        import('./database/database-startup-logging'),
         import('./database/database-startup-owner'),
         import('./database/database-startup-ipc'),
         import('./projects/prisma-client'),
@@ -279,23 +281,14 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       installWindowShortcuts(app)
 
       const webMode = parseWebModeOptions(process.argv)
+      const databaseStartupLogging = createDatabaseStartupLogging(log, app.getVersion())
       const databaseStartupOwner = createDatabaseStartupOwner({
-        reportBlocked: (error) => {
-          log.error('database startup blocked', {
-            appVersion: app.getVersion(),
-            code: error.code,
-            migrationId: error.migrationId ?? null,
-            retryable: error.retryable,
-            ...diagnosticErrorFields(error.cause ?? error)
-          })
-        },
+        reportBlocked: databaseStartupLogging.reportBlocked,
         verifyDatabase: async (onProgress) => {
-          await getProjectDbClient(resolveStorageRoot(), {
-            onProgress,
-            onCompatibilityVerified: ({ sqliteVersion }) => {
-              log.info(`database runtime verified: sqlite_version=${sqliteVersion}`)
-            }
-          })
+          await getProjectDbClient(
+            resolveStorageRoot(),
+            databaseStartupLogging.migrationOptions(onProgress)
+          )
         }
       })
       const startupWindowCloseOptions = createStartupWindowCloseOptions(() => app.quit())

--- a/src/main/projects/prisma-client.test.ts
+++ b/src/main/projects/prisma-client.test.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { access, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { Prisma, type PrismaClient } from '@prisma/client'
+import { Prisma, PrismaClient } from '@prisma/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { applyRuntimeSchemaBaseline } from '../database/legacy-baseline-adapter'
@@ -247,11 +247,20 @@ describe('project prisma client (integration)', () => {
 
     await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
       code: 'database_validation_failed',
-      cause: expect.objectContaining({
-        message: expect.stringContaining(
-          'FileOriginSession.state contains unsupported value "corrupt"'
-        )
-      })
+      cause: {
+        name: 'DatabaseValidationError',
+        data: {
+          kind: 'unsupported-value',
+          table: 'FileOriginSession',
+          column: 'state',
+          expected: ['active', 'deleting', 'deleted'],
+          actual: {
+            type: 'string',
+            length: 7,
+            sha256: expect.stringMatching(/^[0-9a-f]{64}$/)
+          }
+        }
+      }
     })
     await expect(
       client.$queryRawUnsafe<Array<{ state: string }>>(
@@ -285,7 +294,14 @@ describe('project prisma client (integration)', () => {
 
     await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
       code: 'database_validation_failed',
-      cause: expect.objectContaining({ message: expect.stringMatching(/futureMarker/) })
+      cause: {
+        name: 'DatabaseValidationError',
+        data: {
+          kind: 'unknown-columns',
+          table: 'FileOriginSession',
+          actual: ['futureMarker']
+        }
+      }
     })
     await expect(
       client.$queryRawUnsafe<Array<{ name: string }>>(`PRAGMA table_info('FileOriginSession')`)
@@ -612,6 +628,56 @@ describe('project prisma client (integration)', () => {
 
     expect(second).not.toBe(first)
     await expect(second.$queryRawUnsafe('PRAGMA integrity_check')).resolves.toBeDefined()
+  })
+
+  it('backs up legacy data through the shared client on a portable storage path', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open science 数据 legacy backup-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    const seedClient = createProjectDbClient(storageRoot)
+    try {
+      await seedClient.$executeRawUnsafe(`CREATE TABLE "Project" (
+        "id" TEXT NOT NULL PRIMARY KEY,
+        "name" TEXT NOT NULL,
+        "description" TEXT NOT NULL DEFAULT '',
+        "isExample" BOOLEAN NOT NULL DEFAULT false,
+        "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "updatedAt" DATETIME NOT NULL
+      )`)
+      await seedClient.$executeRaw`
+        INSERT INTO "Project" ("id", "name", "updatedAt")
+        VALUES (${'legacy-project'}, ${'Preserved'}, ${new Date('2026-01-02T03:04:05Z')})
+      `
+    } finally {
+      await seedClient.$disconnect()
+    }
+
+    disconnect = disconnectProjectDbClient
+    const client = await getProjectDbClient(storageRoot)
+
+    await expect(access(backupPath)).resolves.toBeUndefined()
+    await expect(
+      client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
+    ).resolves.toMatchObject({ name: 'Preserved' })
+
+    const backupClient = new PrismaClient({
+      datasources: { db: { url: `file:${backupPath.replaceAll('\\', '/')}` } }
+    })
+    try {
+      await expect(
+        backupClient.$queryRaw<Array<{ id: string; name: string }>>`
+          SELECT "id", "name" FROM "Project"
+        `
+      ).resolves.toEqual([{ id: 'legacy-project', name: 'Preserved' }])
+      await expect(
+        backupClient.$queryRaw<Array<{ name: string }>>`
+          SELECT "name" FROM "sqlite_schema"
+          WHERE "type" = 'table' AND "name" = '_open_science_migrations'
+        `
+      ).resolves.toEqual([])
+    } finally {
+      await backupClient.$disconnect()
+    }
   })
 
   it('round-trips artifact lineage versions and enforces their session-scoped ordering keys', async () => {

--- a/src/main/projects/prisma-client.ts
+++ b/src/main/projects/prisma-client.ts
@@ -13,12 +13,14 @@ const PROJECT_DB_FILE = 'open-science.db'
 // SQLite PRAGMAs used by migrations are connection-scoped. Keeping a single connection also avoids
 // unnecessary SQLITE_BUSY contention for the local application database.
 const PROJECT_DB_CONNECTION_LIMIT = 1
+const projectDatabasePath = (storageRoot: string): string =>
+  join(storageRoot, PROJECT_DB_FILE).replace(/\\/g, '/')
 
 // Builds a client bound to the SQLite file under the given storage root. Not a singleton, so tests can
 // point separate clients at temp directories. Backslashes are normalized so the file: URL is valid on
 // Windows (Prisma's SQLite connector expects forward slashes).
 const createProjectDbClient = (storageRoot: string): PrismaClient => {
-  const dbPath = join(storageRoot, PROJECT_DB_FILE).replace(/\\/g, '/')
+  const dbPath = projectDatabasePath(storageRoot)
 
   return new PrismaClient({
     datasources: {
@@ -41,7 +43,10 @@ const getProjectDbClient = (
       try {
         await mkdir(storageRoot, { recursive: true })
         client = createProjectDbClient(storageRoot)
-        await migrateApplicationDatabase(client, migrationOptions)
+        await migrateApplicationDatabase(client, {
+          ...migrationOptions,
+          databasePath: projectDatabasePath(storageRoot)
+        })
       } catch (error) {
         await client?.$disconnect().catch(() => undefined)
         throw classifyDatabaseFailure(error, 'open')


### PR DESCRIPTION
## Problem

The ledger-aware startup path could upgrade an existing SQLite database without first preserving a durable recovery snapshot. Existing same-name backups also needed stronger validation, and migration failures did not expose enough sanitized schema context for support diagnosis.

Related issue: none.

## Proposed change

- Require a SQLite-owned snapshot before migrations that opt into `backupOnApply: required`.
- Publish backups through `VACUUM INTO` plus atomic rename so WAL data is included and partial files are never reusable.
- Reuse an existing backup only when `integrity_check`, schema objects, table sets, and full logical table contents including duplicate multiplicity match the live database.
- Run the generated current-schema verifier before compatibility reporting and backup cleanup, including when the ledger is already complete.
- Preserve explicitly supported retired Review/Finding columns during legacy adoption and final verification; unknown schema drift still fails closed.
- Keep apply-time backup requirements independent from `backupRetention`, so a future release can retire old snapshots only after successful final verification.
- Emit structured, redacted migration and backup lifecycle diagnostics, and pass the authoritative production database path into the migration service.
- Route structural migration SQL through the private migration executor while preserving the generated canonical schema and frozen baseline checksum.

```mermaid
flowchart LR
  A["Database startup"] --> B["Validate ledger"]
  B --> C{"Pending migration?"}
  C -->|"Yes, existing data"| D["Create or verify exact backup"]
  D --> E["Apply migration transaction"]
  C -->|"No"| F["Verify generated current schema"]
  E --> F
  F --> G["Verify SQLite runtime"]
  G --> H["Apply retention policy"]
  H --> I["Continue startup"]
  B -->|"Invalid history"| X["Blocked loading state"]
  D -->|"Backup failure or mismatch"| X
  E -->|"Migration failure"| X
  F -->|"Schema drift or corruption"| X
```

## Scope and non-goals

- No Prisma business-model, table-field, foreign-key, ownership, or delete-policy changes.
- No automatic restore, reset, downgrade, or continue-anyway behavior.
- No new renderer workflow; compatible databases continue normally, while failures remain on the existing loading gate.
- The internal design document remains under ignored `docs/internal` and is not part of this PR.
- No build, installer, native-engine, or release-workflow files change in this PR.

## Acceptance criteria and validation

All commands below ran after the final material edit.

| Behavior / affected consumer | Actual command | Result | Lane rationale |
| --- | --- | --- | --- |
| Explicitly retired Review/Finding columns remain accepted and preserved; unknown extra schema still blocks; failed final verification retains the recovery snapshot | `npm test -- src/main/database/migration-service.test.ts -t "keeps explicitly retired Review\|rejects schema objects outside\|keeps a recovery snapshot"` | 3/3 selected tests passed | Direct regressions for the exact-verifier boundary and retention ordering |
| Migration ordering, legacy adoption, pre-write backup, exact backup reuse, `integrity_check`, duplicate-row multiplicity, complete-ledger drift rejection, startup logging, production Prisma adapter, authoritative path, reopen, spaces and non-ASCII paths | `npm test -- src/main/database/migration-service.test.ts src/main/database/database-startup-logging.test.ts src/main/projects/prisma-client.test.ts` | 3/3 files and 68/68 tests passed | Covers every changed runtime owner plus the direct production client consumer |
| Node main-process and renderer interface compatibility | `npm run typecheck` | Node and web typechecks passed | Covers compile-time consumers across main/shared/renderer boundaries |
| Prisma plus CHECK overlay to generated canonical SQL drift | `npm run db:schema:check` | Generated database schema is current | Confirms no target-schema or frozen SQL drift |
| Repository lint policy | `npm run lint` | Passed with 0 errors; 17 warnings are in files outside this PR | Full repository lint is required after source edits |
| Cross-module portable fallback | `rtk npm test -- --maxWorkers=2` | 928 files and 13,374 tests passed; 15 files and 193 tests skipped | Full unfiltered suite selected because the change crosses migration, startup logging, and the production Prisma adapter; worker limiting changes only concurrency |
| Initial concurrency-timeout diagnosis | `npm test -- src/main/acp/runtime.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts` | 2/2 files and 517/517 tests passed | Confirms three unrelated timeouts from the first four-worker full run were resource contention; the final two-worker full run is green |
| Formatting and patch integrity | `npx prettier --check src/main/database/legacy-baseline-adapter.ts src/main/database/migration-service.ts src/main/database/migration-service.test.ts`; `git diff --check` | Passed | Covers the final material code edits and whitespace integrity |

Consumer lane choice: the focused set includes every changed runtime owner and direct production adapter. The full portable suite is also included because startup database eligibility affects all downstream repositories even though their files are unchanged.

Platform lane choice: exact-head PR Gate passed its macOS build/E2E and Windows core/E2E lanes. Local execution still does not claim native installed-package certification: architecture-specific macOS/Windows/Linux package launch, bundled Prisma engine, read-only/locked/disk-full process behavior, and Windows downgrade-chain evidence remain authoritative in release CI/nightly. This PR does not alter packaging or workflow files. Exact-head AI review also completed as mergeable with no actionable findings.

## Review focus

- Confirm every required backup completes before migration or ledger writes.
- Confirm backup reuse fails closed on SQLite index corruption and duplicate-count differences without exposing row values.
- Confirm the generated current-schema verifier runs before any retention cleanup, including the complete-ledger path.
- Confirm final verification tolerates only classifier-supported retired columns and preserves their values while unknown drift remains blocked.
- Confirm retention cleanup does not report deletion for an absent file.
- Confirm the latest-main equivalent legacy CHECK handling and immutable `0001` checksum remain intact.
