### PR TITLE
fix(session-resume): recover unavailable persisted Codex sessions

### DIFF
--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -533,6 +533,29 @@ describe('AcpProviderSessionResumer', () => {
     expect(harness.adopt).toHaveBeenCalledOnce()
   })
 
+  it('fresh-adopts a persisted Codex Responses Session after its adapter returns Unknown error', async () => {
+    const providerSessionId = '019fb8c8-6c66-7f22-9653-17b5b287dbbb'
+    const harness = createHarness({
+      initialBackend: codexResponsesBackend,
+      resumeError: { code: -32603, message: 'Unknown error' }
+    })
+
+    await expect(
+      harness.resume({
+        providerSessionId,
+        previousFrameworkId: 'codex',
+        previousBackendId: codexResponsesBackend.backendId
+      })
+    ).resolves.toMatchObject({ contextReset: true })
+
+    expect(harness.request).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sessionId: providerSessionId })
+    )
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.adopt).toHaveBeenCalledOnce()
+  })
+
   it('fresh-adopts a legacy OpenCode Session after its adapter returns Unknown error', async () => {
     const harness = createHarness({
       initialBackend: opencodeBackend,

--- a/src/main/acp/session-resume-policy.test.ts
+++ b/src/main/acp/session-resume-policy.test.ts
@@ -325,23 +325,26 @@ describe('ACP Session resume policy', () => {
     }
   )
 
-  it('keeps an Unknown error authoritative for a persisted Codex Responses identity', () => {
-    const policy = new AcpSessionResumePolicy()
+  it.each(['codex-responses', 'codex-responses-compatibility'] as const)(
+    'classifies a persisted %s Unknown error as adoptable',
+    (currentModelRoute) => {
+      const policy = new AcpSessionResumePolicy()
 
-    expect(
-      policy.classifyFailure(
-        { code: -32603, message: 'Unknown error' },
-        {
-          currentFrameworkId: 'codex',
-          currentModelRoute: 'codex-responses',
-          providerSessionIdPersisted: true
-        }
-      )
-    ).toEqual({
-      disposition: 'authoritative',
-      reason: 'non-internal-error'
-    })
-  })
+      expect(
+        policy.classifyFailure(
+          { code: -32603, message: 'Unknown error' },
+          {
+            currentFrameworkId: 'codex',
+            currentModelRoute,
+            providerSessionIdPersisted: true
+          }
+        )
+      ).toEqual({
+        disposition: 'adoptable',
+        reason: 'legacy-codex-session-unavailable'
+      })
+    }
+  )
 
   it('keeps an Unknown error authoritative for a persisted OpenCode identity', () => {
     const policy = new AcpSessionResumePolicy()

--- a/src/main/acp/session-resume-policy.ts
+++ b/src/main/acp/session-resume-policy.ts
@@ -269,19 +269,16 @@ class AcpSessionResumePolicy {
     if (service.value === 'session') return adoptableFailure('session-service-failure')
     if (service.value !== undefined) return authoritativeFailure('non-session-service-failure')
 
-    if (
-      context?.providerSessionIdPersisted === false &&
-      typeof message.value === 'string' &&
-      /^unknown error\.?$/i.test(message.value.trim())
-    ) {
+    if (typeof message.value === 'string' && /^unknown error\.?$/i.test(message.value.trim())) {
       if (
-        context.currentFrameworkId === 'codex' &&
+        context?.currentFrameworkId === 'codex' &&
         (context.currentModelRoute === 'codex-responses' ||
           context.currentModelRoute === 'codex-responses-compatibility')
       ) {
         return adoptableFailure('legacy-codex-session-unavailable')
       }
       if (
+        context?.providerSessionIdPersisted === false &&
         context.currentFrameworkId === 'opencode' &&
         (context.currentModelRoute === 'opencode-anthropic' ||
           context.currentModelRoute === 'opencode-openai')


### PR DESCRIPTION
﻿## Problem

Persisted Codex Responses and Responses Compatibility sessions can return JSON-RPC `-32603 Unknown error` when the provider rollout is no longer available. The resume policy only treated this adapter response as recoverable when no provider session ID had been persisted, so affected users saw `Agent session resume failed: Unknown error` instead of recovering.

## Proposed change

- Treat the exact `-32603 Unknown error` response as an unavailable Codex provider session for the `codex-responses` and `codex-responses-compatibility` routes, including persisted identities.
- Fresh-adopt a provider session through the existing ownership-release and `contextReset` flow.
- Add policy coverage for both Codex routes and an end-to-end resumer regression test for a persisted provider session ID.

## Scope and non-goals

- Persisted OpenCode identities remain authoritative.
- Claude Code and Codex Bridge behavior is unchanged and remains fail-closed.
- No UI, persistence schema, database migration, subscription timing, or listener cleanup behavior changes.
- No historical data migration is required. Provider-native hidden state cannot be recovered; the existing active-branch history replay restores local conversation context after adoption.

## Acceptance criteria and validation

All checks below ran after the last material edit.

| Behavior / consumer | Check | Result |
| --- | --- | --- |
| Codex Responses and Compatibility exact-error classification | `vitest run src/main/acp/provider-session-resumer.test.ts src/main/acp/session-resume-policy.test.ts` | Passed: 67/67 |
| Fresh adoption releases the failed resume capability and returns `contextReset` | `provider-session-resumer.test.ts` regression case | Passed |
| Node process types | `tsc --noEmit -p tsconfig.node.json --composite false` | Passed |
| Changed ACP files | `eslint src/main/acp/session-resume-policy.ts src/main/acp/session-resume-policy.test.ts src/main/acp/provider-session-resumer.test.ts` | Passed |
| Repository lint fallback | `eslint --cache .` | Blocked by pre-existing `src/renderer/src/stores/settings-preferences-slice.test.ts:84` return-type error and 15 unrelated warnings |
| Repository test fallback | `npm test` | Did not pass; failures were outside the changed ACP files, including Windows symlink `EPERM`, a Prisma test database/client schema mismatch, an existing component line-count threshold, and an unrelated render timeout |

Uncovered risk: exact-head CI remains authoritative for the unrelated repository-wide failures above and for platform lanes not reproduced locally.

## Review focus

Please verify that the fallback remains restricted to the exact internal error and the two Codex Responses routes, while the existing fail-closed behavior for persisted OpenCode, Claude Code, and Codex Bridge remains intact.
