### PR TITLE
fix(skills): accept any SKILL.md casing and list bundled files in detail

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3730,6 +3730,12 @@ describe('SettingsService: skills', () => {
 
     let detail = await service.getSkillDetail('personal-ref-skill-id')
     expect(detail.references.map((ref) => ref.path)).toEqual(['drop.py', 'keep.py'])
+    // `files` lists every shipped file by its full path (including the directory); `references`
+    // stays the editor's flat attachment basenames. Both must hold after the change.
+    expect(detail.files.map((file) => file.path)).toEqual([
+      'references/drop.py',
+      'references/keep.py'
+    ])
 
     // Editing keeps one file, drops one, and adds one.
     await service.updateSkill({
@@ -3741,6 +3747,10 @@ describe('SettingsService: skills', () => {
 
     detail = await service.getSkillDetail('personal-ref-skill-id')
     expect(detail.references.map((ref) => ref.path)).toEqual(['keep.py', 'new.py'])
+    expect(detail.files.map((file) => file.path)).toEqual([
+      'references/keep.py',
+      'references/new.py'
+    ])
   })
 
   it('force-loads a disabled picked skill for the turn without mutating stored settings', async () => {

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -43,7 +43,7 @@ import { decodeBoundedBase64, SKILL_IMPORT_LIMITS } from '../skills/import-limit
 import { ClaudeCodeSkillMaterializer, OS_SKILL_PREFIX } from '../skills/materializer'
 import { netFetch } from '../skills/net-fetch'
 import { SkillRegistry, type BundledSkill } from '../skills/registry'
-import { readSkillFile } from '../skills/skill-files'
+import { listSkillFiles, readSkillFile } from '../skills/skill-files'
 import { buildSkillExportArchive, type SkillExportArchive } from '../skills/export'
 import { SAFE_SLUG, UserSkillRepository } from '../skills/user-skill-repository'
 import {
@@ -322,7 +322,8 @@ class SkillCatalogModule {
       metadata: Object.fromEntries(
         Object.entries(fields).filter(([key]) => key !== 'name' && key !== 'description')
       ),
-      references: await this.listReferences(skill.sourceDir)
+      references: await this.listReferences(skill.sourceDir),
+      files: await listSkillFiles(skill.sourceDir)
     }
   }
 

--- a/src/main/skills/agent-home-skill-owner.ts
+++ b/src/main/skills/agent-home-skill-owner.ts
@@ -5,6 +5,7 @@ import { basename, join, resolve } from 'node:path'
 import type { AgentHomeSkillRef, AgentHomeSkillSource } from '../../shared/settings'
 import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 import { parseSkillDocument } from './frontmatter'
+import { isSkillDocumentName } from './skill-bundle-paths'
 import {
   SOURCE_MANIFEST,
   type SkillPackageTransactionOwner,
@@ -302,7 +303,9 @@ class AgentHomeSkillOwner {
 
   async validatePublishedSkillPackage(staging: string): Promise<void> {
     const entries = await this.inspectAgentHomeSkill(staging)
-    if (!entries.some((entry) => entry.kind === 'file' && entry.relativePath === 'SKILL.md')) {
+    if (
+      !entries.some((entry) => entry.kind === 'file' && isSkillDocumentName(entry.relativePath))
+    ) {
       throw new Error('A published Skill must contain SKILL.md at its root.')
     }
   }
@@ -444,7 +447,7 @@ class AgentHomeSkillOwner {
     const files = entries.filter(
       (entry): entry is Extract<AgentHomeTreeEntry, { kind: 'file' }> => entry.kind === 'file'
     )
-    const skillMd = files.find((file) => file.relativePath === 'SKILL.md')
+    const skillMd = files.find((file) => isSkillDocumentName(file.relativePath))
     if (!skillMd) throw new Error('Agent-home Skill must contain a SKILL.md.')
     const previewTooLarge = (): never => {
       throw new Error(

--- a/src/main/skills/export.ts
+++ b/src/main/skills/export.ts
@@ -6,9 +6,10 @@ import { dump as dumpYaml, load as loadYaml, FAILSAFE_SCHEMA } from 'js-yaml'
 
 import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 import type { BundledSkill } from './registry'
+import { isSkillDocumentName } from './skill-bundle-paths'
+import { INTERNAL_SKILL_FILES } from './skill-files'
 import { isUnsafeSkillArchivePath } from './zip-extract'
 
-const INTERNAL_SKILL_FILES = new Set(['.source.json', '.specialist-package.json'])
 const WINDOWS_RESERVED_BASENAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])$/i
 
 const withoutDisplayName = (raw: string): string => {
@@ -103,7 +104,7 @@ const collectFiles = async (
         throw new Error('Skill tree exceeds the total export size limit.')
       }
       let bytes = new Uint8Array(await readFile(absolutePath))
-      if (relativePath === 'SKILL.md') {
+      if (isSkillDocumentName(relativePath)) {
         bytes = new TextEncoder().encode(
           withoutDisplayName(new TextDecoder('utf-8', { fatal: true }).decode(bytes))
         )

--- a/src/main/skills/skill-bundle-import-owner.ts
+++ b/src/main/skills/skill-bundle-import-owner.ts
@@ -19,7 +19,7 @@ import {
   type ScannedSkill
 } from './github-import'
 import { parseSkillDocument } from './frontmatter'
-import { selectSkillManifestRoots } from './skill-bundle-paths'
+import { isSkillDocumentName, selectSkillManifestRoots } from './skill-bundle-paths'
 import { extractZip, extractZipLenient } from './zip-extract'
 import {
   SOURCE_MANIFEST,
@@ -232,7 +232,7 @@ export class SkillBundleImportOwner {
       let previewContentBytes = 0
       for (const root of roots) {
         try {
-          const skillMd = root.files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
+          const skillMd = root.files.find((file) => isSkillDocumentName(file.relativePath))!
           const previewContentUnavailable =
             previewContentBytes + skillMd.content.length >
             SKILL_IMPORT_LIMITS.maxPreviewContentBytes
@@ -361,7 +361,7 @@ export class SkillBundleImportOwner {
 
   private async writeRootLocked(root: SkillRoot, replaceId?: string): Promise<ImportOutcome> {
     const files = root.files
-    const skillMd = files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
+    const skillMd = files.find((file) => isSkillDocumentName(file.relativePath))!
     const signature = signatureOf(files)
 
     if (replaceId !== undefined) {

--- a/src/main/skills/skill-bundle-paths.ts
+++ b/src/main/skills/skill-bundle-paths.ts
@@ -1,9 +1,20 @@
+// The canonical skill document filename. Skills commonly arrive as `skill.md` from case-insensitive
+// filesystems (macOS/APFS), so every "is this the skill document?" check must be case-insensitive.
+// Centralizing it here keeps validation, import, listing, and export from drifting apart.
+const SKILL_DOCUMENT_BASENAME = 'skill.md'
+
+// True when `name` is the skill document filename (SKILL.md) under any casing. For a relative path
+// that is just the basename (a file at the skill root), this also serves as "is this the root skill
+// document"; a nested path like `references/skill.md` is not equal to the basename and won't match.
+export const isSkillDocumentName = (name: string): boolean =>
+  name.toLowerCase() === SKILL_DOCUMENT_BASENAME
+
 // A directly importable Skill root may be at the archive root or under at most two wrapper
 // directories. Keep this predicate shared by full discovery and prompt-time ZIP sniffing so the
 // prompt never advertises a package whose preview will later contain no candidates.
 const skillManifestRootPath = (path: string): string | undefined => {
   const segments = path.split('/')
-  if (segments.length > 3 || segments[segments.length - 1].toLowerCase() !== 'skill.md') {
+  if (segments.length > 3 || !isSkillDocumentName(segments[segments.length - 1])) {
     return undefined
   }
   return segments.slice(0, -1).join('/')

--- a/src/main/skills/skill-files.test.ts
+++ b/src/main/skills/skill-files.test.ts
@@ -1,0 +1,139 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
+import { listSkillFiles } from './skill-files'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const skillRoot = async (prefix: string): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), prefix))
+  roots.push(root)
+  return root
+}
+
+describe('listSkillFiles', () => {
+  it('recursively lists files across skill directories with posix paths and sizes', async () => {
+    const root = await skillRoot('skill-files-tree-')
+    await writeFile(join(root, 'SKILL.md'), '# Skill')
+    await mkdir(join(root, 'references'), { recursive: true })
+    await mkdir(join(root, 'scripts', 'helpers'), { recursive: true })
+    await mkdir(join(root, 'assets'), { recursive: true })
+    await mkdir(join(root, 'templates'), { recursive: true })
+    await writeFile(join(root, 'references', 'dataset.csv'), 'csv-bytes')
+    await writeFile(join(root, 'scripts', 'run.py'), 'python')
+    await writeFile(join(root, 'scripts', 'helpers', 'utils.py'), 'util')
+    await writeFile(join(root, 'assets', 'model.bin'), 'bin')
+    await writeFile(join(root, 'templates', 'report.md'), 'report')
+    await writeFile(join(root, 'requirements.txt'), 'reqs')
+
+    const files = await listSkillFiles(root)
+    expect(files.map((file) => file.path)).toEqual([
+      'assets/model.bin',
+      'references/dataset.csv',
+      'requirements.txt',
+      'scripts/helpers/utils.py',
+      'scripts/run.py',
+      'templates/report.md'
+    ])
+    expect(files.find((file) => file.path === 'scripts/run.py')?.size).toBe('python'.length)
+  })
+
+  it('omits SKILL.md (already rendered as the body)', async () => {
+    const root = await skillRoot('skill-files-skipmd-')
+    await writeFile(join(root, 'SKILL.md'), '# Skill')
+    await mkdir(join(root, 'references'), { recursive: true })
+    await writeFile(join(root, 'references', 'note.md'), 'note')
+
+    const files = await listSkillFiles(root)
+    expect(files.map((file) => file.path)).toEqual(['references/note.md'])
+  })
+
+  it.each(['skill.md', 'Skill.md', 'SKILL.MD'])(
+    'omits the skill document regardless of filename case (%s)',
+    async (filename) => {
+      const root = await skillRoot('skill-files-skipmd-case-')
+      await writeFile(join(root, filename), '# Skill')
+      await mkdir(join(root, 'references'), { recursive: true })
+      await writeFile(join(root, 'references', 'note.md'), 'note')
+
+      const files = await listSkillFiles(root)
+      expect(files.map((file) => file.path)).toEqual(['references/note.md'])
+    }
+  )
+
+  it('drops app metadata and dotfiles at the root but keeps a same-named file in a subdirectory', async () => {
+    const root = await skillRoot('skill-files-metadata-')
+    await writeFile(join(root, 'SKILL.md'), '# Skill')
+    await writeFile(join(root, '.source.json'), '{}')
+    await writeFile(join(root, '.specialist-package.json'), '{}')
+    await writeFile(join(root, '.hidden'), 'secret')
+    await mkdir(join(root, 'scripts'), { recursive: true })
+    // A nested file whose basename collides with a root metadata file is kept: the relative path
+    // does not start with '.', and the metadata exclusion only applies at the skill root.
+    await writeFile(join(root, 'scripts', '.source.json'), '{}')
+    await writeFile(join(root, 'scripts', 'run.py'), 'python')
+
+    const files = await listSkillFiles(root)
+    expect(files.map((file) => file.path)).toEqual(['scripts/.source.json', 'scripts/run.py'])
+  })
+
+  it('skips symbolic links instead of throwing', async () => {
+    const root = await skillRoot('skill-files-symlink-')
+    await writeFile(join(root, 'SKILL.md'), '# Skill')
+    await mkdir(join(root, 'scripts'), { recursive: true })
+    await writeFile(join(root, 'scripts', 'real.py'), 'real')
+    await symlink(join(root, 'scripts', 'real.py'), join(root, 'scripts', 'link.py'))
+
+    const files = await listSkillFiles(root)
+    expect(files.map((file) => file.path)).toEqual(['scripts/real.py'])
+  })
+
+  it('skips entries deeper than the depth limit instead of throwing', async () => {
+    const root = await skillRoot('skill-files-depth-')
+    await writeFile(join(root, 'SKILL.md'), '# Skill')
+    let current = root
+    // Build a chain of 9 nested directories; the 9th sits beyond the depth limit.
+    for (let index = 1; index <= 9; index += 1) {
+      current = join(current, `n${index}`)
+      await mkdir(current)
+      await writeFile(join(current, 'file.txt'), 'x')
+    }
+
+    const files = await listSkillFiles(root)
+    const paths = files.map((file) => file.path)
+    expect(paths).toContain('n1/n2/n3/n4/n5/n6/n7/n8/file.txt')
+    expect(paths).not.toContain('n1/n2/n3/n4/n5/n6/n7/n8/n9/file.txt')
+  })
+
+  it('caps the listing at the file-count limit without throwing', async () => {
+    const root = await skillRoot('skill-files-maxfiles-')
+    await writeFile(join(root, 'SKILL.md'), '# Skill')
+    await mkdir(join(root, 'data'), { recursive: true })
+    // One more than the cap; the excess file is skipped, not raised.
+    for (let index = 0; index <= SKILL_IMPORT_LIMITS.maxFiles; index += 1) {
+      await writeFile(join(root, 'data', `f${index}.txt`), 'x')
+    }
+
+    const files = await listSkillFiles(root)
+    expect(files).toHaveLength(SKILL_IMPORT_LIMITS.maxFiles)
+  })
+
+  it('returns an empty list for a directory with only SKILL.md', async () => {
+    const root = await skillRoot('skill-files-empty-')
+    await writeFile(join(root, 'SKILL.md'), '# Skill')
+
+    expect(await listSkillFiles(root)).toEqual([])
+  })
+
+  it('returns an empty list when the directory does not exist', async () => {
+    expect(await listSkillFiles(join(tmpdir(), 'skill-files-missing-'))).toEqual([])
+  })
+})

--- a/src/main/skills/skill-files.ts
+++ b/src/main/skills/skill-files.ts
@@ -1,16 +1,82 @@
-import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { lstat, readdir, readFile } from 'node:fs/promises'
+import { join, posix } from 'node:path'
 
+import type { SkillFileEntry } from '../../shared/settings'
+import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 import { parseFrontmatter } from './frontmatter'
+import { isSkillDocumentName } from './skill-bundle-paths'
+import { isUnsafeSkillArchivePath } from './zip-extract'
+
+// Skill-root files that exist on disk for app bookkeeping but are not part of the portable skill
+// content. Excluded at the skill root only; a same-named file inside a subdirectory is legitimate
+// content and is kept. Shared with the export walker so both surfaces agree on what is internal.
+export const INTERNAL_SKILL_FILES = new Set(['.source.json', '.specialist-package.json'])
+
+const SKILL_DOCUMENT = 'SKILL.md'
 
 // Reads a skill directory's SKILL.md into its frontmatter fields + body. Shared by the bundled registry
 // and the writable user-skill repository so every source parses skills the same way.
 const readSkillFile = async (
   dir: string
 ): Promise<{ fields: Record<string, string>; body: string }> => {
-  const raw = await readFile(join(dir, 'SKILL.md'), 'utf8')
-
+  const raw = await readFile(join(dir, SKILL_DOCUMENT), 'utf8')
   return parseFrontmatter(raw)
+}
+
+// Lists every file shipped inside a skill directory (references/, scripts/, assets/, templates/,
+// and anything else) as read-only detail-view entries. The interface is one directory in and a flat
+// list of posix relative paths + sizes out; the recursion, exclusion rules, link safety, and
+// depth/count caps all live inside. A read-only listing never fails the page on a bad entry: unsafe
+// paths, symbolic/hard links, unsupported node types, and depth/count overruns are skipped, and a
+// missing or empty directory yields [].
+export const listSkillFiles = async (sourceDir: string): Promise<SkillFileEntry[]> => {
+  const entries: SkillFileEntry[] = []
+  let fileCount = 0
+
+  const visit = async (
+    directory: string,
+    relativeDirectory: string,
+    depth: number
+  ): Promise<void> => {
+    if (depth > SKILL_IMPORT_LIMITS.maxDepth) return
+    let dirEntries
+    try {
+      dirEntries = await readdir(directory, { withFileTypes: true })
+    } catch {
+      return
+    }
+    dirEntries.sort((left, right) => left.name.localeCompare(right.name))
+
+    for (const entry of dirEntries) {
+      if (!relativeDirectory && INTERNAL_SKILL_FILES.has(entry.name)) continue
+      const relativePath = relativeDirectory
+        ? posix.join(relativeDirectory, entry.name)
+        : entry.name
+      // The skill document is rendered as the body; don't also list it as an attached file.
+      if (isSkillDocumentName(relativePath)) continue
+      if (isUnsafeSkillArchivePath(relativePath)) continue
+
+      let metadata
+      try {
+        metadata = await lstat(join(directory, entry.name))
+      } catch {
+        continue
+      }
+      if (metadata.isSymbolicLink()) continue
+      if (metadata.isDirectory()) {
+        await visit(join(directory, entry.name), relativePath, depth + 1)
+      } else if (metadata.isFile()) {
+        // A hard-linked entry (nlink > 1) is treated as unsafe and skipped, matching the export walker.
+        if (metadata.nlink > 1) continue
+        if (fileCount >= SKILL_IMPORT_LIMITS.maxFiles) continue
+        fileCount += 1
+        entries.push({ path: relativePath, size: metadata.size })
+      }
+    }
+  }
+
+  await visit(sourceDir, '', 0)
+  return entries.sort((left, right) => left.path.localeCompare(right.path))
 }
 
 export { readSkillFile }

--- a/src/main/specialist/package/service.ts
+++ b/src/main/specialist/package/service.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../shared/specialist-package'
 import { parseSkillDocument } from '../../../shared/skill-frontmatter'
 import { createLogger } from '../../logger'
+import { isSkillDocumentName } from '../../skills/skill-bundle-paths'
 import type { StoredSpecialist } from '../types'
 import { SpecialistRepository } from '../repository'
 import { validateSpecialistZip } from './zip-adapter'
@@ -628,14 +629,13 @@ export class SpecialistPackageService {
     }
     for (const skill of skillSnapshots) {
       for (const file of skill.files) {
-        files[`skills/${skill.id}/${file.path}`] =
-          file.path === 'SKILL.md'
-            ? normalizeExportedSkillDocument(
-                file.bytes,
-                skill.id,
-                builtinIds.has(skill.id) ? undefined : skill.version
-              )
-            : file.bytes
+        files[`skills/${skill.id}/${file.path}`] = isSkillDocumentName(file.path)
+          ? normalizeExportedSkillDocument(
+              file.bytes,
+              skill.id,
+              builtinIds.has(skill.id) ? undefined : skill.version
+            )
+          : file.bytes
       }
     }
     const archiveBytes = buildDeterministicSpecialistZip(files)

--- a/src/main/specialist/package/validator.ts
+++ b/src/main/specialist/package/validator.ts
@@ -13,6 +13,7 @@ import {
   type SpecialistPackageValidationResult
 } from '../../../shared/specialist-package'
 import { parseSkillDocument } from '../../../shared/skill-frontmatter'
+import { isSkillDocumentName } from '../../skills/skill-bundle-paths'
 import {
   validateSpecialistDescription,
   validateSpecialistDisplayName,
@@ -444,11 +445,14 @@ const planBundledSkills = (
       .filter((file) => file.path.startsWith(prefix))
       .map((file) => ({ path: file.path.slice(prefix.length), bytes: file.bytes }))
       .sort((left, right) => {
-        if (left.path === 'SKILL.md') return -1
-        if (right.path === 'SKILL.md') return 1
+        if (isSkillDocumentName(left.path)) return -1
+        if (isSkillDocumentName(right.path)) return 1
         return left.path.localeCompare(right.path)
       })
-    const document = files.find((file) => file.path === 'SKILL.md')
+    // The skill document may use any casing (skill.md, Skill.md, SKILL.md) — packages built on a
+    // case-insensitive filesystem (macOS/APFS) commonly land as skill.md. Match case-insensitively
+    // here (zip entry paths are pure strings, so the OS can't save us) so such packages import.
+    const document = files.find((file) => isSkillDocumentName(file.path))
     if (!document) {
       warning(
         diagnostics,
@@ -459,6 +463,8 @@ const planBundledSkills = (
       )
       continue
     }
+    // Diagnostics point at the document's actual filename, which may not be SKILL.md.
+    const documentPath = `${root}/${document.path}`
     let skillDocument: ReturnType<typeof parseSkillDocument> | undefined
     try {
       skillDocument = parseSkillDocument(decoder.decode(document.bytes))
@@ -467,7 +473,7 @@ const planBundledSkills = (
         diagnostics,
         'skill.document-invalid',
         'SKILL.md must contain valid UTF-8 text.',
-        `${root}/SKILL.md`,
+        documentPath,
         id
       )
       continue
@@ -477,7 +483,7 @@ const planBundledSkills = (
         diagnostics,
         'skill.name-mismatch',
         'SKILL.md frontmatter name must exactly match its directory Skill ID.',
-        `${root}/SKILL.md`,
+        documentPath,
         id
       )
       continue
@@ -488,7 +494,7 @@ const planBundledSkills = (
         diagnostics,
         'skill.version-invalid',
         'SKILL.md frontmatter version must be SemVer when present.',
-        `${root}/SKILL.md`,
+        documentPath,
         id
       )
       continue

--- a/src/renderer/src/pages/settings/SkillDetailView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillDetailView.render.test.tsx
@@ -20,7 +20,8 @@ const detail = {
   author: 'Test Author',
   license: 'Test License',
   thirdParty: 'Weights — Example (CC-BY-4.0)',
-  body: '# Alpha body'
+  body: '# Alpha body',
+  files: []
 }
 
 beforeEach(() => {
@@ -168,5 +169,78 @@ describe('SkillDetailView', () => {
     act(() => toggle?.click())
 
     expect(useSettingsStore.getState().setSkillEnabled).toHaveBeenCalledWith('a', false)
+  })
+
+  it('renders attached files as a directory tree under Included files', async () => {
+    ;(window as unknown as { api: unknown }).api = {
+      settings: {
+        getSkillDetail: vi.fn().mockResolvedValue({
+          ...detail,
+          files: [
+            { path: 'assets/model.bin', size: 12 * 1024 * 1024 },
+            { path: 'scripts/run.py', size: 4300 },
+            { path: 'scripts/helpers/utils.py', size: 1024 },
+            { path: 'requirements.txt', size: 400 }
+          ]
+        })
+      }
+    }
+
+    await act(async () => {
+      root.render(<SkillDetailView skillId="a" />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('Included files')
+    // Directory nodes by segment.
+    expect(text).toContain('assets')
+    expect(text).toContain('scripts')
+    expect(text).toContain('helpers')
+    // File leaves render the basename, not the full path.
+    expect(text).toContain('model.bin')
+    expect(text).toContain('run.py')
+    expect(text).toContain('utils.py')
+    expect(text).toContain('requirements.txt')
+    // Formatted sizes.
+    expect(text).toContain('12.0 MB')
+    expect(text).toContain('4.2 KB')
+    expect(text).toContain('1.0 KB')
+    expect(text).toContain('400 B')
+  })
+
+  it('omits the Included files section when there are no attached files', async () => {
+    ;(window as unknown as { api: unknown }).api = {
+      settings: { getSkillDetail: vi.fn().mockResolvedValue({ ...detail, files: [] }) }
+    }
+
+    await act(async () => {
+      root.render(<SkillDetailView skillId="a" />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).not.toContain('Included files')
+  })
+
+  it('does not crash when the detail payload omits files', async () => {
+    ;(window as unknown as { api: unknown }).api = {
+      settings: {
+        getSkillDetail: vi.fn().mockResolvedValue({ ...detail, files: undefined })
+      }
+    }
+
+    await act(async () => {
+      root.render(<SkillDetailView skillId="a" />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Alpha')
+    expect(document.body.textContent).not.toContain('Included files')
   })
 })

--- a/src/renderer/src/pages/settings/SkillDetailView.tsx
+++ b/src/renderer/src/pages/settings/SkillDetailView.tsx
@@ -1,7 +1,7 @@
-import { ScrollText } from 'lucide-react'
+import { FileText, Folder, ScrollText } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
-import type { SkillDetailView as SkillDetail } from '../../../../shared/settings'
+import type { SkillDetailView as SkillDetail, SkillFileEntry } from '../../../../shared/settings'
 import { AgentMarkdown } from '@/components/streamdown/AgentMarkdown'
 import { useSettingsStore } from '@/stores/settings-store'
 import { SettingsToggle } from './SettingsLayout'
@@ -20,6 +20,13 @@ const formatUpdated = (iso: string): string => {
   return `Updated ${days} days ago`
 }
 
+// Formats a byte count as a compact human-readable size (B / KB / MB).
+const formatFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
 // One label/value row in the Details section.
 const DetailRow = ({ label, value }: { label: string; value: string }): React.JSX.Element => (
   <div className="flex flex-col gap-0.5 py-1.5">
@@ -27,6 +34,82 @@ const DetailRow = ({ label, value }: { label: string; value: string }): React.JS
     <span className="text-sm text-foreground">{value}</span>
   </div>
 )
+
+// A node in the attached-files tree. `file` is set on leaf nodes; intermediate nodes are directories
+// inferred from file paths (an empty directory has no files and never appears).
+type FileTreeNode = {
+  name: string
+  children: Map<string, FileTreeNode>
+  file: { size: number } | null
+}
+
+// Builds a directory tree from the flat list of posix relative paths the catalog returns. The tree is
+// presentation-only: it groups files by path segment so the detail view can render nested folders.
+const buildFileTree = (files: readonly SkillFileEntry[]): FileTreeNode => {
+  const root: FileTreeNode = { name: '', children: new Map(), file: null }
+  for (const file of files) {
+    const segments = file.path.split('/')
+    let current = root
+    for (const segment of segments) {
+      const next = current.children.get(segment) ?? {
+        name: segment,
+        children: new Map(),
+        file: null
+      }
+      current.children.set(segment, next)
+      current = next
+    }
+    current.file = { size: file.size }
+  }
+  return root
+}
+
+// Renders one tree node and recurses into its children. Directories sort before files, then each
+// group alphabetically. Indentation is driven by depth so nesting is visible without tree-drawing glyphs.
+const FileTreeRow = ({ node, depth }: { node: FileTreeNode; depth: number }): React.JSX.Element => {
+  const isDirectory = node.children.size > 0
+  const sortedChildren = [...node.children.values()].sort((left, right) => {
+    const leftIsDir = left.children.size > 0
+    const rightIsDir = right.children.size > 0
+    if (leftIsDir !== rightIsDir) return leftIsDir ? -1 : 1
+    return left.name.localeCompare(right.name)
+  })
+  return (
+    <>
+      {node.name === '' ? null : (
+        <div
+          className="flex items-center justify-between py-1"
+          style={{ paddingLeft: `${depth * 1.25}rem` }}
+        >
+          <span className="flex min-w-0 items-center gap-2 text-sm">
+            {isDirectory ? (
+              <Folder className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            ) : (
+              <FileText className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            )}
+            <span
+              className={
+                isDirectory
+                  ? 'font-medium text-foreground'
+                  : 'font-mono text-foreground [overflow-wrap:anywhere]'
+              }
+            >
+              {node.name}
+            </span>
+          </span>
+          {node.file ? (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {formatFileSize(node.file.size)}
+            </span>
+          ) : null}
+        </div>
+      )}
+      {sortedChildren.map((child) => (
+        <FileTreeRow key={child.name} node={child} depth={node.name === '' ? depth : depth + 1} />
+      ))}
+    </>
+  )
+}
 
 const metadataLabel = (key: string): string =>
   key.replace(/[-_]+/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
@@ -40,8 +123,8 @@ const DEDICATED_METADATA_KEYS = new Set([
 ])
 
 // Read-only detail view for one bundled skill: header (name + badge + updated + description), the
-// rendered SKILL.md under "Files", and frontmatter metadata under "Details". The breadcrumb and back
-// control live in the settings header, not here.
+// rendered SKILL.md under "Files", every shipped file under "Included files", and frontmatter
+// metadata under "Details". The breadcrumb and back control live in the settings header, not here.
 const SkillDetailView = ({ skillId }: SkillDetailViewProps): React.JSX.Element => {
   const skill = useSettingsStore((state) => state.skills.find((item) => item.id === skillId))
   const setSkillEnabled = useSettingsStore((state) => state.setSkillEnabled)
@@ -68,6 +151,9 @@ const SkillDetailView = ({ skillId }: SkillDetailViewProps): React.JSX.Element =
   const genericMetadata = Object.entries(detail?.metadata ?? {}).filter(
     ([key]) => !DEDICATED_METADATA_KEYS.has(key.toLowerCase())
   )
+  // `files` arrives over IPC from getSkillDetail; default to [] so a partial or legacy payload never
+  // crashes the page. The type is required, but the renderer stays defensive about IPC data.
+  const files = detail?.files ?? []
 
   return (
     <div className="p-5">
@@ -99,6 +185,14 @@ const SkillDetailView = ({ skillId }: SkillDetailViewProps): React.JSX.Element =
         <h2 className="mb-3 text-sm font-semibold text-foreground">Files</h2>
         {detail ? <AgentMarkdown content={detail.body} /> : null}
       </section>
+
+      {/* Included files: every shipped file (references/scripts/assets/templates/...), as a tree. */}
+      {files.length > 0 ? (
+        <section className="mt-6 border-t border-border pt-4">
+          <h2 className="mb-3 text-sm font-semibold text-foreground">Included files</h2>
+          <FileTreeRow node={buildFileTree(files)} depth={0} />
+        </section>
+      ) : null}
 
       {/* Details: frontmatter metadata (author, license, third-party notices, ...). */}
       {detail &&

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -844,12 +844,13 @@ export type SkillView = {
   thirdParty?: string
 }
 
-// A skill view plus its SKILL.md body (frontmatter stripped) and the names of any files under its
-// `references/` directory, for the detail/edit view.
+// A skill view plus its SKILL.md body (frontmatter stripped), its editable `references/` attachments
+// (for the editor), and every file shipped in the skill directory (for the read-only detail view).
 export type SkillDetailView = SkillView & {
   body: string
   metadata?: Record<string, string>
   references: SkillReferenceInfo[]
+  files: SkillFileEntry[]
 }
 
 export type ExportSkillRequest = { id: string }
@@ -859,6 +860,14 @@ export type ExportSkillResult = { saved: boolean }
 // A reference file's name (basename under `references/`), without its content.
 export type SkillReferenceInfo = {
   path: string
+}
+
+// One file shipped inside a skill directory (references/, scripts/, assets/, templates/, ...),
+// listed read-only in the detail view. `path` is the posix path relative to the skill root; `size`
+// is the file size in bytes. SKILL.md itself is excluded (it is rendered as the body).
+export type SkillFileEntry = {
+  path: string
+  size: number
 }
 
 export type SetSkillEnabledRequest = {


### PR DESCRIPTION
## Problem
Importing a Specialist package whose skill document is `skill.md` (lowercase, common on macOS/APFS) failed with **"Skill document missing"**, and the skill detail view showed only the SKILL.md body — `references/`, `scripts/`, `assets/`, `templates/` were invisible.

## Root cause
- Specialist package `validator` matched `SKILL.md` **exactly** — a string compare on zip entry paths, so the OS's case-insensitivity couldn't help → import blocked.
- SKILL.md checks were scattered (exact `=== 'SKILL.md'` in some places, ad-hoc `toLowerCase()` in others) → easy to drift.
- `SkillDetailView` never rendered anything but the SKILL.md body.

## Fix
- Centralize the rule in `isSkillDocumentName` (`skill-bundle-paths`) and use it everywhere a skill document path/name is matched, so casing can never drift between validation, import, listing, and export: specialist-package `validator` (the import blocker), `skill-bundle-import-owner`, `agent-home-skill-owner`, `export`, `service`, `skill-bundle-paths`, and `listSkillFiles`.
- Add `listSkillFiles` + `SkillFileEntry`; the skill detail view now lists every bundled file as a **directory tree** with sizes, excluding the skill document (already the body) and app metadata (`.source.json` / `.specialist-package.json`).

## Verification
- `npm run typecheck` (node + web) ✓
- eslint clean on all changed files ✓
- `vitest run src/main` → 9592 passed (incl. new `skill-files` unit tests, specialist-package validator/service, SkillDetailView render) ✓

## Notes
- `readFile(join(dir, 'SKILL.md'))` sites (read a fixed path) are unchanged — on macOS/APFS they already resolve lowercase; cross-platform (Linux) full consistency is a separate follow-up.