### PR TITLE
fix(acp): serialize durable permission requests

### DIFF
--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -4,7 +4,8 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   AcpPermissionBroker,
   ConversationPermissionGrantStore,
-  permissionRequestFingerprint
+  permissionRequestFingerprint,
+  type DurablePermissionWaitCandidate
 } from './permission-broker'
 import { withTrustedNativeToolIdentity } from './permission-policy'
 
@@ -113,6 +114,18 @@ const createCodexCommandPermissionRequest = (
   ]
 })
 
+const createCodexExecutePermissionRequest = (command: string): RequestPermissionRequest => {
+  const request = createCodexCommandPermissionRequest()
+  return {
+    ...request,
+    toolCall: {
+      ...request.toolCall,
+      title: command,
+      rawInput: { command }
+    }
+  }
+}
+
 // Codex MCP requests send two allow_always variants: a session-scoped one and a persistent one.
 const createCodexMcpPermissionRequest = (sessionId = 'session-1'): RequestPermissionRequest => ({
   sessionId,
@@ -180,6 +193,104 @@ describe('ACP permission broker', () => {
     await expect(providerResponse).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'reject-once' }
     })
+  })
+
+  it('serializes durable permission requests for the same session', async () => {
+    const emitted: EmittedPermissionRequest[] = []
+    let activeRequestId: string | undefined
+    const persist = vi.fn(async (candidate: DurablePermissionWaitCandidate) => {
+      if (activeRequestId) {
+        throw new Error('Another durable permission request already owns this Session.')
+      }
+      activeRequestId = candidate.request.requestId
+      return true
+    })
+    const settleLive = vi.fn(async (candidate: DurablePermissionWaitCandidate) => {
+      expect(activeRequestId).toBe(candidate.request.requestId)
+      activeRequestId = undefined
+    })
+    const broker = new AcpPermissionBroker(
+      (request) => emitted.push(request),
+      undefined,
+      undefined,
+      undefined,
+      { persist, settleLive }
+    )
+    const policy = {
+      profile: 'ask' as const,
+      frameworkId: 'codex' as const,
+      cwd: '/workspace',
+      projectId: 'project-1',
+      promptMessageId: 'prompt-1'
+    }
+
+    const first = broker.requestPermission(
+      createCodexExecutePermissionRequest('python first.py'),
+      policy
+    )
+    const second = broker.requestPermission(
+      createCodexExecutePermissionRequest('python second.py'),
+      policy
+    )
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    expect(emitted.map(({ title }) => title)).toEqual(['python first.py'])
+    expect(broker.getPendingRequests().map(({ title }) => title)).toEqual(['python first.py'])
+
+    await broker.respond({
+      requestId: emitted[0].requestId,
+      optionId: emitted[0].options.find((option) => option.kind === 'allow_once')?.optionId
+    })
+    await expect(first).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow_once' }
+    })
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    expect(emitted.map(({ title }) => title)).toEqual(['python first.py', 'python second.py'])
+    expect(broker.getPendingRequests().map(({ title }) => title)).toEqual(['python second.py'])
+
+    await broker.respond({ requestId: emitted[1].requestId, cancelled: true })
+    await expect(second).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+    expect(persist).toHaveBeenCalledTimes(2)
+    expect(settleLive).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancels queued durable permission requests without persisting or publishing them', async () => {
+    const emitted: EmittedPermissionRequest[] = []
+    const persist = vi.fn(async () => true)
+    const settleLive = vi.fn(async () => undefined)
+    const broker = new AcpPermissionBroker(
+      (request) => emitted.push(request),
+      undefined,
+      undefined,
+      undefined,
+      { persist, settleLive }
+    )
+    const policy = {
+      profile: 'ask' as const,
+      frameworkId: 'codex' as const,
+      cwd: '/workspace',
+      projectId: 'project-1',
+      promptMessageId: 'prompt-1'
+    }
+    const first = broker.requestPermission(
+      createCodexExecutePermissionRequest('python first.py'),
+      policy
+    )
+    const second = broker.requestPermission(
+      createCodexExecutePermissionRequest('python second.py'),
+      policy
+    )
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    broker.cancelForSession('session-1')
+
+    await expect(first).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+    await expect(second).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+    expect(persist).toHaveBeenCalledOnce()
+    expect(settleLive).toHaveBeenCalledOnce()
+    expect(emitted.map(({ title }) => title)).toEqual(['python first.py'])
+    expect(broker.getPendingRequests()).toEqual([])
   })
 
   it('abandons a durable provider RPC during teardown without settling its restored card', async () => {

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -47,9 +47,11 @@ type PendingPermission = {
   durableCandidate?: DurablePermissionWaitCandidate
   durablePersisted?: boolean
   durableReady?: Promise<void>
+  durableStarted?: boolean
   durablePersistenceSettled?: boolean
   settled?: boolean
   resolve: (response: RequestPermissionResponse) => void
+  reject: (error: unknown) => void
 }
 
 type EmitPermissionRequest = (request: AcpPermissionRequest) => void
@@ -724,6 +726,8 @@ const projectRegistrySessionGrants = (
 class AcpPermissionBroker {
   private pendingRequests = new Map<string, PendingPermission>()
   private readonly restoredAllowOnceBySession = new Map<string, string>()
+  private readonly durableRequestQueues = new Map<string, string[]>()
+  private readonly activeDurableRequestBySession = new Map<string, string>()
   private cancellationGeneration = 0
   private readonly sessionCancellationGenerations = new Map<string, number>()
   private readonly livePermissionProfiles = new Map<
@@ -749,7 +753,14 @@ class AcpPermissionBroker {
 
   // Returns serializable pending requests for runtime snapshots.
   getPendingRequests(): AcpPermissionRequest[] {
-    return Array.from(this.pendingRequests.values(), ({ request }) => request)
+    return Array.from(this.pendingRequests.values())
+      .filter(
+        (pending) =>
+          !pending.durableCandidate ||
+          !this.permissionWaitHooks ||
+          pending.durablePersistenceSettled === true
+      )
+      .map(({ request }) => request)
   }
 
   hasPendingForSession(sessionId: string): boolean {
@@ -1080,7 +1091,7 @@ class AcpPermissionBroker {
   }
 
   private resolveOrEnqueuePermissionRequest(
-    pending: Omit<PendingPermission, 'resolve'> & { requestId: string }
+    pending: Omit<PendingPermission, 'resolve' | 'reject'> & { requestId: string }
   ): Promise<RequestPermissionResponse> {
     const liveAutomaticOptionId = pending.automaticRequest
       ? this.resolveCurrentAutomaticPermission(pending.automaticRequest, pending.policyContext)
@@ -1111,16 +1122,19 @@ class AcpPermissionBroker {
   }
 
   private enqueuePermissionRequest(
-    pending: Omit<PendingPermission, 'resolve'> & { requestId: string }
+    pending: Omit<PendingPermission, 'resolve' | 'reject'> & { requestId: string }
   ): Promise<RequestPermissionResponse> {
     let resolveResponse!: (response: RequestPermissionResponse) => void
-    const response = new Promise<RequestPermissionResponse>((resolve) => {
+    let rejectResponse!: (error: unknown) => void
+    const response = new Promise<RequestPermissionResponse>((resolve, reject) => {
       resolveResponse = resolve
+      rejectResponse = reject
     })
     const { requestId, ...entry } = pending
     const stored: PendingPermission = {
       ...entry,
-      resolve: resolveResponse
+      resolve: resolveResponse,
+      reject: rejectResponse
     }
     this.pendingRequests.set(requestId, stored)
 
@@ -1129,30 +1143,85 @@ class AcpPermissionBroker {
       return response
     }
 
-    stored.durableReady = this.permissionWaitHooks.persist(stored.durableCandidate).then(
-      (persisted) => {
+    const sessionId = stored.request.sessionId
+    const queue = this.durableRequestQueues.get(sessionId) ?? []
+    queue.push(requestId)
+    this.durableRequestQueues.set(sessionId, queue)
+    this.startNextDurablePermission(sessionId)
+    return response
+  }
+
+  private startNextDurablePermission(sessionId: string): void {
+    if (this.activeDurableRequestBySession.has(sessionId)) return
+
+    const hooks = this.permissionWaitHooks
+    if (!hooks) return
+    const queue = this.durableRequestQueues.get(sessionId)
+    while (queue?.length) {
+      const requestId = queue.shift()!
+      const stored = this.pendingRequests.get(requestId)
+      const candidate = stored?.durableCandidate
+      if (!stored || !candidate) continue
+
+      if (queue.length === 0) this.durableRequestQueues.delete(sessionId)
+      this.activeDurableRequestBySession.set(sessionId, requestId)
+      stored.durableStarted = true
+      stored.durablePersistenceSettled = false
+      stored.durableReady = hooks.persist(candidate).then((persisted) => {
         stored.durablePersisted = persisted
         stored.durablePersistenceSettled = true
         if (persisted) stored.request = { ...stored.request, durable: true }
-      },
-      (error: unknown) => {
-        stored.durablePersistenceSettled = true
-        throw error
-      }
-    )
-    return stored.durableReady.then(
-      () => {
+
         if (this.pendingRequests.get(requestId) === stored) {
           this.emitPermissionRequest(stored.request)
         }
-        return response
-      },
-      (error: unknown) => {
-        this.pendingRequests.delete(requestId)
-        this.settlePending(stored, { outcome: { outcome: 'cancelled' } }, 'cancelled')
-        throw error
-      }
-    )
+        if (!persisted) this.releaseDurablePermissionSlot(stored)
+      })
+      void stored.durableReady.catch((error: unknown) => {
+        stored.durablePersistenceSettled = true
+        if (this.pendingRequests.get(requestId) === stored) {
+          this.pendingRequests.delete(requestId)
+        }
+        this.rejectPending(stored, error, 'cancelled')
+        this.cancelQueuedDurablePermissions(sessionId)
+        this.activeDurableRequestBySession.delete(sessionId)
+      })
+      return
+    }
+
+    this.durableRequestQueues.delete(sessionId)
+  }
+
+  private releaseDurablePermissionSlot(pending: PendingPermission): void {
+    const sessionId = pending.request.sessionId
+    if (this.activeDurableRequestBySession.get(sessionId) !== pending.request.requestId) {
+      return
+    }
+
+    this.activeDurableRequestBySession.delete(sessionId)
+    this.startNextDurablePermission(sessionId)
+  }
+
+  private removeQueuedDurablePermission(pending: PendingPermission): void {
+    const sessionId = pending.request.sessionId
+    const queue = this.durableRequestQueues.get(sessionId)
+    if (!queue) return
+
+    const requestIndex = queue.indexOf(pending.request.requestId)
+    if (requestIndex >= 0) queue.splice(requestIndex, 1)
+    if (queue.length === 0) this.durableRequestQueues.delete(sessionId)
+  }
+
+  private cancelQueuedDurablePermissions(sessionId: string): void {
+    const requestIds = this.durableRequestQueues.get(sessionId) ?? []
+    this.durableRequestQueues.delete(sessionId)
+
+    for (const requestId of requestIds) {
+      const queued = this.pendingRequests.get(requestId)
+      if (!queued) continue
+      this.pendingRequests.delete(requestId)
+      this.settlePending(queued, { outcome: { outcome: 'cancelled' } }, 'cancelled')
+    }
   }
 
   // Resolves one pending request and reports whether it was found.
@@ -1261,11 +1330,19 @@ class AcpPermissionBroker {
     const hooks = this.permissionWaitHooks
     if (!candidate || !hooks) return undefined
     return (async () => {
+      if (!pending.durableStarted) {
+        this.removeQueuedDurablePermission(pending)
+        return
+      }
+
       try {
         await pending.durableReady
         if (!pending.durablePersisted) return
         await hooks.settleLive(candidate)
+        this.releaseDurablePermissionSlot(pending)
       } catch (error) {
+        this.cancelQueuedDurablePermissions(pending.request.sessionId)
+        this.activeDurableRequestBySession.delete(pending.request.sessionId)
         this.settlePending(pending, { outcome: { outcome: 'cancelled' } }, 'cancelled')
         throw new Error(
           'Permission decision could not be persisted; the tool call was cancelled.',
@@ -1285,6 +1362,21 @@ class AcpPermissionBroker {
     if (pending.settled) return
     pending.settled = true
     pending.resolve(response)
+    try {
+      this.onPermissionSettled?.(pending.request.requestId, state)
+    } catch {
+      // Notification projection failures must never change the permission decision.
+    }
+  }
+
+  private rejectPending(
+    pending: PendingPermission,
+    error: unknown,
+    state: AcpPermissionSettlementState
+  ): void {
+    if (pending.settled) return
+    pending.settled = true
+    pending.reject(error)
     try {
       this.onPermissionSettled?.(pending.request.requestId, state)
     } catch {
@@ -1364,6 +1456,8 @@ class AcpPermissionBroker {
     this.cancellationGeneration += 1
     this.livePermissionProfiles.clear()
     this.restoredAllowOnceBySession.clear()
+    this.durableRequestQueues.clear()
+    this.activeDurableRequestBySession.clear()
     const pending = Array.from(this.pendingRequests.values())
     this.pendingRequests.clear()
     for (const request of pending) {


### PR DESCRIPTION
## Problem

Two Codex `execute` permission RPCs can arrive within milliseconds for the same Session. Both previously attempted to persist durable approval authority immediately. The second request then violated the single-owner invariant and threw `Another durable permission request already owns this Session.`, cancelling the provider turn while the first persisted approval remained visible but no longer had a live provider RPC.

Closes #1123.

## Proposed change

- Serialize durable permission requests per Session with a FIFO queue in the shared `AcpPermissionBroker`.
- Persist and publish only the active request; queued requests stay out of runtime snapshots until promoted.
- Promote the next request only after the active durable authority is settled.
- Cancel queued requests without persisting or publishing them when the Session permission flow is cancelled.
- Clear in-memory queue ownership during connection teardown while preserving the existing restored-card behavior for an already persisted active request.

The broker is shared by the `claude-code`, `opencode`, `codex-response`, and `codex-bridge` execution paths.

## Scope and non-goals

This changes only ACP permission scheduling and its regression coverage. It does not change permission policy, remembered-grant semantics, renderer components, persisted Session schema, or provider protocol adapters.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- concurrent Codex execute approvals are serialized and published one at a time -> `npm test -- src/main/acp/permission-broker.test.ts` -> 101 passed
- broker/context/registry contracts remain compatible -> `npm test -- src/main/acp/permission-broker.test.ts src/main/acp/permission-broker-registry.test.ts src/main/acp/permission-context.test.ts` -> 197 passed
- durable owner and runtime composition hooks remain compatible -> `npm test -- src/main/acp/permission-wait-owner.test.ts src/main/acp/runtime-session-composition.test.ts` -> 7 passed
- runtime durable permission consumer -> `npm test -- src/main/acp/runtime.test.ts -t "durable permission"` -> 1 passed
- runtime permission cancellation consumers -> `npm test -- src/main/acp/runtime.test.ts -t "permission.*cancel|cancel.*permission"` -> 8 passed
- main-process types -> `npm run typecheck:node` -> passed
- lint -> `npm run lint` -> passed with 0 errors and 13 pre-existing warnings in unrelated files
- whitespace -> `git diff --check` -> passed

The complete `npm test` portable suite was also attempted. It did not pass locally because unrelated Windows symlink tests returned `EPERM`, parallel tests hit timeouts/file locks, and Prisma storage tests used a test database missing `codecVersion`. No failure was reported in the changed permission broker test; the focused impact set above passed.

## Review focus

Please review the FIFO ownership transition in `AcpPermissionBroker`, especially cancellation before a queued request is activated and connection teardown while an active durable request is being persisted.
