### PR TITLE
fix(startup): reuse branded database loading animation

### DIFF
--- a/src/renderer/src/components/database-startup-gate.test.tsx
+++ b/src/renderer/src/components/database-startup-gate.test.tsx
@@ -12,9 +12,13 @@ describe('DatabaseStartupGate', () => {
   const retry = vi.fn<() => Promise<DatabaseStartupState>>()
   const quit = vi.fn<() => Promise<void>>()
 
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
 
   beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
     getState.mockReset().mockResolvedValue({ phase: 'checking' })
     retry.mockReset()
     quit.mockReset().mockResolvedValue()
@@ -29,6 +33,23 @@ describe('DatabaseStartupGate', () => {
         }
       }
     } as unknown as Window['api']
+  })
+
+  it('reuses the branded startup loader while checking and migrating the database', () => {
+    render(
+      <DatabaseStartupGate>
+        <div>Business application</div>
+      </DatabaseStartupGate>
+    )
+
+    const startupLoader = screen.getByTestId('open-science-logo-loader')
+    expect(screen.getByText('Checking database…')).toBeTruthy()
+
+    act(() => publish({ phase: 'migrating', migrationId: '0002_example' }))
+
+    expect(screen.getByText('Updating database…')).toBeTruthy()
+    expect(screen.getByText('Keep Open Science open while this finishes.')).toBeTruthy()
+    expect(screen.getByTestId('open-science-logo-loader')).toBe(startupLoader)
   })
 
   it('keeps the application unmounted until the database and runtime are ready', async () => {

--- a/src/renderer/src/components/database-startup-gate.tsx
+++ b/src/renderer/src/components/database-startup-gate.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ReactNode } from 'react'
 
 import logo from '@/assets/logo.png'
 import logoDark from '@/assets/logo-dark.png'
+import { OpenScienceLogoLoader } from '@/components/OpenScienceLogoLoader'
 import { Button } from '@/components/ui/button'
 import type { DatabaseStartupState } from '../../../shared/database-startup'
 
@@ -48,10 +49,12 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
       aria-live="polite"
     >
       <section className="flex w-full max-w-md flex-col items-center text-center">
-        <div className="mb-10">
-          <img src={logo} alt="Open Science" className="h-12 w-auto dark:hidden" />
-          <img src={logoDark} alt="Open Science" className="hidden h-12 w-auto dark:block" />
-        </div>
+        {state.phase === 'blocked' ? (
+          <div className="mb-10">
+            <img src={logo} alt="Open Science" className="h-12 w-auto dark:hidden" />
+            <img src={logoDark} alt="Open Science" className="hidden h-12 w-auto dark:block" />
+          </div>
+        ) : null}
 
         {state.phase === 'blocked' ? (
           <div className="w-full rounded-xl border border-border bg-card p-7 text-left shadow-card">
@@ -75,19 +78,18 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
             </div>
           </div>
         ) : (
-          <div className="flex flex-col items-center gap-4">
-            <span
-              className="size-6 animate-spin rounded-full border-2 border-border border-t-primary"
-              aria-hidden="true"
-            />
-            <h1 className="text-base font-medium text-foreground">
-              {state.phase === 'migrating' ? 'Updating database…' : 'Checking database…'}
-            </h1>
-            {state.phase === 'migrating' ? (
-              <p className="text-sm text-muted-foreground">
-                Keep Open Science open while this finishes.
-              </p>
-            ) : null}
+          <div className="flex flex-col items-center gap-14">
+            <OpenScienceLogoLoader />
+            <div className="flex flex-col items-center gap-4">
+              <h1 className="text-base font-medium text-foreground">
+                {state.phase === 'migrating' ? 'Updating database…' : 'Checking database…'}
+              </h1>
+              {state.phase === 'migrating' ? (
+                <p className="text-sm text-muted-foreground">
+                  Keep Open Science open while this finishes.
+                </p>
+              ) : null}
+            </div>
           </div>
         )}
       </section>


### PR DESCRIPTION
## Problem

Database checking and migration used a separate static logo and spinner, so the startup experience did not match the branded loading animation already used for settings and saved conversations.

## Proposed change

- Reuse `OpenScienceLogoLoader` for both database checking and migration.
- Preserve the same loader canvas across the checking-to-migrating state transition.
- Keep the migration status copy and keep-open guidance.
- Leave the blocked database error surface unchanged.

## Scope and non-goals

- No database schema, migration engine, IPC, or startup-state changes.
- No new animation implementation or dependency.
- No E2E snapshot update: the existing Electron E2E startup fixture waits for `databaseStartup` to become `ready` and does not capture the transient checking/migrating surface.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Database loading presentation -> `npm test -- src/renderer/src/components/database-startup-gate.test.tsx` -> 4 tests passed.
- Renderer and main-process types -> `npm run typecheck` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors and 17 pre-existing warnings outside this diff.
- Production Electron bundles -> `npm run build:e2e` -> passed.
- Electron startup gate and desktop journey -> `npm run test:e2e -- e2e/electron-foundation.spec.ts` -> 3 tests passed.
- Complete portable suite -> `npm test` -> 927 files passed, 15 skipped, with one unrelated 15-second architecture-scan timeout.
- Timed-out architecture scan -> `npm test -- src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts -t 'keeps private owners behind the public facade'` -> passed in 3.7 seconds.

Uncovered risk: the transient animated migration frame is not screenshot-tested end to end. The deterministic owner test verifies that checking and migration render and retain the same branded loader canvas; PR Gate remains the final validation authority.

## Review focus

- Confirm the database checking and migration states now match the existing branded startup loader.
- Confirm the blocked error state keeps its existing static branding and controls.
