### PR TITLE
fix(web-service): keep auth URL out of daemon logs

### DIFF
--- a/scripts/linux-package-smoke.mjs
+++ b/scripts/linux-package-smoke.mjs
@@ -13,6 +13,7 @@ import {
   verifyLegacyProjectPreserved,
   writeDatabaseMigrationCertification
 } from './database-migration-ledger-smoke.mjs'
+import { authenticatePackagedAppEndpoint } from './packaged-web-service-auth.mjs'
 
 const APPIMAGE_PATTERN = /^aipoch-open-science-(.+)-linux-x86_64\.AppImage$/
 const SMOKE_ROOT_PREFIX = 'open-science-linux-package-smoke-'
@@ -39,12 +40,15 @@ const appImageVersion = (path) => {
 
 const parsePackagedAppEndpoint = (output) => {
   const match = output.match(
-    /Open Science Web:\s+(http:\/\/127\.0\.0\.1:\d+\/\?token=[A-Za-z0-9_-]+)/
+    /Open Science Web:\s+(http:\/\/127\.0\.0\.1:\d+\/(?:\?token=[A-Za-z0-9_-]+)?)/
   )
   if (!match) return undefined
   const url = new URL(match[1])
   const token = url.searchParams.get('token')
-  return token ? { endpoint: url.origin, auth: `token=${encodeURIComponent(token)}` } : undefined
+  return {
+    endpoint: url.origin,
+    ...(token ? { auth: `token=${encodeURIComponent(token)}` } : {})
+  }
 }
 
 const pathExists = async (path) => {
@@ -145,7 +149,9 @@ const launchAndProbe = async ({ executable, expectedVersion, env }) => {
 
   try {
     const service = await Promise.race([
-      waitFor('the packaged Linux web service', async () => parsePackagedAppEndpoint(output)),
+      waitFor('the packaged Linux web service', async () =>
+        authenticatePackagedAppEndpoint(output, [env.OPEN_SCIENCE_E2E_STORAGE_ROOT])
+      ),
       exit.then((code) => {
         throw new Error(`Packaged Linux app exited before becoming healthy (${code}).\n${output}`)
       })
@@ -291,6 +297,7 @@ if (invokedAsScript) {
 }
 
 export {
+  authenticatePackagedAppEndpoint,
   appImageVersion,
   assertPackagedResources,
   findOne,

--- a/scripts/linux-package-smoke.test.ts
+++ b/scripts/linux-package-smoke.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import {
+  authenticatePackagedAppEndpoint,
   appImageVersion,
   assertPackagedResources,
   findOne,
@@ -24,14 +25,20 @@ describe('Linux package smoke', () => {
     await expect(findOne(root, /\.AppImage$/, 'AppImage')).rejects.toThrow(/exactly one/)
   })
 
-  it('parses only the authenticated packaged-app endpoint', () => {
-    expect(
-      parsePackagedAppEndpoint('Open Science Web: http://127.0.0.1:44001/?token=linux_smoke-token')
-    ).toEqual({
+  it('authenticates the token-free readiness endpoint through the service state contract', async () => {
+    const output = 'Open Science Web: http://127.0.0.1:44001/'
+    expect(parsePackagedAppEndpoint(output)).toEqual({ endpoint: 'http://127.0.0.1:44001' })
+    await expect(
+      authenticatePackagedAppEndpoint(output, ['/config'], {
+        readText: async (path: string) =>
+          path.endsWith('web-service.json')
+            ? JSON.stringify({ port: 44001 })
+            : 'linux_smoke_token_12345678901234567890\n'
+      })
+    ).resolves.toEqual({
       endpoint: 'http://127.0.0.1:44001',
-      auth: 'token=linux_smoke-token'
+      auth: 'token=linux_smoke_token_12345678901234567890'
     })
-    expect(parsePackagedAppEndpoint('Open Science Web: http://127.0.0.1:44001/')).toBeUndefined()
   })
 
   it('requires explicit package and installed executable paths', () => {

--- a/scripts/macos-package-smoke.mjs
+++ b/scripts/macos-package-smoke.mjs
@@ -13,6 +13,7 @@ import {
   verifyLegacyProjectPreserved,
   writeDatabaseMigrationCertification
 } from './database-migration-ledger-smoke.mjs'
+import { authenticatePackagedAppEndpoint } from './packaged-web-service-auth.mjs'
 
 const ARTIFACT_PATTERN = /^aipoch-open-science-(.+)-mac-(?:arm64|x64)\.(dmg|zip)$/
 const SMOKE_ROOT_PREFIX = 'open-science-macos-package-smoke-'
@@ -51,12 +52,15 @@ const findAppBundle = async (directory) => {
 
 const parsePackagedAppEndpoint = (output) => {
   const match = output.match(
-    /Open Science Web:\s+(http:\/\/127\.0\.0\.1:\d+\/\?token=[A-Za-z0-9_-]+)/
+    /Open Science Web:\s+(http:\/\/127\.0\.0\.1:\d+\/(?:\?token=[A-Za-z0-9_-]+)?)/
   )
   if (!match) return undefined
   const url = new URL(match[1])
   const token = url.searchParams.get('token')
-  return token ? { endpoint: url.origin, auth: `token=${encodeURIComponent(token)}` } : undefined
+  return {
+    endpoint: url.origin,
+    ...(token ? { auth: `token=${encodeURIComponent(token)}` } : {})
+  }
 }
 
 const waitFor = async (description, check, timeoutMs = STARTUP_TIMEOUT_MS) => {
@@ -139,7 +143,9 @@ const launchAndProbe = async ({ executable, expectedVersion, env, userDataRoot }
 
   try {
     const service = await Promise.race([
-      waitFor('the packaged macOS web service', async () => parsePackagedAppEndpoint(output)),
+      waitFor('the packaged macOS web service', async () =>
+        authenticatePackagedAppEndpoint(output, [env.OPEN_SCIENCE_E2E_STORAGE_ROOT])
+      ),
       exit.then((code) => {
         throw new Error(`Packaged macOS app exited before becoming healthy (${code}).\n${output}`)
       })
@@ -343,6 +349,7 @@ if (invokedAsScript) {
 }
 
 export {
+  authenticatePackagedAppEndpoint,
   artifactVersion,
   assertPackagedResources,
   findAppBundle,

--- a/scripts/macos-package-smoke.test.ts
+++ b/scripts/macos-package-smoke.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import {
+  authenticatePackagedAppEndpoint,
   artifactVersion,
   assertPackagedResources,
   findAppBundle,
@@ -60,10 +61,20 @@ describe('macOS package smoke', () => {
     expect(() => parseArguments([])).toThrow(/Usage/)
   })
 
-  it('extracts the authenticated packaged service endpoint', () => {
-    expect(
-      parsePackagedAppEndpoint('Open Science Web: http://127.0.0.1:3210/?token=abc_123')
-    ).toEqual({ endpoint: 'http://127.0.0.1:3210', auth: 'token=abc_123' })
+  it('authenticates the token-free readiness endpoint through the service state contract', async () => {
+    const output = 'Open Science Web: http://127.0.0.1:3210/'
+    expect(parsePackagedAppEndpoint(output)).toEqual({ endpoint: 'http://127.0.0.1:3210' })
+    await expect(
+      authenticatePackagedAppEndpoint(output, ['/config'], {
+        readText: async (path: string) =>
+          path.endsWith('web-service.json')
+            ? JSON.stringify({ port: 3210 })
+            : 'macos_smoke_token_12345678901234567890\n'
+      })
+    ).resolves.toEqual({
+      endpoint: 'http://127.0.0.1:3210',
+      auth: 'token=macos_smoke_token_12345678901234567890'
+    })
     expect(parsePackagedAppEndpoint('not ready')).toBeUndefined()
   })
 

--- a/scripts/packaged-web-service-auth.mjs
+++ b/scripts/packaged-web-service-auth.mjs
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const STATE_FILE = 'web-service.json'
+const TOKEN_FILE = 'web-token'
+const READY_URL_PATTERN =
+  /Open Science Web:\s+(http:\/\/127\.0\.0\.1:\d+\/(?:\?token=[A-Za-z0-9_-]+)?)/
+
+const parsePackagedAppEndpoint = (output) => {
+  const match = output.match(READY_URL_PATTERN)
+  if (!match) return undefined
+  const url = new URL(match[1])
+  const token = url.searchParams.get('token')
+  return {
+    endpoint: url.origin,
+    ...(token ? { auth: `token=${encodeURIComponent(token)}` } : {})
+  }
+}
+
+const authenticatePackagedAppEndpoint = async (
+  output,
+  configRoots = [],
+  { readText = readFile, joinPath = join } = {}
+) => {
+  const service = parsePackagedAppEndpoint(output)
+  if (!service || service.auth) return service
+
+  const port = Number(new URL(service.endpoint).port)
+  const roots = [...new Set(configRoots.filter((root) => typeof root === 'string' && root))]
+
+  for (const root of roots) {
+    try {
+      const state = JSON.parse(await readText(joinPath(root, STATE_FILE), 'utf8'))
+      if (state.port !== port) continue
+      const token = (await readText(joinPath(root, TOKEN_FILE), 'utf8')).trim()
+      if (token.length < 32) continue
+      return {
+        ...service,
+        auth: `token=${encodeURIComponent(token)}`
+      }
+    } catch {
+      // State and token files are published independently; retry while the service is starting.
+    }
+  }
+
+  return undefined
+}
+
+export { authenticatePackagedAppEndpoint, parsePackagedAppEndpoint }

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -18,6 +18,7 @@ import {
   verifyLegacyProjectPreserved,
   writeDatabaseMigrationCertification
 } from './database-migration-ledger-smoke.mjs'
+import { authenticatePackagedAppEndpoint } from './packaged-web-service-auth.mjs'
 
 const APP_EXECUTABLE = 'open-science.exe'
 const ARTIFACT_MCP_SERVER_ARG = '--open-science-artifact-mcp'
@@ -109,16 +110,15 @@ const requestPackagedAppShutdown = async (endpoint, auth, fetchImpl = fetchWithT
 
 const parsePackagedAppEndpoint = (output) => {
   const match = output.match(
-    /Open Science Web:\s+(http:\/\/127\.0\.0\.1:\d+\/\?token=[A-Za-z0-9_-]+)/
+    /Open Science Web:\s+(http:\/\/127\.0\.0\.1:\d+\/(?:\?token=[A-Za-z0-9_-]+)?)/
   )
   if (!match) return undefined
 
   const url = new URL(match[1])
   const token = url.searchParams.get('token')
-  if (!token) return undefined
   return {
     endpoint: url.origin,
-    auth: `token=${encodeURIComponent(token)}`
+    ...(token ? { auth: `token=${encodeURIComponent(token)}` } : {})
   }
 }
 
@@ -754,7 +754,10 @@ const launchAndProbe = async ({
   try {
     const { endpoint, auth } = await Promise.race([
       waitFor('the installed app web service', async () => {
-        return parsePackagedAppEndpoint(output())
+        return authenticatePackagedAppEndpoint(output(), [
+          env.OPEN_SCIENCE_E2E_STORAGE_ROOT,
+          ...(legacyConfigRoots ?? [])
+        ])
       }),
       exit.then((code) => {
         throw new Error(`Installed app exited before becoming healthy (${code}).\n${output()}`)
@@ -824,7 +827,12 @@ const launchAndExpectDatabaseBlocked = async ({ installDirectory, env }) => {
 
 // Leaves a healthy packaged process running so the next silent installer must handle the real
 // executable/process lock. The caller owns termination if installation fails.
-const launchForProcessLock = async ({ installDirectory, expectedVersion, env }) => {
+const launchForProcessLock = async ({
+  installDirectory,
+  expectedVersion,
+  env,
+  legacyConfigRoots
+}) => {
   const executable = join(installDirectory, APP_EXECUTABLE)
   const child = spawn(executable, ['--open-science-headless', '--serve=0'], {
     env,
@@ -840,7 +848,12 @@ const launchForProcessLock = async ({ installDirectory, expectedVersion, env }) 
   const exit = observeChildExit(child)
   try {
     const { endpoint, auth } = await Promise.race([
-      waitFor('the process-lock app web service', async () => parsePackagedAppEndpoint(output())),
+      waitFor('the process-lock app web service', async () =>
+        authenticatePackagedAppEndpoint(output(), [
+          env.OPEN_SCIENCE_E2E_STORAGE_ROOT,
+          ...(legacyConfigRoots ?? [])
+        ])
+      ),
       exit.then((code) => {
         throw new Error(`Process-lock app exited before becoming healthy (${code}).\n${output()}`)
       })
@@ -888,13 +901,15 @@ const installOverRunningApp = async ({
   installDirectory,
   phase,
   env,
+  legacyConfigRoots,
   launchInstalledApp = true,
   onSqliteVersion
 }) => {
   const running = await launchForProcessLock({
     installDirectory,
     expectedVersion: installerVersion(runningInstaller),
-    env
+    env,
+    legacyConfigRoots
   })
   try {
     await runProcess(installer, ['/S', `/D=${installDirectory}`], { env })
@@ -912,6 +927,7 @@ const installOverRunningApp = async ({
     installDirectory,
     expectedVersion: installerVersion(installer),
     env,
+    legacyConfigRoots,
     verifyLedger: true,
     onSqliteVersion
   })
@@ -1013,13 +1029,14 @@ const main = async () => {
               ...cycle,
               installDirectory,
               env,
+              legacyConfigRoots,
               onSqliteVersion: cycle.phase === 'rollback' ? undefined : onSqliteVersion
             })
           : await installAndProbe({
               ...cycle,
               installDirectory,
               env,
-              legacyConfigRoots: cycle.phase === 'previous' ? legacyConfigRoots : undefined,
+              legacyConfigRoots,
               onSqliteVersion: cycle.phase === 'previous' ? undefined : onSqliteVersion
             })
         if (cycle.phase === 'rollback' && upgradeProfileGuard.shouldExpectDowngradeBlock()) {
@@ -1084,6 +1101,7 @@ if (invokedAsScript) {
 }
 
 export {
+  authenticatePackagedAppEndpoint,
   assertPackagedResources,
   assertUpgradeProfilePreserved,
   buildSmokePlan,

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   assertPackagedResources,
+  authenticatePackagedAppEndpoint,
   assertUpgradeProfilePreserved,
   buildSmokePlan,
   cleanupSmokeRoot,
@@ -100,16 +101,33 @@ describe('Windows installer smoke plan', () => {
     expect(text).toHaveBeenCalledOnce()
   })
 
-  it('discovers the authenticated service endpoint from packaged app output', () => {
-    expect(
-      parsePackagedAppEndpoint(`
-[main] app starting
-Open Science Web: http://127.0.0.1:52378/?token=iUFHGSACwBz2k1kSJfPixHbclDywVg0CrcdTs42uvLE
-`)
-    ).toEqual({
-      auth: 'token=iUFHGSACwBz2k1kSJfPixHbclDywVg0CrcdTs42uvLE',
+  it('authenticates token-free readiness through state while accepting legacy token output', async () => {
+    const output = 'Open Science Web: http://127.0.0.1:52378/'
+    expect(parsePackagedAppEndpoint(output)).toEqual({
       endpoint: 'http://127.0.0.1:52378'
     })
+    await expect(
+      authenticatePackagedAppEndpoint(output, ['C:\\profile\\.open-science'], {
+        readText: async (path: string) =>
+          path.endsWith('web-service.json')
+            ? JSON.stringify({ port: 52378 })
+            : 'windows_smoke_token_12345678901234567890\n'
+      })
+    ).resolves.toEqual({
+      auth: 'token=windows_smoke_token_12345678901234567890',
+      endpoint: 'http://127.0.0.1:52378'
+    })
+
+    const legacyOutput = `
+[main] app starting
+Open Science Web: http://127.0.0.1:52378/?token=iUFHGSACwBz2k1kSJfPixHbclDywVg0CrcdTs42uvLE
+`
+    const legacyService = {
+      auth: 'token=iUFHGSACwBz2k1kSJfPixHbclDywVg0CrcdTs42uvLE',
+      endpoint: 'http://127.0.0.1:52378'
+    }
+    expect(parsePackagedAppEndpoint(legacyOutput)).toEqual(legacyService)
+    await expect(authenticatePackagedAppEndpoint(legacyOutput)).resolves.toEqual(legacyService)
     expect(parsePackagedAppEndpoint('[main] app starting')).toBeUndefined()
   })
 

--- a/scripts/windows-updater-certification.mjs
+++ b/scripts/windows-updater-certification.mjs
@@ -20,7 +20,7 @@ import {
   installerVersion,
   installAndProbe,
   launchAndProbe,
-  parsePackagedAppEndpoint,
+  authenticatePackagedAppEndpoint,
   runProcess,
   terminateProcessTree,
   uninstallAndVerify,
@@ -304,6 +304,7 @@ exit $exitCode
 const runElectronUpdater = async ({
   executable,
   env,
+  configRoots,
   expectedVersion,
   expectedInstaller,
   onDownloaded
@@ -332,7 +333,9 @@ const runElectronUpdater = async ({
   let installerExit
   try {
     const { endpoint, auth } = await Promise.race([
-      waitFor('the updater app web service', async () => parsePackagedAppEndpoint(output())),
+      waitFor('the updater app web service', async () =>
+        authenticatePackagedAppEndpoint(output(), configRoots)
+      ),
       exit.then((code) => {
         throw new Error(
           `Updater app exited before becoming healthy (${code}).\n${diagnosticOutput()}`
@@ -560,6 +563,7 @@ const main = async () => {
     await runElectronUpdater({
       executable: join(installDirectory, 'open-science.exe'),
       env,
+      configRoots: [previousConfigRoot],
       expectedVersion: currentVersion,
       expectedInstaller: join(
         env.LOCALAPPDATA,
@@ -594,7 +598,8 @@ const main = async () => {
     const currentConfigRoot = await launchAndProbe({
       installDirectory,
       expectedVersion: currentVersion,
-      env
+      env,
+      legacyConfigRoots: [previousConfigRoot]
     })
     await profileGuard.verifyCycle('current', currentConfigRoot)
     console.log('Windows electron-updater differential certification completed successfully.')

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -121,6 +121,20 @@ describe('createWebServiceController', () => {
     expect(h.controller.runningPort()).toBe(44100)
   })
 
+  it('keeps the bearer token out of daemon stdout when the service starts', async () => {
+    const stdout = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const h = makeController()
+
+    try {
+      const result = await h.controller.ensureStarted(44100, { attached: false })
+
+      expect(result.url).toBe('http://127.0.0.1:44100/?token=tok-123')
+      expect(stdout.mock.calls.flat().join(' ')).not.toContain('tok-123')
+    } finally {
+      stdout.mockRestore()
+    }
+  })
+
   it('is idempotent: a second ensureStarted while running reuses the server (no second start)', async () => {
     const h = makeController()
     await h.controller.ensureStarted(44100, { attached: false })

--- a/src/main/web-service/controller.test.ts
+++ b/src/main/web-service/controller.test.ts
@@ -129,6 +129,7 @@ describe('createWebServiceController', () => {
       const result = await h.controller.ensureStarted(44100, { attached: false })
 
       expect(result.url).toBe('http://127.0.0.1:44100/?token=tok-123')
+      expect(stdout).toHaveBeenCalledWith('Open Science Web: http://127.0.0.1:44100/')
       expect(stdout.mock.calls.flat().join(' ')).not.toContain('tok-123')
     } finally {
       stdout.mockRestore()

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -209,6 +209,7 @@ const createWebServiceController = (
       port: server.port,
       attached
     })
+    console.log(`Open Science Web: http://127.0.0.1:${server.port}/`)
     return { port: server.port, url }
   }
 

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -209,7 +209,6 @@ const createWebServiceController = (
       port: server.port,
       attached
     })
-    console.log(`Open Science Web: ${url}`)
     return { port: server.port, url }
   }
 


### PR DESCRIPTION
## Problem

The web-service controller printed the full authenticated browser URL to stdout after startup. The CLI daemon redirects stdout and stderr to `cli-daemon.log`, so the bearer token was persisted in a same-host readable log and could also be included in startup-failure log tails.

## Proposed change

- Keep the readiness line for packaged smoke and updater workflows, but print only `http://127.0.0.1:<port>/`.
- Preserve the authenticated URL returned by `ensureStarted()` for explicit application callers.
- Make packaged smoke and updater certification obtain authentication from the existing `web-service.json` and `web-token` files, matching the advertised port before using the token.
- Retain legacy token-bearing readiness parsing only in package certification so a current updater test can launch an older package.

## Scope and non-goals

- No authentication protocol, web-service API, persistence format, or data model change.
- No token rotation.
- No migration or proactive cleanup of historical `cli-daemon.log` files.
- Existing authenticated URLs, cookies, and API credentials remain valid.
- A future daemon start still truncates its launch log through the existing write-mode behavior.
- The legacy parser is test infrastructure for cross-version package certification, not production historical-data compatibility.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Bearer token is excluded from daemon stdout while readiness remains observable -> controller regression test included in the focused suite.
- Web-service, CLI, Linux package, macOS package, Windows installer, and Windows updater behavior -> `npm test -- src/main/web-service packages/open-science/cli.test.ts scripts/linux-package-smoke.test.ts scripts/macos-package-smoke.test.ts scripts/windows-installer-smoke.test.ts scripts/windows-updater-certification.test.ts` -> passed (108/108 across 12 files).
- Changed-file formatting -> `npx.cmd prettier --check <changed files>` -> passed.
- Node and renderer type safety -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors and 13 pre-existing warnings in unrelated files.
- Full portable fallback -> `npm test` -> attempted but did not pass in this Windows environment. Representative failures include symlink creation denied with `EPERM`, temporary storage roots reported unusable, a stale Prisma test database/client mismatch, and unrelated timeouts. Representative symlink and storage failures were reproduced unchanged on the unmodified `main` worktree.

The focused suite covers every changed owner/consumer path. CI remains authoritative for the full portable suite.

## Review focus

Confirm that the token-free readiness contract closes the daemon log leak while package smoke/updater workflows recover authentication only from the existing restricted state files.