### PR TITLE
fix(ci-policy): isolate summary output test

### DIFF
--- a/scripts/ci/check-pr-policy.test.ts
+++ b/scripts/ci/check-pr-policy.test.ts
@@ -410,6 +410,7 @@ const MIGRATION_MANIFEST = [
           ...process.env,
           BASE_SHA: target,
           EVENT_NAME: 'pull_request',
+          GITHUB_STEP_SUMMARY: '',
           HEAD_SHA: head,
           POLICY_SCOPE: 'commits'
         }


### PR DESCRIPTION
## Problem

GitHub Actions sets `GITHUB_STEP_SUMMARY`. The target-base migration test spreads `process.env` into its spawned PR-policy CLI, then asserts the CLI's stdout. In Actions, the inherited variable makes the CLI write its report to the step-summary file instead, so stdout is empty and the assertion fails.

Before the fix, this reproduces the CI failure deterministically:

```sh
env GITHUB_STEP_SUMMARY=/private/tmp/open-science-pr-policy-summary.md npx vitest run scripts/ci/check-pr-policy.test.ts -t "uses the current target base when choosing the next migration version"
```

The failure is `expected '' to contain 'next migration version 0003'`.

## Proposed change

Set `GITHUB_STEP_SUMMARY` to an empty string only in the stdout-oriented spawned fixture. This makes the test hermetic while preserving the PR-policy CLI's production behavior.

## Scope and non-goals

- Changes only `scripts/ci/check-pr-policy.test.ts`.
- No production behavior or CI workflow changes.
- No architecture, database schema, migration, data model, relation, UI, Host Frames, or PR #1090 commit impact.

## Acceptance criteria and validation

All final checks below ran after the last material edit.

| Behavior | Command | Result |
| --- | --- | --- |
| Actions environment no longer redirects this fixture's asserted output | `env GITHUB_STEP_SUMMARY=/private/tmp/open-science-pr-policy-summary.md npx vitest run scripts/ci/check-pr-policy.test.ts -t "uses the current target base when choosing the next migration version"` | Passed, 1/1 |
| Complete PR-policy behavior remains covered | `npm test -- scripts/ci/check-pr-policy.test.ts` | Passed, 16/16 |
| Node and web TypeScript contracts | `npm run typecheck` | Passed |
| Repository lint | `npm run lint` | Passed with 0 errors; existing warnings are outside the changed file |
| Complete portable Vitest suite | `npm test` | Passed: 935 files, 13,508 tests; 15 files and 193 tests skipped by suite configuration |
| Patch whitespace | `git diff --check` | Passed |

Required exact-head CI remains the final authority. No test-specific platform or consumer risk remains beyond those repository-wide lanes.

## Review focus

Confirm the stdout-oriented fixture clears only the inherited step-summary destination and remains consistent with the existing title-only CLI fixture.
