### PR TITLE
fix(remote-access): recover loading and trap operation focus

### DIFF
--- a/src/renderer/src/pages/settings/RemoteControlPanel.tsx
+++ b/src/renderer/src/pages/settings/RemoteControlPanel.tsx
@@ -122,6 +122,7 @@ export const RemoteControlPanel = (): React.JSX.Element => {
   const [copied, setCopied] = useState(false)
 
   const operationTriggerRef = useRef<HTMLElement | null>(null)
+  const initialLoadRetryRef = useRef(false)
   const refresh = async (detect = false, completesBusyOperation = true): Promise<void> => {
     try {
       const next = detect
@@ -181,6 +182,14 @@ export const RemoteControlPanel = (): React.JSX.Element => {
     }
   }
 
+  const retryInitialLoad = (): void => {
+    if (initialLoadRetryRef.current) return
+    initialLoadRetryRef.current = true
+    void run('loading', () => loadRemoteAccessSnapshot(setSnapshot)).finally(() => {
+      initialLoadRetryRef.current = false
+    })
+  }
+
   const approve = (requestId: string, decision: RemotePairingDecision): void => {
     void run(`approve:${requestId}`, () => window.api.remoteAccess.approve({ requestId, decision }))
   }
@@ -193,7 +202,7 @@ export const RemoteControlPanel = (): React.JSX.Element => {
   }
 
   if (!snapshot) {
-    if (!snapshot && actionError) {
+    if (actionError) {
       return (
         <div className="p-5" data-testid="remote-control-load-error">
           <div
@@ -209,7 +218,8 @@ export const RemoteControlPanel = (): React.JSX.Element => {
                 variant="outline"
                 size="sm"
                 className="mt-3"
-                onClick={() => void run('loading', () => loadRemoteAccessSnapshot(setSnapshot))}
+                disabled={busy !== null}
+                onClick={retryInitialLoad}
               >
                 <RefreshCw className="size-3.5" aria-hidden="true" />
                 Try again

--- a/src/renderer/src/pages/settings/RemoteControlPanel.tsx
+++ b/src/renderer/src/pages/settings/RemoteControlPanel.tsx
@@ -88,9 +88,11 @@ const providerStatus = (snapshot: RemoteAccessSnapshot): string => {
 }
 
 const loadRemoteAccessSnapshot = async (
-  onInitial: (snapshot: RemoteAccessSnapshot) => void = () => undefined
+  onInitial: (snapshot: RemoteAccessSnapshot) => void = () => undefined,
+  isActive: () => boolean = () => true
 ): Promise<RemoteAccessSnapshot> => {
   const initial = await window.api.remoteAccess.getSnapshot()
+  if (!isActive()) return initial
   onInitial(initial)
   return initial.canManage ? window.api.remoteAccess.detect() : initial
 }
@@ -123,6 +125,7 @@ export const RemoteControlPanel = (): React.JSX.Element => {
 
   const operationTriggerRef = useRef<HTMLElement | null>(null)
   const initialLoadRetryRef = useRef(false)
+  const mountedRef = useRef(false)
   const refresh = async (detect = false, completesBusyOperation = true): Promise<void> => {
     try {
       const next = detect
@@ -139,9 +142,13 @@ export const RemoteControlPanel = (): React.JSX.Element => {
 
   useEffect(() => {
     let active = true
-    void loadRemoteAccessSnapshot((initial) => {
-      if (active) setSnapshot(initial)
-    })
+    mountedRef.current = true
+    void loadRemoteAccessSnapshot(
+      (initial) => {
+        if (active) setSnapshot(initial)
+      },
+      () => active
+    )
       .then((next) => {
         if (!active) return
         setSnapshot(next)
@@ -159,6 +166,7 @@ export const RemoteControlPanel = (): React.JSX.Element => {
     })
     return () => {
       active = false
+      mountedRef.current = false
       unsubscribe()
     }
   }, [])
@@ -185,7 +193,9 @@ export const RemoteControlPanel = (): React.JSX.Element => {
   const retryInitialLoad = (): void => {
     if (initialLoadRetryRef.current) return
     initialLoadRetryRef.current = true
-    void run('loading', () => loadRemoteAccessSnapshot(setSnapshot)).finally(() => {
+    void run('loading', () =>
+      loadRemoteAccessSnapshot(setSnapshot, () => mountedRef.current)
+    ).finally(() => {
       initialLoadRetryRef.current = false
     })
   }

--- a/src/renderer/src/pages/settings/RemoteControlPanel.tsx
+++ b/src/renderer/src/pages/settings/RemoteControlPanel.tsx
@@ -1,5 +1,7 @@
 import { QRCodeSVG } from '@rc-component/qrcode'
+import { Dialog } from 'radix-ui'
 import {
+  AlertTriangle,
   CheckCircle2,
   CircleOff,
   Copy,
@@ -12,8 +14,7 @@ import {
   Smartphone,
   Trash2
 } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { useEffect, useRef, useState } from 'react'
 
 import type {
   RemoteAccessMode,
@@ -23,6 +24,13 @@ import type {
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import {
+  dialogDescriptionClassName,
+  dialogOverlayClassName,
+  dialogPanelClassName,
+  dialogTitleClassName
+} from '@/components/ui/dialog-chrome'
+import { cn } from '@/lib/utils'
 import { SettingsSection } from './SettingsLayout'
 
 const REMOTE_IT_DOWNLOAD_URL = 'https://www.remote.it/download/'
@@ -79,6 +87,14 @@ const providerStatus = (snapshot: RemoteAccessSnapshot): string => {
   return 'Ready'
 }
 
+const loadRemoteAccessSnapshot = async (
+  onInitial: (snapshot: RemoteAccessSnapshot) => void = () => undefined
+): Promise<RemoteAccessSnapshot> => {
+  const initial = await window.api.remoteAccess.getSnapshot()
+  onInitial(initial)
+  return initial.canManage ? window.api.remoteAccess.detect() : initial
+}
+
 const BrowserAccessSteps = (): React.JSX.Element => (
   <div className="mt-4 flex items-start gap-3 border-t border-blue-600/15 pt-4">
     <Smartphone className="mt-0.5 size-5 shrink-0 text-blue-600" aria-hidden="true" />
@@ -105,6 +121,7 @@ export const RemoteControlPanel = (): React.JSX.Element => {
   const [actionError, setActionError] = useState<string | undefined>()
   const [copied, setCopied] = useState(false)
 
+  const operationTriggerRef = useRef<HTMLElement | null>(null)
   const refresh = async (detect = false, completesBusyOperation = true): Promise<void> => {
     try {
       const next = detect
@@ -121,15 +138,12 @@ export const RemoteControlPanel = (): React.JSX.Element => {
 
   useEffect(() => {
     let active = true
-    void window.api.remoteAccess
-      .getSnapshot()
-      .then(async (initial) => {
+    void loadRemoteAccessSnapshot((initial) => {
+      if (active) setSnapshot(initial)
+    })
+      .then((next) => {
         if (!active) return
-        setSnapshot(initial)
-        if (initial.canManage) {
-          const detected = await window.api.remoteAccess.detect()
-          if (active) setSnapshot(detected)
-        }
+        setSnapshot(next)
       })
       .catch((error: unknown) => {
         if (active) setActionError(error instanceof Error ? error.message : String(error))
@@ -147,6 +161,12 @@ export const RemoteControlPanel = (): React.JSX.Element => {
       unsubscribe()
     }
   }, [])
+
+  useEffect(() => {
+    if (busy !== null || !operationTriggerRef.current) return
+    operationTriggerRef.current.focus()
+    operationTriggerRef.current = null
+  }, [busy])
 
   const run = async (name: string, action: () => Promise<RemoteAccessSnapshot>): Promise<void> => {
     setBusy(name)
@@ -173,6 +193,32 @@ export const RemoteControlPanel = (): React.JSX.Element => {
   }
 
   if (!snapshot) {
+    if (!snapshot && actionError) {
+      return (
+        <div className="p-5" data-testid="remote-control-load-error">
+          <div
+            className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            role="alert"
+          >
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+            <div className="min-w-0 flex-1">
+              <div className="font-medium">Remote access couldn&apos;t be loaded.</div>
+              <div className="mt-1 break-words text-xs">{actionError}</div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-3"
+                onClick={() => void run('loading', () => loadRemoteAccessSnapshot(setSnapshot))}
+              >
+                <RefreshCw className="size-3.5" aria-hidden="true" />
+                Try again
+              </Button>
+            </div>
+          </div>
+        </div>
+      )
+    }
     return (
       <div className="flex min-h-64 items-center justify-center text-sm text-muted-foreground">
         <LoaderCircle className="mr-2 size-4 animate-spin" aria-hidden="true" />
@@ -199,7 +245,8 @@ export const RemoteControlPanel = (): React.JSX.Element => {
       variant="outline"
       size="sm"
       disabled={busy !== null}
-      onClick={() => {
+      onClick={(event) => {
+        operationTriggerRef.current = event.currentTarget
         setBusy('detect')
         void refresh(true)
       }}
@@ -215,32 +262,37 @@ export const RemoteControlPanel = (): React.JSX.Element => {
 
   return (
     <div className="space-y-5 p-5" data-testid="remote-control-panel">
-      {blockingRemoteOperation
-        ? createPortal(
-            <div
-              className="fixed inset-0 z-[100] flex items-center justify-center bg-black/45 p-6"
-              data-testid="remote-access-operation-overlay"
-              role="status"
-              aria-busy="true"
-              aria-live="assertive"
-            >
-              <div className="flex max-w-sm items-center gap-3 rounded-xl border border-border bg-background px-5 py-4 text-foreground shadow-dialog">
-                <LoaderCircle className="size-5 shrink-0 animate-spin text-primary" aria-hidden />
-                <div>
-                  <div className="text-sm font-medium">
-                    {detectingAndRepairing
-                      ? 'Checking and setting up remote access…'
-                      : 'Applying remote access settings…'}
-                  </div>
-                  <div className="mt-1 text-xs text-muted-foreground">
-                    Waiting for the system command to finish.
-                  </div>
-                </div>
-              </div>
-            </div>,
-            document.body
-          )
-        : null}
+      <Dialog.Root open={blockingRemoteOperation}>
+        <Dialog.Portal>
+          <Dialog.Overlay
+            className={cn(dialogOverlayClassName, 'z-[100] bg-black/45')}
+            data-testid="remote-access-operation-scrim"
+          />
+          <Dialog.Content
+            className={dialogPanelClassName(
+              'z-[100] flex w-[min(384px,calc(100vw-3rem))] max-w-sm items-center gap-3 px-5 py-4'
+            )}
+            onEscapeKeyDown={(event) => event.preventDefault()}
+            onInteractOutside={(event) => event.preventDefault()}
+            aria-modal="true"
+            aria-busy="true"
+            aria-live="assertive"
+            data-testid="remote-access-operation-overlay"
+          >
+            <LoaderCircle className="size-5 shrink-0 animate-spin text-primary" aria-hidden />
+            <div>
+              <Dialog.Title className={dialogTitleClassName}>
+                {detectingAndRepairing
+                  ? 'Checking and setting up remote access…'
+                  : 'Applying remote access settings…'}
+              </Dialog.Title>
+              <Dialog.Description className={cn(dialogDescriptionClassName, 'mt-1 text-xs')}>
+                Waiting for the system command to finish.
+              </Dialog.Description>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
 
       <SettingsSection
         className="relative"
@@ -306,7 +358,10 @@ export const RemoteControlPanel = (): React.JSX.Element => {
                   aria-label={option.title}
                   checked={selected}
                   disabled={disabled}
-                  onChange={selectMode}
+                  onChange={(event) => {
+                    operationTriggerRef.current = event.currentTarget
+                    selectMode()
+                  }}
                   className="peer sr-only"
                 />
                 <div className="flex min-w-0 items-center gap-2">

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1173,7 +1173,25 @@ describe('SettingsPage layout', () => {
         }
       }
     ).api.remoteAccess
-    remoteAccess.getSnapshot.mockRejectedValueOnce(new Error('Remote access is unavailable.'))
+    const retrySnapshot = {
+      canManage: true,
+      canManagePairing: true,
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'disabled',
+      remoteIt: { installed: false, loggedIn: false, registered: false },
+      pendingRequests: [],
+      trustedBrowsers: []
+    }
+    let finishRetry!: (snapshot: typeof retrySnapshot) => void
+    remoteAccess.getSnapshot
+      .mockRejectedValueOnce(new Error('Remote access is unavailable.'))
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishRetry = resolve
+          })
+      )
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -1187,13 +1205,21 @@ describe('SettingsPage layout', () => {
     )
     expect(retryButton).not.toBeUndefined()
 
-    await act(async () => {
+    act(() => {
       retryButton?.click()
+      retryButton?.click()
+    })
+
+    expect(remoteAccess.getSnapshot).toHaveBeenCalledTimes(2)
+    expect(document.body.textContent).toContain('Loading remote access')
+    expect(document.body.textContent).not.toContain('Try again')
+
+    await act(async () => {
+      finishRetry(retrySnapshot)
       await Promise.resolve()
       await Promise.resolve()
     })
 
-    expect(remoteAccess.getSnapshot).toHaveBeenCalledTimes(2)
     expect(document.body.textContent).not.toContain('Remote access is unavailable.')
     expect(document.body.querySelector('[data-testid="remote-access-status"]')?.textContent).toBe(
       'Remote access is off'

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1226,6 +1226,97 @@ describe('SettingsPage layout', () => {
     )
   })
 
+  it('does not detect after leaving Remote control during the initial snapshot load', async () => {
+    const remoteAccess = (
+      window as unknown as {
+        api: {
+          remoteAccess: {
+            getSnapshot: ReturnType<typeof vi.fn>
+            detect: ReturnType<typeof vi.fn>
+          }
+        }
+      }
+    ).api.remoteAccess
+    const manageableSnapshot = {
+      canManage: true,
+      canManagePairing: true,
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'disabled',
+      remoteIt: { installed: false, loggedIn: false, registered: false },
+      pendingRequests: [],
+      trustedBrowsers: []
+    }
+    let finishInitialLoad!: (snapshot: typeof manageableSnapshot) => void
+    remoteAccess.getSnapshot.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishInitialLoad = resolve
+        })
+    )
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () => navButton('Remote control')?.click())
+    expect(document.body.textContent).toContain('Loading remote access')
+
+    act(() => navButton('Model')?.click())
+    await act(async () => {
+      finishInitialLoad(manageableSnapshot)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(remoteAccess.detect).not.toHaveBeenCalled()
+  })
+
+  it('does not detect after leaving Remote control during an initial-load retry', async () => {
+    const remoteAccess = (
+      window as unknown as {
+        api: {
+          remoteAccess: {
+            getSnapshot: ReturnType<typeof vi.fn>
+            detect: ReturnType<typeof vi.fn>
+          }
+        }
+      }
+    ).api.remoteAccess
+    const manageableSnapshot = {
+      canManage: true,
+      canManagePairing: true,
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'disabled',
+      remoteIt: { installed: false, loggedIn: false, registered: false },
+      pendingRequests: [],
+      trustedBrowsers: []
+    }
+    let finishRetry!: (snapshot: typeof manageableSnapshot) => void
+    remoteAccess.getSnapshot
+      .mockRejectedValueOnce(new Error('Remote access is unavailable.'))
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishRetry = resolve
+          })
+      )
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () => navButton('Remote control')?.click())
+    const retryButton = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Try again')
+    )
+    act(() => retryButton?.click())
+
+    act(() => navButton('Model')?.click())
+    await act(async () => {
+      finishRetry(manageableSnapshot)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(remoteAccess.detect).not.toHaveBeenCalled()
+  })
+
   it('covers the whole app while a remote mode system command is still running', async () => {
     const remoteAccess = (
       window as unknown as {

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1163,6 +1163,43 @@ describe('SettingsPage layout', () => {
     ).toHaveBeenCalledOnce()
   })
 
+  it('exits loading when the initial remote access snapshot fails', async () => {
+    const remoteAccess = (
+      window as unknown as {
+        api: {
+          remoteAccess: {
+            getSnapshot: ReturnType<typeof vi.fn>
+          }
+        }
+      }
+    ).api.remoteAccess
+    remoteAccess.getSnapshot.mockRejectedValueOnce(new Error('Remote access is unavailable.'))
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await act(async () => navButton('Remote control')?.click())
+
+    expect(document.body.textContent).not.toContain('Loading remote access')
+    expect(document.body.textContent).toContain('Remote access is unavailable.')
+    const retryButton = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Try again')
+    )
+    expect(retryButton).not.toBeUndefined()
+
+    await act(async () => {
+      retryButton?.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(remoteAccess.getSnapshot).toHaveBeenCalledTimes(2)
+    expect(document.body.textContent).not.toContain('Remote access is unavailable.')
+    expect(document.body.querySelector('[data-testid="remote-access-status"]')?.textContent).toBe(
+      'Remote access is off'
+    )
+  })
+
   it('covers the whole app while a remote mode system command is still running', async () => {
     const remoteAccess = (
       window as unknown as {
@@ -1217,10 +1254,16 @@ describe('SettingsPage layout', () => {
 
     expect(remoteAccess.setMode).toHaveBeenCalledTimes(1)
     const overlay = document.body.querySelector('[data-testid="remote-access-operation-overlay"]')
+    const scrim = document.body.querySelector('[data-testid="remote-access-operation-scrim"]')
+    expect(scrim).not.toBeNull()
+
     expect(overlay).not.toBeNull()
     expect(overlay?.textContent).toContain('Applying remote access settings')
-    expect(overlay?.className).toContain('fixed')
-    expect(overlay?.className).toContain('inset-0')
+    expect(scrim?.className).toContain('fixed')
+    expect(scrim?.className).toContain('inset-0')
+    expect(overlay?.getAttribute('role')).toBe('dialog')
+    expect(overlay?.getAttribute('aria-modal')).toBe('true')
+    expect(overlay?.contains(document.activeElement)).toBe(true)
     expect(document.body.querySelector('[data-testid="remote-access-status"]')?.textContent).toBe(
       'Changing access mode…'
     )
@@ -1252,6 +1295,7 @@ describe('SettingsPage layout', () => {
     expect(
       document.body.querySelector('[data-testid="remote-access-operation-overlay"]')
     ).toBeNull()
+    expect(document.activeElement).toBe(remoteItMode)
     expect(document.body.querySelector('[data-testid="remote-access-status"]')?.textContent).toBe(
       'App access is on'
     )


### PR DESCRIPTION
## Problem

The Remote control settings panel could become permanently stuck on “Loading remote access…” when the initial snapshot IPC call rejected. The error was stored, but the `snapshot === null` early return made the error UI unreachable.

Blocking Remote.It operations used a visual portal overlay with `role=status`, but it did not establish a modal focus boundary. Keyboard and assistive-technology focus could remain in the settings UI behind the scrim.

## Proposed change

- Render a retryable error state when the initial snapshot cannot be loaded.
- Preserve the initial snapshot while desktop provider detection completes, matching the prior successful-path behavior.
- Prevent overlapping initial-load retries and skip provider detection if the panel unmounts before the snapshot resolves.
- Replace the hand-built blocking portal with the shared Radix Dialog primitives.
- Prevent Escape and outside interaction while the system command is running.
- Return focus to the mode or Detect control that started the operation.
- Add regression coverage for initial failure/retry, retry concurrency, unmount cancellation, modal semantics, focus containment, and focus restoration.

## Scope and non-goals

This is limited to the Remote control renderer panel and its existing SettingsPage render tests. It does not change Remote Access IPC, service behavior, persistence, or Remote.It command execution.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Initial load failure exits Loading and exposes retry; retry recovers; duplicate retries are rejected; provider detection is cancelled after the panel unmounts -> `npm test -- src/renderer/src/pages/settings/SettingsPage.render.test.tsx --reporter=dot` -> passed, 60/60.
- Blocking provider commands use a modal dialog, move focus inside it, remain visible across lifecycle broadcasts, and restore the initiating control -> same SettingsPage test file -> passed, 60/60.
- Renderer and shared TypeScript contracts -> `npm run typecheck` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors; 13 existing warnings remain outside the changed files.
- Portable fallback suite -> `npm test -- --reporter=dot` -> attempted but did not pass because of unrelated cross-module failures in this Windows environment. A representative symlink failure reproduces on the unchanged `main` worktree with `EPERM`; a Subagent render failure from the full run passes when run alone on unchanged `main`.

The module-impact manifest does not assign this panel a narrow owner, so the full fallback was attempted. No existing Remote control E2E accessibility scenario was found. The renderer test exercises the real SettingsPage/RemoteControlPanel seam; CI remains authoritative for the complete portable and platform suites.

## Review focus

- Whether the retry state preserves the intended initial snapshot/detect sequence without overlapping work or post-unmount detection.
- Whether the nested Radix dialog correctly isolates and restores focus inside the already-modal Settings window.