### PR TITLE
fix(workspace): improve composer accessibility

### DIFF
--- a/src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx
@@ -53,7 +53,10 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
   }>): React.JSX.Element =>
     // asChild items keep their real child element; wire the select handler onto its click.
     asChild && isValidElement(children) ? (
-      cloneElement(children as ReactElement<{ onClick?: () => void }>, { onClick: onSelect })
+      cloneElement(children as ReactElement<{ onClick?: () => void }>, {
+        ...rest,
+        onClick: onSelect
+      })
     ) : (
       <button type="button" disabled={disabled} onClick={onSelect} {...rest}>
         {children}
@@ -152,6 +155,28 @@ describe('ComposerYourFilesMenu', () => {
     expect(rootRow?.textContent).toContain('ro')
   })
 
+  it('keeps hidden row actions visible to keyboard and no-hover users', async () => {
+    renderMenu()
+
+    const removeButton = container.querySelector('[data-testid="your-files-remove-root-1"]')
+    expect(removeButton?.classList).not.toContain('opacity-0')
+    expect(removeButton?.classList).toContain('[@media(hover:hover)]:opacity-0')
+    expect(removeButton?.classList).toContain('[@media(hover:hover)]:focus-visible:opacity-100')
+    expect(removeButton?.classList).toContain('focus-visible:ring-[3px]')
+    expect(removeButton?.classList).toContain('[@media(pointer:coarse)]:size-11')
+    expect(removeButton?.parentElement?.classList).toContain('[@media(pointer:coarse)]:h-11')
+
+    await click(container.querySelector('[data-testid="your-files-root-toggle-root-1"]'))
+    await flush()
+
+    const sendButton = container.querySelector('[data-testid="your-files-send-root-1-study.csv"]')
+    expect(sendButton?.classList).not.toContain('opacity-0')
+    expect(sendButton?.classList).toContain('[@media(hover:hover)]:opacity-0')
+    expect(sendButton?.classList).toContain('[@media(hover:hover)]:focus-visible:opacity-100')
+    expect(sendButton?.classList).toContain('focus-visible:ring-[3px]')
+    expect(sendButton?.classList).toContain('[@media(pointer:coarse)]:size-11')
+    expect(sendButton?.parentElement?.classList).toContain('[@media(pointer:coarse)]:min-h-11')
+  })
   it('shows a quiet hint when no folders are granted', () => {
     useGrantedFoldersStore.setState({ roots: [], loaded: true })
     renderMenu()

--- a/src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx
@@ -177,6 +177,20 @@ describe('ComposerYourFilesMenu', () => {
     expect(sendButton?.classList).toContain('[@media(pointer:coarse)]:size-11')
     expect(sendButton?.parentElement?.classList).toContain('[@media(pointer:coarse)]:min-h-11')
   })
+  it('gives root and nested directory toggles coarse-pointer hit targets', async () => {
+    renderMenu()
+
+    const rootToggle = container.querySelector('[data-testid="your-files-root-toggle-root-1"]')
+    expect(rootToggle?.classList).toContain('[@media(pointer:coarse)]:min-h-11')
+
+    await click(rootToggle)
+    await flush()
+
+    const nestedToggle = container.querySelector('[data-testid="your-files-dir-root-1-raw"]')
+    expect(nestedToggle?.classList).toContain('[@media(pointer:coarse)]:min-h-11')
+    expect(nestedToggle?.parentElement?.classList).toContain('[@media(pointer:coarse)]:py-0')
+  })
+
   it('shows a quiet hint when no folders are granted', () => {
     useGrantedFoldersStore.setState({ roots: [], loaded: true })
     renderMenu()

--- a/src/renderer/src/pages/workspace/ComposerYourFilesMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerYourFilesMenu.tsx
@@ -170,7 +170,7 @@ export const ComposerYourFilesMenu = ({
               title={relativePath}
               // Same metrics as the directory rows above: identical padding, text size, icon size,
               // and hover background so every tree row has one consistent height and hover style.
-              className="group relative flex items-center gap-0.5 rounded-md py-1 pr-1.5 text-[13px] text-text-000 hover:bg-bg-200"
+              className="group relative flex items-center gap-0.5 rounded-md py-1 pr-1.5 text-[13px] text-text-000 hover:bg-bg-200 [@media(pointer:coarse)]:min-h-11"
               style={{ paddingLeft: indentForDepth(depth) }}
             >
               <File
@@ -196,10 +196,10 @@ export const ComposerYourFilesMenu = ({
                         className={cn(
                           // min-h-0/p-0/transparent backgrounds cancel the DropdownMenuItem base
                           // chrome — this is a bare icon, not a full-size menu row.
-                          'flex min-h-0 shrink-0 items-center justify-center p-0 transition-opacity hover:bg-transparent data-[highlighted]:bg-transparent',
+                          'relative flex min-h-0 shrink-0 items-center justify-center p-0 opacity-100 transition-opacity hover:bg-transparent focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 data-[highlighted]:bg-transparent [@media(pointer:coarse)]:size-11',
                           isAdded
                             ? 'text-mention-chip-foreground'
-                            : 'text-text-100 opacity-0 hover:text-text-000 group-hover:opacity-100 data-[highlighted]:text-text-000 data-[highlighted]:opacity-100'
+                            : 'text-text-100 hover:text-text-000 data-[highlighted]:text-text-000 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:focus-visible:opacity-100 [@media(hover:hover)]:data-[highlighted]:opacity-100'
                         )}
                       >
                         <button
@@ -269,7 +269,7 @@ export const ComposerYourFilesMenu = ({
                 <div key={root.id} data-testid={`your-files-root-${root.id}`}>
                   {/* Fixed height + opacity-based reveal for the × action: hover only changes the
                       background, so the row (and the list below it) never shifts. */}
-                  <div className="group flex h-[30px] items-center gap-1.5 rounded-md pr-1.5 pl-1.5 text-[13px] text-text-000 hover:bg-bg-200">
+                  <div className="group flex h-[30px] items-center gap-1.5 rounded-md pr-1.5 pl-1.5 text-[13px] text-text-000 hover:bg-bg-200 [@media(pointer:coarse)]:h-11">
                     <button
                       type="button"
                       aria-expanded={isExpanded}
@@ -305,7 +305,7 @@ export const ComposerYourFilesMenu = ({
                         event.preventDefault()
                         void remove(root.id).catch(() => undefined)
                       }}
-                      className="flex size-[22px] shrink-0 items-center justify-center rounded-[5px] text-text-100 opacity-0 transition-opacity duration-150 hover:bg-bg-300 hover:text-text-000 group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100"
+                      className="relative flex size-[22px] shrink-0 items-center justify-center rounded-[5px] text-text-100 opacity-100 transition-opacity duration-150 hover:bg-bg-300 hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 motion-reduce:transition-none [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:focus-visible:opacity-100 [@media(hover:none)]:opacity-100 [@media(pointer:coarse)]:size-11"
                     >
                       <X className="size-3.5" strokeWidth={2} aria-hidden="true" />
                     </button>

--- a/src/renderer/src/pages/workspace/ComposerYourFilesMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerYourFilesMenu.tsx
@@ -133,7 +133,7 @@ export const ComposerYourFilesMenu = ({
             return (
               <div key={childPath}>
                 <div
-                  className="group flex items-center gap-1.5 rounded-md py-1 pr-1.5 text-[13px] text-text-000 hover:bg-bg-200"
+                  className="group flex items-center gap-1.5 rounded-md py-1 pr-1.5 text-[13px] text-text-000 hover:bg-bg-200 [@media(pointer:coarse)]:py-0"
                   style={{ paddingLeft: indentForDepth(depth) }}
                 >
                   <button
@@ -141,7 +141,7 @@ export const ComposerYourFilesMenu = ({
                     aria-expanded={isExpanded}
                     data-testid={`your-files-dir-${root.id}-${relativePath}`}
                     onClick={() => toggleDir(childPath)}
-                    className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                    className="flex min-w-0 flex-1 items-center gap-1.5 text-left [@media(pointer:coarse)]:min-h-11"
                   >
                     <ChevronRight
                       className={cn(
@@ -275,7 +275,7 @@ export const ComposerYourFilesMenu = ({
                       aria-expanded={isExpanded}
                       data-testid={`your-files-root-toggle-${root.id}`}
                       onClick={() => toggleDir(root.path)}
-                      className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                      className="flex min-w-0 flex-1 items-center gap-1.5 text-left [@media(pointer:coarse)]:min-h-11"
                     >
                       <ChevronRight
                         className={cn(

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -124,7 +124,13 @@ const MessageTimestamp = ({
   date: Date
 }): React.JSX.Element => {
   return (
-    <time dateTime={date.toISOString()} title={messageTimestampTitleFormatter.format(date)}>
+    <time
+      role={label === 'Completed' ? 'status' : label === 'Failed' ? 'alert' : undefined}
+      aria-live={label === 'Completed' ? 'polite' : label === 'Failed' ? 'assertive' : undefined}
+      aria-atomic={label === 'Sent' ? undefined : true}
+      dateTime={date.toISOString()}
+      title={messageTimestampTitleFormatter.format(date)}
+    >
       {label} {messageTimestampFormatter.format(date)}
     </time>
   )

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -124,13 +124,7 @@ const MessageTimestamp = ({
   date: Date
 }): React.JSX.Element => {
   return (
-    <time
-      role={label === 'Completed' ? 'status' : label === 'Failed' ? 'alert' : undefined}
-      aria-live={label === 'Completed' ? 'polite' : label === 'Failed' ? 'assertive' : undefined}
-      aria-atomic={label === 'Sent' ? undefined : true}
-      dateTime={date.toISOString()}
-      title={messageTimestampTitleFormatter.format(date)}
-    >
+    <time dateTime={date.toISOString()} title={messageTimestampTitleFormatter.format(date)}>
       {label} {messageTimestampFormatter.format(date)}
     </time>
   )

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -2347,11 +2347,12 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
       )
     })
-    const mentionAlert = container.querySelector('[role="alert"]')
-    expect(mentionAlert).not.toBeNull()
-    expect(mentionAlert?.getAttribute('aria-live')).toBe('assertive')
-    expect(mentionAlert?.getAttribute('aria-atomic')).toBe('true')
-    expect(mentionAlert?.textContent).toBe('')
+    const mentionLiveRegion = container.querySelector('[data-testid="mention-notice-live-region"]')
+    expect(mentionLiveRegion).not.toBeNull()
+    expect(mentionLiveRegion?.getAttribute('role')).toBeNull()
+    expect(mentionLiveRegion?.getAttribute('aria-live')).toBe('assertive')
+    expect(mentionLiveRegion?.getAttribute('aria-atomic')).toBe('true')
+    expect(mentionLiveRegion?.textContent).toBe('')
     const pill = container.querySelector<HTMLButtonElement>('[aria-label="Preview sin.png"]')
     expect(pill).not.toBeNull()
     await act(async () => {
@@ -2405,9 +2406,9 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(container.textContent).toContain(
       'Linked-folder files are not available until the folder is connected.'
     )
-    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
-      'Linked-folder files are not available until the folder is connected.'
-    )
+    expect(
+      container.querySelector('[data-testid="mention-notice-live-region"]')?.textContent
+    ).toContain('Linked-folder files are not available until the folder is connected.')
   })
 
   it('does not read a generated text thumbnail until its card approaches the viewport', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -2347,6 +2347,11 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
       )
     })
+    const mentionAlert = container.querySelector('[role="alert"]')
+    expect(mentionAlert).not.toBeNull()
+    expect(mentionAlert?.getAttribute('aria-live')).toBe('assertive')
+    expect(mentionAlert?.getAttribute('aria-atomic')).toBe('true')
+    expect(mentionAlert?.textContent).toBe('')
     const pill = container.querySelector<HTMLButtonElement>('[aria-label="Preview sin.png"]')
     expect(pill).not.toBeNull()
     await act(async () => {
@@ -2398,6 +2403,9 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
     expect(upsertAndActivateItem).not.toHaveBeenCalled()
     expect(container.textContent).toContain(
+      'Linked-folder files are not available until the folder is connected.'
+    )
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
       'Linked-folder files are not available until the folder is connected.'
     )
   })

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -466,6 +466,139 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(container.textContent).toContain('Completed')
   })
 
+  it('announces only assistant terminal transitions after the current branch mounts', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const historicalPrompt = createMessage({
+      id: 'prompt-historical-failure',
+      sortIndex: 1,
+      createdAt: 100
+    })
+    const historicalFailure = createMessage({
+      id: 'reply-historical-failure',
+      role: 'agent',
+      content: 'Historical failure',
+      status: 'error',
+      responseToMessageId: historicalPrompt.id,
+      failedAt: 102,
+      sortIndex: 2,
+      createdAt: 101,
+      updatedAt: 102
+    })
+    const completionPrompt = createMessage({
+      id: 'prompt-live-completion',
+      sortIndex: 3,
+      createdAt: 200
+    })
+    const streamingCompletion = createMessage({
+      id: 'reply-live-completion',
+      role: 'agent',
+      content: '',
+      status: 'streaming',
+      streamId: 'stream-live-completion',
+      responseToMessageId: completionPrompt.id,
+      sortIndex: 4,
+      createdAt: 201
+    })
+    const failurePrompt = createMessage({
+      id: 'prompt-live-failure',
+      sortIndex: 5,
+      createdAt: 300
+    })
+    const streamingFailure = createMessage({
+      id: 'reply-live-failure',
+      role: 'agent',
+      content: '',
+      status: 'streaming',
+      streamId: 'stream-live-failure',
+      responseToMessageId: failurePrompt.id,
+      sortIndex: 6,
+      createdAt: 301
+    })
+    const render = async (session: ChatSession): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+        )
+      })
+    }
+
+    root = createRoot(container)
+    await render(
+      createSession({
+        status: 'error',
+        messages: [historicalPrompt, historicalFailure]
+      })
+    )
+
+    const completionRegion = container.querySelector(
+      '[data-testid="message-completion-live-region"]'
+    )
+    const failureRegion = container.querySelector('[data-testid="message-failure-live-region"]')
+    expect(completionRegion?.getAttribute('aria-live')).toBe('polite')
+    expect(failureRegion?.getAttribute('aria-live')).toBe('assertive')
+    expect(completionRegion?.textContent).toBe('')
+    expect(failureRegion?.textContent).toBe('')
+
+    await render(
+      createSession({
+        messages: [historicalPrompt, historicalFailure, completionPrompt, streamingCompletion],
+        activeRun: { promptMessageId: completionPrompt.id, startedAt: 200 }
+      })
+    )
+    expect(completionRegion?.textContent).toBe('')
+    expect(failureRegion?.textContent).toBe('')
+
+    const completedReply = {
+      ...streamingCompletion,
+      status: 'complete' as const,
+      completedAt: 202,
+      updatedAt: 202
+    }
+    await render(
+      createSession({
+        status: 'idle',
+        messages: [historicalPrompt, historicalFailure, completionPrompt, completedReply]
+      })
+    )
+    expect(completionRegion?.textContent).toBe('Response completed.')
+    expect(failureRegion?.textContent).toBe('')
+
+    await render(
+      createSession({
+        messages: [
+          historicalPrompt,
+          historicalFailure,
+          completionPrompt,
+          completedReply,
+          failurePrompt,
+          streamingFailure
+        ],
+        activeRun: { promptMessageId: failurePrompt.id, startedAt: 300 }
+      })
+    )
+    const failedReply = {
+      ...streamingFailure,
+      status: 'error' as const,
+      failedAt: 302,
+      updatedAt: 302
+    }
+    await render(
+      createSession({
+        status: 'error',
+        messages: [
+          historicalPrompt,
+          historicalFailure,
+          completionPrompt,
+          completedReply,
+          failurePrompt,
+          failedReply
+        ]
+      })
+    )
+    expect(completionRegion?.textContent).toBe('')
+    expect(failureRegion?.textContent).toBe('Response failed.')
+  })
+
   it('does not replay a buffered assistant message after switching sessions', async () => {
     vi.useFakeTimers()
     vi.stubGlobal(

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -768,6 +768,46 @@ describe('WorkspaceMessageScroller loading render', () => {
     expect(html).not.toContain('Input</dt>')
   })
 
+  it('exposes completed and failed assistant timestamps as status messages', async () => {
+    const completedHtml = await renderScroller(
+      createSession({
+        status: 'idle',
+        messages: [
+          createMessage({ id: 'prompt-complete' }),
+          createMessage({
+            id: 'reply-complete',
+            role: 'agent',
+            content: 'Done',
+            responseToMessageId: 'prompt-complete',
+            completedAt: 1710000001000
+          })
+        ]
+      })
+    )
+    const failedHtml = await renderScroller(
+      createSession({
+        status: 'error',
+        messages: [
+          createMessage({ id: 'prompt-failed' }),
+          createMessage({
+            id: 'reply-failed',
+            role: 'agent',
+            content: 'Could not finish',
+            status: 'error',
+            responseToMessageId: 'prompt-failed',
+            failedAt: 1710000001000
+          })
+        ]
+      })
+    )
+
+    expect(completedHtml).toMatch(
+      /<time[^>]*role="status"[^>]*aria-live="polite"[^>]*aria-atomic="true"/
+    )
+    expect(failedHtml).toMatch(
+      /<time[^>]*role="alert"[^>]*aria-live="assertive"[^>]*aria-atomic="true"/
+    )
+  })
   it('does not expose the fallback framework from a synthesized legacy graph', async () => {
     const messages = [
       createMessage({ id: 'prompt-1' }),

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -768,7 +768,7 @@ describe('WorkspaceMessageScroller loading render', () => {
     expect(html).not.toContain('Input</dt>')
   })
 
-  it('exposes completed and failed assistant timestamps as status messages', async () => {
+  it('keeps persisted completed and failed timestamps outside live regions', async () => {
     const completedHtml = await renderScroller(
       createSession({
         status: 'idle',
@@ -801,12 +801,15 @@ describe('WorkspaceMessageScroller loading render', () => {
       })
     )
 
-    expect(completedHtml).toMatch(
-      /<time[^>]*role="status"[^>]*aria-live="polite"[^>]*aria-atomic="true"/
-    )
-    expect(failedHtml).toMatch(
-      /<time[^>]*role="alert"[^>]*aria-live="assertive"[^>]*aria-atomic="true"/
-    )
+    const completedTimestamp = completedHtml.match(/<time[^>]*>Completed [^<]*<\/time>/)?.[0]
+    const failedTimestamp = failedHtml.match(/<time[^>]*>Failed [^<]*<\/time>/)?.[0]
+
+    expect(completedTimestamp).toBeDefined()
+    expect(completedTimestamp).not.toContain('role=')
+    expect(completedTimestamp).not.toContain('aria-live=')
+    expect(failedTimestamp).toBeDefined()
+    expect(failedTimestamp).not.toContain('role=')
+    expect(failedTimestamp).not.toContain('aria-live=')
   })
   it('does not expose the fallback framework from a synthesized legacy graph', async () => {
     const messages = [

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1055,16 +1055,18 @@ const WorkspaceMessageScrollerImpl = ({
           <MessageScrollerButton className="z-10 border-transparent bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3" />
 
           {/* Transient warning shown when a mention target no longer resolves to a file or skill. */}
-          {mentionNotice ? (
-            <div
-              role="status"
-              className="pointer-events-none absolute inset-x-0 bottom-14 z-10 flex justify-center px-4"
-            >
+          <div
+            role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
+            className="pointer-events-none absolute inset-x-0 bottom-14 z-10 flex justify-center px-4"
+          >
+            {mentionNotice ? (
               <span className="rounded-full border border-border-200 bg-bg-000 px-3 py-1 text-[13px] text-text-100 shadow-card">
                 {mentionNotice}
               </span>
-            </div>
-          ) : null}
+            ) : null}
+          </div>
         </MessageScroller>
       </MessageScrollerProvider>
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/stores/preview-workbench-store'
 import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
 import { useSettingsStore } from '@/stores/settings-store'
-import { useSessionStore, type ChatSession } from '@/stores/session-store'
+import { useSessionStore, type ChatMessage, type ChatSession } from '@/stores/session-store'
 import {
   memo,
   useCallback,
@@ -83,6 +83,16 @@ type WorkspaceMessageScrollerProps = {
   // Events are read-only projections; retry sends an intent that main validates against its state.
   handoffLifecycleSource?: HandoffLifecycleEventSource
   onRetryHandoff?: (request: HandoffRetryRequest) => Promise<void>
+}
+
+type TerminalAnnouncement = {
+  messageId: string
+  status: 'complete' | 'error'
+}
+
+type TerminalMessageSnapshot = {
+  scopeId: string | undefined
+  statuses: Map<string, ChatMessage['status']>
 }
 
 type SessionScopedActivityGroupState = {
@@ -479,6 +489,48 @@ const WorkspaceMessageScrollerImpl = ({
     [activeSession?.messages]
   )
   const agentLoadingPhase = getAgentLoadingPhase(activeSession)
+  const [terminalAnnouncement, setTerminalAnnouncement] = useState<
+    TerminalAnnouncement | undefined
+  >()
+  const terminalMessageSnapshotRef = useRef<TerminalMessageSnapshot>({
+    scopeId: undefined,
+    statuses: new Map()
+  })
+
+  // Persisted terminal messages are history, not live events. Establish a fresh snapshot whenever
+  // the visible session/branch changes, then announce only terminal states observed afterwards.
+  useEffect(() => {
+    const terminalMessages = (activeSession?.messages ?? []).filter(
+      (message) => message.role === 'agent' && assistantFooterMessageIds.has(message.id)
+    )
+    const nextStatuses = new Map(
+      terminalMessages.map((message) => [message.id, message.status] as const)
+    )
+    const previousSnapshot = terminalMessageSnapshotRef.current
+    let nextAnnouncement: TerminalAnnouncement | undefined
+
+    if (currentPresentationScopeId && previousSnapshot.scopeId === currentPresentationScopeId) {
+      for (const message of terminalMessages) {
+        if (
+          (message.status === 'complete' || message.status === 'error') &&
+          previousSnapshot.statuses.get(message.id) !== message.status
+        ) {
+          nextAnnouncement = { messageId: message.id, status: message.status }
+        }
+      }
+    }
+
+    terminalMessageSnapshotRef.current = {
+      scopeId: currentPresentationScopeId,
+      statuses: nextStatuses
+    }
+    if (previousSnapshot.scopeId !== currentPresentationScopeId) {
+      setTerminalAnnouncement(undefined)
+    } else if (nextAnnouncement) {
+      setTerminalAnnouncement(nextAnnouncement)
+    }
+  }, [activeSession?.messages, assistantFooterMessageIds, currentPresentationScopeId])
+
   const messageCreatedAtById = new Map(
     activeSession?.messages.map((message) => [message.id, message.createdAt]) ?? []
   )
@@ -1053,6 +1105,26 @@ const WorkspaceMessageScrollerImpl = ({
           ) : null}
 
           <MessageScrollerButton className="z-10 border-transparent bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3" />
+          <div
+            data-testid="message-completion-live-region"
+            aria-live="polite"
+            aria-atomic="true"
+            className="sr-only"
+          >
+            {terminalAnnouncement?.status === 'complete' ? (
+              <span key={`${terminalAnnouncement.messageId}:complete`}>Response completed.</span>
+            ) : null}
+          </div>
+          <div
+            data-testid="message-failure-live-region"
+            aria-live="assertive"
+            aria-atomic="true"
+            className="sr-only"
+          >
+            {terminalAnnouncement?.status === 'error' ? (
+              <span key={`${terminalAnnouncement.messageId}:error`}>Response failed.</span>
+            ) : null}
+          </div>
 
           {/* Transient warning shown when a mention target no longer resolves to a file or skill. */}
           <div

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1056,7 +1056,7 @@ const WorkspaceMessageScrollerImpl = ({
 
           {/* Transient warning shown when a mention target no longer resolves to a file or skill. */}
           <div
-            role="alert"
+            data-testid="mention-notice-live-region"
             aria-live="assertive"
             aria-atomic="true"
             className="pointer-events-none absolute inset-x-0 bottom-14 z-10 flex justify-center px-4"

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
@@ -108,6 +108,11 @@ describe('ArtifactMentionPopup', () => {
     act(() => {
       root.render(<ArtifactMentionPopup query="seq" onSelect={vi.fn()} onClose={vi.fn()} />)
     })
+    const loadingStatus = document.body.querySelector('[role="status"]')
+    expect(document.body.querySelector('[role="listbox"]')).not.toBeNull()
+    expect(loadingStatus?.textContent).toContain('Loading project files')
+    expect(loadingStatus?.getAttribute('aria-live')).toBe('polite')
+    expect(loadingStatus?.getAttribute('aria-atomic')).toBe('true')
     const event = new KeyboardEvent('keydown', {
       key: 'Enter',
       bubbles: true,
@@ -187,6 +192,10 @@ describe('ArtifactMentionPopup', () => {
     await renderPopup()
 
     expect(options()).toHaveLength(0)
+    const alert = document.body.querySelector('[role="alert"]')
+    expect(alert?.textContent).toContain('Could not load project files')
+    expect(alert?.getAttribute('aria-live')).toBe('assertive')
+    expect(alert?.getAttribute('aria-atomic')).toBe('true')
     expect(document.body.textContent).toContain('Could not load project files')
     expect(document.body.textContent).not.toContain('No artifacts yet')
   })

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -25,6 +25,8 @@ export type PickedArtifact = {
 // the composer keeps caret focus, so this listens for navigation keys on document while mounted.
 type ArtifactMentionPopupProps = {
   query: string
+  listboxId?: string
+  onActiveOptionIdChange?: (optionId: string | undefined) => void
   onSelect: (ref: PickedArtifact) => void
   onClose: () => void
 }
@@ -67,11 +69,14 @@ const loadProjectFiles = async (projectId: string): Promise<ProjectFileItem[]> =
 
 export const ArtifactMentionPopup = ({
   query,
+  listboxId,
+  onActiveOptionIdChange,
   onSelect,
   onClose
 }: ArtifactMentionPopupProps): React.JSX.Element | null => {
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
-  const listboxId = useId()
+  const generatedListboxId = useId()
+  const resolvedListboxId = listboxId ?? generatedListboxId
   const [projectFiles, setProjectFiles] = useState<{
     projectId?: string
     files: ProjectFileItem[]
@@ -146,6 +151,18 @@ export const ArtifactMentionPopup = ({
   // Keep the highlight within the current match set even after filtering shrinks it.
   const safeIndex = matches.length === 0 ? 0 : Math.min(activeIndex, matches.length - 1)
 
+  const activeOptionId = matches.length > 0 ? `${resolvedListboxId}-option-${safeIndex}` : undefined
+
+  // Focus remains in the editor, so keep its active-descendant target synchronized and visible.
+  useEffect(() => {
+    onActiveOptionIdChange?.(activeOptionId)
+    return () => onActiveOptionIdChange?.(undefined)
+  }, [activeOptionId, onActiveOptionIdChange])
+
+  useEffect(() => {
+    if (activeOptionId)
+      document.getElementById(activeOptionId)?.scrollIntoView?.({ block: 'nearest' })
+  }, [activeOptionId])
   // Handle navigation keys at the document level while mounted, since focus stays in the editor.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
@@ -203,7 +220,7 @@ export const ArtifactMentionPopup = ({
     return (
       <li
         key={`${row.source}:${row.id}`}
-        id={`${listboxId}-option-${index}`}
+        id={`${resolvedListboxId}-option-${index}`}
         role="option"
         aria-selected={isActive}
         onMouseEnter={() => setActiveIndex(index)}
@@ -248,44 +265,48 @@ export const ArtifactMentionPopup = ({
   return (
     <div className="absolute bottom-full left-0 mb-1 z-50 bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)] overflow-hidden">
       {matches.length === 0 ? (
-        <div className="px-2 py-1.5 text-sm text-text-300">
+        <div
+          role={loadState === 'error' ? 'alert' : 'status'}
+          aria-live={loadState === 'error' ? 'assertive' : 'polite'}
+          aria-atomic="true"
+          className="px-2 py-1.5 text-sm text-text-300"
+        >
           {loadState === 'loading'
             ? 'Loading project files…'
             : loadState === 'error'
               ? 'Could not load project files'
               : 'No artifacts yet'}
         </div>
-      ) : (
-        <ul
-          id={`${listboxId}-listbox`}
-          role="listbox"
-          aria-label="Artifact suggestions"
-          className="overflow-y-auto max-h-[min(45vh,18rem)]"
-        >
-          {uploadMatches.length > 0 ? (
-            <>
-              <li
-                aria-hidden="true"
-                className="px-2 pt-1 pb-0.5 text-[11px] font-medium uppercase tracking-wide text-text-400 select-none"
-              >
-                {SECTION_UPLOADS}
-              </li>
-              {uploadMatches.map((row, index) => renderRow(row, index))}
-            </>
-          ) : null}
-          {artifactMatches.length > 0 ? (
-            <>
-              <li
-                aria-hidden="true"
-                className="px-2 pt-1 pb-0.5 text-[11px] font-medium uppercase tracking-wide text-text-400 select-none"
-              >
-                {SECTION_ARTIFACTS}
-              </li>
-              {artifactMatches.map((row, index) => renderRow(row, uploadMatches.length + index))}
-            </>
-          ) : null}
-        </ul>
-      )}
+      ) : null}
+      <ul
+        id={resolvedListboxId}
+        role="listbox"
+        aria-label="Artifact suggestions"
+        className="overflow-y-auto max-h-[min(45vh,18rem)]"
+      >
+        {uploadMatches.length > 0 ? (
+          <>
+            <li
+              aria-hidden="true"
+              className="px-2 pt-1 pb-0.5 text-[11px] font-medium uppercase tracking-wide text-text-400 select-none"
+            >
+              {SECTION_UPLOADS}
+            </li>
+            {uploadMatches.map((row, index) => renderRow(row, index))}
+          </>
+        ) : null}
+        {artifactMatches.length > 0 ? (
+          <>
+            <li
+              aria-hidden="true"
+              className="px-2 pt-1 pb-0.5 text-[11px] font-medium uppercase tracking-wide text-text-400 select-none"
+            >
+              {SECTION_ARTIFACTS}
+            </li>
+            {artifactMatches.map((row, index) => renderRow(row, uploadMatches.length + index))}
+          </>
+        ) : null}
+      </ul>
       <div className="mt-1 -mx-1.5 -mb-1.5 px-3.5 pt-1.5 pb-2 border-t border-border-300 flex items-center gap-3 text-[11px] text-text-400 select-none">
         <span>
           <span className="text-text-300">↑↓</span> navigate

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -520,6 +520,32 @@ describe('ComposerEditor', () => {
     expect(lastCall.nodes.some((node) => node.type === 'skill' && node.id === 'lit')).toBe(true)
   })
 
+  it('exposes the active skill suggestion from the focused editor', () => {
+    renderEditor()
+
+    const textNode = document.createTextNode('/')
+    editor().appendChild(textNode)
+    setCaret(textNode, 1)
+    act(() => {
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    const listbox = document.body.querySelector<HTMLElement>('[role="listbox"]')
+    const options = document.body.querySelectorAll<HTMLElement>('[role="option"]')
+    expect(editor().getAttribute('aria-autocomplete')).toBe('list')
+    expect(editor().getAttribute('aria-controls')).toBe(listbox?.id)
+    expect(editor().getAttribute('aria-activedescendant')).toBe(options[0]?.id)
+
+    dispatchKey(document, 'ArrowDown')
+
+    expect(editor().getAttribute('aria-activedescendant')).toBe(options[1]?.id)
+
+    dispatchKey(document, 'Escape')
+
+    expect(editor().getAttribute('aria-autocomplete')).toBeNull()
+    expect(editor().getAttribute('aria-controls')).toBeNull()
+    expect(editor().getAttribute('aria-activedescendant')).toBeNull()
+  })
   it('deletes the whole chip on Backspace when the caret is right after it', () => {
     const onDocChange = vi.fn()
     renderEditor({
@@ -592,6 +618,27 @@ describe('ComposerEditor', () => {
     ).toBe(true)
   })
 
+  it('exposes the active artifact suggestion from the focused editor', async () => {
+    renderEditor()
+
+    const textNode = document.createTextNode('@')
+    editor().appendChild(textNode)
+    setCaret(textNode, 1)
+    act(() => {
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await flushProjectFiles()
+
+    const listbox = document.body.querySelector<HTMLElement>('[role="listbox"]')
+    const options = document.body.querySelectorAll<HTMLElement>('[role="option"]')
+    expect(editor().getAttribute('aria-autocomplete')).toBe('list')
+    expect(editor().getAttribute('aria-controls')).toBe(listbox?.id)
+    expect(editor().getAttribute('aria-activedescendant')).toBe(options[0]?.id)
+
+    dispatchKey(document, 'ArrowDown')
+
+    expect(editor().getAttribute('aria-activedescendant')).toBe(options[1]?.id)
+  })
   it('allows multiple artifact chips in one message', async () => {
     const onDocChange = vi.fn()
     renderEditor({

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useLayoutEffect, useRef } from 'react'
+import { useCallback, useId, useLayoutEffect, useRef, useState } from 'react'
 
 import type { SkillView } from '../../../../../shared/settings'
 import { resolveLocalPath } from '../../../../../shared/local-fs'
@@ -182,6 +182,8 @@ export const ComposerEditor = ({
   const editorRef = useRef<HTMLDivElement>(null)
   const historyDescriptionId = useId()
   const historyStatusId = useId()
+  const mentionListboxId = useId()
+  const [activeMentionOptionId, setActiveMentionOptionId] = useState<string | undefined>()
   const restoreHistoryCaretRef = useRef(false)
   // Tracks IME composition so Enter never submits mid-composition.
   const composingRef = useRef(false)
@@ -202,6 +204,7 @@ export const ComposerEditor = ({
     trigger: '@',
     disabled: disabled || docArtifactCount(doc) >= MAX_COMPOSER_ARTIFACT_MENTIONS
   })
+  const mentionPopupOpen = mention.active || artifactMention.active
 
   // Read the live DOM back into a doc and notify the parent.
   const emitDocFromDom = useCallback((): void => {
@@ -389,6 +392,9 @@ export const ComposerEditor = ({
         aria-describedby={`${historyDescriptionId} ${historyStatusId}`}
         aria-disabled={disabled || undefined}
         aria-haspopup="listbox"
+        aria-controls={mentionPopupOpen ? mentionListboxId : undefined}
+        aria-activedescendant={mentionPopupOpen ? activeMentionOptionId : undefined}
+        aria-autocomplete={mentionPopupOpen ? 'list' : undefined}
         contentEditable={!disabled}
         suppressContentEditableWarning
         data-placeholder={placeholder}
@@ -420,6 +426,8 @@ export const ComposerEditor = ({
         <SkillMentionPopup
           query={mention.query}
           allowedSkillIds={allowedSkillIds}
+          listboxId={mentionListboxId}
+          onActiveOptionIdChange={setActiveMentionOptionId}
           onSelect={handleSelectSkill}
           onClose={mention.cancel}
         />
@@ -429,6 +437,8 @@ export const ComposerEditor = ({
           query={artifactMention.query}
           onSelect={handleSelectArtifact}
           onClose={artifactMention.cancel}
+          listboxId={mentionListboxId}
+          onActiveOptionIdChange={setActiveMentionOptionId}
         />
       ) : null}
     </div>

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
@@ -19,6 +19,8 @@ const TIER_DESCRIPTION = 0
 type SkillMentionPopupProps = {
   query: string
   allowedSkillIds?: readonly string[]
+  listboxId?: string
+  onActiveOptionIdChange?: (optionId: string | undefined) => void
   onSelect: (skill: SkillView) => void
   onClose: () => void
 }
@@ -33,12 +35,15 @@ const SOURCE_LABELS: Record<SkillSource, string> = {
 export const SkillMentionPopup = ({
   query,
   allowedSkillIds,
+  listboxId,
+  onActiveOptionIdChange,
   onSelect,
   onClose
 }: SkillMentionPopupProps): React.JSX.Element | null => {
   const skills = useSettingsStore((state) => state.skills)
   const loadSkills = useSettingsStore((state) => state.loadSkills)
-  const listboxId = useId()
+  const generatedListboxId = useId()
+  const resolvedListboxId = listboxId ?? generatedListboxId
 
   // The skill list is loaded lazily by the Settings panel; the composer may open before that ever ran,
   // so hydrate it here when empty. Cheap and idempotent — the store keeps the result after the first load.
@@ -93,6 +98,18 @@ export const SkillMentionPopup = ({
 
   // Keep the highlight within the current match set even after filtering shrinks it.
   const safeIndex = matches.length === 0 ? 0 : Math.min(activeIndex, matches.length - 1)
+  const activeOptionId = matches.length > 0 ? `${resolvedListboxId}-option-${safeIndex}` : undefined
+
+  // Focus remains in the editor, so keep its active-descendant target synchronized and visible.
+  useEffect(() => {
+    onActiveOptionIdChange?.(activeOptionId)
+    return () => onActiveOptionIdChange?.(undefined)
+  }, [activeOptionId, onActiveOptionIdChange])
+
+  useEffect(() => {
+    if (activeOptionId)
+      document.getElementById(activeOptionId)?.scrollIntoView?.({ block: 'nearest' })
+  }, [activeOptionId])
 
   // Handle navigation keys at the document level while mounted, since focus stays in the editor.
   useEffect(() => {
@@ -129,7 +146,7 @@ export const SkillMentionPopup = ({
   return (
     <div className="absolute bottom-full left-0 mb-1 z-50 bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)] overflow-hidden">
       <ul
-        id={`${listboxId}-listbox`}
+        id={resolvedListboxId}
         role="listbox"
         aria-label="Skill suggestions"
         className="overflow-y-auto max-h-[min(45vh,18rem)]"
@@ -139,7 +156,7 @@ export const SkillMentionPopup = ({
           return (
             <li
               key={skill.id}
-              id={`${listboxId}-option-${index}`}
+              id={`${resolvedListboxId}-option-${index}`}
               role="option"
               aria-selected={isActive}
               onMouseEnter={() => setActiveIndex(index)}


### PR DESCRIPTION
## Problem

The reported accessibility gaps are reproducible and worth fixing:

- file attach/remove actions are hidden behind hover, so touch users cannot discover them and keyboard focus has no reliable visible reveal;
- skill and artifact suggestions keep focus in the composer but do not connect the textbox to the listbox or expose the active option to assistive technology;
- completion, failure, and unresolved-mention feedback is rendered visually without reliable live-region semantics.

## Proposed change

- Keep row actions visible on no-hover devices, preserve hover reveal on hover-capable pointers, add visible focus rings, and use 44 px coarse-pointer targets.
- Give both mention popups one editor-owned listbox id and synchronize `aria-controls`, `aria-autocomplete`, and `aria-activedescendant`; keep the active option scrolled into view.
- Announce normal completion politely and failures or unresolved mentions assertively; retain a mounted mention alert container so text changes are announced reliably.
- Cover the behavior with focused interaction and render regressions.

## Scope

Renderer workspace UI only. No data model, IPC, storage, dependency, or public API changes.

## Acceptance / validation

- `npm test -- <7 affected Renderer test files>`: 168 passed.
- `npm run typecheck:web`: passed.
- `npm run lint`: passed with 0 errors; 13 pre-existing warnings remain in unrelated files.
- `npm run build:e2e`: passed.
- Accessibility E2E: startup/Home and core dialog/workspace axe scans passed; the keyboard-only journey passed when rerun alone. The full serial suite still has a Windows hidden-window fixture timing issue where dynamic fake-agent replies stop at partial text, causing 3 timeouts before later axe assertions (no blocking axe violation was reported in the surfaces that ran).

## Review focus

- Hover-capable versus coarse/no-hover visibility and target-size variants.
- Active-descendant id integrity while switching and closing skill/artifact suggestion popups.
- Polite completion announcements versus assertive failure and invalid-mention announcements.