### PR TITLE
perf(message-stream): smooth live response rendering

### DIFF
--- a/src/main/acp/connection-close-workflow.test.ts
+++ b/src/main/acp/connection-close-workflow.test.ts
@@ -39,6 +39,7 @@ const createWorkflow = (overrides: Record<string, unknown> = {}): TestHarness =>
     clearHttpRoutes: vi.fn(() => actions.push('routes')),
     selectSession: vi.fn(() => actions.push('select')),
     publishInterruptedPromptFailures: vi.fn(() => actions.push('prompt-failures')),
+    cancelPendingStatePublication: vi.fn(() => actions.push('publication-cancel')),
     setStatus: vi.fn((status: AcpStateSnapshot['status']) => actions.push(status)),
     transitionStatus: vi.fn((status: AcpStateSnapshot['status']) => actions.push(status)),
     emitState: vi.fn(() => actions.push('emit')),
@@ -103,7 +104,7 @@ const createWorkflow = (overrides: Record<string, unknown> = {}): TestHarness =>
 
 describe('AcpConnectionCloseWorkflow', () => {
   it('coordinates expected teardown while preserving owner ordering', async () => {
-    const { workflow, actions, resources, transitions } = createWorkflow()
+    const { workflow, actions, resources, transitions, state } = createWorkflow()
 
     await expect(workflow.disconnect()).resolves.toBe(snapshot)
 
@@ -111,6 +112,7 @@ describe('AcpConnectionCloseWorkflow', () => {
     expect(resources.supersede).toHaveBeenCalledOnce()
     expect(resources.teardown).toHaveBeenCalledOnce()
     expect(resources.closeMcp).toHaveBeenCalledOnce()
+    expect(state.cancelPendingStatePublication).toHaveBeenCalledOnce()
     expect(actions).toEqual([
       'model-cancel',
       'invalidate',
@@ -130,8 +132,23 @@ describe('AcpConnectionCloseWorkflow', () => {
       'routes',
       'select',
       'closed',
-      'backend:2'
+      'backend:2',
+      'publication-cancel'
     ])
+  })
+
+  it('cancels pending state publication before a failed disconnect returns ownership', async () => {
+    const disconnectFailure = new Error('disconnect failed')
+    const { workflow, resources, state } = createWorkflow({
+      disconnectCurrent: vi.fn(async () => {
+        throw disconnectFailure
+      })
+    })
+
+    await expect(workflow.disconnect()).rejects.toBe(disconnectFailure)
+
+    expect(resources.restorePublished).toHaveBeenCalledOnce()
+    expect(state.cancelPendingStatePublication).toHaveBeenCalledOnce()
   })
 
   it('cleans an unexpected close once, reports interrupted prompts, then reevaluates intents', () => {
@@ -144,7 +161,9 @@ describe('AcpConnectionCloseWorkflow', () => {
     expect(state.publishInterruptedPromptFailures).toHaveBeenCalledWith(['prompt'])
     expect(transitions.resetReconnect).toHaveBeenCalledOnce()
     expect(transitions.activityChanged).toHaveBeenCalledOnce()
+    expect(state.cancelPendingStatePublication).toHaveBeenCalledOnce()
     expect(actions).toEqual([
+      'publication-cancel',
       'model-cancel',
       'invalidate',
       'permission',
@@ -179,6 +198,7 @@ describe('AcpConnectionCloseWorkflow', () => {
     expect(resources.beginAwaitableShutdown).toHaveBeenCalledWith(true)
     expect(state.clearPlanInteractions).toHaveBeenCalledOnce()
     expect(state.clearSessionProjection).toHaveBeenCalledOnce()
+    expect(state.cancelPendingStatePublication).toHaveBeenCalledOnce()
   })
 
   it('clears Plan interactions during synchronous shutdown', () => {
@@ -187,6 +207,7 @@ describe('AcpConnectionCloseWorkflow', () => {
     workflow.shutdown()
 
     expect(state.clearPlanInteractions).toHaveBeenCalledOnce()
+    expect(state.cancelPendingStatePublication).toHaveBeenCalledOnce()
   })
 
   it('clears usage before deferring provider reconnect and delegates intent ownership', async () => {

--- a/src/main/acp/connection-close-workflow.ts
+++ b/src/main/acp/connection-close-workflow.ts
@@ -29,6 +29,7 @@ type CloseState = Readonly<{
   clearHttpRoutes: () => void
   selectSession: () => void
   publishInterruptedPromptFailures: (prompts: readonly unknown[]) => void
+  cancelPendingStatePublication: () => void
   setStatus: (status: CloseStatus) => void
   transitionStatus: (status: CloseStatus) => void
   emitState: () => void
@@ -68,19 +69,23 @@ class AcpConnectionCloseWorkflow {
   constructor(private readonly options: AcpConnectionCloseWorkflowOptions) {}
   async disconnect(emitClosedStatus = true): Promise<AcpStateSnapshot> {
     this.options.modelChanges.cancel()
-    return this.options.transitions.settleTeardown(async () => {
-      const teardownGeneration = this.options.resources.supersede()
-      this.options.state.invalidatePendingSessionStartups()
-      try {
-        return await (this.options.disconnectCurrent?.(emitClosedStatus, teardownGeneration) ??
-          this.disconnectCurrent(emitClosedStatus, teardownGeneration))
-      } catch (error) {
-        this.options.resources.restorePublished(teardownGeneration)
-        throw error
-      } finally {
-        await this.options.resources.closeMcp(teardownGeneration)
-      }
-    })
+    try {
+      return await this.options.transitions.settleTeardown(async () => {
+        const teardownGeneration = this.options.resources.supersede()
+        this.options.state.invalidatePendingSessionStartups()
+        try {
+          return await (this.options.disconnectCurrent?.(emitClosedStatus, teardownGeneration) ??
+            this.disconnectCurrent(emitClosedStatus, teardownGeneration))
+        } catch (error) {
+          this.options.resources.restorePublished(teardownGeneration)
+          throw error
+        } finally {
+          await this.options.resources.closeMcp(teardownGeneration)
+        }
+      })
+    } finally {
+      this.options.state.cancelPendingStatePublication()
+    }
   }
   async disconnectCurrent(
     emitClosedStatus = true,
@@ -134,6 +139,7 @@ class AcpConnectionCloseWorkflow {
     ) {
       return
     }
+    this.options.state.cancelPendingStatePublication()
     this.options.modelChanges.cancel()
     const teardownGeneration = this.options.currentGeneration()
     const interruptedPrompts = this.options.state.settleActivePrompts()
@@ -164,6 +170,7 @@ class AcpConnectionCloseWorkflow {
     }
   }
   shutdown(): void {
+    this.options.state.cancelPendingStatePublication()
     this.options.modelChanges.cancel()
     this.options.resources.shutdownSynchronously(() => {
       this.options.state.invalidatePendingSessionStartups()

--- a/src/main/acp/runtime-lifecycle-composition.ts
+++ b/src/main/acp/runtime-lifecycle-composition.ts
@@ -115,6 +115,7 @@ const composeAcpRuntimeLifecycleOwners = (
         }
       }
     },
+    cancelPendingStatePublication: () => session.publication.cancelPendingStatePublication(),
     setStatus,
     transitionStatus: (status) => base.snapshotOwner.transitionStatus(status),
     emitState: () => session.publication.emitState(),

--- a/src/main/acp/runtime-publication-owner.test.ts
+++ b/src/main/acp/runtime-publication-owner.test.ts
@@ -16,6 +16,85 @@ const createProjection = (): RuntimeSnapshotProjection => ({
 })
 
 describe('AcpRuntimePublicationOwner', () => {
+  it('coalesces assistant text state while publishing every event immediately', () => {
+    const order: string[] = []
+    let releaseScheduledState: (() => void) | undefined
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection: createProjection,
+      callbacks: {
+        onEvent: (event) => order.push(`event:${event.text}`),
+        onStateChanged: (snapshot) => order.push(`state:${snapshot.events.length}`)
+      },
+      scheduleStatePublication: (publish) => {
+        releaseScheduledState = publish
+        return () => (releaseScheduledState = undefined)
+      }
+    })
+
+    owner.pushEvent({ kind: 'message', level: 'info', role: 'assistant', text: 'one' })
+    owner.pushEvent({ kind: 'message', level: 'info', role: 'assistant', text: 'two' })
+
+    expect(order).toEqual(['event:one', 'event:two'])
+    releaseScheduledState?.()
+    expect(order).toEqual(['event:one', 'event:two', 'state:2'])
+  })
+
+  it('flushes pending assistant text at a tool boundary without losing event order', () => {
+    const order: string[] = []
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection: createProjection,
+      callbacks: {
+        onEvent: (event) => order.push(`event:${event.kind}`),
+        onStateChanged: (snapshot) => order.push(`state:${snapshot.events.length}`)
+      },
+      scheduleStatePublication: () => () => undefined
+    })
+
+    owner.pushEvent({ kind: 'message', level: 'info', role: 'assistant', text: 'before' })
+    owner.pushEvent({ kind: 'tool', level: 'info', toolCallId: 'tool-1', status: 'in_progress' })
+
+    expect(order).toEqual(['event:message', 'event:tool', 'state:2'])
+  })
+
+  it('keeps a mixed 121-event burst within the frame and boundary publication budget', () => {
+    let scheduledState: (() => void) | undefined
+    let eventPublications = 0
+    let statePublications = 0
+    const snapshotOwner = new AcpRuntimeSnapshotOwner('/workspace')
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner,
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection: createProjection,
+      callbacks: {
+        onEvent: () => (eventPublications += 1),
+        onStateChanged: () => (statePublications += 1)
+      },
+      scheduleStatePublication: (publish) => {
+        scheduledState = publish
+        return () => {
+          if (scheduledState === publish) scheduledState = undefined
+        }
+      }
+    })
+
+    for (let index = 0; index < 60; index += 1) {
+      owner.pushEvent({ kind: 'message', level: 'info', role: 'assistant', text: `${index}` })
+    }
+    owner.pushEvent({ kind: 'tool', level: 'info', toolCallId: 'tool-1', status: 'completed' })
+    for (let index = 0; index < 60; index += 1) {
+      owner.pushEvent({ kind: 'message', level: 'info', role: 'assistant', text: `${index}` })
+    }
+    scheduledState?.()
+
+    expect(eventPublications).toBe(121)
+    expect(snapshotOwner.snapshot(createProjection()).events).toHaveLength(121)
+    expect(statePublications).toBeLessThanOrEqual(3)
+  })
+
   it('publishes an event only after append hooks and before the resulting state', () => {
     const order: string[] = []
     const snapshotOwner = new AcpRuntimeSnapshotOwner('/workspace')

--- a/src/main/acp/runtime-publication-owner.ts
+++ b/src/main/acp/runtime-publication-owner.ts
@@ -17,11 +17,28 @@ type AcpRuntimePublicationOwnerOptions = Readonly<{
   interactions: Pick<AcpSessionInteractionOwner, 'current'>
   snapshotProjection: () => RuntimeSnapshotProjection
   callbacks: AcpRuntimePublicationCallbacks
+  scheduleStatePublication?: (publish: () => void) => () => void
 }>
+
+const STATE_PUBLICATION_INTERVAL_MS = 16
+
+const scheduleStatePublication = (publish: () => void): (() => void) => {
+  const timer = setTimeout(publish, STATE_PUBLICATION_INTERVAL_MS)
+  return () => clearTimeout(timer)
+}
+
+const isCoalescibleAssistantTextEvent = (event: AcpRuntimeEvent): boolean =>
+  event.kind === 'message' &&
+  event.role === 'assistant' &&
+  typeof event.text === 'string' &&
+  event.text.length > 0 &&
+  !event.image
 
 // Owns renderer publication order while AcpRuntimeSnapshotOwner remains the sole event/status writer.
 // Every projection is read live from the authoritative owners; this owner caches no runtime facts.
 class AcpRuntimePublicationOwner {
+  private cancelScheduledStatePublication?: () => void
+
   constructor(private readonly options: AcpRuntimePublicationOwnerOptions) {}
 
   getSnapshot(): AcpStateSnapshot {
@@ -42,7 +59,11 @@ class AcpRuntimePublicationOwner {
     const runtimeEvent = this.options.snapshotOwner.appendEvent(scopedEvent)
     onAppended?.()
     this.options.callbacks.onEvent?.(runtimeEvent)
-    this.emitState()
+    if (isCoalescibleAssistantTextEvent(runtimeEvent)) {
+      this.scheduleStatePublication()
+    } else {
+      this.emitState()
+    }
   }
 
   publishPermissionRequest(request: AcpPermissionRequest): void {
@@ -60,7 +81,19 @@ class AcpRuntimePublicationOwner {
   }
 
   emitState(): void {
+    this.cancelScheduledStatePublication?.()
+    this.cancelScheduledStatePublication = undefined
     this.options.callbacks.onStateChanged?.(this.getSnapshot())
+  }
+
+  private scheduleStatePublication(): void {
+    if (this.cancelScheduledStatePublication) return
+
+    const schedule = this.options.scheduleStatePublication ?? scheduleStatePublication
+    this.cancelScheduledStatePublication = schedule(() => {
+      this.cancelScheduledStatePublication = undefined
+      this.options.callbacks.onStateChanged?.(this.getSnapshot())
+    })
   }
 }
 

--- a/src/main/acp/runtime-publication-owner.ts
+++ b/src/main/acp/runtime-publication-owner.ts
@@ -81,9 +81,13 @@ class AcpRuntimePublicationOwner {
   }
 
   emitState(): void {
+    this.cancelPendingStatePublication()
+    this.options.callbacks.onStateChanged?.(this.getSnapshot())
+  }
+
+  cancelPendingStatePublication(): void {
     this.cancelScheduledStatePublication?.()
     this.cancelScheduledStatePublication = undefined
-    this.options.callbacks.onStateChanged?.(this.getSnapshot())
   }
 
   private scheduleStatePublication(): void {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -21,6 +21,7 @@ import type { AcpConnectionCloseWorkflow } from './connection-close-workflow'
 import { composeAcpRuntimePlanWorkflow } from './runtime-plan-composition'
 import { SessionPlanInteractionOwner } from '../session-plan/session-plan-interaction-owner'
 import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
+import type { RuntimeEventInput } from './runtime-snapshot-owner'
 import { AcpPermissionContext } from './permission-context'
 import { ContextUsageTracker, type TokenCounter } from './context-usage-tracker'
 import {
@@ -984,6 +985,12 @@ const connectionCloseForTest = (
   runtime: AcpRuntime
 ): Pick<AcpConnectionCloseWorkflow, 'disconnectCurrent'> =>
   (runtime as unknown as { connectionClose: AcpConnectionCloseWorkflow }).connectionClose
+
+const publicationForTest = (
+  runtime: AcpRuntime
+): { pushEvent: (event: RuntimeEventInput) => void } =>
+  (runtime as unknown as { publication: { pushEvent: (event: RuntimeEventInput) => void } })
+    .publication
 
 const invalidatePendingSessionStartupsForTest = (runtime: AcpRuntime): void => {
   const owners = runtime as unknown as {
@@ -3935,6 +3942,33 @@ describe('ACP runtime session management', () => {
     // Calling it again after the process is gone is a no-op, not a crash.
     expect(() => runtime.shutdown()).not.toThrow()
     await vi.waitFor(() => expect(release).toHaveBeenCalledOnce())
+  })
+
+  it('cancels delayed state publication before synchronous shutdown releases the runtime', () => {
+    vi.useFakeTimers()
+    try {
+      const onStateChanged = vi.fn()
+      const runtime = new AcpRuntime({
+        appVersion: '0.2.0',
+        defaultCwd: '/workspace',
+        callbacks: { onStateChanged }
+      })
+
+      publicationForTest(runtime).pushEvent({
+        kind: 'message',
+        level: 'info',
+        role: 'assistant',
+        text: 'buffered state'
+      })
+      expect(onStateChanged).not.toHaveBeenCalled()
+
+      runtime.shutdown()
+      vi.advanceTimersByTime(16)
+
+      expect(onStateChanged).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('kills a child that finishes spawning after shutdown began, so quit-during-connect cannot orphan it', async () => {

--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -163,8 +163,15 @@
       @apply hidden;
     }
 
-    & > div > :empty {
+    & > div > :empty:not(:last-child) {
       @apply hidden;
+    }
+
+    & .agent-markdown > :last-child::after {
+      display: inline-block;
+      margin-inline-start: 0.08em;
+      color: currentColor;
+      opacity: 1;
     }
   }
 

--- a/src/renderer/src/components/environment-check-row.tsx
+++ b/src/renderer/src/components/environment-check-row.tsx
@@ -105,7 +105,7 @@ const EnvironmentCheckRow = ({ check, icon }: EnvironmentCheckRowProps): React.J
         </div>
         <p className="mt-0.5 text-xs text-muted-foreground">{check.summary}</p>
         {check.detail ? (
-          <p className="mt-1 break-words text-[11px] leading-relaxed text-muted-foreground/80">
+          <p className="mt-1 break-words text-[11px] leading-relaxed text-muted-foreground">
             {check.detail}
           </p>
         ) : null}

--- a/src/renderer/src/components/streamdown/AgentMarkdown.streaming.render.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.streaming.render.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AgentMarkdown } from './AgentMarkdown'
+
+describe('AgentMarkdown streaming presentation', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    container.remove()
+  })
+
+  it('continues painting while target content grows faster than animation frames', async () => {
+    await act(async () => {
+      root.render(<AgentMarkdown content="流" isAnimating />)
+    })
+
+    for (let length = 2; length <= 70; length += 1) {
+      await act(async () => vi.advanceTimersByTimeAsync(8))
+      await act(async () => {
+        root.render(<AgentMarkdown content={'流'.repeat(length)} isAnimating />)
+      })
+    }
+
+    const visible = container.querySelector('.agent-markdown')?.textContent ?? ''
+    expect(visible.length).toBeGreaterThan(0)
+    expect(visible.length).toBeLessThan(70)
+  })
+})

--- a/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
@@ -233,6 +233,29 @@ describe('AgentMarkdown renderer recovery', () => {
     expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('流')
   })
 
+  it('flushes a non-append correction that preserves the visible prefix', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    streamdownHarness.shouldThrow = false
+
+    await act(async () => {
+      root.render(<AgentMarkdown content="abcdef" isAnimating />)
+    })
+    await act(async () => vi.advanceTimersByTimeAsync(544))
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('abc')
+
+    await act(async () => {
+      root.render(<AgentMarkdown content="abcXYZ" isAnimating />)
+    })
+
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('abcXYZ')
+  })
+
   it('uses one lazy, no-referrer favicon source per hostname and falls back on failure', async () => {
     await act(async () => {
       root.render(

--- a/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
@@ -6,7 +6,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const streamdownHarness = vi.hoisted(() => ({
   shouldThrow: true,
   disallowedElements: undefined as readonly string[] | undefined,
-  components: undefined as Record<string, unknown> | undefined
+  components: undefined as Record<string, unknown> | undefined,
+  animated: undefined as unknown,
+  caret: undefined as string | undefined
 }))
 
 vi.mock('@streamdown/code', () => ({ code: {} }))
@@ -16,15 +18,21 @@ vi.mock('@streamdown/mermaid', () => ({ mermaid: {} }))
 vi.mock('streamdown', () => ({
   Streamdown: ({
     children,
+    animated,
+    caret,
     components,
     disallowedElements
   }: PropsWithChildren<{
+    animated?: unknown
+    caret?: string
     components?: Record<string, unknown>
     disallowedElements?: readonly string[]
   }>): React.JSX.Element => {
     if (streamdownHarness.shouldThrow) throw new Error('optimized Markdown chunk failed to load')
     streamdownHarness.components = components
     streamdownHarness.disallowedElements = disallowedElements
+    streamdownHarness.animated = animated
+    streamdownHarness.caret = caret
 
     return <div data-testid="rich-markdown">{children}</div>
   }
@@ -40,6 +48,8 @@ describe('AgentMarkdown renderer recovery', () => {
     streamdownHarness.shouldThrow = true
     streamdownHarness.disallowedElements = undefined
     streamdownHarness.components = undefined
+    streamdownHarness.animated = undefined
+    streamdownHarness.caret = undefined
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -48,7 +58,9 @@ describe('AgentMarkdown renderer recovery', () => {
 
   afterEach(() => {
     act(() => root.unmount())
+    vi.useRealTimers()
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
     container.remove()
   })
 
@@ -110,6 +122,115 @@ describe('AgentMarkdown renderer recovery', () => {
       root.render(<AgentMarkdown content="Session markdown" sessionLinks />)
     })
     expect(streamdownHarness.components?.a).toBe(SessionMessageLink)
+  })
+
+  it('reveals a buffered segment across frames while keeping a caret at the visible tail', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    streamdownHarness.shouldThrow = false
+    const content = '流畅输出'.repeat(13)
+
+    await act(async () => {
+      root.render(<AgentMarkdown content={content} isAnimating />)
+    })
+    expect(streamdownHarness.caret).toBe('block')
+    expect(streamdownHarness.animated).toBe(false)
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('')
+
+    await act(async () => vi.advanceTimersByTimeAsync(512))
+    const firstFrame = container.querySelector('[data-testid="rich-markdown"]')?.textContent ?? ''
+    expect(firstFrame).toBe('流')
+
+    for (let expectedLength = 2; expectedLength <= 12; expectedLength += 1) {
+      await act(async () => vi.advanceTimersByTimeAsync(16))
+      expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent?.length).toBe(
+        expectedLength
+      )
+    }
+
+    await act(async () => vi.advanceTimersByTimeAsync(900))
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe(content)
+
+    await act(async () => {
+      root.render(<AgentMarkdown content={content} />)
+    })
+    expect(streamdownHarness.caret).toBeUndefined()
+  })
+
+  it('keeps revealing while faster stream updates extend the target between frames', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    streamdownHarness.shouldThrow = false
+
+    await act(async () => {
+      root.render(<AgentMarkdown content="流" isAnimating />)
+    })
+
+    for (let length = 2; length <= 70; length += 1) {
+      await act(async () => vi.advanceTimersByTimeAsync(8))
+      await act(async () => {
+        root.render(<AgentMarkdown content={'流'.repeat(length)} isAnimating />)
+      })
+    }
+
+    const visible = container.querySelector('[data-testid="rich-markdown"]')?.textContent ?? ''
+    expect(visible.length).toBeGreaterThan(0)
+    expect(visible.length).toBeLessThan(70)
+    expect(streamdownHarness.caret).toBe('block')
+  })
+
+  it('prebuffers a small segment instead of exposing source jitter directly', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    streamdownHarness.shouldThrow = false
+
+    await act(async () => {
+      root.render(<AgentMarkdown content={'流'.repeat(12)} isAnimating />)
+    })
+    await act(async () => vi.advanceTimersByTimeAsync(480))
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('')
+    expect(streamdownHarness.caret).toBe('block')
+
+    await act(async () => {
+      root.render(<AgentMarkdown content={'流'.repeat(40)} isAnimating />)
+    })
+    await act(async () => vi.advanceTimersByTimeAsync(32))
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('流')
+  })
+
+  it('starts a slow stream after the bounded prebuffer delay', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    streamdownHarness.shouldThrow = false
+
+    await act(async () => {
+      root.render(<AgentMarkdown content={'流'.repeat(12)} isAnimating />)
+    })
+    await act(async () => vi.advanceTimersByTimeAsync(496))
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('')
+
+    await act(async () => vi.advanceTimersByTimeAsync(16))
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('流')
   })
 
   it('uses one lazy, no-referrer favicon source per hostname and falls back on failure', async () => {

--- a/src/renderer/src/components/streamdown/AgentMarkdown.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.tsx
@@ -19,6 +19,7 @@ import 'katex/dist/katex.min.css'
 import { AGENT_ALLOWED_TAGS, AGENT_CONTROLS } from './streamdown-config'
 import { LinkSafetyModal } from './LinkSafetyModal'
 import { normalizeAgentMarkdown } from './normalize-agent-markdown'
+import { useSmoothStreamingContent } from './use-smooth-streaming-content'
 import { cn } from '@/lib/utils'
 
 type AgentMarkdownProps = {
@@ -130,7 +131,7 @@ type AgentMarkdownErrorBoundaryProps = {
 }
 
 type AgentMarkdownErrorBoundaryState = {
-  content: string
+  failedContent: string | null
   hasError: boolean
 }
 
@@ -188,7 +189,7 @@ class AgentMarkdownErrorBoundary extends Component<
   AgentMarkdownErrorBoundaryState
 > {
   state: AgentMarkdownErrorBoundaryState = {
-    content: this.props.content,
+    failedContent: null,
     hasError: false
   }
 
@@ -196,17 +197,20 @@ class AgentMarkdownErrorBoundary extends Component<
     props: AgentMarkdownErrorBoundaryProps,
     state: AgentMarkdownErrorBoundaryState
   ): AgentMarkdownErrorBoundaryState | null {
-    if (props.content === state.content) return null
+    if (!state.hasError || state.failedContent === null || props.content === state.failedContent) {
+      return null
+    }
 
     // A changed message gets a fresh rich-render attempt instead of inheriting the previous failure.
-    return { content: props.content, hasError: false }
+    return { failedContent: null, hasError: false }
   }
 
   static getDerivedStateFromError(): Partial<AgentMarkdownErrorBoundaryState> {
-    return { hasError: true }
+    return { failedContent: null, hasError: true }
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.setState({ failedContent: this.props.content })
     console.error('Failed to render rich Markdown; showing plain text fallback.', error, errorInfo)
   }
 
@@ -253,6 +257,7 @@ const RichAgentMarkdown = memo(
           mode={isAnimating ? 'streaming' : 'static'}
           isAnimating={isAnimating}
           animated={false}
+          caret={isAnimating ? 'block' : undefined}
           parseIncompleteMarkdown={isAnimating}
           normalizeHtmlIndentation={!isAnimating}
           allowedTags={AGENT_ALLOWED_TAGS}
@@ -269,8 +274,9 @@ const RichAgentMarkdown = memo(
 
 RichAgentMarkdown.displayName = 'RichAgentMarkdown'
 
-// Keeps renderer-specific failures from unmounting the surrounding workspace.
-const AgentMarkdown = memo(
+// Renders already-paced content. Message surfaces that own a broader visual lifecycle can use this
+// directly so their cursor and terminal chrome settle in the same render.
+const PresentedAgentMarkdown = memo(
   ({
     content,
     isAnimating = false,
@@ -288,6 +294,29 @@ const AgentMarkdown = memo(
   )
 )
 
+PresentedAgentMarkdown.displayName = 'PresentedAgentMarkdown'
+
+// Keeps renderer-specific failures from unmounting the surrounding workspace.
+const AgentMarkdown = memo(
+  ({
+    content,
+    isAnimating = false,
+    allowMedia = true,
+    sessionLinks = false
+  }: AgentMarkdownProps): React.JSX.Element => {
+    const presentation = useSmoothStreamingContent(content, isAnimating)
+
+    return (
+      <PresentedAgentMarkdown
+        content={presentation.content}
+        isAnimating={presentation.isPresenting}
+        allowMedia={allowMedia}
+        sessionLinks={sessionLinks}
+      />
+    )
+  }
+)
+
 AgentMarkdown.displayName = 'AgentMarkdown'
 
-export { AgentMarkdown, SessionMessageLink }
+export { AgentMarkdown, PresentedAgentMarkdown, SessionMessageLink }

--- a/src/renderer/src/components/streamdown/AgentMarkdownFullscreenChrome.test.ts
+++ b/src/renderer/src/components/streamdown/AgentMarkdownFullscreenChrome.test.ts
@@ -4,6 +4,18 @@ import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 describe('AgentMarkdown fullscreen chrome', () => {
+  it('keeps the streaming caret visible before and between text segments', () => {
+    const css = readFileSync(resolve(__dirname, '../../assets/agent-markdown.css'), 'utf8')
+    const streamingBlock = css.slice(
+      css.indexOf('.agent-markdown-streaming'),
+      css.indexOf('/* --- Streamdown dropdown panels')
+    )
+
+    expect(streamingBlock).toContain('& > div > :empty:not(:last-child)')
+    expect(streamingBlock).toContain('opacity: 1')
+    expect(streamingBlock).not.toContain('cursor-blink')
+  })
+
   it('keeps Mermaid fullscreen functionality enabled while matching the dialog overlay chrome', () => {
     const css = readFileSync(resolve(__dirname, '../../assets/agent-markdown.css'), 'utf8')
     const config = readFileSync(resolve(__dirname, 'streamdown-config.ts'), 'utf8')

--- a/src/renderer/src/components/streamdown/use-smooth-streaming-content.ts
+++ b/src/renderer/src/components/streamdown/use-smooth-streaming-content.ts
@@ -116,13 +116,6 @@ const useSmoothStreamingContent = (
         pendingGraphemesRef.current.push(...appended)
         lastTargetUpdateAtRef.current = now
       }
-    } else if (content.startsWith(visibleContentRef.current)) {
-      pendingGraphemesRef.current = splitGraphemes(content.slice(visibleContentRef.current.length))
-      pendingIndexRef.current = 0
-      playbackStartedRef.current = false
-      presentationSpeedRef.current = 1
-      bufferingStartedAtRef.current = now
-      lastTargetUpdateAtRef.current = now
     } else {
       resetPending()
       commit(content)

--- a/src/renderer/src/components/streamdown/use-smooth-streaming-content.ts
+++ b/src/renderer/src/components/streamdown/use-smooth-streaming-content.ts
@@ -1,0 +1,237 @@
+import { useEffect, useRef, useState } from 'react'
+
+const RESERVE_GRAPHEMES = 18
+const PREBUFFER_MS = 500
+const RESERVE_HOLD_MS = 120
+const SPEED_UP_TO_TWO_GRAPHEMES = 120
+const SPEED_UP_TO_THREE_GRAPHEMES = 240
+const SPEED_DOWN_TO_TWO_GRAPHEMES = 180
+const SPEED_DOWN_TO_ONE_GRAPHEMES = 60
+const graphemeSegmenter =
+  typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : undefined
+
+const splitGraphemes = (value: string): string[] =>
+  graphemeSegmenter
+    ? Array.from(graphemeSegmenter.segment(value), ({ segment }) => segment)
+    : Array.from(value)
+
+const shouldAnimateStreamingContent = (): boolean => {
+  if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return false
+  return !(
+    typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+type SmoothStreamingContent = {
+  content: string
+  isPresenting: boolean
+}
+
+type PresentationSpeed = 1 | 2 | 3
+
+const nextPresentationSpeed = (
+  current: PresentationSpeed,
+  bufferedGraphemes: number
+): PresentationSpeed => {
+  if (current === 1) return bufferedGraphemes >= SPEED_UP_TO_TWO_GRAPHEMES ? 2 : 1
+  if (current === 2) {
+    if (bufferedGraphemes >= SPEED_UP_TO_THREE_GRAPHEMES) return 3
+    return bufferedGraphemes <= SPEED_DOWN_TO_ONE_GRAPHEMES ? 1 : 2
+  }
+  if (bufferedGraphemes <= SPEED_DOWN_TO_ONE_GRAPHEMES) return 1
+  return bufferedGraphemes <= SPEED_DOWN_TO_TWO_GRAPHEMES ? 2 : 3
+}
+
+// Keeps canonical Session content complete while a hysteretic jitter buffer advances the caret.
+// Backlog can raise the rate gradually, but separate up/down thresholds prevent speed oscillation.
+const useSmoothStreamingContent = (
+  content: string,
+  sourceOpen: boolean,
+  animateOnMount = sourceOpen
+): SmoothStreamingContent => {
+  const [visibleContent, setVisibleContent] = useState(() => (animateOnMount ? '' : content))
+  const [isPresenting, setIsPresenting] = useState(animateOnMount)
+  const visibleContentRef = useRef(visibleContent)
+  const targetContentRef = useRef(content)
+  const pendingGraphemesRef = useRef(animateOnMount ? splitGraphemes(content) : [])
+  const pendingIndexRef = useRef(0)
+  const playbackStartedRef = useRef(false)
+  const presentationSpeedRef = useRef<PresentationSpeed>(1)
+  const bufferingStartedAtRef = useRef<number | undefined>(undefined)
+  const lastTargetUpdateAtRef = useRef(0)
+  const sourceOpenRef = useRef(sourceOpen)
+  const isPresentingRef = useRef(animateOnMount)
+
+  useEffect(() => {
+    const now = Date.now()
+    const previousTarget = targetContentRef.current
+    sourceOpenRef.current = sourceOpen
+    targetContentRef.current = content
+    const commit = (value: string): void => {
+      if (visibleContentRef.current === value) return
+      visibleContentRef.current = value
+      setVisibleContent(value)
+    }
+    const setPresentationActive = (active: boolean): void => {
+      if (isPresentingRef.current === active) return
+      isPresentingRef.current = active
+      setIsPresenting(active)
+    }
+    const resetPending = (): void => {
+      pendingGraphemesRef.current = []
+      pendingIndexRef.current = 0
+      playbackStartedRef.current = false
+      presentationSpeedRef.current = 1
+      bufferingStartedAtRef.current = undefined
+    }
+
+    if (!shouldAnimateStreamingContent()) {
+      resetPending()
+      commit(content)
+      setPresentationActive(sourceOpen)
+      return
+    }
+    if (!sourceOpen && !isPresentingRef.current) {
+      resetPending()
+      commit(content)
+      return
+    }
+
+    if (content.startsWith(previousTarget)) {
+      const appended = splitGraphemes(content.slice(previousTarget.length))
+      if (
+        bufferingStartedAtRef.current === undefined &&
+        pendingGraphemesRef.current.length > pendingIndexRef.current
+      ) {
+        bufferingStartedAtRef.current = now
+        lastTargetUpdateAtRef.current = now
+      }
+      if (appended.length > 0) {
+        if (pendingGraphemesRef.current.length === pendingIndexRef.current) {
+          resetPending()
+          bufferingStartedAtRef.current = now
+        }
+        pendingGraphemesRef.current.push(...appended)
+        lastTargetUpdateAtRef.current = now
+      }
+    } else if (content.startsWith(visibleContentRef.current)) {
+      pendingGraphemesRef.current = splitGraphemes(content.slice(visibleContentRef.current.length))
+      pendingIndexRef.current = 0
+      playbackStartedRef.current = false
+      presentationSpeedRef.current = 1
+      bufferingStartedAtRef.current = now
+      lastTargetUpdateAtRef.current = now
+    } else {
+      resetPending()
+      commit(content)
+    }
+
+    const hasPending = pendingGraphemesRef.current.length > pendingIndexRef.current
+    if (sourceOpen || hasPending) setPresentationActive(true)
+    else setPresentationActive(false)
+  }, [content, sourceOpen])
+
+  useEffect(() => {
+    if (!isPresenting) return
+
+    let cancelled = false
+    let cancelFrame = (): void => undefined
+    const commit = (value: string): void => {
+      if (visibleContentRef.current === value) return
+      visibleContentRef.current = value
+      setVisibleContent(value)
+    }
+    const finishPresentation = (): void => {
+      if (sourceOpenRef.current || !isPresentingRef.current) return
+      isPresentingRef.current = false
+      setIsPresenting(false)
+    }
+    const resetPending = (): void => {
+      pendingGraphemesRef.current = []
+      pendingIndexRef.current = 0
+      playbackStartedRef.current = false
+      presentationSpeedRef.current = 1
+      bufferingStartedAtRef.current = undefined
+    }
+    const scheduleFrame = (callback: () => void): (() => void) => {
+      if (typeof requestAnimationFrame === 'function') {
+        const frameId = requestAnimationFrame(callback)
+        return () => cancelAnimationFrame(frameId)
+      }
+      const timer = setTimeout(callback, 16)
+      return () => clearTimeout(timer)
+    }
+    const revealNext = (): void => {
+      if (cancelled) return
+      const current = visibleContentRef.current
+      const target = targetContentRef.current
+      if (!target.startsWith(current) || !shouldAnimateStreamingContent()) {
+        resetPending()
+        commit(target)
+        finishPresentation()
+      } else if (current !== target) {
+        const pending = pendingGraphemesRef.current
+        const remaining = pending.length - pendingIndexRef.current
+        const now = Date.now()
+        const bufferedForMs = now - (bufferingStartedAtRef.current ?? now)
+        if (
+          !playbackStartedRef.current &&
+          (!sourceOpenRef.current || bufferedForMs >= PREBUFFER_MS)
+        ) {
+          playbackStartedRef.current = true
+        }
+        const sourceIsIdle =
+          !sourceOpenRef.current || now - lastTargetUpdateAtRef.current >= RESERVE_HOLD_MS
+        const releasable = playbackStartedRef.current
+          ? sourceIsIdle
+            ? remaining
+            : Math.max(0, remaining - RESERVE_GRAPHEMES)
+          : 0
+
+        if (releasable > 0) {
+          presentationSpeedRef.current = nextPresentationSpeed(
+            presentationSpeedRef.current,
+            remaining
+          )
+          const revealCount = Math.min(releasable, presentationSpeedRef.current)
+          const nextIndex = pendingIndexRef.current + revealCount
+          commit(`${current}${pending.slice(pendingIndexRef.current, nextIndex).join('')}`)
+          pendingIndexRef.current = nextIndex
+          if (nextIndex === pending.length) {
+            resetPending()
+            finishPresentation()
+          }
+        }
+      } else {
+        finishPresentation()
+      }
+
+      if (isPresentingRef.current) cancelFrame = scheduleFrame(revealNext)
+    }
+    const handleVisibilityChange = (): void => {
+      if (document.visibilityState !== 'hidden') return
+      resetPending()
+      commit(targetContentRef.current)
+      finishPresentation()
+    }
+
+    cancelFrame = scheduleFrame(revealNext)
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+    }
+
+    return () => {
+      cancelled = true
+      cancelFrame()
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange)
+      }
+    }
+  }, [isPresenting])
+
+  return { content: visibleContent, isPresenting }
+}
+
+export { useSmoothStreamingContent }

--- a/src/renderer/src/lib/acp/chat-events.ts
+++ b/src/renderer/src/lib/acp/chat-events.ts
@@ -35,10 +35,23 @@ const isAssistantRuntimeChatMessageEvent = (
 ): event is AssistantRuntimeChatMessageEvent =>
   isRuntimeChatMessageEvent(event) && event.role === 'assistant' && Boolean(event.sessionId)
 
+// Text-only assistant deltas are safe to pace and batch. Images remain hard presentation boundaries.
+const isBufferableAssistantTextEvent = (
+  event: AcpRuntimeEvent
+): event is AssistantRuntimeChatMessageEvent & { text: string } =>
+  isAssistantRuntimeChatMessageEvent(event) &&
+  typeof getAcpRuntimeEventText(event) === 'string' &&
+  !getAcpRuntimeEventImage(event)
+
 // Chooses the stream id used by the workspace store for chunk merging.
 const createRuntimeStreamId = (event: RuntimeChatMessageEvent): string =>
   event.messageId ?? event.id
 
-export { createRuntimeStreamId, isAssistantRuntimeChatMessageEvent, isRuntimeChatMessageEvent }
+export {
+  createRuntimeStreamId,
+  isAssistantRuntimeChatMessageEvent,
+  isBufferableAssistantTextEvent,
+  isRuntimeChatMessageEvent
+}
 export { getAcpRuntimeEventImage, getAcpRuntimeEventText }
 export type { RuntimeChatMessageEvent, RuntimeChatRole }

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -198,6 +198,157 @@ describe('workspace permission profile persistence', () => {
 })
 
 describe('workspace agent runtime event processing', () => {
+  const createTextEvents = (count: number): AcpRuntimeEvent[] =>
+    Array.from({ length: count }, (_, index) =>
+      createEvent({
+        id: `message-event-${index + 1}`,
+        role: 'assistant',
+        messageId: 'assistant-message-1',
+        text: '字'
+      })
+    )
+
+  const createTimerPresentation = (): {
+    now: () => number
+    schedule: (callback: () => void, delayMs: number) => () => void
+    shouldAnimate: () => boolean
+  } => ({
+    now: Date.now,
+    schedule: (callback: () => void, delayMs: number): (() => void) => {
+      const timer = setTimeout(callback, delayMs)
+      return () => clearTimeout(timer)
+    },
+    shouldAnimate: () => true
+  })
+
+  it('releases fast assistant text in grapheme-budgeted 30 fps batches', async () => {
+    vi.useFakeTimers()
+    try {
+      const visibleBatches: Array<{ ids: string[]; timestamp: number }> = []
+      const applyEvent = vi
+        .fn<(event: AcpRuntimeEvent) => Promise<boolean>>()
+        .mockResolvedValue(true)
+      const processor = createWorkspaceRuntimeEventProcessor(applyEvent, {
+        applyEventBatch: async (events) => {
+          visibleBatches.push({ ids: events.map((event) => event.id), timestamp: Date.now() })
+          return true
+        },
+        presentation: createTimerPresentation()
+      })
+
+      const drain = processor.process(createTextEvents(24))
+      await vi.advanceTimersByTimeAsync(200)
+      await drain
+
+      expect(visibleBatches.map(({ ids }) => ids.length)).toEqual([8, 8, 8])
+      expect(visibleBatches.flatMap(({ ids }) => ids)).toEqual(
+        createTextEvents(24).map((event) => event.id)
+      )
+      expect(
+        visibleBatches
+          .slice(1)
+          .every((batch, index) => batch.timestamp - visibleBatches[index].timestamp >= 33)
+      ).toBe(true)
+      expect(applyEvent).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('catches up before an ordinary tool boundary within four presentation frames', async () => {
+    vi.useFakeTimers()
+    try {
+      const calls: Array<{ kind: 'text' | 'tool'; timestamp: number; count: number }> = []
+      const processor = createWorkspaceRuntimeEventProcessor(
+        async (event) => {
+          calls.push({
+            kind: event.kind === 'tool' ? 'tool' : 'text',
+            timestamp: Date.now(),
+            count: 1
+          })
+          return true
+        },
+        {
+          applyEventBatch: async (events) => {
+            calls.push({ kind: 'text', timestamp: Date.now(), count: events.length })
+            return true
+          },
+          presentation: createTimerPresentation()
+        }
+      )
+      const tool = createEvent({
+        id: 'tool-event-1',
+        kind: 'tool',
+        toolCallId: 'tool-1',
+        status: 'in_progress'
+      })
+
+      const drain = processor.process([...createTextEvents(32), tool])
+      await vi.advanceTimersByTimeAsync(200)
+      await drain
+
+      expect(calls.map(({ kind, count }) => `${kind}:${count}`)).toEqual([
+        'text:8',
+        'text:8',
+        'text:8',
+        'text:8',
+        'tool:1'
+      ])
+      expect(calls.at(-1)!.timestamp - calls[0].timestamp).toBeLessThanOrEqual(132)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('flushes all pending text immediately at a terminal boundary', async () => {
+    const calls: string[] = []
+    const processor = createWorkspaceRuntimeEventProcessor(
+      async (event) => {
+        calls.push(event.kind)
+        return true
+      },
+      {
+        applyEventBatch: async (events) => {
+          calls.push(`text:${events.length}`)
+          return true
+        },
+        presentation: createTimerPresentation()
+      }
+    )
+
+    await processor.process([
+      ...createTextEvents(24),
+      createEvent({ id: 'stop-event-1', kind: 'stop' })
+    ])
+
+    expect(calls).toEqual(['text:24', 'stop'])
+  })
+
+  it('flushes accepted text immediately at a persistence barrier', async () => {
+    vi.useFakeTimers()
+    try {
+      const visibleEventIds: string[] = []
+      const processor = createWorkspaceRuntimeEventProcessor(async () => true, {
+        applyEventBatch: async (events) => {
+          visibleEventIds.push(...events.map((event) => event.id))
+          return true
+        },
+        presentation: createTimerPresentation()
+      })
+
+      const visibleDrain = processor.process(createTextEvents(24))
+      await Promise.resolve()
+      await Promise.resolve()
+      const persistenceDrain = processor.drain()
+      await Promise.all([visibleDrain, persistenceDrain])
+
+      expect(visibleEventIds).toEqual(createTextEvents(24).map((event) => event.id))
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not mark failed runtime events as processed so they can retry', async () => {
     const processedEventIds = new Set<string>()
     const event = createEvent({

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -40,6 +40,7 @@ import {
   getAcpRuntimeEventImage,
   getAcpRuntimeEventText,
   isAssistantRuntimeChatMessageEvent,
+  isBufferableAssistantTextEvent,
   isRuntimeChatMessageEvent
 } from './chat-events'
 
@@ -862,8 +863,53 @@ const applyWorkspaceRuntimeEvent = async (
   return false
 }
 
+// A presentation tick contains only adjacent text deltas from one Session lane. Projecting the
+// complete tick in one store transaction preserves every event id while avoiding one React update
+// and growing-Markdown parse per provider token.
+const applyWorkspaceRuntimeEventBatch = async (events: AcpRuntimeEvent[]): Promise<boolean> => {
+  if (events.length === 0) return true
+  if (!events.every(isBufferableAssistantTextEvent)) {
+    for (const event of events) await applyWorkspaceRuntimeEvent(event)
+    return true
+  }
+
+  const store = useSessionStore.getState()
+  const inputs: Parameters<typeof store.appendAgentMessageChunks>[0] = []
+  const completedActivityGroups = new Set<string>()
+
+  for (const event of events) {
+    const content = getAcpRuntimeEventText(event)
+    const session = store.sessions.find((candidate) => candidate.id === event.sessionId)
+    if (
+      session?.agentFrameworkId === 'codex' &&
+      typeof content === 'string' &&
+      content.trim().length > 0 &&
+      isNonActionableCodexDiagnostic(content)
+    ) {
+      continue
+    }
+
+    const activityGroupKey = `${event.sessionId}\0${event.promptMessageId ?? ''}`
+    if (!completedActivityGroups.has(activityGroupKey)) {
+      store.completeActivityGroup(event.sessionId, event.promptMessageId)
+      completedActivityGroups.add(activityGroupKey)
+    }
+    inputs.push({
+      sessionId: event.sessionId,
+      streamId: createRuntimeStreamId(event),
+      eventId: event.id,
+      promptMessageId: event.promptMessageId,
+      content
+    })
+  }
+
+  store.appendAgentMessageChunks(inputs)
+  return true
+}
+
 export {
   applyWorkspaceRuntimeEvent,
+  applyWorkspaceRuntimeEventBatch,
   assembleReviewRunRequest,
   suppressAutoReviewsForQuit,
   suppressNextAutoReview,

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -16,7 +16,14 @@ import {
   acceptAcpRuntimeSnapshotRevision,
   resetAcpRuntimeSnapshotRevisionForTests
 } from './runtime-snapshot-revision-owner'
-import { applyWorkspaceRuntimeEvent } from './workspace-events'
+import { isBufferableAssistantTextEvent } from './chat-events'
+import { applyWorkspaceRuntimeEvent, applyWorkspaceRuntimeEventBatch } from './workspace-events'
+import {
+  createWorkspaceRuntimePresentationBuffer,
+  liveWorkspaceRuntimePresentation,
+  type WorkspacePresentationLane,
+  type WorkspaceRuntimePresentation
+} from './workspace-runtime-presentation-buffer'
 
 // Snapshot projections retain only transition edges; durable chat facts remain in Session Store.
 const pendingPermissionSessionIds = new Set<string>()
@@ -24,6 +31,11 @@ const pendingElicitationSessionIds = new Set<string>()
 const firstOutputWaitingSessionIds = new Set<string>()
 
 type RuntimeEventApplier = (event: AcpRuntimeEvent) => Promise<boolean>
+type RuntimeEventBatchApplier = (events: AcpRuntimeEvent[]) => Promise<boolean>
+type WorkspaceRuntimeEventProcessorOptions = {
+  applyEventBatch?: RuntimeEventBatchApplier
+  presentation?: WorkspaceRuntimePresentation
+}
 type WorkspacePermissionLifecycleEvent = AcpRuntimeEvent & { permissionRequestId: string }
 type WorkspacePermissionLifecycleObserver = {
   shouldApply: (event: WorkspacePermissionLifecycleEvent) => boolean
@@ -43,10 +55,14 @@ const processVisibleWorkspaceRuntimeEvents = async (
   events: AcpRuntimeEvent[],
   processedEventIds: Set<string>,
   applyEvent: RuntimeEventApplier = applyWorkspaceRuntimeEvent,
-  processingEventIds = new Set<string>()
+  processingEventIds = new Set<string>(),
+  options: {
+    applyEventBatch?: RuntimeEventBatchApplier
+    retainedEvents?: AcpRuntimeEvent[]
+  } = {}
 ): Promise<void> => {
   // Runtime snapshots are bounded, so forget ids that can no longer be replayed from the source list.
-  const visibleEventIds = new Set(events.map((event) => event.id))
+  const visibleEventIds = new Set((options.retainedEvents ?? events).map((event) => event.id))
 
   for (const eventId of processedEventIds) {
     if (!visibleEventIds.has(eventId)) processedEventIds.delete(eventId)
@@ -56,26 +72,46 @@ const processVisibleWorkspaceRuntimeEvents = async (
     if (!visibleEventIds.has(eventId)) processingEventIds.delete(eventId)
   }
 
-  for (const event of events) {
+  for (let index = 0; index < events.length; index += 1) {
+    const event = events[index]
     if (processedEventIds.has(event.id) || processingEventIds.has(event.id)) continue
 
-    processingEventIds.add(event.id)
+    const batch = [event]
+    if (options.applyEventBatch && isBufferableAssistantTextEvent(event)) {
+      for (let candidateIndex = index + 1; candidateIndex < events.length; candidateIndex += 1) {
+        const candidate = events[candidateIndex]
+        if (!isBufferableAssistantTextEvent(candidate) || candidate.sessionId !== event.sessionId) {
+          break
+        }
+        index = candidateIndex
+        if (!processedEventIds.has(candidate.id) && !processingEventIds.has(candidate.id)) {
+          batch.push(candidate)
+        }
+      }
+    }
+
+    for (const candidate of batch) processingEventIds.add(candidate.id)
     try {
       // Apply visible events sequentially so message chunks and artifact finalization stay ordered.
-      await applyEvent(event)
-      processedEventIds.add(event.id)
+      if (batch.length > 1 && options.applyEventBatch) {
+        await options.applyEventBatch(batch)
+      } else {
+        await applyEvent(event)
+      }
+      for (const candidate of batch) processedEventIds.add(candidate.id)
     } catch {
       // Artifact finalization errors are recorded by the adapter before throwing.
       // Keeping this id unprocessed lets the same visible runtime event retry.
       continue
     } finally {
-      processingEventIds.delete(event.id)
+      for (const candidate of batch) processingEventIds.delete(candidate.id)
     }
   }
 }
 
 const createWorkspaceRuntimeEventProcessor = (
-  applyEvent: RuntimeEventApplier = applyWorkspaceRuntimeEvent
+  applyEvent: RuntimeEventApplier = applyWorkspaceRuntimeEvent,
+  options: WorkspaceRuntimeEventProcessorOptions = {}
 ): WorkspaceRuntimeEventProcessor => {
   type EventLane = {
     acceptedEvents: Map<string, AcpRuntimeEvent>
@@ -84,10 +120,12 @@ const createWorkspaceRuntimeEventProcessor = (
     processingEventIds: Set<string>
     drainInFlight?: Promise<void>
     drainAgain: boolean
+    presentation: WorkspacePresentationLane
   }
 
   const unscopedEventLane = Symbol('unscoped-workspace-runtime-events')
   const eventLanes = new Map<string | symbol, EventLane>()
+  const presentationBuffer = createWorkspaceRuntimePresentationBuffer(options.presentation)
   let latestEvents: AcpRuntimeEvent[] = []
   let acceptedEventVersion = 0
 
@@ -102,7 +140,8 @@ const createWorkspaceRuntimeEventProcessor = (
         failedEventIds: new Set<string>(),
         processedEventIds: new Set<string>(),
         processingEventIds: new Set<string>(),
-        drainAgain: false
+        drainAgain: false,
+        presentation: presentationBuffer.createLane()
       }
       eventLanes.set(laneKey, lane)
     }
@@ -127,6 +166,11 @@ const createWorkspaceRuntimeEventProcessor = (
     if (lane.acceptedEvents.size === 0 && !lane.drainInFlight) eventLanes.delete(laneKey)
   }
 
+  const pendingLaneEvents = (lane: EventLane): AcpRuntimeEvent[] =>
+    [...lane.acceptedEvents.values()].filter(
+      (event) => !lane.processedEventIds.has(event.id) && !lane.processingEventIds.has(event.id)
+    )
+
   const drainLane = async (laneKey: string | symbol): Promise<void> => {
     const lane = getEventLane(laneKey)
 
@@ -138,8 +182,14 @@ const createWorkspaceRuntimeEventProcessor = (
     lane.drainInFlight = (async () => {
       do {
         lane.drainAgain = false
+        const pendingBeforeWait = pendingLaneEvents(lane)
+        await presentationBuffer.prepare(lane.presentation, pendingBeforeWait)
+        const selectedEvents = presentationBuffer.select(lane.presentation, pendingLaneEvents(lane))
+        if (selectedEvents.length === 0) continue
+
+        const processedCount = lane.processedEventIds.size
         await processVisibleWorkspaceRuntimeEvents(
-          [...lane.acceptedEvents.values()],
+          selectedEvents,
           lane.processedEventIds,
           async (event) => {
             const hadFailed = lane.failedEventIds.has(event.id)
@@ -160,8 +210,18 @@ const createWorkspaceRuntimeEventProcessor = (
               throw error
             }
           },
-          lane.processingEventIds
+          lane.processingEventIds,
+          {
+            applyEventBatch: options.applyEventBatch,
+            retainedEvents: [...lane.acceptedEvents.values()]
+          }
         )
+        const madeProgress = lane.processedEventIds.size > processedCount
+        const hasPending = pendingLaneEvents(lane).length > 0
+        if (madeProgress) {
+          presentationBuffer.recordProgress(lane.presentation, selectedEvents, hasPending)
+          if (hasPending) lane.drainAgain = true
+        }
       } while (lane.drainAgain)
     })()
 
@@ -191,6 +251,7 @@ const createWorkspaceRuntimeEventProcessor = (
           // A bounded source snapshot may evict this event before a slow predecessor finishes.
           lane.acceptedEvents.set(event.id, event)
           acceptedEventVersion += 1
+          presentationBuffer.forceOnAccepted(lane.presentation, event)
         }
       }
 
@@ -205,13 +266,20 @@ const createWorkspaceRuntimeEventProcessor = (
     },
     drain: async (sessionId) => {
       if (sessionId !== undefined) {
-        if (eventLanes.has(sessionId)) await drainLane(sessionId)
+        const lane = eventLanes.get(sessionId)
+        if (lane) {
+          presentationBuffer.force(lane.presentation)
+          await drainLane(sessionId)
+        }
         return
       }
 
       let drainedVersion: number
       do {
         drainedVersion = acceptedEventVersion
+        for (const lane of eventLanes.values()) {
+          presentationBuffer.force(lane.presentation)
+        }
         await Promise.all([...eventLanes.keys()].map((laneKey) => drainLane(laneKey)))
       } while (drainedVersion !== acceptedEventVersion)
     }
@@ -240,24 +308,30 @@ const subscribeWorkspacePermissionLifecycle = (
   return () => permissionLifecycleObservers.delete(observer)
 }
 
-const liveWorkspaceRuntimeEventProcessor = createWorkspaceRuntimeEventProcessor(async (event) => {
-  const permissionLifecycleEvent = isWorkspacePermissionLifecycleEvent(event) ? event : undefined
-  if (
-    permissionLifecycleEvent &&
-    [...permissionLifecycleObservers].some(
-      (observer) => !observer.shouldApply(permissionLifecycleEvent)
-    )
-  ) {
-    return true
-  }
-  const applied = await applyWorkspaceRuntimeEvent(event)
-  if (applied && permissionLifecycleEvent) {
-    for (const observer of permissionLifecycleObservers) {
-      observer.onApplied(permissionLifecycleEvent)
+const liveWorkspaceRuntimeEventProcessor = createWorkspaceRuntimeEventProcessor(
+  async (event) => {
+    const permissionLifecycleEvent = isWorkspacePermissionLifecycleEvent(event) ? event : undefined
+    if (
+      permissionLifecycleEvent &&
+      [...permissionLifecycleObservers].some(
+        (observer) => !observer.shouldApply(permissionLifecycleEvent)
+      )
+    ) {
+      return true
     }
+    const applied = await applyWorkspaceRuntimeEvent(event)
+    if (applied && permissionLifecycleEvent) {
+      for (const observer of permissionLifecycleObservers) {
+        observer.onApplied(permissionLifecycleEvent)
+      }
+    }
+    return applied
+  },
+  {
+    applyEventBatch: applyWorkspaceRuntimeEventBatch,
+    presentation: liveWorkspaceRuntimePresentation
   }
-  return applied
-})
+)
 
 // Projects runtime foreground ownership and its initial silent gap into renderer-only state. Unknown
 // ids belong to background/runtime-only sessions; repeated snapshots must not restart the gap timer.

--- a/src/renderer/src/lib/acp/workspace-runtime-presentation-buffer.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-presentation-buffer.ts
@@ -1,0 +1,221 @@
+import type { AcpRuntimeEvent } from '../../../../shared/acp'
+import { getAcpRuntimeEventText, isBufferableAssistantTextEvent } from './chat-events'
+
+type WorkspacePresentationScheduler = (callback: () => void, delayMs: number) => () => void
+
+type WorkspaceRuntimePresentation = {
+  now: () => number
+  schedule: WorkspacePresentationScheduler
+  shouldAnimate: () => boolean
+}
+
+type WorkspacePresentationLane = {
+  force: boolean
+  nextAt: number
+  toolCatchUpFramesRemaining?: number
+  wait?: {
+    cancel: () => void
+    finish: () => void
+  }
+}
+
+const PRESENTATION_INTERVAL_MS = 33
+const PRESENTATION_BASE_GRAPHEMES = 8
+const PRESENTATION_LAG_FRAMES = 7
+const TOOL_CATCH_UP_FRAMES = 4
+const MAX_BUFFERED_GRAPHEMES = 32_768
+const graphemeSegmenter =
+  typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : undefined
+
+const countEventGraphemes = (event: AcpRuntimeEvent): number => {
+  const text = getAcpRuntimeEventText(event) ?? ''
+  return graphemeSegmenter
+    ? Array.from(graphemeSegmenter.segment(text)).length
+    : Array.from(text).length
+}
+
+const isImmediatePresentationBoundary = (event: AcpRuntimeEvent): boolean =>
+  !isBufferableAssistantTextEvent(event) && event.kind !== 'tool'
+
+const defaultPresentationSchedule: WorkspacePresentationScheduler = (callback, delayMs) => {
+  let frameId: number | undefined
+  let timerId: ReturnType<typeof setTimeout> | undefined
+  let finished = false
+  const cleanup = (): void => {
+    if (timerId !== undefined) clearTimeout(timerId)
+    if (frameId !== undefined && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(frameId)
+    }
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }
+  const finish = (): void => {
+    if (finished) return
+    finished = true
+    cleanup()
+    callback()
+  }
+  const handleVisibilityChange = (): void => {
+    if (document.visibilityState === 'hidden') finish()
+  }
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+  }
+  if (typeof requestAnimationFrame === 'function') {
+    const deadline = performance.now() + delayMs
+    const tick = (timestamp: number): void => {
+      if (timestamp >= deadline) finish()
+      else frameId = requestAnimationFrame(tick)
+    }
+    frameId = requestAnimationFrame(tick)
+  } else {
+    timerId = setTimeout(finish, delayMs)
+  }
+
+  return () => {
+    finished = true
+    cleanup()
+  }
+}
+
+const shouldAnimateWorkspacePresentation = (): boolean => {
+  if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return false
+  return !(
+    typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+const liveWorkspaceRuntimePresentation: WorkspaceRuntimePresentation = {
+  now: Date.now,
+  schedule: defaultPresentationSchedule,
+  shouldAnimate: shouldAnimateWorkspacePresentation
+}
+
+const createWorkspaceRuntimePresentationBuffer = (
+  presentation?: WorkspaceRuntimePresentation
+): {
+  createLane: () => WorkspacePresentationLane
+  forceOnAccepted: (lane: WorkspacePresentationLane, event: AcpRuntimeEvent) => void
+  force: (lane: WorkspacePresentationLane) => void
+  prepare: (lane: WorkspacePresentationLane, pending: AcpRuntimeEvent[]) => Promise<void>
+  select: (lane: WorkspacePresentationLane, pending: AcpRuntimeEvent[]) => AcpRuntimeEvent[]
+  recordProgress: (
+    lane: WorkspacePresentationLane,
+    selected: AcpRuntimeEvent[],
+    hasPending: boolean
+  ) => void
+} => {
+  const wake = (lane: WorkspacePresentationLane): void => {
+    const wait = lane.wait
+    if (!wait) return
+    wait.cancel()
+    wait.finish()
+  }
+
+  const force = (lane: WorkspacePresentationLane): void => {
+    lane.force = true
+    wake(lane)
+  }
+
+  const prepare = async (
+    lane: WorkspacePresentationLane,
+    pending: AcpRuntimeEvent[]
+  ): Promise<void> => {
+    const first = pending[0]
+    const boundary = pending.find((event) => !isBufferableAssistantTextEvent(event))
+    if (
+      !presentation ||
+      lane.force ||
+      !presentation.shouldAnimate() ||
+      !first ||
+      !isBufferableAssistantTextEvent(first) ||
+      (boundary && isImmediatePresentationBoundary(boundary))
+    ) {
+      return
+    }
+
+    const delayMs = Math.max(0, lane.nextAt - presentation.now())
+    if (delayMs === 0) return
+    await new Promise<void>((resolve) => {
+      let finished = false
+      const finish = (): void => {
+        if (finished) return
+        finished = true
+        lane.wait = undefined
+        resolve()
+      }
+      lane.wait = { cancel: presentation.schedule(finish, delayMs), finish }
+    })
+  }
+
+  const select = (
+    lane: WorkspacePresentationLane,
+    pending: AcpRuntimeEvent[]
+  ): AcpRuntimeEvent[] => {
+    if (!presentation) return pending
+    const first = pending[0]
+    if (!first || !isBufferableAssistantTextEvent(first)) return first ? [first] : []
+
+    const textRun = pending.slice(
+      0,
+      pending.findIndex((event) => !isBufferableAssistantTextEvent(event)) === -1
+        ? pending.length
+        : pending.findIndex((event) => !isBufferableAssistantTextEvent(event))
+    )
+    const boundary = pending[textRun.length]
+    const totalGraphemes = textRun.reduce((total, event) => total + countEventGraphemes(event), 0)
+    if (
+      lane.force ||
+      !presentation.shouldAnimate() ||
+      (boundary && isImmediatePresentationBoundary(boundary)) ||
+      totalGraphemes > MAX_BUFFERED_GRAPHEMES
+    ) {
+      lane.toolCatchUpFramesRemaining = undefined
+      return textRun
+    }
+
+    const remaining =
+      boundary?.kind === 'tool'
+        ? (lane.toolCatchUpFramesRemaining ?? TOOL_CATCH_UP_FRAMES)
+        : PRESENTATION_LAG_FRAMES
+    const targetGraphemes = Math.max(
+      boundary?.kind === 'tool' ? 1 : PRESENTATION_BASE_GRAPHEMES,
+      Math.ceil(totalGraphemes / remaining)
+    )
+    lane.toolCatchUpFramesRemaining =
+      boundary?.kind === 'tool' ? Math.max(1, remaining - 1) : undefined
+
+    const selected: AcpRuntimeEvent[] = []
+    let selectedGraphemes = 0
+    for (const event of textRun) {
+      selected.push(event)
+      selectedGraphemes += countEventGraphemes(event)
+      if (selectedGraphemes >= targetGraphemes) break
+    }
+    if (selected.length === textRun.length) lane.toolCatchUpFramesRemaining = undefined
+    return selected
+  }
+
+  return {
+    createLane: () => ({ force: false, nextAt: 0 }),
+    forceOnAccepted: (lane, event) => {
+      if (isImmediatePresentationBoundary(event)) force(lane)
+    },
+    force,
+    prepare,
+    select,
+    recordProgress: (lane, selected, hasPending) => {
+      if (selected.some(isBufferableAssistantTextEvent) && presentation?.shouldAnimate()) {
+        lane.nextAt = presentation.now() + PRESENTATION_INTERVAL_MS
+      }
+      if (!hasPending) lane.force = false
+    }
+  }
+}
+
+export { createWorkspaceRuntimePresentationBuffer, liveWorkspaceRuntimePresentation }
+export type { WorkspacePresentationLane, WorkspaceRuntimePresentation }

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -448,6 +448,8 @@ beforeEach(() => {
 
 afterEach(() => {
   act(() => root.unmount())
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
   container.remove()
 })
 
@@ -1589,6 +1591,86 @@ describe('ConversationPanel composer intake', () => {
     expect(followUp.disabled).toBe(false)
     expect(container.querySelector('[aria-label="Send Side chat follow up"]')).toBeNull()
     expect(container.querySelector('[aria-label="Cancel Side chat response"]')).not.toBeNull()
+  })
+
+  it('paces only the live Side chat turn and keeps its tool behind visible text', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    const sideChatProps = {
+      onSendSideChat: vi.fn(async () => true),
+      onSideChatDraftChange: vi.fn(),
+      onCancelSideChat: vi.fn(),
+      onCloseSideChat: vi.fn()
+    }
+    const entries = [
+      { id: 'user-history', kind: 'message' as const, role: 'user' as const, text: 'Old prompt' },
+      {
+        id: 'assistant-history',
+        kind: 'message' as const,
+        role: 'assistant' as const,
+        text: 'Historical answer'
+      },
+      { id: 'user-live', kind: 'message' as const, role: 'user' as const, text: 'New prompt' },
+      {
+        id: 'assistant-live',
+        kind: 'message' as const,
+        role: 'assistant' as const,
+        text: '流畅输出'
+      }
+    ]
+
+    renderPanel({
+      ...sideChatProps,
+      sideChat: {
+        generation: 1,
+        parentSessionId: 'session-existing',
+        projectId: 'project-a',
+        sideSessionId: 'side-1',
+        draft: '',
+        running: true,
+        entries
+      }
+    })
+
+    expect(container.textContent).toContain('Historical answer')
+    expect(container.textContent).not.toContain('流畅输出')
+    expect(container.querySelectorAll('.agent-markdown-streaming')).toHaveLength(1)
+
+    await act(async () => vi.advanceTimersByTimeAsync(496))
+    expect(container.textContent).not.toContain('流畅输出')
+    await act(async () => vi.advanceTimersByTimeAsync(16))
+    expect(container.textContent).toContain('流')
+
+    renderPanel({
+      ...sideChatProps,
+      sideChat: {
+        generation: 1,
+        parentSessionId: 'session-existing',
+        projectId: 'project-a',
+        sideSessionId: 'side-1',
+        draft: '',
+        running: true,
+        entries: [
+          ...entries,
+          {
+            id: 'tool-live',
+            kind: 'tool',
+            title: 'Tool after current answer',
+            status: 'in_progress'
+          }
+        ]
+      }
+    })
+    expect(container.textContent).not.toContain('Tool after current answer')
+
+    await act(async () => vi.advanceTimersByTimeAsync(96))
+    expect(container.textContent).toContain('流畅输出')
+    expect(container.textContent).toContain('Tool after current answer')
   })
 
   it('keeps main approval and ask-user surfaces waiting while Side chat is open', () => {

--- a/src/renderer/src/pages/workspace/SideChatPanel.tsx
+++ b/src/renderer/src/pages/workspace/SideChatPanel.tsx
@@ -2,16 +2,26 @@
  * Hallmark · modern-minimal · quiet utility · palette: existing semantic theme
  * Macrostructure: integrated in-flow side panel · pre-emit critique: P5 H5 E4 S5 R5 V4
  */
-import { AgentMarkdown } from '@/components/streamdown/AgentMarkdown'
+import { PresentedAgentMarkdown } from '@/components/streamdown/AgentMarkdown'
+import { useSmoothStreamingContent } from '@/components/streamdown/use-smooth-streaming-content'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Textarea } from '@/components/ui/textarea'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { ArrowUp, MessageCircleMore, Plus, Square, X } from 'lucide-react'
-import { useEffect, useRef, type KeyboardEvent, type ReactNode, type SetStateAction } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+  type SetStateAction
+} from 'react'
 
 import { ComposerModelPicker } from './ComposerModelPicker'
 import { ResizableBottomPanel } from './ResizableBottomPanel'
-import type { SideChatView } from './use-side-chat-controller'
+import type { SideChatEntry, SideChatView } from './use-side-chat-controller'
 
 type SideChatPanelProps = Readonly<{
   view: SideChatView
@@ -21,6 +31,39 @@ type SideChatPanelProps = Readonly<{
   onClose: () => void
   controls?: ReactNode
 }>
+
+type SideChatMessageEntry = Extract<SideChatEntry, { kind: 'message' }>
+
+type SideChatPresentationState = Readonly<{
+  generation: number
+  entryIds: Set<string>
+}>
+
+const SideChatAssistantMessage = ({
+  entry,
+  sourceOpen,
+  animateOnMount,
+  onPresentationChange
+}: {
+  entry: SideChatMessageEntry
+  sourceOpen: boolean
+  animateOnMount: boolean
+  onPresentationChange: (entryId: string, presenting: boolean) => void
+}): React.JSX.Element => {
+  const presentation = useSmoothStreamingContent(entry.text, sourceOpen, animateOnMount)
+
+  useLayoutEffect(() => {
+    onPresentationChange(entry.id, presentation.isPresenting)
+    return () => onPresentationChange(entry.id, false)
+  }, [entry.id, onPresentationChange, presentation.isPresenting])
+
+  return (
+    <PresentedAgentMarkdown
+      content={presentation.content}
+      isAnimating={presentation.isPresenting}
+    />
+  )
+}
 
 const SideChatPanel = ({
   view,
@@ -32,13 +75,44 @@ const SideChatPanel = ({
 }: SideChatPanelProps): React.JSX.Element => {
   const messageScrollRef = useRef<HTMLDivElement>(null)
   const followUpRef = useRef<HTMLTextAreaElement>(null)
+  const [presentationState, setPresentationState] = useState<SideChatPresentationState>(() => ({
+    generation: view.generation,
+    entryIds: new Set()
+  }))
+  const lastUserEntryIndex = view.entries.findLastIndex(
+    (entry) => entry.kind === 'message' && entry.role === 'user'
+  )
+  const lastUserEntryId = lastUserEntryIndex >= 0 ? view.entries[lastUserEntryIndex]?.id : undefined
+  const liveTurnUserId = view.liveTurnUserEntryId ?? (view.running ? lastUserEntryId : undefined)
+  const presentingEntryIds =
+    presentationState.generation === view.generation
+      ? presentationState.entryIds
+      : new Set<string>()
+  const presentationBarrierIndex = view.entries.findIndex((entry) =>
+    presentingEntryIds.has(entry.id)
+  )
+  const handlePresentationChange = useCallback(
+    (entryId: string, presenting: boolean): void => {
+      setPresentationState((currentState) => {
+        const currentEntryIds =
+          currentState.generation === view.generation ? currentState.entryIds : new Set<string>()
+        if (currentEntryIds.has(entryId) === presenting) return currentState
+
+        const nextEntryIds = new Set(currentEntryIds)
+        if (presenting) nextEntryIds.add(entryId)
+        else nextEntryIds.delete(entryId)
+        return { generation: view.generation, entryIds: nextEntryIds }
+      })
+    },
+    [view.generation]
+  )
 
   useEffect(() => {
     const messageScroll = messageScrollRef.current?.querySelector<HTMLElement>(
       '[data-slot="scroll-area-viewport"]'
     )
     if (messageScroll) messageScroll.scrollTop = messageScroll.scrollHeight
-  }, [view.entries, view.running, view.error])
+  }, [presentationBarrierIndex, view.entries, view.running, view.error])
   useEffect(() => {
     if (view.sideSessionId) followUpRef.current?.focus()
   }, [view.sideSessionId])
@@ -99,26 +173,47 @@ const SideChatPanel = ({
             className="h-full overscroll-contain text-[14px] leading-6"
           >
             <div className="px-5 py-4">
-              {view.entries.map((entry) =>
-                entry.kind === 'tool' ? (
-                  <div key={entry.id} className="my-2 text-[12px] text-text-300">
-                    {entry.title}
-                    {entry.status ? ` · ${entry.status}` : ''}
-                  </div>
-                ) : entry.role === 'user' ? (
-                  <div key={entry.id} className="my-3 flex justify-end">
-                    <div className="max-w-[80%] whitespace-pre-wrap break-words rounded-2xl bg-bg-200 px-3 py-2 text-text-000">
-                      {entry.text}
+              {view.entries.map((entry, entryIndex) => {
+                if (presentationBarrierIndex >= 0 && entryIndex > presentationBarrierIndex) {
+                  return null
+                }
+                if (entry.kind === 'tool') {
+                  return (
+                    <div key={entry.id} className="my-2 text-[12px] text-text-300">
+                      {entry.title}
+                      {entry.status ? ` · ${entry.status}` : ''}
                     </div>
-                  </div>
-                ) : (
+                  )
+                }
+                if (entry.role === 'user') {
+                  return (
+                    <div key={entry.id} className="my-3 flex justify-end">
+                      <div className="max-w-[80%] whitespace-pre-wrap break-words rounded-2xl bg-bg-200 px-3 py-2 text-text-000">
+                        {entry.text}
+                      </div>
+                    </div>
+                  )
+                }
+
+                const animateOnMount =
+                  lastUserEntryId === liveTurnUserId && entryIndex > lastUserEntryIndex
+                const sourceOpen =
+                  animateOnMount && view.running && entryIndex === view.entries.length - 1
+                return (
                   <div key={entry.id} className="my-3 min-w-0 text-text-000">
-                    <AgentMarkdown content={entry.text} isAnimating={view.running} />
+                    <SideChatAssistantMessage
+                      entry={entry}
+                      sourceOpen={sourceOpen}
+                      animateOnMount={animateOnMount}
+                      onPresentationChange={handlePresentationChange}
+                    />
                   </div>
                 )
-              )}
-              {view.running ? <div className="py-2 text-text-300">Thinking…</div> : null}
-              {view.error ? (
+              })}
+              {view.running && presentationBarrierIndex < 0 ? (
+                <div className="py-2 text-text-300">Thinking…</div>
+              ) : null}
+              {view.error && presentationBarrierIndex < 0 ? (
                 <div role="alert" className="py-2 text-[12px] text-danger-000">
                   {view.error}
                 </div>

--- a/src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx
@@ -598,7 +598,7 @@ describe('release-gate Subagent surfaces', () => {
       })
     })
 
-    expect(screen.getByText('Live child evidence')).toBeTruthy()
+    expect(await screen.findByText('Live child evidence')).toBeTruthy()
     expect(screen.queryByText('Stale child output')).toBeNull()
     expect(useSessionStore.getState().sessions[0]).toEqual(rootBefore)
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -18,7 +18,8 @@ vi.mock('@/components/ui/message-scroller', () => ({
 }))
 
 vi.mock('@/components/streamdown/AgentMarkdown', () => ({
-  AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
+  AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+  PresentedAgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
 }))
 
 // Artifact rendering is outside this test's boundary and imports the PDF worker bundle.

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -15,7 +15,8 @@ vi.mock('@/components/ui/message-scroller', () => ({
 }))
 
 vi.mock('@/components/streamdown/AgentMarkdown', () => ({
-  AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
+  AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+  PresentedAgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
 }))
 
 vi.mock('./artifact-preview', () => ({

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -1,4 +1,5 @@
-import { AgentMarkdown } from '@/components/streamdown/AgentMarkdown'
+import { PresentedAgentMarkdown } from '@/components/streamdown/AgentMarkdown'
+import { useSmoothStreamingContent } from '@/components/streamdown/use-smooth-streaming-content'
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -20,7 +21,7 @@ import {
   MessageCircleMore,
   Pencil
 } from 'lucide-react'
-import { useEffect, useId, useRef, useState, type FocusEvent } from 'react'
+import { useEffect, useId, useLayoutEffect, useRef, useState, type FocusEvent } from 'react'
 import type { ArtifactPreviewResult } from '../../../../shared/artifacts'
 import type { ProvenanceMessagePart } from '../../../../shared/artifact-provenance'
 import type { AcpTurnTokenUsage } from '../../../../shared/acp'
@@ -91,6 +92,8 @@ type WorkspaceMessageItemProps = {
   // Immutable Provenance uses the normal message surface but keeps mention pills non-interactive.
   // These path-free parts override message.parts only for display; editing still uses live parts.
   staticParts?: ProvenanceMessagePart[]
+  onPresentationChange?: (messageId: string, presenting: boolean) => void
+  presentationSourceOpen?: boolean
 }
 
 const ARTIFACT_GALLERY_VISIBLE_COUNT = 5
@@ -788,11 +791,31 @@ const WorkspaceMessageItem = ({
   subsequentTurns = 0,
   revisionNavigation,
   artifacts = [],
-  staticParts
+  staticParts,
+  onPresentationChange,
+  presentationSourceOpen
 }: WorkspaceMessageItemProps): React.JSX.Element => {
   const isUserMessage = message.role === 'user'
   const isSideChatAdvisory =
     message.relayedFrom?.kind === 'side-chat' && message.relayedFrom.direction === 'to-main'
+  const presentsAssistantMessage = !isUserMessage && !isSideChatAdvisory
+  const shouldAnimateAssistant = presentsAssistantMessage && message.status === 'streaming'
+  const assistantSourceOpen = shouldAnimateAssistant && (presentationSourceOpen ?? true)
+  const assistantPresentation = useSmoothStreamingContent(
+    presentsAssistantMessage ? message.content : '',
+    assistantSourceOpen,
+    shouldAnimateAssistant
+  )
+  const isAssistantPresenting = presentsAssistantMessage && assistantPresentation.isPresenting
+
+  // Keep later transcript items behind this message's visual buffer. Layout timing prevents a tool
+  // boundary from painting once before the parent learns that this row is still presenting.
+  useLayoutEffect(() => {
+    if (!presentsAssistantMessage || !onPresentationChange) return
+    onPresentationChange(message.id, isAssistantPresenting)
+    return () => onPresentationChange(message.id, false)
+  }, [isAssistantPresenting, message.id, onPresentationChange, presentsAssistantMessage])
+
   const uploads = message.uploads ?? []
   const hasTurnUsage = Boolean(message.turnUsage || message.turnUsageUnavailable)
   const showTurnUsage = hasTurnUsage || (message.status === 'complete' && Boolean(runtimeIdentity))
@@ -873,7 +896,7 @@ const WorkspaceMessageItem = ({
     <MessageScrollerItem
       key={message.id}
       messageId={message.id}
-      disableContainment={message.status === 'streaming'}
+      disableContainment={message.status === 'streaming' || isAssistantPresenting}
       scrollAnchor={message.role === 'user'}
       className="min-w-0"
     >
@@ -1044,15 +1067,16 @@ const WorkspaceMessageItem = ({
         ) : (
           <div className={cn(assistantMessageSurfaceClassName, 'select-text overflow-visible')}>
             {message.content ? (
-              <AgentMarkdown
-                content={message.content}
-                isAnimating={message.status === 'streaming'}
+              <PresentedAgentMarkdown
+                content={assistantPresentation.content}
+                isAnimating={isAssistantPresenting}
                 sessionLinks
               />
             ) : null}
             <MessageImageList images={message.images ?? []} />
             <MessageArtifactList onPreviewArtifact={onPreviewArtifact} artifacts={artifacts} />
             {showAssistantFooter &&
+            !isAssistantPresenting &&
             (terminalDate || (terminalTimestamp !== undefined && showTurnUsage)) ? (
               <div
                 data-slot="assistant-message-footer"

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -69,7 +69,18 @@ vi.mock('@/components/streamdown/AgentMarkdown', () => ({
   AgentMarkdown: ({ content }: { content: string }) => {
     agentMarkdownRenderMock(content)
     return <div>{content}</div>
-  }
+  },
+  PresentedAgentMarkdown: ({
+    content,
+    isAnimating
+  }: {
+    content: string
+    isAnimating?: boolean
+  }) => (
+    <div data-testid="presented-agent-markdown" data-animating={isAnimating || undefined}>
+      {content}
+    </div>
+  )
 }))
 
 vi.mock('@/components/ui/message-scroller', () => {
@@ -282,7 +293,135 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await act(async () => {
       root.unmount()
     })
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
     container.remove()
+  })
+
+  it('keeps later tools behind the visible assistant prefix', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const prompt = createMessage({ id: 'prompt-stream', sortIndex: 1, createdAt: 100 })
+    const reply = createMessage({
+      id: 'reply-stream',
+      role: 'agent',
+      content: '流畅输出',
+      status: 'streaming',
+      streamId: 'stream-1',
+      responseToMessageId: prompt.id,
+      sortIndex: 2,
+      createdAt: 101
+    })
+    const render = async (session: ChatSession): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+        )
+      })
+    }
+
+    root = createRoot(container)
+    await render(
+      createSession({
+        activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+        messages: [prompt, reply]
+      })
+    )
+    expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
+      ''
+    )
+
+    await act(async () => vi.advanceTimersByTimeAsync(512))
+    expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
+      '流'
+    )
+
+    const tool = createActivity({
+      id: 'tool-after-stream',
+      title: 'Tool after buffered text',
+      promptMessageId: prompt.id,
+      sortIndex: 3,
+      createdAt: 102
+    })
+    await render(
+      createSession({
+        activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+        messages: [prompt, reply],
+        activities: [tool]
+      })
+    )
+    expect(
+      container.querySelector('[data-message-id="activity-group-tool-after-stream"]')
+    ).toBeNull()
+
+    await act(async () => vi.advanceTimersByTimeAsync(96))
+    expect(container.textContent).toContain('流畅输出')
+    expect(
+      container.querySelector('[data-message-id="activity-group-tool-after-stream"]')
+    ).not.toBeNull()
+  })
+
+  it('keeps terminal metadata behind the final visible assistant prefix', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const prompt = createMessage({ id: 'prompt-terminal', sortIndex: 1, createdAt: 100 })
+    const reply = createMessage({
+      id: 'reply-terminal',
+      role: 'agent',
+      content: '完整结尾',
+      status: 'streaming',
+      streamId: 'stream-terminal',
+      responseToMessageId: prompt.id,
+      sortIndex: 2,
+      createdAt: 101
+    })
+    const render = async (session: ChatSession): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+        )
+      })
+    }
+
+    root = createRoot(container)
+    await render(
+      createSession({
+        activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+        messages: [prompt, reply]
+      })
+    )
+    await render(
+      createSession({
+        status: 'idle',
+        messages: [
+          prompt,
+          {
+            ...reply,
+            status: 'complete',
+            completedAt: 200,
+            updatedAt: 200
+          }
+        ]
+      })
+    )
+    expect(container.textContent).not.toContain('Completed')
+    expect(container.textContent).not.toContain('完整结尾')
+
+    await act(async () => vi.advanceTimersByTimeAsync(96))
+    expect(container.textContent).toContain('完整结尾')
+    expect(container.textContent).toContain('Completed')
   })
 
   it('opens the exact durable source Frame from an inline upward message', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -14,7 +14,16 @@ import { describe, expect, it, vi } from 'vitest'
 import type { ToolActivityDetails } from './workspace-tool-activity-details'
 
 vi.mock('@/components/streamdown/AgentMarkdown', () => ({
-  AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
+  AgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+  PresentedAgentMarkdown: ({ content }: { content: string }) => <div>{content}</div>
+}))
+
+vi.mock('@/components/streamdown/use-smooth-streaming-content', () => ({
+  useSmoothStreamingContent: (
+    content: string,
+    sourceOpen: boolean,
+    animateOnMount = sourceOpen
+  ) => ({ content, isPresenting: animateOnMount })
 }))
 
 vi.mock('@/components/ui/message-scroller', () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -92,6 +92,11 @@ type SessionScopedActivityExpansionState = {
   overrides: ActivityExpansionOverrides
 }
 
+type SessionScopedMessagePresentationState = {
+  sessionId: string | undefined
+  messageIds: Set<string>
+}
+
 type MessageUploadAttachment = NonNullable<ChatSession['messages'][number]['uploads']>[number]
 const conversationContentClassName = 'relative mx-auto w-full max-w-4xl pb-[56px]'
 // How long a "no longer available" mention notice stays visible before auto-dismissing.
@@ -319,6 +324,11 @@ const WorkspaceMessageScrollerImpl = ({
       sessionId: undefined,
       overrides: {}
     }))
+  const [messagePresentationState, setMessagePresentationState] =
+    useState<SessionScopedMessagePresentationState>(() => ({
+      sessionId: undefined,
+      messageIds: new Set()
+    }))
   const collapsedActivityGroups =
     collapsedActivityGroupState.sessionId === currentSessionId
       ? collapsedActivityGroupState.groupIds
@@ -334,6 +344,28 @@ const WorkspaceMessageScrollerImpl = ({
   const conversationItems = useMemo(
     () => groupConversationItems(rawConversationItems, activeSession?.activityGroups),
     [activeSession?.activityGroups, rawConversationItems]
+  )
+  const presentingMessageIds =
+    messagePresentationState.sessionId === currentSessionId
+      ? messagePresentationState.messageIds
+      : new Set<string>()
+  const presentationBarrierIndex = conversationItems.findIndex(
+    (item) => item.type === 'message' && presentingMessageIds.has(item.message.id)
+  )
+  const handleMessagePresentationChange = useCallback(
+    (messageId: string, presenting: boolean): void => {
+      setMessagePresentationState((currentState) => {
+        const currentMessageIds =
+          currentState.sessionId === currentSessionId ? currentState.messageIds : new Set<string>()
+        if (currentMessageIds.has(messageId) === presenting) return currentState
+
+        const nextMessageIds = new Set(currentMessageIds)
+        if (presenting) nextMessageIds.add(messageId)
+        else nextMessageIds.delete(messageId)
+        return { sessionId: currentSessionId, messageIds: nextMessageIds }
+      })
+    },
+    [currentSessionId]
   )
   const durablePlanOwnerActivityId = useMemo(
     () => findDurablePlanOwnerActivityId(activeSession, rawConversationItems),
@@ -617,6 +649,10 @@ const WorkspaceMessageScrollerImpl = ({
               <div className={conversationContentClassName}>
                 {/* Messages and tool activities share one sorted transcript timeline. */}
                 {conversationItems.map((item, itemIndex) => {
+                  if (presentationBarrierIndex >= 0 && itemIndex > presentationBarrierIndex) {
+                    return null
+                  }
+
                   if (item.type === 'message') {
                     const artifacts = artifactVisibility.artifactsForMessage(item.message)
                     // Jobs pre-assigned to this slot: each job appears in exactly one slot.
@@ -697,6 +733,11 @@ const WorkspaceMessageScrollerImpl = ({
                           : undefined,
                       artifacts
                     }
+                    if (item.message.role === 'agent') {
+                      messageItemProps.onPresentationChange = handleMessagePresentationChange
+                      messageItemProps.presentationSourceOpen =
+                        itemIndex === conversationItems.length - 1
+                    }
 
                     return (
                       <div key={item.id}>
@@ -719,7 +760,9 @@ const WorkspaceMessageScrollerImpl = ({
                         ) : (
                           <WorkspaceMessageItem {...messageItemProps} canEditMessage={false} />
                         )}
-                        {currentSessionId && item.message.role === 'agent' ? (
+                        {currentSessionId &&
+                        item.message.role === 'agent' &&
+                        !presentingMessageIds.has(item.message.id) ? (
                           <WorkspaceMessageReview
                             projectId={currentProjectId}
                             sessionId={currentSessionId}
@@ -852,25 +895,29 @@ const WorkspaceMessageScrollerImpl = ({
                 })}
 
                 {/* Render any remaining unbound completed jobs after all conversation items */}
-                {trailingJobs.map((job) => (
-                  <MessageScrollerItem
-                    key={`completed-job-${job.job_id}`}
-                    messageId={`completed-job-${job.job_id}`}
-                    className="min-w-0"
-                  >
-                    <div className="px-4 py-1 md:px-6">
-                      <div className="mx-auto w-full max-w-4xl">
-                        <CompletedJobCard job={job} onOpen={handleOpenJobDetail} />
-                      </div>
-                    </div>
-                  </MessageScrollerItem>
-                ))}
+                {presentationBarrierIndex < 0
+                  ? trailingJobs.map((job) => (
+                      <MessageScrollerItem
+                        key={`completed-job-${job.job_id}`}
+                        messageId={`completed-job-${job.job_id}`}
+                        className="min-w-0"
+                      >
+                        <div className="px-4 py-1 md:px-6">
+                          <div className="mx-auto w-full max-w-4xl">
+                            <CompletedJobCard job={job} onOpen={handleOpenJobDetail} />
+                          </div>
+                        </div>
+                      </MessageScrollerItem>
+                    ))
+                  : null}
 
-                {trailingContent}
+                {presentationBarrierIndex < 0 ? trailingContent : null}
 
-                {isResumingSession && activeSession ? (
+                {presentationBarrierIndex < 0 && isResumingSession && activeSession ? (
                   <WorkspaceAgentLoadingRow sessionId={activeSession.id} phase="resuming" />
-                ) : agentLoadingPhase !== 'hidden' && activeSession ? (
+                ) : presentationBarrierIndex < 0 &&
+                  agentLoadingPhase !== 'hidden' &&
+                  activeSession ? (
                   <WorkspaceAgentLoadingRow
                     sessionId={activeSession.id}
                     phase={agentLoadingPhase}

--- a/src/renderer/src/pages/workspace/artifact-preview.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.tsx
@@ -401,11 +401,11 @@ export const ArtifactPreview = ({
     return (
       <div className="size-full overflow-hidden bg-bg-000 px-2 py-1.5">
         {previewText ? (
-          <pre className="m-0 line-clamp-4 whitespace-pre-wrap break-words font-mono text-[9px] leading-[1.15] text-text-100">
+          <pre className="m-0 line-clamp-4 whitespace-pre-wrap break-words font-mono text-[9px] leading-[1.15] text-text-000">
             {previewText}
           </pre>
         ) : (
-          <span className="text-[11px] font-semibold text-text-100">
+          <span className="text-[11px] font-semibold text-text-000">
             {getArtifactExtensionLabel(artifact)}
           </span>
         )}

--- a/src/renderer/src/pages/workspace/use-side-chat-controller.test.ts
+++ b/src/renderer/src/pages/workspace/use-side-chat-controller.test.ts
@@ -64,6 +64,8 @@ describe('Side chat renderer controller', () => {
       role: 'user',
       text: 'Initial question'
     })
+    const initialLiveTurnUserEntryId = result.current.view?.entries[0]?.id
+    expect(result.current.view?.liveTurnUserEntryId).toBe(initialLiveTurnUserEntryId)
 
     act(() => {
       eventListener?.({
@@ -111,6 +113,11 @@ describe('Side chat renderer controller', () => {
       expect(await result.current.send('Follow up')).toBe(true)
     })
     expect(send).toHaveBeenCalledWith({ sideSessionId: 'side-1', text: 'Follow up' })
+    const followUpEntry = result.current.view?.entries.findLast(
+      (entry) => entry.kind === 'message' && entry.role === 'user'
+    )
+    expect(result.current.view?.liveTurnUserEntryId).toBe(followUpEntry?.id)
+    expect(result.current.view?.liveTurnUserEntryId).not.toBe(initialLiveTurnUserEntryId)
 
     act(() => result.current.close())
     expect(close).toHaveBeenCalledWith({ sideSessionId: 'side-1' })
@@ -350,6 +357,7 @@ describe('Side chat renderer controller', () => {
     await render()
     expect(list).toHaveBeenCalledOnce()
     expect(result.current.view?.entries[0]).toMatchObject({ text: 'B' })
+    expect(result.current.view?.liveTurnUserEntryId).toBeUndefined()
 
     act(() => {
       eventListener?.({
@@ -375,6 +383,7 @@ describe('Side chat renderer controller', () => {
       expect.objectContaining({ text: 'A' }),
       expect.objectContaining({ text: 'A answer' })
     ])
+    expect(result.current.view?.liveTurnUserEntryId).toBe('user-a')
     act(() => root.unmount())
   })
 

--- a/src/renderer/src/pages/workspace/use-side-chat-controller.ts
+++ b/src/renderer/src/pages/workspace/use-side-chat-controller.ts
@@ -23,6 +23,7 @@ type SideChatView = Readonly<{
   projectId: string
   sideSessionId?: string
   entries: readonly SideChatEntry[]
+  liveTurnUserEntryId?: string
   draft: string
   running: boolean
   error?: string
@@ -60,6 +61,9 @@ const errorText = (error: unknown): string =>
 
 const hasMainConversation = (session: ChatSession | undefined): boolean =>
   Boolean(session?.messages.some((message) => message.role === 'user' && !message.relayedFrom))
+
+const getLastSideChatUserEntryId = (entries: readonly SideChatEntry[]): string | undefined =>
+  entries.findLast((entry) => entry.kind === 'message' && entry.role === 'user')?.id
 
 const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
   const [views, setViews] = useState<ReadonlyMap<string, SideChatView>>(() => new Map())
@@ -99,6 +103,9 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
       projectId: snapshot.projectId,
       sideSessionId: snapshot.sideSessionId,
       entries: snapshot.entries,
+      liveTurnUserEntryId: snapshot.running
+        ? getLastSideChatUserEntryId(snapshot.entries)
+        : current?.liveTurnUserEntryId,
       draft: current?.draft ?? '',
       running: snapshot.running,
       error: snapshot.error
@@ -256,12 +263,14 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
       }
       sequenceRef.current += 1
       const generation = sequenceRef.current
+      const userEntryId = `side-user-${generation}-1`
       const next: SideChatView = {
         generation,
         revision: 0,
         parentSessionId: parent.sessionId,
         projectId: parent.projectId,
-        entries: [{ id: `side-user-${generation}-1`, kind: 'message', role: 'user', text }],
+        entries: [{ id: userEntryId, kind: 'message', role: 'user', text }],
+        liveTurnUserEntryId: userEntryId,
         draft: '',
         running: true
       }
@@ -297,17 +306,19 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
       const current = viewsRef.current.get(parentSessionId)
       if (!current?.sideSessionId || current.running || !text) return false
       sequenceRef.current += 1
+      const userEntryId = `side-user-${current.generation}-${sequenceRef.current}`
       const next = {
         ...current,
         entries: [
           ...current.entries,
           {
-            id: `side-user-${current.generation}-${sequenceRef.current}`,
+            id: userEntryId,
             kind: 'message' as const,
             role: 'user' as const,
             text
           }
         ],
+        liveTurnUserEntryId: userEntryId,
         running: true,
         error: undefined
       }

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -330,8 +330,9 @@ describe('conversation message scroller integration', () => {
     expect(workspaceMessageScrollerSource).toContain('<WorkspaceMessageItem')
     expect(workspaceMessageItemSource).toContain("scrollAnchor={message.role === 'user'}")
     expect(workspaceMessageItemSource).toContain('messageId={message.id}')
-    expect(workspaceMessageItemSource).toContain('<AgentMarkdown')
-    expect(workspaceMessageItemSource).toContain('content={message.content}')
+    expect(workspaceMessageItemSource).toContain('<PresentedAgentMarkdown')
+    expect(workspaceMessageItemSource).toContain('content={assistantPresentation.content}')
+    expect(workspaceMessageItemSource).toContain('useSmoothStreamingContent(')
     expect(workspaceMessageItemSource).toContain('sessionLinks')
   })
 
@@ -511,8 +512,8 @@ describe('conversation message scroller integration', () => {
       'canExpand={Boolean(details.query || details.resultCount)}'
     )
     expect(workspaceMessageItemSource).toContain('const WorkspaceMessageItem')
-    expect(workspaceMessageItemSource).toContain('<AgentMarkdown')
-    expect(workspaceMessageItemSource).toContain('content={message.content}')
+    expect(workspaceMessageItemSource).toContain('<PresentedAgentMarkdown')
+    expect(workspaceMessageItemSource).toContain('content={assistantPresentation.content}')
     expect(workspaceAgentLoadingRowSource).toContain('const WorkspaceAgentLoadingRow')
     expect(workspaceAgentLoadingRowSource).toContain('thinking')
   })
@@ -593,7 +594,7 @@ describe('conversation message scroller integration', () => {
     expect(workspaceAgentLoadingRowSource).toContain('role="status"')
     expect(workspaceAgentLoadingRowSource).toContain('aria-live="polite"')
     expect(workspaceAgentLoadingRowSource).toContain('thinking')
-    expect(workspaceMessageItemSource).toContain("isAnimating={message.status === 'streaming'}")
+    expect(workspaceMessageItemSource).toContain('isAnimating={isAssistantPresenting}')
   })
 })
 

--- a/src/renderer/src/stores/session-store-run-projection-owner.ts
+++ b/src/renderer/src/stores/session-store-run-projection-owner.ts
@@ -53,6 +53,7 @@ type SessionStateSetter = StoreApi<SessionStoreData>['setState']
 
 export type SessionRunProjectionActions = {
   appendAgentMessageChunk: (input: AppendAgentMessageChunkInput) => AppendMessageResult | undefined
+  appendAgentMessageChunks: (inputs: AppendAgentMessageChunkInput[]) => AppendMessageResult[]
   setAwaitingFirstAgentOutput: (sessionId: string, waiting: boolean) => void
   setAgentPromptInFlight: (sessionId: string, inFlight: boolean) => void
   setElicitationPending: (sessionId: string, pending: boolean) => void
@@ -146,23 +147,40 @@ export const createSessionRunProjectionOwner = <
   get: StoreApi<State>['getState']
 ): SessionRunProjectionActions => {
   const setSessionState = set as SessionStateSetter
+  const appendAgentMessageChunks = (
+    inputs: AppendAgentMessageChunkInput[]
+  ): AppendMessageResult[] => {
+    if (inputs.length === 0) return []
+
+    const state = get()
+    let sessions = state.sessions
+    let shouldCommit = false
+    const results: AppendMessageResult[] = []
+
+    for (const input of inputs) {
+      if (!input.sessionId) continue
+      const session = sessions.find((candidate) => candidate.id === input.sessionId)
+      if (!session) continue
+      const projection = projectAgentMessageChunk(session, input)
+      if (projection.result) results.push(projection.result)
+      if (!projection.shouldCommit) continue
+
+      shouldCommit = true
+      sessions = sessions.map((candidate) =>
+        candidate.id === input.sessionId ? projection.session : candidate
+      )
+    }
+
+    if (shouldCommit) setSessionState({ sessions } as Partial<State>)
+    return results
+  }
 
   return {
     appendAgentMessageChunk: (input) => {
-      if (!input.sessionId) return undefined
-      const state = get()
-      const session = state.sessions.find((candidate) => candidate.id === input.sessionId)
-      if (!session) return undefined
-      const projection = projectAgentMessageChunk(session, input)
-      if (!projection.result) return undefined
-      if (projection.shouldCommit)
-        setSessionState({
-          sessions: state.sessions.map((candidate) =>
-            candidate.id === input.sessionId ? projection.session : candidate
-          )
-        } as Partial<State>)
-      return projection.result
+      return appendAgentMessageChunks([input])[0]
     },
+
+    appendAgentMessageChunks,
 
     setAwaitingFirstAgentOutput: (sessionId, waiting) => {
       setSessionState((state) => ({

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -942,6 +942,7 @@ describe('Session Store architecture', () => {
       ownerTypeProperties('session-store-run-projection-owner.ts', 'SessionRunProjectionActions')
     ).toEqual([
       'appendAgentMessageChunk',
+      'appendAgentMessageChunks',
       'attachRunArtifacts',
       'beginActivityGroup',
       'beginCompaction',

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -169,6 +169,37 @@ describe('session store', () => {
     expect(useSessionStore.getState().sessions[0].awaitingFirstAgentOutput).toBeUndefined()
   })
 
+  it('projects a visible Agent text batch with one store commit', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Stream a response'
+    })
+    let commits = 0
+    const unsubscribe = useSessionStore.subscribe(() => (commits += 1))
+
+    useSessionStore.getState().appendAgentMessageChunks([
+      {
+        sessionId: 'transport-session-1',
+        streamId: 'assistant-message-1',
+        eventId: 'event-1',
+        content: 'Hello'
+      },
+      {
+        sessionId: 'transport-session-1',
+        streamId: 'assistant-message-1',
+        eventId: 'event-2',
+        content: ' world'
+      }
+    ])
+    unsubscribe()
+
+    expect(commits).toBe(1)
+    expect(useSessionStore.getState().sessions[0].messages.at(-1)).toMatchObject({
+      content: 'Hello world',
+      eventIds: ['event-1', 'event-2']
+    })
+  })
+
   it('keeps waiting through whitespace-only Agent chunks', () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',
@@ -4280,6 +4311,7 @@ describe('session store public contract', () => {
       [
         'activateMessageBranch',
         'appendAgentMessageChunk',
+        'appendAgentMessageChunks',
         'appendPendingUserMessage',
         'appendRoutedUserMessage',
         'appendUserMessage',


### PR DESCRIPTION
## Problem

High-throughput model responses could overwhelm cumulative state publication and rich Markdown rendering. This made text appear frame-stuttered, allowed tool rows to paint before their preceding text, and could show terminal metadata such as Completed while buffered text was still being revealed. Side Chat had the same ordering risk.

## Proposed change

- Coalesce high-frequency assistant state snapshots while keeping runtime events and hard lifecycle boundaries immediate.
- Cancel delayed state publication before a runtime generation leaves teardown ownership, including synchronous shutdown, unexpected close, retirement, quit, and update-gate paths.
- Add a renderer presentation buffer plus a requestAnimationFrame-driven grapheme buffer with a 500 ms maximum first-output wait, a small reserve, and hysteretic 1/2/3-grapheme catch-up.
- Render a steady cursor at the visible text boundary and hold later tools, loading indicators, reviews, trailing content, and terminal metadata behind the active presentation barrier.
- Apply the same live-turn pacing to Side Chat while leaving historical Side Chat messages static.
- Flush safely for hidden tabs, reduced-motion users, persistence drains, and all non-append content changes.
- Strengthen the contrast of onboarding detail and compact file-preview text so accessibility results are stable across macOS rendering environments.

## Scope and non-goals

- No persisted Session, database, IPC payload, or historical-data schema changes.
- The Side Chat live-turn marker is renderer-only transient view state and is not written to durable snapshots.
- Preview surfaces are not given a second presentation buffer; the already-paced Markdown surface is split out so workspace and Side Chat do not double-buffer content.
- This does not add user-facing speed controls or change model/provider transport behavior.

## Acceptance criteria and validation

The interactive cadence and ordering were manually accepted in the development UI.

- Main-process publication coalescing, hard-boundary flushing, and teardown cancellation -> runtime publication/close workflow tests -> passed.
- Shared ACP lifecycle behavior -> Claude Code, OpenCode, Codex Responses, and Codex bridge all use the same runtime publication and close workflow owners; no framework-specific wire shape, replay, or adapter behavior changed.
- Renderer event batching, persistence drain, and Session projection -> impacted ACP/Session test set -> passed.
- Grapheme pacing, adaptive thresholds, cursor behavior, non-append correction flushing, tool ordering, and terminal footer ordering -> focused renderer interaction/render tests -> passed.
- Side Chat live-turn selection, hydration, Follow up switching, and presentation barriers -> controller and Conversation Panel tests -> passed.
- Accessibility regression -> Electron accessibility E2E for startup/home and permission/file preview states -> 2 passed.
- Final review impact set -> publication owner, close workflow, runtime lifecycle, runtime shutdown, and Markdown streaming tests -> 16 passed.
- Type safety -> node and web typecheck -> passed.
- Static checks -> changed-file ESLint -> passed with 0 errors and 0 warnings; repository lint has 0 errors and pre-existing warnings outside this change.
- Full fallback -> 14,336 tests passed and 198 skipped; 2 unrelated concurrent wait tests failed only in the combined run, then both passed in an isolated rerun.

The full test suite and the isolated rerun used loopback access because several project-owned integration tests bind to 127.0.0.1.

## Review focus

- Ordering at assistant-text to tool and assistant-text to terminal-state boundaries.
- Publication cancellation before runtime ownership is released on every teardown path.
- Presentation-hook transitions around the first chunk, idle reserve release, source close, non-append correction, reduced motion, and hidden tabs.
- Side Chat distinction between restored historical content and the current live turn.

Independent review identified and drove the teardown-publication and non-append-correction regression coverage. The remaining uncovered risk is subjective cadence variance across refresh rates and operating systems; the current development environment was manually accepted, while PR Gate and platform lanes remain authoritative.
