### PR TITLE
fix(artifacts): stabilize runtime message ownership

### DIFF
--- a/src/renderer/src/stores/session-store-run-output-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-output-helpers.ts
@@ -16,8 +16,25 @@ import {
   synchronizeSessionGraph
 } from './session-store-message-graph-helpers'
 import type { AppendMessageResult } from './session-store-message-graph-helpers'
-import { createMessageId, createSortIndex } from './session-store-message-graph-owner'
+import { createSortIndex } from './session-store-message-graph-owner'
 import type { ChatMessage, ChatSession } from './session-store-persistence-owner'
+
+// A Session can be projected by more than one renderer. Derive Agent identity from runtime-owned
+// stream identity so both projections choose the same Artifact owner instead of local sequence ids.
+const createRuntimeAgentMessageId = (
+  sessionId: string,
+  streamId: string,
+  responseToMessageId?: string
+): string => {
+  let hash = 0xcbf29ce484222325n
+  for (const byte of new TextEncoder().encode(
+    `${sessionId}\0${responseToMessageId ?? ''}\0${streamId}`
+  )) {
+    hash ^= BigInt(byte)
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n)
+  }
+  return `message-stream-${hash.toString(16).padStart(16, '0')}`
+}
 
 export type AppendAgentMessageChunkInput = {
   sessionId: string
@@ -179,7 +196,9 @@ export const projectAgentMessageChunk = (
     const text = `${current}${content}`
     return session.agentFrameworkId === 'claude-code' ? normalizeClaudeCodeRefusalText(text) : text
   }
-  const messageId = existingMessage?.id ?? createMessageId()
+  const messageId =
+    existingMessage?.id ??
+    createRuntimeAgentMessageId(input.sessionId, input.streamId, responseToMessageId)
   const result = { sessionId: input.sessionId, messageId }
   const now = Date.now()
 
@@ -320,7 +339,9 @@ export const projectRunArtifacts = (
     return { session }
   }
 
-  const messageId = existingMessage?.id ?? createMessageId()
+  const messageId =
+    existingMessage?.id ??
+    createRuntimeAgentMessageId(input.sessionId, input.runId, responseToMessageId)
   const result = { sessionId: input.sessionId, messageId }
   if (existingMessage) {
     const messages = session.messages.map((message) =>

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -200,6 +200,34 @@ describe('session store', () => {
     })
   })
 
+  it('keeps artifact finalization idempotent across independent renderer projections', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Stream a response'
+    })
+    const initialSession = toPersistedSession(useSessionStore.getState().sessions[0])
+    const input = {
+      sessionId: 'transport-session-1',
+      streamId: 'assistant-message-1',
+      eventId: 'event-1',
+      content: 'Hello'
+    }
+
+    const firstProjection = useSessionStore.getState().appendAgentMessageChunk(input)
+    useSessionStore.getState().hydrateSessions([initialSession])
+    const secondProjection = useSessionStore.getState().appendAgentMessageChunk(input)
+    let finalizedMessageId: string | undefined
+    const finalize = (messageId: string | undefined): void => {
+      if (finalizedMessageId && finalizedMessageId !== messageId) {
+        throw new Error(`Artifact run claim already finalized for message: ${finalizedMessageId}`)
+      }
+      finalizedMessageId = messageId
+    }
+
+    finalize(firstProjection?.messageId)
+    expect(() => finalize(secondProjection?.messageId)).not.toThrow()
+  })
+
   it('keeps waiting through whitespace-only Agent chunks', () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',
@@ -3514,6 +3542,28 @@ describe('session store', () => {
       parentMessageId: userMessage?.messageId,
       artifactIds: ['artifact-session-1:run-1:result.txt']
     })
+  })
+
+  it('keeps file-only artifact ownership stable across independent renderer projections', () => {
+    const userMessage = useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Create an image'
+    })
+    useSessionStore.getState().finishRun('transport-session-1')
+    const initialSession = toPersistedSession(useSessionStore.getState().sessions[0])
+    const input = {
+      sessionId: 'transport-session-1',
+      runId: 'run-1',
+      promptMessageId: userMessage?.messageId,
+      eventId: 'artifact-event-1',
+      artifacts: [createArtifactFile({ name: 'image.png', mimeType: 'image/png' })]
+    }
+
+    const firstProjection = useSessionStore.getState().attachRunArtifacts(input)
+    useSessionStore.getState().hydrateSessions([initialSession])
+    const secondProjection = useSessionStore.getState().attachRunArtifacts(input)
+
+    expect(secondProjection?.messageId).toBe(firstProjection?.messageId)
   })
 
   it('replaces pending artifact metadata with finalized message files', () => {


### PR DESCRIPTION
## Problem

Independent renderer projections can assign different local message IDs to the same runtime stream. When both process one generated-file claim, the first finalization succeeds and the second fails with `Artifact run claim already finalized for message`. This can surface after renderer reloads or when multiple application projections consume the same event stream.

## Proposed change

- derive Agent message IDs deterministically from the Session, prompt message, and runtime stream identity
- use the artifact run ID for artifact-only Agent responses
- cover independent text and file-only renderer projections with regression tests

## Scope and non-goals

The main-process ownership guard remains strict. This PR does not treat conflicting ownership as success or change the artifact finalization protocol.

## Acceptance criteria and validation

All commands below ran after the final material edit.

- independent text projections use one Artifact owner -> `npm test -- --run src/renderer/src/stores/session-store.test.ts src/renderer/src/lib/acp/workspace-events.test.ts` -> 228 tests passed
- file-only projections use one Artifact owner -> same command -> passed
- Renderer types remain valid -> `npm run typecheck:web` -> passed
- linted source remains valid -> `npm run lint` -> 0 errors; 13 pre-existing warnings in unrelated files
- portable suite -> `npm test` -> 14,387 passed; 4 unrelated concurrency/time-limit flakes
- failed portable files rerun in isolation -> 68 tests passed

No platform-specific behavior or public Interface changed, so no E2E or platform lane was required. CI remains authoritative for the complete portable suite.

## Review focus

Please verify that the stable identity inputs preserve distinct messages across Sessions, prompts, and runtime streams while converging independent renderer projections.