### PR TITLE
ci(release): lower macOS runner version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,14 @@
 name: Build
 
-# Reusable build workflow: packages the app for macOS (arm64 + x64) and Linux, each on its own
-# native runner, and uploads the installers as pipeline artifacts. Called by release.yml (stable,
+# Reusable build workflow: packages the app for macOS (arm64 + x64), Linux, and Windows, and uploads
+# the installers as pipeline artifacts. Called by release.yml (stable,
 # on tag) and nightly.yml (rolling prerelease, on push to main) so the build matrix lives in one
 # place. Publishing is done by the caller, not here.
 #
 # `npm ci` on each runner installs the native binaries it needs (claude-agent-sdk optional package,
-# Prisma query engine). macOS uses native ARM64 and Intel macOS 26 runners so packaged-app
-# certification does not execute across architectures and Xcode 26 can compile the Icon Composer
-# asset; Linux runs on ubuntu-latest and Windows x64 on windows-latest.
+# Prisma query engine). Both macOS packages use the more available ARM64 macOS 15 runners; the x64
+# lane rebuilds its native addon for Intel and validates under Rosetta. Xcode 26 still compiles the
+# Icon Composer asset; Linux runs on ubuntu-latest and Windows x64 on windows-latest.
 on:
   workflow_call:
     inputs:
@@ -79,16 +79,18 @@ jobs:
       - id: set
         shell: bash
         run: |
-          # Run each macOS package on its native macOS 26 architecture so P0, visual, and package
-          # smoke can execute the produced app while Xcode 26 compiles build/icon.icon. Windows'
+          # Build both macOS packages on ARM64 macOS 15 runners so neither lane waits for scarce
+          # macOS 26 or Intel capacity. The x64 lane cross-rebuilds native dependencies and installs
+          # Rosetta for its package smoke. The job still selects Xcode 26 below so actool can compile
+          # build/icon.icon. Windows'
           # engine is query_engine-windows.dll.node (no `lib`
           # prefix, .dll.node not .so/.dylib). engine_keep = substring of the engine file to keep.
           # subdir/bin_os/bin_arch drive the notebook runtime staging step: `subdir` is the conda
           # platform whose micromamba + offline bundle to fetch, and bin_os/bin_arch are the
           # resources/bin/<os>/<arch> path electron-builder.yml reads the micromamba binary from.
           mac='[
-            {"name":"macos-arm64","os":"macos-26","platform":"mac","eb_args":"--mac --arm64","engine_keep":"darwin-arm64","subdir":"osx-arm64","bin_os":"mac","bin_arch":"arm64"},
-            {"name":"macos-x64","os":"macos-26-intel","platform":"mac","eb_args":"--mac --x64","engine_keep":"darwin.dylib","subdir":"osx-64","bin_os":"mac","bin_arch":"x64"}
+            {"name":"macos-arm64","os":"macos-15","platform":"mac","eb_args":"--mac --arm64","engine_keep":"darwin-arm64","subdir":"osx-arm64","bin_os":"mac","bin_arch":"arm64"},
+            {"name":"macos-x64","os":"macos-15","platform":"mac","eb_args":"--mac --x64","engine_keep":"darwin.dylib","subdir":"osx-64","bin_os":"mac","bin_arch":"x64"}
           ]'
           rest='[
             {"name":"linux-x64","os":"ubuntu-latest","platform":"linux","eb_args":"--linux","engine_keep":".so.node","subdir":"linux-64","bin_os":"linux","bin_arch":"x64"},
@@ -113,7 +115,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     # Keep native dependencies and packaged binaries compatible with the app's declared macOS 12
-    # minimum even though the native builders run on macOS 26.
+    # minimum even though the native builders select the Xcode 26 toolchain.
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.platform == 'mac' && '12.0' || '' }}
 
@@ -127,12 +129,47 @@ jobs:
           node-version: 22
           cache: npm
 
+      # macOS 15 images include Xcode 26 but default to Xcode 16. Select any installed Xcode 26
+      # before npm ci so native dependencies and the Icon Composer asset use the release toolchain.
+      - name: Select Xcode 26
+        if: ${{ matrix.platform == 'mac' }}
+        shell: bash
+        run: |
+          xcode=$(find /Applications -maxdepth 1 -type d -name 'Xcode_26*.app' -print -quit)
+          if [ -z "$xcode" ]; then
+            echo "::error::Xcode 26 is not installed on this runner"
+            exit 1
+          fi
+          sudo xcode-select --switch "$xcode/Contents/Developer"
+          xcodebuild -version
+
+      # Stable/nightly package smoke executes the Intel Electron app and micromamba on this ARM host.
+      # The notarization dry-run installs Rosetta in its later notarize job before final package smoke.
+      - name: Enable Intel emulation
+        if: ${{ matrix.name == 'macos-x64' && !inputs.skip_verify }}
+        run: sudo softwareupdate --install-rosetta --agree-to-license
+
       # npm ci runs postinstall: prisma generate + electron-builder install-app-deps.
       - name: Install dependencies
         run: npm ci
 
+      # npm ci rebuilds native modules for the ARM host. Rebuild the shipped N-API addon for Intel
+      # before electron-builder copies it into the x64 app, then fail closed on the Mach-O slice.
+      - name: Rebuild Intel native dependencies
+        if: ${{ matrix.name == 'macos-x64' }}
+        shell: bash
+        run: |
+          ./node_modules/.bin/electron-builder install-app-deps --platform darwin --arch x64
+          addon=$(find node_modules/@aipoch/safe-file-publisher-native/build/Release -type f -name '*.node' -print -quit)
+          if [ -z "$addon" ]; then
+            echo "::error::safe-file-publisher native addon was not rebuilt"
+            exit 1
+          fi
+          lipo -verify_arch x86_64 "$addon"
+          lipo -info "$addon"
+
       # electron-builder compiles build/icon.icon with actool. Fail here with a focused diagnostic
-      # instead of much later in packaging if the runner image ever loses its Xcode 26 selection.
+      # instead of much later in packaging if the selected Xcode 26 installation is incomplete.
       - name: Verify Icon Composer build tools
         if: ${{ matrix.platform == 'mac' }}
         run: actool --version
@@ -193,8 +230,8 @@ jobs:
           fi
 
       # electron-builder 26.15.3 creates its temporary keychain with a random password but invokes
-      # `security set-key-partition-list -k` with the P12 password. macOS 26 Intel rejects that
-      # mismatch with SecKeychainUnlock. Import the certificate ourselves with the correct password
+      # `security set-key-partition-list -k` with the P12 password. The temporary keychain can reject
+      # that mismatch with SecKeychainUnlock, so import the certificate with the correct password
       # for each boundary, then give electron-builder only the prepared keychain path.
       - name: Prepare macOS signing keychain
         id: mac_signing
@@ -361,7 +398,7 @@ jobs:
         run: npm run test:e2e:p0
 
       # Visual behavior uses the same renderer bundle on every package. Keep one canonical hard gate
-      # beside P0 instead of multiplying antialiasing and launch variance across four native runners.
+      # beside P0 instead of multiplying antialiasing and launch variance across four packages.
       - name: Run desktop visual regression
         id: visual
         if: >-

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -60,8 +60,8 @@ permissions:
 jobs:
   notarize:
     name: Notarize + staple ${{ matrix.arch }}
-    # The final package smoke launches the stapled app. Keep it architecture-native so the x64
-    # launch is not silently dependent on Rosetta being installed on an Apple Silicon runner.
+    # Both architectures use ARM64 capacity. The x64 lane enables Rosetta before launching the
+    # stapled Intel app and micromamba during final package smoke.
     runs-on: ${{ matrix.os }}
     # Hard ceiling so a stuck notarization can never run forever (see also the wait --timeout below).
     timeout-minutes: 30
@@ -73,7 +73,7 @@ jobs:
           - arch: arm64
             os: macos-15
           - arch: x64
-            os: macos-15-intel
+            os: macos-15
     steps:
       # Notarization is optional: if the API key secret isn't configured, no-op so a tagged release
       # still succeeds with the ad-hoc mac build (today's behavior) instead of failing here. Every
@@ -105,6 +105,12 @@ jobs:
       - name: Install dependencies
         if: steps.gate.outputs.enabled == 'true'
         run: npm ci
+
+      # The x64 artifact was cross-built on ARM and final smoke launches its Intel app and micromamba.
+      # Install Rosetta only when notarization is enabled and those launch checks will run.
+      - name: Enable Intel emulation
+        if: ${{ steps.gate.outputs.enabled == 'true' && matrix.arch == 'x64' }}
+        run: sudo softwareupdate --install-rosetta --agree-to-license
 
       # Call path (from_run): pull this run's signed artifacts for the arch (uploaded by build.yml).
       - name: Download signed mac artifact (from this run)

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -151,6 +151,9 @@ describe('post-merge Windows validation', () => {
     const setup = readWorkflow('build.yml').jobs.setup.steps?.find(({ id }) => id === 'set')
     const job = readWorkflow('build.yml').jobs.build
     const names = job.steps?.map(({ name }) => name) ?? []
+    const selectXcode = findStep(job, 'Select Xcode 26')
+    const buildRosetta = findStep(job, 'Enable Intel emulation')
+    const rebuildIntel = findStep(job, 'Rebuild Intel native dependencies')
     const packaged = findStep(job, 'Resolve packaged Electron executable')
     const p0 = findStep(job, 'Run P0 Electron certification')
     const visual = findStep(job, 'Run desktop visual regression')
@@ -158,15 +161,27 @@ describe('post-merge Windows validation', () => {
     const linux = findStep(job, 'Smoke test Linux packages')
     const evidence = findStep(job, 'Record platform certification evidence')
     const notarize = readWorkflow('notarize-mac.yml').jobs.notarize
+    const notarizeRosetta = findStep(notarize, 'Enable Intel emulation')
     const notarizeDryRun = readWorkflow('notarize-dryrun.yml').jobs.notarize
     const finalMacos = findStep(notarize, 'Smoke test final macOS packages')
     const refreshedMacosEvidence = findStep(notarize, 'Refresh macOS certification evidence')
 
-    expect(setup.run).toContain('"name":"macos-arm64","os":"macos-26"')
-    expect(setup.run).toContain('"name":"macos-x64","os":"macos-26-intel"')
+    expect(setup.run).toContain('"name":"macos-arm64","os":"macos-15"')
+    expect(setup.run).toContain('"name":"macos-x64","os":"macos-15"')
+    expect(selectXcode.if).toBe("${{ matrix.platform == 'mac' }}")
+    expect(selectXcode.run).toContain("-name 'Xcode_26*.app'")
+    expect(selectXcode.run).toContain('xcode-select --switch')
+    expect(selectXcode.run).toContain('xcodebuild -version')
     expect(job.env?.MACOSX_DEPLOYMENT_TARGET).toBe(
       "${{ matrix.platform == 'mac' && '12.0' || '' }}"
     )
+    expect(buildRosetta.if).toBe("${{ matrix.name == 'macos-x64' && !inputs.skip_verify }}")
+    expect(buildRosetta.run).toContain('softwareupdate --install-rosetta --agree-to-license')
+    expect(rebuildIntel.if).toBe("${{ matrix.name == 'macos-x64' }}")
+    expect(rebuildIntel.run).toContain(
+      'electron-builder install-app-deps --platform darwin --arch x64'
+    )
+    expect(rebuildIntel.run).toContain('lipo -verify_arch x86_64')
     expect(packaged.id).toBe('packaged_app')
     expect(packaged.run).toContain('Open Science.app/Contents/MacOS/Open Science')
     expect(packaged.run).toContain('win-unpacked/open-science.exe')
@@ -197,13 +212,17 @@ describe('post-merge Windows validation', () => {
     expect(notarize.strategy?.matrix).toEqual({
       include: [
         { arch: 'arm64', os: 'macos-15' },
-        { arch: 'x64', os: 'macos-15-intel' }
+        { arch: 'x64', os: 'macos-15' }
       ]
     })
     expect(refreshedMacosEvidence.run).toContain('--package-smoke passed')
     expect(refreshedMacosEvidence.run).toContain(
       '--database-migration-certification mac/database-migration-certification.json'
     )
+    expect(notarizeRosetta.if).toBe(
+      "${{ steps.gate.outputs.enabled == 'true' && matrix.arch == 'x64' }}"
+    )
+    expect(notarizeRosetta.run).toContain('softwareupdate --install-rosetta --agree-to-license')
     expect(refreshedMacosEvidence.run).toContain("matrix.arch == 'arm64'")
     expect(refreshedMacosEvidence.if).toContain('inputs.certified_build')
     expect(notarizeDryRun.with?.certified_build).toBe(false)


### PR DESCRIPTION
## Problem

Release and notarization jobs can wait a long time for scarce `macos-26` and `macos-15-intel` hosted runners. The linked release run queued the macOS lane without assigning a runner, which also made the no-publish notarization dry-run slow to start.

## Proposed change

- Run both macOS arm64 and x64 packaging lanes on `macos-15` ARM runners.
- Rebuild `@aipoch/safe-file-publisher-native` for x86_64 before packaging and verify its Mach-O slice with Xcode `lipo`.
- Install Rosetta only where an x64 package or runtime must be smoke-tested on an ARM host.
- Apply the same ARM runner topology to the notarization workflow.
- Use the existing ICNS artwork for the macOS app and DMG. Xcode 26 `actool` from the macOS 15 image crashes while compiling the Icon Composer source package, so keeping adaptive Icon Composer output would still require a macOS 26 runner.
- Allow up to three minutes for the first Rosetta launch of the packaged Intel Electron app and preserve its output on timeout.
- Extend workflow, builder configuration, and macOS package-smoke contracts to lock these requirements down.

## Scope and non-goals

This changes release/notarization workflows, macOS icon packaging configuration, package smoke behavior, and their contract tests. It does not change application source, publishing behavior, signing inputs, or the dry-run no-publish boundary. The committed `build/icon.icon` source remains available for a future precompiled adaptive-icon pipeline, but this PR deliberately does not compile it on macOS 15.

## Acceptance criteria and validation

- Full no-publish notarization dry-run: [run 31564506723](https://github.com/aipoch/open-science/actions/runs/31564506723) — passed.
  - `macos-arm64` build/package/artifact — passed on `macos-15` ARM.
  - `macos-x64` cross-rebuild/build/package/artifact — passed on `macos-15` ARM.
  - arm64 notarization, staple, Gatekeeper/package smoke — passed.
  - x64 notarization, staple, Rosetta/Gatekeeper/package smoke — passed.
  - checksum/publish path — skipped by the dry-run boundary.
- Affected contracts: `vitest run scripts/macos-package-smoke.test.ts scripts/windows-release-workflows.test.ts scripts/electron-builder-config.test.ts` — passed, 22/22.
- Repository lint: `npm run lint` — passed with 15 pre-existing warnings and no errors.
- Diff hygiene: `git diff --check` — passed.
- Earlier local typecheck was blocked by the shared generated Prisma client being older than the checked-in schema (missing `permissionGrantSeed`, `grantedLocalRoot`, and `agentContext`). GitHub PR static checks passed.
- Earlier local full test run had Windows environment/schema failures; GitHub PR module tests, macOS tests, Windows core, and static checks passed on the branch.

## Review focus

Please focus on the x64 native dependency rebuild, Rosetta gating/startup allowance, the deliberate ICNS fallback, and keeping both macOS architectures off Intel/macOS 26 runners without weakening the dry-run publish guard.