### PR TITLE
ci(notarize): install dependencies before macOS package smoke

### DIFF
--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -100,6 +100,12 @@ jobs:
         with:
           node-version: 22
 
+      # The notarize smoke test imports database-migration-ledger-smoke.mjs, which requires
+      # @prisma/client at runtime. Install dependencies so the smoke script can resolve them.
+      - name: Install dependencies
+        if: steps.gate.outputs.enabled == 'true'
+        run: npm ci
+
       # Call path (from_run): pull this run's signed artifacts for the arch (uploaded by build.yml).
       - name: Download signed mac artifact (from this run)
         if: steps.gate.outputs.enabled == 'true' && inputs.from_run


### PR DESCRIPTION
## Problem

The v0.13.1 release notarize jobs (both arm64 and x64) fail at the "Smoke test final macOS packages" step:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@prisma/client' imported from
scripts/database-migration-ledger-smoke.mjs
```

The notarize job checks out the repo and sets up Node, but never runs `npm ci`. PR #1077 (part of this release) added `database-migration-ledger-smoke.mjs` imports to `macos-package-smoke.mjs`, which requires `@prisma/client` at runtime. The build jobs already run `npm ci` before their smoke tests; the notarize job does not.

## Proposed change

Add an `npm ci` step to the notarize job, after Node setup and before artifact download, gated on `steps.gate.outputs.enabled == 'true'` to match the surrounding steps.

## Scope and non-goals

- **In scope:** `.github/workflows/notarize-mac.yml` only — one step added.
- **Non-goals:** no changes to the smoke script, migration code, or build workflow.

## Historical compatibility

No historical data concern. This only adds a dependency-install step to a CI workflow.

## Review focus

The step placement (after Node setup, before artifact download) ensures `@prisma/client` is available when the smoke test runs. The `npm ci` postinstall (prisma generate + electron-builder install-app-deps) is the same pattern the build jobs already use.
