### PR TITLE
feat(providers): enable DeepSeek V4 Pro Responses

### DIFF
--- a/src/main/settings/provider-runtime-projection.test.ts
+++ b/src/main/settings/provider-runtime-projection.test.ts
@@ -74,6 +74,29 @@ describe('ProviderRuntimeProjectionOwner', () => {
     expect(provider).toEqual(before)
   })
 
+  it('routes DeepSeek V4 Pro through native Responses for Codex', () => {
+    const owner = new ProviderRuntimeProjectionOwner()
+    const provider: StoredProvider = {
+      id: 'deepseek',
+      type: 'official',
+      vendorId: 'deepseek',
+      name: 'DeepSeek'
+    }
+
+    expect(
+      owner.resolveRuntimeTarget(
+        provider,
+        { kind: 'required', model: 'deepseek-v4-pro' },
+        getAgentFramework('codex')
+      )
+    ).toMatchObject({
+      apiEndpoints: ['anthropic', 'openai', 'responses'],
+      frameworkCompatible: true,
+      needsChatResponsesBridge: false,
+      needsNativeResponsesCompatibility: true
+    })
+  })
+
   it('keeps an exact required model when a subscription catalog is unknown', () => {
     const owner = new ProviderRuntimeProjectionOwner()
     const provider: StoredProvider = {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2684,9 +2684,14 @@ describe('SettingsService: preflight & spawn config', () => {
     await repository.setAgentFramework('codex')
     const provider = (
       await service.upsertProvider({
-        type: 'official',
-        name: 'DeepSeek',
-        vendorId: 'deepseek',
+        type: 'custom',
+        name: 'Chat Gateway',
+        apiEndpoints: ['openai'],
+        baseUrl: 'https://api.deepseek.com/v1',
+        model: 'deepseek-v4-pro',
+        contextWindow: 1_000_000,
+        reasoningEffortPreset: 'none-high',
+        reasoningEffortTransport: 'deepseek',
         key: 'test-key'
       })
     ).providers[0]
@@ -2695,9 +2700,7 @@ describe('SettingsService: preflight & spawn config', () => {
       ...storedProvider,
       lastValidatedAt: Date.now()
     })
-    // deepseek-v4-pro does not yet support the native Responses API, so it drives the Chat Completions
-    // bridge (the test's whole purpose). deepseek-v4-flash would route to native Responses instead.
-    await service.setActiveProvider(provider.id, 'deepseek-v4-pro')
+    await service.setActiveProvider(provider.id)
     await repository.setReasoningEffort('low')
 
     vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'codex')

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3337,24 +3337,22 @@ describe('SettingsService: official vendors', () => {
     })
   })
 
-  it('probes DeepSeek with the bridge tool-call contract under Codex', async () => {
+  it('probes DeepSeek Pro through the native Responses route under Codex', async () => {
     const service = createService()
     await repository.setAgentFramework('codex')
-    const fetchMock = vi.fn().mockResolvedValue(validBridgeToolCallResponse())
+    const fetchMock = vi.fn().mockResolvedValue(validNativeCompatibilityToolCallResponse())
     vi.stubGlobal('fetch', fetchMock)
 
     const result = await service.validateProvider({
       draft: { type: 'official', vendorId: 'deepseek', key: 'sk-ds' }
     })
 
-    expect(result.ok).toBe(true)
-    // The dual-endpoint vendor reaches Codex through the Chat Completions bridge, so the probe must
-    // prove streaming function calls on the same OpenAI route before validation succeeds.
-    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body))
-    expect(fetchMock.mock.calls[0][0]).toBe('https://api.deepseek.com/v1/chat/completions')
-    expect(body).toMatchObject({
+    expect(result).toMatchObject({ ok: true, category: 'ok' })
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.deepseek.com/v1/responses')
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+      model: 'deepseek-v4-pro',
       stream: true,
-      tools: [{ type: 'function', function: { name: 'open_science_bridge_probe' } }]
+      tools: [{ type: 'function', name: 'open_science__bridge_probe' }]
     })
   })
 

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -617,13 +617,14 @@ describe('provider registry', () => {
       expect(isVendorModelResponsesSupported('volcengine', 'doubao-seed-2-1-pro-260628')).toBe(true)
     })
 
-    it('returns true for DeepSeek flash only (per-model Responses support)', () => {
+    it('returns true for every bundled DeepSeek V4 model', () => {
+      expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-pro')).toBe(true)
+      expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-pro[1m]')).toBe(true)
       expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-flash')).toBe(true)
     })
 
-    it('returns false for DeepSeek models that do not yet implement Responses', () => {
-      expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-pro')).toBe(false)
-      expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-pro[1m]')).toBe(false)
+    it('returns false for unknown DeepSeek models', () => {
+      expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v3')).toBe(false)
     })
 
     it('returns false for vendors with no Responses support at all', () => {

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -215,9 +215,9 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       { id: 'deepseek-v4-pro[1m]', contextWindow: 1_000_000 },
       { id: 'deepseek-v4-flash', contextWindow: 1_000_000 }
     ],
-    // DeepSeek serves a native Responses API for deepseek-v4-flash only; deepseek-v4-pro does not yet
-    // implement /v1/responses (planned for early August 2026), so it stays on the Chat Completions bridge.
-    responsesModels: ['deepseek-v4-flash']
+    // Both DeepSeek V4 models serve the native Responses API. Keep the explicit list because the
+    // vendor also exposes non-Responses models through its live model catalog.
+    responsesModels: ['deepseek-v4-pro', 'deepseek-v4-pro[1m]', 'deepseek-v4-flash']
     // DeepSeek's chat models are text-only, so no `multimodal` rule (image input stays disabled).
   },
   {


### PR DESCRIPTION
## Problem

DeepSeek now documents native Responses API support for `deepseek-v4-pro`, but the provider registry still advertised Responses only for `deepseek-v4-flash`. Codex therefore treated the Pro model and its bundled `[1m]` variant as incompatible.

## Proposed change

- Advertise native Responses support for `deepseek-v4-pro` and `deepseek-v4-pro[1m]`.
- Keep the existing explicit per-model capability list so unknown live-catalog models remain fail-closed.
- Add registry and runtime projection coverage proving Codex selects native Responses compatibility instead of the Chat Completions bridge.

Official capability reference: https://api-docs.deepseek.com/zh-cn/quick_start/pricing/

## Scope and non-goals

This reuses the existing Responses transport and compatibility proxy. It does not change protocol adapters, persistence, provider setup UI, model context windows, or non-DeepSeek providers.

## Acceptance criteria and validation

All checks listed below ran after the final material edit:

- DeepSeek V4 Responses capability and Codex runtime routing -> `npm run test:module -- settings_provider_accounts` -> 20 files, 331 tests passed.
- Main-process TypeScript consumers -> `npm run typecheck:node` -> passed.
- Shared registry renderer consumers -> `npm run typecheck:web` -> passed.
- Source lint and formatting rules -> `npm run lint` -> passed.
- Patch whitespace validity -> `git diff --check` -> passed.

Consumer and platform impact: the changed shared capability is consumed by settings runtime projection and account resolution, both covered by the module impact set. No protocol adapter, persistence, path, OS-specific, or UI behavior changed, so no additional platform or E2E lanes were included. CI remains authoritative for cross-platform verification.

Uncovered risk: validation confirms routing selection without making a live authenticated DeepSeek API request.

## Review focus

Confirm the explicit DeepSeek model list matches the official Responses support matrix and that the existing native Responses compatibility route remains the correct Codex path.