### PR TITLE
ci(database): enforce versioned schema migrations

### DIFF
--- a/scripts/ci/check-pr-policy.mjs
+++ b/scripts/ci/check-pr-policy.mjs
@@ -5,6 +5,8 @@ import { appendFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { parseNameStatus } from './classify-pr-changes.mjs'
+
 const allowedTypes = [
   'feat',
   'fix',
@@ -22,6 +24,117 @@ const allowedTypes = [
 const subjectPattern = new RegExp(
   `^(${allowedTypes.join('|')})\\([a-z][A-Za-z0-9-]*\\)!?: [a-z][^\\r\\n]*$`
 )
+
+const databaseSchemaPaths = new Set([
+  'prisma/schema.prisma',
+  'prisma/sqlite-check-constraints.json'
+])
+const migrationDirectory = 'src/main/database/migrations/'
+const migrationServicePath = 'src/main/database/migration-service.ts'
+const migrationPathPattern =
+  /^src\/main\/database\/migrations\/(\d{4})-([a-z0-9]+(?:-[a-z0-9]+)*)\.ts$/
+
+const migrationVersion = (path) => Number(path.match(migrationPathPattern)?.[1])
+
+const escapeRegularExpression = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+export function checkDatabaseMigrationPolicy({ changes, baseMigrationPaths, headFiles = {} }) {
+  const violations = []
+  const basePaths = new Set(baseMigrationPaths)
+  const schemaChanged = changes.some(({ path, previousPath }) =>
+    [path, previousPath].some((candidate) => databaseSchemaPaths.has(candidate))
+  )
+  const addedPaths = changes
+    .filter(
+      ({ path, status }) =>
+        path.startsWith(migrationDirectory) &&
+        !basePaths.has(path) &&
+        ['added', 'copied', 'renamed'].includes(status)
+    )
+    .map(({ path }) => path)
+
+  for (const { path, previousPath, status } of changes) {
+    const changedReleasedPath =
+      (basePaths.has(path) && status !== 'copied') ||
+      (basePaths.has(previousPath) && ['deleted', 'renamed'].includes(status))
+    if (changedReleasedPath) {
+      violations.push({
+        kind: 'database-migration',
+        subject: `${previousPath ?? path} is immutable; add a new versioned migration instead`
+      })
+    }
+  }
+
+  if (schemaChanged && addedPaths.length === 0) {
+    violations.push({
+      kind: 'database-migration',
+      subject: `database schema contracts changed without a new migration under ${migrationDirectory}`
+    })
+  }
+
+  const baseVersions = baseMigrationPaths.map(migrationVersion).filter(Number.isInteger)
+  let expectedVersion = Math.max(0, ...baseVersions) + 1
+  const versionedPaths = []
+  for (const path of addedPaths) {
+    const match = path.match(migrationPathPattern)
+    if (!match) {
+      violations.push({
+        kind: 'database-migration',
+        subject: `${path} must use the NNNN-lowercase-description.ts format`
+      })
+      continue
+    }
+    versionedPaths.push({ path, version: Number(match[1]), description: match[2] })
+  }
+
+  const serviceSource = headFiles[migrationServicePath] ?? ''
+  const manifestSource = serviceSource.match(
+    /const MIGRATION_MANIFEST = \[([\s\S]*?)\]\s+as const satisfies/
+  )?.[1]
+  for (const { path, version, description } of versionedPaths.sort(
+    (left, right) => left.version - right.version || left.path.localeCompare(right.path)
+  )) {
+    if (version !== expectedVersion) {
+      violations.push({
+        kind: 'database-migration',
+        subject: `${path} must use the next migration version ${String(expectedVersion).padStart(4, '0')}`
+      })
+    }
+    expectedVersion += 1
+
+    const migrationSource = headFiles[path] ?? ''
+    const declaration = migrationSource.match(
+      /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*\{[^}]*\bid:\s*['"]([^'"]+)['"]/
+    )
+    const expectedId = `${String(version).padStart(4, '0')}_${description.replaceAll('-', '_')}`
+    if (!declaration || declaration[2] !== expectedId) {
+      violations.push({
+        kind: 'database-migration',
+        subject: `${path} must declare migration id ${expectedId}`
+      })
+      continue
+    }
+
+    const migrationName = declaration[1]
+    const moduleName = path.slice(migrationDirectory.length, -3)
+    const importPattern = new RegExp(
+      `import\\s*\\{[^}]*\\b${escapeRegularExpression(migrationName)}\\b[^}]*\\}\\s*from\\s*['"]\\.\\/migrations\\/${escapeRegularExpression(moduleName)}['"]`
+    )
+    const manifestPattern = new RegExp(`\\.\\.\\.${escapeRegularExpression(migrationName)}\\b`)
+    if (
+      !importPattern.test(serviceSource) ||
+      !manifestSource ||
+      !manifestPattern.test(manifestSource)
+    ) {
+      violations.push({
+        kind: 'database-migration',
+        subject: `${path} must be imported and registered in MIGRATION_MANIFEST`
+      })
+    }
+  }
+
+  return violations
+}
 
 export function checkPrPolicy({
   eventName,
@@ -90,21 +203,62 @@ export function runPrPolicyCli(environment = process.env) {
   }
   let commitSubjects = []
   let commitMessages = []
+  let databaseMigrationViolations = []
 
-  if (eventName === 'pull_request' && scope !== 'title') {
+  if (['pull_request', 'merge_group'].includes(eventName) && scope !== 'title') {
     const base = requireCommit(environment.BASE_SHA, 'BASE_SHA')
     const head = requireCommit(environment.HEAD_SHA, 'HEAD_SHA')
-    const commitHashes = execFileSync('git', ['log', '--format=%H', `${base}..${head}`], {
+    const mergeBase = execFileSync('git', ['merge-base', base, head], {
       encoding: 'utf8'
-    })
+    }).trim()
+    const changes = parseNameStatus(
+      execFileSync('git', ['diff', '--name-status', '-z', mergeBase, head]).toString('utf8')
+    )
+    const baseMigrationPaths = execFileSync(
+      'git',
+      ['ls-tree', '-r', '--name-only', mergeBase, '--', migrationDirectory],
+      { encoding: 'utf8' }
+    )
       .split('\n')
       .filter(Boolean)
-    commitSubjects = commitHashes.map((commit) =>
-      execFileSync('git', ['show', '-s', '--format=%s', commit], { encoding: 'utf8' }).trimEnd()
+    const addedMigrationPaths = changes
+      .filter(
+        ({ path, status }) =>
+          path.startsWith(migrationDirectory) &&
+          !baseMigrationPaths.includes(path) &&
+          ['added', 'copied', 'renamed'].includes(status)
+      )
+      .map(({ path }) => path)
+    const headPaths = new Set(addedMigrationPaths)
+    if (addedMigrationPaths.length > 0) headPaths.add(migrationServicePath)
+    const headFiles = Object.fromEntries(
+      [...headPaths].map((path) => [
+        path,
+        execFileSync('git', ['show', `${head}:${path}`], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore']
+        })
+      ])
     )
-    commitMessages = commitHashes.map((commit) =>
-      execFileSync('git', ['show', '-s', '--format=%B', commit], { encoding: 'utf8' }).trimEnd()
-    )
+    databaseMigrationViolations = checkDatabaseMigrationPolicy({
+      changes,
+      baseMigrationPaths,
+      headFiles
+    })
+
+    if (eventName === 'pull_request') {
+      const commitHashes = execFileSync('git', ['log', '--format=%H', `${base}..${head}`], {
+        encoding: 'utf8'
+      })
+        .split('\n')
+        .filter(Boolean)
+      commitSubjects = commitHashes.map((commit) =>
+        execFileSync('git', ['show', '-s', '--format=%s', commit], { encoding: 'utf8' }).trimEnd()
+      )
+      commitMessages = commitHashes.map((commit) =>
+        execFileSync('git', ['show', '-s', '--format=%B', commit], { encoding: 'utf8' }).trimEnd()
+      )
+    }
   }
 
   const result = checkPrPolicy({
@@ -114,6 +268,8 @@ export function runPrPolicyCli(environment = process.env) {
     commitMessages,
     scope
   })
+  result.violations.push(...databaseMigrationViolations)
+  result.ok = result.violations.length === 0
   const summary = formatPrPolicySummary(result)
   if (environment.GITHUB_STEP_SUMMARY) appendFileSync(environment.GITHUB_STEP_SUMMARY, summary)
   else process.stdout.write(summary)

--- a/scripts/ci/check-pr-policy.mjs
+++ b/scripts/ci/check-pr-policy.mjs
@@ -104,13 +104,73 @@ const sanitizePolicySource = (source, { maskStrings = false } = {}) => {
   return result
 }
 
-const manifestMigrationNames = (source) => {
-  const manifest = sanitizePolicySource(source, { maskStrings: true }).match(
+const manifestEntries = (source) => {
+  const sanitized = sanitizePolicySource(source, { maskStrings: true })
+  const match = sanitized.match(
     /(?:^|\n)\s*const MIGRATION_MANIFEST = \[([\s\S]*?)\]\s+as const satisfies/m
-  )?.[1]
-  return manifest
-    ? [...manifest.matchAll(/\.\.\.([A-Za-z_$][\w$]*)\b/g)].map((match) => match[1])
-    : []
+  )
+  if (!match) return []
+
+  const bodyStart = match.index + match[0].indexOf('[') + 1
+  const bodyEnd = bodyStart + match[1].length
+  const entries = []
+  const depth = { brace: 0, bracket: 0, parenthesis: 0 }
+  let entryStart = bodyStart
+  for (let index = bodyStart; index < bodyEnd; index += 1) {
+    switch (sanitized[index]) {
+      case '{':
+        depth.brace += 1
+        break
+      case '}':
+        depth.brace -= 1
+        break
+      case '[':
+        depth.bracket += 1
+        break
+      case ']':
+        depth.bracket -= 1
+        break
+      case '(':
+        depth.parenthesis += 1
+        break
+      case ')':
+        depth.parenthesis -= 1
+        break
+      case ',':
+        if (depth.brace === 0 && depth.bracket === 0 && depth.parenthesis === 0) {
+          const entry = source.slice(entryStart, index).trim()
+          if (entry) entries.push(entry)
+          entryStart = index + 1
+        }
+        break
+    }
+  }
+  const finalEntry = source.slice(entryStart, bodyEnd).trim()
+  if (finalEntry) entries.push(finalEntry)
+  return entries
+}
+
+const manifestMigrationNames = (source) =>
+  manifestEntries(source).flatMap((entry) =>
+    [
+      ...sanitizePolicySource(entry, { maskStrings: true }).matchAll(/\.\.\.([A-Za-z_$][\w$]*)\b/g)
+    ].map((match) => match[1])
+  )
+
+const namedImports = (source) => {
+  const imports = new Map()
+  const sanitized = sanitizePolicySource(source)
+  for (const match of sanitized.matchAll(
+    /(?:^|\n)\s*import\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/gm
+  )) {
+    for (const specifier of match[1].split(',')) {
+      const names = specifier
+        .trim()
+        .match(/^(?:type\s+)?([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/)
+      if (names) imports.set(names[2] ?? names[1], `${names[1]}\0${match[2]}`)
+    }
+  }
+  return imports
 }
 
 export function checkDatabaseMigrationPolicy({
@@ -210,18 +270,24 @@ export function checkDatabaseMigrationPolicy({
   }
 
   if (Object.hasOwn(baseFiles, migrationServicePath)) {
-    const expectedManifestNames = [
-      ...manifestMigrationNames(baseFiles[migrationServicePath]),
-      ...addedMigrationNames
-    ]
+    const baseServiceSource = baseFiles[migrationServicePath]
+    const baseManifestEntries = manifestEntries(baseServiceSource)
+    const headManifestEntries = manifestEntries(headFiles[migrationServicePath] ?? '')
+    const baseManifestNames = manifestMigrationNames(baseServiceSource)
+    const expectedManifestNames = [...baseManifestNames, ...addedMigrationNames]
+    const baseImports = namedImports(baseServiceSource)
+    const headImports = namedImports(headFiles[migrationServicePath] ?? '')
     if (
+      headManifestEntries.length !== baseManifestEntries.length + addedMigrationNames.length ||
+      baseManifestEntries.some((entry, index) => headManifestEntries[index] !== entry) ||
+      baseManifestNames.some((name) => baseImports.get(name) !== headImports.get(name)) ||
       expectedManifestNames.length !== headManifestNames.length ||
       expectedManifestNames.some((name, index) => headManifestNames[index] !== name)
     ) {
       violations.push({
         kind: 'database-migration',
         subject:
-          'MIGRATION_MANIFEST must preserve the existing order and append new migrations in version order'
+          'MIGRATION_MANIFEST must preserve existing entries and imports exactly and append new migrations in version order'
       })
     }
   }

--- a/scripts/ci/check-pr-policy.mjs
+++ b/scripts/ci/check-pr-policy.mjs
@@ -38,7 +38,87 @@ const migrationVersion = (path) => Number(path.match(migrationPathPattern)?.[1])
 
 const escapeRegularExpression = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-export function checkDatabaseMigrationPolicy({ changes, baseMigrationPaths, headFiles = {} }) {
+const sanitizePolicySource = (source, { maskStrings = false } = {}) => {
+  let result = ''
+  let state = 'code'
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index]
+    const next = source[index + 1]
+
+    if (state === 'line-comment') {
+      if (character === '\n') {
+        result += '\n'
+        state = 'code'
+      } else result += ' '
+      continue
+    }
+    if (state === 'block-comment') {
+      if (character === '*' && next === '/') {
+        result += '  '
+        index += 1
+        state = 'code'
+      } else result += character === '\n' ? '\n' : ' '
+      continue
+    }
+    if (state === 'template') {
+      if (character === '\\' && next) {
+        result += '  '
+        index += 1
+      } else if (character === '`') {
+        result += '`'
+        state = 'code'
+      } else result += character === '\n' ? '\n' : ' '
+      continue
+    }
+    if (state === 'single-quote' || state === 'double-quote') {
+      const quote = state === 'single-quote' ? "'" : '"'
+      if (character === '\\' && next) {
+        result += maskStrings ? '  ' : `${character}${next}`
+        index += 1
+      } else {
+        result += maskStrings && character !== quote ? ' ' : character
+        if (character === quote) state = 'code'
+      }
+      continue
+    }
+
+    if (character === '/' && next === '/') {
+      result += '  '
+      index += 1
+      state = 'line-comment'
+    } else if (character === '/' && next === '*') {
+      result += '  '
+      index += 1
+      state = 'block-comment'
+    } else if (character === '`') {
+      result += '`'
+      state = 'template'
+    } else if (character === "'") {
+      result += character
+      state = 'single-quote'
+    } else if (character === '"') {
+      result += character
+      state = 'double-quote'
+    } else result += character
+  }
+  return result
+}
+
+const manifestMigrationNames = (source) => {
+  const manifest = sanitizePolicySource(source, { maskStrings: true }).match(
+    /(?:^|\n)\s*const MIGRATION_MANIFEST = \[([\s\S]*?)\]\s+as const satisfies/m
+  )?.[1]
+  return manifest
+    ? [...manifest.matchAll(/\.\.\.([A-Za-z_$][\w$]*)\b/g)].map((match) => match[1])
+    : []
+}
+
+export function checkDatabaseMigrationPolicy({
+  changes,
+  baseMigrationPaths,
+  baseFiles = {},
+  headFiles = {}
+}) {
   const violations = []
   const basePaths = new Set(baseMigrationPaths)
   const schemaChanged = changes.some(({ path, previousPath }) =>
@@ -87,10 +167,9 @@ export function checkDatabaseMigrationPolicy({ changes, baseMigrationPaths, head
     versionedPaths.push({ path, version: Number(match[1]), description: match[2] })
   }
 
-  const serviceSource = headFiles[migrationServicePath] ?? ''
-  const manifestSource = serviceSource.match(
-    /const MIGRATION_MANIFEST = \[([\s\S]*?)\]\s+as const satisfies/
-  )?.[1]
+  const serviceSource = sanitizePolicySource(headFiles[migrationServicePath] ?? '')
+  const headManifestNames = manifestMigrationNames(headFiles[migrationServicePath] ?? '')
+  const addedMigrationNames = []
   for (const { path, version, description } of versionedPaths.sort(
     (left, right) => left.version - right.version || left.path.localeCompare(right.path)
   )) {
@@ -102,9 +181,9 @@ export function checkDatabaseMigrationPolicy({ changes, baseMigrationPaths, head
     }
     expectedVersion += 1
 
-    const migrationSource = headFiles[path] ?? ''
+    const migrationSource = sanitizePolicySource(headFiles[path] ?? '')
     const declaration = migrationSource.match(
-      /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*\{[^}]*\bid:\s*['"]([^'"]+)['"]/
+      /(?:^|\n)\s*const\s+([A-Za-z_$][\w$]*)\s*=\s*\{[^}]*\bid:\s*['"]([^'"]+)['"]/m
     )
     const expectedId = `${String(version).padStart(4, '0')}_${description.replaceAll('-', '_')}`
     if (!declaration || declaration[2] !== expectedId) {
@@ -116,19 +195,33 @@ export function checkDatabaseMigrationPolicy({ changes, baseMigrationPaths, head
     }
 
     const migrationName = declaration[1]
+    addedMigrationNames.push(migrationName)
     const moduleName = path.slice(migrationDirectory.length, -3)
     const importPattern = new RegExp(
-      `import\\s*\\{[^}]*\\b${escapeRegularExpression(migrationName)}\\b[^}]*\\}\\s*from\\s*['"]\\.\\/migrations\\/${escapeRegularExpression(moduleName)}['"]`
+      `(?:^|\\n)\\s*import\\s*\\{[^}]*\\b${escapeRegularExpression(migrationName)}\\b[^}]*\\}\\s*from\\s*['"]\\.\\/migrations\\/${escapeRegularExpression(moduleName)}['"]`,
+      'm'
     )
-    const manifestPattern = new RegExp(`\\.\\.\\.${escapeRegularExpression(migrationName)}\\b`)
-    if (
-      !importPattern.test(serviceSource) ||
-      !manifestSource ||
-      !manifestPattern.test(manifestSource)
-    ) {
+    if (!importPattern.test(serviceSource) || !headManifestNames.includes(migrationName)) {
       violations.push({
         kind: 'database-migration',
         subject: `${path} must be imported and registered in MIGRATION_MANIFEST`
+      })
+    }
+  }
+
+  if (Object.hasOwn(baseFiles, migrationServicePath)) {
+    const expectedManifestNames = [
+      ...manifestMigrationNames(baseFiles[migrationServicePath]),
+      ...addedMigrationNames
+    ]
+    if (
+      expectedManifestNames.length !== headManifestNames.length ||
+      expectedManifestNames.some((name, index) => headManifestNames[index] !== name)
+    ) {
+      violations.push({
+        kind: 'database-migration',
+        subject:
+          'MIGRATION_MANIFEST must preserve the existing order and append new migrations in version order'
       })
     }
   }
@@ -216,7 +309,7 @@ export function runPrPolicyCli(environment = process.env) {
     )
     const baseMigrationPaths = execFileSync(
       'git',
-      ['ls-tree', '-r', '--name-only', mergeBase, '--', migrationDirectory],
+      ['ls-tree', '-r', '--name-only', base, '--', migrationDirectory],
       { encoding: 'utf8' }
     )
       .split('\n')
@@ -230,7 +323,10 @@ export function runPrPolicyCli(environment = process.env) {
       )
       .map(({ path }) => path)
     const headPaths = new Set(addedMigrationPaths)
-    if (addedMigrationPaths.length > 0) headPaths.add(migrationServicePath)
+    const serviceChanged = changes.some(({ path, previousPath }) =>
+      [path, previousPath].includes(migrationServicePath)
+    )
+    if (addedMigrationPaths.length > 0 || serviceChanged) headPaths.add(migrationServicePath)
     const headFiles = Object.fromEntries(
       [...headPaths].map((path) => [
         path,
@@ -240,9 +336,23 @@ export function runPrPolicyCli(environment = process.env) {
         })
       ])
     )
+    let baseFiles = {}
+    if (headPaths.has(migrationServicePath)) {
+      try {
+        baseFiles = {
+          [migrationServicePath]: execFileSync('git', ['show', `${base}:${migrationServicePath}`], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore']
+          })
+        }
+      } catch {
+        baseFiles = {}
+      }
+    }
     databaseMigrationViolations = checkDatabaseMigrationPolicy({
       changes,
       baseMigrationPaths,
+      baseFiles,
       headFiles
     })
 

--- a/scripts/ci/check-pr-policy.test.ts
+++ b/scripts/ci/check-pr-policy.test.ts
@@ -131,7 +131,53 @@ const MIGRATION_MANIFEST = [
         }
       })
     ).toEqual([
-      expect.objectContaining({ subject: expect.stringContaining('preserve the existing order') })
+      expect.objectContaining({ subject: expect.stringContaining('preserve existing entries') })
+    ])
+  })
+
+  it('keeps every existing migration manifest entry immutable', () => {
+    const baseSource = `const MIGRATION_MANIFEST = [
+  {
+    ...runtimeSchemaBaselineMigration,
+    checksum: BASELINE_CHECKSUM,
+    backupOnApply: 'required'
+  }
+] as const satisfies readonly MigrationManifestEntry[]
+`
+    const changedSource = baseSource.replace("backupOnApply: 'required'", "backupOnApply: 'none'")
+
+    expect(
+      checkDatabaseMigrationPolicy({
+        changes: [{ path: 'src/main/database/migration-service.ts', status: 'modified' }],
+        baseMigrationPaths: baselineMigrations,
+        baseFiles: { 'src/main/database/migration-service.ts': baseSource },
+        headFiles: { 'src/main/database/migration-service.ts': changedSource }
+      })
+    ).toEqual([
+      expect.objectContaining({ subject: expect.stringContaining('preserve existing entries') })
+    ])
+  })
+
+  it('keeps imports for existing migration manifest entries immutable', () => {
+    const baseSource = `import { runtimeSchemaBaselineMigration } from './migrations/0001-runtime-schema-baseline'
+const MIGRATION_MANIFEST = [
+  { ...runtimeSchemaBaselineMigration }
+] as const satisfies readonly MigrationManifestEntry[]
+`
+    const changedSource = baseSource.replace(
+      './migrations/0001-runtime-schema-baseline',
+      './migrations/0002-project-agent-context'
+    )
+
+    expect(
+      checkDatabaseMigrationPolicy({
+        changes: [{ path: 'src/main/database/migration-service.ts', status: 'modified' }],
+        baseMigrationPaths: baselineMigrations,
+        baseFiles: { 'src/main/database/migration-service.ts': baseSource },
+        headFiles: { 'src/main/database/migration-service.ts': changedSource }
+      })
+    ).toEqual([
+      expect.objectContaining({ subject: expect.stringContaining('preserve existing entries') })
     ])
   })
 
@@ -153,7 +199,7 @@ const MIGRATION_MANIFEST = [
     ).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ subject: expect.stringContaining('declare migration id') }),
-        expect.objectContaining({ subject: expect.stringContaining('preserve the existing order') })
+        expect.objectContaining({ subject: expect.stringContaining('preserve existing entries') })
       ])
     )
   })

--- a/scripts/ci/check-pr-policy.test.ts
+++ b/scripts/ci/check-pr-policy.test.ts
@@ -1,13 +1,104 @@
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { checkPrPolicy } from './check-pr-policy.mjs'
+import { checkDatabaseMigrationPolicy, checkPrPolicy } from './check-pr-policy.mjs'
+
+const baselineMigrations = [
+  'src/main/database/migrations/0001-runtime-schema-baseline.ts',
+  'src/main/database/migrations/0002-project-agent-context.ts'
+]
+const nextMigrationPath = 'src/main/database/migrations/0003-project-label.ts'
+const nextMigrationSource = `const projectLabelMigration = {
+  id: '0003_project_label',
+  statements: [],
+  verifiers: []
+}
+`
+const migrationServiceSource = `import { projectLabelMigration } from './migrations/0003-project-label'
+const MIGRATION_MANIFEST = [
+  { ...projectLabelMigration }
+] as const satisfies readonly MigrationManifestEntry[]
+`
 
 describe('pull request policy', () => {
+  it('requires schema contract changes to add and register the next migration version', () => {
+    expect(
+      checkDatabaseMigrationPolicy({
+        changes: [{ path: 'prisma/schema.prisma', status: 'modified' }],
+        baseMigrationPaths: baselineMigrations
+      })
+    ).toEqual([
+      expect.objectContaining({ subject: expect.stringContaining('without a new migration') })
+    ])
+
+    expect(
+      checkDatabaseMigrationPolicy({
+        changes: [
+          { path: 'prisma/schema.prisma', status: 'modified' },
+          { path: nextMigrationPath, status: 'added' }
+        ],
+        baseMigrationPaths: baselineMigrations,
+        headFiles: {
+          [nextMigrationPath]: nextMigrationSource,
+          'src/main/database/migration-service.ts': migrationServiceSource
+        }
+      })
+    ).toEqual([])
+  })
+
+  it('keeps released migrations immutable', () => {
+    expect(
+      checkDatabaseMigrationPolicy({
+        changes: [{ path: baselineMigrations[1], status: 'modified' }],
+        baseMigrationPaths: baselineMigrations
+      })
+    ).toEqual([expect.objectContaining({ subject: expect.stringContaining('is immutable') })])
+  })
+
+  it('rejects skipped and mismatched migration versions', () => {
+    const path = 'src/main/database/migrations/0004-project-label.ts'
+    const violations = checkDatabaseMigrationPolicy({
+      changes: [{ path, status: 'added' }],
+      baseMigrationPaths: baselineMigrations,
+      headFiles: {
+        [path]: nextMigrationSource,
+        'src/main/database/migration-service.ts': ''
+      }
+    })
+
+    expect(violations.map(({ subject }) => subject)).toEqual([
+      expect.stringContaining('next migration version 0003'),
+      expect.stringContaining('must declare migration id 0004_project_label')
+    ])
+  })
+
+  it('rejects unversioned and unregistered migration files', () => {
+    expect(
+      checkDatabaseMigrationPolicy({
+        changes: [{ path: 'src/main/database/migrations/project-label.ts', status: 'added' }],
+        baseMigrationPaths: baselineMigrations
+      })
+    ).toEqual([
+      expect.objectContaining({ subject: expect.stringContaining('NNNN-lowercase-description.ts') })
+    ])
+
+    expect(
+      checkDatabaseMigrationPolicy({
+        changes: [{ path: nextMigrationPath, status: 'added' }],
+        baseMigrationPaths: baselineMigrations,
+        headFiles: { [nextMigrationPath]: nextMigrationSource }
+      })
+    ).toEqual([
+      expect.objectContaining({
+        subject: expect.stringContaining('registered in MIGRATION_MANIFEST')
+      })
+    ])
+  })
+
   it('validates commit subjects from the Git revision CLI', () => {
     const root = mkdtempSync(join(tmpdir(), 'pr-policy-'))
     const summary = join(root, 'summary')
@@ -60,6 +151,65 @@ describe('pull request policy', () => {
 
       expect(result.status, result.stderr).toBe(0)
       expect(readFileSync(summary, 'utf8')).toContain('Result: **pass**')
+    } finally {
+      rmSync(root, { force: true, recursive: true })
+    }
+  })
+
+  it('rejects an unversioned schema contract change from the Git revision CLI', () => {
+    const root = mkdtempSync(join(tmpdir(), 'database-migration-policy-'))
+    const summary = join(root, 'summary')
+
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: root })
+      execFileSync('git', ['config', 'user.email', 'ci@example.com'], { cwd: root })
+      execFileSync('git', ['config', 'user.name', 'CI Test'], { cwd: root })
+      mkdirSync(join(root, 'prisma'), { recursive: true })
+      mkdirSync(join(root, 'src/main/database/migrations'), { recursive: true })
+      writeFileSync(join(root, 'prisma/schema.prisma'), 'model Probe { id String @id }\n')
+      writeFileSync(
+        join(root, 'src/main/database/migrations/0001-runtime-schema-baseline.ts'),
+        "const baseline = { id: '0001_runtime_schema_baseline' }\n"
+      )
+      execFileSync('git', ['add', '.'], { cwd: root })
+      execFileSync('git', ['commit', '--quiet', '-m', 'chore(fixture): add baseline'], {
+        cwd: root
+      })
+      const base = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: root,
+        encoding: 'utf8'
+      }).trim()
+
+      writeFileSync(
+        join(root, 'prisma/schema.prisma'),
+        'model Probe { id String @id, value String }\n'
+      )
+      execFileSync('git', ['add', 'prisma/schema.prisma'], { cwd: root })
+      execFileSync('git', ['commit', '--quiet', '-m', 'feat(database): add probe value'], {
+        cwd: root
+      })
+      const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: root,
+        encoding: 'utf8'
+      }).trim()
+
+      const result = spawnSync(process.execPath, [resolve('scripts/ci/check-pr-policy.mjs')], {
+        cwd: root,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          BASE_SHA: base,
+          EVENT_NAME: 'pull_request',
+          GITHUB_STEP_SUMMARY: summary,
+          HEAD_SHA: head,
+          POLICY_SCOPE: 'commits'
+        }
+      })
+
+      expect(result.status, result.stderr).toBe(1)
+      expect(readFileSync(summary, 'utf8')).toContain(
+        'database schema contracts changed without a new migration'
+      )
     } finally {
       rmSync(root, { force: true, recursive: true })
     }

--- a/scripts/ci/check-pr-policy.test.ts
+++ b/scripts/ci/check-pr-policy.test.ts
@@ -18,8 +18,19 @@ const nextMigrationSource = `const projectLabelMigration = {
   verifiers: []
 }
 `
-const migrationServiceSource = `import { projectLabelMigration } from './migrations/0003-project-label'
+const baseMigrationServiceSource = `import { runtimeSchemaBaselineMigration } from './migrations/0001-runtime-schema-baseline'
+import { projectAgentContextMigration } from './migrations/0002-project-agent-context'
 const MIGRATION_MANIFEST = [
+  { ...runtimeSchemaBaselineMigration },
+  { ...projectAgentContextMigration }
+] as const satisfies readonly MigrationManifestEntry[]
+`
+const migrationServiceSource = `import { projectLabelMigration } from './migrations/0003-project-label'
+import { runtimeSchemaBaselineMigration } from './migrations/0001-runtime-schema-baseline'
+import { projectAgentContextMigration } from './migrations/0002-project-agent-context'
+const MIGRATION_MANIFEST = [
+  { ...runtimeSchemaBaselineMigration },
+  { ...projectAgentContextMigration },
   { ...projectLabelMigration }
 ] as const satisfies readonly MigrationManifestEntry[]
 `
@@ -42,6 +53,7 @@ describe('pull request policy', () => {
           { path: nextMigrationPath, status: 'added' }
         ],
         baseMigrationPaths: baselineMigrations,
+        baseFiles: { 'src/main/database/migration-service.ts': baseMigrationServiceSource },
         headFiles: {
           [nextMigrationPath]: nextMigrationSource,
           'src/main/database/migration-service.ts': migrationServiceSource
@@ -97,6 +109,53 @@ describe('pull request policy', () => {
         subject: expect.stringContaining('registered in MIGRATION_MANIFEST')
       })
     ])
+  })
+
+  it('requires new migrations to append after the unchanged manifest prefix', () => {
+    const reversedServiceSource = `import { projectLabelMigration } from './migrations/0003-project-label'
+const MIGRATION_MANIFEST = [
+  { ...projectLabelMigration },
+  { ...runtimeSchemaBaselineMigration },
+  { ...projectAgentContextMigration }
+] as const satisfies readonly MigrationManifestEntry[]
+`
+
+    expect(
+      checkDatabaseMigrationPolicy({
+        changes: [{ path: nextMigrationPath, status: 'added' }],
+        baseMigrationPaths: baselineMigrations,
+        baseFiles: { 'src/main/database/migration-service.ts': baseMigrationServiceSource },
+        headFiles: {
+          [nextMigrationPath]: nextMigrationSource,
+          'src/main/database/migration-service.ts': reversedServiceSource
+        }
+      })
+    ).toEqual([
+      expect.objectContaining({ subject: expect.stringContaining('preserve the existing order') })
+    ])
+  })
+
+  it('does not accept migration declarations and registrations found only in comments', () => {
+    expect(
+      checkDatabaseMigrationPolicy({
+        changes: [{ path: nextMigrationPath, status: 'added' }],
+        baseMigrationPaths: baselineMigrations,
+        baseFiles: { 'src/main/database/migration-service.ts': baseMigrationServiceSource },
+        headFiles: {
+          [nextMigrationPath]: "// const projectLabelMigration = { id: '0003_project_label' }\n",
+          'src/main/database/migration-service.ts': `// import { projectLabelMigration } from './migrations/0003-project-label'
+const MIGRATION_MANIFEST = [
+  // { ...projectLabelMigration }
+] as const satisfies readonly MigrationManifestEntry[]
+`
+        }
+      })
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ subject: expect.stringContaining('declare migration id') }),
+        expect.objectContaining({ subject: expect.stringContaining('preserve the existing order') })
+      ])
+    )
   })
 
   it('validates commit subjects from the Git revision CLI', () => {
@@ -210,6 +269,108 @@ describe('pull request policy', () => {
       expect(readFileSync(summary, 'utf8')).toContain(
         'database schema contracts changed without a new migration'
       )
+    } finally {
+      rmSync(root, { force: true, recursive: true })
+    }
+  })
+
+  it('uses the current target base when choosing the next migration version', () => {
+    const root = mkdtempSync(join(tmpdir(), 'database-migration-target-base-'))
+
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: root })
+      execFileSync('git', ['config', 'user.email', 'ci@example.com'], { cwd: root })
+      execFileSync('git', ['config', 'user.name', 'CI Test'], { cwd: root })
+      mkdirSync(join(root, 'prisma'), { recursive: true })
+      mkdirSync(join(root, 'src/main/database/migrations'), { recursive: true })
+      writeFileSync(join(root, 'prisma/schema.prisma'), 'model Probe { id String @id }\n')
+      writeFileSync(
+        join(root, 'src/main/database/migrations/0001-runtime-schema-baseline.ts'),
+        "const runtimeSchemaBaselineMigration = { id: '0001_runtime_schema_baseline' }\n"
+      )
+      writeFileSync(
+        join(root, 'src/main/database/migration-service.ts'),
+        `import { runtimeSchemaBaselineMigration } from './migrations/0001-runtime-schema-baseline'
+const MIGRATION_MANIFEST = [
+  { ...runtimeSchemaBaselineMigration }
+] as const satisfies readonly MigrationManifestEntry[]
+`
+      )
+      execFileSync('git', ['add', '.'], { cwd: root })
+      execFileSync('git', ['commit', '--quiet', '-m', 'chore(fixture): add baseline'], {
+        cwd: root
+      })
+      const common = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: root,
+        encoding: 'utf8'
+      }).trim()
+
+      execFileSync('git', ['checkout', '--quiet', '-b', 'feature'], { cwd: root })
+      writeFileSync(
+        join(root, 'prisma/schema.prisma'),
+        'model Probe { id String @id, value String }\n'
+      )
+      writeFileSync(
+        join(root, 'src/main/database/migrations/0002-feature-value.ts'),
+        "const featureValueMigration = { id: '0002_feature_value' }\n"
+      )
+      writeFileSync(
+        join(root, 'src/main/database/migration-service.ts'),
+        `import { runtimeSchemaBaselineMigration } from './migrations/0001-runtime-schema-baseline'
+import { featureValueMigration } from './migrations/0002-feature-value'
+const MIGRATION_MANIFEST = [
+  { ...runtimeSchemaBaselineMigration },
+  { ...featureValueMigration }
+] as const satisfies readonly MigrationManifestEntry[]
+`
+      )
+      execFileSync('git', ['add', '.'], { cwd: root })
+      execFileSync('git', ['commit', '--quiet', '-m', 'feat(database): add feature value'], {
+        cwd: root
+      })
+      const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: root,
+        encoding: 'utf8'
+      }).trim()
+
+      execFileSync('git', ['checkout', '--quiet', '-b', 'target', common], { cwd: root })
+      writeFileSync(
+        join(root, 'src/main/database/migrations/0002-target-field.ts'),
+        "const targetFieldMigration = { id: '0002_target_field' }\n"
+      )
+      writeFileSync(
+        join(root, 'src/main/database/migration-service.ts'),
+        `import { runtimeSchemaBaselineMigration } from './migrations/0001-runtime-schema-baseline'
+import { targetFieldMigration } from './migrations/0002-target-field'
+const MIGRATION_MANIFEST = [
+  { ...runtimeSchemaBaselineMigration },
+  { ...targetFieldMigration }
+] as const satisfies readonly MigrationManifestEntry[]
+`
+      )
+      execFileSync('git', ['add', '.'], { cwd: root })
+      execFileSync('git', ['commit', '--quiet', '-m', 'feat(database): add target field'], {
+        cwd: root
+      })
+      const target = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: root,
+        encoding: 'utf8'
+      }).trim()
+
+      const result = spawnSync(process.execPath, [resolve('scripts/ci/check-pr-policy.mjs')], {
+        cwd: root,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          BASE_SHA: target,
+          EVENT_NAME: 'pull_request',
+          HEAD_SHA: head,
+          POLICY_SCOPE: 'commits'
+        }
+      })
+
+      expect(result.status, result.stdout).toBe(1)
+      expect(result.stdout).toContain('next migration version 0003')
     } finally {
       rmSync(root, { force: true, recursive: true })
     }


### PR DESCRIPTION
## Problem

The application now owns a forward-only database migration ledger, but PR Gate does not reject a schema contract change that forgets its migration version. A released migration can also be edited or replaced without an immediate policy failure.

## Proposed change

Extend the existing protected PR policy check so pull requests and merge groups:

- require changes to `prisma/schema.prisma` or `prisma/sqlite-check-constraints.json` to add a migration;
- keep migration files present on the current target revision immutable;
- require new migrations to use the next contiguous `NNNN-description.ts` version and a matching `NNNN_description` id;
- require the exported migration to be imported and appended to `MIGRATION_MANIFEST` in version order;
- keep imports and complete manifest entries for released migrations immutable, including checksum and backup policy;
- ignore declarations and registrations that only appear in comments or string content.

The policy uses the merge base to identify the PR's changes, then checks released migrations and the next version against the current target revision. This rejects stale branches that try to reuse a migration version already added to the target branch.

## Scope and non-goals

This changes CI policy only. It does not change the database schema, migration runtime, generated schema, release packaging, or application behavior. Existing schema generation and migration tests remain responsible for validating DDL and upgrade behavior.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- version policy behavior and Git revision CLI -> `npx --no-install vitest run scripts/ci/check-pr-policy.test.ts` -> pass (16 tests);
- existing `0001` migration history -> `node scripts/ci/check-pr-policy.mjs` against `f44ce72b^..f44ce72b` -> pass; the historical `0002` introduction intentionally rewrote the `0001` manifest entry before this future-facing policy existed and is now correctly rejected by the stricter invariant;
- exact branch commit and migration policy after the final commit -> `node scripts/ci/check-pr-policy.mjs` with `origin/main...HEAD` revisions -> pass;
- Node and Web types -> `npm run typecheck` -> pass;
- repository lint -> `npm run lint` -> pass (0 errors; 17 pre-existing warnings);
- complete portable Vitest suite outside the loopback-restricted sandbox -> `npm test -- --maxWorkers=2` -> pass (932 files / 13,464 tests; 15 files / 193 tests skipped by suite configuration);
- formatting and whitespace -> Prettier check and `git diff --check` -> pass.

No runtime consumer or platform-specific lane was added locally because the diff only changes the global PR policy input and its tests. The full portable suite was included because global gate inputs require the full fallback. Exact-head required CI remains authoritative.

## Review focus

- Confirm that the two schema contract paths are the correct trigger boundary.
- Confirm that migration immutability and contiguous numbering are evaluated relative to the current target revision while PR changes come from the merge base.
- Confirm that comment stripping and complete manifest/import prefix comparison match the established migration convention without permitting released checksum or backup-policy changes.

Uncovered risk: `scripts/ci/check-pr-policy.mjs` is an established protected gate control-plane file, so this introducing PR is expected to require the repository's explicit maintainer ruleset bypass. After merge, the base-checked protection prevents ordinary PRs from silently weakening this policy.
