### PR TITLE
fix(preview): register managed scheme before window

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -298,6 +298,7 @@ class ElectronAppHarness implements ElectronApp {
               key: string
               model: string
               name: string
+              supportsImageInput: true
               type: 'custom'
             }) => Promise<{ providers: Array<{ id: string; name: string }> }>
           }
@@ -309,7 +310,8 @@ class ElectronAppHarness implements ElectronApp {
         apiEndpoints: ['openai'],
         baseUrl: 'http://127.0.0.1:9/v1',
         model: 'e2e-model',
-        key: 'e2e-key'
+        key: 'e2e-key',
+        supportsImageInput: true
       })
       const provider = snapshot.providers.find((item) => item.name === providerName)
       if (!provider) throw new Error('The E2E provider was not persisted.')

--- a/e2e/workspace-files.spec.ts
+++ b/e2e/workspace-files.spec.ts
@@ -5,6 +5,11 @@ import { test } from './fixtures/electron-app'
 const PROJECT_NAME = 'Project files journey'
 const FILE_NAME = 'research-notes.md'
 const FILE_CONTENT = '# Fixture findings\n\nDeterministic preview content.'
+const IMAGE_NAME = 'preview.png'
+const IMAGE_CONTENT = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+  'base64'
+)
 
 const createProject = async (page: Page): Promise<void> => {
   await page.getByRole('button', { name: 'New project' }).click()
@@ -40,4 +45,27 @@ test('uploads an attachment and previews it from Project files', async ({ app })
   await expect(preview.getByText('Deterministic preview content.', { exact: true })).toBeVisible()
   await preview.getByRole('button', { name: `Close preview of ${FILE_NAME}` }).click()
   await expect(preview).toBeHidden()
+})
+
+test('loads managed image previews from Project files', async ({ app }) => {
+  let page = await app.completeOnboarding()
+  page = await app.configureFakeAgent()
+  await createProject(page)
+
+  await page.locator('input[type="file"][multiple]').setInputFiles({
+    name: IMAGE_NAME,
+    mimeType: 'image/png',
+    buffer: IMAGE_CONTENT
+  })
+  await expect(page.getByRole('button', { name: `Remove attachment ${IMAGE_NAME}` })).toBeVisible()
+  await page.getByRole('textbox', { name: 'Ask anything' }).fill('Use the attached image.')
+  await page.getByRole('button', { name: 'Send message' }).click()
+  await expect(page.getByText('Deterministic reply:', { exact: false })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Files', exact: true }).click()
+  const image = page.getByRole('img', { name: `Preview of ${IMAGE_NAME}` })
+  await expect(image).toBeVisible()
+  await expect
+    .poll(() => image.evaluate((element) => (element as HTMLImageElement).naturalWidth))
+    .toBeGreaterThan(0)
 })

--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -53,7 +53,7 @@ describe('production application command wiring', () => {
     const sharedOwners = [
       [
         'managedPreviewOwners',
-        'installManagedPreviewElectronAdapter(previewResources, undefined, managedPreviewOwners)',
+        'installManagedPreviewElectronAdapter( previewResources, managedPreviewProtocol, managedPreviewOwners )',
         'managedPreview: managedPreviewOwners'
       ],
       [

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,8 @@
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 
-// Only lightweight, Electron-free diagnostics and argv flags are imported statically here. The MCP
-// server modules (and their heavy SDK graph) remain lazy inside the matching execution branch.
+// Only lightweight, Electron-free bootstrap modules are imported statically here. The MCP server
+// modules (and their heavy SDK graph) remain lazy inside the matching execution branch.
 import {
   ARTIFACT_MCP_SERVER_ARG,
   NOTEBOOK_MCP_SERVER_ARG,
@@ -17,6 +18,8 @@ import {
   reportApplicationStartupFailure
 } from './diagnostics/startup'
 import { createLogger, diagnosticErrorFields, flushLogs } from './logger'
+import { MANAGED_PREVIEW_SCHEME } from './managed-preview-resources'
+import { OFFICE_PREVIEW_RUNTIME_SCHEME_CONFIG } from './office-preview/office-preview-runtime-protocol'
 import {
   createRendererFailureReporter,
   registerRendererDiagnosticsIpc
@@ -84,7 +87,14 @@ if (shouldRunArtifactMcpServer) {
 // Boots the Electron app only in normal UI mode, keeping artifact MCP mode free of Electron imports.
 async function startElectronApp(mainEntryPath: string): Promise<void> {
   const { app, BrowserWindow, crashReporter, ipcMain, nativeImage, nativeTheme, protocol } =
-    await import('electron')
+    createRequire(import.meta.url)('electron') as typeof import('electron')
+
+  // Electron accepts privileged schemes only before app ready. Keep this in the synchronous UI
+  // bootstrap before any awaited import can yield to the ready event.
+  protocol.registerSchemesAsPrivileged([
+    MANAGED_PREVIEW_SCHEME,
+    OFFICE_PREVIEW_RUNTIME_SCHEME_CONFIG
+  ])
 
   // Establish identity and single-writer ownership before opening main.log. A secondary launch must
   // never rotate or append to the primary process's file sink. These two modules are lightweight; all
@@ -211,9 +221,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       startupDiagnostics?.phase('load-application-modules')
       const [
         { registerIpcHandlers },
+        { createManagedPreviewProtocolBridge },
         { configureMainWindow, createMainWindow },
-        { MANAGED_PREVIEW_SCHEME },
-        { OFFICE_PREVIEW_RUNTIME_SCHEME_CONFIG },
         { installMigrationQuitGuard, isMigrationInProgress },
         { createAppTray, setTrayIconVariant },
         { installAppLifecycle },
@@ -236,9 +245,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { resolveStorageRoot }
       ] = await Promise.all([
         import('./ipc'),
+        import('./managed-preview-protocol'),
         import('./windows'),
-        import('./managed-preview-resources'),
-        import('./office-preview/office-preview-runtime-protocol'),
         import('./storage/migration-state'),
         import('./tray'),
         import('./app-lifecycle'),
@@ -261,14 +269,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./storage-root')
       ])
 
-      protocol.registerSchemesAsPrivileged([
-        MANAGED_PREVIEW_SCHEME,
-        OFFICE_PREVIEW_RUNTIME_SCHEME_CONFIG
-      ])
-
       startupDiagnostics?.phase('electron-ready')
       await app.whenReady()
       startupDiagnostics?.phase('prepare-shell')
+      const managedPreviewProtocolBridge = createManagedPreviewProtocolBridge(protocol)
 
       // Set app user model id for windows
       electronApp.setAppUserModelId(APP_USER_MODEL_ID)
@@ -368,6 +372,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           dispose: disposeApplicationRuntime
         } = await registerIpcHandlers({
           mainEntryPath,
+          managedPreviewProtocol: managedPreviewProtocolBridge.registrar,
           handoffRuntime: 'production',
           headless: webMode.headless,
           onAppIconVariantChanged: (variant) => {
@@ -485,12 +490,14 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           databaseStartupOwner,
           databaseStartupQuitGuard,
           disposeIpcHandlerRegistry: () => {
+            managedPreviewProtocolBridge.dispose()
             disposeDatabaseStartupIpc()
             disposeIpcHandlerRegistry()
           }
         }
       } catch (error) {
         databaseStartupQuitGuard.dispose()
+        managedPreviewProtocolBridge.dispose()
         disposeDatabaseStartupIpc()
         if (startupWindow && !startupWindow.isDestroyed()) startupWindow.destroy()
         app.quit()

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -102,6 +102,7 @@ import {
   installManagedPreviewElectronAdapter
 } from './managed-preview-ipc'
 import { ManagedPreviewResources } from './managed-preview-resources'
+import type { PreviewProtocolRegistrar } from './managed-preview-protocol'
 import type { ManagedPreviewSource } from '../shared/preview-resources'
 import {
   createOfficePreviewFrameProcessResolver,
@@ -279,6 +280,7 @@ const permissionGrantsLog = createLogger('permission-grants')
 
 type IpcRegistrationOptions = {
   mainEntryPath: string
+  managedPreviewProtocol: PreviewProtocolRegistrar
   // Headless web-serve launches (--serve) have no local desktop user; task notifications are
   // disabled there by contract, not just incidentally via Notification.isSupported().
   headless?: boolean
@@ -335,6 +337,7 @@ const previewArgs = (args: Record<string, unknown>): string => {
 const createApplicationModules = async (
   {
     mainEntryPath,
+    managedPreviewProtocol,
     headless = false,
     onAppIconVariantChanged,
     listAppIconPreviews
@@ -2144,7 +2147,11 @@ const createApplicationModules = async (
     registerRuntimeIpcHandlers(runtimeSelectionWorkflows)
   )
   declareElectronAdapter('managed-preview', () =>
-    installManagedPreviewElectronAdapter(previewResources, undefined, managedPreviewOwners)
+    installManagedPreviewElectronAdapter(
+      previewResources,
+      managedPreviewProtocol,
+      managedPreviewOwners
+    )
   )
   declareElectronAdapter('office-preview-runtime', () =>
     registerOfficePreviewRuntimeProtocol(

--- a/src/main/managed-preview-protocol.test.ts
+++ b/src/main/managed-preview-protocol.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ManagedPreviewResources } from './managed-preview-resources'
 import {
+  createManagedPreviewProtocolBridge,
   createManagedPreviewProtocolHandler,
   registerManagedPreviewProtocol
 } from './managed-preview-protocol'
@@ -19,6 +20,44 @@ describe('managed preview protocol', () => {
 
     expect(targetProtocol.handle).toHaveBeenCalledWith('open-science-preview', expect.any(Function))
     unregister()
+    expect(targetProtocol.unhandle).toHaveBeenCalledWith('open-science-preview')
+  })
+
+  it('installs a stable session route before the resource handler is available', async () => {
+    let sessionHandler: ((request: Request) => Promise<Response> | Response) | undefined
+    const targetProtocol = {
+      handle: vi.fn((_scheme: string, handler: typeof sessionHandler) => {
+        sessionHandler = handler
+      }),
+      unhandle: vi.fn()
+    }
+    const bridge = createManagedPreviewProtocolBridge(targetProtocol)
+    const resources = {
+      resolveProtocolResource: vi.fn().mockResolvedValue({
+        filePath: '/managed/plot.png',
+        mimeType: 'image/png'
+      })
+    } as unknown as ManagedPreviewResources
+    const fetchFile = vi.fn().mockResolvedValue(new Response('image', { status: 200 }))
+
+    expect(targetProtocol.handle).toHaveBeenCalledWith('open-science-preview', expect.any(Function))
+    expect(
+      (await sessionHandler!(new Request('open-science-preview://resource-1/plot.png'))).status
+    ).toBe(404)
+
+    bridge.registrar.handle(
+      'open-science-preview',
+      createManagedPreviewProtocolHandler(resources, fetchFile)
+    )
+    expect(
+      (await sessionHandler!(new Request('open-science-preview://resource-1/plot.png'))).status
+    ).toBe(200)
+
+    bridge.registrar.unhandle('open-science-preview')
+    expect(
+      (await sessionHandler!(new Request('open-science-preview://resource-1/plot.png'))).status
+    ).toBe(404)
+    bridge.dispose()
     expect(targetProtocol.unhandle).toHaveBeenCalledWith('open-science-preview')
   })
 

--- a/src/main/managed-preview-protocol.ts
+++ b/src/main/managed-preview-protocol.ts
@@ -23,6 +23,10 @@ const HTML_PREVIEW_CSP = [
 
 type FetchManagedFile = (filePath: string, request: Request) => Promise<Response>
 type PreviewProtocolRegistrar = Pick<typeof protocol, 'handle' | 'unhandle'>
+type ManagedPreviewProtocolBridge = {
+  readonly registrar: PreviewProtocolRegistrar
+  dispose(): void
+}
 type ManagedPreviewProtocolOptions = {
   isResourceAllowed?: (resourceId: string) => boolean
 }
@@ -200,5 +204,54 @@ const registerManagedPreviewProtocol = (
   return () => targetProtocol.unhandle(PREVIEW_SCHEME)
 }
 
-export { createManagedPreviewProtocolHandler, registerManagedPreviewProtocol }
-export type { FetchManagedFile, ManagedPreviewProtocolOptions, PreviewProtocolRegistrar }
+const createManagedPreviewProtocolBridge = (
+  targetProtocol: PreviewProtocolRegistrar
+): ManagedPreviewProtocolBridge => {
+  type ProtocolHandler = Parameters<PreviewProtocolRegistrar['handle']>[1]
+  let delegate: ProtocolHandler | undefined
+  let disposed = false
+
+  targetProtocol.handle(PREVIEW_SCHEME, (request) => {
+    const handler = delegate
+    return handler ? handler(request) : createLoadErrorResponse()
+  })
+
+  const assertScheme = (scheme: string): void => {
+    if (scheme !== PREVIEW_SCHEME) {
+      throw new Error(`Managed preview bridge cannot register scheme: ${scheme}`)
+    }
+    if (disposed) throw new Error('Managed preview protocol bridge is disposed.')
+  }
+
+  return {
+    registrar: {
+      handle: (scheme, handler) => {
+        assertScheme(scheme)
+        if (delegate) throw new Error('Managed preview protocol handler is already registered.')
+        delegate = handler
+      },
+      unhandle: (scheme) => {
+        assertScheme(scheme)
+        delegate = undefined
+      }
+    },
+    dispose: () => {
+      if (disposed) return
+      delegate = undefined
+      targetProtocol.unhandle(PREVIEW_SCHEME)
+      disposed = true
+    }
+  }
+}
+
+export {
+  createManagedPreviewProtocolBridge,
+  createManagedPreviewProtocolHandler,
+  registerManagedPreviewProtocol
+}
+export type {
+  FetchManagedFile,
+  ManagedPreviewProtocolBridge,
+  ManagedPreviewProtocolOptions,
+  PreviewProtocolRegistrar
+}


### PR DESCRIPTION
## Problem

PR #1077 introduced a database startup window before full runtime adapter composition. The managed preview custom protocol was still installed during the later adapter phase, so the Chromium network context created for that window treated `open-science-preview://` thumbnail URLs as unknown and emitted `net::ERR_UNKNOWN_URL_SCHEME`.

The custom scheme originated in #147; #1077 made the protocol-handler and window ordering regress.

## Proposed change

- register privileged preview and office schemes synchronously before Electron can become ready
- install a stable managed-preview protocol bridge before creating the startup `BrowserWindow`
- bind the application-owned resource handler into that bridge after runtime composition, preserving current ownership and cleanup
- add a real Electron E2E that uploads a PNG and verifies the managed thumbnail decodes

## Scope and non-goals

- No database migration, backfill, or historical artifact compatibility path is required; preview URLs are process-local capability URLs.
- Existing artifact and upload data, path resolution, and persisted formats are unchanged.
- `project-files:get-overview` registration works in fresh startup and restart E2E and the reported error was not reproducible. This PR does not add speculative retries or error suppression for it.
- No user-facing UI changes.

## Acceptance criteria and validation

Final HEAD `e5037cd6701f2c83dc1adbabfad429c9e2dd464e` was checked after the last material edit.

| Behavior / risk | Check | Result |
| --- | --- | --- |
| Stable protocol bridge and deferred binding | targeted Vitest suite | 5 files, 63 tests passed |
| Managed PNG preview through startup window, Project Files IPC, and renderer failure gate | `npm run test:e2e -- e2e/workspace-files.spec.ts` | 2 passed |
| Electron bundle and startup integration | `npm run build:e2e` | passed |
| Node and renderer contracts | `npm run typecheck` | passed |
| Repository lint | `npm run lint` | passed with 0 errors; 13 pre-existing warnings outside changed files |
| Global startup and adapter regression risk | `npm test` | 986 files and 14,316 tests passed; 15 files and 198 tests skipped |

Remaining validation risk: the real Electron regression test ran on the current local OS; cross-platform protocol behavior remains covered by CI platform lanes. The separately reported `project-files:get-overview` log was not independently reproduced.

## Review focus

- the bridge is installed before `createMainWindow`
- delegate binding and cleanup preserve application ownership
- MCP and server modes remain Electron-free because Electron is loaded only in the UI branch
- the E2E exercises actual Chromium custom-scheme resolution rather than only mocking IPC