### PR TITLE
fix(skills): refresh changed bundled skill content

### DIFF
--- a/resources/skills/manifest.json
+++ b/resources/skills/manifest.json
@@ -113,7 +113,7 @@
       "id": "customize",
       "name": "Customize",
       "source": "featured",
-      "updatedAt": "2026-07-31T00:00:00.000Z"
+      "updatedAt": "2026-08-12T00:00:00.000Z"
     },
     {
       "id": "self-awareness",

--- a/src/main/skills/materializer.test.ts
+++ b/src/main/skills/materializer.test.ts
@@ -80,9 +80,13 @@ describe('ClaudeCodeSkillMaterializer', () => {
     expect(await listSkillDirs(configDir)).toEqual(['os-beta'])
   })
 
-  it('skips re-copying when updatedAt is unchanged and re-copies when it changes', async () => {
+  it('re-copies when content compatibility changes even if updatedAt does not', async () => {
     const configDir = await skillsDir()
-    const skill = { ...(await makeSkill('gamma')), updatedAt: 'v1' }
+    const skill = {
+      ...(await makeSkill('gamma')),
+      updatedAt: 'v1',
+      compatibility: 'sha256:v1'
+    }
     const materializer = new ClaudeCodeSkillMaterializer()
 
     await materializer.sync(configDir, [skill])
@@ -90,15 +94,16 @@ describe('ClaudeCodeSkillMaterializer', () => {
       '# gamma'
     )
 
-    // Change the source but keep the same version: the copy is skipped, so the target stays stale.
+    // A source edit with an unchanged fingerprint is skipped.
     await writeFile(join(skill.sourceDir, 'SKILL.md'), '# gamma edited', 'utf8')
     await materializer.sync(configDir, [skill])
     expect(await readFile(join(configDir, 'skills', 'os-gamma', 'SKILL.md'), 'utf8')).toBe(
       '# gamma'
     )
 
-    // Bump the version: the skill is re-copied and the target refreshes.
-    await materializer.sync(configDir, [{ ...skill, updatedAt: 'v2' }])
+    // Registry compatibility tracks content, so a new fingerprint refreshes the materialized copy
+    // even when human-maintained updatedAt metadata was not bumped.
+    await materializer.sync(configDir, [{ ...skill, compatibility: 'sha256:v2' }])
     expect(await readFile(join(configDir, 'skills', 'os-gamma', 'SKILL.md'), 'utf8')).toBe(
       '# gamma edited'
     )

--- a/src/main/skills/materializer.ts
+++ b/src/main/skills/materializer.ts
@@ -11,8 +11,9 @@ const log = createLogger('skills')
 // and never touches imported/personal/user skills that may live alongside them later.
 const OS_SKILL_PREFIX = 'os-'
 
-// Tracks the version (updatedAt) last materialized per managed dir so unchanged skills are skipped
-// instead of recopied on every spawn. Not a skill dir, so the claude skill loader ignores it.
+// Tracks the content compatibility (falling back to updatedAt) last materialized per managed dir so
+// unchanged skills are skipped instead of recopied on every spawn. Not a skill dir, so the Claude
+// Skill loader ignores it.
 const VERSION_MANIFEST = '.os-versions.json'
 
 // Marker line in an injected notice, used to keep injection idempotent.
@@ -145,10 +146,10 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
       }
     }
 
-    // Copy new or changed skills. A skill with a stable, unchanged version whose dir already exists is
-    // skipped; one with no version (empty updatedAt) is always recopied.
+    // Copy new or changed skills. Registry content compatibility prevents stale copies when updatedAt
+    // metadata was not bumped; non-registry callers retain the existing updatedAt fallback.
     for (const [name, skill] of wanted) {
-      const version = skill.updatedAt || ''
+      const version = skill.compatibility || skill.updatedAt || ''
       const unchanged = version !== '' && existingDirs.has(name) && versions[name] === version
       if (unchanged) continue
 


### PR DESCRIPTION
## Problem

The bundled Customize Skill was updated from snake_case to camelCase Host JavaScript inputs, but its manifest `updatedAt` was not bumped. Existing materialized copies therefore stayed stale and continued instructing Agents to call `host.agents.create()` with rejected snake_case keys such as `system_prompt`.

## Proposed change

- Prefer the registry-provided Skill content compatibility fingerprint when deciding whether to refresh a materialized bundled Skill.
- Retain `updatedAt` as the fallback for callers without a content fingerprint.
- Bump the Customize manifest timestamp and cover the unchanged-timestamp/changed-content regression.

## Scope and non-goals

- Keep the public `host.agents` JavaScript API camelCase-only.
- Do not change private RPC parameter naming or the `specialists.json` persistence schema.
- Keep `.os-versions.json` as an internal opaque string map; existing timestamp values safely mismatch the new content fingerprints and cause a one-time bundled Skill refresh.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Changed bundled Skill content refreshes despite stable `updatedAt` -> `npm test -- --run src/main/skills/materializer.test.ts` -> 14/14 passed.
- Affected Node and Web TypeScript processes -> `npm run typecheck` -> passed.
- Source and test lint -> `npm run lint` -> passed with 0 errors and 13 unrelated pre-existing warnings.
- Full fallback selected because `resources/skills/manifest.json` has no module owner -> `npm test` -> 986 files passed, 15 skipped; 14,320 tests passed, 198 skipped.

No separate UI/E2E, migration, or platform lane was included: the change is shared materialization invalidation with no UI, RPC, Specialist persistence, or platform-specific branch. The complete portable suite passed. The expected operational effect is a one-time recopy of bundled Skills whose cached timestamp token differs from their content fingerprint.

## Review focus

Please verify that content compatibility is the right primary invalidation token and that the `updatedAt` fallback preserves handcrafted/non-registry callers.
