### PR TITLE
feat(updates): add prominent update reminders

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -344,18 +344,18 @@
     animation: home-session-running-shimmer 7.2s cubic-bezier(0.65, 0, 0.35, 1) infinite;
   }
 
-  @keyframes update-reminder-trail-run {
+  @keyframes update-reminder-orbit-run {
     0% {
       opacity: 0;
-      transform: translate(var(--update-trail-from-x), var(--update-trail-from-y));
+      transform: rotate(-80deg);
     }
-    16%,
-    84% {
+    10%,
+    86% {
       opacity: 1;
     }
     100% {
       opacity: 0;
-      transform: translate(var(--update-trail-to-x), var(--update-trail-to-y));
+      transform: rotate(640deg);
     }
   }
 
@@ -398,23 +398,7 @@
     }
   }
 
-  @keyframes update-reminder-halo-release {
-    0%,
-    68% {
-      opacity: 0;
-      transform: scale(0.94);
-    }
-    72% {
-      opacity: 0.5;
-      transform: scale(0.98);
-    }
-    100% {
-      opacity: 0;
-      transform: scale(1.12);
-    }
-  }
-
-  /* One finite attention cue: surface light → border trail → icon wiggle → quiet halo release. */
+  /* One finite attention cue: surface light → exterior orbit → icon wiggle. */
   .update-reminder {
     --update-reminder-gradient-start: color-mix(
       in srgb,
@@ -433,6 +417,13 @@
       in srgb,
       var(--color-primary-foreground) 16%,
       transparent
+    );
+    --update-reminder-orbit-edge: color-mix(in srgb, var(--color-session-running) 20%, transparent);
+    --update-reminder-orbit-tail: color-mix(in srgb, var(--color-session-running) 42%, transparent);
+    --update-reminder-orbit-head: color-mix(
+      in srgb,
+      var(--color-session-running) 90%,
+      var(--color-primary-foreground)
     );
     overflow: visible;
   }
@@ -482,88 +473,35 @@
     animation: update-reminder-sheen-pass 1.4s cubic-bezier(0.4, 0, 0.2, 1) both;
   }
 
-  .update-reminder-trail,
-  .update-reminder-halo {
+  .update-reminder-orbit {
     position: absolute;
+    z-index: 6;
     inset: 0;
+    overflow: hidden;
+    padding: 0.0625rem;
     border-radius: inherit;
+    background: var(--update-reminder-orbit-edge);
+    -webkit-mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
   }
 
-  .update-reminder-trail > span {
+  .update-reminder-orbit::before {
     position: absolute;
-    border-radius: inherit;
+    inset: -100%;
+    background: conic-gradient(
+      from 0deg,
+      transparent 0deg 276deg,
+      var(--update-reminder-orbit-tail) 308deg,
+      var(--update-reminder-orbit-head) 328deg,
+      transparent 344deg 360deg
+    );
+    content: '';
     opacity: 0;
-    animation: update-reminder-trail-run 380ms cubic-bezier(0.4, 0, 0.2, 1) both;
-  }
-
-  .update-reminder-trail > span:nth-child(2) {
-    animation-delay: 260ms;
-  }
-
-  .update-reminder-trail > span:nth-child(3) {
-    animation-delay: 520ms;
-  }
-
-  .update-reminder-trail > span:nth-child(4) {
-    animation-delay: 780ms;
-  }
-
-  .update-reminder-trail > span:nth-child(1),
-  .update-reminder-trail > span:nth-child(3) {
-    width: 42%;
-    height: 0.125rem;
-  }
-
-  .update-reminder-trail > span:nth-child(2),
-  .update-reminder-trail > span:nth-child(4) {
-    width: 0.125rem;
-    height: 42%;
-  }
-
-  .update-reminder-trail > span:nth-child(1) {
-    --update-trail-from-x: -110%;
-    --update-trail-from-y: 0;
-    --update-trail-to-x: 340%;
-    --update-trail-to-y: 0;
-    top: 0;
-    left: 0;
-    background: linear-gradient(90deg, transparent, currentColor);
-  }
-
-  .update-reminder-trail > span:nth-child(2) {
-    --update-trail-from-x: 0;
-    --update-trail-from-y: -110%;
-    --update-trail-to-x: 0;
-    --update-trail-to-y: 340%;
-    top: 0;
-    right: 0;
-    background: linear-gradient(180deg, transparent, currentColor);
-  }
-
-  .update-reminder-trail > span:nth-child(3) {
-    --update-trail-from-x: 110%;
-    --update-trail-from-y: 0;
-    --update-trail-to-x: -340%;
-    --update-trail-to-y: 0;
-    right: 0;
-    bottom: 0;
-    background: linear-gradient(270deg, transparent, currentColor);
-  }
-
-  .update-reminder-trail > span:nth-child(4) {
-    --update-trail-from-x: 0;
-    --update-trail-from-y: 110%;
-    --update-trail-to-x: 0;
-    --update-trail-to-y: -340%;
-    bottom: 0;
-    left: 0;
-    background: linear-gradient(0deg, transparent, currentColor);
-  }
-
-  .update-reminder-halo {
-    box-shadow: 0 0 0 0.125rem currentColor;
-    opacity: 0;
-    animation: update-reminder-halo-release 1.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+    transform: rotate(-80deg);
+    animation: update-reminder-orbit-run 1.8s cubic-bezier(0.65, 0, 0.35, 1) both;
   }
 
   .update-reminder-mark {
@@ -595,8 +533,7 @@
     pointer-events: none;
   }
 
-  .update-reminder:disabled .update-reminder-trail > span,
-  .update-reminder:disabled .update-reminder-halo,
+  .update-reminder:disabled .update-reminder-orbit::before,
   .update-reminder:disabled .update-reminder-sheen::after,
   .update-reminder:disabled .update-reminder-mark > svg {
     animation: none;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1,4 +1,4 @@
-/* Hallmark · pre-emit critique: P5 H4 E5 S5 R5 V4 */
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import './agent-markdown.css';
@@ -344,6 +344,268 @@
     animation: home-session-running-shimmer 7.2s cubic-bezier(0.65, 0, 0.35, 1) infinite;
   }
 
+  @keyframes update-reminder-trail-run {
+    0% {
+      opacity: 0;
+      transform: translate(var(--update-trail-from-x), var(--update-trail-from-y));
+    }
+    16%,
+    84% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+      transform: translate(var(--update-trail-to-x), var(--update-trail-to-y));
+    }
+  }
+
+  @keyframes update-reminder-sheen-pass {
+    0%,
+    8% {
+      opacity: 0;
+      transform: translateX(-135%) skewX(-18deg);
+    }
+    18%,
+    68% {
+      opacity: 0.88;
+    }
+    88%,
+    100% {
+      opacity: 0;
+      transform: translateX(245%) skewX(-18deg);
+    }
+  }
+
+  @keyframes update-reminder-mark-wiggle {
+    0%,
+    12%,
+    72%,
+    100% {
+      transform: rotate(0) scale(1);
+    }
+    20%,
+    40%,
+    60% {
+      transform: rotate(-11deg) scale(1.06);
+    }
+    30%,
+    50%,
+    68% {
+      transform: rotate(11deg) scale(1.06);
+    }
+    82% {
+      transform: rotate(0) scale(1.1);
+    }
+  }
+
+  @keyframes update-reminder-halo-release {
+    0%,
+    68% {
+      opacity: 0;
+      transform: scale(0.94);
+    }
+    72% {
+      opacity: 0.5;
+      transform: scale(0.98);
+    }
+    100% {
+      opacity: 0;
+      transform: scale(1.12);
+    }
+  }
+
+  /* One finite attention cue: surface light → border trail → icon wiggle → quiet halo release. */
+  .update-reminder {
+    --update-reminder-gradient-start: color-mix(
+      in srgb,
+      var(--color-session-running) 15%,
+      transparent
+    );
+    --update-reminder-gradient-end: color-mix(in srgb, var(--color-accent) 18%, transparent);
+    --update-reminder-sheen-soft: color-mix(
+      in srgb,
+      var(--color-primary-foreground) 12%,
+      transparent
+    );
+    --update-reminder-sheen-warm: color-mix(in srgb, var(--color-accent) 58%, transparent);
+    --update-reminder-sheen-cool: color-mix(in srgb, var(--color-session-running) 34%, transparent);
+    --update-reminder-inner-edge: color-mix(
+      in srgb,
+      var(--color-primary-foreground) 16%,
+      transparent
+    );
+    overflow: visible;
+  }
+
+  .update-reminder:is([data-state='available'], [data-state='ready']) {
+    background-image: linear-gradient(
+      110deg,
+      var(--update-reminder-gradient-start),
+      transparent 44%,
+      var(--update-reminder-gradient-end)
+    );
+    box-shadow: inset 0 0.0625rem 0 var(--update-reminder-inner-edge);
+  }
+
+  .update-reminder-attention {
+    position: absolute;
+    z-index: 5;
+    inset: -0.125rem;
+    border-radius: 0.5rem;
+    pointer-events: none;
+  }
+
+  .update-reminder-sheen {
+    position: absolute;
+    inset: 0.25rem;
+    overflow: hidden;
+    border-radius: 0.25rem;
+  }
+
+  .update-reminder-sheen::after {
+    position: absolute;
+    inset-block: 0;
+    left: 0;
+    width: 48%;
+    border-radius: inherit;
+    background: linear-gradient(
+      105deg,
+      transparent,
+      var(--update-reminder-sheen-soft) 28%,
+      var(--update-reminder-sheen-warm) 48%,
+      var(--update-reminder-sheen-cool) 66%,
+      transparent
+    );
+    content: '';
+    opacity: 0;
+    transform: translateX(-135%) skewX(-18deg);
+    animation: update-reminder-sheen-pass 1.4s cubic-bezier(0.4, 0, 0.2, 1) both;
+  }
+
+  .update-reminder-trail,
+  .update-reminder-halo {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+  }
+
+  .update-reminder-trail > span {
+    position: absolute;
+    border-radius: inherit;
+    opacity: 0;
+    animation: update-reminder-trail-run 380ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  }
+
+  .update-reminder-trail > span:nth-child(2) {
+    animation-delay: 260ms;
+  }
+
+  .update-reminder-trail > span:nth-child(3) {
+    animation-delay: 520ms;
+  }
+
+  .update-reminder-trail > span:nth-child(4) {
+    animation-delay: 780ms;
+  }
+
+  .update-reminder-trail > span:nth-child(1),
+  .update-reminder-trail > span:nth-child(3) {
+    width: 42%;
+    height: 0.125rem;
+  }
+
+  .update-reminder-trail > span:nth-child(2),
+  .update-reminder-trail > span:nth-child(4) {
+    width: 0.125rem;
+    height: 42%;
+  }
+
+  .update-reminder-trail > span:nth-child(1) {
+    --update-trail-from-x: -110%;
+    --update-trail-from-y: 0;
+    --update-trail-to-x: 340%;
+    --update-trail-to-y: 0;
+    top: 0;
+    left: 0;
+    background: linear-gradient(90deg, transparent, currentColor);
+  }
+
+  .update-reminder-trail > span:nth-child(2) {
+    --update-trail-from-x: 0;
+    --update-trail-from-y: -110%;
+    --update-trail-to-x: 0;
+    --update-trail-to-y: 340%;
+    top: 0;
+    right: 0;
+    background: linear-gradient(180deg, transparent, currentColor);
+  }
+
+  .update-reminder-trail > span:nth-child(3) {
+    --update-trail-from-x: 110%;
+    --update-trail-from-y: 0;
+    --update-trail-to-x: -340%;
+    --update-trail-to-y: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(270deg, transparent, currentColor);
+  }
+
+  .update-reminder-trail > span:nth-child(4) {
+    --update-trail-from-x: 0;
+    --update-trail-from-y: 110%;
+    --update-trail-to-x: 0;
+    --update-trail-to-y: -340%;
+    bottom: 0;
+    left: 0;
+    background: linear-gradient(0deg, transparent, currentColor);
+  }
+
+  .update-reminder-halo {
+    box-shadow: 0 0 0 0.125rem currentColor;
+    opacity: 0;
+    animation: update-reminder-halo-release 1.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  .update-reminder-mark {
+    position: relative;
+    z-index: 10;
+    display: inline-grid;
+    width: 1.125rem;
+    height: 1.125rem;
+    flex: 0 0 1.125rem;
+    place-items: center;
+  }
+
+  .update-reminder:is([data-state='available'], [data-state='ready']) .update-reminder-mark > svg {
+    transform-origin: center;
+    animation: update-reminder-mark-wiggle 1.4s cubic-bezier(0.4, 0, 0.2, 1) both;
+  }
+
+  .update-reminder-status-dot {
+    position: absolute;
+    z-index: 30;
+    top: -0.125rem;
+    right: -0.125rem;
+    width: 0.375rem;
+    height: 0.375rem;
+    border: 0.0625rem solid var(--color-primary-foreground);
+    border-radius: 999px;
+    background: var(--color-accent);
+    box-shadow: 0 0 0 0.0625rem var(--color-primary);
+    pointer-events: none;
+  }
+
+  .update-reminder:disabled .update-reminder-trail > span,
+  .update-reminder:disabled .update-reminder-halo,
+  .update-reminder:disabled .update-reminder-sheen::after,
+  .update-reminder:disabled .update-reminder-mark > svg {
+    animation: none;
+  }
+
+  .update-reminder:disabled .update-reminder-attention {
+    display: none;
+  }
+
   .home-session-dismiss {
     opacity: 1;
   }
@@ -445,6 +707,18 @@
     .home-session-title-running::after {
       animation: none;
       display: none;
+    }
+
+    .update-reminder-attention {
+      display: none;
+    }
+
+    .update-reminder:is([data-state='available'], [data-state='ready'])
+      .update-reminder-mark
+      > svg {
+      animation: none;
+      opacity: 1;
+      transform: none;
     }
 
     .open-science-thinking-indicator,

--- a/src/renderer/src/components/UpdateCapsule.render.test.tsx
+++ b/src/renderer/src/components/UpdateCapsule.render.test.tsx
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
-import { act } from 'react'
+import { act, StrictMode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useUpdateStore } from '@/stores/update-store'
 import { UpdateCapsule } from './UpdateCapsule'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
 let container: HTMLDivElement
 let root: Root
@@ -16,13 +18,16 @@ beforeEach(() => {
 
   useUpdateStore.setState({
     appInfo: null,
-    status: { state: 'up-to-date', current: '0.2.0', latest: '0.2.0' }
+    status: { state: 'up-to-date', current: '0.2.0', latest: '0.2.0' },
+    isDialogOpen: false
   })
 })
 
 afterEach(() => {
   act(() => root.unmount())
-  container.remove()
+  document.body.innerHTML = ''
+  vi.useRealTimers()
+  vi.restoreAllMocks()
 })
 
 describe('UpdateCapsule', () => {
@@ -35,16 +40,111 @@ describe('UpdateCapsule', () => {
     expect(container.children.length).toBe(0)
   })
 
-  it('renders the update capsule when a new version is available', () => {
+  it('renders a compact Home action, exposes details on focus, and opens the update dialog', async () => {
     useUpdateStore.setState({
       status: { state: 'available', current: '0.2.0', latest: '0.3.0', notes: 'n' }
+    })
+
+    await act(async () => {
+      root.render(<UpdateCapsule />)
+    })
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="New version: Update (v0.3.0)"]'
+    )
+    expect(button).not.toBeNull()
+    expect(button?.getAttribute('data-variant')).toBe('home')
+    expect(button?.querySelector('.update-reminder-sheen')).not.toBeNull()
+    expect(button?.querySelectorAll('.update-reminder-trail > span')).toHaveLength(4)
+    expect(button?.querySelector('.update-reminder-halo')).not.toBeNull()
+    expect(button?.querySelector('.update-reminder-status-dot')).not.toBeNull()
+    expect(button?.textContent).toBe('Update')
+
+    await act(async () => button?.focus())
+
+    const details = document.body.querySelector('[data-update-details]')
+    expect(details?.textContent).toContain('New version')
+    expect(details?.textContent).toContain('Update')
+
+    act(() => button?.click())
+    expect(useUpdateStore.getState().isDialogOpen).toBe(true)
+  })
+
+  it('shows download progress without replaying the available-update attention cue', () => {
+    useUpdateStore.setState({
+      status: { state: 'downloading', current: '0.2.0', latest: '0.3.0', progress: 41.6 }
     })
 
     act(() => {
       root.render(<UpdateCapsule />)
     })
 
-    const button = container.querySelector('button[aria-label="Update available: 0.3.0"]')
-    expect(button).not.toBeNull()
+    const button = container.querySelector('button[aria-label="Downloading: 42% (v0.3.0)"]')
+    expect(button?.textContent).toContain('42%')
+    expect(button?.querySelector('.animate-spin')).not.toBeNull()
+    expect(button?.querySelector('.update-reminder-attention')).toBeNull()
+    expect(button?.querySelector('.update-reminder-status-dot')).toBeNull()
+  })
+
+  it('keeps a failed update visible when a retry target exists', () => {
+    useUpdateStore.setState({
+      status: {
+        state: 'error',
+        current: '0.2.0',
+        latest: '0.3.0',
+        error: 'Download failed'
+      }
+    })
+
+    act(() => {
+      root.render(<UpdateCapsule />)
+    })
+
+    const button = container.querySelector('button[aria-label="Update failed: Retry (v0.3.0)"]')
+    expect(button?.textContent).toContain('Retry')
+    expect(button?.querySelector('.update-reminder-attention')).toBeNull()
+  })
+
+  it('renders the persistent Session action with the ready-state copy', () => {
+    useUpdateStore.setState({
+      status: { state: 'ready', current: '0.2.0', latest: '0.3.0', applyKind: 'restart' }
+    })
+
+    act(() => {
+      root.render(<UpdateCapsule variant="session" />)
+    })
+
+    const button = container.querySelector('button[aria-label="Update ready: Restart (v0.3.0)"]')
+    expect(button?.getAttribute('data-variant')).toBe('session')
+    expect(button?.textContent).toBe('Restart')
+    expect(button?.querySelector('.update-reminder-sheen')).not.toBeNull()
+  })
+
+  it('replays the finite attention cue after a visible window regains focus past the cooldown', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-13T00:00:00Z'))
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    useUpdateStore.setState({
+      status: { state: 'available', current: '0.2.0', latest: '0.3.0' }
+    })
+
+    act(() => {
+      root.render(
+        <StrictMode>
+          <UpdateCapsule />
+        </StrictMode>
+      )
+    })
+
+    const firstCue = container.querySelector('.update-reminder-attention')
+    act(() => window.dispatchEvent(new Event('focus')))
+    expect(container.querySelector('.update-reminder-attention')).toBe(firstCue)
+
+    act(() => {
+      vi.advanceTimersByTime(15 * 60 * 1000)
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    expect(container.querySelector('.update-reminder-attention')).not.toBe(firstCue)
   })
 })

--- a/src/renderer/src/components/UpdateCapsule.render.test.tsx
+++ b/src/renderer/src/components/UpdateCapsule.render.test.tsx
@@ -55,8 +55,7 @@ describe('UpdateCapsule', () => {
     expect(button).not.toBeNull()
     expect(button?.getAttribute('data-variant')).toBe('home')
     expect(button?.querySelector('.update-reminder-sheen')).not.toBeNull()
-    expect(button?.querySelectorAll('.update-reminder-trail > span')).toHaveLength(4)
-    expect(button?.querySelector('.update-reminder-halo')).not.toBeNull()
+    expect(button?.querySelector('.update-reminder-orbit')).not.toBeNull()
     expect(button?.querySelector('.update-reminder-status-dot')).not.toBeNull()
     expect(button?.textContent).toBe('Update')
 

--- a/src/renderer/src/components/UpdateCapsule.tsx
+++ b/src/renderer/src/components/UpdateCapsule.tsx
@@ -1,4 +1,4 @@
-/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
 /* Hallmark · component: update action · genre: modern-minimal · theme: existing Open Science
  * states: default · hover · focus · active · disabled · loading · error · success
  * contrast: existing project token pairs
@@ -42,13 +42,7 @@ const updateCopy = (status: UpdateStatus): { title: string; action: string; icon
 const UpdateAttention = (): React.JSX.Element => (
   <span className="update-reminder-attention" aria-hidden="true">
     <span className="update-reminder-sheen" />
-    <span className="update-reminder-trail">
-      <span />
-      <span />
-      <span />
-      <span />
-    </span>
-    <span className="update-reminder-halo" />
+    <span className="update-reminder-orbit" />
   </span>
 )
 

--- a/src/renderer/src/components/UpdateCapsule.tsx
+++ b/src/renderer/src/components/UpdateCapsule.tsx
@@ -1,32 +1,200 @@
-import { ArrowUp } from 'lucide-react'
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
+/* Hallmark · component: update action · genre: modern-minimal · theme: existing Open Science
+ * states: default · hover · focus · active · disabled · loading · error · success
+ * contrast: existing project token pairs
+ */
+import { useEffect, useRef, useState } from 'react'
+import { ArrowUp, LoaderCircle, RefreshCw, RotateCcw, type LucideIcon } from 'lucide-react'
 
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { useUpdateStore } from '@/stores/update-store'
+import type { UpdateStatus } from '../../../shared/update'
 
-// External "update available" affordance shown only while an update exists (sidebar footer + home
-// header). Clicking opens the shared update dialog (version + notes + download). Renders nothing when
-// there is no update — zero nagging.
-const UpdateCapsule = ({ className }: { className?: string }): React.JSX.Element | null => {
+type UpdateCapsuleProps = {
+  className?: string
+  variant?: 'home' | 'session'
+}
+
+const FOCUS_ATTENTION_COOLDOWN_MS = 15 * 60 * 1000
+
+const updateCopy = (status: UpdateStatus): { title: string; action: string; icon: LucideIcon } => {
+  if (status.state === 'downloading') {
+    return {
+      title: 'Downloading',
+      action: `${Math.round(status.progress ?? 0)}%`,
+      icon: LoaderCircle
+    }
+  }
+  if (status.state === 'ready') {
+    return {
+      title: 'Update ready',
+      action: status.applyKind === 'installer' ? 'Install' : 'Restart',
+      icon: RefreshCw
+    }
+  }
+  if (status.state === 'error') {
+    return { title: 'Update failed', action: 'Retry', icon: RotateCcw }
+  }
+  return { title: 'New version', action: 'Update', icon: ArrowUp }
+}
+
+const UpdateAttention = (): React.JSX.Element => (
+  <span className="update-reminder-attention" aria-hidden="true">
+    <span className="update-reminder-sheen" />
+    <span className="update-reminder-trail">
+      <span />
+      <span />
+      <span />
+      <span />
+    </span>
+    <span className="update-reminder-halo" />
+  </span>
+)
+
+const UpdateMark = ({
+  Icon,
+  status
+}: {
+  Icon: LucideIcon
+  status: UpdateStatus
+}): React.JSX.Element => {
+  return (
+    <span className="update-reminder-mark" aria-hidden="true">
+      <Icon
+        className={cn(
+          'relative z-10 size-3.5',
+          status.state === 'downloading' && 'animate-spin motion-reduce:animate-none'
+        )}
+        strokeWidth={2.25}
+      />
+    </span>
+  )
+}
+
+// The same terse update action fits both constrained surfaces: Home exposes extra context on
+// hover/focus, while Session keeps a single persistent action above the footer controls.
+const UpdateCapsule = ({
+  className,
+  variant = 'home'
+}: UpdateCapsuleProps): React.JSX.Element | null => {
   const status = useUpdateStore((state) => state.status)
   const openDialog = useUpdateStore((state) => state.openDialog)
+  const [focusAttentionCycle, setFocusAttentionCycle] = useState(0)
+  const lastAttentionAtRef = useRef(0)
+
+  const drawsAttention = status.state === 'available' || status.state === 'ready'
+
+  useEffect(() => {
+    if (!drawsAttention) return
+
+    lastAttentionAtRef.current = Date.now()
+
+    const replayAttention = (): void => {
+      const now = Date.now()
+      if (
+        document.visibilityState !== 'visible' ||
+        now - lastAttentionAtRef.current < FOCUS_ATTENTION_COOLDOWN_MS
+      ) {
+        return
+      }
+      lastAttentionAtRef.current = now
+      setFocusAttentionCycle((cycle) => cycle + 1)
+    }
+
+    window.addEventListener('focus', replayAttention)
+    return () => window.removeEventListener('focus', replayAttention)
+  }, [drawsAttention, status.latest, status.state])
 
   const isVisible =
-    status.state === 'available' || status.state === 'downloading' || status.state === 'ready'
+    status.state === 'available' ||
+    status.state === 'downloading' ||
+    status.state === 'ready' ||
+    (status.state === 'error' && Boolean(status.latest))
   if (!isVisible) return null
 
+  const copy = updateCopy(status)
+  const Icon = copy.icon
+  const label = `${copy.title}: ${copy.action}${status.latest ? ` (v${status.latest})` : ''}`
+  const hasError = status.state === 'error'
+  const attentionKey = `${status.state}:${status.latest ?? ''}:${focusAttentionCycle}`
+
+  if (variant === 'session') {
+    return (
+      <button
+        type="button"
+        data-variant="session"
+        data-state={status.state}
+        onClick={() => openDialog()}
+        aria-label={label}
+        className={cn(
+          'update-reminder relative isolate inline-flex h-8 w-full cursor-pointer items-center justify-center gap-1.5 rounded-md bg-primary px-2 text-xs font-semibold whitespace-nowrap text-primary-foreground transition-[background-color,transform] duration-150 ease-out hover:bg-primary/80 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 active:translate-y-px disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:h-11 motion-reduce:transform-none motion-reduce:transition-none',
+          hasError && 'bg-danger-000 text-white hover:bg-danger-000/90',
+          className
+        )}
+      >
+        {drawsAttention ? <UpdateAttention key={`${attentionKey}:attention`} /> : null}
+        <UpdateMark
+          key={drawsAttention ? `${attentionKey}:mark` : undefined}
+          Icon={Icon}
+          status={status}
+        />
+        <span className="relative z-10">{copy.action}</span>
+        {drawsAttention ? <span className="update-reminder-status-dot" aria-hidden="true" /> : null}
+      </button>
+    )
+  }
+
   return (
-    <button
-      type="button"
-      onClick={() => openDialog()}
-      aria-label={`Update available: ${status.latest}`}
-      className={cn(
-        'inline-flex h-8 items-center gap-1 rounded-full border border-primary/20 bg-primary/10 px-2.5 text-xs font-medium text-primary transition-colors duration-150 ease-out hover:border-primary/30 hover:bg-primary/15',
-        className
-      )}
-    >
-      <ArrowUp className="size-3.5" strokeWidth={2.5} aria-hidden="true" />
-      Update
-    </button>
+    <TooltipProvider delayDuration={800}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            data-variant="home"
+            data-state={status.state}
+            onClick={() => openDialog()}
+            aria-label={label}
+            className={cn(
+              'update-reminder relative isolate inline-flex size-8 min-w-8 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-md bg-primary px-2 text-xs font-semibold whitespace-nowrap text-primary-foreground transition-[background-color,transform] duration-150 ease-out hover:bg-primary/80 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 active:translate-y-px disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:px-2.5 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:min-w-11 motion-reduce:transform-none motion-reduce:transition-none',
+              hasError && 'bg-danger-000 text-white hover:bg-danger-000/90',
+              className
+            )}
+          >
+            {drawsAttention ? <UpdateAttention key={`${attentionKey}:attention`} /> : null}
+            <UpdateMark
+              key={drawsAttention ? `${attentionKey}:mark` : undefined}
+              Icon={Icon}
+              status={status}
+            />
+            <span className="relative z-10 hidden sm:inline">{copy.action}</span>
+            {drawsAttention ? (
+              <span className="update-reminder-status-dot" aria-hidden="true" />
+            ) : null}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          data-update-details
+          side="bottom"
+          align="end"
+          sideOffset={6}
+          className={cn(
+            'flex w-28 flex-col border border-border bg-popover px-2 py-1.5 text-left text-popover-foreground shadow-menu',
+            hasError && 'border-danger-000/30'
+          )}
+        >
+          <span
+            className={cn(
+              'text-[10px] font-medium leading-4 text-muted-foreground',
+              hasError && 'text-danger-000'
+            )}
+          >
+            {copy.title}
+          </span>
+          <span className="text-xs font-semibold leading-4">{copy.action}</span>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -20,7 +20,13 @@ import { clickRadixMenuItem, openRadixMenu } from '../settings/test-utils'
 import { HomePage } from './HomePage'
 
 vi.mock('@/components/GitHubStarBadge', () => ({ GitHubStarBadge: () => null }))
-vi.mock('@/components/UpdateCapsule', () => ({ UpdateCapsule: () => null }))
+vi.mock('@/components/UpdateCapsule', () => ({
+  UpdateCapsule: () => (
+    <button type="button" data-testid="home-update-capsule">
+      Update
+    </button>
+  )
+}))
 
 let container: HTMLDivElement
 let root: Root
@@ -767,6 +773,26 @@ describe('HomePage activity overview', () => {
     )
 
     expect(onOpenGlobalSearch).toHaveBeenCalledOnce()
+  })
+
+  it('places the update action beside Settings and before New project', async () => {
+    await act(async () =>
+      root.render(
+        <HomePage canDeleteProjects hasCompleteSessionCatalog onOpenGlobalSearch={vi.fn()} />
+      )
+    )
+
+    const settings = container.querySelector('[aria-label="Model settings"]')
+    const update = container.querySelector('[data-testid="home-update-capsule"]')
+    const newProject = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('New project')
+    )
+
+    expect(settings).not.toBeNull()
+    expect(update).not.toBeNull()
+    expect(newProject).toBeDefined()
+    expect(settings?.compareDocumentPosition(update!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(update?.compareDocumentPosition(newProject!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
   })
 
   it('prioritizes needs-you cards and shows separate per-project activity counts', async () => {

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -498,7 +498,6 @@ const HomePage = ({
             <div className="mt-1 text-[11px] text-muted-foreground">Beta</div>
           </div>
           <div className="flex flex-wrap items-center justify-end gap-1 sm:gap-2">
-            <UpdateCapsule />
             {requiredEnvironmentFailures.length > 0 && environmentRepairPanel ? (
               <button
                 type="button"
@@ -539,6 +538,7 @@ const HomePage = ({
             >
               <Settings className="size-4" strokeWidth={2} aria-hidden="true" />
             </button>
+            <UpdateCapsule />
             {/* Account button hidden for now; restore when the account flow lands. */}
             <Button
               variant="outline"

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -5,7 +5,8 @@ import { createRoot } from 'react-dom/client'
 import { act, Children, isValidElement, type ReactElement, type ReactNode } from 'react'
 import { Toolbox } from 'lucide-react'
 import type { ChatSession } from '@/stores/session-store'
-import { describe, expect, it, vi } from 'vitest'
+import { useUpdateStore } from '@/stores/update-store'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -98,6 +99,13 @@ const getTextContent = (node: ReactNode): string => {
     .join('')
 }
 
+beforeEach(() => {
+  useUpdateStore.setState({
+    status: { state: 'up-to-date', current: '0.2.0', latest: '0.2.0' },
+    isDialogOpen: false
+  })
+})
+
 describe('WorkspaceSidebar accessible render', () => {
   it('keeps the sidebar card inset even on both sides', async () => {
     const html = await renderSidebar([createSession({ id: 'session-a' })])
@@ -112,6 +120,54 @@ describe('WorkspaceSidebar accessible render', () => {
 
     expect(html).toContain('-top-12 h-12 bg-gradient-to-t from-rail-card-bg')
     expect(html).not.toContain('-top-6 h-6 bg-gradient-to-t from-rail-card-bg')
+  })
+
+  it('docks the update action on the row above Settings', async () => {
+    useUpdateStore.setState({
+      status: { state: 'available', current: '0.2.0', latest: '0.3.0' }
+    })
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    try {
+      const { WorkspaceSidebar } = await import('./WorkspaceSidebar')
+      await act(async () => {
+        root.render(
+          <WorkspaceSidebar
+            projectName="Example project"
+            sessions={[createSession({ id: 'session-a' })]}
+            activeSessionId="session-a"
+            canCreateConversation
+            canMutateConversations
+            canDeleteConversations
+            onGoHome={vi.fn()}
+            onNewConversation={vi.fn()}
+            isFilesOpen={false}
+            onOpenFiles={vi.fn()}
+            onOpenSession={vi.fn()}
+            onRenameSession={vi.fn()}
+            canDownloadArtifacts
+            onDownloadArtifacts={vi.fn()}
+            onViewNotebook={vi.fn()}
+            onTogglePin={vi.fn()}
+            onDeleteSession={vi.fn()}
+            onOpenSettings={vi.fn()}
+            onOpenProjectSettings={vi.fn()}
+            onNewProject={vi.fn()}
+          />
+        )
+      })
+      const update = container.querySelector('[data-variant="session"]')
+      const settings = container.querySelector('[aria-label="Settings"]')
+
+      expect(update).not.toBeNull()
+      expect(settings).not.toBeNull()
+      expect(update?.compareDocumentPosition(settings!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    } finally {
+      act(() => root.unmount())
+      container.remove()
+    }
   })
 
   it('keeps the header row free of floating-toggle padding now that the toggle sits inline', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -639,31 +639,33 @@ const WorkspaceSidebarView = ({
             ))}
           </div>
 
-          <div className="relative flex shrink-0 items-center gap-1 p-2">
+          <div className="relative shrink-0 px-2 pt-2">
             <div
               aria-hidden="true"
               className="pointer-events-none absolute inset-x-0 -top-12 h-12 bg-gradient-to-t from-rail-card-bg to-rail-card-bg/0"
             />
-            <NotificationBell
-              side="top"
-              align="start"
-              className="size-8 rounded-md"
-              onOpen={mobileMode ? onMobileClose : undefined}
-            />
-            <button
-              type="button"
-              onClick={onOpenSettings}
-              className={cn(
-                'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-text-300 hover:bg-bg-300 hover:text-text-000',
-                sidebarInteractiveTransitionClassName
-              )}
-              aria-label="Settings"
-            >
-              <Settings className="size-4" strokeWidth={2} aria-hidden="true" />
-            </button>
-            <UpdateCapsule />
-            <GitHubStarBadge />
-            <NetworkStatusIndicator variant="icon" />
+            <UpdateCapsule variant="session" className="mb-1.5" />
+            <div className="flex items-center gap-1 pb-2">
+              <NotificationBell
+                side="top"
+                align="start"
+                className="size-8 rounded-md"
+                onOpen={mobileMode ? onMobileClose : undefined}
+              />
+              <button
+                type="button"
+                onClick={onOpenSettings}
+                className={cn(
+                  'inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-text-300 hover:bg-bg-300 hover:text-text-000',
+                  sidebarInteractiveTransitionClassName
+                )}
+                aria-label="Settings"
+              >
+                <Settings className="size-4" strokeWidth={2} aria-hidden="true" />
+              </button>
+              <GitHubStarBadge />
+              <NetworkStatusIndicator variant="icon" />
+            </div>
           </div>
         </nav>
       </div>


### PR DESCRIPTION
## Problem

Available app updates are easy to miss on the Project and Session surfaces, especially when space is constrained.

## Proposed change

- Add a compact update action beside Project settings that reveals two lines of context on hover or focus.
- Add a persistent Session update action on the row above Settings.
- Guide attention with a finite gradient sheen, a quiet outer border with a traveling cyan arc, icon movement, a status dot, and a 15-minute focus replay cooldown.
- Keep downloading, ready, installer, restart, and retry states concise and actionable.
- Respect reduced-motion preferences and retain the shared update dialog as the click destination.

## Scope and non-goals

- Included consumers: HomePage and WorkspaceSidebar, the only production consumers of UpdateCapsule.
- No changes to update discovery, download, installer, restart, or release backend behavior.
- No platform-specific updater lanes changed; native installer execution remains outside this UI-only validation scope.

## Acceptance criteria and validation

The checks below ran after the last material edit, and a final independent diff-to-consumer review confirmed that the mapping covers the final state.

| Behavior | Evidence | Result |
| --- | --- | --- |
| Compact Project action, focus details, click behavior, status copy, orbit attention markup, and focus replay cooldown | npm test -- src/renderer/src/components/UpdateCapsule.render.test.tsx src/renderer/src/pages/home/HomePage.render.test.tsx src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx | 3 files and 66 tests passed |
| Project action appears between Settings and New project | HomePage.render.test.tsx in the targeted command above | Passed |
| Session action remains above Settings | WorkspaceSidebar.render.test.tsx in the targeted command above | Passed |
| Renderer and Node types remain valid | npm run typecheck | Passed |
| Repository lint policy | npm run lint | Passed with 0 errors and 13 pre-existing warnings in unchanged files |
| Portable repository fallback | npm test -- --maxWorkers=2 | 990 files passed, 15 skipped; 14,446 tests passed, 198 skipped |
| Patch whitespace integrity | git diff --check | Passed |

The default full-suite concurrency produced non-deterministic resource-contention timeouts in unrelated architecture, Prisma, R, and ACP tests. The initially failing five files passed in isolation with 607 of 607 tests, and the complete suite passed with two workers while preserving the repository default test timeouts.

## Review focus

- Whether the short cyan arc makes the update noticeable without becoming persistent visual noise.
- Whether the terse labels remain understandable in constrained Project and Session layouts.
- Keyboard focus, tooltip accessibility, and reduced-motion behavior.

## Uncovered risks

- CSS motion timing and perceived prominence are visual judgments; the final design was reviewed in the local prototype but is not screenshot-regression tested.
- The native updater and installer flow was not executed because its implementation and contracts are unchanged.

Related issue: none.