### PR TITLE
fix(status-copy): align shipped capability wording

### DIFF
--- a/src/main/agent-framework/registry.ts
+++ b/src/main/agent-framework/registry.ts
@@ -9,11 +9,11 @@ const FRAMEWORKS: Record<AgentFrameworkId, AgentFramework> = {
   codex: codexFramework
 }
 
-// The default framework until framework selection is wired into settings.
+// Fallback for settings documents created before framework selection was persisted.
 export const DEFAULT_AGENT_FRAMEWORK_ID: AgentFrameworkId = 'claude-code'
 
 // Resolves a framework by id for the runtime/settings; ids come from a fixed union so this is total.
 export const getAgentFramework = (id: AgentFrameworkId): AgentFramework => FRAMEWORKS[id]
 
-// Lists every registered framework for the (future) settings selector.
+// Lists every registered framework for Settings and runtime capability projection.
 export const listAgentFrameworks = (): AgentFramework[] => Object.values(FRAMEWORKS)

--- a/src/main/agents/agents-service.ts
+++ b/src/main/agents/agents-service.ts
@@ -67,8 +67,8 @@ export type AgentsServiceDeps = {
   // optional resolver lets host.agents share the authoritative custom MCP status without owning
   // the connector runtime or forcing read-only tests to construct it.
   customServerAvailability?: (id: string) => CustomMcpFailureAvailability | undefined
-  // Injected (fake-able) seams consumed by the future privileged-mutation and switch slices
-  // (issues 04/05). The read slice leaves these unset; the dispatcher routes privileged ops through
+  // Injected (fake-able) seams for privileged mutations and Specialist switches. Read-only callers
+  // may leave these unset; the dispatcher routes privileged ops through
   // `approvalGateway` and signals approved switches via `switchNotifier`. They are SERVER-supplied
   // — never reachable from sandbox request params (the RPC route strips reserved keys first).
   approvalGateway?: ApprovalGateway
@@ -77,7 +77,7 @@ export type AgentsServiceDeps = {
     onAwaitingApproval(context: HandoffApprovalContext): void
     settleApproval(context: HandoffApprovalContext, approved: boolean): void
   }
-  // The durable switch lifecycle (issue 05) reuses the EXISTING SessionBindingService (in-memory
+  // The durable switch lifecycle reuses the existing SessionBindingService (in-memory
   // binding) and the EXISTING durable session-file persistence seam — there is no parallel switch
   // service. They are optional so the read slice and its tests can omit them; the dispatcher fails
   // closed if a `switch` op arrives without them configured.
@@ -86,7 +86,7 @@ export type AgentsServiceDeps = {
   // Invalidates the runtime catalog (Settings/picker/runtime capability resolution) after a successful
   // privileged mutation (delete). Ordinary mutations already invalidate via the
   // existing ProfileService/catalog-change broadcast path; the privileged delete runs through a
-  // dedicated module that calls this only on success. Wired in issue 08.
+  // dedicated module that calls this only on success.
   invalidateCatalog?: () => Promise<void> | void
   deleteSpecialist?: (request: SpecialistDeleteRequest) => Promise<SpecialistDeleteResult>
 }
@@ -189,9 +189,9 @@ export class AgentsService {
 
   constructor(private readonly deps: AgentsServiceDeps) {}
 
-  // The extensible operation dispatcher (issue 02 round 2). This is the single entry point the RPC
-  // route should call so that adding a new operation (create/update/delete/switch later) requires NO
-  // change to the auth/token transport path in local-rpc-server.ts.
+  // The extensible operation dispatcher is the single RPC entry point for reads, mutations, deletes,
+  // and switches. Adding another operation requires no change to the auth/token transport path in
+  // local-rpc-server.ts.
   //
   // EXTENSION POINT — to add a new operation:
   //   1. Add its name to AgentsOpName in src/shared/agents-contract.ts.
@@ -201,7 +201,6 @@ export class AgentsService {
   // You do NOT touch local-rpc-server.ts: it already strips reserved routing/identity keys, forwards
   // the op, and passes the trusted calling session as `context`.
   async dispatch(op: unknown, context: TrustedCallingSession = {}): Promise<unknown> {
-    void context // reserved for the future switch/privileged-mutation slices; unused by reads.
     if (!op || typeof op !== 'object' || !('op' in op)) {
       throw new AgentsCallError('unknown', 'Invalid request')
     }

--- a/src/main/specialist/ipc.ts
+++ b/src/main/specialist/ipc.ts
@@ -291,8 +291,8 @@ export const registerSpecialistIpcHandlers = (
     ipcMainHandle(SPECIALIST_IPC.EXPORT_CONTRIBUTION_TEMPLATE, exportContributionTemplate)
   }
 
-  // Session switching. This handler is a named seam: the future host.agents.switch() SDK (issue 08)
-  // will resolve name→UUID and call this same channel, not a parallel path.
+  // Renderer-initiated session switching. host.agents.switch reuses the same SessionBindingService
+  // and persistence seam through SwitchOperation instead of routing through renderer IPC.
   ipcMainHandle(
     SPECIALIST_IPC.SET_SESSION_SPECIALIST,
     async (_event, request: SetSessionSpecialistRequest): Promise<SetSessionSpecialistResponse> => {

--- a/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
@@ -129,7 +129,8 @@ describe('ComputeHostDetail', () => {
       root.render(<ComputeHostDetail providerId="ssh:biowulf" onRemoved={vi.fn()} />)
     })
 
-    expect(container.textContent).toContain('(default)')
+    expect(container.textContent).toContain('10 (default)')
+    expect(container.textContent).not.toContain('Not yet enforced')
   })
 
   it('shows concurrencyLimit value when set', () => {

--- a/src/renderer/src/pages/settings/ComputeHostDetail.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.tsx
@@ -591,7 +591,7 @@ export function ComputeHostDetail({
           <div className="min-w-0">
             <h4 className="text-sm font-medium text-foreground">Concurrent job limit</h4>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Maximum jobs running at the same time on this host (1–500). Not yet enforced.
+              Maximum jobs running at the same time on this host (1–500).
             </p>
           </div>
           {!isEditingConcurrency ? (
@@ -655,7 +655,7 @@ export function ComputeHostDetail({
         ) : (
           <div className="mt-3 rounded-lg border border-border bg-muted/20 px-3.5 py-2.5">
             <span className="font-mono text-xs text-muted-foreground">
-              {host.concurrencyLimit != null ? host.concurrencyLimit : '100 (default)'}
+              {host.concurrencyLimit != null ? host.concurrencyLimit : '10 (default)'}
             </span>
           </div>
         )}

--- a/src/shared/agents-contract.ts
+++ b/src/shared/agents-contract.ts
@@ -229,7 +229,7 @@ export type SpecialistPermissionCardPayload =
 // Trusted calling-session + pending-switch/reconfigure notification seam
 // ---------------------------------------------------------------------------
 
-// The pending-switch state the switch slice (issue 05) persists and the renderer (issue 07) renders.
+// The pending-switch state persisted by the switch lifecycle and rendered by handoff surfaces.
 // Mirrors design.md §9 / PRD §8: the approved target is persisted immediately and takes effect on
 // the NEXT message, surviving restart.
 export type PendingSwitch = {
@@ -251,10 +251,9 @@ export type ApprovedSwitchReadback = {
   pendingReconfigure: PendingSwitch
 }
 
-// INJECTED seam consumed by the future switch + renderer slices. It is supplied server-side (in the
-// dispatch context), and sandbox request params must NEVER be able to supply or override it. The
-// switch module (issue 05) will call `notify` after an approved switch; the renderer module
-// (issue 07) will subscribe. This type only defines the sink; wiring is deferred to issue 08.
+// Server-injected sink used by SwitchOperation and the completion handoff pipeline. Sandbox request
+// params must NEVER be able to supply or override it. Downstream lifecycle projections publish an
+// approved switch to the renderer.
 export type SwitchNotifier = {
   authority?: 'completion-gate'
   notify(pending: PendingSwitch): Promise<void> | void

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -31,7 +31,7 @@ export type ArtifactReference = {
   path: string
   source: 'upload' | 'artifact'
   mimeType?: string
-  // Reserved for a future version switcher; no version UI ships yet.
+  // Carries immutable version identity when the selected artifact has native provenance.
   versionId?: string
 }
 


### PR DESCRIPTION
## Problem

Several adjacent comments and UI strings still described shipped capabilities as future work. The Compute Host detail also said its concurrency limit was unenforced and displayed a default of 100, while the runtime enforces a default provider ceiling of 10.

## Proposed change

- Align Artifact version, Agent Framework, and Specialist switch/handoff comments with the shipped implementation.
- Remove the redundant `void context` expression whose comment incorrectly said the dispatch context was unused.
- Update Compute Host concurrency copy to reflect enforcement and show the runtime default of 10.
- Tighten the existing render test around the default value and removed promise wording.

## Scope and non-goals

This does not change contracts, persistence, concurrency behavior, or the disabled remote-file import flow. The latter still accurately says "coming soon" and remains unchanged.

## Acceptance criteria and validation

All passing checks below ran after the last material edit:

- Compute Host copy/default -> `npm test -- src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx` -> 9/9 passed.
- Agent framework, dispatch, and Specialist IPC coverage -> `npm test -- src/main/agent-framework/registry.test.ts src/main/agents/agents-dispatch.test.ts src/main/specialist/ipc.test.ts` -> 34/34 passed.
- Node/shared type safety -> `npm run typecheck:node` -> passed.
- Renderer/shared type safety -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors; 11 pre-existing warnings remain in untouched files.
- Portable suite -> `npm test` -> attempted but did not pass because of unrelated Windows/baseline failures, including symlink `EPERM`, Prisma client/schema mismatch (`codecVersion` absent), temporary-database `EBUSY`, and timeouts. No reported failure referenced a changed file.

No interface consumers or platform-specific lanes were added because the final diff changes comments and copy only, plus removes a redundant no-op expression. The unsuccessful full-suite run is the remaining uncovered validation risk.

## Review focus

- Confirm the Compute Host default copy stays aligned with `DEFAULT_PROVIDER_CEILING = 10`.
- Confirm the revised comments describe current ownership and routing without preserving issue-era implementation promises.
