### PR TITLE
fix(workspace): focus composer after session navigation

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -1551,7 +1551,20 @@ describe('ConversationPanel composer intake', () => {
       (container.querySelector('[aria-label="Close Side chat"]') as HTMLButtonElement).click()
     )
     expect(onCloseSideChat).toHaveBeenCalledOnce()
+    renderPanel({ onCloseSideChat })
     expect(document.activeElement).toBe(getComposerEditor())
+
+    const navigationButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Open navigation"]'
+    )!
+    navigationButton.focus()
+    renderPanel({
+      composerFocusKey: 'session-blocked-after-side-chat',
+      pendingPermissions: [{ requestId: 'permission-after-side-chat' } as never]
+    })
+
+    expect(getComposerForm().hidden).toBe(true)
+    expect(document.activeElement).toBe(navigationButton)
   })
 
   it('keeps the Side chat input fixed and pins streamed output to the bottom', () => {

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -454,6 +454,36 @@ afterEach(() => {
 })
 
 describe('ConversationPanel composer intake', () => {
+  it('focuses the ordinary composer when the draft context changes', () => {
+    renderPanel({ composerFocusKey: 'session-a' })
+    expect(document.activeElement).toBe(getComposerEditor())
+
+    const navigationButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Open navigation"]'
+    )!
+    navigationButton.focus()
+    expect(document.activeElement).toBe(navigationButton)
+
+    renderPanel({ composerFocusKey: 'session-b' })
+    expect(document.activeElement).toBe(getComposerEditor())
+  })
+
+  it('does not focus the hidden composer while a blocking interaction owns its lane', () => {
+    renderPanel({ composerFocusKey: 'session-a' })
+    const navigationButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Open navigation"]'
+    )!
+    navigationButton.focus()
+
+    renderPanel({
+      composerFocusKey: 'session-blocked',
+      pendingPermissions: [{ requestId: 'permission-focus' } as never]
+    })
+
+    expect(getComposerForm().hidden).toBe(true)
+    expect(document.activeElement).toBe(navigationButton)
+  })
+
   it('keeps the Main composer available while a delegated question is pending', () => {
     renderPanel({
       activeSession: delegatedQuestionSession(),

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -484,6 +484,18 @@ describe('ConversationPanel composer intake', () => {
     expect(document.activeElement).toBe(navigationButton)
   })
 
+  it('does not refocus the composer when draft editing becomes available', () => {
+    renderPanel({ composerFocusKey: 'session-preparing', canEditDraft: false })
+    const navigationButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Open navigation"]'
+    )!
+    navigationButton.focus()
+
+    renderPanel({ composerFocusKey: 'session-preparing', canEditDraft: true })
+
+    expect(document.activeElement).toBe(navigationButton)
+  })
+
   it('keeps the Main composer available while a delegated question is pending', () => {
     renderPanel({
       activeSession: delegatedQuestionSession(),

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -503,8 +503,6 @@ const ConversationPanel = ({
   const ordinaryComposerBlocked = Boolean(
     sideChat || hasPendingPermission || pendingElicitation || pendingPlan
   )
-  const composerFocusRequest =
-    canEditDraft && !ordinaryComposerBlocked ? composerFocusKey : undefined
 
   // Re-attaches the interrupted session; on success the banner unmounts, so guard the state update.
   const handleResume = async (): Promise<void> => {
@@ -1124,7 +1122,7 @@ const ConversationPanel = ({
                               ? { sessionId: activeSession.id, projectId: activeSession.projectId }
                               : undefined
                           }
-                          focusRequest={composerFocusRequest}
+                          focusRequest={composerFocusKey}
                           restoreFocusRequest={composerRestoreFocusRequest}
                         />
                       </div>

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1123,7 +1123,7 @@ const ConversationPanel = ({
                               : undefined
                           }
                           focusRequest={composerFocusKey}
-                          restoreFocusRequest={composerRestoreFocusRequest}
+                          restoreFocusRequest={sideChat ? undefined : composerRestoreFocusRequest}
                         />
                       </div>
 

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -182,6 +182,7 @@ const formatAttachmentSize = (size: number): string => {
 
 type ConversationPanelProps = {
   activeSession: ChatSession | undefined
+  composerFocusKey?: string
   draftDoc: ComposerDoc
   canSendMessage: boolean
   canEditDraft: boolean
@@ -277,6 +278,7 @@ type ConversationPanelProps = {
 // Middle chat surface owns the visible conversation and local message composer UI.
 const ConversationPanel = ({
   activeSession,
+  composerFocusKey,
   draftDoc,
   canSendMessage,
   canEditDraft,
@@ -365,7 +367,7 @@ const ConversationPanel = ({
   const [isReportOpen, setIsReportOpen] = useState(false)
   const [isContextWindowOpen, setIsContextWindowOpen] = useState(false)
   const [reportDialogEpoch, setReportDialogEpoch] = useState(0)
-  const [composerFocusRequest, setComposerFocusRequest] = useState<number>()
+  const [composerRestoreFocusRequest, setComposerRestoreFocusRequest] = useState<number>()
 
   const openReportDialog = (): void => {
     setReportDialogEpoch((epoch) => epoch + 1)
@@ -498,6 +500,11 @@ const ConversationPanel = ({
         : undefined
   const hasPendingPermission = pendingPermissions.length > 0
   const delegatedQuestion = projectDelegatedQuestionQueue(activeSession)[0]
+  const ordinaryComposerBlocked = Boolean(
+    sideChat || hasPendingPermission || pendingElicitation || pendingPlan
+  )
+  const composerFocusRequest =
+    canEditDraft && !ordinaryComposerBlocked ? composerFocusKey : undefined
 
   // Re-attaches the interrupted session; on success the banner unmounts, so guard the state update.
   const handleResume = async (): Promise<void> => {
@@ -591,7 +598,7 @@ const ConversationPanel = ({
 
   const handleCloseSideChat = (): void => {
     onCloseSideChat?.()
-    setComposerFocusRequest((request) => (request ?? 0) + 1)
+    setComposerRestoreFocusRequest((request) => (request ?? 0) + 1)
   }
 
   // Converts the hidden file input selection into the shared staging callback.
@@ -972,13 +979,10 @@ const ConversationPanel = ({
                   {/* Composer stays mounted to preserve its draft, but a pending blocking interaction
                       owns the lane and makes the ordinary controls unreachable. */}
                   <form
-                    hidden={Boolean(
-                      sideChat || hasPendingPermission || pendingElicitation || pendingPlan
-                    )}
+                    hidden={ordinaryComposerBlocked}
                     className={cn(
                       'relative z-10 flex flex-col gap-2 rounded-2xl border border-border-200 bg-bg-000 px-3 py-2',
-                      (sideChat || hasPendingPermission || pendingElicitation || pendingPlan) &&
-                        'hidden'
+                      ordinaryComposerBlocked && 'hidden'
                     )}
                     onSubmit={(event) => event.preventDefault()}
                     {...dropZoneProps}
@@ -1121,6 +1125,7 @@ const ConversationPanel = ({
                               : undefined
                           }
                           focusRequest={composerFocusRequest}
+                          restoreFocusRequest={composerRestoreFocusRequest}
                         />
                       </div>
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -26,6 +26,7 @@ import { emptyDoc, type ComposerDoc } from './composer/composer-doc'
 
 // Capture the props passed to the heavy child components so the test can drive selection and drafts.
 let conversationProps: {
+  composerFocusKey: string
   draftDoc: ComposerDoc
   attachments: UploadedAttachment[]
   attachmentTransfers: ComposerUploadTransfer[]
@@ -329,6 +330,7 @@ describe('WorkspacePage draft preservation', () => {
 
   it('preserves each session doc independently when switching away and back', async () => {
     await renderPage()
+    expect(conversationProps.composerFocusKey).toBe('sess-a')
 
     await act(async () => {
       conversationProps.onDraftDocChange(textDoc('draft for A'))
@@ -337,6 +339,7 @@ describe('WorkspacePage draft preservation', () => {
 
     // Switching to session B clears the composer to B's own (empty) doc.
     await openSession('sess-b')
+    expect(conversationProps.composerFocusKey).toBe('sess-b')
     expect(conversationProps.draftDoc).toEqual(emptyDoc)
 
     await act(async () => {
@@ -345,6 +348,7 @@ describe('WorkspacePage draft preservation', () => {
 
     // Switching back to session A restores A's doc, and B keeps its own.
     await openSession('sess-a')
+    expect(conversationProps.composerFocusKey).toBe('sess-a')
     expect(conversationProps.draftDoc).toEqual(textDoc('draft for A'))
 
     await openSession('sess-b')
@@ -368,6 +372,26 @@ describe('WorkspacePage draft preservation', () => {
     })
 
     expect(conversationProps.permissionProfile).toBe('auto')
+    expect(conversationProps.composerFocusKey).toBe('new:proj-1')
+  })
+
+  it('targets the new-conversation composer after the keyboard shortcut', async () => {
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === 'sess-a'
+          ? { ...session, messages: [userMessage('prompt', 'Start a new conversation')] }
+          : session
+      )
+    }))
+    await renderPage()
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'n', ctrlKey: true, cancelable: true })
+      )
+    })
+
+    expect(conversationProps.composerFocusKey).toBe('new:proj-1')
   })
 
   it('browses visible Session prompts and restores the unsent scratch draft', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1028,6 +1028,7 @@ const WorkspacePage = ({
         }) => (
           <ConversationPanel
             activeSession={activeSession}
+            composerFocusKey={currentDraftKey}
             draftDoc={draftDoc}
             canSendMessage={canSendMessage}
             canEditDraft={canEditDraft}

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -192,6 +192,8 @@ type Overrides = Partial<{
   historyStatus: string
   onNavigateHistory: (direction: 'previous' | 'next') => boolean
   mentionPreviewContext: { sessionId: string; projectId?: string }
+  focusRequest: string | number
+  restoreFocusRequest: number
 }>
 
 const renderEditor = (overrides: Overrides = {}): void => {
@@ -209,6 +211,8 @@ const renderEditor = (overrides: Overrides = {}): void => {
         historyStatus={overrides.historyStatus}
         onNavigateHistory={overrides.onNavigateHistory}
         mentionPreviewContext={overrides.mentionPreviewContext}
+        focusRequest={overrides.focusRequest}
+        restoreFocusRequest={overrides.restoreFocusRequest}
       />
     )
   })
@@ -428,6 +432,19 @@ describe('ComposerEditor', () => {
     expect(selection?.anchorOffset).toBe(editor().childNodes.length)
     expect(document.querySelector('[role="status"]')?.textContent).toBe('History item 1 of 1')
     expect(editor().getAttribute('aria-describedby')).toBeTruthy()
+  })
+
+  it('focuses the end of a restored draft when requested', () => {
+    renderEditor({ focusRequest: 'session-b' })
+    renderEditor({
+      doc: { nodes: [{ type: 'text', text: 'restored draft' }] },
+      focusRequest: 'session-b'
+    })
+
+    const selection = window.getSelection()
+    expect(document.activeElement).toBe(editor())
+    expect(selection?.anchorNode).toBe(editor())
+    expect(selection?.anchorOffset).toBe(editor().childNodes.length)
   })
 
   it('forwards paste to onPaste and inserts clipboard text as plain text', () => {

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -226,12 +226,13 @@ export const ComposerEditor = ({
 
   useLayoutEffect(() => {
     const root = editorRef.current
-    if (
-      root &&
-      (restoreFocusRequest !== undefined || (focusRequest !== undefined && canReceiveFocus(root)))
-    )
-      moveCaretToEnd(root)
-  }, [focusRequest, restoreFocusRequest])
+    if (root && focusRequest !== undefined && canReceiveFocus(root)) moveCaretToEnd(root)
+  }, [focusRequest])
+
+  useLayoutEffect(() => {
+    const root = editorRef.current
+    if (root && restoreFocusRequest !== undefined && canReceiveFocus(root)) moveCaretToEnd(root)
+  }, [restoreFocusRequest])
 
   const handleInput = useCallback((): void => emitDocFromDom(), [emitDocFromDom])
 

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -50,7 +50,8 @@ type ComposerEditorProps = {
   // Scope for previewing clicked `@` mention chips (uploads/artifacts); without it those chips
   // stay inert on click (linked-folder chips resolve through the granted-roots store instead).
   mentionPreviewContext?: { sessionId: string; projectId?: string }
-  focusRequest?: number
+  focusRequest?: string | number
+  restoreFocusRequest?: number
 }
 
 // Structural equality over doc nodes; used to decide whether the incoming prop diverges from what
@@ -172,7 +173,8 @@ export const ComposerEditor = ({
   historyStatus = '',
   onNavigateHistory,
   mentionPreviewContext,
-  focusRequest
+  focusRequest,
+  restoreFocusRequest
 }: ComposerEditorProps): React.JSX.Element => {
   const editorRef = useRef<HTMLDivElement>(null)
   const historyDescriptionId = useId()
@@ -209,16 +211,20 @@ export const ComposerEditor = ({
   useLayoutEffect(() => {
     const root = editorRef.current
     if (!root) return
-    if (!nodesEqual(domToDoc(root).nodes, doc.nodes)) applyDocToDom(root, doc)
-    if (restoreHistoryCaretRef.current) {
+    const shouldPreserveFocus = focusRequest !== undefined && document.activeElement === root
+    const docChanged = !nodesEqual(domToDoc(root).nodes, doc.nodes)
+    if (docChanged) applyDocToDom(root, doc)
+    if (restoreHistoryCaretRef.current || (docChanged && shouldPreserveFocus)) {
       restoreHistoryCaretRef.current = false
       moveCaretToEnd(root)
     }
-  }, [doc])
+  }, [doc, focusRequest])
 
   useLayoutEffect(() => {
-    if (focusRequest !== undefined && editorRef.current) moveCaretToEnd(editorRef.current)
-  }, [focusRequest])
+    if ((focusRequest !== undefined || restoreFocusRequest !== undefined) && editorRef.current) {
+      moveCaretToEnd(editorRef.current)
+    }
+  }, [focusRequest, restoreFocusRequest])
 
   const handleInput = useCallback((): void => emitDocFromDom(), [emitDocFromDom])
 

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -157,6 +157,9 @@ const moveCaretToEnd = (root: HTMLElement): void => {
   selection?.addRange(range)
 }
 
+const canReceiveFocus = (root: HTMLElement): boolean =>
+  root.getAttribute('contenteditable') === 'true' && root.closest('[hidden]') === null
+
 // A contenteditable composer driven by a pure ComposerDoc model. External doc changes flow into the
 // DOM via applyDocToDom; user edits flow out via domToDoc. A `/` mention trigger mounts a skill popup.
 export const ComposerEditor = ({
@@ -211,7 +214,8 @@ export const ComposerEditor = ({
   useLayoutEffect(() => {
     const root = editorRef.current
     if (!root) return
-    const shouldPreserveFocus = focusRequest !== undefined && document.activeElement === root
+    const shouldPreserveFocus =
+      focusRequest !== undefined && canReceiveFocus(root) && document.activeElement === root
     const docChanged = !nodesEqual(domToDoc(root).nodes, doc.nodes)
     if (docChanged) applyDocToDom(root, doc)
     if (restoreHistoryCaretRef.current || (docChanged && shouldPreserveFocus)) {
@@ -221,9 +225,12 @@ export const ComposerEditor = ({
   }, [doc, focusRequest])
 
   useLayoutEffect(() => {
-    if ((focusRequest !== undefined || restoreFocusRequest !== undefined) && editorRef.current) {
-      moveCaretToEnd(editorRef.current)
-    }
+    const root = editorRef.current
+    if (
+      root &&
+      (restoreFocusRequest !== undefined || (focusRequest !== undefined && canReceiveFocus(root)))
+    )
+      moveCaretToEnd(root)
   }, [focusRequest, restoreFocusRequest])
 
   const handleInput = useCallback((): void => emitDocFromDom(), [emitDocFromDom])


### PR DESCRIPTION
## Problem

After switching Sessions, opening a Project, or starting a new Session from the button or keyboard shortcut, focus could remain on the navigation control instead of moving to the composer. Users then had to click the input before typing.

## Proposed change

- Key composer focus requests to the active draft context, covering existing Sessions and Project-scoped new-conversation drafts.
- Focus the contenteditable composer and place the caret at the end after the target draft is restored.
- Preserve the existing Side Chat close focus restoration.
- Avoid stealing focus while Permission approval, Ask-User elicitation, Plan approval, or Side Chat owns the composer lane.

## Scope and non-goals

- Renderer-only focus behavior; no persistence, session model, IPC, ACP, or database changes.
- No change to blocking-interaction focus ownership.
- No new dependency or global event channel.

## Acceptance criteria and validation

All commands below ran after the final material edit.

- Session/new-conversation navigation and restored-draft caret placement -> `npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx src/renderer/src/pages/workspace/workspace-page.architecture.test.ts` -> 154 tests passed.
- Affected Node and renderer types -> `npm run typecheck` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors and 13 pre-existing warnings in unchanged files.
- Portable regression suite -> `npm test` -> 987 files / 14,350 tests passed; 15 files / 198 tests skipped.

The final impact analysis used the full fallback because `ConversationPanel` and `ComposerEditor` are not declared owner paths in the module-impact manifest. No ACP framework, launcher, model, platform-specific path, persistence, or IPC behavior is affected. Platform-specific Cmd/Ctrl shortcut routing is unchanged; the tests verify the shared draft-context result.

Uncovered risk: no packaged Electron manual or E2E focus journey was run; automated jsdom interaction coverage verifies focus ownership and caret placement.

## Review focus

- Confirm every Session/Project entry path converges on `currentDraftKey`.
- Confirm blocking interactions retain focus ownership.
- Confirm restored non-empty drafts keep the caret at the end without refocusing during ordinary edits.