### PR TITLE
fix(conversation): refine first-message scroll control

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -111,17 +111,18 @@ vi.mock('@/components/ui/message-scroller', () => {
   }: PropsWithChildren<{ messageId?: string }>): React.JSX.Element => (
     <div data-message-id={messageId}>{children}</div>
   )
-  const Button = ({
-    children,
-    direction = 'end',
-    ...props
-  }: PropsWithChildren<
-    React.ButtonHTMLAttributes<HTMLButtonElement> & { direction?: 'start' | 'end' }
-  >): React.JSX.Element => (
-    <button type="button" data-direction={direction} {...props}>
-      {children ?? `Scroll to ${direction}`}
-    </button>
-  )
+  const Button = forwardRef<
+    HTMLButtonElement,
+    PropsWithChildren<
+      React.ButtonHTMLAttributes<HTMLButtonElement> & { direction?: 'start' | 'end' }
+    >
+  >(function MockMessageScrollerButton({ children, direction = 'end', ...props }, ref) {
+    return (
+      <button ref={ref} type="button" data-direction={direction} {...props}>
+        {children ?? `Scroll to ${direction}`}
+      </button>
+    )
+  })
 
   return {
     MessageScrollerProvider: Wrapper,
@@ -2219,7 +2220,8 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(announceWindowFindReady).toHaveBeenCalledTimes(1)
   })
 
-  it('offers scrolling to the first message only for long, sufficiently scrolled idle Sessions', async () => {
+  it('reveals scrolling to the first message on upward scroll, then hides it after inactivity', async () => {
+    vi.useFakeTimers()
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
     const messages = [
       createMessage({ id: 'prompt-1' }),
@@ -2268,6 +2270,10 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     const firstMessageButton = container.querySelector('[aria-label="Scroll to first message"]')
     const lastMessageButton = container.querySelector('[data-direction="end"]')
     expect(firstMessageButton).not.toBeNull()
+    expect(firstMessageButton?.getAttribute('data-revealed')).toBe('false')
+    expect(firstMessageButton?.getAttribute('aria-hidden')).toBe('true')
+    expect(firstMessageButton?.getAttribute('tabindex')).toBe('-1')
+    expect(firstMessageButton?.classList.contains('gap-1')).toBe(true)
     expect(lastMessageButton).not.toBeNull()
     for (const button of [firstMessageButton, lastMessageButton]) {
       expect(button?.classList.contains('border-transparent')).toBe(true)
@@ -2275,15 +2281,44 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       expect(button?.classList.contains('border-border-200')).toBe(false)
     }
 
-    await scrollTo(400, { clientHeight: 400, scrollHeight: 10_000 })
-    expect(container.querySelector('[aria-label="Scroll to first message"]')).not.toBeNull()
+    await scrollTo(1200, { clientHeight: 400, scrollHeight: 10_000 })
+    expect(firstMessageButton?.getAttribute('data-revealed')).toBe('false')
+
+    await scrollTo(1199, { clientHeight: 400, scrollHeight: 10_000 })
+    expect(firstMessageButton?.getAttribute('data-revealed')).toBe('true')
+    expect(firstMessageButton?.getAttribute('aria-hidden')).toBe('false')
+    expect(firstMessageButton?.getAttribute('tabindex')).toBe('0')
+
+    await act(async () => vi.advanceTimersByTimeAsync(2999))
+    expect(firstMessageButton?.getAttribute('data-revealed')).toBe('true')
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+    expect(firstMessageButton?.getAttribute('data-revealed')).toBe('false')
+
+    await scrollTo(1198, { clientHeight: 400, scrollHeight: 10_000 })
+    expect(firstMessageButton?.getAttribute('data-revealed')).toBe('true')
+    await scrollTo(1199, { clientHeight: 400, scrollHeight: 10_000 })
+    expect(firstMessageButton?.getAttribute('data-revealed')).toBe('false')
+
+    await scrollTo(1198, { clientHeight: 400, scrollHeight: 10_000 })
+    expect(firstMessageButton?.getAttribute('data-revealed')).toBe('true')
+    await render('idle', messages, { id: 'session-2' })
+    expect(
+      container
+        .querySelector('[aria-label="Scroll to first message"]')
+        ?.getAttribute('data-revealed')
+    ).not.toBe('true')
 
     await render('idle', messages.slice(0, 2))
     await scrollTo(200, { clientHeight: 400, scrollHeight: 700 })
     expect(container.querySelector('[aria-label="Scroll to first message"]')).toBeNull()
 
+    await scrollTo(80, { clientHeight: 400, scrollHeight: 800 })
     await scrollTo(40, { clientHeight: 400, scrollHeight: 800 })
-    expect(container.querySelector('[aria-label="Scroll to first message"]')).not.toBeNull()
+    expect(
+      container
+        .querySelector('[aria-label="Scroll to first message"]')
+        ?.getAttribute('data-revealed')
+    ).toBe('true')
 
     await render('idle', messages, { compacting: true })
     await scrollTo(400)
@@ -2302,7 +2337,11 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
 
     await render('error')
     await scrollTo(60)
-    expect(container.querySelector('[aria-label="Scroll to first message"]')).not.toBeNull()
+    expect(
+      container
+        .querySelector('[aria-label="Scroll to first message"]')
+        ?.getAttribute('data-revealed')
+    ).toBe('true')
   })
 
   it('does not write to the preview store for non-managed-file artifacts', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -137,6 +137,7 @@ const SCROLL_TO_FIRST_MESSAGE_MIN_USER_TURNS = 2
 const SCROLL_TO_FIRST_MESSAGE_MIN_HEIGHT_VIEWPORTS = 2
 const SCROLL_TO_FIRST_MESSAGE_MIN_PROGRESS = 0.1
 const SCROLL_TO_FIRST_MESSAGE_MIN_DISTANCE_VIEWPORTS = 1
+const SCROLL_TO_FIRST_MESSAGE_IDLE_TIMEOUT_MS = 3000
 // How long a "no longer available" mention notice stays visible before auto-dismissing.
 const MENTION_NOTICE_TIMEOUT_MS = 3000
 
@@ -301,6 +302,9 @@ const WorkspaceMessageScrollerImpl = ({
   )
   const messageScrollerViewportRef = useRef<HTMLDivElement | null>(null)
   const messageScrollerContentRef = useRef<HTMLDivElement | null>(null)
+  const scrollToFirstMessageButtonRef = useRef<HTMLButtonElement | null>(null)
+  const previousMessageScrollerScrollTopRef = useRef(0)
+  const scrollToFirstMessageHideTimeoutRef = useRef<number | undefined>(undefined)
   const [scrollThresholdAllowsFirstMessage, setScrollThresholdAllowsFirstMessage] = useState(false)
   const activeConversationFrame = activeSession?.conversationGraph?.frames.find(
     (frame) => frame.id === activeSession.conversationGraph?.activeFrameId
@@ -421,11 +425,11 @@ const WorkspaceMessageScrollerImpl = ({
   const userTurnCount = presentedConversationItems.filter(
     (item) => item.type === 'message' && item.message.role === 'user'
   ).length
-  const updateScrollToFirstMessageVisibility = useCallback((): void => {
+  const updateScrollToFirstMessageEligibility = useCallback((): boolean => {
     const viewport = messageScrollerViewportRef.current
     if (!viewport || viewport.clientHeight <= 0) {
       setScrollThresholdAllowsFirstMessage(false)
-      return
+      return false
     }
 
     const maximumScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
@@ -437,22 +441,62 @@ const WorkspaceMessageScrollerImpl = ({
       (viewport.scrollTop >= maximumScrollTop * SCROLL_TO_FIRST_MESSAGE_MIN_PROGRESS ||
         viewport.scrollTop >=
           viewport.clientHeight * SCROLL_TO_FIRST_MESSAGE_MIN_DISTANCE_VIEWPORTS)
-    setScrollThresholdAllowsFirstMessage(hasEnoughConversation && hasScrolledFarEnough)
+    const eligible = hasEnoughConversation && hasScrolledFarEnough
+    setScrollThresholdAllowsFirstMessage(eligible)
+    return eligible
   }, [userTurnCount])
-  useLayoutEffect(updateScrollToFirstMessageVisibility, [
-    currentSessionId,
-    updateScrollToFirstMessageVisibility,
-    visibleMessageIdsKey
-  ])
+  const clearScrollToFirstMessageHideTimeout = useCallback((): void => {
+    if (scrollToFirstMessageHideTimeoutRef.current !== undefined) {
+      window.clearTimeout(scrollToFirstMessageHideTimeoutRef.current)
+      scrollToFirstMessageHideTimeoutRef.current = undefined
+    }
+  }, [])
+  const setScrollToFirstMessageRevealed = useCallback((revealed: boolean): void => {
+    const button = scrollToFirstMessageButtonRef.current
+    if (!button) return
+    button.dataset.revealed = String(revealed)
+    button.setAttribute('aria-hidden', String(!revealed))
+    button.tabIndex = revealed ? 0 : -1
+  }, [])
+  const hideScrollToFirstMessage = useCallback((): void => {
+    clearScrollToFirstMessageHideTimeout()
+    setScrollToFirstMessageRevealed(false)
+  }, [clearScrollToFirstMessageHideTimeout, setScrollToFirstMessageRevealed])
+  const revealScrollToFirstMessage = useCallback((): void => {
+    clearScrollToFirstMessageHideTimeout()
+    setScrollToFirstMessageRevealed(true)
+    scrollToFirstMessageHideTimeoutRef.current = window.setTimeout(() => {
+      scrollToFirstMessageHideTimeoutRef.current = undefined
+      setScrollToFirstMessageRevealed(false)
+    }, SCROLL_TO_FIRST_MESSAGE_IDLE_TIMEOUT_MS)
+  }, [clearScrollToFirstMessageHideTimeout, setScrollToFirstMessageRevealed])
+  const handleMessageScrollerScroll = useCallback((): void => {
+    const viewport = messageScrollerViewportRef.current
+    if (!viewport) return
+
+    const previousScrollTop = previousMessageScrollerScrollTopRef.current
+    previousMessageScrollerScrollTopRef.current = viewport.scrollTop
+    const eligible = updateScrollToFirstMessageEligibility()
+    if (viewport.scrollTop < previousScrollTop && eligible) revealScrollToFirstMessage()
+    else if (viewport.scrollTop > previousScrollTop) hideScrollToFirstMessage()
+  }, [hideScrollToFirstMessage, revealScrollToFirstMessage, updateScrollToFirstMessageEligibility])
+  useLayoutEffect(() => {
+    updateScrollToFirstMessageEligibility()
+  }, [currentSessionId, updateScrollToFirstMessageEligibility, visibleMessageIdsKey])
+  useLayoutEffect(() => {
+    previousMessageScrollerScrollTopRef.current = messageScrollerViewportRef.current?.scrollTop ?? 0
+    hideScrollToFirstMessage()
+  }, [currentSessionId, hideScrollToFirstMessage])
+  useEffect(() => clearScrollToFirstMessageHideTimeout, [clearScrollToFirstMessageHideTimeout])
   useEffect(() => {
     if (typeof ResizeObserver === 'undefined') return
-    const observer = new ResizeObserver(updateScrollToFirstMessageVisibility)
+    const observer = new ResizeObserver(updateScrollToFirstMessageEligibility)
     const viewport = messageScrollerViewportRef.current
     const content = messageScrollerContentRef.current
     if (viewport) observer.observe(viewport)
     if (content) observer.observe(content)
     return () => observer.disconnect()
-  }, [currentSessionId, updateScrollToFirstMessageVisibility])
+  }, [currentSessionId, updateScrollToFirstMessageEligibility])
   const showScrollToFirstMessage =
     statusAllowsScrollToFirstMessage && scrollThresholdAllowsFirstMessage
   const handleVisibleMessageSnapshotCommit = useCallback(
@@ -800,7 +844,7 @@ const WorkspaceMessageScrollerImpl = ({
           <MessageScrollerViewport
             ref={messageScrollerViewportRef}
             aria-label="Conversation"
-            onScroll={updateScrollToFirstMessageVisibility}
+            onScroll={handleMessageScrollerScroll}
           >
             <MessageScrollerContent ref={messageScrollerContentRef} className="gap-0 px-4">
               <div className={conversationContentClassName}>
@@ -1095,10 +1139,14 @@ const WorkspaceMessageScrollerImpl = ({
 
           {showScrollToFirstMessage ? (
             <MessageScrollerButton
+              ref={scrollToFirstMessageButtonRef}
               direction="start"
               aria-label="Scroll to first message"
+              aria-hidden="true"
+              data-revealed="false"
+              tabIndex={-1}
               size="default"
-              className="z-20 min-h-11 rounded-full border-transparent bg-bg-000 px-4 text-sm shadow-card hover:bg-bg-200 data-[direction=start]:top-3"
+              className="z-20 min-h-11 gap-1 rounded-full border-transparent bg-bg-000 px-4 text-sm shadow-card transition-[translate,scale,opacity] hover:bg-bg-200 data-[direction=start]:top-3 data-[revealed=false]:pointer-events-none data-[revealed=false]:-translate-y-2 data-[revealed=false]:opacity-0 motion-reduce:transition-none"
             >
               <ArrowDownIcon aria-hidden="true" />
               <span>First message</span>


### PR DESCRIPTION
## Problem

The First message control uses too much space between its icon and label, and once eligible it remains pinned near the top of long conversations. Keeping it visible indefinitely adds persistent chrome, while repeatedly resurfacing it on passive content or layout changes would distract users.

## Proposed change

- reduce the icon-to-label gap from 6px to 4px;
- keep the existing long-conversation, scroll-distance, and Session-status eligibility gates;
- reveal the control only after an eligible upward user scroll;
- fade it out after 3 seconds without scrolling and hide it immediately on downward scrolling;
- keep the hidden control out of pointer, keyboard, and accessibility interaction;
- reset its presentation when switching Sessions without rerendering the transcript on every scroll event.

## Scope and non-goals

This changes only the renderer-local First message affordance and its interaction test. The shared message-scroller primitive, transcript data, session persistence, conversation branches, runtime frameworks, and platform-specific code paths are unchanged.

## Acceptance criteria and validation

The checks below ran after the last material source edit:

- First-message visibility, direction, timeout, spacing, focus, and Session reset -> `npm test -- --run src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx` -> 31/31 passed.
- Renderer types -> `npm run typecheck:web` -> passed after fast-forwarding to the latest `origin/main`.
- Source lint -> `npm run lint -- --quiet` -> passed after fast-forwarding; the full lint run also completed with 0 errors and 11 pre-existing warnings outside the changed files.
- Portable suite -> `npm test` -> 14,517 passed / 198 skipped on the final source implementation. A later repeat after a test-only assertion addition had six unrelated full-load timeouts; rerunning all four affected files passed 638/638.

Consumer inclusion: `WorkspaceMessageScroller` callers continue to use the unchanged component interface, and the complete portable suite exercised renderer and consumer coverage. The shared `MessageScrollerButton` interface was not changed.

Platform exclusion: no paths, Electron IPC, native behavior, persistence, or OS-specific interactions changed, so no platform-specific lane was added locally. Required CI remains authoritative for platform lanes.

Uncovered risk: the exact visual feel of the 3-second fade was not exercised through screenshot/E2E automation; class behavior and interaction semantics are covered by the focused test.

## Review focus

Please review the upward/downward scroll-direction behavior, the 3-second idle timing, and hidden-state accessibility semantics.
