### PR TITLE
style(renderer): tighten interaction states and tokens

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -212,7 +212,7 @@ Target values for dark mode. Apply under `.dark` when dark theme is enabled:
 
 1. Default to shadcn semantic classes for new UI: `bg-background`, `text-foreground`, `bg-card`, `bg-accent`, `text-muted-foreground`, and so on.
 2. Use workspace classes only where this document names a workspace surface (shell, sidebar rows, composer, session menus, markdown blocks, and similar).
-3. Do not add new color token names. Extend styling only through the shadcn and workspace token sets below.
+3. Add color roles only when an existing semantic token cannot preserve the intended meaning and visual value. Register the role in `main.css` and document it here before using it in components.
 
 ### shadcn Semantic Tokens
 
@@ -259,6 +259,31 @@ Workspace-only tokens without a shadcn counterpart, plus shadow tokens. For shar
 | `--shadow-card`                     | `shadow-card`                      | `0 0 0 1px rgb(10 10 10 / 0.06), 0 4px 24px rgb(10 10 10 / 0.04)` | Sidebar rail card and composer dock         |
 | `--shadow-card-opaque`              | `shadow-card-opaque`               | `0 0 0 1px rgb(10 10 10 / 0.08), 0 8px 28px rgb(10 10 10 / 0.1)`  | Composer form                               |
 | `--shadow-menu` / `--shadow-dialog` | `shadow-menu`, `shadow-dialog`     | `0 2px 8px rgb(0 0 0 / 0.08)`, `0 8px 32px rgb(10 10 10 / 12%)`   | Menus and modal dialogs                     |
+
+### Settings Status and Category Tokens
+
+Settings views use named aliases for categorical data and host status. The aliases in `main.css`
+resolve to the established Tailwind palette values, so semantic cleanup does not change the rendered
+colors.
+
+| Semantic role        | Tailwind classes                                                                                                                             | Usage                                          |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Storage categories   | `bg-storage-artifacts`, `bg-storage-delegation`, `bg-storage-runtime`, `bg-storage-uploads`, `bg-storage-notebooks`, `bg-storage-workspaces` | Disk-usage bar segments and legend swatches    |
+| Success surface      | `bg-status-success-surface`, `text-status-success-foreground`                                                                                | Reachable Compute host icon and badge          |
+| Success accent       | `bg-status-success-accent/10`, `text-status-success-accent-foreground`                                                                       | Completed storage migration icon               |
+| Failure surface      | `bg-status-failure-surface`, `text-status-failure-foreground`                                                                                | Failed Compute host icon and badge             |
+| Failure detail       | `border-status-failure-border`, `bg-status-failure-subtle/50`, `text-status-failure-accent`, `text-status-failure-strong`                    | Compute probe failure panel                    |
+| Dark status variants | `dark:*-status-success-dark-*`, `dark:*-status-failure-dark-*`                                                                               | Preserve the existing dark-mode status palette |
+
+Do not use these tokens as general brand accents. Storage colors distinguish categories; status
+colors communicate a successful or failed probe/migration result.
+
+### Named Layer Tokens
+
+| Token                     | Tailwind class    | Value | Usage                                                              |
+| ------------------------- | ----------------- | ----- | ------------------------------------------------------------------ |
+| `--z-index-markdown-menu` | `z-markdown-menu` | `200` | Streamdown Mermaid and table format menus above fullscreen content |
+| -----                     | --------------    | ----- | -----                                                              |
 
 ### Border Opacity
 

--- a/src/renderer/src/assets/agent-markdown.css
+++ b/src/renderer/src/assets/agent-markdown.css
@@ -149,7 +149,7 @@
     }
 
     [data-streamdown='mermaid-block-actions'] .relative > .absolute {
-      @apply fixed! z-[200] m-0! min-w-[7.5rem] w-max overflow-hidden rounded-md border border-sd-border bg-sd-surface! shadow-sd-menu break-normal;
+      @apply fixed! z-markdown-menu m-0! min-w-[7.5rem] w-max overflow-hidden rounded-md border border-sd-border bg-sd-surface! shadow-sd-menu break-normal;
       top: var(--sd-menu-top, 0) !important;
       right: var(--sd-menu-right, 0) !important;
       left: auto !important;
@@ -198,18 +198,18 @@
   }
 
   .agent-markdown-root [data-streamdown='mermaid-block-actions'] .relative > .absolute {
-    @apply z-[200] min-w-[7.5rem] w-max shadow-sd-menu;
+    @apply z-markdown-menu min-w-[7.5rem] w-max shadow-sd-menu;
   }
 
   [data-streamdown='table-fullscreen'] .relative > .absolute {
-    @apply z-[10000]! min-w-32! w-max! max-w-[calc(100vw-1rem)]! transform-none!;
+    @apply z-markdown-menu! min-w-32! w-max! max-w-[calc(100vw-1rem)]! transform-none!;
   }
 
   body
     > div.fixed.inset-0.z-50.flex.items-center.justify-center[role='button']:not([data-streamdown])
     .relative
     > .absolute {
-    @apply absolute! right-0! left-auto! z-[200] m-0 min-w-[7.5rem] w-max overflow-hidden rounded-md border border-sd-border bg-sd-surface! shadow-sd-menu-lg break-normal;
+    @apply absolute! right-0! left-auto! z-markdown-menu m-0 min-w-[7.5rem] w-max overflow-hidden rounded-md border border-sd-border bg-sd-surface! shadow-sd-menu-lg break-normal;
     top: auto !important;
     bottom: calc(100% + 4px) !important;
   }
@@ -236,7 +236,7 @@
 
   /* Inline chat table format menu (plain DOM portal — avoids scroll clipping). */
   .sd-table-format-menu {
-    @apply fixed z-[10000] min-w-32 overflow-hidden rounded-md border border-sd-border bg-sd-surface shadow-sd-menu-lg;
+    @apply fixed z-markdown-menu min-w-32 overflow-hidden rounded-md border border-sd-border bg-sd-surface shadow-sd-menu-lg;
 
     & > button {
       @apply block box-border w-full min-w-32 cursor-pointer border-0 bg-sd-surface px-3 py-2 text-left text-sm leading-5 whitespace-nowrap text-sd-ink transition-colors duration-150;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -51,6 +51,31 @@
   --color-danger-900: var(--danger-900);
   --color-warning-100: var(--warning-100);
   --color-warning-900: var(--warning-900);
+  /* Settings-only categorical and status roles. These aliases preserve the established palette
+     while keeping feature components independent from raw Tailwind color names. */
+  --color-storage-artifacts: var(--color-sky-500);
+  --color-storage-delegation: var(--color-cyan-500);
+  --color-storage-runtime: var(--color-violet-500);
+  --color-storage-uploads: var(--color-amber-500);
+  --color-storage-notebooks: var(--color-emerald-500);
+  --color-storage-workspaces: var(--color-rose-500);
+  --color-status-success-surface: var(--color-emerald-100);
+  --color-status-success-foreground: var(--color-emerald-700);
+  --color-status-success-accent: var(--color-emerald-500);
+  --color-status-success-accent-foreground: var(--color-emerald-600);
+  --color-status-success-dark-surface: var(--color-emerald-950);
+  --color-status-success-dark-foreground: var(--color-emerald-400);
+  --color-status-failure-surface: var(--color-rose-100);
+  --color-status-failure-subtle: var(--color-rose-50);
+  --color-status-failure-border: var(--color-rose-200);
+  --color-status-failure-foreground: var(--color-rose-700);
+  --color-status-failure-accent: var(--color-rose-600);
+  --color-status-failure-strong: var(--color-rose-800);
+  --color-status-failure-dark-surface: var(--color-rose-950);
+  --color-status-failure-dark-border: var(--color-rose-800);
+  --color-status-failure-dark-foreground: var(--color-rose-400);
+  --color-status-failure-dark-emphasis: var(--color-rose-300);
+  --color-status-failure-dark-code: var(--color-rose-900);
   --color-success-000: var(--success-000);
   --color-syntax-keyword: var(--syntax-keyword);
   --color-syntax-string: var(--syntax-string);
@@ -73,6 +98,7 @@
   --shadow-dialog: var(--shadow-dialog-value);
   --z-index-modal: 50;
   --z-index-toast: 70;
+  --z-index-markdown-menu: 200;
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/src/renderer/src/components/DownloadProgressLine.render.test.tsx
+++ b/src/renderer/src/components/DownloadProgressLine.render.test.tsx
@@ -37,6 +37,10 @@ describe('DownloadProgressLine', () => {
       )
     )
     expect(container.textContent).toContain('2.3 MB/s')
+    const progressBar = container.querySelector<HTMLElement>('[style*="scaleX"]')
+    expect(progressBar?.className).toContain('transition-transform')
+    expect(progressBar?.className).toContain('motion-reduce:transition-none')
+    expect(progressBar?.className).not.toContain('transition-all')
     expect(container.textContent).toContain('14%')
   })
 

--- a/src/renderer/src/components/DownloadProgressLine.tsx
+++ b/src/renderer/src/components/DownloadProgressLine.tsx
@@ -17,10 +17,10 @@ export const DownloadProgressLine = ({
       </div>
       <div className="h-1.5 w-full overflow-hidden rounded-full bg-bg-300">
         <div
-          className={`h-full rounded-full bg-primary transition-all duration-150 ease-out ${
+          className={`h-full origin-left rounded-full bg-primary transition-transform duration-150 ease-out motion-reduce:transition-none ${
             reconnecting ? 'animate-pulse' : ''
-          } ${known ? '' : 'w-1/3 animate-pulse'}`}
-          style={known ? { width: `${progress.percent}%` } : undefined}
+          } ${known ? 'w-full' : 'w-1/3 animate-pulse'}`}
+          style={known ? { transform: `scaleX(${progress.percent! / 100})` } : undefined}
         />
       </div>
     </div>

--- a/src/renderer/src/components/streamdown/AgentMarkdownFullscreenChrome.test.ts
+++ b/src/renderer/src/components/streamdown/AgentMarkdownFullscreenChrome.test.ts
@@ -74,6 +74,7 @@ describe('AgentMarkdown fullscreen chrome', () => {
 
   it('uses theme-aware shared chrome for table fullscreen without changing table rendering', () => {
     const css = readFileSync(resolve(__dirname, '../../assets/agent-markdown.css'), 'utf8')
+    const themeCss = readFileSync(resolve(__dirname, '../../assets/main.css'), 'utf8')
     const blockEnd = css.indexOf('/* Mermaid fullscreen portal')
     const blockStart = css.lastIndexOf("[data-streamdown='table-fullscreen'] {", blockEnd)
     const tableFullscreenBlock = css.slice(blockStart, blockEnd)
@@ -88,6 +89,10 @@ describe('AgentMarkdown fullscreen chrome', () => {
     expect(tableFullscreenBlock).toContain('z-[80]!')
     expect(tableFullscreenBlock).toContain('pointer-events: auto !important')
     expect(tableFullscreenBlock).toContain('pointer-events: none !important')
+    expect(css).toContain('z-markdown-menu')
+    expect(css).not.toContain('z-[10000]')
+    expect(themeCss).toContain('--z-index-markdown-menu: 200')
+    expect(themeCss).not.toContain('--z-index-markdown-menu: 10000')
   })
 
   it('disables both fullscreen animations when reduced motion is requested', () => {

--- a/src/renderer/src/components/ui/badge.tsx
+++ b/src/renderer/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { Slot } from 'radix-ui'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!',
+  'group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-colors duration-150 motion-reduce:transition-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!',
   {
     variants: {
       variant: {

--- a/src/renderer/src/components/ui/control-primitives.render.test.tsx
+++ b/src/renderer/src/components/ui/control-primitives.render.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { Badge } from './badge'
 import { Button } from './button'
 import {
   DropdownMenu,
@@ -145,5 +146,21 @@ describe('shared control interaction styling', () => {
     expect(thumb?.className).toContain('motion-reduce:transition-none')
     expect(textarea?.disabled).toBe(true)
     expect(textarea?.className).toContain('focus-visible:ring-3')
+  })
+
+  it('keeps badge focus rings instant while limiting hover motion to colors', () => {
+    act(() => {
+      root.render(
+        <Badge asChild>
+          <a href="#status">Connected</a>
+        </Badge>
+      )
+    })
+
+    const badge = document.body.querySelector<HTMLElement>('[data-slot="badge"]')
+    expect(badge?.className).toContain('transition-colors')
+    expect(badge?.className).toContain('motion-reduce:transition-none')
+    expect(badge?.className).toContain('focus-visible:ring-[3px]')
+    expect(badge?.className).not.toContain('transition-all')
   })
 })

--- a/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
@@ -142,6 +142,30 @@ describe('ComputeHostDetail', () => {
     expect(container.textContent).toContain('10')
   })
 
+  it('uses semantic failure roles for a failed probe', () => {
+    useComputeStore.setState({
+      hosts: [
+        host({
+          probeResult: {
+            ok: false,
+            probedAt: new Date().toISOString(),
+            exitCode: 255,
+            errorTail: 'offline'
+          }
+        })
+      ],
+      isLoaded: true
+    })
+
+    act(() => {
+      root.render(<ComputeHostDetail providerId="ssh:biowulf" onRemoved={vi.fn()} />)
+    })
+
+    const failure = container.querySelector<HTMLElement>('[role="alert"]')
+    expect(failure?.className).toContain('border-status-failure-border')
+    expect(failure?.className).toContain('bg-status-failure-subtle/50')
+  })
+
   it('calls saveDetails with author=user when Save is clicked in details editor', async () => {
     const saveDetails = vi.fn(() => Promise.resolve())
     useComputeStore.setState({ hosts: [host()], isLoaded: true, saveDetails })
@@ -155,6 +179,10 @@ describe('ComputeHostDetail', () => {
     await act(async () => {
       await Promise.resolve()
     })
+    const details = container.querySelector<HTMLElement>('pre')
+    expect(details?.className).toContain('transition-opacity')
+    expect(details?.className).toContain('motion-reduce:transition-none')
+    expect(details?.className).not.toContain('transition-all')
 
     const editButton = Array.from(container.querySelectorAll('button')).find(
       (b) => b.textContent?.trim() === 'Edit' && b.closest('div')?.textContent?.includes('Details')

--- a/src/renderer/src/pages/settings/ComputeHostDetail.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.tsx
@@ -1,4 +1,14 @@
-import { AlertTriangle, ChevronDown, ChevronUp, Cpu, HardDrive, MemoryStick, Pin, RefreshCw, Zap } from 'lucide-react'
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp,
+  Cpu,
+  HardDrive,
+  MemoryStick,
+  Pin,
+  RefreshCw,
+  Zap
+} from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 
 import type { ComputeHost } from '../../../../shared/compute'
@@ -220,9 +230,9 @@ export function ComputeHostDetail({
             className={cn(
               'flex size-10 shrink-0 items-center justify-center rounded-lg',
               status === 'connected'
-                ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400'
+                ? 'bg-status-success-surface text-status-success-foreground dark:bg-status-success-dark-surface/40 dark:text-status-success-dark-foreground'
                 : status === 'failed'
-                  ? 'bg-rose-100 text-rose-700 dark:bg-rose-950/40 dark:text-rose-400'
+                  ? 'bg-status-failure-surface text-status-failure-foreground dark:bg-status-failure-dark-surface/40 dark:text-status-failure-dark-foreground'
                   : 'bg-muted text-muted-foreground'
             )}
             aria-hidden="true"
@@ -233,11 +243,11 @@ export function ComputeHostDetail({
             <div className="flex flex-wrap items-center gap-2">
               <h3 className="truncate text-lg font-semibold text-foreground">{host.displayName}</h3>
               {status === 'connected' ? (
-                <Badge className="bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400">
+                <Badge className="bg-status-success-surface text-status-success-foreground dark:bg-status-success-dark-surface/40 dark:text-status-success-dark-foreground">
                   Connected
                 </Badge>
               ) : status === 'failed' ? (
-                <Badge className="bg-rose-100 text-rose-700 dark:bg-rose-950/40 dark:text-rose-400">
+                <Badge className="bg-status-failure-surface text-status-failure-foreground dark:bg-status-failure-dark-surface/40 dark:text-status-failure-dark-foreground">
                   Probe failed
                 </Badge>
               ) : (
@@ -278,14 +288,14 @@ export function ComputeHostDetail({
       {status === 'failed' && probed ? (
         <div
           role="alert"
-          className="mt-5 rounded-xl border border-rose-200 bg-rose-50/50 px-3 py-3 dark:border-rose-800/50 dark:bg-rose-950/20"
+          className="mt-5 rounded-xl border border-status-failure-border bg-status-failure-subtle/50 px-3 py-3 dark:border-status-failure-dark-border/50 dark:bg-status-failure-dark-surface/20"
         >
           <div className="flex items-center gap-2">
             <AlertTriangle
-              className="size-4 shrink-0 text-rose-600 dark:text-rose-400"
+              className="size-4 shrink-0 text-status-failure-accent dark:text-status-failure-dark-foreground"
               aria-hidden="true"
             />
-            <span className="text-sm font-semibold text-rose-700 dark:text-rose-300">
+            <span className="text-sm font-semibold text-status-failure-foreground dark:text-status-failure-dark-emphasis">
               Probe failed
             </span>
             <Button
@@ -295,7 +305,7 @@ export function ComputeHostDetail({
               onClick={() => void handleProbe()}
               disabled={isProbing}
               aria-label="Retry probe"
-              className="ml-auto text-rose-600 hover:bg-rose-100 dark:text-rose-400"
+              className="ml-auto text-status-failure-accent hover:bg-status-failure-surface dark:text-status-failure-dark-foreground"
             >
               <RefreshCw
                 className={cn('size-3.5', isProbing && 'animate-spin')}
@@ -304,7 +314,7 @@ export function ComputeHostDetail({
             </Button>
           </div>
           {probed.errorTail ? (
-            <pre className="mt-2 overflow-x-auto rounded bg-rose-100/50 px-2 py-1.5 font-mono text-xs text-rose-800 dark:bg-rose-900/30 dark:text-rose-300">
+            <pre className="mt-2 overflow-x-auto rounded bg-status-failure-surface/50 px-2 py-1.5 font-mono text-xs text-status-failure-strong dark:bg-status-failure-dark-code/30 dark:text-status-failure-dark-emphasis">
               {probed.errorTail}
             </pre>
           ) : null}
@@ -450,7 +460,7 @@ export function ComputeHostDetail({
               <pre
                 ref={detailsRef}
                 className={cn(
-                  'overflow-x-auto whitespace-pre-wrap px-4 py-3 font-mono text-xs text-foreground/80 transition-all',
+                  'overflow-x-auto whitespace-pre-wrap px-4 py-3 font-mono text-xs text-foreground/80 transition-opacity duration-150 motion-reduce:transition-none',
                   !isDetailsExpanded && 'max-h-[200px]',
                   isSkeleton && 'opacity-70'
                 )}

--- a/src/renderer/src/pages/settings/ComputePanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputePanel.render.test.tsx
@@ -99,4 +99,36 @@ describe('ComputePanel', () => {
     expect(deleteHost).toHaveBeenCalledWith('ssh:biowulf')
     expect(container.textContent).toContain('Removed biowulf.')
   })
+
+  it('uses semantic success and failure roles for probed hosts', () => {
+    useComputeStore.setState({
+      hosts: [
+        host({
+          probeResult: {
+            ok: true,
+            probedAt: new Date().toISOString(),
+            exitCode: 0,
+            errorTail: null
+          }
+        }),
+        host({
+          id: 'host-2',
+          providerId: 'ssh:failed',
+          displayName: 'failed',
+          probeResult: {
+            ok: false,
+            probedAt: new Date().toISOString(),
+            exitCode: 255,
+            errorTail: 'offline'
+          }
+        })
+      ],
+      isLoaded: true
+    })
+
+    act(() => root.render(<ComputePanel onNavigate={vi.fn()} />))
+
+    expect(container.querySelector('.bg-status-success-surface')).not.toBeNull()
+    expect(container.querySelector('.bg-status-failure-surface')).not.toBeNull()
+  })
 })

--- a/src/renderer/src/pages/settings/ComputePanel.tsx
+++ b/src/renderer/src/pages/settings/ComputePanel.tsx
@@ -64,9 +64,9 @@ const HostCard = ({
         className={cn(
           'flex size-9 shrink-0 items-center justify-center rounded-lg',
           status === 'connected'
-            ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400'
+            ? 'bg-status-success-surface text-status-success-foreground dark:bg-status-success-dark-surface/40 dark:text-status-success-dark-foreground'
             : status === 'failed'
-              ? 'bg-rose-100 text-rose-700 dark:bg-rose-950/40 dark:text-rose-400'
+              ? 'bg-status-failure-surface text-status-failure-foreground dark:bg-status-failure-dark-surface/40 dark:text-status-failure-dark-foreground'
               : 'bg-muted text-muted-foreground'
         )}
         aria-hidden="true"
@@ -137,11 +137,11 @@ const HostCard = ({
       </TooltipProvider>
 
       {status === 'connected' ? (
-        <Badge className="shrink-0 bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400">
+        <Badge className="shrink-0 bg-status-success-surface text-status-success-foreground dark:bg-status-success-dark-surface/40 dark:text-status-success-dark-foreground">
           Connected
         </Badge>
       ) : status === 'failed' ? (
-        <Badge className="shrink-0 bg-rose-100 text-rose-700 dark:bg-rose-950/40 dark:text-rose-400">
+        <Badge className="shrink-0 bg-status-failure-surface text-status-failure-foreground dark:bg-status-failure-dark-surface/40 dark:text-status-failure-dark-foreground">
           Probe failed
         </Badge>
       ) : (

--- a/src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
@@ -112,6 +112,10 @@ describe('StorageMigrationModal', () => {
 
     expect(document.body.textContent).toContain('/home/u/.open-science/artifacts/report.pdf')
     expect(document.body.textContent).toMatch(/50%/)
+    const progressBar = document.body.querySelector<HTMLElement>('[style*="scaleX"]')
+    expect(progressBar?.className).toContain('transition-transform')
+    expect(progressBar?.className).toContain('motion-reduce:transition-none')
+    expect(progressBar?.className).not.toContain('transition-all')
 
     // The migrating stage shows a running elapsed clock and a don't-quit warning (design follow-up).
     expect(document.body.textContent).toMatch(/Elapsed 0:00/)
@@ -135,6 +139,8 @@ describe('StorageMigrationModal', () => {
 
     // Done stage: copy is complete but nothing is committed. "Restart now" commits + relaunches.
     expect(document.body.textContent).toMatch(/data copied/i)
+    expect(document.body.querySelector('.bg-status-success-accent\\/10')).not.toBeNull()
+    expect(document.body.querySelector('.text-emerald-600')).toBeNull()
     expect(api.commitAndRelaunch).not.toHaveBeenCalled()
     await act(async () => {
       clickButton((button) => button.textContent?.trim() === 'Restart now')

--- a/src/renderer/src/pages/settings/StorageMigrationModal.tsx
+++ b/src/renderer/src/pages/settings/StorageMigrationModal.tsx
@@ -265,8 +265,8 @@ const StorageMigrationModal = ({
               </Dialog.Description>
               <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-bg-300">
                 <div
-                  className="h-full rounded-full bg-primary transition-all duration-150 ease-out"
-                  style={{ width: `${percent}%` }}
+                  className="h-full w-full origin-left rounded-full bg-primary transition-transform duration-150 ease-out motion-reduce:transition-none"
+                  style={{ transform: `scaleX(${percent / 100})` }}
                 />
               </div>
               <p className="mt-1.5 text-xs tabular-nums text-muted-foreground">{percent}%</p>
@@ -302,7 +302,7 @@ const StorageMigrationModal = ({
             <>
               <div className="flex items-start gap-3">
                 <span
-                  className="flex size-9 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                  className="flex size-9 shrink-0 items-center justify-center rounded-full bg-status-success-accent/10 text-status-success-accent-foreground dark:text-status-success-dark-foreground"
                   aria-hidden="true"
                 >
                   <Check className="size-[18px]" />

--- a/src/renderer/src/pages/settings/StoragePanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/StoragePanel.render.test.tsx
@@ -496,6 +496,10 @@ describe('StoragePanel', () => {
     expect(container.textContent).toContain('Total')
     expect(container.textContent).toContain('Available on disk')
     expect(container.textContent).toMatch(/530\.6 GB/)
+    expect(container.querySelector('.bg-storage-artifacts')).not.toBeNull()
+    expect(container.querySelector('.bg-storage-runtime')).not.toBeNull()
+    expect(container.querySelector('.bg-sky-500')).toBeNull()
+    expect(container.querySelector('.bg-violet-500')).toBeNull()
 
     // Children are collapsed until the runtime row is expanded.
     expect(container.textContent).not.toContain('python')

--- a/src/renderer/src/pages/settings/StoragePanel.tsx
+++ b/src/renderer/src/pages/settings/StoragePanel.tsx
@@ -51,12 +51,12 @@ const CATEGORY_LABELS: Record<UsageCategoryKey, string> = {
 // Fixed swatch palette keyed by category so the stacked bar and legend always agree on color,
 // even though the bar only renders non-zero segments while the legend lists every category.
 const CATEGORY_COLORS: Record<UsageCategoryKey, string> = {
-  artifacts: 'bg-sky-500',
-  delegation: 'bg-cyan-500',
-  runtime: 'bg-violet-500',
-  uploads: 'bg-amber-500',
-  notebooks: 'bg-emerald-500',
-  workspaces: 'bg-rose-500'
+  artifacts: 'bg-storage-artifacts',
+  delegation: 'bg-storage-delegation',
+  runtime: 'bg-storage-runtime',
+  uploads: 'bg-storage-uploads',
+  notebooks: 'bg-storage-notebooks',
+  workspaces: 'bg-storage-workspaces'
 }
 
 // Shared path-pill style, matching GeneralPanel's log-file display so every settings path reads the same.

--- a/src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx
@@ -231,7 +231,11 @@ describe('ComposerYourFilesMenu', () => {
   it('removes access via the store from the hover × action', async () => {
     renderMenu()
 
-    await click(container.querySelector('[data-testid="your-files-remove-root-1"]'))
+    const removeButton = container.querySelector('[data-testid="your-files-remove-root-1"]')
+    expect(removeButton?.className).toContain('focus-visible:opacity-100')
+    expect(removeButton?.className).toContain('[@media(hover:none)]:opacity-100')
+    expect(removeButton?.className).toContain('motion-reduce:transition-none')
+    await click(removeButton)
     await flush()
 
     expect(removeGrantedRoot).toHaveBeenCalledWith({ id: 'root-1' })

--- a/src/renderer/src/pages/workspace/ComposerYourFilesMenu.tsx
+++ b/src/renderer/src/pages/workspace/ComposerYourFilesMenu.tsx
@@ -305,7 +305,7 @@ export const ComposerYourFilesMenu = ({
                         event.preventDefault()
                         void remove(root.id).catch(() => undefined)
                       }}
-                      className="flex size-[22px] shrink-0 items-center justify-center rounded-[5px] text-text-100 opacity-0 transition-opacity hover:bg-bg-300 hover:text-text-000 group-hover:opacity-100"
+                      className="flex size-[22px] shrink-0 items-center justify-center rounded-[5px] text-text-100 opacity-0 transition-opacity duration-150 hover:bg-bg-300 hover:text-text-000 group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none [@media(hover:none)]:opacity-100"
                     >
                       <X className="size-3.5" strokeWidth={2} aria-hidden="true" />
                     </button>

--- a/src/renderer/src/pages/workspace/EnvProvisionOverlay.tsx
+++ b/src/renderer/src/pages/workspace/EnvProvisionOverlay.tsx
@@ -35,8 +35,8 @@ const EnvProvisionOverlay = ({
               for overall position while the detail line adds speed/ETA/resume during the fetch. */}
           <div className="h-1.5 w-56 overflow-hidden rounded-full bg-bg-300">
             <div
-              className="h-full bg-primary transition-all"
-              style={{ width: `${Math.round(ui.progress * 100)}%` }}
+              className="h-full w-full origin-left bg-primary transition-transform duration-150 ease-out motion-reduce:transition-none"
+              style={{ transform: `scaleX(${ui.progress})` }}
             />
           </div>
           {ui.download ? (

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -74,6 +74,10 @@ describe('EnvProvisionOverlay', () => {
     act(() => root.render(<EnvProvisionOverlay ui={ui} />))
     const gate = container.querySelector('[data-testid="notebook-env-gate"]')
     expect(gate?.textContent).toContain('Preparing Python environment')
+    const progressBar = gate?.querySelector<HTMLElement>('[style*="scaleX"]')
+    expect(progressBar?.className).toContain('transition-transform')
+    expect(progressBar?.className).toContain('motion-reduce:transition-none')
+    expect(progressBar?.className).not.toContain('transition-all')
   })
 
   it('renders a retry affordance in the error state', () => {


### PR DESCRIPTION
## Summary

- expose the linked-folder remove action to keyboard focus and touch-only pointers
- replace the five broad/layout transitions with explicit color, opacity, or transform transitions and reduced-motion fallbacks
- introduce documented semantic tokens for Settings storage/status colors and a named Markdown menu layer
- preserve the current layout, palette values, information architecture, and overall visual language

## Why

The approved Hallmark audit found one hover-only action, five `transition-all` usages, localized raw palette usage, and a `z-[10000]` layer. These were local interaction and token hygiene issues; the UI did not need a redesign.

## Impact

- keyboard and touch users can discover and trigger the linked-folder action
- progress animations are transform-only, and motion-sensitive users get an explicit reduced-motion fallback
- Settings status/category colors retain their existing appearance while gaining semantic ownership
- Markdown popovers retain their stacking behavior through a documented named layer

## Test impact set

- interaction fallback: `ComposerYourFilesMenu.interaction.test.tsx`
- progress and primitive transitions: `DownloadProgressLine.render.test.tsx`, `control-primitives.render.test.tsx`, `NotebookPreview.gate.render.test.tsx`, `StorageMigrationModal.render.test.tsx`
- semantic Settings tokens: `StoragePanel.render.test.tsx`, `ComputePanel.render.test.tsx`, `ComputeHostDetail.render.test.tsx`
- named Markdown layer: `AgentMarkdownFullscreenChrome.test.ts`

## Validation

- targeted renderer Vitest: 9 files, 89 tests passed
- `npm run typecheck:web`: passed
- `npm run build:e2e`: passed
- `npm run lint`: passed with 0 errors (existing warnings remain)
- local Playwright Hallmark screenshot case: passed
- `git diff --check`: passed

The full `npm test` command was also attempted. It is not green in this Windows environment because unrelated suites hit symlink `EPERM`, unusable temporary storage directories, Prisma temporary database/schema locks, and cascading timeouts. The scoped renderer tests above pass.