### PR TITLE
refactor(project-scope): add artifact notebook project id adapters

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -35,8 +35,10 @@ delete process.env.OPEN_SCIENCE_MCP_RPC_TOKEN
 // enumerates process.env sees neither the token nor the routing identity. Absent -> host.compute call
 // payloads omit them and the approval broker falls back to 'once'-only semantics.
 const COMPUTE_SESSION_ID = process.env.OPEN_SCIENCE_NOTEBOOK_SESSION_ID
-const COMPUTE_PROJECT_NAME = process.env.OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME
+const COMPUTE_PROJECT_NAME =
+  process.env.OPEN_SCIENCE_NOTEBOOK_PROJECT_ID || process.env.OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME
 delete process.env.OPEN_SCIENCE_NOTEBOOK_SESSION_ID
+delete process.env.OPEN_SCIENCE_NOTEBOOK_PROJECT_ID
 delete process.env.OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME
 
 // Updated only by the trusted kernel request frame while one serialized control invocation is

--- a/src/main/acp/session-capability-owner.ts
+++ b/src/main/acp/session-capability-owner.ts
@@ -784,7 +784,7 @@ export class AcpSessionCapabilityOwner {
     const connection = await this.options.artifacts.getRpcConnection?.()
     return {
       storageRoot: this.options.artifacts.dataRoot,
-      projectName,
+      projectId: projectName,
       sessionId: routingId,
       currentRunFile:
         this.options.artifacts.currentRunFile ??
@@ -814,7 +814,7 @@ export class AcpSessionCapabilityOwner {
       endpoint: connection.endpoint,
       socketPath: connection.socketPath,
       token: connection.token,
-      projectName,
+      projectId: projectName,
       sessionId: routingId,
       workspaceCwd: sessionCwd
     }

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -25,6 +25,7 @@ import type {
   GetArtifactCodeReconstructionRequest
 } from '../../shared/artifact-code-reconstruction'
 import { parseArtifactVersionLocator } from '../../shared/artifact-provenance'
+import { resolveProjectId } from '../../shared/project-scope'
 import type {
   FinalizeRunArtifactsRequest,
   ListProjectArtifactsRequest,
@@ -172,9 +173,16 @@ const createArtifactHandlers = (
         })
       ),
     listProjectFiles: (request) =>
-      repository.listProjectArtifacts(request.projectName, inFlightRunIds()),
+      repository.listProjectArtifacts(resolveProjectId(request), inFlightRunIds()),
     reconcilePendingArtifacts: (request) =>
-      withDataRootWrite(() => repository.reconcilePendingArtifactPaths(request)),
+      withDataRootWrite(() =>
+        repository.reconcilePendingArtifactPaths({
+          projectName: resolveProjectId(request),
+          sessionId: request.sessionId,
+          messageId: request.messageId,
+          pendingPaths: request.pendingPaths
+        })
+      ),
     openFile: async (request) => {
       // Resolve through the repository first so shell.openPath never sees unmanaged locations.
       const versionIdentity = parseArtifactVersionLocator(request.path)

--- a/src/main/artifacts/mcp-server.test.ts
+++ b/src/main/artifacts/mcp-server.test.ts
@@ -360,6 +360,7 @@ describe('artifact MCP server', () => {
       env: [
         { name: 'ELECTRON_RUN_AS_NODE', value: '1' },
         { name: 'OPEN_SCIENCE_ARTIFACT_STORAGE_ROOT', value: '/Users/example/.open-science' },
+        { name: 'OPEN_SCIENCE_ARTIFACT_PROJECT_ID', value: 'default-project' },
         { name: 'OPEN_SCIENCE_ARTIFACT_PROJECT_NAME', value: 'default-project' },
         { name: 'OPEN_SCIENCE_ARTIFACT_SESSION_ID', value: 'session-1' },
         {
@@ -411,11 +412,32 @@ describe('artifact MCP server', () => {
       })
     ).toEqual({
       storageRoot: '/Users/example/.open-science',
-      projectName: 'default-project',
+      projectId: 'default-project',
       sessionId: 'session-1',
       currentRunFile: '/tmp/current-run.json',
       allowedImportRoots: ['/Users/example/workspace', '/Users/example/.open-science/notebooks']
     })
+  })
+
+  it('prefers projectId and rejects a conflicting legacy projectName environment value', () => {
+    const base = {
+      OPEN_SCIENCE_ARTIFACT_STORAGE_ROOT: '/Users/example/.open-science',
+      OPEN_SCIENCE_ARTIFACT_SESSION_ID: 'session-1',
+      OPEN_SCIENCE_ARTIFACT_CURRENT_RUN_FILE: '/tmp/current-run.json'
+    }
+    expect(
+      createArtifactMcpEnvironmentFromProcess({
+        ...base,
+        OPEN_SCIENCE_ARTIFACT_PROJECT_ID: 'project-1'
+      }).projectId
+    ).toBe('project-1')
+    expect(() =>
+      createArtifactMcpEnvironmentFromProcess({
+        ...base,
+        OPEN_SCIENCE_ARTIFACT_PROJECT_ID: 'project-1',
+        OPEN_SCIENCE_ARTIFACT_PROJECT_NAME: 'renamed-project'
+      })
+    ).toThrow('Conflicting projectId and legacy projectName values.')
   })
 
   it('reads the notebook data dir and session root from the per-turn handoff', async () => {

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -15,15 +15,16 @@ import type {
   CreateArtifactVersionRequest,
   ReplayArtifactVersionRequest
 } from '../../shared/artifact-provenance'
+import { resolveProjectId } from '../../shared/project-scope'
+import type { ProjectIdScope } from '../../shared/project-scope'
 import { ARTIFACT_MCP_SERVER_ARG } from '../mcp-server-args'
 import { fetchLocalRpc } from '../local-rpc-transport'
 import { ArtifactRepository } from './repository'
 
 const ARTIFACT_MCP_SERVER_NAME = 'open-science-artifacts'
 
-type ArtifactMcpEnvironment = {
+type ArtifactMcpEnvironment = ProjectIdScope & {
   storageRoot: string
-  projectName: string
   sessionId: string
   currentRunFile: string
   allowedImportRoots: string[]
@@ -321,6 +322,7 @@ const writeArtifactFileForCurrentRun = async (
   input: ArtifactToolWriteInput,
   invocation: ArtifactWriteInvocation = {}
 ): Promise<ArtifactFile | ArtifactVersionFile> => {
+  const projectId = resolveProjectId(environment)
   const context = await readCurrentRunContext(environment.currentRunFile)
   const artifactStorageSessionId = context.artifactStorageSessionId ?? environment.sessionId
   const source = normalizeArtifactToolWriteInput(
@@ -340,7 +342,7 @@ const writeArtifactFileForCurrentRun = async (
       ]
     : environment.allowedImportRoots.slice(0, 1)
   const writeRequest = {
-    projectName: environment.projectName,
+    projectName: projectId,
     sessionId: artifactStorageSessionId,
     runId: context.artifactRunId,
     filename: input.filename,
@@ -391,12 +393,7 @@ const writeArtifactFileForCurrentRun = async (
     (invocation.requestId !== undefined
       ? `artifact-write-${createHash('sha256')
           .update(
-            JSON.stringify([
-              environment.projectName,
-              appSessionId,
-              context.artifactRunId,
-              invocation.requestId
-            ])
+            JSON.stringify([projectId, appSessionId, context.artifactRunId, invocation.requestId])
           )
           .digest('hex')}`
       : `artifact-write-${randomUUID()}`)
@@ -406,7 +403,7 @@ const writeArtifactFileForCurrentRun = async (
   // byte-checked below so reusing an operation with different inline bytes is still a hard conflict.
   if (source.kind === 'localPath') {
     const replay = await callArtifactReplayRpc(environment, rpcCapabilityToken, {
-      projectId: environment.projectName,
+      projectId,
       appSessionId,
       artifactStorageSessionId,
       artifactRunId: context.artifactRunId,
@@ -439,7 +436,7 @@ const writeArtifactFileForCurrentRun = async (
         .digest('hex')
 
       return callArtifactRpc(environment, rpcCapabilityToken, {
-        projectId: environment.projectName,
+        projectId,
         appSessionId,
         artifactStorageSessionId,
         artifactRunId: context.artifactRunId,
@@ -524,36 +521,33 @@ const createArtifactMcpServer = (
 }
 
 // Creates the ACP MCP config that launches this Electron entry point in Node-compatible mode.
-const createArtifactMcpServerConfig = ({
-  command,
-  entryPath,
-  storageRoot,
-  projectName,
-  sessionId,
-  currentRunFile,
-  allowedImportRoots,
-  rpcEndpoint,
-  rpcSocketPath
-}: ArtifactMcpServerConfigRequest): McpServerStdio => ({
-  name: ARTIFACT_MCP_SERVER_NAME,
-  command,
-  args: [entryPath, ARTIFACT_MCP_SERVER_ARG],
-  env: [
-    { name: 'ELECTRON_RUN_AS_NODE', value: '1' },
-    { name: 'OPEN_SCIENCE_ARTIFACT_STORAGE_ROOT', value: storageRoot },
-    { name: 'OPEN_SCIENCE_ARTIFACT_PROJECT_NAME', value: projectName },
-    { name: 'OPEN_SCIENCE_ARTIFACT_SESSION_ID', value: sessionId },
-    { name: 'OPEN_SCIENCE_ARTIFACT_CURRENT_RUN_FILE', value: currentRunFile },
-    {
-      name: 'OPEN_SCIENCE_ARTIFACT_ALLOWED_IMPORT_ROOTS',
-      value: JSON.stringify(allowedImportRoots)
-    },
-    ...(rpcEndpoint ? [{ name: 'OPEN_SCIENCE_ARTIFACT_RPC_ENDPOINT', value: rpcEndpoint }] : []),
-    ...(rpcSocketPath
-      ? [{ name: 'OPEN_SCIENCE_ARTIFACT_RPC_SOCKET_PATH', value: rpcSocketPath }]
-      : [])
-  ]
-})
+const createArtifactMcpServerConfig = (request: ArtifactMcpServerConfigRequest): McpServerStdio => {
+  const projectId = resolveProjectId(request)
+  return {
+    name: ARTIFACT_MCP_SERVER_NAME,
+    command: request.command,
+    args: [request.entryPath, ARTIFACT_MCP_SERVER_ARG],
+    env: [
+      { name: 'ELECTRON_RUN_AS_NODE', value: '1' },
+      { name: 'OPEN_SCIENCE_ARTIFACT_STORAGE_ROOT', value: request.storageRoot },
+      { name: 'OPEN_SCIENCE_ARTIFACT_PROJECT_ID', value: projectId },
+      // Keep the old variable for rollback to a child entry point that predates the adapter.
+      { name: 'OPEN_SCIENCE_ARTIFACT_PROJECT_NAME', value: projectId },
+      { name: 'OPEN_SCIENCE_ARTIFACT_SESSION_ID', value: request.sessionId },
+      { name: 'OPEN_SCIENCE_ARTIFACT_CURRENT_RUN_FILE', value: request.currentRunFile },
+      {
+        name: 'OPEN_SCIENCE_ARTIFACT_ALLOWED_IMPORT_ROOTS',
+        value: JSON.stringify(request.allowedImportRoots)
+      },
+      ...(request.rpcEndpoint
+        ? [{ name: 'OPEN_SCIENCE_ARTIFACT_RPC_ENDPOINT', value: request.rpcEndpoint }]
+        : []),
+      ...(request.rpcSocketPath
+        ? [{ name: 'OPEN_SCIENCE_ARTIFACT_RPC_SOCKET_PATH', value: request.rpcSocketPath }]
+        : [])
+    ]
+  }
+}
 
 // Fails fast when the app launches MCP mode without the required artifact routing context.
 const requireEnvironmentVariable = (
@@ -575,15 +569,21 @@ const parseAllowedImportRoots = (value: string | undefined): string[] =>
 // Reconstructs the repository/session context passed from the ACP runtime to the MCP process.
 const createArtifactMcpEnvironmentFromProcess = (
   env: NodeJS.ProcessEnv = process.env
-): ArtifactMcpEnvironment => ({
-  storageRoot: requireEnvironmentVariable(env, 'OPEN_SCIENCE_ARTIFACT_STORAGE_ROOT'),
-  projectName: requireEnvironmentVariable(env, 'OPEN_SCIENCE_ARTIFACT_PROJECT_NAME'),
-  sessionId: requireEnvironmentVariable(env, 'OPEN_SCIENCE_ARTIFACT_SESSION_ID'),
-  currentRunFile: requireEnvironmentVariable(env, 'OPEN_SCIENCE_ARTIFACT_CURRENT_RUN_FILE'),
-  allowedImportRoots: parseAllowedImportRoots(env.OPEN_SCIENCE_ARTIFACT_ALLOWED_IMPORT_ROOTS),
-  rpcEndpoint: env.OPEN_SCIENCE_ARTIFACT_RPC_ENDPOINT,
-  rpcSocketPath: env.OPEN_SCIENCE_ARTIFACT_RPC_SOCKET_PATH
-})
+): ArtifactMcpEnvironment => {
+  const projectId = resolveProjectId({
+    projectId: env.OPEN_SCIENCE_ARTIFACT_PROJECT_ID,
+    projectName: env.OPEN_SCIENCE_ARTIFACT_PROJECT_NAME
+  })
+  return {
+    storageRoot: requireEnvironmentVariable(env, 'OPEN_SCIENCE_ARTIFACT_STORAGE_ROOT'),
+    projectId,
+    sessionId: requireEnvironmentVariable(env, 'OPEN_SCIENCE_ARTIFACT_SESSION_ID'),
+    currentRunFile: requireEnvironmentVariable(env, 'OPEN_SCIENCE_ARTIFACT_CURRENT_RUN_FILE'),
+    allowedImportRoots: parseAllowedImportRoots(env.OPEN_SCIENCE_ARTIFACT_ALLOWED_IMPORT_ROOTS),
+    rpcEndpoint: env.OPEN_SCIENCE_ARTIFACT_RPC_ENDPOINT,
+    rpcSocketPath: env.OPEN_SCIENCE_ARTIFACT_RPC_SOCKET_PATH
+  }
+}
 
 // Runs only the artifact MCP server; Electron app modules are intentionally not loaded in this mode.
 const runArtifactMcpServer = async (

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -660,6 +660,8 @@ class ArtifactProvenanceRepository {
       createdAt: version.createdAt.toISOString(),
       producerRunId: version.producerRunId ?? undefined,
       environment,
+      projectId,
+      // Compatibility output for an older renderer/main pair; this value is the Project id.
       projectName: projectId,
       sessionId: appSessionId,
       runId: version.artifactRunId,

--- a/src/main/artifacts/storage-access.ts
+++ b/src/main/artifacts/storage-access.ts
@@ -385,6 +385,8 @@ class ArtifactStorageAccess {
     const ownerId = request.messageId ?? request.runId ?? 'artifact'
     return {
       id: `${request.sessionId}:${ownerId}:${request.filename}`,
+      projectId: request.projectName,
+      // Compatibility output for an older renderer/main pair; this value is the Project id.
       projectName: request.projectName,
       sessionId: request.sessionId,
       messageId: request.messageId,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -539,8 +539,7 @@ const createApplicationModules = async (
     current: undefined
   }
   const notebookActivityRef: {
-    current:
-      { getActiveNotebookSessions(): { projectName: string; sessionId: string }[] } | undefined
+    current: { getActiveNotebookSessions(): { projectId: string; sessionId: string }[] } | undefined
   } = { current: undefined }
 
   // Construct one storage/index/deletion graph for every related IPC surface. Sharing these instances
@@ -850,7 +849,7 @@ const createApplicationModules = async (
     {
       configRoot: resolveConfigRoot(),
       dataRoot: resolveDataRoot(),
-      projectName: DEFAULT_ARTIFACT_PROJECT_NAME,
+      projectId: DEFAULT_ARTIFACT_PROJECT_NAME,
       repository: new NotebookRunRepository(resolveDataRoot()),
       getPackageMirror: () => settingsService.getPackageMirror(),
       notebookRuntimeSettings,

--- a/src/main/notebook/application.ts
+++ b/src/main/notebook/application.ts
@@ -4,21 +4,22 @@ import type { NotebookEnvironmentLifecycle } from './environment-lifecycle-workf
 import type { NotebookLocalRpcCapability } from './local-rpc-notebook-adapter'
 import { createNotebookCommandWorkflows, type NotebookCommandWorkflows } from './notebook-workflows'
 import { NotebookRuntimeService, type NotebookRuntimeServiceOptions } from './runtime-service'
+import type { ProjectIdScope } from '../../shared/project-scope'
 
 type NotebookApplicationDeps = Pick<
   NotebookRuntimeServiceOptions,
   | 'configRoot'
   | 'dataRoot'
-  | 'projectName'
   | 'repository'
   | 'getPackageMirror'
   | 'notebookRuntimeSettings'
   | 'micromambaRunner'
   | 'locale'
   | 'appVersion'
-> & {
-  events: ApplicationEventPublisher
-}
+> &
+  ProjectIdScope & {
+    events: ApplicationEventPublisher
+  }
 
 type NotebookApplication = {
   // Retained as the internal compatibility surface while later Notebook slices narrow remaining

--- a/src/main/notebook/environment-operations.test.ts
+++ b/src/main/notebook/environment-operations.test.ts
@@ -24,7 +24,7 @@ const createRoot = async (): Promise<string> => {
 }
 
 type TestSession = {
-  projectName: string
+  projectId: string
   sessionId: string
   lane: NotebookLaneIdentity
   bindings: Partial<Record<NotebookLanguage, NotebookSessionRuntimeBinding>>
@@ -169,7 +169,7 @@ describe('NotebookEnvironmentOperations', () => {
     let releaseDrain!: () => void
     const terminations: string[] = []
     const session: TestSession = {
-      projectName: 'project',
+      projectId: 'project',
       sessionId: 'session-1',
       lane: createRootNotebookLane('project', 'session-1', 'root-frame-session-1'),
       bindings: {

--- a/src/main/notebook/environment-operations.ts
+++ b/src/main/notebook/environment-operations.ts
@@ -21,7 +21,7 @@ import {
 type EnvironmentOperationKind = 'execution' | 'inspection' | 'mutation' | 'provision' | 'revocation'
 
 type EnvironmentOperationSession = {
-  readonly projectName: string
+  readonly projectId: string
   readonly sessionId: string
   readonly lane: NotebookLaneIdentity
   runtimeBinding(language: NotebookLanguage): NotebookSessionRuntimeBinding | undefined

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -416,7 +416,7 @@ class NotebookExecutionOwner {
                   mcpRpcSocketPath: mcpRpc?.socketPath,
                   mcpRpcToken: mcpRpc?.token,
                   sessionId: session.sessionId,
-                  projectName: session.projectName,
+                  projectId: session.projectId,
                   inputRunLeaseId: request.inputRunLeaseId,
                   controlInvocationId: runId
                 })
@@ -534,7 +534,7 @@ class NotebookExecutionOwner {
     session.setKernelStatus('repl', status)
     try {
       await this.options.repository.updateKernelStatus({
-        projectName: session.projectName,
+        projectName: session.projectId,
         sessionId: session.sessionId,
         lane: session.lane,
         status

--- a/src/main/notebook/export-reader.ts
+++ b/src/main/notebook/export-reader.ts
@@ -4,6 +4,7 @@ import type {
   NotebookRunDocument
 } from '../../shared/notebook'
 import { resolveDataKernelForTab } from '../../shared/notebook'
+import { resolveProjectId } from '../../shared/project-scope'
 import { runDocumentToIpynbByKernel, runDocumentToIpynbForKernel } from './ipynb-export'
 import type { NotebookRunRepository } from './repository'
 
@@ -16,7 +17,7 @@ type NotebookExportFile = {
 type NotebookExportReaderOptions = {
   repository: Pick<NotebookRunRepository, 'findExisting'> &
     Partial<Pick<NotebookRunRepository, 'readSessionRuns'>>
-  defaultProjectName: string
+  defaultProjectId: string
   appVersion?: string
 }
 
@@ -70,13 +71,13 @@ class NotebookExportReader {
   private async loadDocument(
     request: ExportNotebookAllRequest | ExportNotebookKernelRequest
   ): Promise<NotebookRunDocument> {
-    const projectName = request.projectName ?? this.options.defaultProjectName
-    const document = await this.options.repository.findExisting(projectName, request.sessionId)
+    const projectId = resolveProjectId(request, this.options.defaultProjectId)
+    const document = await this.options.repository.findExisting(projectId, request.sessionId)
     if (!document) {
       throw new Error(`Notebook session not found: ${request.sessionId}`)
     }
     const sessionRuns = this.options.repository.readSessionRuns
-      ? await this.options.repository.readSessionRuns(projectName, request.sessionId)
+      ? await this.options.repository.readSessionRuns(projectId, request.sessionId)
       : document.runs
     const runs =
       request.agentFrameFilter === undefined

--- a/src/main/notebook/ipynb-export.test.ts
+++ b/src/main/notebook/ipynb-export.test.ts
@@ -26,7 +26,7 @@ const makeRun = (overrides: Partial<NotebookRunRecord> = {}): NotebookRunRecord 
 
 const makeDocument = (runs: NotebookRunRecord[]): NotebookRunDocument => ({
   version: 1,
-  projectName: 'default-project',
+  projectId: 'default-project',
   sessionId: 'session-123',
   workspaceCwd: '/workspace',
   notebookSessionRoot: '/data/notebooks/default-project/session-123',

--- a/src/main/notebook/ipynb-export.ts
+++ b/src/main/notebook/ipynb-export.ts
@@ -60,6 +60,7 @@ type IpynbNotebook = {
     }
     open_science: {
       sessionId: string
+      // Frozen export metadata key; its value is the immutable Project id.
       projectName: string
       artifactSessionId?: string
       appVersion?: string
@@ -267,6 +268,8 @@ const runDocumentToIpynb = (
   options: RunDocumentToIpynbOptions = {},
   kernel: 'python' | 'r' | undefined = undefined
 ): IpynbNotebook => {
+  const projectId = document.projectId ?? document.projectName
+  if (!projectId) throw new Error('A persisted projectId is required.')
   const resolvedKernel = kernel ?? dominantKernel(document.runs)
   const kernelspec = kernelspecFor(resolvedKernel)
   const environment = dominantEnvironment(document.runs, resolvedKernel)
@@ -279,7 +282,8 @@ const runDocumentToIpynb = (
       language_info: { name: kernelspec.language },
       open_science: {
         sessionId: document.sessionId,
-        projectName: document.projectName,
+        // Frozen nbformat metadata key; its value remains the immutable Project id.
+        projectName: projectId,
         ...(document.artifactSessionId ? { artifactSessionId: document.artifactSessionId } : {}),
         ...(options.appVersion ? { appVersion: options.appVersion } : {}),
         ...(environment ? { environment } : {})

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -579,8 +579,12 @@ class NotebookKernelExecutor implements NotebookExecutor {
       ...(kind === 'repl' && request.sessionId
         ? { OPEN_SCIENCE_NOTEBOOK_SESSION_ID: request.sessionId }
         : {}),
-      ...(kind === 'repl' && request.projectName
-        ? { OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME: request.projectName }
+      ...(kind === 'repl' && request.projectId
+        ? {
+            OPEN_SCIENCE_NOTEBOOK_PROJECT_ID: request.projectId,
+            // Compatibility for the existing REPL bridge until its next protocol revision.
+            OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME: request.projectId
+          }
         : {}),
       ...(kind === 'repl' ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
       ...(rEnvPrefix ? { OPEN_SCIENCE_R_ENV_PREFIX: rEnvPrefix } : {})

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -760,7 +760,7 @@ class NotebookLocalRpcServer {
           ? Promise.resolve()
           : new Promise<void>((resolve) => delegatedNotebook.drainWaiters.add(resolve))
       const shutdown = this.service.shutdown({
-        projectName: scope.projectId,
+        projectId: scope.projectId,
         sessionId: scope.sessionId,
         workspaceCwd: scope.workspaceCwd,
         provenanceContext: delegatedNotebook.provenanceContext,
@@ -1266,6 +1266,7 @@ class NotebookLocalRpcServer {
         resolvedParams = {
           ...resolvedParams,
           sessionId: authenticatedBinding.sessionId,
+          projectId: authenticatedBinding.projectId,
           projectName: authenticatedBinding.projectId,
           workspaceCwd: authenticatedBinding.delegatedNotebook.workspaceCwd,
           provenanceContext: authenticatedBinding.delegatedNotebook.provenanceContext,

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -27,6 +27,7 @@ import {
   compactRuntimeBindingResult,
   compactShutdownResult,
   compactRestartResult,
+  createNotebookMcpEnvironmentFromProcess,
   createNotebookMcpServerConfig,
   serializeNotebookToolResult
 } from './mcp-server'
@@ -53,11 +54,34 @@ describe('notebook MCP server config', () => {
         { name: 'ELECTRON_RUN_AS_NODE', value: '1' },
         { name: 'OPEN_SCIENCE_NOTEBOOK_RPC_ENDPOINT', value: 'http://127.0.0.1:4567' },
         { name: 'OPEN_SCIENCE_NOTEBOOK_RPC_TOKEN', value: 'secret-token' },
+        { name: 'OPEN_SCIENCE_NOTEBOOK_PROJECT_ID', value: 'default-project' },
         { name: 'OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME', value: 'default-project' },
         { name: 'OPEN_SCIENCE_NOTEBOOK_SESSION_ID', value: 'session-1' },
         { name: 'OPEN_SCIENCE_NOTEBOOK_WORKSPACE_CWD', value: '/workspace' }
       ]
     })
+  })
+
+  it('accepts legacy projectName but rejects conflicting project environment values', () => {
+    const base = {
+      OPEN_SCIENCE_NOTEBOOK_RPC_ENDPOINT: 'http://127.0.0.1:4567',
+      OPEN_SCIENCE_NOTEBOOK_RPC_TOKEN: 'secret-token',
+      OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-1',
+      OPEN_SCIENCE_NOTEBOOK_WORKSPACE_CWD: '/workspace'
+    }
+    expect(
+      createNotebookMcpEnvironmentFromProcess({
+        ...base,
+        OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME: 'legacy-project-id'
+      }).projectId
+    ).toBe('legacy-project-id')
+    expect(() =>
+      createNotebookMcpEnvironmentFromProcess({
+        ...base,
+        OPEN_SCIENCE_NOTEBOOK_PROJECT_ID: 'project-1',
+        OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME: 'renamed-project'
+      })
+    ).toThrow('Conflicting projectId and legacy projectName values.')
   })
 
   it('passes the Windows named-pipe path to the notebook MCP process', () => {
@@ -326,13 +350,19 @@ describe('notebook_execute tool', () => {
     try {
       const result = await callNotebookRpc(environment, 'execute', {
         code: '1 + 1',
-        language: 'r'
+        language: 'r',
+        projectId: 'forged-project',
+        sessionId: 'forged-session'
       })
 
       expect(result).toEqual({ ok: true })
       expect(fetchCalls).toHaveLength(1)
-      const sentBody = JSON.parse(fetchCalls[0].body) as { params: { language?: string } }
+      const sentBody = JSON.parse(fetchCalls[0].body) as {
+        params: { language?: string; projectId?: string; sessionId?: string }
+      }
       expect(sentBody.params.language).toBe('r')
+      expect(sentBody.params.projectId).toBe('default-project')
+      expect(sentBody.params.sessionId).toBe('session-1')
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -12,6 +12,8 @@ import {
 } from '../../shared/elicitation'
 import { NOTEBOOK_MCP_SERVER_ARG } from '../mcp-server-args'
 import { fetchLocalRpc, type LocalRpcTransport } from '../local-rpc-transport'
+import { resolveProjectId } from '../../shared/project-scope'
+import type { ProjectIdScope } from '../../shared/project-scope'
 
 const NOTEBOOK_MCP_SERVER_NAME = 'open-science-notebook'
 const MAX_RUNTIME_RESULTS = 40
@@ -46,11 +48,11 @@ type NotebookRpcConnection = LocalRpcTransport & {
   release?: () => void
 }
 
-type NotebookMcpEnvironment = NotebookRpcConnection & {
-  projectName: string
-  sessionId: string
-  workspaceCwd: string
-}
+type NotebookMcpEnvironment = NotebookRpcConnection &
+  ProjectIdScope & {
+    sessionId: string
+    workspaceCwd: string
+  }
 
 type NotebookMcpServerConfigRequest = NotebookMcpEnvironment & {
   command: string
@@ -234,29 +236,27 @@ type NotebookRpcToolDefinition = {
 }
 
 // Creates the ACP MCP-server declaration that launches this app bundle in notebook stdio mode.
-const createNotebookMcpServerConfig = ({
-  command,
-  entryPath,
-  endpoint,
-  socketPath,
-  token,
-  projectName,
-  sessionId,
-  workspaceCwd
-}: NotebookMcpServerConfigRequest): McpServerStdio => ({
-  name: NOTEBOOK_MCP_SERVER_NAME,
-  command,
-  args: [entryPath, NOTEBOOK_MCP_SERVER_ARG],
-  env: [
-    { name: 'ELECTRON_RUN_AS_NODE', value: '1' },
-    { name: 'OPEN_SCIENCE_NOTEBOOK_RPC_ENDPOINT', value: endpoint },
-    ...(socketPath ? [{ name: 'OPEN_SCIENCE_NOTEBOOK_RPC_SOCKET_PATH', value: socketPath }] : []),
-    { name: 'OPEN_SCIENCE_NOTEBOOK_RPC_TOKEN', value: token },
-    { name: 'OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME', value: projectName },
-    { name: 'OPEN_SCIENCE_NOTEBOOK_SESSION_ID', value: sessionId },
-    { name: 'OPEN_SCIENCE_NOTEBOOK_WORKSPACE_CWD', value: workspaceCwd }
-  ]
-})
+const createNotebookMcpServerConfig = (request: NotebookMcpServerConfigRequest): McpServerStdio => {
+  const projectId = resolveProjectId(request)
+  return {
+    name: NOTEBOOK_MCP_SERVER_NAME,
+    command: request.command,
+    args: [request.entryPath, NOTEBOOK_MCP_SERVER_ARG],
+    env: [
+      { name: 'ELECTRON_RUN_AS_NODE', value: '1' },
+      { name: 'OPEN_SCIENCE_NOTEBOOK_RPC_ENDPOINT', value: request.endpoint },
+      ...(request.socketPath
+        ? [{ name: 'OPEN_SCIENCE_NOTEBOOK_RPC_SOCKET_PATH', value: request.socketPath }]
+        : []),
+      { name: 'OPEN_SCIENCE_NOTEBOOK_RPC_TOKEN', value: request.token },
+      { name: 'OPEN_SCIENCE_NOTEBOOK_PROJECT_ID', value: projectId },
+      // Keep the old variable for rollback to a child entry point that predates the adapter.
+      { name: 'OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME', value: projectId },
+      { name: 'OPEN_SCIENCE_NOTEBOOK_SESSION_ID', value: request.sessionId },
+      { name: 'OPEN_SCIENCE_NOTEBOOK_WORKSPACE_CWD', value: request.workspaceCwd }
+    ]
+  }
+}
 
 // Reads one required environment value for the stdio MCP subprocess.
 const requireEnvironmentVariable = (
@@ -275,14 +275,20 @@ const requireEnvironmentVariable = (
 // Reconstructs the notebook RPC routing context passed through the MCP server environment.
 const createNotebookMcpEnvironmentFromProcess = (
   env: NodeJS.ProcessEnv = process.env
-): NotebookMcpEnvironment => ({
-  endpoint: requireEnvironmentVariable(env, 'OPEN_SCIENCE_NOTEBOOK_RPC_ENDPOINT'),
-  socketPath: env.OPEN_SCIENCE_NOTEBOOK_RPC_SOCKET_PATH,
-  token: requireEnvironmentVariable(env, 'OPEN_SCIENCE_NOTEBOOK_RPC_TOKEN'),
-  projectName: requireEnvironmentVariable(env, 'OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME'),
-  sessionId: requireEnvironmentVariable(env, 'OPEN_SCIENCE_NOTEBOOK_SESSION_ID'),
-  workspaceCwd: requireEnvironmentVariable(env, 'OPEN_SCIENCE_NOTEBOOK_WORKSPACE_CWD')
-})
+): NotebookMcpEnvironment => {
+  const projectId = resolveProjectId({
+    projectId: env.OPEN_SCIENCE_NOTEBOOK_PROJECT_ID,
+    projectName: env.OPEN_SCIENCE_NOTEBOOK_PROJECT_NAME
+  })
+  return {
+    endpoint: requireEnvironmentVariable(env, 'OPEN_SCIENCE_NOTEBOOK_RPC_ENDPOINT'),
+    socketPath: env.OPEN_SCIENCE_NOTEBOOK_RPC_SOCKET_PATH,
+    token: requireEnvironmentVariable(env, 'OPEN_SCIENCE_NOTEBOOK_RPC_TOKEN'),
+    projectId,
+    sessionId: requireEnvironmentVariable(env, 'OPEN_SCIENCE_NOTEBOOK_SESSION_ID'),
+    workspaceCwd: requireEnvironmentVariable(env, 'OPEN_SCIENCE_NOTEBOOK_WORKSPACE_CWD')
+  }
+}
 
 // Sends a tool request to the app-local notebook RPC server and returns its raw result payload.
 const callNotebookRpc = async (
@@ -290,6 +296,7 @@ const callNotebookRpc = async (
   method: string,
   params: unknown = {}
 ): Promise<unknown> => {
+  const projectId = resolveProjectId(environment)
   const response = await fetchLocalRpc(
     environment,
     {
@@ -301,10 +308,10 @@ const callNotebookRpc = async (
       body: JSON.stringify({
         method,
         params: {
+          ...((params ?? {}) as Record<string, unknown>),
           sessionId: environment.sessionId,
           workspaceCwd: environment.workspaceCwd,
-          projectName: environment.projectName,
-          ...((params ?? {}) as Record<string, unknown>)
+          projectId
         }
       } satisfies RpcRequest)
     },

--- a/src/main/notebook/package-admission.ts
+++ b/src/main/notebook/package-admission.ts
@@ -217,6 +217,7 @@ class NotebookPackageAdmissionOwner {
         value: await this.options.loadSession({
           sessionId: request.sessionId,
           workspaceCwd: request.workspaceCwd,
+          projectId: request.projectId,
           projectName: request.projectName
         })
       }

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 
 import { PROD_SESSION_DIR_NAME } from '../session-persistence/repository'
+import type { OptionalProjectIdScope } from '../../shared/project-scope'
 import type {
   NotebookEnvironmentPackageChange,
   NotebookLanguage,
@@ -40,7 +41,7 @@ import {
   runtimeRoot
 } from './runtime-paths'
 
-export type InstallRequest = {
+export type InstallRequest = OptionalProjectIdScope & {
   language: NotebookLanguage
   packages: string[]
   usePip?: boolean
@@ -52,13 +53,12 @@ export type InstallRequest = {
   // notebook tool call). Lets managePackages consult THIS session's runtime binding so an install into
   // a bound external env is gated on that env's per-env install authorization. Absent -> managed path.
   sessionId?: string
-  // workspaceCwd/projectName travel on every notebook RPC call too (the local RPC requires
+  // workspaceCwd/projectId travel on every notebook RPC call too (the local RPC requires
   // workspaceCwd; mcp-server injects both). managePackages uses them to ensureSession() — loading and
   // rehydrating persisted runtime bindings — BEFORE resolving the binding, so the FIRST install after
   // an app restart (session not yet in memory) still sees the persisted binding instead of silently
   // targeting the default env.
   workspaceCwd?: string
-  projectName?: string
 }
 // method records which installer actually ran: conda (micromamba), pip, or cran (R install.packages
 // fallback) — useful to verify the path taken, especially when conda falls back.

--- a/src/main/notebook/repository.test.ts
+++ b/src/main/notebook/repository.test.ts
@@ -160,6 +160,7 @@ describe('notebook run repository', () => {
 
     expect(document).toMatchObject({
       version: 1,
+      projectId: 'default-project',
       projectName: 'default-project',
       sessionId: 'session-1',
       workspaceCwd: '/workspace',
@@ -174,9 +175,14 @@ describe('notebook run repository', () => {
       },
       runs: []
     })
-    await expect(
-      readFile(join(root, 'notebooks', 'default-project', 'session-1', 'run.json'), 'utf8')
-    ).resolves.toContain('"sessionId": "session-1"')
+    const persisted = JSON.parse(
+      await readFile(join(root, 'notebooks', 'default-project', 'session-1', 'run.json'), 'utf8')
+    )
+    expect(persisted).toMatchObject({
+      projectId: 'default-project',
+      sessionId: 'session-1'
+    })
+    expect(persisted.projectName).toBeUndefined()
   })
 
   it('appends completed runs with working file metadata but not file contents', async () => {
@@ -397,6 +403,8 @@ describe('notebook run repository', () => {
 
     // Simulate a pre-kernelKind run.json written before this field existed.
     const legacyDocument = JSON.parse(await readFile(runJsonPath, 'utf8'))
+    delete legacyDocument.projectId
+    legacyDocument.projectName = 'default-project'
     legacyDocument.runs = [
       {
         runId: 'legacy-run-1',
@@ -417,6 +425,62 @@ describe('notebook run repository', () => {
     const reloaded = await repository.findExisting('default-project', 'session-1')
 
     expect(reloaded?.runs[0]).toMatchObject({ runId: 'legacy-run-1', kernelKind: 'python' })
+  })
+
+  it('loads canonical projectId values before legacy aliases', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const runJsonPath = join(root, 'notebooks', 'canonical-project', 'session-1', 'run.json')
+
+    await repository.loadOrCreate({
+      projectName: 'canonical-project',
+      sessionId: 'session-1',
+      lane: createRootNotebookLane('canonical-project', 'session-1', 'root-frame-session-1'),
+      workspaceCwd: '/workspace'
+    })
+
+    const persisted = JSON.parse(await readFile(runJsonPath, 'utf8'))
+    persisted.projectId = 'canonical-project'
+    persisted.projectName = 'renamed-project'
+    persisted.runs = [
+      {
+        runId: 'run-1',
+        cellId: 'cell-1',
+        source: 'agent',
+        kernelKind: 'python',
+        script: '1',
+        status: 'completed',
+        startedAt: 100,
+        text: { stdout: '', stderr: '', traceback: '', plain: [] },
+        outputs: [],
+        artifacts: [
+          {
+            id: 'artifact-1',
+            projectId: 'canonical-project',
+            projectName: 'renamed-project',
+            sessionId: 'session-1',
+            name: 'result.txt',
+            path: '$DATA/notebooks/canonical-project/session-1/data/processed/result.txt',
+            size: 1,
+            mtimeMs: 1
+          }
+        ],
+        workingFiles: []
+      }
+    ]
+    await writeFile(runJsonPath, JSON.stringify(persisted, null, 2), 'utf8')
+
+    const reloaded = await repository.findExisting('canonical-project', 'session-1')
+
+    expect(reloaded).toMatchObject({
+      projectId: 'canonical-project',
+      projectName: 'canonical-project',
+      notebookSessionRoot: join(root, 'notebooks', 'canonical-project', 'session-1')
+    })
+    expect(reloaded?.runs[0].artifacts[0]).toMatchObject({
+      projectId: 'canonical-project',
+      projectName: 'canonical-project'
+    })
   })
 
   it('keeps an explicit kernelKind when loading a run record from disk', async () => {

--- a/src/main/notebook/repository.ts
+++ b/src/main/notebook/repository.ts
@@ -172,11 +172,12 @@ const normalizeDocument = (
   request: NormalizeNotebookRunDocumentRequest,
   document: NotebookRunDocument
 ): NotebookRunDocument => {
-  const projectName = assertSafeNotebookPathSegment(request.projectName)
+  const storageProjectId = assertSafeNotebookPathSegment(request.projectName)
+  const projectId = assertSafeNotebookPathSegment(document.projectId ?? document.projectName)
   const sessionId = assertSafeNotebookPathSegment(request.sessionId)
   const notebookSessionRoot = getNotebookSessionRoot(
     storageRoot,
-    projectName,
+    storageProjectId,
     sessionId,
     request.lane
   )
@@ -184,12 +185,13 @@ const normalizeDocument = (
   return {
     ...document,
     version: 1,
-    projectName,
+    projectId,
+    projectName: projectId,
     sessionId,
     artifactSessionId: request.artifactSessionId ?? document.artifactSessionId,
     workspaceCwd: request.workspaceCwd ?? document.workspaceCwd,
     notebookSessionRoot,
-    dataRoot: getNotebookDataRoot(storageRoot, projectName, sessionId, request.lane),
+    dataRoot: getNotebookDataRoot(storageRoot, storageProjectId, sessionId, request.lane),
     kernel: {
       ...document.kernel,
       language: 'python',

--- a/src/main/notebook/run-document-data-paths.test.ts
+++ b/src/main/notebook/run-document-data-paths.test.ts
@@ -81,6 +81,10 @@ describe('run document data-path codec', () => {
       '$DATA/notebooks/default-project/session-1/data/processed/plot.png'
     )
     expect(encoded.runs[0].artifacts[0].fileUrl).toBeUndefined()
+    expect(encoded).toMatchObject({ projectId: 'default-project' })
+    expect(encoded.projectName).toBeUndefined()
+    expect(encoded.runs[0].artifacts[0]).toMatchObject({ projectId: 'default-project' })
+    expect(encoded.runs[0].artifacts[0].projectName).toBeUndefined()
 
     // Unrelated fields are untouched.
     expect(encoded.runs[0].text.stdout).toBe('hello\n')
@@ -106,6 +110,60 @@ describe('run document data-path codec', () => {
       at('notebooks/default-project/session-1/data/processed/plot.png')
     )
     expect(decoded.runs[0].artifacts[0].fileUrl).toMatch(/^file:\/\/.*plot\.png$/)
+    expect(decoded.runs[0].artifacts[0]).toMatchObject({
+      projectId: 'default-project',
+      projectName: 'default-project'
+    })
+  })
+
+  it('reads historical projectName-only documents and nested artifacts', () => {
+    const decoded = decodeRunDocumentDataPaths(buildDocument(), ROOT)
+
+    expect(decoded).toMatchObject({
+      projectId: 'default-project',
+      projectName: 'default-project'
+    })
+    expect(decoded.runs[0].artifacts[0]).toMatchObject({
+      projectId: 'default-project',
+      projectName: 'default-project'
+    })
+  })
+
+  it('writes canonical application artifacts without the legacy field', () => {
+    const doc = buildDocument()
+    doc.runs[0].artifacts[0] = { ...doc.runs[0].artifacts[0], projectId: 'default-project' }
+    delete (doc.runs[0].artifacts[0] as { projectName?: string }).projectName
+
+    const artifact = encodeRunDocumentDataPaths(doc, ROOT).runs[0].artifacts[0]
+    expect(artifact.projectId).toBe('default-project')
+    expect(artifact.projectName).toBeUndefined()
+  })
+
+  it('prefers projectId over a conflicting legacy alias at both persisted levels', () => {
+    const doc = {
+      ...buildDocument(),
+      projectId: 'canonical-project',
+      projectName: 'renamed-project'
+    }
+    doc.runs[0].artifacts[0] = {
+      ...doc.runs[0].artifacts[0],
+      projectId: 'canonical-project',
+      projectName: 'renamed-project'
+    }
+
+    const decoded = decodeRunDocumentDataPaths(doc, ROOT)
+    expect(decoded).toMatchObject({
+      projectId: 'canonical-project',
+      projectName: 'canonical-project'
+    })
+    expect(decoded.runs[0].artifacts[0]).toMatchObject({
+      projectId: 'canonical-project',
+      projectName: 'canonical-project'
+    })
+
+    const encoded = encodeRunDocumentDataPaths(decoded, ROOT)
+    expect(encoded.projectName).toBeUndefined()
+    expect(encoded.runs[0].artifacts[0].projectName).toBeUndefined()
   })
 
   it('leaves an external workspaceCwd unchanged on encode', () => {

--- a/src/main/notebook/run-document-data-paths.ts
+++ b/src/main/notebook/run-document-data-paths.ts
@@ -8,12 +8,23 @@ import type {
 } from '../../shared/notebook'
 import { decodeDataPath, encodeDataPath } from '../storage/data-path'
 
+// Persisted documents are versionless historical input: once the canonical field exists it wins,
+// while legacy documents fall back to the old alias.
+const persistedProjectId = (scope: { projectId?: string; projectName?: string }): string => {
+  const projectId = scope.projectId ?? scope.projectName
+  if (!projectId) throw new Error('A persisted projectId is required.')
+  return projectId
+}
+
 // Replaces a data-root absolute path with a $DATA sentinel and drops the derived fileUrl.
 const encodeArtifact = (artifact: ArtifactFile, dataRoot: string | undefined): ArtifactFile => {
+  const projectId = persistedProjectId(artifact)
   const encoded: ArtifactFile = {
     ...artifact,
+    projectId,
     path: encodeDataPath(artifact.path, dataRoot) as string
   }
+  delete (encoded as { projectName?: string }).projectName
   delete (encoded as Partial<ArtifactFile>).fileUrl
   return encoded
 }
@@ -21,7 +32,8 @@ const encodeArtifact = (artifact: ArtifactFile, dataRoot: string | undefined): A
 // Resolves a $DATA sentinel back to an absolute path and recomputes fileUrl from it.
 const decodeArtifact = (artifact: ArtifactFile, dataRoot: string | undefined): ArtifactFile => {
   const path = decodeDataPath(artifact.path, dataRoot) as string
-  return { ...artifact, path, fileUrl: pathToFileURL(path).href }
+  const projectId = persistedProjectId(artifact)
+  return { ...artifact, projectId, projectName: projectId, path, fileUrl: pathToFileURL(path).href }
 }
 
 // Encodes/decodes a single working file's absolute path, leaving the already-relative field alone.
@@ -57,30 +69,41 @@ const decodeRun = (run: NotebookRunRecord, dataRoot: string | undefined): Notebo
 export const encodeRunDocumentDataPaths = (
   doc: NotebookRunDocument,
   dataRoot?: string
-): NotebookRunDocument => ({
-  ...doc,
-  workspaceCwd: encodeDataPath(doc.workspaceCwd, dataRoot) as string,
-  notebookSessionRoot: encodeDataPath(doc.notebookSessionRoot, dataRoot) as string,
-  dataRoot: encodeDataPath(doc.dataRoot, dataRoot) as string,
-  kernel: {
-    ...doc.kernel,
-    runtimeRoot: encodeDataPath(doc.kernel.runtimeRoot, dataRoot) as string
-  },
-  runs: doc.runs.map((run) => encodeRun(run, dataRoot))
-})
+): NotebookRunDocument => {
+  const projectId = persistedProjectId(doc)
+  const encoded: NotebookRunDocument = {
+    ...doc,
+    projectId,
+    workspaceCwd: encodeDataPath(doc.workspaceCwd, dataRoot) as string,
+    notebookSessionRoot: encodeDataPath(doc.notebookSessionRoot, dataRoot) as string,
+    dataRoot: encodeDataPath(doc.dataRoot, dataRoot) as string,
+    kernel: {
+      ...doc.kernel,
+      runtimeRoot: encodeDataPath(doc.kernel.runtimeRoot, dataRoot) as string
+    },
+    runs: doc.runs.map((run) => encodeRun(run, dataRoot))
+  }
+  delete (encoded as { projectName?: string }).projectName
+  return encoded
+}
 
 // Resolves a decoded document's "$DATA/..." sentinels against the current data root.
 export const decodeRunDocumentDataPaths = (
   doc: NotebookRunDocument,
   dataRoot?: string
-): NotebookRunDocument => ({
-  ...doc,
-  workspaceCwd: decodeDataPath(doc.workspaceCwd, dataRoot) as string,
-  notebookSessionRoot: decodeDataPath(doc.notebookSessionRoot, dataRoot) as string,
-  dataRoot: decodeDataPath(doc.dataRoot, dataRoot) as string,
-  kernel: {
-    ...doc.kernel,
-    runtimeRoot: decodeDataPath(doc.kernel.runtimeRoot, dataRoot) as string
-  },
-  runs: doc.runs.map((run) => decodeRun(run, dataRoot))
-})
+): NotebookRunDocument => {
+  const projectId = persistedProjectId(doc)
+  return {
+    ...doc,
+    projectId,
+    projectName: projectId,
+    workspaceCwd: decodeDataPath(doc.workspaceCwd, dataRoot) as string,
+    notebookSessionRoot: decodeDataPath(doc.notebookSessionRoot, dataRoot) as string,
+    dataRoot: decodeDataPath(doc.dataRoot, dataRoot) as string,
+    kernel: {
+      ...doc.kernel,
+      runtimeRoot: decodeDataPath(doc.kernel.runtimeRoot, dataRoot) as string
+    },
+    runs: doc.runs.map((run) => decodeRun(run, dataRoot))
+  }
+}

--- a/src/main/notebook/run-terminalization.test.ts
+++ b/src/main/notebook/run-terminalization.test.ts
@@ -11,7 +11,7 @@ import { createRootNotebookLane } from './lane-identity'
 import { NotebookRunTerminalizationOwner } from './run-terminalization'
 
 const session = {
-  projectName: 'project-1',
+  projectId: 'project-1',
   sessionId: 'session-1',
   lane: createRootNotebookLane('project-1', 'session-1', 'root-frame-session-1'),
   notebookSessionRoot: '/storage/notebooks/project-1/session-1',
@@ -42,7 +42,7 @@ const runningRun = (
 
 const documentWith = (runs: NotebookRunRecord[]): NotebookRunDocument => ({
   version: 1,
-  projectName: session.projectName,
+  projectName: session.projectId,
   sessionId: session.sessionId,
   workspaceCwd: '/workspace',
   notebookSessionRoot: session.notebookSessionRoot,

--- a/src/main/notebook/run-terminalization.ts
+++ b/src/main/notebook/run-terminalization.ts
@@ -15,7 +15,7 @@ type NotebookRunIdentity = Readonly<{
 }>
 
 type NotebookRunTerminalizationSession = Readonly<{
-  projectName: string
+  projectId: string
   sessionId: string
   lane: NotebookLaneIdentity
 }>
@@ -71,7 +71,7 @@ class NotebookRunTerminalizationOwner {
     const { session, runningRun } = request
     const lane = session.lane
     await this.options.repository.appendRun({
-      projectName: session.projectName,
+      projectName: session.projectId,
       sessionId: session.sessionId,
       lane,
       run: runningRun
@@ -108,7 +108,7 @@ class NotebookRunTerminalizationOwner {
         : {})
     }
     const document = await this.options.repository.updateRun({
-      projectName: session.projectName,
+      projectName: session.projectId,
       sessionId: session.sessionId,
       lane,
       run: terminalRun

--- a/src/main/notebook/runtime-binding.ts
+++ b/src/main/notebook/runtime-binding.ts
@@ -23,7 +23,7 @@ type RuntimeBindingSession = Pick<
   NotebookSessionAggregate,
   'runtimeBinding' | 'setRuntimeBinding'
 > & {
-  readonly projectName: string
+  readonly projectId: string
   readonly sessionId: string
   readonly lane: NotebookSessionAggregate['lane']
 }
@@ -260,7 +260,7 @@ export class NotebookRuntimeBindingOwner {
   async persist(session: RuntimeBindingSession): Promise<void> {
     try {
       await this.options.repository.setRuntimeBindings(
-        session.projectName,
+        session.projectId,
         session.sessionId,
         this.snapshot(session),
         session.lane

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1653,7 +1653,7 @@ describe('notebook runtime service', () => {
     expect(executions).toHaveLength(1)
     expect(executions[0].kind).toBe('repl')
     expect(executions[0].sessionId).toBe('session-9')
-    expect(executions[0].projectName).toBe('my-project')
+    expect(executions[0].projectId).toBe('my-project')
   })
 
   it('records a failed repl run when the executor throws', async () => {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -86,6 +86,7 @@ import { createLogger, getLogFilePath } from '../logger'
 import { EnvironmentStateTracker, type EnvironmentCaptureTarget } from './environment-state-tracker'
 import { NotebookRuntimeBindingOwner } from './runtime-binding'
 import type { RuntimeDiagnosticLogger } from './runtime-diagnostics'
+import { resolveProjectId, type ProjectIdScope } from '../../shared/project-scope'
 import { NotebookRunTerminalizationOwner } from './run-terminalization'
 import type { NotebookShellProcess, NotebookShellResult } from './shell-process'
 import {
@@ -139,12 +140,11 @@ type McpRpcConnectionBinding = {
   attemptId?: string
 }
 
-type NotebookRuntimeServiceOptions = {
+type NotebookRuntimeServiceOptions = ProjectIdScope & {
   // Config root: source of the app-owned claude config dir (protected from the kernel). Never relocated.
   configRoot: string
   // Data root: where notebook workspaces, data, and the runtime install live (user-relocatable).
   dataRoot: string
-  projectName: string
   repository?: NotebookRunRepository
   executorFactory?: (
     sessionId: string,
@@ -335,10 +335,11 @@ class NotebookRuntimeService {
   private disposalPromise: Promise<{ reaped: boolean }> | undefined
 
   constructor(private readonly options: NotebookRuntimeServiceOptions) {
+    const defaultProjectId = resolveProjectId(options)
     this.repository = options.repository ?? new NotebookRunRepository(options.dataRoot)
     this.exportReader = new NotebookExportReader({
       repository: this.repository,
-      defaultProjectName: options.projectName,
+      defaultProjectId,
       appVersion: options.appVersion
     })
     this.sessions = new NotebookSessionRegistry({
@@ -373,7 +374,7 @@ class NotebookRuntimeService {
     })
     this.sessionReadModel = new NotebookSessionReadModel({
       storageRoot: options.dataRoot,
-      defaultProjectName: options.projectName,
+      defaultProjectId,
       repository: this.repository,
       findSession: (sessionId) => this.sessions.get(this.sessionLifecycle.rootLane(sessionId)),
       runtimeBindings: (session) => this.runtimeBindingOwner.snapshot(session),
@@ -382,7 +383,7 @@ class NotebookRuntimeService {
     })
     this.sessionLifecycle = new NotebookSessionLifecycleOwner({
       storageRoot: options.dataRoot,
-      defaultProjectName: options.projectName,
+      defaultProjectId,
       repository: this.repository,
       sessions: this.sessions,
       runtimeBindings: this.runtimeBindingOwner,
@@ -814,7 +815,7 @@ class NotebookRuntimeService {
     const envKeys = session.kernelProcessKeys()
 
     await this.repository.updateKernelStatus({
-      projectName: session.projectName,
+      projectName: session.projectId,
       sessionId: session.sessionId,
       lane: session.lane,
       status: 'restarting'
@@ -826,7 +827,7 @@ class NotebookRuntimeService {
       this.environmentOperations.clearRestartRecommendations(envKeys)
     } finally {
       await this.repository.updateKernelStatus({
-        projectName: session.projectName,
+        projectName: session.projectId,
         sessionId: session.sessionId,
         lane: session.lane,
         status: 'idle'
@@ -1032,7 +1033,7 @@ class NotebookRuntimeService {
   }
 
   // Lists sessions with a cell mid-execution, for the pre-migration active-session warning.
-  getActiveNotebookSessions(): { projectName: string; sessionId: string }[] {
+  getActiveNotebookSessions(): { projectId: string; sessionId: string }[] {
     return this.sessionLifecycle.activeSessions()
   }
 }

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../shared/notebook'
 import type { NotebookRuntimeBinding } from '../../shared/notebook-runtime'
 import type { TrustedControlInvocationIdentity } from '../../shared/agents-contract'
+import { resolveProjectId, type ProjectIdScope } from '../../shared/project-scope'
 import { notebookLaneScope, type NotebookLaneIdentity } from './lane-identity'
 
 export type NotebookSessionResolvedInterpreter = {
@@ -42,7 +43,7 @@ export type NotebookSessionExecutionRequest = {
   mcpRpcSocketPath?: string
   mcpRpcToken?: string
   sessionId?: string
-  projectName?: string
+  projectId?: string
   inputRunLeaseId?: string
   // Opaque per-control invocation identity forwarded through the REPL request frame. It binds a
   // host.agents.switch approval to this exact outer repl_execute completion.
@@ -94,9 +95,8 @@ export type NotebookSessionMcpRpcConnection = {
 export type NotebookSessionAggregateInit<
   Request = NotebookSessionExecutionRequest,
   Result = NotebookSessionExecutionResult
-> = {
+> = ProjectIdScope & {
   sessionId: string
-  projectName: string
   cwd: string
   notebookSessionRoot: string
   dataRoot: string
@@ -111,7 +111,7 @@ export type NotebookSessionAggregateInit<
 export type NotebookSessionSnapshot = Readonly<{
   id: string
   sessionId: string
-  projectName: string
+  projectId: string
   cwd: string
   notebookSessionRoot: string
   dataRoot: string
@@ -147,7 +147,7 @@ export class NotebookSessionAggregate<
 > {
   readonly id: string
   readonly sessionId: string
-  readonly projectName: string
+  readonly projectId: string
   readonly notebookSessionRoot: string
   readonly dataRoot: string
   readonly runtimeRoot: string
@@ -177,7 +177,7 @@ export class NotebookSessionAggregate<
   constructor(init: NotebookSessionAggregateInit<Request, Result>) {
     this.id = `notebook-session-${init.sessionId}`
     this.sessionId = init.sessionId
-    this.projectName = init.projectName
+    this.projectId = resolveProjectId(init)
     this.cwdValue = init.cwd
     this.notebookSessionRoot = init.notebookSessionRoot
     this.dataRoot = init.dataRoot
@@ -198,7 +198,7 @@ export class NotebookSessionAggregate<
     return {
       id: this.id,
       sessionId: this.sessionId,
-      projectName: this.projectName,
+      projectId: this.projectId,
       cwd: this.cwdValue,
       notebookSessionRoot: this.notebookSessionRoot,
       dataRoot: this.dataRoot,
@@ -439,7 +439,7 @@ export class NotebookSessionAggregate<
       const lane = notebookLaneScope(this.lane)
       this.mcpRpcConnection = await resolver({
         sessionId: this.sessionId,
-        projectId: this.projectName,
+        projectId: this.projectId,
         agentFrameId: lane.agentFrameId,
         ...(lane.attemptId ? { attemptId: lane.attemptId } : {})
       })

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -23,6 +23,7 @@ import {
   notebookLaneScope,
   type NotebookLaneIdentity
 } from './lane-identity'
+import { resolveProjectId } from '../../shared/project-scope'
 
 type RuntimeSession = NotebookSessionAggregate
 
@@ -38,7 +39,7 @@ type NotebookSessionLifecycleCallbacks = {
 
 type NotebookSessionLifecycleOptions = {
   storageRoot: string
-  defaultProjectName: string
+  defaultProjectId: string
   repository: NotebookRunRepository
   sessions: NotebookSessionRegistry<RuntimeSession>
   runtimeBindings: NotebookRuntimeBindingOwner
@@ -76,34 +77,34 @@ class NotebookSessionLifecycleOwner {
   constructor(private readonly options: NotebookSessionLifecycleOptions) {}
 
   laneForRequest(request: NotebookSessionRequest): NotebookLaneIdentity {
-    const projectName = request.projectName ?? this.options.defaultProjectName
+    const projectId = resolveProjectId(request, this.options.defaultProjectId)
     const context = request.provenanceContext
     const attemptId = (request as InternalNotebookSessionRequest).delegatedWorkAttemptId
     if (context && context.agentFrameId === context.rootFrameId) {
-      return createRootNotebookLane(projectName, request.sessionId, context.agentFrameId)
+      return createRootNotebookLane(projectId, request.sessionId, context.agentFrameId)
     }
     return context?.agentFrameId
-      ? createFrameNotebookLane(projectName, request.sessionId, context.agentFrameId, attemptId)
-      : this.rootLane(request.sessionId, projectName)
+      ? createFrameNotebookLane(projectId, request.sessionId, context.agentFrameId, attemptId)
+      : this.rootLane(request.sessionId, projectId)
   }
 
-  rootLane(sessionId: string, projectName = this.options.defaultProjectName): NotebookLaneIdentity {
-    return createRootNotebookLane(projectName, sessionId, `root-frame-${sessionId}`)
+  rootLane(sessionId: string, projectId = this.options.defaultProjectId): NotebookLaneIdentity {
+    return createRootNotebookLane(projectId, sessionId, `root-frame-${sessionId}`)
   }
 
   ensure(request: NotebookSessionRequest): Promise<RuntimeSession> {
-    const projectName = request.projectName ?? this.options.defaultProjectName
+    const projectId = resolveProjectId(request, this.options.defaultProjectId)
     const lane = this.laneForRequest(request)
     return this.options.sessions.getOrCreate(lane, async () => {
       let document = await this.options.repository.loadOrCreate({
-        projectName,
+        projectName: projectId,
         sessionId: request.sessionId,
         workspaceCwd: request.workspaceCwd,
         lane
       })
       if (document.runs.some((run) => run.status === 'running' || run.status === 'queued')) {
         document = await this.options.repository.reconcileInterruptedRuns(
-          projectName,
+          projectId,
           request.sessionId,
           lane
         )
@@ -112,14 +113,14 @@ class NotebookSessionLifecycleOwner {
       const ownedExecutor = this.createExecutor(lane)
       const session = new NotebookSessionAggregate({
         sessionId: request.sessionId,
-        projectName,
+        projectId,
         cwd: document.dataRoot,
         notebookSessionRoot: document.notebookSessionRoot,
         dataRoot: document.dataRoot,
         runtimeRoot: document.kernel.runtimeRoot,
         runJsonPath: getNotebookRunJsonPath(
           this.options.storageRoot,
-          projectName,
+          projectId,
           request.sessionId,
           lane
         ),
@@ -197,10 +198,10 @@ class NotebookSessionLifecycleOwner {
     return this.options.runtimeBindings.withGlobalTeardown(() => this.options.sessions.dispose())
   }
 
-  activeSessions(): { projectName: string; sessionId: string }[] {
+  activeSessions(): { projectId: string; sessionId: string }[] {
     return Array.from(this.options.sessions.values())
       .filter((session) => session.hasActiveRun())
-      .map((session) => ({ projectName: session.projectName, sessionId: session.sessionId }))
+      .map((session) => ({ projectId: session.projectId, sessionId: session.sessionId }))
   }
 
   notifyAvailable(session: RuntimeSession, source: NotebookRunSource): void {
@@ -223,7 +224,7 @@ class NotebookSessionLifecycleOwner {
     if (!persistsToRunJson(processKey)) return
     try {
       await this.options.repository.updateKernelStatus({
-        projectName: session.projectName,
+        projectName: session.projectId,
         sessionId: session.sessionId,
         lane: session.lane,
         status

--- a/src/main/notebook/session-read-model.test.ts
+++ b/src/main/notebook/session-read-model.test.ts
@@ -42,12 +42,12 @@ const makeSession = (
   withRuntimeBinding = false
 ): NotebookSessionReadSource => {
   const sessionId = 'session-1'
-  const projectName = 'default-project'
-  const notebookSessionRoot = join(storageRoot, 'notebooks', projectName, sessionId)
+  const projectId = 'default-project'
+  const notebookSessionRoot = join(storageRoot, 'notebooks', projectId, sessionId)
   const snapshot: NotebookSessionSnapshot = {
     id: `notebook-session-${sessionId}`,
     sessionId,
-    projectName,
+    projectId,
     cwd: join(storageRoot, 'workspace'),
     notebookSessionRoot,
     dataRoot: join(notebookSessionRoot, 'data'),
@@ -61,13 +61,13 @@ const makeSession = (
   return {
     id: snapshot.id,
     sessionId,
-    projectName,
+    projectId,
     cwd: snapshot.cwd,
     notebookSessionRoot,
     dataRoot: snapshot.dataRoot,
     runtimeRoot: snapshot.runtimeRoot,
     runJsonPath: snapshot.runJsonPath,
-    lane: createFrameNotebookLane(projectName, sessionId, 'root-frame-session-1'),
+    lane: createFrameNotebookLane(projectId, sessionId, 'root-frame-session-1'),
     snapshot: () => snapshot,
     kernelStatusEntries: () => snapshot.kernelStatuses.map((entry) => [...entry]),
     runtimeBindingEntries: () =>
@@ -97,7 +97,7 @@ const makeReadModel = (
 ): NotebookSessionReadModel<NotebookSessionReadSource> =>
   new NotebookSessionReadModel({
     storageRoot,
-    defaultProjectName: 'default-project',
+    defaultProjectId: 'default-project',
     repository,
     findSession: vi.fn(() => session),
     runtimeBindings: () => ({
@@ -164,7 +164,7 @@ describe('NotebookSessionReadModel', () => {
       ]
     })
     await repository.loadOrCreate({
-      projectName: session.projectName,
+      projectName: session.projectId,
       sessionId: session.sessionId,
       lane: session.lane,
       workspaceCwd: session.cwd,
@@ -212,7 +212,7 @@ describe('NotebookSessionReadModel', () => {
 
     const persistedWorkspace = join(storageRoot, 'persisted-workspace')
     await repository.loadOrCreate({
-      projectName: session.projectName,
+      projectName: session.projectId,
       sessionId: session.sessionId,
       lane: session.lane,
       workspaceCwd: persistedWorkspace
@@ -225,12 +225,13 @@ describe('NotebookSessionReadModel', () => {
       })
     ).resolves.toEqual({
       sessionId: session.sessionId,
-      projectName: session.projectName,
+      projectId: session.projectId,
+      projectName: session.projectId,
       workspaceCwd: persistedWorkspace,
       notebookSessionRoot: session.notebookSessionRoot,
       dataRoot: session.dataRoot,
       runtimeRoot: session.runtimeRoot,
-      runJsonPath: getNotebookRunJsonPath(storageRoot, session.projectName, session.sessionId)
+      runJsonPath: getNotebookRunJsonPath(storageRoot, session.projectId, session.sessionId)
     })
     await expect(
       durableModel.getSessionReference({

--- a/src/main/notebook/session-read-model.ts
+++ b/src/main/notebook/session-read-model.ts
@@ -19,6 +19,7 @@ import {
 } from './repository'
 import type { NotebookSessionSnapshot } from './session-aggregate'
 import type { NotebookLaneIdentity } from './lane-identity'
+import { resolveProjectId } from '../../shared/project-scope'
 
 type NotebookHandoffContext = {
   activeRunId?: string
@@ -47,7 +48,7 @@ type NotebookHandoffContext = {
 type NotebookSessionReadSource = {
   readonly id: string
   readonly sessionId: string
-  readonly projectName: string
+  readonly projectId: string
   readonly cwd: string
   readonly notebookSessionRoot: string
   readonly dataRoot: string
@@ -61,7 +62,7 @@ type NotebookSessionReadSource = {
 
 type NotebookSessionReadModelOptions<Session extends NotebookSessionReadSource> = {
   storageRoot: string
-  defaultProjectName: string
+  defaultProjectId: string
   repository: NotebookRunRepository
   findSession: (sessionId: string) => Session | undefined
   runtimeBindings: (session: Session) => NotebookRuntimeBindings
@@ -128,16 +129,13 @@ class NotebookSessionReadModel<Session extends NotebookSessionReadSource> {
     session: Session
   ): Promise<NotebookSessionState & { runtimeBindings: NotebookRuntimeBindings }> {
     const document = await this.options.repository.loadOrCreate({
-      projectName: session.projectName,
+      projectName: session.projectId,
       sessionId: session.sessionId,
       workspaceCwd: session.cwd,
       lane: session.lane
     })
     const snapshot = session.snapshot()
-    const runs = await this.options.repository.readSessionRuns(
-      session.projectName,
-      session.sessionId
-    )
+    const runs = await this.options.repository.readSessionRuns(session.projectId, session.sessionId)
 
     return {
       id: session.id,
@@ -162,35 +160,39 @@ class NotebookSessionReadModel<Session extends NotebookSessionReadSource> {
   async getSessionReference(
     request: NotebookSessionRequest
   ): Promise<NotebookSessionReference | null> {
+    const projectId = resolveProjectId(request, this.options.defaultProjectId)
     const live = this.options.findSession(request.sessionId)
     if (live) return this.toSessionReference(live)
 
-    const projectName = request.projectName ?? this.options.defaultProjectName
-    const document = await this.options.repository.findAnyExisting(projectName, request.sessionId)
+    const document = await this.options.repository.findAnyExisting(projectId, request.sessionId)
     if (!document) return null
 
-    const rootDocument = await this.options.repository.findExisting(projectName, request.sessionId)
+    const rootDocument = await this.options.repository.findExisting(projectId, request.sessionId)
     const notebookSessionRoot = getNotebookSessionRoot(
       this.options.storageRoot,
-      projectName,
+      projectId,
       request.sessionId
     )
 
     return {
       sessionId: request.sessionId,
-      projectName,
+      projectId,
+      // Compatibility output for an older renderer/main pair; this value is the Project id.
+      projectName: projectId,
       workspaceCwd: rootDocument?.workspaceCwd ?? request.workspaceCwd,
       notebookSessionRoot,
-      dataRoot: getNotebookDataRoot(this.options.storageRoot, projectName, request.sessionId),
+      dataRoot: getNotebookDataRoot(this.options.storageRoot, projectId, request.sessionId),
       runtimeRoot: document.kernel.runtimeRoot,
-      runJsonPath: getNotebookRunJsonPath(this.options.storageRoot, projectName, request.sessionId)
+      runJsonPath: getNotebookRunJsonPath(this.options.storageRoot, projectId, request.sessionId)
     }
   }
 
   toSessionReference(session: Session): NotebookSessionReference {
     return {
       sessionId: session.sessionId,
-      projectName: session.projectName,
+      projectId: session.projectId,
+      // Compatibility output for an older renderer/main pair; this value is the Project id.
+      projectName: session.projectId,
       workspaceCwd: session.cwd,
       notebookSessionRoot: session.notebookSessionRoot,
       dataRoot: session.dataRoot,

--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -44,7 +44,8 @@ import { createLogger, diagnosticErrorFields, type Logger } from '../logger'
 import { startDiagnosticOperation } from '../diagnostics/operation'
 import { markApplicationShutdownTrigger } from '../application-shutdown-trigger'
 
-type SessionSource = { projectName: string; sessionId: string }
+type LegacySessionSource = { projectName: string; sessionId: string }
+type NotebookSessionSource = { projectId: string; sessionId: string }
 
 type StorageCommandOwnerDeps = {
   // disconnect/shutdownAll drive the reusable migration session-interrupt; shutdownForQuit/dispose are
@@ -56,10 +57,10 @@ type StorageCommandOwnerDeps = {
   notebook: {
     shutdownAll: () => Promise<{ reaped: boolean }>
     dispose: () => Promise<{ reaped: boolean }>
-    getActiveNotebookSessions: () => SessionSource[]
+    getActiveNotebookSessions: () => NotebookSessionSource[]
   }
-  getActivePromptSessions: () => SessionSource[]
-  getActiveDelegatedSessions: () => SessionSource[]
+  getActivePromptSessions: () => LegacySessionSource[]
+  getActiveDelegatedSessions: () => LegacySessionSource[]
   settingsService: {
     setDataRoot: (path: string) => Promise<void>
     // Stamps onboardingCompletedAt. Injected (rather than importing the renderer store action)

--- a/src/main/storage/detect-active.test.ts
+++ b/src/main/storage/detect-active.test.ts
@@ -42,10 +42,10 @@ describe('detectActiveSessions', () => {
       delegated: {
         getActiveDelegatedSessions: () => [{ projectName: 'p', sessionId: 'delegated-1' }]
       },
-      notebook: { getActiveNotebookSessions: () => [{ projectName: 'p', sessionId: 's2' }] }
+      notebook: { getActiveNotebookSessions: () => [{ projectId: 'p', sessionId: 's2' }] }
     })
 
-    // The runtime source calls the storage key projectName; detect-active exposes it as projectId.
+    // The ACP runtime still uses its legacy key; the Notebook source is already canonical.
     expect(result).toEqual([
       { projectId: 'p', sessionId: 'delegated-1', kind: 'delegated' },
       { projectId: 'p', sessionId: 's1', kind: 'agent' },
@@ -68,7 +68,7 @@ describe('detectActiveSessions', () => {
     const result = detectActiveSessions({
       runtime: { getActivePromptSessions: () => [source] },
       delegated: { getActiveDelegatedSessions: () => [source] },
-      notebook: { getActiveNotebookSessions: () => [source] }
+      notebook: { getActiveNotebookSessions: () => [{ projectId: 'p', sessionId: 's1' }] }
     })
 
     expect(result).toEqual([

--- a/src/main/storage/detect-active.ts
+++ b/src/main/storage/detect-active.ts
@@ -9,26 +9,25 @@ import type { PersistedChatSession } from '../../shared/session-persistence'
 
 export type { ActiveSessionInfo }
 
-// The runtime layer calls the artifact/notebook storage key `projectName`, but it holds the project
-// id; this module translates it to the honest `projectId` on the ActiveSessionInfo it exposes.
-type ActiveSessionSource = { projectName: string; sessionId: string }
+type LegacyActiveSessionSource = { projectName: string; sessionId: string }
+type ActiveNotebookSessionSource = { projectId: string; sessionId: string }
 
 type ActiveDetectionDeps = {
-  runtime: { getActivePromptSessions(): ActiveSessionSource[] }
-  delegated: { getActiveDelegatedSessions(): ActiveSessionSource[] }
-  notebook: { getActiveNotebookSessions(): ActiveSessionSource[] }
+  runtime: { getActivePromptSessions(): LegacyActiveSessionSource[] }
+  delegated: { getActiveDelegatedSessions(): LegacyActiveSessionSource[] }
+  notebook: { getActiveNotebookSessions(): ActiveNotebookSessionSource[] }
 }
 
 type DelegatedActivityProjection = Readonly<{
   recordSession(session: PersistedChatSession): void
-  getActiveDelegatedSessions(): ActiveSessionSource[]
+  getActiveDelegatedSessions(): LegacyActiveSessionSource[]
 }>
 
 // Bridges the durable, async delegated-work owner to synchronous Electron close/migration gates.
 // It stores only active identities, so terminal mutations release their blocker immediately and
 // completed Sessions do not accumulate in memory.
 const createDelegatedActivityProjection = (): DelegatedActivityProjection => {
-  const activeSessions = new Map<string, ActiveSessionSource>()
+  const activeSessions = new Map<string, LegacyActiveSessionSource>()
   return {
     recordSession: (session) => {
       const key = JSON.stringify([session.projectId, session.id])
@@ -65,7 +64,7 @@ export const detectActiveSessions = (deps: ActiveDetectionDeps): ActiveSessionIn
       kind: 'agent'
     })),
     ...deps.notebook.getActiveNotebookSessions().map((entry) => ({
-      projectId: entry.projectName,
+      projectId: entry.projectId,
       sessionId: entry.sessionId,
       kind: 'notebook' as const
     }))

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -365,9 +365,7 @@ describe('storage IPC handlers', () => {
       notebook: {
         shutdownAll: vi.fn().mockResolvedValue({ reaped: true }),
         dispose: vi.fn().mockResolvedValue({ reaped: true }),
-        getActiveNotebookSessions: vi
-          .fn()
-          .mockReturnValue([{ projectName: 'p', sessionId: 'nb-1' }])
+        getActiveNotebookSessions: vi.fn().mockReturnValue([{ projectId: 'p', sessionId: 'nb-1' }])
       }
     })
     registerStorageIpcHandlers(deps)
@@ -384,10 +382,10 @@ describe('storage IPC handlers', () => {
     // `this.sessions`. The handler must invoke it as a method — extracting it as a bare function
     // reference drops `this` and throws "Cannot read properties of undefined (reading 'values')".
     class FakeNotebookService {
-      private sessions = new Map([['nb-1', { projectName: 'p', sessionId: 'nb-1' }]])
+      private sessions = new Map([['nb-1', { projectId: 'p', sessionId: 'nb-1' }]])
       shutdownAll = vi.fn().mockResolvedValue({ reaped: true })
       dispose = vi.fn().mockResolvedValue({ reaped: true })
-      getActiveNotebookSessions(): { projectName: string; sessionId: string }[] {
+      getActiveNotebookSessions(): { projectId: string; sessionId: string }[] {
         return Array.from(this.sessions.values())
       }
     }

--- a/src/main/storage/normalize-legacy-paths.test.ts
+++ b/src/main/storage/normalize-legacy-paths.test.ts
@@ -181,6 +181,8 @@ describe('normalizeLegacyDataPaths (integration)', () => {
     const runRawAfterFirstPass = await readFile(join(notebookSessionDir, NOTEBOOK_RUN_FILE), 'utf8')
     expect(runRawAfterFirstPass).toContain('$DATA/')
     expect(runRawAfterFirstPass).not.toContain(dataRoot)
+    expect(JSON.parse(runRawAfterFirstPass)).toMatchObject({ projectId: projectName })
+    expect(JSON.parse(runRawAfterFirstPass).projectName).toBeUndefined()
 
     // --- Relocation: reading from a different data root resolves paths under the new root. ---
     const newRoot = await mkdtemp(join(tmpdir(), 'open-science-normalize-newroot-'))

--- a/src/main/storage/provenance-migration-validation.test.ts
+++ b/src/main/storage/provenance-migration-validation.test.ts
@@ -579,7 +579,7 @@ describe('validateProvenanceMigrationState', () => {
       join(notebookDirectory, 'run.json'),
       JSON.stringify({
         version: 1,
-        projectName: 'project-1',
+        projectId: 'project-1',
         sessionId: 'notebook-session-1',
         runs: [
           {

--- a/src/main/storage/provenance-migration-validation.ts
+++ b/src/main/storage/provenance-migration-validation.ts
@@ -131,7 +131,8 @@ const validateReferencedEnvironmentManifests = async (
       const runPath = join(notebooksRoot, project.name, session.name, NOTEBOOK_RUN_FILE)
       if (!(await fileExists(runPath))) continue
       const document = await readRecord(runPath)
-      if (document.projectName !== project.name || document.sessionId !== session.name) {
+      const projectId = document.projectId ?? document.projectName
+      if (projectId !== project.name || document.sessionId !== session.name) {
         throw new Error(`Notebook run ownership is invalid: ${project.name}/${session.name}`)
       }
       const runs = Array.isArray(document.runs) ? document.runs : []

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1882,7 +1882,7 @@ describe('workspace agent message sending', () => {
     expect(shutdown).toHaveBeenCalledWith({
       sessionId: 'transport-session-1',
       workspaceCwd: '/workspace/project',
-      projectName: 'project-1'
+      projectId: 'project-1'
     })
     expect(resetSessionContext).toHaveBeenCalledOnce()
     expect(shutdown.mock.invocationCallOrder[0]).toBeLessThan(

--- a/src/renderer/src/lib/acp/workspace-elicitation-runtime.ts
+++ b/src/renderer/src/lib/acp/workspace-elicitation-runtime.ts
@@ -92,10 +92,10 @@ const restoreElicitationRevisionProjection = (projection: ChatSession): void => 
 const shutdownNotebookForElicitationRevision = async (
   sessionId: string,
   workspaceCwd: string,
-  projectName?: string
+  projectId?: string
 ): Promise<void> => {
   if (typeof window === 'undefined' || !window.api?.notebook?.shutdown) return
-  await window.api.notebook.shutdown({ sessionId, workspaceCwd, projectName })
+  await window.api.notebook.shutdown({ sessionId, workspaceCwd, projectId })
 }
 
 const reviseWorkspaceElicitation = async (

--- a/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
@@ -102,10 +102,10 @@ const buildReplay = (
 const shutdownNotebookForBranchChange = async (
   sessionId: string,
   workspaceCwd: string,
-  projectName?: string
+  projectId?: string
 ): Promise<void> => {
   if (typeof window === 'undefined' || !window.api?.notebook?.shutdown) return
-  await window.api.notebook.shutdown({ sessionId, workspaceCwd, projectName })
+  await window.api.notebook.shutdown({ sessionId, workspaceCwd, projectId })
 }
 
 const unwrapIpcErrorDetail = (message: string): string =>

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -103,7 +103,7 @@ describe('reconcilePendingArtifacts', () => {
     await reconcilePendingArtifacts(api)
 
     expect(api.reconcilePendingArtifacts).toHaveBeenCalledWith({
-      projectName: 'proj-1',
+      projectId: 'proj-1',
       sessionId: 'session-1',
       messageId: 'message-1',
       pendingPaths: [pendingPath]

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -180,7 +180,7 @@ const reconcilePendingArtifacts = async (api: ArtifactReconcileApi): Promise<voi
 
       try {
         const finalized = await api.reconcilePendingArtifacts({
-          projectName: session.projectId,
+          projectId: session.projectId,
           sessionId: session.id,
           messageId: message.id,
           pendingPaths

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -763,7 +763,7 @@ const ConversationPanel = ({
                         ? {
                             sessionId: activeSession.id,
                             workspaceCwd: activeSession.cwd ?? '',
-                            projectName: activeSession.projectId
+                            projectId: activeSession.projectId
                           }
                         : undefined
                     }
@@ -936,7 +936,7 @@ const ConversationPanel = ({
                             ? {
                                 sessionId: activeSession.id,
                                 workspaceCwd: activeSession.cwd ?? '',
-                                projectName: activeSession.projectId
+                                projectId: activeSession.projectId
                               }
                             : undefined
                         }

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -20,6 +20,7 @@ import type {
   NotebookSessionReference,
   NotebookSessionState
 } from '../../../../shared/notebook'
+import { resolveProjectId } from '../../../../shared/project-scope'
 import { EnvProvisionOverlay } from './EnvProvisionOverlay'
 import { shouldProvisionR } from './lazy-r'
 import { notebookGated } from './provisioning-view'
@@ -81,11 +82,11 @@ const getErrorMessage = (error: unknown): string =>
 const createNotebookRequest = (
   notebook: NotebookSessionReference
 ): {
-  projectName: string
+  projectId: string
   sessionId: string
   workspaceCwd: string
 } => ({
-  projectName: notebook.projectName,
+  projectId: resolveProjectId(notebook),
   sessionId: notebook.sessionId,
   workspaceCwd: notebook.workspaceCwd
 })

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { AcpPermissionRequest } from '../../../../shared/acp'
 import type { NotebookSessionRequest } from '../../../../shared/notebook'
+import { resolveProjectId } from '../../../../shared/project-scope'
 import { isEnvEnabled } from '../../../../shared/notebook-runtime'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -351,7 +352,9 @@ const useNotebookEnvironment = (
   kernelKind: 'python' | 'r' | undefined
 ): string | undefined => {
   const [environment, setEnvironment] = useState<{ key: string; name: string | undefined }>()
-  const lookupKey = lookup ? `${lookup.projectName ?? ''}:${lookup.sessionId}` : undefined
+  const lookupKey = lookup
+    ? `${resolveProjectId(lookup, 'default-project')}:${lookup.sessionId}`
+    : undefined
   const key = lookupKey && kernelKind ? `${lookupKey}:${kernelKind}` : undefined
   useEffect(() => {
     if (!lookup || !key || !kernelKind) return

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
@@ -453,7 +453,7 @@ const SessionNotebookDialog = ({
 
       void loadSessionNotebookRuns(window.api.notebook, {
         sessionId,
-        projectName: projectId,
+        projectId,
         workspaceCwd: cwd ?? ''
       })
         .then((loadedRuns) => {
@@ -509,7 +509,7 @@ const SessionNotebookDialog = ({
               onExport={async (kernel, agentFrameFilter) => {
                 await window.api.notebook.exportIpynb({
                   sessionId: dialogSession.id,
-                  projectName: dialogSession.projectId,
+                  projectId: dialogSession.projectId,
                   workspaceCwd: dialogSession.cwd ?? '',
                   kernel,
                   ...(agentFrameFilter !== undefined ? { agentFrameFilter } : {})
@@ -518,7 +518,7 @@ const SessionNotebookDialog = ({
               onExportAll={async (agentFrameFilter) => {
                 const result = await window.api.notebook.exportIpynbAll({
                   sessionId: dialogSession.id,
-                  projectName: dialogSession.projectId,
+                  projectId: dialogSession.projectId,
                   workspaceCwd: dialogSession.cwd ?? '',
                   ...(agentFrameFilter !== undefined ? { agentFrameFilter } : {})
                 })

--- a/src/renderer/src/pages/workspace/WorkspaceArtifactVisibility.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceArtifactVisibility.tsx
@@ -8,6 +8,7 @@ import {
   type ArtifactVersionDescriptor
 } from '../../../../shared/artifact-provenance'
 import { projectRootArtifactVisibility } from '../../../../shared/artifact-visibility'
+import { resolveProjectId } from '../../../../shared/project-scope'
 import { resolveTurnTerminalAgentMessageIds } from './workspace-conversation-items'
 
 type MessageArtifact = NonNullable<ChatSession['artifacts']>[number] & {
@@ -50,7 +51,7 @@ const toResolvedMessageArtifact = (descriptor: ArtifactVersionDescriptor): Messa
   versionNumber: descriptor.versionNumber,
   kind: 'managed-file',
   path: createArtifactVersionLocator({
-    projectId: descriptor.projectName,
+    projectId: resolveProjectId(descriptor),
     appSessionId: descriptor.sessionId,
     artifactId: descriptor.artifactId,
     versionId: descriptor.versionId
@@ -60,7 +61,7 @@ const toResolvedMessageArtifact = (descriptor: ArtifactVersionDescriptor): Messa
   size: descriptor.size,
   mtimeMs: descriptor.mtimeMs,
   sha256: descriptor.checksum,
-  resolvedProjectId: descriptor.projectName,
+  resolvedProjectId: resolveProjectId(descriptor),
   resolvedSessionId: descriptor.sessionId
 })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -36,6 +36,7 @@ import {
 } from './preview-file-item'
 import { createPreviewRequestScope } from './previews/preview-file-reader'
 import { resolveLocalPath } from '../../../../shared/local-fs'
+import { resolveProjectId } from '../../../../shared/project-scope'
 import { useGrantedFoldersStore } from '@/stores/granted-folders-store'
 import type { JobSummary } from '../../../../shared/compute'
 import { CompletedJobCard } from '@/components/CompletedJobCard'
@@ -1113,7 +1114,8 @@ const areWorkspaceMessageScrollerPropsEqual = (
   previous.trailingContent === next.trailingContent &&
   previous.isResumingSession === next.isResumingSession &&
   previous.notebookReference?.sessionId === next.notebookReference?.sessionId &&
-  previous.notebookReference?.projectName === next.notebookReference?.projectName &&
+  (previous.notebookReference ? resolveProjectId(previous.notebookReference) : undefined) ===
+    (next.notebookReference ? resolveProjectId(next.notebookReference) : undefined) &&
   previous.notebookReference?.workspaceCwd === next.notebookReference?.workspaceCwd &&
   areSessionsEqualForTranscript(previous.activeSession, next.activeSession)
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx
@@ -156,7 +156,7 @@ describe('WorkspacePage notebook entry hydration', () => {
     expect(getReference).toHaveBeenCalledWith({
       sessionId: 'sess-1',
       workspaceCwd: '/workspace/proj-1',
-      projectName: 'proj-1'
+      projectId: 'proj-1'
     })
   })
 })

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -684,7 +684,7 @@ const WorkspacePage = ({
       .getReference({
         sessionId: activeSessionId,
         workspaceCwd: activeSessionCwd ?? '',
-        projectName: activeSessionProjectId
+        projectId: activeSessionProjectId
       })
       .then((reference) => {
         if (cancelled || !reference) return

--- a/src/renderer/src/pages/workspace/use-notebook-runs-by-id.test.ts
+++ b/src/renderer/src/pages/workspace/use-notebook-runs-by-id.test.ts
@@ -73,7 +73,7 @@ describe('useNotebookRunsById', () => {
     await waitFor(() => expect(result.current.get('run-1')).toBeDefined())
     expect(window.api.notebook.state).toHaveBeenCalledWith({
       sessionId: 'session-1',
-      projectName: 'project-1',
+      projectId: 'project-1',
       workspaceCwd: '/workspace'
     })
     expect(result.current.get('run-1')?.outputs).toEqual([

--- a/src/renderer/src/pages/workspace/use-notebook-runs-by-id.ts
+++ b/src/renderer/src/pages/workspace/use-notebook-runs-by-id.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import type { NotebookRunRecord, NotebookSessionReference } from '../../../../shared/notebook'
+import { resolveProjectId } from '../../../../shared/project-scope'
 
 type NotebookRunSnapshot = {
   sessionId?: string
@@ -18,11 +19,11 @@ const useNotebookRunsById = (
     runsById: EMPTY_RUNS_BY_ID
   })
   const sessionId = reference?.sessionId
-  const projectName = reference?.projectName
+  const projectId = reference ? resolveProjectId(reference) : undefined
   const workspaceCwd = reference?.workspaceCwd
 
   useEffect(() => {
-    if (!sessionId || !projectName || workspaceCwd === undefined) {
+    if (!sessionId || !projectId || workspaceCwd === undefined) {
       return undefined
     }
 
@@ -32,7 +33,7 @@ const useNotebookRunsById = (
       const sequence = ++requestSequence
 
       try {
-        const state = await window.api.notebook.state({ sessionId, projectName, workspaceCwd })
+        const state = await window.api.notebook.state({ sessionId, projectId, workspaceCwd })
 
         if (!active || sequence !== requestSequence) return
         setSnapshot({
@@ -55,7 +56,7 @@ const useNotebookRunsById = (
       active = false
       stopChanged()
     }
-  }, [projectName, sessionId, workspaceCwd])
+  }, [projectId, sessionId, workspaceCwd])
 
   return snapshot.sessionId === sessionId ? snapshot.runsById : EMPTY_RUNS_BY_ID
 }

--- a/src/renderer/src/pages/workspace/use-project-artifact-files.test.ts
+++ b/src/renderer/src/pages/workspace/use-project-artifact-files.test.ts
@@ -58,8 +58,8 @@ afterEach(() => {
 describe('useProjectArtifactFiles', () => {
   it('never returns the previous project files while the new project scan is in flight', async () => {
     let resolveProjectB: ((files: ArtifactFile[]) => void) | undefined
-    const listProjectFiles = vi.fn((request: { projectName: string }) => {
-      if (request.projectName === 'project-a') {
+    const listProjectFiles = vi.fn((request: { projectId: string }) => {
+      if (request.projectId === 'project-a') {
         return Promise.resolve([artifact('project-a', 'a.txt')])
       }
       // project-b's scan is held open so the test can observe the value while it is still pending.

--- a/src/renderer/src/pages/workspace/use-project-artifact-files.ts
+++ b/src/renderer/src/pages/workspace/use-project-artifact-files.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import type { ArtifactFile } from '../../../../shared/artifacts'
 import { useSessionStore } from '@/stores/session-store'
 
-// Loads every on-disk artifact for a project (the storage project name matches the durable project id)
+// Loads every on-disk artifact for an immutable Project id.
 // so the file library can surface files whose owning session was deleted. Re-fetches when the project
 // changes or when the set of sessions in it changes — the only events that can create or clear an
 // orphan (a delete removes the metadata that was keeping a file "owned"). Failures resolve to an empty
@@ -34,7 +34,7 @@ export const useProjectArtifactFiles = (projectId: string | undefined): Artifact
     const load = async (): Promise<ArtifactFile[]> => {
       if (!projectId) return []
       try {
-        return await window.api.artifacts.listProjectFiles({ projectName: projectId })
+        return await window.api.artifacts.listProjectFiles({ projectId })
       } catch {
         return []
       }

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -1,7 +1,9 @@
-// Renderer-safe description of one generated file without embedding file contents.
-export type ArtifactFile = {
+import type { ProjectIdScope } from './project-scope'
+
+// Renderer-safe description of one generated file without embedding file contents. `projectName`
+// remains a rolling/historical transport alias whose value is a Project id, never a display name.
+export type ArtifactFile = ProjectIdScope & {
   id: string
-  projectName: string
   sessionId: string
   messageId?: string
   runId?: string
@@ -153,9 +155,7 @@ export type ListMessageArtifactsRequest = {
 
 // Renderer request to enumerate every finalized artifact on disk for one project, so the file library
 // can surface files whose owning session was deleted (the project name matches the durable project id).
-export type ListProjectArtifactsRequest = {
-  projectName: string
-}
+export type ListProjectArtifactsRequest = ProjectIdScope
 
 // A copied conversation stores native generated-file Version ids in its messages, not paths or a
 // second file-library entry. Keep this query small because it is issued while historical messages
@@ -173,8 +173,7 @@ export type ResolveArtifactVersionDescriptorsRequest = {
 // Renderer request to re-finalize pending artifacts a crash left behind: the persisted message still
 // references `.pending/<run>/<file>` paths whose in-memory finalize claim was lost on restart. Returns
 // the message's finalized files so the renderer can replace the stale pending references.
-export type ReconcilePendingArtifactsRequest = {
-  projectName: string
+export type ReconcilePendingArtifactsRequest = ProjectIdScope & {
   sessionId: string
   messageId: string
   pendingPaths: string[]

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -1,5 +1,6 @@
 import type { ArtifactFile } from './artifacts'
 import type { NotebookRuntimeBindings } from './notebook-runtime'
+import type { OptionalProjectIdScope, ProjectIdScope } from './project-scope'
 
 export const NOTEBOOKS_DIR = 'notebooks'
 export const NOTEBOOK_RUN_FILE = 'run.json'
@@ -345,9 +346,8 @@ export type NotebookRunRecord = {
 }
 
 // The complete JSON document persisted at each notebook session's run.json path.
-export type NotebookRunDocument = {
+export type NotebookRunDocument = ProjectIdScope & {
   version: 1
-  projectName: string
   sessionId: string
   artifactSessionId?: string
   workspaceCwd: string
@@ -420,9 +420,8 @@ export type NotebookSessionState = {
 }
 
 // Lightweight session handle used by events and preview tabs to reopen the notebook.
-export type NotebookSessionReference = {
+export type NotebookSessionReference = ProjectIdScope & {
   sessionId: string
-  projectName: string
   workspaceCwd: string
   notebookSessionRoot: string
   dataRoot: string
@@ -444,8 +443,7 @@ export type NotebookRunSummary = Omit<NotebookRunRecord, 'inputFiles'> & {
 }
 
 // Common routing fields required by every notebook command.
-export type NotebookSessionRequest = {
-  projectName?: string
+export type NotebookSessionRequest = OptionalProjectIdScope & {
   sessionId: string
   workspaceCwd: string
   provenanceContext?: NotebookRunProvenanceContext

--- a/src/shared/project-scope.test.ts
+++ b/src/shared/project-scope.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveProjectId } from './project-scope'
+
+describe('resolveProjectId', () => {
+  it('prefers the canonical projectId and accepts the matching legacy alias', () => {
+    expect(resolveProjectId({ projectId: 'project-1' })).toBe('project-1')
+    expect(resolveProjectId({ projectId: 'project-1', projectName: 'project-1' })).toBe('project-1')
+  })
+
+  it('accepts a historical projectName value and an explicit fallback as Project ids', () => {
+    expect(resolveProjectId({ projectName: 'legacy-project-id' })).toBe('legacy-project-id')
+    expect(resolveProjectId({}, 'default-project')).toBe('default-project')
+  })
+
+  it('rejects ambiguous or missing Project identity', () => {
+    expect(() =>
+      resolveProjectId({ projectId: 'project-1', projectName: 'renamed-project' })
+    ).toThrow('Conflicting projectId and legacy projectName values.')
+    expect(() => resolveProjectId({})).toThrow('A projectId is required.')
+  })
+})

--- a/src/shared/project-scope.ts
+++ b/src/shared/project-scope.ts
@@ -1,0 +1,24 @@
+// Canonical Project routing uses the immutable Project id. `projectName` is accepted only because
+// older Artifact/Notebook transports used that field name while carrying the id as its value.
+export type ProjectIdScope =
+  | Readonly<{ projectId: string; projectName?: string }>
+  | Readonly<{ projectId?: undefined; projectName: string }>
+
+export type OptionalProjectIdScope = Readonly<{
+  projectId?: string
+  projectName?: string
+}>
+
+export const resolveProjectId = (scope: OptionalProjectIdScope, fallback?: string): string => {
+  if (
+    scope.projectId !== undefined &&
+    scope.projectName !== undefined &&
+    scope.projectId !== scope.projectName
+  ) {
+    throw new Error('Conflicting projectId and legacy projectName values.')
+  }
+
+  const projectId = scope.projectId ?? scope.projectName ?? fallback
+  if (!projectId) throw new Error('A projectId is required.')
+  return projectId
+}


### PR DESCRIPTION
## Problem

Artifact and Notebook routing used the name `projectName` while carrying the immutable Project id. The convention was internally consistent only while every producer knew that undocumented meaning. A caller using the mutable display name, or a partial migration across process boundaries, could split Notebook history and Artifact storage from their Project-scoped provenance.

## Proposed change

- Make `projectId` the canonical Artifact and Notebook application/transport field.
- Keep compatibility adapters for legacy request fields and MCP environment variables.
- Write only `projectId` in new Notebook `run.json` documents and their nested `runs[].artifacts[]` entries.
- Read historical `projectName` only when `projectId` is absent; when both exist, `projectId` is authoritative at the persistence boundary.
- Preserve existing Project-id-based storage paths and the reserved `default-project` bucket.

## Scope and non-goals

- No Prisma schema, database migration, directory move, or user-interface change.
- No Project display-name snapshot is added.
- The broader ACP Session `projectName` migration is intentionally out of scope; Artifact and Notebook adapters translate at their boundaries.
- Existing historical `run.json` files are not bulk rewritten. A later normal save writes the canonical-only representation.
- This intentionally does not preserve rollback compatibility for an older application reading a newly written `run.json`; current code remains able to read historical documents.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Canonical-only Notebook persistence and historical top-level/nested Artifact fallback -> `npm test -- --run src/main/notebook/run-document-data-paths.test.ts src/main/notebook/repository.test.ts src/main/notebook/ipynb-export.test.ts src/main/storage/normalize-legacy-paths.test.ts src/main/storage/provenance-migration-validation.test.ts` -> 5 files passed, 52 tests passed.
- Node and renderer contract compatibility -> `npm run typecheck` -> passed.
- Source style and static rules -> `npm run lint` -> passed with 0 errors and 13 pre-existing unrelated warnings.
- Cross-process Artifact/Notebook/MCP/persistence regression coverage -> `npm test` -> 989 files passed, 15 skipped; 14,409 tests passed, 198 skipped.
- Serialized diff hygiene -> `git diff --check` -> passed.

No UI E2E or platform packaging lane was run locally because this change has no interaction or platform-path behavior. Required CI remains authoritative for platform lanes. The known uncovered compatibility risk is rollback to an older binary after it has received a canonical-only Notebook file.

## Review focus

- Confirm that canonical-only writes plus legacy read fallback match the intended historical-data policy.
- Review trust boundaries where conflicting current and legacy request fields are rejected, versus persisted documents where `projectId` is authoritative.
- Verify that legacy aliases remain limited to compatibility edges and do not become new internal state owners.
