### PR TITLE
ci(release): decouple package validation retries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,10 @@ name: Build
 # place. Publishing is done by the caller, not here.
 #
 # `npm ci` on each runner installs the native binaries it needs (claude-agent-sdk optional package,
-# Prisma query engine). macOS uses native ARM64 and Intel macOS 26 runners so packaged-app
-# certification does not execute across architectures and Xcode 26 can compile the Icon Composer
-# asset; Linux runs on ubuntu-latest and Windows x64 on windows-latest.
+# Prisma query engine). macOS uses native ARM64 and Intel macOS 26 runners so packaging does not
+# cross architectures and Xcode 26 can compile the Icon Composer asset; Linux runs on ubuntu-latest
+# and Windows x64 on windows-latest. Package smoke and desktop regression consume these immutable
+# artifacts in separate workflows so either can be retried without rebuilding.
 on:
   workflow_call:
     inputs:
@@ -79,8 +80,8 @@ jobs:
       - id: set
         shell: bash
         run: |
-          # Run each macOS package on its native macOS 26 architecture so P0, visual, and package
-          # smoke can execute the produced app while Xcode 26 compiles build/icon.icon. Windows'
+          # Build each macOS package on its native macOS 26 architecture while Xcode 26 compiles
+          # build/icon.icon. Downstream validation uses the same native runner mapping. Windows'
           # engine is query_engine-windows.dll.node (no `lib`
           # prefix, .dll.node not .so/.dylib). engine_keep = substring of the engine file to keep.
           # subdir/bin_os/bin_arch drive the notebook runtime staging step: `subdir` is the conda
@@ -326,131 +327,13 @@ jobs:
           security delete-keychain "$MAC_SIGNING_KEYCHAIN" || true
           rm -f "$MAC_SIGNING_CERTIFICATE" "$MAC_SIGNING_KEYCHAIN_LIST"
 
-      - name: Resolve packaged Electron executable
-        id: packaged_app
-        if: ${{ !inputs.skip_verify }}
-        continue-on-error: true
-        shell: bash
-        run: |
-          set -euo pipefail
-          case "${{ matrix.platform }}" in
-            mac) candidate="$(find dist -type f -path '*/Open Science.app/Contents/MacOS/Open Science' -print -quit)" ;;
-            win) candidate="$(find dist -type f -path '*/win-unpacked/open-science.exe' -print -quit)" ;;
-            linux) candidate="$(find dist -type f -path '*/linux-unpacked/open-science' -print -quit)" ;;
-            *) echo "Unsupported packaged Electron platform" >&2; exit 1 ;;
-          esac
-          if [ -z "$candidate" ] || [ ! -f "$candidate" ]; then
-            echo "Packaged Electron executable was not produced for ${{ matrix.name }}" >&2
-            exit 1
-          fi
-          executable="$(node -e 'process.stdout.write(require("path").resolve(process.argv[1]))' "$candidate")"
-          echo "executable=$executable" >> "$GITHUB_OUTPUT"
-
-      # Run the portable release-critical desktop journeys once against the packaged ARM64 app.
-      # Native installer/package behavior remains hard-gated below for every published target.
-      - name: Run P0 Electron certification
-        id: p0
-        if: >-
-          ${{ !inputs.skip_verify &&
-              matrix.name == 'macos-arm64' &&
-              steps.packaged_app.outcome == 'success' }}
-        continue-on-error: true
-        shell: bash
-        env:
-          OPEN_SCIENCE_E2E_EXECUTABLE: ${{ steps.packaged_app.outputs.executable }}
-        run: npm run test:e2e:p0
-
-      # Visual behavior uses the same renderer bundle on every package. Keep one canonical hard gate
-      # beside P0 instead of multiplying antialiasing and launch variance across four native runners.
-      - name: Run desktop visual regression
-        id: visual
-        if: >-
-          ${{ !inputs.skip_verify &&
-              matrix.name == 'macos-arm64' &&
-              steps.packaged_app.outcome == 'success' }}
-        continue-on-error: true
-        shell: bash
-        env:
-          OPEN_SCIENCE_E2E_EXECUTABLE: ${{ steps.packaged_app.outputs.executable }}
-        run: npm run test:e2e:visual
-
-      # Exercise both macOS distributables rather than treating the unpacked app launch above as
-      # package coverage: mount the DMG, extract the ZIP, verify each bundle, and launch each app.
-      - name: Smoke test macOS packages
-        if: ${{ matrix.platform == 'mac' && !inputs.skip_verify }}
-        id: macos_smoke
-        continue-on-error: true
-        timeout-minutes: 10
-        run: node scripts/macos-package-smoke.mjs --artifact-dir dist
-
-      # Run the actual NSIS artifact, not the source tree: silent install into an isolated directory,
-      # start the packaged app in headless web mode, verify its authenticated bootstrap and bundled
-      # Windows runtime resources, request a clean shutdown, then silently uninstall it.
-      - name: Smoke test Windows installer
-        if: ${{ matrix.platform == 'win' && !inputs.skip_verify }}
-        id: windows_smoke
-        continue-on-error: true
-        timeout-minutes: 10
-        run: node scripts/windows-installer-smoke.mjs --installer-dir dist
-
-      # Install the deb with apt, launch the installed application, then extract and launch the
-      # AppImage. Both paths verify authenticated bootstrap and packaged native/runtime resources.
-      - name: Smoke test Linux packages
-        if: ${{ matrix.platform == 'linux' && !inputs.skip_verify }}
-        id: linux_smoke
-        continue-on-error: true
-        timeout-minutes: 10
-        shell: bash
-        run: |
-          sudo apt-get install --yes ./dist/*.deb
-          trap 'sudo apt-get remove --yes open-science || true' EXIT
-          xvfb-run -a node scripts/linux-package-smoke.mjs \
-            --artifact-dir dist \
-            --installed-executable /usr/bin/open-science
-
-      - name: Record platform certification evidence
-        if: >-
-          ${{ !inputs.skip_verify &&
-              steps.packaged_app.outcome == 'success' &&
-              ((matrix.name == 'macos-arm64' &&
-                steps.p0.outcome == 'success' &&
-                steps.visual.outcome == 'success') ||
-               (matrix.name != 'macos-arm64' &&
-                steps.p0.outcome == 'skipped' &&
-                steps.visual.outcome == 'skipped')) &&
-              ((matrix.platform == 'mac' && steps.macos_smoke.outcome == 'success') ||
-               (matrix.platform == 'win' && steps.windows_smoke.outcome == 'success') ||
-               (matrix.platform == 'linux' && steps.linux_smoke.outcome == 'success')) }}
-        shell: bash
-        run: |
-          electron_p0=not-applicable
-          visual_regression=not-applicable
-          if [ "${{ matrix.name }}" = "macos-arm64" ]; then
-            electron_p0=passed
-            visual_regression=passed
-          fi
-          package_smoke=passed
-          authenticode=not-applicable
-          if [ "${{ matrix.platform }}" = "win" ]; then
-            authenticode=not-required
-          fi
-          node scripts/ci/release-certification-evidence.mjs write \
-            --platform "${{ matrix.name }}" \
-            --artifact-dir dist \
-            --output "dist/certification-${{ matrix.name }}.json" \
-            --electron-p0 "$electron_p0" \
-            --visual-regression "$visual_regression" \
-            --package-smoke "$package_smoke" \
-            --database-migration-certification dist/database-migration-certification.json \
-            --authenticode "$authenticode"
-
-      # Upload only the distributables + electron-updater metadata for the caller's publish job.
+      # Upload the build once. Blocking package smoke and advisory desktop regression download this
+      # immutable artifact, so re-running either validation never rebuilds or re-signs the package.
       - name: Upload build artifacts
-        if: ${{ always() && steps.package.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.name }}
-          retention-days: 1
+          retention-days: 7
           path: |
             dist/*.dmg
             dist/*.zip
@@ -460,39 +343,4 @@ jobs:
             dist/*.blockmap
             dist/latest*.yml
             dist/*-mac.yml
-            dist/certification-*.json
           if-no-files-found: error
-
-      - name: Enforce platform certification
-        if: ${{ !inputs.skip_verify && always() }}
-        shell: bash
-        env:
-          LINUX_SMOKE_OUTCOME: ${{ steps.linux_smoke.outcome }}
-          MACOS_SMOKE_OUTCOME: ${{ steps.macos_smoke.outcome }}
-          MATRIX_NAME: ${{ matrix.name }}
-          P0_OUTCOME: ${{ steps.p0.outcome }}
-          PACKAGED_APP_OUTCOME: ${{ steps.packaged_app.outcome }}
-          PLATFORM: ${{ matrix.platform }}
-          VISUAL_OUTCOME: ${{ steps.visual.outcome }}
-          WINDOWS_SMOKE_OUTCOME: ${{ steps.windows_smoke.outcome }}
-        run: |
-          set -euo pipefail
-          failed=0
-          check() {
-            if [[ "$2" != "success" ]]; then
-              echo "$1 ended with $2" >&2
-              failed=1
-            fi
-          }
-          check packaged_app "$PACKAGED_APP_OUTCOME"
-          if [[ "$MATRIX_NAME" == "macos-arm64" ]]; then
-            check p0 "$P0_OUTCOME"
-            check visual "$VISUAL_OUTCOME"
-          fi
-          case "$PLATFORM" in
-            mac) check macos_smoke "$MACOS_SMOKE_OUTCOME" ;;
-            win) check windows_smoke "$WINDOWS_SMOKE_OUTCOME" ;;
-            linux) check linux_smoke "$LINUX_SMOKE_OUTCOME" ;;
-            *) echo "Unsupported platform: $PLATFORM" >&2; failed=1 ;;
-          esac
-          exit "$failed"

--- a/.github/workflows/desktop-regression.yml
+++ b/.github/workflows/desktop-regression.yml
@@ -2,7 +2,8 @@ name: Desktop Regression
 
 # Advisory desktop behavior checks. Packaged P0 consumes the immutable ARM64 release artifact while
 # visual regression uses the same macos-14 source-build environment that owns the canonical Darwin
-# baselines. The independent jobs can be re-run without rebuilding or re-signing release packages.
+# baselines. Release and Nightly call this reusable workflow inside their existing low-privilege run,
+# so the independent jobs can be retried without a privileged workflow_run checkout boundary.
 on:
   workflow_call:
     inputs:
@@ -16,12 +17,6 @@ on:
         required: false
         type: string
         default: ''
-  workflow_run:
-    workflows:
-      - Release
-      - Nightly
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       run_id:
@@ -36,9 +31,6 @@ permissions:
 jobs:
   source:
     name: Resolve source build
-    if: >-
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.event != 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       available: ${{ steps.resolve.outputs.available }}
@@ -49,13 +41,11 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVENT_NAME: ${{ github.event_name }}
           MANUAL_RUN_ID: ${{ inputs.run_id }}
-          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
           CURRENT_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          run_id="${MANUAL_RUN_ID:-${SOURCE_RUN_ID:-$CURRENT_RUN_ID}}"
+          run_id="${MANUAL_RUN_ID:-$CURRENT_RUN_ID}"
           if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
             echo "Source run ID must be numeric." >&2
             exit 1
@@ -71,7 +61,7 @@ jobs:
           available=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts?per_page=100" \
             --jq 'any(.artifacts[]; .name == "macos-arm64" and (.expired | not))')
           echo "available=$available" >> "$GITHUB_OUTPUT"
-          if [ "$available" != "true" ] && [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "$available" != "true" ]; then
             echo "Source run $run_id has no active macos-arm64 artifact." >&2
             exit 1
           fi
@@ -163,15 +153,9 @@ jobs:
       - name: Build Electron application
         run: npm run build:e2e
 
-      # The pre-PR Release dry-run keeps Playwright's single retry as its existing acceptance rule.
-      # A completed Release/Nightly triggers the stricter advisory lane below, where retry-passes
-      # remain visible as flaky without blocking publication.
-      - name: Run visual regression
-        if: github.event_name != 'workflow_run'
-        run: npm run test:e2e:visual
-
+      # Preserve Playwright's single retry, but keep retry-passes visible as flaky. The caller marks
+      # this job advisory, so the signal cannot block Release or Nightly publication.
       - name: Run visual stability regression
-        if: github.event_name == 'workflow_run'
         run: npm run test:e2e:visual -- --fail-on-flaky-tests
 
       - name: Upload visual diagnostics

--- a/.github/workflows/desktop-regression.yml
+++ b/.github/workflows/desktop-regression.yml
@@ -1,8 +1,8 @@
 name: Desktop Regression
 
-# Advisory packaged-app behavior checks. They consume a completed Release/Nightly build artifact and
-# intentionally live in a separate workflow so failures never block publication. Each matrix leg is
-# independently red and independently re-runnable without rebuilding the package.
+# Advisory desktop behavior checks. Packaged P0 consumes the immutable ARM64 release artifact while
+# visual regression uses the same macos-14 source-build environment that owns the canonical Darwin
+# baselines. The independent jobs can be re-run without rebuilding or re-signing release packages.
 on:
   workflow_call:
     inputs:
@@ -71,20 +71,12 @@ jobs:
             exit 1
           fi
 
-  regression:
-    name: ${{ matrix.name }} (macos-arm64 artifact)
+  p0:
+    name: p0 (macos-arm64 artifact)
     needs: source
     if: needs.source.outputs.available == 'true'
     runs-on: macos-26
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: p0
-            command: npm run test:e2e:p0
-          - name: visual
-            command: npm run test:e2e:visual
     steps:
       - name: Checkout source revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -124,16 +116,56 @@ jobs:
           test -n "$executable"
           echo "executable=$(node -e 'process.stdout.write(require("path").resolve(process.argv[1]))' "$executable")" >> "$GITHUB_OUTPUT"
 
-      - name: Run packaged desktop regression
+      - name: Run packaged P0 regression
         env:
           OPEN_SCIENCE_E2E_EXECUTABLE: ${{ steps.packaged_app.outputs.executable }}
-        run: ${{ matrix.command }}
+        run: npm run test:e2e:p0
 
-      - name: Upload regression diagnostics
-        if: failure()
+      - name: Upload P0 diagnostics
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: desktop-regression-${{ matrix.name }}-${{ needs.source.outputs.run_id }}
+          name: desktop-regression-p0-${{ needs.source.outputs.run_id }}
+          retention-days: 7
+          path: |
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore
+
+  visual:
+    name: visual (canonical macos-14 source build)
+    needs: source
+    if: needs.source.outputs.available == 'true'
+    runs-on: macos-14
+    timeout-minutes: 15
+    steps:
+      - name: Checkout source revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.source.outputs.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Electron application
+        run: npm run build:e2e
+
+      # Keep Playwright's single CI retry for diagnostics, but report a retry-pass as flaky so this
+      # advisory check records baseline instability instead of silently normalizing it.
+      - name: Run visual regression
+        run: npm run test:e2e:visual -- --fail-on-flaky-tests
+
+      - name: Upload visual diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: desktop-regression-visual-${{ needs.source.outputs.run_id }}
           retention-days: 7
           path: |
             test-results/

--- a/.github/workflows/desktop-regression.yml
+++ b/.github/workflows/desktop-regression.yml
@@ -1,0 +1,141 @@
+name: Desktop Regression
+
+# Advisory packaged-app behavior checks. They consume a completed Release/Nightly build artifact and
+# intentionally live in a separate workflow so failures never block publication. Each matrix leg is
+# independently red and independently re-runnable without rebuilding the package.
+on:
+  workflow_call:
+    inputs:
+      run_id:
+        description: 'Optional caller run ID; defaults to the current Release dry-run'
+        required: false
+        type: string
+        default: ''
+  workflow_run:
+    workflows:
+      - Release
+      - Nightly
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Release or Nightly workflow run ID whose macos-arm64 artifact should be tested'
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  source:
+    name: Resolve source build
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.event != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      available: ${{ steps.resolve.outputs.available }}
+      run_id: ${{ steps.resolve.outputs.run_id }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Resolve source run
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_RUN_ID: ${{ inputs.run_id }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          run_id="${MANUAL_RUN_ID:-${SOURCE_RUN_ID:-$CURRENT_RUN_ID}}"
+          if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
+            echo "Source run ID must be numeric." >&2
+            exit 1
+          fi
+          metadata=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id")
+          workflow=$(jq -r .name <<<"$metadata")
+          if [ "$workflow" != "Release" ] && [ "$workflow" != "Nightly" ]; then
+            echo "Source run must belong to Release or Nightly, got: $workflow" >&2
+            exit 1
+          fi
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          jq -r '"sha=" + .head_sha' <<<"$metadata" >> "$GITHUB_OUTPUT"
+          available=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts?per_page=100" \
+            --jq 'any(.artifacts[]; .name == "macos-arm64" and (.expired | not))')
+          echo "available=$available" >> "$GITHUB_OUTPUT"
+          if [ "$available" != "true" ] && [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Source run $run_id has no active macos-arm64 artifact." >&2
+            exit 1
+          fi
+
+  regression:
+    name: ${{ matrix.name }} (macos-arm64 artifact)
+    needs: source
+    if: needs.source.outputs.available == 'true'
+    runs-on: macos-26
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: p0
+            command: npm run test:e2e:p0
+          - name: visual
+            command: npm run test:e2e:visual
+    steps:
+      - name: Checkout source revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.source.outputs.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download macOS ARM64 package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ needs.source.outputs.run_id }}
+          name: macos-arm64
+          path: package
+
+      - name: Extract packaged application
+        run: |
+          set -euo pipefail
+          zip=$(find package -maxdepth 1 -type f -name '*-mac-arm64.zip' -print -quit)
+          test -n "$zip"
+          mkdir -p extracted
+          ditto -x -k "$zip" extracted
+
+      - name: Resolve packaged Electron executable
+        id: packaged_app
+        run: |
+          set -euo pipefail
+          executable=$(find extracted -type f -path '*/Open Science.app/Contents/MacOS/Open Science' -print -quit)
+          test -n "$executable"
+          echo "executable=$(node -e 'process.stdout.write(require("path").resolve(process.argv[1]))' "$executable")" >> "$GITHUB_OUTPUT"
+
+      - name: Run packaged desktop regression
+        env:
+          OPEN_SCIENCE_E2E_EXECUTABLE: ${{ steps.packaged_app.outputs.executable }}
+        run: ${{ matrix.command }}
+
+      - name: Upload regression diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: desktop-regression-${{ matrix.name }}-${{ needs.source.outputs.run_id }}
+          retention-days: 7
+          path: |
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore

--- a/.github/workflows/desktop-regression.yml
+++ b/.github/workflows/desktop-regression.yml
@@ -156,9 +156,15 @@ jobs:
       - name: Build Electron application
         run: npm run build:e2e
 
-      # Keep Playwright's single CI retry for diagnostics, but report a retry-pass as flaky so this
-      # advisory check records baseline instability instead of silently normalizing it.
+      # The pre-PR Release dry-run keeps Playwright's single retry as its existing acceptance rule.
+      # A completed Release/Nightly triggers the stricter advisory lane below, where retry-passes
+      # remain visible as flaky without blocking publication.
       - name: Run visual regression
+        if: github.event_name != 'workflow_run'
+        run: npm run test:e2e:visual
+
+      - name: Run visual stability regression
+        if: github.event_name == 'workflow_run'
         run: npm run test:e2e:visual -- --fail-on-flaky-tests
 
       - name: Upload visual diagnostics

--- a/.github/workflows/desktop-regression.yml
+++ b/.github/workflows/desktop-regression.yml
@@ -6,6 +6,11 @@ name: Desktop Regression
 on:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'Keep regression advisory when embedded in the Release no-publish dry-run'
+        required: false
+        type: boolean
+        default: false
       run_id:
         description: 'Optional caller run ID; defaults to the current Release dry-run'
         required: false
@@ -75,6 +80,7 @@ jobs:
     name: p0 (macos-arm64 artifact)
     needs: source
     if: needs.source.outputs.available == 'true'
+    continue-on-error: ${{ inputs.allow_failure }}
     runs-on: macos-26
     timeout-minutes: 15
     steps:
@@ -136,6 +142,7 @@ jobs:
     name: visual (canonical macos-14 source build)
     needs: source
     if: needs.source.outputs.available == 'true'
+    continue-on-error: ${{ inputs.allow_failure }}
     runs-on: macos-14
     timeout-minutes: 15
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,13 +45,17 @@ jobs:
     with:
       nightly: true
 
+  package-smoke:
+    needs: build
+    uses: ./.github/workflows/package-smoke.yml
+
   # Aggregate and checksum on the low-privilege build run. A manual Nightly stops here, making this
   # the focused no-side-effect dry-run; a successful schedule hands these prepared files to the
   # separate publisher as artifacts, never as executable code.
   prepare:
     name: Prepare nightly publish artifact
-    needs: [plan, build]
-    if: needs.build.result == 'success'
+    needs: [plan, build, package-smoke]
+    if: needs.build.result == 'success' && needs.package-smoke.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,14 @@ jobs:
     needs: build
     uses: ./.github/workflows/package-smoke.yml
 
+  # Run advisory desktop behavior checks inside the same read-only Nightly run. Failures remain
+  # visible and independently rerunnable, but do not gate preparation or publication.
+  regression:
+    needs: [build, package-smoke]
+    uses: ./.github/workflows/desktop-regression.yml
+    with:
+      allow_failure: true
+
   # Aggregate and checksum on the low-privilege build run. A manual Nightly stops here, making this
   # the focused no-side-effect dry-run; a successful schedule hands these prepared files to the
   # separate publisher as artifacts, never as executable code.

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -114,6 +114,16 @@ jobs:
           name: macos-${{ matrix.arch }}
           path: mac
 
+      - name: Download macOS certification evidence (from this run)
+        if: >-
+          steps.gate.outputs.enabled == 'true' &&
+          inputs.from_run &&
+          inputs.certified_build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: certification-macos-${{ matrix.arch }}
+          path: mac
+
       # Standalone path: pull the arch's signed assets straight off the existing Release.
       - name: Download signed mac assets (from the release)
         if: steps.gate.outputs.enabled == 'true' && !inputs.from_run
@@ -253,7 +263,7 @@ jobs:
           '
 
       # Stapling changes the installer bytes. Re-hash the final artifacts while preserving the
-      # platform certification signal already established by the build job.
+      # package certification signal already established by the separate smoke job.
       - name: Refresh macOS certification evidence
         if: >-
           steps.gate.outputs.enabled == 'true' &&
@@ -264,11 +274,35 @@ jobs:
           --platform "macos-${{ matrix.arch }}"
           --artifact-dir mac
           --output "mac/certification-macos-${{ matrix.arch }}.json"
-          --electron-p0 "${{ matrix.arch == 'arm64' && 'passed' || 'not-applicable' }}"
-          --visual-regression "${{ matrix.arch == 'arm64' && 'passed' || 'not-applicable' }}"
+          --electron-p0 not-applicable
+          --visual-regression not-applicable
           --package-smoke passed
           --database-migration-certification mac/database-migration-certification.json
           --authenticode not-applicable
+
+      - name: Preserve final database certification name
+        if: >-
+          steps.gate.outputs.enabled == 'true' &&
+          inputs.from_run &&
+          inputs.certified_build
+        run: >-
+          mv mac/database-migration-certification.json
+          "mac/database-migration-certification-macos-${{ matrix.arch }}.json"
+
+      - name: Replace macOS certification evidence
+        if: >-
+          steps.gate.outputs.enabled == 'true' &&
+          inputs.from_run &&
+          inputs.certified_build
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: certification-macos-${{ matrix.arch }}
+          overwrite: true
+          retention-days: 7
+          path: |
+            mac/certification-macos-${{ matrix.arch }}.json
+            mac/database-migration-certification-macos-${{ matrix.arch }}.json
+          if-no-files-found: error
 
       # Call path: replace this run's signed artifacts with the stapled ones (same names) plus the
       # regenerated ${arch}-mac.yml feed, so the publish job's merge-multiple download picks them up.
@@ -280,12 +314,11 @@ jobs:
         with:
           name: macos-${{ matrix.arch }}
           overwrite: true
-          retention-days: 1
+          retention-days: 7
           path: |
             mac/*-mac-*.dmg
             mac/*-mac-*.zip
             mac/*-mac.yml
-            mac/certification-*.json
           if-no-files-found: error
 
       # Standalone path: push the stapled dmg/zip + regenerated feed back onto the Release, replacing

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,0 +1,99 @@
+name: Package Smoke
+
+# Blocking native-package certification. Each matrix leg downloads the exact artifact produced by
+# build.yml, so a failed smoke can be retried without rebuilding or re-signing any package.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Smoke ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macos-arm64
+            os: macos-26
+            platform: mac
+          - name: macos-x64
+            os: macos-26-intel
+            platform: mac
+          - name: linux-x64
+            os: ubuntu-latest
+            platform: linux
+          - name: windows-x64
+            os: windows-latest
+            platform: win
+    steps:
+      - name: Checkout certification tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ matrix.name }}
+          path: dist
+
+      - name: Smoke test macOS packages
+        if: matrix.platform == 'mac'
+        timeout-minutes: 10
+        run: node scripts/macos-package-smoke.mjs --artifact-dir dist
+
+      - name: Smoke test Windows installer
+        if: matrix.platform == 'win'
+        timeout-minutes: 10
+        run: node scripts/windows-installer-smoke.mjs --installer-dir dist
+
+      - name: Smoke test Linux packages
+        if: matrix.platform == 'linux'
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          sudo apt-get install --yes ./dist/*.deb
+          trap 'sudo apt-get remove --yes open-science || true' EXIT
+          xvfb-run -a node scripts/linux-package-smoke.mjs \
+            --artifact-dir dist \
+            --installed-executable /usr/bin/open-science
+
+      - name: Record platform certification evidence
+        shell: bash
+        run: |
+          database_certification="dist/database-migration-certification-${{ matrix.name }}.json"
+          mv dist/database-migration-certification.json "$database_certification"
+          authenticode=not-applicable
+          if [ "${{ matrix.platform }}" = "win" ]; then
+            authenticode=not-required
+          fi
+          node scripts/ci/release-certification-evidence.mjs write \
+            --platform "${{ matrix.name }}" \
+            --artifact-dir dist \
+            --output "dist/certification-${{ matrix.name }}.json" \
+            --electron-p0 not-applicable \
+            --visual-regression not-applicable \
+            --package-smoke passed \
+            --database-migration-certification "$database_certification" \
+            --authenticode "$authenticode"
+
+      - name: Upload platform certification evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: certification-${{ matrix.name }}
+          retention-days: 7
+          path: |
+            dist/certification-${{ matrix.name }}.json
+            dist/database-migration-certification-${{ matrix.name }}.json
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 # Required to create a Release and upload assets.
 permissions:
+  actions: read
   contents: write
 
 concurrency:
@@ -50,12 +51,25 @@ jobs:
     uses: ./.github/workflows/build.yml
     secrets: inherit
 
+  # Exercise the exact uploaded packages in separate native jobs. A failed matrix leg can be retried
+  # against the immutable build artifact without repeating installation, packaging, or signing.
+  package-smoke:
+    needs: build
+    uses: ./.github/workflows/package-smoke.yml
+
+  # The manual Release entry is the no-publish dry-run. Exercise the same advisory regression
+  # workflow before a PR without making tagged releases wait on flaky behavior checks.
+  regression-dry-run:
+    needs: [build, package-smoke]
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/desktop-regression.yml
+
   # Notarize + staple the signed macOS artifacts on their own runner, then re-emit the stapled dmg/zip
   # (overwriting the build's signed-only ones) so publish always attaches a stapled mac build. Kept out
   # of the build matrix so a slow Apple notarization never holds up the platform builds; the job is
   # time-capped and re-runnable (see notarize-mac.yml). No-ops when signing secrets aren't configured.
   notarize-mac:
-    needs: build
+    needs: [build, package-smoke]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     uses: ./.github/workflows/notarize-mac.yml
     secrets: inherit
@@ -64,7 +78,7 @@ jobs:
   # publish job avoids the race of multiple build jobs writing the same Release). Depends on
   # notarize-mac so the mac dmg/zip it downloads are the stapled versions.
   publish:
-    needs: [build, notarize-mac]
+    needs: [build, package-smoke, notarize-mac]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     # Job-level permissions fully override the workflow-level block, so contents:write is restated
@@ -86,8 +100,8 @@ jobs:
           path: artifacts
           merge-multiple: true # flatten every platform's files into one directory
 
-      # Fail closed unless every native target reports P0 Electron, visual, and package evidence for
-      # this exact tag commit. The historical Windows update drill runs independently as diagnostics.
+      # Fail closed unless every native target reports package evidence for this exact tag commit.
+      # P0 and visual regression run independently as advisory Desktop Regression checks.
       - name: Aggregate release certification evidence
         run: >-
           node scripts/ci/release-certification-evidence.mjs aggregate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,10 @@ jobs:
     needs: build
     uses: ./.github/workflows/package-smoke.yml
 
-  # The manual Release entry is the no-publish dry-run. Exercise advisory regression and retain its
-  # diagnostics without allowing known flakes to override the blocking build + package-smoke result.
-  regression-dry-run:
+  # Exercise advisory regression in this low-privilege build run and retain its diagnostics without
+  # allowing known flakes to override the blocking build + package-smoke result.
+  regression:
     needs: [build, package-smoke]
-    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/desktop-regression.yml
     with:
       allow_failure: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,14 @@ jobs:
     needs: build
     uses: ./.github/workflows/package-smoke.yml
 
-  # The manual Release entry is the no-publish dry-run. Exercise the same advisory regression
-  # workflow before a PR without making tagged releases wait on flaky behavior checks.
+  # The manual Release entry is the no-publish dry-run. Exercise advisory regression and retain its
+  # diagnostics without allowing known flakes to override the blocking build + package-smoke result.
   regression-dry-run:
     needs: [build, package-smoke]
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/desktop-regression.yml
+    with:
+      allow_failure: true
 
   # Notarize + staple the signed macOS artifacts on their own runner, then re-emit the stapled dmg/zip
   # (overwriting the build's signed-only ones) so publish always attaches a stapled mac build. Kept out

--- a/scripts/ci/release-certification-evidence.mjs
+++ b/scripts/ci/release-certification-evidence.mjs
@@ -241,7 +241,6 @@ const aggregateEvidence = async ({ argv }) => {
 
   for (const platform of PLATFORMS) {
     const record = byPlatform.get(platform)
-    const expectedPortableCheck = platform === 'macos-arm64' ? 'passed' : 'not-applicable'
     try {
       assertDatabaseMigrationCertification(record?.databaseMigration)
     } catch {
@@ -250,8 +249,8 @@ const aggregateEvidence = async ({ argv }) => {
     if (
       record.schemaVersion !== 1 ||
       record.source?.sha !== expectedSha ||
-      record.checks?.electronP0 !== expectedPortableCheck ||
-      record.checks?.visualRegression !== expectedPortableCheck ||
+      record.checks?.electronP0 !== 'not-applicable' ||
+      record.checks?.visualRegression !== 'not-applicable' ||
       !Array.isArray(record.artifacts) ||
       record.artifacts.length === 0
     ) {

--- a/scripts/ci/release-certification-evidence.test.ts
+++ b/scripts/ci/release-certification-evidence.test.ts
@@ -249,8 +249,8 @@ describe('release certification evidence', () => {
       platform,
       source: { sha },
       checks: {
-        electronP0: platform === 'macos-arm64' ? 'passed' : 'not-applicable',
-        visualRegression: platform === 'macos-arm64' ? 'passed' : 'not-applicable',
+        electronP0: 'not-applicable',
+        visualRegression: 'not-applicable',
         packageSmoke: 'passed',
         authenticode: platform === 'windows-x64' ? 'not-required' : 'not-applicable'
       },
@@ -292,22 +292,22 @@ describe('release certification evidence', () => {
     })
 
     await writeFile(
-      join(root, 'certification-windows-x64.json'),
+      join(root, 'certification-macos-arm64.json'),
       JSON.stringify({
-        ...recordFor('windows-x64'),
+        ...recordFor('macos-arm64'),
         checks: {
-          ...recordFor('windows-x64').checks,
+          ...recordFor('macos-arm64').checks,
           electronP0: 'passed',
           visualRegression: 'passed'
         }
       })
     )
     await expect(aggregateEvidence({ argv: args })).rejects.toThrow(
-      /Invalid release certification evidence for windows-x64/
+      /Invalid release certification evidence for macos-arm64/
     )
     await writeFile(
-      join(root, 'certification-windows-x64.json'),
-      JSON.stringify(recordFor('windows-x64'))
+      join(root, 'certification-macos-arm64.json'),
+      JSON.stringify(recordFor('macos-arm64'))
     )
 
     await writeFile(

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -78,9 +78,9 @@ describe('release and scheduled workflow topology', () => {
 
     expect(build.needs).toBe('setup')
     expect(build.if).toBe("${{ needs.setup.result == 'success' }}")
-    expect(nightly.jobs.prepare.needs).toEqual(['plan', 'build'])
-    expect(release.jobs.publish.needs).toEqual(['build', 'notarize-mac'])
-    expect(release.jobs['notarize-mac'].needs).toBe('build')
+    expect(nightly.jobs.prepare.needs).toEqual(['plan', 'build', 'package-smoke'])
+    expect(release.jobs.publish.needs).toEqual(['build', 'package-smoke', 'notarize-mac'])
+    expect(release.jobs['notarize-mac'].needs).toEqual(['build', 'package-smoke'])
   })
 
   it('batches Nightly hourly and prepares publication without write access', () => {
@@ -107,8 +107,8 @@ describe('release and scheduled workflow topology', () => {
     )
     expect(nightly.jobs).not.toHaveProperty('publish-dry-run')
     expect(prepare).toMatchObject({
-      needs: ['plan', 'build'],
-      if: "needs.build.result == 'success'",
+      needs: ['plan', 'build', 'package-smoke'],
+      if: "needs.build.result == 'success' && needs.package-smoke.result == 'success'",
       'runs-on': 'ubuntu-latest'
     })
     expect(step(prepare, 'Aggregate release certification evidence').run).toContain(

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -203,7 +203,7 @@ describe('post-merge Windows validation', () => {
     expect(uploadEvidence.with?.['retention-days']).toBe(7)
     expect(p0Regression).toMatchObject({ needs: 'source', 'runs-on': 'macos-26' })
     expect(p0Regression.if).toBe("needs.source.outputs.available == 'true'")
-    expect(p0Regression['continue-on-error']).toBeUndefined()
+    expect(p0Regression['continue-on-error']).toBe('${{ inputs.allow_failure }}')
     expect(findStep(p0Regression, 'Download macOS ARM64 package').with?.name).toBe('macos-arm64')
     expect(findStep(p0Regression, 'Download macOS ARM64 package').with?.['run-id']).toBe(
       '${{ needs.source.outputs.run_id }}'
@@ -216,7 +216,7 @@ describe('post-merge Windows validation', () => {
     expect(findStep(p0Regression, 'Upload P0 diagnostics').if).toBe('always()')
     expect(visualRegression).toMatchObject({ needs: 'source', 'runs-on': 'macos-14' })
     expect(visualRegression.if).toBe("needs.source.outputs.available == 'true'")
-    expect(visualRegression['continue-on-error']).toBeUndefined()
+    expect(visualRegression['continue-on-error']).toBe('${{ inputs.allow_failure }}')
     expect(findStep(visualRegression, 'Build Electron application').run).toBe('npm run build:e2e')
     expect(findStep(visualRegression, 'Run visual regression')).toMatchObject({
       if: "github.event_name != 'workflow_run'",
@@ -287,7 +287,8 @@ describe('post-merge Windows validation', () => {
     expect(release.jobs['regression-dry-run']).toMatchObject({
       needs: ['build', 'package-smoke'],
       if: "github.event_name == 'workflow_dispatch'",
-      uses: './.github/workflows/desktop-regression.yml'
+      uses: './.github/workflows/desktop-regression.yml',
+      with: { allow_failure: true }
     })
     expect(release.jobs.regression).toBeUndefined()
     expect(nightly.jobs.regression).toBeUndefined()

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -157,7 +157,8 @@ describe('post-merge Windows validation', () => {
     const evidence = findStep(smoke, 'Record platform certification evidence')
     const uploadEvidence = findStep(smoke, 'Upload platform certification evidence')
     const regressionWorkflow = readWorkflow('desktop-regression.yml')
-    const regression = regressionWorkflow.jobs.regression
+    const p0Regression = regressionWorkflow.jobs.p0
+    const visualRegression = regressionWorkflow.jobs.visual
     const notarize = readWorkflow('notarize-mac.yml').jobs.notarize
     const notarizeDryRun = readWorkflow('notarize-dryrun.yml').jobs.notarize
     const finalMacos = findStep(notarize, 'Smoke test final macOS packages')
@@ -200,26 +201,27 @@ describe('post-merge Windows validation', () => {
     expect(evidence.run).toContain('--database-migration-certification "$database_certification"')
     expect(uploadEvidence.with?.name).toBe('certification-${{ matrix.name }}')
     expect(uploadEvidence.with?.['retention-days']).toBe(7)
-    expect(regression).toMatchObject({ needs: 'source', 'runs-on': 'macos-26' })
-    expect(regression.if).toBe("needs.source.outputs.available == 'true'")
-    expect(regression['continue-on-error']).toBeUndefined()
-    expect(regression.strategy?.matrix).toEqual({
-      include: [
-        { name: 'p0', command: 'npm run test:e2e:p0' },
-        { name: 'visual', command: 'npm run test:e2e:visual' }
-      ]
-    })
-    expect(findStep(regression, 'Download macOS ARM64 package').with?.name).toBe('macos-arm64')
-    expect(findStep(regression, 'Download macOS ARM64 package').with?.['run-id']).toBe(
+    expect(p0Regression).toMatchObject({ needs: 'source', 'runs-on': 'macos-26' })
+    expect(p0Regression.if).toBe("needs.source.outputs.available == 'true'")
+    expect(p0Regression['continue-on-error']).toBeUndefined()
+    expect(findStep(p0Regression, 'Download macOS ARM64 package').with?.name).toBe('macos-arm64')
+    expect(findStep(p0Regression, 'Download macOS ARM64 package').with?.['run-id']).toBe(
       '${{ needs.source.outputs.run_id }}'
     )
-    expect(findStep(regression, 'Extract packaged application').run).toContain('ditto -x -k')
-    expect(findStep(regression, 'Run packaged desktop regression').run).toBe(
-      '${{ matrix.command }}'
-    )
+    expect(findStep(p0Regression, 'Extract packaged application').run).toContain('ditto -x -k')
+    expect(findStep(p0Regression, 'Run packaged P0 regression').run).toBe('npm run test:e2e:p0')
     expect(
-      findStep(regression, 'Run packaged desktop regression').env?.OPEN_SCIENCE_E2E_EXECUTABLE
+      findStep(p0Regression, 'Run packaged P0 regression').env?.OPEN_SCIENCE_E2E_EXECUTABLE
     ).toBe('${{ steps.packaged_app.outputs.executable }}')
+    expect(findStep(p0Regression, 'Upload P0 diagnostics').if).toBe('always()')
+    expect(visualRegression).toMatchObject({ needs: 'source', 'runs-on': 'macos-14' })
+    expect(visualRegression.if).toBe("needs.source.outputs.available == 'true'")
+    expect(visualRegression['continue-on-error']).toBeUndefined()
+    expect(findStep(visualRegression, 'Build Electron application').run).toBe('npm run build:e2e')
+    expect(findStep(visualRegression, 'Run visual regression').run).toBe(
+      'npm run test:e2e:visual -- --fail-on-flaky-tests'
+    )
+    expect(findStep(visualRegression, 'Upload visual diagnostics').if).toBe('always()')
     expect(finalMacos.run).toBe(
       'node scripts/macos-package-smoke.mjs --artifact-dir mac --gatekeeper'
     )

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -32,9 +32,11 @@ type WorkflowJob = {
 
 type Workflow = {
   jobs: Record<string, WorkflowJob>
+  permissions?: Record<string, string>
   on?: {
     push?: { branches?: string[]; tags?: string[] }
     schedule?: Array<{ cron: string }>
+    workflow_run?: { workflows?: string[]; types?: string[] }
     workflow_call?: unknown
     workflow_dispatch?: unknown
   }
@@ -85,19 +87,13 @@ describe('post-merge Windows validation', () => {
   })
 
   it('hard-gates every packaged Windows build on a fresh install/start/uninstall smoke', () => {
-    const job = readWorkflow('build.yml').jobs.build
-    const buildIndex = job.steps?.findIndex(({ name }) => name === 'Build & package') ?? -1
-    const smokeIndex =
-      job.steps?.findIndex(({ name }) => name === 'Smoke test Windows installer') ?? -1
-    const uploadIndex = job.steps?.findIndex(({ name }) => name === 'Upload build artifacts') ?? -1
+    const job = readWorkflow('package-smoke.yml').jobs.smoke
     const smoke = findStep(job, 'Smoke test Windows installer')
 
-    expect(smoke.if).toBe("${{ matrix.platform == 'win' && !inputs.skip_verify }}")
+    expect(job['continue-on-error']).toBeUndefined()
+    expect(smoke.if).toBe("matrix.platform == 'win'")
     expect(smoke.run).toBe('node scripts/windows-installer-smoke.mjs --installer-dir dist')
     expect(smoke['timeout-minutes']).toBe(10)
-    expect(buildIndex).toBeGreaterThan(-1)
-    expect(smokeIndex).toBeGreaterThan(buildIndex)
-    expect(uploadIndex).toBeGreaterThan(smokeIndex)
   })
 
   it('keeps Windows packaging unsigned until signing credentials are available', () => {
@@ -147,16 +143,21 @@ describe('post-merge Windows validation', () => {
     expect(packageStep.run).not.toContain('publisherName')
   })
 
-  it('runs one canonical packaged P0 and visual gate plus native package smoke on every target', () => {
+  it('separates immutable builds from blocking package smoke and advisory regressions', () => {
     const setup = readWorkflow('build.yml').jobs.setup.steps?.find(({ id }) => id === 'set')
-    const job = readWorkflow('build.yml').jobs.build
-    const names = job.steps?.map(({ name }) => name) ?? []
-    const packaged = findStep(job, 'Resolve packaged Electron executable')
-    const p0 = findStep(job, 'Run P0 Electron certification')
-    const visual = findStep(job, 'Run desktop visual regression')
-    const macos = findStep(job, 'Smoke test macOS packages')
-    const linux = findStep(job, 'Smoke test Linux packages')
-    const evidence = findStep(job, 'Record platform certification evidence')
+    const build = readWorkflow('build.yml').jobs.build
+    const buildNames = build.steps?.map(({ name }) => name) ?? []
+    const upload = findStep(build, 'Upload build artifacts')
+    const smokeWorkflow = readWorkflow('package-smoke.yml')
+    const smoke = smokeWorkflow.jobs.smoke
+    const downloadPackage = findStep(smoke, 'Download packaged artifacts')
+    const macos = findStep(smoke, 'Smoke test macOS packages')
+    const windows = findStep(smoke, 'Smoke test Windows installer')
+    const linux = findStep(smoke, 'Smoke test Linux packages')
+    const evidence = findStep(smoke, 'Record platform certification evidence')
+    const uploadEvidence = findStep(smoke, 'Upload platform certification evidence')
+    const regressionWorkflow = readWorkflow('desktop-regression.yml')
+    const regression = regressionWorkflow.jobs.regression
     const notarize = readWorkflow('notarize-mac.yml').jobs.notarize
     const notarizeDryRun = readWorkflow('notarize-dryrun.yml').jobs.notarize
     const finalMacos = findStep(notarize, 'Smoke test final macOS packages')
@@ -164,32 +165,61 @@ describe('post-merge Windows validation', () => {
 
     expect(setup.run).toContain('"name":"macos-arm64","os":"macos-26"')
     expect(setup.run).toContain('"name":"macos-x64","os":"macos-26-intel"')
-    expect(job.env?.MACOSX_DEPLOYMENT_TARGET).toBe(
+    expect(build.env?.MACOSX_DEPLOYMENT_TARGET).toBe(
       "${{ matrix.platform == 'mac' && '12.0' || '' }}"
     )
-    expect(packaged.id).toBe('packaged_app')
-    expect(packaged.run).toContain('Open Science.app/Contents/MacOS/Open Science')
-    expect(packaged.run).toContain('win-unpacked/open-science.exe')
-    expect(packaged.run).toContain('linux-unpacked/open-science')
-    expect(p0.env?.OPEN_SCIENCE_E2E_EXECUTABLE).toBe('${{ steps.packaged_app.outputs.executable }}')
-    expect(visual.env?.OPEN_SCIENCE_E2E_EXECUTABLE).toBe(
-      '${{ steps.packaged_app.outputs.executable }}'
+    expect(buildNames).not.toEqual(
+      expect.arrayContaining([
+        'Run P0 Electron certification',
+        'Run desktop visual regression',
+        'Smoke test macOS packages',
+        'Smoke test Windows installer',
+        'Smoke test Linux packages'
+      ])
     )
-    expect(p0.if).toContain("matrix.name == 'macos-arm64'")
-    expect(visual.if).toContain("matrix.name == 'macos-arm64'")
-    expect(p0.run).toBe('npm run test:e2e:p0')
-    expect(visual.run).toBe('npm run test:e2e:visual')
-    expect(macos.if).toBe("${{ matrix.platform == 'mac' && !inputs.skip_verify }}")
+    expect(upload.if).toBeUndefined()
+    expect(upload.with?.['retention-days']).toBe(7)
+    expect(smoke.strategy?.matrix).toEqual({
+      include: [
+        { name: 'macos-arm64', os: 'macos-26', platform: 'mac' },
+        { name: 'macos-x64', os: 'macos-26-intel', platform: 'mac' },
+        { name: 'linux-x64', os: 'ubuntu-latest', platform: 'linux' },
+        { name: 'windows-x64', os: 'windows-latest', platform: 'win' }
+      ]
+    })
+    expect(downloadPackage.with?.name).toBe('${{ matrix.name }}')
+    expect(downloadPackage.with?.path).toBe('dist')
+    expect(macos.if).toBe("matrix.platform == 'mac'")
     expect(macos.run).toBe('node scripts/macos-package-smoke.mjs --artifact-dir dist')
+    expect(windows.run).toBe('node scripts/windows-installer-smoke.mjs --installer-dir dist')
     expect(linux.run).toContain('scripts/linux-package-smoke.mjs')
-    expect(evidence.run).toContain('package_smoke=passed')
-    expect(evidence.run).toContain('electron_p0=not-applicable')
-    expect(evidence.run).toContain('visual_regression=not-applicable')
-    expect(evidence.run).toContain('--electron-p0 "$electron_p0"')
-    expect(evidence.run).toContain('--visual-regression "$visual_regression"')
-    expect(evidence.run).toContain(
-      '--database-migration-certification dist/database-migration-certification.json'
+    expect(evidence.run).toContain('--electron-p0 not-applicable')
+    expect(evidence.run).toContain('--visual-regression not-applicable')
+    expect(evidence.run).toContain('--package-smoke passed')
+    expect(evidence.run).toContain('database-migration-certification-${{ matrix.name }}.json')
+    expect(evidence.run).toContain('--database-migration-certification "$database_certification"')
+    expect(uploadEvidence.with?.name).toBe('certification-${{ matrix.name }}')
+    expect(uploadEvidence.with?.['retention-days']).toBe(7)
+    expect(regression).toMatchObject({ needs: 'source', 'runs-on': 'macos-26' })
+    expect(regression.if).toBe("needs.source.outputs.available == 'true'")
+    expect(regression['continue-on-error']).toBeUndefined()
+    expect(regression.strategy?.matrix).toEqual({
+      include: [
+        { name: 'p0', command: 'npm run test:e2e:p0' },
+        { name: 'visual', command: 'npm run test:e2e:visual' }
+      ]
+    })
+    expect(findStep(regression, 'Download macOS ARM64 package').with?.name).toBe('macos-arm64')
+    expect(findStep(regression, 'Download macOS ARM64 package').with?.['run-id']).toBe(
+      '${{ needs.source.outputs.run_id }}'
     )
+    expect(findStep(regression, 'Extract packaged application').run).toContain('ditto -x -k')
+    expect(findStep(regression, 'Run packaged desktop regression').run).toBe(
+      '${{ matrix.command }}'
+    )
+    expect(
+      findStep(regression, 'Run packaged desktop regression').env?.OPEN_SCIENCE_E2E_EXECUTABLE
+    ).toBe('${{ steps.packaged_app.outputs.executable }}')
     expect(finalMacos.run).toBe(
       'node scripts/macos-package-smoke.mjs --artifact-dir mac --gatekeeper'
     )
@@ -204,58 +234,56 @@ describe('post-merge Windows validation', () => {
     expect(refreshedMacosEvidence.run).toContain(
       '--database-migration-certification mac/database-migration-certification.json'
     )
-    expect(refreshedMacosEvidence.run).toContain("matrix.arch == 'arm64'")
+    expect(refreshedMacosEvidence.run).toContain('--electron-p0 not-applicable')
+    expect(refreshedMacosEvidence.run).toContain('--visual-regression not-applicable')
     expect(refreshedMacosEvidence.if).toContain('inputs.certified_build')
     expect(notarizeDryRun.with?.certified_build).toBe(false)
-    expect(names.indexOf('Record platform certification evidence')).toBeGreaterThan(
-      names.indexOf('Smoke test macOS packages')
-    )
-    expect(names.indexOf('Record platform certification evidence')).toBeGreaterThan(
-      names.indexOf('Smoke test Linux packages')
-    )
-    expect(names.indexOf('Upload build artifacts')).toBeGreaterThan(
-      names.indexOf('Record platform certification evidence')
-    )
     expect(notarize.steps?.indexOf(refreshedMacosEvidence)).toBeGreaterThan(
       notarize.steps?.indexOf(finalMacos) ?? -1
     )
   })
 
-  it('uploads built packages before enforcing collected certification outcomes', () => {
-    const job = readWorkflow('build.yml').jobs.build
-    const names = job.steps?.map(({ name }) => name) ?? []
-    const packaged = findStep(job, 'Build & package')
-    const p0 = findStep(job, 'Run P0 Electron certification')
-    const visual = findStep(job, 'Run desktop visual regression')
-    const macos = findStep(job, 'Smoke test macOS packages')
-    const windows = findStep(job, 'Smoke test Windows installer')
-    const linux = findStep(job, 'Smoke test Linux packages')
-    const evidence = findStep(job, 'Record platform certification evidence')
-    const upload = findStep(job, 'Upload build artifacts')
-    const enforce = findStep(job, 'Enforce platform certification')
+  it('keeps package smoke blocking while release and nightly regressions are advisory', () => {
+    const release = readWorkflow('release.yml')
+    const nightly = readWorkflow('nightly.yml')
+    const regression = readWorkflow('desktop-regression.yml')
 
-    expect(packaged.id).toBe('package')
-    for (const step of [p0, visual, macos, windows, linux]) {
-      expect(step.id).toBeDefined()
-      expect(step['continue-on-error']).toBe(true)
-    }
-    expect(evidence.if).toContain("steps.p0.outcome == 'success'")
-    expect(evidence.if).toContain("steps.visual.outcome == 'success'")
-    expect(evidence.if).toContain("matrix.name != 'macos-arm64'")
-    expect(evidence.if).toContain("steps.p0.outcome == 'skipped'")
-    expect(evidence.if).toContain("steps.visual.outcome == 'skipped'")
-    expect(upload.if).toBe("${{ always() && steps.package.outcome == 'success' }}")
-    expect(enforce.if).toBe('${{ !inputs.skip_verify && always() }}')
-    expect(enforce.env).toMatchObject({
-      MATRIX_NAME: '${{ matrix.name }}',
-      P0_OUTCOME: '${{ steps.p0.outcome }}',
-      VISUAL_OUTCOME: '${{ steps.visual.outcome }}'
+    expect(release.jobs.build.uses).toBe('./.github/workflows/build.yml')
+    expect(release).toMatchObject({ permissions: { actions: 'read', contents: 'write' } })
+    expect(release.jobs['package-smoke']).toMatchObject({
+      needs: 'build',
+      uses: './.github/workflows/package-smoke.yml'
     })
-    expect(enforce.run).toContain('if [[ "$MATRIX_NAME" == "macos-arm64" ]]')
-    expect(enforce.run).toContain('exit "$failed"')
-    expect(names.indexOf('Upload build artifacts')).toBeLessThan(
-      names.indexOf('Enforce platform certification')
+    expect(release.jobs['notarize-mac'].needs).toEqual(['build', 'package-smoke'])
+    expect(release.jobs.publish.needs).toEqual(['build', 'package-smoke', 'notarize-mac'])
+    expect(nightly.jobs.build.uses).toBe('./.github/workflows/build.yml')
+    expect(nightly.jobs['package-smoke']).toMatchObject({
+      needs: 'build',
+      uses: './.github/workflows/package-smoke.yml'
+    })
+    expect(nightly.jobs.prepare.needs).toEqual(['plan', 'build', 'package-smoke'])
+    expect(regression.on?.workflow_run).toMatchObject({
+      workflows: ['Release', 'Nightly'],
+      types: ['completed']
+    })
+    expect(regression.on).toHaveProperty('workflow_dispatch')
+    expect(regression.on).toHaveProperty('workflow_call')
+    expect(regression.jobs.source.if).toContain(
+      "github.event.workflow_run.event != 'workflow_dispatch'"
     )
+    expect(findStep(regression.jobs.source, 'Resolve source run').run).toContain(
+      '.name == "macos-arm64" and (.expired | not)'
+    )
+    expect(findStep(regression.jobs.source, 'Resolve source run').run).toContain(
+      'EVENT_NAME" = "workflow_dispatch"'
+    )
+    expect(release.jobs['regression-dry-run']).toMatchObject({
+      needs: ['build', 'package-smoke'],
+      if: "github.event_name == 'workflow_dispatch'",
+      uses: './.github/workflows/desktop-regression.yml'
+    })
+    expect(release.jobs.regression).toBeUndefined()
+    expect(nightly.jobs.regression).toBeUndefined()
   })
 
   it('builds every platform without repeating the verified typecheck', () => {
@@ -311,7 +339,7 @@ describe('post-merge Windows validation', () => {
     ).toMatchObject({ id: 'installer', 'continue-on-error': true })
     expect(release.jobs['windows-full-test']).toBeUndefined()
     expect(release.jobs['windows-upgrade-smoke']).toBeUndefined()
-    expect(release.jobs.publish.needs).toEqual(['build', 'notarize-mac'])
+    expect(release.jobs.publish.needs).toEqual(['build', 'package-smoke', 'notarize-mac'])
     expect(
       findStep(release.jobs.publish, 'Aggregate release certification evidence').run
     ).not.toContain('--require-signed-windows')
@@ -429,6 +457,11 @@ describe('post-merge Windows validation', () => {
 
   it('pins external actions in every changed release workflow', () => {
     for (const workflowName of [
+      'build.yml',
+      'desktop-regression.yml',
+      'nightly.yml',
+      'notarize-mac.yml',
+      'package-smoke.yml',
       'release.yml',
       'mirror-to-website.yml',
       'windows-upgrade-smoke.yml'

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -218,9 +218,14 @@ describe('post-merge Windows validation', () => {
     expect(visualRegression.if).toBe("needs.source.outputs.available == 'true'")
     expect(visualRegression['continue-on-error']).toBeUndefined()
     expect(findStep(visualRegression, 'Build Electron application').run).toBe('npm run build:e2e')
-    expect(findStep(visualRegression, 'Run visual regression').run).toBe(
-      'npm run test:e2e:visual -- --fail-on-flaky-tests'
-    )
+    expect(findStep(visualRegression, 'Run visual regression')).toMatchObject({
+      if: "github.event_name != 'workflow_run'",
+      run: 'npm run test:e2e:visual'
+    })
+    expect(findStep(visualRegression, 'Run visual stability regression')).toMatchObject({
+      if: "github.event_name == 'workflow_run'",
+      run: 'npm run test:e2e:visual -- --fail-on-flaky-tests'
+    })
     expect(findStep(visualRegression, 'Upload visual diagnostics').if).toBe('always()')
     expect(finalMacos.run).toBe(
       'node scripts/macos-package-smoke.mjs --artifact-dir mac --gatekeeper'

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -218,12 +218,7 @@ describe('post-merge Windows validation', () => {
     expect(visualRegression.if).toBe("needs.source.outputs.available == 'true'")
     expect(visualRegression['continue-on-error']).toBe('${{ inputs.allow_failure }}')
     expect(findStep(visualRegression, 'Build Electron application').run).toBe('npm run build:e2e')
-    expect(findStep(visualRegression, 'Run visual regression')).toMatchObject({
-      if: "github.event_name != 'workflow_run'",
-      run: 'npm run test:e2e:visual'
-    })
     expect(findStep(visualRegression, 'Run visual stability regression')).toMatchObject({
-      if: "github.event_name == 'workflow_run'",
       run: 'npm run test:e2e:visual -- --fail-on-flaky-tests'
     })
     expect(findStep(visualRegression, 'Upload visual diagnostics').if).toBe('always()')
@@ -269,29 +264,22 @@ describe('post-merge Windows validation', () => {
       uses: './.github/workflows/package-smoke.yml'
     })
     expect(nightly.jobs.prepare.needs).toEqual(['plan', 'build', 'package-smoke'])
-    expect(regression.on?.workflow_run).toMatchObject({
-      workflows: ['Release', 'Nightly'],
-      types: ['completed']
-    })
+    expect(regression.on).not.toHaveProperty('workflow_run')
     expect(regression.on).toHaveProperty('workflow_dispatch')
     expect(regression.on).toHaveProperty('workflow_call')
-    expect(regression.jobs.source.if).toContain(
-      "github.event.workflow_run.event != 'workflow_dispatch'"
-    )
     expect(findStep(regression.jobs.source, 'Resolve source run').run).toContain(
       '.name == "macos-arm64" and (.expired | not)'
     )
-    expect(findStep(regression.jobs.source, 'Resolve source run').run).toContain(
-      'EVENT_NAME" = "workflow_dispatch"'
-    )
-    expect(release.jobs['regression-dry-run']).toMatchObject({
+    expect(release.jobs.regression).toMatchObject({
       needs: ['build', 'package-smoke'],
-      if: "github.event_name == 'workflow_dispatch'",
       uses: './.github/workflows/desktop-regression.yml',
       with: { allow_failure: true }
     })
-    expect(release.jobs.regression).toBeUndefined()
-    expect(nightly.jobs.regression).toBeUndefined()
+    expect(nightly.jobs.regression).toMatchObject({
+      needs: ['build', 'package-smoke'],
+      uses: './.github/workflows/desktop-regression.yml',
+      with: { allow_failure: true }
+    })
   })
 
   it('builds every platform without repeating the verified typecheck', () => {


### PR DESCRIPTION
## Problem

Release packaging, package smoke, P0 certification, and visual regression ran in the same native build jobs. A flaky validation therefore forced installation, signing, and packaging to run again. Run 31577092365 showed this on macOS: packaging and package smoke succeeded, while artifact-provenance receipt parsing repeatedly failed; visual regression also exposed a separate retry-only pixel difference.

## Proposed change

- Build and upload each native package once with seven-day artifact retention.
- Move blocking native package smoke into a reusable four-platform workflow that consumes the immutable artifacts.
- Move packaged P0 and visual regression into independently rerunnable Desktop Regression jobs.
- Keep packaged P0 on macos-26 ARM, while visual uses the canonical macos-14 source-build baseline environment.
- Always upload Playwright diagnostics. Preserve one visual retry; advisory visual runs fail on flaky tests for visibility.
- Keep Release/Nightly publication gated by package smoke, not P0 or visual regression.
- Invoke advisory regression directly from the low-privilege Release/Nightly workflows instead of using a privileged `workflow_run` trigger.

## Scope and non-goals

This change fixes CI retry granularity, runner consistency, and the privileged-workflow cache-poisoning risk reported by CodeQL. It does not claim to fix the underlying artifact-provenance receipt truncation or the visual pixel instability. It does not raise the visual pixel budget. Tagged notarization and publication behavior remain unchanged apart from consuming the new certification artifacts.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Workflow topology and evidence contracts -> `npm test -- --run scripts/ci/release-workflows.test.ts scripts/windows-release-workflows.test.ts scripts/ci/release-certification-evidence.test.ts` -> 3 files, 22 tests passed.
- Workflow syntax -> `actionlint .github/workflows/desktop-regression.yml .github/workflows/release.yml .github/workflows/nightly.yml` -> passed.
- Linted configuration and tests -> `npm run lint -- --concurrency auto` -> 0 errors; 13 pre-existing warnings outside this change.
- Whitespace integrity -> `git diff --check` -> passed.
- Exact-head no-publish Release dry-run -> https://github.com/aipoch/open-science/actions/runs/31588446314 -> overall success on `807fcc78`; verify, all four native builds, and all four blocking package-smoke jobs passed. Visual passed on canonical macos-14. Packaged P0 reproduced the known receipt truncation (the other four P0 tests passed), remained advisory, and did not rebuild or block the dry-run.
- CodeQL Actions analysis -> passed after removing the privileged `workflow_run` entry point.
- Automated Codex review -> mergeable, no actionable findings.

No `src/` files or application logic changed, so the project policy does not require a separate local full `npm test`; the exact-head Release dry-run executed the complete portable verification suite.

Uncovered risks: the tagged notarization/publish path was intentionally not executed by the no-publish dry-run. The provenance parser/test instability and unbundled-font visual instability remain separate follow-up work. The repository currently has a separate Windows workspace fixture outage: multiple unrelated PRs fail the same five tests because the deterministic agent reply is absent; #1142 does not modify application or E2E fixture code.

## Review focus

- Confirm package smoke is the only new publication gate and consumes the exact build artifacts.
- Confirm P0 and visual failures can be retried independently without rebuilding packages.
- Confirm visual baseline ownership stays on macos-14 and no tolerance was relaxed.
- Confirm certification aggregation treats advisory checks as not applicable while retaining blocking package-smoke evidence.
- Confirm regression jobs execute only in the caller's low-privilege context.
