### PR TITLE
perf(renderer): avoid terminal event recomputation

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -116,7 +116,7 @@ vi.mock('@/hooks/useUnreadTaskViewSync', () => ({
 vi.mock('@/components/global-search/GlobalSearchDialog', () => ({
   GlobalSearchDialog: (props: { open: boolean }) => {
     mocks.globalSearch.props = props
-    return null
+    return <div data-testid="global-search" />
   }
 }))
 vi.mock('@/stores/navigation-store', () => ({
@@ -426,7 +426,7 @@ describe('App startup routing', () => {
     mocks.settings.isLoaded = true
     await render()
 
-    expect(mocks.globalSearch.props?.open).toBe(false)
+    expect(document.querySelector('[data-testid="global-search"]')).toBeNull()
     await act(async () => {
       window.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'k', metaKey: true, cancelable: true })
@@ -439,14 +439,14 @@ describe('App startup routing', () => {
         new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, cancelable: true })
       )
     })
-    expect(mocks.globalSearch.props?.open).toBe(false)
+    expect(document.querySelector('[data-testid="global-search"]')).toBeNull()
   })
 
   it('opens the same global search from the Home header action', async () => {
     mocks.settings.isLoaded = true
     await render()
 
-    expect(mocks.globalSearch.props?.open).toBe(false)
+    expect(document.querySelector('[data-testid="global-search"]')).toBeNull()
 
     await act(async () => mocks.homePage.props?.onOpenGlobalSearch())
 
@@ -473,7 +473,7 @@ describe('App startup routing', () => {
     act(() => {
       expect(mocks.closeActiveModal.handler?.()).toBe(true)
     })
-    expect(mocks.globalSearch.props?.open).toBe(false)
+    expect(document.querySelector('[data-testid="global-search"]')).toBeNull()
   })
 
   it('does not open Settings over an active dialog', async () => {
@@ -552,7 +552,7 @@ describe('App startup routing', () => {
       )
     })
 
-    expect(mocks.globalSearch.props?.open).toBe(false)
+    expect(document.querySelector('[data-testid="global-search"]')).toBeNull()
   })
 
   it('does not open Settings under the active expanded preview modal', async () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -609,12 +609,13 @@ const AppContent = (): React.JSX.Element | null => {
       <ComputeApprovalDialog blockedSessionIds={openSideChatParentSessionIds} />
       <UpdateDialog />
       <CloseConfirmModal onOpenChange={setIsCloseConfirmOpen} />
-      <GlobalSearchDialog
-        key={String(isGlobalSearchOpen)}
-        open={isGlobalSearchOpen}
-        onOpenChange={setIsGlobalSearchOpen}
-        isSessionPersistenceReady={isSessionPersistenceReady}
-      />
+      {isGlobalSearchOpen ? (
+        <GlobalSearchDialog
+          open
+          onOpenChange={setIsGlobalSearchOpen}
+          isSessionPersistenceReady={isSessionPersistenceReady}
+        />
+      ) : null}
       <DataRootMissingDialog
         open={missingDataRoot !== undefined}
         dataRoot={missingDataRoot ?? ''}

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -580,6 +580,41 @@ describe('GlobalSearchDialog', () => {
     })
   })
 
+  it('does not reload artifacts while terminal output streams', async () => {
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === 'session-a'
+          ? {
+              ...session,
+              status: 'running',
+              activeRun: { promptMessageId: 'prompt-a', startedAt: 1 }
+            }
+          : session
+      )
+    }))
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+    const searchArtifacts = vi.mocked(window.api.projectFiles.searchArtifacts)
+    const initialCallCount = searchArtifacts.mock.calls.length
+
+    await act(async () => {
+      useSessionStore.getState().upsertToolActivity({
+        sessionId: 'session-a',
+        toolCallId: 'terminal-a',
+        eventId: 'terminal-output-a',
+        title: 'python analysis.py',
+        status: 'in_progress',
+        terminalOutput: 'processing row 1\n'
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(searchArtifacts).toHaveBeenCalledTimes(initialCallCount)
+  })
+
   it('excludes individually archived sessions from artifact queries', async () => {
     useSessionStore.setState((state) => ({
       sessions: state.sessions.map((session) =>

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { ArrowUpRight, AtSign, Hash, MessageCircle, Search, Zap } from 'lucide-react'
 import { Dialog } from 'radix-ui'
+import { useShallow } from 'zustand/react/shallow'
 
 import type { ProjectFileItem } from '../../../../shared/project-files'
 import { Button } from '@/components/ui/button'
@@ -137,13 +138,13 @@ export const GlobalSearchDialog = ({
 
   const allProjects = useProjectStore((state) => state.projects)
   const allSessions = useSessionStore((state) => state.sessions)
-  const archivedSessionIds = useMemo(
-    () =>
-      allSessions
+  const archivedSessionIds = useSessionStore(
+    useShallow((state) =>
+      state.sessions
         .filter((session) => session.archivedAt !== undefined)
         .map((session) => session.id)
-        .sort(),
-    [allSessions]
+        .sort()
+    )
   )
   const projects = useMemo(
     () => allProjects.filter((project) => project.archivedAt === undefined),

--- a/src/renderer/src/pages/workspace/ContextWindowDialog.tsx
+++ b/src/renderer/src/pages/workspace/ContextWindowDialog.tsx
@@ -440,7 +440,13 @@ const ContextWindowDialog = ({
   session,
   onOpenChange
 }: ContextWindowDialogProps): React.JSX.Element => {
-  const points = useMemo(() => selectContextWindowTrendPoints(session), [session])
+  const messages = session?.messages
+  const conversationGraph = session?.conversationGraph
+  const points = useMemo(
+    () =>
+      messages === undefined ? [] : selectContextWindowTrendPoints({ conversationGraph, messages }),
+    [conversationGraph, messages]
+  )
   const contentRef = useRef<HTMLDivElement>(null)
 
   return (

--- a/src/renderer/src/pages/workspace/WorkspaceArtifactVisibility.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceArtifactVisibility.tsx
@@ -16,13 +16,13 @@ type MessageArtifact = NonNullable<ChatSession['artifacts']>[number] & {
 }
 
 const getMessageArtifacts = (
-  session: ChatSession,
+  artifacts: ChatSession['artifacts'],
   message: ChatSession['messages'][number],
   resolvedArtifactsByVersionId?: ReadonlyMap<string, MessageArtifact | undefined>
 ): MessageArtifact[] => {
   if (!message.artifactIds) return []
   const artifactsById = new Map(
-    (session.artifacts ?? []).map((artifact) => [artifact.id, artifact as MessageArtifact])
+    (artifacts ?? []).map((artifact) => [artifact.id, artifact as MessageArtifact])
   )
   const artifactsByLogicalId = new Map<string, MessageArtifact>()
   for (const artifactId of message.artifactIds) {
@@ -65,7 +65,10 @@ const toResolvedMessageArtifact = (descriptor: ArtifactVersionDescriptor): Messa
 })
 
 const useHistoricalArtifactDescriptors = (
-  activeSession: ChatSession | undefined,
+  sessionId: string | undefined,
+  projectId: string | undefined,
+  messages: ChatSession['messages'] | undefined,
+  artifacts: ChatSession['artifacts'],
   projectedVersionIds: readonly string[]
 ): ReadonlyMap<string, MessageArtifact | undefined> => {
   const resolvedRef = useRef<{
@@ -88,22 +91,24 @@ const useHistoricalArtifactDescriptors = (
   }, [])
 
   useEffect(() => {
-    const sessionId = activeSession?.id
     if (resolvedRef.current.sessionId !== sessionId) {
       resolvedRef.current = { sessionId, artifactsByVersionId: new Map() }
       retriedVersionIdsRef.current.clear()
       setResolved(resolvedRef.current)
     }
-    if (!activeSession || typeof window.api?.artifacts?.resolveVersionDescriptors !== 'function') {
+    if (
+      sessionId === undefined ||
+      projectId === undefined ||
+      messages === undefined ||
+      typeof window.api?.artifacts?.resolveVersionDescriptors !== 'function'
+    ) {
       return
     }
     const cache = resolvedRef.current.artifactsByVersionId
-    const storedArtifactIds = new Set(
-      (activeSession.artifacts ?? []).map((artifact) => artifact.id)
-    )
+    const storedArtifactIds = new Set((artifacts ?? []).map((artifact) => artifact.id))
     const unresolvedVersionIds = [
       ...new Set([
-        ...activeSession.messages.flatMap((message) => message.artifactIds ?? []),
+        ...messages.flatMap((message) => message.artifactIds ?? []),
         ...projectedVersionIds
       ])
     ].filter(
@@ -125,8 +130,8 @@ const useHistoricalArtifactDescriptors = (
         )
         try {
           const descriptors = await window.api.artifacts.resolveVersionDescriptors({
-            projectId: activeSession.projectId,
-            appSessionId: activeSession.id,
+            projectId,
+            appSessionId: sessionId,
             versionIds
           })
           for (const descriptor of descriptors) {
@@ -161,9 +166,9 @@ const useHistoricalArtifactDescriptors = (
         setResolved({ sessionId, artifactsByVersionId: new Map(cache) })
       }
     })()
-  }, [activeSession, projectedVersionIds, retryToken])
+  }, [artifacts, messages, projectId, projectedVersionIds, retryToken, sessionId])
 
-  return resolved.sessionId === activeSession?.id ? resolved.artifactsByVersionId : new Map()
+  return resolved.sessionId === sessionId ? resolved.artifactsByVersionId : new Map()
 }
 
 const useWorkspaceArtifactVisibility = (
@@ -171,14 +176,18 @@ const useWorkspaceArtifactVisibility = (
 ): Readonly<{
   artifactsForMessage(message: ChatSession['messages'][number]): MessageArtifact[]
 }> => {
+  const sessionId = activeSession?.id
+  const projectId = activeSession?.projectId
+  const messages = activeSession?.messages
+  const artifacts = activeSession?.artifacts
+  const graph = activeSession?.conversationGraph
   const projection = useMemo(() => {
-    const graph = activeSession?.conversationGraph
-    if (!activeSession || !graph || graph.activeFrameId !== graph.rootFrameId) return undefined
+    if (!graph || graph.activeFrameId !== graph.rootFrameId) return undefined
     const rootFrame = graph.frames.find(({ id }) => id === graph.rootFrameId)
     return rootFrame
-      ? projectRootArtifactVisibility(activeSession, rootFrame.activeBranchId)
+      ? projectRootArtifactVisibility({ conversationGraph: graph }, rootFrame.activeBranchId)
       : undefined
-  }, [activeSession])
+  }, [graph])
   const projectedVersionIds = useMemo(
     () => projection?.placements.map(({ artifactVersionId }) => artifactVersionId) ?? [],
     [projection]
@@ -195,13 +204,19 @@ const useWorkspaceArtifactVisibility = (
   // The terminal agent fragment of each turn is the only place projected child Versions render,
   // mirroring how main-agent artifacts attach to the turn's final assistant message.
   const terminalAgentMessageIds = useMemo(
-    () => resolveTurnTerminalAgentMessageIds(activeSession?.messages ?? []),
-    [activeSession]
+    () => resolveTurnTerminalAgentMessageIds(messages ?? []),
+    [messages]
   )
-  const historicalArtifacts = useHistoricalArtifactDescriptors(activeSession, projectedVersionIds)
+  const historicalArtifacts = useHistoricalArtifactDescriptors(
+    sessionId,
+    projectId,
+    messages,
+    artifacts,
+    projectedVersionIds
+  )
   const artifactsForMessage = useCallback(
     (message: ChatSession['messages'][number]) => {
-      if (!activeSession) return []
+      if (sessionId === undefined) return []
       const projectedVersionIdsForTurn =
         message.role === 'agent' &&
         message.responseToMessageId &&
@@ -209,10 +224,10 @@ const useWorkspaceArtifactVisibility = (
           ? projectedArtifactVersionIdsByRootMessageId.get(message.responseToMessageId)
           : undefined
       if (!projectedVersionIdsForTurn || projectedVersionIdsForTurn.length === 0) {
-        return getMessageArtifacts(activeSession, message, historicalArtifacts)
+        return getMessageArtifacts(artifacts, message, historicalArtifacts)
       }
       return getMessageArtifacts(
-        activeSession,
+        artifacts,
         {
           ...message,
           artifactIds: [...(message.artifactIds ?? []), ...projectedVersionIdsForTurn]
@@ -221,9 +236,10 @@ const useWorkspaceArtifactVisibility = (
       )
     },
     [
-      activeSession,
+      artifacts,
       historicalArtifacts,
       projectedArtifactVersionIdsByRootMessageId,
+      sessionId,
       terminalAgentMessageIds
     ]
   )

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -344,7 +344,7 @@ const WorkspaceMessageScrollerImpl = ({
   // Legacy unlinked messages remain independent so older transcripts do not lose their timestamps.
   const assistantFooterMessageIds = useMemo(
     () => resolveTurnTerminalAgentMessageIds(activeSession?.messages ?? []),
-    [activeSession]
+    [activeSession?.messages]
   )
   const agentLoadingPhase = getAgentLoadingPhase(activeSession)
   const messageCreatedAtById = new Map(

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -741,6 +741,7 @@ const WorkspacePage = ({
     sessionController.actions,
     setAttachmentError
   ])
+  const activeSessionHasMessages = (activeSession?.messages.length ?? 0) > 0
 
   useEffect(() => {
     const openNewConversationFromShortcut = (event: KeyboardEvent): void => {
@@ -759,13 +760,13 @@ const WorkspacePage = ({
       }
 
       event.preventDefault()
-      if (!activeSession || activeSession.messages.length === 0) return
+      if (!activeSessionHasMessages) return
       openNewConversation()
     }
 
     window.addEventListener('keydown', openNewConversationFromShortcut)
     return () => window.removeEventListener('keydown', openNewConversationFromShortcut)
-  }, [activeSession, openNewConversation])
+  }, [activeSessionHasMessages, openNewConversation])
 
   // Synchronizes the hidden chat session id with the selected session list item.
   const openSession = (sessionId: string): void => {

--- a/src/renderer/src/pages/workspace/context-window-trend.ts
+++ b/src/renderer/src/pages/workspace/context-window-trend.ts
@@ -2,6 +2,8 @@ import type { AcpContextWindowSample } from '../../../../shared/acp'
 import type { PersistedRuntimeSegment } from '../../../../shared/conversation-graph'
 import type { ChatSession } from '@/stores/session-store'
 
+type ContextWindowTrendSession = Pick<ChatSession, 'conversationGraph' | 'messages'>
+
 export type ContextWindowTrendPoint = Readonly<{
   runNumber: number
   messageNumber: number
@@ -34,7 +36,7 @@ const visibleMessageSamples = (
 }
 
 export const selectContextWindowTrendPoints = (
-  session: ChatSession | undefined
+  session: ContextWindowTrendSession | undefined
 ): ContextWindowTrendPoint[] => {
   if (!session) return []
 

--- a/src/shared/artifact-visibility.ts
+++ b/src/shared/artifact-visibility.ts
@@ -100,7 +100,7 @@ const sourceForPrompt = (
 }
 
 const projectRootArtifactVisibility = (
-  session: PersistedChatSession,
+  session: Pick<PersistedChatSession, 'conversationGraph'>,
   rootBranchId: string
 ): RootArtifactVisibilityProjection => {
   const graph = session.conversationGraph


### PR DESCRIPTION
## Problem

Every accepted `tool_call_update` replaces the owning Session object. Several renderer consumers
used the whole Session or Session array as a memo/effect dependency even when they only read stable
graph, Message, Artifact, or archive fields. In Global Search, one terminal-output update therefore
caused one redundant `projectFiles.searchArtifacts` IPC request.

## Proposed change

- Mount Global Search only while it is open and shallow-select archived Session ids.
- Key Artifact visibility and Context-window projections to the fields they actually read.
- Keep assistant-footer derivation and the New Conversation shortcut independent of activity-only
  Session updates.
- Add a regression test that emits a real terminal tool-activity update and asserts that Global
  Search does not reload Artifacts.

## Scope and non-goals

- Preserve runtime event ordering, event frequency, visible terminal streaming, Session timestamps,
  and persistence formats.
- Do not debounce, throttle, or coalesce `tool_call_update` events.
- Do not change Session archive behavior, Artifact query contents, or historical data interpretation.

## Acceptance criteria and validation

The final impact classifier selected the full fallback because `App.test.tsx` has no module owner.
The checks below ran after the last material edit:

- Global Search terminal streaming ->
  `npm test -- src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx -t 'does not reload artifacts while terminal output streams'`
  -> 1 passed.
- Existing Project Files terminal stability ->
  `npm test -- src/renderer/src/pages/workspace/ProjectFilesView.test.tsx -t 'keeps the files index stable while terminal output streams'`
  -> 1 passed.
- Renderer/shared behavior -> targeted 8-file Vitest run -> 194 passed.
- Node and renderer type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors; changed-file lint is clean.
- Complete portable suite -> `npm test` -> 14,321 passed, 198 skipped. The suite was rerun outside
  the sandbox because its local RPC/HTTP tests must listen on `127.0.0.1`.

No UI E2E or platform-specific lane was run. The change does not touch platform adapters,
persistence, migrations, or visual behavior; the complete portable suite and focused render tests
cover the affected interfaces locally.

## Historical compatibility

No compatibility path is required. The change does not read, write, migrate, or reinterpret
persisted data. Event coalescing and `updatedAt` semantics remain unchanged and out of scope.

## Review focus

- Confirm activity-only Session updates keep the derived archive/graph/Message/Artifact identities
  stable.
- Confirm conditional Global Search mounting matches the prior keyed lifetime reset.
- Confirm no runtime-event or persistence semantics changed.
