### PR TITLE
fix(onboarding): recover narrow-screen setup failures

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -613,9 +613,9 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 ### Onboarding
 
 - Root: `h-svh overflow-y-auto bg-bg-10 text-text-000`.
-- Container: `mx-auto min-h-full w-full max-w-[1040px] px-8 py-7`.
+- Container: `mx-auto min-h-full w-full max-w-[1040px] px-4 py-5 sm:px-8 sm:py-7`.
 - Brand: reuse the exact Home treatment, `font-serif text-[26px] font-medium leading-none tracking-[-0.02em] text-text-000`; do not recolor it with `primary`.
-- Main layout: `mt-12 grid grid-cols-[240px_minmax(0,1fr)] gap-10`; the left column is unframed introduction/progress, and the right column is the only visible work card.
+- Main layout: one column with compact spacing below `md`; at `md` and wider use `mt-12 grid grid-cols-[240px_minmax(0,1fr)] gap-10`. The left column is unframed introduction/progress, and the right column is the only visible work card.
 - Work surface: one shadcn `Card`, `min-h-[420px] gap-0 rounded-lg bg-bg-000 py-0 shadow-card ring-1 ring-border-200`; do not nest visual cards inside it.
 - Current step uses `bg-primary text-primary-foreground`; completed and inactive labels remain neutral.
 - Commands use shadcn `Button`; primary commands inherit the shared deep-green `primary` variant.

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -85,6 +85,9 @@ const mocks = vi.hoisted(() => {
     },
     startupView: 'app' as 'app' | 'onboarding',
     getInfo: vi.fn(),
+    onboarding: {
+      props: undefined as { loadStorageInfo: () => Promise<unknown> } | undefined
+    },
     syncWindowFindAppearance: vi.fn(),
     syncUnreadTaskView: vi.fn(),
     globalSearch: { props: undefined as { open: boolean } | undefined },
@@ -228,7 +231,10 @@ vi.mock('@/pages/home/HomePage', () => ({
   }
 }))
 vi.mock('@/pages/onboarding/OnboardingWizard', () => ({
-  OnboardingWizard: (): React.JSX.Element => <div data-testid="onboarding-page" />
+  OnboardingWizard: (props: { loadStorageInfo: () => Promise<unknown> }): React.JSX.Element => {
+    mocks.onboarding.props = props
+    return <div data-testid="onboarding-page" />
+  }
 }))
 vi.mock('@/pages/settings/ConnectorApprovalDialog', () => ({
   ConnectorApprovalDialog: (): React.JSX.Element => <div data-testid="approval-dialog" />
@@ -326,12 +332,13 @@ describe('App startup routing', () => {
     mocks.lifecycleSync.mockClear()
     mocks.syncWindowFindAppearance.mockClear()
     mocks.syncUnreadTaskView.mockClear()
-    mocks.getInfo.mockResolvedValue({
+    mocks.getInfo.mockReset().mockResolvedValue({
       dataRoot: '/workspace/OpenScience',
       dataRootMissing: false,
       legacyDataMovePrompt: false,
       defaultParent: '/workspace'
     })
+    mocks.onboarding.props = undefined
     window.api = {
       storage: { getInfo: mocks.getInfo },
       settings: {
@@ -819,6 +826,39 @@ describe('App startup routing', () => {
 
     expect(container.querySelector('[data-testid="onboarding-page"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
+  })
+
+  it('shares the startup storage lookup with onboarding', async () => {
+    mocks.settings.isLoaded = true
+    mocks.startupView = 'onboarding'
+
+    await render()
+    expect(mocks.getInfo).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      await mocks.onboarding.props?.loadStorageInfo()
+    })
+
+    expect(mocks.getInfo).toHaveBeenCalledOnce()
+  })
+
+  it('allows onboarding to retry a failed shared storage lookup', async () => {
+    mocks.settings.isLoaded = true
+    mocks.startupView = 'onboarding'
+    mocks.getInfo.mockRejectedValueOnce(new Error('storage unavailable')).mockResolvedValueOnce({
+      dataRoot: '/workspace/OpenScience',
+      dataRootMissing: false,
+      legacyDataMovePrompt: false,
+      defaultParent: '/workspace'
+    })
+
+    await render()
+
+    await act(async () => {
+      await mocks.onboarding.props?.loadStorageInfo()
+    })
+
+    expect(mocks.getInfo).toHaveBeenCalledTimes(2)
   })
 
   it('continues the startup animation while the initial session snapshot loads', async () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { OpenSessionFromNotificationRequest } from '../../shared/notifications'
+import type { StorageInfo } from '../../shared/storage'
 
 import { useDeepLinkNavigation } from '@/lib/deep-link'
 import { WorkspaceAgentRuntimeProvider } from '@/lib/acp/useWorkspaceAgentRuntime'
@@ -132,6 +133,31 @@ const AppContent = (): React.JSX.Element | null => {
   const [legacyMove, setLegacyMove] = useState<
     { currentDataRoot: string; defaultParent: string } | undefined
   >(undefined)
+  const storageInfoRequest = useRef<Promise<StorageInfo> | undefined>(undefined)
+  const loadStorageInfo = useCallback((): Promise<StorageInfo> => {
+    if (storageInfoRequest.current) return storageInfoRequest.current
+
+    const request = Promise.resolve()
+      .then(() => window.api.storage.getInfo())
+      .then(
+        (info) => {
+          if (info.dataRootMissing) setMissingDataRoot(info.dataRoot)
+          else if (info.legacyDataMovePrompt) {
+            setLegacyMove({
+              currentDataRoot: info.dataRoot,
+              defaultParent: info.defaultParent
+            })
+          }
+          return info
+        },
+        (error: unknown) => {
+          if (storageInfoRequest.current === request) storageInfoRequest.current = undefined
+          throw error
+        }
+      )
+    storageInfoRequest.current = request
+    return request
+  }, [])
   const deferredNotification = useRef<OpenSessionFromNotificationRequest | undefined>(undefined)
   const pendingNotificationOpenQueue = useRef<Promise<void>>(Promise.resolve())
   const notificationOpenIntent = useRef<NotificationOpenIntent>({
@@ -295,18 +321,11 @@ const AppContent = (): React.JSX.Element | null => {
 
   // Checked once at startup, after the gate is settled: dataRootMissing only fires for an
   // explicitly-configured root, which implies onboarding already completed - never during the
-  // wizard itself.
+  // wizard itself. Onboarding shares this promise because usage calculation recursively scans the
+  // data root; a rejection clears the cache so its Retry action can start a fresh request.
   useEffect(() => {
-    void window.api.storage.getInfo().then((info) => {
-      if (info.dataRootMissing) setMissingDataRoot(info.dataRoot)
-      else if (info.legacyDataMovePrompt) {
-        setLegacyMove({
-          currentDataRoot: info.dataRoot,
-          defaultParent: info.defaultParent
-        })
-      }
-    })
-  }, [])
+    void loadStorageInfo().catch(() => undefined)
+  }, [loadStorageInfo])
 
   // Subscribe once to connector approval requests from the main-process gate; they surface as a
   // modal the user must answer before the held connector call proceeds.
@@ -518,7 +537,7 @@ const AppContent = (): React.JSX.Element | null => {
   }
 
   if (startupView === 'onboarding') {
-    return <OnboardingWizard />
+    return <OnboardingWizard loadStorageInfo={loadStorageInfo} />
   }
 
   if (!isSessionPersistenceHydrated && isSessionPersistenceLoading) {

--- a/src/renderer/src/pages/onboarding/LocationStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.render.test.tsx
@@ -52,10 +52,12 @@ const renderStep = async (): Promise<RenderResult> => {
     return (
       <LocationStep
         dataRootInfo={storageInfo()}
+        dataRootError={undefined}
         locationDraft={locationDraft}
         onLocationDraftChange={setLocationDraft}
         relaunchError={relaunchError}
         onRelaunchErrorChange={setRelaunchError}
+        onRetryDataRootInfo={vi.fn()}
         onBack={onBack}
         setIsRelaunching={setIsRelaunching}
       />
@@ -68,6 +70,14 @@ const renderStep = async (): Promise<RenderResult> => {
 }
 
 describe('LocationStep', () => {
+  it('stacks the data path and Browse control on narrow screens', async () => {
+    await renderStep()
+
+    const controls = container.querySelector('[aria-label="Data location path"]')?.parentElement
+    expect(controls?.className).toContain('flex-col')
+    expect(controls?.className).toContain('sm:flex-row')
+  })
+
   it('returns to the notebook step from the Back button', async () => {
     const { onBack } = await renderStep()
 
@@ -163,6 +173,17 @@ describe('LocationStep', () => {
     expect(document.body.querySelector('[role="alertdialog"]')).toBeNull()
   })
 
+  it('a rejected default completion stays recoverable and shows the failure', async () => {
+    useSettingsStore.setState({
+      completeOnboarding: vi.fn().mockRejectedValue(new Error('Settings write failed.'))
+    })
+    await renderStep()
+
+    await clickButton(/finish/i)
+
+    expect(container.textContent).toContain('Settings write failed.')
+    expect(container.querySelector('section[aria-label="Choose data location"]')).not.toBeNull()
+  })
   it('Finish with a chosen non-default path shows a restart confirm dialog', async () => {
     window.api.storage.pickDirectory = vi.fn().mockResolvedValue('/mnt/data')
     window.api.storage.inspectDataRoot = vi
@@ -227,6 +248,24 @@ describe('LocationStep', () => {
     // the wizard - not Home - is still what's rendered, with the error visible on Location.
     expect(useSettingsStore.getState().completeOnboarding).not.toHaveBeenCalled()
     expect(container.textContent).toContain('Disk is full.')
+    expect(container.querySelector('section[aria-label="Choose data location"]')).not.toBeNull()
+    expect(setIsRelaunching).toHaveBeenLastCalledWith(false)
+  })
+
+  it('a rejected setDataRootAndRelaunch call shows the inline error and resets the relaunch flag', async () => {
+    window.api.storage.pickDirectory = vi.fn().mockResolvedValue('/mnt/data')
+    window.api.storage.inspectDataRoot = vi
+      .fn()
+      .mockResolvedValue({ kind: 'move', dataRoot: '/mnt/data/OpenScience' })
+    window.api.storage.setDataRootAndRelaunch = vi
+      .fn()
+      .mockRejectedValue(new Error('Relaunch IPC failed.'))
+    const { setIsRelaunching } = await renderStep()
+    await clickButton(/browse/i)
+    await clickButton(/finish/i)
+    await clickButton(/^restart$/i)
+
+    expect(container.textContent).toContain('Relaunch IPC failed.')
     expect(container.querySelector('section[aria-label="Choose data location"]')).not.toBeNull()
     expect(setIsRelaunching).toHaveBeenLastCalledWith(false)
   })

--- a/src/renderer/src/pages/onboarding/LocationStep.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.tsx
@@ -19,14 +19,17 @@ import { Separator } from '@/components/ui/separator'
 import type { StorageInfo } from '../../../../shared/storage'
 import { useSettingsStore } from '@/stores/settings-store'
 import { DataRootWarning } from '@/components/DataRootWarning'
+import { onboardingErrorMessage } from './onboarding-error'
 
 type LocationStepProps = {
   // Fetched once by the wizard shell up front, so this step has the default location to show.
   dataRootInfo: StorageInfo | null
+  dataRootError: string | undefined
   locationDraft: LocationDraft
   onLocationDraftChange: (draft: LocationDraft) => void
   relaunchError: string | undefined
   onRelaunchErrorChange: (error: string | undefined) => void
+  onRetryDataRootInfo: () => void
   onBack: () => void
   // Relaunch replaces the whole wizard with a bare "Setting up…" screen, so the flag lives in the
   // shell and this step only reports it.
@@ -38,16 +41,17 @@ type LocationDraft = {
   chosenDataRoot: string
   chosenKind: 'move' | 'adopt' | null
 }
-
 // Final step (doubles as Finish): pick where large data lives, then either completeOnboarding
 // (default kept) or confirm a restart that applies the new root. Only `dataRoot` is ever touched
 // here — the config root (settings, sessions, db, claude, skills) always stays at its fixed default.
 const LocationStep = ({
   dataRootInfo,
+  dataRootError,
   locationDraft,
   onLocationDraftChange,
   relaunchError,
   onRelaunchErrorChange,
+  onRetryDataRootInfo,
   onBack,
   setIsRelaunching
 }: LocationStepProps): React.JSX.Element => {
@@ -86,6 +90,17 @@ const LocationStep = ({
     setLocationError(undefined)
   }
 
+  const completeWithDefaultLocation = async (): Promise<void> => {
+    onRelaunchErrorChange(undefined)
+    try {
+      await completeOnboarding()
+    } catch (error) {
+      onRelaunchErrorChange(
+        onboardingErrorMessage(error, 'Could not finish setup with the default data location.')
+      )
+    }
+  }
+
   const handleFinishLocation = async (): Promise<void> => {
     if (chosenParent) {
       // A custom location was chosen: gate completeOnboarding behind the user's confirmation.
@@ -94,7 +109,7 @@ const LocationStep = ({
       setConfirmRestart(true)
     } else {
       // Default kept: nothing more to do, the App gate takes it from here — no relaunch.
-      await completeOnboarding()
+      await completeWithDefaultLocation()
     }
   }
 
@@ -106,7 +121,7 @@ const LocationStep = ({
     if (isRestartingRef.current) return
 
     setConfirmRestart(false)
-    await completeOnboarding()
+    await completeWithDefaultLocation()
   }
 
   const handleRestart = async (): Promise<void> => {
@@ -121,19 +136,27 @@ const LocationStep = ({
     // would turn the failure branch below into dead code. Instead the main-process handler marks
     // onboarding complete itself, in the same step as setDataRoot, right before it relaunches -
     // so the gate only flips once the new location is actually persisted.
-    const result = await window.api.storage.setDataRootAndRelaunch(chosenParent, true)
-    if (!result.ok) {
+    try {
+      const result = await window.api.storage.setDataRootAndRelaunch(chosenParent, true)
+      if (result.ok) return
+
       // The app is not relaunching; the gate was never flipped, so we're still on the wizard -
       // surface the error here and let the user retry or fall back to Keep default.
       isRestartingRef.current = false
       setIsRelaunching(false)
       onRelaunchErrorChange(result.error ?? 'Could not restart to apply the new location.')
+    } catch (error) {
+      isRestartingRef.current = false
+      setIsRelaunching(false)
+      onRelaunchErrorChange(
+        onboardingErrorMessage(error, 'Could not restart to apply the new location.')
+      )
     }
   }
 
   return (
     <>
-      <CardHeader className="gap-1 rounded-t-lg px-6 py-5">
+      <CardHeader className="gap-1 rounded-t-lg px-4 py-5 sm:px-6">
         <CardTitle className="text-[15px] font-semibold">
           Where should Open Science store your data?
         </CardTitle>
@@ -144,31 +167,49 @@ const LocationStep = ({
       </CardHeader>
       <Separator className="bg-border-200" />
 
-      <CardContent className="flex-1 px-6 py-5">
+      <CardContent className="flex-1 px-4 py-5 sm:px-6">
         <section aria-label="Choose data location" className="space-y-5">
+          {dataRootError ? (
+            <div
+              className="flex flex-col gap-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive sm:flex-row sm:items-center sm:justify-between"
+              role="alert"
+            >
+              <span>Could not load the default data location: {dataRootError}</span>
+              <Button
+                type="button"
+                variant="link"
+                size="xs"
+                onClick={onRetryDataRootInfo}
+                className="h-auto self-start p-0 text-destructive hover:text-text-000 sm:self-auto"
+              >
+                Retry
+              </Button>
+            </div>
+          ) : null}
+
           {relaunchError ? (
             <p
               className="rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive"
               role="alert"
             >
-              Could not switch to the new location: {relaunchError} You can retry or keep the
-              default location.
+              Could not finish setting up storage: {relaunchError} You can retry or keep the default
+              location.
             </p>
           ) : null}
 
           <div className="rounded-xl border border-border-200 p-4">
             <span className="text-xs font-medium text-text-100">Location</span>
-            <div className="mt-1 flex items-center gap-2">
+            <div className="mt-1 flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
               <p
                 aria-label="Data location path"
-                className="flex-1 truncate rounded-lg border border-border-200 bg-bg-000 px-2.5 py-1.5 font-mono text-xs"
+                className="min-w-0 flex-1 truncate rounded-lg border border-border-200 bg-bg-000 px-2.5 py-1.5 font-mono text-xs"
               >
                 {chosenDataRoot || dataRootInfo?.dataRoot || ''}
               </p>
               <button
                 type="button"
                 onClick={() => void handleBrowseLocation()}
-                className="inline-flex shrink-0 items-center rounded-lg border border-border-200 px-3 py-1.5 text-sm font-medium text-text-000 transition-colors hover:bg-bg-10"
+                className="inline-flex shrink-0 items-center justify-center rounded-lg border border-border-200 px-3 py-1.5 text-sm font-medium text-text-000 transition-colors hover:bg-bg-10"
               >
                 Browse…
               </button>
@@ -205,7 +246,7 @@ const LocationStep = ({
           <DataRootWarning />
         </section>
       </CardContent>
-      <CardFooter className="mt-auto justify-end gap-2 rounded-b-lg border-border-200 bg-bg-10 px-6 py-3">
+      <CardFooter className="mt-auto justify-end gap-2 rounded-b-lg border-border-200 bg-bg-10 px-4 py-3 sm:px-6">
         <Button type="button" variant="outline" onClick={onBack}>
           Back
         </Button>

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -237,4 +237,16 @@ describe('OnboardingWizard flow', () => {
     expect(container.textContent).toContain(DEFAULT_DATA_ROOT)
     expect(window.api.storage.getInfo).toHaveBeenCalledTimes(2)
   })
+
+  it('uses the startup storage loader supplied by App', async () => {
+    const loadStorageInfo = vi.fn().mockResolvedValue(storageInfo())
+    readyClaudeState()
+
+    await act(async () => {
+      root.render(<OnboardingWizard loadStorageInfo={loadStorageInfo} />)
+    })
+
+    expect(loadStorageInfo).toHaveBeenCalledOnce()
+    expect(window.api.storage.getInfo).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx
@@ -10,6 +10,8 @@ import { useSettingsStore } from '@/stores/settings-store'
 import { OnboardingWizard } from './OnboardingWizard'
 import {
   clickButton,
+  DEFAULT_DATA_ROOT,
+  storageInfo,
   fillRequiredProviderFields,
   readyClaudeState,
   resetOnboardingStores,
@@ -56,6 +58,16 @@ const goToLocationStep = async (): Promise<void> => {
 }
 
 describe('OnboardingWizard flow', () => {
+  it('uses a single-column layout before the desktop breakpoint', async () => {
+    readyClaudeState()
+
+    await renderWizard()
+
+    const layout = container.querySelector<HTMLElement>('[data-onboarding-layout="split"]')
+    expect(layout?.className).toContain('grid-cols-1')
+    expect(layout?.className).toContain('md:grid-cols-[240px_minmax(0,1fr)]')
+  })
+
   it('walks all five steps forward in order, tracking progress', async () => {
     readyClaudeState()
 
@@ -204,5 +216,25 @@ describe('OnboardingWizard flow', () => {
     expect(container.textContent).toContain('Disk is full.')
     expect(container.textContent).toContain('/mnt/data/OpenScience')
     expect(useSettingsStore.getState().completeOnboarding).not.toHaveBeenCalled()
+  })
+
+  it('keeps onboarding recoverable when loading storage information rejects', async () => {
+    window.api.storage.getInfo = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Storage is unavailable.'))
+      .mockResolvedValueOnce(storageInfo())
+    readyClaudeState()
+
+    await renderWizard()
+    await goToLocationStep()
+
+    expect(currentSection('Choose data location')).not.toBeNull()
+    expect(container.querySelector('[role="alert"]')).not.toBeNull()
+    expect(container.textContent).toContain('Storage is unavailable.')
+
+    await clickButton(/^retry$/i)
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+    expect(container.textContent).toContain(DEFAULT_DATA_ROOT)
+    expect(window.api.storage.getInfo).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -1,5 +1,5 @@
 import { Check } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
@@ -15,6 +15,7 @@ import { AgentStep } from './AgentStep'
 import { EnvironmentStep } from './EnvironmentStep'
 import { LocationStep, type LocationDraft } from './LocationStep'
 import { NotebookStep } from './NotebookStep'
+import { onboardingErrorMessage } from './onboarding-error'
 import { ProviderStep } from './ProviderStep'
 
 // Location is last: it doubles as the wizard's Finish step, so the confirm-restart dialog can
@@ -91,6 +92,7 @@ const OnboardingWizard = (): React.JSX.Element => {
   // Fetched once, up front, so the Location step has the default to show and the provider step can
   // later tell whether the user's choice actually differs from it.
   const [dataRootInfo, setDataRootInfo] = useState<StorageInfo | null>(null)
+  const [dataRootError, setDataRootError] = useState<string | undefined>(undefined)
   // Like the provider draft, the data-location choice belongs to the stable shell so Back/Continue
   // does not discard it when LocationStep unmounts.
   const [locationDraft, setLocationDraft] = useState<LocationDraft>({
@@ -108,9 +110,22 @@ const OnboardingWizard = (): React.JSX.Element => {
 
   // Fetch the default data location once, up front, so the Location step has something to show
   // and the provider step can later tell whether the user's choice actually differs from it.
-  useEffect(() => {
-    void window.api.storage.getInfo().then(setDataRootInfo)
+  const handleDataRootInfoSuccess = useCallback((info: StorageInfo): void => {
+    setDataRootInfo(info)
+    setDataRootError(undefined)
   }, [])
+  const handleDataRootInfoFailure = useCallback((error: unknown): void => {
+    setDataRootError(
+      onboardingErrorMessage(error, 'Could not load the default data location. Please try again.')
+    )
+  }, [])
+  const retryDataRootInfo = useCallback((): void => {
+    void window.api.storage.getInfo().then(handleDataRootInfoSuccess, handleDataRootInfoFailure)
+  }, [handleDataRootInfoFailure, handleDataRootInfoSuccess])
+
+  useEffect(() => {
+    void window.api.storage.getInfo().then(handleDataRootInfoSuccess, handleDataRootInfoFailure)
+  }, [handleDataRootInfoFailure, handleDataRootInfoSuccess])
 
   // App starts this check on every launch. This local fallback also keeps the wizard self-contained in
   // tests or alternate entry surfaces where it may be mounted without App as its parent.
@@ -145,7 +160,7 @@ const OnboardingWizard = (): React.JSX.Element => {
 
   return (
     <main className="h-svh overflow-y-auto bg-bg-10 text-text-000">
-      <div className="mx-auto min-h-full w-full max-w-[1040px] px-8 py-7">
+      <div className="mx-auto min-h-full w-full max-w-[1040px] px-4 py-5 sm:px-8 sm:py-7">
         <a
           href={APP.links.website}
           target="_blank"
@@ -157,9 +172,9 @@ const OnboardingWizard = (): React.JSX.Element => {
 
         <div
           data-onboarding-layout="split"
-          className="mt-12 grid grid-cols-[240px_minmax(0,1fr)] gap-10"
+          className="mt-8 grid grid-cols-1 gap-6 md:mt-12 md:grid-cols-[240px_minmax(0,1fr)] md:gap-10"
         >
-          <section aria-labelledby="onboarding-introduction-title" className="pt-2">
+          <section aria-labelledby="onboarding-introduction-title" className="md:pt-2">
             <p className="text-[11px] font-medium text-muted-foreground">FIRST-TIME SETUP</p>
             <h1
               id="onboarding-introduction-title"
@@ -200,10 +215,12 @@ const OnboardingWizard = (): React.JSX.Element => {
             ) : (
               <LocationStep
                 dataRootInfo={dataRootInfo}
+                dataRootError={dataRootError}
                 locationDraft={locationDraft}
                 onLocationDraftChange={setLocationDraft}
                 relaunchError={relaunchError}
                 onRelaunchErrorChange={setRelaunchError}
+                onRetryDataRootInfo={retryDataRootInfo}
                 onBack={() => setStep('notebook')}
                 setIsRelaunching={setIsRelaunching}
               />

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -21,6 +21,9 @@ import { ProviderStep } from './ProviderStep'
 // Location is last: it doubles as the wizard's Finish step, so the confirm-restart dialog can
 // show only once the provider is already validated.
 type WizardStep = 'environment' | 'agent' | 'provider' | 'notebook' | 'location'
+type OnboardingWizardProps = {
+  loadStorageInfo?: () => Promise<StorageInfo>
+}
 
 const STEP_ORDER: WizardStep[] = ['environment', 'agent', 'provider', 'notebook', 'location']
 const STEP_LABELS: Record<WizardStep, string> = {
@@ -30,6 +33,7 @@ const STEP_LABELS: Record<WizardStep, string> = {
   notebook: 'Notebook runtime',
   location: 'Data location'
 }
+const loadStorageInfoFromBridge = (): Promise<StorageInfo> => window.api.storage.getInfo()
 
 // Keeps the five-step sequence visible without turning the lightweight setup flow into navigation.
 const OnboardingProgress = ({ step }: { step: WizardStep }): React.JSX.Element => {
@@ -73,7 +77,9 @@ const OnboardingProgress = ({ step }: { step: WizardStep }): React.JSX.Element =
 // First-run gate: inspect the host, install the agent runtime, configure and validate a model
 // provider, optionally set up the notebook runtime, then choose where data lives — one focused
 // step each. Completed users repair later environment regressions from the relevant Settings panel.
-const OnboardingWizard = (): React.JSX.Element => {
+const OnboardingWizard = ({
+  loadStorageInfo = loadStorageInfoFromBridge
+}: OnboardingWizardProps): React.JSX.Element => {
   const environmentCheck = useSettingsStore((state) => state.environmentCheck)
   const environmentCheckError = useSettingsStore((state) => state.environmentCheckError)
   const isCheckingEnvironment = useSettingsStore((state) => state.isCheckingEnvironment)
@@ -120,12 +126,12 @@ const OnboardingWizard = (): React.JSX.Element => {
     )
   }, [])
   const retryDataRootInfo = useCallback((): void => {
-    void window.api.storage.getInfo().then(handleDataRootInfoSuccess, handleDataRootInfoFailure)
-  }, [handleDataRootInfoFailure, handleDataRootInfoSuccess])
+    void loadStorageInfo().then(handleDataRootInfoSuccess, handleDataRootInfoFailure)
+  }, [handleDataRootInfoFailure, handleDataRootInfoSuccess, loadStorageInfo])
 
   useEffect(() => {
-    void window.api.storage.getInfo().then(handleDataRootInfoSuccess, handleDataRootInfoFailure)
-  }, [handleDataRootInfoFailure, handleDataRootInfoSuccess])
+    void loadStorageInfo().then(handleDataRootInfoSuccess, handleDataRootInfoFailure)
+  }, [handleDataRootInfoFailure, handleDataRootInfoSuccess, loadStorageInfo])
 
   // App starts this check on every launch. This local fallback also keeps the wizard self-contained in
   // tests or alternate entry surfaces where it may be mounted without App as its parent.

--- a/src/renderer/src/pages/onboarding/onboarding-error.ts
+++ b/src/renderer/src/pages/onboarding/onboarding-error.ts
@@ -1,0 +1,8 @@
+const onboardingErrorMessage = (error: unknown, fallback: string): string =>
+  error instanceof Error
+    ? error.message
+    : typeof error === 'string' && error.trim()
+      ? error
+      : fallback
+
+export { onboardingErrorMessage }


### PR DESCRIPTION
## Problem

The first-run onboarding shell used a fixed 240px sidebar and 40px gap at every viewport width. At 320–414px this collapsed the work card to an unusable width. Storage bootstrap and completion calls also left raw promise rejections unhandled: a rejected relaunch IPC call could leave the renderer on the full-screen waiting state permanently.

## Proposed change

- Switch onboarding to a compact single-column layout below the `md` breakpoint, restoring the existing split layout at desktop widths.
- Stack the data-location path and Browse control on narrow screens.
- Surface storage bootstrap failures inline with a Retry action.
- Catch default-completion and relaunch rejections, preserve the location draft, reset the relaunch gate, and keep retry/fallback actions available.
- Centralize onboarding error normalization and update the renderer design owner document.

## Scope and non-goals

This changes only first-run onboarding presentation and renderer-side failure recovery. It does not change storage migration, persistence schemas, or main-process storage commands.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- Narrow layout and onboarding storage recovery -> `npm test -- src/renderer/src/pages/onboarding/OnboardingWizard.render.test.tsx src/renderer/src/pages/onboarding/LocationStep.render.test.tsx` -> 24/24 passed.
- Renderer contracts and props -> `npm run typecheck:web` -> passed.
- Source/style rules -> `npm run lint` -> passed with 0 errors; 13 pre-existing warnings remain in unchanged files.
- Independent Standards and Spec reviews -> 0 findings on both axes.

`npm test` was also run after the last material edit, but the portable suite remains blocked by unrelated baseline/environment failures (182 in the latest run), primarily Windows symlink `EPERM`, stale Prisma/database fixtures, temporary database locks, storage IPC fixture failures, and an unrelated workspace render timeout. The representative symlink failure reproduces from the unchanged main checkout. No onboarding test failed.

Uncovered risk: responsive behavior is locked by renderer class-level tests; no packaged-app narrow-viewport visual certification was run locally.

## Review focus

- Breakpoint behavior between 320px and desktop widths.
- Recovery state after rejected `storage.getInfo`, `completeOnboarding`, and `setDataRootAndRelaunch` calls.
- Preservation of the selected data location after a failed restart.
