### PR TITLE
fix(project-files): keep files stable during terminal streaming

### DIFF
--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -494,6 +494,55 @@ describe('ProjectFilesView', () => {
     expect(container.textContent).toContain('No files yet')
   })
 
+  it('keeps the files index stable while terminal output streams', async () => {
+    await renderView([
+      createSession({
+        id: 'session-1',
+        messages: [createMessage({ id: 'prompt-1', role: 'user' })],
+        activeRun: { promptMessageId: 'prompt-1', startedAt: 1710000001000 },
+        artifacts: [
+          {
+            id: 'artifact-1',
+            kind: 'managed-file',
+            path: '/workspace/result.txt',
+            name: 'result.txt'
+          }
+        ]
+      })
+    ])
+    const { useSessionStore } = await import('@/stores/session-store')
+    const getOverview = vi.mocked(window.api.projectFiles.getOverview)
+    const listFiles = vi.mocked(window.api.projectFiles.listFiles)
+    const listArtifactGroups = vi.mocked(window.api.projectFiles.listArtifactGroups)
+    const initialCallCounts = {
+      overview: getOverview.mock.calls.length,
+      files: listFiles.mock.calls.length,
+      groups: listArtifactGroups.mock.calls.length
+    }
+
+    await act(async () => {
+      useSessionStore.getState().upsertToolActivity({
+        sessionId: 'session-1',
+        toolCallId: 'terminal-1',
+        eventId: 'terminal-output-1',
+        title: 'python analysis.py',
+        status: 'in_progress',
+        terminalOutput: 'processing row 1\n'
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect({
+      overview: getOverview.mock.calls.length,
+      files: listFiles.mock.calls.length,
+      groups: listArtifactGroups.mock.calls.length
+    }).toEqual(initialCallCounts)
+    expect(
+      container.querySelector('[aria-label="Preview generated file result.txt"]')
+    ).not.toBeNull()
+  })
+
   it('hides archived session artifacts and their filter option', async () => {
     await renderView([
       createSession({

--- a/src/renderer/src/pages/workspace/project-files-query-model.ts
+++ b/src/renderer/src/pages/workspace/project-files-query-model.ts
@@ -8,6 +8,7 @@ import {
   type RefObject,
   type SetStateAction
 } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 
 import { useSessionStore, type ChatSession } from '@/stores/session-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -207,15 +208,15 @@ const useProjectFilesQueryModel = (activeProjectId: string | undefined): Project
     return () => window.clearTimeout(timer)
   }, [searchQuery])
 
-  const archivedSessionIds = useMemo(
-    () =>
-      allSessions
+  const archivedSessionIds = useSessionStore(
+    useShallow((state) =>
+      state.sessions
         .filter(
           (session) => session.projectId === activeProjectId && session.archivedAt !== undefined
         )
         .map((session) => session.id)
-        .sort(),
-    [activeProjectId, allSessions]
+        .sort()
+    )
   )
   const archivedSessionIdSet = useMemo(() => new Set(archivedSessionIds), [archivedSessionIds])
   const catalogIndex = useProjectFilesIndex(


### PR DESCRIPTION
## Problem

Streaming terminal tool activity updates replace the renderer session array. The Files query model rebuilt an equivalent archived-session ID array on every update, so the Files index treated unchanged filters as a new query, cleared its loaded pages, and repeated overview, file, and artifact-group requests. This caused the visible Files panel to flicker while terminal output streamed.

## Proposed change

- preserve the archived-session ID array identity with the existing Zustand shallow selector until its contents actually change
- add a renderer regression test that streams real `terminalOutput` through the session store and verifies that Files queries and rendered file rows remain stable

## Scope and non-goals

- renderer-only change in the `project_files_view` owner module
- real project switches, archive changes, and `project-files:changed` invalidations continue to refresh the index
- no database, persistence, IPC, API, or managed-file format changes
- no historical-data compatibility path is required

## Acceptance criteria and validation

All checks below ran after the last material edit.

- terminal streaming does not refresh or clear Files -> `npm test -- src/renderer/src/pages/workspace/ProjectFilesView.test.tsx -t "keeps the files index stable while terminal output streams"` -> passed, 1/1
- Project Files owner, contract, and consumer behavior -> `npm run test:module -- project_files_view` -> passed, 152/152 across 6 files
- renderer type safety -> `npm run typecheck:web` -> passed
- source lint -> `npm run lint` -> passed with 0 errors; 13 pre-existing warnings are outside this diff

The selective Test Impact Set is sufficient because `scripts/ci/module-impact.json` identifies both changed files under `project_files_view`, including its declared owner, contract, consumer tests, and `renderer_state` overlay. Full fallback, persistence, migration, ACP framework, and platform lanes are excluded because no shared interface, persistence boundary, protocol, path handling, or platform-specific behavior changed.

Uncovered risk: no manual Electron visual run was performed; the regression test exercises the real Files view plus session-store terminal projection and directly asserts the repeated queries that caused the flicker.

## Review focus

Please verify that shallow equality changes the query identity only when the archived-session ID set changes and that genuine Files invalidation events retain their existing behavior.