### PR TITLE
perf(message-stream): preserve markdown blocks on completion

### DIFF
--- a/src/renderer/src/components/streamdown/AgentMarkdown.streaming.render.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.streaming.render.test.tsx
@@ -3,7 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { AgentMarkdown } from './AgentMarkdown'
+import { AgentMarkdown, PresentedAgentMarkdown } from './AgentMarkdown'
 
 describe('AgentMarkdown streaming presentation', () => {
   let container: HTMLDivElement
@@ -44,5 +44,40 @@ describe('AgentMarkdown streaming presentation', () => {
     const visible = container.querySelector('.agent-markdown')?.textContent ?? ''
     expect(visible.length).toBeGreaterThan(0)
     expect(visible.length).toBeLessThan(70)
+  })
+
+  it('keeps completed Markdown blocks mounted when streaming settles', async () => {
+    vi.useRealTimers()
+
+    const content = Array.from(
+      { length: 40 },
+      (_, index) => `Paragraph ${index + 1} with **formatted content**.`
+    ).join('\n\n')
+
+    await act(async () => {
+      root.render(<PresentedAgentMarkdown content={content} isAnimating />)
+    })
+
+    const firstParagraph = container.querySelector('p')
+    expect(firstParagraph).not.toBeNull()
+
+    const createElement = document.createElement.bind(document) as typeof document.createElement
+    let createdParagraphs = 0
+    vi.spyOn(document, 'createElement').mockImplementation(((
+      tagName: string,
+      options?: ElementCreationOptions
+    ) => {
+      if (tagName === 'p') {
+        createdParagraphs += 1
+      }
+      return createElement(tagName, options)
+    }) as typeof document.createElement)
+
+    await act(async () => {
+      root.render(<PresentedAgentMarkdown content={content} />)
+    })
+
+    expect(createdParagraphs).toBe(0)
+    expect(container.querySelector('p')).toBe(firstParagraph)
   })
 })

--- a/src/renderer/src/components/streamdown/AgentMarkdown.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.tsx
@@ -29,6 +29,10 @@ type AgentMarkdownProps = {
   sessionLinks?: boolean
 }
 
+type RichAgentMarkdownProps = AgentMarkdownProps & {
+  incrementalBlocks?: boolean
+}
+
 type SessionMessageLinkProps = ComponentProps<'a'> & {
   node?: unknown
   'data-incomplete'?: boolean
@@ -236,8 +240,9 @@ const RichAgentMarkdown = memo(
     content,
     isAnimating = false,
     allowMedia = true,
-    sessionLinks = false
-  }: AgentMarkdownProps): React.JSX.Element => {
+    sessionLinks = false,
+    incrementalBlocks = false
+  }: RichAgentMarkdownProps): React.JSX.Element => {
     const renderedContent = useMemo(() => normalizeAgentMarkdown(content), [content])
 
     return (
@@ -254,7 +259,7 @@ const RichAgentMarkdown = memo(
           linkSafety={agentLinkSafety}
           components={sessionLinks ? sessionLinkComponents : undefined}
           dir="auto"
-          mode={isAnimating ? 'streaming' : 'static'}
+          mode={isAnimating || incrementalBlocks ? 'streaming' : 'static'}
           isAnimating={isAnimating}
           animated={false}
           parseIncompleteMarkdown={isAnimating}
@@ -280,14 +285,16 @@ const PresentedAgentMarkdown = memo(
     content,
     isAnimating = false,
     allowMedia = true,
-    sessionLinks = false
-  }: AgentMarkdownProps): React.JSX.Element => (
+    sessionLinks = false,
+    incrementalBlocks = true
+  }: RichAgentMarkdownProps): React.JSX.Element => (
     <AgentMarkdownErrorBoundary content={content}>
       <RichAgentMarkdown
         content={content}
         isAnimating={isAnimating}
         allowMedia={allowMedia}
         sessionLinks={sessionLinks}
+        incrementalBlocks={incrementalBlocks}
       />
     </AgentMarkdownErrorBoundary>
   )
@@ -311,6 +318,7 @@ const AgentMarkdown = memo(
         isAnimating={presentation.isPresenting}
         allowMedia={allowMedia}
         sessionLinks={sessionLinks}
+        incrementalBlocks={false}
       />
     )
   }


### PR DESCRIPTION
## Problem

When a streamed assistant response finished, the message renderer switched Streamdown from `streaming` to `static` mode. That replaced the block tree and reparsed/remounted the complete answer on the renderer thread, producing an end-of-stream UI stall. Controls such as the model picker could appear unresponsive during that work.

## Proposed change

- Keep message surfaces on Streamdown's incremental block renderer after live presentation settles.
- Preserve static rendering for generic, non-message Markdown surfaces.
- Add a regression test that verifies completed paragraph nodes are not recreated when streaming settles.

## Scope and non-goals

This change is limited to Markdown rendering on workspace and side-chat message surfaces. It does not change ACP provider handling, stream transport, message persistence, graph synchronization, or model-picker behavior.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- completed message blocks stay mounted at stream finalization -> `npm test -- src/renderer/src/components/streamdown/AgentMarkdown.test.tsx src/renderer/src/components/streamdown/AgentMarkdown.streaming.render.test.tsx` -> 13/13 passed
- renderer and Node type safety plus production bundles -> `npm run build` -> passed
- source lint -> `npm run lint` -> passed with 0 errors and 13 pre-existing warnings in untouched files
- full fallback selected because the changed component has no module-owner mapping -> `npm test` -> the new regression passed, but the suite remained blocked by unrelated local Windows/database failures in untouched `src/main` tests (including stale Prisma schema columns and symlink/temp-directory permission errors)

PR Gate remains authoritative for the portable and platform suites. No platform-specific production code, persistence, migration, or interface contract changed.

Uncovered risk: the final evidence mapping has not yet received the independent review required to mark the change verified.

## Review focus

Please confirm that keeping incremental block mode on message surfaces does not change completed Markdown semantics, and that generic static Markdown consumers remain on static mode.