### PR TITLE
feat(conversation): add first-message scroll control

### DIFF
--- a/src/renderer/src/components/ui/message-scroller.test.tsx
+++ b/src/renderer/src/components/ui/message-scroller.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   MessageScroller,
+  MessageScrollerButton,
   MessageScrollerContent,
   MessageScrollerItem,
   MessageScrollerProvider,
@@ -52,5 +53,49 @@ describe('MessageScrollerItem', () => {
     expect(stableItem?.className).toContain('[contain-intrinsic-size:auto_10rem]')
     expect(streamingItem?.className).not.toContain('content-visibility')
     expect(streamingItem?.className).not.toContain('contain-intrinsic-size')
+  })
+
+  it('scrolls the viewport to the start from a start-direction button', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(
+        <MessageScrollerProvider>
+          <MessageScroller>
+            <MessageScrollerViewport>
+              <MessageScrollerContent>
+                <MessageScrollerItem messageId="first-message">First message</MessageScrollerItem>
+              </MessageScrollerContent>
+            </MessageScrollerViewport>
+            <MessageScrollerButton direction="start">First message</MessageScrollerButton>
+          </MessageScroller>
+        </MessageScrollerProvider>
+      )
+    })
+
+    const viewport = container.querySelector<HTMLElement>('[data-slot="message-scroller-viewport"]')
+    const button = container.querySelector<HTMLButtonElement>(
+      '[data-slot="message-scroller-button"]'
+    )
+    expect(viewport).not.toBeNull()
+    expect(button).not.toBeNull()
+
+    Object.defineProperties(viewport, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 600 },
+      scrollTop: { configurable: true, writable: true, value: 160 }
+    })
+    const scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      if (typeof top === 'number' && viewport) viewport.scrollTop = top
+    })
+    Object.defineProperty(viewport, 'scrollTo', { configurable: true, value: scrollTo })
+
+    await act(async () => viewport?.dispatchEvent(new Event('scroll', { bubbles: true })))
+    expect(button?.dataset.active).toBe('true')
+
+    await act(async () => button?.click())
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -2081,7 +2081,15 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
     root = createRoot(container)
     await render('idle')
-    expect(container.querySelector('[aria-label="Scroll to first message"]')).not.toBeNull()
+    const firstMessageButton = container.querySelector('[aria-label="Scroll to first message"]')
+    const lastMessageButton = container.querySelector('[data-direction="end"]')
+    expect(firstMessageButton).not.toBeNull()
+    expect(lastMessageButton).not.toBeNull()
+    for (const button of [firstMessageButton, lastMessageButton]) {
+      expect(button?.classList.contains('border-transparent')).toBe(true)
+      expect(button?.classList.contains('shadow-card')).toBe(true)
+      expect(button?.classList.contains('border-border-200')).toBe(false)
+    }
 
     for (const status of [
       'running',

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -91,7 +91,17 @@ vi.mock('@/components/ui/message-scroller', () => {
   }: PropsWithChildren<{ messageId?: string }>): React.JSX.Element => (
     <div data-message-id={messageId}>{children}</div>
   )
-  const Button = (): React.JSX.Element => <button type="button">Scroll to end</button>
+  const Button = ({
+    children,
+    direction = 'end',
+    ...props
+  }: PropsWithChildren<
+    React.ButtonHTMLAttributes<HTMLButtonElement> & { direction?: 'start' | 'end' }
+  >): React.JSX.Element => (
+    <button type="button" data-direction={direction} {...props}>
+      {children ?? `Scroll to ${direction}`}
+    </button>
+  )
 
   return {
     MessageScrollerProvider: Wrapper,
@@ -2054,6 +2064,37 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     // The find bar is an Electron overlay owned by main; the Workspace's only job is to announce it is
     // mounted and searchable so main intercepts Cmd/Ctrl+F.
     expect(announceWindowFindReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers scrolling to the first message only while the Session is idle or terminal', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const render = async (status: ChatSession['status']): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <WorkspaceMessageScroller
+            activeSession={createSession({ status })}
+            onSendEditedMessage={vi.fn()}
+          />
+        )
+      })
+    }
+
+    root = createRoot(container)
+    await render('idle')
+    expect(container.querySelector('[aria-label="Scroll to first message"]')).not.toBeNull()
+
+    for (const status of [
+      'running',
+      'waiting-for-user',
+      'waiting-permission',
+      'waiting-plan-approval'
+    ] as const) {
+      await render(status)
+      expect(container.querySelector('[aria-label="Scroll to first message"]')).toBeNull()
+    }
+
+    await render('error')
+    expect(container.querySelector('[aria-label="Scroll to first message"]')).not.toBeNull()
   })
 
   it('does not write to the preview store for non-managed-file artifacts', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, useCallback, useEffect } from 'react'
+import { act, forwardRef, useCallback, useEffect } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { PropsWithChildren } from 'react'
 import {
@@ -85,6 +85,26 @@ vi.mock('@/components/streamdown/AgentMarkdown', () => ({
 
 vi.mock('@/components/ui/message-scroller', () => {
   const Wrapper = ({ children }: PropsWithChildren): React.JSX.Element => <div>{children}</div>
+  const Viewport = forwardRef<
+    HTMLDivElement,
+    PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>
+  >(function MockMessageScrollerViewport({ children, ...props }, ref) {
+    return (
+      <div ref={ref} data-testid="message-scroller-viewport" {...props}>
+        {children}
+      </div>
+    )
+  })
+  const Content = forwardRef<
+    HTMLDivElement,
+    PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>
+  >(function MockMessageScrollerContent({ children, ...props }, ref) {
+    return (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    )
+  })
   const Item = ({
     children,
     messageId
@@ -106,8 +126,8 @@ vi.mock('@/components/ui/message-scroller', () => {
   return {
     MessageScrollerProvider: Wrapper,
     MessageScroller: Wrapper,
-    MessageScrollerViewport: Wrapper,
-    MessageScrollerContent: Wrapper,
+    MessageScrollerViewport: Viewport,
+    MessageScrollerContent: Content,
     MessageScrollerItem: Item,
     MessageScrollerButton: Button
   }
@@ -2066,21 +2086,51 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(announceWindowFindReady).toHaveBeenCalledTimes(1)
   })
 
-  it('offers scrolling to the first message only while the Session is idle or terminal', async () => {
+  it('offers scrolling to the first message only for long, sufficiently scrolled idle Sessions', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
-    const render = async (status: ChatSession['status']): Promise<void> => {
+    const messages = [
+      createMessage({ id: 'prompt-1' }),
+      createMessage({ id: 'reply-1', role: 'agent' }),
+      createMessage({ id: 'prompt-2' }),
+      createMessage({ id: 'reply-2', role: 'agent' })
+    ]
+    const render = async (
+      status: ChatSession['status'],
+      sessionMessages: ChatMessage[] = messages
+    ): Promise<void> => {
       await act(async () => {
         root.render(
           <WorkspaceMessageScroller
-            activeSession={createSession({ status })}
+            activeSession={createSession({ status, messages: sessionMessages })}
             onSendEditedMessage={vi.fn()}
           />
         )
       })
     }
+    const scrollTo = async (
+      scrollTop: number,
+      { clientHeight = 400, scrollHeight = 1000 } = {}
+    ): Promise<void> => {
+      const viewport = container.querySelector<HTMLElement>(
+        '[data-testid="message-scroller-viewport"]'
+      )
+      Object.defineProperties(viewport, {
+        clientHeight: { configurable: true, value: clientHeight },
+        scrollHeight: { configurable: true, value: scrollHeight },
+        scrollTop: { configurable: true, writable: true, value: scrollTop }
+      })
+      await act(async () => viewport?.dispatchEvent(new Event('scroll', { bubbles: true })))
+    }
 
     root = createRoot(container)
     await render('idle')
+    await scrollTo(0, { clientHeight: 400, scrollHeight: 400 })
+    expect(container.querySelector('[aria-label="Scroll to first message"]')).toBeNull()
+
+    await scrollTo(59)
+    expect(container.querySelector('[aria-label="Scroll to first message"]')).toBeNull()
+
+    await scrollTo(60)
     const firstMessageButton = container.querySelector('[aria-label="Scroll to first message"]')
     const lastMessageButton = container.querySelector('[data-direction="end"]')
     expect(firstMessageButton).not.toBeNull()
@@ -2091,6 +2141,16 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       expect(button?.classList.contains('border-border-200')).toBe(false)
     }
 
+    await scrollTo(400, { clientHeight: 400, scrollHeight: 10_000 })
+    expect(container.querySelector('[aria-label="Scroll to first message"]')).not.toBeNull()
+
+    await render('idle', messages.slice(0, 2))
+    await scrollTo(200, { clientHeight: 400, scrollHeight: 700 })
+    expect(container.querySelector('[aria-label="Scroll to first message"]')).toBeNull()
+
+    await scrollTo(40, { clientHeight: 400, scrollHeight: 800 })
+    expect(container.querySelector('[aria-label="Scroll to first message"]')).not.toBeNull()
+
     for (const status of [
       'running',
       'waiting-for-user',
@@ -2098,10 +2158,12 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       'waiting-plan-approval'
     ] as const) {
       await render(status)
+      await scrollTo(400)
       expect(container.querySelector('[aria-label="Scroll to first message"]')).toBeNull()
     }
 
     await render('error')
+    await scrollTo(60)
     expect(container.querySelector('[aria-label="Scroll to first message"]')).not.toBeNull()
   })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -2096,12 +2096,13 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     ]
     const render = async (
       status: ChatSession['status'],
-      sessionMessages: ChatMessage[] = messages
+      sessionMessages: ChatMessage[] = messages,
+      overrides: Partial<ChatSession> = {}
     ): Promise<void> => {
       await act(async () => {
         root.render(
           <WorkspaceMessageScroller
-            activeSession={createSession({ status, messages: sessionMessages })}
+            activeSession={createSession({ status, messages: sessionMessages, ...overrides })}
             onSendEditedMessage={vi.fn()}
           />
         )
@@ -2150,6 +2151,10 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
     await scrollTo(40, { clientHeight: 400, scrollHeight: 800 })
     expect(container.querySelector('[aria-label="Scroll to first message"]')).not.toBeNull()
+
+    await render('idle', messages, { compacting: true })
+    await scrollTo(400)
+    expect(container.querySelector('[aria-label="Scroll to first message"]')).toBeNull()
 
     for (const status of [
       'running',

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1,3 +1,4 @@
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
 import {
   MessageScroller,
   MessageScrollerButton,
@@ -993,14 +994,14 @@ const WorkspaceMessageScrollerImpl = ({
               direction="start"
               aria-label="Scroll to first message"
               size="default"
-              className="z-20 min-h-11 rounded-full border-border-200 bg-bg-000 px-4 text-sm shadow-card hover:bg-bg-200 data-[direction=start]:top-3"
+              className="z-20 min-h-11 rounded-full border-transparent bg-bg-000 px-4 text-sm shadow-card hover:bg-bg-200 data-[direction=start]:top-3"
             >
               <ArrowDownIcon aria-hidden="true" />
               <span>First message</span>
             </MessageScrollerButton>
           ) : null}
 
-          <MessageScrollerButton className="z-10 border-border-200 bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3" />
+          <MessageScrollerButton className="z-10 border-transparent bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3" />
 
           {/* Transient warning shown when a mention target no longer resolves to a file or skill. */}
           {mentionNotice ? (

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -24,6 +24,7 @@ import {
   type ComponentProps,
   type ReactNode
 } from 'react'
+import { ArrowDownIcon } from 'lucide-react'
 
 import { getAgentLoadingPhase } from './agent-loading-message'
 import {
@@ -276,6 +277,11 @@ const WorkspaceMessageScrollerImpl = ({
 }: WorkspaceMessageScrollerProps): React.JSX.Element => {
   const currentSessionId = activeSession?.id
   const currentProjectId = activeSession?.projectId
+  const showScrollToFirstMessage = Boolean(
+    activeSession &&
+    activeSession.status !== 'running' &&
+    !activeSession.status.startsWith('waiting-')
+  )
   const activeConversationFrame = activeSession?.conversationGraph?.frames.find(
     (frame) => frame.id === activeSession.conversationGraph?.activeFrameId
   )
@@ -981,6 +987,18 @@ const WorkspaceMessageScrollerImpl = ({
               </div>
             </MessageScrollerContent>
           </MessageScrollerViewport>
+
+          {showScrollToFirstMessage ? (
+            <MessageScrollerButton
+              direction="start"
+              aria-label="Scroll to first message"
+              size="default"
+              className="z-20 min-h-11 rounded-full border-border-200 bg-bg-000 px-4 text-sm shadow-card hover:bg-bg-200 data-[direction=start]:top-3"
+            >
+              <ArrowDownIcon aria-hidden="true" />
+              <span>First message</span>
+            </MessageScrollerButton>
+          ) : null}
 
           <MessageScrollerButton className="z-10 border-border-200 bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3" />
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -285,7 +285,8 @@ const WorkspaceMessageScrollerImpl = ({
   const statusAllowsScrollToFirstMessage = Boolean(
     activeSession &&
     activeSession.status !== 'running' &&
-    !activeSession.status.startsWith('waiting-')
+    !activeSession.status.startsWith('waiting-') &&
+    !activeSession.compacting
   )
   const messageScrollerViewportRef = useRef<HTMLDivElement | null>(null)
   const messageScrollerContentRef = useRef<HTMLDivElement | null>(null)

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -122,6 +122,10 @@ const VisibleMessageSnapshotCommit = ({
 
 type MessageUploadAttachment = NonNullable<ChatSession['messages'][number]['uploads']>[number]
 const conversationContentClassName = 'relative mx-auto w-full max-w-4xl pb-[56px]'
+const SCROLL_TO_FIRST_MESSAGE_MIN_USER_TURNS = 2
+const SCROLL_TO_FIRST_MESSAGE_MIN_HEIGHT_VIEWPORTS = 2
+const SCROLL_TO_FIRST_MESSAGE_MIN_PROGRESS = 0.1
+const SCROLL_TO_FIRST_MESSAGE_MIN_DISTANCE_VIEWPORTS = 1
 // How long a "no longer available" mention notice stays visible before auto-dismissing.
 const MENTION_NOTICE_TIMEOUT_MS = 3000
 
@@ -278,11 +282,14 @@ const WorkspaceMessageScrollerImpl = ({
 }: WorkspaceMessageScrollerProps): React.JSX.Element => {
   const currentSessionId = activeSession?.id
   const currentProjectId = activeSession?.projectId
-  const showScrollToFirstMessage = Boolean(
+  const statusAllowsScrollToFirstMessage = Boolean(
     activeSession &&
     activeSession.status !== 'running' &&
     !activeSession.status.startsWith('waiting-')
   )
+  const messageScrollerViewportRef = useRef<HTMLDivElement | null>(null)
+  const messageScrollerContentRef = useRef<HTMLDivElement | null>(null)
+  const [scrollThresholdAllowsFirstMessage, setScrollThresholdAllowsFirstMessage] = useState(false)
   const activeConversationFrame = activeSession?.conversationGraph?.frames.find(
     (frame) => frame.id === activeSession.conversationGraph?.activeFrameId
   )
@@ -391,12 +398,51 @@ const WorkspaceMessageScrollerImpl = ({
   const presentationBarrierIndex = conversationItems.findIndex(
     (item) => item.type === 'message' && presentingMessageIds.has(item.message.id)
   )
-  const visibleMessageIds = (
+  const presentedConversationItems =
     presentationBarrierIndex >= 0
       ? conversationItems.slice(0, presentationBarrierIndex + 1)
       : conversationItems
-  ).flatMap((item) => (item.type === 'message' ? [item.message.id] : []))
+  const visibleMessageIds = presentedConversationItems.flatMap((item) =>
+    item.type === 'message' ? [item.message.id] : []
+  )
   const visibleMessageIdsKey = JSON.stringify(visibleMessageIds)
+  const userTurnCount = presentedConversationItems.filter(
+    (item) => item.type === 'message' && item.message.role === 'user'
+  ).length
+  const updateScrollToFirstMessageVisibility = useCallback((): void => {
+    const viewport = messageScrollerViewportRef.current
+    if (!viewport || viewport.clientHeight <= 0) {
+      setScrollThresholdAllowsFirstMessage(false)
+      return
+    }
+
+    const maximumScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+    const hasEnoughConversation =
+      userTurnCount >= SCROLL_TO_FIRST_MESSAGE_MIN_USER_TURNS ||
+      viewport.scrollHeight >= viewport.clientHeight * SCROLL_TO_FIRST_MESSAGE_MIN_HEIGHT_VIEWPORTS
+    const hasScrolledFarEnough =
+      maximumScrollTop > 0 &&
+      (viewport.scrollTop >= maximumScrollTop * SCROLL_TO_FIRST_MESSAGE_MIN_PROGRESS ||
+        viewport.scrollTop >=
+          viewport.clientHeight * SCROLL_TO_FIRST_MESSAGE_MIN_DISTANCE_VIEWPORTS)
+    setScrollThresholdAllowsFirstMessage(hasEnoughConversation && hasScrolledFarEnough)
+  }, [userTurnCount])
+  useLayoutEffect(updateScrollToFirstMessageVisibility, [
+    currentSessionId,
+    updateScrollToFirstMessageVisibility,
+    visibleMessageIdsKey
+  ])
+  useEffect(() => {
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(updateScrollToFirstMessageVisibility)
+    const viewport = messageScrollerViewportRef.current
+    const content = messageScrollerContentRef.current
+    if (viewport) observer.observe(viewport)
+    if (content) observer.observe(content)
+    return () => observer.disconnect()
+  }, [currentSessionId, updateScrollToFirstMessageVisibility])
+  const showScrollToFirstMessage =
+    statusAllowsScrollToFirstMessage && scrollThresholdAllowsFirstMessage
   const handleVisibleMessageSnapshotCommit = useCallback(
     (scopeId: string | undefined, messageIds: Set<string>): void => {
       setVisibleMessageSnapshot({ scopeId, messageIds })
@@ -697,8 +743,12 @@ const WorkspaceMessageScrollerImpl = ({
             aria-hidden="true"
             className="pointer-events-none absolute inset-x-0 top-0 z-10 h-6 bg-gradient-to-b from-bg-10 to-bg-10/0"
           />
-          <MessageScrollerViewport aria-label="Conversation">
-            <MessageScrollerContent className="gap-0 px-4">
+          <MessageScrollerViewport
+            ref={messageScrollerViewportRef}
+            aria-label="Conversation"
+            onScroll={updateScrollToFirstMessageVisibility}
+          >
+            <MessageScrollerContent ref={messageScrollerContentRef} className="gap-0 px-4">
               <div className={conversationContentClassName}>
                 <VisibleMessageSnapshotCommit
                   scopeId={currentPresentationScopeId}


### PR DESCRIPTION
## Problem

Long conversations do not provide a quick way to return to the first message on the active conversation branch.

## Proposed change

- Add a compact `First message` control at the top of the conversation viewport.
- Reuse the existing message-scroller start-direction behavior for smooth scrolling and edge-based visibility.
- Hide the control while a Session is `running` or in any `waiting-*` state.
- Preserve the existing active-branch projection, so the control returns to the first message of the currently selected branch.

## Scope and non-goals

- Renderer-only interaction change; no Session persistence, conversation graph, or ACP behavior changes.
- No new dependencies or shared abstractions.
- The existing scroll-to-end control is unchanged.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- Scroll-to-first primitive behavior -> `npm test -- --run src/renderer/src/components/ui/message-scroller.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx` -> 4 files passed, 115 tests passed.
- Session-status visibility (`idle` / `error` visible; `running` / all `waiting-*` hidden) -> same targeted command -> passed.
- Renderer and main TypeScript contracts -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> 0 errors; 13 pre-existing warnings in unchanged files.
- Complete portable suite -> `npm test` -> 988 files passed, 15 skipped; 14,396 tests passed, 198 skipped.

Consumer/platform impact: the change stays inside the renderer conversation surface and reuses the existing cross-platform scrolling primitive. No persistence, IPC, ACP, path, native-process, or platform-specific code changes, so no additional platform lane was included locally. CI remains authoritative for packaged Electron and OS-specific coverage.

## Review focus

- Whether the control should remain hidden for every current and future `waiting-*` Session status.
- Placement and visual weight relative to the existing scroll-to-end control and top fade.
