### PR TITLE
fix(reviewer): hide auditor prompts from local transcript

### DIFF
--- a/src/main/reviewer/correction.test.ts
+++ b/src/main/reviewer/correction.test.ts
@@ -319,12 +319,13 @@ describe('single-round auditor correction', () => {
     expect(correctionSendPrompt).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'main-session-1',
+        suppressUserMessage: true,
         provenanceContext: expect.objectContaining({
           rootFrameId: 'root-frame-pending-session-1',
           agentFrameId: 'root-frame-pending-session-1',
           messageBranchId: 'message-branch-pending-session-1',
           runtimeSegmentId: 'runtime-segment-pending-session-1',
-          promptMessageId: expect.stringMatching(/^prompt-/u)
+          promptMessageId: 'msg-1'
         })
       })
     )

--- a/src/main/reviewer/correction.ts
+++ b/src/main/reviewer/correction.ts
@@ -79,8 +79,14 @@ export const injectAuditorMessage = async (options: {
 
   try {
     // Inject through the main-session sendPrompt path (design.md cross-cutting requirement).
-    // This is a normal prompt turn that the user sees in the conversation.
-    await acpRuntime.sendPrompt({ sessionId: mainSessionId, text: message, provenanceContext })
+    // The provider retains the ordinary save-as-user prompt semantics, while Open Science keeps
+    // the application-owned Auditor instruction out of the visible and durable local transcript.
+    await acpRuntime.sendPrompt({
+      sessionId: mainSessionId,
+      text: message,
+      provenanceContext,
+      suppressUserMessage: true
+    })
     log.info('[Auditor] correction turn complete', { mainSessionId })
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error)

--- a/src/main/reviewer/reviewer-fix-loop-owner.test.ts
+++ b/src/main/reviewer/reviewer-fix-loop-owner.test.ts
@@ -10,7 +10,15 @@ import type { ReviewRepository } from './repository'
 
 const mocks = vi.hoisted(() => ({
   injectAuditorMessage: vi.fn(),
-  runReviewAssessment: vi.fn()
+  runReviewAssessment: vi.fn(),
+  getActiveConversationContext: vi.fn(() => ({})),
+  resolveActiveConversationMessages: vi.fn(() => [
+    {
+      id: 'originating-user',
+      role: 'user',
+      status: 'complete'
+    }
+  ])
 }))
 
 vi.mock('./correction', () => ({ injectAuditorMessage: mocks.injectAuditorMessage }))
@@ -21,7 +29,8 @@ vi.mock('../../shared/session-persistence', () => ({
   materializeSessionConversationGraph: () => ({ conversationGraph: {} })
 }))
 vi.mock('../../shared/conversation-graph', () => ({
-  getActiveConversationContext: () => ({})
+  getActiveConversationContext: mocks.getActiveConversationContext,
+  resolveActiveConversationMessages: mocks.resolveActiveConversationMessages
 }))
 
 const { runReviewerFixLoop } = await import('./reviewer-fix-loop-owner')
@@ -109,6 +118,14 @@ describe('reviewer fix-loop owner', () => {
   beforeEach(() => {
     mocks.injectAuditorMessage.mockReset().mockResolvedValue(undefined)
     mocks.runReviewAssessment.mockReset()
+    mocks.getActiveConversationContext.mockReset().mockReturnValue({})
+    mocks.resolveActiveConversationMessages.mockReset().mockReturnValue([
+      {
+        id: 'originating-user',
+        role: 'user',
+        status: 'complete'
+      }
+    ])
   })
 
   it('reviews the exact durable snapshot that proves the correction completed', async () => {
@@ -144,6 +161,7 @@ describe('reviewer fix-loop owner', () => {
       })
     )
     expect(getSession).toHaveBeenCalledTimes(2)
+    expect(mocks.getActiveConversationContext).toHaveBeenCalledWith({}, 'originating-user')
     expect(repository.commitFindingDispositions).not.toHaveBeenCalled()
   })
 

--- a/src/main/reviewer/reviewer-fix-loop-owner.ts
+++ b/src/main/reviewer/reviewer-fix-loop-owner.ts
@@ -1,14 +1,15 @@
 // Owns the bounded Reviewer correction loop and its durable re-review lifecycle.
 
-import { randomUUID } from 'node:crypto'
-
 import { createLogger } from '../logger'
 import type { ReviewCheck, ReviewWithChecks } from '../../shared/reviewer'
 import {
   materializeSessionConversationGraph,
   type PersistedChatSession
 } from '../../shared/session-persistence'
-import { getActiveConversationContext } from '../../shared/conversation-graph'
+import {
+  getActiveConversationContext,
+  resolveActiveConversationMessages
+} from '../../shared/conversation-graph'
 import type { ReviewerAcpRuntime } from './acp-runtime'
 import { injectAuditorMessage } from './correction'
 import type { ArtifactVersionContentResolver } from './host-sdk'
@@ -192,9 +193,19 @@ export const runReviewerFixLoop = async (options: ReviewerFixLoopOptions): Promi
     // Step B: inject [Auditor] with the currently-open warn/fail checks.
     let correctionFailed = false
     try {
+      const conversationGraph =
+        materializeSessionConversationGraph(sessionBefore).conversationGraph!
+      const originatingPrompt = resolveActiveConversationMessages(conversationGraph)
+        .toReversed()
+        .find((message) => message.role === 'user' && message.status === 'complete')
+      if (!originatingPrompt) {
+        throw new Error(
+          'The active conversation has no complete user prompt for correction provenance.'
+        )
+      }
       const provenanceContext = getActiveConversationContext(
-        materializeSessionConversationGraph(sessionBefore).conversationGraph!,
-        `prompt-${randomUUID()}`
+        conversationGraph,
+        originatingPrompt.id
       )
       await injectAuditorMessage({
         sessionId,


### PR DESCRIPTION
## Problem

Reviewer warn/fail findings were sent through the normal prompt path and projected into the Open Science transcript as user-authored messages before the agent corrected them.

## Proposed change

- Keep the existing `sendPrompt` entry and its admission, cancellation, and lifecycle behavior.
- Set the existing application-owned `suppressUserMessage` flag for Auditor correction turns so Open Science neither displays nor durably stores a local user message.
- Preserve the provider's ordinary save-as-user prompt semantics, matching the supplied raw session example without introducing a new ACP capability or provider protocol.
- Bind correction tool and artifact provenance to the latest complete user prompt on the active conversation branch instead of a synthetic message ID.

## Scope and non-goals

- Four reviewer files changed.
- No new `internal-reviewer` protocol, capability, request field, or managed Codex patch.
- No Prisma schema, table, migration, renderer, or side-chat changes.
- Reviewer cards, correction behavior, and the re-review loop remain unchanged.

## Acceptance criteria and validation

Checks ran after the last material code edit and rebase onto the latest `main`.

- Reviewer ownership tests -> `npm test -- src/main/reviewer` -> 23 files, 252 tests passed.
- Declared reviewer consumer tests -> direct Vitest invocation of the 12 consumer files from `reviewer_orchestrator` -> 12 files, 268 tests passed.
- Focused visibility, provenance, lifecycle, and prior CI regressions -> 5 files, 41 tests passed.
- Changed-file ESLint and Prettier -> passed.
- Repository lint -> passed with unrelated existing warnings.
- Full `npm test` completed with 58 failures outside this four-file diff, primarily Windows temp-directory/symlink restrictions and an existing WorkspacePage line-count gate.
- Local Node typecheck is blocked because the shared dependency installation predates latest `main` and lacks `sharp`; exact-head CI installs the current lockfile and remains authoritative.

## Review focus

- Auditor prompts remain invisible and absent from the local durable transcript while still reaching the provider through `sendPrompt`.
- Correction activities and artifacts inherit the originating durable user prompt's active-branch provenance.
