### PR TITLE
feat(workspace): add new conversation shortcut

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -651,6 +651,51 @@ describe('WorkspacePage draft preservation', () => {
     expect(conversationProps.draftDoc).toEqual(textDoc('draft for new conversation'))
   })
 
+  it.each([
+    ['Cmd+N on macOS', 'darwin', { metaKey: true }],
+    ['Ctrl+N on Windows', 'win32', { ctrlKey: true }]
+  ])('opens a new conversation with %s', async (_label, platform, modifiers) => {
+    window.api = { ...window.api, platform } as never
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === 'sess-a'
+          ? { ...session, messages: [userMessage('prompt', 'existing conversation')] }
+          : session
+      )
+    }))
+    await renderPage()
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'n',
+      bubbles: true,
+      cancelable: true,
+      ...modifiers
+    })
+    await act(async () => window.dispatchEvent(event))
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
+  })
+
+  it('keeps the draft when the current conversation has no messages', async () => {
+    await renderPage()
+    await act(async () => {
+      conversationProps.onDraftDocChange(textDoc('unsent draft'))
+    })
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'n',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    await act(async () => window.dispatchEvent(event))
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(useSessionStore.getState().selectedSessionId).toBe('sess-a')
+    expect(conversationProps.draftDoc).toEqual(textDoc('unsent draft'))
+  })
+
   it('preserves a skill chip as a structured node when switching away and back', async () => {
     await renderPage()
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -68,6 +68,8 @@ type WorkspacePageProps = {
 
 // New-conversation drafts are project-scoped so switching projects never leaks unsent intent.
 const newConversationDraftKeyFor = (projectId: string): string => `new:${projectId}`
+const OPEN_DIALOG_SELECTOR =
+  '[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"])'
 
 // Renders the workspace shell and bridges the chat surface to the session store.
 const WorkspacePage = ({
@@ -721,7 +723,7 @@ const WorkspacePage = ({
   }, [activeSessionId])
 
   // Keeps New as a local draft reset after persistence hydration has selected restored sessions.
-  const openNewConversation = (): void => {
+  const openNewConversation = useCallback((): void => {
     if (!isSessionPersistenceReady) return
 
     // The draft effect saves the outgoing doc/attachments and restores the new-conversation state.
@@ -732,7 +734,38 @@ const WorkspacePage = ({
     useNavigationStore.getState().recordUserNavigation()
     sessionController.actions.resetNewConversationSpecialist()
     clearSelection()
-  }
+  }, [
+    clearSelection,
+    defaultPermissionProfile,
+    isSessionPersistenceReady,
+    sessionController.actions,
+    setAttachmentError
+  ])
+
+  useEffect(() => {
+    const openNewConversationFromShortcut = (event: KeyboardEvent): void => {
+      const isMac = window.api?.platform === 'darwin'
+      if (
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.repeat ||
+        event.key.toLowerCase() !== 'n' ||
+        event.altKey ||
+        event.shiftKey ||
+        !(isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey) ||
+        document.querySelector(OPEN_DIALOG_SELECTOR) !== null
+      ) {
+        return
+      }
+
+      event.preventDefault()
+      if (!activeSession || activeSession.messages.length === 0) return
+      openNewConversation()
+    }
+
+    window.addEventListener('keydown', openNewConversationFromShortcut)
+    return () => window.removeEventListener('keydown', openNewConversationFromShortcut)
+  }, [activeSession, openNewConversation])
 
   // Synchronizes the hidden chat session id with the selected session list item.
   const openSession = (sessionId: string): void => {


### PR DESCRIPTION
## Problem

Starting a fresh conversation requires clicking the workspace sidebar even though this is a frequent keyboard workflow.

## Proposed change

- Handle `Cmd+N` on macOS and `Ctrl+N` on Windows/Linux in the workspace.
- Reuse the existing New-conversation transition when the visible session already has messages.
- Consume the shortcut without switching when the current conversation has no messages, preserving its unsent draft.
- Ignore composing, repeated, modified, already-handled, and modal-covered key events.

## Scope and non-goals

- Renderer-only change in `WorkspacePage` plus focused coverage.
- No session persistence, schema, data relationship, ACP, or runtime changes.
- No historical-data compatibility handling is required because no persisted format changes.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- New-conversation shortcut and empty-conversation draft preservation -> `npm test -- src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx` -> 33 passed.
- Workspace owner and contract impact set -> `npm run test:module -- workspace_page` -> 23 files, 379 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Repository lint -> `npm run lint` -> passed with 13 pre-existing warnings outside the changed files and no errors.

Platform coverage: macOS `Meta+N` and Windows `Control+N` are exercised directly. Linux shares the non-macOS `Control+N` path and is not duplicated locally. Packaged OS-level shortcut behavior is left to CI; no local packaged E2E lane was run.

## Review focus

- Platform-specific modifier filtering.
- The no-message guard that preserves the current draft.
- Suppression while a dialog is open.
