### PR TITLE
feat(host): add bounded REPL inference

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -983,7 +983,8 @@ const HOST_CAPABILITY_NAMES = [
   'skills',
   'artifacts',
   'lineage',
-  'frames'
+  'frames',
+  'llm'
 ]
 
 async function hostCapabilities(...args) {
@@ -1010,6 +1011,150 @@ async function hostCapabilities(...args) {
   }
   return Object.freeze(
     Object.fromEntries(HOST_CAPABILITY_NAMES.map((name) => [name, result[name]]))
+  )
+}
+
+const HOST_LLM_STOP_REASONS = new Set([
+  'end_turn',
+  'max_tokens',
+  'max_turn_requests',
+  'refusal',
+  'cancelled'
+])
+
+const validatedHostLlmUsage = (value) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('host.llm returned invalid usage')
+  }
+  const required = ['input_tokens', 'cache_tokens', 'output_tokens']
+  const optional = ['cached_read_tokens', 'cached_write_tokens', 'turn_count']
+  const keys = Object.keys(value)
+  if (
+    required.some((key) => !keys.includes(key)) ||
+    keys.some((key) => !required.includes(key) && !optional.includes(key)) ||
+    [...required, ...optional].some(
+      (key) =>
+        value[key] !== undefined &&
+        (typeof value[key] !== 'number' || !Number.isSafeInteger(value[key]) || value[key] < 0)
+    ) ||
+    (value.turn_count !== undefined && value.turn_count < 1)
+  ) {
+    throw new Error('host.llm returned invalid usage')
+  }
+  return Object.freeze(Object.fromEntries(keys.map((key) => [key, value[key]])))
+}
+
+const validatedHostLlmResult = (value) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('host.llm returned an invalid result')
+  }
+  const keys = Object.keys(value)
+  if (
+    !['text', 'model', 'stop_reason'].every((key) => keys.includes(key)) ||
+    keys.some((key) => !['text', 'model', 'stop_reason', 'usage'].includes(key)) ||
+    typeof value.text !== 'string' ||
+    typeof value.model !== 'string' ||
+    !HOST_LLM_STOP_REASONS.has(value.stop_reason)
+  ) {
+    throw new Error('host.llm returned an invalid result')
+  }
+  return Object.freeze({
+    text: value.text,
+    model: value.model,
+    stop_reason: value.stop_reason,
+    ...(value.usage === undefined ? {} : { usage: validatedHostLlmUsage(value.usage) })
+  })
+}
+
+const normalizedHostLlmRequest = (value) => {
+  if (typeof value === 'string') return value
+  try {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+    const keys = Reflect.ownKeys(value)
+    const prompt = value.prompt
+    if (keys.length !== 1 || keys[0] !== 'prompt' || typeof prompt !== 'string') {
+      return undefined
+    }
+    return { prompt }
+  } catch {
+    return undefined
+  }
+}
+
+const normalizedHostLlmOptions = (value) => {
+  if (value === undefined) return undefined
+  let concurrency
+  try {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new TypeError('host.llm batch options only accept max_concurrency.')
+    }
+    const keys = Reflect.ownKeys(value)
+    if (keys.some((key) => key !== 'max_concurrency')) {
+      throw new TypeError('host.llm batch options only accept max_concurrency.')
+    }
+    if (keys.length === 0) return {}
+    concurrency = value.max_concurrency
+  } catch {
+    throw new TypeError('host.llm batch options only accept max_concurrency.')
+  }
+  if (
+    typeof concurrency !== 'number' ||
+    !Number.isInteger(concurrency) ||
+    concurrency < 1 ||
+    concurrency > 4
+  ) {
+    throw new TypeError('host.llm max_concurrency must be an integer from 1 through 4.')
+  }
+  return { max_concurrency: concurrency }
+}
+
+async function hostLlm(request, options = undefined) {
+  if (arguments.length < 1 || arguments.length > 2) {
+    throw new TypeError('host.llm accepts a request and optional batch options')
+  }
+  const batch = Array.isArray(request)
+  if (!batch && arguments.length > 1) {
+    throw new TypeError('host.llm options are only accepted for batch calls')
+  }
+  const normalizedRequest = batch
+    ? request.map((item) => normalizedHostLlmRequest(item) ?? null)
+    : normalizedHostLlmRequest(request)
+  if (!batch && normalizedRequest === undefined) {
+    throw new TypeError('host.llm requests must be a prompt string or an exact { prompt } object.')
+  }
+  const normalizedOptions =
+    batch && arguments.length > 1 ? normalizedHostLlmOptions(options) : undefined
+  if (!RPC_ENDPOINT) throw new Error('host.llm is unavailable: RPC endpoint not set')
+  const params = batch
+    ? {
+        requests: normalizedRequest,
+        ...(arguments.length > 1 ? { options: normalizedOptions } : {})
+      }
+    : { request: normalizedRequest }
+  const res = await capturedRpcFetch(RPC_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
+    body: JSON.stringify({ method: 'llmCall', params })
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok || body.error) throw new Error(body.error || 'host.llm HTTP ' + res.status)
+  if (!batch) return validatedHostLlmResult(body.result)
+  if (!Array.isArray(body.result) || body.result.length !== request.length) {
+    throw new Error('host.llm returned an invalid batch result')
+  }
+  return Object.freeze(
+    body.result.map((item) => {
+      if (
+        item &&
+        typeof item === 'object' &&
+        !Array.isArray(item) &&
+        Object.keys(item).length === 1 &&
+        typeof item.error === 'string'
+      ) {
+        return Object.freeze({ error: item.error })
+      }
+      return validatedHostLlmResult(item)
+    })
   )
 }
 
@@ -2366,6 +2511,7 @@ const hostCompute = {
 const sandbox = {
   host: {
     capabilities: hostCapabilities,
+    llm: hostLlm,
     artifacts: hostArtifacts,
     artifact_path: hostArtifactPath,
     lineage: hostLineage,

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -14,7 +14,7 @@ JavaScript control REPL; Python and R data kernels do not receive it.
 const caps = await host.capabilities()
 ```
 
-The v1 result contains exactly seven boolean keys:
+The v1 result contains exactly eight boolean keys:
 
 - `mcp` gates `host.mcp` connector calls.
 - `compute` gates the `host.compute` namespace.
@@ -23,6 +23,7 @@ The v1 result contains exactly seven boolean keys:
 - `artifacts` gates `host.artifacts` and `host.artifact_path`.
 - `lineage` gates the read-only `host.lineage` namespace.
 - `frames` gates the read-only `host.frames` namespace.
+- `llm` gates `host.llm` one-shot, tool-less inference.
 
 Interpret the result narrowly:
 
@@ -36,6 +37,10 @@ Interpret the result narrowly:
 const caps = await host.capabilities()
 if (caps.compute === true) {
   const availableHosts = await host.compute.list()
+}
+
+if (caps.llm === true) {
+  const result = await host.llm('Summarize the current findings.')
 }
 ```
 

--- a/src/main/acp/artifact-code-reconstruction-runner.test.ts
+++ b/src/main/acp/artifact-code-reconstruction-runner.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { CODEX_SHARED_PROVIDER_ID } from '../../shared/settings'
 import type { ResolvedAgentBackend } from '../agent-framework'
 import { claudeCodeFramework } from '../agent-framework/claude-code'
 import { codexFramework } from '../agent-framework/codex'
@@ -13,11 +14,13 @@ import {
   prepareBackend,
   resolveReconstructionModel
 } from './artifact-code-reconstruction-runner'
+import { RestrictedInferenceRunner } from './restricted-inference-runner'
 import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
 
 let temporaryRoot: string | undefined
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true })
   temporaryRoot = undefined
 })
@@ -138,6 +141,32 @@ describe('Artifact code reconstruction backend profiles', () => {
 })
 
 describe('ArtifactCodeReconstructionRunner cleanup', () => {
+  it('keeps Artifact output unbounded at the restricted inference Seam', async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-output-'))
+    const text = 'x'.repeat(300 * 1024)
+    const inference = vi.spyOn(RestrictedInferenceRunner.prototype, 'run').mockResolvedValue({
+      text,
+      frameworkId: 'claude-code',
+      model: 'model-a',
+      stopReason: 'end_turn'
+    })
+    const runner = new ArtifactCodeReconstructionRunner({
+      appVersion: '0.11.0',
+      configRoot: temporaryRoot,
+      captureTarget: vi.fn(),
+      resolveTarget: vi.fn()
+    })
+
+    await expect(
+      runner.run('evidence', { ...target, frameworkId: 'claude-code' })
+    ).resolves.toEqual({
+      text,
+      frameworkId: 'claude-code',
+      model: 'model-a'
+    })
+    expect(inference.mock.calls[0]?.[0]).not.toHaveProperty('outputLimitBytes')
+  })
+
   it('removes stale disposable profiles while retaining recent work', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-sweep-'))
     const now = Date.parse('2026-08-06T12:00:00.000Z')
@@ -186,6 +215,24 @@ describe('ArtifactCodeReconstructionRunner cleanup', () => {
     expect(release).toHaveBeenCalledOnce()
   })
 
+  it('preserves the Artifact error for unsupported Codex subscription authentication', async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-subscription-'))
+    const resolveTarget = vi.fn()
+    const runner = new ArtifactCodeReconstructionRunner({
+      appVersion: '0.11.0',
+      configRoot: temporaryRoot,
+      captureTarget: vi.fn(),
+      resolveTarget
+    })
+
+    await expect(
+      runner.run('evidence', { ...target, providerId: CODEX_SHARED_PROVIDER_ID })
+    ).rejects.toThrow(
+      'Artifact code reconstruction is unavailable with Codex subscription authentication.'
+    )
+    expect(resolveTarget).not.toHaveBeenCalled()
+  })
+
   it('rejects new work after shutdown begins', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-shutdown-'))
     const captureTarget = vi.fn(async () => target)
@@ -201,5 +248,28 @@ describe('ArtifactCodeReconstructionRunner cleanup', () => {
     await expect(runner.captureTarget()).rejects.toThrow('is shutting down')
     await expect(runner.run('evidence', target)).rejects.toThrow('is shutting down')
     expect(captureTarget).not.toHaveBeenCalled()
+  })
+
+  it('preserves the Artifact shutdown error while target resolution is pending', async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-shutdown-race-'))
+    let finishResolution!: (backend: ResolvedAgentBackend) => void
+    const resolving = new Promise<ResolvedAgentBackend>((resolve) => {
+      finishResolution = resolve
+    })
+    const resolveTarget = vi.fn(() => resolving)
+    const runner = new ArtifactCodeReconstructionRunner({
+      appVersion: '0.11.0',
+      configRoot: temporaryRoot,
+      captureTarget: vi.fn(),
+      resolveTarget
+    })
+    const call = runner.run('evidence', { ...target, frameworkId: 'claude-code' })
+
+    await vi.waitFor(() => expect(resolveTarget).toHaveBeenCalledOnce())
+    const shutdown = runner.shutdown()
+    finishResolution(backend(claudeCodeFramework))
+
+    await expect(call).rejects.toThrow('Artifact code reconstruction is shutting down.')
+    await expect(shutdown).resolves.toBeUndefined()
   })
 })

--- a/src/main/acp/artifact-code-reconstruction-runner.ts
+++ b/src/main/acp/artifact-code-reconstruction-runner.ts
@@ -1,14 +1,12 @@
-import { mkdir, mkdtemp, readdir, rm, stat } from 'node:fs/promises'
-import { join } from 'node:path'
-
-import type { AcpRuntimeEvent } from '../../shared/acp'
-import type { AgentFrameworkId } from '../../shared/settings'
+import { isCodexSubscriptionProviderId, type AgentFrameworkId } from '../../shared/settings'
 import type { ResolvedAgentBackend } from '../agent-framework'
 import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
-import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
-import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
-import { AcpRuntime, type AcpRuntimeOptions } from './runtime'
 import { prepareRestrictedBackend } from './restricted-runtime-profile'
+import {
+  RestrictedInferenceError,
+  RestrictedInferenceRunner,
+  resolveRestrictedInferenceModel
+} from './restricted-inference-runner'
 
 const RECONSTRUCTION_SYSTEM_PROMPT = [
   'You reconstruct a standalone script from immutable Artifact Execution Log evidence.',
@@ -17,8 +15,6 @@ const RECONSTRUCTION_SYSTEM_PROMPT = [
 ].join(' ')
 
 const RECONSTRUCTION_AGENT_NAME = 'open-science-reconstruction'
-const STALE_PROFILE_AGE_MS = 24 * 60 * 60 * 1000
-const PROVIDER_DEFAULT_MODEL = 'provider-default'
 
 export type ArtifactCodeReconstructionRunResult = {
   text: string
@@ -37,15 +33,6 @@ type ArtifactCodeReconstructionRunnerOptions = {
   now?: () => number
 }
 
-const releaseUnattachedBackend = async (backend: ResolvedAgentBackend): Promise<void> => {
-  const owned: Array<{ release: () => Promise<void> }> = []
-  if (backend.responsesBridgeLease) owned.push(backend.responsesBridgeLease)
-  if (backend.anthropicBridgeLease) owned.push(backend.anthropicBridgeLease)
-  if (backend.providerTransportLease) owned.push(backend.providerTransportLease)
-  const leases = new Set(owned)
-  await Promise.all([...leases].map((lease) => lease.release().catch(() => undefined)))
-}
-
 export const prepareBackend = (
   backend: ResolvedAgentBackend,
   profileRoot: string
@@ -61,41 +48,25 @@ export const prepareBackend = (
 export const resolveReconstructionModel = (
   backend: Pick<ResolvedAgentBackend, 'contextUsageModel' | 'sessionModel'>,
   target: ExplicitAgentBackendTarget
-): string =>
-  backend.contextUsageModel?.trim() ||
-  backend.sessionModel?.trim() ||
-  (target.model.kind === 'required' ? target.model.id : PROVIDER_DEFAULT_MODEL)
+): string => resolveRestrictedInferenceModel(backend, target)
 
 export class ArtifactCodeReconstructionRunner {
-  private readonly root: string
-  private readonly now: () => number
+  private readonly inference: RestrictedInferenceRunner
   private running = false
   private shuttingDown = false
-  private activeRuntime: AcpRuntime | undefined
 
   constructor(private readonly options: ArtifactCodeReconstructionRunnerOptions) {
-    this.root = join(options.configRoot, 'runtime-support', 'artifact-code-reconstruction')
-    this.now = options.now ?? Date.now
+    this.inference = new RestrictedInferenceRunner({
+      appVersion: options.appVersion,
+      configRoot: options.configRoot,
+      profileNamespace: 'artifact-code-reconstruction',
+      resolveTarget: options.resolveTarget,
+      now: options.now
+    })
   }
 
   async sweepStaleProfiles(): Promise<void> {
-    await mkdir(this.root, { recursive: true })
-    const entries = await readdir(this.root, { withFileTypes: true })
-    await Promise.all(
-      entries.flatMap((entry) => {
-        if (!entry.isDirectory() || !entry.name.startsWith('job-')) return []
-        const path = join(this.root, entry.name)
-        return [
-          stat(path)
-            .then((value) =>
-              this.now() - value.mtimeMs >= STALE_PROFILE_AGE_MS
-                ? rm(path, { recursive: true, force: true })
-                : undefined
-            )
-            .catch(() => undefined)
-        ]
-      })
-    )
+    await this.inference.sweepStaleProfiles()
   }
 
   captureTarget(): Promise<ExplicitAgentBackendTarget> {
@@ -112,109 +83,47 @@ export class ArtifactCodeReconstructionRunner {
     if (this.shuttingDown) throw new Error('Artifact code reconstruction is shutting down.')
     if (this.running) throw new Error('Artifact code reconstruction is already running.')
     this.running = true
-    let jobRoot: string | undefined
-    let backend: ResolvedAgentBackend | undefined
-    let sessionId: string | undefined
-    let toolLessBridgeScopeRegistered = false
-    let backendTransferred = false
-    let toolViolation = false
-    const assistantChunks: string[] = []
-    let runtime: AcpRuntime | undefined
-
-    const onEvent = (event: AcpRuntimeEvent): void => {
-      if (event.kind === 'message' && event.role === 'assistant' && event.text) {
-        assistantChunks.push(event.text)
-      }
-      if (event.kind === 'tool') {
-        toolViolation = true
-        if (sessionId && runtime) void runtime.cancelPrompt({ sessionId }).catch(() => undefined)
-      }
-    }
-
     try {
-      await mkdir(this.root, { recursive: true })
-      jobRoot = await mkdtemp(join(this.root, 'job-'))
-      const cwd = join(jobRoot, 'cwd')
-      const profileRoot = join(jobRoot, 'profile')
-      await Promise.all([mkdir(cwd), mkdir(profileRoot)])
-      backend = await this.options.resolveTarget(target, {
-        systemPromptAppends: [RECONSTRUCTION_SYSTEM_PROMPT],
-        forceCodexNativeResponsesCompatibility: true
+      const result = await this.inference.run({
+        prompt,
+        target,
+        systemPrompt: RECONSTRUCTION_SYSTEM_PROMPT,
+        agentName: RECONSTRUCTION_AGENT_NAME,
+        description: 'One-shot Artifact code reconstruction without tools.'
       })
-      if (this.shuttingDown) throw new Error('Artifact code reconstruction is shutting down.')
-      const resolvedBackend = await prepareBackend(backend, profileRoot)
-      backend = resolvedBackend
-      if (this.shuttingDown) throw new Error('Artifact code reconstruction is shutting down.')
-      if (
-        resolvedBackend.responsesBridgeLease &&
-        (!resolvedBackend.responsesBridgeLease.registerToolLessSession ||
-          !resolvedBackend.responsesBridgeLease.unregisterToolLessSession)
-      ) {
-        throw new Error('The selected Codex transport cannot enforce a tool-less session.')
+      return {
+        text: result.text,
+        frameworkId: result.frameworkId,
+        model: result.model
       }
-      const runtimeOptions: AcpRuntimeOptions = {
-        appVersion: this.options.appVersion,
-        defaultCwd: cwd,
-        resolveBackend: () => {
-          backendTransferred = true
-          return Promise.resolve(resolvedBackend)
-        },
-        callbacks: {
-          onEvent,
-          onPermissionRequest: (request) => {
-            toolViolation = true
-            if (runtime) {
-              void runtime
-                .respondToPermission({ requestId: request.requestId, cancelled: true })
-                .catch(() => undefined)
-            }
-          }
-        }
-      }
-      const base = composeAcpRuntimeBaseOwners(runtimeOptions)
-      runtime = new AcpRuntime(
-        runtimeOptions,
-        base,
-        composeAcpRuntimeSessionOwners(runtimeOptions, base)
-      )
-      this.activeRuntime = runtime
-      const created = await runtime.createSession({ cwd, permissionProfile: 'ask' })
-      sessionId = created.sessionId
-      if (resolvedBackend.responsesBridgeLease) {
-        resolvedBackend.responsesBridgeLease.registerToolLessSession?.(sessionId)
-        toolLessBridgeScopeRegistered = true
-      }
-      await runtime.sendPrompt({ sessionId, text: prompt, suppressUserMessage: true })
-      if (toolViolation) {
+    } catch (error) {
+      if (error instanceof RestrictedInferenceError && error.code === 'tool-violation') {
         throw new Error('The selected agent attempted to use a tool during code reconstruction.')
       }
-      if (toolLessBridgeScopeRegistered) {
-        const observed = resolvedBackend.responsesBridgeLease!.unregisterToolLessSession!(sessionId)
-        toolLessBridgeScopeRegistered = false
-        if (!observed) {
-          throw new Error('The selected Codex transport did not apply its tool-less session scope.')
-        }
+      if (
+        error instanceof RestrictedInferenceError &&
+        (error.code === 'shutting-down' || (this.shuttingDown && error.code === 'cancelled'))
+      ) {
+        throw new Error('Artifact code reconstruction is shutting down.')
       }
-
-      return {
-        text: assistantChunks.join(''),
-        frameworkId: resolvedBackend.framework.id,
-        model: resolveReconstructionModel(resolvedBackend, target)
+      if (
+        error instanceof RestrictedInferenceError &&
+        error.code === 'transport-unavailable' &&
+        target.frameworkId === 'codex' &&
+        isCodexSubscriptionProviderId(target.providerId)
+      ) {
+        throw new Error(
+          'Artifact code reconstruction is unavailable with Codex subscription authentication.'
+        )
       }
+      throw error
     } finally {
-      if (sessionId && toolLessBridgeScopeRegistered) {
-        backend?.responsesBridgeLease?.unregisterToolLessSession?.(sessionId)
-      }
-      await runtime?.shutdownForQuit().catch(() => undefined)
-      if (backend && !backendTransferred) await releaseUnattachedBackend(backend)
-      if (this.activeRuntime === runtime) this.activeRuntime = undefined
-      if (jobRoot) await rm(jobRoot, { recursive: true, force: true }).catch(() => undefined)
       this.running = false
     }
   }
 
   async shutdown(): Promise<void> {
     this.shuttingDown = true
-    await this.activeRuntime?.shutdownForQuit().catch(() => undefined)
+    await this.inference.shutdown()
   }
 }

--- a/src/main/acp/restricted-inference-runner.test.ts
+++ b/src/main/acp/restricted-inference-runner.test.ts
@@ -1,0 +1,392 @@
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { CODEX_SHARED_PROVIDER_ID } from '../../shared/settings'
+import type { AcpRuntimeEvent, AcpTurnTokenUsage } from '../../shared/acp'
+import type { ResolvedAgentBackend } from '../agent-framework'
+import { claudeCodeFramework } from '../agent-framework/claude-code'
+import { codexFramework } from '../agent-framework/codex'
+import { opencodeFramework } from '../agent-framework/opencode'
+import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
+import type { AcpRuntimeOptions } from './runtime'
+import {
+  RestrictedInferenceError,
+  RestrictedInferenceRunner,
+  type RestrictedInferenceRuntime
+} from './restricted-inference-runner'
+
+let temporaryRoot: string | undefined
+
+afterEach(async () => {
+  if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true })
+  temporaryRoot = undefined
+})
+
+const target = (
+  frameworkId: ExplicitAgentBackendTarget['frameworkId'] = 'claude-code',
+  providerId = 'provider-a'
+): ExplicitAgentBackendTarget => ({
+  frameworkId,
+  providerId,
+  model: { kind: 'required', id: 'model-a' },
+  reasoningEffort: 'high'
+})
+
+const backend = (
+  framework: ResolvedAgentBackend['framework'],
+  extra: Partial<ResolvedAgentBackend> = {}
+): ResolvedAgentBackend => ({
+  framework,
+  executablePath: `/managed/${framework.id}`,
+  env: {},
+  sessionModel: 'model-a',
+  contextUsageModel: 'model-a',
+  ...extra
+})
+
+type RuntimeHarnessOptions = Readonly<{
+  response?: { stopReason: 'end_turn' | 'cancelled' }
+  events?: AcpRuntimeEvent[]
+  permissionRequest?: true
+  onRuntime?: () => void
+  onCreateSession?: () => Promise<void>
+  onPrompt?: () => Promise<void>
+}>
+
+const runtimeHarness = (
+  options: AcpRuntimeOptions,
+  input: RuntimeHarnessOptions = {}
+): RestrictedInferenceRuntime => {
+  let resolvedBackend: ResolvedAgentBackend | undefined
+  return {
+    createSession: vi.fn(async () => {
+      resolvedBackend = await (options.resolveBackend as () => Promise<ResolvedAgentBackend>)()
+      await input.onCreateSession?.()
+      return { sessionId: 'provider-session-1' } as never
+    }),
+    sendPrompt: vi.fn(async () => {
+      for (const event of input.events ?? []) options.callbacks?.onEvent?.(event)
+      if (input.permissionRequest) {
+        options.callbacks?.onPermissionRequest?.({
+          requestId: 'permission-1',
+          sessionId: 'provider-session-1',
+          toolCallId: 'tool-1',
+          title: 'Run a tool',
+          options: []
+        })
+      }
+      await input.onPrompt?.()
+      return input.response ?? { stopReason: 'end_turn' }
+    }),
+    cancelPrompt: vi.fn(async () => ({ stopReason: 'cancelled' }) as never),
+    respondToPermission: vi.fn(async () => undefined),
+    shutdownForQuit: vi.fn(async () => {
+      await resolvedBackend?.responsesBridgeLease?.release()
+    })
+  } as unknown as RestrictedInferenceRuntime
+}
+
+const event = (value: Partial<AcpRuntimeEvent>): AcpRuntimeEvent =>
+  ({
+    id: 'event-1',
+    timestamp: 1,
+    kind: 'message',
+    level: 'info',
+    ...value
+  }) as AcpRuntimeEvent
+
+const makeRunner = async (
+  resolved: ResolvedAgentBackend,
+  runtime: RuntimeHarnessOptions = {}
+): Promise<{
+  runner: RestrictedInferenceRunner
+  resolveTarget: ReturnType<typeof vi.fn>
+  runtimes: RestrictedInferenceRuntime[]
+}> => {
+  temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-restricted-inference-'))
+  const resolveTarget = vi.fn(async () => resolved)
+  const runtimes: RestrictedInferenceRuntime[] = []
+  const runner = new RestrictedInferenceRunner({
+    appVersion: '0.11.0',
+    configRoot: temporaryRoot,
+    profileNamespace: 'test-inference',
+    resolveTarget,
+    createRuntime: (options) => {
+      runtime.onRuntime?.()
+      const created = runtimeHarness(options, runtime)
+      runtimes.push(created)
+      return created
+    }
+  })
+  return { runner, resolveTarget, runtimes }
+}
+
+const runInput = (
+  overrides: Partial<Parameters<RestrictedInferenceRunner['run']>[0]> = {}
+): Parameters<RestrictedInferenceRunner['run']>[0] => ({
+  prompt: 'Return PONG.',
+  target: target(),
+  systemPrompt: 'Do not use tools.',
+  agentName: 'open-science-test-inference',
+  description: 'Test inference without tools.',
+  ...overrides
+})
+
+describe('RestrictedInferenceRunner', () => {
+  it('fails closed only for native Codex subscription targets', async () => {
+    const { runner } = await makeRunner(backend(claudeCodeFramework))
+
+    expect(runner.supportsTarget(target('claude-code'))).toBe(true)
+    expect(runner.supportsTarget(target('opencode'))).toBe(true)
+    expect(runner.supportsTarget(target('codex'))).toBe(true)
+    expect(runner.supportsTarget(target('codex', CODEX_SHARED_PROVIDER_ID))).toBe(false)
+    await expect(
+      runner.run(runInput({ target: target('codex', CODEX_SHARED_PROVIDER_ID) }))
+    ).rejects.toMatchObject({
+      code: 'transport-unavailable'
+    })
+  })
+
+  it('collects text and provider-neutral usage while verifying the Codex tool-less scope', async () => {
+    const usage: AcpTurnTokenUsage = {
+      inputTokens: 12,
+      cacheTokens: 3,
+      cachedReadTokens: 2,
+      cachedWriteTokens: 1,
+      outputTokens: 4,
+      turnCount: 1
+    }
+    const registered = new Set<string>()
+    const registerToolLessSession = vi.fn((id: string) => registered.add(id))
+    const unregisterToolLessSession = vi.fn((id: string) => registered.delete(id))
+    const release = vi.fn(async () => undefined)
+    const { runner, resolveTarget } = await makeRunner(
+      backend(codexFramework, {
+        responsesBridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => false),
+          registerToolLessSession,
+          unregisterToolLessSession,
+          release
+        }
+      }),
+      {
+        events: [
+          event({ role: 'assistant', text: 'PONG' }),
+          event({ kind: 'stop', text: 'end_turn', turnUsage: usage })
+        ]
+      }
+    )
+
+    await expect(runner.run(runInput({ target: target('codex') }))).resolves.toEqual({
+      text: 'PONG',
+      frameworkId: 'codex',
+      model: 'model-a',
+      stopReason: 'end_turn',
+      usage
+    })
+    expect(resolveTarget).toHaveBeenCalledWith(target('codex'), {
+      systemPromptAppends: ['Do not use tools.'],
+      forceCodexNativeResponsesCompatibility: true
+    })
+    expect(registerToolLessSession).toHaveBeenCalledWith('provider-session-1')
+    expect(unregisterToolLessSession).toHaveBeenCalledWith('provider-session-1')
+    expect(release).toHaveBeenCalledOnce()
+    await expect(
+      readdir(join(temporaryRoot!, 'runtime-support', 'test-inference'))
+    ).resolves.toEqual([])
+  })
+
+  it('cancels and rejects tool events and oversized output', async () => {
+    const cases: Array<{
+      name: string
+      runtime: RuntimeHarnessOptions
+      expectedCode: RestrictedInferenceError['code']
+      outputLimitBytes?: number
+    }> = [
+      {
+        name: 'tool event',
+        runtime: { events: [event({ kind: 'tool' })] },
+        expectedCode: 'tool-violation'
+      },
+      {
+        name: 'oversized output',
+        runtime: { events: [event({ role: 'assistant', text: '12345' })] },
+        expectedCode: 'output-limit',
+        outputLimitBytes: 4
+      }
+    ]
+
+    for (const current of cases) {
+      const { runner, runtimes } = await makeRunner(
+        backend(current.name === 'oversized output' ? opencodeFramework : claudeCodeFramework),
+        current.runtime
+      )
+      await expect(
+        runner.run(runInput({ outputLimitBytes: current.outputLimitBytes }))
+      ).rejects.toMatchObject({ code: current.expectedCode })
+      expect(runtimes[0]?.cancelPrompt).toHaveBeenCalled()
+      await rm(temporaryRoot!, { recursive: true, force: true })
+      temporaryRoot = undefined
+    }
+  })
+
+  it.each([
+    ['claude-code', claudeCodeFramework, target('claude-code')],
+    ['opencode', opencodeFramework, target('opencode')],
+    ['codex response routes', codexFramework, target('codex')]
+  ] as const)('fails closed on %s permission requests', async (_name, framework, runTarget) => {
+    const resolved = backend(
+      framework,
+      framework.id === 'codex'
+        ? {
+            responsesBridgeLease: {
+              selectSkills: vi.fn(async () => []),
+              registerReviewerSession: vi.fn(),
+              unregisterReviewerSession: vi.fn(() => false),
+              registerToolLessSession: vi.fn(),
+              unregisterToolLessSession: vi.fn(() => true),
+              release: vi.fn(async () => undefined)
+            }
+          }
+        : {}
+    )
+    const { runner, runtimes } = await makeRunner(resolved, { permissionRequest: true })
+
+    await expect(runner.run(runInput({ target: runTarget }))).rejects.toMatchObject({
+      code: 'tool-violation'
+    })
+    expect(runtimes[0]?.respondToPermission).toHaveBeenCalledWith({
+      requestId: 'permission-1',
+      cancelled: true
+    })
+    expect(runtimes[0]?.cancelPrompt).toHaveBeenCalled()
+  })
+
+  it('releases every unattached backend lease when tool-less enforcement is unavailable', async () => {
+    const releaseResponses = vi.fn(async () => undefined)
+    const releaseAnthropic = vi.fn(async () => undefined)
+    const releaseTransport = vi.fn(async () => undefined)
+    const { runner, runtimes } = await makeRunner(
+      backend(codexFramework, {
+        responsesBridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => false),
+          release: releaseResponses
+        },
+        anthropicBridgeLease: { setTarget: vi.fn(() => true), release: releaseAnthropic },
+        providerTransportLease: { setTarget: vi.fn(() => true), release: releaseTransport }
+      })
+    )
+
+    await expect(runner.run(runInput({ target: target('codex') }))).rejects.toMatchObject({
+      code: 'transport-unavailable'
+    })
+    expect(runtimes).toHaveLength(0)
+    expect(releaseResponses).toHaveBeenCalledOnce()
+    expect(releaseAnthropic).toHaveBeenCalledOnce()
+    expect(releaseTransport).toHaveBeenCalledOnce()
+  })
+
+  it('leaves output unbounded when an Adapter does not opt into a limit', async () => {
+    const text = 'x'.repeat(300 * 1024)
+    const { runner } = await makeRunner(backend(claudeCodeFramework), {
+      events: [event({ role: 'assistant', text })]
+    })
+
+    await expect(runner.run(runInput())).resolves.toMatchObject({ text })
+  })
+
+  it('propagates caller cancellation and drains active work during shutdown', async () => {
+    let releasePrompt = (): void => undefined
+    const promptBlocked = new Promise<void>((resolve) => {
+      releasePrompt = resolve
+    })
+    const { runner, runtimes } = await makeRunner(backend(claudeCodeFramework), {
+      response: { stopReason: 'cancelled' },
+      onPrompt: () => promptBlocked
+    })
+    const call = runner.run(runInput())
+
+    await vi.waitFor(() => expect(runtimes).toHaveLength(1))
+    const shutdown = runner.shutdown()
+    await vi.waitFor(() => expect(runtimes[0]?.cancelPrompt).toHaveBeenCalled())
+    releasePrompt()
+
+    await expect(call).rejects.toMatchObject({ code: 'cancelled' })
+    await expect(shutdown).resolves.toBeUndefined()
+    await expect(runner.run(runInput())).rejects.toMatchObject({ code: 'shutting-down' })
+  })
+
+  it('rejects a pre-aborted caller before resolving a backend', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const { runner, resolveTarget, runtimes } = await makeRunner(backend(claudeCodeFramework))
+
+    await expect(runner.run(runInput({ signal: controller.signal }))).rejects.toMatchObject({
+      code: 'cancelled'
+    })
+    expect(resolveTarget).not.toHaveBeenCalled()
+    expect(runtimes).toHaveLength(0)
+  })
+
+  it('does not dispatch a prompt when cancellation lands during session setup', async () => {
+    let finishCreate = (): void => undefined
+    const creating = new Promise<void>((resolve) => {
+      finishCreate = resolve
+    })
+    const controller = new AbortController()
+    const { runner, runtimes } = await makeRunner(backend(claudeCodeFramework), {
+      onCreateSession: () => creating
+    })
+    const call = runner.run(runInput({ signal: controller.signal }))
+
+    await vi.waitFor(() => expect(runtimes[0]?.createSession).toHaveBeenCalled())
+    controller.abort()
+    finishCreate()
+
+    await expect(call).rejects.toMatchObject({ code: 'cancelled' })
+    expect(runtimes[0]?.sendPrompt).not.toHaveBeenCalled()
+  })
+
+  it('does not create a session when cancellation lands after profile preparation', async () => {
+    const controller = new AbortController()
+    const { runner, runtimes } = await makeRunner(backend(claudeCodeFramework), {
+      onRuntime: () => controller.abort()
+    })
+
+    await expect(runner.run(runInput({ signal: controller.signal }))).rejects.toMatchObject({
+      code: 'cancelled'
+    })
+    expect(runtimes[0]?.createSession).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch a prompt when cancellation lands during tool-less scope registration', async () => {
+    const controller = new AbortController()
+    const registerToolLessSession = vi.fn(() => controller.abort())
+    const unregisterToolLessSession = vi.fn(() => true)
+    const { runner, runtimes } = await makeRunner(
+      backend(codexFramework, {
+        responsesBridgeLease: {
+          selectSkills: vi.fn(async () => []),
+          registerReviewerSession: vi.fn(),
+          unregisterReviewerSession: vi.fn(() => false),
+          registerToolLessSession,
+          unregisterToolLessSession,
+          release: vi.fn(async () => undefined)
+        }
+      })
+    )
+
+    await expect(
+      runner.run(runInput({ target: target('codex'), signal: controller.signal }))
+    ).rejects.toMatchObject({ code: 'cancelled' })
+    expect(registerToolLessSession).toHaveBeenCalledWith('provider-session-1')
+    expect(runtimes[0]?.sendPrompt).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/acp/restricted-inference-runner.ts
+++ b/src/main/acp/restricted-inference-runner.ts
@@ -1,0 +1,329 @@
+import type { PromptResponse } from '@agentclientprotocol/sdk'
+import { mkdir, mkdtemp, readdir, rm, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { isCodexSubscriptionProviderId } from '../../shared/settings'
+import type { AcpRuntimeEvent, AcpTurnTokenUsage } from '../../shared/acp'
+import type { AgentFrameworkId } from '../../shared/settings'
+import type { ResolvedAgentBackend } from '../agent-framework'
+import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
+import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
+import { AcpRuntime, type AcpRuntimeOptions } from './runtime'
+import { prepareRestrictedBackend } from './restricted-runtime-profile'
+
+const STALE_PROFILE_AGE_MS = 24 * 60 * 60 * 1000
+const DEFAULT_OUTPUT_LIMIT_BYTES = 256 * 1024
+const PROVIDER_DEFAULT_MODEL = 'provider-default'
+
+type RestrictedInferenceErrorCode =
+  'cancelled' | 'output-limit' | 'shutting-down' | 'tool-violation' | 'transport-unavailable'
+
+class RestrictedInferenceError extends Error {
+  constructor(
+    readonly code: RestrictedInferenceErrorCode,
+    message: string
+  ) {
+    super(message)
+  }
+}
+
+type RestrictedInferenceResult = Readonly<{
+  text: string
+  frameworkId: AgentFrameworkId
+  model: string
+  stopReason: PromptResponse['stopReason']
+  usage?: AcpTurnTokenUsage
+}>
+
+type RestrictedInferenceRunInput = Readonly<{
+  prompt: string
+  target: ExplicitAgentBackendTarget
+  systemPrompt: string
+  agentName: string
+  description: string
+  signal?: AbortSignal
+  outputLimitBytes?: number
+}>
+
+type RestrictedInferenceRuntime = Pick<
+  AcpRuntime,
+  'cancelPrompt' | 'createSession' | 'respondToPermission' | 'sendPrompt' | 'shutdownForQuit'
+>
+
+type RestrictedInferenceRunnerOptions = Readonly<{
+  appVersion: string
+  configRoot: string
+  profileNamespace: string
+  resolveTarget: (
+    target: ExplicitAgentBackendTarget,
+    context: { systemPromptAppends: string[]; forceCodexNativeResponsesCompatibility: true }
+  ) => Promise<ResolvedAgentBackend>
+  now?: () => number
+  createRuntime?: (options: AcpRuntimeOptions) => RestrictedInferenceRuntime
+}>
+
+type ActiveRun = {
+  controller: AbortController
+  done: Promise<void>
+  finish: () => void
+}
+
+const deferred = (): Pick<ActiveRun, 'done' | 'finish'> => {
+  let finish = (): void => undefined
+  const done = new Promise<void>((resolve) => {
+    finish = resolve
+  })
+  return { done, finish }
+}
+
+const releaseUnattachedBackend = async (backend: ResolvedAgentBackend): Promise<void> => {
+  const owned: Array<{ release: () => Promise<void> }> = []
+  if (backend.responsesBridgeLease) owned.push(backend.responsesBridgeLease)
+  if (backend.anthropicBridgeLease) owned.push(backend.anthropicBridgeLease)
+  if (backend.providerTransportLease) owned.push(backend.providerTransportLease)
+  await Promise.all([...new Set(owned)].map((lease) => lease.release().catch(() => undefined)))
+}
+
+const resolveRestrictedInferenceModel = (
+  backend: Pick<ResolvedAgentBackend, 'contextUsageModel' | 'sessionModel'>,
+  target: ExplicitAgentBackendTarget
+): string =>
+  backend.contextUsageModel?.trim() ||
+  backend.sessionModel?.trim() ||
+  (target.model.kind === 'required' ? target.model.id : PROVIDER_DEFAULT_MODEL)
+
+const createRuntime = (options: AcpRuntimeOptions): RestrictedInferenceRuntime => {
+  const base = composeAcpRuntimeBaseOwners(options)
+  return new AcpRuntime(options, base, composeAcpRuntimeSessionOwners(options, base))
+}
+
+class RestrictedInferenceRunner {
+  private readonly root: string
+  private readonly now: () => number
+  private readonly runtimeFactory: NonNullable<RestrictedInferenceRunnerOptions['createRuntime']>
+  private readonly activeRuns = new Set<ActiveRun>()
+  private shuttingDown = false
+
+  constructor(private readonly options: RestrictedInferenceRunnerOptions) {
+    this.root = join(options.configRoot, 'runtime-support', options.profileNamespace)
+    this.now = options.now ?? Date.now
+    this.runtimeFactory = options.createRuntime ?? createRuntime
+  }
+
+  supportsTarget(target: ExplicitAgentBackendTarget): boolean {
+    return !(target.frameworkId === 'codex' && isCodexSubscriptionProviderId(target.providerId))
+  }
+
+  async sweepStaleProfiles(): Promise<void> {
+    await mkdir(this.root, { recursive: true })
+    const entries = await readdir(this.root, { withFileTypes: true })
+    await Promise.all(
+      entries.flatMap((entry) => {
+        if (!entry.isDirectory() || !entry.name.startsWith('job-')) return []
+        const path = join(this.root, entry.name)
+        return [
+          stat(path)
+            .then((value) =>
+              this.now() - value.mtimeMs >= STALE_PROFILE_AGE_MS
+                ? rm(path, { recursive: true, force: true })
+                : undefined
+            )
+            .catch(() => undefined)
+        ]
+      })
+    )
+  }
+
+  async run(input: RestrictedInferenceRunInput): Promise<RestrictedInferenceResult> {
+    if (this.shuttingDown) {
+      throw new RestrictedInferenceError('shutting-down', 'Restricted inference is shutting down.')
+    }
+    if (!this.supportsTarget(input.target)) {
+      throw new RestrictedInferenceError(
+        'transport-unavailable',
+        'The selected Codex transport cannot enforce a tool-less session.'
+      )
+    }
+
+    const lifecycle = deferred()
+    const active: ActiveRun = {
+      controller: new AbortController(),
+      ...lifecycle
+    }
+    this.activeRuns.add(active)
+    const forwardAbort = (): void => active.controller.abort(input.signal?.reason)
+    input.signal?.addEventListener('abort', forwardAbort, { once: true })
+    if (input.signal?.aborted) forwardAbort()
+
+    let jobRoot: string | undefined
+    let backend: ResolvedAgentBackend | undefined
+    let backendTransferred = false
+    let runtime: RestrictedInferenceRuntime | undefined
+    let sessionId: string | undefined
+    let toolLessBridgeScopeRegistered = false
+    let toolViolation = false
+    let outputLimitExceeded = false
+    let assistantBytes = 0
+    let turnUsage: AcpTurnTokenUsage | undefined
+    const assistantChunks: string[] = []
+    const outputLimitBytes = input.outputLimitBytes
+    const cancelPrompt = (): void => {
+      if (runtime && sessionId) void runtime.cancelPrompt({ sessionId }).catch(() => undefined)
+    }
+    const onAbort = (): void => cancelPrompt()
+    active.controller.signal.addEventListener('abort', onAbort, { once: true })
+    const ensureActive = (): void => {
+      if (active.controller.signal.aborted) {
+        throw new RestrictedInferenceError('cancelled', 'Restricted inference was cancelled.')
+      }
+    }
+
+    const onEvent = (event: AcpRuntimeEvent): void => {
+      if (event.kind === 'message' && event.role === 'assistant' && event.text) {
+        assistantBytes += Buffer.byteLength(event.text, 'utf8')
+        if (outputLimitBytes !== undefined && assistantBytes > outputLimitBytes) {
+          outputLimitExceeded = true
+          cancelPrompt()
+        } else {
+          assistantChunks.push(event.text)
+        }
+      }
+      if (event.kind === 'stop' && event.turnUsage) turnUsage = event.turnUsage
+      if (event.kind === 'tool') {
+        toolViolation = true
+        cancelPrompt()
+      }
+    }
+
+    try {
+      ensureActive()
+      await mkdir(this.root, { recursive: true })
+      jobRoot = await mkdtemp(join(this.root, 'job-'))
+      const cwd = join(jobRoot, 'cwd')
+      const profileRoot = join(jobRoot, 'profile')
+      await Promise.all([mkdir(cwd), mkdir(profileRoot)])
+      backend = await this.options.resolveTarget(input.target, {
+        systemPromptAppends: [input.systemPrompt],
+        forceCodexNativeResponsesCompatibility: true
+      })
+      ensureActive()
+      const resolvedBackend = await prepareRestrictedBackend(backend, profileRoot, {
+        agentName: input.agentName,
+        description: input.description,
+        systemPrompt: input.systemPrompt,
+        openCodePermissions: { '*': 'deny' },
+        steps: 1
+      })
+      backend = resolvedBackend
+      ensureActive()
+      const bridge = resolvedBackend.responsesBridgeLease
+      if (
+        resolvedBackend.framework.id === 'codex' &&
+        (!bridge?.registerToolLessSession || !bridge.unregisterToolLessSession)
+      ) {
+        throw new RestrictedInferenceError(
+          'transport-unavailable',
+          'The selected Codex transport cannot enforce a tool-less session.'
+        )
+      }
+
+      const runtimeOptions: AcpRuntimeOptions = {
+        appVersion: this.options.appVersion,
+        defaultCwd: cwd,
+        resolveBackend: () => {
+          backendTransferred = true
+          return Promise.resolve(resolvedBackend)
+        },
+        callbacks: {
+          onEvent,
+          onPermissionRequest: (request) => {
+            toolViolation = true
+            void runtime
+              ?.respondToPermission({ requestId: request.requestId, cancelled: true })
+              .catch(() => undefined)
+            cancelPrompt()
+          }
+        }
+      }
+      runtime = this.runtimeFactory(runtimeOptions)
+      ensureActive()
+      const created = await runtime.createSession({ cwd, permissionProfile: 'ask' })
+      sessionId = created.sessionId
+      ensureActive()
+      if (bridge) {
+        bridge.registerToolLessSession!(sessionId)
+        toolLessBridgeScopeRegistered = true
+      }
+      ensureActive()
+      const response = await runtime.sendPrompt({
+        sessionId,
+        text: input.prompt,
+        suppressUserMessage: true
+      })
+
+      if (toolViolation) {
+        throw new RestrictedInferenceError(
+          'tool-violation',
+          'The selected agent attempted to use a tool during restricted inference.'
+        )
+      }
+      if (outputLimitExceeded) {
+        throw new RestrictedInferenceError(
+          'output-limit',
+          `Restricted inference exceeded the ${outputLimitBytes}-byte output limit.`
+        )
+      }
+      ensureActive()
+      if (toolLessBridgeScopeRegistered) {
+        const observed = bridge!.unregisterToolLessSession!(sessionId)
+        toolLessBridgeScopeRegistered = false
+        if (!observed) {
+          throw new RestrictedInferenceError(
+            'transport-unavailable',
+            'The selected Codex transport did not apply its tool-less session scope.'
+          )
+        }
+      }
+
+      return Object.freeze({
+        text: assistantChunks.join(''),
+        frameworkId: resolvedBackend.framework.id,
+        model: resolveRestrictedInferenceModel(resolvedBackend, input.target),
+        stopReason: response.stopReason,
+        ...(turnUsage ? { usage: Object.freeze({ ...turnUsage }) } : {})
+      })
+    } finally {
+      input.signal?.removeEventListener('abort', forwardAbort)
+      active.controller.signal.removeEventListener('abort', onAbort)
+      if (sessionId && toolLessBridgeScopeRegistered) {
+        backend?.responsesBridgeLease?.unregisterToolLessSession?.(sessionId)
+      }
+      await runtime?.shutdownForQuit().catch(() => undefined)
+      if (backend && !backendTransferred) await releaseUnattachedBackend(backend)
+      if (jobRoot) await rm(jobRoot, { recursive: true, force: true }).catch(() => undefined)
+      this.activeRuns.delete(active)
+      active.finish()
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true
+    const active = [...this.activeRuns]
+    for (const run of active) run.controller.abort()
+    await Promise.all(active.map((run) => run.done))
+  }
+}
+
+export {
+  DEFAULT_OUTPUT_LIMIT_BYTES,
+  RestrictedInferenceError,
+  RestrictedInferenceRunner,
+  resolveRestrictedInferenceModel
+}
+export type {
+  RestrictedInferenceResult,
+  RestrictedInferenceRunInput,
+  RestrictedInferenceRunnerOptions,
+  RestrictedInferenceRuntime
+}

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -689,7 +689,7 @@ describe('ACP session capability owner', () => {
     ['codex-response', codexFramework, true, false],
     ['codex-bridge', codexFramework, false, true]
   ] as const)(
-    'publishes Host Lineage and Frames through the %s primary control descriptor',
+    'publishes Host Lineage, Frames, and LLM through the %s primary control descriptor',
     async (_route, framework, nativeMcpEnabled, bridgeMcpAliasesEnabled) => {
       const owner = createOwner()
       const built = await owner.provision({

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -650,7 +650,8 @@ describe('ACP session capability owner', () => {
       'skill-import',
       'host-agents',
       'host-skills',
-      'host-frames'
+      'host-frames',
+      'host-llm'
     ])
     expect(primary.descriptor.modelFacingMcpServerNames).toEqual([
       'open_science_artifacts',
@@ -669,7 +670,8 @@ describe('ACP session capability owner', () => {
       'computeCall',
       'agentsCall',
       'skillsCall',
-      'framesCall'
+      'framesCall',
+      'llmCall'
     ])
     expect(reviewer.mcpServers).toEqual([])
     expect(reviewer.descriptor.capabilities).toEqual([])
@@ -700,10 +702,12 @@ describe('ACP session capability owner', () => {
         projectName: 'project'
       })
 
-      expect(built.descriptor.controlRpcMethods).toContain('capabilitiesCall')
-      expect(built.descriptor.controlRpcMethods).toContain('lineageCall')
-      expect(built.descriptor.controlRpcMethods).toContain('framesCall')
-      expect(built.descriptor.capabilities).toContain('host-frames')
+      expect(built.descriptor.controlRpcMethods).toEqual(
+        expect.arrayContaining(['capabilitiesCall', 'lineageCall', 'framesCall', 'llmCall'])
+      )
+      expect(built.descriptor.capabilities).toEqual(
+        expect.arrayContaining(['host-frames', 'host-llm'])
+      )
     }
   )
 

--- a/src/main/acp/session-capability-owner.ts
+++ b/src/main/acp/session-capability-owner.ts
@@ -43,6 +43,7 @@ const CURRENT_PRIMARY_CAPABILITIES = [
   'host-agents',
   'host-skills',
   'host-frames',
+  'host-llm',
   'host-message'
 ] as const
 const NOTEBOOK_CONTROL_RPC_METHODS = [
@@ -52,7 +53,8 @@ const NOTEBOOK_CONTROL_RPC_METHODS = [
   'computeCall',
   'agentsCall',
   'skillsCall',
-  'framesCall'
+  'framesCall',
+  'llmCall'
 ] as const
 
 export type SessionCapabilityName = (typeof CURRENT_PRIMARY_CAPABILITIES)[number]
@@ -515,6 +517,12 @@ export class AcpSessionCapabilityOwner {
     ) {
       capabilities.push('host-frames')
     }
+    if (
+      capabilities.includes('notebook') &&
+      policyAllowsSessionCapability(request.policy, 'host-llm')
+    ) {
+      capabilities.push('host-llm')
+    }
 
     const descriptor = freezeDescriptor({
       role: request.policy.role,
@@ -526,7 +534,8 @@ export class AcpSessionCapabilityOwner {
       controlRpcMethods:
         capabilities.includes('host-agents') ||
         capabilities.includes('host-skills') ||
-        capabilities.includes('host-frames')
+        capabilities.includes('host-frames') ||
+        capabilities.includes('host-llm')
           ? [...NOTEBOOK_CONTROL_RPC_METHODS]
           : []
     })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -36,6 +36,7 @@ import { createAcpCreateSessionWorkflow } from './acp/create-session-workflow'
 import { createAcpHandlerWorkflows } from './acp/handler-workflows'
 import { createAcpTaskAgentPort } from './acp/task-agent-port'
 import { ArtifactCodeReconstructionRunner } from './acp/artifact-code-reconstruction-runner'
+import { RestrictedInferenceRunner } from './acp/restricted-inference-runner'
 import { ArchiveCoordinator } from './archive/coordinator'
 import { ArtifactCodeReconstructionService } from './artifacts/code-reconstruction'
 import {
@@ -124,6 +125,7 @@ import { runtimeRoot } from './notebook/runtime-paths'
 import { HostArtifactsService } from './notebook/host-artifacts-service'
 import { HostLineageService } from './notebook/host-lineage-service'
 import { HostFramesService } from './notebook/host-frames-service'
+import { HostLlmService } from './notebook/host-llm-service'
 import type { NotebookEnvironmentManager } from './notebook/runtime-service'
 import { parseArtifactVersionLocator } from '../shared/artifact-provenance'
 import { DEFAULT_ARTIFACT_PROJECT_NAME } from '../shared/artifacts'
@@ -1248,6 +1250,29 @@ const createApplicationModules = async (
     },
     onPublishedSkillsChanged: () => void runtimeRef.current?.requestSkillsReload()
   })
+  const hostLlmLog = createLogger('notebook:host-llm')
+  const hostLlmService = await modules.add(
+    new HostLlmService({
+      captureTarget: () => settingsService.captureActiveExplicitAgentBackendTarget(),
+      runner: new RestrictedInferenceRunner({
+        appVersion: app.getVersion(),
+        configRoot,
+        profileNamespace: 'host-llm',
+        resolveTarget: (target, context) =>
+          settingsService.resolveExplicitAgentBackend(target, context)
+      })
+    }),
+    (service) => ({
+      name: 'host-llm-service',
+      capability: service,
+      dispose: () => service.shutdown()
+    })
+  )
+  void hostLlmService
+    .sweepStaleProfiles()
+    .catch((error) =>
+      hostLlmLog.error('stale host.llm profile cleanup failed', diagnosticErrorFields(error))
+    )
   const notebookRpcServer = await modules.add(
     new NotebookLocalRpcServer(notebookLocalRpc, {
       onSessionReleased: (sessionId) => completionGateCoordinator.releaseSession(sessionId),
@@ -1298,7 +1323,8 @@ const createApplicationModules = async (
       }),
       inputRegistry: notebookInputRegistry,
       agentsService,
-      skillsService: hostSkillsService
+      skillsService: hostSkillsService,
+      hostLlm: hostLlmService
     }),
     createNotebookLocalRpcModule
   )

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1251,28 +1251,16 @@ const createApplicationModules = async (
     onPublishedSkillsChanged: () => void runtimeRef.current?.requestSkillsReload()
   })
   const hostLlmLog = createLogger('notebook:host-llm')
-  const hostLlmService = await modules.add(
-    new HostLlmService({
-      captureTarget: () => settingsService.captureActiveExplicitAgentBackendTarget(),
-      runner: new RestrictedInferenceRunner({
-        appVersion: app.getVersion(),
-        configRoot,
-        profileNamespace: 'host-llm',
-        resolveTarget: (target, context) =>
-          settingsService.resolveExplicitAgentBackend(target, context)
-      })
-    }),
-    (service) => ({
-      name: 'host-llm-service',
-      capability: service,
-      dispose: () => service.shutdown()
+  const hostLlmService = new HostLlmService({
+    captureTarget: () => settingsService.captureActiveExplicitAgentBackendTarget(),
+    runner: new RestrictedInferenceRunner({
+      appVersion: app.getVersion(),
+      configRoot,
+      profileNamespace: 'host-llm',
+      resolveTarget: (target, context) =>
+        settingsService.resolveExplicitAgentBackend(target, context)
     })
-  )
-  void hostLlmService
-    .sweepStaleProfiles()
-    .catch((error) =>
-      hostLlmLog.error('stale host.llm profile cleanup failed', diagnosticErrorFields(error))
-    )
+  })
   const notebookRpcServer = await modules.add(
     new NotebookLocalRpcServer(notebookLocalRpc, {
       onSessionReleased: (sessionId) => completionGateCoordinator.releaseSession(sessionId),
@@ -1328,6 +1316,17 @@ const createApplicationModules = async (
     }),
     createNotebookLocalRpcModule
   )
+  // Reverse module disposal cancels active inference before the RPC server waits for its handlers.
+  await modules.add(hostLlmService, (service) => ({
+    name: 'host-llm-service',
+    capability: service,
+    dispose: () => service.shutdown()
+  }))
+  void hostLlmService
+    .sweepStaleProfiles()
+    .catch((error) =>
+      hostLlmLog.error('stale host.llm profile cleanup failed', diagnosticErrorFields(error))
+    )
   // Register ownership before ACP construction. Reverse disposal therefore drains ACP + Notebook
   // through the coordinator first, then releases the local bridge without creating a second runtime
   // shutdown owner; rollback also closes a server started during partial composition.

--- a/src/main/notebook/application.test.ts
+++ b/src/main/notebook/application.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { NotebookRuntimeServiceOptions } from './runtime-service'
@@ -152,6 +154,15 @@ describe('Notebook application composition', () => {
 
     expect(order).toEqual(['backend-shutdown-coordinator', 'local-rpc', 'application-events'])
     expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('registers Host LLM after local RPC so reverse disposal cancels inference first', () => {
+    const source = readFileSync(resolve(__dirname, '../ipc.ts'), 'utf8')
+    const localRpcRegistration = source.indexOf('const notebookRpcServer = await modules.add(')
+    const hostLlmRegistration = source.indexOf("name: 'host-llm-service'")
+
+    expect(localRpcRegistration).toBeGreaterThan(-1)
+    expect(hostLlmRegistration).toBeGreaterThan(localRpcRegistration)
   })
 
   it('closes local RPC once when later composition rolls back', async () => {

--- a/src/main/notebook/host-llm-service.test.ts
+++ b/src/main/notebook/host-llm-service.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { CODEX_SHARED_PROVIDER_ID } from '../../shared/settings'
+import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
+import {
+  DEFAULT_OUTPUT_LIMIT_BYTES,
+  RestrictedInferenceError,
+  type RestrictedInferenceResult,
+  type RestrictedInferenceRunner
+} from '../acp/restricted-inference-runner'
+import {
+  MAX_BATCH_BYTES,
+  MAX_BATCH_ITEMS,
+  MAX_PROMPT_BYTES,
+  HostLlmService
+} from './host-llm-service'
+
+const target: ExplicitAgentBackendTarget = {
+  frameworkId: 'claude-code',
+  providerId: 'provider-a',
+  model: { kind: 'required', id: 'model-a' },
+  reasoningEffort: 'high'
+}
+
+const inferenceResult = (
+  text: string,
+  overrides: Partial<RestrictedInferenceResult> = {}
+): RestrictedInferenceResult => ({
+  text,
+  frameworkId: 'claude-code',
+  model: 'model-a',
+  stopReason: 'end_turn',
+  ...overrides
+})
+
+type RunnerHarness = Pick<
+  RestrictedInferenceRunner,
+  'run' | 'shutdown' | 'supportsTarget' | 'sweepStaleProfiles'
+> & {
+  run: ReturnType<typeof vi.fn>
+  shutdown: ReturnType<typeof vi.fn>
+  supportsTarget: ReturnType<typeof vi.fn>
+  sweepStaleProfiles: ReturnType<typeof vi.fn>
+}
+
+const makeService = (
+  run: (
+    input: Parameters<RestrictedInferenceRunner['run']>[0]
+  ) => Promise<RestrictedInferenceResult>,
+  capturedTarget: ExplicitAgentBackendTarget = target
+): {
+  service: HostLlmService
+  runner: RunnerHarness
+  captureTarget: ReturnType<typeof vi.fn>
+} => {
+  const captureTarget = vi.fn(async () => capturedTarget)
+  const runner: RunnerHarness = {
+    run: vi.fn(run),
+    shutdown: vi.fn(async () => undefined),
+    sweepStaleProfiles: vi.fn(async () => undefined),
+    supportsTarget: vi.fn(
+      (value: ExplicitAgentBackendTarget) => value.providerId !== CODEX_SHARED_PROVIDER_ID
+    )
+  }
+  return {
+    service: new HostLlmService({ captureTarget, runner }),
+    runner,
+    captureTarget
+  }
+}
+
+describe('HostLlmService', () => {
+  it('accepts a string or exact prompt object and returns a deeply frozen projection', async () => {
+    const { service, runner, captureTarget } = makeService(async ({ prompt }) =>
+      inferenceResult(`answer:${prompt}`, {
+        usage: {
+          inputTokens: 10,
+          cacheTokens: 3,
+          cachedReadTokens: 2,
+          cachedWriteTokens: 1,
+          outputTokens: 4,
+          turnCount: 1
+        }
+      })
+    )
+
+    const first = await service.call({ request: 'one' })
+    const second = await service.call({ request: { prompt: 'two' } })
+
+    expect(first).toEqual({
+      text: 'answer:one',
+      model: 'model-a',
+      stop_reason: 'end_turn',
+      usage: {
+        input_tokens: 10,
+        cache_tokens: 3,
+        output_tokens: 4,
+        cached_read_tokens: 2,
+        cached_write_tokens: 1,
+        turn_count: 1
+      }
+    })
+    expect(second).toMatchObject({ text: 'answer:two' })
+    expect(Object.isFrozen(first)).toBe(true)
+    expect(Object.isFrozen('usage' in first ? first.usage : undefined)).toBe(true)
+    expect(captureTarget).toHaveBeenCalledTimes(2)
+    expect(runner.run.mock.calls[0]?.[0].target).toBe(target)
+    expect(runner.run.mock.calls[0]?.[0].outputLimitBytes).toBe(DEFAULT_OUTPUT_LIMIT_BYTES)
+  })
+
+  it('preserves batch order, isolates item failures, and captures one target', async () => {
+    let active = 0
+    let maxActive = 0
+    const { service, captureTarget } = makeService(async ({ prompt }) => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, prompt === 'slow' ? 15 : 1))
+      active -= 1
+      if (prompt === 'fail') {
+        throw new RestrictedInferenceError('tool-violation', 'private provider detail')
+      }
+      return inferenceResult(prompt.toUpperCase())
+    })
+
+    await expect(
+      service.call({
+        requests: ['slow', { prompt: 'fast' }, { prompt: '', extra: true } as never, 'fail'],
+        options: { max_concurrency: 2 }
+      })
+    ).resolves.toEqual([
+      { text: 'SLOW', model: 'model-a', stop_reason: 'end_turn' },
+      { text: 'FAST', model: 'model-a', stop_reason: 'end_turn' },
+      { error: 'host.llm requests must be a prompt string or an exact { prompt } object.' },
+      { error: 'host.llm stopped because the selected agent attempted to use a tool.' }
+    ])
+    expect(maxActive).toBe(2)
+    expect(captureTarget).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ['the default', undefined, 2],
+    ['empty options as the default', {}, 2],
+    ['the maximum', { max_concurrency: 4 }, 4]
+  ] as const)('enforces %s batch concurrency', async (_name, options, expected) => {
+    let active = 0
+    let maxActive = 0
+    const { service } = makeService(async ({ prompt }) => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      active -= 1
+      return inferenceResult(prompt)
+    })
+
+    const result = await service.call({
+      requests: ['a', 'b', 'c', 'd', 'e', 'f'],
+      ...(options ? { options } : {})
+    })
+
+    expect(result).toHaveLength(6)
+    expect(maxActive).toBe(expected)
+  })
+
+  it('rejects global bounds and returns per-item validation failures before dispatch', async () => {
+    const { service, runner, captureTarget } = makeService(async ({ prompt }) =>
+      inferenceResult(prompt)
+    )
+
+    await expect(service.call({ request: '' })).rejects.toThrow('must not be empty')
+    await expect(service.call({ request: 'x'.repeat(MAX_PROMPT_BYTES + 1) })).rejects.toThrow(
+      `${MAX_PROMPT_BYTES}`
+    )
+    await expect(
+      service.call({ request: { prompt: 'x', model: 'secret' } as never })
+    ).rejects.toThrow('exact { prompt }')
+    await expect(service.call({ requests: [] })).rejects.toThrow('from 1 through')
+    await expect(
+      service.call({ requests: Array.from({ length: MAX_BATCH_ITEMS + 1 }, () => 'x') })
+    ).rejects.toThrow(`${MAX_BATCH_ITEMS}`)
+    await expect(
+      service.call({
+        requests: Array.from({ length: 9 }, () => 'x'.repeat(Math.ceil(MAX_BATCH_BYTES / 9)))
+      })
+    ).rejects.toThrow(`${MAX_BATCH_BYTES}`)
+    for (const max_concurrency of [0, 1.5, 5, '2']) {
+      await expect(
+        service.call({ requests: ['x'], options: { max_concurrency } as never })
+      ).rejects.toThrow('max_concurrency')
+    }
+
+    await expect(
+      service.call({ requests: [{ prompt: '', unknown: true } as never] })
+    ).resolves.toEqual([
+      { error: 'host.llm requests must be a prompt string or an exact { prompt } object.' }
+    ])
+    expect(runner.run).not.toHaveBeenCalled()
+    expect(captureTarget).not.toHaveBeenCalled()
+  })
+
+  it('fails availability and calls closed for unsupported Codex subscription routes', async () => {
+    const unsupported = {
+      ...target,
+      frameworkId: 'codex' as const,
+      providerId: CODEX_SHARED_PROVIDER_ID
+    }
+    const { service, runner, captureTarget } = makeService(
+      async ({ prompt }) => inferenceResult(prompt),
+      unsupported
+    )
+
+    await expect(service.isAvailable()).resolves.toBe(false)
+    await expect(service.call({ request: 'hello' })).rejects.toThrow(
+      'selected backend cannot enforce tool-less execution'
+    )
+    expect(captureTarget).toHaveBeenCalledTimes(2)
+    expect(runner.run).not.toHaveBeenCalled()
+  })
+
+  it('cancels the owning call and drains the runner during shutdown', async () => {
+    const { service, runner } = makeService(
+      ({ signal }) =>
+        new Promise<RestrictedInferenceResult>((_resolve, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => reject(new RestrictedInferenceError('cancelled', 'private detail')),
+            { once: true }
+          )
+        })
+    )
+    const call = service.call({ requests: ['one', 'two'] })
+
+    await vi.waitFor(() => expect(runner.run).toHaveBeenCalled())
+    await service.shutdown()
+
+    await expect(call).rejects.toThrow('host.llm call was cancelled')
+    expect(runner.shutdown).toHaveBeenCalledOnce()
+    await expect(service.call({ request: 'later' })).rejects.toThrow('is shutting down')
+  })
+
+  it('propagates a caller AbortSignal to active inference', async () => {
+    const controller = new AbortController()
+    let observedSignal: AbortSignal | undefined
+    const { service, runner } = makeService(
+      ({ signal }) =>
+        new Promise<RestrictedInferenceResult>((_resolve, reject) => {
+          observedSignal = signal
+          signal?.addEventListener(
+            'abort',
+            () => reject(new RestrictedInferenceError('cancelled', 'private detail')),
+            { once: true }
+          )
+        })
+    )
+    const call = service.call({ request: 'one' }, controller.signal)
+
+    await vi.waitFor(() => expect(runner.run).toHaveBeenCalledOnce())
+    controller.abort()
+
+    await expect(call).rejects.toThrow('host.llm call was cancelled')
+    expect(observedSignal?.aborted).toBe(true)
+  })
+
+  it('does not report availability after shutdown starts during target capture', async () => {
+    let finishCapture!: (target: ExplicitAgentBackendTarget) => void
+    const captured = new Promise<ExplicitAgentBackendTarget>((resolve) => {
+      finishCapture = resolve
+    })
+    const { runner } = makeService(async ({ prompt }) => inferenceResult(prompt))
+    const service = new HostLlmService({
+      captureTarget: vi.fn(() => captured),
+      runner
+    })
+    const availability = service.isAvailable()
+
+    await service.shutdown()
+    finishCapture(target)
+
+    await expect(availability).resolves.toBe(false)
+  })
+})

--- a/src/main/notebook/host-llm-service.test.ts
+++ b/src/main/notebook/host-llm-service.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   MAX_BATCH_BYTES,
   MAX_BATCH_ITEMS,
+  MAX_CONCURRENCY,
   MAX_PROMPT_BYTES,
   HostLlmService
 } from './host-llm-service'
@@ -159,6 +160,66 @@ describe('HostLlmService', () => {
 
     expect(result).toHaveLength(6)
     expect(maxActive).toBe(expected)
+  })
+
+  it('caps runner concurrency across overlapping public calls', async () => {
+    let active = 0
+    let maxActive = 0
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const { service, runner, captureTarget } = makeService(async ({ prompt }) => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await gate
+      active -= 1
+      return inferenceResult(prompt)
+    })
+
+    const first = service.call({
+      requests: ['a', 'b', 'c', 'd'],
+      options: { max_concurrency: MAX_CONCURRENCY }
+    })
+    const second = service.call({
+      requests: ['e', 'f', 'g', 'h'],
+      options: { max_concurrency: MAX_CONCURRENCY }
+    })
+
+    await vi.waitFor(() => expect(runner.run.mock.calls.length).toBeGreaterThanOrEqual(4))
+    const activeBeforeRelease = maxActive
+    release()
+    await Promise.all([first, second])
+
+    expect(activeBeforeRelease).toBe(MAX_CONCURRENCY)
+    expect(maxActive).toBe(MAX_CONCURRENCY)
+    expect(captureTarget).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancels a public call while it waits for a shared runner slot', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const { service, runner, captureTarget } = makeService(async ({ prompt }) => {
+      await gate
+      return inferenceResult(prompt)
+    })
+    const active = service.call({
+      requests: ['a', 'b', 'c', 'd'],
+      options: { max_concurrency: MAX_CONCURRENCY }
+    })
+    await vi.waitFor(() => expect(runner.run).toHaveBeenCalledTimes(MAX_CONCURRENCY))
+
+    const controller = new AbortController()
+    const queued = service.call({ request: 'queued' }, controller.signal)
+    await vi.waitFor(() => expect(captureTarget).toHaveBeenCalledTimes(2))
+    controller.abort()
+
+    await expect(queued).rejects.toThrow('host.llm call was cancelled')
+    expect(runner.run).toHaveBeenCalledTimes(MAX_CONCURRENCY)
+    release()
+    await expect(active).resolves.toHaveLength(MAX_CONCURRENCY)
   })
 
   it('rejects global bounds and returns per-item validation failures before dispatch', async () => {

--- a/src/main/notebook/host-llm-service.ts
+++ b/src/main/notebook/host-llm-service.ts
@@ -148,6 +148,8 @@ const projectResult = (result: RestrictedInferenceResult): HostLlmResult => {
 class HostLlmService {
   private readonly activeCalls = new Set<AbortController>()
   private readonly callDrainWaiters = new Set<() => void>()
+  private readonly runSlotWaiters: Array<() => void> = []
+  private activeRuns = 0
   private shuttingDown = false
 
   constructor(private readonly options: HostLlmServiceOptions) {}
@@ -252,21 +254,67 @@ class HostLlmService {
     })
   }
 
+  private acquireRunSlot(signal: AbortSignal): Promise<() => void> {
+    if (signal.aborted) {
+      return Promise.reject(new RestrictedInferenceError('cancelled', 'Cancelled.'))
+    }
+    if (this.activeRuns < MAX_CONCURRENCY) {
+      this.activeRuns += 1
+      return Promise.resolve(() => this.releaseRunSlot())
+    }
+    return new Promise<() => void>((resolve, reject) => {
+      const start = (): void => {
+        signal.removeEventListener('abort', cancel)
+        if (signal.aborted) {
+          this.releaseRunSlot()
+          reject(new RestrictedInferenceError('cancelled', 'Cancelled.'))
+          return
+        }
+        resolve(() => this.releaseRunSlot())
+      }
+      const cancel = (): void => {
+        const index = this.runSlotWaiters.indexOf(start)
+        if (index >= 0) this.runSlotWaiters.splice(index, 1)
+        reject(new RestrictedInferenceError('cancelled', 'Cancelled.'))
+      }
+      signal.addEventListener('abort', cancel, { once: true })
+      this.runSlotWaiters.push(start)
+    })
+  }
+
+  private releaseRunSlot(): void {
+    const next = this.runSlotWaiters.shift()
+    if (next) next()
+    else this.activeRuns -= 1
+  }
+
+  private async runInference(
+    prompt: string,
+    target: ExplicitAgentBackendTarget,
+    signal: AbortSignal
+  ): Promise<RestrictedInferenceResult> {
+    const release = await this.acquireRunSlot(signal)
+    try {
+      if (signal.aborted) throw new RestrictedInferenceError('cancelled', 'Cancelled.')
+      return await this.options.runner.run({
+        prompt,
+        target,
+        systemPrompt: HOST_LLM_SYSTEM_PROMPT,
+        agentName: 'open-science-host-llm',
+        description: 'One-shot host.llm inference without tools.',
+        signal,
+        outputLimitBytes: DEFAULT_OUTPUT_LIMIT_BYTES
+      })
+    } finally {
+      release()
+    }
+  }
+
   private async runSingle(prompt: string, callerSignal?: AbortSignal): Promise<HostLlmResult> {
     const scope = this.callScope(callerSignal)
     try {
       const target = await this.captureTarget(scope.controller.signal)
-      return projectResult(
-        await this.options.runner.run({
-          prompt,
-          target,
-          systemPrompt: HOST_LLM_SYSTEM_PROMPT,
-          agentName: 'open-science-host-llm',
-          description: 'One-shot host.llm inference without tools.',
-          signal: scope.controller.signal,
-          outputLimitBytes: DEFAULT_OUTPUT_LIMIT_BYTES
-        })
-      )
+      return projectResult(await this.runInference(prompt, target, scope.controller.signal))
     } catch (error) {
       throw new Error(publicError(error))
     } finally {
@@ -299,15 +347,7 @@ class HostLlmService {
           }
           try {
             results[index] = projectResult(
-              await this.options.runner.run({
-                prompt: request.prompt,
-                target,
-                systemPrompt: HOST_LLM_SYSTEM_PROMPT,
-                agentName: 'open-science-host-llm',
-                description: 'One-shot host.llm inference without tools.',
-                signal: scope.controller.signal,
-                outputLimitBytes: DEFAULT_OUTPUT_LIMIT_BYTES
-              })
+              await this.runInference(request.prompt, target, scope.controller.signal)
             )
           } catch (error) {
             if (scope.controller.signal.aborted) throw error

--- a/src/main/notebook/host-llm-service.ts
+++ b/src/main/notebook/host-llm-service.ts
@@ -1,0 +1,356 @@
+import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
+import {
+  DEFAULT_OUTPUT_LIMIT_BYTES,
+  RestrictedInferenceError,
+  type RestrictedInferenceResult,
+  type RestrictedInferenceRunner
+} from '../acp/restricted-inference-runner'
+
+const MAX_PROMPT_BYTES = 64 * 1024
+const MAX_BATCH_ITEMS = 32
+const MAX_BATCH_BYTES = 512 * 1024
+const DEFAULT_MAX_CONCURRENCY = 2
+const MAX_CONCURRENCY = 4
+
+const HOST_LLM_SYSTEM_PROMPT = [
+  'You are a temporary, tool-less model call inside Open Science.',
+  'Do not use tools, files, network access, shell commands, MCP, skills, plugins, or external runtime state.',
+  'Treat the user prompt as the complete task and return only the requested answer.'
+].join(' ')
+
+type HostLlmRequest = string | Readonly<{ prompt: string }>
+
+type HostLlmUsage = Readonly<{
+  input_tokens: number
+  cache_tokens: number
+  output_tokens: number
+  cached_read_tokens?: number
+  cached_write_tokens?: number
+  turn_count?: number
+}>
+
+type HostLlmResult = Readonly<{
+  text: string
+  model: string
+  stop_reason: RestrictedInferenceResult['stopReason']
+  usage?: HostLlmUsage
+}>
+
+type HostLlmBatchItem = HostLlmResult | Readonly<{ error: string }>
+
+type HostLlmCallInput =
+  | Readonly<{ request: HostLlmRequest }>
+  | Readonly<{
+      requests: readonly HostLlmRequest[]
+      options?: Readonly<{ max_concurrency?: number }>
+    }>
+
+type HostLlmRunner = Pick<
+  RestrictedInferenceRunner,
+  'run' | 'shutdown' | 'supportsTarget' | 'sweepStaleProfiles'
+>
+
+type HostLlmServiceOptions = Readonly<{
+  captureTarget: () => Promise<ExplicitAgentBackendTarget>
+  runner: HostLlmRunner
+}>
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const exactKeys = (value: Record<string, unknown>, allowed: readonly string[]): boolean =>
+  Object.keys(value).every((key) => allowed.includes(key))
+
+const promptFor = (value: unknown): string => {
+  const prompt =
+    typeof value === 'string'
+      ? value
+      : isRecord(value) && exactKeys(value, ['prompt']) && typeof value.prompt === 'string'
+        ? value.prompt
+        : undefined
+  if (prompt === undefined) {
+    throw new TypeError('host.llm requests must be a prompt string or an exact { prompt } object.')
+  }
+  if (!prompt.trim()) throw new TypeError('host.llm prompts must not be empty.')
+  if (Buffer.byteLength(prompt, 'utf8') > MAX_PROMPT_BYTES) {
+    throw new TypeError(`host.llm prompts must not exceed ${MAX_PROMPT_BYTES} UTF-8 bytes.`)
+  }
+  return prompt
+}
+
+const batchSize = (requests: readonly unknown[]): number => {
+  try {
+    return Buffer.byteLength(JSON.stringify(requests), 'utf8')
+  } catch {
+    throw new TypeError('host.llm requests must be JSON-serializable.')
+  }
+}
+
+const concurrencyFor = (value: unknown): number => {
+  if (value === undefined) return DEFAULT_MAX_CONCURRENCY
+  if (!isRecord(value) || !exactKeys(value, ['max_concurrency'])) {
+    throw new TypeError('host.llm batch options only accept max_concurrency.')
+  }
+  const concurrency = value.max_concurrency
+  if (concurrency === undefined) return DEFAULT_MAX_CONCURRENCY
+  if (
+    typeof concurrency !== 'number' ||
+    !Number.isInteger(concurrency) ||
+    concurrency < 1 ||
+    concurrency > MAX_CONCURRENCY
+  ) {
+    throw new TypeError(
+      `host.llm max_concurrency must be an integer from 1 through ${MAX_CONCURRENCY}.`
+    )
+  }
+  return concurrency
+}
+
+const publicError = (error: unknown): string => {
+  if (!(error instanceof RestrictedInferenceError)) return 'host.llm inference failed.'
+  switch (error.code) {
+    case 'cancelled':
+      return 'host.llm call was cancelled.'
+    case 'output-limit':
+      return `host.llm response exceeded the ${DEFAULT_OUTPUT_LIMIT_BYTES}-byte output limit.`
+    case 'shutting-down':
+      return 'host.llm is shutting down.'
+    case 'tool-violation':
+      return 'host.llm stopped because the selected agent attempted to use a tool.'
+    case 'transport-unavailable':
+      return 'host.llm is unavailable because the selected backend cannot enforce tool-less execution.'
+  }
+}
+
+const projectResult = (result: RestrictedInferenceResult): HostLlmResult => {
+  const usage = result.usage
+    ? Object.freeze({
+        input_tokens: result.usage.inputTokens,
+        cache_tokens: result.usage.cacheTokens,
+        output_tokens: result.usage.outputTokens,
+        ...(result.usage.cachedReadTokens === undefined
+          ? {}
+          : { cached_read_tokens: result.usage.cachedReadTokens }),
+        ...(result.usage.cachedWriteTokens === undefined
+          ? {}
+          : { cached_write_tokens: result.usage.cachedWriteTokens }),
+        ...(result.usage.turnCount === undefined ? {} : { turn_count: result.usage.turnCount })
+      })
+    : undefined
+  return Object.freeze({
+    text: result.text,
+    model: result.model,
+    stop_reason: result.stopReason,
+    ...(usage ? { usage } : {})
+  })
+}
+
+class HostLlmService {
+  private readonly activeCalls = new Set<AbortController>()
+  private readonly callDrainWaiters = new Set<() => void>()
+  private shuttingDown = false
+
+  constructor(private readonly options: HostLlmServiceOptions) {}
+
+  async isAvailable(): Promise<boolean> {
+    if (this.shuttingDown) return false
+    try {
+      const target = await this.options.captureTarget()
+      return !this.shuttingDown && this.options.runner.supportsTarget(target)
+    } catch {
+      return false
+    }
+  }
+
+  sweepStaleProfiles(): Promise<void> {
+    return this.options.runner.sweepStaleProfiles()
+  }
+
+  async call(
+    input: HostLlmCallInput,
+    callerSignal?: AbortSignal
+  ): Promise<HostLlmResult | readonly HostLlmBatchItem[]> {
+    if (this.shuttingDown) throw new Error('host.llm is shutting down.')
+    if (!isRecord(input)) throw new TypeError('host.llm RPC input must be an object.')
+    const payload: Record<string, unknown> = input
+
+    const batch = Object.hasOwn(payload, 'requests')
+    if (batch) {
+      if (!exactKeys(payload, ['requests', 'options']) || !Array.isArray(payload.requests)) {
+        throw new TypeError('host.llm batch input must contain only requests and options.')
+      }
+      const requests = payload.requests
+      if (requests.length === 0 || requests.length > MAX_BATCH_ITEMS) {
+        throw new TypeError(
+          `host.llm batches must contain from 1 through ${MAX_BATCH_ITEMS} requests.`
+        )
+      }
+      if (batchSize(requests) > MAX_BATCH_BYTES) {
+        throw new TypeError(`host.llm batches must not exceed ${MAX_BATCH_BYTES} serialized bytes.`)
+      }
+      const concurrency = concurrencyFor(payload.options)
+      const parsed = requests.map((request) => {
+        try {
+          return { prompt: promptFor(request) } as const
+        } catch (error) {
+          return {
+            error: error instanceof Error ? error.message : 'host.llm request is invalid.'
+          } as const
+        }
+      })
+      if (parsed.every((request) => 'error' in request)) {
+        return Object.freeze(parsed.map((request) => Object.freeze({ error: request.error! })))
+      }
+      return this.runBatch(parsed, concurrency, callerSignal)
+    }
+
+    if (!exactKeys(payload, ['request']) || !Object.hasOwn(payload, 'request')) {
+      throw new TypeError('host.llm single input must contain only request.')
+    }
+    return this.runSingle(promptFor(payload.request), callerSignal)
+  }
+
+  private async captureTarget(signal: AbortSignal): Promise<ExplicitAgentBackendTarget> {
+    const target = await this.options.captureTarget()
+    if (signal.aborted) throw new RestrictedInferenceError('cancelled', 'Cancelled.')
+    if (!this.options.runner.supportsTarget(target)) {
+      throw new RestrictedInferenceError('transport-unavailable', 'Unavailable.')
+    }
+    return target
+  }
+
+  private callScope(callerSignal: AbortSignal | undefined): {
+    controller: AbortController
+    close: () => void
+  } {
+    const controller = new AbortController()
+    const forwardAbort = (): void => controller.abort(callerSignal?.reason)
+    callerSignal?.addEventListener('abort', forwardAbort, { once: true })
+    if (callerSignal?.aborted) forwardAbort()
+    this.activeCalls.add(controller)
+    return {
+      controller,
+      close: () => {
+        callerSignal?.removeEventListener('abort', forwardAbort)
+        this.activeCalls.delete(controller)
+        if (this.activeCalls.size === 0) {
+          for (const resolve of this.callDrainWaiters) resolve()
+          this.callDrainWaiters.clear()
+        }
+      }
+    }
+  }
+
+  private waitForCalls(): Promise<void> {
+    if (this.activeCalls.size === 0) return Promise.resolve()
+    return new Promise<void>((resolve) => {
+      this.callDrainWaiters.add(resolve)
+      if (this.activeCalls.size === 0) {
+        this.callDrainWaiters.delete(resolve)
+        resolve()
+      }
+    })
+  }
+
+  private async runSingle(prompt: string, callerSignal?: AbortSignal): Promise<HostLlmResult> {
+    const scope = this.callScope(callerSignal)
+    try {
+      const target = await this.captureTarget(scope.controller.signal)
+      return projectResult(
+        await this.options.runner.run({
+          prompt,
+          target,
+          systemPrompt: HOST_LLM_SYSTEM_PROMPT,
+          agentName: 'open-science-host-llm',
+          description: 'One-shot host.llm inference without tools.',
+          signal: scope.controller.signal,
+          outputLimitBytes: DEFAULT_OUTPUT_LIMIT_BYTES
+        })
+      )
+    } catch (error) {
+      throw new Error(publicError(error))
+    } finally {
+      scope.close()
+    }
+  }
+
+  private async runBatch(
+    parsed: readonly (Readonly<{ prompt: string }> | Readonly<{ error: string }>)[],
+    concurrency: number,
+    callerSignal?: AbortSignal
+  ): Promise<readonly HostLlmBatchItem[]> {
+    const scope = this.callScope(callerSignal)
+    try {
+      const target = await this.captureTarget(scope.controller.signal)
+      const results = new Array<HostLlmBatchItem>(parsed.length)
+      let next = 0
+      const worker = async (): Promise<void> => {
+        for (;;) {
+          if (scope.controller.signal.aborted) {
+            throw new RestrictedInferenceError('cancelled', 'Cancelled.')
+          }
+          const index = next
+          next += 1
+          if (index >= parsed.length) return
+          const request = parsed[index]!
+          if ('error' in request) {
+            results[index] = Object.freeze({ error: request.error })
+            continue
+          }
+          try {
+            results[index] = projectResult(
+              await this.options.runner.run({
+                prompt: request.prompt,
+                target,
+                systemPrompt: HOST_LLM_SYSTEM_PROMPT,
+                agentName: 'open-science-host-llm',
+                description: 'One-shot host.llm inference without tools.',
+                signal: scope.controller.signal,
+                outputLimitBytes: DEFAULT_OUTPUT_LIMIT_BYTES
+              })
+            )
+          } catch (error) {
+            if (scope.controller.signal.aborted) throw error
+            results[index] = Object.freeze({ error: publicError(error) })
+          }
+        }
+      }
+      const workers = Array.from({ length: Math.min(concurrency, parsed.length) }, () => worker())
+      const settled = await Promise.allSettled(workers)
+      const rejected = settled.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected'
+      )
+      if (rejected) throw rejected.reason
+      return Object.freeze(results)
+    } catch (error) {
+      throw new Error(publicError(error))
+    } finally {
+      scope.close()
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true
+    for (const call of this.activeCalls) call.abort()
+    await this.options.runner.shutdown()
+    await this.waitForCalls()
+  }
+}
+
+export {
+  DEFAULT_MAX_CONCURRENCY,
+  HOST_LLM_SYSTEM_PROMPT,
+  MAX_BATCH_BYTES,
+  MAX_BATCH_ITEMS,
+  MAX_CONCURRENCY,
+  MAX_PROMPT_BYTES,
+  HostLlmService
+}
+export type {
+  HostLlmBatchItem,
+  HostLlmCallInput,
+  HostLlmRequest,
+  HostLlmResult,
+  HostLlmServiceOptions,
+  HostLlmUsage
+}

--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -40,7 +40,8 @@ describe('capabilitiesCall RPC', () => {
       skillsService: {} as never,
       hostArtifacts: {} as never,
       hostLineage: {} as never,
-      hostFrames: {} as never
+      hostFrames: {} as never,
+      hostLlm: { isAvailable: async () => true, call: async () => ({}) as never }
     })
     const connection = await server.issueControlConnection('trusted-session', 'trusted-project')
 
@@ -59,7 +60,8 @@ describe('capabilitiesCall RPC', () => {
         skills: true,
         artifacts: true,
         lineage: true,
-        frames: true
+        frames: true,
+        llm: true
       }
     })
   })
@@ -80,7 +82,8 @@ describe('capabilitiesCall RPC', () => {
           skills: false,
           artifacts: false,
           lineage: false,
-          frames: false
+          frames: false,
+          llm: false
         }
       }
     })
@@ -95,6 +98,30 @@ describe('capabilitiesCall RPC', () => {
 
     await expect(callCapabilities(connection)).resolves.toMatchObject({
       payload: { result: { frames: false } }
+    })
+  })
+
+  it('returns false when host.llm is configured but the active route is unavailable', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostLlm: { isAvailable: async () => false, call: async () => ({}) as never }
+    })
+    const connection = await server.issueControlConnection('trusted-session', 'trusted-project')
+
+    await expect(callCapabilities(connection)).resolves.toMatchObject({
+      payload: { result: { llm: false } }
+    })
+  })
+
+  it('does not advertise host.llm through a non-control session capability', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostLlm: { isAvailable: async () => true, call: async () => ({}) as never }
+    })
+    const connection = await server.issueSessionConnection('trusted-session', 'trusted-project')
+
+    await expect(callCapabilities(connection)).resolves.toMatchObject({
+      payload: { result: { llm: false } }
     })
   })
 

--- a/src/main/notebook/local-rpc-server.llm.test.ts
+++ b/src/main/notebook/local-rpc-server.llm.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { HostLlmCallInput, HostLlmResult } from './host-llm-service'
+import { NotebookLocalRpcServer } from './local-rpc-server'
+
+let server: NotebookLocalRpcServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+const call = async (
+  endpoint: string,
+  token: string,
+  params: Record<string, unknown>,
+  signal?: AbortSignal
+): Promise<Response> =>
+  fetch(endpoint, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ method: 'llmCall', params }),
+    signal
+  })
+
+describe('llmCall RPC', () => {
+  it('routes only through a control capability and strips trusted identity fields', async () => {
+    const hostLlmCall = vi.fn<
+      (input: HostLlmCallInput, signal?: AbortSignal) => Promise<HostLlmResult>
+    >(async () => ({ text: 'PONG', model: 'model-a', stop_reason: 'end_turn' }))
+    const hostLlm = {
+      isAvailable: vi.fn(async () => true),
+      call: hostLlmCall
+    }
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostLlm
+    })
+    const control = await server.issueControlConnection('trusted-session', 'trusted-project')
+
+    const response = await call(control.endpoint, control.token, {
+      request: 'PING',
+      sessionId: 'forged-session',
+      projectId: 'forged-project'
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      result: { text: 'PONG', model: 'model-a', stop_reason: 'end_turn' }
+    })
+    expect(hostLlmCall).toHaveBeenCalledOnce()
+    expect(hostLlmCall.mock.calls[0]?.[0]).toEqual({ request: 'PING' })
+    expect(hostLlmCall.mock.calls[0]?.[1]).toBeInstanceOf(AbortSignal)
+
+    const agent = await server.issueSessionConnection('trusted-session', 'trusted-project')
+    const forbidden = await call(agent.endpoint, agent.token, { request: 'PING' })
+    expect(forbidden.status).toBe(403)
+    await expect(forbidden.json()).resolves.toEqual({
+      error: 'host.llm requires a control-plane REPL capability.'
+    })
+
+    const bootstrap = await server.ensureStarted()
+    const unauthorized = await call(bootstrap.endpoint, bootstrap.token, { request: 'PING' })
+    expect(unauthorized.status).toBe(401)
+    await expect(unauthorized.json()).resolves.toEqual({
+      error: 'A session-bound notebook RPC token is required.'
+    })
+  })
+
+  it('aborts host inference when the RPC client disconnects', async () => {
+    let observedSignal: AbortSignal | undefined
+    const hostLlm = {
+      isAvailable: vi.fn(async () => true),
+      call: vi.fn(
+        async (_input: unknown, signal?: AbortSignal) =>
+          new Promise<never>((_resolve, reject) => {
+            observedSignal = signal
+            signal?.addEventListener('abort', () => reject(new Error('cancelled')), {
+              once: true
+            })
+          })
+      )
+    }
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostLlm
+    })
+    const control = await server.issueControlConnection('trusted-session', 'trusted-project')
+    const controller = new AbortController()
+    const request = call(control.endpoint, control.token, { request: 'PING' }, controller.signal)
+
+    await vi.waitFor(() => expect(hostLlm.call).toHaveBeenCalled())
+    controller.abort()
+
+    await expect(request).rejects.toThrow()
+    await vi.waitFor(() => expect(observedSignal?.aborted).toBe(true))
+  })
+})

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -43,6 +43,7 @@ import {
 } from '../local-rpc-transport'
 import { createLogger, errorLogFields } from '../logger'
 import { PlanCommandError } from '../../shared/session-plan/contract'
+import type { HostLlmCallInput, HostLlmResult, HostLlmBatchItem } from './host-llm-service'
 
 const log = createLogger('notebook:local-rpc')
 
@@ -169,6 +170,13 @@ type NotebookLocalRpcServerOptions = {
   skillsService?: {
     dispatch(op: unknown, context: TrustedCallingSession): Promise<unknown>
   }
+  hostLlm?: {
+    isAvailable(): Promise<boolean>
+    call(
+      input: HostLlmCallInput,
+      signal?: AbortSignal
+    ): Promise<HostLlmResult | readonly HostLlmBatchItem[]>
+  }
 }
 
 type NotebookRpcPayload = {
@@ -217,6 +225,7 @@ const CONTROL_RPC_METHODS = new Set([
   'computeCall',
   'agentsCall',
   'skillsCall',
+  'llmCall',
   'requestUserInput'
 ])
 const SKILL_IMPORT_RPC_METHODS = new Set(['skillImport'])
@@ -266,6 +275,7 @@ class NotebookLocalRpcServer {
   private readonly hostFrames: NotebookLocalRpcServerOptions['hostFrames']
   private readonly agentsService: NotebookLocalRpcServerOptions['agentsService']
   private readonly skillsService: NotebookLocalRpcServerOptions['skillsService']
+  private readonly hostLlm: NotebookLocalRpcServerOptions['hostLlm']
   private server: Server | undefined
   private startPromise: Promise<NotebookRpcConnection> | undefined
   private readonly sessionAliases = new Map<string, string>()
@@ -305,6 +315,7 @@ class NotebookLocalRpcServer {
     this.hostFrames = options.hostFrames
     this.agentsService = options.agentsService
     this.skillsService = options.skillsService
+    this.hostLlm = options.hostLlm
   }
 
   issueArtifactRunCapability(
@@ -711,6 +722,13 @@ class NotebookLocalRpcServer {
     }
 
     let releaseArtifactRequest: (() => void) | undefined
+    const requestAbort = new AbortController()
+    const abortRequest = (): void => requestAbort.abort()
+    const abortClosedResponse = (): void => {
+      if (!response.writableEnded) abortRequest()
+    }
+    request.once('aborted', abortRequest)
+    response.once('close', abortClosedResponse)
     try {
       const payload = await readJsonBody(request)
       const method = typeof payload.method === 'string' ? payload.method : ''
@@ -721,7 +739,14 @@ class NotebookLocalRpcServer {
         : ''
       let hostCapabilities:
         | Record<
-            'mcp' | 'compute' | 'agents' | 'skills' | 'artifacts' | 'lineage' | 'frames',
+            | 'mcp'
+            | 'compute'
+            | 'agents'
+            | 'skills'
+            | 'artifacts'
+            | 'lineage'
+            | 'frames'
+            | 'llm',
             boolean
           >
         | undefined
@@ -758,6 +783,9 @@ class NotebookLocalRpcServer {
           if (method === 'framesCall' && !sessionBinding.isControl) {
             throw new RpcHttpError(403, 'host.frames requires a control-plane REPL capability.')
           }
+          if (method === 'llmCall' && !sessionBinding.isControl) {
+            throw new RpcHttpError(403, 'host.llm requires a control-plane REPL capability.')
+          }
           if (
             method === 'agentsCall' &&
             params.op === 'switch' &&
@@ -781,7 +809,12 @@ class NotebookLocalRpcServer {
               frames:
                 Boolean(sessionBinding.isControl) &&
                 allows('framesCall') &&
-                Boolean(this.hostFrames)
+                Boolean(this.hostFrames),
+              llm:
+                sessionBinding.isControl === true &&
+                allows('llmCall') &&
+                Boolean(this.hostLlm) &&
+                (await this.hostLlm!.isAvailable())
             }
           }
           // The request body is agent-controlled. Owner fields always come from the unforgeable,
@@ -815,7 +848,8 @@ class NotebookLocalRpcServer {
       }
       // Resolve pre-session aliases before the runtime service looks up persistent state.
       const result =
-        hostCapabilities ?? (await this.dispatch(method, this.resolveSessionAlias(params)))
+        hostCapabilities ??
+        (await this.dispatch(method, this.resolveSessionAlias(params), requestAbort.signal))
 
       writeJson(response, 200, { result })
     } catch (error) {
@@ -834,12 +868,18 @@ class NotebookLocalRpcServer {
         error: serializedError
       })
     } finally {
+      request.removeListener('aborted', abortRequest)
+      response.removeListener('close', abortClosedResponse)
       releaseArtifactRequest?.()
     }
   }
 
   // Maps the narrow RPC method names to strongly-typed runtime service calls.
-  private async dispatch(method: string, params: Record<string, unknown>): Promise<unknown> {
+  private async dispatch(
+    method: string,
+    params: Record<string, unknown>,
+    signal?: AbortSignal
+  ): Promise<unknown> {
     // Artifact stdio/HTTP MCP handlers cannot own SQLite connections. Route the trusted run-bound
     // save envelope back into the main process, where the Provenance repository owns transactions,
     // immutable Version publication, and idempotency.
@@ -955,6 +995,14 @@ class NotebookLocalRpcServer {
       if (params.op === 'list') return this.hostFrames.list(params.options, context)
       if (params.op === 'get') return this.hostFrames.get(params.frame_id, params.options, context)
       throw new Error('Unknown host Frame operation.')
+    }
+
+    if (method === 'llmCall') {
+      if (!this.hostLlm) throw new Error('host.llm is not configured.')
+      const { sessionId: _sessionId, projectId: _projectId, ...input } = params
+      void _sessionId
+      void _projectId
+      return this.hostLlm.call(input as HostLlmCallInput, signal)
     }
 
     if (method === 'resolveNotebookInput') {

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -739,14 +739,7 @@ class NotebookLocalRpcServer {
         : ''
       let hostCapabilities:
         | Record<
-            | 'mcp'
-            | 'compute'
-            | 'agents'
-            | 'skills'
-            | 'artifacts'
-            | 'lineage'
-            | 'frames'
-            | 'llm',
+            'mcp' | 'compute' | 'agents' | 'skills' | 'artifacts' | 'lineage' | 'frames' | 'llm',
             boolean
           >
         | undefined

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -343,6 +343,7 @@ describe('repl_execute tool', () => {
     expect(tool?.description).toBe(REPL_EXECUTE_DOC)
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('host.capabilities')
     expect(tool?.description).toContain('host.capabilities')
+    expect(tool?.description).toContain('host.llm')
     expect(tool?.description).toContain('self-awareness')
     expect(tool?.description).toContain('host.mcp')
     // host.compute (remote compute) is only reachable here too, same as host.mcp.

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -23,7 +23,7 @@ const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
   'Notebook tool instructions (only applies when using open-science-notebook tools).',
   'In Default mode, use `ask_user_question` as the first tool call when a request has materially different interpretations; do not inspect or use other tools first, and never print a textual choice list. Put all 1-3 known questions in one call with 2-4 real options each. Infer minor reversible details and omit Other; the UI adds custom, agent-decide, and Skip. It shows questions one at a time, then continues the task after Finish. A pending result ends the turn normally.',
   'Notebook preview is only for code and execution results; keep chat, explanation, and diagnosis in the chat area.',
-  'Use `notebook_execute` for one persistent Python/R cell per call; reuse `cellId` to rerun it. Python/R data kernels cannot call connectors; use `repl_execute` for `host.capabilities`/`host.mcp`/`host.compute`/`host.agents`/`host.skills`. For large cross-kernel data, write under `process.env.OPEN_SCIENCE_HANDOFF_DIR` in the REPL and read that path from Python/R.',
+  'Use `notebook_execute` for one persistent Python/R cell per call; reuse `cellId` to rerun it. Python/R data kernels cannot call connectors; use `repl_execute` for `host.capabilities`/`host.llm`/`host.mcp`/`host.compute`/`host.agents`/`host.skills`. For large cross-kernel data, write under `process.env.OPEN_SCIENCE_HANDOFF_DIR` in the REPL and read that path from Python/R.',
   'Each runtime is a separate persistent namespace. Create named runtimes with `manage_environments`, select them with the bind/switch tools, and use files to move data across runtimes. Memory is lost on restart or app reopen; run history and files survive.',
   'The notebook already runs inside a writable session workspace. The cwd is already the session data dir; use plain relative paths for normal inputs and outputs. The connector handoff directory is outside that cwd and must be resolved from `OPEN_SCIENCE_HANDOFF_DIR`. Never copy a saved file onto the same path. Do not modify original user files.',
   'Use `inspect_packages` for version checks and `manage_packages` for installs. Never install inside a cell or shell. App-managed runtime contents belong under `$OPEN_SCIENCE_RUNTIME_DIR`, never the project, workspace, system Python, or a user global environment.',
@@ -167,7 +167,7 @@ const SWITCH_RUNTIME_DOC = [
 const REPL_EXECUTE_DOC = [
   'Run JavaScript in the persistent control-plane REPL, separate from notebook_execute Python/R data kernels.',
   'Use `await host.capabilities()` to feature-gate optional host namespaces; load the `self-awareness` Skill for its boolean contract and current capability map.',
-  'Only this kernel can call connectors (`await host.mcp(server, method, args)`), remote compute (`host.compute`; load its skill for the API), Specialist management (`host.agents`), and Skill authoring (`host.skills`).',
+  'Only this kernel can call temporary tool-less inference (`await host.llm(prompt)` or a bounded prompt batch), connectors (`await host.mcp(server, method, args)`), remote compute (`host.compute`; load its skill for the API), Specialist management (`host.agents`), and Skill authoring (`host.skills`).',
   'Globals persist and a trailing expression is returned. Return results directly when they are for Agent inspection. To hand off large data from the REPL to Python/R, write it under process.env.OPEN_SCIENCE_HANDOFF_DIR; Python/R reads the same OPEN_SCIENCE_HANDOFF_DIR path. Use notebook_execute for analysis code.'
 ].join('\n')
 

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -108,7 +108,8 @@ describe('repl_loop local RPC transport', () => {
                 skills: true,
                 artifacts: true,
                 lineage: true,
-                frames: true
+                frames: true,
+                llm: true
               }
             : {
                 mcp: true,
@@ -117,7 +118,8 @@ describe('repl_loop local RPC transport', () => {
                 skills: true,
                 artifacts: true,
                 lineage: true,
-                frames: true
+                frames: true,
+                llm: true
               }
         response
           .writeHead(200, { 'content-type': 'application/json' })
@@ -149,7 +151,8 @@ describe('repl_loop local RPC transport', () => {
           skills: true,
           artifacts: true,
           lineage: true,
-          frames: true
+          frames: true,
+          llm: true
         },
         second: {
           mcp: true,
@@ -158,7 +161,8 @@ describe('repl_loop local RPC transport', () => {
           skills: true,
           artifacts: true,
           lineage: true,
-          frames: true
+          frames: true,
+          llm: true
         },
         frozen: true,
         same: false
@@ -451,6 +455,196 @@ describe('repl_loop local RPC transport', () => {
         'host.lineage.get returned an invalid operation-log truncation'
       )
       expect(requests).toHaveLength(7)
+    } finally {
+      child.kill()
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  }, 60_000)
+
+  it('validates and deeply freezes host.llm single and batch results', async () => {
+    const requests: Array<{ method?: string; params?: Record<string, unknown> }> = []
+    const server = createServer((request, response) => {
+      let body = ''
+      request.on('data', (chunk) => (body += chunk))
+      request.on('end', () => {
+        const parsed = JSON.parse(body) as {
+          method?: string
+          params?: Record<string, unknown>
+        }
+        requests.push(parsed)
+        const batchRequests = parsed.params?.requests
+        const result = Array.isArray(batchRequests)
+          ? batchRequests.map((request, index) =>
+              request === null
+                ? {
+                    error:
+                      'host.llm requests must be a prompt string or an exact { prompt } object.'
+                  }
+                : index === 1
+                  ? { error: 'provider unavailable' }
+                  : { text: 'A', model: 'model-a', stop_reason: 'end_turn' }
+            )
+          : parsed.params?.request === 'INVALID_RESULT'
+            ? { text: 'leak', model: 'model-a', stop_reason: 'end_turn', raw: 'private' }
+            : parsed.params?.request === 'INVALID_USAGE'
+              ? {
+                  text: 'leak',
+                  model: 'model-a',
+                  stop_reason: 'end_turn',
+                  usage: { input_tokens: 1, output_tokens: 1 }
+                }
+              : {
+                  text: 'PONG',
+                  model: 'model-a',
+                  stop_reason: 'end_turn',
+                  usage: {
+                    input_tokens: 10,
+                    cache_tokens: 3,
+                    output_tokens: 4,
+                    cached_read_tokens: 2,
+                    cached_write_tokens: 1,
+                    turn_count: 1
+                  }
+                }
+        response
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ result }))
+      })
+    })
+    const connection = await listenForLocalRpc(server, {
+      name: 'repl-loop-host-llm-test',
+      transport: 'pipe'
+    })
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+      OPEN_SCIENCE_MCP_RPC_SOCKET_PATH: connection.socketPath,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'test-token'
+    })
+
+    try {
+      const single = await send(
+        "const value = await host.llm('PING'); " +
+          'return JSON.stringify({ value, frozen: Object.isFrozen(value), usageFrozen: Object.isFrozen(value.usage) })'
+      )
+      expect(single.error).toBeNull()
+      expect(JSON.parse(single.result ?? '{}')).toEqual({
+        value: {
+          text: 'PONG',
+          model: 'model-a',
+          stop_reason: 'end_turn',
+          usage: {
+            input_tokens: 10,
+            cache_tokens: 3,
+            output_tokens: 4,
+            cached_read_tokens: 2,
+            cached_write_tokens: 1,
+            turn_count: 1
+          }
+        },
+        frozen: true,
+        usageFrozen: true
+      })
+
+      const batch = await send(
+        "const value = await host.llm(['a', { prompt: 'b' }], { max_concurrency: 2 }); " +
+          'return JSON.stringify({ value, frozen: Object.isFrozen(value), itemFrozen: value.every(Object.isFrozen) })'
+      )
+      expect(batch.error).toBeNull()
+      expect(JSON.parse(batch.result ?? '{}')).toEqual({
+        value: [
+          { text: 'A', model: 'model-a', stop_reason: 'end_turn' },
+          { error: 'provider unavailable' }
+        ],
+        frozen: true,
+        itemFrozen: true
+      })
+      expect(requests).toEqual([
+        { method: 'llmCall', params: { request: 'PING' } },
+        {
+          method: 'llmCall',
+          params: { requests: ['a', { prompt: 'b' }], options: { max_concurrency: 2 } }
+        }
+      ])
+
+      const invalidOptions = await send(
+        "try { await host.llm('single', { max_concurrency: 2 }); return 'no error' } " +
+          "catch (error) { return error.name + ': ' + error.message }"
+      )
+      expect(invalidOptions.result).toBe(
+        'TypeError: host.llm options are only accepted for batch calls'
+      )
+      expect(requests).toHaveLength(2)
+
+      const invalidSingle = await send(
+        "try { await host.llm({ prompt: 'x', model: undefined }); return 'no error' } " +
+          "catch (error) { return error.name + ': ' + error.message }"
+      )
+      expect(invalidSingle.result).toBe(
+        'TypeError: host.llm requests must be a prompt string or an exact { prompt } object.'
+      )
+      expect(requests).toHaveLength(2)
+
+      const invalidBatchOptions = await send(
+        "try { await host.llm(['x'], { max_concurrency: 2, extra: undefined }); return 'no error' } " +
+          "catch (error) { return error.name + ': ' + error.message }"
+      )
+      expect(invalidBatchOptions.result).toBe(
+        'TypeError: host.llm batch options only accept max_concurrency.'
+      )
+      expect(requests).toHaveLength(2)
+
+      const isolatedInvalidItems = await send(
+        "const cyclic = { prompt: 'bad' }; cyclic.extra = cyclic; " +
+          "const value = await host.llm(['ok', 1n, cyclic]); return JSON.stringify(value)"
+      )
+      expect(isolatedInvalidItems.error).toBeNull()
+      expect(JSON.parse(isolatedInvalidItems.result ?? '[]')).toEqual([
+        { text: 'A', model: 'model-a', stop_reason: 'end_turn' },
+        { error: 'host.llm requests must be a prompt string or an exact { prompt } object.' },
+        { error: 'host.llm requests must be a prompt string or an exact { prompt } object.' }
+      ])
+      expect(requests.at(-1)).toEqual({
+        method: 'llmCall',
+        params: { requests: ['ok', null, null] }
+      })
+
+      const snapshottedAccessor = await send(
+        "let reads = 0; const item = { get prompt() { reads += 1; return reads === 1 ? 'snapshot' : 1n } }; " +
+          'const value = await host.llm([item]); return JSON.stringify({ value, reads })'
+      )
+      expect(snapshottedAccessor.error).toBeNull()
+      expect(JSON.parse(snapshottedAccessor.result ?? '{}')).toEqual({
+        value: [{ text: 'A', model: 'model-a', stop_reason: 'end_turn' }],
+        reads: 1
+      })
+      expect(requests.at(-1)).toEqual({
+        method: 'llmCall',
+        params: { requests: [{ prompt: 'snapshot' }] }
+      })
+
+      const throwingOptionsAccessor = await send(
+        "const options = {}; Object.defineProperty(options, 'max_concurrency', { get() { throw new Error('raw getter detail') } }); " +
+          "try { await host.llm(['x'], options); return 'no error' } " +
+          "catch (error) { return error.name + ': ' + error.message }"
+      )
+      expect(throwingOptionsAccessor.result).toBe(
+        'TypeError: host.llm batch options only accept max_concurrency.'
+      )
+      expect(requests).toHaveLength(4)
+
+      const invalidResult = await send(
+        "try { await host.llm('INVALID_RESULT'); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(invalidResult.result).toBe('host.llm returned an invalid result')
+
+      const invalidUsage = await send(
+        "try { await host.llm('INVALID_USAGE'); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(invalidUsage.result).toBe('host.llm returned invalid usage')
     } finally {
       child.kill()
       await new Promise<void>((resolve, reject) =>

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -536,7 +536,9 @@ describe('Settings backend ownership architecture', () => {
     ])
     expect(importersOf(settingsPaths.backendResolver)).toEqual([
       'src/main/acp/artifact-code-reconstruction-runner.ts',
+      'src/main/acp/restricted-inference-runner.ts',
       'src/main/artifacts/code-reconstruction.ts',
+      'src/main/notebook/host-llm-service.ts',
       'src/main/settings/service.ts',
       'src/main/side-chat/runtime-owner.ts'
     ])
@@ -607,6 +609,7 @@ describe('Settings backend ownership architecture', () => {
       'computeCall',
       'agentsCall',
       'skillsCall',
+      'llmCall',
       'requestUserInput'
     ])
     expect(

--- a/src/main/skills/self-awareness-skill.test.ts
+++ b/src/main/skills/self-awareness-skill.test.ts
@@ -22,12 +22,13 @@ describe('self-awareness bundled Skill', () => {
     expect(skill?.description).toMatch(/JavaScript control REPL/i)
   })
 
-  it('documents the shipped seven-key JavaScript contract and read limits', async () => {
+  it('documents the shipped eight-key JavaScript contract and read limits', async () => {
     const body = await new SkillRegistry(skillsRoot).body('self-awareness')
 
     for (const phrase of [
       'repl_execute',
       'await host.capabilities()',
+      'exactly eight boolean keys',
       '`mcp`',
       '`compute`',
       '`agents`',
@@ -35,6 +36,7 @@ describe('self-awareness bundled Skill', () => {
       '`artifacts`',
       '`lineage`',
       '`frames`',
+      '`llm`',
       'caps.compute === true',
       'caps.artifacts === true',
       'caps.frames === true',
@@ -51,6 +53,8 @@ describe('self-awareness bundled Skill', () => {
       'never content',
       'fresh frozen projection',
       'caps.lineage === true',
+      'caps.llm === true',
+      'await host.llm',
       'await host.lineage.graph(versionId)',
       'await host.lineage.get(versionId)',
       'graph discovery',


### PR DESCRIPTION
## Problem

Notebook JavaScript REPL code cannot make a small, provider-neutral LLM call without exposing the full agent runtime, provider-specific controls, or tool authority.

## Proposed change

- Add JS REPL-only `host.llm` single and bounded batch calls with exact input/output validation and deeply frozen results.
- Add the `llmCall` control RPC, `llm` capability projection, and primary `host-llm` capability.
- Reuse a restricted inference runner across Host LLM and Artifact reconstruction while preserving Artifact's unbounded output and public error behavior.
- Enforce tool-less execution, sanitized Host LLM errors, target capture once per public call, cancellation propagation, shutdown draining, and lease/runtime/profile cleanup.

## Scope and non-goals

- Single input is a string or exact `{ prompt }`; batch is a non-empty array of the same.
- Limits: 32 items, 512 KiB serialized batch, 64 KiB UTF-8 prompt, concurrency default 2/max 4, and 256 KiB Host LLM output.
- No user model/system/messages/images/tools/tool choice/temperature/token controls.
- Native Codex subscription authentication fails closed because tool-less execution cannot be enforced.
- No database, schema, persistence, UI, Settings, renderer, preload, or Web changes.
- Host Frames PR #1090 remains open; this PR does not copy or remove Frames changes.

## Acceptance criteria and validation

- [x] Single failures throw; batch item failures preserve order and become `{ error: string }`.
- [x] Active backend target is captured once per call, including batches.
- [x] Tool and permission attempts fail closed across Claude Code, OpenCode, and Codex-compatible routes.
- [x] Caller abort/RPC disconnect/shutdown cancellation prevents late inference starts and drains active work.
- [x] Artifact reconstruction retains no output cap and compatible public errors.
- [x] Independent standards and spec reviews completed; the one accessor-snapshot finding was fixed and re-reviewed with no remaining findings.

Validation evidence:

- `npm test` — 931 files passed, 15 skipped; 13,405 tests passed, 193 skipped.
- `npm run typecheck:node` — passed.
- `npm run typecheck:web` — passed.
- `npm run lint` — passed with 0 errors (17 existing repository warnings outside this change).
- Focused Host LLM/runner/RPC/REPL/capability suite — 7 files passed; 74 passed, 30 skipped.
- Focused Codex bridge/native compatibility/forced routing checks — 3 passed.

Live provider sessions and Windows named-pipe/process cleanup remain CI/provider validation risks; deterministic transport and lifecycle contracts cover them locally.

## Review focus

- Exact JS boundary validation/freezing and batch isolation.
- Tool-less and permission fail-closed enforcement across backend routes.
- Cancellation timing, shutdown drain, and lease/runtime/temp cleanup.
- Artifact reconstruction compatibility after extracting the shared restricted runner.
