### PR TITLE
fix(ci): record granted-local-roots migration in ledger smoke

### DIFF
--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -12,6 +12,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0002_project_agent_context',
     checksum: 'f3b29cf4543d1739a0cd211ddea172dcfd18aa9d7c8f94d520913ab88cb977c6'
+  },
+  {
+    id: '0003_granted_local_roots',
+    checksum: '3bc5e32cdf7f793771d22fe3027f082c1ba8e3a5e4decab37bd0c92c7928bfc7'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -24,6 +24,10 @@ describe('packaged database migration ledger smoke', () => {
         {
           id: '0002_project_agent_context',
           checksum: 'f3b29cf4543d1739a0cd211ddea172dcfd18aa9d7c8f94d520913ab88cb977c6'
+        },
+        {
+          id: '0003_granted_local_roots',
+          checksum: '3bc5e32cdf7f793771d22fe3027f082c1ba8e3a5e4decab37bd0c92c7928bfc7'
         }
       ])
     ).not.toThrow()


### PR DESCRIPTION
## Problem

The v0.13.1 release workflow failed on the Linux and Windows build jobs at the "Enforce platform certification" step:

```
Error: Packaged application did not record the expected application database migration ledger.
```

Migration `0003_granted_local_roots` (added in #798) is applied by the packaged app, but `scripts/database-migration-ledger-smoke.mjs` still pins `EXPECTED_MIGRATION_LEDGER` to only `0001` and `0002`. The packaged app now records three migrations; the smoke asserts two and fails.

## Proposed change

Add the `0003_granted_local_roots` entry (id + checksum) to `EXPECTED_MIGRATION_LEDGER` in the smoke script and update the corresponding unit test assertion.

The checksum is computed by the same `checksumMigrationPayload` function the migration service uses at runtime — verified locally against the existing `0001` and `0002` checksums.

## Scope and non-goals

- **In scope:** smoke-test ledger and its unit test only.
- **Non-goals:** no schema, migration, runtime, or packaging changes.

## Acceptance criteria and validation

- `behavior -> ledger smoke matches 3-migration reality -> npm test -> passed` (4/4 tests, run after last edit)
- `behavior -> checksum for 0003 matches runtime computation -> manual verification against checksumMigrationPayload -> match`

## Historical compatibility

No historical data compatibility concern. This only updates a CI certification assertion — it does not change any migration, schema, or persisted format.

## Review focus

Confirm the `0003` checksum value matches the runtime computation. The migration source is immutable (never changes after release), so the checksum is stable.
