### PR TITLE
fix(connectors): restore CLI paths for custom MCP servers

### DIFF
--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, it, expect, vi } from 'vitest'
+import { delimiter } from 'node:path'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
@@ -10,6 +11,7 @@ import { z } from 'zod'
 import { McpClientManager, McpToolCallError, buildTransport } from './mcp-client-manager'
 import type { CustomMcpServerConfig } from './mcp-client-manager'
 import { OAuthCallbackServer, type PersistentOAuthClientProvider } from './oauth-client'
+import { EXTRA_PATH_DIRS } from '../settings/shell-path'
 
 afterEach(() => vi.restoreAllMocks())
 
@@ -468,6 +470,18 @@ describe('McpClientManager', () => {
 })
 
 describe('buildTransport', () => {
+  const stdioTransportEnvironment = (env?: Record<string, string>): Record<string, string> => {
+    const transport = buildTransport({
+      id: 'srv-stdio',
+      name: 'stdio-server',
+      transport: 'stdio',
+      command: 'npx',
+      env
+    }) as unknown as { _serverParams: { env?: Record<string, string> } }
+
+    return transport._serverParams.env ?? {}
+  }
+
   it('builds a StdioClientTransport for a stdio config', () => {
     const transport = buildTransport({
       id: 'srv-stdio',
@@ -478,6 +492,33 @@ describe('buildTransport', () => {
     })
 
     expect(transport).toBeInstanceOf(StdioClientTransport)
+  })
+
+  it('augments the stdio PATH while preserving explicitly configured environment values', () => {
+    const childEnv = stdioTransportEnvironment({ CUSTOM_API_KEY: 'configured-secret' })
+    const pathDirs = childEnv?.PATH?.split(delimiter) ?? []
+
+    expect(pathDirs).toEqual(expect.arrayContaining(EXTRA_PATH_DIRS))
+    expect(childEnv?.CUSTOM_API_KEY).toBe('configured-secret')
+  })
+
+  it('keeps an explicitly configured stdio PATH ahead of the augmented directories', () => {
+    const customPath = '/custom/bin'
+    const pathDirs = stdioTransportEnvironment({ PATH: customPath }).PATH?.split(delimiter) ?? []
+
+    expect(pathDirs[0]).toBe(customPath)
+    expect(pathDirs).toEqual(expect.arrayContaining(EXTRA_PATH_DIRS))
+  })
+
+  it('does not expose unrelated host secrets to a custom stdio server', () => {
+    const secretName = 'OPEN_SCIENCE_MCP_TEST_SECRET'
+    vi.stubEnv(secretName, 'host-only-secret')
+
+    try {
+      expect(stdioTransportEnvironment()).not.toHaveProperty(secretName)
+    } finally {
+      vi.unstubAllEnvs()
+    }
   })
 
   it('throws when a stdio config is missing a command', () => {

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -1,5 +1,8 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import {
+  StdioClientTransport,
+  getDefaultEnvironment
+} from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
@@ -7,6 +10,7 @@ import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
 
 import { OAuthCallbackServer, PersistentOAuthClientProvider } from './oauth-client'
 import type { StoredCustomMcpOAuthState } from '../settings/types'
+import { augmentedPathEnv } from '../settings/shell-path'
 
 // Config for a user-added custom MCP server. OAuth state is a transient main-process projection;
 // stdio remains non-OAuth and remote servers can use OAuth, static headers, or neither.
@@ -67,7 +71,10 @@ export function buildTransport(
       return new StdioClientTransport({
         command: config.command,
         args: config.args,
-        env: config.env
+        env: augmentedPathEnv({
+          ...getDefaultEnvironment(),
+          ...config.env
+        }) as Record<string, string>
       })
     }
     case 'streamable_http': {


### PR DESCRIPTION
## Problem

Custom stdio MCP servers can be configured with commands such as `npx`, but Open Science may start from an Electron/GUI environment whose inherited `PATH` omits user CLI locations. The MCP process then fails to spawn, and `host.mcp()` reports `connector_unavailable`.

## Proposed change

- Build custom stdio MCP environments from the MCP SDK's safe inherited environment.
- Reuse the app's existing GUI-safe `PATH` augmentation before spawning the custom server.
- Preserve configured environment values and keep an explicitly configured `PATH` ahead of appended fallback directories.
- Add regression coverage for PATH augmentation, configured environment forwarding, and host-secret isolation.

## Scope and non-goals

- No Connector settings schema or persisted-data changes.
- No change to remote HTTP/SSE MCP transports, Connector routing, ACP behavior, permission policy, failure caching, or retry behavior.
- No dependency changes.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- Custom stdio PATH augmentation, configured env precedence, host-secret isolation, and existing MCP client lifecycle -> `npm test -- src/main/connectors/mcp-client-manager.test.ts src/main/settings/shell-path.test.ts` -> passed, 30/30 tests.
- Main-process TypeScript contract -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed with 13 pre-existing warnings outside the changed lines.
- Patch formatting -> `git diff --check` -> passed before commit.

Consumer and platform impact:

- Included the `McpClientManager` owner test and the reused shell-PATH helper test.
- Excluded `ConnectorService`, settings persistence, renderer, and ACP tests because their interfaces and dispatch behavior did not change; only the stdio child-process environment at the transport boundary changed.
- The regression uses the platform delimiter and platform-owned fallback directory list. Windows CI remains authoritative for Windows command-shim behavior.

Uncovered risks:

- The exact Ubuntu AppImage plus `@sura_ai/elabftw` end-to-end path was not executed locally because downloading and executing that third-party package was not approved by the execution safety policy.
- Independent review of the final evidence mapping remains pending.

## Review focus

- Confirm the child environment remains limited to the MCP SDK allowlist plus Connector-configured values.
- Confirm configured `PATH` entries retain precedence over appended GUI fallback directories.

Closes #1120
