### PR TITLE
feat(cli): support explicit run working directories

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -89,8 +89,20 @@ Provide a prompt directly, read it from a UTF-8 file, or pipe it through stdin:
 ```bash
 open-science run --project "Systematic review" --prompt "Summarize the evidence" --wait
 open-science run --project "Systematic review" --prompt-file ./task.md --wait --json
+open-science run --project "Systematic review" --cwd ./research --prompt-file ./task.md --wait --json
 printf '%s\n' "Summarize the evidence" | open-science run --project "Systematic review" --wait --json
 ```
+
+`--cwd <path>` selects an externally owned working directory for the Session. The CLI resolves a
+relative path from the directory where the command is invoked. Open Science then resolves the real
+path, verifies that it exists, is a directory, and is readable and writable, and persists that
+canonical path on a newly created Session. Open Science does not take ownership of or remove an
+external working directory. Without `--cwd`, Open Science allocates its usual managed workspace.
+
+The working directory is a Session boundary, not a per-Run override. When `--session` and `--cwd`
+are used together, the requested path must resolve to the Session's recorded working directory. A
+different, missing, or otherwise invalid recorded directory is rejected; it is not migrated,
+replaced, or repaired by the Run request.
 
 Without `--wait`, the command returns as soon as the run starts. Use the returned `id` and `sessionId`
 to poll its state:
@@ -132,6 +144,8 @@ The default approval profile is `ask`. Unattended workflows must explicitly use
 
 Use `--json` to emit one result. `--jsonl` requires `run --wait` and emits progress events followed by
 the final run object, one JSON value per line:
+
+Every Run object includes its effective `cwd`; progress events and Session summaries do not.
 
 The event stream includes `run.progress` phase changes and ten-second liveness heartbeats before the
 first visible provider output. Each progress payload includes `runId`, `sessionId`, `projectId`,

--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -15,11 +15,18 @@ const client = await connectToOpenScience()
 const run = await client.startRun({
   project: 'systematic-review',
   prompt: 'Summarize the evidence.',
+  cwd: '/absolute/path/to/research',
   permissionProfile: 'auto'
 })
 const result = await client.waitForRun(run.id)
 console.log(result.output)
 ```
+
+SDK and HTTP callers must supply an absolute `cwd`. Open Science canonicalizes and validates it,
+persists it as the Session working directory, and returns the effective path on every Run. Supplying
+`cwd` with `sessionId` is allowed only when both paths resolve to the same directory. Omit `cwd` to
+use a managed workspace. External working directories remain caller-owned and are never removed by
+Open Science.
 
 For live automation feedback, subscribe before starting the Run. `run.progress` reports ordered
 provider-neutral phases and emits a heartbeat every ten seconds until the first visible provider

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -43,6 +43,7 @@ Options:
   --data-root <path>     Current Data Root override (rollback only)
   --project <id-or-name> Project id or exact name
   --session <id>         Resume an existing session
+  --cwd <path>           Working directory for a new or matching existing session
   --prompt <text>        Prompt text (or read stdin when omitted)
   --prompt-file <path>   Read the prompt from a UTF-8 file
   --approval-profile <profile>  ask, auto, or full (default: ask)
@@ -67,6 +68,7 @@ const VALUE_OPTIONS = {
   '--data-root': 'dataRoot',
   '--project': 'project',
   '--session': 'session',
+  '--cwd': 'cwd',
   '--prompt': 'prompt',
   '--prompt-file': 'promptFile',
   '--approval-profile': 'approvalProfile',
@@ -145,6 +147,12 @@ export const parseCliArgs = (argv) => {
   }
   if (options.json && options.jsonl) {
     throw new CliUsageError('Use only one of --json or --jsonl.')
+  }
+  if (options.cwd !== undefined && !options.cwd.trim()) {
+    throw new CliUsageError('--cwd requires a non-empty path.')
+  }
+  if (options.cwd && (command !== 'run' || subcommand)) {
+    throw new CliUsageError('--cwd requires run.')
   }
   if (options.jsonl && (command !== 'run' || subcommand || !options.wait)) {
     throw new CliUsageError('--jsonl requires run --wait.')
@@ -730,6 +738,7 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
       const started = await client.startRun({
         project: options.project,
         prompt,
+        ...(options.cwd ? { cwd: resolve(options.cwd) } : {}),
         ...(options.session ? { sessionId: options.session } : {}),
         ...(options.approvalProfile ? { permissionProfile: options.approvalProfile } : {}),
         ...(options.skills?.length ? { skillIds: options.skills } : {})

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import { PUBLIC_TERMINAL_FIXTURE } from '../../test/fixtures/renderer-contract-certification'
@@ -21,6 +22,8 @@ describe('task CLI', () => {
         'task.md',
         '--session',
         'session-1',
+        '--cwd',
+        'workspace',
         '--approval-profile',
         'auto',
         '--wait',
@@ -36,6 +39,7 @@ describe('task CLI', () => {
         project: 'systematic-review',
         promptFile: 'task.md',
         session: 'session-1',
+        cwd: 'workspace',
         approvalProfile: 'auto'
       }
     })
@@ -114,6 +118,10 @@ describe('task CLI', () => {
     expect(() => parseCliArgs(['run', '--json', '--jsonl', '--wait'])).toThrow(
       'Use only one of --json or --jsonl.'
     )
+    expect(() => parseCliArgs(['run', 'status', 'run-1', '--cwd', '.'])).toThrow(
+      '--cwd requires run.'
+    )
+    expect(() => parseCliArgs(['run', '--cwd', '   '])).toThrow('--cwd requires a non-empty path.')
     expect(() => parseCliArgs(['status', '--unknown'])).toThrow('Unknown option: --unknown')
   })
 
@@ -139,6 +147,7 @@ describe('task CLI', () => {
         options: {
           project: 'project-1',
           promptFile: 'task.md',
+          cwd: 'workspace',
           approvalProfile: 'auto',
           wait: true,
           json: true,
@@ -156,6 +165,7 @@ describe('task CLI', () => {
     expect(client.startRun).toHaveBeenCalledWith({
       project: 'project-1',
       prompt: 'Research this.',
+      cwd: resolve('workspace'),
       permissionProfile: 'auto'
     })
     expect(client.waitForRun).toHaveBeenCalledWith('run-1')

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -51,6 +51,7 @@ describe('OpenScienceClient', () => {
             id: 'run-1',
             sessionId: 'session-1',
             projectId: 'project-1',
+            cwd: '/workspace/research',
             status: 'running',
             startedAt: 1,
             artifacts: []
@@ -63,6 +64,7 @@ describe('OpenScienceClient', () => {
             id: 'run-1',
             sessionId: 'session-1',
             projectId: 'project-1',
+            cwd: '/workspace/research',
             status: 'running',
             startedAt: 1,
             artifacts: []
@@ -75,6 +77,7 @@ describe('OpenScienceClient', () => {
             id: 'run-1',
             sessionId: 'session-1',
             projectId: 'project-1',
+            cwd: '/workspace/research',
             status: 'completed',
             startedAt: 1,
             completedAt: 2,
@@ -93,12 +96,17 @@ describe('OpenScienceClient', () => {
     const started = await client.startRun({
       project: 'project-1',
       prompt: 'Research this.',
+      cwd: '/workspace/research',
       permissionProfile: 'auto',
       skillIds: ['literature-review']
     })
     const completed = await client.waitForRun(started.id)
 
-    expect(completed).toMatchObject({ status: 'completed', output: 'Done' })
+    expect(completed).toMatchObject({
+      cwd: '/workspace/research',
+      status: 'completed',
+      output: 'Done'
+    })
     expect(fetch).toHaveBeenNthCalledWith(
       1,
       'http://127.0.0.1:44100/api/v1/runs',
@@ -108,6 +116,7 @@ describe('OpenScienceClient', () => {
         body: JSON.stringify({
           project: 'project-1',
           prompt: 'Research this.',
+          cwd: '/workspace/research',
           permissionProfile: 'auto',
           skillIds: ['literature-review']
         })

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -33,6 +33,7 @@ export type Run = {
   id: string
   sessionId: string
   projectId: string
+  cwd: string
   status: RunStatus
   startedAt: number
   cancelRequestedAt?: number
@@ -90,6 +91,7 @@ export class OpenScienceClient {
   startRun(request: {
     project: string
     prompt: string
+    cwd?: string
     sessionId?: string
     permissionProfile?: PermissionProfile
     skillIds?: string[]

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -55,7 +55,11 @@ describe('ACP Task Agent port', () => {
     )
     await expect(port.listAttachedSessionIds()).resolves.toEqual(['session-attached'])
     await expect(
-      port.createSession({ projectId: 'project-1', permissionProfile: 'auto' })
+      port.createSession({
+        projectId: 'project-1',
+        permissionProfile: 'auto',
+        cwd: '/workspace/external'
+      })
     ).resolves.toMatchObject({
       sessionId: 'session-created',
       frameworkId: 'codex',
@@ -88,7 +92,8 @@ describe('ACP Task Agent port', () => {
 
     expect(create).toHaveBeenCalledWith({
       projectName: 'project-1',
-      permissionProfile: 'auto'
+      permissionProfile: 'auto',
+      cwd: '/workspace/external'
     })
     expect(withSessionAvailable).toHaveBeenCalledWith('project-1', 'session-stable', admitted)
     expect(runtime.resumeSession).toHaveBeenCalledWith({

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -56,7 +56,8 @@ const createAcpTaskAgentPort = (
   createSession: (request) =>
     createSessionWorkflow.create({
       projectName: request.projectId,
-      permissionProfile: request.permissionProfile
+      permissionProfile: request.permissionProfile,
+      ...(request.cwd ? { cwd: request.cwd } : {})
     }),
   resumeSession: (request) =>
     runtime.resumeSession({

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { AcpRuntimeEvent } from '../../shared/acp'
 import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
@@ -11,6 +15,14 @@ import {
   type TaskRunnerDependencies,
   type TaskSessionPort
 } from './task-runner'
+
+const temporaryRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  )
+})
 
 const project: Project = {
   id: 'project-1',
@@ -194,12 +206,141 @@ describe('TaskRunner', () => {
         permissionProfile: 'unsafe' as never
       })
     ).rejects.toMatchObject({ code: 'invalid_request' })
+    await expect(
+      runner.startRun({ project: project.id, prompt: 'Research', cwd: 'relative/workspace' })
+    ).rejects.toMatchObject({
+      code: 'invalid_request',
+      message: 'Working directory must be an absolute path.'
+    })
+    await expect(
+      runner.startRun({ project: project.id, prompt: 'Research', cwd: 42 as never })
+    ).rejects.toMatchObject({
+      code: 'invalid_request',
+      message: 'Working directory must be a string.'
+    })
     expect(listedProjects).toBe(false)
   })
 
+  it('rejects missing and non-directory paths before creating an external-workspace Session', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-task-cwd-file-'))
+    temporaryRoots.push(root)
+    const filePath = join(root, 'input.txt')
+    await writeFile(filePath, 'not a directory', 'utf8')
+    const createSession = vi.fn(async () => ({ sessionId: 'must-not-create' }))
+    const runner = createRunner({
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession,
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => undefined
+      }
+    })
+
+    const missingPath = join(root, 'missing')
+    await expect(
+      runner.startRun({
+        project: project.id,
+        prompt: 'Research in a missing directory.',
+        cwd: missingPath
+      })
+    ).rejects.toMatchObject({
+      code: 'invalid_request',
+      message: `Working directory does not exist: ${missingPath}`
+    })
+
+    await expect(
+      runner.startRun({
+        project: project.id,
+        prompt: 'Research this file.',
+        cwd: filePath
+      })
+    ).rejects.toMatchObject({
+      code: 'invalid_request',
+      message: `Working directory is not a directory: ${filePath}`
+    })
+    expect(createSession).not.toHaveBeenCalled()
+  })
+
+  it('rejects a cwd that conflicts with an existing Session workspace', async () => {
+    const existingRoot = await mkdtemp(join(tmpdir(), 'open-science-task-existing-cwd-'))
+    const requestedRoot = await mkdtemp(join(tmpdir(), 'open-science-task-requested-cwd-'))
+    temporaryRoots.push(existingRoot, requestedRoot)
+    const existing = { ...session, cwd: existingRoot }
+    const withSessionAvailable = vi.fn(async (_projectId, _sessionId, operation) => operation())
+    const runner = createRunner({
+      sessions: { list: async () => [existing], save: async () => undefined },
+      agent: {
+        withSessionAvailable,
+        listAttachedSessionIds: async () => [existing.id],
+        createSession: async () => ({ sessionId: 'must-not-create' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => undefined
+      }
+    })
+
+    await expect(
+      runner.startRun({
+        project: project.id,
+        sessionId: existing.id,
+        prompt: 'Continue elsewhere.',
+        cwd: requestedRoot
+      })
+    ).rejects.toMatchObject({
+      code: 'invalid_request',
+      message: `Working directory does not match Session ${existing.id}.`
+    })
+    expect(withSessionAvailable).not.toHaveBeenCalled()
+  })
+
+  it('keeps an existing explicit workspace spelling when cwd resolves to the same directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-task-equivalent-cwd-'))
+    temporaryRoots.push(root)
+    await mkdir(join(root, 'nested'))
+    const existingCwd = `${root}${sep}nested${sep}..`
+    const existing = { ...session, cwd: existingCwd }
+    const savedSessions: PersistedChatSession[] = []
+    const runner = createRunner({
+      sessions: {
+        list: async () => [existing],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [existing.id],
+        createSession: async () => ({ sessionId: 'must-not-create' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => undefined
+      }
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'Continue in place.',
+      cwd: root
+    })
+    expect(started.cwd).toBe(existingCwd)
+
+    await runner.waitForRun(started.id)
+    expect(savedSessions.at(-1)?.cwd).toBe(existingCwd)
+  })
+
   it('runs a prompt in a new durable session and returns the assistant output', async () => {
+    const requestedCwd = await mkdtemp(join(tmpdir(), 'open-science-task-cwd-'))
+    temporaryRoots.push(requestedCwd)
+    const canonicalCwd = await realpath(requestedCwd)
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
     const savedSessions: PersistedChatSession[] = []
+    const createRequests: unknown[] = []
     const ids = ['user-message-1', 'run-1', 'assistant-message-1']
     const runner = createRunner({
       sessions: {
@@ -211,12 +352,15 @@ describe('TaskRunner', () => {
       agent: {
         withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
         listAttachedSessionIds: async () => [],
-        createSession: async () => ({
-          sessionId: 'session-1',
-          cwd: '/workspace/session-1',
-          frameworkId: 'codex',
-          backendId: 'codex:shared'
-        }),
+        createSession: async (request) => {
+          createRequests.push(request)
+          return {
+            sessionId: 'session-1',
+            cwd: canonicalCwd,
+            frameworkId: 'codex',
+            backendId: 'codex:shared'
+          }
+        },
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
         cancelPrompt: async () => undefined,
@@ -254,22 +398,30 @@ describe('TaskRunner', () => {
     const started = await runner.startRun({
       project: project.name,
       prompt: 'Review these papers.',
-      permissionProfile: 'auto'
+      permissionProfile: 'auto',
+      cwd: requestedCwd
     })
     expect(started).toMatchObject({
       id: 'run-1',
       sessionId: 'session-1',
       projectId: project.id,
-      status: 'running'
+      status: 'running',
+      cwd: canonicalCwd
     })
+
+    expect(createRequests).toEqual([
+      { projectId: project.id, permissionProfile: 'auto', cwd: canonicalCwd }
+    ])
 
     await expect(runner.waitForRun('run-1')).resolves.toMatchObject({
       status: 'completed',
-      output: 'Research complete.'
+      output: 'Research complete.',
+      cwd: canonicalCwd
     })
     expect(savedSessions.at(-1)).toMatchObject({
       id: 'session-1',
       projectId: project.id,
+      cwd: canonicalCwd,
       status: 'idle',
       permissionProfile: 'auto',
       messages: [
@@ -282,6 +434,69 @@ describe('TaskRunner', () => {
         }
       ]
     })
+  })
+
+  it('keeps concurrent external-workspace Sessions isolated by canonical cwd', async () => {
+    const requestedCwds = await Promise.all([
+      mkdtemp(join(tmpdir(), 'open-science-task-concurrent-a-')),
+      mkdtemp(join(tmpdir(), 'open-science-task-concurrent-b-'))
+    ])
+    temporaryRoots.push(...requestedCwds)
+    const canonicalCwds = await Promise.all(requestedCwds.map((cwd) => realpath(cwd)))
+    const sessionIdByCwd = new Map([
+      [canonicalCwds[0], 'session-a'],
+      [canonicalCwds[1], 'session-b']
+    ])
+    const createRequests: Array<{ projectId: string; permissionProfile: string; cwd?: string }> = []
+    const savedSessions: PersistedChatSession[] = []
+    let nextId = 0
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async (request) => {
+          createRequests.push(request)
+          return {
+            sessionId: sessionIdByCwd.get(request.cwd ?? '') ?? 'unexpected-session',
+            cwd: request.cwd
+          }
+        },
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => undefined
+      },
+      createId: () => `generated-${++nextId}`
+    })
+
+    const started = await Promise.all(
+      requestedCwds.map((cwd, index) =>
+        runner.startRun({ project: project.id, prompt: `Research stream ${index + 1}.`, cwd })
+      )
+    )
+    const completed = await Promise.all(started.map((run) => runner.waitForRun(run.id)))
+
+    expect(createRequests).toEqual(
+      expect.arrayContaining(
+        canonicalCwds.map((cwd) => ({ projectId: project.id, permissionProfile: 'ask', cwd }))
+      )
+    )
+    for (const [index, cwd] of canonicalCwds.entries()) {
+      const sessionId = sessionIdByCwd.get(cwd)
+      expect(started[index]).toMatchObject({ sessionId, cwd })
+      expect(completed[index]).toMatchObject({ sessionId, cwd, status: 'completed' })
+      expect(savedSessions.findLast((saved) => saved.id === sessionId)).toMatchObject({
+        id: sessionId,
+        cwd,
+        status: 'idle'
+      })
+    }
   })
 
   it('publishes ordered Run progress from acceptance through completion', async () => {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -1,3 +1,7 @@
+import { constants } from 'node:fs'
+import { access, realpath, stat } from 'node:fs/promises'
+import { isAbsolute } from 'node:path'
+
 import type { AcpRuntimeEvent } from '../../shared/acp'
 import {
   getAcpRuntimeEventImage,
@@ -68,6 +72,7 @@ type TaskAgentSession = {
 type TaskAgentCreateSessionRequest = {
   projectId: string
   permissionProfile: PermissionProfileId
+  cwd?: string
 }
 
 type TaskAgentResumeSessionRequest = {
@@ -177,6 +182,7 @@ const cloneRun = (run: MutableTaskRun): TaskRun => ({
   id: run.id,
   sessionId: run.sessionId,
   projectId: run.projectId,
+  cwd: run.cwd,
   status: run.status,
   startedAt: run.startedAt,
   cancelRequestedAt: run.cancelRequestedAt,
@@ -271,6 +277,52 @@ class TaskRunnerError extends Error {
   }
 }
 
+const isMissingPathError = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
+
+const canonicalizeTaskWorkingDirectory = async (value: string): Promise<string> => {
+  const cwd = value.trim()
+  if (!cwd) {
+    throw new TaskRunnerError(
+      'invalid_request',
+      'Working directory is required when cwd is supplied.'
+    )
+  }
+  if (!isAbsolute(cwd)) {
+    throw new TaskRunnerError('invalid_request', 'Working directory must be an absolute path.')
+  }
+  let canonicalCwd: string
+  try {
+    canonicalCwd = await realpath(cwd)
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      throw new TaskRunnerError('invalid_request', `Working directory does not exist: ${cwd}`)
+    }
+    throw new TaskRunnerError('invalid_request', `Working directory is not accessible: ${cwd}`)
+  }
+  let metadata: Awaited<ReturnType<typeof stat>>
+  try {
+    metadata = await stat(canonicalCwd)
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      throw new TaskRunnerError('invalid_request', `Working directory does not exist: ${cwd}`)
+    }
+    throw new TaskRunnerError('invalid_request', `Working directory is not accessible: ${cwd}`)
+  }
+  if (!metadata.isDirectory()) {
+    throw new TaskRunnerError('invalid_request', `Working directory is not a directory: ${cwd}`)
+  }
+  try {
+    await access(canonicalCwd, constants.R_OK | constants.W_OK)
+  } catch {
+    throw new TaskRunnerError(
+      'invalid_request',
+      `Working directory must be readable and writable: ${cwd}`
+    )
+  }
+  return canonicalCwd
+}
+
 class TaskRunner {
   private readonly runs = new Map<string, MutableTaskRun>()
   private readonly activeRunBySession = new Map<string, string>()
@@ -359,6 +411,9 @@ class TaskRunner {
     if (request.sessionId !== undefined && typeof request.sessionId !== 'string') {
       throw new TaskRunnerError('invalid_request', 'Session id must be a string.')
     }
+    if (request.cwd !== undefined && typeof request.cwd !== 'string') {
+      throw new TaskRunnerError('invalid_request', 'Working directory must be a string.')
+    }
     if (
       request.permissionProfile !== undefined &&
       !['ask', 'auto', 'full'].includes(request.permissionProfile)
@@ -374,6 +429,9 @@ class TaskRunner {
     }
     const prompt = typeof request.prompt === 'string' ? request.prompt.trim() : ''
     if (!prompt) throw new TaskRunnerError('invalid_request', 'Prompt is required.')
+    const cwd =
+      request.cwd === undefined ? undefined : await canonicalizeTaskWorkingDirectory(request.cwd)
+    const normalizedRequest: StartTaskRunRequest = cwd === undefined ? request : { ...request, cwd }
 
     const project = await this.resolveProject(request.project)
     const sessions = await this.dependencies.sessions.list()
@@ -389,13 +447,22 @@ class TaskRunner {
         `Session ${existing.id} does not belong to project ${project.id}.`
       )
     }
+    if (existing && cwd !== undefined) {
+      const existingCwd = await canonicalizeTaskWorkingDirectory(existing.cwd)
+      if (cwd !== existingCwd) {
+        throw new TaskRunnerError(
+          'invalid_request',
+          `Working directory does not match Session ${existing.id}.`
+        )
+      }
+    }
     const userMessageId = this.dependencies.createId()
     const runId = this.dependencies.createId()
     if (existing) this.reserveSession(existing.id, runId)
     let prepared: Awaited<ReturnType<TaskRunner['prepareSession']>>
     try {
       const prepare = (): ReturnType<TaskRunner['prepareSession']> =>
-        this.prepareSession(project, existing, request, prompt, userMessageId)
+        this.prepareSession(project, existing, normalizedRequest, prompt, userMessageId)
       prepared = existing
         ? await this.dependencies.agent.withSessionAvailable(project.id, existing.id, prepare)
         : await prepare()
@@ -409,6 +476,7 @@ class TaskRunner {
       id: runId,
       sessionId: session.id,
       projectId: project.id,
+      cwd: session.cwd,
       status: 'running' as const,
       startedAt: this.dependencies.now(),
       artifacts: [],
@@ -428,7 +496,7 @@ class TaskRunner {
     run.completion = this.executeRun(
       run,
       session,
-      request,
+      normalizedRequest,
       prompt,
       prepared.historyPreamble,
       prepared.contextReset,
@@ -546,7 +614,8 @@ class TaskRunner {
     } else {
       sessionInfo = await this.dependencies.agent.createSession({
         projectId: project.id,
-        permissionProfile
+        permissionProfile,
+        ...(request.cwd ? { cwd: request.cwd } : {})
       })
     }
 
@@ -570,7 +639,7 @@ class TaskRunner {
           id: sessionInfo.sessionId,
           projectId: project.id,
           title: createTitle(prompt),
-          cwd: sessionInfo.cwd ?? '',
+          cwd: request.cwd ?? sessionInfo.cwd ?? '',
           status: 'running',
           permissionProfile,
           agentFrameworkId: sessionInfo.frameworkId,

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -707,6 +707,7 @@ describe('startWebHttpServer', () => {
         id: 'run-1',
         sessionId: 'session-1',
         projectId: 'project-1',
+        cwd: '/workspace/research',
         status: 'running' as const,
         startedAt: 1,
         artifacts: []
@@ -1267,6 +1268,7 @@ describe('startWebHttpServer', () => {
         id: 'run-1',
         sessionId: 'session-1',
         projectId: 'project-1',
+        cwd: '/workspace/research',
         status: 'running',
         startedAt: 1,
         artifacts: []
@@ -1275,6 +1277,7 @@ describe('startWebHttpServer', () => {
         id: 'run-1',
         sessionId: 'session-1',
         projectId: 'project-1',
+        cwd: '/workspace/research',
         status: 'completed',
         startedAt: 1,
         completedAt: 2,
@@ -1285,6 +1288,7 @@ describe('startWebHttpServer', () => {
         id: 'run/1',
         sessionId: 'session-1',
         projectId: 'project-1',
+        cwd: '/workspace/research',
         status: 'cancelled',
         startedAt: 1,
         cancelRequestedAt: 2,
@@ -1397,14 +1401,22 @@ describe('startWebHttpServer', () => {
       body: JSON.stringify({
         project: 'project-1',
         prompt: 'Research this.',
+        cwd: '/workspace/research',
         permissionProfile: 'auto'
       })
     })
     expect(started.status).toBe(202)
-    expect(await started.json()).toMatchObject({ data: { id: 'run-1', status: 'running' } })
+    expect(await started.json()).toMatchObject({
+      data: {
+        id: 'run-1',
+        cwd: '/workspace/research',
+        status: 'running'
+      }
+    })
     expect(tasks.startRun).toHaveBeenCalledWith({
       project: 'project-1',
       prompt: 'Research this.',
+      cwd: '/workspace/research',
       permissionProfile: 'auto'
     })
 

--- a/src/shared/renderer-surface-matrix.test.ts
+++ b/src/shared/renderer-surface-matrix.test.ts
@@ -30,6 +30,7 @@ import { isWebRpcChannel, isWebRpcEventChannel } from './web-rpc-contract'
 const TASK_RUN_REQUEST_FIELDS = {
   project: true,
   prompt: true,
+  cwd: true,
   sessionId: true,
   permissionProfile: true,
   skillIds: true
@@ -214,6 +215,7 @@ describe('renderer surface compatibility matrix', () => {
       )
     ).toBe(false)
     expect(Object.keys(TASK_RUN_REQUEST_FIELDS).sort()).toEqual([
+      'cwd',
       'permissionProfile',
       'project',
       'prompt',

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -29,6 +29,7 @@ export type StartTaskRunRequest = {
   project: string
   prompt: string
   sessionId?: string
+  cwd?: string
   permissionProfile?: PermissionProfileId
   skillIds?: string[]
 }
@@ -37,6 +38,7 @@ export type TaskRun = {
   id: string
   sessionId: string
   projectId: string
+  cwd: string
   status: TaskRunStatus
   startedAt: number
   cancelRequestedAt?: number


### PR DESCRIPTION
## Problem

CLI and automation callers cannot currently choose the working directory used by a new Open Science Session. Runs therefore always allocate a managed workspace, even when the caller already owns the intended research directory.

Closes #1135

## Approach

- Add optional `cwd` support to the CLI, SDK, HTTP request, and shared Task API contract.
- Resolve relative CLI paths client-side; require absolute paths from SDK and HTTP callers.
- Validate, canonicalize, and persist explicit paths in the Task owner before crossing the Agent port.
- Treat the working directory as a durable Session boundary. A resumed Session accepts an explicit path only when it resolves to the recorded directory.
- Reuse the existing ACP explicit-workspace path so caller-owned directories bypass managed allocation.
- Return the effective `cwd` on every Run while leaving progress events and Session summaries unchanged.

No data migration or ownership field is introduced. Existing valid external workspaces remain usable, canonical-equivalent paths are accepted without rewriting the stored spelling, and invalid historical paths are rejected rather than adopted or repaired.

## User-visible behavior

```bash
open-science run \
  --project "Systematic review" \
  --cwd ./research \
  --prompt-file ./task.md \
  --wait \
  --json
```

Omitting `--cwd` preserves managed-workspace allocation. Whitespace-only, missing, inaccessible, non-directory, or conflicting paths fail with an `invalid_request` error. Open Science never removes an externally owned working directory.

## Validation

All listed checks ran after the final material edit.

- Working-directory validation, canonical persistence, resume conflicts, managed fallback, ACP forwarding, and concurrent Session isolation ? `npm test -- src/main/tasks/task-runner.test.ts src/main/acp/task-agent-port.test.ts src/main/acp/create-session-workflow.test.ts packages/open-science/cli.test.ts packages/open-science/client.test.ts src/main/web-service/http-server.test.ts src/shared/renderer-surface-matrix.test.ts` ? 7 files, 92 tests passed.
- Node and Web public contracts ? `npm run typecheck` ? passed.
- Source and documentation style ? `npm run lint` ? passed with 0 errors; 13 pre-existing warnings outside this diff.
- Complete portable suite ? `npm test` ? not green in the current Windows environment. Failures are outside this feature slice and include Windows symlink-permission errors, stale Prisma test-schema failures, and unrelated timeouts; a representative storage failure reproduces in the unmodified main worktree.
- Independent Standards and Spec reviews of the final commit ? passed with no remaining actionable findings.

The new path/concurrency test is portable and ran locally on Windows. Existing PR unit lanes provide macOS execution; direct Linux execution remains CI evidence rather than local evidence.

## Review focus

- Session-level semantics when both `sessionId` and `cwd` are supplied.
- Canonical comparison without rewriting existing valid Session data.
- Public Run response compatibility across CLI, SDK, and HTTP.
- Preservation of managed-workspace allocation when `cwd` is omitted.
