### PR TITLE
fix(renderer): improve responsive panel accessibility

### DIFF
--- a/src/renderer/src/components/ui/resizable.test.tsx
+++ b/src/renderer/src/components/ui/resizable.test.tsx
@@ -27,4 +27,19 @@ describe('ResizableHandle', () => {
       ])
     )
   })
+
+  it('includes horizontal-separator geometry for vertical panel groups', () => {
+    const markup = renderToStaticMarkup(<ResizableHandle aria-label="Resize stacked panels" />)
+    const classNames = markup.match(/class="([^"]*)"/)?.[1]?.split(' ') ?? []
+
+    expect(classNames).toEqual(
+      expect.arrayContaining([
+        'aria-[orientation=horizontal]:h-px',
+        'aria-[orientation=horizontal]:w-full',
+        'aria-[orientation=horizontal]:after:h-3',
+        'aria-[orientation=horizontal]:before:h-0.5',
+        'aria-[orientation=horizontal]:before:w-8'
+      ])
+    )
+  })
 })

--- a/src/renderer/src/components/ui/resizable.tsx
+++ b/src/renderer/src/components/ui/resizable.tsx
@@ -36,9 +36,9 @@ function ResizableHandle({
       data-slot="resizable-handle"
       className={cn(
         // Wide after-hit area makes CSS :hover match the draggable edge; default tick is thin and centered.
-        'relative flex w-px items-center justify-center bg-transparent outline-none',
-        "after:absolute after:inset-y-0 after:left-1/2 after:w-3 after:-translate-x-1/2 after:content-['']",
-        'before:pointer-events-none before:absolute before:top-1/2 before:left-1/2 before:z-10 before:h-8 before:w-0.5 before:-translate-x-1/2 before:-translate-y-1/2 before:rounded-full before:bg-text-300 before:opacity-0',
+        'relative flex w-px items-center justify-center bg-transparent outline-none aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full',
+        "after:absolute after:inset-y-0 after:left-1/2 after:w-3 after:-translate-x-1/2 after:content-[''] aria-[orientation=horizontal]:after:inset-x-0 aria-[orientation=horizontal]:after:inset-y-auto aria-[orientation=horizontal]:after:top-1/2 aria-[orientation=horizontal]:after:h-3 aria-[orientation=horizontal]:after:w-auto aria-[orientation=horizontal]:after:-translate-y-1/2 aria-[orientation=horizontal]:after:translate-x-0",
+        'before:pointer-events-none before:absolute before:top-1/2 before:left-1/2 before:z-10 before:h-8 before:w-0.5 before:-translate-x-1/2 before:-translate-y-1/2 before:rounded-full before:bg-text-300 before:opacity-0 aria-[orientation=horizontal]:before:h-0.5 aria-[orientation=horizontal]:before:w-8',
         'hover:before:opacity-60 focus-visible:before:opacity-60 data-[separator=active]:before:opacity-60',
         className
       )}

--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -246,6 +246,28 @@ describe('ConnectorsPanel (groups)', () => {
     expect(addConnector?.getAttribute('data-variant')).toBe('outline')
   })
 
+  it('uses a two-row narrow toolbar with full-width search and paired actions', () => {
+    act(() => {
+      root.render(<ConnectorsPanel onNavigate={vi.fn()} />)
+    })
+
+    const toolbar = document.body.querySelector<HTMLElement>('[data-testid="connectors-toolbar"]')
+    const search = document.body.querySelector<HTMLInputElement>('[aria-label="Search connectors"]')
+    const filter = document.body.querySelector<HTMLElement>(
+      '[aria-label="Filter connectors by group"]'
+    )
+    const addConnector = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('button')
+    ).find((button) => button.textContent?.includes('Add connector'))
+
+    expect(toolbar?.className).toContain('grid-cols-2')
+    expect(toolbar?.className).toContain('sm:grid-cols-[minmax(0,1fr)_9rem_auto]')
+    expect(search?.parentElement?.className).toContain('col-span-2')
+    expect(search?.parentElement?.className).toContain('sm:col-span-1')
+    expect(filter?.className).toContain('w-full')
+    expect(addConnector?.className).toContain('w-full')
+  })
+
   it('toggles a featured connector and navigates to its detail on row click', () => {
     const onNavigate = vi.fn()
     act(() => {

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -368,9 +368,22 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
         )}
       </SettingsSection>
 
-      <div className="mb-4 flex items-center gap-2">
+      <div
+        className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-[minmax(0,1fr)_9rem_auto] sm:items-center"
+        data-testid="connectors-toolbar"
+      >
+        <SettingsSearchInput
+          aria-label="Search connectors"
+          containerClassName="col-span-2 min-w-0 sm:col-span-1 sm:col-start-1 sm:row-start-1"
+          placeholder="Search connectors…"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
         <Select value={filter} onValueChange={(value) => setFilter(value as GroupFilter)}>
-          <SelectTrigger aria-label="Filter connectors by group" className="w-36">
+          <SelectTrigger
+            aria-label="Filter connectors by group"
+            className="w-full sm:col-start-2 sm:row-start-1"
+          >
             <span>{FILTER_LABELS[filter]}</span>
           </SelectTrigger>
           <SelectContent>
@@ -380,15 +393,12 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
             <SelectItem value="custom">Custom</SelectItem>
           </SelectContent>
         </Select>
-        <SettingsSearchInput
-          aria-label="Search connectors"
-          placeholder="Search connectors…"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-        />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" className="shrink-0">
+            <Button
+              variant="outline"
+              className="w-full justify-center sm:col-start-3 sm:row-start-1 sm:w-auto sm:shrink-0"
+            >
               <Plus data-icon="inline-start" aria-hidden="true" />
               Add connector
               <ChevronDown data-icon="inline-end" className="opacity-70" aria-hidden="true" />

--- a/src/renderer/src/pages/settings/RemoteControlPanel.tsx
+++ b/src/renderer/src/pages/settings/RemoteControlPanel.tsx
@@ -31,9 +31,10 @@ import {
   dialogTitleClassName
 } from '@/components/ui/dialog-chrome'
 import { cn } from '@/lib/utils'
-import { SettingsSection } from './SettingsLayout'
+import { SettingsIconAction, SettingsSection } from './SettingsLayout'
 
 const REMOTE_IT_DOWNLOAD_URL = 'https://www.remote.it/download/'
+type CopyStatus = 'idle' | 'copied' | 'error'
 
 const lifecycleLabel = (snapshot: RemoteAccessSnapshot): string => {
   if (snapshot.lifecycle === 'starting') return 'Starting…'
@@ -121,11 +122,12 @@ export const RemoteControlPanel = (): React.JSX.Element => {
   const [snapshot, setSnapshot] = useState<RemoteAccessSnapshot | null>(null)
   const [busy, setBusy] = useState<string | null>('loading')
   const [actionError, setActionError] = useState<string | undefined>()
-  const [copied, setCopied] = useState(false)
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle')
 
   const operationTriggerRef = useRef<HTMLElement | null>(null)
   const initialLoadRetryRef = useRef(false)
   const mountedRef = useRef(false)
+  const copyResetTimerRef = useRef<number | undefined>(undefined)
   const refresh = async (detect = false, completesBusyOperation = true): Promise<void> => {
     try {
       const next = detect
@@ -167,6 +169,9 @@ export const RemoteControlPanel = (): React.JSX.Element => {
     return () => {
       active = false
       mountedRef.current = false
+      if (copyResetTimerRef.current !== undefined) {
+        window.clearTimeout(copyResetTimerRef.current)
+      }
       unsubscribe()
     }
   }, [])
@@ -206,9 +211,21 @@ export const RemoteControlPanel = (): React.JSX.Element => {
 
   const copyUrl = async (): Promise<void> => {
     if (!snapshot?.accessUrl) return
-    await navigator.clipboard.writeText(snapshot.accessUrl)
-    setCopied(true)
-    window.setTimeout(() => setCopied(false), 1_500)
+    if (copyResetTimerRef.current !== undefined) {
+      window.clearTimeout(copyResetTimerRef.current)
+    }
+    setCopyStatus('idle')
+
+    try {
+      await navigator.clipboard.writeText(snapshot.accessUrl)
+      if (!mountedRef.current) return
+      setCopyStatus('copied')
+      copyResetTimerRef.current = window.setTimeout(() => {
+        if (mountedRef.current) setCopyStatus('idle')
+      }, 1_500)
+    } catch {
+      if (mountedRef.current) setCopyStatus('error')
+    }
   }
 
   if (!snapshot) {
@@ -514,7 +531,7 @@ export const RemoteControlPanel = (): React.JSX.Element => {
                             onClick={() => void copyUrl()}
                           >
                             <Copy className="size-3.5" aria-hidden="true" />
-                            {copied ? 'Copied' : 'Copy'}
+                            {copyStatus === 'copied' ? 'Copied' : 'Copy'}
                           </Button>
                           <Button type="button" variant="outline" size="sm" asChild>
                             <a href={snapshot.accessUrl} target="_blank" rel="noreferrer">
@@ -527,6 +544,24 @@ export const RemoteControlPanel = (): React.JSX.Element => {
                       <div className="mt-1 break-all font-mono text-xs text-muted-foreground">
                         {snapshot.accessUrl}
                       </div>
+                      {copyStatus === 'error' ? (
+                        <div
+                          role="alert"
+                          className="mt-2 text-xs text-destructive"
+                          data-testid="remote-link-copy-error"
+                        >
+                          Could not copy the browser link. Select it and copy it manually.
+                        </div>
+                      ) : null}
+                      <span
+                        role="status"
+                        aria-live="polite"
+                        aria-atomic="true"
+                        className="sr-only"
+                        data-testid="remote-link-copy-status"
+                      >
+                        {copyStatus === 'copied' ? 'Browser link copied.' : ''}
+                      </span>
                     </div>
                   </div>
                   <BrowserAccessSteps />
@@ -583,21 +618,17 @@ export const RemoteControlPanel = (): React.JSX.Element => {
                       Last used {timeLabel(browser.lastSeenAt)}
                     </div>
                   </div>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
+                  <SettingsIconAction
+                    label={`Revoke ${browser.browser}`}
+                    icon={Trash2}
+                    danger
                     disabled={busy !== null}
                     onClick={() =>
                       void run(`revoke:${browser.id}`, () =>
                         window.api.remoteAccess.revokeBrowser({ browserId: browser.id })
                       )
                     }
-                    aria-label={`Revoke ${browser.browser}`}
-                    className="text-muted-foreground hover:text-destructive"
-                  >
-                    <Trash2 className="size-4" aria-hidden="true" />
-                  </Button>
+                  />
                 </div>
               ))}
             </div>

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1785,6 +1785,58 @@ describe('SettingsPage layout', () => {
     expect(settingsSection('Remote App Access')).toBeUndefined()
   })
 
+  it('reports and announces a rejected browser-link copy attempt', async () => {
+    const remoteAccess = (
+      window as unknown as {
+        api: {
+          remoteAccess: {
+            getSnapshot: ReturnType<typeof vi.fn>
+            detect: ReturnType<typeof vi.fn>
+          }
+        }
+      }
+    ).api.remoteAccess
+    const publicSnapshot = {
+      canManage: true,
+      canManagePairing: true,
+      mode: 'remoteit-public',
+      enabled: true,
+      lifecycle: 'running',
+      accessUrl: 'https://open-science.connect.remote.it/',
+      remoteItPublicUrl: 'https://open-science.connect.remote.it/',
+      remoteIt: {
+        installed: true,
+        loggedIn: true,
+        registered: true,
+        service: { id: 'service-1', host: '127.0.0.1', port: 44100, enabled: true, ready: true }
+      },
+      pendingRequests: [],
+      trustedBrowsers: []
+    }
+    remoteAccess.getSnapshot.mockResolvedValue(publicSnapshot)
+    remoteAccess.detect.mockResolvedValue(publicSnapshot)
+    const writeText = vi.fn().mockRejectedValue(new Error('Clipboard permission denied'))
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await act(async () => navButton('Remote control')?.click())
+    const copyButton = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Copy'
+    )
+
+    await act(async () => {
+      copyButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(writeText).toHaveBeenCalledWith(publicSnapshot.accessUrl)
+    const copyError = document.body.querySelector('[data-testid="remote-link-copy-error"]')
+    expect(copyError?.getAttribute('role')).toBe('alert')
+    expect(copyError?.textContent).toContain('Could not copy the browser link')
+  })
+
   it('explains Remote.It Device setup after a pre-install selection failed', async () => {
     const remoteAccess = (
       window as unknown as {

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -331,6 +331,29 @@ describe('NotebookPreview per-kernel tabs', () => {
     }
   }
 
+  it('uses one notebook scroll owner and an accessible real resize handle', async () => {
+    await mountWithRuns([makeRun({ runId: 'p1', kernelKind: 'python' })])
+
+    const split = container.querySelector<HTMLElement>('[data-group]')
+    const cellsPanel = container.querySelector<HTMLElement>('[data-panel]')
+    const cellsPanelContent = cellsPanel?.firstElementChild as HTMLElement | undefined
+    const cells = container.querySelector<HTMLElement>('[data-testid="notebook-cells"]')
+    const divider = container.querySelector<HTMLElement>('[data-separator]')
+
+    expect(split?.hasAttribute('data-group')).toBe(true)
+    expect(split?.className).toContain('flex-col')
+    expect(cellsPanel?.hasAttribute('data-panel')).toBe(true)
+    expect(cellsPanelContent?.className).toContain('overflow-hidden')
+    expect(cells?.className).toContain('overflow-y-auto')
+    expect(cells?.parentElement).toBe(cellsPanelContent)
+    expect(divider?.getAttribute('role')).toBe('separator')
+    expect(divider?.getAttribute('aria-label')).toBe('Resize notebook and terminal')
+    expect(divider?.getAttribute('aria-orientation')).toBe('horizontal')
+    expect(
+      container.querySelector('[data-testid="notebook-terminal-header"]')?.textContent
+    ).toContain('Python kernel')
+  })
+
   it('shows a tab only for kernel kinds present in the runs (no default python/r tab)', async () => {
     await mountWithRuns([
       makeRun({ runId: 'p1', kernelKind: 'python' }),

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
 
 import type {
   NotebookEnvironmentStatus,
@@ -549,32 +550,44 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
         </div>
       ) : null}
 
-      <div className="flex min-h-0 flex-1 flex-col" data-testid="operon-notebook-terminal-split">
-        <div className="min-h-0 flex-[4_1_0] overflow-visible" data-testid="notebook-cells-panel">
-          <div className="flex h-full min-h-0 flex-col overflow-auto">
-            <div className="min-h-0 flex-1 overflow-y-auto" data-testid="notebook-cells">
-              <div className="divide-y divide-border-100">
-                {visibleRuns.map((run, index) => (
-                  <NotebookRunCell key={run.runId} run={run} index={index} />
-                ))}
-              </div>
+      <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 flex-col">
+        <ResizablePanel
+          id="notebook-cells-panel"
+          defaultSize="80%"
+          minSize="35%"
+          className="min-h-0 overflow-hidden"
+        >
+          <div
+            className="h-full min-h-0 overflow-y-auto overscroll-contain"
+            data-testid="notebook-cells"
+          >
+            <div className="divide-y divide-border-100">
+              {visibleRuns.map((run, index) => (
+                <NotebookRunCell key={run.runId} run={run} index={index} />
+              ))}
             </div>
           </div>
-        </div>
+        </ResizablePanel>
 
-        <div
-          aria-orientation="horizontal"
-          className="group relative flex shrink-0 select-none items-center justify-between gap-2 border-y border-border-200 bg-bg-200/70 px-3 py-1 text-[11px] text-text-300 outline-none transition-colors hover:bg-bg-200"
-          data-testid="notebook-terminal-divider"
-          role="separator"
+        <ResizableHandle
+          aria-label="Resize notebook and terminal"
+          className="shrink-0 bg-border-200"
+        />
+
+        <ResizablePanel
+          id="notebook-terminal-panel"
+          defaultSize="20%"
+          minSize="15%"
+          className="min-h-0 overflow-hidden"
         >
-          <span>Python kernel · shared with the agent</span>
-          <div className="pointer-events-none absolute left-1/2 top-1/2 h-1 w-8 -translate-x-1/2 -translate-y-1/2 rounded-full bg-border-100 opacity-60 transition duration-150 group-hover:opacity-100" />
-          <span>{isNotebookBusy ? 'running' : 'idle'}</span>
-        </div>
-
-        <div className="min-h-0 flex-[1_1_0]" data-testid="notebook-terminal-panel">
           <div className="flex h-full min-h-0 flex-col bg-bg-200" data-testid="kernel-terminal">
+            <div
+              className="flex shrink-0 items-center justify-between gap-2 border-b border-border-200 bg-bg-200/70 px-3 py-1 text-[11px] text-text-300"
+              data-testid="notebook-terminal-header"
+            >
+              <span>Python kernel · shared with the agent</span>
+              <span>{isNotebookBusy ? 'running' : 'idle'}</span>
+            </div>
             {actionError ? (
               <div className="border-b border-border-100/60 px-3 py-2 font-mono text-xs text-danger-000">
                 {actionError}
@@ -590,8 +603,8 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
               }}
             />
           </div>
-        </div>
-      </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
     </section>
   )
 }

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -189,7 +189,9 @@ const PreviewFileHeader = ({
               <Maximize2 aria-hidden="true" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent className={tooltipClassName}>Open full screen preview</TooltipContent>
+          <TooltipContent className={tooltipClassName}>
+            {`Open full screen preview of ${item.title}`}
+          </TooltipContent>
         </Tooltip>
       </TooltipProvider>
     ) : null}
@@ -207,7 +209,9 @@ const PreviewFileHeader = ({
             <X aria-hidden="true" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent className={tooltipClassName}>Close preview</TooltipContent>
+        <TooltipContent className={tooltipClassName}>
+          {`Close preview of ${item.title}`}
+        </TooltipContent>
       </Tooltip>
     </TooltipProvider>
   </header>

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -803,7 +803,7 @@ describe('ProjectFilesView', () => {
         )
         ?.focus()
     })
-    expect(document.body.textContent).toContain('Open in split view beside the session')
+    expect(document.body.textContent).toContain('Open result.txt in split view beside the session')
 
     await act(async () => {
       container.querySelector<HTMLButtonElement>('[aria-label="List view"]')?.click()
@@ -958,7 +958,7 @@ describe('ProjectFilesView', () => {
     expect(clearButton?.className).not.toContain('focus-visible:ring-2')
 
     await act(async () => clearButton?.focus())
-    expect(document.body.textContent).toContain('Clear search')
+    expect(document.body.textContent).toContain('Clear file search')
 
     await act(async () => clearButton?.click())
     expect(search?.value).toBe('')
@@ -1107,6 +1107,27 @@ describe('ProjectFilesView', () => {
       await Promise.resolve()
     })
     expect(repairIndex).toHaveBeenCalledWith({ projectId: 'default' })
+  })
+
+  it('wraps and announces a long file loading error while keeping retry available', async () => {
+    const message =
+      'Could not load project files because the remote catalog returned a detailed error that must remain readable on narrow screens.'
+
+    await renderView([], false, () => {
+      vi.mocked(window.api.projectFiles.getOverview).mockRejectedValue(new Error(message))
+    })
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(message)
+    })
+
+    const alert = container.querySelector<HTMLElement>('[role="alert"]')
+    const errorText = alert?.querySelector('span')
+    expect(alert?.getAttribute('aria-atomic')).toBe('true')
+    expect(errorText?.className).toContain('whitespace-pre-wrap')
+    expect(errorText?.className).toContain('break-words')
+    expect(errorText?.className).not.toContain('truncate')
+    expect(alert?.querySelector<HTMLButtonElement>('button')?.textContent).toBe('Retry')
   })
 
   it('renders uploaded files under Your uploads without a session group', async () => {

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -94,8 +94,12 @@ const PageLoadError = ({
   message: string
   onRetry: () => void
 }): React.JSX.Element => (
-  <div className="flex items-center justify-between gap-3 px-4 py-3 text-[11px] text-danger-000">
-    <span className="min-w-0 flex-1 truncate">{message}</span>
+  <div
+    role="alert"
+    aria-atomic="true"
+    className="flex items-start justify-between gap-3 px-4 py-3 text-[11px] text-danger-000"
+  >
+    <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">{message}</span>
     <Button type="button" variant="outline" className="h-7 shrink-0 px-2.5" onClick={onRetry}>
       Retry
     </Button>
@@ -451,6 +455,7 @@ const ProjectFilesViewContent = ({
   const selectedLocalRoot = selectedLocalRootId
     ? grantedRoots.find((root) => root.id === selectedLocalRootId)
     : undefined
+  const filesExpansionLabel = isFilesExpanded ? 'Exit full screen files' : 'Expand files'
 
   return (
     <div data-testid="files-view" className="flex h-full min-h-0 w-full flex-col bg-bg-10">
@@ -540,7 +545,7 @@ const ProjectFilesViewContent = ({
                   variant="ghost"
                   size="icon"
                   className="rounded-md text-text-000 hover:bg-muted"
-                  aria-label={isFilesExpanded ? 'Exit full screen files' : 'Expand files'}
+                  aria-label={filesExpansionLabel}
                   onClick={() =>
                     setToolItemExpanded(isFilesExpanded ? null : PROJECT_FILES_PREVIEW_ID)
                   }
@@ -552,9 +557,7 @@ const ProjectFilesViewContent = ({
                   )}
                 </Button>
               </TooltipTrigger>
-              <TooltipContent className="z-[70]">
-                {isFilesExpanded ? 'Exit full screen' : 'Expand files'}
-              </TooltipContent>
+              <TooltipContent className="z-[70]">{filesExpansionLabel}</TooltipContent>
             </Tooltip>
           </div>
         </TooltipProvider>
@@ -594,7 +597,7 @@ const ProjectFilesViewContent = ({
                       <X className="size-3.5" strokeWidth={2} aria-hidden="true" />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent className="z-[70]">Clear search</TooltipContent>
+                  <TooltipContent className="z-[70]">Clear file search</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             ) : null}

--- a/src/renderer/src/pages/workspace/project-files-presentation-owner.tsx
+++ b/src/renderer/src/pages/workspace/project-files-presentation-owner.tsx
@@ -153,7 +153,7 @@ const FileActionButtons = ({
             <ArrowUpRight aria-hidden="true" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>Open in split view beside the session</TooltipContent>
+        <TooltipContent>{`Open ${name} in split view beside the session`}</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   </div>


### PR DESCRIPTION
## Problem

Several renderer surfaces had related responsive-layout and accessibility gaps:

- Connectors collapsed its toolbar poorly at narrow widths.
- Notebook preview nested multiple scroll owners and used a visual-only divider.
- Files load errors could be clipped and were not announced.
- Copying a remote link could fail silently.
- Icon-only controls did not consistently keep their accessible name and tooltip text aligned.

## Solution

- Reworked the Connectors toolbar into a responsive grid so search remains primary and actions stay usable on narrow screens.
- Replaced the Notebook preview divider with an accessible vertical resizable panel group and kept one scroll owner per pane.
- Made Files load errors wrapping, persistent, and announced through an atomic alert while keeping Retry visible.
- Added explicit copied/error clipboard feedback with cleanup in the remote control panel.
- Standardized the affected icon buttons so tooltip text exactly matches the `aria-label`.
- Added focused regression coverage for responsive layout, separator semantics, error announcements, clipboard failures, and icon-button naming.

## Validation

- `npm run typecheck:web`
- `npm run lint` — passes with 12 pre-existing warnings and no changed-file warnings
- 7 focused Vitest files: 228 tests passed
- `npm run build:e2e`
- Electron screenshot fixture: 1 test passed, covering wide/narrow Connectors, Notebook preview, and narrow Files error states
- `git diff --check`

## Test Impact Set

- Connectors toolbar: `ConnectorsPanel.render.test.tsx`, `SettingsPage.render.test.tsx`
- Notebook panels and separator: `resizable.test.tsx`, `NotebookPreview.gate.render.test.tsx`
- Files errors and copy feedback: `ProjectFilesView.test.tsx`, `workspace-components.test.tsx`
- Icon-button labeling: `PreviewFileSurface.test.tsx`, `workspace-components.test.tsx`

## Uncovered risks

A full `npm test` run was attempted but the current Windows environment is not green for unrelated baseline reasons, including symlink `EPERM`, a stale Prisma test database missing `Review.codecVersion`, and parallel test-collection timeouts. The complete affected renderer test set above passes after the final edit.

Independent review has not yet been performed; this PR remains a draft.
