### PR TITLE
refactor(host-js)!: use camelCase for REPL calls

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -1082,21 +1082,39 @@ const normalizedHostLlmRequest = (value) => {
   }
 }
 
+const remappedHostObject = (value, label, keyMap) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`)
+  }
+  const keys = Reflect.ownKeys(value)
+  const unknown = keys.find(
+    (key) => typeof key !== 'string' || !Object.prototype.hasOwnProperty.call(keyMap, key)
+  )
+  if (unknown !== undefined) throw new TypeError(`${label} unknown option: ${String(unknown)}`)
+  return Object.fromEntries(keys.map((key) => [keyMap[key], value[key]]))
+}
+
 const normalizedHostLlmOptions = (value) => {
   if (value === undefined) return undefined
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('host.llm batch options only accept maxConcurrency.')
+  }
+  let keys
+  try {
+    keys = Reflect.ownKeys(value)
+  } catch {
+    throw new TypeError('host.llm batch options only accept maxConcurrency.')
+  }
+  const unknown = keys.find((key) => key !== 'maxConcurrency')
+  if (unknown !== undefined) {
+    throw new TypeError(`host.llm batch options unknown option: ${String(unknown)}`)
+  }
+  if (keys.length === 0) return {}
   let concurrency
   try {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      throw new TypeError('host.llm batch options only accept max_concurrency.')
-    }
-    const keys = Reflect.ownKeys(value)
-    if (keys.some((key) => key !== 'max_concurrency')) {
-      throw new TypeError('host.llm batch options only accept max_concurrency.')
-    }
-    if (keys.length === 0) return {}
-    concurrency = value.max_concurrency
+    concurrency = value.maxConcurrency
   } catch {
-    throw new TypeError('host.llm batch options only accept max_concurrency.')
+    throw new TypeError('host.llm batch options only accept maxConcurrency.')
   }
   if (
     typeof concurrency !== 'number' ||
@@ -1104,7 +1122,7 @@ const normalizedHostLlmOptions = (value) => {
     concurrency < 1 ||
     concurrency > 4
   ) {
-    throw new TypeError('host.llm max_concurrency must be an integer from 1 through 4.')
+    throw new TypeError('host.llm maxConcurrency must be an integer from 1 through 4.')
   }
   return { max_concurrency: concurrency }
 }
@@ -1162,7 +1180,7 @@ async function hostLlm(request, options = undefined) {
 async function artifactsRpc(op, params) {
   if (!RPC_ENDPOINT)
     throw new Error(
-      `host.${op === 'list' ? 'artifacts' : 'artifact_path'} is unavailable: RPC endpoint not set`
+      `host.${op === 'list' ? 'artifacts' : 'artifactPath'} is unavailable: RPC endpoint not set`
     )
   const res = await capturedRpcFetch(RPC_ENDPOINT, {
     method: 'POST',
@@ -1172,7 +1190,7 @@ async function artifactsRpc(op, params) {
   const body = await res.json().catch(() => ({}))
   if (!res.ok || body.error) {
     throw new Error(
-      `host.${op === 'list' ? 'artifacts' : 'artifact_path'}: ${body.error || 'HTTP ' + res.status}`
+      `host.${op === 'list' ? 'artifacts' : 'artifactPath'}: ${body.error || 'HTTP ' + res.status}`
     )
   }
   return body.result
@@ -1189,6 +1207,18 @@ const HOST_ARTIFACT_REQUIRED_KEYS = [
   'latest_version_created_at'
 ]
 const HOST_ARTIFACT_OPTIONAL_KEYS = ['content_type', 'checksum']
+const HOST_ARTIFACT_INPUT_KEYS = {
+  versionId: 'version_id',
+  sessionId: 'session_id',
+  filename: 'filename',
+  exact: 'exact',
+  search: 'search',
+  contentType: 'content_type',
+  after: 'after',
+  before: 'before',
+  cursor: 'cursor',
+  limit: 'limit'
+}
 
 const validatedHostArtifact = (value) => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -1226,7 +1256,9 @@ const validatedHostArtifact = (value) => {
 
 async function hostArtifacts(options = {}) {
   if (arguments.length > 1) throw new TypeError('host.artifacts accepts at most one options object')
-  const result = await artifactsRpc('list', { options })
+  const result = await artifactsRpc('list', {
+    options: remappedHostObject(options, 'host.artifacts options', HOST_ARTIFACT_INPUT_KEYS)
+  })
   if (
     !result ||
     typeof result !== 'object' ||
@@ -1255,10 +1287,10 @@ async function hostArtifacts(options = {}) {
 }
 
 async function hostArtifactPath(versionId) {
-  if (arguments.length !== 1) throw new TypeError('host.artifact_path accepts one version_id')
+  if (arguments.length !== 1) throw new TypeError('host.artifactPath accepts one versionId')
   const result = await artifactsRpc('path', { version_id: versionId })
   if (typeof result !== 'string' || !path.isAbsolute(result)) {
-    throw new Error('host.artifact_path returned an invalid path')
+    throw new Error('host.artifactPath returned an invalid path')
   }
   return result
 }
@@ -2148,13 +2180,22 @@ const validatedHostLineageVersion = (value) => {
 
 async function hostLineageGraph(versionId, options = {}) {
   if (arguments.length < 1 || arguments.length > 2) {
-    throw new TypeError('host.lineage.graph accepts version_id and at most one options object')
+    throw new TypeError('host.lineage.graph accepts versionId and at most one options object')
   }
-  return validatedHostLineageGraph(await lineageRpc('graph', { version_id: versionId, options }))
+  return validatedHostLineageGraph(
+    await lineageRpc('graph', {
+      version_id: versionId,
+      options: remappedHostObject(options, 'host.lineage.graph options', {
+        direction: 'direction',
+        maxDepth: 'max_depth',
+        maxNodes: 'max_nodes'
+      })
+    })
+  )
 }
 
 async function hostLineageGet(versionId) {
-  if (arguments.length !== 1) throw new TypeError('host.lineage.get accepts one version_id')
+  if (arguments.length !== 1) throw new TypeError('host.lineage.get accepts one versionId')
   return validatedHostLineageVersion(await lineageRpc('get', { version_id: versionId }))
 }
 
@@ -2163,7 +2204,19 @@ const hostLineage = Object.freeze({ graph: hostLineageGraph, get: hostLineageGet
 async function hostFramesList(options = {}) {
   if (arguments.length > 1)
     throw new TypeError('host.frames.list accepts at most one options object')
-  const result = await framesRpc('list', { options })
+  const result = await framesRpc('list', {
+    options: remappedHostObject(options, 'host.frames.list options', {
+      sessionId: 'session_id',
+      rootsOnly: 'roots_only',
+      kind: 'kind',
+      archived: 'archived',
+      search: 'search',
+      after: 'after',
+      before: 'before',
+      limit: 'limit',
+      cursor: 'cursor'
+    })
+  })
   const required = ['project_id', 'frames', 'total_count']
   const optional = ['next_cursor']
   if (
@@ -2186,9 +2239,17 @@ async function hostFramesList(options = {}) {
 
 async function hostFramesGet(frameId, options = {}) {
   if (arguments.length < 1 || arguments.length > 2) {
-    throw new TypeError('host.frames.get accepts frame_id and at most one options object')
+    throw new TypeError('host.frames.get accepts frameId and at most one options object')
   }
-  const result = await framesRpc('get', { frame_id: frameId, options })
+  const result = await framesRpc('get', {
+    frame_id: frameId,
+    options: remappedHostObject(options, 'host.frames.get options', {
+      sessionId: 'session_id',
+      branchId: 'branch_id',
+      before: 'before',
+      limit: 'limit'
+    })
+  })
   const keys = ['project_id', 'session', 'frame', 'branch', 'transcript', 'runtime_segments']
   if (
     !exactObject(result, keys) ||
@@ -2479,20 +2540,6 @@ async function delegatedMessageRpc(op, params) {
 // post-write camelCase Profile read-back and never echo requested input. switch/delete are the
 // privileged surface (issue 04/05): authorized this milestone by the /customize Skill's chat-text
 // confirmation + the pass-through SDK approval gateway (design.md §7/§14), not the standard card.
-function agentsWriteParams(value) {
-  const names = {
-    displayName: 'display_name',
-    systemPrompt: 'system_prompt',
-    iconKey: 'icon_key',
-    colorKey: 'color_key',
-    skillNames: 'skill_names',
-    connectorNames: 'connector_names'
-  }
-  return Object.fromEntries(
-    Object.entries(value || {}).map(([key, entry]) => [names[key] || key, entry])
-  )
-}
-
 const hostAgents = {
   async list() {
     return agentsRpc('list')
@@ -2507,10 +2554,38 @@ const hostAgents = {
     return agentsRpc('list_connectors', nameOrId !== undefined ? { name_or_id: nameOrId } : {})
   },
   async create(input) {
-    return agentsRpc('create', agentsWriteParams(input))
+    return agentsRpc(
+      'create',
+      remappedHostObject(input || {}, 'host.agents.create input', {
+        name: 'name',
+        displayName: 'display_name',
+        description: 'description',
+        systemPrompt: 'system_prompt',
+        iconKey: 'icon_key',
+        colorKey: 'color_key',
+        enabled: 'enabled',
+        unrestricted: 'unrestricted',
+        skillNames: 'skill_names',
+        connectorNames: 'connector_names'
+      })
+    )
   },
   async update(name, patch) {
-    return agentsRpc('update', { name, patch: agentsWriteParams(patch) })
+    return agentsRpc('update', {
+      name,
+      patch: remappedHostObject(patch || {}, 'host.agents.update patch', {
+        displayName: 'display_name',
+        revision: 'revision',
+        description: 'description',
+        systemPrompt: 'system_prompt',
+        iconKey: 'icon_key',
+        colorKey: 'color_key',
+        enabled: 'enabled',
+        unrestricted: 'unrestricted',
+        skillNames: 'skill_names',
+        connectorNames: 'connector_names'
+      })
+    })
   },
   async attachSkill(name, skillRef, options) {
     return agentsRpc('attach_skill', { name, skill_ref: skillRef, ...(options || {}) })
@@ -2572,12 +2647,12 @@ const hostSkills = {
   async validate(name) {
     return skillsRpc('validate', { name })
   },
-  async edit(name, path, content, old_string = undefined) {
+  async edit(name, path, content, oldString = undefined) {
     return skillsRpc('edit', {
       name,
       path,
       content,
-      ...(old_string !== undefined ? { old_string } : {})
+      ...(oldString !== undefined ? { old_string: oldString } : {})
     })
   },
   async publish(name, overwrite = false) {
@@ -2607,8 +2682,8 @@ function computeError(raw) {
   return new Error(String(raw))
 }
 
-// host.compute namespace mirroring the spec's Python API surface (kept snake_case on purpose — a JS
-// camelCase pass is a deferred one-shot rename once the whole compute feature lands; see roadmap §8).
+// host.compute namespace. Public methods and input keys are camelCase; the adapter immediately maps
+// them to the existing snake_case computeCall RPC contract.
 const hostCompute = {
   // Enumerate registered compute hosts for discovery. No approval, no session context.
   async list() {
@@ -2617,52 +2692,82 @@ const hostCompute = {
 
   // Returns session-enabled compute hosts (≠ list() which returns all registered hosts).
   // Uses COMPUTE_SESSION_ID from spawn env so the registry lookup is always session-scoped.
-  async list_compute() {
+  async listCompute() {
     return computeRpc({ op: 'list_compute', session_id: COMPUTE_SESSION_ID })
   },
-  // Bind a thin handle to one provider (no network call). call_command runs one short remote command;
-  // login_shell defaults to true (runs login profiles, then attempts a readable ~/.bashrc, before the
+  // Bind a thin handle to one provider (no network call). callCommand runs one short remote command;
+  // loginShell defaults to true (runs login profiles, then attempts a readable ~/.bashrc, before the
   // command). A .bashrc can deliberately return early for non-interactive shells. false performs no
   // shell initialization.
-  // timeout_seconds
+  // timeoutSeconds
   // is optional (the service applies its own default when omitted). Session/project context is threaded
   // from the spawn env so the approval broker can remember a grant for this conversation/project.
   //
-  // submit_job: non-blocking job submission — returns {job_id, provider_id, status:'submitted',
+  // submitJob: non-blocking job submission — returns {job_id, provider_id, status:'submitted',
   // remote_workdir} immediately, before any SSH. Background dispatch runs the job detached.
-  // attach_job: returns a handle with .status() to read job state from DB without SSH.
+  // attachJob: returns a handle with .status() to read job state from DB without SSH.
   create(providerId) {
     return {
       provider_id: providerId,
-      async call_command(cmd, intent, options = {}) {
+      async callCommand(cmd, intent, options = {}) {
+        const normalized = remappedHostObject(options, 'host.compute.callCommand options', {
+          loginShell: 'login_shell',
+          timeoutSeconds: 'timeout_seconds'
+        })
         return computeRpc({
           op: 'call_command',
           provider_id: providerId,
           cmd,
           intent,
-          login_shell: options.login_shell !== undefined ? options.login_shell : true,
-          timeout_seconds: options.timeout_seconds,
+          login_shell: normalized.login_shell !== undefined ? normalized.login_shell : true,
+          timeout_seconds: normalized.timeout_seconds,
           session_id: COMPUTE_SESSION_ID,
           project_id: COMPUTE_PROJECT_NAME
         })
       },
 
       // Non-blocking job submission. Returns immediately with job_id + remote_workdir.
-      // options: { environment?, resources?, inputs?, outputs?, timeout_seconds?, harvest? }
+      // options: { environment?, resources?, inputs?, outputs?, timeoutSeconds?, harvest? }
       // Session/project context is always threaded from spawn env for grant-scope memory.
       // workspace_cwd is captured at spawn time so the main process can resolve workspace paths.
-      async submit_job(intent, command, options = {}) {
+      async submitJob(intent, command, options = {}) {
+        const normalized = remappedHostObject(options, 'host.compute.submitJob options', {
+          environment: 'environment',
+          resources: 'resources',
+          inputs: 'inputs',
+          outputs: 'outputs',
+          timeoutSeconds: 'timeout_seconds',
+          harvest: 'harvest'
+        })
+        if (normalized.inputs !== undefined && !Array.isArray(normalized.inputs)) {
+          throw new TypeError('host.compute.submitJob inputs must be an array.')
+        }
+        const inputs = normalized.inputs?.map((input) =>
+          remappedHostObject(input, 'host.compute.submitJob input', {
+            src: 'src',
+            dstFilename: 'dst_filename',
+            remotePath: 'remote_path'
+          })
+        )
+        const harvest =
+          normalized.harvest === undefined
+            ? undefined
+            : remappedHostObject(normalized.harvest, 'host.compute.submitJob harvest', {
+                exclude: 'exclude',
+                maxFileMb: 'max_file_mb',
+                maxTotalMb: 'max_total_mb'
+              })
         return computeRpc({
           op: 'submit_job',
           provider_id: providerId,
           intent,
           command,
-          environment: options.environment,
-          resources: options.resources,
-          inputs: options.inputs,
-          outputs: options.outputs,
-          timeout_seconds: options.timeout_seconds,
-          harvest: options.harvest,
+          environment: normalized.environment,
+          resources: normalized.resources,
+          inputs,
+          outputs: normalized.outputs,
+          timeout_seconds: normalized.timeout_seconds,
+          harvest,
           session_id: COMPUTE_SESSION_ID,
           project_id: COMPUTE_PROJECT_NAME,
           workspace_cwd: process.cwd()
@@ -2672,7 +2777,7 @@ const hostCompute = {
       // Attaches to an existing job by job_id. .status() reads from DB only (no SSH).
       // .result() returns the full JobResult (spec §11.4): scans the local harvest directory,
       // returns workspace-relative file paths, never triggers harvest or SSH (design §9).
-      attach_job(jobId) {
+      attachJob(jobId) {
         return {
           job_id: jobId,
           async status() {
@@ -2687,9 +2792,9 @@ const hostCompute = {
       // Set session-level concurrency limit (Phase 3c). Limits the number of non-terminal jobs
       // that can run simultaneously across all providers in this session. Jobs exceeding the limit
       // enter 'queued' state and auto-dispatch when slots free up.
-      async set_concurrency_limit(k) {
+      async setConcurrencyLimit(k) {
         if (typeof k !== 'number' || k <= 0 || k > 500 || !Number.isInteger(k)) {
-          throw new Error('set_concurrency_limit: k must be a positive integer between 1 and 500')
+          throw new Error('setConcurrencyLimit: k must be a positive integer between 1 and 500')
         }
         return computeRpc({
           op: 'set_concurrency_limit',
@@ -2710,15 +2815,20 @@ const hostCompute = {
     }
   },
   // Read/append/replace the host knowledge doc. mode defaults to 'read'; append needs `text`; replace
-  // needs `text` + `old_text` (old_text must match the current doc exactly, guarding against clobbering
-  // a concurrent edit). Snake_case option keys mirror the RPC contract and the spec's Python surface.
+  // needs `text` + `oldText` (oldText must match the current doc exactly, guarding against clobbering
+  // a concurrent edit).
   async details(providerId, options = {}) {
+    const normalized = remappedHostObject(options, 'host.compute.details options', {
+      mode: 'mode',
+      text: 'text',
+      oldText: 'old_text'
+    })
     return computeRpc({
       op: 'details',
       provider_id: providerId,
-      mode: options.mode || 'read',
-      text: options.text,
-      old_text: options.old_text
+      mode: normalized.mode || 'read',
+      text: normalized.text,
+      old_text: normalized.old_text
     })
   }
 }
@@ -2743,7 +2853,7 @@ const sandbox = {
     capabilities: hostCapabilities,
     llm: hostLlm,
     artifacts: hostArtifacts,
-    artifact_path: hostArtifactPath,
+    artifactPath: hostArtifactPath,
     lineage: hostLineage,
     frames: hostFrames,
     mcp: hostMcp,

--- a/resources/skills/borzoi/SKILL.md
+++ b/resources/skills/borzoi/SKILL.md
@@ -63,12 +63,12 @@ environment with `borzoi-pytorch`, then:
 
 ```python
 c = host.compute.create(provider)
-job = c.submit_job(
+job = c.submitJob(
     intent="Borzoi track prediction for 1 locus — 1×GPU, ~2 min",
-    inputs=[{"src": "borzoi_run.py", "dst_filename": "borzoi_run.py"}],
+    inputs=[{"src": "borzoi_run.py", "dstFilename": "borzoi_run.py"}],
     command="python3 borzoi_run.py",   # env selection is host-specific — see compute_details for your provider
     outputs=["tracks.npz"],
-    timeout_seconds=1800,
+    timeoutSeconds=1800,
 )
 print(job.job_id)   # cell ends here — kernel never blocks on compute
 ```
@@ -81,7 +81,7 @@ save_artifacts(payload["featured_files"])   # paths under hpc/<job_id>/
 ```
 
 For the full result dict (`output_files`, `remote_workdir`, …), re-enter the
-kernel: `c.attach_job(job_id).result()` then `c.close()`. See the
+kernel: `c.attachJob(job_id).result()` then `c.close()`. See the
 `remote-compute-ssh` / `remote-compute-modal` skill for the orchestration
 details.
 

--- a/resources/skills/borzoi/SKILL.md
+++ b/resources/skills/borzoi/SKILL.md
@@ -54,7 +54,6 @@ centred on the variant and compare per-track output.
 `(B, T, L)` tensor — `T` tracks × `L` 32-bp bins. Track metadata (assay,
 biosample) is in `borzoi_pytorch.pytorch_borzoi_model.TRACKS_DF` (or `model.tracks_df` when using the `AnnotatedBorzoi` subclass) — the base `Borzoi` model has no `targets` attribute.
 
-
 ## Remote compute
 
 Needs ≥24 GB VRAM and either pre-cached HF weights or egress to
@@ -88,13 +87,12 @@ details.
 If the provider exposes a weight-cache mount, point `HF_HOME` at it inside
 `borzoi_run.py` (path is in `compute_details`).
 
-
 ## Troubleshooting
 
-| Symptom                        | Cause                    | Fix                                  |
-| ------------------------------ | ------------------------ | ------------------------------------ |
-| `module has no __version__`    | Package exposes no attr  | Use `importlib.metadata.version("borzoi-pytorch")` |
-| Shape mismatch on input        | Wrong window length      | Pad/crop to 524288 bp (fixed; not exposed as a model attribute) |
+| Symptom                     | Cause                   | Fix                                                             |
+| --------------------------- | ----------------------- | --------------------------------------------------------------- |
+| `module has no __version__` | Package exposes no attr | Use `importlib.metadata.version("borzoi-pytorch")`              |
+| Shape mismatch on input     | Wrong window length     | Pad/crop to 524288 bp (fixed; not exposed as a model attribute) |
 
 ---
 

--- a/resources/skills/customize/SKILL.md
+++ b/resources/skills/customize/SKILL.md
@@ -150,9 +150,9 @@ confirmation before executing. The review must show:
 
 For an update, also identify the changed fields.
 
-For multi-field capability edits, prefer **one atomic `update`** over a loop of `attach_*`/`detach_*`
-calls that could partially succeed. Use `attach_*`/`detach_*` only for a single incremental collection
-move.
+For multi-field capability edits, prefer **one atomic `update`** over a loop of attach/detach calls
+that could partially succeed. Use `attachSkill`/`detachSkill` or
+`attachConnector`/`detachConnector` only for a single incremental collection move.
 
 ## Confirmation boundaries
 
@@ -174,8 +174,8 @@ When you describe one of these privileged actions, explain:
 
 ## Revision and stale drafts
 
-Carry the reviewed `revision` into `update`/`delete`/`attach_*`/`detach_*`. A stale revision fails
-**without merge or retry**. When it fails, re-read, rebuild the complete draft, and ask for
+Carry the reviewed `revision` into `update`, `delete`, and the attach/detach methods. A stale revision
+fails **without merge or retry**. When it fails, re-read, rebuild the complete draft, and ask for
 confirmation again. A changed draft also invalidates the user's earlier confirmation — re-review after
 the user edits the draft. Do not automatically retry declined or stale privileged operations.
 

--- a/resources/skills/evo2/SKILL.md
+++ b/resources/skills/evo2/SKILL.md
@@ -28,12 +28,12 @@ metadata:
 
 ## Prerequisites
 
-| Requirement | Minimum | Recommended      |
-| ----------- | ------- | ---------------- |
-| Python      | 3.11    | 3.12 (<3.13)     |
-| CUDA        | 12.1+   | 12.4+            |
-| GPU VRAM    | 24 GB (7B bf16) | 80 GB (40B) |
-| RAM         | 32 GB   | 128 GB           |
+| Requirement | Minimum         | Recommended  |
+| ----------- | --------------- | ------------ |
+| Python      | 3.11            | 3.12 (<3.13) |
+| CUDA        | 12.1+           | 12.4+        |
+| GPU VRAM    | 24 GB (7B bf16) | 80 GB (40B)  |
+| RAM         | 32 GB           | 128 GB       |
 
 ## How to run
 
@@ -68,11 +68,11 @@ print(out.sequences[0])
 
 ## Models
 
-| Name        | Params | Context | VRAM (bf16) | Notes                              |
-| ----------- | ------ | ------- | ----------- | ---------------------------------- |
-| `evo2_7b`   | 7 B    | 1 M nt  | ~22 GB      | Default; fits on a single 24 GB+ GPU |
-| `evo2_40b`  | 40 B   | 1 M nt  | ~78 GB      | H100 80 GB or multi-GPU            |
-| `evo2_1b_base` | 1 B | 8 K nt  | ~6 GB       | FP8 path requires sm_89+ (H100)    |
+| Name           | Params | Context | VRAM (bf16) | Notes                                |
+| -------------- | ------ | ------- | ----------- | ------------------------------------ |
+| `evo2_7b`      | 7 B    | 1 M nt  | ~22 GB      | Default; fits on a single 24 GB+ GPU |
+| `evo2_40b`     | 40 B   | 1 M nt  | ~78 GB      | H100 80 GB or multi-GPU              |
+| `evo2_1b_base` | 1 B    | 8 K nt  | ~6 GB       | FP8 path requires sm_89+ (H100)      |
 
 ## Output format
 
@@ -92,7 +92,6 @@ Need a DNA model?
 ├─ Predict experimental tracks (expression, accessibility) → borzoi
 └─ Protein, not DNA → fair-esm2 / esmfold2
 ```
-
 
 ## Remote compute
 
@@ -129,23 +128,22 @@ Inside `score_evo2.py`, point `HF_HOME` at the provider's weight-cache mount
 doesn't try to write `refs/` into a read-only mount. Weight footprint:
 ~15 GB (7B), ~80 GB (40B).
 
-
 ## Typical performance
 
-| Task                        | 7B on H100 | Notes                       |
-| --------------------------- | ---------- | --------------------------- |
-| Model load (cached)         | ~5-7 min   | First call hydrates weights |
-| `score_sequences`, 200×200bp| ~10-20 s   | After load                  |
-| `generate`, 1×512 nt        | ~15 s      |                             |
+| Task                         | 7B on H100 | Notes                       |
+| ---------------------------- | ---------- | --------------------------- |
+| Model load (cached)          | ~5-7 min   | First call hydrates weights |
+| `score_sequences`, 200×200bp | ~10-20 s   | After load                  |
+| `generate`, 1×512 nt         | ~15 s      |                             |
 
 ## Troubleshooting
 
-| Symptom                              | Cause                          | Fix                                        |
-| ------------------------------------ | ------------------------------ | ------------------------------------------ |
-| `Transformer Engine not installed`   | No FP8 — falls back to bf16    | Informational only on non-H100; ignore     |
-| OOM on load                          | 40B on <80 GB GPU              | Use `evo2_7b` or shard with `device_map`   |
-| HF tries to write `refs/main`        | `HF_HOME` points at RO mount   | Set `HF_HUB_OFFLINE=1`                     |
-| `dtype mismatch` in `score_sequences`| Passing tensors not strings    | Pass `list[str]`; the API tokenises for you |
+| Symptom                               | Cause                        | Fix                                         |
+| ------------------------------------- | ---------------------------- | ------------------------------------------- |
+| `Transformer Engine not installed`    | No FP8 — falls back to bf16  | Informational only on non-H100; ignore      |
+| OOM on load                           | 40B on <80 GB GPU            | Use `evo2_7b` or shard with `device_map`    |
+| HF tries to write `refs/main`         | `HF_HOME` points at RO mount | Set `HF_HUB_OFFLINE=1`                      |
+| `dtype mismatch` in `score_sequences` | Passing tensors not strings  | Pass `list[str]`; the API tokenises for you |
 
 ---
 

--- a/resources/skills/evo2/SKILL.md
+++ b/resources/skills/evo2/SKILL.md
@@ -102,12 +102,12 @@ Need a DNA model?
 
 ```python
 c = host.compute.create(provider)
-job = c.submit_job(
+job = c.submitJob(
     intent="Evo2-7B score 200bp variant window — 1×GPU, ~2 min",
-    inputs=[{"src": "score_evo2.py", "dst_filename": "score_evo2.py"}],
+    inputs=[{"src": "score_evo2.py", "dstFilename": "score_evo2.py"}],
     command="python3 score_evo2.py",   # env selection is host-specific — see compute_details for your provider
     outputs=["scores.json"],
-    timeout_seconds=1800,
+    timeoutSeconds=1800,
 )
 print(job.job_id)   # cell ends here — kernel never blocks on compute
 ```
@@ -120,7 +120,7 @@ save_artifacts(payload["featured_files"])   # paths under hpc/<job_id>/
 ```
 
 For the full result dict (`output_files`, `remote_workdir`, …), re-enter the
-kernel: `c.attach_job(job_id).result()` then `c.close()`. See the
+kernel: `c.attachJob(job_id).result()` then `c.close()`. See the
 `remote-compute-ssh` / `remote-compute-modal` skill for the orchestration
 details.
 

--- a/resources/skills/fair-esm2/SKILL.md
+++ b/resources/skills/fair-esm2/SKILL.md
@@ -32,10 +32,10 @@ ESM-2 code and weights are MIT (Meta AI, github.com/facebookresearch/esm).
 
 ## Prerequisites
 
-| Requirement | Minimum | Recommended |
-| ----------- | ------- | ----------- |
-| Python      | 3.8+    | 3.11        |
-| CUDA        | 11.7+   | 12.x        |
+| Requirement | Minimum                 | Recommended        |
+| ----------- | ----------------------- | ------------------ |
+| Python      | 3.8+                    | 3.11               |
+| CUDA        | 11.7+                   | 12.x               |
 | GPU VRAM    | 8 GB (8M), 16 GB (650M) | 24 GB+ (650M / 3B) |
 
 ## How to run
@@ -76,17 +76,16 @@ contacts = out["contacts"][0]         # (L, L)
 
 ## Models
 
-| Name                       | Layers | Dim  | Params | Use                        |
-| -------------------------- | ------ | ---- | ------ | -------------------------- |
-| `esm2_t6_8M_UR50D`         | 6      | 320  | 8 M    | Fast smoke / tiny embeddings |
-| `esm2_t33_650M_UR50D`      | 33     | 1280 | 650 M  | Default embedding model    |
-| `esm2_t36_3B_UR50D`        | 36     | 2560 | 3 B    | Best embeddings, 24 GB+    |
+| Name                  | Layers | Dim  | Params | Use                          |
+| --------------------- | ------ | ---- | ------ | ---------------------------- |
+| `esm2_t6_8M_UR50D`    | 6      | 320  | 8 M    | Fast smoke / tiny embeddings |
+| `esm2_t33_650M_UR50D` | 33     | 1280 | 650 M  | Default embedding model      |
+| `esm2_t36_3B_UR50D`   | 36     | 2560 | 3 B    | Best embeddings, 24 GB+      |
 
 ## Output format
 
 `out["representations"][layer]` is `(B, L+2, D)`; slice `[ :, 1:-1, : ]` to
 drop BOS/EOS. `out["contacts"]` (when `return_contacts=True`) is `(B, L, L)`.
-
 
 ## Remote compute
 
@@ -126,13 +125,12 @@ details.
 Inside `embed_esm2.py`, set `TORCH_HOME` to the provider's torch-hub cache
 mount (path is in `compute_details`) so `esm.pretrained.*` resolves locally.
 
-
 ## Troubleshooting
 
-| Symptom                                       | Cause                              | Fix                                   |
-| --------------------------------------------- | ---------------------------------- | ------------------------------------- |
+| Symptom                                             | Cause                                        | Fix                                                      |
+| --------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------- |
 | `ModuleNotFoundError: No module named 'esm.models'` | You want Biohub's `esm` fork, not `fair-esm` | See `esmfold2` skill; this skill uses `esm.pretrained.*` |
-| Slow first call                               | Downloading weights via torch.hub  | Set `TORCH_HOME` to a cached location |
+| Slow first call                                     | Downloading weights via torch.hub            | Set `TORCH_HOME` to a cached location                    |
 
 ---
 

--- a/resources/skills/fair-esm2/SKILL.md
+++ b/resources/skills/fair-esm2/SKILL.md
@@ -97,16 +97,16 @@ and a torch-hub weight cache, then:
 
 ```python
 c = host.compute.create(provider)
-job = c.submit_job(
+job = c.submitJob(
     intent="ESM-2 650M embeddings for 200 sequences — 1×GPU, ~2 min",
     inputs=[
-        {"src": "seqs.fasta", "dst_filename": "seqs.fasta"},
-        {"src": "embed_esm2.py", "dst_filename": "embed_esm2.py"},
+        {"src": "seqs.fasta", "dstFilename": "seqs.fasta"},
+        {"src": "embed_esm2.py", "dstFilename": "embed_esm2.py"},
     ],
     command="python3 embed_esm2.py",
     environment=...,   # env name from compute_details
     outputs=["embeddings.pt"],
-    timeout_seconds=1800,
+    timeoutSeconds=1800,
 )
 print(job.job_id)   # cell ends here — kernel never blocks on compute
 ```
@@ -119,7 +119,7 @@ save_artifacts(payload["featured_files"])   # paths under hpc/<job_id>/
 ```
 
 For the full result dict (`output_files`, `remote_workdir`, …), re-enter the
-kernel: `c.attach_job(job_id).result()` then `c.close()`. See the
+kernel: `c.attachJob(job_id).result()` then `c.close()`. See the
 `remote-compute-ssh` / `remote-compute-modal` skill for the orchestration
 details.
 

--- a/resources/skills/remote-compute-ssh/SKILL.md
+++ b/resources/skills/remote-compute-ssh/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 ---
 
 This skill covers remote compute over SSH: listing hosts, creating handles, running short
-remote commands (call_command), reading/writing host knowledge docs, and the full async
+remote commands (callCommand), reading/writing host knowledge docs, and the full async
 job lifecycle — submit → harvest → analysis turn → publish artifacts.
 
 **Where host.compute runs:** `host.compute` lives ONLY on the control-plane REPL kernel — run
@@ -35,7 +35,7 @@ Always check which host is active before creating a handle:
 ```javascript
 // Returns the session-enabled host provider_ids (a string[] subset of all registered hosts).
 // Empty array means the user hasn't chosen a host for this conversation yet.
-const activeHosts = await host.compute.list_compute()
+const activeHosts = await host.compute.listCompute()
 const c = activeHosts[0] ? host.compute.create(activeHosts[0]) : null
 ```
 
@@ -46,15 +46,15 @@ const c = activeHosts[0] ? host.compute.create(activeHosts[0]) : null
 const hosts = await host.compute.list()
 
 // List session-enabled hosts (user's active selection for this conversation)
-const activeHosts = await host.compute.list_compute()
+const activeHosts = await host.compute.listCompute()
 
 // Create a handle to a specific host (no network call)
 const c = host.compute.create('ssh:<alias>')
 
 // Run a short remote command (throws on approval_denied / host_unreachable / timeout)
-const result = await c.call_command('<shell command>', '<one-line intent for the approval card>', {
-  login_shell: true, // default: true — runs login profiles, then readable ~/.bashrc, before this command
-  timeout_seconds: 60 // optional — the host applies its own default (60s) when omitted
+const result = await c.callCommand('<shell command>', '<one-line intent for the approval card>', {
+  loginShell: true, // default: true — runs login profiles, then readable ~/.bashrc, before this command
+  timeoutSeconds: 60 // optional — the host applies its own default (60s) when omitted
 })
 // result → { exit_code, stdout, stderr, truncated }
 
@@ -67,41 +67,41 @@ await host.compute.details('ssh:<alias>', {
   text: '\n## Note\nlearned X on <date>'
 })
 
-// Replace the entire host knowledge doc (old_text must match the current doc exactly)
+// Replace the entire host knowledge doc (oldText must match the current doc exactly)
 await host.compute.details('ssh:<alias>', {
   mode: 'replace',
   text: '<new full doc>',
-  old_text: info.doc // from the read above
+  oldText: info.doc // from the read above
 })
 ```
 
-With `login_shell: true`, the remote Bash login profiles run first and then Open Science attempts to
+With `loginShell: true`, the remote Bash login profiles run first and then Open Science attempts to
 source `~/.bashrc` when it is readable. A `.bashrc` can deliberately return early for non-interactive
 shells, so variables declared after such a guard are not available. A missing `.bashrc` is a no-op.
-Set `login_shell: false` to run the command without either initialization step. Initialization failures
+Set `loginShell: false` to run the command without either initialization step. Initialization failures
 are reported through the normal command result/error behavior.
 
 ## API reference (async jobs)
 
-Use `submit_job` for long-running computations (minutes to hours). It returns immediately with a
+Use `submitJob` for long-running computations (minutes to hours). It returns immediately with a
 `job_id`; the job runs on the remote host in the background. When the job finishes, the app
 automatically harvests the outputs and initiates a new analysis turn — **you never poll or block**.
 
 ```javascript
 // List the session's active compute hosts (set via the ≡ host selector)
-const activeHosts = await host.compute.list_compute()
+const activeHosts = await host.compute.listCompute()
 // returns ['ssh:<alias>', ...] — the provider_ids currently enabled for this session
 
 // Submit a non-blocking job — returns immediately after the user approves
 const c = host.compute.create('ssh:<alias>')
-const job = await c.submit_job(
+const job = await c.submitJob(
   '<one-line intent for the approval card>', // shown in the approval card
   '<shell command>', // command to run remotely
   {
-    timeout_seconds: 3600, // optional; default 24 h, max 7 days
+    timeoutSeconds: 3600, // optional; default 24 h, max 7 days
     inputs: [
-      { src: 'in.dat', dst_filename: 'in.dat' }, // stage a workspace file
-      { remote_path: 'ssh:<alias>/<abs_path>' } // link a remote file (no transfer)
+      { src: 'in.dat', dstFilename: 'in.dat' }, // stage a workspace file
+      { remotePath: 'ssh:<alias>/<abs_path>' } // link a remote file (no transfer)
     ],
     outputs: [
       '*.result', // featured (default visibility)
@@ -111,8 +111,8 @@ const job = await c.submit_job(
     ],
     harvest: {
       exclude: ['work/**'], // never harvest these paths
-      max_file_mb: 100, // single-file cap (default 100 MB)
-      max_total_mb: 500 // total-harvest cap (default 500 MB)
+      maxFileMb: 100, // single-file cap (default 100 MB)
+      maxTotalMb: 500 // total-harvest cap (default 500 MB)
     }
   }
 )
@@ -130,7 +130,7 @@ conversation — the conversation is NOT locked while the job runs, so the user 
   other tasks. No blocking wait.
 - **When the job finishes:** the app initiates a new analysis turn automatically. You do not
   trigger this — it happens without any action on your part.
-- **Do NOT write** a loop calling `attach_job().status()` to wait for completion. That is the
+- **Do NOT write** a loop calling `attachJob().status()` to wait for completion. That is the
   app's job, not yours. Writing such a loop would block the conversation for the entire job
   duration.
 
@@ -138,13 +138,13 @@ conversation — the conversation is NOT locked while the job runs, so the user 
 
 ```javascript
 // Non-blocking DB read — no SSH. Use if you need a status snapshot mid-conversation.
-const handle = c.attach_job(job.job_id)
+const handle = c.attachJob(job.job_id)
 const s = await handle.status()
 // s → { job_id, status, exit_code, stdout_tail, stderr_tail, remote_workdir }
 // status: 'submitted' | 'running' | 'success' | 'failed' | 'timeout' | 'error'
 ```
 
-### submit_job status values
+### submitJob status values
 
 | status      | meaning                                                                |
 | ----------- | ---------------------------------------------------------------------- |
@@ -152,7 +152,7 @@ const s = await handle.status()
 | `running`   | remote process confirmed alive (pid recorded)                          |
 | `success`   | exit code 0                                                            |
 | `failed`    | non-zero exit (`job_failed`) or process vanished (`process_vanished`)  |
-| `timeout`   | exceeded `timeout_seconds`                                             |
+| `timeout`   | exceeded `timeoutSeconds`                                             |
 | `error`     | never reached the remote host (`host_unreachable` / `dispatch_failed`) |
 
 ## Workflow: the analysis turn
@@ -160,14 +160,14 @@ const s = await handle.status()
 When the app initiates the analysis turn, it provides the `job_id`, `status`, and
 `featured_files` (workspace-relative paths under `hpc/<job_id>/featured/`). In this turn:
 
-1. Call `attach_job(job_id).result()` to get the full result dict.
+1. Call `attachJob(job_id).result()` to get the full result dict.
 2. Inspect the outputs, run any analysis needed.
 3. Call `write_artifact_file` to publish outputs worth keeping as artifacts.
 
 ```javascript
 // In the analysis turn — read the full harvested result (non-blocking DB + directory scan)
 const c = host.compute.create('ssh:<alias>')
-const r = await c.attach_job(job_id).result()
+const r = await c.attachJob(job_id).result()
 // r → {
 //   job_id, status, exit_code,
 //   featured_files: ['hpc/<job_id>/featured/out.result', ...],   // workspace-relative
@@ -205,26 +205,26 @@ for (const path of r.featured_files) {
 
 Read `r.exit_code` and `r.stderr_tail`. An infrastructure failure (wrong partition, env not
 activated, missing module, OOM, walltime) is yours to fix — adjust `command`, record the fix,
-fresh `c.submit_job()`. A harvest failure (`r.stderr_tail` notes it, `r.remote_workdir` is
+fresh `c.submitJob()`. A harvest failure (`r.stderr_tail` notes it, `r.remote_workdir` is
 preserved) means some files were not downloaded — the remote workdir is kept so you can
-`c.call_command('ls ...', intent='...')` to inspect what's there.
+`c.callCommand('ls ...', intent='...')` to inspect what's there.
 
 ## Chaining jobs via left_on_remote
 
 Large outputs declared with `residency: 'remote'` or files that exceed the size threshold stay
-on the remote host and appear in `r.left_on_remote`. Use their URIs directly as `remote_path`
+on the remote host and appear in `r.left_on_remote`. Use their URIs directly as `remotePath`
 inputs to the next job — no local round-trip:
 
 ```javascript
 // In the analysis turn — chain a left_on_remote output into the next job
 const big_output_uri = r.left_on_remote[0].uri // e.g. 'ssh:biowulf//scratch/jobs/<id>/big.h5'
 
-const job2 = await c.submit_job(
+const job2 = await c.submitJob(
   'process big.h5 output from job 1',
   'python process.py --input big.h5 --out summary.csv',
   {
     inputs: [
-      { remote_path: big_output_uri } // symlinked in job workdir, no transfer
+      { remotePath: big_output_uri } // symlinked in job workdir, no transfer
     ],
     outputs: ['summary.csv']
   }
@@ -242,13 +242,13 @@ completions into one turn with multiple job_ids):
 const c = host.compute.create('ssh:gpu-cluster')
 const jobs = []
 for (const seed of [0, 1, 2, 3, 4]) {
-  const job = await c.submit_job(
+  const job = await c.submitJob(
     `AlphaFold seed ${seed}`,
     `python fold.py --seed ${seed} --in input.fasta --out ranked.pdb`,
     {
-      inputs: [{ src: 'input.fasta', dst_filename: 'input.fasta' }],
+      inputs: [{ src: 'input.fasta', dstFilename: 'input.fasta' }],
       outputs: [{ glob: '*.pdb', visibility: 'featured' }],
-      timeout_seconds: 3600
+      timeoutSeconds: 3600
     }
   )
   jobs.push(job.job_id)
@@ -271,7 +271,7 @@ the whole conversation, not on the handle's bound provider.
 const c = host.compute.create('ssh:<alias>')
 
 // Set the conversation-wide limit (positive integer 1..500).
-await c.set_concurrency_limit(2)
+await c.setConcurrencyLimit(2)
 
 // Read the session's concurrency status (non-blocking DB read, no SSH).
 const s = await c.status()
@@ -283,11 +283,11 @@ const s = await c.status()
 // }
 ```
 
-## call_command error handling
+## callCommand error handling
 
 ```javascript
 try {
-  const r = await c.call_command('cmd', '<intent>')
+  const r = await c.callCommand('cmd', '<intent>')
 } catch (e) {
   const code = e.error_code || ''
   if (code === 'host_unreachable') {
@@ -295,7 +295,7 @@ try {
   } else if (code === 'approval_denied') {
     // User declined the approval card
   } else if (code === 'timeout') {
-    // Command exceeded timeout_seconds
+    // Command exceeded timeoutSeconds
   }
 }
 ```
@@ -305,7 +305,7 @@ try {
 1. `await host.compute.details(provider_id, { mode: 'read' })` — a `## Resources` skeleton means
    first contact; populated sections mean prior sessions did the legwork, trust them.
 2. Bind once: `const c = host.compute.create(provider_id)`.
-3. Run one batched probe: `await c.call_command('id; module avail 2>&1 | head -40', '<intent>')`.
+3. Run one batched probe: `await c.callCommand('id; module avail 2>&1 | head -40', '<intent>')`.
 4. Append what you learned via `await host.compute.details(..., { mode: 'append' })`.
 
 ## What to record in the knowledge doc

--- a/resources/skills/remote-compute-ssh/SKILL.md
+++ b/resources/skills/remote-compute-ssh/SKILL.md
@@ -152,7 +152,7 @@ const s = await handle.status()
 | `running`   | remote process confirmed alive (pid recorded)                          |
 | `success`   | exit code 0                                                            |
 | `failed`    | non-zero exit (`job_failed`) or process vanished (`process_vanished`)  |
-| `timeout`   | exceeded `timeoutSeconds`                                             |
+| `timeout`   | exceeded `timeoutSeconds`                                              |
 | `error`     | never reached the remote host (`host_unreachable` / `dispatch_failed`) |
 
 ## Workflow: the analysis turn

--- a/resources/skills/scgpt/SKILL.md
+++ b/resources/skills/scgpt/SKILL.md
@@ -82,16 +82,16 @@ and a pre-cached checkpoint directory, then:
 
 ```python
 c = host.compute.create(provider)
-job = c.submit_job(
+job = c.submitJob(
     intent="scGPT embed 50k cells — 1×GPU, ~5 min",
     inputs=[
-        {"src": "dataset.h5ad", "dst_filename": "dataset.h5ad"},
-        {"src": "embed.py", "dst_filename": "embed.py"},
+        {"src": "dataset.h5ad", "dstFilename": "dataset.h5ad"},
+        {"src": "embed.py", "dstFilename": "embed.py"},
     ],
     command="python3 embed.py",
     environment=...,   # env name from compute_details
     outputs=["embedded.h5ad"],
-    timeout_seconds=1800,
+    timeoutSeconds=1800,
 )
 print(job.job_id)   # cell ends here — kernel never blocks on compute
 ```
@@ -109,7 +109,7 @@ handle, not on the job object:
 
 ```python
 h = host.compute.create(provider)
-res = h.attach_job(job_id).result()
+res = h.attachJob(job_id).result()
 h.close()
 ```
 

--- a/resources/skills/scgpt/SKILL.md
+++ b/resources/skills/scgpt/SKILL.md
@@ -72,7 +72,6 @@ emb = embed_data(
 embedding (`n_cells × emb_dim`, 512 by default). Downstream: feed to
 `scanpy.pp.neighbors` / `scanpy.tl.umap`.
 
-
 ## Remote compute
 
 Needs ≥24 GB VRAM and the released human checkpoint (~200 MB:
@@ -120,7 +119,6 @@ In `embed.py`, pass `model_dir=` the checkpoint path from `compute_details`.
 If `flash-attn` is unavailable in that environment, set
 `use_fast_transformer=False`.
 
-
 ## Gotchas
 
 - **`use_fast_transformer` default is `True`** but resolves to a FlashAttention
@@ -135,11 +133,11 @@ If `flash-attn` is unavailable in that environment, set
 
 ## Troubleshooting
 
-| Symptom                                           | Fix                                              |
-| ------------------------------------------------- | ------------------------------------------------ |
-| `flash_attn is not installed` warning at import   | Harmless; pass `use_fast_transformer=False`      |
-| `'Vocab' object has no attribute 'vocab'`         | Env has an old torchtext shim — update the env   |
-| Nearly all genes dropped                          | Wrong `gene_col`; check `adata.var.columns`      |
+| Symptom                                              | Fix                                                                                                                                                                           |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flash_attn is not installed` warning at import      | Harmless; pass `use_fast_transformer=False`                                                                                                                                   |
+| `'Vocab' object has no attribute 'vocab'`            | Env has an old torchtext shim — update the env                                                                                                                                |
+| Nearly all genes dropped                             | Wrong `gene_col`; check `adata.var.columns`                                                                                                                                   |
 | "scgpt not in manifest" / env-detection misses scGPT | The baked env manifest lists the distribution as `scGPT` (and `flash_attn`), pip's canonical casing — normalize manifest keys before lookup: `name.lower().replace('-', '_')` |
 
 ---

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -20,7 +20,7 @@ The v1 result contains exactly eight boolean keys:
 - `compute` gates the `host.compute` namespace.
 - `agents` gates the `host.agents` namespace.
 - `skills` gates the `host.skills` namespace.
-- `artifacts` gates `host.artifacts` and `host.artifact_path`.
+- `artifacts` gates `host.artifacts` and `host.artifactPath`.
 - `lineage` gates the read-only `host.lineage` namespace.
 - `frames` gates the read-only `host.frames` namespace.
 - `llm` gates `host.llm` one-shot, tool-less inference.
@@ -51,21 +51,21 @@ call returns a fresh frozen projection.
 ## Discover managed Project files
 
 When `caps.artifacts === true`, use `await host.artifacts(options)` to list generated Artifacts and
-user Uploads across the current Project. Optional snake_case fields are `version_id`, `session_id`,
-`filename`, `exact`, `search`, `content_type`, `after`, `before`, `cursor`, and `limit` (default 20,
-maximum 100). `version_id` is exclusive; `exact` requires `filename`; `search` and `filename` cannot
+user Uploads across the current Project. Optional camelCase fields are `versionId`, `sessionId`,
+`filename`, `exact`, `search`, `contentType`, `after`, `before`, `cursor`, and `limit` (default 20,
+maximum 100). `versionId` is exclusive; `exact` requires `filename`; `search` and `filename` cannot
 be combined. Bare dates are UTC midnight, `after` is inclusive, and `before` is exclusive.
 
 ```javascript
 const page = await host.artifacts({ search: 'report', limit: 20 })
 const localPath = page.artifacts[0]
-  ? await host.artifact_path(page.artifacts[0].latest_version_id)
+  ? await host.artifactPath(page.artifacts[0].latest_version_id)
   : undefined
 ```
 
-`session_id` only narrows the token-owned current Project. There is no Project override or all-
+`sessionId` only narrows the token-owned current Project. There is no Project override or all-
 Projects scope. Results contain metadata and immutable Version identity, never content; use
-`host.artifact_path(version_id)` to resolve a checksum-validated local absolute path for an exact
+`host.artifactPath(versionId)` to resolve a checksum-validated local absolute path for an exact
 generated Artifact Version or Upload Version, then use the existing file workflow. Version ID
 collisions, missing Versions, cross-Project ownership, and checksum mismatches fail closed.
 
@@ -76,8 +76,8 @@ markers, or a content-read API.
 
 When `caps.lineage === true`, start with
 `await host.lineage.graph(versionId, options)` to inspect the dependency graph without reading
-Artifact content. `options` accepts only `direction` (`'up'` by default or `'down'`), `max_depth`
-(default 5, maximum 20), and `max_nodes` (default 100, maximum 500). Graphs use stable BFS order;
+Artifact content. `options` accepts only `direction` (`'up'` by default or `'down'`), `maxDepth`
+(default 5, maximum 20), and `maxNodes` (default 100, maximum 500). Graphs use stable BFS order;
 an Upload is an upstream leaf and may be a downstream root. A truncated result includes a reason
 and `frontier_version_ids` for a narrower follow-up query.
 
@@ -93,7 +93,7 @@ if (caps.lineage === true) {
 Use `await host.lineage.get(versionId)` only for a generated Artifact Version after graph discovery.
 It returns the existing immutable core provenance projection: reproduction code when available,
 producer and environment status/evidence, and typed input Version evidence. Upload Versions are
-rejected by `get`; obtain their metadata with `host.artifacts({ version_id: versionId })`.
+rejected by `get`; obtain their metadata with `host.artifacts({ versionId })`.
 
 Both calls are fresh, frozen reads scoped only by the session-bound control token to the current
 Project, including Versions created in another Session of that Project. They never accept Project or
@@ -105,13 +105,13 @@ client cache, Python/R `host`, or lineage API outside the JavaScript control REP
 ## Discover Agent Frames
 
 When `caps.frames === true`, use `await host.frames.list(options)` for a metadata-only catalog across
-Sessions in the token-owned current Project. It never searches message bodies. Optional snake_case
-fields are `search`, `session_id`, `roots_only` (default `true`), `kind`, `archived`
+Sessions in the token-owned current Project. It never searches message bodies. Optional camelCase
+fields are `search`, `sessionId`, `rootsOnly` (default `true`), `kind`, `archived`
 (`exclude`/`include`/`only`, default `exclude`), `after`, `before`, `cursor`, and `limit` (default 20,
 maximum 100). Metadata search fuzzily matches Session title, `agent_name`, and `delegate_name`.
 
 Use `await host.frames.get(frameId, options)` with an exact full Frame ID to read one visible
-conversation path. `session_id` may narrow or disambiguate within the current Project. `branch_id`
+conversation path. `sessionId` may narrow or disambiguate within the current Project. `branchId`
 selects a specific Branch; without it, the Frame's active Branch is used. The latest 40 messages are
 returned chronologically by default, with a maximum of 100. Pass `before` with the returned
 `previous_cursor` to page backward through older messages.

--- a/src/main/agents/agents-repl.integration.test.ts
+++ b/src/main/agents/agents-repl.integration.test.ts
@@ -152,7 +152,11 @@ gate('host.agents repl integration', () => {
         }
       }
     })
-    const connection = await rpcServer.issueControlConnection('session-trusted', 'default-project')
+    const connection = await rpcServer.issueControlConnection(
+      'session-trusted',
+      'default-project',
+      'root-frame-session-trusted'
+    )
     endpoint = connection.endpoint
     token = connection.token
     releaseControl = connection.release

--- a/src/main/agents/agents-repl.integration.test.ts
+++ b/src/main/agents/agents-repl.integration.test.ts
@@ -117,6 +117,7 @@ gate('host.agents repl integration', () => {
   let runtimeStorage: string
   let agentsService: AgentsService
   let capturedSessionId: string | undefined
+  let releaseControl: (() => void) | undefined
 
   beforeAll(async () => {
     profileStorage = await mkdtemp(join(tmpdir(), 'os-agents-profile-'))
@@ -151,15 +152,17 @@ gate('host.agents repl integration', () => {
         }
       }
     })
-    const connection = await rpcServer.ensureStarted()
+    const connection = await rpcServer.issueControlConnection('session-trusted', 'default-project')
     endpoint = connection.endpoint
     token = connection.token
+    releaseControl = connection.release
 
     // Seed a specialist profile directly through the authoritative ProfileService.
     await profileService.create({ name: 'Bio Expert', description: 'secret: apikey=XYZ' })
   })
 
   afterAll(async () => {
+    releaseControl?.()
     await rpcServer?.close()
     await rm(profileStorage, { recursive: true, force: true })
     await rm(runtimeStorage, { recursive: true, force: true })
@@ -331,7 +334,7 @@ gate('host.agents repl integration', () => {
       // Even via a legitimate call, the trusted identity is the captured one.
       const r2 = await send('return JSON.stringify(await host.agents.list())')
       expect(r2.error).toBeNull()
-      expect(capturedSessionId).toBe('session-real')
+      expect(capturedSessionId).toBe('session-trusted')
     } finally {
       child.kill()
     }

--- a/src/main/agents/agents-repl.mutations.integration.test.ts
+++ b/src/main/agents/agents-repl.mutations.integration.test.ts
@@ -57,7 +57,7 @@ const startLoop = (
 }
 
 // A catalog stub that returns a deterministic, secret-free catalog. Includes a Main-disabled skill
-// (personal-foo) and a custom connector (cust-1, runnable) plus an unreachable custom connector
+// (personal-foo) and a custom connector (my-server, runnable) plus an unreachable custom connector
 // (cust-dead) to exercise the availability gate.
 const stubCatalog: AgentsCatalogSource = {
   listSkillCatalog: async () => [
@@ -108,6 +108,7 @@ gate('host.agents repl mutation integration', () => {
   let token: string
   let profileStorage: string
   let runtimeStorage: string
+  let releaseControl: (() => void) | undefined
 
   beforeAll(async () => {
     profileStorage = await mkdtemp(join(tmpdir(), 'os-agents-mut-profile-'))
@@ -136,12 +137,14 @@ gate('host.agents repl mutation integration', () => {
       token: 'integration-token',
       agentsService
     })
-    const connection = await rpcServer.ensureStarted()
+    const connection = await rpcServer.issueControlConnection('mutation-session', 'default-project')
     endpoint = connection.endpoint
     token = connection.token
+    releaseControl = connection.release
   })
 
   afterAll(async () => {
+    releaseControl?.()
     await rpcServer?.close()
     await rm(profileStorage, { recursive: true, force: true })
     await rm(runtimeStorage, { recursive: true, force: true })
@@ -165,6 +168,29 @@ gate('host.agents repl mutation integration', () => {
       expect(created.capabilityMode).toBe('full')
       expect(created.revision).toBe(1)
       expect(typeof created.id).toBe('string')
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('create() maps every camelCase public input key to the unchanged Agents RPC contract', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const r = await send(
+        "return JSON.stringify(await host.agents.create({ name: 'MappedBot', displayName: 'Mapped Bot', description: 'mapped', systemPrompt: 'prompt', iconKey: 'beaker', colorKey: 'green', enabled: true, skillNames: ['demo'], connectorNames: ['cust-1'] }))"
+      )
+      expect(r.error).toBeNull()
+      expect(JSON.parse(r.result ?? '{}')).toMatchObject({
+        name: 'MappedBot',
+        displayName: 'Mapped Bot',
+        description: 'mapped',
+        systemPrompt: 'prompt',
+        iconKey: 'beaker',
+        colorKey: 'green',
+        enabled: true,
+        capabilityMode: 'selected',
+        selectedCapabilities: { skillIds: ['demo'], connectorIds: ['cust-1'] }
+      })
     } finally {
       child.kill()
     }
@@ -212,15 +238,49 @@ gate('host.agents repl mutation integration', () => {
         ).result ?? '{}'
       )
       const r = await send(
-        `return JSON.stringify(await host.agents.update('UpdBot', { revision: ${created.revision}, description: 'after', skillNames: ['demo'] }))`
+        `return JSON.stringify(await host.agents.update('UpdBot', { revision: ${created.revision}, displayName: 'Updated Bot', description: 'after', systemPrompt: 'updated prompt', iconKey: 'flask', colorKey: 'blue', skillNames: ['demo'], connectorNames: ['cust-1'] }))`
       )
       expect(r.error).toBeNull()
       const updated = JSON.parse(r.result ?? '{}')
       // read-back reflects the actual post-write state, not the echoed request.
+      expect(updated.displayName).toBe('Updated Bot')
       expect(updated.description).toBe('after')
+      expect(updated.systemPrompt).toBe('updated prompt')
+      expect(updated.iconKey).toBe('flask')
+      expect(updated.colorKey).toBe('blue')
       expect(updated.capabilityMode).toBe('selected')
       expect(updated.selectedCapabilities.skillIds).toEqual(['demo'])
+      expect(updated.selectedCapabilities.connectorIds).toEqual(['cust-1'])
       expect(updated.revision).toBe(created.revision + 1)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('rejects every old Agents input key before it reaches the RPC service', async () => {
+    const { child, send } = startLoop(env())
+    try {
+      const r = await send(
+        "const errors = []; for (const key of ['system_prompt', 'icon_key', 'color_key', 'skill_names', 'connector_names']) { " +
+          "try { await host.agents.create({ name: 'Old-' + key, [key]: key.endsWith('_names') ? [] : 'x' }) } " +
+          "catch (error) { errors.push(error.name + ': ' + error.message) } } " +
+          "for (const key of ['system_prompt', 'icon_key', 'color_key', 'skill_names', 'connector_names']) { " +
+          "try { await host.agents.update('MappedBot', { revision: 1, [key]: key.endsWith('_names') ? [] : 'x' }) } " +
+          "catch (error) { errors.push(error.name + ': ' + error.message) } } return JSON.stringify(errors)"
+      )
+      expect(r.error).toBeNull()
+      expect(JSON.parse(r.result ?? '[]')).toEqual([
+        'TypeError: host.agents.create input unknown option: system_prompt',
+        'TypeError: host.agents.create input unknown option: icon_key',
+        'TypeError: host.agents.create input unknown option: color_key',
+        'TypeError: host.agents.create input unknown option: skill_names',
+        'TypeError: host.agents.create input unknown option: connector_names',
+        'TypeError: host.agents.update patch unknown option: system_prompt',
+        'TypeError: host.agents.update patch unknown option: icon_key',
+        'TypeError: host.agents.update patch unknown option: color_key',
+        'TypeError: host.agents.update patch unknown option: skill_names',
+        'TypeError: host.agents.update patch unknown option: connector_names'
+      ])
     } finally {
       child.kill()
     }

--- a/src/main/agents/agents-repl.mutations.integration.test.ts
+++ b/src/main/agents/agents-repl.mutations.integration.test.ts
@@ -137,7 +137,11 @@ gate('host.agents repl mutation integration', () => {
       token: 'integration-token',
       agentsService
     })
-    const connection = await rpcServer.issueControlConnection('mutation-session', 'default-project')
+    const connection = await rpcServer.issueControlConnection(
+      'mutation-session',
+      'default-project',
+      'root-frame-mutation-session'
+    )
     endpoint = connection.endpoint
     token = connection.token
     releaseControl = connection.release

--- a/src/main/agents/agents-repl.mutations.integration.test.ts
+++ b/src/main/agents/agents-repl.mutations.integration.test.ts
@@ -181,7 +181,7 @@ gate('host.agents repl mutation integration', () => {
     const { child, send } = startLoop(env())
     try {
       const r = await send(
-        "return JSON.stringify(await host.agents.create({ name: 'MappedBot', displayName: 'Mapped Bot', description: 'mapped', systemPrompt: 'prompt', iconKey: 'beaker', colorKey: 'green', enabled: true, skillNames: ['demo'], connectorNames: ['cust-1'] }))"
+        "return JSON.stringify(await host.agents.create({ name: 'MappedBot', displayName: 'Mapped Bot', description: 'mapped', systemPrompt: 'prompt', iconKey: 'beaker', colorKey: 'green', enabled: true, skillNames: ['demo'], connectorNames: ['my-server'] }))"
       )
       expect(r.error).toBeNull()
       expect(JSON.parse(r.result ?? '{}')).toMatchObject({
@@ -193,7 +193,7 @@ gate('host.agents repl mutation integration', () => {
         colorKey: 'green',
         enabled: true,
         capabilityMode: 'selected',
-        selectedCapabilities: { skillIds: ['demo'], connectorIds: ['cust-1'] }
+        selectedCapabilities: { skillIds: ['demo'], connectorIds: ['my-server'] }
       })
     } finally {
       child.kill()
@@ -220,12 +220,12 @@ gate('host.agents repl mutation integration', () => {
     const { child, send } = startLoop(env())
     try {
       const r = await send(
-        "return JSON.stringify(await host.agents.create({ name: 'ConnBot', connectorNames: ['cust-1'] }))"
+        "return JSON.stringify(await host.agents.create({ name: 'ConnBot', connectorNames: ['my-server'] }))"
       )
       expect(r.error).toBeNull()
       const created = JSON.parse(r.result ?? '{}')
       expect(created.capabilityMode).toBe('selected')
-      expect(created.selectedCapabilities.connectorIds).toEqual(['cust-1'])
+      expect(created.selectedCapabilities.connectorIds).toEqual(['my-server'])
     } finally {
       child.kill()
     }
@@ -242,7 +242,7 @@ gate('host.agents repl mutation integration', () => {
         ).result ?? '{}'
       )
       const r = await send(
-        `return JSON.stringify(await host.agents.update('UpdBot', { revision: ${created.revision}, displayName: 'Updated Bot', description: 'after', systemPrompt: 'updated prompt', iconKey: 'flask', colorKey: 'blue', skillNames: ['demo'], connectorNames: ['cust-1'] }))`
+        `return JSON.stringify(await host.agents.update('UpdBot', { revision: ${created.revision}, displayName: 'Updated Bot', description: 'after', systemPrompt: 'updated prompt', iconKey: 'flask', colorKey: 'blue', skillNames: ['demo'], connectorNames: ['my-server'] }))`
       )
       expect(r.error).toBeNull()
       const updated = JSON.parse(r.result ?? '{}')
@@ -254,7 +254,7 @@ gate('host.agents repl mutation integration', () => {
       expect(updated.colorKey).toBe('blue')
       expect(updated.capabilityMode).toBe('selected')
       expect(updated.selectedCapabilities.skillIds).toEqual(['demo'])
-      expect(updated.selectedCapabilities.connectorIds).toEqual(['cust-1'])
+      expect(updated.selectedCapabilities.connectorIds).toEqual(['my-server'])
       expect(updated.revision).toBe(created.revision + 1)
     } finally {
       child.kill()
@@ -265,20 +265,22 @@ gate('host.agents repl mutation integration', () => {
     const { child, send } = startLoop(env())
     try {
       const r = await send(
-        "const errors = []; for (const key of ['system_prompt', 'icon_key', 'color_key', 'skill_names', 'connector_names']) { " +
+        "const errors = []; for (const key of ['display_name', 'system_prompt', 'icon_key', 'color_key', 'skill_names', 'connector_names']) { " +
           "try { await host.agents.create({ name: 'Old-' + key, [key]: key.endsWith('_names') ? [] : 'x' }) } " +
           "catch (error) { errors.push(error.name + ': ' + error.message) } } " +
-          "for (const key of ['system_prompt', 'icon_key', 'color_key', 'skill_names', 'connector_names']) { " +
+          "for (const key of ['display_name', 'system_prompt', 'icon_key', 'color_key', 'skill_names', 'connector_names']) { " +
           "try { await host.agents.update('MappedBot', { revision: 1, [key]: key.endsWith('_names') ? [] : 'x' }) } " +
           "catch (error) { errors.push(error.name + ': ' + error.message) } } return JSON.stringify(errors)"
       )
       expect(r.error).toBeNull()
       expect(JSON.parse(r.result ?? '[]')).toEqual([
+        'TypeError: host.agents.create input unknown option: display_name',
         'TypeError: host.agents.create input unknown option: system_prompt',
         'TypeError: host.agents.create input unknown option: icon_key',
         'TypeError: host.agents.create input unknown option: color_key',
         'TypeError: host.agents.create input unknown option: skill_names',
         'TypeError: host.agents.create input unknown option: connector_names',
+        'TypeError: host.agents.update patch unknown option: display_name',
         'TypeError: host.agents.update patch unknown option: system_prompt',
         'TypeError: host.agents.update patch unknown option: icon_key',
         'TypeError: host.agents.update patch unknown option: color_key',
@@ -361,15 +363,15 @@ gate('host.agents repl mutation integration', () => {
       const attached = JSON.parse(
         (
           await send(
-            `return JSON.stringify(await host.agents.attachConnector('ConnAttachBot', 'cust-1', { revision: ${created.revision} }))`
+            `return JSON.stringify(await host.agents.attachConnector('ConnAttachBot', 'my-server', { revision: ${created.revision} }))`
           )
         ).result ?? '{}'
       )
-      expect(attached.selectedCapabilities.connectorIds).toEqual(['cust-1'])
+      expect(attached.selectedCapabilities.connectorIds).toEqual(['my-server'])
       const detached = JSON.parse(
         (
           await send(
-            `return JSON.stringify(await host.agents.detachConnector('ConnAttachBot', 'cust-1', { revision: ${attached.revision} }))`
+            `return JSON.stringify(await host.agents.detachConnector('ConnAttachBot', 'my-server', { revision: ${attached.revision} }))`
           )
         ).result ?? '{}'
       )

--- a/src/main/agents/agents-repl.privileged.integration.test.ts
+++ b/src/main/agents/agents-repl.privileged.integration.test.ts
@@ -61,7 +61,8 @@ const gate = process.env.RUN_KERNEL ? describe : describe.skip
 const LOOP = join(__dirname, '../../../resources/notebook/repl_loop.js')
 
 const startLoop = (
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  controlInvocationId?: string
 ): {
   child: ChildProcessWithoutNullStreams
   send: (code: string) => Promise<KernelLoopResponse>
@@ -84,7 +85,7 @@ const startLoop = (
     new Promise((resolve) => {
       const reqId = randomUUID()
       waiters.set(reqId, resolve)
-      child.stdin.write(framePythonRequest(reqId, code))
+      child.stdin.write(framePythonRequest(reqId, code, controlInvocationId))
     })
   return { child, send }
 }
@@ -183,19 +184,22 @@ const agentsCallFetch = (
   endpoint: string,
   token: string,
   sessionId: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  controlInvocationId?: string
 ): string => {
   const payload = JSON.stringify({
     method: 'agentsCall',
-    params: { session_id: sessionId, ...params }
+    params: {
+      session_id: sessionId,
+      ...(controlInvocationId ? { control_invocation_id: controlInvocationId } : {}),
+      ...params
+    }
   })
   return `const res = await fetch(${JSON.stringify(endpoint)}, { method: 'POST', headers: { 'content-type': 'application/json', authorization: 'Bearer ' + ${JSON.stringify(token)} }, body: ${JSON.stringify(payload)} }); const body = await res.json(); return JSON.stringify({ ok: res.ok, body })`
 }
 
 gate('host.agents repl privileged integration', () => {
   let rpcServer: NotebookLocalRpcServer
-  let endpoint: string
-  let token: string
   let profileStorage: string
   let runtimeStorage: string
   let agentsService: AgentsService
@@ -238,9 +242,6 @@ gate('host.agents repl privileged integration', () => {
       token: 'integration-token',
       agentsService
     })
-    const connection = await rpcServer.ensureStarted()
-    endpoint = connection.endpoint
-    token = connection.token
   })
 
   afterAll(async () => {
@@ -253,17 +254,38 @@ gate('host.agents repl privileged integration', () => {
   // trusted-session identity and in-memory binding state never bleed across assertions.
   const withLoop = async <T>(
     sessionId: string | undefined,
-    run: (send: (code: string) => Promise<KernelLoopResponse>) => Promise<T>
+    run: (
+      send: (code: string) => Promise<KernelLoopResponse>,
+      connection: { endpoint: string; token: string },
+      controlInvocationId: string
+    ) => Promise<T>
   ): Promise<T> => {
-    const { child, send } = startLoop({
-      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
-      OPEN_SCIENCE_MCP_RPC_TOKEN: token,
-      ...(sessionId ? { OPEN_SCIENCE_NOTEBOOK_SESSION_ID: sessionId } : {})
+    const boundSessionId = sessionId ?? `agents-privileged-${randomUUID()}`
+    const connection = await rpcServer.issueControlConnection(
+      boundSessionId,
+      'default-project',
+      `root-frame-${boundSessionId}`
+    )
+    const controlInvocationId = randomUUID()
+    const endInvocation = connection.beginControlInvocation({
+      turnId: `turn-${controlInvocationId}`,
+      controlInvocationGeneration: 1,
+      toolInvocationId: controlInvocationId
     })
+    const { child, send } = startLoop(
+      {
+        OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+        OPEN_SCIENCE_MCP_RPC_TOKEN: connection.token,
+        OPEN_SCIENCE_NOTEBOOK_SESSION_ID: boundSessionId
+      },
+      controlInvocationId
+    )
     try {
-      return await run(send)
+      return await run(send, connection, controlInvocationId)
     } finally {
       child.kill()
+      endInvocation()
+      connection.release()
     }
   }
 
@@ -341,21 +363,30 @@ gate('host.agents repl privileged integration', () => {
       controlInvocationGeneration: 1,
       toolInvocationId: 'delegate-tool-1'
     })
-    const { child, send } = startLoop({
-      OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
-      OPEN_SCIENCE_MCP_RPC_TOKEN: connection.token,
-      OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'delegate-switch-session'
-    })
+    const { child, send } = startLoop(
+      {
+        OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+        OPEN_SCIENCE_MCP_RPC_TOKEN: connection.token,
+        OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'delegate-switch-session'
+      },
+      'delegate-tool-1'
+    )
 
     try {
       const response = await send(
-        agentsCallFetch(connection.endpoint, connection.token, 'forged-session', {
-          op: 'switch',
-          name: 'DELEGATE_SWITCH_TARGET',
-          caller_role: 'main',
-          role: 'main',
-          is_main: true
-        })
+        agentsCallFetch(
+          connection.endpoint,
+          connection.token,
+          'forged-session',
+          {
+            op: 'switch',
+            name: 'DELEGATE_SWITCH_TARGET',
+            caller_role: 'main',
+            role: 'main',
+            is_main: true
+          },
+          'delegate-tool-1'
+        )
       )
       expect(response.error).toBeNull()
       const parsed = JSON.parse(response.result ?? '{}')
@@ -426,7 +457,7 @@ gate('host.agents repl privileged integration', () => {
   // the structured-decline wire envelope / no-retry dispatch over a custom decline gateway.
 
   it('switch cannot forge a different calling session: reserved identity keys are dropped, only the trusted session is bound', async () => {
-    await withLoop('session-real', async (send) => {
+    await withLoop('session-real', async (send, connection, controlInvocationId) => {
       const created = JSON.parse(
         (await send("return JSON.stringify(await host.agents.create({ name: 'GUARD_TARGET' }))"))
           .result ?? '{}'
@@ -435,14 +466,20 @@ gate('host.agents repl privileged integration', () => {
       // reconfigure flag) alongside the trusted session. The dispatcher strips every reserved key;
       // the switch binds ONLY the trusted calling session.
       const r = await send(
-        agentsCallFetch(endpoint, token, 'session-real', {
-          op: 'switch',
-          name: 'GUARD_TARGET',
-          sessionId: 'forged-camel',
-          specialist_id: 'forged-specialist',
-          target_specialist_id: 'forged-target',
-          reconfigure: true
-        })
+        agentsCallFetch(
+          connection.endpoint,
+          connection.token,
+          'session-real',
+          {
+            op: 'switch',
+            name: 'GUARD_TARGET',
+            sessionId: 'forged-camel',
+            specialist_id: 'forged-specialist',
+            target_specialist_id: 'forged-target',
+            reconfigure: true
+          },
+          controlInvocationId
+        )
       )
       const parsed = JSON.parse(r.result ?? '{}')
       expect(parsed.ok).toBe(true)
@@ -552,20 +589,36 @@ gate('host.agents repl privileged integration', () => {
       }),
       { token: 'decline-token', agentsService: composed.agentsService }
     )
-    const conn = await declineRpc.ensureStarted()
+    const conn = await declineRpc.issueControlConnection(
+      'session-decline',
+      'default-project',
+      'root-frame-session-decline'
+    )
+    const controlInvocationId = 'decline-tool'
+    const endInvocation = conn.beginControlInvocation({
+      turnId: 'decline-turn',
+      controlInvocationGeneration: 1,
+      toolInvocationId: controlInvocationId
+    })
     try {
-      const { child, send } = startLoop({
-        OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
-        OPEN_SCIENCE_MCP_RPC_TOKEN: conn.token,
-        OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-decline'
-      })
+      const { child, send } = startLoop(
+        {
+          OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
+          OPEN_SCIENCE_MCP_RPC_TOKEN: conn.token,
+          OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-decline'
+        },
+        controlInvocationId
+      )
       try {
         await send("return JSON.stringify(await host.agents.create({ name: 'DECLINE_TARGET' }))")
         const r = await send(
-          agentsCallFetch(conn.endpoint, conn.token, 'session-decline', {
-            op: 'switch',
-            name: 'DECLINE_TARGET'
-          })
+          agentsCallFetch(
+            conn.endpoint,
+            conn.token,
+            'session-decline',
+            { op: 'switch', name: 'DECLINE_TARGET' },
+            controlInvocationId
+          )
         )
         const parsed = JSON.parse(r.result ?? '{}')
         // Decline is a STRUCTURED non-error result (HTTP 200), not a thrown error.
@@ -578,6 +631,8 @@ gate('host.agents repl privileged integration', () => {
         child.kill()
       }
     } finally {
+      endInvocation()
+      conn.release()
       await declineRpc.close()
     }
   })
@@ -612,13 +667,26 @@ gate('host.agents repl privileged integration', () => {
       }),
       { token: 'decline-del-token', agentsService: composed.agentsService }
     )
-    const conn = await declineRpc.ensureStarted()
+    const conn = await declineRpc.issueControlConnection(
+      'session-decline-del',
+      'default-project',
+      'root-frame-session-decline-del'
+    )
+    const controlInvocationId = 'decline-delete-tool'
+    const endInvocation = conn.beginControlInvocation({
+      turnId: 'decline-delete-turn',
+      controlInvocationGeneration: 1,
+      toolInvocationId: controlInvocationId
+    })
     try {
-      const { child, send } = startLoop({
-        OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
-        OPEN_SCIENCE_MCP_RPC_TOKEN: conn.token,
-        OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-decline-del'
-      })
+      const { child, send } = startLoop(
+        {
+          OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
+          OPEN_SCIENCE_MCP_RPC_TOKEN: conn.token,
+          OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-decline-del'
+        },
+        controlInvocationId
+      )
       try {
         const created = JSON.parse(
           (await send("return JSON.stringify(await host.agents.create({ name: 'DECLINE_DEL' }))"))
@@ -626,11 +694,17 @@ gate('host.agents repl privileged integration', () => {
         )
         const beforeInvalidated = composed.invalidateCount()
         const r = await send(
-          agentsCallFetch(conn.endpoint, conn.token, 'session-decline-del', {
-            op: 'delete',
-            name: 'DECLINE_DEL',
-            revision: created.revision
-          })
+          agentsCallFetch(
+            conn.endpoint,
+            conn.token,
+            'session-decline-del',
+            {
+              op: 'delete',
+              name: 'DECLINE_DEL',
+              revision: created.revision
+            },
+            controlInvocationId
+          )
         )
         const parsed = JSON.parse(r.result ?? '{}')
         expect(parsed.ok).toBe(true)
@@ -648,6 +722,8 @@ gate('host.agents repl privileged integration', () => {
         child.kill()
       }
     } finally {
+      endInvocation()
+      conn.release()
       await declineRpc.close()
     }
   })
@@ -700,7 +776,11 @@ gate('host.agents repl privileged integration', () => {
       }),
       { token: 'no-approval-upd-token', agentsService: composed.agentsService }
     )
-    const conn = await declineRpc.ensureStarted()
+    const conn = await declineRpc.issueControlConnection(
+      'session-no-approval-upd',
+      'default-project',
+      'root-frame-session-no-approval-upd'
+    )
     try {
       const { child, send } = startLoop({
         OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
@@ -728,6 +808,7 @@ gate('host.agents repl privileged integration', () => {
         child.kill()
       }
     } finally {
+      conn.release()
       await declineRpc.close()
     }
   })
@@ -761,20 +842,36 @@ gate('host.agents repl privileged integration', () => {
       }),
       { token: 'no-retry-token', agentsService: composed.agentsService }
     )
-    const conn = await declineRpc.ensureStarted()
+    const conn = await declineRpc.issueControlConnection(
+      'session-no-retry',
+      'default-project',
+      'root-frame-session-no-retry'
+    )
+    const controlInvocationId = 'no-retry-tool'
+    const endInvocation = conn.beginControlInvocation({
+      turnId: 'no-retry-turn',
+      controlInvocationGeneration: 1,
+      toolInvocationId: controlInvocationId
+    })
     try {
-      const { child, send } = startLoop({
-        OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
-        OPEN_SCIENCE_MCP_RPC_TOKEN: conn.token,
-        OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-no-retry'
-      })
+      const { child, send } = startLoop(
+        {
+          OPEN_SCIENCE_MCP_RPC_ENDPOINT: conn.endpoint,
+          OPEN_SCIENCE_MCP_RPC_TOKEN: conn.token,
+          OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-no-retry'
+        },
+        controlInvocationId
+      )
       try {
         await send("return JSON.stringify(await host.agents.create({ name: 'NO_RETRY_T' }))")
         await send(
-          agentsCallFetch(conn.endpoint, conn.token, 'session-no-retry', {
-            op: 'switch',
-            name: 'NO_RETRY_T'
-          })
+          agentsCallFetch(
+            conn.endpoint,
+            conn.token,
+            'session-no-retry',
+            { op: 'switch', name: 'NO_RETRY_T' },
+            controlInvocationId
+          )
         )
         // Exactly one decision, never retried.
         expect(decide).toHaveBeenCalledTimes(1)
@@ -782,6 +879,8 @@ gate('host.agents repl privileged integration', () => {
         child.kill()
       }
     } finally {
+      endInvocation()
+      conn.release()
       await declineRpc.close()
     }
   })

--- a/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
+++ b/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
@@ -122,6 +122,7 @@ gate('host.agents repl runtime whitelist consumption', () => {
   let token: string
   let profileStorage: string
   let runtimeStorage: string
+  let releaseControl: (() => void) | undefined
 
   beforeAll(async () => {
     profileStorage = await mkdtemp(join(tmpdir(), 'os-agents-rt-profile-'))
@@ -150,12 +151,14 @@ gate('host.agents repl runtime whitelist consumption', () => {
       token: 'integration-token',
       agentsService
     })
-    const connection = await rpcServer.ensureStarted()
+    const connection = await rpcServer.issueControlConnection('runtime-session', 'default-project')
     endpoint = connection.endpoint
     token = connection.token
+    releaseControl = connection.release
   })
 
   afterAll(async () => {
+    releaseControl?.()
     await rpcServer?.close()
     await rm(profileStorage, { recursive: true, force: true })
     await rm(runtimeStorage, { recursive: true, force: true })
@@ -256,7 +259,7 @@ gate('host.agents repl runtime whitelist consumption', () => {
           )
         ).result ?? '{}'
       )
-      // Read-back resolved the connector reference to the stable id 'cust-1'.
+      // Read-back preserves the exact stable connector id.
       expect(created.selectedCapabilities.connectorIds).toEqual(['cust-1'])
       // The Connector gate consumes the post-write config: the provisioned `mcp-cust-1` connector
       // skill is allowed, any other connector is filtered out.

--- a/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
+++ b/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
@@ -151,7 +151,11 @@ gate('host.agents repl runtime whitelist consumption', () => {
       token: 'integration-token',
       agentsService
     })
-    const connection = await rpcServer.issueControlConnection('runtime-session', 'default-project')
+    const connection = await rpcServer.issueControlConnection(
+      'runtime-session',
+      'default-project',
+      'root-frame-runtime-session'
+    )
     endpoint = connection.endpoint
     token = connection.token
     releaseControl = connection.release

--- a/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
+++ b/src/main/agents/agents-repl.runtime-consumption.integration.test.ts
@@ -259,19 +259,19 @@ gate('host.agents repl runtime whitelist consumption', () => {
       const created = JSON.parse(
         (
           await send(
-            "return JSON.stringify(await host.agents.create({ name: 'CONN_SET', connectorNames: ['cust-1'] }))"
+            "return JSON.stringify(await host.agents.create({ name: 'CONN_SET', connectorNames: ['my-server'] }))"
           )
         ).result ?? '{}'
       )
-      // Read-back preserves the exact stable connector id.
-      expect(created.selectedCapabilities.connectorIds).toEqual(['cust-1'])
-      // The Connector gate consumes the post-write config: the provisioned `mcp-cust-1` connector
+      // Read-back resolves the immutable connector name to its public stable id.
+      expect(created.selectedCapabilities.connectorIds).toEqual(['my-server'])
+      // The Connector gate consumes the post-write config: the provisioned `mcp-my-server` connector
       // skill is allowed, any other connector is filtered out.
       const allowed = filterSpecialistConnectorSkills(
-        ['mcp-cust-1', 'mcp-other'],
+        ['mcp-my-server', 'mcp-other'],
         asProfile(created)
       )
-      expect(allowed).toEqual(['mcp-cust-1'])
+      expect(allowed).toEqual(['mcp-my-server'])
     })
   })
 

--- a/src/main/agents/customize/skill-creator-package.test.ts
+++ b/src/main/agents/customize/skill-creator-package.test.ts
@@ -52,11 +52,13 @@ describe('skill-creator bundled package', () => {
     const skill = await readFile(join(skillRoot, 'SKILL.md'), 'utf8')
     expect(skill).toContain('JavaScript control-plane REPL')
     expect(skill).toContain('host.skills.validate(')
+    expect(skill).toContain('host.agents.attachSkill(')
     expect(skill).toContain('references/schemas.md')
     expect(skill).toContain('agents/grader.md')
     expect(skill).toContain('eval-viewer/generate-review.js')
     expect(skill).not.toMatch(/python -m|\.py\b/)
     expect(skill).not.toMatch(/await host\.skills\.\w+\([^)]*=/)
+    expect(skill).not.toContain('host.agents.attach_skill(')
 
     const triggerReview = await readFile(join(skillRoot, 'assets', 'eval_review.html'), 'utf8')
     expect(triggerReview).toContain('schema_version: 1')

--- a/src/main/agents/customize/workflow.test.ts
+++ b/src/main/agents/customize/workflow.test.ts
@@ -158,10 +158,22 @@ describe('customize Skill: bundled source', () => {
       'host.agents.switch(',
       'host.agents.delete(',
       'host.agents.listSkills(',
-      'host.agents.listConnectors('
+      'host.agents.listConnectors(',
+      'host.agents.attachSkill(',
+      'host.agents.detachSkill(',
+      'host.agents.attachConnector(',
+      'host.agents.detachConnector('
     ]) {
       expect(raw).toContain(method)
     }
+    expect(raw).toContain('systemPrompt')
+    expect(raw).toContain('iconKey')
+    expect(raw).toContain('colorKey')
+    expect(raw).toContain('skillNames')
+    expect(raw).toContain('connectorNames')
+    expect(raw).not.toMatch(
+      /host\.agents\.(?:list_skills|list_connectors|attach_skill|detach_skill|attach_connector|detach_connector)|\b(?:system_prompt|icon_key|color_key|skill_names|connector_names)\b/
+    )
   })
 
   it('routes Skill requests to the internal native Skill Creator without using Artifacts', async () => {

--- a/src/main/compute/agent-no-list-jobs.test.ts
+++ b/src/main/compute/agent-no-list-jobs.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 // Regression guard (design.md §9): the agent-facing repl kernel must NOT expose a
 // "list jobs" or "list_jobs" method. Only the renderer IPC surface (`compute:jobs:list`)
 // is allowed to enumerate session jobs — the agent side only knows about handle-based
-// queries (`attach_job(jobId).status()`).
+// queries (`attachJob(jobId).status()`).
 //
 // If this test fails, a "list_jobs" method has been added to the repl kernel, which
 // would break the agent/renderer surface separation required by design.md §9.
@@ -28,9 +28,9 @@ describe('agent repl — no list_jobs method (design.md §9 regression guard)', 
     expect(replLoop).not.toMatch(/op:\s*['"]jobs_list['"]/)
   })
 
-  it('only has attach_job for per-job handle queries', () => {
-    // attach_job should exist (the allowed handle-query path).
-    expect(replLoop).toContain('attach_job')
+  it('only has attachJob for per-job handle queries', () => {
+    // attachJob should exist (the allowed handle-query path).
+    expect(replLoop).toContain('attachJob')
     // job_status op is the allowed DB read-only query.
     expect(replLoop).toContain("op: 'job_status'")
   })

--- a/src/main/compute/skill-doc.test.ts
+++ b/src/main/compute/skill-doc.test.ts
@@ -62,6 +62,48 @@ const writeCanonicalDocument = async (skillsDir: string): Promise<void> => {
 }
 
 describe('syncComputeSkillDoc', () => {
+  it('documents only camelCase compute calls and inputs while preserving return fields', async () => {
+    const doc = await readFile(
+      join(__dirname, '..', '..', '..', 'resources', 'skills', 'remote-compute-ssh', 'SKILL.md'),
+      'utf8'
+    )
+
+    for (const name of [
+      'listCompute',
+      'callCommand',
+      'submitJob',
+      'attachJob',
+      'setConcurrencyLimit',
+      'loginShell',
+      'timeoutSeconds',
+      'oldText',
+      'dstFilename',
+      'remotePath',
+      'maxFileMb',
+      'maxTotalMb'
+    ]) {
+      expect(doc).toContain(name)
+    }
+    expect(doc).toContain('job.job_id')
+    expect(doc).toContain('r.featured_files')
+    expect(doc).not.toMatch(
+      /\b(?:list_compute|call_command|submit_job|attach_job|set_concurrency_limit|login_shell|timeout_seconds|old_text|dst_filename|remote_path|max_file_mb|max_total_mb)\b/
+    )
+  })
+
+  it('keeps bundled model-compute examples on the camelCase contract', async () => {
+    const skillsRoot = join(__dirname, '..', '..', '..', 'resources', 'skills')
+    for (const skillId of ['borzoi', 'evo2', 'fair-esm2', 'scgpt']) {
+      const doc = await readFile(join(skillsRoot, skillId, 'SKILL.md'), 'utf8')
+      expect(doc).toContain('submitJob')
+      expect(doc).toContain('dstFilename')
+      expect(doc).toContain('timeoutSeconds')
+      expect(doc).toContain('attachJob')
+      expect(doc).toContain('job_id')
+      expect(doc).not.toMatch(/\b(?:submit_job|dst_filename|timeout_seconds|attach_job)\b/)
+    }
+  })
+
   it('updates the one canonical document with the current host projection', async () => {
     const root = await mkdtemp(join(tmpdir(), 'compute-skill-doc-'))
     roots.push(root)

--- a/src/main/notebook/host-artifacts-service.ts
+++ b/src/main/notebook/host-artifacts-service.ts
@@ -253,7 +253,7 @@ class HostArtifactsService {
 
   async resolvePath(versionIdValue: unknown, context: HostArtifactReadContext): Promise<string> {
     if (typeof versionIdValue !== 'string' || !versionIdValue || versionIdValue.length > 512) {
-      throw new Error('host.artifact_path version_id must be a non-empty string.')
+      throw new Error('host.artifactPath versionId must be a non-empty string.')
     }
     const [item] = await this.catalog.readHostArtifactCatalog({
       projectId: context.projectId,

--- a/src/main/notebook/host-compute.integration.test.ts
+++ b/src/main/notebook/host-compute.integration.test.ts
@@ -15,25 +15,31 @@ const REPL_LOOP = join(__dirname, '../../../resources/notebook/repl_loop.js')
 const makeExecutor = (): NotebookKernelExecutor =>
   new NotebookKernelExecutor({ replLoopPath: REPL_LOOP })
 
-// Minimal stub computeCall RPC endpoint that captures the last params and returns a fixed ExecResult,
-// mirroring the main-process ComputeService's call_command result shape.
+// Minimal stub computeCall RPC endpoint that captures params and returns representative unchanged
+// snake_case result projections.
 const startStub = async (): Promise<{
   endpoint: string
   close: () => void
-  received: () => { params?: Record<string, unknown> }
+  received: () => Array<{ params?: Record<string, unknown> }>
 }> => {
   const { createServer } = await import('node:http')
-  let last: { params?: Record<string, unknown> } = {}
+  const requests: Array<{ params?: Record<string, unknown> }> = []
   const server = createServer((req, res) => {
     let body = ''
     req.on('data', (c) => (body += c))
     req.on('end', () => {
-      last = body ? JSON.parse(body) : {}
-      res
-        .writeHead(200, { 'content-type': 'application/json' })
-        .end(
-          JSON.stringify({ result: { exit_code: 0, stdout: 'ok', stderr: '', truncated: false } })
-        )
+      const request = body ? JSON.parse(body) : {}
+      requests.push(request)
+      const op = request.params?.op
+      const result =
+        op === 'submit_job'
+          ? { job_id: 'job-1', provider_id: 'ssh:x', status: 'submitted' }
+          : op === 'list_compute'
+            ? ['ssh:x']
+            : op === 'details'
+              ? { doc: 'details', is_skeleton: false }
+              : { exit_code: 0, stdout: 'ok', stderr: '', truncated: false }
+      res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify({ result }))
     })
   })
   await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
@@ -41,7 +47,7 @@ const startStub = async (): Promise<{
   return {
     endpoint: `http://127.0.0.1:${addr.port}`,
     close: () => server.close(),
-    received: () => last
+    received: () => requests
   }
 }
 
@@ -66,12 +72,12 @@ const baseRequest = (
 })
 
 gate('repl kernel host.compute', () => {
-  it('call_command posts to the computeCall RPC endpoint and returns the ExecResult', async () => {
+  it('callCommand posts unchanged call_command wire params and returns the ExecResult', async () => {
     const stub = await startStub()
     const exec = makeExecutor()
     const result = await exec.execute(
       baseRequest({
-        code: "const r = await host.compute.create('ssh:x').call_command('id','probe'); console.log(r.stdout)",
+        code: "const r = await host.compute.create('ssh:x').callCommand('id', 'probe', { loginShell: false, timeoutSeconds: 30 }); console.log(JSON.stringify(r))",
         mcpRpcEndpoint: stub.endpoint,
         mcpRpcToken: 'tok'
       })
@@ -80,8 +86,13 @@ gate('repl kernel host.compute', () => {
     stub.close()
     expect(result.status).toBe('completed')
     expect(result.stdout).toContain('ok')
-    expect(stub.received().params?.op).toBe('call_command')
-    expect(stub.received().params?.provider_id).toBe('ssh:x')
+    expect(result.stdout).toContain('"exit_code":0')
+    expect(stub.received()[0]?.params).toMatchObject({
+      op: 'call_command',
+      provider_id: 'ssh:x',
+      login_shell: false,
+      timeout_seconds: 30
+    })
   })
 
   it('forwards the request session/project identity into the call_command payload (buildEnv)', async () => {
@@ -89,7 +100,7 @@ gate('repl kernel host.compute', () => {
     const exec = makeExecutor()
     const result = await exec.execute(
       baseRequest({
-        code: "await host.compute.create('ssh:x').call_command('id','probe'); console.log('done')",
+        code: "await host.compute.create('ssh:x').callCommand('id','probe'); console.log('done')",
         mcpRpcEndpoint: stub.endpoint,
         mcpRpcToken: 'tok',
         sessionId: 'session-7',
@@ -99,7 +110,102 @@ gate('repl kernel host.compute', () => {
     await exec.shutdown()
     stub.close()
     expect(result.status).toBe('completed')
-    expect(stub.received().params?.session_id).toBe('session-7')
-    expect(stub.received().params?.project_id).toBe('proj-x')
+    expect(stub.received()[0]?.params?.session_id).toBe('session-7')
+    expect(stub.received()[0]?.params?.project_id).toBe('proj-x')
+  })
+
+  it('maps listCompute, details, submitJob, attachJob, and setConcurrencyLimit to unchanged wire params', async () => {
+    const stub = await startStub()
+    const exec = makeExecutor()
+    const result = await exec.execute(
+      baseRequest({
+        code:
+          "const c = host.compute.create('ssh:x'); " +
+          'await host.compute.listCompute(); ' +
+          "await host.compute.details('ssh:x', { mode: 'replace', text: 'new', oldText: 'old' }); " +
+          "const job = await c.submitJob('analyze', 'run', { timeoutSeconds: 60, " +
+          "inputs: [{ src: 'in.dat', dstFilename: 'input.dat' }, { remotePath: '/remote/ref.dat', dstFilename: 'ref.dat' }], " +
+          "outputs: ['*.csv'], harvest: { exclude: ['tmp/**'], maxFileMb: 10, maxTotalMb: 20 } }); " +
+          'await c.attachJob(job.job_id).status(); await c.attachJob(job.job_id).result(); ' +
+          'await c.setConcurrencyLimit(2); console.log(JSON.stringify(job))',
+        mcpRpcEndpoint: stub.endpoint,
+        mcpRpcToken: 'tok',
+        sessionId: 'session-7',
+        projectName: 'proj-x'
+      })
+    )
+    await exec.shutdown()
+    stub.close()
+
+    expect(result.status).toBe('completed')
+    expect(result.stdout).toContain('"job_id":"job-1"')
+    expect(stub.received().map((request) => request.params)).toEqual([
+      { op: 'list_compute', session_id: 'session-7' },
+      {
+        op: 'details',
+        provider_id: 'ssh:x',
+        mode: 'replace',
+        text: 'new',
+        old_text: 'old'
+      },
+      {
+        op: 'submit_job',
+        provider_id: 'ssh:x',
+        intent: 'analyze',
+        command: 'run',
+        inputs: [
+          { src: 'in.dat', dst_filename: 'input.dat' },
+          { remote_path: '/remote/ref.dat', dst_filename: 'ref.dat' }
+        ],
+        outputs: ['*.csv'],
+        timeout_seconds: 60,
+        harvest: { exclude: ['tmp/**'], max_file_mb: 10, max_total_mb: 20 },
+        session_id: 'session-7',
+        project_id: 'proj-x',
+        workspace_cwd: process.cwd()
+      },
+      { op: 'job_status', job_id: 'job-1' },
+      { op: 'job_result', job_id: 'job-1' },
+      { op: 'set_concurrency_limit', session_id: 'session-7', limit: 2 }
+    ])
+  })
+
+  it('rejects every old compute input key before RPC', async () => {
+    const stub = await startStub()
+    const exec = makeExecutor()
+    const result = await exec.execute(
+      baseRequest({
+        code:
+          "const c = host.compute.create('ssh:x'); const errors = []; " +
+          'for (const call of [' +
+          "() => c.callCommand('id', 'probe', { login_shell: true }), " +
+          "() => c.callCommand('id', 'probe', { timeout_seconds: 1 }), " +
+          "() => host.compute.details('ssh:x', { old_text: 'old' }), " +
+          "() => c.submitJob('i', 'c', { timeout_seconds: 1 }), " +
+          "() => c.submitJob('i', 'c', { inputs: [{ src: 'a', dst_filename: 'a' }] }), " +
+          "() => c.submitJob('i', 'c', { inputs: [{ remote_path: '/a' }] }), " +
+          "() => c.submitJob('i', 'c', { harvest: { max_file_mb: 1 } }), " +
+          "() => c.submitJob('i', 'c', { harvest: { max_total_mb: 1 } })]) " +
+          '{ try { await call() } catch (error) { errors.push(error.message) } } ' +
+          'console.log(JSON.stringify(errors))',
+        mcpRpcEndpoint: stub.endpoint,
+        mcpRpcToken: 'tok'
+      })
+    )
+    await exec.shutdown()
+    stub.close()
+
+    expect(result.status).toBe('completed')
+    expect(JSON.parse(result.stdout.trim())).toEqual([
+      'host.compute.callCommand options unknown option: login_shell',
+      'host.compute.callCommand options unknown option: timeout_seconds',
+      'host.compute.details options unknown option: old_text',
+      'host.compute.submitJob options unknown option: timeout_seconds',
+      'host.compute.submitJob input unknown option: dst_filename',
+      'host.compute.submitJob input unknown option: remote_path',
+      'host.compute.submitJob harvest unknown option: max_file_mb',
+      'host.compute.submitJob harvest unknown option: max_total_mb'
+    ])
+    expect(stub.received()).toEqual([])
   })
 })

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -57,6 +57,58 @@ const startLoop = (
 }
 
 describe('repl_loop local RPC transport', () => {
+  it('exposes only the camelCase public method names', async () => {
+    const { child, send } = startLoop({})
+    try {
+      const result = await send(
+        "const c = host.compute.create('ssh:x'); " +
+          'return JSON.stringify({' +
+          "artifactPath: 'artifactPath' in host, artifact_path: 'artifact_path' in host, " +
+          "listSkills: 'listSkills' in host.agents, list_skills: 'list_skills' in host.agents, " +
+          "listConnectors: 'listConnectors' in host.agents, list_connectors: 'list_connectors' in host.agents, " +
+          "attachSkill: 'attachSkill' in host.agents, attach_skill: 'attach_skill' in host.agents, " +
+          "detachSkill: 'detachSkill' in host.agents, detach_skill: 'detach_skill' in host.agents, " +
+          "attachConnector: 'attachConnector' in host.agents, attach_connector: 'attach_connector' in host.agents, " +
+          "detachConnector: 'detachConnector' in host.agents, detach_connector: 'detach_connector' in host.agents, " +
+          "listCompute: 'listCompute' in host.compute, list_compute: 'list_compute' in host.compute, " +
+          "callCommand: 'callCommand' in c, call_command: 'call_command' in c, " +
+          "submitJob: 'submitJob' in c, submit_job: 'submit_job' in c, " +
+          "attachJob: 'attachJob' in c, attach_job: 'attach_job' in c, " +
+          "setConcurrencyLimit: 'setConcurrencyLimit' in c, set_concurrency_limit: 'set_concurrency_limit' in c" +
+          '})'
+      )
+      expect(result.error).toBeNull()
+      expect(JSON.parse(result.result ?? '{}')).toEqual({
+        artifactPath: true,
+        artifact_path: false,
+        listSkills: true,
+        list_skills: false,
+        listConnectors: true,
+        list_connectors: false,
+        attachSkill: true,
+        attach_skill: false,
+        detachSkill: true,
+        detach_skill: false,
+        attachConnector: true,
+        attach_connector: false,
+        detachConnector: true,
+        detach_connector: false,
+        listCompute: true,
+        list_compute: false,
+        callCommand: true,
+        call_command: false,
+        submitJob: true,
+        submit_job: false,
+        attachJob: true,
+        attach_job: false,
+        setConcurrencyLimit: true,
+        set_concurrency_limit: false
+      })
+    } finally {
+      child.kill()
+    }
+  })
+
   it('echoes a trailing expression when the call spans multiple lines', async () => {
     const { child, send } = startLoop({})
 
@@ -1070,8 +1122,8 @@ describe('repl_loop local RPC transport', () => {
 
     try {
       const projection = await send(
-        "const first = await host.lineage.graph('artifact-v1', { max_depth: 0 }); " +
-          "const second = await host.lineage.graph('artifact-v1', { max_depth: 0 }); " +
+        "const first = await host.lineage.graph('artifact-v1', { direction: 'down', maxDepth: 0, maxNodes: 5 }); " +
+          "const second = await host.lineage.graph('artifact-v1', { direction: 'down', maxDepth: 0, maxNodes: 5 }); " +
           "const core = await host.lineage.get('artifact-v1'); " +
           'return JSON.stringify({ firstFrozen: Object.isFrozen(first), ' +
           'nodesFrozen: Object.isFrozen(first.nodes), nodeFrozen: Object.isFrozen(first.nodes[0]), ' +
@@ -1081,7 +1133,8 @@ describe('repl_loop local RPC transport', () => {
           'packagesFrozen: Object.isFrozen(core.environment.packages), ' +
           'packageFrozen: Object.isFrozen(core.environment.packages[0]), ' +
           'opLogFrozen: Object.isFrozen(core.environment.op_log), ' +
-          'attemptFrozen: Object.isFrozen(core.environment.op_log[0].attempts[0]) })'
+          'attemptFrozen: Object.isFrozen(core.environment.op_log[0].attempts[0]), ' +
+          'returnFields: [first.root_version_id, first.nodes[0].version_id, core.version_id] })'
       )
       expect(projection.error).toBeNull()
       expect(JSON.parse(projection.result ?? '{}')).toEqual({
@@ -1096,16 +1149,25 @@ describe('repl_loop local RPC transport', () => {
         packagesFrozen: true,
         packageFrozen: true,
         opLogFrozen: true,
-        attemptFrozen: true
+        attemptFrozen: true,
+        returnFields: ['artifact-v1', 'artifact-v1', 'artifact-v1']
       })
       expect(requests).toEqual([
         {
           method: 'lineageCall',
-          params: { op: 'graph', version_id: 'artifact-v1', options: { max_depth: 0 } }
+          params: {
+            op: 'graph',
+            version_id: 'artifact-v1',
+            options: { direction: 'down', max_depth: 0, max_nodes: 5 }
+          }
         },
         {
           method: 'lineageCall',
-          params: { op: 'graph', version_id: 'artifact-v1', options: { max_depth: 0 } }
+          params: {
+            op: 'graph',
+            version_id: 'artifact-v1',
+            options: { direction: 'down', max_depth: 0, max_nodes: 5 }
+          }
         },
         { method: 'lineageCall', params: { op: 'get', version_id: 'artifact-v1' } }
       ])
@@ -1114,7 +1176,19 @@ describe('repl_loop local RPC transport', () => {
         "try { await host.lineage.get('artifact-v1', {}); return 'no error' } " +
           "catch (error) { return error.name + ': ' + error.message }"
       )
-      expect(extraArgument.result).toBe('TypeError: host.lineage.get accepts one version_id')
+      expect(extraArgument.result).toBe('TypeError: host.lineage.get accepts one versionId')
+      expect(requests).toHaveLength(3)
+
+      const oldOptions = await send(
+        "const errors = []; for (const [key, value] of [['max_depth', 0], ['max_nodes', 5]]) { " +
+          "try { await host.lineage.graph('artifact-v1', { [key]: value }) } " +
+          "catch (error) { errors.push(error.name + ': ' + error.message) } } " +
+          'return JSON.stringify(errors)'
+      )
+      expect(JSON.parse(oldOptions.result ?? '[]')).toEqual([
+        'TypeError: host.lineage.graph options unknown option: max_depth',
+        'TypeError: host.lineage.graph options unknown option: max_nodes'
+      ])
       expect(requests).toHaveLength(3)
 
       const invalidProjection = await send(
@@ -1243,7 +1317,7 @@ describe('repl_loop local RPC transport', () => {
       })
 
       const batch = await send(
-        "const value = await host.llm(['a', { prompt: 'b' }], { max_concurrency: 2 }); " +
+        "const value = await host.llm(['a', { prompt: 'b' }], { maxConcurrency: 2 }); " +
           'return JSON.stringify({ value, frozen: Object.isFrozen(value), itemFrozen: value.every(Object.isFrozen) })'
       )
       expect(batch.error).toBeNull()
@@ -1264,7 +1338,7 @@ describe('repl_loop local RPC transport', () => {
       ])
 
       const invalidOptions = await send(
-        "try { await host.llm('single', { max_concurrency: 2 }); return 'no error' } " +
+        "try { await host.llm('single', { maxConcurrency: 2 }); return 'no error' } " +
           "catch (error) { return error.name + ': ' + error.message }"
       )
       expect(invalidOptions.result).toBe(
@@ -1282,11 +1356,20 @@ describe('repl_loop local RPC transport', () => {
       expect(requests).toHaveLength(2)
 
       const invalidBatchOptions = await send(
-        "try { await host.llm(['x'], { max_concurrency: 2, extra: undefined }); return 'no error' } " +
+        "try { await host.llm(['x'], { maxConcurrency: 2, extra: undefined }); return 'no error' } " +
           "catch (error) { return error.name + ': ' + error.message }"
       )
       expect(invalidBatchOptions.result).toBe(
-        'TypeError: host.llm batch options only accept max_concurrency.'
+        'TypeError: host.llm batch options unknown option: extra'
+      )
+      expect(requests).toHaveLength(2)
+
+      const oldBatchOption = await send(
+        "try { await host.llm(['x'], { max_concurrency: 2 }); return 'no error' } " +
+          "catch (error) { return error.name + ': ' + error.message }"
+      )
+      expect(oldBatchOption.result).toBe(
+        'TypeError: host.llm batch options unknown option: max_concurrency'
       )
       expect(requests).toHaveLength(2)
 
@@ -1320,12 +1403,12 @@ describe('repl_loop local RPC transport', () => {
       })
 
       const throwingOptionsAccessor = await send(
-        "const options = {}; Object.defineProperty(options, 'max_concurrency', { get() { throw new Error('raw getter detail') } }); " +
+        "const options = {}; Object.defineProperty(options, 'maxConcurrency', { get() { throw new TypeError('unknown option: raw getter detail') } }); " +
           "try { await host.llm(['x'], options); return 'no error' } " +
           "catch (error) { return error.name + ': ' + error.message }"
       )
       expect(throwingOptionsAccessor.result).toBe(
-        'TypeError: host.llm batch options only accept max_concurrency.'
+        'TypeError: host.llm batch options only accept maxConcurrency.'
       )
       expect(requests).toHaveLength(4)
 
@@ -1348,7 +1431,7 @@ describe('repl_loop local RPC transport', () => {
     }
   }, 60_000)
 
-  it('validates and freezes host.artifacts results and resolves host.artifact_path', async () => {
+  it('validates and freezes host.artifacts results and resolves host.artifactPath', async () => {
     const requests: Array<{ method?: string; params?: Record<string, unknown> }> = []
     const managedPath = join(tmpdir(), 'managed', 'report.pdf')
     const server = createServer((request, response) => {
@@ -1409,26 +1492,58 @@ describe('repl_loop local RPC transport', () => {
 
     try {
       const projection = await send(
-        "const page = await host.artifacts({ search: 'report', limit: 2 }); " +
-          'const localPath = await host.artifact_path(page.artifacts[1].latest_version_id); ' +
+        "const page = await host.artifacts({ search: 'report', sessionId: 'session-a', contentType: 'text/csv', limit: 2 }); " +
+          "await host.artifacts({ versionId: 'artifact-version-1' }); " +
+          'const localPath = await host.artifactPath(page.artifacts[1].latest_version_id); ' +
           'return JSON.stringify({ page, localPath, pageFrozen: Object.isFrozen(page), ' +
           'artifactsFrozen: Object.isFrozen(page.artifacts), itemFrozen: Object.isFrozen(page.artifacts[0]) })'
       )
       expect(projection.error).toBeNull()
-      expect(JSON.parse(projection.result ?? '{}')).toMatchObject({
-        page: { count: 2, project_id: 'project-a', truncated: false },
+      const projected = JSON.parse(projection.result ?? '{}')
+      expect(projected).toMatchObject({
+        page: {
+          count: 2,
+          project_id: 'project-a',
+          truncated: false
+        },
         localPath: managedPath,
         pageFrozen: true,
         artifactsFrozen: true,
         itemFrozen: true
       })
+      expect(projected.page.artifacts[0].latest_version_id).toBe('artifact-version-1')
       expect(requests).toEqual([
         {
           method: 'artifactsCall',
-          params: { op: 'list', options: { search: 'report', limit: 2 } }
+          params: {
+            op: 'list',
+            options: {
+              search: 'report',
+              session_id: 'session-a',
+              content_type: 'text/csv',
+              limit: 2
+            }
+          }
+        },
+        {
+          method: 'artifactsCall',
+          params: { op: 'list', options: { version_id: 'artifact-version-1' } }
         },
         { method: 'artifactsCall', params: { op: 'path', version_id: 'upload-version-1' } }
       ])
+
+      const oldOptions = await send(
+        "const errors = []; for (const [key, value] of [['version_id', 'artifact-version-1'], ['session_id', 'session-a'], ['content_type', 'text/csv']]) { " +
+          'try { await host.artifacts({ [key]: value }) } ' +
+          "catch (error) { errors.push(error.name + ': ' + error.message) } } " +
+          'return JSON.stringify(errors)'
+      )
+      expect(JSON.parse(oldOptions.result ?? '[]')).toEqual([
+        'TypeError: host.artifacts options unknown option: version_id',
+        'TypeError: host.artifacts options unknown option: session_id',
+        'TypeError: host.artifacts options unknown option: content_type'
+      ])
+      expect(requests).toHaveLength(3)
     } finally {
       child.kill()
       await new Promise<void>((resolve, reject) =>
@@ -1536,8 +1651,8 @@ describe('repl_loop local RPC transport', () => {
 
     try {
       const projection = await send(
-        "const page = await host.frames.list({ search: 'research' }); " +
-          "const detail = await host.frames.get('frame-1', { branch_id: 'branch-1' }); " +
+        "const page = await host.frames.list({ search: 'research', sessionId: 'session-a', rootsOnly: false }); " +
+          "const detail = await host.frames.get('frame-1', { sessionId: 'session-a', branchId: 'branch-1' }); " +
           'return JSON.stringify({ page, detail, pageFrozen: Object.isFrozen(page), ' +
           'framesFrozen: Object.isFrozen(page.frames), frameFrozen: Object.isFrozen(page.frames[0]), ' +
           'detailFrozen: Object.isFrozen(detail), transcriptFrozen: Object.isFrozen(detail.transcript), ' +
@@ -1573,13 +1688,37 @@ describe('repl_loop local RPC transport', () => {
       expect(requests).toEqual([
         {
           method: 'framesCall',
-          params: { op: 'list', options: { search: 'research' } }
+          params: {
+            op: 'list',
+            options: { search: 'research', session_id: 'session-a', roots_only: false }
+          }
         },
         {
           method: 'framesCall',
-          params: { op: 'get', frame_id: 'frame-1', options: { branch_id: 'branch-1' } }
+          params: {
+            op: 'get',
+            frame_id: 'frame-1',
+            options: { session_id: 'session-a', branch_id: 'branch-1' }
+          }
         }
       ])
+
+      const oldOptions = await send(
+        'const errors = []; for (const call of [' +
+          "() => host.frames.list({ session_id: 'session-a' }), " +
+          '() => host.frames.list({ roots_only: false }), ' +
+          "() => host.frames.get('frame-1', { session_id: 'session-a' }), " +
+          "() => host.frames.get('frame-1', { branch_id: 'branch-1' })]) { " +
+          "try { await call() } catch (error) { errors.push(error.name + ': ' + error.message) } } " +
+          'return JSON.stringify(errors)'
+      )
+      expect(JSON.parse(oldOptions.result ?? '[]')).toEqual([
+        'TypeError: host.frames.list options unknown option: session_id',
+        'TypeError: host.frames.list options unknown option: roots_only',
+        'TypeError: host.frames.get options unknown option: session_id',
+        'TypeError: host.frames.get options unknown option: branch_id'
+      ])
+      expect(requests).toHaveLength(2)
 
       const invalid = await send(
         "try { await host.frames.list(); return 'no error' } " +
@@ -2026,7 +2165,7 @@ gate('repl_loop.js host.compute', () => {
     }
   }, 60_000)
 
-  it('create().call_command() posts op=call_command with defaults and returns the ExecResult', async () => {
+  it('create().callCommand() posts op=call_command with defaults and returns the ExecResult', async () => {
     next = {
       status: 200,
       body: { result: { exit_code: 0, stdout: 'hi', stderr: '', truncated: false } }
@@ -2037,7 +2176,7 @@ gate('repl_loop.js host.compute', () => {
     })
     try {
       const r = await send(
-        "const c = host.compute.create('ssh:biowulf'); const res = await c.call_command('echo hi', 'probe'); return res.stdout"
+        "const c = host.compute.create('ssh:biowulf'); const res = await c.callCommand('echo hi', 'probe'); return res.stdout"
       )
       expect(r.error).toBeNull()
       expect(r.result).toContain('hi')
@@ -2045,7 +2184,7 @@ gate('repl_loop.js host.compute', () => {
       expect(received.params?.provider_id).toBe('ssh:biowulf')
       expect(received.params?.cmd).toBe('echo hi')
       expect(received.params?.intent).toBe('probe')
-      // login_shell defaults to true; timeout_seconds omitted -> the service applies its own default.
+      // Public loginShell defaults to true; omitted timeoutSeconds stays omitted on the wire.
       expect(received.params?.login_shell).toBe(true)
       expect(received.params?.timeout_seconds).toBeUndefined()
     } finally {
@@ -2072,7 +2211,7 @@ gate('repl_loop.js host.compute', () => {
     try {
       const r = await send(
         "const c = host.compute.create('ssh:x');\n" +
-          'try { await c.call_command("id", "probe") }\n' +
+          'try { await c.callCommand("id", "probe") }\n' +
           'catch (e) { return JSON.stringify({ code: e.error_code, retry: e.retry_after_user_action, msg: e.message }) }'
       )
       expect(r.error).toBeNull()
@@ -2085,7 +2224,7 @@ gate('repl_loop.js host.compute', () => {
     }
   }, 60_000)
 
-  it('details() posts op=details with mode/text/old_text and returns the result', async () => {
+  it('details() maps public oldText to wire old_text and returns the result', async () => {
     next = { status: 200, body: { result: { doc: 'the doc', isSkeleton: false } } }
     const { child, send } = startLoop({
       OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
@@ -2102,10 +2241,10 @@ gate('repl_loop.js host.compute', () => {
       expect(received.params?.provider_id).toBe('ssh:biowulf')
       expect(received.params?.mode).toBe('read')
 
-      // replace: text + old_text are forwarded (snake_case matches the RPC contract).
+      // Public oldText maps immediately to the unchanged snake_case RPC field.
       next = { status: 200, body: { result: { ok: true } } }
       const replace = await send(
-        "await host.compute.details('ssh:biowulf', { mode: 'replace', text: 'new', old_text: 'old' }); return 'done'"
+        "await host.compute.details('ssh:biowulf', { mode: 'replace', text: 'new', oldText: 'old' }); return 'done'"
       )
       expect(replace.error).toBeNull()
       expect(received.params?.mode).toBe('replace')
@@ -2116,7 +2255,7 @@ gate('repl_loop.js host.compute', () => {
     }
   }, 60_000)
 
-  it('threads session/project identity from the spawn env into the call_command payload', async () => {
+  it('threads session/project identity from the spawn env into the callCommand payload', async () => {
     next = {
       status: 200,
       body: { result: { exit_code: 0, stdout: '', stderr: '', truncated: false } }
@@ -2129,7 +2268,7 @@ gate('repl_loop.js host.compute', () => {
     })
     try {
       const r = await send(
-        "await host.compute.create('ssh:biowulf').call_command('id', 'probe'); return 'ok'"
+        "await host.compute.create('ssh:biowulf').callCommand('id', 'probe'); return 'ok'"
       )
       expect(r.error).toBeNull()
       expect(received.params?.session_id).toBe('session-42')
@@ -2157,7 +2296,7 @@ gate('repl_loop.js host.compute', () => {
     }
   }, 60_000)
 
-  it('create().set_concurrency_limit(k) posts op=set_concurrency_limit with session_id and limit', async () => {
+  it('create().setConcurrencyLimit(k) posts op=set_concurrency_limit with session_id and limit', async () => {
     next = { status: 200, body: { result: null } }
     const { child, send } = startLoop({
       OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
@@ -2166,7 +2305,7 @@ gate('repl_loop.js host.compute', () => {
     })
     try {
       const r = await send(
-        "const c = host.compute.create('ssh:biowulf'); await c.set_concurrency_limit(5); return 'ok'"
+        "const c = host.compute.create('ssh:biowulf'); await c.setConcurrencyLimit(5); return 'ok'"
       )
       expect(r.error).toBeNull()
       expect(r.result).toContain('ok')
@@ -2178,7 +2317,7 @@ gate('repl_loop.js host.compute', () => {
     }
   }, 60_000)
 
-  it('create().set_concurrency_limit() validates that k is a positive integer', async () => {
+  it('create().setConcurrencyLimit() validates that k is a positive integer', async () => {
     const { child, send } = startLoop({
       OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
       OPEN_SCIENCE_MCP_RPC_TOKEN: 'tok',
@@ -2187,19 +2326,19 @@ gate('repl_loop.js host.compute', () => {
     try {
       // Negative number should throw
       const r1 = await send(
-        "const c = host.compute.create('ssh:biowulf'); try { await c.set_concurrency_limit(-1); return 'bad' } catch (e) { return e.message }"
+        "const c = host.compute.create('ssh:biowulf'); try { await c.setConcurrencyLimit(-1); return 'bad' } catch (e) { return e.message }"
       )
       expect(r1.result).toContain('positive integer')
 
       // Zero should throw
       const r2 = await send(
-        "const c2 = host.compute.create('ssh:biowulf'); try { await c2.set_concurrency_limit(0); return 'bad' } catch (e) { return e.message }"
+        "const c2 = host.compute.create('ssh:biowulf'); try { await c2.setConcurrencyLimit(0); return 'bad' } catch (e) { return e.message }"
       )
       expect(r2.result).toContain('positive integer')
 
       // Float should throw
       const r3 = await send(
-        "const c3 = host.compute.create('ssh:biowulf'); try { await c3.set_concurrency_limit(2.5); return 'bad' } catch (e) { return e.message }"
+        "const c3 = host.compute.create('ssh:biowulf'); try { await c3.setConcurrencyLimit(2.5); return 'bad' } catch (e) { return e.message }"
       )
       expect(r3.result).toContain('positive integer')
     } finally {

--- a/src/main/skills/self-awareness-skill.test.ts
+++ b/src/main/skills/self-awareness-skill.test.ts
@@ -42,7 +42,7 @@ describe('self-awareness bundled Skill', () => {
       'caps.artifacts === true',
       'caps.frames === true',
       'await host.artifacts(options)',
-      'await host.artifact_path',
+      'await host.artifactPath',
       'await host.frames.list(options)',
       'await host.frames.get(frameId, options)',
       'current Project',
@@ -58,6 +58,13 @@ describe('self-awareness bundled Skill', () => {
       'await host.llm',
       'await host.lineage.graph(versionId)',
       'await host.lineage.get(versionId)',
+      '`versionId`',
+      '`sessionId`',
+      '`contentType`',
+      '`maxDepth`',
+      '`maxNodes`',
+      '`rootsOnly`',
+      '`branchId`',
       'graph discovery',
       'session-bound control token',
       'another Session',
@@ -68,6 +75,9 @@ describe('self-awareness bundled Skill', () => {
     ]) {
       expect(body).toContain(phrase)
     }
+    expect(body).not.toMatch(
+      /host\.artifact_path|`(?:version_id|session_id|content_type|max_depth|max_nodes|roots_only|branch_id)`/
+    )
     expect(body).not.toMatch(/host\.(query|artifact_read)/)
   })
 })

--- a/src/renderer/src/lib/compute/job-analysis-trigger.test.ts
+++ b/src/renderer/src/lib/compute/job-analysis-trigger.test.ts
@@ -56,7 +56,8 @@ describe('buildAnalysisPrompt', () => {
     const prompt = buildAnalysisPrompt([job])
     expect(prompt).toContain('job-abc')
     expect(prompt).toContain('hpc/job-abc/featured/out.txt')
-    expect(prompt).toContain('attach_job')
+    expect(prompt).toContain('attachJob')
+    expect(prompt).not.toContain('attach_job')
     expect(prompt).toContain('result()')
   })
 

--- a/src/renderer/src/lib/compute/job-analysis-trigger.ts
+++ b/src/renderer/src/lib/compute/job-analysis-trigger.ts
@@ -39,7 +39,7 @@ export const buildAnalysisPrompt = (jobs: JobSummary[]): string => {
 
     lines.push('')
     lines.push(
-      `Please use \`attach_job("${job.job_id}").result()\` to retrieve the full result dictionary, ` +
+      `Please use \`attachJob("${job.job_id}").result()\` to retrieve the full result dictionary, ` +
         `examine the output files, and call \`write_artifact_file\` to publish any results worth preserving.`
     )
 


### PR DESCRIPTION
## Problem

The public Host JavaScript surface mixed camelCase with snake_case method names and caller-supplied option keys. This made JavaScript examples inconsistent and exposed internal RPC spellings at the public adapter seam.

## Proposed change

- Rename the approved public Host JavaScript methods and caller input keys to camelCase.
- Remove former public snake_case properties and reject former input keys; no aliases or dual spelling remain.
- Translate camelCase inputs immediately in `repl_loop.js` to the unchanged snake_case RPC operations and wire parameters.
- Update bundled runtime Skills, examples, narrow Host-facing fakes/workflows, and their content/integration tests.
- Preserve the latest `main` resource-identity contract: immutable invocation `name`, mutable `displayName`, and camelCase Agents read-backs.
- Keep all other returned objects structurally unchanged, including snake_case fields such as `latest_version_id` and `job_id`.

## Scope and non-goals

- This is an intentional breaking JavaScript API migration.
- RPC method names, `op` values, wire params, persisted records, database/Prisma contracts, shared renderer models, status/error-code strings, and return projections are unchanged.
- The fourth `host.mcp` compatibility argument is unchanged.
- No renderer UI, architecture, data-model, or data-relationship changes are included.
- The ignored `docs/internal` design plan is not included in the commit or PR.

## Acceptance criteria and validation

The branch was rebased onto `origin/main` at `c06c87c8` and validated at head `348e5638`. Conflict resolution preserves the latest resource-identity and delegated-control capability behavior while retaining the strict camelCase Host adapter.

- Behavior: public camelCase methods/keys map to unchanged RPC payloads; old properties are absent; old keys fail before RPC; return shapes remain on the latest `main` contract.
  - Command: `RUN_KERNEL=1 npm test -- src/main/notebook/repl-loop.integration.test.ts src/main/notebook/host-compute.integration.test.ts src/main/notebook/host-artifacts-service.test.ts src/main/agents/agents-repl.integration.test.ts src/main/agents/agents-repl.mutations.integration.test.ts src/main/agents/agents-repl.runtime-consumption.integration.test.ts src/main/agents/agents-repl.privileged.integration.test.ts src/main/host-sdk/help.test.ts src/main/compute/agent-no-list-jobs.test.ts src/main/compute/skill-doc.test.ts src/main/skills/self-awareness-skill.test.ts src/main/agents/customize/workflow.test.ts src/main/agents/customize/skill-creator-package.test.ts src/renderer/src/lib/compute/job-analysis-trigger.test.ts`
  - Result: 14 test files passed; 183 tests passed.
- Behavior: Node and renderer TypeScript consumers remain compatible.
  - Command: `npm run typecheck`
  - Result: Node and web typechecks passed.
- Behavior: source and test lint contract remains satisfied.
  - Command: `npm run lint`
  - Result: passed with 0 errors; 13 existing `main` warnings.
- Behavior: touched Skill documents and adjusted test fixtures satisfy full-file formatting.
  - Command: `npx prettier --check` over all touched Skill documents and rebase-adjusted Agents tests.
  - Result: all checked files passed.
- Behavior: cross-module portable regressions remain green, including the newly rebased delegation/resource-identity code.
  - Command: `npm test -- --maxWorkers=8`
  - Result: 986 test files passed; 14,315 tests passed; 15 files / 198 tests intentionally skipped.
- Behavior: the exact final diff has an independent contract/test-impact review.
  - Result: no actionable findings after adding `display_name` rejection coverage and aligning the privileged REPL fixtures with session/frame/control-invocation capabilities.

The full portable suite is included because the public adapter crosses Notebook, Agents, Compute, bundled Skill consumers, and the latest delegated-control seam. CI remains authoritative for platform packaging and UI E2E lanes. No known functional risk remains beyond the explicitly approved public history break.

## Review focus

- Confirm the public seam contains only the new camelCase names.
- Confirm each adapter mapping preserves the existing RPC operation/wire spelling and the latest `main` return shape.
- Confirm bundled examples call camelCase inputs while continuing to access intentionally snake_case return fields.
- Confirm the diff does not expand into database, Prisma, renderer UI/shared contracts, persisted formats, or `docs/internal`.

## Breaking change

`host.artifactPath`, the renamed `host.agents` and `host.compute` methods, and all listed camelCase input keys are now required. Former snake_case public spellings have been removed.
