### PR TITLE
feat(notebook): separate approval from execution state

### DIFF
--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -746,7 +746,8 @@ class AcpPermissionBroker {
     private readonly permissionGrantRegistry?: PermissionGrantRegistry,
     private readonly onPermissionSettled?: (
       requestId: string,
-      state: AcpPermissionSettlementState
+      state: AcpPermissionSettlementState,
+      request: AcpPermissionRequest
     ) => void,
     private readonly permissionWaitHooks?: PermissionWaitHooks
   ) {}
@@ -1363,7 +1364,7 @@ class AcpPermissionBroker {
     pending.settled = true
     pending.resolve(response)
     try {
-      this.onPermissionSettled?.(pending.request.requestId, state)
+      this.onPermissionSettled?.(pending.request.requestId, state, pending.request)
     } catch {
       // Notification projection failures must never change the permission decision.
     }
@@ -1378,7 +1379,7 @@ class AcpPermissionBroker {
     pending.settled = true
     pending.reject(error)
     try {
-      this.onPermissionSettled?.(pending.request.requestId, state)
+      this.onPermissionSettled?.(pending.request.requestId, state, pending.request)
     } catch {
       // Notification projection failures must never change the permission decision.
     }

--- a/src/main/acp/permission-context.test.ts
+++ b/src/main/acp/permission-context.test.ts
@@ -12,6 +12,7 @@ import {
   HUMAN_PERMISSION_ACTION_ORIGIN
 } from './permission-context'
 import type { AcpPermissionContextOptions } from './permission-context'
+import { permissionRequestFingerprint } from './permission-broker'
 
 const NOTEBOOK_SERVERS = ['open-science-notebook']
 
@@ -68,23 +69,237 @@ const observe = (
 }
 
 describe('ACP permission context', () => {
-  it('reports allowed, rejected, and session-cancelled permission lifecycles', async () => {
-    const onPermissionSettled = vi.fn()
+  it.each([
+    {
+      name: 'Claude Code',
+      framework: 'claude-code' as const,
+      title: 'mcp__open-science-notebook__notebook_execute',
+      providerToolName: 'mcp__open-science-notebook__notebook_execute',
+      toolKind: 'other' as const,
+      rawInput: { language: 'python', code: 'print(1)' },
+      notificationRawInput: { language: 'python', code: 'print(1)' },
+      meta: { claudeCode: { toolName: 'mcp__open-science-notebook__notebook_execute' } }
+    },
+    {
+      name: 'OpenCode',
+      framework: 'opencode' as const,
+      title: 'open_science_notebook_notebook_execute',
+      providerToolName: 'open_science_notebook_notebook_execute',
+      toolKind: 'other' as const,
+      rawInput: { language: 'python', code: 'print(1)' },
+      notificationRawInput: { language: 'python', code: 'print(1)' },
+      meta: { toolName: 'open_science_notebook_notebook_execute' }
+    },
+    {
+      name: 'Codex Responses / Bridge',
+      framework: 'codex' as const,
+      title: 'mcp.open-science-notebook.notebook_execute',
+      providerToolName: 'notebook_execute',
+      toolKind: 'execute' as const,
+      rawInput: { language: 'python', code: 'print(1)' },
+      notificationRawInput: {
+        server: 'open-science-notebook',
+        tool: 'notebook_execute',
+        arguments: { language: 'python', code: 'print(1)' }
+      },
+      meta: { is_mcp_tool_call: true }
+    }
+  ])(
+    'projects an exact restored Notebook replay through the original toolCallId for $name',
+    async ({
+      framework,
+      title,
+      providerToolName,
+      toolKind,
+      rawInput,
+      notificationRawInput,
+      meta
+    }) => {
+      const context = new AcpPermissionContext({
+        emitPermissionRequest: vi.fn(),
+        routing: permissionRouting({
+          sessionSnapshot: () => ({
+            cwd: '/workspace',
+            frameworkId: framework,
+            permissionProfile: { selectedProfile: 'ask' }
+          })
+        })
+      })
+      const request = {
+        requestId: 'permission-restored',
+        sessionId: 'session-1',
+        toolCallId: 'tool-original',
+        title,
+        providerToolName,
+        isMcp: true,
+        mcpIdentity: 'open-science-notebook/notebook_execute',
+        toolKind,
+        rawInput,
+        options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' as const }]
+      }
+      const fingerprint = permissionRequestFingerprint(request)
+      expect(fingerprint).toMatch(/^[a-f0-9]{64}$/)
+      await context.prepareRestoredDecision(
+        {
+          state: 'pending',
+          request,
+          originatingPromptMessageId: 'prompt-1',
+          fingerprint: fingerprint!,
+          createdAt: 1
+        },
+        request.options[0],
+        'default-project'
+      )
+
+      observe(
+        context,
+        {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'tool-replayed',
+            title,
+            kind: toolKind,
+            status: 'pending',
+            rawInput: notificationRawInput,
+            _meta: meta
+          }
+        },
+        framework
+      )
+
+      expect(context.presentationToolCallId('session-1', 'tool-replayed')).toBe('tool-original')
+      context.clearRestoredDecision('session-1')
+      expect(context.presentationToolCallId('session-1', 'tool-replayed')).toBe('tool-original')
+      context.clearCorrelationsForSession('session-1')
+      expect(context.presentationToolCallId('session-1', 'tool-replayed')).toBe('tool-replayed')
+    }
+  )
+
+  it('keeps a non-matching restored Notebook replay on its provider toolCallId', async () => {
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: vi.fn(),
+      routing: permissionRouting()
+    })
+    const request = {
+      requestId: 'permission-restored',
+      sessionId: 'session-1',
+      toolCallId: 'tool-original',
+      title: 'open_science_notebook_notebook_execute',
+      providerToolName: 'open_science_notebook_notebook_execute',
+      isMcp: true,
+      mcpIdentity: 'open-science-notebook/notebook_execute',
+      toolKind: 'other' as const,
+      rawInput: { language: 'python', code: 'print(1)' },
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' as const }]
+    }
+    await context.prepareRestoredDecision(
+      {
+        state: 'pending',
+        request,
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: permissionRequestFingerprint(request)!,
+        createdAt: 1
+      },
+      request.options[0],
+      'default-project'
+    )
+
+    observe(
+      context,
+      {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tool-replayed',
+          title: request.title,
+          kind: 'other',
+          status: 'pending',
+          rawInput: { language: 'python', code: 'print(2)' },
+          _meta: { toolName: request.providerToolName }
+        }
+      },
+      'opencode'
+    )
+
+    expect(context.presentationToolCallId('session-1', 'tool-replayed')).toBe('tool-replayed')
+  })
+
+  it.each([
+    ['Claude Code', 'claude-code'],
+    ['OpenCode', 'opencode'],
+    ['Codex Responses', 'codex'],
+    ['Codex Bridge', 'codex']
+  ] as const)(
+    'reports allowed, rejected, and session-cancelled permission lifecycles for %s',
+    async (_name, frameworkId) => {
+      const onPermissionSettled = vi.fn()
+      const onToolPermissionSettled = vi.fn()
+      const context = new AcpPermissionContext({
+        emitPermissionRequest: vi.fn(),
+        routing: permissionRouting({
+          sessionSnapshot: () => ({
+            cwd: '/workspace',
+            frameworkId,
+            permissionProfile: { selectedProfile: 'ask' }
+          })
+        }),
+        onPermissionSettled,
+        onToolPermissionSettled
+      })
+
+      const allowed = context.requestPermission(permissionRequest('session-1', 'allow-call'))
+      const allowedRequest = context.getPendingRequests()[0]
+      await context.respondToPermission(
+        { requestId: allowedRequest.requestId, optionId: 'allow-once' },
+        HUMAN_PERMISSION_ACTION_ORIGIN
+      )
+      await allowed
+
+      const rejected = context.requestPermission(permissionRequest('session-1', 'reject-call'))
+      const rejectedRequest = context.getPendingRequests()[0]
+      await context.respondToPermission(
+        { requestId: rejectedRequest.requestId, optionId: 'reject-once' },
+        HUMAN_PERMISSION_ACTION_ORIGIN
+      )
+      await rejected
+
+      const cancelled = context.requestPermission(permissionRequest('session-1', 'cancel-call'))
+      const cancelledRequest = context.getPendingRequests()[0]
+      context.cancelForSession('session-1')
+      await cancelled
+
+      expect(onPermissionSettled).toHaveBeenNthCalledWith(1, allowedRequest.requestId, 'resolved')
+      expect(onPermissionSettled).toHaveBeenNthCalledWith(2, rejectedRequest.requestId, 'rejected')
+      expect(onPermissionSettled).toHaveBeenNthCalledWith(
+        3,
+        cancelledRequest.requestId,
+        'cancelled'
+      )
+      expect(onToolPermissionSettled).toHaveBeenNthCalledWith(1, allowedRequest, 'resolved')
+      expect(onToolPermissionSettled).toHaveBeenNthCalledWith(2, rejectedRequest, 'rejected')
+      expect(onToolPermissionSettled).toHaveBeenNthCalledWith(3, cancelledRequest, 'cancelled')
+    }
+  )
+
+  it('retains the originating prompt for rejected and cancelled permission settlements', async () => {
+    const onToolPermissionSettled = vi.fn()
     const context = new AcpPermissionContext({
       emitPermissionRequest: vi.fn(),
       routing: permissionRouting(),
-      onPermissionSettled
+      onToolPermissionSettled
     })
+    const policyContext = {
+      profile: 'ask' as const,
+      frameworkId: 'opencode' as const,
+      cwd: '/workspace',
+      mcpServerNames: NOTEBOOK_SERVERS
+    }
 
-    const allowed = context.requestPermission(permissionRequest('session-1', 'allow-call'))
-    const allowedRequest = context.getPendingRequests()[0]
-    await context.respondToPermission(
-      { requestId: allowedRequest.requestId, optionId: 'allow-once' },
-      HUMAN_PERMISSION_ACTION_ORIGIN
-    )
-    await allowed
-
-    const rejected = context.requestPermission(permissionRequest('session-1', 'reject-call'))
+    const rejected = context.requestPermission(permissionRequest('session-1', 'reject-call'), {
+      ...policyContext,
+      promptMessageId: 'prompt-rejected'
+    })
     const rejectedRequest = context.getPendingRequests()[0]
     await context.respondToPermission(
       { requestId: rejectedRequest.requestId, optionId: 'reject-once' },
@@ -92,22 +307,49 @@ describe('ACP permission context', () => {
     )
     await rejected
 
-    const cancelled = context.requestPermission(permissionRequest('session-1', 'cancel-call'))
+    const cancelled = context.requestPermission(permissionRequest('session-1', 'cancel-call'), {
+      ...policyContext,
+      promptMessageId: 'prompt-cancelled'
+    })
     const cancelledRequest = context.getPendingRequests()[0]
     context.cancelForSession('session-1')
     await cancelled
 
-    expect(onPermissionSettled).toHaveBeenNthCalledWith(1, allowedRequest.requestId, 'resolved')
-    expect(onPermissionSettled).toHaveBeenNthCalledWith(2, rejectedRequest.requestId, 'rejected')
-    expect(onPermissionSettled).toHaveBeenNthCalledWith(3, cancelledRequest.requestId, 'cancelled')
+    expect(onToolPermissionSettled).toHaveBeenNthCalledWith(1, rejectedRequest, 'rejected', {
+      promptMessageId: 'prompt-rejected'
+    })
+    expect(onToolPermissionSettled).toHaveBeenNthCalledWith(2, cancelledRequest, 'cancelled', {
+      promptMessageId: 'prompt-cancelled'
+    })
+  })
+
+  it('does not create an approval wait for trusted automatic permission', async () => {
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: vi.fn(),
+      routing: permissionRouting()
+    })
+    const params = permissionRequest('session-1', 'auto-call')
+
+    await expect(
+      context.requestPermission(params, {
+        profile: 'full',
+        frameworkId: 'opencode',
+        cwd: '/workspace',
+        mcpServerNames: NOTEBOOK_SERVERS
+      })
+    ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow-once' } })
+
+    expect(context.getPendingRequests()).toEqual([])
   })
 
   it('cancels a late OpenCode primary request when no prompt owns the active Session', async () => {
     const emitPermissionRequest = vi.fn()
     const resolveReviewerPermission = vi.fn()
+    const onToolPermissionSettled = vi.fn()
     const context = new AcpPermissionContext({
       emitPermissionRequest,
-      routing: permissionRouting({ resolveReviewerPermission })
+      routing: permissionRouting({ resolveReviewerPermission }),
+      onToolPermissionSettled
     })
 
     await expect(
@@ -117,6 +359,44 @@ describe('ACP permission context', () => {
     ).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
     expect(resolveReviewerPermission).not.toHaveBeenCalled()
     expect(emitPermissionRequest).not.toHaveBeenCalled()
+    expect(onToolPermissionSettled).not.toHaveBeenCalled()
+  })
+
+  it('reports a late-cancelled OpenCode Notebook permission as permission-closed activity', async () => {
+    const onToolPermissionSettled = vi.fn()
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: vi.fn(),
+      routing: permissionRouting({
+        capturePrompt: () => ({
+          sequence: 7,
+          promptMessageId: 'prompt-1',
+          isCancellationAccepted: () => true
+        }),
+        currentInteractionSequence: () => 7
+      }),
+      onToolPermissionSettled
+    })
+
+    await expect(
+      context.handleProviderRequest(
+        permissionRequest('session-1', 'late-notebook-call', {
+          rawInput: { language: 'python', code: 'print(1)' }
+        })
+      )
+    ).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+
+    expect(onToolPermissionSettled).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        toolCallId: 'late-notebook-call',
+        title: 'open_science_notebook_notebook_execute',
+        isMcp: true,
+        mcpIdentity: 'open-science-notebook/notebook_execute',
+        rawInput: { language: 'python', code: 'print(1)' }
+      }),
+      'cancelled',
+      { promptMessageId: 'prompt-1' }
+    )
   })
 
   it('routes an isolated OpenCode reviewer request without a primary attachment', async () => {
@@ -364,6 +644,120 @@ describe('ACP permission context', () => {
     expect(context.snapshot().sessions['session-1']?.pendingWaiters ?? 0).toBe(0)
   })
 
+  it('keeps the permission preview bounded while authorizing the complete trusted input', async () => {
+    const code = 'x <- 1\n'.repeat(2_000)
+    const onNotebookExecutionAuthorized = vi.fn()
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: (request) => {
+        queueMicrotask(() => {
+          void context.respondToPermission(
+            { requestId: request.requestId, optionId: 'allow-once' },
+            HUMAN_PERMISSION_ACTION_ORIGIN
+          )
+        })
+      },
+      routing: permissionRouting({
+        capturePrompt: () => ({
+          sequence: 1,
+          promptMessageId: 'prompt-1',
+          isCancellationAccepted: () => false
+        }),
+        currentInteractionSequence: () => 1
+      }),
+      onNotebookExecutionAuthorized
+    })
+
+    observe(
+      context,
+      {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'call-1',
+          title: 'open_science_notebook_repl_execute',
+          kind: 'other',
+          status: 'pending',
+          rawInput: { code }
+        }
+      },
+      'opencode'
+    )
+
+    await expect(
+      context.handleProviderRequest(
+        permissionRequest('session-1', 'call-1', {
+          title: 'open_science_notebook_repl_execute',
+          rawInput: {}
+        })
+      )
+    ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow-once' } })
+    expect(onNotebookExecutionAuthorized).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'executeControl',
+        rawInput: {
+          language: 'javascript',
+          code: code.slice(0, 7_500),
+          inputTruncated: true
+        },
+        executionInput: { code }
+      })
+    )
+  })
+
+  it('authorizes a native Claude Notebook call once when executable input arrives late', () => {
+    const onNotebookExecutionAuthorized = vi.fn()
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: vi.fn(),
+      routing: permissionRouting(),
+      onNotebookExecutionAuthorized
+    })
+    const toolCall = {
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call' as const,
+        toolCallId: 'call-1',
+        title: 'mcp__open-science-notebook__notebook_execute',
+        kind: 'execute' as const,
+        status: 'pending' as const,
+        rawInput: {}
+      }
+    }
+    const permissionContext = {
+      sessionId: 'session-1',
+      framework: 'claude-code' as const,
+      mcpServerNames: NOTEBOOK_SERVERS,
+      nativeFullAccess: true,
+      promptMessageId: 'prompt-1'
+    }
+
+    context.observeToolCall(toolCall, permissionContext)
+    for (let index = 0; index < 2; index += 1) {
+      context.observeToolCall(
+        {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'call-1',
+            status: 'in_progress',
+            rawInput: { language: 'python', code: 'print(1)' }
+          }
+        },
+        permissionContext
+      )
+    }
+
+    expect(onNotebookExecutionAuthorized).toHaveBeenCalledOnce()
+    expect(onNotebookExecutionAuthorized).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        toolCallId: 'call-1',
+        promptMessageId: 'prompt-1',
+        method: 'execute',
+        executionInput: { language: 'python', code: 'print(1)' }
+      })
+    )
+  })
+
   it('keeps a human-only decision parked when an agent-origin action tries to resolve it', async () => {
     const emitted: Array<{ requestId: string }> = []
     const context = new AcpPermissionContext({
@@ -514,6 +908,40 @@ describe('ACP permission context', () => {
     context.dispose()
 
     await expect(correlation).resolves.toBeUndefined()
+    expect(context.snapshot()).toEqual({ pendingRequests: [], sessions: {} })
+  })
+
+  it('disposes complete execution input after its permission preview is consumed', async () => {
+    const context = new AcpPermissionContext({
+      emitPermissionRequest: vi.fn(),
+      routing: permissionRouting()
+    })
+    observe(
+      context,
+      {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'call-1',
+          title: 'open_science_notebook_notebook_execute',
+          kind: 'other',
+          status: 'pending',
+          rawInput: { language: 'python', code: 'print(1)' }
+        }
+      },
+      'opencode'
+    )
+
+    await context.restoreToolCall(permissionRequest('session-1', 'call-1'), {
+      sessionId: 'session-1',
+      framework: 'opencode',
+      mcpServerNames: NOTEBOOK_SERVERS,
+      isCancelled: () => false
+    })
+    expect(context.snapshot().sessions).toHaveProperty('session-1')
+
+    context.dispose()
+
     expect(context.snapshot()).toEqual({ pendingRequests: [], sessions: {} })
   })
 })

--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -3,11 +3,13 @@ import type {
   RequestPermissionResponse,
   SessionNotification
 } from '@agentclientprotocol/sdk'
+import { randomUUID } from 'node:crypto'
 
 import type {
   AcpPermissionGrant,
   AcpPermissionRequest,
   AcpPermissionResponse,
+  AcpRuntimeEvent,
   AcpPermissionSettlementState
 } from '../../shared/acp'
 import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
@@ -16,17 +18,20 @@ import type { AgentFrameworkId } from '../../shared/settings'
 import { getAgentFramework, type AgentFramework } from '../agent-framework'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import type { SessionPermissionRuntimeContext } from '../../shared/session-persistence'
+import type { NotebookExecutionRpcMethod } from '../../shared/notebook'
 import { resolveCanonicalMcpToolIdentity } from '../agent-framework/app-mcp-names'
 import { createLogger } from '../logger'
 import {
   AcpPermissionBroker,
   ConversationPermissionGrantStore,
+  permissionRequestFingerprint,
   resolveNotebookPermissionContext,
   type PermissionWaitHooks
 } from './permission-broker'
 import type { PermissionPolicyContext } from './permission-policy'
 import {
   isMcpToolName,
+  trustedMcpToolIdentity,
   withTrustedMcpToolIdentity,
   withTrustedNativeToolIdentity
 } from './permission-policy'
@@ -40,6 +45,8 @@ type PermissionToolContext = {
   sessionId: string
   framework: PermissionFramework
   mcpServerNames: readonly string[]
+  nativeFullAccess?: boolean
+  promptMessageId?: string
 }
 
 type PermissionRestoreContext = PermissionToolContext & {
@@ -88,7 +95,13 @@ type AcpPermissionContextOptions = {
           cwd?: string
           frameworkId?: AgentFrameworkId
           permissionProfile?: Readonly<
-            Pick<SessionPermissionProfileState, 'selectedProfile' | 'autoReviewStrategy'>
+            Pick<SessionPermissionProfileState, 'selectedProfile' | 'autoReviewStrategy'> &
+              Partial<
+                Pick<
+                  SessionPermissionProfileState,
+                  'effectiveProfile' | 'currentModeId' | 'availableModeIds'
+                >
+              >
           >
         }
       | undefined
@@ -125,6 +138,21 @@ type AcpPermissionContextOptions = {
     waitMs: number
   }) => void
   onPermissionSettled?: (requestId: string, state: AcpPermissionSettlementState) => void
+  onToolPermissionSettled?: (
+    request: AcpPermissionRequest,
+    state: AcpPermissionSettlementState,
+    context?: Readonly<{ promptMessageId?: string }>
+  ) => void
+  onNotebookExecutionAuthorized?: (authorization: {
+    sessionId: string
+    toolCallId: string
+    promptMessageId: string
+    title: string
+    providerToolName?: string
+    rawInput?: unknown
+    executionInput?: unknown
+    method: NotebookExecutionRpcMethod
+  }) => void
   permissionWaitHooks?: PermissionWaitHooks
 }
 
@@ -147,6 +175,11 @@ type AcpPermissionContextSnapshot = {
   sessions: Record<string, PermissionContextSessionSnapshot>
 }
 
+type RestoredNotebookPresentationCandidate = Readonly<{
+  originalToolCallId: string
+  fingerprint: string
+}>
+
 const AGENT_PERMISSION_ACTION_ORIGIN: AuthorizedPermissionActionOrigin = { kind: 'agent' }
 const HUMAN_PERMISSION_ACTION_ORIGIN: AuthorizedPermissionActionOrigin = { kind: 'human' }
 const SYSTEM_PERMISSION_ACTION_ORIGIN: AuthorizedPermissionActionOrigin = { kind: 'system' }
@@ -156,6 +189,48 @@ const MAX_CLAUDE_CODE_MCP_TOOL_INPUTS_PER_SESSION = 32
 const MAX_OPENCODE_MCP_TOOL_INPUTS_PER_SESSION = 32
 const MAX_PERMISSION_CODE_PREVIEW_CHARS = 7_500
 const OPENCODE_PERMISSION_CONTEXT_WAIT_MS = 1_000
+
+const notebookExecutionMethod = (
+  identity: string | undefined
+): NotebookExecutionRpcMethod | undefined => {
+  const separator = identity?.indexOf('/') ?? -1
+  if (!identity || separator <= 0) return undefined
+  const server = identity.slice(0, separator).replaceAll('_', '-').toLowerCase()
+  if (server !== 'open-science-notebook') return undefined
+
+  const tool = identity.slice(separator + 1).toLowerCase()
+  if (tool === 'notebook_execute') return 'execute'
+  if (tool === 'repl_execute') return 'executeControl'
+  if (tool === 'bash_execute') return 'executeShell'
+  return undefined
+}
+
+const usesNativeFullAccess = (
+  framework: AgentFramework,
+  profile: NonNullable<
+    ReturnType<AcpPermissionContextOptions['routing']['sessionSnapshot']>
+  >['permissionProfile']
+): boolean => {
+  if (
+    profile?.selectedProfile !== 'full' ||
+    profile.effectiveProfile !== 'full' ||
+    !profile.currentModeId ||
+    !profile.availableModeIds
+  ) {
+    return false
+  }
+
+  try {
+    return (
+      framework.mapPermissionProfile('full', {
+        currentModeId: profile.currentModeId,
+        availableModes: profile.availableModeIds.map((id) => ({ id, name: id }))
+      }).modeId === profile.currentModeId
+    )
+  } catch {
+    return false
+  }
+}
 
 const errorMessage = (error: unknown): string => {
   try {
@@ -197,7 +272,7 @@ const boundedNotebookPermissionInput = (
     (field) => typeof input[field] === 'string'
   )
 
-  for (const field of ['kernelKind', 'kernel', 'language']) {
+  for (const field of ['kernelKind', 'kernel', 'language', 'cellId']) {
     if (typeof input[field] === 'string') bounded[field] = input[field]
   }
   if (
@@ -220,6 +295,18 @@ const boundedNotebookPermissionInput = (
   }
 
   return bounded
+}
+
+const trustedNotebookExecutionInput = (
+  title: string,
+  rawInput: unknown,
+  mcpServerNames: readonly string[]
+): Record<string, unknown> | undefined => {
+  if (!resolveNotebookPermissionContext(title, rawInput, mcpServerNames)) return undefined
+
+  const outer = isRecord(rawInput) ? rawInput : undefined
+  const input = isRecord(outer?.arguments) ? outer.arguments : outer
+  return isRecord(input) ? input : undefined
 }
 
 const isCodexMcpApproval = (params: RequestPermissionRequest): boolean => {
@@ -256,7 +343,6 @@ const codexMcpToolIdentity = (
   const permissionInput = isRecord(event.rawInput)
     ? event.rawInput.arguments
     : boundedNotebookPermissionInput(title, rawInput, mcpServerNames)
-
   return {
     title,
     providerToolName: tool,
@@ -273,15 +359,26 @@ const countNested = <T>(contexts: Map<string, Map<string, T>>, sessionId: string
 class AcpPermissionContext {
   private readonly broker: AcpPermissionBroker
   private readonly humanOnlyRequestIds = new Set<string>()
+  private readonly permissionPromptMessageIds = new Map<string, Map<string, string>>()
   private readonly codexMcpToolIdentities = new Map<string, Map<string, CodexMcpToolIdentity>>()
   private readonly claudeCodeMcpToolInputs = new Map<string, Map<string, ClaudeCodeMcpToolInput>>()
   private readonly opencodeMcpToolInputs = new Map<string, Map<string, OpenCodeMcpToolInput>>()
+  private readonly notebookExecutionInputs = new Map<string, Map<string, Record<string, unknown>>>()
+  private readonly nativeNotebookExecutionAuthorizations = new Map<string, Set<string>>()
   private readonly opencodeNativeSkillToolCalls = new Map<string, Map<string, true>>()
   private readonly opencodeMcpToolInputWaiters = new Map<
     string,
     Map<string, Set<OpenCodePermissionContextWaiter>>
   >()
   private readonly closedOpenCodeToolCalls = new Map<string, Set<string>>()
+  // A restored approval makes the provider retry the parked call with a fresh protocol id. Keep
+  // execution bound to that real id, but project the exact fingerprint match through the original
+  // durable activity id so restart does not duplicate the displayed Notebook code.
+  private readonly restoredNotebookPresentationCandidates = new Map<
+    string,
+    RestoredNotebookPresentationCandidate
+  >()
+  private readonly restoredNotebookPresentationAliases = new Map<string, Map<string, string>>()
   private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
 
@@ -296,7 +393,17 @@ class AcpPermissionContext {
       },
       options.conversationGrants,
       options.permissionGrantRegistry,
-      options.onPermissionSettled,
+      (requestId, state, request) => {
+        options.onPermissionSettled?.(requestId, state)
+        const promptMessageId = this.permissionPromptMessageIds
+          .get(request.sessionId)
+          ?.get(request.toolCallId)
+        options.onToolPermissionSettled?.(
+          request,
+          state,
+          ...(promptMessageId ? [{ promptMessageId }] : [])
+        )
+      },
       options.permissionWaitHooks
     )
     this.setTimer = options.setTimer ?? setTimeout
@@ -333,8 +440,16 @@ class AcpPermissionContext {
       !normalizedParams ||
       this.isPermissionRequestCancelled(params.toolCall.toolCallId, restoreContext)
     ) {
+      this.deleteNotebookExecutionInput(appSessionId, params.toolCall.toolCallId)
+      this.reportLateCancelledNotebookPermission(
+        normalizedParams ?? params,
+        appSessionId,
+        mcpServerNames,
+        promptInteraction?.promptMessageId
+      )
       return { outcome: { outcome: 'cancelled' } }
     }
+    const executionMethod = notebookExecutionMethod(trustedMcpToolIdentity(normalizedParams))
 
     // Keep the audit record useful without logging titles, URLs, raw input, or provider payloads.
     const toolName = extractProviderToolName(normalizedParams.toolCall)
@@ -367,25 +482,59 @@ class AcpPermissionContext {
       const permissionFramework =
         frameworkId === currentFramework.id ? currentFramework : getAgentFramework(frameworkId)
 
-      return await this.requestPermission(
+      const routedParams =
         appSessionId === normalizedParams.sessionId
           ? normalizedParams
-          : { ...normalizedParams, sessionId: appSessionId },
-        {
-          profile: profileState?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE,
-          frameworkId,
-          shellDialect: permissionFramework.commandShellDialect,
-          autoReviewStrategy: profileState?.autoReviewStrategy,
-          cwd: aggregateSnapshot?.cwd,
-          mcpServerNames,
-          projectId:
-            this.options.permissionGrantContext?.projectId ??
-            routing.resolveProjectId(appSessionId),
-          permissionGrantSessionId: this.options.permissionGrantContext?.sessionId,
-          promptMessageId: promptInteraction?.promptMessageId
+          : { ...normalizedParams, sessionId: appSessionId }
+      const response = await this.requestPermission(routedParams, {
+        profile: profileState?.selectedProfile ?? DEFAULT_PERMISSION_PROFILE,
+        frameworkId,
+        shellDialect: permissionFramework.commandShellDialect,
+        autoReviewStrategy: profileState?.autoReviewStrategy,
+        cwd: aggregateSnapshot?.cwd,
+        mcpServerNames,
+        projectId:
+          this.options.permissionGrantContext?.projectId ?? routing.resolveProjectId(appSessionId),
+        permissionGrantSessionId: this.options.permissionGrantContext?.sessionId,
+        promptMessageId: promptInteraction?.promptMessageId
+      })
+      const selectedOptionId =
+        response.outcome.outcome === 'selected' ? response.outcome.optionId : undefined
+      const selectedOption = selectedOptionId
+        ? routedParams.options.find((option) => option.optionId === selectedOptionId)
+        : undefined
+      if (
+        selectedOption?.kind.toLowerCase().startsWith('allow_') &&
+        promptInteraction?.promptMessageId
+      ) {
+        if (executionMethod) {
+          const cachedExecutionInput = this.takeNotebookExecutionInput(
+            appSessionId,
+            routedParams.toolCall.toolCallId
+          )
+          const requestExecutionInput = isRecord(routedParams.toolCall.rawInput)
+            ? routedParams.toolCall.rawInput
+            : undefined
+          const executionInput =
+            cachedExecutionInput ??
+            (requestExecutionInput?.inputTruncated === true ? undefined : requestExecutionInput)
+          this.options.onNotebookExecutionAuthorized?.({
+            sessionId: appSessionId,
+            toolCallId: routedParams.toolCall.toolCallId,
+            promptMessageId: promptInteraction.promptMessageId,
+            title: routedParams.toolCall.title ?? routedParams.toolCall.toolCallId,
+            providerToolName: extractProviderToolName(routedParams.toolCall),
+            rawInput: routedParams.toolCall.rawInput,
+            executionInput,
+            method: executionMethod
+          })
         }
-      )
+      } else if (executionMethod) {
+        this.deleteNotebookExecutionInput(appSessionId, routedParams.toolCall.toolCallId)
+      }
+      return response
     } catch (error) {
+      this.deleteNotebookExecutionInput(appSessionId, params.toolCall.toolCallId)
       log.error('permission request failed', {
         message: errorMessage(error),
         tool:
@@ -405,12 +554,26 @@ class AcpPermissionContext {
 
     const sessionId = routing.resolveAppSessionId(notification.sessionId)
     const reviewerContext = routing.reviewerContextFor(notification.sessionId)
+    const snapshot = routing.sessionSnapshot(sessionId)
+    const frameworkId = reviewerContext?.frameworkId ?? snapshot?.frameworkId
+    const currentFramework = routing.currentFramework()
+    const framework =
+      frameworkId === currentFramework.id
+        ? currentFramework
+        : frameworkId
+          ? getAgentFramework(frameworkId)
+          : undefined
+    const prompt = reviewerContext ? undefined : routing.capturePrompt(sessionId)
     const routed = structuredClone(notification)
     routed.sessionId = sessionId
     this.observeToolCall(routed, {
       sessionId,
-      framework: reviewerContext?.frameworkId ?? routing.sessionSnapshot(sessionId)?.frameworkId,
-      mcpServerNames: reviewerContext?.mcpServerNames ?? routing.mcpServerNamesFor(sessionId)
+      framework: frameworkId,
+      mcpServerNames: reviewerContext?.mcpServerNames ?? routing.mcpServerNamesFor(sessionId),
+      nativeFullAccess: framework
+        ? usesNativeFullAccess(framework, snapshot?.permissionProfile)
+        : false,
+      promptMessageId: prompt?.promptMessageId
     })
   }
 
@@ -427,11 +590,53 @@ class AcpPermissionContext {
     option: AcpPermissionRequest['options'][number] | undefined,
     projectId: string
   ): Promise<void> {
-    return this.broker.prepareRestoredDecision(permission, option, projectId)
+    return this.broker.prepareRestoredDecision(permission, option, projectId).then(() => {
+      const allowsReplay = option?.kind.toLowerCase().startsWith('allow_') === true
+      if (
+        !allowsReplay ||
+        !notebookExecutionMethod(permission.request.mcpIdentity) ||
+        permission.fingerprint !== permissionRequestFingerprint(permission.request)
+      ) {
+        this.restoredNotebookPresentationCandidates.delete(permission.request.sessionId)
+        return
+      }
+      this.restoredNotebookPresentationCandidates.set(permission.request.sessionId, {
+        originalToolCallId: permission.request.toolCallId,
+        fingerprint: permission.fingerprint
+      })
+    })
   }
 
   clearRestoredDecision(sessionId: string): void {
     this.broker.clearRestoredDecision(sessionId)
+    this.restoredNotebookPresentationCandidates.delete(sessionId)
+  }
+
+  presentationToolCallId(sessionId: string, providerToolCallId: string): string {
+    return (
+      this.restoredNotebookPresentationAliases.get(sessionId)?.get(providerToolCallId) ??
+      providerToolCallId
+    )
+  }
+
+  presentationToolCallIdForUpdate(
+    notification: SessionNotification,
+    context: PermissionToolContext
+  ): string | undefined {
+    const routed =
+      context.sessionId === notification.sessionId
+        ? notification
+        : { ...notification, sessionId: context.sessionId }
+    const event = toAcpRuntimeEvent(routed, 'permission-tool-presentation')
+    if (event.kind !== 'tool' || !event.toolCallId) return undefined
+    if (notification.update.sessionUpdate === 'tool_call') {
+      this.matchRestoredNotebookPresentationUpdate(
+        routed,
+        event as AcpRuntimeEvent & Readonly<{ kind: 'tool'; toolCallId: string }>,
+        context
+      )
+    }
+    return this.presentationToolCallId(context.sessionId, event.toolCallId)
   }
 
   async applyPermissionProfile(
@@ -486,7 +691,21 @@ class AcpPermissionContext {
     params: RequestPermissionRequest,
     policyContext?: PermissionPolicyContext
   ): Promise<RequestPermissionResponse> {
-    return this.broker.requestPermission(params, policyContext)
+    const promptMessageId = policyContext?.promptMessageId
+    if (promptMessageId) {
+      const prompts = this.permissionPromptMessageIds.get(params.sessionId) ?? new Map()
+      prompts.set(params.toolCall.toolCallId, promptMessageId)
+      this.permissionPromptMessageIds.set(params.sessionId, prompts)
+    }
+
+    try {
+      return this.broker.requestPermission(params, policyContext).finally(() => {
+        this.deletePermissionPromptMessageId(params.sessionId, params.toolCall.toolCallId)
+      })
+    } catch (error) {
+      this.deletePermissionPromptMessageId(params.sessionId, params.toolCall.toolCallId)
+      throw error
+    }
   }
 
   requestAppApproval(input: {
@@ -526,6 +745,14 @@ class AcpPermissionContext {
       return
     }
 
+    if (notification.update.sessionUpdate === 'tool_call') {
+      this.matchRestoredNotebookPresentationUpdate(
+        routed,
+        event as AcpRuntimeEvent & Readonly<{ kind: 'tool'; toolCallId: string }>,
+        context
+      )
+    }
+
     if (framework === 'codex') {
       if (!isCodexMcpToolCall(notification.update)) return
       const identity = codexMcpToolIdentity(event, notification.update.rawInput, mcpServerNames)
@@ -539,19 +766,41 @@ class AcpPermissionContext {
         MAX_CODEX_MCP_TOOL_IDENTITIES_PER_SESSION
       )
       this.codexMcpToolIdentities.set(sessionId, identities)
+      this.rememberNotebookExecutionInput(
+        sessionId,
+        event.toolCallId,
+        trustedNotebookExecutionInput(identity.title, notification.update.rawInput, mcpServerNames)
+      )
+      if (notification.update.sessionUpdate === 'tool_call') {
+        this.authorizeNativeNotebookExecution(event.toolCallId, identity, context)
+      }
       return
     }
 
     if (framework === 'claude-code') {
-      const title = event.title
+      const inputs = this.claudeCodeMcpToolInputs.get(sessionId) ?? new Map()
+      const previous = inputs.get(event.toolCallId)
+      const title = event.title ?? previous?.title
       if (!title || !isMcpToolName(title, mcpServerNames)) return
-      const providerToolName = event.providerToolName ?? title
+      const canReusePreviousIdentity = event.title == null || event.title === previous?.title
+      const providerToolName =
+        event.providerToolName ??
+        (canReusePreviousIdentity ? previous?.providerToolName : undefined) ??
+        title
       const mcpIdentity =
         resolveCanonicalMcpToolIdentity(providerToolName, mcpServerNames) ??
-        resolveCanonicalMcpToolIdentity(title, mcpServerNames)
+        resolveCanonicalMcpToolIdentity(title, mcpServerNames) ??
+        (canReusePreviousIdentity ? previous?.mcpIdentity : undefined)
       if (!mcpIdentity) return
 
-      const inputs = this.claudeCodeMcpToolInputs.get(sessionId) ?? new Map()
+      const executionInput = trustedNotebookExecutionInput(
+        title,
+        notification.update.sessionUpdate === 'tool_call' ||
+          notification.update.sessionUpdate === 'tool_call_update'
+          ? notification.update.rawInput
+          : undefined,
+        mcpServerNames
+      )
       this.setBounded(
         inputs,
         event.toolCallId,
@@ -564,6 +813,17 @@ class AcpPermissionContext {
         MAX_CLAUDE_CODE_MCP_TOOL_INPUTS_PER_SESSION
       )
       this.claudeCodeMcpToolInputs.set(sessionId, inputs)
+      this.rememberNotebookExecutionInput(sessionId, event.toolCallId, executionInput)
+      if (
+        notification.update.sessionUpdate === 'tool_call' ||
+        notification.update.sessionUpdate === 'tool_call_update'
+      ) {
+        this.authorizeNativeNotebookExecution(
+          event.toolCallId,
+          inputs.get(event.toolCallId),
+          context
+        )
+      }
       return
     }
 
@@ -602,6 +862,7 @@ class AcpPermissionContext {
 
     const rawInput =
       boundedNotebookPermissionInput(title, originalRawInput, mcpServerNames) ?? event.rawInput
+    const executionInput = trustedNotebookExecutionInput(title, originalRawInput, mcpServerNames)
     const hasRawInput = isRecord(rawInput) && Object.keys(rawInput).length > 0
     const next: OpenCodeMcpToolInput = {
       title,
@@ -616,6 +877,7 @@ class AcpPermissionContext {
 
     this.setBounded(inputs, event.toolCallId, next, MAX_OPENCODE_MCP_TOOL_INPUTS_PER_SESSION)
     this.opencodeMcpToolInputs.set(sessionId, inputs)
+    this.rememberNotebookExecutionInput(sessionId, event.toolCallId, executionInput)
     if (hasRawInput) this.resolveOpenCodeWaiters(sessionId, event.toolCallId)
   }
 
@@ -739,8 +1001,13 @@ class AcpPermissionContext {
     this.codexMcpToolIdentities.delete(sessionId)
     this.claudeCodeMcpToolInputs.delete(sessionId)
     this.opencodeMcpToolInputs.delete(sessionId)
+    this.notebookExecutionInputs.delete(sessionId)
+    this.nativeNotebookExecutionAuthorizations.delete(sessionId)
     this.opencodeNativeSkillToolCalls.delete(sessionId)
     this.closedOpenCodeToolCalls.delete(sessionId)
+    this.restoredNotebookPresentationCandidates.delete(sessionId)
+    this.restoredNotebookPresentationAliases.delete(sessionId)
+    this.permissionPromptMessageIds.delete(sessionId)
     const sessionWaiters = this.opencodeMcpToolInputWaiters.get(sessionId)
     if (!sessionWaiters) return
 
@@ -756,9 +1023,14 @@ class AcpPermissionContext {
       ...this.codexMcpToolIdentities.keys(),
       ...this.claudeCodeMcpToolInputs.keys(),
       ...this.opencodeMcpToolInputs.keys(),
+      ...this.notebookExecutionInputs.keys(),
+      ...this.nativeNotebookExecutionAuthorizations.keys(),
       ...this.opencodeNativeSkillToolCalls.keys(),
       ...this.closedOpenCodeToolCalls.keys(),
-      ...this.opencodeMcpToolInputWaiters.keys()
+      ...this.opencodeMcpToolInputWaiters.keys(),
+      ...this.restoredNotebookPresentationCandidates.keys(),
+      ...this.restoredNotebookPresentationAliases.keys(),
+      ...this.permissionPromptMessageIds.keys()
     ])
     for (const sessionId of sessionIds) this.clearCorrelationsForSession(sessionId)
   }
@@ -774,6 +1046,7 @@ class AcpPermissionContext {
       ...this.codexMcpToolIdentities.keys(),
       ...this.claudeCodeMcpToolInputs.keys(),
       ...this.opencodeMcpToolInputs.keys(),
+      ...this.notebookExecutionInputs.keys(),
       ...this.opencodeNativeSkillToolCalls.keys(),
       ...this.closedOpenCodeToolCalls.keys(),
       ...this.opencodeMcpToolInputWaiters.keys()
@@ -961,6 +1234,186 @@ class AcpPermissionContext {
     contexts.set(toolCallId, context)
   }
 
+  private authorizeNativeNotebookExecution(
+    toolCallId: string,
+    identity: CodexMcpToolIdentity | ClaudeCodeMcpToolInput | undefined,
+    context: PermissionToolContext
+  ): void {
+    if (
+      !context.nativeFullAccess ||
+      !context.promptMessageId ||
+      !identity ||
+      !this.options.onNotebookExecutionAuthorized
+    ) {
+      return
+    }
+    const method = notebookExecutionMethod(identity.mcpIdentity)
+    if (!method) return
+    const executionInput = this.takeNotebookExecutionInput(context.sessionId, toolCallId)
+    const executable = executionInput?.[method === 'executeShell' ? 'command' : 'code']
+    if (typeof executable !== 'string') return
+
+    const authorized =
+      this.nativeNotebookExecutionAuthorizations.get(context.sessionId) ?? new Set()
+    if (authorized.has(toolCallId)) return
+    // Mark before publishing because the authorization callback synchronously emits a tool update
+    // that re-enters this observer with the same provider call identity.
+    this.addBounded(authorized, toolCallId, MAX_CLAUDE_CODE_MCP_TOOL_INPUTS_PER_SESSION)
+    this.nativeNotebookExecutionAuthorizations.set(context.sessionId, authorized)
+
+    this.options.onNotebookExecutionAuthorized({
+      sessionId: context.sessionId,
+      toolCallId,
+      promptMessageId: context.promptMessageId,
+      title: identity.title,
+      providerToolName: identity.providerToolName,
+      rawInput: identity.rawInput,
+      executionInput,
+      method
+    })
+  }
+
+  private matchRestoredNotebookPresentation(
+    sessionId: string,
+    providerToolCallId: string,
+    toolKind: AcpPermissionRequest['toolKind'],
+    identity: CodexMcpToolIdentity | ClaudeCodeMcpToolInput | OpenCodeMcpToolInput | undefined
+  ): void {
+    const candidate = this.restoredNotebookPresentationCandidates.get(sessionId)
+    if (!candidate || !identity || !notebookExecutionMethod(identity.mcpIdentity)) return
+    const fingerprint = permissionRequestFingerprint({
+      requestId: 'restored-notebook-presentation',
+      sessionId,
+      toolCallId: providerToolCallId,
+      title: identity.title,
+      providerToolName: identity.providerToolName,
+      isMcp: true,
+      mcpIdentity: identity.mcpIdentity,
+      toolKind,
+      rawInput: identity.rawInput,
+      options: []
+    })
+    if (fingerprint !== candidate.fingerprint) return
+
+    const aliases = this.restoredNotebookPresentationAliases.get(sessionId) ?? new Map()
+    aliases.set(providerToolCallId, candidate.originalToolCallId)
+    this.restoredNotebookPresentationAliases.set(sessionId, aliases)
+    this.restoredNotebookPresentationCandidates.delete(sessionId)
+  }
+
+  private matchRestoredNotebookPresentationUpdate(
+    notification: SessionNotification,
+    event: AcpRuntimeEvent & Readonly<{ kind: 'tool'; toolCallId: string }>,
+    context: PermissionToolContext
+  ): void {
+    const { sessionId, framework, mcpServerNames } = context
+    if (!this.restoredNotebookPresentationCandidates.has(sessionId)) return
+
+    if (framework === 'codex') {
+      if (!isCodexMcpToolCall(notification.update)) return
+      const identity = codexMcpToolIdentity(event, notification.update.rawInput, mcpServerNames)
+      if (identity) {
+        this.matchRestoredNotebookPresentation(
+          sessionId,
+          event.toolCallId,
+          event.toolKind,
+          identity
+        )
+      }
+      return
+    }
+
+    const title = event.title
+    if (!title || !isMcpToolName(title, mcpServerNames)) return
+    const providerToolName = event.providerToolName ?? title
+    const mcpIdentity =
+      resolveCanonicalMcpToolIdentity(providerToolName, mcpServerNames) ??
+      resolveCanonicalMcpToolIdentity(title, mcpServerNames)
+    if (!mcpIdentity) return
+    const updateRawInput =
+      notification.update.sessionUpdate === 'tool_call' ? notification.update.rawInput : undefined
+    const rawInput =
+      framework === 'opencode'
+        ? (boundedNotebookPermissionInput(title, updateRawInput, mcpServerNames) ?? event.rawInput)
+        : event.rawInput
+    this.matchRestoredNotebookPresentation(sessionId, event.toolCallId, event.toolKind, {
+      title,
+      providerToolName,
+      mcpIdentity,
+      ...(isRecord(rawInput) ? { rawInput } : {})
+    })
+  }
+
+  private rememberNotebookExecutionInput(
+    sessionId: string,
+    toolCallId: string,
+    input: Record<string, unknown> | undefined
+  ): void {
+    if (!input) return
+    const inputs = this.notebookExecutionInputs.get(sessionId) ?? new Map()
+    this.setBounded(inputs, toolCallId, input, MAX_OPENCODE_MCP_TOOL_INPUTS_PER_SESSION)
+    this.notebookExecutionInputs.set(sessionId, inputs)
+  }
+
+  private deletePermissionPromptMessageId(sessionId: string, toolCallId: string): void {
+    const prompts = this.permissionPromptMessageIds.get(sessionId)
+    prompts?.delete(toolCallId)
+    if (prompts?.size === 0) this.permissionPromptMessageIds.delete(sessionId)
+  }
+
+  private takeNotebookExecutionInput(
+    sessionId: string,
+    toolCallId: string
+  ): Record<string, unknown> | undefined {
+    const input = this.notebookExecutionInputs.get(sessionId)?.get(toolCallId)
+    this.deleteNotebookExecutionInput(sessionId, toolCallId)
+    return input
+  }
+
+  private deleteNotebookExecutionInput(sessionId: string, toolCallId: string): void {
+    const inputs = this.notebookExecutionInputs.get(sessionId)
+    inputs?.delete(toolCallId)
+    if (inputs?.size === 0) this.notebookExecutionInputs.delete(sessionId)
+  }
+
+  private reportLateCancelledNotebookPermission(
+    params: RequestPermissionRequest,
+    sessionId: string,
+    mcpServerNames: readonly string[],
+    promptMessageId: string | undefined
+  ): void {
+    const providerToolName = extractProviderToolName(params.toolCall)
+    const mcpIdentity =
+      trustedMcpToolIdentity(params) ??
+      resolveCanonicalMcpToolIdentity(providerToolName ?? params.toolCall.title, mcpServerNames)
+    const rawInput = boundedNotebookPermissionInput(
+      providerToolName ?? params.toolCall.title ?? '',
+      params.toolCall.rawInput,
+      mcpServerNames
+    )
+    if (!notebookExecutionMethod(mcpIdentity) && rawInput === undefined) return
+
+    const request: AcpPermissionRequest = {
+      requestId: randomUUID(),
+      sessionId,
+      toolCallId: params.toolCall.toolCallId,
+      title: params.toolCall.title ?? params.toolCall.toolCallId,
+      status: params.toolCall.status ?? undefined,
+      providerToolName,
+      isMcp: true,
+      ...(mcpIdentity ? { mcpIdentity } : {}),
+      toolKind: params.toolCall.kind ?? undefined,
+      toolLocations: params.toolCall.locations ?? undefined,
+      rawInput,
+      options: params.options.map(({ optionId, name, kind }) => ({ optionId, name, kind }))
+    }
+    try {
+      this.options.onToolPermissionSettled?.(request, 'cancelled', { promptMessageId })
+    } catch {
+      // Notification projection failures must never change the provider-facing cancellation.
+    }
+  }
+
   private addBounded(contexts: Set<string>, toolCallId: string, limit: number): void {
     if (!contexts.has(toolCallId) && contexts.size >= limit) {
       const oldestToolCallId = contexts.values().next().value
@@ -985,6 +1438,12 @@ class AcpPermissionContext {
     const opencodeInputs = this.opencodeMcpToolInputs.get(sessionId)
     opencodeInputs?.delete(toolCallId)
     if (opencodeInputs?.size === 0) this.opencodeMcpToolInputs.delete(sessionId)
+    this.deleteNotebookExecutionInput(sessionId, toolCallId)
+    const nativeAuthorizations = this.nativeNotebookExecutionAuthorizations.get(sessionId)
+    nativeAuthorizations?.delete(toolCallId)
+    if (nativeAuthorizations?.size === 0) {
+      this.nativeNotebookExecutionAuthorizations.delete(sessionId)
+    }
     const opencodeNativeSkills = this.opencodeNativeSkillToolCalls.get(sessionId)
     opencodeNativeSkills?.delete(toolCallId)
     if (opencodeNativeSkills?.size === 0) this.opencodeNativeSkillToolCalls.delete(sessionId)
@@ -1007,6 +1466,12 @@ class AcpPermissionContext {
       const calls = sessions.get(sessionId)
       calls?.delete(toolCallId)
       if (calls?.size === 0) sessions.delete(sessionId)
+    }
+    this.deleteNotebookExecutionInput(sessionId, toolCallId)
+    const nativeAuthorizations = this.nativeNotebookExecutionAuthorizations.get(sessionId)
+    nativeAuthorizations?.delete(toolCallId)
+    if (nativeAuthorizations?.size === 0) {
+      this.nativeNotebookExecutionAuthorizations.delete(sessionId)
     }
     this.resolveOpenCodeWaiters(sessionId, toolCallId, 'cancelled')
   }

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -273,6 +273,8 @@ const createAcpRuntime = ({
                   notebookRpcServer.releaseSessionCapabilities(sessionId),
                 registerSessionSpecialist: (sessionId, specialistId) =>
                   notebookRpcServer.registerSessionSpecialist(sessionId, specialistId),
+                authorizeExecution: (authorization) =>
+                  notebookRpcServer.authorizeExecution(authorization),
                 setArtifactProvenanceContext: (sessionId, context) =>
                   notebookRpcServer.setArtifactProvenanceContext(sessionId, context),
                 registerTurnInputs: (request) =>

--- a/src/main/acp/runtime-session-composition.ts
+++ b/src/main/acp/runtime-session-composition.ts
@@ -188,6 +188,46 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     setTimer: base.setTimer,
     clearTimer: base.clearTimer,
     onPermissionSettled: callbacks.onPermissionSettled,
+    onToolPermissionSettled: (request, state, context) => {
+      if (state === 'resolved') return
+      publication.pushEvent({
+        kind: 'tool',
+        level: 'info',
+        sessionId: request.sessionId,
+        toolCallId: request.toolCallId,
+        promptMessageId: context?.promptMessageId,
+        title: request.title,
+        providerToolName: request.providerToolName ?? request.mcpIdentity,
+        rawInput: request.rawInput,
+        status: state === 'rejected' ? 'completed' : 'in_progress',
+        toolDisposition: state === 'rejected' ? 'declined' : 'permission-closed'
+      })
+    },
+    onNotebookExecutionAuthorized: (authorization) => {
+      const executionInvocationId = options.notebook?.authorizeExecution?.({
+        sessionId: authorization.sessionId,
+        toolCallId: authorization.toolCallId,
+        promptMessageId: authorization.promptMessageId,
+        method: authorization.method,
+        rawInput: authorization.executionInput
+      })
+      if (!executionInvocationId) return
+      publication.pushEvent({
+        kind: 'tool',
+        level: 'info',
+        sessionId: authorization.sessionId,
+        toolCallId: permissionContext.presentationToolCallId(
+          authorization.sessionId,
+          authorization.toolCallId
+        ),
+        promptMessageId: authorization.promptMessageId,
+        title: authorization.title,
+        providerToolName: authorization.providerToolName,
+        rawInput: authorization.rawInput,
+        status: 'in_progress',
+        executionInvocationId
+      })
+    },
     onOpenCodeWaitTimeout: ({ sessionId, toolCallId, waitMs }) => {
       log.warn('OpenCode permission context wait timed out', { sessionId, toolCallId, waitMs })
     }
@@ -241,6 +281,9 @@ const composeAcpRuntimeSessionOwners = (options: AcpRuntimeOptions, base: AcpRun
     currentFramework: () => base.backendGeneration.current.framework.id,
     reconnectPending: () => base.connectionTransitions.providerReconnectPending,
     mcpServerNamesFor: (sessionId) => base.sessionCapabilities.mcpServerNamesFor(sessionId),
+    presentationToolCallId: (notification, context, providerToolCallId) =>
+      permissionContext.presentationToolCallIdForUpdate(notification, context) ??
+      providerToolCallId,
     nextEventId: () => publication.nextEventId(),
     setProviderPermissionProfile: (sessionId, profile) =>
       permissionContext.setProviderPermissionProfile(sessionId, profile),

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -23,6 +23,7 @@ import { SessionPlanInteractionOwner } from '../session-plan/session-plan-intera
 import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
 import type { RuntimeEventInput } from './runtime-snapshot-owner'
 import { AcpPermissionContext } from './permission-context'
+import { permissionRequestFingerprint } from './permission-broker'
 import { ContextUsageTracker, type TokenCounter } from './context-usage-tracker'
 import {
   ACP_PROMPT_FAILED_EVENT_TITLE,
@@ -733,6 +734,9 @@ const startPermissionProbeAgent = (
     codexMcpTitle?: string
     codexMcpApprovalViaElicitation?: boolean
     announceToolCall?: boolean
+    toolCallUpdateRawInput?: unknown
+    toolCallUpdateCount?: number
+    skipPermissionRequest?: boolean
     sparseCodexMcpApproval?: boolean
     modes?: SessionModeState
     onSetMode?: (context: {
@@ -800,6 +804,18 @@ const startPermissionProbeAgent = (
         })
       }
 
+      for (let index = 0; index < (options.toolCallUpdateCount ?? 0); index += 1) {
+        await ctx.client.notify(acp.methods.client.session.update, {
+          sessionId: ctx.params.sessionId,
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: options.toolCallId,
+            status: 'in_progress',
+            rawInput: options.toolCallUpdateRawInput
+          }
+        })
+      }
+
       if (options.codexMcpIdentity) {
         await ctx.client.notify(acp.methods.client.session.update, {
           sessionId: ctx.params.sessionId,
@@ -835,6 +851,8 @@ const startPermissionProbeAgent = (
         options.onPermissionResponse?.(response)
         return { stopReason: 'end_turn' }
       }
+
+      if (options.skipPermissionRequest) return { stopReason: 'end_turn' }
 
       const response = await ctx.client.request(acp.methods.client.session.requestPermission, {
         sessionId: ctx.params.sessionId,
@@ -1690,6 +1708,486 @@ describe('ACP runtime provider prompt acceptance', () => {
   )
 })
 
+const PERMISSION_PROJECTION_FRAMEWORKS = [
+  ['Claude Code', claudeCodeFramework, 'claude-anthropic', 'claude-code:provider-a'],
+  ['OpenCode', opencodeFramework, 'opencode-openai', 'opencode:provider-a'],
+  ['Codex Responses', codexFramework, 'codex-responses', 'codex:provider-a'],
+  ['Codex Bridge', codexFramework, 'codex-bridge', 'codex:provider-a']
+] as const
+
+const PERMISSION_PROJECTION_DECISIONS = [
+  ['allow', 'allow-once', undefined],
+  ['deny', 'reject-once', 'declined'],
+  ['cancel', undefined, 'permission-closed']
+] as const
+
+describe('ACP Notebook permission presentation contract', () => {
+  it.each([
+    [
+      'Claude Code',
+      claudeCodeFramework,
+      'claude-anthropic',
+      'claude-code:provider-a',
+      createModes(['default', 'bypassPermissions']),
+      true
+    ],
+    [
+      'Codex Responses',
+      codexFramework,
+      'codex-responses',
+      'codex:provider-a',
+      createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      false
+    ],
+    [
+      'Codex Bridge',
+      codexFramework,
+      'codex-bridge',
+      'codex:provider-a',
+      createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      false
+    ]
+  ] as const)(
+    'projects native Full Access %s Notebook calls as executing without a permission request',
+    async (_name, framework, modelRoute, backendId, modes, lateInput) => {
+      const process = new FakeAgentProcess()
+      const toolCallId = `native-full-${modelRoute}`
+      const authorizeExecution = vi.fn(() => `invocation-${toolCallId}`)
+      const onPermissionRequest = vi.fn()
+      const isCodex = framework.id === 'codex'
+      startPermissionProbeAgent(process, {
+        newSessionId: `session-${modelRoute}`,
+        toolCallId,
+        toolTitle: isCodex
+          ? 'mcp.open-science-notebook.notebook_execute'
+          : 'mcp__open-science-notebook__notebook_execute',
+        toolKind: 'execute',
+        toolRawInput: lateInput ? {} : { language: 'python', code: 'print(1)' },
+        ...(lateInput
+          ? {
+              toolCallUpdateRawInput: { language: 'python', code: 'print(1)' },
+              toolCallUpdateCount: 2
+            }
+          : {}),
+        ...(isCodex
+          ? {
+              codexMcpIdentity: {
+                server: 'open-science-notebook',
+                tool: 'notebook_execute',
+                arguments: { language: 'python', code: 'print(1)' }
+              }
+            }
+          : {
+              announceToolCall: true,
+              announcedProviderToolName: 'mcp__open-science-notebook__notebook_execute'
+            }),
+        modes,
+        skipPermissionRequest: true
+      })
+      const bridgeLease =
+        modelRoute === 'codex-bridge' ? createBackendLeaseHarness().lease : undefined
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        notebook: {
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' }),
+          authorizeExecution
+        },
+        callbacks: { onPermissionRequest },
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          backendId,
+          modelRoute,
+          executablePath: '/bin/agent',
+          env: {},
+          ...(bridgeLease ? { responsesBridgeLease: bridgeLease } : {})
+        })
+      })
+
+      const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'full' })
+      await runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'run this notebook cell',
+        provenanceContext: { promptMessageId: 'prompt-native-full' }
+      })
+
+      expect(onPermissionRequest).not.toHaveBeenCalled()
+      expect(authorizeExecution.mock.calls).toEqual([
+        [
+          expect.objectContaining({
+            sessionId: session.sessionId,
+            toolCallId,
+            promptMessageId: 'prompt-native-full',
+            method: 'execute',
+            rawInput: { language: 'python', code: 'print(1)' }
+          })
+        ]
+      ])
+      expect(runtime.getSnapshot().events).toContainEqual(
+        expect.objectContaining({
+          kind: 'tool',
+          toolCallId,
+          executionInvocationId: `invocation-${toolCallId}`
+        })
+      )
+    },
+    30_000
+  )
+
+  it.each([
+    [
+      'OpenCode broker Full Access',
+      opencodeFramework,
+      createModes(['build', 'plan'], 'build'),
+      {
+        announceToolCall: true,
+        announcedProviderToolName: 'open_science_notebook_notebook_execute'
+      }
+    ],
+    [
+      'untrusted Codex metadata',
+      codexFramework,
+      createModes(['read-only', 'agent', 'agent-full-access'], 'agent'),
+      {
+        codexMcpIdentity: {
+          server: 'open-science-notebook',
+          tool: 'notebook_execute',
+          arguments: { language: 'python', code: 'print(1)' }
+        },
+        codexMcpMarker: false
+      }
+    ]
+  ] as const)(
+    'does not infer execution authorization from %s provider updates',
+    async (_name, framework, modes, providerOptions) => {
+      const process = new FakeAgentProcess()
+      const authorizeExecution = vi.fn(() => 'unexpected-invocation')
+      startPermissionProbeAgent(process, {
+        newSessionId: `session-${framework.id}`,
+        toolCallId: `untrusted-${framework.id}`,
+        toolTitle:
+          framework.id === 'codex'
+            ? 'mcp.open-science-notebook.notebook_execute'
+            : 'open_science_notebook_notebook_execute',
+        toolKind: 'execute',
+        toolRawInput: { language: 'python', code: 'print(1)' },
+        modes,
+        skipPermissionRequest: true,
+        ...providerOptions
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        framework,
+        spawnAgent: () => asAgentProcess(process),
+        notebook: {
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' }),
+          authorizeExecution
+        }
+      })
+
+      const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'full' })
+      await runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'run this notebook cell',
+        provenanceContext: { promptMessageId: 'prompt-untrusted' }
+      })
+
+      expect(authorizeExecution).not.toHaveBeenCalled()
+      expect(
+        runtime.getSnapshot().events.some((event) => event.executionInvocationId != null)
+      ).toBe(false)
+    }
+  )
+
+  it.each(
+    PERMISSION_PROJECTION_FRAMEWORKS.flatMap(([name, framework, modelRoute, backendId]) =>
+      PERMISSION_PROJECTION_DECISIONS.map(
+        ([decision, optionId, disposition]) =>
+          [name, framework, modelRoute, backendId, decision, optionId, disposition] as const
+      )
+    )
+  )(
+    'projects session/request_permission %s %s without inventing execution',
+    async (_name, framework, modelRoute, backendId, _decision, optionId, disposition) => {
+      const process = new FakeAgentProcess()
+      const toolCallId = `notebook-${modelRoute}-${_decision}`
+      const isCodex = framework.id === 'codex'
+      let permissionResponse: unknown
+      startPermissionProbeAgent(process, {
+        newSessionId: `session-${modelRoute}-${_decision}`,
+        toolCallId,
+        toolTitle:
+          framework.id === 'claude-code'
+            ? 'mcp__open-science-notebook__notebook_execute'
+            : 'open_science_notebook_notebook_execute',
+        toolKind: 'execute',
+        toolRawInput: { language: 'python', code: 'print(1)' },
+        ...(isCodex
+          ? {
+              codexMcpIdentity: {
+                server: 'open-science-notebook',
+                tool: 'notebook_execute',
+                arguments: { language: 'python', code: 'print(1)' }
+              },
+              sparseCodexMcpApproval: true
+            }
+          : {
+              announceToolCall: true,
+              announcedProviderToolName:
+                framework.id === 'claude-code'
+                  ? 'mcp__open-science-notebook__notebook_execute'
+                  : 'open_science_notebook_notebook_execute'
+            }),
+        modes: isCodex
+          ? createModes(['read-only', 'agent', 'agent-full-access'], 'read-only')
+          : undefined,
+        permissionOptions: [
+          { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+          { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+        ],
+        onPermissionResponse: (response) => {
+          permissionResponse = response
+        }
+      })
+      const bridgeLease =
+        modelRoute === 'codex-bridge' ? createBackendLeaseHarness().lease : undefined
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        notebook: {
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' })
+        },
+        callbacks: {
+          onPermissionRequest: (request) => {
+            void runtime.respondToPermission({
+              requestId: request.requestId,
+              ...(optionId ? { optionId } : { cancelled: true })
+            })
+          }
+        },
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          backendId,
+          modelRoute,
+          executablePath: '/bin/agent',
+          env: {},
+          ...(bridgeLease ? { responsesBridgeLease: bridgeLease } : {})
+        })
+      })
+
+      const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+      await runtime.sendPrompt({ sessionId: session.sessionId, text: 'run this notebook cell' })
+
+      expect(permissionResponse).toEqual(
+        optionId
+          ? { outcome: { outcome: 'selected', optionId } }
+          : { outcome: { outcome: 'cancelled' } }
+      )
+      const projected = runtime
+        .getSnapshot()
+        .events.filter((event) => event.toolCallId === toolCallId && event.toolDisposition)
+      if (disposition) {
+        expect(projected).toContainEqual(
+          expect.objectContaining({
+            kind: 'tool',
+            toolDisposition: disposition,
+            status: disposition === 'declined' ? 'completed' : 'in_progress'
+          })
+        )
+      } else {
+        expect(projected).toEqual([])
+      }
+    },
+    30_000
+  )
+
+  it.each([
+    ['Claude Code', claudeCodeFramework, 'mcp__open-science-notebook__notebook_execute'],
+    ['OpenCode', opencodeFramework, 'open_science_notebook_notebook_execute']
+  ] as const)(
+    'issues a fresh execution identity for each %s call released by a remembered grant',
+    async (_name, framework, toolTitle) => {
+      const process = new FakeAgentProcess()
+      const permissionRequests: AcpPermissionRequest[] = []
+      const executionToolCallIds: string[] = []
+      let promptIndex = 0
+      acp
+        .agent({ name: 'remembered-notebook-permission-agent' })
+        .onRequest(acp.methods.agent.initialize, () => ({
+          protocolVersion: acp.PROTOCOL_VERSION,
+          agentCapabilities: { loadSession: false, sessionCapabilities: { close: {} } },
+          authMethods: []
+        }))
+        .onRequest(acp.methods.agent.session.new, () => ({ sessionId: 'remembered-session' }))
+        .onRequest(acp.methods.agent.session.prompt, async (ctx) => {
+          const toolCallId = `remembered-call-${++promptIndex}`
+          const rawInput = { language: 'python', code: `print(${promptIndex})` }
+          await ctx.client.notify(acp.methods.client.session.update, {
+            sessionId: ctx.params.sessionId,
+            update: {
+              sessionUpdate: 'tool_call',
+              toolCallId,
+              title: toolTitle,
+              kind: 'other',
+              status: 'pending',
+              rawInput
+            }
+          })
+          await ctx.client.request(acp.methods.client.session.requestPermission, {
+            sessionId: ctx.params.sessionId,
+            toolCall: {
+              toolCallId,
+              title: toolTitle,
+              kind: 'other',
+              status: 'pending',
+              rawInput
+            },
+            options: [
+              { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+              { optionId: 'reject-once', name: 'Reject', kind: 'reject_once' }
+            ]
+          })
+          return { stopReason: 'end_turn' }
+        })
+        .onRequest(acp.methods.agent.session.close, () => ({}))
+        .connect(
+          acp.ndJsonStream(
+            Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+            Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+          )
+        )
+
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        framework,
+        notebook: {
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' }),
+          authorizeExecution: (authorization) => {
+            executionToolCallIds.push(authorization.toolCallId)
+            return `invocation-${authorization.toolCallId}`
+          }
+        },
+        callbacks: {
+          onPermissionRequest: (request) => {
+            permissionRequests.push(request)
+            const sessionOptionId = request.options.find(
+              (option) => option.scope === 'session'
+            )?.optionId
+            if (!sessionOptionId) throw new Error('Missing Session grant option')
+            void runtime.respondToPermission({
+              requestId: request.requestId,
+              optionId: sessionOptionId
+            })
+          }
+        }
+      })
+      const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+      await runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'run once',
+        provenanceContext: { promptMessageId: 'prompt-1' }
+      })
+      await runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'run again',
+        provenanceContext: { promptMessageId: 'prompt-2' }
+      })
+
+      expect(permissionRequests).toHaveLength(1)
+      expect(executionToolCallIds).toEqual(['remembered-call-1', 'remembered-call-2'])
+    }
+  )
+
+  it.each(
+    PERMISSION_PROJECTION_FRAMEWORKS.filter(([, framework]) => framework.id === 'codex').flatMap(
+      ([name, framework, modelRoute, backendId]) =>
+        PERMISSION_PROJECTION_DECISIONS.map(
+          ([decision, , disposition]) =>
+            [name, framework, modelRoute, backendId, decision, disposition] as const
+        )
+    )
+  )(
+    'projects elicitation/create %s %s without inventing execution',
+    async (_name, framework, modelRoute, backendId, _decision, disposition) => {
+      const process = new FakeAgentProcess()
+      const toolCallId = `elicitation-${modelRoute}-${_decision}`
+      let elicitationResponse: unknown
+      startPermissionProbeAgent(process, {
+        newSessionId: `elicitation-session-${modelRoute}-${_decision}`,
+        toolCallId,
+        toolTitle: 'unused by sparse Codex approval',
+        codexMcpIdentity: {
+          server: 'open-science-notebook',
+          tool: 'notebook_execute',
+          arguments: { language: 'python', code: 'print(1)' }
+        },
+        codexMcpApprovalViaElicitation: true,
+        modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only'),
+        onPermissionResponse: (response) => {
+          elicitationResponse = response
+        }
+      })
+      const bridgeLease =
+        modelRoute === 'codex-bridge' ? createBackendLeaseHarness().lease : undefined
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        notebook: {
+          projectName: 'default-project',
+          mcpEntryPath: '/app/out/main/index.js',
+          getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' })
+        },
+        callbacks: {
+          onPermissionRequest: (request) => {
+            const decisionOptionId = request.options.find((option) =>
+              _decision === 'allow' ? option.kind === 'allow_once' : option.kind === 'reject_once'
+            )?.optionId
+            void runtime.respondToPermission({
+              requestId: request.requestId,
+              ...(_decision === 'cancel' ? { cancelled: true } : { optionId: decisionOptionId })
+            })
+          }
+        },
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          backendId,
+          modelRoute,
+          executablePath: '/bin/agent',
+          env: {},
+          ...(bridgeLease ? { responsesBridgeLease: bridgeLease } : {})
+        })
+      })
+
+      const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
+      await runtime.sendPrompt({ sessionId: session.sessionId, text: 'run this notebook cell' })
+
+      expect(elicitationResponse).toEqual({
+        action: _decision === 'allow' ? 'accept' : _decision === 'deny' ? 'decline' : 'cancel'
+      })
+      const projected = runtime
+        .getSnapshot()
+        .events.filter((event) => event.toolCallId === toolCallId && event.toolDisposition)
+      if (disposition) {
+        expect(projected).toContainEqual(expect.objectContaining({ toolDisposition: disposition }))
+      } else {
+        expect(projected).toEqual([])
+      }
+    },
+    30_000
+  )
+})
+
 const createRestoredContinuationSession = (
   promptMessageId = 'prompt-1',
   sessionId = 'restored-session',
@@ -1849,6 +2347,152 @@ const RESTORED_CONTINUATION_FRAMEWORKS = [
 ] as const
 
 describe('ACP runtime restored permission continuation', () => {
+  it('keeps the original Notebook presentation id while authorizing the provider replay id', async () => {
+    const process = new FakeAgentProcess()
+    const originalToolCallId = 'notebook-original'
+    const replayToolCallId = 'notebook-replayed'
+    const toolTitle = 'mcp.open-science-notebook.notebook_execute'
+    const rawInput = { language: 'python', code: 'print(1)' }
+    const originalRequest: AcpPermissionRequest = {
+      requestId: 'permission-restored',
+      sessionId: 'restored-session',
+      toolCallId: originalToolCallId,
+      title: toolTitle,
+      providerToolName: 'notebook_execute',
+      isMcp: true,
+      mcpIdentity: 'open-science-notebook/notebook_execute',
+      toolKind: 'execute',
+      rawInput,
+      options: [
+        {
+          optionId: 'allow-once',
+          name: 'Allow once',
+          kind: 'allow_once',
+          scope: 'once'
+        }
+      ]
+    }
+    let runtimeContext: SessionRuntimeContext = {
+      version: 1,
+      revision: 1,
+      permission: {
+        state: 'pending',
+        request: originalRequest,
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: permissionRequestFingerprint(originalRequest)!,
+        createdAt: 1
+      }
+    }
+    const messages: PersistedChatSession['messages'] = [
+      {
+        id: 'prompt-1',
+        role: 'user',
+        content: 'Run the Notebook code.',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+    const persistedSession: PersistedChatSession = {
+      id: 'restored-session',
+      projectId: 'project-1',
+      title: 'Restored Notebook permission',
+      cwd: '/workspace',
+      status: 'waiting-permission',
+      messages,
+      conversationGraph: createLinearConversationGraph({
+        sessionId: 'restored-session',
+        messages,
+        frameworkId: 'codex',
+        backendId: 'codex:provider-a',
+        createdAt: 1,
+        updatedAt: 1
+      }),
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const authorizeExecution = vi.fn(() => 'execution-replayed')
+    startPermissionProbeAgent(process, {
+      newSessionId: 'restored-session',
+      toolCallId: replayToolCallId,
+      toolTitle,
+      toolKind: 'execute',
+      toolRawInput: rawInput,
+      codexMcpIdentity: {
+        server: 'open-science-notebook',
+        tool: 'notebook_execute',
+        arguments: rawInput
+      },
+      sparseCodexMcpApproval: true,
+      modes: createModes(['read-only', 'agent', 'agent-full-access'], 'read-only'),
+      permissionOptions: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      notebook: {
+        projectName: 'project-1',
+        mcpEntryPath: '/app/out/main/index.js',
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' }),
+        authorizeExecution
+      },
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+          patchSessionRuntimeContext: vi.fn(async (command) => {
+            runtimeContext = {
+              ...runtimeContext,
+              ...command.patch,
+              revision: runtimeContext.revision + 1
+            }
+            return structuredClone(runtimeContext)
+          }),
+          containsMessageOnActiveBranch: vi.fn(async () => true),
+          loadSessionForContinuation: vi.fn(async () => structuredClone(persistedSession))
+        }
+      },
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        backendId: 'codex:provider-a',
+        modelRoute: 'codex-responses',
+        executablePath: '/bin/agent',
+        env: {}
+      })
+    })
+    await runtime.createSession({ cwd: '/workspace', projectName: 'project-1' })
+
+    await runtime.respondToPermission({
+      requestId: originalRequest.requestId,
+      optionId: 'allow-once',
+      restored: { sessionId: 'restored-session', projectId: 'project-1' }
+    })
+
+    await vi.waitFor(() => expect(authorizeExecution).toHaveBeenCalledOnce())
+    expect(authorizeExecution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'restored-session',
+        toolCallId: replayToolCallId,
+        promptMessageId: 'prompt-1',
+        rawInput
+      })
+    )
+    const notebookEvents = runtime
+      .getSnapshot()
+      .events.filter((event) => event.kind === 'tool' && event.executionInvocationId)
+    expect(notebookEvents).toContainEqual(
+      expect.objectContaining({
+        toolCallId: originalToolCallId,
+        executionInvocationId: 'execution-replayed'
+      })
+    )
+    expect(
+      runtime
+        .getSnapshot()
+        .events.some((event) => event.kind === 'tool' && event.toolCallId === replayToolCallId)
+    ).toBe(false)
+  })
+
   it('cancels restored pending authority without a live ACP interaction', async () => {
     let runtimeContext: SessionRuntimeContext = {
       version: 1,
@@ -10486,6 +11130,12 @@ describe('ACP runtime session management', () => {
     const process = new FakeAgentProcess()
     const permissionRequests: AcpPermissionRequest[] = []
     const permissionResponses: unknown[] = []
+    const executionAuthorizations: Array<{
+      sessionId: string
+      toolCallId: string
+      promptMessageId: string
+      method: string
+    }> = []
     const toolInputs = [
       { code: 'x = 1', language: 'python' },
       { code: 'x = 1', language: 'python' },
@@ -10584,7 +11234,11 @@ describe('ACP runtime session management', () => {
       notebook: {
         projectName: 'default-project',
         mcpEntryPath: '/app/out/main/index.js',
-        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' })
+        getRpcConnection: async () => ({ endpoint: 'http://127.0.0.1:4567', token: 'nb' }),
+        authorizeExecution: (authorization) => {
+          executionAuthorizations.push(authorization)
+          return `invocation-${authorization.toolCallId}`
+        }
       },
       callbacks: {
         onPermissionRequest: (request) => {
@@ -10605,8 +11259,12 @@ describe('ACP runtime session management', () => {
     const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'ask' })
     expect(mcpServerNamesFor(runtime, session.sessionId)).toContain('open-science-notebook')
 
-    for (const toolInput of toolInputs) {
-      await runtime.sendPrompt({ sessionId: session.sessionId, text: `run ${toolInput.language}` })
+    for (const [index, toolInput] of toolInputs.entries()) {
+      await runtime.sendPrompt({
+        sessionId: session.sessionId,
+        text: `run ${toolInput.language}`,
+        provenanceContext: { promptMessageId: `prompt-${index + 1}` }
+      })
     }
 
     expect(permissionRequests).toHaveLength(2)
@@ -10617,6 +11275,15 @@ describe('ACP runtime session management', () => {
     expect(permissionResponses).toEqual(
       toolInputs.map(() => ({ outcome: { outcome: 'selected', optionId: 'once' } }))
     )
+    // Calls 2 and 3 are app-remembered Python grants, while call 4 establishes the R grant. Every
+    // released OpenCode call still creates a fresh one-shot execution identity.
+    expect(executionAuthorizations.map(({ toolCallId }) => toolCallId)).toEqual([
+      'opencode-notebook-1',
+      'opencode-notebook-2',
+      'opencode-notebook-3',
+      'opencode-notebook-4'
+    ])
+    expect(executionAuthorizations[3]).toMatchObject({ rawInput: toolInputs[3] })
     expect(runtime.getSnapshot().permissionGrants[session.sessionId]).toEqual([
       {
         categoryKey: 'mcp:open-science-notebook/notebook_execute:python',
@@ -20185,6 +20852,16 @@ describe('ACP runtime session management', () => {
 
     await vi.waitFor(() => expect(prompts).toHaveLength(2))
     expect(prompts[1]).toContain('permission')
+    expect(runtime.getSnapshot().events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'tool',
+          toolCallId: 'denied-command',
+          status: 'completed',
+          toolDisposition: 'declined'
+        })
+      ])
+    )
     expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([session.sessionId])
 
     const cancelSnapshot = await runtime.cancelPrompt({ sessionId: session.sessionId })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -59,6 +59,7 @@ import { ArtifactRepository } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
 import type { NotebookRpcConnection } from '../notebook/mcp-server'
 import type { NotebookHandoffContext } from '../notebook/runtime-service'
+import type { NotebookExecutionRpcMethod } from '../../shared/notebook'
 import type { SkillImportRpcConnection } from '../skills/mcp-server'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../agent-framework/codex'
 import { getAppClaudeConfigDir } from '../settings/provider-env'
@@ -283,6 +284,13 @@ type AcpRuntimeNotebookOptions = {
   registerSessionAlias?: (aliasSessionId: string, sessionId: string) => void
   releaseSessionCapabilities?: (sessionId: string) => void
   registerSessionSpecialist?: (sessionId: string, specialistId: string | undefined) => void
+  authorizeExecution?: (authorization: {
+    sessionId: string
+    toolCallId: string
+    promptMessageId: string
+    method: NotebookExecutionRpcMethod
+    rawInput?: unknown
+  }) => string | undefined
   setArtifactProvenanceContext?: (
     sessionId: string,
     context: import('../../shared/notebook').NotebookRunProvenanceContext | undefined
@@ -1367,10 +1375,27 @@ class AcpRuntime {
       }
     })
     this.schedulePendingAppContinuation(restored.sessionId)
-    this.options.callbacks?.onPermissionSettled?.(
-      response.requestId,
-      response.cancelled ? 'cancelled' : decision.denied ? 'rejected' : 'resolved'
-    )
+    const settlementState = response.cancelled
+      ? 'cancelled'
+      : decision.denied
+        ? 'rejected'
+        : 'resolved'
+    this.options.callbacks?.onPermissionSettled?.(response.requestId, settlementState)
+    if (settlementState !== 'resolved') {
+      this.pushEvent({
+        kind: 'tool',
+        level: 'info',
+        sessionId: restored.sessionId,
+        promptMessageId: decision.permission.originatingPromptMessageId,
+        toolCallId: decision.permission.request.toolCallId,
+        title: decision.permission.request.title,
+        providerToolName:
+          decision.permission.request.providerToolName ?? decision.permission.request.mcpIdentity,
+        rawInput: decision.permission.request.rawInput,
+        status: settlementState === 'rejected' ? 'completed' : 'in_progress',
+        toolDisposition: settlementState === 'rejected' ? 'declined' : 'permission-closed'
+      })
+    }
     this.pushEvent({
       kind: 'permission',
       level: 'info',

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -34,7 +34,12 @@ const createProjector = (
     availableModeIds: ['default', 'bypassPermissions'],
     fullAccessAvailable: true
   },
-  acceptProviderPermissionProfile = true
+  acceptProviderPermissionProfile = true,
+  presentationToolCallId: (
+    notification: SessionNotification,
+    context: Readonly<{ sessionId: string }>,
+    providerToolCallId: string
+  ) => string = (_notification, _context, providerToolCallId) => providerToolCallId
 ): TestProjector => {
   let routing: TestRouting = {
     eventId: 'event-route',
@@ -87,6 +92,7 @@ const createProjector = (
     currentFramework: () => routing.framework ?? 'claude-code',
     reconnectPending: () => routing.reconnectPending,
     mcpServerNamesFor: () => routing.mcpServerNames,
+    presentationToolCallId,
     nextEventId: () => routing.eventId,
     setProviderPermissionProfile: (sessionId, profile) => {
       if (!acceptProviderPermissionProfile) return false
@@ -115,6 +121,49 @@ const createProjector = (
 }
 
 describe('AcpSessionUpdateProjector', () => {
+  it('projects a provider tool replay through its app presentation identity', () => {
+    const projector = createProjector(
+      undefined,
+      true,
+      (_notification, context, providerToolCallId) =>
+        context.sessionId === 'stable-session' && providerToolCallId === 'tool-replayed'
+          ? 'tool-original'
+          : providerToolCallId
+    )
+
+    const effects = projector.route(
+      {
+        sessionId: 'provider-session',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tool-replayed',
+          title: 'mcp__open-science-notebook__notebook_execute',
+          kind: 'other',
+          status: 'pending',
+          rawInput: { language: 'python', code: 'print(1)' }
+        }
+      },
+      {
+        framework: 'claude-code',
+        appSessionId: 'stable-session',
+        eventId: 'event-replayed',
+        visible: true,
+        reconnectPending: false,
+        mcpServerNames: ['open-science-notebook']
+      }
+    )
+
+    expect(effects).toContainEqual(
+      expect.objectContaining({
+        kind: 'visible-event',
+        event: expect.objectContaining({
+          sessionId: 'stable-session',
+          toolCallId: 'tool-original'
+        })
+      })
+    )
+  })
+
   it('routes stable Session usage through context owners in projection order', () => {
     const journal: string[] = []
     const beginSession = vi.fn(() => journal.push('context:begin'))
@@ -145,6 +194,7 @@ describe('AcpSessionUpdateProjector', () => {
       currentFramework: () => 'claude-code',
       reconnectPending: () => false,
       mcpServerNamesFor: () => [],
+      presentationToolCallId: (_notification, _context, providerToolCallId) => providerToolCallId,
       nextEventId,
       setProviderPermissionProfile: () => true,
       emitState: () => journal.push('state:emit'),

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -71,6 +71,15 @@ type AcpSessionUpdateProjectorOptions = Readonly<{
   currentFramework: () => AgentFrameworkId
   reconnectPending: () => boolean
   mcpServerNamesFor: (sessionId: string) => readonly string[]
+  presentationToolCallId: (
+    notification: SessionNotification,
+    context: Readonly<{
+      sessionId: string
+      framework: AgentFrameworkId
+      mcpServerNames: readonly string[]
+    }>,
+    providerToolCallId: string
+  ) => string
   nextEventId: () => string
   setProviderPermissionProfile: (
     sessionId: string,
@@ -201,11 +210,11 @@ class AcpSessionUpdateProjector {
       )
     )
     const projectedEvent = projection.event
-    const event = deepFreeze(
+    const unaliasedEvent =
       routing.framework === 'codex' &&
-        projectedEvent.kind === 'message' &&
-        projectedEvent.messageId === undefined &&
-        projectedEvent.text?.trim() === CODEX_LEGACY_COMPACTION_NOTICE
+      projectedEvent.kind === 'message' &&
+      projectedEvent.messageId === undefined &&
+      projectedEvent.text?.trim() === CODEX_LEGACY_COMPACTION_NOTICE
         ? {
             id: projectedEvent.id,
             timestamp: projectedEvent.timestamp,
@@ -217,6 +226,21 @@ class AcpSessionUpdateProjector {
             toolCallId: `context-compaction:${routing.eventId}`
           }
         : projectedEvent
+    const event = deepFreeze(
+      unaliasedEvent.kind === 'tool' && unaliasedEvent.toolCallId
+        ? {
+            ...unaliasedEvent,
+            toolCallId: this.options.presentationToolCallId(
+              notification,
+              {
+                sessionId: routed.sessionId,
+                framework: routing.framework ?? this.options.currentFramework(),
+                mcpServerNames: routing.mcpServerNames
+              },
+              unaliasedEvent.toolCallId
+            )
+          }
+        : unaliasedEvent
     )
     // codex-acp 1.1.4 flattens Codex's post-compaction warning into an unscoped assistant chunk.
     // Keep the separate compaction notice, but do not attribute this adapter-authored warning to the model.

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -134,21 +134,25 @@ class NotebookExecutionOwner {
   }
   async executeDataCell(
     session: NotebookSessionAggregate,
-    request: RunNotebookCellRequest
+    request: RunNotebookCellRequest,
+    signal?: AbortSignal
   ): Promise<NotebookRunRecord> {
     const cell = session.cellView(request.cellId)
     if (session.isCellReceiving(cell.id)) {
       throw new Error(`Notebook cell is still receiving code: ${cell.id}`)
     }
     const route = this.options.dataExecutionAdmission.route(session, cell.language)
-    return session.enqueueExecution(route.processKey, () =>
-      this.executeDataCellExclusive(session, cell, request)
+    return session.enqueueExecution(
+      route.processKey,
+      () => this.executeDataCellExclusive(session, cell, request, signal),
+      signal
     )
   }
   private async executeDataCellExclusive(
     session: NotebookSessionAggregate,
     cell: Readonly<NotebookCell>,
-    request: RunNotebookCellRequest
+    request: RunNotebookCellRequest,
+    signal?: AbortSignal
   ): Promise<NotebookRunRecord> {
     this.options.notifyAvailable(session, request.source ?? 'agent')
     const { runId } = this.options.runTerminalization.allocateRunIdentity()
@@ -161,6 +165,9 @@ class NotebookExecutionOwner {
     session.markCellRunning(cell.id, runId, executionCount)
     const runningRun: NotebookRunRecord = {
       runId,
+      ...(request.executionInvocationId
+        ? { executionInvocationId: request.executionInvocationId }
+        : {}),
       cellId: cell.id,
       source: request.source ?? 'agent',
       inputKind: request.inputKind ?? 'cell',
@@ -226,6 +233,7 @@ class NotebookExecutionOwner {
               runtimeRoot: session.runtimeRoot,
               protectedDirs: [getAppClaudeConfigDir(this.options.configRoot)],
               timeoutMs: request.timeoutMs,
+              signal,
               resolvedInterpreter,
               inputRunLeaseId: request.inputRunLeaseId
             })
@@ -267,7 +275,7 @@ class NotebookExecutionOwner {
             }
           }
         }),
-      postCommit: (result) => {
+      settleLive: (result) => {
         session.completeCellRun(cell.id, result.status, result.cwdAfter ?? cwdBefore)
       }
     })
@@ -337,6 +345,9 @@ class NotebookExecutionOwner {
     this.options.notifyAvailable(session, 'agent')
     const runningRun: NotebookRunRecord = {
       runId,
+      ...(request.executionInvocationId
+        ? { executionInvocationId: request.executionInvocationId }
+        : {}),
       cellId: `repl-${runId}`,
       source: 'agent',
       inputKind: 'cell',
@@ -449,6 +460,9 @@ class NotebookExecutionOwner {
     const { runId } = this.options.runTerminalization.allocateRunIdentity()
     const runningRun: NotebookRunRecord = {
       runId,
+      ...(request.executionInvocationId
+        ? { executionInvocationId: request.executionInvocationId }
+        : {}),
       cellId: `bash-${runId}`,
       source: 'agent',
       inputKind: 'cell',

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -175,7 +175,11 @@ const makeDefaultEnvCwd = async (prefix: string): Promise<string> => {
 }
 
 type ExecutorInternals = { procs: Map<string, ProcStateLike> }
-type ProcStateLike = { child: ChildProcessWithoutNullStreams; env: string }
+type ProcStateLike = {
+  child: ChildProcessWithoutNullStreams
+  env: string
+  pending?: { timeout?: TimeoutController }
+}
 // Composite process key: 'repl' for the control kernel, `${kind}:${env}` for data kernels. `env`
 // defaults to the language's default env so existing single-env call sites need no change.
 const procKeyFor = (kind: 'python' | 'r' | 'repl', env?: string): string =>
@@ -519,6 +523,117 @@ gate('NotebookKernelExecutor (fake loop)', () => {
     }
   }, 15_000)
 
+  it('cancels a long run with SIGINT and preserves the kernel process', async () => {
+    cwdDir = await makeDefaultEnvCwd('os-kernel-cancel-')
+    const executor = makeExecutor()
+    try {
+      await executor.execute({ ...baseRequest(cwdDir), code: 'warm' })
+      const child = procFor(executor, 'python')?.child as ChildProcessWithoutNullStreams
+      const killSpy = vi.spyOn(child, 'kill')
+      const cancellation = new AbortController()
+
+      const run = executor.execute({
+        ...baseRequest(cwdDir),
+        code: '__SLEEP__',
+        signal: cancellation.signal
+      })
+      await vi.waitFor(() => expect(procFor(executor, 'python')?.pending).toBeDefined())
+      cancellation.abort()
+
+      await expect(run).resolves.toMatchObject({ status: 'cancelled' })
+      expect(killSpy).toHaveBeenCalledWith('SIGINT')
+      expect(killSpy).not.toHaveBeenCalledWith('SIGKILL')
+
+      const next = await executor.execute({ ...baseRequest(cwdDir), code: 'again' })
+      expect(next.status).toBe('completed')
+      expect(procFor(executor, 'python')?.child).toBe(child)
+    } finally {
+      await executor.shutdown()
+    }
+  }, 15_000)
+
+  it('drops and respawns the kernel when Windows cancellation cannot preserve it', async () => {
+    cwdDir = await makeDefaultEnvCwd('os-kernel-windows-cancel-')
+    const terminated: Array<['python' | 'r' | 'repl', string]> = []
+    const executor = new NotebookKernelExecutor({
+      pythonLoopPath: FIXTURE,
+      platform: 'win32',
+      onTerminated: (kind, env) => terminated.push([kind, env])
+    })
+    try {
+      await executor.execute({ ...baseRequest(cwdDir), code: 'warm' })
+      const child = procFor(executor, 'python')?.child
+      const cancellation = new AbortController()
+      const run = executor.execute({
+        ...baseRequest(cwdDir),
+        code: '__SLEEP__',
+        signal: cancellation.signal
+      })
+      await vi.waitFor(() => expect(procFor(executor, 'python')?.pending).toBeDefined())
+
+      cancellation.abort()
+
+      await expect(run).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+      expect(procFor(executor, 'python')).toBeUndefined()
+      expect(terminated).toEqual([['python', DEFAULT_PY_ENV]])
+
+      const next = await executor.execute({ ...baseRequest(cwdDir), code: 'again' })
+      expect(next.status).toBe('completed')
+      expect(procFor(executor, 'python')?.child).not.toBe(child)
+    } finally {
+      await executor.shutdown()
+    }
+  }, 15_000)
+
+  it('drops a POSIX kernel that does not acknowledge cancellation within the grace period', async () => {
+    cwdDir = await makeDefaultEnvCwd('os-kernel-posix-cancel-grace-')
+    const terminated: Array<['python' | 'r' | 'repl', string]> = []
+    const executor = new NotebookKernelExecutor({
+      pythonLoopPath: FIXTURE,
+      platform: 'linux',
+      cancellationGraceMs: 50,
+      onTerminated: (kind, env) => terminated.push([kind, env])
+    })
+    try {
+      await executor.execute({ ...baseRequest(cwdDir), code: 'warm' })
+      const child = procFor(executor, 'python')?.child
+      const cancellation = new AbortController()
+      const run = executor.execute({
+        ...baseRequest(cwdDir),
+        code: '__IGNORE_SIGINT__',
+        signal: cancellation.signal
+      })
+      await vi.waitFor(() => expect(procFor(executor, 'python')?.pending).toBeDefined())
+
+      cancellation.abort()
+
+      await expect(run).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+      expect(procFor(executor, 'python')).toBeUndefined()
+      expect(terminated).toEqual([['python', DEFAULT_PY_ENV]])
+
+      const next = await executor.execute({ ...baseRequest(cwdDir), code: 'again' })
+      expect(next.status).toBe('completed')
+      expect(procFor(executor, 'python')?.child).not.toBe(child)
+    } finally {
+      await executor.shutdown()
+    }
+  }, 15_000)
+
+  it('does not arm an execution timeout when a data-kernel request omits timeoutMs', async () => {
+    cwdDir = await makeDefaultEnvCwd('os-kernel-unbounded-')
+    const executor = makeExecutor()
+    try {
+      const resultPromise = executor.execute({ ...baseRequest(cwdDir), code: '__SLEEP__' })
+      await vi.waitFor(() => expect(procFor(executor, 'python')?.pending).toBeDefined())
+
+      expect(procFor(executor, 'python')?.pending?.timeout).toBeUndefined()
+      await executor.shutdown()
+      await expect(resultPromise).resolves.toMatchObject({ status: 'failed' })
+    } finally {
+      await executor.shutdown()
+    }
+  }, 15_000)
+
   it('shutdown terminates a loop that only soft-timed-out (child.killed but still alive)', async () => {
     cwdDir = await makeDefaultEnvCwd('os-kernel-shutdown-soft-')
     const executor = makeExecutor()
@@ -653,6 +768,43 @@ gate('NotebookKernelExecutor (fake loop)', () => {
 })
 
 posixGate('NotebookKernelExecutor (real Python loop mutation policy)', () => {
+  it('cancels a run without clearing the persistent Python namespace', async () => {
+    cwdDir = await mkdtemp(join(tmpdir(), 'os-python-loop-cancel-'))
+    const request = baseRequest(cwdDir)
+    await stubEnvPython(request.runtimeRoot, DEFAULT_PY_ENV)
+    const executor = new NotebookKernelExecutor({
+      pythonLoopPath: join(__dirname, '../../../resources/notebook/python_loop.py'),
+      platform: 'linux'
+    })
+
+    try {
+      await expect(
+        executor.execute({ ...request, code: 'preserved_after_cancel = 41', language: 'python' })
+      ).resolves.toMatchObject({ status: 'completed' })
+      const child = procFor(executor, 'python')?.child
+      const cancellation = new AbortController()
+      const run = executor.execute({
+        ...request,
+        code: 'import time\ntime.sleep(30)',
+        language: 'python',
+        signal: cancellation.signal
+      })
+      await vi.waitFor(() => expect(procFor(executor, 'python')?.pending).toBeDefined())
+      cancellation.abort()
+
+      await expect(run).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+      const next = await executor.execute({
+        ...request,
+        code: 'print(preserved_after_cancel + 1)',
+        language: 'python'
+      })
+      expect(next).toMatchObject({ status: 'completed', stdout: '42\n' })
+      expect(procFor(executor, 'python')?.child).toBe(child)
+    } finally {
+      await executor.shutdown()
+    }
+  }, 15_000)
+
   it('blocks dynamically assembled venv and pip subprocess entry points', async () => {
     cwdDir = await mkdtemp(join(tmpdir(), 'os-python-loop-package-guard-'))
     const request = baseRequest(cwdDir)
@@ -801,6 +953,43 @@ posixGate('NotebookKernelExecutor (real Python loop mutation policy)', () => {
 })
 
 describe.skipIf(!rExecutable || !rScriptExecutable)('NotebookKernelExecutor (real R loop)', () => {
+  it('cancels a run without clearing the persistent R namespace', async () => {
+    cwdDir = await mkdtemp(join(tmpdir(), 'os-r-loop-cancel-'))
+    const request = baseRequest(cwdDir)
+    await stubEnvR(request.runtimeRoot, DEFAULT_R_ENV)
+    const executor = new NotebookKernelExecutor({
+      rLoopPath: join(__dirname, '../../../resources/notebook/r_loop.R'),
+      platform: 'linux'
+    })
+
+    try {
+      await expect(
+        executor.execute({ ...request, code: 'preserved_after_cancel <- 41', language: 'r' })
+      ).resolves.toMatchObject({ status: 'completed' })
+      const child = procFor(executor, 'r')?.child
+      const cancellation = new AbortController()
+      const run = executor.execute({
+        ...request,
+        code: 'Sys.sleep(30)',
+        language: 'r',
+        signal: cancellation.signal
+      })
+      await vi.waitFor(() => expect(procFor(executor, 'r')?.pending).toBeDefined())
+      cancellation.abort()
+
+      await expect(run).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+      const next = await executor.execute({
+        ...request,
+        code: 'cat(preserved_after_cancel + 1)',
+        language: 'r'
+      })
+      expect(next).toMatchObject({ status: 'completed', stdout: '42' })
+      expect(procFor(executor, 'r')?.child).toBe(child)
+    } finally {
+      await executor.shutdown()
+    }
+  }, 15_000)
+
   it.each([
     {
       name: 'base graphics through a PNG device',
@@ -1609,6 +1798,44 @@ describe('NotebookKernelExecutor repl kind (real repl_loop.js)', () => {
       await executor.shutdown()
     }
   })
+
+  it.runIf(process.platform === 'win32')(
+    'cancels by terminating and lazily respawning the kernel on Windows',
+    async () => {
+      cwdDir = await mkdtemp(join(tmpdir(), 'os-kernel-repl-windows-cancel-'))
+      const terminated: Array<['python' | 'r' | 'repl', string]> = []
+      const executor = new NotebookKernelExecutor({
+        replLoopPath: REPL_LOOP,
+        onTerminated: (kind, env) => terminated.push([kind, env])
+      })
+      try {
+        await executor.execute({ ...baseRequest(cwdDir), code: 'return 1', kind: 'repl' })
+        const child = procFor(executor, 'repl')?.child
+        const cancellation = new AbortController()
+        const run = executor.execute({
+          ...baseRequest(cwdDir),
+          code: 'await new Promise(() => {})',
+          kind: 'repl',
+          signal: cancellation.signal
+        })
+        await vi.waitFor(() => expect(procFor(executor, 'repl')?.pending).toBeDefined())
+        cancellation.abort()
+
+        await expect(run).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+        expect(terminated).toEqual([['repl', '']])
+        const next = await executor.execute({
+          ...baseRequest(cwdDir),
+          code: 'return 2',
+          kind: 'repl'
+        })
+        expect(next.status).toBe('completed')
+        expect(procFor(executor, 'repl')?.child).not.toBe(child)
+      } finally {
+        await executor.shutdown()
+      }
+    },
+    15_000
+  )
 
   it.skipIf(process.platform === 'win32')(
     'allows read-only child argv but blocks descriptor permission changes in the managed runtime',

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -32,7 +32,7 @@ import type {
   NotebookExecutionResult,
   NotebookExecutor
 } from './runtime-service'
-import { DEFAULT_TIMEOUT_MS, TimeoutController } from './timeout-controller'
+import { TimeoutController } from './timeout-controller'
 import { startWorkingFileObservation, type WorkingFileObservation } from './working-file-observer'
 
 // Driver-internal process kind. 'python'/'r' are the data kernels selected by the agent-facing
@@ -58,6 +58,7 @@ type CancelIdleTimer = (handle: IdleTimerHandle) => void
 // kernel is opt-in via OPEN_SCIENCE_KERNEL_IDLE_MS (a positive ms value); 0 / unset keeps kernels
 // alive until an explicit shutdown/restart or session teardown.
 const DEFAULT_IDLE_MS = 0
+const DEFAULT_CANCELLATION_GRACE_MS = 2_000
 
 // Real scheduler: unref'd so a pending idle timer alone never keeps the process alive.
 const defaultScheduleIdleTimer: ScheduleIdleTimer = (fn, ms) => {
@@ -95,6 +96,9 @@ export type NotebookKernelExecutorOptions = {
   // respawns a fresh one (namespace cleared). Defaults to OPEN_SCIENCE_KERNEL_IDLE_MS if that is a
   // positive ms value, else DEFAULT_IDLE_MS (0 = disabled). A non-positive value keeps kernels alive.
   idleTimeoutMs?: number
+  // Time allowed for a POSIX kernel to acknowledge SIGINT before its process tree is dropped. The
+  // short grace preserves responsive namespaces without letting cancellation hang indefinitely.
+  cancellationGraceMs?: number
   // Injectable idle-timer scheduler/canceller so tests drive idle-shutdown with a fake clock instead
   // of waiting out the real idle window.
   scheduleIdleTimer?: ScheduleIdleTimer
@@ -103,9 +107,10 @@ export type NotebookKernelExecutorOptions = {
   // kernel status upward (see NotebookRuntimeService). Carries the resolved env so the caller marks
   // the right per-(kind, env) kernel status ('' for the env-agnostic repl).
   onIdleShutdown?: (kind: KernelProcessKind, env: string) => void
-  // Invoked once a proc is lost unexpectedly (a crash exit or a hard-timeout drop), NOT on an
-  // intentional shutdown()/restart(). Parallels onIdleShutdown so the caller can persist a
-  // 'terminated' kernel status for an involuntary loss too (see NotebookRuntimeService).
+  // Invoked once a proc is lost unexpectedly (a crash exit or a hard-timeout drop), or cancellation
+  // must drop it because Windows cannot recoverably interrupt it or a POSIX grace period expires.
+  // NOT invoked on an intentional shutdown()/restart(). Parallels onIdleShutdown so the caller can
+  // persist a 'terminated' kernel status for an involuntary loss too (see NotebookRuntimeService).
   onTerminated?: (kind: KernelProcessKind, env: string) => void
   // Injectable only to exercise the Windows conda activation contract on non-Windows test hosts.
   platform?: NodeJS.Platform
@@ -116,8 +121,12 @@ type PendingRequest = {
   reqId: string
   resolve: (response: KernelLoopResponse) => void
   reject: (error: unknown) => void
-  timeout: TimeoutController
-  timeoutMs: number
+  cancelled: boolean
+  signal?: AbortSignal
+  abortListener?: () => void
+  cancellationTimer?: IdleTimerHandle
+  timeout?: TimeoutController
+  timeoutMs?: number
 }
 
 // One persistent loop process for a (kind, env), reused across cells until it exits or is killed.
@@ -149,6 +158,13 @@ class NotebookExecutionTimeoutError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'NotebookExecutionTimeoutError'
+  }
+}
+
+class NotebookExecutionCancelledError extends Error {
+  constructor() {
+    super('Notebook execution was cancelled.')
+    this.name = 'NotebookExecutionCancelledError'
   }
 }
 
@@ -209,6 +225,18 @@ const errorToExecutionResult = (
   error: unknown,
   request: NotebookExecutionRequest
 ): NotebookExecutionResult => {
+  if (error instanceof NotebookExecutionCancelledError) {
+    return {
+      status: 'cancelled',
+      stdout: '',
+      stderr: '',
+      traceback: '',
+      cwdAfter: request.cwd,
+      outputs: [],
+      workingFiles: []
+    }
+  }
+
   const message = error instanceof Error ? error.message : String(error)
 
   return {
@@ -244,6 +272,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
   private readonly cancelIdleTimer: CancelIdleTimer
   private readonly onIdleShutdown?: (kind: KernelProcessKind, env: string) => void
   private readonly onTerminated?: (kind: KernelProcessKind, env: string) => void
+  private readonly cancellationGraceMs: number
   private readonly platform: NodeJS.Platform
 
   constructor(options: NotebookKernelExecutorOptions = {}) {
@@ -255,6 +284,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
     this.cancelIdleTimer = options.cancelIdleTimer ?? defaultCancelIdleTimer
     this.onIdleShutdown = options.onIdleShutdown
     this.onTerminated = options.onTerminated
+    this.cancellationGraceMs = options.cancellationGraceMs ?? DEFAULT_CANCELLATION_GRACE_MS
     this.platform = options.platform ?? process.platform
   }
 
@@ -262,6 +292,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
   async execute(request: NotebookExecutionRequest): Promise<NotebookExecutionResult> {
     let workingFileObservation: WorkingFileObservation | undefined
     try {
+      if (request.signal?.aborted) throw new NotebookExecutionCancelledError()
       const kind = resolveProcessKind(request)
       const env = kind === 'repl' ? '' : resolveRequestEnv(kind, request)
       const key = resolveProcessKey(request)
@@ -274,7 +305,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
 
       workingFileObservation = await startWorkingFileObservation(request)
       const reqId = randomUUID()
-      const { response, timedOut } = await this.sendRequest(proc, reqId, request)
+      const { response, timedOut, cancelled } = await this.sendRequest(proc, reqId, request)
       const workingFiles = await workingFileObservation.finish()
       workingFileObservation = undefined
 
@@ -290,15 +321,23 @@ class NotebookKernelExecutor implements NotebookExecutor {
 
       // A soft-timeout interrupt was sent for this run; whatever answered is reported as a timeout,
       // not trusted as a genuine completion (an interrupt ack does not prove the loop stopped).
-      const status = timedOut ? 'timeout' : response.error !== null ? 'failed' : 'completed'
+      const status = cancelled
+        ? 'cancelled'
+        : timedOut
+          ? 'timeout'
+          : response.error !== null
+            ? 'failed'
+            : 'completed'
 
       return {
         status,
         stdout: mapped.stdout,
         stderr: mapped.stderr,
-        traceback: mapped.traceback,
+        traceback: cancelled ? '' : mapped.traceback,
         cwdAfter: response.cwd || request.cwd,
-        outputs: mapped.outputs,
+        outputs: cancelled
+          ? mapped.outputs.filter((output) => output.type !== 'error')
+          : mapped.outputs,
         workingFiles,
         environmentOverlay: response.environmentOverlay
       }
@@ -463,7 +502,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
       const pending = proc.pending
       this.rejectPending(
         proc,
-        pending?.timeout.timedOut
+        pending?.timeout?.timedOut && pending.timeoutMs !== undefined
           ? new NotebookExecutionTimeoutError(
               `Notebook execution timed out after ${pending.timeoutMs}ms.`
             )
@@ -604,39 +643,86 @@ class NotebookKernelExecutor implements NotebookExecutor {
     proc: ProcState,
     reqId: string,
     request: NotebookExecutionRequest
-  ): Promise<{ response: KernelLoopResponse; timedOut: boolean }> {
+  ): Promise<{ response: KernelLoopResponse; timedOut: boolean; cancelled: boolean }> {
     return new Promise((resolve, reject) => {
-      const timeoutMs = request.timeoutMs ?? DEFAULT_TIMEOUT_MS
-      const timeout = new TimeoutController({
-        // SIGINT (soft) goes to the direct loop so it can interrupt gracefully. The hard SIGKILL is
-        // routed through terminateProcessTree, which enumerates descendants BEFORE killing — so a
-        // grandchild the loop spawned is reaped too, not orphaned by a premature direct kill of the
-        // root (killing the root first would reparent its children away from any ps-walk).
-        kill: (signal) => {
-          if (signal === 'SIGKILL') this.killChildTracked(proc)
-          else proc.child.kill(signal)
-        },
-        onHardTimeout: () => {
-          // The tree kill was already initiated by kill('SIGKILL') above; here we just drop the wedged
-          // loop (next execute respawns), surface 'terminated', and fail this run.
-          if (proc.pending?.reqId !== reqId) return
-          proc.pending = undefined
-          this.dropProc(proc)
-          // The dropped proc is gone for good; surface it as 'terminated' (its exit handler no longer
-          // fires onTerminated because dropProc already removed it from the map).
-          this.onTerminated?.(proc.kind, proc.env)
-          reject(
-            new NotebookExecutionTimeoutError(`Notebook execution timed out after ${timeoutMs}ms.`)
-          )
-        }
-      })
+      if (request.signal?.aborted) {
+        reject(new NotebookExecutionCancelledError())
+        return
+      }
+      const timeoutMs = request.timeoutMs
+      const timeout =
+        timeoutMs === undefined
+          ? undefined
+          : new TimeoutController({
+              // SIGINT (soft) goes to the direct loop so it can interrupt gracefully. The hard
+              // SIGKILL is routed through terminateProcessTree, which reaps descendants too.
+              kill: (signal) => {
+                if (signal === 'SIGKILL') this.killChildTracked(proc)
+                else proc.child.kill(signal)
+              },
+              onHardTimeout: () => {
+                // Drop the wedged loop so the next execute respawns it, then fail this run.
+                if (proc.pending?.reqId !== reqId) return
+                this.clearPendingResources(proc.pending)
+                proc.pending = undefined
+                this.dropProc(proc)
+                this.onTerminated?.(proc.kind, proc.env)
+                reject(
+                  new NotebookExecutionTimeoutError(
+                    `Notebook execution timed out after ${timeoutMs}ms.`
+                  )
+                )
+              }
+            })
 
-      proc.pending = {
+      const pending: PendingRequest = {
         reqId,
-        resolve: (response) => resolve({ response, timedOut: timeout.timedOut }),
+        resolve: (response) =>
+          resolve({
+            response,
+            timedOut: timeout?.timedOut ?? false,
+            cancelled: pending.cancelled
+          }),
         reject,
+        cancelled: false,
+        signal: request.signal,
         timeout,
         timeoutMs
+      }
+      proc.pending = pending
+
+      if (request.signal) {
+        pending.abortListener = () => {
+          if (proc.pending !== pending || pending.cancelled) return
+          pending.cancelled = true
+          pending.timeout?.disarm()
+
+          // Node maps SIGINT to TerminateProcess on Windows, so it cannot preserve this headless
+          // kernel's namespace. Make that platform limitation explicit: drop and reap the whole
+          // process tree, mark the kernel terminated, and let the next execute lazily respawn it.
+          if (this.platform === 'win32') {
+            this.clearPendingResources(pending)
+            proc.pending = undefined
+            this.dropProc(proc)
+            this.killChildTracked(proc)
+            this.onTerminated?.(proc.kind, proc.env)
+            pending.reject(new NotebookExecutionCancelledError())
+            return
+          }
+
+          proc.child.kill('SIGINT')
+          pending.cancellationTimer = this.scheduleIdleTimer(() => {
+            pending.cancellationTimer = undefined
+            if (proc.pending !== pending) return
+            this.clearPendingResources(pending)
+            proc.pending = undefined
+            this.dropProc(proc)
+            this.killChildTracked(proc)
+            this.onTerminated?.(proc.kind, proc.env)
+            pending.reject(new NotebookExecutionCancelledError())
+          }, this.cancellationGraceMs)
+        }
+        request.signal.addEventListener('abort', pending.abortListener, { once: true })
       }
 
       if (proc.kind === 'r') {
@@ -645,7 +731,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
         // Python and the repl (JS) loop share the same JSON-lines request framing.
         proc.child.stdin.write(framePythonRequest(reqId, request.code, request.controlInvocationId))
       }
-      timeout.arm(timeoutMs)
+      if (timeout && timeoutMs !== undefined) timeout.arm(timeoutMs)
     })
   }
 
@@ -657,7 +743,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
     const pending = proc.pending
     if (!pending || pending.reqId !== response.reqId) return
 
-    pending.timeout.disarm()
+    this.clearPendingResources(pending)
     proc.pending = undefined
     pending.resolve(response)
     this.rearmIdleTimerIfLive(proc)
@@ -692,10 +778,21 @@ class NotebookKernelExecutor implements NotebookExecutor {
     const pending = proc.pending
     if (!pending) return
 
-    pending.timeout.disarm()
+    this.clearPendingResources(pending)
     proc.pending = undefined
-    pending.reject(error)
+    pending.reject(pending.cancelled ? new NotebookExecutionCancelledError() : error)
     this.rearmIdleTimerIfLive(proc)
+  }
+
+  private clearPendingResources(pending: PendingRequest): void {
+    pending.timeout?.disarm()
+    if (pending.cancellationTimer !== undefined) {
+      this.cancelIdleTimer(pending.cancellationTimer)
+      pending.cancellationTimer = undefined
+    }
+    if (pending.signal && pending.abortListener) {
+      pending.signal.removeEventListener('abort', pending.abortListener)
+    }
   }
 
   // Arms the idle-shutdown timer for a proc that just went idle (no pending request). A non-positive

--- a/src/main/notebook/local-rpc-notebook-adapter.test.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.test.ts
@@ -97,6 +97,24 @@ describe('notebook local RPC adapter', () => {
     }
   )
 
+  it.each(['runCell', 'execute'] as const)(
+    'forwards request cancellation to data execution method %s',
+    async (method) => {
+      const capability = createCapability()
+      const handler = resolveNotebookLocalRpcHandler(capability, method, request)
+      const cancellation = new AbortController()
+
+      await (
+        handler as unknown as (
+          request: Record<string, unknown>,
+          signal: AbortSignal
+        ) => Promise<unknown>
+      )(request, cancellation.signal)
+
+      expect(capability[method]).toHaveBeenCalledWith(request, cancellation.signal)
+    }
+  )
+
   it('validates common notebook routing fields before resolving a handler', () => {
     const capability = createCapability()
 

--- a/src/main/notebook/local-rpc-notebook-adapter.ts
+++ b/src/main/notebook/local-rpc-notebook-adapter.ts
@@ -26,8 +26,8 @@ type NotebookLocalRpcCapability = {
   beginCodeCell(request: BeginNotebookCodeCellRequest): Promise<unknown>
   appendCodeCell(request: AppendNotebookCodeCellRequest): Promise<unknown>
   finishCodeCell(request: FinishNotebookCodeCellRequest): Promise<unknown>
-  runCell(request: RunNotebookCellRequest): Promise<unknown>
-  execute(request: ExecuteNotebookCodeRequest): Promise<unknown>
+  runCell(request: RunNotebookCellRequest, signal?: AbortSignal): Promise<unknown>
+  execute(request: ExecuteNotebookCodeRequest, signal?: AbortSignal): Promise<unknown>
   executeControl(request: ExecuteNotebookControlRequest): Promise<unknown>
   executeShell(request: ExecuteShellRequest): Promise<unknown>
   state(request: NotebookSessionRequest): Promise<unknown>
@@ -61,7 +61,10 @@ const NOTEBOOK_LOCAL_RPC_METHODS = [
 ] as const
 
 type NotebookLocalRpcMethod = (typeof NOTEBOOK_LOCAL_RPC_METHODS)[number]
-type NotebookLocalRpcHandler = (request: Record<string, unknown>) => Promise<unknown>
+type NotebookLocalRpcHandler = (
+  request: Record<string, unknown>,
+  signal?: AbortSignal
+) => Promise<unknown>
 
 const NOTEBOOK_LOCAL_RPC_METHOD_SET = new Set<string>(NOTEBOOK_LOCAL_RPC_METHODS)
 const NOTEBOOK_INPUT_RUN_METHODS = new Set<NotebookLocalRpcMethod>([
@@ -102,9 +105,9 @@ const resolveNotebookLocalRpcHandler = (
     case 'finishCodeCell':
       return (request) => capability.finishCodeCell(request as FinishNotebookCodeCellRequest)
     case 'runCell':
-      return (request) => capability.runCell(request as RunNotebookCellRequest)
+      return (request, signal) => capability.runCell(request as RunNotebookCellRequest, signal)
     case 'execute':
-      return (request) => capability.execute(request as ExecuteNotebookCodeRequest)
+      return (request, signal) => capability.execute(request as ExecuteNotebookCodeRequest, signal)
     case 'executeControl':
       return (request) => capability.executeControl(request as ExecuteNotebookControlRequest)
     case 'executeShell':

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -117,6 +117,206 @@ describe('notebook local RPC server', () => {
     }
   })
 
+  it('injects only a fresh unambiguous app-owned execution authorization', async () => {
+    const server = new NotebookLocalRpcServer({
+      execute: vi.fn(async (request: unknown) => request),
+      executeControl: vi.fn(async (request: unknown) => request),
+      executeShell: vi.fn(async (request: unknown) => request)
+    } as never)
+    const connections: Array<Awaited<ReturnType<typeof server.issueSessionConnection>>> = []
+    const dispatch = async (
+      sessionId: string,
+      code = 'print(1)'
+    ): Promise<Record<string, unknown>> => {
+      const connection = await server.issueSessionConnection(
+        sessionId,
+        'project-1',
+        `root-frame-${sessionId}`
+      )
+      connections.push(connection)
+      const response = await fetchLocalRpc(
+        connection,
+        {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${connection.token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({
+            method: 'execute',
+            params: {
+              sessionId: 'forged',
+              workspaceCwd: '/workspace',
+              code,
+              executionInvocationId: 'caller-controlled'
+            }
+          })
+        },
+        'Notebook execution authorization test'
+      )
+      expect(response.status).toBe(200)
+      const payload = (await response.json()) as { result: Record<string, unknown> }
+      return payload.result
+    }
+
+    const setTurn = (sessionId: string, promptMessageId = 'prompt-1'): void =>
+      server.setArtifactProvenanceContext(sessionId, {
+        rootFrameId: `root-frame-${sessionId}`,
+        agentFrameId: `root-frame-${sessionId}`,
+        messageBranchId: 'branch-1',
+        runtimeSegmentId: 'runtime-1',
+        promptMessageId
+      })
+
+    try {
+      setTurn('fresh')
+      const freshId = server.authorizeExecution({
+        sessionId: 'fresh',
+        toolCallId: 'tool-fresh',
+        promptMessageId: 'prompt-1',
+        method: 'execute',
+        rawInput: { code: 'print(1)' }
+      })
+      expect(freshId).toEqual(expect.any(String))
+      expect(await dispatch('fresh')).toMatchObject({ executionInvocationId: freshId })
+
+      setTurn('missing')
+      expect(await dispatch('missing')).not.toHaveProperty('executionInvocationId')
+
+      setTurn('stale', 'current-prompt')
+      expect(
+        server.authorizeExecution({
+          sessionId: 'stale',
+          toolCallId: 'tool-stale',
+          promptMessageId: 'old-prompt',
+          method: 'execute',
+          rawInput: { code: 'print(1)' }
+        })
+      ).toBeUndefined()
+      expect(await dispatch('stale')).not.toHaveProperty('executionInvocationId')
+
+      setTurn('duplicate')
+      const firstId = server.authorizeExecution({
+        sessionId: 'duplicate',
+        toolCallId: 'tool-1',
+        promptMessageId: 'prompt-1',
+        method: 'execute',
+        rawInput: { code: 'print(1)' }
+      })
+      expect(
+        server.authorizeExecution({
+          sessionId: 'duplicate',
+          toolCallId: 'tool-1',
+          promptMessageId: 'prompt-1',
+          method: 'execute',
+          rawInput: { code: 'print(1)' }
+        })
+      ).toBe(firstId)
+      expect(
+        server.authorizeExecution({
+          sessionId: 'duplicate',
+          toolCallId: 'tool-2',
+          promptMessageId: 'prompt-1',
+          method: 'execute',
+          rawInput: { code: 'print(2)' }
+        })
+      ).toBeUndefined()
+      expect(await dispatch('duplicate')).not.toHaveProperty('executionInvocationId')
+
+      setTurn('mismatch')
+      server.authorizeExecution({
+        sessionId: 'mismatch',
+        toolCallId: 'tool-mismatch',
+        promptMessageId: 'prompt-1',
+        method: 'execute',
+        rawInput: { code: 'print(1)' }
+      })
+      expect(await dispatch('mismatch', 'print(2)')).not.toHaveProperty('executionInvocationId')
+      expect(await dispatch('mismatch')).not.toHaveProperty('executionInvocationId')
+
+      setTurn('repl-default')
+      const replId = server.authorizeExecution({
+        sessionId: 'repl-default',
+        toolCallId: 'tool-repl-default',
+        promptMessageId: 'prompt-1',
+        method: 'executeControl',
+        rawInput: { code: 'return 1' }
+      })
+      const replConnection = await server.issueSessionConnection(
+        'repl-default',
+        'project-1',
+        'root-frame-repl-default'
+      )
+      connections.push(replConnection)
+      const replResponse = await fetchLocalRpc(
+        replConnection,
+        {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${replConnection.token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({
+            method: 'executeControl',
+            params: {
+              sessionId: 'repl-default',
+              workspaceCwd: '/workspace',
+              code: 'return 1',
+              timeoutMs: 1_815_000
+            }
+          })
+        },
+        'Notebook execution RPC'
+      )
+      expect(replResponse.status).toBe(200)
+      expect(await replResponse.json()).toMatchObject({
+        result: { executionInvocationId: replId }
+      })
+
+      setTurn('shell-default')
+      const shellId = server.authorizeExecution({
+        sessionId: 'shell-default',
+        toolCallId: 'tool-shell-default',
+        promptMessageId: 'prompt-1',
+        method: 'executeShell',
+        rawInput: { command: 'echo hi' }
+      })
+      const shellConnection = await server.issueSessionConnection(
+        'shell-default',
+        'project-1',
+        'root-frame-shell-default'
+      )
+      connections.push(shellConnection)
+      const shellResponse = await fetchLocalRpc(
+        shellConnection,
+        {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${shellConnection.token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({
+            method: 'executeShell',
+            params: {
+              sessionId: 'shell-default',
+              workspaceCwd: '/workspace',
+              command: 'echo hi',
+              timeoutMs: 120_000
+            }
+          })
+        },
+        'Notebook execution RPC'
+      )
+      expect(shellResponse.status).toBe(200)
+      expect(await shellResponse.json()).toMatchObject({
+        result: { executionInvocationId: shellId }
+      })
+    } finally {
+      for (const connection of connections) connection.release?.()
+      await server.close()
+    }
+  })
+
   it('fails closed when a Session capability omits its Frame owner', async () => {
     const server = new NotebookLocalRpcServer({} as never)
 
@@ -337,6 +537,53 @@ describe('notebook local RPC server', () => {
       } finally {
         pendingCall.resolve(undefined)
         connection.release?.()
+        await server.close()
+      }
+    }
+  )
+
+  it.each(['tcp', 'pipe'] as const)(
+    'aborts notebook data execution when its client disconnects over %s',
+    async (transport) => {
+      const callStarted = createDeferred<AbortSignal>()
+      const pendingCall = createDeferred<unknown>()
+      const server = new NotebookLocalRpcServer(
+        {
+          execute: async (_request: unknown, signal?: AbortSignal) => {
+            if (!signal) throw new Error('Expected a notebook execution signal.')
+            callStarted.resolve(signal)
+            return pendingCall.promise
+          }
+        } as never,
+        { transport }
+      )
+      const connection = await server.ensureStarted()
+      const disconnect = new AbortController()
+
+      try {
+        const request = fetchLocalRpc(
+          connection,
+          {
+            method: 'POST',
+            headers: {
+              authorization: `Bearer ${connection.token}`,
+              'content-type': 'application/json'
+            },
+            body: JSON.stringify({
+              method: 'execute',
+              params: { sessionId: 'session-1', workspaceCwd: '/workspace', code: 'long()' }
+            }),
+            signal: disconnect.signal
+          },
+          'Notebook execution RPC'
+        )
+        const signal = await callStarted.promise
+        expect(signal.aborted).toBe(false)
+        disconnect.abort()
+        await expect(request).rejects.toMatchObject({ cause: expect.any(Error) })
+        await vi.waitFor(() => expect(signal.aborted).toBe(true))
+      } finally {
+        pendingCall.resolve(undefined)
         await server.close()
       }
     }

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -39,6 +39,11 @@ import {
   type TrustedControlInvocationIdentity
 } from '../../shared/agents-contract'
 import {
+  NOTEBOOK_REPL_DEFAULT_TIMEOUT_MS,
+  NOTEBOOK_SHELL_DEFAULT_TIMEOUT_MS,
+  type NotebookExecutionRpcMethod
+} from '../../shared/notebook'
+import {
   listenForLocalRpc,
   localRpcServerLogFields,
   type LocalRpcListenOptions
@@ -236,6 +241,13 @@ type NotebookRpcSessionBinding = {
   }
 }
 
+type NotebookExecutionAuthorization = Readonly<{
+  executionInvocationId: string
+  toolCallId: string
+  promptMessageId: string
+  inputFingerprint: string
+}>
+
 type DelegatedNotebookConnectionRequest = Readonly<{
   projectId: string
   sessionId: string
@@ -312,6 +324,44 @@ const isArtifactRpcMethod = (method: string): method is ArtifactRpcMethod =>
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
 
+// Session, prompt, method, and one-shot ownership are checked separately. This digest binds the
+// authorization to executable input so a racing same-method request cannot take another Tool's join.
+const notebookExecutionInputFingerprint = (
+  method: NotebookExecutionRpcMethod,
+  rawInput: unknown
+): string | undefined => {
+  const outer = isRecord(rawInput) ? rawInput : undefined
+  const input = isRecord(outer?.arguments) ? outer.arguments : outer
+  const executable = input?.[method === 'executeShell' ? 'command' : 'code']
+  if (typeof executable !== 'string') return undefined
+  const timeoutMs =
+    method === 'executeControl'
+      ? typeof input?.timeoutMs === 'number'
+        ? input.timeoutMs
+        : NOTEBOOK_REPL_DEFAULT_TIMEOUT_MS
+      : method === 'executeShell'
+        ? typeof input?.timeoutMs === 'number'
+          ? input.timeoutMs
+          : NOTEBOOK_SHELL_DEFAULT_TIMEOUT_MS
+        : null
+
+  return createHash('sha256')
+    .update(
+      JSON.stringify([
+        method,
+        executable,
+        timeoutMs,
+        method === 'execute' && typeof input?.language === 'string'
+          ? input.language.toLowerCase()
+          : method === 'execute'
+            ? 'python'
+            : null,
+        method === 'execute' && typeof input?.cellId === 'string' ? input.cellId : null
+      ])
+    )
+    .digest('hex')
+}
+
 // Reads the full HTTP request body and parses it as the notebook RPC payload.
 const readJsonBody = async (request: IncomingMessage): Promise<NotebookRpcPayload> => {
   const chunks: Buffer[] = []
@@ -377,6 +427,11 @@ class NotebookLocalRpcServer {
   private readonly inputRunLeaseIds = new WeakMap<NotebookInputRunLease, string>()
   private readonly artifactRpcCapabilities = new Map<string, ArtifactRpcCapability>()
   private readonly drainingArtifactRpcCapabilities = new Map<string, Promise<void>>()
+  private readonly executionAuthorizations = new Map<
+    string,
+    Map<NotebookExecutionRpcMethod, NotebookExecutionAuthorization | 'ambiguous'>
+  >()
+  private readonly consumedExecutionToolCalls = new Map<string, Set<string>>()
 
   constructor(
     private readonly service: NotebookLocalRpcCapability,
@@ -504,6 +559,8 @@ class NotebookLocalRpcServer {
     this.sessionRpcCapabilities.clear()
     this.sessionRpcTokens.clear()
     this.skillImportRpcTokens.clear()
+    this.executionAuthorizations.clear()
+    this.consumedExecutionToolCalls.clear()
 
     if (!server || !lifecycle) return Promise.resolve()
 
@@ -648,6 +705,8 @@ class NotebookLocalRpcServer {
     this.revokePlanSessionCapabilities(sessionId)
     for (const ownedSessionId of ownedSessionIds) {
       this.sessionSpecialists.delete(ownedSessionId)
+      this.executionAuthorizations.delete(ownedSessionId)
+      this.consumedExecutionToolCalls.delete(ownedSessionId)
     }
     for (const [aliasSessionId, targetSessionId] of this.sessionAliases) {
       if (ownedSessionIds.has(aliasSessionId) || ownedSessionIds.has(targetSessionId)) {
@@ -655,6 +714,82 @@ class NotebookLocalRpcServer {
       }
     }
     this.onSessionReleased?.(sessionId)
+  }
+
+  // Creates the app-owned half of an exact ACP-tool/Notebook-Run join before permission is released.
+  // The authenticated RPC bridge consumes it only for the matching method and active prompt. Two
+  // different unclaimed calls for the same lane become ambiguous and therefore never show running.
+  authorizeExecution(authorization: {
+    sessionId: string
+    toolCallId: string
+    promptMessageId: string
+    method: NotebookExecutionRpcMethod
+    rawInput?: unknown
+  }): string | undefined {
+    const sessionId = this.sessionAliases.get(authorization.sessionId) ?? authorization.sessionId
+    const inputFingerprint = notebookExecutionInputFingerprint(
+      authorization.method,
+      authorization.rawInput
+    )
+    if (
+      !inputFingerprint ||
+      this.artifactProvenanceContexts.get(sessionId)?.promptMessageId !==
+        authorization.promptMessageId ||
+      this.consumedExecutionToolCalls.get(sessionId)?.has(authorization.toolCallId)
+    ) {
+      return undefined
+    }
+
+    const byMethod = this.executionAuthorizations.get(sessionId) ?? new Map()
+    const existing = byMethod.get(authorization.method)
+    if (existing === 'ambiguous') return undefined
+    if (
+      existing?.toolCallId === authorization.toolCallId &&
+      existing.inputFingerprint === inputFingerprint
+    ) {
+      return existing.executionInvocationId
+    }
+    if (existing) {
+      byMethod.set(authorization.method, 'ambiguous')
+      this.executionAuthorizations.set(sessionId, byMethod)
+      return undefined
+    }
+
+    const executionInvocationId = randomUUID()
+    byMethod.set(authorization.method, {
+      executionInvocationId,
+      toolCallId: authorization.toolCallId,
+      promptMessageId: authorization.promptMessageId,
+      inputFingerprint
+    })
+    this.executionAuthorizations.set(sessionId, byMethod)
+    return executionInvocationId
+  }
+
+  private claimExecutionAuthorization(
+    sessionId: string,
+    method: string,
+    params: Record<string, unknown>
+  ): string | undefined {
+    if (method !== 'execute' && method !== 'executeControl' && method !== 'executeShell') {
+      return undefined
+    }
+    const byMethod = this.executionAuthorizations.get(sessionId)
+    const authorization = byMethod?.get(method)
+    byMethod?.delete(method)
+    if (byMethod?.size === 0) this.executionAuthorizations.delete(sessionId)
+    if (!authorization || authorization === 'ambiguous') return undefined
+    const consumed = this.consumedExecutionToolCalls.get(sessionId) ?? new Set<string>()
+    consumed.add(authorization.toolCallId)
+    this.consumedExecutionToolCalls.set(sessionId, consumed)
+    if (
+      this.artifactProvenanceContexts.get(sessionId)?.promptMessageId !==
+        authorization.promptMessageId ||
+      notebookExecutionInputFingerprint(method, params) !== authorization.inputFingerprint
+    ) {
+      return undefined
+    }
+    return authorization.executionInvocationId
   }
 
   async issueSessionConnection(
@@ -898,6 +1033,12 @@ class NotebookLocalRpcServer {
     context: NotebookRunProvenanceContext | undefined
   ): void {
     if (context) {
+      const previousPromptMessageId =
+        this.artifactProvenanceContexts.get(sessionId)?.promptMessageId
+      if (previousPromptMessageId && previousPromptMessageId !== context.promptMessageId) {
+        this.executionAuthorizations.delete(sessionId)
+        this.consumedExecutionToolCalls.delete(sessionId)
+      }
       this.artifactProvenanceContexts.set(sessionId, context)
       if (context.agentFrameId === context.rootFrameId) {
         for (const binding of this.sessionRpcCapabilities.values()) {
@@ -916,6 +1057,8 @@ class NotebookLocalRpcServer {
     } else {
       this.artifactProvenanceContexts.delete(sessionId)
       this.activeTurnProjectIds.delete(sessionId)
+      this.executionAuthorizations.delete(sessionId)
+      this.consumedExecutionToolCalls.delete(sessionId)
     }
   }
 
@@ -1260,7 +1403,8 @@ class NotebookLocalRpcServer {
       }
       // Resolve pre-session aliases before the runtime service looks up persistent state.
       if (method === 'planCall' && lifecycle.closing) disconnect.abort()
-      let resolvedParams = this.resolveSessionAlias(params)
+      let resolvedParams = { ...this.resolveSessionAlias(params) }
+      delete resolvedParams.executionInvocationId
       const authenticatedBinding = authenticatedSessionBinding
       if (authenticatedBinding?.delegatedNotebook && isNotebookLocalRpcMethod(method)) {
         resolvedParams = {
@@ -1303,6 +1447,24 @@ class NotebookLocalRpcServer {
           activeContext.agentFrameId !== authenticatedBinding.agentFrameId
         ) {
           throw new RpcHttpError(403, 'Notebook RPC capability does not match active Agent Frame.')
+        }
+      }
+      if (
+        authenticatedBinding &&
+        !authenticatedBinding.delegatedNotebook &&
+        !authenticatedBinding.isControl &&
+        authenticatedBinding.delegatedWorkRole === 'main' &&
+        !authenticatedBinding.allowedMethods &&
+        typeof resolvedParams.sessionId === 'string' &&
+        (method === 'execute' || method === 'executeControl' || method === 'executeShell')
+      ) {
+        const executionInvocationId = this.claimExecutionAuthorization(
+          resolvedParams.sessionId,
+          method,
+          resolvedParams
+        )
+        if (executionInvocationId) {
+          resolvedParams = { ...resolvedParams, executionInvocationId }
         }
       }
       const result =
@@ -2034,11 +2196,14 @@ class NotebookLocalRpcServer {
       this.inputRunLeaseIds.set(lease, inputRunLeaseId)
       this.activeInputRunLeases.set(sessionId, leases)
       try {
-        return await handler({
-          ...params,
-          registeredInputFiles: lease.getRunInputFiles(),
-          inputRunLeaseId
-        })
+        return await handler(
+          {
+            ...params,
+            registeredInputFiles: lease.getRunInputFiles(),
+            inputRunLeaseId
+          },
+          signal
+        )
       } finally {
         lease.close()
         leases.delete(lease)
@@ -2047,7 +2212,7 @@ class NotebookLocalRpcServer {
       }
     }
 
-    return handler(params)
+    return handler(params, signal)
   }
 
   // Rewrites the temporary notebook session id to the final ACP session id when needed.

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -29,6 +29,7 @@ import {
   compactRestartResult,
   createNotebookMcpEnvironmentFromProcess,
   createNotebookMcpServerConfig,
+  resolveNotebookRpcFetch,
   serializeNotebookToolResult
 } from './mcp-server'
 
@@ -327,6 +328,14 @@ describe('notebook_execute tool', () => {
     })
   })
 
+  it('does not expose a hidden execution deadline to the agent', () => {
+    expect(tool).toBeDefined()
+    expect(Object.keys(tool?.inputSchema ?? {})).not.toContain('timeoutMs')
+
+    const schema = z.object(tool?.inputSchema ?? {})
+    expect(schema.parse({ code: 'print(1)', timeoutMs: 5 })).toEqual({ code: 'print(1)' })
+  })
+
   it('forwards the selected language straight through to the execute RPC call', async () => {
     const environment = {
       endpoint: 'http://127.0.0.1:4567',
@@ -338,34 +347,71 @@ describe('notebook_execute tool', () => {
     // The MCP tool handler passes schema-validated input straight to callNotebookRpc as the
     // RPC params, so asserting the call helper forwards `language` covers the handler wiring.
     const fetchCalls: Array<{ body: string }> = []
-    const originalFetch = globalThis.fetch
-    globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    const fetchRpc = async (_environment: unknown, init: RequestInit): Promise<Response> => {
       fetchCalls.push({ body: String(init?.body ?? '') })
       return {
         ok: true,
         json: async () => ({ result: { ok: true } })
       } as Response
-    }) as typeof fetch
+    }
 
-    try {
-      const result = await callNotebookRpc(environment, 'execute', {
+    const result = await callNotebookRpc(
+      environment,
+      'execute',
+      {
         code: '1 + 1',
         language: 'r',
         projectId: 'forged-project',
         sessionId: 'forged-session'
-      })
+      },
+      fetchRpc
+    )
 
-      expect(result).toEqual({ ok: true })
-      expect(fetchCalls).toHaveLength(1)
-      const sentBody = JSON.parse(fetchCalls[0].body) as {
-        params: { language?: string; projectId?: string; sessionId?: string }
-      }
-      expect(sentBody.params.language).toBe('r')
-      expect(sentBody.params.projectId).toBe('default-project')
-      expect(sentBody.params.sessionId).toBe('session-1')
-    } finally {
-      globalThis.fetch = originalFetch
+    expect(result).toEqual({ ok: true })
+    expect(fetchCalls).toHaveLength(1)
+    const sentBody = JSON.parse(fetchCalls[0].body) as {
+      params: { language?: string; projectId?: string; sessionId?: string }
     }
+    expect(sentBody.params.language).toBe('r')
+    expect(sentBody.params.projectId).toBe('default-project')
+    expect(sentBody.params.sessionId).toBe('session-1')
+  })
+
+  it.each([
+    ['execute', true],
+    ['executeControl', false],
+    ['executeShell', false],
+    ['state', true]
+  ] as const)(
+    'forwards MCP cancellation for %s only when the RPC consumes it',
+    async (method, forwards) => {
+      const environment = {
+        endpoint: 'http://127.0.0.1:4567',
+        token: 'secret-token',
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        workspaceCwd: '/workspace'
+      }
+      const cancellation = new AbortController()
+      let forwardedSignal: AbortSignal | null | undefined
+      const fetchRpc = async (_environment: unknown, init: RequestInit): Promise<Response> => {
+        forwardedSignal = init.signal
+        return {
+          ok: true,
+          json: async () => ({ result: { ok: true } })
+        } as Response
+      }
+
+      await callNotebookRpc(environment, method, { code: '1 + 1' }, fetchRpc, cancellation.signal)
+
+      expect(forwardedSignal).toBe(forwards ? cancellation.signal : undefined)
+    }
+  )
+
+  it('uses the unbounded transport only for Python/R execution', () => {
+    expect(resolveNotebookRpcFetch('execute').name).toBe('fetchLongLivedLocalRpc')
+    expect(resolveNotebookRpcFetch('state').name).toBe('fetchLocalRpc')
+    expect(resolveNotebookRpcFetch('executeControl').name).toBe('fetchLocalRpc')
   })
 })
 

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -11,17 +11,18 @@ import {
   MIN_AGENT_USER_CHOICE_OPTIONS
 } from '../../shared/elicitation'
 import { NOTEBOOK_MCP_SERVER_ARG } from '../mcp-server-args'
-import { fetchLocalRpc, type LocalRpcTransport } from '../local-rpc-transport'
+import {
+  fetchLocalRpc,
+  fetchLongLivedLocalRpc,
+  type LocalRpcTransport
+} from '../local-rpc-transport'
 import { resolveProjectId } from '../../shared/project-scope'
 import type { ProjectIdScope } from '../../shared/project-scope'
+import { NOTEBOOK_REPL_DEFAULT_TIMEOUT_MS } from '../../shared/notebook'
 
 const NOTEBOOK_MCP_SERVER_NAME = 'open-science-notebook'
 const MAX_RUNTIME_RESULTS = 40
 const MAX_ENVIRONMENT_RESULTS = 30
-// Host SDK bounded observations allow 30 minutes. Keep the outer control REPL alive slightly longer
-// so its default deadline cannot destroy the kernel while collect/message_receipt is still valid.
-const REPL_EXECUTE_DEFAULT_TIMEOUT_MS = 30 * 60 * 1_000 + 15_000
-
 const HOST_SDK_DISCOVERY_GUIDANCE =
   "Host SDK discovery (use from `repl_execute`): `await host.help()` is the role-aware catalog. Query only the operation you plan to call; each topic returns concise parameter and result field descriptions. Main/root agents can use `await host.help('delegate')` when delegation guidance is needed; do not prefetch all Help topics. Delegate agents should use the same catalog for messaging and structured-output operations; unavailable root-only topics remain visible with a reason."
 
@@ -61,7 +62,6 @@ type NotebookMcpServerConfigRequest = NotebookMcpEnvironment & {
 
 const executeToolSchema = {
   code: z.string(),
-  timeoutMs: z.number().int().positive().optional(),
   cellId: z.string().min(1).optional(),
   language: z.enum(['python', 'r']).optional()
   // No `environment`: the env is the session's bound runtime (notebook_bind_runtime), not a per-call
@@ -70,7 +70,7 @@ const executeToolSchema = {
 
 const replExecuteToolSchema = {
   code: z.string(),
-  timeoutMs: z.number().int().positive().default(REPL_EXECUTE_DEFAULT_TIMEOUT_MS)
+  timeoutMs: z.number().int().positive().default(NOTEBOOK_REPL_DEFAULT_TIMEOUT_MS)
 }
 
 const bashExecuteToolSchema = {
@@ -235,6 +235,12 @@ type NotebookRpcToolDefinition = {
   resultLimitChars?: number
 }
 
+const notebookRpcSignal = (
+  method: string,
+  signal: AbortSignal | undefined
+): AbortSignal | undefined =>
+  method === 'executeControl' || method === 'executeShell' ? undefined : signal
+
 // Creates the ACP MCP-server declaration that launches this app bundle in notebook stdio mode.
 const createNotebookMcpServerConfig = (request: NotebookMcpServerConfigRequest): McpServerStdio => {
   const projectId = resolveProjectId(request)
@@ -294,10 +300,12 @@ const createNotebookMcpEnvironmentFromProcess = (
 const callNotebookRpc = async (
   environment: NotebookMcpEnvironment,
   method: string,
-  params: unknown = {}
+  params: unknown = {},
+  fetchRpc: typeof fetchLocalRpc = resolveNotebookRpcFetch(method),
+  signal?: AbortSignal
 ): Promise<unknown> => {
   const projectId = resolveProjectId(environment)
-  const response = await fetchLocalRpc(
+  const response = await fetchRpc(
     environment,
     {
       method: 'POST',
@@ -313,7 +321,11 @@ const callNotebookRpc = async (
           workspaceCwd: environment.workspaceCwd,
           projectId
         }
-      } satisfies RpcRequest)
+      } satisfies RpcRequest),
+      // Control REPL and shell execution do not yet consume cancellation below the RPC boundary.
+      // Keep their transport attached so Agent cancellation cannot report completion while they
+      // continue mutating state. Python/R execution owns its AbortSignal end to end.
+      signal: notebookRpcSignal(method, signal)
     },
     'Notebook RPC'
   )
@@ -326,6 +338,11 @@ const callNotebookRpc = async (
 
   return payload.result
 }
+
+// Python/R cells are intentionally unbounded. Only their local RPC hop needs the transport that
+// omits Undici's response-headers deadline; short control methods retain the ordinary transport.
+const resolveNotebookRpcFetch = (method: string): typeof fetchLocalRpc =>
+  method === 'execute' ? fetchLongLivedLocalRpc : fetchLocalRpc
 
 // These character caps apply only to serialized MCP replies; full values stay in run.json and the
 // notebook preview.
@@ -719,7 +736,13 @@ const registerNotebookRpcTool = (
         definition.method === 'requestUserInput'
           ? { ...input, _appToolRequestId: String(extra.requestId) }
           : input
-      const raw = await callNotebookRpc(environment, definition.method, rpcInput)
+      const raw = await callNotebookRpc(
+        environment,
+        definition.method,
+        rpcInput,
+        resolveNotebookRpcFetch(definition.method),
+        extra.signal
+      )
       const result = definition.mapResult ? definition.mapResult(raw, input) : raw
       return {
         content: [
@@ -1086,6 +1109,7 @@ export {
   NOTEBOOK_RPC_TOOLS,
   NOTEBOOK_SYSTEM_PROMPT_APPEND,
   callNotebookRpc,
+  resolveNotebookRpcFetch,
   compactNotebookExecutionResult,
   compactNotebookStateResult,
   compactManagePackagesResult,

--- a/src/main/notebook/notebook-workflows.ts
+++ b/src/main/notebook/notebook-workflows.ts
@@ -72,8 +72,15 @@ const withoutTrustedTurnContext = <
 >(
   request: Request
 ): Request => {
-  const { provenanceContext, registeredInputFiles, inputRunLeaseId, ...publicRequest } = request
+  const {
+    provenanceContext,
+    executionInvocationId,
+    registeredInputFiles,
+    inputRunLeaseId,
+    ...publicRequest
+  } = request
   void provenanceContext
+  void executionInvocationId
   void registeredInputFiles
   void inputRunLeaseId
   return publicRequest as Request

--- a/src/main/notebook/run-terminalization.test.ts
+++ b/src/main/notebook/run-terminalization.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type {
   NotebookEnvironmentManifest,
@@ -58,9 +58,9 @@ const documentWith = (runs: NotebookRunRecord[]): NotebookRunDocument => ({
 })
 
 const completedResult = (
-  status: NotebookRunStatus = 'completed'
+  status: Exclude<NotebookRunStatus, 'queued' | 'running'> = 'completed'
 ): {
-  status: NotebookRunStatus
+  status: Exclude<NotebookRunStatus, 'queued' | 'running'>
   stdout: string
   stderr: string
   traceback: string
@@ -98,6 +98,7 @@ const createHarness = (
     now?: () => number
     appendFailure?: Error
     updateFailure?: Error
+    updateFailureCount?: number
     omitUpdatedRun?: boolean
   } = {}
 ): {
@@ -107,6 +108,7 @@ const createHarness = (
 } => {
   const events: string[] = []
   let document = documentWith([])
+  let updateFailuresRemaining = options.updateFailureCount ?? Number.POSITIVE_INFINITY
   const owner = new NotebookRunTerminalizationOwner({
     repository: {
       appendRun: async ({ run }) => {
@@ -117,7 +119,10 @@ const createHarness = (
       },
       updateRun: async ({ run }) => {
         events.push(`update:${run.status}`)
-        if (options.updateFailure) throw options.updateFailure
+        if (options.updateFailure && updateFailuresRemaining > 0) {
+          updateFailuresRemaining -= 1
+          throw options.updateFailure
+        }
         document = documentWith(
           document.runs.map((candidate) => (candidate.runId === run.runId ? run : candidate))
         )
@@ -155,7 +160,7 @@ describe('NotebookRunTerminalizationOwner', () => {
     })
   })
 
-  it('commits one terminal record before post-commit work and the final notification', async () => {
+  it('commits one terminal record before settling live ownership and the final notification', async () => {
     const harness = createHarness()
     const running = runningRun('run-1')
 
@@ -166,8 +171,8 @@ describe('NotebookRunTerminalizationOwner', () => {
         harness.events.push('invoke')
         return completedResult()
       },
-      postCommit: (result, run) => {
-        harness.events.push(`post-commit:${result.status}:${run.status}`)
+      settleLive: (result) => {
+        harness.events.push(`settle-live:${result.status}`)
       }
     })
 
@@ -176,7 +181,7 @@ describe('NotebookRunTerminalizationOwner', () => {
       'notify:running',
       'invoke',
       'update:completed',
-      'post-commit:completed:completed',
+      'settle-live:completed',
       'notify:completed'
     ])
     const document = harness.document()
@@ -190,6 +195,33 @@ describe('NotebookRunTerminalizationOwner', () => {
     })
     expect(terminalized.run).toEqual(document.runs[0])
     expect(terminalized.result.status).toBe('completed')
+  })
+
+  it('keeps an admitted Run running across hours without an elapsed-time transition', async () => {
+    vi.useFakeTimers()
+    try {
+      const harness = createHarness()
+      let finish!: (result: ReturnType<typeof completedResult>) => void
+      const result = new Promise<ReturnType<typeof completedResult>>((resolve) => {
+        finish = resolve
+      })
+      const execution = harness.owner.run({
+        session,
+        runningRun: runningRun('run-hours'),
+        invoke: () => result
+      })
+      await vi.waitFor(() => expect(harness.document().runs[0]?.status).toBe('running'))
+
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1_000)
+      expect(harness.document().runs[0]?.status).toBe('running')
+      expect(harness.events).not.toContainEqual(expect.stringMatching(/^update:/))
+
+      finish(completedResult())
+      await execution
+      expect(harness.document().runs[0]?.status).toBe('completed')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it.each(['failed', 'timeout', 'cancelled'] as const)(
@@ -265,7 +297,7 @@ describe('NotebookRunTerminalizationOwner', () => {
     expect(unavailable.document().runs[0]).not.toHaveProperty('environmentManifestChecksum')
   })
 
-  it('keeps the running record when invocation rejects unexpectedly', async () => {
+  it('terminalizes an unexpected invocation rejection as interrupted before rethrowing', async () => {
     const harness = createHarness()
 
     await expect(
@@ -275,15 +307,33 @@ describe('NotebookRunTerminalizationOwner', () => {
         invoke: async () => {
           harness.events.push('invoke')
           throw new Error('unexpected rejection')
-        }
+        },
+        settleLive: (result) => harness.events.push(`settle-live:${result.status}`)
       })
     ).rejects.toThrow('unexpected rejection')
 
-    expect(harness.events).toEqual(['append:running', 'notify:running', 'invoke'])
-    expect(harness.document().runs[0]).toMatchObject({ runId: 'run-rejected', status: 'running' })
+    expect(harness.events).toEqual([
+      'append:running',
+      'notify:running',
+      'invoke',
+      'update:interrupted',
+      'settle-live:interrupted',
+      'notify:interrupted'
+    ])
+    expect(harness.document().runs[0]).toMatchObject({
+      runId: 'run-rejected',
+      status: 'interrupted',
+      endedAt: 200,
+      interruptionReason: 'execution-error',
+      text: {
+        stderr: 'unexpected rejection',
+        plain: ['unexpected rejection']
+      },
+      environmentCapture: { state: 'unavailable', reason: 'environment-capture-failed' }
+    })
   })
 
-  it('does not invoke or notify when the initial append fails', async () => {
+  it('settles live ownership without invoking when the initial append fails', async () => {
     const harness = createHarness({ appendFailure: new Error('append failed') })
 
     await expect(
@@ -293,33 +343,80 @@ describe('NotebookRunTerminalizationOwner', () => {
         invoke: async () => {
           harness.events.push('invoke')
           return completedResult()
-        }
+        },
+        settleLive: (result) => harness.events.push(`settle-live:${result.status}`)
       })
     ).rejects.toThrow('append failed')
 
-    expect(harness.events).toEqual(['append:running'])
+    expect(harness.events).toEqual([
+      'append:running',
+      'settle-live:interrupted',
+      'notify:undefined'
+    ])
     expect(harness.document().runs).toEqual([])
   })
 
-  it('keeps the running record when the terminal update fails', async () => {
+  it('releases live ownership when the terminal update fails', async () => {
     const harness = createHarness({ updateFailure: new Error('update failed') })
 
     await expect(
       harness.owner.run({
         session,
         runningRun: runningRun('run-update-failed'),
-        invoke: async () => completedResult()
+        invoke: async () => completedResult(),
+        settleLive: (result) => harness.events.push(`settle-live:${result.status}`)
       })
     ).rejects.toThrow('update failed')
 
-    expect(harness.events).toEqual(['append:running', 'notify:running', 'update:completed'])
+    expect(harness.events).toEqual([
+      'append:running',
+      'notify:running',
+      'update:completed',
+      'settle-live:completed',
+      'notify:running'
+    ])
     expect(harness.document().runs[0]).toMatchObject({
       runId: 'run-update-failed',
       status: 'running'
     })
   })
 
-  it('leaves the terminal update committed when post-commit work fails', async () => {
+  it('retries a pending terminal write in the same process on later reconciliation', async () => {
+    const harness = createHarness({
+      updateFailure: new Error('transient update failure'),
+      updateFailureCount: 1
+    })
+
+    await expect(
+      harness.owner.run({
+        session,
+        runningRun: runningRun('run-retry'),
+        invoke: async () => completedResult(),
+        settleLive: (result) => harness.events.push(`settle-live:${result.status}`)
+      })
+    ).rejects.toThrow('transient update failure')
+
+    expect(harness.document().runs[0]?.status).toBe('running')
+
+    await harness.owner.reconcilePending(session)
+
+    expect(harness.document().runs[0]).toMatchObject({
+      runId: 'run-retry',
+      status: 'completed',
+      endedAt: 200
+    })
+    expect(harness.events).toEqual([
+      'append:running',
+      'notify:running',
+      'update:completed',
+      'settle-live:completed',
+      'notify:running',
+      'update:completed',
+      'notify:completed'
+    ])
+  })
+
+  it('leaves the terminal update committed when settling live ownership fails', async () => {
     const harness = createHarness()
 
     await expect(
@@ -327,18 +424,19 @@ describe('NotebookRunTerminalizationOwner', () => {
         session,
         runningRun: runningRun('run-post-commit-failed'),
         invoke: async () => completedResult(),
-        postCommit: () => {
-          harness.events.push('post-commit')
-          throw new Error('post-commit failed')
+        settleLive: () => {
+          harness.events.push('settle-live')
+          throw new Error('settle-live failed')
         }
       })
-    ).rejects.toThrow('post-commit failed')
+    ).rejects.toThrow('settle-live failed')
 
     expect(harness.events).toEqual([
       'append:running',
       'notify:running',
       'update:completed',
-      'post-commit'
+      'settle-live',
+      'notify:completed'
     ])
     expect(harness.document().runs[0]).toMatchObject({
       runId: 'run-post-commit-failed',
@@ -357,6 +455,11 @@ describe('NotebookRunTerminalizationOwner', () => {
       })
     ).rejects.toThrow('Notebook run not found after update: run-missing')
 
-    expect(harness.events).toEqual(['append:running', 'notify:running', 'update:completed'])
+    expect(harness.events).toEqual([
+      'append:running',
+      'notify:running',
+      'update:completed',
+      'notify:completed'
+    ])
   })
 })

--- a/src/main/notebook/run-terminalization.ts
+++ b/src/main/notebook/run-terminalization.ts
@@ -7,7 +7,7 @@ import type {
   NotebookWorkingFile
 } from '../../shared/notebook'
 import type { NotebookRunRepository } from './repository'
-import type { NotebookLaneIdentity } from './lane-identity'
+import { notebookLaneKey, type NotebookLaneIdentity } from './lane-identity'
 
 type NotebookRunIdentity = Readonly<{
   runId: string
@@ -21,7 +21,7 @@ type NotebookRunTerminalizationSession = Readonly<{
 }>
 
 type NotebookRunTerminalResult = {
-  status: NotebookRunStatus
+  status: Exclude<NotebookRunStatus, 'queued' | 'running'>
   stdout: string
   stderr: string
   traceback: string
@@ -37,7 +37,7 @@ type TerminalizeNotebookRunRequest<Result extends NotebookRunTerminalResult> = {
   session: NotebookRunTerminalizationSession
   runningRun: NotebookRunRecord
   invoke: () => Promise<Result>
-  postCommit?: (result: Result, run: NotebookRunRecord) => void
+  settleLive?: (result: NotebookRunTerminalResult) => void
 }
 
 type NotebookRunTerminalizationOwnerOptions = {
@@ -49,9 +49,20 @@ type NotebookRunTerminalizationOwnerOptions = {
 const outputPlainText = (stdout: string, stderr: string): string[] =>
   [stdout, stderr].filter((text) => text.trim().length > 0)
 
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
 class NotebookRunTerminalizationOwner {
   private sequence = 0
   private readonly now: () => number
+  private readonly pendingTerminalRuns = new Map<
+    string,
+    Readonly<{
+      session: NotebookRunTerminalizationSession
+      run: NotebookRunRecord
+    }>
+  >()
+  private readonly terminalRecoveryByLane = new Map<string, Promise<void>>()
 
   constructor(private readonly options: NotebookRunTerminalizationOwnerOptions) {
     this.now = options.now ?? (() => Date.now())
@@ -70,15 +81,93 @@ class NotebookRunTerminalizationOwner {
   ): Promise<{ run: NotebookRunRecord; result: Result }> {
     const { session, runningRun } = request
     const lane = session.lane
-    await this.options.repository.appendRun({
-      projectName: session.projectId,
-      sessionId: session.sessionId,
-      lane,
-      run: runningRun
-    })
-    this.options.notifyChanged(session)
+    let liveResult: NotebookRunTerminalResult | undefined
+    try {
+      await this.reconcilePending(session)
+      await this.options.repository.appendRun({
+        projectName: session.projectId,
+        sessionId: session.sessionId,
+        lane,
+        run: runningRun
+      })
+      this.options.notifyChanged(session)
 
-    const result = await request.invoke()
+      let result: Result
+      try {
+        result = await request.invoke()
+      } catch (error) {
+        liveResult = {
+          status: 'interrupted',
+          stdout: '',
+          stderr: errorMessage(error),
+          traceback: '',
+          cwdAfter: runningRun.cwdBefore,
+          outputs: []
+        }
+        await this.commitOrRememberTerminalRun(
+          session,
+          this.buildTerminalRun(runningRun, liveResult, 'execution-error')
+        )
+        throw error
+      }
+      liveResult = result
+      const terminalRun = this.buildTerminalRun(runningRun, result)
+      const run = await this.commitOrRememberTerminalRun(session, terminalRun)
+
+      return { run, result }
+    } catch (error) {
+      liveResult ??= {
+        status: 'interrupted',
+        stdout: '',
+        stderr: errorMessage(error),
+        traceback: '',
+        cwdAfter: runningRun.cwdBefore,
+        outputs: []
+      }
+      throw error
+    } finally {
+      try {
+        if (liveResult) request.settleLive?.(liveResult)
+      } finally {
+        if (liveResult) this.options.notifyChanged(session)
+      }
+    }
+  }
+
+  // A transient final-write failure must not require an app restart to repair. The Notebook state
+  // poll and the next execution both re-enter here; each caller joins one bounded retry per lane.
+  async reconcilePending(session: NotebookRunTerminalizationSession): Promise<void> {
+    const laneKey = notebookLaneKey(session.lane)
+    const pending = Array.from(this.pendingTerminalRuns.entries()).filter(
+      ([, candidate]) => notebookLaneKey(candidate.session.lane) === laneKey
+    )
+    if (pending.length === 0) return
+
+    const activeRecovery = this.terminalRecoveryByLane.get(laneKey)
+    if (activeRecovery) return activeRecovery
+
+    const recovery = (async () => {
+      for (const [pendingKey, candidate] of pending) {
+        await this.commitTerminalRun(candidate.session, candidate.run)
+        if (this.pendingTerminalRuns.get(pendingKey) === candidate) {
+          this.pendingTerminalRuns.delete(pendingKey)
+        }
+        this.options.notifyChanged(candidate.session)
+      }
+    })().finally(() => {
+      if (this.terminalRecoveryByLane.get(laneKey) === recovery) {
+        this.terminalRecoveryByLane.delete(laneKey)
+      }
+    })
+    this.terminalRecoveryByLane.set(laneKey, recovery)
+    return recovery
+  }
+
+  private buildTerminalRun(
+    runningRun: NotebookRunRecord,
+    result: NotebookRunTerminalResult,
+    interruptionReason?: NotebookRunRecord['interruptionReason']
+  ): NotebookRunRecord {
     const environmentCapture: NotebookRunEnvironmentCapture =
       result.environmentCapture ??
       (runningRun.kernelKind === 'python' || runningRun.kernelKind === 'r'
@@ -100,6 +189,7 @@ class NotebookRunTerminalizationOwner {
       outputs: result.outputs,
       workingFiles: result.workingFiles ?? [],
       environmentCapture,
+      ...(interruptionReason ? { interruptionReason } : {}),
       ...(environmentCapture.state !== 'unavailable' && result.environmentManifest
         ? { environmentManifest: result.environmentManifest }
         : {}),
@@ -107,22 +197,41 @@ class NotebookRunTerminalizationOwner {
         ? { environmentManifestChecksum: result.environmentManifestChecksum }
         : {})
     }
+    return terminalRun
+  }
+
+  private async commitTerminalRun(
+    session: NotebookRunTerminalizationSession,
+    terminalRun: NotebookRunRecord
+  ): Promise<NotebookRunRecord> {
     const document = await this.options.repository.updateRun({
       projectName: session.projectId,
       sessionId: session.sessionId,
-      lane,
+      lane: session.lane,
       run: terminalRun
     })
-    const run = document.runs.find((candidate) => candidate.runId === runningRun.runId)
+    const run = document.runs.find((candidate) => candidate.runId === terminalRun.runId)
 
     if (!run) {
-      throw new Error(`Notebook run not found after update: ${runningRun.runId}`)
+      throw new Error(`Notebook run not found after update: ${terminalRun.runId}`)
     }
 
-    request.postCommit?.(result, run)
-    this.options.notifyChanged(session)
+    return run
+  }
 
-    return { run, result }
+  private async commitOrRememberTerminalRun(
+    session: NotebookRunTerminalizationSession,
+    terminalRun: NotebookRunRecord
+  ): Promise<NotebookRunRecord> {
+    try {
+      return await this.commitTerminalRun(session, terminalRun)
+    } catch (error) {
+      this.pendingTerminalRuns.set(`${notebookLaneKey(session.lane)}:${terminalRun.runId}`, {
+        session,
+        run: terminalRun
+      })
+      throw error
+    }
   }
 }
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -65,6 +65,17 @@ const createStorageRoot = async (): Promise<string> => {
   return storageRoot
 }
 
+const createDeferred = <Value>(): {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+} => {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
 afterEach(async () => {
   vi.unstubAllEnvs()
   if (storageRoot) {
@@ -498,6 +509,116 @@ describe('notebook runtime service', () => {
     })
   })
 
+  it('persists an Agent-cancelled data execution as a cancelled run', async () => {
+    const root = await createStorageRoot()
+    const executionStarted = createDeferred<NotebookExecutionRequest>()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      environmentStateTracker: verifiedPackageMutationTracker(),
+      executorFactory: () => ({
+        execute: async (request) => {
+          executionStarted.resolve(request)
+          await new Promise<void>((resolve) => {
+            request.signal?.addEventListener('abort', () => resolve(), { once: true })
+          })
+          return {
+            status: 'cancelled',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }
+        },
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    const cancellation = new AbortController()
+    const run = service.execute(
+      {
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        code: 'long_running_analysis()'
+      },
+      cancellation.signal
+    )
+    const execution = await executionStarted.promise
+
+    expect(execution.signal).toBe(cancellation.signal)
+    cancellation.abort()
+
+    await expect(run).resolves.toMatchObject({ status: 'cancelled' })
+    await expect(
+      service.state({ sessionId: 'session-1', workspaceCwd: root })
+    ).resolves.toMatchObject({
+      cells: [
+        expect.objectContaining({
+          status: 'cancelled'
+        })
+      ],
+      runs: [
+        expect.objectContaining({
+          status: 'cancelled',
+          script: 'long_running_analysis()'
+        })
+      ]
+    })
+    const runJson = JSON.parse(
+      await readFile(join(root, 'notebooks', 'default-project', 'session-1', 'run.json'), 'utf8')
+    ) as { runs: Array<{ status: string }> }
+    expect(runJson.runs).toEqual([expect.objectContaining({ status: 'cancelled' })])
+  })
+
+  it('repairs a transient terminal write failure on the next same-process state read', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    vi.spyOn(repository, 'updateRun').mockRejectedValueOnce(
+      new Error('transient terminal write failure')
+    )
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository,
+      executorFactory: () => ({
+        execute: async (request) => ({
+          status: 'completed',
+          stdout: 'done\n',
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+
+    await expect(
+      service.execute({
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        code: 'print("done")'
+      })
+    ).rejects.toThrow('transient terminal write failure')
+
+    const state = await service.state({
+      projectName: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: root
+    })
+
+    expect(state.runs).toEqual([
+      expect.objectContaining({
+        status: 'completed',
+        text: expect.objectContaining({ stdout: 'done\n' })
+      })
+    ])
+  })
+
   it('does not invoke the executor when the initial running record cannot be persisted', async () => {
     const root = await createStorageRoot()
     const repository = new NotebookRunRepository(root)
@@ -543,10 +664,10 @@ describe('notebook runtime service', () => {
     expect(execute).not.toHaveBeenCalled()
     const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
     expect(state.runs).toEqual([])
-    expect(state.activeRunId).toMatch(/^notebook-run-/)
+    expect(state.activeRunId).toBeUndefined()
   })
 
-  it('leaves the running record recoverable when its terminal update cannot be persisted', async () => {
+  it('releases live ownership while leaving the running record recoverable when its terminal update cannot be persisted', async () => {
     const root = await createStorageRoot()
     const repository = new NotebookRunRepository(root)
     const updateError = new Error('could not persist terminal run')
@@ -606,8 +727,9 @@ describe('notebook runtime service', () => {
       status: 'running',
       script: 'print("done")'
     })
-    const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
-    expect(state.activeRunId).toBe(document.runs[0]?.runId)
+    await expect(service.state({ sessionId: 'session-1', workspaceCwd: root })).rejects.toBe(
+      updateError
+    )
   })
 
   it('persists a fail-closed default-runtime admission without dispatching or capturing evidence', async () => {
@@ -2494,6 +2616,66 @@ describe('notebook runtime service', () => {
     >
     expect(document.runs).toHaveLength(2)
     expect(document.runs.every((run) => run.status === 'completed')).toBe(true)
+  })
+
+  it('settles a cancelled queued run before the active interpreter execution finishes', async () => {
+    const root = await createStorageRoot()
+    const executionStarted = createDeferred<void>()
+    const releaseExecution = createDeferred<void>()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => {
+          executionStarted.resolve()
+          await releaseExecution.promise
+          return {
+            status: 'completed',
+            stdout: `${request.code}\n`,
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: [],
+            workingFiles: []
+          }
+        },
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    const first = service.execute({
+      sessionId: 'session-1',
+      workspaceCwd: root,
+      code: 'long_running_analysis()'
+    })
+    await executionStarted.promise
+
+    const cancellation = new AbortController()
+    const queued = service.execute(
+      {
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        code: 'should_not_run()'
+      },
+      cancellation.signal
+    )
+    await vi.waitFor(async () => {
+      const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+      expect(state.cells).toHaveLength(2)
+    })
+    cancellation.abort()
+
+    await expect(queued).rejects.toBe(cancellation.signal.reason)
+    const queuedState = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+    expect(queuedState.runs).toHaveLength(1)
+    expect(queuedState.cells[1]).toMatchObject({
+      code: 'should_not_run()',
+      status: 'idle'
+    })
+
+    releaseExecution.resolve()
+    await expect(first).resolves.toMatchObject({ status: 'completed' })
   })
 
   it('runs different sessions in parallel instead of serializing across sessions', async () => {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -720,14 +720,20 @@ class NotebookRuntimeService {
   }
 
   // Compatibility facade: Session lookup and public summary projection stay here; lifecycle is owned.
-  async runCell(request: RunNotebookCellRequest): Promise<NotebookRunSummary> {
+  async runCell(
+    request: RunNotebookCellRequest,
+    signal?: AbortSignal
+  ): Promise<NotebookRunSummary> {
     const session = await this.sessionLifecycle.ensure(request)
-    const run = await this.executionOwner.executeDataCell(session, request)
+    const run = await this.executionOwner.executeDataCell(session, request, signal)
     return this.sessionReadModel.toRunSummary(session, run)
   }
 
   // Convenience path used by the terminal and MCP to write a temporary cell and run it.
-  async execute(request: ExecuteNotebookCodeRequest): Promise<NotebookRunSummary> {
+  async execute(
+    request: ExecuteNotebookCodeRequest,
+    signal?: AbortSignal
+  ): Promise<NotebookRunSummary> {
     const begin = await this.beginCodeCell(request)
 
     await this.appendCodeCell({
@@ -742,10 +748,13 @@ class NotebookRuntimeService {
       cellId: begin.cellId
     })
 
-    return this.runCell({
-      ...request,
-      cellId: begin.cellId
-    })
+    return this.runCell(
+      {
+        ...request,
+        cellId: begin.cellId
+      },
+      signal
+    )
   }
 
   // Compatibility facade for the control-plane REPL. Admission, capability lifetime, dispatch,
@@ -774,6 +783,7 @@ class NotebookRuntimeService {
     request: NotebookSessionRequest
   ): Promise<NotebookSessionState & { runtimeBindings: NotebookRuntimeBindings }> {
     const session = await this.sessionLifecycle.ensure(request)
+    await this.runTerminalization.reconcilePending(session)
     return this.sessionReadModel.state(session)
   }
 

--- a/src/main/notebook/session-aggregate.test.ts
+++ b/src/main/notebook/session-aggregate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { NotebookCell } from '../../shared/notebook'
 
@@ -58,6 +58,56 @@ describe('NotebookSessionAggregate', () => {
     expect(started).toEqual(['first', 'other', 'second'])
   })
 
+  it('settles an aborted queued execution without waiting for the active process', async () => {
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const session = new NotebookSessionAggregate({
+      sessionId: 'session-1',
+      projectName: 'default-project',
+      lane: createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1'),
+      cwd: '/workspace/data',
+      notebookSessionRoot: '/workspace',
+      dataRoot: '/workspace/data',
+      runtimeRoot: '/runtime',
+      runJsonPath: '/workspace/run.json',
+      executionCount: 0,
+      executorGeneration: Symbol('executor-1'),
+      executor: {
+        execute: async () => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: '/workspace/data',
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      }
+    })
+    const first = session.enqueueExecution('python:default-python', async () => {
+      await firstGate
+      return 'first-result'
+    })
+    const cancellation = new AbortController()
+    const queuedTask = vi.fn(async () => 'queued-result')
+    const queued = session.enqueueExecution(
+      'python:default-python',
+      queuedTask,
+      cancellation.signal
+    )
+
+    cancellation.abort()
+
+    await expect(queued).rejects.toBe(cancellation.signal.reason)
+    expect(queuedTask).not.toHaveBeenCalled()
+    releaseFirst()
+    await expect(first).resolves.toBe('first-result')
+    await session.drainExecution('python:default-python')
+    expect(queuedTask).not.toHaveBeenCalled()
+  })
+
   it('returns snapshots that cannot mutate owned cell or kernel state', () => {
     const session = new NotebookSessionAggregate({
       sessionId: 'session-1',
@@ -103,5 +153,11 @@ describe('NotebookSessionAggregate', () => {
       cells: [{ id: 'cell-1', code: 'original', status: 'idle' }],
       kernelStatuses: [['python:default-python', 'idle']]
     })
+
+    for (const status of ['completed', 'failed', 'timeout', 'interrupted', 'cancelled'] as const) {
+      session.markCellRunning('cell-1', `run-${status}`, 1)
+      session.completeCellRun('cell-1', status, '/workspace/data')
+      expect(session.cellView('cell-1').status).toBe(status)
+    }
   })
 })

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -35,6 +35,7 @@ export type NotebookSessionExecutionRequest = {
   runtimeRoot: string
   protectedDirs?: string[]
   timeoutMs?: number
+  signal?: AbortSignal
   language?: NotebookLanguage
   environment?: string
   resolvedInterpreter?: NotebookSessionResolvedInterpreter
@@ -279,27 +280,62 @@ export class NotebookSessionAggregate<
 
   completeCellRun(
     cellId: string,
-    status: NotebookSessionExecutionResult['status'],
+    status: Exclude<NotebookRunStatus, 'queued' | 'running'>,
     cwdAfter: string
   ): void {
     const cell = this.requireCell(cellId)
     this.cwdValue = cwdAfter
     this.activeRunIdValue = undefined
-    cell.status = status === 'completed' ? 'completed' : 'failed'
+    cell.status = status
   }
 
   hasActiveRun(): boolean {
     return this.activeRunIdValue !== undefined
   }
 
-  enqueueExecution<T>(processKey: string, task: () => Promise<T>): Promise<T> {
+  enqueueExecution<T>(
+    processKey: string,
+    task: () => Promise<T>,
+    signal?: AbortSignal
+  ): Promise<T> {
     const previous = this.executionQueues.get(processKey) ?? Promise.resolve()
-    const run = previous.then(task)
+    if (!signal) {
+      const run = previous.then(task)
+      this.executionQueues.set(
+        processKey,
+        run.catch(() => undefined)
+      )
+      return run
+    }
+
+    signal.throwIfAborted()
+    let started = false
+    let resolveResult!: (result: T | PromiseLike<T>) => void
+    let rejectResult!: (reason?: unknown) => void
+    const result = new Promise<T>((resolve, reject) => {
+      resolveResult = resolve
+      rejectResult = reject
+    })
+    const onAbort = (): void => {
+      if (!started) rejectResult(signal.reason)
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    const run = previous.then(async () => {
+      if (signal.aborted) return
+      started = true
+      signal.removeEventListener('abort', onAbort)
+      try {
+        resolveResult(await task())
+      } catch (error) {
+        rejectResult(error)
+      }
+    })
     this.executionQueues.set(
       processKey,
       run.catch(() => undefined)
     )
-    return run
+    return result
   }
 
   async drainExecution(processKey: string): Promise<void> {

--- a/src/main/notebook/shell-process.ts
+++ b/src/main/notebook/shell-process.ts
@@ -4,9 +4,8 @@ import { win32 } from 'node:path'
 import { protectManagedRuntimeWrites } from './managed-runtime-guard'
 import { terminateProcessTree } from '../process-tree'
 import { resolveWindowsPowerShellExecutable } from '../windows-powershell'
+import { NOTEBOOK_SHELL_DEFAULT_TIMEOUT_MS } from '../../shared/notebook'
 
-// Default bash_execute timeout, matching the data/repl kernels' own default.
-const DEFAULT_SHELL_TIMEOUT_MS = 120_000
 // Grace between the POSIX process group's polite termination and an uncatchable group kill.
 const SHELL_KILL_GRACE_MS = 2_000
 
@@ -255,7 +254,7 @@ const runShellCommand = (
   }
 ): Promise<NotebookShellResult> =>
   new Promise((resolve) => {
-    const timeoutMs = options.timeoutMs ?? DEFAULT_SHELL_TIMEOUT_MS
+    const timeoutMs = options.timeoutMs ?? NOTEBOOK_SHELL_DEFAULT_TIMEOUT_MS
     const platform = options.platform ?? process.platform
     const invocation = protectManagedRuntimeWrites(
       resolveShellInvocation(options.command, platform),

--- a/src/renderer/src/lib/acp/runtime-event-presentation.ts
+++ b/src/renderer/src/lib/acp/runtime-event-presentation.ts
@@ -158,6 +158,8 @@ const applyRuntimePresentationEvent = (
       promptMessageId: event.promptMessageId,
       title: event.title,
       status: event.status,
+      toolDisposition: event.toolDisposition,
+      executionInvocationId: event.executionInvocationId,
       providerToolName: event.providerToolName,
       toolKind: event.toolKind,
       toolContent: event.toolContent,

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -235,6 +235,46 @@ describe('workspace runtime events', () => {
     ])
   })
 
+  it('projects Notebook authorization and declined permission metadata', async () => {
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'tool-prepared',
+        kind: 'tool',
+        toolCallId: 'tool-approved',
+        providerToolName: 'mcp__open-science-notebook__notebook_execute',
+        status: 'in_progress'
+      })
+    )
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'tool-authorized',
+        kind: 'tool',
+        toolCallId: 'tool-approved',
+        status: 'in_progress',
+        executionInvocationId: 'invocation-1'
+      })
+    )
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'tool-declined',
+        kind: 'tool',
+        toolCallId: 'tool-declined',
+        providerToolName: 'mcp__open-science-notebook__notebook_execute',
+        status: 'completed',
+        toolDisposition: 'declined'
+      })
+    )
+
+    expect(useSessionStore.getState().sessions[0].activities).toEqual([
+      expect.objectContaining({
+        id: 'tool-approved',
+        executionInvocationId: 'invocation-1',
+        eventIds: ['tool-prepared', 'tool-authorized']
+      }),
+      expect.objectContaining({ id: 'tool-declined', toolDisposition: 'declined' })
+    ])
+  })
+
   it('applies assistant image events without creating placeholder text', async () => {
     await applyWorkspaceRuntimeEvent(
       createEvent({

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -589,6 +589,8 @@ const applyWorkspaceRuntimeEvent = async (
       promptMessageId: event.promptMessageId,
       title: event.title,
       status: event.status,
+      toolDisposition: event.toolDisposition,
+      executionInvocationId: event.executionInvocationId,
       providerToolName: event.providerToolName,
       toolKind: event.toolKind,
       toolContent: event.toolContent,

--- a/src/renderer/src/pages/workspace/ArtifactProvenanceMessages.integration.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenanceMessages.integration.test.tsx
@@ -76,7 +76,7 @@ describe('ProvenanceMessagesTimeline integration', () => {
     })
 
     expect(container.textContent).toContain('Plot a sine curve')
-    expect(container.textContent).toContain('Notebook execution')
+    expect(container.textContent).toContain('Notebook code shown')
 
     const messageRow = container.querySelector<HTMLElement>('[class~="pb-1"][class~="pt-5"]')
     const activityGroup = container.querySelector<HTMLElement>('[data-testid="tool-group"]')

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -35,6 +35,7 @@ import {
   isProblemRunStatus,
   kernelKindLabel,
   kernelOriginLabel,
+  notebookRunStatusLabel,
   resolveRunEnvironment,
   resolveRunKernelKind
 } from './notebook-cell-utils'
@@ -111,6 +112,7 @@ const NotebookRunCell = ({
   index: number
 }): React.JSX.Element => {
   const isProblem = isProblemRunStatus(run.status)
+  const statusLabel = notebookRunStatusLabel(run.status)
   const errorLine = isProblem ? resolveRunErrorLine(run) : undefined
   const kind = resolveRunKernelKind(run)
   const originLabel = kernelOriginLabel(kind)
@@ -132,6 +134,8 @@ const NotebookRunCell = ({
             ) : (
               <span className="rounded bg-danger-900 px-1.5 py-0.5 text-danger-000">error</span>
             )
+          ) : statusLabel ? (
+            <span className="rounded bg-bg-300 px-1.5 py-0.5 text-text-200">{statusLabel}</span>
           ) : null}
         </div>
         {originLabel ? (

--- a/src/renderer/src/pages/workspace/NotebookRunOutputs.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookRunOutputs.render.test.tsx
@@ -219,6 +219,19 @@ describe('NotebookRunOutputs', () => {
     expect(outputs?.textContent?.match(/Traceback \(most recent call last\):/g)).toHaveLength(1)
   })
 
+  it('keeps timeout diagnostics neutral', () => {
+    render(
+      [{ type: 'error', message: 'execution limit reached', traceback: 'execution limit reached' }],
+      {
+        status: 'timeout'
+      }
+    )
+
+    const output = container.querySelector('[data-testid="notebook-text-output"] pre')
+    expect(output?.className).toContain('text-text-200')
+    expect(output?.className).not.toContain('text-danger-000')
+  })
+
   it('renders ANSI SGR color codes as styled text, stripping the escapes', () => {
     render([{ type: 'stream', name: 'stdout', text: '[31mred[0m normal' }])
 

--- a/src/renderer/src/pages/workspace/NotebookRunOutputs.tsx
+++ b/src/renderer/src/pages/workspace/NotebookRunOutputs.tsx
@@ -164,7 +164,11 @@ const NotebookDisplayTextOutput = ({
 }
 
 // Renders one structured output entry, or null when it carries no visible content.
-const renderTextOutput = (output: NotebookOutput, index: number): React.JSX.Element | null => {
+const renderTextOutput = (
+  output: NotebookOutput,
+  index: number,
+  errorClassName: string
+): React.JSX.Element | null => {
   switch (output.type) {
     case 'stream': {
       const text = trimTrailingNewline(output.text)
@@ -174,7 +178,7 @@ const renderTextOutput = (output: NotebookOutput, index: number): React.JSX.Elem
       return (
         <pre
           key={index}
-          className={`${preClassName} ${output.name === 'stderr' ? 'text-danger-000' : 'text-text-200'}`}
+          className={`${preClassName} ${output.name === 'stderr' ? errorClassName : 'text-text-200'}`}
         >
           {renderAnsi(text)}
         </pre>
@@ -210,7 +214,7 @@ const renderTextOutput = (output: NotebookOutput, index: number): React.JSX.Elem
       if (body.trim().length === 0) return null
 
       return (
-        <pre key={index} className={`${preClassName} text-danger-000`}>
+        <pre key={index} className={`${preClassName} ${errorClassName}`}>
           {renderAnsi(body)}
         </pre>
       )
@@ -237,7 +241,11 @@ const LegacyTextOutput = ({ run }: { run: NotebookRunRecord }): React.JSX.Elemen
         <pre className={`${preClassName} text-text-200`}>{renderAnsi(stdout)}</pre>
       ) : null}
       {stderr.trim().length > 0 ? (
-        <pre className={`${preClassName} text-danger-000`}>{renderAnsi(stderr)}</pre>
+        <pre
+          className={`${preClassName} ${run.status === 'failed' ? 'text-danger-000' : 'text-text-200'}`}
+        >
+          {renderAnsi(stderr)}
+        </pre>
       ) : null}
     </>
   )
@@ -245,10 +253,11 @@ const LegacyTextOutput = ({ run }: { run: NotebookRunRecord }): React.JSX.Elemen
 
 const NotebookRunTextOutputs = ({ run }: { run: NotebookRunRecord }): React.JSX.Element | null => {
   let rendered: React.JSX.Element[]
+  const errorClassName = run.status === 'failed' ? 'text-danger-000' : 'text-text-200'
 
   if (run.outputs.length > 0) {
     rendered = run.outputs
-      .map((output, index) => renderTextOutput(output, index))
+      .map((output, index) => renderTextOutput(output, index, errorClassName))
       .filter((node): node is React.JSX.Element => node !== null)
   } else {
     const legacy = <LegacyTextOutput run={run} />

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -409,7 +409,7 @@ describe('PermissionApprovalControls', () => {
       />
     )
     expect(notebookHtml).toContain('data-testid="permission-code-toggle"')
-    expect(notebookHtml).toContain('Run notebook cell')
+    expect(notebookHtml).toContain('Start Notebook run')
 
     const bashHtml = renderToStaticMarkup(
       <PermissionApprovalControls requests={[bashPermissionRequest]} onRespond={() => undefined} />
@@ -466,7 +466,7 @@ describe('PermissionApprovalControls', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls requests={[brokerShape]} onRespond={() => undefined} />
     )
-    expect(html).toContain('Run notebook cell')
+    expect(html).toContain('Start Notebook run')
     expect(html).toContain('data-testid="permission-impact-info"')
     expect(html).toContain('data-testid="permission-tool-info"')
     expect(html).toContain('data-language="python"')
@@ -491,7 +491,7 @@ describe('PermissionApprovalControls', () => {
     const html = renderToStaticMarkup(
       <PermissionApprovalControls requests={[opencodeShape]} onRespond={() => undefined} />
     )
-    expect(html).toContain('Run notebook cell')
+    expect(html).toContain('Start Notebook run')
     expect(html).toContain('data-testid="permission-tool-info"')
     expect(html).toContain('data-language="python"')
     expect(html).not.toContain('data-language="bash"')
@@ -560,7 +560,7 @@ describe('PermissionApprovalControls', () => {
     )
     expect(html).toContain('data-testid="tool-code-block"')
     expect(html).toContain('DROP TABLE users')
-    expect(html).not.toContain('Run notebook cell')
+    expect(html).not.toContain('Start Notebook run')
   })
 
   it('treats a notebook_execute from another MCP server as generic JSON, not a notebook', () => {
@@ -583,7 +583,7 @@ describe('PermissionApprovalControls', () => {
     // JSON path shows every argument, including the production target the notebook path would hide.
     expect(html).toContain('data-language="json"')
     expect(html).toContain('prod')
-    expect(html).not.toContain('Run notebook cell')
+    expect(html).not.toContain('Start Notebook run')
     expect(html).toContain('External service</span>')
   })
 

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -253,7 +253,7 @@ const extractPermissionCode = (request: AcpPermissionRequest): PermissionCode | 
 
 // A friendly action title for the code card header, matching the transcript's activity phrasing.
 const getPermissionActionTitle = (request: AcpPermissionRequest, fallback: string): string => {
-  if (resolveNotebookToolName(request)) return 'Run notebook cell'
+  if (resolveNotebookToolName(request)) return 'Start Notebook run'
   if (isArtifactWriteRequest(request)) return 'Artifact file input'
   if (isMcpPermissionRequest(request)) return 'External service input'
   if (request.toolKind === 'execute' || request.providerToolName === 'Bash') return 'Run command'

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
@@ -73,6 +73,23 @@ describe('SessionNotebookContent', () => {
     expect(html).toContain('ModuleNotFoundError')
   })
 
+  it('renders timeout as a neutral limit instead of an error', () => {
+    const html = renderContent({
+      sessionId: 's1',
+      status: 'ready',
+      runs: [
+        makeRun({
+          status: 'timeout',
+          text: { stdout: '', stderr: 'limit', traceback: '', plain: [] }
+        })
+      ]
+    })
+
+    expect(html).toContain('limit reached')
+    expect(html).not.toContain('>error<')
+    expect(html).not.toContain('text-danger-000')
+  })
+
   it('shows exact registered input Versions inside the run that used them', () => {
     const html = renderContent({
       projectId: 'project-1',

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
@@ -24,6 +24,7 @@ import {
   isProblemRunStatus,
   kernelKindLabel,
   kernelOriginLabel,
+  notebookRunStatusLabel,
   resolveRunErrorLine,
   resolveRunKernelKind
 } from './notebook-cell-utils'
@@ -62,6 +63,7 @@ const NotebookDialogCell = ({
   showInputData?: boolean
 }): React.JSX.Element => {
   const isProblem = isProblemRunStatus(run.status)
+  const statusLabel = notebookRunStatusLabel(run.status)
   const errorLine = isProblem ? resolveRunErrorLine(run) : undefined
   const kind = resolveRunKernelKind(run)
   const originLabel = kernelOriginLabel(kind)
@@ -80,6 +82,10 @@ const NotebookDialogCell = ({
             ) : (
               <span className="rounded bg-danger-900 px-1.5 py-0.5 text-danger-000">error</span>
             )
+          ) : statusLabel ? (
+            <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground">
+              {statusLabel}
+            </span>
           ) : null}
         </div>
         {originLabel ? (

--- a/src/renderer/src/pages/workspace/WorkspaceActivityGroup.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceActivityGroup.tsx
@@ -14,7 +14,7 @@ import { WorkspaceWebSearchActivityRow } from './WorkspaceWebSearchActivityRow'
 import { buildToolActivityDetails } from './workspace-tool-activity-details'
 import {
   formatActivityGroupElapsed,
-  formatActivityGroupTitle,
+  formatActivityGroupPresentationTitle,
   formatStepCount,
   getActivityGroupElapsedMs,
   getRenderableActivityEntries,
@@ -24,8 +24,9 @@ import type {
   ActivityExpansionOverrides,
   ConversationActivityGroupItem
 } from './workspace-tool-activity-groups'
-import { isActivityActive } from './workspace-conversation-items'
 import { formatWebSearchDetails } from './workspace-web-search-details'
+import { getCorrelatedNotebookRun, getToolExecutionPhase } from './tool-execution-phase'
+import type { SessionPermissionRuntimeContext } from '../../../../shared/session-persistence'
 
 type WorkspaceActivityGroupProps = {
   group: ConversationActivityGroupItem
@@ -40,17 +41,24 @@ type WorkspaceActivityGroupProps = {
   // Map of job_id → JobSummary for jobs bound to activities in this group.
   jobsByActivityId?: Map<string, JobSummary>
   onOpenJobDetail?: (job: JobSummary) => void
+  permission?: SessionPermissionRuntimeContext
 }
 
 const ACTIVE_ELAPSED_TICK_MS = 100
 
 // Isolates the ticking clock so active tools do not re-render the group's expanded detail rows.
 const ActivityGroupElapsed = ({
-  activities
+  activities,
+  permission,
+  notebookRunsById
 }: {
   activities: ConversationActivityGroupItem['activities']
+  permission?: SessionPermissionRuntimeContext
+  notebookRunsById?: ReadonlyMap<string, NotebookRunRecord>
 }): React.JSX.Element => {
-  const isActive = activities.some(isActivityActive)
+  const isExecuting = (activity: (typeof activities)[number]): boolean =>
+    getToolExecutionPhase(activity, permission, notebookRunsById) === 'executing'
+  const isActive = activities.some(isExecuting)
   const [now, setNow] = useState(() => Date.now())
 
   useEffect(() => {
@@ -60,7 +68,7 @@ const ActivityGroupElapsed = ({
     return () => clearInterval(timer)
   }, [isActive])
 
-  return <>{formatActivityGroupElapsed(getActivityGroupElapsedMs(activities, now))}</>
+  return <>{formatActivityGroupElapsed(getActivityGroupElapsedMs(activities, now, isExecuting))}</>
 }
 
 // Renders adjacent tool calls as one collapsible transcript row group.
@@ -73,7 +81,8 @@ const WorkspaceActivityGroup = ({
   notebookRunsById,
   contentPaddingClassName,
   jobsByActivityId,
-  onOpenJobDetail
+  onOpenJobDetail,
+  permission
 }: WorkspaceActivityGroupProps): React.JSX.Element => {
   // ToolSearch wrapper rows are hidden when concrete search rows are present.
   const renderableActivityEntries = getRenderableActivityEntries(group.activities)
@@ -102,17 +111,28 @@ const WorkspaceActivityGroup = ({
               <ChevronRight className="size-3.5" strokeWidth={2.2} aria-hidden="true" />
             </span>
             <span className="min-w-0 truncate text-left font-medium text-text-000">
-              {formatActivityGroupTitle(group.activities, group.title)}
+              {formatActivityGroupPresentationTitle(
+                group.activities,
+                group.title,
+                permission,
+                notebookRunsById
+              )}
             </span>
-            <span className="ml-auto shrink-0 whitespace-nowrap text-[12px] tabular-nums text-text-100">
-              {formatStepCount(visibleActivities)} ·{' '}
-              <ActivityGroupElapsed activities={visibleActivities} />
+            <span className="ml-auto shrink-0 whitespace-nowrap text-[12px] tabular-nums text-text-000">
+              {formatStepCount(visibleActivities, permission, notebookRunsById)} ·{' '}
+              <ActivityGroupElapsed
+                activities={visibleActivities}
+                permission={permission}
+                notebookRunsById={notebookRunsById}
+              />
             </span>
           </button>
           {isExpanded ? (
             <div className="grid grid-rows-[1fr] transition-[grid-template-rows] duration-200 ease-out">
               <div className="min-h-0 overflow-hidden">
                 {renderableActivityEntries.map(({ activity, activityIndex }) => {
+                  const phase = getToolExecutionPhase(activity, permission, notebookRunsById)
+                  const correlatedNotebookRun = getCorrelatedNotebookRun(activity, notebookRunsById)
                   // Search rows get bespoke query/result details; other tools reuse the shared builder.
                   const isSearch = isSearchActivity(activity, group.activities, activityIndex)
                   const searchDetails = isSearch ? formatWebSearchDetails(activity) : undefined
@@ -126,6 +146,7 @@ const WorkspaceActivityGroup = ({
                       {searchDetails ? (
                         <WorkspaceWebSearchActivityRow
                           activity={activity}
+                          phase={phase}
                           details={searchDetails}
                           isExpanded={isRowExpanded}
                           onToggleSearch={onToggleRow}
@@ -133,17 +154,19 @@ const WorkspaceActivityGroup = ({
                       ) : toolDetails ? (
                         <WorkspaceToolDetailsRow
                           activity={activity}
+                          phase={phase}
                           details={toolDetails}
                           notebookRun={
-                            toolDetails.notebookRunId
+                            correlatedNotebookRun ??
+                            (toolDetails.notebookRunId
                               ? notebookRunsById?.get(toolDetails.notebookRunId)
-                              : undefined
+                              : undefined)
                           }
                           isExpanded={isRowExpanded}
                           onToggle={onToggleRow}
                         />
                       ) : (
-                        <WorkspaceToolActivityRow activity={activity} />
+                        <WorkspaceToolActivityRow activity={activity} phase={phase} />
                       )}
                       {/* RemoteJobRow: injected below a repl_execute activity that submitted a job */}
                       {(() => {

--- a/src/renderer/src/pages/workspace/WorkspaceActivityIcon.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceActivityIcon.tsx
@@ -15,14 +15,19 @@ import {
 } from 'lucide-react'
 
 import { isActivityActive, isContextCompactionActivity } from './workspace-conversation-items'
+import type { ToolExecutionPhase } from './tool-execution-phase'
 
 type WorkspaceActivityIconProps = {
   activity: ToolActivity
+  phase?: ToolExecutionPhase
 }
 
 // Picks the smallest status/tool-kind icon that describes the current activity state.
-const WorkspaceActivityIcon = ({ activity }: WorkspaceActivityIconProps): React.JSX.Element => {
-  const isActive = isActivityActive(activity)
+const WorkspaceActivityIcon = ({
+  activity,
+  phase
+}: WorkspaceActivityIconProps): React.JSX.Element => {
+  const isActive = phase ? phase === 'executing' : isActivityActive(activity)
   const className = cn('size-3.5 shrink-0', isActive ? 'animate-spin' : undefined)
   const iconProps = {
     className,
@@ -32,11 +37,24 @@ const WorkspaceActivityIcon = ({ activity }: WorkspaceActivityIconProps): React.
 
   // Status takes precedence over tool kind so terminal or active states are unmistakable.
   if (isActive) return <LoaderCircle {...iconProps} />
-  if (activity.status === 'failed') return <CircleAlert {...iconProps} />
+  if (phase ? phase === 'failed' : activity.status === 'failed') {
+    return <CircleAlert {...iconProps} />
+  }
+  if (
+    phase === 'closed' ||
+    phase === 'declined' ||
+    phase === 'limit-reached' ||
+    phase === 'cancelled' ||
+    phase === 'interrupted'
+  ) {
+    return <CircleMinus {...iconProps} />
+  }
   if (isContextCompactionActivity(activity) && activity.title === 'Context compaction cancelled') {
     return <CircleMinus {...iconProps} />
   }
-  if (activity.status === 'completed') return <Check {...iconProps} />
+  if (phase ? phase === 'completed' : activity.status === 'completed') {
+    return <Check {...iconProps} />
+  }
 
   // Otherwise the tool kind hints at what the call did.
   switch (activity.toolKind) {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -1436,6 +1436,37 @@ describe('WorkspaceMessageScroller loading render', () => {
     expect(html).not.toContain('https://example.com/breaking-news')
   })
 
+  it('renders a closed search permission as neutral and inactive', async () => {
+    const html = await renderScroller(
+      createSession({
+        status: 'idle',
+        messages: [createMessage({ id: 'prompt-1' })],
+        activities: [
+          createActivity({
+            status: 'in_progress',
+            providerToolName: 'WebSearch',
+            toolDisposition: 'permission-closed',
+            toolContent: [
+              {
+                type: 'content',
+                content: {
+                  type: 'text',
+                  text: JSON.stringify({ query: 'closed query', results: [] })
+                }
+              }
+            ]
+          })
+        ]
+      })
+    )
+
+    expect(html).toContain('Tool request ended')
+    expect(html).toContain('>request ended<')
+    expect(html).toContain('lucide-circle-minus')
+    expect(html).not.toContain('animate-spin')
+    expect(html.match(/<button[^>]*data-testid="tool-chip"[^>]*>/u)?.[0]).not.toContain('aria-live')
+  })
+
   it('keeps Claude web search payload links collapsed by default', async () => {
     const html = await renderScroller(
       createSession({
@@ -2009,6 +2040,43 @@ describe('WorkspaceActivityGroup header summaries', () => {
 })
 
 describe('WorkspaceToolDetailsRow expanded rendering', () => {
+  it.each([
+    ['timeout', 'limit-reached', 'limit reached'],
+    ['cancelled', 'cancelled', 'cancelled'],
+    ['interrupted', 'interrupted', 'interrupted']
+  ] as const)('renders the neutral Notebook %s status', async (status, phase, label) => {
+    const { WorkspaceToolDetailsRow } = await import('./WorkspaceToolDetailsRow')
+    const html = renderToStaticMarkup(
+      <WorkspaceToolDetailsRow
+        activity={createActivity({
+          id: 'tool-notebook-1',
+          providerToolName: 'mcp__open-science-notebook__notebook_execute'
+        })}
+        phase={phase}
+        details={{ displayName: 'Notebook cell', metaLabel: 'success', sections: [] }}
+        notebookRun={{
+          runId: 'run-1',
+          cellId: 'cell-1',
+          source: 'agent',
+          kernelKind: 'python',
+          script: 'print(1)',
+          status,
+          startedAt: 1,
+          endedAt: 2,
+          text: { stdout: '', stderr: '', traceback: '', plain: [] },
+          outputs: [],
+          artifacts: [],
+          workingFiles: []
+        }}
+        isExpanded={false}
+        onToggle={() => {}}
+      />
+    )
+
+    expect(html).toContain(label)
+    expect(html).not.toContain('success')
+  })
+
   it('renders command and output code blocks when expanded', async () => {
     const { WorkspaceToolDetailsRow } = await import('./WorkspaceToolDetailsRow')
     const details: ToolActivityDetails = {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1097,6 +1097,7 @@ const WorkspaceMessageScrollerImpl = ({
                       expansionOverrides={activityExpansionOverrides}
                       onToggleRow={toggleActivityRow}
                       notebookRunsById={notebookRunsById}
+                      permission={activeSession?.runtimeContext?.permission}
                       jobsByActivityId={jobsByActivityId}
                       onOpenJobDetail={handleOpenJobDetail}
                     />

--- a/src/renderer/src/pages/workspace/WorkspaceToolActivityRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolActivityRow.tsx
@@ -3,28 +3,33 @@ import type { ToolActivity } from '@/stores/session-store'
 import { WorkspaceActivityIcon } from './WorkspaceActivityIcon'
 import { formatActivityTitle, isActivityActive } from './workspace-conversation-items'
 import { getActivitySurfaceClassName } from './workspace-tool-activity-style'
+import type { ToolExecutionPhase } from './tool-execution-phase'
 
 type WorkspaceToolActivityRowProps = {
   activity: ToolActivity
+  phase?: ToolExecutionPhase
 }
 
 // Renders a compact non-search tool activity with live status semantics while it is running.
 const WorkspaceToolActivityRow = ({
-  activity
+  activity,
+  phase
 }: WorkspaceToolActivityRowProps): React.JSX.Element => {
-  const isActive = isActivityActive(activity)
+  const isActive = phase ? phase === 'executing' : isActivityActive(activity)
 
   return (
     <div
-      className={getActivitySurfaceClassName(activity)}
+      className={getActivitySurfaceClassName(activity, phase)}
       data-testid="tool-chip"
       role={isActive ? 'status' : undefined}
       aria-live={isActive ? 'polite' : undefined}
     >
       <span className="mt-0.5 inline-flex shrink-0 items-center md:mt-0">
-        <WorkspaceActivityIcon activity={activity} />
+        <WorkspaceActivityIcon activity={activity} phase={phase} />
       </span>
-      <span className="min-w-0 flex-1 truncate text-left">{formatActivityTitle(activity)}</span>
+      <span className="min-w-0 flex-1 truncate text-left">
+        {formatActivityTitle(activity, phase)}
+      </span>
     </div>
   )
 }

--- a/src/renderer/src/pages/workspace/WorkspaceToolActivityRowButton.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolActivityRowButton.tsx
@@ -5,9 +5,11 @@ import type { ToolActivity } from '@/stores/session-store'
 import { WorkspaceActivityIcon } from './WorkspaceActivityIcon'
 import { isActivityActive } from './workspace-conversation-items'
 import { getActivitySurfaceClassName } from './workspace-tool-activity-style'
+import type { ToolExecutionPhase } from './tool-execution-phase'
 
 type WorkspaceToolActivityRowButtonProps = {
   activity: ToolActivity
+  phase?: ToolExecutionPhase
   label: string
   subtitle?: ReactNode
   metaLabel?: string
@@ -26,6 +28,7 @@ const createRowDetailsDomId = (activityId: string): string =>
 // The shared expandable row shell: icon + "label · subtitle" + right meta, with its detail panel.
 const WorkspaceToolActivityRowButton = ({
   activity,
+  phase,
   label,
   subtitle,
   metaLabel,
@@ -36,14 +39,14 @@ const WorkspaceToolActivityRowButton = ({
   onToggle,
   children
 }: WorkspaceToolActivityRowButtonProps): React.JSX.Element => {
-  const isActive = isActivityActive(activity)
+  const isActive = phase ? phase === 'executing' : isActivityActive(activity)
   const detailsDomId = createRowDetailsDomId(activity.id)
 
   return (
     <>
       <button
         type="button"
-        className={getActivitySurfaceClassName(activity)}
+        className={getActivitySurfaceClassName(activity, phase)}
         data-testid="tool-chip"
         aria-expanded={canExpand ? isExpanded : undefined}
         aria-controls={canExpand ? detailsDomId : undefined}
@@ -52,7 +55,7 @@ const WorkspaceToolActivityRowButton = ({
         onClick={() => onToggle(activity.id, !isExpanded)}
       >
         <span className="mt-0.5 inline-flex shrink-0 items-center md:mt-0">
-          <WorkspaceActivityIcon activity={activity} />
+          <WorkspaceActivityIcon activity={activity} phase={phase} />
         </span>
         <span className="min-w-0 flex-1 text-left md:flex md:items-center md:gap-2">
           <span className="block shrink-0 text-text-000">{label}</span>

--- a/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx
@@ -215,6 +215,35 @@ describe('WorkspaceToolDetailsRow', () => {
     expect(container.textContent).toContain('hi')
   })
 
+  it('renders a closed permission as neutral terminal metadata', async () => {
+    const activity = createActivity({
+      providerToolName: 'Bash',
+      toolKind: 'execute',
+      title: 'echo hi',
+      status: 'in_progress',
+      toolDisposition: 'permission-closed'
+    })
+    const details = buildToolActivityDetails(activity)
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceToolDetailsRow
+          activity={activity}
+          phase="closed"
+          details={details!}
+          isExpanded={false}
+          onToggle={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.textContent).toContain('request ended')
+    expect(container.querySelector('.animate-spin')).toBeNull()
+    expect(container.querySelector('[aria-live="polite"]')).toBeNull()
+    expect(container.querySelector('.lucide-circle-minus')).not.toBeNull()
+  })
+
   it('renders local notebook figures outside the independently collapsible text output', async () => {
     const activity = createActivity({
       providerToolName: 'mcp__open-science-notebook__notebook_execute',

--- a/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.tsx
@@ -4,6 +4,7 @@ import type { NotebookRunRecord } from '../../../../shared/notebook'
 import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { formatNotebookRunFigureMeta } from './notebook-run-figures'
 import { NotebookRunFigureOutputs } from './NotebookRunOutputs'
+import { notebookRunStatusLabel } from './notebook-cell-utils'
 import { usePreviewFileContent } from './previews/usePreviewFileContent'
 
 // Byte cap for inline tool-output image previews. Co-located here (rather than in preview-support,
@@ -18,9 +19,11 @@ import type {
 import { WorkspaceToolActivityRowButton } from './WorkspaceToolActivityRowButton'
 import { WorkspaceToolCodeBlock } from './WorkspaceToolCodeBlock'
 import { WorkspaceToolDiffBlock } from './WorkspaceToolDiffBlock'
+import type { ToolExecutionPhase } from './tool-execution-phase'
 
 type WorkspaceToolDetailsRowProps = {
   activity: ToolActivity
+  phase?: ToolExecutionPhase
   details: ToolActivityDetails
   notebookRun?: NotebookRunRecord
   isExpanded: boolean
@@ -131,16 +134,19 @@ const renderSection = (section: ToolDetailSection, index: number): React.JSX.Ele
 // Renders a non-search tool call with an expandable panel showing input, output, or diffs.
 const WorkspaceToolDetailsRow = ({
   activity,
+  phase,
   details,
   notebookRun,
   isExpanded,
   onToggle
 }: WorkspaceToolDetailsRowProps): React.JSX.Element => {
   const notebookFigureMeta = notebookRun ? formatNotebookRunFigureMeta(notebookRun) : undefined
+  const notebookRunMeta = notebookRun ? notebookRunStatusLabel(notebookRun.status) : undefined
 
   return (
     <WorkspaceToolActivityRowButton
       activity={activity}
+      phase={phase}
       label={details.displayName}
       subtitle={
         details.displayName === 'Write file' && details.subtitle ? (
@@ -149,7 +155,17 @@ const WorkspaceToolDetailsRow = ({
           details.subtitle
         )
       }
-      metaLabel={notebookFigureMeta ?? details.metaLabel}
+      metaLabel={
+        phase === 'prepared'
+          ? 'code shown'
+          : phase === 'awaiting-approval'
+            ? 'waiting for your approval'
+            : phase === 'declined'
+              ? 'declined by you'
+              : phase === 'closed'
+                ? 'request ended'
+                : (notebookRunMeta ?? notebookFigureMeta ?? details.metaLabel)
+      }
       isExpanded={isExpanded}
       panelClassName="mx-1 mb-1.5 space-y-2.5 md:ml-[30px]"
       panelTestId="tool-details"

--- a/src/renderer/src/pages/workspace/WorkspaceWebSearchActivityRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceWebSearchActivityRow.tsx
@@ -1,10 +1,12 @@
 import type { ToolActivity } from '@/stores/session-store'
 
 import { WorkspaceToolActivityRowButton } from './WorkspaceToolActivityRowButton'
+import type { ToolExecutionPhase } from './tool-execution-phase'
 import type { WebSearchDetails } from './workspace-web-search-details'
 
 type WorkspaceWebSearchActivityRowProps = {
   activity: ToolActivity
+  phase?: ToolExecutionPhase
   details: WebSearchDetails
   isExpanded: boolean
   onToggleSearch: (activityId: string, nextExpanded: boolean) => void
@@ -46,15 +48,17 @@ const renderSearchDetailsBody = (details: WebSearchDetails): React.JSX.Element =
 // Renders one web-search activity row with an optional expandable result summary.
 const WorkspaceWebSearchActivityRow = ({
   activity,
+  phase,
   details,
   isExpanded,
   onToggleSearch
 }: WorkspaceWebSearchActivityRowProps): React.JSX.Element => (
   <WorkspaceToolActivityRowButton
     activity={activity}
+    phase={phase}
     label="Web Search"
     subtitle={details.query || undefined}
-    metaLabel={formatResultCountLabel(details.resultCount)}
+    metaLabel={phase === 'closed' ? 'request ended' : formatResultCountLabel(details.resultCount)}
     isExpanded={isExpanded}
     // Rows without any query or result metadata remain visible but non-interactive.
     canExpand={Boolean(details.query || details.resultCount)}

--- a/src/renderer/src/pages/workspace/agent-loading-message.test.ts
+++ b/src/renderer/src/pages/workspace/agent-loading-message.test.ts
@@ -118,6 +118,49 @@ describe('agent loading message state', () => {
     expect(getAgentLoadingPhase(session)).toBe('interacting-with-tools')
   })
 
+  it('shows Notebook tool interaction while approval waiting remains a distinct phase', async () => {
+    const { getAgentLoadingPhase } = await loadAgentLoadingMessageModule()
+    const session = createSession({
+      activeRun: {
+        promptMessageId: 'prompt-1',
+        startedAt: 1710000000100
+      },
+      messages: [createMessage({ id: 'prompt-1', sortIndex: 1 })],
+      activities: [
+        createActivity({
+          status: 'in_progress',
+          providerToolName: 'mcp__open-science-notebook__notebook_execute',
+          rawInput: { code: 'print(1)' }
+        })
+      ]
+    })
+
+    expect(getAgentLoadingPhase(session)).toBe('interacting-with-tools')
+    expect(
+      getAgentLoadingPhase({
+        ...session,
+        status: 'waiting-permission',
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            state: 'pending',
+            request: {
+              requestId: 'permission-1',
+              sessionId: 'session-1',
+              toolCallId: 'tool-1',
+              title: 'Run code',
+              options: []
+            },
+            originatingPromptMessageId: 'prompt-1',
+            fingerprint: 'fingerprint-1',
+            createdAt: 1710000000400
+          }
+        }
+      })
+    ).toBe('waiting-for-approval')
+  })
+
   it('ignores active tools from a historical run when no prompt is in flight', async () => {
     const { getAgentLoadingPhase } = await loadAgentLoadingMessageModule()
     const session = createSession({

--- a/src/renderer/src/pages/workspace/agent-loading-message.ts
+++ b/src/renderer/src/pages/workspace/agent-loading-message.ts
@@ -1,5 +1,4 @@
 import type { ChatMessage, ChatSession, ToolActivity } from '@/stores/session-store'
-import { isActivityActive } from './workspace-conversation-items'
 
 type TimelinePosition = {
   updatedAt: number
@@ -19,6 +18,12 @@ const findLatest = <T extends TimelinePosition>(items: T[]): T | undefined =>
     (latest, item) => (!latest || isLaterThan(item, latest) ? item : latest),
     undefined
   )
+
+// The transcript row projection keeps a prepared Notebook call static, but the Activity Stream still
+// reports the provider-owned tool interaction. Settled permission dispositions are no longer active.
+const isCurrentToolActive = (activity: ToolActivity): boolean =>
+  (activity.status === 'pending' || activity.status === 'in_progress') &&
+  activity.toolDisposition === undefined
 
 const getCurrentRunTimeline = (
   session: ChatSession
@@ -68,7 +73,9 @@ const getAgentLoadingPhase = (session: ChatSession | undefined): AgentLoadingPha
   const promptMessageId = session.activeRun?.promptMessageId ?? prompt?.id
 
   // Any live tool in the current request takes precedence over the surrounding thinking gaps.
-  if (currentRunTools.some(isActivityActive)) return 'interacting-with-tools'
+  if (currentRunTools.some(isCurrentToolActive)) {
+    return 'interacting-with-tools'
+  }
   if (session.awaitingFirstAgentOutput) return 'thinking'
   if (!session.activeRun) return 'hidden'
 

--- a/src/renderer/src/pages/workspace/notebook-cell-utils.test.ts
+++ b/src/renderer/src/pages/workspace/notebook-cell-utils.test.ts
@@ -4,8 +4,10 @@ import {
   deriveErrorLine,
   detectCellLanguage,
   environmentLabel,
+  isProblemRunStatus,
   kernelKindLabel,
   kernelOriginLabel,
+  notebookRunStatusLabel,
   resolveRunErrorLine,
   resolveRunEnvironment,
   resolveRunKernelKind
@@ -196,5 +198,21 @@ describe('environmentLabel', () => {
 
   it('returns named envs as-is', () => {
     expect(environmentLabel('my-analysis')).toBe('my-analysis')
+  })
+})
+
+describe('notebook run terminal presentation', () => {
+  it('reserves error treatment for failed runs', () => {
+    expect(isProblemRunStatus('failed')).toBe(true)
+    expect(isProblemRunStatus('timeout')).toBe(false)
+    expect(isProblemRunStatus('interrupted')).toBe(false)
+    expect(isProblemRunStatus('cancelled')).toBe(false)
+  })
+
+  it('uses neutral, distinct labels for non-failure terminal states', () => {
+    expect(notebookRunStatusLabel('timeout')).toBe('limit reached')
+    expect(notebookRunStatusLabel('interrupted')).toBe('interrupted')
+    expect(notebookRunStatusLabel('cancelled')).toBe('cancelled')
+    expect(notebookRunStatusLabel('failed')).toBe('error')
   })
 })

--- a/src/renderer/src/pages/workspace/notebook-cell-utils.ts
+++ b/src/renderer/src/pages/workspace/notebook-cell-utils.ts
@@ -1,8 +1,22 @@
 import type { NotebookKernelKind, NotebookRunRecord } from '../../../../shared/notebook'
 
-// Groups the non-success terminal states rendered with a diagnostic error badge.
-const isProblemRunStatus = (status: NotebookRunRecord['status']): boolean =>
-  status === 'failed' || status === 'timeout' || status === 'interrupted'
+// Only an execution failure is an error. Limits and deliberate/process interruptions stay neutral.
+const isProblemRunStatus = (status: NotebookRunRecord['status']): boolean => status === 'failed'
+
+const notebookRunStatusLabel = (status: NotebookRunRecord['status']): string | undefined => {
+  switch (status) {
+    case 'failed':
+      return 'error'
+    case 'timeout':
+      return 'limit reached'
+    case 'interrupted':
+      return 'interrupted'
+    case 'cancelled':
+      return 'cancelled'
+    default:
+      return undefined
+  }
+}
 
 // Best-effort 1-based error line, parsed from the user-code frames of a Python traceback. The
 // executor compiles cells as "<cell>" (runtime errors) and ast.parse reports "<unknown>" (syntax
@@ -108,6 +122,7 @@ export {
   detectCellLanguage,
   environmentLabel,
   isProblemRunStatus,
+  notebookRunStatusLabel,
   kernelKindLabel,
   kernelOriginLabel,
   resolveRunErrorLine,

--- a/src/renderer/src/pages/workspace/tool-execution-phase.test.ts
+++ b/src/renderer/src/pages/workspace/tool-execution-phase.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionPermissionRuntimeContext } from '../../../../shared/session-persistence'
+import type { NotebookRunRecord } from '../../../../shared/notebook'
+import type { ToolActivity } from '@/stores/session-store'
+import { getToolExecutionPhase } from './tool-execution-phase'
+
+const activity = (overrides: Partial<ToolActivity> = {}): ToolActivity => ({
+  id: 'tool-1',
+  kind: 'tool',
+  title: 'mcp__open-science-notebook__notebook_execute',
+  providerToolName: 'mcp__open-science-notebook__notebook_execute',
+  promptMessageId: 'prompt-1',
+  status: 'in_progress',
+  eventIds: ['event-1'],
+  sortIndex: 1,
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides
+})
+
+const permission = (
+  overrides: Partial<SessionPermissionRuntimeContext> = {}
+): SessionPermissionRuntimeContext => ({
+  state: 'pending',
+  request: {
+    requestId: 'permission-1',
+    sessionId: 'session-1',
+    toolCallId: 'tool-1',
+    title: 'Run code',
+    options: []
+  },
+  originatingPromptMessageId: 'prompt-1',
+  fingerprint: 'fingerprint-1',
+  createdAt: 1,
+  ...overrides
+})
+
+const run = (overrides: Partial<NotebookRunRecord> = {}): NotebookRunRecord => ({
+  runId: 'run-1',
+  executionInvocationId: 'invocation-1',
+  cellId: 'cell-1',
+  source: 'agent',
+  kernelKind: 'python',
+  script: 'print(1)',
+  status: 'running',
+  startedAt: 1,
+  text: { stdout: '', stderr: '', traceback: '', plain: [] },
+  outputs: [],
+  artifacts: [],
+  workingFiles: [],
+  ...overrides
+})
+
+describe('getToolExecutionPhase', () => {
+  it('separates prepared code from a matching durable approval wait', () => {
+    expect(getToolExecutionPhase(activity(), undefined)).toBe('prepared')
+    expect(getToolExecutionPhase(activity(), permission())).toBe('awaiting-approval')
+  })
+
+  it('fails closed when permission identity does not match the active activity', () => {
+    expect(
+      getToolExecutionPhase(
+        activity(),
+        permission({ request: { ...permission().request, toolCallId: 'other-tool' } })
+      )
+    ).toBe('prepared')
+    expect(
+      getToolExecutionPhase(activity(), permission({ originatingPromptMessageId: 'other-prompt' }))
+    ).toBe('prepared')
+  })
+
+  it('keeps explicit rejection and permission closure distinct from observer failure', () => {
+    expect(
+      getToolExecutionPhase(
+        activity({ status: 'completed', toolDisposition: 'declined' }),
+        undefined
+      )
+    ).toBe('declined')
+    expect(
+      getToolExecutionPhase(
+        activity({ status: 'in_progress', toolDisposition: 'permission-closed' }),
+        undefined
+      )
+    ).toBe('prepared')
+    expect(getToolExecutionPhase(activity({ status: 'failed' }), undefined)).toBe('prepared')
+  })
+
+  it('closes an ordinary tool row when its permission settles without execution', () => {
+    expect(
+      getToolExecutionPhase(
+        activity({
+          title: 'Run shell command',
+          providerToolName: 'Bash',
+          toolDisposition: 'permission-closed'
+        }),
+        undefined
+      )
+    ).toBe('closed')
+  })
+
+  it('requires an exact app-owned invocation identity before showing Notebook execution', () => {
+    const runs = new Map([['run-1', run()]])
+    expect(getToolExecutionPhase(activity({ status: 'completed' }), undefined, runs)).toBe(
+      'prepared'
+    )
+    expect(
+      getToolExecutionPhase(activity({ executionInvocationId: 'invocation-1' }), undefined, runs)
+    ).toBe('executing')
+    expect(
+      getToolExecutionPhase(
+        activity({ status: 'completed', executionInvocationId: 'stale-invocation' }),
+        undefined,
+        runs
+      )
+    ).toBe('prepared')
+  })
+
+  it.each(['Claude Code', 'OpenCode', 'Codex Responses', 'Codex Bridge'])(
+    'does not let a %s observer limit terminate or relabel an admitted Run',
+    () => {
+      const runs = new Map([['run-1', run()]])
+      expect(
+        getToolExecutionPhase(
+          activity({ status: 'failed', executionInvocationId: 'invocation-1' }),
+          undefined,
+          runs
+        )
+      ).toBe('executing')
+
+      runs.set('run-1', run({ status: 'completed', endedAt: 2 }))
+      expect(
+        getToolExecutionPhase(
+          activity({ status: 'failed', executionInvocationId: 'invocation-1' }),
+          undefined,
+          runs
+        )
+      ).toBe('completed')
+    }
+  )
+
+  it.each([
+    ['failed', 'failed'],
+    ['timeout', 'limit-reached'],
+    ['interrupted', 'interrupted'],
+    ['cancelled', 'cancelled'],
+    ['completed', 'completed']
+  ] as const)('preserves the correlated Run terminal status %s', (status, phase) => {
+    const runs = new Map([['run-1', run({ status, endedAt: 2 })]])
+
+    expect(
+      getToolExecutionPhase(
+        activity({ status: 'completed', executionInvocationId: 'invocation-1' }),
+        undefined,
+        runs
+      )
+    ).toBe(phase)
+  })
+})

--- a/src/renderer/src/pages/workspace/tool-execution-phase.ts
+++ b/src/renderer/src/pages/workspace/tool-execution-phase.ts
@@ -1,0 +1,81 @@
+import type { SessionPermissionRuntimeContext } from '../../../../shared/session-persistence'
+import type { NotebookRunRecord } from '../../../../shared/notebook'
+import type { ToolActivity } from '@/stores/session-store'
+
+import { isNotebookExecuteToolName } from './notebook-tool-names'
+
+type ToolExecutionPhase =
+  | 'prepared'
+  | 'awaiting-approval'
+  | 'executing'
+  | 'completed'
+  | 'declined'
+  | 'closed'
+  | 'failed'
+  | 'limit-reached'
+  | 'cancelled'
+  | 'interrupted'
+
+const isNotebookExecutionActivity = (activity: ToolActivity): boolean =>
+  isNotebookExecuteToolName(activity.providerToolName) || isNotebookExecuteToolName(activity.title)
+
+const getCorrelatedNotebookRun = (
+  activity: ToolActivity,
+  notebookRunsById?: ReadonlyMap<string, NotebookRunRecord>
+): NotebookRunRecord | undefined =>
+  activity.executionInvocationId
+    ? Array.from(notebookRunsById?.values() ?? []).find(
+        (run) => run.executionInvocationId === activity.executionInvocationId
+      )
+    : undefined
+
+const getToolExecutionPhase = (
+  activity: ToolActivity,
+  permission: SessionPermissionRuntimeContext | undefined,
+  notebookRunsById?: ReadonlyMap<string, NotebookRunRecord>
+): ToolExecutionPhase => {
+  if (activity.toolDisposition === 'declined') return 'declined'
+  const correlatedRun = isNotebookExecutionActivity(activity)
+    ? getCorrelatedNotebookRun(activity, notebookRunsById)
+    : undefined
+  // Notebook owns execution truth. An outer ACP observer failure/closure cannot stop or relabel a
+  // Run that the authenticated bridge has already admitted, including multi-hour executions.
+  switch (correlatedRun?.status) {
+    case 'queued':
+    case 'running':
+      return 'executing'
+    case 'completed':
+      return 'completed'
+    case 'failed':
+      return 'failed'
+    case 'timeout':
+      return 'limit-reached'
+    case 'cancelled':
+      return 'cancelled'
+    case 'interrupted':
+      return 'interrupted'
+  }
+
+  if (activity.toolDisposition === 'permission-closed') {
+    return isNotebookExecutionActivity(activity) ? 'prepared' : 'closed'
+  }
+  if (
+    permission?.state === 'pending' &&
+    permission.request.toolCallId === activity.id &&
+    permission.originatingPromptMessageId === activity.promptMessageId
+  ) {
+    return 'awaiting-approval'
+  }
+
+  if (isNotebookExecutionActivity(activity)) {
+    // ACP status describes the outer tool observer, not Notebook execution. Without an exact
+    // app-owned Run join, even a terminal observer stays fail-closed at prepared (static code).
+    return 'prepared'
+  }
+  if (activity.status === 'failed') return 'failed'
+  if (activity.status === 'completed') return 'completed'
+  return 'executing'
+}
+
+export { getCorrelatedNotebookRun, getToolExecutionPhase, isNotebookExecutionActivity }
+export type { ToolExecutionPhase }

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -499,8 +499,8 @@ describe('conversation message scroller integration', () => {
     expect(workspaceActivityGroupSource).toContain('data-testid="tool-group"')
     expect(workspaceActivityGroupSource).toContain('data-testid="tool-group-header"')
     expect(workspaceActivityGroupSource).toContain('<WorkspaceWebSearchActivityRow')
-    expect(workspaceActivityGroupSource).toContain(
-      'formatActivityGroupTitle(group.activities, group.title)'
+    expect(workspaceActivityGroupSource).toMatch(
+      /formatActivityGroupPresentationTitle\(\s*group\.activities,\s*group\.title,\s*permission,\s*notebookRunsById\s*\)/
     )
     expect(workspaceActivityGroupSource).toContain('getRenderableActivityEntries(group.activities)')
     expect(workspaceWebSearchActivityRowSource).toContain('const WorkspaceWebSearchActivityRow')
@@ -631,7 +631,7 @@ describe('notebook preview integration', () => {
     expect(notebookPreviewSource).toContain("source: 'user'")
     expect(notebookPreviewSource).toContain("inputKind: 'terminal'")
     expect(notebookPreviewSource).toContain(
-      "import {\n  resolveRunErrorLine,\n  environmentLabel,\n  isProblemRunStatus,\n  kernelKindLabel,\n  kernelOriginLabel,\n  resolveRunEnvironment,\n  resolveRunKernelKind\n} from './notebook-cell-utils'"
+      "import {\n  resolveRunErrorLine,\n  environmentLabel,\n  isProblemRunStatus,\n  kernelKindLabel,\n  kernelOriginLabel,\n  notebookRunStatusLabel,\n  resolveRunEnvironment,\n  resolveRunKernelKind\n} from './notebook-cell-utils'"
     )
     expect(notebookPreviewSource).toContain('[{index}]')
     expect(notebookPreviewSource).toContain('resolveRunKernelKind(run)')

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.test.ts
@@ -659,7 +659,7 @@ describe('workspace conversation items', () => {
           toolKind: 'other'
         })
       )
-    ).toBe('Used tool: Notebook cell')
+    ).toBe('Used tool: Notebook run')
 
     expect(
       formatActivityTitle(
@@ -673,6 +673,33 @@ describe('workspace conversation items', () => {
     ).toBe('Using tool: Notebook restart')
   })
 
+  it.each([
+    ['limit-reached', 'Execution limit reached: Notebook run'],
+    ['cancelled', 'Cancelled: Notebook run'],
+    ['interrupted', 'Interrupted: Notebook run'],
+    ['failed', 'Tool failed: Notebook run'],
+    ['completed', 'Used tool: Notebook run']
+  ] as const)('formats the Notebook terminal phase %s', (phase, expected) => {
+    expect(
+      formatActivityTitle(
+        createActivity({
+          status: 'completed',
+          providerToolName: 'mcp__open-science-notebook__notebook_execute'
+        }),
+        phase
+      )
+    ).toBe(expected)
+  })
+
+  it('formats an ordinary closed tool without implying rejection or execution cancellation', () => {
+    expect(
+      formatActivityTitle(
+        createActivity({ status: 'in_progress', providerToolName: 'Bash' }),
+        'closed'
+      )
+    ).toBe('Request ended: Bash')
+  })
+
   it('detects notebook tools whose server name was underscore-sanitized (Codex/gpt bridge)', () => {
     // The gpt/codex bridge rewrites the hyphenated server name to underscores; still a notebook cell.
     expect(
@@ -684,7 +711,7 @@ describe('workspace conversation items', () => {
           toolKind: 'other'
         })
       )
-    ).toBe('Used tool: Notebook cell')
+    ).toBe('Used tool: Notebook run')
   })
 
   it('detects a Codex notebook activity whose MCP identity is only in the title', () => {
@@ -697,7 +724,7 @@ describe('workspace conversation items', () => {
           toolKind: 'execute'
         })
       )
-    ).toBe('Used tool: Notebook cell')
+    ).toBe('Used tool: Notebook run')
   })
 
   it('falls back to readable tool kind names for unnamed tools', () => {

--- a/src/renderer/src/pages/workspace/workspace-conversation-items.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-items.ts
@@ -11,6 +11,7 @@ import {
   projectInlineParentMessages,
   type InlineParentMessageProjection
 } from './subagent-release-projection'
+import { isNotebookExecutionActivity, type ToolExecutionPhase } from './tool-execution-phase'
 
 type ConversationMessageItem = {
   id: string
@@ -92,7 +93,7 @@ const formatNotebookToolName = (toolName: string): string | undefined => {
 
   switch (suffix) {
     case 'notebook_execute':
-      return 'Notebook cell'
+      return 'Notebook run'
     case 'notebook_state':
       return 'Notebook state'
     case 'notebook_restart':
@@ -106,7 +107,8 @@ const formatNotebookToolName = (toolName: string): string | undefined => {
 
 // Treats pending and in-progress tool calls as live activity rows.
 const isActivityActive = (activity: ToolActivity): boolean =>
-  activity.status === 'pending' || activity.status === 'in_progress'
+  (activity.status === 'pending' || activity.status === 'in_progress') &&
+  !isNotebookExecutionActivity(activity)
 
 const isContextCompactionActivity = (activity: ToolActivity): boolean =>
   activity.providerToolName === ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME
@@ -153,7 +155,9 @@ const formatActivityToolName = (activity: ToolActivity): string => {
 }
 
 // Builds the status-sensitive text for non-search activity chips.
-const formatActivityTitle = (activity: ToolActivity): string => {
+const formatActivityTitle = (activity: ToolActivity, phase?: ToolExecutionPhase): string => {
+  if (phase === 'closed') return `Request ended: ${formatActivityToolName(activity)}`
+
   if (isContextCompactionActivity(activity)) {
     const title = trimDetail(activity.title)
 
@@ -175,6 +179,15 @@ const formatActivityTitle = (activity: ToolActivity): string => {
 
   const toolName = formatActivityToolName(activity)
 
+  if (phase === 'declined') return `Declined by you: ${toolName}`
+  if (phase === 'awaiting-approval') return `Waiting for your approval: ${toolName}`
+  if (phase === 'prepared') return `Code shown: ${toolName}`
+  if (phase === 'limit-reached') return `Execution limit reached: ${toolName}`
+  if (phase === 'cancelled') return `Cancelled: ${toolName}`
+  if (phase === 'interrupted') return `Interrupted: ${toolName}`
+  if (phase === 'failed') return `Tool failed: ${toolName}`
+  if (phase === 'completed') return `Used tool: ${toolName}`
+  if (phase === 'executing') return `Using tool: ${toolName}`
   if (activity.status === 'failed') return `Tool failed: ${toolName}`
   if (activity.status === 'completed') return `Used tool: ${toolName}`
 

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
@@ -209,7 +209,7 @@ describe('workspace tool activity details', () => {
     })
     const details = buildToolActivityDetails(activity)
 
-    expect(details?.displayName).toBe('Notebook cell')
+    expect(details?.displayName).toBe('Notebook run')
     // Only the compact run id enters transcript presentation data. Figure bytes stay in the local
     // notebook state and are resolved by the expanded row at render time.
     expect(details?.notebookRunId).toBe('notebook-run-1')
@@ -249,7 +249,7 @@ describe('workspace tool activity details', () => {
     })
     const details = buildToolActivityDetails(activity)
 
-    expect(details?.displayName).toBe('Notebook cell')
+    expect(details?.displayName).toBe('Notebook run')
     expect(details?.sections[0]).toMatchObject({
       kind: 'code',
       label: 'Code',
@@ -270,7 +270,7 @@ describe('workspace tool activity details', () => {
     })
     const details = buildToolActivityDetails(activity)
 
-    expect(details?.displayName).toBe('Notebook cell')
+    expect(details?.displayName).toBe('Notebook run')
     expect(details?.sections[0]).toMatchObject({
       kind: 'code',
       language: 'python',
@@ -296,7 +296,7 @@ describe('workspace tool activity details', () => {
     })
     const details = buildToolActivityDetails(activity)
 
-    expect(details?.displayName).toBe('Notebook cell')
+    expect(details?.displayName).toBe('Notebook run')
   })
 
   it('falls back to the run summary script when notebook input code is unavailable', () => {
@@ -343,7 +343,7 @@ describe('workspace tool activity details', () => {
 
     const details = buildToolActivityDetails(activity)
 
-    expect(details?.displayName).toBe('Notebook cell')
+    expect(details?.displayName).toBe('Notebook run')
     expect(details?.sections[0]).toMatchObject({
       label: 'Code',
       language: 'r',

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
@@ -728,9 +728,10 @@ const buildNotebookDetails = (activity: ToolActivity): ToolActivityDetails | und
 
   const status = summary && typeof summary.status === 'string' ? summary.status : undefined
 
-  // Derive display name from language: python/r are cells, javascript (repl) is Agent SDK, bash is shell.
+  // Derive display name from language: python/r are Notebook runs, javascript (repl) is Agent SDK,
+  // and bash is shell.
   const displayName =
-    language === 'javascript' ? 'Agent SDK' : language === 'bash' ? 'Shell' : 'Notebook cell'
+    language === 'javascript' ? 'Agent SDK' : language === 'bash' ? 'Shell' : 'Notebook run'
 
   return {
     displayName,

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ChatMessage, ToolActivity } from '@/stores/session-store'
+import type { NotebookRunRecord } from '../../../../shared/notebook'
 import type { ConversationItem } from './workspace-conversation-items'
 import {
   formatActivityGroupElapsed,
+  formatActivityGroupPresentationTitle,
   formatActivityGroupTitle,
   formatStepCount,
   getActivityGroupElapsedMs,
@@ -255,9 +257,17 @@ describe('formatActivityGroupTitle', () => {
   it('categorizes representative tools through the header clause', () => {
     const cases: Array<[Partial<ToolActivity>, string]> = [
       [{ providerToolName: 'websearch' }, 'Ran a search'],
-      [{ providerToolName: 'mcp__open-science-notebook__notebook_execute' }, 'Ran a notebook cell'],
+      [
+        { providerToolName: 'mcp__open-science-notebook__notebook_execute' },
+        'Completed a Notebook run'
+      ],
       // Codex/gpt bridge underscore-sanitizes the server name; still categorized as a notebook cell.
-      [{ providerToolName: 'mcp__open_science_notebook__notebook_execute' }, 'Ran a notebook cell'],
+      [
+        { providerToolName: 'mcp__open_science_notebook__notebook_execute' },
+        'Completed a Notebook run'
+      ],
+      // OpenCode flattens the server/tool boundary to a single underscore.
+      [{ providerToolName: 'open-science-notebook_notebook_execute' }, 'Completed a Notebook run'],
       [{ providerToolName: 'skill' }, 'Loaded a skill'],
       [{ providerToolName: 'save_artifacts' }, 'Saved a file'],
       [{ providerToolName: 'manage_packages' }, 'Managed an environment'],
@@ -273,6 +283,90 @@ describe('formatActivityGroupTitle', () => {
     for (const [overrides, expected] of cases) {
       expect(formatActivityGroupTitle([createActivity(overrides)])).toBe(expected)
     }
+  })
+})
+
+describe('formatActivityGroupPresentationTitle', () => {
+  const notebook = (overrides: Partial<ToolActivity> = {}): ToolActivity =>
+    createActivity({
+      status: 'in_progress',
+      providerToolName: 'mcp__open-science-notebook__notebook_execute',
+      promptMessageId: 'prompt-1',
+      ...overrides
+    })
+
+  it('separates prepared and waiting Notebook headers without inferring execution', () => {
+    expect(formatActivityGroupPresentationTitle([notebook()], undefined, undefined)).toBe(
+      'Notebook code shown'
+    )
+    expect(
+      formatActivityGroupPresentationTitle([notebook()], undefined, {
+        state: 'pending',
+        request: {
+          requestId: 'permission-1',
+          sessionId: 'session-1',
+          toolCallId: 'tool-1',
+          title: 'Run code',
+          options: []
+        },
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: 'fingerprint-1',
+        createdAt: 1
+      })
+    ).toBe('Waiting for your approval')
+  })
+
+  it.each([
+    ['timeout', 'Execution limit reached for Notebook run'],
+    ['cancelled', 'Cancelled Notebook run'],
+    ['interrupted', 'Interrupted Notebook run'],
+    ['failed', 'Failed Notebook run']
+  ] as const)('preserves the correlated Notebook %s group outcome', (status, expected) => {
+    const notebookActivity = notebook({ executionInvocationId: 'invocation-1' })
+    const notebookRun: NotebookRunRecord = {
+      runId: 'run-1',
+      executionInvocationId: 'invocation-1',
+      cellId: 'cell-1',
+      source: 'agent',
+      kernelKind: 'python',
+      script: 'print(1)',
+      status,
+      startedAt: 1,
+      endedAt: 2,
+      text: { stdout: '', stderr: '', traceback: '', plain: [] },
+      outputs: [],
+      artifacts: [],
+      workingFiles: []
+    }
+
+    expect(
+      formatActivityGroupPresentationTitle(
+        [notebookActivity],
+        undefined,
+        undefined,
+        new Map([['run-1', notebookRun]])
+      )
+    ).toBe(expected)
+  })
+
+  it('leaves non-Notebook group titles unchanged', () => {
+    expect(
+      formatActivityGroupPresentationTitle(
+        [createActivity({ toolKind: 'read' })],
+        undefined,
+        undefined
+      )
+    ).toBe('Read a file')
+  })
+
+  it('does not describe a closed ordinary tool request as executed', () => {
+    expect(
+      formatActivityGroupPresentationTitle(
+        [createActivity({ status: 'in_progress', toolDisposition: 'permission-closed' })],
+        undefined,
+        undefined
+      )
+    ).toBe('Tool request ended')
   })
 })
 
@@ -334,6 +428,18 @@ describe('formatStepCount', () => {
     expect(formatStepCount([createActivity({ id: 's1' }), createActivity({ id: 's2' })])).toBe(
       '2 steps'
     )
+  })
+
+  it('does not count a closed Notebook permission as an execution failure', () => {
+    expect(
+      formatStepCount([
+        createActivity({
+          status: 'failed',
+          providerToolName: 'mcp__open-science-notebook__notebook_execute',
+          toolDisposition: 'permission-closed'
+        })
+      ])
+    ).toBe('1 step')
   })
 })
 

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
@@ -1,13 +1,12 @@
 import type { PersistedActivityGroup } from '../../../../shared/session-persistence'
 import type { ToolActivity } from '@/stores/session-store'
 
-import {
-  getNotebookToolSuffix,
-  isActivityActive,
-  type ConversationItem
-} from './workspace-conversation-items'
+import { isActivityActive, type ConversationItem } from './workspace-conversation-items'
 import { isEditActivity, isSkillActivity } from './workspace-tool-activity-details'
 import { hasWebSearchContentEvidence } from './workspace-web-search-details'
+import { getToolExecutionPhase, isNotebookExecutionActivity } from './tool-execution-phase'
+import type { SessionPermissionRuntimeContext } from '../../../../shared/session-persistence'
+import type { NotebookRunRecord } from '../../../../shared/notebook'
 
 type ConversationActivityGroupItem = {
   id: string
@@ -191,8 +190,8 @@ const categorizeActivity = (
 
   const providerName = getNormalizedProviderName(activity)
 
-  // A notebook_execute call is one cell run; summarize it as such instead of a generic tool.
-  if (getNotebookToolSuffix(providerName) === 'notebook_execute') return 'notebook'
+  // A Notebook execution is one run; use the shared provider-name matcher for every ACP backend.
+  if (isNotebookExecutionActivity(activity)) return 'notebook'
   if (isSkillActivity(activity)) return 'skill'
   if (providerName === 'save_artifacts' || providerName.includes('artifact')) return 'artifact'
   if (providerName === 'manage_packages' || providerName.includes('package')) return 'environment'
@@ -233,7 +232,7 @@ const formatCategoryClause = (category: ActivityCategory, count: number): string
     case 'artifact':
       return count === 1 ? 'saved a file' : `saved ${count} files`
     case 'notebook':
-      return count === 1 ? 'ran a notebook cell' : `ran ${count} notebook cells`
+      return count === 1 ? 'completed a Notebook run' : `completed ${count} Notebook runs`
     default:
       return count === 1 ? 'ran a tool' : `ran ${count} tools`
   }
@@ -269,6 +268,37 @@ const formatActivityGroupTitle = (activities: ToolActivity[], declaredTitle?: st
   return capitalizeFirst(clauses.join(', '))
 }
 
+const formatActivityGroupPresentationTitle = (
+  activities: ToolActivity[],
+  declaredTitle: string | undefined,
+  permission: SessionPermissionRuntimeContext | undefined,
+  notebookRunsById?: ReadonlyMap<string, NotebookRunRecord>
+): string => {
+  const activityPhases = activities.map((activity) => ({
+    isNotebook: isNotebookExecutionActivity(activity),
+    phase: getToolExecutionPhase(activity, permission, notebookRunsById)
+  }))
+  const phases = activityPhases.filter(({ isNotebook }) => isNotebook).map(({ phase }) => phase)
+  const notebookCount = phases.length
+  if (notebookCount === 0) {
+    if (activityPhases.length > 0 && activityPhases.every(({ phase }) => phase === 'closed')) {
+      return activityPhases.length === 1 ? 'Tool request ended' : 'Tool requests ended'
+    }
+    return formatActivityGroupTitle(activities, declaredTitle)
+  }
+  const noun = notebookCount === 1 ? 'Notebook run' : `${notebookCount} Notebook runs`
+
+  if (phases.includes('awaiting-approval')) return 'Waiting for your approval'
+  if (phases.includes('executing')) return `Running ${noun}`
+  if (phases.includes('prepared')) return 'Notebook code shown'
+  if (phases.includes('declined')) return `Declined ${noun}`
+  if (phases.includes('failed')) return `Failed ${noun}`
+  if (phases.includes('limit-reached')) return `Execution limit reached for ${noun}`
+  if (phases.includes('interrupted')) return `Interrupted ${noun}`
+  if (phases.includes('cancelled')) return `Cancelled ${noun}`
+  return formatActivityGroupTitle(activities, declaredTitle)
+}
+
 // Removes ToolSearch wrapper rows from rendering once concrete search rows are available.
 const getRenderableActivityEntries = (activities: ToolActivity[]): RenderableActivityEntry[] => {
   const hasSearchActivities = countSearchActivities(activities) > 0
@@ -279,20 +309,29 @@ const getRenderableActivityEntries = (activities: ToolActivity[]): RenderableAct
 }
 
 // Formats the group header's total visible-step count, flagging any failed steps.
-const formatStepCount = (activities: ToolActivity[]): string => {
+const formatStepCount = (
+  activities: ToolActivity[],
+  permission?: SessionPermissionRuntimeContext,
+  notebookRunsById?: ReadonlyMap<string, NotebookRunRecord>
+): string => {
   const activityCount = activities.length
   const stepLabel = activityCount === 1 ? '1 step' : `${activityCount} steps`
-  const failedCount = activities.filter((activity) => activity.status === 'failed').length
+  const failedCount = activities.filter(
+    (activity) => getToolExecutionPhase(activity, permission, notebookRunsById) === 'failed'
+  ).length
 
   return failedCount > 0 ? `${stepLabel} · ${failedCount} failed` : stepLabel
 }
 
 // Adds each tool's own runtime, excluding idle gaps between tools in the same group.
-const getActivityGroupElapsedMs = (activities: ToolActivity[], now: number): number =>
+const getActivityGroupElapsedMs = (
+  activities: ToolActivity[],
+  now: number,
+  isActive: (activity: ToolActivity) => boolean = isActivityActive
+): number =>
   activities.reduce(
     (total, activity) =>
-      total +
-      Math.max(0, (isActivityActive(activity) ? now : activity.updatedAt) - activity.createdAt),
+      total + Math.max(0, (isActive(activity) ? now : activity.updatedAt) - activity.createdAt),
     0
   )
 
@@ -313,6 +352,7 @@ const formatActivityGroupElapsed = (elapsedMs: number): string => {
 
 export {
   formatActivityGroupElapsed,
+  formatActivityGroupPresentationTitle,
   formatActivityGroupTitle,
   formatStepCount,
   getActivityGroupElapsedMs,

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-style.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-style.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ToolActivity } from '@/stores/session-store'
+
+import { getActivitySurfaceClassName } from './workspace-tool-activity-style'
+
+const activity: ToolActivity = {
+  id: 'tool-1',
+  kind: 'tool',
+  title: 'Notebook cell',
+  status: 'completed',
+  eventIds: ['event-1'],
+  sortIndex: 1,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+describe('getActivitySurfaceClassName', () => {
+  it('keeps active and inactive surface classes when an execution phase is provided', () => {
+    expect(getActivitySurfaceClassName(activity, 'executing')).toContain(
+      'text-text-000 hover:bg-bg-300'
+    )
+    expect(getActivitySurfaceClassName(activity, 'completed')).toContain(
+      'text-text-100 hover:bg-bg-200'
+    )
+  })
+
+  it('keeps the danger surface for failed execution', () => {
+    expect(getActivitySurfaceClassName(activity, 'failed')).toContain(
+      'text-danger-000 hover:bg-danger-900'
+    )
+  })
+})

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-style.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-style.ts
@@ -2,14 +2,15 @@ import { cn } from '@/lib/utils'
 import type { ToolActivity } from '@/stores/session-store'
 
 import { isActivityActive } from './workspace-conversation-items'
+import type { ToolExecutionPhase } from './tool-execution-phase'
 
 // Centralizes compact activity-row styling so search and generic tool rows stay visually aligned.
-const getActivitySurfaceClassName = (activity: ToolActivity): string =>
+const getActivitySurfaceClassName = (activity: ToolActivity, phase?: ToolExecutionPhase): string =>
   cn(
     'flex w-full min-h-[44px] items-start gap-2 rounded-lg py-2 pl-1.5 pr-2.5 text-[13px] transition-colors md:min-h-0 md:items-center md:py-[5px]',
-    activity.status === 'failed'
+    (phase ? phase === 'failed' : activity.status === 'failed')
       ? 'text-danger-000 hover:bg-danger-900'
-      : isActivityActive(activity)
+      : (phase ? phase === 'executing' : isActivityActive(activity))
         ? 'text-text-000 hover:bg-bg-300'
         : 'text-text-100 hover:bg-bg-200'
   )

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -55,6 +55,8 @@ export type ToolActivity = {
   activityGroupId?: string
   promptMessageId?: string
   status: ToolActivityStatus
+  toolDisposition?: 'declined' | 'permission-closed'
+  executionInvocationId?: string
   eventIds: string[]
   sortIndex: number
   providerToolName?: string

--- a/src/renderer/src/stores/session-store-run-activity-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-activity-helpers.ts
@@ -21,6 +21,8 @@ export type UpsertToolActivityInput = {
   promptMessageId?: string
   title?: string
   status?: string
+  toolDisposition?: 'declined' | 'permission-closed'
+  executionInvocationId?: string
   providerToolName?: string
   toolKind?: ToolKind
   toolContent?: ToolCallContent[]
@@ -192,6 +194,8 @@ export const projectToolActivity = (
               promptMessageId: input.promptMessageId ?? activity.promptMessageId,
               title: input.title?.trim() || activity.title,
               status: mergeToolActivityStatus(activity.status, nextStatus),
+              toolDisposition: input.toolDisposition ?? activity.toolDisposition,
+              executionInvocationId: input.executionInvocationId ?? activity.executionInvocationId,
               providerToolName: input.providerToolName ?? activity.providerToolName,
               toolKind: input.toolKind ?? activity.toolKind,
               toolContent: input.toolContent ?? activity.toolContent,
@@ -221,6 +225,8 @@ export const projectToolActivity = (
     kind: 'tool',
     title: createToolActivityTitle(input.title, input.toolKind),
     status: nextStatus ?? 'pending',
+    toolDisposition: input.toolDisposition,
+    executionInvocationId: input.executionInvocationId,
     eventIds: [input.eventId],
     sortIndex: createSortIndex(),
     activityGroupId: activeGroup?.id,

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -4485,6 +4485,7 @@ describe('session store public contract', () => {
       'src/renderer/src/pages/workspace/session-notebook-projection.ts',
       'src/renderer/src/pages/workspace/session-plan/active-branch-plan.ts',
       'src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.ts',
+      'src/renderer/src/pages/workspace/tool-execution-phase.ts',
       'src/renderer/src/pages/workspace/use-project-artifact-files.ts',
       'src/renderer/src/pages/workspace/use-side-chat-controller.ts',
       'src/renderer/src/pages/workspace/workspace-conversation-controller.ts',

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -497,6 +497,12 @@ export type AcpRuntimeEvent = {
   title?: string
   status?: string
   toolCallId?: string
+  // App-owned authorization outcome. It stays separate from provider tool status so a rejected or
+  // otherwise closed permission request cannot be presented as an execution failure.
+  toolDisposition?: 'declined' | 'permission-closed'
+  // App-owned one-shot identity for exact Notebook activity/Run correlation. Provider payloads
+  // cannot supply it; the permission and authenticated RPC owners issue and consume it.
+  executionInvocationId?: string
   providerToolName?: string
   toolKind?: ToolKind
   toolContent?: ToolCallContent[]

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -4,9 +4,16 @@ import type { OptionalProjectIdScope, ProjectIdScope } from './project-scope'
 
 export const NOTEBOOKS_DIR = 'notebooks'
 export const NOTEBOOK_RUN_FILE = 'run.json'
+// Execution authorization canonicalizes omitted control/shell deadlines to the same defaults used
+// by the MCP schema and process owner. These are runtime constants, not persisted schema fields.
+export const NOTEBOOK_REPL_DEFAULT_TIMEOUT_MS = 30 * 60 * 1_000 + 15_000
+export const NOTEBOOK_SHELL_DEFAULT_TIMEOUT_MS = 120_000
 
 // Identifies whether a run was initiated by the agent or by the user terminal.
 export type NotebookRunSource = 'agent' | 'user'
+
+// Exact app-local dispatch methods corresponding to the three approval-gated Notebook MCP tools.
+export type NotebookExecutionRpcMethod = 'execute' | 'executeControl' | 'executeShell'
 
 // Distinguishes regular notebook cells from terminal submissions in the same history.
 export type NotebookRunInputKind = 'cell' | 'terminal'
@@ -306,6 +313,9 @@ export type NotebookKernelMetadata = {
 // Stores one durable notebook execution, including code, output, and generated-file references.
 export type NotebookRunRecord = {
   runId: string
+  // App-owned one-shot identity joining an authorized ACP tool call to the execution admitted by
+  // the authenticated Notebook RPC bridge. Optional keeps existing run.json documents readable.
+  executionInvocationId?: string
   cellId: string
   source: NotebookRunSource
   inputKind?: NotebookRunInputKind
@@ -340,9 +350,10 @@ export type NotebookRunRecord = {
   messageBranchId?: string
   runtimeSegmentId?: string
   promptMessageId?: string
-  // Why a run ended non-normally. Set to 'app-terminated' when a stale 'running' run is reconciled to
-  // 'interrupted' on the next startup (the process died mid-run). Absent for normal completions.
-  interruptionReason?: 'app-terminated'
+  // Why a run ended non-normally. 'app-terminated' is startup reconciliation after process death;
+  // 'execution-error' is an unexpected execution-infrastructure rejection in the live process.
+  // Optional keeps existing run.json documents readable without a migration.
+  interruptionReason?: 'app-terminated' | 'execution-error'
 }
 
 // The complete JSON document persisted at each notebook session's run.json path.
@@ -368,7 +379,15 @@ export type NotebookCell = {
   id: string
   language: NotebookLanguage
   code: string
-  status: 'idle' | 'receiving-code' | 'running' | 'completed' | 'failed'
+  status:
+    | 'idle'
+    | 'receiving-code'
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'timeout'
+    | 'interrupted'
+    | 'cancelled'
   writeId?: string
   executionCount?: number
   latestRunId?: string
@@ -447,6 +466,8 @@ export type NotebookSessionRequest = OptionalProjectIdScope & {
   sessionId: string
   workspaceCwd: string
   provenanceContext?: NotebookRunProvenanceContext
+  // Injected only by the authenticated local RPC bridge. Public/renderer adapters strip it.
+  executionInvocationId?: string
   // Injected only by the authenticated local RPC bridge after resolving the active turn registry.
   // Renderer IPC strips this field before calling the runtime service.
   registeredInputFiles?: NotebookRunInputFile[]

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -1017,6 +1017,7 @@ describe('sanitizeToolActivity', () => {
       title: 'Edit app.ts',
       activityGroupId: 'group-1',
       promptMessageId: 'prompt-1',
+      executionInvocationId: 'execution-1',
       status: 'completed',
       sortIndex: 3,
       eventIds: ['event-1'],
@@ -1038,6 +1039,7 @@ describe('sanitizeToolActivity', () => {
       title: 'Edit app.ts',
       activityGroupId: 'group-1',
       promptMessageId: 'prompt-1',
+      executionInvocationId: 'execution-1',
       status: 'completed',
       providerToolName: 'Edit',
       toolKind: 'edit',
@@ -1048,6 +1050,36 @@ describe('sanitizeToolActivity', () => {
       { type: 'content', content: { type: 'text', text: 'ok' } },
       { type: 'diff', path: '/repo/app.ts', oldText: 'a', newText: 'b' }
     ])
+  })
+
+  it('keeps legacy activities without an execution invocation identity', () => {
+    const activity = sanitizeToolActivity({ id: 'legacy-tool', status: 'in_progress' })
+
+    expect(activity).not.toHaveProperty('executionInvocationId')
+  })
+
+  it('keeps only known tool dispositions', () => {
+    expect(
+      sanitizeToolActivity({
+        id: 'tool-closed',
+        status: 'in_progress',
+        toolDisposition: 'permission-closed'
+      })
+    ).toMatchObject({ toolDisposition: 'permission-closed' })
+    expect(
+      sanitizeToolActivity({
+        id: 'tool-declined',
+        status: 'completed',
+        toolDisposition: 'declined'
+      })?.toolDisposition
+    ).toBe('declined')
+    expect(
+      sanitizeToolActivity({
+        id: 'tool-unknown',
+        status: 'completed',
+        toolDisposition: 'cancelled'
+      })?.toolDisposition
+    ).toBeUndefined()
   })
 
   it('truncates oversized terminal output', () => {
@@ -2078,6 +2110,71 @@ describe('normalizeSessionFile with activities', () => {
         id: 'activity-1',
         kind: 'tool',
         title: 'downloading',
+        status: 'in_progress',
+        sortIndex: 1,
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      })
+    )
+
+    expect(activities?.[0]?.status).toBe('failed')
+  })
+
+  it.each([
+    'mcp__open-science-notebook__notebook_execute',
+    'open_science_notebook_repl_execute',
+    'mcp.open-science-notebook.bash_execute',
+    'open-science-notebook/notebook_execute'
+  ])('restores an unowned Notebook activity as static code for %s', (providerToolName) => {
+    const activities = getRestoredActivities(
+      createSessionWithActivity({
+        id: 'activity-1',
+        kind: 'tool',
+        title: providerToolName,
+        providerToolName,
+        executionInvocationId: 'stale-invocation',
+        status: 'in_progress',
+        sortIndex: 1,
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      })
+    )
+
+    expect(activities?.[0]).toMatchObject({
+      status: 'in_progress',
+      toolDisposition: 'permission-closed'
+    })
+    expect(activities?.[0]).not.toHaveProperty('executionInvocationId')
+  })
+
+  it('keeps terminal Notebook Run correlation for historical projection', () => {
+    const activities = getRestoredActivities(
+      createSessionWithActivity({
+        id: 'activity-1',
+        kind: 'tool',
+        title: 'mcp__open-science-notebook__notebook_execute',
+        providerToolName: 'mcp__open-science-notebook__notebook_execute',
+        executionInvocationId: 'completed-invocation',
+        status: 'completed',
+        sortIndex: 1,
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 2
+      })
+    )
+
+    expect(activities?.[0]?.executionInvocationId).toBe('completed-invocation')
+  })
+
+  it('does not treat a lookalike Notebook server as app-owned static code', () => {
+    const activities = getRestoredActivities(
+      createSessionWithActivity({
+        id: 'activity-1',
+        kind: 'tool',
+        title: 'mcp__open-science-notebook-staging__notebook_execute',
+        providerToolName: 'mcp__open-science-notebook-staging__notebook_execute',
         status: 'in_progress',
         sortIndex: 1,
         eventIds: [],

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -397,6 +397,7 @@ export type PersistedPendingHistoryReplay =
   { kind: 'all' } | { kind: 'before-message'; messageId: string }
 
 export type PersistedToolActivityStatus = 'pending' | 'in_progress' | 'completed' | 'failed'
+export type PersistedToolActivityDisposition = 'declined' | 'permission-closed'
 
 // A file location a tool touched; kept small so it can always be persisted.
 export type PersistedToolCallLocation = {
@@ -413,6 +414,8 @@ export type PersistedToolActivity = {
   activityGroupId?: string
   promptMessageId?: string
   status: PersistedToolActivityStatus
+  toolDisposition?: PersistedToolActivityDisposition
+  executionInvocationId?: string
   sortIndex: number
   eventIds: string[]
   providerToolName?: string
@@ -537,6 +540,10 @@ const TOOL_ACTIVITY_STATUSES = new Set<PersistedToolActivityStatus>([
   'in_progress',
   'completed',
   'failed'
+])
+const TOOL_ACTIVITY_DISPOSITIONS = new Set<PersistedToolActivityDisposition>([
+  'declined',
+  'permission-closed'
 ])
 const SESSION_STATUSES = new Set<PersistedSessionStatus>([
   'idle',
@@ -2407,6 +2414,41 @@ const asToolActivityStatus = (value: unknown): PersistedToolActivityStatus => {
   return status && TOOL_ACTIVITY_STATUSES.has(status) ? status : 'completed'
 }
 
+const asToolActivityDisposition = (
+  value: unknown
+): PersistedToolActivityDisposition | undefined => {
+  const disposition = asString(value) as PersistedToolActivityDisposition | undefined
+  return disposition && TOOL_ACTIVITY_DISPOSITIONS.has(disposition) ? disposition : undefined
+}
+
+const NOTEBOOK_RUN_TOOL_SUFFIXES = new Set(['notebook_execute', 'repl_execute', 'bash_execute'])
+
+// Matches only the app-owned Notebook server identities emitted by supported ACP adapters.
+// Restoration must fail closed: a lookalike provider tool is never reclassified as static code.
+const isPersistedNotebookRunActivity = (activity: PersistedToolActivity): boolean => {
+  const names = [activity.providerToolName, activity.title]
+  return names.some((candidate) => {
+    const name = candidate?.trim().toLowerCase()
+    if (!name) return false
+
+    const segments = name.split(/__|\.|\//u)
+    if (segments.length >= 2) {
+      const tool = segments.at(-1)
+      const server = segments.at(-2)?.replace(/_/gu, '-')
+      if (server === 'open-science-notebook' && tool && NOTEBOOK_RUN_TOOL_SUFFIXES.has(tool)) {
+        return true
+      }
+    }
+
+    for (const tool of NOTEBOOK_RUN_TOOL_SUFFIXES) {
+      if (name === `open-science-notebook_${tool}` || name === `open_science_notebook_${tool}`) {
+        return true
+      }
+    }
+    return false
+  })
+}
+
 // Rebuilds a persisted tool activity from durable fields, bounding every large payload.
 export const sanitizeToolActivity = (activity: unknown): PersistedToolActivity | undefined => {
   if (!isRecord(activity)) return undefined
@@ -2436,6 +2478,8 @@ export const sanitizeToolActivity = (activity: unknown): PersistedToolActivity |
   const terminalOutput = asCappedString(activity.terminalOutput, MAX_PERSISTED_TEXT_CHARS)
   const terminalExitCode = asNumber(activity.terminalExitCode)
   const elicitation = sanitizeElicitationProjection(activity.elicitation)
+  const toolDisposition = asToolActivityDisposition(activity.toolDisposition)
+  const executionInvocationId = asString(activity.executionInvocationId)
 
   if (providerToolName) sanitized.providerToolName = providerToolName
   if (activityGroupId) sanitized.activityGroupId = activityGroupId
@@ -2448,27 +2492,43 @@ export const sanitizeToolActivity = (activity: unknown): PersistedToolActivity |
   if (terminalOutput !== undefined) sanitized.terminalOutput = terminalOutput
   if (terminalExitCode !== undefined) sanitized.terminalExitCode = terminalExitCode
   if (elicitation) sanitized.elicitation = elicitation
+  if (toolDisposition) sanitized.toolDisposition = toolDisposition
+  if (executionInvocationId) sanitized.executionInvocationId = executionInvocationId
 
   return sanitized
 }
 
 // Runtime activity state cannot resume after restart unless the exact active-Branch tool call is
-// parked behind durable permission authority. Restore every other open activity as failed.
+// parked behind durable permission authority. An unowned Notebook call remains static: process loss
+// is not evidence that its displayed code failed. Its process-scoped Run correlation is discarded.
 const normalizeActivityAfterRestore = (
   activity: PersistedToolActivity,
   permissionAuthority?: RestorablePermissionToolAuthority
-): PersistedToolActivity => ({
-  ...activity,
-  ...((activity.status === 'pending' || activity.status === 'in_progress') &&
-  !activity.elicitation?.durable &&
-  (activity.id !== permissionAuthority?.activity.id ||
-    activity.promptMessageId !== permissionAuthority.permission.originatingPromptMessageId)
-    ? { status: 'failed' as const }
-    : {}),
-  ...(activity.elicitation?.state === 'pending' && !activity.elicitation.durable
-    ? { elicitation: { ...activity.elicitation, state: 'cancelled' as const } }
-    : {})
-})
+): PersistedToolActivity => {
+  const closesOpenActivity =
+    (activity.status === 'pending' || activity.status === 'in_progress') &&
+    !activity.elicitation?.durable &&
+    (activity.id !== permissionAuthority?.activity.id ||
+      activity.promptMessageId !== permissionAuthority.permission.originatingPromptMessageId)
+  const closesOpenNotebookActivity = closesOpenActivity && isPersistedNotebookRunActivity(activity)
+  const normalized: PersistedToolActivity = {
+    ...activity,
+    ...(closesOpenActivity
+      ? closesOpenNotebookActivity
+        ? { toolDisposition: 'permission-closed' as const }
+        : { status: 'failed' as const }
+      : {}),
+    ...(activity.elicitation?.state === 'pending' && !activity.elicitation.durable
+      ? { elicitation: { ...activity.elicitation, state: 'cancelled' as const } }
+      : {})
+  }
+
+  if (closesOpenNotebookActivity) {
+    delete normalized.executionInvocationId
+  }
+
+  return normalized
+}
 
 export const sanitizeActivityGroup = (group: unknown): PersistedActivityGroup | undefined => {
   if (!isRecord(group)) return undefined


### PR DESCRIPTION
## Problem

Notebook tool presentation currently looks like execution has already started. A code preview or a durable approval wait can therefore appear as a running Notebook, and an execution/terminalization failure can leave the persisted Run stuck in `running` until reconciliation restarts. Long-running work must also not be failed or shown in red merely because time has elapsed.

After an app restart, approving a restored Notebook permission makes the provider replay the parked call with a fresh protocol `toolCallId`. Without a stable presentation identity, that replay can create a second visible copy of the same Notebook code.

## Proposed change

- Split Notebook tool presentation into prepared code, waiting for approval, executing, and terminal phases.
- Treat the Notebook Run as the source of execution truth, joined to the approved ACP tool call with an app-owned one-shot `executionInvocationId`.
- Consume that authorization only through the authenticated session-bound Notebook RPC capability and fail closed for missing, stale, duplicate, ambiguous, or input-mismatched joins.
- Keep denied and permission-closed calls neutral and distinct from execution cancellation.
- Remove the implicit Python/R execution deadline and use the long-lived RPC transport.
- Propagate Agent request cancellation through MCP and local RPC to an admitted Notebook execution. The Run becomes `cancelled`; responsive POSIX kernels preserve their namespace, while an unresponsive kernel is reclaimed after a two-second cancellation grace period.
- Bind each one-shot execution authorization to a canonical digest of its complete trusted executable input while retaining only a bounded permission preview for UI and persistence.
- Release live cell ownership when terminal persistence fails and retry the pending terminal write during later same-process reconciliation.
- Reserve red error treatment for actual failed Runs.
- For a restored Notebook approval, keep the provider replay ID for protocol authorization but project an exact permission-fingerprint match through the original durable activity ID. This process-local alias is consumed once and mismatches remain separate.

## Platform behavior and non-goals

- On Windows, Node cannot send a recoverable console interrupt to the current headless kernel process. Cancellation therefore persists the Run as `cancelled`, terminates the kernel tree, marks the kernel `terminated`, and lazily starts a fresh kernel on the next execution. No app restart is required, but the in-memory namespace is lost. POSIX uses the same fallback only when the kernel does not acknowledge `SIGINT` within two seconds.
- Namespace-preserving Windows cancellation is deferred and is not part of this PR's protocol scope.
- No database migration or persistence schema version bump is required. New correlation fields are optional; restored replay presentation aliases are process-local.
- Existing Run statuses remain readable; this changes their UI projection, not their stored meaning.
- Explicit internal execution limits remain supported; elapsed time alone does not stop an agent-facing Python/R Notebook Run.
- Control REPL and shell tools retain their explicit execution limits. Until their process owners consume cancellation end to end, their RPC transport remains attached so Agent cancellation cannot falsely report completion while work continues.
- Unrelated approval systems keep their authorization semantics.

## Acceptance criteria and validation

The final focused Test Impact Set ran after the last material edit on `6bc20522`:

- Restored permission identity and projection contracts: `npm test -- --run src/main/acp/permission-context.test.ts src/main/acp/session-update-projector.test.ts` — 43 tests passed.
- Restored continuation and Notebook presentation contracts, including Codex Responses replay with no visible replay ID: `npm test -- --run src/main/acp/runtime.test.ts -t 'ACP runtime restored permission continuation|ACP Notebook permission presentation contract|original Notebook presentation id'` — 40 tests passed, 504 skipped by the explicit filter.
- Runtime composition and root renderer consumer: `npm test -- --run src/main/acp/runtime-session-composition.test.ts src/renderer/src/lib/acp/workspace-events.test.ts` — 84 tests passed.
- Cross-process TypeScript contracts: `npm run typecheck` — passed.
- Source/style validation: `npm run lint` — passed with 0 errors; 11 pre-existing warnings remain outside the changed files.
- Changed-file formatting: `npx prettier --check <six changed ACP files>` — passed.
- Diff validation: `git diff --check` — passed.

Earlier iterations also ran the complete portable suite after the broad lifecycle implementation. The latest replay-only adjustment used the focused impact set above; exact-head CI is authoritative for the complete portable suite, native Windows execution, and platform packaging.

## Historical compatibility

- Legacy Sessions and Runs without `executionInvocationId` continue to deserialize. They remain static unless an exact current Run correlation exists.
- Persisted approval waits continue to restore after app restart.
- A matching replay updates the original Notebook activity instead of creating a second code row; this requires no persisted alias or migration.
- Restored unfinished Notebook activities do not become errors solely due to process loss.
- Existing `timeout`, `cancelled`, and `interrupted` Run records retain their stored statuses and use neutral presentation.
- The Windows fallback reuses existing Run/kernel statuses and therefore requires no historical data migration.

## Review focus

- Trust boundary between ACP permission identity, restored replay presentation identity, the session-bound RPC capability, and Run creation.
- Exact-match and fail-closed behavior for a provider replay after restart.
- Cancellation propagation from Agent request ownership to the admitted Notebook Run.
- POSIX kernel preservation versus the explicitly documented Windows fallback.
- Same-process terminal-write retry and cleanup of live cell ownership.
- Historical restore behavior and consistent Activity Stream language.
