### PR TITLE
ci(nightly): keep regression source resolution advisory

### DIFF
--- a/.github/workflows/desktop-regression.yml
+++ b/.github/workflows/desktop-regression.yml
@@ -31,6 +31,7 @@ permissions:
 jobs:
   source:
     name: Resolve source build
+    continue-on-error: ${{ inputs.allow_failure }}
     runs-on: ubuntu-latest
     outputs:
       available: ${{ steps.resolve.outputs.available }}

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -267,6 +267,7 @@ describe('post-merge Windows validation', () => {
     expect(regression.on).not.toHaveProperty('workflow_run')
     expect(regression.on).toHaveProperty('workflow_dispatch')
     expect(regression.on).toHaveProperty('workflow_call')
+    expect(regression.jobs.source['continue-on-error']).toBe('${{ inputs.allow_failure }}')
     expect(findStep(regression.jobs.source, 'Resolve source run').run).toContain(
       '.name == "macos-arm64" and (.expired | not)'
     )


### PR DESCRIPTION
## Problem

The rolling `nightly` release stayed on commit `370602e` even though the Nightly workflow kept receiving scheduled runs. Those runs were failing before `nightly-publish.yml` could update the release.

PR #1142 made desktop P0 and visual regression jobs advisory for Nightly, but the reusable regression workflow source-resolution job remained blocking. A transient source/artifact lookup failure could therefore still turn Nightly red and suppress its success-only publisher.

## Proposed change

- Apply the existing `allow_failure` input to the regression source-resolution job as well.
- Add a workflow contract assertion so Nightly and release regressions remain advisory end to end.

## Scope and non-goals

- The hourly cron remains unchanged at `17 * * * *`.
- Build and package-smoke jobs remain blocking.
- Publishing permissions and the separate success-only publisher remain unchanged.
- Windows Full Test is a separate hourly workflow and its current test failures are not changed here.

## Acceptance criteria and validation

- [x] Regression source resolution honors `${{ inputs.allow_failure }}`.
- [x] Focused contract test failed before the workflow edit and passed after it.
- [x] Release/workflow integrity suite: 4 files, 59 tests passed.
- [x] `npm run lint` passed.
- [x] `actionlint .github/workflows/desktop-regression.yml` passed.
- [x] Prettier check passed for both changed files.
- [x] CI integrity CLI passed against `origin/main...HEAD`.
- [x] Branch-head Nightly dry-run #31592555795: verify, four platform builds, four package-smoke jobs, publish artifact preparation, and regression source resolution all passed. The run was then superseded by the next scheduled Nightly through `concurrency.cancel-in-progress`, which cancelled only the two queued advisory macOS regression jobs.

Dry-run: https://github.com/aipoch/open-science/actions/runs/31592555795

## Residual risk

The success-only scheduled publisher cannot be exercised from `workflow_dispatch` by design. The next post-merge scheduled Nightly is the final publication check. GitHub scheduled workflows may also start later than the literal cron minute.