### PR TITLE
fix(e2e): keep test windows hidden

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -11,6 +11,7 @@ const APP_ROOT = resolve(process.cwd())
 const FAKE_AGENT_PATH = resolve(APP_ROOT, 'e2e', 'fixtures', 'fake-opencode.mjs')
 const FAKE_REMOTEIT_PATH = resolve(APP_ROOT, 'e2e', 'fixtures', 'fake-remoteit.cjs')
 const FAKE_PROVIDER_NAME = 'Electron E2E provider'
+type E2eWindowMode = 'hidden' | 'inactive' | 'normal'
 
 const electronLaunchTarget = (
   userDataRoot: string,
@@ -111,7 +112,8 @@ const launchEnvironment = (
   storageRoot: string,
   fakeAgentBinRoot?: string,
   inheritedEnvironment: NodeJS.ProcessEnv = process.env,
-  fakeRemoteItRoot?: string
+  fakeRemoteItRoot?: string,
+  windowMode: E2eWindowMode = 'hidden'
 ): Record<string, string> => {
   const environment: Record<string, string> = {}
 
@@ -121,6 +123,7 @@ const launchEnvironment = (
 
   environment.OPEN_SCIENCE_STORAGE_ROOT = storageRoot
   environment.OPEN_SCIENCE_E2E_HANDOFF_CAPTURE_ROOT = join(storageRoot, 'e2e-handoff-captures')
+  environment.OPEN_SCIENCE_E2E_WINDOW_MODE = windowMode
   if (environment.OPEN_SCIENCE_E2E_EXECUTABLE) {
     environment.OPEN_SCIENCE_E2E_STORAGE_ROOT = storageRoot
   }
@@ -145,7 +148,8 @@ const launchOpenScience = async (
   { storageRoot, userDataRoot, fakeAgentBinRoot }: LaunchRoots,
   fakeAgentEnabled: boolean,
   fakeRemoteItEnabled: boolean,
-  fakeRemoteItRoot: string
+  fakeRemoteItRoot: string,
+  windowMode: E2eWindowMode
 ): Promise<ElectronApplication> => {
   const application = await electron.launch({
     ...electronLaunchTarget(userDataRoot),
@@ -154,7 +158,8 @@ const launchOpenScience = async (
       storageRoot,
       fakeAgentEnabled ? fakeAgentBinRoot : undefined,
       process.env,
-      fakeRemoteItEnabled ? fakeRemoteItRoot : undefined
+      fakeRemoteItEnabled ? fakeRemoteItRoot : undefined,
+      windowMode
     )
   })
 
@@ -244,18 +249,23 @@ class ElectronAppHarness implements ElectronApp {
 
   private constructor(
     private readonly testRoot: string,
-    private readonly roots: LaunchRoots
+    private readonly roots: LaunchRoots,
+    private readonly windowMode: E2eWindowMode
   ) {}
 
-  static async create(): Promise<ElectronAppHarness> {
+  static async create(windowMode: E2eWindowMode): Promise<ElectronAppHarness> {
     const testRoot = await mkdtemp(join(tmpdir(), 'open-science-electron-e2e-'))
-    const harness = new ElectronAppHarness(testRoot, {
-      fakeAgentBinRoot: join(testRoot, 'fake-agent-bin'),
-      fakeRemoteItRoot: join(testRoot, 'fake-remoteit'),
-      fakeRemoteItState: join(testRoot, 'storage', 'fake-remoteit-state.json'),
-      storageRoot: join(testRoot, 'storage'),
-      userDataRoot: join(testRoot, 'electron-profile')
-    })
+    const harness = new ElectronAppHarness(
+      testRoot,
+      {
+        fakeAgentBinRoot: join(testRoot, 'fake-agent-bin'),
+        fakeRemoteItRoot: join(testRoot, 'fake-remoteit'),
+        fakeRemoteItState: join(testRoot, 'storage', 'fake-remoteit-state.json'),
+        storageRoot: join(testRoot, 'storage'),
+        userDataRoot: join(testRoot, 'electron-profile')
+      },
+      windowMode
+    )
     try {
       await mkdir(harness.roots.storageRoot, { recursive: true })
       await writeFile(harness.roots.fakeRemoteItState, JSON.stringify({ services: [] }), 'utf8')
@@ -385,7 +395,8 @@ class ElectronAppHarness implements ElectronApp {
             this.roots.storageRoot,
             this.fakeAgentEnabled ? this.roots.fakeAgentBinRoot : undefined,
             process.env,
-            this.fakeRemoteItEnabled ? this.roots.fakeRemoteItRoot : undefined
+            this.fakeRemoteItEnabled ? this.roots.fakeRemoteItRoot : undefined,
+            this.windowMode
           ),
           stdio: 'ignore'
         }
@@ -509,7 +520,8 @@ class ElectronAppHarness implements ElectronApp {
       this.roots,
       this.fakeAgentEnabled,
       this.fakeRemoteItEnabled,
-      this.roots.fakeRemoteItRoot
+      this.roots.fakeRemoteItRoot,
+      this.windowMode
     )
     this.currentPage = await openMainWindow(this.application, this.rendererFailures)
   }
@@ -598,11 +610,11 @@ class ElectronAppHarness implements ElectronApp {
   }
 }
 
-const test = base.extend<{ app: ElectronApp }>({
+const test = base.extend<{ app: ElectronApp; windowMode: E2eWindowMode }>({
+  windowMode: ['hidden', { option: true }],
   // Playwright fixture callbacks require an object pattern even when no base fixture is needed.
-  // eslint-disable-next-line no-empty-pattern
-  app: async ({}, install) => {
-    const app = await ElectronAppHarness.create()
+  app: async ({ windowMode }, install) => {
+    const app = await ElectronAppHarness.create(windowMode)
 
     try {
       await install(app)

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -11,7 +11,7 @@ const APP_ROOT = resolve(process.cwd())
 const FAKE_AGENT_PATH = resolve(APP_ROOT, 'e2e', 'fixtures', 'fake-opencode.mjs')
 const FAKE_REMOTEIT_PATH = resolve(APP_ROOT, 'e2e', 'fixtures', 'fake-remoteit.cjs')
 const FAKE_PROVIDER_NAME = 'Electron E2E provider'
-type E2eWindowMode = 'hidden' | 'inactive' | 'normal'
+type E2eWindowMode = 'hidden' | 'normal'
 
 const electronLaunchTarget = (
   userDataRoot: string,

--- a/e2e/launch-environment.spec.ts
+++ b/e2e/launch-environment.spec.ts
@@ -13,6 +13,7 @@ test('normalizes a Windows-style Path before injecting the fake Agent directory'
   expect(environment.ELECTRON_RENDERER_URL).toBeUndefined()
   expect(environment.OPEN_SCIENCE_E2E_STORAGE_ROOT).toBeUndefined()
   expect(environment.OPEN_SCIENCE_STORAGE_ROOT).toBe('storage-root')
+  expect(environment.OPEN_SCIENCE_E2E_WINDOW_MODE).toBe('hidden')
 })
 
 test('isolates packaged certification storage without changing the process home', () => {
@@ -22,6 +23,12 @@ test('isolates packaged certification storage without changing the process home'
 
   expect(environment.OPEN_SCIENCE_E2E_STORAGE_ROOT).toBe('storage-root')
   expect(environment.OPEN_SCIENCE_STORAGE_ROOT).toBe('storage-root')
+})
+
+test('allows native window-system tests to opt into normal presentation', () => {
+  const environment = launchEnvironment('storage-root', undefined, {}, undefined, 'normal')
+
+  expect(environment.OPEN_SCIENCE_E2E_WINDOW_MODE).toBe('normal')
 })
 
 test('enables the basic password store only for Linux E2E profiles', () => {

--- a/e2e/window-presentation.spec.ts
+++ b/e2e/window-presentation.spec.ts
@@ -1,0 +1,10 @@
+import { expect } from '@playwright/test'
+import { test } from './fixtures/electron-app'
+
+test('keeps the E2E window hidden across relaunch', async ({ app }) => {
+  await expect.poll(() => app.mainWindowState()).toEqual({ minimized: false, visible: false })
+
+  await app.restart()
+
+  await expect.poll(() => app.mainWindowState()).toEqual({ minimized: false, visible: false })
+})

--- a/e2e/windows-window-system.spec.ts
+++ b/e2e/windows-window-system.spec.ts
@@ -14,6 +14,7 @@ const openGeneralSettings = async (page: Page): Promise<Locator> => {
 
 test.describe('Windows window system', () => {
   test.skip(process.platform !== 'win32', 'Windows window behavior requires a Windows host.')
+  test.use({ windowMode: 'normal' })
 
   test('persists minimize-to-tray across titlebar close, relaunch, and Ctrl+W', async ({ app }) => {
     let page = await app.completeOnboarding()

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   CLOSE_ACTIVE_PANE_CHANNEL,
@@ -66,6 +66,8 @@ class FakeBrowserWindow {
   destroyMock = vi.fn()
   loadFileMock = vi.fn(() => Promise.resolve())
   sendMock = vi.fn()
+  showInactiveMock = vi.fn()
+  showMock = vi.fn()
   webContentsHandlers = new Map<string, WebContentsHandler>()
   handlers = new Map<string, Array<(event: CloseEvent) => void>>()
   hidden = false
@@ -109,6 +111,12 @@ class FakeBrowserWindow {
   }
 
   show(): void {
+    this.showMock()
+    this.hidden = false
+  }
+
+  showInactive(): void {
+    this.showInactiveMock()
     this.hidden = false
   }
 
@@ -189,6 +197,45 @@ const emitClose = (window: FakeBrowserWindow): CloseEvent => {
   if (!event.defaultPrevented) window.destroyed = true
   return event
 }
+
+describe('window presentation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('keeps E2E windows hidden when they become ready', () => {
+    vi.stubEnv('OPEN_SCIENCE_E2E_WINDOW_MODE', 'hidden')
+
+    createMainWindow()
+    const window = lastWindow!
+    for (const handler of window.handlers.get('ready-to-show') ?? []) handler({} as CloseEvent)
+
+    expect(window.showMock).not.toHaveBeenCalled()
+    expect(window.showInactiveMock).not.toHaveBeenCalled()
+  })
+
+  it('shows E2E windows without activating them in inactive mode', () => {
+    vi.stubEnv('OPEN_SCIENCE_E2E_WINDOW_MODE', 'inactive')
+
+    createMainWindow()
+    const window = lastWindow!
+    for (const handler of window.handlers.get('ready-to-show') ?? []) handler({} as CloseEvent)
+
+    expect(window.showMock).not.toHaveBeenCalled()
+    expect(window.showInactiveMock).toHaveBeenCalledOnce()
+  })
+
+  it('keeps normal application startup behavior when no E2E mode is set', () => {
+    vi.stubEnv('OPEN_SCIENCE_E2E_WINDOW_MODE', undefined)
+
+    createMainWindow()
+    const window = lastWindow!
+    for (const handler of window.handlers.get('ready-to-show') ?? []) handler({} as CloseEvent)
+
+    expect(window.showMock).toHaveBeenCalledOnce()
+    expect(window.showInactiveMock).not.toHaveBeenCalled()
+  })
+})
 
 describe('window navigation policy', () => {
   it('allows only explicit external URL protocols', async () => {

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -66,7 +66,6 @@ class FakeBrowserWindow {
   destroyMock = vi.fn()
   loadFileMock = vi.fn(() => Promise.resolve())
   sendMock = vi.fn()
-  showInactiveMock = vi.fn()
   showMock = vi.fn()
   webContentsHandlers = new Map<string, WebContentsHandler>()
   handlers = new Map<string, Array<(event: CloseEvent) => void>>()
@@ -112,11 +111,6 @@ class FakeBrowserWindow {
 
   show(): void {
     this.showMock()
-    this.hidden = false
-  }
-
-  showInactive(): void {
-    this.showInactiveMock()
     this.hidden = false
   }
 
@@ -211,18 +205,6 @@ describe('window presentation', () => {
     for (const handler of window.handlers.get('ready-to-show') ?? []) handler({} as CloseEvent)
 
     expect(window.showMock).not.toHaveBeenCalled()
-    expect(window.showInactiveMock).not.toHaveBeenCalled()
-  })
-
-  it('shows E2E windows without activating them in inactive mode', () => {
-    vi.stubEnv('OPEN_SCIENCE_E2E_WINDOW_MODE', 'inactive')
-
-    createMainWindow()
-    const window = lastWindow!
-    for (const handler of window.handlers.get('ready-to-show') ?? []) handler({} as CloseEvent)
-
-    expect(window.showMock).not.toHaveBeenCalled()
-    expect(window.showInactiveMock).toHaveBeenCalledOnce()
   })
 
   it('keeps normal application startup behavior when no E2E mode is set', () => {
@@ -233,7 +215,6 @@ describe('window presentation', () => {
     for (const handler of window.handlers.get('ready-to-show') ?? []) handler({} as CloseEvent)
 
     expect(window.showMock).toHaveBeenCalledOnce()
-    expect(window.showInactiveMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -38,6 +38,7 @@ const icon = process.platform === 'win32' ? iconWindows : iconPng
 // same way in dev (project root) and packaged (asar root) via app.getAppPath().
 const findOverlayEntry = join(app.getAppPath(), 'resources/find-overlay/index.html')
 const log = createLogger('window')
+const E2E_WINDOW_MODE_ENV = 'OPEN_SCIENCE_E2E_WINDOW_MODE'
 const RENDERER_RECOVERY_WINDOW_MS = 60_000
 const MAX_AUTOMATIC_RENDERER_RECOVERIES = 2
 const RECOVERABLE_RENDERER_EXIT_REASONS = new Set([
@@ -58,6 +59,7 @@ const loadRenderer = (window: BrowserWindow): void => {
 }
 
 const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindow => {
+  const e2eWindowMode = process.env[E2E_WINDOW_MODE_ENV]
   const window = new BrowserWindow({
     show: false,
     autoHideMenuBar: true,
@@ -73,6 +75,11 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
   })
 
   window.on('ready-to-show', () => {
+    if (e2eWindowMode === 'hidden') return
+    if (e2eWindowMode === 'inactive') {
+      window.showInactive()
+      return
+    }
     window.show()
   })
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -76,10 +76,6 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
 
   window.on('ready-to-show', () => {
     if (e2eWindowMode === 'hidden') return
-    if (e2eWindowMode === 'inactive') {
-      window.showInactive()
-      return
-    }
     window.show()
   })
 


### PR DESCRIPTION
## Problem

Electron E2E tests show the application window as soon as it is ready, which can interrupt foreground work and makes delegated/background E2E runs intrusive.

## Proposed change

- Default the Electron E2E harness to a hidden window presentation mode.
- Preserve the selected mode across relaunches and second-instance launches.
- Let Windows native window-system tests explicitly opt into normal presentation.
- Keep regular application startup unchanged when the E2E mode is absent.
- Add a real Electron E2E assertion that the native window remains hidden on initial launch and after relaunch.

## Scope and non-goals

This only changes Electron E2E launch behavior. It does not change normal application presentation. The unused `inactive` mode was removed; supported E2E modes are `hidden` and `normal`.

## Acceptance criteria and validation

All checks below ran against the final rebased HEAD (`2a2ade22`) after the last material edit:

- Hidden/normal main-process presentation behavior -> `npm test -- src/main/windows.test.ts` -> 49 passed.
- E2E launch environment contract -> `npx playwright test e2e/launch-environment.spec.ts` -> 5 passed.
- Native window hidden on initial launch and relaunch -> `npx playwright test e2e/window-presentation.spec.ts` -> 1 passed.
- Hidden windows remain operable through Playwright, including relaunch journeys -> `npx playwright test e2e/electron-foundation.spec.ts` -> 3 passed.
- Electron application still builds -> `npm run build:e2e` -> passed.
- Affected Node/Electron types -> `npm run typecheck:node` -> passed.
- Repository lint for source changes -> `npm run lint` -> passed.
- Independent review confirmed the final impact mapping and the rebase conflict resolution, including preservation of the existing delegated handoff capture environment.

The three Playwright specs were also run together: 9 passed.

## Platform coverage and uncovered risk

`e2e/windows-window-system.spec.ts` explicitly opts into `normal` presentation. It cannot run on the local macOS host, so the Windows-native minimize-to-tray behavior remains covered by the Windows CI lane and can be manually certified on Windows.

## Review focus

- The `OPEN_SCIENCE_E2E_WINDOW_MODE` boundary in the main process.
- Propagation of the presentation mode across harness launch, restart, and second-instance paths.
- The real Electron visibility assertion in `e2e/window-presentation.spec.ts`.
