### PR TITLE
fix(connectors): preserve connector-managed login recovery

### DIFF
--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -7,7 +7,9 @@ export type CustomMcpFailureAvailability = 'unavailable' | 'unauthenticated'
 
 export const classifyCustomMcpFailure = (error: unknown): CustomMcpFailureAvailability =>
   error instanceof Error &&
-  /(?:401|403|unauthoriz|authenticat|forbidden|invalid_token)/i.test(error.message)
+  /(?:401|403|unauthoriz|authenticat|forbidden|invalid_token|(?:log(?:ged)?|sign(?:ed)?)[\s_-]?in)/i.test(
+    error.message
+  )
     ? 'unauthenticated'
     : 'unavailable'
 

--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -93,6 +93,18 @@ describe('syncCustomServerSkillDocs', () => {
     expect(entries).toEqual([])
   })
 
+  it('refreshes one server without validating or deleting unrelated server Skills', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'custom-skills-targeted-'))
+    const target = makeServer({ id: 'target', slug: 'target', name: 'Target' })
+    const unrelated = makeServer({ id: 'unrelated', slug: 'unrelated', name: 'Unrelated' })
+    const listTools = async (): Promise<typeof FAKE_TOOLS> => FAKE_TOOLS
+
+    await syncCustomServerSkillDocs(dir, [target, unrelated], listTools)
+    await syncCustomServerSkillDocs(dir, [target], listTools, ['target'])
+
+    expect((await readdir(dir)).sort()).toEqual(['mcp-target', 'mcp-unrelated'])
+  })
+
   it('isolates an unavailable server while materializing the remaining enabled servers', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'custom-skills-unavailable-'))
     const unavailable = makeServer({ id: 'unavailable', slug: 'unavailable' })

--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -7,7 +7,7 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { z } from 'zod'
-import { McpClientManager, buildTransport } from './mcp-client-manager'
+import { McpClientManager, McpToolCallError, buildTransport } from './mcp-client-manager'
 import type { CustomMcpServerConfig } from './mcp-client-manager'
 import { OAuthCallbackServer, type PersistentOAuthClientProvider } from './oauth-client'
 
@@ -71,8 +71,12 @@ describe('McpClientManager', () => {
   it('throws when the tool result has isError set', async () => {
     const { createClient } = makeTestServer()
     const manager = new McpClientManager({ createClient: () => createClient() })
+    const failure = manager.call(config, 'boom', {})
 
-    await expect(manager.call(config, 'boom', {})).rejects.toThrow(/kaboom/)
+    await expect(failure).rejects.toEqual(
+      expect.objectContaining({ name: 'McpToolCallError', message: 'kaboom' })
+    )
+    await expect(failure).rejects.toBeInstanceOf(McpToolCallError)
   })
 
   it('dedupes concurrent connects for the same server id', async () => {

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -35,6 +35,15 @@ export type McpClientManagerTool = {
   inputSchema?: unknown
 }
 
+// Marks an MCP server's structured tool-level failure separately from connection/transport errors.
+// Callers can report a safe category without treating a reachable server as physically unavailable.
+export class McpToolCallError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'McpToolCallError'
+  }
+}
+
 type McpClientManagerDeps = {
   createClient?: (
     config: CustomMcpServerConfig,
@@ -315,7 +324,7 @@ function unwrapToolResult(result: unknown): unknown {
       : undefined
 
   if (isError) {
-    throw new Error(typeof text === 'string' ? text : 'MCP tool call failed')
+    throw new McpToolCallError(typeof text === 'string' ? text : 'MCP tool call failed')
   }
   if (typeof text === 'string') {
     try {

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -100,7 +100,8 @@ const isSafeCustomServerSlug = (slug: string): boolean =>
 export async function syncCustomServerSkillDocs(
   skillsDir: string,
   servers: StoredCustomMcpServer[],
-  listTools: CustomServerListTools
+  listTools: CustomServerListTools,
+  cleanupSlugs?: readonly string[]
 ): Promise<CustomServerSkillSyncResult> {
   await mkdir(skillsDir, { recursive: true })
   const safeServers = servers
@@ -136,6 +137,7 @@ export async function syncCustomServerSkillDocs(
     materializedSlugs.push(slug)
   }
   const enabledSlugs = new Set(materializedSlugs)
+  const cleanupScope = cleanupSlugs ? new Set(cleanupSlugs) : undefined
   const existing = await readdir(skillsDir).catch(() => [] as string[])
   for (const entry of existing) {
     const slug = customConnectorSlugFromSkillName(entry)
@@ -143,6 +145,7 @@ export async function syncCustomServerSkillDocs(
     // here, even a case-variant like mcp-Chemistry that the built-in sync has written its doc into.
     // Invalid/non-canonical names are also unowned and must be preserved.
     if (!slug || namesBundledConnector(slug)) continue
+    if (cleanupScope && !cleanupScope.has(slug)) continue
     if (!enabledSlugs.has(slug)) {
       await rm(join(skillsDir, entry), { recursive: true, force: true })
     }

--- a/src/main/connectors/runtime-settings-projection.test.ts
+++ b/src/main/connectors/runtime-settings-projection.test.ts
@@ -62,6 +62,63 @@ describe('ConnectorRuntimeSettingsProjection', () => {
     expect(projection.materializedCustomSkillNames()).toEqual(['mcp-enabled'])
   })
 
+  it('refreshes and reports checking for only the requested custom server', async () => {
+    const target = {
+      id: 'target-id',
+      slug: 'target',
+      name: 'Target',
+      transport: 'stdio' as const,
+      command: 'mcp',
+      enabled: true
+    }
+    const unrelated = {
+      id: 'unrelated-id',
+      slug: 'unrelated',
+      name: 'Unrelated',
+      transport: 'stdio' as const,
+      command: 'mcp',
+      enabled: true
+    }
+    let finishTargetedSync: (() => void) | undefined
+    const targetedSync = new Promise<{ materializedSlugs: string[]; failures: [] }>((resolve) => {
+      finishTargetedSync = () => resolve({ materializedSlugs: ['target'], failures: [] })
+    })
+    const syncCustomSkillDocs = vi
+      .fn()
+      .mockResolvedValueOnce({ materializedSlugs: ['target', 'unrelated'], failures: [] })
+      .mockReturnValueOnce(targetedSync)
+    const projection = new ConnectorRuntimeSettingsProjection({
+      readConnectors: vi.fn().mockResolvedValue(
+        connectors({
+          customMcpServers: [target, unrelated]
+        })
+      ),
+      skillsDir: '/config/skills',
+      mcpClientManager: { listTools: vi.fn().mockResolvedValue([]) },
+      syncBundledSkillDocs: vi.fn().mockResolvedValue(undefined),
+      syncCustomSkillDocs
+    })
+
+    await projection.refresh()
+    const refresh = projection.refreshCustomServer(target.id)
+
+    expect(projection.isRefreshing(target.id)).toBe(true)
+    expect(projection.isRefreshing(unrelated.id)).toBe(false)
+    await vi.waitFor(() =>
+      expect(syncCustomSkillDocs).toHaveBeenLastCalledWith(
+        '/config/skills',
+        [target],
+        expect.any(Function),
+        ['target']
+      )
+    )
+
+    finishTargetedSync?.()
+    await refresh
+
+    expect(projection.materializedCustomSkillNames()).toEqual(['mcp-target', 'mcp-unrelated'])
+  })
+
   it('advertises only custom Skills that materialized when one enabled server is unavailable', async () => {
     const unavailable = {
       id: 'unavailable-id',

--- a/src/main/connectors/runtime-settings-projection.ts
+++ b/src/main/connectors/runtime-settings-projection.ts
@@ -8,7 +8,7 @@ import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './provision'
 import { ALL_CONNECTOR_IDS } from './registry'
 import { customConnectorSkillName, customConnectorSlug } from '../../shared/custom-connector'
 import type { McpClientManager } from './mcp-client-manager'
-import type { StoredConnectors } from '../settings/types'
+import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
 
 type ConnectorRuntimeSettingsProjectionOptions = {
   readConnectors: () => Promise<StoredConnectors | undefined>
@@ -29,6 +29,7 @@ class ConnectorRuntimeSettingsProjection {
   private discoveryAvailabilities = new Map<string, CustomMcpFailureAvailability>()
   private dispatchAvailabilities = new Map<string, CustomMcpFailureAvailability>()
   private pendingRefreshes = 0
+  private pendingCustomServerRefreshes = new Map<string, number>()
   private refreshQueue: Promise<void> = Promise.resolve()
   private readonly syncBundledSkillDocs: typeof syncConnectorSkillDocs
   private readonly syncCustomSkillDocs: typeof syncCustomServerSkillDocs
@@ -56,8 +57,11 @@ class ConnectorRuntimeSettingsProjection {
     return this.dispatchAvailabilities.get(id) ?? this.discoveryAvailabilities.get(id)
   }
 
-  isRefreshing(): boolean {
-    return this.pendingRefreshes > 0
+  isRefreshing(serverId?: string): boolean {
+    if (this.pendingRefreshes > 0) return true
+    return serverId
+      ? (this.pendingCustomServerRefreshes.get(serverId) ?? 0) > 0
+      : this.pendingCustomServerRefreshes.size > 0
   }
 
   setCustomServerDispatchAvailability(
@@ -72,22 +76,50 @@ class ConnectorRuntimeSettingsProjection {
   }
 
   async refresh(): Promise<void> {
-    if (this.pendingRefreshes++ === 0) this.options.notifyStatusChanged?.()
+    return this.enqueueRefresh()
+  }
+
+  async refreshCustomServer(serverId: string): Promise<void> {
+    return this.enqueueRefresh(serverId)
+  }
+
+  private enqueueRefresh(serverId?: string): Promise<void> {
+    if (serverId) {
+      const pending = this.pendingCustomServerRefreshes.get(serverId) ?? 0
+      this.pendingCustomServerRefreshes.set(serverId, pending + 1)
+      if (pending === 0 && this.pendingRefreshes === 0) this.options.notifyStatusChanged?.()
+    } else if (this.pendingRefreshes++ === 0) {
+      this.options.notifyStatusChanged?.()
+    }
+
     const queued = this.refreshQueue
-      .then(() => this.refreshOnce())
+      .then(() => this.refreshOnce(serverId))
       .finally(() => {
-        this.pendingRefreshes--
-        if (this.pendingRefreshes === 0) this.options.notifyStatusChanged?.()
+        if (serverId) {
+          const remaining = (this.pendingCustomServerRefreshes.get(serverId) ?? 1) - 1
+          if (remaining > 0) this.pendingCustomServerRefreshes.set(serverId, remaining)
+          else {
+            this.pendingCustomServerRefreshes.delete(serverId)
+            if (this.pendingRefreshes === 0) this.options.notifyStatusChanged?.()
+          }
+        } else if (--this.pendingRefreshes === 0) {
+          this.options.notifyStatusChanged?.()
+        }
       })
     this.refreshQueue = queued
     return queued
   }
 
-  private async refreshOnce(): Promise<void> {
-    this.materializedCustomSkills = []
+  private async refreshOnce(serverId?: string): Promise<void> {
+    if (!serverId) this.materializedCustomSkills = []
     try {
       const connectors = await this.options.readConnectors()
       this.snapshot = connectors
+
+      if (serverId) {
+        await this.refreshCustomServerOnce(connectors, serverId)
+        return
+      }
 
       const disabled = new Set(connectors?.disabledConnectorIds ?? [])
       const enabledIds = ALL_CONNECTOR_IDS.filter((id) => !disabled.has(id))
@@ -103,18 +135,52 @@ class ConnectorRuntimeSettingsProjection {
       this.discoveryAvailabilities = new Map(
         customSync.failures.map(({ server, error }) => [server.id, classifyCustomMcpFailure(error)])
       )
-      for (const { server, error } of customSync.failures) {
-        this.reportError(
-          new Error(
-            `Failed to sync custom MCP server "${customConnectorSlug(server)}" skill docs`,
-            {
-              cause: error
-            }
-          )
-        )
-      }
+      this.reportCustomSyncFailures(customSync.failures)
     } catch (error) {
       this.reportError(error)
+    }
+  }
+
+  private async refreshCustomServerOnce(
+    connectors: StoredConnectors | undefined,
+    serverId: string
+  ): Promise<void> {
+    const server = connectors?.customMcpServers?.find((candidate) => candidate.id === serverId)
+    if (!server) return
+
+    const slug = customConnectorSlug(server)
+    const enabledServer = selectEnabledCustomServers(connectors).find(
+      (candidate) => candidate.id === serverId
+    )
+    const customSync = await this.syncCustomSkillDocs(
+      this.options.skillsDir,
+      enabledServer ? [enabledServer] : [],
+      (candidate) => this.options.mcpClientManager.listTools(toCustomMcpConfig(candidate)),
+      [slug]
+    )
+    const skillName = customConnectorSkillName(slug)
+    const materialized = new Set(this.materializedCustomSkills)
+    if (customSync.materializedSlugs.includes(slug)) materialized.add(skillName)
+    else materialized.delete(skillName)
+    this.materializedCustomSkills = [...materialized]
+
+    this.discoveryAvailabilities.delete(serverId)
+    const failure = customSync.failures.find(({ server: failed }) => failed.id === serverId)
+    if (failure) {
+      this.discoveryAvailabilities.set(serverId, classifyCustomMcpFailure(failure.error))
+    }
+    this.reportCustomSyncFailures(customSync.failures)
+  }
+
+  private reportCustomSyncFailures(
+    failures: Array<{ server: StoredCustomMcpServer; error: unknown }>
+  ): void {
+    for (const { server, error } of failures) {
+      this.reportError(
+        new Error(`Failed to sync custom MCP server "${customConnectorSlug(server)}" skill docs`, {
+          cause: error
+        })
+      )
     }
   }
 }

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ConnectorService } from './service'
 import { ParserEngine } from './engine'
+import { McpToolCallError } from './mcp-client-manager'
 import type { SpecialistProfileView } from '../../shared/specialist'
 import type { CustomMcpServerConfig } from './mcp-client-manager'
 
@@ -995,6 +996,38 @@ describe('ConnectorService', () => {
       )
       expect(mcpClientManager.listTools).not.toHaveBeenCalled()
       expect(call).not.toHaveBeenCalled()
+    })
+
+    it('keeps a connector-managed authentication tool reachable after a sign-in error', async () => {
+      const call = vi
+        .fn()
+        .mockRejectedValueOnce(new McpToolCallError('Not logged in. Call login first.'))
+        .mockResolvedValueOnce({ authenticated: true })
+      const svc = new ConnectorService({
+        mcpClientManager: manager(call, ['status', 'login']),
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'content-service-id',
+              name: 'content-service',
+              transport: 'stdio',
+              command: 'content-service-mcp',
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined
+      })
+
+      await expect(svc.call('content-service', 'status', {}, internal)).rejects.toThrow(
+        'connector_unauthenticated'
+      )
+      await expect(svc.call('content-service', 'login', {}, internal)).resolves.toEqual({
+        authenticated: true
+      })
+      expect(call).toHaveBeenCalledTimes(2)
     })
 
     it('recovers from a cached authentication failure after successful sign-in', async () => {

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -998,6 +998,40 @@ describe('ConnectorService', () => {
       expect(call).not.toHaveBeenCalled()
     })
 
+    it('records structured authentication failures for a host-managed OAuth connector', async () => {
+      const call = vi.fn().mockRejectedValue(new McpToolCallError('Not logged in. Sign in again.'))
+      const onCustomServerAvailabilityChanged = vi.fn()
+      const svc = new ConnectorService({
+        mcpClientManager: manager(call, ['lookup']),
+        getConnectors: () => ({
+          enabledIds: [],
+          autoAllowIds: [],
+          customMcpServers: [
+            {
+              id: 'oauth-1',
+              name: 'oauth-server',
+              transport: 'streamable_http',
+              url: 'https://mcp.example.test',
+              oauth: {},
+              oauthState: { tokens: { access_token: 'stale', token_type: 'Bearer' } },
+              enabled: true
+            }
+          ]
+        }),
+        resolveApiKey: () => undefined,
+        onCustomServerAvailabilityChanged
+      })
+
+      await expect(svc.call('oauth-server', 'lookup', {}, internal)).rejects.toThrow(
+        'connector_unauthenticated'
+      )
+      await expect(svc.call('oauth-server', 'lookup', {}, internal)).rejects.toThrow(
+        'connector_unauthenticated'
+      )
+      expect(call).toHaveBeenCalledOnce()
+      expect(onCustomServerAvailabilityChanged).toHaveBeenCalledWith('oauth-1', 'unauthenticated')
+    })
+
     it('keeps a connector-managed authentication tool reachable after a sign-in error', async () => {
       const call = vi
         .fn()

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -374,9 +374,12 @@ export class ConnectorService {
       return result
     } catch (error) {
       const availability = classifyCustomMcpFailure(error)
-      // A structured tool error proves the MCP server is reachable. Do not poison the whole
-      // connector: it may expose its own login/authentication tool for recovering this session.
-      if (!(error instanceof McpToolCallError)) {
+      // A structured tool error proves the MCP server is reachable. Keep connector-managed login
+      // tools callable, but publish stale host-managed OAuth so Settings can offer sign-in recovery.
+      if (
+        !(error instanceof McpToolCallError) ||
+        (custom.oauth && availability === 'unauthenticated')
+      ) {
         this.recordCustomServerFailure(custom.id, failureEpoch, availability)
       }
       throw new ConnectorGateError(customMcpFailureCategory(availability))

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -8,7 +8,7 @@ import {
   toCustomMcpConfig,
   type CustomMcpFailureAvailability
 } from './custom-mcp-bootstrap'
-import type { CustomMcpServerConfig } from './mcp-client-manager'
+import { McpToolCallError, type CustomMcpServerConfig } from './mcp-client-manager'
 import type { ConnectorCredentials, ToolDescriptor } from './types'
 import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
@@ -374,7 +374,11 @@ export class ConnectorService {
       return result
     } catch (error) {
       const availability = classifyCustomMcpFailure(error)
-      this.recordCustomServerFailure(custom.id, failureEpoch, availability)
+      // A structured tool error proves the MCP server is reachable. Do not poison the whole
+      // connector: it may expose its own login/authentication tool for recovering this session.
+      if (!(error instanceof McpToolCallError)) {
+        this.recordCustomServerFailure(custom.id, failureEpoch, availability)
+      }
       throw new ConnectorGateError(customMcpFailureCategory(availability))
     }
   }

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -163,7 +163,7 @@ describe('renderSkillDoc', () => {
 
   it('directs custom connector authentication failures to a listed login tool', () => {
     const md = renderCustomSkillDoc({ slug: 'content-service', name: 'Content Service' }, [
-      { name: 'login' },
+      { name: 'content_login' },
       { name: 'search' }
     ])
 
@@ -171,7 +171,28 @@ describe('renderSkillDoc', () => {
     expect(md).toContain('use a login or authentication tool listed in this Skill')
     expect(md).toContain('then retry the original call')
     expect(md).toContain('Do not treat an authentication requirement as connector unavailability')
-    expect(md).toContain('if this Skill lists none')
+    expect(md).not.toContain('Settings > Connectors')
+  })
+
+  it('directs host-managed OAuth authentication to Connector settings', () => {
+    const md = renderCustomSkillDoc(
+      { slug: 'content-service', name: 'Content Service', oauth: {} },
+      [{ name: 'content_login' }, { name: 'search' }]
+    )
+
+    expect(md).toContain('`connector_unauthenticated`')
+    expect(md).toContain('Settings > Connectors')
+    expect(md).toContain('then retry the original call')
+    expect(md).not.toContain('use a login or authentication tool listed in this Skill')
+  })
+
+  it('omits authentication recovery guidance when the connector declares neither mode', () => {
+    const md = renderCustomSkillDoc({ slug: 'content-service', name: 'Content Service' }, [
+      { name: 'search' }
+    ])
+
+    expect(md).not.toContain('`connector_unauthenticated`')
+    expect(md).not.toContain('Settings > Connectors')
   })
 
   it('keeps the PubMed Skill under a 2.3k-token on-demand budget', () => {

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -161,6 +161,19 @@ describe('renderSkillDoc', () => {
     expect(md).toContain('approval')
   })
 
+  it('directs custom connector authentication failures to a listed login tool', () => {
+    const md = renderCustomSkillDoc({ slug: 'content-service', name: 'Content Service' }, [
+      { name: 'login' },
+      { name: 'search' }
+    ])
+
+    expect(md).toContain('`connector_unauthenticated`')
+    expect(md).toContain('use a login or authentication tool listed in this Skill')
+    expect(md).toContain('then retry the original call')
+    expect(md).toContain('Do not treat an authentication requirement as connector unavailability')
+    expect(md).toContain('if this Skill lists none')
+  })
+
   it('keeps the PubMed Skill under a 2.3k-token on-demand budget', () => {
     const md = renderSkillDoc('pubmed')
 

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -18,7 +18,8 @@ const SKILL_CONVENTIONS =
 
 const CUSTOM_SKILL_CONVENTIONS =
   `${SKILL_CONVENTIONS} Do not bypass \`host.mcp\` with raw HTTP or calls from Python/R: ` +
-  'the host path enforces approval, tool policy, credentials, and rate limits.'
+  'the host path enforces approval, tool policy, credentials, and rate limits. ' +
+  'If a call reports `connector_unauthenticated` or says sign-in is required, use a login or authentication tool listed in this Skill when one exists, wait for it to complete, then retry the original call. Do not treat an authentication requirement as connector unavailability or invent a login tool; if this Skill lists none, ask the user to sign in from Settings > Connectors.'
 
 // Placeholder value for one JSON-Schema field in a call example: an enum's first choice or the field's
 // own default when present, otherwise a type-keyed stand-in. Rendered as a JSON literal.

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -18,8 +18,7 @@ const SKILL_CONVENTIONS =
 
 const CUSTOM_SKILL_CONVENTIONS =
   `${SKILL_CONVENTIONS} Do not bypass \`host.mcp\` with raw HTTP or calls from Python/R: ` +
-  'the host path enforces approval, tool policy, credentials, and rate limits. ' +
-  'If a call reports `connector_unauthenticated` or says sign-in is required, use a login or authentication tool listed in this Skill when one exists, wait for it to complete, then retry the original call. Do not treat an authentication requirement as connector unavailability or invent a login tool; if this Skill lists none, ask the user to sign in from Settings > Connectors.'
+  'the host path enforces approval, tool policy, credentials, and rate limits.'
 
 // Placeholder value for one JSON-Schema field in a call example: an enum's first choice or the field's
 // own default when present, otherwise a type-keyed stand-in. Rendered as a JSON literal.
@@ -128,7 +127,12 @@ export function renderConnectorInstructions(skillNames: string[]): string {
   )
 }
 
-export type CustomSkillDocServer = { name: string; slug?: string; description?: string }
+export type CustomSkillDocServer = {
+  name: string
+  slug?: string
+  description?: string
+  oauth?: unknown
+}
 export type CustomSkillDocTool = { name: string; description?: string; inputSchema?: unknown }
 
 // Same shape as renderSkillDoc, but for a user-added custom MCP server: schema comes from
@@ -141,6 +145,15 @@ export function renderCustomSkillDoc(
   tools: CustomSkillDocTool[]
 ): string {
   const slug = customConnectorSlug(server)
+  const authenticationConvention = server.oauth
+    ? ' If a call reports `connector_unauthenticated` or says sign-in is required, ask the user to sign in from Settings > Connectors, wait for sign-in to complete, then retry the original call. Do not treat an authentication requirement as connector unavailability or call a connector-managed login tool; this connector uses host-managed OAuth.'
+    : tools.some((tool) =>
+          /(?:^|[_-])(?:log[_-]?in|sign[_-]?in|authenticate|authentication)(?:$|[_-])/i.test(
+            tool.name
+          )
+        )
+      ? ' If a call reports `connector_unauthenticated` or says sign-in is required, use a login or authentication tool listed in this Skill, wait for it to complete, then retry the original call. Do not treat an authentication requirement as connector unavailability; this connector manages its own sign-in.'
+      : ''
   const useWhen =
     server.description ??
     `Use when you need tools from the ${server.name} MCP server — ${tools.map((t) => t.name).join(', ')}.`
@@ -154,6 +167,6 @@ export function renderCustomSkillDoc(
     .join('\n')
   return (
     `${header}\n> This connector is rate-limited at the upstream API.\n\n` +
-    `${CUSTOM_SKILL_CONVENTIONS}\n\n## Tools\n\n${methods}`
+    `${CUSTOM_SKILL_CONVENTIONS}${authenticationConvention}\n\n## Tools\n\n${methods}`
   )
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1001,7 +1001,7 @@ const createApplicationModules = async (
   settingsService.setCustomServerRuntimeProjectionProvider({
     materializedSkillNames: () => connectorRuntimeSettings.materializedCustomSkillNames(),
     availability: (id) => connectorRuntimeSettings.customServerAvailability(id),
-    isRefreshing: () => connectorRuntimeSettings.isRefreshing()
+    isRefreshing: (id) => connectorRuntimeSettings.isRefreshing(id)
   })
   settingsService.setCustomServerAuthenticator(
     async (serverId) => {
@@ -1741,7 +1741,10 @@ const createApplicationModules = async (
     skills: { requestSkillsReload: () => void runtime.requestSkillsReload() },
     connectors: {
       invalidatePermissionProjection: () => permissionGrantProjection.invalidateProjection(),
-      refreshConnectorSkillDocs: () => connectorRuntimeSettings.refresh(),
+      refreshConnectorSkillDocs: (customServerId) =>
+        customServerId
+          ? connectorRuntimeSettings.refreshCustomServer(customServerId)
+          : connectorRuntimeSettings.refresh(),
       requestSkillsReload: () => void runtime.requestSkillsReload(),
       pruneCustomServerPermissions: (serverId) =>
         permissionGrantRegistry.prune({ kind: 'mcp_server', serverId }).then(() => undefined),

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -252,6 +252,31 @@ describe('ConnectorSettingsModule', () => {
     expect(server).toMatchObject({ id, enabled: true, checking: true })
   })
 
+  it('projects checking only for the custom server currently being refreshed', async () => {
+    const first = await service.addCustomServer({
+      name: 'refreshing-server',
+      transport: 'stdio',
+      command: 'example-mcp'
+    })
+    const refreshingId = first.customServers[0].id
+    const second = await service.addCustomServer({
+      name: 'settled-server',
+      transport: 'stdio',
+      command: 'example-mcp'
+    })
+    const settledId = second.customServers.find((server) => server.id !== refreshingId)!.id
+    service.setCustomServerRuntimeProjectionProvider({
+      materializedSkillNames: () => [],
+      availability: () => undefined,
+      isRefreshing: (serverId) => serverId === refreshingId
+    })
+
+    const servers = (await service.listConnectors()).customServers
+
+    expect(servers.find((server) => server.id === refreshingId)).toMatchObject({ checking: true })
+    expect(servers.find((server) => server.id === settledId)?.checking).toBeUndefined()
+  })
+
   it('rejects duplicate and built-in custom connector names', async () => {
     await service.addCustomServer({
       name: 'example-server',

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -43,7 +43,7 @@ type CustomServerSecurityChangeGuard = {
 type CustomServerRuntimeProjectionProvider = {
   materializedSkillNames: () => readonly string[]
   availability: (id: string) => CustomServerView['availability']
-  isRefreshing: () => boolean
+  isRefreshing: (id: string) => boolean
 }
 
 const normalizeOAuthConfig = (
@@ -549,7 +549,7 @@ class ConnectorSettingsModule {
           server.enabled &&
           !configurationAvailability &&
           !runtimeAvailability &&
-          this.customServerRuntimeProjectionProvider.isRefreshing()
+          this.customServerRuntimeProjectionProvider.isRefreshing(server.id)
         )
         return {
           id: server.id,

--- a/src/main/settings/workflows.test.ts
+++ b/src/main/settings/workflows.test.ts
@@ -542,6 +542,19 @@ describe('SettingsWorkflows catalog and appearance effects', () => {
     await vi.waitFor(() => expect(calls).toEqual(['persist', 'invalidate', 'refresh', 'reload']))
   })
 
+  it('refreshes only the custom server whose enabled state changed', async () => {
+    const { capability } = fakeStore()
+    const refreshConnectorSkillDocs = vi.fn(async () => undefined)
+    const effects = testEffects({ refreshConnectorSkillDocs })
+
+    await createSettingsWorkflows(capability, effects).connectors.setCustomServerEnabled({
+      id: 'server-1',
+      enabled: true
+    })
+
+    expect(refreshConnectorSkillDocs).toHaveBeenCalledWith('server-1')
+  })
+
   it('refreshes Connector projections after OAuth authentication', async () => {
     const calls: string[] = []
     const { store, capability } = fakeStore()

--- a/src/main/settings/workflows/connectors.ts
+++ b/src/main/settings/workflows/connectors.ts
@@ -30,7 +30,7 @@ type ConnectorSettingsWorkflowStore = Pick<
 
 type ConnectorSettingsWorkflowEffects = {
   invalidatePermissionProjection: () => void
-  refreshConnectorSkillDocs: () => Promise<unknown>
+  refreshConnectorSkillDocs: (customServerId?: string) => Promise<unknown>
   requestSkillsReload: () => void
   pruneCustomServerPermissions: (serverId: string) => Promise<void>
   beginCustomServerSecurityChange: (serverId: string) => CustomServerSecurityChangeGuard | undefined
@@ -79,7 +79,9 @@ class ConnectorSettingsWorkflows {
   async setCustomServerEnabled(
     request: Parameters<ConnectorSettingsWorkflowStore['setCustomServerEnabled']>[0]
   ): WorkflowResult<'setCustomServerEnabled'> {
-    return this.afterConnectorsChanged(() => this.settings.setCustomServerEnabled(request))
+    const snapshot = await this.settings.setCustomServerEnabled(request)
+    this.connectorsChanged(request.id)
+    return snapshot
   }
 
   async removeCustomServer(
@@ -135,14 +137,14 @@ class ConnectorSettingsWorkflows {
     return result
   }
 
-  private connectorsChanged(): void {
+  private connectorsChanged(customServerId?: string): void {
     this.effects.invalidatePermissionProjection()
-    void this.refreshConnectorProjection()
+    void this.refreshConnectorProjection(customServerId)
   }
 
-  private refreshConnectorProjection(): Promise<unknown> {
+  private refreshConnectorProjection(customServerId?: string): Promise<unknown> {
     return wireConnectorReload(
-      this.effects.refreshConnectorSkillDocs,
+      () => this.effects.refreshConnectorSkillDocs(customServerId),
       this.effects.requestSkillsReload
     )
   }

--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -379,6 +379,13 @@ describe('ConnectorsPanel (groups)', () => {
     expect(connectedToggle?.disabled).toBe(false)
     expect(connectedToggle?.getAttribute('aria-disabled')).toBeNull()
     expect(connectedToggle?.getAttribute('data-state')).toBe('checked')
+
+    const connectedStatus = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button')
+    ).find((button) => button.textContent?.trim() === 'Connected')
+    expect(connectedStatus?.disabled).toBe(true)
+    act(() => connectedStatus?.click())
+    expect(useSettingsStore.getState().authenticateCustomServer).toHaveBeenCalledTimes(1)
   })
 
   it('shows an unavailable custom Connector and retries it in place', async () => {
@@ -484,7 +491,12 @@ describe('ConnectorsPanel (groups)', () => {
     act(() => root.render(<ConnectorsPanel onNavigate={vi.fn()} />))
 
     expect(document.body.textContent).toContain('Sign-in required')
-    await act(async () => clickButtonByText('Sign in'))
+    const expiredToggle = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Expired OAuth"]'
+    )
+    expect(expiredToggle?.getAttribute('data-state')).toBe('checked')
+    expect(expiredToggle?.getAttribute('aria-disabled')).toBeNull()
+    await act(async () => clickButtonByText('Retry'))
     expect(useSettingsStore.getState().authenticateCustomServer).toHaveBeenCalledWith({
       id: 'expired-oauth'
     })
@@ -512,12 +524,12 @@ describe('ConnectorsPanel (groups)', () => {
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'edit', id: 'anonymous-remote' })
   })
 
-  it('cancels a waiting OAuth sign-in and allows retry', async () => {
-    const rejectAuthentications: Array<(error: Error) => void> = []
+  it('keeps a waiting OAuth sign-in disabled until it settles', async () => {
+    let finishAuthentication!: () => void
     const authenticateCustomServer = vi.fn(
       () =>
-        new Promise<void>((_resolve, reject) => {
-          rejectAuthentications.push(reject)
+        new Promise<void>((resolve) => {
+          finishAuthentication = resolve
         })
     )
     useSettingsStore.setState({
@@ -540,35 +552,28 @@ describe('ConnectorsPanel (groups)', () => {
     })
 
     clickButtonByText('Sign in')
-    expect(document.body.textContent).toContain('Cancel')
+    const connecting = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Connecting…'
+    )
+    expect(connecting?.disabled).toBe(true)
+    expect(document.body.textContent).not.toContain('Cancel')
+    act(() => connecting?.click())
+    expect(authenticateCustomServer).toHaveBeenCalledOnce()
+    expect(useSettingsStore.getState().cancelCustomServerAuthentication).not.toHaveBeenCalled()
 
-    await act(async () => clickButtonByText('Cancel'))
-
-    expect(useSettingsStore.getState().cancelCustomServerAuthentication).toHaveBeenCalledWith({
-      id: 'oauth-mcp'
-    })
-    expect(document.body.textContent).toContain('Sign in')
-
-    clickButtonByText('Sign in')
-    expect(authenticateCustomServer).toHaveBeenCalledTimes(2)
-
-    await act(async () => rejectAuthentications[0](new Error('Authorization denied')))
-    expect(document.body.textContent).not.toContain('Authorization denied')
-    expect(useSettingsStore.getState().loadConnectors).toHaveBeenCalledTimes(2)
+    await act(async () => finishAuthentication())
   })
 
-  it('keeps independent cancel controls for concurrent OAuth sign-ins', async () => {
-    const rejectAuthentications = new Map<string, (error: Error) => void>()
+  it('keeps concurrent OAuth sign-ins independently disabled', async () => {
+    const finishAuthentications = new Map<string, () => void>()
     const authenticateCustomServer = vi.fn(
       ({ id }: { id: string }) =>
-        new Promise<void>((_resolve, reject) => {
-          rejectAuthentications.set(id, reject)
+        new Promise<void>((resolve) => {
+          finishAuthentications.set(id, resolve)
         })
     )
-    const cancelCustomServerAuthentication = vi.fn().mockResolvedValue(undefined)
     useSettingsStore.setState({
       authenticateCustomServer,
-      cancelCustomServerAuthentication,
       customServers: [
         {
           id: 'oauth-a',
@@ -604,17 +609,14 @@ describe('ConnectorsPanel (groups)', () => {
 
     act(() => clickRowAction('OAuth A', 'Sign in'))
     act(() => clickRowAction('OAuth B', 'Sign in'))
-    expect(row('OAuth A')?.textContent).toContain('Cancel')
-    expect(row('OAuth B')?.textContent).toContain('Cancel')
+    expect(row('OAuth A')?.textContent).toContain('Connecting…')
+    expect(row('OAuth B')?.textContent).toContain('Connecting…')
 
-    await act(async () => clickRowAction('OAuth A', 'Cancel'))
-    expect(cancelCustomServerAuthentication).toHaveBeenCalledWith({ id: 'oauth-a' })
+    await act(async () => finishAuthentications.get('oauth-a')?.())
     expect(row('OAuth A')?.textContent).toContain('Sign in')
-    expect(row('OAuth B')?.textContent).toContain('Cancel')
+    expect(row('OAuth B')?.textContent).toContain('Connecting…')
 
-    await act(async () => rejectAuthentications.get('oauth-a')?.(new Error('cancelled')))
-    await act(async () => clickRowAction('OAuth B', 'Cancel'))
-    await act(async () => rejectAuthentications.get('oauth-b')?.(new Error('cancelled')))
+    await act(async () => finishAuthentications.get('oauth-b')?.())
   })
 
   it('uses the Settings danger banner for OAuth errors', async () => {

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -10,7 +10,7 @@ import {
   Trash2
 } from 'lucide-react'
 import { AlertDialog } from 'radix-ui'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import type { SpecialistListItem } from '../../../../shared/specialist'
 import type {
@@ -104,9 +104,6 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
   const retryCustomServer = useSettingsStore((state) => state.retryCustomServer)
   const removeCustomServer = useSettingsStore((state) => state.removeCustomServer)
   const authenticateCustomServer = useSettingsStore((state) => state.authenticateCustomServer)
-  const cancelCustomServerAuthentication = useSettingsStore(
-    (state) => state.cancelCustomServerAuthentication
-  )
   const setNcbiCredentials = useSettingsStore((state) => state.setNcbiCredentials)
 
   const [filter, setFilter] = useState<GroupFilter>('all')
@@ -126,7 +123,6 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
   } | null>(null)
   const [removing, setRemoving] = useState(false)
   const [removalError, setRemovalError] = useState<string | null>(null)
-  const authenticationAttempts = useRef(new Map<string, number>())
 
   useEffect(() => {
     void loadConnectors()
@@ -172,35 +168,13 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
   }
 
   const signIn = async (id: string): Promise<void> => {
-    const attempt = (authenticationAttempts.current.get(id) ?? 0) + 1
-    authenticationAttempts.current.set(id, attempt)
     setAuthenticatingIds((current) => new Set(current).add(id))
     setAuthError(null)
     try {
       await authenticateCustomServer({ id })
     } catch (error) {
       await loadConnectors().catch(() => undefined)
-      if (attempt === authenticationAttempts.current.get(id)) {
-        setAuthError(error instanceof Error ? error.message : 'OAuth sign-in failed.')
-      }
-    } finally {
-      if (attempt === authenticationAttempts.current.get(id)) {
-        setAuthenticatingIds((current) => {
-          const next = new Set(current)
-          next.delete(id)
-          return next
-        })
-      }
-    }
-  }
-
-  const cancelSignIn = async (id: string): Promise<void> => {
-    authenticationAttempts.current.set(id, (authenticationAttempts.current.get(id) ?? 0) + 1)
-    setAuthError(null)
-    try {
-      await cancelCustomServerAuthentication({ id })
-    } catch (error) {
-      setAuthError(error instanceof Error ? error.message : 'Could not cancel OAuth sign-in.')
+      setAuthError(error instanceof Error ? error.message : 'OAuth sign-in failed.')
     } finally {
       setAuthenticatingIds((current) => {
         const next = new Set(current)
@@ -592,17 +566,19 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
                               ? 'outline'
                               : 'default'
                           }
-                          onClick={() =>
-                            void (authenticatingIds.has(server.id)
-                              ? cancelSignIn(server.id)
-                              : signIn(server.id))
+                          disabled={
+                            authenticatingIds.has(server.id) ||
+                            (server.oauth.hasTokens && server.availability !== 'unauthenticated')
                           }
+                          onClick={() => void signIn(server.id)}
                         >
                           {authenticatingIds.has(server.id)
-                            ? 'Cancel'
+                            ? 'Connecting…'
                             : server.oauth.hasTokens && server.availability !== 'unauthenticated'
                               ? 'Connected'
-                              : 'Sign in'}
+                              : server.availability === 'unauthenticated'
+                                ? 'Retry'
+                                : 'Sign in'}
                         </Button>
                       ) : null}
                       <SettingsToggle


### PR DESCRIPTION
## Problem

Custom MCP failures currently collapse two different authentication models into connector availability:

- Standard MCP OAuth is host-managed: missing tokens must stay fail-closed and direct the user to Settings > Connectors.
- Connector-managed sign-in is tool-managed: a server can return a structured `isError` such as "Not logged in. Call login first." and expose its own `login` or authentication tool.

The second case was classified as `connector_unavailable`, and the tool error was cached as a physical server failure. That cache then blocked the connector's own login tool, so Codex and the other ACP consumers could not recover even though the server was reachable.

## Proposed change

- Preserve structured MCP tool failures as a typed `McpToolCallError`.
- Classify common login/sign-in wording as `connector_unauthenticated`.
- Cache connection, discovery, and transport failures, but do not poison the whole connector after a structured tool-level error.
- Scope generated authentication guidance to the configured mode: host-managed OAuth points to Settings > Connectors, connector-managed sign-in uses an actually listed login/authentication tool, and connectors declaring neither mode receive no authentication paragraph.

## Scope and non-goals

- Standard host-managed OAuth behavior is unchanged: missing credentials still prevent contacting the server, and successful host sign-in clears cached authentication failures.
- Transport and tool-discovery failures remain fail-closed and cached.
- The implementation and tests are connector-generic; there are no connector-specific names, rules, or adapters.
- Claude Code, OpenCode, Codex Responses, and Codex Bridge continue consuming the same materialized custom-connector Skill rather than receiving framework-specific branches.

## Acceptance criteria and validation

Final checks ran after the last material edit.

- Connector-managed login remains callable after a structured sign-in error -> `src/main/connectors/service.test.ts` in `npm test` -> passed.
- Structured MCP `isError` results retain their origin -> `src/main/connectors/mcp-client-manager.test.ts` in `npm test` -> passed.
- Custom Skills keep host-managed OAuth, listed login tools, and connectors without authentication guidance separate -> `src/main/connectors/skill-doc.test.ts` in `npm test` -> passed.
- Standard OAuth remains host-managed, publishes stale-token failures to Settings, and recovers after successful sign-in -> OAuth callback and connector-service tests in `npm test` -> passed.
- `npm run typecheck` -> passed for node and web.
- `npm run lint` -> passed with 17 pre-existing warnings and no warnings in modified files.
- `npm test` -> passed: 935 files passed, 15 skipped; 13,513 tests passed, 193 skipped.

The portable local suite covers the shared ACP-facing connector path. No OS-specific code changed, so Windows/Linux package lanes are left to PR Gate. The Notion plugin was suggested for live standard-OAuth validation but was not exposed in this session, so live Notion authorization remains uncovered. Independent review and exact-head CI are still pending.

## Review focus

- Whether the typed boundary correctly distinguishes a reachable server's tool failure from connection/transport failure.
- Whether authentication failures remain safely categorized without weakening standard OAuth's fail-closed behavior.
- Whether the generated Skill guidance is specific enough to recover through listed tools without inventing connector capabilities.
