### PR TITLE
fix(settings): align connector toolbar order

### DIFF
--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -246,7 +246,7 @@ describe('ConnectorsPanel (groups)', () => {
     expect(addConnector?.getAttribute('data-variant')).toBe('outline')
   })
 
-  it('uses a two-row narrow toolbar with full-width search and paired actions', () => {
+  it('orders the group filter before search and keeps the narrow toolbar contained', () => {
     act(() => {
       root.render(<ConnectorsPanel onNavigate={vi.fn()} />)
     })
@@ -260,11 +260,14 @@ describe('ConnectorsPanel (groups)', () => {
       document.body.querySelectorAll<HTMLButtonElement>('button')
     ).find((button) => button.textContent?.includes('Add connector'))
 
-    expect(toolbar?.className).toContain('grid-cols-2')
-    expect(toolbar?.className).toContain('sm:grid-cols-[minmax(0,1fr)_9rem_auto]')
-    expect(search?.parentElement?.className).toContain('col-span-2')
-    expect(search?.parentElement?.className).toContain('sm:col-span-1')
+    expect(toolbar?.className).toContain('grid-cols-[9rem_minmax(0,1fr)]')
+    expect(toolbar?.className).toContain('sm:grid-cols-[9rem_minmax(0,1fr)_auto]')
+    expect(filter?.compareDocumentPosition(search!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(search?.compareDocumentPosition(addConnector!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(search?.parentElement?.className).toContain('min-w-0')
+    expect(search?.parentElement?.className).toContain('sm:col-start-2')
     expect(filter?.className).toContain('w-full')
+    expect(addConnector?.className).toContain('col-span-2')
     expect(addConnector?.className).toContain('w-full')
   })
 

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -369,20 +369,13 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
       </SettingsSection>
 
       <div
-        className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-[minmax(0,1fr)_9rem_auto] sm:items-center"
+        className="mb-4 grid grid-cols-[9rem_minmax(0,1fr)] gap-2 sm:grid-cols-[9rem_minmax(0,1fr)_auto] sm:items-center"
         data-testid="connectors-toolbar"
       >
-        <SettingsSearchInput
-          aria-label="Search connectors"
-          containerClassName="col-span-2 min-w-0 sm:col-span-1 sm:col-start-1 sm:row-start-1"
-          placeholder="Search connectors…"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-        />
         <Select value={filter} onValueChange={(value) => setFilter(value as GroupFilter)}>
           <SelectTrigger
             aria-label="Filter connectors by group"
-            className="w-full sm:col-start-2 sm:row-start-1"
+            className="w-full sm:col-start-1 sm:row-start-1"
           >
             <span>{FILTER_LABELS[filter]}</span>
           </SelectTrigger>
@@ -393,11 +386,18 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
             <SelectItem value="custom">Custom</SelectItem>
           </SelectContent>
         </Select>
+        <SettingsSearchInput
+          aria-label="Search connectors"
+          containerClassName="min-w-0 sm:col-start-2 sm:row-start-1"
+          placeholder="Search connectors…"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="w-full justify-center sm:col-start-3 sm:row-start-1 sm:w-auto sm:shrink-0"
+              className="col-span-2 row-start-2 w-full justify-center sm:col-span-1 sm:col-start-3 sm:row-start-1 sm:w-auto sm:shrink-0"
             >
               <Plus data-icon="inline-start" aria-hidden="true" />
               Add connector


### PR DESCRIPTION
## Problem

The Connectors list toolbar placed Search before its category filter, while the Skills list toolbar uses category filter, Search, then Add. The inconsistent order also made the two settings panels scan and navigate differently.

## Proposed change

- place the Connector group filter before the search field in DOM, keyboard, and desktop visual order
- keep the search field flexible and the Add connector action right-aligned
- preserve a contained narrow layout: filter + search on the first row and a full-width Add connector action on the second row
- lock the order and responsive grid contract in the existing render test

## Scope and non-goals

This is a renderer-only layout change. It does not change filtering, search behavior, connector data, settings state, copy, tokens, or add-connector flows.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Connector toolbar order and existing panel behavior -> `npm test -- src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx` -> 19/19 passed
- Renderer types -> `npm run typecheck:web` -> passed
- Source lint -> `npm run lint` -> passed with 11 pre-existing warnings and 0 errors; changed files emitted no warnings
- Production Electron build -> `npm run build:e2e` -> passed
- Responsive toolbar containment and visual order at 320, 375, 414, 768, and 1280 px -> temporary Playwright Electron check -> passed; temporary test removed before commit

Consumer and platform assessment: `ConnectorsPanel` remains consumed by `SettingsPage`; no component interface, state, IPC, persistence, or platform-specific behavior changed, so no additional consumer or platform lane was included. CI remains the final cross-platform authority.

## Review focus

Please verify that the responsive grid keeps Filter -> Search -> Add consistent with Skills while preserving usable controls at compact widths.