### PR TITLE
test(artifacts): make handoff path assertions portable

### DIFF
--- a/src/main/acp/artifact-turn-owner.test.ts
+++ b/src/main/acp/artifact-turn-owner.test.ts
@@ -280,8 +280,22 @@ describe('ArtifactTurnOwner', () => {
     )
     const handoffFiles = children.map((child) => owner.handoffFile(child))
     expect(handoffFiles).toEqual([
-      expect.stringMatching(/artifact-session-1\/\.execution-handoffs\/artifact-run-100-1\.json$/),
-      expect.stringMatching(/artifact-session-2\/\.execution-handoffs\/artifact-run-100-2\.json$/)
+      join(
+        dataRoot,
+        'artifacts',
+        'project-1',
+        'artifact-session-1',
+        '.execution-handoffs',
+        'artifact-run-100-1.json'
+      ),
+      join(
+        dataRoot,
+        'artifacts',
+        'project-1',
+        'artifact-session-2',
+        '.execution-handoffs',
+        'artifact-run-100-2.json'
+      )
     ])
 
     await Promise.all(children.map((child) => owner.dispose(child)))

--- a/src/main/delegation/delegated-artifact-evidence.test.ts
+++ b/src/main/delegation/delegated-artifact-evidence.test.ts
@@ -84,8 +84,15 @@ describe('delegated Artifact evidence adapter', () => {
     }
 
     const handle = await evidence.open(scope)
-    expect(handle.execution?.currentRunFile).toMatch(
-      /\.execution-handoffs\/artifact-run-10-1\.json$/
+    expect(handle.execution?.currentRunFile).toBe(
+      join(
+        dataRoot,
+        'artifacts',
+        'project-1',
+        'artifact-session-1',
+        '.execution-handoffs',
+        'artifact-run-10-1.json'
+      )
     )
     const ownerHandle = owner.handleForExecution('attempt-1')
     await owner.write(ownerHandle, { filename: 'child.md', content: 'child bytes' })

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -2097,8 +2097,15 @@ describe('production delegated-work composition', () => {
     })
     await expect.poll(() => execution.controls()).toHaveLength(1)
     const control = execution.controls()[0]
-    expect(control.input.artifactCurrentRunFile).toMatch(
-      /\.execution-handoffs\/artifact-run-10-1\.json$/
+    expect(control.input.artifactCurrentRunFile).toBe(
+      join(
+        root,
+        'artifacts',
+        'project-1',
+        'artifact-session-codex',
+        '.execution-handoffs',
+        'artifact-run-10-1.json'
+      )
     )
     const turn = turns.handleForExecution(control.input.attemptId)
     await turns.write(turn, { filename: 'evidence.md', content: 'exact child evidence' })


### PR DESCRIPTION
﻿## Problem

The scheduled [Windows Full Test run](https://github.com/aipoch/open-science/actions/runs/31613266137) failed in all three shards. Each shard reached Vitest successfully, then one Artifact handoff-path assertion failed because the tests only accepted POSIX `/` separators while `node:path.join` correctly produced Windows `\` paths.

## Proposed change

Build the three expected Artifact execution handoff paths with `node:path.join` and compare the complete path. This preserves coverage of the data root, project, Artifact storage Session, handoff directory, and run file while making the expectations portable across Windows, macOS, and Linux.

## Scope and non-goals

- Changes only three test files.
- Does not modify Artifact, ACP, delegation, persistence, or runtime behavior.
- Does not change CI workflow configuration.

## Acceptance criteria and validation

The listed checks ran after the last material edit:

- Windows Artifact handoff path behavior -> `npm test -- src/main/acp/artifact-turn-owner.test.ts src/main/delegation/delegated-artifact-evidence.test.ts src/main/delegation/production-composition.test.ts` -> passed (3 files, 54 tests).
- Main-process and renderer typing -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors; existing baseline warnings remained. After formatting, targeted ESLint on all three changed files passed cleanly.
- Complete portable suite -> `npm test` -> attempted but the managed local Windows environment produced unrelated failures, including symlink creation `EPERM`, sandbox temp-directory rejection, and a stale shared Prisma client missing `codecVersion`. The three changed test files pass independently; exact-head GitHub CI remains authoritative.

The module-impact manifest does not currently declare these three test files, so the local validation used the full-fallback checks rather than claiming selective module coverage.

## Review focus

Confirm that the exact `join(...)` expectations preserve the intended Artifact storage contract and remove only the separator-specific behavior that caused the Windows failures.
