### PR TITLE
fix(composer): keep mention filenames together

### DIFF
--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -223,7 +223,7 @@ export const ArtifactMentionPopup = ({
         <span className="flex min-w-0 flex-1 font-medium">
           {row.positions?.length ? (
             <>
-              <span className="min-w-0 flex-1 truncate">
+              <span className="min-w-0 shrink truncate">
                 <HighlightedText text={parts.head} positions={headPositions} />
               </span>
               <span className="shrink-0">


### PR DESCRIPTION
## Problem

When searching files with `@` in the composer, the filename head used `flex-1`, which could push the filename tail and extension to the far right and visually split one filename across the suggestion row.

## Proposed change

Use `shrink` for the searched filename head so the head, tail, and extension remain together in the suggestion row.

## Scope and non-goals

This is a renderer-only layout fix for composer file-mention suggestions. It does not change file search, selection, or mention data. No new regression test was added per request; the existing popup test module was used for validation.

## Acceptance criteria and validation

- `npm test -- --run src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx` — 17 tests passed.
- `npm run typecheck:web` — passed.
- `npm run lint` — passed with 0 errors; 13 warnings remain in unrelated existing files.
- `git diff --check` — passed after the final edit.

All checks above ran after the last material edit.

## Review focus

Please verify that searched filenames keep their visible head, tail, and extension together without changing selection behavior.