### PR TITLE
fix(message-stream): preserve presentation progress across remounts

### DIFF
--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -173,7 +173,7 @@
 
     & .agent-markdown > :last-child:empty::after,
     & .agent-markdown > :last-child > :last-child::after {
-      content: var(--streamdown-caret, none);
+      content: '';
       display: inline-block;
       width: 1px;
       height: 1.25em;

--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -168,9 +168,19 @@
     }
 
     & .agent-markdown > :last-child::after {
+      content: none;
+    }
+
+    & .agent-markdown > :last-child:empty::after,
+    & .agent-markdown > :last-child > :last-child::after {
+      content: var(--streamdown-caret, none);
       display: inline-block;
+      width: 1px;
+      height: 1.25em;
+      overflow: hidden;
       margin-inline-start: 0.08em;
-      color: currentColor;
+      vertical-align: -0.18em;
+      background-color: currentColor;
       opacity: 1;
     }
   }

--- a/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
@@ -133,18 +133,18 @@ describe('AgentMarkdown renderer recovery', () => {
     )
     vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
     streamdownHarness.shouldThrow = false
-    const content = '流畅输出'.repeat(13)
+    const content = 'flow'.repeat(13)
 
     await act(async () => {
       root.render(<AgentMarkdown content={content} isAnimating />)
     })
-    expect(streamdownHarness.caret).toBe('block')
+    expect(streamdownHarness.caret).toBeUndefined()
     expect(streamdownHarness.animated).toBe(false)
     expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('')
 
     await act(async () => vi.advanceTimersByTimeAsync(512))
     const firstFrame = container.querySelector('[data-testid="rich-markdown"]')?.textContent ?? ''
-    expect(firstFrame).toBe('流')
+    expect(firstFrame).toBe('f')
 
     for (let expectedLength = 2; expectedLength <= 12; expectedLength += 1) {
       await act(async () => vi.advanceTimersByTimeAsync(16))
@@ -173,20 +173,20 @@ describe('AgentMarkdown renderer recovery', () => {
     streamdownHarness.shouldThrow = false
 
     await act(async () => {
-      root.render(<AgentMarkdown content="流" isAnimating />)
+      root.render(<AgentMarkdown content="x" isAnimating />)
     })
 
     for (let length = 2; length <= 70; length += 1) {
       await act(async () => vi.advanceTimersByTimeAsync(8))
       await act(async () => {
-        root.render(<AgentMarkdown content={'流'.repeat(length)} isAnimating />)
+        root.render(<AgentMarkdown content={'x'.repeat(length)} isAnimating />)
       })
     }
 
     const visible = container.querySelector('[data-testid="rich-markdown"]')?.textContent ?? ''
     expect(visible.length).toBeGreaterThan(0)
     expect(visible.length).toBeLessThan(70)
-    expect(streamdownHarness.caret).toBe('block')
+    expect(streamdownHarness.caret).toBeUndefined()
   })
 
   it('prebuffers a small segment instead of exposing source jitter directly', async () => {
@@ -200,17 +200,17 @@ describe('AgentMarkdown renderer recovery', () => {
     streamdownHarness.shouldThrow = false
 
     await act(async () => {
-      root.render(<AgentMarkdown content={'流'.repeat(12)} isAnimating />)
+      root.render(<AgentMarkdown content={'x'.repeat(12)} isAnimating />)
     })
     await act(async () => vi.advanceTimersByTimeAsync(480))
     expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('')
-    expect(streamdownHarness.caret).toBe('block')
+    expect(streamdownHarness.caret).toBeUndefined()
 
     await act(async () => {
-      root.render(<AgentMarkdown content={'流'.repeat(40)} isAnimating />)
+      root.render(<AgentMarkdown content={'x'.repeat(40)} isAnimating />)
     })
     await act(async () => vi.advanceTimersByTimeAsync(32))
-    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('流')
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('x')
   })
 
   it('starts a slow stream after the bounded prebuffer delay', async () => {
@@ -224,13 +224,13 @@ describe('AgentMarkdown renderer recovery', () => {
     streamdownHarness.shouldThrow = false
 
     await act(async () => {
-      root.render(<AgentMarkdown content={'流'.repeat(12)} isAnimating />)
+      root.render(<AgentMarkdown content={'x'.repeat(12)} isAnimating />)
     })
     await act(async () => vi.advanceTimersByTimeAsync(496))
     expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('')
 
     await act(async () => vi.advanceTimersByTimeAsync(16))
-    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('流')
+    expect(container.querySelector('[data-testid="rich-markdown"]')?.textContent).toBe('x')
   })
 
   it('flushes a non-append correction that preserves the visible prefix', async () => {

--- a/src/renderer/src/components/streamdown/AgentMarkdown.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.tsx
@@ -257,7 +257,6 @@ const RichAgentMarkdown = memo(
           mode={isAnimating ? 'streaming' : 'static'}
           isAnimating={isAnimating}
           animated={false}
-          caret={isAnimating ? 'block' : undefined}
           parseIncompleteMarkdown={isAnimating}
           normalizeHtmlIndentation={!isAnimating}
           allowedTags={AGENT_ALLOWED_TAGS}

--- a/src/renderer/src/components/streamdown/AgentMarkdownFullscreenChrome.test.ts
+++ b/src/renderer/src/components/streamdown/AgentMarkdownFullscreenChrome.test.ts
@@ -1,5 +1,8 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Streamdown } from 'streamdown'
 
 import { describe, expect, it } from 'vitest'
 
@@ -14,6 +17,30 @@ describe('AgentMarkdown fullscreen chrome', () => {
     expect(streamingBlock).toContain('& > div > :empty:not(:last-child)')
     expect(streamingBlock).toContain('opacity: 1')
     expect(streamingBlock).not.toContain('cursor-blink')
+  })
+
+  it('anchors a thin streaming caret to the terminal text block', () => {
+    const css = readFileSync(resolve(__dirname, '../../assets/agent-markdown.css'), 'utf8')
+    const streamingBlock = css.slice(
+      css.indexOf('.agent-markdown-streaming'),
+      css.indexOf('/* --- Streamdown dropdown panels')
+    )
+    const markup = renderToStaticMarkup(
+      createElement(
+        Streamdown,
+        { animated: false, caret: 'block', dir: 'auto', isAnimating: true, mode: 'streaming' },
+        '好的，我用 Python (matplotlib)'
+      )
+    )
+
+    expect(markup).toContain('style="display:contents"')
+    expect(streamingBlock).toContain('& .agent-markdown > :last-child:empty::after')
+    expect(streamingBlock).toContain('& .agent-markdown > :last-child > :last-child::after')
+    expect(streamingBlock).toContain('content: var(--streamdown-caret, none)')
+    expect(streamingBlock).toContain('width: 1px')
+    expect(streamingBlock).toContain('height: 1.25em')
+    expect(streamingBlock).toContain('overflow: hidden')
+    expect(streamingBlock).toContain('background-color: currentColor')
   })
 
   it('keeps Mermaid fullscreen functionality enabled while matching the dialog overlay chrome', () => {

--- a/src/renderer/src/components/streamdown/AgentMarkdownFullscreenChrome.test.ts
+++ b/src/renderer/src/components/streamdown/AgentMarkdownFullscreenChrome.test.ts
@@ -28,15 +28,17 @@ describe('AgentMarkdown fullscreen chrome', () => {
     const markup = renderToStaticMarkup(
       createElement(
         Streamdown,
-        { animated: false, caret: 'block', dir: 'auto', isAnimating: true, mode: 'streaming' },
-        '好的，我用 Python (matplotlib)'
+        { animated: false, dir: 'auto', isAnimating: true, mode: 'streaming' },
+        'Example output with Python (matplotlib)'
       )
     )
 
     expect(markup).toContain('style="display:contents"')
+    expect(markup).not.toContain('--streamdown-caret')
+    expect(streamingBlock).not.toContain('!important')
     expect(streamingBlock).toContain('& .agent-markdown > :last-child:empty::after')
     expect(streamingBlock).toContain('& .agent-markdown > :last-child > :last-child::after')
-    expect(streamingBlock).toContain('content: var(--streamdown-caret, none)')
+    expect(streamingBlock).toContain("content: ''")
     expect(streamingBlock).toContain('width: 1px')
     expect(streamingBlock).toContain('height: 1.25em')
     expect(streamingBlock).toContain('overflow: hidden')

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -1633,6 +1633,18 @@ describe('ConversationPanel composer intake', () => {
         sideSessionId: 'side-1',
         draft: '',
         running: true,
+        entries: entries.slice(0, -1)
+      }
+    })
+    renderPanel({
+      ...sideChatProps,
+      sideChat: {
+        generation: 1,
+        parentSessionId: 'session-existing',
+        projectId: 'project-a',
+        sideSessionId: 'side-1',
+        draft: '',
+        running: true,
         entries
       }
     })
@@ -1645,6 +1657,13 @@ describe('ConversationPanel composer intake', () => {
     expect(container.textContent).not.toContain('流畅输出')
     await act(async () => vi.advanceTimersByTimeAsync(16))
     expect(container.textContent).toContain('流')
+
+    const nextAssistant = {
+      id: 'assistant-after-tool',
+      kind: 'message' as const,
+      role: 'assistant' as const,
+      text: '工具后的新内容'
+    }
 
     renderPanel({
       ...sideChatProps,
@@ -1662,15 +1681,81 @@ describe('ConversationPanel composer intake', () => {
             kind: 'tool',
             title: 'Tool after current answer',
             status: 'in_progress'
-          }
+          },
+          nextAssistant
         ]
       }
     })
     expect(container.textContent).not.toContain('Tool after current answer')
+    expect(container.textContent).not.toContain(nextAssistant.text)
 
     await act(async () => vi.advanceTimersByTimeAsync(96))
     expect(container.textContent).toContain('流畅输出')
     expect(container.textContent).toContain('Tool after current answer')
+    expect(container.textContent).not.toContain(nextAssistant.text)
+    await act(async () => vi.advanceTimersByTimeAsync(512))
+    expect(container.textContent).toContain('工')
+    expect(container.textContent).not.toContain(nextAssistant.text)
+  })
+
+  it('does not replay a buffered Side chat answer after the panel reopens', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    const sideChatProps = {
+      onSendSideChat: vi.fn(async () => true),
+      onSideChatDraftChange: vi.fn(),
+      onCancelSideChat: vi.fn(),
+      onCloseSideChat: vi.fn()
+    }
+    const userEntry = {
+      id: 'user-reopen',
+      kind: 'message' as const,
+      role: 'user' as const,
+      text: 'Keep going'
+    }
+    const assistantEntry = {
+      id: 'assistant-reopen',
+      kind: 'message' as const,
+      role: 'assistant' as const,
+      text: '重新打开时不应从头播放'
+    }
+    const sideChat = {
+      generation: 2,
+      parentSessionId: 'session-existing',
+      projectId: 'project-a',
+      sideSessionId: 'side-2',
+      draft: '',
+      running: true,
+      entries: [userEntry, assistantEntry]
+    }
+
+    renderPanel({ ...sideChatProps, sideChat: { ...sideChat, entries: [userEntry] } })
+    renderPanel({ ...sideChatProps, sideChat })
+    await act(async () => vi.advanceTimersByTimeAsync(512))
+    expect(container.textContent).toContain('重')
+    expect(container.textContent).not.toContain(assistantEntry.text)
+
+    renderPanel()
+    renderPanel({ ...sideChatProps, sideChat })
+
+    expect(container.textContent).toContain(assistantEntry.text)
+
+    const continuedAnswer = `${assistantEntry.text}，继续输出`
+    renderPanel({
+      ...sideChatProps,
+      sideChat: {
+        ...sideChat,
+        entries: [userEntry, { ...assistantEntry, text: continuedAnswer }]
+      }
+    })
+    expect(container.textContent).not.toContain(continuedAnswer)
+    await act(async () => vi.advanceTimersByTimeAsync(512))
+    expect(container.textContent).toContain(`${assistantEntry.text}，`)
   })
 
   it('keeps main approval and ask-user surfaces waiting while Side chat is open', () => {

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -1620,7 +1620,7 @@ describe('ConversationPanel composer intake', () => {
         id: 'assistant-live',
         kind: 'message' as const,
         role: 'assistant' as const,
-        text: '流畅输出'
+        text: 'Flow'
       }
     ]
 
@@ -1650,19 +1650,19 @@ describe('ConversationPanel composer intake', () => {
     })
 
     expect(container.textContent).toContain('Historical answer')
-    expect(container.textContent).not.toContain('流畅输出')
+    expect(container.textContent).not.toContain('Flow')
     expect(container.querySelectorAll('.agent-markdown-streaming')).toHaveLength(1)
 
     await act(async () => vi.advanceTimersByTimeAsync(496))
-    expect(container.textContent).not.toContain('流畅输出')
+    expect(container.textContent).not.toContain('Flow')
     await act(async () => vi.advanceTimersByTimeAsync(16))
-    expect(container.textContent).toContain('流')
+    expect(container.textContent).toContain('F')
 
     const nextAssistant = {
       id: 'assistant-after-tool',
       kind: 'message' as const,
       role: 'assistant' as const,
-      text: '工具后的新内容'
+      text: 'Next'
     }
 
     renderPanel({
@@ -1690,11 +1690,11 @@ describe('ConversationPanel composer intake', () => {
     expect(container.textContent).not.toContain(nextAssistant.text)
 
     await act(async () => vi.advanceTimersByTimeAsync(96))
-    expect(container.textContent).toContain('流畅输出')
+    expect(container.textContent).toContain('Flow')
     expect(container.textContent).toContain('Tool after current answer')
     expect(container.textContent).not.toContain(nextAssistant.text)
     await act(async () => vi.advanceTimersByTimeAsync(512))
-    expect(container.textContent).toContain('工')
+    expect(container.textContent).toContain('N')
     expect(container.textContent).not.toContain(nextAssistant.text)
   })
 
@@ -1722,7 +1722,7 @@ describe('ConversationPanel composer intake', () => {
       id: 'assistant-reopen',
       kind: 'message' as const,
       role: 'assistant' as const,
-      text: '重新打开时不应从头播放'
+      text: 'Resume without replay'
     }
     const sideChat = {
       generation: 2,
@@ -1737,7 +1737,7 @@ describe('ConversationPanel composer intake', () => {
     renderPanel({ ...sideChatProps, sideChat: { ...sideChat, entries: [userEntry] } })
     renderPanel({ ...sideChatProps, sideChat })
     await act(async () => vi.advanceTimersByTimeAsync(512))
-    expect(container.textContent).toContain('重')
+    expect(container.textContent).toContain('R')
     expect(container.textContent).not.toContain(assistantEntry.text)
 
     renderPanel()
@@ -1745,7 +1745,7 @@ describe('ConversationPanel composer intake', () => {
 
     expect(container.textContent).toContain(assistantEntry.text)
 
-    const continuedAnswer = `${assistantEntry.text}，继续输出`
+    const continuedAnswer = `${assistantEntry.text}, then continue`
     renderPanel({
       ...sideChatProps,
       sideChat: {
@@ -1755,7 +1755,7 @@ describe('ConversationPanel composer intake', () => {
     })
     expect(container.textContent).not.toContain(continuedAnswer)
     await act(async () => vi.advanceTimersByTimeAsync(512))
-    expect(container.textContent).toContain(`${assistantEntry.text}，`)
+    expect(container.textContent).toContain(`${assistantEntry.text},`)
   })
 
   it('keeps main approval and ask-user surfaces waiting while Side chat is open', () => {
@@ -2273,7 +2273,7 @@ describe('ConversationPanel + menu', () => {
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement
     await act(async () => {
       const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
-      setter?.call(textarea, '批准执行')
+      setter?.call(textarea, 'Approved for execution')
       textarea.dispatchEvent(new Event('input', { bubbles: true }))
       textarea
         .closest('form')
@@ -2283,7 +2283,7 @@ describe('ConversationPanel + menu', () => {
 
     expect(respondToSessionPlanMock).toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: 'session-plan-text-approval' }),
-      { feedback: '批准执行' }
+      { feedback: 'Approved for execution' }
     )
   })
 

--- a/src/renderer/src/pages/workspace/SideChatPanel.tsx
+++ b/src/renderer/src/pages/workspace/SideChatPanel.tsx
@@ -39,6 +39,26 @@ type SideChatPresentationState = Readonly<{
   entryIds: Set<string>
 }>
 
+type VisibleSideChatEntrySnapshot = Readonly<{
+  generation: number | undefined
+  entryIds: Set<string>
+}>
+
+const VisibleSideChatEntrySnapshotCommit = ({
+  generation,
+  entryIdsKey,
+  onCommit
+}: {
+  generation: number
+  entryIdsKey: string
+  onCommit: (generation: number, entryIds: Set<string>) => void
+}): null => {
+  useLayoutEffect(() => {
+    onCommit(generation, new Set(JSON.parse(entryIdsKey)))
+  }, [entryIdsKey, generation, onCommit])
+  return null
+}
+
 const SideChatAssistantMessage = ({
   entry,
   sourceOpen,
@@ -79,6 +99,10 @@ const SideChatPanel = ({
     generation: view.generation,
     entryIds: new Set()
   }))
+  const [visibleEntrySnapshot, setVisibleEntrySnapshot] = useState<VisibleSideChatEntrySnapshot>(
+    () => ({ generation: undefined, entryIds: new Set() })
+  )
+  const generationRemainedVisible = visibleEntrySnapshot.generation === view.generation
   const lastUserEntryIndex = view.entries.findLastIndex(
     (entry) => entry.kind === 'message' && entry.role === 'user'
   )
@@ -90,6 +114,18 @@ const SideChatPanel = ({
       : new Set<string>()
   const presentationBarrierIndex = view.entries.findIndex((entry) =>
     presentingEntryIds.has(entry.id)
+  )
+  const visibleEntryIds = (
+    presentationBarrierIndex >= 0
+      ? view.entries.slice(0, presentationBarrierIndex + 1)
+      : view.entries
+  ).map((entry) => entry.id)
+  const visibleEntryIdsKey = JSON.stringify(visibleEntryIds)
+  const handleVisibleEntrySnapshotCommit = useCallback(
+    (generation: number, entryIds: Set<string>): void => {
+      setVisibleEntrySnapshot({ generation, entryIds })
+    },
+    []
   )
   const handlePresentationChange = useCallback(
     (entryId: string, presenting: boolean): void => {
@@ -173,13 +209,21 @@ const SideChatPanel = ({
             className="h-full overscroll-contain text-[14px] leading-6"
           >
             <div className="px-5 py-4">
+              <VisibleSideChatEntrySnapshotCommit
+                generation={view.generation}
+                entryIdsKey={visibleEntryIdsKey}
+                onCommit={handleVisibleEntrySnapshotCommit}
+              />
               {view.entries.map((entry, entryIndex) => {
                 if (presentationBarrierIndex >= 0 && entryIndex > presentationBarrierIndex) {
                   return null
                 }
                 if (entry.kind === 'tool') {
                   return (
-                    <div key={entry.id} className="my-2 text-[12px] text-text-300">
+                    <div
+                      key={JSON.stringify([view.generation, entry.id])}
+                      className="my-2 text-[12px] text-text-300"
+                    >
                       {entry.title}
                       {entry.status ? ` · ${entry.status}` : ''}
                     </div>
@@ -187,7 +231,10 @@ const SideChatPanel = ({
                 }
                 if (entry.role === 'user') {
                   return (
-                    <div key={entry.id} className="my-3 flex justify-end">
+                    <div
+                      key={JSON.stringify([view.generation, entry.id])}
+                      className="my-3 flex justify-end"
+                    >
                       <div className="max-w-[80%] whitespace-pre-wrap break-words rounded-2xl bg-bg-200 px-3 py-2 text-text-000">
                         {entry.text}
                       </div>
@@ -195,12 +242,19 @@ const SideChatPanel = ({
                   )
                 }
 
-                const animateOnMount =
+                const belongsToLiveTurn =
                   lastUserEntryId === liveTurnUserId && entryIndex > lastUserEntryIndex
                 const sourceOpen =
-                  animateOnMount && view.running && entryIndex === view.entries.length - 1
+                  belongsToLiveTurn && view.running && entryIndex === view.entries.length - 1
+                const animateOnMount =
+                  sourceOpen &&
+                  generationRemainedVisible &&
+                  !visibleEntrySnapshot.entryIds.has(entry.id)
                 return (
-                  <div key={entry.id} className="my-3 min-w-0 text-text-000">
+                  <div
+                    key={JSON.stringify([view.generation, entry.id])}
+                    className="my-3 min-w-0 text-text-000"
+                  >
                     <SideChatAssistantMessage
                       entry={entry}
                       sourceOpen={sourceOpen}

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -94,6 +94,7 @@ type WorkspaceMessageItemProps = {
   staticParts?: ProvenanceMessagePart[]
   onPresentationChange?: (messageId: string, presenting: boolean) => void
   presentationSourceOpen?: boolean
+  presentationAnimateOnMount?: boolean
 }
 
 const ARTIFACT_GALLERY_VISIBLE_COUNT = 5
@@ -793,7 +794,8 @@ const WorkspaceMessageItem = ({
   artifacts = [],
   staticParts,
   onPresentationChange,
-  presentationSourceOpen
+  presentationSourceOpen,
+  presentationAnimateOnMount = true
 }: WorkspaceMessageItemProps): React.JSX.Element => {
   const isUserMessage = message.role === 'user'
   const isSideChatAdvisory =
@@ -804,7 +806,7 @@ const WorkspaceMessageItem = ({
   const assistantPresentation = useSmoothStreamingContent(
     presentsAssistantMessage ? message.content : '',
     assistantSourceOpen,
-    shouldAnimateAssistant
+    shouldAnimateAssistant && assistantSourceOpen && presentationAnimateOnMount
   )
   const isAssistantPresenting = presentsAssistantMessage && assistantPresentation.isPresenting
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -311,7 +311,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     const reply = createMessage({
       id: 'reply-stream',
       role: 'agent',
-      content: '流畅输出',
+      content: 'Flow',
       status: 'streaming',
       streamId: 'stream-1',
       responseToMessageId: prompt.id,
@@ -345,7 +345,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
     await act(async () => vi.advanceTimersByTimeAsync(512))
     expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
-      '流'
+      'F'
     )
 
     const tool = createActivity({
@@ -367,7 +367,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     ).toBeNull()
 
     await act(async () => vi.advanceTimersByTimeAsync(96))
-    expect(container.textContent).toContain('流畅输出')
+    expect(container.textContent).toContain('Flow')
     expect(
       container.querySelector('[data-message-id="activity-group-tool-after-stream"]')
     ).not.toBeNull()
@@ -386,7 +386,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     const reply = createMessage({
       id: 'reply-terminal',
       role: 'agent',
-      content: '完整结尾',
+      content: 'Done',
       status: 'streaming',
       streamId: 'stream-terminal',
       responseToMessageId: prompt.id,
@@ -429,10 +429,10 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       })
     )
     expect(container.textContent).not.toContain('Completed')
-    expect(container.textContent).not.toContain('完整结尾')
+    expect(container.textContent).not.toContain('Done')
 
     await act(async () => vi.advanceTimersByTimeAsync(96))
-    expect(container.textContent).toContain('完整结尾')
+    expect(container.textContent).toContain('Done')
     expect(container.textContent).toContain('Completed')
   })
 
@@ -449,7 +449,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     const reply = createMessage({
       id: 'reply-session-a',
       role: 'agent',
-      content: '切换会话后不应重新播放这一段流式内容',
+      content: 'Resume without replay after switching sessions',
       status: 'streaming',
       streamId: 'stream-session-a',
       responseToMessageId: prompt.id,
@@ -480,7 +480,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await render(sessionA)
     await act(async () => vi.advanceTimersByTimeAsync(512))
     expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
-      '切'
+      'R'
     )
 
     await render(
@@ -495,14 +495,14 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       reply.content
     )
 
-    const continuedReply = { ...reply, content: `${reply.content}继续输出` }
+    const continuedReply = { ...reply, content: `${reply.content} plus more` }
     await render({ ...sessionA, messages: [prompt, continuedReply] })
     expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
       reply.content
     )
     await act(async () => vi.advanceTimersByTimeAsync(512))
     expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
-      `${reply.content}继`
+      `${reply.content} `
     )
   })
 
@@ -519,7 +519,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     const reply = createMessage({
       id: 'reply-before-tool',
       role: 'agent',
-      content: '工具调用前的文字已经固定',
+      content: 'Fixed before tool',
       status: 'streaming',
       streamId: 'stream-before-tool',
       responseToMessageId: prompt.id,
@@ -569,7 +569,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     const beforeTool = createMessage({
       id: 'reply-before-live-tool',
       role: 'agent',
-      content: '前置缓冲文字',
+      content: 'Before tool',
       status: 'streaming',
       streamId: 'stream-around-tool',
       responseToMessageId: prompt.id,
@@ -586,7 +586,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     const afterTool = createMessage({
       id: 'reply-after-live-tool',
       role: 'agent',
-      content: '工具后的新文字',
+      content: 'After tool',
       status: 'streaming',
       streamId: 'stream-around-tool',
       responseToMessageId: prompt.id,
@@ -632,7 +632,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(assistantSurfaces[0]?.textContent).toBe(beforeTool.content)
     expect(assistantSurfaces[1]?.textContent).toBe('')
     await act(async () => vi.advanceTimersByTimeAsync(512))
-    expect(assistantSurfaces[1]?.textContent).toBe('工')
+    expect(assistantSurfaces[1]?.textContent).toBe('A')
   })
 
   it('does not replay a buffered assistant message after switching active branches', async () => {
@@ -648,7 +648,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     const replyA = createMessage({
       id: 'reply-branch-a',
       role: 'agent',
-      content: '返回原分支时不应重新播放',
+      content: 'Resume without replay on the original branch',
       status: 'streaming',
       streamId: 'stream-branch-a',
       responseToMessageId: promptA.id,
@@ -699,7 +699,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await render(sessionFromGraph(streamingGraphA))
     await act(async () => vi.advanceTimersByTimeAsync(512))
     expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
-      '返'
+      'R'
     )
 
     await render(sessionFromGraph(branchBGraph))

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -330,6 +330,12 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await render(
       createSession({
         activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+        messages: [prompt]
+      })
+    )
+    await render(
+      createSession({
+        activeRun: { promptMessageId: prompt.id, startedAt: 100 },
         messages: [prompt, reply]
       })
     )
@@ -399,6 +405,12 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await render(
       createSession({
         activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+        messages: [prompt]
+      })
+    )
+    await render(
+      createSession({
+        activeRun: { promptMessageId: prompt.id, startedAt: 100 },
         messages: [prompt, reply]
       })
     )
@@ -422,6 +434,279 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await act(async () => vi.advanceTimersByTimeAsync(96))
     expect(container.textContent).toContain('完整结尾')
     expect(container.textContent).toContain('Completed')
+  })
+
+  it('does not replay a buffered assistant message after switching sessions', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const prompt = createMessage({ id: 'prompt-session-a', sortIndex: 1, createdAt: 100 })
+    const reply = createMessage({
+      id: 'reply-session-a',
+      role: 'agent',
+      content: '切换会话后不应重新播放这一段流式内容',
+      status: 'streaming',
+      streamId: 'stream-session-a',
+      responseToMessageId: prompt.id,
+      sortIndex: 2,
+      createdAt: 101
+    })
+    const sessionA = createSession({
+      id: 'session-a',
+      activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+      messages: [prompt, reply]
+    })
+    const render = async (session: ChatSession): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+        )
+      })
+    }
+
+    root = createRoot(container)
+    await render(
+      createSession({
+        id: sessionA.id,
+        activeRun: sessionA.activeRun,
+        messages: [prompt]
+      })
+    )
+    await render(sessionA)
+    await act(async () => vi.advanceTimersByTimeAsync(512))
+    expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
+      '切'
+    )
+
+    await render(
+      createSession({
+        id: 'session-b',
+        messages: [createMessage({ id: 'prompt-session-b' })]
+      })
+    )
+    await render(sessionA)
+
+    expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
+      reply.content
+    )
+
+    const continuedReply = { ...reply, content: `${reply.content}继续输出` }
+    await render({ ...sessionA, messages: [prompt, continuedReply] })
+    expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
+      reply.content
+    )
+    await act(async () => vi.advanceTimersByTimeAsync(512))
+    expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
+      `${reply.content}继`
+    )
+  })
+
+  it('does not replay an assistant fragment after the turn advances to a tool', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const prompt = createMessage({ id: 'prompt-before-tool', sortIndex: 1, createdAt: 100 })
+    const reply = createMessage({
+      id: 'reply-before-tool',
+      role: 'agent',
+      content: '工具调用前的文字已经固定',
+      status: 'streaming',
+      streamId: 'stream-before-tool',
+      responseToMessageId: prompt.id,
+      sortIndex: 2,
+      createdAt: 101
+    })
+    const tool = createActivity({
+      id: 'tool-after-fixed-fragment',
+      title: 'Tool after fixed fragment',
+      promptMessageId: prompt.id,
+      sortIndex: 3,
+      createdAt: 102
+    })
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({
+            activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+            messages: [prompt, reply],
+            activities: [tool]
+          })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
+      reply.content
+    )
+    expect(
+      container.querySelector('[data-message-id="activity-group-tool-after-fixed-fragment"]')
+    ).not.toBeNull()
+  })
+
+  it('paces a new assistant fragment that arrives after a tool', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const prompt = createMessage({ id: 'prompt-around-tool', sortIndex: 1, createdAt: 100 })
+    const beforeTool = createMessage({
+      id: 'reply-before-live-tool',
+      role: 'agent',
+      content: '前置缓冲文字',
+      status: 'streaming',
+      streamId: 'stream-around-tool',
+      responseToMessageId: prompt.id,
+      sortIndex: 2,
+      createdAt: 101
+    })
+    const tool = createActivity({
+      id: 'tool-between-fragments',
+      title: 'Tool between fragments',
+      promptMessageId: prompt.id,
+      sortIndex: 3,
+      createdAt: 102
+    })
+    const afterTool = createMessage({
+      id: 'reply-after-live-tool',
+      role: 'agent',
+      content: '工具后的新文字',
+      status: 'streaming',
+      streamId: 'stream-around-tool',
+      responseToMessageId: prompt.id,
+      sortIndex: 4,
+      createdAt: 103
+    })
+    const render = async (session: ChatSession): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+        )
+      })
+    }
+
+    root = createRoot(container)
+    await render(
+      createSession({
+        activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+        messages: [prompt]
+      })
+    )
+    await render(
+      createSession({
+        activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+        messages: [prompt, beforeTool]
+      })
+    )
+    await act(async () => vi.advanceTimersByTimeAsync(512))
+    await render(
+      createSession({
+        activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+        messages: [prompt, beforeTool, afterTool],
+        activities: [tool]
+      })
+    )
+    expect(
+      container.querySelector('[data-message-id="activity-group-tool-between-fragments"]')
+    ).toBeNull()
+    await act(async () => vi.advanceTimersByTimeAsync(160))
+
+    const assistantSurfaces = container.querySelectorAll('[data-testid="presented-agent-markdown"]')
+    expect(assistantSurfaces).toHaveLength(2)
+    expect(assistantSurfaces[0]?.textContent).toBe(beforeTool.content)
+    expect(assistantSurfaces[1]?.textContent).toBe('')
+    await act(async () => vi.advanceTimersByTimeAsync(512))
+    expect(assistantSurfaces[1]?.textContent).toBe('工')
+  })
+
+  it('does not replay a buffered assistant message after switching active branches', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const promptA = createMessage({ id: 'prompt-branch-a', sortIndex: 1, createdAt: 100 })
+    const replyA = createMessage({
+      id: 'reply-branch-a',
+      role: 'agent',
+      content: '返回原分支时不应重新播放',
+      status: 'streaming',
+      streamId: 'stream-branch-a',
+      responseToMessageId: promptA.id,
+      sortIndex: 2,
+      createdAt: 101
+    })
+    const createGraph = (
+      messages: ChatMessage[]
+    ): ReturnType<typeof createLinearConversationGraph> =>
+      createLinearConversationGraph({
+        sessionId: 'branched-stream-session',
+        messages,
+        frameworkId: 'codex',
+        createdAt: 100,
+        updatedAt: 101
+      })
+    const initialGraphA = createGraph([promptA])
+    const streamingGraphA = createGraph([promptA, replyA])
+    const branchBGraph = structuredClone(streamingGraphA)
+    branchBGraph.branches.push({
+      ...branchBGraph.branches[0],
+      id: 'branch-b',
+      parentBranchId: branchBGraph.branches[0].id,
+      createdAt: 102,
+      updatedAt: 102
+    })
+    branchBGraph.frames[0].activeBranchId = 'branch-b'
+    const sessionFromGraph = (graph: typeof streamingGraphA): ChatSession =>
+      createSession({
+        id: 'branched-stream-session',
+        activeRun: { promptMessageId: promptA.id, startedAt: 100 },
+        conversationGraph: graph,
+        messages: resolveActiveConversationMessages(graph).map((message, index) => ({
+          ...projectConversationMessage(message),
+          sortIndex: index + 1
+        }))
+      })
+    const render = async (session: ChatSession): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+        )
+      })
+    }
+
+    root = createRoot(container)
+    await render(sessionFromGraph(initialGraphA))
+    await render(sessionFromGraph(streamingGraphA))
+    await act(async () => vi.advanceTimersByTimeAsync(512))
+    expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
+      '返'
+    )
+
+    await render(sessionFromGraph(branchBGraph))
+
+    expect(container.querySelector('[data-testid="presented-agent-markdown"]')?.textContent).toBe(
+      replyA.content
+    )
   })
 
   it('opens the exact durable source Frame from an inline upward message', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -17,6 +17,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -93,8 +94,28 @@ type SessionScopedActivityExpansionState = {
 }
 
 type SessionScopedMessagePresentationState = {
-  sessionId: string | undefined
+  scopeId: string | undefined
   messageIds: Set<string>
+}
+
+type VisibleMessageSnapshot = {
+  scopeId: string | undefined
+  messageIds: Set<string>
+}
+
+const VisibleMessageSnapshotCommit = ({
+  scopeId,
+  messageIdsKey,
+  onCommit
+}: {
+  scopeId: string | undefined
+  messageIdsKey: string
+  onCommit: (scopeId: string | undefined, messageIds: Set<string>) => void
+}): null => {
+  useLayoutEffect(() => {
+    onCommit(scopeId, new Set(JSON.parse(messageIdsKey)))
+  }, [messageIdsKey, onCommit, scopeId])
+  return null
 }
 
 type MessageUploadAttachment = NonNullable<ChatSession['messages'][number]['uploads']>[number]
@@ -255,6 +276,12 @@ const WorkspaceMessageScrollerImpl = ({
 }: WorkspaceMessageScrollerProps): React.JSX.Element => {
   const currentSessionId = activeSession?.id
   const currentProjectId = activeSession?.projectId
+  const activeConversationFrame = activeSession?.conversationGraph?.frames.find(
+    (frame) => frame.id === activeSession.conversationGraph?.activeFrameId
+  )
+  const currentPresentationScopeId = currentSessionId
+    ? JSON.stringify([currentSessionId, activeConversationFrame?.activeBranchId ?? 'legacy'])
+    : undefined
   const artifactVisibility = useWorkspaceArtifactVisibility(activeSession)
   const notebookRunsById = useNotebookRunsById(notebookReference)
   const handoffEvents = useHandoffLifecycleEvents(handoffLifecycleSource, currentSessionId)
@@ -326,7 +353,7 @@ const WorkspaceMessageScrollerImpl = ({
     }))
   const [messagePresentationState, setMessagePresentationState] =
     useState<SessionScopedMessagePresentationState>(() => ({
-      sessionId: undefined,
+      scopeId: undefined,
       messageIds: new Set()
     }))
   const collapsedActivityGroups =
@@ -345,27 +372,46 @@ const WorkspaceMessageScrollerImpl = ({
     () => groupConversationItems(rawConversationItems, activeSession?.activityGroups),
     [activeSession?.activityGroups, rawConversationItems]
   )
+  const [visibleMessageSnapshot, setVisibleMessageSnapshot] = useState<VisibleMessageSnapshot>(
+    () => ({ scopeId: undefined, messageIds: new Set() })
+  )
+  const presentationScopeRemainedVisible =
+    visibleMessageSnapshot.scopeId === currentPresentationScopeId
   const presentingMessageIds =
-    messagePresentationState.sessionId === currentSessionId
+    messagePresentationState.scopeId === currentPresentationScopeId
       ? messagePresentationState.messageIds
       : new Set<string>()
   const presentationBarrierIndex = conversationItems.findIndex(
     (item) => item.type === 'message' && presentingMessageIds.has(item.message.id)
   )
+  const visibleMessageIds = (
+    presentationBarrierIndex >= 0
+      ? conversationItems.slice(0, presentationBarrierIndex + 1)
+      : conversationItems
+  ).flatMap((item) => (item.type === 'message' ? [item.message.id] : []))
+  const visibleMessageIdsKey = JSON.stringify(visibleMessageIds)
+  const handleVisibleMessageSnapshotCommit = useCallback(
+    (scopeId: string | undefined, messageIds: Set<string>): void => {
+      setVisibleMessageSnapshot({ scopeId, messageIds })
+    },
+    []
+  )
   const handleMessagePresentationChange = useCallback(
     (messageId: string, presenting: boolean): void => {
       setMessagePresentationState((currentState) => {
         const currentMessageIds =
-          currentState.sessionId === currentSessionId ? currentState.messageIds : new Set<string>()
+          currentState.scopeId === currentPresentationScopeId
+            ? currentState.messageIds
+            : new Set<string>()
         if (currentMessageIds.has(messageId) === presenting) return currentState
 
         const nextMessageIds = new Set(currentMessageIds)
         if (presenting) nextMessageIds.add(messageId)
         else nextMessageIds.delete(messageId)
-        return { sessionId: currentSessionId, messageIds: nextMessageIds }
+        return { scopeId: currentPresentationScopeId, messageIds: nextMessageIds }
       })
     },
-    [currentSessionId]
+    [currentPresentationScopeId]
   )
   const durablePlanOwnerActivityId = useMemo(
     () => findDurablePlanOwnerActivityId(activeSession, rawConversationItems),
@@ -647,6 +693,11 @@ const WorkspaceMessageScrollerImpl = ({
           <MessageScrollerViewport aria-label="Conversation">
             <MessageScrollerContent className="gap-0 px-4">
               <div className={conversationContentClassName}>
+                <VisibleMessageSnapshotCommit
+                  scopeId={currentPresentationScopeId}
+                  messageIdsKey={visibleMessageIdsKey}
+                  onCommit={handleVisibleMessageSnapshotCommit}
+                />
                 {/* Messages and tool activities share one sorted transcript timeline. */}
                 {conversationItems.map((item, itemIndex) => {
                   if (presentationBarrierIndex >= 0 && itemIndex > presentationBarrierIndex) {
@@ -737,10 +788,13 @@ const WorkspaceMessageScrollerImpl = ({
                       messageItemProps.onPresentationChange = handleMessagePresentationChange
                       messageItemProps.presentationSourceOpen =
                         itemIndex === conversationItems.length - 1
+                      messageItemProps.presentationAnimateOnMount =
+                        presentationScopeRemainedVisible &&
+                        !visibleMessageSnapshot.messageIds.has(item.message.id)
                     }
 
                     return (
-                      <div key={item.id}>
+                      <div key={JSON.stringify([currentPresentationScopeId, item.id])}>
                         {/* Unbound completed jobs that belong chronologically before this message */}
                         {jobsBeforeMessage.map((job) => (
                           <MessageScrollerItem


### PR DESCRIPTION
## Problem

Buffered assistant text is presentation state, but remounting a session or side chat discarded that state. Returning to an in-progress turn could replay already visible text from the beginning, including text before a later tool call. The streaming caret also attached to Streamdown's `dir="auto"` wrapper, so it could render on the next line as a large block instead of following the visible text.

## Proposed change

- Track presentation checkpoints by session, active branch, and message in the main transcript.
- Track equivalent checkpoints by side-chat generation and entry.
- Restore already visible prefixes without mount animation while allowing genuinely new suffixes to keep using smooth streaming.
- Scope tool-boundary snapshots so only visible committed fragments become fixed.
- Anchor the streaming caret to the terminal rendered text block and style it as a thin, slightly taller line.

## Scope and non-goals

This is renderer-only presentation behavior. It does not change session persistence, the canonical conversation graph, controller state, runtime protocols, or stored message data. No historical data migration or compatibility layer is required.

It does not retune buffer pacing or replace the Markdown renderer.

## Acceptance criteria and validation

- Switching away from and back to a streaming session does not replay already presented text.
- A fragment before a tool call remains fixed when later fragments stream.
- Branch switching with shared message IDs does not leak presentation state across branches.
- Closing and reopening side chat does not replay existing text; later suffixes still animate.
- The caret follows the final visible text and renders as a thin black/current-color line that is slightly taller than the body text.

Validation after the final material change:

- `npm test -- --run src/renderer/src/components/streamdown/AgentMarkdownFullscreenChrome.test.ts` — 5 passed.
- `npm run typecheck` — node and web typechecks passed.
- `npm run lint` — 0 errors; 13 pre-existing warnings outside the changed files.
- `npm test` — 987 test files passed, 15 skipped; 14,352 tests passed, 198 skipped.

## Review focus

- Presentation checkpoint identity and visibility barriers across session/branch/tool transitions.
- Main transcript and side-chat parity.
- Caret selectors against Streamdown's `dir="auto"` `display: contents` wrapper and terminal Markdown blocks.
- Manual UI acceptance is still recommended for exact cursor alignment and animation feel; automated coverage verifies the DOM/CSS contract and lifecycle behavior.
