### PR TITLE
perf(startup): instrument loading diagnostics

### DIFF
--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -109,6 +109,43 @@ describe('database startup logging', () => {
     )
   })
 
+  it('records a timed operation for each database startup attempt', () => {
+    const { log, records } = createLog()
+    const options = createDatabaseStartupLogging(log, '0.13.0').migrationOptions(vi.fn())
+
+    options.onProgress?.({ phase: 'checking' })
+    options.onCompatibilityVerified?.({ sqliteVersion: '3.49.1' })
+    options.onCompleted?.({
+      from: '0003_granted_local_roots',
+      to: '0003_granted_local_roots',
+      applied: [],
+      adoptedLegacy: false
+    })
+
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: 'operation phase',
+          data: expect.objectContaining({
+            operation: 'database-startup',
+            phase: 'runtime-verified',
+            elapsedMs: expect.any(Number),
+            phaseDurationMs: expect.any(Number)
+          })
+        }),
+        expect.objectContaining({
+          message: 'operation completed',
+          data: expect.objectContaining({
+            operation: 'database-startup',
+            outcome: 'completed',
+            appliedCount: 0,
+            durationMs: expect.any(Number)
+          })
+        })
+      ])
+    )
+  })
+
   it('records structured validation details through the mandatory redactor', () => {
     const sensitiveValue = 'customer-secret-value'
     const cause = new DatabaseValidationError('Schema mismatch.', {
@@ -126,9 +163,11 @@ describe('database startup logging', () => {
     )
     const { log, records } = createLog()
 
-    createDatabaseStartupLogging(log, '0.13.0').reportBlocked(error)
+    const logging = createDatabaseStartupLogging(log, '0.13.0')
+    logging.migrationOptions(vi.fn())
+    logging.reportBlocked(error)
 
-    const record = records[0]!
+    const record = records.find(({ message }) => message === 'database startup blocked')!
     const line = formatLine('error', 'main', record.message, record.data)
     expect(line).not.toContain(sensitiveValue)
     expect(JSON.parse(line)).toMatchObject({
@@ -147,6 +186,19 @@ describe('database startup logging', () => {
         }
       }
     })
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'error',
+          message: 'operation failed',
+          data: expect.objectContaining({
+            operation: 'database-startup',
+            outcome: 'failed',
+            code: 'database_validation_failed'
+          })
+        })
+      ])
+    )
   })
 
   it('records non-blocking backup retirement failures', () => {
@@ -158,7 +210,9 @@ describe('database startup logging', () => {
       error: Object.assign(new Error('permission denied'), { code: 'EACCES' })
     })
 
-    expect(records).toEqual([
+    expect(
+      records.filter(({ message }) => message === 'database migration backup retirement failed')
+    ).toEqual([
       expect.objectContaining({
         level: 'warn',
         message: 'database migration backup retirement failed',
@@ -178,7 +232,9 @@ describe('database startup logging', () => {
 
     options.onBackupRetired?.({ migrationId: '0001_runtime_schema_baseline', path })
 
-    expect(records).toEqual([
+    expect(
+      records.filter(({ message }) => message === 'database migration backup retired')
+    ).toEqual([
       {
         level: 'info',
         message: 'database migration backup retired',

--- a/src/main/database/database-startup-logging.ts
+++ b/src/main/database/database-startup-logging.ts
@@ -1,4 +1,5 @@
 import { errorLogFields, type Logger } from '../logger'
+import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnostics/operation'
 import {
   type DatabaseMigrationError,
   type SchemaMigrationOptions,
@@ -12,51 +13,77 @@ type DatabaseStartupLogging = {
   ) => SchemaMigrationOptions
 }
 
-const createDatabaseStartupLogging = (log: Logger, appVersion: string): DatabaseStartupLogging => ({
-  reportBlocked: (error) => {
-    log.error('database startup blocked', {
-      appVersion,
-      code: error.code,
-      migrationId: error.migrationId ?? null,
-      retryable: error.retryable,
-      details: errorLogFields(error)
-    })
-  },
-  migrationOptions: (forwardProgress) => ({
-    onProgress: (progress) => {
-      log.info(
-        progress.phase === 'checking'
-          ? 'database migration checking'
-          : 'database migration started',
-        progress.phase === 'migrating' ? { migrationId: progress.migrationId } : undefined
-      )
-      forwardProgress(progress)
-    },
-    onCompatibilityVerified: ({ sqliteVersion }) => {
-      log.info(`database runtime verified: sqlite_version=${sqliteVersion}`)
-    },
-    onBackupReady: ({ migrationId, path, reused }) => {
-      log.info('database pre-migration backup ready', {
-        migrationId,
-        backupPath: path,
-        reused
+const createDatabaseStartupLogging = (log: Logger, appVersion: string): DatabaseStartupLogging => {
+  let operation: DiagnosticOperation | undefined
+
+  return {
+    reportBlocked: (error) => {
+      operation?.fail(error, {
+        code: error.code,
+        migrationId: error.migrationId ?? null,
+        retryable: error.retryable
+      })
+      log.error('database startup blocked', {
+        appVersion,
+        code: error.code,
+        migrationId: error.migrationId ?? null,
+        retryable: error.retryable,
+        details: errorLogFields(error)
       })
     },
-    onBackupRetired: ({ migrationId, path }) => {
-      log.info('database migration backup retired', { migrationId, backupPath: path })
-    },
-    onBackupRetirementFailed: ({ migrationId, path, error }) => {
-      log.warn('database migration backup retirement failed', {
-        migrationId,
-        backupPath: path ?? null,
-        ...errorLogFields(error)
+    migrationOptions: (forwardProgress) => {
+      operation = startDiagnosticOperation(log, {
+        operation: 'database-startup',
+        fields: { appVersion }
       })
-    },
-    onCompleted: ({ from, to, applied, adoptedLegacy }) => {
-      log.info('database migration completed', { from, to, applied, adoptedLegacy })
+      return {
+        onProgress: (progress) => {
+          operation?.phase(
+            progress.phase,
+            progress.phase === 'migrating' ? { migrationId: progress.migrationId } : undefined
+          )
+          log.info(
+            progress.phase === 'checking'
+              ? 'database migration checking'
+              : 'database migration started',
+            progress.phase === 'migrating' ? { migrationId: progress.migrationId } : undefined
+          )
+          forwardProgress(progress)
+        },
+        onCompatibilityVerified: ({ sqliteVersion }) => {
+          operation?.phase('runtime-verified', { sqliteVersion })
+          log.info(`database runtime verified: sqlite_version=${sqliteVersion}`)
+        },
+        onBackupReady: ({ migrationId, path, reused }) => {
+          log.info('database pre-migration backup ready', {
+            migrationId,
+            backupPath: path,
+            reused
+          })
+        },
+        onBackupRetired: ({ migrationId, path }) => {
+          log.info('database migration backup retired', { migrationId, backupPath: path })
+        },
+        onBackupRetirementFailed: ({ migrationId, path, error }) => {
+          log.warn('database migration backup retirement failed', {
+            migrationId,
+            backupPath: path ?? null,
+            ...errorLogFields(error)
+          })
+        },
+        onCompleted: ({ from, to, applied, adoptedLegacy }) => {
+          log.info('database migration completed', { from, to, applied, adoptedLegacy })
+          operation?.complete({
+            appliedCount: applied.length,
+            adoptedLegacy,
+            from: from ?? null,
+            to
+          })
+        }
+      }
     }
-  })
-})
+  }
+}
 
 export { createDatabaseStartupLogging }
 export type { DatabaseStartupLogging }

--- a/src/main/diagnostics/operation.test.ts
+++ b/src/main/diagnostics/operation.test.ts
@@ -75,8 +75,32 @@ describe('diagnostic operation', () => {
         filesCopied: 3,
         operation: 'data-root-migration',
         operationId: 'migration-1',
-        phase: 'copy'
+        phase: 'copy',
+        elapsedMs: 0,
+        phaseDurationMs: 0
       }
+    })
+  })
+
+  it('records cumulative and previous-phase duration for every phase', () => {
+    const { logger, records } = createRecordingLogger()
+    let timestamp = 100
+    const operation = startDiagnosticOperation(logger, {
+      operation: 'application-startup',
+      operationId: 'startup-1',
+      now: () => timestamp
+    })
+
+    timestamp = 125
+    operation.phase('database-startup')
+    timestamp = 170
+    operation.phase('compose-runtime')
+
+    expect(records[1]).toMatchObject({
+      data: { phase: 'database-startup', elapsedMs: 25, phaseDurationMs: 25 }
+    })
+    expect(records[2]).toMatchObject({
+      data: { phase: 'compose-runtime', elapsedMs: 70, phaseDurationMs: 45 }
     })
   })
 
@@ -237,7 +261,9 @@ describe('diagnostic operation', () => {
       scalar: 1,
       operation: 'update-check',
       operationId: 'update-1',
-      phase: 'checking'
+      phase: 'checking',
+      elapsedMs: 0,
+      phaseDurationMs: 0
     })
     expect(records[2].data).toEqual({
       result: true,

--- a/src/main/diagnostics/operation.ts
+++ b/src/main/diagnostics/operation.ts
@@ -104,6 +104,7 @@ export const startDiagnosticOperation = (
   const startedAt = readNow()
   const baseFields = scalarFields(inputValue(input, 'fields') as DiagnosticFields | undefined)
   let latestPhase: string | undefined
+  let phaseStartedAt = startedAt
   let terminal = false
 
   const eventFields = (fields?: DiagnosticFields): Record<string, unknown> => ({
@@ -140,8 +141,15 @@ export const startDiagnosticOperation = (
   return {
     phase: (name, fields) => {
       if (terminal) return
+      const phaseAt = readNow()
       latestPhase = name
-      emitSafely(logger, 'info', 'operation phase', { ...eventFields(fields), phase: name })
+      emitSafely(logger, 'info', 'operation phase', {
+        ...eventFields(fields),
+        phase: name,
+        elapsedMs: Math.max(0, phaseAt - startedAt),
+        phaseDurationMs: Math.max(0, phaseAt - phaseStartedAt)
+      })
+      phaseStartedAt = phaseAt
     },
     complete: (fields) => finish('info', 'operation completed', 'completed', fields),
     cancel: (fields) => finish('warn', 'operation cancelled', 'cancelled', fields),

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -2371,7 +2371,15 @@ describe('SessionPersistenceCoordinator', () => {
     const session = createSession({ title: 'Private analysis', cwd: '/private/workspace' })
     const result = { sessions: [session], manifest: { version: 1 as const } }
     const repository = createSessionRepository({
-      loadAllWithDiagnostics: vi.fn().mockResolvedValue({ result, isComplete: true })
+      loadAllWithDiagnostics: vi.fn().mockResolvedValue({
+        result,
+        isComplete: true,
+        scanMetrics: {
+          projectDirectoryCount: 1,
+          sessionFileCount: 1,
+          sessionBytes: 4096
+        }
+      })
     })
     const log = createTestLogger()
     const coordinator = new SessionPersistenceCoordinator(
@@ -2393,6 +2401,7 @@ describe('SessionPersistenceCoordinator', () => {
       'operation phase',
       'operation phase',
       'operation phase',
+      'operation phase',
       'operation completed'
     ])
     expect(
@@ -2401,6 +2410,7 @@ describe('SessionPersistenceCoordinator', () => {
         .filter(Boolean)
     ).toEqual([
       'load-authority',
+      'authority-loaded',
       'recover-delegation',
       'reconcile-unread-sessions',
       'reconcile-derived-state',
@@ -2422,6 +2432,15 @@ describe('SessionPersistenceCoordinator', () => {
       })
     )
     const diagnosticPayload = JSON.stringify(log.info.mock.calls)
+    expect(log.info).toHaveBeenCalledWith(
+      'operation phase',
+      expect.objectContaining({
+        phase: 'authority-loaded',
+        projectDirectoryCount: 1,
+        sessionFileCount: 1,
+        sessionBytes: 4096
+      })
+    )
     expect(diagnosticPayload).not.toContain('Private analysis')
     expect(diagnosticPayload).not.toContain('/private/workspace')
   })
@@ -2626,6 +2645,7 @@ describe('SessionPersistenceCoordinator', () => {
     expect(log.info.mock.calls.map(([message]) => message)).toEqual([
       'operation started',
       'operation phase',
+      'operation phase',
       'operation completed'
     ])
     expect(log.info).toHaveBeenLastCalledWith(
@@ -2634,7 +2654,7 @@ describe('SessionPersistenceCoordinator', () => {
         operation: 'session-hydration',
         operationId: expect.any(String),
         mode: 'read-only',
-        phase: 'load-authority',
+        phase: 'authority-loaded',
         outcome: 'completed',
         status: 'degraded',
         sessionCount: 1,
@@ -3887,7 +3907,7 @@ describe('SessionPersistenceCoordinator', () => {
       'operation completed',
       expect.objectContaining({
         operation: 'session-hydration',
-        phase: 'load-authority',
+        phase: 'authority-loaded',
         outcome: 'completed',
         status: 'partial',
         sessionCount: 1,

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -75,6 +75,11 @@ type SessionMutationRepository = {
     result: LoadAllSessionsResult
     isComplete: boolean
     warnings?: SessionLoadWarning[]
+    scanMetrics?: {
+      projectDirectoryCount: number
+      sessionFileCount: number
+      sessionBytes: number
+    }
     failure?: SessionLoadFailure
   }>
   loadProjectWithDiagnostics(projectId: string): Promise<{
@@ -299,6 +304,11 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
         throw error
       }
       this.stateOwner.replaceMetadata(scan.result.sessions, false)
+      operation.phase('authority-loaded', {
+        sessionCount: scan.result.sessions.length,
+        warningCount: scan.warnings?.length ?? 0,
+        ...scan.scanMetrics
+      })
       operation.complete({
         status: 'degraded',
         sessionCount: scan.result.sessions.length,
@@ -344,6 +354,11 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
         throw error
       }
       this.stateOwner.replaceMetadata(scan.result.sessions, scan.isComplete)
+      operation.phase('authority-loaded', {
+        sessionCount: scan.result.sessions.length,
+        warningCount: scan.warnings?.length ?? 0,
+        ...scan.scanMetrics
+      })
       scan.result.diagnostics = {
         isComplete: scan.isComplete,
         warnings: scan.warnings ?? [],

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -607,6 +607,31 @@ describe('session persistence repository (per-session files)', () => {
     expect(nextScan.warnings).toEqual(scan.warnings)
   })
 
+  it('reports aggregate Session scan scale without exposing catalog identifiers', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    const projectA = join(storageRoot!, 'sessions', 'project-a')
+    const projectB = join(storageRoot!, 'sessions', 'project-b')
+    const rawA = JSON.stringify({ version: 2, session: createSession() })
+    const rawB = JSON.stringify({
+      version: 2,
+      session: createSession({ id: 'session-2', projectId: 'project-b' })
+    })
+    await mkdir(projectA, { recursive: true })
+    await mkdir(projectB, { recursive: true })
+    await writeFile(join(projectA, 'private-session-a.json'), rawA, 'utf8')
+    await writeFile(join(projectB, 'private-session-b.json'), rawB, 'utf8')
+
+    const scan = await repository.loadAllWithDiagnostics()
+
+    expect(scan.scanMetrics).toEqual({
+      projectDirectoryCount: 2,
+      sessionFileCount: 2,
+      sessionBytes: Buffer.byteLength(rawA, 'utf8') + Buffer.byteLength(rawB, 'utf8')
+    })
+    expect(JSON.stringify(scan.scanMetrics)).not.toContain('private-session')
+    expect(JSON.stringify(scan.scanMetrics)).not.toContain('project-a')
+  })
+
   it('reports corrupt authority without moving files during a read-only scan', async () => {
     const repository = new SessionRepository(await createStorageRoot())
     const sessionsDir = join(storageRoot!, 'sessions')

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -89,12 +89,19 @@ const hasSubagentModelAttemptSchema = (value: unknown): boolean => {
   )
 }
 
+type SessionScanMetrics = {
+  projectDirectoryCount: number
+  sessionFileCount: number
+  sessionBytes: number
+}
+
 type SessionLoadDiagnostics = {
   result: LoadAllSessionsResult
   // False means at least one directory or session file could not be read or safely quarantined.
   // Callers may hydrate the returned sessions but must not reconcile absent index rows as deletions.
   isComplete: boolean
   warnings: SessionLoadWarning[]
+  scanMetrics: SessionScanMetrics
   failure?: SessionLoadFailure
 }
 
@@ -272,8 +279,14 @@ class SessionRepository {
   // partial read. Project recovery owns tombstone cleanup before ordinary hydration is allowed.
   async loadAllWithDiagnostics(options: SessionScanOptions = {}): Promise<SessionLoadDiagnostics> {
     const quarantineInvalidFiles = options.mode !== 'read-only'
+    const scanMetrics: SessionScanMetrics = {
+      projectDirectoryCount: 0,
+      sessionFileCount: 0,
+      sessionBytes: 0
+    }
     const { sessions, isComplete, warnings } = await this.readAllSessions({
-      quarantineInvalidFiles
+      quarantineInvalidFiles,
+      scanMetrics
     })
     const manifestRead = await this.readManifest({ quarantineInvalidFiles })
 
@@ -282,7 +295,8 @@ class SessionRepository {
       // The manifest is only a last-open pointer. It must never make a complete Session authority
       // scan read-only; a later selection write will retry persistence through the normal saver.
       isComplete,
-      warnings: manifestRead.warning ? [...warnings, manifestRead.warning] : warnings
+      warnings: manifestRead.warning ? [...warnings, manifestRead.warning] : warnings,
+      scanMetrics
     }
   }
 
@@ -702,13 +716,17 @@ class SessionRepository {
   // Reads every project directory's session files and propagates completeness across every level.
   // Repair scans quarantine invalid data; read-only scans report it in place. I/O errors keep
   // reconciliation disabled until the next repair.
-  private async readAllSessions(options: { quarantineInvalidFiles: boolean }): Promise<{
+  private async readAllSessions(options: {
+    quarantineInvalidFiles: boolean
+    scanMetrics: SessionScanMetrics
+  }): Promise<{
     sessions: PersistedChatSession[]
     isComplete: boolean
     warnings: SessionLoadWarning[]
   }> {
     const projectDirectories = await this.listDirectoryNames(this.sessionsDir)
     const sessions: PersistedChatSession[] = []
+    options.scanMetrics.projectDirectoryCount = projectDirectories.names.length
     const warnings: SessionLoadWarning[] = []
     let isComplete = projectDirectories.isComplete
 
@@ -716,7 +734,8 @@ class SessionRepository {
       const project = await this.readProjectSessions(projectId, {
         missingDirectoryIsIncomplete: true,
         quarantineInvalidFiles: options.quarantineInvalidFiles,
-        warnings
+        warnings,
+        scanMetrics: options.scanMetrics
       })
       sessions.push(...project.sessions)
       isComplete &&= project.isComplete
@@ -732,6 +751,7 @@ class SessionRepository {
       quarantinedIsIncomplete?: boolean
       quarantineInvalidFiles?: boolean
       warnings?: SessionLoadWarning[]
+      scanMetrics?: SessionScanMetrics
     } = {}
   ): Promise<ProjectSessionLoadDiagnostics> {
     const projectId = assertSafeSegment(projectIdValue)
@@ -750,6 +770,7 @@ class SessionRepository {
       quarantinedIsIncomplete?: boolean
       quarantineInvalidFiles?: boolean
       warnings?: SessionLoadWarning[]
+      scanMetrics?: SessionScanMetrics
     } = {}
   ): Promise<ProjectSessionLoadDiagnostics> {
     const sessionFiles = await this.listSessionFileNames(projectDir, {
@@ -757,6 +778,7 @@ class SessionRepository {
     })
     const sessions: PersistedChatSession[] = []
     const activeQuarantines = new Set(sessionFiles.quarantinedPrimaryFileNames)
+    if (options.scanMetrics) options.scanMetrics.sessionFileCount += sessionFiles.names.length
     const warnedFiles = new Set<string>()
     let isComplete = sessionFiles.isComplete
 
@@ -764,7 +786,8 @@ class SessionRepository {
       // The directory is the authoritative owning project, regardless of the file's stored projectId.
       const read = await this.readSessionFile(join(projectDir, fileName), projectId, {
         missingIsIncomplete: true,
-        quarantineInvalidFiles: options.quarantineInvalidFiles
+        quarantineInvalidFiles: options.quarantineInvalidFiles,
+        scanMetrics: options.scanMetrics
       })
       isComplete &&= read.isComplete
       if (options.quarantinedIsIncomplete && read.wasQuarantined) isComplete = false
@@ -797,7 +820,11 @@ class SessionRepository {
   private async readSessionFile(
     filePath: string,
     projectId: string,
-    options: { missingIsIncomplete?: boolean; quarantineInvalidFiles?: boolean } = {}
+    options: {
+      missingIsIncomplete?: boolean
+      quarantineInvalidFiles?: boolean
+      scanMetrics?: SessionScanMetrics
+    } = {}
   ): Promise<{
     session?: PersistedChatSession
     isComplete: boolean
@@ -819,6 +846,7 @@ class SessionRepository {
         }
       }
     }
+    if (options.scanMetrics) options.scanMetrics.sessionBytes += Buffer.byteLength(raw, 'utf8')
 
     try {
       const session = normalizeSessionFile(JSON.parse(raw) as unknown, {
@@ -962,4 +990,4 @@ const isMissingFileError = (error: unknown): boolean =>
 
 export { SessionRepository, getSessionPersistenceDir }
 export type { ProjectSessionDeletionState, ProjectSessionLoadDiagnostics, SessionLoadDiagnostic }
-export type { SessionLoadDiagnostics }
+export type { SessionLoadDiagnostics, SessionScanMetrics }

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -19,6 +19,7 @@ import type { ClaudeSharedAuthControllerPort } from './claude-shared-auth'
 import type { UserSkillRepository } from '../skills/user-skill-repository'
 import type { SystemProxyEnvironment } from './system-proxy'
 import type { AgentBackendResolutionContext } from './backend-resolver'
+import type { Logger } from '../logger'
 
 // Reversible fake safeStorage so provider keys can be encrypted/decrypted without an OS keychain.
 vi.mock('electron', () => ({
@@ -133,6 +134,13 @@ type ManagedCodexInstallImpl = (options: {
   codexVersion?: string
 }>
 
+const silentLog: Logger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined
+}
+
 const createService = (
   detectResult: ClaudeDetectResult = { found: true, path: '/bin/claude', version: '2.1.0' },
   options: {
@@ -162,10 +170,12 @@ const createService = (
     userClaudeDir?: string
     userCodexDir?: string
     userAgentsDir?: string
+    log?: Logger
   } = {}
 ): InstanceType<typeof SettingsService> =>
   new SettingsService({
     repository,
+    log: options.log ?? silentLog,
     storageRoot,
     // Point at a non-existent user Claude dir so tests never read the real ~/.claude. The same
     // path is now used by claude-isolated skill-scanning; claude-default is gone.
@@ -251,6 +261,36 @@ afterEach(async () => {
   vi.unstubAllGlobals()
   vi.unstubAllEnvs()
   await rm(storageRoot, { recursive: true, force: true })
+})
+
+describe('SettingsService: load diagnostics', () => {
+  it('records the renderer-safe settings load phases and duration', async () => {
+    const log = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    } satisfies Logger
+    const service = createService(undefined, { log })
+
+    await service.getSettingsView()
+
+    expect(
+      log.info.mock.calls
+        .filter(([message]) => message === 'operation phase')
+        .map(([, fields]) => (fields as { phase: string }).phase)
+    ).toEqual(['read-authority', 'migrate-legacy-key-refs', 'build-renderer-view'])
+    expect(log.info).toHaveBeenLastCalledWith(
+      'operation completed',
+      expect.objectContaining({
+        operation: 'settings-load',
+        outcome: 'completed',
+        providerCount: expect.any(Number),
+        durationMs: expect.any(Number)
+      })
+    )
+    expect(JSON.stringify(log.info.mock.calls)).not.toContain(storageRoot)
+  })
 })
 
 describe('SettingsService: custom MCP OAuth', () => {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -60,6 +60,8 @@ import type {
   ValidateProviderRequest,
   ValidateProviderResult
 } from '../../shared/settings'
+import { createLogger, type Logger } from '../logger'
+import { startDiagnosticOperation } from '../diagnostics/operation'
 import type { PackageMirror } from '../../shared/mirror'
 import { resolveNetworkProxySettings, type NetworkProxySettings } from '../../shared/network-proxy'
 import type { GrantedLocalRoot } from '../../shared/local-fs'
@@ -68,12 +70,10 @@ import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-
 import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
 import { resolveStorageRoot } from '../storage-root'
-import {
-  DEFAULT_AGENT_FRAMEWORK_ID,
-  listAgentFrameworks,
-  type AgentModelChangeTarget,
-  type AgentFrameworkId,
-  type ResolvedAgentBackend
+import type {
+  AgentModelChangeTarget,
+  AgentFrameworkId,
+  ResolvedAgentBackend
 } from '../agent-framework'
 import type { ClaudeDetectDeps } from './claude-detect'
 import type { OpencodeDetectDeps } from './opencode-detect'
@@ -84,7 +84,8 @@ import type { InstallManagedClaudeOptions, ManagedInstallOutcome } from './manag
 import { isEncryptionAvailable } from './crypto'
 import { getUserClaudeConfigDir } from './provider-env'
 import { SettingsRepository } from './repository'
-import { SettingsPreferencesModule, toSettingsPreferencesSnapshot } from './preferences'
+import { SettingsPreferencesModule } from './preferences'
+import { buildSettingsSnapshot } from './settings-view'
 import { NotebookRuntimeSettingsModule } from './notebook-runtime-settings'
 import { SkillCatalogModule } from './skill-catalog'
 import { ConnectorSettingsModule, type CustomServerSecurityChangeGuard } from './connector-settings'
@@ -121,6 +122,7 @@ export type UninstallResult = {
 export type SettingsServiceOptions = {
   repository?: SettingsRepository
   storageRoot?: string
+  log?: Logger
   detectDeps?: ClaudeDetectDeps
   opencodeDetectDeps?: OpencodeDetectDeps
   // Reserves the authenticated loopback HTTP port exposed by `opencode acp`. Injectable so settings
@@ -187,6 +189,7 @@ class SettingsService {
   private readonly storageRoot: string
   private readonly applyNetworkProxy: (settings: NetworkProxySettings) => Promise<void>
   private readonly userClaudeDir: string
+  private readonly log: Logger
   private customServerAuthenticator?: (serverId: string) => Promise<void>
   private customServerAuthenticationCanceller?: (serverId: string) => Promise<void>
   private skillDeletionGuard?: (skillId: string) => Promise<void>
@@ -194,6 +197,7 @@ class SettingsService {
     this.storageRoot = options.storageRoot ?? resolveStorageRoot()
     this.repository = options.repository ?? new SettingsRepository(this.storageRoot)
     this.applyNetworkProxy = options.applyNetworkProxy ?? (async () => undefined)
+    this.log = options.log ?? createLogger('settings')
     this.preferences = new SettingsPreferencesModule(this.repository)
     this.notebookRuntimeSettings = new NotebookRuntimeSettingsModule(this.repository)
     this.connectors = new ConnectorSettingsModule(this.repository)
@@ -265,55 +269,19 @@ class SettingsService {
 
   // Returns the renderer-safe (masked) snapshot of settings.
   async getSettingsView(): Promise<SettingsSnapshot> {
-    const settings = await this.migrateLegacyKeyRefs(await this.repository.getSettings())
-    const preferences = toSettingsPreferencesSnapshot(settings)
-
-    return {
-      claude: settings.claude ?? {},
-      opencode: { resolvedPath: settings.opencodePath, version: settings.opencodeVersion },
-      codex: {
-        resolvedPath: settings.codex?.resolvedPath,
-        version: settings.codex?.version,
-        nativeVersion: settings.codex?.nativeVersion
-      },
-      claudeManaged: settings.claude?.resolvedPath
-        ? this.runtimeManager.isManagedRuntimePath('claude-code', settings.claude.resolvedPath)
-        : false,
-      opencodeManaged: settings.opencodePath
-        ? this.runtimeManager.isManagedRuntimePath('opencode', settings.opencodePath)
-        : false,
-      codexManaged: settings.codex?.resolvedPath
-        ? this.runtimeManager.isManagedRuntimePath('codex', settings.codex.resolvedPath)
-        : false,
-      activeProviderId: settings.activeProviderId,
-      claudeSubscriptionProviderId: settings.claudeSubscriptionProviderId,
-      activeModel: settings.activeModel,
-      providers: settings.providers.map((provider) =>
-        this.providers.toProviderView(
-          provider,
-          provider.id === settings.activeProviderId ? settings.activeModel : undefined
-        )
-      ),
-      onboardingCompletedAt: preferences.onboardingCompletedAt,
-      packageMirror: settings.packageMirror,
-      networkProxy: resolveNetworkProxySettings(settings.networkProxy),
-      reasoningEffort: preferences.reasoningEffort,
-      subagentModel: settings.subagentModel ?? { mode: 'inherit' },
-      notificationsEnabled: preferences.notificationsEnabled,
-      conversationSkillImportEnabled: preferences.conversationSkillImportEnabled,
-      closePreference: preferences.closePreference,
-      appIconVariant: preferences.appIconVariant,
-      projectFilesFilter: preferences.projectFilesFilter,
-      defaultPermissionProfile: preferences.defaultPermissionProfile,
-
-      agentFrameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
-      agentFrameworks: listAgentFrameworks().map((framework) => ({
-        id: framework.id,
-        displayName: framework.displayName,
-        supportsSkills: framework.supportsSkills,
-        supportsDelegatedWork: framework.supportsDelegatedWork,
-        supportedApiTypes: [...framework.supportedApiTypes]
-      }))
+    const operation = startDiagnosticOperation(this.log, { operation: 'settings-load' })
+    try {
+      operation.phase('read-authority')
+      const stored = await this.repository.getSettings()
+      operation.phase('migrate-legacy-key-refs')
+      const settings = await this.migrateLegacyKeyRefs(stored)
+      operation.phase('build-renderer-view')
+      const snapshot = buildSettingsSnapshot(settings, this.runtimeManager, this.providers)
+      operation.complete({ providerCount: settings.providers.length })
+      return snapshot
+    } catch (error) {
+      operation.fail(error)
+      throw error
     }
   }
 

--- a/src/main/settings/settings-view.ts
+++ b/src/main/settings/settings-view.ts
@@ -1,0 +1,73 @@
+import type { ProviderView, SettingsSnapshot } from '../../shared/settings'
+import { resolveNetworkProxySettings } from '../../shared/network-proxy'
+import {
+  DEFAULT_AGENT_FRAMEWORK_ID,
+  listAgentFrameworks,
+  type AgentFrameworkId
+} from '../agent-framework'
+import { toSettingsPreferencesSnapshot } from './preferences'
+import type { StoredProvider, StoredSettings } from './types'
+
+type ManagedRuntimeProjection = {
+  isManagedRuntimePath: (frameworkId: AgentFrameworkId, path: string) => boolean
+}
+
+type ProviderViewProjection = {
+  toProviderView: (provider: StoredProvider, activeModel?: string) => ProviderView
+}
+
+export const buildSettingsSnapshot = (
+  settings: StoredSettings,
+  runtimeManager: ManagedRuntimeProjection,
+  providers: ProviderViewProjection
+): SettingsSnapshot => {
+  const preferences = toSettingsPreferencesSnapshot(settings)
+
+  return {
+    claude: settings.claude ?? {},
+    opencode: { resolvedPath: settings.opencodePath, version: settings.opencodeVersion },
+    codex: {
+      resolvedPath: settings.codex?.resolvedPath,
+      version: settings.codex?.version,
+      nativeVersion: settings.codex?.nativeVersion
+    },
+    claudeManaged: settings.claude?.resolvedPath
+      ? runtimeManager.isManagedRuntimePath('claude-code', settings.claude.resolvedPath)
+      : false,
+    opencodeManaged: settings.opencodePath
+      ? runtimeManager.isManagedRuntimePath('opencode', settings.opencodePath)
+      : false,
+    codexManaged: settings.codex?.resolvedPath
+      ? runtimeManager.isManagedRuntimePath('codex', settings.codex.resolvedPath)
+      : false,
+    activeProviderId: settings.activeProviderId,
+    claudeSubscriptionProviderId: settings.claudeSubscriptionProviderId,
+    activeModel: settings.activeModel,
+    providers: settings.providers.map((provider) =>
+      providers.toProviderView(
+        provider,
+        provider.id === settings.activeProviderId ? settings.activeModel : undefined
+      )
+    ),
+    onboardingCompletedAt: preferences.onboardingCompletedAt,
+    packageMirror: settings.packageMirror,
+    networkProxy: resolveNetworkProxySettings(settings.networkProxy),
+    reasoningEffort: preferences.reasoningEffort,
+    subagentModel: settings.subagentModel ?? { mode: 'inherit' },
+    notificationsEnabled: preferences.notificationsEnabled,
+    conversationSkillImportEnabled: preferences.conversationSkillImportEnabled,
+    closePreference: preferences.closePreference,
+    appIconVariant: preferences.appIconVariant,
+    projectFilesFilter: preferences.projectFilesFilter,
+    defaultPermissionProfile: preferences.defaultPermissionProfile,
+
+    agentFrameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
+    agentFrameworks: listAgentFrameworks().map((framework) => ({
+      id: framework.id,
+      displayName: framework.displayName,
+      supportsSkills: framework.supportsSkills,
+      supportsDelegatedWork: framework.supportsDelegatedWork,
+      supportedApiTypes: [...framework.supportedApiTypes]
+    }))
+  }
+}


### PR DESCRIPTION
## Problem

Users report that Open Science startup has become slower and remains on loading for too long. Existing diagnostics do not expose per-phase timing or the scale of the local Session scan, so database startup, Settings hydration, Session file I/O, JSON parsing, and reconciliation cannot be distinguished from field logs.

A local stress harness showed near-linear Session authority scan growth: 25 representative Session files loaded in about 0.54s, while 250 loaded in about 4.67–5.37s. The temporary harness was removed after measurement.

## Proposed change

- Add cumulative `elapsedMs` and previous-phase `phaseDurationMs` to diagnostic operation phase events.
- Instrument database startup across checking, migrations, runtime verification, completion, and blocked startup.
- Instrument renderer-safe Settings loading across authority read, legacy key-reference migration, and view construction.
- Record Session authority scan timing and privacy-safe aggregate scale: project directory count, Session file count, bytes read, loaded Session count, and warning count.
- Preserve existing startup behavior and error handling.
- Keep diagnostic payloads free of project names, Session IDs, file paths, and conversation content.

## Scope and non-goals

This PR adds observability only. It does not change the loading UI, storage schema, startup ordering, Session reconciliation semantics, or persistence format.

A likely follow-up, if production logs confirm the correlation, is a SQLite metadata catalog/index with full Session JSON loaded on demand. Moving complete conversation bodies into the database is intentionally not part of this PR.

## Acceptance criteria and validation

Final evidence mapping; the listed passing checks ran after the last material edit:

- diagnostic phase duration semantics -> focused diagnostic operation tests -> passed
- database startup lifecycle and redaction -> focused database logging and privacy-canary tests -> passed
- Session scan aggregates, hydration phases, and privacy -> focused repository/coordinator tests -> passed
- Settings loading phases and protected importer/file-size seams -> targeted Settings test plus architecture tests -> passed
- affected main and renderer TypeScript processes -> `npm run typecheck` -> passed
- repository lint policy -> `npm run lint` -> passed with 0 errors and 11 pre-existing warnings outside this diff
- combined final impact set -> focused Vitest command -> 6 files, 207 tests passed
- Settings diagnostic test -> targeted Vitest command -> 1 test passed
- complete portable fallback -> `npm test -- --reporter=dot` -> 14,281 passed, 136 failed, 291 skipped

The complete local fallback is not green in this Windows environment. Failures are concentrated in pre-existing Windows `EBUSY`/Prisma temporary-database cleanup cascades, `EPERM` symlink restrictions, storage-migration tests, timeouts, and existing architecture guards outside this diff. The focused tests for every changed behavior pass. PR Gate and platform CI remain authoritative.

This draft is not marked fully verified until independent review confirms the final impact mapping and CI evaluates the clean environment.

## Review focus

- Whether `phaseDurationMs` is interpreted correctly as time since the previous phase.
- Whether the database and Session phase boundaries are sufficient to isolate the visible loading delay.
- Whether the aggregate Session scan fields satisfy privacy expectations.
- Whether Settings snapshot extraction preserves the protected module seams.