### PR TITLE
fix(global-search): stabilize async search results

### DIFF
--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -16,6 +16,7 @@ import { GlobalSearchDialog } from './GlobalSearchDialog'
 
 let container: HTMLDivElement
 let root: Root
+let scrollIntoView: ReturnType<typeof vi.fn>
 
 const artifact = {
   id: 'artifact-1',
@@ -32,6 +33,11 @@ const artifact = {
 }
 
 beforeEach(() => {
+  scrollIntoView = vi.fn()
+  Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: scrollIntoView
+  })
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -122,6 +128,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount())
   container.remove()
+  Reflect.deleteProperty(window.HTMLElement.prototype, 'scrollIntoView')
   vi.restoreAllMocks()
 })
 
@@ -196,6 +203,81 @@ describe('GlobalSearchDialog', () => {
       artifactId: 'artifact-1',
       projectId: 'project-a'
     })
+  })
+
+  it('waits for Artifact search before showing a complete keyword result set', async () => {
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const delayedResult = {
+      primary: { items: [artifact], totalCount: 1 },
+      other: [],
+      isIndexComplete: true
+    }
+    let resolveSearch!: (value: typeof delayedResult) => void
+    const pendingSearch = new Promise<typeof delayedResult>((resolve) => {
+      resolveSearch = resolve
+    })
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockImplementationOnce(() => pendingSearch)
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )?.set
+
+    await act(async () => {
+      valueSetter?.call(input, 'sin')
+      input?.dispatchEvent(new Event('input', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Searching…')
+    expect(document.body.querySelector('[role="group"][aria-label="Sessions"]')).toBeNull()
+    expect(document.body.querySelector('[role="option"][aria-selected="true"]')).toBeNull()
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 170))
+    })
+
+    expect(document.body.textContent).toContain('Searching…')
+    expect(document.body.querySelector('[role="group"][aria-label="Sessions"]')).toBeNull()
+    expect(document.body.querySelector('[role="option"][aria-selected="true"]')).toBeNull()
+
+    await act(async () => {
+      resolveSearch(delayedResult)
+      await pendingSearch
+    })
+
+    const groupHeadings = [...document.body.querySelectorAll('[role="group"] h2')].map(
+      (heading) => heading.textContent
+    )
+    expect(groupHeadings.slice(0, 2)).toEqual(['Artifacts', 'Sessions'])
+  })
+
+  it('scrolls active results for keyboard navigation but not pointer hover', async () => {
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+    scrollIntoView.mockClear()
+
+    const sessionRow = document.body.querySelector<HTMLElement>(
+      '[role="group"][aria-label="Recent sessions"] [role="option"]'
+    )
+    act(() => sessionRow?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+
+    expect(scrollIntoView).not.toHaveBeenCalled()
+
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    act(() =>
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+      )
+    )
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
   })
 
   it('keeps the result list scrollable and the shortcut footer outside the scroll viewport', async () => {

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -235,7 +235,9 @@ describe('GlobalSearchDialog', () => {
 
     expect(document.body.textContent).toContain('Searching…')
     expect(document.body.querySelector('[role="group"][aria-label="Sessions"]')).toBeNull()
-    expect(document.body.querySelector('[role="option"][aria-selected="true"]')).toBeNull()
+    expect(
+      document.body.querySelector('[role="option"][aria-selected="true"]')?.textContent
+    ).toContain('New session')
 
     await act(async () => {
       await new Promise((resolve) => window.setTimeout(resolve, 170))
@@ -243,7 +245,9 @@ describe('GlobalSearchDialog', () => {
 
     expect(document.body.textContent).toContain('Searching…')
     expect(document.body.querySelector('[role="group"][aria-label="Sessions"]')).toBeNull()
-    expect(document.body.querySelector('[role="option"][aria-selected="true"]')).toBeNull()
+    expect(
+      document.body.querySelector('[role="option"][aria-selected="true"]')?.textContent
+    ).toContain('New session')
 
     await act(async () => {
       resolveSearch(delayedResult)

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -387,7 +387,7 @@ export const GlobalSearchDialog = ({
       ? ({ kind: 'new-session' } as const)
       : ({ kind: 'new-project' } as const)
     if (!primaryProject) return isProjectScope ? [] : [command]
-    if (isSearchPending) return []
+    if (isSearchPending) return [command]
     if (!isSearchMode) {
       return [
         ...displayedArtifacts.map((artifact) => ({ kind: 'artifact' as const, artifact })),

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -5,7 +5,7 @@
  * contrast: inherited from the app's verified semantic tokens · slop: pass
  */
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
-import { ArrowUpRight, AtSign, Hash, MessageCircle, Search, Zap } from 'lucide-react'
+import { ArrowUpRight, AtSign, Hash, LoaderCircle, MessageCircle, Search, Zap } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 import { useShallow } from 'zustand/react/shallow'
 
@@ -126,6 +126,7 @@ export const GlobalSearchDialog = ({
 }: GlobalSearchDialogProps): React.JSX.Element => {
   const inputRef = useRef<HTMLInputElement>(null)
   const requestVersionRef = useRef(0)
+  const keyboardNavigationRef = useRef(false)
   const listboxId = useId()
   const [query, setQuery] = useState('')
   const [visibleSessionCount, setVisibleSessionCount] = useState(GLOBAL_SEARCH_PAGE_SIZE)
@@ -334,11 +335,12 @@ export const GlobalSearchDialog = ({
     setQuery(nextQuery)
     setVisibleSessionCount(GLOBAL_SEARCH_PAGE_SIZE)
     setArtifacts(emptyArtifactState)
-    setArtifactStatus('idle')
+    setArtifactStatus(nextQuery.trim() ? 'loading' : 'idle')
     setArtifactError(undefined)
     setFailedArtifactCursor(undefined)
     setActionError(undefined)
     setActiveIndex(0)
+    keyboardNavigationRef.current = false
   }
 
   useEffect(() => {
@@ -364,6 +366,8 @@ export const GlobalSearchDialog = ({
           ),
     [artifacts.items, artifacts.other, isProjectScope]
   )
+  const isSearchPending =
+    isSearchMode && artifactStatus === 'loading' && displayedArtifacts.length === 0
   const otherRows = useMemo<SelectableRow[]>(() => {
     if (!isProjectScope || !isSearchMode) return []
     return [
@@ -383,6 +387,7 @@ export const GlobalSearchDialog = ({
       ? ({ kind: 'new-session' } as const)
       : ({ kind: 'new-project' } as const)
     if (!primaryProject) return isProjectScope ? [] : [command]
+    if (isSearchPending) return []
     if (!isSearchMode) {
       return [
         ...displayedArtifacts.map((artifact) => ({ kind: 'artifact' as const, artifact })),
@@ -404,6 +409,7 @@ export const GlobalSearchDialog = ({
     artifactError,
     displayedArtifacts,
     isProjectScope,
+    isSearchPending,
     isSearchMode,
     otherRows,
     primaryProject,
@@ -412,10 +418,13 @@ export const GlobalSearchDialog = ({
     sessionMoreCount
   ])
 
-  const activeRowIndex = Math.max(0, Math.min(activeIndex, selectableRows.length - 1))
+  const activeRowIndex =
+    selectableRows.length === 0 ? -1 : Math.max(0, Math.min(activeIndex, selectableRows.length - 1))
   const activeRowId = `global-search-option-${activeRowIndex}`
 
   useEffect(() => {
+    if (!keyboardNavigationRef.current) return
+    keyboardNavigationRef.current = false
     if (!open || selectableRows.length === 0) return
     document.getElementById(activeRowId)?.scrollIntoView?.({ block: 'nearest' })
   }, [activeRowId, open, selectableRows.length])
@@ -526,20 +535,30 @@ export const GlobalSearchDialog = ({
       if (selectableRows.length === 0) return
       setActiveIndex((current) => {
         const normalized = Math.max(0, Math.min(current, selectableRows.length - 1))
-        return event.key === 'ArrowDown'
-          ? (normalized + 1) % selectableRows.length
-          : (normalized - 1 + selectableRows.length) % selectableRows.length
+        const nextIndex =
+          event.key === 'ArrowDown'
+            ? (normalized + 1) % selectableRows.length
+            : (normalized - 1 + selectableRows.length) % selectableRows.length
+        keyboardNavigationRef.current = nextIndex !== current
+        return nextIndex
       })
       return
     }
     if (event.key === 'Home') {
       event.preventDefault()
-      setActiveIndex(0)
+      setActiveIndex((current) => {
+        keyboardNavigationRef.current = current !== 0
+        return 0
+      })
       return
     }
     if (event.key === 'End') {
       event.preventDefault()
-      setActiveIndex(Math.max(0, selectableRows.length - 1))
+      setActiveIndex((current) => {
+        const nextIndex = Math.max(0, selectableRows.length - 1)
+        keyboardNavigationRef.current = nextIndex !== current
+        return nextIndex
+      })
       return
     }
     if (event.key === 'Enter') {
@@ -553,10 +572,12 @@ export const GlobalSearchDialog = ({
     }
   }
 
-  const resultCount = isSearchMode
-    ? (sessionGroups?.primaryTotalCount ?? 0) +
-      (isProjectScope ? artifacts.totalCount + otherRows.length : displayedArtifacts.length)
-    : displayedArtifacts.length + recentSessions.length
+  const resultCount = isSearchPending
+    ? 0
+    : isSearchMode
+      ? (sessionGroups?.primaryTotalCount ?? 0) +
+        (isProjectScope ? artifacts.totalCount + otherRows.length : displayedArtifacts.length)
+      : displayedArtifacts.length + recentSessions.length
   const renderSessionRow = (session: SessionSearchResult, rowIndex: number): React.JSX.Element => {
     const active = rowIndex === activeRowIndex
     return (
@@ -780,9 +801,16 @@ export const GlobalSearchDialog = ({
                       {displayedArtifacts.map((artifact) =>
                         renderArtifactRow(artifact, nextIndex())
                       )}
-                      {artifactStatus === 'loading' && displayedArtifacts.length === 0 ? (
-                        <p className="px-4 py-3 text-sm text-muted-foreground">
-                          Searching artifacts…
+                      {isSearchPending ? (
+                        <p
+                          role="status"
+                          className="flex items-center gap-2 px-4 py-3 text-sm text-muted-foreground"
+                        >
+                          <LoaderCircle
+                            className="size-3.5 animate-spin motion-reduce:animate-none"
+                            aria-hidden="true"
+                          />
+                          Searching…
                         </p>
                       ) : null}
                       {artifactError ? (
@@ -821,7 +849,7 @@ export const GlobalSearchDialog = ({
                       ) : null}
                     </section>
                   ) : null}
-                  {sessionGroups?.primary.length ? (
+                  {!isSearchPending && sessionGroups?.primary.length ? (
                     <section role="group" aria-label="Sessions">
                       <h2 className={sectionTitleClassName}>Sessions</h2>
                       {sessionGroups.primary.map((session) =>
@@ -846,7 +874,7 @@ export const GlobalSearchDialog = ({
                       ) : null}
                     </section>
                   ) : null}
-                  {otherRows.length > 0 ? (
+                  {!isSearchPending && otherRows.length > 0 ? (
                     <section role="group" aria-label="Other projects">
                       <h2 className={sectionTitleClassName}>Other projects</h2>
                       {otherRows.map((row) =>


### PR DESCRIPTION
## Problem

Cmd/Ctrl+K rendered matching Sessions immediately while the debounced Artifact query was still pending. Slow Artifact results then appeared above those Sessions and shifted the list. Pointer hover also changed the active row through the same effect used by keyboard navigation, so repeated hover/scroll feedback could move the viewport to the bottom.

## Proposed change

- Mark keyword searches pending as soon as input changes, retain the existing 150 ms debounce, and show a compact loading state.
- Reveal Artifact and Session matches together after the Artifact query settles, preserving Artifact-first ordering.
- Restrict automatic active-row scrolling to keyboard navigation; pointer hover only updates highlighting.
- Keep the result selection empty while loading so a fast Enter cannot activate an unrelated command.

## Scope and non-goals

Renderer-only change in the shared global-search dialog. No IPC, Artifact query, persistence, backend, debounce-duration, or result-ranking contracts change.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Atomic loading and result ordering; pointer-safe scrolling -> `npm test -- src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx` -> 17 passed.
- Renderer and process type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors and 13 pre-existing warnings outside the changed files.
- Complete portable regression suite -> `npm test` -> 14,323 passed, 198 skipped.

The shared Renderer component and its DOM behavior are covered. No IPC interface, persistence, path handling, native packaging, or platform-specific behavior changed, so no additional platform lane is included locally. Remaining risk: jsdom verifies result visibility and `scrollIntoView` intent, but not physical pointer motion in a packaged Electron window.

## Review focus

Please verify the pending-state selection behavior and the separation between pointer highlighting and keyboard-owned scrolling.