### PR TITLE
ci(release): lower macOS runner version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,11 +135,13 @@ jobs:
         if: ${{ matrix.platform == 'mac' }}
         shell: bash
         run: |
-          xcode=$(find /Applications -maxdepth 1 -type d -name 'Xcode_26*.app' -print -quit)
-          if [ -z "$xcode" ]; then
+          shopt -s nullglob
+          xcodes=(/Applications/Xcode_26*.app)
+          if [ "${#xcodes[@]}" -eq 0 ]; then
             echo "::error::Xcode 26 is not installed on this runner"
             exit 1
           fi
+          xcode="${xcodes[0]}"
           sudo xcode-select --switch "$xcode/Contents/Developer"
           xcodebuild -version
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ name: Build
 #
 # `npm ci` on each runner installs the native binaries it needs (claude-agent-sdk optional package,
 # Prisma query engine). Both macOS packages use the more available ARM64 macOS 15 runners; the x64
-# lane rebuilds its native addon for Intel and validates under Rosetta. Xcode 26 still compiles the
-# Icon Composer asset; Linux runs on ubuntu-latest and Windows x64 on windows-latest.
+# lane rebuilds its native addon for Intel and validates under Rosetta. macOS packaging uses the
+# compatible ICNS app icon; Linux runs on ubuntu-latest and Windows x64 on windows-latest.
 on:
   workflow_call:
     inputs:
@@ -81,8 +81,7 @@ jobs:
         run: |
           # Build both macOS packages on ARM64 macOS 15 runners so neither lane waits for scarce
           # macOS 26 or Intel capacity. The x64 lane cross-rebuilds native dependencies and installs
-          # Rosetta for its package smoke. The job still selects Xcode 26 below so actool can compile
-          # build/icon.icon. Windows'
+          # Rosetta for its package smoke. Windows'
           # engine is query_engine-windows.dll.node (no `lib`
           # prefix, .dll.node not .so/.dylib). engine_keep = substring of the engine file to keep.
           # subdir/bin_os/bin_arch drive the notebook runtime staging step: `subdir` is the conda
@@ -115,7 +114,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     # Keep native dependencies and packaged binaries compatible with the app's declared macOS 12
-    # minimum even though the native builders select the Xcode 26 toolchain.
+    # minimum on the macOS 15 ARM builders.
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.platform == 'mac' && '12.0' || '' }}
 
@@ -128,20 +127,6 @@ jobs:
         with:
           node-version: 22
           cache: npm
-
-      # macOS 15 images default to Xcode 16. Pin Xcode 26.3: its actool supports Icon Composer,
-      # while 26.0.1 can crash against macOS 15 system frameworks during asset compilation.
-      - name: Select Xcode 26
-        if: ${{ matrix.platform == 'mac' }}
-        shell: bash
-        run: |
-          xcode=/Applications/Xcode_26.3.app
-          if [ ! -d "$xcode" ]; then
-            echo "::error::Xcode 26.3 is not installed on this runner"
-            exit 1
-          fi
-          sudo xcode-select --switch "$xcode/Contents/Developer"
-          xcodebuild -version
 
       # Stable/nightly package smoke executes the Intel Electron app and micromamba on this ARM host.
       # The notarization dry-run installs Rosetta in its later notarize job before final package smoke.
@@ -167,12 +152,6 @@ jobs:
           fi
           lipo "$addon" -verify_arch x86_64
           lipo -info "$addon"
-
-      # electron-builder compiles build/icon.icon with actool. Fail here with a focused diagnostic
-      # instead of much later in packaging if the selected Xcode 26 installation is incomplete.
-      - name: Verify Icon Composer build tools
-        if: ${{ matrix.platform == 'mac' }}
-        run: actool --version
 
       # Installers do not carry a managed-runtime bundle. Stable/nightly builds therefore fail closed
       # unless the exact immutable manifest required by this app version and platform is already live

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
             echo "::error::safe-file-publisher native addon was not rebuilt"
             exit 1
           fi
-          lipo -verify_arch x86_64 "$addon"
+          lipo "$addon" -verify_arch x86_64
           lipo -info "$addon"
 
       # electron-builder compiles build/icon.icon with actool. Fail here with a focused diagnostic

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,14 @@
 name: Build
 
-# Reusable build workflow: packages the app for macOS (arm64 + x64) and Linux, each on its own
-# native runner, and uploads the installers as pipeline artifacts. Called by release.yml (stable,
+# Reusable build workflow: packages the app for macOS (arm64 + x64), Linux, and Windows, and uploads
+# the installers as pipeline artifacts. Called by release.yml (stable,
 # on tag) and nightly.yml (rolling prerelease, on push to main) so the build matrix lives in one
 # place. Publishing is done by the caller, not here.
 #
 # `npm ci` on each runner installs the native binaries it needs (claude-agent-sdk optional package,
-# Prisma query engine). macOS uses native ARM64 and Intel macOS 26 runners so packaged-app
-# certification does not execute across architectures and Xcode 26 can compile the Icon Composer
-# asset; Linux runs on ubuntu-latest and Windows x64 on windows-latest.
+# Prisma query engine). Both macOS packages use the more available ARM64 macOS 15 runners; the x64
+# lane rebuilds its native addon for Intel and validates under Rosetta. Xcode 26 still compiles the
+# Icon Composer asset; Linux runs on ubuntu-latest and Windows x64 on windows-latest.
 on:
   workflow_call:
     inputs:
@@ -79,16 +79,18 @@ jobs:
       - id: set
         shell: bash
         run: |
-          # Run each macOS package on its native macOS 26 architecture so P0, visual, and package
-          # smoke can execute the produced app while Xcode 26 compiles build/icon.icon. Windows'
+          # Build both macOS packages on ARM64 macOS 15 runners so neither lane waits for scarce
+          # macOS 26 or Intel capacity. The x64 lane cross-rebuilds native dependencies and installs
+          # Rosetta for its package smoke. The job still selects Xcode 26 below so actool can compile
+          # build/icon.icon. Windows'
           # engine is query_engine-windows.dll.node (no `lib`
           # prefix, .dll.node not .so/.dylib). engine_keep = substring of the engine file to keep.
           # subdir/bin_os/bin_arch drive the notebook runtime staging step: `subdir` is the conda
           # platform whose micromamba + offline bundle to fetch, and bin_os/bin_arch are the
           # resources/bin/<os>/<arch> path electron-builder.yml reads the micromamba binary from.
           mac='[
-            {"name":"macos-arm64","os":"macos-26","platform":"mac","eb_args":"--mac --arm64","engine_keep":"darwin-arm64","subdir":"osx-arm64","bin_os":"mac","bin_arch":"arm64"},
-            {"name":"macos-x64","os":"macos-26-intel","platform":"mac","eb_args":"--mac --x64","engine_keep":"darwin.dylib","subdir":"osx-64","bin_os":"mac","bin_arch":"x64"}
+            {"name":"macos-arm64","os":"macos-15","platform":"mac","eb_args":"--mac --arm64","engine_keep":"darwin-arm64","subdir":"osx-arm64","bin_os":"mac","bin_arch":"arm64"},
+            {"name":"macos-x64","os":"macos-15","platform":"mac","eb_args":"--mac --x64","engine_keep":"darwin.dylib","subdir":"osx-64","bin_os":"mac","bin_arch":"x64"}
           ]'
           rest='[
             {"name":"linux-x64","os":"ubuntu-latest","platform":"linux","eb_args":"--linux","engine_keep":".so.node","subdir":"linux-64","bin_os":"linux","bin_arch":"x64"},
@@ -113,7 +115,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     # Keep native dependencies and packaged binaries compatible with the app's declared macOS 12
-    # minimum even though the native builders run on macOS 26.
+    # minimum even though the native builders select the Xcode 26 toolchain.
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.platform == 'mac' && '12.0' || '' }}
 
@@ -127,12 +129,47 @@ jobs:
           node-version: 22
           cache: npm
 
+      # macOS 15 images include Xcode 26 but default to Xcode 16. Select any installed Xcode 26
+      # before npm ci so native dependencies and the Icon Composer asset use the release toolchain.
+      - name: Select Xcode 26
+        if: ${{ matrix.platform == 'mac' }}
+        shell: bash
+        run: |
+          xcode=$(find /Applications -maxdepth 1 -type d -name 'Xcode_26*.app' -print -quit)
+          if [ -z "$xcode" ]; then
+            echo "::error::Xcode 26 is not installed on this runner"
+            exit 1
+          fi
+          sudo xcode-select --switch "$xcode/Contents/Developer"
+          xcodebuild -version
+
+      # Stable/nightly package smoke executes the Intel Electron app and micromamba on this ARM host.
+      # The notarization dry-run installs Rosetta in its later notarize job before final package smoke.
+      - name: Enable Intel emulation
+        if: ${{ matrix.name == 'macos-x64' && !inputs.skip_verify }}
+        run: sudo softwareupdate --install-rosetta --agree-to-license
+
       # npm ci runs postinstall: prisma generate + electron-builder install-app-deps.
       - name: Install dependencies
         run: npm ci
 
+      # npm ci rebuilds native modules for the ARM host. Rebuild the shipped N-API addon for Intel
+      # before electron-builder copies it into the x64 app, then fail closed on the Mach-O slice.
+      - name: Rebuild Intel native dependencies
+        if: ${{ matrix.name == 'macos-x64' }}
+        shell: bash
+        run: |
+          ./node_modules/.bin/electron-builder install-app-deps --platform darwin --arch x64
+          addon=$(find node_modules/@aipoch/safe-file-publisher-native/build/Release -type f -name '*.node' -print -quit)
+          if [ -z "$addon" ]; then
+            echo "::error::safe-file-publisher native addon was not rebuilt"
+            exit 1
+          fi
+          lipo -verify_arch x86_64 "$addon"
+          lipo -info "$addon"
+
       # electron-builder compiles build/icon.icon with actool. Fail here with a focused diagnostic
-      # instead of much later in packaging if the runner image ever loses its Xcode 26 selection.
+      # instead of much later in packaging if the selected Xcode 26 installation is incomplete.
       - name: Verify Icon Composer build tools
         if: ${{ matrix.platform == 'mac' }}
         run: actool --version
@@ -193,8 +230,8 @@ jobs:
           fi
 
       # electron-builder 26.15.3 creates its temporary keychain with a random password but invokes
-      # `security set-key-partition-list -k` with the P12 password. macOS 26 Intel rejects that
-      # mismatch with SecKeychainUnlock. Import the certificate ourselves with the correct password
+      # `security set-key-partition-list -k` with the P12 password. The temporary keychain can reject
+      # that mismatch with SecKeychainUnlock, so import the certificate with the correct password
       # for each boundary, then give electron-builder only the prepared keychain path.
       - name: Prepare macOS signing keychain
         id: mac_signing
@@ -361,7 +398,7 @@ jobs:
         run: npm run test:e2e:p0
 
       # Visual behavior uses the same renderer bundle on every package. Keep one canonical hard gate
-      # beside P0 instead of multiplying antialiasing and launch variance across four native runners.
+      # beside P0 instead of multiplying antialiasing and launch variance across four packages.
       - name: Run desktop visual regression
         id: visual
         if: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,19 +129,17 @@ jobs:
           node-version: 22
           cache: npm
 
-      # macOS 15 images include Xcode 26 but default to Xcode 16. Select any installed Xcode 26
-      # before npm ci so native dependencies and the Icon Composer asset use the release toolchain.
+      # macOS 15 images default to Xcode 16. Pin Xcode 26.3: its actool supports Icon Composer,
+      # while 26.0.1 can crash against macOS 15 system frameworks during asset compilation.
       - name: Select Xcode 26
         if: ${{ matrix.platform == 'mac' }}
         shell: bash
         run: |
-          shopt -s nullglob
-          xcodes=(/Applications/Xcode_26*.app)
-          if [ "${#xcodes[@]}" -eq 0 ]; then
-            echo "::error::Xcode 26 is not installed on this runner"
+          xcode=/Applications/Xcode_26.3.app
+          if [ ! -d "$xcode" ]; then
+            echo "::error::Xcode 26.3 is not installed on this runner"
             exit 1
           fi
-          xcode="${xcodes[0]}"
           sudo xcode-select --switch "$xcode/Contents/Developer"
           xcodebuild -version
 

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -60,8 +60,8 @@ permissions:
 jobs:
   notarize:
     name: Notarize + staple ${{ matrix.arch }}
-    # The final package smoke launches the stapled app. Keep it architecture-native so the x64
-    # launch is not silently dependent on Rosetta being installed on an Apple Silicon runner.
+    # Both architectures use ARM64 capacity. The x64 lane enables Rosetta before launching the
+    # stapled Intel app and micromamba during final package smoke.
     runs-on: ${{ matrix.os }}
     # Hard ceiling so a stuck notarization can never run forever (see also the wait --timeout below).
     timeout-minutes: 30
@@ -73,7 +73,7 @@ jobs:
           - arch: arm64
             os: macos-15
           - arch: x64
-            os: macos-15-intel
+            os: macos-15
     steps:
       # Notarization is optional: if the API key secret isn't configured, no-op so a tagged release
       # still succeeds with the ad-hoc mac build (today's behavior) instead of failing here. Every
@@ -105,6 +105,12 @@ jobs:
       - name: Install dependencies
         if: steps.gate.outputs.enabled == 'true'
         run: npm ci
+
+      # The x64 artifact was cross-built on ARM and final smoke launches its Intel app and micromamba.
+      # Install Rosetta only when notarization is enabled and those launch checks will run.
+      - name: Enable Intel emulation
+        if: ${{ steps.gate.outputs.enabled == 'true' && matrix.arch == 'x64' }}
+        run: sudo softwareupdate --install-rosetta --agree-to-license
 
       # Call path (from_run): pull this run's signed artifacts for the arch (uploaded by build.yml).
       - name: Download signed mac artifact (from this run)

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -104,10 +104,9 @@ nsis:
   allowToChangeInstallationDirectory: true
   include: build/installer.nsh
 mac:
-  # Compile the Icon Composer package into the app bundle (Assets.car + an ICNS fallback for
-  # pre-Tahoe macOS). This is intentionally separate from dmg.icon below: the mounted installer
-  # volume still uses the legacy, explicitly-designed ICNS artwork.
-  icon: build/icon.icon
+  # Xcode 26 actool cannot reliably compile Icon Composer packages on macOS 15 runners. Use the
+  # existing ICNS artwork for both the app and mounted installer volume.
+  icon: build/icon.icns
   darkModeSupport: true
   artifactName: aipoch-${name}-${version}-mac-${arch}.${ext}
   # Minimum macOS to run the app (written to Info.plist LSMinimumSystemVersion). macOS 12 (Monterey)

--- a/scripts/electron-builder-config.test.ts
+++ b/scripts/electron-builder-config.test.ts
@@ -72,13 +72,13 @@ describe('electron-builder Linux desktop identity', () => {
 })
 
 describe('electron-builder macOS icons', () => {
-  it('uses Icon Composer for the app and signs the legacy-icon DMG container', () => {
+  it('uses ICNS for the app and signed DMG while preserving adaptive source artwork', () => {
     const config = load(readFileSync(join(process.cwd(), 'electron-builder.yml'), 'utf8')) as {
       mac?: { icon?: string; darkModeSupport?: boolean }
       dmg?: { icon?: string; sign?: boolean }
     }
 
-    expect(config.mac?.icon).toBe('build/icon.icon')
+    expect(config.mac?.icon).toBe('build/icon.icns')
     expect(config.mac?.darkModeSupport).toBe(true)
     expect(config.dmg?.icon).toBe('build/icon.icns')
     expect(config.dmg?.sign).toBe(true)

--- a/scripts/macos-package-smoke.mjs
+++ b/scripts/macos-package-smoke.mjs
@@ -16,7 +16,7 @@ import {
 
 const ARTIFACT_PATTERN = /^aipoch-open-science-(.+)-mac-(?:arm64|x64)\.(dmg|zip)$/
 const SMOKE_ROOT_PREFIX = 'open-science-macos-package-smoke-'
-const STARTUP_TIMEOUT_MS = 60_000
+const STARTUP_TIMEOUT_MS = 180_000
 
 const delay = (milliseconds) =>
   new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds))
@@ -137,7 +137,11 @@ const launchAndProbe = async ({ executable, expectedVersion, env, userDataRoot }
 
   try {
     const service = await Promise.race([
-      waitFor('the packaged macOS web service', async () => parsePackagedAppEndpoint(output)),
+      waitFor('the packaged macOS web service', async () => parsePackagedAppEndpoint(output)).catch(
+        (error) => {
+          throw new Error(`${error.message}\n${output}`)
+        }
+      ),
       exit.then((code) => {
         throw new Error(`Packaged macOS app exited before becoming healthy (${code}).\n${output}`)
       })

--- a/scripts/macos-package-smoke.mjs
+++ b/scripts/macos-package-smoke.mjs
@@ -96,9 +96,7 @@ const assertPackagedResources = async (appBundle) => {
     join(appBundle, 'Contents', 'MacOS', 'Open Science'),
     join(resources, 'app.asar'),
     join(resources, 'micromamba'),
-    // electron-builder compiles build/icon.icon into the adaptive catalog and also emits an ICNS
-    // fallback for macOS releases that predate Icon Composer.
-    join(resources, 'Assets.car'),
+    // The macOS 15-compatible package uses the committed ICNS artwork.
     join(resources, 'icon.icns')
   ]
   for (const path of paths) await access(path)

--- a/scripts/macos-package-smoke.test.ts
+++ b/scripts/macos-package-smoke.test.ts
@@ -91,7 +91,6 @@ describe('macOS package smoke', () => {
       writeFile(join(executableDirectory, 'Open Science'), ''),
       writeFile(join(resources, 'app.asar'), ''),
       writeFile(join(resources, 'micromamba'), ''),
-      writeFile(join(resources, 'Assets.car'), ''),
       writeFile(join(resources, 'icon.icns'), ''),
       writeFile(join(prismaClient, 'libquery_engine-darwin-arm64.dylib.node'), '')
     ])
@@ -101,10 +100,6 @@ describe('macOS package smoke', () => {
       micromamba: join(resources, 'micromamba')
     })
 
-    await rm(join(resources, 'Assets.car'))
-    await expect(assertPackagedResources(appBundle)).rejects.toThrow()
-
-    await writeFile(join(resources, 'Assets.car'), '')
     await writeFile(join(prismaClient, 'libquery_engine-darwin.dylib.node'), '')
     await expect(assertPackagedResources(appBundle)).rejects.toThrow(/exactly one Prisma engine/)
     await rm(join(prismaClient, 'libquery_engine-darwin.dylib.node'))

--- a/scripts/macos-package-smoke.test.ts
+++ b/scripts/macos-package-smoke.test.ts
@@ -75,7 +75,7 @@ describe('macOS package smoke', () => {
     ])
   })
 
-  it('requires the adaptive icon catalog and its legacy ICNS fallback', async () => {
+  it('requires the ICNS icon and architecture-specific Prisma engine', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-macos-app-'))
     roots.push(root)
     const appBundle = join(root, 'Open Science.app')

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -151,7 +151,6 @@ describe('post-merge Windows validation', () => {
     const setup = readWorkflow('build.yml').jobs.setup.steps?.find(({ id }) => id === 'set')
     const job = readWorkflow('build.yml').jobs.build
     const names = job.steps?.map(({ name }) => name) ?? []
-    const selectXcode = findStep(job, 'Select Xcode 26')
     const buildRosetta = findStep(job, 'Enable Intel emulation')
     const rebuildIntel = findStep(job, 'Rebuild Intel native dependencies')
     const packaged = findStep(job, 'Resolve packaged Electron executable')
@@ -168,10 +167,6 @@ describe('post-merge Windows validation', () => {
 
     expect(setup.run).toContain('"name":"macos-arm64","os":"macos-15"')
     expect(setup.run).toContain('"name":"macos-x64","os":"macos-15"')
-    expect(selectXcode.if).toBe("${{ matrix.platform == 'mac' }}")
-    expect(selectXcode.run).toContain('xcode=/Applications/Xcode_26.3.app')
-    expect(selectXcode.run).toContain('xcode-select --switch')
-    expect(selectXcode.run).toContain('xcodebuild -version')
     expect(job.env?.MACOSX_DEPLOYMENT_TARGET).toBe(
       "${{ matrix.platform == 'mac' && '12.0' || '' }}"
     )

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -151,6 +151,9 @@ describe('post-merge Windows validation', () => {
     const setup = readWorkflow('build.yml').jobs.setup.steps?.find(({ id }) => id === 'set')
     const job = readWorkflow('build.yml').jobs.build
     const names = job.steps?.map(({ name }) => name) ?? []
+    const selectXcode = findStep(job, 'Select Xcode 26')
+    const buildRosetta = findStep(job, 'Enable Intel emulation')
+    const rebuildIntel = findStep(job, 'Rebuild Intel native dependencies')
     const packaged = findStep(job, 'Resolve packaged Electron executable')
     const p0 = findStep(job, 'Run P0 Electron certification')
     const visual = findStep(job, 'Run desktop visual regression')
@@ -158,15 +161,27 @@ describe('post-merge Windows validation', () => {
     const linux = findStep(job, 'Smoke test Linux packages')
     const evidence = findStep(job, 'Record platform certification evidence')
     const notarize = readWorkflow('notarize-mac.yml').jobs.notarize
+    const notarizeRosetta = findStep(notarize, 'Enable Intel emulation')
     const notarizeDryRun = readWorkflow('notarize-dryrun.yml').jobs.notarize
     const finalMacos = findStep(notarize, 'Smoke test final macOS packages')
     const refreshedMacosEvidence = findStep(notarize, 'Refresh macOS certification evidence')
 
-    expect(setup.run).toContain('"name":"macos-arm64","os":"macos-26"')
-    expect(setup.run).toContain('"name":"macos-x64","os":"macos-26-intel"')
+    expect(setup.run).toContain('"name":"macos-arm64","os":"macos-15"')
+    expect(setup.run).toContain('"name":"macos-x64","os":"macos-15"')
+    expect(selectXcode.if).toBe("${{ matrix.platform == 'mac' }}")
+    expect(selectXcode.run).toContain("-name 'Xcode_26*.app'")
+    expect(selectXcode.run).toContain('xcode-select --switch')
+    expect(selectXcode.run).toContain('xcodebuild -version')
     expect(job.env?.MACOSX_DEPLOYMENT_TARGET).toBe(
       "${{ matrix.platform == 'mac' && '12.0' || '' }}"
     )
+    expect(buildRosetta.if).toBe("${{ matrix.name == 'macos-x64' && !inputs.skip_verify }}")
+    expect(buildRosetta.run).toContain('softwareupdate --install-rosetta --agree-to-license')
+    expect(rebuildIntel.if).toBe("${{ matrix.name == 'macos-x64' }}")
+    expect(rebuildIntel.run).toContain(
+      'electron-builder install-app-deps --platform darwin --arch x64'
+    )
+    expect(rebuildIntel.run).toContain('lipo -verify_arch x86_64')
     expect(packaged.id).toBe('packaged_app')
     expect(packaged.run).toContain('Open Science.app/Contents/MacOS/Open Science')
     expect(packaged.run).toContain('win-unpacked/open-science.exe')
@@ -197,13 +212,17 @@ describe('post-merge Windows validation', () => {
     expect(notarize.strategy?.matrix).toEqual({
       include: [
         { arch: 'arm64', os: 'macos-15' },
-        { arch: 'x64', os: 'macos-15-intel' }
+        { arch: 'x64', os: 'macos-15' }
       ]
     })
     expect(refreshedMacosEvidence.run).toContain('--package-smoke passed')
     expect(refreshedMacosEvidence.run).toContain(
       '--database-migration-certification mac/database-migration-certification.json'
     )
+    expect(notarizeRosetta.if).toBe(
+      "${{ steps.gate.outputs.enabled == 'true' && matrix.arch == 'x64' }}"
+    )
+    expect(notarizeRosetta.run).toContain('softwareupdate --install-rosetta --agree-to-license')
     expect(refreshedMacosEvidence.run).toContain("matrix.arch == 'arm64'")
     expect(refreshedMacosEvidence.if).toContain('inputs.certified_build')
     expect(notarizeDryRun.with?.certified_build).toBe(false)

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -169,7 +169,9 @@ describe('post-merge Windows validation', () => {
     expect(setup.run).toContain('"name":"macos-arm64","os":"macos-15"')
     expect(setup.run).toContain('"name":"macos-x64","os":"macos-15"')
     expect(selectXcode.if).toBe("${{ matrix.platform == 'mac' }}")
-    expect(selectXcode.run).toContain("-name 'Xcode_26*.app'")
+    expect(selectXcode.run).toContain('shopt -s nullglob')
+    expect(selectXcode.run).toContain('xcodes=(/Applications/Xcode_26*.app)')
+    expect(selectXcode.run).toContain('xcode="${xcodes[0]}"')
     expect(selectXcode.run).toContain('xcode-select --switch')
     expect(selectXcode.run).toContain('xcodebuild -version')
     expect(job.env?.MACOSX_DEPLOYMENT_TARGET).toBe(

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -169,9 +169,7 @@ describe('post-merge Windows validation', () => {
     expect(setup.run).toContain('"name":"macos-arm64","os":"macos-15"')
     expect(setup.run).toContain('"name":"macos-x64","os":"macos-15"')
     expect(selectXcode.if).toBe("${{ matrix.platform == 'mac' }}")
-    expect(selectXcode.run).toContain('shopt -s nullglob')
-    expect(selectXcode.run).toContain('xcodes=(/Applications/Xcode_26*.app)')
-    expect(selectXcode.run).toContain('xcode="${xcodes[0]}"')
+    expect(selectXcode.run).toContain('xcode=/Applications/Xcode_26.3.app')
     expect(selectXcode.run).toContain('xcode-select --switch')
     expect(selectXcode.run).toContain('xcodebuild -version')
     expect(job.env?.MACOSX_DEPLOYMENT_TARGET).toBe(

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -183,7 +183,7 @@ describe('post-merge Windows validation', () => {
     expect(rebuildIntel.run).toContain(
       'electron-builder install-app-deps --platform darwin --arch x64'
     )
-    expect(rebuildIntel.run).toContain('lipo -verify_arch x86_64')
+    expect(rebuildIntel.run).toContain('lipo "$addon" -verify_arch x86_64')
     expect(packaged.id).toBe('packaged_app')
     expect(packaged.run).toContain('Open Science.app/Contents/MacOS/Open Science')
     expect(packaged.run).toContain('win-unpacked/open-science.exe')


### PR DESCRIPTION
## Problem

Release and notarization jobs can wait a long time for scarce `macos-26` and `macos-15-intel` hosted runners. The linked release run queued the macOS lane without assigning a runner, which also made the no-publish notarization dry-run slow to start.

## Proposed change

- Run both macOS arm64 and x64 packaging lanes on `macos-15` ARM runners.
- Rebuild `@aipoch/safe-file-publisher-native` for x86_64 before packaging and verify its Mach-O slice with Xcode `lipo`.
- Install Rosetta only where an x64 package or runtime must be smoke-tested on an ARM host.
- Apply the same ARM runner topology to the notarization workflow.
- Use the existing ICNS artwork for the macOS app and DMG. Xcode 26 `actool` from the macOS 15 image crashes while compiling the Icon Composer source package, so keeping adaptive Icon Composer output would still require a macOS 26 runner.
- Allow up to three minutes for the first Rosetta launch of the packaged Intel Electron app and preserve its output on timeout.
- Extend workflow, builder configuration, and macOS package-smoke contracts to lock these requirements down.

## Scope and non-goals

This changes release/notarization workflows, macOS icon packaging configuration, package smoke behavior, and their contract tests. It does not change application source, publishing behavior, signing inputs, or the dry-run no-publish boundary. The committed `build/icon.icon` source remains available for a future precompiled adaptive-icon pipeline, but this PR deliberately does not compile it on macOS 15.

## Acceptance criteria and validation

- Final head: `68417d23000710ed631a1b99b45e23bd2b831042`.
- Full no-publish notarization dry-run: [run 31566541147](https://github.com/aipoch/open-science/actions/runs/31566541147) - passed.
  - `macos-arm64` build/package/artifact - passed on `macos-15` ARM.
  - `macos-x64` cross-rebuild/build/package/artifact - passed on `macos-15` ARM.
  - arm64 notarization, staple, Gatekeeper/package smoke - passed.
  - x64 notarization, staple, Rosetta/Gatekeeper/package smoke - passed.
  - checksum/publish path - skipped by the dry-run boundary.
- GitHub PR checks - passed, including PR Gate, both macOS module shards, module coverage, macOS build/E2E, Windows core/E2E, static checks, CI Integrity, CodeQL, and Codex review.
- Affected contracts: `vitest run scripts/macos-package-smoke.test.ts scripts/windows-release-workflows.test.ts scripts/electron-builder-config.test.ts` - passed, 22/22.
- Repository lint: `npm run lint` - passed with 15 pre-existing warnings and no errors.
- Diff hygiene: `git diff --check` - passed.
- Earlier local typecheck was blocked by the shared generated Prisma client being older than the checked-in schema (missing `permissionGrantSeed`, `grantedLocalRoot`, and `agentContext`). GitHub PR static checks passed.
- Earlier local full test run had Windows environment/schema failures; GitHub PR module tests, macOS tests, Windows core, and static checks passed on the branch.

## Review focus

Please focus on the x64 native dependency rebuild, Rosetta gating/startup allowance, the deliberate ICNS fallback, and keeping both macOS architectures off Intel/macOS 26 runners without weakening the dry-run publish guard.