### PR TITLE
fix(notebook): authenticate local RPC before reading body

### DIFF
--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -77,6 +77,46 @@ afterEach(async () => {
 })
 
 describe('notebook local RPC server', () => {
+  it('rejects an invalid token before reading the request body', async () => {
+    const server = new NotebookLocalRpcServer({} as never, {
+      transport: 'tcp',
+      token: 'secret-token'
+    })
+    const connection = await server.ensureStarted()
+    const underlying = (server as unknown as { server?: Server }).server
+    if (!underlying) throw new Error('Expected the local RPC server to be listening.')
+    const accepted = once(underlying, 'request')
+    let responseStatus: number | undefined
+    let responseConnection: string | undefined
+    const request = httpRequest(
+      connection.endpoint,
+      {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer invalid-token',
+          'content-type': 'application/json',
+          'content-length': 1024
+        }
+      },
+      (response) => {
+        responseStatus = response.statusCode
+        responseConnection = response.headers.connection
+        response.resume()
+      }
+    )
+    request.once('error', () => undefined)
+
+    try {
+      request.write('{')
+      await accepted
+      await vi.waitFor(() => expect(responseStatus).toBe(401), { timeout: 500 })
+      expect(responseConnection).toBe('close')
+    } finally {
+      request.destroy()
+      await server.close()
+    }
+  })
+
   it('fails closed when a Session capability omits its Frame owner', async () => {
     const server = new NotebookLocalRpcServer({} as never)
 
@@ -1750,7 +1790,7 @@ describe('notebook local RPC server', () => {
       server.revokeArtifactRunCapability(revokedToken)
       const revoked = await call(revokedToken)
       expect(revoked.status).toBe(401)
-      await expect(revoked.json()).resolves.toEqual({ error: 'Invalid Artifact RPC capability.' })
+      await expect(revoked.json()).resolves.toEqual({ error: 'Invalid notebook RPC token.' })
       expect(createVersion).not.toHaveBeenCalled()
     } finally {
       await server.close()

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -329,6 +329,13 @@ const writeJson = (response: ServerResponse, statusCode: number, payload: unknow
   response.end(`${JSON.stringify(payload)}\n`)
 }
 
+const closeRequestAfterResponse = (request: IncomingMessage, response: ServerResponse): void => {
+  response.shouldKeepAlive = false
+  if (!response.headersSent) response.setHeader('connection', 'close')
+  if (response.writableFinished) request.destroy()
+  else response.once('finish', () => request.destroy())
+}
+
 // Hosts an authenticated app-local bridge between MCP stdio tools and the runtime service. The wire
 // protocol is HTTP/JSON; Windows carries it over a named pipe instead of loopback TCP.
 class NotebookLocalRpcServer {
@@ -1040,15 +1047,31 @@ class NotebookLocalRpcServer {
         writeJson(response, 405, { error: 'Notebook RPC only accepts POST requests.' })
         return
       }
+      const authorization = request.headers.authorization
+      const bearerToken = authorization?.startsWith('Bearer ')
+        ? authorization.slice('Bearer '.length)
+        : ''
+      const artifactCapability = this.artifactRpcCapabilities.get(bearerToken)
+      if (artifactCapability && artifactCapability.expiresAt <= this.now()) {
+        void this.revokeArtifactRunCapability(bearerToken)
+        closeRequestAfterResponse(request, response)
+        writeJson(response, 401, { error: 'Artifact RPC capability expired.' })
+        return
+      }
+      const hasKnownToken =
+        authorization === `Bearer ${this.token}` ||
+        this.sessionRpcCapabilities.has(bearerToken) ||
+        Boolean(artifactCapability)
+      if (!hasKnownToken) {
+        closeRequestAfterResponse(request, response)
+        writeJson(response, 401, { error: 'Invalid notebook RPC token.' })
+        return
+      }
       const payload = await readJsonBody(request)
       activeRequest.bodyComplete = true
       const method = typeof payload.method === 'string' ? payload.method : ''
       activeRequest.method = method
       let params = isRecord(payload.params) ? payload.params : {}
-      const authorization = request.headers.authorization
-      const bearerToken = authorization?.startsWith('Bearer ')
-        ? authorization.slice('Bearer '.length)
-        : ''
       let hostCapabilities:
         | Record<
             'mcp' | 'compute' | 'agents' | 'skills' | 'artifacts' | 'lineage' | 'frames' | 'llm',


### PR DESCRIPTION
## Problem

Notebook local RPC read and buffered the complete HTTP request body before validating the bearer token. An unauthenticated local process could therefore keep streaming data and grow the Electron Main process heap.

## Proposed change

- validate master, Session-bound, and Artifact capability tokens before reading the request body
- reject unknown or expired tokens with HTTP 401
- disable keep-alive and destroy the rejected upload after the response finishes
- retain the existing method-level capability authorization after JSON parsing
- add a regression test using an invalid token and a partial request body that never completes

## Scope and non-goals

This change does not add a size limit for authenticated RPC requests and does not change persisted data or migrations.

A revoked Artifact capability now receives the generic `Invalid notebook RPC token.` error text; its HTTP status remains 401.

## Acceptance criteria and validation

Checks ran after the last material edit:

- unauthenticated partial body is rejected before EOF -> `npm test -- src/main/notebook/local-rpc-server.test.ts -t 'rejects an invalid token before reading the request body'` -> passed
- all Notebook local RPC capability consumers -> targeted 12-file Vitest invocation -> 12 files / 110 tests passed
- Node and renderer type safety -> `npm run typecheck` -> passed
- lint -> `npm run lint` -> passed with 0 errors and 13 pre-existing warnings in unchanged files
- formatting -> `git diff --check` -> passed

The full portable `npm test` fallback was also attempted. It did not pass because the shared worktree dependency/environment state produced 178 unrelated failures, including a stale Prisma client missing `codecVersion`, unusable Storage test temp directories, and an Office package timeout. The focused Notebook RPC suite passed independently.

## Review focus

- token admission occurs before `readJsonBody`
- expired Artifact capability behavior preserves its existing error contract
- rejected uploads close only after the 401 response is flushed
- method-level authorization remains unchanged after body parsing
