### PR TITLE
fix(resource-identity)!: make invocation names immutable

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -662,6 +662,16 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 - Select fields use `Select`, with a `32px` trigger height.
 - A visible Settings search or filter field owns the platform search shortcut: `Cmd+K` on macOS and `Ctrl+K` on Windows/Linux focus it without selecting or clearing its value. The topmost nested Settings dialog wins over a search behind it; hidden or disabled searches do not intercept the shortcut. Persistent list-toolbars show the shortcut as right-aligned keycaps inside the field, while transient searches such as runtime-package and Specialist capability filters expose the same behavior through `aria-keyshortcuts` without repeating the visual hint.
 
+#### Resource identity and display names
+
+- Connector, Skill, and Specialist `name` values are stable invocation identities. They are fixed after creation and are used by host APIs, generated Skill documents, package references, and policy routing. Editing a presentation label must never change these references.
+- `displayName` is presentation-only and may appear in lists, search results, prompts, and approval UI. Connector and Specialist editors may change it freely. A Skill may read an optional `displayName` from external `SKILL.md` frontmatter and falls back to `name`; built-in Skills and app-generated Skill exports omit that non-standard field, and the app does not maintain a separate Skill display-name field outside the manifest.
+- Connector context follows a distinct derived path: after live tool discovery the app generates an on-demand `mcp-<name>/SKILL.md`. Its frontmatter identity and every `host.mcp` example use immutable `name`; `displayName` may appear only in generated prose (or through an explicit `listConnectors()` result). Updating a Connector regenerates this document and reloads Skills without creating an invocation alias. Auth-recovery guidance derived from Connector configuration and discovered login tools remains part of the generated document.
+- A custom Connector also has an internal UUID `id`. Runtime calls and Specialist capability references use its immutable lowercase-hyphenated `name`; durable permission grants use the UUID. The UI shows `displayName` and exposes the immutable Connector ID separately. Display names and UUIDs are not invocation aliases.
+- Connector template schema v1 stores both `name` and `displayName` directly. Export never includes secrets, and import does not synthesize compatibility aliases from a display name.
+- Specialist package schema v1 remains byte-for-byte compatible in field shape: package `name` stays the immutable invocation identity and `displayName` stays editable presentation metadata.
+- Public JavaScript host APIs and their object fields use camelCase (`listSkills`, `listConnectors`, `attachSkill`, `displayName`, `systemPrompt`, and related fields). Internal transport operation names may remain snake_case behind that boundary.
+
 #### Skills panel
 
 - Panel navigation is breadcrumb-driven: the list, detail, create, edit, import, and upload screens are second-level pages reached through the settings header's back / forward history and maximize control, not separate dialogs.

--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -2233,8 +2233,8 @@ async function computeRpc(params) {
   return body.result
 }
 
-// host.agents: control-plane Specialist management SDK (issue 02). Read-only in this slice
-// (list/get/list_skills/list_connectors); mutation/switch land in later issues. Routed over the SAME
+// host.agents: control-plane Specialist management SDK. Reads, ordinary mutations, and privileged
+// delete/switch operations are routed over the SAME
 // app-local RPC endpoint as host.mcp/host.compute but as its own `agentsCall` method — never through
 // host.mcp(). Uses the captured RPC endpoint/token + client for the same token-isolation reasons. The
 // trusted calling session identity is the COMPUTE_SESSION_ID captured at spawn time
@@ -2262,10 +2262,17 @@ async function agentsRpc(op, params = {}, sessionId = COMPUTE_SESSION_ID) {
     // (auth, unknown method) are not method-scoped, so prefix them with the op the caller invoked so
     // the agent always sees a host.agents.* namespaced, secret-free message.
     const serverMessage = body.error || 'host.agents HTTP ' + res.status
-    const prefixed = /^host\.agents\./.test(serverMessage)
-      ? serverMessage
-      : `host.agents.${op}: ${serverMessage}`
-    throw new Error(prefixed)
+    const publicMethod =
+      {
+        list_skills: 'listSkills',
+        list_connectors: 'listConnectors',
+        attach_skill: 'attachSkill',
+        detach_skill: 'detachSkill',
+        attach_connector: 'attachConnector',
+        detach_connector: 'detachConnector'
+      }[op] || op
+    const detail = String(serverMessage).replace(/^host\.agents\.[^:]+:\s*/, '')
+    throw new Error(`host.agents.${publicMethod}: ${detail}`)
   }
   return body.result
 }
@@ -2465,12 +2472,27 @@ async function delegatedMessageRpc(op, params) {
   return body.result
 }
 
-// host.agents namespace. Methods and filter/write fields are snake_case; returned records are
-// camelCase. list_skills/list_connectors accept an optional stable id or unique public name.
-// create/update/attach_*/detach_* are the ordinary-mutation surface (issue 03); they return a real
+// host.agents namespace. JavaScript methods, inputs, and returned records use camelCase. The private
+// RPC operation names remain transport details.
+// create/update/attachSkill/detachSkill/attachConnector/detachConnector are the ordinary-mutation
+// surface (issue 03); they return a real
 // post-write camelCase Profile read-back and never echo requested input. switch/delete are the
 // privileged surface (issue 04/05): authorized this milestone by the /customize Skill's chat-text
 // confirmation + the pass-through SDK approval gateway (design.md §7/§14), not the standard card.
+function agentsWriteParams(value) {
+  const names = {
+    displayName: 'display_name',
+    systemPrompt: 'system_prompt',
+    iconKey: 'icon_key',
+    colorKey: 'color_key',
+    skillNames: 'skill_names',
+    connectorNames: 'connector_names'
+  }
+  return Object.fromEntries(
+    Object.entries(value || {}).map(([key, entry]) => [names[key] || key, entry])
+  )
+}
+
 const hostAgents = {
   async list() {
     return agentsRpc('list')
@@ -2478,30 +2500,28 @@ const hostAgents = {
   async get(name) {
     return agentsRpc('get', { name })
   },
-  async list_skills(nameOrId = undefined) {
+  async listSkills(nameOrId = undefined) {
     return agentsRpc('list_skills', nameOrId !== undefined ? { name_or_id: nameOrId } : {})
   },
-  async list_connectors(nameOrId = undefined) {
+  async listConnectors(nameOrId = undefined) {
     return agentsRpc('list_connectors', nameOrId !== undefined ? { name_or_id: nameOrId } : {})
   },
   async create(input) {
-    return agentsRpc('create', input || {})
+    return agentsRpc('create', agentsWriteParams(input))
   },
   async update(name, patch) {
-    // Nest the patch so a rename (patch.name) never collides with the lookup name on the wire —
-    // design.md §4 / customize-skill.md: update(name, patch) where patch may carry a new `name`.
-    return agentsRpc('update', { name, patch: patch || {} })
+    return agentsRpc('update', { name, patch: agentsWriteParams(patch) })
   },
-  async attach_skill(name, skillRef, options) {
+  async attachSkill(name, skillRef, options) {
     return agentsRpc('attach_skill', { name, skill_ref: skillRef, ...(options || {}) })
   },
-  async detach_skill(name, skillRef, options) {
+  async detachSkill(name, skillRef, options) {
     return agentsRpc('detach_skill', { name, skill_ref: skillRef, ...(options || {}) })
   },
-  async attach_connector(name, connectorRef, options) {
+  async attachConnector(name, connectorRef, options) {
     return agentsRpc('attach_connector', { name, connector_ref: connectorRef, ...(options || {}) })
   },
-  async detach_connector(name, connectorRef, options) {
+  async detachConnector(name, connectorRef, options) {
     return agentsRpc('detach_connector', { name, connector_ref: connectorRef, ...(options || {}) })
   },
   // Privileged: switch binds only the trusted calling session (server-captured). After approval the

--- a/resources/skills/customize/SKILL.md
+++ b/resources/skills/customize/SKILL.md
@@ -42,22 +42,23 @@ The Skill never uses the following, and you must not invent them:
 
 ## The `host.agents` SDK surface
 
-The SDK is name-first and lives in the trusted calling session. Read methods and returned records use
-camelCase; write-side fields use snake_case. Methods:
+The SDK is name-first and lives in the trusted calling session. JavaScript methods, inputs, and
+returned records all use camelCase. Methods:
 
 - `host.agents.list()` — custom Specialists only.
-- `host.agents.get(name)` — one Specialist by public name (returns stable `id` and `revision`, but you
+- `host.agents.get(name)` — one Specialist by immutable name (returns stable `id` and `revision`, but you
   do not show those to the user).
 - `host.agents.create(input)` — object form (see below).
-- `host.agents.update(name, patch)` — may include a new `name`; renames are ordinary chat-reviewed
-  updates, not privileged.
+- `host.agents.update(name, patch)` — `name` selects the Specialist and is immutable; use
+  `patch.displayName` to change its presentation label.
 - `host.agents.switch(nameOrNull)` — switches the **current conversation** only; `null` returns to Main
   Agent. Does not accept a caller-supplied session id.
 - `host.agents.delete(name, { revision })`.
-- `host.agents.attach_skill(name, skillRef, { revision })` / `host.agents.detach_skill(...)`.
-- `host.agents.attach_connector(name, connectorRef, { revision })` / `host.agents.detach_connector(...)`.
-- `host.agents.list_skills(nameOrId?)` — complete Skill catalog, including Main-disabled Skills.
-- `host.agents.list_connectors(nameOrId?)` — public Connector information; never credentials, headers,
+- `host.agents.attachSkill(name, skillRef, { revision })` / `host.agents.detachSkill(...)`.
+- `host.agents.attachConnector(name, connectorRef, { revision })` /
+  `host.agents.detachConnector(...)`.
+- `host.agents.listSkills(nameOrId?)` — complete Skill catalog, including Main-disabled Skills.
+- `host.agents.listConnectors(nameOrId?)` — public Connector information; never credentials, headers,
   environment values, Connector arguments, or tokens.
 
 `create` takes an object:
@@ -65,28 +66,29 @@ camelCase; write-side fields use snake_case. Methods:
 ```js
 host.agents.create({
   name,
+  displayName,
   description,
-  system_prompt,
-  icon_key,
-  color_key,
+  systemPrompt,
+  iconKey,
+  colorKey,
   enabled,
   unrestricted,
-  skill_names,
-  connector_names
+  skillNames,
+  connectorNames
 })
 ```
 
-Skill/Connector references resolve an exact stable catalog id first, otherwise a unique public name. An
-ambiguous name is rejected — tell the user to use the stable id from `list_skills`/`list_connectors`.
+Skill/Connector references resolve an exact stable catalog id first, otherwise a unique immutable name. An
+ambiguous name is rejected — tell the user to use the stable id from `listSkills`/`listConnectors`.
 
 Errors are sanitized and prefixed `host.agents.<method>:`; they never contain system instructions,
 credentials, headers, environment values, Connector arguments, or the RPC token.
 
 ## Specialist identity and composition
 
-Treat `system_prompt` as the Specialist's identity override while the application's safety, tool, and
-workflow rules remain in force. Lead with `You are {display_name}.`, replacing `{display_name}` with
-the proposed public name. State the Specialist's one focused job, what it handles, and what the
+Treat `systemPrompt` as the Specialist's identity override while the application's safety, tool, and
+workflow rules remain in force. Lead with `You are {displayName}.`, replacing `{displayName}` with
+the proposed display name. State the Specialist's one focused job, what it handles, and what the
 Specialist does not do. Keep the identity concise; the heavy how-to lives in Skills, not in the system
 prompt. Reuse or create Skills for recurring procedures instead of copying those procedures into the
 identity.
@@ -101,7 +103,7 @@ Follow this order for every mutation. Do not skip the live read, and do not snap
 into a profile or session (resolution is always live):
 
 1. **Understand scope.** What does the user want to create/change/delete/switch?
-2. **Live read.** Call `get`/`list` plus `list_skills`/`list_connectors` to read the current state and
+2. **Live read.** Call `get`/`list` plus `listSkills`/`listConnectors` to read the current state and
    the catalogs before proposing anything.
 3. **Complete draft.** Build the full target state, not a partial edit.
 4. **Review.** Show the complete target state to the user.
@@ -118,13 +120,14 @@ request such as "full access" or "same capabilities as Main."
 
 Capability semantics:
 
-- `create` with neither `skill_names` nor `connector_names` → Full access. But only use this after the
+- `create` with neither `skillNames` nor `connectorNames` → Full access. But only use this after the
   user explicitly chose Full.
 - Supplying either array on `create` → Selected; an omitted other array becomes empty.
 - `update({ unrestricted: true })` → Full, preserving the stored Selected configuration.
-- Supplying `skill_names` or `connector_names` to `update` exactly replaces the supplied collection and
+- Supplying `skillNames` or `connectorNames` to `update` exactly replaces the supplied collection and
   switches to Selected; an omitted collection is preserved.
-- `attach_*`/`detach_*` mutate the current mode without changing it (Selected: add/remove an inclusion;
+- `attachSkill`/`detachSkill` and `attachConnector`/`detachConnector` mutate the current mode without
+  changing it (Selected: add/remove an inclusion;
   Full: remove/add an exclusion).
 - Selected mode with zero Skills and zero Connectors is valid.
 
@@ -153,10 +156,11 @@ move.
 
 ## Confirmation boundaries
 
-- **Create and update (including renames):** show the complete target state and wait for the user's
+- **Create and update:** show the complete target state and wait for the user's
   explicit confirmation (for example "yes", "confirm", "ok") before executing. The initial `/customize`
-  entry and the composer prefill are **not** confirmation. A rename is an ordinary update field: the
-  whole patch is applied atomically by the service, and a stale revision fails without merge or retry.
+  entry and the composer prefill are **not** confirmation. `name` is immutable; `displayName` is an
+  ordinary update field. The whole patch is applied atomically, and a stale revision fails without
+  merge or retry.
 - **Delete, switch:** describe the impending action, then execute it directly. These operations are
   privileged and pass through the app's approval card.
 

--- a/resources/skills/skill-creator/SKILL.md
+++ b/resources/skills/skill-creator/SKILL.md
@@ -61,7 +61,8 @@ user's technical comfort.
 
 1. Call `host.skills.list()` before editing. Read every existing file you intend to change.
 2. For Built-in or Imported Skills, create a Personal fork under a new lowercase hyphenated name.
-3. Use frontmatter with exactly `name` and `description`; the name must equal the draft slug.
+3. Use frontmatter with `name` and `description`, plus optional `displayName`; `name` must equal the
+   immutable draft slug and defaults as the presentation label when `displayName` is omitted.
 4. Put stable procedures in `SKILL.md`, detailed knowledge in `references/`, deterministic automation
    in `scripts/`, and output templates in `assets/`.
 5. Prefer imperative instructions and explain why constraints matter. Avoid brittle lists of MUSTs.
@@ -128,4 +129,4 @@ replace an existing Personal Skill. Read the published `SKILL.md` back and repor
 origin.
 
 If the user asks to attach it to a Specialist, read the live Specialist and Skill catalogs first,
-then call `host.agents.attach_skill(...)` and report the returned read-back. Never attach automatically.
+then call `host.agents.attachSkill(...)` and report the returned read-back. Never attach automatically.

--- a/resources/skills/skill-creator/scripts/quick-validate.js
+++ b/resources/skills/skill-creator/scripts/quick-validate.js
@@ -9,8 +9,11 @@ const validateSkillDocument = (content, expectedName) => {
     entry[2].trim().replace(/^['"]|['"]$/g, '')
   ])
   const names = fields.map(([name]) => name).sort()
-  if (names.join(',') !== 'description,name') {
-    return { valid: false, error: 'Frontmatter must contain exactly name and description.' }
+  if (!['description,name', 'description,displayname,name'].includes(names.join(','))) {
+    return {
+      valid: false,
+      error: 'Frontmatter may only contain name, displayName, and description.'
+    }
   }
   const values = Object.fromEntries(fields)
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(values.name) || values.name.length > 64) {
@@ -25,7 +28,12 @@ const validateSkillDocument = (content, expectedName) => {
   if (!values.description || values.description.length > 1024 || /[<>]/.test(values.description)) {
     return { valid: false, error: 'Description must be 1-1024 characters without angle brackets.' }
   }
-  return { valid: true, name: values.name, description: values.description }
+  return {
+    valid: true,
+    name: values.name,
+    ...(values.displayname ? { displayName: values.displayname } : {}),
+    description: values.description
+  }
 }
 
 const quickValidate = async (hostSkills, name) => {

--- a/src/main/agents/agents-dispatch.test.ts
+++ b/src/main/agents/agents-dispatch.test.ts
@@ -363,10 +363,10 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     return { service, profileService, gateway, invalidateCatalog }
   }
 
-  it('routes a rename through the ordinary mutation path (real read-back, no echo, no approval)', async () => {
-    // The ProfileService returns the REAL post-write record (new name + bumped revision); the dispatcher
+  it('routes a displayName edit through the ordinary mutation path', async () => {
+    // The ProfileService returns the real post-write record; the dispatcher
     // must surface it verbatim, not echo the request patch.
-    const updated = specialist({ name: 'Biology', description: 'new', revision: 4 })
+    const updated = specialist({ displayName: 'Biology', description: 'new', revision: 4 })
     const { service, profileService, gateway } = buildService({
       profiles: [specialist()]
     })
@@ -374,18 +374,19 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
 
     const result = (await service.dispatch({
       op: 'update',
-      params: { name: 'Bio', patch: { name: 'Biology', description: 'new', revision: 3 } }
+      params: { name: 'Bio', patch: { display_name: 'Biology', description: 'new', revision: 3 } }
     })) as SpecialistProfileView
 
     // Ordinary path returns a projected AgentReadModel (no {status:'updated'} envelope).
-    expect(result.name).toBe('Biology')
+    expect(result.name).toBe('Bio')
+    expect(result.displayName).toBe('Biology')
     expect(result.revision).toBe(4)
     // The ordinary path pinned the re-resolved name -> id and revision before update.
     const updateArgs = (profileService.update as ReturnType<typeof vi.fn>).mock.calls[0][0]
     expect(updateArgs.id).toBe('sp-1')
     expect(updateArgs.revision).toBe(3)
-    expect(updateArgs.name).toBe('Biology')
-    // Renames are chat-reviewed, not privileged: the gateway was never consulted.
+    expect(updateArgs.name).toBeUndefined()
+    expect(updateArgs.displayName).toBe('Biology')
     expect(gateway.decide).not.toHaveBeenCalled()
   })
 
@@ -478,11 +479,7 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     expect(result).toEqual({ status: 'deleted', name: 'Bio' })
   })
 
-  // Regression (08a review): a name-changing patch that ALSO edits capabilities MUST apply both
-  // atomically. The /customize Skill sends skill_names/connector_names in the same update patch as a
-  // rename (preferAtomicUpdate), and explainNameChange promises to "rename ... and apply the rest of
-  // the reviewed changes in one step". Previously runPrivilegedUpdate projected identity/text fields
-  // only and silently dropped the capability edit.
+  // A display-label patch that also edits capabilities must apply both atomically.
   const skillCatalog = (): AgentsCatalogSource => ({
     listSkillCatalog: vi.fn(async () => [
       {
@@ -531,11 +528,11 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     return { service, profileService, gateway, invalidateCatalog }
   }
 
-  it('a name-changing patch that also edits skill_names applies BOTH atomically (no capability drop)', async () => {
-    // The ProfileService returns the REAL post-write record (renamed, bumped revision, AND the new
+  it('a displayName patch that also edits skill_names applies both atomically', async () => {
+    // The ProfileService returns the real post-write record (new label, bumped revision, and the new
     // selected capability collection). The dispatcher must surface it verbatim, not echo the request.
     const updated: SpecialistProfileView = {
-      ...specialist({ name: 'Biology', revision: 4 }),
+      ...specialist({ displayName: 'Biology', revision: 4 }),
       capabilityMode: 'selected',
       selectedCapabilities: { skillIds: ['sk-reviewer'], connectorIds: [], connectorTools: [] },
       fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] }
@@ -549,31 +546,31 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
       op: 'update',
       params: {
         name: 'Bio',
-        patch: { name: 'Biology', skill_names: ['sk-reviewer'], revision: 3 }
+        patch: { display_name: 'Biology', skill_names: ['sk-reviewer'], revision: 3 }
       }
     })) as SpecialistProfileView
 
-    // REAL post-write read-back: BOTH the rename and the capability edit landed.
-    expect(result.name).toBe('Biology')
+    expect(result.name).toBe('Bio')
+    expect(result.displayName).toBe('Biology')
     expect(result.capabilityMode).toBe('selected')
     expect(result.selectedCapabilities.skillIds).toEqual(['sk-reviewer'])
     expect(result.revision).toBe(4)
 
-    // The ordinary path received the COMPLETE patch: name + resolved capability fields. The
+    // The ordinary path received the complete patch: displayName + resolved capability fields. The
     // skill ref was resolved to its stable id and projected onto the patch (not stripped).
     const updateArgs = (profileService.update as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    expect(updateArgs.name).toBe('Biology')
+    expect(updateArgs.name).toBeUndefined()
+    expect(updateArgs.displayName).toBe('Biology')
     expect(updateArgs.capabilityMode).toBe('selected')
     expect(updateArgs.selectedCapabilities).toEqual({
       skillIds: ['sk-reviewer'],
       connectorIds: [],
       connectorTools: []
     })
-    // No approval card for renames.
     expect(gateway.decide).not.toHaveBeenCalled()
   })
 
-  it('a combined name+capability patch with a stale revision fails closed (no mutation)', async () => {
+  it('a combined displayName+capability patch with a stale revision fails closed', async () => {
     // Live revision drifted to 5 while the reviewed revision was 3.
     const { service, profileService, invalidateCatalog } = buildServiceWithSkills({
       profiles: [specialist({ revision: 5 })]
@@ -584,7 +581,7 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
         op: 'update',
         params: {
           name: 'Bio',
-          patch: { name: 'Biology', skill_names: ['sk-reviewer'], revision: 3 }
+          patch: { display_name: 'Biology', skill_names: ['sk-reviewer'], revision: 3 }
         }
       })
     ).rejects.toThrow(/host\.agents\.update:.*revision/)
@@ -592,26 +589,23 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     expect(invalidateCatalog).not.toHaveBeenCalled()
   })
 
-  // Regression (defect #1): a name-changing patch that ALSO toggles `enabled` must land BOTH. The
+  // A displayName patch that also toggles `enabled` must land both. The
   // ordinary update path applies `enabled` via a separate ProfileService.setEnabled(...) call after
   // the identity/capability update.
-  it('a name-changing patch that also toggles enabled applies BOTH the rename and the enabled change', async () => {
-    // After the atomic rename (revision 3->4), setEnabled flips enabled to false and bumps again
-    // (revision 4->5). The dispatcher must return the REAL post-setEnabled read-back with the new
-    // name AND enabled === false.
-    const renamed = specialist({ name: 'Biology', revision: 4, enabled: true })
-    const afterToggle = specialist({ name: 'Biology', revision: 5, enabled: false })
+  it('a displayName patch that also toggles enabled applies both changes', async () => {
+    const renamed = specialist({ displayName: 'Biology', revision: 4, enabled: true })
+    const afterToggle = specialist({ displayName: 'Biology', revision: 5, enabled: false })
     const { service, profileService } = buildService({ profiles: [specialist()] })
     ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(renamed)
     ;(profileService.setEnabled as ReturnType<typeof vi.fn>) = vi.fn(async () => afterToggle)
 
     const result = (await service.dispatch({
       op: 'update',
-      params: { name: 'Bio', patch: { name: 'Biology', enabled: false, revision: 3 } }
+      params: { name: 'Bio', patch: { display_name: 'Biology', enabled: false, revision: 3 } }
     })) as SpecialistProfileView
 
-    // REAL post-write read-back carries BOTH the rename and the enabled toggle.
-    expect(result.name).toBe('Biology')
+    expect(result.name).toBe('Bio')
+    expect(result.displayName).toBe('Biology')
     expect(result.enabled).toBe(false)
     expect(result.revision).toBe(5)
     // setEnabled was invoked with the toggled value, after the atomic rename committed.
@@ -621,9 +615,7 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     )
   })
 
-  // Regression (defect #5): a rename patch must reject unknown keys the same way every other update
-  // patch does — an unknown field must never be silently ignored.
-  it('rejects a name-changing patch carrying an unknown field with a sanitized error', async () => {
+  it('rejects a displayName patch carrying an unknown field with a sanitized error', async () => {
     const { service, profileService, invalidateCatalog } = buildService({
       profiles: [specialist()]
     })
@@ -633,7 +625,7 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
         op: 'update',
         params: {
           name: 'Bio',
-          patch: { name: 'Biology', malicious_field: 'x', revision: 3 }
+          patch: { display_name: 'Biology', malicious_field: 'x', revision: 3 }
         }
       })
     ).rejects.toThrow(/host\.agents\.update:.*Unknown field "malicious_field"/)

--- a/src/main/agents/agents-mutations.test.ts
+++ b/src/main/agents/agents-mutations.test.ts
@@ -91,7 +91,6 @@ const makeProfileService = (
       const idx = stored.findIndex((p) => p.id === input.id)
       if (idx < 0) throw new Error(`Specialist ${input.id} not found after update.`)
       const merged: SpecialistProfileView = { ...stored[idx] }
-      if (input.name !== undefined) merged.name = input.name
       if (input.displayName !== undefined) merged.displayName = input.displayName
       if (input.description !== undefined) merged.description = input.description
       if (input.systemPrompt !== undefined) merged.systemPrompt = input.systemPrompt
@@ -238,6 +237,7 @@ const skills = (...entries: Partial<SkillCatalogReadModel>[]): SkillCatalogReadM
 const connectors = (...entries: Partial<ConnectorReadModel>[]): ConnectorReadModel[] =>
   entries.map((e) => ({
     id: 'bundled',
+    name: 'bundled',
     displayName: 'Bundled',
     description: '',
     mainEnabled: true,
@@ -435,14 +435,14 @@ describe('executeAgentsMutation — create', () => {
     expect(passed.selectedCapabilities?.skillIds).toEqual(['stable-1'])
   })
 
-  it('create resolves a connector public name to its stable id', async () => {
+  it('create resolves a connector immutable name to its stable id', async () => {
     const svc = makeProfileService([])
     const { catalog } = makeCatalog(
       skills(),
-      connectors({ id: 'stable-c', displayName: 'My Connector' })
+      connectors({ id: 'stable-c', name: 'my-connector', displayName: 'My Connector' })
     )
     await executeAgentsMutation(
-      { op: 'create', params: { name: 'Bio', connector_names: ['My Connector'] } },
+      { op: 'create', params: { name: 'Bio', connector_names: ['my-connector'] } },
       { profileService: svc, catalog }
     )
     const passed = svc.calls[0].args[0] as CreateSpecialistInput
@@ -605,7 +605,7 @@ describe('executeAgentsMutation — update', () => {
     expect(decide).not.toHaveBeenCalled()
   })
 
-  it('update reads changes from the nested patch so a rename never collides with the lookup name', async () => {
+  it('update reads changes from the nested patch', async () => {
     const svc = makeProfileService([baseProfile({ revision: 1 })])
     const { catalog } = makeCatalog(skills(), connectors())
     const result = (await executeAgentsMutation(
@@ -617,16 +617,18 @@ describe('executeAgentsMutation — update', () => {
     expect(result.revision).toBe(2)
   })
 
-  it('update applies a rename on the ordinary path (renames are chat-reviewed, not privileged)', async () => {
+  it('update changes displayName without changing the immutable name', async () => {
     const svc = makeProfileService([baseProfile({ revision: 1 })])
     const { catalog } = makeCatalog(skills(), connectors())
     const decide = vi.fn()
     const result = (await executeAgentsMutation(
-      { op: 'update', params: { name: 'Bio', patch: { revision: 1, name: 'NewName' } } },
+      {
+        op: 'update',
+        params: { name: 'Bio', patch: { revision: 1, display_name: 'New label' } }
+      },
       { profileService: svc, catalog, approvalGateway: { decide } }
     )) as SpecialistProfileView
-    expect(result.name).toBe('NewName')
-    // Rename is an ordinary mutation: the approval gateway is never consulted.
+    expect(result).toMatchObject({ name: 'Bio', displayName: 'New label' })
     expect(decide).not.toHaveBeenCalled()
   })
 

--- a/src/main/agents/agents-mutations.ts
+++ b/src/main/agents/agents-mutations.ts
@@ -1,15 +1,15 @@
 // host.agents ordinary-mutation operation module (issue 03).
 //
-// This module implements the ORDINARY Profile mutations + read-back: create, non-name update,
+// This module implements ordinary Profile mutations + read-back: create, mutable-field update,
 // enable/disable, and incremental whole-Skill/whole-Connector attach/detach. It is deliberately a
 // standalone module so issue 08 can compose it into the shared dispatcher without changing issues
-// 04/05. The privileged ops (delete, switch, and name-changing update) stay out of scope here — they
+// 04/05. The privileged delete and switch operations stay out of scope here — they
 // require the injected approval gateway.
 //
 // Design rules (design.md §4/§5/§8, PRD §2/§4):
 //  - ProfileService is the SINGLE domain mutation service. This module never writes the repository
 //    directly and never re-implements the Full/Selected collection rules; it only translates the
-//    public snake_case SDK input into ProfileService input and delegates.
+//    private snake_case transport input into ProfileService input and delegates.
 //  - Every successful mutation returns an actual post-write camelCase Profile read-back, never an
 //    echo of the requested input.
 //  - Skill/Connector references resolve an exact catalog ID first, otherwise an unambiguous public
@@ -106,8 +106,7 @@ const optionalStringOrThrow = (value: unknown, label: string): string | undefine
 
 // A string array of non-empty references (skill_names / connector_names). Rejects non-arrays,
 // non-string elements, and empty-string entries. Duplicates are preserved as-is and de-duped later.
-// Exported so the privileged name-changing update path (agents-service.runPrivilegedUpdate) reuses
-// the EXACT validation the ordinary update path uses — no duplicated payload plumbing.
+// Exported so all capability mutations share the same payload validation.
 export const asStringArray = (value: unknown): string[] | undefined => {
   if (value === undefined) return undefined
   if (!Array.isArray(value) || !value.every((item) => isString(item) && item.length > 0)) {
@@ -120,9 +119,7 @@ export const asStringArray = (value: unknown): string[] | undefined => {
 // Catalog resolution (reuses the read slice's projection + name/id filter)
 // ---------------------------------------------------------------------------
 
-// Resolves each public name/id skill reference to its stable id via the read slice's name/id filter
-// (exact id wins, otherwise a unique public name; ambiguity is rejected with a stable-id hint).
-// Exported so the privileged name-changing update path reuses the same resolution.
+// Resolves each immutable name/id Skill reference to its stable id via the read slice's filter.
 export const resolveSkillRefs = async (
   catalog: AgentsMutationCatalog,
   refs: string[],
@@ -143,8 +140,7 @@ export const resolveSkillRefs = async (
 // Resolves each connector reference to its stable id and, when `gateUnavailable` is set (a NEW
 // attachment via create/attach_connector/update connector_names), rejects a missing, unavailable, or
 // unauthenticated custom connector. Existing stale references remain readable and removable via
-// detach (which calls this with gateUnavailable=false). Exported so the privileged name-changing
-// update path reuses the same resolution + gating.
+// detach (which calls this with gateUnavailable=false).
 export const resolveConnectorRefs = async (
   catalog: AgentsMutationCatalog,
   refs: string[],
@@ -170,8 +166,7 @@ export const resolveConnectorRefs = async (
 }
 
 // ---------------------------------------------------------------------------
-// Shared capability projection (used by BOTH the ordinary update path AND the
-// privileged name-changing update path so the two NEVER diverge)
+// Shared capability projection for ordinary updates.
 // ---------------------------------------------------------------------------
 
 // The capability-bearing slice of an UpdateSpecialistInput / SpecialistUpdatePatch. Returned
@@ -192,7 +187,7 @@ export type CapabilityProjection = {
 //     connectorTools is re-read from `current`. fullAccess is left unset.
 //   - neither array present but unrestricted:true -> 'full' (Selected configuration preserved).
 //   - neither -> returns an EMPTY projection (caller leaves capability fields unset; we do NOT
-//     force full-access). This is what lets a rename-only patch leave capabilities untouched.
+//     force full-access). This lets presentation-only patches leave capabilities untouched.
 // `current` is the live profile the patch is being applied against (for preserving omitted
 // collections and connectorTools). `method` scopes error messages.
 export const projectCapabilityFields = async (
@@ -239,6 +234,7 @@ export const projectCapabilityFields = async (
 // unknown fields must not reach the repository).
 const CREATE_ALLOWED_KEYS = new Set([
   'name',
+  'display_name',
   'description',
   'system_prompt',
   'icon_key',
@@ -259,6 +255,7 @@ const handleCreate = async (
   if (!name.trim()) throw new Error('name is required')
 
   const description = optionalStringOrThrow(params.description, 'description')
+  const displayName = optionalStringOrThrow(params.display_name, 'display name')
   const systemPrompt = optionalStringOrThrow(params.system_prompt, 'system prompt')
   const iconKey = optionalStringOrThrow(params.icon_key, 'icon key')
   const colorKey = optionalStringOrThrow(params.color_key, 'color key')
@@ -283,6 +280,7 @@ const handleCreate = async (
 
   const input: CreateSpecialistInput = {
     name,
+    displayName,
     description,
     systemPrompt,
     iconKey,
@@ -324,7 +322,7 @@ const handleCreate = async (
 // The set of update-patch keys the public SDK accepts. Anything else is rejected (cross-cutting:
 // unknown fields must not reach the repository).
 export const UPDATE_ALLOWED_KEYS = new Set([
-  'name',
+  'display_name',
   'revision',
   'description',
   'system_prompt',
@@ -342,9 +340,7 @@ const handleUpdate = async (
 ): Promise<SpecialistProfileView> => {
   const name = isString(params.name) ? params.name : throwShape('name is required')
 
-  // The patch is a NESTED object so a rename (patch.name) never collides with the lookup name
-  // (params.name) on the wire — design.md §4 / customize-skill.md: `update(name, patch)` where the
-  // patch may carry a new `name`. params.name resolves the target; every field in `patch` is a change.
+  // params.name resolves the immutable Specialist name; every field in patch is a change.
   const patch = params.patch
   if (!isRecord(patch)) throw new Error('patch is required and must be an object.')
   rejectUnknownKeys(patch, UPDATE_ALLOWED_KEYS, 'update')
@@ -362,7 +358,7 @@ const handleUpdate = async (
   const input: {
     id: string
     revision: number
-    name?: string
+    displayName?: string
     description?: string
     systemPrompt?: string
     iconKey?: string
@@ -372,12 +368,8 @@ const handleUpdate = async (
     selectedCapabilities?: SpecialistSelectedConfig
   } = { id: current.id, revision }
 
-  // A rename (patch.name) is an ordinary chat-reviewed mutation like every other update field: the
-  // revision guard above plus the atomic single-profile update are the only authority. An
-  // uncustomized displayName follows the rename inside ProfileService.update, keeping the settings
-  // list in sync without a display_name SDK field.
-  const mappedName = optionalStringOrThrow(patch.name, 'name')
-  if (mappedName !== undefined) input.name = mappedName
+  const displayName = optionalStringOrThrow(patch.display_name, 'display name')
+  if (displayName !== undefined) input.displayName = displayName
   const description = optionalStringOrThrow(patch.description, 'description')
   if (description !== undefined) input.description = description
   const systemPrompt = optionalStringOrThrow(patch.system_prompt, 'system prompt')
@@ -391,8 +383,7 @@ const handleUpdate = async (
     throw new Error('enabled must be a boolean.')
   }
 
-  // Capability projection is shared with the privileged name-changing update path so the two NEVER
-  // diverge on the Selected/Full + collection-replacement semantics.
+  // Capability projection centralizes the Selected/Full + collection-replacement semantics.
   const capability = await projectCapabilityFields(patch, current, deps.catalog, 'update')
   if (capability.capabilityMode !== undefined) {
     input.capabilityMode = capability.capabilityMode
@@ -450,7 +441,7 @@ const handleAttachDetach = async (
   // attach resolves the reference to a stable id (and gates unavailable custom connectors). detach is
   // a removal, so an existing STALE reference that no longer appears in the catalog must still be
   // removable (design.md §5: "existing stale references remain readable and removable"). We try to
-  // resolve first (so a public name still works), but on detach we fall back to the literal reference
+  // resolve first (so an immutable name still works), but on detach we fall back to the literal reference
   // as the stable id when nothing matches.
   let stableId: string
   if (op.endsWith('skill')) {
@@ -497,8 +488,7 @@ const resolveOrPassThrough = async <T extends SkillCatalogReadModel | ConnectorR
 // Helpers
 // ---------------------------------------------------------------------------
 
-// Exported so the privileged name-changing update path reuses the EXACT unknown-key rejection the
-// ordinary path uses (defect #5). Throws a sanitized `Unknown field "<key>".` error.
+// Exported so every caller shares the exact unknown-key rejection behavior.
 export function rejectUnknownKeys(
   params: Record<string, unknown>,
   allowed: Set<string>,

--- a/src/main/agents/agents-repl.integration.test.ts
+++ b/src/main/agents/agents-repl.integration.test.ts
@@ -97,7 +97,14 @@ const stubCatalog: AgentsCatalogSource = {
     autoAllowIds: [],
     disabledConnectorIds: ['chemistry'],
     customMcpServers: [
-      { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' }
+      {
+        id: 'cust-1',
+        name: 'my-server',
+        displayName: 'My Server',
+        transport: 'stdio',
+        enabled: true,
+        command: 'run'
+      }
     ]
   })
 }
@@ -196,13 +203,13 @@ gate('host.agents repl integration', () => {
     }
   }, 60_000)
 
-  it('host.agents.list_skills() returns the full catalog including Main-disabled skills', async () => {
+  it('host.agents.listSkills() returns the full catalog including Main-disabled skills', async () => {
     const { child, send } = startLoop({
       OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
       OPEN_SCIENCE_MCP_RPC_TOKEN: token
     })
     try {
-      const r = await send('return JSON.stringify(await host.agents.list_skills())')
+      const r = await send('return JSON.stringify(await host.agents.listSkills())')
       expect(r.error).toBeNull()
       const skills = JSON.parse(r.result ?? '[]')
       expect(skills.find((s: { id: string }) => s.id === 'personal-foo').mainEnabled).toBe(false)
@@ -212,13 +219,13 @@ gate('host.agents repl integration', () => {
     }
   }, 60_000)
 
-  it('host.agents.list_skills() filters by exact stable id', async () => {
+  it('host.agents.listSkills() filters by exact stable id', async () => {
     const { child, send } = startLoop({
       OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
       OPEN_SCIENCE_MCP_RPC_TOKEN: token
     })
     try {
-      const r = await send("return JSON.stringify(await host.agents.list_skills('personal-foo'))")
+      const r = await send("return JSON.stringify(await host.agents.listSkills('personal-foo'))")
       expect(r.error).toBeNull()
       const skills = JSON.parse(r.result ?? '[]')
       expect(skills).toHaveLength(1)
@@ -228,14 +235,14 @@ gate('host.agents repl integration', () => {
     }
   }, 60_000)
 
-  it('host.agents.list_skills() rejects an ambiguous public name with a stable-id hint', async () => {
+  it('host.agents.listSkills() rejects an ambiguous immutable name with a stable-id hint', async () => {
     const { child, send } = startLoop({
       OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
       OPEN_SCIENCE_MCP_RPC_TOKEN: token
     })
     try {
       const r = await send(
-        "try { await host.agents.list_skills('dup'); return 'no-throw' } catch (e) { return e.message }"
+        "try { await host.agents.listSkills('dup'); return 'no-throw' } catch (e) { return e.message }"
       )
       expect(r.result).toMatch(/stable id/)
     } finally {
@@ -243,13 +250,13 @@ gate('host.agents repl integration', () => {
     }
   }, 60_000)
 
-  it('host.agents.list_connectors() projects connectors without secrets', async () => {
+  it('host.agents.listConnectors() projects connectors without secrets', async () => {
     const { child, send } = startLoop({
       OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
       OPEN_SCIENCE_MCP_RPC_TOKEN: token
     })
     try {
-      const r = await send('return JSON.stringify(await host.agents.list_connectors())')
+      const r = await send('return JSON.stringify(await host.agents.listConnectors())')
       expect(r.error).toBeNull()
       const text = r.result ?? ''
       // No secret material leaks.

--- a/src/main/agents/agents-repl.mutations.integration.test.ts
+++ b/src/main/agents/agents-repl.mutations.integration.test.ts
@@ -83,8 +83,21 @@ const stubCatalog: AgentsCatalogSource = {
     autoAllowIds: [],
     disabledConnectorIds: [],
     customMcpServers: [
-      { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' },
-      { id: 'cust-dead', name: 'Dead Server', transport: 'stdio', enabled: true }
+      {
+        id: 'cust-1',
+        name: 'my-server',
+        displayName: 'My Server',
+        transport: 'stdio',
+        enabled: true,
+        command: 'run'
+      },
+      {
+        id: 'cust-dead',
+        name: 'dead-server',
+        displayName: 'Dead Server',
+        transport: 'stdio',
+        enabled: true
+      }
     ]
   })
 }
@@ -157,11 +170,11 @@ gate('host.agents repl mutation integration', () => {
     }
   }, 60_000)
 
-  it('create() with skill_names produces Selected and resolves a public name to a stable id', async () => {
+  it('create() with skillNames produces Selected and resolves a public name to a stable id', async () => {
     const { child, send } = startLoop(env())
     try {
       const r = await send(
-        "return JSON.stringify(await host.agents.create({ name: 'SelBot', skill_names: ['foo'] }))"
+        "return JSON.stringify(await host.agents.create({ name: 'SelBot', skillNames: ['foo'] }))"
       )
       expect(r.error).toBeNull()
       const created = JSON.parse(r.result ?? '{}')
@@ -177,7 +190,7 @@ gate('host.agents repl mutation integration', () => {
     const { child, send } = startLoop(env())
     try {
       const r = await send(
-        "return JSON.stringify(await host.agents.create({ name: 'ConnBot', connector_names: ['cust-1'] }))"
+        "return JSON.stringify(await host.agents.create({ name: 'ConnBot', connectorNames: ['cust-1'] }))"
       )
       expect(r.error).toBeNull()
       const created = JSON.parse(r.result ?? '{}')
@@ -199,7 +212,7 @@ gate('host.agents repl mutation integration', () => {
         ).result ?? '{}'
       )
       const r = await send(
-        `return JSON.stringify(await host.agents.update('UpdBot', { revision: ${created.revision}, description: 'after', skill_names: ['demo'] }))`
+        `return JSON.stringify(await host.agents.update('UpdBot', { revision: ${created.revision}, description: 'after', skillNames: ['demo'] }))`
       )
       expect(r.error).toBeNull()
       const updated = JSON.parse(r.result ?? '{}')
@@ -219,7 +232,7 @@ gate('host.agents repl mutation integration', () => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'SwitchBot', skill_names: ['demo'] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'SwitchBot', skillNames: ['demo'] }))"
           )
         ).result ?? '{}'
       )
@@ -236,13 +249,13 @@ gate('host.agents repl mutation integration', () => {
     }
   }, 60_000)
 
-  it('attach_skill / detach_skill mutate the current mode without switching it', async () => {
+  it('attachSkill / detachSkill mutate the current mode without switching it', async () => {
     const { child, send } = startLoop(env())
     try {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'AttachBot', skill_names: [] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'AttachBot', skillNames: [] }))"
           )
         ).result ?? '{}'
       )
@@ -250,7 +263,7 @@ gate('host.agents repl mutation integration', () => {
       const attached = JSON.parse(
         (
           await send(
-            `return JSON.stringify(await host.agents.attach_skill('AttachBot', 'demo', { revision: ${created.revision} }))`
+            `return JSON.stringify(await host.agents.attachSkill('AttachBot', 'demo', { revision: ${created.revision} }))`
           )
         ).result ?? '{}'
       )
@@ -260,7 +273,7 @@ gate('host.agents repl mutation integration', () => {
       const detached = JSON.parse(
         (
           await send(
-            `return JSON.stringify(await host.agents.detach_skill('AttachBot', 'demo', { revision: ${attached.revision} }))`
+            `return JSON.stringify(await host.agents.detachSkill('AttachBot', 'demo', { revision: ${attached.revision} }))`
           )
         ).result ?? '{}'
       )
@@ -271,20 +284,20 @@ gate('host.agents repl mutation integration', () => {
     }
   }, 60_000)
 
-  it('attach_connector / detach_connector follow the same mode rules', async () => {
+  it('attachConnector / detachConnector follow the same mode rules', async () => {
     const { child, send } = startLoop(env())
     try {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'ConnAttachBot', connector_names: [] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'ConnAttachBot', connectorNames: [] }))"
           )
         ).result ?? '{}'
       )
       const attached = JSON.parse(
         (
           await send(
-            `return JSON.stringify(await host.agents.attach_connector('ConnAttachBot', 'cust-1', { revision: ${created.revision} }))`
+            `return JSON.stringify(await host.agents.attachConnector('ConnAttachBot', 'cust-1', { revision: ${created.revision} }))`
           )
         ).result ?? '{}'
       )
@@ -292,7 +305,7 @@ gate('host.agents repl mutation integration', () => {
       const detached = JSON.parse(
         (
           await send(
-            `return JSON.stringify(await host.agents.detach_connector('ConnAttachBot', 'cust-1', { revision: ${attached.revision} }))`
+            `return JSON.stringify(await host.agents.detachConnector('ConnAttachBot', 'cust-1', { revision: ${attached.revision} }))`
           )
         ).result ?? '{}'
       )
@@ -319,7 +332,7 @@ gate('host.agents repl mutation integration', () => {
     const { child, send } = startLoop(env())
     try {
       const r = await send(
-        "try { await host.agents.create({ name: 'AmbigBot', skill_names: ['nope'] }); return 'no-throw' } catch (e) { return e.message }"
+        "try { await host.agents.create({ name: 'AmbigBot', skillNames: ['nope'] }); return 'no-throw' } catch (e) { return e.message }"
       )
       expect(r.result).toMatch(/host\.agents\.create:/)
       expect(r.result).toMatch(/stable id|No skill matches/)
@@ -334,14 +347,14 @@ gate('host.agents repl mutation integration', () => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'GateBot', connector_names: [] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'GateBot', connectorNames: [] }))"
           )
         ).result ?? '{}'
       )
       const r = await send(
-        `try { await host.agents.attach_connector('GateBot', 'cust-dead', { revision: ${created.revision} }); return 'no-throw' } catch (e) { return e.message }`
+        `try { await host.agents.attachConnector('GateBot', 'cust-dead', { revision: ${created.revision} }); return 'no-throw' } catch (e) { return e.message }`
       )
-      expect(r.result).toMatch(/host\.agents\.attach_connector:/)
+      expect(r.result).toMatch(/host\.agents\.attachConnector:/)
     } finally {
       child.kill()
     }
@@ -354,12 +367,12 @@ gate('host.agents repl mutation integration', () => {
     // them. (delete/switch are the privileged ops that require approval; they are out of scope here.)
     const { child, send } = startLoop(env())
     try {
-      // Create in Selected mode (skill_names: []) so attach_skill mutates inclusions; the point is
+      // Create in Selected mode (skillNames: []) so attachSkill mutates inclusions; the point is
       // that the whole round-trip completes with no approval gateway wired.
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'NoCardBot', description: 'd', skill_names: [] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'NoCardBot', description: 'd', skillNames: [] }))"
           )
         ).result ?? '{}'
       )
@@ -376,7 +389,7 @@ gate('host.agents repl mutation integration', () => {
       const attached = JSON.parse(
         (
           await send(
-            `return JSON.stringify(await host.agents.attach_skill('NoCardBot', 'demo', { revision: ${updated.revision} }))`
+            `return JSON.stringify(await host.agents.attachSkill('NoCardBot', 'demo', { revision: ${updated.revision} }))`
           )
         ).result ?? '{}'
       )

--- a/src/main/agents/agents-repl.privileged.integration.test.ts
+++ b/src/main/agents/agents-repl.privileged.integration.test.ts
@@ -30,8 +30,8 @@ import type { ApprovalGateway, ApprovalResult } from '../../shared/agents-contra
 // SwitchNotifier broadcast, and the catalog-invalidation callback.
 //
 // Coverage (design.md §15 / acceptance criteria 1, 4, 6):
-//  - a name-changing update committed atomically through host.agents.update, returning real post-write
-//    read-back (not echoed input) and BYPASSING the approval gateway (renames are ordinary
+//  - a displayName update committed atomically through host.agents.update, returning real post-write
+//    read-back (not echoed input) and BYPASSING the approval gateway (ordinary updates are
 //    chat-reviewed mutations, not privileged);
 //  - delete through the pass-through gateway: bound conversations are left unavailable (bindings are
 //    NOT silently cleared);
@@ -40,8 +40,8 @@ import type { ApprovalGateway, ApprovalResult } from '../../shared/agents-contra
 //    notification is broadcast;
 //  - a structured DECLINE on a configurable approval gateway returns a non-error result for both
 //    delete and switch, with no mutation/persist/notify;
-//  - optimistic concurrency: a stale revision fails for both an ordinary update and a name-changing
-//    update, without merge or retry.
+//  - optimistic concurrency: a stale revision fails for ordinary updates, including displayName
+//    updates, without merge or retry.
 //
 // Notes on what this milestone ships vs. what is deferred:
 //  - The pass-through approval gateway always approves; it is the milestone substitution seam
@@ -49,8 +49,8 @@ import type { ApprovalGateway, ApprovalResult } from '../../shared/agents-contra
 //    structured decline shape, proving the dispatcher honors the gateway seam. The pass-through
 //    gateway itself never declines by design.
 //  - The public `host.agents` SDK exposes first-class `switch()`/`delete()` methods alongside
-//    `update` (which routes name-changing patches through the privileged module). Those SDK methods
-//    are exercised end-to-end below. The `agentsCall` fetch helper is retained for cases that must
+//    ordinary `update`. Those SDK methods are exercised end-to-end below. The `agentsCall` fetch
+//    helper is retained for cases that must
 //    drive the transport BELOW the SDK surface — smuggling forged identity keys to prove the
 //    dispatcher strips reserved keys, and other transport-level assertions.
 //  - Trusted-session capture and forged-identity rejection for ordinary reads are covered end-to-end
@@ -107,7 +107,14 @@ const stubCatalog: AgentsCatalogSource = {
     autoAllowIds: [],
     disabledConnectorIds: [],
     customMcpServers: [
-      { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' }
+      {
+        id: 'cust-1',
+        name: 'my-server',
+        displayName: 'My Server',
+        transport: 'stdio',
+        enabled: true,
+        command: 'run'
+      }
     ]
   })
 }
@@ -387,23 +394,24 @@ gate('host.agents repl privileged integration', () => {
     expect(invalidateCount()).toBeGreaterThan(invalidatedBefore)
   })
 
-  it('a name-changing update is an ordinary mutation: no approval gateway, atomic single-profile commit, real read-back', async () => {
+  it('a displayName update is an ordinary mutation: no approval gateway, atomic single-profile commit, real read-back', async () => {
     await withLoop(undefined, async (send) => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'ATOM_PROBE', description: 'before' }))"
+            "return JSON.stringify(await host.agents.create({ name: 'ATOM_PROBE', displayName: 'Atom Probe', description: 'before' }))"
           )
         ).result ?? '{}'
       )
-      // A patch that changes the public `name` applies like any other update field (renames are
-      // chat-reviewed, not privileged): the SDK returns the real camelCase profile read-back.
+      // A displayName patch applies like any other update field: the SDK returns the real camelCase
+      // profile read-back while the invocation name remains immutable.
       const r = await send(
-        `return JSON.stringify(await host.agents.update('ATOM_PROBE', { name: 'ATOM_ANALYZER', description: 'after', revision: ${created.revision} }))`
+        `return JSON.stringify(await host.agents.update('ATOM_PROBE', { displayName: 'Atom Analyzer', description: 'after', revision: ${created.revision} }))`
       )
       expect(r.error).toBeNull()
       const updated = JSON.parse(r.result ?? '{}')
-      expect(updated.name).toBe('ATOM_ANALYZER')
+      expect(updated.name).toBe('ATOM_PROBE')
+      expect(updated.displayName).toBe('Atom Analyzer')
       expect(updated.description).toBe('after')
       // Revision was bumped by the authoritative ProfileService, not echoed.
       expect(updated.revision).toBe(created.revision + 1)
@@ -472,44 +480,44 @@ gate('host.agents repl privileged integration', () => {
     expect(invalidateCount()).toBeGreaterThan(invalidatedBefore)
   })
 
-  it('a name-changing update keeps stable conversation bindings: the binding follows the profile (UUID), not the name', async () => {
-    // design.md §4/§10: stable conversation bindings are UUID-based. A rename changes the public name
-    // but NOT the UUID, so an already-bound conversation keeps resolving the SAME profile under its new
-    // name. This is the integration proof of the rename-keeps-binding contract.
+  it('a displayName update keeps stable conversation bindings and the immutable invocation name', async () => {
+    // Stable conversation bindings are UUID-based. A displayName update changes neither the UUID nor
+    // the invocation name, so an already-bound conversation keeps resolving the same profile.
     await withLoop(undefined, async (send) => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'RENAME_OLD', description: 'x' }))"
+            "return JSON.stringify(await host.agents.create({ name: 'RENAME_OLD', displayName: 'Old Label', description: 'x' }))"
           )
         ).result ?? '{}'
       )
       // Simulate an existing conversation bound to this Specialist by its stable UUID.
-      durableBindings.set('session-bound-rename', created.id)
-      sessionBinding.setBinding('session-bound-rename', created.id)
-      // Before the rename, the binding resolves bound under the old name.
-      const before = await sessionBinding.resolve('session-bound-rename')
+      durableBindings.set('session-bound-display', created.id)
+      sessionBinding.setBinding('session-bound-display', created.id)
+      // Before the update, the binding resolves the profile.
+      const before = await sessionBinding.resolve('session-bound-display')
       expect(before.kind).toBe('bound')
 
-      // Name-changing update (ordinary chat-reviewed mutation).
+      // displayName update (ordinary chat-reviewed mutation).
       const r = await send(
-        `return JSON.stringify(await host.agents.update('RENAME_OLD', { name: 'RENAME_NEW', revision: ${created.revision} }))`
+        `return JSON.stringify(await host.agents.update('RENAME_OLD', { displayName: 'New Label', revision: ${created.revision} }))`
       )
       const updated = JSON.parse(r.result ?? '{}')
-      expect(updated.name).toBe('RENAME_NEW')
-      // The UUID is unchanged across the rename.
+      expect(updated.name).toBe('RENAME_OLD')
+      expect(updated.displayName).toBe('New Label')
+      // The UUID is unchanged across the update.
       expect(updated.id).toBe(created.id)
 
-      // The bound conversation STILL resolves the SAME profile (now under its new name) — the binding
-      // follows the profile (UUID), not the public name. No integration code rewrites it.
-      const after = await sessionBinding.resolve('session-bound-rename')
+      // The bound conversation still resolves the same profile. No integration code rewrites it.
+      const after = await sessionBinding.resolve('session-bound-display')
       expect(after.kind).toBe('bound')
       if (after.kind === 'bound') {
         expect(after.profile.id).toBe(created.id)
-        expect(after.profile.name).toBe('RENAME_NEW')
+        expect(after.profile.name).toBe('RENAME_OLD')
+        expect(after.profile.displayName).toBe('New Label')
       }
       // The durable binding record is untouched.
-      expect(durableBindings.get('session-bound-rename')).toBe(created.id)
+      expect(durableBindings.get('session-bound-display')).toBe(created.id)
     })
   })
 
@@ -654,18 +662,18 @@ gate('host.agents repl privileged integration', () => {
     })
   })
 
-  it('optimistic concurrency: a stale revision on a name-changing update fails without merge or retry', async () => {
+  it('optimistic concurrency: a stale revision on a displayName update fails without merge or retry', async () => {
     await withLoop(undefined, async (send) => {
       await send("return JSON.stringify(await host.agents.create({ name: 'STALE_PRIV' }))")
       const r = await send(
-        "try { await host.agents.update('STALE_PRIV', { name: 'STALE_PRIV_RENAMED', revision: 999 }); return 'no-throw' } catch (e) { return e.message }"
+        "try { await host.agents.update('STALE_PRIV', { displayName: 'Stale Label', revision: 999 }); return 'no-throw' } catch (e) { return e.message }"
       )
       // The ordinary update path fails closed on revision drift with a sanitized host.agents.update: error.
       expect(r.result).toMatch(/host\.agents\.update:/)
     })
   })
 
-  it('a name-changing update bypasses the approval gateway entirely (renames are not privileged)', async () => {
+  it('a displayName update bypasses the approval gateway entirely', async () => {
     const decide = vi.fn(async (): Promise<ApprovalResult> => ({
       status: 'declined',
       operation: 'delete'
@@ -703,16 +711,17 @@ gate('host.agents repl privileged integration', () => {
         const created = JSON.parse(
           (
             await send(
-              "return JSON.stringify(await host.agents.create({ name: 'ATOMIC_OLD', description: 'keep-me' }))"
+              "return JSON.stringify(await host.agents.create({ name: 'ATOMIC_OLD', displayName: 'Atomic Old', description: 'keep-me' }))"
             )
           ).result ?? '{}'
         )
         const r = await send(
-          `return JSON.stringify(await host.agents.update('ATOMIC_OLD', { name: 'ATOMIC_NEW', description: 'applied', revision: ${created.revision} }))`
+          `return JSON.stringify(await host.agents.update('ATOMIC_OLD', { displayName: 'Atomic New', description: 'applied', revision: ${created.revision} }))`
         )
         const result = JSON.parse(r.result ?? '{}')
-        // Rename applied directly; even a decline-configured gateway is never consulted.
-        expect(result.name).toBe('ATOMIC_NEW')
+        // Ordinary update applied directly; even a decline-configured gateway is never consulted.
+        expect(result.name).toBe('ATOMIC_OLD')
+        expect(result.displayName).toBe('Atomic New')
         expect(result.description).toBe('applied')
         expect(decide).not.toHaveBeenCalled()
       } finally {

--- a/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
+++ b/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
@@ -100,7 +100,14 @@ const stubCatalog: AgentsCatalogSource = {
     autoAllowIds: [],
     disabledConnectorIds: [],
     customMcpServers: [
-      { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' }
+      {
+        id: 'cust-1',
+        name: 'my-server',
+        displayName: 'My Server',
+        transport: 'stdio',
+        enabled: true,
+        command: 'run'
+      }
     ]
   })
 }
@@ -175,7 +182,7 @@ gate('host.agents repl runtime whitelist consumption', () => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'SKILL_SET', skill_names: ['demo'] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'SKILL_SET', skillNames: ['demo'] }))"
           )
         ).result ?? '{}'
       )
@@ -198,7 +205,7 @@ gate('host.agents repl runtime whitelist consumption', () => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'MAIN_DIS_SKILL', skill_names: ['foo'] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'MAIN_DIS_SKILL', skillNames: ['foo'] }))"
           )
         ).result ?? '{}'
       )
@@ -213,19 +220,19 @@ gate('host.agents repl runtime whitelist consumption', () => {
     })
   })
 
-  it('attach_skill changes the consumed whitelist without switching mode (Selected inclusion grows)', async () => {
+  it('attachSkill changes the consumed whitelist without switching mode (Selected inclusion grows)', async () => {
     await withLoop(async (send) => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'ATTACH_RT', skill_names: ['demo'] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'ATTACH_RT', skillNames: ['demo'] }))"
           )
         ).result ?? '{}'
       )
       const after = JSON.parse(
         (
           await send(
-            `return JSON.stringify(await host.agents.attach_skill('ATTACH_RT', 'foo', { revision: ${created.revision} }))`
+            `return JSON.stringify(await host.agents.attachSkill('ATTACH_RT', 'foo', { revision: ${created.revision} }))`
           )
         ).result ?? '{}'
       )
@@ -245,7 +252,7 @@ gate('host.agents repl runtime whitelist consumption', () => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'CONN_SET', connector_names: ['cust-1'] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'CONN_SET', connectorNames: ['cust-1'] }))"
           )
         ).result ?? '{}'
       )
@@ -266,7 +273,7 @@ gate('host.agents repl runtime whitelist consumption', () => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'TO_FULL', skill_names: ['demo'] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'TO_FULL', skillNames: ['demo'] }))"
           )
         ).result ?? '{}'
       )
@@ -288,19 +295,19 @@ gate('host.agents repl runtime whitelist consumption', () => {
     })
   })
 
-  it('detach_skill shrinks the consumed whitelist without switching mode', async () => {
+  it('detachSkill shrinks the consumed whitelist without switching mode', async () => {
     await withLoop(async (send) => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'DETACH_RT', skill_names: ['demo', 'foo'] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'DETACH_RT', skillNames: ['demo', 'foo'] }))"
           )
         ).result ?? '{}'
       )
       const after = JSON.parse(
         (
           await send(
-            `return JSON.stringify(await host.agents.detach_skill('DETACH_RT', 'demo', { revision: ${created.revision} }))`
+            `return JSON.stringify(await host.agents.detachSkill('DETACH_RT', 'demo', { revision: ${created.revision} }))`
           )
         ).result ?? '{}'
       )
@@ -312,13 +319,13 @@ gate('host.agents repl runtime whitelist consumption', () => {
     })
   })
 
-  it('snake_case writes produce camelCase read-back the runtime consumes unchanged', async () => {
+  it('camelCase writes produce camelCase read-back the runtime consumes unchanged', async () => {
     await withLoop(async (send) => {
-      // snake_case write fields on create.
+      // camelCase write fields on create.
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'CASE_MAP', description: 'd', system_prompt: 'p', icon_key: 'beaker', color_key: 'green', skill_names: ['demo'] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'CASE_MAP', description: 'd', systemPrompt: 'p', iconKey: 'beaker', colorKey: 'green', skillNames: ['demo'] }))"
           )
         ).result ?? '{}'
       )

--- a/src/main/agents/agents-service.test.ts
+++ b/src/main/agents/agents-service.test.ts
@@ -109,17 +109,26 @@ describe('AgentsService read surface', () => {
       autoAllowIds: [],
       disabledConnectorIds: ['chemistry'],
       customMcpServers: [
-        { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' },
+        {
+          id: 'cust-1',
+          name: 'my-server',
+          displayName: 'My Server',
+          transport: 'stdio',
+          enabled: true,
+          command: 'run'
+        },
         {
           id: 'cust-reserved',
-          name: 'Chemistry!',
+          name: 'chemistry',
+          displayName: 'Chemistry!',
           transport: 'stdio',
           enabled: true,
           command: 'run'
         },
         {
           id: 'oauth-1',
-          name: 'OAuth Server',
+          name: 'oauth-server',
+          displayName: 'OAuth Server',
           transport: 'streamable_http',
           enabled: true,
           url: 'https://mcp.example.test',
@@ -243,7 +252,14 @@ describe('AgentsService connector runtime availability', () => {
       enabledIds: [],
       autoAllowIds: [],
       customMcpServers: [
-        { id: 'cust-1', name: 'My Server', transport: 'stdio', enabled: true, command: 'run' }
+        {
+          id: 'cust-1',
+          name: 'my-server',
+          displayName: 'My Server',
+          transport: 'stdio',
+          enabled: true,
+          command: 'run'
+        }
       ]
     }
     const profiles = mutatingProfileService([profile()])
@@ -290,7 +306,7 @@ describe('AgentsService privileged dispatch — trusted session threading', () =
     expect(seenSessions).toEqual([{ sessionId: 'trusted-session-1' }])
   })
 
-  it('applies a rename as an ordinary mutation without consulting the approval gateway', async () => {
+  it('updates displayName without changing immutable name or consulting approval', async () => {
     const decided: unknown[] = []
     const service = new AgentsService({
       profileService: mutatingProfileService([profile()]),
@@ -307,13 +323,14 @@ describe('AgentsService privileged dispatch — trusted session threading', () =
         op: 'update',
         params: {
           name: 'Bio Expert',
-          patch: { name: 'Chem Expert', revision: 3 }
+          patch: { display_name: 'Chem Expert', revision: 3 }
         }
       },
       { sessionId: 'trusted-session-2' }
     )
-    // Renames are ordinary chat-reviewed updates: the rename lands and no approval card is parked.
-    expect(result).toEqual<SpecialistProfileView>(expect.objectContaining({ name: 'Chem Expert' }))
+    expect(result).toEqual<SpecialistProfileView>(
+      expect.objectContaining({ name: 'Bio Expert', displayName: 'Chem Expert' })
+    )
     expect(decided).toHaveLength(0)
   })
 

--- a/src/main/agents/agents-service.ts
+++ b/src/main/agents/agents-service.ts
@@ -22,7 +22,6 @@ import type { ProfileService } from '../specialist/service'
 import type { SessionBindingService } from '../specialist/session-binding'
 import type { SpecialistProfileView } from '../../shared/specialist'
 import type { StoredConnectors } from '../settings/types'
-import { customConnectorSlug } from '../../shared/custom-connector'
 import {
   isAgentsOpName,
   isAgentsParams,
@@ -85,7 +84,7 @@ export type AgentsServiceDeps = {
   sessionBinding?: SessionBindingService
   persistSessionSpecialist?: (sessionId: string, specialistId: string | undefined) => Promise<void>
   // Invalidates the runtime catalog (Settings/picker/runtime capability resolution) after a successful
-  // privileged mutation (delete). Ordinary mutations (including renames) already invalidate via the
+  // privileged mutation (delete). Ordinary mutations already invalidate via the
   // existing ProfileService/catalog-change broadcast path; the privileged delete runs through a
   // dedicated module that calls this only on success. Wired in issue 08.
   invalidateCatalog?: () => Promise<void> | void
@@ -127,6 +126,7 @@ export type ConnectorToolReadModel = {
 
 export type ConnectorReadModel = {
   id: string
+  name: string
   displayName: string
   description: string
   mainEnabled: boolean
@@ -220,8 +220,7 @@ export class AgentsService {
       if (opName === 'get') return await this.get(params)
       if (opName === 'list_skills') return await this.listSkills(params)
       if (opName === 'list_connectors') return await this.listConnectors(params)
-      // Ordinary mutations (issue 03): create, update (including renames — update is an ordinary
-      // chat-reviewed mutation for every field, no approval card), and whole-Skill/whole-Connector
+      // Ordinary mutations (issue 03): create, update of mutable fields, and whole-Skill/whole-Connector
       // attach/detach. Routed to the standalone mutation module, which delegates to ProfileService,
       // resolves name/id references, gates unavailable connectors, and returns a real read-back.
       if (
@@ -367,12 +366,12 @@ export class AgentsService {
   }
 
   // Returns the complete Specialist-visible skill catalog, including Main-disabled installed
-  // Skills. Optional name_or_id filters to one entry via stable ID first, then unique public name.
+  // Skills. Optional name_or_id filters to one entry via stable ID first, then immutable name.
   async listSkills(params: { name_or_id?: unknown }): Promise<SkillCatalogReadModel[]> {
     const catalog = await this.deps.catalog.listSkillCatalog()
     const entries = catalog.map((skill) => ({
       id: skill.id,
-      // Public name: the durable framework-facing name the agent/Skill chip uses.
+      // Immutable framework-facing invocation name; chips render displayName.
       name: skill.frameworkName,
       displayName: skill.displayName,
       source: skill.source,
@@ -416,6 +415,7 @@ export const projectConnectorsFromStored = (
   const disabled = new Set(stored?.disabledConnectorIds ?? [])
   const bundled: ConnectorReadModel[] = (CONNECTOR_CATALOG as ConnectorMeta[]).map((meta) => ({
     id: meta.id,
+    name: meta.id,
     displayName: meta.displayName,
     description: meta.description,
     mainEnabled: !disabled.has(meta.id),
@@ -437,9 +437,10 @@ export const projectConnectorsFromStored = (
         (server.transport !== 'stdio' && !server.url)
       const unauthenticated = Boolean(server.oauth && !server.oauthState?.tokens?.access_token)
       return {
-        // The slug is the immutable public route; the UUID remains local Settings/OAuth identity.
-        id: customConnectorSlug(server),
-        displayName: server.name,
+        // The name is the immutable public route; the UUID remains local Settings/OAuth identity.
+        id: server.name,
+        name: server.name,
+        displayName: server.displayName,
         description: server.description ?? '',
         mainEnabled: server.enabled && !unauthenticated,
         // Custom MCP servers expose their tools dynamically; we do not enumerate them here (the
@@ -476,15 +477,15 @@ export function applyNameOrIdFilter<T extends Nameable>(
   const byId = entries.filter((entry) => entry.id === ref)
   if (byId.length > 0) return byId
 
-  // 2. Otherwise match a unique public name (name, then display name).
-  const byName = entries.filter((entry) => entry.name === ref || entry.displayName === ref)
+  // 2. Otherwise match a unique immutable public name. Display labels are never references.
+  const byName = entries.filter((entry) => entry.name === ref)
   if (byName.length === 0) {
     throw new Error(
-      `No catalog entry matches "${ref}". Use the stable id from list_skills/list_connectors.`
+      `No catalog entry matches "${ref}". Use the stable id from listSkills()/listConnectors().`
     )
   }
   if (byName.length > 1) {
-    // Ambiguous public name: instruct the caller to use the stable id instead of guessing.
+    // Ambiguous immutable name: instruct the caller to use the stable id instead of guessing.
     const ids = byName.map((entry) => entry.id).join(', ')
     throw new Error(
       `Multiple catalog entries match name "${ref}" (${ids}). Use the stable id from ${method} instead.`

--- a/src/main/agents/customize/fake-host-agents.ts
+++ b/src/main/agents/customize/fake-host-agents.ts
@@ -2,8 +2,8 @@
 //
 // The real SDK lives in the control-plane REPL and is wired by issue 08. This fake implements the
 // FULL public surface from design.md §4 / PRD §2 against in-memory state, so the customize Skill's
-// workflow tests can exercise create/read/ordinary-update/capability-update/name-changing-update/
-// delete/switch with the snake_case-write / camelCase-return contract, the monotonic revision, the
+// workflow tests can exercise create/read/update/capability-update/delete/switch with the camelCase
+// JavaScript contract, the monotonic revision, the
 // structured decline result, and the sanitized `host.agents.<method>:` errors — without depending on
 // the not-yet-built mutation modules (issues 03/04/05).
 //
@@ -14,12 +14,13 @@
 import type { AgentReadModel, ConnectorReadModel, SkillCatalogReadModel } from '../agents-service'
 
 // ---------------------------------------------------------------------------
-// Internal fake state (snake_case write side; camelCase read models mirror the real SDK)
+// Internal fake state
 // ---------------------------------------------------------------------------
 
 export type FakeProfileRecord = {
   id: string
   name: string
+  displayName: string
   description: string
   systemPrompt: string
   iconKey?: string
@@ -42,7 +43,7 @@ export type FakeHostAgentsOptions = {
   // real ACP broker; the customize Skill tests wire a recording fake.
   approvalGateway?: {
     decide: (request: {
-      operation: 'update' | 'delete' | 'switch'
+      operation: 'delete' | 'switch'
       summary: { name?: string; newName?: string; target?: string | null }
     }) => Promise<{ status: 'approved' | 'declined'; reason?: string }>
   }
@@ -94,7 +95,7 @@ export class FakeHostAgents {
   // ----- read models (camelCase) -------------------------------------------------
 
   // Validates that every supplied Skill/Connector reference resolves against the live catalog
-  // (exact stable id first, otherwise unique public name). Mirrors the real catalog resolution so
+  // (exact stable id first, otherwise unique immutable name). Mirrors the real catalog resolution so
   // the customize Skill's review reflects only attachable references. design.md §4.
   private validateCatalogRefs(
     skillNames: string[],
@@ -102,12 +103,12 @@ export class FakeHostAgents {
     method: string
   ): void {
     for (const ref of skillNames) {
-      if (!this.skills.some((s) => s.id === ref || s.name === ref || s.displayName === ref)) {
+      if (!this.skills.some((s) => s.id === ref || s.name === ref)) {
         throw agentsError(method, `Unknown skill reference "${ref}"`)
       }
     }
     for (const ref of connectorNames) {
-      if (!this.connectors.some((c) => c.id === ref || c.displayName === ref)) {
+      if (!this.connectors.some((c) => c.id === ref || c.name === ref)) {
         throw agentsError(method, `Unknown connector reference "${ref}"`)
       }
     }
@@ -117,7 +118,7 @@ export class FakeHostAgents {
     return {
       id: profile.id,
       name: profile.name,
-      displayName: profile.name,
+      displayName: profile.displayName,
       description: profile.description,
       systemPrompt: profile.systemPrompt,
       iconKey: profile.iconKey,
@@ -152,51 +153,53 @@ export class FakeHostAgents {
     return this.project(profile)
   }
 
-  async list_skills(nameOrId?: string): Promise<FakeSkillCatalogEntry[]> {
+  async listSkills(nameOrId?: string): Promise<FakeSkillCatalogEntry[]> {
     if (!nameOrId) return clone(this.skills)
-    return applyNameOrIdFilter(this.skills, nameOrId, 'list_skills')
+    return applyNameOrIdFilter(this.skills, nameOrId, 'listSkills')
   }
 
-  async list_connectors(nameOrId?: string): Promise<FakeConnectorCatalogEntry[]> {
+  async listConnectors(nameOrId?: string): Promise<FakeConnectorCatalogEntry[]> {
     if (!nameOrId) return clone(this.connectors)
-    return applyNameOrIdFilter(this.connectors, nameOrId, 'list_connectors')
+    return applyNameOrIdFilter(this.connectors, nameOrId, 'listConnectors')
   }
 
   // ----- create ------------------------------------------------------------------
 
   async create(input: {
     name: string
+    displayName?: string
     description?: string
-    system_prompt?: string
-    icon_key?: string
-    color_key?: string
+    systemPrompt?: string
+    iconKey?: string
+    colorKey?: string
     enabled?: boolean
     unrestricted?: boolean
-    skill_names?: string[]
-    connector_names?: string[]
+    skillNames?: string[]
+    connectorNames?: string[]
   }): Promise<AgentReadModel> {
     const method = 'create'
     const name = input.name
     if (!name || typeof name !== 'string') throw agentsError(method, 'name is required')
     if (this.profiles.has(name)) throw agentsError(method, `Specialist "${name}" already exists`)
 
-    const hasSkillNames = input.skill_names !== undefined
-    const hasConnectorNames = input.connector_names !== undefined
+    const hasSkillNames = input.skillNames !== undefined
+    const hasConnectorNames = input.connectorNames !== undefined
     // design.md §5: omit both arrays => Full; supply either => Selected (omitted other => empty).
     const unrestricted =
       (input.unrestricted ?? !(hasSkillNames || hasConnectorNames)) ? true : false
 
-    const skillNames = input.skill_names ?? (unrestricted ? [] : [])
-    const connectorNames = input.connector_names ?? (unrestricted ? [] : [])
+    const skillNames = input.skillNames ?? (unrestricted ? [] : [])
+    const connectorNames = input.connectorNames ?? (unrestricted ? [] : [])
     this.validateCatalogRefs(skillNames, connectorNames, method)
 
     const record: FakeProfileRecord = {
       id: `sp-${this.nextId++}`,
       name,
+      displayName: input.displayName ?? name,
       description: input.description ?? '',
-      systemPrompt: input.system_prompt ?? '',
-      iconKey: input.icon_key,
-      colorKey: input.color_key,
+      systemPrompt: input.systemPrompt ?? '',
+      iconKey: input.iconKey,
+      colorKey: input.colorKey,
       enabled: input.enabled ?? true,
       unrestricted,
       skillIds: skillNames,
@@ -207,20 +210,20 @@ export class FakeHostAgents {
     return this.project(record)
   }
 
-  // ----- ordinary + name-changing update -----------------------------------------
+  // ----- update ------------------------------------------------------------------
 
   async update(
     name: string,
     patch: {
-      name?: string
+      displayName?: string
       description?: string
-      system_prompt?: string
-      icon_key?: string
-      color_key?: string
+      systemPrompt?: string
+      iconKey?: string
+      colorKey?: string
       enabled?: boolean
       unrestricted?: boolean
-      skill_names?: string[]
-      connector_names?: string[]
+      skillNames?: string[]
+      connectorNames?: string[]
       revision?: number
     }
   ): Promise<AgentReadModel> {
@@ -233,57 +236,33 @@ export class FakeHostAgents {
       throw agentsError(method, 'stale revision — re-read and review again')
     }
 
-    const isNameChange = patch.name !== undefined && patch.name !== name
-    if (isNameChange) {
-      // design.md §4/§7: a name change makes the WHOLE patch privileged. The standard permission card
-      // is the single authorization point; approve => apply atomically, decline => no change.
-      const decision = await this.approvalGateway?.decide({
-        operation: 'update',
-        summary: { name, newName: patch.name }
-      })
-      if (decision?.status === 'declined') {
-        return {
-          status: 'declined',
-          operation: 'update',
-          reason: decision.reason
-        } as unknown as AgentReadModel
-      }
-      // Re-resolve target name + revision after approval (design.md §8).
-      if (this.profiles.has(patch.name!)) {
-        throw agentsError(method, `Specialist "${patch.name}" already exists`)
-      }
-    }
-
     const next: FakeProfileRecord = { ...existing }
-    next.name = patch.name ?? next.name
+    next.displayName = patch.displayName ?? next.displayName
     next.description = patch.description ?? next.description
-    next.systemPrompt = patch.system_prompt ?? next.systemPrompt
-    next.iconKey = patch.icon_key ?? next.iconKey
-    next.colorKey = patch.color_key ?? next.colorKey
+    next.systemPrompt = patch.systemPrompt ?? next.systemPrompt
+    next.iconKey = patch.iconKey ?? next.iconKey
+    next.colorKey = patch.colorKey ?? next.colorKey
     next.enabled = patch.enabled ?? next.enabled
 
     // design.md §5 capability semantics for update.
     if (patch.unrestricted === true) {
       next.unrestricted = true // switch to Full, preserve stored Selected config
-    } else if (patch.skill_names !== undefined || patch.connector_names !== undefined) {
+    } else if (patch.skillNames !== undefined || patch.connectorNames !== undefined) {
       // Supplying a collection exactly replaces it and switches to Selected; omitted is preserved.
       next.unrestricted = false
-      next.skillIds = patch.skill_names ?? next.skillIds
-      next.connectorIds = patch.connector_names ?? next.connectorIds
+      next.skillIds = patch.skillNames ?? next.skillIds
+      next.connectorIds = patch.connectorNames ?? next.connectorIds
     }
     this.validateCatalogRefs(next.skillIds, next.connectorIds, method)
 
     next.revision = existing.revision + 1
-    if (isNameChange) {
-      this.profiles.delete(name)
-    }
     this.profiles.set(next.name, next)
     return this.project(next)
   }
 
   // ----- incremental attach/detach (single-collection, does not change mode) -----
 
-  async attach_skill(
+  async attachSkill(
     name: string,
     skillRef: string,
     options: { revision?: number } = {}
@@ -291,7 +270,7 @@ export class FakeHostAgents {
     return this.mutateCollection(name, 'skill', skillRef, 'attach', options.revision)
   }
 
-  async detach_skill(
+  async detachSkill(
     name: string,
     skillRef: string,
     options: { revision?: number } = {}
@@ -299,7 +278,7 @@ export class FakeHostAgents {
     return this.mutateCollection(name, 'skill', skillRef, 'detach', options.revision)
   }
 
-  async attach_connector(
+  async attachConnector(
     name: string,
     connectorRef: string,
     options: { revision?: number } = {}
@@ -307,7 +286,7 @@ export class FakeHostAgents {
     return this.mutateCollection(name, 'connector', connectorRef, 'attach', options.revision)
   }
 
-  async detach_connector(
+  async detachConnector(
     name: string,
     connectorRef: string,
     options: { revision?: number } = {}
@@ -322,7 +301,7 @@ export class FakeHostAgents {
     action: 'attach' | 'detach',
     revision: number | undefined
   ): AgentReadModel {
-    const method = `${action}_${kind}`
+    const method = `${action}${kind[0].toUpperCase()}${kind.slice(1)}`
     const existing = this.profiles.get(name)
     if (!existing) throw agentsError(method, `Specialist "${name}" not found.`)
     if (revision !== undefined && revision !== existing.revision) {
@@ -416,7 +395,7 @@ function applyNameOrIdFilter<T extends { id: string; name?: string; displayName?
 ): T[] {
   const byId = entries.filter((entry) => entry.id === ref)
   if (byId.length > 0) return clone(byId)
-  const byName = entries.filter((entry) => entry.name === ref || entry.displayName === ref)
+  const byName = entries.filter((entry) => entry.name === ref)
   if (byName.length === 0) {
     throw agentsError(method, `No catalog entry matches "${ref}".`)
   }

--- a/src/main/agents/customize/skill-creator-package.test.ts
+++ b/src/main/agents/customize/skill-creator-package.test.ts
@@ -104,7 +104,16 @@ describe('skill-creator bundled package', () => {
         '---\nname: data-helper\ndescription: Analyze data.\ncompatibility: node\n---\nBody.\n',
         'data-helper'
       )
-    ).toEqual({ valid: false, error: 'Frontmatter must contain exactly name and description.' })
+    ).toEqual({
+      valid: false,
+      error: 'Frontmatter may only contain name, displayName, and description.'
+    })
+    expect(
+      validateSkillDocument(
+        '---\nname: data-helper\ndisplayName: Data Helper\ndescription: Analyze data.\n---\nBody.\n',
+        'data-helper'
+      )
+    ).toMatchObject({ valid: true, name: 'data-helper', displayName: 'Data Helper' })
   })
 
   it('gates evaluation behind the app-owned host.skills.evals capability', async () => {

--- a/src/main/agents/customize/workflow.test.ts
+++ b/src/main/agents/customize/workflow.test.ts
@@ -17,7 +17,6 @@ import {
   buildReviewedTarget,
   draftChangedSinceConfirmation,
   explainDelete,
-  explainNameChange,
   explainSwitch,
   isExplicitConfirmation,
   isStaleRevision,
@@ -39,6 +38,7 @@ import {
 const demoProfile = (overrides: Partial<FakeProfileRecord> = {}): FakeProfileRecord => ({
   id: 'sp-1',
   name: 'Bio Expert',
+  displayName: 'Bio Expert',
   description: 'a specialist',
   systemPrompt: 'You are a bio expert.',
   iconKey: 'beaker',
@@ -73,6 +73,7 @@ const skills = [
 const connectors: ConnectorReadModel[] = [
   {
     id: 'conn-a',
+    name: 'conn-a',
     displayName: 'Chemistry',
     description: 'chemistry connector',
     mainEnabled: true,
@@ -87,7 +88,7 @@ const recordingGateway = (
   decision: 'approved' | 'declined'
 ): {
   decide: (request: {
-    operation: 'update' | 'delete' | 'switch'
+    operation: 'delete' | 'switch'
     summary: { name?: string; newName?: string; target?: string | null }
   }) => Promise<ApprovalResult>
   decisions: Array<Record<string, unknown>>
@@ -95,7 +96,7 @@ const recordingGateway = (
   const decisions: Array<Record<string, unknown>> = []
   const decide = async (
     request: {
-      operation: 'update' | 'delete' | 'switch'
+      operation: 'delete' | 'switch'
       summary: { name?: string; newName?: string; target?: string | null }
     } & Record<string, unknown>
   ): Promise<ApprovalResult> => {
@@ -156,8 +157,8 @@ describe('customize Skill: bundled source', () => {
       'host.agents.update(',
       'host.agents.switch(',
       'host.agents.delete(',
-      'host.agents.list_skills(',
-      'host.agents.list_connectors('
+      'host.agents.listSkills(',
+      'host.agents.listConnectors('
     ]) {
       expect(raw).toContain(method)
     }
@@ -172,7 +173,7 @@ describe('customize Skill: bundled source', () => {
 
   it('documents identity-first, bounded, composable Specialist authoring and offers switching', async () => {
     const raw = await readFile(skillPath, 'utf8')
-    expect(raw).toContain('You are {display_name}')
+    expect(raw).toContain('You are {displayName}')
     expect(raw).toMatch(/what\s+(?:the\s+)?Specialist\s+does not do/i)
     expect(raw).toMatch(/heavy how-to.*Skills/i)
     expect(raw).toMatch(/after.*exists.*offer.*switch/is)
@@ -283,8 +284,8 @@ describe('customize Skill: scope clarification', () => {
 
   it('treats explicit full or supplied arrays as decided', () => {
     expect(resolveCreateScope({ unrestricted: true })).toBe('full')
-    expect(resolveCreateScope({ skill_names: ['skill-a'] })).toBe('selected')
-    expect(resolveCreateScope({ connector_names: ['conn-a'] })).toBe('selected')
+    expect(resolveCreateScope({ skillNames: ['skill-a'] })).toBe('selected')
+    expect(resolveCreateScope({ connectorNames: ['conn-a'] })).toBe('selected')
   })
 })
 
@@ -292,8 +293,8 @@ describe('customize Skill: live read + complete draft', () => {
   it('reads live Profiles plus Skill/Connector catalogs before proposing a target state', async () => {
     const sdk = makeSdk()
     const [profile] = await sdk.list()
-    const skillCatalog = await sdk.list_skills()
-    const connectorCatalog = await sdk.list_connectors()
+    const skillCatalog = await sdk.listSkills()
+    const connectorCatalog = await sdk.listConnectors()
     expect(profile.name).toBe('Bio Expert')
     expect(skillCatalog.map((entry) => entry.id)).toContain('skill-a')
     expect(connectorCatalog.map((entry) => entry.id)).toContain('conn-a')
@@ -381,10 +382,10 @@ describe('customize Skill: atomic update preference', () => {
     const plan = preferAtomicUpdate(target, live)
     expect(plan.kind).toBe('atomic-update')
     expect(plan.patch.description).toBe('new')
-    expect(plan.patch.system_prompt).toBe('new prompt')
-    expect(plan.patch.skill_names).toEqual(['skill-a', 'skill-b'])
+    expect(plan.patch.systemPrompt).toBe('new prompt')
+    expect(plan.patch.skillNames).toEqual(['skill-a', 'skill-b'])
     // connector unchanged => not present in patch
-    expect(plan.patch.connector_names).toBeUndefined()
+    expect(plan.patch.connectorNames).toBeUndefined()
   })
 
   it('applies the atomic patch in a single update call that returns read-back', async () => {
@@ -408,11 +409,9 @@ describe('customize Skill: confirmation boundaries', () => {
     expect(requiresSystemPermissionCard('ordinary-update')).toBe(false)
   })
 
-  it('name-changing update, delete, switch use the system card as the only authorization point', () => {
-    expect(requiresSystemPermissionCard('name-changing-update')).toBe(true)
+  it('delete and switch use the system card as the only authorization point', () => {
     expect(requiresSystemPermissionCard('delete')).toBe(true)
     expect(requiresSystemPermissionCard('switch')).toBe(true)
-    expect(requiresTextualConfirmation('name-changing-update')).toBe(false)
     expect(requiresTextualConfirmation('delete')).toBe(false)
     expect(requiresTextualConfirmation('switch')).toBe(false)
   })
@@ -430,9 +429,9 @@ describe('customize Skill: create read-back', () => {
     const created = await sdk.create({
       name: 'New',
       description: 'd',
-      system_prompt: 'p',
-      skill_names: ['skill-a'],
-      connector_names: ['conn-a']
+      systemPrompt: 'p',
+      skillNames: ['skill-a'],
+      connectorNames: ['conn-a']
     })
     expect(created.capabilityMode).toBe('selected')
     expect(created.selectedCapabilities.skillIds).toEqual(['skill-a'])
@@ -451,7 +450,7 @@ describe('customize Skill: capability update read-back', () => {
     expect(toFull.capabilityMode).toBe('full')
     // switching back to Selected with a new skill set
     const toSelected = await sdk.update('Bio Expert', {
-      skill_names: ['skill-b'],
+      skillNames: ['skill-b'],
       revision: toFull.revision
     })
     expect(toSelected.capabilityMode).toBe('selected')
@@ -475,24 +474,22 @@ describe('customize Skill: stale re-review', () => {
   })
 })
 
-describe('customize Skill: approved privileged operations', () => {
-  it('approved name-changing update applies atomically via the system card', async () => {
-    const gateway = recordingGateway('approved')
-    const sdk = makeSdk({ approvalGateway: gateway })
+describe('customize Skill: display-name updates', () => {
+  it('changes displayName as an ordinary update without changing name', async () => {
+    const sdk = makeSdk()
     const before = await sdk.get('Bio Expert')
     const result = await sdk.update('Bio Expert', {
-      name: 'Renamed',
+      displayName: 'Renamed label',
       description: 'new desc',
       revision: before.revision
     })
-    expect(result.name).toBe('Renamed')
+    expect(result.name).toBe('Bio Expert')
+    expect(result.displayName).toBe('Renamed label')
     expect(result.description).toBe('new desc')
-    expect(gateway.decisions[0]).toMatchObject({ operation: 'update' })
-    expect(gateway.decisions[0].summary).toMatchObject({ name: 'Bio Expert', newName: 'Renamed' })
-    // old name no longer resolves
-    await expect(sdk.get('Bio Expert')).rejects.toThrow(/not found/i)
   })
+})
 
+describe('customize Skill: approved privileged operations', () => {
   it('approved delete removes the profile', async () => {
     const gateway = recordingGateway('approved')
     const sdk = makeSdk({ approvalGateway: gateway })
@@ -533,22 +530,6 @@ describe('customize Skill: approved privileged operations', () => {
 })
 
 describe('customize Skill: declined privileged operations', () => {
-  it('declined name-changing update leaves every field unchanged and is not retried', async () => {
-    const gateway = recordingGateway('declined')
-    const sdk = makeSdk({ approvalGateway: gateway })
-    const before = await sdk.get('Bio Expert')
-    const result = (await sdk.update('Bio Expert', {
-      name: 'Renamed',
-      revision: before.revision
-    })) as unknown as { status: string; operation: string }
-    expect(result.status).toBe('declined')
-    expect(result.operation).toBe('update')
-    // nothing changed
-    const unchanged = await sdk.get('Bio Expert')
-    expect(unchanged.revision).toBe(before.revision)
-    expect(gateway.decisions).toHaveLength(1) // not retried
-  })
-
   it('declined delete is reported as a user decision and not retried', async () => {
     const gateway = recordingGateway('declined')
     const sdk = makeSdk({ approvalGateway: gateway })
@@ -596,7 +577,6 @@ describe('customize Skill: reporting', () => {
 
   it('privileged explanations name the impending action', () => {
     expect(explainSwitch('Bio Expert', 'Other')).toMatch(/continues automatically/i)
-    expect(explainNameChange('A', 'B')).toMatch(/rename.*A.*B/i)
     expect(explainDelete('A')).toMatch(/delete.*A/i)
     expect(explainDelete('A')).toMatch(/unavailable/i)
   })
@@ -626,7 +606,7 @@ describe('customize Skill: catalog resolution + sanitized errors', () => {
       ],
       connectors: []
     })
-    await expect(sdk.list_skills('dup')).rejects.toThrow(/host\.agents\.list_skills:.*multiple/i)
+    await expect(sdk.listSkills('dup')).rejects.toThrow(/host\.agents\.listSkills:.*multiple/i)
   })
 
   it('errors are sanitized and prefixed host.agents.<method>:', async () => {
@@ -636,7 +616,7 @@ describe('customize Skill: catalog resolution + sanitized errors', () => {
 
   it('never returns secret material from the connector catalog', async () => {
     const sdk = makeSdk()
-    const catalog = await sdk.list_connectors()
+    const catalog = await sdk.listConnectors()
     const serialized = JSON.stringify(catalog)
     expect(serialized).not.toMatch(/secret|token|apiKey|password/i)
   })

--- a/src/main/agents/customize/workflow.ts
+++ b/src/main/agents/customize/workflow.ts
@@ -7,9 +7,9 @@
 // The Skill is WORKFLOW GUIDANCE, not a security boundary (design.md §11, PRD §10). It never merges
 // or auto-retries; it never treats the chat entry as authorization; it never exposes UUIDs/revisions
 // in ordinary prose. Confirmation boundaries (design.md §7):
-//  - ordinary mutations (create, non-name update): chat review + explicit textual confirmation; no
+//  - ordinary mutations (create and update): chat review + explicit textual confirmation; no
 //    second system permission card;
-//  - privileged mutations (name-changing update, delete, switch): explain the impending action, then
+//  - privileged mutations (delete and switch): explain the impending action, then
 //    invoke the SDK — the standard permission card is the single authorization point.
 
 import type { AgentReadModel } from '../agents-service'
@@ -24,11 +24,11 @@ export type CapabilityScope = 'full' | 'selected' | 'unspecified'
 
 export const resolveCreateScope = (input: {
   unrestricted?: boolean
-  skill_names?: unknown
-  connector_names?: unknown
+  skillNames?: unknown
+  connectorNames?: unknown
 }): CapabilityScope => {
   if (input.unrestricted === true) return 'full'
-  if (input.skill_names !== undefined || input.connector_names !== undefined) return 'selected'
+  if (input.skillNames !== undefined || input.connectorNames !== undefined) return 'selected'
   return 'unspecified'
 }
 
@@ -48,6 +48,7 @@ export const SCOPE_CLARIFICATION =
 // live Profiles plus Skill/Connector catalogs before proposing this.
 export type ReviewedTargetState = {
   name: string
+  displayName: string
   description: string
   systemPrompt: string
   iconKey?: string
@@ -61,6 +62,7 @@ export type ReviewedTargetState = {
 
 export const buildReviewedTarget = (profile: AgentReadModel): ReviewedTargetState => ({
   name: profile.name,
+  displayName: profile.displayName,
   description: profile.description,
   systemPrompt: profile.systemPrompt,
   iconKey: profile.iconKey,
@@ -82,6 +84,7 @@ export const renderOrdinaryReview = (
 ): string => {
   const lines: string[] = []
   lines.push(`Name: ${target.name}`)
+  lines.push(`Display name: ${target.displayName}`)
   lines.push(`Description: ${target.description}`)
   lines.push('Full system instructions:')
   lines.push(target.systemPrompt)
@@ -104,14 +107,13 @@ export const renderOrdinaryReview = (
 // Confirmation boundaries (design.md §7)
 // ---------------------------------------------------------------------------
 
-export type OperationKind =
-  'create' | 'ordinary-update' | 'name-changing-update' | 'delete' | 'switch'
+export type OperationKind = 'create' | 'ordinary-update' | 'delete' | 'switch'
 
 // Ordinary mutations use chat review + explicit textual confirmation and do NOT request a second
 // system permission card. Name-changing update, delete, and switch explain the impending action and
 // invoke the SDK directly; the standard card is the only authorization point.
 export const requiresSystemPermissionCard = (kind: OperationKind): boolean =>
-  kind === 'name-changing-update' || kind === 'delete' || kind === 'switch'
+  kind === 'delete' || kind === 'switch'
 
 // Whether the operation waits for an explicit textual confirmation in chat BEFORE mutating (ordinary
 // path). Privileged ops do not require a separate preceding "yes": the card is the authorization.
@@ -150,14 +152,14 @@ export const draftChangedSinceConfirmation = <T>(
 export type OrdinaryChangePlan = {
   kind: 'atomic-update'
   patch: {
-    name?: string
+    displayName?: string
     description?: string
-    system_prompt?: string
-    icon_key?: string
-    color_key?: string
+    systemPrompt?: string
+    iconKey?: string
+    colorKey?: string
     enabled?: boolean
-    skill_names?: string[]
-    connector_names?: string[]
+    skillNames?: string[]
+    connectorNames?: string[]
   }
 }
 
@@ -166,15 +168,16 @@ export const preferAtomicUpdate = (
   live: ReviewedTargetState
 ): OrdinaryChangePlan => {
   const patch: OrdinaryChangePlan['patch'] = {}
+  if (target.displayName !== live.displayName) patch.displayName = target.displayName
   if (target.description !== live.description) patch.description = target.description
-  if (target.systemPrompt !== live.systemPrompt) patch.system_prompt = target.systemPrompt
-  if ((target.iconKey ?? '') !== (live.iconKey ?? '')) patch.icon_key = target.iconKey
-  if ((target.colorKey ?? '') !== (live.colorKey ?? '')) patch.color_key = target.colorKey
+  if (target.systemPrompt !== live.systemPrompt) patch.systemPrompt = target.systemPrompt
+  if ((target.iconKey ?? '') !== (live.iconKey ?? '')) patch.iconKey = target.iconKey
+  if ((target.colorKey ?? '') !== (live.colorKey ?? '')) patch.colorKey = target.colorKey
   if (target.enabled !== live.enabled) patch.enabled = target.enabled
   const skillChanged = JSON.stringify(target.skillIds) !== JSON.stringify(live.skillIds)
   const connectorChanged = JSON.stringify(target.connectorIds) !== JSON.stringify(live.connectorIds)
-  if (skillChanged) patch.skill_names = target.skillIds
-  if (connectorChanged) patch.connector_names = target.connectorIds
+  if (skillChanged) patch.skillNames = target.skillIds
+  if (connectorChanged) patch.connectorNames = target.connectorIds
   return { kind: 'atomic-update', patch }
 }
 
@@ -188,10 +191,6 @@ export const explainSwitch = (currentName: string | null, targetName: string | n
   `About to switch this conversation from ${currentName ?? 'Main Agent'} to ${
     targetName ?? 'Main Agent'
   }. If approved, the current control tool finishes and the conversation continues automatically under the approved identity.`
-
-export const explainNameChange = (oldName: string, newName: string): string =>
-  `About to rename "${oldName}" to "${newName}" and apply the rest of the reviewed changes in one ` +
-  'step. Stable conversation bindings do not change.'
 
 export const explainDelete = (name: string): string =>
   `About to delete "${name}". Conversations still bound to it become unavailable; they are not ` +

--- a/src/main/compute/skill-provisioning.test.ts
+++ b/src/main/compute/skill-provisioning.test.ts
@@ -82,6 +82,7 @@ describe('SSH Compute Skill provisioning lifecycle', () => {
     const bundledSkill: BundledSkill = {
       id: 'remote-compute-ssh',
       name: 'Remote Compute (SSH)',
+      displayName: 'Remote Compute (SSH)',
       description: 'Discover SSH compute hosts.',
       source: 'featured',
       updatedAt: 'v1',

--- a/src/main/connectors/custom-mcp-bootstrap.test.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.test.ts
@@ -6,7 +6,8 @@ describe('toCustomMcpConfig', () => {
   it('maps a stored stdio server to a McpClientManager config', () => {
     const server: StoredCustomMcpServer = {
       id: 'srv-1',
-      name: 'My Server',
+      name: 'my-server',
+      displayName: 'My Server',
       transport: 'stdio',
       command: 'npx',
       args: ['-y', 'some-mcp-server'],
@@ -16,7 +17,7 @@ describe('toCustomMcpConfig', () => {
 
     expect(toCustomMcpConfig(server)).toEqual({
       id: 'srv-1',
-      name: 'My Server',
+      name: 'my-server',
       transport: 'stdio',
       command: 'npx',
       args: ['-y', 'some-mcp-server'],
@@ -29,7 +30,8 @@ describe('toCustomMcpConfig', () => {
   it('falls back to an empty command when the stored server has none', () => {
     const server: StoredCustomMcpServer = {
       id: 'srv-1',
-      name: 'My Server',
+      name: 'my-server',
+      displayName: 'My Server',
       transport: 'stdio',
       enabled: true
     }
@@ -40,7 +42,8 @@ describe('toCustomMcpConfig', () => {
   it('maps a remote server url/headers/transport', () => {
     const server: StoredCustomMcpServer = {
       id: 'srv-remote',
-      name: 'Remote Server',
+      name: 'remote-server',
+      displayName: 'Remote Server',
       transport: 'streamable_http',
       url: 'https://example.com/mcp',
       headers: { Authorization: 'Bearer token' },
@@ -49,7 +52,7 @@ describe('toCustomMcpConfig', () => {
 
     expect(toCustomMcpConfig(server)).toEqual({
       id: 'srv-remote',
-      name: 'Remote Server',
+      name: 'remote-server',
       transport: 'streamable_http',
       command: '',
       args: undefined,
@@ -62,7 +65,8 @@ describe('toCustomMcpConfig', () => {
   it('maps OAuth configuration and decrypted state to the manager', () => {
     const server: StoredCustomMcpServer = {
       id: 'srv-oauth',
-      name: 'OAuth Server',
+      name: 'oauth-server',
+      displayName: 'OAuth Server',
       transport: 'streamable_http',
       url: 'https://example.com/mcp',
       oauth: { scopes: ['openid'] },
@@ -72,7 +76,7 @@ describe('toCustomMcpConfig', () => {
 
     expect(toCustomMcpConfig(server)).toEqual({
       id: 'srv-oauth',
-      name: 'OAuth Server',
+      name: 'oauth-server',
       transport: 'streamable_http',
       command: '',
       args: undefined,
@@ -90,7 +94,8 @@ describe('toCustomMcpConfig', () => {
 describe('selectEnabledCustomServers', () => {
   const stdioServer: StoredCustomMcpServer = {
     id: 'srv-stdio',
-    name: 'Stdio Server',
+    name: 'stdio-server',
+    displayName: 'Stdio Server',
     transport: 'stdio',
     command: 'npx',
     enabled: true
@@ -98,19 +103,22 @@ describe('selectEnabledCustomServers', () => {
   const disabledServer: StoredCustomMcpServer = {
     ...stdioServer,
     id: 'srv-off',
-    name: 'Disabled Server',
+    name: 'disabled-server',
+    displayName: 'Disabled Server',
     enabled: false
   }
   const remoteServer: StoredCustomMcpServer = {
     id: 'srv-remote',
-    name: 'Remote Server',
+    name: 'remote-server',
+    displayName: 'Remote Server',
     transport: 'streamable_http',
     url: 'https://example.com/mcp',
     enabled: true
   }
   const sseServer: StoredCustomMcpServer = {
     id: 'srv-sse',
-    name: 'SSE Server',
+    name: 'sse-server',
+    displayName: 'SSE Server',
     transport: 'sse',
     url: 'https://example.com/sse',
     enabled: true
@@ -118,29 +126,34 @@ describe('selectEnabledCustomServers', () => {
   const unauthenticatedOAuthServer: StoredCustomMcpServer = {
     ...remoteServer,
     id: 'srv-oauth-waiting',
-    name: 'OAuth Waiting',
+    name: 'oauth-waiting',
+    displayName: 'OAuth Waiting',
     oauth: {}
   }
   const authenticatedOAuthServer: StoredCustomMcpServer = {
     ...unauthenticatedOAuthServer,
     id: 'srv-oauth-ready',
-    name: 'OAuth Ready',
+    name: 'oauth-ready',
+    displayName: 'OAuth Ready',
     oauthState: { tokens: { access_token: 'access', token_type: 'Bearer' } }
   }
   const bundledRouteCollision: StoredCustomMcpServer = {
     ...stdioServer,
     id: 'srv-reserved-route',
-    name: 'Chemistry'
+    name: 'chemistry',
+    displayName: 'Other Chemistry'
   }
   const duplicateRouteA: StoredCustomMcpServer = {
     ...stdioServer,
     id: 'srv-duplicate-a',
-    name: 'Duplicate MCP'
+    name: 'duplicate-mcp',
+    displayName: 'Duplicate A'
   }
   const duplicateRouteB: StoredCustomMcpServer = {
     ...stdioServer,
     id: 'srv-duplicate-b',
-    name: 'Duplicate-MCP!'
+    name: 'duplicate-mcp',
+    displayName: 'Duplicate B'
   }
 
   it('returns enabled servers across all supported transports', () => {
@@ -176,31 +189,25 @@ describe('selectEnabledCustomServers', () => {
     expect(selectEnabledCustomServers({ enabledIds: [], autoAllowIds: [] })).toEqual([])
   })
 
-  it('fails closed when a slug overlaps another Connector legacy alias', () => {
-    const legacyOwner: StoredCustomMcpServer = {
+  it('fails closed when custom Connectors have duplicate names', () => {
+    const first: StoredCustomMcpServer = {
       ...stdioServer,
-      id: 'legacy-owner-uuid',
-      slug: 'stable-owner',
-      name: 'legacy-route'
+      id: 'first',
+      name: 'same-name',
+      displayName: 'First'
     }
-    const nameHijacker: StoredCustomMcpServer = {
+    const second: StoredCustomMcpServer = {
       ...stdioServer,
-      id: 'name-hijacker-uuid',
-      slug: 'legacy-route',
-      name: 'Name hijacker'
-    }
-    const uuidHijacker: StoredCustomMcpServer = {
-      ...stdioServer,
-      id: 'uuid-hijacker-uuid',
-      slug: 'legacy-owner-uuid',
-      name: 'UUID hijacker'
+      id: 'second',
+      name: 'same-name',
+      displayName: 'Second'
     }
 
     expect(
       selectEnabledCustomServers({
         enabledIds: [],
         autoAllowIds: [],
-        customMcpServers: [legacyOwner, nameHijacker, uuidHijacker]
+        customMcpServers: [first, second]
       })
     ).toEqual([])
   })

--- a/src/main/connectors/custom-mcp-bootstrap.ts
+++ b/src/main/connectors/custom-mcp-bootstrap.ts
@@ -1,6 +1,5 @@
 import type { CustomMcpServerConfig } from './mcp-client-manager'
 import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
-import { customConnectorAliasKey, customConnectorAliases } from '../../shared/custom-connector'
 import { ALL_CONNECTOR_IDS } from './registry'
 
 export type CustomMcpFailureAvailability = 'unavailable' | 'unauthenticated'
@@ -49,23 +48,15 @@ const SUPPORTED_CUSTOM_MCP_TRANSPORTS = new Set<StoredCustomMcpServer['transport
   'sse'
 ])
 
-// Legacy records derive their public route from the display name. A derived route that is already
-// owned by a bundled Connector or another custom record must remain visible in Settings but cannot
-// be exposed or dispatched.
+// A name already owned by a bundled Connector or another custom record remains visible in Settings
+// but cannot be exposed or dispatched.
 export const isCustomMcpServerRouteSafe = (
   server: StoredCustomMcpServer,
   allServers: readonly StoredCustomMcpServer[]
 ): boolean => {
-  const aliases = new Set(customConnectorAliases(server).map(customConnectorAliasKey))
-  if (ALL_CONNECTOR_IDS.some((id) => aliases.has(customConnectorAliasKey(id)))) return false
+  if (ALL_CONNECTOR_IDS.includes(server.name)) return false
 
-  return allServers.every(
-    (candidate) =>
-      candidate === server ||
-      customConnectorAliases(candidate).every(
-        (alias) => !aliases.has(customConnectorAliasKey(alias))
-      )
-  )
+  return allServers.every((candidate) => candidate === server || candidate.name !== server.name)
 }
 
 // Selects runnable custom servers for discovery and skill-doc sync. OAuth Connectors remain absent

--- a/src/main/connectors/custom-skill-doc.test.ts
+++ b/src/main/connectors/custom-skill-doc.test.ts
@@ -18,8 +18,8 @@ const FAKE_TOOLS = [
 function makeServer(overrides: Partial<StoredCustomMcpServer> = {}): StoredCustomMcpServer {
   return {
     id: 'srv-1',
-    slug: 'myserver',
     name: 'myserver',
+    displayName: 'My server',
     transport: 'stdio',
     command: 'npx',
     enabled: true,
@@ -28,9 +28,9 @@ function makeServer(overrides: Partial<StoredCustomMcpServer> = {}): StoredCusto
 }
 
 describe('renderCustomSkillDoc', () => {
-  it('uses the immutable slug for skill identity and routing while keeping the display name in prose', () => {
+  it('uses the immutable name for skill identity and routing while keeping displayName in prose', () => {
     const md = renderCustomSkillDoc(
-      { slug: 'example-oauth-e2e', name: 'Example OAuth E2E' },
+      { name: 'example-oauth-e2e', displayName: 'Example OAuth E2E' },
       FAKE_TOOLS
     )
     expect(md).toContain('name: mcp-example-oauth-e2e')
@@ -46,9 +46,31 @@ describe('renderCustomSkillDoc', () => {
     expect(md).toContain('host.mcp("example-oauth-e2e", "fetch")')
   })
 
+  it('changes generated prose without changing Skill or host.mcp identity', () => {
+    const before = renderCustomSkillDoc(
+      { name: 'stable-connector', displayName: 'Before Label' },
+      FAKE_TOOLS
+    )
+    const after = renderCustomSkillDoc(
+      { name: 'stable-connector', displayName: 'After Label' },
+      FAKE_TOOLS
+    )
+
+    expect(before).toContain('Before Label MCP server')
+    expect(after).toContain('After Label MCP server')
+    for (const doc of [before, after]) {
+      expect(doc).toContain('name: mcp-stable-connector')
+      expect(doc).toContain('host.mcp("stable-connector", "search")')
+    }
+  })
+
   it('uses the server-provided description verbatim when present', () => {
     const md = renderCustomSkillDoc(
-      { slug: 'myserver', name: 'myserver', description: 'Use when the user asks about widgets.' },
+      {
+        name: 'myserver',
+        displayName: 'My server',
+        description: 'Use when the user asks about widgets.'
+      },
       FAKE_TOOLS
     )
     const frontmatter = md.slice(0, md.indexOf('---', 3))
@@ -56,7 +78,7 @@ describe('renderCustomSkillDoc', () => {
   })
 
   it('renders a concrete dict example from a custom tool inputSchema', () => {
-    const md = renderCustomSkillDoc({ slug: 'myserver', name: 'myserver' }, [
+    const md = renderCustomSkillDoc({ name: 'myserver', displayName: 'My server' }, [
       {
         name: 'lookup',
         description: 'Look up a record',
@@ -74,7 +96,7 @@ describe('renderCustomSkillDoc', () => {
 })
 
 describe('syncCustomServerSkillDocs', () => {
-  it('writes mcp-<slug>/SKILL.md for an enabled server and removes it once disabled', async () => {
+  it('writes mcp-<name>/SKILL.md for an enabled server and removes it once disabled', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'custom-skills-'))
     const server = makeServer()
     const listTools = async (): Promise<typeof FAKE_TOOLS> => FAKE_TOOLS
@@ -95,8 +117,12 @@ describe('syncCustomServerSkillDocs', () => {
 
   it('refreshes one server without validating or deleting unrelated server Skills', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'custom-skills-targeted-'))
-    const target = makeServer({ id: 'target', slug: 'target', name: 'Target' })
-    const unrelated = makeServer({ id: 'unrelated', slug: 'unrelated', name: 'Unrelated' })
+    const target = makeServer({ id: 'target', name: 'target', displayName: 'Target' })
+    const unrelated = makeServer({
+      id: 'unrelated',
+      name: 'unrelated',
+      displayName: 'Unrelated'
+    })
     const listTools = async (): Promise<typeof FAKE_TOOLS> => FAKE_TOOLS
 
     await syncCustomServerSkillDocs(dir, [target, unrelated], listTools)
@@ -107,8 +133,8 @@ describe('syncCustomServerSkillDocs', () => {
 
   it('isolates an unavailable server while materializing the remaining enabled servers', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'custom-skills-unavailable-'))
-    const unavailable = makeServer({ id: 'unavailable', slug: 'unavailable' })
-    const healthy = makeServer({ id: 'healthy', slug: 'healthy', name: 'Healthy server' })
+    const unavailable = makeServer({ id: 'unavailable', name: 'unavailable' })
+    const healthy = makeServer({ id: 'healthy', name: 'healthy', displayName: 'Healthy server' })
     await mkdir(join(dir, 'mcp-unavailable'), { recursive: true })
     await writeFile(join(dir, 'mcp-unavailable', 'SKILL.md'), 'stale')
 
@@ -119,7 +145,7 @@ describe('syncCustomServerSkillDocs', () => {
       return FAKE_TOOLS
     })
 
-    expect(result.materializedSlugs).toEqual(['healthy'])
+    expect(result.materializedNames).toEqual(['healthy'])
     expect(result.failures).toEqual([
       {
         server: unavailable,
@@ -134,45 +160,45 @@ describe('syncCustomServerSkillDocs', () => {
     const dir = join(root, 'skills')
     const listTools = async (): Promise<typeof FAKE_TOOLS> => FAKE_TOOLS
 
-    // Display names never become paths. Explicit safe slugs remain the only directory identities.
-    const traversal = makeServer({ slug: 'safe-escape', name: '../escape' })
-    const collision = makeServer({ slug: 'custom-chemistry', name: 'chemistry' })
+    // Display names never become paths. Explicit safe names remain the only directory identities.
+    const traversal = makeServer({ name: 'safe-escape', displayName: '../escape' })
+    const collision = makeServer({ name: 'custom-chemistry', displayName: 'chemistry' })
 
     await syncCustomServerSkillDocs(dir, [traversal, collision], listTools)
 
     // Nothing was written outside the skills dir.
     expect((await readdir(root)).sort()).toEqual(['skills'])
-    // Both servers materialized under their slug, and no `mcp-chemistry` directory was produced.
+    // Both servers materialized under their name, and no `mcp-chemistry` directory was produced.
     const entries = (await readdir(dir)).sort()
     expect(entries).toEqual(['mcp-custom-chemistry', 'mcp-safe-escape'])
   })
 
-  it('normalizes an unsafe legacy slug and skips a built-in collision', async () => {
+  it('skips an unsafe name and a built-in collision', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'custom-skills-tampered-'))
     const listTools = async (): Promise<typeof FAKE_TOOLS> => FAKE_TOOLS
 
-    const badPath = makeServer({ slug: '../../evil', name: 'Evil server' })
-    const bundledId = makeServer({ slug: 'chemistry', name: 'Other server' })
+    const badPath = makeServer({ name: '../../evil', displayName: 'Evil server' })
+    const bundledId = makeServer({ name: 'chemistry', displayName: 'Other server' })
 
     await syncCustomServerSkillDocs(dir, [badPath, bundledId], listTools)
 
-    expect((await readdir(dir)).sort()).toEqual(['mcp-evil-server'])
+    expect((await readdir(dir)).sort()).toEqual([])
   })
 
-  it('does not overwrite a built-in connector with a case-variant slug', async () => {
+  it('does not overwrite a built-in connector with a case-variant name', async () => {
     // On a case-insensitive filesystem `mcp-Chemistry` and `mcp-chemistry` are the same directory, so
-    // a tampered mixed-case slug must be normalized away from the built-in identity.
+    // a tampered mixed-case name must be rejected.
     const dir = await mkdtemp(join(tmpdir(), 'connector-case-'))
     await syncConnectorSkillDocs(dir, ['chemistry'])
     const builtinDoc = join(dir, 'mcp-chemistry', 'SKILL.md')
     const before = await readFile(builtinDoc, 'utf8')
 
-    const tampered = makeServer({ slug: 'Chemistry', name: 'tampered' })
+    const tampered = makeServer({ name: 'Chemistry', displayName: 'Tampered' })
     await syncCustomServerSkillDocs(dir, [tampered], async () => [])
 
     // The built-in doc is untouched, and no case-variant directory was created.
     expect(await readFile(builtinDoc, 'utf8')).toBe(before)
-    expect((await readdir(dir)).sort()).toEqual(['mcp-chemistry', 'mcp-tampered'])
+    expect((await readdir(dir)).sort()).toEqual(['mcp-chemistry'])
   })
 
   it('does not delete the built-in doc when an upgrade left a case-variant directory', async () => {
@@ -206,11 +232,11 @@ describe('syncCustomServerSkillDocs', () => {
 
     const result = await syncCustomServerSkillDocs(
       dir,
-      [makeServer({ slug: 'xt', name: 'XT' })],
+      [makeServer({ name: 'xt', displayName: 'XT' })],
       async () => FAKE_TOOLS
     )
 
-    expect(result.materializedSlugs).toEqual([])
+    expect(result.materializedNames).toEqual([])
     expect(result.failures).toHaveLength(1)
     const entries = await readdir(dir)
     expect(entries).toEqual(['mcp-XT'])

--- a/src/main/connectors/provision.ts
+++ b/src/main/connectors/provision.ts
@@ -4,10 +4,7 @@ import { ALL_CONNECTOR_IDS } from './registry'
 import { renderSkillDoc, renderCustomSkillDoc } from './skill-doc'
 import type { CustomSkillDocTool } from './skill-doc'
 import type { StoredCustomMcpServer } from '../settings/types'
-import {
-  customConnectorSlug,
-  customConnectorSlugFromSkillName
-} from '../../shared/custom-connector'
+import { customConnectorNameFromSkillName } from '../../shared/custom-connector'
 import { parseFrontmatter } from '../skills/frontmatter'
 
 // Whether an `mcp-<x>` directory's suffix names a bundled connector — CASE-INSENSITIVELY. This
@@ -81,7 +78,7 @@ export async function syncConnectorSkillDocs(
 export type CustomServerListTools = (server: StoredCustomMcpServer) => Promise<CustomSkillDocTool[]>
 
 export type CustomServerSkillSyncResult = {
-  materializedSlugs: string[]
+  materializedNames: string[]
   failures: Array<{ server: StoredCustomMcpServer; error: unknown }>
 }
 
@@ -90,10 +87,10 @@ export type MaterializedCustomSkillDocSyncResult = {
   failures: Array<{ skillName: string; error: unknown }>
 }
 
-const isSafeCustomServerSlug = (slug: string): boolean =>
-  /^[a-z0-9-]+$/.test(slug) && !ALL_CONNECTOR_IDS.includes(slug)
+const isSafeCustomServerName = (name: string): boolean =>
+  /^[a-z0-9-]+$/.test(name) && !ALL_CONNECTOR_IDS.includes(name)
 
-// Writes skills/mcp-<slug>/SKILL.md for enabled custom MCP servers, sourced from the server's
+// Writes skills/mcp-<name>/SKILL.md for enabled custom MCP servers, sourced from the server's
 // live listTools() schema rather than a bundled descriptor table (§3.4). Cleanup mirrors
 // syncConnectorSkillDocs: it only removes ids that are NOT known bundled connector ids, so
 // the two sync passes never delete each other's directories even when run against the same dir.
@@ -101,16 +98,16 @@ export async function syncCustomServerSkillDocs(
   skillsDir: string,
   servers: StoredCustomMcpServer[],
   listTools: CustomServerListTools,
-  cleanupSlugs?: readonly string[]
+  cleanupNames?: readonly string[]
 ): Promise<CustomServerSkillSyncResult> {
   await mkdir(skillsDir, { recursive: true })
   const safeServers = servers
-    .map((server) => ({ server, slug: customConnectorSlug(server) }))
-    .filter(({ slug }) => isSafeCustomServerSlug(slug))
-  const materializedSlugs: string[] = []
+    .map((server) => ({ server, name: server.name }))
+    .filter(({ name }) => isSafeCustomServerName(name))
+  const materializedNames: string[] = []
   const failures: CustomServerSkillSyncResult['failures'] = []
-  for (const { server, slug } of safeServers) {
-    const skillName = `mcp-${slug}`
+  for (const { server, name } of safeServers) {
+    const skillName = `mcp-${name}`
     const dir = join(skillsDir, skillName)
     const caseFoldedAlias = await findCaseFoldedAlias(skillsDir, skillName)
     if (caseFoldedAlias) {
@@ -134,23 +131,23 @@ export async function syncCustomServerSkillDocs(
     }
     await mkdir(dir, { recursive: true })
     await writeFile(join(dir, 'SKILL.md'), renderCustomSkillDoc(server, tools), 'utf8')
-    materializedSlugs.push(slug)
+    materializedNames.push(name)
   }
-  const enabledSlugs = new Set(materializedSlugs)
-  const cleanupScope = cleanupSlugs ? new Set(cleanupSlugs) : undefined
+  const enabledNames = new Set(materializedNames)
+  const cleanupScope = cleanupNames ? new Set(cleanupNames) : undefined
   const existing = await readdir(skillsDir).catch(() => [] as string[])
   for (const entry of existing) {
-    const slug = customConnectorSlugFromSkillName(entry)
+    const name = customConnectorNameFromSkillName(entry)
     // A bundled-connector dir (case-insensitive) belongs to syncConnectorSkillDocs — never delete it
     // here, even a case-variant like mcp-Chemistry that the built-in sync has written its doc into.
     // Invalid/non-canonical names are also unowned and must be preserved.
-    if (!slug || namesBundledConnector(slug)) continue
-    if (cleanupScope && !cleanupScope.has(slug)) continue
-    if (!enabledSlugs.has(slug)) {
+    if (!name || namesBundledConnector(name)) continue
+    if (cleanupScope && !cleanupScope.has(name)) continue
+    if (!enabledNames.has(name)) {
       await rm(join(skillsDir, entry), { recursive: true, force: true })
     }
   }
-  return { materializedSlugs, failures }
+  return { materializedNames, failures }
 }
 
 // Copies only successfully generated custom Connector docs from the canonical app-owned Claude
@@ -166,8 +163,8 @@ export async function syncMaterializedCustomServerSkillDocs(
   const requested = [
     ...new Set(
       skillNames.filter((skillName) => {
-        const slug = customConnectorSlugFromSkillName(skillName)
-        return slug !== undefined && !namesBundledConnector(slug)
+        const name = customConnectorNameFromSkillName(skillName)
+        return name !== undefined && !namesBundledConnector(name)
       })
     )
   ]
@@ -226,8 +223,8 @@ export async function syncMaterializedCustomServerSkillDocs(
 
   const materialized = new Set(materializedSkillNames)
   for (const entry of await readdir(targetSkillsDir).catch(() => [] as string[])) {
-    const slug = customConnectorSlugFromSkillName(entry)
-    if (!slug || namesBundledConnector(slug)) continue
+    const name = customConnectorNameFromSkillName(entry)
+    if (!name || namesBundledConnector(name)) continue
     if (!materialized.has(entry)) {
       await rm(join(targetSkillsDir, entry), { recursive: true, force: true })
     }

--- a/src/main/connectors/runtime-settings-projection.test.ts
+++ b/src/main/connectors/runtime-settings-projection.test.ts
@@ -16,14 +16,16 @@ describe('ConnectorRuntimeSettingsProjection', () => {
       customMcpServers: [
         {
           id: 'server-id',
-          name: 'Enabled',
+          name: 'enabled',
+          displayName: 'Enabled',
           transport: 'stdio',
           command: 'mcp',
           enabled: true
         },
         {
           id: 'disabled-id',
-          name: 'Disabled',
+          name: 'disabled',
+          displayName: 'Disabled',
           transport: 'stdio',
           command: 'mcp',
           enabled: false
@@ -34,7 +36,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
     const syncBundledSkillDocs = vi.fn().mockResolvedValue(undefined)
     const syncCustomSkillDocs = vi.fn(async (_dir, servers, loadTools) => {
       await loadTools(servers[0])
-      return { materializedSlugs: ['enabled'], failures: [] }
+      return { materializedNames: ['enabled'], failures: [] }
     })
     const projection = new ConnectorRuntimeSettingsProjection({
       readConnectors: vi.fn().mockResolvedValue(stored),
@@ -65,27 +67,27 @@ describe('ConnectorRuntimeSettingsProjection', () => {
   it('refreshes and reports checking for only the requested custom server', async () => {
     const target = {
       id: 'target-id',
-      slug: 'target',
-      name: 'Target',
+      name: 'target',
+      displayName: 'Target',
       transport: 'stdio' as const,
       command: 'mcp',
       enabled: true
     }
     const unrelated = {
       id: 'unrelated-id',
-      slug: 'unrelated',
-      name: 'Unrelated',
+      name: 'unrelated',
+      displayName: 'Unrelated',
       transport: 'stdio' as const,
       command: 'mcp',
       enabled: true
     }
     let finishTargetedSync: (() => void) | undefined
-    const targetedSync = new Promise<{ materializedSlugs: string[]; failures: [] }>((resolve) => {
-      finishTargetedSync = () => resolve({ materializedSlugs: ['target'], failures: [] })
+    const targetedSync = new Promise<{ materializedNames: string[]; failures: [] }>((resolve) => {
+      finishTargetedSync = () => resolve({ materializedNames: ['target'], failures: [] })
     })
     const syncCustomSkillDocs = vi
       .fn()
-      .mockResolvedValueOnce({ materializedSlugs: ['target', 'unrelated'], failures: [] })
+      .mockResolvedValueOnce({ materializedNames: ['target', 'unrelated'], failures: [] })
       .mockReturnValueOnce(targetedSync)
     const projection = new ConnectorRuntimeSettingsProjection({
       readConnectors: vi.fn().mockResolvedValue(
@@ -122,16 +124,16 @@ describe('ConnectorRuntimeSettingsProjection', () => {
   it('advertises only custom Skills that materialized when one enabled server is unavailable', async () => {
     const unavailable = {
       id: 'unavailable-id',
-      slug: 'unavailable',
-      name: 'Unavailable',
+      name: 'unavailable',
+      displayName: 'Unavailable',
       transport: 'stdio' as const,
       command: 'node',
       enabled: true
     }
     const healthy = {
       id: 'healthy-id',
-      slug: 'healthy',
-      name: 'Healthy',
+      name: 'healthy',
+      displayName: 'Healthy',
       transport: 'stdio' as const,
       command: 'node',
       enabled: true
@@ -148,7 +150,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
       mcpClientManager: { listTools: vi.fn().mockResolvedValue([]) },
       syncBundledSkillDocs: vi.fn().mockResolvedValue(undefined),
       syncCustomSkillDocs: vi.fn().mockResolvedValue({
-        materializedSlugs: ['healthy'],
+        materializedNames: ['healthy'],
         failures: [{ server: unavailable, error: failure }]
       }),
       reportError
@@ -168,8 +170,8 @@ describe('ConnectorRuntimeSettingsProjection', () => {
   it('classifies authentication discovery failures without exposing transport details', async () => {
     const server = {
       id: 'oauth-id',
-      slug: 'oauth',
-      name: 'OAuth',
+      name: 'oauth',
+      displayName: 'OAuth',
       transport: 'streamable_http' as const,
       url: 'https://mcp.example.test',
       enabled: true
@@ -180,7 +182,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
       mcpClientManager: { listTools: vi.fn().mockResolvedValue([]) },
       syncBundledSkillDocs: vi.fn().mockResolvedValue(undefined),
       syncCustomSkillDocs: vi.fn().mockResolvedValue({
-        materializedSlugs: [],
+        materializedNames: [],
         failures: [{ server, error: new Error('401 invalid_token for a secret endpoint') }]
       }),
       reportError: vi.fn()
@@ -194,8 +196,8 @@ describe('ConnectorRuntimeSettingsProjection', () => {
   it('clears a runtime failure after a successful retry refresh', async () => {
     const server = {
       id: 'recovering-id',
-      slug: 'recovering',
-      name: 'Recovering',
+      name: 'recovering',
+      displayName: 'Recovering',
       transport: 'stdio' as const,
       command: 'node',
       enabled: true
@@ -203,10 +205,10 @@ describe('ConnectorRuntimeSettingsProjection', () => {
     const syncCustomSkillDocs = vi
       .fn()
       .mockResolvedValueOnce({
-        materializedSlugs: [],
+        materializedNames: [],
         failures: [{ server, error: new Error('Connection closed') }]
       })
-      .mockResolvedValueOnce({ materializedSlugs: ['recovering'], failures: [] })
+      .mockResolvedValueOnce({ materializedNames: ['recovering'], failures: [] })
     const projection = new ConnectorRuntimeSettingsProjection({
       readConnectors: vi.fn().mockResolvedValue(connectors({ customMcpServers: [server] })),
       skillsDir: '/config/skills',
@@ -226,8 +228,8 @@ describe('ConnectorRuntimeSettingsProjection', () => {
 
   it('publishes checking and settled states without blocking snapshot reads', async () => {
     let finishSync: (() => void) | undefined
-    const sync = new Promise<{ materializedSlugs: string[]; failures: [] }>((resolve) => {
-      finishSync = () => resolve({ materializedSlugs: ['checking'], failures: [] })
+    const sync = new Promise<{ materializedNames: string[]; failures: [] }>((resolve) => {
+      finishSync = () => resolve({ materializedNames: ['checking'], failures: [] })
     })
     const notifyStatusChanged = vi.fn()
     const projection = new ConnectorRuntimeSettingsProjection({
@@ -253,7 +255,8 @@ describe('ConnectorRuntimeSettingsProjection', () => {
   it('keeps discovery status when a newer dispatch failure is cleared', async () => {
     const server = {
       id: 'server-id',
-      name: 'Server',
+      name: 'server',
+      displayName: 'Server',
       transport: 'stdio' as const,
       command: 'mcp',
       enabled: true
@@ -265,7 +268,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
       mcpClientManager: { listTools: vi.fn().mockResolvedValue([]) },
       syncBundledSkillDocs: vi.fn().mockResolvedValue(undefined),
       syncCustomSkillDocs: vi.fn().mockResolvedValue({
-        materializedSlugs: [],
+        materializedNames: [],
         failures: [{ server, error: new Error('Connection closed') }]
       }),
       notifyStatusChanged
@@ -298,7 +301,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
       skillsDir: '/config/skills',
       mcpClientManager: { listTools: vi.fn().mockResolvedValue([]) },
       syncBundledSkillDocs,
-      syncCustomSkillDocs: vi.fn().mockResolvedValue({ materializedSlugs: [], failures: [] }),
+      syncCustomSkillDocs: vi.fn().mockResolvedValue({ materializedNames: [], failures: [] }),
       reportError
     })
 
@@ -341,7 +344,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
       skillsDir: '/config/skills',
       mcpClientManager: { listTools: vi.fn().mockResolvedValue([]) },
       syncBundledSkillDocs,
-      syncCustomSkillDocs: vi.fn().mockResolvedValue({ materializedSlugs: [], failures: [] })
+      syncCustomSkillDocs: vi.fn().mockResolvedValue({ materializedNames: [], failures: [] })
     })
 
     const olderRefresh = projection.refresh()
@@ -384,7 +387,7 @@ describe('ConnectorRuntimeSettingsProjection', () => {
         .fn()
         .mockRejectedValueOnce(new Error('older sync failed'))
         .mockResolvedValueOnce(undefined),
-      syncCustomSkillDocs: vi.fn().mockResolvedValue({ materializedSlugs: [], failures: [] }),
+      syncCustomSkillDocs: vi.fn().mockResolvedValue({ materializedNames: [], failures: [] }),
       reportError
     })
 

--- a/src/main/connectors/runtime-settings-projection.ts
+++ b/src/main/connectors/runtime-settings-projection.ts
@@ -6,7 +6,7 @@ import {
 } from './custom-mcp-bootstrap'
 import { syncConnectorSkillDocs, syncCustomServerSkillDocs } from './provision'
 import { ALL_CONNECTOR_IDS } from './registry'
-import { customConnectorSkillName, customConnectorSlug } from '../../shared/custom-connector'
+import { customConnectorSkillName } from '../../shared/custom-connector'
 import type { McpClientManager } from './mcp-client-manager'
 import type { StoredConnectors, StoredCustomMcpServer } from '../settings/types'
 
@@ -131,7 +131,7 @@ class ConnectorRuntimeSettingsProjection {
         customServers,
         (server) => this.options.mcpClientManager.listTools(toCustomMcpConfig(server))
       )
-      this.materializedCustomSkills = customSync.materializedSlugs.map(customConnectorSkillName)
+      this.materializedCustomSkills = customSync.materializedNames.map(customConnectorSkillName)
       this.discoveryAvailabilities = new Map(
         customSync.failures.map(({ server, error }) => [server.id, classifyCustomMcpFailure(error)])
       )
@@ -148,7 +148,7 @@ class ConnectorRuntimeSettingsProjection {
     const server = connectors?.customMcpServers?.find((candidate) => candidate.id === serverId)
     if (!server) return
 
-    const slug = customConnectorSlug(server)
+    const name = server.name
     const enabledServer = selectEnabledCustomServers(connectors).find(
       (candidate) => candidate.id === serverId
     )
@@ -156,11 +156,11 @@ class ConnectorRuntimeSettingsProjection {
       this.options.skillsDir,
       enabledServer ? [enabledServer] : [],
       (candidate) => this.options.mcpClientManager.listTools(toCustomMcpConfig(candidate)),
-      [slug]
+      [name]
     )
-    const skillName = customConnectorSkillName(slug)
+    const skillName = customConnectorSkillName(name)
     const materialized = new Set(this.materializedCustomSkills)
-    if (customSync.materializedSlugs.includes(slug)) materialized.add(skillName)
+    if (customSync.materializedNames.includes(name)) materialized.add(skillName)
     else materialized.delete(skillName)
     this.materializedCustomSkills = [...materialized]
 
@@ -177,7 +177,7 @@ class ConnectorRuntimeSettingsProjection {
   ): void {
     for (const { server, error } of failures) {
       this.reportError(
-        new Error(`Failed to sync custom MCP server "${customConnectorSlug(server)}" skill docs`, {
+        new Error(`Failed to sync custom MCP server "${server.name}" skill docs`, {
           cause: error
         })
       )

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -419,8 +419,8 @@ describe('ConnectorService', () => {
           customMcpServers: [
             {
               id: 'srv-1',
-              slug: 'example-oauth-e2e',
-              name: 'Example OAuth E2E',
+              name: 'example-oauth-e2e',
+              displayName: 'Example OAuth E2E',
               transport: 'stdio',
               command: 'npx',
               args: ['-y', '@example/server'],
@@ -436,7 +436,7 @@ describe('ConnectorService', () => {
       expect(call).toHaveBeenCalledWith(
         {
           id: 'srv-1',
-          name: 'Example OAuth E2E',
+          name: 'example-oauth-e2e',
           transport: 'stdio',
           command: 'npx',
           args: ['-y', '@example/server'],
@@ -449,7 +449,7 @@ describe('ConnectorService', () => {
       )
     })
 
-    it('fails closed when a legacy custom route collides with a bundled connector', async () => {
+    it('does not dispatch a custom name that collides with a bundled connector', async () => {
       const call = vi.fn()
       const mcpClientManager = manager(call)
       const svc = new ConnectorService({
@@ -460,7 +460,8 @@ describe('ConnectorService', () => {
           customMcpServers: [
             {
               id: 'srv-reserved',
-              name: 'Chemistry!',
+              name: 'chemistry',
+              displayName: 'Other Chemistry',
               transport: 'stdio',
               command: 'npx',
               enabled: true
@@ -470,12 +471,12 @@ describe('ConnectorService', () => {
         resolveApiKey: () => undefined
       })
 
-      await expect(svc.call('Chemistry!', 'do_thing', {}, internal)).rejects.toThrow(/unavailable/)
+      await expect(svc.call('chemistry', 'do_thing', {}, internal)).rejects.toThrow(/unknown tool/)
       expect(mcpClientManager.listTools).not.toHaveBeenCalled()
       expect(call).not.toHaveBeenCalled()
     })
 
-    it('fails closed when legacy custom Connectors derive the same route', async () => {
+    it('fails closed when custom Connectors have the same name', async () => {
       const call = vi.fn()
       const mcpClientManager = manager(call)
       const svc = new ConnectorService({
@@ -486,14 +487,16 @@ describe('ConnectorService', () => {
           customMcpServers: [
             {
               id: 'srv-duplicate-a',
-              name: 'Duplicate MCP',
+              name: 'duplicate-mcp',
+              displayName: 'Duplicate A',
               transport: 'stdio',
               command: 'first-command',
               enabled: true
             },
             {
               id: 'srv-duplicate-b',
-              name: 'Duplicate-MCP!',
+              name: 'duplicate-mcp',
+              displayName: 'Duplicate B',
               transport: 'stdio',
               command: 'second-command',
               enabled: true
@@ -522,6 +525,7 @@ describe('ConnectorService', () => {
           {
             id: '11111111-1111-4111-8111-111111111111',
             name: 'myserver',
+            displayName: 'My server',
             transport: 'stdio' as const,
             command: 'server-command',
             enabled: true
@@ -560,6 +564,7 @@ describe('ConnectorService', () => {
         {
           id: '11111111-1111-4111-8111-111111111111',
           name: 'myserver',
+          displayName: 'My server',
           transport: 'stdio' as const,
           command: 'server-command',
           enabled: true
@@ -601,6 +606,7 @@ describe('ConnectorService', () => {
           {
             id: '11111111-1111-4111-8111-111111111111',
             name: 'myserver',
+            displayName: 'My server',
             transport: 'stdio' as const,
             command: 'server-command',
             enabled: true
@@ -634,6 +640,7 @@ describe('ConnectorService', () => {
             {
               id: 'srv-remote',
               name: 'remoteserver',
+              displayName: 'Remote server',
               transport: 'streamable_http',
               url: 'https://example.com/mcp',
               headers: { Authorization: 'Bearer token' },
@@ -669,7 +676,14 @@ describe('ConnectorService', () => {
           enabledIds: [],
           autoAllowIds: [],
           customMcpServers: [
-            { id: 'srv-1', name: 'myserver', transport: 'stdio', command: 'npx', enabled: false }
+            {
+              id: 'srv-1',
+              name: 'myserver',
+              displayName: 'My server',
+              transport: 'stdio',
+              command: 'npx',
+              enabled: false
+            }
           ]
         }),
         resolveApiKey: () => undefined
@@ -694,7 +708,14 @@ describe('ConnectorService', () => {
           askToolIds: ['myserver/dangerous'],
           blockedToolIds: ['myserver/dangerous'],
           customMcpServers: [
-            { id: 'srv-1', name: 'myserver', transport: 'stdio', command: 'npx', enabled: true }
+            {
+              id: 'srv-1',
+              name: 'myserver',
+              displayName: 'My server',
+              transport: 'stdio',
+              command: 'npx',
+              enabled: true
+            }
           ]
         }),
         resolveApiKey: () => undefined,
@@ -728,7 +749,14 @@ describe('ConnectorService', () => {
           autoAllowIds: [],
           askToolIds: ['myserver/do_thing'],
           customMcpServers: [
-            { id: 'srv-1', name: 'myserver', transport: 'stdio', command: 'npx', enabled: true }
+            {
+              id: 'srv-1',
+              name: 'myserver',
+              displayName: 'My server',
+              transport: 'stdio',
+              command: 'npx',
+              enabled: true
+            }
           ]
         }),
         resolveApiKey: () => undefined,
@@ -743,7 +771,7 @@ describe('ConnectorService', () => {
       )
 
       expect(requestApproval).toHaveBeenCalledWith({
-        connector: 'myserver',
+        connector: 'My server',
         method: 'do_thing',
         args: { x: 1 },
         sessionId: 'session-99',
@@ -765,6 +793,7 @@ describe('ConnectorService', () => {
             {
               id: 'srv-1',
               name: 'myserver',
+              displayName: 'My server',
               transport: 'streamable_http',
               url: 'https://private.example/mcp',
               headers: { Authorization: 'Bearer secret' },
@@ -811,6 +840,7 @@ describe('ConnectorService', () => {
             {
               id: 'srv-stable',
               name: 'myserver',
+              displayName: 'My server',
               transport: 'stdio',
               command: 'npx',
               enabled: true
@@ -842,6 +872,7 @@ describe('ConnectorService', () => {
       const original = {
         id: 'srv-stable',
         name: 'myserver',
+        displayName: 'My server',
         transport: 'stdio' as const,
         command: 'old-command',
         enabled: true
@@ -922,6 +953,7 @@ describe('ConnectorService', () => {
             {
               id: 'srv-1',
               name: 'secured-server',
+              displayName: 'Secured server',
               transport: 'streamable_http',
               url: 'https://private.example/mcp',
               enabled: true
@@ -981,6 +1013,7 @@ describe('ConnectorService', () => {
             {
               id: 'oauth-1',
               name: 'oauth-server',
+              displayName: 'OAuth server',
               transport: 'streamable_http',
               url: 'https://mcp.example.test',
               oauth: {},
@@ -1010,6 +1043,7 @@ describe('ConnectorService', () => {
             {
               id: 'oauth-1',
               name: 'oauth-server',
+              displayName: 'OAuth server',
               transport: 'streamable_http',
               url: 'https://mcp.example.test',
               oauth: {},
@@ -1046,6 +1080,7 @@ describe('ConnectorService', () => {
             {
               id: 'content-service-id',
               name: 'content-service',
+              displayName: 'Content service',
               transport: 'stdio',
               command: 'content-service-mcp',
               enabled: true
@@ -1079,6 +1114,7 @@ describe('ConnectorService', () => {
             {
               id: 'srv-1',
               name: 'secured-server',
+              displayName: 'Secured server',
               transport: 'streamable_http',
               url: 'https://mcp.example.test',
               enabled: true
@@ -1134,6 +1170,7 @@ describe('ConnectorService', () => {
             {
               id: 'srv-1',
               name: 'concurrent-server',
+              displayName: 'Concurrent server',
               transport: 'stdio',
               command: 'mcp',
               enabled: true
@@ -1180,6 +1217,7 @@ describe('ConnectorService', () => {
             {
               id: 'srv-1',
               name: 'secured-server',
+              displayName: 'Secured server',
               transport: 'streamable_http',
               url: 'https://mcp.example.test',
               enabled: true
@@ -1203,7 +1241,7 @@ describe('ConnectorService', () => {
       expect(call).toHaveBeenCalledOnce()
     })
 
-    it('resolves remembered grants by immutable custom server id after a rename', async () => {
+    it('resolves remembered grants by immutable custom server id after a display-name edit', async () => {
       const call = vi.fn().mockResolvedValue({ ok: true })
       const requestApproval = vi.fn().mockResolvedValue('once')
       const resolve = vi.fn().mockResolvedValue({ matchedScope: 'session' })
@@ -1212,12 +1250,12 @@ describe('ConnectorService', () => {
         getConnectors: () => ({
           enabledIds: [],
           autoAllowIds: [],
-          // The editable name remains a supported policy alias while the grant uses immutable id.
-          askToolIds: ['renamed-server/do_thing'],
+          askToolIds: ['stable-server/do_thing'],
           customMcpServers: [
             {
               id: 'srv-stable',
-              name: 'renamed-server',
+              name: 'stable-server',
+              displayName: 'Renamed server',
               transport: 'stdio',
               command: 'npx',
               enabled: true
@@ -1230,7 +1268,7 @@ describe('ConnectorService', () => {
       })
 
       await svc.call(
-        'renamed-server',
+        'stable-server',
         'do_thing',
         { x: 1 },
         { origin: 'internal', sessionId: 'session-1', projectId: 'project-1' }
@@ -1258,7 +1296,14 @@ describe('ConnectorService', () => {
           autoAllowIds: [],
           askToolIds: ['myserver/future_method'],
           customMcpServers: [
-            { id: 'srv-1', name: 'myserver', transport: 'stdio', command: 'npx', enabled: true }
+            {
+              id: 'srv-1',
+              name: 'myserver',
+              displayName: 'My server',
+              transport: 'stdio',
+              command: 'npx',
+              enabled: true
+            }
           ]
         }),
         resolveApiKey: () => undefined,
@@ -1364,7 +1409,7 @@ describe('ConnectorService specialist capability gate', () => {
     expect(localHandler).toHaveBeenCalledTimes(3)
   })
 
-  it('accepts a legacy custom Connector UUID as a Specialist capability alias', async () => {
+  it('accepts only the custom Connector name as a Specialist capability reference', async () => {
     const call = vi.fn().mockResolvedValue({ ok: true })
     const listTools = vi.fn().mockResolvedValue([{ name: 'do_thing' }])
     let current = specialist({
@@ -1383,8 +1428,8 @@ describe('ConnectorService specialist capability gate', () => {
         customMcpServers: [
           {
             id: 'custom-server-uuid',
-            slug: 'public-route',
-            name: 'Public Route',
+            name: 'public-route',
+            displayName: 'Public Route',
             transport: 'stdio',
             command: 'npx',
             enabled: true
@@ -1400,13 +1445,26 @@ describe('ConnectorService specialist capability gate', () => {
       specialistId: current.id
     }
 
+    await expect(svc.call('public-route', 'do_thing', {}, context)).rejects.toThrow(
+      'specialist_capability_denied'
+    )
+    expect(call).not.toHaveBeenCalled()
+
+    current = specialist({
+      capabilityMode: 'selected',
+      selectedCapabilities: {
+        skillIds: [],
+        connectorIds: ['public-route'],
+        connectorTools: []
+      }
+    })
     await expect(svc.call('public-route', 'do_thing', {}, context)).resolves.toEqual({ ok: true })
 
     current = specialist({
       capabilityMode: 'full',
       fullAccess: {
         excludedSkillIds: [],
-        excludedConnectorIds: ['custom-server-uuid'],
+        excludedConnectorIds: ['public-route'],
         connectorTools: []
       }
     })

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -17,7 +17,6 @@ import type { ConnectorPermissionRequest } from '../permission-grants/connector-
 import type { PermissionGrantScope } from '../../shared/permission-grants'
 import type { ApprovalDecision, ConnectorApprovalScope } from '../../shared/settings'
 import type { SpecialistProfileView } from '../../shared/specialist'
-import { customConnectorSlug } from '../../shared/custom-connector'
 
 type McpClientManagerLike = {
   listTools(config: CustomMcpServerConfig): Promise<Array<{ name: string }>>
@@ -217,13 +216,11 @@ export class ConnectorService {
     }
 
     const customServers = (await this.currentConnectors())?.customMcpServers ?? []
-    const custom =
-      customServers.find((server) => customConnectorSlug(server) === connector) ??
-      customServers.find((server) => server.name === connector)
+    const custom = customServers.find((server) => server.name === connector)
     const access = await this.resolveAccess(
       connector,
       context,
-      custom ? [customConnectorSlug(custom), custom.name, custom.id] : [connector]
+      custom ? [custom.name] : [connector]
     )
     if (!custom) {
       throw new ConnectorGateError(
@@ -300,7 +297,10 @@ export class ConnectorService {
     const physicalFailure = this.unavailableCustomConnectors.get(custom.id)
     if (physicalFailure) throw new ConnectorGateError(physicalFailure)
     if (!access.bypassMainEnablement && !custom.enabled) {
-      throw new ConnectorGateError('connector_disabled', `connector not enabled: ${custom.name}`)
+      throw new ConnectorGateError(
+        'connector_disabled',
+        `connector not enabled: ${custom.displayName}`
+      )
     }
     if (!this.isCustomConfigRunnable(custom, customServers)) {
       throw new ConnectorGateError('connector_unavailable')
@@ -429,7 +429,7 @@ export class ConnectorService {
   }
 
   // The Permission Broker owns Connector policy precedence as well as durable grant matching. This
-  // service supplies only the registered identity, routing aliases, and current settings snapshot.
+  // service supplies only the registered identity and current settings snapshot.
   private async ensureAuthorized(
     connectorLabel: string,
     capabilityServerId: string,
@@ -491,16 +491,19 @@ export class ConnectorService {
       if (!current) throw new ConnectorGateError('connector_unavailable')
       this.assertCustomServerCurrent(current, generation)
       if (!access.bypassMainEnablement && !current.enabled) {
-        throw new ConnectorGateError('connector_disabled', `connector not enabled: ${current.name}`)
+        throw new ConnectorGateError(
+          'connector_disabled',
+          `connector not enabled: ${current.displayName}`
+        )
       }
       if (!this.isCustomConfigRunnable(current, customServers)) {
         throw new ConnectorGateError('connector_unavailable')
       }
 
       const request = this.authorizationRequest(
-        current.name,
+        current.displayName,
         current.id,
-        [current.id, customConnectorSlug(current), current.name],
+        [current.name],
         method,
         args,
         context,

--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -105,7 +105,7 @@ describe('renderSkillDoc', () => {
   it('falls back to a schema-built call example for tools without an authored example', () => {
     // Custom MCP servers ship no `example`, so the doc must still render a concrete, copyable call.
     const md = renderCustomSkillDoc(
-      { slug: 'acme', name: 'Acme', description: 'Use when you need acme tools.' },
+      { name: 'acme', displayName: 'Acme', description: 'Use when you need acme tools.' },
       [
         {
           name: 'do_thing',
@@ -122,7 +122,7 @@ describe('renderSkillDoc', () => {
   it('renders a no-arg tool without a third argument (never a literal ...)', () => {
     // A literal `...` as the args positional reaches the bridge as Ellipsis and raises; a no-arg tool
     // must render as host.mcp(server, method) so the example is copy-runnable.
-    const md = renderCustomSkillDoc({ slug: 'acme', name: 'Acme' }, [
+    const md = renderCustomSkillDoc({ name: 'acme', displayName: 'Acme' }, [
       { name: 'ping', inputSchema: { type: 'object', properties: {} } }
     ])
     expect(md).toContain('const result = await host.mcp("acme", "ping")')
@@ -152,7 +152,7 @@ describe('renderSkillDoc', () => {
     // Custom servers do not always receive the bundled connector baseline, so their compact Skill
     // still carries the minimum persistence rule without copying the full shared conventions.
     const md = renderCustomSkillDoc(
-      { slug: 'acme', name: 'Acme', description: 'Use when you need acme tools.' },
+      { name: 'acme', displayName: 'Acme', description: 'Use when you need acme tools.' },
       [{ name: 'do_thing', inputSchema: { type: 'object', properties: { q: { type: 'string' } } } }]
     )
     expect(md).toContain('persistent')
@@ -162,7 +162,7 @@ describe('renderSkillDoc', () => {
   })
 
   it('directs custom connector authentication failures to a listed login tool', () => {
-    const md = renderCustomSkillDoc({ slug: 'content-service', name: 'Content Service' }, [
+    const md = renderCustomSkillDoc({ name: 'content-service', displayName: 'Content Service' }, [
       { name: 'content_login' },
       { name: 'search' }
     ])
@@ -176,7 +176,7 @@ describe('renderSkillDoc', () => {
 
   it('directs host-managed OAuth authentication to Connector settings', () => {
     const md = renderCustomSkillDoc(
-      { slug: 'content-service', name: 'Content Service', oauth: {} },
+      { name: 'content-service', displayName: 'Content Service', oauth: {} },
       [{ name: 'content_login' }, { name: 'search' }]
     )
 
@@ -187,7 +187,7 @@ describe('renderSkillDoc', () => {
   })
 
   it('omits authentication recovery guidance when the connector declares neither mode', () => {
-    const md = renderCustomSkillDoc({ slug: 'content-service', name: 'Content Service' }, [
+    const md = renderCustomSkillDoc({ name: 'content-service', displayName: 'Content Service' }, [
       { name: 'search' }
     ])
 

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -1,6 +1,5 @@
 import { CONNECTOR_CATALOG } from './catalog'
 import { getConnectorTools } from './registry'
-import { customConnectorSlug } from '../../shared/custom-connector'
 
 const CONVENTIONS = [
   'Reach this service ONLY from the REPL control-plane kernel: call it inside the `repl_execute` tool as `const result = await host.mcp(server, method, {...})`. host.mcp is async — always `await` it. The python and r DATA cells have NO connector access; do not call host.mcp (or urllib / requests / fetch) from them — it will fail.',
@@ -129,7 +128,7 @@ export function renderConnectorInstructions(skillNames: string[]): string {
 
 export type CustomSkillDocServer = {
   name: string
-  slug?: string
+  displayName: string
   description?: string
   oauth?: unknown
 }
@@ -138,13 +137,12 @@ export type CustomSkillDocTool = { name: string; description?: string; inputSche
 // Same shape as renderSkillDoc, but for a user-added custom MCP server: schema comes from
 // McpClientManager.listTools() at runtime rather than a bundled descriptor table, and the
 // trigger-style description falls back to a composed one when the server has no useWhen text.
-// The skill name and host.mcp route both use the immutable safe slug. The display name remains free
+// The skill name and host.mcp route both use the immutable safe name. The display name remains free
 // to contain spaces and punctuation and is used only in user-facing prose.
 export function renderCustomSkillDoc(
   server: CustomSkillDocServer,
   tools: CustomSkillDocTool[]
 ): string {
-  const slug = customConnectorSlug(server)
   const authenticationConvention = server.oauth
     ? ' If a call reports `connector_unauthenticated` or says sign-in is required, ask the user to sign in from Settings > Connectors, wait for sign-in to complete, then retry the original call. Do not treat an authentication requirement as connector unavailability or call a connector-managed login tool; this connector uses host-managed OAuth.'
     : tools.some((tool) =>
@@ -156,13 +154,13 @@ export function renderCustomSkillDoc(
       : ''
   const useWhen =
     server.description ??
-    `Use when you need tools from the ${server.name} MCP server — ${tools.map((t) => t.name).join(', ')}.`
-  const header = `---\nname: mcp-${slug}\ndescription: ${JSON.stringify(useWhen)}\nsource: connector\n---\n`
+    `Use when you need tools from the ${server.displayName} MCP server — ${tools.map((t) => t.name).join(', ')}.`
+  const header = `---\nname: mcp-${server.name}\ndescription: ${JSON.stringify(useWhen)}\nsource: connector\n---\n`
   const methods = tools
     .map(
       (t) =>
         `### ${t.name}\n\n${t.description ?? ''}\n\n**Input:** ${inlineCode(JSON.stringify(t.inputSchema ?? {}))}\n\n` +
-        renderExample(slug, t.name, t.inputSchema)
+        renderExample(server.name, t.name, t.inputSchema)
     )
     .join('\n')
   return (

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,7 +1,6 @@
 import { basename, dirname, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { readFile, stat, writeFile } from 'node:fs/promises'
-import { customConnectorSlug } from '../shared/custom-connector'
 
 import {
   app,
@@ -874,19 +873,8 @@ const createApplicationModules = async (
             ...ALL_CONNECTOR_IDS,
             ...customMcpServers
               .filter((server) => isCustomMcpServerRouteSafe(server, customMcpServers))
-              .map(customConnectorSlug)
+              .map((server) => server.name)
           ])
-        ),
-        connectorAliases: Object.fromEntries(
-          customMcpServers
-            .filter((server) => isCustomMcpServerRouteSafe(server, customMcpServers))
-            .flatMap((server) => {
-              const slug = customConnectorSlug(server)
-              return [
-                [server.name, slug],
-                [server.id, slug]
-              ]
-            })
         ),
         protectedSpecialistIds: ['reviewer'],
         protectedSpecialistNames: ['Reviewer']
@@ -1476,8 +1464,8 @@ const createApplicationModules = async (
   const hostSkillsCatalog: HostSkillsCatalog = {
     list: () => settingsService.listHostSkills(),
     withSkillRead: (id, read) => settingsService.withHostSkillRead(id, read),
-    publishPersonalDirectory: (slug, sourcePath, overwrite) =>
-      settingsService.publishHostSkill(slug, sourcePath, overwrite),
+    publishPersonalDirectory: (name, sourcePath, overwrite) =>
+      settingsService.publishHostSkill(name, sourcePath, overwrite),
     deletePublished: async (id) => {
       await settingsService.deleteSkill({ id })
     }

--- a/src/main/permission-grants/catalog.test.ts
+++ b/src/main/permission-grants/catalog.test.ts
@@ -97,9 +97,11 @@ describe('permission grant renderer projection', () => {
     const snapshot = projectPermissionGrantSnapshot(records, {
       connectorPolicy: {
         bundledConnectorIds: ['chemistry'],
-        customMcpServers: [{ id: 'custom-1', name: 'renamed', enabled: true }],
-        blockedToolIds: ['renamed/write'],
-        askToolIds: ['renamed/write']
+        customMcpServers: [
+          { id: 'custom-1', name: 'stable', displayName: 'Renamed', enabled: true }
+        ],
+        blockedToolIds: ['stable/write'],
+        askToolIds: ['stable/write']
       }
     })
 

--- a/src/main/permission-grants/catalog.ts
+++ b/src/main/permission-grants/catalog.ts
@@ -6,7 +6,6 @@ import type {
   PermissionGrantSnapshot,
   PermissionGrantView
 } from '../../shared/permission-grants'
-import { customConnectorSlug } from '../../shared/custom-connector'
 
 type PermissionGrantNames = {
   projects?: ReadonlyMap<string, string>
@@ -27,8 +26,8 @@ type ConnectorPolicySnapshot = {
   disabledConnectorIds?: readonly string[]
   customMcpServers?: ReadonlyArray<{
     id: string
-    slug?: string
     name: string
+    displayName: string
     enabled: boolean
     oauth?: unknown
     oauthState?: { tokens?: { access_token?: string } }
@@ -138,7 +137,7 @@ const connectorProjection = (
   const custom = policy?.customMcpServers?.find((server) => server.id === serverId)
   const isBundled = policy?.bundledConnectorIds?.includes(serverId) ?? false
   if (!custom && !isBundled) return {}
-  const aliases = custom ? [custom.id, customConnectorSlug(custom), custom.name] : [serverId]
+  const aliases = custom ? [custom.name] : [serverId]
   const hasToolPolicy = (entries: readonly string[] | undefined): boolean =>
     aliases.some((alias) => entries?.includes(`${alias}/${toolName}`)) ?? false
   const disabled = custom

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -3,6 +3,8 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { AddCustomServerRequest, ConnectorsSnapshot } from '../../shared/settings'
+
 const keychain = vi.hoisted(() => ({ available: true }))
 
 // Reversible fake safeStorage so secrets can be encrypted without an OS keychain.
@@ -30,6 +32,10 @@ describe('ConnectorSettingsModule', () => {
   let dir: string
   let service: InstanceType<typeof ConnectorSettingsModule>
   let repository: InstanceType<typeof SettingsRepository>
+  const addCustomServer = (
+    request: Omit<AddCustomServerRequest, 'displayName'> & { displayName?: string }
+  ): Promise<ConnectorsSnapshot> =>
+    service.addCustomServer({ ...request, displayName: request.displayName ?? request.name })
 
   beforeEach(async () => {
     keychain.available = true
@@ -138,7 +144,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('adds, toggles, and removes a local (stdio) custom server', async () => {
-    let snapshot = await service.addCustomServer({
+    let snapshot = await addCustomServer({
       name: 'my-mem',
       transport: 'stdio',
       command: 'npx',
@@ -148,8 +154,8 @@ describe('ConnectorSettingsModule', () => {
     expect(snapshot.customServers).toHaveLength(1)
     const added = snapshot.customServers[0]
     expect(added).toMatchObject({
-      slug: 'my-mem',
       name: 'my-mem',
+      displayName: 'my-mem',
       transport: 'stdio',
       command: 'npx',
       enabled: true,
@@ -160,17 +166,17 @@ describe('ConnectorSettingsModule', () => {
     snapshot = await service.setCustomServerEnabled({ id: added.id, enabled: false })
     expect(snapshot.customServers[0].enabled).toBe(false)
 
-    await repository.setConnectorAutoAllow(added.slug, true)
-    await repository.setToolPolicy(`${added.slug}/lookup`, true, false)
+    await repository.setConnectorAutoAllow(added.name, true)
+    await repository.setToolPolicy(`${added.name}/lookup`, true, false)
     snapshot = await service.removeCustomServer({ id: added.id })
     expect(snapshot.customServers).toEqual([])
     const afterRemoval = (await repository.getSettings()).connectors
-    expect(afterRemoval?.autoAllowIds).not.toContain(added.slug)
-    expect(afterRemoval?.askToolIds ?? []).not.toContain(`${added.slug}/lookup`)
+    expect(afterRemoval?.autoAllowIds).not.toContain(added.name)
+    expect(afterRemoval?.askToolIds ?? []).not.toContain(`${added.name}/lookup`)
   })
 
   it('advertises only safe custom Connector Skills from the successful materialization projection', async () => {
-    await service.addCustomServer({
+    await addCustomServer({
       name: 'custom-catalog',
       transport: 'stdio',
       command: 'example-mcp'
@@ -212,7 +218,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('projects runtime availability separately from logical enablement', async () => {
-    const added = await service.addCustomServer({
+    const added = await addCustomServer({
       name: 'offline-server',
       transport: 'stdio',
       command: 'example-mcp'
@@ -234,7 +240,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('does not block listing while the current runtime refresh is still pending', async () => {
-    const added = await service.addCustomServer({
+    const added = await addCustomServer({
       name: 'late-offline-server',
       transport: 'stdio',
       command: 'example-mcp'
@@ -255,12 +261,14 @@ describe('ConnectorSettingsModule', () => {
   it('projects checking only for the custom server currently being refreshed', async () => {
     const first = await service.addCustomServer({
       name: 'refreshing-server',
+      displayName: 'Refreshing server',
       transport: 'stdio',
       command: 'example-mcp'
     })
     const refreshingId = first.customServers[0].id
     const second = await service.addCustomServer({
       name: 'settled-server',
+      displayName: 'Settled server',
       transport: 'stdio',
       command: 'example-mcp'
     })
@@ -278,78 +286,66 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('rejects duplicate and built-in custom connector names', async () => {
-    await service.addCustomServer({
+    await addCustomServer({
       name: 'example-server',
       transport: 'stdio',
       command: 'example-mcp'
     })
 
     await expect(
-      service.addCustomServer({
-        name: ' Example-Server ',
+      addCustomServer({
+        name: 'example-server',
+        displayName: 'Another label',
         transport: 'stdio',
         command: 'another-mcp'
       })
     ).rejects.toThrow('already exists')
     await expect(
-      service.addCustomServer({ name: 'Chemistry', transport: 'stdio', command: 'example-mcp' })
+      addCustomServer({ name: 'chemistry', transport: 'stdio', command: 'example-mcp' })
     ).rejects.toThrow('reserved by a built-in connector')
   })
 
   it('separates the display name from the immutable host.mcp Connector ID', async () => {
-    const snapshot = await service.addCustomServer({
-      name: 'Example OAuth E2E',
+    const snapshot = await addCustomServer({
+      name: 'example-oauth-e2e',
+      displayName: 'Example OAuth E2E',
       transport: 'streamable_http',
       url: 'https://mcp.example.test',
       oauth: {}
     })
 
     expect(snapshot.customServers[0]).toMatchObject({
-      name: 'Example OAuth E2E',
-      slug: 'example-oauth-e2e'
+      name: 'example-oauth-e2e',
+      displayName: 'Example OAuth E2E'
     })
     await expect(
-      service.addCustomServer({
-        name: 'Another display name',
-        slug: 'example-oauth-e2e',
+      addCustomServer({
+        name: 'example-oauth-e2e',
+        displayName: 'Another display name',
         transport: 'stdio',
         command: 'example-mcp'
       })
     ).rejects.toThrow('already exists')
   })
 
-  it('rejects IDs and names that overlap an installed Connector legacy alias', async () => {
-    const existing = await service.addCustomServer({
-      name: 'legacy-route',
-      slug: 'stable-route',
+  it('does not reserve display labels or UUIDs as routing aliases', async () => {
+    const existing = await addCustomServer({
+      name: 'stable-route',
+      displayName: 'legacy-route',
       transport: 'stdio',
       command: 'example-mcp'
     })
 
-    await expect(
-      service.addCustomServer({
-        name: 'Different name',
-        slug: 'legacy-route',
-        transport: 'stdio',
-        command: 'example-mcp'
-      })
-    ).rejects.toThrow('conflicts with an existing Connector alias')
-    await expect(
-      service.addCustomServer({
-        name: 'Another name',
-        slug: existing.customServers[0].id,
-        transport: 'stdio',
-        command: 'example-mcp'
-      })
-    ).rejects.toThrow('conflicts with an existing Connector alias')
-    await expect(
-      service.addCustomServer({
-        name: 'stable-route',
-        slug: 'new-route',
-        transport: 'stdio',
-        command: 'example-mcp'
-      })
-    ).rejects.toThrow('conflicts with an existing Connector identity')
+    const added = await addCustomServer({
+      name: 'legacy-route',
+      displayName: existing.customServers[0].id,
+      transport: 'stdio',
+      command: 'example-mcp'
+    })
+    expect(added.customServers.map((server) => server.name)).toEqual([
+      'legacy-route',
+      'stable-route'
+    ])
   })
 
   it('fails closed when a legacy Connector derives a bundled route', async () => {
@@ -359,11 +355,12 @@ describe('ConnectorSettingsModule', () => {
       transport: 'stdio',
       enabled: true,
       command: 'legacy-command'
-    })
+    } as never)
 
     const snapshot = await service.listConnectors()
     expect(snapshot.customServers[0]).toMatchObject({
-      slug: 'chemistry',
+      name: 'chemistry',
+      displayName: 'Chemistry!',
       enabled: false,
       availability: 'unavailable'
     })
@@ -376,14 +373,14 @@ describe('ConnectorSettingsModule', () => {
       transport: 'stdio',
       enabled: true,
       command: 'first-command'
-    })
+    } as never)
     await repository.addCustomServer({
       id: 'legacy-duplicate-b',
       name: 'Duplicate-MCP!',
       transport: 'stdio',
       enabled: true,
       command: 'second-command'
-    })
+    } as never)
 
     const snapshot = await service.listConnectors()
     expect(snapshot.customServers).toHaveLength(2)
@@ -396,7 +393,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('exports only credential names and validates imports against installed connectors', async () => {
-    const snapshot = await service.addCustomServer({
+    const snapshot = await addCustomServer({
       name: 'example-export',
       transport: 'stdio',
       command: 'npx',
@@ -418,7 +415,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('adds a remote (streamable_http) custom server with a url', async () => {
-    const snapshot = await service.addCustomServer({
+    const snapshot = await addCustomServer({
       name: 'remote-x',
       transport: 'streamable_http',
       url: 'https://example.com/mcp',
@@ -432,7 +429,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('stores OAuth configuration publicly and OAuth state encrypted', async () => {
-    const snapshot = await service.addCustomServer({
+    const snapshot = await addCustomServer({
       name: 'oauth-x',
       transport: 'streamable_http',
       url: 'https://example.com/mcp',
@@ -470,7 +467,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('clears OAuth credentials when the remote endpoint changes', async () => {
-    const added = await service.addCustomServer({
+    const added = await addCustomServer({
       name: 'oauth-endpoint',
       transport: 'streamable_http',
       url: 'https://one.example/mcp',
@@ -499,7 +496,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('clears OAuth when switching a remote Connector to local transport', async () => {
-    const added = await service.addCustomServer({
+    const added = await addCustomServer({
       name: 'oauth-to-local',
       transport: 'streamable_http',
       url: 'https://mcp.example.test',
@@ -528,7 +525,7 @@ describe('ConnectorSettingsModule', () => {
 
   it('keeps OAuth and static-header authentication mutually exclusive', async () => {
     await expect(
-      service.addCustomServer({
+      addCustomServer({
         name: 'invalid-auth',
         transport: 'streamable_http',
         url: 'https://example.com/mcp',
@@ -537,7 +534,7 @@ describe('ConnectorSettingsModule', () => {
       })
     ).rejects.toThrow('OAuth and static headers cannot be configured together')
 
-    const added = await service.addCustomServer({
+    const added = await addCustomServer({
       name: 'switch-auth',
       transport: 'streamable_http',
       url: 'https://example.com/mcp',
@@ -558,13 +555,13 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('rejects an invalid custom server (stdio without a command)', async () => {
-    await expect(service.addCustomServer({ name: 'bad', transport: 'stdio' })).rejects.toThrow(
+    await expect(addCustomServer({ name: 'bad', transport: 'stdio' })).rejects.toThrow(
       /Invalid custom connector/
     )
   })
 
   it('does not expose custom-server env or header secrets in the view', async () => {
-    const snapshot = await service.addCustomServer({
+    const snapshot = await addCustomServer({
       name: 'secretful',
       transport: 'stdio',
       command: 'run',
@@ -581,6 +578,7 @@ describe('ConnectorSettingsModule', () => {
     await repository.addCustomServer({
       id: 'legacy',
       name: 'legacy',
+      displayName: 'Legacy',
       transport: 'streamable_http',
       enabled: true,
       url: 'https://example.test/mcp',
@@ -603,6 +601,7 @@ describe('ConnectorSettingsModule', () => {
     await repository.addCustomServer({
       id: 'legacy',
       name: 'legacy',
+      displayName: 'Legacy',
       transport: 'stdio',
       enabled: true,
       command: 'old-command',
@@ -619,7 +618,7 @@ describe('ConnectorSettingsModule', () => {
       command: 'new-command'
     })
     await expect(
-      service.addCustomServer({
+      addCustomServer({
         name: 'new-secret',
         transport: 'stdio',
         command: 'run',
@@ -634,7 +633,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('edits a custom server, keeping its name and preserving omitted env', async () => {
-    const added = await service.addCustomServer({
+    const added = await addCustomServer({
       name: 'my-mem',
       transport: 'stdio',
       command: 'npx',
@@ -660,7 +659,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('invalidates remembered authority before persisting a security-sensitive server edit', async () => {
-    const added = await service.addCustomServer({
+    const added = await addCustomServer({
       name: 'mutable-endpoint',
       transport: 'stdio',
       command: 'old-command',
@@ -700,7 +699,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('keeps grants for display-only edits and fails closed when invalidation fails', async () => {
-    const added = await service.addCustomServer({
+    const added = await addCustomServer({
       name: 'stable-endpoint',
       description: 'Before',
       transport: 'stdio',
@@ -741,7 +740,7 @@ describe('ConnectorSettingsModule', () => {
   })
 
   it('rolls back the custom-server security barrier when persistence fails', async () => {
-    const added = await service.addCustomServer({
+    const added = await addCustomServer({
       name: 'rollback-endpoint',
       transport: 'stdio',
       command: 'old-command'

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -20,12 +20,8 @@ import type {
   UpdateCustomServerRequest
 } from '../../shared/settings'
 import {
-  customConnectorAliasKey,
-  customConnectorAliases,
-  customConnectorSlug,
-  customConnectorSlugFromSkillName,
-  isCustomConnectorSlug,
-  toCustomConnectorSlug
+  customConnectorNameFromSkillName,
+  isCustomConnectorName
 } from '../../shared/custom-connector'
 import { CONNECTOR_CATALOG } from '../connectors/catalog'
 import { isCustomMcpServerRouteSafe } from '../connectors/custom-mcp-bootstrap'
@@ -86,8 +82,8 @@ class ConnectorSettingsModule {
     return [
       ...new Set(
         this.customServerRuntimeProjectionProvider.materializedSkillNames().filter((skillName) => {
-          const slug = customConnectorSlugFromSkillName(skillName)
-          return slug !== undefined && !bundled.has(slug)
+          const name = customConnectorNameFromSkillName(skillName)
+          return name !== undefined && !bundled.has(name)
         })
       )
     ]
@@ -189,8 +185,8 @@ class ConnectorSettingsModule {
 
     return buildConnectorTemplateExport({
       id: server.id,
-      slug: customConnectorSlug(server),
       name: server.name,
+      displayName: server.displayName,
       transport: server.transport,
       ...(server.description ? { description: server.description } : {}),
       ...(server.command ? { command: server.command } : {}),
@@ -209,9 +205,7 @@ class ConnectorSettingsModule {
   async previewCustomServerTemplateImport(contents: string): Promise<ConnectorTemplatePreview> {
     const customServers = (await this.repository.getSettings()).connectors?.customMcpServers ?? []
     return parseConnectorTemplate(contents, {
-      existingIds: customServers.map((server) => server.id),
       existingNames: customServers.map((server) => server.name),
-      existingSlugs: customServers.map(customConnectorSlug),
       bundledIds: CONNECTOR_CATALOG.map((connector) => connector.id)
     })
   }
@@ -280,32 +274,17 @@ class ConnectorSettingsModule {
 
   async addCustomServer(request: AddCustomServerRequest): Promise<ConnectorsSnapshot> {
     const name = request.name.trim()
-    const normalizedName = name.toLowerCase()
-    const slug = request.slug?.trim() || toCustomConnectorSlug(name)
+    const displayName = request.displayName.trim()
     const existingServers = (await this.repository.getSettings()).connectors?.customMcpServers ?? []
-    const existingAliasKeys = new Set(
-      existingServers.flatMap(customConnectorAliases).map(customConnectorAliasKey)
-    )
-    if (CONNECTOR_CATALOG.some((connector) => connector.id.toLowerCase() === normalizedName)) {
-      throw new Error(`Connector name "${name}" is reserved by a built-in connector`)
-    }
-    if (existingServers.some((server) => server.name.toLowerCase() === normalizedName)) {
-      throw new Error(`A custom connector named "${name}" already exists`)
-    }
-    if (existingAliasKeys.has(normalizedName)) {
-      throw new Error(`Connector name "${name}" conflicts with an existing Connector identity`)
-    }
-    if (!isCustomConnectorSlug(slug)) {
+    if (!displayName) throw new Error('Display name is required')
+    if (!isCustomConnectorName(name)) {
       throw new Error('Connector ID must use only lowercase letters, numbers, and hyphens')
     }
-    if (CONNECTOR_CATALOG.some((connector) => connector.id === slug)) {
-      throw new Error(`Connector ID "${slug}" is reserved by a built-in connector`)
+    if (CONNECTOR_CATALOG.some((connector) => connector.id === name)) {
+      throw new Error(`Connector ID "${name}" is reserved by a built-in connector`)
     }
-    if (existingServers.some((server) => customConnectorSlug(server) === slug)) {
-      throw new Error(`A custom connector with ID "${slug}" already exists`)
-    }
-    if (existingAliasKeys.has(customConnectorAliasKey(slug))) {
-      throw new Error(`Connector ID "${slug}" conflicts with an existing Connector alias`)
+    if (existingServers.some((server) => server.name === name)) {
+      throw new Error(`A custom connector with ID "${name}" already exists`)
     }
     if (request.transport === 'stdio' && request.oauth) {
       throw new Error('OAuth is only supported for remote custom connectors')
@@ -315,8 +294,8 @@ class ConnectorSettingsModule {
     }
     const candidate: StoredCustomMcpServer = {
       id: randomUUID(),
-      slug,
       name,
+      displayName,
       transport: request.transport,
       enabled: !request.oauth,
       trustedAt: Date.now(),
@@ -352,7 +331,7 @@ class ConnectorSettingsModule {
       )
       if (!server) throw new Error(`Unknown custom connector: ${request.id}`)
       if (server.oauth && !server.oauthState?.tokens?.access_token) {
-        throw new Error(`Sign in to "${server.name}" before enabling it`)
+        throw new Error(`Sign in to "${server.displayName}" before enabling it`)
       }
     }
     await this.repository.setCustomServerEnabled(request.id, request.enabled)
@@ -379,6 +358,8 @@ class ConnectorSettingsModule {
     )
 
     if (!existing) throw new Error(`Unknown custom connector: ${request.id}`)
+    const displayName = request.displayName?.trim() ?? existing.displayName
+    if (!displayName) throw new Error('Display name is required')
 
     const envRefs = request.env ? this.encryptSecretRecord(request.env) : existing.envRefs
     // Preserve legacy plaintext only when the caller leaves it untouched and safeStorage is still
@@ -415,8 +396,8 @@ class ConnectorSettingsModule {
       existing.url !== request.url?.trim()
     const merged: StoredCustomMcpServer = {
       id: existing.id,
-      slug: customConnectorSlug(existing),
       name: existing.name,
+      displayName,
       transport: request.transport,
       enabled: nextOAuth && oauthCredentialsChanged ? false : existing.enabled,
       ...(existing.trustedAt !== undefined ? { trustedAt: existing.trustedAt } : {}),
@@ -553,8 +534,8 @@ class ConnectorSettingsModule {
         )
         return {
           id: server.id,
-          slug: customConnectorSlug(server),
           name: server.name,
+          displayName: server.displayName,
           description: server.description,
           transport: server.transport,
           enabled: server.enabled && !unavailable && !unauthenticated,
@@ -584,7 +565,7 @@ class ConnectorSettingsModule {
           ...(checking ? { checking: true } : {})
         }
       })
-      .sort((a, b) => a.name.localeCompare(b.name))
+      .sort((a, b) => a.displayName.localeCompare(b.displayName))
   }
 
   private async connectorsSnapshot(): Promise<ConnectorsSnapshot> {

--- a/src/main/settings/connector-template.test.ts
+++ b/src/main/settings/connector-template.test.ts
@@ -9,7 +9,7 @@ describe('Connector configuration templates', () => {
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'example-research',
-        slug: 'example-research',
+        displayName: 'Example Research',
         transport: 'stdio',
         command: 'npx',
         args: ['-y', '@example/research-mcp'],
@@ -24,7 +24,7 @@ describe('Connector configuration templates', () => {
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'example-research',
-        slug: 'example-research',
+        displayName: 'Example Research',
         transport: 'stdio',
         command: 'npx',
         args: ['-y', '@example/research-mcp'],
@@ -39,6 +39,7 @@ describe('Connector configuration templates', () => {
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'example-remote',
+        displayName: 'example-remote',
         transport: 'streamable_http',
         url: 'https://mcp.example.test/mcp',
         oauth: { authorizationServerUrl: 'https://auth.example.test', scopes: ['openid'] }
@@ -52,30 +53,34 @@ describe('Connector configuration templates', () => {
     })
   })
 
-  it('derives a safe Connector ID from a display name and accepts an explicit portable ID', () => {
-    const derived = parseConnectorTemplate(
+  it('requires an explicit stable name separate from the display name', () => {
+    const valid = parseConnectorTemplate(
       JSON.stringify({
         schemaVersion: 1,
         kind: 'open-science.connector',
-        name: 'Example OAuth E2E',
+        name: 'example-oauth-e2e',
+        displayName: 'Example OAuth E2E',
         transport: 'streamable_http',
         url: 'https://mcp.example.test/mcp',
         oauth: {}
       })
     )
-    expect(derived.definition?.slug).toBe('example-oauth-e2e')
+    expect(valid.definition).toMatchObject({
+      name: 'example-oauth-e2e',
+      displayName: 'Example OAuth E2E'
+    })
 
-    const explicit = parseConnectorTemplate(
+    const invalid = parseConnectorTemplate(
       JSON.stringify({
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'Example OAuth E2E',
-        slug: 'example-e2e',
+        displayName: 'Example OAuth E2E',
         transport: 'streamable_http',
         url: 'https://mcp.example.test/mcp'
       })
     )
-    expect(explicit.definition?.slug).toBe('example-e2e')
+    expect(invalid.diagnostics.map((item) => item.code)).toContain('connector-template.name')
   })
 
   it.each([
@@ -89,6 +94,7 @@ describe('Connector configuration templates', () => {
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'example-server',
+        displayName: 'example-server',
         transport: 'streamable_http',
         url: 'https://mcp.example.test/mcp',
         ...extra
@@ -105,6 +111,7 @@ describe('Connector configuration templates', () => {
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'example-secret-query',
+        displayName: 'example-secret-query',
         transport: 'streamable_http',
         url: 'https://mcp.example.test/mcp?token_key=secret'
       })
@@ -118,6 +125,7 @@ describe('Connector configuration templates', () => {
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'example-ordinary-query',
+        displayName: 'example-ordinary-query',
         transport: 'streamable_http',
         url: 'https://mcp.example.test/mcp?monkey=capuchin&postcode=100000'
       })
@@ -131,6 +139,7 @@ describe('Connector configuration templates', () => {
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'example-server',
+        displayName: 'example-server',
         transport: 'stdio',
         command: 'node',
         args: ['/Users/example/bin/server.mjs', '--stdio']
@@ -150,6 +159,7 @@ describe('Connector configuration templates', () => {
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'example-command',
+        displayName: 'example-command',
         transport: 'stdio',
         command: '/opt/example/bin/server'
       })
@@ -170,6 +180,7 @@ describe('Connector configuration templates', () => {
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'example-remote',
+        displayName: 'example-remote',
         transport: 'streamable_http',
         url: 'https://mcp.example.test',
         oauth: { scopes: ['openid'] },
@@ -185,6 +196,7 @@ describe('Connector configuration templates', () => {
         schemaVersion: 1,
         kind: 'open-science.connector',
         name: 'example-remote',
+        displayName: 'example-remote',
         transport: 'streamable_http',
         url: 'https://mcp.example.test',
         requiredSecrets: { environment: ['API_TOKEN'] }
@@ -198,67 +210,36 @@ describe('Connector configuration templates', () => {
       JSON.stringify({
         schemaVersion: 1,
         kind: 'open-science.connector',
-        name: 'Example Server',
+        name: 'example-server',
+        displayName: 'Another display label',
         transport: 'stdio',
         command: 'example-mcp'
       }),
-      { existingNames: ['example server'] }
+      { existingNames: ['example-server'] }
     )
     expect(duplicate.diagnostics.map((item) => item.code)).toContain(
       'connector-template.duplicate-name'
     )
 
-    const duplicateSlug = parseConnectorTemplate(
+    const reusedDisplayName = parseConnectorTemplate(
       JSON.stringify({
         schemaVersion: 1,
         kind: 'open-science.connector',
-        name: 'Different display name',
-        slug: 'example-server',
+        name: 'different-route',
+        displayName: 'example-server',
         transport: 'stdio',
         command: 'example-mcp'
       }),
-      { existingSlugs: ['example-server'] }
+      { existingNames: ['example-server'] }
     )
-    expect(duplicateSlug.diagnostics.map((item) => item.code)).toContain(
-      'connector-template.duplicate-slug'
-    )
-
-    const legacyAliasCollision = parseConnectorTemplate(
-      JSON.stringify({
-        schemaVersion: 1,
-        kind: 'open-science.connector',
-        name: 'Different display name',
-        slug: 'legacy-route',
-        transport: 'stdio',
-        command: 'example-mcp'
-      }),
-      { existingIds: ['installed-uuid'], existingNames: ['legacy-route'] }
-    )
-    expect(legacyAliasCollision.diagnostics.map((item) => item.code)).toContain(
-      'connector-template.identity-conflict'
-    )
-
-    const uuidAliasCollision = parseConnectorTemplate(
-      JSON.stringify({
-        schemaVersion: 1,
-        kind: 'open-science.connector',
-        name: 'Different display name',
-        slug: 'installed-uuid',
-        transport: 'stdio',
-        command: 'example-mcp'
-      }),
-      { existingIds: ['installed-uuid'] }
-    )
-    expect(uuidAliasCollision.diagnostics.map((item) => item.code)).toContain(
-      'connector-template.identity-conflict'
-    )
+    expect(reusedDisplayName.ready).toBe(true)
   })
 
   it('exports only secret names and produces a stable digest', () => {
     const result = buildConnectorTemplateExport({
       id: 'local-id',
-      slug: 'example-server',
       name: 'example-server',
+      displayName: 'Example Server',
       transport: 'stdio',
       command: 'npx',
       args: ['-y', '@example/mcp'],

--- a/src/main/settings/connector-template.ts
+++ b/src/main/settings/connector-template.ts
@@ -9,12 +9,12 @@ import type {
   CustomServerTransport
 } from '../../shared/settings'
 import { CONNECTOR_TEMPLATE_MAX_BYTES } from '../../shared/settings'
-import { isCustomConnectorSlug, toCustomConnectorSlug } from '../../shared/custom-connector'
+import { isCustomConnectorName } from '../../shared/custom-connector'
 
 export type ConnectorTemplateSource = {
   id: string
-  slug: string
   name: string
+  displayName: string
   description?: string
   transport: CustomServerTransport
   command?: string
@@ -26,9 +26,7 @@ export type ConnectorTemplateSource = {
 }
 
 type ParseOptions = {
-  existingIds?: readonly string[]
   existingNames?: readonly string[]
-  existingSlugs?: readonly string[]
   bundledIds?: readonly string[]
 }
 
@@ -36,7 +34,7 @@ const ROOT_FIELDS = new Set([
   'schemaVersion',
   'kind',
   'name',
-  'slug',
+  'displayName',
   'description',
   'transport',
   'command',
@@ -408,16 +406,18 @@ export const parseConnectorTemplate = (
     )
   }
 
-  const name = readString(parsed.name, diagnostics, 'name', { required: true, max: 128 })
-  const requestedSlug = readString(parsed.slug, diagnostics, 'slug', { max: 64 })
-  const slug = requestedSlug ?? (name ? toCustomConnectorSlug(name) : undefined)
-  if (requestedSlug && !isCustomConnectorSlug(requestedSlug)) {
+  const name = readString(parsed.name, diagnostics, 'name', { required: true, max: 64 })
+  const displayName = readString(parsed.displayName, diagnostics, 'displayName', {
+    required: true,
+    max: 128
+  })
+  if (name && !isCustomConnectorName(name)) {
     diagnostic(
       diagnostics,
       'error',
-      'connector-template.slug',
-      'slug must use only lowercase letters, numbers, and hyphens.',
-      'slug'
+      'connector-template.name',
+      'name must use only lowercase letters, numbers, and hyphens.',
+      'name'
     )
   }
   const description = readString(parsed.description, diagnostics, 'description', { max: 2_000 })
@@ -502,77 +502,34 @@ export const parseConnectorTemplate = (
   validateArgs(args, diagnostics)
 
   if (name) {
-    const normalizedName = name.toLowerCase()
-    if (options.bundledIds?.some((id) => id.toLowerCase() === normalizedName)) {
+    if (options.bundledIds?.includes(name)) {
       diagnostic(
         diagnostics,
         'error',
         'connector-template.reserved-name',
-        `Connector name "${name}" is reserved by a built-in connector.`,
+        `Connector ID "${name}" is reserved by a built-in connector.`,
         'name'
       )
     }
-    if (options.existingNames?.some((item) => item.toLowerCase() === normalizedName)) {
+    if (options.existingNames?.includes(name)) {
       diagnostic(
         diagnostics,
         'error',
         'connector-template.duplicate-name',
-        `A custom Connector named "${name}" is already installed.`,
+        `A custom Connector with ID "${name}" is already installed.`,
         'name'
-      )
-    } else if (
-      [...(options.existingSlugs ?? []), ...(options.existingIds ?? [])].some(
-        (item) => item.toLowerCase() === normalizedName
-      )
-    ) {
-      diagnostic(
-        diagnostics,
-        'error',
-        'connector-template.identity-conflict',
-        `Connector name "${name}" conflicts with an installed Connector identity.`,
-        'name'
-      )
-    }
-  }
-  if (slug) {
-    if (options.bundledIds?.includes(slug)) {
-      diagnostic(
-        diagnostics,
-        'error',
-        'connector-template.reserved-slug',
-        `Connector ID "${slug}" is reserved by a built-in connector.`,
-        'slug'
-      )
-    }
-    if (options.existingSlugs?.includes(slug)) {
-      diagnostic(
-        diagnostics,
-        'error',
-        'connector-template.duplicate-slug',
-        `A custom Connector with ID "${slug}" is already installed.`,
-        'slug'
-      )
-    } else if (
-      [...(options.existingNames ?? []), ...(options.existingIds ?? [])].some(
-        (item) => item.toLowerCase() === slug
-      )
-    ) {
-      diagnostic(
-        diagnostics,
-        'error',
-        'connector-template.identity-conflict',
-        `Connector ID "${slug}" conflicts with an installed Connector alias.`,
-        'slug'
       )
     }
   }
 
-  if (hasErrors(diagnostics) || !name || !slug || !transport) return { diagnostics, ready: false }
+  if (hasErrors(diagnostics) || !name || !displayName || !transport) {
+    return { diagnostics, ready: false }
+  }
   const definition: ConnectorTemplateDefinition = {
     schemaVersion: 1,
     kind: 'open-science.connector',
     name,
-    slug,
+    displayName,
     transport,
     ...(description ? { description } : {}),
     ...(command ? { command } : {}),
@@ -594,7 +551,7 @@ export const buildConnectorTemplateExport = (
     schemaVersion: 1,
     kind: 'open-science.connector',
     name: source.name,
-    slug: source.slug,
+    displayName: source.displayName,
     transport: source.transport,
     ...(source.description ? { description: source.description } : {}),
     ...(source.command ? { command: source.command } : {}),
@@ -619,7 +576,7 @@ export const buildConnectorTemplateExport = (
     preview: {
       ...parsed,
       connectorId: source.id,
-      ...(digest ? { digest, suggestedFileName: `open-science-connector-${source.slug}.json` } : {})
+      ...(digest ? { digest, suggestedFileName: `open-science-connector-${source.name}.json` } : {})
     },
     ...(parsed.ready ? { contents } : {})
   }

--- a/src/main/settings/custom-mcp-settings.test.ts
+++ b/src/main/settings/custom-mcp-settings.test.ts
@@ -6,7 +6,8 @@ describe('sanitizeCustomMcpServer', () => {
     expect(
       sanitizeCustomMcpServer({
         id: 'srv-1',
-        name: 'My Server',
+        name: 'my-server',
+        displayName: 'My Server',
         transport: 'stdio',
         command: 'npx',
         args: ['-y', 'some-mcp-server'],
@@ -17,7 +18,8 @@ describe('sanitizeCustomMcpServer', () => {
       })
     ).toEqual({
       id: 'srv-1',
-      name: 'My Server',
+      name: 'my-server',
+      displayName: 'My Server',
       transport: 'stdio',
       command: 'npx',
       args: ['-y', 'some-mcp-server'],
@@ -28,26 +30,26 @@ describe('sanitizeCustomMcpServer', () => {
     })
   })
 
-  it('keeps a safe explicit slug and drops an invalid legacy value', () => {
+  it('uses the canonical name and ignores a legacy slug', () => {
     const base = {
       id: 'srv-1',
-      name: 'Example OAuth E2E',
+      name: 'example-oauth-e2e',
+      displayName: 'Example OAuth E2E',
       transport: 'stdio',
       command: 'npx',
       enabled: true
     }
 
-    expect(sanitizeCustomMcpServer({ ...base, slug: 'example-oauth-e2e' })).toMatchObject({
-      slug: 'example-oauth-e2e'
-    })
-    expect(sanitizeCustomMcpServer({ ...base, slug: '../unsafe' })).not.toHaveProperty('slug')
+    expect(sanitizeCustomMcpServer({ ...base, slug: 'different-name' })).toMatchObject(base)
+    expect(sanitizeCustomMcpServer({ ...base, slug: '../unsafe' })).toMatchObject(base)
   })
 
   it('drops a stdio server missing command', () => {
     expect(
       sanitizeCustomMcpServer({
         id: 'srv-1',
-        name: 'My Server',
+        name: 'my-server',
+        displayName: 'My Server',
         transport: 'stdio',
         enabled: true
       })
@@ -58,7 +60,8 @@ describe('sanitizeCustomMcpServer', () => {
     expect(
       sanitizeCustomMcpServer({
         id: 'srv-1',
-        name: 'My Server',
+        name: 'my-server',
+        displayName: 'My Server',
         transport: 'websocket',
         command: 'npx',
         enabled: true
@@ -78,7 +81,8 @@ describe('sanitizeCustomMcpServer', () => {
       })
     ).toEqual({
       id: 'srv-1',
-      name: 'My Server',
+      name: 'my-server',
+      displayName: 'My Server',
       transport: 'stdio',
       command: 'npx',
       env: { FOO: 'bar' },
@@ -90,7 +94,8 @@ describe('sanitizeCustomMcpServer', () => {
     expect(
       sanitizeCustomMcpServer({
         id: 'srv-remote',
-        name: 'Remote Server',
+        name: 'remote-server',
+        displayName: 'Remote Server',
         transport: 'streamable_http',
         url: 'https://example.com/mcp',
         headers: { Authorization: 'Bearer token' },
@@ -98,7 +103,8 @@ describe('sanitizeCustomMcpServer', () => {
       })
     ).toEqual({
       id: 'srv-remote',
-      name: 'Remote Server',
+      name: 'remote-server',
+      displayName: 'Remote Server',
       transport: 'streamable_http',
       url: 'https://example.com/mcp',
       headers: { Authorization: 'Bearer token' },
@@ -110,14 +116,16 @@ describe('sanitizeCustomMcpServer', () => {
     expect(
       sanitizeCustomMcpServer({
         id: 'srv-sse',
-        name: 'SSE Server',
+        name: 'sse-server',
+        displayName: 'SSE Server',
         transport: 'sse',
         url: 'https://example.com/sse',
         enabled: true
       })
     ).toEqual({
       id: 'srv-sse',
-      name: 'SSE Server',
+      name: 'sse-server',
+      displayName: 'SSE Server',
       transport: 'sse',
       url: 'https://example.com/sse',
       enabled: true
@@ -128,7 +136,8 @@ describe('sanitizeCustomMcpServer', () => {
     expect(
       sanitizeCustomMcpServer({
         id: 'srv-remote',
-        name: 'Remote Server',
+        name: 'remote-server',
+        displayName: 'Remote Server',
         transport: 'streamable_http',
         enabled: true
       })
@@ -136,7 +145,8 @@ describe('sanitizeCustomMcpServer', () => {
     expect(
       sanitizeCustomMcpServer({
         id: 'srv-sse',
-        name: 'SSE Server',
+        name: 'sse-server',
+        displayName: 'SSE Server',
         transport: 'sse',
         enabled: true
       })
@@ -147,7 +157,8 @@ describe('sanitizeCustomMcpServer', () => {
     expect(
       sanitizeCustomMcpServer({
         id: 'srv-remote',
-        name: 'Remote Server',
+        name: 'remote-server',
+        displayName: 'Remote Server',
         transport: 'streamable_http',
         url: 'https://example.com/mcp',
         headers: { Authorization: 'Bearer token', BAD: 42 },
@@ -155,7 +166,8 @@ describe('sanitizeCustomMcpServer', () => {
       })
     ).toEqual({
       id: 'srv-remote',
-      name: 'Remote Server',
+      name: 'remote-server',
+      displayName: 'Remote Server',
       transport: 'streamable_http',
       url: 'https://example.com/mcp',
       headers: { Authorization: 'Bearer token' },
@@ -167,7 +179,8 @@ describe('sanitizeCustomMcpServer', () => {
     expect(
       sanitizeCustomMcpServer({
         id: 'srv-oauth',
-        name: 'OAuth Server',
+        name: 'oauth-server',
+        displayName: 'OAuth Server',
         transport: 'streamable_http',
         url: 'https://example.com/mcp',
         enabled: true,
@@ -182,7 +195,8 @@ describe('sanitizeCustomMcpServer', () => {
       })
     ).toEqual({
       id: 'srv-oauth',
-      name: 'OAuth Server',
+      name: 'oauth-server',
+      displayName: 'OAuth Server',
       transport: 'streamable_http',
       url: 'https://example.com/mcp',
       enabled: true,
@@ -201,14 +215,28 @@ describe('sanitizeConnectors customMcpServers', () => {
       enabledIds: [],
       autoAllowIds: [],
       customMcpServers: [
-        { id: 'srv-1', name: 'Valid', transport: 'stdio', command: 'npx', enabled: true },
+        {
+          id: 'srv-1',
+          name: 'valid',
+          displayName: 'Valid',
+          transport: 'stdio',
+          command: 'npx',
+          enabled: true
+        },
         { id: 'srv-2', name: 'Missing command', transport: 'stdio', enabled: true },
         { id: '', name: 'No id', transport: 'stdio', command: 'npx', enabled: true }
       ]
     })
 
     expect(result?.customMcpServers).toEqual([
-      { id: 'srv-1', name: 'Valid', transport: 'stdio', command: 'npx', enabled: true }
+      {
+        id: 'srv-1',
+        name: 'valid',
+        displayName: 'Valid',
+        transport: 'stdio',
+        command: 'npx',
+        enabled: true
+      }
     ])
   })
 
@@ -220,5 +248,30 @@ describe('sanitizeConnectors customMcpServers', () => {
     })
 
     expect(result?.customMcpServers).toBeUndefined()
+  })
+
+  it('does not treat a custom server UUID or displayName as a policy identity', () => {
+    const result = sanitizeConnectors({
+      enabledIds: [],
+      autoAllowIds: ['chemistry', 'srv-1'],
+      blockedToolIds: ['chemistry/search', 'srv-1/write'],
+      askToolIds: ['chemistry/lookup', 'srv-1/read'],
+      customMcpServers: [
+        {
+          id: 'srv-1',
+          name: 'custom-chemistry',
+          displayName: 'chemistry',
+          transport: 'stdio',
+          command: 'npx',
+          enabled: true
+        }
+      ]
+    })
+
+    expect(result).toMatchObject({
+      autoAllowIds: ['chemistry', 'srv-1'],
+      blockedToolIds: ['chemistry/search', 'srv-1/write'],
+      askToolIds: ['chemistry/lookup', 'srv-1/read']
+    })
   })
 })

--- a/src/main/settings/integration-application-commands.test.ts
+++ b/src/main/settings/integration-application-commands.test.ts
@@ -317,7 +317,9 @@ describe('Settings integration application commands', () => {
     )
     await router.dispatcher.invoke(
       settingsIntegrationApplicationCommands.addCustomServer,
-      invocation([{ name: 'custom', transport: 'stdio', command: 'custom-mcp' }] as const)
+      invocation([
+        { name: 'custom', displayName: 'Custom', transport: 'stdio', command: 'custom-mcp' }
+      ] as const)
     )
     await router.dispatcher.invoke(
       settingsIntegrationApplicationCommands.setCustomServerEnabled,
@@ -357,6 +359,7 @@ describe('Settings integration application commands', () => {
     })
     expect(connectorMethod('addCustomServer')).toHaveBeenCalledWith({
       name: 'custom',
+      displayName: 'Custom',
       transport: 'stdio',
       command: 'custom-mcp'
     })

--- a/src/main/settings/record-codec.ts
+++ b/src/main/settings/record-codec.ts
@@ -6,7 +6,7 @@ import type {
   ValidationCategory
 } from '../../shared/settings'
 import { isCodexSubscriptionProvider } from '../../shared/settings'
-import { isCustomConnectorSlug } from '../../shared/custom-connector'
+import { isCustomConnectorName, toCustomConnectorName } from '../../shared/custom-connector'
 import type { PackageMirror } from '../../shared/mirror'
 import { isOfficialVendorId } from '../../shared/provider-registry'
 import {
@@ -214,12 +214,24 @@ export const sanitizeProvider = (value: unknown): StoredProvider | undefined => 
 export const sanitizeCustomMcpServer = (value: unknown): StoredCustomMcpServer | undefined => {
   if (!isRecord(value)) return undefined
   const id = asString(value.id)
-  const name = asString(value.name)
+  const storedName = asString(value.name)
+  const storedDisplayName = asString(value.displayName)
+  const legacySlug = asString(value.slug)
+  const name = storedDisplayName
+    ? storedName
+    : legacySlug && isCustomConnectorName(legacySlug)
+      ? legacySlug
+      : storedName
+        ? toCustomConnectorName(storedName)
+        : undefined
+  const displayName = storedDisplayName ?? storedName
   const transport = asString(value.transport) as StoredCustomMcpServer['transport'] | undefined
   const enabled = asBoolean(value.enabled)
   if (
     !id ||
     !name ||
+    !displayName ||
+    !isCustomConnectorName(name) ||
     !transport ||
     !CUSTOM_MCP_TRANSPORTS.has(transport) ||
     enabled === undefined
@@ -231,9 +243,7 @@ export const sanitizeCustomMcpServer = (value: unknown): StoredCustomMcpServer |
   if (transport === 'stdio' && !command) return undefined
   if ((transport === 'streamable_http' || transport === 'sse') && !url) return undefined
 
-  const storedSlug = asString(value.slug)
-  const server: StoredCustomMcpServer = { id, name, transport, enabled }
-  if (storedSlug && isCustomConnectorSlug(storedSlug)) server.slug = storedSlug
+  const server: StoredCustomMcpServer = { id, name, displayName, transport, enabled }
   if (command) server.command = command
   const args = asStringArray(value.args)
   if (args.length) server.args = args
@@ -305,7 +315,9 @@ export const sanitizeConnectors = (value: unknown): StoredConnectors | undefined
         .map(sanitizeCustomMcpServer)
         .filter((server): server is StoredCustomMcpServer => !!server)
     : []
-  if (customMcpServers.length) connectors.customMcpServers = customMcpServers
+  if (customMcpServers.length) {
+    connectors.customMcpServers = customMcpServers
+  }
   return connectors
 }
 

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -20,7 +20,6 @@ import type { PackageMirror } from '../../shared/mirror'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
 import type { CloseActionPreference } from '../../shared/window-controls'
-import { customConnectorSlug } from '../../shared/custom-connector'
 import {
   type StoredComputeGrant,
   type StoredConnectors,
@@ -552,14 +551,14 @@ class SettingsRepository {
     })
   }
 
-  // Removes a custom MCP server by id and every policy alias owned by its local id/public identity.
+  // Removes a custom MCP server by id and policy entries owned by its public name.
   async removeCustomServer(id: string): Promise<StoredSettings> {
     return this.mutateConnectors((connectors) => {
       const removed = (connectors.customMcpServers ?? []).find((s) => s.id === id)
       connectors.customMcpServers = (connectors.customMcpServers ?? []).filter((s) => s.id !== id)
       if (!removed) return
 
-      const aliases = new Set([removed.id, customConnectorSlug(removed), removed.name])
+      const aliases = new Set([removed.name])
       connectors.autoAllowIds = connectors.autoAllowIds.filter((entry) => !aliases.has(entry))
       const withoutToolAliases = (entries: string[] | undefined): string[] | undefined => {
         const kept = (entries ?? []).filter(

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -257,7 +257,8 @@ describe('SettingsService: custom MCP OAuth', () => {
   it('delegates authentication and returns the refreshed connector snapshot', async () => {
     const service = createService()
     const added = await service.addCustomServer({
-      name: 'OAuth MCP',
+      name: 'oauth-mcp',
+      displayName: 'OAuth MCP',
       transport: 'streamable_http',
       url: 'https://mcp.example.test',
       oauth: { scopes: ['openid'] }
@@ -3611,7 +3612,8 @@ describe('SettingsService: skills', () => {
     expect(skills).toEqual([
       expect.objectContaining({
         id: 'demo',
-        name: 'Demo',
+        name: 'demo',
+        displayName: 'Demo',
         description: 'A demo skill.',
         enabled: true
       })
@@ -3640,7 +3642,7 @@ describe('SettingsService: skills', () => {
     const service = await createSkillService()
 
     let skills = await service.createSkill({
-      name: 'My Skill',
+      name: 'my-skill',
       description: 'Mine.',
       body: '# Mine',
       metadata: { author: 'Ada', license: 'MIT', category: 'research' }
@@ -3656,7 +3658,6 @@ describe('SettingsService: skills', () => {
 
     skills = await service.updateSkill({
       id: 'personal-my-skill',
-      name: 'My Skill',
       description: 'Edited.',
       body: '# Edited',
       metadata: detail.metadata
@@ -3672,7 +3673,7 @@ describe('SettingsService: skills', () => {
 
   it('runs the shared live-reference guard before direct Skill deletion', async () => {
     const service = await createSkillService()
-    await service.createSkill({ name: 'My Skill', description: 'Mine.', body: '# Mine' })
+    await service.createSkill({ name: 'my-skill', description: 'Mine.', body: '# Mine' })
     const guard = vi.fn().mockRejectedValue(
       Object.assign(new Error('Skill is referenced by specialist-1.'), {
         code: 'protected-skill'
@@ -3689,7 +3690,7 @@ describe('SettingsService: skills', () => {
 
   it('checks live Specialist references atomically with direct Skill deletion', async () => {
     const service = await createSkillService()
-    await service.createSkill({ name: 'My Skill', description: 'Mine.', body: '# Mine' })
+    await service.createSkill({ name: 'my-skill', description: 'Mine.', body: '# Mine' })
     const packageSkills = new UserSkillSpecialistPackageAdapter(storageRoot)
     await packageSkills.beginMutation('tx-delete-race', 'research-synth', [])
 
@@ -3713,15 +3714,14 @@ describe('SettingsService: skills', () => {
     await expect(service.getSkillDetail('personal-my-skill')).resolves.toBeDefined()
   })
 
-  it('creates with a custom slug and reconciles references reported by the detail view', async () => {
+  it('uses the immutable name and reconciles references reported by the detail view', async () => {
     const service = await createSkillService()
     const b64 = (text: string): string => Buffer.from(text).toString('base64')
 
     await service.createSkill({
-      name: 'Ref Skill',
+      name: 'ref-skill-id',
       description: 'd',
       body: '# body',
-      slug: 'ref-skill-id',
       references: [
         { path: 'keep.py', dataBase64: b64('keep') },
         { path: 'drop.py', dataBase64: b64('drop') }
@@ -3734,7 +3734,6 @@ describe('SettingsService: skills', () => {
     // Editing keeps one file, drops one, and adds one.
     await service.updateSkill({
       id: 'personal-ref-skill-id',
-      name: 'Ref Skill',
       description: 'd',
       body: '# body',
       references: [{ path: 'keep.py' }, { path: 'new.py', dataBase64: b64('new') }]
@@ -4079,7 +4078,7 @@ describe('SettingsService: skills', () => {
   it('reports disabled picks and resolves agent-readable skill nudge names', async () => {
     const service = await createSkillService()
 
-    await service.createSkill({ name: 'My Skill', description: 'Mine.', body: '# Mine' })
+    await service.createSkill({ name: 'my-skill', description: 'Mine.', body: '# Mine' })
     await service.setSkillEnabled({ id: 'demo', enabled: false })
 
     // Only the disabled pick (demo) needs a respawn; the enabled personal skill does not.
@@ -4089,7 +4088,7 @@ describe('SettingsService: skills', () => {
     // Featured ids are the agent-facing frontmatter names, but user-skill ids carry an app prefix.
     expect(await service.skillNudgeNamesForIds(['demo', 'personal-my-skill', 'nope'])).toEqual([
       'demo',
-      'My Skill'
+      'my-skill'
     ])
   })
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -510,8 +510,8 @@ class SettingsService {
     return this.skills.withHostSkillRead(id, read)
   }
 
-  async publishHostSkill(slug: string, sourcePath: string, overwrite: boolean): Promise<string> {
-    return this.skills.publishHostSkill(slug, sourcePath, overwrite)
+  async publishHostSkill(name: string, sourcePath: string, overwrite: boolean): Promise<string> {
+    return this.skills.publishHostSkill(name, sourcePath, overwrite)
   }
 
   async buildSkillExport(id: string): Promise<SkillExportArchive> {

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -253,7 +253,7 @@ describe('SkillCatalogModule', () => {
       })
     ).resolves.toEqual([])
     expect(
-      (await catalog.createSkill({ name: 'My Skill', description: 'Mine.', body: '# Mine' })).map(
+      (await catalog.createSkill({ name: 'my-skill', description: 'Mine.', body: '# Mine' })).map(
         (skill) => skill.id
       )
     ).toEqual(['demo', 'personal-my-skill'])
@@ -261,12 +261,19 @@ describe('SkillCatalogModule', () => {
       (
         await catalog.updateSkill({
           id: 'personal-my-skill',
-          name: 'My Skill',
           description: 'Edited.',
           body: '# Edited'
         })
       ).find((skill) => skill.id === 'personal-my-skill')
     ).toMatchObject({ description: 'Edited.' })
+    await expect(
+      catalog.updateSkill({
+        id: 'personal-my-skill',
+        name: 'Renamed Skill',
+        description: 'Edited.',
+        body: '# Edited'
+      } as never)
+    ).rejects.toThrow('Skill name is immutable.')
     expect(
       (await catalog.deleteSkill({ id: 'personal-my-skill' })).map((skill) => skill.id)
     ).toEqual(['demo'])
@@ -323,7 +330,7 @@ describe('SkillCatalogModule', () => {
   it('exports a personal Skill as a portable ZIP archive', async () => {
     const catalog = await createCatalog()
     await catalog.createSkill({
-      name: 'My Skill',
+      name: 'my-skill',
       description: 'Mine.',
       body: '# Mine',
       references: [

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -170,8 +170,8 @@ class SkillCatalogModule {
     return bundled ? read(bundled) : this.userSkills.withSkillReadLock(id, read)
   }
 
-  async publishHostSkill(slug: string, sourcePath: string, overwrite: boolean): Promise<string> {
-    return this.userSkills.publishPersonalDirectory(slug, sourcePath, overwrite)
+  async publishHostSkill(name: string, sourcePath: string, overwrite: boolean): Promise<string> {
+    return this.userSkills.publishPersonalDirectory(name, sourcePath, overwrite)
   }
 
   async listSkills(): Promise<SkillView[]> {
@@ -201,8 +201,8 @@ class SkillCatalogModule {
     const disabled = new Set(settings.disabledSkillIds ?? [])
     return skills.map((skill) => ({
       id: skill.id,
-      frameworkName: skill.source === 'featured' ? skill.id : skill.name,
-      displayName: skill.name,
+      frameworkName: skill.name,
+      displayName: skill.displayName,
       source: skill.source,
       mainEnabled: !disabled.has(skill.id),
       // Catalog entries are installed skills, so they resolve to a present entry at dispatch time.
@@ -218,12 +218,7 @@ class SkillCatalogModule {
   }
 
   async skillNudgeNamesForIds(ids: string[]): Promise<string[]> {
-    const nameById = new Map(
-      (await this.managedCatalog()).map((skill) => [
-        skill.id,
-        skill.source === 'featured' ? skill.id : skill.name
-      ])
-    )
+    const nameById = new Map((await this.managedCatalog()).map((skill) => [skill.id, skill.name]))
     return ids.map((id) => nameById.get(id)).filter((name): name is string => name !== undefined)
   }
 
@@ -246,7 +241,7 @@ class SkillCatalogModule {
       const realFile = await realpath(filePath).catch(() => undefined)
       if (!realFile || !realFile.startsWith(rootWithSep)) continue
       descriptors.push({
-        name: skill.source === 'featured' ? skill.id : skill.name,
+        name: skill.name,
         path: filePath
       })
     }
@@ -277,7 +272,7 @@ class SkillCatalogModule {
         .filter((skill) => skill.exposure === 'internal' || !disabled.has(skill.id))
         .map((skill) => ({
           directory: `${OS_SKILL_PREFIX}${skill.id}`,
-          name: skill.source === 'featured' ? skill.id : skill.name,
+          name: skill.name,
           description: skill.description
         })),
       ...extensions
@@ -346,13 +341,18 @@ class SkillCatalogModule {
   }
 
   async createSkill(request: CreateSkillRequest): Promise<SkillView[]> {
-    await this.userSkills.createPersonal(request, request.slug)
+    await this.userSkills.createPersonal(request)
     return this.listSkills()
   }
 
   async updateSkill(request: UpdateSkillRequest): Promise<SkillView[]> {
+    if ('name' in request) throw new Error('Skill name is immutable.')
+    const skill = (await this.managedCatalog()).find((entry) => entry.id === request.id)
+    if (!skill || skill.source !== 'personal') {
+      throw new Error(`Not a personal skill id: ${request.id}`)
+    }
     await this.userSkills.updatePersonal(request.id, {
-      name: request.name,
+      name: skill.name,
       description: request.description,
       body: request.body,
       metadata: request.metadata,
@@ -816,6 +816,7 @@ class SkillCatalogModule {
     return {
       id: skill.id,
       name: skill.name,
+      displayName: skill.displayName,
       description: skill.description,
       source: skill.source,
       updatedAt: skill.updatedAt,

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -99,9 +99,10 @@ export type StoredCustomMcpOAuthState = {
 // the main process when constructing the MCP transport.
 export type StoredCustomMcpServer = {
   id: string
-  // Added after custom Connectors shipped. Older records derive it from immutable `name` on read.
-  slug?: string
+  // Immutable public invocation name used by host.mcp, Specialists, policy, and generated Skills.
   name: string
+  // Presentation-only label. It may enter context but never participates in identity resolution.
+  displayName: string
   transport: 'stdio' | 'streamable_http' | 'sse'
   command?: string
   args?: string[]

--- a/src/main/settings/workflows.test.ts
+++ b/src/main/settings/workflows.test.ts
@@ -555,6 +555,24 @@ describe('SettingsWorkflows catalog and appearance effects', () => {
     expect(refreshConnectorSkillDocs).toHaveBeenCalledWith('server-1')
   })
 
+  it('regenerates Connector Skill docs after a displayName update', async () => {
+    const { store, capability } = fakeStore()
+    const refreshConnectorSkillDocs = vi.fn(async () => undefined)
+    store.updateCustomServer.mockResolvedValue({ connectors: [] })
+
+    await createSettingsWorkflows(
+      capability,
+      testEffects({ refreshConnectorSkillDocs })
+    ).connectors.updateCustomServer({
+      id: 'server-1',
+      displayName: 'Updated label',
+      transport: 'stdio',
+      command: 'mcp'
+    })
+
+    expect(refreshConnectorSkillDocs).toHaveBeenCalledOnce()
+  })
+
   it('refreshes Connector projections after OAuth authentication', async () => {
     const calls: string[] = []
     const { store, capability } = fakeStore()

--- a/src/main/skills/export.test.ts
+++ b/src/main/skills/export.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { unzipSync } from 'fflate'
+import { strFromU8, unzipSync } from 'fflate'
 
 import { buildSkillExportArchive, saveSkillExport, skillExportFileName } from './export'
 import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
@@ -66,6 +66,7 @@ describe('Skill ZIP export', () => {
       buildSkillExportArchive({
         id: 'personal-safe',
         name: 'Safe',
+        displayName: 'Safe',
         description: '',
         source: 'personal',
         updatedAt: '2026-08-07T00:00:00.000Z',
@@ -84,6 +85,7 @@ describe('Skill ZIP export', () => {
       buildSkillExportArchive({
         id: 'personal-large',
         name: 'Large',
+        displayName: 'Large',
         description: '',
         source: 'personal',
         updatedAt: '2026-08-07T00:00:00.000Z',
@@ -92,22 +94,29 @@ describe('Skill ZIP export', () => {
     ).rejects.toThrow('Skill file exceeds the export size limit.')
   })
 
-  it('omits Specialist ownership metadata from a portable archive', async () => {
+  it('omits app-only metadata and displayName from a portable archive', async () => {
     const root = await mkdtemp(join(tmpdir(), 'skill-export-metadata-'))
     roots.push(root)
-    await writeFile(join(root, 'SKILL.md'), '# Portable')
+    await writeFile(
+      join(root, 'SKILL.md'),
+      '---\nname: portable-skill\ndisplayName: >\n  Portable Skill\ndescription: Portable.\n---\nBody.'
+    )
     await writeFile(join(root, '.specialist-package.json'), '{"ownerIds":["specialist"]}')
 
     const exported = await buildSkillExportArchive({
       id: 'portable-skill',
       name: 'Portable',
+      displayName: 'Portable',
       description: '',
       source: 'personal',
       updatedAt: '2026-08-07T00:00:00.000Z',
       sourceDir: root
     })
 
-    expect(Object.keys(unzipSync(exported.archiveBytes))).toEqual(['SKILL.md'])
+    const archive = unzipSync(exported.archiveBytes)
+    expect(Object.keys(archive)).toEqual(['SKILL.md'])
+    expect(strFromU8(archive['SKILL.md']!)).not.toContain('displayName')
+    expect(strFromU8(archive['SKILL.md']!)).toContain('Body.')
   })
 
   it.each(['.hidden', '__MACOSX/metadata'])(
@@ -123,6 +132,7 @@ describe('Skill ZIP export', () => {
         buildSkillExportArchive({
           id: 'personal-portable',
           name: 'Portable',
+          displayName: 'Portable',
           description: '',
           source: 'personal',
           updatedAt: '2026-08-07T00:00:00.000Z',
@@ -144,6 +154,7 @@ describe('Skill ZIP export', () => {
         buildSkillExportArchive({
           id: 'personal-portable',
           name: 'Portable',
+          displayName: 'Portable',
           description: '',
           source: 'personal',
           updatedAt: '2026-08-07T00:00:00.000Z',

--- a/src/main/skills/export.ts
+++ b/src/main/skills/export.ts
@@ -2,6 +2,7 @@ import { lstat, readFile, readdir } from 'node:fs/promises'
 import { basename, join, posix } from 'node:path'
 
 import { zipSync, type Zippable } from 'fflate'
+import { dump as dumpYaml, load as loadYaml, FAILSAFE_SCHEMA } from 'js-yaml'
 
 import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 import type { BundledSkill } from './registry'
@@ -9,6 +10,23 @@ import { isUnsafeSkillArchivePath } from './zip-extract'
 
 const INTERNAL_SKILL_FILES = new Set(['.source.json', '.specialist-package.json'])
 const WINDOWS_RESERVED_BASENAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])$/i
+
+const withoutDisplayName = (raw: string): string => {
+  const normalized = raw.replace(/\r\n?/g, '\n')
+  const match = /^---\n([\s\S]*?)\n---\n?/.exec(normalized)
+  if (!match) return raw
+
+  const parsed = loadYaml(match[1], { schema: FAILSAFE_SCHEMA })
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return raw
+  const fields = Object.entries(parsed as Record<string, unknown>)
+  if (!fields.some(([key]) => key.toLowerCase() === 'displayname')) return raw
+
+  const frontmatter = Object.fromEntries(
+    fields.filter(([key]) => key.toLowerCase() !== 'displayname')
+  )
+  const separator = match[0].endsWith('\n') ? '\n' : ''
+  return `---\n${dumpYaml(frontmatter, { lineWidth: -1 }).trimEnd()}\n---${separator}${normalized.slice(match[0].length)}`
+}
 
 export type SkillExportArchive = {
   fileName: string
@@ -84,7 +102,12 @@ const collectFiles = async (
       if (state.totalBytes > SKILL_IMPORT_LIMITS.maxTotalBytes) {
         throw new Error('Skill tree exceeds the total export size limit.')
       }
-      const bytes = new Uint8Array(await readFile(absolutePath))
+      let bytes = new Uint8Array(await readFile(absolutePath))
+      if (relativePath === 'SKILL.md') {
+        bytes = new TextEncoder().encode(
+          withoutDisplayName(new TextDecoder('utf-8', { fatal: true }).decode(bytes))
+        )
+      }
       state.totalBytes += bytes.byteLength - metadata.size
       if (bytes.byteLength > SKILL_IMPORT_LIMITS.maxFileBytes) {
         throw new Error('Skill file exceeds the export size limit.')
@@ -104,7 +127,7 @@ const collectFiles = async (
 export const buildSkillExportArchive = async (
   skill: BundledSkill
 ): Promise<SkillExportArchive> => ({
-  fileName: skillExportFileName(skill.name, basename(skill.sourceDir) || skill.id),
+  fileName: skillExportFileName(skill.displayName, basename(skill.sourceDir) || skill.id),
   archiveBytes: zipSync(await collectFiles(skill.sourceDir), { level: 6 })
 })
 

--- a/src/main/skills/host-skills-service.test.ts
+++ b/src/main/skills/host-skills-service.test.ts
@@ -33,6 +33,7 @@ const makeFixture = async (): Promise<{
   const featured: BundledSkill = {
     id: 'literature-review',
     name: 'literature-review',
+    displayName: 'Literature Review',
     description: 'Review literature.',
     source: 'featured',
     updatedAt: '2026-08-09',
@@ -45,8 +46,8 @@ const makeFixture = async (): Promise<{
       if (id === featured.id) return read(featured)
       return userSkills.withSkillReadLock(id, read)
     },
-    publishPersonalDirectory: (slug, sourcePath, overwrite) =>
-      userSkills.publishPersonalDirectory(slug, sourcePath, overwrite),
+    publishPersonalDirectory: (name, sourcePath, overwrite) =>
+      userSkills.publishPersonalDirectory(name, sourcePath, overwrite),
     deletePublished: (id) => userSkills.delete(id)
   }
   const approveDelete = vi.fn(async () => true)
@@ -155,6 +156,7 @@ describe('HostSkillsService', () => {
       {
         id: 'literature-review',
         name: 'literature-review',
+        displayName: 'Literature Review',
         description: 'Review literature.',
         origin: 'featured',
         editable: false
@@ -162,6 +164,7 @@ describe('HostSkillsService', () => {
       {
         id: 'draft-new-skill',
         name: 'new-skill',
+        displayName: 'new-skill',
         description: 'New skill.',
         origin: 'draft',
         editable: true
@@ -256,14 +259,14 @@ describe('HostSkillsService', () => {
 
     await expect(
       service.dispatch({ op: 'publish', params: { name: 'extra-metadata' } })
-    ).rejects.toThrow('frontmatter must contain exactly name and description')
+    ).rejects.toThrow('frontmatter may only contain name, displayName, and description')
     expect(await userSkills.list()).toHaveLength(0)
   })
 
   it('deletes an explicit draft without deleting its published Personal Skill', async () => {
     const { service, root, userSkills, approveDelete, reload } = await makeFixture()
     await userSkills.createPersonal({
-      name: 'Disposable',
+      name: 'disposable',
       description: 'Delete me.',
       body: 'Published body.'
     })
@@ -305,7 +308,7 @@ describe('HostSkillsService', () => {
   it('edits a draft by the stable id returned from list', async () => {
     const { service, userSkills } = await makeFixture()
     await userSkills.createPersonal({
-      name: 'Editable',
+      name: 'editable',
       description: 'Edit me.',
       body: 'Published body.'
     })
@@ -339,7 +342,7 @@ describe('HostSkillsService', () => {
     ).resolves.toMatchObject({ content: expect.stringContaining('Second draft.') })
   })
 
-  it('allows a new Skill slug to start with the draft prefix', async () => {
+  it('allows a new Skill name to start with the draft prefix', async () => {
     const { service } = await makeFixture()
 
     await expect(
@@ -357,21 +360,21 @@ describe('HostSkillsService', () => {
     )
   })
 
-  it('resolves an exact published stable id before colliding public slugs', async () => {
+  it('resolves an exact published stable id before a colliding immutable name', async () => {
     const { service, userSkills } = await makeFixture()
-    await userSkills.createPersonal({ name: 'Foo', description: 'Exact id.', body: 'Exact body.' })
+    await userSkills.createPersonal({ name: 'foo', description: 'Exact id.', body: 'Exact body.' })
     await userSkills.createPersonal({
-      name: 'Personal Foo',
-      description: 'Colliding slug.',
+      name: 'personal-foo',
+      description: 'Colliding name.',
       body: 'Collision body.'
     })
 
     await expect(
       service.dispatch({ op: 'read', params: { name: 'personal-foo' } })
-    ).resolves.toMatchObject({ name: 'Foo', content: expect.stringContaining('Exact body.') })
+    ).resolves.toMatchObject({ name: 'foo', content: expect.stringContaining('Exact body.') })
   })
 
-  it('rejects an unqualified delete when a published display name matches a draft slug', async () => {
+  it('rejects an unqualified delete when a published display name matches a draft name', async () => {
     const { service, catalog, root, approveDelete } = await makeFixture()
     await service.dispatch({
       op: 'edit',
@@ -387,6 +390,7 @@ describe('HostSkillsService', () => {
       {
         id: 'custom-package-id',
         name: 'shared-name',
+        displayName: 'Shared name',
         description: 'Published alias.',
         source: 'imported',
         updatedAt: '2026-08-09',
@@ -403,7 +407,7 @@ describe('HostSkillsService', () => {
     expect(approveDelete).not.toHaveBeenCalled()
   })
 
-  it('rejects reserved Skill slugs before creating a draft', async () => {
+  it('rejects reserved Skill names before creating a draft', async () => {
     const { service } = await makeFixture()
 
     for (const name of ['os-review', 'mcp-review']) {
@@ -424,7 +428,7 @@ describe('HostSkillsService', () => {
   it('requires approval for delete and reports a decline as a normal result', async () => {
     const { service, userSkills, approveDelete, reload } = await makeFixture()
     await userSkills.createPersonal({
-      name: 'Disposable',
+      name: 'disposable',
       description: 'Delete me.',
       body: 'Body.'
     })
@@ -444,7 +448,7 @@ describe('HostSkillsService', () => {
         { op: 'delete', params: { name: 'personal-disposable' } },
         { sessionId: 'session-1' }
       )
-    ).resolves.toEqual({ status: 'deleted', operation: 'delete', name: 'Disposable' })
+    ).resolves.toEqual({ status: 'deleted', operation: 'delete', name: 'disposable' })
     expect(await userSkills.list()).toHaveLength(0)
     expect(reload).toHaveBeenCalledTimes(1)
   })

--- a/src/main/skills/host-skills-service.ts
+++ b/src/main/skills/host-skills-service.ts
@@ -6,13 +6,13 @@ import type { TrustedCallingSession } from '../../shared/agents-contract'
 import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 import { frontmatterFieldNames, parseSkillDocument } from './frontmatter'
 import type { BundledSkill } from './registry'
-import { SAFE_SLUG, assertUsableSlug, parseUserSkillId } from './user-skill-repository'
+import { SAFE_SKILL_NAME, assertUsableSkillName, parseUserSkillId } from './user-skill-repository'
 import { isUnsafeSkillArchivePath } from './zip-extract'
 
 export type HostSkillsCatalog = {
   list(): Promise<BundledSkill[]>
   withSkillRead<T>(id: string, read: (skill: BundledSkill) => Promise<T>): Promise<T | undefined>
-  publishPersonalDirectory(slug: string, sourcePath: string, overwrite: boolean): Promise<string>
+  publishPersonalDirectory(name: string, sourcePath: string, overwrite: boolean): Promise<string>
   deletePublished(id: string): Promise<void>
 }
 
@@ -67,12 +67,13 @@ const readPackageText = async (root: string, relativePath: string): Promise<stri
   return readBoundedText(current)
 }
 
-const publicSlug = (skill: BundledSkill): string | undefined => parseUserSkillId(skill.id)?.slug
+const personalDirectoryName = (skill: BundledSkill): string | undefined =>
+  parseUserSkillId(skill.id)?.slug
 
-const explicitDraftSlug = (reference: string): string | undefined => {
+const explicitDraftName = (reference: string): string | undefined => {
   if (!reference.startsWith('draft-')) return undefined
-  const slug = reference.slice('draft-'.length)
-  return SAFE_SLUG.test(slug) ? slug : undefined
+  const name = reference.slice('draft-'.length)
+  return SAFE_SKILL_NAME.test(name) ? name : undefined
 }
 
 class HostSkillsCallError extends Error {
@@ -133,14 +134,14 @@ export class HostSkillsService {
     }
   }
 
-  private draftDir(slug: string): string {
-    return join(this.draftsRoot, slug)
+  private draftDir(name: string): string {
+    return join(this.draftsRoot, name)
   }
 
-  private async draftSlugs(): Promise<string[]> {
+  private async draftNames(): Promise<string[]> {
     try {
       return (await readdir(this.draftsRoot, { withFileTypes: true }))
-        .filter((entry) => entry.isDirectory() && SAFE_SLUG.test(entry.name))
+        .filter((entry) => entry.isDirectory() && SAFE_SKILL_NAME.test(entry.name))
         .map((entry) => entry.name)
     } catch {
       return []
@@ -151,22 +152,34 @@ export class HostSkillsService {
     const installed = (await this.options.catalog.list()).map((skill) => ({
       id: skill.id,
       name: skill.name,
+      displayName: skill.displayName,
       description: skill.description,
       origin: skill.source,
       editable: skill.source === 'personal'
     }))
     const drafts = await Promise.all(
-      (await this.draftSlugs()).map(async (slug) => {
-        let name = slug
+      (await this.draftNames()).map(async (draftName) => {
+        let name = draftName
+        let displayName = draftName
         let description = ''
         try {
-          const parsed = parseSkillDocument(await readPackageText(this.draftDir(slug), 'SKILL.md'))
-          name = parsed.name?.trim() || slug
+          const parsed = parseSkillDocument(
+            await readPackageText(this.draftDir(draftName), 'SKILL.md')
+          )
+          name = parsed.name?.trim() || draftName
+          displayName = parsed.metadata.displayname?.trim() || name
           description = parsed.description ?? ''
         } catch {
-          // An incomplete draft remains visible and editable under its stable slug.
+          // An incomplete draft remains visible and editable under its stable name.
         }
-        return { id: `draft-${slug}`, name, description, origin: 'draft', editable: true }
+        return {
+          id: `draft-${draftName}`,
+          name,
+          displayName,
+          description,
+          origin: 'draft',
+          editable: true
+        }
       })
     )
     return [...installed, ...drafts].sort((left, right) => left.name.localeCompare(right.name))
@@ -177,7 +190,7 @@ export class HostSkillsService {
     const exactIds = skills.filter((skill) => skill.id === name)
     if (exactIds.length > 1) throw new Error(`Skill id "${name}" is duplicated`)
     if (exactIds[0]) return exactIds[0]
-    const matches = skills.filter((skill) => skill.name === name || publicSlug(skill) === name)
+    const matches = skills.filter((skill) => skill.name === name)
     if (matches.length > 1) throw new Error(`Skill reference "${name}" is ambiguous`)
     return matches[0]
   }
@@ -186,14 +199,14 @@ export class HostSkillsService {
     const requestedName = asString(params.name)?.trim()
     if (!requestedName) throw new Error('name is required')
     const relativePath = safeRelativePath(params.path, 'SKILL.md')
-    const draftSlug =
-      explicitDraftSlug(requestedName) ??
-      (SAFE_SLUG.test(requestedName) ? requestedName : undefined)
-    if (draftSlug && (await exists(this.draftDir(draftSlug)))) {
+    const draftName =
+      explicitDraftName(requestedName) ??
+      (SAFE_SKILL_NAME.test(requestedName) ? requestedName : undefined)
+    if (draftName && (await exists(this.draftDir(draftName)))) {
       return {
-        name: draftSlug,
+        name: draftName,
         path: relativePath,
-        content: await readPackageText(this.draftDir(draftSlug), relativePath),
+        content: await readPackageText(this.draftDir(draftName), relativePath),
         origin: 'draft'
       }
     }
@@ -217,23 +230,28 @@ export class HostSkillsService {
       throw new Error('SKILL.md requires name and description frontmatter')
     }
     const fieldNames = frontmatterFieldNames(skillDocument).sort()
-    if (fieldNames.length !== 2 || fieldNames[0] !== 'description' || fieldNames[1] !== 'name') {
-      throw new Error('SKILL.md frontmatter must contain exactly name and description')
+    if (
+      (fieldNames.length !== 2 && fieldNames.length !== 3) ||
+      fieldNames[0] !== 'description' ||
+      (fieldNames.length === 3 && fieldNames[1] !== 'displayname') ||
+      fieldNames.at(-1) !== 'name'
+    ) {
+      throw new Error('SKILL.md frontmatter may only contain name, displayName, and description')
     }
     const name = parsed.name.trim()
     if (expectedName && name !== expectedName)
-      throw new Error('SKILL.md name must match the draft slug')
+      throw new Error('SKILL.md name must match the draft name')
     return name
   }
 
   private async validate(params: Params): Promise<unknown> {
     const requestedName = asString(params.name)?.trim()
     if (!requestedName) throw new Error('name is required')
-    const draftSlug =
-      explicitDraftSlug(requestedName) ??
-      (SAFE_SLUG.test(requestedName) ? requestedName : undefined)
-    if (draftSlug && (await exists(this.draftDir(draftSlug)))) {
-      const name = await this.validatePackage(this.draftDir(draftSlug), draftSlug)
+    const draftName =
+      explicitDraftName(requestedName) ??
+      (SAFE_SKILL_NAME.test(requestedName) ? requestedName : undefined)
+    if (draftName && (await exists(this.draftDir(draftName)))) {
+      const name = await this.validatePackage(this.draftDir(draftName), draftName)
       return { valid: true, name, origin: 'draft' }
     }
 
@@ -246,38 +264,38 @@ export class HostSkillsService {
     return { valid: true, name, origin: published.source }
   }
 
-  private async ensureDraft(name: string): Promise<{ slug: string; path: string }> {
-    if (!SAFE_SLUG.test(name)) {
+  private async ensureDraft(name: string): Promise<{ name: string; path: string }> {
+    if (!SAFE_SKILL_NAME.test(name)) {
       const existing = await this.resolvePublished(name)
-      if (!existing) throw new Error('new Skill names must be lowercase hyphenated slugs')
+      if (!existing) throw new Error('new Skill names must be lowercase hyphenated names')
       if (existing.source !== 'personal')
         throw new Error('built-in and imported Skills are read-only')
-      const slug = publicSlug(existing)
-      if (!slug) throw new Error('personal Skill has no editable slug')
-      return this.seedPersonalDraft(existing, slug)
+      const directoryName = personalDirectoryName(existing)
+      if (!directoryName) throw new Error('personal Skill has no editable package name')
+      return this.seedPersonalDraft(existing, directoryName)
     }
 
     const path = this.draftDir(name)
-    if (await exists(path)) return { slug: name, path }
+    if (await exists(path)) return { name, path }
     const existing = await this.resolvePublished(name)
     if (existing) {
       if (existing.source !== 'personal')
         throw new Error('built-in and imported Skills are read-only')
-      return this.seedPersonalDraft(existing, publicSlug(existing) ?? name)
+      return this.seedPersonalDraft(existing, personalDirectoryName(existing) ?? name)
     }
-    assertUsableSlug(name)
+    assertUsableSkillName(name)
     await mkdir(path, { recursive: true })
-    return { slug: name, path }
+    return { name, path }
   }
 
   private async seedPersonalDraft(
     skill: BundledSkill,
-    slug: string
-  ): Promise<{ slug: string; path: string }> {
-    const destination = this.draftDir(slug)
-    if (await exists(destination)) return { slug, path: destination }
+    name: string
+  ): Promise<{ name: string; path: string }> {
+    const destination = this.draftDir(name)
+    if (await exists(destination)) return { name, path: destination }
     await mkdir(this.draftsRoot, { recursive: true })
-    const staging = join(this.draftsRoot, `.${slug}.seed-${randomUUID()}`)
+    const staging = join(this.draftsRoot, `.${name}.seed-${randomUUID()}`)
     try {
       const seeded = await this.options.catalog.withSkillRead(skill.id, async (lockedSkill) => {
         await cp(lockedSkill.sourceDir, staging, {
@@ -295,7 +313,7 @@ export class HostSkillsService {
         return true
       })
       if (!seeded) throw new Error(`Unknown Skill: ${skill.id}`)
-      return { slug, path: destination }
+      return { name, path: destination }
     } catch (error) {
       await rm(staging, { recursive: true, force: true }).catch(() => undefined)
       throw error
@@ -359,7 +377,7 @@ export class HostSkillsService {
       throw new Error('content is too large')
     }
     const relativePath = safeRelativePath(params.path)
-    const explicitDraft = explicitDraftSlug(requestedName)
+    const explicitDraft = explicitDraftName(requestedName)
     const existingExplicitDraft =
       explicitDraft && (await exists(this.draftDir(explicitDraft))) ? explicitDraft : undefined
     const draft = await this.ensureDraft(existingExplicitDraft ?? requestedName)
@@ -391,12 +409,12 @@ export class HostSkillsService {
       await rm(temporary, { force: true }).catch(() => undefined)
       throw error
     }
-    return { status: 'edited', name: draft.slug, path: relativePath, origin: 'draft' }
+    return { status: 'edited', name: draft.name, path: relativePath, origin: 'draft' }
   }
 
   private async publish(params: Params): Promise<unknown> {
     const name = asString(params.name)?.trim()
-    if (!name || !SAFE_SLUG.test(name)) throw new Error('a draft slug is required')
+    if (!name || !SAFE_SKILL_NAME.test(name)) throw new Error('a draft name is required')
     const overwrite = params.overwrite === true
     if (params.overwrite !== undefined && typeof params.overwrite !== 'boolean') {
       throw new Error('overwrite must be a boolean')
@@ -415,7 +433,7 @@ export class HostSkillsService {
     const requestedName = asString(params.name)?.trim()
     if (!requestedName) throw new Error('name is required')
 
-    const requestedDraft = explicitDraftSlug(requestedName)
+    const requestedDraft = explicitDraftName(requestedName)
     if (requestedDraft) {
       if (!(await exists(this.draftDir(requestedDraft)))) {
         throw new Error(`Unknown draft: ${requestedDraft}`)
@@ -431,7 +449,7 @@ export class HostSkillsService {
 
     const published = await this.resolvePublished(requestedName)
     const unqualifiedDraft =
-      SAFE_SLUG.test(requestedName) && (await exists(this.draftDir(requestedName)))
+      SAFE_SKILL_NAME.test(requestedName) && (await exists(this.draftDir(requestedName)))
     if (published && published.id !== requestedName && unqualifiedDraft) {
       throw new Error(
         `ambiguous Skill name; use draft-${requestedName} or ${published.id} to choose what to delete`

--- a/src/main/skills/materializer.test.ts
+++ b/src/main/skills/materializer.test.ts
@@ -22,7 +22,15 @@ const makeSkill = async (name: string): Promise<BundledSkill> => {
   await mkdir(join(root, 'scripts'), { recursive: true })
   await writeFile(join(root, 'SKILL.md'), `# ${name}`, 'utf8')
   await writeFile(join(root, 'scripts', 'main.py'), 'print(1)', 'utf8')
-  return { id: name, name, description: '', source: 'featured', updatedAt: '', sourceDir: root }
+  return {
+    id: name,
+    name,
+    displayName: name,
+    description: '',
+    source: 'featured',
+    updatedAt: '',
+    sourceDir: root
+  }
 }
 
 const skillsDir = async (): Promise<string> => {
@@ -178,6 +186,7 @@ describe('ClaudeCodeSkillMaterializer', () => {
     const computeSkill: BundledSkill = {
       id: 'remote-compute-ssh',
       name: 'Remote Compute (SSH)',
+      displayName: 'Remote Compute (SSH)',
       description: 'Discover SSH compute hosts.',
       source: 'featured',
       updatedAt: 'v1',
@@ -265,7 +274,8 @@ describe('ClaudeCodeSkillMaterializer', () => {
       source: 'featured',
       updatedAt: '',
       sourceDir: root,
-      ...extra
+      ...extra,
+      displayName: extra.displayName ?? name
     }
   }
 

--- a/src/main/skills/registry.test.ts
+++ b/src/main/skills/registry.test.ts
@@ -46,7 +46,8 @@ describe('SkillRegistry', () => {
     expect(skills).toHaveLength(1)
     expect(skills[0]).toMatchObject({
       id: 'demo',
-      name: 'Demo',
+      name: 'demo',
+      displayName: 'Demo',
       description: 'A demo skill.',
       source: 'featured',
       author: 'Test Author',
@@ -57,6 +58,51 @@ describe('SkillRegistry', () => {
       // materializer only substring-matches gpu/compute, so this stays equivalent.
       requirements: 'gpu'
     })
+  })
+
+  it('uses an optional SKILL.md displayName instead of the manifest presentation name', async () => {
+    const root = await seedRoot()
+    await writeFile(
+      join(root, 'demo', 'SKILL.md'),
+      [
+        '---',
+        'name: demo',
+        'displayName: Demo Skill',
+        'description: A demo skill.',
+        '---',
+        '',
+        '# Demo body'
+      ].join('\n'),
+      'utf8'
+    )
+
+    expect((await new SkillRegistry(root).list())[0]?.displayName).toBe('Demo Skill')
+  })
+
+  it('sorts bundled skills by presentation name instead of invocation name', async () => {
+    const root = await seedRoot()
+    await mkdir(join(root, 'alpha'), { recursive: true })
+    await writeFile(
+      join(root, 'alpha', 'SKILL.md'),
+      '---\nname: zebra\ndescription: Another skill.\n---\nBody.',
+      'utf8'
+    )
+    await writeFile(
+      join(root, 'manifest.json'),
+      JSON.stringify({
+        version: 1,
+        skills: [
+          { id: 'demo', name: 'Zebra', source: 'featured', updatedAt: '2026-01-01' },
+          { id: 'alpha', name: 'Alpha', source: 'featured', updatedAt: '2026-01-01' }
+        ]
+      }),
+      'utf8'
+    )
+
+    expect((await new SkillRegistry(root).list()).map((skill) => skill.id)).toEqual([
+      'alpha',
+      'demo'
+    ])
   })
 
   it('returns the SKILL.md body via body(id)', async () => {

--- a/src/main/skills/registry.ts
+++ b/src/main/skills/registry.ts
@@ -15,7 +15,9 @@ const log = createLogger('skills')
 // tooling needs a compute backend this app does not provide.
 export type BundledSkill = {
   id: string
+  // Stable invocation name from SKILL.md. Presentation must use displayName instead.
   name: string
+  displayName: string
   description: string
   source: SkillSource
   updatedAt: string
@@ -123,7 +125,8 @@ class SkillRegistry {
 
         skills.push({
           id: entry.id,
-          name: entry.name,
+          name: fields.name || entry.id,
+          displayName: fields.displayname || entry.name || fields.name || entry.id,
           description: fields.description ?? '',
           source: entry.source,
           updatedAt: entry.updatedAt,
@@ -142,8 +145,8 @@ class SkillRegistry {
       }
     }
 
-    // Featured skills always display alphabetically by name; the manifest order is not significant.
-    return skills.sort((a, b) => a.name.localeCompare(b.name))
+    // Featured skills always display alphabetically by presentation label; manifest order is not significant.
+    return skills.sort((a, b) => a.displayName.localeCompare(b.displayName))
   }
 
   async body(id: string): Promise<string> {

--- a/src/main/skills/self-awareness-skill.test.ts
+++ b/src/main/skills/self-awareness-skill.test.ts
@@ -14,7 +14,8 @@ describe('self-awareness bundled Skill', () => {
 
     expect(skill).toMatchObject({
       id: 'self-awareness',
-      name: 'Self-awareness',
+      name: 'self-awareness',
+      displayName: 'Self-awareness',
       source: 'featured',
       exposure: 'internal'
     })

--- a/src/main/skills/skill-nudge-identity.test.ts
+++ b/src/main/skills/skill-nudge-identity.test.ts
@@ -15,15 +15,16 @@ const skillsRoot = join(__dirname, '..', '..', '..', 'resources', 'skills')
 // name, or the agent fails the pick with "Unknown skill: <id>". This guards that contract for the whole
 // bundled set — a new skill whose manifest id drifts from its frontmatter name breaks the picker.
 describe('bundled skill nudge identity', () => {
-  it('has manifest id === SKILL.md frontmatter name for every bundled skill', async () => {
+  it('uses only the manifest id as every bundled Skill name', async () => {
     const skills = await new SkillRegistry(skillsRoot).list()
     expect(skills.length).toBeGreaterThan(0)
 
     for (const skill of skills) {
       const raw = await readFile(join(skill.sourceDir, 'SKILL.md'), 'utf8')
-      const frontmatterName = parseFrontmatter(raw).fields.name
+      const fields = parseFrontmatter(raw).fields
 
-      expect(frontmatterName, `skill "${skill.id}" frontmatter name`).toBe(skill.id)
+      expect(fields.name, `skill "${skill.id}" frontmatter name`).toBe(skill.id)
+      expect(fields.displayname, `skill "${skill.id}" displayName`).toBeUndefined()
     }
   })
 })

--- a/src/main/skills/user-skill-repository.architecture.test.ts
+++ b/src/main/skills/user-skill-repository.architecture.test.ts
@@ -203,9 +203,10 @@ describe('User Skill repository architecture', () => {
   it('locks the compatibility export and operation inventories', () => {
     expect(exportInventory()).toEqual([
       'type:ImportOutcome',
+      'value:SAFE_SKILL_NAME',
       'value:SAFE_SLUG',
       'value:UserSkillRepository',
-      'value:assertUsableSlug',
+      'value:assertUsableSkillName',
       'value:frontmatterBlock',
       'value:parseUserSkillId',
       'value:toSlug'

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -220,7 +220,7 @@ describe('UserSkillRepository', () => {
   it('holds the mutation lock throughout a caller-controlled Skill read', async () => {
     const repo = new UserSkillRepository(await makeStorage())
     const id = await repo.createPersonal({
-      name: 'Locked',
+      name: 'locked',
       description: 'Original.',
       body: '# Original'
     })
@@ -242,7 +242,7 @@ describe('UserSkillRepository', () => {
 
     let updateFinished = false
     const update = repo
-      .updatePersonal(id, { name: 'Locked', description: 'Updated.', body: '# Updated' })
+      .updatePersonal(id, { name: 'locked', description: 'Updated.', body: '# Updated' })
       .finally(() => {
         updateFinished = true
       })
@@ -250,7 +250,7 @@ describe('UserSkillRepository', () => {
     expect(updateFinished).toBe(false)
 
     releaseRead()
-    await expect(read).resolves.toBe('Locked')
+    await expect(read).resolves.toBe('locked')
     await update
     expect(updateFinished).toBe(true)
   })
@@ -259,7 +259,7 @@ describe('UserSkillRepository', () => {
     const repo = new UserSkillRepository(await makeStorage())
 
     const id = await repo.createPersonal({
-      name: 'My Skill',
+      name: 'my-skill',
       description: 'Does a thing.',
       body: '# My Skill\nBody.'
     })
@@ -269,7 +269,7 @@ describe('UserSkillRepository', () => {
     expect(listed).toHaveLength(1)
     expect(listed[0]).toMatchObject({
       id: 'personal-my-skill',
-      name: 'My Skill',
+      name: 'my-skill',
       description: 'Does a thing.',
       source: 'personal'
     })
@@ -277,7 +277,7 @@ describe('UserSkillRepository', () => {
     expect(await repo.body(id)).toContain('# My Skill')
 
     await repo.updatePersonal(id, {
-      name: 'My Skill',
+      name: 'my-skill',
       description: 'Updated.',
       body: '# Updated body'
     })
@@ -295,7 +295,7 @@ describe('UserSkillRepository', () => {
     // a bogus field (`not: a-key`). It must survive intact and leave the body untouched.
     const description = 'First line\n---\nnot: a-key\nSecond line'
     const id = await repo.createPersonal({
-      name: 'Tricky',
+      name: 'tricky',
       description,
       body: '# Real body\nkeep me'
     })
@@ -311,14 +311,15 @@ describe('UserSkillRepository', () => {
     expect(body).not.toContain('not: a-key')
   })
 
-  it('gives colliding names a numeric suffix', async () => {
+  it('rejects colliding personal skill names', async () => {
     const repo = new UserSkillRepository(await makeStorage())
 
-    const first = await repo.createPersonal({ name: 'Dup', description: 'a', body: 'x' })
-    const second = await repo.createPersonal({ name: 'Dup', description: 'b', body: 'y' })
+    const first = await repo.createPersonal({ name: 'dup', description: 'a', body: 'x' })
 
     expect(first).toBe('personal-dup')
-    expect(second).toBe('personal-dup-2')
+    await expect(repo.createPersonal({ name: 'dup', description: 'b', body: 'y' })).rejects.toThrow(
+      /already exists/
+    )
   })
 
   it('writes reference files under references/ when creating a skill', async () => {
@@ -326,7 +327,7 @@ describe('UserSkillRepository', () => {
     const repo = new UserSkillRepository(storage)
 
     await repo.createPersonal({
-      name: 'With Refs',
+      name: 'with-refs',
       description: 'd',
       body: 'x',
       references: [{ path: 'helper.py', dataBase64: Buffer.from('print(1)').toString('base64') }]
@@ -339,28 +340,28 @@ describe('UserSkillRepository', () => {
     expect(written).toBe('print(1)')
   })
 
-  it('honors an explicit slug and rejects collisions, reserved prefixes, and invalid ids', async () => {
+  it('uses the immutable name and rejects collisions, reserved prefixes, and invalid names', async () => {
     const repo = new UserSkillRepository(await makeStorage())
 
-    const id = await repo.createPersonal({ name: 'Anything', description: 'd', body: 'x' }, 'my-id')
+    const id = await repo.createPersonal({ name: 'my-id', description: 'd', body: 'x' })
     expect(id).toBe('personal-my-id')
 
-    // Colliding with the just-created slug is rejected (no silent suffix).
+    // Colliding with the just-created name is rejected (no silent suffix).
     await expect(
-      repo.createPersonal({ name: 'Other', description: 'd', body: 'y' }, 'my-id')
+      repo.createPersonal({ name: 'my-id', description: 'd', body: 'y' })
     ).rejects.toThrow(/already exists/)
 
     // Reserved built-in / MCP prefixes are rejected.
     await expect(
-      repo.createPersonal({ name: 'x', description: 'd', body: 'x' }, 'os-thing')
+      repo.createPersonal({ name: 'os-thing', description: 'd', body: 'x' })
     ).rejects.toThrow(/os- or mcp-/)
     await expect(
-      repo.createPersonal({ name: 'x', description: 'd', body: 'x' }, 'mcp-thing')
+      repo.createPersonal({ name: 'mcp-thing', description: 'd', body: 'x' })
     ).rejects.toThrow(/os- or mcp-/)
 
     // Unsafe characters are rejected.
     await expect(
-      repo.createPersonal({ name: 'x', description: 'd', body: 'x' }, 'Bad ID')
+      repo.createPersonal({ name: 'Bad Name', description: 'd', body: 'x' })
     ).rejects.toThrow(/lowercase/)
   })
 
@@ -370,7 +371,7 @@ describe('UserSkillRepository', () => {
     const b64 = (text: string): string => Buffer.from(text).toString('base64')
 
     const id = await repo.createPersonal({
-      name: 'Refs',
+      name: 'refs',
       description: 'd',
       body: 'x',
       references: [
@@ -380,7 +381,7 @@ describe('UserSkillRepository', () => {
     })
 
     await repo.updatePersonal(id, {
-      name: 'Refs',
+      name: 'refs',
       description: 'd',
       body: 'x',
       references: [
@@ -1428,7 +1429,7 @@ describe('UserSkillRepository', () => {
     const storage = await makeStorage()
     const repo = new UserSkillRepository(storage)
     const id = await repo.createPersonal({
-      name: 'Round Trip',
+      name: 'round-trip',
       description: 'desc',
       metadata: {
         author: 'Ada',
@@ -1445,10 +1446,10 @@ describe('UserSkillRepository', () => {
       join(storage, 'skills', 'personal', 'round-trip', 'SKILL.md'),
       'utf8'
     )
-    expect(raw).toContain('name: Round Trip')
+    expect(raw).toContain('name: round-trip')
     expect(raw).toContain('description: desc')
     expect(parseFrontmatter(raw).fields).toMatchObject({
-      name: 'Round Trip',
+      name: 'round-trip',
       description: 'desc',
       author: 'Ada',
       license: 'MIT'

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -20,8 +20,9 @@ import {
 import type { ImportOutcome, ParsedSkillPreview } from './user-skill-import-contracts'
 import {
   SAFE_SLUG,
+  SAFE_SKILL_NAME,
   UserSkillStore,
-  assertUsableSlug,
+  assertUsableSkillName,
   frontmatterBlock,
   parseUserSkillId,
   toSlug,
@@ -67,11 +68,9 @@ class UserSkillRepository {
     return this.store.body(id)
   }
 
-  // Creates a personal skill, returning its new id. With an explicit `requestedSlug`, that slug is
-  // used verbatim (validated, and rejected if already taken); otherwise a slug is derived from the
-  // name and collisions get a numeric suffix.
-  async createPersonal(input: WriteSkillInput, requestedSlug?: string): Promise<string> {
-    return this.store.createPersonal(input, requestedSlug)
+  // Creates a personal skill whose immutable name is also its package directory name.
+  async createPersonal(input: WriteSkillInput): Promise<string> {
+    return this.store.createPersonal(input)
   }
 
   // Publishes an app-authored draft as a complete Personal Skill package. Unlike the form editor,
@@ -79,11 +78,11 @@ class UserSkillRepository {
   // The source is validated and copied into a sibling staging directory before the live package is
   // swapped, so a failed copy or replace never exposes a partial Skill.
   async publishPersonalDirectory(
-    requestedSlug: string,
+    name: string,
     sourcePath: string,
     overwrite = false
   ): Promise<string> {
-    return this.store.publishPersonalDirectory(requestedSlug, sourcePath, overwrite, (staging) =>
+    return this.store.publishPersonalDirectory(name, sourcePath, overwrite, (staging) =>
       this.agentHomeSkills.validatePublishedSkillPackage(staging)
     )
   }
@@ -159,8 +158,9 @@ class UserSkillRepository {
 
 export {
   SAFE_SLUG,
+  SAFE_SKILL_NAME,
   UserSkillRepository,
-  assertUsableSlug,
+  assertUsableSkillName,
   frontmatterBlock,
   parseUserSkillId,
   toSlug

--- a/src/main/skills/user-skill-store.ts
+++ b/src/main/skills/user-skill-store.ts
@@ -25,15 +25,17 @@ export type UserSkillSource = (typeof USER_SOURCES)[number]
 // Only lowercase slugs so a skill id maps 1:1 to a safe directory name.
 export const SAFE_SLUG = /^[a-z0-9-]+$/
 
-const RESERVED_SLUG_PREFIXES = ['os-', 'mcp-'] as const
+export const SAFE_SKILL_NAME = /^(?=.{1,64}$)[a-z0-9]+(?:-[a-z0-9]+)*$/
+const SKILL_NAME_MAX_LENGTH = 64
+const RESERVED_SKILL_NAME_PREFIXES = ['os-', 'mcp-'] as const
 
-export const assertUsableSlug = (slug: string): void => {
-  if (!slug) throw new Error('Skill ID is required.')
-  if (!SAFE_SLUG.test(slug)) {
-    throw new Error('Skill ID may only contain lowercase letters, numbers, and hyphens.')
+export const assertUsableSkillName = (name: string): void => {
+  if (!name) throw new Error('Skill name is required.')
+  if (!SAFE_SKILL_NAME.test(name) || name.length > SKILL_NAME_MAX_LENGTH) {
+    throw new Error('Skill name must use up to 64 lowercase letters, numbers, and single hyphens.')
   }
-  if (RESERVED_SLUG_PREFIXES.some((prefix) => slug.startsWith(prefix))) {
-    throw new Error(`Skill ID may not start with ${RESERVED_SLUG_PREFIXES.join(' or ')}.`)
+  if (RESERVED_SKILL_NAME_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+    throw new Error(`Skill name may not start with ${RESERVED_SKILL_NAME_PREFIXES.join(' or ')}.`)
   }
 }
 
@@ -123,6 +125,7 @@ export class UserSkillStore {
           skills.push({
             id: packageMetadata?.id ?? `${source}-${slug}`,
             name: fields.name || slug,
+            displayName: fields.displayname || fields.name || slug,
             description: fields.description ?? '',
             source,
             updatedAt,
@@ -159,39 +162,33 @@ export class UserSkillStore {
     })
   }
 
-  async createPersonal(input: WriteSkillInput, requestedSlug?: string): Promise<string> {
+  async createPersonal(input: WriteSkillInput): Promise<string> {
     return this.transactions.runExclusive(async () => {
-      if (requestedSlug !== undefined) {
-        const slug = requestedSlug.trim()
-        assertUsableSlug(slug)
-        if (await this.slugTaken('personal', slug)) {
-          throw new Error(`A skill with ID "${slug}" already exists.`)
-        }
-        await this.writeSkill('personal', slug, input)
-        return `personal-${slug}`
+      const name = input.name.trim()
+      assertUsableSkillName(name)
+      if (await this.slugTaken('personal', name)) {
+        throw new Error(`A skill named "${name}" already exists.`)
       }
-
-      const slug = await this.uniqueSlug('personal', toSlug(input.name) || 'skill')
-      await this.writeSkill('personal', slug, input)
-      return `personal-${slug}`
+      await this.writeSkill('personal', name, { ...input, name })
+      return `personal-${name}`
     })
   }
 
   async publishPersonalDirectory(
-    requestedSlug: string,
+    name: string,
     sourcePath: string,
     overwrite: boolean,
     validatePackage: ValidatePackage
   ): Promise<string> {
-    const slug = requestedSlug.trim()
-    assertUsableSlug(slug)
+    const normalizedName = name.trim()
+    assertUsableSkillName(normalizedName)
 
     return this.transactions.runRecovered(async () => {
-      if (!overwrite && (await this.slugTaken('personal', slug))) {
-        throw new Error(`A skill with ID "${slug}" already exists.`)
+      if (!overwrite && (await this.slugTaken('personal', normalizedName))) {
+        throw new Error(`A skill named "${normalizedName}" already exists.`)
       }
 
-      const staged = await this.transactions.stage('personal', slug, async (staging) => {
+      const staged = await this.transactions.stage('personal', normalizedName, async (staging) => {
         await cp(sourcePath, staging, {
           recursive: true,
           force: false,
@@ -209,7 +206,7 @@ export class UserSkillStore {
         await validatePackage(staging)
       })
       await this.transactions.promote(staged)
-      return `personal-${slug}`
+      return `personal-${normalizedName}`
     }, ['personal'])
   }
 
@@ -263,9 +260,12 @@ export class UserSkillStore {
           typeof value === 'string'
       )
     )
+    const displayName = metadata.displayname
+    delete metadata.displayname
     const frontmatter = `---\n${frontmatterBlock({
       name: input.name,
       description: input.description,
+      ...(displayName ? { displayName } : {}),
       ...metadata
     })}---`
     await writeFile(join(dir, 'SKILL.md'), `${frontmatter}\n\n${input.body.trimStart()}`, 'utf8')

--- a/src/main/specialist/package/service.test.ts
+++ b/src/main/specialist/package/service.test.ts
@@ -428,7 +428,7 @@ describe('SpecialistPackageService', () => {
               {
                 path: 'SKILL.md',
                 bytes: encoder.encode(
-                  '---\nname: document-reader\ndescription: Read documents\nversion: 9.9.9\n---\nRead documents.'
+                  '---\nname: document-reader\ndisplayName: Document Reader\ndescription: Read documents\nversion: 9.9.9\n---\nRead documents.'
                 )
               }
             ]
@@ -450,7 +450,7 @@ describe('SpecialistPackageService', () => {
               {
                 path: 'SKILL.md',
                 bytes: encoder.encode(
-                  '---\nname: analysis-tools\ndescription: Analyze data\n---\nUse the tools.'
+                  '---\nname: analysis-tools\ndisplayName: Analysis Tools\ndescription: Analyze data\n---\nUse the tools.'
                 )
               }
             ]
@@ -481,6 +481,8 @@ describe('SpecialistPackageService', () => {
     expect(archive['skills/analysis-tools/SKILL.md']).toBeDefined()
     expect(archive['skills/os-document-reader/SKILL.md']).toBeUndefined()
     expect(strFromU8(archive['skills/document-reader/SKILL.md']!)).not.toContain('version: 9.9.9')
+    expect(strFromU8(archive['skills/document-reader/SKILL.md']!)).not.toContain('displayName')
+    expect(strFromU8(archive['skills/analysis-tools/SKILL.md']!)).not.toContain('displayName')
   })
 
   it('exports a personal Skill under its portable ID without the personal source prefix', async () => {

--- a/src/main/specialist/package/service.ts
+++ b/src/main/specialist/package/service.ts
@@ -97,7 +97,7 @@ const normalizeExportedSkillDocument = (
   const document = parseSkillDocument(new TextDecoder('utf-8', { fatal: true }).decode(bytes))
   if (!document.hasFrontmatter) throw new Error(`Skill ${id} has no frontmatter.`)
   const metadata = Object.entries(document.metadata)
-    .filter(([key]) => key !== 'version')
+    .filter(([key]) => key !== 'displayname' && key !== 'version')
     .sort(([left], [right]) => left.localeCompare(right))
   const fields = [
     `name: ${JSON.stringify(id)}`,

--- a/src/main/specialist/repository.test.ts
+++ b/src/main/specialist/repository.test.ts
@@ -229,9 +229,10 @@ describe('SpecialistRepository.update', () => {
     const repo = new SpecialistRepository(tmpDir)
     const sp = makeSpecialist({ revision: 1 })
     await repo.insert(sp)
-    await repo.update(sp.id, { name: 'Updated' }, 1)
+    await repo.update(sp.id, { displayName: 'Updated' }, 1)
     const doc = await repo.getAll()
-    expect(doc.specialists[0].name).toBe('Updated')
+    expect(doc.specialists[0].name).toBe(sp.name)
+    expect(doc.specialists[0].displayName).toBe('Updated')
     expect(doc.specialists[0].revision).toBe(2)
   })
 
@@ -251,13 +252,15 @@ describe('SpecialistRepository.update', () => {
     expect(doc.specialists[0].id).toBe('fixed-id')
   })
 
-  it('rejects name change to existing name', async () => {
+  it('rejects any name change', async () => {
     const repo = new SpecialistRepository(tmpDir)
     const sp1 = makeSpecialist({ name: 'NAME_ONE' })
     const sp2 = makeSpecialist({ name: 'NAME_TWO', revision: 1 })
     await repo.insert(sp1)
     await repo.insert(sp2)
-    await expect(repo.update(sp2.id, { name: 'NAME_ONE' }, 1)).rejects.toThrow()
+    await expect(repo.update(sp2.id, { name: 'NAME_ONE' }, 1)).rejects.toThrow(
+      'Specialist name is immutable.'
+    )
   })
 })
 

--- a/src/main/specialist/repository.ts
+++ b/src/main/specialist/repository.ts
@@ -258,16 +258,14 @@ export class SpecialistRepository {
           `Revision conflict: expected ${expectedRevision}, found ${current.revision}.`
         )
       }
-      // Name uniqueness when renaming.
-      if (patch.name && patch.name !== current.name) {
-        if (doc.specialists.some((s) => s.id !== id && s.name === patch.name)) {
-          throw new Error(`Specialist with name "${patch.name}" already exists.`)
-        }
+      if (patch.name !== undefined && patch.name !== current.name) {
+        throw new Error('Specialist name is immutable.')
       }
       const updated: StoredSpecialist = {
         ...current,
         ...patch,
         id, // id is immutable
+        name: current.name,
         revision: current.revision + 1
       }
       const specialists = [...doc.specialists]

--- a/src/main/specialist/service.test.ts
+++ b/src/main/specialist/service.test.ts
@@ -121,9 +121,6 @@ describe('ProfileService.create', () => {
     await expect(
       guarded.update({ id: builtin.id, revision: 0, description: 'changed' })
     ).rejects.toMatchObject(builtinError)
-    await expect(
-      guarded.rename({ id: builtin.id, name: 'RENAMED', expectedRevision: 0 })
-    ).rejects.toMatchObject(builtinError)
     await expect(guarded.setEnabled(builtin.id, false)).rejects.toMatchObject(builtinError)
     await expect(guarded.delete(builtin.id)).rejects.toMatchObject(builtinError)
     await expect(guarded.attachSkill(builtin.id, 'skill-a', 0)).rejects.toMatchObject(builtinError)
@@ -391,41 +388,44 @@ describe('ProfileService.update', () => {
     await expect(restarted.getById(created.id)).resolves.toMatchObject({ packageVersion: '1.0.0' })
   })
 
-  it('atomically persists enabled with other fields and bumps revision once', async () => {
+  it('atomically persists enabled with displayName and bumps revision once', async () => {
     const created = await service.create({ name: 'My Bot' })
     const updated = await service.update({
       id: created.id,
       revision: created.revision,
-      name: 'My Disabled Bot',
+      displayName: 'My Disabled Bot',
       enabled: false
     })
 
     expect(updated).toMatchObject({
       id: created.id,
-      name: 'My Disabled Bot',
+      name: 'My Bot',
+      displayName: 'My Disabled Bot',
       enabled: false,
       revision: created.revision + 1
     })
 
     const restarted = new ProfileService(new SpecialistRepository(tmpDir))
     await expect(restarted.getById(created.id)).resolves.toMatchObject({
-      name: 'My Disabled Bot',
+      name: 'My Bot',
+      displayName: 'My Disabled Bot',
       enabled: false,
       revision: created.revision + 1
     })
   })
 
-  it('updates identity fields and bumps revision', async () => {
+  it('updates presentation fields and bumps revision without changing name', async () => {
     const created = await service.create({ name: 'RNA-seq Reviewer' })
     const updated = await service.update({
       id: created.id,
       revision: created.revision,
-      name: 'RNA-seq Auditor',
+      displayName: 'RNA-seq Auditor',
       description: 'Updated description.',
       systemPrompt: 'Be rigorous.'
     })
     expect(updated.id).toBe(created.id)
-    expect(updated.name).toBe('RNA-seq Auditor')
+    expect(updated.name).toBe('RNA-seq Reviewer')
+    expect(updated.displayName).toBe('RNA-seq Auditor')
     expect(updated.description).toBe('Updated description.')
     expect(updated.systemPrompt).toBe('Be rigorous.')
     expect(updated.revision).toBe(created.revision + 1)
@@ -509,41 +509,47 @@ describe('ProfileService.update', () => {
     })
   })
 
-  it('keeps the immutable id and supports renaming', async () => {
+  it('rejects a name field smuggled across the update boundary', async () => {
     const created = await service.create({ name: 'My Bot' })
-    const updated = await service.update({
-      id: created.id,
-      revision: created.revision,
-      name: 'Custom Renamed'
-    })
-    expect(updated.id).toBe(created.id)
-    expect(updated.name).toBe('Custom Renamed')
+    await expect(
+      service.update({
+        id: created.id,
+        revision: created.revision,
+        name: 'Custom Renamed'
+      } as never)
+    ).rejects.toThrow(/name is immutable/i)
+    expect(await service.getById(created.id)).toMatchObject(created)
   })
 
-  it('allows keeping the same name (self excluded from uniqueness)', async () => {
+  it('allows keeping the same display name', async () => {
     const created = await service.create({ name: 'My Bot' })
     const updated = await service.update({
       id: created.id,
       revision: created.revision,
-      name: created.name
+      displayName: created.displayName
     })
     expect(updated.name).toBe(created.name)
   })
 
-  it('rejects a name that collides with another specialist', async () => {
+  it('allows duplicate display names because they are not references', async () => {
     const first = await service.create({ name: 'Alpha Bot' })
     const second = await service.create({ name: 'Beta Bot' })
-    await expect(
-      service.update({ id: second.id, revision: second.revision, name: first.name })
-    ).rejects.toThrow(/already in use/i)
-
-    expect(await service.list()).toHaveLength(2)
+    const updated = await service.update({
+      id: second.id,
+      revision: second.revision,
+      displayName: first.displayName
+    })
+    expect(updated).toMatchObject({ name: 'Beta Bot', displayName: 'Alpha Bot' })
   })
 
   it('rejects a stale revision (optimistic concurrency conflict)', async () => {
     const created = await service.create({ name: 'My Bot' })
     await expect(
-      service.update({ id: created.id, revision: created.revision + 1, name: 'Valid Name' })
+      service.update({
+        id: created.id,
+        revision: created.revision + 1,
+        displayName: 'Valid label'
+      })
     ).rejects.toThrow(/revision conflict/i)
   })
 
@@ -555,39 +561,25 @@ describe('ProfileService.update', () => {
     expect(listener).toHaveBeenCalledOnce()
   })
 
-  it('follows an uncustomized display name across a rename so the settings list shows the new name', async () => {
-    // No displayName at create: it is snapshotted to the name (service.ts create defaulting).
+  it('defaults displayName to name and lets displayName change independently', async () => {
     const created = await service.create({ name: 'Old Name' })
-    const renamed = await service.update({
+    expect(created.displayName).toBe('Old Name')
+    const updated = await service.update({
       id: created.id,
       revision: created.revision,
-      name: 'New Name'
+      displayName: 'New Label'
     })
-    // The settings list shows displayName ?? name; an uncustomized display name must follow the
-    // rename (host.agents.update rename path), not keep showing the stale snapshot.
-    expect(renamed.displayName).toBe('New Name')
+    expect(updated).toMatchObject({ name: 'Old Name', displayName: 'New Label' })
   })
 
-  it('keeps a custom display name across a rename when displayName is left unset', async () => {
+  it('keeps a custom display name when it is omitted from an update', async () => {
     const created = await service.create({ name: 'Old Name', displayName: 'Friendly Name' })
-    const renamed = await service.update({
+    const updated = await service.update({
       id: created.id,
       revision: created.revision,
-      name: 'New Name'
+      description: 'Changed'
     })
-    expect(renamed.name).toBe('New Name')
-    expect(renamed.displayName).toBe('Friendly Name')
-  })
-
-  it('explicitly setting displayName in the same rename patch still wins over the follow-along default', async () => {
-    const created = await service.create({ name: 'Old Name' })
-    const renamed = await service.update({
-      id: created.id,
-      revision: created.revision,
-      name: 'New Name',
-      displayName: 'Explicit Label'
-    })
-    expect(renamed.displayName).toBe('Explicit Label')
+    expect(updated).toMatchObject({ name: 'Old Name', displayName: 'Friendly Name' })
   })
 
   it('rejects an update missing revision', async () => {
@@ -658,16 +650,20 @@ describe('ProfileService lifecycle mutations', () => {
     })
   })
 
-  it('keeps UUID stable across public rename and rejects a stale delete', async () => {
+  it('keeps UUID and name stable across a display-name edit and rejects a stale delete', async () => {
     const created = await service.create({ name: 'RNA Reviewer', displayName: 'RNA reviewer' })
-    const renamed = await service.rename({
+    const updated = await service.update({
       id: created.id,
-      name: 'RNA Auditor',
-      expectedRevision: created.revision
+      revision: created.revision,
+      displayName: 'RNA Auditor'
     })
-    expect(renamed).toMatchObject({ id: created.id, name: 'RNA Auditor' })
+    expect(updated).toMatchObject({
+      id: created.id,
+      name: 'RNA Reviewer',
+      displayName: 'RNA Auditor'
+    })
     await expect(service.delete(created.id, created.revision)).rejects.toThrow(/revision conflict/i)
-    expect(await service.getById(created.id)).toMatchObject({ name: 'RNA Auditor' })
+    expect(await service.getById(created.id)).toMatchObject({ name: 'RNA Reviewer' })
   })
 
   it('duplicates deeply without persisting until the caller creates it', async () => {
@@ -681,7 +677,7 @@ describe('ProfileService lifecycle mutations', () => {
       }
     })
     const draft = await service.duplicate(created.id)
-    // New single-name model: duplicate returns a free-form "Copy" suffix name.
+    // A duplicate receives a new immutable name and matching initial display label.
     expect(draft).toMatchObject({ name: 'Chemist Copy', displayName: 'Chemist Copy' })
     expect(await service.list()).toHaveLength(1)
     draft.selectedCapabilities?.skillIds.push('other')
@@ -733,24 +729,24 @@ describe('ProfileService restart persistence', () => {
 })
 
 describe('ProfileService session binding with stable IDs', () => {
-  it('keeps the UUID stable after rename — a stored session binding still resolves', async () => {
+  it('keeps the UUID stable after a display-name edit — a stored session binding still resolves', async () => {
     const created = await service.create({ name: 'RNA_REVIEWER' })
     const originalId = created.id
 
     // Simulate a session binding: record the profile UUID.
     const sessionBinding = { profileId: created.id }
 
-    // Rename the profile.
-    await service.rename({
+    await service.update({
       id: created.id,
-      name: 'RNA_AUDITOR',
-      expectedRevision: created.revision
+      displayName: 'RNA Auditor',
+      revision: created.revision
     })
 
-    // The session binding UUID still resolves to the renamed profile.
+    // The session binding UUID still resolves to the same immutable profile name.
     const resolved = await service.getById(sessionBinding.profileId)
     expect(resolved.id).toBe(originalId)
-    expect(resolved.name).toBe('RNA_AUDITOR')
+    expect(resolved.name).toBe('RNA_REVIEWER')
+    expect(resolved.displayName).toBe('RNA Auditor')
   })
 
   it('reports missing for a deleted profile UUID without erroring the catalog', async () => {

--- a/src/main/specialist/service.ts
+++ b/src/main/specialist/service.ts
@@ -21,7 +21,6 @@ import type {
 import {
   validateCreateSpecialistInput,
   validateUpdateSpecialistInput,
-  validateSpecialistPublicName,
   emptyFullAccessConfig,
   emptySelectedConfig
 } from '../../shared/specialist'
@@ -388,16 +387,15 @@ export class ProfileService {
     return toView(found)
   }
 
-  // Atomically patches identity/instructions fields on an existing specialist.
-  // Re-validates display name and public name (uniqueness skips the record's own
-  // id so self-rename is allowed). `revision` must match the stored record
+  // Atomically patches presentation/instructions fields on an existing specialist.
+  // The stable name is immutable. `revision` must match the stored record
   // (optimistic concurrency); the repository bumps it and rejects stale writes.
   async update(input: UpdateSpecialistInput): Promise<SpecialistProfileView> {
     if (!input || typeof input.id !== 'string' || typeof input.revision !== 'number') {
       throw new Error('Update requires id and revision.')
     }
-    if (input.name !== undefined && typeof input.name !== 'string') {
-      throw new Error('Name must be a string.')
+    if ('name' in input) {
+      throw new Error('Specialist name is immutable.')
     }
     if (input.enabled !== undefined && typeof input.enabled !== 'boolean') {
       throw new Error('Enabled must be a boolean.')
@@ -410,10 +408,7 @@ export class ProfileService {
     assertCapabilityConfigShape(input)
 
     const doc = await this.repo.getAll()
-    const existingNames = doc.specialists.map((s) => s.name)
-    const existingIds = new Map(doc.specialists.map((s) => [s.name, s.id]))
-
-    const errors = validateUpdateSpecialistInput(input, existingNames, existingIds)
+    const errors = validateUpdateSpecialistInput(input)
     if (errors.length > 0) {
       throw new Error(errors.map((e) => e.message).join('; '))
     }
@@ -427,22 +422,8 @@ export class ProfileService {
       throw new Error('Complete Specialist setup before enabling it.')
     }
     if (input.packageVersion !== undefined) patch.packageVersion = input.packageVersion
-    if (input.name !== undefined) patch.name = input.name
-    // A rename that leaves displayName unset keeps a CUSTOM display name (the settings list shows
-    // displayName ?? name), but an UNcustomized one (snapshotted to the old name at create) must
-    // follow the rename — otherwise the settings list keeps showing the old name after a
-    // host.agents.update rename. Mirrors create()'s `displayName ?? name` defaulting.
     if (input.displayName !== undefined) {
       patch.displayName = input.displayName
-    } else if (input.name !== undefined) {
-      const current = doc.specialists.find((s) => s.id === input.id)
-      if (
-        current &&
-        (current.displayName ?? current.name) === current.name &&
-        current.name !== input.name
-      ) {
-        patch.displayName = input.name
-      }
     }
     if (input.description !== undefined) patch.description = input.description
     if (input.systemPrompt !== undefined) patch.systemPrompt = input.systemPrompt
@@ -459,29 +440,13 @@ export class ProfileService {
       patch.selectedCapabilities = input.selectedCapabilities
     }
 
-    log.info('updating specialist', { id: input.id, name: patch.name })
+    log.info('updating specialist', { id: input.id })
 
     const updatedDoc = await this.repo.update(input.id, patch, input.revision)
     this.notify()
     const updated = updatedDoc.specialists.find((s) => s.id === input.id)
     if (!updated) throw new Error(`Specialist ${input.id} not found after update.`)
     return toView(updated)
-  }
-
-  // Naming is kept as a separate lifecycle mutation so SDK approval flows can
-  // re-check the exact record and revision immediately before committing.
-  async rename(input: {
-    id: string
-    name: string
-    expectedRevision?: number
-  }): Promise<SpecialistProfileView> {
-    await this.assertMutableId(input.id)
-    // Use the same relaxed public-name validator as create() for consistency.
-    const nameError = validateSpecialistPublicName(input.name)
-    if (nameError) throw new Error(nameError)
-    const current = await this.getById(input.id)
-    const revision = input.expectedRevision ?? current.revision
-    return this.update({ id: input.id, name: input.name, revision })
   }
 
   async delete(id: string, expectedRevision?: number): Promise<void> {
@@ -503,7 +468,7 @@ export class ProfileService {
     await this.assertMutableId(id)
     const source = await this.getById(id)
     const names = new Set((await this.list()).map((profile) => profile.name))
-    // Use the display name (which equals name in the single-name model) as the base.
+    // Use the current display label as the base for the new Specialist's identity.
     const sourceName = source.displayName ?? source.name
     const base = `${sourceName} Copy`
     let name = base.slice(0, 80)

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -97,8 +97,8 @@ describe('ConnectorAddForm (local command)', () => {
 
     expect(useSettingsStore.getState().addCustomServer).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: 'Memory',
-        slug: 'memory',
+        name: 'memory',
+        displayName: 'Memory',
         transport: 'stdio',
         command: 'npx'
       })
@@ -126,7 +126,7 @@ describe('ConnectorAddForm (local command)', () => {
             schemaVersion: 1,
             kind: 'open-science.connector',
             name: 'example-research',
-            slug: 'example-research',
+            displayName: 'Example Research',
             transport: 'stdio',
             command: 'npx',
             args: ['-y', '@example/research-mcp', '--label', 'two words'],
@@ -140,7 +140,7 @@ describe('ConnectorAddForm (local command)', () => {
 
     expect(
       document.body.querySelector<HTMLInputElement>('[aria-label="Display name"]')?.value
-    ).toBe('example-research')
+    ).toBe('Example Research')
     expect(
       document.body.querySelector<HTMLTextAreaElement>('[aria-label="Environment variables"]')
         ?.value
@@ -155,7 +155,7 @@ describe('ConnectorAddForm (local command)', () => {
     expect(useSettingsStore.getState().addCustomServer).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'example-research',
-        slug: 'example-research',
+        displayName: 'Example Research',
         command: 'npx',
         args: ['-y', '@example/research-mcp', '--label', 'two words'],
         env: { API_TOKEN: 'local-secret' }
@@ -208,8 +208,8 @@ describe('ConnectorAddForm (remote server)', () => {
     })
 
     expect(useSettingsStore.getState().addCustomServer).toHaveBeenCalledWith({
-      name: 'OAuth MCP',
-      slug: 'oauth-mcp',
+      name: 'oauth-mcp',
+      displayName: 'OAuth MCP',
       description: undefined,
       transport: 'streamable_http',
       url: 'https://mcp.example.test',
@@ -225,8 +225,8 @@ describe('ConnectorAddForm (remote server)', () => {
 describe('ConnectorAddForm (edit)', () => {
   const editServer = {
     id: 'srv-1',
-    slug: 'my-mem',
     name: 'my-mem',
+    displayName: 'my-mem',
     description: 'Memory server',
     transport: 'stdio' as const,
     enabled: true,
@@ -244,13 +244,19 @@ describe('ConnectorAddForm (edit)', () => {
       root.render(<ConnectorAddForm editServer={editServer} onDone={onDone} onCancel={vi.fn()} />)
     })
 
-    const nameInput = document.body.querySelector<HTMLInputElement>('[aria-label="Display name"]')
+    const nameInput = document.body.querySelector<HTMLInputElement>('[aria-label="Connector ID"]')
     expect(nameInput?.value).toBe('my-mem')
-    expect(nameInput?.disabled).toBe(true) // name is immutable
+    expect(nameInput?.disabled).toBe(true) // name is immutable and visibly disabled
+    const displayNameInput = document.body.querySelector<HTMLInputElement>(
+      '[aria-label="Display name"]'
+    )
+    expect(displayNameInput?.value).toBe('my-mem')
+    expect(displayNameInput?.readOnly).toBe(false)
     // The command Select shows the pre-filled runtime.
     expect(document.body.querySelector('[aria-label="Command"]')?.textContent).toContain('npx')
 
     // Edit a non-secret field.
+    setValue('Display name', 'My Memory')
     setValue('Description', 'Updated memory')
     const save = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
       (b) => b.textContent?.trim() === 'Save changes'
@@ -264,6 +270,7 @@ describe('ConnectorAddForm (edit)', () => {
     expect(useSettingsStore.getState().updateCustomServer).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'srv-1',
+        displayName: 'My Memory',
         transport: 'stdio',
         command: 'npx',
         description: 'Updated memory'
@@ -284,8 +291,8 @@ describe('ConnectorAddForm (edit)', () => {
         <ConnectorAddForm
           editServer={{
             id: 'remote-1',
-            slug: 'remote',
-            name: 'Remote',
+            name: 'remote',
+            displayName: 'Remote',
             transport: 'streamable_http',
             enabled: true,
             url: 'https://mcp.example.test',
@@ -316,8 +323,8 @@ describe('ConnectorAddForm (edit)', () => {
         <ConnectorAddForm
           editServer={{
             id: 'remote-1',
-            slug: 'remote',
-            name: 'Remote',
+            name: 'remote',
+            displayName: 'Remote',
             transport: 'streamable_http',
             enabled: true,
             url: 'https://mcp.example.test',
@@ -351,8 +358,8 @@ describe('ConnectorAddForm (edit)', () => {
         <ConnectorAddForm
           editServer={{
             id: 'remote-1',
-            slug: 'remote',
-            name: 'Remote',
+            name: 'remote',
+            displayName: 'Remote',
             transport: 'streamable_http',
             enabled: true,
             url: 'https://mcp.example.test',

--- a/src/renderer/src/pages/settings/ConnectorAddForm.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.tsx
@@ -12,12 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import { useSettingsStore } from '@/stores/settings-store'
-import {
-  customConnectorAliasKey,
-  customConnectorAliases,
-  isCustomConnectorSlug,
-  toCustomConnectorSlug
-} from '../../../../shared/custom-connector'
+import { isCustomConnectorName, toCustomConnectorName } from '../../../../shared/custom-connector'
 import { SettingsRow } from './SettingsLayout'
 
 // Which kind of custom connector is being added: a local stdio command or a remote HTTP/SSE server.
@@ -88,7 +83,7 @@ const COMMAND_OPTIONS: { value: string; label: string }[] = [
 type ConnectorAddFormProps = {
   initialTransport?: ConnectorMode
   initialTemplate?: ConnectorTemplateDefinition
-  // When set, the form edits this custom server instead of adding a new one. The name is immutable.
+  // When set, the form edits this custom server instead of adding a new one. Its name is immutable.
   editServer?: CustomServerView
   // Called after the custom server has been added/updated successfully.
   onDone: () => void
@@ -121,34 +116,30 @@ export function ConnectorAddForm({
         ? modeForTransport(initialTemplate.transport)
         : (initialTransport ?? 'local')
   )
+  const [displayName, setDisplayName] = useState(
+    editServer?.displayName ?? initialTemplate?.displayName ?? ''
+  )
   const [name, setName] = useState(editServer?.name ?? initialTemplate?.name ?? '')
-  const [slug, setSlug] = useState(editServer?.slug ?? initialTemplate?.slug ?? '')
-  const [slugTouched, setSlugTouched] = useState(initialTemplate !== undefined)
-  const currentSlug = isEdit
-    ? (editServer?.slug ?? '')
-    : slugTouched
-      ? slug
-      : toCustomConnectorSlug(name)
-  const slugError = useMemo((): string | null => {
-    if (!currentSlug || !isCustomConnectorSlug(currentSlug)) {
+  const [nameTouched, setNameTouched] = useState(initialTemplate !== undefined)
+  const currentName = isEdit
+    ? (editServer?.name ?? '')
+    : nameTouched
+      ? name
+      : toCustomConnectorName(displayName)
+  const nameError = useMemo((): string | null => {
+    if (!currentName || !isCustomConnectorName(currentName)) {
       return 'Use only lowercase letters, numbers, and hyphens.'
     }
-    if (connectors.some((connector) => connector.id === currentSlug)) {
+    if (connectors.some((connector) => connector.id === currentName)) {
       return 'This ID is reserved by a built-in Connector.'
     }
     if (
-      customServers.some(
-        (server) =>
-          server.id !== editServer?.id &&
-          customConnectorAliases(server)
-            .map(customConnectorAliasKey)
-            .includes(customConnectorAliasKey(currentSlug))
-      )
+      customServers.some((server) => server.id !== editServer?.id && server.name === currentName)
     ) {
       return 'A custom Connector with this ID already exists.'
     }
     return null
-  }, [connectors, currentSlug, customServers, editServer?.id])
+  }, [connectors, currentName, customServers, editServer?.id])
   const [description, setDescription] = useState(
     editServer?.description ?? initialTemplate?.description ?? ''
   )
@@ -222,8 +213,8 @@ export function ConnectorAddForm({
         requiredHeaders.every((header) => (parsedHeaders[header] ?? '').trim().length > 0)))
 
   const requiredFilled =
-    name.trim().length > 0 &&
-    !slugError &&
+    displayName.trim().length > 0 &&
+    !nameError &&
     (mode === 'local' ? command.trim().length > 0 : url.trim().length > 0) &&
     requiredSecretValuesFilled
   const canSubmit = requiredFilled && trusted && !submitting
@@ -249,6 +240,7 @@ export function ConnectorAddForm({
       const hasHeaders = headersText.trim().length > 0
       const transport: CustomServerTransport = mode === 'local' ? 'stdio' : remoteTransport
       const shared = {
+        displayName: displayName.trim(),
         description: description.trim() || undefined,
         transport,
         ...(mode === 'local'
@@ -288,8 +280,7 @@ export function ConnectorAddForm({
         await updateCustomServer(request)
       } else {
         const request: AddCustomServerRequest = {
-          name: name.trim(),
-          slug: currentSlug,
+          name: currentName,
           ...shared,
           ...(mode === 'local' && Object.keys(env).length > 0 ? { env } : {}),
           ...(mode === 'remote' && remoteAuth === 'headers' && Object.keys(headers).length > 0
@@ -350,21 +341,15 @@ export function ConnectorAddForm({
         <div className="space-y-1.5">
           <label className={fieldLabelClassName} htmlFor="connector-name">
             Display name
-            {isEdit ? null : <RequiredMark />}
+            <RequiredMark />
           </label>
           <Input
             id="connector-name"
             aria-label="Display name"
-            value={name}
-            disabled={isEdit}
+            value={displayName}
             placeholder="e.g. Memory server"
-            onChange={(event) => setName(event.target.value)}
+            onChange={(event) => setDisplayName(event.target.value)}
           />
-          {isEdit ? (
-            <p className="text-xs text-muted-foreground">
-              The display name is fixed after creation.
-            </p>
-          ) : null}
         </div>
 
         <SettingsRow
@@ -375,25 +360,25 @@ export function ConnectorAddForm({
             </>
           }
           description={
-            <span className={slugError ? 'text-destructive' : undefined}>
-              {slugError ??
-                `Used by host.mcp("${currentSlug}", …), Specialists, and the generated MCP skill.`}
+            <span className={nameError ? 'text-destructive' : undefined}>
+              {nameError ??
+                `Used by host.mcp("${currentName}", …), Specialists, and the generated MCP skill.`}
             </span>
           }
         >
           <Input
-            id="connector-slug"
+            id="connector-name-id"
             aria-label="Connector ID"
-            value={currentSlug}
-            readOnly={isEdit}
-            aria-invalid={slugError ? true : undefined}
+            value={currentName}
+            disabled={isEdit}
+            aria-invalid={nameError ? true : undefined}
             className="font-mono"
             onChange={
               isEdit
                 ? undefined
                 : (event) => {
-                    setSlugTouched(true)
-                    setSlug(event.target.value.toLowerCase())
+                    setNameTouched(true)
+                    setName(event.target.value.toLowerCase())
                   }
             }
           />

--- a/src/renderer/src/pages/settings/ConnectorImportView.tsx
+++ b/src/renderer/src/pages/settings/ConnectorImportView.tsx
@@ -142,7 +142,11 @@ export function ConnectorImportView({
             </div>
             <dl className="divide-y divide-border border-y border-border text-sm">
               <div className="grid grid-cols-[8rem_1fr] gap-3 py-2.5">
-                <dt className="text-muted-foreground">Name</dt>
+                <dt className="text-muted-foreground">Display name</dt>
+                <dd className="min-w-0 break-words text-foreground">{definition.displayName}</dd>
+              </div>
+              <div className="grid grid-cols-[8rem_1fr] gap-3 py-2.5">
+                <dt className="text-muted-foreground">Connector ID</dt>
                 <dd className="min-w-0 break-words text-foreground">{definition.name}</dd>
               </div>
               <div className="grid grid-cols-[8rem_1fr] gap-3 py-2.5">

--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -56,8 +56,8 @@ const seedConnectors = [
 const seedCustomServers = [
   {
     id: 'custom-server-uuid',
-    slug: 'my-mcp',
-    name: 'My MCP',
+    name: 'my-mcp',
+    displayName: 'My MCP',
     description: 'A local tool server',
     transport: 'stdio' as const,
     enabled: true,
@@ -295,10 +295,8 @@ describe('ConnectorsPanel (groups)', () => {
       await Promise.resolve()
     })
     expect(useSettingsStore.getState().removeCustomServer).not.toHaveBeenCalled()
-    expect(document.body.textContent).toContain('This Connector is used by 4 Specialists')
-    expect(document.body.textContent).toContain('Selected by legacy UUID')
+    expect(document.body.textContent).toContain('This Connector is used by 2 Specialists')
     expect(document.body.textContent).toContain('Selected by ID')
-    expect(document.body.textContent).toContain('Selected by legacy name')
     expect(document.body.textContent).toContain('Full access')
 
     const confirm = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
@@ -330,8 +328,8 @@ describe('ConnectorsPanel (groups)', () => {
       customServers: [
         {
           id: 'oauth-mcp',
-          slug: 'oauth-mcp',
-          name: 'OAuth MCP',
+          name: 'oauth-mcp',
+          displayName: 'OAuth MCP',
           transport: 'streamable_http',
           enabled: false,
           url: 'https://mcp.example.test',
@@ -362,8 +360,8 @@ describe('ConnectorsPanel (groups)', () => {
         customServers: [
           {
             id: 'oauth-mcp',
-            slug: 'oauth-mcp',
-            name: 'OAuth MCP',
+            name: 'oauth-mcp',
+            displayName: 'OAuth MCP',
             transport: 'streamable_http',
             enabled: true,
             url: 'https://mcp.example.test',
@@ -401,8 +399,8 @@ describe('ConnectorsPanel (groups)', () => {
       customServers: [
         {
           id: 'offline-mcp',
-          slug: 'offline-mcp',
-          name: 'Offline MCP',
+          name: 'offline-mcp',
+          displayName: 'Offline MCP',
           transport: 'stdio',
           enabled: true,
           command: 'mcp',
@@ -430,8 +428,8 @@ describe('ConnectorsPanel (groups)', () => {
       customServers: [
         {
           id: 'invalid-mcp',
-          slug: 'invalid-mcp',
-          name: 'Invalid MCP',
+          name: 'invalid-mcp',
+          displayName: 'Invalid MCP',
           transport: 'stdio',
           enabled: false,
           availability: 'unavailable'
@@ -457,8 +455,8 @@ describe('ConnectorsPanel (groups)', () => {
       customServers: [
         {
           id: 'checking-mcp',
-          slug: 'checking-mcp',
-          name: 'Checking MCP',
+          name: 'checking-mcp',
+          displayName: 'Checking MCP',
           transport: 'stdio',
           enabled: true,
           command: 'mcp',
@@ -478,8 +476,8 @@ describe('ConnectorsPanel (groups)', () => {
       customServers: [
         {
           id: 'expired-oauth',
-          slug: 'expired-oauth',
-          name: 'Expired OAuth',
+          name: 'expired-oauth',
+          displayName: 'Expired OAuth',
           transport: 'streamable_http',
           enabled: true,
           url: 'https://mcp.example.test',
@@ -508,8 +506,8 @@ describe('ConnectorsPanel (groups)', () => {
       customServers: [
         {
           id: 'anonymous-remote',
-          slug: 'anonymous-remote',
-          name: 'Anonymous Remote',
+          name: 'anonymous-remote',
+          displayName: 'Anonymous Remote',
           transport: 'streamable_http',
           enabled: true,
           url: 'https://mcp.example.test',
@@ -538,8 +536,8 @@ describe('ConnectorsPanel (groups)', () => {
       customServers: [
         {
           id: 'oauth-mcp',
-          slug: 'oauth-mcp',
-          name: 'OAuth MCP',
+          name: 'oauth-mcp',
+          displayName: 'OAuth MCP',
           transport: 'streamable_http',
           enabled: false,
           url: 'https://mcp.example.test',
@@ -577,8 +575,8 @@ describe('ConnectorsPanel (groups)', () => {
       customServers: [
         {
           id: 'oauth-a',
-          slug: 'oauth-a',
-          name: 'OAuth A',
+          name: 'oauth-a',
+          displayName: 'OAuth A',
           transport: 'streamable_http',
           enabled: false,
           url: 'https://a.example.test',
@@ -586,8 +584,8 @@ describe('ConnectorsPanel (groups)', () => {
         },
         {
           id: 'oauth-b',
-          slug: 'oauth-b',
-          name: 'OAuth B',
+          name: 'oauth-b',
+          displayName: 'OAuth B',
           transport: 'streamable_http',
           enabled: false,
           url: 'https://b.example.test',
@@ -625,8 +623,8 @@ describe('ConnectorsPanel (groups)', () => {
       customServers: [
         {
           id: 'oauth-mcp',
-          slug: 'oauth-mcp',
-          name: 'OAuth MCP',
+          name: 'oauth-mcp',
+          displayName: 'OAuth MCP',
           transport: 'streamable_http',
           enabled: false,
           url: 'https://mcp.example.test',

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -64,9 +64,8 @@ const FILTER_LABELS: Record<GroupFilter, string> = {
 
 const specialistNamesUsingConnector = (
   items: SpecialistListItem[],
-  server: Pick<CustomServerView, 'id' | 'name' | 'slug'>
+  server: Pick<CustomServerView, 'name'>
 ): string[] => {
-  const aliases = new Set([server.slug, server.name, server.id])
   return items
     .flatMap((item) => {
       if (item.kind === 'reviewer') return []
@@ -75,9 +74,7 @@ const specialistNamesUsingConnector = (
           ? item.fullAccess.excludedConnectorIds
           : item.selectedCapabilities.connectorIds
       const usesConnector =
-        item.capabilityMode === 'full'
-          ? !ids.some((id) => aliases.has(id))
-          : ids.some((id) => aliases.has(id))
+        item.capabilityMode === 'full' ? !ids.includes(server.name) : ids.includes(server.name)
       return usesConnector ? [item.displayName?.trim() || item.name] : []
     })
     .sort((a, b) => a.localeCompare(b))
@@ -143,6 +140,7 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
     if (!term) return customServers
     return customServers.filter(
       (server) =>
+        server.displayName.toLowerCase().includes(term) ||
         server.name.toLowerCase().includes(term) ||
         (server.description?.toLowerCase().includes(term) ?? false)
     )
@@ -492,13 +490,12 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
                       <ConnectorGlyph size={24} />
                       <div className="min-w-0 flex-1">
                         <span className="block truncate text-sm text-foreground">
-                          {server.name}
+                          {server.displayName}
                         </span>
-                        {server.description ? (
-                          <span className="block truncate text-xs text-muted-foreground">
-                            {server.description}
-                          </span>
-                        ) : null}
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {server.name}
+                          {server.description ? ` · ${server.description}` : ''}
+                        </span>
                         <span
                           className={`block truncate text-xs ${
                             server.availability && !server.checking && !retryingIds.has(server.id)
@@ -520,17 +517,17 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
                         </span>
                       </div>
                       <SettingsIconAction
-                        label={`Export ${server.name}`}
+                        label={`Export ${server.displayName}`}
                         icon={Download}
                         onClick={() => onNavigate({ kind: 'export', id: server.id })}
                       />
                       <SettingsIconAction
-                        label={`Edit ${server.name}`}
+                        label={`Edit ${server.displayName}`}
                         icon={Pencil}
                         onClick={() => onNavigate({ kind: 'edit', id: server.id })}
                       />
                       <SettingsIconAction
-                        label={`Remove ${server.name}`}
+                        label={`Remove ${server.displayName}`}
                         icon={Trash2}
                         onClick={() => void requestRemoval(server)}
                         danger
@@ -583,7 +580,7 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
                       ) : null}
                       <SettingsToggle
                         enabled={server.enabled}
-                        aria-label={server.name}
+                        aria-label={server.displayName}
                         aria-disabled={requiresSignInBeforeEnable(server) || undefined}
                         className={
                           requiresSignInBeforeEnable(server)
@@ -626,7 +623,7 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
           <AlertDialog.Overlay className={dialogOverlayClassName} />
           <AlertDialog.Content className={dialogPanelClassName('w-[min(440px,calc(100vw-2rem))]')}>
             <AlertDialog.Title className={dialogTitleClassName}>
-              Remove “{removal?.server.name}”?
+              Remove “{removal?.server.displayName}”?
             </AlertDialog.Title>
             <AlertDialog.Description className={dialogDescriptionClassName}>
               This removes the Connector configuration and credentials from this app. Existing

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -59,6 +59,7 @@ const installApi = (): void => {
         {
           id: 'alpha',
           name: 'Alpha',
+          displayName: 'Alpha',
           description: 'First',
           source: 'featured',
           updatedAt: '2026-07-08T00:00:00.000Z',
@@ -68,6 +69,7 @@ const installApi = (): void => {
       getSkillDetail: vi.fn().mockResolvedValue({
         id: 'alpha',
         name: 'Alpha',
+        displayName: 'Alpha',
         description: 'First',
         source: 'featured',
         updatedAt: '2026-07-08T00:00:00.000Z',
@@ -1859,10 +1861,10 @@ describe('SettingsPage layout', () => {
       await Promise.resolve()
     })
 
-    // Landed on the specialist's editor (name input prefilled with the public name), not the
+    // Landed on the specialist's editor (display name prefilled), not the
     // default Model panel.
     const name = document.body.querySelector<HTMLInputElement>('#sp-name')
-    expect(name?.value).toBe('RESEARCHER')
+    expect(name?.value).toBe('Researcher')
     expect(document.body.querySelector('section[aria-label="Providers"]')).toBeNull()
     // The pending id is consumed so a later normal open won't jump back to it.
     expect(useSettingsStore.getState().pendingSpecialistId).toBeUndefined()

--- a/src/renderer/src/pages/settings/SkillDetailView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillDetailView.render.test.tsx
@@ -12,6 +12,7 @@ let root: Root
 const detail = {
   id: 'a',
   name: 'Alpha',
+  displayName: 'Alpha',
   description: 'First skill description.',
   source: 'featured' as const,
   updatedAt: '2026-07-08T00:00:00.000Z',
@@ -32,6 +33,7 @@ beforeEach(() => {
       {
         id: 'a',
         name: 'Alpha',
+        displayName: 'Alpha',
         description: 'First skill description.',
         source: 'featured',
         updatedAt: '2026-07-08T00:00:00.000Z',
@@ -129,6 +131,7 @@ describe('SkillDetailView', () => {
           {
             id: 'a',
             name: 'Alpha',
+            displayName: 'Alpha',
             description: 'First skill description.',
             source,
             updatedAt: detail.updatedAt,

--- a/src/renderer/src/pages/settings/SkillEditor.tsx
+++ b/src/renderer/src/pages/settings/SkillEditor.tsx
@@ -17,13 +17,15 @@ export type SkillDraft = {
   description: string
   body: string
   metadata?: Record<string, string>
-  slug?: string
   references?: SkillReference[]
 }
 
-// Reserved id namespaces a user-authored skill may not claim (mirrors the main-process rule):
+const SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const SKILL_NAME_MAX_LENGTH = 64
+
+// Reserved name namespaces a user-authored skill may not claim (mirrors the main-process rule):
 // `os-` is the app's own materialized prefix, `mcp-` is reserved for MCP-provided skills.
-const RESERVED_SLUG_PREFIXES = ['os-', 'mcp-']
+const RESERVED_SKILL_NAME_PREFIXES = ['os-', 'mcp-']
 
 // Reads a File as base64 (for binary-safe reference transport to the main process).
 const fileToBase64 = (file: File): Promise<string> =>
@@ -34,21 +36,13 @@ const fileToBase64 = (file: File): Promise<string> =>
     reader.readAsDataURL(file)
   })
 
-// Renderer-side slug preview mirroring the main-process slug rule (lowercase a–z, 0–9, hyphens).
-const toSlug = (name: string): string =>
-  name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 64)
-
 type SkillEditorProps = {
   initial: SkillDraft
   onCancel: () => void
   onSave: (draft: SkillDraft) => Promise<void>
 }
 
-// Create/edit form for a personal skill: Identity (name/id/description) + Content (SKILL.md body).
+// Create/edit form for a personal skill: Identity (name/description) + Content (SKILL.md body).
 // Pasting a full SKILL.md with a frontmatter block auto-fills name/description.
 const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX.Element => {
   const isCreate = !initial.id
@@ -62,35 +56,32 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
   const [references, setReferences] = useState<{ path: string; dataBase64?: string }[]>(() =>
     (initial.references ?? []).map((ref) => ({ path: ref.path, dataBase64: ref.dataBase64 }))
   )
-  const [slug, setSlug] = useState('')
-  const [slugTouched, setSlugTouched] = useState(false)
   const [saving, setSaving] = useState(false)
 
-  // The effective id: the user's typed value once they edit it, otherwise derived from the name.
-  const currentSlug = isCreate && !slugTouched ? toSlug(name) : slug
+  const currentName = name.trim()
 
-  // Validates the chosen id against the same rules the main process enforces, plus a live
+  // Validates the immutable name against the same rules the main process enforces, plus a live
   // collision check against already-loaded personal skills. Only meaningful when creating.
-  const slugError = useMemo((): string | null => {
+  const nameError = useMemo((): string | null => {
     if (!isCreate) return null
-    if (!currentSlug) return 'Skill ID is required.'
-    if (!/^[a-z0-9-]+$/.test(currentSlug)) {
-      return 'Only lowercase letters, numbers, and hyphens.'
+    if (!currentName) return 'Name is required.'
+    if (!SKILL_NAME_PATTERN.test(currentName) || currentName.length > SKILL_NAME_MAX_LENGTH) {
+      return 'Use up to 64 lowercase letters, numbers, and single hyphens.'
     }
-    if (RESERVED_SLUG_PREFIXES.some((prefix) => currentSlug.startsWith(prefix))) {
-      return `Can't start with ${RESERVED_SLUG_PREFIXES.join(' or ')}.`
+    if (RESERVED_SKILL_NAME_PREFIXES.some((prefix) => currentName.startsWith(prefix))) {
+      return `Can't start with ${RESERVED_SKILL_NAME_PREFIXES.join(' or ')}.`
     }
-    if (skills.some((entry) => entry.id === `personal-${currentSlug}`)) {
-      return 'A skill with this ID already exists.'
+    if (skills.some((entry) => entry.id === `personal-${currentName}`)) {
+      return 'A skill with this name already exists.'
     }
     return null
-  }, [isCreate, currentSlug, skills])
+  }, [isCreate, currentName, skills])
 
   const importedContent = frontmatterImportMode ? parseSkillDocument(body) : undefined
   const persistedBody = importedContent?.hasFrontmatter ? importedContent.body : body
   const persistedMetadata = importedContent?.hasFrontmatter ? importedContent.metadata : metadata
   const metadataEntries = Object.entries(persistedMetadata ?? {})
-  const canSave = name.trim().length > 0 && persistedBody.trim().length > 0 && !slugError && !saving
+  const canSave = currentName.length > 0 && persistedBody.trim().length > 0 && !nameError && !saving
 
   // Plain textarea edits are always literal body content and keep the separately displayed metadata.
   // In import mode the visible frontmatter is authoritative, so removing it clears derived metadata.
@@ -98,7 +89,7 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
     if (frontmatterImportMode) {
       const parsed = parseSkillDocument(value)
       if (parsed.hasFrontmatter) {
-        if (parsed.name !== undefined) setName(parsed.name)
+        if (isCreate && parsed.name !== undefined) setName(parsed.name)
         if (parsed.description !== undefined) setDescription(parsed.description)
         setMetadata(parsed.metadata)
       } else {
@@ -114,7 +105,7 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
   const importContent = (value: string): void => {
     const parsed = parseSkillDocument(value)
     if (parsed.hasFrontmatter) {
-      if (parsed.name && !name.trim()) setName(parsed.name)
+      if (isCreate && parsed.name && !name.trim()) setName(parsed.name)
       if (parsed.description && !description.trim()) setDescription(parsed.description)
       setMetadata(parsed.metadata)
       setFrontmatterImportMode(true)
@@ -187,11 +178,10 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
     try {
       await onSave({
         id: initial.id,
-        name: name.trim(),
+        name: currentName,
         description: description.trim(),
         body: persistedBody,
         metadata: persistedMetadata,
-        slug: isCreate ? currentSlug : undefined,
         references: references.map((ref) => ({ path: ref.path, dataBase64: ref.dataBase64 }))
       })
     } finally {
@@ -214,42 +204,12 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
                 <Input
                   aria-label="Skill name"
                   value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  placeholder="e.g. Changelog style"
+                  onChange={isCreate ? (event) => setName(event.target.value) : undefined}
+                  disabled={!isCreate}
+                  aria-invalid={nameError ? true : undefined}
+                  placeholder="e.g. changelog-style"
                 />
-              </label>
-              <label className="flex flex-col gap-1.5">
-                <span className="text-sm font-medium text-foreground">Skill ID</span>
-                <Input
-                  aria-label="Skill ID"
-                  value={isCreate ? currentSlug : (initial.id ?? '').replace(/^personal-/, '')}
-                  onChange={
-                    isCreate
-                      ? (event) => {
-                          setSlugTouched(true)
-                          setSlug(event.target.value.toLowerCase())
-                        }
-                      : undefined
-                  }
-                  readOnly={!isCreate}
-                  aria-invalid={slugError ? true : undefined}
-                  className={`font-mono ${
-                    isCreate
-                      ? slugError
-                        ? 'border-danger-000 text-foreground'
-                        : 'text-foreground'
-                      : 'text-muted-foreground'
-                  }`}
-                />
-                {slugError ? (
-                  <span className="text-xs text-danger-000">{slugError}</span>
-                ) : (
-                  <span className="text-xs text-muted-foreground">
-                    {isCreate
-                      ? 'Used as the folder name — lowercase a–z, 0–9, hyphens. Locked after creation.'
-                      : 'The skill ID is fixed after creation.'}
-                  </span>
-                )}
+                {nameError ? <span className="text-xs text-danger-000">{nameError}</span> : null}
               </label>
               <label className="flex flex-col gap-1.5">
                 <span className="text-sm font-medium text-foreground">Description</span>
@@ -480,7 +440,6 @@ const SkillEditLoader = ({ skillId, onDone }: SkillEditLoaderProps): React.JSX.E
       onSave={async (next) => {
         await updateSkill({
           id: next.id ?? skillId,
-          name: next.name,
           description: next.description,
           body: next.body,
           metadata: next.metadata,

--- a/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
@@ -49,6 +49,7 @@ beforeEach(() => {
       {
         id: 'a',
         name: 'Alpha',
+        displayName: 'Alpha',
         description: 'First',
         source: 'featured' as const,
         updatedAt: '2026-07-08T00:00:00.000Z',

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -17,6 +17,7 @@ const seedSkills = [
   {
     id: 'a',
     name: 'Alpha',
+    displayName: 'Alpha',
     description: 'First',
     source: 'featured' as const,
     updatedAt: '2026-07-08T00:00:00.000Z',
@@ -25,6 +26,7 @@ const seedSkills = [
   {
     id: 'b',
     name: 'Beta',
+    displayName: 'Beta',
     description: 'Second',
     source: 'featured' as const,
     updatedAt: '2026-07-08T00:00:00.000Z',
@@ -33,6 +35,7 @@ const seedSkills = [
   {
     id: 'personal-mine',
     name: 'Mine',
+    displayName: 'Mine',
     description: 'Custom',
     source: 'personal' as const,
     updatedAt: '2026-07-08T00:00:00.000Z',
@@ -302,6 +305,7 @@ describe('SkillsPanel (list view)', () => {
         {
           id: 'imported-shared',
           name: 'Shared',
+          displayName: 'Shared',
           description: 'Imported',
           source: 'imported',
           updatedAt: '2026-07-08T00:00:00.000Z',
@@ -484,6 +488,11 @@ describe('SkillsPanel (sub-views)', () => {
       await Promise.resolve()
     })
 
+    expect(
+      document.body.querySelector<HTMLInputElement>('[aria-label="Skill name"]')?.disabled
+    ).toBe(true)
+    expect(document.body.querySelector('[aria-label="Skill ID"]')).toBeNull()
+
     const save = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
       (button) => button.textContent?.trim() === 'Save'
     )
@@ -494,7 +503,6 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
-      name: 'Mine',
       description: 'Custom',
       body: '# Body',
       metadata: { author: 'Ada', license: 'MIT', category: 'research' },
@@ -549,7 +557,6 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
-      name: 'Mine',
       description: 'Custom',
       body: '# New body',
       metadata: { author: 'Grace', tags: 'analysis, writing' },
@@ -591,7 +598,6 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
-      name: 'Mine',
       description: 'Custom',
       body: '# New body',
       metadata: { author: 'Ada', license: 'MIT' },
@@ -640,7 +646,6 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
-      name: 'Mine',
       description: 'Custom',
       body: '# Plain replacement',
       metadata: { author: 'Old author', license: 'MIT' },
@@ -693,11 +698,11 @@ describe('SkillsPanel (sub-views)', () => {
     })
     pasteValue(
       'Skill body',
-      ['---', 'name: Original', 'description: Before', 'author: Ada', '---', '# Body'].join('\n')
+      ['---', 'name: original', 'description: Before', 'author: Ada', '---', '# Body'].join('\n')
     )
     setValue(
       'Skill body',
-      ['---', 'name: Revised', 'description: After', 'author: Ada', '---', '# Body'].join('\n')
+      ['---', 'name: revised', 'description: After', 'author: Ada', '---', '# Body'].join('\n')
     )
 
     const publish = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
@@ -706,11 +711,10 @@ describe('SkillsPanel (sub-views)', () => {
     act(() => publish?.click())
 
     expect(useSettingsStore.getState().createSkill).toHaveBeenCalledWith({
-      name: 'Revised',
+      name: 'revised',
       description: 'After',
       body: '# Body',
       metadata: { author: 'Ada' },
-      slug: 'revised',
       references: []
     })
   })
@@ -719,7 +723,7 @@ describe('SkillsPanel (sub-views)', () => {
     act(() => {
       root.render(<SkillsPanel view={{ kind: 'create' }} onNavigate={vi.fn()} />)
     })
-    setValue('Skill name', 'YAML Example')
+    setValue('Skill name', 'yaml-example')
     const body = ['---', 'example: literal documentation', '---', '# Instructions'].join('\n')
     setValue('Skill body', body)
 
@@ -729,11 +733,10 @@ describe('SkillsPanel (sub-views)', () => {
     act(() => publish?.click())
 
     expect(useSettingsStore.getState().createSkill).toHaveBeenCalledWith({
-      name: 'YAML Example',
+      name: 'yaml-example',
       description: '',
       body,
       metadata: undefined,
-      slug: 'yaml-example',
       references: []
     })
   })
@@ -751,7 +754,8 @@ describe('SkillsPanel (sub-views)', () => {
     expect(
       document.body.querySelector('[aria-label="Skill body"]')?.getAttribute('data-slot')
     ).toBe('textarea')
-    setValue('Skill name', 'My New Skill')
+    expect(document.body.querySelector('[aria-label="Skill ID"]')).toBeNull()
+    setValue('Skill name', 'my-new-skill')
     setValue('Skill body', '# Body')
 
     const publish = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
@@ -760,12 +764,28 @@ describe('SkillsPanel (sub-views)', () => {
     act(() => publish?.click())
 
     expect(useSettingsStore.getState().createSkill).toHaveBeenCalledWith({
-      name: 'My New Skill',
+      name: 'my-new-skill',
       description: '',
       body: '# Body',
-      slug: 'my-new-skill',
       references: []
     })
+  })
+
+  it('requires the personal skill name to be the immutable lowercase identity', () => {
+    act(() => {
+      root.render(<SkillsPanel view={{ kind: 'create' }} onNavigate={vi.fn()} />)
+    })
+    setValue('Skill name', 'My New Skill')
+    setValue('Skill body', '# Body')
+
+    const publish = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Publish'
+    )
+    expect(document.body.textContent).toContain(
+      'Use up to 64 lowercase letters, numbers, and single hyphens.'
+    )
+    expect(publish?.disabled).toBe(true)
+    expect(useSettingsStore.getState().createSkill).not.toHaveBeenCalled()
   })
 
   it('preserves frontmatter metadata pasted into the create editor', () => {
@@ -775,7 +795,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     const pasted = [
       '---',
-      'name: Pasted Skill',
+      'name: pasted-skill',
       'description: Pasted description',
       'author: Ada',
       'category: research',
@@ -792,11 +812,10 @@ describe('SkillsPanel (sub-views)', () => {
     act(() => publish?.click())
 
     expect(useSettingsStore.getState().createSkill).toHaveBeenCalledWith({
-      name: 'Pasted Skill',
+      name: 'pasted-skill',
       description: 'Pasted description',
       body: '# Body',
       metadata: { author: 'Ada', category: 'research' },
-      slug: 'pasted-skill',
       references: []
     })
   })

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -129,7 +129,9 @@ const SkillsPanel = ({
       if (filter !== 'all' && skill.source !== filter) return false
       if (!term) return true
       return (
-        skill.name.toLowerCase().includes(term) || skill.description.toLowerCase().includes(term)
+        skill.displayName.toLowerCase().includes(term) ||
+        skill.name.toLowerCase().includes(term) ||
+        skill.description.toLowerCase().includes(term)
       )
     })
   }, [skills, filter, query])
@@ -148,7 +150,6 @@ const SkillsPanel = ({
             description: draft.description,
             body: draft.body,
             ...(draft.metadata === undefined ? {} : { metadata: draft.metadata }),
-            slug: draft.slug,
             references: draft.references
           })
           onNavigate({ kind: 'list' })
@@ -347,7 +348,7 @@ const SkillsPanel = ({
                           className="min-w-0 flex-1 text-left"
                         >
                           <span className="block truncate text-sm text-foreground">
-                            {skill.name}
+                            {skill.displayName}
                           </span>
                           <span className="block truncate text-xs text-muted-foreground">
                             {skill.description}
@@ -360,22 +361,22 @@ const SkillsPanel = ({
                         ) : null}
                         {skill.source !== 'featured' && canExportSkills ? (
                           <SettingsIconAction
-                            label={`Export ${skill.name}`}
+                            label={`Export ${skill.displayName}`}
                             icon={Download}
                             disabled={exportingId !== undefined}
-                            onClick={() => void exportSkill(skill.id, skill.name)}
+                            onClick={() => void exportSkill(skill.id, skill.displayName)}
                           />
                         ) : null}
                         {skill.source === 'personal' ? (
                           <SettingsIconAction
-                            label={`Edit ${skill.name}`}
+                            label={`Edit ${skill.displayName}`}
                             icon={Pencil}
                             onClick={() => onNavigate({ kind: 'edit', id: skill.id })}
                           />
                         ) : null}
                         {skill.source !== 'featured' ? (
                           <SettingsIconAction
-                            label={`Delete ${skill.name}`}
+                            label={`Delete ${skill.displayName}`}
                             icon={Trash2}
                             onClick={() => {
                               setDeleteError(undefined)
@@ -392,7 +393,7 @@ const SkillsPanel = ({
                         ) : null}
                         <SettingsToggle
                           enabled={skill.enabled}
-                          aria-label={`Toggle ${skill.name}`}
+                          aria-label={`Toggle ${skill.displayName}`}
                           onToggle={() => void setSkillEnabled(skill.id, !skill.enabled)}
                         />
                       </li>

--- a/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
@@ -45,6 +45,7 @@ describe('SpecialistEditor', () => {
         {
           id: 'main-disabled',
           name: 'Main disabled',
+          displayName: 'Main disabled',
           description: '',
           source: 'featured',
           enabled: false,
@@ -53,6 +54,7 @@ describe('SpecialistEditor', () => {
         {
           id: 'included',
           name: 'Included',
+          displayName: 'Included',
           description: '',
           source: 'featured',
           enabled: true,
@@ -160,8 +162,8 @@ describe('SpecialistEditor', () => {
       customServers: [
         {
           id: 'broken-server-uuid',
-          slug: 'broken-server',
-          name: 'Broken Server',
+          name: 'broken-server',
+          displayName: 'Broken Server',
           transport: 'stdio',
           enabled: true,
           availability: 'unavailable'
@@ -186,7 +188,7 @@ describe('SpecialistEditor', () => {
             },
             selectedCapabilities: {
               skillIds: [],
-              connectorIds: ['broken-server-uuid'],
+              connectorIds: ['broken-server'],
               connectorTools: []
             },
             revision: 1
@@ -308,6 +310,7 @@ describe('SpecialistEditor', () => {
         {
           id: 'literature-review',
           name: 'Literature Review',
+          displayName: 'Literature Review',
           description: '',
           source: 'featured',
           enabled: true,
@@ -406,7 +409,7 @@ describe('SpecialistEditor', () => {
       expect.objectContaining({
         id: 'rna-reviewer',
         revision: 3,
-        name: 'RNA Reviewer'
+        displayName: 'RNA Reviewer'
       })
     )
     // Create path is not used in edit mode.

--- a/src/renderer/src/pages/settings/SpecialistEditor.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.tsx
@@ -11,6 +11,7 @@ import {
   SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH,
   validateCreateSpecialistInput,
   validateSpecialistPackageVersion,
+  validateUpdateSpecialistInput,
   type CreateSpecialistInput,
   type UpdateSpecialistInput,
   type SpecialistFieldError,
@@ -112,7 +113,7 @@ const SpecialistEditor = ({
   const [form, setForm] = useState<FormState>(() =>
     editSpecialist
       ? {
-          name: editSpecialist.name,
+          name: editSpecialist.displayName ?? editSpecialist.name,
           packageVersion: editSpecialist.packageVersion ?? '0.1.0',
           description: editSpecialist.description,
           systemPrompt: editSpecialist.systemPrompt,
@@ -211,12 +212,9 @@ const SpecialistEditor = ({
         available: true
       })),
       ...customServers.map((server) => ({
-        id:
-          [server.id, server.name].find((alias) =>
-            [...form.excludedConnectorIds, ...form.connectorIds].includes(alias)
-          ) ?? server.slug,
-        name: server.name,
-        description: server.description,
+        id: server.name,
+        name: server.displayName,
+        description: server.description ? `${server.name} · ${server.description}` : server.name,
         mainEnabled: server.enabled,
         available: server.availability === undefined,
         availability: server.availability
@@ -291,11 +289,9 @@ const SpecialistEditor = ({
         available: true
       })),
       ...customServers.map((server) => ({
-        id:
-          [server.id, server.name].find((alias) => form.connectorIds.includes(alias)) ??
-          server.slug,
-        name: server.name,
-        description: server.description,
+        id: server.name,
+        name: server.displayName,
+        description: server.description ? `${server.name} · ${server.description}` : server.name,
         mainEnabled: server.enabled,
         available: server.availability === undefined,
         availability: server.availability
@@ -354,12 +350,23 @@ const SpecialistEditor = ({
 
   const validate = (): boolean => {
     // Client-side validation using the shared validator.
-    const input: CreateSpecialistInput = {
-      name: form.name,
-      description: form.description || undefined,
-      systemPrompt: form.systemPrompt || undefined
-    }
-    const errors = validateCreateSpecialistInput(input, existingNames)
+    const errors = isEdit
+      ? validateUpdateSpecialistInput({
+          id: editSpecialist.id,
+          revision: form.baseRevision,
+          displayName: form.name,
+          description: form.description || undefined,
+          systemPrompt: form.systemPrompt || undefined
+        })
+      : validateCreateSpecialistInput(
+          {
+            name: form.name,
+            displayName: form.name,
+            description: form.description || undefined,
+            systemPrompt: form.systemPrompt || undefined
+          },
+          existingNames
+        )
     if (isEdit) {
       const packageVersionError = validateSpecialistPackageVersion(form.packageVersion)
       if (packageVersionError) {
@@ -378,7 +385,6 @@ const SpecialistEditor = ({
     setHasConflict(false)
     try {
       const trimmed = {
-        name: form.name.trim(),
         displayName: form.name.trim(),
         description: form.description.trim() || undefined,
         systemPrompt: form.systemPrompt.trim() || undefined,
@@ -418,7 +424,7 @@ const SpecialistEditor = ({
         // Advance the base revision only after a confirmed save.
         setForm((prev) => ({ ...prev, baseRevision: prev.baseRevision + 1 }))
       } else {
-        await onSave(trimmed)
+        await onSave({ name: form.name.trim(), ...trimmed })
       }
     } catch (error) {
       const message =
@@ -450,7 +456,7 @@ const SpecialistEditor = ({
       const fresh = await onReload()
       if (fresh) {
         setForm({
-          name: fresh.name,
+          name: fresh.displayName ?? fresh.name,
           packageVersion: fresh.packageVersion ?? '0.1.0',
           description: fresh.description,
           systemPrompt: fresh.systemPrompt,
@@ -500,7 +506,7 @@ const SpecialistEditor = ({
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="text-[15px] font-semibold text-foreground">
-                  {editSpecialist.name}
+                  {editSpecialist.displayName ?? editSpecialist.name}
                 </span>
                 <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                   {editSpecialist.setupPending ? 'Setup incomplete' : 'Saved'}
@@ -623,7 +629,7 @@ const SpecialistEditor = ({
           {/* Name */}
           <div className="mb-4">
             <label htmlFor="sp-name" className="mb-1.5 flex items-baseline justify-between text-xs">
-              <span>Name</span>
+              <span>{isEdit ? 'Display name' : 'Name'}</span>
               <span className="text-[11px] tabular-nums text-muted-foreground">
                 {form.name.length} / {SPECIALIST_NAME_MAX_LENGTH}
               </span>
@@ -710,6 +716,13 @@ const SpecialistEditor = ({
                     {getFieldError('packageVersion')}
                   </p>
                 ) : null}
+              </div>
+              <div>
+                <label htmlFor="sp-specialist-name" className="mb-1.5 block text-xs font-semibold">
+                  Specialist name
+                </label>
+                <Input id="sp-specialist-name" value={editSpecialist.name} readOnly />
+                <p className="mt-1 text-xs text-muted-foreground">Fixed after creation.</p>
               </div>
               <div>
                 <label htmlFor="sp-specialist-id" className="mb-1.5 block text-xs font-semibold">

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -520,6 +520,7 @@ describe('WorkspacePage draft preservation', () => {
         {
           id: 'lit',
           name: 'Literature',
+          displayName: 'Literature',
           description: 'Search papers',
           source: 'featured',
           enabled: true,

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -40,6 +40,7 @@ const seedSkills = [
   {
     id: 'lit',
     name: 'Literature',
+    displayName: 'Literature',
     description: 'Find, verify, and synthesize scientific papers',
     source: 'featured' as const,
     updatedAt: '2026-07-08T00:00:00.000Z',
@@ -48,6 +49,7 @@ const seedSkills = [
   {
     id: 'mpnn',
     name: 'ProteinMPNN',
+    displayName: 'ProteinMPNN',
     description: 'Inverse-fold a protein backbone into sequence',
     source: 'personal' as const,
     updatedAt: '2026-07-08T00:00:00.000Z',

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -347,7 +347,7 @@ export const ComposerEditor = ({
 
   // Replace the active `/query` token with a skill chip, then close the popup.
   const handleSelectSkill = (skill: SkillView): void => {
-    mention.replaceTokenWith({ type: 'skill', id: skill.id, name: skill.name })
+    mention.replaceTokenWith({ type: 'skill', id: skill.id, name: skill.displayName })
     mention.cancel()
   }
 

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
@@ -13,6 +13,7 @@ const seedSkills = [
   {
     id: 'lit',
     name: 'Literature Review',
+    displayName: 'Literature Review',
     description: 'Find, verify, and synthesize scientific papers',
     source: 'featured' as const,
     updatedAt: '2026-07-08T00:00:00.000Z',
@@ -21,6 +22,7 @@ const seedSkills = [
   {
     id: 'mpnn',
     name: 'ProteinMPNN',
+    displayName: 'ProteinMPNN',
     description: 'Inverse-fold a protein backbone into sequence',
     source: 'personal' as const,
     updatedAt: '2026-07-08T00:00:00.000Z',
@@ -29,6 +31,7 @@ const seedSkills = [
   {
     id: 'imp',
     name: 'Imported Helper',
+    displayName: 'Imported Helper',
     description: 'A literature-adjacent skill from GitHub',
     source: 'imported' as const,
     updatedAt: '2026-07-08T00:00:00.000Z',

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
@@ -60,7 +60,7 @@ export const SkillMentionPopup = ({
     return (
       visibleSkills
         .map((skill) => {
-          const nameMatch = fuzzyScore(needle, skill.name)
+          const nameMatch = fuzzyScore(needle, skill.displayName)
           if (nameMatch) {
             return {
               skill,
@@ -153,7 +153,7 @@ export const SkillMentionPopup = ({
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <span className="truncate font-medium text-sm">
-                    <HighlightedText text={skill.name} positions={positions} />
+                    <HighlightedText text={skill.displayName} positions={positions} />
                   </span>
                   <div className="flex-1" />
                   <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent text-accent-foreground">

--- a/src/renderer/src/stores/settings-connectors-slice.test.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.test.ts
@@ -38,8 +38,8 @@ const connector = (
 
 const server = (id: string, enabled = true): CustomServerView => ({
   id,
-  slug: id,
   name: id,
+  displayName: id,
   transport: 'stdio',
   enabled,
   command: 'npx'
@@ -283,7 +283,12 @@ describe('settings Connectors slice', () => {
       .setNcbiCredentials({ contactEmail: 'science@example.test', apiKey: 'secret' })
     expect(store.getState().ncbi).toEqual(withCredentials.ncbi)
 
-    await store.getState().addCustomServer({ name: 'Created', transport: 'stdio', command: 'npx' })
+    await store.getState().addCustomServer({
+      name: 'created',
+      displayName: 'Created',
+      transport: 'stdio',
+      command: 'npx'
+    })
     expect(store.getState().customServers).toEqual([created])
 
     await store.getState().updateCustomServer({

--- a/src/renderer/src/stores/settings-skills-slice.test.ts
+++ b/src/renderer/src/stores/settings-skills-slice.test.ts
@@ -29,6 +29,7 @@ type SkillCommands = Parameters<
 const skill = (id: string, enabled = true): SkillView => ({
   id,
   name: id,
+  displayName: id,
   description: `${id} description`,
   source: 'personal',
   updatedAt: '2026-08-06T00:00:00.000Z',

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -119,6 +119,7 @@ const providerView = (id: string): SettingsSnapshot['providers'][number] => ({
 const skillView = (id: string, name: string): SkillView => ({
   id,
   name,
+  displayName: name,
   description: '',
   source: 'personal',
   updatedAt: '',
@@ -1125,7 +1126,7 @@ describe('settings store: refreshProviderModels', () => {
 
     await useSettingsStore
       .getState()
-      .updateSkill({ id: created.id, name: 'Updated demo', description: '', body: '# Demo' })
+      .updateSkill({ id: created.id, description: '', body: '# Demo' })
     expect(useSettingsStore.getState().skills).toEqual([updated])
 
     await useSettingsStore.getState().deleteSkill(created.id)
@@ -1410,11 +1411,15 @@ describe('settings store: connectors slice', () => {
       ncbi: { hasApiKey: false }
     })
 
-    await useSettingsStore
-      .getState()
-      .addCustomServer({ name: 'my-mem', transport: 'stdio', command: 'npx' })
+    await useSettingsStore.getState().addCustomServer({
+      name: 'my-mem',
+      displayName: 'My Memory',
+      transport: 'stdio',
+      command: 'npx'
+    })
     expect(api.addCustomServer).toHaveBeenCalledWith({
       name: 'my-mem',
+      displayName: 'My Memory',
       transport: 'stdio',
       command: 'npx'
     })
@@ -1428,8 +1433,8 @@ describe('settings store: connectors slice', () => {
   it('authenticateCustomServer reconciles the OAuth status from main', async () => {
     const server: CustomServerView = {
       id: 'oauth-1',
-      slug: 'oauth-server',
-      name: 'OAuth server',
+      name: 'oauth-server',
+      displayName: 'OAuth server',
       transport: 'streamable_http',
       enabled: true,
       url: 'https://mcp.example.test',
@@ -1450,8 +1455,8 @@ describe('settings store: connectors slice', () => {
   it('refreshes OAuth status after authenticateCustomServer fails', async () => {
     const server: CustomServerView = {
       id: 'oauth-1',
-      slug: 'oauth-server',
-      name: 'OAuth server',
+      name: 'oauth-server',
+      displayName: 'OAuth server',
       transport: 'streamable_http',
       enabled: true,
       url: 'https://mcp.example.test',

--- a/src/shared/custom-connector.ts
+++ b/src/shared/custom-connector.ts
@@ -1,39 +1,20 @@
-export const CUSTOM_CONNECTOR_SLUG_MAX_LENGTH = 64
-export const CUSTOM_CONNECTOR_SLUG_PATTERN = /^[a-z0-9-]+$/
+export const CUSTOM_CONNECTOR_NAME_MAX_LENGTH = 64
+export const CUSTOM_CONNECTOR_NAME_PATTERN = /^[a-z0-9-]+$/
 
-export const toCustomConnectorSlug = (name: string): string =>
-  name
+export const toCustomConnectorName = (displayName: string): string =>
+  displayName
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-    .slice(0, CUSTOM_CONNECTOR_SLUG_MAX_LENGTH) || 'connector'
+    .slice(0, CUSTOM_CONNECTOR_NAME_MAX_LENGTH) || 'connector'
 
-export const isCustomConnectorSlug = (value: string): boolean =>
-  value.length <= CUSTOM_CONNECTOR_SLUG_MAX_LENGTH && CUSTOM_CONNECTOR_SLUG_PATTERN.test(value)
+export const isCustomConnectorName = (value: string): boolean =>
+  value.length <= CUSTOM_CONNECTOR_NAME_MAX_LENGTH && CUSTOM_CONNECTOR_NAME_PATTERN.test(value)
 
-export const customConnectorSkillName = (slug: string): string => `mcp-${slug}`
+export const customConnectorSkillName = (name: string): string => `mcp-${name}`
 
-export const customConnectorSlugFromSkillName = (name: string): string | undefined => {
+export const customConnectorNameFromSkillName = (name: string): string | undefined => {
   if (!name.startsWith('mcp-')) return undefined
-  const slug = name.slice('mcp-'.length)
-  return isCustomConnectorSlug(slug) ? slug : undefined
+  const connectorName = name.slice('mcp-'.length)
+  return isCustomConnectorName(connectorName) ? connectorName : undefined
 }
-
-export const customConnectorSlug = (server: { name: string; slug?: string }): string =>
-  server.slug && isCustomConnectorSlug(server.slug)
-    ? server.slug
-    : toCustomConnectorSlug(server.name)
-
-export const customConnectorAliases = (server: {
-  id?: string
-  name: string
-  slug?: string
-}): string[] => [
-  ...new Set([
-    customConnectorSlug(server),
-    server.name,
-    ...(server.id === undefined ? [] : [server.id])
-  ])
-]
-
-export const customConnectorAliasKey = (value: string): string => value.trim().toLowerCase()

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -830,7 +830,10 @@ export type SkillSource = 'featured' | 'imported' | 'personal'
 // Renderer-safe view of one bundled skill (no file contents).
 export type SkillView = {
   id: string
+  // Stable invocation name from SKILL.md.
   name: string
+  // Presentation label supplied by the catalog source, falling back to name.
+  displayName: string
   description: string
   source: SkillSource
   updatedAt: string
@@ -870,21 +873,19 @@ export type SkillReference = {
   dataBase64?: string
 }
 
-// Create a personal (user-authored) skill from the in-app editor. `slug` is the user-chosen Skill ID
-// (without the `personal-` prefix); when omitted, it is derived from the name.
+// Create a personal (user-authored) skill from the in-app editor. `name` is the immutable invocation
+// identity and the package directory name.
 export type CreateSkillRequest = {
   name: string
   description: string
   body: string
   metadata?: Record<string, string>
-  slug?: string
   references?: SkillReference[]
 }
 
 // Update an existing personal skill in place.
 export type UpdateSkillRequest = {
   id: string
-  name: string
   description: string
   body: string
   metadata?: Record<string, string>
@@ -1160,10 +1161,10 @@ export type CustomServerTransport = 'stdio' | 'streamable_http' | 'sse'
 // Renderer-safe view of one user-added custom MCP server (no secret env/header values).
 export type CustomServerView = {
   id: string
-  // Immutable agent-facing route used by host.mcp, Specialists, and generated MCP skills.
-  slug: string
-  // User-facing label; spaces and punctuation are allowed.
+  // Immutable agent-facing name used by host.mcp, Specialists, and generated MCP skills.
   name: string
+  // User-facing label; spaces, punctuation, and duplicates are allowed.
+  displayName: string
   description?: string
   transport: CustomServerTransport
   enabled: boolean
@@ -1201,7 +1202,7 @@ export type SetNcbiCredentialsRequest = { contactEmail?: string; apiKey?: string
 // Add a custom MCP server. stdio requires `command`; the remote transports require `url`.
 export type AddCustomServerRequest = {
   name: string
-  slug?: string
+  displayName: string
   description?: string
   transport: CustomServerTransport
   command?: string
@@ -1227,7 +1228,7 @@ export type ConnectorTemplateDefinition = {
   schemaVersion: 1
   kind: 'open-science.connector'
   name: string
-  slug: string
+  displayName: string
   description?: string
   transport: CustomServerTransport
   command?: string
@@ -1274,11 +1275,11 @@ export type SelectCustomServerTemplateRequest = {
 export type ExportCustomServerTemplateRequest = { id: string; expectedDigest: string }
 export type ExportCustomServerTemplateResult = { saved: boolean }
 
-// Edit an existing custom MCP server. The name is immutable (it is the server's identity — host.mcp
-// routing, skill-doc name, and per-tool policy keys all depend on it). Omitted env/headers keep the
-// stored values; providing them replaces the set.
+// Edit an existing custom MCP server. `name` is deliberately absent because it is immutable.
+// Omitted env/headers keep the stored values; providing them replaces the set.
 export type UpdateCustomServerRequest = {
   id: string
+  displayName?: string
   description?: string
   transport: CustomServerTransport
   command?: string

--- a/src/shared/specialist.test.ts
+++ b/src/shared/specialist.test.ts
@@ -68,14 +68,9 @@ describe('validateCreateSpecialistInput', () => {
     expect(errors.some((e) => e.field === 'name')).toBe(true)
   })
 
-  it('rejects invalid public names even when displayName is omitted', () => {
+  it('rejects invalid public names on create', () => {
     expect(
       validateCreateSpecialistInput({ name: '<bad>' }, []).map((error) => error.message)
-    ).toContain('Name may only contain letters, digits, spaces, hyphens, and underscores.')
-    expect(
-      validateUpdateSpecialistInput({ id: 'specialist-1', revision: 1, name: '<bad>' }, []).map(
-        (error) => error.message
-      )
     ).toContain('Name may only contain letters, digits, spaces, hyphens, and underscores.')
   })
 
@@ -87,14 +82,11 @@ describe('validateCreateSpecialistInput', () => {
     ).toContain('Display name is required.')
 
     expect(
-      validateUpdateSpecialistInput(
-        {
-          id: 'specialist-1',
-          revision: 1,
-          displayName: 'x'.repeat(SPECIALIST_DISPLAY_NAME_MAX_LENGTH + 1)
-        },
-        []
-      ).map((error) => error.message)
+      validateUpdateSpecialistInput({
+        id: 'specialist-1',
+        revision: 1,
+        displayName: 'x'.repeat(SPECIALIST_DISPLAY_NAME_MAX_LENGTH + 1)
+      }).map((error) => error.message)
     ).toContain(`Display name must be ${SPECIALIST_DISPLAY_NAME_MAX_LENGTH} characters or fewer.`)
   })
 })
@@ -127,10 +119,11 @@ describe('description validation in create/update inputs', () => {
   })
 
   it('surfaces a description error on update when too long', () => {
-    const errors = validateUpdateSpecialistInput(
-      { id: 'x', revision: 1, description: 'a'.repeat(SPECIALIST_DESCRIPTION_MAX_LENGTH + 1) },
-      []
-    )
+    const errors = validateUpdateSpecialistInput({
+      id: 'x',
+      revision: 1,
+      description: 'a'.repeat(SPECIALIST_DESCRIPTION_MAX_LENGTH + 1)
+    })
     expect(errors.some((e) => e.field === 'description')).toBe(true)
   })
 })
@@ -145,10 +138,11 @@ describe('system prompt validation in create/update inputs', () => {
       )
     ).toBe(true)
     expect(
-      validateUpdateSpecialistInput(
-        { id: 'specialist-1', revision: 1, systemPrompt: oversized },
-        []
-      ).some((error) => error.field === 'systemPrompt')
+      validateUpdateSpecialistInput({
+        id: 'specialist-1',
+        revision: 1,
+        systemPrompt: oversized
+      }).some((error) => error.field === 'systemPrompt')
     ).toBe(true)
   })
 })
@@ -156,13 +150,14 @@ describe('system prompt validation in create/update inputs', () => {
 describe('package version validation in update inputs', () => {
   it('accepts SemVer and rejects a non-SemVer package version', () => {
     expect(
-      validateUpdateSpecialistInput(
-        { id: 'specialist-1', revision: 1, packageVersion: '2.0.0-beta.1+build.7' },
-        []
-      )
+      validateUpdateSpecialistInput({
+        id: 'specialist-1',
+        revision: 1,
+        packageVersion: '2.0.0-beta.1+build.7'
+      })
     ).toEqual([])
     expect(
-      validateUpdateSpecialistInput({ id: 'specialist-1', revision: 1, packageVersion: 'next' }, [])
+      validateUpdateSpecialistInput({ id: 'specialist-1', revision: 1, packageVersion: 'next' })
     ).toEqual([{ field: 'packageVersion', message: 'Package version must be valid SemVer.' }])
   })
 })

--- a/src/shared/specialist.ts
+++ b/src/shared/specialist.ts
@@ -73,7 +73,7 @@ export type CompletionHandoffCommand = { id: string; sessionId: string }
 // source of truth for approved SDK handoffs.
 export type PendingSwitchBroadcast = {
   sessionId: string
-  // Target Specialist public name, or null to revert to Main Agent. Display-only; never a secret.
+  // Target Specialist immutable public name, or null to revert to Main Agent. Never a secret.
   targetName: string | null
 }
 
@@ -271,7 +271,6 @@ export type UpdateSpecialistInput = {
   id: string
   revision: number
   packageVersion?: string
-  name?: string
   displayName?: string
   description?: string
   systemPrompt?: string
@@ -426,12 +425,9 @@ export const validateCreateSpecialistInput = (
 }
 
 // Validate the provided (partial) fields for an UpdateSpecialistInput.
-// Only fields that are present are validated. Name uniqueness skips the
-// specialist's own id (`input.id`) so self-rename is allowed.
+// Only fields that are present are validated. The stable name is not updateable.
 export const validateUpdateSpecialistInput = (
-  input: UpdateSpecialistInput,
-  existingNames: string[],
-  existingIds?: Map<string, string>
+  input: UpdateSpecialistInput
 ): SpecialistFieldError[] => {
   const errors: SpecialistFieldError[] = []
 
@@ -439,15 +435,6 @@ export const validateUpdateSpecialistInput = (
     const packageVersionError = validateSpecialistPackageVersion(input.packageVersion)
     if (packageVersionError) {
       errors.push({ field: 'packageVersion', message: packageVersionError })
-    }
-  }
-
-  if (input.name !== undefined) {
-    const nameError = validateSpecialistName(input.name, existingNames, input.id, existingIds)
-    if (nameError) errors.push({ field: 'name', message: nameError })
-    else {
-      const publicNameError = validateSpecialistPublicName(input.name)
-      if (publicNameError) errors.push({ field: 'name', message: publicNameError })
     }
   }
 


### PR DESCRIPTION
## Problem

Connector display labels were also accepted as runtime identities, while Connector settings and templates mixed mutable presentation text with the value used by `host.mcp`, generated Skills, Specialist capability references, and policy routing. Skill and Specialist editing exposed similar ambiguity, and the public `host.agents` JavaScript surface used snake_case methods and write fields.

## Proposed change

- Give custom Connectors an immutable lowercase-hyphenated `name` and an editable `displayName`; route only by `name` and keep the internal UUID for Settings/OAuth and durable permission grants.
- Update Connector template schema v1 in place to require `name` and `displayName`; do not retain the former `slug` shape or display-name/UUID invocation aliases.
- Keep Connector context generation distinct from ordinary Skill loading: live discovery generates `mcp-<name>/SKILL.md`, whose frontmatter identity and `host.mcp(name, ...)` examples use immutable `name`; `displayName` is limited to generated prose and explicit connector listings.
- Preserve both host-managed OAuth recovery and connector-managed login-tool guidance when generated Connector Skill docs are refreshed, including the latest targeted-refresh behavior from `main`.
- Tolerate optional Skill `displayName` from external `SKILL.md` files while falling back to that file's immutable `name`, without adding a separate display-name store or editor field. Personal Skill creation accepts only the standard immutable `name`; the same value is used in `SKILL.md`, as the package directory, and in the `personal-<name>` catalog ID, with no separate `slug`, normalization, or automatic numeric suffix. Built-in Skills omit the non-standard field and preserve their manifest `name` as presentation metadata; both ordinary Skill ZIP exports and Skills embedded in Specialist ZIP exports strip `displayName`.
- Make Specialist `name` immutable after creation while keeping `displayName` editable; leave Specialist package schema v1 unchanged.
- Use camelCase for public `host.agents` JavaScript methods and write fields while translating to the private snake_case RPC transport internally.
- Update Settings, generated Connector Skills, runtime routing, Specialist capability selection, documentation, and tests to use the same identity model.

## Scope and non-goals

- This intentionally makes no compatibility promise for custom Connector invocation by prior display labels or UUIDs.
- Connector template v1 is changed directly; old `slug` templates are rejected.
- Stored pre-field-shape Connector settings are canonicalized on read so current records remain loadable, but no runtime aliases are retained. Ambiguous allow-policy migration fails closed.
- Specialist ZIP/package v1 field shape is unchanged, preserving distributed package compatibility.
- Personal Skill names must be lowercase hyphenated standard names and are rejected, not rewritten, when invalid or duplicated.
- External Skill presentation defaults to `SKILL.md.name`; bundled Skill presentation uses the built-in manifest `name`. External `displayName` metadata may be read for compatibility but is not emitted by built-in or exported Skills.

## Context and identity invariants

- Connector: `name` is the only runtime invocation identity; `displayName` can change and may enter generated prose without changing `mcp-<name>` or `host.mcp(name, ...)`.
- Skill: `SKILL.md.name` is the invocation identity and the default presentation label for ordinary Skills. Personal creation uses this same immutable value for package storage and catalog identity. Bundled Skills retain the human-readable manifest `name` for presentation. Built-in and app-exported standard Skill files contain no `displayName` field.
- Specialist: package/service `name` is the invocation identity; `displayName` is editable presentation metadata.
- JavaScript APIs use camelCase even where the private RPC transport remains snake_case.

## Acceptance criteria and validation

The final rebased commit is based on `aa9f977b` (`origin/main` at validation time). The full suite ran before the latest main rebase; after resolving the `repl_loop.js` overlap with the new delegation workflow, Node/Web typechecks and 177 focused tests passed again.

- Full portable suite (run outside the sandbox so loopback MCP tests can bind): `npm test` -> 945 files passed, 15 skipped; 13,671 tests passed, 193 skipped.
- Node contracts and runtime consumers: `npm run typecheck:node` -> passed.
- Renderer contracts and Settings UI: `npm run typecheck:web` -> passed.
- Connector identity, generated Skill-doc refresh, authentication guidance, Settings, and bundled Skill metadata focused coverage -> 9 files, 184 tests passed; MCP client manager -> 23 tests passed.
- Built-in Skill frontmatter plus ordinary and Specialist Skill export normalization -> 6 files, 67 tests passed.
- Immutable edit-field presentation, hidden Skill ID, and Connector policy identity regression coverage -> 3 files, 64 tests passed.
- Personal immutable-name creation, Host Skill publishing, bundled manifest presentation, and Settings projections -> 8 files, 195 tests passed.
- Formatting/whitespace: Prettier on changed files and `git diff --check` -> passed.
- Lint: `npm run lint` -> passed with 15 pre-existing warnings and no errors.

## Review focus

- Confirm that custom Connector runtime resolution has no `displayName`/UUID alias path and that permission grants remain UUID-keyed.
- Confirm that changing `displayName` regenerates Connector prose but leaves generated Skill identity and every `host.mcp` example unchanged.
- Confirm that Connector auth-recovery guidance survives full and targeted Skill-doc refreshes.
- Confirm that Connector template v1 intentionally rejects `slug` and exports `name` plus `displayName` without secrets.
- Confirm that no built-in `SKILL.md`, ordinary Skill export, or Specialist-embedded Skill export contains `displayName`.
- Confirm that external optional Skill display metadata is read from `SKILL.md`, not the external bundle manifest, and falls back to `name`.
- Confirm that bundled Skills use manifest `name` for presentation and SKILL.md `name` for invocation, including presentation-label sorting.
- Confirm that Personal Skill creation and publishing have no `slug` parameter or alias: the validated immutable `name` is used unchanged for frontmatter, package directory, and `personal-<name>` ID.
- Confirm that Skill and Specialist invocation names cannot be changed through editor, service, repository, or `host.agents.update` paths.
- Confirm that Connector ID renders as disabled in edit mode, while Skill ID is not rendered and the immutable Skill Name remains disabled when editing.
- Confirm that stored Connector policy is never canonicalized through a custom Connector UUID or `displayName`; runtime policy matching uses immutable `name` only.
- Review the public camelCase/private snake_case translation boundary in `resources/notebook/repl_loop.js`.

Independent maintainer review is still required before treating this cross-module change as fully verified.
