### PR TITLE
fix(ci): restore PR gate baseline

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -67,7 +67,7 @@ const createStorageRoot = async (): Promise<string> => {
 afterEach(async () => {
   vi.unstubAllEnvs()
   if (storageRoot) {
-    await rm(storageRoot, { recursive: true, force: true })
+    await rm(storageRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
     storageRoot = undefined
   }
 })

--- a/src/renderer/src/pages/workspace/project-files-presentation-owner.tsx
+++ b/src/renderer/src/pages/workspace/project-files-presentation-owner.tsx
@@ -410,10 +410,6 @@ const FilterMenuItem = ({
   </DropdownMenuItem>
 )
 
-// One granted local folder in the "This computer" section: two-line row (name + truncated path)
-// with an ro/rw badge. Clicking the row browses the folder; the trailing "…" opens a submenu with
-// the access-level toggle and removal. The "…" stops propagation so it never selects the row.
-// A selected row shows the same trailing Check as the machine row.
 const GrantedRootMenuRow = ({
   root,
   isSelected,

--- a/src/renderer/src/stores/settings-preferences-slice.test.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.test.ts
@@ -81,7 +81,10 @@ const deferred = <T>(): {
 // Preference writes accumulate like the real settings.json: a later command's snapshot still
 // carries earlier writes, so reconcile never clobbers a sibling preference back to its default.
 const createCommands = (persisted: Partial<SettingsSnapshot>): CommandMocks => {
-  const save = <K extends keyof SettingsSnapshot>(key: K, value: SettingsSnapshot[K]) =>
+  const save = <K extends keyof SettingsSnapshot>(
+    key: K,
+    value: SettingsSnapshot[K]
+  ): Promise<SettingsSnapshot> =>
     Promise.resolve(snapshot({ ...persisted, [key]: (persisted[key] = value) }))
 
   return {


### PR DESCRIPTION
## Problem

The current default branch has three PR Gate regressions: a missing explicit test-helper return type, a project-files owner that exceeds its enforced 750-line boundary because of stale commentary, and transient Windows EBUSY failures while deleting runtime-service test fixtures after a timed-out shell command.

## Proposed change

- Declare the settings preference helper return type.
- Remove four stale comment lines that describe an obsolete ellipsis-button interaction, restoring the project-files owner boundary without changing behavior.
- Use Node native recursive-rm retries for transient Windows fixture locks.

## Scope and non-goals

No runtime architecture, data model, or user interaction changes. The Windows change is limited to test teardown.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Lint regression -> `npx eslint src/renderer/src/stores/settings-preferences-slice.test.ts` -> passed.
- Project-files module boundary -> `npm test -- src/renderer/src/pages/workspace/workspace-components.test.tsx` -> 28 passed.
- Notebook runtime test coverage -> `npm test -- src/main/notebook/runtime-service.test.ts` -> 184 passed.
- Formatting -> targeted Prettier check -> passed.
- Node and Web contracts -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors and 15 pre-existing warnings.
- Portable suite -> `npm test` -> 945 files passed, 15 skipped; 13,656 tests passed, 193 skipped.

The Windows-hosted PR Gate lane remains authoritative for the platform-specific EBUSY regression.

## Review focus

Please verify that the bounded `rm` retry is appropriate for transient Windows watcher/process handle release and does not hide a persistent cleanup leak.